### PR TITLE
feat(tui): stream agents over the daemon HTTP/SSE relay

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -264,3 +264,5 @@ tests/unit/eval/test_mcp_tool_reliability_scenarios.py
 /.codex/
 /.cursor/
 /.claude/skills/m365-email/
+# Claudia agent worktrees (local orchestration scratch)
+.claudia-worktrees/

--- a/docs/plans/email-agent-tui-port.md
+++ b/docs/plans/email-agent-tui-port.md
@@ -283,7 +283,33 @@ table, so a "tasks" pane needs backend work.
 
 ---
 
-### Phase 6 (v2) — Agent-led connector onboarding · **file as an issue, do not build now**
+### Phase 5b — Retire `gaia email` from the legacy Python CLI
+
+Once the TUI can install, run, and configure the email agent, the `gaia email` subcommand
+is a second front door to the same sidecar with none of the UI. Remove it.
+
+**This is a decommission, not a rewrite.** Only the `email` subcommand goes. The rest of
+the legacy Python CLI stays exactly as it is — it will be retired separately, later.
+
+- Remove the `email` subparser (`src/gaia/cli.py:1772-1829`), `handle_email_command`
+  (`:5012-5095`), and `_email_interactive` (`:5098-5134`).
+- **Keep `src/gaia/daemon/agent_query.py`.** It is the generic daemon thin-client used by
+  more than email and it is the reference implementation the TUI's Go transport mirrors.
+- `--spec` needs a home before the removal lands — it is the only email surface that
+  needs no daemon and no LLM. Either move it under `gaia hub` or expose it in the TUI.
+- Delete the now-dead tests, and update `docs/reference/cli.mdx`, `docs/guides/email.mdx`,
+  and every doc that shows a `gaia email ...` invocation. The doc-sync rule in `CLAUDE.md`
+  applies: grep the old command across all of them, including the email package's own
+  `README.md` / `SPEC.md` / `SKILL.md` / `CHANGELOG.md`.
+- Print a clear pointer to the replacement rather than a bare "unknown command".
+
+**Sequencing is the whole risk here.** This must not merge until Phases 1-3 are verified
+working end to end, or we remove the only working entry point before the replacement
+exists. Prepare it early, land it last.
+
+---
+
+### Phase 6 (v2) — Agent-led connector onboarding · **filed as #2469, do not build now**
 
 Today, connecting a mailbox means the user finds Settings, obtains a Google OAuth client
 id and secret, and pastes both into a terminal. That is the worst moment in the product.

--- a/docs/plans/email-agent-tui-port.md
+++ b/docs/plans/email-agent-tui-port.md
@@ -344,6 +344,43 @@ Phases 1 and 2 are independent of each other and can run in parallel (one Go-hea
 Python-heavy). Phase 5.1 should jump the queue — it is small and it is the difference
 between "it didn't work" and "here's what to fix".
 
+## 3b. Design review outcome — amendments to this plan
+
+The user-journey design (`docs/plans/tui-user-journey.md`) reviewed this plan and pushed back
+on ten points. Accepted amendments, in order of how much they change the build:
+
+- **Preflight moves into Phase 1 as its exit test.** It was scoped here as Phase 5.1 polish
+  that "should jump the queue". That undersold it: without the readiness gate, every failure
+  of the new transport — daemon down, token rotated, version gate failed, model missing —
+  reaches the user as a raw HTTP status. Phase 1 isn't done when the stream parses; it's done
+  when a stream that *can't start* explains itself.
+- **Drop "always allow" from the approval UI.** The nine gated tools are gated precisely
+  because they're irreversible, and "this session" has no boundary a user can hold in a TUI
+  that stays open for days. Attack approval *cost* — two keystrokes, no scrolling — not
+  approval count.
+- **Replace the three-level autonomy enum with two plain controls.** `manual | assisted |
+  autonomous` is implementer vocabulary; approvals are identical across the top two levels by
+  design, so the only real axis is whether background jobs run. Ship fixed "always ask before
+  irreversible things" plus a background-work checklist. Same code, nothing to teach, and it
+  doesn't promise a goal engine that doesn't exist.
+- **No background timers inside the TUI.** The TUI is closed most of the time, so a timer in
+  it means "autonomous while you watch" — the one case where just asking is easier. Scan on
+  launch instead: simpler, and it's what produces the day-5 screen.
+- **`builtin_specs()` — filter, explicitly.** Label unrunnable catalog entries as such rather
+  than offering them as Available. Zero cost, closes the dead end. Synthesis becomes real work
+  when the second installable agent arrives.
+- **Three render primitives, not four.** `image` is base64 raster and can't render in a
+  terminal; `diff` has no producer. Build `table`, `key_value`, `list` plus the fallback.
+- **Settings screen shrinks to what persists** (accounts, memory, app-local prefs), with the
+  budget moved to the config file that makes the rest real. Filed as #2470; scheduled-jobs
+  API as #2471.
+
+Three further pre-existing bugs found on the first-run path, added to §5: the hub opens on an
+empty `Installed` tab on a fresh machine; its 26-row chrome budget overflows an 80x24
+terminal; and connection state is signalled by colour alone. Also `backspace` currently
+triggers uninstall alongside `d`/`delete` — harmless today, destructive once uninstall is
+real — and chat's `/init` prints a message and does nothing.
+
 ## 4. Open decisions
 
 - **D1** — `/query` + resume, or `/agent/query` + `confirm-tool`? Resume is the better

--- a/docs/plans/email-agent-tui-port.md
+++ b/docs/plans/email-agent-tui-port.md
@@ -89,6 +89,14 @@ Everything else depends on this. `client.AgentClient` is already transport-agnos
    accumulate `[{role, content}]` and push it as `context` each turn, appending a turn
    only when it terminated in `final` (so a failed turn doesn't poison the next).
 
+   ⚠️ **`context` must marshal to `[]`, never `null`, and this breaks on the first turn.**
+   `QueryRequest.context` is a *required* `List` (`query_routes.py:175`), and the model
+   forbids extras — `null` is a 422. A Go nil slice marshals to `null`, so the natural
+   implementation (`var ctx []ContextItem`) fails on exactly the cold-start case where there
+   is no history yet, and passes every later turn. Initialize to `make([]ContextItem, 0)`
+   and add a test asserting the serialized body contains `"context":[]` on turn one. A mock
+   that returns 200 will not catch this — assert the wire bytes.
+
 *Known sharp edges to fix while here:* `strings.Fields` command splitting breaks on paths
 with spaces; cancellation doesn't actually stop the child; unparsed events are silently
 dropped rather than surfaced.

--- a/docs/plans/email-agent-tui-port.md
+++ b/docs/plans/email-agent-tui-port.md
@@ -13,7 +13,7 @@ browser plus a chat screen. It knows how to do exactly one thing: launch a local
 executable and trade newline-delimited JSON with it over stdin/stdout
 (`tui/internal/client/subprocess.go`). Its agent list is a hardcoded Go slice
 (`tui/internal/catalog/catalog.go:179`). Email is already in that list at
-`catalog.go:230` — marked `StatusAvailable` with no binary, i.e. visible but dead.
+`catalog.go:231` — marked `StatusAvailable` with no binary, i.e. visible but dead.
 
 **The email agent** does not work that way. Since #2191 it runs as a long-lived HTTP
 service (a "sidecar") that the GAIA daemon starts, supervises, and proxies for.
@@ -139,7 +139,7 @@ for all four platforms, and the file isn't shipped in the wheel at all.
    0/1) — today `chat --query` still opens the alt-screen, which makes it useless for
    scripts and CI.
 5. **Housekeeping:** flip `interfaces.tui: false → true` in
-   `hub/agents/python/email/gaia-agent.yaml:47`. `catalog_test.go` and `smoke_test.go`
+   `hub/agents/python/email/gaia-agent.yaml:44`. `catalog_test.go` and `smoke_test.go`
    both hardcode `installed == 1` — they will fail the moment email becomes installable.
    That's the canary; update both.
 
@@ -293,8 +293,13 @@ the legacy Python CLI stays exactly as it is — it will be retired separately, 
 
 - Remove the `email` subparser (`src/gaia/cli.py:1772-1829`), `handle_email_command`
   (`:5012-5095`), and `_email_interactive` (`:5098-5134`).
