### PR TITLE
fix(agents): actually ask before running confirmation-gated tools

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -264,3 +264,5 @@ tests/unit/eval/test_mcp_tool_reliability_scenarios.py
 /.codex/
 /.cursor/
 /.claude/skills/m365-email/
+# Claudia agent worktrees (local orchestration scratch)
+.claudia-worktrees/

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -127,6 +127,7 @@
                     "group": "MCP Integration",
                     "pages": [
                       "guides/mcp/agent-ui",
+                      "guides/mcp/tui",
                       "guides/mcp/client",
                       "guides/mcp/windows-system-health"
                     ]

--- a/docs/guides/email.mdx
+++ b/docs/guides/email.mdx
@@ -270,7 +270,7 @@ This is detection only, distinct from autonomous follow-ups ([#555](https://gith
 
 ### Reply / send (require confirmation)
 
-`draft_reply`, `draft_forward` — drafts are harmless. `send_draft`, `send_now`, `forward_message` — gated by user confirmation; the UI shows the literal recipient/subject/body before you approve.
+`draft_reply`, `draft_forward` — drafts are harmless. `send_draft`, `send_now`, `forward_message` — gated by user confirmation; you always see the literal recipient/subject/body before you approve, in the UI's permission dialog or as a terminal prompt on the CLI. With no way to ask you — output piped or redirected, CI, an unattended host — these tools are **denied**, never sent silently (see [troubleshooting](/reference/troubleshooting)).
 
 ### Scheduled send & snooze
 

--- a/docs/guides/email.mdx
+++ b/docs/guides/email.mdx
@@ -24,7 +24,7 @@ The Email Triage Agent connects to your Gmail account through GAIA's connectors 
 - **Find past mail** — search your mailbox with keyword or Gmail-syntax queries (`from:alice is:unread newer_than:7d`). Ask in chat (the `search_messages` tool) or call it from a consuming app via `POST /v1/email/search` on the REST contract; results carry metadata only (id, sender, subject, date, snippet) — never message bodies.
 - **Organize** — archive, label, mark read/unread, star/unstar. Reversible via the per-action undo log.
 - **Soft-delete with undo** — `trash_message` records the action; `restore_message` reverses it within a 30-second window.
-- **Draft + confirmed send** — generate replies (`draft_reply`) and forwards (`draft_forward`); `send_draft` and `send_now` require explicit user confirmation in the UI.
+- **Draft + confirmed send** — generate replies (`draft_reply`) and forwards (`draft_forward`); `send_draft` and `send_now` require explicit user confirmation — the UI's permission dialog or a terminal prompt on the CLI — and are refused outright when there is nobody to ask.
 - **Attachments** — reading a message exposes each attachment's name, type, and size, and `draft_reply` / `send_now` accept local file paths to attach (contract schema 2.2, #1542).
 - **Voice-matched drafting** — learn your writing style from your Sent mail (`build_voice_profile`) so drafts sound like you; the style profile is derived and stored locally, nothing leaves the device.
 - **Calendar** — list events, accept/decline invites, create events from email content (all calendar mutations gated by user confirmation).

--- a/docs/guides/mcp/tui.mdx
+++ b/docs/guides/mcp/tui.mdx
@@ -1,0 +1,249 @@
+---
+title: "TUI Control MCP Server"
+description: "Let Claude Code drive the GAIA terminal hub while you watch the same live session"
+icon: "terminal"
+---
+
+<Info>
+  **Prerequisites:** the GAIA TUI binary, started with the control API on:
+  `gaia tui --control`.
+</Info>
+
+## Overview
+
+The GAIA TUI can expose a loopback control API, and this MCP server wraps it as
+tools. An assistant then navigates the hub, types into chat, and launches agents
+**in the session you are looking at** — same process, same terminal, frames
+updating live. It is not a headless replica and not a replay.
+
+That makes two things possible that were not before:
+
+- **Testing the TUI without a human at the keyboard.** Send keys, wait for a
+  condition, read the rendered screen, assert.
+- **Watching an assistant work.** You keep your terminal open; navigation,
+  filtering, and agent launches happen in front of you.
+
+```
+┌──────────────┐    stdio/HTTP    ┌───────────────────┐
+│ Claude Code  │ ◄──────────────► │ TUI Control MCP   │
+│ / MCP client │     MCP tools    │ server (Python)   │
+└──────────────┘                  └─────────┬─────────┘
+                                            │ loopback HTTP + bearer token
+                                            │ (discovered via ~/.gaia/tui/control.json)
+                                            ▼
+                                  ┌───────────────────┐
+                                  │ gaia tui --control│  ← the terminal you are watching
+                                  │ (Go / Bubble Tea) │
+                                  └───────────────────┘
+```
+
+Keys are injected into the running `tea.Program` with `Send`; the screen served
+back is the exact frame the renderer just drew.
+
+### Available Tools
+
+| Tool | Description |
+|------|-------------|
+| `tui_status` | Is a TUI running, and what is on screen conceptually: view, active agent, streaming, hub tab, selection, terminal size |
+| `tui_screen` | The rendered screen as plain text (ANSI stripped). The workhorse — read it after every action |
+| `tui_send_keys` | Inject named keys: `enter`, `esc`, `tab`, `shift+tab`, arrows, `pgup`/`pgdown`, `backspace`, `ctrl+c`, `?`, `/` … |
+| `tui_send_text` | Type a string as runes (what a human typing produces) |
+| `tui_wait_for` | Block until text appears (or disappears), with a timeout. **Use this instead of polling** |
+| `tui_launch_agent` | High level: find the agent by id across hub tabs, move the selection, launch it |
+| | *(refuses in a standalone `gaia chat` session, where esc quits instead of returning to a hub)* |
+| `tui_install_agent` / `tui_uninstall_agent` | High level: navigate to an agent and trigger the hub's install/uninstall binding |
+| `tui_resize` | Re-lay-out at a given size, e.g. 80x24 versus 200x50 |
+
+<Warning>
+  `tui_install_agent` needs an install keybinding on the hub screen, and the
+  hub does not have one yet — the tool reads the bindings off the footer rather
+  than guessing a key, so today it returns "not yet available" and lists what
+  the hub does offer. It starts working the moment the binding lands, with no
+  change here. Neither tool takes "the key was pressed" as success:
+  `tui_uninstall_agent` requires the agent to be gone from the hub's list, and
+  `tui_install_agent` requires the screen to have changed at all (an install
+  promotes the row to a different tab, so it may legitimately leave the current
+  one). A refusal quotes the hub's own status line.
+</Warning>
+
+<Note>
+  `tui_wait_for` is the one that makes automation reliable. Without it, every
+  caller busy-polls `tui_screen` and races the render. On timeout it reports
+  **what the screen actually contained**, so a failure is debuggable.
+</Note>
+
+`tui_send_keys`, `tui_send_text`, and `tui_resize` return only once the input has
+been *consumed and redrawn*, so reading `tui_screen` immediately after is
+race-free. They report `settled: false` if the model was still busy — the input
+is queued, so re-read the screen rather than assume it was dropped.
+
+That is not the same as "the consequences finished". Pressing `enter` to launch
+an agent is consumed at once, while the view switch it starts arrives a moment
+later — so wait on the outcome (`tui_wait_for`) rather than reading the screen
+once and concluding nothing happened.
+
+If the user has quit the TUI (or it is still starting), these tools fail with
+"the TUI is not accepting input" instead of reporting a success. Bubble Tea
+discards messages sent outside its event loop, so a success there would be a
+lie. `tui_status` and `tui_screen` keep working, and `tui_status` reports
+`running: false`.
+
+---
+
+## Setup with Claude Code
+
+<Steps>
+  <Step title="Start the TUI with the control API">
+    ```bash
+    gaia tui --control
+    ```
+
+    The TUI prints the port it bound and writes `~/.gaia/tui/control.json`
+    (mode `0600`) holding the pid, port, and bearer token. The token is never
+    printed. Add `--debug` to log every injected key, state transition, and
+    wait resolution to stderr.
+
+    For a fixed port: `gaia tui --control-port 8770`.
+  </Step>
+
+  <Step title="Add the MCP server to Claude Code">
+    ```bash
+    # Project-scoped (recommended)
+    claude mcp add gaia-tui -s project -- uv run python -m gaia.mcp.servers.tui_mcp --stdio
+
+    # Or user-scoped
+    claude mcp add gaia-tui -s user -- uv run python -m gaia.mcp.servers.tui_mcp --stdio
+    ```
+  </Step>
+
+  <Step title="Start a new Claude Code conversation">
+    MCP tools are loaded at conversation start, so open a new one. Ask for
+    `tui_status` first — it confirms the assistant can see your session.
+  </Step>
+</Steps>
+
+The server can also run over Streamable HTTP, the same as the Agent UI MCP
+server:
+
+```bash
+gaia mcp tui                 # HTTP on :8767  → http://localhost:8767/mcp
+gaia mcp tui --stdio         # stdio, for Claude Code
+gaia mcp tui --port 9100     # custom port
+
+# Equivalent module invocations
+uv run python -m gaia.mcp.servers.tui_mcp --stdio
+uv run python -m gaia.mcp.servers.tui_mcp --port 9100
+```
+
+---
+
+## Usage Examples
+
+### Navigate the hub
+
+```
+"Show me what's on the TUI right now, then switch to the Available tab
+ and tell me which agents are listed."
+```
+
+The assistant calls `tui_status`, `tui_send_keys(["tab"])`, `tui_wait_for`, and
+`tui_screen`. You watch the tab change in your terminal.
+
+### Launch an agent and ask it something
+
+```
+"Launch the email agent in the TUI and ask it to triage my inbox."
+```
+
+`tui_launch_agent("email")` walks the hub tabs until the agent is visible,
+moves the selection onto it, presses Enter, and waits for the chat view to
+open. Then `tui_send_text` + `tui_send_keys(["enter"])` sends the query.
+
+### Check the layout at a small terminal
+
+```
+"Resize the TUI to 80x24 and check nothing overflows."
+```
+
+`tui_resize(80, 24)` followed by `tui_screen`.
+
+---
+
+## Discovery and Trust
+
+The MCP server finds the TUI by reading `~/.gaia/tui/control.json` — there is
+no fixed port. Before trusting it, it checks **both**:
+
+1. the recorded pid is alive, and
+2. `GET /control/v1/status` answers with our service id and a **matching pid**.
+
+Either check failing means the file is stale: after a crash it can point at a
+port some unrelated process now owns. The tool then says so and names the
+remedy rather than talking to a stranger's socket.
+
+Every error is structured and actionable — no tracebacks, no leaked URLs, and
+never the token. With no TUI running, every tool answers with exactly that,
+plus the command to start one.
+
+<Warning>
+  Anything that can read `~/.gaia/tui/control.json` can drive your TUI. Start
+  the TUI without `--control` (the default) when you do not want that.
+</Warning>
+
+---
+
+## Configuration
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--stdio` | off | Use stdio transport (for Claude Code) |
+| `--port` | `8767` | HTTP MCP server port |
+| `--host` | `localhost` | HTTP MCP server host |
+
+Environment:
+
+| Variable | Description |
+|----------|-------------|
+| `GAIA_TUI_HOME` | Directory holding `control.json` (default `~/.gaia/tui`). Both halves read it, so tests can isolate a run from your real session. |
+
+---
+
+## Troubleshooting
+
+<AccordionGroup>
+  <Accordion title="'No GAIA TUI is running'">
+    The control file does not exist. Start the TUI with `gaia tui --control`
+    (plain `gaia tui` does not expose the API).
+  </Accordion>
+
+  <Accordion title="'stale control file' / pid is not running">
+    A previous TUI crashed without cleaning up. Start a fresh one with
+    `gaia tui --control` — it overwrites the registration.
+  </Accordion>
+
+  <Accordion title="Keys seem to do nothing">
+    Check `tui_status` first: a help overlay or confirmation dialog swallows
+    keys until it is dismissed (`esc`). If the hub still shows `Loading...`,
+    it has not received a terminal size — call `tui_resize`.
+  </Accordion>
+
+  <Accordion title="tui_wait_for keeps timing out">
+    The timeout reports the screen it actually saw. Compare it with what you
+    were matching on — styling is stripped in plain mode, so match on the text,
+    not on box-drawing characters. `gaia tui --control --debug` logs every
+    injected key and every wait resolution to stderr.
+  </Accordion>
+</AccordionGroup>
+
+---
+
+## Related
+
+<CardGroup cols={2}>
+  <Card title="TUI control API reference" icon="terminal" href="/reference/cli">
+    The HTTP endpoints, flags, and discovery file this server wraps.
+  </Card>
+  <Card title="Agent UI MCP Server" icon="plug" href="/guides/mcp/agent-ui">
+    The same idea for the browser-based Agent UI.
+  </Card>
+</CardGroup>

--- a/docs/plans/email-agent-tui-port.md
+++ b/docs/plans/email-agent-tui-port.md
@@ -283,7 +283,33 @@ table, so a "tasks" pane needs backend work.
 
 ---
 
-### Phase 6 (v2) — Agent-led connector onboarding · **file as an issue, do not build now**
+### Phase 5b — Retire `gaia email` from the legacy Python CLI
+
+Once the TUI can install, run, and configure the email agent, the `gaia email` subcommand
+is a second front door to the same sidecar with none of the UI. Remove it.
+
+**This is a decommission, not a rewrite.** Only the `email` subcommand goes. The rest of
+the legacy Python CLI stays exactly as it is — it will be retired separately, later.
+
+- Remove the `email` subparser (`src/gaia/cli.py:1772-1829`), `handle_email_command`
+  (`:5012-5095`), and `_email_interactive` (`:5098-5134`).
+- **Keep `src/gaia/daemon/agent_query.py`.** It is the generic daemon thin-client used by
+  more than email and it is the reference implementation the TUI's Go transport mirrors.
+- `--spec` needs a home before the removal lands — it is the only email surface that
+  needs no daemon and no LLM. Either move it under `gaia hub` or expose it in the TUI.
+- Delete the now-dead tests, and update `docs/reference/cli.mdx`, `docs/guides/email.mdx`,
+  and every doc that shows a `gaia email ...` invocation. The doc-sync rule in `CLAUDE.md`
+  applies: grep the old command across all of them, including the email package's own
+  `README.md` / `SPEC.md` / `SKILL.md` / `CHANGELOG.md`.
+- Print a clear pointer to the replacement rather than a bare "unknown command".
+
+**Sequencing is the whole risk here.** This must not merge until Phases 1-3 are verified
+working end to end, or we remove the only working entry point before the replacement
+exists. Prepare it early, land it last.
+
+---
+
+### Phase 6 (v2) — Agent-led connector onboarding · **filed as #2469, do not build now**
 
 Today, connecting a mailbox means the user finds Settings, obtains a Google OAuth client
 id and secret, and pastes both into a terminal. That is the worst moment in the product.

--- a/docs/plans/email-agent-tui-port.md
+++ b/docs/plans/email-agent-tui-port.md
@@ -344,6 +344,43 @@ Phases 1 and 2 are independent of each other and can run in parallel (one Go-hea
 Python-heavy). Phase 5.1 should jump the queue — it is small and it is the difference
 between "it didn't work" and "here's what to fix".
 
+## 3b. Design review outcome — amendments to this plan
+
+The user-journey design (`docs/plans/tui-user-journey.md`) reviewed this plan and pushed back
+on ten points. Accepted amendments, in order of how much they change the build:
+
+- **Preflight moves into Phase 1 as its exit test.** It was scoped here as Phase 5.1 polish
+  that "should jump the queue". That undersold it: without the readiness gate, every failure
+  of the new transport — daemon down, token rotated, version gate failed, model missing —
+  reaches the user as a raw HTTP status. Phase 1 isn't done when the stream parses; it's done
+  when a stream that *can't start* explains itself.
+- **Drop "always allow" from the approval UI.** The nine gated tools are gated precisely
+  because they're irreversible, and "this session" has no boundary a user can hold in a TUI
+  that stays open for days. Attack approval *cost* — two keystrokes, no scrolling — not
+  approval count.
+- **Replace the three-level autonomy enum with two plain controls.** `manual | assisted |
+  autonomous` is implementer vocabulary; approvals are identical across the top two levels by
+  design, so the only real axis is whether background jobs run. Ship fixed "always ask before
+  irreversible things" plus a background-work checklist. Same code, nothing to teach, and it
+  doesn't promise a goal engine that doesn't exist.
+- **No background timers inside the TUI.** The TUI is closed most of the time, so a timer in
+  it means "autonomous while you watch" — the one case where just asking is easier. Scan on
+  launch instead: simpler, and it's what produces the day-5 screen.
+- **`builtin_specs()` — filter, explicitly.** Label unrunnable catalog entries as such rather
+  than offering them as Available. Zero cost, closes the dead end. Synthesis becomes real work
+  when the second installable agent arrives.
+- **Three render primitives, not four.** `image` is base64 raster and can't render in a
+  terminal; `diff` has no producer. Build `table`, `key_value`, `list` plus the fallback.
+- **Settings screen shrinks to what persists** (accounts, memory, app-local prefs), with the
+  budget moved to the config file that makes the rest real. Filed as #2470; scheduled-jobs
+  API as #2471.
+
+Three further pre-existing bugs found on the first-run path, added to §5: the hub opens on an
+empty `Installed` tab on a fresh machine; its 26-row chrome budget overflows an 80x24
+terminal; and connection state is signalled by colour alone. Also `backspace` currently
+triggers uninstall alongside `d`/`delete` — harmless today, destructive once uninstall is
+real — and chat's `/init` prints a message and does nothing.
+
 ## 4. Open decisions
 
 - **D1** — `/query` + resume, or `/agent/query` + `confirm-tool`? Resume is the better

--- a/docs/plans/email-agent-tui-port.md
+++ b/docs/plans/email-agent-tui-port.md
@@ -89,6 +89,14 @@ Everything else depends on this. `client.AgentClient` is already transport-agnos
    accumulate `[{role, content}]` and push it as `context` each turn, appending a turn
    only when it terminated in `final` (so a failed turn doesn't poison the next).
 
+   ⚠️ **`context` must marshal to `[]`, never `null`, and this breaks on the first turn.**
+   `QueryRequest.context` is a *required* `List` (`query_routes.py:175`), and the model
+   forbids extras — `null` is a 422. A Go nil slice marshals to `null`, so the natural
+   implementation (`var ctx []ContextItem`) fails on exactly the cold-start case where there
+   is no history yet, and passes every later turn. Initialize to `make([]ContextItem, 0)`
+   and add a test asserting the serialized body contains `"context":[]` on turn one. A mock
+   that returns 200 will not catch this — assert the wire bytes.
+
 *Known sharp edges to fix while here:* `strings.Fields` command splitting breaks on paths
 with spaces; cancellation doesn't actually stop the child; unparsed events are silently
 dropped rather than surfaced.

--- a/docs/plans/email-agent-tui-port.md
+++ b/docs/plans/email-agent-tui-port.md
@@ -13,7 +13,7 @@ browser plus a chat screen. It knows how to do exactly one thing: launch a local
 executable and trade newline-delimited JSON with it over stdin/stdout
 (`tui/internal/client/subprocess.go`). Its agent list is a hardcoded Go slice
 (`tui/internal/catalog/catalog.go:179`). Email is already in that list at
-`catalog.go:230` — marked `StatusAvailable` with no binary, i.e. visible but dead.
+`catalog.go:231` — marked `StatusAvailable` with no binary, i.e. visible but dead.
 
 **The email agent** does not work that way. Since #2191 it runs as a long-lived HTTP
 service (a "sidecar") that the GAIA daemon starts, supervises, and proxies for.
@@ -139,7 +139,7 @@ for all four platforms, and the file isn't shipped in the wheel at all.
    0/1) — today `chat --query` still opens the alt-screen, which makes it useless for
    scripts and CI.
 5. **Housekeeping:** flip `interfaces.tui: false → true` in
-   `hub/agents/python/email/gaia-agent.yaml:47`. `catalog_test.go` and `smoke_test.go`
+   `hub/agents/python/email/gaia-agent.yaml:44`. `catalog_test.go` and `smoke_test.go`
    both hardcode `installed == 1` — they will fail the moment email becomes installable.
    That's the canary; update both.
 
@@ -293,8 +293,13 @@ the legacy Python CLI stays exactly as it is — it will be retired separately, 
 
 - Remove the `email` subparser (`src/gaia/cli.py:1772-1829`), `handle_email_command`
   (`:5012-5095`), and `_email_interactive` (`:5098-5134`).
-- **Keep `src/gaia/daemon/agent_query.py`.** It is the generic daemon thin-client used by
-  more than email and it is the reference implementation the TUI's Go transport mirrors.
+- **`src/gaia/daemon/agent_query.py` becomes dead code — decide deliberately.** Its
+  `run_query` / `ConsoleRenderer` have exactly two callers, both inside the email handler
+  being deleted, so removing the subcommand orphans all 346 lines. It is *not* shared
+  infrastructure. Two defensible options: keep it as the reference implementation the Go
+  transport mirrors and the thin-client the next agent will reuse (then say so in a module
+  docstring, so the next reader doesn't delete it as unused), or delete it with the
+  subcommand and let the Go client stand alone. Pick one; do not leave it unexplained.
 - `--spec` needs a home before the removal lands — it is the only email surface that
   needs no daemon and no LLM. Either move it under `gaia hub` or expose it in the TUI.
 - Delete the now-dead tests, and update `docs/reference/cli.mdx`, `docs/guides/email.mdx`,

--- a/docs/plans/email-agent-tui-port.md
+++ b/docs/plans/email-agent-tui-port.md
@@ -1,0 +1,348 @@
+# Porting the Email Agent into the TUI
+
+Status: Scoping / not started
+Owner: TBD
+Related: #1186 (TUI), #2191 (email thin client), #2142 (daemon relay), #555 (autonomy epic)
+
+---
+
+## 1. Where we are today
+
+**The TUI** (`tui/`, Go + Bubble Tea, ~4k LOC, landed whole in `aa2ca33f`) is an agent
+browser plus a chat screen. It knows how to do exactly one thing: launch a local
+executable and trade newline-delimited JSON with it over stdin/stdout
+(`tui/internal/client/subprocess.go`). Its agent list is a hardcoded Go slice
+(`tui/internal/catalog/catalog.go:179`). Email is already in that list at
+`catalog.go:230` — marked `StatusAvailable` with no binary, i.e. visible but dead.
+
+**The email agent** does not work that way. Since #2191 it runs as a long-lived HTTP
+service (a "sidecar") that the GAIA daemon starts, supervises, and proxies for.
+`gaia email` is now a thin client: it finds the daemon, asks it to ensure the sidecar
+is up, then streams Server-Sent Events through the daemon's relay
+(`src/gaia/daemon/agent_query.py:253`). Nothing about it is a subprocess the TUI can spawn.
+
+So the port is not "wire up a binary". It is "teach the TUI to be a second thin client",
+plus the install/settings/autonomy surface the user asked for.
+
+### Two landmines found during review
+
+These are the reason the design below picks the transport it picks.
+
+**(a) The subprocess path silently auto-approves destructive actions.**
+`OutputHandler.confirm_tool_execution` returns `True` unconditionally
+(`src/gaia/agents/base/console.py:219-225`), and `AgentConsole` — what the agent builds
+when driven from a CLI — never overrides it. The email agent gates nine tools behind
+confirmation (`send_draft`, `send_now`, `schedule_send`, `forward_message`,
+`permanent_delete`, `accept_invite`, `decline_invite`, `create_event_from_email`,
+`quarantine_phishing_message` — `agent.py:296`), and on that path **every one of them
+executes with no prompt and no event**. If the TUI reuses `subprocess.go`, it ships an
+email client that can send mail on the model's say-so. Non-negotiable: do not use that path.
+
+**(b) The canonical SSE endpoint cannot complete a gated action.**
+`/v1/email/query` implements the frozen seven-event contract but deliberately has no
+resume: on `needs_confirmation` it emits the event, emits a refusal, and kills the run
+(`query_routes.py:374-381`). The stateful `/v1/email/agent/query` *can* — it blocks the
+agent and waits for a separate `POST /v1/email/agent/confirm-tool` (60s timeout, denies
+on expiry, `src/gaia/ui/sse_handler.py:829-902`). Approvals therefore require either the
+stateful surface or a contract change to `/query`.
+
+**Decision (D1):** use the canonical `/v1/email/query` relay for normal turns — it is the
+frozen contract, it is what `gaia email` uses, and it keeps the TUI provider-agnostic —
+and add resume to it (Phase 3) rather than binding the TUI to the email-specific stateful
+surface. Fallback if resume slips: use `/v1/email/agent/*` for email only, behind the
+same Go interface, and swap later.
+
+---
+
+## 2. What has to be built, by phase
+
+### Phase 1 — Give the TUI an HTTP/SSE transport (foundation)
+
+Everything else depends on this. `client.AgentClient` is already transport-agnostic
+(`Send(ctx, query) (<-chan interface{}, error)`); only one line in
+`root/model.go:130` hardcodes the subprocess implementation.
+
+1. **Daemon discovery + auth in Go.** Read `~/.gaia/host/instance.json`
+   (`{pid, port, token, api_version}`, mode 0600, `GAIA_DAEMON_HOME` override). Trust it
+   only after verifying the pid is alive *and* `GET /daemon/v1/status` returns
+   `service == "gaia-daemon"` with a matching pid — a recycled port after a crash is a
+   real case (`src/gaia/daemon/instance.py:135-170`). Enforce the version gate:
+   MAJOR == 1, MINOR >= 1. **The token rotates on every daemon restart** — re-read the
+   file on any 401, never cache it for the session.
+2. **Start-or-attach.** If no live daemon: take `flock` on `~/.gaia/host/instance.lock`,
+   re-check, spawn `gaia daemon start` detached, poll for registration (30s cap).
+   Mirrors `client.py:80-158`.
+3. **SSE client** (`tui/internal/client/sse.go`) implementing `AgentClient`.
+   `POST /v1/email/query` with `Authorization: Bearer <daemon token>`,
+   `Accept: text/event-stream`, body `{query, run_id (uuid4), context, model?, max_steps?}`.
+   Parse the seven canonical events: `status | token | tool_call | tool_result |
+   needs_confirmation | final | error`. Exactly one terminal `final|error`; a stream that
+   ends without one is a failure, not a success. On cancel, `POST /v1/email/query/{run_id}/cancel`.
+   Reference implementation to mirror line-for-line: `src/gaia/daemon/agent_query.py`.
+4. **Event vocabulary.** The TUI's current 13 types (`tui/internal/event/types.go`) are
+   the *old in-process* vocabulary, not the canonical seven. Add the canonical set,
+   including `ToolResultEvent.Render string` and `Data json.RawMessage` (see Phase 5).
+   Keep the legacy types for the bash agent.
+5. **Transport discriminator on the catalog entry** (`Transport: subprocess | daemon`) and
+   a branch at `root/model.go:launchAgent`.
+6. **Host owns the transcript.** The sidecar is stateless on `/query`; the TUI must
+   accumulate `[{role, content}]` and push it as `context` each turn, appending a turn
+   only when it terminated in `final` (so a failed turn doesn't poison the next).
+
+*Known sharp edges to fix while here:* `strings.Fields` command splitting breaks on paths
+with spaces; cancellation doesn't actually stop the child; unparsed events are silently
+dropped rather than surfaced.
+
+**Size:** ~700-900 lines of Go + tests. The single biggest chunk of the port.
+
+---
+
+### Phase 2 — Install / run / uninstall
+
+**The gap:** there is no install or uninstall path anywhere except the web UI's FastAPI
+server (`src/gaia/ui/routers/hub.py:166,232`, port 4200). The daemon has no install API.
+There is no `gaia hub install` CLI. The lazy binary fetch in
+`src/gaia/daemon/sidecars/fetch.py` is **dead** — the committed
+`hub/agents/npm/agent-email/binaries.lock.json` has `PENDING-1648-replace-with-real-sha256`
+for all four platforms, and the file isn't shipped in the wheel at all.
+
+**Decision (D2):** add install/uninstall to the **daemon**, not to the TUI. Three clients
+(TUI, CLI, web UI) then share one implementation, one lock, one integrity check.
+`gaia.hub.installer` already exists and is daemon-safe.
+
+1. **New daemon routes** (`src/gaia/daemon/sidecars/routes.py`):
+   - `GET /daemon/v1/catalog` — proxy + cache `https://hub.amd-gaia.ai/index.json`
+     (public, unauthenticated, currently lists exactly one agent: email 0.5.0).
+   - `POST /daemon/v1/agents/{id}/install {version?}` → 202, plus
+     `GET .../install-status` for progress. Must stop a running sidecar first — the
+     install directory *is* the binary cache (mirror `hub.py:58-81`, which aborts with
+     500 if the pid survives).
+   - `DELETE /daemon/v1/agents/{id}` → stop, verify the pid is gone, then
+     `rmtree ~/.gaia/agents/{id}`.
+   - Reuse `installer._install_slot` so two clients can't install the same agent at once.
+2. **Wire the existing `gaia hub` CLI** to the same routes (there is no install CLI today
+   — this is a ~50-line handler and it unblocks scripted setup independently of the TUI).
+3. **TUI hub screen:** `i` = install (progress bar), `d` = uninstall (reuse the existing
+   `ConfirmModel`), `Enter` = run. Catalog comes from `/daemon/v1/catalog` instead of
+   `seedAgents()`. Installed state comes from `~/.gaia/agents/*/.installed` sentinels.
+   Show download size (the catalog carries `download_size_bytes`).
+4. **TUI CLI switches** (`tui/internal/cli/`):
+   ```
+   gaia tui                          # hub (default)
+   gaia tui run email [--query "..."]
+   gaia tui install email [--version X]
+   gaia tui uninstall email
+   gaia tui list [--installed]
+   gaia tui status
+   ```
+   `run --query` must be a genuine non-interactive one-shot (print to stdout, exit code
+   0/1) — today `chat --query` still opens the alt-screen, which makes it useless for
+   scripts and CI.
+5. **Housekeeping:** flip `interfaces.tui: false → true` in
+   `hub/agents/python/email/gaia-agent.yaml:47`. `catalog_test.go` and `smoke_test.go`
+   both hardcode `installed == 1` — they will fail the moment email becomes installable.
+   That's the canary; update both.
+
+**Blocker to resolve first:** `builtin_specs()` (`sidecars/spec.py:68`) is a static dict
+containing only `email`, with `token_env_var` / `service_id` / `expected_api_major`
+hardcoded per agent. "Install anything from the catalog and run it" needs those synthesized
+from the installed `gaia-agent.yaml`. For an email-only v1 this can be deferred, but the
+hub screen will happily install agents the daemon then refuses to start — so either
+synthesize, or filter the catalog to what `builtin_specs()` knows.
+
+**Size:** ~400 lines Python (daemon routes) + ~500 lines Go + tests.
+
+---
+
+### Phase 3 — Interactive and autonomous by default
+
+**What "autonomous" can honestly mean today.** There is no autonomy setting anywhere in
+the codebase. Grep finds only doc comments pointing at unimplemented issues.
+`docs/spec/autonomous-agent-mode.md:31-38` specifies `manual | goal_driven | autonomous`
+with autonomous as the default — 0% implemented. But the *ingredients* exist:
+
+- The job scheduler is already on by default (`config.py:148`) and fires scheduled sends
+  and snooze-restores unattended.
+- The daily briefing exists, off by default, behind three env vars, requiring a restart.
+- Reversible actions (archive, label, mark-read, trash) are **already** unconfirmed, with
+  a 30-second undo window.
+- The nine irreversible actions already prompt.
+
+**Decision (D3):** ship a three-level `autonomy` setting whose default is "autonomous",
+defined as: *run everything reversible without asking; always ask before anything
+irreversible or externally visible.* This is honest to the spec's own G9 ("no destructive
+action without live user approval regardless of mode") and needs no goal engine.
+
+| Level | Behaviour |
+|---|---|
+| `manual` | Ask before every tool that writes anything. |
+| `assisted` | Ask before irreversible actions; run reversible ones. |
+| `autonomous` (default) | Same approvals, **plus** background work on: proactive inbox scan on a timer, daily briefing on, follow-up check on a timer. |
+
+1. **Approval UI.** New canonical event handling for `needs_confirmation` → a modal built
+   on the existing `components/confirm.go`, showing action + summary, with
+   Approve / Deny / Always-allow-this-action-this-session. Blocks input, honours the 60s
+   server timeout with a visible countdown.
+2. **Resume on `/v1/email/query`** (the contract change flagged in D1): keep the run alive
+   on `needs_confirmation` and accept `POST /v1/email/query/{run_id}/confirm {approved}`.
+   This is a contract MINOR and needs the spec doc, `openapi.email.json`, `SPEC.md`,
+   `README.md`, `SKILL.md`, and `CHANGELOG.md` updated together — see the doc-sync rule in
+   CLAUDE.md. Alternative if this is too big: point the TUI at `/v1/email/agent/query` +
+   `/confirm-tool`, which already works, and migrate later.
+3. **Autonomous background work:** the briefing currently needs env vars + a sidecar
+   restart. Either make it settable at runtime, or have the TUI run its own timer against
+   the read-only, non-gated `pre_scan_inbox` and `check_followups`. The TUI-timer version
+   is materially cheaper and gets 80% of the perceived value.
+4. **Fix the auto-approve hole** (landmine (a)) regardless of which path ships — either
+   make `AgentConsole` deny-by-default when non-interactive, or make the base handler
+   refuse rather than return `True`. This is a security fix that stands on its own.
+
+**Size:** ~300 lines Go (approval UI) + ~250 Python (resume) + docs.
+
+---
+
+### Phase 4 — Settings
+
+**The gap is severe.** Of roughly 22 settings worth exposing, exactly **two** have an HTTP
+API: the memory toggle (`POST /v1/email/agent/memory`) and connectors
+(`GET/POST/DELETE /v1/email/connectors`). `EmailAgentConfig` is a plain in-memory
+dataclass — no file, no env, no persistence, constructed fresh every time. Session
+creation ignores config entirely (`agent_routes.py:272-274` passes zero kwargs).
+
+1. **A config file that does not exist yet:** `~/.gaia/agents/email/config.json`, read at
+   agent construction, with `GET/PUT /v1/email/config` to read and write it. Changes that
+   need a restart must say so in the response.
+2. **Settings screen** (`tui/internal/ui/settings/`), reachable with `s` from the hub and
+   `/settings` from chat:
+   - Autonomy level (Phase 3)
+   - Connected accounts — status, connect, disconnect (the only part with a working API today)
+   - Model + context size
+   - Memory on/off (works today)
+   - Daily briefing on/off + time
+   - Undo window, follow-up window
+   - Priority / low-priority senders (currently only reachable by asking the agent in
+     natural language)
+3. **Connector flow, v1:** `GET /v1/email/connectors` already returns
+   `{provider, connected, account_email, scopes, can_send}` per provider. Connections live
+   in a machine-global keyring shared with the web UI and `gaia connectors`, so most users
+   will already show `connected: true` and need nothing. When not connected: POST configure,
+   the sidecar opens the system browser, and the TUI shows the URL as a copy-paste fallback
+   plus a 120-second spinner. There is no device-code flow and no headless path.
+   Google also requires a client id **and** secret typed into a terminal — genuinely poor
+   UX, which is exactly why Phase 6 exists.
+
+**Size:** ~350 lines Python (config file + endpoints) + ~600 Go (settings screen).
+
+---
+
+### Phase 5 — UX wins that are cheap and land hard
+
+Ordered by value-per-hour. All of these are pure TUI work against APIs that already exist.
+
+1. **Preflight / readiness screen — the single best item in this scope.** Four calls,
+   four checkmark rows, each with a copyable fix:
+   `GET /daemon/v1/status` (daemon up) · `GET /daemon/v1/agents` (sidecar running) ·
+   `GET /v1/email/init` (Lemonade reachable, version >= 10.2.0, model downloaded, live ctx
+   size) · `GET /v1/email/connectors` (mailbox connected, agent granted).
+   `/v1/email/init` already returns a structured readiness report *with an actionable
+   `hint` string*, 200 when ready and 503 when not, same body either way. Today the user
+   discovers each of these preconditions by hitting a wall one at a time.
+2. **The inbox pre-scan card.** The agent already emits `render: "email_pre_scan"` on
+   `tool_result` (`sse_translation.py:54`) carrying urgent / actionable / suggested-archive
+   lists with sender, subject and a reason, plus pre-cap totals and which preferences were
+   applied. Crucially the tool's docstring **tells the model not to describe the results in
+   prose** because a card is expected — so a client that ignores `render` gets one terse
+   sentence and nothing else. Rendering this turns the flagship interaction from a
+   shrug into the product. Multi-mailbox scans also return `mailbox_errors[]`, which is a
+   free "this account's grant is broken" banner.
+3. **Generic render primitives.** The contract already defines `table`, `key_value`,
+   `list`, `diff` (`docs/spec/agent-ui-query-sse-contract.md:238-274`) that any agent may
+   emit. Implement the four and every future agent card renders with no TUI change.
+4. **Error remedy ladder.** `playground_html.py:358-370` already encodes cause → command →
+   hint, specific-before-generic. Port it verbatim; it covers Lemonade down, model missing,
+   no mailbox, missing grant, revoked token, ambiguous provider, version mismatch.
+5. **Briefing splash on launch** — `GET /v1/email/briefing` reuses the pre-scan renderer;
+   404 shows the enable hint. Free once #2 exists.
+6. **Model provisioning from inside the TUI** — `POST /v1/email/init` streams progress
+   lines while pulling the model; the final line's `✓`/`✗` is authoritative. Turns
+   "go run `gaia init` and come back" into a progress bar.
+7. **Triage panel** — port `renderTriage` (`playground_html.py:433-448`) 1:1: category pill,
+   spam/phishing badges, summary, action-item checklist.
+8. **Inbox table + calendar list** — `POST /v1/email/search` returns paged rows with a
+   cursor; `GET /v1/email/calendar/events` returns event rows. Both already typed.
+
+**Not free (needs a backend line each):** rich cards for follow-ups, scheduled jobs, and
+sender profiles. For any tool without a `render` entry the payload degrades to
+`{summary, success, latency_ms}` — there is nothing to draw. Adding one is two lines
+(the tool returns `{"ok", "data": {"kind": ...}}` and both copies of `_RENDER_TOOL_TO_LANG`
+gain an entry) but it is a contract MINOR. Emitting the generic `table` key costs no
+frontend work at all and is the cheapest path.
+
+**Also missing entirely:** there is no REST route for the persisted action-items/tasks
+table, so a "tasks" pane needs backend work.
+
+---
+
+### Phase 6 (v2) — Agent-led connector onboarding · **file as an issue, do not build now**
+
+Today, connecting a mailbox means the user finds Settings, obtains a Google OAuth client
+id and secret, and pastes both into a terminal. That is the worst moment in the product.
+
+The v2 target: the agent notices it has no mailbox and handles it conversationally —
+"I need access to your Gmail to do that. Want me to walk you through it?" — driving the
+flow itself, asking only for what it genuinely can't obtain, opening the browser, and
+confirming when it lands. Same pattern for a revoked token or a missing scope mid-task:
+the agent should recover in-conversation rather than returning a 403 for the user to decode.
+
+Prerequisites this needs and doesn't have: a way for the agent to request structured input
+mid-run and get an answer back (Phase 3's resume mechanism is the same primitive), a
+first-party OAuth client so users don't supply their own credentials, and probably a device-code
+flow so nothing depends on a local browser. Worth an issue; not worth blocking v1.
+
+---
+
+## 3. Order and rough size
+
+| Phase | What | Blocks | Rough size |
+|---|---|---|---|
+| 1 | HTTP/SSE transport + daemon discovery | everything | L |
+| 2 | Install / run / uninstall + CLI switches | — | L |
+| 5.1 | Preflight screen | — (do early, it's cheap) | S |
+| 5.2 | Pre-scan card + generic primitives | 1 | M |
+| 3 | Approvals + autonomy default | 1 | M |
+| 4 | Config file + settings screen | 1 | L |
+| 5.3-8 | Remaining UX polish | 1, 5.2 | M |
+| 6 | Agent-led onboarding | 3 | issue only |
+
+Phases 1 and 2 are independent of each other and can run in parallel (one Go-heavy, one
+Python-heavy). Phase 5.1 should jump the queue — it is small and it is the difference
+between "it didn't work" and "here's what to fix".
+
+## 4. Open decisions
+
+- **D1** — `/query` + resume, or `/agent/query` + `confirm-tool`? Resume is the better
+  long-term contract but is a spec change touching six documents.
+- **D2** — install in the daemon (shared by three clients) or in the TUI (faster, forks
+  the logic). Recommend the daemon.
+- **D4** — does the TUI ship inside the `amd-gaia` wheel, or as its own binary? Affects how
+  `gaia tui` is even invoked, and whether Go tests run in CI (they don't today).
+- **D5** — email-only v1, or generic-agent v1? `builtin_specs()` currently knows only email.
+
+## 5. Pre-existing bugs found during review (worth filing regardless)
+
+1. `AgentConsole` auto-approves every gated tool on the CLI path — send, forward,
+   permanent delete, RSVP (`src/gaia/agents/base/console.py:219`). **Security.**
+2. `binaries.lock.json` ships placeholder SHAs, so daemon lazy-fetch always fails; and the
+   file isn't in the wheel, so pip installs can't reach it either.
+3. `gaia email -q X -i` silently discards `-q` (`cli.py:5083`).
+4. `--trace`, `--stats`, `--stream`, `--list-tools`, `--max-steps` are parsed and ignored on
+   `gaia email`. `--use-claude` / `--use-chatgpt` are accepted and silently ignored — the
+   local-only guarantee rests on non-consumption, not rejection.
+5. `gaia email "query"` (positional) doesn't work despite the handler docstring saying it does.
+6. `--spec` with the package missing raises a raw traceback instead of a clean error.
+7. `hub/agents/python/email/gaia_agent_email/cli.py` is dead code (117 lines, no entry point,
+   no importer) and its docstring describes a dispatch path that no longer exists.
+8. `TestHubTabSwitching` / `TestHubSearch` send the three runes `t`,`a`,`b` instead of the Tab
+   key and only assert "didn't panic".
+9. `findBinaryInRepo` only looks in `cpp/build/*` for `.exe` — can never find a Python or
+   frozen agent on macOS/Linux.

--- a/docs/reference/cli.mdx
+++ b/docs/reference/cli.mdx
@@ -124,6 +124,38 @@ export GAIA_AGENT_TOOL_TIMEOUT=300
 
 Tools that legitimately run longer opt out in code via `@tool(timeout=...)` — for example image generation, which may need to download a model on first use. An invalid `GAIA_AGENT_TOOL_TIMEOUT` value (non-numeric or ≤ 0) fails fast with an actionable error rather than silently removing the guard.
 
+### Confirming dangerous tools
+
+Shell commands, file writes, and an agent's own destructive tools (email send /
+forward / permanent delete, calendar RSVP) prompt before they run:
+
+```
+⚠️  Confirm: send_now
+{
+  "subject": "Q3 budget",
+  "to": "boss@example.com"
+}
+Allow this? [y]es / [N]o / [a]lways for this tool:
+```
+
+The default is **no** — a bare Enter, Ctrl-C, or EOF denies. `a` remembers that
+one tool until the command exits (not offered for `run_shell_command` /
+`run_cli_command`).
+
+When GAIA is not attached to a terminal — output piped or redirected, a CI job, a
+host process — there is nobody to ask, so gated tools are **denied** with an
+actionable error rather than run silently. For an unattended run you trust, set
+`GAIA_AUTO_APPROVE_TOOLS=1` in the launching environment:
+
+```bash
+# CI / batch use only — the model can then send mail and run shell commands
+# without asking. Every approval is logged with the tool name.
+GAIA_AUTO_APPROVE_TOOLS=1 gaia analyze data.csv --json > report.json
+```
+
+A `.env` file cannot set this variable; it must come from the real process
+environment, so a project directory can never switch off your prompts.
+
 ---
 
 ## Initialization

--- a/docs/reference/cli.mdx
+++ b/docs/reference/cli.mdx
@@ -1443,6 +1443,7 @@ gaia mcp test --query "Hello from GAIA MCP!"
 | `agent` | Invoke the MCP orchestrator agent (positional `request` arg + `--domain`, `--context`) |
 | `docker` | Start the Docker MCP server (default port 8080) |
 | `serve` | Start the Agent UI MCP server (wraps the Agent UI backend) |
+| `tui` | Start the TUI control MCP server (drives a running `gaia tui --control`) |
 
 #### `gaia mcp start` options
 
@@ -1477,6 +1478,21 @@ Pass a natural-language `request` and, optionally, a `--domain` (e.g. `jira`,
 
 `--port` defaults to `8080`. <Warning>This is the **same default** as `gaia api
 start` — run them on different ports if you need both alive at once.</Warning>
+
+#### `gaia mcp tui` options
+
+Wraps the [TUI control API](#tui-control-api) as MCP tools, so an assistant can
+navigate and type in the TUI session you are watching. The TUI must already be
+running with `gaia tui --control`; the server finds it through
+`~/.gaia/tui/control.json` rather than a fixed port.
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `--stdio` | off | Use stdio transport (what Claude Code expects) |
+| `--host` | `localhost` | HTTP MCP bind address |
+| `--port` | `8767` | HTTP MCP port |
+
+[→ Full TUI Control MCP Guide](/guides/mcp/tui)
 
 [→ Full MCP Integration Guide](/integrations/mcp)
 
@@ -2232,6 +2248,87 @@ gaia daemon stop-agent email              # stop one sidecar, daemon stays up
 | `agents` | — | List every registered sidecar agent: id, state, and (when running) mode, pid, port, contract version — never the bearer token. Dev-mode entries also show their source dir. |
 | `start-agent <id>` | `--mode user\|dev` | Start (or attach to) one agent's sidecar, auto-starting the daemon if needed. Requesting a mode different from the running sidecar's is a loud conflict — stop it first. |
 | `stop-agent <id>` | — | Tree-kill one agent's sidecar; the daemon keeps running. Attach-only: no daemon running → clear error, exit 1. A sidecar surviving the kill is a loud failure, never silent. |
+
+---
+
+### TUI Control API
+
+The terminal hub (`gaia tui`, the Go/Bubble Tea binary) can expose a loopback
+HTTP API that drives **the session you are looking at** — not a headless copy.
+An assistant navigates, types, and launches agents while the frames render in
+your terminal in real time. It is how the TUI gets tested without a human at
+the keyboard.
+
+Off by default. Bound to `127.0.0.1` only, and every request needs a bearer
+token.
+
+```bash
+gaia tui --control                 # auto-assign a port
+gaia tui --control-port 8770       # explicit port (implies --control)
+gaia tui --control --debug         # log every injected key, state change, and wait
+```
+
+<Note>
+  These are persistent flags on the TUI binary's root command, so they apply to
+  the hub, `hub`, and `chat` alike. Building from source, that binary is
+  `tui/bin/gaia` (`cd tui && make build`).
+</Note>
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--control` | flag | off | Start the control API on an auto-assigned loopback port. |
+| `--control-port` | integer | `0` | Bind a specific port. Implies `--control`. `0` auto-assigns. Port `4001` is reserved and rejected. |
+| `--debug` | flag | off | Log every injected key, state transition, and wait resolution/timeout to stderr. |
+
+On start the TUI writes `~/.gaia/tui/control.json` (mode `0600`) holding the
+pid, port, and token, and removes it on exit. Clients find the TUI by reading
+that file — the token is never printed to the terminal. A client must verify
+**both** that the recorded pid is alive and that `/control/v1/status` answers
+with a matching pid before trusting the port: after a crash the file can point
+at a port some unrelated process now owns.
+
+<Warning>
+  Anything that can read `~/.gaia/tui/control.json` can drive your TUI — the
+  same trust boundary as `~/.gaia/host/instance.json` for the daemon. Leave
+  `--control` off unless you want a session driven.
+</Warning>
+
+Endpoints (all under `/control/v1`, all requiring `Authorization: Bearer <token>`):
+
+| Endpoint | Purpose |
+|----------|---------|
+| `GET /status` | `running` plus the active view, active agent, streaming, hub tab, selection, terminal size, and `can_return_to_hub`. |
+| `GET /screen` | The current rendered frame. `?format=plain` (default, ANSI stripped) or `?format=ansi`. |
+| `POST /keys` | Inject named keys — `{"keys": ["tab","down","enter"]}`. |
+| `POST /text` | Type a string as runes — `{"text": "triage my inbox"}`. |
+| `POST /wait` | Block until the screen or state matches, or time out. A timeout reports what the screen actually contained. |
+| `GET /frames` | Recent rendered frames (`?since=N`), for debugging what happened. |
+| `POST /resize` | Re-lay-out at a given size — `{"cols":120,"rows":40}`. |
+
+Errors come back as `{"error": {"code", "message", "hint"}}`; a `/wait` timeout is
+HTTP 408 and carries the screen it saw.
+
+Two response details matter when driving this:
+
+- **`settled`** on `/keys`, `/text`, and `/resize`. The call returns only once every
+  injected key has been *consumed and redrawn*, so reading `/screen` straight after
+  is race-free. `settled: false` means the model was still busy — the input is
+  queued, so re-read rather than assume it was ignored. It does **not** promise the
+  consequences are done: pressing `enter` to launch an agent is consumed
+  immediately, while the view switch it kicks off lands later. Use `/wait` for
+  anything asynchronous.
+- **HTTP 503 `not_running`** when the TUI's event loop is not consuming input —
+  it is still starting, or the user has quit. Bubble Tea silently drops messages
+  in that window, so the API refuses instead of reporting a success for keys that
+  went nowhere. Reads (`/status`, `/screen`, `/frames`) keep working.
+
+`can_return_to_hub` exists because `esc` is not universally "go back": in a chat
+opened from the hub it returns there, but in a standalone `gaia chat --subprocess`
+session it **quits the program**. A driver that guesses wrong kills the session it
+was asked to drive, so the state says which.
+
+Most callers should not speak this API directly — the
+[TUI MCP server](/guides/mcp/tui) wraps it as MCP tools.
 
 ---
 

--- a/docs/reference/troubleshooting.mdx
+++ b/docs/reference/troubleshooting.mdx
@@ -78,6 +78,35 @@ icon: "bug"
 ## Agent & SDK Issues
 
 <AccordionGroup>
+  <Accordion title="Agent says a tool 'requires explicit user approval'" icon="shield-halved">
+    Dangerous tools — shell commands, file writes, email send / forward /
+    permanent delete, calendar RSVP — only run after you approve them. If nothing
+    can ask you, the tool is denied rather than run silently:
+
+    ```
+    'send_now' requires explicit user approval and cannot run unattended…
+    ```
+
+    You'll see this when the agent is driven without a terminal: output piped or
+    redirected (`gaia chat -q "…" > out.txt`), a CI job, or a host process such as
+    the OpenAI-compatible `gaia api` server, which has no way to show a prompt.
+
+    - **Working interactively?** Run the command in a terminal without redirecting
+      stdout, and answer the `[y]es / [N]o / [a]lways` prompt. In the Agent UI,
+      approve the permission dialog instead.
+    - **Genuinely unattended run you trust** (CI, a batch job, a host that already
+      asked the user): export `GAIA_AUTO_APPROVE_TOOLS=1` in the environment that
+      launches GAIA. Every tool approved this way is logged with its name. A `.env`
+      file cannot set it — that would let a project directory switch off your
+      prompts.
+
+    <Warning>
+      Don't leave `GAIA_AUTO_APPROVE_TOOLS=1` set on a machine with a mailbox
+      connected: it lets the model send, forward, and permanently delete mail
+      without asking.
+    </Warning>
+  </Accordion>
+
   <Accordion title="Agent not found after install" icon="magnifying-glass">
     ```bash
     # Verify package is installed

--- a/docs/sdk/core/console.mdx
+++ b/docs/sdk/core/console.mdx
@@ -83,6 +83,39 @@ agent = MyAgent(output_handler=handler)
 
 ---
 
+## Confirming Dangerous Tools
+
+Tools listed in the agent's `confirmation_required_tools()` set — the generic
+shell / file-mutation names plus whatever the agent declares in
+`CONFIRMATION_REQUIRED_TOOLS` (email send, permanent delete, calendar RSVP) —
+never execute until `confirm_tool_execution()` returns `True`. The gate is
+name-based and applies to `Agent._execute_tool`, so a tool that isn't in that set
+(or code that bypasses the agent loop) is not covered. What a confirmation means
+depends on the handler:
+
+| Handler | Behaviour |
+|---------|-----------|
+| `AgentConsole` / `SilentConsole`, stdin **and** stdout are a terminal | Prints the tool and its literal arguments, then asks `[y]es / [N]o / [a]lways for this tool`. Defaults to **no**; Ctrl-C and EOF also mean no. `a` remembers that one tool for the life of the console (never offered for `run_shell_command` / `run_cli_command`, where the name says nothing about the next call). Silent mode suppresses narration, not consent. |
+| Either console with piped stdin, redirected stdout, CI, or a subprocess host | **Denies** — there is nobody to ask, or nowhere the question would be visible. The tool result explains why and how to proceed. |
+| Any handler that doesn't override the default (e.g. the OpenAI-compatible API server's SSE handler) | **Denies**, same reasoning. |
+| Agent UI's `SSEOutputHandler` | Emits a `permission_request` event, blocks up to 60 s for the modal's answer, denies on timeout. |
+
+The agent loop turns a denial into a `{"status": "denied", "error": ...}` tool
+result, so the model can explain itself or pick a different action instead of the
+run crashing.
+
+<Warning>
+  For a genuinely unattended run (CI, a batch job, a host that already asked the
+  user), set `GAIA_AUTO_APPROVE_TOOLS=1` in the launching environment, or
+  construct the console with `AgentConsole(auto_approve_gated_tools=True)`. Every
+  approval taken this way is logged with the tool name. The variable is read from
+  the environment as it was at startup, so a project-local `.env` cannot enable
+  it. Do not leave it set on a machine with a live mailbox connected — it lets the
+  model send, forward, and permanently delete without asking.
+</Warning>
+
+---
+
 ## Related Topics
 
 - **[Agent System](./agent-system)** - Learn about the agent foundation

--- a/docs/sdk/infrastructure/api-server.mdx
+++ b/docs/sdk/infrastructure/api-server.mdx
@@ -170,6 +170,20 @@ both surfaces.
 {"event": "answer", "data": {"text": "Here's the code..."}}
 ```
 
+### Confirmation-gated tools are denied on this surface
+
+This stream is one-way — the client has no channel to answer a permission
+request — so tools in the agent's `confirmation_required_tools()` set (shell,
+file mutation, email send/delete) return
+`{"status": "denied", "error": "…requires explicit user approval…"}` instead of
+executing. The Agent UI handler is the surface with a real confirmation
+handshake (`permission_request` + `POST /api/chat/confirm-tool`).
+
+If you are deliberately running an unattended agent through this server and
+accept that the model can write files and run shell commands unprompted, set
+`GAIA_AUTO_APPROVE_TOOLS=1` in the server's environment; every approval is logged
+with the tool name. See [Output Handlers](../core/console#confirming-dangerous-tools).
+
 ---
 
 ## Related Topics

--- a/docs/sdk/sdks/governance.mdx
+++ b/docs/sdk/sdks/governance.mdx
@@ -105,8 +105,9 @@ agent = MyAgent(
 An explicit `governance_reviewer` takes precedence. If none is configured,
 governance delegates to `console.confirm_tool_execution` only when the console
 advertises `blocking_confirmation = True`; Agent UI's `SSEOutputHandler` does
-this and emits the existing `permission_request` modal. GAIA's default console is
-not consulted because its confirmation method auto-approves.
+this and emits the existing `permission_request` modal. GAIA's CLI console is not
+consulted: it prompts only when stdin is a terminal and denies otherwise
+(#2210), so it cannot guarantee a reviewer is reachable.
 
 When a policy returns `BLOCK`, the governed tool body is not executed and the
 adapter writes a BLOCK receipt. If the active console supports

--- a/docs/spec/console.mdx
+++ b/docs/spec/console.mdx
@@ -205,12 +205,62 @@ class OutputHandler(ABC):
     def display_stats(self, stats: Dict[str, Any]):
         """Display performance statistics. Optional - default no-op."""
         ...
+
+    # === Confirmation of gated tools (#2210) ===
+
+    auto_approve_gated_tools: bool = False   # explicit unattended opt-in
+
+    def confirm_tool_execution(self, tool_name: str, tool_args: Dict[str, Any]) -> bool:
+        """Approve or deny a tool in ``Agent.confirmation_required_tools()``.
+
+        DENIES by default: a handler with no way to reach a human must not answer
+        on their behalf. Overridden by the CLI consoles (terminal prompt) and the
+        Agent UI handler (permission modal).
+        """
+        ...
+
+    def confirmation_denied_reason(self, tool_name: str) -> str:
+        """Why the last denial happened, for the ``{"status": "denied"}`` result."""
+        ...
+```
+
+<Warning>
+  A handler that inherits this default and cannot ask anyone will refuse every
+  gated tool. That is deliberate — silently approving shell commands, file writes,
+  and email sends is the failure mode this replaced. An intentionally unattended
+  host opts in with `auto_approve_gated_tools=True` or
+  `GAIA_AUTO_APPROVE_TOOLS=1` (read from the startup environment, so a `.env`
+  cannot set it), and every approval taken that way is logged.
+</Warning>
+
+### TerminalConfirmationMixin
+
+```python
+class TerminalConfirmationMixin:
+    """The terminal prompt shared by both CLI consoles.
+
+    Mixed into AgentConsole *and* SilentConsole: silence suppresses narration,
+    not consent — `gaia chat` builds a SilentConsole for a real user at a real
+    terminal.
+
+    - stdin AND stdout a TTY -> shows the tool and its literal arguments, then
+      reads `[y]es / [N]o / [a]lways for this tool`. Default is no; Ctrl-C and
+      EOF are no. "always" is per tool and never offered for
+      `run_shell_command` / `run_cli_command`.
+    - otherwise -> denies with an actionable message.
+    - a broken terminal (render or read fails) -> denies; the gate never raises
+      into the agent loop.
+    """
+
+    def confirm_tool_execution(self, tool_name: str, tool_args: Any) -> bool: ...
+    def reset_tool_approvals(self) -> None:
+        """Forget every "always allow" answer (new session / new user)."""
 ```
 
 ### AgentConsole
 
 ```python
-class AgentConsole(OutputHandler):
+class AgentConsole(TerminalConfirmationMixin, OutputHandler):
     """
     Rich console output for CLI applications.
 
@@ -222,8 +272,14 @@ class AgentConsole(OutputHandler):
     - Formatted tables for statistics
     """
 
-    def __init__(self):
-        """Initialize the AgentConsole with Rich library support."""
+    def __init__(self, auto_approve_gated_tools: bool = False):
+        """Initialize the AgentConsole with Rich library support.
+
+        Args:
+            auto_approve_gated_tools: Unattended harnesses only — run
+                confirmation-gated tools without asking. Every approval is logged.
+        """
+        self.auto_approve_gated_tools = auto_approve_gated_tools
         self.rich_available = RICH_AVAILABLE
         self.console = Console() if self.rich_available else None
         self.progress = ProgressIndicator()
@@ -274,7 +330,7 @@ class AgentConsole(OutputHandler):
 ### SilentConsole
 
 ```python
-class SilentConsole(OutputHandler):
+class SilentConsole(TerminalConfirmationMixin, OutputHandler):
     """
     Silent console that suppresses all output for JSON-only mode.
 
@@ -286,17 +342,27 @@ class SilentConsole(OutputHandler):
     All methods are no-ops except:
     - print_final_answer (unless silence_final_answer=True)
     - display_stats (if explicitly requested)
+    - confirm_tool_execution (still prompts on a terminal — consent is not
+      narration; the unattended denial notice is logged, not printed, so
+      JSON-only output stays parseable)
     """
 
-    def __init__(self, silence_final_answer: bool = False):
+    def __init__(
+        self,
+        silence_final_answer: bool = False,
+        auto_approve_gated_tools: bool = False,
+    ):
         """
         Initialize the silent console.
 
         Args:
             silence_final_answer: If True, suppress even the final answer
+            auto_approve_gated_tools: Unattended harnesses only — run
+                confirmation-gated tools without asking. Every approval is logged.
         """
         self.streaming_buffer = ""
         self.silence_final_answer = silence_final_answer
+        self.auto_approve_gated_tools = auto_approve_gated_tools
 
     def print_final_answer(self, answer: str, streaming: bool = True) -> None:
         """

--- a/src/gaia/__init__.py
+++ b/src/gaia/__init__.py
@@ -8,9 +8,45 @@ AMD's framework for running generative AI applications locally on AMD hardware.
 
 # Load environment variables from .env file BEFORE any other imports
 # This ensures all SDK components respect .env configuration
+import logging as _logging
+import os as _os
+import typing as _typing
+
 from dotenv import load_dotenv
 
+# The REAL process environment, captured before ``.env`` is merged in.
+_PRE_DOTENV_ENVIRON = dict(_os.environ)
+
 load_dotenv()
+
+
+def pre_dotenv_env(name: str) -> "_typing.Optional[str]":
+    """Read a variable from the process environment as it was at startup.
+
+    Security-sensitive opt-ins must use this instead of ``os.environ``: a
+    ``.env`` file travels with a directory and is not a decision the operator
+    made, so it must not be able to grant a permission (#2210 —
+    ``GAIA_AUTO_APPROVE_TOOLS``). Everything else should keep reading
+    ``os.environ``; configuring the rest through ``.env`` is intended.
+    """
+    return _PRE_DOTENV_ENVIRON.get(name)
+
+
+# Warn loudly when a ``.env`` tried to grant unattended tool approval. The
+# guarantee comes from ``pre_dotenv_env`` above, not from scrubbing — several
+# modules call ``load_dotenv()`` again on import, which would re-inject it.
+# Keep the name in sync with ``gaia.agents.base.console.AUTO_APPROVE_ENV_VAR``
+# (a unit test pins this).
+_AUTO_APPROVE_TOOLS_VAR = "GAIA_AUTO_APPROVE_TOOLS"
+if (
+    _AUTO_APPROVE_TOOLS_VAR in _os.environ
+    and _AUTO_APPROVE_TOOLS_VAR not in _PRE_DOTENV_ENVIRON
+):
+    _logging.getLogger(__name__).warning(
+        "Ignoring %s from a .env file — unattended approval of confirmation-gated "
+        "tools must come from the process environment, not a project file.",
+        _AUTO_APPROVE_TOOLS_VAR,
+    )
 
 # pylint: disable=wrong-import-position
 from gaia.agents.base import Agent, MCPAgent, tool  # noqa: F401, E402

--- a/src/gaia/agents/base/agent.py
+++ b/src/gaia/agents/base/agent.py
@@ -1907,6 +1907,20 @@ Do NOT wrap conversational replies in JSON.
             cls.CONFIRMATION_REQUIRED_TOOLS
         )
 
+    def _confirmation_denied_error(self, tool_name: str) -> str:
+        """Explain a confirmation denial to the model in the tool result.
+
+        Consoles may expose ``confirmation_denied_reason`` to distinguish "a human
+        said no" from "nothing could ask a human" (#2210); duck-typed so custom
+        handlers without the hook still get the generic wording.
+        """
+        reason_hook = getattr(self.console, "confirmation_denied_reason", None)
+        if callable(reason_hook):
+            reason = reason_hook(tool_name)
+            if reason:
+                return str(reason)
+        return f"Tool '{tool_name}' was denied by the user."
+
     def _execute_tool(self, tool_name: str, tool_args: Dict[str, Any]) -> Any:
         """
         Execute a tool by name with the provided arguments.
@@ -1977,13 +1991,14 @@ Do NOT wrap conversational replies in JSON.
                 return {"status": "error", "error": err}
 
         # Guardrail: require explicit user confirmation for high-risk tools.
-        # The SSEOutputHandler overrides this to block until the frontend
-        # responds; the default implementation auto-approves (CLI path).
+        # Consoles that cannot reach a human deny rather than answer for them
+        # (#2210): AgentConsole prompts on a TTY, SSEOutputHandler blocks on the
+        # frontend modal, everything else denies with an actionable message.
         if tool_name in self.confirmation_required_tools():
             if not self.console.confirm_tool_execution(tool_name, tool_args):
                 return {
                     "status": "denied",
-                    "error": f"Tool '{tool_name}' was denied by the user.",
+                    "error": self._confirmation_denied_error(tool_name),
                 }
 
         # Dynamic tool loader (#1449): record use for LRU recency. The name is

--- a/src/gaia/agents/base/console.py
+++ b/src/gaia/agents/base/console.py
@@ -3,11 +3,13 @@
 
 import json
 import logging
+import os
 import subprocess
+import sys
 import threading
 import time
 from abc import ABC, abstractmethod
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Set, Tuple
 
 from gaia.agents.base.tools import get_tool_display_name
 
@@ -53,6 +55,128 @@ ANSI_MAGENTA = "\033[95m"
 ANSI_CYAN = "\033[96m"
 
 
+# === Confirmation-gated tools (#2210) ===
+#
+# Tools in ``Agent.confirmation_required_tools()`` must never execute without an
+# explicit human decision. A console that cannot reach a human DENIES. The only
+# ways to pre-approve them for a trusted unattended run (CI, a batch job, a host
+# that already asked the user) are ``GAIA_AUTO_APPROVE_TOOLS=1`` in the real
+# process environment or ``auto_approve_gated_tools=True`` on the console; every
+# auto-approval is logged with the tool name.
+AUTO_APPROVE_ENV_VAR = "GAIA_AUTO_APPROVE_TOOLS"
+
+_TRUTHY_ENV_VALUES = frozenset({"1", "true", "yes", "on"})
+
+# Confirmation prompts show the literal arguments so the user approves what will
+# actually happen. Individual long values are shortened head+tail — never the
+# whole payload from the front, because for a shell command or a file path the
+# decision-critical part is often at the end.
+MAX_CONFIRMATION_VALUE_CHARS = 600
+
+# "Always allow" is never offered for these: the tool name says nothing about
+# what the next call will do, so one approval would hand over arbitrary
+# execution for the rest of the session.
+NO_ALWAYS_ALLOW_TOOLS = frozenset({"run_shell_command", "run_cli_command"})
+
+
+def auto_approve_env_enabled() -> bool:
+    """True when the operator opted into unattended approval of gated tools.
+
+    Reads the environment as it was at startup, before any ``.env`` was merged
+    in (``gaia.pre_dotenv_env``): a project-local file must not be able to switch
+    off every confirmation prompt. A library host that wants unattended approval
+    passes ``auto_approve_gated_tools=True`` to its console instead.
+    """
+    import gaia  # deferred: gaia/__init__ imports this module
+
+    reader = getattr(gaia, "pre_dotenv_env", None)
+    if reader is None:  # partially-initialised package — assume no opt-in
+        return False
+    return (reader(AUTO_APPROVE_ENV_VAR) or "").strip().lower() in _TRUTHY_ENV_VALUES
+
+
+def unattended_denial_message(tool_name: str) -> str:
+    """Actionable denial text for a gated tool with no human to ask."""
+    return (
+        f"'{tool_name}' requires explicit user approval and cannot run "
+        "unattended: this console has no interactive terminal to ask on. "
+        "Re-run the request from an interactive terminal to approve it, or set "
+        f"{AUTO_APPROVE_ENV_VAR}=1 to pre-approve confirmation-gated tools for "
+        "a trusted automated run."
+    )
+
+
+def user_denial_message(tool_name: str) -> str:
+    """Denial text for a human who was asked and said no."""
+    return f"Tool '{tool_name}' was denied by the user."
+
+
+def unaskable_denial_message(tool_name: str) -> str:
+    """Denial text for when the terminal broke mid-question.
+
+    Approving something the user never saw — or never answered — is not an
+    option, so a broken prompt denies.
+    """
+    return (
+        f"'{tool_name}' requires explicit user approval, and this terminal could "
+        "not present the request or read an answer. Nothing was executed. Retry "
+        "from a working interactive terminal, or set "
+        f"{AUTO_APPROVE_ENV_VAR}=1 for a trusted automated run."
+    )
+
+
+def terminal_is_interactive() -> bool:
+    """True when a human can both see a prompt and answer it.
+
+    Both ends must be a TTY: with stdout redirected (``gaia … > log.txt``) the
+    question lands in the file and the user is left staring at a blank screen
+    while the agent blocks on a read. Same requirement as the Lemonade installer
+    prompt in ``gaia.llm.lemonade_client``.
+    """
+    for stream in (sys.stdin, sys.stdout):
+        try:
+            if stream is None or not stream.isatty():
+                return False
+        except (AttributeError, ValueError):
+            # ValueError: stream closed (pytest capture, detached subprocess).
+            return False
+    return True
+
+
+def _shorten(value: str) -> str:
+    """Head+tail shortening, so the end of a command/path stays visible."""
+    if len(value) <= MAX_CONFIRMATION_VALUE_CHARS:
+        return value
+    keep = MAX_CONFIRMATION_VALUE_CHARS // 2
+    return f"{value[:keep]} …[{len(value)} chars]… {value[-keep:]}"
+
+
+def format_confirmation_args(tool_args: Any) -> str:
+    """Render tool arguments for a confirmation prompt.
+
+    Every argument name is always shown — a hidden key is a hidden side effect.
+    Only oversized individual values are shortened.
+
+    Accepts whatever the model actually emitted, not just a dict: a malformed
+    ``tool_args`` (a list, a bare string) must still be shown to the user rather
+    than raising, because the alternative is a crash on the one code path whose
+    job is to protect them.
+    """
+    if not tool_args:
+        return "(no arguments)"
+    if not isinstance(tool_args, dict):
+        return _shorten(str(tool_args))
+    shortened = {
+        key: _shorten(value) if isinstance(value, str) else value
+        for key, value in tool_args.items()
+    }
+    # ensure_ascii=False: the shortening marker (…) and any non-ASCII content in
+    # the arguments must stay readable in the prompt, not appear as \uXXXX.
+    return json.dumps(
+        shortened, indent=2, default=str, sort_keys=True, ensure_ascii=False
+    )
+
+
 class OutputHandler(ABC):
     """
     Abstract base class for handling agent output.
@@ -69,6 +193,21 @@ class OutputHandler(ABC):
 
     blocking_confirmation: bool = False
     """Whether ``confirm_tool_execution`` waits for an explicit user decision."""
+
+    auto_approve_gated_tools: bool = False
+    """Explicit opt-in: approve confirmation-gated tools with no human present.
+
+    Never default-on. A host sets this (or the operator sets
+    ``GAIA_AUTO_APPROVE_TOOLS=1``) when it has already obtained consent or is a
+    trusted unattended harness. Every approval taken this way is logged.
+    """
+
+    _last_denial: Optional[Tuple[str, str]] = None
+    """``(tool_name, reason)`` for the most recent denial (#2210).
+
+    Bound to the tool so a handler that denies without recording a reason can
+    never inherit the previous tool's explanation.
+    """
 
     # === Core Progress/State Methods (Required) ===
 
@@ -218,11 +357,56 @@ class OutputHandler(ABC):
 
     def confirm_tool_execution(
         self,
-        tool_name: str,  # pylint: disable=unused-argument
+        tool_name: str,
         tool_args: Dict[str, Any],  # pylint: disable=unused-argument
     ) -> bool:
-        """Request user confirmation before executing a tool. Returns True to proceed."""
-        return True
+        """Request user confirmation before executing a tool. True proceeds.
+
+        Denies by default (#2210). A handler that cannot reach a human must not
+        answer on their behalf, and denying is recoverable — the agent loop turns
+        it into a ``{"status": "denied"}`` tool result the model can act on —
+        whereas raising would abort runs mid-flight for every unattended host
+        that inherits this default. Override to actually ask (see
+        ``AgentConsole`` for the CLI prompt and ``SSEOutputHandler`` for the
+        Agent UI permission modal).
+        """
+        if self.auto_approve_confirmations_enabled():
+            self.log_auto_approval(tool_name)
+            return True
+        return self.deny_tool_execution(tool_name, unattended_denial_message(tool_name))
+
+    def auto_approve_confirmations_enabled(self) -> bool:
+        """True when this handler may approve gated tools without asking."""
+        return bool(self.auto_approve_gated_tools) or auto_approve_env_enabled()
+
+    def log_auto_approval(self, tool_name: str) -> None:
+        """Record that a gated tool ran without a human decision."""
+        self._last_denial = None
+        logger.warning(
+            "Auto-approved confirmation-gated tool '%s' — unattended approval is "
+            "enabled for this run (%s or an explicit host opt-in).",
+            tool_name,
+            AUTO_APPROVE_ENV_VAR,
+        )
+
+    def deny_tool_execution(self, tool_name: str, reason: str) -> bool:
+        """Record and log a denial, then return False for the caller to return."""
+        self._last_denial = (tool_name, reason)
+        logger.warning("Denied confirmation-gated tool '%s': %s", tool_name, reason)
+        return False
+
+    def confirmation_denied_reason(self, tool_name: str) -> str:
+        """Actionable explanation for the most recent denial.
+
+        ``Agent._execute_tool`` puts this in the ``{"status": "denied"}`` result
+        so the model (and the user reading the transcript) sees *why* — a human
+        said no, versus nothing could ask one. Falls back to the generic wording
+        unless the recorded denial is for this exact tool.
+        """
+        recorded = self._last_denial
+        if recorded and recorded[0] == tool_name:
+            return recorded[1]
+        return user_denial_message(tool_name)
 
     def print_policy_alert(
         self,
@@ -386,15 +570,200 @@ class ProgressIndicator:
             print("\r" + " " * (len(self.message) + 5) + "\r", end="", flush=True)
 
 
-class AgentConsole(OutputHandler):
+class TerminalConfirmationMixin:
+    """Asks the user, on the terminal, before a confirmation-gated tool runs.
+
+    Mixed into every console that a person might be sitting in front of —
+    ``AgentConsole`` and ``SilentConsole`` alike. Silent mode suppresses
+    *narration*, never *consent*: `gaia chat` builds a ``SilentConsole`` for a
+    real user at a real terminal, so a question it cannot ask is a tool the user
+    can never approve (#2210).
+
+    The prompt writes with plain ``print``/``input`` so it works with or without
+    Rich and regardless of how quiet the host console is; ``AgentConsole``
+    overrides ``_render_confirmation_request`` to draw it as a Rich panel.
+
+    Mix in alongside ``OutputHandler``, whose ``deny_tool_execution`` /
+    ``auto_approve_confirmations_enabled`` / progress hooks this relies on.
+    """
+
+    CONFIRMATION_PROMPT = "Allow this? [y]es / [N]o / [a]lways for this tool: "
+    CONFIRMATION_PROMPT_NO_ALWAYS = "Allow this? [y]es / [N]o: "
+
+    def confirm_tool_execution(self, tool_name: str, tool_args: Dict[str, Any]) -> bool:
+        """Ask the user on the terminal before running a gated tool.
+
+        Shows the tool and its literal arguments, then reads an answer that
+        defaults to **no**. With no interactive terminal (piped stdin, redirected
+        stdout, CI, a subprocess host) there is nobody to ask, so the call is
+        denied with an actionable message instead of silently approved (#2210).
+        """
+        if self.auto_approve_confirmations_enabled():
+            self.log_auto_approval(tool_name)
+            return True
+
+        if tool_name in self._always_allowed():
+            logger.info(
+                "Confirmation-gated tool '%s' pre-approved for this session by the user",
+                tool_name,
+            )
+            return True
+
+        if not terminal_is_interactive():
+            reason = unattended_denial_message(tool_name)
+            # A model that keeps retrying the tool would otherwise repeat the
+            # whole notice each time; the log still records every denial.
+            if tool_name not in self._notified_denials():
+                self._notified_denials().add(tool_name)
+                self._display("denial notice", self._show_denial_notice, reason)
+            return self.deny_tool_execution(tool_name, reason)
+
+        allow_always = tool_name not in NO_ALWAYS_ALLOW_TOOLS
+        # A live spinner/preview would fight with the prompt for the terminal.
+        self._display("progress pause", self.pause_progress)
+        try:
+            shown = self._display(
+                "confirmation request",
+                self._render_confirmation_request,
+                tool_name,
+                tool_args,
+            )
+            if not shown:
+                # The user never saw what they would be approving.
+                return self.deny_tool_execution(
+                    tool_name, unaskable_denial_message(tool_name)
+                )
+            answer = self._read_confirmation_answer(allow_always)
+        finally:
+            self._display("progress resume", self.resume_progress)
+
+        if answer is None:
+            return self.deny_tool_execution(
+                tool_name, unaskable_denial_message(tool_name)
+            )
+
+        if allow_always and answer in ("a", "always"):
+            self._always_allowed().add(tool_name)
+            logger.info(
+                "User approved '%s' for the remainder of this session", tool_name
+            )
+            self._last_denial = None
+            return True
+        if answer in ("y", "yes"):
+            logger.info("User approved confirmation-gated tool '%s'", tool_name)
+            self._last_denial = None
+            return True
+
+        self._display("denial echo", print, f"Denied '{tool_name}'.")
+        return self.deny_tool_execution(tool_name, user_denial_message(tool_name))
+
+    def _display(self, what: str, action: Any, *args: Any) -> bool:
+        """Run a terminal-display step; report whether it worked.
+
+        Broad by design: a broken, closed, or redirected terminal must never turn
+        the confirmation gate into a crash — before this gate existed the tool
+        just ran, so an exception escaping here would be a new way to break a
+        working session. Failures are logged with a traceback and push the
+        decision toward DENY; nothing is ever approved because rendering failed.
+        """
+        try:
+            action(*args)
+            return True
+        except Exception as exc:  # pylint: disable=broad-exception-caught
+            logger.warning(
+                "Confirmation %s failed on this terminal: %s", what, exc, exc_info=True
+            )
+            return False
+
+    def reset_tool_approvals(self) -> None:
+        """Forget every "always allow" answer.
+
+        Call when the conversation the approvals were given in ends (new session,
+        new user) so consent does not outlive its context.
+        """
+        self._always_allowed().clear()
+        self._notified_denials().clear()
+
+    def _always_allowed(self) -> Set[str]:
+        """The per-console "always allow" set, created on first use.
+
+        Lazily instantiated per instance — never a shared class-level set, which
+        would leak one user's approval into every other console in the process —
+        so a subclass that skips ``super().__init__()`` still behaves.
+        """
+        return self._lazy_tool_set("_session_approved_tools")
+
+    def _notified_denials(self) -> Set[str]:
+        """Tools whose unattended-denial notice has already been shown."""
+        return self._lazy_tool_set("_denial_notices_shown")
+
+    def _lazy_tool_set(self, attribute: str) -> Set[str]:
+        """Per-instance set of tool names, created on first use."""
+        names = getattr(self, attribute, None)
+        if names is None:
+            names = set()
+            setattr(self, attribute, names)
+        return names
+
+    def _show_denial_notice(self, reason: str) -> None:
+        """Tell the user why a gated tool was refused. Quiet consoles stay quiet
+        — the denial is always logged, and JSON-only output must stay parseable."""
+        print(f"\n⚠️  {reason}\n")
+
+    def _render_confirmation_request(
+        self, tool_name: str, tool_args: Dict[str, Any]
+    ) -> None:
+        """Show the pending tool call so the user approves what will happen."""
+        print(f"\n⚠️  Confirm: {get_tool_display_name(tool_name)}")
+        print(format_confirmation_args(tool_args))
+
+    def _read_confirmation_answer(self, allow_always: bool = True) -> Optional[str]:
+        """Read the user's answer.
+
+        Ctrl-C / EOF read as an explicit "no" (empty string). ``None`` means the
+        terminal broke before an answer could be read (a detached or closed tty
+        raises ``OSError`` from ``input()``) — the caller denies with a different
+        message, because nobody actually said no.
+        """
+        prompt = (
+            self.CONFIRMATION_PROMPT
+            if allow_always
+            else self.CONFIRMATION_PROMPT_NO_ALWAYS
+        )
+        try:
+            return input(prompt).strip().lower()
+        except (EOFError, KeyboardInterrupt):
+            self._display("newline after cancel", print)
+            return ""
+        except Exception as exc:  # pylint: disable=broad-exception-caught
+            # OSError (broken/detached tty), and anything else a hostile stdin
+            # raises. Never let it escape: see ``_display``.
+            logger.warning(
+                "Could not read a confirmation answer from this terminal: %s",
+                exc,
+                exc_info=True,
+            )
+            return None
+
+
+class AgentConsole(TerminalConfirmationMixin, OutputHandler):
     """
     A class to handle all display-related functionality for the agent.
     Provides rich text formatting and progress indicators when available.
     Implements OutputHandler for CLI-based output.
+
+    Confirmation-gated tools prompt on the terminal when stdin is interactive and
+    are denied otherwise (#2210) — see ``confirm_tool_execution``.
     """
 
-    def __init__(self):
-        """Initialize the AgentConsole with appropriate display capabilities."""
+    def __init__(self, auto_approve_gated_tools: bool = False):
+        """Initialize the AgentConsole with appropriate display capabilities.
+
+        Args:
+            auto_approve_gated_tools: Run confirmation-gated tools without asking.
+                Unattended harnesses only; every approval is logged.
+        """
+        self.auto_approve_gated_tools = auto_approve_gated_tools
         self.rich_available = RICH_AVAILABLE
         self.console = Console() if self.rich_available else None
         self.progress = ProgressIndicator()
@@ -964,8 +1333,6 @@ class AgentConsole(OutputHandler):
             caption: Optional caption to display
             prompt_to_open: If True, prompt user to open in default viewer after display
         """
-        import os
-        import sys
         from pathlib import Path
 
         path = Path(image_path)
@@ -1092,6 +1459,36 @@ class AgentConsole(OutputHandler):
             print("=" * 50)
             print(diff)
             print("=" * 50 + "\n")
+
+    # === Tool Confirmation (Rich rendering of the mixin's prompt) ===
+
+    def _show_denial_notice(self, reason: str) -> None:
+        """Surface an unattended denial in the CLI's usual warning style."""
+        self.print_warning(reason)
+
+    def _render_confirmation_request(
+        self, tool_name: str, tool_args: Dict[str, Any]
+    ) -> None:
+        """Show the pending tool call as a panel with its literal arguments."""
+        if not self.rich_available:
+            super()._render_confirmation_request(tool_name, tool_args)
+            return
+
+        body = format_confirmation_args(tool_args)
+        renderable = (
+            Syntax(body, "json", theme="monokai", word_wrap=True)
+            if Syntax is not None and tool_args
+            else body
+        )
+        self.console.print()
+        self.console.print(
+            Panel(
+                renderable,
+                title=f"⚠️  Confirm: {get_tool_display_name(tool_name)}",
+                border_style="yellow",
+                padding=(0, 1),
+            )
+        )
 
     def print_repeated_tool_warning(self) -> None:
         """Print a warning about repeated tool calls."""
@@ -1546,8 +1943,6 @@ class AgentConsole(OutputHandler):
             bytes_total: Total bytes to download
             speed_mbps: Download speed in MB/s (optional)
         """
-        import sys
-
         # Format sizes
         if bytes_total > 1024**3:  # > 1 GB
             dl_str = f"{bytes_downloaded / 1024**3:.2f} GB"
@@ -2032,21 +2427,38 @@ class AgentConsole(OutputHandler):
         )
 
 
-class SilentConsole(OutputHandler):
+class SilentConsole(TerminalConfirmationMixin, OutputHandler):
     """
     A silent console that suppresses all output for JSON-only mode.
     Provides the same interface as AgentConsole but with no-op methods.
     Implements OutputHandler for silent/suppressed output.
+
+    Silence covers narration, not consent: `gaia chat` runs on this console with
+    a real user at the terminal, so confirmation-gated tools still prompt when
+    stdin/stdout are a TTY and are denied otherwise (#2210). The unattended
+    denial notice is logged rather than printed, so JSON-only output stays clean.
     """
 
-    def __init__(self, silence_final_answer: bool = False):
+    def __init__(
+        self,
+        silence_final_answer: bool = False,
+        auto_approve_gated_tools: bool = False,
+    ):
         """Initialize the silent console.
 
         Args:
             silence_final_answer: If True, suppress even the final answer (for JSON-only mode)
+            auto_approve_gated_tools: Run confirmation-gated tools without asking.
+                Unattended harnesses only; every approval is logged.
         """
         self.streaming_buffer = ""  # Maintain compatibility
         self.silence_final_answer = silence_final_answer
+        self.auto_approve_gated_tools = auto_approve_gated_tools
+
+    def _show_denial_notice(self, reason: str) -> None:
+        """Stay silent — JSON-only output must remain parseable. The denial is
+        still logged by ``deny_tool_execution`` and returned to the caller in the
+        tool result."""
 
     # Implementation of OutputHandler abstract methods - all no-ops
     def print_final_answer(

--- a/src/gaia/api/sse_handler.py
+++ b/src/gaia/api/sse_handler.py
@@ -24,6 +24,13 @@ class SSEOutputHandler(OutputHandler):
     Each output is converted to a dictionary and added to a queue
     that can be consumed by the API server.
 
+    This stream is one-way: there is no channel for the client to answer a
+    permission request, so confirmation-gated tools (shell, file mutation, email
+    send/delete) are DENIED here via the inherited ``OutputHandler`` default
+    (#2210) rather than silently approved. An operator running an intentionally
+    unattended agent opts in with ``GAIA_AUTO_APPROVE_TOOLS=1``; the proper fix
+    is a permission event plus a resolve endpoint, as the Agent UI has.
+
     Args:
         debug_mode: If True, include verbose event details. If False, only stream
                    clean, user-friendly status updates.

--- a/src/gaia/cli.py
+++ b/src/gaia/cli.py
@@ -2778,6 +2778,22 @@ Examples:
         help="Use stdio transport instead of HTTP (for Claude Code / eval runner integration)",
     )
 
+    mcp_tui_parser = mcp_subparsers.add_parser(
+        "tui",
+        help="Start TUI control MCP server (drives a running `gaia tui --control`)",
+    )
+    mcp_tui_parser.add_argument(
+        "--host", default="localhost", help="Host to bind to (default: localhost)"
+    )
+    mcp_tui_parser.add_argument(
+        "--port", type=int, default=8767, help="Port to listen on (default: 8767)"
+    )
+    mcp_tui_parser.add_argument(
+        "--stdio",
+        action="store_true",
+        help="Use stdio transport instead of HTTP (for Claude Code integration)",
+    )
+
     # MCP Client commands (connect to external MCP servers).
     # `add` and `remove` moved to `gaia connectors mcp add/remove` (#977) so
     # configuration goes through the connectors framework with keyring-backed
@@ -7508,6 +7524,8 @@ def handle_mcp_command(args):
         handle_mcp_docker(args)
     elif args.mcp_action == "serve":
         handle_mcp_serve(args)
+    elif args.mcp_action == "tui":
+        handle_mcp_tui(args)
     elif args.mcp_action == "list":
         handle_mcp_list(args)
     elif args.mcp_action == "tools":
@@ -8135,6 +8153,55 @@ def handle_mcp_serve(args):
     except Exception as e:
         log.error(f"Error starting Agent UI MCP server: {e}")
         print(f"❌ Error starting Agent UI MCP server: {e}")
+
+
+def handle_mcp_tui(args):
+    """Start the TUI control MCP server (drives a running `gaia tui --control`)."""
+    log = get_logger(__name__)
+
+    try:
+        from gaia.mcp.servers.tui_mcp import create_tui_mcp, route_logging_to_stderr
+
+        mcp = create_tui_mcp()
+
+        if args.stdio:
+            # stdout carries JSON-RPC only; GAIA's root log handler writes there.
+            route_logging_to_stderr()
+            print(
+                "Starting GAIA TUI Control MCP Server (stdio mode)...",
+                file=__import__("sys").stderr,
+            )
+            mcp.run(transport="stdio")
+        else:
+            mcp.settings.host = args.host
+            mcp.settings.port = args.port
+
+            print("=" * 60)
+            print("🖥️  GAIA TUI Control MCP Server")
+            print("=" * 60)
+            print("   Target  : the running `gaia tui --control` session")
+            print(f"   MCP     : http://{args.host}:{args.port}/mcp")
+            try:
+                tool_count = len(
+                    mcp._tool_manager._tools
+                )  # pylint: disable=protected-access
+                print(f"   Tools   : {tool_count} registered")
+            except AttributeError:
+                log.debug("FastMCP tool registry layout changed; skipping tool count")
+            print("\nPress Ctrl+C to stop")
+            print("=" * 60)
+            mcp.run(transport="streamable-http")
+
+    except KeyboardInterrupt:
+        print("\n✅ TUI control MCP server stopped")
+    except ImportError as e:
+        log.error(f"Failed to import TUI control MCP server: {e}")
+        print("❌ Error: Could not load the TUI control MCP server")
+        print(f"   {e}")
+        print('   Install the MCP extras: uv pip install -e ".[mcp]"')
+    except Exception as e:
+        log.error(f"Error starting TUI control MCP server: {e}")
+        print(f"❌ Error starting TUI control MCP server: {e}")
 
 
 def handle_mcp_list(args):

--- a/src/gaia/governance/README.md
+++ b/src/gaia/governance/README.md
@@ -97,9 +97,10 @@ When a `REVIEW` decision fires, an explicit `governance_reviewer`
 callback takes precedence. If none is configured, the mixin delegates to
 `console.confirm_tool_execution` only when the active console advertises
 `blocking_confirmation = True`. Agent UI's `SSEOutputHandler` sets this flag and
-emits the existing `permission_request` modal. GAIA's default console is not used
-as an implicit reviewer because it returns `True`, and a silent auto-approve
-would defeat the decision.
+emits the existing `permission_request` modal. GAIA's CLI console is not used as
+an implicit reviewer: it prompts only when stdin is a terminal (#2210), so it
+cannot promise a live decision channel — governance keeps failing closed unless
+the caller wraps it in an explicit `governance_reviewer`.
 
 ```python
 def my_reviewer(tool_name, tool_args, decision) -> bool:

--- a/src/gaia/governance/mixin.py
+++ b/src/gaia/governance/mixin.py
@@ -327,13 +327,12 @@ class GovernedAgentMixin:
         intentionally NOT caught — those should propagate.
 
         An explicit ``governance_reviewer`` callback takes precedence.
-        Without one, GAIA's ``AgentConsole.confirm_tool_execution`` is
-        consulted only when the console advertises
-        ``blocking_confirmation = True``. The default console returns
-        ``True`` immediately, so silently treating every console as a
-        reviewer would break the fail-closed contract. Agent UI's
-        ``SSEOutputHandler`` sets that flag because it blocks on the
-        frontend permission modal.
+        Without one, ``console.confirm_tool_execution`` is consulted only
+        when the console advertises ``blocking_confirmation = True``.
+        ``AgentConsole`` does not: it prompts only when stdin is a terminal
+        and denies otherwise (#2210), so it cannot promise a reviewer is
+        reachable. Agent UI's ``SSEOutputHandler`` sets the flag because it
+        blocks on the frontend permission modal.
         """
         reviewer = self._governance_reviewer
         if reviewer is None:

--- a/src/gaia/mcp/servers/tui_mcp.py
+++ b/src/gaia/mcp/servers/tui_mcp.py
@@ -1,0 +1,1442 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+"""MCP server that drives the GAIA terminal UI through its local control API.
+
+Lets an MCP client (Claude Code, the eval harness, a script) read what the TUI
+is currently showing, send keystrokes and text to it, wait for the screen to
+reach a given state, and drive high-level flows like launching an agent from
+the hub.
+
+The TUI must be started with its control server enabled (``gaia tui --control``).
+That server binds loopback on an ephemeral port and advertises itself in
+``~/.gaia/tui/control.json`` (mode 0600), so every tool here starts by
+discovering and validating that file rather than assuming a fixed port.
+
+Usage:
+    uv run python -m gaia.mcp.servers.tui_mcp --stdio
+    uv run python -m gaia.mcp.servers.tui_mcp --port 8767
+"""
+
+import argparse
+import json
+import logging
+import os
+import re
+import sys
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Union
+
+import requests
+
+from gaia.logger import get_logger
+
+if TYPE_CHECKING:  # import only for type checking; runtime import is lazy (#1750)
+    from mcp.server.fastmcp import FastMCP
+
+logger = get_logger(__name__)
+
+# ── Control-server contract ──────────────────────────────────────────
+
+#: Directory holding ``control.json``. ``GAIA_TUI_HOME`` overrides it (tests, and
+#: side-by-side TUIs); the override is read on every call, never cached.
+ENV_TUI_HOME = "GAIA_TUI_HOME"
+CONTROL_FILE_NAME = "control.json"
+
+#: Stable identity the control server stamps into the file and returns from
+#: ``/control/v1/status``. A foreign process that grabbed the recycled port
+#: cannot answer with this id, so the probe below rejects it.
+SERVICE_ID = "gaia-tui-control"
+API_PREFIX = "/control/v1"
+AUTH_SCHEME = "Bearer"
+
+#: Loopback answers in milliseconds; a longer wait only delays the "no TUI" verdict.
+PROBE_TIMEOUT = 1.5
+REQUEST_TIMEOUT = 15.0
+
+#: Extra seconds added to a ``/wait`` request's HTTP timeout on top of the
+#: caller's ``timeout_ms``, so the server's own 408 always wins the race.
+WAIT_TIMEOUT_SLACK = 5.0
+
+#: How much screen text an error detail carries before it is truncated.
+SCREEN_TRUNCATE = 2000
+
+#: Tab presses allowed when the build reports no ``hub_tab_index`` and the wrap
+#: back to the starting tab therefore cannot be detected.
+MAX_TAB_PROBES = 4
+
+#: Runaway guard for the tab cycle; the wrap-detection is what normally ends it.
+MAX_HUB_TABS = 32
+
+#: Server-side limits (``tui/internal/control/server.go``). Enforced here too so
+#: an out-of-range argument gets a useful message instead of a bare 400.
+MIN_COLS, MAX_COLS = 20, 500
+MIN_ROWS, MAX_ROWS = 5, 200
+MAX_KEYS_PER_CALL = 100
+MAX_DELAY_MS = 2000
+MAX_WAIT_MS = 10 * 60 * 1000
+
+#: A batch's total pause budget (``delay_ms × (count - 1)``), so a request can
+#: never outlive the client's own HTTP timeout.
+MAX_INJECTION_DELAY_MS = 10_000
+
+#: The TUI ships as its own binary; ``gaia tui`` is the packaged entry point and
+#: ``tui/bin/gaia`` the source build. Both spellings are given because a remedy
+#: the reader cannot actually run is not a remedy.
+_START_CMD = "gaia tui --control (source build: ./tui/bin/gaia --control)"
+START_HINT = f"Start one with: {_START_CMD}"
+RESTART_HINT = f"Restart it with: {_START_CMD}"
+
+#: Only loopback is ever legitimate: the control server binds 127.0.0.1 and the
+#: bearer token must never be sent anywhere else.
+LOOPBACK_HOSTS = frozenset({"127.0.0.1", "localhost", "::1"})
+
+#: requests honours HTTP_PROXY/ALL_PROXY by default. Loopback must never be
+#: proxied — it would hand the bearer token and the screen text to the proxy.
+NO_PROXY: Dict[str, Any] = {"http": None, "https": None}
+
+MCP_DEFAULT_PORT = 8767  # 8765/8766 belong to agent_ui_mcp
+MCP_DEFAULT_HOST = "localhost"
+
+
+# ── Discovery ────────────────────────────────────────────────────────
+
+
+class ControlHomeError(RuntimeError):
+    """Raised when neither ``GAIA_TUI_HOME`` nor a home directory is resolvable."""
+
+
+def control_dir() -> Path:
+    """Directory that contains ``control.json`` (``GAIA_TUI_HOME`` overrides)."""
+    override = os.environ.get(ENV_TUI_HOME)
+    if override:
+        return Path(override)
+    try:
+        return Path.home() / ".gaia" / "tui"
+    except RuntimeError as e:
+        raise ControlHomeError(
+            f"Cannot locate your home directory ({e}), so the GAIA TUI control "
+            f"file cannot be found. Set {ENV_TUI_HOME} to the directory holding "
+            f"{CONTROL_FILE_NAME}."
+        ) from e
+
+
+def control_path() -> Path:
+    """Full path to the TUI control file."""
+    return control_dir() / CONTROL_FILE_NAME
+
+
+def _display_path() -> str:
+    """``control_path()`` with the user's home collapsed to ``~`` for messages."""
+    path = control_path()
+    try:
+        return f"~/{path.relative_to(Path.home())}"
+    except (ValueError, RuntimeError):
+        return str(path)
+
+
+def read_control_file() -> Optional[Dict[str, Any]]:
+    """Load ``control.json``.
+
+    Returns ``None`` when the file is absent, unreadable, or malformed — a
+    half-written or garbage file is "no trustworthy TUI", never an exception the
+    caller has to catch. Malformed content is logged so it is not silent.
+    """
+    path = control_path()
+    try:
+        raw = path.read_text(encoding="utf-8")
+    except FileNotFoundError:
+        return None
+    except OSError as e:
+        logger.warning("tui: cannot read %s: %s", path, e)
+        return None
+    try:
+        data = json.loads(raw)
+        if not isinstance(data, dict):
+            raise TypeError(f"expected a JSON object, got {type(data).__name__}")
+        return {
+            "pid": int(data["pid"]),
+            "port": int(data["port"]),
+            "token": str(data["token"]),
+            "host": str(data.get("host", "127.0.0.1")),
+            "service": str(data.get("service", SERVICE_ID)),
+            "api_version": str(data.get("api_version", "v1")),
+            "started_at": float(data.get("started_at", 0.0)),
+            "version": str(data.get("version", "")),
+        }
+    except (ValueError, KeyError, TypeError) as e:
+        logger.warning(
+            "tui: %s is present but malformed (%s); treating as stale", path, e
+        )
+        return None
+
+
+def pid_alive(pid: int) -> bool:
+    """True if *pid* refers to a running (non-zombie) process."""
+    import psutil
+
+    try:
+        return psutil.pid_exists(pid) and psutil.Process(pid).status() not in (
+            psutil.STATUS_ZOMBIE,
+            psutil.STATUS_DEAD,
+        )
+    except (psutil.NoSuchProcess, psutil.AccessDenied):
+        # AccessDenied means the pid exists but belongs to another user; the
+        # token-authed probe below is the real check either way.
+        return bool(psutil.pid_exists(pid))
+
+
+def base_url_of(info: Dict[str, Any]) -> str:
+    """Loopback base URL for a discovered control server."""
+    return f"http://{info['host']}:{info['port']}"
+
+
+def _err(detail: str) -> Dict[str, Any]:
+    return {"status": "error", "detail": detail}
+
+
+def _probe(info: Dict[str, Any], timeout: float) -> Tuple[Optional[dict], str]:
+    """Token-authed ``/status`` probe.
+
+    Returns ``(body, "")`` when the server is genuinely our TUI, otherwise
+    ``(None, kind)`` where *kind* is ``"unreachable"`` (no answer / not JSON)
+    or ``"foreign"`` (answered, but a different service or pid).
+    """
+    url = f"{base_url_of(info)}{API_PREFIX}/status"
+    try:
+        r = requests.get(
+            url,
+            headers={"Authorization": f"{AUTH_SCHEME} {info['token']}"},
+            timeout=timeout,
+            proxies=NO_PROXY,
+        )
+    except requests.exceptions.RequestException:
+        return None, "unreachable"
+    if r.status_code != 200:
+        return None, "unreachable"
+    try:
+        body = r.json()
+    except ValueError:
+        return None, "unreachable"
+    if not isinstance(body, dict) or body.get("service") != SERVICE_ID:
+        return None, "foreign"
+    try:
+        if int(body.get("pid", -1)) != info["pid"]:
+            return None, "foreign"
+    except (TypeError, ValueError):
+        return None, "foreign"
+    return body, ""
+
+
+def discover(
+    timeout: float = PROBE_TIMEOUT,
+) -> Tuple[Optional[Dict[str, Any]], Optional[Dict[str, Any]]]:
+    """Find the running TUI's control server.
+
+    Returns ``(info, None)`` on success or ``(None, error_dict)`` — exactly one
+    is non-None. Trust requires two checks, because a crashed TUI leaves a file
+    behind and the OS happily recycles both its pid and its port: the recorded
+    pid must be alive AND the recorded port must answer a token-authed status
+    probe with our service id and that same pid.
+    """
+    try:
+        disp = _display_path()
+        # Read first, then classify — checking existence first would call a file
+        # deleted in between "malformed" and tell the user to delete it again.
+        info = read_control_file()
+        missing = info is None and not control_path().exists()
+    except ControlHomeError as e:
+        return None, _err(str(e))
+
+    if info is None:
+        if missing:
+            return None, _err(
+                f"No GAIA TUI is running (no control file at {disp}). {START_HINT}"
+            )
+        return None, _err(
+            f"The GAIA TUI control file at {disp} is malformed or unreadable, so it "
+            f"cannot be trusted. Delete it and start a fresh TUI with: "
+            f"gaia tui --control"
+        )
+
+    if info["host"] not in LOOPBACK_HOSTS:
+        # The token travels on every request; a control file naming a remote
+        # host would hand it — and the screen contents — to that host.
+        return None, _err(
+            f"The GAIA TUI control file at {disp} names a non-loopback host "
+            f"({info['host']!r}). The control server only ever binds 127.0.0.1, so "
+            f"this file has been tampered with or corrupted. Delete it and "
+            f"{RESTART_HINT.lower()}"
+        )
+
+    if not pid_alive(info["pid"]):
+        return None, _err(
+            f"No GAIA TUI is running: the control file at {disp} records pid "
+            f"{info['pid']}, which is not running — a stale control file left by a "
+            f"crashed TUI. {START_HINT}"
+        )
+
+    body, kind = _probe(info, timeout=timeout)
+    if kind == "unreachable":
+        return None, _err(
+            f"The GAIA TUI recorded in {disp} (pid {info['pid']}) did not answer the "
+            f"control status probe on its recorded port. The TUI may be hung, or the "
+            f"port may have been recycled by another process. {RESTART_HINT}"
+        )
+    if kind == "foreign":
+        return None, _err(
+            f"Another process now owns the port recorded in {disp} — it answered the "
+            f"probe but is not this GAIA TUI (service or pid mismatch), so the control "
+            f"file is stale. {RESTART_HINT}"
+        )
+
+    resolved = dict(info)
+    resolved["status"] = body
+    return resolved, None
+
+
+def _discovered() -> Tuple[Dict[str, Any], Optional[Dict[str, Any]]]:
+    """:func:`discover` with the info slot always a dict, for call sites.
+
+    The dict is empty exactly when the error is set, so ``if error: return error``
+    remains the only branch a tool needs.
+    """
+    info, error = discover()
+    return (info or {}), error
+
+
+# ── HTTP plumbing ────────────────────────────────────────────────────
+
+
+def _scrub(text: str, base_url: str, token: str = "") -> str:
+    """Strip the control server's URL and auth token out of a message."""
+    out = (text or "").replace(base_url, "")
+    # urllib3 spells the endpoint host:port in some messages, without a scheme.
+    out = out.replace(base_url.replace("http://", ""), "")
+    if token:
+        out = out.replace(token, "<redacted>")
+    return out.strip()
+
+
+def _normalize_error(
+    e: Exception,
+    base_url: str,
+    status_code: Optional[int] = None,
+    token: str = "",
+) -> Dict[str, Any]:
+    """Normalize an exception into a structured error dict without leaking URLs.
+
+    Returns ``{"status": "error", "detail": "<clean message>"}``. Control-server
+    errors arrive as ``{"error": {"code", "message", "hint"}}``; the message
+    (plus hint) is what the caller can act on, so unwrap it. The base URL and the
+    auth token are scrubbed — an error body is a message to a user, not a place
+    to echo credentials.
+    """
+    if isinstance(e, requests.exceptions.ConnectionError):
+        result = _err(
+            f"Cannot reach the GAIA TUI control server — the TUI is no longer "
+            f"listening. {RESTART_HINT}"
+        )
+        # Flagged, not sniffed out of the prose: callers that need to know the
+        # server went away must not depend on the wording of this sentence.
+        result["unreachable"] = True
+        return result
+
+    if isinstance(e, requests.exceptions.Timeout):
+        return _err("The GAIA TUI control server did not respond in time.")
+
+    if isinstance(e, requests.exceptions.HTTPError):
+        resp = e.response
+        code = resp.status_code if resp is not None else (status_code or 0)
+        detail = ""
+        if resp is not None:
+            try:
+                body = resp.json()
+            except ValueError:
+                body = None
+            if isinstance(body, dict) and isinstance(body.get("error"), dict):
+                envelope = body["error"]
+                detail = str(envelope.get("message", "") or "")
+                hint = str(envelope.get("hint", "") or "")
+                if hint:
+                    detail = f"{detail} Hint: {hint}".strip()
+            elif resp.text:
+                detail = resp.text[:200]
+        if not detail:
+            detail = f"HTTP {code}"
+        return _err(_scrub(detail, base_url, token))
+
+    return _err(_scrub(str(e)[:400], base_url, token))
+
+
+def _raw_request(
+    info: Dict[str, Any],
+    method: str,
+    path: str,
+    *,
+    timeout: float = REQUEST_TIMEOUT,
+    **kwargs,
+) -> requests.Response:
+    """Issue a token-authed request to the control server (may raise)."""
+    url = f"{base_url_of(info)}{API_PREFIX}{path}"
+    return requests.request(
+        method.upper(),
+        url,
+        headers={"Authorization": f"{AUTH_SCHEME} {info['token']}"},
+        timeout=timeout,
+        proxies=NO_PROXY,
+        **kwargs,
+    )
+
+
+def _request(
+    info: Dict[str, Any],
+    method: str,
+    path: str,
+    *,
+    timeout: float = REQUEST_TIMEOUT,
+    **kwargs,
+) -> Dict[str, Any]:
+    """Token-authed request returning the JSON body or a structured error dict."""
+    base_url = base_url_of(info)
+    # Transport and HTTP errors are handled separately from decoding: several
+    # requests exceptions (MissingSchema, InvalidURL, InvalidJSONError) subclass
+    # ValueError, so a shared handler would report a malformed control file as
+    # "the server returned a non-JSON response" and point the user at the TUI.
+    try:
+        r = _raw_request(info, method, path, timeout=timeout, **kwargs)
+        r.raise_for_status()
+    except Exception as e:  # pylint: disable=broad-except
+        return _normalize_error(e, base_url, token=info.get("token", ""))
+    try:
+        return _json_object(r.json())
+    except ValueError:
+        return _err(
+            "The GAIA TUI control server returned a response that was not JSON. "
+            f"{RESTART_HINT}"
+        )
+
+
+def _json_object(body: Any) -> Dict[str, Any]:
+    """Return a decoded JSON body, rejecting anything that is not an object."""
+    if not isinstance(body, dict):
+        raise ValueError(f"expected a JSON object, got {type(body).__name__}")
+    return body
+
+
+def _is_error(result: Any) -> bool:
+    return isinstance(result, dict) and result.get("status") == "error"
+
+
+def _truncate(text: str, limit: int = SCREEN_TRUNCATE) -> str:
+    text = text or ""
+    if len(text) <= limit:
+        return text
+    return text[:limit] + f"\n… [truncated, {len(text)} chars total]"
+
+
+# ── State helpers ────────────────────────────────────────────────────
+
+
+def _state_of(status: Dict[str, Any]) -> Dict[str, Any]:
+    state = status.get("state")
+    return state if isinstance(state, dict) else {}
+
+
+def _view_of(status: Dict[str, Any]) -> str:
+    return _state_of(status).get("view") or "unknown"
+
+
+def _summarize(status: Dict[str, Any]) -> str:
+    """One-line human summary of what the TUI is showing."""
+    state = _state_of(status)
+    view = _view_of(status)
+
+    # A TUI whose event loop is not consuming messages reads fine but silently
+    # discards every keystroke — lead with that, it explains everything after it.
+    if status.get("running") is False:
+        return (
+            "NOT ACCEPTING INPUT — the TUI's event loop is not running (still "
+            "starting up, or the user quit it). Reads still work; keys and text "
+            "are refused. Start a fresh one with: gaia tui --control"
+        )
+
+    if view == "chat":
+        agent = state.get("agent") or "?"
+        summary = f"chat with {agent!r}"
+        if state.get("streaming"):
+            summary += ", streaming"
+        if state.get("can_return_to_hub") is False:
+            summary += " (standalone session — esc quits, there is no hub)"
+        return summary
+
+    if view == "hub":
+        parts = ["hub view"]
+        tab = state.get("hub_tab")
+        if tab:
+            parts.append(f"tab {tab!r}")
+        visible = state.get("visible_agent_ids") or []
+        parts.append(f"{len(visible)} agents visible")
+        selected = state.get("selected_agent_id")
+        if selected:
+            parts.append(f"selected {selected!r}")
+        if state.get("filtering"):
+            parts.append("search filter active")
+        overlay = state.get("overlay")
+        if overlay:
+            parts.append(f"overlay {overlay!r}")
+        return ", ".join(parts)
+
+    return (
+        "TUI is running but does not report its view state "
+        "(read the screen with tui_screen)"
+    )
+
+
+def _normalize_keys(keys: Any) -> Tuple[List[str], Optional[str]]:
+    """Accept a list of key names or one comma/space separated string."""
+    if isinstance(keys, str):
+        items: List[Any] = [keys]
+    elif isinstance(keys, (list, tuple)):
+        items = list(keys)
+    else:
+        return [], (
+            "keys must be a list of key names (e.g. ['tab', 'down', 'enter']) or a "
+            f"comma/space separated string, got {type(keys).__name__}"
+        )
+
+    out: List[str] = []
+    for item in items:
+        if not isinstance(item, str):
+            return [], (
+                f"key names must be strings, got {type(item).__name__} in the keys list"
+            )
+        if len(item) == 1:
+            # A one-character item is the key itself — "," and " " are typeable.
+            out.append(item)
+            continue
+        out.extend(part for part in re.split(r"[,\s]+", item.strip()) if part)
+
+    if not out:
+        return [], "No keys given — pass at least one key name, e.g. ['enter']."
+    return out, None
+
+
+#: Phrases the hub uses when it refuses to launch something. Matched only on a
+#: line that also names the agent.
+_REFUSAL_PHRASES = (
+    "not installed",
+    "coming soon",
+    "not available",
+    "unavailable",
+    "failed",
+)
+
+#: Verb forms for the fallback scan, where no agent name anchors the match. The
+#: hub's tab bar reads "Installed (1)  Available (9)  Coming Soon (3)", so a bare
+#: "coming soon" would quote the tab bar back as if it were an explanation.
+_REFUSAL_SENTENCES = (
+    "is not installed",
+    "is coming soon",
+    "is not available",
+    "is unavailable",
+    "failed to",
+)
+
+
+def _hub_status_line(screen: str, agent_id: str) -> str:
+    """Pull the hub's own explanation out of a rendered screen, or ``""``.
+
+    Never guesses: the last line of a hub screen is the keybinding footer, and
+    quoting that back as "the hub says" would be an invented explanation.
+    """
+    lines = [ln.strip() for ln in (screen or "").splitlines() if ln.strip()]
+    lowered_id = agent_id.lower()
+    for ln in reversed(lines):
+        low = ln.lower()
+        if lowered_id in low and any(p in low for p in _REFUSAL_PHRASES):
+            return ln
+    for ln in reversed(lines):
+        if any(p in ln.lower() for p in _REFUSAL_SENTENCES):
+            return ln
+    return ""
+
+
+_FOOTER_SEP_RE = re.compile(r"\s{2,}|\s*[·|•]\s*")
+
+
+def _parse_footer_bindings(screen: str) -> Dict[str, str]:
+    """Parse the hub footer (``Enter=launch  /=search  d=delete``) into key→action.
+
+    Returns the bindings of the last line that advertises at least two of them,
+    or ``{}`` when the screen has no recognizable footer.
+    """
+    for line in reversed([ln for ln in (screen or "").splitlines() if ln.strip()]):
+        bindings: Dict[str, str] = {}
+        for token in _FOOTER_SEP_RE.split(line.strip()):
+            if "=" not in token:
+                continue
+            key, _, action = token.partition("=")
+            key, action = key.strip(), action.strip()
+            if key and action:
+                bindings[key] = action
+        if len(bindings) >= 2:
+            return bindings
+    return {}
+
+
+_UNINSTALL_ACTION_RE = re.compile(r"uninstall|delete|remove", re.IGNORECASE)
+_INSTALL_ACTION_RE = re.compile(r"(?<!un)install", re.IGNORECASE)
+
+
+def _find_binding(bindings: Dict[str, str], kind: str) -> Optional[str]:
+    """Return the key bound to install/uninstall, or ``None`` if the hub offers none."""
+    pattern = _UNINSTALL_ACTION_RE if kind == "uninstall" else _INSTALL_ACTION_RE
+    for key, action in bindings.items():
+        if pattern.search(action):
+            return key
+    return None
+
+
+def _format_bindings(bindings: Dict[str, str]) -> str:
+    if not bindings:
+        return "none (no footer bindings were visible on screen)"
+    return "  ".join(f"{k}={v}" for k, v in bindings.items())
+
+
+# ── Tool implementations (plain functions — importable without ``mcp``) ──
+
+
+def _status() -> Dict[str, Any]:
+    info, error = _discovered()
+    if error:
+        return error
+    body = _request(info, "get", "/status")
+    if _is_error(body):
+        return body
+    body["summary"] = _summarize(body)
+    return body
+
+
+def _screen(fmt: str = "plain") -> Dict[str, Any]:
+    if fmt not in ("plain", "ansi"):
+        return _err(f"Unknown format {fmt!r} — use 'plain' (default) or 'ansi'.")
+    info, error = _discovered()
+    if error:
+        return error
+    return _request(info, "get", "/screen", params={"format": fmt})
+
+
+def _send_keys(keys: Any, delay_ms: int = 0) -> Dict[str, Any]:
+    names, key_error = _normalize_keys(keys)
+    if key_error:
+        return _err(key_error)
+    if len(names) > MAX_KEYS_PER_CALL:
+        return _err(
+            f"{len(names)} keys is more than the control server accepts in one "
+            f"call (max {MAX_KEYS_PER_CALL}) — split it across calls."
+        )
+    try:
+        delay_ms = int(delay_ms)
+    except (TypeError, ValueError):
+        return _err(f"delay_ms must be a whole number of ms, got {delay_ms!r}.")
+    if not 0 <= delay_ms <= MAX_DELAY_MS:
+        return _err(f"delay_ms must be between 0 and {MAX_DELAY_MS}, got {delay_ms}.")
+    budget = delay_ms * max(len(names) - 1, 0)
+    if budget > MAX_INJECTION_DELAY_MS:
+        return _err(
+            f"delay_ms {delay_ms} across {len(names)} keys would pause for "
+            f"{budget} ms, over the {MAX_INJECTION_DELAY_MS} ms cap — lower "
+            f"delay_ms or split the batch."
+        )
+    info, error = _discovered()
+    if error:
+        return error
+    return _request(info, "post", "/keys", json={"keys": names, "delay_ms": delay_ms})
+
+
+def _send_text(text: str) -> Dict[str, Any]:
+    if not isinstance(text, str) or not text:
+        return _err("No text given — pass the text to type into the TUI.")
+    info, error = _discovered()
+    if error:
+        return error
+    return _request(info, "post", "/text", json={"text": text})
+
+
+def _wait(
+    info: Dict[str, Any],
+    *,
+    contains: str = "",
+    absent: str = "",
+    state: Optional[Dict[str, Any]] = None,
+    timeout_ms: int = 30000,
+) -> Dict[str, Any]:
+    """POST /wait against an already-discovered control server.
+
+    A wait timeout comes back as HTTP 408 carrying the screen the TUI actually
+    had — surfaced as a structured error including that screen, because "timed
+    out" on its own tells the caller nothing about what went wrong.
+    """
+    try:
+        timeout_ms = int(timeout_ms)
+    except (TypeError, ValueError):
+        return _err(f"timeout_ms must be a whole number of ms, got {timeout_ms!r}.")
+    if not 0 < timeout_ms <= MAX_WAIT_MS:
+        return _err(
+            f"timeout_ms must be between 1 and {MAX_WAIT_MS} (10 minutes), "
+            f"got {timeout_ms}."
+        )
+
+    payload: Dict[str, Any] = {"timeout_ms": timeout_ms}
+    if contains:
+        payload["contains"] = contains
+    if absent:
+        payload["absent"] = absent
+    if state:
+        payload["state"] = state
+    if len(payload) == 1:
+        return _err(
+            "Nothing to wait for — pass at least one of contains, absent, or a state "
+            "matcher."
+        )
+
+    base_url = base_url_of(info)
+    http_timeout = int(timeout_ms) / 1000.0 + WAIT_TIMEOUT_SLACK
+    try:
+        r = _raw_request(info, "post", "/wait", timeout=http_timeout, json=payload)
+    except Exception as e:  # pylint: disable=broad-except
+        return _normalize_error(e, base_url, token=info.get("token", ""))
+
+    if r.status_code == 408:
+        try:
+            body = r.json()
+        except ValueError:
+            body = {}
+        envelope = body.get("error") if isinstance(body, dict) else {}
+        envelope = envelope if isinstance(envelope, dict) else {}
+        screen = str(envelope.get("screen", "") or "")
+        elapsed = envelope.get("elapsed_ms", timeout_ms)
+        wanted = ", ".join(
+            filter(
+                None,
+                [
+                    f"contains {contains!r}" if contains else "",
+                    f"absent {absent!r}" if absent else "",
+                    f"state {state!r}" if state else "",
+                ],
+            )
+        )
+        result = _err(
+            f"Timed out after {elapsed} ms waiting for {wanted}. "
+            f"The screen actually contained:\n{_truncate(screen)}"
+        )
+        result["matched"] = False
+        result["timed_out"] = True
+        result["elapsed_ms"] = elapsed
+        result["screen"] = screen
+        if envelope.get("state"):
+            result["state"] = envelope["state"]
+        return result
+
+    try:
+        r.raise_for_status()
+    except Exception as e:  # pylint: disable=broad-except
+        return _normalize_error(e, base_url, token=info.get("token", ""))
+    try:
+        return _json_object(r.json())
+    except ValueError:
+        return _err(
+            "The GAIA TUI control server returned a response that was not JSON. "
+            f"{RESTART_HINT}"
+        )
+
+
+def _wait_for(
+    contains: str = "", absent: str = "", timeout_ms: int = 30000
+) -> Dict[str, Any]:
+    info, error = _discovered()
+    if error:
+        return error
+    return _wait(info, contains=contains, absent=absent, timeout_ms=timeout_ms)
+
+
+def _resize(cols: int, rows: int) -> Dict[str, Any]:
+    try:
+        cols, rows = int(cols), int(rows)
+    except (TypeError, ValueError):
+        return _err("cols and rows must be integers.")
+    if not MIN_COLS <= cols <= MAX_COLS or not MIN_ROWS <= rows <= MAX_ROWS:
+        return _err(
+            f"Terminal size out of range: got {cols}x{rows}, but cols must be "
+            f"{MIN_COLS}-{MAX_COLS} and rows {MIN_ROWS}-{MAX_ROWS}."
+        )
+    info, error = _discovered()
+    if error:
+        return error
+    return _request(info, "post", "/resize", json={"cols": cols, "rows": rows})
+
+
+def _press(info: Dict[str, Any], key: str) -> Dict[str, Any]:
+    """Send one navigation key and require the TUI to have redrawn for it.
+
+    ``settled: false`` means the model was still busy, so the status read that
+    follows would describe the screen *before* the key — and every navigation
+    step here is a decision made from that status. Acting on it is the race the
+    whole state-driven design exists to avoid, so stop instead.
+    """
+    result = _request(info, "post", "/keys", json={"keys": [key], "delay_ms": 0})
+    if _is_error(result):
+        return result
+    if result.get("settled") is False:
+        return _err(
+            f"The TUI did not finish handling {key!r} in time (settled=false), so "
+            f"its reported state is not current and navigating on it would act on "
+            f"a stale screen. The key is queued and may still land — read "
+            f"tui_screen before retrying."
+        )
+    return result
+
+
+def _leave_chat(
+    info: Dict[str, Any], status: Dict[str, Any]
+) -> Tuple[Dict[str, Any], Optional[Dict[str, Any]]]:
+    """Return to the hub if a chat is open, so hub-only reads are of the hub.
+
+    Returns ``(status, None)`` with a re-read status, or ``({}, error)``.
+    """
+    if _view_of(status) != "chat":
+        return status, None
+
+    # Whether esc goes back or quits is the model's to answer, not ours to guess:
+    # in a standalone `gaia chat --subprocess` session esc IS quit, so pressing it
+    # would kill the very session we were asked to drive.
+    can_return = _state_of(status).get("can_return_to_hub")
+    if can_return is False:
+        return {}, _err(
+            "This is a standalone chat session, not a chat opened from the hub — "
+            "esc there quits the TUI instead of returning to a hub, so there is no "
+            "hub to navigate. Drive this session directly with tui_send_text and "
+            "tui_send_keys, and read it with tui_screen."
+        )
+    if can_return is None:
+        return {}, _err(
+            "The running TUI does not report can_return_to_hub, so whether esc "
+            "returns to the hub or quits the program cannot be known — and "
+            "guessing wrong ends the session. Drive it directly with "
+            f"tui_send_keys, or run a current build: {START_HINT}"
+        )
+
+    # Esc cancels an in-flight response. Throwing away the user's running turn to
+    # satisfy a navigation step is not this tool's call to make.
+    if _state_of(status).get("streaming"):
+        return {}, _err(
+            "The chat is streaming a response right now, and leaving it would "
+            "cancel that turn. Wait for it to finish (tui_wait_for) or cancel it "
+            "deliberately with tui_send_keys(['esc'])."
+        )
+
+    pressed = _press(info, "esc")
+    if _is_error(pressed):
+        return {}, pressed
+    waited = _wait(info, state={"view": "hub"}, timeout_ms=5000)
+    if _is_error(waited):
+        # A standalone `gaia chat --control` session has no hub to go back to —
+        # there esc quits, so the control server dies with it.
+        if waited.get("unreachable"):
+            return {}, _err(
+                "The TUI exited when leaving the chat: a standalone chat session "
+                "quits on esc instead of returning to a hub. Agent navigation by "
+                f"id needs the hub TUI — {START_HINT}"
+            )
+        return {}, _err(
+            f"Could not return to the hub from the chat view: {waited['detail']}"
+        )
+    status = _request(info, "get", "/status")
+    if _is_error(status):
+        return {}, status
+    return status, None
+
+
+def _navigate_to_agent(
+    info: Dict[str, Any], agent_id: str
+) -> Tuple[Optional[Dict[str, Any]], Optional[Dict[str, Any]]]:
+    """Put the hub's selection on *agent_id*.
+
+    Returns ``(status, None)`` with the status read after the last move, or
+    ``(None, error)``. Every step is driven off the TUI's reported state rather
+    than a blind key-count, so it either converges or says why it could not.
+    """
+    status = _request(info, "get", "/status")
+    if _is_error(status):
+        return None, status
+
+    if _view_of(status) == "unknown":
+        return None, _err(
+            "The running GAIA TUI does not report its view state, so high-level "
+            "navigation is unavailable in this build. Drive it manually with "
+            "tui_send_keys and read the result with tui_screen."
+        )
+
+    status, leave_error = _leave_chat(info, status)
+    if leave_error:
+        return None, leave_error
+
+    # An overlay eats the next keypress (any key dismisses help; the confirm
+    # dialog answers it), so navigating under one moves nothing and misreports
+    # why. Say what is in the way instead of pressing into it.
+    overlay = str(_state_of(status).get("overlay") or "")
+    if overlay:
+        return None, _err(
+            f"The hub is covered by the {overlay!r} overlay, which would swallow "
+            f"the navigation keys. Dismiss it first with tui_send_keys(['esc']), "
+            f"then retry."
+        )
+
+    if _state_of(status).get("filtering"):
+        pressed = _press(info, "esc")
+        if _is_error(pressed):
+            return None, pressed
+        status = _request(info, "get", "/status")
+        if _is_error(status):
+            return None, status
+
+    # Cycle tabs until the agent is among the visible ids. ``POST /keys`` applies
+    # the key before it answers, so the status read after each press is current.
+    seen: List[str] = []
+    found = False
+    first_tab_index = _state_of(status).get("hub_tab_index")
+    # The wrap back to the first tab is the real bound — the cap only stops a
+    # build that reports no tab index, so adding a hub tab cannot silently make
+    # the last one unreachable.
+    for _ in range(MAX_TAB_PROBES if first_tab_index is None else MAX_HUB_TABS):
+        state = _state_of(status)
+        visible = list(state.get("visible_agent_ids") or [])
+        if agent_id in visible:
+            found = True
+            break
+        tab = state.get("hub_tab") or "?"
+        seen.append(f"{tab}: {', '.join(visible) if visible else '(empty)'}")
+        pressed = _press(info, "tab")
+        if _is_error(pressed):
+            return None, pressed
+        status = _request(info, "get", "/status")
+        if _is_error(status):
+            return None, status
+        if first_tab_index is not None:
+            if _state_of(status).get("hub_tab_index") == first_tab_index:
+                break
+
+    if not found:
+        return None, _err(
+            f"Agent {agent_id!r} is not in any hub tab. Agents seen per tab — "
+            + " | ".join(seen)
+        )
+
+    # Move the selection onto the agent. The hub list does not wrap and keeps its
+    # cursor across a tab switch, so the direction has to be computed — pressing
+    # "down" alone never reaches a row above the cursor.
+    visible = list(_state_of(status).get("visible_agent_ids") or [])
+    selected = _state_of(status).get("selected_agent_id") or ""
+    if selected not in visible:
+        return None, _err(
+            f"The hub does not report which row is selected (it says "
+            f"{selected!r}), so the selection cannot be moved onto {agent_id!r}. "
+            f"Move it yourself with tui_send_keys(['down']) and read tui_screen."
+        )
+
+    delta = visible.index(agent_id) - visible.index(selected)
+    key = "down" if delta > 0 else "up"
+    for _ in range(abs(delta)):
+        pressed = _press(info, key)
+        if _is_error(pressed):
+            return None, pressed
+        status = _request(info, "get", "/status")
+        if _is_error(status):
+            return None, status
+
+    if _state_of(status).get("selected_agent_id") == agent_id:
+        return status, None
+
+    return None, _err(
+        f"Could not move the hub selection onto {agent_id!r} — after "
+        f"{abs(delta)} {key!r} presses the selection is "
+        f"{_state_of(status).get('selected_agent_id')!r}. The visible agents are: "
+        f"{', '.join(visible) if visible else '(none)'}."
+    )
+
+
+def _with_screen(info: Dict[str, Any], result: Dict[str, Any]) -> Dict[str, Any]:
+    """Attach the current plain screen to a success result.
+
+    A failed read reports itself in ``screen_error`` rather than passing an empty
+    string off as the screen — the caller would read that as a blank TUI.
+    """
+    screen_result = _request(info, "get", "/screen", params={"format": "plain"})
+    if _is_error(screen_result):
+        result["screen"] = ""
+        result["screen_error"] = screen_result["detail"]
+    else:
+        result["screen"] = screen_result.get("screen", "")
+    return result
+
+
+def _launch_agent(agent_id: str, timeout_ms: int = 20000) -> Dict[str, Any]:
+    if not agent_id:
+        return _err("No agent_id given — pass the agent to launch, e.g. 'email'.")
+
+    info, error = _discovered()
+    if error:
+        return error
+
+    # Already there: re-launching would close the chat and throw the conversation
+    # away to arrive back where we started.
+    opening = _request(info, "get", "/status")
+    if _is_error(opening):
+        return opening
+    if _view_of(opening) == "chat" and _state_of(opening).get("agent") == agent_id:
+        result = {"launched": True, "already_open": True, "agent": agent_id}
+        return _with_screen(info, result)
+
+    _, nav_error = _navigate_to_agent(info, agent_id)
+    if nav_error:
+        return nav_error
+
+    pressed = _press(info, "enter")
+    if _is_error(pressed):
+        return pressed
+
+    waited = _wait(
+        info, state={"view": "chat", "agent": agent_id}, timeout_ms=timeout_ms
+    )
+    if _is_error(waited):
+        # Only a genuine wait timeout means "the TUI refused"; a transport error
+        # is its own failure and must not be reported as a hub refusal.
+        status = _request(info, "get", "/status") if waited.get("timed_out") else {}
+        if not _is_error(status) and _view_of(status) == "hub":
+            screen_result = _request(info, "get", "/screen", params={"format": "plain"})
+            screen = (
+                screen_result.get("screen", "")
+                if not _is_error(screen_result)
+                else waited.get("screen", "")
+            )
+            line = _hub_status_line(screen, agent_id)
+            detail = f"The TUI stayed on the hub instead of launching {agent_id!r}."
+            if line:
+                detail += f" The hub says: {line!r}"
+            result = _err(detail)
+            result["screen"] = _truncate(screen)
+            return result
+        return waited
+
+    return _with_screen(info, {"launched": True, "agent": agent_id})
+
+
+def _hub_capability(
+    info: Dict[str, Any], kind: str, status: Optional[Dict[str, Any]] = None
+) -> Tuple[Optional[str], Optional[Dict[str, Any]]]:
+    """Find the hub's install/uninstall key, or explain that it has none.
+
+    The key is read off the rendered footer rather than guessed, so this stays
+    correct as the hub's bindings change (and fails loudly when they are absent).
+    """
+    # An overlay replaces the whole screen, footer included — reading it there
+    # would report "no such keybinding" for a hub that has one.
+    overlay = str(_state_of(status or {}).get("overlay") or "")
+    if overlay:
+        return None, _err(
+            f"The hub is covered by the {overlay!r} overlay, so its keybindings are "
+            f"not readable. Dismiss it first with tui_send_keys(['esc'])."
+        )
+
+    screen_result = _request(info, "get", "/screen", params={"format": "plain"})
+    if _is_error(screen_result):
+        return None, screen_result
+    bindings = _parse_footer_bindings(screen_result.get("screen", ""))
+    key = _find_binding(bindings, kind)
+    if not key:
+        verb = "Uninstall" if kind == "uninstall" else "Install"
+        return None, _err(
+            f"{verb} from the TUI hub is not yet available — the hub screen has no "
+            f"{kind} keybinding in this build. Bindings currently offered: "
+            f"{_format_bindings(bindings)}."
+        )
+    return key, None
+
+
+_YES_RE = re.compile(r"\bYes\b")
+_NO_RE = re.compile(r"\bNo\b")
+
+
+def _confirm_marker(screen: str) -> str:
+    """Marker text for an open confirmation dialog, or ``""`` if none is showing.
+
+    Word-bounded on purpose: a substring test would read an agent named ``Notion``
+    as a "No" button and send a stray ``y`` into whatever is actually focused.
+    """
+    screen = screen or ""
+    if 'Uninstall "' in screen:
+        return 'Uninstall "'
+    if _YES_RE.search(screen) and _NO_RE.search(screen):
+        return "Yes"
+    return ""
+
+
+def _hub_action(agent_id: str, kind: str) -> Dict[str, Any]:
+    if not agent_id:
+        return _err(f"No agent_id given — pass the agent to {kind}.")
+
+    info, error = _discovered()
+    if error:
+        return error
+
+    status = _request(info, "get", "/status")
+    if _is_error(status):
+        return status
+    if _view_of(status) == "unknown":
+        return _err(
+            "The running GAIA TUI does not report its view state, so high-level "
+            "navigation is unavailable in this build. Drive it manually with "
+            "tui_send_keys and read the result with tui_screen."
+        )
+
+    # The capability is read off the hub's footer, so a chat must be closed
+    # first — otherwise the chat's status bar is mistaken for "no binding".
+    status, leave_error = _leave_chat(info, status)
+    if leave_error:
+        return leave_error
+
+    key, cap_error = _hub_capability(info, kind, status)
+    if cap_error or not key:
+        return cap_error or _err(f"The hub offers no {kind} keybinding in this build.")
+
+    _, nav_error = _navigate_to_agent(info, agent_id)
+    if nav_error:
+        return nav_error
+
+    # Snapshot what the hub looked like before the key, so "did anything happen?"
+    # is answerable afterwards without assuming which way the row should move.
+    before = _request(info, "get", "/screen", params={"format": "plain"})
+    if _is_error(before):
+        return before
+    before_screen = before.get("screen", "")
+
+    pressed = _press(info, key)
+    if _is_error(pressed):
+        return pressed
+
+    screen_result = _request(info, "get", "/screen", params={"format": "plain"})
+    if _is_error(screen_result):
+        return screen_result
+    screen = screen_result.get("screen", "")
+
+    # A reported overlay is authoritative; the screen text is the fallback for a
+    # build whose state does not carry one.
+    status = _request(info, "get", "/status")
+    if _is_error(status):
+        return status
+    overlay = str(_state_of(status).get("overlay") or "")
+    marker = _confirm_marker(screen)
+
+    confirmed_dialog = bool(overlay or marker)
+    if confirmed_dialog:
+        pressed = _press(info, "y")
+        if _is_error(pressed):
+            return pressed
+        if overlay:
+            waited = _wait(info, state={"overlay": ""}, timeout_ms=15000)
+        else:
+            waited = _wait(info, absent=marker, timeout_ms=15000)
+        if _is_error(waited):
+            return waited
+        screen_result = _request(info, "get", "/screen", params={"format": "plain"})
+        if _is_error(screen_result):
+            return screen_result
+        screen = screen_result.get("screen", "")
+
+    verify_error = _verify_hub_action(info, agent_id, kind, screen, before_screen)
+    if verify_error:
+        return verify_error
+
+    done_key = "uninstalled" if kind == "uninstall" else "installed"
+    return {
+        done_key: True,
+        "agent": agent_id,
+        "confirmed": confirmed_dialog,
+        "screen": screen,
+    }
+
+
+def _verify_hub_action(
+    info: Dict[str, Any], agent_id: str, kind: str, screen: str, before_screen: str
+) -> Optional[Dict[str, Any]]:
+    """Confirm the hub actually did it. Returns an error dict, or None if it did.
+
+    Pressing a key and seeing a dialog close is not evidence: the hub ignores its
+    uninstall key unless the agent is installed, so reporting "uninstalled" for a
+    row still sitting on screen is exactly the quiet wrong answer the
+    No-Silent-Fallbacks rule forbids.
+    """
+    status = _request(info, "get", "/status")
+    if _is_error(status):
+        return status
+    visible = list(_state_of(status).get("visible_agent_ids") or [])
+
+    if kind == "uninstall":
+        if agent_id not in visible:
+            return None
+        detail = (
+            f"The hub still lists {agent_id!r} on the "
+            f"{_state_of(status).get('hub_tab') or 'current'} tab after the "
+            f"uninstall key, so nothing was removed — the hub only uninstalls an "
+            f"agent that is currently installed."
+        )
+    else:
+        # An install promotes the agent to another tab, so it may legitimately
+        # vanish from this one. The only claim that holds either way is that
+        # SOMETHING changed; an unchanged screen means the key was ignored.
+        if screen != before_screen:
+            return None
+        detail = (
+            f"The hub ignored the install key for {agent_id!r} — the screen is "
+            f"unchanged, so nothing was installed."
+        )
+
+    line = _hub_status_line(screen, agent_id)
+    if line:
+        detail += f" The hub says: {line!r}"
+    result = _err(detail)
+    result["screen"] = _truncate(screen)
+    return result
+
+
+def _uninstall_agent(agent_id: str) -> Dict[str, Any]:
+    return _hub_action(agent_id, "uninstall")
+
+
+def _install_agent(agent_id: str) -> Dict[str, Any]:
+    return _hub_action(agent_id, "install")
+
+
+# ── MCP server ───────────────────────────────────────────────────────
+
+
+def route_logging_to_stderr() -> None:
+    """Move stdout log handlers to stderr — required before stdio transport.
+
+    Importing ``gaia`` installs a root log handler on **stdout**
+    (:mod:`gaia.logger`), and the MCP server itself logs one INFO line per
+    request. On stdio transport stdout carries JSON-RPC only, so those lines
+    land mid-stream and the client rejects every message that follows.
+    """
+    for handler in logging.getLogger().handlers:
+        if isinstance(handler, logging.StreamHandler) and handler.stream is sys.stdout:
+            handler.setStream(sys.stderr)
+
+
+def create_tui_mcp() -> "FastMCP":
+    """Create the MCP server exposing the GAIA TUI control tools."""
+    # Imported lazily so the helpers above stay importable without the optional
+    # ``mcp`` dependency, which the unit-test job does not install (issue #1750).
+    from mcp.server.fastmcp import FastMCP
+
+    mcp = FastMCP(name="GAIA TUI")
+
+    @mcp.tool()
+    def tui_status() -> Dict[str, Any]:
+        """Check whether a GAIA TUI is running and what it is currently showing.
+
+        Start here: it verifies the TUI's control server is reachable and returns
+        the terminal size, the frame sequence number, and a ``summary`` line such
+        as "hub view, tab 'Installed', 5 agents visible, selected 'bash'" or
+        "chat with 'email', streaming".
+
+        ``running: false`` means the TUI answers reads but is not consuming
+        input — every keystroke would be refused. The summary leads with that
+        when it happens, so check it before blaming a key that "did nothing".
+
+        If no TUI is running at all, the error explains how to start one.
+        """
+        return _status()
+
+    @mcp.tool()
+    def tui_screen(format: str = "plain") -> Dict[str, Any]:
+        """Read what the GAIA TUI is showing right now.
+
+        This is the workhorse — read the screen after every tui_send_keys or
+        tui_send_text call to see what actually happened, instead of assuming.
+
+        Args:
+            format: "plain" (default) strips ANSI escapes and is what you want
+                for reading text; "ansi" keeps colors and cursor codes.
+        """
+        return _screen(format)
+
+    @mcp.tool()
+    def tui_send_keys(keys: Union[List[str], str], delay_ms: int = 0) -> Dict[str, Any]:
+        """Send one or more keystrokes to the GAIA TUI.
+
+        Keys are named: "enter", "esc", "tab", "up", "down", "left", "right",
+        "backspace", "space", "ctrl+c", or a single character like "y".
+        For convenience you may also pass one comma/space separated string
+        (``"tab,down,enter"``) instead of a list.
+
+        Read the result with tui_screen — key delivery says nothing about what
+        the TUI did with it.
+
+        The reply carries ``settled``: true means the batch was handled AND
+        redrawn, so reading the screen straight after is race-free; false means
+        the TUI was still busy — the keys are queued, not dropped, so re-read
+        rather than resend. If the TUI's event loop is not running (starting up,
+        or the user quit), this fails instead of pretending the keys landed.
+
+        Args:
+            keys: Key names, e.g. ["tab", "down", "enter"].
+            delay_ms: Milliseconds to pause between keys (default 0, max 2000;
+                the total pause across a batch may not exceed 10s).
+        """
+        return _send_keys(keys, delay_ms)
+
+    @mcp.tool()
+    def tui_send_text(text: str) -> Dict[str, Any]:
+        """Type text into the GAIA TUI's focused input (e.g. the chat prompt).
+
+        This types only — it does not submit. Follow with
+        tui_send_keys(["enter"]) to send the message.
+
+        Like tui_send_keys, the reply carries ``settled``: false means the TUI
+        was still busy and the runes are queued, so re-read the screen instead of
+        typing again.
+        """
+        return _send_text(text)
+
+    @mcp.tool()
+    def tui_wait_for(
+        contains: str = "", absent: str = "", timeout_ms: int = 30000
+    ) -> Dict[str, Any]:
+        """Block until the GAIA TUI's screen matches, instead of polling it.
+
+        Pass at least one matcher; both are ANDed and matched against the plain
+        (ANSI-stripped) screen. On timeout this returns an error containing the
+        text the screen actually had, so you can see why the match never landed.
+
+        Args:
+            contains: Text that must appear on screen.
+            absent: Text that must have disappeared from the screen.
+            timeout_ms: How long to wait before giving up (default 30000).
+        """
+        return _wait_for(contains=contains, absent=absent, timeout_ms=timeout_ms)
+
+    @mcp.tool()
+    def tui_resize(cols: int, rows: int) -> Dict[str, Any]:
+        """Resize the GAIA TUI's virtual terminal.
+
+        Useful for reproducing narrow-terminal layout bugs, or for widening the
+        screen so long lines are not wrapped before you read them.
+
+        The reply carries ``settled`` (see tui_send_keys). If the TUI ends up
+        laid out for a different size — a real terminal resize can override this
+        one — that comes back as an error naming both sizes, not as a success
+        echoing the numbers you asked for.
+
+        Args:
+            cols: Terminal width, 20-500.
+            rows: Terminal height, 5-200.
+        """
+        return _resize(cols, rows)
+
+    @mcp.tool()
+    def tui_launch_agent(agent_id: str, timeout_ms: int = 20000) -> Dict[str, Any]:
+        """Open an agent's chat from the GAIA TUI hub, by id.
+
+        Handles the whole navigation: leaves any open chat, clears an active
+        search filter, cycles hub tabs until the agent is visible, moves the
+        selection onto it, presses enter, and waits for the chat view to appear.
+        Each step is verified against the TUI's reported state.
+
+        Returns ``{"launched": true, "agent": ..., "screen": ...}``. If that chat
+        is already open it returns ``already_open: true`` without touching the
+        keyboard, so an open conversation is never thrown away.
+
+        It refuses rather than press a key when doing so would destroy something:
+        while the chat is streaming a response, or while a help/confirm overlay
+        is covering the hub. If the agent cannot be launched (not installed,
+        coming soon), the error quotes the hub's own status line.
+
+        Args:
+            agent_id: The hub's agent id, e.g. "email" or "bash".
+            timeout_ms: How long to wait for the chat view (default 20000).
+        """
+        return _launch_agent(agent_id, timeout_ms)
+
+    @mcp.tool()
+    def tui_uninstall_agent(agent_id: str) -> Dict[str, Any]:
+        """Uninstall an agent from the GAIA TUI hub.
+
+        Navigates to the agent, presses the hub's uninstall key, and confirms the
+        dialog if one appears. The key is read off the hub footer rather than
+        guessed — if this build's hub has no uninstall binding, the tool says so
+        instead of pressing something arbitrary.
+
+        The outcome is verified, not assumed: the hub ignores its uninstall key
+        for an agent that is not installed, and that comes back as an error
+        rather than a cheerful ``uninstalled: true``.
+        """
+        return _uninstall_agent(agent_id)
+
+    @mcp.tool()
+    def tui_install_agent(agent_id: str) -> Dict[str, Any]:
+        """Install an agent from the GAIA TUI hub.
+
+        Navigates to the agent, presses the hub's install key, and confirms the
+        dialog if one appears. The key is read off the hub footer rather than
+        guessed.
+
+        Note: the hub has no install binding today, so this reports that it is
+        not yet available and lists the bindings the hub does offer. Installing
+        an agent still goes through `gaia agent install` on the CLI.
+        """
+        return _install_agent(agent_id)
+
+    return mcp
+
+
+def main():
+    parser = argparse.ArgumentParser(description="GAIA TUI control MCP Server")
+    parser.add_argument(
+        "--port",
+        type=int,
+        default=MCP_DEFAULT_PORT,
+        help=f"MCP server port (default: {MCP_DEFAULT_PORT})",
+    )
+    parser.add_argument(
+        "--host",
+        default=MCP_DEFAULT_HOST,
+        help=f"MCP server host (default: {MCP_DEFAULT_HOST})",
+    )
+    parser.add_argument(
+        "--stdio",
+        action="store_true",
+        help="Use stdio transport instead of HTTP (for Claude Code integration)",
+    )
+    args = parser.parse_args()
+
+    mcp = create_tui_mcp()
+
+    if args.stdio:
+        route_logging_to_stderr()
+        print("Starting GAIA TUI MCP Server (stdio mode)...", file=sys.stderr)
+        mcp.run(transport="stdio")
+    else:
+        mcp.settings.host = args.host
+        mcp.settings.port = args.port
+        print("\n🚀 GAIA TUI MCP Server")
+        print(f"   Control file: {_display_path()}")
+        print(f"   MCP: http://{args.host}:{args.port}/mcp")
+        tool_count = len(mcp._tool_manager._tools)  # pylint: disable=protected-access
+        print(f"   Tools: {tool_count} registered\n")
+        mcp.run(transport="streamable-http")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/gaia/mcp/servers/tui_mcp.py
+++ b/src/gaia/mcp/servers/tui_mcp.py
@@ -95,7 +95,7 @@ LOOPBACK_HOSTS = frozenset({"127.0.0.1", "localhost", "::1"})
 #: proxied — it would hand the bearer token and the screen text to the proxy.
 NO_PROXY: Dict[str, Any] = {"http": None, "https": None}
 
-MCP_DEFAULT_PORT = 8767  # 8765/8766 belong to agent_ui_mcp
+MCP_DEFAULT_PORT = 8767  # 8765 is agent_ui_mcp, 8766 is the MCP bridge (cli.py)
 MCP_DEFAULT_HOST = "localhost"
 
 

--- a/src/gaia/ui/server.py
+++ b/src/gaia/ui/server.py
@@ -416,6 +416,9 @@ def create_app(db_path: str = None, webui_dist: str = None) -> FastAPI:
                 # activates on the "doc" profile — wired for future-proofing so
                 # this path doesn't silently diverge if that ever changes.
                 dynamic_tools = db.get_setting("dynamic_tools", "false") == "true"
+                # Nobody is watching a scheduled run, so confirmation-gated tools
+                # (shell, file writes) are denied here — same posture as an
+                # autonomous background tick (#2210).
                 config = ChatAgentConfig(
                     max_steps=5,
                     silent_mode=True,

--- a/src/gaia/ui/sse_handler.py
+++ b/src/gaia/ui/sse_handler.py
@@ -841,21 +841,23 @@ class SSEOutputHandler(OutputHandler):
         """
         # Background mode: immediately deny — no semaphore hold, no waiting.
         if self.background_mode:
+            unattended_message = (
+                f"'{tool_name}' requires live user approval and cannot run "
+                "unattended. Use request_user_input() to notify the user, "
+                "then retry in a subsequent turn."
+            )
             self._emit(
                 {
                     "type": "tool_confirm_denied",
                     "tool": tool_name,
                     "reason": "unattended",
-                    "message": (
-                        f"'{tool_name}' requires live user approval and cannot run "
-                        "unattended. Use request_user_input() to notify the user, "
-                        "then retry in a subsequent turn."
-                    ),
+                    "message": unattended_message,
                 }
             )
             logger.info(
                 "Background mode: immediately denied confirmation for '%s'", tool_name
             )
+            self._last_denial = (tool_name, unattended_message)
             return False
 
         confirm_id = str(uuid.uuid4())
@@ -863,6 +865,7 @@ class SSEOutputHandler(OutputHandler):
             self._confirm_event = threading.Event()
             self._confirm_result = False
         self._confirm_id = confirm_id
+        self._last_denial = None
 
         self._emit(
             {
@@ -880,6 +883,11 @@ class SSEOutputHandler(OutputHandler):
             if self.cancelled.is_set():
                 self._confirm_id = None
                 self._confirm_event = None
+                self._last_denial = (
+                    tool_name,
+                    f"Confirmation for '{tool_name}' was abandoned: the run was "
+                    "cancelled before the user answered.",
+                )
                 return False
             if self._confirm_event.wait(timeout=0.5):
                 break
@@ -895,11 +903,22 @@ class SSEOutputHandler(OutputHandler):
             logger.warning("Tool confirmation timed out for '%s'", tool_name)
             self._confirm_id = None
             self._confirm_event = None
+            self._last_denial = (
+                tool_name,
+                f"Confirmation for '{tool_name}' timed out after "
+                f"{TOOL_CONFIRM_TIMEOUT_SECONDS} s with no user response. "
+                "Execution denied.",
+            )
             return False
 
         result = self._confirm_result
         self._confirm_id = None
         self._confirm_event = None
+        if not result:
+            self._last_denial = (
+                tool_name,
+                f"Tool '{tool_name}' was denied by the user.",
+            )
         return result
 
     def print_policy_alert(

--- a/tests/integration/test_cli_tool_confirmation.py
+++ b/tests/integration/test_cli_tool_confirmation.py
@@ -1,0 +1,243 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""End-to-end confirmation behaviour for CLI-driven agents (#2210).
+
+The unit tests for this fix patch ``sys.stdin``, which proves the branch but not
+the branch *condition*: under pytest, stdin is already a non-TTY stand-in, so a
+mocked ``isatty()`` could pass while the real thing behaves differently. These
+tests run a real agent in a real child process — once with a pipe on stdin (a
+subprocess host, a CI job, ``gaia … < file``) and once behind a real pty (a user
+at a terminal) — and check what the user actually gets.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+# A minimal real Agent with one confirmation-gated tool, driven through the real
+# AgentConsole. Prints a single machine-readable line for the test to assert on.
+PROBE_SCRIPT = '''
+import json
+import os
+from unittest.mock import patch
+
+from gaia.agents.base.agent import Agent
+from gaia.agents.base.console import AgentConsole, SilentConsole
+from gaia.agents.base.tools import tool
+
+# GAIA_CONSOLE=silent exercises the console `gaia chat` actually builds.
+CONSOLE = SilentConsole if os.environ.get("GAIA_CONSOLE") == "silent" else AgentConsole
+
+
+class ProbeAgent(Agent):
+    AGENT_ID = "cli-confirmation-probe"
+    CONFIRMATION_REQUIRED_TOOLS = frozenset({"send_now"})
+
+    def __init__(self, **kwargs):
+        self.executed = []
+        super().__init__(**kwargs)
+
+    def _create_console(self):
+        return CONSOLE()
+
+    def _get_system_prompt(self):
+        return "probe"
+
+    def _register_tools(self):
+        executed = self.executed
+
+        @tool
+        def send_now(to: str) -> str:
+            """Send an email immediately. Gated."""
+            executed.append(to)
+            return "SENT"
+
+
+with patch("gaia.agents.base.agent.AgentSDK"):
+    agent = ProbeAgent(skip_lemonade=True)
+
+result = agent._execute_tool("send_now", {"to": "boss@example.com"})
+print("RESULT " + json.dumps({"result": result, "executed": agent.executed}))
+'''
+
+
+def _child_env() -> dict:
+    env = os.environ.copy()
+    # Real initial state: the unattended opt-in must not be inherited.
+    env.pop("GAIA_AUTO_APPROVE_TOOLS", None)
+    src = str(REPO_ROOT / "src")
+    env["PYTHONPATH"] = (
+        src + os.pathsep + env["PYTHONPATH"] if env.get("PYTHONPATH") else src
+    )
+    # Keep the child's output plain so the assertions read the payload, not ANSI.
+    env["TERM"] = "dumb"
+    env["NO_COLOR"] = "1"
+    return env
+
+
+def _result_line(output: str) -> dict:
+    import json
+
+    for line in output.splitlines():
+        if line.startswith("RESULT "):
+            return json.loads(line[len("RESULT ") :])
+    raise AssertionError(f"probe produced no RESULT line. Output was:\n{output}")
+
+
+class TestPipedStdin:
+    """A subprocess host / CI job: no terminal, so nobody can approve."""
+
+    def test_redirected_stdout_is_not_treated_as_interactive(self, tmp_path):
+        """`gaia … > log.txt` from a terminal: prompting there would block on a
+        question the user cannot see, so it must deny instead."""
+        log = tmp_path / "out.log"
+        with open(log, "w", encoding="utf-8") as sink:
+            proc = subprocess.run(
+                [sys.executable, "-c", PROBE_SCRIPT],
+                cwd=REPO_ROOT,
+                env=_child_env(),
+                stdin=subprocess.DEVNULL,
+                stdout=sink,
+                stderr=subprocess.PIPE,
+                text=True,
+                timeout=180,
+            )
+        assert proc.returncode == 0, proc.stderr
+        payload = _result_line(log.read_text(encoding="utf-8"))
+        assert payload["result"]["status"] == "denied"
+        assert payload["executed"] == []
+
+    def test_gated_tool_is_denied_and_never_executes(self):
+        proc = subprocess.run(
+            [sys.executable, "-c", PROBE_SCRIPT],
+            cwd=REPO_ROOT,
+            env=_child_env(),
+            stdin=subprocess.DEVNULL,
+            capture_output=True,
+            text=True,
+            timeout=180,
+        )
+        assert proc.returncode == 0, proc.stderr
+
+        payload = _result_line(proc.stdout)
+        assert payload["result"]["status"] == "denied"
+        assert payload["executed"] == []
+        # The denial must tell the operator what to do about it.
+        assert "GAIA_AUTO_APPROVE_TOOLS" in payload["result"]["error"]
+
+    def test_explicit_opt_in_lets_an_unattended_host_proceed(self):
+        env = _child_env()
+        env["GAIA_AUTO_APPROVE_TOOLS"] = "1"
+        proc = subprocess.run(
+            [sys.executable, "-c", PROBE_SCRIPT],
+            cwd=REPO_ROOT,
+            env=env,
+            stdin=subprocess.DEVNULL,
+            capture_output=True,
+            text=True,
+            timeout=180,
+        )
+        assert proc.returncode == 0, proc.stderr
+
+        payload = _result_line(proc.stdout)
+        assert payload["result"] == "SENT"
+        assert payload["executed"] == ["boss@example.com"]
+
+
+@pytest.mark.skipif(
+    sys.platform == "win32", reason="pty is POSIX-only; Windows uses the piped path"
+)
+class TestRealTerminal:
+    """A user at a terminal: the prompt appears and the answer is honoured."""
+
+    @staticmethod
+    def _run_behind_pty(answer: str, console: str = "rich") -> str:
+        import pty
+        import select
+
+        env = _child_env()
+        env["GAIA_CONSOLE"] = console
+        primary, secondary = pty.openpty()
+        proc = subprocess.Popen(
+            [sys.executable, "-c", PROBE_SCRIPT],
+            cwd=REPO_ROOT,
+            env=env,
+            stdin=secondary,
+            stdout=secondary,
+            stderr=secondary,
+            text=False,
+        )
+        os.close(secondary)
+
+        chunks: list[bytes] = []
+        answered = False
+        try:
+            while proc.poll() is None or select.select([primary], [], [], 0.2)[0]:
+                ready = select.select([primary], [], [], 0.5)[0]
+                if ready:
+                    try:
+                        data = os.read(primary, 4096)
+                    except OSError:
+                        break
+                    if not data:
+                        break
+                    chunks.append(data)
+                if not answered and b"Allow this?" in b"".join(chunks):
+                    os.write(primary, answer.encode())
+                    answered = True
+            proc.wait(timeout=180)
+        finally:
+            os.close(primary)
+            if proc.poll() is None:  # pragma: no cover - safety net
+                proc.kill()
+
+        assert (
+            answered
+        ), "the confirmation prompt never appeared on a real terminal:\n" + b"".join(
+            chunks
+        ).decode(
+            errors="replace"
+        )
+        return b"".join(chunks).decode(errors="replace")
+
+    def test_prompt_shows_the_tool_and_its_arguments(self):
+        output = self._run_behind_pty("n\r")
+        assert "send_now" in output
+        assert "boss@example.com" in output
+
+    def test_answering_no_denies_and_the_tool_never_runs(self):
+        payload = _result_line(self._run_behind_pty("n\r"))
+        assert payload["result"]["status"] == "denied"
+        assert payload["result"]["error"] == "Tool 'send_now' was denied by the user."
+        assert payload["executed"] == []
+
+    def test_bare_enter_denies(self):
+        """The prompt defaults to no — a stray Enter must not send mail."""
+        payload = _result_line(self._run_behind_pty("\r"))
+        assert payload["result"]["status"] == "denied"
+        assert payload["executed"] == []
+
+    def test_answering_yes_executes(self):
+        payload = _result_line(self._run_behind_pty("y\r"))
+        assert payload["result"] == "SENT"
+        assert payload["executed"] == ["boss@example.com"]
+
+    def test_silent_console_still_asks_the_user_at_a_terminal(self):
+        """`gaia chat` builds a SilentConsole even for an interactive user, so
+        silence must not swallow the question (#2210)."""
+        output = self._run_behind_pty("y\r", console="silent")
+        assert "send_now" in output
+        payload = _result_line(output)
+        assert payload["result"] == "SENT"
+
+    def test_silent_console_honours_no(self):
+        payload = _result_line(self._run_behind_pty("n\r", console="silent"))
+        assert payload["result"]["status"] == "denied"
+        assert payload["executed"] == []

--- a/tests/integration/test_tui_control_e2e.py
+++ b/tests/integration/test_tui_control_e2e.py
@@ -1,0 +1,306 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+"""End-to-end: the real Go TUI control server driven by the real Python client.
+
+Every other test of this feature mocks one side or the other, which proves only
+that a call was made — not that the two halves agree on the wire. This one boots
+`gaia --control` for real, discovers it through `~/.gaia/tui/control.json`, and
+drives it with the same helper functions the MCP tools call, so a drift in the
+endpoint paths, the error envelope, the 408 timeout contract, or the `state`
+field names fails here instead of in a user's terminal.
+
+Skips (never fails) when Go or the TUI source is unavailable, or on Windows,
+where the pty this needs does not exist.
+"""
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+import threading
+import time
+from pathlib import Path
+
+import pytest
+
+from gaia.mcp.servers import tui_mcp
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+TUI_DIR = REPO_ROOT / "tui"
+
+# Building the TUI is the slow part; the drive itself takes under a second.
+BUILD_TIMEOUT = 300
+STARTUP_TIMEOUT = 30
+
+
+def _skip_reason():
+    if os.name != "posix":
+        return "needs a pty; POSIX only"
+    if not (TUI_DIR / "go.mod").exists():
+        return f"no TUI source at {TUI_DIR}"
+    if shutil.which("go") is None:
+        return "go toolchain not installed"
+    return None
+
+
+class _Drain:
+    """Continuously read the TUI's pty and stderr so it never blocks on write."""
+
+    def __init__(self, pty_fd, stderr):
+        self._pty_fd = pty_fd
+        self._stderr = stderr
+        self.stderr_text = []
+        self._stop = threading.Event()
+        self._threads = [
+            threading.Thread(target=self._drain_pty, daemon=True),
+            threading.Thread(target=self._drain_stderr, daemon=True),
+        ]
+        for t in self._threads:
+            t.start()
+
+    def _drain_pty(self):
+        while not self._stop.is_set():
+            try:
+                if not os.read(self._pty_fd, 65536):
+                    return
+            except OSError:
+                return
+
+    def _drain_stderr(self):
+        for line in iter(self._stderr.readline, b""):
+            self.stderr_text.append(line.decode(errors="replace"))
+
+    def stop(self):
+        self._stop.set()
+
+
+@pytest.fixture(scope="module")
+def tui_binary(tmp_path_factory):
+    reason = _skip_reason()
+    if reason:
+        pytest.skip(reason)
+
+    out = tmp_path_factory.mktemp("tui-bin") / "gaia"
+    build = subprocess.run(
+        ["go", "build", "-o", str(out), "./cmd/gaia"],
+        cwd=TUI_DIR,
+        capture_output=True,
+        text=True,
+        timeout=BUILD_TIMEOUT,
+        check=False,
+    )
+    if build.returncode != 0:
+        pytest.fail(f"go build failed:\n{build.stderr}")
+    return out
+
+
+@pytest.fixture
+def live_tui(tui_binary, tmp_path, monkeypatch):
+    """Start the real TUI under a pty and wait until it is discoverable."""
+    import pty
+
+    home = tmp_path / "tui-home"
+    home.mkdir()
+    monkeypatch.setenv(tui_mcp.ENV_TUI_HOME, str(home))
+
+    # A pty: Bubble Tea needs a terminal on stdin/stdout, and this keeps the
+    # test's own output clean of alt-screen escapes.
+    controller, follower = pty.openpty()
+    env = dict(os.environ)
+    env[tui_mcp.ENV_TUI_HOME] = str(home)
+
+    proc = subprocess.Popen(
+        [str(tui_binary), "--control", "--debug"],
+        stdin=follower,
+        stdout=follower,
+        stderr=subprocess.PIPE,
+        env=env,
+        close_fds=True,
+    )
+    os.close(follower)
+
+    # A real terminal consumes what the TUI writes. Nothing here does, so both
+    # the pty and the stderr pipe fill (--debug logs every key) and the TUI
+    # blocks mid-write — which looks exactly like a hung control server.
+    drained = _Drain(controller, proc.stderr)
+
+    control_file = home / "control.json"
+    deadline = time.time() + STARTUP_TIMEOUT
+    while time.time() < deadline:
+        if proc.poll() is not None:
+            drained.stop()
+            os.close(controller)
+            pytest.fail(
+                f"TUI exited early (rc={proc.returncode}):\n"
+                + "".join(drained.stderr_text)
+            )
+        if control_file.exists():
+            break
+        time.sleep(0.05)
+    else:
+        proc.kill()
+        drained.stop()
+        os.close(controller)
+        pytest.fail(f"TUI never published {control_file} within {STARTUP_TIMEOUT}s")
+
+    try:
+        yield proc
+    finally:
+        proc.terminate()
+        try:
+            proc.wait(timeout=10)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+            proc.wait(timeout=5)
+        drained.stop()
+        os.close(controller)
+
+
+def _ready(cols=120, rows=40):
+    """Give the TUI a terminal size and wait for the hub to lay out."""
+    resized = tui_mcp._resize(cols, rows)
+    assert resized.get("status") != "error", resized
+    waited = tui_mcp._wait_for(contains="Installed", timeout_ms=10000)
+    assert waited.get("matched") is True, waited
+
+
+@pytest.mark.integration
+def test_discovery_matches_the_real_control_file(live_tui, tmp_path):
+    info, error = tui_mcp.discover()
+    assert error is None, error
+    assert info["service"] == tui_mcp.SERVICE_ID
+    assert info["host"] in tui_mcp.LOOPBACK_HOSTS
+    assert info["pid"] == live_tui.pid
+
+    control_file = Path(os.environ[tui_mcp.ENV_TUI_HOME]) / "control.json"
+    if os.name == "posix":
+        assert oct(control_file.stat().st_mode & 0o777) == "0o600"
+    assert len(json.loads(control_file.read_text())["token"]) == 64
+
+
+@pytest.mark.integration
+def test_status_state_field_names_match_the_server(live_tui):
+    _ready()
+    status = tui_mcp._status()
+    assert status.get("status") != "error", status
+    assert status["service"] == tui_mcp.SERVICE_ID
+
+    state = status["state"]
+    # Every key the Python side reads must exist on the Go side.
+    for key in (
+        "view",
+        "agent",
+        "streaming",
+        "hub_tab",
+        "hub_tab_index",
+        "selected_agent_id",
+        "visible_agent_ids",
+        "filtering",
+        # Drives whether esc returns to the hub or QUITS the TUI, so the client
+        # must never have to guess it.
+        "can_return_to_hub",
+    ):
+        assert key in state, f"{key!r} missing from the real /status payload: {state}"
+    assert state["view"] == "hub"
+    assert isinstance(state["visible_agent_ids"], list)
+    assert "hub view" in status["summary"]
+
+
+@pytest.mark.integration
+def test_keys_and_screen_round_trip(live_tui):
+    _ready()
+    before = tui_mcp._status()["state"]["hub_tab"]
+
+    sent = tui_mcp._send_keys(["tab"])
+    assert sent.get("status") != "error", sent
+    # The contract that makes "send then read" race-free: the call returns only
+    # once the key has been handled AND redrawn.
+    assert sent["settled"] is True, sent
+
+    after = tui_mcp._status()["state"]["hub_tab"]
+    assert after != before, f"the tab key did not switch category (still {after!r})"
+
+    screen = tui_mcp._screen()
+    assert screen.get("status") != "error", screen
+    assert "\x1b[" not in screen["screen"], "plain format leaked ANSI escapes"
+    assert after in screen["screen"]
+
+    ansi = tui_mcp._screen("ansi")
+    assert "\x1b[" in ansi["screen"], "ansi format stripped the escapes"
+
+
+@pytest.mark.integration
+def test_status_reports_running_true_against_a_live_loop(live_tui):
+    """`running` is computed, not hardcoded — a quit TUI must be able to say so."""
+    _ready()
+    assert tui_mcp._status()["running"] is True
+
+
+@pytest.mark.integration
+def test_send_text_types_into_the_filter(live_tui):
+    _ready()
+    tui_mcp._send_keys(["/"])
+    typed = tui_mcp._send_text("bash")
+    assert typed.get("sent_runes") == 4, typed
+
+    waited = tui_mcp._wait_for(contains="bash", timeout_ms=5000)
+    assert waited.get("matched") is True, waited
+    assert tui_mcp._status()["state"]["filtering"] is True
+
+
+@pytest.mark.integration
+def test_wait_timeout_reports_the_real_screen(live_tui):
+    """The 408 contract: a timeout must carry what the screen actually had."""
+    _ready()
+    out = tui_mcp._wait_for(contains="text that is on no screen", timeout_ms=500)
+    assert out["status"] == "error"
+    assert out["timed_out"] is True
+    assert "Installed" in out["screen"], out["screen"][:400]
+    assert "Installed" in out["detail"]
+
+
+@pytest.mark.integration
+def test_launch_agent_opens_the_chat_view(live_tui):
+    _ready()
+    out = tui_mcp._launch_agent("bash", timeout_ms=15000)
+    assert out.get("launched") is True, out
+
+    state = tui_mcp._status()["state"]
+    assert state["view"] == "chat"
+    assert state["agent"] == "bash"
+
+
+@pytest.mark.integration
+def test_install_agent_reports_the_missing_binding(live_tui):
+    """The hub has no install key today; the tool must say so, not guess one."""
+    _ready()
+    out = tui_mcp._install_agent("bash")
+    assert out["status"] == "error"
+    assert "not yet available" in out["detail"]
+    assert "Enter=launch" in out["detail"]
+
+
+@pytest.mark.integration
+def test_stale_control_file_is_rejected_after_the_tui_exits(live_tui):
+    """A crashed TUI leaves the file behind; the pid check must catch it."""
+    _ready()
+    control_file = Path(os.environ[tui_mcp.ENV_TUI_HOME]) / "control.json"
+    stale = json.loads(control_file.read_text())
+
+    live_tui.terminate()
+    live_tui.wait(timeout=10)
+
+    # Simulate the crash case: the file survives the process.
+    control_file.write_text(json.dumps(stale), encoding="utf-8")
+
+    info, error = tui_mcp.discover()
+    assert info is None
+    assert error["status"] == "error"
+    assert "gaia tui --control" in error["detail"]
+    assert stale["token"] not in error["detail"]
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-v"]))

--- a/tests/unit/agents/test_console_tool_confirmation.py
+++ b/tests/unit/agents/test_console_tool_confirmation.py
@@ -1,0 +1,809 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""Unit tests for console-level confirmation of gated tools (#2210).
+
+Before this, ``OutputHandler.confirm_tool_execution`` returned ``True``
+unconditionally and ``AgentConsole`` never overrode it, so every tool in
+``Agent.confirmation_required_tools()`` executed with no prompt whenever an
+agent was driven from a CLI or a subprocess. These tests pin the safe
+behaviour: prompt on a TTY (defaulting to "no"), deny when there is nobody to
+ask, and approve only on an explicit yes or an explicit unattended opt-in.
+"""
+
+import io
+import json
+import logging
+import os
+from pathlib import Path
+
+import pytest
+
+import gaia.agents.base.console as console_module
+from gaia.agents.base.agent import Agent
+from gaia.agents.base.console import (
+    AUTO_APPROVE_ENV_VAR,
+    AgentConsole,
+    OutputHandler,
+    SilentConsole,
+    format_confirmation_args,
+    terminal_is_interactive,
+)
+from gaia.agents.base.tools import tool
+
+REPO_SRC = Path(__file__).resolve().parents[3] / "src"
+
+
+class _FakeStream(io.StringIO):
+    """stdin/stdout stand-in whose ``isatty()`` is controllable."""
+
+    def __init__(self, interactive: bool):
+        super().__init__("")
+        self._interactive = interactive
+
+    def isatty(self) -> bool:
+        return self._interactive
+
+
+@pytest.fixture(autouse=True)
+def _no_env_opt_in(monkeypatch):
+    """Every test starts from the user's real state: no unattended opt-in set."""
+    import gaia
+
+    monkeypatch.delenv(AUTO_APPROVE_ENV_VAR, raising=False)
+    monkeypatch.delitem(gaia._PRE_DOTENV_ENVIRON, AUTO_APPROVE_ENV_VAR, raising=False)
+
+
+def _set_env_opt_in(monkeypatch, value: str) -> None:
+    """Opt in the way an operator does: in the real process environment.
+
+    ``os.environ`` alone is deliberately NOT enough — see
+    ``TestDotenvCannotGrantApproval``.
+    """
+    import gaia
+
+    monkeypatch.setenv(AUTO_APPROVE_ENV_VAR, value)
+    monkeypatch.setitem(gaia._PRE_DOTENV_ENVIRON, AUTO_APPROVE_ENV_VAR, value)
+
+
+@pytest.fixture
+def tty(monkeypatch):
+    """Report an interactive terminal without displacing pytest's capture.
+
+    ``terminal_is_interactive`` itself is tested against real streams in
+    ``TestTerminalDetection``, and end-to-end behind a real pty in
+    ``tests/integration/test_cli_tool_confirmation.py``.
+    """
+    monkeypatch.setattr(console_module, "terminal_is_interactive", lambda: True)
+
+
+@pytest.fixture
+def no_tty(monkeypatch):
+    """Report no terminal (CI, subprocess host, `cmd < file`, `cmd > file`)."""
+    monkeypatch.setattr(console_module, "terminal_is_interactive", lambda: False)
+
+
+def _answer(monkeypatch, *answers):
+    """Feed answers to the console's ``input()`` prompt, in order."""
+    queue = list(answers)
+    captured = []
+
+    def _fake_input(prompt=""):
+        captured.append(prompt)
+        return queue.pop(0)
+
+    monkeypatch.setattr("builtins.input", _fake_input)
+    return captured
+
+
+class _MinimalHandler(OutputHandler):
+    """Concrete OutputHandler that implements only the abstract methods, so the
+    inherited confirmation default is what gets exercised."""
+
+    def print_processing_start(self, query, max_steps, model_id=None):
+        pass
+
+    def print_step_header(self, step_num, step_limit):
+        pass
+
+    def print_state_info(self, state_message):
+        pass
+
+    def print_thought(self, thought):
+        pass
+
+    def print_goal(self, goal):
+        pass
+
+    def print_plan(self, plan, current_step=None):
+        pass
+
+    def print_tool_usage(self, tool_name):
+        pass
+
+    def print_tool_complete(self):
+        pass
+
+    def pretty_print_json(self, data, title=None):
+        pass
+
+    def print_error(self, error_message):
+        pass
+
+    def print_warning(self, warning_message):
+        pass
+
+    def print_info(self, message):
+        pass
+
+    def start_progress(self, message):
+        pass
+
+    def stop_progress(self):
+        pass
+
+    def pause_progress(self):
+        pass
+
+    def resume_progress(self):
+        pass
+
+    def print_final_answer(self, answer):
+        pass
+
+    def print_repeated_tool_warning(self):
+        pass
+
+    def print_completion(self, steps_taken, steps_limit):
+        pass
+
+    def print_step_paused(self, description):
+        pass
+
+    def print_command_executing(self, command):
+        pass
+
+    def print_agent_selected(self, agent_name, language, project_type):
+        pass
+
+
+class TestBaseHandlerDefault:
+    """The root cause: a handler that cannot ask a human must not answer."""
+
+    def test_default_denies(self):
+        assert (
+            _MinimalHandler().confirm_tool_execution("send_now", {"to": "a@b.c"})
+            is False
+        )
+
+    def test_denial_reason_is_actionable(self):
+        handler = _MinimalHandler()
+        handler.confirm_tool_execution("send_now", {})
+        reason = handler.confirmation_denied_reason("send_now")
+        assert "send_now" in reason
+        assert "cannot run" in reason
+        # Names both ways out: an interactive terminal, or the explicit opt-in.
+        assert "interactive terminal" in reason
+        assert AUTO_APPROVE_ENV_VAR in reason
+
+    def test_denial_is_logged(self, caplog):
+        with caplog.at_level(logging.WARNING, logger="gaia.agents.base.console"):
+            _MinimalHandler().confirm_tool_execution("permanent_delete", {})
+        assert any("permanent_delete" in r.getMessage() for r in caplog.records)
+
+    def test_silent_console_denies(self):
+        """JSON-only / MCP-wrapper hosts have no prompt channel either."""
+        assert SilentConsole().confirm_tool_execution("write_file", {}) is False
+
+    def test_host_opt_in_approves_and_logs(self, caplog):
+        handler = SilentConsole(auto_approve_gated_tools=True)
+        with caplog.at_level(logging.WARNING, logger="gaia.agents.base.console"):
+            assert handler.confirm_tool_execution("write_file", {}) is True
+        assert any("Auto-approved" in r.getMessage() for r in caplog.records)
+
+    def test_env_opt_in_approves(self, monkeypatch):
+        _set_env_opt_in(monkeypatch, "1")
+        assert _MinimalHandler().confirm_tool_execution("send_now", {}) is True
+        assert AgentConsole().confirm_tool_execution("send_now", {}) is True
+
+    def test_env_opt_in_ignores_junk_values(self, monkeypatch):
+        _set_env_opt_in(monkeypatch, "0")
+        assert _MinimalHandler().confirm_tool_execution("send_now", {}) is False
+        _set_env_opt_in(monkeypatch, "maybe")
+        assert _MinimalHandler().confirm_tool_execution("send_now", {}) is False
+
+    def test_os_environ_alone_does_not_opt_in(self, monkeypatch):
+        """Only the startup environment counts — see the .env tests below."""
+        monkeypatch.setenv(AUTO_APPROVE_ENV_VAR, "1")
+        assert _MinimalHandler().confirm_tool_execution("send_now", {}) is False
+
+
+class TestAgentConsoleNonInteractive:
+    """The CLI console driven from a pipe / CI / subprocess host."""
+
+    def test_denies_without_tty(self, no_tty):
+        assert AgentConsole().confirm_tool_execution("send_draft", {}) is False
+
+    def test_denial_message_is_shown_to_the_user(self, no_tty, capsys):
+        console = AgentConsole()
+        console.confirm_tool_execution("send_draft", {"to": "a@b.c"})
+        out = capsys.readouterr().out
+        assert "send_draft" in out
+        assert AUTO_APPROVE_ENV_VAR in out
+
+    def test_never_prompts_without_tty(self, no_tty, monkeypatch):
+        """No blocking read on a closed/piped stdin — that would hang a daemon."""
+
+        def _explode(prompt=""):
+            raise AssertionError("input() must not be called without a TTY")
+
+        monkeypatch.setattr("builtins.input", _explode)
+        assert AgentConsole().confirm_tool_execution("send_now", {}) is False
+
+    def test_denial_notice_is_silent_on_a_json_only_console(self, no_tty, capsys):
+        """JSON-only output must stay parseable — the reason goes to the log."""
+        SilentConsole().confirm_tool_execution("send_draft", {})
+        assert capsys.readouterr().out == ""
+
+
+class TestTerminalDetection:
+    """``terminal_is_interactive`` against real stream objects."""
+
+    def test_both_ends_a_tty(self, monkeypatch):
+        monkeypatch.setattr("sys.stdin", _FakeStream(interactive=True))
+        monkeypatch.setattr("sys.stdout", _FakeStream(interactive=True))
+        assert terminal_is_interactive() is True
+
+    def test_piped_stdin(self, monkeypatch):
+        monkeypatch.setattr("sys.stdin", _FakeStream(interactive=False))
+        monkeypatch.setattr("sys.stdout", _FakeStream(interactive=True))
+        assert terminal_is_interactive() is False
+
+    def test_redirected_stdout(self, monkeypatch):
+        """`gaia … > log.txt`: prompting would block on a question nobody sees."""
+        monkeypatch.setattr("sys.stdin", _FakeStream(interactive=True))
+        monkeypatch.setattr("sys.stdout", _FakeStream(interactive=False))
+        assert terminal_is_interactive() is False
+
+    def test_closed_stream(self, monkeypatch):
+        class _Closed:
+            def isatty(self):
+                raise ValueError("I/O operation on closed file")
+
+        monkeypatch.setattr("sys.stdin", _Closed())
+        assert terminal_is_interactive() is False
+
+    def test_missing_stream(self, monkeypatch):
+        """A pythonw / frozen build can have stdin set to None."""
+        monkeypatch.setattr("sys.stdin", None)
+        assert terminal_is_interactive() is False
+
+    def test_gated_tool_is_denied_when_no_terminal(self, monkeypatch):
+        monkeypatch.setattr("sys.stdin", _FakeStream(interactive=False))
+        monkeypatch.setattr("sys.stdout", _FakeStream(interactive=False))
+        assert AgentConsole().confirm_tool_execution("send_now", {}) is False
+
+
+class TestAgentConsoleInteractive:
+    """The CLI console attached to a real terminal."""
+
+    @pytest.mark.parametrize("answer", ["y", "Y", "yes", "  yes  "])
+    def test_yes_approves(self, tty, monkeypatch, answer):
+        _answer(monkeypatch, answer)
+        assert AgentConsole().confirm_tool_execution("send_now", {}) is True
+
+    @pytest.mark.parametrize("answer", ["n", "no", "", "   ", "whatever"])
+    def test_no_and_empty_deny(self, tty, monkeypatch, answer):
+        _answer(monkeypatch, answer)
+        console = AgentConsole()
+        assert console.confirm_tool_execution("send_now", {}) is False
+        assert "denied by the user" in console.confirmation_denied_reason("send_now")
+
+    def test_eof_denies(self, tty, monkeypatch):
+        def _eof(prompt=""):
+            raise EOFError
+
+        monkeypatch.setattr("builtins.input", _eof)
+        assert AgentConsole().confirm_tool_execution("send_now", {}) is False
+
+    def test_ctrl_c_denies(self, tty, monkeypatch):
+        def _interrupt(prompt=""):
+            raise KeyboardInterrupt
+
+        monkeypatch.setattr("builtins.input", _interrupt)
+        assert AgentConsole().confirm_tool_execution("send_now", {}) is False
+
+    def test_prompt_shows_tool_and_arguments(self, tty, monkeypatch, capsys):
+        _answer(monkeypatch, "n")
+        AgentConsole().confirm_tool_execution(
+            "send_now", {"to": "boss@example.com", "subject": "resignation"}
+        )
+        out = capsys.readouterr().out
+        assert "send_now" in out
+        assert "boss@example.com" in out
+        assert "resignation" in out
+
+    def test_prompt_defaults_to_no(self, tty, monkeypatch):
+        prompts = _answer(monkeypatch, "")
+        AgentConsole().confirm_tool_execution("send_now", {})
+        # Capitalised N marks the default; y/a are the explicit approvals.
+        assert "[N]o" in prompts[0]
+
+    def test_always_approves_that_tool_for_the_session_only(self, tty, monkeypatch):
+        _answer(monkeypatch, "a", "n")
+        console = AgentConsole()
+        assert console.confirm_tool_execution("write_file", {"path": "a.py"}) is True
+        # Second call to the same tool does not re-prompt (no answers consumed).
+        assert console.confirm_tool_execution("write_file", {"path": "b.py"}) is True
+        # A different tool still asks — and the queued "n" denies it.
+        assert console.confirm_tool_execution("send_now", {}) is False
+
+    def test_always_does_not_leak_across_consoles(self, tty, monkeypatch):
+        _answer(monkeypatch, "a", "n")
+        assert AgentConsole().confirm_tool_execution("write_file", {}) is True
+        assert AgentConsole().confirm_tool_execution("write_file", {}) is False
+
+
+class TestArgumentRendering:
+    def test_no_arguments_is_labelled(self):
+        assert format_confirmation_args({}) == "(no arguments)"
+
+    def test_long_values_are_shortened(self):
+        rendered = format_confirmation_args({"body": "x" * 10_000})
+        assert "10000 chars" in rendered
+        assert len(rendered) < 2_000
+
+    def test_every_argument_name_survives_shortening(self):
+        """A hidden key is a hidden side effect — names are never dropped."""
+        rendered = format_confirmation_args(
+            {"command": "rm -rf " + "a" * 5_000 + "/important", "cwd": "/tmp"}
+        )
+        assert "command" in rendered and "cwd" in rendered
+        # Head AND tail of the shortened value stay visible.
+        assert "rm -rf" in rendered
+        assert "/important" in rendered
+
+
+# === The agent-loop contract ===
+
+
+class _GatedAgent(Agent):
+    """Agent with one gated tool that records whether its body ran."""
+
+    CONFIRMATION_REQUIRED_TOOLS = frozenset({"send_now"})
+
+    def __init__(self, console, **kwargs):
+        self.sent = []
+        self._console_override = console
+        super().__init__(**kwargs)
+
+    def _get_system_prompt(self) -> str:
+        return "gated"
+
+    def _create_console(self):
+        return self._console_override
+
+    def _register_tools(self) -> None:
+        sent = self.sent
+
+        @tool
+        def send_now(to: str) -> str:
+            """Send an email immediately. Gated."""
+            sent.append(to)
+            return "SENT"
+
+
+def _make_agent(console):
+    from unittest.mock import patch
+
+    with patch("gaia.agents.base.agent.AgentSDK"):
+        return _GatedAgent(console=console, silent_mode=True, skip_lemonade=True)
+
+
+class TestExecuteToolContract:
+    def test_non_tty_cli_denies_and_body_never_runs(self, no_tty):
+        agent = _make_agent(AgentConsole())
+        result = agent._execute_tool("send_now", {"to": "a@b.c"})
+        assert result["status"] == "denied"
+        assert agent.sent == []
+
+    def test_denied_result_carries_the_actionable_reason(self, no_tty):
+        agent = _make_agent(AgentConsole())
+        error = agent._execute_tool("send_now", {"to": "a@b.c"})["error"]
+        assert "send_now" in error
+        assert AUTO_APPROVE_ENV_VAR in error
+
+    def test_interactive_no_reports_a_user_denial(self, tty, monkeypatch):
+        _answer(monkeypatch, "n")
+        agent = _make_agent(AgentConsole())
+        result = agent._execute_tool("send_now", {"to": "a@b.c"})
+        assert result["status"] == "denied"
+        assert result["error"] == "Tool 'send_now' was denied by the user."
+        assert agent.sent == []
+
+    def test_interactive_yes_executes(self, tty, monkeypatch):
+        _answer(monkeypatch, "y")
+        agent = _make_agent(AgentConsole())
+        result = agent._execute_tool("send_now", {"to": "a@b.c"})
+        assert result == "SENT"
+        assert agent.sent == ["a@b.c"]
+
+    def test_ungated_tools_are_unaffected(self, no_tty):
+        """The gate only touches the confirmation set — normal tools still run."""
+        agent = _make_agent(AgentConsole())
+        result = agent._execute_tool("unknown_tool_name", {})
+        # Unknown-tool error, not a confirmation denial.
+        assert result["status"] == "error"
+
+    def test_console_without_the_reason_hook_still_gets_a_message(self, no_tty):
+        """Duck-typed hook: a custom console that only implements the bool API."""
+
+        class _BareConsole(AgentConsole):
+            def confirm_tool_execution(self, tool_name, tool_args):
+                return False
+
+            confirmation_denied_reason = None  # not callable
+
+        agent = _make_agent(_BareConsole())
+        result = agent._execute_tool("send_now", {"to": "a@b.c"})
+        assert result["status"] == "denied"
+        assert result["error"] == "Tool 'send_now' was denied by the user."
+
+
+class TestSilentModeStillAsks:
+    """`gaia chat` builds a SilentConsole for a real user at a real terminal
+    (cli.py sets ``silent_mode=True`` for everything but ``--debug``). Silence
+    must suppress narration, not consent — otherwise the flagship CLI would go
+    from "runs gated tools without asking" to "refuses them without asking".
+    """
+
+    def test_silent_console_prompts_on_a_terminal(self, tty, monkeypatch):
+        _answer(monkeypatch, "y")
+        assert SilentConsole().confirm_tool_execution("write_file", {}) is True
+
+    def test_silent_console_no_denies(self, tty, monkeypatch):
+        _answer(monkeypatch, "n")
+        assert SilentConsole().confirm_tool_execution("write_file", {}) is False
+
+    def test_both_cli_consoles_share_the_prompt_implementation(self):
+        from gaia.agents.base.console import TerminalConfirmationMixin
+
+        assert issubclass(AgentConsole, TerminalConfirmationMixin)
+        assert issubclass(SilentConsole, TerminalConfirmationMixin)
+
+    def test_chat_agents_console_can_be_asked(self, tty, monkeypatch):
+        """Pins the real console the real entry point builds."""
+        pytest.importorskip("gaia_agent_chat")
+        from gaia_agent_chat.agent import ChatAgent, ChatAgentConfig
+
+        stub = _StubChatAgent(ChatAgentConfig(silent_mode=True))
+        console = ChatAgent._create_console(stub)
+        _answer(monkeypatch, "n")
+        assert console.confirm_tool_execution("write_file", {}) is False
+        _answer(monkeypatch, "y")
+        assert console.confirm_tool_execution("write_file", {}) is True
+
+
+class _StubChatAgent:
+    """Just enough of ChatAgent for ``_create_console`` — no LLM, no RAG."""
+
+    def __init__(self, config):
+        self.silent_mode = config.silent_mode
+
+
+class TestAlwaysAllowScope:
+    """ "Always" must not become a blank cheque for arbitrary execution."""
+
+    @pytest.mark.parametrize("tool_name", ["run_shell_command", "run_cli_command"])
+    def test_shell_tools_never_offer_always(self, tty, monkeypatch, tool_name):
+        prompts = _answer(monkeypatch, "a", "n")
+        console = AgentConsole()
+        # "a" is not an approval for these — the tool name says nothing about
+        # what the next command will be.
+        assert console.confirm_tool_execution(tool_name, {"command": "ls"}) is False
+        assert "always" not in prompts[0]
+        # And nothing was remembered: the next call asks again.
+        assert (
+            console.confirm_tool_execution(tool_name, {"command": "rm -rf /"}) is False
+        )
+
+    def test_reset_clears_remembered_approvals(self, tty, monkeypatch):
+        _answer(monkeypatch, "a", "n")
+        console = AgentConsole()
+        assert console.confirm_tool_execution("write_file", {}) is True
+        console.reset_tool_approvals()
+        # Asks again after the reset — and the queued "n" denies.
+        assert console.confirm_tool_execution("write_file", {}) is False
+
+
+class TestDenialReasonBinding:
+    """The reason must belong to the tool it is reported for."""
+
+    def test_reason_is_not_reused_for_a_different_tool(self, no_tty):
+        console = AgentConsole()
+        console.confirm_tool_execution("send_now", {})
+        assert "send_now" in console.confirmation_denied_reason("send_now")
+        # A console that denies without recording a reason (a third-party
+        # handler, a monkeypatched test seam) must not inherit this one.
+        assert console.confirmation_denied_reason("permanent_delete") == (
+            "Tool 'permanent_delete' was denied by the user."
+        )
+
+    def test_approval_clears_a_stale_reason(self, tty, monkeypatch):
+        _answer(monkeypatch, "n", "y")
+        console = AgentConsole()
+        console.confirm_tool_execution("send_now", {})
+        assert console.confirm_tool_execution("send_now", {}) is True
+        assert console._last_denial is None
+
+
+class TestDotenvCannotGrantApproval:
+    """A ``.env`` file travels with a directory; it is not an operator decision.
+
+    ``gaia/__init__.py`` runs ``load_dotenv()`` at import, which would otherwise
+    let a project-local file switch off every confirmation prompt.
+    """
+
+    def test_env_var_name_matches_the_scrubbed_one(self):
+        import gaia
+
+        assert gaia._AUTO_APPROVE_TOOLS_VAR == AUTO_APPROVE_ENV_VAR
+
+    def test_dotenv_injected_value_is_dropped(self, tmp_path):
+        """Import GAIA in a child process whose CWD holds a hostile .env."""
+        import subprocess
+        import sys
+
+        (tmp_path / ".env").write_text("GAIA_AUTO_APPROVE_TOOLS=1\n")
+        script = (
+            "import os, sys, json\n"
+            "sys.path.insert(0, os.environ['GAIA_SRC'])\n"
+            "import gaia\n"
+            "from gaia.agents.base.console import auto_approve_env_enabled\n"
+            "print(json.dumps({'enabled': auto_approve_env_enabled(),\n"
+            "                  'env': os.environ.get('GAIA_AUTO_APPROVE_TOOLS')}))\n"
+        )
+        env = dict(os.environ)
+        env.pop("GAIA_AUTO_APPROVE_TOOLS", None)
+        env["GAIA_SRC"] = str(REPO_SRC)
+        proc = subprocess.run(
+            [sys.executable, "-c", script],
+            cwd=tmp_path,
+            env=env,
+            capture_output=True,
+            text=True,
+            timeout=180,
+        )
+        assert proc.returncode == 0, proc.stderr
+        payload = json.loads(proc.stdout.strip().splitlines()[-1])
+        assert payload["enabled"] is False, "a .env file enabled unattended approval"
+        # dotenv did inject it into os.environ — the point is that the
+        # confirmation gate does not read from there.
+        assert payload["env"] == "1"
+        assert "Ignoring GAIA_AUTO_APPROVE_TOOLS from a .env file" in proc.stderr
+
+    def test_real_process_environment_still_works(self, tmp_path):
+        """The operator's own export must keep working — only dotenv is dropped."""
+        import subprocess
+        import sys
+
+        script = (
+            "import os, sys, json\n"
+            "sys.path.insert(0, os.environ['GAIA_SRC'])\n"
+            "import gaia\n"
+            "from gaia.agents.base.console import auto_approve_env_enabled\n"
+            "print(json.dumps({'enabled': auto_approve_env_enabled()}))\n"
+        )
+        env = dict(os.environ)
+        env["GAIA_AUTO_APPROVE_TOOLS"] = "1"
+        env["GAIA_SRC"] = str(REPO_SRC)
+        proc = subprocess.run(
+            [sys.executable, "-c", script],
+            cwd=tmp_path,
+            env=env,
+            capture_output=True,
+            text=True,
+            timeout=180,
+        )
+        assert proc.returncode == 0, proc.stderr
+        assert json.loads(proc.stdout.strip().splitlines()[-1])["enabled"] is True
+
+
+class TestApiServerHandlerDenies:
+    """The OpenAI-compatible API stream is one-way: no channel to approve on."""
+
+    def test_api_sse_handler_denies_gated_tools(self):
+        from gaia.api.sse_handler import SSEOutputHandler as ApiSSEOutputHandler
+
+        handler = ApiSSEOutputHandler()
+        assert handler.confirm_tool_execution("write_file", {"path": "x"}) is False
+        assert AUTO_APPROVE_ENV_VAR in handler.confirmation_denied_reason("write_file")
+
+
+class TestDenialNoticeThrottling:
+    """A retrying model must not bury the transcript in repeated notices."""
+
+    def test_notice_is_shown_once_per_tool(self, no_tty, capsys):
+        console = AgentConsole()
+        for _ in range(3):
+            assert console.confirm_tool_execution("send_now", {}) is False
+        out = capsys.readouterr().out
+        assert out.count("requires explicit user approval") == 1
+
+        # A different tool gets its own notice.
+        assert console.confirm_tool_execution("write_file", {}) is False
+        assert "write_file" in capsys.readouterr().out
+
+    def test_every_denial_is_still_logged(self, no_tty, caplog):
+        console = AgentConsole()
+        with caplog.at_level(logging.WARNING, logger="gaia.agents.base.console"):
+            for _ in range(3):
+                console.confirm_tool_execution("send_now", {})
+        denials = [
+            r for r in caplog.records if "Denied confirmation-gated" in r.getMessage()
+        ]
+        assert len(denials) == 3
+
+
+class TestGateNeverCrashes:
+    """A broken terminal must DENY, not raise.
+
+    Before the gate existed the tool simply ran, so an exception escaping
+    ``confirm_tool_execution`` would be a brand-new way to kill a working
+    session — and it propagates: ``Agent._execute_tool``'s callers do not wrap
+    it. Every one of these inputs used to raise out of the gate.
+    """
+
+    def test_malformed_tool_args_still_prompt(self, tty, monkeypatch):
+        """A model can emit ``tool_args`` as a list or a bare string."""
+        _answer(monkeypatch, "n", "n", "n")
+        console = AgentConsole()
+        for bad_args in (["boss@example.com"], "boss@example.com", 42):
+            assert console.confirm_tool_execution("send_now", bad_args) is False
+
+    def test_malformed_tool_args_are_shown_not_hidden(self, tty, monkeypatch, capsys):
+        _answer(monkeypatch, "y")
+        AgentConsole().confirm_tool_execution("send_now", ["boss@example.com"])
+        assert "boss@example.com" in capsys.readouterr().out
+
+    def test_unreadable_terminal_denies(self, tty, monkeypatch):
+        """`input()` raises OSError on a detached / broken tty."""
+
+        def _broken(prompt=""):
+            raise OSError(5, "Input/output error")
+
+        monkeypatch.setattr("builtins.input", _broken)
+        console = AgentConsole()
+        assert console.confirm_tool_execution("send_now", {"to": "a@b.c"}) is False
+        # Nobody said no — the reason must not blame the user.
+        reason = console.confirmation_denied_reason("send_now")
+        assert "could not present the request or read an answer" in reason
+        assert "denied by the user" not in reason
+
+    def test_undisplayable_request_denies_without_prompting(self, tty, monkeypatch):
+        """If the request cannot be rendered, do not ask the user to approve
+        something they never saw."""
+
+        def _explode(*_a, **_kw):
+            raise RuntimeError("terminal exploded")
+
+        def _must_not_prompt(prompt=""):
+            raise AssertionError("prompted for a request the user never saw")
+
+        monkeypatch.setattr("builtins.input", _must_not_prompt)
+        console = AgentConsole()
+        monkeypatch.setattr(console, "_render_confirmation_request", _explode)
+        assert console.confirm_tool_execution("send_now", {"to": "a@b.c"}) is False
+        assert "could not present" in console.confirmation_denied_reason("send_now")
+
+    def test_broken_stdout_on_the_deny_path_still_denies(self, no_tty, monkeypatch):
+        """A daemon-hosted agent can have a closed stdout."""
+
+        class _Closed:
+            def write(self, *_a):
+                raise ValueError("I/O operation on closed file")
+
+            def flush(self):
+                pass
+
+            def isatty(self):
+                return False
+
+        monkeypatch.setattr("sys.stdout", _Closed())
+        assert AgentConsole().confirm_tool_execution("send_now", {}) is False
+
+    def test_broken_progress_hooks_still_reach_a_decision(self, tty, monkeypatch):
+        _answer(monkeypatch, "y")
+        console = AgentConsole()
+        monkeypatch.setattr(
+            console, "pause_progress", lambda: (_ for _ in ()).throw(OSError("nope"))
+        )
+        monkeypatch.setattr(
+            console, "resume_progress", lambda: (_ for _ in ()).throw(OSError("nope"))
+        )
+        assert console.confirm_tool_execution("send_now", {"to": "a@b.c"}) is True
+
+    def test_display_failures_are_logged(self, no_tty, monkeypatch, caplog):
+        console = AgentConsole()
+        monkeypatch.setattr(
+            console,
+            "_show_denial_notice",
+            lambda _r: (_ for _ in ()).throw(RuntimeError("boom")),
+        )
+        with caplog.at_level(logging.WARNING, logger="gaia.agents.base.console"):
+            assert console.confirm_tool_execution("send_now", {}) is False
+        assert any("failed on this terminal" in r.getMessage() for r in caplog.records)
+
+
+class TestSideEffectNeverHappensOnTheBrokenPaths:
+    """The point of the gate: the tool body must not run. Asserted on the side
+    effect itself, not on whether a prompt was requested."""
+
+    def test_unreadable_terminal_does_not_execute_the_tool(self, tty, monkeypatch):
+        def _broken(prompt=""):
+            raise OSError(5, "Input/output error")
+
+        monkeypatch.setattr("builtins.input", _broken)
+        agent = _make_agent(AgentConsole())
+        result = agent._execute_tool("send_now", {"to": "a@b.c"})
+        assert result["status"] == "denied"
+        assert agent.sent == [], "the send ran on a terminal that could not ask"
+
+    def test_malformed_args_do_not_execute_the_tool(self, tty, monkeypatch):
+        _answer(monkeypatch, "n")
+        agent = _make_agent(AgentConsole())
+        result = agent._execute_tool("send_now", ["a@b.c"])
+        assert result["status"] == "denied"
+        assert agent.sent == []
+
+    def test_no_exception_escapes_the_gate_into_the_agent_loop(self, tty, monkeypatch):
+        """``_execute_tool``'s callers don't catch — a raise here kills the run."""
+
+        def _broken(prompt=""):
+            raise OSError(5, "Input/output error")
+
+        monkeypatch.setattr("builtins.input", _broken)
+        agent = _make_agent(AgentConsole())
+        # Would raise AttributeError/OSError before the fix.
+        assert agent._execute_tool("send_now", {"to": "a@b.c"})["status"] == "denied"
+
+
+class TestPromptDoesNotAlterWhatRuns:
+    """Shortening is for the display only. If it leaked into the arguments, an
+    approved write would silently truncate the user's file."""
+
+    def test_arguments_are_not_mutated_by_rendering(self, tty, monkeypatch):
+        _answer(monkeypatch, "y")
+        args = {"path": "/tmp/x.txt", "content": "y" * 5_000}
+        AgentConsole().confirm_tool_execution("write_file", args)
+        assert len(args["content"]) == 5_000
+
+    def test_approved_tool_receives_the_full_arguments(self, tty, monkeypatch):
+        _answer(monkeypatch, "y")
+        received = {}
+
+        class _Probe(Agent):
+            AGENT_ID = "confirmation-arg-fidelity"
+            CONFIRMATION_REQUIRED_TOOLS = frozenset({"write_file"})
+
+            def _create_console(self):
+                return AgentConsole()
+
+            def _get_system_prompt(self):
+                return "p"
+
+            def _register_tools(self):
+                @tool
+                def write_file(path: str, content: str) -> str:
+                    """Write a file. Gated."""
+                    received["len"] = len(content)
+                    return "WROTE"
+
+        from unittest.mock import patch
+
+        with patch("gaia.agents.base.agent.AgentSDK"):
+            agent = _Probe(silent_mode=True, skip_lemonade=True)
+
+        agent._execute_tool(
+            "write_file", {"path": "/tmp/x.txt", "content": "y" * 5_000}
+        )
+        assert received["len"] == 5_000

--- a/tests/unit/agents/test_email_agent_confirmation.py
+++ b/tests/unit/agents/test_email_agent_confirmation.py
@@ -19,6 +19,30 @@ pytest.importorskip("gaia_agent_email")
 from gaia_agent_email.agent import EmailTriageAgent  # noqa: E402
 
 
+def _no_terminal(monkeypatch) -> None:
+    """No interactive terminal — piped stdin, CI, or a subprocess host."""
+    monkeypatch.setattr(
+        "gaia.agents.base.console.terminal_is_interactive", lambda: False
+    )
+
+
+def _at_a_terminal(monkeypatch, *answers: str) -> None:
+    """A user sitting at a terminal, answering the prompt in order."""
+    monkeypatch.setattr(
+        "gaia.agents.base.console.terminal_is_interactive", lambda: True
+    )
+    queue = list(answers)
+    monkeypatch.setattr("builtins.input", lambda _prompt="": queue.pop(0))
+
+
+def _clear_env_opt_in(monkeypatch) -> None:
+    import gaia
+    from gaia.agents.base.console import AUTO_APPROVE_ENV_VAR
+
+    monkeypatch.delenv(AUTO_APPROVE_ENV_VAR, raising=False)
+    monkeypatch.delitem(gaia._PRE_DOTENV_ENVIRON, AUTO_APPROVE_ENV_VAR, raising=False)
+
+
 class TestConfirmationGatingAtBaseLevel:
     """The EmailTriageAgent's confirmation set (its own
     ``CONFIRMATION_REQUIRED_TOOLS`` merged with the generic base set via
@@ -71,3 +95,117 @@ class TestConfirmationGatingAtBaseLevel:
     )
     def test_safe_tool_is_NOT_gated(self, tool_name):
         assert tool_name not in EmailTriageAgent.confirmation_required_tools()
+
+
+class TestGatedEmailToolsCannotRunUnprompted:
+    """The gate must hold on the CLI/subprocess path too (#2210).
+
+    Before the fix, ``AgentConsole`` inherited an ``OutputHandler`` default that
+    approved everything, so ``gaia email -i`` (and any subprocess host) executed
+    send / forward / permanent-delete / RSVP with no prompt at all. These tests
+    drive the REAL email gate set through the REAL default CLI console with a
+    non-interactive stdin — the exact shape of a piped or daemon-hosted run.
+    """
+
+    @staticmethod
+    def _probe_agent(console):
+        """A real ``Agent`` carrying the email agent's own gate set.
+
+        ``EmailTriageAgent`` needs live mail/calendar backends to construct, so
+        the probe borrows its ``CONFIRMATION_REQUIRED_TOOLS`` verbatim and runs
+        the identical inherited ``Agent._execute_tool`` gate (asserted below).
+        """
+        from unittest.mock import patch
+
+        from gaia.agents.base.agent import Agent
+        from gaia.agents.base.tools import tool
+
+        class _EmailProbeAgent(Agent):
+            AGENT_ID = "email-confirmation-probe"
+            CONFIRMATION_REQUIRED_TOOLS = EmailTriageAgent.CONFIRMATION_REQUIRED_TOOLS
+
+            def __init__(self, **kwargs):
+                self.executed = []
+                self._console_override = console
+                super().__init__(**kwargs)
+
+            def _create_console(self):
+                return self._console_override
+
+            def _get_system_prompt(self):
+                return "email confirmation probe"
+
+            def _register_tools(self):
+                executed = self.executed
+
+                for name in sorted(EmailTriageAgent.CONFIRMATION_REQUIRED_TOOLS):
+
+                    def _make(tool_name):
+                        def _fn(**kwargs):
+                            executed.append(tool_name)
+                            return "EXECUTED"
+
+                        _fn.__name__ = tool_name
+                        _fn.__doc__ = f"Stand-in for the gated {tool_name} tool."
+                        return _fn
+
+                    tool(_make(name))
+
+        with patch("gaia.agents.base.agent.AgentSDK"):
+            return _EmailProbeAgent(silent_mode=True, skip_lemonade=True)
+
+    def test_email_agent_uses_the_inherited_gate_and_the_cli_console(self):
+        """Pins the two assumptions the probe rests on."""
+        import typing
+
+        from gaia.agents.base.agent import Agent
+        from gaia.agents.base.console import AgentConsole
+
+        assert EmailTriageAgent._execute_tool is Agent._execute_tool
+        hints = typing.get_type_hints(EmailTriageAgent._create_console)
+        assert hints["return"] is AgentConsole
+
+    def test_send_draft_is_denied_without_a_terminal(self, monkeypatch):
+        from gaia.agents.base.console import AUTO_APPROVE_ENV_VAR, AgentConsole
+
+        _clear_env_opt_in(monkeypatch)
+        _no_terminal(monkeypatch)
+
+        agent = self._probe_agent(AgentConsole())
+        result = agent._execute_tool("send_draft", {"draft_id": "d1", "confirm": True})
+
+        assert result["status"] == "denied"
+        assert agent.executed == [], "send_draft ran without any user approval"
+        assert AUTO_APPROVE_ENV_VAR in result["error"]
+
+    @pytest.mark.parametrize(
+        "tool_name", sorted(EmailTriageAgent.CONFIRMATION_REQUIRED_TOOLS)
+    )
+    def test_every_gated_email_tool_is_denied_without_a_terminal(
+        self, tool_name, monkeypatch
+    ):
+        from gaia.agents.base.console import AgentConsole
+
+        _clear_env_opt_in(monkeypatch)
+        _no_terminal(monkeypatch)
+
+        agent = self._probe_agent(AgentConsole())
+        result = agent._execute_tool(tool_name, {})
+
+        assert result["status"] == "denied"
+        assert agent.executed == []
+
+    def test_interactive_no_denies_and_yes_approves(self, monkeypatch):
+        from gaia.agents.base.console import AgentConsole
+
+        _clear_env_opt_in(monkeypatch)
+        _at_a_terminal(monkeypatch, "n", "y")
+
+        agent = self._probe_agent(AgentConsole())
+        denied = agent._execute_tool("send_now", {"to": "a@b.c"})
+        assert denied["status"] == "denied"
+        assert agent.executed == []
+
+        approved = agent._execute_tool("send_now", {"to": "a@b.c"})
+        assert approved == "EXECUTED"
+        assert agent.executed == ["send_now"]

--- a/tests/unit/chat/ui/test_sse_confirmation.py
+++ b/tests/unit/chat/ui/test_sse_confirmation.py
@@ -12,6 +12,7 @@ import time
 
 import pytest
 
+from gaia.agents.base.console import OutputHandler
 from gaia.ui.sse_handler import SSEOutputHandler
 
 # ---------------------------------------------------------------------------
@@ -290,3 +291,95 @@ class TestConfirmToolEndpoint:
             json={"session_id": "nonexistent", "approved": True},
         )
         assert resp.status_code == 404
+
+
+# ===========================================================================
+# Regression: the SSE path must NOT inherit the deny-by-default (#2210)
+# ===========================================================================
+
+
+class TestSSEPathUnaffectedByDenyByDefault:
+    """``OutputHandler.confirm_tool_execution`` now denies when it cannot reach a
+    human (#2210). The Agent UI path has a human — the frontend permission modal
+    — so it must still emit ``permission_request``, block, and honour whatever
+    ``resolve_tool_confirmation`` says.
+    """
+
+    def test_permission_request_still_fires_and_approval_still_runs_the_tool(self):
+        """End-to-end through the agent gate: request event, then execution."""
+        from unittest.mock import patch
+
+        from gaia.agents.base.agent import Agent
+        from gaia.agents.base.tools import tool
+
+        class _GatedAgent(Agent):
+            CONFIRMATION_REQUIRED_TOOLS = frozenset({"send_now"})
+
+            def __init__(self, console, **kwargs):
+                self.sent = []
+                self._console_override = console
+                super().__init__(**kwargs)
+
+            def _get_system_prompt(self):
+                return "gated"
+
+            def _create_console(self):
+                return self._console_override
+
+            def _register_tools(self):
+                sent = self.sent
+
+                @tool
+                def send_now(to: str) -> str:
+                    """Send an email immediately. Gated."""
+                    sent.append(to)
+                    return "SENT"
+
+        handler = SSEOutputHandler()
+        with patch("gaia.agents.base.agent.AgentSDK"):
+            agent = _GatedAgent(console=handler, silent_mode=True, skip_lemonade=True)
+
+        result_holder = {}
+
+        def run_tool():
+            result_holder["result"] = agent._execute_tool("send_now", {"to": "a@b.c"})
+
+        t = threading.Thread(target=run_tool)
+        t.start()
+        _wait_for_pending_confirmation(handler)
+
+        events = _drain(handler)
+        permission = [e for e in events if e.get("type") == "permission_request"]
+        assert len(permission) == 1
+        assert permission[0]["tool"] == "send_now"
+        assert permission[0]["args"] == {"to": "a@b.c"}
+        assert permission[0]["confirm_id"]
+
+        handler.resolve_tool_confirmation(approved=True)
+        t.join(timeout=3.0)
+        assert not t.is_alive()
+        assert result_holder["result"] == "SENT"
+        assert agent.sent == ["a@b.c"]
+
+    def test_blocking_handler_does_not_auto_deny(self, handler):
+        """The handler advertises a live confirmation channel and overrides the
+        base default — no synchronous deny before the modal is shown."""
+        assert handler.blocking_confirmation is True
+        assert handler.auto_approve_gated_tools is False
+        assert (
+            SSEOutputHandler.confirm_tool_execution
+            is not OutputHandler.confirm_tool_execution
+        )
+
+    def test_background_mode_still_denies_with_the_unattended_reason(self):
+        """Autonomous runs keep their existing auto-deny event and now surface
+        the same wording in the tool result the model sees."""
+        handler = SSEOutputHandler(background_mode=True)
+        assert handler.confirm_tool_execution("send_now", {}) is False
+
+        events = _drain(handler)
+        denied = [e for e in events if e.get("type") == "tool_confirm_denied"]
+        assert len(denied) == 1
+        assert denied[0]["reason"] == "unattended"
+        assert "cannot run" in denied[0]["message"]
+        assert handler.confirmation_denied_reason("send_now") == denied[0]["message"]

--- a/tests/unit/test_tui_mcp.py
+++ b/tests/unit/test_tui_mcp.py
@@ -1,0 +1,1229 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+"""Unit tests for the GAIA TUI control MCP server.
+
+These run without the optional ``mcp`` package and without a TUI: the tools are
+plain module-level functions, and the control server is a scripted fake that
+replaces the module's ``requests`` handle.
+"""
+
+import json
+import logging
+
+import psutil
+import pytest
+import requests
+
+from gaia.mcp.servers import tui_mcp
+
+TOKEN = "f" * 64
+PID = 4242
+PORT = 8770
+BASE_URL = f"http://127.0.0.1:{PORT}"
+
+HUB_FOOTER = (
+    "Enter=launch  /=search  Tab=category  d=delete  v=vote  r=request  "
+    "?=help  q=quit"
+)
+HUB_FOOTER_NO_INSTALL = (
+    "Enter=launch  /=search  Tab=category  v=vote  r=request  ?=help  q=quit"
+)
+
+
+# ── Fixtures / fakes ─────────────────────────────────────────────────
+
+
+def write_control(tmp_path, monkeypatch, **overrides):
+    """Point GAIA_TUI_HOME at *tmp_path* and write a control.json there."""
+    monkeypatch.setenv(tui_mcp.ENV_TUI_HOME, str(tmp_path))
+    info = {
+        "pid": PID,
+        "port": PORT,
+        "token": TOKEN,
+        "host": "127.0.0.1",
+        "service": "gaia-tui-control",
+        "api_version": "v1",
+        "started_at": 1730000000.0,
+        "version": "dev",
+    }
+    info.update(overrides)
+    (tmp_path / "control.json").write_text(json.dumps(info), encoding="utf-8")
+    return info
+
+
+def set_pid_alive(monkeypatch, alive):
+    """Make ``pid_alive`` deterministic regardless of the host's real pids."""
+    monkeypatch.setattr(psutil, "pid_exists", lambda pid: alive)
+
+    class _NoProcess:
+        def __init__(self, pid):
+            raise psutil.NoSuchProcess(pid)
+
+    monkeypatch.setattr(psutil, "Process", _NoProcess)
+
+
+class FakeResponse:
+    def __init__(self, status_code, body=None, text=None):
+        self.status_code = status_code
+        self._body = body
+        self.text = text if text is not None else json.dumps(body)
+
+    def json(self):
+        if self._body is None:
+            raise ValueError("not json")
+        return self._body
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            raise requests.exceptions.HTTPError(
+                f"HTTP {self.status_code}", response=self
+            )
+
+
+def _api_error(status, code, message, **extra):
+    """The control server's error envelope."""
+    return FakeResponse(status, {"error": {"code": code, "message": message, **extra}})
+
+
+class FakeTui:
+    """A scripted control server: keys mutate state, state drives the screen."""
+
+    exceptions = requests.exceptions
+
+    def __init__(
+        self,
+        tabs=(("Installed", ["bash", "chat"]),),
+        launchable=True,
+        footer=HUB_FOOTER,
+        status_line="",
+        view="hub",
+        agent="",
+        service=tui_mcp.SERVICE_ID,
+        pid=PID,
+        unreachable=False,
+        confirms=True,
+        selected_index=0,
+        streaming=False,
+        overlay="",
+        can_return_to_hub=True,
+        settled=True,
+        running=True,
+    ):
+        self.confirms = confirms
+        self.streaming = streaming
+        self.overlay = overlay
+        self.can_return_to_hub = can_return_to_hub
+        self.settled = settled
+        self.running = running
+        self.tabs = [(name, list(ids)) for name, ids in tabs]
+        self.tab_index = 0
+        self.selected_index = selected_index
+        self.view = view
+        self.agent = agent
+        self.launchable = launchable
+        self.footer = footer
+        self.status_line = status_line
+        self.service = service
+        self.pid = pid
+        self.unreachable = unreachable
+        self.seq = 0
+        self.keys_sent = []
+        self.text_sent = []
+        self.confirm_open = False
+        self.requests_seen = []
+        self.tokens_seen = []
+
+    # -- state --------------------------------------------------------
+
+    def visible(self):
+        return self.tabs[self.tab_index][1]
+
+    def tab_name(self):
+        return self.tabs[self.tab_index][0]
+
+    def selected(self):
+        vis = self.visible()
+        if not vis:
+            return ""
+        return vis[min(self.selected_index, len(vis) - 1)]
+
+    def state(self):
+        if self.view == "chat":
+            state = {
+                "view": "chat",
+                "agent": self.agent,
+                "streaming": self.streaming,
+            }
+            # Absent only when the build predates the field; None means "omit".
+            if self.can_return_to_hub is not None:
+                state["can_return_to_hub"] = self.can_return_to_hub
+            return state
+        return {
+            "view": "hub",
+            "agent": "",
+            "streaming": False,
+            "can_return_to_hub": False,
+            "hub_tab": self.tab_name(),
+            "hub_tab_index": self.tab_index,
+            "selected_agent_id": self.selected(),
+            "visible_agent_ids": list(self.visible()),
+            "filtering": False,
+            "overlay": self.overlay or ("confirm" if self.confirm_open else ""),
+        }
+
+    def screen(self):
+        if self.view == "chat":
+            return f"chat with {self.agent}\n> \nEsc=back  q=quit"
+        lines = [f"GAIA hub — {self.tab_name()}"]
+        for i, aid in enumerate(self.visible()):
+            lines.append(("> " if i == self.selected_index else "  ") + aid)
+        if self.confirm_open:
+            lines.append(f'Uninstall "{self.selected()}"?    Yes    No')
+        if self.status_line:
+            lines.append(self.status_line)
+        lines.append(self.footer)
+        return "\n".join(lines)
+
+    def press(self, key):
+        self.keys_sent.append(key)
+        self.seq += 1
+        if self.confirm_open:
+            if key == "y":
+                name, ids = self.tabs[self.tab_index]
+                target = self.selected()
+                if target in ids:
+                    ids.remove(target)
+                self.tabs[self.tab_index] = (name, ids)
+                self.selected_index = 0
+                self.confirm_open = False
+            elif key in ("n", "esc"):
+                self.confirm_open = False
+            return
+        if key == "tab":
+            # bubbles' list.SetItems keeps the cursor index across a tab switch;
+            # it does not reset to the top. The navigation code must cope.
+            self.tab_index = (self.tab_index + 1) % len(self.tabs)
+            self.selected_index = min(
+                self.selected_index, max(len(self.visible()) - 1, 0)
+            )
+        elif key == "down":
+            self.selected_index = min(self.selected_index + 1, len(self.visible()) - 1)
+        elif key == "up":
+            self.selected_index = max(self.selected_index - 1, 0)
+        elif key == "esc":
+            self.view = "hub"
+            self.agent = ""
+        elif key == "enter" and self.view == "hub" and self.launchable:
+            self.view = "chat"
+            self.agent = self.selected()
+        elif key == "d" and self.confirms:
+            # The real hub opens the dialog only for an installed/idle agent;
+            # for anything else 'd' is a no-op, which confirms=False models.
+            self.confirm_open = True
+
+    # -- transport ----------------------------------------------------
+
+    def _status_body(self):
+        return {
+            "service": self.service,
+            "api_version": "v1",
+            "version": "dev",
+            "pid": self.pid,
+            "running": self.running,
+            "uptime_ms": 1000,
+            "cols": 80,
+            "rows": 24,
+            "frame_seq": self.seq,
+            "state": self.state(),
+        }
+
+    def get(self, url, headers=None, timeout=None, **kwargs):
+        return self.request("GET", url, headers=headers, timeout=timeout, **kwargs)
+
+    def request(
+        self,
+        method,
+        url,
+        headers=None,
+        timeout=None,
+        json=None,
+        params=None,
+        proxies=None,
+    ):
+        if self.unreachable:
+            raise requests.exceptions.ConnectionError("refused")
+        assert url.startswith(BASE_URL), url
+        # Loopback must never be proxied — HTTP_PROXY would otherwise be handed
+        # the bearer token and the screen contents.
+        assert proxies == {"http": None, "https": None}, proxies
+        auth = (headers or {}).get("Authorization", "")
+        self.tokens_seen.append(auth)
+        assert auth == f"Bearer {TOKEN}", auth
+        path = url.split(tui_mcp.API_PREFIX, 1)[1]
+        method = method.upper()
+        self.requests_seen.append((method, path))
+
+        # Contract checks the real server enforces (tui/internal/control/
+        # server.go): method per route, DisallowUnknownFields on every POST body,
+        # and the documented value ranges. Without these the fake would only
+        # prove the call was made, not that it would be accepted.
+        rejection = self._reject_invalid(method, path, json)
+        if rejection is not None:
+            return rejection
+
+        if path == "/status":
+            return FakeResponse(200, self._status_body())
+
+        if path == "/screen":
+            fmt = (params or {}).get("format", "plain")
+            text = self.screen()
+            return FakeResponse(
+                200,
+                {
+                    "format": fmt,
+                    "seq": self.seq,
+                    "cols": 80,
+                    "rows": 24,
+                    "lines": len(text.splitlines()),
+                    "screen": text,
+                },
+            )
+
+        if path == "/keys":
+            keys = (json or {}).get("keys", [])
+            for key in keys:
+                self.press(key)
+            return FakeResponse(
+                200,
+                {
+                    "sent": len(keys),
+                    "keys": keys,
+                    "seq": self.seq,
+                    "settled": self.settled,
+                },
+            )
+
+        if path == "/text":
+            text = (json or {}).get("text", "")
+            self.text_sent.append(text)
+            self.seq += 1
+            return FakeResponse(
+                200,
+                {"sent_runes": len(text), "seq": self.seq, "settled": self.settled},
+            )
+
+        if path == "/resize":
+            return FakeResponse(
+                200,
+                {
+                    "cols": (json or {}).get("cols"),
+                    "rows": (json or {}).get("rows"),
+                    "seq": self.seq,
+                    "settled": self.settled,
+                },
+            )
+
+        if path == "/wait":
+            return self._wait(json or {})
+
+        return FakeResponse(
+            404, {"error": {"code": "not_found", "message": f"no route {path}"}}
+        )
+
+    #: route -> (method, allowed body fields) exactly as the Go server declares.
+    ROUTES = {
+        "/status": ("GET", None),
+        "/screen": ("GET", None),
+        "/frames": ("GET", None),
+        "/keys": ("POST", {"keys", "delay_ms"}),
+        "/text": ("POST", {"text", "delay_ms"}),
+        "/wait": ("POST", {"contains", "absent", "state", "timeout_ms"}),
+        "/resize": ("POST", {"cols", "rows"}),
+    }
+    STATE_MATCHER_KEYS = {
+        "view": str,
+        "agent": str,
+        "can_return_to_hub": bool,
+        "hub_tab": str,
+        "selected_agent_id": str,
+        "overlay": str,
+        "streaming": bool,
+        "filtering": bool,
+        "hub_tab_index": (int, float),
+        "visible_contains": str,
+    }
+
+    def _reject_invalid(self, method, path, body):
+        route = self.ROUTES.get(path)
+        if route is None:
+            return None  # the 404 branch below handles unknown routes
+        want_method, allowed = route
+        if method != want_method:
+            return _api_error(405, "method_not_allowed", f"{path} wants {want_method}")
+        if allowed is None:
+            return None
+        if not self.running:
+            # tea.Program.Send silently discards while the loop is not consuming,
+            # so the server refuses instead of answering 200 with a lie.
+            return _api_error(
+                503,
+                "not_running",
+                "the TUI is not accepting input: its event loop is not running",
+                hint="check GET /control/v1/status; if running is false, start a "
+                "new TUI with the control API enabled",
+            )
+        unknown = set(body or {}) - allowed
+        if unknown:
+            return _api_error(400, "bad_json", f"unknown field {sorted(unknown)[0]!r}")
+
+        body = body or {}
+        if path == "/keys":
+            if not body.get("keys"):
+                return _api_error(400, "no_keys", "keys is empty")
+            if len(body["keys"]) > tui_mcp.MAX_KEYS_PER_CALL:
+                return _api_error(400, "too_many_keys", "too many keys in one call")
+        if path in ("/keys", "/text"):
+            delay = body.get("delay_ms", 0)
+            if not 0 <= delay <= tui_mcp.MAX_DELAY_MS:
+                return _api_error(400, "bad_delay", f"delay_ms {delay} out of range")
+            count = len(body.get("keys", [])) if path == "/keys" else 1
+            if delay * max(count - 1, 0) > tui_mcp.MAX_INJECTION_DELAY_MS:
+                return _api_error(
+                    400, "delay_budget_exceeded", "the batch would pause too long"
+                )
+        if path == "/resize":
+            cols, rows = body.get("cols"), body.get("rows")
+            if not (20 <= cols <= 500 and 5 <= rows <= 200):
+                return _api_error(400, "bad_size", f"{cols}x{rows} out of range")
+        if path == "/wait":
+            timeout = body.get("timeout_ms")
+            if timeout is not None and not 0 < timeout <= 600000:
+                return _api_error(400, "bad_timeout", f"timeout_ms {timeout} invalid")
+            for key, want in (body.get("state") or {}).items():
+                want_type = self.STATE_MATCHER_KEYS.get(key)
+                if want_type is None:
+                    return _api_error(
+                        400, "bad_state_matcher", f"unknown state key {key!r}"
+                    )
+                if not isinstance(want, want_type):
+                    return _api_error(
+                        400, "bad_state_matcher", f"state key {key!r} has a bad type"
+                    )
+        return None
+
+    def _wait(self, payload):
+        screen = self.screen()
+        matched = True
+        if payload.get("contains") and payload["contains"] not in screen:
+            matched = False
+        if payload.get("absent") and payload["absent"] in screen:
+            matched = False
+        for key, value in (payload.get("state") or {}).items():
+            if self.state().get(key) != value:
+                matched = False
+        if matched:
+            return FakeResponse(
+                200,
+                {
+                    "matched": True,
+                    "elapsed_ms": 12,
+                    "seq": self.seq,
+                    "screen": screen,
+                },
+            )
+        return FakeResponse(
+            408,
+            {
+                "error": {
+                    "code": "wait_timeout",
+                    "message": "wait timed out",
+                    "screen": screen,
+                    "elapsed_ms": payload.get("timeout_ms", 0),
+                    "state": self.state(),
+                }
+            },
+        )
+
+
+@pytest.fixture
+def live_tui(tmp_path, monkeypatch):
+    """A discoverable, healthy fake TUI. Returns the FakeTui instance."""
+
+    def _make(**kwargs):
+        write_control(tmp_path, monkeypatch)
+        set_pid_alive(monkeypatch, True)
+        fake = FakeTui(**kwargs)
+        monkeypatch.setattr(tui_mcp, "requests", fake)
+        return fake
+
+    return _make
+
+
+# ── Discovery ────────────────────────────────────────────────────────
+
+
+def test_control_dir_honors_env_per_call(tmp_path, monkeypatch):
+    monkeypatch.delenv(tui_mcp.ENV_TUI_HOME, raising=False)
+    default = tui_mcp.control_dir()
+    assert default.name == "tui"
+
+    monkeypatch.setenv(tui_mcp.ENV_TUI_HOME, str(tmp_path))
+    assert tui_mcp.control_dir() == tmp_path
+    assert tui_mcp.control_path() == tmp_path / "control.json"
+
+    other = tmp_path / "other"
+    monkeypatch.setenv(tui_mcp.ENV_TUI_HOME, str(other))
+    # Re-read, not cached from the first call.
+    assert tui_mcp.control_dir() == other
+
+
+def test_discover_no_control_file(tmp_path, monkeypatch):
+    monkeypatch.setenv(tui_mcp.ENV_TUI_HOME, str(tmp_path))
+    info, error = tui_mcp.discover()
+    assert info is None
+    assert error["status"] == "error"
+    assert "No GAIA TUI is running" in error["detail"]
+    assert "control.json" in error["detail"]
+    assert "gaia tui --control" in error["detail"]
+
+
+def test_discover_malformed_file(tmp_path, monkeypatch, caplog):
+    monkeypatch.setenv(tui_mcp.ENV_TUI_HOME, str(tmp_path))
+    (tmp_path / "control.json").write_text("{not json", encoding="utf-8")
+    with caplog.at_level(logging.WARNING, logger="gaia.mcp.servers.tui_mcp"):
+        info, error = tui_mcp.discover()
+    assert info is None
+    assert "malformed" in error["detail"]
+    assert "control.json" in error["detail"]
+    assert "gaia tui --control" in error["detail"]
+    assert any("malformed" in r.getMessage() for r in caplog.records)
+
+
+def test_read_control_file_missing_returns_none(tmp_path, monkeypatch):
+    monkeypatch.setenv(tui_mcp.ENV_TUI_HOME, str(tmp_path))
+    assert tui_mcp.read_control_file() is None
+
+
+def test_read_control_file_missing_required_key(tmp_path, monkeypatch):
+    monkeypatch.setenv(tui_mcp.ENV_TUI_HOME, str(tmp_path))
+    (tmp_path / "control.json").write_text('{"pid": 1}', encoding="utf-8")
+    assert tui_mcp.read_control_file() is None
+
+
+def test_discover_dead_pid(tmp_path, monkeypatch):
+    write_control(tmp_path, monkeypatch)
+    set_pid_alive(monkeypatch, False)
+    info, error = tui_mcp.discover()
+    assert info is None
+    assert str(PID) in error["detail"]
+    assert "not running" in error["detail"]
+    assert "stale control file" in error["detail"]
+    assert "gaia tui --control" in error["detail"]
+
+
+def test_discover_probe_unreachable(tmp_path, monkeypatch):
+    write_control(tmp_path, monkeypatch)
+    set_pid_alive(monkeypatch, True)
+    monkeypatch.setattr(tui_mcp, "requests", FakeTui(unreachable=True))
+    info, error = tui_mcp.discover()
+    assert info is None
+    assert "did not answer the control status probe" in error["detail"]
+    assert "recycled" in error["detail"]
+    assert "gaia tui --control" in error["detail"]
+
+
+def test_discover_probe_wrong_service(tmp_path, monkeypatch):
+    write_control(tmp_path, monkeypatch)
+    set_pid_alive(monkeypatch, True)
+    monkeypatch.setattr(tui_mcp, "requests", FakeTui(service="some-other-server"))
+    info, error = tui_mcp.discover()
+    assert info is None
+    assert "Another process now owns the port" in error["detail"]
+    assert "gaia tui --control" in error["detail"]
+
+
+def test_discover_probe_pid_mismatch(tmp_path, monkeypatch):
+    write_control(tmp_path, monkeypatch)
+    set_pid_alive(monkeypatch, True)
+    monkeypatch.setattr(tui_mcp, "requests", FakeTui(pid=PID + 1))
+    info, error = tui_mcp.discover()
+    assert info is None
+    assert "Another process now owns the port" in error["detail"]
+
+
+def test_discover_happy_path(live_tui):
+    live_tui()
+    info, error = tui_mcp.discover()
+    assert error is None
+    assert info["pid"] == PID
+    assert info["port"] == PORT
+    assert tui_mcp.base_url_of(info) == BASE_URL
+
+
+def test_discovery_errors_are_distinct_and_never_leak_the_token(tmp_path, monkeypatch):
+    details = []
+
+    monkeypatch.setenv(tui_mcp.ENV_TUI_HOME, str(tmp_path))
+    details.append(tui_mcp.discover()[1]["detail"])
+
+    (tmp_path / "control.json").write_text("{oops", encoding="utf-8")
+    details.append(tui_mcp.discover()[1]["detail"])
+
+    write_control(tmp_path, monkeypatch)
+    set_pid_alive(monkeypatch, False)
+    details.append(tui_mcp.discover()[1]["detail"])
+
+    set_pid_alive(monkeypatch, True)
+    monkeypatch.setattr(tui_mcp, "requests", FakeTui(unreachable=True))
+    details.append(tui_mcp.discover()[1]["detail"])
+
+    monkeypatch.setattr(tui_mcp, "requests", FakeTui(service="nope"))
+    details.append(tui_mcp.discover()[1]["detail"])
+
+    assert len(set(details)) == len(details), details
+    for detail in details:
+        assert "gaia tui --control" in detail
+        assert TOKEN not in detail
+        assert str(PORT) not in detail
+
+
+# ── _normalize_error ─────────────────────────────────────────────────
+
+
+def test_normalize_error_unwraps_error_envelope():
+    resp = FakeResponse(
+        400,
+        {
+            "error": {
+                "code": "unknown_key",
+                "message": "unknown key name 'flurb'",
+                "hint": "supported: enter, esc, tab, up, down",
+            }
+        },
+    )
+    err = requests.exceptions.HTTPError("400", response=resp)
+    out = tui_mcp._normalize_error(err, BASE_URL)
+    assert out["status"] == "error"
+    assert "unknown key name 'flurb'" in out["detail"]
+    assert "supported: enter, esc, tab, up, down" in out["detail"]
+
+
+def test_normalize_error_falls_back_to_http_code():
+    resp = FakeResponse(503, None, text="")
+    err = requests.exceptions.HTTPError("503", response=resp)
+    assert tui_mcp._normalize_error(err, BASE_URL)["detail"] == "HTTP 503"
+
+
+def test_normalize_error_strips_base_url():
+    resp = FakeResponse(500, None, text=f"boom at {BASE_URL}/control/v1/keys")
+    err = requests.exceptions.HTTPError("500", response=resp)
+    detail = tui_mcp._normalize_error(err, BASE_URL)["detail"]
+    assert BASE_URL not in detail
+    assert "/control/v1/keys" in detail
+
+    generic = tui_mcp._normalize_error(RuntimeError(f"bad {BASE_URL}/x"), BASE_URL)
+    assert BASE_URL not in generic["detail"]
+
+
+def test_normalize_error_redacts_the_token():
+    resp = FakeResponse(
+        401,
+        {"error": {"code": "unauthorized", "message": f"bad token {TOKEN}"}},
+    )
+    err = requests.exceptions.HTTPError("401", response=resp)
+    detail = tui_mcp._normalize_error(err, BASE_URL, token=TOKEN)["detail"]
+    assert TOKEN not in detail
+    assert "<redacted>" in detail
+
+    generic = tui_mcp._normalize_error(
+        RuntimeError(f"auth={TOKEN}"), BASE_URL, token=TOKEN
+    )
+    assert TOKEN not in generic["detail"]
+
+
+def test_normalize_error_connection_error_is_actionable():
+    out = tui_mcp._normalize_error(
+        requests.exceptions.ConnectionError("refused"), BASE_URL
+    )
+    assert "gaia tui --control" in out["detail"]
+    assert BASE_URL not in out["detail"]
+
+
+# ── Tools: no TUI running ────────────────────────────────────────────
+
+
+def test_every_tool_errors_cleanly_when_no_tui(monkeypatch):
+    error = tui_mcp._err("No GAIA TUI is running. Start one with: gaia tui --control")
+    monkeypatch.setattr(tui_mcp, "discover", lambda *a, **k: (None, error))
+
+    results = {
+        "status": tui_mcp._status(),
+        "screen": tui_mcp._screen(),
+        "send_keys": tui_mcp._send_keys(["enter"]),
+        "send_text": tui_mcp._send_text("hello"),
+        "wait_for": tui_mcp._wait_for(contains="hi"),
+        "resize": tui_mcp._resize(120, 40),
+        "launch": tui_mcp._launch_agent("email"),
+        "install": tui_mcp._install_agent("email"),
+        "uninstall": tui_mcp._uninstall_agent("email"),
+    }
+    for name, result in results.items():
+        assert result["status"] == "error", name
+        assert "gaia tui --control" in result["detail"], name
+
+
+def test_bad_arguments_are_rejected_before_discovery(monkeypatch):
+    def _boom(*a, **k):
+        raise AssertionError("discover should not be called")
+
+    monkeypatch.setattr(tui_mcp, "discover", _boom)
+    assert tui_mcp._screen("html")["status"] == "error"
+    assert tui_mcp._send_keys([])["status"] == "error"
+    assert tui_mcp._send_keys(5)["status"] == "error"
+    assert tui_mcp._send_text("")["status"] == "error"
+    assert tui_mcp._resize(0, 40)["status"] == "error"
+
+
+# ── Tools: happy paths ───────────────────────────────────────────────
+
+
+def test_status_summary_hub(live_tui):
+    live_tui(tabs=(("Installed", ["bash", "chat", "email", "jira", "code"]),))
+    out = tui_mcp._status()
+    assert out["summary"] == (
+        "hub view, tab 'Installed', 5 agents visible, selected 'bash'"
+    )
+
+
+def test_status_summary_chat(live_tui):
+    live_tui(view="chat", agent="email")
+    out = tui_mcp._status()
+    assert out["summary"] == "chat with 'email'"
+
+
+def test_status_summary_unknown_view(live_tui):
+    fake = live_tui()
+    fake.state = lambda: {"view": "unknown"}
+    out = tui_mcp._status()
+    assert "does not report its view state" in out["summary"]
+
+
+def test_screen_default_is_plain(live_tui):
+    fake = live_tui()
+    out = tui_mcp._screen()
+    assert out["format"] == "plain"
+    assert "GAIA hub" in out["screen"]
+    assert ("GET", "/screen") in fake.requests_seen
+
+
+def test_send_keys_accepts_a_string(live_tui):
+    fake = live_tui()
+    out = tui_mcp._send_keys("tab, down enter")
+    assert out["sent"] == 3
+    assert fake.keys_sent == ["tab", "down", "enter"]
+
+
+def test_send_text(live_tui):
+    fake = live_tui()
+    out = tui_mcp._send_text("triage my inbox")
+    assert out["sent_runes"] == len("triage my inbox")
+    assert fake.text_sent == ["triage my inbox"]
+
+
+def test_resize(live_tui):
+    live_tui()
+    out = tui_mcp._resize(120, 40)
+    assert out["cols"] == 120 and out["rows"] == 40
+
+
+def test_wait_for_requires_a_matcher(live_tui):
+    live_tui()
+    out = tui_mcp._wait_for()
+    assert out["status"] == "error"
+    assert "at least one" in out["detail"]
+
+
+def test_wait_for_match(live_tui):
+    live_tui()
+    out = tui_mcp._wait_for(contains="GAIA hub")
+    assert out["matched"] is True
+
+
+def test_wait_for_timeout_returns_the_actual_screen(live_tui):
+    live_tui()
+    out = tui_mcp._wait_for(contains="never on this screen", timeout_ms=1000)
+    assert out["status"] == "error"
+    assert "Timed out after 1000 ms" in out["detail"]
+    assert "GAIA hub" in out["detail"]  # what WAS on screen
+    assert "bash" in out["screen"]
+    assert out["matched"] is False
+
+
+def test_wait_uses_a_timeout_longer_than_the_wait(live_tui):
+    fake = live_tui()
+    seen = {}
+    original = fake.request
+
+    def _record(method, url, **kwargs):
+        if url.endswith("/wait"):
+            seen["timeout"] = kwargs.get("timeout")
+        return original(method, url, **kwargs)
+
+    fake.request = _record
+    tui_mcp._wait_for(contains="GAIA hub", timeout_ms=30000)
+    assert seen["timeout"] == 30 + tui_mcp.WAIT_TIMEOUT_SLACK
+
+
+# ── tui_launch_agent ─────────────────────────────────────────────────
+
+
+def test_launch_agent_navigates_tabs_and_rows(live_tui):
+    fake = live_tui(
+        tabs=(
+            ("Installed", ["bash", "chat"]),
+            ("All", ["alpha", "beta", "gamma", "email"]),
+        )
+    )
+    out = tui_mcp._launch_agent("email")
+    assert out.get("launched") is True
+    assert out["agent"] == "email"
+    assert fake.keys_sent == ["tab", "down", "down", "down", "enter"]
+    assert "chat with email" in out["screen"]
+
+
+def test_launch_agent_moves_up_when_the_target_is_above_the_cursor(live_tui):
+    """The hub list does not wrap — 'down' alone can never reach a row above."""
+    fake = live_tui(tabs=(("Installed", ["bash", "chat", "email"]),), selected_index=2)
+    out = tui_mcp._launch_agent("bash")
+    assert out.get("launched") is True
+    assert fake.keys_sent == ["up", "up", "enter"]
+
+
+def test_launch_agent_handles_the_cursor_surviving_a_tab_switch(live_tui):
+    """bubbles keeps the cursor index across SetItems; the target may be above it."""
+    fake = live_tui(
+        tabs=(
+            ("Installed", ["bash", "chat", "code"]),
+            ("All", ["alpha", "beta", "email"]),
+        ),
+        selected_index=2,
+    )
+    out = tui_mcp._launch_agent("alpha")
+    assert out.get("launched") is True
+    assert fake.keys_sent == ["tab", "up", "up", "enter"]
+
+
+def test_launch_agent_already_open_sends_no_keys(live_tui):
+    """Re-launching the open chat would close it and throw the conversation away."""
+    fake = live_tui(view="chat", agent="email")
+    out = tui_mcp._launch_agent("email")
+    assert out == {
+        "launched": True,
+        "already_open": True,
+        "agent": "email",
+        "screen": out["screen"],
+    }
+    assert fake.keys_sent == []
+
+
+def test_launch_agent_refuses_to_interrupt_a_streaming_chat(live_tui):
+    fake = live_tui(
+        tabs=(("Installed", ["bash", "email"]),),
+        view="chat",
+        agent="bash",
+        streaming=True,
+    )
+    out = tui_mcp._launch_agent("email")
+    assert out["status"] == "error"
+    assert "streaming" in out["detail"]
+    assert fake.keys_sent == []
+
+
+@pytest.mark.parametrize("overlay", ["help", "confirm"])
+def test_launch_agent_refuses_under_an_overlay(live_tui, overlay):
+    """Any key dismisses help / answers the dialog — navigating under one is blind."""
+    fake = live_tui(tabs=(("Installed", ["bash", "email"]),), overlay=overlay)
+    out = tui_mcp._launch_agent("email")
+    assert out["status"] == "error"
+    assert f"{overlay!r} overlay" in out["detail"]
+    assert fake.keys_sent == []
+
+
+def test_launch_agent_reports_a_failed_screen_read_instead_of_a_blank_screen(live_tui):
+    fake = live_tui(tabs=(("Installed", ["email"]),))
+    original = fake.request
+
+    def _fail_screen_reads(method, url, **kwargs):
+        if url.endswith("/screen"):
+            raise requests.exceptions.ConnectionError("socket closed")
+        return original(method, url, **kwargs)
+
+    fake.request = _fail_screen_reads
+    out = tui_mcp._launch_agent("email")
+    assert out.get("launched") is True
+    assert out["screen"] == ""
+    assert "Cannot reach" in out["screen_error"]
+
+
+def test_launch_agent_refuses_before_esc_in_a_standalone_chat(live_tui):
+    """can_return_to_hub=false: esc QUITS there, so the key must never be sent."""
+    fake = live_tui(
+        tabs=(("Installed", ["email"]),),
+        view="chat",
+        agent="bash",
+        can_return_to_hub=False,
+    )
+    out = tui_mcp._launch_agent("email")
+    assert out["status"] == "error"
+    assert "standalone chat session" in out["detail"]
+    assert "quits the TUI" in out["detail"]
+    assert "tui_send_keys" in out["detail"]
+    assert fake.keys_sent == []
+
+
+def test_launch_agent_refuses_when_the_build_cannot_say_whether_esc_quits(live_tui):
+    """Absent field: unknowable, and guessing wrong ends the user's session."""
+    fake = live_tui(
+        tabs=(("Installed", ["email"]),),
+        view="chat",
+        agent="bash",
+        can_return_to_hub=None,
+    )
+    out = tui_mcp._launch_agent("email")
+    assert out["status"] == "error"
+    assert "can_return_to_hub" in out["detail"]
+    assert fake.keys_sent == []
+
+
+def test_standalone_chat_is_called_out_in_the_status_summary(live_tui):
+    live_tui(view="chat", agent="bash", can_return_to_hub=False)
+    assert "standalone session" in tui_mcp._status()["summary"]
+
+
+def test_launch_agent_explains_a_standalone_chat_quitting_on_esc(live_tui):
+    """Belt and braces: a build that says it can return, but esc still quits."""
+    fake = live_tui(tabs=(("Installed", ["email"]),), view="chat", agent="bash")
+    original_press = fake.press
+
+    def _quit_on_esc(key):
+        original_press(key)
+        if key == "esc":
+            fake.unreachable = True
+
+    fake.press = _quit_on_esc
+    out = tui_mcp._launch_agent("email")
+    assert out["status"] == "error"
+    assert "standalone chat session" in out["detail"]
+    assert "gaia tui --control" in out["detail"]
+
+
+def test_launch_agent_leaves_chat_view_first(live_tui):
+    fake = live_tui(tabs=(("Installed", ["bash", "email"]),), view="chat", agent="bash")
+    out = tui_mcp._launch_agent("email")
+    assert out.get("launched") is True
+    assert fake.keys_sent == ["esc", "down", "enter"]
+
+
+def test_launch_agent_not_found_lists_ids_seen(live_tui):
+    fake = live_tui(tabs=(("Installed", ["bash", "chat"]), ("All", ["alpha", "beta"])))
+    out = tui_mcp._launch_agent("nowhere")
+    assert out["status"] == "error"
+    assert "'nowhere' is not in any hub tab" in out["detail"]
+    assert "bash" in out["detail"] and "alpha" in out["detail"]
+    assert "Installed" in out["detail"] and "All" in out["detail"]
+    assert "enter" not in fake.keys_sent
+
+
+def test_launch_agent_surfaces_hub_status_line_on_timeout(live_tui):
+    live_tui(
+        tabs=(("Installed", ["bash", "email"]),),
+        launchable=False,
+        status_line="email is not installed yet",
+    )
+    out = tui_mcp._launch_agent("email", timeout_ms=1000)
+    assert out["status"] == "error"
+    assert "stayed on the hub" in out["detail"]
+    assert "email is not installed yet" in out["detail"]
+
+
+def test_launch_agent_stops_after_a_full_tab_cycle(live_tui):
+    """Two tabs means two probes, not four — the cycle back to tab 0 ends it."""
+    fake = live_tui(
+        tabs=(("Installed", ["bash"]), ("All", ["alpha"])),
+    )
+    out = tui_mcp._launch_agent("nowhere")
+    assert out["status"] == "error"
+    assert fake.keys_sent == ["tab", "tab"]
+    assert out["detail"].count("|") == 1  # exactly two tabs reported
+
+
+def test_launch_agent_transport_failure_is_not_reported_as_a_hub_refusal(live_tui):
+    fake = live_tui(tabs=(("Installed", ["email"]),))
+    original = fake.request
+
+    def _die_on_wait(method, url, **kwargs):
+        if url.endswith("/wait"):
+            raise requests.exceptions.ConnectionError("socket closed")
+        return original(method, url, **kwargs)
+
+    fake.request = _die_on_wait
+    out = tui_mcp._launch_agent("email")
+    assert out["status"] == "error"
+    assert "stayed on the hub" not in out["detail"]
+    assert "Cannot reach the GAIA TUI control server" in out["detail"]
+
+
+def test_launch_agent_unknown_state_explains_manual_fallback(live_tui):
+    fake = live_tui()
+    fake.state = lambda: {"view": "unknown"}
+    out = tui_mcp._launch_agent("email")
+    assert out["status"] == "error"
+    assert "does not report its view state" in out["detail"]
+    assert "tui_send_keys" in out["detail"]
+    assert fake.keys_sent == []
+
+
+# ── install / uninstall ──────────────────────────────────────────────
+
+
+def test_install_agent_without_a_binding_sends_no_keys(live_tui):
+    fake = live_tui(footer=HUB_FOOTER_NO_INSTALL)
+    out = tui_mcp._install_agent("bash")
+    assert out["status"] == "error"
+    assert "not yet available" in out["detail"]
+    assert "Bindings currently offered:" in out["detail"]
+    assert "Enter=launch" in out["detail"]
+    assert fake.keys_sent == []
+
+
+def test_uninstall_agent_uses_the_footer_binding_and_confirms(live_tui):
+    fake = live_tui(tabs=(("Installed", ["bash", "email"]),))
+    out = tui_mcp._uninstall_agent("email")
+    assert out.get("uninstalled") is True
+    assert out["confirmed"] is True
+    assert fake.keys_sent == ["down", "d", "y"]
+    assert "email" not in out["screen"]
+
+
+def test_confirm_marker_is_word_bounded():
+    """An agent called 'Notion' must not read as a No button."""
+    assert tui_mcp._confirm_marker("  Notion\n  Yesterday's runs") == ""
+    assert tui_mcp._confirm_marker("Delete bash?    Yes    No") == "Yes"
+    assert tui_mcp._confirm_marker('Uninstall "email"?  Yes  No') == 'Uninstall "'
+    assert tui_mcp._confirm_marker("") == ""
+
+
+def test_uninstall_the_hub_ignores_is_an_error_and_sends_no_y(live_tui):
+    """The real hub ignores 'd' unless the agent is installed — that is not success.
+
+    'Notion' is on screen on purpose: a substring test for a "No" button would
+    fire here and send a stray 'y' into whatever is focused.
+    """
+    fake = live_tui(tabs=(("Installed", ["Notion", "email"]),), confirms=False)
+    out = tui_mcp._uninstall_agent("email")
+    assert out["status"] == "error"
+    assert "still lists 'email'" in out["detail"]
+    assert fake.keys_sent == ["down", "d"]
+
+
+def test_uninstall_refuses_while_an_overlay_hides_the_footer(live_tui):
+    """The help overlay replaces the screen; no footer is not 'no keybinding'."""
+    fake = live_tui(tabs=(("Installed", ["email"]),), overlay="help")
+    fake.screen = lambda: "GAIA help\n\nEnter  launch the selected agent\n\nesc closes"
+    out = tui_mcp._uninstall_agent("email")
+    assert out["status"] == "error"
+    assert "'help' overlay" in out["detail"]
+    assert "not yet available" not in out["detail"]
+    assert fake.keys_sent == []
+
+
+def test_hub_status_line_never_quotes_the_footer_or_the_tab_bar():
+    screen = f"GAIA hub\n  bash\n  email\n{HUB_FOOTER}"
+    assert tui_mcp._hub_status_line(screen, "email") == ""
+    # The tab bar says "Coming Soon (3)" on every hub screen; quoting that back
+    # as the hub's explanation is an invented answer.
+    tabs = f"Installed (1)    Available (9)    Coming Soon (3)\n  bash\n{HUB_FOOTER}"
+    assert tui_mcp._hub_status_line(tabs, "email") == ""
+    real = f"{tabs}\nEmail is not installed yet"
+    assert tui_mcp._hub_status_line(real, "email") == "Email is not installed yet"
+    with_status = f"GAIA hub\n  email\nemail is not installed yet\n{HUB_FOOTER}"
+    assert (
+        tui_mcp._hub_status_line(with_status, "email") == "email is not installed yet"
+    )
+
+
+def test_resize_rejects_sizes_the_server_would_400(live_tui):
+    fake = live_tui()
+    for cols, rows in ((10, 3), (600, 24), (80, 400)):
+        out = tui_mcp._resize(cols, rows)
+        assert out["status"] == "error", (cols, rows)
+        assert "out of range" in out["detail"]
+    assert ("POST", "/resize") not in fake.requests_seen
+
+
+def test_send_keys_rejects_a_delay_the_server_would_400(live_tui):
+    fake = live_tui()
+    assert tui_mcp._send_keys(["enter"], delay_ms=9999)["status"] == "error"
+    assert fake.keys_sent == []
+
+
+def test_send_keys_rejects_a_batch_over_the_delay_budget(live_tui):
+    """delay_ms × (count-1) > 10s would outlive the client's HTTP timeout."""
+    fake = live_tui()
+    out = tui_mcp._send_keys(["down"] * 20, delay_ms=2000)
+    assert out["status"] == "error"
+    assert "over the 10000 ms cap" in out["detail"]
+    assert fake.keys_sent == []
+    # Just inside the budget still goes through.
+    assert tui_mcp._send_keys(["down"] * 6, delay_ms=2000).get("sent") == 6
+
+
+def test_settled_is_passed_through_to_the_caller(live_tui):
+    live_tui(settled=False)
+    assert tui_mcp._send_keys(["down"])["settled"] is False
+    assert tui_mcp._send_text("hi")["settled"] is False
+    assert tui_mcp._resize(100, 30)["settled"] is False
+
+
+def test_navigation_stops_instead_of_acting_on_an_unsettled_press(live_tui):
+    """settled=false means the next /status read describes the pre-key screen."""
+    fake = live_tui(tabs=(("Installed", ["bash", "email"]),), settled=False)
+    out = tui_mcp._launch_agent("email")
+    assert out["status"] == "error"
+    assert "settled=false" in out["detail"]
+    assert "queued and may still land" in out["detail"]
+    assert fake.keys_sent == ["down"]  # stopped after the first unconfirmed key
+
+
+def test_injection_is_refused_while_the_event_loop_is_not_running(live_tui):
+    """503 not_running: a 200 there would be a lie — Send discards the message."""
+    live_tui(running=False)
+    out = tui_mcp._send_keys(["enter"])
+    assert out["status"] == "error"
+    assert "not accepting input" in out["detail"]
+    assert "running is false" in out["detail"]  # the server's hint survives
+    # Reads still work, and the summary leads with why keys would do nothing.
+    summary = tui_mcp._status()["summary"]
+    assert summary.startswith("NOT ACCEPTING INPUT")
+    assert tui_mcp._screen()["screen"]
+
+
+def test_install_verification_accepts_the_agent_moving_to_another_tab(live_tui):
+    """A real install promotes the row to the Installed tab — it may vanish here."""
+    fake = live_tui(
+        tabs=(("Available", ["email", "jira"]),),
+        footer="Enter=launch  i=install  ?=help  q=quit",
+    )
+
+    def _install(key):
+        fake.keys_sent.append(key)
+        fake.seq += 1
+        if key == "i":  # promoted away from this tab
+            fake.tabs[0] = ("Available", ["jira"])
+            fake.selected_index = 0
+
+    fake.press = _install
+    out = tui_mcp._install_agent("email")
+    assert out.get("installed") is True, out
+    assert fake.keys_sent == ["i"]
+
+
+def test_install_that_changes_nothing_is_an_error(live_tui):
+    fake = live_tui(
+        tabs=(("Available", ["email"]),),
+        footer="Enter=launch  i=install  ?=help  q=quit",
+    )
+    fake.press = lambda key: fake.keys_sent.append(key)  # the hub ignores it
+    out = tui_mcp._install_agent("email")
+    assert out["status"] == "error"
+    assert "ignored the install key" in out["detail"]
+
+
+def test_footer_parsing():
+    bindings = tui_mcp._parse_footer_bindings(f"hub\n  bash\n{HUB_FOOTER}")
+    assert bindings["Enter"] == "launch"
+    assert bindings["d"] == "delete"
+    assert tui_mcp._find_binding(bindings, "uninstall") == "d"
+    assert tui_mcp._find_binding(bindings, "install") is None
+
+    with_install = tui_mcp._parse_footer_bindings("x\nEnter=launch  i=install  q=quit")
+    assert tui_mcp._find_binding(with_install, "install") == "i"
+    assert tui_mcp._find_binding(with_install, "uninstall") is None
+
+    assert tui_mcp._parse_footer_bindings("") == {}
+
+
+# ── Post-review hardening ────────────────────────────────────────────
+
+
+def test_discover_rejects_a_non_loopback_host(tmp_path, monkeypatch):
+    """The bearer token must never leave loopback, whatever the file claims."""
+    write_control(tmp_path, monkeypatch, host="10.0.0.7")
+    set_pid_alive(monkeypatch, True)
+
+    def _explode(*a, **k):  # the probe must not run at all
+        raise AssertionError("a request was made to a non-loopback host")
+
+    monkeypatch.setattr(tui_mcp.requests, "get", _explode)
+
+    info, error = tui_mcp.discover()
+    assert info is None
+    assert "non-loopback host" in error["detail"]
+    assert "10.0.0.7" in error["detail"]
+    assert TOKEN not in error["detail"]
+
+
+def test_uninstall_that_leaves_the_agent_listed_is_an_error(live_tui):
+    """Pressing the key is not evidence: verify the row actually went away."""
+    fake = live_tui(
+        tabs=(("Installed", ["bash", "email"]),),
+        status_line="Email is coming soon — press 'v' to vote",
+        confirms=False,
+    )
+    # The hub refuses this row: the keypress is accepted but nothing is removed,
+    # which is exactly how the real hub treats a coming-soon entry.
+    original_press = fake.press
+
+    def _refuse(key):
+        if key == "d":
+            fake.keys_sent.append(key)
+            return
+        original_press(key)
+
+    fake.press = _refuse
+    out = tui_mcp._uninstall_agent("email")
+    assert out["status"] == "error"
+    assert "still lists" in out["detail"]
+    assert "coming soon" in out["detail"]
+
+
+def test_request_layer_failure_is_not_reported_as_a_non_json_response(monkeypatch):
+    """requests' MissingSchema subclasses ValueError — it must not be swallowed.
+
+    Sharing one ``except ValueError`` between the transport and the JSON decode
+    reports a malformed control file as "the server returned a non-JSON
+    response", sending the reader to debug a TUI that is fine.
+    """
+
+    class _BadTransport:
+        exceptions = requests.exceptions
+
+        @staticmethod
+        def request(*a, **k):
+            raise requests.exceptions.MissingSchema("Invalid URL 'http://:0'")
+
+    monkeypatch.setattr(tui_mcp, "requests", _BadTransport)
+    out = tui_mcp._request(
+        {"host": "127.0.0.1", "port": PORT, "token": TOKEN}, "get", "/status"
+    )
+    assert out["status"] == "error"
+    assert "not JSON" not in out["detail"]
+    assert "Invalid URL" in out["detail"]
+
+
+def test_start_hint_names_a_runnable_command():
+    """A remedy the reader cannot type is not a remedy."""
+    assert "gaia tui --control" in tui_mcp.START_HINT
+    assert "./tui/bin/gaia --control" in tui_mcp.START_HINT
+    assert "gaia tui --control" in tui_mcp.RESTART_HINT

--- a/tui/go.mod
+++ b/tui/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/charmbracelet/glamour v1.0.0
 	github.com/charmbracelet/lipgloss v1.1.1-0.20250404203927-76690c660834
 	github.com/spf13/cobra v1.10.2
+	golang.org/x/sys v0.38.0
 )
 
 require (
@@ -43,7 +44,6 @@ require (
 	github.com/yuin/goldmark v1.7.13 // indirect
 	github.com/yuin/goldmark-emoji v1.0.6 // indirect
 	golang.org/x/net v0.38.0 // indirect
-	golang.org/x/sys v0.38.0 // indirect
 	golang.org/x/term v0.36.0 // indirect
 	golang.org/x/text v0.30.0 // indirect
 )

--- a/tui/go.mod
+++ b/tui/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/charmbracelet/bubbletea v1.3.10
 	github.com/charmbracelet/glamour v1.0.0
 	github.com/charmbracelet/lipgloss v1.1.1-0.20250404203927-76690c660834
+	github.com/charmbracelet/x/ansi v0.11.6
 	github.com/spf13/cobra v1.10.2
 	golang.org/x/sys v0.38.0
 )
@@ -17,7 +18,6 @@ require (
 	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect
 	github.com/aymerick/douceur v0.2.0 // indirect
 	github.com/charmbracelet/colorprofile v0.4.1 // indirect
-	github.com/charmbracelet/x/ansi v0.11.6 // indirect
 	github.com/charmbracelet/x/cellbuf v0.0.15 // indirect
 	github.com/charmbracelet/x/exp/slice v0.0.0-20250327172914-2fdc97757edf // indirect
 	github.com/charmbracelet/x/term v0.2.2 // indirect

--- a/tui/internal/catalog/agent.go
+++ b/tui/internal/catalog/agent.go
@@ -54,6 +54,35 @@ func (s AgentStatus) IsLaunchable() bool {
 	return s == StatusInstalled || s == StatusActive || s == StatusIdle
 }
 
+// Transport is how the TUI talks to an agent.
+//
+// The zero value is TransportSubprocess — the original stdin/stdout JSONL path,
+// which every pre-existing catalog entry uses.
+type Transport int
+
+const (
+	// TransportSubprocess spawns BinaryPath and trades newline-delimited JSON
+	// over stdin/stdout. Used by the local C++ agents.
+	TransportSubprocess Transport = iota
+
+	// TransportDaemon streams canonical SSE events through the GAIA daemon's
+	// relay (POST /v1/<id>/query). Used by the long-lived HTTP sidecar agents,
+	// which the daemon starts and supervises — there is no binary to spawn.
+	TransportDaemon
+)
+
+// String returns the wire name of the transport.
+func (t Transport) String() string {
+	switch t {
+	case TransportSubprocess:
+		return "subprocess"
+	case TransportDaemon:
+		return "daemon"
+	default:
+		return "unknown"
+	}
+}
+
 // Agent represents a GAIA agent in the catalog.
 type Agent struct {
 	ID          string
@@ -64,8 +93,9 @@ type Agent struct {
 	Icon        string // emoji
 	Version     string // semver, e.g. "0.1.0"
 	Status      AgentStatus
-	BinaryPath  string   // e.g. "gaia-bash"
-	BinaryArgs  []string // e.g. ["--json-events"]
+	Transport   Transport
+	BinaryPath  string   // e.g. "gaia-bash" (subprocess transport only)
+	BinaryArgs  []string // e.g. ["--json-events"] (subprocess transport only)
 	Votes       int      // for coming-soon agents
 }
 

--- a/tui/internal/catalog/catalog.go
+++ b/tui/internal/catalog/catalog.go
@@ -49,9 +49,10 @@ func (c *Catalog) Get(id string) *Agent {
 }
 
 // DiscoverBinaries searches for agent executables on PATH and in common build locations.
+// Daemon-transport agents are skipped — the daemon owns their lifecycle.
 func (c *Catalog) DiscoverBinaries() {
 	for i := range c.agents {
-		if c.agents[i].BinaryPath == "" {
+		if c.agents[i].Transport == TransportDaemon || c.agents[i].BinaryPath == "" {
 			continue
 		}
 		name := c.agents[i].BinaryPath
@@ -98,8 +99,12 @@ func findBinaryInRepo(name string) string {
 }
 
 // SetMockBinary overrides all installed agent binary paths with a mock binary for testing.
+// Daemon-transport agents are skipped — they have no binary to override.
 func (c *Catalog) SetMockBinary(binaryPath string) {
 	for i := range c.agents {
+		if c.agents[i].Transport == TransportDaemon {
+			continue
+		}
 		if c.agents[i].Status == StatusInstalled || c.agents[i].Status == StatusActive || c.agents[i].Status == StatusIdle {
 			c.agents[i].BinaryPath = binaryPath
 			c.agents[i].BinaryArgs = nil
@@ -228,9 +233,12 @@ func seedAgents() []Agent {
 			Icon: "📝", Version: "0.1.0", Status: StatusAvailable,
 		},
 		{
+			// The email agent is an HTTP sidecar the daemon supervises, not a
+			// binary the TUI can spawn — it is reached through the daemon relay.
 			ID: "email", Name: "Email", Description: "Email triage, drafting, and calendar",
 			Category: "Productivity", Tags: []string{"email", "gmail", "calendar", "communication"},
 			Icon: "📧", Version: "0.1.0", Status: StatusAvailable,
+			Transport: TransportDaemon,
 		},
 
 		// --- Coming Soon ---

--- a/tui/internal/catalog/catalog_test.go
+++ b/tui/internal/catalog/catalog_test.go
@@ -295,3 +295,51 @@ func TestAllSections(t *testing.T) {
 		t.Fatalf("AllSections()[2] = %q, want %q", sections[2], SectionComingSoon)
 	}
 }
+
+func TestTransportZeroValueIsSubprocess(t *testing.T) {
+	var zero Transport
+	if zero != TransportSubprocess {
+		t.Fatalf("the zero Transport must be subprocess so existing entries keep working, got %v", zero)
+	}
+	if TransportSubprocess.String() != "subprocess" || TransportDaemon.String() != "daemon" {
+		t.Errorf("unexpected transport names: %q / %q", TransportSubprocess, TransportDaemon)
+	}
+}
+
+func TestEmailUsesTheDaemonTransport(t *testing.T) {
+	c := NewCatalog()
+
+	email := c.Get("email")
+	if email == nil {
+		t.Fatal("email is missing from the catalog")
+	}
+	if email.Transport != TransportDaemon {
+		t.Errorf("email transport = %v, want daemon (it is an HTTP sidecar, not a spawnable binary)", email.Transport)
+	}
+	if email.BinaryPath != "" {
+		t.Errorf("a daemon-transport agent must carry no binary path, got %q", email.BinaryPath)
+	}
+
+	// Every other seeded agent still uses the subprocess transport.
+	for _, a := range c.All() {
+		if a.ID == "email" {
+			continue
+		}
+		if a.Transport != TransportSubprocess {
+			t.Errorf("agent %q transport = %v, want subprocess", a.ID, a.Transport)
+		}
+	}
+}
+
+func TestSetMockBinarySkipsDaemonTransport(t *testing.T) {
+	c := NewCatalog()
+	c.SetStatus("email", StatusInstalled)
+	c.SetMockBinary("/tmp/mock-agent")
+
+	if got := c.Get("email").BinaryPath; got != "" {
+		t.Errorf("a daemon-transport agent must not get a mock binary, got %q", got)
+	}
+	if got := c.Get("bash").BinaryPath; got != "/tmp/mock-agent" {
+		t.Errorf("bash binary = %q, want the mock", got)
+	}
+}

--- a/tui/internal/cli/chat.go
+++ b/tui/internal/cli/chat.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/spf13/cobra"
 
@@ -11,22 +12,46 @@ import (
 var (
 	subprocess string
 	query      string
+	agentID    string
+	chatModel  string
 )
 
 var chatCmd = &cobra.Command{
 	Use:   "chat",
 	Short: "Start interactive chat with an agent",
-	Long:  "Launch the Bubble Tea chat TUI connected to an agent via subprocess or API.",
+	Long: "Launch the chat TUI connected to an agent, either by catalog id " +
+		"(--agent, which uses the transport that agent declares) or by spawning a " +
+		"binary directly (--subprocess).",
 	RunE: func(cmd *cobra.Command, args []string) error {
+		if agentID != "" && subprocess != "" {
+			return fmt.Errorf("--agent and --subprocess are mutually exclusive: pick one")
+		}
+		if agentID != "" {
+			code, err := ui.RunAgent(agentID, query, chatModel, debug)
+			if err != nil {
+				return err
+			}
+			if code != 0 {
+				// The failure was already rendered to stderr; exit without
+				// letting cobra print a second, less useful message.
+				os.Exit(code)
+			}
+			return nil
+		}
 		if subprocess == "" {
-			return fmt.Errorf("--subprocess flag is required\n\nUsage: gaia chat --subprocess \"./gaia-bash --json-events\"")
+			return fmt.Errorf("one of --agent or --subprocess is required\n\n" +
+				"Usage: gaia tui chat --agent email\n" +
+				"       gaia tui chat --agent email --query \"triage my inbox\"\n" +
+				"       gaia tui chat --subprocess \"./gaia-bash --json-events\"")
 		}
 		return ui.RunChat(subprocess, query, debug)
 	},
 }
 
 func init() {
+	chatCmd.Flags().StringVar(&agentID, "agent", "", "catalog agent id to chat with (e.g. \"email\")")
+	chatCmd.Flags().StringVar(&chatModel, "model", "", "model id override (--agent only; the sidecar default is used when unset)")
 	chatCmd.Flags().StringVar(&subprocess, "subprocess", "", "command to spawn agent subprocess (e.g. \"./gaia-bash --json-events\")")
-	chatCmd.Flags().StringVar(&query, "query", "", "single query to send (non-interactive mode)")
+	chatCmd.Flags().StringVar(&query, "query", "", "single query to send; with --agent this is a genuine non-interactive one-shot (answer on stdout, exit 0/1)")
 	rootCmd.AddCommand(chatCmd)
 }

--- a/tui/internal/cli/chat.go
+++ b/tui/internal/cli/chat.go
@@ -44,7 +44,11 @@ var chatCmd = &cobra.Command{
 				"       gaia tui chat --agent email --query \"triage my inbox\"\n" +
 				"       gaia tui chat --subprocess \"./gaia-bash --json-events\"")
 		}
-		return ui.RunChat(subprocess, query, debug)
+		ctrl, err := controlOptionsFor(cmd)
+		if err != nil {
+			return err
+		}
+		return ui.RunChat(subprocess, query, debug, ctrl)
 	},
 }
 

--- a/tui/internal/cli/control.go
+++ b/tui/internal/cli/control.go
@@ -1,0 +1,48 @@
+package cli
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/amd/gaia/tui/internal/control"
+)
+
+var (
+	controlEnabled bool
+	controlPort    int
+)
+
+// controlOptionsFor reads this command's flags. Split from controlOptions so the
+// decision logic stays a pure function (and so the package has no init cycle
+// between rootCmd and the flag lookup).
+func controlOptionsFor(cmd *cobra.Command) (*control.Options, error) {
+	return controlOptions(controlEnabled, controlPort, cmd.Flags().Changed("control-port"))
+}
+
+// controlOptions turns the --control / --control-port flags into control
+// options, or nil when the control API is off (the default).
+//
+// --control-port implies --control: asking for a specific port and then not
+// getting a server would be a silent no-op.
+func controlOptions(enabled bool, port int, explicitPort bool) (*control.Options, error) {
+	// explicitPort, not "port != 0": `--control-port 0` means "auto-assign", and
+	// inferring "off" from the zero value would start the TUI with no control
+	// API while the user believes they enabled it.
+	if !enabled && !explicitPort {
+		return nil, nil
+	}
+	if port == control.ReservedPort {
+		return nil, fmt.Errorf(
+			"--control-port %d is reserved and must never be bound; pick another port or drop the flag to auto-assign",
+			control.ReservedPort)
+	}
+	if port < 0 || (port > 0 && port < 1024) || port > 65535 {
+		return nil, fmt.Errorf("--control-port %d is not a usable port; pass 1024-65535, or omit it to auto-assign", port)
+	}
+	return &control.Options{
+		Port:    port,
+		Debug:   debug,
+		Version: version,
+	}, nil
+}

--- a/tui/internal/cli/control_test.go
+++ b/tui/internal/cli/control_test.go
@@ -1,0 +1,79 @@
+package cli
+
+import (
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/amd/gaia/tui/internal/control"
+)
+
+func TestControlOffByDefault(t *testing.T) {
+	opts, err := controlOptions(false, 0, false)
+	if err != nil {
+		t.Fatalf("controlOptions: %v", err)
+	}
+	if opts != nil {
+		t.Error("the control API must be off unless asked for")
+	}
+}
+
+// TestExplicitZeroPortStillEnablesControl pins a silent no-op: `--control-port 0`
+// means "auto-assign", and inferring "off" from the zero value would start the
+// TUI with no control API while the user believes they enabled it.
+func TestExplicitZeroPortStillEnablesControl(t *testing.T) {
+	opts, err := controlOptions(false, 0, true)
+	if err != nil {
+		t.Fatalf("controlOptions: %v", err)
+	}
+	if opts == nil {
+		t.Fatal("--control-port 0 silently disabled the control API")
+	}
+	if opts.Port != 0 {
+		t.Errorf("Port = %d, want 0 (auto-assign)", opts.Port)
+	}
+}
+
+func TestControlFlagEnablesWithAutoPort(t *testing.T) {
+	opts, err := controlOptions(true, 0, false)
+	if err != nil {
+		t.Fatalf("controlOptions: %v", err)
+	}
+	if opts == nil || opts.Port != 0 {
+		t.Errorf("--control alone should enable with an auto-assigned port, got %+v", opts)
+	}
+}
+
+func TestControlPortRejectsReservedAndUnusablePorts(t *testing.T) {
+	for _, tc := range []struct {
+		port int
+		want string
+	}{
+		{control.ReservedPort, "reserved"},
+		{80, "not a usable port"},
+		{-1, "not a usable port"},
+		{70000, "not a usable port"},
+	} {
+		_, err := controlOptions(true, tc.port, true)
+		if err == nil {
+			t.Errorf("port %d was accepted", tc.port)
+			continue
+		}
+		if !strings.Contains(err.Error(), tc.want) {
+			t.Errorf("port %d: error %q should mention %q", tc.port, err, tc.want)
+		}
+		if !strings.Contains(err.Error(), strconv.Itoa(tc.port)) {
+			t.Errorf("port %d: error %q should quote the offending port", tc.port, err)
+		}
+	}
+}
+
+func TestControlPortAcceptsAUsablePort(t *testing.T) {
+	opts, err := controlOptions(false, 8770, true)
+	if err != nil {
+		t.Fatalf("controlOptions: %v", err)
+	}
+	if opts == nil || opts.Port != 8770 {
+		t.Errorf("got %+v, want port 8770", opts)
+	}
+}

--- a/tui/internal/cli/hub.go
+++ b/tui/internal/cli/hub.go
@@ -13,7 +13,11 @@ var hubCmd = &cobra.Command{
 	Short: "Browse and launch GAIA agents",
 	Long:  "Open the Agent Hub to discover, search, and launch GAIA agents.",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return ui.RunHub(debug, mockAgent)
+		ctrl, err := controlOptionsFor(cmd)
+		if err != nil {
+			return err
+		}
+		return ui.RunHub(debug, mockAgent, ctrl)
 	},
 }
 

--- a/tui/internal/cli/root.go
+++ b/tui/internal/cli/root.go
@@ -16,12 +16,20 @@ var rootCmd = &cobra.Command{
 	Short: "GAIA Terminal Agent Hub",
 	Long:  "Terminal-native hub for browsing, launching, and chatting with GAIA agents.",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return ui.RunHub(debug, mockAgent)
+		ctrl, err := controlOptionsFor(cmd)
+		if err != nil {
+			return err
+		}
+		return ui.RunHub(debug, mockAgent, ctrl)
 	},
 }
 
 func init() {
 	rootCmd.PersistentFlags().BoolVar(&debug, "debug", false, "enable debug logging to stderr")
+	rootCmd.PersistentFlags().BoolVar(&controlEnabled, "control", false,
+		"expose the loopback control API so an assistant can drive this session (auto-assigned port)")
+	rootCmd.PersistentFlags().IntVar(&controlPort, "control-port", 0,
+		"control API port (implies --control; 0 auto-assigns)")
 	rootCmd.Flags().StringVar(&mockAgent, "mock", "", "path to mock agent binary for testing (overrides all agent binaries)")
 }
 

--- a/tui/internal/client/client.go
+++ b/tui/internal/client/client.go
@@ -5,7 +5,7 @@ import (
 )
 
 // AgentClient is the interface for communicating with an agent backend.
-// Both subprocess (JSONL) and API (SSE) modes implement this interface.
+// Both subprocess (JSONL) and daemon-relay (SSE) transports implement it.
 type AgentClient interface {
 	// Send starts a conversation turn. Events stream on the returned channel.
 	// The channel is closed when the turn is complete (answer/done/status-complete event).
@@ -13,4 +13,11 @@ type AgentClient interface {
 
 	// Close terminates the connection or process.
 	Close() error
+}
+
+// TranscriptResetter is implemented by transports that own the conversation
+// transcript host-side and push it back to a stateless agent on every turn.
+// Clearing the visible history must also clear what gets pushed.
+type TranscriptResetter interface {
+	ResetTranscript()
 }

--- a/tui/internal/client/cmdline.go
+++ b/tui/internal/client/cmdline.go
@@ -1,0 +1,79 @@
+package client
+
+import (
+	"fmt"
+	"strings"
+)
+
+// SplitCommandLine splits a user-supplied command string into argv, honouring
+// single and double quotes and backslash escapes.
+//
+// Whitespace splitting alone (strings.Fields) silently corrupts any path with a
+// space in it — "/Users/me/My Agents/gaia-bash" becomes two argv entries and the
+// launch fails with a confusing "no such file". Unbalanced quoting is an error,
+// not a guess.
+func SplitCommandLine(cmdLine string) ([]string, error) {
+	var (
+		argv    []string
+		cur     strings.Builder
+		inWord  bool
+		quote   rune // 0, '\'' or '"'
+		escaped bool
+	)
+
+	flush := func() {
+		if inWord {
+			argv = append(argv, cur.String())
+			cur.Reset()
+			inWord = false
+		}
+	}
+
+	for _, r := range cmdLine {
+		switch {
+		case escaped:
+			cur.WriteRune(r)
+			inWord = true
+			escaped = false
+		case quote == '\'':
+			// Single quotes are literal — not even a backslash escapes inside them.
+			if r == '\'' {
+				quote = 0
+			} else {
+				cur.WriteRune(r)
+			}
+		case quote == '"':
+			switch r {
+			case '"':
+				quote = 0
+			case '\\':
+				escaped = true
+			default:
+				cur.WriteRune(r)
+			}
+		case r == '\\':
+			escaped = true
+		case r == '\'' || r == '"':
+			quote = r
+			inWord = true
+		case r == ' ' || r == '\t' || r == '\n' || r == '\r':
+			flush()
+		default:
+			cur.WriteRune(r)
+			inWord = true
+		}
+	}
+
+	if escaped {
+		return nil, fmt.Errorf("command %q ends with a dangling backslash", cmdLine)
+	}
+	if quote != 0 {
+		return nil, fmt.Errorf("command %q has an unbalanced %c quote", cmdLine, quote)
+	}
+	flush()
+
+	if len(argv) == 0 {
+		return nil, fmt.Errorf("command %q contains no executable to run", cmdLine)
+	}
+	return argv, nil
+}

--- a/tui/internal/client/cmdline_test.go
+++ b/tui/internal/client/cmdline_test.go
@@ -1,0 +1,67 @@
+package client
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestSplitCommandLine(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want []string
+	}{
+		{"plain", `gaia-bash --json-events`, []string{"gaia-bash", "--json-events"}},
+		{"extra whitespace", "  gaia-bash \t --json-events  ", []string{"gaia-bash", "--json-events"}},
+		{
+			"double-quoted path with space",
+			`"/Users/me/My Agents/gaia-bash" --json-events`,
+			[]string{"/Users/me/My Agents/gaia-bash", "--json-events"},
+		},
+		{
+			"single-quoted path with space",
+			`'/Users/me/My Agents/gaia-bash' --model Gemma-4-E4B-it-GGUF`,
+			[]string{"/Users/me/My Agents/gaia-bash", "--model", "Gemma-4-E4B-it-GGUF"},
+		},
+		{
+			"escaped space",
+			`/Users/me/My\ Agents/gaia-bash`,
+			[]string{"/Users/me/My Agents/gaia-bash"},
+		},
+		{"empty quoted arg", `agent --flag ""`, []string{"agent", "--flag", ""}},
+		{"quote inside word", `agent --msg="hello world"`, []string{"agent", "--msg=hello world"}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := SplitCommandLine(tc.in)
+			if err != nil {
+				t.Fatalf("SplitCommandLine(%q): %v", tc.in, err)
+			}
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("SplitCommandLine(%q) = %#v, want %#v", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestSplitCommandLineErrors(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+	}{
+		{"empty", ""},
+		{"whitespace only", "   \t "},
+		{"unbalanced double quote", `agent "unterminated`},
+		{"unbalanced single quote", `agent 'unterminated`},
+		{"dangling backslash", `agent \`},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got, err := SplitCommandLine(tc.in); err == nil {
+				t.Fatalf("SplitCommandLine(%q) = %#v, want an error", tc.in, got)
+			}
+		})
+	}
+}

--- a/tui/internal/client/factory.go
+++ b/tui/internal/client/factory.go
@@ -1,0 +1,51 @@
+package client
+
+import (
+	"fmt"
+
+	"github.com/amd/gaia/tui/internal/catalog"
+	"github.com/amd/gaia/tui/internal/daemon"
+)
+
+// ForAgentOptions configures the transport built by ForAgent.
+type ForAgentOptions struct {
+	// Debug enables the subprocess transport's stderr diagnostics.
+	Debug bool
+	// Model / MaxSteps override the sidecar defaults on the daemon transport.
+	// Ignored by the subprocess transport, which takes its model via BinaryArgs.
+	Model    string
+	MaxSteps int
+	// Logf receives transport diagnostics. Never given a token.
+	Logf func(format string, args ...any)
+}
+
+// ForAgent builds the transport a catalog entry declares.
+//
+// This is the single transport switch: the chat UI, the hub, and the
+// non-interactive CLI paths all go through it, so adding a transport never means
+// finding every launch site. It deliberately lives here rather than on a Bubble
+// Tea model — the headless CLI paths need it without a UI.
+func ForAgent(agent catalog.Agent, opts ForAgentOptions) (AgentClient, error) {
+	switch agent.Transport {
+	case catalog.TransportDaemon:
+		return NewSSEClient(agent.ID, daemon.New(daemon.Options{Logf: opts.Logf}), SSEOptions{
+			Model:    opts.Model,
+			MaxSteps: opts.MaxSteps,
+			Logf:     opts.Logf,
+		}), nil
+
+	case catalog.TransportSubprocess:
+		if agent.BinaryPath == "" {
+			return nil, fmt.Errorf(
+				"agent %q uses the subprocess transport but no binary was found — "+
+					"build it, put it on PATH, or pass --mock <path> to run against a stub",
+				agent.ID)
+		}
+		return NewSubprocessClient(agent.BinaryPath, agent.BinaryArgs, opts.Debug), nil
+
+	default:
+		return nil, fmt.Errorf(
+			"agent %q declares transport %d, which this build does not know how to reach — "+
+				"upgrade GAIA or fix the catalog entry", agent.ID, int(agent.Transport))
+	}
+}

--- a/tui/internal/client/factory_test.go
+++ b/tui/internal/client/factory_test.go
@@ -1,0 +1,72 @@
+package client
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/amd/gaia/tui/internal/catalog"
+)
+
+func TestForAgentBuildsTheDeclaredTransport(t *testing.T) {
+	daemonAgent := catalog.Agent{ID: "email", Transport: catalog.TransportDaemon}
+	c, err := ForAgent(daemonAgent, ForAgentOptions{})
+	if err != nil {
+		t.Fatalf("ForAgent(daemon): %v", err)
+	}
+	defer c.Close()
+	if _, ok := c.(*SSEClient); !ok {
+		t.Errorf("daemon transport built %T, want *SSEClient", c)
+	}
+
+	subAgent := catalog.Agent{ID: "bash", BinaryPath: "/usr/bin/true", BinaryArgs: []string{"--json-events"}}
+	c2, err := ForAgent(subAgent, ForAgentOptions{})
+	if err != nil {
+		t.Fatalf("ForAgent(subprocess): %v", err)
+	}
+	defer c2.Close()
+	if _, ok := c2.(*SubprocessClient); !ok {
+		t.Errorf("subprocess transport built %T, want *SubprocessClient", c2)
+	}
+}
+
+// A subprocess agent whose binary was never found must fail with a remedy, not
+// produce a client that dies later with a confusing message.
+func TestForAgentRejectsAMissingBinary(t *testing.T) {
+	_, err := ForAgent(catalog.Agent{ID: "bash"}, ForAgentOptions{})
+	if err == nil {
+		t.Fatal("expected an error for a subprocess agent with no binary")
+	}
+	if !strings.Contains(err.Error(), "--mock") {
+		t.Errorf("error should name a way forward: %v", err)
+	}
+}
+
+func TestForAgentRejectsAnUnknownTransport(t *testing.T) {
+	_, err := ForAgent(catalog.Agent{ID: "future", Transport: catalog.Transport(99)}, ForAgentOptions{})
+	if err == nil {
+		t.Fatal("expected an error for an unknown transport rather than a silent default")
+	}
+	if !strings.Contains(err.Error(), "99") {
+		t.Errorf("error should name the transport it cannot reach: %v", err)
+	}
+}
+
+// Model / MaxSteps must reach the request body, not be silently dropped.
+func TestForAgentPlumbsModelAndMaxSteps(t *testing.T) {
+	c, err := ForAgent(
+		catalog.Agent{ID: "email", Transport: catalog.TransportDaemon},
+		ForAgentOptions{Model: "Gemma-4-E4B-it-GGUF", MaxSteps: 7},
+	)
+	if err != nil {
+		t.Fatalf("ForAgent: %v", err)
+	}
+	defer c.Close()
+
+	sse, ok := c.(*SSEClient)
+	if !ok {
+		t.Fatalf("got %T", c)
+	}
+	if sse.opts.Model != "Gemma-4-E4B-it-GGUF" || sse.opts.MaxSteps != 7 {
+		t.Errorf("options not plumbed: %+v", sse.opts)
+	}
+}

--- a/tui/internal/client/sse.go
+++ b/tui/internal/client/sse.go
@@ -6,6 +6,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"net/url"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -20,6 +22,8 @@ import (
 const (
 	defaultConnectTimeout = 10 * time.Second
 	defaultReadTimeout    = 300 * time.Second
+	// A cancel POST must never wait out a stream read timeout.
+	cancelTimeout = 10 * time.Second
 )
 
 // Turn is one entry of the host-owned transcript.
@@ -58,6 +62,13 @@ type SSEClient struct {
 	opts    SSEOptions
 	// stream is reused across turns: one Transport per client, not per turn.
 	stream *http.Client
+	// cancelHTTP is the short-timeout client for the cancel POST.
+	cancelHTTP *http.Client
+
+	// done is closed by Close(). It is the only way to unblock a consume()
+	// goroutine whose consumer has stopped reading and whose buffer is full —
+	// without it, Close() could not deliver the shutdown it advertises.
+	done chan struct{}
 
 	mu         sync.Mutex
 	inst       *daemon.Instance
@@ -85,10 +96,12 @@ func NewSSEClient(agentID string, dc *daemon.Client, opts SSEOptions) *SSEClient
 		opts.Logf = func(string, ...any) {}
 	}
 	return &SSEClient{
-		agentID: agentID,
-		daemon:  dc,
-		opts:    opts,
-		stream:  daemon.StreamHTTPClient(opts.ConnectTimeout),
+		agentID:    agentID,
+		daemon:     dc,
+		opts:       opts,
+		done:       make(chan struct{}),
+		stream:     daemon.StreamHTTPClient(opts.ConnectTimeout, opts.ReadTimeout),
+		cancelHTTP: &http.Client{Timeout: cancelTimeout},
 	}
 }
 
@@ -152,7 +165,7 @@ func (s *SSEClient) Send(ctx context.Context, query string) (<-chan interface{},
 
 	resp, inst, err := s.daemon.Do(runCtx, inst, daemon.Request{
 		Method: http.MethodPost,
-		Path:   fmt.Sprintf("/v1/%s/query", s.agentID),
+		Path:   fmt.Sprintf("/v1/%s/query", url.PathEscape(s.agentID)),
 		Body:   payload,
 		Header: http.Header{
 			"Content-Type": []string{"application/json"},
@@ -167,8 +180,20 @@ func (s *SSEClient) Send(ctx context.Context, query string) (<-chan interface{},
 	}
 	if resp.StatusCode != http.StatusOK {
 		detail := daemon.ErrorDetail(resp)
+		status := resp.StatusCode
 		resp.Body.Close()
 		cancel()
+		if status == http.StatusNotFound {
+			// A 404 on the query path is specifically "this route does not exist
+			// there" — most often a sidecar predating the canonical /query
+			// endpoint. Saying so beats making the user decode a bare 404.
+			return nil, fmt.Errorf(
+				"the '%s' agent has no /query endpoint (%s). Either the installed sidecar "+
+					"predates the canonical query contract — check its version with "+
+					"`gaia daemon agents` and reinstall/update the agent — or no agent with "+
+					"that id is registered with the daemon",
+				s.agentID, detail)
+		}
 		return nil, fmt.Errorf(
 			"the daemon relay refused the '%s' query (%s). Check `gaia daemon status`",
 			s.agentID, detail)
@@ -180,10 +205,17 @@ func (s *SSEClient) Send(ctx context.Context, query string) (<-chan interface{},
 	// Close() may have landed while the request was in flight; registering the
 	// handle unconditionally would leave that run un-cancellable.
 	closedMidFlight := s.closed
+	superseded := s.active
 	if !closedMidFlight {
 		s.active = handle
 	}
 	s.mu.Unlock()
+
+	// Send() is documented as serialized, but an orphaned run would keep a
+	// sidecar working with nobody listening — cancel it rather than trust the doc.
+	if superseded != nil {
+		superseded.cancel()
+	}
 
 	if closedMidFlight {
 		cancel()
@@ -229,15 +261,19 @@ func (s *SSEClient) consume(
 			return true
 		case <-ctx.Done():
 			return false
+		case <-s.done:
+			return false
 		}
 	}
 
 	reader := newSSEFrameReader(resp.Body, func() { watchdog.Reset(s.opts.ReadTimeout) })
 
 	var (
-		terminal  string
-		answer    string
-		streamed  string
+		terminal string
+		answer   string
+		// A local Builder is never copied, so it is safe here (unlike one held in
+		// a value-copied Bubble Tea model) and avoids quadratic reallocation.
+		streamed  strings.Builder
 		delivered = true
 	)
 
@@ -252,7 +288,7 @@ func (s *SSEClient) consume(
 			s.opts.Logf("sse: unparseable '%s' frame (%s) — skipped", s.agentID, malformed.Reason)
 		}
 		if tok, isToken := evt.(event.CanonicalTokenEvent); isToken {
-			streamed += tok.Delta
+			streamed.WriteString(tok.Delta)
 		}
 		if fin, isFinal := evt.(event.CanonicalFinalEvent); isFinal {
 			answer = fin.Answer
@@ -272,7 +308,7 @@ func (s *SSEClient) consume(
 			if answer == "" {
 				// The sidecar streamed the answer as tokens and closed with an
 				// empty `final` — keep the streamed text as the turn's answer.
-				answer = streamed
+				answer = streamed.String()
 			}
 			s.appendTurn(query, answer)
 		}
@@ -324,7 +360,10 @@ func (s *SSEClient) consume(
 		})
 	}
 
-	s.cancelRun(handle)
+	// Deliberately not inline: cancelRun runs before every deferred cleanup,
+	// including close(ch), so a slow or hung daemon would hold the channel open
+	// and let a superseded turn's completion land on the next turn.
+	go s.cancelRun(handle)
 }
 
 func (s *SSEClient) readTimeoutDetail() string {
@@ -334,7 +373,12 @@ func (s *SSEClient) readTimeoutDetail() string {
 		s.agentID, s.opts.ReadTimeout)
 }
 
-// cancelRun tells the relay to drop a run we are abandoning. Best-effort.
+// cancelRun asks the relay to drop a run we are abandoning.
+//
+// Best-effort: the sidecar may already be gone. It owns its own background
+// context so a cancelled caller context cannot kill the cancel itself, and it
+// lives here rather than in the daemon package because the cancel path is part
+// of the AGENT wire contract, not the daemon control plane.
 func (s *SSEClient) cancelRun(handle *runHandle) {
 	s.mu.Lock()
 	inst := s.inst
@@ -342,7 +386,35 @@ func (s *SSEClient) cancelRun(handle *runHandle) {
 	if inst == nil {
 		return
 	}
-	s.daemon.CancelRun(inst, s.agentID, handle.runID)
+
+	ctx, cancel := context.WithTimeout(context.Background(), cancelTimeout)
+	defer cancel()
+
+	resp, _, err := s.daemon.Do(ctx, inst, daemon.Request{
+		Method: http.MethodPost,
+		Path: fmt.Sprintf("/v1/%s/query/%s/cancel",
+			url.PathEscape(s.agentID), url.PathEscape(handle.runID)),
+		HTTPClient: s.cancelHTTP,
+		Op:         fmt.Sprintf("cancel the '%s' run", s.agentID),
+	})
+	if err != nil {
+		s.opts.Logf("sse: best-effort cancel for '%s' run_id=%s failed: %v",
+			s.agentID, handle.runID, err)
+		return
+	}
+	defer resp.Body.Close()
+	// 404 is the documented answer for a run that is no longer in flight — which
+	// is exactly the case when we abandon a stream that already ended. That is
+	// success, not a failure worth reporting as one.
+	if resp.StatusCode == http.StatusNotFound {
+		s.opts.Logf("sse: '%s' run_id=%s had already finished; nothing to cancel",
+			s.agentID, handle.runID)
+		return
+	}
+	if resp.StatusCode != http.StatusOK {
+		s.opts.Logf("sse: cancel for '%s' run_id=%s answered HTTP %d",
+			s.agentID, handle.runID, resp.StatusCode)
+	}
 }
 
 func (s *SSEClient) clearActive(handle *runHandle) {
@@ -381,11 +453,15 @@ func (s *SSEClient) ResetTranscript() {
 // Close cancels any in-flight run and refuses further sends.
 func (s *SSEClient) Close() error {
 	s.mu.Lock()
+	alreadyClosed := s.closed
 	s.closed = true
 	active := s.active
 	s.active = nil
 	s.mu.Unlock()
 
+	if !alreadyClosed {
+		close(s.done)
+	}
 	if active != nil {
 		active.cancel()
 	}

--- a/tui/internal/client/sse.go
+++ b/tui/internal/client/sse.go
@@ -177,8 +177,20 @@ func (s *SSEClient) Send(ctx context.Context, query string) (<-chan interface{},
 	handle := &runHandle{runID: runID, cancel: cancel}
 	s.mu.Lock()
 	s.inst = inst
-	s.active = handle
+	// Close() may have landed while the request was in flight; registering the
+	// handle unconditionally would leave that run un-cancellable.
+	closedMidFlight := s.closed
+	if !closedMidFlight {
+		s.active = handle
+	}
 	s.mu.Unlock()
+
+	if closedMidFlight {
+		cancel()
+		resp.Body.Close()
+		return nil, fmt.Errorf(
+			"the %s agent connection was closed while the query was being sent", s.agentID)
+	}
 
 	ch := make(chan interface{}, 32)
 	go s.consume(ctx, runCtx, handle, resp, ch, query)

--- a/tui/internal/client/sse.go
+++ b/tui/internal/client/sse.go
@@ -1,0 +1,400 @@
+package client
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/amd/gaia/tui/internal/daemon"
+	"github.com/amd/gaia/tui/internal/event"
+)
+
+// Timeouts mirror src/gaia/daemon/agent_query.py: connect fast (a dead daemon
+// should fail quickly), read generously — a single upstream chunk can span a
+// whole agent-loop step.
+const (
+	defaultConnectTimeout = 10 * time.Second
+	defaultReadTimeout    = 300 * time.Second
+)
+
+// Turn is one entry of the host-owned transcript.
+//
+// The sidecar is stateless on /query (contract §2.4), so the TUI accumulates the
+// transcript and pushes the slice as `context` on every turn. A turn is appended
+// only when it terminated in `final`, so a failed run cannot poison the next one.
+type Turn struct {
+	Role    string `json:"role"`
+	Content string `json:"content"`
+}
+
+// SSEOptions configures an SSEClient. The zero value is valid.
+type SSEOptions struct {
+	// Model overrides the sidecar's default model id. Empty means "sidecar default".
+	Model string
+	// MaxSteps overrides the agent-loop step ceiling. Zero means "sidecar default".
+	MaxSteps int
+	// ConnectTimeout / ReadTimeout default to 10s / 300s. ReadTimeout is an
+	// idle timeout: it fires only if no byte of the stream arrives within it.
+	ConnectTimeout time.Duration
+	ReadTimeout    time.Duration
+	// Logf receives progress and best-effort-failure notes. Never given a token.
+	Logf func(format string, args ...any)
+}
+
+// SSEClient drives one agent through the GAIA daemon's relay: it ensures the
+// daemon and the agent's sidecar are up, POSTs /v1/<agent>/query, and streams the
+// canonical SSE events (contract §4) onto the AgentClient channel.
+//
+// It holds only the DAEMON client token — never the sidecar's bearer, which stays
+// server-side. Send() calls must be serialized, matching the AgentClient contract.
+type SSEClient struct {
+	agentID string
+	daemon  *daemon.Client
+	opts    SSEOptions
+	// stream is reused across turns: one Transport per client, not per turn.
+	stream *http.Client
+
+	mu         sync.Mutex
+	inst       *daemon.Instance
+	transcript []Turn
+	closed     bool
+	active     *runHandle
+}
+
+// runHandle is the cancel side of the currently streaming run.
+type runHandle struct {
+	runID  string
+	cancel context.CancelFunc
+}
+
+// NewSSEClient builds a daemon-transport client for agentID (the path segment in
+// /v1/<agent>/query, e.g. "email").
+func NewSSEClient(agentID string, dc *daemon.Client, opts SSEOptions) *SSEClient {
+	if opts.ConnectTimeout <= 0 {
+		opts.ConnectTimeout = defaultConnectTimeout
+	}
+	if opts.ReadTimeout <= 0 {
+		opts.ReadTimeout = defaultReadTimeout
+	}
+	if opts.Logf == nil {
+		opts.Logf = func(string, ...any) {}
+	}
+	return &SSEClient{
+		agentID: agentID,
+		daemon:  dc,
+		opts:    opts,
+		stream:  daemon.StreamHTTPClient(opts.ConnectTimeout),
+	}
+}
+
+type queryRequest struct {
+	Query    string `json:"query"`
+	RunID    string `json:"run_id"`
+	Context  []Turn `json:"context"`
+	Model    string `json:"model,omitempty"`
+	MaxSteps int    `json:"max_steps,omitempty"`
+}
+
+// Send starts one turn. The returned channel carries the canonical event types
+// from the event package and is closed when the turn ends.
+//
+// Every turn ends with exactly one terminal event: the wire's `final` / `error`,
+// or — if the stream ended without one — a synthesized CanonicalErrorEvent. A
+// stream that stops early is a failure, never a quiet success.
+func (s *SSEClient) Send(ctx context.Context, query string) (<-chan interface{}, error) {
+	s.mu.Lock()
+	closed := s.closed
+	s.mu.Unlock()
+	if closed {
+		return nil, fmt.Errorf("the %s agent connection is closed; relaunch the agent from the hub", s.agentID)
+	}
+
+	runID, err := newRunID()
+	if err != nil {
+		return nil, err
+	}
+
+	// Blocking: daemon start-or-attach, sidecar spawn, and a possible first-run
+	// binary fetch all happen here. Loud on failure — no in-process fallback.
+	inst, err := s.daemon.EnsureAgent(ctx, s.agentID)
+	if err != nil {
+		return nil, err
+	}
+
+	s.mu.Lock()
+	s.inst = inst
+	// Non-nil even when empty: `context` is a REQUIRED array in the request
+	// schema, and a nil slice would marshal to `null` and fail validation.
+	history := make([]Turn, 0, len(s.transcript))
+	history = append(history, s.transcript...)
+	s.mu.Unlock()
+
+	payload, err := json.Marshal(queryRequest{
+		Query:    query,
+		RunID:    runID,
+		Context:  history,
+		Model:    s.opts.Model,
+		MaxSteps: s.opts.MaxSteps,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("could not encode the '%s' query request: %w", s.agentID, err)
+	}
+
+	// runCtx is cancelled by Close() and by the read-idle watchdog. It derives
+	// from ctx so the caller's own cancel (Esc) still aborts the stream, while
+	// events can still be delivered on ctx after runCtx is gone.
+	runCtx, cancel := context.WithCancel(ctx)
+
+	resp, inst, err := s.daemon.Do(runCtx, inst, daemon.Request{
+		Method: http.MethodPost,
+		Path:   fmt.Sprintf("/v1/%s/query", s.agentID),
+		Body:   payload,
+		Header: http.Header{
+			"Content-Type": []string{"application/json"},
+			"Accept":       []string{"text/event-stream"},
+		},
+		HTTPClient: s.stream,
+		Op:         fmt.Sprintf("stream the '%s' query through the daemon relay", s.agentID),
+	})
+	if err != nil {
+		cancel()
+		return nil, err
+	}
+	if resp.StatusCode != http.StatusOK {
+		detail := daemon.ErrorDetail(resp)
+		resp.Body.Close()
+		cancel()
+		return nil, fmt.Errorf(
+			"the daemon relay refused the '%s' query (%s). Check `gaia daemon status`",
+			s.agentID, detail)
+	}
+
+	handle := &runHandle{runID: runID, cancel: cancel}
+	s.mu.Lock()
+	s.inst = inst
+	s.active = handle
+	s.mu.Unlock()
+
+	ch := make(chan interface{}, 32)
+	go s.consume(ctx, runCtx, handle, resp, ch, query)
+	return ch, nil
+}
+
+// consume reads the SSE response and enforces the terminal-event contract.
+func (s *SSEClient) consume(
+	ctx context.Context,
+	runCtx context.Context,
+	handle *runHandle,
+	resp *http.Response,
+	ch chan interface{},
+	query string,
+) {
+	defer close(ch)
+	defer resp.Body.Close()
+	defer handle.cancel()
+	defer s.clearActive(handle)
+
+	// Read-idle watchdog: mirrors agent_query.py's read timeout. Any traffic —
+	// including a heartbeat comment — resets it; if it fires, the request is
+	// cancelled and the run surfaces an error rather than hanging forever.
+	var timedOut atomic.Bool
+	watchdog := time.AfterFunc(s.opts.ReadTimeout, func() {
+		timedOut.Store(true)
+		handle.cancel()
+	})
+	defer watchdog.Stop()
+
+	// emit selects on the CALLER's context, not the run context, so a watchdog or
+	// Close() cancellation can still deliver its terminal error.
+	emit := func(evt interface{}) bool {
+		select {
+		case ch <- evt:
+			return true
+		case <-ctx.Done():
+			return false
+		}
+	}
+
+	reader := newSSEFrameReader(resp.Body, func() { watchdog.Reset(s.opts.ReadTimeout) })
+
+	var (
+		terminal  string
+		answer    string
+		streamed  string
+		delivered = true
+	)
+
+	for {
+		payload, ok := reader.Next()
+		if !ok {
+			break
+		}
+		evt := event.ParseCanonicalEvent(payload)
+		if malformed, bad := evt.(event.CanonicalMalformedEvent); bad {
+			// Visible, but never fatal: one broken frame must not kill the run.
+			s.opts.Logf("sse: unparseable '%s' frame (%s) — skipped", s.agentID, malformed.Reason)
+		}
+		if tok, isToken := evt.(event.CanonicalTokenEvent); isToken {
+			streamed += tok.Delta
+		}
+		if fin, isFinal := evt.(event.CanonicalFinalEvent); isFinal {
+			answer = fin.Answer
+		}
+		if !emit(evt) {
+			delivered = false
+			break
+		}
+		if t := event.CanonicalTerminalType(evt); t != "" {
+			terminal = t
+			break
+		}
+	}
+
+	if terminal != "" {
+		if terminal == event.CanonicalTypeFinal {
+			if answer == "" {
+				// The sidecar streamed the answer as tokens and closed with an
+				// empty `final` — keep the streamed text as the turn's answer.
+				answer = streamed
+			}
+			s.appendTurn(query, answer)
+		}
+		return
+	}
+
+	// No terminal event: report first (the user should not wait on a network
+	// round-trip to learn the turn failed), then ask the relay to drop the run —
+	// it may still be live inside the sidecar.
+	switch {
+	case timedOut.Load():
+		emit(event.CanonicalErrorEvent{
+			Type:   event.CanonicalTypeError,
+			Detail: s.readTimeoutDetail(),
+			Status: http.StatusGatewayTimeout,
+			Source: "tui",
+		})
+	case ctx.Err() != nil || !delivered:
+		// The user cancelled the turn (Esc / hub exit) — the UI already says so.
+		s.opts.Logf("sse: '%s' run %s cancelled by the caller", s.agentID, handle.runID)
+	case runCtx.Err() != nil:
+		// Close() cancelled the run without the caller's context ending.
+		emit(event.CanonicalErrorEvent{
+			Type:   event.CanonicalTypeError,
+			Detail: fmt.Sprintf("the '%s' agent connection was closed mid-run", s.agentID),
+			Status: http.StatusServiceUnavailable,
+			Source: "tui",
+		})
+	case reader.Err() != nil:
+		emit(event.CanonicalErrorEvent{
+			Type: event.CanonicalTypeError,
+			Detail: fmt.Sprintf(
+				"the '%s' query stream failed mid-run: %v. Check `gaia daemon status`",
+				s.agentID, reader.Err()),
+			Status: http.StatusBadGateway,
+			Source: "tui",
+		})
+	default:
+		// The contract mandates exactly one terminal event; a clean EOF without
+		// one is a failure, surfaced loudly rather than as an empty answer.
+		emit(event.CanonicalErrorEvent{
+			Type: event.CanonicalTypeError,
+			Detail: fmt.Sprintf(
+				"the '%s' query stream ended without a terminal final/error event — "+
+					"the sidecar may have crashed mid-run. Check `gaia daemon status`",
+				s.agentID),
+			Status: http.StatusBadGateway,
+			Source: "tui",
+		})
+	}
+
+	s.cancelRun(handle)
+}
+
+func (s *SSEClient) readTimeoutDetail() string {
+	return fmt.Sprintf(
+		"the '%s' query stream sent nothing for %s and was abandoned. "+
+			"The sidecar may be stuck loading a model — check `gaia daemon status`",
+		s.agentID, s.opts.ReadTimeout)
+}
+
+// cancelRun tells the relay to drop a run we are abandoning. Best-effort.
+func (s *SSEClient) cancelRun(handle *runHandle) {
+	s.mu.Lock()
+	inst := s.inst
+	s.mu.Unlock()
+	if inst == nil {
+		return
+	}
+	s.daemon.CancelRun(inst, s.agentID, handle.runID)
+}
+
+func (s *SSEClient) clearActive(handle *runHandle) {
+	s.mu.Lock()
+	if s.active == handle {
+		s.active = nil
+	}
+	s.mu.Unlock()
+}
+
+func (s *SSEClient) appendTurn(query, answer string) {
+	s.mu.Lock()
+	s.transcript = append(s.transcript,
+		Turn{Role: "user", Content: query},
+		Turn{Role: "assistant", Content: answer},
+	)
+	s.mu.Unlock()
+}
+
+// Transcript returns a copy of the host-owned transcript pushed as `context`.
+func (s *SSEClient) Transcript() []Turn {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([]Turn(nil), s.transcript...)
+}
+
+// ResetTranscript drops the accumulated context, so the next turn starts fresh.
+// Wired to the chat screen's /clear, which would otherwise clear the visible
+// history while still pushing it as `context`.
+func (s *SSEClient) ResetTranscript() {
+	s.mu.Lock()
+	s.transcript = nil
+	s.mu.Unlock()
+}
+
+// Close cancels any in-flight run and refuses further sends.
+func (s *SSEClient) Close() error {
+	s.mu.Lock()
+	s.closed = true
+	active := s.active
+	s.active = nil
+	s.mu.Unlock()
+
+	if active != nil {
+		active.cancel()
+	}
+	return nil
+}
+
+// newRunID mints the host-side run handle (contract §2.3): the client knows it
+// before the request is sent, so a run is cancellable from that instant.
+func newRunID() (string, error) {
+	var b [16]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		return "", fmt.Errorf("could not mint a run id: %w", err)
+	}
+	b[6] = (b[6] & 0x0f) | 0x40 // version 4
+	b[8] = (b[8] & 0x3f) | 0x80 // RFC 4122 variant
+	return fmt.Sprintf("%x-%x-%x-%x-%x", b[0:4], b[4:6], b[6:8], b[8:10], b[10:16]), nil
+}
+
+// Compile-time proof the daemon transport satisfies the same interface as the
+// subprocess one.
+var (
+	_ AgentClient        = (*SSEClient)(nil)
+	_ TranscriptResetter = (*SSEClient)(nil)
+)

--- a/tui/internal/client/sse_frame.go
+++ b/tui/internal/client/sse_frame.go
@@ -49,8 +49,10 @@ func (r *sseFrameReader) Next() (payload []byte, ok bool) {
 		if strings.HasPrefix(line, ":") {
 			continue
 		}
-		field, value, found := strings.Cut(line, ":")
-		if !found || field != "data" {
+		// A field line with no colon carries an empty value, per the SSE spec
+		// (and matching the reference implementation's str.partition).
+		field, value, _ := strings.Cut(line, ":")
+		if field != "data" {
 			continue
 		}
 		r.data = append(r.data, strings.TrimPrefix(value, " "))

--- a/tui/internal/client/sse_frame.go
+++ b/tui/internal/client/sse_frame.go
@@ -1,0 +1,74 @@
+package client
+
+import (
+	"bufio"
+	"io"
+	"strings"
+)
+
+// maxFrameBytes caps one SSE line. A tool_result payload can be large (search
+// hits, an inbox pre-scan), so the ceiling is generous; beyond it the scanner
+// errors instead of silently truncating the JSON into something unparseable.
+const maxFrameBytes = 4 << 20
+
+// sseFrameReader turns an SSE byte stream into JSON payloads.
+//
+// Framing rules (contract §3, mirroring _iter_sse_events in
+// src/gaia/daemon/agent_query.py):
+//   - `data:` field lines accumulate until a blank line, then join with "\n".
+//   - `:`-prefixed lines are comments/heartbeats and are skipped.
+//   - other SSE fields (`event:`, `id:`, `retry:`) are framing, not payload.
+//   - a trailing frame with no terminating blank line is still flushed at EOF.
+type sseFrameReader struct {
+	sc   *bufio.Scanner
+	data []string
+	// onLine fires after every physical line, so a caller can reset a read-idle
+	// watchdog on any traffic — including heartbeats.
+	onLine func()
+}
+
+func newSSEFrameReader(r io.Reader, onLine func()) *sseFrameReader {
+	sc := bufio.NewScanner(r)
+	sc.Buffer(make([]byte, 0, 64*1024), maxFrameBytes)
+	return &sseFrameReader{sc: sc, onLine: onLine}
+}
+
+// Next returns the next complete frame payload. ok is false once the stream ends.
+func (r *sseFrameReader) Next() (payload []byte, ok bool) {
+	for r.sc.Scan() {
+		if r.onLine != nil {
+			r.onLine()
+		}
+		line := r.sc.Text()
+		if line == "" {
+			if p, flushed := r.flush(); flushed {
+				return p, true
+			}
+			continue
+		}
+		if strings.HasPrefix(line, ":") {
+			continue
+		}
+		field, value, found := strings.Cut(line, ":")
+		if !found || field != "data" {
+			continue
+		}
+		r.data = append(r.data, strings.TrimPrefix(value, " "))
+	}
+	return r.flush()
+}
+
+// Err reports a read failure (including a line above maxFrameBytes). nil at a
+// clean EOF.
+func (r *sseFrameReader) Err() error {
+	return r.sc.Err()
+}
+
+func (r *sseFrameReader) flush() ([]byte, bool) {
+	if len(r.data) == 0 {
+		return nil, false
+	}
+	payload := strings.Join(r.data, "\n")
+	r.data = r.data[:0]
+	return []byte(payload), true
+}

--- a/tui/internal/client/sse_test.go
+++ b/tui/internal/client/sse_test.go
@@ -1,0 +1,765 @@
+package client
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/amd/gaia/tui/internal/daemon"
+	"github.com/amd/gaia/tui/internal/event"
+)
+
+// sidecarBearer stands in for the sidecar token the daemon's /ensure response
+// carries. The TUI must never present it on any request.
+const sidecarBearer = "SIDECAR-BEARER-MUST-NOT-LEAK"
+
+// fakeRelay is an httptest server standing in for the GAIA daemon: the status
+// probe, the sidecar ensure, and the /v1/<agent>/query SSE relay.
+type fakeRelay struct {
+	t   *testing.T
+	srv *httptest.Server
+	dir string
+
+	// stream writes the SSE body for one run. Set per test.
+	stream func(w http.ResponseWriter, flush func(), body queryRequest)
+	// queryStatus, when non-zero, is returned instead of a stream.
+	queryStatus int
+	// onEnsure runs after a successful ensure — used to simulate a daemon
+	// restart (and therefore a token rotation) mid-Send.
+	onEnsure func()
+
+	mu        sync.Mutex
+	token     string
+	queries   []queryRequest
+	rawBodies []string
+	cancelled []string
+	auths     []string
+}
+
+func newFakeRelay(t *testing.T) *fakeRelay {
+	t.Helper()
+
+	dir := t.TempDir()
+	t.Setenv(daemon.EnvHome, dir)
+
+	f := &fakeRelay{t: t, dir: dir, token: "token-A"}
+	f.srv = httptest.NewServer(http.HandlerFunc(f.handle))
+	t.Cleanup(f.srv.Close)
+
+	if f.port() == daemon.ReservedPort {
+		t.Fatalf("test server bound the reserved port %d", daemon.ReservedPort)
+	}
+	f.writeInstance("token-A")
+	return f
+}
+
+func (f *fakeRelay) port() int {
+	u, err := url.Parse(f.srv.URL)
+	if err != nil {
+		f.t.Fatalf("parse server URL: %v", err)
+	}
+	p, err := strconv.Atoi(u.Port())
+	if err != nil {
+		f.t.Fatalf("parse port: %v", err)
+	}
+	return p
+}
+
+func (f *fakeRelay) writeInstance(token string) {
+	f.t.Helper()
+	payload := map[string]any{
+		"pid": os.Getpid(), "port": f.port(), "token": token,
+		"host": "127.0.0.1", "api_version": "1.1", "service": "gaia-daemon",
+		"started_at": 1.0,
+	}
+	raw, err := json.Marshal(payload)
+	if err != nil {
+		f.t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(f.dir, "instance.json"), raw, 0o600); err != nil {
+		f.t.Fatal(err)
+	}
+}
+
+func (f *fakeRelay) rotateToken(next string) {
+	f.mu.Lock()
+	f.token = next
+	f.mu.Unlock()
+	f.writeInstance(next)
+}
+
+func (f *fakeRelay) handle(w http.ResponseWriter, r *http.Request) {
+	f.mu.Lock()
+	token := f.token
+	f.auths = append(f.auths, r.Header.Get("Authorization"))
+	f.mu.Unlock()
+
+	if r.Header.Get("Authorization") != "Bearer "+token {
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte(`{"detail":"invalid or expired client token"}`))
+		return
+	}
+
+	switch {
+	case r.URL.Path == "/daemon/v1/status":
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprintf(w, `{"service":"gaia-daemon","pid":%d}`, os.Getpid())
+
+	case strings.HasSuffix(r.URL.Path, "/ensure"):
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprintf(w, `{"port":51999,"token":%q,"state":"running"}`, sidecarBearer)
+		if f.onEnsure != nil {
+			f.onEnsure()
+		}
+
+	case strings.HasSuffix(r.URL.Path, "/cancel"):
+		parts := strings.Split(r.URL.Path, "/")
+		f.mu.Lock()
+		f.cancelled = append(f.cancelled, parts[len(parts)-2])
+		f.mu.Unlock()
+		w.WriteHeader(http.StatusOK)
+
+	case strings.HasSuffix(r.URL.Path, "/query"):
+		var body queryRequest
+		raw, _ := io.ReadAll(r.Body)
+		if err := json.Unmarshal(raw, &body); err != nil {
+			f.t.Errorf("query body is not valid JSON: %v (%s)", err, raw)
+		}
+		f.mu.Lock()
+		f.queries = append(f.queries, body)
+		f.rawBodies = append(f.rawBodies, string(raw))
+		f.mu.Unlock()
+
+		if f.queryStatus != 0 {
+			w.WriteHeader(f.queryStatus)
+			_, _ = w.Write([]byte(`{"detail":"the email sidecar is not running"}`))
+			return
+		}
+		if accept := r.Header.Get("Accept"); accept != "text/event-stream" {
+			f.t.Errorf("Accept = %q, want text/event-stream", accept)
+		}
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		flusher, ok := w.(http.Flusher)
+		if !ok {
+			f.t.Fatal("test server response writer is not a Flusher")
+		}
+		f.stream(w, flusher.Flush, body)
+
+	default:
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(`{"detail":"no route"}`))
+	}
+}
+
+func (f *fakeRelay) lastQuery() queryRequest {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if len(f.queries) == 0 {
+		f.t.Fatal("no query was received")
+	}
+	return f.queries[len(f.queries)-1]
+}
+
+func (f *fakeRelay) client(t *testing.T) *SSEClient {
+	t.Helper()
+	dc := daemon.New(daemon.Options{
+		ProbeTimeout:  2 * time.Second,
+		EnsureTimeout: 5 * time.Second,
+		StartCommand: func(context.Context) (*exec.Cmd, error) {
+			return nil, fmt.Errorf("the test daemon must already be attachable")
+		},
+		Logf: func(format string, args ...any) { t.Logf(format, args...) },
+	})
+	return NewSSEClient("email", dc, SSEOptions{
+		ReadTimeout: 5 * time.Second,
+		Logf:        func(format string, args ...any) { t.Logf(format, args...) },
+	})
+}
+
+// frame writes one canonical SSE event.
+func frame(w io.Writer, payload string) {
+	fmt.Fprintf(w, "data: %s\n\n", payload)
+}
+
+// collect drains a turn's channel.
+func collect(t *testing.T, ch <-chan interface{}) []interface{} {
+	t.Helper()
+	var got []interface{}
+	timeout := time.After(15 * time.Second)
+	for {
+		select {
+		case evt, ok := <-ch:
+			if !ok {
+				return got
+			}
+			got = append(got, evt)
+		case <-timeout:
+			t.Fatalf("timed out draining the event channel after %d events", len(got))
+		}
+	}
+}
+
+func typeNames(events []interface{}) []string {
+	names := make([]string, 0, len(events))
+	for _, e := range events {
+		names = append(names, fmt.Sprintf("%T", e))
+	}
+	return names
+}
+
+// --- happy path -------------------------------------------------------------
+
+func TestSSEClientFullRun(t *testing.T) {
+	f := newFakeRelay(t)
+	f.stream = func(w http.ResponseWriter, flush func(), _ queryRequest) {
+		frame(w, `{"type":"status","message":"Scanning inbox"}`)
+		frame(w, `{"type":"tool_call","tool":"pre_scan_inbox","args":{"max":50}}`)
+		frame(w, `{"type":"tool_result","tool":"pre_scan_inbox","render":"email_pre_scan","data":{"urgent":[]}}`)
+		frame(w, `{"type":"token","delta":"You have "}`)
+		frame(w, `{"type":"token","delta":"3 urgent emails."}`)
+		frame(w, `{"type":"final","answer":"You have 3 urgent emails.","usage":{"steps":2,"tools_used":1}}`)
+		flush()
+	}
+
+	c := f.client(t)
+	defer c.Close()
+
+	ch, err := c.Send(context.Background(), "triage my inbox")
+	if err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+	got := collect(t, ch)
+
+	want := []string{
+		"event.CanonicalStatusEvent",
+		"event.CanonicalToolCallEvent",
+		"event.CanonicalToolResultEvent",
+		"event.CanonicalTokenEvent",
+		"event.CanonicalTokenEvent",
+		"event.CanonicalFinalEvent",
+	}
+	if names := typeNames(got); !equalStrings(names, want) {
+		t.Fatalf("event sequence = %v, want %v", names, want)
+	}
+
+	tr := got[2].(event.CanonicalToolResultEvent)
+	if tr.Render != "email_pre_scan" {
+		t.Errorf("render hint lost: %+v", tr)
+	}
+	if !strings.Contains(string(tr.Data), "urgent") {
+		t.Errorf("render data lost: %s", tr.Data)
+	}
+
+	fin := got[5].(event.CanonicalFinalEvent)
+	if fin.Answer != "You have 3 urgent emails." {
+		t.Errorf("answer = %q", fin.Answer)
+	}
+	if u := event.CanonicalUsageOf(fin); u.Steps != 2 || u.ToolsUsed != 1 {
+		t.Errorf("usage = %+v", u)
+	}
+
+	// The request must carry a v4 run_id and an (empty) context array.
+	q := f.lastQuery()
+	if len(q.RunID) != 36 {
+		t.Errorf("run_id %q is not a uuid4", q.RunID)
+	}
+	if q.RunID[14] != '4' {
+		t.Errorf("run_id %q is not version 4", q.RunID)
+	}
+	if len(q.Context) != 0 {
+		t.Errorf("first turn must push an empty context, got %+v", q.Context)
+	}
+	if q.Query != "triage my inbox" {
+		t.Errorf("query = %q", q.Query)
+	}
+
+	// `context` is a REQUIRED array: an empty transcript must serialize as [],
+	// never null, or the sidecar rejects the body.
+	f.mu.Lock()
+	rawBody := f.rawBodies[len(f.rawBodies)-1]
+	f.mu.Unlock()
+	if !strings.Contains(rawBody, `"context":[]`) {
+		t.Errorf("first turn body must carry an empty context array, got %s", rawBody)
+	}
+}
+
+// The host owns the transcript and pushes it back on every turn.
+func TestSSEClientPushesHostOwnedTranscript(t *testing.T) {
+	f := newFakeRelay(t)
+	f.stream = func(w http.ResponseWriter, flush func(), body queryRequest) {
+		frame(w, fmt.Sprintf(`{"type":"final","answer":"reply to %s"}`, body.Query))
+		flush()
+	}
+
+	c := f.client(t)
+	defer c.Close()
+
+	for _, q := range []string{"first", "second"} {
+		ch, err := c.Send(context.Background(), q)
+		if err != nil {
+			t.Fatalf("Send(%q): %v", q, err)
+		}
+		collect(t, ch)
+	}
+
+	q := f.lastQuery()
+	if len(q.Context) != 2 {
+		t.Fatalf("second turn context = %+v, want 2 entries", q.Context)
+	}
+	if q.Context[0].Role != "user" || q.Context[0].Content != "first" {
+		t.Errorf("context[0] = %+v", q.Context[0])
+	}
+	if q.Context[1].Role != "assistant" || !strings.Contains(q.Context[1].Content, "first") {
+		t.Errorf("context[1] = %+v", q.Context[1])
+	}
+
+	if got := c.Transcript(); len(got) != 4 {
+		t.Errorf("transcript = %+v, want 4 entries after two turns", got)
+	}
+	c.ResetTranscript()
+	if got := c.Transcript(); len(got) != 0 {
+		t.Errorf("ResetTranscript left %+v", got)
+	}
+}
+
+// A `final` with an empty answer after streamed tokens keeps the streamed text.
+func TestSSEClientTranscriptFallsBackToStreamedTokens(t *testing.T) {
+	f := newFakeRelay(t)
+	f.stream = func(w http.ResponseWriter, flush func(), _ queryRequest) {
+		frame(w, `{"type":"token","delta":"streamed "}`)
+		frame(w, `{"type":"token","delta":"answer"}`)
+		frame(w, `{"type":"final","answer":""}`)
+		flush()
+	}
+
+	c := f.client(t)
+	defer c.Close()
+
+	ch, err := c.Send(context.Background(), "hello")
+	if err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+	collect(t, ch)
+
+	tr := c.Transcript()
+	if len(tr) != 2 || tr[1].Content != "streamed answer" {
+		t.Fatalf("transcript = %+v", tr)
+	}
+}
+
+// --- terminal-event contract -------------------------------------------------
+
+// A stream that ends without final/error is a FAILURE, not an empty success.
+func TestSSEClientStreamWithoutTerminalEventIsAnError(t *testing.T) {
+	f := newFakeRelay(t)
+	f.stream = func(w http.ResponseWriter, flush func(), _ queryRequest) {
+		frame(w, `{"type":"status","message":"working"}`)
+		frame(w, `{"type":"token","delta":"half an ans"}`)
+		flush()
+		// …and the sidecar dies: the stream just ends.
+	}
+
+	c := f.client(t)
+	defer c.Close()
+
+	ch, err := c.Send(context.Background(), "triage")
+	if err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+	got := collect(t, ch)
+
+	if len(got) == 0 {
+		t.Fatal("expected events")
+	}
+	last, ok := got[len(got)-1].(event.CanonicalErrorEvent)
+	if !ok {
+		t.Fatalf("last event = %T, want a synthesized CanonicalErrorEvent (%v)", got[len(got)-1], typeNames(got))
+	}
+	if !strings.Contains(last.Detail, "without a terminal") {
+		t.Errorf("detail must explain the missing terminal event: %q", last.Detail)
+	}
+	if !strings.Contains(last.Detail, "gaia daemon status") {
+		t.Errorf("detail must be actionable: %q", last.Detail)
+	}
+	if last.Source != "tui" {
+		t.Errorf("synthesized errors must be attributed to the tui, got %q", last.Source)
+	}
+	// A failed turn must not poison the next one's context.
+	if tr := c.Transcript(); len(tr) != 0 {
+		t.Errorf("a turn without `final` must not be appended to the transcript: %+v", tr)
+	}
+}
+
+func TestSSEClientTerminalErrorEvent(t *testing.T) {
+	f := newFakeRelay(t)
+	f.stream = func(w http.ResponseWriter, flush func(), _ queryRequest) {
+		frame(w, `{"type":"status","message":"loading model"}`)
+		frame(w, `{"type":"error","detail":"Lemonade Server is not reachable at http://localhost:8000 — run `+"`gaia init`"+`","status":503}`)
+		flush()
+	}
+
+	c := f.client(t)
+	defer c.Close()
+
+	ch, err := c.Send(context.Background(), "triage")
+	if err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+	got := collect(t, ch)
+
+	last, ok := got[len(got)-1].(event.CanonicalErrorEvent)
+	if !ok {
+		t.Fatalf("last event = %T, want CanonicalErrorEvent", got[len(got)-1])
+	}
+	if !strings.Contains(last.Detail, "gaia init") {
+		t.Errorf("the wire detail must be surfaced verbatim: %q", last.Detail)
+	}
+	if last.Status != 503 {
+		t.Errorf("status = %d, want 503", last.Status)
+	}
+	if last.Source != "" {
+		t.Errorf("a wire error must not be attributed to the tui, got %q", last.Source)
+	}
+	if tr := c.Transcript(); len(tr) != 0 {
+		t.Errorf("an errored turn must not be appended to the transcript: %+v", tr)
+	}
+}
+
+// --- framing ----------------------------------------------------------------
+
+func TestSSEClientSkipsUnparseableFramesAndHeartbeats(t *testing.T) {
+	f := newFakeRelay(t)
+	f.stream = func(w http.ResponseWriter, flush func(), _ queryRequest) {
+		fmt.Fprint(w, ": keep-alive\n\n")
+		frame(w, `{"type":"status","message":"one"}`)
+		frame(w, `{"type":"token", TRUNCATED`)       // not valid JSON
+		fmt.Fprint(w, ": another heartbeat\n")       // comment, no blank line
+		frame(w, `{"type":"brand_new_event","x":1}`) // unknown canonical type
+		frame(w, `{"type":"status","message":"two"}`)
+		frame(w, `{"type":"final","answer":"survived"}`)
+		flush()
+	}
+
+	c := f.client(t)
+	defer c.Close()
+
+	ch, err := c.Send(context.Background(), "triage")
+	if err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+	got := collect(t, ch)
+
+	want := []string{
+		"event.CanonicalStatusEvent",
+		"event.CanonicalMalformedEvent",
+		"event.CanonicalUnsupportedEvent",
+		"event.CanonicalStatusEvent",
+		"event.CanonicalFinalEvent",
+	}
+	if names := typeNames(got); !equalStrings(names, want) {
+		t.Fatalf("event sequence = %v, want %v (heartbeats must be dropped, bad frames surfaced)", names, want)
+	}
+	if fin := got[4].(event.CanonicalFinalEvent); fin.Answer != "survived" {
+		t.Errorf("the run must survive a bad frame, got %+v", fin)
+	}
+}
+
+// A final frame with no trailing blank line must still be delivered.
+func TestSSEClientFlushesTrailingFrameWithoutBlankLine(t *testing.T) {
+	f := newFakeRelay(t)
+	f.stream = func(w http.ResponseWriter, flush func(), _ queryRequest) {
+		frame(w, `{"type":"status","message":"working"}`)
+		fmt.Fprint(w, `data: {"type":"final","answer":"no trailing newline"}`)
+		flush()
+	}
+
+	c := f.client(t)
+	defer c.Close()
+
+	ch, err := c.Send(context.Background(), "triage")
+	if err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+	got := collect(t, ch)
+
+	fin, ok := got[len(got)-1].(event.CanonicalFinalEvent)
+	if !ok {
+		t.Fatalf("last event = %T, want CanonicalFinalEvent (%v)", got[len(got)-1], typeNames(got))
+	}
+	if fin.Answer != "no trailing newline" {
+		t.Errorf("answer = %q", fin.Answer)
+	}
+}
+
+// Multi-line `data:` fields join with a newline, per the SSE spec.
+func TestSSEClientJoinsMultiLineDataFields(t *testing.T) {
+	f := newFakeRelay(t)
+	f.stream = func(w http.ResponseWriter, flush func(), _ queryRequest) {
+		fmt.Fprint(w, "data: {\"type\":\"final\",\ndata: \"answer\":\"split payload\"}\n\n")
+		flush()
+	}
+
+	c := f.client(t)
+	defer c.Close()
+
+	ch, err := c.Send(context.Background(), "triage")
+	if err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+	got := collect(t, ch)
+
+	fin, ok := got[0].(event.CanonicalFinalEvent)
+	if !ok {
+		t.Fatalf("event = %T, want CanonicalFinalEvent", got[0])
+	}
+	if fin.Answer != "split payload" {
+		t.Errorf("answer = %q", fin.Answer)
+	}
+}
+
+// --- auth -------------------------------------------------------------------
+
+// The token rotates on every daemon restart: a 401 mid-Send must re-read
+// instance.json and retry exactly once.
+func TestSSEClientRetriesOnceAfterTokenRotation(t *testing.T) {
+	f := newFakeRelay(t)
+	// The daemon restarts right after the ensure — the query then presents a
+	// token the new daemon does not know.
+	f.onEnsure = func() { f.rotateToken("token-B") }
+	f.stream = func(w http.ResponseWriter, flush func(), _ queryRequest) {
+		frame(w, `{"type":"final","answer":"after rotation"}`)
+		flush()
+	}
+
+	c := f.client(t)
+	defer c.Close()
+
+	ch, err := c.Send(context.Background(), "triage")
+	if err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+	got := collect(t, ch)
+
+	fin, ok := got[len(got)-1].(event.CanonicalFinalEvent)
+	if !ok {
+		t.Fatalf("last event = %T, want CanonicalFinalEvent (%v)", got[len(got)-1], typeNames(got))
+	}
+	if fin.Answer != "after rotation" {
+		t.Errorf("answer = %q", fin.Answer)
+	}
+
+	f.mu.Lock()
+	auths := append([]string(nil), f.auths...)
+	f.mu.Unlock()
+	var sawA, sawB bool
+	for _, a := range auths {
+		switch a {
+		case "Bearer token-A":
+			sawA = true
+		case "Bearer token-B":
+			sawB = true
+		case "Bearer " + sidecarBearer:
+			t.Fatal("the sidecar bearer was presented to the daemon")
+		}
+	}
+	if !sawA || !sawB {
+		t.Errorf("expected attempts with both tokens, saw %v", auths)
+	}
+}
+
+func TestSSEClientNeverPresentsTheSidecarBearer(t *testing.T) {
+	f := newFakeRelay(t)
+	f.stream = func(w http.ResponseWriter, flush func(), _ queryRequest) {
+		frame(w, `{"type":"final","answer":"ok"}`)
+		flush()
+	}
+
+	c := f.client(t)
+	defer c.Close()
+
+	ch, err := c.Send(context.Background(), "triage")
+	if err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+	collect(t, ch)
+
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	for _, a := range f.auths {
+		if strings.Contains(a, sidecarBearer) {
+			t.Fatalf("the sidecar bearer leaked onto the wire: %q", a)
+		}
+	}
+}
+
+// --- refusals ---------------------------------------------------------------
+
+func TestSSEClientSurfacesRelayRefusal(t *testing.T) {
+	f := newFakeRelay(t)
+	f.queryStatus = http.StatusServiceUnavailable
+	f.stream = func(http.ResponseWriter, func(), queryRequest) {}
+
+	c := f.client(t)
+	defer c.Close()
+
+	_, err := c.Send(context.Background(), "triage")
+	if err == nil {
+		t.Fatal("expected an error when the relay refuses the query")
+	}
+	if !strings.Contains(err.Error(), "not running") {
+		t.Errorf("the relay's detail must be surfaced: %v", err)
+	}
+	if !strings.Contains(err.Error(), "gaia daemon status") {
+		t.Errorf("the error must be actionable: %v", err)
+	}
+}
+
+func TestSSEClientFailsLoudlyWithNoDaemon(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv(daemon.EnvHome, dir)
+
+	dc := daemon.New(daemon.Options{
+		ProbeTimeout: time.Second,
+		StartCommand: func(context.Context) (*exec.Cmd, error) {
+			return nil, fmt.Errorf("no launcher in this test")
+		},
+	})
+	c := NewSSEClient("email", dc, SSEOptions{})
+	defer c.Close()
+
+	_, err := c.Send(context.Background(), "triage")
+	if err == nil {
+		t.Fatal("expected a loud error when no daemon is registered")
+	}
+	if !strings.Contains(err.Error(), "no launcher in this test") {
+		t.Errorf("the start failure must be surfaced: %v", err)
+	}
+}
+
+// --- cancellation -----------------------------------------------------------
+
+// Cancelling the turn must POST the run's cancel endpoint so the sidecar stops
+// between tool steps.
+func TestSSEClientCancelPostsToCancelEndpoint(t *testing.T) {
+	f := newFakeRelay(t)
+	started := make(chan struct{})
+	release := make(chan struct{})
+	f.stream = func(w http.ResponseWriter, flush func(), _ queryRequest) {
+		frame(w, `{"type":"status","message":"thinking"}`)
+		flush()
+		close(started)
+		<-release // hold the stream open with no terminal event
+	}
+
+	c := f.client(t)
+	defer c.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	ch, err := c.Send(ctx, "triage")
+	if err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+	if _, ok := <-ch; !ok {
+		t.Fatal("expected the status event before cancelling")
+	}
+	<-started
+	cancel()
+	for range ch { // drain
+	}
+	close(release)
+
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		f.mu.Lock()
+		n := len(f.cancelled)
+		runIDs := append([]string(nil), f.cancelled...)
+		f.mu.Unlock()
+		if n > 0 {
+			if runIDs[0] != f.lastQuery().RunID {
+				t.Errorf("cancelled run_id %q, want %q", runIDs[0], f.lastQuery().RunID)
+			}
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("no cancel was posted within 5s of cancelling the turn")
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+
+	if tr := c.Transcript(); len(tr) != 0 {
+		t.Errorf("a cancelled turn must not be appended to the transcript: %+v", tr)
+	}
+}
+
+// The read-idle watchdog must abandon a silent stream with an actionable error.
+func TestSSEClientReadIdleTimeout(t *testing.T) {
+	f := newFakeRelay(t)
+	release := make(chan struct{})
+	t.Cleanup(func() { close(release) })
+	f.stream = func(w http.ResponseWriter, flush func(), _ queryRequest) {
+		frame(w, `{"type":"status","message":"loading model"}`)
+		flush()
+		<-release
+	}
+
+	dc := daemon.New(daemon.Options{
+		ProbeTimeout: 2 * time.Second,
+		StartCommand: func(context.Context) (*exec.Cmd, error) {
+			return nil, fmt.Errorf("unused")
+		},
+	})
+	c := NewSSEClient("email", dc, SSEOptions{ReadTimeout: 300 * time.Millisecond})
+	defer c.Close()
+
+	ch, err := c.Send(context.Background(), "triage")
+	if err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+	got := collect(t, ch)
+
+	last, ok := got[len(got)-1].(event.CanonicalErrorEvent)
+	if !ok {
+		t.Fatalf("last event = %T, want CanonicalErrorEvent (%v)", got[len(got)-1], typeNames(got))
+	}
+	if !strings.Contains(last.Detail, "sent nothing for") {
+		t.Errorf("detail must explain the idle timeout: %q", last.Detail)
+	}
+}
+
+func TestSSEClientRefusesSendAfterClose(t *testing.T) {
+	f := newFakeRelay(t)
+	f.stream = func(http.ResponseWriter, func(), queryRequest) {}
+
+	c := f.client(t)
+	if err := c.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	if _, err := c.Send(context.Background(), "triage"); err == nil {
+		t.Fatal("expected an error sending on a closed client")
+	}
+}
+
+func equalStrings(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/tui/internal/client/subprocess.go
+++ b/tui/internal/client/subprocess.go
@@ -9,7 +9,6 @@ import (
 	"net/http"
 	"os"
 	"os/exec"
-	"strings"
 	"sync"
 	"time"
 
@@ -34,25 +33,57 @@ func detectLemonadeURL() string {
 	return ""
 }
 
-// SubprocessClient communicates with a C++ agent via stdin/stdout JSONL.
+// procHandle owns one child process so exactly one Wait() ever runs for it —
+// the reader goroutine, a cancellation kill, and Close() all funnel through it.
+type procHandle struct {
+	cmd      *exec.Cmd
+	waitOnce sync.Once
+	state    *os.ProcessState
+}
+
+// wait reaps the child and returns its final state (nil if it was never started).
+func (p *procHandle) wait() *os.ProcessState {
+	p.waitOnce.Do(func() {
+		_ = p.cmd.Wait()
+		p.state = p.cmd.ProcessState
+	})
+	return p.state
+}
+
+// kill terminates the child and reaps it.
+func (p *procHandle) kill() {
+	if p.cmd.Process != nil {
+		_ = p.cmd.Process.Kill()
+	}
+	p.wait()
+}
+
+// SubprocessClient communicates with a local agent binary via stdin/stdout JSONL.
 // Send() calls must be serialized — do not overlap two Send() calls.
 type SubprocessClient struct {
-	cmdLine string
-	debug   bool
+	path  string
+	args  []string
+	debug bool
 
 	mu      sync.Mutex
-	cmd     *exec.Cmd
+	proc    *procHandle
 	stdin   io.WriteCloser
 	stdout  *bufio.Scanner
 	stderr  *bytes.Buffer
 	started bool
 }
 
-// NewSubprocessClient creates a client from a command string like "./gaia-bash --json-events".
-func NewSubprocessClient(cmdLine string, debug bool) *SubprocessClient {
+// NewSubprocessClient creates a client for an agent binary and its arguments.
+//
+// argv is taken pre-split: a single command string would have to be re-split on
+// whitespace, which corrupts any path containing a space. Callers holding one
+// string (e.g. `gaia tui chat --subprocess "..."`) split it with
+// SplitCommandLine, which honours quoting.
+func NewSubprocessClient(path string, args []string, debug bool) *SubprocessClient {
 	return &SubprocessClient{
-		cmdLine: cmdLine,
-		debug:   debug,
+		path:  path,
+		args:  args,
+		debug: debug,
 	}
 }
 
@@ -64,33 +95,31 @@ func (s *SubprocessClient) start() error {
 	if s.started {
 		return nil
 	}
-
-	parts := strings.Fields(s.cmdLine)
-	if len(parts) == 0 {
-		return fmt.Errorf("empty subprocess command")
+	if s.path == "" {
+		return fmt.Errorf("no agent binary was given, so nothing can be launched")
 	}
 
-	s.cmd = exec.Command(parts[0], parts[1:]...)
+	cmd := exec.Command(s.path, s.args...)
 	s.stderr = &bytes.Buffer{}
-	s.cmd.Stderr = s.stderr
+	cmd.Stderr = s.stderr
 
 	// Auto-detect Lemonade URL if not set in environment
 	if os.Getenv("LEMONADE_BASE_URL") == "" {
 		if url := detectLemonadeURL(); url != "" {
-			s.cmd.Env = append(os.Environ(), "LEMONADE_BASE_URL="+url)
+			cmd.Env = append(os.Environ(), "LEMONADE_BASE_URL="+url)
 			if s.debug {
 				fmt.Fprintf(os.Stderr, "[DEBUG] Auto-detected Lemonade at %s\n", url)
 			}
 		}
 	}
 
-	stdinPipe, err := s.cmd.StdinPipe()
+	stdinPipe, err := cmd.StdinPipe()
 	if err != nil {
 		return fmt.Errorf("failed to create stdin pipe: %w", err)
 	}
 	s.stdin = stdinPipe
 
-	stdoutPipe, err := s.cmd.StdoutPipe()
+	stdoutPipe, err := cmd.StdoutPipe()
 	if err != nil {
 		return fmt.Errorf("failed to create stdout pipe: %w", err)
 	}
@@ -100,10 +129,11 @@ func (s *SubprocessClient) start() error {
 	scanner.Buffer(make([]byte, 0, 1024*1024), 1024*1024)
 	s.stdout = scanner
 
-	if err := s.cmd.Start(); err != nil {
-		return fmt.Errorf("failed to start subprocess %q: %w", parts[0], err)
+	if err := cmd.Start(); err != nil {
+		return fmt.Errorf("failed to start agent %q: %w", s.path, err)
 	}
 
+	s.proc = &procHandle{cmd: cmd}
 	s.started = true
 	return nil
 }
@@ -115,21 +145,44 @@ func (s *SubprocessClient) Send(ctx context.Context, query string) (<-chan inter
 	}
 
 	if _, err := fmt.Fprintln(s.stdin, query); err != nil {
-		return nil, fmt.Errorf("failed to write to subprocess stdin: %w", err)
+		return nil, fmt.Errorf("failed to write to agent stdin: %w", err)
 	}
 
 	// Capture references under lock so the goroutine doesn't race with Close().
 	s.mu.Lock()
 	scanner := s.stdout
-	cmd := s.cmd
+	proc := s.proc
 	stderrBuf := s.stderr
 	debug := s.debug
 	s.mu.Unlock()
 
 	ch := make(chan interface{}, 32)
 
+	// A cancelled turn must actually stop the child. Abandoning the read while
+	// the agent keeps writing leaves the tail of this turn's output in the pipe,
+	// which the NEXT turn would read as its own — so the process is killed and
+	// respawned instead.
+	turnDone := make(chan struct{})
+	go func() {
+		select {
+		case <-ctx.Done():
+			s.terminate()
+		case <-turnDone:
+		}
+	}()
+
 	go func() {
 		defer close(ch)
+		defer close(turnDone)
+
+		emit := func(evt interface{}) bool {
+			select {
+			case ch <- evt:
+				return true
+			case <-ctx.Done():
+				return false
+			}
+		}
 
 		for scanner.Scan() {
 			line := scanner.Bytes()
@@ -139,8 +192,17 @@ func (s *SubprocessClient) Send(ctx context.Context, query string) (<-chan inter
 
 			evt, err := event.ParseEvent(line)
 			if err != nil {
+				// Visible, not dropped: a status warning keeps the turn alive
+				// while making a bad producer obvious.
 				if debug {
 					fmt.Fprintf(os.Stderr, "[DEBUG] parse error: %v (line: %s)\n", err, string(line))
+				}
+				if !emit(event.StatusEvent{
+					Type:    "status",
+					Status:  "warning",
+					Message: fmt.Sprintf("unreadable agent event (%v): %s", err, truncateLine(string(line))),
+				}) {
+					return
 				}
 				continue
 			}
@@ -150,9 +212,7 @@ func (s *SubprocessClient) Send(ctx context.Context, query string) (<-chan inter
 				continue
 			}
 
-			select {
-			case ch <- evt:
-			case <-ctx.Done():
+			if !emit(evt) {
 				return
 			}
 
@@ -169,59 +229,74 @@ func (s *SubprocessClient) Send(ctx context.Context, query string) (<-chan inter
 
 		// Scanner stopped — check for read errors or unexpected process exit.
 		if err := scanner.Err(); err != nil {
-			select {
-			case ch <- event.AgentErrorEvent{
+			emit(event.AgentErrorEvent{
 				Type:    "agent_error",
-				Content: fmt.Sprintf("subprocess stdout read error: %v", err),
-			}:
-			case <-ctx.Done():
-			}
+				Content: fmt.Sprintf("agent stdout read error: %v", err),
+			})
 			return
 		}
 
-		// Process exited — wait to get exit code, then report if non-zero.
-		_ = cmd.Wait()
-		if cmd.ProcessState != nil && !cmd.ProcessState.Success() {
+		// Process exited — reap it to get the exit code, then report if non-zero.
+		state := proc.wait()
+		if state != nil && !state.Success() {
 			stderrContent := stderrBuf.String()
-			msg := fmt.Sprintf("agent process exited with code %d", cmd.ProcessState.ExitCode())
+			msg := fmt.Sprintf("agent process exited with code %d", state.ExitCode())
 			if stderrContent != "" {
 				msg += "\n" + stderrContent
 			}
-			select {
-			case ch <- event.AgentErrorEvent{
+			emit(event.AgentErrorEvent{
 				Type:    "agent_error",
 				Content: msg,
-			}:
-			case <-ctx.Done():
-			}
+			})
 		}
 	}()
 
 	return ch, nil
 }
 
-// Close terminates the subprocess.
-func (s *SubprocessClient) Close() error {
+// detach clears the client's process state and hands back what it was holding.
+func (s *SubprocessClient) detach() (*procHandle, io.WriteCloser) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	if !s.started {
-		return nil
-	}
-
-	// Close stdin to signal EOF to the child process.
-	if s.stdin != nil {
-		s.stdin.Close()
-	}
-
-	if s.cmd != nil {
-		s.cmd.Wait()
-	}
-
+	proc, stdin := s.proc, s.stdin
+	s.proc = nil
 	s.stdin = nil
 	s.stdout = nil
 	s.stderr = nil
-	s.cmd = nil
 	s.started = false
+	return proc, stdin
+}
+
+// terminate kills the child and resets the client so the next Send respawns it
+// against a clean pipe.
+func (s *SubprocessClient) terminate() {
+	proc, stdin := s.detach()
+	if stdin != nil {
+		stdin.Close()
+	}
+	if proc != nil {
+		proc.kill()
+	}
+}
+
+// Close terminates the subprocess.
+func (s *SubprocessClient) Close() error {
+	proc, stdin := s.detach()
+	// Close stdin to signal EOF to the child process.
+	if stdin != nil {
+		stdin.Close()
+	}
+	if proc != nil {
+		proc.wait()
+	}
 	return nil
+}
+
+func truncateLine(s string) string {
+	const limit = 200
+	if len(s) <= limit {
+		return s
+	}
+	return s[:limit] + "…"
 }

--- a/tui/internal/client/subprocess.go
+++ b/tui/internal/client/subprocess.go
@@ -15,6 +15,10 @@ import (
 	"github.com/amd/gaia/tui/internal/event"
 )
 
+// closeGrace bounds how long Close() waits for an in-flight turn's reader to
+// finish before giving up on a clean reap.
+const closeGrace = 2 * time.Second
+
 // detectLemonadeURL probes common Lemonade Server ports and returns the first reachable URL.
 func detectLemonadeURL() string {
 	ports := []string{"13305", "8000"}
@@ -33,16 +37,21 @@ func detectLemonadeURL() string {
 	return ""
 }
 
-// procHandle owns one child process so exactly one Wait() ever runs for it —
-// the reader goroutine, a cancellation kill, and Close() all funnel through it.
+// procHandle owns one child process.
+//
+// Reaping is the READER's job: os/exec forbids calling Wait before all reads
+// from a pipe have completed, so a kill from elsewhere must not also reap — it
+// would close the stdout pipe under the reader and turn a deliberate kill into a
+// spurious "file already closed" read error.
 type procHandle struct {
 	cmd      *exec.Cmd
 	waitOnce sync.Once
 	state    *os.ProcessState
 }
 
-// wait reaps the child and returns its final state (nil if it was never started).
-func (p *procHandle) wait() *os.ProcessState {
+// reap waits for the child and returns its final state. Safe to call more than
+// once; only the first call waits. Call it only once reads are done.
+func (p *procHandle) reap() *os.ProcessState {
 	p.waitOnce.Do(func() {
 		_ = p.cmd.Wait()
 		p.state = p.cmd.ProcessState
@@ -50,12 +59,11 @@ func (p *procHandle) wait() *os.ProcessState {
 	return p.state
 }
 
-// kill terminates the child and reaps it.
+// kill signals the child without reaping it.
 func (p *procHandle) kill() {
 	if p.cmd.Process != nil {
 		_ = p.cmd.Process.Kill()
 	}
-	p.wait()
 }
 
 // SubprocessClient communicates with a local agent binary via stdin/stdout JSONL.
@@ -71,6 +79,9 @@ type SubprocessClient struct {
 	stdout  *bufio.Scanner
 	stderr  *bytes.Buffer
 	started bool
+	// turnDone is closed by the in-flight turn's reader when it exits. nil when
+	// no turn is running.
+	turnDone chan struct{}
 }
 
 // NewSubprocessClient creates a client for an agent binary and its arguments.
@@ -87,21 +98,31 @@ func NewSubprocessClient(path string, args []string, debug bool) *SubprocessClie
 	}
 }
 
-// start spawns the subprocess if not already running.
-func (s *SubprocessClient) start() error {
-	s.mu.Lock()
-	defer s.mu.Unlock()
+// turnState is everything one turn needs, captured under a single lock so it can
+// never be read while a concurrent cancel is clearing the client's fields.
+type turnState struct {
+	stdin    io.WriteCloser
+	scanner  *bufio.Scanner
+	proc     *procHandle
+	stderr   *bytes.Buffer
+	turnDone chan struct{}
+}
 
+// startLocked spawns the subprocess if needed and returns the turn's handles.
+// The caller MUST hold s.mu.
+func (s *SubprocessClient) startLocked() (turnState, error) {
 	if s.started {
-		return nil
+		done := make(chan struct{})
+		s.turnDone = done
+		return turnState{s.stdin, s.stdout, s.proc, s.stderr, done}, nil
 	}
 	if s.path == "" {
-		return fmt.Errorf("no agent binary was given, so nothing can be launched")
+		return turnState{}, fmt.Errorf("no agent binary was given, so nothing can be launched")
 	}
 
 	cmd := exec.Command(s.path, s.args...)
-	s.stderr = &bytes.Buffer{}
-	cmd.Stderr = s.stderr
+	stderr := &bytes.Buffer{}
+	cmd.Stderr = stderr
 
 	// Auto-detect Lemonade URL if not set in environment
 	if os.Getenv("LEMONADE_BASE_URL") == "" {
@@ -115,67 +136,80 @@ func (s *SubprocessClient) start() error {
 
 	stdinPipe, err := cmd.StdinPipe()
 	if err != nil {
-		return fmt.Errorf("failed to create stdin pipe: %w", err)
+		return turnState{}, fmt.Errorf("failed to create stdin pipe: %w", err)
 	}
-	s.stdin = stdinPipe
-
 	stdoutPipe, err := cmd.StdoutPipe()
 	if err != nil {
-		return fmt.Errorf("failed to create stdout pipe: %w", err)
+		return turnState{}, fmt.Errorf("failed to create stdout pipe: %w", err)
 	}
 
 	scanner := bufio.NewScanner(stdoutPipe)
 	// 1MB buffer for large tool outputs
 	scanner.Buffer(make([]byte, 0, 1024*1024), 1024*1024)
-	s.stdout = scanner
 
 	if err := cmd.Start(); err != nil {
-		return fmt.Errorf("failed to start agent %q: %w", s.path, err)
+		return turnState{}, fmt.Errorf("failed to start agent %q: %w", s.path, err)
 	}
 
+	done := make(chan struct{})
+	s.stdin = stdinPipe
+	s.stdout = scanner
+	s.stderr = stderr
 	s.proc = &procHandle{cmd: cmd}
 	s.started = true
-	return nil
+	s.turnDone = done
+	return turnState{stdinPipe, scanner, s.proc, stderr, done}, nil
 }
 
 // Send writes a query to stdin and returns a channel of parsed events.
 func (s *SubprocessClient) Send(ctx context.Context, query string) (<-chan interface{}, error) {
-	if err := s.start(); err != nil {
+	s.mu.Lock()
+	st, err := s.startLocked()
+	debug := s.debug
+	s.mu.Unlock()
+	if err != nil {
 		return nil, err
 	}
 
-	if _, err := fmt.Fprintln(s.stdin, query); err != nil {
+	if _, err := fmt.Fprintln(st.stdin, query); err != nil {
 		return nil, fmt.Errorf("failed to write to agent stdin: %w", err)
 	}
-
-	// Capture references under lock so the goroutine doesn't race with Close().
-	s.mu.Lock()
-	scanner := s.stdout
-	proc := s.proc
-	stderrBuf := s.stderr
-	debug := s.debug
-	s.mu.Unlock()
 
 	ch := make(chan interface{}, 32)
 
 	// A cancelled turn must actually stop the child. Abandoning the read while
 	// the agent keeps writing leaves the tail of this turn's output in the pipe,
-	// which the NEXT turn would read as its own — so the process is killed and
-	// respawned instead.
-	turnDone := make(chan struct{})
+	// which the NEXT turn would read as its own. Kill only — the reader reaps.
 	go func() {
 		select {
 		case <-ctx.Done():
-			s.terminate()
-		case <-turnDone:
+			st.proc.kill()
+		case <-st.turnDone:
 		}
 	}()
 
 	go func() {
 		defer close(ch)
-		defer close(turnDone)
+		defer close(st.turnDone)
 
+		// Registered last so it runs FIRST: every exit path from this goroutine
+		// — including the early returns mid-loop — must reset the client when the
+		// turn was cancelled, or the next Send reuses the child we just killed
+		// and reads nothing.
+		defer func() {
+			if ctx.Err() != nil {
+				st.proc.reap()
+				s.discard(st.proc)
+			}
+		}()
+
+		// Deterministic: once the turn is cancelled nothing is pushed into the
+		// abandoned channel. Selecting on both a ready send and a ready
+		// ctx.Done() would pick randomly and leak events into the next turn.
 		emit := func(evt interface{}) bool {
+			if ctx.Err() != nil {
+				return false
+			}
 			select {
 			case ch <- evt:
 				return true
@@ -184,23 +218,23 @@ func (s *SubprocessClient) Send(ctx context.Context, query string) (<-chan inter
 			}
 		}
 
-		for scanner.Scan() {
-			line := scanner.Bytes()
+		for st.scanner.Scan() {
+			line := st.scanner.Bytes()
 			if len(line) == 0 {
 				continue
 			}
 
-			evt, err := event.ParseEvent(line)
-			if err != nil {
+			evt, perr := event.ParseEvent(line)
+			if perr != nil {
 				// Visible, not dropped: a status warning keeps the turn alive
 				// while making a bad producer obvious.
 				if debug {
-					fmt.Fprintf(os.Stderr, "[DEBUG] parse error: %v (line: %s)\n", err, string(line))
+					fmt.Fprintf(os.Stderr, "[DEBUG] parse error: %v (line: %s)\n", perr, string(line))
 				}
 				if !emit(event.StatusEvent{
 					Type:    "status",
 					Status:  "warning",
-					Message: fmt.Sprintf("unreadable agent event (%v): %s", err, truncateLine(string(line))),
+					Message: fmt.Sprintf("unreadable agent event (%v): %s", perr, truncateLine(string(line))),
 				}) {
 					return
 				}
@@ -227,8 +261,14 @@ func (s *SubprocessClient) Send(ctx context.Context, query string) (<-chan inter
 			}
 		}
 
-		// Scanner stopped — check for read errors or unexpected process exit.
-		if err := scanner.Err(); err != nil {
+		// The read is over, so reaping is safe from here on. A cancelled turn
+		// killed the child on purpose: a dead child is the expected outcome, not
+		// an error to report, and the deferred reset above respawns next time.
+		if ctx.Err() != nil {
+			return
+		}
+
+		if err := st.scanner.Err(); err != nil {
 			emit(event.AgentErrorEvent{
 				Type:    "agent_error",
 				Content: fmt.Sprintf("agent stdout read error: %v", err),
@@ -236,10 +276,12 @@ func (s *SubprocessClient) Send(ctx context.Context, query string) (<-chan inter
 			return
 		}
 
-		// Process exited — reap it to get the exit code, then report if non-zero.
-		state := proc.wait()
+		// The child exited on its own — reap it for the exit code and report a
+		// non-zero one. The next Send respawns.
+		state := st.proc.reap()
+		s.discard(st.proc)
 		if state != nil && !state.Success() {
-			stderrContent := stderrBuf.String()
+			stderrContent := st.stderr.String()
 			msg := fmt.Sprintf("agent process exited with code %d", state.ExitCode())
 			if stderrContent != "" {
 				msg += "\n" + stderrContent
@@ -254,42 +296,66 @@ func (s *SubprocessClient) Send(ctx context.Context, query string) (<-chan inter
 	return ch, nil
 }
 
-// detach clears the client's process state and hands back what it was holding.
-func (s *SubprocessClient) detach() (*procHandle, io.WriteCloser) {
+// discard clears the client's process state, but only if it still refers to
+// proc — a newer Send may already have respawned.
+func (s *SubprocessClient) discard(proc *procHandle) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-
-	proc, stdin := s.proc, s.stdin
+	if s.proc != proc {
+		return
+	}
 	s.proc = nil
 	s.stdin = nil
 	s.stdout = nil
 	s.stderr = nil
 	s.started = false
-	return proc, stdin
-}
-
-// terminate kills the child and resets the client so the next Send respawns it
-// against a clean pipe.
-func (s *SubprocessClient) terminate() {
-	proc, stdin := s.detach()
-	if stdin != nil {
-		stdin.Close()
-	}
-	if proc != nil {
-		proc.kill()
-	}
+	s.turnDone = nil
 }
 
 // Close terminates the subprocess.
 func (s *SubprocessClient) Close() error {
-	proc, stdin := s.detach()
-	// Close stdin to signal EOF to the child process.
+	s.mu.Lock()
+	if !s.started {
+		s.mu.Unlock()
+		return nil
+	}
+	proc, stdin, turnDone := s.proc, s.stdin, s.turnDone
+	s.proc = nil
+	s.stdin = nil
+	s.stdout = nil
+	s.stderr = nil
+	s.started = false
+	s.turnDone = nil
+	s.mu.Unlock()
+
+	// Closing stdin is how a well-behaved agent is asked to exit.
 	if stdin != nil {
 		stdin.Close()
 	}
-	if proc != nil {
-		proc.wait()
+	if proc == nil {
+		return nil
 	}
+
+	// If a turn's reader is still in flight it owns the reap (os/exec forbids
+	// Wait before reads complete), so wait for it rather than racing it.
+	if turnDone != nil {
+		select {
+		case <-turnDone:
+		case <-time.After(closeGrace):
+			// The agent ignored EOF. Kill it and let the reader finish.
+			proc.kill()
+			select {
+			case <-turnDone:
+			case <-time.After(closeGrace):
+				// The reader is wedged; leave the child to the OS rather than
+				// calling Wait underneath an active read.
+				return nil
+			}
+		}
+		return nil
+	}
+
+	proc.reap()
 	return nil
 }
 

--- a/tui/internal/client/subprocess_test.go
+++ b/tui/internal/client/subprocess_test.go
@@ -6,9 +6,11 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"testing"
 	"time"
 
+	"github.com/amd/gaia/tui/internal/daemon"
 	"github.com/amd/gaia/tui/internal/event"
 )
 
@@ -68,7 +70,7 @@ func main() {
 func TestSubprocessClient_SendReceivesEvents(t *testing.T) {
 	bin := buildMockAgent(t)
 
-	c := NewSubprocessClient(bin, true)
+	c := NewSubprocessClient(bin, nil, true)
 	defer c.Close()
 
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
@@ -119,7 +121,7 @@ func TestSubprocessClient_SendReceivesEvents(t *testing.T) {
 func TestSubprocessClient_MultiTurn(t *testing.T) {
 	bin := buildMockAgent(t)
 
-	c := NewSubprocessClient(bin, false)
+	c := NewSubprocessClient(bin, nil, false)
 	defer c.Close()
 
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
@@ -153,7 +155,7 @@ func TestSubprocessClient_MultiTurn(t *testing.T) {
 }
 
 func TestSubprocessClient_InvalidCommand(t *testing.T) {
-	c := NewSubprocessClient("nonexistent_binary_xyz_12345", false)
+	c := NewSubprocessClient("nonexistent_binary_xyz_12345", nil, false)
 	defer c.Close()
 
 	ctx := context.Background()
@@ -163,8 +165,8 @@ func TestSubprocessClient_InvalidCommand(t *testing.T) {
 	}
 }
 
-func TestSubprocessClient_EmptyCommand(t *testing.T) {
-	c := NewSubprocessClient("", false)
+func TestSubprocessClient_EmptyBinaryPath(t *testing.T) {
+	c := NewSubprocessClient("", nil, false)
 
 	ctx := context.Background()
 	_, err := c.Send(ctx, "hello")
@@ -174,7 +176,7 @@ func TestSubprocessClient_EmptyCommand(t *testing.T) {
 }
 
 func TestSubprocessClient_CloseBeforeSend(t *testing.T) {
-	c := NewSubprocessClient("echo", false)
+	c := NewSubprocessClient("echo", nil, false)
 
 	// Close without ever starting should be a no-op.
 	if err := c.Close(); err != nil {
@@ -211,7 +213,7 @@ func main() { os.Exit(1) }
 		t.Fatalf("build exit agent: %v\n%s", err, out)
 	}
 
-	c := NewSubprocessClient(binPath, false)
+	c := NewSubprocessClient(binPath, nil, false)
 	defer c.Close()
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
@@ -239,3 +241,197 @@ func main() { os.Exit(1) }
 
 // Verify the interface is satisfied at compile time.
 var _ AgentClient = (*SubprocessClient)(nil)
+
+// buildAgentFrom compiles src into dir and returns the binary path.
+func buildAgentFrom(t *testing.T, dir, name, src string) string {
+	t.Helper()
+
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", dir, err)
+	}
+	srcPath := filepath.Join(dir, name+".go")
+	if err := os.WriteFile(srcPath, []byte(src), 0644); err != nil {
+		t.Fatalf("write %s: %v", srcPath, err)
+	}
+
+	binName := name
+	if runtime.GOOS == "windows" {
+		binName += ".exe"
+	}
+	binPath := filepath.Join(dir, binName)
+
+	goExe := "go"
+	if p, err := exec.LookPath("go"); err == nil {
+		goExe = p
+	}
+	cmd := exec.Command(goExe, "build", "-o", binPath, srcPath)
+	cmd.Env = append(os.Environ(), "CGO_ENABLED=0")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("build %s: %v\n%s", name, err, out)
+	}
+	return binPath
+}
+
+const echoAgentSrc = `package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	scanner := bufio.NewScanner(os.Stdin)
+	for scanner.Scan() {
+		fmt.Println("{\"type\":\"answer\",\"content\":\"ok\",\"steps\":1,\"tools_used\":0}")
+	}
+}
+`
+
+// A path containing a space used to be re-split on whitespace, so the binary
+// could never be found.
+func TestSubprocessClient_BinaryPathWithSpaces(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "My Agents")
+	bin := buildAgentFrom(t, dir, "spaced_agent", echoAgentSrc)
+	if !strings.Contains(bin, " ") {
+		t.Fatalf("test setup: expected a space in %q", bin)
+	}
+
+	c := NewSubprocessClient(bin, nil, false)
+	defer c.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	ch, err := c.Send(ctx, "hello")
+	if err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+	var got []interface{}
+	for evt := range ch {
+		got = append(got, evt)
+	}
+	if len(got) != 1 {
+		t.Fatalf("expected 1 event, got %d: %+v", len(got), got)
+	}
+	if _, ok := got[0].(event.AnswerEvent); !ok {
+		t.Fatalf("expected AnswerEvent, got %T", got[0])
+	}
+}
+
+const slowAgentSrc = `package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"time"
+)
+
+func main() {
+	scanner := bufio.NewScanner(os.Stdin)
+	for scanner.Scan() {
+		fmt.Println("{\"type\":\"step\",\"step\":1,\"total\":2,\"status\":\"running\"}")
+		time.Sleep(30 * time.Second)
+		fmt.Println("{\"type\":\"answer\",\"content\":\"late\",\"steps\":1,\"tools_used\":0}")
+	}
+}
+`
+
+// Cancelling a turn must stop the child. Leaving it alive lets the tail of this
+// turn's output surface as the NEXT turn's events.
+func TestSubprocessClient_CancelKillsChild(t *testing.T) {
+	bin := buildAgentFrom(t, t.TempDir(), "slow_agent", slowAgentSrc)
+
+	c := NewSubprocessClient(bin, nil, false)
+	defer c.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	ch, err := c.Send(ctx, "start")
+	if err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+	if _, ok := <-ch; !ok {
+		t.Fatal("expected the first event before cancelling")
+	}
+
+	c.mu.Lock()
+	pid := c.proc.cmd.Process.Pid
+	c.mu.Unlock()
+
+	cancel()
+	for range ch { // drain
+	}
+
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		c.mu.Lock()
+		started := c.started
+		c.mu.Unlock()
+		if !started {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("client still holds a started process 5s after cancellation")
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+
+	if daemon.PIDAlive(pid) {
+		t.Errorf("child pid %d is still alive after cancellation", pid)
+	}
+}
+
+const garbageAgentSrc = `package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	scanner := bufio.NewScanner(os.Stdin)
+	for scanner.Scan() {
+		fmt.Println("this is not json at all")
+		fmt.Println("{\"type\":\"brand_new_type\"}")
+		fmt.Println("{\"type\":\"answer\",\"content\":\"done\",\"steps\":1,\"tools_used\":0}")
+	}
+}
+`
+
+// An unreadable line must be surfaced, not silently dropped, and must not end
+// the turn.
+func TestSubprocessClient_UnparseableLineIsVisible(t *testing.T) {
+	bin := buildAgentFrom(t, t.TempDir(), "garbage_agent", garbageAgentSrc)
+
+	c := NewSubprocessClient(bin, nil, false)
+	defer c.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	ch, err := c.Send(ctx, "hello")
+	if err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+
+	var warnings int
+	var answered bool
+	for evt := range ch {
+		switch e := evt.(type) {
+		case event.StatusEvent:
+			if e.Status == "warning" {
+				warnings++
+			}
+		case event.AnswerEvent:
+			answered = true
+		}
+	}
+	if warnings != 2 {
+		t.Errorf("expected 2 warning status events (bad JSON + unknown type), got %d", warnings)
+	}
+	if !answered {
+		t.Error("the turn must still reach its answer after an unreadable line")
+	}
+}

--- a/tui/internal/client/subprocess_test.go
+++ b/tui/internal/client/subprocess_test.go
@@ -435,3 +435,69 @@ func TestSubprocessClient_UnparseableLineIsVisible(t *testing.T) {
 		t.Error("the turn must still reach its answer after an unreadable line")
 	}
 }
+
+// A cancelled turn kills the child on purpose, so the resulting non-zero exit /
+// closed pipe must NOT surface as an agent error — that put a spurious
+// "exited with code -1" bubble under the "cancelled" line about half the time.
+func TestSubprocessClient_CancelEmitsNoSpuriousError(t *testing.T) {
+	bin := buildAgentFrom(t, t.TempDir(), "slow_cancel_agent", slowAgentSrc)
+
+	const runs = 8
+	for i := 0; i < runs; i++ {
+		c := NewSubprocessClient(bin, nil, false)
+		ctx, cancel := context.WithCancel(context.Background())
+
+		ch, err := c.Send(ctx, "start")
+		if err != nil {
+			t.Fatalf("run %d: Send: %v", i, err)
+		}
+		if _, ok := <-ch; !ok {
+			t.Fatalf("run %d: expected an event before cancelling", i)
+		}
+		cancel()
+
+		for evt := range ch {
+			if ae, ok := evt.(event.AgentErrorEvent); ok {
+				t.Fatalf("run %d: cancelling emitted a spurious agent error: %q", i, ae.Content)
+			}
+		}
+		c.Close()
+	}
+}
+
+// The turn after a cancel must respawn cleanly: the cancel path clears the
+// client's pipes from another goroutine, so an unsynchronised read of them in
+// Send was both a data race and a nil-deref.
+func TestSubprocessClient_SendAfterCancelRespawns(t *testing.T) {
+	bin := buildAgentFrom(t, t.TempDir(), "respawn_agent", echoAgentSrc)
+
+	c := NewSubprocessClient(bin, nil, false)
+	defer c.Close()
+
+	for i := 0; i < 10; i++ {
+		ctx, cancel := context.WithCancel(context.Background())
+		ch, err := c.Send(ctx, "cancel me")
+		if err != nil {
+			t.Fatalf("iteration %d: Send: %v", i, err)
+		}
+		cancel()
+		for range ch {
+		}
+
+		// A full turn immediately afterwards, while the cancel teardown may
+		// still be running.
+		ch2, err := c.Send(context.Background(), "real turn")
+		if err != nil {
+			t.Fatalf("iteration %d: Send after cancel: %v", i, err)
+		}
+		var answered bool
+		for evt := range ch2 {
+			if _, ok := evt.(event.AnswerEvent); ok {
+				answered = true
+			}
+		}
+		if !answered {
+			t.Fatalf("iteration %d: the turn after a cancel produced no answer", i)
+		}
+	}
+}

--- a/tui/internal/control/doc.go
+++ b/tui/internal/control/doc.go
@@ -1,0 +1,32 @@
+// Package control exposes a loopback HTTP API that drives the *running* TUI.
+//
+// It is not a headless replica: keys and text are injected into the live
+// [tea.Program] with Send, and the screen served back is the exact frame the
+// human at the keyboard is looking at. That makes it possible for an assistant
+// to navigate the TUI while the user watches the same session.
+//
+// The server binds 127.0.0.1 only, requires a bearer token on every request,
+// and advertises itself through ~/.gaia/tui/control.json (mode 0600) so a
+// client can find it without a fixed port.
+package control
+
+const (
+	// ServiceID identifies this server in the discovery file and /status so a
+	// client can tell a recycled port from a real TUI.
+	ServiceID = "gaia-tui-control"
+
+	// APIVersion is the wire contract version carried in the URL and /status.
+	APIVersion = "v1"
+
+	// APIPrefix is the common prefix for every control endpoint.
+	APIPrefix = "/control/v1"
+
+	// AuthScheme is the Authorization header scheme clients must use.
+	AuthScheme = "Bearer"
+
+	// Host is the only interface the control server ever binds.
+	Host = "127.0.0.1"
+
+	// ReservedPort is never bound. 4001 is reserved repo-wide.
+	ReservedPort = 4001
+)

--- a/tui/internal/control/keys.go
+++ b/tui/internal/control/keys.go
@@ -1,0 +1,145 @@
+package control
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+// namedKeys maps a key name to the tea.KeyType that produces it.
+//
+// The names are taken from bubbletea itself (KeyType.String()), so
+// KeyMsgFor(name).String() round-trips back to name for every entry. That is
+// the property the TUI's own handlers switch on — HubModel.handleKey compares
+// msg.String() against "tab", "shift+tab", "enter" and friends — so a name that
+// does not round-trip would silently do the wrong thing. The round-trip is
+// asserted in TestKeyNamesRoundTrip.
+var namedKeys = map[string]tea.KeyType{}
+
+// keyAliases maps caller-friendly spellings to a canonical name in namedKeys.
+var keyAliases = map[string]string{
+	"escape":    "esc",
+	"return":    "enter",
+	"pageup":    "pgup",
+	"page_up":   "pgup",
+	"pgdn":      "pgdown",
+	"pagedown":  "pgdown",
+	"page_down": "pgdown",
+	"del":       "delete",
+	"space":     " ",
+	"spacebar":  " ",
+	"ins":       "insert",
+	"bs":        "backspace",
+}
+
+func init() {
+	keyTypes := []tea.KeyType{
+		tea.KeyEnter, tea.KeyEsc, tea.KeyTab, tea.KeyShiftTab, tea.KeyBackspace,
+		tea.KeyUp, tea.KeyDown, tea.KeyLeft, tea.KeyRight,
+		tea.KeyPgUp, tea.KeyPgDown, tea.KeyHome, tea.KeyEnd,
+		tea.KeyDelete, tea.KeyInsert, tea.KeySpace,
+		tea.KeyCtrlA, tea.KeyCtrlB, tea.KeyCtrlC, tea.KeyCtrlD, tea.KeyCtrlE,
+		tea.KeyCtrlF, tea.KeyCtrlG, tea.KeyCtrlJ, tea.KeyCtrlK, tea.KeyCtrlL,
+		tea.KeyCtrlN, tea.KeyCtrlO, tea.KeyCtrlP, tea.KeyCtrlQ, tea.KeyCtrlR,
+		tea.KeyCtrlS, tea.KeyCtrlT, tea.KeyCtrlU, tea.KeyCtrlV, tea.KeyCtrlW,
+		tea.KeyCtrlX, tea.KeyCtrlY, tea.KeyCtrlZ,
+		tea.KeyCtrlUp, tea.KeyCtrlDown, tea.KeyCtrlLeft, tea.KeyCtrlRight,
+		tea.KeyCtrlHome, tea.KeyCtrlEnd, tea.KeyCtrlPgUp, tea.KeyCtrlPgDown,
+		tea.KeyShiftUp, tea.KeyShiftDown, tea.KeyShiftLeft, tea.KeyShiftRight,
+		tea.KeyShiftHome, tea.KeyShiftEnd,
+		tea.KeyF1, tea.KeyF2, tea.KeyF3, tea.KeyF4, tea.KeyF5, tea.KeyF6,
+		tea.KeyF7, tea.KeyF8, tea.KeyF9, tea.KeyF10, tea.KeyF11, tea.KeyF12,
+	}
+	for _, kt := range keyTypes {
+		name := kt.String()
+		if name == "" {
+			// A bubbletea upgrade dropped a name we depend on. Fail at startup
+			// rather than silently accepting a key that maps to nothing.
+			panic(fmt.Sprintf("control: bubbletea KeyType %d has no name", int(kt)))
+		}
+		namedKeys[name] = kt
+	}
+}
+
+// KeyMsgFor converts a key name into the tea.KeyMsg the TUI's handlers expect.
+//
+// Accepted forms, in precedence order:
+//
+//	named key   "enter", "esc", "tab", "shift+tab", "up", "pgdown", "ctrl+c", "f5"
+//	alias       "escape", "return", "pgdn", "pageup", "space", "del"
+//	alt+<rune>  "alt+x"  (a single rune with the Alt modifier)
+//	single rune "?", "/", "q", "Y"  (case is preserved)
+//
+// A three-letter name like "tab" is the Tab key, never the runes t-a-b. Sending
+// runes is what POST /control/v1/text is for.
+func KeyMsgFor(name string) (tea.KeyMsg, error) {
+	if name == "" {
+		return tea.KeyMsg{}, fmt.Errorf("empty key name")
+	}
+
+	// Checked before trimming: a lone " " is bubbletea's own name for the space
+	// key, and trimming would turn it into an empty, unmatchable name.
+	if name == " " {
+		return tea.KeyMsg{Type: tea.KeySpace, Runes: []rune{' '}}, nil
+	}
+
+	lookup := strings.ToLower(strings.TrimSpace(name))
+	if canonical, ok := keyAliases[lookup]; ok {
+		lookup = canonical
+	}
+	if kt, ok := namedKeys[lookup]; ok {
+		if kt == tea.KeySpace {
+			// bubbles' text inputs insert from Runes, not from the type, so a
+			// bare KeySpace types nothing at all.
+			return tea.KeyMsg{Type: tea.KeySpace, Runes: []rune{' '}}, nil
+		}
+		return tea.KeyMsg{Type: kt}, nil
+	}
+
+	if strings.HasPrefix(lookup, "alt+") {
+		runes := []rune(strings.TrimPrefix(strings.TrimSpace(name), "alt+"))
+		if len(runes) != 1 {
+			return tea.KeyMsg{}, fmt.Errorf("%q is not a supported key: alt+ accepts exactly one character (e.g. \"alt+x\")", name)
+		}
+		return tea.KeyMsg{Type: tea.KeyRunes, Runes: runes, Alt: true}, nil
+	}
+
+	// Case is preserved for literal characters: "Y" and "y" are different keys
+	// to a confirmation dialog.
+	if runes := []rune(strings.TrimSpace(name)); len(runes) == 1 {
+		return tea.KeyMsg{Type: tea.KeyRunes, Runes: runes}, nil
+	}
+
+	return tea.KeyMsg{}, fmt.Errorf("%q is not a supported key name; pass a single character to type it, or one of: %s",
+		name, strings.Join(SupportedKeys(), ", "))
+}
+
+// SupportedKeys lists every named key, sorted, for error messages and docs.
+func SupportedKeys() []string {
+	names := make([]string, 0, len(namedKeys)+len(keyAliases))
+	for name := range namedKeys {
+		if name == " " {
+			name = "space"
+		}
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
+}
+
+// TextKeyMsgs converts a string into one KeyMsg per rune, which is how a human
+// typing at the keyboard reaches the model.
+func TextKeyMsgs(text string) []tea.KeyMsg {
+	runes := []rune(text)
+	msgs := make([]tea.KeyMsg, 0, len(runes))
+	for _, r := range runes {
+		if r == ' ' {
+			msgs = append(msgs, tea.KeyMsg{Type: tea.KeySpace, Runes: []rune{' '}})
+			continue
+		}
+		msgs = append(msgs, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{r}})
+	}
+	return msgs
+}

--- a/tui/internal/control/keys_test.go
+++ b/tui/internal/control/keys_test.go
@@ -1,0 +1,186 @@
+package control
+
+import (
+	"strings"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+// TestKeyNamesRoundTrip is the contract test: the TUI's own handlers switch on
+// tea.KeyMsg.String(), so every name we accept must produce a message whose
+// String() is that same name. A name that does not round-trip silently does
+// something else.
+func TestKeyNamesRoundTrip(t *testing.T) {
+	for _, name := range SupportedKeys() {
+		msg, err := KeyMsgFor(name)
+		if err != nil {
+			t.Fatalf("KeyMsgFor(%q) returned an error: %v", name, err)
+		}
+		want := name
+		if name == "space" {
+			want = " " // bubbletea's own name for KeySpace
+		}
+		if got := msg.String(); got != want {
+			t.Errorf("KeyMsgFor(%q).String() = %q, want %q", name, got, want)
+		}
+	}
+}
+
+// TestNamedKeysAreNotRunes pins the bug the existing smoke tests contain:
+// tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("tab")} is the three runes
+// t-a-b, not the Tab key, so HubModel.handleKey never sees "tab".
+func TestNamedKeysAreNotRunes(t *testing.T) {
+	for _, name := range []string{"tab", "enter", "esc", "up", "down", "pgup", "delete"} {
+		msg, err := KeyMsgFor(name)
+		if err != nil {
+			t.Fatalf("KeyMsgFor(%q): %v", name, err)
+		}
+		if msg.Type == tea.KeyRunes {
+			t.Errorf("KeyMsgFor(%q) produced KeyRunes %q — that is the literal characters, not the key", name, string(msg.Runes))
+		}
+		if len(msg.Runes) != 0 {
+			t.Errorf("KeyMsgFor(%q) carried runes %q; a named key carries none", name, string(msg.Runes))
+		}
+	}
+}
+
+// TestSpaceKeyCarriesItsRune pins a bug that answers 200 while typing nothing:
+// bubbles' textinput/textarea insert from msg.Runes, so a KeySpace with no
+// runes is silently dropped and the caller sees a success response.
+func TestSpaceKeyCarriesItsRune(t *testing.T) {
+	for _, name := range []string{"space", "spacebar", " "} {
+		msg, err := KeyMsgFor(name)
+		if err != nil {
+			t.Fatalf("KeyMsgFor(%q): %v", name, err)
+		}
+		if msg.Type != tea.KeySpace {
+			t.Errorf("KeyMsgFor(%q).Type = %d, want KeySpace", name, msg.Type)
+		}
+		if len(msg.Runes) != 1 || msg.Runes[0] != ' ' {
+			t.Errorf("KeyMsgFor(%q).Runes = %q, want a single space — text inputs insert from Runes", name, string(msg.Runes))
+		}
+	}
+}
+
+func TestKeyMsgForSupportedNames(t *testing.T) {
+	cases := []struct {
+		name     string
+		wantType tea.KeyType
+		wantStr  string
+	}{
+		{"enter", tea.KeyEnter, "enter"},
+		{"esc", tea.KeyEsc, "esc"},
+		{"escape", tea.KeyEsc, "esc"},
+		{"return", tea.KeyEnter, "enter"},
+		{"tab", tea.KeyTab, "tab"},
+		{"shift+tab", tea.KeyShiftTab, "shift+tab"},
+		{"up", tea.KeyUp, "up"},
+		{"down", tea.KeyDown, "down"},
+		{"left", tea.KeyLeft, "left"},
+		{"right", tea.KeyRight, "right"},
+		{"pgup", tea.KeyPgUp, "pgup"},
+		{"pgdn", tea.KeyPgDown, "pgdown"},
+		{"pgdown", tea.KeyPgDown, "pgdown"},
+		{"pageup", tea.KeyPgUp, "pgup"},
+		{"pagedown", tea.KeyPgDown, "pgdown"},
+		{"backspace", tea.KeyBackspace, "backspace"},
+		{"delete", tea.KeyDelete, "delete"},
+		{"del", tea.KeyDelete, "delete"},
+		{"home", tea.KeyHome, "home"},
+		{"end", tea.KeyEnd, "end"},
+		{"ctrl+c", tea.KeyCtrlC, "ctrl+c"},
+		{"ctrl+d", tea.KeyCtrlD, "ctrl+d"},
+		{"CTRL+C", tea.KeyCtrlC, "ctrl+c"},
+		{"space", tea.KeySpace, " "},
+		{"f5", tea.KeyF5, "f5"},
+		{"?", tea.KeyRunes, "?"},
+		{"/", tea.KeyRunes, "/"},
+		{"q", tea.KeyRunes, "q"},
+		{"v", tea.KeyRunes, "v"},
+	}
+	for _, tc := range cases {
+		msg, err := KeyMsgFor(tc.name)
+		if err != nil {
+			t.Errorf("KeyMsgFor(%q): %v", tc.name, err)
+			continue
+		}
+		if msg.Type != tc.wantType {
+			t.Errorf("KeyMsgFor(%q).Type = %d, want %d", tc.name, msg.Type, tc.wantType)
+		}
+		if got := msg.String(); got != tc.wantStr {
+			t.Errorf("KeyMsgFor(%q).String() = %q, want %q", tc.name, got, tc.wantStr)
+		}
+	}
+}
+
+func TestKeyMsgForPreservesCase(t *testing.T) {
+	upper, err := KeyMsgFor("Y")
+	if err != nil {
+		t.Fatalf("KeyMsgFor(\"Y\"): %v", err)
+	}
+	if upper.String() != "Y" {
+		t.Errorf("KeyMsgFor(\"Y\").String() = %q, want %q — a confirm dialog treats Y and y differently", upper.String(), "Y")
+	}
+}
+
+func TestKeyMsgForAlt(t *testing.T) {
+	msg, err := KeyMsgFor("alt+x")
+	if err != nil {
+		t.Fatalf("KeyMsgFor(\"alt+x\"): %v", err)
+	}
+	if !msg.Alt || msg.String() != "alt+x" {
+		t.Errorf("KeyMsgFor(\"alt+x\") = %+v (String %q), want the Alt modifier", msg, msg.String())
+	}
+	if _, err := KeyMsgFor("alt+abc"); err == nil {
+		t.Error("KeyMsgFor(\"alt+abc\") should be rejected — alt+ takes exactly one character")
+	}
+}
+
+func TestKeyMsgForRejectsUnknown(t *testing.T) {
+	for _, name := range []string{"", "supertab", "ctrl+shift+meta+q", "hyper"} {
+		_, err := KeyMsgFor(name)
+		if err == nil {
+			t.Errorf("KeyMsgFor(%q) should have failed", name)
+			continue
+		}
+		if name != "" && !strings.Contains(err.Error(), name) {
+			t.Errorf("KeyMsgFor(%q) error %q should quote the offending name", name, err)
+		}
+	}
+}
+
+func TestTextKeyMsgs(t *testing.T) {
+	msgs := TextKeyMsgs("hi there")
+	if len(msgs) != len("hi there") {
+		t.Fatalf("TextKeyMsgs produced %d messages, want %d", len(msgs), len("hi there"))
+	}
+	var got strings.Builder
+	for _, m := range msgs {
+		got.WriteString(m.String())
+	}
+	if got.String() != "hi there" {
+		t.Errorf("TextKeyMsgs round-trip = %q, want %q", got.String(), "hi there")
+	}
+	// The space must arrive as KeySpace with its rune set — that is what
+	// bubbles/textarea inserts from.
+	space := msgs[2]
+	if space.Type != tea.KeySpace || len(space.Runes) != 1 || space.Runes[0] != ' ' {
+		t.Errorf("space key = %+v, want KeySpace carrying ' '", space)
+	}
+}
+
+func TestSupportedKeysIncludesTheDocumentedSet(t *testing.T) {
+	supported := map[string]bool{}
+	for _, name := range SupportedKeys() {
+		supported[name] = true
+	}
+	for _, required := range []string{
+		"enter", "esc", "tab", "shift+tab", "up", "down", "left", "right",
+		"pgup", "pgdown", "backspace", "ctrl+c", "ctrl+d", "space",
+	} {
+		if !supported[required] {
+			t.Errorf("SupportedKeys() is missing %q", required)
+		}
+	}
+}

--- a/tui/internal/control/paths.go
+++ b/tui/internal/control/paths.go
@@ -1,0 +1,161 @@
+package control
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// EnvHome overrides the directory holding control.json. Tests set it so a run
+// never clobbers the user's real TUI registration, and so concurrent tests stay
+// isolated. Read on every call — never cached — so a subprocess spawned with a
+// different environment resolves its own directory.
+const EnvHome = "GAIA_TUI_HOME"
+
+// Info is the discovery record persisted to control.json.
+type Info struct {
+	PID        int     `json:"pid"`
+	Port       int     `json:"port"`
+	Token      string  `json:"token"`
+	Host       string  `json:"host"`
+	Service    string  `json:"service"`
+	APIVersion string  `json:"api_version"`
+	StartedAt  float64 `json:"started_at"`
+	Version    string  `json:"version"`
+}
+
+// Dir returns the directory holding control.json.
+func Dir() (string, error) {
+	if override := os.Getenv(EnvHome); override != "" {
+		return override, nil
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("cannot locate the home directory for %s: %w (set %s to choose one explicitly)", filepath.Join("~", ".gaia", "tui"), err, EnvHome)
+	}
+	return filepath.Join(home, ".gaia", "tui"), nil
+}
+
+// FilePath returns the full path of the discovery file.
+func FilePath() (string, error) {
+	dir, err := Dir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(dir, "control.json"), nil
+}
+
+// WriteInfo persists info to control.json at mode 0600.
+//
+// Written to a uniquely named temp file in the same directory, fsynced, then
+// renamed over the target, so a crash mid-write can never leave a half-written
+// (and therefore trusted) file. The temp file is created O_EXCL at 0600 so the
+// token is never briefly world-readable.
+func WriteInfo(info Info) error {
+	path, err := FilePath()
+	if err != nil {
+		return err
+	}
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return fmt.Errorf("cannot create %s: %w", dir, err)
+	}
+
+	payload, err := json.MarshalIndent(info, "", "  ")
+	if err != nil {
+		return fmt.Errorf("cannot encode the control discovery record: %w", err)
+	}
+
+	tmp := filepath.Join(dir, fmt.Sprintf(".control.json.%d.tmp", os.Getpid()))
+	// Clear a leftover temp from a prior crashed writer with the same pid, so
+	// the O_EXCL create below always makes a fresh file at 0600 rather than
+	// failing (or, without O_EXCL, inheriting the old file's permissions).
+	if err := os.Remove(tmp); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("cannot clear the stale temp file %s: %w", tmp, err)
+	}
+	f, err := os.OpenFile(tmp, os.O_WRONLY|os.O_CREATE|os.O_EXCL|os.O_TRUNC, 0o600)
+	if err != nil {
+		return fmt.Errorf("cannot create %s: %w", tmp, err)
+	}
+	if _, err := f.Write(payload); err != nil {
+		f.Close()
+		os.Remove(tmp)
+		return fmt.Errorf("cannot write %s: %w", tmp, err)
+	}
+	if err := f.Sync(); err != nil {
+		f.Close()
+		os.Remove(tmp)
+		return fmt.Errorf("cannot flush %s: %w", tmp, err)
+	}
+	if err := f.Close(); err != nil {
+		os.Remove(tmp)
+		return fmt.Errorf("cannot close %s: %w", tmp, err)
+	}
+	if err := os.Rename(tmp, path); err != nil {
+		os.Remove(tmp)
+		return fmt.Errorf("cannot install %s: %w", path, err)
+	}
+	// Rename preserves the temp's mode on POSIX; re-assert for platforms where
+	// it is not carried across.
+	if err := os.Chmod(path, 0o600); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("cannot restrict permissions on %s: %w", path, err)
+	}
+	return nil
+}
+
+// ReadInfo loads control.json. A missing file returns (nil, nil) — that is the
+// normal "no TUI is running" answer, not an error.
+func ReadInfo() (*Info, error) {
+	path, err := FilePath()
+	if err != nil {
+		return nil, err
+	}
+	raw, err := os.ReadFile(path) // #nosec G304 -- path is derived from the user's home dir
+	if os.IsNotExist(err) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("cannot read %s: %w", path, err)
+	}
+	var info Info
+	if err := json.Unmarshal(raw, &info); err != nil {
+		return nil, fmt.Errorf("%s is present but malformed: %w", path, err)
+	}
+	return &info, nil
+}
+
+// RemoveInfo deletes control.json, but only when it still records onlyPID — so
+// a shutting-down TUI never clobbers the registration of a newer one that
+// already reclaimed the slot.
+func RemoveInfo(onlyPID int) error {
+	path, err := FilePath()
+	if err != nil {
+		return err
+	}
+	info, err := ReadInfo()
+	if err != nil {
+		return err
+	}
+	if info == nil {
+		return nil
+	}
+	if info.PID != onlyPID {
+		return nil
+	}
+	if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("cannot remove %s: %w", path, err)
+	}
+	return nil
+}
+
+// newToken mints a 256-bit bearer token. Never logged, never printed.
+func newToken() (string, error) {
+	buf := make([]byte, 32)
+	if _, err := rand.Read(buf); err != nil {
+		return "", fmt.Errorf("cannot generate a control auth token: %w", err)
+	}
+	return hex.EncodeToString(buf), nil
+}

--- a/tui/internal/control/server.go
+++ b/tui/internal/control/server.go
@@ -1,0 +1,911 @@
+package control
+
+import (
+	"context"
+	"crypto/subtle"
+	"encoding/json"
+	"fmt"
+	"net"
+	"net/http"
+	"os"
+	"sort"
+	"strconv"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+// Sender is the subset of *tea.Program the control server needs. Program.Send
+// is safe to call from another goroutine — that is the whole injection
+// mechanism — and narrowing it to an interface keeps the server testable
+// without booting a terminal.
+type Sender interface {
+	Send(tea.Msg)
+}
+
+// Options configures the control server.
+type Options struct {
+	// Port to bind. 0 auto-assigns. 4001 is rejected — it is reserved.
+	Port int
+	// Debug mirrors the TUI's --debug flag: every injected key, every state
+	// transition, and every wait resolution is logged to stderr.
+	Debug bool
+	// Version is reported by /status and written to the discovery file.
+	Version string
+}
+
+// Server is the running control API.
+type Server struct {
+	http     *http.Server
+	listener net.Listener
+	state    *State
+	sender   Sender
+	token    string
+	port     int
+	pid      int
+	version  string
+	debugf   func(format string, args ...any)
+	// done is closed by Stop so parked /wait handlers return immediately
+	// instead of holding the shutdown open for their full timeout.
+	done     chan struct{}
+	stopOnce sync.Once
+
+	// discoveryPath is resolved at Start so the caller never has to re-resolve
+	// (and handle a second error) between Start and Run.
+	discoveryPath string
+
+	// running reports whether the Bubble Tea event loop is consuming messages.
+	// tea.Program.Send DISCARDS messages once the program's context is done, so
+	// without this a request to a quit TUI would answer 200 for keys that went
+	// nowhere.
+	running atomic.Bool
+
+	// injectMu serializes injection so one caller's batch is applied as a unit
+	// and marks stay ordered. Two concurrent /keys calls would otherwise
+	// interleave, and the later mark could satisfy the earlier waiter.
+	injectMu sync.Mutex
+}
+
+// renderSettleTimeout bounds how long a mutating endpoint waits for the model
+// to re-render before answering. It exists so "send keys, then read the screen"
+// does not race the render; it is not a retry loop.
+const renderSettleTimeout = 250 * time.Millisecond
+
+// defaultWaitTimeout applies when POST /wait omits timeout_ms.
+const defaultWaitTimeout = 30 * time.Second
+
+// maxWaitTimeout caps POST /wait so a caller cannot pin a connection forever.
+const maxWaitTimeout = 10 * time.Minute
+
+// Debugf returns a logger honouring opts.Debug, for the caller to share with
+// NewState so the recorder and the server log through the same switch.
+func Debugf(debug bool) func(format string, args ...any) {
+	if !debug {
+		return func(string, ...any) {}
+	}
+	return func(format string, args ...any) {
+		fmt.Fprintf(os.Stderr, "[control] "+format+"\n", args...)
+	}
+}
+
+// Start binds the control API on loopback and registers it for discovery.
+//
+// The returned Server must be stopped with Stop so the discovery file does not
+// outlive the TUI.
+func Start(sender Sender, state *State, opts Options) (*Server, error) {
+	if sender == nil {
+		return nil, fmt.Errorf("control: no tea.Program to drive; the control server must be started after the program is created")
+	}
+	if state == nil {
+		return nil, fmt.Errorf("control: no shared state; wrap the root model with control.NewRecorder first")
+	}
+	if opts.Port == ReservedPort {
+		return nil, fmt.Errorf("control: port %d is reserved and must never be bound; pick another --control-port or drop the flag to auto-assign", ReservedPort)
+	}
+
+	listener, err := listen(opts.Port)
+	if err != nil {
+		return nil, err
+	}
+	port := listener.Addr().(*net.TCPAddr).Port
+
+	token, err := newToken()
+	if err != nil {
+		listener.Close()
+		return nil, err
+	}
+
+	debugf := Debugf(opts.Debug)
+	version := opts.Version
+	if version == "" {
+		version = "dev"
+	}
+
+	s := &Server{
+		listener: listener,
+		state:    state,
+		sender:   sender,
+		token:    token,
+		port:     port,
+		pid:      os.Getpid(),
+		version:  version,
+		debugf:   debugf,
+		done:     make(chan struct{}),
+	}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc(APIPrefix+"/status", s.auth(s.handleStatus))
+	mux.HandleFunc(APIPrefix+"/screen", s.auth(s.handleScreen))
+	mux.HandleFunc(APIPrefix+"/keys", s.auth(s.handleKeys))
+	mux.HandleFunc(APIPrefix+"/text", s.auth(s.handleText))
+	mux.HandleFunc(APIPrefix+"/wait", s.auth(s.handleWait))
+	mux.HandleFunc(APIPrefix+"/frames", s.auth(s.handleFrames))
+	mux.HandleFunc(APIPrefix+"/resize", s.auth(s.handleResize))
+	// Unknown paths answer in the same error envelope as everything else, so a
+	// typo'd endpoint is a readable message rather than Go's HTML 404 page.
+	mux.HandleFunc("/", s.auth(s.handleNotFound))
+
+	s.http = &http.Server{
+		Handler:           mux,
+		ReadHeaderTimeout: 10 * time.Second,
+	}
+
+	// Resolved before anything is published, so a failure here cannot leave a
+	// discovery file pointing at a server we then tear down.
+	path, err := FilePath()
+	if err != nil {
+		listener.Close()
+		return nil, err
+	}
+	s.discoveryPath = path
+
+	info := Info{
+		PID:        s.pid,
+		Port:       port,
+		Token:      token,
+		Host:       Host,
+		Service:    ServiceID,
+		APIVersion: APIVersion,
+		StartedAt:  float64(time.Now().UnixNano()) / 1e9,
+		Version:    version,
+	}
+	if err := WriteInfo(info); err != nil {
+		listener.Close()
+		return nil, fmt.Errorf("control: cannot publish the discovery file: %w", err)
+	}
+
+	go func() {
+		err := s.http.Serve(listener)
+		if err != nil && err != http.ErrServerClosed {
+			// The TUI keeps running, but nothing can drive it any more — say so
+			// rather than leaving the caller waiting on a dead socket.
+			fmt.Fprintf(os.Stderr, "control API stopped serving: %v — restart the TUI to re-enable it\n", err)
+		}
+	}()
+
+	s.debugf("listening on %s:%d (discovery file %s, token withheld)", Host, port, path)
+	return s, nil
+}
+
+// DiscoveryPath is where this server published its control.json.
+func (s *Server) DiscoveryPath() string { return s.discoveryPath }
+
+// MarkRunning must be called immediately before the Bubble Tea program starts
+// consuming messages, and MarkStopped once Run returns. Injection endpoints
+// refuse while the loop is not running rather than reporting a success for
+// messages tea.Program silently discards.
+func (s *Server) MarkRunning() { s.running.Store(true) }
+func (s *Server) MarkStopped() { s.running.Store(false) }
+
+// listen binds loopback, never the reserved port.
+func listen(port int) (net.Listener, error) {
+	if port != 0 {
+		l, err := net.Listen("tcp", fmt.Sprintf("%s:%d", Host, port))
+		if err != nil {
+			return nil, fmt.Errorf("control: cannot bind %s:%d: %w (is another TUI already running with --control-port %d?)", Host, port, err, port)
+		}
+		return l, nil
+	}
+	// Auto-assign, retrying in the vanishingly unlikely case the kernel hands
+	// out the reserved port.
+	for attempt := 0; attempt < 8; attempt++ {
+		l, err := net.Listen("tcp", Host+":0")
+		if err != nil {
+			return nil, fmt.Errorf("control: cannot bind an auto-assigned port on %s: %w", Host, err)
+		}
+		if l.Addr().(*net.TCPAddr).Port != ReservedPort {
+			return l, nil
+		}
+		l.Close()
+	}
+	return nil, fmt.Errorf("control: the kernel kept handing out the reserved port %d; pass an explicit --control-port", ReservedPort)
+}
+
+// Port is the bound port.
+func (s *Server) Port() int { return s.port }
+
+// BaseURL is the control API root.
+func (s *Server) BaseURL() string { return fmt.Sprintf("http://%s:%d", Host, s.port) }
+
+// Token is the bearer token. Exposed for in-process tests only — it is never
+// printed to the terminal and never logged.
+func (s *Server) Token() string { return s.token }
+
+// Stop shuts the listener down and removes the discovery file.
+func (s *Server) Stop() error {
+	s.stopOnce.Do(func() { close(s.done) })
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	shutdownErr := s.http.Shutdown(ctx)
+	removeErr := RemoveInfo(s.pid)
+	s.debugf("stopped")
+	if shutdownErr != nil {
+		return fmt.Errorf("control: shutdown failed: %w", shutdownErr)
+	}
+	if removeErr != nil {
+		return removeErr
+	}
+	return nil
+}
+
+// ── plumbing ────────────────────────────────────────────────────────
+
+type apiError struct {
+	Code      string    `json:"code"`
+	Message   string    `json:"message"`
+	Hint      string    `json:"hint,omitempty"`
+	Screen    string    `json:"screen,omitempty"`
+	ElapsedMS int64     `json:"elapsed_ms,omitempty"`
+	State     *Snapshot `json:"state,omitempty"`
+}
+
+func writeJSON(w http.ResponseWriter, status int, payload any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	if err := json.NewEncoder(w).Encode(payload); err != nil {
+		// The response is already committed; nothing actionable remains but to
+		// leave a trace for whoever reads the log.
+		fmt.Fprintf(os.Stderr, "[control] failed to encode response: %v\n", err)
+	}
+}
+
+func writeErr(w http.ResponseWriter, status int, e apiError) {
+	writeJSON(w, status, map[string]apiError{"error": e})
+}
+
+func (s *Server) auth(next http.HandlerFunc) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		header := r.Header.Get("Authorization")
+		prefix := AuthScheme + " "
+		ok := strings.HasPrefix(header, prefix) &&
+			subtle.ConstantTimeCompare([]byte(strings.TrimPrefix(header, prefix)), []byte(s.token)) == 1
+		if !ok {
+			s.debugf("rejected %s %s: bad or missing token", r.Method, r.URL.Path)
+			writeErr(w, http.StatusUnauthorized, apiError{
+				Code:    "unauthorized",
+				Message: "missing or invalid bearer token",
+				Hint:    "send Authorization: Bearer <token>, reading the token from the TUI control discovery file",
+			})
+			return
+		}
+		next(w, r)
+	}
+}
+
+func (s *Server) decode(w http.ResponseWriter, r *http.Request, dst any) bool {
+	if r.Method != http.MethodPost {
+		writeErr(w, http.StatusMethodNotAllowed, apiError{
+			Code:    "method_not_allowed",
+			Message: fmt.Sprintf("%s requires POST, got %s", r.URL.Path, r.Method),
+		})
+		return false
+	}
+	dec := json.NewDecoder(http.MaxBytesReader(w, r.Body, 1<<20))
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(dst); err != nil {
+		writeErr(w, http.StatusBadRequest, apiError{
+			Code:    "bad_request",
+			Message: fmt.Sprintf("cannot parse the request body: %v", err),
+			Hint:    "send a JSON object with only the documented fields",
+		})
+		return false
+	}
+	return true
+}
+
+func (s *Server) requireGet(w http.ResponseWriter, r *http.Request) bool {
+	if r.Method != http.MethodGet {
+		writeErr(w, http.StatusMethodNotAllowed, apiError{
+			Code:    "method_not_allowed",
+			Message: fmt.Sprintf("%s requires GET, got %s", r.URL.Path, r.Method),
+		})
+		return false
+	}
+	return true
+}
+
+// send injects msgs into the live program and waits for them to be handled and
+// rendered, so a caller that immediately reads /screen sees the whole batch.
+//
+// Program.Send only queues the message, so waiting for "some newer frame" is
+// not enough: a spinner tick, or the first key of a three-key batch, satisfies
+// it while the rest are still in flight. A trailing MarkMsg is queued behind
+// the batch, and Bubble Tea's in-order processing makes "the mark has been
+// rendered" mean "every key before it has been handled and drawn".
+func (s *Server) send(msgs []tea.Msg, delay time.Duration) (seq int, settled bool) {
+	s.injectMu.Lock()
+	mark := s.state.NextMark()
+	for i, msg := range msgs {
+		if i > 0 && delay > 0 {
+			time.Sleep(delay)
+		}
+		s.sender.Send(msg)
+	}
+	s.sender.Send(MarkMsg{ID: mark})
+	s.injectMu.Unlock()
+	return s.settle(mark)
+}
+
+// injectable reports whether the program can receive messages, writing the
+// refusal itself when it cannot.
+func (s *Server) injectable(w http.ResponseWriter) bool {
+	if s.running.Load() {
+		return true
+	}
+	s.debugf("refused injection: the Bubble Tea program is not consuming messages")
+	writeErr(w, http.StatusServiceUnavailable, apiError{
+		Code: "not_running",
+		Message: "the TUI is not accepting input: its event loop is not running " +
+			"(it is still starting up, or the user has quit it)",
+		Hint: "check GET " + APIPrefix + "/status; if running is false, start a new TUI with the control API enabled",
+	})
+	return false
+}
+
+// settle waits up to renderSettleTimeout for the batch's mark to be rendered.
+// settled=false means the model was too busy to confirm within the window — the
+// keys are queued, but the caller must re-read the screen rather than assume.
+func (s *Server) settle(mark int64) (seq int, settled bool) {
+	deadline := time.Now().Add(renderSettleTimeout)
+	for {
+		ch := s.state.Changed()
+		_, seq, _ = s.state.Current()
+		if s.state.RenderedMark() >= mark {
+			return seq, true
+		}
+		remaining := time.Until(deadline)
+		if remaining <= 0 {
+			s.debugf("settle: mark %d not rendered within %s; the program may be busy", mark, renderSettleTimeout)
+			return seq, false
+		}
+		timer := time.NewTimer(remaining)
+		select {
+		case <-ch:
+		case <-timer.C:
+		}
+		timer.Stop()
+	}
+}
+
+// ── handlers ────────────────────────────────────────────────────────
+
+func (s *Server) handleStatus(w http.ResponseWriter, r *http.Request) {
+	if !s.requireGet(w, r) {
+		return
+	}
+	_, seq, snap := s.state.Current()
+	cols, rows := s.state.Size()
+	if snap.VisibleAgentIDs == nil {
+		snap.VisibleAgentIDs = []string{}
+	}
+	writeJSON(w, http.StatusOK, map[string]any{
+		"service":     ServiceID,
+		"api_version": APIVersion,
+		"version":     s.version,
+		"pid":         s.pid,
+		"running":     s.running.Load(),
+		"uptime_ms":   s.state.UptimeMS(),
+		"cols":        cols,
+		"rows":        rows,
+		"frame_seq":   seq,
+		"state":       snap,
+	})
+}
+
+func (s *Server) handleScreen(w http.ResponseWriter, r *http.Request) {
+	if !s.requireGet(w, r) {
+		return
+	}
+	format := r.URL.Query().Get("format")
+	if format == "" {
+		format = "plain"
+	}
+	if format != "plain" && format != "ansi" {
+		writeErr(w, http.StatusBadRequest, apiError{
+			Code:    "bad_format",
+			Message: fmt.Sprintf("unknown format %q", format),
+			Hint:    "use format=plain (ANSI stripped, the default) or format=ansi",
+		})
+		return
+	}
+	raw, seq, _ := s.state.Current()
+	screen := raw
+	if format == "plain" {
+		screen = PlainScreen(raw)
+	}
+	cols, rows := s.state.Size()
+	writeJSON(w, http.StatusOK, map[string]any{
+		"format": format,
+		"seq":    seq,
+		"cols":   cols,
+		"rows":   rows,
+		"lines":  countLines(screen),
+		"screen": screen,
+	})
+}
+
+type keysRequest struct {
+	Keys    []string `json:"keys"`
+	DelayMS int      `json:"delay_ms"`
+}
+
+func (s *Server) handleKeys(w http.ResponseWriter, r *http.Request) {
+	var req keysRequest
+	if !s.decode(w, r, &req) {
+		return
+	}
+	if len(req.Keys) == 0 {
+		writeErr(w, http.StatusBadRequest, apiError{
+			Code:    "no_keys",
+			Message: "keys is empty",
+			Hint:    `send {"keys": ["tab", "down", "enter"]}`,
+		})
+		return
+	}
+	if len(req.Keys) > 100 {
+		writeErr(w, http.StatusBadRequest, apiError{
+			Code:    "too_many_keys",
+			Message: fmt.Sprintf("%d keys in one request; the cap is 100", len(req.Keys)),
+			Hint:    "split the sequence across several calls, reading the screen in between",
+		})
+		return
+	}
+	if err := checkDelayBudget(req.DelayMS, len(req.Keys)); err != nil {
+		writeErr(w, http.StatusBadRequest, *err)
+		return
+	}
+
+	msgs := make([]tea.Msg, 0, len(req.Keys))
+	for _, name := range req.Keys {
+		key, err := KeyMsgFor(name)
+		if err != nil {
+			writeErr(w, http.StatusBadRequest, apiError{
+				Code:    "unknown_key",
+				Message: err.Error(),
+				Hint:    "supported names: " + strings.Join(SupportedKeys(), ", "),
+			})
+			return
+		}
+		msgs = append(msgs, key)
+	}
+
+	if !s.injectable(w) {
+		return
+	}
+	s.debugf("inject: keys %v (delay %dms)", req.Keys, req.DelayMS)
+	seq, settled := s.send(msgs, time.Duration(req.DelayMS)*time.Millisecond)
+	writeJSON(w, http.StatusOK, map[string]any{
+		"sent":    len(msgs),
+		"keys":    req.Keys,
+		"seq":     seq,
+		"settled": settled,
+	})
+}
+
+type textRequest struct {
+	Text    string `json:"text"`
+	DelayMS int    `json:"delay_ms"`
+}
+
+func (s *Server) handleText(w http.ResponseWriter, r *http.Request) {
+	var req textRequest
+	if !s.decode(w, r, &req) {
+		return
+	}
+	if req.Text == "" {
+		writeErr(w, http.StatusBadRequest, apiError{
+			Code:    "no_text",
+			Message: "text is empty",
+			Hint:    `send {"text": "triage my inbox"}`,
+		})
+		return
+	}
+	if err := checkDelayBudget(req.DelayMS, len([]rune(req.Text))); err != nil {
+		writeErr(w, http.StatusBadRequest, *err)
+		return
+	}
+
+	keys := TextKeyMsgs(req.Text)
+	msgs := make([]tea.Msg, 0, len(keys))
+	for _, k := range keys {
+		msgs = append(msgs, k)
+	}
+	if !s.injectable(w) {
+		return
+	}
+	s.debugf("inject: text %q (%d runes)", req.Text, len(keys))
+	seq, settled := s.send(msgs, time.Duration(req.DelayMS)*time.Millisecond)
+	writeJSON(w, http.StatusOK, map[string]any{
+		"sent_runes": len(keys),
+		"seq":        seq,
+		"settled":    settled,
+	})
+}
+
+type waitRequest struct {
+	Contains string         `json:"contains"`
+	Absent   string         `json:"absent"`
+	State    map[string]any `json:"state"`
+	// Pointer so "omitted" (use the default) is distinguishable from an
+	// explicit 0, which is a client bug: the caller's own HTTP timeout would be
+	// far shorter than the wait, turning a reportable 408 into a dead socket.
+	TimeoutMS *int `json:"timeout_ms"`
+}
+
+func (s *Server) handleWait(w http.ResponseWriter, r *http.Request) {
+	var req waitRequest
+	if !s.decode(w, r, &req) {
+		return
+	}
+	if req.Contains == "" && req.Absent == "" && len(req.State) == 0 {
+		writeErr(w, http.StatusBadRequest, apiError{
+			Code:    "no_condition",
+			Message: "nothing to wait for",
+			Hint:    `pass "contains", "absent", or "state" (they are ANDed)`,
+		})
+		return
+	}
+	if err := validateStateMatcher(req.State); err != nil {
+		writeErr(w, http.StatusBadRequest, apiError{
+			Code:    "bad_state_matcher",
+			Message: err.Error(),
+			Hint:    "supported state keys: " + strings.Join(stateMatcherKeys(), ", "),
+		})
+		return
+	}
+
+	timeout := defaultWaitTimeout
+	if req.TimeoutMS != nil {
+		if *req.TimeoutMS <= 0 {
+			writeErr(w, http.StatusBadRequest, apiError{
+				Code:    "bad_timeout",
+				Message: fmt.Sprintf("timeout_ms must be positive, got %d", *req.TimeoutMS),
+				Hint:    fmt.Sprintf("omit timeout_ms for the %s default, or pass a positive value up to %s", defaultWaitTimeout, maxWaitTimeout),
+			})
+			return
+		}
+		timeout = time.Duration(*req.TimeoutMS) * time.Millisecond
+	}
+	if timeout > maxWaitTimeout {
+		writeErr(w, http.StatusBadRequest, apiError{
+			Code:    "timeout_too_long",
+			Message: fmt.Sprintf("timeout_ms %d exceeds the %s cap", *req.TimeoutMS, maxWaitTimeout),
+		})
+		return
+	}
+
+	start := time.Now()
+	deadline := start.Add(timeout)
+	for {
+		// Take the wakeup channel BEFORE checking, or a change landing between
+		// the check and the select is lost and the wait hangs to its deadline.
+		ch := s.state.Changed()
+		raw, seq, snap := s.state.Current()
+		screen := PlainScreen(raw)
+		if matchesWait(req, screen, snap) {
+			elapsed := time.Since(start).Milliseconds()
+			s.debugf("wait: matched after %dms (seq %d)", elapsed, seq)
+			writeJSON(w, http.StatusOK, map[string]any{
+				"matched":    true,
+				"elapsed_ms": elapsed,
+				"seq":        seq,
+				"state":      snap,
+				"screen":     screen,
+			})
+			return
+		}
+
+		remaining := time.Until(deadline)
+		if remaining <= 0 {
+			elapsed := time.Since(start).Milliseconds()
+			s.debugf("wait: TIMEOUT after %dms; condition %s; screen was:\n%s",
+				elapsed, describeWait(req), screen)
+			writeErr(w, http.StatusRequestTimeout, apiError{
+				Code:      "wait_timeout",
+				Message:   fmt.Sprintf("timed out after %dms waiting for %s", elapsed, describeWait(req)),
+				Hint:      "the screen field shows what the TUI was actually displaying when the wait expired",
+				Screen:    screen,
+				ElapsedMS: elapsed,
+				State:     &snap,
+			})
+			return
+		}
+
+		timer := time.NewTimer(remaining)
+		select {
+		case <-ch:
+		case <-timer.C:
+		case <-r.Context().Done():
+			timer.Stop()
+			s.debugf("wait: client disconnected after %dms", time.Since(start).Milliseconds())
+			return
+		case <-s.done:
+			timer.Stop()
+			s.debugf("wait: aborted after %dms — the TUI is shutting down", time.Since(start).Milliseconds())
+			writeErr(w, http.StatusServiceUnavailable, apiError{
+				Code:    "shutting_down",
+				Message: "the GAIA TUI is shutting down, so the wait was abandoned",
+				Hint:    "start a new TUI with the control API enabled before driving it again",
+				Screen:  screen,
+			})
+			return
+		}
+		timer.Stop()
+	}
+}
+
+func (s *Server) handleFrames(w http.ResponseWriter, r *http.Request) {
+	if !s.requireGet(w, r) {
+		return
+	}
+	since, err := intParam(r, "since", 0)
+	if err != nil {
+		writeErr(w, http.StatusBadRequest, apiError{Code: "bad_param", Message: err.Error()})
+		return
+	}
+	limit, err := intParam(r, "limit", 20)
+	if err != nil {
+		writeErr(w, http.StatusBadRequest, apiError{Code: "bad_param", Message: err.Error()})
+		return
+	}
+	frames, latest, truncated := s.state.Frames(since, limit)
+	if frames == nil {
+		frames = []Frame{}
+	}
+	writeJSON(w, http.StatusOK, map[string]any{
+		"frames":     frames,
+		"latest_seq": latest,
+		"truncated":  truncated,
+	})
+}
+
+type resizeRequest struct {
+	Cols int `json:"cols"`
+	Rows int `json:"rows"`
+}
+
+func (s *Server) handleResize(w http.ResponseWriter, r *http.Request) {
+	var req resizeRequest
+	if !s.decode(w, r, &req) {
+		return
+	}
+	if req.Cols < 20 || req.Cols > 500 || req.Rows < 5 || req.Rows > 200 {
+		writeErr(w, http.StatusBadRequest, apiError{
+			Code:    "bad_size",
+			Message: fmt.Sprintf("%dx%d is out of range", req.Cols, req.Rows),
+			Hint:    "cols must be 20-500 and rows 5-200",
+		})
+		return
+	}
+	if !s.injectable(w) {
+		return
+	}
+	s.debugf("inject: resize %dx%d", req.Cols, req.Rows)
+	seq, settled := s.send([]tea.Msg{tea.WindowSizeMsg{Width: req.Cols, Height: req.Rows}}, 0)
+	cols, rows := s.state.Size()
+	if settled && (cols != req.Cols || rows != req.Rows) {
+		// The model was reached but is laid out for a different size — report
+		// it rather than echoing numbers that imply the resize took.
+		writeErr(w, http.StatusConflict, apiError{
+			Code: "resize_not_applied",
+			Message: fmt.Sprintf("asked for %dx%d but the TUI is laid out for %dx%d",
+				req.Cols, req.Rows, cols, rows),
+			Hint: "a real terminal resize may have overridden it; try again",
+		})
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{
+		"cols":    cols,
+		"rows":    rows,
+		"seq":     seq,
+		"settled": settled,
+	})
+}
+
+func (s *Server) handleNotFound(w http.ResponseWriter, r *http.Request) {
+	writeErr(w, http.StatusNotFound, apiError{
+		Code:    "not_found",
+		Message: fmt.Sprintf("no control endpoint at %s", r.URL.Path),
+		Hint: "available endpoints: " + strings.Join([]string{
+			"GET " + APIPrefix + "/status",
+			"GET " + APIPrefix + "/screen",
+			"POST " + APIPrefix + "/keys",
+			"POST " + APIPrefix + "/text",
+			"POST " + APIPrefix + "/wait",
+			"GET " + APIPrefix + "/frames",
+			"POST " + APIPrefix + "/resize",
+		}, ", "),
+	})
+}
+
+// maxInjectionDelay bounds how long one request may spend typing. Clients set
+// their HTTP timeout from a fixed budget, so an unbounded delay_ms * count
+// would time the caller out mid-batch and leave it unable to tell what landed.
+const maxInjectionDelay = 10 * time.Second
+
+func checkDelayBudget(delayMS, count int) *apiError {
+	if delayMS < 0 || delayMS > 2000 {
+		return &apiError{
+			Code:    "bad_delay",
+			Message: fmt.Sprintf("delay_ms %d is out of range", delayMS),
+			Hint:    "delay_ms must be between 0 and 2000",
+		}
+	}
+	total := time.Duration(delayMS) * time.Millisecond * time.Duration(max(count-1, 0))
+	if total > maxInjectionDelay {
+		return &apiError{
+			Code: "delay_budget_exceeded",
+			Message: fmt.Sprintf("delay_ms %d across %d items would take %s, over the %s cap",
+				delayMS, count, total, maxInjectionDelay),
+			Hint: "lower delay_ms or split the batch, so the request finishes inside the client's timeout",
+		}
+	}
+	return nil
+}
+
+// ── matching ────────────────────────────────────────────────────────
+
+func matchesWait(req waitRequest, screen string, snap Snapshot) bool {
+	if req.Contains != "" && !strings.Contains(screen, req.Contains) {
+		return false
+	}
+	if req.Absent != "" && strings.Contains(screen, req.Absent) {
+		return false
+	}
+	for key, want := range req.State {
+		if !matchesStateKey(key, want, snap) {
+			return false
+		}
+	}
+	return true
+}
+
+func matchesStateKey(key string, want any, snap Snapshot) bool {
+	switch key {
+	case "view":
+		return want == snap.View
+	case "agent":
+		return want == snap.Agent
+	case "hub_tab":
+		return want == snap.HubTab
+	case "selected_agent_id":
+		return want == snap.SelectedAgentID
+	case "overlay":
+		return want == snap.Overlay
+	case "streaming":
+		return want == snap.Streaming
+	case "filtering":
+		return want == snap.Filtering
+	case "can_return_to_hub":
+		return want == snap.CanReturnToHub
+	case "hub_tab_index":
+		n, ok := want.(float64)
+		return ok && int(n) == snap.HubTabIndex
+	case "visible_contains":
+		s, ok := want.(string)
+		if !ok {
+			return false
+		}
+		for _, id := range snap.VisibleAgentIDs {
+			if id == s {
+				return true
+			}
+		}
+		return false
+	}
+	return false
+}
+
+// stateMatcherTypes documents the accepted type for each state matcher key, so
+// a typo or a wrong type is a 400 instead of a wait that can never succeed.
+var stateMatcherTypes = map[string]string{
+	"view":              "string",
+	"agent":             "string",
+	"hub_tab":           "string",
+	"selected_agent_id": "string",
+	"overlay":           "string",
+	"visible_contains":  "string",
+	"streaming":         "bool",
+	"filtering":         "bool",
+	"can_return_to_hub": "bool",
+	"hub_tab_index":     "number",
+}
+
+func stateMatcherKeys() []string {
+	keys := make([]string, 0, len(stateMatcherTypes))
+	for k := range stateMatcherTypes {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+func validateStateMatcher(matcher map[string]any) error {
+	for key, want := range matcher {
+		wantType, ok := stateMatcherTypes[key]
+		if !ok {
+			return fmt.Errorf("unknown state key %q", key)
+		}
+		switch wantType {
+		case "string":
+			if _, ok := want.(string); !ok {
+				return fmt.Errorf("state key %q expects a string, got %T", key, want)
+			}
+		case "bool":
+			if _, ok := want.(bool); !ok {
+				return fmt.Errorf("state key %q expects a boolean, got %T", key, want)
+			}
+		case "number":
+			if _, ok := want.(float64); !ok {
+				return fmt.Errorf("state key %q expects a number, got %T", key, want)
+			}
+		}
+	}
+	return nil
+}
+
+func describeWait(req waitRequest) string {
+	var parts []string
+	if req.Contains != "" {
+		parts = append(parts, fmt.Sprintf("screen containing %q", req.Contains))
+	}
+	if req.Absent != "" {
+		parts = append(parts, fmt.Sprintf("screen no longer containing %q", req.Absent))
+	}
+	keys := make([]string, 0, len(req.State))
+	for k := range req.State {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	for _, k := range keys {
+		parts = append(parts, fmt.Sprintf("state %s=%v", k, req.State[k]))
+	}
+	return strings.Join(parts, " and ")
+}
+
+// countLines reports rendered lines; an empty screen is 0, not the 1 that a
+// naive Split would report.
+func countLines(screen string) int {
+	if screen == "" {
+		return 0
+	}
+	return strings.Count(screen, "\n") + 1
+}
+
+func intParam(r *http.Request, name string, def int) (int, error) {
+	raw := r.URL.Query().Get(name)
+	if raw == "" {
+		return def, nil
+	}
+	n, err := strconv.Atoi(raw)
+	if err != nil {
+		return 0, fmt.Errorf("%s must be an integer, got %q", name, raw)
+	}
+	if n < 0 {
+		return 0, fmt.Errorf("%s must not be negative, got %d", name, n)
+	}
+	return n, nil
+}

--- a/tui/internal/control/server_test.go
+++ b/tui/internal/control/server_test.go
@@ -1,0 +1,919 @@
+package control
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"runtime"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+// ── harness ─────────────────────────────────────────────────────────
+
+// testModel is a stand-in root model: it echoes what it received and reports a
+// snapshot, which is all the control API reads.
+type testModel struct {
+	lines []string
+	snap  Snapshot
+}
+
+func newTestModel() testModel {
+	return testModel{
+		lines: []string{"GAIA Agent Hub"},
+		snap: Snapshot{
+			View:            "hub",
+			HubTab:          "Installed",
+			SelectedAgentID: "bash",
+			VisibleAgentIDs: []string{"bash", "email"},
+		},
+	}
+}
+
+func (m testModel) Init() tea.Cmd { return nil }
+
+func (m testModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	lines := append([]string{}, m.lines...)
+	switch msg := msg.(type) {
+	case tea.KeyMsg:
+		lines = append(lines, "key:"+msg.String())
+		switch msg.String() {
+		case "enter":
+			m.snap = Snapshot{View: "chat", Agent: "email"}
+		case "esc":
+			m.snap = newTestModel().snap
+		case "tab":
+			m.snap.HubTabIndex++
+			m.snap.HubTab = fmt.Sprintf("Tab%d", m.snap.HubTabIndex)
+		}
+	case tea.WindowSizeMsg:
+		lines = append(lines, fmt.Sprintf("size:%dx%d", msg.Width, msg.Height))
+	}
+	m.lines = lines
+	return m, nil
+}
+
+func (m testModel) View() string { return strings.Join(m.lines, "\n") }
+
+func (m testModel) ControlSnapshot() Snapshot { return m.snap }
+
+// fakeProgram stands in for *tea.Program: Send only QUEUES the message, and a
+// separate goroutine runs the Update+View loop — the same asynchrony the real
+// program has. A synchronous fake would hide every settle/ordering bug, which
+// is exactly the class of bug this server has to get right.
+type fakeProgram struct {
+	msgs  chan tea.Msg
+	done  chan struct{}
+	stop  chan struct{}
+	model tea.Model
+
+	// delay is applied before each message is processed, to widen the window a
+	// caller could observe a half-applied batch in.
+	delay time.Duration
+}
+
+func newFakeProgram(model tea.Model, delay time.Duration) *fakeProgram {
+	f := &fakeProgram{
+		msgs:  make(chan tea.Msg, 256),
+		done:  make(chan struct{}),
+		stop:  make(chan struct{}),
+		model: model,
+		delay: delay,
+	}
+	go f.loop()
+	return f
+}
+
+func (f *fakeProgram) loop() {
+	defer close(f.done)
+	for {
+		select {
+		case <-f.stop:
+			return
+		case msg := <-f.msgs:
+			if f.delay > 0 {
+				time.Sleep(f.delay)
+			}
+			next, _ := f.model.Update(msg)
+			f.model = next
+			_ = next.View() // the event loop renders after every message
+		}
+	}
+}
+
+func (f *fakeProgram) Send(msg tea.Msg) { f.msgs <- msg }
+
+func (f *fakeProgram) Close() {
+	close(f.stop)
+	<-f.done
+}
+
+func newTestServer(t *testing.T) (*Server, *State) {
+	t.Helper()
+	t.Setenv(EnvHome, t.TempDir())
+
+	return newTestServerWithDelay(t, 0)
+}
+
+func newTestServerWithDelay(t *testing.T, delay time.Duration) (*Server, *State) {
+	t.Helper()
+	state := NewState(nil)
+	rec := NewRecorder(newTestModel(), state)
+	prog := newFakeProgram(rec, delay)
+	_ = rec.View() // seed the first frame, as the event loop does on start
+
+	srv, err := Start(prog, state, Options{Version: "test"})
+	if err != nil {
+		prog.Close()
+		t.Fatalf("Start: %v", err)
+	}
+	// Mirrors app.go: the event loop is running, so injection is allowed.
+	srv.MarkRunning()
+	t.Cleanup(func() {
+		srv.MarkStopped()
+		if err := srv.Stop(); err != nil {
+			t.Errorf("Stop: %v", err)
+		}
+		prog.Close()
+	})
+	return srv, state
+}
+
+func request(t *testing.T, srv *Server, method, path string, body any, token string) (int, map[string]any) {
+	t.Helper()
+	var reader io.Reader
+	if body != nil {
+		raw, err := json.Marshal(body)
+		if err != nil {
+			t.Fatalf("marshal request: %v", err)
+		}
+		reader = bytes.NewReader(raw)
+	}
+	req, err := http.NewRequest(method, srv.BaseURL()+APIPrefix+path, reader)
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	if token != "" {
+		req.Header.Set("Authorization", AuthScheme+" "+token)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("%s %s: %v", method, path, err)
+	}
+	defer resp.Body.Close()
+	var decoded map[string]any
+	if err := json.NewDecoder(resp.Body).Decode(&decoded); err != nil {
+		t.Fatalf("%s %s: cannot decode response: %v", method, path, err)
+	}
+	return resp.StatusCode, decoded
+}
+
+func errorField(t *testing.T, body map[string]any, field string) string {
+	t.Helper()
+	envelope, ok := body["error"].(map[string]any)
+	if !ok {
+		t.Fatalf("response has no error envelope: %v", body)
+	}
+	value, _ := envelope[field].(string)
+	return value
+}
+
+// ── auth ────────────────────────────────────────────────────────────
+
+func TestAuthRejectsMissingAndWrongToken(t *testing.T) {
+	srv, _ := newTestServer(t)
+
+	for _, tc := range []struct{ name, token string }{
+		{"no token", ""},
+		{"wrong token", "0000000000000000000000000000000000000000000000000000000000000000"},
+		{"prefix of the real token", srv.Token()[:16]},
+	} {
+		status, body := request(t, srv, http.MethodGet, "/status", nil, tc.token)
+		if status != http.StatusUnauthorized {
+			t.Errorf("%s: status = %d, want 401", tc.name, status)
+		}
+		if code := errorField(t, body, "code"); code != "unauthorized" {
+			t.Errorf("%s: error code = %q, want %q", tc.name, code, "unauthorized")
+		}
+		if hint := errorField(t, body, "hint"); !strings.Contains(hint, "Bearer") {
+			t.Errorf("%s: hint %q should name the header to send", tc.name, hint)
+		}
+	}
+}
+
+func TestAuthNeverLeaksTheToken(t *testing.T) {
+	srv, _ := newTestServer(t)
+	_, body := request(t, srv, http.MethodGet, "/status", nil, "")
+	raw, err := json.Marshal(body)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if strings.Contains(string(raw), srv.Token()) {
+		t.Error("the 401 response echoed the real token")
+	}
+}
+
+// ── status / screen ─────────────────────────────────────────────────
+
+func TestStatusReportsServiceAndState(t *testing.T) {
+	srv, _ := newTestServer(t)
+	status, body := request(t, srv, http.MethodGet, "/status", nil, srv.Token())
+	if status != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (%v)", status, body)
+	}
+	if body["service"] != ServiceID {
+		t.Errorf("service = %v, want %q", body["service"], ServiceID)
+	}
+	if body["api_version"] != APIVersion {
+		t.Errorf("api_version = %v, want %q", body["api_version"], APIVersion)
+	}
+	if body["running"] != true {
+		t.Errorf("running = %v, want true", body["running"])
+	}
+	state, ok := body["state"].(map[string]any)
+	if !ok {
+		t.Fatalf("status has no state object: %v", body)
+	}
+	if state["view"] != "hub" || state["selected_agent_id"] != "bash" {
+		t.Errorf("state = %v, want the hub view with bash selected", state)
+	}
+}
+
+func TestScreenFormats(t *testing.T) {
+	srv, state := newTestServer(t)
+	state.recordFrame("\x1b[1mAgent Hub\x1b[0m")
+
+	status, body := request(t, srv, http.MethodGet, "/screen", nil, srv.Token())
+	if status != http.StatusOK {
+		t.Fatalf("screen: status = %d (%v)", status, body)
+	}
+	if body["format"] != "plain" {
+		t.Errorf("default format = %v, want plain", body["format"])
+	}
+	if screen, _ := body["screen"].(string); screen != "Agent Hub" {
+		t.Errorf("plain screen = %q, want %q", screen, "Agent Hub")
+	}
+
+	_, ansiBody := request(t, srv, http.MethodGet, "/screen?format=ansi", nil, srv.Token())
+	if screen, _ := ansiBody["screen"].(string); !strings.Contains(screen, "\x1b[1m") {
+		t.Errorf("ansi screen = %q, want the escape sequences intact", screen)
+	}
+
+	badStatus, badBody := request(t, srv, http.MethodGet, "/screen?format=html", nil, srv.Token())
+	if badStatus != http.StatusBadRequest {
+		t.Errorf("format=html status = %d, want 400", badStatus)
+	}
+	if hint := errorField(t, badBody, "hint"); !strings.Contains(hint, "plain") {
+		t.Errorf("hint %q should name the valid formats", hint)
+	}
+}
+
+// ── keys / text / resize ────────────────────────────────────────────
+
+func TestSendKeysReachesTheModel(t *testing.T) {
+	srv, _ := newTestServer(t)
+	status, body := request(t, srv, http.MethodPost, "/keys",
+		map[string]any{"keys": []string{"tab", "down", "enter"}}, srv.Token())
+	if status != http.StatusOK {
+		t.Fatalf("keys: status = %d (%v)", status, body)
+	}
+	if body["sent"] != float64(3) {
+		t.Errorf("sent = %v, want 3", body["sent"])
+	}
+
+	_, screen := request(t, srv, http.MethodGet, "/screen", nil, srv.Token())
+	text, _ := screen["screen"].(string)
+	for _, want := range []string{"key:tab", "key:down", "key:enter"} {
+		if !strings.Contains(text, want) {
+			t.Errorf("screen %q is missing %q — the key did not reach the model as a named key", text, want)
+		}
+	}
+	if strings.Contains(text, "key:t\nkey:a\nkey:b") {
+		t.Error("\"tab\" was delivered as three runes")
+	}
+}
+
+func TestSendKeysRejectsUnknownName(t *testing.T) {
+	srv, _ := newTestServer(t)
+	status, body := request(t, srv, http.MethodPost, "/keys",
+		map[string]any{"keys": []string{"enter", "supertab"}}, srv.Token())
+	if status != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", status)
+	}
+	if code := errorField(t, body, "code"); code != "unknown_key" {
+		t.Errorf("code = %q, want unknown_key", code)
+	}
+	if msg := errorField(t, body, "message"); !strings.Contains(msg, "supertab") {
+		t.Errorf("message %q should quote the offending key", msg)
+	}
+	if hint := errorField(t, body, "hint"); !strings.Contains(hint, "shift+tab") {
+		t.Errorf("hint %q should list the supported names", hint)
+	}
+
+	// Nothing may have been injected: the whole batch is validated first.
+	_, screen := request(t, srv, http.MethodGet, "/screen", nil, srv.Token())
+	if text, _ := screen["screen"].(string); strings.Contains(text, "key:enter") {
+		t.Error("a rejected batch still injected its valid prefix")
+	}
+}
+
+func TestSendKeysValidatesShape(t *testing.T) {
+	srv, _ := newTestServer(t)
+
+	status, body := request(t, srv, http.MethodPost, "/keys", map[string]any{"keys": []string{}}, srv.Token())
+	if status != http.StatusBadRequest || errorField(t, body, "code") != "no_keys" {
+		t.Errorf("empty keys: status %d code %q, want 400/no_keys", status, errorField(t, body, "code"))
+	}
+
+	many := make([]string, 101)
+	for i := range many {
+		many[i] = "down"
+	}
+	status, body = request(t, srv, http.MethodPost, "/keys", map[string]any{"keys": many}, srv.Token())
+	if status != http.StatusBadRequest || errorField(t, body, "code") != "too_many_keys" {
+		t.Errorf("101 keys: status %d code %q, want 400/too_many_keys", status, errorField(t, body, "code"))
+	}
+
+	status, body = request(t, srv, http.MethodPost, "/keys",
+		map[string]any{"keys": []string{"down"}, "delay_ms": 9000}, srv.Token())
+	if status != http.StatusBadRequest || errorField(t, body, "code") != "bad_delay" {
+		t.Errorf("delay 9000: status %d code %q, want 400/bad_delay", status, errorField(t, body, "code"))
+	}
+
+	status, _ = request(t, srv, http.MethodGet, "/keys", nil, srv.Token())
+	if status != http.StatusMethodNotAllowed {
+		t.Errorf("GET /keys: status = %d, want 405", status)
+	}
+
+	status, body = request(t, srv, http.MethodPost, "/keys",
+		map[string]any{"keys": []string{"down"}, "typo": true}, srv.Token())
+	if status != http.StatusBadRequest {
+		t.Errorf("unknown field: status = %d, want 400 (%v)", status, body)
+	}
+}
+
+func TestSendText(t *testing.T) {
+	srv, _ := newTestServer(t)
+	status, body := request(t, srv, http.MethodPost, "/text",
+		map[string]any{"text": "hi you"}, srv.Token())
+	if status != http.StatusOK {
+		t.Fatalf("text: status = %d (%v)", status, body)
+	}
+	if body["sent_runes"] != float64(6) {
+		t.Errorf("sent_runes = %v, want 6", body["sent_runes"])
+	}
+	_, screen := request(t, srv, http.MethodGet, "/screen", nil, srv.Token())
+	text, _ := screen["screen"].(string)
+	if !strings.Contains(text, "key:h") || !strings.Contains(text, "key:y") {
+		t.Errorf("screen %q is missing the typed runes", text)
+	}
+
+	status, body = request(t, srv, http.MethodPost, "/text", map[string]any{"text": ""}, srv.Token())
+	if status != http.StatusBadRequest || errorField(t, body, "code") != "no_text" {
+		t.Errorf("empty text: status %d code %q, want 400/no_text", status, errorField(t, body, "code"))
+	}
+}
+
+func TestResize(t *testing.T) {
+	srv, _ := newTestServer(t)
+	status, body := request(t, srv, http.MethodPost, "/resize",
+		map[string]any{"cols": 120, "rows": 40}, srv.Token())
+	if status != http.StatusOK {
+		t.Fatalf("resize: status = %d (%v)", status, body)
+	}
+	if body["cols"] != float64(120) || body["rows"] != float64(40) {
+		t.Errorf("resize returned %v x %v, want 120 x 40", body["cols"], body["rows"])
+	}
+
+	_, screen := request(t, srv, http.MethodGet, "/screen", nil, srv.Token())
+	if text, _ := screen["screen"].(string); !strings.Contains(text, "size:120x40") {
+		t.Errorf("screen %q shows no resize; the model never got the WindowSizeMsg", text)
+	}
+
+	status, body = request(t, srv, http.MethodPost, "/resize",
+		map[string]any{"cols": 5, "rows": 2}, srv.Token())
+	if status != http.StatusBadRequest || errorField(t, body, "code") != "bad_size" {
+		t.Errorf("tiny size: status %d code %q, want 400/bad_size", status, errorField(t, body, "code"))
+	}
+}
+
+// ── wait ────────────────────────────────────────────────────────────
+
+func TestWaitResolvesImmediately(t *testing.T) {
+	srv, _ := newTestServer(t)
+	status, body := request(t, srv, http.MethodPost, "/wait",
+		map[string]any{"contains": "GAIA Agent Hub", "timeout_ms": 2000}, srv.Token())
+	if status != http.StatusOK {
+		t.Fatalf("wait: status = %d (%v)", status, body)
+	}
+	if body["matched"] != true {
+		t.Errorf("matched = %v, want true", body["matched"])
+	}
+}
+
+func TestWaitResolvesOnLaterChange(t *testing.T) {
+	srv, _ := newTestServer(t)
+
+	go func() {
+		time.Sleep(150 * time.Millisecond)
+		request(t, srv, http.MethodPost, "/keys", map[string]any{"keys": []string{"enter"}}, srv.Token())
+	}()
+
+	start := time.Now()
+	status, body := request(t, srv, http.MethodPost, "/wait",
+		map[string]any{"state": map[string]any{"view": "chat", "agent": "email"}, "timeout_ms": 5000}, srv.Token())
+	elapsed := time.Since(start)
+
+	if status != http.StatusOK {
+		t.Fatalf("wait: status = %d (%v)", status, body)
+	}
+	if elapsed < 100*time.Millisecond {
+		t.Errorf("wait returned in %s — it cannot have observed the change", elapsed)
+	}
+	if elapsed > 3*time.Second {
+		t.Errorf("wait took %s — it is not being woken by the state change", elapsed)
+	}
+	state, _ := body["state"].(map[string]any)
+	if state["view"] != "chat" {
+		t.Errorf("resolved state = %v, want the chat view", state)
+	}
+}
+
+func TestWaitTimeoutReportsTheActualScreen(t *testing.T) {
+	srv, _ := newTestServer(t)
+	status, body := request(t, srv, http.MethodPost, "/wait",
+		map[string]any{"contains": "Inbox triaged", "timeout_ms": 200}, srv.Token())
+	if status != http.StatusRequestTimeout {
+		t.Fatalf("status = %d, want 408 (%v)", status, body)
+	}
+	if code := errorField(t, body, "code"); code != "wait_timeout" {
+		t.Errorf("code = %q, want wait_timeout", code)
+	}
+	if msg := errorField(t, body, "message"); !strings.Contains(msg, "Inbox triaged") {
+		t.Errorf("message %q should quote what was being waited for", msg)
+	}
+	screen := errorField(t, body, "screen")
+	if !strings.Contains(screen, "GAIA Agent Hub") {
+		t.Errorf("timeout screen = %q — a timeout must report what the screen actually contained", screen)
+	}
+	envelope, _ := body["error"].(map[string]any)
+	if envelope["state"] == nil {
+		t.Error("timeout should also report the state snapshot")
+	}
+}
+
+func TestWaitAbsentMatcher(t *testing.T) {
+	srv, _ := newTestServer(t)
+	status, body := request(t, srv, http.MethodPost, "/wait",
+		map[string]any{"absent": "Loading...", "timeout_ms": 500}, srv.Token())
+	if status != http.StatusOK || body["matched"] != true {
+		t.Errorf("absent matcher: status %d matched %v, want 200/true", status, body["matched"])
+	}
+}
+
+func TestWaitValidatesMatchers(t *testing.T) {
+	srv, _ := newTestServer(t)
+
+	status, body := request(t, srv, http.MethodPost, "/wait", map[string]any{"timeout_ms": 100}, srv.Token())
+	if status != http.StatusBadRequest || errorField(t, body, "code") != "no_condition" {
+		t.Errorf("no condition: status %d code %q, want 400/no_condition", status, errorField(t, body, "code"))
+	}
+
+	status, body = request(t, srv, http.MethodPost, "/wait",
+		map[string]any{"state": map[string]any{"vieww": "hub"}}, srv.Token())
+	if status != http.StatusBadRequest || errorField(t, body, "code") != "bad_state_matcher" {
+		t.Errorf("typo'd state key: status %d code %q, want 400/bad_state_matcher", status, errorField(t, body, "code"))
+	}
+	if hint := errorField(t, body, "hint"); !strings.Contains(hint, "selected_agent_id") {
+		t.Errorf("hint %q should list the supported state keys", hint)
+	}
+
+	status, body = request(t, srv, http.MethodPost, "/wait",
+		map[string]any{"state": map[string]any{"streaming": "yes"}}, srv.Token())
+	if status != http.StatusBadRequest {
+		t.Errorf("wrong matcher type: status = %d, want 400 (%v)", status, body)
+	}
+
+	status, _ = request(t, srv, http.MethodPost, "/wait",
+		map[string]any{"contains": "x", "timeout_ms": 999999999}, srv.Token())
+	if status != http.StatusBadRequest {
+		t.Errorf("absurd timeout: status = %d, want 400", status)
+	}
+}
+
+// ── frames ──────────────────────────────────────────────────────────
+
+func TestFramesEndpoint(t *testing.T) {
+	srv, _ := newTestServer(t)
+	request(t, srv, http.MethodPost, "/keys", map[string]any{"keys": []string{"tab", "down"}}, srv.Token())
+
+	status, body := request(t, srv, http.MethodGet, "/frames?since=0&limit=50", nil, srv.Token())
+	if status != http.StatusOK {
+		t.Fatalf("frames: status = %d (%v)", status, body)
+	}
+	frames, ok := body["frames"].([]any)
+	if !ok || len(frames) < 2 {
+		t.Fatalf("frames = %v, want at least the two renders the keys caused", body["frames"])
+	}
+	last, _ := frames[len(frames)-1].(map[string]any)
+	if screen, _ := last["screen"].(string); !strings.Contains(screen, "key:down") {
+		t.Errorf("last frame = %q, want the down key visible", screen)
+	}
+
+	status, body = request(t, srv, http.MethodGet, "/frames?since=abc", nil, srv.Token())
+	if status != http.StatusBadRequest {
+		t.Errorf("since=abc: status = %d, want 400 (%v)", status, body)
+	}
+}
+
+// ── discovery file ──────────────────────────────────────────────────
+
+func TestDiscoveryFileLifecycle(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv(EnvHome, dir)
+
+	state := NewState(nil)
+	rec := NewRecorder(newTestModel(), state)
+	prog := newFakeProgram(rec, 0)
+	defer prog.Close()
+	srv, err := Start(prog, state, Options{Version: "test"})
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	info, err := ReadInfo()
+	if err != nil {
+		t.Fatalf("ReadInfo: %v", err)
+	}
+	if info == nil {
+		t.Fatal("Start did not publish a discovery file")
+	}
+	if info.Port != srv.Port() || info.Service != ServiceID || info.Token != srv.Token() {
+		t.Errorf("discovery record = %+v, want port %d service %q and the live token", info, srv.Port(), ServiceID)
+	}
+	if info.Host != Host {
+		t.Errorf("host = %q, want %q — the control server must never advertise a non-loopback address", info.Host, Host)
+	}
+
+	if runtime.GOOS != "windows" {
+		path, _ := FilePath()
+		stat, err := os.Stat(path)
+		if err != nil {
+			t.Fatalf("stat: %v", err)
+		}
+		if perm := stat.Mode().Perm(); perm != 0o600 {
+			t.Errorf("discovery file mode = %o, want 600 — it holds the bearer token", perm)
+		}
+	}
+
+	if err := srv.Stop(); err != nil {
+		t.Fatalf("Stop: %v", err)
+	}
+	after, err := ReadInfo()
+	if err != nil {
+		t.Fatalf("ReadInfo after stop: %v", err)
+	}
+	if after != nil {
+		t.Error("Stop left the discovery file behind; a client would trust a dead TUI")
+	}
+}
+
+func TestRemoveInfoLeavesANewerRegistrationAlone(t *testing.T) {
+	t.Setenv(EnvHome, t.TempDir())
+	if err := WriteInfo(Info{PID: 4242, Port: 9999, Token: "t", Service: ServiceID}); err != nil {
+		t.Fatalf("WriteInfo: %v", err)
+	}
+	if err := RemoveInfo(1); err != nil {
+		t.Fatalf("RemoveInfo: %v", err)
+	}
+	info, err := ReadInfo()
+	if err != nil {
+		t.Fatalf("ReadInfo: %v", err)
+	}
+	if info == nil || info.PID != 4242 {
+		t.Error("RemoveInfo deleted a registration owned by a different pid")
+	}
+}
+
+func TestReadInfoOnMissingAndMalformedFile(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv(EnvHome, dir)
+
+	info, err := ReadInfo()
+	if err != nil || info != nil {
+		t.Errorf("ReadInfo with no file = (%v, %v), want (nil, nil)", info, err)
+	}
+
+	path, _ := FilePath()
+	if err := os.WriteFile(path, []byte("{not json"), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if _, err := ReadInfo(); err == nil {
+		t.Error("a malformed discovery file must be an error, not a silently empty result")
+	} else if !strings.Contains(err.Error(), "malformed") {
+		t.Errorf("error %q should say the file is malformed", err)
+	}
+}
+
+func TestStartRejectsTheReservedPort(t *testing.T) {
+	t.Setenv(EnvHome, t.TempDir())
+	state := NewState(nil)
+	rec := NewRecorder(newTestModel(), state)
+	prog := newFakeProgram(rec, 0)
+	defer prog.Close()
+	_, err := Start(prog, state, Options{Port: ReservedPort})
+	if err == nil {
+		t.Fatalf("Start bound the reserved port %d", ReservedPort)
+	}
+	if !strings.Contains(err.Error(), fmt.Sprint(ReservedPort)) {
+		t.Errorf("error %q should name the reserved port", err)
+	}
+	info, _ := ReadInfo()
+	if info != nil {
+		t.Error("a rejected Start still published a discovery file")
+	}
+}
+
+func TestStartRequiresASenderAndState(t *testing.T) {
+	t.Setenv(EnvHome, t.TempDir())
+	if _, err := Start(nil, NewState(nil), Options{}); err == nil {
+		t.Error("Start with no program should fail loudly")
+	}
+	if _, err := Start(newFakeProgram(newTestModel(), 0), nil, Options{}); err == nil {
+		t.Error("Start with no state should fail loudly")
+	}
+}
+
+func TestUnknownEndpointAnswersInTheErrorEnvelope(t *testing.T) {
+	srv, _ := newTestServer(t)
+	status, body := request(t, srv, http.MethodGet, "/screne", nil, srv.Token())
+	if status != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404", status)
+	}
+	if code := errorField(t, body, "code"); code != "not_found" {
+		t.Errorf("code = %q, want not_found", code)
+	}
+	if hint := errorField(t, body, "hint"); !strings.Contains(hint, "/screen") {
+		t.Errorf("hint %q should list the real endpoints", hint)
+	}
+}
+
+// TestSendKeysBatchIsFullyAppliedBeforeAnswering is the regression for a race
+// the old synchronous test harness could not see: tea.Program.Send only queues,
+// so answering on "some newer frame" let /keys return with later keys of the
+// batch still in flight. A caller that then read /screen saw a mid-sequence
+// frame and concluded the key did nothing.
+func TestSendKeysBatchIsFullyAppliedBeforeAnswering(t *testing.T) {
+	// A per-message delay makes a partially-applied batch the likely outcome
+	// if the server does not wait for the whole batch.
+	srv, _ := newTestServerWithDelay(t, 5*time.Millisecond)
+
+	status, body := request(t, srv, http.MethodPost, "/keys",
+		map[string]any{"keys": []string{"tab", "down", "down", "enter"}}, srv.Token())
+	if status != http.StatusOK {
+		t.Fatalf("keys: status %d (%v)", status, body)
+	}
+
+	// Read immediately — no sleep, no retry. Every key must already be visible.
+	_, screen := request(t, srv, http.MethodGet, "/screen", nil, srv.Token())
+	text, _ := screen["screen"].(string)
+	if strings.Count(text, "key:") != 4 {
+		t.Errorf("screen shows %d keys, want 4 — /keys answered before the batch was applied:\n%s",
+			strings.Count(text, "key:"), text)
+	}
+	if !strings.Contains(text, "key:enter") {
+		t.Errorf("the last key of the batch is missing:\n%s", text)
+	}
+}
+
+// TestSendKeysSettlesEvenWhenNothingChanges guards the other side of the same
+// protocol: a key the model ignores draws an identical frame, and the request
+// must still return promptly rather than burning the settle timeout.
+func TestSendKeysSettlesEvenWhenNothingChanges(t *testing.T) {
+	srv, _ := newTestServerWithDelay(t, 0)
+	// Prime, then send a key the test model renders identically.
+	request(t, srv, http.MethodPost, "/keys", map[string]any{"keys": []string{"f5"}}, srv.Token())
+
+	start := time.Now()
+	status, _ := request(t, srv, http.MethodPost, "/keys",
+		map[string]any{"keys": []string{"f5"}}, srv.Token())
+	elapsed := time.Since(start)
+
+	if status != http.StatusOK {
+		t.Fatalf("status = %d, want 200", status)
+	}
+	if elapsed > renderSettleTimeout {
+		t.Errorf("took %s — a no-op key should settle on the mark, not wait out the %s timeout",
+			elapsed, renderSettleTimeout)
+	}
+}
+
+func TestWaitRejectsNonPositiveTimeout(t *testing.T) {
+	srv, _ := newTestServer(t)
+	for _, bad := range []int{0, -1} {
+		status, body := request(t, srv, http.MethodPost, "/wait",
+			map[string]any{"contains": "x", "timeout_ms": bad}, srv.Token())
+		if status != http.StatusBadRequest {
+			t.Errorf("timeout_ms=%d: status = %d, want 400", bad, status)
+			continue
+		}
+		if code := errorField(t, body, "code"); code != "bad_timeout" {
+			t.Errorf("timeout_ms=%d: code = %q, want bad_timeout", bad, code)
+		}
+	}
+
+	// Omitting it entirely still means "use the default", not an error.
+	status, body := request(t, srv, http.MethodPost, "/wait",
+		map[string]any{"contains": "GAIA Agent Hub"}, srv.Token())
+	if status != http.StatusOK {
+		t.Errorf("omitted timeout_ms: status = %d, want 200 (%v)", status, body)
+	}
+}
+
+func TestVisibleAgentIDsAreNeverNull(t *testing.T) {
+	srv, state := newTestServer(t)
+	// A model that reports no ids at all — the chat view does exactly this.
+	state.setSnapshot(Snapshot{View: "chat", Agent: "email"})
+
+	_, status := request(t, srv, http.MethodGet, "/status", nil, srv.Token())
+	st, _ := status["state"].(map[string]any)
+	if st["visible_agent_ids"] == nil {
+		t.Error("/status served visible_agent_ids: null; a client taking its length would crash")
+	}
+
+	_, waited := request(t, srv, http.MethodPost, "/wait",
+		map[string]any{"state": map[string]any{"view": "chat"}, "timeout_ms": 2000}, srv.Token())
+	wst, _ := waited["state"].(map[string]any)
+	if wst["visible_agent_ids"] == nil {
+		t.Error("/wait served visible_agent_ids: null")
+	}
+}
+
+// TestInjectionIsRefusedWhenTheProgramIsNotRunning covers the case that used to
+// answer 200 for keys that went nowhere: tea.Program.Send DISCARDS messages once
+// the program's context is done, so a TUI the user has quit would happily
+// "accept" input and never change.
+func TestInjectionIsRefusedWhenTheProgramIsNotRunning(t *testing.T) {
+	srv, _ := newTestServer(t)
+	srv.MarkStopped() // the user quit; the process has not exited yet
+
+	for _, tc := range []struct {
+		path string
+		body map[string]any
+	}{
+		{"/keys", map[string]any{"keys": []string{"enter"}}},
+		{"/text", map[string]any{"text": "hello"}},
+		{"/resize", map[string]any{"cols": 100, "rows": 30}},
+	} {
+		status, body := request(t, srv, http.MethodPost, tc.path, tc.body, srv.Token())
+		if status != http.StatusServiceUnavailable {
+			t.Errorf("%s: status = %d, want 503", tc.path, status)
+			continue
+		}
+		if code := errorField(t, body, "code"); code != "not_running" {
+			t.Errorf("%s: code = %q, want not_running", tc.path, code)
+		}
+		if msg := errorField(t, body, "message"); !strings.Contains(msg, "quit") {
+			t.Errorf("%s: message %q should explain why", tc.path, msg)
+		}
+	}
+
+	// Reads still work — the last frame is exactly what a caller needs to see.
+	status, _ := request(t, srv, http.MethodGet, "/screen", nil, srv.Token())
+	if status != http.StatusOK {
+		t.Errorf("GET /screen while stopped: status = %d, want 200", status)
+	}
+}
+
+func TestStatusReportsTheRealRunningState(t *testing.T) {
+	srv, _ := newTestServer(t)
+	_, body := request(t, srv, http.MethodGet, "/status", nil, srv.Token())
+	if body["running"] != true {
+		t.Errorf("running = %v while the loop is running, want true", body["running"])
+	}
+
+	srv.MarkStopped()
+	_, body = request(t, srv, http.MethodGet, "/status", nil, srv.Token())
+	if body["running"] != false {
+		t.Errorf("running = %v after the loop stopped, want false — it was hardcoded true", body["running"])
+	}
+}
+
+func TestDelayBudgetIsBounded(t *testing.T) {
+	srv, _ := newTestServer(t)
+	keys := make([]string, 100)
+	for i := range keys {
+		keys[i] = "down"
+	}
+	// 100 keys * 500ms would take 49.5s — far past any client's timeout.
+	status, body := request(t, srv, http.MethodPost, "/keys",
+		map[string]any{"keys": keys, "delay_ms": 500}, srv.Token())
+	if status != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", status)
+	}
+	if code := errorField(t, body, "code"); code != "delay_budget_exceeded" {
+		t.Errorf("code = %q, want delay_budget_exceeded", code)
+	}
+
+	// A single key with any legal delay is fine: the budget counts gaps.
+	status, _ = request(t, srv, http.MethodPost, "/keys",
+		map[string]any{"keys": []string{"down"}, "delay_ms": 2000}, srv.Token())
+	if status != http.StatusOK {
+		t.Errorf("one key with delay 2000: status = %d, want 200", status)
+	}
+}
+
+// TestConcurrentInjectionKeepsBatchesWhole guards the mark protocol under the
+// concurrency it will actually see. Each caller sends a batch of keys unique to
+// it and, the instant its request returns, checks that its OWN keys are on
+// screen. Without serialized injection, caller A's "wait for mark >= 1" is
+// satisfied by caller B's later mark 2 while A's keys are still queued — so A
+// returns 200 and reads a screen missing its own input.
+func TestConcurrentInjectionKeepsBatchesWhole(t *testing.T) {
+	srv, _ := newTestServerWithDelay(t, 2*time.Millisecond)
+
+	const callers, perCaller = 4, 3
+	var wg sync.WaitGroup
+	for i := 1; i <= callers; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			key := fmt.Sprintf("f%d", i)
+			batch := make([]string, perCaller)
+			for j := range batch {
+				batch[j] = key
+			}
+
+			status, body := request(t, srv, http.MethodPost, "/keys",
+				map[string]any{"keys": batch}, srv.Token())
+			if status != http.StatusOK {
+				t.Errorf("%s: status = %d (%v)", key, status, body)
+				return
+			}
+			if body["settled"] != true {
+				t.Errorf("%s: settled = %v, want true", key, body["settled"])
+			}
+
+			// No sleep: the 200 is supposed to mean "applied and rendered".
+			_, screen := request(t, srv, http.MethodGet, "/screen", nil, srv.Token())
+			text, _ := screen["screen"].(string)
+			if got := strings.Count(text, "key:"+key); got < perCaller {
+				t.Errorf("%s: only %d/%d of my own keys were on screen when my request returned — another caller's mark satisfied my wait",
+					key, got, perCaller)
+			}
+		}(i)
+	}
+	wg.Wait()
+
+	_, screen := request(t, srv, http.MethodGet, "/screen", nil, srv.Token())
+	text, _ := screen["screen"].(string)
+	if got := strings.Count(text, "key:f"); got != callers*perCaller {
+		t.Errorf("screen shows %d function keys, want %d — a batch was lost:\n%s",
+			got, callers*perCaller, text)
+	}
+}
+
+func TestScreenLineCount(t *testing.T) {
+	srv, state := newTestServer(t)
+	state.recordFrame("one\ntwo\nthree")
+	_, body := request(t, srv, http.MethodGet, "/screen", nil, srv.Token())
+	if body["lines"] != float64(3) {
+		t.Errorf("lines = %v, want 3", body["lines"])
+	}
+
+	state.recordFrame("")
+	_, body = request(t, srv, http.MethodGet, "/screen", nil, srv.Token())
+	if body["lines"] != float64(0) {
+		t.Errorf("lines = %v for an empty screen, want 0", body["lines"])
+	}
+}
+
+func TestWaitAcceptsTheHubReturnabilityMatcher(t *testing.T) {
+	srv, state := newTestServer(t)
+	state.setSnapshot(Snapshot{View: "chat", Agent: "email", CanReturnToHub: true})
+
+	status, body := request(t, srv, http.MethodPost, "/wait",
+		map[string]any{"state": map[string]any{"can_return_to_hub": true}, "timeout_ms": 2000}, srv.Token())
+	if status != http.StatusOK || body["matched"] != true {
+		t.Fatalf("status %d matched %v, want 200/true (%v)", status, body["matched"], body)
+	}
+	st, _ := body["state"].(map[string]any)
+	if st["can_return_to_hub"] != true {
+		t.Errorf("state.can_return_to_hub = %v, want true", st["can_return_to_hub"])
+	}
+
+	// A standalone chat must be distinguishable: esc quits there.
+	state.setSnapshot(Snapshot{View: "chat", Agent: "email", CanReturnToHub: false})
+	status, body = request(t, srv, http.MethodPost, "/wait",
+		map[string]any{"state": map[string]any{"can_return_to_hub": true}, "timeout_ms": 200}, srv.Token())
+	if status != http.StatusRequestTimeout {
+		t.Errorf("status = %d, want 408 (%v)", status, body)
+	}
+}

--- a/tui/internal/control/state.go
+++ b/tui/internal/control/state.go
@@ -1,0 +1,342 @@
+package control
+
+import (
+	"strings"
+	"sync"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/x/ansi"
+)
+
+// maxFrames caps the rendered-frame history kept for GET /frames.
+const maxFrames = 200
+
+// Snapshot is the navigation state the control API reports. A model that can
+// describe itself implements [SnapshotProvider]; anything else is reported with
+// View "unknown" rather than a guess.
+type Snapshot struct {
+	View            string   `json:"view"`
+	Agent           string   `json:"agent"`
+	Streaming       bool     `json:"streaming"`
+	HubTab          string   `json:"hub_tab,omitempty"`
+	HubTabIndex     int      `json:"hub_tab_index"`
+	SelectedAgentID string   `json:"selected_agent_id,omitempty"`
+	VisibleAgentIDs []string `json:"visible_agent_ids"`
+	Filtering       bool     `json:"filtering"`
+	Overlay         string   `json:"overlay,omitempty"`
+
+	// CanReturnToHub reports whether esc leaves the chat for the hub. In a
+	// standalone chat (`gaia chat --subprocess`) esc QUITS the program, so a
+	// client that presses it to "go back" would kill the session it is driving.
+	CanReturnToHub bool `json:"can_return_to_hub"`
+}
+
+// ViewUnknown is reported when the running model cannot describe its own state.
+const ViewUnknown = "unknown"
+
+// SnapshotProvider is implemented by a root model that can report where the
+// user currently is. Keeping it an interface means the control package never
+// imports the view packages, so the two can evolve independently.
+type SnapshotProvider interface {
+	ControlSnapshot() Snapshot
+}
+
+// Frame is one rendered screen, kept for debugging what happened.
+type Frame struct {
+	Seq    int    `json:"seq"`
+	AtMS   int64  `json:"at_ms"`
+	Screen string `json:"screen"`
+}
+
+// MarkMsg is a sentinel the control server injects after a batch of keys.
+//
+// Bubble Tea processes messages in order and renders after each one, so once a
+// frame has been drawn *for the mark*, every key sent before it has been both
+// handled and rendered. Program.Send only queues, so without this a caller that
+// sends three keys and reads the screen can see a mid-sequence frame.
+type MarkMsg struct{ ID int64 }
+
+// State holds everything the HTTP handlers read: the last rendered frame, the
+// frame history, the terminal size, and the model's own snapshot.
+//
+// Bubble Tea calls Update and View from its event loop; HTTP handlers read from
+// their own goroutines. Every field is guarded by mu.
+type State struct {
+	mu      sync.RWMutex
+	seq     int
+	lastRaw string
+	frames  []Frame
+	cols    int
+	rows    int
+	snap    Snapshot
+	started time.Time
+
+	// pendingMark is set when Update sees a MarkMsg; renderedMark is promoted
+	// from it by the View that immediately follows.
+	pendingMark  int64
+	renderedMark int64
+	markCounter  int64
+
+	// changed is closed (and replaced) whenever the frame or the snapshot
+	// changes, so POST /wait blocks instead of busy-polling.
+	changed chan struct{}
+
+	debugf func(format string, args ...any)
+}
+
+// NewState creates the shared state. debugf may be nil.
+func NewState(debugf func(format string, args ...any)) *State {
+	if debugf == nil {
+		debugf = func(string, ...any) {}
+	}
+	return &State{
+		// VisibleAgentIDs is set here, not left nil: a Server started without a
+		// Recorder would otherwise serve `"visible_agent_ids": null` and any
+		// client taking its length would crash.
+		snap:    Snapshot{View: ViewUnknown, VisibleAgentIDs: []string{}},
+		started: time.Now(),
+		changed: make(chan struct{}),
+		debugf:  debugf,
+	}
+}
+
+// Changed returns the channel that closes on the next frame or state change.
+// Callers must take the channel BEFORE re-checking the condition, or they can
+// miss a wakeup that lands between the check and the wait.
+func (s *State) Changed() <-chan struct{} {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.changed
+}
+
+// broadcast wakes every waiter. Caller must hold the write lock.
+func (s *State) broadcast() {
+	close(s.changed)
+	s.changed = make(chan struct{})
+}
+
+// recordFrame caches a newly rendered frame and promotes the pending mark.
+// Identical consecutive frames are dropped from the history — Bubble Tea
+// re-renders on every message, including spinner ticks — but the mark is
+// promoted either way, because a key that changes nothing visible is still
+// handled.
+func (s *State) recordFrame(raw string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	markAdvanced := s.renderedMark != s.pendingMark
+	s.renderedMark = s.pendingMark
+
+	if raw == s.lastRaw && s.seq > 0 {
+		if markAdvanced {
+			s.broadcast()
+		}
+		return
+	}
+	s.seq++
+	s.lastRaw = raw
+	s.frames = append(s.frames, Frame{
+		Seq:    s.seq,
+		AtMS:   time.Since(s.started).Milliseconds(),
+		Screen: PlainScreen(raw),
+	})
+	if len(s.frames) > maxFrames {
+		s.frames = s.frames[len(s.frames)-maxFrames:]
+	}
+	s.broadcast()
+}
+
+// NextMark reserves a sentinel id for the next injected batch.
+func (s *State) NextMark() int64 {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.markCounter++
+	return s.markCounter
+}
+
+// setPendingMark records that a MarkMsg reached the model.
+//
+// Monotonic on purpose: settle waits for "rendered >= my mark", so a mark
+// going backwards would let an earlier waiter return before its own keys were
+// processed. Injection is serialized, but this keeps the invariant local.
+func (s *State) setPendingMark(id int64) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if id > s.pendingMark {
+		s.pendingMark = id
+	}
+}
+
+// RenderedMark is the newest mark whose frame has been drawn and cached.
+func (s *State) RenderedMark() int64 {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.renderedMark
+}
+
+// setSnapshot stores the model's self-reported state and logs transitions.
+func (s *State) setSnapshot(snap Snapshot) {
+	if snap.VisibleAgentIDs == nil {
+		// Normalized once, here, so every endpoint serves [] and no client has
+		// to guard against null before taking its length.
+		snap.VisibleAgentIDs = []string{}
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	prev := s.snap
+	if snapshotsEqual(prev, snap) {
+		return
+	}
+	s.snap = snap
+	s.broadcast()
+	if prev.View != snap.View || prev.Agent != snap.Agent || prev.Streaming != snap.Streaming {
+		s.debugf("state: view %s→%s agent %q→%q streaming %v→%v",
+			prev.View, snap.View, prev.Agent, snap.Agent, prev.Streaming, snap.Streaming)
+	}
+}
+
+// SetSize records the terminal size the model is laid out for.
+func (s *State) SetSize(cols, rows int) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.cols == cols && s.rows == rows {
+		return
+	}
+	s.cols, s.rows = cols, rows
+	s.broadcast()
+	s.debugf("state: size %dx%d", cols, rows)
+}
+
+// Size returns the last known terminal size.
+func (s *State) Size() (cols, rows int) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.cols, s.rows
+}
+
+// Current returns the last rendered frame (raw, ANSI intact), its sequence
+// number, and the model snapshot — read atomically so a caller never mixes a
+// frame with a snapshot from a different render.
+func (s *State) Current() (raw string, seq int, snap Snapshot) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.lastRaw, s.seq, s.snap
+}
+
+// Frames returns frames with Seq > since, newest last, capped at limit.
+// A limit <= 0 means no cap — the ring itself bounds the result at maxFrames.
+// truncated reports whether older frames were dropped from the ring.
+func (s *State) Frames(since, limit int) (frames []Frame, latestSeq int, truncated bool) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	for _, f := range s.frames {
+		if f.Seq > since {
+			frames = append(frames, f)
+		}
+	}
+	if len(s.frames) > 0 && s.frames[0].Seq > since+1 {
+		truncated = true
+	}
+	if limit > 0 && len(frames) > limit {
+		frames = frames[len(frames)-limit:]
+		truncated = true
+	}
+	return frames, s.seq, truncated
+}
+
+// UptimeMS is how long the state has been collecting frames.
+func (s *State) UptimeMS() int64 {
+	return time.Since(s.started).Milliseconds()
+}
+
+func snapshotsEqual(a, b Snapshot) bool {
+	if a.View != b.View || a.Agent != b.Agent || a.Streaming != b.Streaming ||
+		a.HubTab != b.HubTab || a.HubTabIndex != b.HubTabIndex ||
+		a.SelectedAgentID != b.SelectedAgentID || a.Filtering != b.Filtering ||
+		a.Overlay != b.Overlay || a.CanReturnToHub != b.CanReturnToHub ||
+		len(a.VisibleAgentIDs) != len(b.VisibleAgentIDs) {
+		return false
+	}
+	for i := range a.VisibleAgentIDs {
+		if a.VisibleAgentIDs[i] != b.VisibleAgentIDs[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// PlainScreen strips ANSI styling and trailing padding so the result is what an
+// assistant should read. Lipgloss pads every line to the layout width; keeping
+// that padding just wastes tokens and makes diffs unreadable.
+func PlainScreen(raw string) string {
+	stripped := ansi.Strip(raw)
+	lines := strings.Split(stripped, "\n")
+	for i, line := range lines {
+		lines[i] = strings.TrimRight(line, " \t\r")
+	}
+	for len(lines) > 0 && lines[len(lines)-1] == "" {
+		lines = lines[:len(lines)-1]
+	}
+	return strings.Join(lines, "\n")
+}
+
+// Recorder wraps the root model so every rendered frame is cached for the
+// control API. Bubble Tea does not expose the last frame it drew, and scraping
+// the terminal is not an option, so the model itself reports it.
+//
+// Recorder is a value type (like every Bubble Tea model) but carries a pointer
+// to the shared State, so mutations survive the copies Bubble Tea makes.
+type Recorder struct {
+	inner tea.Model
+	state *State
+}
+
+// NewRecorder wraps inner, publishing its frames and snapshots into state.
+//
+// The snapshot is seeded here rather than at Init so /status answers with the
+// real view from the moment the server is up, not "unknown" until the first
+// message arrives.
+func NewRecorder(inner tea.Model, state *State) Recorder {
+	state.setSnapshot(snapshotOf(inner))
+	return Recorder{inner: inner, state: state}
+}
+
+// State returns the shared state the control server serves from.
+func (r Recorder) State() *State { return r.state }
+
+func (r Recorder) Init() tea.Cmd {
+	r.state.setSnapshot(snapshotOf(r.inner))
+	return r.inner.Init()
+}
+
+func (r Recorder) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch m := msg.(type) {
+	case MarkMsg:
+		// The sentinel is ours; the wrapped model must never see it.
+		r.state.setPendingMark(m.ID)
+		return r, nil
+	case tea.WindowSizeMsg:
+		r.state.SetSize(m.Width, m.Height)
+	case tea.KeyMsg:
+		r.state.debugf("inject: key %q reached the model", m.String())
+	}
+
+	next, cmd := r.inner.Update(msg)
+	r.inner = next
+	r.state.setSnapshot(snapshotOf(next))
+	return r, cmd
+}
+
+func (r Recorder) View() string {
+	view := r.inner.View()
+	r.state.recordFrame(view)
+	return view
+}
+
+func snapshotOf(m tea.Model) Snapshot {
+	if sp, ok := m.(SnapshotProvider); ok {
+		return sp.ControlSnapshot()
+	}
+	return Snapshot{View: ViewUnknown}
+}

--- a/tui/internal/control/state_test.go
+++ b/tui/internal/control/state_test.go
@@ -1,0 +1,190 @@
+package control
+
+import (
+	"fmt"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/charmbracelet/lipgloss"
+)
+
+func TestPlainScreenStripsANSI(t *testing.T) {
+	styled := lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("150")).Render("Agent Hub")
+	if !strings.Contains(styled, "\x1b[") {
+		t.Skip("lipgloss produced no escape sequences in this environment; nothing to strip")
+	}
+	plain := PlainScreen(styled)
+	if plain != "Agent Hub" {
+		t.Errorf("PlainScreen(%q) = %q, want %q", styled, plain, "Agent Hub")
+	}
+	if strings.Contains(plain, "\x1b") {
+		t.Errorf("PlainScreen left an escape sequence in %q", plain)
+	}
+}
+
+func TestPlainScreenTrimsPaddingAndTrailingBlanks(t *testing.T) {
+	raw := "Installed   \nBash        \n\n\n"
+	want := "Installed\nBash"
+	if got := PlainScreen(raw); got != want {
+		t.Errorf("PlainScreen(%q) = %q, want %q", raw, got, want)
+	}
+}
+
+func TestPlainScreenKeepsAnsiFormatSeparate(t *testing.T) {
+	raw := "\x1b[1mbold\x1b[0m"
+	if got := PlainScreen(raw); got != "bold" {
+		t.Errorf("PlainScreen = %q, want %q", got, "bold")
+	}
+}
+
+func TestRecordFrameDedupesAndSequences(t *testing.T) {
+	st := NewState(nil)
+	st.recordFrame("one")
+	st.recordFrame("one")
+	st.recordFrame("two")
+
+	raw, seq, _ := st.Current()
+	if raw != "two" {
+		t.Errorf("Current screen = %q, want %q", raw, "two")
+	}
+	if seq != 2 {
+		t.Errorf("seq = %d, want 2 (identical consecutive frames must not advance it)", seq)
+	}
+	frames, latest, _ := st.Frames(0, 10)
+	if len(frames) != 2 || latest != 2 {
+		t.Fatalf("Frames returned %d frames (latest %d), want 2 (latest 2)", len(frames), latest)
+	}
+	if frames[0].Screen != "one" || frames[1].Screen != "two" {
+		t.Errorf("frames = %+v, want [one two] in order", frames)
+	}
+}
+
+func TestFramesSinceAndLimit(t *testing.T) {
+	st := NewState(nil)
+	for i := 0; i < 10; i++ {
+		st.recordFrame(fmt.Sprintf("frame %d", i))
+	}
+	frames, latest, truncated := st.Frames(7, 20)
+	if latest != 10 {
+		t.Errorf("latest_seq = %d, want 10", latest)
+	}
+	if len(frames) != 3 {
+		t.Fatalf("since=7 returned %d frames, want 3", len(frames))
+	}
+	if frames[0].Seq != 8 {
+		t.Errorf("first frame seq = %d, want 8", frames[0].Seq)
+	}
+	if truncated {
+		t.Error("truncated should be false when nothing was dropped")
+	}
+
+	limited, _, truncated := st.Frames(0, 2)
+	if len(limited) != 2 || !truncated {
+		t.Errorf("limit=2 returned %d frames (truncated %v), want 2 and truncated=true", len(limited), truncated)
+	}
+}
+
+func TestFrameRingIsBounded(t *testing.T) {
+	st := NewState(nil)
+	for i := 0; i < maxFrames+50; i++ {
+		st.recordFrame(fmt.Sprintf("frame %d", i))
+	}
+	frames, latest, truncated := st.Frames(0, 0)
+	if len(frames) != maxFrames {
+		t.Errorf("ring holds %d frames, want %d", len(frames), maxFrames)
+	}
+	if latest != maxFrames+50 {
+		t.Errorf("latest_seq = %d, want %d", latest, maxFrames+50)
+	}
+	if !truncated {
+		t.Error("truncated should be true once the ring has dropped frames")
+	}
+}
+
+// TestFrameCacheUnderConcurrentAccess is the real shape of production: Bubble
+// Tea writes frames from its event loop while HTTP handlers read. Run with
+// -race to make a missing lock fail.
+func TestFrameCacheUnderConcurrentAccess(t *testing.T) {
+	st := NewState(nil)
+	var wg sync.WaitGroup
+	stop := make(chan struct{})
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 0; ; i++ {
+			select {
+			case <-stop:
+				return
+			default:
+			}
+			st.recordFrame(fmt.Sprintf("frame %d", i))
+			st.setSnapshot(Snapshot{View: "hub", HubTabIndex: i % 3})
+			st.SetSize(80+i%40, 24)
+		}
+	}()
+
+	for r := 0; r < 4; r++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			deadline := time.Now().Add(200 * time.Millisecond)
+			for time.Now().Before(deadline) {
+				raw, seq, snap := st.Current()
+				_ = PlainScreen(raw)
+				_ = seq
+				_ = snap.View
+				st.Frames(0, 5)
+				st.Size()
+				st.UptimeMS()
+			}
+		}()
+	}
+
+	time.Sleep(200 * time.Millisecond)
+	close(stop)
+	wg.Wait()
+
+	if _, seq, _ := st.Current(); seq == 0 {
+		t.Error("no frames were recorded")
+	}
+}
+
+func TestChangedBroadcastsOnNewFrame(t *testing.T) {
+	st := NewState(nil)
+	ch := st.Changed()
+	select {
+	case <-ch:
+		t.Fatal("Changed() fired before anything changed")
+	default:
+	}
+
+	st.recordFrame("hello")
+	select {
+	case <-ch:
+	case <-time.After(time.Second):
+		t.Fatal("Changed() did not fire after a new frame")
+	}
+}
+
+func TestChangedBroadcastsOnSnapshotChangeOnly(t *testing.T) {
+	st := NewState(nil)
+	st.setSnapshot(Snapshot{View: "hub"})
+
+	ch := st.Changed()
+	st.setSnapshot(Snapshot{View: "hub"}) // identical — must not wake waiters
+	select {
+	case <-ch:
+		t.Fatal("an identical snapshot woke waiters")
+	default:
+	}
+
+	st.setSnapshot(Snapshot{View: "chat", Agent: "email"})
+	select {
+	case <-ch:
+	case <-time.After(time.Second):
+		t.Fatal("a state change with no repaint did not wake waiters — POST /wait on a state matcher would hang")
+	}
+}

--- a/tui/internal/daemon/client.go
+++ b/tui/internal/daemon/client.go
@@ -1,0 +1,557 @@
+package daemon
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+// Timeouts mirror src/gaia/daemon/{instance,client}.py.
+const (
+	// A live daemon answers loopback in milliseconds; a longer wait only delays
+	// reclaiming a dead one.
+	defaultProbeTimeout = 1500 * time.Millisecond
+	// Daemon start: spawn + bind + import.
+	defaultStartTimeout = 30 * time.Second
+	// Ensure: a first-run ensure may lazily fetch the sidecar binary before answering.
+	defaultEnsureTimeout = 900 * time.Second
+	// Cancel must never wait out a stream read timeout.
+	defaultCancelTimeout = 10 * time.Second
+	// Cap on captured launcher output quoted back in an error.
+	maxLauncherOutput = 4096
+)
+
+// Options configures a Client. The zero value is valid and uses the defaults
+// above with the real `gaia daemon start` launcher.
+type Options struct {
+	ProbeTimeout  time.Duration
+	StartTimeout  time.Duration
+	EnsureTimeout time.Duration
+
+	// StartCommand builds the command that starts the daemon. Defaults to
+	// `gaia daemon start`, which is preferred over invoking the module directly
+	// because it validates the required extras and produces better errors.
+	// Overridden by tests.
+	StartCommand func(ctx context.Context) (*exec.Cmd, error)
+
+	// PIDAlive overrides the process-liveness check. Defaults to PIDAlive.
+	PIDAlive func(pid int) bool
+
+	// Logf receives progress and best-effort-failure notes. It MUST never be
+	// given a raw token; pass Instance values (whose String redacts it).
+	Logf func(format string, args ...any)
+}
+
+// Client is a thin client for one machine's GAIA daemon.
+//
+// It is safe for concurrent use: it holds no mutable instance state. Callers pass
+// the *Instance they are working with, and Do hands back the (possibly
+// refreshed) instance whose token authorized the call — the token rotates on
+// every daemon restart, so it is never cached for the process lifetime.
+type Client struct {
+	opts Options
+	// control is used for short control-plane calls (the status probe).
+	control *http.Client
+	// ensure is used for the possibly-very-slow ensure call.
+	ensure *http.Client
+	// cancel is used for the best-effort run-cancel POST, which must not be cut
+	// short by the probe timeout nor wait out a stream read timeout.
+	cancel *http.Client
+}
+
+// New builds a Client, filling unset options with their defaults.
+func New(opts Options) *Client {
+	if opts.ProbeTimeout <= 0 {
+		opts.ProbeTimeout = defaultProbeTimeout
+	}
+	if opts.StartTimeout <= 0 {
+		opts.StartTimeout = defaultStartTimeout
+	}
+	if opts.EnsureTimeout <= 0 {
+		opts.EnsureTimeout = defaultEnsureTimeout
+	}
+	if opts.PIDAlive == nil {
+		opts.PIDAlive = PIDAlive
+	}
+	if opts.StartCommand == nil {
+		opts.StartCommand = gaiaDaemonStart
+	}
+	if opts.Logf == nil {
+		opts.Logf = func(string, ...any) {}
+	}
+	return &Client{
+		opts:    opts,
+		control: &http.Client{Timeout: opts.ProbeTimeout},
+		ensure:  &http.Client{Timeout: opts.EnsureTimeout},
+		cancel:  &http.Client{Timeout: defaultCancelTimeout},
+	}
+}
+
+// Attach returns the running daemon if one is live and contract-compatible.
+//
+// It returns *NotRunningError / *StaleError when there is nothing to attach to,
+// and *VersionError when a live daemon speaks the wrong contract — a version
+// skew is never fixed by starting another daemon, so callers must surface it.
+func (c *Client) Attach(ctx context.Context) (*Instance, error) {
+	inst, err := ReadInstance()
+	if err != nil {
+		return nil, err
+	}
+	if err := c.verify(ctx, inst); err != nil {
+		return nil, err
+	}
+	if err := inst.CheckVersion(); err != nil {
+		return nil, err
+	}
+	return inst, nil
+}
+
+// verify applies the two-check trust rule: the recorded pid must be alive AND a
+// token-authed /daemon/v1/status probe must answer with our service id and the
+// recorded pid. After a hard crash the file points at a dead pid or a freed port
+// some unrelated process now owns — either check fails.
+func (c *Client) verify(ctx context.Context, inst *Instance) error {
+	path, _ := InstancePath()
+	if !c.opts.PIDAlive(inst.PID) {
+		return &StaleError{Path: path, Reason: fmt.Sprintf("its pid %d is not running", inst.PID)}
+	}
+	if err := c.probe(ctx, inst); err != nil {
+		return &StaleError{Path: path, Reason: err.Error()}
+	}
+	return nil
+}
+
+type statusBody struct {
+	Service string `json:"service"`
+	PID     int    `json:"pid"`
+}
+
+// probe checks the recorded port with the recorded token. It returns nil only if
+// the server answers 200 with our service id and the pid from the registry.
+func (c *Client) probe(ctx context.Context, inst *Instance) error {
+	ctx, cancel := context.WithTimeout(ctx, c.opts.ProbeTimeout)
+	defer cancel()
+
+	req, err := c.newRequest(ctx, inst, http.MethodGet, APIPrefix+"/status", nil, nil)
+	if err != nil {
+		return err
+	}
+	resp, err := c.control.Do(req)
+	if err != nil {
+		return fmt.Errorf("port %d did not answer a status probe (%v)", inst.Port, err)
+	}
+	defer drainAndClose(resp)
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("port %d answered the status probe with HTTP %d", inst.Port, resp.StatusCode)
+	}
+	var body statusBody
+	if err := json.NewDecoder(io.LimitReader(resp.Body, 1<<16)).Decode(&body); err != nil {
+		return fmt.Errorf("port %d answered the status probe with an unreadable body (%v)", inst.Port, err)
+	}
+	if body.Service != ServiceID {
+		return fmt.Errorf("port %d is served by %q, not %q — an unrelated process took the freed port",
+			inst.Port, body.Service, ServiceID)
+	}
+	if body.PID != inst.PID {
+		return fmt.Errorf("port %d is served by pid %d but the registry records pid %d",
+			inst.Port, body.PID, inst.PID)
+	}
+	return nil
+}
+
+// StartOrAttach returns the running daemon, starting one only if needed.
+// Single-instance is guaranteed by the exclusive start lock.
+func (c *Client) StartOrAttach(ctx context.Context) (*Instance, error) {
+	inst, err := c.Attach(ctx)
+	if err == nil {
+		return inst, nil
+	}
+	// A contract skew is the user's to resolve — starting a second daemon cannot
+	// help, and attaching anyway would 404 or misbehave silently.
+	if isVersionError(err) {
+		return nil, err
+	}
+	c.opts.Logf("daemon: no attachable instance (%v); starting one", err)
+
+	if _, derr := ensureHostDir(); derr != nil {
+		return nil, derr
+	}
+	lockPath, err := LockPath()
+	if err != nil {
+		return nil, err
+	}
+	lock, err := acquireLock(lockPath, c.opts.StartTimeout)
+	if err != nil {
+		return nil, err
+	}
+	defer lock.release()
+
+	// Re-check under the lock: a concurrent caller may have just started it.
+	inst, err = c.Attach(ctx)
+	if err == nil {
+		return inst, nil
+	}
+	if isVersionError(err) {
+		return nil, err
+	}
+
+	// A recorded pid that is alive but unresponsive is a daemon gone bad. The TUI
+	// deliberately does NOT kill it (unlike the Python client, which can verify
+	// the cmdline via psutil first): killing a possibly-recycled pid from a UI is
+	// worse than telling the user exactly what to run.
+	if rec, rerr := ReadInstance(); rerr == nil && c.opts.PIDAlive(rec.PID) {
+		return nil, &StartError{Reason: fmt.Sprintf(
+			"the recorded daemon pid %d is running but does not answer a status probe on port %d. "+
+				"Run `gaia daemon restart` to reclaim it", rec.PID, rec.Port)}
+	}
+
+	return c.spawnAndWait(ctx)
+}
+
+// gaiaDaemonStart builds the default launcher command.
+func gaiaDaemonStart(ctx context.Context) (*exec.Cmd, error) {
+	bin, err := exec.LookPath("gaia")
+	if err != nil {
+		return nil, &StartError{Reason: "the `gaia` CLI is not on PATH, so the daemon cannot be launched. " +
+			"Install GAIA (`pip install -e .` in the repo, or the released wheel) and retry"}
+	}
+	return exec.CommandContext(ctx, bin, "daemon", "start"), nil
+}
+
+// spawnAndWait launches the daemon and polls until a live instance registers.
+//
+// Unlike the Python client, the pid of the process we launch is NOT matched
+// against instance.json: `gaia daemon start` is a launcher that itself spawns the
+// detached daemon, so the registered pid belongs to its grandchild. Trust comes
+// from the two-check verify plus the version gate instead.
+func (c *Client) spawnAndWait(ctx context.Context) (*Instance, error) {
+	startCtx, cancel := context.WithTimeout(ctx, c.opts.StartTimeout)
+	defer cancel()
+
+	cmd, err := c.opts.StartCommand(startCtx)
+	if err != nil {
+		return nil, err
+	}
+	var out bytes.Buffer
+	if cmd.Stdout == nil {
+		cmd.Stdout = &out
+	}
+	if cmd.Stderr == nil {
+		cmd.Stderr = &out
+	}
+	if err := cmd.Start(); err != nil {
+		return nil, &StartError{Reason: fmt.Sprintf("failed to launch `%s`: %v", strings.Join(cmd.Args, " "), err)}
+	}
+
+	launcherDone := make(chan error, 1)
+	go func() { launcherDone <- cmd.Wait() }()
+
+	ticker := time.NewTicker(100 * time.Millisecond)
+	defer ticker.Stop()
+	cmdLine := strings.Join(cmd.Args, " ")
+	var launcherExit error
+	launcherExited := false
+
+	for {
+		inst, aerr := c.Attach(ctx)
+		if aerr == nil {
+			c.opts.Logf("daemon: started %s", inst)
+			return inst, nil
+		}
+		if isVersionError(aerr) {
+			return nil, aerr
+		}
+
+		// The launcher exits as soon as the daemon has registered, so a clean
+		// exit gets one more Attach above before we call it a failure. Reading
+		// `out` is only safe once Wait has returned.
+		if launcherExited {
+			reason := "exited cleanly but no live daemon registered"
+			if launcherExit != nil {
+				reason = fmt.Sprintf("exited with %v before a daemon registered", launcherExit)
+			}
+			return nil, &StartError{Reason: fmt.Sprintf("`%s` %s. Last attach error: %v.%s",
+				cmdLine, reason, aerr, quoteOutput(out.String()))}
+		}
+
+		select {
+		case launcherExit = <-launcherDone:
+			launcherExited = true
+		case <-ticker.C:
+		case <-startCtx.Done():
+			if cmd.Process != nil {
+				_ = cmd.Process.Kill()
+			}
+			<-launcherDone
+			return nil, &StartError{Reason: fmt.Sprintf(
+				"no daemon became healthy within %s — `%s` may be stuck binding a port or importing.%s",
+				c.opts.StartTimeout, cmdLine, quoteOutput(out.String()))}
+		}
+	}
+}
+
+// isVersionError reports whether err is (or wraps) a contract-version failure.
+func isVersionError(err error) bool {
+	var verr *VersionError
+	return errors.As(err, &verr)
+}
+
+func quoteOutput(s string) string {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return ""
+	}
+	if len(s) > maxLauncherOutput {
+		s = s[:maxLauncherOutput] + "…"
+	}
+	return " Launcher output:\n" + s
+}
+
+// Request is one authenticated call against the daemon.
+type Request struct {
+	Method string
+	// Path is daemon-root-relative, e.g. "/daemon/v1/agents/email/ensure" or
+	// "/v1/email/query".
+	Path string
+	// Body is the raw request body, nil for none. It is retained so the call can
+	// be replayed after a token refresh.
+	Body []byte
+	// Header carries extra request headers; Authorization is always set by Do.
+	Header http.Header
+	// HTTPClient overrides the client used for this call (streaming needs its own).
+	HTTPClient *http.Client
+	// Op names the operation for error messages, e.g. "stream the 'email' query".
+	Op string
+}
+
+// Do sends an authenticated request to the daemon.
+//
+// The client token rotates on every daemon restart, so a 401 is not a fatal
+// auth failure: instance.json is re-read, the fresh instance re-verified, and
+// the request replayed exactly once. The instance whose token authorized the
+// response is returned so the caller can reuse it (e.g. to cancel a run).
+//
+// The caller owns resp.Body and must close it.
+func (c *Client) Do(ctx context.Context, inst *Instance, r Request) (*http.Response, *Instance, error) {
+	resp, err := c.send(ctx, inst, r)
+	if err != nil {
+		return nil, inst, err
+	}
+	if resp.StatusCode != http.StatusUnauthorized {
+		return resp, inst, nil
+	}
+	drainAndClose(resp)
+
+	fresh, err := c.refresh(ctx, inst)
+	if err != nil {
+		return nil, inst, err
+	}
+	c.opts.Logf("daemon: client token rotated; retrying %s %s", r.Method, r.Path)
+
+	resp, err = c.send(ctx, fresh, r)
+	if err != nil {
+		return nil, fresh, err
+	}
+	if resp.StatusCode == http.StatusUnauthorized {
+		drainAndClose(resp)
+		return nil, fresh, &RequestError{
+			Op: c.opDescription(r),
+			Detail: "the daemon rejected the refreshed client token (HTTP 401). " +
+				"Run `gaia daemon restart` to mint a new one",
+		}
+	}
+	return resp, fresh, nil
+}
+
+// refresh re-reads instance.json after a 401 and re-verifies it. An unchanged
+// token means the 401 was not a rotation, so retrying would just 401 again —
+// that surfaces as a loud error instead.
+func (c *Client) refresh(ctx context.Context, old *Instance) (*Instance, error) {
+	fresh, err := ReadInstance()
+	if err != nil {
+		return nil, err
+	}
+	if fresh.Token == old.Token {
+		return nil, &RequestError{
+			Op: "authenticate against the daemon",
+			Detail: "it rejected the client token (HTTP 401) but instance.json still records the same token. " +
+				"Run `gaia daemon restart` to mint a new one",
+		}
+	}
+	if err := c.verify(ctx, fresh); err != nil {
+		return nil, err
+	}
+	if err := fresh.CheckVersion(); err != nil {
+		return nil, err
+	}
+	return fresh, nil
+}
+
+func (c *Client) send(ctx context.Context, inst *Instance, r Request) (*http.Response, error) {
+	req, err := c.newRequest(ctx, inst, r.Method, r.Path, r.Body, r.Header)
+	if err != nil {
+		return nil, err
+	}
+	httpClient := r.HTTPClient
+	if httpClient == nil {
+		httpClient = c.control
+	}
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return nil, &RequestError{Op: c.opDescription(r), Detail: err.Error()}
+	}
+	return resp, nil
+}
+
+func (c *Client) opDescription(r Request) string {
+	if r.Op != "" {
+		return r.Op
+	}
+	return fmt.Sprintf("call %s %s on the daemon", r.Method, r.Path)
+}
+
+func (c *Client) newRequest(
+	ctx context.Context,
+	inst *Instance,
+	method, path string,
+	body []byte,
+	header http.Header,
+) (*http.Request, error) {
+	var rdr io.Reader
+	if body != nil {
+		rdr = bytes.NewReader(body)
+	}
+	req, err := http.NewRequestWithContext(ctx, method, inst.BaseURL()+path, rdr)
+	if err != nil {
+		return nil, &RequestError{
+			Op:     fmt.Sprintf("build a %s request for %s", method, path),
+			Detail: err.Error(),
+		}
+	}
+	for k, vs := range header {
+		for _, v := range vs {
+			req.Header.Add(k, v)
+		}
+	}
+	req.Header.Set("Authorization", AuthScheme+" "+inst.Token)
+	return req, nil
+}
+
+// EnsureAgent starts-or-attaches the daemon and ensures agentID's sidecar is
+// running, returning the daemon instance a thin client drives it through.
+//
+// The ensure response body is deliberately NOT read: it carries the sidecar's
+// bearer token, which a thin client must never learn or hold. The TUI presents
+// only the daemon client token and the daemon swaps it server-side.
+//
+// Blocking — daemon start, sidecar spawn, and a possible first-run binary fetch
+// all happen here. Call it off the UI event loop.
+func (c *Client) EnsureAgent(ctx context.Context, agentID string) (*Instance, error) {
+	if agentID == "" {
+		return nil, &RequestError{Op: "ensure an agent sidecar", Detail: "no agent id was given"}
+	}
+	inst, err := c.StartOrAttach(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if err := inst.CheckAgentsFloor(); err != nil {
+		return nil, err
+	}
+
+	resp, inst, err := c.Do(ctx, inst, Request{
+		Method:     http.MethodPost,
+		Path:       APIPrefix + "/agents/" + agentID + "/ensure",
+		Body:       []byte("{}"),
+		Header:     http.Header{"Content-Type": []string{"application/json"}},
+		HTTPClient: c.ensure,
+		Op:         fmt.Sprintf("ensure the '%s' sidecar via the daemon", agentID),
+	})
+	if err != nil {
+		return nil, err
+	}
+	defer drainAndClose(resp)
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, &RequestError{
+			Op:     fmt.Sprintf("ensure the '%s' sidecar via the daemon", agentID),
+			Detail: ErrorDetail(resp),
+		}
+	}
+	return inst, nil
+}
+
+// CancelRun asks the relay to cancel a streaming run. Best-effort: the sidecar
+// may already be gone, so failures are logged, never raised.
+func (c *Client) CancelRun(inst *Instance, agentID, runID string) {
+	ctx, cancel := context.WithTimeout(context.Background(), defaultCancelTimeout)
+	defer cancel()
+
+	resp, _, err := c.Do(ctx, inst, Request{
+		Method:     http.MethodPost,
+		Path:       fmt.Sprintf("/v1/%s/query/%s/cancel", agentID, runID),
+		HTTPClient: c.cancel,
+		Op:         fmt.Sprintf("cancel the '%s' run", agentID),
+	})
+	if err != nil {
+		c.opts.Logf("daemon: best-effort cancel for '%s' run_id=%s failed: %v", agentID, runID, err)
+		return
+	}
+	defer drainAndClose(resp)
+	if resp.StatusCode != http.StatusOK {
+		c.opts.Logf("daemon: best-effort cancel for '%s' run_id=%s answered HTTP %d",
+			agentID, runID, resp.StatusCode)
+	}
+}
+
+// ErrorDetail extracts the actionable `detail` from a daemon error response,
+// falling back to the bare status line when the body carries none.
+func ErrorDetail(resp *http.Response) string {
+	raw, err := io.ReadAll(io.LimitReader(resp.Body, 1<<16))
+	if err != nil || len(raw) == 0 {
+		return fmt.Sprintf("HTTP %d", resp.StatusCode)
+	}
+	var body struct {
+		Detail json.RawMessage `json:"detail"`
+	}
+	if err := json.Unmarshal(raw, &body); err == nil && len(body.Detail) > 0 {
+		var s string
+		if err := json.Unmarshal(body.Detail, &s); err == nil && s != "" {
+			return fmt.Sprintf("HTTP %d: %s", resp.StatusCode, s)
+		}
+		return fmt.Sprintf("HTTP %d: %s", resp.StatusCode, string(body.Detail))
+	}
+	return fmt.Sprintf("HTTP %d: %s", resp.StatusCode, strings.TrimSpace(string(raw)))
+}
+
+// StreamHTTPClient builds an HTTP client for a long-lived SSE response: connect
+// fast (a dead daemon should fail quickly), then hold the stream open — a single
+// upstream chunk can span a whole agent-loop step, so read pacing is enforced by
+// the caller's own idle watchdog rather than a client-wide timeout.
+func StreamHTTPClient(connectTimeout time.Duration) *http.Client {
+	return &http.Client{
+		Transport: &http.Transport{
+			DialContext:         (&net.Dialer{Timeout: connectTimeout}).DialContext,
+			TLSHandshakeTimeout: connectTimeout,
+			// Loopback only, one stream at a time — no pooling benefit, and a
+			// pooled connection would outlive the run.
+			DisableKeepAlives: true,
+		},
+	}
+}
+
+func drainAndClose(resp *http.Response) {
+	if resp == nil || resp.Body == nil {
+		return
+	}
+	_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, 1<<16))
+	resp.Body.Close()
+}

--- a/tui/internal/daemon/client.go
+++ b/tui/internal/daemon/client.go
@@ -19,6 +19,11 @@ const (
 	// A live daemon answers loopback in milliseconds; a longer wait only delays
 	// reclaiming a dead one.
 	defaultProbeTimeout = 1500 * time.Millisecond
+	// Default for a general Do() call. Deliberately NOT the probe timeout: a
+	// relay call does real work (e.g. GET /v1/<agent>/init checks Lemonade, the
+	// model, and connectors) and 1.5s times it out. Callers with a known-slow or
+	// streaming call still pass their own client.
+	defaultRequestTimeout = 60 * time.Second
 	// Daemon start: spawn + bind + import.
 	defaultStartTimeout = 30 * time.Second
 	// Ensure: a first-run ensure may lazily fetch the sidecar binary before answering.
@@ -58,8 +63,12 @@ type Options struct {
 // every daemon restart, so it is never cached for the process lifetime.
 type Client struct {
 	opts Options
-	// control is used for short control-plane calls (the status probe).
+	// control is used ONLY for the status probe, whose timeout is deliberately
+	// tiny — a live daemon answers loopback in milliseconds.
 	control *http.Client
+	// request is the default for Do(): everything that is not a probe, not an
+	// ensure, and not a stream.
+	request *http.Client
 	// ensure is used for the possibly-very-slow ensure call.
 	ensure *http.Client
 	// cancel is used for the best-effort run-cancel POST, which must not be cut
@@ -90,6 +99,7 @@ func New(opts Options) *Client {
 	return &Client{
 		opts:    opts,
 		control: &http.Client{Timeout: opts.ProbeTimeout},
+		request: &http.Client{Timeout: defaultRequestTimeout},
 		ensure:  &http.Client{Timeout: opts.EnsureTimeout},
 		cancel:  &http.Client{Timeout: defaultCancelTimeout},
 	}
@@ -327,7 +337,8 @@ type Request struct {
 	Body []byte
 	// Header carries extra request headers; Authorization is always set by Do.
 	Header http.Header
-	// HTTPClient overrides the client used for this call (streaming needs its own).
+	// HTTPClient overrides the client used for this call. Required for a
+	// streaming call, and for anything that can outlast defaultRequestTimeout.
 	HTTPClient *http.Client
 	// Op names the operation for error messages, e.g. "stream the 'email' query".
 	Op string
@@ -403,7 +414,7 @@ func (c *Client) send(ctx context.Context, inst *Instance, r Request) (*http.Res
 	}
 	httpClient := r.HTTPClient
 	if httpClient == nil {
-		httpClient = c.control
+		httpClient = c.request
 	}
 	resp, err := httpClient.Do(req)
 	if err != nil {
@@ -506,6 +517,13 @@ func (c *Client) CancelRun(inst *Instance, agentID, runID string) {
 		return
 	}
 	defer drainAndClose(resp)
+	// 404 is the documented answer for a run that is no longer in flight, which
+	// is exactly the case when we abandon a stream that already ended — that is
+	// success, not a failure worth reporting as one.
+	if resp.StatusCode == http.StatusNotFound {
+		c.opts.Logf("daemon: '%s' run_id=%s had already finished; nothing to cancel", agentID, runID)
+		return
+	}
 	if resp.StatusCode != http.StatusOK {
 		c.opts.Logf("daemon: best-effort cancel for '%s' run_id=%s answered HTTP %d",
 			agentID, runID, resp.StatusCode)

--- a/tui/internal/daemon/client.go
+++ b/tui/internal/daemon/client.go
@@ -28,8 +28,6 @@ const (
 	defaultStartTimeout = 30 * time.Second
 	// Ensure: a first-run ensure may lazily fetch the sidecar binary before answering.
 	defaultEnsureTimeout = 900 * time.Second
-	// Cancel must never wait out a stream read timeout.
-	defaultCancelTimeout = 10 * time.Second
 	// Cap on captured launcher output quoted back in an error.
 	maxLauncherOutput = 4096
 )
@@ -71,9 +69,6 @@ type Client struct {
 	request *http.Client
 	// ensure is used for the possibly-very-slow ensure call.
 	ensure *http.Client
-	// cancel is used for the best-effort run-cancel POST, which must not be cut
-	// short by the probe timeout nor wait out a stream read timeout.
-	cancel *http.Client
 }
 
 // New builds a Client, filling unset options with their defaults.
@@ -101,7 +96,6 @@ func New(opts Options) *Client {
 		control: &http.Client{Timeout: opts.ProbeTimeout},
 		request: &http.Client{Timeout: defaultRequestTimeout},
 		ensure:  &http.Client{Timeout: opts.EnsureTimeout},
-		cancel:  &http.Client{Timeout: defaultCancelTimeout},
 	}
 }
 
@@ -131,10 +125,14 @@ func (c *Client) Attach(ctx context.Context) (*Instance, error) {
 func (c *Client) verify(ctx context.Context, inst *Instance) error {
 	path, _ := InstancePath()
 	if !c.opts.PIDAlive(inst.PID) {
-		return &StaleError{Path: path, Reason: fmt.Sprintf("its pid %d is not running", inst.PID)}
+		return &StaleError{
+			Kind:   StalePIDDead,
+			Path:   path,
+			Reason: fmt.Sprintf("its pid %d is not running", inst.PID),
+		}
 	}
-	if err := c.probe(ctx, inst); err != nil {
-		return &StaleError{Path: path, Reason: err.Error()}
+	if kind, err := c.probe(ctx, inst); err != nil {
+		return &StaleError{Kind: kind, Path: path, Reason: err.Error()}
 	}
 	return nil
 }
@@ -144,38 +142,48 @@ type statusBody struct {
 	PID     int    `json:"pid"`
 }
 
-// probe checks the recorded port with the recorded token. It returns nil only if
-// the server answers 200 with our service id and the pid from the registry.
-func (c *Client) probe(ctx context.Context, inst *Instance) error {
+// probe checks the recorded port with the recorded token. It returns a nil error
+// only if the server answers 200 with our service id and the pid from the
+// registry. The returned StaleKind says whether a failure looks like OUR daemon
+// misbehaving or an unrelated process holding a recycled port.
+func (c *Client) probe(ctx context.Context, inst *Instance) (StaleKind, error) {
 	ctx, cancel := context.WithTimeout(ctx, c.opts.ProbeTimeout)
 	defer cancel()
 
 	req, err := c.newRequest(ctx, inst, http.MethodGet, APIPrefix+"/status", nil, nil)
 	if err != nil {
-		return err
+		return StaleUnresponsive, err
 	}
 	resp, err := c.control.Do(req)
 	if err != nil {
-		return fmt.Errorf("port %d did not answer a status probe (%v)", inst.Port, err)
+		// Refused / timed out: nothing is serving, so this is our own daemon
+		// wedged or dying rather than a foreign process.
+		return StaleUnresponsive, fmt.Errorf("port %d did not answer a status probe (%v)", inst.Port, err)
 	}
 	defer drainAndClose(resp)
 
 	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("port %d answered the status probe with HTTP %d", inst.Port, resp.StatusCode)
+		// 401 and 5xx are shapes OUR daemon produces; any other 4xx is most
+		// likely a foreign HTTP server that does not know this route.
+		kind := StaleForeign
+		if resp.StatusCode == http.StatusUnauthorized || resp.StatusCode >= 500 {
+			kind = StaleUnresponsive
+		}
+		return kind, fmt.Errorf("port %d answered the status probe with HTTP %d", inst.Port, resp.StatusCode)
 	}
 	var body statusBody
 	if err := json.NewDecoder(io.LimitReader(resp.Body, 1<<16)).Decode(&body); err != nil {
-		return fmt.Errorf("port %d answered the status probe with an unreadable body (%v)", inst.Port, err)
+		return StaleForeign, fmt.Errorf("port %d answered the status probe with an unreadable body (%v)", inst.Port, err)
 	}
 	if body.Service != ServiceID {
-		return fmt.Errorf("port %d is served by %q, not %q — an unrelated process took the freed port",
+		return StaleForeign, fmt.Errorf("port %d is served by %q, not %q — an unrelated process took the freed port",
 			inst.Port, body.Service, ServiceID)
 	}
 	if body.PID != inst.PID {
-		return fmt.Errorf("port %d is served by pid %d but the registry records pid %d",
+		return StaleForeign, fmt.Errorf("port %d is served by pid %d but the registry records pid %d",
 			inst.Port, body.PID, inst.PID)
 	}
-	return nil
+	return StaleCorrupt, nil
 }
 
 // StartOrAttach returns the running daemon, starting one only if needed.
@@ -214,14 +222,22 @@ func (c *Client) StartOrAttach(ctx context.Context) (*Instance, error) {
 		return nil, err
 	}
 
-	// A recorded pid that is alive but unresponsive is a daemon gone bad. The TUI
-	// deliberately does NOT kill it (unlike the Python client, which can verify
-	// the cmdline via psutil first): killing a possibly-recycled pid from a UI is
-	// worse than telling the user exactly what to run.
-	if rec, rerr := ReadInstance(); rerr == nil && c.opts.PIDAlive(rec.PID) {
-		return nil, &StartError{Reason: fmt.Sprintf(
-			"the recorded daemon pid %d is running but does not answer a status probe on port %d. "+
-				"Run `gaia daemon restart` to reclaim it", rec.PID, rec.Port)}
+	// A recorded pid that is alive AND whose port looks like our own wedged
+	// daemon must not be silently replaced. The TUI deliberately does NOT kill it
+	// (unlike the Python client, which can verify the cmdline via psutil first):
+	// killing a possibly-recycled pid from a UI is worse than telling the user
+	// exactly what to run.
+	//
+	// A FOREIGN answer on that port is different: the probe already proved the
+	// record is garbage (recycled pid, port taken by something else), so blocking
+	// on it would leave the TUI permanently unable to start a daemon.
+	var stale *StaleError
+	if errors.As(err, &stale) && stale.Kind == StaleUnresponsive {
+		if rec, rerr := ReadInstance(); rerr == nil && c.opts.PIDAlive(rec.PID) {
+			return nil, &StartError{Reason: fmt.Sprintf(
+				"the recorded daemon pid %d is running but does not answer a status probe on port %d. "+
+					"Run `gaia daemon restart` to reclaim it", rec.PID, rec.Port)}
+		}
 	}
 
 	return c.spawnAndWait(ctx)
@@ -250,6 +266,11 @@ func (c *Client) spawnAndWait(ctx context.Context) (*Instance, error) {
 	cmd, err := c.opts.StartCommand(startCtx)
 	if err != nil {
 		return nil, err
+	}
+	if cmd == nil {
+		return nil, &StartError{
+			Reason: "the configured daemon start command returned no command to run",
+		}
 	}
 	var out bytes.Buffer
 	if cmd.Stdout == nil {
@@ -362,7 +383,7 @@ func (c *Client) Do(ctx context.Context, inst *Instance, r Request) (*http.Respo
 	}
 	drainAndClose(resp)
 
-	fresh, err := c.refresh(ctx, inst)
+	fresh, err := c.refresh(ctx, inst, r.Path)
 	if err != nil {
 		return nil, inst, err
 	}
@@ -386,12 +407,23 @@ func (c *Client) Do(ctx context.Context, inst *Instance, r Request) (*http.Respo
 // refresh re-reads instance.json after a 401 and re-verifies it. An unchanged
 // token means the 401 was not a rotation, so retrying would just 401 again —
 // that surfaces as a loud error instead.
-func (c *Client) refresh(ctx context.Context, old *Instance) (*Instance, error) {
+func (c *Client) refresh(ctx context.Context, old *Instance, path string) (*Instance, error) {
 	fresh, err := ReadInstance()
 	if err != nil {
 		return nil, err
 	}
 	if fresh.Token == old.Token {
+		// A 401 on a RELAYED path may be the sidecar refusing its own bearer,
+		// which a daemon restart does not fix — pointing the user at
+		// `gaia daemon restart` would send them down the wrong path.
+		if !strings.HasPrefix(path, APIPrefix) {
+			return nil, &RequestError{
+				Op: fmt.Sprintf("authenticate the relayed call to %s", path),
+				Detail: "the daemon client token is current, so the 401 came from the agent sidecar " +
+					"rather than the daemon. Restart the sidecar with " +
+					"`gaia daemon stop-agent <id>` and retry",
+			}
+		}
 		return nil, &RequestError{
 			Op: "authenticate against the daemon",
 			Detail: "it rejected the client token (HTTP 401) but instance.json still records the same token. " +
@@ -500,34 +532,11 @@ func (c *Client) EnsureAgent(ctx context.Context, agentID string) (*Instance, er
 	return inst, nil
 }
 
-// CancelRun asks the relay to cancel a streaming run. Best-effort: the sidecar
-// may already be gone, so failures are logged, never raised.
-func (c *Client) CancelRun(inst *Instance, agentID, runID string) {
-	ctx, cancel := context.WithTimeout(context.Background(), defaultCancelTimeout)
-	defer cancel()
-
-	resp, _, err := c.Do(ctx, inst, Request{
-		Method:     http.MethodPost,
-		Path:       fmt.Sprintf("/v1/%s/query/%s/cancel", agentID, runID),
-		HTTPClient: c.cancel,
-		Op:         fmt.Sprintf("cancel the '%s' run", agentID),
-	})
-	if err != nil {
-		c.opts.Logf("daemon: best-effort cancel for '%s' run_id=%s failed: %v", agentID, runID, err)
-		return
-	}
-	defer drainAndClose(resp)
-	// 404 is the documented answer for a run that is no longer in flight, which
-	// is exactly the case when we abandon a stream that already ended — that is
-	// success, not a failure worth reporting as one.
-	if resp.StatusCode == http.StatusNotFound {
-		c.opts.Logf("daemon: '%s' run_id=%s had already finished; nothing to cancel", agentID, runID)
-		return
-	}
-	if resp.StatusCode != http.StatusOK {
-		c.opts.Logf("daemon: best-effort cancel for '%s' run_id=%s answered HTTP %d",
-			agentID, runID, resp.StatusCode)
-	}
+// Logf emits a diagnostic through the client's configured logger. Exported so
+// callers that own an agent-contract call (e.g. the SSE transport's cancel) log
+// through the same channel. Never pass a raw token.
+func (c *Client) Logf(format string, args ...any) {
+	c.opts.Logf(format, args...)
 }
 
 // ErrorDetail extracts the actionable `detail` from a daemon error response,
@@ -554,11 +563,18 @@ func ErrorDetail(resp *http.Response) string {
 // fast (a dead daemon should fail quickly), then hold the stream open — a single
 // upstream chunk can span a whole agent-loop step, so read pacing is enforced by
 // the caller's own idle watchdog rather than a client-wide timeout.
-func StreamHTTPClient(connectTimeout time.Duration) *http.Client {
+//
+// headerTimeout bounds the wait for the response STATUS LINE only, which no
+// client-wide timeout can express without also capping the stream. Without it a
+// daemon that completes the handshake and never answers hangs the caller
+// forever — the reference implementation gets this for free because requests'
+// read timeout also covers the header wait.
+func StreamHTTPClient(connectTimeout, headerTimeout time.Duration) *http.Client {
 	return &http.Client{
 		Transport: &http.Transport{
-			DialContext:         (&net.Dialer{Timeout: connectTimeout}).DialContext,
-			TLSHandshakeTimeout: connectTimeout,
+			DialContext:           (&net.Dialer{Timeout: connectTimeout}).DialContext,
+			TLSHandshakeTimeout:   connectTimeout,
+			ResponseHeaderTimeout: headerTimeout,
 			// Loopback only, one stream at a time — no pooling benefit, and a
 			// pooled connection would outlive the run.
 			DisableKeepAlives: true,

--- a/tui/internal/daemon/daemon_test.go
+++ b/tui/internal/daemon/daemon_test.go
@@ -732,3 +732,173 @@ func containsAuth(seen []string, token string) bool {
 	}
 	return false
 }
+
+// A recycled pid whose port is answered by an UNRELATED service means the record
+// is garbage — the probe already proved it. Blocking on it (as an earlier version
+// did, keying only off pid liveness) left the TUI permanently unable to start a
+// daemon until the user intervened.
+func TestStartOrAttachReclaimsARecycledPortFromAForeignService(t *testing.T) {
+	f := newFakeDaemon(t)
+	f.writeInstance(nil)
+	f.mu.Lock()
+	f.service = "some-unrelated-server" // the freed port was taken by something else
+	f.mu.Unlock()
+
+	// The launcher registers a fresh, healthy instance.
+	fresh := &Instance{
+		PID: os.Getpid(), Port: f.port(), Token: "token-A",
+		Host: DefaultHost, APIVersion: "1.1", Service: ServiceID,
+	}
+	payload, err := json.Marshal(fresh)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	spawned := false
+	c := testClient(t, func(o *Options) {
+		// The recorded pid IS alive (it is this test process).
+		o.StartCommand = func(ctx context.Context) (*exec.Cmd, error) {
+			spawned = true
+			f.mu.Lock()
+			f.service = ServiceID // the new daemon answers properly
+			f.mu.Unlock()
+			return launcher(t, f.dir, string(payload), "")(ctx)
+		}
+	})
+
+	if _, err := c.StartOrAttach(context.Background()); err != nil {
+		t.Fatalf("StartOrAttach must reclaim a garbage record, got: %v", err)
+	}
+	if !spawned {
+		t.Error("a foreign service on the recorded port must not block starting a daemon")
+	}
+}
+
+// The mirror case: our OWN pid alive and the port refusing/erroring is a wedged
+// daemon, which must NOT be silently replaced.
+func TestStaleKindClassification(t *testing.T) {
+	f := newFakeDaemon(t)
+	f.writeInstance(nil)
+
+	cases := []struct {
+		name   string
+		setup  func()
+		want   StaleKind
+		reason string
+	}{
+		{"foreign service", func() { f.mu.Lock(); f.service = "other"; f.mu.Unlock() }, StaleForeign, "took the freed port"},
+		{"pid mismatch", func() {
+			f.mu.Lock()
+			f.service = ServiceID
+			f.reportedPID = os.Getpid() + 100000
+			f.mu.Unlock()
+		}, StaleForeign, "registry records pid"},
+		{"our daemon 5xx", func() {
+			f.mu.Lock()
+			f.reportedPID = os.Getpid()
+			f.statusCode = http.StatusInternalServerError
+			f.mu.Unlock()
+		}, StaleUnresponsive, "HTTP 500"},
+		{"foreign 404", func() { f.mu.Lock(); f.statusCode = http.StatusNotFound; f.mu.Unlock() }, StaleForeign, "HTTP 404"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			tc.setup()
+			_, err := testClient(t, nil).Attach(context.Background())
+			var se *StaleError
+			if !asError(err, &se) {
+				t.Fatalf("expected *StaleError, got %#v (%v)", err, err)
+			}
+			if se.Kind != tc.want {
+				t.Errorf("Kind = %d, want %d (%v)", se.Kind, tc.want, err)
+			}
+			if !strings.Contains(err.Error(), tc.reason) {
+				t.Errorf("error %q must mention %q", err, tc.reason)
+			}
+		})
+	}
+}
+
+func TestStartOrAttachRejectsANilStartCommand(t *testing.T) {
+	newFakeDaemon(t) // no instance.json written
+
+	c := testClient(t, func(o *Options) {
+		o.StartCommand = func(context.Context) (*exec.Cmd, error) { return nil, nil }
+	})
+	_, err := c.StartOrAttach(context.Background())
+	var se *StartError
+	if !asError(err, &se) {
+		t.Fatalf("expected *StartError rather than a panic, got %#v (%v)", err, err)
+	}
+}
+
+// A 401 on a RELAYED path is the sidecar refusing its bearer, which a daemon
+// restart does not fix — the remedy must not point at the daemon.
+func TestRelayed401BlamesTheSidecarNotTheDaemon(t *testing.T) {
+	f := newFakeDaemon(t)
+	f.writeInstance(nil)
+
+	c := testClient(t, nil)
+	inst, err := c.Attach(context.Background())
+	if err != nil {
+		t.Fatalf("Attach: %v", err)
+	}
+	f.mu.Lock()
+	f.token = "server-only-token" // every request now 401s, file unchanged
+	f.mu.Unlock()
+
+	_, _, err = c.Do(context.Background(), inst, Request{
+		Method: http.MethodPost, Path: "/v1/email/query",
+	})
+	if err == nil {
+		t.Fatal("expected an error")
+	}
+	if !strings.Contains(err.Error(), "sidecar") {
+		t.Errorf("a relayed 401 must blame the sidecar: %v", err)
+	}
+	if strings.Contains(err.Error(), "gaia daemon restart") {
+		t.Errorf("a relayed 401 must not send the user to restart the daemon: %v", err)
+	}
+
+	// The daemon-plane equivalent keeps the daemon remedy.
+	_, _, err = c.Do(context.Background(), inst, Request{
+		Method: http.MethodGet, Path: APIPrefix + "/status",
+	})
+	if err == nil || !strings.Contains(err.Error(), "gaia daemon restart") {
+		t.Errorf("a daemon-plane 401 must keep the daemon remedy: %v", err)
+	}
+}
+
+// If the daemon still rejects the refreshed token, that must surface as a loud
+// error rather than an endless retry loop.
+func TestDoFailsWhenTheRefreshedTokenIsAlsoRejected(t *testing.T) {
+	f := newFakeDaemon(t)
+	f.writeInstance(nil)
+
+	c := testClient(t, nil)
+	inst, err := c.Attach(context.Background())
+	if err != nil {
+		t.Fatalf("Attach: %v", err)
+	}
+
+	// instance.json rotates to token-B (so the retry is attempted) but the server
+	// requires a third token neither side has.
+	f.writeInstance(func(i *Instance) { i.Token = "token-B" })
+	f.mu.Lock()
+	f.token = "token-C"
+	f.mu.Unlock()
+
+	_, _, err = c.Do(context.Background(), inst, Request{
+		Method: http.MethodGet,
+		Path:   APIPrefix + "/status",
+	})
+	if err == nil {
+		t.Fatal("expected an error when the refreshed token is also rejected")
+	}
+	// The refreshed instance cannot pass the liveness probe either, so the failure
+	// must name the stale registry rather than loop.
+	if !strings.Contains(err.Error(), "cannot be trusted") && !strings.Contains(err.Error(), "401") {
+		t.Errorf("error should explain the auth failure: %v", err)
+	}
+}

--- a/tui/internal/daemon/daemon_test.go
+++ b/tui/internal/daemon/daemon_test.go
@@ -1,0 +1,734 @@
+package daemon
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// sidecarSecret stands in for the sidecar bearer the daemon returns from
+// /ensure. A thin client must never end up holding it.
+const sidecarSecret = "SIDECAR-BEARER-MUST-NOT-LEAK"
+
+// fakeDaemon is an httptest server that answers the daemon's control plane,
+// paired with an instance.json in an isolated GAIA_DAEMON_HOME.
+type fakeDaemon struct {
+	t   *testing.T
+	srv *httptest.Server
+	dir string
+
+	mu           sync.Mutex
+	token        string
+	reportedPID  int
+	service      string
+	statusCode   int
+	ensureStatus int
+	ensureDetail string
+	authSeen     []string
+	paths        []string
+}
+
+func newFakeDaemon(t *testing.T) *fakeDaemon {
+	t.Helper()
+
+	dir := t.TempDir()
+	t.Setenv(EnvHome, dir)
+
+	f := &fakeDaemon{
+		t:            t,
+		dir:          dir,
+		token:        "token-A",
+		reportedPID:  os.Getpid(),
+		service:      ServiceID,
+		statusCode:   http.StatusOK,
+		ensureStatus: http.StatusOK,
+	}
+	f.srv = httptest.NewServer(http.HandlerFunc(f.handle))
+	t.Cleanup(f.srv.Close)
+
+	if f.port() == ReservedPort {
+		t.Fatalf("test server bound the reserved port %d", ReservedPort)
+	}
+	return f
+}
+
+func (f *fakeDaemon) port() int {
+	u, err := url.Parse(f.srv.URL)
+	if err != nil {
+		f.t.Fatalf("parse server URL: %v", err)
+	}
+	p, err := strconv.Atoi(u.Port())
+	if err != nil {
+		f.t.Fatalf("parse server port: %v", err)
+	}
+	return p
+}
+
+func (f *fakeDaemon) handle(w http.ResponseWriter, r *http.Request) {
+	f.mu.Lock()
+	token := f.token
+	f.authSeen = append(f.authSeen, r.Header.Get("Authorization"))
+	f.paths = append(f.paths, r.Method+" "+r.URL.Path)
+	f.mu.Unlock()
+
+	if r.Header.Get("Authorization") != AuthScheme+" "+token {
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte(`{"detail":"invalid or expired client token"}`))
+		return
+	}
+
+	switch {
+	case r.URL.Path == APIPrefix+"/status":
+		f.mu.Lock()
+		code, service, pid := f.statusCode, f.service, f.reportedPID
+		f.mu.Unlock()
+		if code != http.StatusOK {
+			w.WriteHeader(code)
+			return
+		}
+		writeJSON(w, map[string]any{"service": service, "pid": pid, "api_version": DAEMONAPIVersionForTest})
+
+	case strings.HasSuffix(r.URL.Path, "/ensure"):
+		f.mu.Lock()
+		code, detail := f.ensureStatus, f.ensureDetail
+		f.mu.Unlock()
+		if code != http.StatusOK {
+			w.WriteHeader(code)
+			writeJSON(w, map[string]any{"detail": detail})
+			return
+		}
+		// The real daemon's ensure response carries the sidecar bearer; the
+		// client must discard it.
+		writeJSON(w, map[string]any{"port": 51999, "token": sidecarSecret, "state": "running"})
+
+	default:
+		w.WriteHeader(http.StatusNotFound)
+		writeJSON(w, map[string]any{"detail": "no route " + r.URL.Path})
+	}
+}
+
+// DAEMONAPIVersionForTest is what the fake reports in its status body. The client
+// reads the contract version from instance.json, not from the probe, so this is
+// only cosmetic.
+const DAEMONAPIVersionForTest = "1.1"
+
+func writeJSON(w http.ResponseWriter, v any) {
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(v)
+}
+
+// writeInstance persists an instance.json into the fake's home directory.
+func (f *fakeDaemon) writeInstance(mutate func(*Instance)) *Instance {
+	f.t.Helper()
+
+	f.mu.Lock()
+	inst := &Instance{
+		PID:        os.Getpid(),
+		Port:       f.port(),
+		Token:      f.token,
+		Host:       DefaultHost,
+		APIVersion: "1.1",
+		Service:    ServiceID,
+		StartedAt:  1.0,
+	}
+	f.mu.Unlock()
+
+	if mutate != nil {
+		mutate(inst)
+	}
+	raw, err := json.MarshalIndent(inst, "", "  ")
+	if err != nil {
+		f.t.Fatalf("marshal instance: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(f.dir, "instance.json"), raw, 0o600); err != nil {
+		f.t.Fatalf("write instance.json: %v", err)
+	}
+	return inst
+}
+
+func (f *fakeDaemon) rotateToken(next string) {
+	f.mu.Lock()
+	f.token = next
+	f.mu.Unlock()
+	f.writeInstance(func(i *Instance) { i.Token = next })
+}
+
+func (f *fakeDaemon) sawPath(want string) bool {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	for _, p := range f.paths {
+		if p == want {
+			return true
+		}
+	}
+	return false
+}
+
+// testClient builds a Client with fast timeouts and no real launcher.
+func testClient(t *testing.T, mutate func(*Options)) *Client {
+	t.Helper()
+	opts := Options{
+		ProbeTimeout:  2 * time.Second,
+		StartTimeout:  3 * time.Second,
+		EnsureTimeout: 5 * time.Second,
+		StartCommand: func(context.Context) (*exec.Cmd, error) {
+			return nil, &StartError{Reason: "no launcher was configured for this test"}
+		},
+		Logf: func(format string, args ...any) { t.Logf(format, args...) },
+	}
+	if mutate != nil {
+		mutate(&opts)
+	}
+	return New(opts)
+}
+
+// --- trust checks -----------------------------------------------------------
+
+func TestAttachHappyPath(t *testing.T) {
+	f := newFakeDaemon(t)
+	f.writeInstance(nil)
+
+	inst, err := testClient(t, nil).Attach(context.Background())
+	if err != nil {
+		t.Fatalf("Attach: %v", err)
+	}
+	if inst.Port != f.port() || inst.Token != "token-A" {
+		t.Errorf("unexpected instance: %+v", inst)
+	}
+}
+
+func TestAttachMissingInstanceFile(t *testing.T) {
+	newFakeDaemon(t) // sets GAIA_DAEMON_HOME, writes nothing
+
+	_, err := testClient(t, nil).Attach(context.Background())
+	var nr *NotRunningError
+	if !asError(err, &nr) {
+		t.Fatalf("expected *NotRunningError, got %#v (%v)", err, err)
+	}
+	if !strings.Contains(err.Error(), "gaia daemon start") {
+		t.Errorf("error must name the remedy: %v", err)
+	}
+}
+
+func TestAttachMalformedInstanceFile(t *testing.T) {
+	f := newFakeDaemon(t)
+	if err := os.WriteFile(filepath.Join(f.dir, "instance.json"), []byte("{not json"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := testClient(t, nil).Attach(context.Background())
+	var se *StaleError
+	if !asError(err, &se) {
+		t.Fatalf("expected *StaleError, got %#v (%v)", err, err)
+	}
+	if !strings.Contains(err.Error(), "gaia daemon restart") {
+		t.Errorf("error must name the remedy: %v", err)
+	}
+}
+
+func TestAttachDeadPID(t *testing.T) {
+	f := newFakeDaemon(t)
+	f.writeInstance(nil)
+
+	c := testClient(t, func(o *Options) {
+		o.PIDAlive = func(int) bool { return false }
+	})
+	_, err := c.Attach(context.Background())
+	var se *StaleError
+	if !asError(err, &se) {
+		t.Fatalf("expected *StaleError, got %#v (%v)", err, err)
+	}
+	if !strings.Contains(err.Error(), "not running") {
+		t.Errorf("error must say the pid is dead: %v", err)
+	}
+	// The probe must not even be attempted once the pid is known dead.
+	if f.sawPath("GET " + APIPrefix + "/status") {
+		t.Error("a dead pid must short-circuit before probing")
+	}
+}
+
+func TestAttachPIDMismatch(t *testing.T) {
+	f := newFakeDaemon(t)
+	f.writeInstance(nil)
+	f.mu.Lock()
+	f.reportedPID = os.Getpid() + 100000 // a different process answers the port
+	f.mu.Unlock()
+
+	_, err := testClient(t, nil).Attach(context.Background())
+	var se *StaleError
+	if !asError(err, &se) {
+		t.Fatalf("expected *StaleError, got %#v (%v)", err, err)
+	}
+	if !strings.Contains(err.Error(), "registry records pid") {
+		t.Errorf("error must name the pid mismatch: %v", err)
+	}
+}
+
+func TestAttachWrongService(t *testing.T) {
+	f := newFakeDaemon(t)
+	f.writeInstance(nil)
+	f.mu.Lock()
+	f.service = "some-other-server"
+	f.mu.Unlock()
+
+	_, err := testClient(t, nil).Attach(context.Background())
+	var se *StaleError
+	if !asError(err, &se) {
+		t.Fatalf("expected *StaleError, got %#v (%v)", err, err)
+	}
+	if !strings.Contains(err.Error(), "took the freed port") {
+		t.Errorf("error must explain the recycled port: %v", err)
+	}
+}
+
+func TestAttachStatusNon200(t *testing.T) {
+	f := newFakeDaemon(t)
+	f.writeInstance(nil)
+	f.mu.Lock()
+	f.statusCode = http.StatusInternalServerError
+	f.mu.Unlock()
+
+	_, err := testClient(t, nil).Attach(context.Background())
+	var se *StaleError
+	if !asError(err, &se) {
+		t.Fatalf("expected *StaleError, got %#v (%v)", err, err)
+	}
+}
+
+func TestAttachMajorVersionMismatch(t *testing.T) {
+	f := newFakeDaemon(t)
+	f.writeInstance(func(i *Instance) { i.APIVersion = "2.0" })
+
+	_, err := testClient(t, nil).Attach(context.Background())
+	var ve *VersionError
+	if !asError(err, &ve) {
+		t.Fatalf("expected *VersionError, got %#v (%v)", err, err)
+	}
+	if !strings.Contains(err.Error(), "gaia daemon restart") {
+		t.Errorf("error must name the remedy: %v", err)
+	}
+}
+
+func TestAttachUnparsableVersion(t *testing.T) {
+	f := newFakeDaemon(t)
+	f.writeInstance(func(i *Instance) { i.APIVersion = "nightly" })
+
+	_, err := testClient(t, nil).Attach(context.Background())
+	var ve *VersionError
+	if !asError(err, &ve) {
+		t.Fatalf("expected *VersionError, got %#v (%v)", err, err)
+	}
+}
+
+func TestEnsureAgentRejectsMinorBelowAgentsFloor(t *testing.T) {
+	f := newFakeDaemon(t)
+	f.writeInstance(func(i *Instance) { i.APIVersion = "1.0" })
+
+	// A pre-#2142 daemon passes the MAJOR gate, so plain Attach succeeds …
+	if _, err := testClient(t, nil).Attach(context.Background()); err != nil {
+		t.Fatalf("Attach on v1.0 should pass the MAJOR gate: %v", err)
+	}
+	// … but every agents route would 404, so EnsureAgent must refuse.
+	_, err := testClient(t, nil).EnsureAgent(context.Background(), "email")
+	var ve *VersionError
+	if !asError(err, &ve) {
+		t.Fatalf("expected *VersionError, got %#v (%v)", err, err)
+	}
+	if !strings.Contains(err.Error(), "v1.1+") {
+		t.Errorf("error must name the required floor: %v", err)
+	}
+	if f.sawPath("POST " + APIPrefix + "/agents/email/ensure") {
+		t.Error("the ensure call must not be attempted below the agents floor")
+	}
+}
+
+func TestAttachRejectsReservedPort(t *testing.T) {
+	f := newFakeDaemon(t)
+	f.writeInstance(func(i *Instance) { i.Port = ReservedPort })
+
+	_, err := testClient(t, nil).Attach(context.Background())
+	var se *StaleError
+	if !asError(err, &se) {
+		t.Fatalf("expected *StaleError, got %#v (%v)", err, err)
+	}
+	if !strings.Contains(err.Error(), strconv.Itoa(ReservedPort)) {
+		t.Errorf("error must name the reserved port: %v", err)
+	}
+}
+
+func TestReadInstanceRejectsIncompleteRecords(t *testing.T) {
+	f := newFakeDaemon(t)
+
+	cases := []struct {
+		name   string
+		mutate func(*Instance)
+		want   string
+	}{
+		{"no pid", func(i *Instance) { i.PID = 0 }, "no usable pid"},
+		{"no token", func(i *Instance) { i.Token = "" }, "no client token"},
+		{"no api_version", func(i *Instance) { i.APIVersion = "" }, "no api_version"},
+		{"foreign service", func(i *Instance) { i.Service = "not-gaia" }, "written by service"},
+		{"bad port", func(i *Instance) { i.Port = 70000 }, "invalid port"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			f.writeInstance(tc.mutate)
+			_, err := ReadInstance()
+			var se *StaleError
+			if !asError(err, &se) {
+				t.Fatalf("expected *StaleError, got %#v (%v)", err, err)
+			}
+			if !strings.Contains(err.Error(), tc.want) {
+				t.Errorf("error %q must mention %q", err, tc.want)
+			}
+		})
+	}
+}
+
+// --- token rotation ---------------------------------------------------------
+
+func TestDoRetriesOnceAfterTokenRotation(t *testing.T) {
+	f := newFakeDaemon(t)
+	f.writeInstance(nil)
+
+	c := testClient(t, nil)
+	inst, err := c.Attach(context.Background())
+	if err != nil {
+		t.Fatalf("Attach: %v", err)
+	}
+
+	// The daemon restarted: it now requires token-B and instance.json records
+	// token-B, while the caller still holds the token-A instance in memory.
+	f.rotateToken("token-B")
+
+	resp, fresh, err := c.Do(context.Background(), inst, Request{
+		Method: http.MethodGet,
+		Path:   APIPrefix + "/status",
+	})
+	if err != nil {
+		t.Fatalf("Do: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("after the retry, status = %d, want 200", resp.StatusCode)
+	}
+	if fresh.Token != "token-B" {
+		t.Errorf("returned instance still carries the old token")
+	}
+	f.mu.Lock()
+	auths := append([]string(nil), f.authSeen...)
+	f.mu.Unlock()
+	if !containsAuth(auths, "token-A") || !containsAuth(auths, "token-B") {
+		t.Errorf("expected one attempt per token, saw %d requests", len(auths))
+	}
+}
+
+func TestDoFailsWhenTokenDidNotRotate(t *testing.T) {
+	f := newFakeDaemon(t)
+	f.writeInstance(nil)
+
+	c := testClient(t, nil)
+	inst, err := c.Attach(context.Background())
+	if err != nil {
+		t.Fatalf("Attach: %v", err)
+	}
+	// The server rejects everything but instance.json still records token-A, so a
+	// retry could only 401 again.
+	f.mu.Lock()
+	f.token = "token-Z"
+	f.mu.Unlock()
+
+	_, _, err = c.Do(context.Background(), inst, Request{
+		Method: http.MethodGet,
+		Path:   APIPrefix + "/status",
+	})
+	if err == nil {
+		t.Fatal("expected an error for an unrotated 401")
+	}
+	if !strings.Contains(err.Error(), "same token") {
+		t.Errorf("error must explain the unrotated token: %v", err)
+	}
+}
+
+// --- ensure -----------------------------------------------------------------
+
+func TestEnsureAgentNeverReturnsTheSidecarToken(t *testing.T) {
+	f := newFakeDaemon(t)
+	f.writeInstance(nil)
+
+	inst, err := testClient(t, nil).EnsureAgent(context.Background(), "email")
+	if err != nil {
+		t.Fatalf("EnsureAgent: %v", err)
+	}
+	if inst.Token != "token-A" {
+		t.Errorf("client must keep presenting the DAEMON token, got %q", inst.Token)
+	}
+	if strings.Contains(inst.String(), sidecarSecret) {
+		t.Error("the sidecar bearer leaked into the instance")
+	}
+	if !f.sawPath("POST " + APIPrefix + "/agents/email/ensure") {
+		t.Error("ensure was never called")
+	}
+}
+
+func TestEnsureAgentSurfacesDaemonRefusal(t *testing.T) {
+	f := newFakeDaemon(t)
+	f.writeInstance(nil)
+	f.mu.Lock()
+	f.ensureStatus = http.StatusServiceUnavailable
+	f.ensureDetail = "agent 'email' is not installed; run `gaia hub install email`"
+	f.mu.Unlock()
+
+	_, err := testClient(t, nil).EnsureAgent(context.Background(), "email")
+	if err == nil {
+		t.Fatal("expected an error when the daemon refuses to ensure")
+	}
+	if !strings.Contains(err.Error(), "gaia hub install email") {
+		t.Errorf("the daemon's actionable detail must be surfaced verbatim: %v", err)
+	}
+}
+
+func TestInstanceStringRedactsToken(t *testing.T) {
+	inst := &Instance{PID: 42, Port: 5000, Token: "super-secret", Host: DefaultHost, APIVersion: "1.1", Service: ServiceID}
+	got := fmt.Sprintf("%v / %s", inst, inst)
+	if strings.Contains(got, "super-secret") {
+		t.Fatalf("token leaked through String(): %s", got)
+	}
+	if !strings.Contains(got, "<redacted>") {
+		t.Errorf("expected a redaction marker, got %s", got)
+	}
+}
+
+// --- start-or-attach --------------------------------------------------------
+
+// TestHelperProcess doubles as a fake `gaia daemon start`: it writes the
+// instance.json handed to it via the environment, then exits.
+func TestHelperProcess(t *testing.T) {
+	if os.Getenv("GAIA_TUI_TEST_LAUNCHER") != "1" {
+		return
+	}
+	defer os.Exit(0)
+
+	if payload := os.Getenv("GAIA_TUI_TEST_INSTANCE"); payload != "" {
+		path := filepath.Join(os.Getenv(EnvHome), "instance.json")
+		if err := os.WriteFile(path, []byte(payload), 0o600); err != nil {
+			fmt.Fprintf(os.Stderr, "helper: %v\n", err)
+			os.Exit(2)
+		}
+	}
+	if code := os.Getenv("GAIA_TUI_TEST_EXIT"); code != "" {
+		fmt.Fprintln(os.Stderr, "helper: simulated launcher failure")
+		n, _ := strconv.Atoi(code)
+		os.Exit(n)
+	}
+}
+
+func launcher(t *testing.T, dir, payload, exitCode string) func(context.Context) (*exec.Cmd, error) {
+	t.Helper()
+	return func(ctx context.Context) (*exec.Cmd, error) {
+		cmd := exec.CommandContext(ctx, os.Args[0], "-test.run=^TestHelperProcess$")
+		cmd.Env = append(os.Environ(),
+			"GAIA_TUI_TEST_LAUNCHER=1",
+			"GAIA_TUI_TEST_INSTANCE="+payload,
+			"GAIA_TUI_TEST_EXIT="+exitCode,
+			EnvHome+"="+dir,
+		)
+		return cmd, nil
+	}
+}
+
+func TestStartOrAttachSpawnsWhenNothingIsRegistered(t *testing.T) {
+	f := newFakeDaemon(t)
+
+	// The launcher registers an instance pointing at the fake server.
+	inst := &Instance{
+		PID: os.Getpid(), Port: f.port(), Token: "token-A",
+		Host: DefaultHost, APIVersion: "1.1", Service: ServiceID,
+	}
+	payload, err := json.Marshal(inst)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	c := testClient(t, func(o *Options) {
+		o.StartCommand = launcher(t, f.dir, string(payload), "")
+	})
+	got, err := c.StartOrAttach(context.Background())
+	if err != nil {
+		t.Fatalf("StartOrAttach: %v", err)
+	}
+	if got.Port != f.port() {
+		t.Errorf("attached to port %d, want %d", got.Port, f.port())
+	}
+}
+
+func TestStartOrAttachSurfacesLauncherFailure(t *testing.T) {
+	f := newFakeDaemon(t)
+
+	c := testClient(t, func(o *Options) {
+		o.StartCommand = launcher(t, f.dir, "", "3")
+	})
+	_, err := c.StartOrAttach(context.Background())
+	var se *StartError
+	if !asError(err, &se) {
+		t.Fatalf("expected *StartError, got %#v (%v)", err, err)
+	}
+	if !strings.Contains(err.Error(), "simulated launcher failure") {
+		t.Errorf("the launcher's own output must be quoted back: %v", err)
+	}
+}
+
+func TestStartOrAttachRefusesToKillALiveButUnresponsiveDaemon(t *testing.T) {
+	f := newFakeDaemon(t)
+	f.writeInstance(nil)
+	f.mu.Lock()
+	f.statusCode = http.StatusInternalServerError
+	f.mu.Unlock()
+
+	c := testClient(t, func(o *Options) {
+		o.StartCommand = func(context.Context) (*exec.Cmd, error) {
+			t.Error("a live-but-unresponsive daemon must not be replaced silently")
+			return nil, &StartError{Reason: "unreachable"}
+		}
+	})
+	_, err := c.StartOrAttach(context.Background())
+	if err == nil {
+		t.Fatal("expected an error")
+	}
+	if !strings.Contains(err.Error(), "gaia daemon restart") {
+		t.Errorf("error must tell the user how to reclaim it: %v", err)
+	}
+}
+
+func TestStartOrAttachPropagatesVersionSkewWithoutSpawning(t *testing.T) {
+	f := newFakeDaemon(t)
+	f.writeInstance(func(i *Instance) { i.APIVersion = "9.0" })
+
+	c := testClient(t, func(o *Options) {
+		o.StartCommand = func(context.Context) (*exec.Cmd, error) {
+			t.Error("a version skew must not trigger a second daemon")
+			return nil, &StartError{Reason: "unreachable"}
+		}
+	})
+	_, err := c.StartOrAttach(context.Background())
+	var ve *VersionError
+	if !asError(err, &ve) {
+		t.Fatalf("expected *VersionError, got %#v (%v)", err, err)
+	}
+}
+
+// --- primitives -------------------------------------------------------------
+
+func TestPIDAlive(t *testing.T) {
+	if !PIDAlive(os.Getpid()) {
+		t.Error("the test process must read as alive")
+	}
+	if PIDAlive(0) || PIDAlive(-1) {
+		t.Error("non-positive pids must read as dead")
+	}
+
+	// A reaped child is the canonical dead pid.
+	cmd := exec.Command(os.Args[0], "-test.run=^TestHelperProcess$")
+	cmd.Env = append(os.Environ(), "GAIA_TUI_TEST_LAUNCHER=1")
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("run helper: %v", err)
+	}
+	if PIDAlive(cmd.Process.Pid) {
+		t.Errorf("reaped pid %d must read as dead", cmd.Process.Pid)
+	}
+}
+
+func TestStartLockIsExclusive(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "instance.lock")
+
+	first, err := acquireLock(path, time.Second)
+	if err != nil {
+		t.Fatalf("first acquireLock: %v", err)
+	}
+
+	if _, err := acquireLock(path, 300*time.Millisecond); err == nil {
+		t.Fatal("a second holder must not get the lock while the first holds it")
+	} else if !strings.Contains(err.Error(), "start lock") {
+		t.Errorf("error must name the lock: %v", err)
+	}
+
+	first.release()
+
+	second, err := acquireLock(path, time.Second)
+	if err != nil {
+		t.Fatalf("acquireLock after release: %v", err)
+	}
+	second.release()
+}
+
+func TestParseAPIVersion(t *testing.T) {
+	cases := []struct {
+		in           string
+		major, minor int
+		wantErr      bool
+	}{
+		{"1.1", 1, 1, false},
+		{"1.0", 1, 0, false},
+		{"1", 1, 0, false},
+		{"2.14", 2, 14, false},
+		{"1.x", 1, 0, false},
+		{"", 0, 0, true},
+		{"beta", 0, 0, true},
+	}
+	for _, tc := range cases {
+		major, minor, err := parseAPIVersion(tc.in)
+		if tc.wantErr {
+			if err == nil {
+				t.Errorf("parseAPIVersion(%q): expected an error", tc.in)
+			}
+			continue
+		}
+		if err != nil {
+			t.Errorf("parseAPIVersion(%q): %v", tc.in, err)
+			continue
+		}
+		if major != tc.major || minor != tc.minor {
+			t.Errorf("parseAPIVersion(%q) = %d.%d, want %d.%d", tc.in, major, minor, tc.major, tc.minor)
+		}
+	}
+}
+
+// --- helpers ----------------------------------------------------------------
+
+// asError is errors.As with the generic plumbing inlined so each test reads as
+// one line.
+func asError[T error](err error, target *T) bool {
+	for err != nil {
+		if t, ok := err.(T); ok {
+			*target = t
+			return true
+		}
+		u, ok := err.(interface{ Unwrap() error })
+		if !ok {
+			return false
+		}
+		err = u.Unwrap()
+	}
+	return false
+}
+
+func containsAuth(seen []string, token string) bool {
+	for _, s := range seen {
+		if s == AuthScheme+" "+token {
+			return true
+		}
+	}
+	return false
+}

--- a/tui/internal/daemon/errors.go
+++ b/tui/internal/daemon/errors.go
@@ -14,12 +14,32 @@ func (e *NotRunningError) Error() string {
 			"Start one with `gaia daemon start`.", e.Path)
 }
 
+// StaleKind classifies WHY a recorded instance cannot be trusted, because the
+// remedy differs: a garbage record is reclaimed by starting a fresh daemon,
+// whereas our own live-but-wedged daemon must not be silently replaced.
+type StaleKind int
+
+const (
+	// StaleCorrupt — the file is missing fields, unreadable, or not JSON.
+	StaleCorrupt StaleKind = iota
+	// StalePIDDead — the recorded pid is gone.
+	StalePIDDead
+	// StaleUnresponsive — the pid is alive but the recorded port does not answer
+	// as a healthy daemon. Probably our own daemon gone bad.
+	StaleUnresponsive
+	// StaleForeign — the port answers as a different service, or as a different
+	// pid. After a hard crash the OS reused the pid AND something else took the
+	// freed port, so the record is garbage and can be reclaimed.
+	StaleForeign
+)
+
 // StaleError means instance.json exists but must not be trusted: it is corrupt,
 // its pid is dead, or the recorded port answers as something other than our
-// daemon. Reason names which check failed.
+// daemon. Reason names which check failed; Kind drives the recovery decision.
 type StaleError struct {
 	Path   string
 	Reason string
+	Kind   StaleKind
 }
 
 func (e *StaleError) Error() string {

--- a/tui/internal/daemon/errors.go
+++ b/tui/internal/daemon/errors.go
@@ -1,0 +1,71 @@
+package daemon
+
+import "fmt"
+
+// NotRunningError means no daemon has registered itself at all — instance.json
+// is absent. Distinct from StaleError so a caller can decide to start one.
+type NotRunningError struct {
+	Path string
+}
+
+func (e *NotRunningError) Error() string {
+	return fmt.Sprintf(
+		"no GAIA daemon is registered (%s does not exist). "+
+			"Start one with `gaia daemon start`.", e.Path)
+}
+
+// StaleError means instance.json exists but must not be trusted: it is corrupt,
+// its pid is dead, or the recorded port answers as something other than our
+// daemon. Reason names which check failed.
+type StaleError struct {
+	Path   string
+	Reason string
+}
+
+func (e *StaleError) Error() string {
+	return fmt.Sprintf(
+		"the recorded GAIA daemon at %s cannot be trusted: %s. "+
+			"Reclaim it with `gaia daemon restart`, then retry; "+
+			"the daemon log is at %s.", e.Path, e.Reason, logPathForMessage())
+}
+
+// VersionError means the running daemon speaks a contract this client cannot
+// use — a MAJOR skew, or a MINOR below the agents/relay floor. The remedy is
+// always a daemon restart: an app update replaced the client while the old
+// daemon kept running.
+type VersionError struct {
+	Have   string
+	Reason string
+}
+
+func (e *VersionError) Error() string {
+	return fmt.Sprintf(
+		"the running GAIA daemon speaks host API v%s: %s. "+
+			"Run `gaia daemon restart`, then retry.", e.Have, e.Reason)
+}
+
+// StartError means we could not bring a daemon up (lock contention, launch
+// failure, or it never registered in time).
+type StartError struct {
+	Reason string
+}
+
+func (e *StartError) Error() string {
+	return fmt.Sprintf(
+		"could not start the GAIA daemon: %s. Inspect the daemon log at %s, "+
+			"or run `gaia daemon start` in a terminal to see the failure directly.",
+		e.Reason, logPathForMessage())
+}
+
+// RequestError is a transport or protocol failure talking to a live daemon.
+// Op names the call ("ensure the 'email' sidecar", "stream the 'email' query").
+type RequestError struct {
+	Op     string
+	Detail string
+}
+
+func (e *RequestError) Error() string {
+	return fmt.Sprintf(
+		"could not %s: %s. Check `gaia daemon status` and the daemon log at %s.",
+		e.Op, e.Detail, logPathForMessage())
+}

--- a/tui/internal/daemon/instance.go
+++ b/tui/internal/daemon/instance.go
@@ -76,39 +76,43 @@ func ReadInstance() (*Instance, error) {
 		return nil, &NotRunningError{Path: path}
 	}
 	if err != nil {
-		return nil, &StaleError{Path: path, Reason: fmt.Sprintf("it cannot be read (%v)", err)}
+		return nil, &StaleError{Kind: StaleCorrupt, Path: path, Reason: fmt.Sprintf("it cannot be read (%v)", err)}
 	}
 
 	var inst Instance
 	if err := json.Unmarshal(raw, &inst); err != nil {
 		return nil, &StaleError{
+			Kind:   StaleCorrupt,
 			Path:   path,
 			Reason: fmt.Sprintf("it is not valid JSON (%v) — a crash mid-write leaves a truncated file", err),
 		}
 	}
 	if inst.PID <= 0 {
-		return nil, &StaleError{Path: path, Reason: "it records no usable pid"}
+		return nil, &StaleError{Kind: StaleCorrupt, Path: path, Reason: "it records no usable pid"}
 	}
 	if inst.Port <= 0 || inst.Port > 65535 {
-		return nil, &StaleError{Path: path, Reason: fmt.Sprintf("it records an invalid port (%d)", inst.Port)}
+		return nil, &StaleError{Kind: StaleCorrupt, Path: path, Reason: fmt.Sprintf("it records an invalid port (%d)", inst.Port)}
 	}
 	if inst.Port == ReservedPort {
 		return nil, &StaleError{
+			Kind:   StaleCorrupt,
 			Path:   path,
 			Reason: fmt.Sprintf("it records port %d, which is reserved and never used by GAIA", ReservedPort),
 		}
 	}
 	if inst.Token == "" {
-		return nil, &StaleError{Path: path, Reason: "it records no client token, so no request could be authenticated"}
+		return nil, &StaleError{Kind: StaleCorrupt, Path: path, Reason: "it records no client token, so no request could be authenticated"}
 	}
 	if inst.Service != "" && inst.Service != ServiceID {
 		return nil, &StaleError{
+			Kind:   StaleCorrupt,
 			Path:   path,
 			Reason: fmt.Sprintf("it was written by service %q, not %q", inst.Service, ServiceID),
 		}
 	}
 	if inst.APIVersion == "" {
 		return nil, &StaleError{
+			Kind:   StaleCorrupt,
 			Path:   path,
 			Reason: "it records no api_version, so the daemon contract version cannot be verified",
 		}

--- a/tui/internal/daemon/instance.go
+++ b/tui/internal/daemon/instance.go
@@ -1,0 +1,174 @@
+package daemon
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"strconv"
+	"strings"
+)
+
+const (
+	// ServiceID is the identity a probed port must answer with before we trust it.
+	ServiceID = "gaia-daemon"
+
+	// APIPrefix is the daemon's versioned client-API surface.
+	APIPrefix = "/daemon/v1"
+
+	// AuthScheme is the client-token auth scheme; the header is
+	// `Authorization: Bearer <token>` on EVERY request.
+	AuthScheme = "Bearer"
+
+	// DefaultHost is the loopback address the daemon binds.
+	DefaultHost = "127.0.0.1"
+
+	// ReservedPort is reserved repo-wide and must never be used by GAIA.
+	// A registry claiming it is treated as untrustworthy.
+	ReservedPort = 4001
+
+	// RequiredAPIMajor is the daemon contract MAJOR this client speaks.
+	RequiredAPIMajor = 1
+
+	// RequiredAgentsMinor is the MINOR that introduced the /daemon/v1/agents
+	// control plane and the /v1/<agent>/* relay. Below it every agents route
+	// 404s, so a pre-#2142 daemon must fail loudly rather than be attached to.
+	RequiredAgentsMinor = 1
+)
+
+// Instance is the daemon's single-instance registry record (~/.gaia/host/instance.json,
+// mode 0600).
+type Instance struct {
+	PID        int     `json:"pid"`
+	Port       int     `json:"port"`
+	Token      string  `json:"token"`
+	Host       string  `json:"host"`
+	APIVersion string  `json:"api_version"`
+	Service    string  `json:"service"`
+	StartedAt  float64 `json:"started_at"`
+}
+
+// BaseURL is the daemon's loopback root, e.g. "http://127.0.0.1:51234".
+func (i *Instance) BaseURL() string {
+	return fmt.Sprintf("http://%s:%d", i.Host, i.Port)
+}
+
+// String redacts the client token so an Instance is safe to log or embed in an
+// error. Never format an Instance with %#v.
+func (i *Instance) String() string {
+	return fmt.Sprintf("daemon{pid:%d port:%d api:%s service:%s token:<redacted>}",
+		i.PID, i.Port, i.APIVersion, i.Service)
+}
+
+// ReadInstance loads and structurally validates instance.json.
+//
+// It returns *NotRunningError when the file is absent and *StaleError when it is
+// present but untrustworthy. A successful read means the record is well-formed —
+// NOT that a daemon is alive; that needs Client.verify (pid + status probe).
+func ReadInstance() (*Instance, error) {
+	path, err := InstancePath()
+	if err != nil {
+		return nil, err
+	}
+	raw, err := os.ReadFile(path)
+	if errors.Is(err, fs.ErrNotExist) {
+		return nil, &NotRunningError{Path: path}
+	}
+	if err != nil {
+		return nil, &StaleError{Path: path, Reason: fmt.Sprintf("it cannot be read (%v)", err)}
+	}
+
+	var inst Instance
+	if err := json.Unmarshal(raw, &inst); err != nil {
+		return nil, &StaleError{
+			Path:   path,
+			Reason: fmt.Sprintf("it is not valid JSON (%v) — a crash mid-write leaves a truncated file", err),
+		}
+	}
+	if inst.PID <= 0 {
+		return nil, &StaleError{Path: path, Reason: "it records no usable pid"}
+	}
+	if inst.Port <= 0 || inst.Port > 65535 {
+		return nil, &StaleError{Path: path, Reason: fmt.Sprintf("it records an invalid port (%d)", inst.Port)}
+	}
+	if inst.Port == ReservedPort {
+		return nil, &StaleError{
+			Path:   path,
+			Reason: fmt.Sprintf("it records port %d, which is reserved and never used by GAIA", ReservedPort),
+		}
+	}
+	if inst.Token == "" {
+		return nil, &StaleError{Path: path, Reason: "it records no client token, so no request could be authenticated"}
+	}
+	if inst.Service != "" && inst.Service != ServiceID {
+		return nil, &StaleError{
+			Path:   path,
+			Reason: fmt.Sprintf("it was written by service %q, not %q", inst.Service, ServiceID),
+		}
+	}
+	if inst.APIVersion == "" {
+		return nil, &StaleError{
+			Path:   path,
+			Reason: "it records no api_version, so the daemon contract version cannot be verified",
+		}
+	}
+	if inst.Host == "" {
+		inst.Host = DefaultHost
+	}
+	return &inst, nil
+}
+
+// parseAPIVersion splits a "MAJOR.MINOR" contract version. A missing MINOR reads
+// as 0 (mirrors the Python floor check); a non-numeric MAJOR is a hard error.
+func parseAPIVersion(v string) (major, minor int, err error) {
+	parts := strings.Split(strings.TrimSpace(v), ".")
+	major, err = strconv.Atoi(parts[0])
+	if err != nil {
+		return 0, 0, fmt.Errorf("cannot parse a MAJOR daemon API version from %q", v)
+	}
+	if len(parts) > 1 {
+		if m, cerr := strconv.Atoi(parts[1]); cerr == nil {
+			minor = m
+		}
+	}
+	return major, minor, nil
+}
+
+// CheckVersion fails loudly on a daemon↔client contract MAJOR skew. An app
+// update replaces the client while an old daemon keeps running, so this is the
+// expected path after an upgrade, not an edge case.
+func (i *Instance) CheckVersion() error {
+	major, _, err := parseAPIVersion(i.APIVersion)
+	if err != nil {
+		return &VersionError{Have: i.APIVersion, Reason: err.Error()}
+	}
+	if major != RequiredAPIMajor {
+		return &VersionError{
+			Have: i.APIVersion,
+			Reason: fmt.Sprintf("this client speaks MAJOR %d and cannot use MAJOR %d",
+				RequiredAPIMajor, major),
+		}
+	}
+	return nil
+}
+
+// CheckAgentsFloor fails loudly if the running daemon predates the sidecar
+// control plane and the /v1/<agent>/* relay (needs v1.1+).
+func (i *Instance) CheckAgentsFloor() error {
+	if err := i.CheckVersion(); err != nil {
+		return err
+	}
+	_, minor, err := parseAPIVersion(i.APIVersion)
+	if err != nil {
+		return &VersionError{Have: i.APIVersion, Reason: err.Error()}
+	}
+	if minor < RequiredAgentsMinor {
+		return &VersionError{
+			Have: i.APIVersion,
+			Reason: fmt.Sprintf("it predates the sidecar control plane + agent relay (needs v%d.%d+), "+
+				"so every agents route would 404", RequiredAPIMajor, RequiredAgentsMinor),
+		}
+	}
+	return nil
+}

--- a/tui/internal/daemon/lock.go
+++ b/tui/internal/daemon/lock.go
@@ -1,0 +1,60 @@
+package daemon
+
+import (
+	"fmt"
+	"os"
+	"time"
+)
+
+// lockPoll is the retry interval while waiting for the start lock.
+const lockPoll = 100 * time.Millisecond
+
+// fileLock holds the exclusive daemon-start lock. Only ONE process may be in the
+// "decide + spawn" critical section at a time, so two concurrent StartOrAttach
+// callers yield exactly one daemon (the loser attaches to the winner's
+// instance.json).
+//
+// An OS advisory lock is used rather than an O_EXCL create-lock because the OS
+// releases it when the holder dies — a create-lock would strand a stale lock
+// file after SIGKILL.
+type fileLock struct {
+	f *os.File
+}
+
+// acquireLock takes the exclusive lock at path, retrying until timeout. Failure
+// is loud: an abandoned start attempt must surface an actionable error rather
+// than hang forever.
+func acquireLock(path string, timeout time.Duration) (*fileLock, error) {
+	// 0600: the lock file lives beside the token-bearing instance.json.
+	f, err := os.OpenFile(path, os.O_RDWR|os.O_CREATE, 0o600)
+	if err != nil {
+		return nil, &StartError{Reason: fmt.Sprintf("cannot open the start lock at %s: %v", path, err)}
+	}
+	deadline := time.Now().Add(timeout)
+	for {
+		ok, lerr := tryLock(f)
+		if lerr != nil {
+			f.Close()
+			return nil, &StartError{Reason: fmt.Sprintf("cannot lock %s: %v", path, lerr)}
+		}
+		if ok {
+			return &fileLock{f: f}, nil
+		}
+		if time.Now().After(deadline) {
+			f.Close()
+			return nil, &StartError{Reason: fmt.Sprintf(
+				"another process held the start lock at %s for more than %s without finishing — "+
+					"look for a stuck `gaia daemon start` or Agent UI launch", path, timeout)}
+		}
+		time.Sleep(lockPoll)
+	}
+}
+
+func (l *fileLock) release() {
+	if l == nil || l.f == nil {
+		return
+	}
+	unlock(l.f)
+	l.f.Close()
+	l.f = nil
+}

--- a/tui/internal/daemon/lock_unix.go
+++ b/tui/internal/daemon/lock_unix.go
@@ -1,0 +1,26 @@
+//go:build !windows
+
+package daemon
+
+import (
+	"errors"
+	"os"
+	"syscall"
+)
+
+// tryLock takes a non-blocking exclusive flock. (false, nil) means "held by
+// someone else, retry"; a non-nil error is a real failure.
+func tryLock(f *os.File) (bool, error) {
+	err := syscall.Flock(int(f.Fd()), syscall.LOCK_EX|syscall.LOCK_NB)
+	if err == nil {
+		return true, nil
+	}
+	if errors.Is(err, syscall.EWOULDBLOCK) || errors.Is(err, syscall.EAGAIN) {
+		return false, nil
+	}
+	return false, err
+}
+
+func unlock(f *os.File) {
+	_ = syscall.Flock(int(f.Fd()), syscall.LOCK_UN)
+}

--- a/tui/internal/daemon/lock_windows.go
+++ b/tui/internal/daemon/lock_windows.go
@@ -1,0 +1,33 @@
+//go:build windows
+
+package daemon
+
+import (
+	"errors"
+	"os"
+
+	"golang.org/x/sys/windows"
+)
+
+// tryLock takes a non-blocking exclusive byte-range lock. (false, nil) means
+// "held by someone else, retry"; a non-nil error is a real failure.
+func tryLock(f *os.File) (bool, error) {
+	var ov windows.Overlapped
+	err := windows.LockFileEx(
+		windows.Handle(f.Fd()),
+		windows.LOCKFILE_EXCLUSIVE_LOCK|windows.LOCKFILE_FAIL_IMMEDIATELY,
+		0, 1, 0, &ov,
+	)
+	if err == nil {
+		return true, nil
+	}
+	if errors.Is(err, windows.ERROR_LOCK_VIOLATION) || errors.Is(err, windows.ERROR_IO_PENDING) {
+		return false, nil
+	}
+	return false, err
+}
+
+func unlock(f *os.File) {
+	var ov windows.Overlapped
+	_ = windows.UnlockFileEx(windows.Handle(f.Fd()), 0, 1, 0, &ov)
+}

--- a/tui/internal/daemon/paths.go
+++ b/tui/internal/daemon/paths.go
@@ -1,0 +1,90 @@
+// Package daemon is the TUI's thin client for the GAIA daemon: single-instance
+// discovery, the start-or-attach handshake, and authenticated calls against the
+// daemon's HTTP control plane (`/daemon/v1/*`) and agent relay (`/v1/<agent>/*`).
+//
+// It is the Go counterpart of src/gaia/daemon/{paths,instance,client}.py and
+// deliberately mirrors their trust rules: a recorded instance is trusted only
+// when its pid is alive AND a token-authed status probe answers with the daemon's
+// service id and the recorded pid — a freed port that some unrelated process
+// grabbed after a crash is a real failure mode, not a theoretical one.
+//
+// Every failure returns an actionable error naming what failed, what to run, and
+// which log to read. There is no silent fallback to a direct sidecar connection:
+// the TUI only ever holds the DAEMON client token, never a sidecar bearer.
+package daemon
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// EnvHome overrides the daemon state directory (tests, and any non-default
+// install). Read on every call, never cached — a subprocess spawned with a
+// different env must resolve its own directory.
+const EnvHome = "GAIA_DAEMON_HOME"
+
+// HostDir returns the directory holding instance.json, the start lock, and the
+// daemon log.
+func HostDir() (string, error) {
+	if override := os.Getenv(EnvHome); override != "" {
+		return override, nil
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf(
+			"cannot resolve the home directory to locate ~/.gaia/host: %w — "+
+				"set %s to the daemon state directory and retry", err, EnvHome)
+	}
+	return filepath.Join(home, ".gaia", "host"), nil
+}
+
+// InstancePath returns the single-instance registry file (pid + port + client token).
+func InstancePath() (string, error) {
+	dir, err := HostDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(dir, "instance.json"), nil
+}
+
+// LockPath returns the advisory lock that serializes daemon start, so two
+// concurrent callers spawn exactly one daemon.
+func LockPath() (string, error) {
+	dir, err := HostDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(dir, "instance.lock"), nil
+}
+
+// LogPath returns the daemon stdout/stderr log (what `gaia daemon logs` tails).
+func LogPath() (string, error) {
+	dir, err := HostDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(dir, "daemon.log"), nil
+}
+
+// logPathForMessage returns LogPath() for embedding in an error string, or a
+// human placeholder if even the home directory is unresolvable.
+func logPathForMessage() string {
+	p, err := LogPath()
+	if err != nil {
+		return "~/.gaia/host/daemon.log"
+	}
+	return p
+}
+
+// ensureHostDir creates the host directory if missing and returns it.
+func ensureHostDir() (string, error) {
+	dir, err := HostDir()
+	if err != nil {
+		return "", err
+	}
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return "", fmt.Errorf("cannot create the daemon state directory %s: %w", dir, err)
+	}
+	return dir, nil
+}

--- a/tui/internal/daemon/pid_unix.go
+++ b/tui/internal/daemon/pid_unix.go
@@ -1,0 +1,24 @@
+//go:build !windows
+
+package daemon
+
+import (
+	"errors"
+	"syscall"
+)
+
+// PIDAlive reports whether pid refers to a running process.
+//
+// signal 0 probes without delivering: nil means the process exists and we may
+// signal it; EPERM means it exists but is owned by another user. Either way the
+// pid is taken, and the status probe is the real trust check.
+func PIDAlive(pid int) bool {
+	if pid <= 0 {
+		return false
+	}
+	err := syscall.Kill(pid, 0)
+	if err == nil {
+		return true
+	}
+	return errors.Is(err, syscall.EPERM)
+}

--- a/tui/internal/daemon/pid_windows.go
+++ b/tui/internal/daemon/pid_windows.go
@@ -1,0 +1,30 @@
+//go:build windows
+
+package daemon
+
+import "golang.org/x/sys/windows"
+
+// stillActive is the exit code Windows reports for a process that has not exited.
+const stillActive = 259
+
+// PIDAlive reports whether pid refers to a running process.
+//
+// A handle can still be opened briefly for an exited process, so the exit code
+// is checked too; the status probe remains the real trust check.
+func PIDAlive(pid int) bool {
+	if pid <= 0 {
+		return false
+	}
+	h, err := windows.OpenProcess(windows.PROCESS_QUERY_LIMITED_INFORMATION, false, uint32(pid))
+	if err != nil {
+		return false
+	}
+	defer windows.CloseHandle(h)
+	var code uint32
+	if err := windows.GetExitCodeProcess(h, &code); err != nil {
+		// The pid is taken but we cannot read its state — treat it as alive and
+		// let the status probe decide.
+		return true
+	}
+	return code == stillActive
+}

--- a/tui/internal/event/canonical.go
+++ b/tui/internal/event/canonical.go
@@ -1,0 +1,132 @@
+package event
+
+import "encoding/json"
+
+// The canonical `/query` SSE vocabulary — the frozen seven event types from
+// docs/spec/agent-ui-query-sse-contract.md §4, streamed by every v2 agent
+// sidecar through the daemon relay.
+//
+// These are NOT the legacy in-process types in types.go (step / thinking /
+// tool_start / chunk / answer / …), which the subprocess transport still uses.
+// Both vocabularies coexist: the transport decides which parser runs.
+//
+// Two extra types carry the contract's receiving-end rules (§7) into the type
+// system, so an event can never be silently dropped:
+// CanonicalUnsupportedEvent (a `type` outside the seven) and
+// CanonicalMalformedEvent (a frame that is not valid JSON for its type).
+const (
+	CanonicalTypeStatus            = "status"
+	CanonicalTypeToken             = "token"
+	CanonicalTypeToolCall          = "tool_call"
+	CanonicalTypeToolResult        = "tool_result"
+	CanonicalTypeNeedsConfirmation = "needs_confirmation"
+	CanonicalTypeFinal             = "final"
+	CanonicalTypeError             = "error"
+)
+
+// CanonicalStatusEvent — progress narration (spinner label / status line).
+type CanonicalStatusEvent struct {
+	Type    string `json:"type"`
+	Message string `json:"message"`
+}
+
+// CanonicalTokenEvent — one incremental chunk of assistant answer text.
+type CanonicalTokenEvent struct {
+	Type  string `json:"type"`
+	Delta string `json:"delta"`
+}
+
+// CanonicalToolCallEvent — a tool invocation with its arguments.
+type CanonicalToolCallEvent struct {
+	Type string          `json:"type"`
+	Tool string          `json:"tool"`
+	Args json.RawMessage `json:"args,omitempty"`
+}
+
+// CanonicalToolResultEvent — a tool's structured result.
+//
+// Render is the sidecar's declared card key (e.g. "email_pre_scan", or one of the
+// generic primitives "table" / "key_value" / "list" / "image" / "diff"). Data is
+// the render-specific payload. An unknown Render must degrade to a generic result
+// card — never to a blank.
+type CanonicalToolResultEvent struct {
+	Type   string          `json:"type"`
+	Tool   string          `json:"tool"`
+	Render string          `json:"render,omitempty"`
+	Data   json.RawMessage `json:"data,omitempty"`
+}
+
+// CanonicalNeedsConfirmationEvent — the run pauses for a user decision.
+// ConfirmURL is present only under the resume model; the stateless surface omits it.
+type CanonicalNeedsConfirmationEvent struct {
+	Type       string `json:"type"`
+	RunID      string `json:"run_id"`
+	Action     string `json:"action"`
+	Summary    string `json:"summary"`
+	ConfirmURL string `json:"confirm_url,omitempty"`
+}
+
+// CanonicalFinalEvent — terminal success. Usage is an optional
+// {steps?, tools_used?, elapsed?, tokens?} object.
+type CanonicalFinalEvent struct {
+	Type   string          `json:"type"`
+	Answer string          `json:"answer"`
+	Usage  json.RawMessage `json:"usage,omitempty"`
+}
+
+// CanonicalUsage is the shape the TUI reads out of CanonicalFinalEvent.Usage.
+// Fields absent from the payload stay zero and are simply not displayed.
+type CanonicalUsage struct {
+	Steps     int     `json:"steps"`
+	ToolsUsed int     `json:"tools_used"`
+	Elapsed   float64 `json:"elapsed"`
+}
+
+// CanonicalErrorEvent — terminal failure. Detail is actionable and surfaced
+// verbatim. Source is set by whoever synthesized the event when it did not come
+// off the wire (e.g. "tui" for a stream that ended with no terminal event).
+type CanonicalErrorEvent struct {
+	Type   string `json:"type"`
+	Detail string `json:"detail"`
+	Status int    `json:"status,omitempty"`
+	Source string `json:"source,omitempty"`
+}
+
+// CanonicalUnsupportedEvent — a top-level `type` outside the frozen seven, from a
+// newer agent talking to this client. Contract §7: surface it visibly, never drop it.
+type CanonicalUnsupportedEvent struct {
+	EventType string
+	Raw       string
+}
+
+// CanonicalMalformedEvent — a data frame that could not be parsed as its declared
+// type. Surfaced so a broken producer is visible instead of looking like silence.
+type CanonicalMalformedEvent struct {
+	Payload string
+	Reason  string
+}
+
+// CanonicalUsageOf decodes a final event's usage object. A missing or unreadable
+// usage payload yields the zero value — it is display metadata, not an outcome.
+func CanonicalUsageOf(e CanonicalFinalEvent) CanonicalUsage {
+	var u CanonicalUsage
+	if len(e.Usage) == 0 {
+		return u
+	}
+	if err := json.Unmarshal(e.Usage, &u); err != nil {
+		return CanonicalUsage{}
+	}
+	return u
+}
+
+// CanonicalTerminalType returns "final" or "error" if evt terminates a run, else "".
+// Exactly one terminal event ends a `/query` stream (contract §3).
+func CanonicalTerminalType(evt interface{}) string {
+	switch evt.(type) {
+	case CanonicalFinalEvent:
+		return CanonicalTypeFinal
+	case CanonicalErrorEvent:
+		return CanonicalTypeError
+	}
+	return ""
+}

--- a/tui/internal/event/canonical_parser.go
+++ b/tui/internal/event/canonical_parser.go
@@ -1,0 +1,75 @@
+package event
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// maxRawEcho caps how much of a bad payload is echoed back into a visible event.
+const maxRawEcho = 400
+
+// ParseCanonicalEvent parses one canonical `/query` SSE data payload.
+//
+// It never returns an error, by design: the contract's receiving-end rules
+// require that nothing is dropped, so both failure modes become visible events —
+// an unknown `type` yields CanonicalUnsupportedEvent and an unreadable payload
+// yields CanonicalMalformedEvent. Callers render whatever comes back and keep
+// reading; only `final` / `error` end a run.
+func ParseCanonicalEvent(data []byte) interface{} {
+	var probe struct {
+		Type string `json:"type"`
+	}
+	if err := json.Unmarshal(data, &probe); err != nil {
+		return CanonicalMalformedEvent{
+			Payload: truncate(string(data), maxRawEcho),
+			Reason:  fmt.Sprintf("not valid JSON: %v", err),
+		}
+	}
+	if probe.Type == "" {
+		return CanonicalMalformedEvent{
+			Payload: truncate(string(data), maxRawEcho),
+			Reason:  "the event carries no `type` field",
+		}
+	}
+
+	switch probe.Type {
+	case CanonicalTypeStatus:
+		return decodeCanonical[CanonicalStatusEvent](data, probe.Type)
+	case CanonicalTypeToken:
+		return decodeCanonical[CanonicalTokenEvent](data, probe.Type)
+	case CanonicalTypeToolCall:
+		return decodeCanonical[CanonicalToolCallEvent](data, probe.Type)
+	case CanonicalTypeToolResult:
+		return decodeCanonical[CanonicalToolResultEvent](data, probe.Type)
+	case CanonicalTypeNeedsConfirmation:
+		return decodeCanonical[CanonicalNeedsConfirmationEvent](data, probe.Type)
+	case CanonicalTypeFinal:
+		return decodeCanonical[CanonicalFinalEvent](data, probe.Type)
+	case CanonicalTypeError:
+		return decodeCanonical[CanonicalErrorEvent](data, probe.Type)
+	default:
+		// §7: a newer agent's new event type must be visible, not dropped.
+		return CanonicalUnsupportedEvent{
+			EventType: probe.Type,
+			Raw:       truncate(string(data), maxRawEcho),
+		}
+	}
+}
+
+func decodeCanonical[T any](data []byte, etype string) interface{} {
+	var e T
+	if err := json.Unmarshal(data, &e); err != nil {
+		return CanonicalMalformedEvent{
+			Payload: truncate(string(data), maxRawEcho),
+			Reason:  fmt.Sprintf("malformed %s event: %v", etype, err),
+		}
+	}
+	return e
+}
+
+func truncate(s string, limit int) string {
+	if len(s) <= limit {
+		return s
+	}
+	return s[:limit] + "…"
+}

--- a/tui/internal/event/canonical_parser_test.go
+++ b/tui/internal/event/canonical_parser_test.go
@@ -1,0 +1,199 @@
+package event
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestParseCanonicalStatus(t *testing.T) {
+	e := ParseCanonicalEvent([]byte(`{"type":"status","message":"Scanning inbox"}`))
+	s, ok := e.(CanonicalStatusEvent)
+	if !ok {
+		t.Fatalf("expected CanonicalStatusEvent, got %T", e)
+	}
+	if s.Message != "Scanning inbox" {
+		t.Errorf("message = %q", s.Message)
+	}
+}
+
+func TestParseCanonicalToken(t *testing.T) {
+	e := ParseCanonicalEvent([]byte(`{"type":"token","delta":"Hel"}`))
+	tok, ok := e.(CanonicalTokenEvent)
+	if !ok {
+		t.Fatalf("expected CanonicalTokenEvent, got %T", e)
+	}
+	if tok.Delta != "Hel" {
+		t.Errorf("delta = %q", tok.Delta)
+	}
+}
+
+func TestParseCanonicalToolCall(t *testing.T) {
+	e := ParseCanonicalEvent([]byte(`{"type":"tool_call","tool":"search_email","args":{"query":"invoice"}}`))
+	tc, ok := e.(CanonicalToolCallEvent)
+	if !ok {
+		t.Fatalf("expected CanonicalToolCallEvent, got %T", e)
+	}
+	if tc.Tool != "search_email" {
+		t.Errorf("tool = %q", tc.Tool)
+	}
+	var args map[string]string
+	if err := json.Unmarshal(tc.Args, &args); err != nil {
+		t.Fatalf("args: %v", err)
+	}
+	if args["query"] != "invoice" {
+		t.Errorf("args[query] = %q", args["query"])
+	}
+}
+
+func TestParseCanonicalToolResultCarriesRenderAndData(t *testing.T) {
+	line := []byte(`{"type":"tool_result","tool":"pre_scan_inbox","render":"email_pre_scan","data":{"urgent":[{"subject":"Wire transfer"}]}}`)
+	e := ParseCanonicalEvent(line)
+	tr, ok := e.(CanonicalToolResultEvent)
+	if !ok {
+		t.Fatalf("expected CanonicalToolResultEvent, got %T", e)
+	}
+	if tr.Tool != "pre_scan_inbox" || tr.Render != "email_pre_scan" {
+		t.Errorf("unexpected values: %+v", tr)
+	}
+	if !strings.Contains(string(tr.Data), "Wire transfer") {
+		t.Errorf("data not carried through: %s", tr.Data)
+	}
+}
+
+func TestParseCanonicalToolResultWithoutRender(t *testing.T) {
+	e := ParseCanonicalEvent([]byte(`{"type":"tool_result","tool":"list_labels","data":{"ok":true}}`))
+	tr, ok := e.(CanonicalToolResultEvent)
+	if !ok {
+		t.Fatalf("expected CanonicalToolResultEvent, got %T", e)
+	}
+	if tr.Render != "" {
+		t.Errorf("render should be empty, got %q", tr.Render)
+	}
+}
+
+func TestParseCanonicalNeedsConfirmation(t *testing.T) {
+	line := []byte(`{"type":"needs_confirmation","run_id":"7b1e","action":"send_draft","summary":"Send reply to alice@example.com"}`)
+	e := ParseCanonicalEvent(line)
+	nc, ok := e.(CanonicalNeedsConfirmationEvent)
+	if !ok {
+		t.Fatalf("expected CanonicalNeedsConfirmationEvent, got %T", e)
+	}
+	if nc.RunID != "7b1e" || nc.Action != "send_draft" {
+		t.Errorf("unexpected values: %+v", nc)
+	}
+	if nc.ConfirmURL != "" {
+		t.Errorf("confirm_url should be absent under the stateless model, got %q", nc.ConfirmURL)
+	}
+}
+
+func TestParseCanonicalFinalWithUsage(t *testing.T) {
+	e := ParseCanonicalEvent([]byte(`{"type":"final","answer":"3 urgent emails","usage":{"steps":4,"tools_used":2,"elapsed":8.5}}`))
+	f, ok := e.(CanonicalFinalEvent)
+	if !ok {
+		t.Fatalf("expected CanonicalFinalEvent, got %T", e)
+	}
+	if f.Answer != "3 urgent emails" {
+		t.Errorf("answer = %q", f.Answer)
+	}
+	usage := CanonicalUsageOf(f)
+	if usage.Steps != 4 || usage.ToolsUsed != 2 || usage.Elapsed != 8.5 {
+		t.Errorf("unexpected usage: %+v", usage)
+	}
+	if CanonicalTerminalType(f) != CanonicalTypeFinal {
+		t.Error("final must be terminal")
+	}
+}
+
+func TestCanonicalUsageOfMissingOrBad(t *testing.T) {
+	if u := CanonicalUsageOf(CanonicalFinalEvent{Type: "final", Answer: "x"}); u != (CanonicalUsage{}) {
+		t.Errorf("absent usage should be zero, got %+v", u)
+	}
+	bad := CanonicalFinalEvent{Type: "final", Usage: json.RawMessage(`"not-an-object"`)}
+	if u := CanonicalUsageOf(bad); u != (CanonicalUsage{}) {
+		t.Errorf("unreadable usage should be zero, got %+v", u)
+	}
+}
+
+func TestParseCanonicalError(t *testing.T) {
+	e := ParseCanonicalEvent([]byte(`{"type":"error","detail":"Lemonade Server is not reachable","status":503}`))
+	ev, ok := e.(CanonicalErrorEvent)
+	if !ok {
+		t.Fatalf("expected CanonicalErrorEvent, got %T", e)
+	}
+	if ev.Detail != "Lemonade Server is not reachable" || ev.Status != 503 {
+		t.Errorf("unexpected values: %+v", ev)
+	}
+	if CanonicalTerminalType(ev) != CanonicalTypeError {
+		t.Error("error must be terminal")
+	}
+}
+
+// Contract §7: an unknown top-level type is surfaced, never dropped.
+func TestParseCanonicalUnknownTypeIsVisible(t *testing.T) {
+	e := ParseCanonicalEvent([]byte(`{"type":"needs_input","prompt":"Which mailbox?"}`))
+	u, ok := e.(CanonicalUnsupportedEvent)
+	if !ok {
+		t.Fatalf("expected CanonicalUnsupportedEvent, got %T", e)
+	}
+	if u.EventType != "needs_input" {
+		t.Errorf("event type = %q", u.EventType)
+	}
+	if !strings.Contains(u.Raw, "Which mailbox?") {
+		t.Errorf("raw payload not retained: %q", u.Raw)
+	}
+}
+
+func TestParseCanonicalMalformedIsVisible(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+	}{
+		{"not json", `{"type":"token"`},
+		{"no type", `{"message":"orphan"}`},
+		{"wrong field type", `{"type":"token","delta":42}`},
+		{"empty", ``},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			e := ParseCanonicalEvent([]byte(tc.in))
+			m, ok := e.(CanonicalMalformedEvent)
+			if !ok {
+				t.Fatalf("expected CanonicalMalformedEvent, got %T", e)
+			}
+			if m.Reason == "" {
+				t.Error("a malformed event must carry a reason")
+			}
+			if CanonicalTerminalType(e) != "" {
+				t.Error("a malformed event must not terminate the run")
+			}
+		})
+	}
+}
+
+func TestParseCanonicalTruncatesHugePayload(t *testing.T) {
+	huge := `{"type":"nope","blob":"` + strings.Repeat("x", 5000) + `"}`
+	u, ok := ParseCanonicalEvent([]byte(huge)).(CanonicalUnsupportedEvent)
+	if !ok {
+		t.Fatalf("expected CanonicalUnsupportedEvent")
+	}
+	if len(u.Raw) > maxRawEcho+4 {
+		t.Errorf("raw echo not truncated: %d bytes", len(u.Raw))
+	}
+}
+
+// The legacy in-process vocabulary must keep working — the subprocess transport
+// still speaks it.
+func TestLegacyParserStillIndependent(t *testing.T) {
+	legacy, err := ParseEvent([]byte(`{"type":"answer","content":"hi","steps":1,"tools_used":0}`))
+	if err != nil {
+		t.Fatalf("legacy ParseEvent: %v", err)
+	}
+	if _, ok := legacy.(AnswerEvent); !ok {
+		t.Fatalf("expected AnswerEvent, got %T", legacy)
+	}
+	// "answer" is not part of the canonical seven.
+	if _, ok := ParseCanonicalEvent([]byte(`{"type":"answer","content":"hi"}`)).(CanonicalUnsupportedEvent); !ok {
+		t.Error("legacy `answer` must read as unsupported on the canonical parser")
+	}
+}

--- a/tui/internal/event/parser.go
+++ b/tui/internal/event/parser.go
@@ -5,7 +5,10 @@ import (
 	"fmt"
 )
 
-// ParseEvent parses a JSONL line into a concrete event type.
+// ParseEvent parses a JSONL line into a concrete LEGACY event type — the
+// subprocess transport's vocabulary (see the freeze note in types.go).
+//
+// Use ParseCanonicalEvent for anything arriving over the daemon relay.
 // Returns the typed event or an error if the line is invalid JSON or has an unknown type.
 func ParseEvent(line []byte) (interface{}, error) {
 	var base Event

--- a/tui/internal/event/types.go
+++ b/tui/internal/event/types.go
@@ -2,6 +2,17 @@ package event
 
 import "encoding/json"
 
+// The LEGACY in-process event vocabulary, spoken only by the subprocess
+// transport (the local C++ agents). It is FROZEN: do not add types here, and do
+// not implement new UI features against it.
+//
+// Everything reached over the daemon relay speaks the canonical seven-event
+// contract in canonical.go instead. New rendering work — approval prompts, result
+// cards, error remedies — belongs on the canonical path only, or it has to be
+// written and maintained twice. The two sets deliberately do not share Go types
+// even where they share wire names (`status`, `tool_result`, `error`), because
+// the parser is chosen by transport and the payload shapes differ.
+
 // Event is the base for all events. Use ParseEvent() to get concrete types.
 type Event struct {
 	Type string `json:"type"`

--- a/tui/internal/ui/app.go
+++ b/tui/internal/ui/app.go
@@ -32,12 +32,19 @@ func RunHub(debug bool, mockAgent string) error {
 }
 
 // RunChat launches the chat TUI directly with a subprocess agent (standalone mode).
+//
+// subprocess is a command line, so it is split with quoting honoured — a binary
+// path containing a space must be quoted, not silently torn in two.
 func RunChat(subprocess string, query string, debug bool) error {
-	c := client.NewSubprocessClient(subprocess, debug)
+	argv, err := client.SplitCommandLine(subprocess)
+	if err != nil {
+		return fmt.Errorf("invalid --subprocess command: %w", err)
+	}
+
+	c := client.NewSubprocessClient(argv[0], argv[1:], debug)
 	defer c.Close()
 
-	agentName := extractAgentName(subprocess)
-	model := chat.NewChatModel(c, agentName, query, debug)
+	model := chat.NewChatModel(c, agentNameFromPath(argv[0]), query, debug)
 
 	p := tea.NewProgram(model, tea.WithAltScreen())
 	if _, err := p.Run(); err != nil {
@@ -46,12 +53,7 @@ func RunChat(subprocess string, query string, debug bool) error {
 	return nil
 }
 
-func extractAgentName(cmdLine string) string {
-	parts := strings.Fields(cmdLine)
-	if len(parts) == 0 {
-		return "agent"
-	}
-	name := filepath.Base(parts[0])
-	name = strings.TrimSuffix(name, ".exe")
-	return name
+func agentNameFromPath(path string) string {
+	name := filepath.Base(path)
+	return strings.TrimSuffix(name, ".exe")
 }

--- a/tui/internal/ui/app.go
+++ b/tui/internal/ui/app.go
@@ -1,7 +1,9 @@
 package ui
 
 import (
+	"context"
 	"fmt"
+	"os"
 	"path/filepath"
 	"strings"
 
@@ -51,6 +53,63 @@ func RunChat(subprocess string, query string, debug bool) error {
 		return fmt.Errorf("TUI error: %w", err)
 	}
 	return nil
+}
+
+// RunAgent launches one catalog agent by id, over whatever transport that entry
+// declares — so the daemon/SSE transport is reachable without waiting for the
+// hub's install flow.
+//
+// With query != "" this is a genuine non-interactive one-shot: no alt screen, the
+// answer on stdout, progress on stderr, and a real exit code. That is what makes
+// the transport exercisable from a script, from CI, and against a live daemon.
+// Returns the process exit code.
+func RunAgent(agentID, query, model string, debug bool) (int, error) {
+	cat := catalog.NewCatalog()
+	cat.DiscoverBinaries()
+
+	agent := cat.Get(agentID)
+	if agent == nil {
+		return 1, fmt.Errorf("no agent %q in the catalog — known ids: %s",
+			agentID, strings.Join(agentIDs(cat), ", "))
+	}
+
+	logf := func(string, ...any) {}
+	if debug {
+		logf = func(format string, args ...any) {
+			fmt.Fprintf(os.Stderr, "[DEBUG] "+format+"\n", args...)
+		}
+	}
+
+	c, err := client.ForAgent(*agent, client.ForAgentOptions{
+		Debug: debug,
+		Model: model,
+		Logf:  logf,
+	})
+	if err != nil {
+		return 1, err
+	}
+	defer c.Close()
+
+	if query != "" {
+		res := RunOneShot(context.Background(), c, query, os.Stdout, os.Stderr)
+		return res.ExitCode, nil
+	}
+
+	model_ := chat.NewChatModel(c, agent.Name, "", debug)
+	p := tea.NewProgram(model_, tea.WithAltScreen())
+	if _, err := p.Run(); err != nil {
+		return 1, fmt.Errorf("TUI error: %w", err)
+	}
+	return 0, nil
+}
+
+func agentIDs(cat *catalog.Catalog) []string {
+	all := cat.All()
+	ids := make([]string, 0, len(all))
+	for _, a := range all {
+		ids = append(ids, a.ID)
+	}
+	return ids
 }
 
 func agentNameFromPath(path string) string {

--- a/tui/internal/ui/app.go
+++ b/tui/internal/ui/app.go
@@ -11,33 +11,29 @@ import (
 
 	"github.com/amd/gaia/tui/internal/catalog"
 	"github.com/amd/gaia/tui/internal/client"
+	"github.com/amd/gaia/tui/internal/control"
 	"github.com/amd/gaia/tui/internal/ui/chat"
 	"github.com/amd/gaia/tui/internal/ui/root"
 )
 
 // RunHub launches the Agent Hub TUI — the main entry point for browsing and launching agents.
 // If mockAgent is non-empty, all agent binary paths are overridden with it for testing.
-func RunHub(debug bool, mockAgent string) error {
+// A non-nil ctrl starts the loopback control API against this very program.
+func RunHub(debug bool, mockAgent string, ctrl *control.Options) error {
 	cat := catalog.NewCatalog()
 	if mockAgent != "" {
 		cat.SetMockBinary(mockAgent)
 	} else {
 		cat.DiscoverBinaries()
 	}
-	model := root.NewRootModel(cat, debug)
-
-	p := tea.NewProgram(model, tea.WithAltScreen())
-	if _, err := p.Run(); err != nil {
-		return fmt.Errorf("TUI error: %w", err)
-	}
-	return nil
+	return run(root.NewRootModel(cat, debug), debug, ctrl)
 }
 
 // RunChat launches the chat TUI directly with a subprocess agent (standalone mode).
 //
 // subprocess is a command line, so it is split with quoting honoured — a binary
 // path containing a space must be quoted, not silently torn in two.
-func RunChat(subprocess string, query string, debug bool) error {
+func RunChat(subprocess string, query string, debug bool, ctrl *control.Options) error {
 	argv, err := client.SplitCommandLine(subprocess)
 	if err != nil {
 		return fmt.Errorf("invalid --subprocess command: %w", err)
@@ -46,10 +42,45 @@ func RunChat(subprocess string, query string, debug bool) error {
 	c := client.NewSubprocessClient(argv[0], argv[1:], debug)
 	defer c.Close()
 
-	model := chat.NewChatModel(c, agentNameFromPath(argv[0]), query, debug)
+	return run(chat.NewChatModel(c, agentNameFromPath(argv[0]), query, debug), debug, ctrl)
+}
 
-	p := tea.NewProgram(model, tea.WithAltScreen())
-	if _, err := p.Run(); err != nil {
+// run boots the Bubble Tea program, optionally wrapping it with the control
+// recorder so the live session can be driven over HTTP.
+func run(model tea.Model, debug bool, ctrl *control.Options) error {
+	if ctrl == nil {
+		p := tea.NewProgram(model, tea.WithAltScreen())
+		if _, err := p.Run(); err != nil {
+			return fmt.Errorf("TUI error: %w", err)
+		}
+		return nil
+	}
+
+	// One debug switch for both halves: --debug on the TUI implies control
+	// logging, and the server must not end up quieter than the recorder.
+	opts := *ctrl
+	opts.Debug = opts.Debug || debug
+	state := control.NewState(control.Debugf(opts.Debug))
+	p := tea.NewProgram(control.NewRecorder(model, state), tea.WithAltScreen())
+
+	srv, err := control.Start(p, state, opts)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if stopErr := srv.Stop(); stopErr != nil {
+			fmt.Fprintf(os.Stderr, "%v\n", stopErr)
+		}
+	}()
+	fmt.Fprintf(os.Stderr, "control API listening on %s:%d — token in %s\n",
+		control.Host, srv.Port(), srv.DiscoveryPath())
+
+	// Bracket Run: tea.Program.Send silently discards messages outside it, so
+	// the control API must refuse injection rather than report a false success.
+	srv.MarkRunning()
+	_, err = p.Run()
+	srv.MarkStopped()
+	if err != nil {
 		return fmt.Errorf("TUI error: %w", err)
 	}
 	return nil

--- a/tui/internal/ui/chat/canonical.go
+++ b/tui/internal/ui/chat/canonical.go
@@ -1,0 +1,161 @@
+package chat
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/amd/gaia/tui/internal/event"
+	"github.com/amd/gaia/tui/internal/ui/components"
+)
+
+// handleCanonicalEvent renders the canonical `/query` SSE vocabulary — what the
+// daemon transport streams. handled is false for anything else, so the legacy
+// in-process types (used by the subprocess transport) fall through untouched.
+func (m ChatModel) handleCanonicalEvent(evt interface{}) (ChatModel, tea.Cmd, bool) {
+	switch e := evt.(type) {
+	case event.CanonicalStatusEvent:
+		if msg := strings.TrimSpace(e.Message); msg != "" {
+			m.activity = append(m.activity, ActivityItem{Kind: "status", Content: msg})
+		}
+
+	case event.CanonicalTokenEvent:
+		m.buffer += e.Delta
+
+	case event.CanonicalToolCallEvent:
+		label := e.Tool
+		if arg := extractCommandFromArgs(e.Args); arg != "" {
+			label += ": " + arg
+		}
+		m.activity = append(m.activity, ActivityItem{Kind: "tool", Content: label})
+
+	case event.CanonicalToolResultEvent:
+		m.markToolDone(e)
+
+	case event.CanonicalNeedsConfirmationEvent:
+		// The approval UI is a later phase. Until then the pause is surfaced as a
+		// message the user can actually read — never swallowed — and the run
+		// continues to its own terminal event.
+		line := "confirmation needed: " + e.Action
+		if summary := strings.TrimSpace(e.Summary); summary != "" {
+			line += " — " + summary
+		}
+		m.messages = append(m.messages, Message{Role: RoleStatus, Content: "⚠️  " + line})
+
+	case event.CanonicalFinalEvent:
+		usage := event.CanonicalUsageOf(e)
+		// Tokens already streamed the answer into the buffer; the terminal
+		// `final` must not print it a second time.
+		content := m.buffer
+		m.buffer = ""
+		if content == "" {
+			content = e.Answer
+		}
+		m.messages = append(m.messages, Message{
+			Role:      RoleAssistant,
+			Content:   content,
+			Rendered:  components.RenderMarkdown(content),
+			Duration:  time.Since(m.queryStart),
+			TTFT:      m.ttft,
+			Steps:     usage.Steps,
+			ToolsUsed: usage.ToolsUsed,
+		})
+		m.streaming = false
+		m.activity = nil
+		if usage.Steps > 0 {
+			m.totalSteps = usage.Steps
+		}
+		m.updateViewport()
+		return m, nil, true
+
+	case event.CanonicalErrorEvent:
+		m.flushBuffer()
+		m.messages = append(m.messages, Message{Role: RoleError, Content: e.Detail})
+		m.streaming = false
+		m.activity = nil
+		m.updateViewport()
+		return m, nil, true
+
+	case event.CanonicalUnsupportedEvent:
+		// Contract §7: a newer agent's event type is shown, never dropped.
+		m.messages = append(m.messages, Message{
+			Role:    RoleStatus,
+			Content: fmt.Sprintf("unsupported event %q from the agent (update GAIA to render it)", e.EventType),
+		})
+
+	case event.CanonicalMalformedEvent:
+		m.messages = append(m.messages, Message{
+			Role:    RoleStatus,
+			Content: "unreadable agent event skipped: " + e.Reason,
+		})
+
+	default:
+		return m, nil, false
+	}
+
+	m.updateViewport()
+	return m, waitForEvent(m.events), true
+}
+
+// markToolDone closes out the activity line opened by the matching tool_call.
+//
+// The canonical tool_result carries no success flag, so the agent's own
+// {"ok": bool} / {"success": bool} convention is read out of `data` when present;
+// absent that, a delivered result counts as completed. The typed render card
+// (Phase 5) is what will show per-tool detail.
+func (m *ChatModel) markToolDone(e event.CanonicalToolResultEvent) {
+	success := toolResultSucceeded(e.Data)
+
+	label := ""
+	if e.Render != "" {
+		label = "render:" + e.Render
+	}
+
+	for i := len(m.activity) - 1; i >= 0; i-- {
+		item := &m.activity[i]
+		if item.Kind != "tool" || item.Done {
+			continue
+		}
+		item.Done = true
+		item.Success = &success
+		if label != "" {
+			item.Content += " → " + label
+		}
+		return
+	}
+
+	// A result with no matching call still has to be visible.
+	content := e.Tool
+	if label != "" {
+		content += " → " + label
+	}
+	m.activity = append(m.activity, ActivityItem{
+		Kind:    "tool",
+		Content: content,
+		Done:    true,
+		Success: &success,
+	})
+}
+
+func toolResultSucceeded(data json.RawMessage) bool {
+	if len(data) == 0 {
+		return true
+	}
+	var probe struct {
+		OK      *bool `json:"ok"`
+		Success *bool `json:"success"`
+	}
+	if err := json.Unmarshal(data, &probe); err != nil {
+		return true
+	}
+	if probe.OK != nil {
+		return *probe.OK
+	}
+	if probe.Success != nil {
+		return *probe.Success
+	}
+	return true
+}

--- a/tui/internal/ui/chat/canonical.go
+++ b/tui/internal/ui/chat/canonical.go
@@ -47,13 +47,16 @@ func (m ChatModel) handleCanonicalEvent(evt interface{}) (ChatModel, tea.Cmd, bo
 
 	case event.CanonicalFinalEvent:
 		usage := event.CanonicalUsageOf(e)
-		// Tokens already streamed the answer into the buffer; the terminal
-		// `final` must not print it a second time.
-		content := m.buffer
-		m.buffer = ""
+		// `answer` is the contract's authoritative field (§4), so it wins over the
+		// streamed tokens rather than the other way round — otherwise the view and
+		// the transcript pushed back as `context` could disagree. The buffered
+		// tokens are the fallback for a sidecar that streams and then sends an
+		// empty `final`. Either way the text is replaced, never printed twice.
+		content := e.Answer
 		if content == "" {
-			content = e.Answer
+			content = m.buffer
 		}
+		m.buffer = ""
 		m.messages = append(m.messages, Message{
 			Role:      RoleAssistant,
 			Content:   content,

--- a/tui/internal/ui/chat/canonical_test.go
+++ b/tui/internal/ui/chat/canonical_test.go
@@ -1,0 +1,235 @@
+package chat
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/amd/gaia/tui/internal/event"
+)
+
+// nullClient satisfies client.AgentClient without doing anything: these tests
+// drive the model's event handling directly.
+type nullClient struct{ resets int }
+
+func (n *nullClient) Send(context.Context, string) (<-chan interface{}, error) {
+	ch := make(chan interface{})
+	close(ch)
+	return ch, nil
+}
+func (n *nullClient) Close() error     { return nil }
+func (n *nullClient) ResetTranscript() { n.resets++ }
+
+func newTestModel(t *testing.T) (ChatModel, *nullClient) {
+	t.Helper()
+	c := &nullClient{}
+	m := NewChatModel(c, "email", "", false)
+	m.width, m.height = 100, 30
+	return m, c
+}
+
+// feed runs a sequence of events through the model, as Bubble Tea would: the
+// model is copied on every update, which is what makes a value-held
+// strings.Builder unusable here.
+func feed(t *testing.T, m ChatModel, events ...interface{}) ChatModel {
+	t.Helper()
+	for _, e := range events {
+		updated, _ := m.handleEvent(e)
+		m = updated.(ChatModel)
+	}
+	return m
+}
+
+func TestCanonicalStreamedTokensBecomeOneAnswer(t *testing.T) {
+	m, _ := newTestModel(t)
+	m.streaming = true
+
+	m = feed(t, m,
+		event.CanonicalStatusEvent{Type: "status", Message: "Scanning inbox"},
+		event.CanonicalTokenEvent{Type: "token", Delta: "You have "},
+		event.CanonicalTokenEvent{Type: "token", Delta: "3 urgent "},
+		event.CanonicalTokenEvent{Type: "token", Delta: "emails."},
+		event.CanonicalFinalEvent{
+			Type:   "final",
+			Answer: "You have 3 urgent emails.",
+			Usage:  []byte(`{"steps":2,"tools_used":1}`),
+		},
+	)
+
+	if m.streaming {
+		t.Error("a terminal `final` must end the turn")
+	}
+	var answers []Message
+	for _, msg := range m.messages {
+		if msg.Role == RoleAssistant {
+			answers = append(answers, msg)
+		}
+	}
+	if len(answers) != 1 {
+		t.Fatalf("expected exactly 1 assistant message, got %d: %+v", len(answers), m.messages)
+	}
+	if answers[0].Content != "You have 3 urgent emails." {
+		t.Errorf("answer = %q", answers[0].Content)
+	}
+	if answers[0].Steps != 2 || answers[0].ToolsUsed != 1 {
+		t.Errorf("usage not carried into the message: %+v", answers[0])
+	}
+}
+
+func TestCanonicalFinalWithoutTokens(t *testing.T) {
+	m, _ := newTestModel(t)
+	m.streaming = true
+
+	m = feed(t, m, event.CanonicalFinalEvent{Type: "final", Answer: "no streaming here"})
+
+	last := m.messages[len(m.messages)-1]
+	if last.Role != RoleAssistant || last.Content != "no streaming here" {
+		t.Fatalf("unexpected message: %+v", last)
+	}
+}
+
+func TestCanonicalToolCallAndResult(t *testing.T) {
+	m, _ := newTestModel(t)
+	m.streaming = true
+
+	m = feed(t, m,
+		event.CanonicalToolCallEvent{Type: "tool_call", Tool: "search_email", Args: []byte(`{"query":"invoice"}`)},
+		event.CanonicalToolResultEvent{
+			Type: "tool_result", Tool: "search_email",
+			Render: "table", Data: []byte(`{"ok":true,"columns":["from"],"rows":[["a@b.c"]]}`),
+		},
+	)
+
+	if len(m.activity) != 1 {
+		t.Fatalf("expected one tool activity line, got %+v", m.activity)
+	}
+	item := m.activity[0]
+	if !item.Done {
+		t.Error("the tool line must be marked done by its result")
+	}
+	if item.Success == nil || !*item.Success {
+		t.Errorf("expected success from {\"ok\":true}, got %v", item.Success)
+	}
+	if !strings.Contains(item.Content, "search_email") || !strings.Contains(item.Content, "invoice") {
+		t.Errorf("tool line lost its detail: %q", item.Content)
+	}
+	// The render key must stay visible until Phase 5 draws the real card.
+	if !strings.Contains(item.Content, "render:table") {
+		t.Errorf("render hint not surfaced: %q", item.Content)
+	}
+}
+
+func TestCanonicalToolResultFailureIsMarkedFailed(t *testing.T) {
+	m, _ := newTestModel(t)
+	m.streaming = true
+
+	m = feed(t, m,
+		event.CanonicalToolCallEvent{Type: "tool_call", Tool: "send_draft"},
+		event.CanonicalToolResultEvent{Type: "tool_result", Tool: "send_draft", Data: []byte(`{"ok":false}`)},
+	)
+
+	item := m.activity[0]
+	if item.Success == nil || *item.Success {
+		t.Errorf("expected failure from {\"ok\":false}, got %v", item.Success)
+	}
+}
+
+// needs_confirmation must be visible and must NOT end the turn — the sidecar
+// sends its own terminal event right after.
+func TestCanonicalNeedsConfirmationIsSurfacedAndTurnContinues(t *testing.T) {
+	m, _ := newTestModel(t)
+	m.streaming = true
+
+	m = feed(t, m, event.CanonicalNeedsConfirmationEvent{
+		Type: "needs_confirmation", RunID: "abc",
+		Action: "send_draft", Summary: "Send reply to alice@example.com",
+	})
+
+	if !m.streaming {
+		t.Error("needs_confirmation must not end the turn on its own")
+	}
+	last := m.messages[len(m.messages)-1]
+	if last.Role != RoleStatus {
+		t.Fatalf("unexpected role %v", last.Role)
+	}
+	if !strings.Contains(last.Content, "send_draft") || !strings.Contains(last.Content, "alice@example.com") {
+		t.Errorf("the pending action must be readable: %q", last.Content)
+	}
+
+	m = feed(t, m, event.CanonicalFinalEvent{Type: "final", Answer: "Skipped — needs approval."})
+	if m.streaming {
+		t.Error("the following `final` must end the turn")
+	}
+}
+
+func TestCanonicalErrorEndsTurnAndKeepsPartialText(t *testing.T) {
+	m, _ := newTestModel(t)
+	m.streaming = true
+
+	m = feed(t, m,
+		event.CanonicalTokenEvent{Type: "token", Delta: "partial answer"},
+		event.CanonicalErrorEvent{Type: "error", Detail: "Lemonade Server is not reachable — run `gaia init`", Status: 503},
+	)
+
+	if m.streaming {
+		t.Error("a terminal `error` must end the turn")
+	}
+	var sawPartial, sawError bool
+	for _, msg := range m.messages {
+		if msg.Role == RoleAssistant && msg.Content == "partial answer" {
+			sawPartial = true
+		}
+		if msg.Role == RoleError && strings.Contains(msg.Content, "gaia init") {
+			sawError = true
+		}
+	}
+	if !sawPartial {
+		t.Error("streamed text must not be discarded when the run errors")
+	}
+	if !sawError {
+		t.Errorf("the actionable detail must be surfaced verbatim: %+v", m.messages)
+	}
+}
+
+func TestCanonicalUnsupportedAndMalformedAreVisible(t *testing.T) {
+	m, _ := newTestModel(t)
+	m.streaming = true
+
+	m = feed(t, m,
+		event.CanonicalUnsupportedEvent{EventType: "needs_input", Raw: `{"type":"needs_input"}`},
+		event.CanonicalMalformedEvent{Payload: `{"type":"token"`, Reason: "not valid JSON: unexpected end"},
+	)
+
+	if !m.streaming {
+		t.Error("neither event terminates the run")
+	}
+	if len(m.messages) != 2 {
+		t.Fatalf("both events must be shown, got %+v", m.messages)
+	}
+	if !strings.Contains(m.messages[0].Content, "needs_input") {
+		t.Errorf("unsupported event not named: %q", m.messages[0].Content)
+	}
+	if !strings.Contains(m.messages[1].Content, "not valid JSON") {
+		t.Errorf("malformed reason not shown: %q", m.messages[1].Content)
+	}
+}
+
+// The legacy in-process vocabulary must keep working for the subprocess transport.
+func TestLegacyEventsStillHandled(t *testing.T) {
+	m, _ := newTestModel(t)
+	m.streaming = true
+
+	m = feed(t, m,
+		event.StepEvent{Type: "step", Step: 1, Total: 3, Status: "running"},
+		event.ThinkingEvent{Type: "thinking", Content: "let me look"},
+		event.AnswerEvent{Type: "answer", Content: "legacy answer", Steps: 1, ToolsUsed: 0},
+	)
+
+	if m.streaming {
+		t.Error("a legacy answer must end the turn")
+	}
+	last := m.messages[len(m.messages)-1]
+	if last.Role != RoleAssistant || last.Content != "legacy answer" {
+		t.Fatalf("unexpected message: %+v", last)
+	}
+}

--- a/tui/internal/ui/chat/introspect.go
+++ b/tui/internal/ui/chat/introspect.go
@@ -1,0 +1,26 @@
+package chat
+
+import "github.com/amd/gaia/tui/internal/control"
+
+// IsStreaming reports whether a query is currently in flight.
+func (m ChatModel) IsStreaming() bool { return m.streaming }
+
+// AgentID is the catalog id of the agent this chat is bound to.
+func (m ChatModel) AgentID() string { return m.agentID }
+
+// CanReturnToHub reports whether esc returns to the hub. When false this chat
+// was launched standalone and esc QUITS — the distinction a driver needs before
+// pressing it.
+func (m ChatModel) CanReturnToHub() bool { return m.fromHub }
+
+// ControlSnapshot lets the control API describe a standalone chat session (the
+// `gaia chat --subprocess` entry point, where ChatModel is the root model).
+func (m ChatModel) ControlSnapshot() control.Snapshot {
+	return control.Snapshot{
+		View:            "chat",
+		Agent:           m.agentID,
+		Streaming:       m.streaming,
+		CanReturnToHub:  m.fromHub,
+		VisibleAgentIDs: []string{},
+	}
+}

--- a/tui/internal/ui/chat/model.go
+++ b/tui/internal/ui/chat/model.go
@@ -88,7 +88,10 @@ type ChatModel struct {
 	messages  []Message
 	activity  []ActivityItem
 	streaming bool
-	buffer    strings.Builder
+	// buffer accumulates streamed answer text. A plain string, not a
+	// strings.Builder: Bubble Tea copies the model on every update, and a
+	// Builder panics the moment a copied non-zero one is written to again.
+	buffer string
 
 	input    textarea.Model
 	viewport viewport.Model
@@ -305,6 +308,12 @@ func (m ChatModel) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			return m, nil
 		case query == "/clear":
 			m.messages = nil
+			// Daemon-transport agents are stateless per turn: the host pushes the
+			// transcript back as `context`, so clearing the view must clear that
+			// too or the "cleared" history keeps being sent.
+			if r, ok := m.client.(client.TranscriptResetter); ok {
+				r.ResetTranscript()
+			}
 			m.updateViewport()
 			return m, nil
 		}
@@ -336,7 +345,7 @@ func (m ChatModel) sendQuery(query string) (tea.Model, tea.Cmd) {
 	})
 	m.streaming = true
 	m.activity = nil
-	m.buffer.Reset()
+	m.buffer = ""
 	m.queryStart = time.Now()
 	m.firstEvent = false
 	m.ttft = 0
@@ -375,6 +384,12 @@ func (m ChatModel) handleEvent(evt interface{}) (tea.Model, tea.Cmd) {
 	if !m.firstEvent {
 		m.firstEvent = true
 		m.ttft = time.Since(m.queryStart)
+	}
+
+	// The daemon transport speaks the canonical seven-event contract; the
+	// subprocess transport speaks the legacy in-process vocabulary below.
+	if updated, cmd, handled := m.handleCanonicalEvent(evt); handled {
+		return updated, cmd
 	}
 
 	switch e := evt.(type) {
@@ -479,7 +494,7 @@ func (m ChatModel) handleEvent(evt interface{}) (tea.Model, tea.Cmd) {
 		return m, nil
 
 	case event.ChunkEvent:
-		m.buffer.WriteString(e.Content)
+		m.buffer += e.Content
 
 	case event.AgentErrorEvent:
 		m.messages = append(m.messages, Message{
@@ -514,7 +529,7 @@ func (m ChatModel) handleEvent(evt interface{}) (tea.Model, tea.Cmd) {
 }
 
 func (m *ChatModel) flushBuffer() {
-	content := m.buffer.String()
+	content := m.buffer
 	if content == "" {
 		return
 	}
@@ -524,7 +539,7 @@ func (m *ChatModel) flushBuffer() {
 		Content:  content,
 		Rendered: rendered,
 	})
-	m.buffer.Reset()
+	m.buffer = ""
 }
 
 func (m *ChatModel) resize() {
@@ -570,7 +585,7 @@ func (m *ChatModel) updateViewport() {
 		sb.WriteString("\n")
 	}
 
-	buf := m.buffer.String()
+	buf := m.buffer
 	if m.streaming && buf != "" {
 		sb.WriteString(assistantStyle.Render(buf))
 		sb.WriteString("\n")

--- a/tui/internal/ui/chat/model.go
+++ b/tui/internal/ui/chat/model.go
@@ -18,9 +18,16 @@ import (
 	"github.com/amd/gaia/tui/internal/ui/components"
 )
 
-type eventMsg struct{ event interface{} }
+// eventMsg and doneMsg carry the channel they came from. Bubble Tea cannot
+// cancel an already-dispatched Cmd, so a cancelled turn's waitForEvent goroutine
+// stays parked on its old channel and delivers late — without the tag, that late
+// delivery would tear down whatever turn is running by then.
+type eventMsg struct {
+	ch    <-chan interface{}
+	event interface{}
+}
 type errMsg struct{ err error }
-type doneMsg struct{}
+type doneMsg struct{ ch <-chan interface{} }
 type sendQueryMsg struct{ query string }
 type channelReadyMsg struct{ ch <-chan interface{} }
 
@@ -187,9 +194,15 @@ func (m ChatModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, waitForEvent(m.events)
 
 	case eventMsg:
+		if m.supersededTurn(msg.ch) {
+			return m, nil
+		}
 		return m.handleEvent(msg.event)
 
 	case doneMsg:
+		if m.supersededTurn(msg.ch) {
+			return m, nil
+		}
 		m.streaming = false
 		m.events = nil
 		m.cancelFn = nil
@@ -374,10 +387,28 @@ func waitForEvent(ch <-chan interface{}) tea.Cmd {
 		}
 		evt, ok := <-ch
 		if !ok {
-			return doneMsg{}
+			return doneMsg{ch: ch}
 		}
-		return eventMsg{event: evt}
+		return eventMsg{ch: ch, event: evt}
 	}
+}
+
+// supersededTurn reports whether a message belongs to a turn that is no longer
+// the current one, so it must be ignored rather than allowed to end the live turn.
+func (m ChatModel) supersededTurn(ch <-chan interface{}) bool {
+	return ch != nil && ch != m.events
+}
+
+// CancelActiveTurn stops any in-flight turn. The UI owns the per-turn context, so
+// tearing this view down has to cancel it — otherwise the transport keeps
+// streaming into a screen nobody is watching and the agent run stays alive.
+func (m *ChatModel) CancelActiveTurn() {
+	if m.cancelFn != nil {
+		m.cancelFn()
+		m.cancelFn = nil
+	}
+	m.streaming = false
+	m.events = nil
 }
 
 func (m ChatModel) handleEvent(evt interface{}) (tea.Model, tea.Cmd) {

--- a/tui/internal/ui/hub/introspect.go
+++ b/tui/internal/ui/hub/introspect.go
@@ -1,0 +1,54 @@
+package hub
+
+import (
+	"github.com/charmbracelet/bubbles/list"
+
+	"github.com/amd/gaia/tui/internal/catalog"
+)
+
+// ActiveTab returns the index and label of the selected category tab.
+func (m HubModel) ActiveTab() (int, string) {
+	if m.activeTab < 0 || m.activeTab >= len(m.tabs) {
+		return m.activeTab, ""
+	}
+	return m.activeTab, string(m.tabs[m.activeTab])
+}
+
+// SelectedAgentID is the catalog id of the highlighted row, or "" when the list
+// is empty.
+func (m HubModel) SelectedAgentID() string {
+	agent, ok := m.list.SelectedItem().(catalog.Agent)
+	if !ok {
+		return ""
+	}
+	return agent.ID
+}
+
+// VisibleAgentIDs lists the rows currently on screen, in order, honouring any
+// active filter. Automation walks this to move the selection deterministically
+// instead of guessing how many times to press down.
+func (m HubModel) VisibleAgentIDs() []string {
+	items := m.list.VisibleItems()
+	ids := make([]string, 0, len(items))
+	for _, item := range items {
+		if agent, ok := item.(catalog.Agent); ok {
+			ids = append(ids, agent.ID)
+		}
+	}
+	return ids
+}
+
+// IsFiltering reports whether a search filter is being typed or is applied —
+// either way the visible rows are a subset, so a caller must clear it before
+// counting rows.
+func (m HubModel) IsFiltering() bool {
+	return m.list.FilterState() != list.Unfiltered
+}
+
+// Overlay names the modal currently covering the hub, or "" when there is none.
+func (m HubModel) Overlay() string {
+	if m.confirm != nil {
+		return "confirm"
+	}
+	return ""
+}

--- a/tui/internal/ui/hub/model.go
+++ b/tui/internal/ui/hub/model.go
@@ -100,6 +100,12 @@ func (m HubModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	return m, cmd
 }
 
+// SetStatus shows an ephemeral message in the hub, used to surface a launch
+// failure without leaving the user staring at an unchanged screen.
+func (m *HubModel) SetStatus(status string) {
+	m.status = status
+}
+
 func (m HubModel) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	switch msg.String() {
 	case "q", "ctrl+c":

--- a/tui/internal/ui/oneshot.go
+++ b/tui/internal/ui/oneshot.go
@@ -1,0 +1,153 @@
+package ui
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/amd/gaia/tui/internal/client"
+	"github.com/amd/gaia/tui/internal/event"
+)
+
+// OneShotResult is the outcome of one non-interactive turn. It mirrors
+// gaia.daemon.agent_query.QueryOutcome so the Go and Python thin clients report
+// the same thing.
+type OneShotResult struct {
+	// ExitCode is 0 on a terminal `final`, 1 on a terminal `error` or a stream
+	// that ended without either.
+	ExitCode int
+	// TerminalType is "final", "error", or "" when no terminal event arrived.
+	TerminalType string
+	Answer       string
+	ErrorDetail  string
+}
+
+// RunOneShot drives a single turn and renders it to plain streams — no alt
+// screen, no TTY required.
+//
+// The answer goes to out and progress to errW, so `... --query X > answer.txt`
+// captures exactly the answer and nothing else. This is the same split the
+// `gaia <agent>` CLI uses, and it is what makes the transport testable from a
+// script and from CI.
+func RunOneShot(
+	ctx context.Context,
+	c client.AgentClient,
+	query string,
+	out, errW io.Writer,
+) OneShotResult {
+	ch, err := c.Send(ctx, query)
+	if err != nil {
+		fmt.Fprintf(errW, "❌ %v\n", err)
+		return OneShotResult{ExitCode: 1, ErrorDetail: err.Error()}
+	}
+
+	var (
+		res       OneShotResult
+		streamed  strings.Builder
+		sawTokens bool
+	)
+
+	for evt := range ch {
+		switch e := evt.(type) {
+		case event.CanonicalStatusEvent:
+			if msg := strings.TrimSpace(e.Message); msg != "" {
+				fmt.Fprintf(errW, "  … %s\n", msg)
+			}
+
+		case event.CanonicalTokenEvent:
+			if e.Delta == "" {
+				continue
+			}
+			sawTokens = true
+			streamed.WriteString(e.Delta)
+			fmt.Fprint(out, e.Delta)
+
+		case event.CanonicalToolCallEvent:
+			fmt.Fprintf(errW, "  🔧 %s\n", e.Tool)
+
+		case event.CanonicalToolResultEvent:
+			if e.Render != "" {
+				fmt.Fprintf(errW, "  ✓ %s (%s)\n", e.Tool, e.Render)
+			} else {
+				fmt.Fprintf(errW, "  ✓ %s\n", e.Tool)
+			}
+
+		case event.CanonicalNeedsConfirmationEvent:
+			line := "  ⚠️  confirmation needed: " + e.Action
+			if summary := strings.TrimSpace(e.Summary); summary != "" {
+				line += " — " + summary
+			}
+			fmt.Fprintln(errW, line)
+
+		case event.CanonicalFinalEvent:
+			res.TerminalType = event.CanonicalTypeFinal
+			// `answer` is authoritative; the streamed tokens are the fallback for
+			// a sidecar that streams and then closes with an empty final.
+			res.Answer = e.Answer
+			if res.Answer == "" {
+				res.Answer = streamed.String()
+			}
+			if sawTokens {
+				// The tokens already printed the answer live — just end the line.
+				fmt.Fprintln(out)
+			} else if res.Answer != "" {
+				fmt.Fprintln(out, res.Answer)
+			}
+			if usage := event.CanonicalUsageOf(e); usage.Steps > 0 || usage.ToolsUsed > 0 {
+				fmt.Fprintf(errW, "  ℹ️  %d steps, %d tools\n", usage.Steps, usage.ToolsUsed)
+			}
+
+		case event.CanonicalErrorEvent:
+			res.TerminalType = event.CanonicalTypeError
+			res.ErrorDetail = e.Detail
+			if sawTokens {
+				fmt.Fprintln(out)
+			}
+			fmt.Fprintf(errW, "❌ %s\n", e.Detail)
+
+		case event.CanonicalUnsupportedEvent:
+			// Contract §7: visible, never dropped.
+			fmt.Fprintf(errW, "  [unsupported event %q]\n", e.EventType)
+
+		case event.CanonicalMalformedEvent:
+			fmt.Fprintf(errW, "  [unreadable event skipped: %s]\n", e.Reason)
+
+		// The legacy in-process vocabulary, so this renderer also works when
+		// pointed at a subprocess agent.
+		case event.AnswerEvent:
+			res.TerminalType = event.CanonicalTypeFinal
+			res.Answer = e.Content
+			fmt.Fprintln(out, e.Content)
+		case event.AgentErrorEvent:
+			res.TerminalType = event.CanonicalTypeError
+			res.ErrorDetail = e.Content
+			fmt.Fprintf(errW, "❌ %s\n", e.Content)
+		case event.ToolStartEvent:
+			fmt.Fprintf(errW, "  🔧 %s\n", e.Tool)
+		case event.StatusEvent:
+			if msg := strings.TrimSpace(e.Message); msg != "" {
+				fmt.Fprintf(errW, "  … %s\n", msg)
+			}
+		case event.ChunkEvent:
+			sawTokens = true
+			streamed.WriteString(e.Content)
+			fmt.Fprint(out, e.Content)
+
+		default:
+			fmt.Fprintf(errW, "  [unhandled event %T]\n", evt)
+		}
+	}
+
+	if res.TerminalType == "" {
+		// Exactly one terminal event is mandatory; a stream that ends without one
+		// is a failure, reported loudly rather than as an empty success.
+		res.ErrorDetail = fmt.Sprintf(
+			"the %q query stream ended without a terminal final/error event", query)
+		fmt.Fprintf(errW, "❌ %s\n", res.ErrorDetail)
+	}
+	if res.TerminalType != event.CanonicalTypeFinal {
+		res.ExitCode = 1
+	}
+	return res
+}

--- a/tui/internal/ui/oneshot_test.go
+++ b/tui/internal/ui/oneshot_test.go
@@ -29,7 +29,7 @@ func (s *scriptedClient) Send(context.Context, string) (<-chan interface{}, erro
 
 func (s *scriptedClient) Close() error { return nil }
 
-func run(t *testing.T, events ...interface{}) (OneShotResult, string, string) {
+func captureOneShot(t *testing.T, events ...interface{}) (OneShotResult, string, string) {
 	t.Helper()
 	var out, errW bytes.Buffer
 	res := RunOneShot(context.Background(), &scriptedClient{events: events}, "q", &out, &errW)
@@ -39,7 +39,7 @@ func run(t *testing.T, events ...interface{}) (OneShotResult, string, string) {
 // The answer goes to stdout and nothing else does, so `--query X > file` captures
 // exactly the answer.
 func TestRunOneShotSeparatesAnswerFromProgress(t *testing.T) {
-	res, out, errW := run(t,
+	res, out, errW := captureOneShot(t,
 		event.CanonicalStatusEvent{Type: "status", Message: "Scanning inbox"},
 		event.CanonicalToolCallEvent{Type: "tool_call", Tool: "pre_scan_inbox"},
 		event.CanonicalToolResultEvent{Type: "tool_result", Tool: "pre_scan_inbox", Render: "email_pre_scan"},
@@ -63,7 +63,7 @@ func TestRunOneShotSeparatesAnswerFromProgress(t *testing.T) {
 }
 
 func TestRunOneShotStreamsTokensWithoutDuplicatingTheAnswer(t *testing.T) {
-	res, out, _ := run(t,
+	res, out, _ := captureOneShot(t,
 		event.CanonicalTokenEvent{Type: "token", Delta: "You have "},
 		event.CanonicalTokenEvent{Type: "token", Delta: "3 urgent emails"},
 		event.CanonicalFinalEvent{Type: "final", Answer: "You have 3 urgent emails"},
@@ -78,7 +78,7 @@ func TestRunOneShotStreamsTokensWithoutDuplicatingTheAnswer(t *testing.T) {
 }
 
 func TestRunOneShotFinalWithEmptyAnswerKeepsStreamedTokens(t *testing.T) {
-	res, out, _ := run(t,
+	res, out, _ := captureOneShot(t,
 		event.CanonicalTokenEvent{Type: "token", Delta: "streamed only"},
 		event.CanonicalFinalEvent{Type: "final", Answer: ""},
 	)
@@ -91,7 +91,7 @@ func TestRunOneShotFinalWithEmptyAnswerKeepsStreamedTokens(t *testing.T) {
 }
 
 func TestRunOneShotTerminalErrorExitsNonZero(t *testing.T) {
-	res, out, errW := run(t,
+	res, out, errW := captureOneShot(t,
 		event.CanonicalErrorEvent{Type: "error", Detail: "Lemonade is not reachable — run `gaia init`", Status: 503},
 	)
 	if res.ExitCode != 1 {
@@ -107,7 +107,7 @@ func TestRunOneShotTerminalErrorExitsNonZero(t *testing.T) {
 
 // A stream that ends with no terminal event is a failure, not an empty success.
 func TestRunOneShotNoTerminalEventExitsNonZero(t *testing.T) {
-	res, _, errW := run(t,
+	res, _, errW := captureOneShot(t,
 		event.CanonicalStatusEvent{Type: "status", Message: "working"},
 	)
 	if res.ExitCode != 1 {
@@ -133,7 +133,7 @@ func TestRunOneShotSendFailureIsReported(t *testing.T) {
 
 // Unknown and unreadable events stay visible (contract §7) and do not end the run.
 func TestRunOneShotSurfacesUnsupportedAndMalformed(t *testing.T) {
-	res, _, errW := run(t,
+	res, _, errW := captureOneShot(t,
 		event.CanonicalUnsupportedEvent{EventType: "needs_input"},
 		event.CanonicalMalformedEvent{Reason: "not valid JSON"},
 		event.CanonicalFinalEvent{Type: "final", Answer: "done"},
@@ -147,7 +147,7 @@ func TestRunOneShotSurfacesUnsupportedAndMalformed(t *testing.T) {
 }
 
 func TestRunOneShotSurfacesNeedsConfirmation(t *testing.T) {
-	_, _, errW := run(t,
+	_, _, errW := captureOneShot(t,
 		event.CanonicalNeedsConfirmationEvent{
 			Type: "needs_confirmation", Action: "send_draft",
 			Summary: "Send reply to alice@example.com",
@@ -161,7 +161,7 @@ func TestRunOneShotSurfacesNeedsConfirmation(t *testing.T) {
 
 // The same renderer also handles a subprocess agent's legacy vocabulary.
 func TestRunOneShotHandlesLegacyEvents(t *testing.T) {
-	res, out, _ := run(t,
+	res, out, _ := captureOneShot(t,
 		event.ToolStartEvent{Type: "tool_start", Tool: "bash"},
 		event.AnswerEvent{Type: "answer", Content: "legacy answer"},
 	)

--- a/tui/internal/ui/oneshot_test.go
+++ b/tui/internal/ui/oneshot_test.go
@@ -1,0 +1,178 @@
+package ui
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/amd/gaia/tui/internal/event"
+)
+
+// scriptedClient replays a fixed event sequence, or fails Send outright.
+type scriptedClient struct {
+	events  []interface{}
+	sendErr error
+}
+
+func (s *scriptedClient) Send(context.Context, string) (<-chan interface{}, error) {
+	if s.sendErr != nil {
+		return nil, s.sendErr
+	}
+	ch := make(chan interface{}, len(s.events))
+	for _, e := range s.events {
+		ch <- e
+	}
+	close(ch)
+	return ch, nil
+}
+
+func (s *scriptedClient) Close() error { return nil }
+
+func run(t *testing.T, events ...interface{}) (OneShotResult, string, string) {
+	t.Helper()
+	var out, errW bytes.Buffer
+	res := RunOneShot(context.Background(), &scriptedClient{events: events}, "q", &out, &errW)
+	return res, out.String(), errW.String()
+}
+
+// The answer goes to stdout and nothing else does, so `--query X > file` captures
+// exactly the answer.
+func TestRunOneShotSeparatesAnswerFromProgress(t *testing.T) {
+	res, out, errW := run(t,
+		event.CanonicalStatusEvent{Type: "status", Message: "Scanning inbox"},
+		event.CanonicalToolCallEvent{Type: "tool_call", Tool: "pre_scan_inbox"},
+		event.CanonicalToolResultEvent{Type: "tool_result", Tool: "pre_scan_inbox", Render: "email_pre_scan"},
+		event.CanonicalFinalEvent{Type: "final", Answer: "3 urgent emails", Usage: []byte(`{"steps":2,"tools_used":1}`)},
+	)
+
+	if res.ExitCode != 0 {
+		t.Errorf("exit code = %d, want 0", res.ExitCode)
+	}
+	if res.TerminalType != event.CanonicalTypeFinal {
+		t.Errorf("terminal = %q", res.TerminalType)
+	}
+	if strings.TrimSpace(out) != "3 urgent emails" {
+		t.Errorf("stdout must carry only the answer, got %q", out)
+	}
+	for _, want := range []string{"Scanning inbox", "pre_scan_inbox", "email_pre_scan", "2 steps"} {
+		if !strings.Contains(errW, want) {
+			t.Errorf("stderr missing %q: %s", want, errW)
+		}
+	}
+}
+
+func TestRunOneShotStreamsTokensWithoutDuplicatingTheAnswer(t *testing.T) {
+	res, out, _ := run(t,
+		event.CanonicalTokenEvent{Type: "token", Delta: "You have "},
+		event.CanonicalTokenEvent{Type: "token", Delta: "3 urgent emails"},
+		event.CanonicalFinalEvent{Type: "final", Answer: "You have 3 urgent emails"},
+	)
+
+	if got := strings.TrimSpace(out); got != "You have 3 urgent emails" {
+		t.Errorf("the answer must not be printed twice, got %q", got)
+	}
+	if res.Answer != "You have 3 urgent emails" {
+		t.Errorf("answer = %q", res.Answer)
+	}
+}
+
+func TestRunOneShotFinalWithEmptyAnswerKeepsStreamedTokens(t *testing.T) {
+	res, out, _ := run(t,
+		event.CanonicalTokenEvent{Type: "token", Delta: "streamed only"},
+		event.CanonicalFinalEvent{Type: "final", Answer: ""},
+	)
+	if res.Answer != "streamed only" {
+		t.Errorf("answer = %q, want the streamed text", res.Answer)
+	}
+	if !strings.Contains(out, "streamed only") {
+		t.Errorf("stdout = %q", out)
+	}
+}
+
+func TestRunOneShotTerminalErrorExitsNonZero(t *testing.T) {
+	res, out, errW := run(t,
+		event.CanonicalErrorEvent{Type: "error", Detail: "Lemonade is not reachable — run `gaia init`", Status: 503},
+	)
+	if res.ExitCode != 1 {
+		t.Errorf("exit code = %d, want 1", res.ExitCode)
+	}
+	if out != "" {
+		t.Errorf("a failed turn must not write to stdout, got %q", out)
+	}
+	if !strings.Contains(errW, "gaia init") {
+		t.Errorf("the actionable detail must be surfaced verbatim: %q", errW)
+	}
+}
+
+// A stream that ends with no terminal event is a failure, not an empty success.
+func TestRunOneShotNoTerminalEventExitsNonZero(t *testing.T) {
+	res, _, errW := run(t,
+		event.CanonicalStatusEvent{Type: "status", Message: "working"},
+	)
+	if res.ExitCode != 1 {
+		t.Errorf("exit code = %d, want 1", res.ExitCode)
+	}
+	if !strings.Contains(errW, "without a terminal") {
+		t.Errorf("stderr must explain the missing terminal event: %q", errW)
+	}
+}
+
+func TestRunOneShotSendFailureIsReported(t *testing.T) {
+	var out, errW bytes.Buffer
+	c := &scriptedClient{sendErr: errFake("no daemon is registered; start one with `gaia daemon start`")}
+	res := RunOneShot(context.Background(), c, "q", &out, &errW)
+
+	if res.ExitCode != 1 {
+		t.Errorf("exit code = %d, want 1", res.ExitCode)
+	}
+	if !strings.Contains(errW.String(), "gaia daemon start") {
+		t.Errorf("the transport error must be surfaced: %q", errW.String())
+	}
+}
+
+// Unknown and unreadable events stay visible (contract §7) and do not end the run.
+func TestRunOneShotSurfacesUnsupportedAndMalformed(t *testing.T) {
+	res, _, errW := run(t,
+		event.CanonicalUnsupportedEvent{EventType: "needs_input"},
+		event.CanonicalMalformedEvent{Reason: "not valid JSON"},
+		event.CanonicalFinalEvent{Type: "final", Answer: "done"},
+	)
+	if res.ExitCode != 0 {
+		t.Errorf("neither event should fail the run, exit = %d", res.ExitCode)
+	}
+	if !strings.Contains(errW, "needs_input") || !strings.Contains(errW, "not valid JSON") {
+		t.Errorf("both must be visible: %q", errW)
+	}
+}
+
+func TestRunOneShotSurfacesNeedsConfirmation(t *testing.T) {
+	_, _, errW := run(t,
+		event.CanonicalNeedsConfirmationEvent{
+			Type: "needs_confirmation", Action: "send_draft",
+			Summary: "Send reply to alice@example.com",
+		},
+		event.CanonicalFinalEvent{Type: "final", Answer: "skipped"},
+	)
+	if !strings.Contains(errW, "send_draft") || !strings.Contains(errW, "alice@example.com") {
+		t.Errorf("a pending approval must never be swallowed: %q", errW)
+	}
+}
+
+// The same renderer also handles a subprocess agent's legacy vocabulary.
+func TestRunOneShotHandlesLegacyEvents(t *testing.T) {
+	res, out, _ := run(t,
+		event.ToolStartEvent{Type: "tool_start", Tool: "bash"},
+		event.AnswerEvent{Type: "answer", Content: "legacy answer"},
+	)
+	if res.ExitCode != 0 {
+		t.Errorf("exit code = %d, want 0", res.ExitCode)
+	}
+	if strings.TrimSpace(out) != "legacy answer" {
+		t.Errorf("stdout = %q", out)
+	}
+}
+
+type errFake string
+
+func (e errFake) Error() string { return string(e) }

--- a/tui/internal/ui/root/introspect.go
+++ b/tui/internal/ui/root/introspect.go
@@ -1,0 +1,35 @@
+package root
+
+import "github.com/amd/gaia/tui/internal/control"
+
+// ControlSnapshot reports where the user currently is, for the control API's
+// /status and for POST /wait state matchers.
+//
+// It satisfies control.SnapshotProvider. Reporting real model state — rather
+// than inferring it from the rendered characters — is what lets an assistant
+// wait on "the chat view for agent X is open" instead of racing on a substring.
+func (m RootModel) ControlSnapshot() control.Snapshot {
+	snap := control.Snapshot{View: control.ViewUnknown, VisibleAgentIDs: []string{}}
+
+	switch m.activeView {
+	case viewHub:
+		snap.View = "hub"
+		snap.HubTabIndex, snap.HubTab = m.hub.ActiveTab()
+		snap.SelectedAgentID = m.hub.SelectedAgentID()
+		snap.VisibleAgentIDs = m.hub.VisibleAgentIDs()
+		snap.Filtering = m.hub.IsFiltering()
+		snap.Overlay = m.hub.Overlay()
+	case viewChat:
+		snap.View = "chat"
+		if m.chat != nil {
+			snap.Agent = m.chat.AgentID()
+			snap.Streaming = m.chat.IsStreaming()
+			snap.CanReturnToHub = m.chat.CanReturnToHub()
+		}
+	}
+
+	if m.showHelp {
+		snap.Overlay = "help"
+	}
+	return snap
+}

--- a/tui/internal/ui/root/model.go
+++ b/tui/internal/ui/root/model.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/amd/gaia/tui/internal/catalog"
 	"github.com/amd/gaia/tui/internal/client"
-	"github.com/amd/gaia/tui/internal/daemon"
 	"github.com/amd/gaia/tui/internal/ui/chat"
 	"github.com/amd/gaia/tui/internal/ui/components"
 	"github.com/amd/gaia/tui/internal/ui/hub"
@@ -128,18 +127,6 @@ func (m RootModel) View() string {
 	return base
 }
 
-// newAgentClient builds the transport the catalog entry asks for.
-func (m RootModel) newAgentClient(agent catalog.Agent) client.AgentClient {
-	if agent.Transport == catalog.TransportDaemon {
-		// HTTP sidecar behind the daemon relay: no binary, no stdin/stdout.
-		return client.NewSSEClient(agent.ID, daemon.New(daemon.Options{Logf: m.logf}), client.SSEOptions{
-			Logf: m.logf,
-		})
-	}
-	// catalog.TransportSubprocess (the zero value): spawn the binary directly.
-	return client.NewSubprocessClient(agent.BinaryPath, agent.BinaryArgs, m.debug)
-}
-
 // logf writes transport diagnostics to stderr in debug mode. It must never be
 // given a daemon token — daemon.Instance redacts its own token when formatted.
 func (m RootModel) logf(format string, args ...any) {
@@ -150,7 +137,12 @@ func (m RootModel) logf(format string, args ...any) {
 }
 
 func (m RootModel) launchAgent(agent catalog.Agent) (tea.Model, tea.Cmd) {
-	c := m.newAgentClient(agent)
+	c, err := client.ForAgent(agent, client.ForAgentOptions{Debug: m.debug, Logf: m.logf})
+	if err != nil {
+		// Stay in the hub and say why, rather than opening a chat that cannot talk.
+		m.hub.SetStatus(err.Error())
+		return m, nil
+	}
 	m.chatClient = c
 
 	m.catalog.SetStatus(agent.ID, catalog.StatusActive)
@@ -174,6 +166,12 @@ func (m RootModel) launchAgent(agent catalog.Agent) (tea.Model, tea.Cmd) {
 func (m RootModel) returnToHub(agentID string) (tea.Model, tea.Cmd) {
 	m.catalog.SetStatus(agentID, catalog.StatusIdle)
 
+	// Cancel before closing: the chat model owns the per-turn context, so closing
+	// the transport without cancelling it can leave a reader streaming into a
+	// screen that no longer exists.
+	if m.chat != nil {
+		m.chat.CancelActiveTurn()
+	}
 	if m.chatClient != nil {
 		m.chatClient.Close()
 		m.chatClient = nil

--- a/tui/internal/ui/root/model.go
+++ b/tui/internal/ui/root/model.go
@@ -1,12 +1,14 @@
 package root
 
 import (
-	"strings"
+	"fmt"
+	"os"
 
 	tea "github.com/charmbracelet/bubbletea"
 
 	"github.com/amd/gaia/tui/internal/catalog"
 	"github.com/amd/gaia/tui/internal/client"
+	"github.com/amd/gaia/tui/internal/daemon"
 	"github.com/amd/gaia/tui/internal/ui/chat"
 	"github.com/amd/gaia/tui/internal/ui/components"
 	"github.com/amd/gaia/tui/internal/ui/hub"
@@ -15,7 +17,7 @@ import (
 type view int
 
 const (
-	viewHub  view = iota
+	viewHub view = iota
 	viewChat
 )
 
@@ -126,13 +128,29 @@ func (m RootModel) View() string {
 	return base
 }
 
-func (m RootModel) launchAgent(agent catalog.Agent) (tea.Model, tea.Cmd) {
-	cmdLine := agent.BinaryPath
-	if len(agent.BinaryArgs) > 0 {
-		cmdLine += " " + strings.Join(agent.BinaryArgs, " ")
+// newAgentClient builds the transport the catalog entry asks for.
+func (m RootModel) newAgentClient(agent catalog.Agent) client.AgentClient {
+	if agent.Transport == catalog.TransportDaemon {
+		// HTTP sidecar behind the daemon relay: no binary, no stdin/stdout.
+		return client.NewSSEClient(agent.ID, daemon.New(daemon.Options{Logf: m.logf}), client.SSEOptions{
+			Logf: m.logf,
+		})
 	}
+	// catalog.TransportSubprocess (the zero value): spawn the binary directly.
+	return client.NewSubprocessClient(agent.BinaryPath, agent.BinaryArgs, m.debug)
+}
 
-	c := client.NewSubprocessClient(cmdLine, m.debug)
+// logf writes transport diagnostics to stderr in debug mode. It must never be
+// given a daemon token — daemon.Instance redacts its own token when formatted.
+func (m RootModel) logf(format string, args ...any) {
+	if !m.debug {
+		return
+	}
+	fmt.Fprintf(os.Stderr, "[DEBUG] "+format+"\n", args...)
+}
+
+func (m RootModel) launchAgent(agent catalog.Agent) (tea.Model, tea.Cmd) {
+	c := m.newAgentClient(agent)
 	m.chatClient = c
 
 	m.catalog.SetStatus(agent.ID, catalog.StatusActive)

--- a/tui/test/control_test.go
+++ b/tui/test/control_test.go
@@ -1,0 +1,332 @@
+package test
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/amd/gaia/tui/internal/catalog"
+	"github.com/amd/gaia/tui/internal/control"
+	"github.com/amd/gaia/tui/internal/ui/root"
+)
+
+// liveTUI boots the real root model inside a real tea.Program, headlessly, with
+// the control server attached — the same wiring `gaia tui --control` uses.
+type liveTUI struct {
+	t     *testing.T
+	srv   *control.Server
+	prog  *tea.Program
+	token string
+}
+
+func startLiveTUI(t *testing.T) *liveTUI {
+	t.Helper()
+	t.Setenv(control.EnvHome, t.TempDir())
+
+	cat := catalog.NewCatalog()
+	state := control.NewState(nil)
+	prog := tea.NewProgram(
+		control.NewRecorder(root.NewRootModel(cat, false), state),
+		tea.WithInput(strings.NewReader("")),
+		tea.WithOutput(io.Discard),
+		tea.WithoutRenderer(),
+	)
+
+	srv, err := control.Start(prog, state, control.Options{Version: "test"})
+	if err != nil {
+		t.Fatalf("control.Start: %v", err)
+	}
+
+	// Bracket Run exactly as ui.run does: the control server refuses injection
+	// while the event loop is not consuming messages.
+	srv.MarkRunning()
+	done := make(chan error, 1)
+	go func() {
+		_, runErr := prog.Run()
+		srv.MarkStopped()
+		done <- runErr
+	}()
+
+	t.Cleanup(func() {
+		prog.Quit()
+		select {
+		case err := <-done:
+			if err != nil {
+				t.Errorf("program exited with %v", err)
+			}
+		case <-time.After(5 * time.Second):
+			t.Error("program did not exit within 5s")
+		}
+		if err := srv.Stop(); err != nil {
+			t.Errorf("control.Stop: %v", err)
+		}
+	})
+
+	return &liveTUI{t: t, srv: srv, prog: prog, token: srv.Token()}
+}
+
+func (l *liveTUI) call(method, path string, body any) (int, map[string]any) {
+	l.t.Helper()
+	var reader io.Reader
+	if body != nil {
+		raw, err := json.Marshal(body)
+		if err != nil {
+			l.t.Fatalf("marshal: %v", err)
+		}
+		reader = bytes.NewReader(raw)
+	}
+	req, err := http.NewRequest(method, l.srv.BaseURL()+"/control/v1"+path, reader)
+	if err != nil {
+		l.t.Fatalf("new request: %v", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+l.token)
+	client := &http.Client{Timeout: 30 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		l.t.Fatalf("%s %s: %v", method, path, err)
+	}
+	defer resp.Body.Close()
+	var decoded map[string]any
+	if err := json.NewDecoder(resp.Body).Decode(&decoded); err != nil {
+		l.t.Fatalf("%s %s: decode: %v", method, path, err)
+	}
+	return resp.StatusCode, decoded
+}
+
+func (l *liveTUI) screen() string {
+	l.t.Helper()
+	status, body := l.call(http.MethodGet, "/screen", nil)
+	if status != http.StatusOK {
+		l.t.Fatalf("GET /screen: status %d (%v)", status, body)
+	}
+	text, _ := body["screen"].(string)
+	return text
+}
+
+func (l *liveTUI) state() map[string]any {
+	l.t.Helper()
+	status, body := l.call(http.MethodGet, "/status", nil)
+	if status != http.StatusOK {
+		l.t.Fatalf("GET /status: status %d (%v)", status, body)
+	}
+	st, _ := body["state"].(map[string]any)
+	return st
+}
+
+func (l *liveTUI) waitFor(matcher map[string]any) map[string]any {
+	l.t.Helper()
+	if _, ok := matcher["timeout_ms"]; !ok {
+		matcher["timeout_ms"] = 5000
+	}
+	status, body := l.call(http.MethodPost, "/wait", matcher)
+	if status != http.StatusOK {
+		envelope, _ := body["error"].(map[string]any)
+		l.t.Fatalf("POST /wait %v: status %d\nmessage: %v\nscreen was:\n%v",
+			matcher, status, envelope["message"], envelope["screen"])
+	}
+	return body
+}
+
+func (l *liveTUI) keys(names ...string) {
+	l.t.Helper()
+	status, body := l.call(http.MethodPost, "/keys", map[string]any{"keys": names})
+	if status != http.StatusOK {
+		l.t.Fatalf("POST /keys %v: status %d (%v)", names, status, body)
+	}
+}
+
+// TestControlDrivesLiveProgram is the end-to-end proof: a real tea.Program, a
+// real root model, driven only over HTTP, with the rendered screen read back.
+func TestControlDrivesLiveProgram(t *testing.T) {
+	tui := startLiveTUI(t)
+
+	// The hub renders "Loading..." until it knows the terminal size, so the
+	// first thing any driver does is set one.
+	status, body := tui.call(http.MethodPost, "/resize", map[string]any{"cols": 120, "rows": 40})
+	if status != http.StatusOK {
+		t.Fatalf("POST /resize: status %d (%v)", status, body)
+	}
+	tui.waitFor(map[string]any{"contains": "Installed"})
+
+	screen := tui.screen()
+	if strings.Contains(screen, "Loading...") {
+		t.Fatalf("hub is still loading after a resize; screen:\n%s", screen)
+	}
+	if !strings.Contains(screen, "Bash") {
+		t.Fatalf("hub screen does not list the seeded Bash agent; screen:\n%s", screen)
+	}
+	if strings.Contains(screen, "\x1b[") {
+		t.Error("format=plain returned ANSI escape sequences")
+	}
+
+	st := tui.state()
+	if st["view"] != "hub" {
+		t.Errorf("view = %v, want hub", st["view"])
+	}
+	if st["hub_tab"] != string(catalog.SectionInstalled) {
+		t.Errorf("hub_tab = %v, want %q", st["hub_tab"], catalog.SectionInstalled)
+	}
+	visible, _ := st["visible_agent_ids"].([]any)
+	if len(visible) == 0 {
+		t.Error("visible_agent_ids is empty; navigation by id would be impossible")
+	}
+}
+
+// TestControlTabKeyIsTheTabKey is the regression the older smoke tests miss:
+// sending tea.KeyRunes{"tab"} types three letters, so the category never
+// changes. Driving through the control API must actually switch tabs.
+func TestControlTabKeyIsTheTabKey(t *testing.T) {
+	tui := startLiveTUI(t)
+	tui.call(http.MethodPost, "/resize", map[string]any{"cols": 120, "rows": 40})
+	tui.waitFor(map[string]any{"state": map[string]any{"view": "hub"}})
+
+	before := tui.state()
+	tui.keys("tab")
+	tui.waitFor(map[string]any{"state": map[string]any{"hub_tab": string(catalog.SectionAvailable)}})
+
+	after := tui.state()
+	if before["hub_tab"] == after["hub_tab"] {
+		t.Fatalf("hub_tab stayed %v after pressing tab", after["hub_tab"])
+	}
+	if !strings.Contains(tui.screen(), string(catalog.SectionAvailable)) {
+		t.Errorf("screen does not show the Available tab:\n%s", tui.screen())
+	}
+
+	tui.keys("shift+tab")
+	tui.waitFor(map[string]any{"state": map[string]any{"hub_tab": string(catalog.SectionInstalled)}})
+}
+
+// TestControlFilterAndSelect exercises the search flow: "/" opens the filter,
+// typed runes narrow it, and the reported selection follows.
+func TestControlFilterAndSelect(t *testing.T) {
+	tui := startLiveTUI(t)
+	tui.call(http.MethodPost, "/resize", map[string]any{"cols": 120, "rows": 40})
+	tui.waitFor(map[string]any{"state": map[string]any{"view": "hub"}})
+
+	tui.keys("/")
+	tui.waitFor(map[string]any{"state": map[string]any{"filtering": true}})
+
+	status, body := tui.call(http.MethodPost, "/text", map[string]any{"text": "bash"})
+	if status != http.StatusOK {
+		t.Fatalf("POST /text: status %d (%v)", status, body)
+	}
+	tui.waitFor(map[string]any{"contains": "bash"})
+
+	tui.keys("esc")
+	tui.waitFor(map[string]any{"state": map[string]any{"filtering": false}})
+}
+
+// TestControlHelpOverlay proves a named single-rune key ("?") reaches the model
+// and that the overlay is reported as state, not guessed from the screen.
+func TestControlHelpOverlay(t *testing.T) {
+	tui := startLiveTUI(t)
+	tui.call(http.MethodPost, "/resize", map[string]any{"cols": 120, "rows": 40})
+	tui.waitFor(map[string]any{"state": map[string]any{"view": "hub"}})
+
+	tui.keys("?")
+	tui.waitFor(map[string]any{"state": map[string]any{"overlay": "help"}})
+
+	tui.keys("esc")
+	tui.waitFor(map[string]any{"state": map[string]any{"overlay": ""}})
+}
+
+// TestControlResizeChangesLayout covers the narrow-terminal case: the same
+// model laid out at 80x24 and at 200x50 must produce different frames.
+func TestControlResizeChangesLayout(t *testing.T) {
+	tui := startLiveTUI(t)
+
+	tui.call(http.MethodPost, "/resize", map[string]any{"cols": 80, "rows": 24})
+	tui.waitFor(map[string]any{"contains": "Installed"})
+	narrow := tui.screen()
+
+	tui.call(http.MethodPost, "/resize", map[string]any{"cols": 200, "rows": 50})
+	tui.waitFor(map[string]any{"contains": "Installed"})
+	wide := tui.screen()
+
+	if narrow == wide {
+		t.Error("the screen is identical at 80x24 and 200x50; the resize never reached the layout")
+	}
+	if widest(narrow) > 80 {
+		t.Errorf("a line of %d columns overflows the 80-column terminal", widest(narrow))
+	}
+}
+
+// TestControlFramesRecordHistory checks the debugging endpoint returns the
+// frames that led to the current screen.
+func TestControlFramesRecordHistory(t *testing.T) {
+	tui := startLiveTUI(t)
+	tui.call(http.MethodPost, "/resize", map[string]any{"cols": 120, "rows": 40})
+	tui.waitFor(map[string]any{"state": map[string]any{"view": "hub"}})
+	tui.keys("tab")
+	tui.waitFor(map[string]any{"state": map[string]any{"hub_tab": string(catalog.SectionAvailable)}})
+
+	status, body := tui.call(http.MethodGet, "/frames?since=0&limit=50", nil)
+	if status != http.StatusOK {
+		t.Fatalf("GET /frames: status %d (%v)", status, body)
+	}
+	frames, _ := body["frames"].([]any)
+	if len(frames) < 2 {
+		t.Fatalf("only %d frames recorded; the history is not usable for debugging", len(frames))
+	}
+	last, _ := frames[len(frames)-1].(map[string]any)
+	if screen, _ := last["screen"].(string); !strings.Contains(screen, string(catalog.SectionAvailable)) {
+		t.Errorf("the newest frame does not show the Available tab:\n%s", screen)
+	}
+}
+
+// TestControlWaitTimeoutShowsTheScreen proves a failed wait is debuggable.
+func TestControlWaitTimeoutShowsTheScreen(t *testing.T) {
+	tui := startLiveTUI(t)
+	tui.call(http.MethodPost, "/resize", map[string]any{"cols": 120, "rows": 40})
+	tui.waitFor(map[string]any{"contains": "Installed"})
+
+	status, body := tui.call(http.MethodPost, "/wait",
+		map[string]any{"contains": "this text is not on any screen", "timeout_ms": 300})
+	if status != http.StatusRequestTimeout {
+		t.Fatalf("status = %d, want 408 (%v)", status, body)
+	}
+	envelope, _ := body["error"].(map[string]any)
+	screen, _ := envelope["screen"].(string)
+	if !strings.Contains(screen, "Installed") {
+		t.Errorf("the timeout did not report the real screen; got:\n%s", screen)
+	}
+}
+
+func widest(screen string) int {
+	max := 0
+	for _, line := range strings.Split(screen, "\n") {
+		if n := len([]rune(line)); n > max {
+			max = n
+		}
+	}
+	return max
+}
+
+// TestControlReportsHubReturnability covers a destructive mistake a driver
+// would otherwise make: in the hub-launched chat esc goes back, but in a
+// standalone chat esc QUITS the program. The snapshot has to say which.
+func TestControlReportsHubReturnability(t *testing.T) {
+	tui := startLiveTUI(t)
+	tui.call(http.MethodPost, "/resize", map[string]any{"cols": 120, "rows": 40})
+	tui.waitFor(map[string]any{"state": map[string]any{"view": "hub"}})
+
+	if got := tui.state()["can_return_to_hub"]; got != false {
+		t.Errorf("can_return_to_hub = %v in the hub view, want false", got)
+	}
+
+	tui.keys("enter") // launch the selected (installed) agent
+	tui.waitFor(map[string]any{"state": map[string]any{"view": "chat"}})
+
+	if got := tui.state()["can_return_to_hub"]; got != true {
+		t.Errorf("can_return_to_hub = %v in a hub-launched chat, want true — esc returns to the hub here", got)
+	}
+
+	tui.keys("esc")
+	tui.waitFor(map[string]any{"state": map[string]any{"view": "hub"}})
+}


### PR DESCRIPTION
Confirmation-gated tools — send, forward, permanent delete, RSVP, shell, file write — executed with **no prompt and no record** whenever an agent was driven from a CLI or subprocess. The base handler answered yes on the user's behalf, so the whole confirmation mechanism was inert outside the SSE path. It now denies by default and the terminal console genuinely asks.

Unattended hosts opt in with `GAIA_AUTO_APPROVE_TOOLS=1`, which deliberately **cannot** be granted by a `.env` file — a project file travelling with a directory is not an operator's decision. The SSE approval path is unchanged.

No eval scenario exercises a gated tool (grepped the suite for all nine email tools plus `run_shell_command`/`write_file` — zero hits), so this is eval-neutral.

### Test plan
- [ ] `pytest tests/unit/agents/test_console_tool_confirmation.py tests/unit/agents/test_email_agent_confirmation.py tests/unit/chat/ui/test_sse_confirmation.py` — 69 pass, 2 skip
- [ ] Drive a gated tool with stdin piped: it is denied with an actionable message, not silently run
- [ ] Same tool on a TTY: prompts, and empty input denies
- [ ] `GAIA_AUTO_APPROVE_TOOLS=1` in a `.env` is ignored and warns