-- **Keep `src/gaia/daemon/agent_query.py`.** It is the generic daemon thin-client used by
-  more than email and it is the reference implementation the TUI's Go transport mirrors.
+- **`src/gaia/daemon/agent_query.py` becomes dead code — decide deliberately.** Its
+  `run_query` / `ConsoleRenderer` have exactly two callers, both inside the email handler
+  being deleted, so removing the subcommand orphans all 346 lines. It is *not* shared
+  infrastructure. Two defensible options: keep it as the reference implementation the Go
+  transport mirrors and the thin-client the next agent will reuse (then say so in a module
+  docstring, so the next reader doesn't delete it as unused), or delete it with the
+  subcommand and let the Go client stand alone. Pick one; do not leave it unexplained.
 - `--spec` needs a home before the removal lands — it is the only email surface that
   needs no daemon and no LLM. Either move it under `gaia hub` or expose it in the TUI.
 - Delete the now-dead tests, and update `docs/reference/cli.mdx`, `docs/guides/email.mdx`,

--- a/docs/plans/email-agent-tui-port.md
+++ b/docs/plans/email-agent-tui-port.md
@@ -1,0 +1,348 @@
+# Porting the Email Agent into the TUI
+
+Status: Scoping / not started
+Owner: TBD
+Related: #1186 (TUI), #2191 (email thin client), #2142 (daemon relay), #555 (autonomy epic)
+
+---
+
+## 1. Where we are today
+
+**The TUI** (`tui/`, Go + Bubble Tea, ~4k LOC, landed whole in `aa2ca33f`) is an agent
+browser plus a chat screen. It knows how to do exactly one thing: launch a local
+executable and trade newline-delimited JSON with it over stdin/stdout
+(`tui/internal/client/subprocess.go`). Its agent list is a hardcoded Go slice
+(`tui/internal/catalog/catalog.go:179`). Email is already in that list at
+`catalog.go:230` — marked `StatusAvailable` with no binary, i.e. visible but dead.
+
+**The email agent** does not work that way. Since #2191 it runs as a long-lived HTTP
+service (a "sidecar") that the GAIA daemon starts, supervises, and proxies for.
+`gaia email` is now a thin client: it finds the daemon, asks it to ensure the sidecar
+is up, then streams Server-Sent Events through the daemon's relay
+(`src/gaia/daemon/agent_query.py:253`). Nothing about it is a subprocess the TUI can spawn.
+
+So the port is not "wire up a binary". It is "teach the TUI to be a second thin client",
+plus the install/settings/autonomy surface the user asked for.
+
+### Two landmines found during review
+
+These are the reason the design below picks the transport it picks.
+
+**(a) The subprocess path silently auto-approves destructive actions.**
+`OutputHandler.confirm_tool_execution` returns `True` unconditionally
+(`src/gaia/agents/base/console.py:219-225`), and `AgentConsole` — what the agent builds
+when driven from a CLI — never overrides it. The email agent gates nine tools behind
+confirmation (`send_draft`, `send_now`, `schedule_send`, `forward_message`,
+`permanent_delete`, `accept_invite`, `decline_invite`, `create_event_from_email`,
+`quarantine_phishing_message` — `agent.py:296`), and on that path **every one of them
+executes with no prompt and no event**. If the TUI reuses `subprocess.go`, it ships an
+email client that can send mail on the model's say-so. Non-negotiable: do not use that path.
+
+**(b) The canonical SSE endpoint cannot complete a gated action.**
+`/v1/email/query` implements the frozen seven-event contract but deliberately has no
+resume: on `needs_confirmation` it emits the event, emits a refusal, and kills the run
+(`query_routes.py:374-381`). The stateful `/v1/email/agent/query` *can* — it blocks the
+agent and waits for a separate `POST /v1/email/agent/confirm-tool` (60s timeout, denies
+on expiry, `src/gaia/ui/sse_handler.py:829-902`). Approvals therefore require either the
+stateful surface or a contract change to `/query`.
+
+**Decision (D1):** use the canonical `/v1/email/query` relay for normal turns — it is the
+frozen contract, it is what `gaia email` uses, and it keeps the TUI provider-agnostic —
+and add resume to it (Phase 3) rather than binding the TUI to the email-specific stateful
+surface. Fallback if resume slips: use `/v1/email/agent/*` for email only, behind the
+same Go interface, and swap later.
+
+---
+
+## 2. What has to be built, by phase
+
+### Phase 1 — Give the TUI an HTTP/SSE transport (foundation)
+
+Everything else depends on this. `client.AgentClient` is already transport-agnostic
+(`Send(ctx, query) (<-chan interface{}, error)`); only one line in
+`root/model.go:130` hardcodes the subprocess implementation.
+
+1. **Daemon discovery + auth in Go.** Read `~/.gaia/host/instance.json`
+   (`{pid, port, token, api_version}`, mode 0600, `GAIA_DAEMON_HOME` override). Trust it
+   only after verifying the pid is alive *and* `GET /daemon/v1/status` returns
+   `service == "gaia-daemon"` with a matching pid — a recycled port after a crash is a
+   real case (`src/gaia/daemon/instance.py:135-170`). Enforce the version gate:
+   MAJOR == 1, MINOR >= 1. **The token rotates on every daemon restart** — re-read the
+   file on any 401, never cache it for the session.
+2. **Start-or-attach.** If no live daemon: take `flock` on `~/.gaia/host/instance.lock`,
+   re-check, spawn `gaia daemon start` detached, poll for registration (30s cap).
+   Mirrors `client.py:80-158`.
+3. **SSE client** (`tui/internal/client/sse.go`) implementing `AgentClient`.
+   `POST /v1/email/query` with `Authorization: Bearer <daemon token>`,
+   `Accept: text/event-stream`, body `{query, run_id (uuid4), context, model?, max_steps?}`.
+   Parse the seven canonical events: `status | token | tool_call | tool_result |
+   needs_confirmation | final | error`. Exactly one terminal `final|error`; a stream that
+   ends without one is a failure, not a success. On cancel, `POST /v1/email/query/{run_id}/cancel`.
+   Reference implementation to mirror line-for-line: `src/gaia/daemon/agent_query.py`.
+4. **Event vocabulary.** The TUI's current 13 types (`tui/internal/event/types.go`) are
+   the *old in-process* vocabulary, not the canonical seven. Add the canonical set,
+   including `ToolResultEvent.Render string` and `Data json.RawMessage` (see Phase 5).
+   Keep the legacy types for the bash agent.
+5. **Transport discriminator on the catalog entry** (`Transport: subprocess | daemon`) and
+   a branch at `root/model.go:launchAgent`.
+6. **Host owns the transcript.** The sidecar is stateless on `/query`; the TUI must
+   accumulate `[{role, content}]` and push it as `context` each turn, appending a turn
+   only when it terminated in `final` (so a failed turn doesn't poison the next).
+
+*Known sharp edges to fix while here:* `strings.Fields` command splitting breaks on paths
+with spaces; cancellation doesn't actually stop the child; unparsed events are silently
+dropped rather than surfaced.
+
+**Size:** ~700-900 lines of Go + tests. The single biggest chunk of the port.
+
+---
+
+### Phase 2 — Install / run / uninstall
+
+**The gap:** there is no install or uninstall path anywhere except the web UI's FastAPI
+server (`src/gaia/ui/routers/hub.py:166,232`, port 4200). The daemon has no install API.
+There is no `gaia hub install` CLI. The lazy binary fetch in
+`src/gaia/daemon/sidecars/fetch.py` is **dead** — the committed
+`hub/agents/npm/agent-email/binaries.lock.json` has `PENDING-1648-replace-with-real-sha256`
+for all four platforms, and the file isn't shipped in the wheel at all.
+
+**Decision (D2):** add install/uninstall to the **daemon**, not to the TUI. Three clients
+(TUI, CLI, web UI) then share one implementation, one lock, one integrity check.
+`gaia.hub.installer` already exists and is daemon-safe.
+
+1. **New daemon routes** (`src/gaia/daemon/sidecars/routes.py`):
+   - `GET /daemon/v1/catalog` — proxy + cache `https://hub.amd-gaia.ai/index.json`
+     (public, unauthenticated, currently lists exactly one agent: email 0.5.0).
+   - `POST /daemon/v1/agents/{id}/install {version?}` → 202, plus
+     `GET .../install-status` for progress. Must stop a running sidecar first — the
+     install directory *is* the binary cache (mirror `hub.py:58-81`, which aborts with
+     500 if the pid survives).
+   - `DELETE /daemon/v1/agents/{id}` → stop, verify the pid is gone, then
+     `rmtree ~/.gaia/agents/{id}`.
+   - Reuse `installer._install_slot` so two clients can't install the same agent at once.
+2. **Wire the existing `gaia hub` CLI** to the same routes (there is no install CLI today
+   — this is a ~50-line handler and it unblocks scripted setup independently of the TUI).
+3. **TUI hub screen:** `i` = install (progress bar), `d` = uninstall (reuse the existing
+   `ConfirmModel`), `Enter` = run. Catalog comes from `/daemon/v1/catalog` instead of
+   `seedAgents()`. Installed state comes from `~/.gaia/agents/*/.installed` sentinels.
+   Show download size (the catalog carries `download_size_bytes`).
+4. **TUI CLI switches** (`tui/internal/cli/`):
+   ```
+   gaia tui                          # hub (default)
+   gaia tui run email [--query "..."]
+   gaia tui install email [--version X]
+   gaia tui uninstall email
+   gaia tui list [--installed]
+   gaia tui status
+   ```
+   `run --query` must be a genuine non-interactive one-shot (print to stdout, exit code
+   0/1) — today `chat --query` still opens the alt-screen, which makes it useless for
+   scripts and CI.
+5. **Housekeeping:** flip `interfaces.tui: false → true` in
+   `hub/agents/python/email/gaia-agent.yaml:47`. `catalog_test.go` and `smoke_test.go`
+   both hardcode `installed == 1` — they will fail the moment email becomes installable.
+   That's the canary; update both.
+
+**Blocker to resolve first:** `builtin_specs()` (`sidecars/spec.py:68`) is a static dict
+containing only `email`, with `token_env_var` / `service_id` / `expected_api_major`
+hardcoded per agent. "Install anything from the catalog and run it" needs those synthesized
+from the installed `gaia-agent.yaml`. For an email-only v1 this can be deferred, but the
+hub screen will happily install agents the daemon then refuses to start — so either
+synthesize, or filter the catalog to what `builtin_specs()` knows.
+
+**Size:** ~400 lines Python (daemon routes) + ~500 lines Go + tests.
+
+---
+
+### Phase 3 — Interactive and autonomous by default
+
+**What "autonomous" can honestly mean today.** There is no autonomy setting anywhere in
+the codebase. Grep finds only doc comments pointing at unimplemented issues.
+`docs/spec/autonomous-agent-mode.md:31-38` specifies `manual | goal_driven | autonomous`
+with autonomous as the default — 0% implemented. But the *ingredients* exist:
+
+- The job scheduler is already on by default (`config.py:148`) and fires scheduled sends
+  and snooze-restores unattended.
+- The daily briefing exists, off by default, behind three env vars, requiring a restart.
+- Reversible actions (archive, label, mark-read, trash) are **already** unconfirmed, with
+  a 30-second undo window.
+- The nine irreversible actions already prompt.
+
+**Decision (D3):** ship a three-level `autonomy` setting whose default is "autonomous",
+defined as: *run everything reversible without asking; always ask before anything
+irreversible or externally visible.* This is honest to the spec's own G9 ("no destructive
+action without live user approval regardless of mode") and needs no goal engine.
+
+| Level | Behaviour |
+|---|---|
+| `manual` | Ask before every tool that writes anything. |
+| `assisted` | Ask before irreversible actions; run reversible ones. |
+| `autonomous` (default) | Same approvals, **plus** background work on: proactive inbox scan on a timer, daily briefing on, follow-up check on a timer. |
+
+1. **Approval UI.** New canonical event handling for `needs_confirmation` → a modal built
+   on the existing `components/confirm.go`, showing action + summary, with
+   Approve / Deny / Always-allow-this-action-this-session. Blocks input, honours the 60s
+   server timeout with a visible countdown.
+2. **Resume on `/v1/email/query`** (the contract change flagged in D1): keep the run alive
+   on `needs_confirmation` and accept `POST /v1/email/query/{run_id}/confirm {approved}`.
+   This is a contract MINOR and needs the spec doc, `openapi.email.json`, `SPEC.md`,
+   `README.md`, `SKILL.md`, and `CHANGELOG.md` updated together — see the doc-sync rule in
+   CLAUDE.md. Alternative if this is too big: point the TUI at `/v1/email/agent/query` +
+   `/confirm-tool`, which already works, and migrate later.
+3. **Autonomous background work:** the briefing currently needs env vars + a sidecar
+   restart. Either make it settable at runtime, or have the TUI run its own timer against
+   the read-only, non-gated `pre_scan_inbox` and `check_followups`. The TUI-timer version
+   is materially cheaper and gets 80% of the perceived value.
+4. **Fix the auto-approve hole** (landmine (a)) regardless of which path ships — either
+   make `AgentConsole` deny-by-default when non-interactive, or make the base handler
+   refuse rather than return `True`. This is a security fix that stands on its own.
+
+**Size:** ~300 lines Go (approval UI) + ~250 Python (resume) + docs.
+
+---
+
+### Phase 4 — Settings
+
+**The gap is severe.** Of roughly 22 settings worth exposing, exactly **two** have an HTTP
+API: the memory toggle (`POST /v1/email/agent/memory`) and connectors
+(`GET/POST/DELETE /v1/email/connectors`). `EmailAgentConfig` is a plain in-memory
+dataclass — no file, no env, no persistence, constructed fresh every time. Session
+creation ignores config entirely (`agent_routes.py:272-274` passes zero kwargs).
+
+1. **A config file that does not exist yet:** `~/.gaia/agents/email/config.json`, read at
+   agent construction, with `GET/PUT /v1/email/config` to read and write it. Changes that
+   need a restart must say so in the response.
+2. **Settings screen** (`tui/internal/ui/settings/`), reachable with `s` from the hub and
+   `/settings` from chat:
+   - Autonomy level (Phase 3)
+   - Connected accounts — status, connect, disconnect (the only part with a working API today)
+   - Model + context size
+   - Memory on/off (works today)
+   - Daily briefing on/off + time
+   - Undo window, follow-up window
+   - Priority / low-priority senders (currently only reachable by asking the agent in
+     natural language)
+3. **Connector flow, v1:** `GET /v1/email/connectors` already returns
+   `{provider, connected, account_email, scopes, can_send}` per provider. Connections live
+   in a machine-global keyring shared with the web UI and `gaia connectors`, so most users
+   will already show `connected: true` and need nothing. When not connected: POST configure,
+   the sidecar opens the system browser, and the TUI shows the URL as a copy-paste fallback
+   plus a 120-second spinner. There is no device-code flow and no headless path.
+   Google also requires a client id **and** secret typed into a terminal — genuinely poor
+   UX, which is exactly why Phase 6 exists.
+
+**Size:** ~350 lines Python (config file + endpoints) + ~600 Go (settings screen).
+
+---
+
+### Phase 5 — UX wins that are cheap and land hard
+
+Ordered by value-per-hour. All of these are pure TUI work against APIs that already exist.
+
+1. **Preflight / readiness screen — the single best item in this scope.** Four calls,
+   four checkmark rows, each with a copyable fix:
+   `GET /daemon/v1/status` (daemon up) · `GET /daemon/v1/agents` (sidecar running) ·
+   `GET /v1/email/init` (Lemonade reachable, version >= 10.2.0, model downloaded, live ctx
+   size) · `GET /v1/email/connectors` (mailbox connected, agent granted).
+   `/v1/email/init` already returns a structured readiness report *with an actionable
+   `hint` string*, 200 when ready and 503 when not, same body either way. Today the user
+   discovers each of these preconditions by hitting a wall one at a time.
+2. **The inbox pre-scan card.** The agent already emits `render: "email_pre_scan"` on
+   `tool_result` (`sse_translation.py:54`) carrying urgent / actionable / suggested-archive
+   lists with sender, subject and a reason, plus pre-cap totals and which preferences were
+   applied. Crucially the tool's docstring **tells the model not to describe the results in
+   prose** because a card is expected — so a client that ignores `render` gets one terse
+   sentence and nothing else. Rendering this turns the flagship interaction from a
+   shrug into the product. Multi-mailbox scans also return `mailbox_errors[]`, which is a
+   free "this account's grant is broken" banner.
+3. **Generic render primitives.** The contract already defines `table`, `key_value`,
+   `list`, `diff` (`docs/spec/agent-ui-query-sse-contract.md:238-274`) that any agent may
+   emit. Implement the four and every future agent card renders with no TUI change.
+4. **Error remedy ladder.** `playground_html.py:358-370` already encodes cause → command →
+   hint, specific-before-generic. Port it verbatim; it covers Lemonade down, model missing,
+   no mailbox, missing grant, revoked token, ambiguous provider, version mismatch.
+5. **Briefing splash on launch** — `GET /v1/email/briefing` reuses the pre-scan renderer;
+   404 shows the enable hint. Free once #2 exists.
+6. **Model provisioning from inside the TUI** — `POST /v1/email/init` streams progress
+   lines while pulling the model; the final line's `✓`/`✗` is authoritative. Turns
+   "go run `gaia init` and come back" into a progress bar.
+7. **Triage panel** — port `renderTriage` (`playground_html.py:433-448`) 1:1: category pill,
+   spam/phishing badges, summary, action-item checklist.
+8. **Inbox table + calendar list** — `POST /v1/email/search` returns paged rows with a
+   cursor; `GET /v1/email/calendar/events` returns event rows. Both already typed.
+
+**Not free (needs a backend line each):** rich cards for follow-ups, scheduled jobs, and
+sender profiles. For any tool without a `render` entry the payload degrades to
+`{summary, success, latency_ms}` — there is nothing to draw. Adding one is two lines
+(the tool returns `{"ok", "data": {"kind": ...}}` and both copies of `_RENDER_TOOL_TO_LANG`
+gain an entry) but it is a contract MINOR. Emitting the generic `table` key costs no
+frontend work at all and is the cheapest path.
+
+**Also missing entirely:** there is no REST route for the persisted action-items/tasks
+table, so a "tasks" pane needs backend work.
+
+---
+
+### Phase 6 (v2) — Agent-led connector onboarding · **file as an issue, do not build now**
+
+Today, connecting a mailbox means the user finds Settings, obtains a Google OAuth client
+id and secret, and pastes both into a terminal. That is the worst moment in the product.
+
+The v2 target: the agent notices it has no mailbox and handles it conversationally —
+"I need access to your Gmail to do that. Want me to walk you through it?" — driving the
+flow itself, asking only for what it genuinely can't obtain, opening the browser, and
+confirming when it lands. Same pattern for a revoked token or a missing scope mid-task:
+the agent should recover in-conversation rather than returning a 403 for the user to decode.
+
+Prerequisites this needs and doesn't have: a way for the agent to request structured input
+mid-run and get an answer back (Phase 3's resume mechanism is the same primitive), a
+first-party OAuth client so users don't supply their own credentials, and probably a device-code
+flow so nothing depends on a local browser. Worth an issue; not worth blocking v1.
+
+---
+
+## 3. Order and rough size
+
+| Phase | What | Blocks | Rough size |
+|---|---|---|---|
+| 1 | HTTP/SSE transport + daemon discovery | everything | L |
+| 2 | Install / run / uninstall + CLI switches | — | L |
+| 5.1 | Preflight screen | — (do early, it's cheap) | S |
+| 5.2 | Pre-scan card + generic primitives | 1 | M |
+| 3 | Approvals + autonomy default | 1 | M |
+| 4 | Config file + settings screen | 1 | L |
+| 5.3-8 | Remaining UX polish | 1, 5.2 | M |
+| 6 | Agent-led onboarding | 3 | issue only |
+
+Phases 1 and 2 are independent of each other and can run in parallel (one Go-heavy, one
+Python-heavy). Phase 5.1 should jump the queue — it is small and it is the difference
+between "it didn't work" and "here's what to fix".
+
+## 4. Open decisions
+
+- **D1** — `/query` + resume, or `/agent/query` + `confirm-tool`? Resume is the better
+  long-term contract but is a spec change touching six documents.
+- **D2** — install in the daemon (shared by three clients) or in the TUI (faster, forks
+  the logic). Recommend the daemon.
+- **D4** — does the TUI ship inside the `amd-gaia` wheel, or as its own binary? Affects how
+  `gaia tui` is even invoked, and whether Go tests run in CI (they don't today).
+- **D5** — email-only v1, or generic-agent v1? `builtin_specs()` currently knows only email.
+
+## 5. Pre-existing bugs found during review (worth filing regardless)
+
+1. `AgentConsole` auto-approves every gated tool on the CLI path — send, forward,
+   permanent delete, RSVP (`src/gaia/agents/base/console.py:219`). **Security.**
+2. `binaries.lock.json` ships placeholder SHAs, so daemon lazy-fetch always fails; and the
+   file isn't in the wheel, so pip installs can't reach it either.
+3. `gaia email -q X -i` silently discards `-q` (`cli.py:5083`).
+4. `--trace`, `--stats`, `--stream`, `--list-tools`, `--max-steps` are parsed and ignored on
+   `gaia email`. `--use-claude` / `--use-chatgpt` are accepted and silently ignored — the
+   local-only guarantee rests on non-consumption, not rejection.
+5. `gaia email "query"` (positional) doesn't work despite the handler docstring saying it does.
+6. `--spec` with the package missing raises a raw traceback instead of a clean error.
+7. `hub/agents/python/email/gaia_agent_email/cli.py` is dead code (117 lines, no entry point,
+   no importer) and its docstring describes a dispatch path that no longer exists.
+8. `TestHubTabSwitching` / `TestHubSearch` send the three runes `t`,`a`,`b` instead of the Tab
+   key and only assert "didn't panic".
+9. `findBinaryInRepo` only looks in `cpp/build/*` for `.exe` — can never find a Python or
+   frozen agent on macOS/Linux.

--- a/tui/go.mod
+++ b/tui/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/charmbracelet/glamour v1.0.0
 	github.com/charmbracelet/lipgloss v1.1.1-0.20250404203927-76690c660834
 	github.com/spf13/cobra v1.10.2
+	golang.org/x/sys v0.38.0
 )
 
 require (
@@ -43,7 +44,6 @@ require (
 	github.com/yuin/goldmark v1.7.13 // indirect
 	github.com/yuin/goldmark-emoji v1.0.6 // indirect
 	golang.org/x/net v0.38.0 // indirect
-	golang.org/x/sys v0.38.0 // indirect
 	golang.org/x/term v0.36.0 // indirect
 	golang.org/x/text v0.30.0 // indirect
 )

--- a/tui/internal/catalog/agent.go
+++ b/tui/internal/catalog/agent.go
@@ -54,6 +54,35 @@ func (s AgentStatus) IsLaunchable() bool {
 	return s == StatusInstalled || s == StatusActive || s == StatusIdle
 }
 
+// Transport is how the TUI talks to an agent.
+//
+// The zero value is TransportSubprocess — the original stdin/stdout JSONL path,
+// which every pre-existing catalog entry uses.
+type Transport int
+
+const (
+	// TransportSubprocess spawns BinaryPath and trades newline-delimited JSON
+	// over stdin/stdout. Used by the local C++ agents.
+	TransportSubprocess Transport = iota
+
+	// TransportDaemon streams canonical SSE events through the GAIA daemon's
+	// relay (POST /v1/<id>/query). Used by the long-lived HTTP sidecar agents,
+	// which the daemon starts and supervises — there is no binary to spawn.
+	TransportDaemon
+)
+
+// String returns the wire name of the transport.
+func (t Transport) String() string {
+	switch t {
+	case TransportSubprocess:
+		return "subprocess"
+	case TransportDaemon:
+		return "daemon"
+	default:
+		return "unknown"
+	}
+}
+
 // Agent represents a GAIA agent in the catalog.
 type Agent struct {
 	ID          string
@@ -64,8 +93,9 @@ type Agent struct {
 	Icon        string // emoji
 	Version     string // semver, e.g. "0.1.0"
 	Status      AgentStatus
-	BinaryPath  string   // e.g. "gaia-bash"
-	BinaryArgs  []string // e.g. ["--json-events"]
+	Transport   Transport
+	BinaryPath  string   // e.g. "gaia-bash" (subprocess transport only)
+	BinaryArgs  []string // e.g. ["--json-events"] (subprocess transport only)
 	Votes       int      // for coming-soon agents
 }
 

--- a/tui/internal/catalog/catalog.go
+++ b/tui/internal/catalog/catalog.go
@@ -49,9 +49,10 @@ func (c *Catalog) Get(id string) *Agent {
 }
 
 // DiscoverBinaries searches for agent executables on PATH and in common build locations.
+// Daemon-transport agents are skipped — the daemon owns their lifecycle.
 func (c *Catalog) DiscoverBinaries() {
 	for i := range c.agents {
-		if c.agents[i].BinaryPath == "" {
+		if c.agents[i].Transport == TransportDaemon || c.agents[i].BinaryPath == "" {
 			continue
 		}
 		name := c.agents[i].BinaryPath
@@ -98,8 +99,12 @@ func findBinaryInRepo(name string) string {
 }
 
 // SetMockBinary overrides all installed agent binary paths with a mock binary for testing.
+// Daemon-transport agents are skipped — they have no binary to override.
 func (c *Catalog) SetMockBinary(binaryPath string) {
 	for i := range c.agents {
+		if c.agents[i].Transport == TransportDaemon {
+			continue
+		}
 		if c.agents[i].Status == StatusInstalled || c.agents[i].Status == StatusActive || c.agents[i].Status == StatusIdle {
 			c.agents[i].BinaryPath = binaryPath
 			c.agents[i].BinaryArgs = nil
@@ -228,9 +233,12 @@ func seedAgents() []Agent {
 			Icon: "📝", Version: "0.1.0", Status: StatusAvailable,
 		},
 		{
+			// The email agent is an HTTP sidecar the daemon supervises, not a
+			// binary the TUI can spawn — it is reached through the daemon relay.
 			ID: "email", Name: "Email", Description: "Email triage, drafting, and calendar",
 			Category: "Productivity", Tags: []string{"email", "gmail", "calendar", "communication"},
 			Icon: "📧", Version: "0.1.0", Status: StatusAvailable,
+			Transport: TransportDaemon,
 		},
 
 		// --- Coming Soon ---

--- a/tui/internal/catalog/catalog_test.go
+++ b/tui/internal/catalog/catalog_test.go
@@ -295,3 +295,51 @@ func TestAllSections(t *testing.T) {
 		t.Fatalf("AllSections()[2] = %q, want %q", sections[2], SectionComingSoon)
 	}
 }
+
+func TestTransportZeroValueIsSubprocess(t *testing.T) {
+	var zero Transport
+	if zero != TransportSubprocess {
+		t.Fatalf("the zero Transport must be subprocess so existing entries keep working, got %v", zero)
+	}
+	if TransportSubprocess.String() != "subprocess" || TransportDaemon.String() != "daemon" {
+		t.Errorf("unexpected transport names: %q / %q", TransportSubprocess, TransportDaemon)
+	}
+}
+
+func TestEmailUsesTheDaemonTransport(t *testing.T) {
+	c := NewCatalog()
+
+	email := c.Get("email")
+	if email == nil {
+		t.Fatal("email is missing from the catalog")
+	}
+	if email.Transport != TransportDaemon {
+		t.Errorf("email transport = %v, want daemon (it is an HTTP sidecar, not a spawnable binary)", email.Transport)
+	}
+	if email.BinaryPath != "" {
+		t.Errorf("a daemon-transport agent must carry no binary path, got %q", email.BinaryPath)
+	}
+
+	// Every other seeded agent still uses the subprocess transport.
+	for _, a := range c.All() {
+		if a.ID == "email" {
+			continue
+		}
+		if a.Transport != TransportSubprocess {
+			t.Errorf("agent %q transport = %v, want subprocess", a.ID, a.Transport)
+		}
+	}
+}
+
+func TestSetMockBinarySkipsDaemonTransport(t *testing.T) {
+	c := NewCatalog()
+	c.SetStatus("email", StatusInstalled)
+	c.SetMockBinary("/tmp/mock-agent")
+
+	if got := c.Get("email").BinaryPath; got != "" {
+		t.Errorf("a daemon-transport agent must not get a mock binary, got %q", got)
+	}
+	if got := c.Get("bash").BinaryPath; got != "/tmp/mock-agent" {
+		t.Errorf("bash binary = %q, want the mock", got)
+	}
+}

--- a/tui/internal/cli/chat.go
+++ b/tui/internal/cli/chat.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/spf13/cobra"
 
@@ -11,22 +12,46 @@ import (
 var (
 	subprocess string
 	query      string
+	agentID    string
+	chatModel  string
 )
 
 var chatCmd = &cobra.Command{
 	Use:   "chat",
 	Short: "Start interactive chat with an agent",
-	Long:  "Launch the Bubble Tea chat TUI connected to an agent via subprocess or API.",
+	Long: "Launch the chat TUI connected to an agent, either by catalog id " +
+		"(--agent, which uses the transport that agent declares) or by spawning a " +
+		"binary directly (--subprocess).",
 	RunE: func(cmd *cobra.Command, args []string) error {
+		if agentID != "" && subprocess != "" {
+			return fmt.Errorf("--agent and --subprocess are mutually exclusive: pick one")
+		}
+		if agentID != "" {
+			code, err := ui.RunAgent(agentID, query, chatModel, debug)
+			if err != nil {
+				return err
+			}
+			if code != 0 {
+				// The failure was already rendered to stderr; exit without
+				// letting cobra print a second, less useful message.
+				os.Exit(code)
+			}
+			return nil
+		}
 		if subprocess == "" {
-			return fmt.Errorf("--subprocess flag is required\n\nUsage: gaia chat --subprocess \"./gaia-bash --json-events\"")
+			return fmt.Errorf("one of --agent or --subprocess is required\n\n" +
+				"Usage: gaia tui chat --agent email\n" +
+				"       gaia tui chat --agent email --query \"triage my inbox\"\n" +
+				"       gaia tui chat --subprocess \"./gaia-bash --json-events\"")
 		}
 		return ui.RunChat(subprocess, query, debug)
 	},
 }
 
 func init() {
+	chatCmd.Flags().StringVar(&agentID, "agent", "", "catalog agent id to chat with (e.g. \"email\")")
+	chatCmd.Flags().StringVar(&chatModel, "model", "", "model id override (--agent only; the sidecar default is used when unset)")
 	chatCmd.Flags().StringVar(&subprocess, "subprocess", "", "command to spawn agent subprocess (e.g. \"./gaia-bash --json-events\")")
-	chatCmd.Flags().StringVar(&query, "query", "", "single query to send (non-interactive mode)")
+	chatCmd.Flags().StringVar(&query, "query", "", "single query to send; with --agent this is a genuine non-interactive one-shot (answer on stdout, exit 0/1)")
 	rootCmd.AddCommand(chatCmd)
 }

--- a/tui/internal/client/client.go
+++ b/tui/internal/client/client.go
@@ -5,7 +5,7 @@ import (
 )
 
 // AgentClient is the interface for communicating with an agent backend.
-// Both subprocess (JSONL) and API (SSE) modes implement this interface.
+// Both subprocess (JSONL) and daemon-relay (SSE) transports implement it.
 type AgentClient interface {
 	// Send starts a conversation turn. Events stream on the returned channel.
 	// The channel is closed when the turn is complete (answer/done/status-complete event).
@@ -13,4 +13,11 @@ type AgentClient interface {
 
 	// Close terminates the connection or process.
 	Close() error
+}
+
+// TranscriptResetter is implemented by transports that own the conversation
+// transcript host-side and push it back to a stateless agent on every turn.
+// Clearing the visible history must also clear what gets pushed.
+type TranscriptResetter interface {
+	ResetTranscript()
 }

--- a/tui/internal/client/cmdline.go
+++ b/tui/internal/client/cmdline.go
@@ -1,0 +1,79 @@
+package client
+
+import (
+	"fmt"
+	"strings"
+)
+
+// SplitCommandLine splits a user-supplied command string into argv, honouring
+// single and double quotes and backslash escapes.
+//
+// Whitespace splitting alone (strings.Fields) silently corrupts any path with a
+// space in it — "/Users/me/My Agents/gaia-bash" becomes two argv entries and the
+// launch fails with a confusing "no such file". Unbalanced quoting is an error,
+// not a guess.
+func SplitCommandLine(cmdLine string) ([]string, error) {
+	var (
+		argv    []string
+		cur     strings.Builder
+		inWord  bool
+		quote   rune // 0, '\'' or '"'
+		escaped bool
+	)
+
+	flush := func() {
+		if inWord {
+			argv = append(argv, cur.String())
+			cur.Reset()
+			inWord = false
+		}
+	}
+
+	for _, r := range cmdLine {
+		switch {
+		case escaped:
+			cur.WriteRune(r)
+			inWord = true
+			escaped = false
+		case quote == '\'':
+			// Single quotes are literal — not even a backslash escapes inside them.
+			if r == '\'' {
+				quote = 0
+			} else {
+				cur.WriteRune(r)
+			}
+		case quote == '"':
+			switch r {
+			case '"':
+				quote = 0
+			case '\\':
+				escaped = true
+			default:
+				cur.WriteRune(r)
+			}
+		case r == '\\':
+			escaped = true
+		case r == '\'' || r == '"':
+			quote = r
+			inWord = true
+		case r == ' ' || r == '\t' || r == '\n' || r == '\r':
+			flush()
+		default:
+			cur.WriteRune(r)
+			inWord = true
+		}
+	}
+
+	if escaped {
+		return nil, fmt.Errorf("command %q ends with a dangling backslash", cmdLine)
+	}
+	if quote != 0 {
+		return nil, fmt.Errorf("command %q has an unbalanced %c quote", cmdLine, quote)
+	}
+	flush()
+
+	if len(argv) == 0 {
+		return nil, fmt.Errorf("command %q contains no executable to run", cmdLine)
+	}
+	return argv, nil
+}

--- a/tui/internal/client/cmdline_test.go
+++ b/tui/internal/client/cmdline_test.go
@@ -1,0 +1,67 @@
+package client
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestSplitCommandLine(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want []string
+	}{
+		{"plain", `gaia-bash --json-events`, []string{"gaia-bash", "--json-events"}},
+		{"extra whitespace", "  gaia-bash \t --json-events  ", []string{"gaia-bash", "--json-events"}},
+		{
+			"double-quoted path with space",
+			`"/Users/me/My Agents/gaia-bash" --json-events`,
+			[]string{"/Users/me/My Agents/gaia-bash", "--json-events"},
+		},
+		{
+			"single-quoted path with space",
+			`'/Users/me/My Agents/gaia-bash' --model Gemma-4-E4B-it-GGUF`,
+			[]string{"/Users/me/My Agents/gaia-bash", "--model", "Gemma-4-E4B-it-GGUF"},
+		},
+		{
+			"escaped space",
+			`/Users/me/My\ Agents/gaia-bash`,
+			[]string{"/Users/me/My Agents/gaia-bash"},
+		},
+		{"empty quoted arg", `agent --flag ""`, []string{"agent", "--flag", ""}},
+		{"quote inside word", `agent --msg="hello world"`, []string{"agent", "--msg=hello world"}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := SplitCommandLine(tc.in)
+			if err != nil {
+				t.Fatalf("SplitCommandLine(%q): %v", tc.in, err)
+			}
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("SplitCommandLine(%q) = %#v, want %#v", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestSplitCommandLineErrors(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+	}{
+		{"empty", ""},
+		{"whitespace only", "   \t "},
+		{"unbalanced double quote", `agent "unterminated`},
+		{"unbalanced single quote", `agent 'unterminated`},
+		{"dangling backslash", `agent \`},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got, err := SplitCommandLine(tc.in); err == nil {
+				t.Fatalf("SplitCommandLine(%q) = %#v, want an error", tc.in, got)
+			}
+		})
+	}
+}

--- a/tui/internal/client/factory.go
+++ b/tui/internal/client/factory.go
@@ -1,0 +1,51 @@
+package client
+
+import (
+	"fmt"
+
+	"github.com/amd/gaia/tui/internal/catalog"
+	"github.com/amd/gaia/tui/internal/daemon"
+)
+
+// ForAgentOptions configures the transport built by ForAgent.
+type ForAgentOptions struct {
+	// Debug enables the subprocess transport's stderr diagnostics.
+	Debug bool
+	// Model / MaxSteps override the sidecar defaults on the daemon transport.
+	// Ignored by the subprocess transport, which takes its model via BinaryArgs.
+	Model    string
+	MaxSteps int
+	// Logf receives transport diagnostics. Never given a token.
+	Logf func(format string, args ...any)
+}
+
+// ForAgent builds the transport a catalog entry declares.
+//
+// This is the single transport switch: the chat UI, the hub, and the
+// non-interactive CLI paths all go through it, so adding a transport never means
+// finding every launch site. It deliberately lives here rather than on a Bubble
+// Tea model — the headless CLI paths need it without a UI.
+func ForAgent(agent catalog.Agent, opts ForAgentOptions) (AgentClient, error) {
+	switch agent.Transport {
+	case catalog.TransportDaemon:
+		return NewSSEClient(agent.ID, daemon.New(daemon.Options{Logf: opts.Logf}), SSEOptions{
+			Model:    opts.Model,
+			MaxSteps: opts.MaxSteps,
+			Logf:     opts.Logf,
+		}), nil
+
+	case catalog.TransportSubprocess:
+		if agent.BinaryPath == "" {
+			return nil, fmt.Errorf(
+				"agent %q uses the subprocess transport but no binary was found — "+
+					"build it, put it on PATH, or pass --mock <path> to run against a stub",
+				agent.ID)
+		}
+		return NewSubprocessClient(agent.BinaryPath, agent.BinaryArgs, opts.Debug), nil
+
+	default:
+		return nil, fmt.Errorf(
+			"agent %q declares transport %d, which this build does not know how to reach — "+
+				"upgrade GAIA or fix the catalog entry", agent.ID, int(agent.Transport))
+	}
+}

--- a/tui/internal/client/factory_test.go
+++ b/tui/internal/client/factory_test.go
@@ -1,0 +1,72 @@
+package client
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/amd/gaia/tui/internal/catalog"
+)
+
+func TestForAgentBuildsTheDeclaredTransport(t *testing.T) {
+	daemonAgent := catalog.Agent{ID: "email", Transport: catalog.TransportDaemon}
+	c, err := ForAgent(daemonAgent, ForAgentOptions{})
+	if err != nil {
+		t.Fatalf("ForAgent(daemon): %v", err)
+	}
+	defer c.Close()
+	if _, ok := c.(*SSEClient); !ok {
+		t.Errorf("daemon transport built %T, want *SSEClient", c)
+	}
+
+	subAgent := catalog.Agent{ID: "bash", BinaryPath: "/usr/bin/true", BinaryArgs: []string{"--json-events"}}
+	c2, err := ForAgent(subAgent, ForAgentOptions{})
+	if err != nil {
+		t.Fatalf("ForAgent(subprocess): %v", err)
+	}
+	defer c2.Close()
+	if _, ok := c2.(*SubprocessClient); !ok {
+		t.Errorf("subprocess transport built %T, want *SubprocessClient", c2)
+	}
+}
+
+// A subprocess agent whose binary was never found must fail with a remedy, not
+// produce a client that dies later with a confusing message.
+func TestForAgentRejectsAMissingBinary(t *testing.T) {
+	_, err := ForAgent(catalog.Agent{ID: "bash"}, ForAgentOptions{})
+	if err == nil {
+		t.Fatal("expected an error for a subprocess agent with no binary")
+	}
+	if !strings.Contains(err.Error(), "--mock") {
+		t.Errorf("error should name a way forward: %v", err)
+	}
+}
+
+func TestForAgentRejectsAnUnknownTransport(t *testing.T) {
+	_, err := ForAgent(catalog.Agent{ID: "future", Transport: catalog.Transport(99)}, ForAgentOptions{})
+	if err == nil {
+		t.Fatal("expected an error for an unknown transport rather than a silent default")
+	}
+	if !strings.Contains(err.Error(), "99") {
+		t.Errorf("error should name the transport it cannot reach: %v", err)
+	}
+}
+
+// Model / MaxSteps must reach the request body, not be silently dropped.
+func TestForAgentPlumbsModelAndMaxSteps(t *testing.T) {
+	c, err := ForAgent(
+		catalog.Agent{ID: "email", Transport: catalog.TransportDaemon},
+		ForAgentOptions{Model: "Gemma-4-E4B-it-GGUF", MaxSteps: 7},
+	)
+	if err != nil {
+		t.Fatalf("ForAgent: %v", err)
+	}
+	defer c.Close()
+
+	sse, ok := c.(*SSEClient)
+	if !ok {
+		t.Fatalf("got %T", c)
+	}
+	if sse.opts.Model != "Gemma-4-E4B-it-GGUF" || sse.opts.MaxSteps != 7 {
+		t.Errorf("options not plumbed: %+v", sse.opts)
+	}
+}

--- a/tui/internal/client/sse.go
+++ b/tui/internal/client/sse.go
@@ -6,6 +6,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"net/url"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -20,6 +22,8 @@ import (
 const (
 	defaultConnectTimeout = 10 * time.Second
 	defaultReadTimeout    = 300 * time.Second
+	// A cancel POST must never wait out a stream read timeout.
+	cancelTimeout = 10 * time.Second
 )
 
 // Turn is one entry of the host-owned transcript.
@@ -58,6 +62,13 @@ type SSEClient struct {
 	opts    SSEOptions
 	// stream is reused across turns: one Transport per client, not per turn.
 	stream *http.Client
+	// cancelHTTP is the short-timeout client for the cancel POST.
+	cancelHTTP *http.Client
+
+	// done is closed by Close(). It is the only way to unblock a consume()
+	// goroutine whose consumer has stopped reading and whose buffer is full —
+	// without it, Close() could not deliver the shutdown it advertises.
+	done chan struct{}
 
 	mu         sync.Mutex
 	inst       *daemon.Instance
@@ -85,10 +96,12 @@ func NewSSEClient(agentID string, dc *daemon.Client, opts SSEOptions) *SSEClient
 		opts.Logf = func(string, ...any) {}
 	}
 	return &SSEClient{
-		agentID: agentID,
-		daemon:  dc,
-		opts:    opts,
-		stream:  daemon.StreamHTTPClient(opts.ConnectTimeout),
+		agentID:    agentID,
+		daemon:     dc,
+		opts:       opts,
+		done:       make(chan struct{}),
+		stream:     daemon.StreamHTTPClient(opts.ConnectTimeout, opts.ReadTimeout),
+		cancelHTTP: &http.Client{Timeout: cancelTimeout},
 	}
 }
 
@@ -152,7 +165,7 @@ func (s *SSEClient) Send(ctx context.Context, query string) (<-chan interface{},
 
 	resp, inst, err := s.daemon.Do(runCtx, inst, daemon.Request{
 		Method: http.MethodPost,
-		Path:   fmt.Sprintf("/v1/%s/query", s.agentID),
+		Path:   fmt.Sprintf("/v1/%s/query", url.PathEscape(s.agentID)),
 		Body:   payload,
 		Header: http.Header{
 			"Content-Type": []string{"application/json"},
@@ -167,8 +180,20 @@ func (s *SSEClient) Send(ctx context.Context, query string) (<-chan interface{},
 	}
 	if resp.StatusCode != http.StatusOK {
 		detail := daemon.ErrorDetail(resp)
+		status := resp.StatusCode
 		resp.Body.Close()
 		cancel()
+		if status == http.StatusNotFound {
+			// A 404 on the query path is specifically "this route does not exist
+			// there" — most often a sidecar predating the canonical /query
+			// endpoint. Saying so beats making the user decode a bare 404.
+			return nil, fmt.Errorf(
+				"the '%s' agent has no /query endpoint (%s). Either the installed sidecar "+
+					"predates the canonical query contract — check its version with "+
+					"`gaia daemon agents` and reinstall/update the agent — or no agent with "+
+					"that id is registered with the daemon",
+				s.agentID, detail)
+		}
 		return nil, fmt.Errorf(
 			"the daemon relay refused the '%s' query (%s). Check `gaia daemon status`",
 			s.agentID, detail)
@@ -180,10 +205,17 @@ func (s *SSEClient) Send(ctx context.Context, query string) (<-chan interface{},
 	// Close() may have landed while the request was in flight; registering the
 	// handle unconditionally would leave that run un-cancellable.
 	closedMidFlight := s.closed
+	superseded := s.active
 	if !closedMidFlight {
 		s.active = handle
 	}
 	s.mu.Unlock()
+
+	// Send() is documented as serialized, but an orphaned run would keep a
+	// sidecar working with nobody listening — cancel it rather than trust the doc.
+	if superseded != nil {
+		superseded.cancel()
+	}
 
 	if closedMidFlight {
 		cancel()
@@ -229,15 +261,19 @@ func (s *SSEClient) consume(
 			return true
 		case <-ctx.Done():
 			return false
+		case <-s.done:
+			return false
 		}
 	}
 
 	reader := newSSEFrameReader(resp.Body, func() { watchdog.Reset(s.opts.ReadTimeout) })
 
 	var (
-		terminal  string
-		answer    string
-		streamed  string
+		terminal string
+		answer   string
+		// A local Builder is never copied, so it is safe here (unlike one held in
+		// a value-copied Bubble Tea model) and avoids quadratic reallocation.
+		streamed  strings.Builder
 		delivered = true
 	)
 
@@ -252,7 +288,7 @@ func (s *SSEClient) consume(
 			s.opts.Logf("sse: unparseable '%s' frame (%s) — skipped", s.agentID, malformed.Reason)
 		}
 		if tok, isToken := evt.(event.CanonicalTokenEvent); isToken {
-			streamed += tok.Delta
+			streamed.WriteString(tok.Delta)
 		}
 		if fin, isFinal := evt.(event.CanonicalFinalEvent); isFinal {
 			answer = fin.Answer
@@ -272,7 +308,7 @@ func (s *SSEClient) consume(
 			if answer == "" {
 				// The sidecar streamed the answer as tokens and closed with an
 				// empty `final` — keep the streamed text as the turn's answer.
-				answer = streamed
+				answer = streamed.String()
 			}
 			s.appendTurn(query, answer)
 		}
@@ -324,7 +360,10 @@ func (s *SSEClient) consume(
 		})
 	}
 
-	s.cancelRun(handle)
+	// Deliberately not inline: cancelRun runs before every deferred cleanup,
+	// including close(ch), so a slow or hung daemon would hold the channel open
+	// and let a superseded turn's completion land on the next turn.
+	go s.cancelRun(handle)
 }
 
 func (s *SSEClient) readTimeoutDetail() string {
@@ -334,7 +373,12 @@ func (s *SSEClient) readTimeoutDetail() string {
 		s.agentID, s.opts.ReadTimeout)
 }
 
-// cancelRun tells the relay to drop a run we are abandoning. Best-effort.
+// cancelRun asks the relay to drop a run we are abandoning.
+//
+// Best-effort: the sidecar may already be gone. It owns its own background
+// context so a cancelled caller context cannot kill the cancel itself, and it
+// lives here rather than in the daemon package because the cancel path is part
+// of the AGENT wire contract, not the daemon control plane.
 func (s *SSEClient) cancelRun(handle *runHandle) {
 	s.mu.Lock()
 	inst := s.inst
@@ -342,7 +386,35 @@ func (s *SSEClient) cancelRun(handle *runHandle) {
 	if inst == nil {
 		return
 	}
-	s.daemon.CancelRun(inst, s.agentID, handle.runID)
+
+	ctx, cancel := context.WithTimeout(context.Background(), cancelTimeout)
+	defer cancel()
+
+	resp, _, err := s.daemon.Do(ctx, inst, daemon.Request{
+		Method: http.MethodPost,
+		Path: fmt.Sprintf("/v1/%s/query/%s/cancel",
+			url.PathEscape(s.agentID), url.PathEscape(handle.runID)),
+		HTTPClient: s.cancelHTTP,
+		Op:         fmt.Sprintf("cancel the '%s' run", s.agentID),
+	})
+	if err != nil {
+		s.opts.Logf("sse: best-effort cancel for '%s' run_id=%s failed: %v",
+			s.agentID, handle.runID, err)
+		return
+	}
+	defer resp.Body.Close()
+	// 404 is the documented answer for a run that is no longer in flight — which
+	// is exactly the case when we abandon a stream that already ended. That is
+	// success, not a failure worth reporting as one.
+	if resp.StatusCode == http.StatusNotFound {
+		s.opts.Logf("sse: '%s' run_id=%s had already finished; nothing to cancel",
+			s.agentID, handle.runID)
+		return
+	}
+	if resp.StatusCode != http.StatusOK {
+		s.opts.Logf("sse: cancel for '%s' run_id=%s answered HTTP %d",
+			s.agentID, handle.runID, resp.StatusCode)
+	}
 }
 
 func (s *SSEClient) clearActive(handle *runHandle) {
@@ -381,11 +453,15 @@ func (s *SSEClient) ResetTranscript() {
 // Close cancels any in-flight run and refuses further sends.
 func (s *SSEClient) Close() error {
 	s.mu.Lock()
+	alreadyClosed := s.closed
 	s.closed = true
 	active := s.active
 	s.active = nil
 	s.mu.Unlock()
 
+	if !alreadyClosed {
+		close(s.done)
+	}
 	if active != nil {
 		active.cancel()
 	}

--- a/tui/internal/client/sse.go
+++ b/tui/internal/client/sse.go
@@ -177,8 +177,20 @@ func (s *SSEClient) Send(ctx context.Context, query string) (<-chan interface{},
 	handle := &runHandle{runID: runID, cancel: cancel}
 	s.mu.Lock()
 	s.inst = inst
-	s.active = handle
+	// Close() may have landed while the request was in flight; registering the
+	// handle unconditionally would leave that run un-cancellable.
+	closedMidFlight := s.closed
+	if !closedMidFlight {
+		s.active = handle
+	}
 	s.mu.Unlock()
+
+	if closedMidFlight {
+		cancel()
+		resp.Body.Close()
+		return nil, fmt.Errorf(
+			"the %s agent connection was closed while the query was being sent", s.agentID)
+	}
 
 	ch := make(chan interface{}, 32)
 	go s.consume(ctx, runCtx, handle, resp, ch, query)

--- a/tui/internal/client/sse.go
+++ b/tui/internal/client/sse.go
@@ -1,0 +1,400 @@
+package client
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/amd/gaia/tui/internal/daemon"
+	"github.com/amd/gaia/tui/internal/event"
+)
+
+// Timeouts mirror src/gaia/daemon/agent_query.py: connect fast (a dead daemon
+// should fail quickly), read generously — a single upstream chunk can span a
+// whole agent-loop step.
+const (
+	defaultConnectTimeout = 10 * time.Second
+	defaultReadTimeout    = 300 * time.Second
+)
+
+// Turn is one entry of the host-owned transcript.
+//
+// The sidecar is stateless on /query (contract §2.4), so the TUI accumulates the
+// transcript and pushes the slice as `context` on every turn. A turn is appended
+// only when it terminated in `final`, so a failed run cannot poison the next one.
+type Turn struct {
+	Role    string `json:"role"`
+	Content string `json:"content"`
+}
+
+// SSEOptions configures an SSEClient. The zero value is valid.
+type SSEOptions struct {
+	// Model overrides the sidecar's default model id. Empty means "sidecar default".
+	Model string
+	// MaxSteps overrides the agent-loop step ceiling. Zero means "sidecar default".
+	MaxSteps int
+	// ConnectTimeout / ReadTimeout default to 10s / 300s. ReadTimeout is an
+	// idle timeout: it fires only if no byte of the stream arrives within it.
+	ConnectTimeout time.Duration
+	ReadTimeout    time.Duration
+	// Logf receives progress and best-effort-failure notes. Never given a token.
+	Logf func(format string, args ...any)
+}
+
+// SSEClient drives one agent through the GAIA daemon's relay: it ensures the
+// daemon and the agent's sidecar are up, POSTs /v1/<agent>/query, and streams the
+// canonical SSE events (contract §4) onto the AgentClient channel.
+//
+// It holds only the DAEMON client token — never the sidecar's bearer, which stays
+// server-side. Send() calls must be serialized, matching the AgentClient contract.
+type SSEClient struct {
+	agentID string
+	daemon  *daemon.Client
+	opts    SSEOptions
+	// stream is reused across turns: one Transport per client, not per turn.
+	stream *http.Client
+
+	mu         sync.Mutex
+	inst       *daemon.Instance
+	transcript []Turn
+	closed     bool
+	active     *runHandle
+}
+
+// runHandle is the cancel side of the currently streaming run.
+type runHandle struct {
+	runID  string
+	cancel context.CancelFunc
+}
+
+// NewSSEClient builds a daemon-transport client for agentID (the path segment in
+// /v1/<agent>/query, e.g. "email").
+func NewSSEClient(agentID string, dc *daemon.Client, opts SSEOptions) *SSEClient {
+	if opts.ConnectTimeout <= 0 {
+		opts.ConnectTimeout = defaultConnectTimeout
+	}
+	if opts.ReadTimeout <= 0 {
+		opts.ReadTimeout = defaultReadTimeout
+	}
+	if opts.Logf == nil {
+		opts.Logf = func(string, ...any) {}
+	}
+	return &SSEClient{
+		agentID: agentID,
+		daemon:  dc,
+		opts:    opts,
+		stream:  daemon.StreamHTTPClient(opts.ConnectTimeout),
+	}
+}
+
+type queryRequest struct {
+	Query    string `json:"query"`
+	RunID    string `json:"run_id"`
+	Context  []Turn `json:"context"`
+	Model    string `json:"model,omitempty"`
+	MaxSteps int    `json:"max_steps,omitempty"`
+}
+
+// Send starts one turn. The returned channel carries the canonical event types
+// from the event package and is closed when the turn ends.
+//
+// Every turn ends with exactly one terminal event: the wire's `final` / `error`,
+// or — if the stream ended without one — a synthesized CanonicalErrorEvent. A
+// stream that stops early is a failure, never a quiet success.
+func (s *SSEClient) Send(ctx context.Context, query string) (<-chan interface{}, error) {
+	s.mu.Lock()
+	closed := s.closed
+	s.mu.Unlock()
+	if closed {
+		return nil, fmt.Errorf("the %s agent connection is closed; relaunch the agent from the hub", s.agentID)
+	}
+
+	runID, err := newRunID()
+	if err != nil {
+		return nil, err
+	}
+
+	// Blocking: daemon start-or-attach, sidecar spawn, and a possible first-run
+	// binary fetch all happen here. Loud on failure — no in-process fallback.
+	inst, err := s.daemon.EnsureAgent(ctx, s.agentID)
+	if err != nil {
+		return nil, err
+	}
+
+	s.mu.Lock()
+	s.inst = inst
+	// Non-nil even when empty: `context` is a REQUIRED array in the request
+	// schema, and a nil slice would marshal to `null` and fail validation.
+	history := make([]Turn, 0, len(s.transcript))
+	history = append(history, s.transcript...)
+	s.mu.Unlock()
+
+	payload, err := json.Marshal(queryRequest{
+		Query:    query,
+		RunID:    runID,
+		Context:  history,
+		Model:    s.opts.Model,
+		MaxSteps: s.opts.MaxSteps,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("could not encode the '%s' query request: %w", s.agentID, err)
+	}
+
+	// runCtx is cancelled by Close() and by the read-idle watchdog. It derives
+	// from ctx so the caller's own cancel (Esc) still aborts the stream, while
+	// events can still be delivered on ctx after runCtx is gone.
+	runCtx, cancel := context.WithCancel(ctx)
+
+	resp, inst, err := s.daemon.Do(runCtx, inst, daemon.Request{
+		Method: http.MethodPost,
+		Path:   fmt.Sprintf("/v1/%s/query", s.agentID),
+		Body:   payload,
+		Header: http.Header{
+			"Content-Type": []string{"application/json"},
+			"Accept":       []string{"text/event-stream"},
+		},
+		HTTPClient: s.stream,
+		Op:         fmt.Sprintf("stream the '%s' query through the daemon relay", s.agentID),
+	})
+	if err != nil {
+		cancel()
+		return nil, err
+	}
+	if resp.StatusCode != http.StatusOK {
+		detail := daemon.ErrorDetail(resp)
+		resp.Body.Close()
+		cancel()
+		return nil, fmt.Errorf(
+			"the daemon relay refused the '%s' query (%s). Check `gaia daemon status`",
+			s.agentID, detail)
+	}
+
+	handle := &runHandle{runID: runID, cancel: cancel}
+	s.mu.Lock()
+	s.inst = inst
+	s.active = handle
+	s.mu.Unlock()
+
+	ch := make(chan interface{}, 32)
+	go s.consume(ctx, runCtx, handle, resp, ch, query)
+	return ch, nil
+}
+
+// consume reads the SSE response and enforces the terminal-event contract.
+func (s *SSEClient) consume(
+	ctx context.Context,
+	runCtx context.Context,
+	handle *runHandle,
+	resp *http.Response,
+	ch chan interface{},
+	query string,
+) {
+	defer close(ch)
+	defer resp.Body.Close()
+	defer handle.cancel()
+	defer s.clearActive(handle)
+
+	// Read-idle watchdog: mirrors agent_query.py's read timeout. Any traffic —
+	// including a heartbeat comment — resets it; if it fires, the request is
+	// cancelled and the run surfaces an error rather than hanging forever.
+	var timedOut atomic.Bool
+	watchdog := time.AfterFunc(s.opts.ReadTimeout, func() {
+		timedOut.Store(true)
+		handle.cancel()
+	})
+	defer watchdog.Stop()
+
+	// emit selects on the CALLER's context, not the run context, so a watchdog or
+	// Close() cancellation can still deliver its terminal error.
+	emit := func(evt interface{}) bool {
+		select {
+		case ch <- evt:
+			return true
+		case <-ctx.Done():
+			return false
+		}
+	}
+
+	reader := newSSEFrameReader(resp.Body, func() { watchdog.Reset(s.opts.ReadTimeout) })
+
+	var (
+		terminal  string
+		answer    string
+		streamed  string
+		delivered = true
+	)
+
+	for {
+		payload, ok := reader.Next()
+		if !ok {
+			break
+		}
+		evt := event.ParseCanonicalEvent(payload)
+		if malformed, bad := evt.(event.CanonicalMalformedEvent); bad {
+			// Visible, but never fatal: one broken frame must not kill the run.
+			s.opts.Logf("sse: unparseable '%s' frame (%s) — skipped", s.agentID, malformed.Reason)
+		}
+		if tok, isToken := evt.(event.CanonicalTokenEvent); isToken {
+			streamed += tok.Delta
+		}
+		if fin, isFinal := evt.(event.CanonicalFinalEvent); isFinal {
+			answer = fin.Answer
+		}
+		if !emit(evt) {
+			delivered = false
+			break
+		}
+		if t := event.CanonicalTerminalType(evt); t != "" {
+			terminal = t
+			break
+		}
+	}
+
+	if terminal != "" {
+		if terminal == event.CanonicalTypeFinal {
+			if answer == "" {
+				// The sidecar streamed the answer as tokens and closed with an
+				// empty `final` — keep the streamed text as the turn's answer.
+				answer = streamed
+			}
+			s.appendTurn(query, answer)
+		}
+		return
+	}
+
+	// No terminal event: report first (the user should not wait on a network
+	// round-trip to learn the turn failed), then ask the relay to drop the run —
+	// it may still be live inside the sidecar.
+	switch {
+	case timedOut.Load():
+		emit(event.CanonicalErrorEvent{
+			Type:   event.CanonicalTypeError,
+			Detail: s.readTimeoutDetail(),
+			Status: http.StatusGatewayTimeout,
+			Source: "tui",
+		})
+	case ctx.Err() != nil || !delivered:
+		// The user cancelled the turn (Esc / hub exit) — the UI already says so.
+		s.opts.Logf("sse: '%s' run %s cancelled by the caller", s.agentID, handle.runID)
+	case runCtx.Err() != nil:
+		// Close() cancelled the run without the caller's context ending.
+		emit(event.CanonicalErrorEvent{
+			Type:   event.CanonicalTypeError,
+			Detail: fmt.Sprintf("the '%s' agent connection was closed mid-run", s.agentID),
+			Status: http.StatusServiceUnavailable,
+			Source: "tui",
+		})
+	case reader.Err() != nil:
+		emit(event.CanonicalErrorEvent{
+			Type: event.CanonicalTypeError,
+			Detail: fmt.Sprintf(
+				"the '%s' query stream failed mid-run: %v. Check `gaia daemon status`",
+				s.agentID, reader.Err()),
+			Status: http.StatusBadGateway,
+			Source: "tui",
+		})
+	default:
+		// The contract mandates exactly one terminal event; a clean EOF without
+		// one is a failure, surfaced loudly rather than as an empty answer.
+		emit(event.CanonicalErrorEvent{
+			Type: event.CanonicalTypeError,
+			Detail: fmt.Sprintf(
+				"the '%s' query stream ended without a terminal final/error event — "+
+					"the sidecar may have crashed mid-run. Check `gaia daemon status`",
+				s.agentID),
+			Status: http.StatusBadGateway,
+			Source: "tui",
+		})
+	}
+
+	s.cancelRun(handle)
+}
+
+func (s *SSEClient) readTimeoutDetail() string {
+	return fmt.Sprintf(
+		"the '%s' query stream sent nothing for %s and was abandoned. "+
+			"The sidecar may be stuck loading a model — check `gaia daemon status`",
+		s.agentID, s.opts.ReadTimeout)
+}
+
+// cancelRun tells the relay to drop a run we are abandoning. Best-effort.
+func (s *SSEClient) cancelRun(handle *runHandle) {
+	s.mu.Lock()
+	inst := s.inst
+	s.mu.Unlock()
+	if inst == nil {
+		return
+	}
+	s.daemon.CancelRun(inst, s.agentID, handle.runID)
+}
+
+func (s *SSEClient) clearActive(handle *runHandle) {
+	s.mu.Lock()
+	if s.active == handle {
+		s.active = nil
+	}
+	s.mu.Unlock()
+}
+
+func (s *SSEClient) appendTurn(query, answer string) {
+	s.mu.Lock()
+	s.transcript = append(s.transcript,
+		Turn{Role: "user", Content: query},
+		Turn{Role: "assistant", Content: answer},
+	)
+	s.mu.Unlock()
+}
+
+// Transcript returns a copy of the host-owned transcript pushed as `context`.
+func (s *SSEClient) Transcript() []Turn {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([]Turn(nil), s.transcript...)
+}
+
+// ResetTranscript drops the accumulated context, so the next turn starts fresh.
+// Wired to the chat screen's /clear, which would otherwise clear the visible
+// history while still pushing it as `context`.
+func (s *SSEClient) ResetTranscript() {
+	s.mu.Lock()
+	s.transcript = nil
+	s.mu.Unlock()
+}
+
+// Close cancels any in-flight run and refuses further sends.
+func (s *SSEClient) Close() error {
+	s.mu.Lock()
+	s.closed = true
+	active := s.active
+	s.active = nil
+	s.mu.Unlock()
+
+	if active != nil {
+		active.cancel()
+	}
+	return nil
+}
+
+// newRunID mints the host-side run handle (contract §2.3): the client knows it
+// before the request is sent, so a run is cancellable from that instant.
+func newRunID() (string, error) {
+	var b [16]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		return "", fmt.Errorf("could not mint a run id: %w", err)
+	}
+	b[6] = (b[6] & 0x0f) | 0x40 // version 4
+	b[8] = (b[8] & 0x3f) | 0x80 // RFC 4122 variant
+	return fmt.Sprintf("%x-%x-%x-%x-%x", b[0:4], b[4:6], b[6:8], b[8:10], b[10:16]), nil
+}
+
+// Compile-time proof the daemon transport satisfies the same interface as the
+// subprocess one.
+var (
+	_ AgentClient        = (*SSEClient)(nil)
+	_ TranscriptResetter = (*SSEClient)(nil)
+)

--- a/tui/internal/client/sse_frame.go
+++ b/tui/internal/client/sse_frame.go
@@ -49,8 +49,10 @@ func (r *sseFrameReader) Next() (payload []byte, ok bool) {
 		if strings.HasPrefix(line, ":") {
 			continue
 		}
-		field, value, found := strings.Cut(line, ":")
-		if !found || field != "data" {
+		// A field line with no colon carries an empty value, per the SSE spec
+		// (and matching the reference implementation's str.partition).
+		field, value, _ := strings.Cut(line, ":")
+		if field != "data" {
 			continue
 		}
 		r.data = append(r.data, strings.TrimPrefix(value, " "))

--- a/tui/internal/client/sse_frame.go
+++ b/tui/internal/client/sse_frame.go
@@ -1,0 +1,74 @@
+package client
+
+import (
+	"bufio"
+	"io"
+	"strings"
+)
+
+// maxFrameBytes caps one SSE line. A tool_result payload can be large (search
+// hits, an inbox pre-scan), so the ceiling is generous; beyond it the scanner
+// errors instead of silently truncating the JSON into something unparseable.
+const maxFrameBytes = 4 << 20
+
+// sseFrameReader turns an SSE byte stream into JSON payloads.
+//
+// Framing rules (contract §3, mirroring _iter_sse_events in
+// src/gaia/daemon/agent_query.py):
+//   - `data:` field lines accumulate until a blank line, then join with "\n".
+//   - `:`-prefixed lines are comments/heartbeats and are skipped.
+//   - other SSE fields (`event:`, `id:`, `retry:`) are framing, not payload.
+//   - a trailing frame with no terminating blank line is still flushed at EOF.
+type sseFrameReader struct {
+	sc   *bufio.Scanner
+	data []string
+	// onLine fires after every physical line, so a caller can reset a read-idle
+	// watchdog on any traffic — including heartbeats.
+	onLine func()
+}
+
+func newSSEFrameReader(r io.Reader, onLine func()) *sseFrameReader {
+	sc := bufio.NewScanner(r)
+	sc.Buffer(make([]byte, 0, 64*1024), maxFrameBytes)
+	return &sseFrameReader{sc: sc, onLine: onLine}
+}
+
+// Next returns the next complete frame payload. ok is false once the stream ends.
+func (r *sseFrameReader) Next() (payload []byte, ok bool) {
+	for r.sc.Scan() {
+		if r.onLine != nil {
+			r.onLine()
+		}
+		line := r.sc.Text()
+		if line == "" {
+			if p, flushed := r.flush(); flushed {
+				return p, true
+			}
+			continue
+		}
+		if strings.HasPrefix(line, ":") {
+			continue
+		}
+		field, value, found := strings.Cut(line, ":")
+		if !found || field != "data" {
+			continue
+		}
+		r.data = append(r.data, strings.TrimPrefix(value, " "))
+	}
+	return r.flush()
+}
+
+// Err reports a read failure (including a line above maxFrameBytes). nil at a
+// clean EOF.
+func (r *sseFrameReader) Err() error {
+	return r.sc.Err()
+}
+
+func (r *sseFrameReader) flush() ([]byte, bool) {
+	if len(r.data) == 0 {
+		return nil, false
+	}
+	payload := strings.Join(r.data, "\n")
+	r.data = r.data[:0]
+	return []byte(payload), true
+}

--- a/tui/internal/client/sse_test.go
+++ b/tui/internal/client/sse_test.go
@@ -1,0 +1,765 @@
+package client
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/amd/gaia/tui/internal/daemon"
+	"github.com/amd/gaia/tui/internal/event"
+)
+
+// sidecarBearer stands in for the sidecar token the daemon's /ensure response
+// carries. The TUI must never present it on any request.
+const sidecarBearer = "SIDECAR-BEARER-MUST-NOT-LEAK"
+
+// fakeRelay is an httptest server standing in for the GAIA daemon: the status
+// probe, the sidecar ensure, and the /v1/<agent>/query SSE relay.
+type fakeRelay struct {
+	t   *testing.T
+	srv *httptest.Server
+	dir string
+
+	// stream writes the SSE body for one run. Set per test.
+	stream func(w http.ResponseWriter, flush func(), body queryRequest)
+	// queryStatus, when non-zero, is returned instead of a stream.
+	queryStatus int
+	// onEnsure runs after a successful ensure — used to simulate a daemon
+	// restart (and therefore a token rotation) mid-Send.
+	onEnsure func()
+
+	mu        sync.Mutex
+	token     string
+	queries   []queryRequest
+	rawBodies []string
+	cancelled []string
+	auths     []string
+}
+
+func newFakeRelay(t *testing.T) *fakeRelay {
+	t.Helper()
+
+	dir := t.TempDir()
+	t.Setenv(daemon.EnvHome, dir)
+
+	f := &fakeRelay{t: t, dir: dir, token: "token-A"}
+	f.srv = httptest.NewServer(http.HandlerFunc(f.handle))
+	t.Cleanup(f.srv.Close)
+
+	if f.port() == daemon.ReservedPort {
+		t.Fatalf("test server bound the reserved port %d", daemon.ReservedPort)
+	}
+	f.writeInstance("token-A")
+	return f
+}
+
+func (f *fakeRelay) port() int {
+	u, err := url.Parse(f.srv.URL)
+	if err != nil {
+		f.t.Fatalf("parse server URL: %v", err)
+	}
+	p, err := strconv.Atoi(u.Port())
+	if err != nil {
+		f.t.Fatalf("parse port: %v", err)
+	}
+	return p
+}
+
+func (f *fakeRelay) writeInstance(token string) {
+	f.t.Helper()
+	payload := map[string]any{
+		"pid": os.Getpid(), "port": f.port(), "token": token,
+		"host": "127.0.0.1", "api_version": "1.1", "service": "gaia-daemon",
+		"started_at": 1.0,
+	}
+	raw, err := json.Marshal(payload)
+	if err != nil {
+		f.t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(f.dir, "instance.json"), raw, 0o600); err != nil {
+		f.t.Fatal(err)
+	}
+}
+
+func (f *fakeRelay) rotateToken(next string) {
+	f.mu.Lock()
+	f.token = next
+	f.mu.Unlock()
+	f.writeInstance(next)
+}
+
+func (f *fakeRelay) handle(w http.ResponseWriter, r *http.Request) {
+	f.mu.Lock()
+	token := f.token
+	f.auths = append(f.auths, r.Header.Get("Authorization"))
+	f.mu.Unlock()
+
+	if r.Header.Get("Authorization") != "Bearer "+token {
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte(`{"detail":"invalid or expired client token"}`))
+		return
+	}
+
+	switch {
+	case r.URL.Path == "/daemon/v1/status":
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprintf(w, `{"service":"gaia-daemon","pid":%d}`, os.Getpid())
+
+	case strings.HasSuffix(r.URL.Path, "/ensure"):
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprintf(w, `{"port":51999,"token":%q,"state":"running"}`, sidecarBearer)
+		if f.onEnsure != nil {
+			f.onEnsure()
+		}
+
+	case strings.HasSuffix(r.URL.Path, "/cancel"):
+		parts := strings.Split(r.URL.Path, "/")
+		f.mu.Lock()
+		f.cancelled = append(f.cancelled, parts[len(parts)-2])
+		f.mu.Unlock()
+		w.WriteHeader(http.StatusOK)
+
+	case strings.HasSuffix(r.URL.Path, "/query"):
+		var body queryRequest
+		raw, _ := io.ReadAll(r.Body)
+		if err := json.Unmarshal(raw, &body); err != nil {
+			f.t.Errorf("query body is not valid JSON: %v (%s)", err, raw)
+		}
+		f.mu.Lock()
+		f.queries = append(f.queries, body)
+		f.rawBodies = append(f.rawBodies, string(raw))
+		f.mu.Unlock()
+
+		if f.queryStatus != 0 {
+			w.WriteHeader(f.queryStatus)
+			_, _ = w.Write([]byte(`{"detail":"the email sidecar is not running"}`))
+			return
+		}
+		if accept := r.Header.Get("Accept"); accept != "text/event-stream" {
+			f.t.Errorf("Accept = %q, want text/event-stream", accept)
+		}
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		flusher, ok := w.(http.Flusher)
+		if !ok {
+			f.t.Fatal("test server response writer is not a Flusher")
+		}
+		f.stream(w, flusher.Flush, body)
+
+	default:
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(`{"detail":"no route"}`))
+	}
+}
+
+func (f *fakeRelay) lastQuery() queryRequest {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if len(f.queries) == 0 {
+		f.t.Fatal("no query was received")
+	}
+	return f.queries[len(f.queries)-1]
+}
+
+func (f *fakeRelay) client(t *testing.T) *SSEClient {
+	t.Helper()
+	dc := daemon.New(daemon.Options{
+		ProbeTimeout:  2 * time.Second,
+		EnsureTimeout: 5 * time.Second,
+		StartCommand: func(context.Context) (*exec.Cmd, error) {
+			return nil, fmt.Errorf("the test daemon must already be attachable")
+		},
+		Logf: func(format string, args ...any) { t.Logf(format, args...) },
+	})
+	return NewSSEClient("email", dc, SSEOptions{
+		ReadTimeout: 5 * time.Second,
+		Logf:        func(format string, args ...any) { t.Logf(format, args...) },
+	})
+}
+
+// frame writes one canonical SSE event.
+func frame(w io.Writer, payload string) {
+	fmt.Fprintf(w, "data: %s\n\n", payload)
+}
+
+// collect drains a turn's channel.
+func collect(t *testing.T, ch <-chan interface{}) []interface{} {
+	t.Helper()
+	var got []interface{}
+	timeout := time.After(15 * time.Second)
+	for {
+		select {
+		case evt, ok := <-ch:
+			if !ok {
+				return got
+			}
+			got = append(got, evt)
+		case <-timeout:
+			t.Fatalf("timed out draining the event channel after %d events", len(got))
+		}
+	}
+}
+
+func typeNames(events []interface{}) []string {
+	names := make([]string, 0, len(events))
+	for _, e := range events {
+		names = append(names, fmt.Sprintf("%T", e))
+	}
+	return names
+}
+
+// --- happy path -------------------------------------------------------------
+
+func TestSSEClientFullRun(t *testing.T) {
+	f := newFakeRelay(t)
+	f.stream = func(w http.ResponseWriter, flush func(), _ queryRequest) {
+		frame(w, `{"type":"status","message":"Scanning inbox"}`)
+		frame(w, `{"type":"tool_call","tool":"pre_scan_inbox","args":{"max":50}}`)
+		frame(w, `{"type":"tool_result","tool":"pre_scan_inbox","render":"email_pre_scan","data":{"urgent":[]}}`)
+		frame(w, `{"type":"token","delta":"You have "}`)
+		frame(w, `{"type":"token","delta":"3 urgent emails."}`)
+		frame(w, `{"type":"final","answer":"You have 3 urgent emails.","usage":{"steps":2,"tools_used":1}}`)
+		flush()
+	}
+
+	c := f.client(t)
+	defer c.Close()
+
+	ch, err := c.Send(context.Background(), "triage my inbox")
+	if err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+	got := collect(t, ch)
+
+	want := []string{
+		"event.CanonicalStatusEvent",
+		"event.CanonicalToolCallEvent",
+		"event.CanonicalToolResultEvent",
+		"event.CanonicalTokenEvent",
+		"event.CanonicalTokenEvent",
+		"event.CanonicalFinalEvent",
+	}
+	if names := typeNames(got); !equalStrings(names, want) {
+		t.Fatalf("event sequence = %v, want %v", names, want)
+	}
+
+	tr := got[2].(event.CanonicalToolResultEvent)
+	if tr.Render != "email_pre_scan" {
+		t.Errorf("render hint lost: %+v", tr)
+	}
+	if !strings.Contains(string(tr.Data), "urgent") {
+		t.Errorf("render data lost: %s", tr.Data)
+	}
+
+	fin := got[5].(event.CanonicalFinalEvent)
+	if fin.Answer != "You have 3 urgent emails." {
+		t.Errorf("answer = %q", fin.Answer)
+	}
+	if u := event.CanonicalUsageOf(fin); u.Steps != 2 || u.ToolsUsed != 1 {
+		t.Errorf("usage = %+v", u)
+	}
+
+	// The request must carry a v4 run_id and an (empty) context array.
+	q := f.lastQuery()
+	if len(q.RunID) != 36 {
+		t.Errorf("run_id %q is not a uuid4", q.RunID)
+	}
+	if q.RunID[14] != '4' {
+		t.Errorf("run_id %q is not version 4", q.RunID)
+	}
+	if len(q.Context) != 0 {
+		t.Errorf("first turn must push an empty context, got %+v", q.Context)
+	}
+	if q.Query != "triage my inbox" {
+		t.Errorf("query = %q", q.Query)
+	}
+
+	// `context` is a REQUIRED array: an empty transcript must serialize as [],
+	// never null, or the sidecar rejects the body.
+	f.mu.Lock()
+	rawBody := f.rawBodies[len(f.rawBodies)-1]
+	f.mu.Unlock()
+	if !strings.Contains(rawBody, `"context":[]`) {
+		t.Errorf("first turn body must carry an empty context array, got %s", rawBody)
+	}
+}
+
+// The host owns the transcript and pushes it back on every turn.
+func TestSSEClientPushesHostOwnedTranscript(t *testing.T) {
+	f := newFakeRelay(t)
+	f.stream = func(w http.ResponseWriter, flush func(), body queryRequest) {
+		frame(w, fmt.Sprintf(`{"type":"final","answer":"reply to %s"}`, body.Query))
+		flush()
+	}
+
+	c := f.client(t)
+	defer c.Close()
+
+	for _, q := range []string{"first", "second"} {
+		ch, err := c.Send(context.Background(), q)
+		if err != nil {
+			t.Fatalf("Send(%q): %v", q, err)
+		}
+		collect(t, ch)
+	}
+
+	q := f.lastQuery()
+	if len(q.Context) != 2 {
+		t.Fatalf("second turn context = %+v, want 2 entries", q.Context)
+	}
+	if q.Context[0].Role != "user" || q.Context[0].Content != "first" {
+		t.Errorf("context[0] = %+v", q.Context[0])
+	}
+	if q.Context[1].Role != "assistant" || !strings.Contains(q.Context[1].Content, "first") {
+		t.Errorf("context[1] = %+v", q.Context[1])
+	}
+
+	if got := c.Transcript(); len(got) != 4 {
+		t.Errorf("transcript = %+v, want 4 entries after two turns", got)
+	}
+	c.ResetTranscript()
+	if got := c.Transcript(); len(got) != 0 {
+		t.Errorf("ResetTranscript left %+v", got)
+	}
+}
+
+// A `final` with an empty answer after streamed tokens keeps the streamed text.
+func TestSSEClientTranscriptFallsBackToStreamedTokens(t *testing.T) {
+	f := newFakeRelay(t)
+	f.stream = func(w http.ResponseWriter, flush func(), _ queryRequest) {
+		frame(w, `{"type":"token","delta":"streamed "}`)
+		frame(w, `{"type":"token","delta":"answer"}`)
+		frame(w, `{"type":"final","answer":""}`)
+		flush()
+	}
+
+	c := f.client(t)
+	defer c.Close()
+
+	ch, err := c.Send(context.Background(), "hello")
+	if err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+	collect(t, ch)
+
+	tr := c.Transcript()
+	if len(tr) != 2 || tr[1].Content != "streamed answer" {
+		t.Fatalf("transcript = %+v", tr)
+	}
+}
+
+// --- terminal-event contract -------------------------------------------------
+
+// A stream that ends without final/error is a FAILURE, not an empty success.
+func TestSSEClientStreamWithoutTerminalEventIsAnError(t *testing.T) {
+	f := newFakeRelay(t)
+	f.stream = func(w http.ResponseWriter, flush func(), _ queryRequest) {
+		frame(w, `{"type":"status","message":"working"}`)
+		frame(w, `{"type":"token","delta":"half an ans"}`)
+		flush()
+		// …and the sidecar dies: the stream just ends.
+	}
+
+	c := f.client(t)
+	defer c.Close()
+
+	ch, err := c.Send(context.Background(), "triage")
+	if err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+	got := collect(t, ch)
+
+	if len(got) == 0 {
+		t.Fatal("expected events")
+	}
+	last, ok := got[len(got)-1].(event.CanonicalErrorEvent)
+	if !ok {
+		t.Fatalf("last event = %T, want a synthesized CanonicalErrorEvent (%v)", got[len(got)-1], typeNames(got))
+	}
+	if !strings.Contains(last.Detail, "without a terminal") {
+		t.Errorf("detail must explain the missing terminal event: %q", last.Detail)
+	}
+	if !strings.Contains(last.Detail, "gaia daemon status") {
+		t.Errorf("detail must be actionable: %q", last.Detail)
+	}
+	if last.Source != "tui" {
+		t.Errorf("synthesized errors must be attributed to the tui, got %q", last.Source)
+	}
+	// A failed turn must not poison the next one's context.
+	if tr := c.Transcript(); len(tr) != 0 {
+		t.Errorf("a turn without `final` must not be appended to the transcript: %+v", tr)
+	}
+}
+
+func TestSSEClientTerminalErrorEvent(t *testing.T) {
+	f := newFakeRelay(t)
+	f.stream = func(w http.ResponseWriter, flush func(), _ queryRequest) {
+		frame(w, `{"type":"status","message":"loading model"}`)
+		frame(w, `{"type":"error","detail":"Lemonade Server is not reachable at http://localhost:8000 — run `+"`gaia init`"+`","status":503}`)
+		flush()
+	}
+
+	c := f.client(t)
+	defer c.Close()
+
+	ch, err := c.Send(context.Background(), "triage")
+	if err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+	got := collect(t, ch)
+
+	last, ok := got[len(got)-1].(event.CanonicalErrorEvent)
+	if !ok {
+		t.Fatalf("last event = %T, want CanonicalErrorEvent", got[len(got)-1])
+	}
+	if !strings.Contains(last.Detail, "gaia init") {
+		t.Errorf("the wire detail must be surfaced verbatim: %q", last.Detail)
+	}
+	if last.Status != 503 {
+		t.Errorf("status = %d, want 503", last.Status)
+	}
+	if last.Source != "" {
+		t.Errorf("a wire error must not be attributed to the tui, got %q", last.Source)
+	}
+	if tr := c.Transcript(); len(tr) != 0 {
+		t.Errorf("an errored turn must not be appended to the transcript: %+v", tr)
+	}
+}
+
+// --- framing ----------------------------------------------------------------
+
+func TestSSEClientSkipsUnparseableFramesAndHeartbeats(t *testing.T) {
+	f := newFakeRelay(t)
+	f.stream = func(w http.ResponseWriter, flush func(), _ queryRequest) {
+		fmt.Fprint(w, ": keep-alive\n\n")
+		frame(w, `{"type":"status","message":"one"}`)
+		frame(w, `{"type":"token", TRUNCATED`)       // not valid JSON
+		fmt.Fprint(w, ": another heartbeat\n")       // comment, no blank line
+		frame(w, `{"type":"brand_new_event","x":1}`) // unknown canonical type
+		frame(w, `{"type":"status","message":"two"}`)
+		frame(w, `{"type":"final","answer":"survived"}`)
+		flush()
+	}
+
+	c := f.client(t)
+	defer c.Close()
+
+	ch, err := c.Send(context.Background(), "triage")
+	if err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+	got := collect(t, ch)
+
+	want := []string{
+		"event.CanonicalStatusEvent",
+		"event.CanonicalMalformedEvent",
+		"event.CanonicalUnsupportedEvent",
+		"event.CanonicalStatusEvent",
+		"event.CanonicalFinalEvent",
+	}
+	if names := typeNames(got); !equalStrings(names, want) {
+		t.Fatalf("event sequence = %v, want %v (heartbeats must be dropped, bad frames surfaced)", names, want)
+	}
+	if fin := got[4].(event.CanonicalFinalEvent); fin.Answer != "survived" {
+		t.Errorf("the run must survive a bad frame, got %+v", fin)
+	}
+}
+
+// A final frame with no trailing blank line must still be delivered.
+func TestSSEClientFlushesTrailingFrameWithoutBlankLine(t *testing.T) {
+	f := newFakeRelay(t)
+	f.stream = func(w http.ResponseWriter, flush func(), _ queryRequest) {
+		frame(w, `{"type":"status","message":"working"}`)
+		fmt.Fprint(w, `data: {"type":"final","answer":"no trailing newline"}`)
+		flush()
+	}
+
+	c := f.client(t)
+	defer c.Close()
+
+	ch, err := c.Send(context.Background(), "triage")
+	if err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+	got := collect(t, ch)
+
+	fin, ok := got[len(got)-1].(event.CanonicalFinalEvent)
+	if !ok {
+		t.Fatalf("last event = %T, want CanonicalFinalEvent (%v)", got[len(got)-1], typeNames(got))
+	}
+	if fin.Answer != "no trailing newline" {
+		t.Errorf("answer = %q", fin.Answer)
+	}
+}
+
+// Multi-line `data:` fields join with a newline, per the SSE spec.
+func TestSSEClientJoinsMultiLineDataFields(t *testing.T) {
+	f := newFakeRelay(t)
+	f.stream = func(w http.ResponseWriter, flush func(), _ queryRequest) {
+		fmt.Fprint(w, "data: {\"type\":\"final\",\ndata: \"answer\":\"split payload\"}\n\n")
+		flush()
+	}
+
+	c := f.client(t)
+	defer c.Close()
+
+	ch, err := c.Send(context.Background(), "triage")
+	if err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+	got := collect(t, ch)
+
+	fin, ok := got[0].(event.CanonicalFinalEvent)
+	if !ok {
+		t.Fatalf("event = %T, want CanonicalFinalEvent", got[0])
+	}
+	if fin.Answer != "split payload" {
+		t.Errorf("answer = %q", fin.Answer)
+	}
+}
+
+// --- auth -------------------------------------------------------------------
+
+// The token rotates on every daemon restart: a 401 mid-Send must re-read
+// instance.json and retry exactly once.
+func TestSSEClientRetriesOnceAfterTokenRotation(t *testing.T) {
+	f := newFakeRelay(t)
+	// The daemon restarts right after the ensure — the query then presents a
+	// token the new daemon does not know.
+	f.onEnsure = func() { f.rotateToken("token-B") }
+	f.stream = func(w http.ResponseWriter, flush func(), _ queryRequest) {
+		frame(w, `{"type":"final","answer":"after rotation"}`)
+		flush()
+	}
+
+	c := f.client(t)
+	defer c.Close()
+
+	ch, err := c.Send(context.Background(), "triage")
+	if err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+	got := collect(t, ch)
+
+	fin, ok := got[len(got)-1].(event.CanonicalFinalEvent)
+	if !ok {
+		t.Fatalf("last event = %T, want CanonicalFinalEvent (%v)", got[len(got)-1], typeNames(got))
+	}
+	if fin.Answer != "after rotation" {
+		t.Errorf("answer = %q", fin.Answer)
+	}
+
+	f.mu.Lock()
+	auths := append([]string(nil), f.auths...)
+	f.mu.Unlock()
+	var sawA, sawB bool
+	for _, a := range auths {
+		switch a {
+		case "Bearer token-A":
+			sawA = true
+		case "Bearer token-B":
+			sawB = true
+		case "Bearer " + sidecarBearer:
+			t.Fatal("the sidecar bearer was presented to the daemon")
+		}
+	}
+	if !sawA || !sawB {
+		t.Errorf("expected attempts with both tokens, saw %v", auths)
+	}
+}
+
+func TestSSEClientNeverPresentsTheSidecarBearer(t *testing.T) {
+	f := newFakeRelay(t)
+	f.stream = func(w http.ResponseWriter, flush func(), _ queryRequest) {
+		frame(w, `{"type":"final","answer":"ok"}`)
+		flush()
+	}
+
+	c := f.client(t)
+	defer c.Close()
+
+	ch, err := c.Send(context.Background(), "triage")
+	if err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+	collect(t, ch)
+
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	for _, a := range f.auths {
+		if strings.Contains(a, sidecarBearer) {
+			t.Fatalf("the sidecar bearer leaked onto the wire: %q", a)
+		}
+	}
+}
+
+// --- refusals ---------------------------------------------------------------
+
+func TestSSEClientSurfacesRelayRefusal(t *testing.T) {
+	f := newFakeRelay(t)
+	f.queryStatus = http.StatusServiceUnavailable
+	f.stream = func(http.ResponseWriter, func(), queryRequest) {}
+
+	c := f.client(t)
+	defer c.Close()
+
+	_, err := c.Send(context.Background(), "triage")
+	if err == nil {
+		t.Fatal("expected an error when the relay refuses the query")
+	}
+	if !strings.Contains(err.Error(), "not running") {
+		t.Errorf("the relay's detail must be surfaced: %v", err)
+	}
+	if !strings.Contains(err.Error(), "gaia daemon status") {
+		t.Errorf("the error must be actionable: %v", err)
+	}
+}
+
+func TestSSEClientFailsLoudlyWithNoDaemon(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv(daemon.EnvHome, dir)
+
+	dc := daemon.New(daemon.Options{
+		ProbeTimeout: time.Second,
+		StartCommand: func(context.Context) (*exec.Cmd, error) {
+			return nil, fmt.Errorf("no launcher in this test")
+		},
+	})
+	c := NewSSEClient("email", dc, SSEOptions{})
+	defer c.Close()
+
+	_, err := c.Send(context.Background(), "triage")
+	if err == nil {
+		t.Fatal("expected a loud error when no daemon is registered")
+	}
+	if !strings.Contains(err.Error(), "no launcher in this test") {
+		t.Errorf("the start failure must be surfaced: %v", err)
+	}
+}
+
+// --- cancellation -----------------------------------------------------------
+
+// Cancelling the turn must POST the run's cancel endpoint so the sidecar stops
+// between tool steps.
+func TestSSEClientCancelPostsToCancelEndpoint(t *testing.T) {
+	f := newFakeRelay(t)
+	started := make(chan struct{})
+	release := make(chan struct{})
+	f.stream = func(w http.ResponseWriter, flush func(), _ queryRequest) {
+		frame(w, `{"type":"status","message":"thinking"}`)
+		flush()
+		close(started)
+		<-release // hold the stream open with no terminal event
+	}
+
+	c := f.client(t)
+	defer c.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	ch, err := c.Send(ctx, "triage")
+	if err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+	if _, ok := <-ch; !ok {
+		t.Fatal("expected the status event before cancelling")
+	}
+	<-started
+	cancel()
+	for range ch { // drain
+	}
+	close(release)
+
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		f.mu.Lock()
+		n := len(f.cancelled)
+		runIDs := append([]string(nil), f.cancelled...)
+		f.mu.Unlock()
+		if n > 0 {
+			if runIDs[0] != f.lastQuery().RunID {
+				t.Errorf("cancelled run_id %q, want %q", runIDs[0], f.lastQuery().RunID)
+			}
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("no cancel was posted within 5s of cancelling the turn")
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+
+	if tr := c.Transcript(); len(tr) != 0 {
+		t.Errorf("a cancelled turn must not be appended to the transcript: %+v", tr)
+	}
+}
+
+// The read-idle watchdog must abandon a silent stream with an actionable error.
+func TestSSEClientReadIdleTimeout(t *testing.T) {
+	f := newFakeRelay(t)
+	release := make(chan struct{})
+	t.Cleanup(func() { close(release) })
+	f.stream = func(w http.ResponseWriter, flush func(), _ queryRequest) {
+		frame(w, `{"type":"status","message":"loading model"}`)
+		flush()
+		<-release
+	}
+
+	dc := daemon.New(daemon.Options{
+		ProbeTimeout: 2 * time.Second,
+		StartCommand: func(context.Context) (*exec.Cmd, error) {
+			return nil, fmt.Errorf("unused")
+		},
+	})
+	c := NewSSEClient("email", dc, SSEOptions{ReadTimeout: 300 * time.Millisecond})
+	defer c.Close()
+
+	ch, err := c.Send(context.Background(), "triage")
+	if err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+	got := collect(t, ch)
+
+	last, ok := got[len(got)-1].(event.CanonicalErrorEvent)
+	if !ok {
+		t.Fatalf("last event = %T, want CanonicalErrorEvent (%v)", got[len(got)-1], typeNames(got))
+	}
+	if !strings.Contains(last.Detail, "sent nothing for") {
+		t.Errorf("detail must explain the idle timeout: %q", last.Detail)
+	}
+}
+
+func TestSSEClientRefusesSendAfterClose(t *testing.T) {
+	f := newFakeRelay(t)
+	f.stream = func(http.ResponseWriter, func(), queryRequest) {}
+
+	c := f.client(t)
+	if err := c.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	if _, err := c.Send(context.Background(), "triage"); err == nil {
+		t.Fatal("expected an error sending on a closed client")
+	}
+}
+
+func equalStrings(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/tui/internal/client/subprocess.go
+++ b/tui/internal/client/subprocess.go
@@ -9,7 +9,6 @@ import (
 	"net/http"
 	"os"
 	"os/exec"
-	"strings"
 	"sync"
 	"time"
 
@@ -34,25 +33,57 @@ func detectLemonadeURL() string {
 	return ""
 }
 
-// SubprocessClient communicates with a C++ agent via stdin/stdout JSONL.
+// procHandle owns one child process so exactly one Wait() ever runs for it —
+// the reader goroutine, a cancellation kill, and Close() all funnel through it.
+type procHandle struct {
+	cmd      *exec.Cmd
+	waitOnce sync.Once
+	state    *os.ProcessState
+}
+
+// wait reaps the child and returns its final state (nil if it was never started).
+func (p *procHandle) wait() *os.ProcessState {
+	p.waitOnce.Do(func() {
+		_ = p.cmd.Wait()
+		p.state = p.cmd.ProcessState
+	})
+	return p.state
+}
+
+// kill terminates the child and reaps it.
+func (p *procHandle) kill() {
+	if p.cmd.Process != nil {
+		_ = p.cmd.Process.Kill()
+	}
+	p.wait()
+}
+
+// SubprocessClient communicates with a local agent binary via stdin/stdout JSONL.
 // Send() calls must be serialized — do not overlap two Send() calls.
 type SubprocessClient struct {
-	cmdLine string
-	debug   bool
+	path  string
+	args  []string
+	debug bool
 
 	mu      sync.Mutex
-	cmd     *exec.Cmd
+	proc    *procHandle
 	stdin   io.WriteCloser
 	stdout  *bufio.Scanner
 	stderr  *bytes.Buffer
 	started bool
 }
 
-// NewSubprocessClient creates a client from a command string like "./gaia-bash --json-events".
-func NewSubprocessClient(cmdLine string, debug bool) *SubprocessClient {
+// NewSubprocessClient creates a client for an agent binary and its arguments.
+//
+// argv is taken pre-split: a single command string would have to be re-split on
+// whitespace, which corrupts any path containing a space. Callers holding one
+// string (e.g. `gaia tui chat --subprocess "..."`) split it with
+// SplitCommandLine, which honours quoting.
+func NewSubprocessClient(path string, args []string, debug bool) *SubprocessClient {
 	return &SubprocessClient{
-		cmdLine: cmdLine,
-		debug:   debug,
+		path:  path,
+		args:  args,
+		debug: debug,
 	}
 }
 
@@ -64,33 +95,31 @@ func (s *SubprocessClient) start() error {
 	if s.started {
 		return nil
 	}
-
-	parts := strings.Fields(s.cmdLine)
-	if len(parts) == 0 {
-		return fmt.Errorf("empty subprocess command")
+	if s.path == "" {
+		return fmt.Errorf("no agent binary was given, so nothing can be launched")
 	}
 
-	s.cmd = exec.Command(parts[0], parts[1:]...)
+	cmd := exec.Command(s.path, s.args...)
 	s.stderr = &bytes.Buffer{}
-	s.cmd.Stderr = s.stderr
+	cmd.Stderr = s.stderr
 
 	// Auto-detect Lemonade URL if not set in environment
 	if os.Getenv("LEMONADE_BASE_URL") == "" {
 		if url := detectLemonadeURL(); url != "" {
-			s.cmd.Env = append(os.Environ(), "LEMONADE_BASE_URL="+url)
+			cmd.Env = append(os.Environ(), "LEMONADE_BASE_URL="+url)
 			if s.debug {
 				fmt.Fprintf(os.Stderr, "[DEBUG] Auto-detected Lemonade at %s\n", url)
 			}
 		}
 	}
 
-	stdinPipe, err := s.cmd.StdinPipe()
+	stdinPipe, err := cmd.StdinPipe()
 	if err != nil {
 		return fmt.Errorf("failed to create stdin pipe: %w", err)
 	}
 	s.stdin = stdinPipe
 
-	stdoutPipe, err := s.cmd.StdoutPipe()
+	stdoutPipe, err := cmd.StdoutPipe()
 	if err != nil {
 		return fmt.Errorf("failed to create stdout pipe: %w", err)
 	}
@@ -100,10 +129,11 @@ func (s *SubprocessClient) start() error {
 	scanner.Buffer(make([]byte, 0, 1024*1024), 1024*1024)
 	s.stdout = scanner
 
-	if err := s.cmd.Start(); err != nil {
-		return fmt.Errorf("failed to start subprocess %q: %w", parts[0], err)
+	if err := cmd.Start(); err != nil {
+		return fmt.Errorf("failed to start agent %q: %w", s.path, err)
 	}
 
+	s.proc = &procHandle{cmd: cmd}
 	s.started = true
 	return nil
 }
@@ -115,21 +145,44 @@ func (s *SubprocessClient) Send(ctx context.Context, query string) (<-chan inter
 	}
 
 	if _, err := fmt.Fprintln(s.stdin, query); err != nil {
-		return nil, fmt.Errorf("failed to write to subprocess stdin: %w", err)
+		return nil, fmt.Errorf("failed to write to agent stdin: %w", err)
 	}
 
 	// Capture references under lock so the goroutine doesn't race with Close().
 	s.mu.Lock()
 	scanner := s.stdout
-	cmd := s.cmd
+	proc := s.proc
 	stderrBuf := s.stderr
 	debug := s.debug
 	s.mu.Unlock()
 
 	ch := make(chan interface{}, 32)
 
+	// A cancelled turn must actually stop the child. Abandoning the read while
+	// the agent keeps writing leaves the tail of this turn's output in the pipe,
+	// which the NEXT turn would read as its own — so the process is killed and
+	// respawned instead.
+	turnDone := make(chan struct{})
+	go func() {
+		select {
+		case <-ctx.Done():
+			s.terminate()
+		case <-turnDone:
+		}
+	}()
+
 	go func() {
 		defer close(ch)
+		defer close(turnDone)
+
+		emit := func(evt interface{}) bool {
+			select {
+			case ch <- evt:
+				return true
+			case <-ctx.Done():
+				return false
+			}
+		}
 
 		for scanner.Scan() {
 			line := scanner.Bytes()
@@ -139,8 +192,17 @@ func (s *SubprocessClient) Send(ctx context.Context, query string) (<-chan inter
 
 			evt, err := event.ParseEvent(line)
 			if err != nil {
+				// Visible, not dropped: a status warning keeps the turn alive
+				// while making a bad producer obvious.
 				if debug {
 					fmt.Fprintf(os.Stderr, "[DEBUG] parse error: %v (line: %s)\n", err, string(line))
+				}
+				if !emit(event.StatusEvent{
+					Type:    "status",
+					Status:  "warning",
+					Message: fmt.Sprintf("unreadable agent event (%v): %s", err, truncateLine(string(line))),
+				}) {
+					return
 				}
 				continue
 			}
@@ -150,9 +212,7 @@ func (s *SubprocessClient) Send(ctx context.Context, query string) (<-chan inter
 				continue
 			}
 
-			select {
-			case ch <- evt:
-			case <-ctx.Done():
+			if !emit(evt) {
 				return
 			}
 
@@ -169,59 +229,74 @@ func (s *SubprocessClient) Send(ctx context.Context, query string) (<-chan inter
 
 		// Scanner stopped — check for read errors or unexpected process exit.
 		if err := scanner.Err(); err != nil {
-			select {
-			case ch <- event.AgentErrorEvent{
+			emit(event.AgentErrorEvent{
 				Type:    "agent_error",
-				Content: fmt.Sprintf("subprocess stdout read error: %v", err),
-			}:
-			case <-ctx.Done():
-			}
+				Content: fmt.Sprintf("agent stdout read error: %v", err),
+			})
 			return
 		}
 
-		// Process exited — wait to get exit code, then report if non-zero.
-		_ = cmd.Wait()
-		if cmd.ProcessState != nil && !cmd.ProcessState.Success() {
+		// Process exited — reap it to get the exit code, then report if non-zero.
+		state := proc.wait()
+		if state != nil && !state.Success() {
 			stderrContent := stderrBuf.String()
-			msg := fmt.Sprintf("agent process exited with code %d", cmd.ProcessState.ExitCode())
+			msg := fmt.Sprintf("agent process exited with code %d", state.ExitCode())
 			if stderrContent != "" {
 				msg += "\n" + stderrContent
 			}
-			select {
-			case ch <- event.AgentErrorEvent{
+			emit(event.AgentErrorEvent{
 				Type:    "agent_error",
 				Content: msg,
-			}:
-			case <-ctx.Done():
-			}
+			})
 		}
 	}()
 
 	return ch, nil
 }
 
-// Close terminates the subprocess.
-func (s *SubprocessClient) Close() error {
+// detach clears the client's process state and hands back what it was holding.
+func (s *SubprocessClient) detach() (*procHandle, io.WriteCloser) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	if !s.started {
-		return nil
-	}
-
-	// Close stdin to signal EOF to the child process.
-	if s.stdin != nil {
-		s.stdin.Close()
-	}
-
-	if s.cmd != nil {
-		s.cmd.Wait()
-	}
-
+	proc, stdin := s.proc, s.stdin
+	s.proc = nil
 	s.stdin = nil
 	s.stdout = nil
 	s.stderr = nil
-	s.cmd = nil
 	s.started = false
+	return proc, stdin
+}
+
+// terminate kills the child and resets the client so the next Send respawns it
+// against a clean pipe.
+func (s *SubprocessClient) terminate() {
+	proc, stdin := s.detach()
+	if stdin != nil {
+		stdin.Close()
+	}
+	if proc != nil {
+		proc.kill()
+	}
+}
+
+// Close terminates the subprocess.
+func (s *SubprocessClient) Close() error {
+	proc, stdin := s.detach()
+	// Close stdin to signal EOF to the child process.
+	if stdin != nil {
+		stdin.Close()
+	}
+	if proc != nil {
+		proc.wait()
+	}
 	return nil
+}
+
+func truncateLine(s string) string {
+	const limit = 200
+	if len(s) <= limit {
+		return s
+	}
+	return s[:limit] + "…"
 }

--- a/tui/internal/client/subprocess.go
+++ b/tui/internal/client/subprocess.go
@@ -15,6 +15,10 @@ import (
 	"github.com/amd/gaia/tui/internal/event"
 )
 
+// closeGrace bounds how long Close() waits for an in-flight turn's reader to
+// finish before giving up on a clean reap.
+const closeGrace = 2 * time.Second
+
 // detectLemonadeURL probes common Lemonade Server ports and returns the first reachable URL.
 func detectLemonadeURL() string {
 	ports := []string{"13305", "8000"}
@@ -33,16 +37,21 @@ func detectLemonadeURL() string {
 	return ""
 }
 
-// procHandle owns one child process so exactly one Wait() ever runs for it —
-// the reader goroutine, a cancellation kill, and Close() all funnel through it.
+// procHandle owns one child process.
+//
+// Reaping is the READER's job: os/exec forbids calling Wait before all reads
+// from a pipe have completed, so a kill from elsewhere must not also reap — it
+// would close the stdout pipe under the reader and turn a deliberate kill into a
+// spurious "file already closed" read error.
 type procHandle struct {
 	cmd      *exec.Cmd
 	waitOnce sync.Once
 	state    *os.ProcessState
 }
 
-// wait reaps the child and returns its final state (nil if it was never started).
-func (p *procHandle) wait() *os.ProcessState {
+// reap waits for the child and returns its final state. Safe to call more than
+// once; only the first call waits. Call it only once reads are done.
+func (p *procHandle) reap() *os.ProcessState {
 	p.waitOnce.Do(func() {
 		_ = p.cmd.Wait()
 		p.state = p.cmd.ProcessState
@@ -50,12 +59,11 @@ func (p *procHandle) wait() *os.ProcessState {
 	return p.state
 }
 
-// kill terminates the child and reaps it.
+// kill signals the child without reaping it.
 func (p *procHandle) kill() {
 	if p.cmd.Process != nil {
 		_ = p.cmd.Process.Kill()
 	}
-	p.wait()
 }
 
 // SubprocessClient communicates with a local agent binary via stdin/stdout JSONL.
@@ -71,6 +79,9 @@ type SubprocessClient struct {
 	stdout  *bufio.Scanner
 	stderr  *bytes.Buffer
 	started bool
+	// turnDone is closed by the in-flight turn's reader when it exits. nil when
+	// no turn is running.
+	turnDone chan struct{}
 }
 
 // NewSubprocessClient creates a client for an agent binary and its arguments.
@@ -87,21 +98,31 @@ func NewSubprocessClient(path string, args []string, debug bool) *SubprocessClie
 	}
 }
 
-// start spawns the subprocess if not already running.
-func (s *SubprocessClient) start() error {
-	s.mu.Lock()
-	defer s.mu.Unlock()
+// turnState is everything one turn needs, captured under a single lock so it can
+// never be read while a concurrent cancel is clearing the client's fields.
+type turnState struct {
+	stdin    io.WriteCloser
+	scanner  *bufio.Scanner
+	proc     *procHandle
+	stderr   *bytes.Buffer
+	turnDone chan struct{}
+}
 
+// startLocked spawns the subprocess if needed and returns the turn's handles.
+// The caller MUST hold s.mu.
+func (s *SubprocessClient) startLocked() (turnState, error) {
 	if s.started {
-		return nil
+		done := make(chan struct{})
+		s.turnDone = done
+		return turnState{s.stdin, s.stdout, s.proc, s.stderr, done}, nil
 	}
 	if s.path == "" {
-		return fmt.Errorf("no agent binary was given, so nothing can be launched")
+		return turnState{}, fmt.Errorf("no agent binary was given, so nothing can be launched")
 	}
 
 	cmd := exec.Command(s.path, s.args...)
-	s.stderr = &bytes.Buffer{}
-	cmd.Stderr = s.stderr
+	stderr := &bytes.Buffer{}
+	cmd.Stderr = stderr
 
 	// Auto-detect Lemonade URL if not set in environment
 	if os.Getenv("LEMONADE_BASE_URL") == "" {
@@ -115,67 +136,80 @@ func (s *SubprocessClient) start() error {
 
 	stdinPipe, err := cmd.StdinPipe()
 	if err != nil {
-		return fmt.Errorf("failed to create stdin pipe: %w", err)
+		return turnState{}, fmt.Errorf("failed to create stdin pipe: %w", err)
 	}
-	s.stdin = stdinPipe
-
 	stdoutPipe, err := cmd.StdoutPipe()
 	if err != nil {
-		return fmt.Errorf("failed to create stdout pipe: %w", err)
+		return turnState{}, fmt.Errorf("failed to create stdout pipe: %w", err)
 	}
 
 	scanner := bufio.NewScanner(stdoutPipe)
 	// 1MB buffer for large tool outputs
 	scanner.Buffer(make([]byte, 0, 1024*1024), 1024*1024)
-	s.stdout = scanner
 
 	if err := cmd.Start(); err != nil {
-		return fmt.Errorf("failed to start agent %q: %w", s.path, err)
+		return turnState{}, fmt.Errorf("failed to start agent %q: %w", s.path, err)
 	}
 
+	done := make(chan struct{})
+	s.stdin = stdinPipe
+	s.stdout = scanner
+	s.stderr = stderr
 	s.proc = &procHandle{cmd: cmd}
 	s.started = true
-	return nil
+	s.turnDone = done
+	return turnState{stdinPipe, scanner, s.proc, stderr, done}, nil
 }
 
 // Send writes a query to stdin and returns a channel of parsed events.
 func (s *SubprocessClient) Send(ctx context.Context, query string) (<-chan interface{}, error) {
-	if err := s.start(); err != nil {
+	s.mu.Lock()
+	st, err := s.startLocked()
+	debug := s.debug
+	s.mu.Unlock()
+	if err != nil {
 		return nil, err
 	}
 
-	if _, err := fmt.Fprintln(s.stdin, query); err != nil {
+	if _, err := fmt.Fprintln(st.stdin, query); err != nil {
 		return nil, fmt.Errorf("failed to write to agent stdin: %w", err)
 	}
-
-	// Capture references under lock so the goroutine doesn't race with Close().
-	s.mu.Lock()
-	scanner := s.stdout
-	proc := s.proc
-	stderrBuf := s.stderr
-	debug := s.debug
-	s.mu.Unlock()
 
 	ch := make(chan interface{}, 32)
 
 	// A cancelled turn must actually stop the child. Abandoning the read while
 	// the agent keeps writing leaves the tail of this turn's output in the pipe,
-	// which the NEXT turn would read as its own — so the process is killed and
-	// respawned instead.
-	turnDone := make(chan struct{})
+	// which the NEXT turn would read as its own. Kill only — the reader reaps.
 	go func() {
 		select {
 		case <-ctx.Done():
-			s.terminate()
-		case <-turnDone:
+			st.proc.kill()
+		case <-st.turnDone:
 		}
 	}()
 
 	go func() {
 		defer close(ch)
-		defer close(turnDone)
+		defer close(st.turnDone)
 
+		// Registered last so it runs FIRST: every exit path from this goroutine
+		// — including the early returns mid-loop — must reset the client when the
+		// turn was cancelled, or the next Send reuses the child we just killed
+		// and reads nothing.
+		defer func() {
+			if ctx.Err() != nil {
+				st.proc.reap()
+				s.discard(st.proc)
+			}
+		}()
+
+		// Deterministic: once the turn is cancelled nothing is pushed into the
+		// abandoned channel. Selecting on both a ready send and a ready
+		// ctx.Done() would pick randomly and leak events into the next turn.
 		emit := func(evt interface{}) bool {
+			if ctx.Err() != nil {
+				return false
+			}
 			select {
 			case ch <- evt:
 				return true
@@ -184,23 +218,23 @@ func (s *SubprocessClient) Send(ctx context.Context, query string) (<-chan inter
 			}
 		}
 
-		for scanner.Scan() {
-			line := scanner.Bytes()
+		for st.scanner.Scan() {
+			line := st.scanner.Bytes()
 			if len(line) == 0 {
 				continue
 			}
 
-			evt, err := event.ParseEvent(line)
-			if err != nil {
+			evt, perr := event.ParseEvent(line)
+			if perr != nil {
 				// Visible, not dropped: a status warning keeps the turn alive
 				// while making a bad producer obvious.
 				if debug {
-					fmt.Fprintf(os.Stderr, "[DEBUG] parse error: %v (line: %s)\n", err, string(line))
+					fmt.Fprintf(os.Stderr, "[DEBUG] parse error: %v (line: %s)\n", perr, string(line))
 				}
 				if !emit(event.StatusEvent{
 					Type:    "status",
 					Status:  "warning",
-					Message: fmt.Sprintf("unreadable agent event (%v): %s", err, truncateLine(string(line))),
+					Message: fmt.Sprintf("unreadable agent event (%v): %s", perr, truncateLine(string(line))),
 				}) {
 					return
 				}
@@ -227,8 +261,14 @@ func (s *SubprocessClient) Send(ctx context.Context, query string) (<-chan inter
 			}
 		}
 
-		// Scanner stopped — check for read errors or unexpected process exit.
-		if err := scanner.Err(); err != nil {
+		// The read is over, so reaping is safe from here on. A cancelled turn
+		// killed the child on purpose: a dead child is the expected outcome, not
+		// an error to report, and the deferred reset above respawns next time.
+		if ctx.Err() != nil {
+			return
+		}
+
+		if err := st.scanner.Err(); err != nil {
 			emit(event.AgentErrorEvent{
 				Type:    "agent_error",
 				Content: fmt.Sprintf("agent stdout read error: %v", err),
@@ -236,10 +276,12 @@ func (s *SubprocessClient) Send(ctx context.Context, query string) (<-chan inter
 			return
 		}
 
-		// Process exited — reap it to get the exit code, then report if non-zero.
-		state := proc.wait()
+		// The child exited on its own — reap it for the exit code and report a
+		// non-zero one. The next Send respawns.
+		state := st.proc.reap()
+		s.discard(st.proc)
 		if state != nil && !state.Success() {
-			stderrContent := stderrBuf.String()
+			stderrContent := st.stderr.String()
 			msg := fmt.Sprintf("agent process exited with code %d", state.ExitCode())
 			if stderrContent != "" {
 				msg += "\n" + stderrContent
@@ -254,42 +296,66 @@ func (s *SubprocessClient) Send(ctx context.Context, query string) (<-chan inter
 	return ch, nil
 }
 
-// detach clears the client's process state and hands back what it was holding.
-func (s *SubprocessClient) detach() (*procHandle, io.WriteCloser) {
+// discard clears the client's process state, but only if it still refers to
+// proc — a newer Send may already have respawned.
+func (s *SubprocessClient) discard(proc *procHandle) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-
-	proc, stdin := s.proc, s.stdin
+	if s.proc != proc {
+		return
+	}
 	s.proc = nil
 	s.stdin = nil
 	s.stdout = nil
 	s.stderr = nil
 	s.started = false
-	return proc, stdin
-}
-
-// terminate kills the child and resets the client so the next Send respawns it
-// against a clean pipe.
-func (s *SubprocessClient) terminate() {
-	proc, stdin := s.detach()
-	if stdin != nil {
-		stdin.Close()
-	}
-	if proc != nil {
-		proc.kill()
-	}
+	s.turnDone = nil
 }
 
 // Close terminates the subprocess.
 func (s *SubprocessClient) Close() error {
-	proc, stdin := s.detach()
-	// Close stdin to signal EOF to the child process.
+	s.mu.Lock()
+	if !s.started {
+		s.mu.Unlock()
+		return nil
+	}
+	proc, stdin, turnDone := s.proc, s.stdin, s.turnDone
+	s.proc = nil
+	s.stdin = nil
+	s.stdout = nil
+	s.stderr = nil
+	s.started = false
+	s.turnDone = nil
+	s.mu.Unlock()
+
+	// Closing stdin is how a well-behaved agent is asked to exit.
 	if stdin != nil {
 		stdin.Close()
 	}
-	if proc != nil {
-		proc.wait()
+	if proc == nil {
+		return nil
 	}
+
+	// If a turn's reader is still in flight it owns the reap (os/exec forbids
+	// Wait before reads complete), so wait for it rather than racing it.
+	if turnDone != nil {
+		select {
+		case <-turnDone:
+		case <-time.After(closeGrace):
+			// The agent ignored EOF. Kill it and let the reader finish.
+			proc.kill()
+			select {
+			case <-turnDone:
+			case <-time.After(closeGrace):
+				// The reader is wedged; leave the child to the OS rather than
+				// calling Wait underneath an active read.
+				return nil
+			}
+		}
+		return nil
+	}
+
+	proc.reap()
 	return nil
 }
 

--- a/tui/internal/client/subprocess_test.go
+++ b/tui/internal/client/subprocess_test.go
@@ -6,9 +6,11 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"testing"
 	"time"
 
+	"github.com/amd/gaia/tui/internal/daemon"
 	"github.com/amd/gaia/tui/internal/event"
 )
 
@@ -68,7 +70,7 @@ func main() {
 func TestSubprocessClient_SendReceivesEvents(t *testing.T) {
 	bin := buildMockAgent(t)
 
-	c := NewSubprocessClient(bin, true)
+	c := NewSubprocessClient(bin, nil, true)
 	defer c.Close()
 
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
@@ -119,7 +121,7 @@ func TestSubprocessClient_SendReceivesEvents(t *testing.T) {
 func TestSubprocessClient_MultiTurn(t *testing.T) {
 	bin := buildMockAgent(t)
 
-	c := NewSubprocessClient(bin, false)
+	c := NewSubprocessClient(bin, nil, false)
 	defer c.Close()
 
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
@@ -153,7 +155,7 @@ func TestSubprocessClient_MultiTurn(t *testing.T) {
 }
 
 func TestSubprocessClient_InvalidCommand(t *testing.T) {
-	c := NewSubprocessClient("nonexistent_binary_xyz_12345", false)
+	c := NewSubprocessClient("nonexistent_binary_xyz_12345", nil, false)
 	defer c.Close()
 
 	ctx := context.Background()
@@ -163,8 +165,8 @@ func TestSubprocessClient_InvalidCommand(t *testing.T) {
 	}
 }
 
-func TestSubprocessClient_EmptyCommand(t *testing.T) {
-	c := NewSubprocessClient("", false)
+func TestSubprocessClient_EmptyBinaryPath(t *testing.T) {
+	c := NewSubprocessClient("", nil, false)
 
 	ctx := context.Background()
 	_, err := c.Send(ctx, "hello")
@@ -174,7 +176,7 @@ func TestSubprocessClient_EmptyCommand(t *testing.T) {
 }
 
 func TestSubprocessClient_CloseBeforeSend(t *testing.T) {
-	c := NewSubprocessClient("echo", false)
+	c := NewSubprocessClient("echo", nil, false)
 
 	// Close without ever starting should be a no-op.
 	if err := c.Close(); err != nil {
@@ -211,7 +213,7 @@ func main() { os.Exit(1) }
 		t.Fatalf("build exit agent: %v\n%s", err, out)
 	}
 
-	c := NewSubprocessClient(binPath, false)
+	c := NewSubprocessClient(binPath, nil, false)
 	defer c.Close()
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
@@ -239,3 +241,197 @@ func main() { os.Exit(1) }
 
 // Verify the interface is satisfied at compile time.
 var _ AgentClient = (*SubprocessClient)(nil)
+
+// buildAgentFrom compiles src into dir and returns the binary path.
+func buildAgentFrom(t *testing.T, dir, name, src string) string {
+	t.Helper()
+
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", dir, err)
+	}
+	srcPath := filepath.Join(dir, name+".go")
+	if err := os.WriteFile(srcPath, []byte(src), 0644); err != nil {
+		t.Fatalf("write %s: %v", srcPath, err)
+	}
+
+	binName := name
+	if runtime.GOOS == "windows" {
+		binName += ".exe"
+	}
+	binPath := filepath.Join(dir, binName)
+
+	goExe := "go"
+	if p, err := exec.LookPath("go"); err == nil {
+		goExe = p
+	}
+	cmd := exec.Command(goExe, "build", "-o", binPath, srcPath)
+	cmd.Env = append(os.Environ(), "CGO_ENABLED=0")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("build %s: %v\n%s", name, err, out)
+	}
+	return binPath
+}
+
+const echoAgentSrc = `package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	scanner := bufio.NewScanner(os.Stdin)
+	for scanner.Scan() {
+		fmt.Println("{\"type\":\"answer\",\"content\":\"ok\",\"steps\":1,\"tools_used\":0}")
+	}
+}
+`
+
+// A path containing a space used to be re-split on whitespace, so the binary
+// could never be found.
+func TestSubprocessClient_BinaryPathWithSpaces(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "My Agents")
+	bin := buildAgentFrom(t, dir, "spaced_agent", echoAgentSrc)
+	if !strings.Contains(bin, " ") {
+		t.Fatalf("test setup: expected a space in %q", bin)
+	}
+
+	c := NewSubprocessClient(bin, nil, false)
+	defer c.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	ch, err := c.Send(ctx, "hello")
+	if err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+	var got []interface{}
+	for evt := range ch {
+		got = append(got, evt)
+	}
+	if len(got) != 1 {
+		t.Fatalf("expected 1 event, got %d: %+v", len(got), got)
+	}
+	if _, ok := got[0].(event.AnswerEvent); !ok {
+		t.Fatalf("expected AnswerEvent, got %T", got[0])
+	}
+}
+
+const slowAgentSrc = `package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"time"
+)
+
+func main() {
+	scanner := bufio.NewScanner(os.Stdin)
+	for scanner.Scan() {
+		fmt.Println("{\"type\":\"step\",\"step\":1,\"total\":2,\"status\":\"running\"}")
+		time.Sleep(30 * time.Second)
+		fmt.Println("{\"type\":\"answer\",\"content\":\"late\",\"steps\":1,\"tools_used\":0}")
+	}
+}
+`
+
+// Cancelling a turn must stop the child. Leaving it alive lets the tail of this
+// turn's output surface as the NEXT turn's events.
+func TestSubprocessClient_CancelKillsChild(t *testing.T) {
+	bin := buildAgentFrom(t, t.TempDir(), "slow_agent", slowAgentSrc)
+
+	c := NewSubprocessClient(bin, nil, false)
+	defer c.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	ch, err := c.Send(ctx, "start")
+	if err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+	if _, ok := <-ch; !ok {
+		t.Fatal("expected the first event before cancelling")
+	}
+
+	c.mu.Lock()
+	pid := c.proc.cmd.Process.Pid
+	c.mu.Unlock()
+
+	cancel()
+	for range ch { // drain
+	}
+
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		c.mu.Lock()
+		started := c.started
+		c.mu.Unlock()
+		if !started {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("client still holds a started process 5s after cancellation")
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+
+	if daemon.PIDAlive(pid) {
+		t.Errorf("child pid %d is still alive after cancellation", pid)
+	}
+}
+
+const garbageAgentSrc = `package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	scanner := bufio.NewScanner(os.Stdin)
+	for scanner.Scan() {
+		fmt.Println("this is not json at all")
+		fmt.Println("{\"type\":\"brand_new_type\"}")
+		fmt.Println("{\"type\":\"answer\",\"content\":\"done\",\"steps\":1,\"tools_used\":0}")
+	}
+}
+`
+
+// An unreadable line must be surfaced, not silently dropped, and must not end
+// the turn.
+func TestSubprocessClient_UnparseableLineIsVisible(t *testing.T) {
+	bin := buildAgentFrom(t, t.TempDir(), "garbage_agent", garbageAgentSrc)
+
+	c := NewSubprocessClient(bin, nil, false)
+	defer c.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	ch, err := c.Send(ctx, "hello")
+	if err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+
+	var warnings int
+	var answered bool
+	for evt := range ch {
+		switch e := evt.(type) {
+		case event.StatusEvent:
+			if e.Status == "warning" {
+				warnings++
+			}
+		case event.AnswerEvent:
+			answered = true
+		}
+	}
+	if warnings != 2 {
+		t.Errorf("expected 2 warning status events (bad JSON + unknown type), got %d", warnings)
+	}
+	if !answered {
+		t.Error("the turn must still reach its answer after an unreadable line")
+	}
+}

--- a/tui/internal/client/subprocess_test.go
+++ b/tui/internal/client/subprocess_test.go
@@ -435,3 +435,69 @@ func TestSubprocessClient_UnparseableLineIsVisible(t *testing.T) {
 		t.Error("the turn must still reach its answer after an unreadable line")
 	}
 }
+
+// A cancelled turn kills the child on purpose, so the resulting non-zero exit /
+// closed pipe must NOT surface as an agent error — that put a spurious
+// "exited with code -1" bubble under the "cancelled" line about half the time.
+func TestSubprocessClient_CancelEmitsNoSpuriousError(t *testing.T) {
+	bin := buildAgentFrom(t, t.TempDir(), "slow_cancel_agent", slowAgentSrc)
+
+	const runs = 8
+	for i := 0; i < runs; i++ {
+		c := NewSubprocessClient(bin, nil, false)
+		ctx, cancel := context.WithCancel(context.Background())
+
+		ch, err := c.Send(ctx, "start")
+		if err != nil {
+			t.Fatalf("run %d: Send: %v", i, err)
+		}
+		if _, ok := <-ch; !ok {
+			t.Fatalf("run %d: expected an event before cancelling", i)
+		}
+		cancel()
+
+		for evt := range ch {
+			if ae, ok := evt.(event.AgentErrorEvent); ok {
+				t.Fatalf("run %d: cancelling emitted a spurious agent error: %q", i, ae.Content)
+			}
+		}
+		c.Close()
+	}
+}
+
+// The turn after a cancel must respawn cleanly: the cancel path clears the
+// client's pipes from another goroutine, so an unsynchronised read of them in
+// Send was both a data race and a nil-deref.
+func TestSubprocessClient_SendAfterCancelRespawns(t *testing.T) {
+	bin := buildAgentFrom(t, t.TempDir(), "respawn_agent", echoAgentSrc)
+
+	c := NewSubprocessClient(bin, nil, false)
+	defer c.Close()
+
+	for i := 0; i < 10; i++ {
+		ctx, cancel := context.WithCancel(context.Background())
+		ch, err := c.Send(ctx, "cancel me")
+		if err != nil {
+			t.Fatalf("iteration %d: Send: %v", i, err)
+		}
+		cancel()
+		for range ch {
+		}
+
+		// A full turn immediately afterwards, while the cancel teardown may
+		// still be running.
+		ch2, err := c.Send(context.Background(), "real turn")
+		if err != nil {
+			t.Fatalf("iteration %d: Send after cancel: %v", i, err)
+		}
+		var answered bool
+		for evt := range ch2 {
+			if _, ok := evt.(event.AnswerEvent); ok {
+				answered = true
+			}
+		}
+		if !answered {
+			t.Fatalf("iteration %d: the turn after a cancel produced no answer", i)
+		}
+	}
+}

--- a/tui/internal/daemon/client.go
+++ b/tui/internal/daemon/client.go
@@ -1,0 +1,557 @@
+package daemon
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+// Timeouts mirror src/gaia/daemon/{instance,client}.py.
+const (
+	// A live daemon answers loopback in milliseconds; a longer wait only delays
+	// reclaiming a dead one.
+	defaultProbeTimeout = 1500 * time.Millisecond
+	// Daemon start: spawn + bind + import.
+	defaultStartTimeout = 30 * time.Second
+	// Ensure: a first-run ensure may lazily fetch the sidecar binary before answering.
+	defaultEnsureTimeout = 900 * time.Second
+	// Cancel must never wait out a stream read timeout.
+	defaultCancelTimeout = 10 * time.Second
+	// Cap on captured launcher output quoted back in an error.
+	maxLauncherOutput = 4096
+)
+
+// Options configures a Client. The zero value is valid and uses the defaults
+// above with the real `gaia daemon start` launcher.
+type Options struct {
+	ProbeTimeout  time.Duration
+	StartTimeout  time.Duration
+	EnsureTimeout time.Duration
+
+	// StartCommand builds the command that starts the daemon. Defaults to
+	// `gaia daemon start`, which is preferred over invoking the module directly
+	// because it validates the required extras and produces better errors.
+	// Overridden by tests.
+	StartCommand func(ctx context.Context) (*exec.Cmd, error)
+
+	// PIDAlive overrides the process-liveness check. Defaults to PIDAlive.
+	PIDAlive func(pid int) bool
+
+	// Logf receives progress and best-effort-failure notes. It MUST never be
+	// given a raw token; pass Instance values (whose String redacts it).
+	Logf func(format string, args ...any)
+}
+
+// Client is a thin client for one machine's GAIA daemon.
+//
+// It is safe for concurrent use: it holds no mutable instance state. Callers pass
+// the *Instance they are working with, and Do hands back the (possibly
+// refreshed) instance whose token authorized the call — the token rotates on
+// every daemon restart, so it is never cached for the process lifetime.
+type Client struct {
+	opts Options
+	// control is used for short control-plane calls (the status probe).
+	control *http.Client
+	// ensure is used for the possibly-very-slow ensure call.
+	ensure *http.Client
+	// cancel is used for the best-effort run-cancel POST, which must not be cut
+	// short by the probe timeout nor wait out a stream read timeout.
+	cancel *http.Client
+}
+
+// New builds a Client, filling unset options with their defaults.
+func New(opts Options) *Client {
+	if opts.ProbeTimeout <= 0 {
+		opts.ProbeTimeout = defaultProbeTimeout
+	}
+	if opts.StartTimeout <= 0 {
+		opts.StartTimeout = defaultStartTimeout
+	}
+	if opts.EnsureTimeout <= 0 {
+		opts.EnsureTimeout = defaultEnsureTimeout
+	}
+	if opts.PIDAlive == nil {
+		opts.PIDAlive = PIDAlive
+	}
+	if opts.StartCommand == nil {
+		opts.StartCommand = gaiaDaemonStart
+	}
+	if opts.Logf == nil {
+		opts.Logf = func(string, ...any) {}
+	}
+	return &Client{
+		opts:    opts,
+		control: &http.Client{Timeout: opts.ProbeTimeout},
+		ensure:  &http.Client{Timeout: opts.EnsureTimeout},
+		cancel:  &http.Client{Timeout: defaultCancelTimeout},
+	}
+}
+
+// Attach returns the running daemon if one is live and contract-compatible.
+//
+// It returns *NotRunningError / *StaleError when there is nothing to attach to,
+// and *VersionError when a live daemon speaks the wrong contract — a version
+// skew is never fixed by starting another daemon, so callers must surface it.
+func (c *Client) Attach(ctx context.Context) (*Instance, error) {
+	inst, err := ReadInstance()
+	if err != nil {
+		return nil, err
+	}
+	if err := c.verify(ctx, inst); err != nil {
+		return nil, err
+	}
+	if err := inst.CheckVersion(); err != nil {
+		return nil, err
+	}
+	return inst, nil
+}
+
+// verify applies the two-check trust rule: the recorded pid must be alive AND a
+// token-authed /daemon/v1/status probe must answer with our service id and the
+// recorded pid. After a hard crash the file points at a dead pid or a freed port
+// some unrelated process now owns — either check fails.
+func (c *Client) verify(ctx context.Context, inst *Instance) error {
+	path, _ := InstancePath()
+	if !c.opts.PIDAlive(inst.PID) {
+		return &StaleError{Path: path, Reason: fmt.Sprintf("its pid %d is not running", inst.PID)}
+	}
+	if err := c.probe(ctx, inst); err != nil {
+		return &StaleError{Path: path, Reason: err.Error()}
+	}
+	return nil
+}
+
+type statusBody struct {
+	Service string `json:"service"`
+	PID     int    `json:"pid"`
+}
+
+// probe checks the recorded port with the recorded token. It returns nil only if
+// the server answers 200 with our service id and the pid from the registry.
+func (c *Client) probe(ctx context.Context, inst *Instance) error {
+	ctx, cancel := context.WithTimeout(ctx, c.opts.ProbeTimeout)
+	defer cancel()
+
+	req, err := c.newRequest(ctx, inst, http.MethodGet, APIPrefix+"/status", nil, nil)
+	if err != nil {
+		return err
+	}
+	resp, err := c.control.Do(req)
+	if err != nil {
+		return fmt.Errorf("port %d did not answer a status probe (%v)", inst.Port, err)
+	}
+	defer drainAndClose(resp)
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("port %d answered the status probe with HTTP %d", inst.Port, resp.StatusCode)
+	}
+	var body statusBody
+	if err := json.NewDecoder(io.LimitReader(resp.Body, 1<<16)).Decode(&body); err != nil {
+		return fmt.Errorf("port %d answered the status probe with an unreadable body (%v)", inst.Port, err)
+	}
+	if body.Service != ServiceID {
+		return fmt.Errorf("port %d is served by %q, not %q — an unrelated process took the freed port",
+			inst.Port, body.Service, ServiceID)
+	}
+	if body.PID != inst.PID {
+		return fmt.Errorf("port %d is served by pid %d but the registry records pid %d",
+			inst.Port, body.PID, inst.PID)
+	}
+	return nil
+}
+
+// StartOrAttach returns the running daemon, starting one only if needed.
+// Single-instance is guaranteed by the exclusive start lock.
+func (c *Client) StartOrAttach(ctx context.Context) (*Instance, error) {
+	inst, err := c.Attach(ctx)
+	if err == nil {
+		return inst, nil
+	}
+	// A contract skew is the user's to resolve — starting a second daemon cannot
+	// help, and attaching anyway would 404 or misbehave silently.
+	if isVersionError(err) {
+		return nil, err
+	}
+	c.opts.Logf("daemon: no attachable instance (%v); starting one", err)
+
+	if _, derr := ensureHostDir(); derr != nil {
+		return nil, derr
+	}
+	lockPath, err := LockPath()
+	if err != nil {
+		return nil, err
+	}
+	lock, err := acquireLock(lockPath, c.opts.StartTimeout)
+	if err != nil {
+		return nil, err
+	}
+	defer lock.release()
+
+	// Re-check under the lock: a concurrent caller may have just started it.
+	inst, err = c.Attach(ctx)
+	if err == nil {
+		return inst, nil
+	}
+	if isVersionError(err) {
+		return nil, err
+	}
+
+	// A recorded pid that is alive but unresponsive is a daemon gone bad. The TUI
+	// deliberately does NOT kill it (unlike the Python client, which can verify
+	// the cmdline via psutil first): killing a possibly-recycled pid from a UI is
+	// worse than telling the user exactly what to run.
+	if rec, rerr := ReadInstance(); rerr == nil && c.opts.PIDAlive(rec.PID) {
+		return nil, &StartError{Reason: fmt.Sprintf(
+			"the recorded daemon pid %d is running but does not answer a status probe on port %d. "+
+				"Run `gaia daemon restart` to reclaim it", rec.PID, rec.Port)}
+	}
+
+	return c.spawnAndWait(ctx)
+}
+
+// gaiaDaemonStart builds the default launcher command.
+func gaiaDaemonStart(ctx context.Context) (*exec.Cmd, error) {
+	bin, err := exec.LookPath("gaia")
+	if err != nil {
+		return nil, &StartError{Reason: "the `gaia` CLI is not on PATH, so the daemon cannot be launched. " +
+			"Install GAIA (`pip install -e .` in the repo, or the released wheel) and retry"}
+	}
+	return exec.CommandContext(ctx, bin, "daemon", "start"), nil
+}
+
+// spawnAndWait launches the daemon and polls until a live instance registers.
+//
+// Unlike the Python client, the pid of the process we launch is NOT matched
+// against instance.json: `gaia daemon start` is a launcher that itself spawns the
+// detached daemon, so the registered pid belongs to its grandchild. Trust comes
+// from the two-check verify plus the version gate instead.
+func (c *Client) spawnAndWait(ctx context.Context) (*Instance, error) {
+	startCtx, cancel := context.WithTimeout(ctx, c.opts.StartTimeout)
+	defer cancel()
+
+	cmd, err := c.opts.StartCommand(startCtx)
+	if err != nil {
+		return nil, err
+	}
+	var out bytes.Buffer
+	if cmd.Stdout == nil {
+		cmd.Stdout = &out
+	}
+	if cmd.Stderr == nil {
+		cmd.Stderr = &out
+	}
+	if err := cmd.Start(); err != nil {
+		return nil, &StartError{Reason: fmt.Sprintf("failed to launch `%s`: %v", strings.Join(cmd.Args, " "), err)}
+	}
+
+	launcherDone := make(chan error, 1)
+	go func() { launcherDone <- cmd.Wait() }()
+
+	ticker := time.NewTicker(100 * time.Millisecond)
+	defer ticker.Stop()
+	cmdLine := strings.Join(cmd.Args, " ")
+	var launcherExit error
+	launcherExited := false
+
+	for {
+		inst, aerr := c.Attach(ctx)
+		if aerr == nil {
+			c.opts.Logf("daemon: started %s", inst)
+			return inst, nil
+		}
+		if isVersionError(aerr) {
+			return nil, aerr
+		}
+
+		// The launcher exits as soon as the daemon has registered, so a clean
+		// exit gets one more Attach above before we call it a failure. Reading
+		// `out` is only safe once Wait has returned.
+		if launcherExited {
+			reason := "exited cleanly but no live daemon registered"
+			if launcherExit != nil {
+				reason = fmt.Sprintf("exited with %v before a daemon registered", launcherExit)
+			}
+			return nil, &StartError{Reason: fmt.Sprintf("`%s` %s. Last attach error: %v.%s",
+				cmdLine, reason, aerr, quoteOutput(out.String()))}
+		}
+
+		select {
+		case launcherExit = <-launcherDone:
+			launcherExited = true
+		case <-ticker.C:
+		case <-startCtx.Done():
+			if cmd.Process != nil {
+				_ = cmd.Process.Kill()
+			}
+			<-launcherDone
+			return nil, &StartError{Reason: fmt.Sprintf(
+				"no daemon became healthy within %s — `%s` may be stuck binding a port or importing.%s",
+				c.opts.StartTimeout, cmdLine, quoteOutput(out.String()))}
+		}
+	}
+}
+
+// isVersionError reports whether err is (or wraps) a contract-version failure.
+func isVersionError(err error) bool {
+	var verr *VersionError
+	return errors.As(err, &verr)
+}
+
+func quoteOutput(s string) string {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return ""
+	}
+	if len(s) > maxLauncherOutput {
+		s = s[:maxLauncherOutput] + "…"
+	}
+	return " Launcher output:\n" + s
+}
+
+// Request is one authenticated call against the daemon.
+type Request struct {
+	Method string
+	// Path is daemon-root-relative, e.g. "/daemon/v1/agents/email/ensure" or
+	// "/v1/email/query".
+	Path string
+	// Body is the raw request body, nil for none. It is retained so the call can
+	// be replayed after a token refresh.
+	Body []byte
+	// Header carries extra request headers; Authorization is always set by Do.
+	Header http.Header
+	// HTTPClient overrides the client used for this call (streaming needs its own).
+	HTTPClient *http.Client
+	// Op names the operation for error messages, e.g. "stream the 'email' query".
+	Op string
+}
+
+// Do sends an authenticated request to the daemon.
+//
+// The client token rotates on every daemon restart, so a 401 is not a fatal
+// auth failure: instance.json is re-read, the fresh instance re-verified, and
+// the request replayed exactly once. The instance whose token authorized the
+// response is returned so the caller can reuse it (e.g. to cancel a run).
+//
+// The caller owns resp.Body and must close it.
+func (c *Client) Do(ctx context.Context, inst *Instance, r Request) (*http.Response, *Instance, error) {
+	resp, err := c.send(ctx, inst, r)
+	if err != nil {
+		return nil, inst, err
+	}
+	if resp.StatusCode != http.StatusUnauthorized {
+		return resp, inst, nil
+	}
+	drainAndClose(resp)
+
+	fresh, err := c.refresh(ctx, inst)
+	if err != nil {
+		return nil, inst, err
+	}
+	c.opts.Logf("daemon: client token rotated; retrying %s %s", r.Method, r.Path)
+
+	resp, err = c.send(ctx, fresh, r)
+	if err != nil {
+		return nil, fresh, err
+	}
+	if resp.StatusCode == http.StatusUnauthorized {
+		drainAndClose(resp)
+		return nil, fresh, &RequestError{
+			Op: c.opDescription(r),
+			Detail: "the daemon rejected the refreshed client token (HTTP 401). " +
+				"Run `gaia daemon restart` to mint a new one",
+		}
+	}
+	return resp, fresh, nil
+}
+
+// refresh re-reads instance.json after a 401 and re-verifies it. An unchanged
+// token means the 401 was not a rotation, so retrying would just 401 again —
+// that surfaces as a loud error instead.
+func (c *Client) refresh(ctx context.Context, old *Instance) (*Instance, error) {
+	fresh, err := ReadInstance()
+	if err != nil {
+		return nil, err
+	}
+	if fresh.Token == old.Token {
+		return nil, &RequestError{
+			Op: "authenticate against the daemon",
+			Detail: "it rejected the client token (HTTP 401) but instance.json still records the same token. " +
+				"Run `gaia daemon restart` to mint a new one",
+		}
+	}
+	if err := c.verify(ctx, fresh); err != nil {
+		return nil, err
+	}
+	if err := fresh.CheckVersion(); err != nil {
+		return nil, err
+	}
+	return fresh, nil
+}
+
+func (c *Client) send(ctx context.Context, inst *Instance, r Request) (*http.Response, error) {
+	req, err := c.newRequest(ctx, inst, r.Method, r.Path, r.Body, r.Header)
+	if err != nil {
+		return nil, err
+	}
+	httpClient := r.HTTPClient
+	if httpClient == nil {
+		httpClient = c.control
+	}
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return nil, &RequestError{Op: c.opDescription(r), Detail: err.Error()}
+	}
+	return resp, nil
+}
+
+func (c *Client) opDescription(r Request) string {
+	if r.Op != "" {
+		return r.Op
+	}
+	return fmt.Sprintf("call %s %s on the daemon", r.Method, r.Path)
+}
+
+func (c *Client) newRequest(
+	ctx context.Context,
+	inst *Instance,
+	method, path string,
+	body []byte,
+	header http.Header,
+) (*http.Request, error) {
+	var rdr io.Reader
+	if body != nil {
+		rdr = bytes.NewReader(body)
+	}
+	req, err := http.NewRequestWithContext(ctx, method, inst.BaseURL()+path, rdr)
+	if err != nil {
+		return nil, &RequestError{
+			Op:     fmt.Sprintf("build a %s request for %s", method, path),
+			Detail: err.Error(),
+		}
+	}
+	for k, vs := range header {
+		for _, v := range vs {
+			req.Header.Add(k, v)
+		}
+	}
+	req.Header.Set("Authorization", AuthScheme+" "+inst.Token)
+	return req, nil
+}
+
+// EnsureAgent starts-or-attaches the daemon and ensures agentID's sidecar is
+// running, returning the daemon instance a thin client drives it through.
+//
+// The ensure response body is deliberately NOT read: it carries the sidecar's
+// bearer token, which a thin client must never learn or hold. The TUI presents
+// only the daemon client token and the daemon swaps it server-side.
+//
+// Blocking — daemon start, sidecar spawn, and a possible first-run binary fetch
+// all happen here. Call it off the UI event loop.
+func (c *Client) EnsureAgent(ctx context.Context, agentID string) (*Instance, error) {
+	if agentID == "" {
+		return nil, &RequestError{Op: "ensure an agent sidecar", Detail: "no agent id was given"}
+	}
+	inst, err := c.StartOrAttach(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if err := inst.CheckAgentsFloor(); err != nil {
+		return nil, err
+	}
+
+	resp, inst, err := c.Do(ctx, inst, Request{
+		Method:     http.MethodPost,
+		Path:       APIPrefix + "/agents/" + agentID + "/ensure",
+		Body:       []byte("{}"),
+		Header:     http.Header{"Content-Type": []string{"application/json"}},
+		HTTPClient: c.ensure,
+		Op:         fmt.Sprintf("ensure the '%s' sidecar via the daemon", agentID),
+	})
+	if err != nil {
+		return nil, err
+	}
+	defer drainAndClose(resp)
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, &RequestError{
+			Op:     fmt.Sprintf("ensure the '%s' sidecar via the daemon", agentID),
+			Detail: ErrorDetail(resp),
+		}
+	}
+	return inst, nil
+}
+
+// CancelRun asks the relay to cancel a streaming run. Best-effort: the sidecar
+// may already be gone, so failures are logged, never raised.
+func (c *Client) CancelRun(inst *Instance, agentID, runID string) {
+	ctx, cancel := context.WithTimeout(context.Background(), defaultCancelTimeout)
+	defer cancel()
+
+	resp, _, err := c.Do(ctx, inst, Request{
+		Method:     http.MethodPost,
+		Path:       fmt.Sprintf("/v1/%s/query/%s/cancel", agentID, runID),
+		HTTPClient: c.cancel,
+		Op:         fmt.Sprintf("cancel the '%s' run", agentID),
+	})
+	if err != nil {
+		c.opts.Logf("daemon: best-effort cancel for '%s' run_id=%s failed: %v", agentID, runID, err)
+		return
+	}
+	defer drainAndClose(resp)
+	if resp.StatusCode != http.StatusOK {
+		c.opts.Logf("daemon: best-effort cancel for '%s' run_id=%s answered HTTP %d",
+			agentID, runID, resp.StatusCode)
+	}
+}
+
+// ErrorDetail extracts the actionable `detail` from a daemon error response,
+// falling back to the bare status line when the body carries none.
+func ErrorDetail(resp *http.Response) string {
+	raw, err := io.ReadAll(io.LimitReader(resp.Body, 1<<16))
+	if err != nil || len(raw) == 0 {
+		return fmt.Sprintf("HTTP %d", resp.StatusCode)
+	}
+	var body struct {
+		Detail json.RawMessage `json:"detail"`
+	}
+	if err := json.Unmarshal(raw, &body); err == nil && len(body.Detail) > 0 {
+		var s string
+		if err := json.Unmarshal(body.Detail, &s); err == nil && s != "" {
+			return fmt.Sprintf("HTTP %d: %s", resp.StatusCode, s)
+		}
+		return fmt.Sprintf("HTTP %d: %s", resp.StatusCode, string(body.Detail))
+	}
+	return fmt.Sprintf("HTTP %d: %s", resp.StatusCode, strings.TrimSpace(string(raw)))
+}
+
+// StreamHTTPClient builds an HTTP client for a long-lived SSE response: connect
+// fast (a dead daemon should fail quickly), then hold the stream open — a single
+// upstream chunk can span a whole agent-loop step, so read pacing is enforced by
+// the caller's own idle watchdog rather than a client-wide timeout.
+func StreamHTTPClient(connectTimeout time.Duration) *http.Client {
+	return &http.Client{
+		Transport: &http.Transport{
+			DialContext:         (&net.Dialer{Timeout: connectTimeout}).DialContext,
+			TLSHandshakeTimeout: connectTimeout,
+			// Loopback only, one stream at a time — no pooling benefit, and a
+			// pooled connection would outlive the run.
+			DisableKeepAlives: true,
+		},
+	}
+}
+
+func drainAndClose(resp *http.Response) {
+	if resp == nil || resp.Body == nil {
+		return
+	}
+	_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, 1<<16))
+	resp.Body.Close()
+}

--- a/tui/internal/daemon/client.go
+++ b/tui/internal/daemon/client.go
@@ -19,6 +19,11 @@ const (
 	// A live daemon answers loopback in milliseconds; a longer wait only delays
 	// reclaiming a dead one.
 	defaultProbeTimeout = 1500 * time.Millisecond
+	// Default for a general Do() call. Deliberately NOT the probe timeout: a
+	// relay call does real work (e.g. GET /v1/<agent>/init checks Lemonade, the
+	// model, and connectors) and 1.5s times it out. Callers with a known-slow or
+	// streaming call still pass their own client.
+	defaultRequestTimeout = 60 * time.Second
 	// Daemon start: spawn + bind + import.
 	defaultStartTimeout = 30 * time.Second
 	// Ensure: a first-run ensure may lazily fetch the sidecar binary before answering.
@@ -58,8 +63,12 @@ type Options struct {
 // every daemon restart, so it is never cached for the process lifetime.
 type Client struct {
 	opts Options
-	// control is used for short control-plane calls (the status probe).
+	// control is used ONLY for the status probe, whose timeout is deliberately
+	// tiny — a live daemon answers loopback in milliseconds.
 	control *http.Client
+	// request is the default for Do(): everything that is not a probe, not an
+	// ensure, and not a stream.
+	request *http.Client
 	// ensure is used for the possibly-very-slow ensure call.
 	ensure *http.Client
 	// cancel is used for the best-effort run-cancel POST, which must not be cut
@@ -90,6 +99,7 @@ func New(opts Options) *Client {
 	return &Client{
 		opts:    opts,
 		control: &http.Client{Timeout: opts.ProbeTimeout},
+		request: &http.Client{Timeout: defaultRequestTimeout},
 		ensure:  &http.Client{Timeout: opts.EnsureTimeout},
 		cancel:  &http.Client{Timeout: defaultCancelTimeout},
 	}
@@ -327,7 +337,8 @@ type Request struct {
 	Body []byte
 	// Header carries extra request headers; Authorization is always set by Do.
 	Header http.Header
-	// HTTPClient overrides the client used for this call (streaming needs its own).
+	// HTTPClient overrides the client used for this call. Required for a
+	// streaming call, and for anything that can outlast defaultRequestTimeout.
 	HTTPClient *http.Client
 	// Op names the operation for error messages, e.g. "stream the 'email' query".
 	Op string
@@ -403,7 +414,7 @@ func (c *Client) send(ctx context.Context, inst *Instance, r Request) (*http.Res
 	}
 	httpClient := r.HTTPClient
 	if httpClient == nil {
-		httpClient = c.control
+		httpClient = c.request
 	}
 	resp, err := httpClient.Do(req)
 	if err != nil {
@@ -506,6 +517,13 @@ func (c *Client) CancelRun(inst *Instance, agentID, runID string) {
 		return
 	}
 	defer drainAndClose(resp)
+	// 404 is the documented answer for a run that is no longer in flight, which
+	// is exactly the case when we abandon a stream that already ended — that is
+	// success, not a failure worth reporting as one.
+	if resp.StatusCode == http.StatusNotFound {
+		c.opts.Logf("daemon: '%s' run_id=%s had already finished; nothing to cancel", agentID, runID)
+		return
+	}
 	if resp.StatusCode != http.StatusOK {
 		c.opts.Logf("daemon: best-effort cancel for '%s' run_id=%s answered HTTP %d",
 			agentID, runID, resp.StatusCode)

--- a/tui/internal/daemon/client.go
+++ b/tui/internal/daemon/client.go
@@ -28,8 +28,6 @@ const (
 	defaultStartTimeout = 30 * time.Second
 	// Ensure: a first-run ensure may lazily fetch the sidecar binary before answering.
 	defaultEnsureTimeout = 900 * time.Second
-	// Cancel must never wait out a stream read timeout.
-	defaultCancelTimeout = 10 * time.Second
 	// Cap on captured launcher output quoted back in an error.
 	maxLauncherOutput = 4096
 )
@@ -71,9 +69,6 @@ type Client struct {
 	request *http.Client
 	// ensure is used for the possibly-very-slow ensure call.
 	ensure *http.Client
-	// cancel is used for the best-effort run-cancel POST, which must not be cut
-	// short by the probe timeout nor wait out a stream read timeout.
-	cancel *http.Client
 }
 
 // New builds a Client, filling unset options with their defaults.
@@ -101,7 +96,6 @@ func New(opts Options) *Client {
 		control: &http.Client{Timeout: opts.ProbeTimeout},
 		request: &http.Client{Timeout: defaultRequestTimeout},
 		ensure:  &http.Client{Timeout: opts.EnsureTimeout},
-		cancel:  &http.Client{Timeout: defaultCancelTimeout},
 	}
 }
 
@@ -131,10 +125,14 @@ func (c *Client) Attach(ctx context.Context) (*Instance, error) {
 func (c *Client) verify(ctx context.Context, inst *Instance) error {
 	path, _ := InstancePath()
 	if !c.opts.PIDAlive(inst.PID) {
-		return &StaleError{Path: path, Reason: fmt.Sprintf("its pid %d is not running", inst.PID)}
+		return &StaleError{
+			Kind:   StalePIDDead,
+			Path:   path,
+			Reason: fmt.Sprintf("its pid %d is not running", inst.PID),
+		}
 	}
-	if err := c.probe(ctx, inst); err != nil {
-		return &StaleError{Path: path, Reason: err.Error()}
+	if kind, err := c.probe(ctx, inst); err != nil {
+		return &StaleError{Kind: kind, Path: path, Reason: err.Error()}
 	}
 	return nil
 }
@@ -144,38 +142,48 @@ type statusBody struct {
 	PID     int    `json:"pid"`
 }
 
-// probe checks the recorded port with the recorded token. It returns nil only if
-// the server answers 200 with our service id and the pid from the registry.
-func (c *Client) probe(ctx context.Context, inst *Instance) error {
+// probe checks the recorded port with the recorded token. It returns a nil error
+// only if the server answers 200 with our service id and the pid from the
+// registry. The returned StaleKind says whether a failure looks like OUR daemon
+// misbehaving or an unrelated process holding a recycled port.
+func (c *Client) probe(ctx context.Context, inst *Instance) (StaleKind, error) {
 	ctx, cancel := context.WithTimeout(ctx, c.opts.ProbeTimeout)
 	defer cancel()
 
 	req, err := c.newRequest(ctx, inst, http.MethodGet, APIPrefix+"/status", nil, nil)
 	if err != nil {
-		return err
+		return StaleUnresponsive, err
 	}
 	resp, err := c.control.Do(req)
 	if err != nil {
-		return fmt.Errorf("port %d did not answer a status probe (%v)", inst.Port, err)
+		// Refused / timed out: nothing is serving, so this is our own daemon
+		// wedged or dying rather than a foreign process.
+		return StaleUnresponsive, fmt.Errorf("port %d did not answer a status probe (%v)", inst.Port, err)
 	}
 	defer drainAndClose(resp)
 
 	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("port %d answered the status probe with HTTP %d", inst.Port, resp.StatusCode)
+		// 401 and 5xx are shapes OUR daemon produces; any other 4xx is most
+		// likely a foreign HTTP server that does not know this route.
+		kind := StaleForeign
+		if resp.StatusCode == http.StatusUnauthorized || resp.StatusCode >= 500 {
+			kind = StaleUnresponsive
+		}
+		return kind, fmt.Errorf("port %d answered the status probe with HTTP %d", inst.Port, resp.StatusCode)
 	}
 	var body statusBody
 	if err := json.NewDecoder(io.LimitReader(resp.Body, 1<<16)).Decode(&body); err != nil {
-		return fmt.Errorf("port %d answered the status probe with an unreadable body (%v)", inst.Port, err)
+		return StaleForeign, fmt.Errorf("port %d answered the status probe with an unreadable body (%v)", inst.Port, err)
 	}
 	if body.Service != ServiceID {
-		return fmt.Errorf("port %d is served by %q, not %q — an unrelated process took the freed port",
+		return StaleForeign, fmt.Errorf("port %d is served by %q, not %q — an unrelated process took the freed port",
 			inst.Port, body.Service, ServiceID)
 	}
 	if body.PID != inst.PID {
-		return fmt.Errorf("port %d is served by pid %d but the registry records pid %d",
+		return StaleForeign, fmt.Errorf("port %d is served by pid %d but the registry records pid %d",
 			inst.Port, body.PID, inst.PID)
 	}
-	return nil
+	return StaleCorrupt, nil
 }
 
 // StartOrAttach returns the running daemon, starting one only if needed.
@@ -214,14 +222,22 @@ func (c *Client) StartOrAttach(ctx context.Context) (*Instance, error) {
 		return nil, err
 	}
 
-	// A recorded pid that is alive but unresponsive is a daemon gone bad. The TUI
-	// deliberately does NOT kill it (unlike the Python client, which can verify
-	// the cmdline via psutil first): killing a possibly-recycled pid from a UI is
-	// worse than telling the user exactly what to run.
-	if rec, rerr := ReadInstance(); rerr == nil && c.opts.PIDAlive(rec.PID) {
-		return nil, &StartError{Reason: fmt.Sprintf(
-			"the recorded daemon pid %d is running but does not answer a status probe on port %d. "+
-				"Run `gaia daemon restart` to reclaim it", rec.PID, rec.Port)}
+	// A recorded pid that is alive AND whose port looks like our own wedged
+	// daemon must not be silently replaced. The TUI deliberately does NOT kill it
+	// (unlike the Python client, which can verify the cmdline via psutil first):
+	// killing a possibly-recycled pid from a UI is worse than telling the user
+	// exactly what to run.
+	//
+	// A FOREIGN answer on that port is different: the probe already proved the
+	// record is garbage (recycled pid, port taken by something else), so blocking
+	// on it would leave the TUI permanently unable to start a daemon.
+	var stale *StaleError
+	if errors.As(err, &stale) && stale.Kind == StaleUnresponsive {
+		if rec, rerr := ReadInstance(); rerr == nil && c.opts.PIDAlive(rec.PID) {
+			return nil, &StartError{Reason: fmt.Sprintf(
+				"the recorded daemon pid %d is running but does not answer a status probe on port %d. "+
+					"Run `gaia daemon restart` to reclaim it", rec.PID, rec.Port)}
+		}
 	}
 
 	return c.spawnAndWait(ctx)
@@ -250,6 +266,11 @@ func (c *Client) spawnAndWait(ctx context.Context) (*Instance, error) {
 	cmd, err := c.opts.StartCommand(startCtx)
 	if err != nil {
 		return nil, err
+	}
+	if cmd == nil {
+		return nil, &StartError{
+			Reason: "the configured daemon start command returned no command to run",
+		}
 	}
 	var out bytes.Buffer
 	if cmd.Stdout == nil {
@@ -362,7 +383,7 @@ func (c *Client) Do(ctx context.Context, inst *Instance, r Request) (*http.Respo
 	}
 	drainAndClose(resp)
 
-	fresh, err := c.refresh(ctx, inst)
+	fresh, err := c.refresh(ctx, inst, r.Path)
 	if err != nil {
 		return nil, inst, err
 	}
@@ -386,12 +407,23 @@ func (c *Client) Do(ctx context.Context, inst *Instance, r Request) (*http.Respo
 // refresh re-reads instance.json after a 401 and re-verifies it. An unchanged
 // token means the 401 was not a rotation, so retrying would just 401 again —
 // that surfaces as a loud error instead.
-func (c *Client) refresh(ctx context.Context, old *Instance) (*Instance, error) {
+func (c *Client) refresh(ctx context.Context, old *Instance, path string) (*Instance, error) {
 	fresh, err := ReadInstance()
 	if err != nil {
 		return nil, err
 	}
 	if fresh.Token == old.Token {
+		// A 401 on a RELAYED path may be the sidecar refusing its own bearer,
+		// which a daemon restart does not fix — pointing the user at
+		// `gaia daemon restart` would send them down the wrong path.
+		if !strings.HasPrefix(path, APIPrefix) {
+			return nil, &RequestError{
+				Op: fmt.Sprintf("authenticate the relayed call to %s", path),
+				Detail: "the daemon client token is current, so the 401 came from the agent sidecar " +
+					"rather than the daemon. Restart the sidecar with " +
+					"`gaia daemon stop-agent <id>` and retry",
+			}
+		}
 		return nil, &RequestError{
 			Op: "authenticate against the daemon",
 			Detail: "it rejected the client token (HTTP 401) but instance.json still records the same token. " +
@@ -500,34 +532,11 @@ func (c *Client) EnsureAgent(ctx context.Context, agentID string) (*Instance, er
 	return inst, nil
 }
 
-// CancelRun asks the relay to cancel a streaming run. Best-effort: the sidecar
-// may already be gone, so failures are logged, never raised.
-func (c *Client) CancelRun(inst *Instance, agentID, runID string) {
-	ctx, cancel := context.WithTimeout(context.Background(), defaultCancelTimeout)
-	defer cancel()
-
-	resp, _, err := c.Do(ctx, inst, Request{
-		Method:     http.MethodPost,
-		Path:       fmt.Sprintf("/v1/%s/query/%s/cancel", agentID, runID),
-		HTTPClient: c.cancel,
-		Op:         fmt.Sprintf("cancel the '%s' run", agentID),
-	})
-	if err != nil {
-		c.opts.Logf("daemon: best-effort cancel for '%s' run_id=%s failed: %v", agentID, runID, err)
-		return
-	}
-	defer drainAndClose(resp)
-	// 404 is the documented answer for a run that is no longer in flight, which
-	// is exactly the case when we abandon a stream that already ended — that is
-	// success, not a failure worth reporting as one.
-	if resp.StatusCode == http.StatusNotFound {
-		c.opts.Logf("daemon: '%s' run_id=%s had already finished; nothing to cancel", agentID, runID)
-		return
-	}
-	if resp.StatusCode != http.StatusOK {
-		c.opts.Logf("daemon: best-effort cancel for '%s' run_id=%s answered HTTP %d",
-			agentID, runID, resp.StatusCode)
-	}
+// Logf emits a diagnostic through the client's configured logger. Exported so
+// callers that own an agent-contract call (e.g. the SSE transport's cancel) log
+// through the same channel. Never pass a raw token.
+func (c *Client) Logf(format string, args ...any) {
+	c.opts.Logf(format, args...)
 }
 
 // ErrorDetail extracts the actionable `detail` from a daemon error response,
@@ -554,11 +563,18 @@ func ErrorDetail(resp *http.Response) string {
 // fast (a dead daemon should fail quickly), then hold the stream open — a single
 // upstream chunk can span a whole agent-loop step, so read pacing is enforced by
 // the caller's own idle watchdog rather than a client-wide timeout.
-func StreamHTTPClient(connectTimeout time.Duration) *http.Client {
+//
+// headerTimeout bounds the wait for the response STATUS LINE only, which no
+// client-wide timeout can express without also capping the stream. Without it a
+// daemon that completes the handshake and never answers hangs the caller
+// forever — the reference implementation gets this for free because requests'
+// read timeout also covers the header wait.
+func StreamHTTPClient(connectTimeout, headerTimeout time.Duration) *http.Client {
 	return &http.Client{
 		Transport: &http.Transport{
-			DialContext:         (&net.Dialer{Timeout: connectTimeout}).DialContext,
-			TLSHandshakeTimeout: connectTimeout,
+			DialContext:           (&net.Dialer{Timeout: connectTimeout}).DialContext,
+			TLSHandshakeTimeout:   connectTimeout,
+			ResponseHeaderTimeout: headerTimeout,
 			// Loopback only, one stream at a time — no pooling benefit, and a
 			// pooled connection would outlive the run.
 			DisableKeepAlives: true,

--- a/tui/internal/daemon/daemon_test.go
+++ b/tui/internal/daemon/daemon_test.go
@@ -732,3 +732,173 @@ func containsAuth(seen []string, token string) bool {
 	}
 	return false
 }
+
+// A recycled pid whose port is answered by an UNRELATED service means the record
+// is garbage — the probe already proved it. Blocking on it (as an earlier version
+// did, keying only off pid liveness) left the TUI permanently unable to start a
+// daemon until the user intervened.
+func TestStartOrAttachReclaimsARecycledPortFromAForeignService(t *testing.T) {
+	f := newFakeDaemon(t)
+	f.writeInstance(nil)
+	f.mu.Lock()
+	f.service = "some-unrelated-server" // the freed port was taken by something else
+	f.mu.Unlock()
+
+	// The launcher registers a fresh, healthy instance.
+	fresh := &Instance{
+		PID: os.Getpid(), Port: f.port(), Token: "token-A",
+		Host: DefaultHost, APIVersion: "1.1", Service: ServiceID,
+	}
+	payload, err := json.Marshal(fresh)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	spawned := false
+	c := testClient(t, func(o *Options) {
+		// The recorded pid IS alive (it is this test process).
+		o.StartCommand = func(ctx context.Context) (*exec.Cmd, error) {
+			spawned = true
+			f.mu.Lock()
+			f.service = ServiceID // the new daemon answers properly
+			f.mu.Unlock()
+			return launcher(t, f.dir, string(payload), "")(ctx)
+		}
+	})
+
+	if _, err := c.StartOrAttach(context.Background()); err != nil {
+		t.Fatalf("StartOrAttach must reclaim a garbage record, got: %v", err)
+	}
+	if !spawned {
+		t.Error("a foreign service on the recorded port must not block starting a daemon")
+	}
+}
+
+// The mirror case: our OWN pid alive and the port refusing/erroring is a wedged
+// daemon, which must NOT be silently replaced.
+func TestStaleKindClassification(t *testing.T) {
+	f := newFakeDaemon(t)
+	f.writeInstance(nil)
+
+	cases := []struct {
+		name   string
+		setup  func()
+		want   StaleKind
+		reason string
+	}{
+		{"foreign service", func() { f.mu.Lock(); f.service = "other"; f.mu.Unlock() }, StaleForeign, "took the freed port"},
+		{"pid mismatch", func() {
+			f.mu.Lock()
+			f.service = ServiceID
+			f.reportedPID = os.Getpid() + 100000
+			f.mu.Unlock()
+		}, StaleForeign, "registry records pid"},
+		{"our daemon 5xx", func() {
+			f.mu.Lock()
+			f.reportedPID = os.Getpid()
+			f.statusCode = http.StatusInternalServerError
+			f.mu.Unlock()
+		}, StaleUnresponsive, "HTTP 500"},
+		{"foreign 404", func() { f.mu.Lock(); f.statusCode = http.StatusNotFound; f.mu.Unlock() }, StaleForeign, "HTTP 404"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			tc.setup()
+			_, err := testClient(t, nil).Attach(context.Background())
+			var se *StaleError
+			if !asError(err, &se) {
+				t.Fatalf("expected *StaleError, got %#v (%v)", err, err)
+			}
+			if se.Kind != tc.want {
+				t.Errorf("Kind = %d, want %d (%v)", se.Kind, tc.want, err)
+			}
+			if !strings.Contains(err.Error(), tc.reason) {
+				t.Errorf("error %q must mention %q", err, tc.reason)
+			}
+		})
+	}
+}
+
+func TestStartOrAttachRejectsANilStartCommand(t *testing.T) {
+	newFakeDaemon(t) // no instance.json written
+
+	c := testClient(t, func(o *Options) {
+		o.StartCommand = func(context.Context) (*exec.Cmd, error) { return nil, nil }
+	})
+	_, err := c.StartOrAttach(context.Background())
+	var se *StartError
+	if !asError(err, &se) {
+		t.Fatalf("expected *StartError rather than a panic, got %#v (%v)", err, err)
+	}
+}
+
+// A 401 on a RELAYED path is the sidecar refusing its bearer, which a daemon
+// restart does not fix — the remedy must not point at the daemon.
+func TestRelayed401BlamesTheSidecarNotTheDaemon(t *testing.T) {
+	f := newFakeDaemon(t)
+	f.writeInstance(nil)
+
+	c := testClient(t, nil)
+	inst, err := c.Attach(context.Background())
+	if err != nil {
+		t.Fatalf("Attach: %v", err)
+	}
+	f.mu.Lock()
+	f.token = "server-only-token" // every request now 401s, file unchanged
+	f.mu.Unlock()
+
+	_, _, err = c.Do(context.Background(), inst, Request{
+		Method: http.MethodPost, Path: "/v1/email/query",
+	})
+	if err == nil {
+		t.Fatal("expected an error")
+	}
+	if !strings.Contains(err.Error(), "sidecar") {
+		t.Errorf("a relayed 401 must blame the sidecar: %v", err)
+	}
+	if strings.Contains(err.Error(), "gaia daemon restart") {
+		t.Errorf("a relayed 401 must not send the user to restart the daemon: %v", err)
+	}
+
+	// The daemon-plane equivalent keeps the daemon remedy.
+	_, _, err = c.Do(context.Background(), inst, Request{
+		Method: http.MethodGet, Path: APIPrefix + "/status",
+	})
+	if err == nil || !strings.Contains(err.Error(), "gaia daemon restart") {
+		t.Errorf("a daemon-plane 401 must keep the daemon remedy: %v", err)
+	}
+}
+
+// If the daemon still rejects the refreshed token, that must surface as a loud
+// error rather than an endless retry loop.
+func TestDoFailsWhenTheRefreshedTokenIsAlsoRejected(t *testing.T) {
+	f := newFakeDaemon(t)
+	f.writeInstance(nil)
+
+	c := testClient(t, nil)
+	inst, err := c.Attach(context.Background())
+	if err != nil {
+		t.Fatalf("Attach: %v", err)
+	}
+
+	// instance.json rotates to token-B (so the retry is attempted) but the server
+	// requires a third token neither side has.
+	f.writeInstance(func(i *Instance) { i.Token = "token-B" })
+	f.mu.Lock()
+	f.token = "token-C"
+	f.mu.Unlock()
+
+	_, _, err = c.Do(context.Background(), inst, Request{
+		Method: http.MethodGet,
+		Path:   APIPrefix + "/status",
+	})
+	if err == nil {
+		t.Fatal("expected an error when the refreshed token is also rejected")
+	}
+	// The refreshed instance cannot pass the liveness probe either, so the failure
+	// must name the stale registry rather than loop.
+	if !strings.Contains(err.Error(), "cannot be trusted") && !strings.Contains(err.Error(), "401") {
+		t.Errorf("error should explain the auth failure: %v", err)
+	}
+}

--- a/tui/internal/daemon/daemon_test.go
+++ b/tui/internal/daemon/daemon_test.go
@@ -1,0 +1,734 @@
+package daemon
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// sidecarSecret stands in for the sidecar bearer the daemon returns from
+// /ensure. A thin client must never end up holding it.
+const sidecarSecret = "SIDECAR-BEARER-MUST-NOT-LEAK"
+
+// fakeDaemon is an httptest server that answers the daemon's control plane,
+// paired with an instance.json in an isolated GAIA_DAEMON_HOME.
+type fakeDaemon struct {
+	t   *testing.T
+	srv *httptest.Server
+	dir string
+
+	mu           sync.Mutex
+	token        string
+	reportedPID  int
+	service      string
+	statusCode   int
+	ensureStatus int
+	ensureDetail string
+	authSeen     []string
+	paths        []string
+}
+
+func newFakeDaemon(t *testing.T) *fakeDaemon {
+	t.Helper()
+
+	dir := t.TempDir()
+	t.Setenv(EnvHome, dir)
+
+	f := &fakeDaemon{
+		t:            t,
+		dir:          dir,
+		token:        "token-A",
+		reportedPID:  os.Getpid(),
+		service:      ServiceID,
+		statusCode:   http.StatusOK,
+		ensureStatus: http.StatusOK,
+	}
+	f.srv = httptest.NewServer(http.HandlerFunc(f.handle))
+	t.Cleanup(f.srv.Close)
+
+	if f.port() == ReservedPort {
+		t.Fatalf("test server bound the reserved port %d", ReservedPort)
+	}
+	return f
+}
+
+func (f *fakeDaemon) port() int {
+	u, err := url.Parse(f.srv.URL)
+	if err != nil {
+		f.t.Fatalf("parse server URL: %v", err)
+	}
+	p, err := strconv.Atoi(u.Port())
+	if err != nil {
+		f.t.Fatalf("parse server port: %v", err)
+	}
+	return p
+}
+
+func (f *fakeDaemon) handle(w http.ResponseWriter, r *http.Request) {
+	f.mu.Lock()
+	token := f.token
+	f.authSeen = append(f.authSeen, r.Header.Get("Authorization"))
+	f.paths = append(f.paths, r.Method+" "+r.URL.Path)
+	f.mu.Unlock()
+
+	if r.Header.Get("Authorization") != AuthScheme+" "+token {
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte(`{"detail":"invalid or expired client token"}`))
+		return
+	}
+
+	switch {
+	case r.URL.Path == APIPrefix+"/status":
+		f.mu.Lock()
+		code, service, pid := f.statusCode, f.service, f.reportedPID
+		f.mu.Unlock()
+		if code != http.StatusOK {
+			w.WriteHeader(code)
+			return
+		}
+		writeJSON(w, map[string]any{"service": service, "pid": pid, "api_version": DAEMONAPIVersionForTest})
+
+	case strings.HasSuffix(r.URL.Path, "/ensure"):
+		f.mu.Lock()
+		code, detail := f.ensureStatus, f.ensureDetail
+		f.mu.Unlock()
+		if code != http.StatusOK {
+			w.WriteHeader(code)
+			writeJSON(w, map[string]any{"detail": detail})
+			return
+		}
+		// The real daemon's ensure response carries the sidecar bearer; the
+		// client must discard it.
+		writeJSON(w, map[string]any{"port": 51999, "token": sidecarSecret, "state": "running"})
+
+	default:
+		w.WriteHeader(http.StatusNotFound)
+		writeJSON(w, map[string]any{"detail": "no route " + r.URL.Path})
+	}
+}
+
+// DAEMONAPIVersionForTest is what the fake reports in its status body. The client
+// reads the contract version from instance.json, not from the probe, so this is
+// only cosmetic.
+const DAEMONAPIVersionForTest = "1.1"
+
+func writeJSON(w http.ResponseWriter, v any) {
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(v)
+}
+
+// writeInstance persists an instance.json into the fake's home directory.
+func (f *fakeDaemon) writeInstance(mutate func(*Instance)) *Instance {
+	f.t.Helper()
+
+	f.mu.Lock()
+	inst := &Instance{
+		PID:        os.Getpid(),
+		Port:       f.port(),
+		Token:      f.token,
+		Host:       DefaultHost,
+		APIVersion: "1.1",
+		Service:    ServiceID,
+		StartedAt:  1.0,
+	}
+	f.mu.Unlock()
+
+	if mutate != nil {
+		mutate(inst)
+	}
+	raw, err := json.MarshalIndent(inst, "", "  ")
+	if err != nil {
+		f.t.Fatalf("marshal instance: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(f.dir, "instance.json"), raw, 0o600); err != nil {
+		f.t.Fatalf("write instance.json: %v", err)
+	}
+	return inst
+}
+
+func (f *fakeDaemon) rotateToken(next string) {
+	f.mu.Lock()
+	f.token = next
+	f.mu.Unlock()
+	f.writeInstance(func(i *Instance) { i.Token = next })
+}
+
+func (f *fakeDaemon) sawPath(want string) bool {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	for _, p := range f.paths {
+		if p == want {
+			return true
+		}
+	}
+	return false
+}
+
+// testClient builds a Client with fast timeouts and no real launcher.
+func testClient(t *testing.T, mutate func(*Options)) *Client {
+	t.Helper()
+	opts := Options{
+		ProbeTimeout:  2 * time.Second,
+		StartTimeout:  3 * time.Second,
+		EnsureTimeout: 5 * time.Second,
+		StartCommand: func(context.Context) (*exec.Cmd, error) {
+			return nil, &StartError{Reason: "no launcher was configured for this test"}
+		},
+		Logf: func(format string, args ...any) { t.Logf(format, args...) },
+	}
+	if mutate != nil {
+		mutate(&opts)
+	}
+	return New(opts)
+}
+
+// --- trust checks -----------------------------------------------------------
+
+func TestAttachHappyPath(t *testing.T) {
+	f := newFakeDaemon(t)
+	f.writeInstance(nil)
+
+	inst, err := testClient(t, nil).Attach(context.Background())
+	if err != nil {
+		t.Fatalf("Attach: %v", err)
+	}
+	if inst.Port != f.port() || inst.Token != "token-A" {
+		t.Errorf("unexpected instance: %+v", inst)
+	}
+}
+
+func TestAttachMissingInstanceFile(t *testing.T) {
+	newFakeDaemon(t) // sets GAIA_DAEMON_HOME, writes nothing
+
+	_, err := testClient(t, nil).Attach(context.Background())
+	var nr *NotRunningError
+	if !asError(err, &nr) {
+		t.Fatalf("expected *NotRunningError, got %#v (%v)", err, err)
+	}
+	if !strings.Contains(err.Error(), "gaia daemon start") {
+		t.Errorf("error must name the remedy: %v", err)
+	}
+}
+
+func TestAttachMalformedInstanceFile(t *testing.T) {
+	f := newFakeDaemon(t)
+	if err := os.WriteFile(filepath.Join(f.dir, "instance.json"), []byte("{not json"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := testClient(t, nil).Attach(context.Background())
+	var se *StaleError
+	if !asError(err, &se) {
+		t.Fatalf("expected *StaleError, got %#v (%v)", err, err)
+	}
+	if !strings.Contains(err.Error(), "gaia daemon restart") {
+		t.Errorf("error must name the remedy: %v", err)
+	}
+}
+
+func TestAttachDeadPID(t *testing.T) {
+	f := newFakeDaemon(t)
+	f.writeInstance(nil)
+
+	c := testClient(t, func(o *Options) {
+		o.PIDAlive = func(int) bool { return false }
+	})
+	_, err := c.Attach(context.Background())
+	var se *StaleError
+	if !asError(err, &se) {
+		t.Fatalf("expected *StaleError, got %#v (%v)", err, err)
+	}
+	if !strings.Contains(err.Error(), "not running") {
+		t.Errorf("error must say the pid is dead: %v", err)
+	}
+	// The probe must not even be attempted once the pid is known dead.
+	if f.sawPath("GET " + APIPrefix + "/status") {
+		t.Error("a dead pid must short-circuit before probing")
+	}
+}
+
+func TestAttachPIDMismatch(t *testing.T) {
+	f := newFakeDaemon(t)
+	f.writeInstance(nil)
+	f.mu.Lock()
+	f.reportedPID = os.Getpid() + 100000 // a different process answers the port
+	f.mu.Unlock()
+
+	_, err := testClient(t, nil).Attach(context.Background())
+	var se *StaleError
+	if !asError(err, &se) {
+		t.Fatalf("expected *StaleError, got %#v (%v)", err, err)
+	}
+	if !strings.Contains(err.Error(), "registry records pid") {
+		t.Errorf("error must name the pid mismatch: %v", err)
+	}
+}
+
+func TestAttachWrongService(t *testing.T) {
+	f := newFakeDaemon(t)
+	f.writeInstance(nil)
+	f.mu.Lock()
+	f.service = "some-other-server"
+	f.mu.Unlock()
+
+	_, err := testClient(t, nil).Attach(context.Background())
+	var se *StaleError
+	if !asError(err, &se) {
+		t.Fatalf("expected *StaleError, got %#v (%v)", err, err)
+	}
+	if !strings.Contains(err.Error(), "took the freed port") {
+		t.Errorf("error must explain the recycled port: %v", err)
+	}
+}
+
+func TestAttachStatusNon200(t *testing.T) {
+	f := newFakeDaemon(t)
+	f.writeInstance(nil)
+	f.mu.Lock()
+	f.statusCode = http.StatusInternalServerError
+	f.mu.Unlock()
+
+	_, err := testClient(t, nil).Attach(context.Background())
+	var se *StaleError
+	if !asError(err, &se) {
+		t.Fatalf("expected *StaleError, got %#v (%v)", err, err)
+	}
+}
+
+func TestAttachMajorVersionMismatch(t *testing.T) {
+	f := newFakeDaemon(t)
+	f.writeInstance(func(i *Instance) { i.APIVersion = "2.0" })
+
+	_, err := testClient(t, nil).Attach(context.Background())
+	var ve *VersionError
+	if !asError(err, &ve) {
+		t.Fatalf("expected *VersionError, got %#v (%v)", err, err)
+	}
+	if !strings.Contains(err.Error(), "gaia daemon restart") {
+		t.Errorf("error must name the remedy: %v", err)
+	}
+}
+
+func TestAttachUnparsableVersion(t *testing.T) {
+	f := newFakeDaemon(t)
+	f.writeInstance(func(i *Instance) { i.APIVersion = "nightly" })
+
+	_, err := testClient(t, nil).Attach(context.Background())
+	var ve *VersionError
+	if !asError(err, &ve) {
+		t.Fatalf("expected *VersionError, got %#v (%v)", err, err)
+	}
+}
+
+func TestEnsureAgentRejectsMinorBelowAgentsFloor(t *testing.T) {
+	f := newFakeDaemon(t)
+	f.writeInstance(func(i *Instance) { i.APIVersion = "1.0" })
+
+	// A pre-#2142 daemon passes the MAJOR gate, so plain Attach succeeds …
+	if _, err := testClient(t, nil).Attach(context.Background()); err != nil {
+		t.Fatalf("Attach on v1.0 should pass the MAJOR gate: %v", err)
+	}
+	// … but every agents route would 404, so EnsureAgent must refuse.
+	_, err := testClient(t, nil).EnsureAgent(context.Background(), "email")
+	var ve *VersionError
+	if !asError(err, &ve) {
+		t.Fatalf("expected *VersionError, got %#v (%v)", err, err)
+	}
+	if !strings.Contains(err.Error(), "v1.1+") {
+		t.Errorf("error must name the required floor: %v", err)
+	}
+	if f.sawPath("POST " + APIPrefix + "/agents/email/ensure") {
+		t.Error("the ensure call must not be attempted below the agents floor")
+	}
+}
+
+func TestAttachRejectsReservedPort(t *testing.T) {
+	f := newFakeDaemon(t)
+	f.writeInstance(func(i *Instance) { i.Port = ReservedPort })
+
+	_, err := testClient(t, nil).Attach(context.Background())
+	var se *StaleError
+	if !asError(err, &se) {
+		t.Fatalf("expected *StaleError, got %#v (%v)", err, err)
+	}
+	if !strings.Contains(err.Error(), strconv.Itoa(ReservedPort)) {
+		t.Errorf("error must name the reserved port: %v", err)
+	}
+}
+
+func TestReadInstanceRejectsIncompleteRecords(t *testing.T) {
+	f := newFakeDaemon(t)
+
+	cases := []struct {
+		name   string
+		mutate func(*Instance)
+		want   string
+	}{
+		{"no pid", func(i *Instance) { i.PID = 0 }, "no usable pid"},
+		{"no token", func(i *Instance) { i.Token = "" }, "no client token"},
+		{"no api_version", func(i *Instance) { i.APIVersion = "" }, "no api_version"},
+		{"foreign service", func(i *Instance) { i.Service = "not-gaia" }, "written by service"},
+		{"bad port", func(i *Instance) { i.Port = 70000 }, "invalid port"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			f.writeInstance(tc.mutate)
+			_, err := ReadInstance()
+			var se *StaleError
+			if !asError(err, &se) {
+				t.Fatalf("expected *StaleError, got %#v (%v)", err, err)
+			}
+			if !strings.Contains(err.Error(), tc.want) {
+				t.Errorf("error %q must mention %q", err, tc.want)
+			}
+		})
+	}
+}
+
+// --- token rotation ---------------------------------------------------------
+
+func TestDoRetriesOnceAfterTokenRotation(t *testing.T) {
+	f := newFakeDaemon(t)
+	f.writeInstance(nil)
+
+	c := testClient(t, nil)
+	inst, err := c.Attach(context.Background())
+	if err != nil {
+		t.Fatalf("Attach: %v", err)
+	}
+
+	// The daemon restarted: it now requires token-B and instance.json records
+	// token-B, while the caller still holds the token-A instance in memory.
+	f.rotateToken("token-B")
+
+	resp, fresh, err := c.Do(context.Background(), inst, Request{
+		Method: http.MethodGet,
+		Path:   APIPrefix + "/status",
+	})
+	if err != nil {
+		t.Fatalf("Do: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("after the retry, status = %d, want 200", resp.StatusCode)
+	}
+	if fresh.Token != "token-B" {
+		t.Errorf("returned instance still carries the old token")
+	}
+	f.mu.Lock()
+	auths := append([]string(nil), f.authSeen...)
+	f.mu.Unlock()
+	if !containsAuth(auths, "token-A") || !containsAuth(auths, "token-B") {
+		t.Errorf("expected one attempt per token, saw %d requests", len(auths))
+	}
+}
+
+func TestDoFailsWhenTokenDidNotRotate(t *testing.T) {
+	f := newFakeDaemon(t)
+	f.writeInstance(nil)
+
+	c := testClient(t, nil)
+	inst, err := c.Attach(context.Background())
+	if err != nil {
+		t.Fatalf("Attach: %v", err)
+	}
+	// The server rejects everything but instance.json still records token-A, so a
+	// retry could only 401 again.
+	f.mu.Lock()
+	f.token = "token-Z"
+	f.mu.Unlock()
+
+	_, _, err = c.Do(context.Background(), inst, Request{
+		Method: http.MethodGet,
+		Path:   APIPrefix + "/status",
+	})
+	if err == nil {
+		t.Fatal("expected an error for an unrotated 401")
+	}
+	if !strings.Contains(err.Error(), "same token") {
+		t.Errorf("error must explain the unrotated token: %v", err)
+	}
+}
+
+// --- ensure -----------------------------------------------------------------
+
+func TestEnsureAgentNeverReturnsTheSidecarToken(t *testing.T) {
+	f := newFakeDaemon(t)
+	f.writeInstance(nil)
+
+	inst, err := testClient(t, nil).EnsureAgent(context.Background(), "email")
+	if err != nil {
+		t.Fatalf("EnsureAgent: %v", err)
+	}
+	if inst.Token != "token-A" {
+		t.Errorf("client must keep presenting the DAEMON token, got %q", inst.Token)
+	}
+	if strings.Contains(inst.String(), sidecarSecret) {
+		t.Error("the sidecar bearer leaked into the instance")
+	}
+	if !f.sawPath("POST " + APIPrefix + "/agents/email/ensure") {
+		t.Error("ensure was never called")
+	}
+}
+
+func TestEnsureAgentSurfacesDaemonRefusal(t *testing.T) {
+	f := newFakeDaemon(t)
+	f.writeInstance(nil)
+	f.mu.Lock()
+	f.ensureStatus = http.StatusServiceUnavailable
+	f.ensureDetail = "agent 'email' is not installed; run `gaia hub install email`"
+	f.mu.Unlock()
+
+	_, err := testClient(t, nil).EnsureAgent(context.Background(), "email")
+	if err == nil {
+		t.Fatal("expected an error when the daemon refuses to ensure")
+	}
+	if !strings.Contains(err.Error(), "gaia hub install email") {
+		t.Errorf("the daemon's actionable detail must be surfaced verbatim: %v", err)
+	}
+}
+
+func TestInstanceStringRedactsToken(t *testing.T) {
+	inst := &Instance{PID: 42, Port: 5000, Token: "super-secret", Host: DefaultHost, APIVersion: "1.1", Service: ServiceID}
+	got := fmt.Sprintf("%v / %s", inst, inst)
+	if strings.Contains(got, "super-secret") {
+		t.Fatalf("token leaked through String(): %s", got)
+	}
+	if !strings.Contains(got, "<redacted>") {
+		t.Errorf("expected a redaction marker, got %s", got)
+	}
+}
+
+// --- start-or-attach --------------------------------------------------------
+
+// TestHelperProcess doubles as a fake `gaia daemon start`: it writes the
+// instance.json handed to it via the environment, then exits.
+func TestHelperProcess(t *testing.T) {
+	if os.Getenv("GAIA_TUI_TEST_LAUNCHER") != "1" {
+		return
+	}
+	defer os.Exit(0)
+
+	if payload := os.Getenv("GAIA_TUI_TEST_INSTANCE"); payload != "" {
+		path := filepath.Join(os.Getenv(EnvHome), "instance.json")
+		if err := os.WriteFile(path, []byte(payload), 0o600); err != nil {
+			fmt.Fprintf(os.Stderr, "helper: %v\n", err)
+			os.Exit(2)
+		}
+	}
+	if code := os.Getenv("GAIA_TUI_TEST_EXIT"); code != "" {
+		fmt.Fprintln(os.Stderr, "helper: simulated launcher failure")
+		n, _ := strconv.Atoi(code)
+		os.Exit(n)
+	}
+}
+
+func launcher(t *testing.T, dir, payload, exitCode string) func(context.Context) (*exec.Cmd, error) {
+	t.Helper()
+	return func(ctx context.Context) (*exec.Cmd, error) {
+		cmd := exec.CommandContext(ctx, os.Args[0], "-test.run=^TestHelperProcess$")
+		cmd.Env = append(os.Environ(),
+			"GAIA_TUI_TEST_LAUNCHER=1",
+			"GAIA_TUI_TEST_INSTANCE="+payload,
+			"GAIA_TUI_TEST_EXIT="+exitCode,
+			EnvHome+"="+dir,
+		)
+		return cmd, nil
+	}
+}
+
+func TestStartOrAttachSpawnsWhenNothingIsRegistered(t *testing.T) {
+	f := newFakeDaemon(t)
+
+	// The launcher registers an instance pointing at the fake server.
+	inst := &Instance{
+		PID: os.Getpid(), Port: f.port(), Token: "token-A",
+		Host: DefaultHost, APIVersion: "1.1", Service: ServiceID,
+	}
+	payload, err := json.Marshal(inst)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	c := testClient(t, func(o *Options) {
+		o.StartCommand = launcher(t, f.dir, string(payload), "")
+	})
+	got, err := c.StartOrAttach(context.Background())
+	if err != nil {
+		t.Fatalf("StartOrAttach: %v", err)
+	}
+	if got.Port != f.port() {
+		t.Errorf("attached to port %d, want %d", got.Port, f.port())
+	}
+}
+
+func TestStartOrAttachSurfacesLauncherFailure(t *testing.T) {
+	f := newFakeDaemon(t)
+
+	c := testClient(t, func(o *Options) {
+		o.StartCommand = launcher(t, f.dir, "", "3")
+	})
+	_, err := c.StartOrAttach(context.Background())
+	var se *StartError
+	if !asError(err, &se) {
+		t.Fatalf("expected *StartError, got %#v (%v)", err, err)
+	}
+	if !strings.Contains(err.Error(), "simulated launcher failure") {
+		t.Errorf("the launcher's own output must be quoted back: %v", err)
+	}
+}
+
+func TestStartOrAttachRefusesToKillALiveButUnresponsiveDaemon(t *testing.T) {
+	f := newFakeDaemon(t)
+	f.writeInstance(nil)
+	f.mu.Lock()
+	f.statusCode = http.StatusInternalServerError
+	f.mu.Unlock()
+
+	c := testClient(t, func(o *Options) {
+		o.StartCommand = func(context.Context) (*exec.Cmd, error) {
+			t.Error("a live-but-unresponsive daemon must not be replaced silently")
+			return nil, &StartError{Reason: "unreachable"}
+		}
+	})
+	_, err := c.StartOrAttach(context.Background())
+	if err == nil {
+		t.Fatal("expected an error")
+	}
+	if !strings.Contains(err.Error(), "gaia daemon restart") {
+		t.Errorf("error must tell the user how to reclaim it: %v", err)
+	}
+}
+
+func TestStartOrAttachPropagatesVersionSkewWithoutSpawning(t *testing.T) {
+	f := newFakeDaemon(t)
+	f.writeInstance(func(i *Instance) { i.APIVersion = "9.0" })
+
+	c := testClient(t, func(o *Options) {
+		o.StartCommand = func(context.Context) (*exec.Cmd, error) {
+			t.Error("a version skew must not trigger a second daemon")
+			return nil, &StartError{Reason: "unreachable"}
+		}
+	})
+	_, err := c.StartOrAttach(context.Background())
+	var ve *VersionError
+	if !asError(err, &ve) {
+		t.Fatalf("expected *VersionError, got %#v (%v)", err, err)
+	}
+}
+
+// --- primitives -------------------------------------------------------------
+
+func TestPIDAlive(t *testing.T) {
+	if !PIDAlive(os.Getpid()) {
+		t.Error("the test process must read as alive")
+	}
+	if PIDAlive(0) || PIDAlive(-1) {
+		t.Error("non-positive pids must read as dead")
+	}
+
+	// A reaped child is the canonical dead pid.
+	cmd := exec.Command(os.Args[0], "-test.run=^TestHelperProcess$")
+	cmd.Env = append(os.Environ(), "GAIA_TUI_TEST_LAUNCHER=1")
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("run helper: %v", err)
+	}
+	if PIDAlive(cmd.Process.Pid) {
+		t.Errorf("reaped pid %d must read as dead", cmd.Process.Pid)
+	}
+}
+
+func TestStartLockIsExclusive(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "instance.lock")
+
+	first, err := acquireLock(path, time.Second)
+	if err != nil {
+		t.Fatalf("first acquireLock: %v", err)
+	}
+
+	if _, err := acquireLock(path, 300*time.Millisecond); err == nil {
+		t.Fatal("a second holder must not get the lock while the first holds it")
+	} else if !strings.Contains(err.Error(), "start lock") {
+		t.Errorf("error must name the lock: %v", err)
+	}
+
+	first.release()
+
+	second, err := acquireLock(path, time.Second)
+	if err != nil {
+		t.Fatalf("acquireLock after release: %v", err)
+	}
+	second.release()
+}
+
+func TestParseAPIVersion(t *testing.T) {
+	cases := []struct {
+		in           string
+		major, minor int
+		wantErr      bool
+	}{
+		{"1.1", 1, 1, false},
+		{"1.0", 1, 0, false},
+		{"1", 1, 0, false},
+		{"2.14", 2, 14, false},
+		{"1.x", 1, 0, false},
+		{"", 0, 0, true},
+		{"beta", 0, 0, true},
+	}
+	for _, tc := range cases {
+		major, minor, err := parseAPIVersion(tc.in)
+		if tc.wantErr {
+			if err == nil {
+				t.Errorf("parseAPIVersion(%q): expected an error", tc.in)
+			}
+			continue
+		}
+		if err != nil {
+			t.Errorf("parseAPIVersion(%q): %v", tc.in, err)
+			continue
+		}
+		if major != tc.major || minor != tc.minor {
+			t.Errorf("parseAPIVersion(%q) = %d.%d, want %d.%d", tc.in, major, minor, tc.major, tc.minor)
+		}
+	}
+}
+
+// --- helpers ----------------------------------------------------------------
+
+// asError is errors.As with the generic plumbing inlined so each test reads as
+// one line.
+func asError[T error](err error, target *T) bool {
+	for err != nil {
+		if t, ok := err.(T); ok {
+			*target = t
+			return true
+		}
+		u, ok := err.(interface{ Unwrap() error })
+		if !ok {
+			return false
+		}
+		err = u.Unwrap()
+	}
+	return false
+}
+
+func containsAuth(seen []string, token string) bool {
+	for _, s := range seen {
+		if s == AuthScheme+" "+token {
+			return true
+		}
+	}
+	return false
+}

--- a/tui/internal/daemon/errors.go
+++ b/tui/internal/daemon/errors.go
@@ -14,12 +14,32 @@ func (e *NotRunningError) Error() string {
 			"Start one with `gaia daemon start`.", e.Path)
 }
 
+// StaleKind classifies WHY a recorded instance cannot be trusted, because the
+// remedy differs: a garbage record is reclaimed by starting a fresh daemon,
+// whereas our own live-but-wedged daemon must not be silently replaced.
+type StaleKind int
+
+const (
+	// StaleCorrupt — the file is missing fields, unreadable, or not JSON.
+	StaleCorrupt StaleKind = iota
+	// StalePIDDead — the recorded pid is gone.
+	StalePIDDead
+	// StaleUnresponsive — the pid is alive but the recorded port does not answer
+	// as a healthy daemon. Probably our own daemon gone bad.
+	StaleUnresponsive
+	// StaleForeign — the port answers as a different service, or as a different
+	// pid. After a hard crash the OS reused the pid AND something else took the
+	// freed port, so the record is garbage and can be reclaimed.
+	StaleForeign
+)
+
 // StaleError means instance.json exists but must not be trusted: it is corrupt,
 // its pid is dead, or the recorded port answers as something other than our
-// daemon. Reason names which check failed.
+// daemon. Reason names which check failed; Kind drives the recovery decision.
 type StaleError struct {
 	Path   string
 	Reason string
+	Kind   StaleKind
 }
 
 func (e *StaleError) Error() string {

--- a/tui/internal/daemon/errors.go
+++ b/tui/internal/daemon/errors.go
@@ -1,0 +1,71 @@
+package daemon
+
+import "fmt"
+
+// NotRunningError means no daemon has registered itself at all — instance.json
+// is absent. Distinct from StaleError so a caller can decide to start one.
+type NotRunningError struct {
+	Path string
+}
+
+func (e *NotRunningError) Error() string {
+	return fmt.Sprintf(
+		"no GAIA daemon is registered (%s does not exist). "+
+			"Start one with `gaia daemon start`.", e.Path)
+}
+
+// StaleError means instance.json exists but must not be trusted: it is corrupt,
+// its pid is dead, or the recorded port answers as something other than our
+// daemon. Reason names which check failed.
+type StaleError struct {
+	Path   string
+	Reason string
+}
+
+func (e *StaleError) Error() string {
+	return fmt.Sprintf(
+		"the recorded GAIA daemon at %s cannot be trusted: %s. "+
+			"Reclaim it with `gaia daemon restart`, then retry; "+
+			"the daemon log is at %s.", e.Path, e.Reason, logPathForMessage())
+}
+
+// VersionError means the running daemon speaks a contract this client cannot
+// use — a MAJOR skew, or a MINOR below the agents/relay floor. The remedy is
+// always a daemon restart: an app update replaced the client while the old
+// daemon kept running.
+type VersionError struct {
+	Have   string
+	Reason string
+}
+
+func (e *VersionError) Error() string {
+	return fmt.Sprintf(
+		"the running GAIA daemon speaks host API v%s: %s. "+
+			"Run `gaia daemon restart`, then retry.", e.Have, e.Reason)
+}
+
+// StartError means we could not bring a daemon up (lock contention, launch
+// failure, or it never registered in time).
+type StartError struct {
+	Reason string
+}
+
+func (e *StartError) Error() string {
+	return fmt.Sprintf(
+		"could not start the GAIA daemon: %s. Inspect the daemon log at %s, "+
+			"or run `gaia daemon start` in a terminal to see the failure directly.",
+		e.Reason, logPathForMessage())
+}
+
+// RequestError is a transport or protocol failure talking to a live daemon.
+// Op names the call ("ensure the 'email' sidecar", "stream the 'email' query").
+type RequestError struct {
+	Op     string
+	Detail string
+}
+
+func (e *RequestError) Error() string {
+	return fmt.Sprintf(
+		"could not %s: %s. Check `gaia daemon status` and the daemon log at %s.",
+		e.Op, e.Detail, logPathForMessage())
+}

--- a/tui/internal/daemon/instance.go
+++ b/tui/internal/daemon/instance.go
@@ -76,39 +76,43 @@ func ReadInstance() (*Instance, error) {
 		return nil, &NotRunningError{Path: path}
 	}
 	if err != nil {
-		return nil, &StaleError{Path: path, Reason: fmt.Sprintf("it cannot be read (%v)", err)}
+		return nil, &StaleError{Kind: StaleCorrupt, Path: path, Reason: fmt.Sprintf("it cannot be read (%v)", err)}
 	}
 
 	var inst Instance
 	if err := json.Unmarshal(raw, &inst); err != nil {
 		return nil, &StaleError{
+			Kind:   StaleCorrupt,
 			Path:   path,
 			Reason: fmt.Sprintf("it is not valid JSON (%v) — a crash mid-write leaves a truncated file", err),
 		}
 	}
 	if inst.PID <= 0 {
-		return nil, &StaleError{Path: path, Reason: "it records no usable pid"}
+		return nil, &StaleError{Kind: StaleCorrupt, Path: path, Reason: "it records no usable pid"}
 	}
 	if inst.Port <= 0 || inst.Port > 65535 {
-		return nil, &StaleError{Path: path, Reason: fmt.Sprintf("it records an invalid port (%d)", inst.Port)}
+		return nil, &StaleError{Kind: StaleCorrupt, Path: path, Reason: fmt.Sprintf("it records an invalid port (%d)", inst.Port)}
 	}
 	if inst.Port == ReservedPort {
 		return nil, &StaleError{
+			Kind:   StaleCorrupt,
 			Path:   path,
 			Reason: fmt.Sprintf("it records port %d, which is reserved and never used by GAIA", ReservedPort),
 		}
 	}
 	if inst.Token == "" {
-		return nil, &StaleError{Path: path, Reason: "it records no client token, so no request could be authenticated"}
+		return nil, &StaleError{Kind: StaleCorrupt, Path: path, Reason: "it records no client token, so no request could be authenticated"}
 	}
 	if inst.Service != "" && inst.Service != ServiceID {
 		return nil, &StaleError{
+			Kind:   StaleCorrupt,
 			Path:   path,
 			Reason: fmt.Sprintf("it was written by service %q, not %q", inst.Service, ServiceID),
 		}
 	}
 	if inst.APIVersion == "" {
 		return nil, &StaleError{
+			Kind:   StaleCorrupt,
 			Path:   path,
 			Reason: "it records no api_version, so the daemon contract version cannot be verified",
 		}

--- a/tui/internal/daemon/instance.go
+++ b/tui/internal/daemon/instance.go
@@ -1,0 +1,174 @@
+package daemon
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"strconv"
+	"strings"
+)
+
+const (
+	// ServiceID is the identity a probed port must answer with before we trust it.
+	ServiceID = "gaia-daemon"
+
+	// APIPrefix is the daemon's versioned client-API surface.
+	APIPrefix = "/daemon/v1"
+
+	// AuthScheme is the client-token auth scheme; the header is
+	// `Authorization: Bearer <token>` on EVERY request.
+	AuthScheme = "Bearer"
+
+	// DefaultHost is the loopback address the daemon binds.
+	DefaultHost = "127.0.0.1"
+
+	// ReservedPort is reserved repo-wide and must never be used by GAIA.
+	// A registry claiming it is treated as untrustworthy.
+	ReservedPort = 4001
+
+	// RequiredAPIMajor is the daemon contract MAJOR this client speaks.
+	RequiredAPIMajor = 1
+
+	// RequiredAgentsMinor is the MINOR that introduced the /daemon/v1/agents
+	// control plane and the /v1/<agent>/* relay. Below it every agents route
+	// 404s, so a pre-#2142 daemon must fail loudly rather than be attached to.
+	RequiredAgentsMinor = 1
+)
+
+// Instance is the daemon's single-instance registry record (~/.gaia/host/instance.json,
+// mode 0600).
+type Instance struct {
+	PID        int     `json:"pid"`
+	Port       int     `json:"port"`
+	Token      string  `json:"token"`
+	Host       string  `json:"host"`
+	APIVersion string  `json:"api_version"`
+	Service    string  `json:"service"`
+	StartedAt  float64 `json:"started_at"`
+}
+
+// BaseURL is the daemon's loopback root, e.g. "http://127.0.0.1:51234".
+func (i *Instance) BaseURL() string {
+	return fmt.Sprintf("http://%s:%d", i.Host, i.Port)
+}
+
+// String redacts the client token so an Instance is safe to log or embed in an
+// error. Never format an Instance with %#v.
+func (i *Instance) String() string {
+	return fmt.Sprintf("daemon{pid:%d port:%d api:%s service:%s token:<redacted>}",
+		i.PID, i.Port, i.APIVersion, i.Service)
+}
+
+// ReadInstance loads and structurally validates instance.json.
+//
+// It returns *NotRunningError when the file is absent and *StaleError when it is
+// present but untrustworthy. A successful read means the record is well-formed —
+// NOT that a daemon is alive; that needs Client.verify (pid + status probe).
+func ReadInstance() (*Instance, error) {
+	path, err := InstancePath()
+	if err != nil {
+		return nil, err
+	}
+	raw, err := os.ReadFile(path)
+	if errors.Is(err, fs.ErrNotExist) {
+		return nil, &NotRunningError{Path: path}
+	}
+	if err != nil {
+		return nil, &StaleError{Path: path, Reason: fmt.Sprintf("it cannot be read (%v)", err)}
+	}
+
+	var inst Instance
+	if err := json.Unmarshal(raw, &inst); err != nil {
+		return nil, &StaleError{
+			Path:   path,
+			Reason: fmt.Sprintf("it is not valid JSON (%v) — a crash mid-write leaves a truncated file", err),
+		}
+	}
+	if inst.PID <= 0 {
+		return nil, &StaleError{Path: path, Reason: "it records no usable pid"}
+	}
+	if inst.Port <= 0 || inst.Port > 65535 {
+		return nil, &StaleError{Path: path, Reason: fmt.Sprintf("it records an invalid port (%d)", inst.Port)}
+	}
+	if inst.Port == ReservedPort {
+		return nil, &StaleError{
+			Path:   path,
+			Reason: fmt.Sprintf("it records port %d, which is reserved and never used by GAIA", ReservedPort),
+		}
+	}
+	if inst.Token == "" {
+		return nil, &StaleError{Path: path, Reason: "it records no client token, so no request could be authenticated"}
+	}
+	if inst.Service != "" && inst.Service != ServiceID {
+		return nil, &StaleError{
+			Path:   path,
+			Reason: fmt.Sprintf("it was written by service %q, not %q", inst.Service, ServiceID),
+		}
+	}
+	if inst.APIVersion == "" {
+		return nil, &StaleError{
+			Path:   path,
+			Reason: "it records no api_version, so the daemon contract version cannot be verified",
+		}
+	}
+	if inst.Host == "" {
+		inst.Host = DefaultHost
+	}
+	return &inst, nil
+}
+
+// parseAPIVersion splits a "MAJOR.MINOR" contract version. A missing MINOR reads
+// as 0 (mirrors the Python floor check); a non-numeric MAJOR is a hard error.
+func parseAPIVersion(v string) (major, minor int, err error) {
+	parts := strings.Split(strings.TrimSpace(v), ".")
+	major, err = strconv.Atoi(parts[0])
+	if err != nil {
+		return 0, 0, fmt.Errorf("cannot parse a MAJOR daemon API version from %q", v)
+	}
+	if len(parts) > 1 {
+		if m, cerr := strconv.Atoi(parts[1]); cerr == nil {
+			minor = m
+		}
+	}
+	return major, minor, nil
+}
+
+// CheckVersion fails loudly on a daemon↔client contract MAJOR skew. An app
+// update replaces the client while an old daemon keeps running, so this is the
+// expected path after an upgrade, not an edge case.
+func (i *Instance) CheckVersion() error {
+	major, _, err := parseAPIVersion(i.APIVersion)
+	if err != nil {
+		return &VersionError{Have: i.APIVersion, Reason: err.Error()}
+	}
+	if major != RequiredAPIMajor {
+		return &VersionError{
+			Have: i.APIVersion,
+			Reason: fmt.Sprintf("this client speaks MAJOR %d and cannot use MAJOR %d",
+				RequiredAPIMajor, major),
+		}
+	}
+	return nil
+}
+
+// CheckAgentsFloor fails loudly if the running daemon predates the sidecar
+// control plane and the /v1/<agent>/* relay (needs v1.1+).
+func (i *Instance) CheckAgentsFloor() error {
+	if err := i.CheckVersion(); err != nil {
+		return err
+	}
+	_, minor, err := parseAPIVersion(i.APIVersion)
+	if err != nil {
+		return &VersionError{Have: i.APIVersion, Reason: err.Error()}
+	}
+	if minor < RequiredAgentsMinor {
+		return &VersionError{
+			Have: i.APIVersion,
+			Reason: fmt.Sprintf("it predates the sidecar control plane + agent relay (needs v%d.%d+), "+
+				"so every agents route would 404", RequiredAPIMajor, RequiredAgentsMinor),
+		}
+	}
+	return nil
+}

--- a/tui/internal/daemon/lock.go
+++ b/tui/internal/daemon/lock.go
@@ -1,0 +1,60 @@
+package daemon
+
+import (
+	"fmt"
+	"os"
+	"time"
+)
+
+// lockPoll is the retry interval while waiting for the start lock.
+const lockPoll = 100 * time.Millisecond
+
+// fileLock holds the exclusive daemon-start lock. Only ONE process may be in the
+// "decide + spawn" critical section at a time, so two concurrent StartOrAttach
+// callers yield exactly one daemon (the loser attaches to the winner's
+// instance.json).
+//
+// An OS advisory lock is used rather than an O_EXCL create-lock because the OS
+// releases it when the holder dies — a create-lock would strand a stale lock
+// file after SIGKILL.
+type fileLock struct {
+	f *os.File
+}
+
+// acquireLock takes the exclusive lock at path, retrying until timeout. Failure
+// is loud: an abandoned start attempt must surface an actionable error rather
+// than hang forever.
+func acquireLock(path string, timeout time.Duration) (*fileLock, error) {
+	// 0600: the lock file lives beside the token-bearing instance.json.
+	f, err := os.OpenFile(path, os.O_RDWR|os.O_CREATE, 0o600)
+	if err != nil {
+		return nil, &StartError{Reason: fmt.Sprintf("cannot open the start lock at %s: %v", path, err)}
+	}
+	deadline := time.Now().Add(timeout)
+	for {
+		ok, lerr := tryLock(f)
+		if lerr != nil {
+			f.Close()
+			return nil, &StartError{Reason: fmt.Sprintf("cannot lock %s: %v", path, lerr)}
+		}
+		if ok {
+			return &fileLock{f: f}, nil
+		}
+		if time.Now().After(deadline) {
+			f.Close()
+			return nil, &StartError{Reason: fmt.Sprintf(
+				"another process held the start lock at %s for more than %s without finishing — "+
+					"look for a stuck `gaia daemon start` or Agent UI launch", path, timeout)}
+		}
+		time.Sleep(lockPoll)
+	}
+}
+
+func (l *fileLock) release() {
+	if l == nil || l.f == nil {
+		return
+	}
+	unlock(l.f)
+	l.f.Close()
+	l.f = nil
+}

--- a/tui/internal/daemon/lock_unix.go
+++ b/tui/internal/daemon/lock_unix.go
@@ -1,0 +1,26 @@
+//go:build !windows
+
+package daemon
+
+import (
+	"errors"
+	"os"
+	"syscall"
+)
+
+// tryLock takes a non-blocking exclusive flock. (false, nil) means "held by
+// someone else, retry"; a non-nil error is a real failure.
+func tryLock(f *os.File) (bool, error) {
+	err := syscall.Flock(int(f.Fd()), syscall.LOCK_EX|syscall.LOCK_NB)
+	if err == nil {
+		return true, nil
+	}
+	if errors.Is(err, syscall.EWOULDBLOCK) || errors.Is(err, syscall.EAGAIN) {
+		return false, nil
+	}
+	return false, err
+}
+
+func unlock(f *os.File) {
+	_ = syscall.Flock(int(f.Fd()), syscall.LOCK_UN)
+}

--- a/tui/internal/daemon/lock_windows.go
+++ b/tui/internal/daemon/lock_windows.go
@@ -1,0 +1,33 @@
+//go:build windows
+
+package daemon
+
+import (
+	"errors"
+	"os"
+
+	"golang.org/x/sys/windows"
+)
+
+// tryLock takes a non-blocking exclusive byte-range lock. (false, nil) means
+// "held by someone else, retry"; a non-nil error is a real failure.
+func tryLock(f *os.File) (bool, error) {
+	var ov windows.Overlapped
+	err := windows.LockFileEx(
+		windows.Handle(f.Fd()),
+		windows.LOCKFILE_EXCLUSIVE_LOCK|windows.LOCKFILE_FAIL_IMMEDIATELY,
+		0, 1, 0, &ov,
+	)
+	if err == nil {
+		return true, nil
+	}
+	if errors.Is(err, windows.ERROR_LOCK_VIOLATION) || errors.Is(err, windows.ERROR_IO_PENDING) {
+		return false, nil
+	}
+	return false, err
+}
+
+func unlock(f *os.File) {
+	var ov windows.Overlapped
+	_ = windows.UnlockFileEx(windows.Handle(f.Fd()), 0, 1, 0, &ov)
+}

--- a/tui/internal/daemon/paths.go
+++ b/tui/internal/daemon/paths.go
@@ -1,0 +1,90 @@
+// Package daemon is the TUI's thin client for the GAIA daemon: single-instance
+// discovery, the start-or-attach handshake, and authenticated calls against the
+// daemon's HTTP control plane (`/daemon/v1/*`) and agent relay (`/v1/<agent>/*`).
+//
+// It is the Go counterpart of src/gaia/daemon/{paths,instance,client}.py and
+// deliberately mirrors their trust rules: a recorded instance is trusted only
+// when its pid is alive AND a token-authed status probe answers with the daemon's
+// service id and the recorded pid — a freed port that some unrelated process
+// grabbed after a crash is a real failure mode, not a theoretical one.
+//
+// Every failure returns an actionable error naming what failed, what to run, and
+// which log to read. There is no silent fallback to a direct sidecar connection:
+// the TUI only ever holds the DAEMON client token, never a sidecar bearer.
+package daemon
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// EnvHome overrides the daemon state directory (tests, and any non-default
+// install). Read on every call, never cached — a subprocess spawned with a
+// different env must resolve its own directory.
+const EnvHome = "GAIA_DAEMON_HOME"
+
+// HostDir returns the directory holding instance.json, the start lock, and the
+// daemon log.
+func HostDir() (string, error) {
+	if override := os.Getenv(EnvHome); override != "" {
+		return override, nil
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf(
+			"cannot resolve the home directory to locate ~/.gaia/host: %w — "+
+				"set %s to the daemon state directory and retry", err, EnvHome)
+	}
+	return filepath.Join(home, ".gaia", "host"), nil
+}
+
+// InstancePath returns the single-instance registry file (pid + port + client token).
+func InstancePath() (string, error) {
+	dir, err := HostDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(dir, "instance.json"), nil
+}
+
+// LockPath returns the advisory lock that serializes daemon start, so two
+// concurrent callers spawn exactly one daemon.
+func LockPath() (string, error) {
+	dir, err := HostDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(dir, "instance.lock"), nil
+}
+
+// LogPath returns the daemon stdout/stderr log (what `gaia daemon logs` tails).
+func LogPath() (string, error) {
+	dir, err := HostDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(dir, "daemon.log"), nil
+}
+
+// logPathForMessage returns LogPath() for embedding in an error string, or a
+// human placeholder if even the home directory is unresolvable.
+func logPathForMessage() string {
+	p, err := LogPath()
+	if err != nil {
+		return "~/.gaia/host/daemon.log"
+	}
+	return p
+}
+
+// ensureHostDir creates the host directory if missing and returns it.
+func ensureHostDir() (string, error) {
+	dir, err := HostDir()
+	if err != nil {
+		return "", err
+	}
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return "", fmt.Errorf("cannot create the daemon state directory %s: %w", dir, err)
+	}
+	return dir, nil
+}

--- a/tui/internal/daemon/pid_unix.go
+++ b/tui/internal/daemon/pid_unix.go
@@ -1,0 +1,24 @@
+//go:build !windows
+
+package daemon
+
+import (
+	"errors"
+	"syscall"
+)
+
+// PIDAlive reports whether pid refers to a running process.
+//
+// signal 0 probes without delivering: nil means the process exists and we may
+// signal it; EPERM means it exists but is owned by another user. Either way the
+// pid is taken, and the status probe is the real trust check.
+func PIDAlive(pid int) bool {
+	if pid <= 0 {
+		return false
+	}
+	err := syscall.Kill(pid, 0)
+	if err == nil {
+		return true
+	}
+	return errors.Is(err, syscall.EPERM)
+}

--- a/tui/internal/daemon/pid_windows.go
+++ b/tui/internal/daemon/pid_windows.go
@@ -1,0 +1,30 @@
+//go:build windows
+
+package daemon
+
+import "golang.org/x/sys/windows"
+
+// stillActive is the exit code Windows reports for a process that has not exited.
+const stillActive = 259
+
+// PIDAlive reports whether pid refers to a running process.
+//
+// A handle can still be opened briefly for an exited process, so the exit code
+// is checked too; the status probe remains the real trust check.
+func PIDAlive(pid int) bool {
+	if pid <= 0 {
+		return false
+	}
+	h, err := windows.OpenProcess(windows.PROCESS_QUERY_LIMITED_INFORMATION, false, uint32(pid))
+	if err != nil {
+		return false
+	}
+	defer windows.CloseHandle(h)
+	var code uint32
+	if err := windows.GetExitCodeProcess(h, &code); err != nil {
+		// The pid is taken but we cannot read its state — treat it as alive and
+		// let the status probe decide.
+		return true
+	}
+	return code == stillActive
+}

--- a/tui/internal/event/canonical.go
+++ b/tui/internal/event/canonical.go
@@ -1,0 +1,132 @@
+package event
+
+import "encoding/json"
+
+// The canonical `/query` SSE vocabulary — the frozen seven event types from
+// docs/spec/agent-ui-query-sse-contract.md §4, streamed by every v2 agent
+// sidecar through the daemon relay.
+//
+// These are NOT the legacy in-process types in types.go (step / thinking /
+// tool_start / chunk / answer / …), which the subprocess transport still uses.
+// Both vocabularies coexist: the transport decides which parser runs.
+//
+// Two extra types carry the contract's receiving-end rules (§7) into the type
+// system, so an event can never be silently dropped:
+// CanonicalUnsupportedEvent (a `type` outside the seven) and
+// CanonicalMalformedEvent (a frame that is not valid JSON for its type).
+const (
+	CanonicalTypeStatus            = "status"
+	CanonicalTypeToken             = "token"
+	CanonicalTypeToolCall          = "tool_call"
+	CanonicalTypeToolResult        = "tool_result"
+	CanonicalTypeNeedsConfirmation = "needs_confirmation"
+	CanonicalTypeFinal             = "final"
+	CanonicalTypeError             = "error"
+)
+
+// CanonicalStatusEvent — progress narration (spinner label / status line).
+type CanonicalStatusEvent struct {
+	Type    string `json:"type"`
+	Message string `json:"message"`
+}
+
+// CanonicalTokenEvent — one incremental chunk of assistant answer text.
+type CanonicalTokenEvent struct {
+	Type  string `json:"type"`
+	Delta string `json:"delta"`
+}
+
+// CanonicalToolCallEvent — a tool invocation with its arguments.
+type CanonicalToolCallEvent struct {
+	Type string          `json:"type"`
+	Tool string          `json:"tool"`
+	Args json.RawMessage `json:"args,omitempty"`
+}
+
+// CanonicalToolResultEvent — a tool's structured result.
+//
+// Render is the sidecar's declared card key (e.g. "email_pre_scan", or one of the
+// generic primitives "table" / "key_value" / "list" / "image" / "diff"). Data is
+// the render-specific payload. An unknown Render must degrade to a generic result
+// card — never to a blank.
+type CanonicalToolResultEvent struct {
+	Type   string          `json:"type"`
+	Tool   string          `json:"tool"`
+	Render string          `json:"render,omitempty"`
+	Data   json.RawMessage `json:"data,omitempty"`
+}
+
+// CanonicalNeedsConfirmationEvent — the run pauses for a user decision.
+// ConfirmURL is present only under the resume model; the stateless surface omits it.
+type CanonicalNeedsConfirmationEvent struct {
+	Type       string `json:"type"`
+	RunID      string `json:"run_id"`
+	Action     string `json:"action"`
+	Summary    string `json:"summary"`
+	ConfirmURL string `json:"confirm_url,omitempty"`
+}
+
+// CanonicalFinalEvent — terminal success. Usage is an optional
+// {steps?, tools_used?, elapsed?, tokens?} object.
+type CanonicalFinalEvent struct {
+	Type   string          `json:"type"`
+	Answer string          `json:"answer"`
+	Usage  json.RawMessage `json:"usage,omitempty"`
+}
+
+// CanonicalUsage is the shape the TUI reads out of CanonicalFinalEvent.Usage.
+// Fields absent from the payload stay zero and are simply not displayed.
+type CanonicalUsage struct {
+	Steps     int     `json:"steps"`
+	ToolsUsed int     `json:"tools_used"`
+	Elapsed   float64 `json:"elapsed"`
+}
+
+// CanonicalErrorEvent — terminal failure. Detail is actionable and surfaced
+// verbatim. Source is set by whoever synthesized the event when it did not come
+// off the wire (e.g. "tui" for a stream that ended with no terminal event).
+type CanonicalErrorEvent struct {
+	Type   string `json:"type"`
+	Detail string `json:"detail"`
+	Status int    `json:"status,omitempty"`
+	Source string `json:"source,omitempty"`
+}
+
+// CanonicalUnsupportedEvent — a top-level `type` outside the frozen seven, from a
+// newer agent talking to this client. Contract §7: surface it visibly, never drop it.
+type CanonicalUnsupportedEvent struct {
+	EventType string
+	Raw       string
+}
+
+// CanonicalMalformedEvent — a data frame that could not be parsed as its declared
+// type. Surfaced so a broken producer is visible instead of looking like silence.
+type CanonicalMalformedEvent struct {
+	Payload string
+	Reason  string
+}
+
+// CanonicalUsageOf decodes a final event's usage object. A missing or unreadable
+// usage payload yields the zero value — it is display metadata, not an outcome.
+func CanonicalUsageOf(e CanonicalFinalEvent) CanonicalUsage {
+	var u CanonicalUsage
+	if len(e.Usage) == 0 {
+		return u
+	}
+	if err := json.Unmarshal(e.Usage, &u); err != nil {
+		return CanonicalUsage{}
+	}
+	return u
+}
+
+// CanonicalTerminalType returns "final" or "error" if evt terminates a run, else "".
+// Exactly one terminal event ends a `/query` stream (contract §3).
+func CanonicalTerminalType(evt interface{}) string {
+	switch evt.(type) {
+	case CanonicalFinalEvent:
+		return CanonicalTypeFinal
+	case CanonicalErrorEvent:
+		return CanonicalTypeError
+	}
+	return ""
+}

--- a/tui/internal/event/canonical_parser.go
+++ b/tui/internal/event/canonical_parser.go
@@ -1,0 +1,75 @@
+package event
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// maxRawEcho caps how much of a bad payload is echoed back into a visible event.
+const maxRawEcho = 400
+
+// ParseCanonicalEvent parses one canonical `/query` SSE data payload.
+//
+// It never returns an error, by design: the contract's receiving-end rules
+// require that nothing is dropped, so both failure modes become visible events —
+// an unknown `type` yields CanonicalUnsupportedEvent and an unreadable payload
+// yields CanonicalMalformedEvent. Callers render whatever comes back and keep
+// reading; only `final` / `error` end a run.
+func ParseCanonicalEvent(data []byte) interface{} {
+	var probe struct {
+		Type string `json:"type"`
+	}
+	if err := json.Unmarshal(data, &probe); err != nil {
+		return CanonicalMalformedEvent{
+			Payload: truncate(string(data), maxRawEcho),
+			Reason:  fmt.Sprintf("not valid JSON: %v", err),
+		}
+	}
+	if probe.Type == "" {
+		return CanonicalMalformedEvent{
+			Payload: truncate(string(data), maxRawEcho),
+			Reason:  "the event carries no `type` field",
+		}
+	}
+
+	switch probe.Type {
+	case CanonicalTypeStatus:
+		return decodeCanonical[CanonicalStatusEvent](data, probe.Type)
+	case CanonicalTypeToken:
+		return decodeCanonical[CanonicalTokenEvent](data, probe.Type)
+	case CanonicalTypeToolCall:
+		return decodeCanonical[CanonicalToolCallEvent](data, probe.Type)
+	case CanonicalTypeToolResult:
+		return decodeCanonical[CanonicalToolResultEvent](data, probe.Type)
+	case CanonicalTypeNeedsConfirmation:
+		return decodeCanonical[CanonicalNeedsConfirmationEvent](data, probe.Type)
+	case CanonicalTypeFinal:
+		return decodeCanonical[CanonicalFinalEvent](data, probe.Type)
+	case CanonicalTypeError:
+		return decodeCanonical[CanonicalErrorEvent](data, probe.Type)
+	default:
+		// §7: a newer agent's new event type must be visible, not dropped.
+		return CanonicalUnsupportedEvent{
+			EventType: probe.Type,
+			Raw:       truncate(string(data), maxRawEcho),
+		}
+	}
+}
+
+func decodeCanonical[T any](data []byte, etype string) interface{} {
+	var e T
+	if err := json.Unmarshal(data, &e); err != nil {
+		return CanonicalMalformedEvent{
+			Payload: truncate(string(data), maxRawEcho),
+			Reason:  fmt.Sprintf("malformed %s event: %v", etype, err),
+		}
+	}
+	return e
+}
+
+func truncate(s string, limit int) string {
+	if len(s) <= limit {
+		return s
+	}
+	return s[:limit] + "…"
+}

--- a/tui/internal/event/canonical_parser_test.go
+++ b/tui/internal/event/canonical_parser_test.go
@@ -1,0 +1,199 @@
+package event
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestParseCanonicalStatus(t *testing.T) {
+	e := ParseCanonicalEvent([]byte(`{"type":"status","message":"Scanning inbox"}`))
+	s, ok := e.(CanonicalStatusEvent)
+	if !ok {
+		t.Fatalf("expected CanonicalStatusEvent, got %T", e)
+	}
+	if s.Message != "Scanning inbox" {
+		t.Errorf("message = %q", s.Message)
+	}
+}
+
+func TestParseCanonicalToken(t *testing.T) {
+	e := ParseCanonicalEvent([]byte(`{"type":"token","delta":"Hel"}`))
+	tok, ok := e.(CanonicalTokenEvent)
+	if !ok {
+		t.Fatalf("expected CanonicalTokenEvent, got %T", e)
+	}
+	if tok.Delta != "Hel" {
+		t.Errorf("delta = %q", tok.Delta)
+	}
+}
+
+func TestParseCanonicalToolCall(t *testing.T) {
+	e := ParseCanonicalEvent([]byte(`{"type":"tool_call","tool":"search_email","args":{"query":"invoice"}}`))
+	tc, ok := e.(CanonicalToolCallEvent)
+	if !ok {
+		t.Fatalf("expected CanonicalToolCallEvent, got %T", e)
+	}
+	if tc.Tool != "search_email" {
+		t.Errorf("tool = %q", tc.Tool)
+	}
+	var args map[string]string
+	if err := json.Unmarshal(tc.Args, &args); err != nil {
+		t.Fatalf("args: %v", err)
+	}
+	if args["query"] != "invoice" {
+		t.Errorf("args[query] = %q", args["query"])
+	}
+}
+
+func TestParseCanonicalToolResultCarriesRenderAndData(t *testing.T) {
+	line := []byte(`{"type":"tool_result","tool":"pre_scan_inbox","render":"email_pre_scan","data":{"urgent":[{"subject":"Wire transfer"}]}}`)
+	e := ParseCanonicalEvent(line)
+	tr, ok := e.(CanonicalToolResultEvent)
+	if !ok {
+		t.Fatalf("expected CanonicalToolResultEvent, got %T", e)
+	}
+	if tr.Tool != "pre_scan_inbox" || tr.Render != "email_pre_scan" {
+		t.Errorf("unexpected values: %+v", tr)
+	}
+	if !strings.Contains(string(tr.Data), "Wire transfer") {
+		t.Errorf("data not carried through: %s", tr.Data)
+	}
+}
+
+func TestParseCanonicalToolResultWithoutRender(t *testing.T) {
+	e := ParseCanonicalEvent([]byte(`{"type":"tool_result","tool":"list_labels","data":{"ok":true}}`))
+	tr, ok := e.(CanonicalToolResultEvent)
+	if !ok {
+		t.Fatalf("expected CanonicalToolResultEvent, got %T", e)
+	}
+	if tr.Render != "" {
+		t.Errorf("render should be empty, got %q", tr.Render)
+	}
+}
+
+func TestParseCanonicalNeedsConfirmation(t *testing.T) {
+	line := []byte(`{"type":"needs_confirmation","run_id":"7b1e","action":"send_draft","summary":"Send reply to alice@example.com"}`)
+	e := ParseCanonicalEvent(line)
+	nc, ok := e.(CanonicalNeedsConfirmationEvent)
+	if !ok {
+		t.Fatalf("expected CanonicalNeedsConfirmationEvent, got %T", e)
+	}
+	if nc.RunID != "7b1e" || nc.Action != "send_draft" {
+		t.Errorf("unexpected values: %+v", nc)
+	}
+	if nc.ConfirmURL != "" {
+		t.Errorf("confirm_url should be absent under the stateless model, got %q", nc.ConfirmURL)
+	}
+}
+
+func TestParseCanonicalFinalWithUsage(t *testing.T) {
+	e := ParseCanonicalEvent([]byte(`{"type":"final","answer":"3 urgent emails","usage":{"steps":4,"tools_used":2,"elapsed":8.5}}`))
+	f, ok := e.(CanonicalFinalEvent)
+	if !ok {
+		t.Fatalf("expected CanonicalFinalEvent, got %T", e)
+	}
+	if f.Answer != "3 urgent emails" {
+		t.Errorf("answer = %q", f.Answer)
+	}
+	usage := CanonicalUsageOf(f)
+	if usage.Steps != 4 || usage.ToolsUsed != 2 || usage.Elapsed != 8.5 {
+		t.Errorf("unexpected usage: %+v", usage)
+	}
+	if CanonicalTerminalType(f) != CanonicalTypeFinal {
+		t.Error("final must be terminal")
+	}
+}
+
+func TestCanonicalUsageOfMissingOrBad(t *testing.T) {
+	if u := CanonicalUsageOf(CanonicalFinalEvent{Type: "final", Answer: "x"}); u != (CanonicalUsage{}) {
+		t.Errorf("absent usage should be zero, got %+v", u)
+	}
+	bad := CanonicalFinalEvent{Type: "final", Usage: json.RawMessage(`"not-an-object"`)}
+	if u := CanonicalUsageOf(bad); u != (CanonicalUsage{}) {
+		t.Errorf("unreadable usage should be zero, got %+v", u)
+	}
+}
+
+func TestParseCanonicalError(t *testing.T) {
+	e := ParseCanonicalEvent([]byte(`{"type":"error","detail":"Lemonade Server is not reachable","status":503}`))
+	ev, ok := e.(CanonicalErrorEvent)
+	if !ok {
+		t.Fatalf("expected CanonicalErrorEvent, got %T", e)
+	}
+	if ev.Detail != "Lemonade Server is not reachable" || ev.Status != 503 {
+		t.Errorf("unexpected values: %+v", ev)
+	}
+	if CanonicalTerminalType(ev) != CanonicalTypeError {
+		t.Error("error must be terminal")
+	}
+}
+
+// Contract §7: an unknown top-level type is surfaced, never dropped.
+func TestParseCanonicalUnknownTypeIsVisible(t *testing.T) {
+	e := ParseCanonicalEvent([]byte(`{"type":"needs_input","prompt":"Which mailbox?"}`))
+	u, ok := e.(CanonicalUnsupportedEvent)
+	if !ok {
+		t.Fatalf("expected CanonicalUnsupportedEvent, got %T", e)
+	}
+	if u.EventType != "needs_input" {
+		t.Errorf("event type = %q", u.EventType)
+	}
+	if !strings.Contains(u.Raw, "Which mailbox?") {
+		t.Errorf("raw payload not retained: %q", u.Raw)
+	}
+}
+
+func TestParseCanonicalMalformedIsVisible(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+	}{
+		{"not json", `{"type":"token"`},
+		{"no type", `{"message":"orphan"}`},
+		{"wrong field type", `{"type":"token","delta":42}`},
+		{"empty", ``},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			e := ParseCanonicalEvent([]byte(tc.in))
+			m, ok := e.(CanonicalMalformedEvent)
+			if !ok {
+				t.Fatalf("expected CanonicalMalformedEvent, got %T", e)
+			}
+			if m.Reason == "" {
+				t.Error("a malformed event must carry a reason")
+			}
+			if CanonicalTerminalType(e) != "" {
+				t.Error("a malformed event must not terminate the run")
+			}
+		})
+	}
+}
+
+func TestParseCanonicalTruncatesHugePayload(t *testing.T) {
+	huge := `{"type":"nope","blob":"` + strings.Repeat("x", 5000) + `"}`
+	u, ok := ParseCanonicalEvent([]byte(huge)).(CanonicalUnsupportedEvent)
+	if !ok {
+		t.Fatalf("expected CanonicalUnsupportedEvent")
+	}
+	if len(u.Raw) > maxRawEcho+4 {
+		t.Errorf("raw echo not truncated: %d bytes", len(u.Raw))
+	}
+}
+
+// The legacy in-process vocabulary must keep working — the subprocess transport
+// still speaks it.
+func TestLegacyParserStillIndependent(t *testing.T) {
+	legacy, err := ParseEvent([]byte(`{"type":"answer","content":"hi","steps":1,"tools_used":0}`))
+	if err != nil {
+		t.Fatalf("legacy ParseEvent: %v", err)
+	}
+	if _, ok := legacy.(AnswerEvent); !ok {
+		t.Fatalf("expected AnswerEvent, got %T", legacy)
+	}
+	// "answer" is not part of the canonical seven.
+	if _, ok := ParseCanonicalEvent([]byte(`{"type":"answer","content":"hi"}`)).(CanonicalUnsupportedEvent); !ok {
+		t.Error("legacy `answer` must read as unsupported on the canonical parser")
+	}
+}

--- a/tui/internal/event/parser.go
+++ b/tui/internal/event/parser.go
@@ -5,7 +5,10 @@ import (
 	"fmt"
 )
 
-// ParseEvent parses a JSONL line into a concrete event type.
+// ParseEvent parses a JSONL line into a concrete LEGACY event type — the
+// subprocess transport's vocabulary (see the freeze note in types.go).
+//
+// Use ParseCanonicalEvent for anything arriving over the daemon relay.
 // Returns the typed event or an error if the line is invalid JSON or has an unknown type.
 func ParseEvent(line []byte) (interface{}, error) {
 	var base Event

--- a/tui/internal/event/types.go
+++ b/tui/internal/event/types.go
@@ -2,6 +2,17 @@ package event
 
 import "encoding/json"
 
+// The LEGACY in-process event vocabulary, spoken only by the subprocess
+// transport (the local C++ agents). It is FROZEN: do not add types here, and do
+// not implement new UI features against it.
+//
+// Everything reached over the daemon relay speaks the canonical seven-event
+// contract in canonical.go instead. New rendering work — approval prompts, result
+// cards, error remedies — belongs on the canonical path only, or it has to be
+// written and maintained twice. The two sets deliberately do not share Go types
+// even where they share wire names (`status`, `tool_result`, `error`), because
+// the parser is chosen by transport and the payload shapes differ.
+
 // Event is the base for all events. Use ParseEvent() to get concrete types.
 type Event struct {
 	Type string `json:"type"`

--- a/tui/internal/ui/app.go
+++ b/tui/internal/ui/app.go
@@ -32,12 +32,19 @@ func RunHub(debug bool, mockAgent string) error {
 }
 
 // RunChat launches the chat TUI directly with a subprocess agent (standalone mode).
+//
+// subprocess is a command line, so it is split with quoting honoured — a binary
+// path containing a space must be quoted, not silently torn in two.
 func RunChat(subprocess string, query string, debug bool) error {
-	c := client.NewSubprocessClient(subprocess, debug)
+	argv, err := client.SplitCommandLine(subprocess)
+	if err != nil {
+		return fmt.Errorf("invalid --subprocess command: %w", err)
+	}
+
+	c := client.NewSubprocessClient(argv[0], argv[1:], debug)
 	defer c.Close()
 
-	agentName := extractAgentName(subprocess)
-	model := chat.NewChatModel(c, agentName, query, debug)
+	model := chat.NewChatModel(c, agentNameFromPath(argv[0]), query, debug)
 
 	p := tea.NewProgram(model, tea.WithAltScreen())
 	if _, err := p.Run(); err != nil {
@@ -46,12 +53,7 @@ func RunChat(subprocess string, query string, debug bool) error {
 	return nil
 }
 
-func extractAgentName(cmdLine string) string {
-	parts := strings.Fields(cmdLine)
-	if len(parts) == 0 {
-		return "agent"
-	}
-	name := filepath.Base(parts[0])
-	name = strings.TrimSuffix(name, ".exe")
-	return name
+func agentNameFromPath(path string) string {
+	name := filepath.Base(path)
+	return strings.TrimSuffix(name, ".exe")
 }

--- a/tui/internal/ui/app.go
+++ b/tui/internal/ui/app.go
@@ -1,7 +1,9 @@
 package ui
 
 import (
+	"context"
 	"fmt"
+	"os"
 	"path/filepath"
 	"strings"
 
@@ -51,6 +53,63 @@ func RunChat(subprocess string, query string, debug bool) error {
 		return fmt.Errorf("TUI error: %w", err)
 	}
 	return nil
+}
+
+// RunAgent launches one catalog agent by id, over whatever transport that entry
+// declares — so the daemon/SSE transport is reachable without waiting for the
+// hub's install flow.
+//
+// With query != "" this is a genuine non-interactive one-shot: no alt screen, the
+// answer on stdout, progress on stderr, and a real exit code. That is what makes
+// the transport exercisable from a script, from CI, and against a live daemon.
+// Returns the process exit code.
+func RunAgent(agentID, query, model string, debug bool) (int, error) {
+	cat := catalog.NewCatalog()
+	cat.DiscoverBinaries()
+
+	agent := cat.Get(agentID)
+	if agent == nil {
+		return 1, fmt.Errorf("no agent %q in the catalog — known ids: %s",
+			agentID, strings.Join(agentIDs(cat), ", "))
+	}
+
+	logf := func(string, ...any) {}
+	if debug {
+		logf = func(format string, args ...any) {
+			fmt.Fprintf(os.Stderr, "[DEBUG] "+format+"\n", args...)
+		}
+	}
+
+	c, err := client.ForAgent(*agent, client.ForAgentOptions{
+		Debug: debug,
+		Model: model,
+		Logf:  logf,
+	})
+	if err != nil {
+		return 1, err
+	}
+	defer c.Close()
+
+	if query != "" {
+		res := RunOneShot(context.Background(), c, query, os.Stdout, os.Stderr)
+		return res.ExitCode, nil
+	}
+
+	model_ := chat.NewChatModel(c, agent.Name, "", debug)
+	p := tea.NewProgram(model_, tea.WithAltScreen())
+	if _, err := p.Run(); err != nil {
+		return 1, fmt.Errorf("TUI error: %w", err)
+	}
+	return 0, nil
+}
+
+func agentIDs(cat *catalog.Catalog) []string {
+	all := cat.All()
+	ids := make([]string, 0, len(all))
+	for _, a := range all {
+		ids = append(ids, a.ID)
+	}
+	return ids
 }
 
 func agentNameFromPath(path string) string {

--- a/tui/internal/ui/chat/canonical.go
+++ b/tui/internal/ui/chat/canonical.go
@@ -1,0 +1,161 @@
+package chat
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/amd/gaia/tui/internal/event"
+	"github.com/amd/gaia/tui/internal/ui/components"
+)
+
+// handleCanonicalEvent renders the canonical `/query` SSE vocabulary — what the
+// daemon transport streams. handled is false for anything else, so the legacy
+// in-process types (used by the subprocess transport) fall through untouched.
+func (m ChatModel) handleCanonicalEvent(evt interface{}) (ChatModel, tea.Cmd, bool) {
+	switch e := evt.(type) {
+	case event.CanonicalStatusEvent:
+		if msg := strings.TrimSpace(e.Message); msg != "" {
+			m.activity = append(m.activity, ActivityItem{Kind: "status", Content: msg})
+		}
+
+	case event.CanonicalTokenEvent:
+		m.buffer += e.Delta
+
+	case event.CanonicalToolCallEvent:
+		label := e.Tool
+		if arg := extractCommandFromArgs(e.Args); arg != "" {
+			label += ": " + arg
+		}
+		m.activity = append(m.activity, ActivityItem{Kind: "tool", Content: label})
+
+	case event.CanonicalToolResultEvent:
+		m.markToolDone(e)
+
+	case event.CanonicalNeedsConfirmationEvent:
+		// The approval UI is a later phase. Until then the pause is surfaced as a
+		// message the user can actually read — never swallowed — and the run
+		// continues to its own terminal event.
+		line := "confirmation needed: " + e.Action
+		if summary := strings.TrimSpace(e.Summary); summary != "" {
+			line += " — " + summary
+		}
+		m.messages = append(m.messages, Message{Role: RoleStatus, Content: "⚠️  " + line})
+
+	case event.CanonicalFinalEvent:
+		usage := event.CanonicalUsageOf(e)
+		// Tokens already streamed the answer into the buffer; the terminal
+		// `final` must not print it a second time.
+		content := m.buffer
+		m.buffer = ""
+		if content == "" {
+			content = e.Answer
+		}
+		m.messages = append(m.messages, Message{
+			Role:      RoleAssistant,
+			Content:   content,
+			Rendered:  components.RenderMarkdown(content),
+			Duration:  time.Since(m.queryStart),
+			TTFT:      m.ttft,
+			Steps:     usage.Steps,
+			ToolsUsed: usage.ToolsUsed,
+		})
+		m.streaming = false
+		m.activity = nil
+		if usage.Steps > 0 {
+			m.totalSteps = usage.Steps
+		}
+		m.updateViewport()
+		return m, nil, true
+
+	case event.CanonicalErrorEvent:
+		m.flushBuffer()
+		m.messages = append(m.messages, Message{Role: RoleError, Content: e.Detail})
+		m.streaming = false
+		m.activity = nil
+		m.updateViewport()
+		return m, nil, true
+
+	case event.CanonicalUnsupportedEvent:
+		// Contract §7: a newer agent's event type is shown, never dropped.
+		m.messages = append(m.messages, Message{
+			Role:    RoleStatus,
+			Content: fmt.Sprintf("unsupported event %q from the agent (update GAIA to render it)", e.EventType),
+		})
+
+	case event.CanonicalMalformedEvent:
+		m.messages = append(m.messages, Message{
+			Role:    RoleStatus,
+			Content: "unreadable agent event skipped: " + e.Reason,
+		})
+
+	default:
+		return m, nil, false
+	}
+
+	m.updateViewport()
+	return m, waitForEvent(m.events), true
+}
+
+// markToolDone closes out the activity line opened by the matching tool_call.
+//
+// The canonical tool_result carries no success flag, so the agent's own
+// {"ok": bool} / {"success": bool} convention is read out of `data` when present;
+// absent that, a delivered result counts as completed. The typed render card
+// (Phase 5) is what will show per-tool detail.
+func (m *ChatModel) markToolDone(e event.CanonicalToolResultEvent) {
+	success := toolResultSucceeded(e.Data)
+
+	label := ""
+	if e.Render != "" {
+		label = "render:" + e.Render
+	}
+
+	for i := len(m.activity) - 1; i >= 0; i-- {
+		item := &m.activity[i]
+		if item.Kind != "tool" || item.Done {
+			continue
+		}
+		item.Done = true
+		item.Success = &success
+		if label != "" {
+			item.Content += " → " + label
+		}
+		return
+	}
+
+	// A result with no matching call still has to be visible.
+	content := e.Tool
+	if label != "" {
+		content += " → " + label
+	}
+	m.activity = append(m.activity, ActivityItem{
+		Kind:    "tool",
+		Content: content,
+		Done:    true,
+		Success: &success,
+	})
+}
+
+func toolResultSucceeded(data json.RawMessage) bool {
+	if len(data) == 0 {
+		return true
+	}
+	var probe struct {
+		OK      *bool `json:"ok"`
+		Success *bool `json:"success"`
+	}
+	if err := json.Unmarshal(data, &probe); err != nil {
+		return true
+	}
+	if probe.OK != nil {
+		return *probe.OK
+	}
+	if probe.Success != nil {
+		return *probe.Success
+	}
+	return true
+}

--- a/tui/internal/ui/chat/canonical.go
+++ b/tui/internal/ui/chat/canonical.go
@@ -47,13 +47,16 @@ func (m ChatModel) handleCanonicalEvent(evt interface{}) (ChatModel, tea.Cmd, bo
 
 	case event.CanonicalFinalEvent:
 		usage := event.CanonicalUsageOf(e)
-		// Tokens already streamed the answer into the buffer; the terminal
-		// `final` must not print it a second time.
-		content := m.buffer
-		m.buffer = ""
+		// `answer` is the contract's authoritative field (§4), so it wins over the
+		// streamed tokens rather than the other way round — otherwise the view and
+		// the transcript pushed back as `context` could disagree. The buffered
+		// tokens are the fallback for a sidecar that streams and then sends an
+		// empty `final`. Either way the text is replaced, never printed twice.
+		content := e.Answer
 		if content == "" {
-			content = e.Answer
+			content = m.buffer
 		}
+		m.buffer = ""
 		m.messages = append(m.messages, Message{
 			Role:      RoleAssistant,
 			Content:   content,

--- a/tui/internal/ui/chat/canonical_test.go
+++ b/tui/internal/ui/chat/canonical_test.go
@@ -1,0 +1,235 @@
+package chat
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/amd/gaia/tui/internal/event"
+)
+
+// nullClient satisfies client.AgentClient without doing anything: these tests
+// drive the model's event handling directly.
+type nullClient struct{ resets int }
+
+func (n *nullClient) Send(context.Context, string) (<-chan interface{}, error) {
+	ch := make(chan interface{})
+	close(ch)
+	return ch, nil
+}
+func (n *nullClient) Close() error     { return nil }
+func (n *nullClient) ResetTranscript() { n.resets++ }
+
+func newTestModel(t *testing.T) (ChatModel, *nullClient) {
+	t.Helper()
+	c := &nullClient{}
+	m := NewChatModel(c, "email", "", false)
+	m.width, m.height = 100, 30
+	return m, c
+}
+
+// feed runs a sequence of events through the model, as Bubble Tea would: the
+// model is copied on every update, which is what makes a value-held
+// strings.Builder unusable here.
+func feed(t *testing.T, m ChatModel, events ...interface{}) ChatModel {
+	t.Helper()
+	for _, e := range events {
+		updated, _ := m.handleEvent(e)
+		m = updated.(ChatModel)
+	}
+	return m
+}
+
+func TestCanonicalStreamedTokensBecomeOneAnswer(t *testing.T) {
+	m, _ := newTestModel(t)
+	m.streaming = true
+
+	m = feed(t, m,
+		event.CanonicalStatusEvent{Type: "status", Message: "Scanning inbox"},
+		event.CanonicalTokenEvent{Type: "token", Delta: "You have "},
+		event.CanonicalTokenEvent{Type: "token", Delta: "3 urgent "},
+		event.CanonicalTokenEvent{Type: "token", Delta: "emails."},
+		event.CanonicalFinalEvent{
+			Type:   "final",
+			Answer: "You have 3 urgent emails.",
+			Usage:  []byte(`{"steps":2,"tools_used":1}`),
+		},
+	)
+
+	if m.streaming {
+		t.Error("a terminal `final` must end the turn")
+	}
+	var answers []Message
+	for _, msg := range m.messages {
+		if msg.Role == RoleAssistant {
+			answers = append(answers, msg)
+		}
+	}
+	if len(answers) != 1 {
+		t.Fatalf("expected exactly 1 assistant message, got %d: %+v", len(answers), m.messages)
+	}
+	if answers[0].Content != "You have 3 urgent emails." {
+		t.Errorf("answer = %q", answers[0].Content)
+	}
+	if answers[0].Steps != 2 || answers[0].ToolsUsed != 1 {
+		t.Errorf("usage not carried into the message: %+v", answers[0])
+	}
+}
+
+func TestCanonicalFinalWithoutTokens(t *testing.T) {
+	m, _ := newTestModel(t)
+	m.streaming = true
+
+	m = feed(t, m, event.CanonicalFinalEvent{Type: "final", Answer: "no streaming here"})
+
+	last := m.messages[len(m.messages)-1]
+	if last.Role != RoleAssistant || last.Content != "no streaming here" {
+		t.Fatalf("unexpected message: %+v", last)
+	}
+}
+
+func TestCanonicalToolCallAndResult(t *testing.T) {
+	m, _ := newTestModel(t)
+	m.streaming = true
+
+	m = feed(t, m,
+		event.CanonicalToolCallEvent{Type: "tool_call", Tool: "search_email", Args: []byte(`{"query":"invoice"}`)},
+		event.CanonicalToolResultEvent{
+			Type: "tool_result", Tool: "search_email",
+			Render: "table", Data: []byte(`{"ok":true,"columns":["from"],"rows":[["a@b.c"]]}`),
+		},
+	)
+
+	if len(m.activity) != 1 {
+		t.Fatalf("expected one tool activity line, got %+v", m.activity)
+	}
+	item := m.activity[0]
+	if !item.Done {
+		t.Error("the tool line must be marked done by its result")
+	}
+	if item.Success == nil || !*item.Success {
+		t.Errorf("expected success from {\"ok\":true}, got %v", item.Success)
+	}
+	if !strings.Contains(item.Content, "search_email") || !strings.Contains(item.Content, "invoice") {
+		t.Errorf("tool line lost its detail: %q", item.Content)
+	}
+	// The render key must stay visible until Phase 5 draws the real card.
+	if !strings.Contains(item.Content, "render:table") {
+		t.Errorf("render hint not surfaced: %q", item.Content)
+	}
+}
+
+func TestCanonicalToolResultFailureIsMarkedFailed(t *testing.T) {
+	m, _ := newTestModel(t)
+	m.streaming = true
+
+	m = feed(t, m,
+		event.CanonicalToolCallEvent{Type: "tool_call", Tool: "send_draft"},
+		event.CanonicalToolResultEvent{Type: "tool_result", Tool: "send_draft", Data: []byte(`{"ok":false}`)},
+	)
+
+	item := m.activity[0]
+	if item.Success == nil || *item.Success {
+		t.Errorf("expected failure from {\"ok\":false}, got %v", item.Success)
+	}
+}
+
+// needs_confirmation must be visible and must NOT end the turn — the sidecar
+// sends its own terminal event right after.
+func TestCanonicalNeedsConfirmationIsSurfacedAndTurnContinues(t *testing.T) {
+	m, _ := newTestModel(t)
+	m.streaming = true
+
+	m = feed(t, m, event.CanonicalNeedsConfirmationEvent{
+		Type: "needs_confirmation", RunID: "abc",
+		Action: "send_draft", Summary: "Send reply to alice@example.com",
+	})
+
+	if !m.streaming {
+		t.Error("needs_confirmation must not end the turn on its own")
+	}
+	last := m.messages[len(m.messages)-1]
+	if last.Role != RoleStatus {
+		t.Fatalf("unexpected role %v", last.Role)
+	}
+	if !strings.Contains(last.Content, "send_draft") || !strings.Contains(last.Content, "alice@example.com") {
+		t.Errorf("the pending action must be readable: %q", last.Content)
+	}
+
+	m = feed(t, m, event.CanonicalFinalEvent{Type: "final", Answer: "Skipped — needs approval."})
+	if m.streaming {
+		t.Error("the following `final` must end the turn")
+	}
+}
+
+func TestCanonicalErrorEndsTurnAndKeepsPartialText(t *testing.T) {
+	m, _ := newTestModel(t)
+	m.streaming = true
+
+	m = feed(t, m,
+		event.CanonicalTokenEvent{Type: "token", Delta: "partial answer"},
+		event.CanonicalErrorEvent{Type: "error", Detail: "Lemonade Server is not reachable — run `gaia init`", Status: 503},
+	)
+
+	if m.streaming {
+		t.Error("a terminal `error` must end the turn")
+	}
+	var sawPartial, sawError bool
+	for _, msg := range m.messages {
+		if msg.Role == RoleAssistant && msg.Content == "partial answer" {
+			sawPartial = true
+		}
+		if msg.Role == RoleError && strings.Contains(msg.Content, "gaia init") {
+			sawError = true
+		}
+	}
+	if !sawPartial {
+		t.Error("streamed text must not be discarded when the run errors")
+	}
+	if !sawError {
+		t.Errorf("the actionable detail must be surfaced verbatim: %+v", m.messages)
+	}
+}
+
+func TestCanonicalUnsupportedAndMalformedAreVisible(t *testing.T) {
+	m, _ := newTestModel(t)
+	m.streaming = true
+
+	m = feed(t, m,
+		event.CanonicalUnsupportedEvent{EventType: "needs_input", Raw: `{"type":"needs_input"}`},
+		event.CanonicalMalformedEvent{Payload: `{"type":"token"`, Reason: "not valid JSON: unexpected end"},
+	)
+
+	if !m.streaming {
+		t.Error("neither event terminates the run")
+	}
+	if len(m.messages) != 2 {
+		t.Fatalf("both events must be shown, got %+v", m.messages)
+	}
+	if !strings.Contains(m.messages[0].Content, "needs_input") {
+		t.Errorf("unsupported event not named: %q", m.messages[0].Content)
+	}
+	if !strings.Contains(m.messages[1].Content, "not valid JSON") {
+		t.Errorf("malformed reason not shown: %q", m.messages[1].Content)
+	}
+}
+
+// The legacy in-process vocabulary must keep working for the subprocess transport.
+func TestLegacyEventsStillHandled(t *testing.T) {
+	m, _ := newTestModel(t)
+	m.streaming = true
+
+	m = feed(t, m,
+		event.StepEvent{Type: "step", Step: 1, Total: 3, Status: "running"},
+		event.ThinkingEvent{Type: "thinking", Content: "let me look"},
+		event.AnswerEvent{Type: "answer", Content: "legacy answer", Steps: 1, ToolsUsed: 0},
+	)
+
+	if m.streaming {
+		t.Error("a legacy answer must end the turn")
+	}
+	last := m.messages[len(m.messages)-1]
+	if last.Role != RoleAssistant || last.Content != "legacy answer" {
+		t.Fatalf("unexpected message: %+v", last)
+	}
+}

--- a/tui/internal/ui/chat/model.go
+++ b/tui/internal/ui/chat/model.go
@@ -88,7 +88,10 @@ type ChatModel struct {
 	messages  []Message
 	activity  []ActivityItem
 	streaming bool
-	buffer    strings.Builder
+	// buffer accumulates streamed answer text. A plain string, not a
+	// strings.Builder: Bubble Tea copies the model on every update, and a
+	// Builder panics the moment a copied non-zero one is written to again.
+	buffer string
 
 	input    textarea.Model
 	viewport viewport.Model
@@ -305,6 +308,12 @@ func (m ChatModel) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			return m, nil
 		case query == "/clear":
 			m.messages = nil
+			// Daemon-transport agents are stateless per turn: the host pushes the
+			// transcript back as `context`, so clearing the view must clear that
+			// too or the "cleared" history keeps being sent.
+			if r, ok := m.client.(client.TranscriptResetter); ok {
+				r.ResetTranscript()
+			}
 			m.updateViewport()
 			return m, nil
 		}
@@ -336,7 +345,7 @@ func (m ChatModel) sendQuery(query string) (tea.Model, tea.Cmd) {
 	})
 	m.streaming = true
 	m.activity = nil
-	m.buffer.Reset()
+	m.buffer = ""
 	m.queryStart = time.Now()
 	m.firstEvent = false
 	m.ttft = 0
@@ -375,6 +384,12 @@ func (m ChatModel) handleEvent(evt interface{}) (tea.Model, tea.Cmd) {
 	if !m.firstEvent {
 		m.firstEvent = true
 		m.ttft = time.Since(m.queryStart)
+	}
+
+	// The daemon transport speaks the canonical seven-event contract; the
+	// subprocess transport speaks the legacy in-process vocabulary below.
+	if updated, cmd, handled := m.handleCanonicalEvent(evt); handled {
+		return updated, cmd
 	}
 
 	switch e := evt.(type) {
@@ -479,7 +494,7 @@ func (m ChatModel) handleEvent(evt interface{}) (tea.Model, tea.Cmd) {
 		return m, nil
 
 	case event.ChunkEvent:
-		m.buffer.WriteString(e.Content)
+		m.buffer += e.Content
 
 	case event.AgentErrorEvent:
 		m.messages = append(m.messages, Message{
@@ -514,7 +529,7 @@ func (m ChatModel) handleEvent(evt interface{}) (tea.Model, tea.Cmd) {
 }
 
 func (m *ChatModel) flushBuffer() {
-	content := m.buffer.String()
+	content := m.buffer
 	if content == "" {
 		return
 	}
@@ -524,7 +539,7 @@ func (m *ChatModel) flushBuffer() {
 		Content:  content,
 		Rendered: rendered,
 	})
-	m.buffer.Reset()
+	m.buffer = ""
 }
 
 func (m *ChatModel) resize() {
@@ -570,7 +585,7 @@ func (m *ChatModel) updateViewport() {
 		sb.WriteString("\n")
 	}
 
-	buf := m.buffer.String()
+	buf := m.buffer
 	if m.streaming && buf != "" {
 		sb.WriteString(assistantStyle.Render(buf))
 		sb.WriteString("\n")

--- a/tui/internal/ui/chat/model.go
+++ b/tui/internal/ui/chat/model.go
@@ -18,9 +18,16 @@ import (
 	"github.com/amd/gaia/tui/internal/ui/components"
 )
 
-type eventMsg struct{ event interface{} }
+// eventMsg and doneMsg carry the channel they came from. Bubble Tea cannot
+// cancel an already-dispatched Cmd, so a cancelled turn's waitForEvent goroutine
+// stays parked on its old channel and delivers late — without the tag, that late
+// delivery would tear down whatever turn is running by then.
+type eventMsg struct {
+	ch    <-chan interface{}
+	event interface{}
+}
 type errMsg struct{ err error }
-type doneMsg struct{}
+type doneMsg struct{ ch <-chan interface{} }
 type sendQueryMsg struct{ query string }
 type channelReadyMsg struct{ ch <-chan interface{} }
 
@@ -187,9 +194,15 @@ func (m ChatModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, waitForEvent(m.events)
 
 	case eventMsg:
+		if m.supersededTurn(msg.ch) {
+			return m, nil
+		}
 		return m.handleEvent(msg.event)
 
 	case doneMsg:
+		if m.supersededTurn(msg.ch) {
+			return m, nil
+		}
 		m.streaming = false
 		m.events = nil
 		m.cancelFn = nil
@@ -374,10 +387,28 @@ func waitForEvent(ch <-chan interface{}) tea.Cmd {
 		}
 		evt, ok := <-ch
 		if !ok {
-			return doneMsg{}
+			return doneMsg{ch: ch}
 		}
-		return eventMsg{event: evt}
+		return eventMsg{ch: ch, event: evt}
 	}
+}
+
+// supersededTurn reports whether a message belongs to a turn that is no longer
+// the current one, so it must be ignored rather than allowed to end the live turn.
+func (m ChatModel) supersededTurn(ch <-chan interface{}) bool {
+	return ch != nil && ch != m.events
+}
+
+// CancelActiveTurn stops any in-flight turn. The UI owns the per-turn context, so
+// tearing this view down has to cancel it — otherwise the transport keeps
+// streaming into a screen nobody is watching and the agent run stays alive.
+func (m *ChatModel) CancelActiveTurn() {
+	if m.cancelFn != nil {
+		m.cancelFn()
+		m.cancelFn = nil
+	}
+	m.streaming = false
+	m.events = nil
 }
 
 func (m ChatModel) handleEvent(evt interface{}) (tea.Model, tea.Cmd) {

--- a/tui/internal/ui/hub/model.go
+++ b/tui/internal/ui/hub/model.go
@@ -100,6 +100,12 @@ func (m HubModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	return m, cmd
 }
 
+// SetStatus shows an ephemeral message in the hub, used to surface a launch
+// failure without leaving the user staring at an unchanged screen.
+func (m *HubModel) SetStatus(status string) {
+	m.status = status
+}
+
 func (m HubModel) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	switch msg.String() {
 	case "q", "ctrl+c":

--- a/tui/internal/ui/oneshot.go
+++ b/tui/internal/ui/oneshot.go
@@ -1,0 +1,153 @@
+package ui
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/amd/gaia/tui/internal/client"
+	"github.com/amd/gaia/tui/internal/event"
+)
+
+// OneShotResult is the outcome of one non-interactive turn. It mirrors
+// gaia.daemon.agent_query.QueryOutcome so the Go and Python thin clients report
+// the same thing.
+type OneShotResult struct {
+	// ExitCode is 0 on a terminal `final`, 1 on a terminal `error` or a stream
+	// that ended without either.
+	ExitCode int
+	// TerminalType is "final", "error", or "" when no terminal event arrived.
+	TerminalType string
+	Answer       string
+	ErrorDetail  string
+}
+
+// RunOneShot drives a single turn and renders it to plain streams — no alt
+// screen, no TTY required.
+//
+// The answer goes to out and progress to errW, so `... --query X > answer.txt`
+// captures exactly the answer and nothing else. This is the same split the
+// `gaia <agent>` CLI uses, and it is what makes the transport testable from a
+// script and from CI.
+func RunOneShot(
+	ctx context.Context,
+	c client.AgentClient,
+	query string,
+	out, errW io.Writer,
+) OneShotResult {
+	ch, err := c.Send(ctx, query)
+	if err != nil {
+		fmt.Fprintf(errW, "❌ %v\n", err)
+		return OneShotResult{ExitCode: 1, ErrorDetail: err.Error()}
+	}
+
+	var (
+		res       OneShotResult
+		streamed  strings.Builder
+		sawTokens bool
+	)
+
+	for evt := range ch {
+		switch e := evt.(type) {
+		case event.CanonicalStatusEvent:
+			if msg := strings.TrimSpace(e.Message); msg != "" {
+				fmt.Fprintf(errW, "  … %s\n", msg)
+			}
+
+		case event.CanonicalTokenEvent:
+			if e.Delta == "" {
+				continue
+			}
+			sawTokens = true
+			streamed.WriteString(e.Delta)
+			fmt.Fprint(out, e.Delta)
+
+		case event.CanonicalToolCallEvent:
+			fmt.Fprintf(errW, "  🔧 %s\n", e.Tool)
+
+		case event.CanonicalToolResultEvent:
+			if e.Render != "" {
+				fmt.Fprintf(errW, "  ✓ %s (%s)\n", e.Tool, e.Render)
+			} else {
+				fmt.Fprintf(errW, "  ✓ %s\n", e.Tool)
+			}
+
+		case event.CanonicalNeedsConfirmationEvent:
+			line := "  ⚠️  confirmation needed: " + e.Action
+			if summary := strings.TrimSpace(e.Summary); summary != "" {
+				line += " — " + summary
+			}
+			fmt.Fprintln(errW, line)
+
+		case event.CanonicalFinalEvent:
+			res.TerminalType = event.CanonicalTypeFinal
+			// `answer` is authoritative; the streamed tokens are the fallback for
+			// a sidecar that streams and then closes with an empty final.
+			res.Answer = e.Answer
+			if res.Answer == "" {
+				res.Answer = streamed.String()
+			}
+			if sawTokens {
+				// The tokens already printed the answer live — just end the line.
+				fmt.Fprintln(out)
+			} else if res.Answer != "" {
+				fmt.Fprintln(out, res.Answer)
+			}
+			if usage := event.CanonicalUsageOf(e); usage.Steps > 0 || usage.ToolsUsed > 0 {
+				fmt.Fprintf(errW, "  ℹ️  %d steps, %d tools\n", usage.Steps, usage.ToolsUsed)
+			}
+
+		case event.CanonicalErrorEvent:
+			res.TerminalType = event.CanonicalTypeError
+			res.ErrorDetail = e.Detail
+			if sawTokens {
+				fmt.Fprintln(out)
+			}
+			fmt.Fprintf(errW, "❌ %s\n", e.Detail)
+
+		case event.CanonicalUnsupportedEvent:
+			// Contract §7: visible, never dropped.
+			fmt.Fprintf(errW, "  [unsupported event %q]\n", e.EventType)
+
+		case event.CanonicalMalformedEvent:
+			fmt.Fprintf(errW, "  [unreadable event skipped: %s]\n", e.Reason)
+
+		// The legacy in-process vocabulary, so this renderer also works when
+		// pointed at a subprocess agent.
+		case event.AnswerEvent:
+			res.TerminalType = event.CanonicalTypeFinal
+			res.Answer = e.Content
+			fmt.Fprintln(out, e.Content)
+		case event.AgentErrorEvent:
+			res.TerminalType = event.CanonicalTypeError
+			res.ErrorDetail = e.Content
+			fmt.Fprintf(errW, "❌ %s\n", e.Content)
+		case event.ToolStartEvent:
+			fmt.Fprintf(errW, "  🔧 %s\n", e.Tool)
+		case event.StatusEvent:
+			if msg := strings.TrimSpace(e.Message); msg != "" {
+				fmt.Fprintf(errW, "  … %s\n", msg)
+			}
+		case event.ChunkEvent:
+			sawTokens = true
+			streamed.WriteString(e.Content)
+			fmt.Fprint(out, e.Content)
+
+		default:
+			fmt.Fprintf(errW, "  [unhandled event %T]\n", evt)
+		}
+	}
+
+	if res.TerminalType == "" {
+		// Exactly one terminal event is mandatory; a stream that ends without one
+		// is a failure, reported loudly rather than as an empty success.
+		res.ErrorDetail = fmt.Sprintf(
+			"the %q query stream ended without a terminal final/error event", query)
+		fmt.Fprintf(errW, "❌ %s\n", res.ErrorDetail)
+	}
+	if res.TerminalType != event.CanonicalTypeFinal {
+		res.ExitCode = 1
+	}
+	return res
+}

--- a/tui/internal/ui/oneshot_test.go
+++ b/tui/internal/ui/oneshot_test.go
@@ -1,0 +1,178 @@
+package ui
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/amd/gaia/tui/internal/event"
+)
+
+// scriptedClient replays a fixed event sequence, or fails Send outright.
+type scriptedClient struct {
+	events  []interface{}
+	sendErr error
+}
+
+func (s *scriptedClient) Send(context.Context, string) (<-chan interface{}, error) {
+	if s.sendErr != nil {
+		return nil, s.sendErr
+	}
+	ch := make(chan interface{}, len(s.events))
+	for _, e := range s.events {
+		ch <- e
+	}
+	close(ch)
+	return ch, nil
+}
+
+func (s *scriptedClient) Close() error { return nil }
+
+func run(t *testing.T, events ...interface{}) (OneShotResult, string, string) {
+	t.Helper()
+	var out, errW bytes.Buffer
+	res := RunOneShot(context.Background(), &scriptedClient{events: events}, "q", &out, &errW)
+	return res, out.String(), errW.String()
+}
+
+// The answer goes to stdout and nothing else does, so `--query X > file` captures
+// exactly the answer.
+func TestRunOneShotSeparatesAnswerFromProgress(t *testing.T) {
+	res, out, errW := run(t,
+		event.CanonicalStatusEvent{Type: "status", Message: "Scanning inbox"},
+		event.CanonicalToolCallEvent{Type: "tool_call", Tool: "pre_scan_inbox"},
+		event.CanonicalToolResultEvent{Type: "tool_result", Tool: "pre_scan_inbox", Render: "email_pre_scan"},
+		event.CanonicalFinalEvent{Type: "final", Answer: "3 urgent emails", Usage: []byte(`{"steps":2,"tools_used":1}`)},
+	)
+
+	if res.ExitCode != 0 {
+		t.Errorf("exit code = %d, want 0", res.ExitCode)
+	}
+	if res.TerminalType != event.CanonicalTypeFinal {
+		t.Errorf("terminal = %q", res.TerminalType)
+	}
+	if strings.TrimSpace(out) != "3 urgent emails" {
+		t.Errorf("stdout must carry only the answer, got %q", out)
+	}
+	for _, want := range []string{"Scanning inbox", "pre_scan_inbox", "email_pre_scan", "2 steps"} {
+		if !strings.Contains(errW, want) {
+			t.Errorf("stderr missing %q: %s", want, errW)
+		}
+	}
+}
+
+func TestRunOneShotStreamsTokensWithoutDuplicatingTheAnswer(t *testing.T) {
+	res, out, _ := run(t,
+		event.CanonicalTokenEvent{Type: "token", Delta: "You have "},
+		event.CanonicalTokenEvent{Type: "token", Delta: "3 urgent emails"},
+		event.CanonicalFinalEvent{Type: "final", Answer: "You have 3 urgent emails"},
+	)
+
+	if got := strings.TrimSpace(out); got != "You have 3 urgent emails" {
+		t.Errorf("the answer must not be printed twice, got %q", got)
+	}
+	if res.Answer != "You have 3 urgent emails" {
+		t.Errorf("answer = %q", res.Answer)
+	}
+}
+
+func TestRunOneShotFinalWithEmptyAnswerKeepsStreamedTokens(t *testing.T) {
+	res, out, _ := run(t,
+		event.CanonicalTokenEvent{Type: "token", Delta: "streamed only"},
+		event.CanonicalFinalEvent{Type: "final", Answer: ""},
+	)
+	if res.Answer != "streamed only" {
+		t.Errorf("answer = %q, want the streamed text", res.Answer)
+	}
+	if !strings.Contains(out, "streamed only") {
+		t.Errorf("stdout = %q", out)
+	}
+}
+
+func TestRunOneShotTerminalErrorExitsNonZero(t *testing.T) {
+	res, out, errW := run(t,
+		event.CanonicalErrorEvent{Type: "error", Detail: "Lemonade is not reachable — run `gaia init`", Status: 503},
+	)
+	if res.ExitCode != 1 {
+		t.Errorf("exit code = %d, want 1", res.ExitCode)
+	}
+	if out != "" {
+		t.Errorf("a failed turn must not write to stdout, got %q", out)
+	}
+	if !strings.Contains(errW, "gaia init") {
+		t.Errorf("the actionable detail must be surfaced verbatim: %q", errW)
+	}
+}
+
+// A stream that ends with no terminal event is a failure, not an empty success.
+func TestRunOneShotNoTerminalEventExitsNonZero(t *testing.T) {
+	res, _, errW := run(t,
+		event.CanonicalStatusEvent{Type: "status", Message: "working"},
+	)
+	if res.ExitCode != 1 {
+		t.Errorf("exit code = %d, want 1", res.ExitCode)
+	}
+	if !strings.Contains(errW, "without a terminal") {
+		t.Errorf("stderr must explain the missing terminal event: %q", errW)
+	}
+}
+
+func TestRunOneShotSendFailureIsReported(t *testing.T) {
+	var out, errW bytes.Buffer
+	c := &scriptedClient{sendErr: errFake("no daemon is registered; start one with `gaia daemon start`")}
+	res := RunOneShot(context.Background(), c, "q", &out, &errW)
+
+	if res.ExitCode != 1 {
+		t.Errorf("exit code = %d, want 1", res.ExitCode)
+	}
+	if !strings.Contains(errW.String(), "gaia daemon start") {
+		t.Errorf("the transport error must be surfaced: %q", errW.String())
+	}
+}
+
+// Unknown and unreadable events stay visible (contract §7) and do not end the run.
+func TestRunOneShotSurfacesUnsupportedAndMalformed(t *testing.T) {
+	res, _, errW := run(t,
+		event.CanonicalUnsupportedEvent{EventType: "needs_input"},
+		event.CanonicalMalformedEvent{Reason: "not valid JSON"},
+		event.CanonicalFinalEvent{Type: "final", Answer: "done"},
+	)
+	if res.ExitCode != 0 {
+		t.Errorf("neither event should fail the run, exit = %d", res.ExitCode)
+	}
+	if !strings.Contains(errW, "needs_input") || !strings.Contains(errW, "not valid JSON") {
+		t.Errorf("both must be visible: %q", errW)
+	}
+}
+
+func TestRunOneShotSurfacesNeedsConfirmation(t *testing.T) {
+	_, _, errW := run(t,
+		event.CanonicalNeedsConfirmationEvent{
+			Type: "needs_confirmation", Action: "send_draft",
+			Summary: "Send reply to alice@example.com",
+		},
+		event.CanonicalFinalEvent{Type: "final", Answer: "skipped"},
+	)
+	if !strings.Contains(errW, "send_draft") || !strings.Contains(errW, "alice@example.com") {
+		t.Errorf("a pending approval must never be swallowed: %q", errW)
+	}
+}
+
+// The same renderer also handles a subprocess agent's legacy vocabulary.
+func TestRunOneShotHandlesLegacyEvents(t *testing.T) {
+	res, out, _ := run(t,
+		event.ToolStartEvent{Type: "tool_start", Tool: "bash"},
+		event.AnswerEvent{Type: "answer", Content: "legacy answer"},
+	)
+	if res.ExitCode != 0 {
+		t.Errorf("exit code = %d, want 0", res.ExitCode)
+	}
+	if strings.TrimSpace(out) != "legacy answer" {
+		t.Errorf("stdout = %q", out)
+	}
+}
+
+type errFake string
+
+func (e errFake) Error() string { return string(e) }

--- a/tui/internal/ui/root/model.go
+++ b/tui/internal/ui/root/model.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/amd/gaia/tui/internal/catalog"
 	"github.com/amd/gaia/tui/internal/client"
-	"github.com/amd/gaia/tui/internal/daemon"
 	"github.com/amd/gaia/tui/internal/ui/chat"
 	"github.com/amd/gaia/tui/internal/ui/components"
 	"github.com/amd/gaia/tui/internal/ui/hub"
@@ -128,18 +127,6 @@ func (m RootModel) View() string {
 	return base
 }
 
-// newAgentClient builds the transport the catalog entry asks for.
-func (m RootModel) newAgentClient(agent catalog.Agent) client.AgentClient {
-	if agent.Transport == catalog.TransportDaemon {
-		// HTTP sidecar behind the daemon relay: no binary, no stdin/stdout.
-		return client.NewSSEClient(agent.ID, daemon.New(daemon.Options{Logf: m.logf}), client.SSEOptions{
-			Logf: m.logf,
-		})
-	}
-	// catalog.TransportSubprocess (the zero value): spawn the binary directly.
-	return client.NewSubprocessClient(agent.BinaryPath, agent.BinaryArgs, m.debug)
-}
-
 // logf writes transport diagnostics to stderr in debug mode. It must never be
 // given a daemon token — daemon.Instance redacts its own token when formatted.
 func (m RootModel) logf(format string, args ...any) {
@@ -150,7 +137,12 @@ func (m RootModel) logf(format string, args ...any) {
 }
 
 func (m RootModel) launchAgent(agent catalog.Agent) (tea.Model, tea.Cmd) {
-	c := m.newAgentClient(agent)
+	c, err := client.ForAgent(agent, client.ForAgentOptions{Debug: m.debug, Logf: m.logf})
+	if err != nil {
+		// Stay in the hub and say why, rather than opening a chat that cannot talk.
+		m.hub.SetStatus(err.Error())
+		return m, nil
+	}
 	m.chatClient = c
 
 	m.catalog.SetStatus(agent.ID, catalog.StatusActive)
@@ -174,6 +166,12 @@ func (m RootModel) launchAgent(agent catalog.Agent) (tea.Model, tea.Cmd) {
 func (m RootModel) returnToHub(agentID string) (tea.Model, tea.Cmd) {
 	m.catalog.SetStatus(agentID, catalog.StatusIdle)
 
+	// Cancel before closing: the chat model owns the per-turn context, so closing
+	// the transport without cancelling it can leave a reader streaming into a
+	// screen that no longer exists.
+	if m.chat != nil {
+		m.chat.CancelActiveTurn()
+	}
 	if m.chatClient != nil {
 		m.chatClient.Close()
 		m.chatClient = nil

--- a/tui/internal/ui/root/model.go
+++ b/tui/internal/ui/root/model.go
@@ -1,12 +1,14 @@
 package root
 
 import (
-	"strings"
+	"fmt"
+	"os"
 
 	tea "github.com/charmbracelet/bubbletea"
 
 	"github.com/amd/gaia/tui/internal/catalog"
 	"github.com/amd/gaia/tui/internal/client"
+	"github.com/amd/gaia/tui/internal/daemon"
 	"github.com/amd/gaia/tui/internal/ui/chat"
 	"github.com/amd/gaia/tui/internal/ui/components"
 	"github.com/amd/gaia/tui/internal/ui/hub"
@@ -15,7 +17,7 @@ import (
 type view int
 
 const (
-	viewHub  view = iota
+	viewHub view = iota
 	viewChat
 )
 
@@ -126,13 +128,29 @@ func (m RootModel) View() string {
 	return base
 }
 
-func (m RootModel) launchAgent(agent catalog.Agent) (tea.Model, tea.Cmd) {
-	cmdLine := agent.BinaryPath
-	if len(agent.BinaryArgs) > 0 {
-		cmdLine += " " + strings.Join(agent.BinaryArgs, " ")
+// newAgentClient builds the transport the catalog entry asks for.
+func (m RootModel) newAgentClient(agent catalog.Agent) client.AgentClient {
+	if agent.Transport == catalog.TransportDaemon {
+		// HTTP sidecar behind the daemon relay: no binary, no stdin/stdout.
+		return client.NewSSEClient(agent.ID, daemon.New(daemon.Options{Logf: m.logf}), client.SSEOptions{
+			Logf: m.logf,
+		})
 	}
+	// catalog.TransportSubprocess (the zero value): spawn the binary directly.
+	return client.NewSubprocessClient(agent.BinaryPath, agent.BinaryArgs, m.debug)
+}
 
-	c := client.NewSubprocessClient(cmdLine, m.debug)
+// logf writes transport diagnostics to stderr in debug mode. It must never be
+// given a daemon token — daemon.Instance redacts its own token when formatted.
+func (m RootModel) logf(format string, args ...any) {
+	if !m.debug {
+		return
+	}
+	fmt.Fprintf(os.Stderr, "[DEBUG] "+format+"\n", args...)
+}
+
+func (m RootModel) launchAgent(agent catalog.Agent) (tea.Model, tea.Cmd) {
+	c := m.newAgentClient(agent)
 	m.chatClient = c
 
 	m.catalog.SetStatus(agent.ID, catalog.StatusActive)


### PR DESCRIPTION
The TUI could only reach agents by spawning a local binary and trading JSON over a pipe. The email agent has been a daemon-managed HTTP sidecar since #2191, so it appeared in the hub greyed out and could never actually run. This teaches the TUI to be a second thin client over the daemon relay.

Also lands a genuine non-interactive one-shot — `gaia tui chat --agent email --query "..."` puts the answer on stdout with real exit codes — which is what makes the TUI scriptable and CI-testable.

### Test plan
- [ ] `cd tui && make lint && go test ./... -count=1 && make build`
- [ ] `gaia tui chat --agent email --query "hello" > out.txt` — out.txt holds only the answer, exit 0
- [ ] Kill the daemon mid-stream: the run fails loudly rather than reporting success
- [ ] First turn with no history sends `"context":[]`, not `null`
