### PR TITLE
feat(tui): add the preflight readiness gate

### DIFF
--- a/docs/reference/cli.mdx
+++ b/docs/reference/cli.mdx
@@ -2400,9 +2400,9 @@ gaia tui status                           # background service + what is install
 | `gaia tui list [--installed]` | List agents with version, install state, download size, and security tier. `--installed` reads the local `~/.gaia/agents/*/.installed` sentinels and never touches the network. |
 | `gaia tui install <id> [--version X] [--trust]` | Install an agent and wait for it to finish. |
 | `gaia tui uninstall <id>` | Stop the agent's sidecar, verify it is gone, remove its install directory. |
-| `gaia tui run <id> [--query "…"] [--model M]` | Run an agent. `--query` is a genuine one-shot. |
+| `gaia tui run <id> [--query "…"] [--model M] [--timeout D]` | Run an agent. `--query` is a genuine one-shot, checked and bounded (`--timeout`, default 15m). |
 | `gaia tui status` | Whether the background service is running, which sidecars it knows, and what is installed. |
-| `gaia tui chat --agent <id>` \| `--subprocess <cmd>` | Chat with an agent by catalog id, or with a binary you spawn directly. |
+| `gaia tui chat --agent <id>` \| `--subprocess <cmd>` | Chat with an agent by catalog id, or with a binary you spawn directly. With `--agent --query` it is the same one-shot `gaia tui run --query` is, `--timeout` included. |
 | `gaia tui hub` | The hub screen explicitly (same as bare `gaia tui`). |
 
 Install and uninstall are served by the GAIA daemon
@@ -2452,6 +2452,32 @@ stderr, and the exit code is `0` on a terminal answer / `1` on an error — so
 gaia tui run email --query "how many unread?" > answer.txt 2> progress.log
 echo $?   # 0
 ```
+
+It never waits on something that is not there. Before the query is sent, a
+one-shot over the daemon transport (the agents the background service supervises)
+runs the same readiness check the hub's launch gate runs — background service,
+sidecar, local model server, model, and for email the mailbox — and if one of
+them is not ready it prints that row and its remedy to stderr and exits non-zero.
+Against an unreachable dependency that is about a second; the ceiling is the time
+it takes to start the sidecar. Nothing is sent to the agent, and the gate screen
+is never rendered: a script has nobody to press a key. An agent that runs as a
+local subprocess has no readiness route to probe, so it is launched directly.
+
+```bash
+$ gaia tui run email --query "triage my inbox"   # with the model server down
+❌ Email is not ready — Local AI: not running at http://localhost:8000/api/v1
+   GAIA needs a local model server. It runs on your machine; no message text ever leaves it.
+…
+        run: lemonade-server serve
+$ echo $?   # 1, after about a second
+```
+
+The turn itself is bounded — 15 minutes by default, `--timeout 90s` / `--timeout
+2h` to change it — so an agent that accepts the query and then stops answering is
+reported with what to read next instead of hanging a CI job until the job's own
+timeout kills it. There is no "wait forever": `--timeout 0` is refused. Interactive
+`gaia tui run <id>` is unaffected — a person can read what arrives and press
+ctrl+c.
 
 #### Hub keys
 

--- a/docs/spec/agent-hub-restructure.mdx
+++ b/docs/spec/agent-hub-restructure.mdx
@@ -66,6 +66,7 @@ src/gaia/agents/                 src/gaia/agents/        ← framework only
 3. **Shared tool mixins promoted to framework.** RAG, FileIO, Shell, CodeIndex mixins move into `src/gaia/agents/tools/` so agents don't depend on each other for tools.
 4. **Entry-point discovery.** Agents register via the `gaia.agent` entry point group. The registry discovers installed agent wheels at startup — no hardcoded agent list.
 5. **Framework-provided generic server.** `src/gaia/agents/base/server.py` wraps any Agent into an OpenAI-compatible REST API + MCP stdio server. Agents don't implement server logic.
+6. **Inherited init.** An agent *declares* what it needs — a model id, a minimum backend version — and the framework serves `GET`/`POST /v1/<id>/init` for it. Agents don't hand-write readiness or provisioning endpoints. See [Inherited init](#inherited-init).
 
 ## Pre-requisite: Promote shared tool mixins
 
@@ -128,6 +129,69 @@ chat = "gaia_agent_chat.agent:ChatAgent"
 
 Agents with cross-agent dependencies (e.g. RoutingAgent uses CodeAgent) declare them as package dependencies: `dependencies = ["amd-gaia>=0.18.0", "gaia-agent-code>=0.1.0"]`.
 
+## Inherited init
+
+An agent that needs a model before it can answer anything should not have to
+hand-write a readiness endpoint to say so. It **declares** the requirement and
+`AgentServer` serves both verbs at `/v1/<id>/init`:
+
+| Verb | Effect | Status |
+|------|--------|--------|
+| `GET` | Read-only readiness probe. Reports backend reachability, version compatibility, and whether the declared model is downloaded — with an actionable `hint` per failure. | `200` ready · `503` not ready, **same body** either way |
+| `POST` | Provisioning. Tells an already-running backend to download the declared model, streaming newline-terminated progress. | `503` before streaming if the backend is down · otherwise a committed `200` |
+
+Declare requirements in `gaia-agent.yaml` (`models:` and
+`requirements.min_lemonade_version`), or pass them explicitly:
+
+```python
+from gaia.agents.base.readiness import AgentRequirements
+from gaia.agents.base.server import AgentServer
+
+server = AgentServer(
+    MyAgent(),
+    agent_id="my-agent",
+    requirements=AgentRequirements(
+        model_id="Gemma-4-E4B-it-GGUF",
+        min_backend_version="10.2.0",
+    ),
+)
+```
+
+An agent that declares nothing gets **no** init routes — a readiness endpoint
+that reports "ready" without having checked anything is worse than a 404,
+because a consumer would trust it.
+
+### Where the boundary sits
+
+Inherited init makes *this agent's* requirements ready: its model, against a
+backend that is already running. **Installing the backend stays with `gaia
+init`.** An agent process cannot bootstrap the server it depends on, so when
+Lemonade is unreachable both verbs fail loudly and name whose job the fix is
+rather than hanging or half-succeeding:
+
+```
+✗ The local Lemonade Server is not reachable at http://127.0.0.1:9099/api/v1.
+✗ Start it with `lemonade-server serve` (or run `gaia init`), then POST to this path again.
+✗ My Agent can't install the backend itself — that's a host prerequisite.
+```
+
+### Reading a provisioning result
+
+Once a streamed `200` is committed the HTTP status can no longer change, so a
+pull that fails half-way still arrives as `200 OK`. **The final line is the
+verdict** — `✓` success, `✗` failure, `⚠` succeeded-but-unverified. Consumers
+must read it rather than the status code; the TUI's preflight gate
+(`tui/internal/ui/preflight`) already does.
+
+Two distinctions the contract preserves deliberately, because each has a
+different remedy:
+
+- **"Could not tell" is not "missing."** If the backend answers `/health` but
+  its model list cannot be read, `present:false` means unknown — reporting it as
+  missing would send the user to re-download a model they may already have.
+- **Indeterminate is not a pass.** A backend that advertises no version yields
+  `compatible: null`, never `true`.
+
 ## Implementation Steps
 
 <Steps>
@@ -153,7 +217,7 @@ Remove agent packages from `setup.py`. Remove `gaia-emr`/`gaia-code` console scr
 Replace ~16 direct agent imports in `cli.py`, `ui/_chat_helpers.py`, `ui/agent_loop.py`, and apps with `registry.create_agent(id)`.
 </Step>
 <Step title="Add framework generic server">
-`src/gaia/agents/base/server.py` wraps any Agent into REST API + MCP server. Enables `gaia agent run <id> --api` and `--mcp`.
+`src/gaia/agents/base/server.py` wraps any Agent into REST API + MCP server. Enables `gaia agent run <id> --api` and `--mcp`, and serves the agent's [inherited init](#inherited-init) routes.
 </Step>
 <Step title="Add CI/CD workflow">
 `.github/workflows/build_agents.yml` matrix-builds the C++ agent binaries;

--- a/src/gaia/agents/base/readiness.py
+++ b/src/gaia/agents/base/readiness.py
@@ -1,0 +1,621 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""Inherited agent init: readiness probing and provisioning, declared not coded.
+
+An agent states what it needs — a model id, a minimum backend version — and gets
+``GET``/``POST /v1/<id>/init`` from :class:`~gaia.agents.base.server.AgentServer`
+for free. Before this module every agent that wanted a readiness contract had to
+hand-write both verbs; the email sidecar did, and was the only one that had them.
+
+Two verbs, deliberately asymmetric:
+
+* **GET** — read-only. Probes the backend and reports a structured status with an
+  actionable ``hint`` per failure. Never pulls, never installs, never mutates.
+* **POST** — provisioning. Tells an *already-running* backend to download the
+  declared model, streaming newline-terminated progress so a consumer can render
+  it terminal-style.
+
+**Where the boundary sits.** Inherited init makes *this agent's* requirements
+ready: its model, against a backend that is already up. Installing the backend
+itself stays with ``gaia init`` — an agent process cannot bootstrap the server it
+depends on, and pretending otherwise would turn a clear error into a hang. When
+the backend is unreachable both verbs fail loudly and name whose job the fix is;
+:func:`provision_progress` is never even reached. Do not grow an installer here.
+
+**Why the final line decides a pull, not the status code.** Once a streamed 200
+is committed the status can no longer change, so a pull that fails half-way still
+arrives as ``200 OK``. The last line carries the verdict: ``✓`` success, ``✗``
+failure, ``⚠`` succeeded-but-unverified. Consumers must read it rather than the
+status. The TUI's preflight gate already does (``tui/internal/ui/preflight``).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Iterator, List, Optional, Tuple
+
+from gaia.logger import get_logger
+
+logger = get_logger(__name__)
+
+# Fast pre-flight timeouts for the "is the backend even up?" probe. The real
+# chat path uses a long scalar timeout — correct for generation, but it also
+# governs the TCP connect, so an unreachable server would block on the OS SYN
+# timeout before erroring. A short connect leg turns "server down" into a prompt
+# answer instead of a 30s hang.
+PROBE_CONNECT_TIMEOUT = 2.0
+PROBE_READ_TIMEOUT = 5.0
+
+# A model pull is a first-download of multi-GB weights — minutes, not seconds.
+# Generous read ceiling so a slow link does not abort a real download; the
+# connect leg stays short so an unreachable server still fails fast.
+PULL_TIMEOUT = (5.0, 1800.0)
+
+
+# ---------------------------------------------------------------------------
+# The declaration
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class AgentRequirements:
+    """What an agent needs before it can serve — the whole declaration.
+
+    Args:
+        model_id: The backend model id the agent loads. ``None`` means the agent
+            has no model requirement, and the model half of the check is skipped
+            rather than reported as missing.
+        min_backend_version: Minimum Lemonade Server version. ``None`` means the
+            agent did not declare one, which is reported as an *indeterminate*
+            version check (``compatible: null``) — never as a pass.
+        base_url: Backend base URL to probe. ``None`` resolves from the
+            environment (``LEMONADE_BASE_URL``), which is what almost every
+            agent wants.
+    """
+
+    model_id: Optional[str] = None
+    min_backend_version: Optional[str] = None
+    base_url: Optional[str] = None
+
+    def declares_anything(self) -> bool:
+        """Whether this states a requirement worth serving an ``/init`` for.
+
+        A declaration of nothing must not produce a readiness endpoint. It would
+        answer ``ready: true`` the moment the backend is up, having verified
+        nothing about the agent — and a consumer would believe it. ``base_url``
+        alone does not count: it says where to look, not what is needed.
+        """
+        return bool(self.model_id or self.min_backend_version)
+
+    @classmethod
+    def from_manifest(cls, manifest: Any) -> "AgentRequirements":
+        """Derive requirements from a parsed ``gaia-agent.yaml``.
+
+        Reads the first entry of the top-level ``models:`` list and
+        ``requirements.min_lemonade_version``.
+
+        NOTE: ``gaia.hub.manifest.Requirements`` does not currently parse
+        ``min_lemonade_version`` — the email manifest declares it and the field
+        is dropped on the floor. Until the parser carries it, this returns
+        ``min_backend_version=None``, which surfaces as ``compatible: null``
+        (indeterminate) rather than a fabricated pass. Agents needing the gate
+        enforced today should construct :class:`AgentRequirements` explicitly.
+        """
+        models = getattr(manifest, "models", None) or []
+        requirements = getattr(manifest, "requirements", None)
+        return cls(
+            model_id=models[0] if models else None,
+            min_backend_version=getattr(requirements, "min_lemonade_version", None),
+        )
+
+
+# ---------------------------------------------------------------------------
+# Response models — the wire contract
+# ---------------------------------------------------------------------------
+#
+# Shape is byte-compatible with the email sidecar's existing /v1/email/init so
+# the TUI preflight gate parses both without a branch. The `lemonade` key is
+# named for the backend rather than generically because that is what shipped and
+# what every consumer already reads; renaming it would break them for cosmetics.
+
+
+def _build_models():
+    """Build the pydantic response models lazily.
+
+    Module import must stay cheap: ``gaia.agents.base.server`` imports this for
+    the dataclass alone in pipe/CLI/MCP modes, which do not pay for pydantic.
+    """
+    from pydantic import BaseModel, Field
+
+    class BackendStatus(BaseModel):
+        """Reachability AND version-compatibility of the local model server."""
+
+        reachable: bool = Field(
+            ..., description="True when the backend answered the /health probe."
+        )
+        base_url: str = Field(..., description="The /api/v1 base URL that was probed.")
+        version: Optional[str] = Field(
+            default=None,
+            description=(
+                "The backend's self-reported version (from /health). Null when "
+                "it does not advertise one."
+            ),
+        )
+        min_version: str = Field(
+            default="",
+            description=(
+                "Minimum backend version this agent declared. Empty when the "
+                "agent declared none, in which case `compatible` is null."
+            ),
+        )
+        compatible: Optional[bool] = Field(
+            default=None,
+            description=(
+                "True when version >= min_version. Null when it could not be "
+                "determined — an indeterminate check, NOT a pass."
+            ),
+        )
+
+    class ModelStatus(BaseModel):
+        """Presence (and, when cheap, loadability) of the declared model."""
+
+        id: str = Field(..., description="The model id the agent declared.")
+        present: bool = Field(
+            ..., description="True when the model is downloaded on the backend."
+        )
+        loadable: Optional[bool] = Field(
+            default=None,
+            description=(
+                "Whether the model actually loads. Not probed — forcing a load "
+                "is heavy — so this is null; `present` is the readiness signal."
+            ),
+        )
+        ctx_size: Optional[int] = Field(
+            default=None,
+            description=(
+                "The context window the model is CURRENTLY loaded at, as "
+                "reported by the backend. Null when it is not loaded right now "
+                "or the backend does not report one — never a config echo."
+            ),
+        )
+
+    class InitResponse(BaseModel):
+        """Readiness preflight for one agent's requirements.
+
+        ``ready`` is True only when the backend is reachable, at a compatible
+        version, and the declared model is present. Served as HTTP 200 when
+        ready and 503 when not, with the SAME body either way, so a consumer can
+        parse one shape and read ``hint`` for the next step.
+        """
+
+        ready: bool = Field(
+            ..., description="True when every declared requirement is satisfied."
+        )
+        lemonade: BackendStatus = Field(..., description="Backend server status.")
+        model: ModelStatus = Field(..., description="Declared model status.")
+        hint: Optional[str] = Field(
+            default=None,
+            description=(
+                "Actionable next step when not ready (what failed / what to "
+                "do). Null when ready."
+            ),
+        )
+
+    return BackendStatus, ModelStatus, InitResponse
+
+
+_MODELS: Optional[Tuple[Any, Any, Any]] = None
+
+
+def init_models() -> Tuple[Any, Any, Any]:
+    """Return ``(BackendStatus, ModelStatus, InitResponse)``, building once."""
+    global _MODELS
+    if _MODELS is None:
+        _MODELS = _build_models()
+    return _MODELS
+
+
+# ---------------------------------------------------------------------------
+# Probes — every one read-only
+# ---------------------------------------------------------------------------
+
+
+def resolve_probe_base(base_url: Optional[str]) -> str:
+    """Resolve the backend's ``/api/v1`` base URL for a probe.
+
+    An explicit ``base_url`` is normalised to end in ``/api/v1`` (callers often
+    omit it); ``None`` falls back to the env-derived default, so every probe in
+    a process targets the same server.
+    """
+    from gaia.llm.lemonade_client import _get_lemonade_config
+
+    if base_url:
+        probe_base = base_url.rstrip("/")
+        if not probe_base.endswith("/api/v1"):
+            probe_base = f"{probe_base}/api/v1"
+        return probe_base
+    _, _, probe_base = _get_lemonade_config()
+    return probe_base
+
+
+def probe_backend_health(
+    base_url: Optional[str] = None,
+) -> Tuple[bool, str, Optional[str], List[dict]]:
+    """Probe the backend's ``/health``.
+
+    Returns ``(reachable, probe_base, version, loaded_models)``. Any HTTP
+    response — even an error status — means the server is up; only a
+    connection/timeout failure counts as unreachable, because auth and model
+    errors surface later on the real call where their messages are specific.
+
+    Never raises: readiness reports values rather than failing.
+    """
+    import requests
+
+    probe_base = resolve_probe_base(base_url)
+    try:
+        resp = requests.get(
+            f"{probe_base}/health",
+            timeout=(PROBE_CONNECT_TIMEOUT, PROBE_READ_TIMEOUT),
+        )
+    except requests.exceptions.RequestException:
+        return False, probe_base, None, []
+
+    version: Optional[str] = None
+    loaded_models: List[dict] = []
+    try:
+        body = resp.json()
+        if isinstance(body, dict):
+            version = body.get("version")
+            raw_loaded = body.get("all_models_loaded", [])
+            if isinstance(raw_loaded, list):
+                loaded_models = [m for m in raw_loaded if isinstance(m, dict)]
+    except ValueError:
+        version = None
+    return True, probe_base, version, loaded_models
+
+
+def probe_model_present(probe_base: str, model_id: str) -> bool:
+    """Check whether ``model_id`` is downloaded on the backend.
+
+    Matches tolerantly via the core comparison — a ``user.``-prefixed
+    registration is listed under the stripped id, so a strict compare would
+    report a downloaded model as missing and send the user to re-pull it.
+
+    Raises ``requests.RequestException`` when the model list cannot be read. The
+    caller MUST distinguish that from "absent": they mean different things and
+    have different remedies.
+    """
+    import requests
+
+    from gaia.llm.lemonade_client import (
+        _model_ids_match,
+        lemonade_auth_headers,
+        resolve_lemonade_api_key,
+    )
+
+    resp = requests.get(
+        f"{probe_base}/models",
+        headers=lemonade_auth_headers(resolve_lemonade_api_key()),
+        timeout=(PROBE_CONNECT_TIMEOUT, PROBE_READ_TIMEOUT),
+    )
+    resp.raise_for_status()
+    body = resp.json()
+    entries = body.get("data", []) if isinstance(body, dict) else []
+    for entry in entries:
+        if isinstance(entry, dict) and _model_ids_match(entry.get("id"), model_id):
+            return True
+    return False
+
+
+def extract_loaded_ctx(loaded_models: List[dict], model_id: str) -> Optional[int]:
+    """The ctx_size the backend reports ``model_id`` loaded at, or None.
+
+    Reports only what the server says: a missing entry, missing
+    ``recipe_options``, or a non-positive value all yield None — never a config
+    echo or a guess.
+    """
+    from gaia.llm.lemonade_client import _model_ids_match
+
+    for entry in loaded_models:
+        if _model_ids_match(entry.get("model_name"), model_id) or _model_ids_match(
+            entry.get("checkpoint"), model_id
+        ):
+            recipe_options = entry.get("recipe_options")
+            if not isinstance(recipe_options, dict):
+                return None
+            ctx = recipe_options.get("ctx_size")
+            if isinstance(ctx, int) and not isinstance(ctx, bool) and ctx > 0:
+                return ctx
+            return None
+    return None
+
+
+def parse_version(version: Optional[str]) -> Optional[Tuple[int, ...]]:
+    """Parse a dotted version into a comparable int tuple, or None."""
+    if not version:
+        return None
+    try:
+        return tuple(int(p) for p in version.lstrip("v").split(".")[:3])
+    except (ValueError, IndexError, AttributeError):
+        return None
+
+
+def version_meets_min(found: Optional[str], minimum: Optional[str]) -> Optional[bool]:
+    """Whether ``found`` >= ``minimum``, or None when it cannot be told.
+
+    None means indeterminate — the server advertised nothing, the string was
+    unparseable, or the agent declared no minimum. Readiness surfaces that as
+    ``compatible: null`` so a consumer sees the check did not run, rather than
+    a fabricated pass.
+    """
+    found_t = parse_version(found)
+    min_t = parse_version(minimum)
+    if found_t is None or min_t is None:
+        return None
+    return found_t >= min_t
+
+
+def pull_model(probe_base: str, model_id: str) -> None:
+    """Tell a RUNNING backend to download ``model_id``.
+
+    Posts ONLY ``model_name`` — sending ``recipe`` for a built-in Lemonade model
+    makes it 400 (#1655), and that failure only reproduces on a cold cache, so
+    it survives every warm-machine test. Raises ``requests.RequestException`` on
+    failure; the caller surfaces it as a loud ``✗`` line.
+
+    This is the ONLY provisioning an agent process can do. It cannot install the
+    backend — see the module docstring.
+    """
+    import requests
+
+    from gaia.llm.lemonade_client import (
+        lemonade_auth_headers,
+        resolve_lemonade_api_key,
+    )
+
+    resp = requests.post(
+        f"{probe_base}/pull",
+        json={"model_name": model_id},
+        headers=lemonade_auth_headers(resolve_lemonade_api_key()),
+        timeout=PULL_TIMEOUT,
+    )
+    resp.raise_for_status()
+
+
+# ---------------------------------------------------------------------------
+# GET — readiness
+# ---------------------------------------------------------------------------
+
+
+def model_list_unreadable(hint: Optional[str]) -> bool:
+    """Whether a hint reports the one failure the structured fields cannot.
+
+    The backend answered /health but its model list read failed, so
+    ``present:false`` means "could not tell", not "missing". Only the hint
+    carries that distinction.
+    """
+    h = (hint or "").lower()
+    return "model list" in h and "could not be read" in h
+
+
+def compute_init_status(
+    requirements: AgentRequirements, agent_name: str = "This agent"
+):
+    """Probe the declared requirements and return a structured status.
+
+    Read-only — never pulls, never installs. Returns a not-ready response with
+    an actionable ``hint`` per failure rather than raising, so one route can
+    serialize the same body under both 200 and 503.
+
+    Failure order is dependency order and it matters: a version too old is
+    reported before a missing model, because upgrading the backend comes first
+    even when both are wrong. Reporting them the other way sends the user to
+    download gigabytes that the old server may then refuse to serve.
+    """
+    import requests
+
+    BackendStatus, ModelStatus, InitResponse = init_models()
+
+    model_id = requirements.model_id
+    reachable, probe_base, version, loaded_models = probe_backend_health(
+        requirements.base_url
+    )
+    compatible = (
+        version_meets_min(version, requirements.min_backend_version)
+        if reachable
+        else None
+    )
+    backend = BackendStatus(
+        reachable=reachable,
+        base_url=probe_base,
+        version=version,
+        min_version=requirements.min_backend_version or "",
+        compatible=compatible,
+    )
+
+    def _model(present: bool, ctx_size: Optional[int] = None):
+        # A model-less agent reports present=True so a consumer's "is the model
+        # downloaded?" check does not raise a failure over a model that was
+        # never required; the id says plainly that there is none.
+        return ModelStatus(
+            id=model_id or "(none required)",
+            present=present,
+            loadable=None,
+            ctx_size=ctx_size,
+        )
+
+    if not reachable:
+        return InitResponse(
+            ready=False,
+            lemonade=backend,
+            model=_model(False),
+            hint=(
+                f"The local Lemonade Server is not reachable at {probe_base} — "
+                "start it with `lemonade-server serve` (or run `gaia init`), "
+                f"then retry. {agent_name} cannot install it: that is a host "
+                "prerequisite, not something an agent can bootstrap."
+            ),
+        )
+
+    # An agent with no declared model has nothing further to check — a reachable
+    # backend at a compatible version is the whole of its readiness.
+    if not model_id:
+        if compatible is False:
+            return InitResponse(
+                ready=False,
+                lemonade=backend,
+                model=_model(False),
+                hint=_version_hint(version, requirements, agent_name),
+            )
+        return InitResponse(ready=True, lemonade=backend, model=_model(True), hint=None)
+
+    loaded_ctx = extract_loaded_ctx(loaded_models, model_id)
+
+    try:
+        present = probe_model_present(probe_base, model_id)
+    except requests.exceptions.RequestException as exc:
+        # Reachable, but the model list could not be read: `present:false` here
+        # means "could not tell", not "missing". Reporting it as missing would
+        # send the user to re-download something they may already have.
+        return InitResponse(
+            ready=False,
+            lemonade=backend,
+            model=_model(False, loaded_ctx),
+            hint=(
+                f"The backend is reachable but its model list at {probe_base}/models "
+                f"could not be read ({type(exc).__name__}: {exc}). Make sure the "
+                "server is healthy, then retry."
+            ),
+        )
+
+    model = _model(present, loaded_ctx)
+
+    if compatible is False:
+        return InitResponse(
+            ready=False,
+            lemonade=backend,
+            model=model,
+            hint=_version_hint(version, requirements, agent_name),
+        )
+
+    if not present:
+        return InitResponse(
+            ready=False,
+            lemonade=backend,
+            model=model,
+            hint=(
+                f"Model `{model_id}` is not downloaded — run `gaia init`, or POST "
+                "to this same path to pull it here, then retry."
+            ),
+        )
+
+    return InitResponse(ready=True, lemonade=backend, model=model, hint=None)
+
+
+def _version_hint(
+    version: Optional[str], requirements: AgentRequirements, agent_name: str
+) -> str:
+    return (
+        f"Lemonade {version} is older than the required "
+        f"{requirements.min_backend_version} that {agent_name} declares — "
+        "upgrade it (see https://lemonade-server.ai or run `gaia init`), then "
+        "retry."
+    )
+
+
+# ---------------------------------------------------------------------------
+# POST — provisioning
+# ---------------------------------------------------------------------------
+
+
+def provision_progress(
+    probe_base: str, model_id: str, agent_name: str = "This agent"
+) -> Iterator[str]:
+    """Yield newline-terminated progress while provisioning the declared model.
+
+    The only provisioning an agent process can do: ask an already-running
+    backend to download the model it declared, narrating each step. The caller
+    checks reachability first so it can return a truthful 503 — this generator
+    runs only once the backend is confirmed up.
+
+    The FINAL line is authoritative (``✓``/``✗``/``⚠``); see the module
+    docstring for why the status code is not.
+    """
+    import requests
+
+    def line(text: str) -> str:
+        return text + "\n"
+
+    yield line(f"→ {agent_name} requires model: {model_id}")
+    yield line(f"→ Backend reachable at {probe_base}")
+    yield line(f"→ Checking whether {model_id} is already downloaded…")
+
+    try:
+        present = probe_model_present(probe_base, model_id)
+    except requests.exceptions.RequestException as exc:
+        yield line(
+            f"✗ Could not read the backend's model list ({type(exc).__name__}: {exc})."
+        )
+        yield line(
+            "✗ Provisioning aborted — make sure the Lemonade Server is healthy, "
+            "then retry."
+        )
+        return
+
+    if present:
+        yield line(f"✓ {model_id} is already downloaded — nothing to pull.")
+        yield line("✓ Provisioning complete. Re-run GET on this path to confirm.")
+        return
+
+    yield line(f"→ Pulling {model_id} — a first download can take several minutes…")
+    try:
+        pull_model(probe_base, model_id)
+    except requests.exceptions.RequestException as exc:
+        yield line(f"✗ Provisioning failed: {type(exc).__name__}: {exc}")
+        yield line(
+            "✗ The model was not downloaded. Check the Lemonade Server logs, "
+            "then retry."
+        )
+        return
+
+    yield line(f"✓ {model_id} downloaded.")
+
+    # Verify the pull actually registered. A verify hiccup is surfaced, not
+    # swallowed, but does not by itself fail a pull the backend reported OK.
+    try:
+        if probe_model_present(probe_base, model_id):
+            yield line(f"✓ Verified {model_id} is registered with the backend.")
+        else:
+            yield line(
+                f"✗ {model_id} is still not listed after the pull — provisioning "
+                "incomplete. Check the Lemonade Server logs, then retry."
+            )
+            return
+    except requests.exceptions.RequestException as exc:
+        yield line(
+            f"⚠ The pull reported success but the model list could not be re-read "
+            f"({type(exc).__name__}). Re-run GET on this path to confirm."
+        )
+
+    yield line("✓ Provisioning complete. Re-run GET on this path to confirm.")
+
+
+def unreachable_progress(
+    probe_base: str, agent_name: str = "This agent"
+) -> Iterator[str]:
+    """The lines a provisioning request gets when the backend is down.
+
+    Yielded under a real 503 — sent BEFORE any streaming commits a 200, so the
+    status code is truthful here and the consumer does not have to parse lines
+    to learn nothing happened.
+    """
+    yield f"✗ The local Lemonade Server is not reachable at {probe_base}.\n"
+    yield (
+        "✗ Start it with `lemonade-server serve` (or run `gaia init`), then "
+        "POST to this path again.\n"
+    )
+    yield (
+        f"✗ {agent_name} can't install the backend itself — that's a host "
+        "prerequisite.\n"
+    )

--- a/src/gaia/agents/base/server.py
+++ b/src/gaia/agents/base/server.py
@@ -91,6 +91,13 @@ class AgentServer:
         model_id: OpenAI-compatible model id for the REST surface. Defaults to
             the agent's :meth:`ApiAgent.get_model_id` (or ``gaia-<classname>``).
         name: Human-readable server name (banners, MCP ``serverInfo``).
+        requirements: What the agent needs before it can serve — see
+            :class:`~gaia.agents.base.readiness.AgentRequirements`. Supplying it
+            (or a manifest that declares ``models:`` /
+            ``requirements.min_lemonade_version``) is what earns the agent
+            ``GET``/``POST /v1/<id>/init`` without hand-writing either verb.
+        agent_id: The id used in the ``/v1/<id>/init`` path. Defaults to the
+            manifest id, else a slug of the class name.
     """
 
     def __init__(
@@ -100,6 +107,8 @@ class AgentServer:
         manifest: Any = None,
         model_id: Optional[str] = None,
         name: Optional[str] = None,
+        requirements: Any = None,
+        agent_id: Optional[str] = None,
     ) -> None:
         if not isinstance(agent, Agent):
             raise TypeError(
@@ -111,6 +120,16 @@ class AgentServer:
         self.manifest = manifest
         self.model_id = model_id or self._default_model_id(agent)
         self.name = name or agent.__class__.__name__
+        self.agent_id = agent_id or self._default_agent_id(agent, manifest)
+        # An explicit declaration wins; otherwise derive from the manifest. Both
+        # absent means the agent declared nothing, and the init routes are not
+        # mounted at all — an /init that answers "ready" without having checked
+        # anything is worse than no /init.
+        if requirements is None and manifest is not None:
+            from gaia.agents.base.readiness import AgentRequirements
+
+            requirements = AgentRequirements.from_manifest(manifest)
+        self.requirements = requirements
 
     # ------------------------------------------------------------------
     # Interface gating (fail loudly)
@@ -123,6 +142,20 @@ class AgentServer:
         cls = agent.__class__.__name__
         base = cls[:-5].lower() if cls.endswith("Agent") else cls.lower()
         return f"gaia-{base}"
+
+    @staticmethod
+    def _default_agent_id(agent: Agent, manifest: Any) -> str:
+        """The id in ``/v1/<id>/init``: the manifest's, else a class-name slug.
+
+        The manifest id is authoritative because that is what the daemon relay
+        and every consumer address the agent by — deriving a different one here
+        would mount the route at a path nothing calls.
+        """
+        manifest_id = getattr(manifest, "id", None)
+        if manifest_id:
+            return str(manifest_id)
+        cls = agent.__class__.__name__
+        return cls[:-5].lower() if cls.endswith("Agent") else cls.lower()
 
     def _ensure_interface(self, interface: str) -> None:
         """Raise if *interface* is disabled by the manifest's ``interfaces``.
@@ -453,6 +486,8 @@ class AgentServer:
         async def list_tools():
             return {"tools": self._tool_definitions()}
 
+        self._mount_init_routes(app)
+
         @app.post("/v1/chat/completions")
         async def create_chat_completion(request: ChatCompletionRequest):
             if request.model != self.model_id:
@@ -505,6 +540,103 @@ class AgentServer:
             )
 
         return app
+
+    def _mount_init_routes(self, app) -> None:
+        """Mount ``GET``/``POST /v1/<id>/init`` when the agent declared needs.
+
+        An agent that declared nothing gets no routes: a readiness endpoint that
+        answers "ready" without having checked anything is worse than a 404,
+        because a consumer would trust it. The absence is logged so the reason
+        is discoverable rather than mysterious.
+        """
+        import asyncio
+
+        from fastapi import Response
+        from fastapi.concurrency import iterate_in_threadpool
+        from fastapi.responses import StreamingResponse
+
+        from gaia.agents.base import readiness
+
+        # An empty declaration is treated exactly like a missing one: a manifest
+        # with no `models:` and no minimum version states nothing to verify, and
+        # an /init built from it would answer "ready" the moment the backend is
+        # up without having checked a single thing about this agent.
+        if self.requirements is None or not self.requirements.declares_anything():
+            logger.debug(
+                "%s declared no requirements, so /v1/%s/init is not mounted. "
+                "Pass requirements=AgentRequirements(...) to AgentServer, or "
+                "declare models:/requirements: in gaia-agent.yaml, to get it.",
+                self.name,
+                self.agent_id,
+            )
+            return
+
+        _, _, InitResponse = readiness.init_models()
+        path = f"/v1/{self.agent_id}/init"
+        requirements = self.requirements
+        agent_name = self.name
+
+        @app.get(
+            path, response_model=InitResponse, responses={503: {"model": InitResponse}}
+        )
+        async def agent_init(response: Response):
+            """Readiness preflight for this agent's declared requirements.
+
+            200 when ready, 503 when not — the SAME body either way, with an
+            actionable ``hint``. Read-only: no pull, no install, no mutation.
+            """
+            status = await asyncio.to_thread(
+                readiness.compute_init_status, requirements, agent_name
+            )
+            if not status.ready:
+                response.status_code = 503
+            return status
+
+        @app.post(path, include_in_schema=False)
+        async def agent_provision() -> StreamingResponse:
+            """Provision this agent's declared model, streaming progress.
+
+            Tells an already-running backend to download the model. It cannot
+            install the backend — if that is what is missing this returns a real
+            503 and pulls nothing. Once a pull starts the response is a
+            committed 200 and the final ``✓``/``✗`` line is authoritative.
+            """
+            media_type = "text/plain; charset=utf-8"
+            model_id = requirements.model_id
+            reachable, probe_base, _version, _loaded = await asyncio.to_thread(
+                readiness.probe_backend_health, requirements.base_url
+            )
+
+            if not reachable:
+                # Fail loudly BEFORE streaming so the status code is a truthful
+                # 503 rather than a 200 the consumer must parse to disbelieve.
+                return StreamingResponse(
+                    readiness.unreachable_progress(probe_base, agent_name),
+                    media_type=media_type,
+                    status_code=503,
+                )
+
+            if not model_id:
+
+                def _nothing_to_do():
+                    yield (
+                        f"✓ {agent_name} declares no model, so there is nothing "
+                        "to provision.\n"
+                    )
+
+                return StreamingResponse(
+                    _nothing_to_do(), media_type=media_type, status_code=200
+                )
+
+            # The generator does blocking HTTP (including a long pull), so it is
+            # iterated in a worker thread and never on the event loop.
+            return StreamingResponse(
+                iterate_in_threadpool(
+                    readiness.provision_progress(probe_base, model_id, agent_name)
+                ),
+                media_type=media_type,
+                status_code=200,
+            )
 
     def _sse_stream(self, prompt: str):
         """Minimal OpenAI-compatible SSE: role chunk, content chunk, done."""

--- a/src/gaia/mcp/servers/tui_mcp.py
+++ b/src/gaia/mcp/servers/tui_mcp.py
@@ -566,17 +566,33 @@ _FOOTER_SEP_RE = re.compile(r"\s{2,}|\s*[·|•]\s*")
 
 
 def _parse_footer_bindings(screen: str) -> Dict[str, str]:
-    """Parse the hub footer (``Enter=launch  /=search  d=delete``) into key→action.
+    """Parse the hub footer into key→action.
 
-    Returns the bindings of the last line that advertises at least two of them,
-    or ``{}`` when the screen has no recognizable footer.
+    Two shapes are accepted, because the product emits the second one and only
+    the fixtures ever emitted the first:
+
+    * ``Enter=launch  /=search`` — explicit ``=``
+    * ``enter run · i install · d remove`` — key, space, action (what the Go
+      hub actually renders; see ``ui/hub/model.go``)
+
+    Requiring ``=`` made every real footer parse to nothing, so the install and
+    uninstall tools always reported the hub as unavailable.
+
+    Returns the bindings of the last line advertising at least two of them, or
+    ``{}`` when the screen has no recognizable footer.
     """
     for line in reversed([ln for ln in (screen or "").splitlines() if ln.strip()]):
         bindings: Dict[str, str] = {}
         for token in _FOOTER_SEP_RE.split(line.strip()):
-            if "=" not in token:
+            token = token.strip()
+            if not token:
                 continue
-            key, _, action = token.partition("=")
+            if "=" in token:
+                key, _, action = token.partition("=")
+            else:
+                # "i install" -> ("i", "install"); "tab category" -> ("tab",
+                # "category"). A lone word is a label, not a binding.
+                key, _, action = token.partition(" ")
             key, action = key.strip(), action.strip()
             if key and action:
                 bindings[key] = action

--- a/tests/unit/test_agent_readiness.py
+++ b/tests/unit/test_agent_readiness.py
@@ -1,0 +1,555 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""Unit tests for inherited agent init (``gaia.agents.base.readiness``).
+
+Covers the readiness probe, the provisioning stream, and the routes
+:class:`~gaia.agents.base.server.AgentServer` mounts from a declaration —
+without a live Lemonade server.
+
+Two properties these tests exist to defend:
+
+* **Indeterminate is never a pass.** A backend that does not advertise a
+  version, or a model list that cannot be read, must be reported as unknown —
+  not as ready, and not as missing.
+* **The agent never installs the backend.** An unreachable backend fails loudly
+  and names whose job the fix is; nothing is pulled.
+"""
+
+import pytest
+import requests
+
+from gaia.agents.base.agent import Agent
+from gaia.agents.base.readiness import (
+    AgentRequirements,
+    compute_init_status,
+    extract_loaded_ctx,
+    parse_version,
+    provision_progress,
+    resolve_probe_base,
+    version_meets_min,
+)
+from gaia.agents.base.server import AgentServer
+
+MODULE = "gaia.agents.base.readiness"
+
+
+class FakeAgent(Agent):
+    """Minimal Agent that skips the heavy LLM/Lemonade ``__init__``."""
+
+    def __init__(self):  # noqa: D401 - deliberately skip super().__init__
+        pass
+
+    def _register_tools(self):
+        pass
+
+    def process_query(self, user_input, **kwargs):
+        return {"status": "success", "result": user_input}
+
+    def get_tools_info(self):
+        return {}
+
+
+@pytest.fixture
+def reqs():
+    return AgentRequirements(model_id="Test-Model", min_backend_version="10.2.0")
+
+
+def _patch_health(monkeypatch, reachable=True, version="10.10.0", loaded=None):
+    monkeypatch.setattr(
+        f"{MODULE}.probe_backend_health",
+        lambda base_url=None: (
+            reachable,
+            "http://localhost:13305/api/v1",
+            version,
+            loaded or [],
+        ),
+    )
+
+
+def _patch_present(monkeypatch, present=True, raises=None):
+    def _probe(probe_base, model_id):
+        if raises is not None:
+            raise raises
+        return present
+
+    monkeypatch.setattr(f"{MODULE}.probe_model_present", _probe)
+
+
+# ---------------------------------------------------------------------------
+# Version comparison — indeterminate is not a pass
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "found,minimum,expected",
+    [
+        ("10.10.0", "10.2.0", True),
+        ("v10.10.0", "10.2.0", True),
+        ("10.2.0", "10.2.0", True),
+        ("10.1.9", "10.2.0", False),
+        ("9.1.4", "10.2.0", False),
+        (None, "10.2.0", None),  # server advertised nothing
+        ("not-a-version", "10.2.0", None),  # unparseable
+        ("10.10.0", None, None),  # agent declared no minimum
+    ],
+)
+def test_version_meets_min(found, minimum, expected):
+    assert version_meets_min(found, minimum) is expected
+
+
+def test_parse_version_ignores_trailing_parts():
+    assert parse_version("10.10.0.1234") == (10, 10, 0)
+
+
+# ---------------------------------------------------------------------------
+# Loaded-context extraction — report, never guess
+# ---------------------------------------------------------------------------
+
+
+def test_extract_loaded_ctx_matches_model_name():
+    loaded = [{"model_name": "Test-Model", "recipe_options": {"ctx_size": 65536}}]
+    assert extract_loaded_ctx(loaded, "Test-Model") == 65536
+
+
+def test_extract_loaded_ctx_matches_checkpoint():
+    loaded = [{"checkpoint": "Test-Model", "recipe_options": {"ctx_size": 4096}}]
+    assert extract_loaded_ctx(loaded, "Test-Model") == 4096
+
+
+@pytest.mark.parametrize(
+    "entry",
+    [
+        {"model_name": "Other-Model", "recipe_options": {"ctx_size": 4096}},
+        {"model_name": "Test-Model"},  # no recipe_options
+        {"model_name": "Test-Model", "recipe_options": {}},  # no ctx_size
+        {"model_name": "Test-Model", "recipe_options": {"ctx_size": 0}},
+        {"model_name": "Test-Model", "recipe_options": {"ctx_size": True}},  # bool
+    ],
+)
+def test_extract_loaded_ctx_returns_none_rather_than_guessing(entry):
+    assert extract_loaded_ctx([entry], "Test-Model") is None
+
+
+# ---------------------------------------------------------------------------
+# Probe base resolution
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "given,expected",
+    [
+        ("http://host:1234", "http://host:1234/api/v1"),
+        ("http://host:1234/", "http://host:1234/api/v1"),
+        ("http://host:1234/api/v1", "http://host:1234/api/v1"),
+    ],
+)
+def test_resolve_probe_base_normalises(given, expected):
+    assert resolve_probe_base(given) == expected
+
+
+# ---------------------------------------------------------------------------
+# Readiness — the failure ladder, in dependency order
+# ---------------------------------------------------------------------------
+
+
+def test_unreachable_backend_names_whose_job_the_fix_is(monkeypatch, reqs):
+    _patch_health(monkeypatch, reachable=False, version=None)
+    status = compute_init_status(reqs, "Test Agent")
+
+    assert status.ready is False
+    assert status.lemonade.reachable is False
+    # Indeterminate, not a failure: an unreachable server has no version to compare.
+    assert status.lemonade.compatible is None
+    assert "lemonade-server serve" in status.hint
+    # The boundary must be explicit — the agent cannot bootstrap the backend.
+    assert "host prerequisite" in status.hint
+
+
+def test_unreachable_backend_never_probes_for_the_model(monkeypatch, reqs):
+    _patch_health(monkeypatch, reachable=False, version=None)
+
+    def _boom(probe_base, model_id):
+        raise AssertionError("must not probe the model list on a dead backend")
+
+    monkeypatch.setattr(f"{MODULE}.probe_model_present", _boom)
+    assert compute_init_status(reqs).ready is False
+
+
+def test_version_too_old_is_reported_before_a_missing_model(monkeypatch, reqs):
+    """Upgrading the backend comes first even when the model is also missing.
+
+    The other order would send the user to download gigabytes that the old
+    server may then refuse to serve.
+    """
+    _patch_health(monkeypatch, version="10.1.0")
+    _patch_present(monkeypatch, present=False)
+
+    status = compute_init_status(reqs, "Test Agent")
+
+    assert status.ready is False
+    assert status.lemonade.compatible is False
+    assert "older than the required 10.2.0" in status.hint
+    assert "not downloaded" not in status.hint
+
+
+def test_missing_model_hint_offers_both_remedies(monkeypatch, reqs):
+    _patch_health(monkeypatch)
+    _patch_present(monkeypatch, present=False)
+
+    status = compute_init_status(reqs, "Test Agent")
+
+    assert status.ready is False
+    assert status.model.present is False
+    assert "gaia init" in status.hint
+    assert "POST" in status.hint  # the pull-it-here path
+
+
+def test_unreadable_model_list_is_not_reported_as_missing(monkeypatch, reqs):
+    """ "Could not tell" and "absent" have different remedies.
+
+    Reporting an unreadable list as a missing model sends the user to
+    re-download something they may already have.
+    """
+    _patch_health(monkeypatch)
+    _patch_present(monkeypatch, raises=requests.exceptions.ConnectionError("boom"))
+
+    status = compute_init_status(reqs, "Test Agent")
+
+    assert status.ready is False
+    assert "model list" in status.hint
+    assert "could not be read" in status.hint
+    assert "not downloaded" not in status.hint
+
+
+def test_indeterminate_version_does_not_block_readiness(monkeypatch, reqs):
+    """A server that advertises no version is unknown, not incompatible."""
+    _patch_health(monkeypatch, version=None)
+    _patch_present(monkeypatch, present=True)
+
+    status = compute_init_status(reqs, "Test Agent")
+
+    assert status.ready is True
+    assert status.lemonade.compatible is None
+
+
+def test_ready_reports_loaded_context_and_no_hint(monkeypatch, reqs):
+    _patch_health(
+        monkeypatch,
+        loaded=[{"model_name": "Test-Model", "recipe_options": {"ctx_size": 65536}}],
+    )
+    _patch_present(monkeypatch, present=True)
+
+    status = compute_init_status(reqs, "Test Agent")
+
+    assert status.ready is True
+    assert status.model.ctx_size == 65536
+    assert status.hint is None
+
+
+def test_agent_with_no_declared_model_is_ready_on_a_live_backend(monkeypatch):
+    """A model-less agent's readiness is just "the backend is up and current"."""
+    _patch_health(monkeypatch)
+
+    def _boom(probe_base, model_id):
+        raise AssertionError("must not probe a model the agent never declared")
+
+    monkeypatch.setattr(f"{MODULE}.probe_model_present", _boom)
+
+    status = compute_init_status(
+        AgentRequirements(min_backend_version="10.2.0"), "Test Agent"
+    )
+    assert status.ready is True
+
+
+def test_model_less_agent_still_fails_an_old_backend(monkeypatch):
+    _patch_health(monkeypatch, version="9.1.4")
+    status = compute_init_status(
+        AgentRequirements(min_backend_version="10.2.0"), "Test Agent"
+    )
+    assert status.ready is False
+    assert "older than the required" in status.hint
+
+
+# ---------------------------------------------------------------------------
+# Provisioning — the final line is the verdict
+# ---------------------------------------------------------------------------
+
+
+def _final(lines):
+    return [ln for ln in lines if ln.strip()][-1]
+
+
+def test_provision_skips_the_pull_when_the_model_is_present(monkeypatch):
+    _patch_present(monkeypatch, present=True)
+    monkeypatch.setattr(
+        f"{MODULE}.pull_model",
+        lambda *a: pytest.fail("must not pull a model that is already present"),
+    )
+
+    lines = list(provision_progress("http://b/api/v1", "Test-Model", "Test Agent"))
+
+    assert "already downloaded" in "".join(lines)
+    assert _final(lines).startswith("✓")
+
+
+def test_provision_pulls_then_verifies(monkeypatch):
+    calls = {"pull": 0, "present": 0}
+
+    def _present(probe_base, model_id):
+        calls["present"] += 1
+        # Absent on the pre-check, present on the post-pull verify.
+        return calls["present"] > 1
+
+    monkeypatch.setattr(f"{MODULE}.probe_model_present", _present)
+    monkeypatch.setattr(
+        f"{MODULE}.pull_model", lambda *a: calls.__setitem__("pull", calls["pull"] + 1)
+    )
+
+    lines = list(provision_progress("http://b/api/v1", "Test-Model", "Test Agent"))
+
+    assert calls["pull"] == 1
+    assert "Verified" in "".join(lines)
+    assert _final(lines).startswith("✓")
+
+
+def test_failed_pull_ends_on_a_failure_line(monkeypatch):
+    """The stream is a committed 200, so the final line has to carry the verdict."""
+    _patch_present(monkeypatch, present=False)
+
+    def _pull(probe_base, model_id):
+        raise requests.exceptions.HTTPError("400 Client Error")
+
+    monkeypatch.setattr(f"{MODULE}.pull_model", _pull)
+
+    lines = list(provision_progress("http://b/api/v1", "Test-Model", "Test Agent"))
+
+    assert _final(lines).startswith("✗")
+    assert "was not downloaded" in "".join(lines)
+
+
+def test_pull_that_does_not_register_is_a_failure_not_a_success(monkeypatch):
+    """Lemonade reporting OK is not proof the model landed."""
+    monkeypatch.setattr(f"{MODULE}.probe_model_present", lambda *a: False)
+    monkeypatch.setattr(f"{MODULE}.pull_model", lambda *a: None)
+
+    lines = list(provision_progress("http://b/api/v1", "Test-Model", "Test Agent"))
+
+    assert _final(lines).startswith("✗")
+    assert "still not listed" in "".join(lines)
+
+
+def test_unverifiable_pull_warns_rather_than_claiming_success(monkeypatch):
+    calls = {"n": 0}
+
+    def _present(probe_base, model_id):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            return False
+        raise requests.exceptions.ConnectionError("verify read failed")
+
+    monkeypatch.setattr(f"{MODULE}.probe_model_present", _present)
+    monkeypatch.setattr(f"{MODULE}.pull_model", lambda *a: None)
+
+    body = "".join(provision_progress("http://b/api/v1", "Test-Model", "Test Agent"))
+
+    assert "⚠" in body
+
+
+def test_unreadable_list_aborts_before_pulling(monkeypatch):
+    _patch_present(monkeypatch, raises=requests.exceptions.ConnectionError("boom"))
+    monkeypatch.setattr(
+        f"{MODULE}.pull_model",
+        lambda *a: pytest.fail("must not pull when the list could not be read"),
+    )
+
+    lines = list(provision_progress("http://b/api/v1", "Test-Model", "Test Agent"))
+    assert _final(lines).startswith("✗")
+
+
+# ---------------------------------------------------------------------------
+# The declaration
+# ---------------------------------------------------------------------------
+
+
+def test_from_manifest_reads_the_declared_model():
+    from gaia.hub.manifest import AgentManifest
+
+    manifest = AgentManifest.from_dict(
+        {
+            "id": "declared",
+            "name": "Declared",
+            "version": "0.1.0",
+            "description": "d",
+            "author": "AMD",
+            "license": "MIT",
+            "language": "python",
+            "models": ["Declared-Model"],
+            "interfaces": {"api_server": True},
+        }
+    )
+    assert AgentRequirements.from_manifest(manifest).model_id == "Declared-Model"
+
+
+def test_from_manifest_without_models_declares_nothing():
+    from gaia.hub.manifest import AgentManifest
+
+    manifest = AgentManifest.from_dict(
+        {
+            "id": "bare",
+            "name": "Bare",
+            "version": "0.1.0",
+            "description": "d",
+            "author": "AMD",
+            "license": "MIT",
+            "language": "python",
+            "interfaces": {"api_server": True},
+        }
+    )
+    assert AgentRequirements.from_manifest(manifest).model_id is None
+
+
+# ---------------------------------------------------------------------------
+# The routes AgentServer mounts from a declaration
+# ---------------------------------------------------------------------------
+
+
+def _client(**kwargs):
+    from fastapi.testclient import TestClient
+
+    server = AgentServer(FakeAgent(), name="Test Agent", **kwargs)
+    return TestClient(server.build_api_app(), raise_server_exceptions=False)
+
+
+def test_no_declaration_means_no_init_route():
+    """An /init that answers "ready" without checking anything is worse than a 404."""
+    assert _client().get("/v1/fake/init").status_code == 404
+
+
+def test_empty_declaration_is_treated_as_no_declaration():
+    """A manifest with no models and no minimum version declares nothing.
+
+    Mounting /init for it would answer "ready" the moment the backend is up,
+    having verified nothing about the agent — and a consumer would believe it.
+    """
+    empty = AgentRequirements()
+    assert empty.declares_anything() is False
+    assert (
+        _client(requirements=empty, agent_id="fake").get("/v1/fake/init").status_code
+        == 404
+    )
+
+
+def test_base_url_alone_does_not_count_as_a_declaration():
+    """It says where to look, not what is required."""
+    assert AgentRequirements(base_url="http://host/api/v1").declares_anything() is False
+
+
+@pytest.mark.parametrize(
+    "requirements",
+    [
+        AgentRequirements(model_id="Test-Model"),
+        AgentRequirements(min_backend_version="10.2.0"),
+    ],
+)
+def test_either_half_of_a_declaration_is_enough(requirements):
+    assert requirements.declares_anything() is True
+
+
+def test_manifest_without_models_mounts_no_init_route():
+    """The manifest path must obey the same rule as the explicit one."""
+    from gaia.hub.manifest import AgentManifest
+
+    manifest = AgentManifest.from_dict(
+        {
+            "id": "bare",
+            "name": "Bare",
+            "version": "0.1.0",
+            "description": "d",
+            "author": "AMD",
+            "license": "MIT",
+            "language": "python",
+            "interfaces": {"api_server": True},
+        }
+    )
+    from fastapi.testclient import TestClient
+
+    server = AgentServer(FakeAgent(), manifest=manifest)
+    client = TestClient(server.build_api_app(), raise_server_exceptions=False)
+    assert client.get("/v1/bare/init").status_code == 404
+
+
+def test_model_less_agent_names_that_no_model_is_required(monkeypatch):
+    _patch_health(monkeypatch)
+    status = compute_init_status(
+        AgentRequirements(min_backend_version="10.2.0"), "Test Agent"
+    )
+    assert status.ready is True
+    # present=True so a consumer's "is the model downloaded?" check does not
+    # fail over a model that was never required; the id says there is none.
+    assert status.model.present is True
+    assert status.model.id == "(none required)"
+
+
+def test_declared_requirements_mount_the_route(monkeypatch, reqs):
+    _patch_health(monkeypatch)
+    _patch_present(monkeypatch, present=True)
+
+    resp = _client(requirements=reqs, agent_id="fake").get("/v1/fake/init")
+
+    assert resp.status_code == 200
+    assert resp.json()["ready"] is True
+
+
+def test_not_ready_is_served_as_503_with_the_same_body(monkeypatch, reqs):
+    _patch_health(monkeypatch, reachable=False, version=None)
+
+    resp = _client(requirements=reqs, agent_id="fake").get("/v1/fake/init")
+
+    assert resp.status_code == 503
+    body = resp.json()
+    # Same shape as the 200 — a consumer parses one contract, not two.
+    assert body["ready"] is False
+    assert set(body) == {"ready", "lemonade", "model", "hint"}
+    assert body["hint"]
+
+
+def test_agent_id_defaults_to_the_manifest_id(reqs):
+    from gaia.hub.manifest import AgentManifest
+
+    manifest = AgentManifest.from_dict(
+        {
+            "id": "from-manifest",
+            "name": "M",
+            "version": "0.1.0",
+            "description": "d",
+            "author": "AMD",
+            "license": "MIT",
+            "language": "python",
+            "interfaces": {"api_server": True},
+        }
+    )
+    server = AgentServer(FakeAgent(), manifest=manifest, requirements=reqs)
+    assert server.agent_id == "from-manifest"
+
+
+def test_provision_route_refuses_with_503_when_the_backend_is_down(monkeypatch, reqs):
+    _patch_health(monkeypatch, reachable=False, version=None)
+    monkeypatch.setattr(
+        f"{MODULE}.pull_model",
+        lambda *a: pytest.fail("must not pull against an unreachable backend"),
+    )
+
+    resp = _client(requirements=reqs, agent_id="fake").post("/v1/fake/init")
+
+    assert resp.status_code == 503
+    assert "host prerequisite" in resp.text
+
+
+def test_provision_route_streams_progress(monkeypatch, reqs):
+    _patch_health(monkeypatch)
+    _patch_present(monkeypatch, present=True)
+
+    resp = _client(requirements=reqs, agent_id="fake").post("/v1/fake/init")
+
+    assert resp.status_code == 200
+    assert resp.text.strip().splitlines()[-1].startswith("✓")

--- a/tests/unit/test_tui_mcp.py
+++ b/tests/unit/test_tui_mcp.py
@@ -22,12 +22,16 @@ PID = 4242
 PORT = 8770
 BASE_URL = f"http://127.0.0.1:{PORT}"
 
+# Verbatim from the Go hub (ui/hub/model.go). The previous fixture used an
+# invented "Enter=launch" form the product has never emitted, so the parser was
+# only ever tested against input that could not occur — and both install tools
+# were broken in the field while these tests passed.
 HUB_FOOTER = (
-    "Enter=launch  /=search  Tab=category  d=delete  v=vote  r=request  "
-    "?=help  q=quit"
+    "  enter run · i install · d remove · / search · tab category · "
+    "v vote · r refresh · ? help · q quit"
 )
 HUB_FOOTER_NO_INSTALL = (
-    "Enter=launch  /=search  Tab=category  v=vote  r=request  ?=help  q=quit"
+    "  enter run · / search · tab category · v vote · r refresh · ? help · q quit"
 )
 
 
@@ -993,7 +997,7 @@ def test_install_agent_without_a_binding_sends_no_keys(live_tui):
     assert out["status"] == "error"
     assert "not yet available" in out["detail"]
     assert "Bindings currently offered:" in out["detail"]
-    assert "Enter=launch" in out["detail"]
+    assert "enter" in out["detail"]
     assert fake.keys_sent == []
 
 
@@ -1142,14 +1146,17 @@ def test_install_that_changes_nothing_is_an_error(live_tui):
 
 def test_footer_parsing():
     bindings = tui_mcp._parse_footer_bindings(f"hub\n  bash\n{HUB_FOOTER}")
-    assert bindings["Enter"] == "launch"
-    assert bindings["d"] == "delete"
+    assert bindings["enter"] == "run"
+    assert bindings["d"] == "remove"
+    assert bindings["i"] == "install"
     assert tui_mcp._find_binding(bindings, "uninstall") == "d"
-    assert tui_mcp._find_binding(bindings, "install") is None
+    assert tui_mcp._find_binding(bindings, "install") == "i"
 
-    with_install = tui_mcp._parse_footer_bindings("x\nEnter=launch  i=install  q=quit")
-    assert tui_mcp._find_binding(with_install, "install") == "i"
-    assert tui_mcp._find_binding(with_install, "uninstall") is None
+    # The legacy "=" form still parses, so a future footer change in either
+    # direction is covered rather than silently unsupported.
+    legacy = tui_mcp._parse_footer_bindings("x\nEnter=launch  i=install  q=quit")
+    assert tui_mcp._find_binding(legacy, "install") == "i"
+    assert tui_mcp._find_binding(legacy, "uninstall") is None
 
     assert tui_mcp._parse_footer_bindings("") == {}
 

--- a/tui/internal/cli/agents.go
+++ b/tui/internal/cli/agents.go
@@ -23,6 +23,7 @@ var (
 	installTrust      bool
 	runQuery          string
 	runModel          string
+	runTimeout        time.Duration
 )
 
 // hubClient builds a client over the real daemon, logging through --debug.
@@ -246,14 +247,19 @@ var runCmd = &cobra.Command{
 	Long: "Open the chat TUI for an installed agent.\n\n" +
 		"--query makes it a genuine non-interactive one-shot: no alt screen, the " +
 		"answer on stdout, progress on stderr, and exit 0 on a final answer / 1 on " +
-		"an error. That is what makes it usable from a script or from CI.",
+		"an error. That is what makes it usable from a script or from CI.\n\n" +
+		"A one-shot checks its preconditions first and refuses in seconds — naming " +
+		"the unmet one and the command that fixes it on stderr — rather than waiting " +
+		"on a model server that is not there. The turn itself is bounded too, so an " +
+		"agent that accepts the query and then goes quiet is reported, never waited " +
+		"on forever — raise or lower that bound with --timeout.",
 	Args:         cobra.ExactArgs(1),
 	SilenceUsage: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if err := checkModelSupported(args[0], runModel); err != nil {
 			return err
 		}
-		code, err := ui.RunAgent(args[0], runQuery, runModel, debug)
+		code, err := ui.RunAgent(args[0], runQuery, runModel, debug, runTimeout)
 		if err != nil {
 			return err
 		}
@@ -381,6 +387,8 @@ func init() {
 		"run one query non-interactively: answer on stdout, exit 0/1")
 	runCmd.Flags().StringVar(&runModel, "model", "",
 		"model id override (the agent's default is used when unset)")
+	runCmd.Flags().DurationVar(&runTimeout, "timeout", ui.DefaultOneShotTimeout,
+		"how long one --query turn may take before it is abandoned and reported (e.g. 90s, 2h)")
 
 	rootCmd.AddCommand(listCmd, installCmd, uninstallCmd, runCmd, statusCmd)
 }

--- a/tui/internal/cli/chat.go
+++ b/tui/internal/cli/chat.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"fmt"
 	"os"
+	"time"
 
 	"github.com/spf13/cobra"
 
@@ -10,10 +11,11 @@ import (
 )
 
 var (
-	subprocess string
-	query      string
-	agentID    string
-	chatModel  string
+	subprocess  string
+	query       string
+	agentID     string
+	chatModel   string
+	chatTimeout time.Duration
 )
 
 var chatCmd = &cobra.Command{
@@ -27,7 +29,7 @@ var chatCmd = &cobra.Command{
 			return fmt.Errorf("--agent and --subprocess are mutually exclusive: pick one")
 		}
 		if agentID != "" {
-			code, err := ui.RunAgent(agentID, query, chatModel, debug)
+			code, err := ui.RunAgent(agentID, query, chatModel, debug, chatTimeout)
 			if err != nil {
 				return err
 			}
@@ -56,6 +58,8 @@ func init() {
 	chatCmd.Flags().StringVar(&agentID, "agent", "", "catalog agent id to chat with (e.g. \"email\")")
 	chatCmd.Flags().StringVar(&chatModel, "model", "", "model id override (--agent only; the sidecar default is used when unset)")
 	chatCmd.Flags().StringVar(&subprocess, "subprocess", "", "command to spawn agent subprocess (e.g. \"./gaia-bash --json-events\")")
-	chatCmd.Flags().StringVar(&query, "query", "", "single query to send; with --agent this is a genuine non-interactive one-shot (answer on stdout, exit 0/1)")
+	chatCmd.Flags().StringVar(&query, "query", "", "single query to send; with --agent this is a genuine non-interactive one-shot: it refuses in seconds when a precondition is unmet, answers on stdout, and exits 0/1")
+	chatCmd.Flags().DurationVar(&chatTimeout, "timeout", ui.DefaultOneShotTimeout,
+		"how long one --query turn may take before it is abandoned and reported (--agent only)")
 	rootCmd.AddCommand(chatCmd)
 }

--- a/tui/internal/ui/app.go
+++ b/tui/internal/ui/app.go
@@ -6,13 +6,16 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
 
 	"github.com/amd/gaia/tui/internal/catalog"
 	"github.com/amd/gaia/tui/internal/client"
 	"github.com/amd/gaia/tui/internal/control"
+	"github.com/amd/gaia/tui/internal/daemon"
 	"github.com/amd/gaia/tui/internal/ui/chat"
+	"github.com/amd/gaia/tui/internal/ui/preflight"
 	"github.com/amd/gaia/tui/internal/ui/root"
 )
 
@@ -93,8 +96,10 @@ func run(model tea.Model, debug bool, ctrl *control.Options) error {
 // With query != "" this is a genuine non-interactive one-shot: no alt screen, the
 // answer on stdout, progress on stderr, and a real exit code. That is what makes
 // the transport exercisable from a script, from CI, and against a live daemon.
+// timeout bounds that turn; it is ignored by the interactive path, where a person
+// can see what is happening and press ctrl+c.
 // Returns the process exit code.
-func RunAgent(agentID, query, model string, debug bool) (int, error) {
+func RunAgent(agentID, query, model string, debug bool, timeout time.Duration) (int, error) {
 	cat := catalog.NewCatalog()
 	cat.DiscoverBinaries()
 
@@ -102,6 +107,15 @@ func RunAgent(agentID, query, model string, debug bool) (int, error) {
 	if agent == nil {
 		return 1, fmt.Errorf("no agent %q in the catalog — known ids: %s",
 			agentID, strings.Join(agentIDs(cat), ", "))
+	}
+
+	// A one-shot is always bounded — that is the whole point — so an unbounded
+	// or negative one is refused here rather than quietly turned into "forever".
+	if query != "" && timeout <= 0 {
+		return 1, fmt.Errorf(
+			"--timeout must be a positive duration, got %s: a one-shot that cannot "+
+				"time out is exactly the hang this bound exists to prevent. Pass a "+
+				"longer bound instead, e.g. --timeout 2h", timeout)
 	}
 
 	logf := func(string, ...any) {}
@@ -122,7 +136,25 @@ func RunAgent(agentID, query, model string, debug bool) (int, error) {
 	defer c.Close()
 
 	if query != "" {
-		res := RunOneShot(context.Background(), c, query, os.Stdout, os.Stderr)
+		// A one-shot runs unattended, so an unmet precondition has to be
+		// reported and refused rather than waited on. Interactive is left alone
+		// on purpose: a person can read a half-answer and press ctrl+c, and the
+		// launch that does have a gate is the hub's.
+		if agent.Transport == catalog.TransportDaemon {
+			// Only a relayed agent has the /v1/<agent>/init route the check
+			// probes. For a subprocess agent the rows could only say "not
+			// installed" — four wrong answers over a launch that works.
+			t := preflight.NewDaemonTransport(daemon.New(daemon.Options{Logf: logf}))
+			rep := ReportReadiness(context.Background(), t,
+				preflight.ConfigFor(agent.ID, agent.Name), os.Stderr)
+			if rep.Blocked() {
+				return 1, nil
+			}
+		}
+
+		ctx, cancel := context.WithTimeout(context.Background(), timeout)
+		defer cancel()
+		res := RunOneShot(ctx, c, query, os.Stdout, os.Stderr)
 		return res.ExitCode, nil
 	}
 

--- a/tui/internal/ui/oneshot.go
+++ b/tui/internal/ui/oneshot.go
@@ -2,12 +2,15 @@ package ui
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"strings"
+	"time"
 
 	"github.com/amd/gaia/tui/internal/client"
 	"github.com/amd/gaia/tui/internal/event"
+	"github.com/amd/gaia/tui/internal/ui/preflight"
 )
 
 // OneShotResult is the outcome of one non-interactive turn. It mirrors
@@ -46,9 +49,10 @@ func RunOneShot(
 		res       OneShotResult
 		streamed  strings.Builder
 		sawTokens bool
+		started   = time.Now()
 	)
 
-	for evt := range ch {
+	handle := func(evt interface{}) {
 		switch e := evt.(type) {
 		case event.CanonicalStatusEvent:
 			if msg := strings.TrimSpace(e.Message); msg != "" {
@@ -57,7 +61,7 @@ func RunOneShot(
 
 		case event.CanonicalTokenEvent:
 			if e.Delta == "" {
-				continue
+				return
 			}
 			sawTokens = true
 			streamed.WriteString(e.Delta)
@@ -139,6 +143,55 @@ func RunOneShot(
 		}
 	}
 
+	for {
+		select {
+		case evt, open := <-ch:
+			if !open {
+				// The stream closed; the terminal-event check decides.
+				return finishOneShot(res, query, errW)
+			}
+			handle(evt)
+
+		case <-ctx.Done():
+			// The caller's deadline is the only bound on a dependency that
+			// accepts the query and then goes quiet — the relay's read watchdog
+			// is reset by every heartbeat, so a wedged sidecar can keep the
+			// stream alive indefinitely without ever answering.
+			//
+			// A plain select picks UNIFORMLY when both cases are ready, so an
+			// answer that landed in the same instant as the deadline would be
+			// thrown away half the time. Everything already delivered is still
+			// the agent's answer: take that first, then give up. The drain is
+			// bounded by what is buffered right now, so a chatty stream cannot
+			// starve the deadline it is being held to.
+			for i, buffered := 0, len(ch); i < buffered; i++ {
+				select {
+				case evt, open := <-ch:
+					if !open {
+						return finishOneShot(res, query, errW)
+					}
+					handle(evt)
+				default:
+				}
+			}
+			if res.TerminalType != "" {
+				return finishOneShot(res, query, errW)
+			}
+
+			if sawTokens {
+				fmt.Fprintln(out)
+			}
+			res.TerminalType = event.CanonicalTypeError
+			res.ExitCode = 1
+			res.ErrorDetail = abandonedDetail(ctx.Err(), query, time.Since(started))
+			fmt.Fprintf(errW, "❌ %s\n", res.ErrorDetail)
+			return res
+		}
+	}
+}
+
+// finishOneShot applies the terminal-event contract to a stream that closed.
+func finishOneShot(res OneShotResult, query string, errW io.Writer) OneShotResult {
 	if res.TerminalType == "" {
 		// Exactly one terminal event is mandatory; a stream that ends without one
 		// is a failure, reported loudly rather than as an empty success.
@@ -150,4 +203,109 @@ func RunOneShot(
 		res.ExitCode = 1
 	}
 	return res
+}
+
+// Bounds on the non-interactive path. Every one of these replaced an unbounded
+// wait: a dependency that refuses is reported by the readiness rows below, but
+// one that accepts and then goes quiet is only ever caught by a deadline.
+const (
+	// readinessEnsureTimeout bounds start-or-attach of the background service and
+	// the spawn of the agent's sidecar. It matches the gate's own ensureTimeout
+	// and the daemon client's ensure budget on purpose: a first run may still
+	// fetch the sidecar binary here, and a bound tighter than the hub's would
+	// refuse a cold start the hub completes on the same machine.
+	readinessEnsureTimeout = 15 * time.Minute
+	// readinessCheckTimeout bounds the readiness probe. Same value as the gate's
+	// checkTimeout, over the same call — two paths asking the same question must
+	// not disagree about how long the answer may take.
+	readinessCheckTimeout = 90 * time.Second
+	// DefaultOneShotTimeout bounds one whole non-interactive turn. The relay
+	// reads with a 300s idle timeout per chunk and an agent loop can take several
+	// steps, so this sits well above a healthy-but-slow run — including one whose
+	// first token waits on a cold model load — while still turning a wedged
+	// stream into a reportable error instead of a silent hang. `--timeout` raises
+	// or lowers it for a run that legitimately needs longer.
+	DefaultOneShotTimeout = 15 * time.Minute
+)
+
+// ReportReadiness runs the readiness gate headlessly for the one-shot path and
+// returns what it found.
+//
+// It deliberately does NOT render the interactive gate: a script has nobody to
+// press a key. Everything it prints goes to errW — the answer's stream stays
+// clean — and the blocked report carries the same rows and remedies the gate
+// shows for the same condition, because both render the same preflight.Report.
+//
+// A report that is neither ready nor blocked (an indeterminate row) does not
+// stop the run, matching the gate: unknown is named, not refused.
+func ReportReadiness(
+	ctx context.Context,
+	t preflight.Transport,
+	cfg preflight.Config,
+	errW io.Writer,
+) preflight.Report {
+	// Start-or-attach the background service and spawn the sidecar first —
+	// exactly what the turn does on its own. Skipping it would newly refuse a
+	// scripted run on a cold machine that used to start what it needed. A
+	// failure is announced, then diagnosed by the rows, which name it with a
+	// remedy instead of a raw transport error.
+	ensureCtx, cancelEnsure := context.WithTimeout(ctx, readinessEnsureTimeout)
+	ensureErr := t.EnsureAgent(ensureCtx, cfg.AgentID)
+	cancelEnsure()
+	if ensureErr != nil {
+		// Through the ladder, so this reads like every other failure the gate
+		// reports: what failed, what to do, where to look — never a raw error.
+		d := preflight.Ladder{AgentID: cfg.AgentID}.
+			Error("start the "+cfg.AgentName+" agent", ensureErr)
+		fmt.Fprintf(errW, "⚠️  %s\n", d.String())
+	}
+
+	checkCtx, cancelCheck := context.WithTimeout(ctx, readinessCheckTimeout)
+	defer cancelCheck()
+
+	rep := preflight.Check(checkCtx, t, cfg)
+	writeReadiness(errW, rep)
+	return rep
+}
+
+// writeReadiness renders a report for a terminal that nobody is watching.
+func writeReadiness(errW io.Writer, rep preflight.Report) {
+	blocker, blocked := rep.Blocker()
+	if !blocked {
+		// Nothing failed. Anything that could not be VERIFIED is still named —
+		// the run proceeds, but silence here would read as "all clear" — and it
+		// keeps its remedy, which is the only thing that makes it fixable.
+		for _, row := range rep.Rows {
+			if !row.NeedsAttention() {
+				continue
+			}
+			fmt.Fprintf(errW, "  ⚠️  %s: %s (could not be verified — continuing)\n",
+				row.Label, row.Line)
+			if row.Remedy.Command != "" {
+				fmt.Fprintf(errW, "      run: %s\n", row.Remedy.Command)
+			}
+		}
+		return
+	}
+
+	fmt.Fprintf(errW, "❌ %s is not ready — %s: %s\n", rep.AgentName, blocker.Label, blocker.Line)
+	if blocker.Detail != "" {
+		fmt.Fprintf(errW, "   %s\n", blocker.Detail)
+	}
+	// Report.String is the preflight package's own headless renderer: every row,
+	// every remedy. Rendering the rows here instead would let the two paths drift.
+	fmt.Fprintf(errW, "\n%s\n", strings.TrimRight(rep.String(), "\n"))
+	fmt.Fprintf(errW, "\nNothing was sent to the %s agent. Fix the row above and re-run.\n", rep.AgentName)
+}
+
+// abandonedDetail says what stopped the turn, how long it ran, and where to look.
+func abandonedDetail(err error, query string, elapsed time.Duration) string {
+	if errors.Is(err, context.DeadlineExceeded) {
+		return fmt.Sprintf(
+			"gave up on the %q query after %s — the agent accepted it and then stopped "+
+				"answering. Read `gaia daemon logs` and the agent's own log under "+
+				"~/.gaia/agents/, then retry", query, elapsed.Round(time.Second))
+	}
+	return fmt.Sprintf("the %q query was cancelled after %s, before the agent answered",
+		query, elapsed.Round(time.Second))
 }

--- a/tui/internal/ui/oneshot_test.go
+++ b/tui/internal/ui/oneshot_test.go
@@ -5,7 +5,9 @@ import (
 	"context"
 	"strings"
 	"testing"
+	"time"
 
+	"github.com/amd/gaia/tui/internal/client"
 	"github.com/amd/gaia/tui/internal/event"
 )
 
@@ -176,3 +178,93 @@ func TestRunOneShotHandlesLegacyEvents(t *testing.T) {
 type errFake string
 
 func (e errFake) Error() string { return string(e) }
+
+// stallingClient accepts the query and then never says anything: the channel is
+// never written to and never closed. This is the failure a readiness check
+// cannot catch — the dependency was reachable, it just stopped answering — so
+// the caller's deadline is the only thing standing between it and a hang.
+type stallingClient struct {
+	// first is emitted before the silence, so the partial-line handling is
+	// exercised too.
+	first interface{}
+}
+
+func (s *stallingClient) Send(context.Context, string) (<-chan interface{}, error) {
+	ch := make(chan interface{}, 1)
+	if s.first != nil {
+		ch <- s.first
+	}
+	return ch, nil
+}
+
+func (s *stallingClient) Close() error { return nil }
+
+// runOneShotAsync runs a turn off the test goroutine so a hang fails the test
+// instead of wedging the suite.
+func runOneShotAsync(
+	t *testing.T,
+	ctx context.Context,
+	c client.AgentClient,
+	out, errW *bytes.Buffer,
+) OneShotResult {
+	t.Helper()
+	done := make(chan OneShotResult, 1)
+	go func() { done <- RunOneShot(ctx, c, "triage my inbox", out, errW) }()
+	select {
+	case res := <-done:
+		return res
+	case <-time.After(15 * time.Second):
+		t.Fatal("RunOneShot never returned after its context was done — this is issue #2483")
+		return OneShotResult{}
+	}
+}
+
+// The bug: an agent that accepts the query and then goes quiet used to hang
+// forever, with nothing on either stream.
+func TestRunOneShotAbandonsAStalledStreamAtTheDeadline(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 150*time.Millisecond)
+	defer cancel()
+
+	var out, errW bytes.Buffer
+	c := &stallingClient{first: event.CanonicalTokenEvent{Type: "token", Delta: "Look"}}
+	res := runOneShotAsync(t, ctx, c, &out, &errW)
+
+	if res.ExitCode != 1 {
+		t.Errorf("exit code = %d, want 1 — an abandoned turn is a failure", res.ExitCode)
+	}
+	if res.TerminalType != event.CanonicalTypeError {
+		t.Errorf("terminal = %q, want error", res.TerminalType)
+	}
+	// The partial answer keeps its own line; the diagnosis belongs on stderr.
+	if out.String() != "Look\n" {
+		t.Errorf("stdout = %q, want the streamed text terminated by a newline", out.String())
+	}
+	for _, want := range []string{"gave up", "triage my inbox", "gaia daemon logs"} {
+		if !strings.Contains(errW.String(), want) {
+			t.Errorf("stderr must say what happened and where to look, missing %q:\n%s", want, errW.String())
+		}
+	}
+}
+
+// A cancelled parent context is reported as a cancellation, not as a deadline —
+// the two send the reader to different places.
+func TestRunOneShotReportsACancelledTurnDistinctly(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	var out, errW bytes.Buffer
+	res := runOneShotAsync(t, ctx, &stallingClient{}, &out, &errW)
+
+	if res.ExitCode != 1 {
+		t.Errorf("exit code = %d, want 1", res.ExitCode)
+	}
+	if !strings.Contains(errW.String(), "cancelled") {
+		t.Errorf("stderr = %q, want it to name the cancellation", errW.String())
+	}
+	if strings.Contains(errW.String(), "gave up") {
+		t.Errorf("a cancellation must not be reported as a deadline: %q", errW.String())
+	}
+	if out.String() != "" {
+		t.Errorf("stdout = %q, want empty", out.String())
+	}
+}

--- a/tui/internal/ui/preflight/check.go
+++ b/tui/internal/ui/preflight/check.go
@@ -1,0 +1,639 @@
+package preflight
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/amd/gaia/tui/internal/daemon"
+)
+
+// ExtraCheck is a per-agent precondition appended after the four generic ones.
+//
+// The first four rows are the same for any sidecar agent that implements
+// GET /v1/<agent>/init. Anything agent-specific — for email, a mailbox that is
+// both connected AND granted send — arrives here, so the screen stays generic.
+type ExtraCheck struct {
+	Key   string
+	Label string
+	Run   func(ctx context.Context, t Transport, cfg Config) Row
+}
+
+// Config parameterises a readiness check.
+type Config struct {
+	// AgentID is the daemon-registered id, e.g. "email". It is the `<agent>` in
+	// every relayed path and in every remedy command.
+	AgentID string
+	// AgentName is the display name, e.g. "Email".
+	AgentName string
+	// Extras run after the generic checks, in order.
+	Extras []ExtraCheck
+}
+
+func (c Config) withDefaults() Config {
+	if c.AgentID == "" {
+		c.AgentID = "email"
+	}
+	if c.AgentName == "" {
+		c.AgentName = strings.ToUpper(c.AgentID[:1]) + c.AgentID[1:]
+	}
+	return c
+}
+
+// EmailConfig is the built-in configuration for the email agent: the four
+// generic checks plus the mailbox check.
+func EmailConfig() Config {
+	return Config{
+		AgentID:   "email",
+		AgentName: "Email",
+		Extras:    []ExtraCheck{MailboxCheck()},
+	}
+}
+
+// ConfigFor is what a launch site calls: the generic checks for any agent, plus
+// whatever extras that agent has. One call site, so adding an agent's extra
+// check never means finding every place a gate is built.
+func ConfigFor(agentID, agentName string) Config {
+	cfg := Config{AgentID: agentID, AgentName: agentName}.withDefaults()
+	if cfg.AgentID == "email" {
+		cfg.Extras = []ExtraCheck{MailboxCheck()}
+	}
+	return cfg
+}
+
+// Check probes every precondition in dependency order and returns a typed
+// report. It is safe to call headlessly — the screen is a renderer over this.
+//
+// Dependency order matters and the walk STOPS at the first failure: "the model
+// is not downloaded" is meaningless when the model server is down, and
+// GET /v1/<agent>/init already orders its own hints that way (version-too-old
+// before model-missing). Rows after a failure are Pending, never OK.
+func Check(ctx context.Context, t Transport, cfg Config) Report {
+	cfg = cfg.withDefaults()
+
+	rep := Report{
+		AgentID:   cfg.AgentID,
+		AgentName: cfg.AgentName,
+		Rows:      blankRows(cfg),
+	}
+
+	steps := []func(context.Context, Transport, Config, *Report) State{
+		checkDaemon,
+		checkSidecar,
+		checkInit, // fills BOTH the lemonade and model rows from one probe
+	}
+	for _, step := range steps {
+		if state := step(ctx, t, cfg, &rep); state == StateFailed {
+			markPending(&rep)
+			return rep
+		}
+	}
+
+	for _, extra := range cfg.Extras {
+		row := extra.Run(ctx, t, cfg)
+		row.Key, row.Label = extra.Key, extra.Label
+		setRow(&rep, row)
+		if row.State == StateFailed {
+			markPending(&rep)
+			return rep
+		}
+	}
+	return rep
+}
+
+// blankRows lays out every row up front so a report always has the same shape —
+// a screen that grows rows as they are answered makes the user re-read it.
+func blankRows(cfg Config) []Row {
+	rows := []Row{
+		{Key: KeyDaemon, Label: "Background service"},
+		{Key: KeySidecar, Label: cfg.AgentName + " agent"},
+		{Key: KeyLemonade, Label: "Local AI"},
+		{Key: KeyModel, Label: "AI model"},
+	}
+	for _, extra := range cfg.Extras {
+		rows = append(rows, Row{Key: extra.Key, Label: extra.Label})
+	}
+	for i := range rows {
+		rows[i].State = StatePending
+		rows[i].Line = "—"
+	}
+	return rows
+}
+
+func setRow(rep *Report, row Row) {
+	for i := range rep.Rows {
+		if rep.Rows[i].Key == row.Key {
+			row.Label = rep.Rows[i].Label
+			rep.Rows[i] = row
+			return
+		}
+	}
+	rep.Rows = append(rep.Rows, row)
+}
+
+// markPending annotates every still-unanswered row with what it is waiting on,
+// so a blank row never reads as "fine" or as "broken".
+func markPending(rep *Report) {
+	blocker, ok := rep.Blocker()
+	if !ok {
+		return
+	}
+	for i := range rep.Rows {
+		if rep.Rows[i].State == StatePending && rep.Rows[i].Line == "—" {
+			rep.Rows[i].Detail = fmt.Sprintf("checked once %q is fixed", blocker.Label)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// 1. The daemon: alive, ours, and speaking a contract we can use.
+// ---------------------------------------------------------------------------
+
+func checkDaemon(ctx context.Context, t Transport, cfg Config, rep *Report) State {
+	l := Ladder{AgentID: cfg.AgentID}
+	row := Row{Key: KeyDaemon}
+
+	inf, err := t.Attach(ctx)
+	if err != nil {
+		d := l.Error("reach the background service", err)
+		row.State = StateFailed
+		row.Line = "not running"
+		row.Detail = d.Cause
+		row.Remedy = d.AsRemedy()
+		row.Raw = err.Error()
+		var missing *daemon.NotRunningError
+		if errors.As(err, &missing) {
+			// The line already says "not running"; the detail's job is to say
+			// why that stops everything else.
+			row.Detail = "Every agent on this machine runs under it, so nothing " +
+				"else can be checked yet."
+		}
+		// Starting a daemon is safe and reversible; reclaiming a wedged one or
+		// resolving a version skew is not, and must stay the user's call.
+		if startable(err) {
+			row.Fix = FixStartDaemon
+			row.Line = "not running"
+		} else {
+			row.Line = "unusable"
+		}
+		return row.commit(rep)
+	}
+
+	row.State = StateOK
+	row.Line = fmt.Sprintf("running (pid %d) · host API v%s", inf.PID, inf.APIVersion)
+	return row.commit(rep)
+}
+
+// startable reports whether the failure is one that starting a daemon fixes. A
+// version skew never is — a second daemon cannot come up alongside the first.
+func startable(err error) bool {
+	var notRunning *daemon.NotRunningError
+	if errors.As(err, &notRunning) {
+		return true
+	}
+	var stale *daemon.StaleError
+	if errors.As(err, &stale) {
+		return stale.Kind != daemon.StaleUnresponsive
+	}
+	return false
+}
+
+func (r Row) commit(rep *Report) State {
+	setRow(rep, r)
+	return r.State
+}
+
+// ---------------------------------------------------------------------------
+// 2. The agent's sidecar: registered with the daemon, and running.
+// ---------------------------------------------------------------------------
+
+type agentsBody struct {
+	Agents []struct {
+		AgentID      string  `json:"agent_id"`
+		State        string  `json:"state"`
+		PID          *int    `json:"pid"`
+		AgentVersion *string `json:"agent_version"`
+		APIVersion   *string `json:"api_version"`
+	} `json:"agents"`
+}
+
+func checkSidecar(ctx context.Context, t Transport, cfg Config, rep *Report) State {
+	l := Ladder{AgentID: cfg.AgentID}
+	row := Row{Key: KeySidecar}
+
+	resp, err := t.Do(ctx, http.MethodGet, daemon.APIPrefix+"/agents", nil)
+	if err != nil {
+		d := l.Error("list the agents the background service supervises", err)
+		row.State, row.Line, row.Detail, row.Remedy, row.Raw =
+			StateFailed, "cannot be listed", d.Cause, d.AsRemedy(), err.Error()
+		return row.commit(rep)
+	}
+	row.Raw = string(resp.Body)
+	if resp.Status != http.StatusOK {
+		d := l.Status("list the supervised agents", resp.Status, string(resp.Body))
+		row.State, row.Line, row.Detail, row.Remedy =
+			StateFailed, "cannot be listed", d.Cause, d.AsRemedy()
+		return row.commit(rep)
+	}
+
+	var body agentsBody
+	if err := json.Unmarshal(resp.Body, &body); err != nil {
+		row.State, row.Line = StateFailed, "unreadable answer"
+		row.Detail = "The background service answered with something this build cannot read."
+		row.Remedy = Remedy{
+			Action:  "Restart it so both sides speak the same contract.",
+			Command: "gaia daemon restart",
+			Where:   daemonLog(),
+		}
+		return row.commit(rep)
+	}
+
+	for _, a := range body.Agents {
+		if a.AgentID != cfg.AgentID {
+			continue
+		}
+		if a.State == "running" {
+			row.State = StateOK
+			row.Line = describeSidecar(a.AgentVersion, a.PID)
+			return row.commit(rep)
+		}
+		row.State = StateFailed
+		row.Line = "installed, not started"
+		row.Detail = fmt.Sprintf("The %s agent is registered but its state is %q.", cfg.AgentName, a.State)
+		row.Fix = FixStartSidecar
+		row.Remedy = Remedy{
+			Action:  "Start it — the background service supervises it from then on.",
+			Command: "gaia daemon start-agent " + cfg.AgentID,
+			Where:   fmt.Sprintf("~/.gaia/agents/%s/logs/", cfg.AgentID),
+		}
+		return row.commit(rep)
+	}
+
+	row.State = StateFailed
+	row.Line = "not installed"
+	row.Detail = fmt.Sprintf("The background service has no agent registered as %q.", cfg.AgentID)
+	row.Remedy = Remedy{
+		Action:  "Install it from the hub, then re-check.",
+		Command: "gaia hub install " + cfg.AgentID,
+		Where:   daemonLog(),
+	}
+	return row.commit(rep)
+}
+
+func describeSidecar(version *string, pid *int) string {
+	parts := []string{}
+	if version != nil && *version != "" {
+		parts = append(parts, *version)
+	}
+	if pid != nil && *pid > 0 {
+		parts = append(parts, fmt.Sprintf("running (pid %d)", *pid))
+	} else {
+		parts = append(parts, "running")
+	}
+	return strings.Join(parts, " · ")
+}
+
+// ---------------------------------------------------------------------------
+// 3+4. GET /v1/<agent>/init — one probe, two rows.
+// ---------------------------------------------------------------------------
+
+type initBody struct {
+	Ready    bool `json:"ready"`
+	Lemonade struct {
+		Reachable  bool    `json:"reachable"`
+		BaseURL    string  `json:"base_url"`
+		Version    *string `json:"version"`
+		MinVersion string  `json:"min_version"`
+		// Compatible is null when the server does not advertise a version. That
+		// is an indeterminate check, NOT a pass.
+		Compatible *bool `json:"compatible"`
+	} `json:"lemonade"`
+	Model struct {
+		ID       string `json:"id"`
+		Present  bool   `json:"present"`
+		Loadable *bool  `json:"loadable"`
+		CtxSize  *int   `json:"ctx_size"`
+	} `json:"model"`
+	Hint *string `json:"hint"`
+}
+
+func (b initBody) hint() string {
+	if b.Hint == nil {
+		return ""
+	}
+	return *b.Hint
+}
+
+func checkInit(ctx context.Context, t Transport, cfg Config, rep *Report) State {
+	l := Ladder{AgentID: cfg.AgentID}
+	lemonade := Row{Key: KeyLemonade}
+	model := Row{Key: KeyModel}
+
+	resp, err := t.Do(ctx, http.MethodGet, "/v1/"+cfg.AgentID+"/init", nil)
+	if err != nil {
+		d := l.Error("check whether the local AI is ready", err)
+		lemonade.State, lemonade.Line, lemonade.Detail, lemonade.Remedy, lemonade.Raw =
+			StateFailed, "cannot be checked", d.Cause, d.AsRemedy(), err.Error()
+		setRow(rep, lemonade)
+		return StateFailed
+	}
+	raw := string(resp.Body)
+	lemonade.Raw, model.Raw = raw, raw
+
+	// 200 = ready, 503 = not ready, SAME body either way. Anything else is the
+	// relay or the sidecar failing, not an answer about readiness.
+	if resp.Status != http.StatusOK && resp.Status != http.StatusServiceUnavailable {
+		d := l.Status("check whether the local AI is ready", resp.Status, raw)
+		lemonade.State, lemonade.Line, lemonade.Detail, lemonade.Remedy =
+			StateFailed, "cannot be checked", d.Cause, d.AsRemedy()
+		setRow(rep, lemonade)
+		return StateFailed
+	}
+
+	var body initBody
+	if err := json.Unmarshal(resp.Body, &body); err != nil {
+		lemonade.State, lemonade.Line = StateFailed, "unreadable answer"
+		lemonade.Detail = fmt.Sprintf("The %s agent's readiness answer could not be read.", cfg.AgentName)
+		lemonade.Remedy = Remedy{
+			Action:  "Restart the agent's sidecar, then re-check.",
+			Command: "gaia daemon start-agent " + cfg.AgentID,
+			Where:   fmt.Sprintf("~/.gaia/agents/%s/logs/", cfg.AgentID),
+		}
+		setRow(rep, lemonade)
+		return StateFailed
+	}
+
+	// --- Local AI ---------------------------------------------------------
+	switch {
+	case !body.Lemonade.Reachable:
+		d := l.Text("reach the local model server", firstNonEmpty(body.hint(), "not reachable"))
+		lemonade.State = StateFailed
+		lemonade.Line = "not running at " + body.Lemonade.BaseURL
+		lemonade.Detail = "GAIA needs a local model server. It runs on your machine; no message text ever leaves it."
+		lemonade.Remedy = d.AsRemedy()
+		// The sidecar cannot install or launch Lemonade — that is a host
+		// prerequisite — so there is no honest one-key fix here.
+		lemonade.Fix = FixNone
+		setRow(rep, lemonade)
+		return StateFailed
+
+	case modelListUnreadable(body):
+		// Reachable, but its model list could not be read: `present:false` here
+		// means "we could not tell", not "it is missing". Reporting it on the
+		// model row would send the user to download something they may already
+		// have. The sidecar's own hint is the only thing that distinguishes the
+		// two, and it orders this before the version check — so does this.
+		lemonade.State = StateFailed
+		lemonade.Line = "running, but not answering properly"
+		lemonade.Detail = body.hint()
+		lemonade.Remedy = Remedy{
+			Action:  "Restart the local model server, then re-check.",
+			Command: "lemonade-server serve",
+			Where:   "https://amd-gaia.ai/docs/guides/install",
+		}
+		setRow(rep, lemonade)
+		return StateFailed
+
+	case body.Lemonade.Compatible != nil && !*body.Lemonade.Compatible:
+		lemonade.State = StateFailed
+		lemonade.Line = fmt.Sprintf("%s is older than %s",
+			versionOr(body.Lemonade.Version, "the installed version"), body.Lemonade.MinVersion)
+		lemonade.Detail = fmt.Sprintf(
+			"The %s agent needs Lemonade %s or newer; upgrading keeps every other GAIA agent working too.",
+			cfg.AgentName, body.Lemonade.MinVersion)
+		lemonade.Remedy = Remedy{
+			Action:  "Upgrade the local model server, then re-check.",
+			Command: "gaia init",
+			Where:   "https://lemonade-server.ai",
+		}
+		setRow(rep, lemonade)
+		return StateFailed
+
+	case body.Lemonade.Compatible == nil:
+		// Reachable, but it did not say which version it is. Indeterminate is
+		// not a pass: the agent's minimum cannot be verified either way.
+		lemonade.State = StateUnknown
+		lemonade.Line = "running, version not advertised"
+		lemonade.Detail = fmt.Sprintf(
+			"Lemonade at %s answered but reported no version, so it cannot be verified as %s or newer.",
+			body.Lemonade.BaseURL, body.Lemonade.MinVersion)
+		lemonade.Remedy = Remedy{
+			Action:  "Upgrade it if anything below behaves oddly; the checks continue either way.",
+			Command: "gaia init",
+			Where:   "https://lemonade-server.ai",
+		}
+
+	default:
+		lemonade.State = StateOK
+		lemonade.Line = "Lemonade " + versionOr(body.Lemonade.Version, "(version unreported)")
+	}
+	setRow(rep, lemonade)
+
+	// --- AI model ---------------------------------------------------------
+	if !body.Model.Present {
+		model.State = StateFailed
+		model.Line = body.Model.ID + " not downloaded"
+		// The sidecar's hint here restates the line and the command; the raw body
+		// is one `d` away, so the row gets the sentence that tells the user
+		// something they do not already see.
+		model.Detail = "About 4 GB. Once downloaded it is reused by every GAIA agent."
+		model.Fix = FixPullModel
+		model.Remedy = Remedy{
+			Action:  "Download it — press f to pull it here, or run the command.",
+			Command: "gaia init",
+			Where:   "https://amd-gaia.ai/docs/guides/install",
+		}
+		setRow(rep, model)
+		return StateFailed
+	}
+
+	model.State = StateOK
+	model.Line = body.Model.ID
+	if body.Model.CtxSize != nil && *body.Model.CtxSize > 0 {
+		model.Line += fmt.Sprintf(" · %s context", humanCtx(*body.Model.CtxSize))
+	} else {
+		model.Line += " · downloaded, not loaded yet"
+	}
+	setRow(rep, model)
+	return model.State
+}
+
+// modelListUnreadable reports the one readiness failure the structured fields
+// cannot express: Lemonade answered /health but its /models read failed, so
+// `present:false` means "could not tell", not "missing". Only the hint carries
+// it (api_routes._compute_init_status).
+func modelListUnreadable(body initBody) bool {
+	h := strings.ToLower(body.hint())
+	return strings.Contains(h, "model list") && strings.Contains(h, "could not be read")
+}
+
+func versionOr(v *string, fallback string) string {
+	if v == nil || *v == "" {
+		return fallback
+	}
+	return *v
+}
+
+func firstNonEmpty(vals ...string) string {
+	for _, v := range vals {
+		if strings.TrimSpace(v) != "" {
+			return v
+		}
+	}
+	return ""
+}
+
+func humanCtx(n int) string {
+	if n >= 1024 && n%1024 == 0 {
+		return fmt.Sprintf("%dK", n/1024)
+	}
+	return fmt.Sprintf("%d", n)
+}
+
+// ---------------------------------------------------------------------------
+// 5. [email-specific] The mailbox: connected AND granted send.
+// ---------------------------------------------------------------------------
+
+type connectorEntry struct {
+	Provider     string   `json:"provider"`
+	Connected    bool     `json:"connected"`
+	AccountEmail *string  `json:"account_email"`
+	Scopes       []string `json:"scopes"`
+	CanSend      bool     `json:"can_send"`
+}
+
+type connectorsBody struct {
+	AgentID   string           `json:"agent_id"`
+	Providers []connectorEntry `json:"providers"`
+}
+
+// Send scopes, mirroring gaia_agent_email.scopes / .outlook_scopes. Quoted in a
+// remedy, so a wrong value would send the user down a dead end.
+const (
+	gmailSendScope   = "https://www.googleapis.com/auth/gmail.send"
+	outlookSendScope = "https://graph.microsoft.com/Mail.Send"
+	// emailAgentGrantID mirrors connector_routes.EMAIL_AGENT_ID.
+	emailAgentGrantID = "installed:email"
+)
+
+// MailboxCheck is the email agent's extra precondition.
+//
+// `connected` and `can_send` are separate answers and the difference matters:
+// an account can be linked while the agent has no send grant, and today that
+// only surfaces as a 403 in the middle of a task the user already approved.
+func MailboxCheck() ExtraCheck {
+	return ExtraCheck{
+		Key:   KeyMailbox,
+		Label: "Mailbox",
+		Run:   runMailboxCheck,
+	}
+}
+
+func runMailboxCheck(ctx context.Context, t Transport, cfg Config) Row {
+	l := Ladder{AgentID: cfg.AgentID}
+	row := Row{Key: KeyMailbox, Label: "Mailbox"}
+
+	resp, err := t.Do(ctx, http.MethodGet, "/v1/"+cfg.AgentID+"/connectors", nil)
+	if err != nil {
+		d := l.Error("check which mailboxes are connected", err)
+		row.State, row.Line, row.Detail, row.Remedy, row.Raw =
+			StateFailed, "cannot be checked", d.Cause, d.AsRemedy(), err.Error()
+		return row
+	}
+	row.Raw = string(resp.Body)
+	if resp.Status != http.StatusOK {
+		d := l.Status("check which mailboxes are connected", resp.Status, string(resp.Body))
+		row.State, row.Line, row.Detail, row.Remedy =
+			StateFailed, "cannot be checked", d.Cause, d.AsRemedy()
+		return row
+	}
+
+	var body connectorsBody
+	if err := json.Unmarshal(resp.Body, &body); err != nil {
+		row.State, row.Line = StateFailed, "unreadable answer"
+		row.Detail = "The mailbox connector list could not be read."
+		row.Remedy = Remedy{
+			Action:  "Restart the agent's sidecar, then re-check.",
+			Command: "gaia daemon start-agent " + cfg.AgentID,
+			Where:   fmt.Sprintf("~/.gaia/agents/%s/logs/", cfg.AgentID),
+		}
+		return row
+	}
+
+	// Prefer a fully usable mailbox; fall back to reporting the connected-but-
+	// not-granted one, which is a distinct failure with a distinct remedy.
+	var connected *connectorEntry
+	for i := range body.Providers {
+		p := &body.Providers[i]
+		if !p.Connected {
+			continue
+		}
+		if p.CanSend {
+			row.State = StateOK
+			row.Line = fmt.Sprintf("%s (%s) · can send",
+				accountOr(p.AccountEmail, "connected"), providerName(p.Provider))
+			return row
+		}
+		if connected == nil {
+			connected = p
+		}
+	}
+
+	if connected != nil {
+		row.State = StateFailed
+		row.Line = fmt.Sprintf("%s connected, send not allowed", accountOr(connected.AccountEmail, providerName(connected.Provider)))
+		row.Detail = fmt.Sprintf(
+			"The account is linked but %s was never granted permission to send, so a send fails mid-task.",
+			cfg.AgentName)
+		row.Fix = FixConnectMailbox
+		row.Provider = connected.Provider
+		row.Remedy = Remedy{
+			Action: "Grant the send scope — press f to reconnect, or run the command.",
+			Command: fmt.Sprintf("gaia connectors grants grant %s %s --scopes %s",
+				connected.Provider, emailAgentGrantID, sendScope(connected.Provider)),
+			Where: "https://amd-gaia.ai/docs/guides/email",
+		}
+		return row
+	}
+
+	row.State = StateFailed
+	row.Line = "not connected"
+	row.Detail = fmt.Sprintf("%s cannot do anything until it can read a mailbox. Connecting takes about three minutes.", cfg.AgentName)
+	row.Fix = FixConnectMailbox
+	row.Provider = "google"
+	row.Remedy = Remedy{
+		Action: "Connect Gmail or Outlook — press f to start, or run the command.",
+		Command: fmt.Sprintf("gaia connectors connect google --grant-agent %s --scopes %s",
+			emailAgentGrantID, gmailSendScope),
+		Where: "https://amd-gaia.ai/docs/guides/email",
+	}
+	return row
+}
+
+func sendScope(provider string) string {
+	if provider == "microsoft" {
+		return outlookSendScope
+	}
+	return gmailSendScope
+}
+
+func providerName(provider string) string {
+	switch provider {
+	case "google":
+		return "Gmail"
+	case "microsoft":
+		return "Outlook"
+	default:
+		return provider
+	}
+}
+
+func accountOr(email *string, fallback string) string {
+	if email == nil || *email == "" {
+		return fallback
+	}
+	return *email
+}

--- a/tui/internal/ui/preflight/check.go
+++ b/tui/internal/ui/preflight/check.go
@@ -38,7 +38,9 @@ func (c Config) withDefaults() Config {
 		c.AgentID = "email"
 	}
 	if c.AgentName == "" {
-		c.AgentName = strings.ToUpper(c.AgentID[:1]) + c.AgentID[1:]
+		// Rune-wise: byte-slicing corrupts a non-ASCII id into mojibake.
+		r := []rune(c.AgentID)
+		c.AgentName = strings.ToUpper(string(r[:1])) + string(r[1:])
 	}
 	return c
 }
@@ -301,8 +303,12 @@ func describeSidecar(version *string, pid *int) string {
 // ---------------------------------------------------------------------------
 
 type initBody struct {
-	Ready    bool `json:"ready"`
-	Lemonade struct {
+	Ready bool `json:"ready"`
+	// Pointers on purpose. A 503 from the RELAY (the sidecar died between the
+	// agents listing and this call) carries `{"detail": ...}` and no `lemonade`
+	// object at all; decoding that into a value struct would read as
+	// "reachable:false" and send the user to start Lemonade over a dead sidecar.
+	Lemonade *struct {
 		Reachable  bool    `json:"reachable"`
 		BaseURL    string  `json:"base_url"`
 		Version    *string `json:"version"`
@@ -311,7 +317,7 @@ type initBody struct {
 		// is an indeterminate check, NOT a pass.
 		Compatible *bool `json:"compatible"`
 	} `json:"lemonade"`
-	Model struct {
+	Model *struct {
 		ID       string `json:"id"`
 		Present  bool   `json:"present"`
 		Loadable *bool  `json:"loadable"`
@@ -353,15 +359,27 @@ func checkInit(ctx context.Context, t Transport, cfg Config, rep *Report) State 
 		return StateFailed
 	}
 
+	// Whatever happens below, the model row keeps the body it was probed with —
+	// `d` on that row must show what the probe saw, not "(no raw answer)". It
+	// stays Pending with the placeholder line so markPending can still tell the
+	// user what it is waiting on.
+	model.State, model.Line = StatePending, "—"
+	setRow(rep, model)
+
 	var body initBody
-	if err := json.Unmarshal(resp.Body, &body); err != nil {
-		lemonade.State, lemonade.Line = StateFailed, "unreadable answer"
-		lemonade.Detail = fmt.Sprintf("The %s agent's readiness answer could not be read.", cfg.AgentName)
-		lemonade.Remedy = Remedy{
-			Action:  "Restart the agent's sidecar, then re-check.",
-			Command: "gaia daemon start-agent " + cfg.AgentID,
-			Where:   fmt.Sprintf("~/.gaia/agents/%s/logs/", cfg.AgentID),
+	if err := json.Unmarshal(resp.Body, &body); err != nil || body.Lemonade == nil || body.Model == nil {
+		// Either unparseable, or parseable but not a readiness answer at all —
+		// the relay's own 503/502 (`{"detail": ...}`) lands here. Diagnosing it
+		// as "Lemonade is down" would name the wrong subject AND the wrong fix.
+		d := l.Status("check whether the local AI is ready", resp.Status, raw)
+		if err == nil {
+			d.Cause = fmt.Sprintf(
+				"The %s agent answered the readiness check without saying anything about "+
+					"the local AI — it is most likely no longer running. %s",
+				cfg.AgentName, d.Cause)
 		}
+		lemonade.State, lemonade.Line, lemonade.Detail, lemonade.Remedy =
+			StateFailed, "cannot be checked", d.Cause, d.AsRemedy()
 		setRow(rep, lemonade)
 		return StateFailed
 	}
@@ -510,14 +528,50 @@ type connectorsBody struct {
 	Providers []connectorEntry `json:"providers"`
 }
 
-// Send scopes, mirroring gaia_agent_email.scopes / .outlook_scopes. Quoted in a
-// remedy, so a wrong value would send the user down a dead end.
-const (
-	gmailSendScope   = "https://www.googleapis.com/auth/gmail.send"
-	outlookSendScope = "https://graph.microsoft.com/Mail.Send"
-	// emailAgentGrantID mirrors connector_routes.EMAIL_AGENT_ID.
-	emailAgentGrantID = "installed:email"
-)
+// emailAgentGrantID mirrors connector_routes.EMAIL_AGENT_ID.
+const emailAgentGrantID = "installed:email"
+
+// connectScopes is the EXACT scope list a reconnect must request, per provider:
+// the connector's default_scopes ∪ the agent's mail scopes, mirroring
+// connector_routes._build_scope_union.
+//
+// The union is not decoration. `gaia connectors connect --scopes` REPLACES the
+// provider defaults rather than adding to them (flow.py: `list(scopes) or
+// list(provider.default_scopes)`), so a remedy naming only the send scope
+// authorizes an account the agent can no longer read — and the mailbox row
+// would then go green over a mailbox that is worse off than before.
+var connectScopes = map[string][]string{
+	"google": {
+		// catalog/google.py default_scopes
+		"openid", "email", "profile",
+		// gaia_agent_email.scopes.GMAIL_SCOPES
+		"https://www.googleapis.com/auth/gmail.modify",
+		"https://www.googleapis.com/auth/gmail.send",
+	},
+	"microsoft": {
+		// catalog/microsoft.py default_scopes
+		"openid", "offline_access", "https://graph.microsoft.com/User.Read",
+		// gaia_agent_email.outlook_scopes.OUTLOOK_MAIL_SCOPES
+		"https://graph.microsoft.com/Mail.ReadWrite",
+		"https://graph.microsoft.com/Mail.Send",
+	},
+}
+
+// connectCommand is the one command that fixes every mailbox state: it
+// re-authorizes with the full scope set AND grants them to the agent in the
+// same flow, so the token and the grant can never disagree.
+//
+// Deliberately NOT `gaia connectors grants grant`: that overwrites the agent's
+// existing scopes (grants.py grant_agent) and cannot add a scope the stored
+// token never carried, so it would trade "cannot send" for "cannot read".
+func connectCommand(provider string) string {
+	scopes, ok := connectScopes[provider]
+	if !ok {
+		provider, scopes = "google", connectScopes["google"]
+	}
+	return fmt.Sprintf("gaia connectors connect %s --grant-agent %s --scopes %s",
+		provider, emailAgentGrantID, strings.Join(scopes, " "))
+}
 
 // MailboxCheck is the email agent's extra precondition.
 //
@@ -591,10 +645,9 @@ func runMailboxCheck(ctx context.Context, t Transport, cfg Config) Row {
 		row.Fix = FixConnectMailbox
 		row.Provider = connected.Provider
 		row.Remedy = Remedy{
-			Action: "Grant the send scope — press f to reconnect, or run the command.",
-			Command: fmt.Sprintf("gaia connectors grants grant %s %s --scopes %s",
-				connected.Provider, emailAgentGrantID, sendScope(connected.Provider)),
-			Where: "https://amd-gaia.ai/docs/guides/email",
+			Action:  "Reconnect it — press f, or run the command. Takes about a minute.",
+			Command: connectCommand(connected.Provider),
+			Where:   "https://amd-gaia.ai/docs/guides/email",
 		}
 		return row
 	}
@@ -603,21 +656,16 @@ func runMailboxCheck(ctx context.Context, t Transport, cfg Config) Row {
 	row.Line = "not connected"
 	row.Detail = fmt.Sprintf("%s cannot do anything until it can read a mailbox. Connecting takes about three minutes.", cfg.AgentName)
 	row.Fix = FixConnectMailbox
-	row.Provider = "google"
+	// No provider: nothing is connected, so the choice between Gmail and Outlook
+	// is the user's and belongs to the connector flow. Naming one here would
+	// route an Outlook user into a Google sign-in.
+	row.Provider = ""
 	row.Remedy = Remedy{
-		Action: "Connect Gmail or Outlook — press f to start, or run the command.",
-		Command: fmt.Sprintf("gaia connectors connect google --grant-agent %s --scopes %s",
-			emailAgentGrantID, gmailSendScope),
-		Where: "https://amd-gaia.ai/docs/guides/email",
+		Action:  "Connect Gmail or Outlook — press f to choose. For Outlook, swap `google` for `microsoft` below.",
+		Command: connectCommand("google"),
+		Where:   "https://amd-gaia.ai/docs/guides/email",
 	}
 	return row
-}
-
-func sendScope(provider string) string {
-	if provider == "microsoft" {
-		return outlookSendScope
-	}
-	return gmailSendScope
 }
 
 func providerName(provider string) string {

--- a/tui/internal/ui/preflight/check_test.go
+++ b/tui/internal/ui/preflight/check_test.go
@@ -1,0 +1,748 @@
+package preflight
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/amd/gaia/tui/internal/daemon"
+)
+
+// --- fixtures ---------------------------------------------------------------
+//
+// Every body below is the REAL shape the corresponding endpoint serializes:
+// InitResponse / InitLemonadeStatus / InitModelStatus from
+// gaia_agent_email/api_routes.py, the connectors body from connector_routes.py,
+// and SidecarRegistry.list_agents from src/gaia/daemon/sidecars/registry.py.
+
+const (
+	agentsRunning = `{"agents":[{"agent_id":"email","state":"running","mode":"frozen",` +
+		`"pid":41999,"port":51234,"base_url":"http://127.0.0.1:51234","api_version":"2.3",` +
+		`"agent_version":"0.5.0","started_at":1750000000.0,"dev_src_dir":null}]}`
+
+	agentsStopped = `{"agents":[{"agent_id":"email","state":"stopped","mode":null,` +
+		`"pid":null,"port":null,"base_url":null,"api_version":null,"agent_version":null,` +
+		`"started_at":null,"dev_src_dir":null}]}`
+
+	agentsEmpty = `{"agents":[]}`
+
+	initReady = `{"ready":true,"lemonade":{"reachable":true,` +
+		`"base_url":"http://localhost:8000/api/v1","version":"8.1.10","min_version":"8.1.0",` +
+		`"compatible":true},"model":{"id":"Gemma-4-E4B-it-GGUF","present":true,"loadable":null,` +
+		`"ctx_size":16384},"hint":null}`
+
+	initUnreachable = `{"ready":false,"lemonade":{"reachable":false,` +
+		`"base_url":"http://localhost:8000/api/v1","version":null,"min_version":"8.1.0",` +
+		`"compatible":null},"model":{"id":"Gemma-4-E4B-it-GGUF","present":false,"loadable":null,` +
+		`"ctx_size":null},"hint":"Local Lemonade Server is not reachable at ` +
+		"http://localhost:8000/api/v1 — start it with `lemonade-server serve` (or run `gaia init`), then retry.\"}"
+
+	initTooOld = `{"ready":false,"lemonade":{"reachable":true,` +
+		`"base_url":"http://localhost:8000/api/v1","version":"8.0.1","min_version":"8.1.0",` +
+		`"compatible":false},"model":{"id":"Gemma-4-E4B-it-GGUF","present":true,"loadable":null,` +
+		`"ctx_size":null},"hint":"Lemonade 8.0.1 is older than the required 8.1.0 — upgrade it ` +
+		"(see https://lemonade-server.ai or run `gaia init`), then retry.\"}"
+
+	// The server does not advertise a version, so `compatible` is null. The
+	// sidecar still reports ready=true (it mirrors gaia init's policy of not
+	// failing on an unparseable version) — the gate must NOT read that as a pass.
+	initUnknownVersion = `{"ready":true,"lemonade":{"reachable":true,` +
+		`"base_url":"http://localhost:8000/api/v1","version":null,"min_version":"8.1.0",` +
+		`"compatible":null},"model":{"id":"Gemma-4-E4B-it-GGUF","present":true,"loadable":null,` +
+		`"ctx_size":16384},"hint":null}`
+
+	// Captured from a live sidecar: when ctx_size is null the serializer OMITS
+	// the key entirely, so the parser must not depend on it being present.
+	initModelMissing = `{"ready":false,"lemonade":{"reachable":true,` +
+		`"base_url":"http://localhost:13305/api/v1","version":"10.2.1","min_version":"10.2.0",` +
+		`"compatible":true},"model":{"id":"Gemma-4-E4B-it-GGUF","present":false,"loadable":null},` +
+		"\"hint\":\"Model `Gemma-4-E4B-it-GGUF` not downloaded — run `gaia init` " +
+		`(or pull it via Lemonade), then retry."}`
+
+	// Lemonade answered /health but its /models read failed. `present:false` here
+	// means "could not tell" — the hint is the ONLY thing that says so.
+	initModelListUnreadable = `{"ready":false,"lemonade":{"reachable":true,` +
+		`"base_url":"http://localhost:13305/api/v1","version":"10.2.1","min_version":"10.2.0",` +
+		`"compatible":true},"model":{"id":"Gemma-4-E4B-it-GGUF","present":false,"loadable":null},` +
+		`"hint":"Lemonade is reachable but its model list at http://localhost:13305/api/v1/models ` +
+		`could not be read (ConnectionError: connection aborted). Make sure the server is healthy, then retry."}`
+
+	connectorsReady = `{"agent_id":"installed:email","providers":[` +
+		`{"provider":"google","connected":true,"account_email":"you@gmail.com",` +
+		`"scopes":["https://www.googleapis.com/auth/gmail.readonly","https://www.googleapis.com/auth/gmail.send"],` +
+		`"can_send":true},` +
+		`{"provider":"microsoft","connected":false,"account_email":null,"scopes":[],"can_send":false}]}`
+
+	connectorsNone = `{"agent_id":"installed:email","providers":[` +
+		`{"provider":"google","connected":false,"account_email":null,"scopes":[],"can_send":false},` +
+		`{"provider":"microsoft","connected":false,"account_email":null,"scopes":[],"can_send":false}]}`
+
+	// Captured live: a connected mailbox whose account_email is null (the store's
+	// DEFAULT_ACCOUNT sentinel is mapped away rather than leaked to the UI).
+	connectorsNoEmail = `{"agent_id":"installed:email","providers":[` +
+		`{"provider":"google","connected":true,"account_email":null,"scopes":[],"can_send":true},` +
+		`{"provider":"microsoft","connected":false,"account_email":null,"scopes":[],"can_send":false}]}`
+
+	// Lemonade answers but advertises no version AND the model is missing — the
+	// live shape that put an indeterminate row above a real failure.
+	initUnknownVersionModelMissing = `{"ready":false,"lemonade":{"reachable":true,` +
+		`"base_url":"http://localhost:13305/api/v1","version":null,"min_version":"10.2.0",` +
+		`"compatible":null},"model":{"id":"Gemma-4-E4B-it-GGUF","present":false,"loadable":null},` +
+		"\"hint\":\"Model `Gemma-4-E4B-it-GGUF` not downloaded — run `gaia init` " +
+		`(or pull it via Lemonade), then retry."}`
+
+	connectorsNoSend = `{"agent_id":"installed:email","providers":[` +
+		`{"provider":"google","connected":true,"account_email":"you@gmail.com",` +
+		`"scopes":["https://www.googleapis.com/auth/gmail.readonly"],"can_send":false},` +
+		`{"provider":"microsoft","connected":false,"account_email":null,"scopes":[],"can_send":false}]}`
+)
+
+// --- fake transport ---------------------------------------------------------
+
+type call struct {
+	method string
+	path   string
+}
+
+type fakeTransport struct {
+	attachErr error
+	startErr  error
+	ensureErr error
+	info      DaemonInfo
+
+	// bodies is keyed "GET /daemon/v1/agents".
+	bodies map[string]Response
+	errs   map[string]error
+
+	streamStatus int
+	streamBody   string
+	streamErr    error
+
+	calls []call
+}
+
+func newFake() *fakeTransport {
+	return &fakeTransport{
+		info: DaemonInfo{PID: 41822, Port: 51230, APIVersion: "1.1"},
+		bodies: map[string]Response{
+			"GET /daemon/v1/agents":    {Status: 200, Body: []byte(agentsRunning)},
+			"GET /v1/email/init":       {Status: 200, Body: []byte(initReady)},
+			"GET /v1/email/connectors": {Status: 200, Body: []byte(connectorsReady)},
+		},
+		errs: map[string]error{},
+	}
+}
+
+func (f *fakeTransport) with(key string, status int, body string) *fakeTransport {
+	f.bodies[key] = Response{Status: status, Body: []byte(body)}
+	return f
+}
+
+func (f *fakeTransport) Attach(context.Context) (DaemonInfo, error) {
+	if f.attachErr != nil {
+		return DaemonInfo{}, f.attachErr
+	}
+	return f.info, nil
+}
+
+func (f *fakeTransport) Start(context.Context) (DaemonInfo, error) {
+	if f.startErr != nil {
+		return DaemonInfo{}, f.startErr
+	}
+	f.attachErr = nil
+	return f.info, nil
+}
+
+func (f *fakeTransport) EnsureAgent(context.Context, string) error { return f.ensureErr }
+
+func (f *fakeTransport) Do(_ context.Context, method, path string, _ []byte) (Response, error) {
+	key := method + " " + path
+	f.calls = append(f.calls, call{method, path})
+	if err, ok := f.errs[key]; ok {
+		return Response{}, err
+	}
+	resp, ok := f.bodies[key]
+	if !ok {
+		return Response{Status: 404, Body: []byte(`{"detail":"not found"}`)}, nil
+	}
+	return resp, nil
+}
+
+func (f *fakeTransport) Stream(_ context.Context, method, path string, _ []byte) (Stream, error) {
+	f.calls = append(f.calls, call{method, path})
+	if f.streamErr != nil {
+		return Stream{}, f.streamErr
+	}
+	status := f.streamStatus
+	if status == 0 {
+		status = 200
+	}
+	return Stream{Status: status, Body: io.NopCloser(strings.NewReader(f.streamBody))}, nil
+}
+
+func (f *fakeTransport) called(method, path string) bool {
+	for _, c := range f.calls {
+		if c.method == method && c.path == path {
+			return true
+		}
+	}
+	return false
+}
+
+// --- the table --------------------------------------------------------------
+
+// realCommands are the command prefixes that actually exist. A remedy that names
+// something outside this set sends the user somewhere that does not work, which
+// is worse than no remedy at all.
+var realCommands = []string{
+	"gaia daemon start",
+	"gaia daemon restart",
+	"gaia daemon start-agent ",
+	"gaia daemon agents",
+	"gaia hub install ",
+	"gaia init",
+	"lemonade-server serve",
+	"gaia connectors connect ",
+	"gaia connectors grants grant ",
+}
+
+func assertRealCommand(t *testing.T, row Row) {
+	t.Helper()
+	cmd := row.Remedy.Command
+	if cmd == "" {
+		t.Fatalf("row %q failed with no command to run: %+v", row.Key, row.Remedy)
+	}
+	for _, prefix := range realCommands {
+		if strings.HasPrefix(cmd, prefix) {
+			if strings.Contains(cmd, "<") {
+				t.Fatalf("row %q remedy still has a placeholder: %q", row.Key, cmd)
+			}
+			return
+		}
+	}
+	t.Fatalf("row %q remedy names a command that does not exist: %q", row.Key, cmd)
+}
+
+func TestCheck(t *testing.T) {
+	tests := []struct {
+		name string
+		// build returns the transport for this scenario.
+		build func() *fakeTransport
+		// wantStates is keyed by row key. Rows omitted are not asserted.
+		wantStates map[string]State
+		wantReady  bool
+		// wantBlocker is the key of the row that must be the first failure, "" for none.
+		wantBlocker string
+		// wantIn asserts substrings on the blocking row's rendered remedy.
+		wantIn []string
+		// wantFix is the fix the blocking row offers.
+		wantFix FixKind
+		// mustNotCall names paths the walk must not reach (stop at first failure).
+		mustNotCall []call
+	}{
+		{
+			name:  "all ready",
+			build: newFake,
+			wantStates: map[string]State{
+				KeyDaemon: StateOK, KeySidecar: StateOK, KeyLemonade: StateOK,
+				KeyModel: StateOK, KeyMailbox: StateOK,
+			},
+			wantReady: true,
+		},
+		{
+			name: "daemon down",
+			build: func() *fakeTransport {
+				f := newFake()
+				f.attachErr = &daemon.NotRunningError{Path: "/tmp/instance.json"}
+				return f
+			},
+			wantStates: map[string]State{
+				KeyDaemon: StateFailed, KeySidecar: StatePending, KeyLemonade: StatePending,
+				KeyModel: StatePending, KeyMailbox: StatePending,
+			},
+			wantBlocker: KeyDaemon,
+			wantIn:      []string{"gaia daemon start"},
+			wantFix:     FixStartDaemon,
+			mustNotCall: []call{{"GET", "/daemon/v1/agents"}, {"GET", "/v1/email/init"}},
+		},
+		{
+			name: "daemon speaks the wrong contract",
+			build: func() *fakeTransport {
+				f := newFake()
+				f.attachErr = &daemon.VersionError{Have: "1.0", Reason: "it predates the agent relay"}
+				return f
+			},
+			wantStates:  map[string]State{KeyDaemon: StateFailed},
+			wantBlocker: KeyDaemon,
+			wantIn:      []string{"gaia daemon restart", "host API v1.0"},
+			// Restarting a machine-wide daemon other clients share is not ours to do.
+			wantFix: FixNone,
+		},
+		{
+			name: "sidecar not running",
+			build: func() *fakeTransport {
+				return newFake().with("GET /daemon/v1/agents", 200, agentsStopped)
+			},
+			wantStates: map[string]State{
+				KeyDaemon: StateOK, KeySidecar: StateFailed, KeyLemonade: StatePending,
+			},
+			wantBlocker: KeySidecar,
+			wantIn:      []string{"gaia daemon start-agent email"},
+			wantFix:     FixStartSidecar,
+			mustNotCall: []call{{"GET", "/v1/email/init"}},
+		},
+		{
+			name: "agent not installed",
+			build: func() *fakeTransport {
+				return newFake().with("GET /daemon/v1/agents", 200, agentsEmpty)
+			},
+			wantStates:  map[string]State{KeySidecar: StateFailed},
+			wantBlocker: KeySidecar,
+			wantIn:      []string{"gaia hub install email"},
+			wantFix:     FixNone,
+		},
+		{
+			name: "lemonade unreachable",
+			build: func() *fakeTransport {
+				return newFake().with("GET /v1/email/init", 503, initUnreachable)
+			},
+			wantStates: map[string]State{
+				KeyDaemon: StateOK, KeySidecar: StateOK, KeyLemonade: StateFailed,
+				KeyModel: StatePending, KeyMailbox: StatePending,
+			},
+			wantBlocker: KeyLemonade,
+			wantIn:      []string{"lemonade-server serve", "not running"},
+			// The sidecar cannot install or launch Lemonade; pretending otherwise
+			// would be a key that does nothing.
+			wantFix:     FixNone,
+			mustNotCall: []call{{"GET", "/v1/email/connectors"}},
+		},
+		{
+			name: "lemonade too old",
+			build: func() *fakeTransport {
+				return newFake().with("GET /v1/email/init", 503, initTooOld)
+			},
+			wantStates: map[string]State{
+				KeyLemonade: StateFailed, KeyModel: StatePending,
+			},
+			wantBlocker: KeyLemonade,
+			wantIn:      []string{"8.0.1", "8.1.0", "gaia init"},
+		},
+		{
+			name: "lemonade version unknown is not a pass",
+			build: func() *fakeTransport {
+				return newFake().with("GET /v1/email/init", 200, initUnknownVersion)
+			},
+			wantStates: map[string]State{
+				KeyDaemon: StateOK, KeySidecar: StateOK, KeyLemonade: StateUnknown,
+				KeyModel: StateOK, KeyMailbox: StateOK,
+			},
+			// Unknown is not ready — but it does not block either, matching the
+			// sidecar's own policy of not failing on an unparseable version.
+			wantReady:   false,
+			wantBlocker: "",
+		},
+		{
+			name: "model missing",
+			build: func() *fakeTransport {
+				return newFake().with("GET /v1/email/init", 503, initModelMissing)
+			},
+			wantStates: map[string]State{
+				KeyLemonade: StateOK, KeyModel: StateFailed, KeyMailbox: StatePending,
+			},
+			wantBlocker: KeyModel,
+			wantIn:      []string{"gaia init", "Gemma-4-E4B-it-GGUF"},
+			wantFix:     FixPullModel,
+		},
+		{
+			name: "no mailbox connected",
+			build: func() *fakeTransport {
+				return newFake().with("GET /v1/email/connectors", 200, connectorsNone)
+			},
+			wantStates: map[string]State{
+				KeyModel: StateOK, KeyMailbox: StateFailed,
+			},
+			wantBlocker: KeyMailbox,
+			wantIn:      []string{"gaia connectors connect google", "installed:email"},
+			wantFix:     FixConnectMailbox,
+		},
+		{
+			name: "mailbox connected but send not granted",
+			build: func() *fakeTransport {
+				return newFake().with("GET /v1/email/connectors", 200, connectorsNoSend)
+			},
+			wantStates:  map[string]State{KeyMailbox: StateFailed},
+			wantBlocker: KeyMailbox,
+			wantIn: []string{
+				"you@gmail.com", "send not allowed",
+				"gaia connectors grants grant google installed:email",
+				"https://www.googleapis.com/auth/gmail.send",
+			},
+			wantFix: FixConnectMailbox,
+		},
+		{
+			// present:false must NOT be reported as "download the model" when the
+			// sidecar could not read the list to begin with.
+			name: "lemonade reachable but its model list is unreadable",
+			build: func() *fakeTransport {
+				return newFake().with("GET /v1/email/init", 503, initModelListUnreadable)
+			},
+			wantStates: map[string]State{
+				KeyLemonade: StateFailed, KeyModel: StatePending,
+			},
+			wantBlocker: KeyLemonade,
+			wantIn:      []string{"model list", "lemonade-server serve"},
+			wantFix:     FixNone,
+		},
+		{
+			name: "sidecar relay is down",
+			build: func() *fakeTransport {
+				return newFake().with("GET /v1/email/init", 502,
+					`{"detail":"the 'email' sidecar is registered but not running (POST /daemon/v1/agents/email/ensure) and retry."}`)
+			},
+			wantStates:  map[string]State{KeyLemonade: StateFailed},
+			wantBlocker: KeyLemonade,
+			wantIn:      []string{"gaia daemon start-agent email"},
+		},
+		{
+			name: "init answers with something unreadable",
+			build: func() *fakeTransport {
+				return newFake().with("GET /v1/email/init", 200, `<html>not json</html>`)
+			},
+			wantStates:  map[string]State{KeyLemonade: StateFailed},
+			wantBlocker: KeyLemonade,
+			wantIn:      []string{"gaia daemon start-agent email"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f := tt.build()
+			rep := Check(context.Background(), f, EmailConfig())
+
+			if got := rep.Ready(); got != tt.wantReady {
+				t.Errorf("Ready() = %v, want %v\n%s", got, tt.wantReady, rep)
+			}
+			for key, want := range tt.wantStates {
+				row, ok := rep.Find(key)
+				if !ok {
+					t.Fatalf("no row %q in report:\n%s", key, rep)
+				}
+				if row.State != want {
+					t.Errorf("row %q state = %s, want %s\n%s", key, row.State.Word(), want.Word(), rep)
+				}
+			}
+
+			blocker, hasBlocker := rep.Blocker()
+			if tt.wantBlocker == "" {
+				if hasBlocker {
+					t.Fatalf("expected no blocking row, got %q\n%s", blocker.Key, rep)
+				}
+			} else {
+				if !hasBlocker {
+					t.Fatalf("expected %q to block, nothing did\n%s", tt.wantBlocker, rep)
+				}
+				if blocker.Key != tt.wantBlocker {
+					t.Fatalf("blocker = %q, want %q\n%s", blocker.Key, tt.wantBlocker, rep)
+				}
+				assertRealCommand(t, blocker)
+				if blocker.Fix != tt.wantFix {
+					t.Errorf("blocker fix = %v, want %v", blocker.Fix, tt.wantFix)
+				}
+				text := fmt.Sprintf("%s %s %s %s %s",
+					blocker.Line, blocker.Detail, blocker.Remedy.Action,
+					blocker.Remedy.Command, blocker.Remedy.Where)
+				for _, want := range tt.wantIn {
+					if !strings.Contains(text, want) {
+						t.Errorf("blocking row does not mention %q; it says: %s", want, text)
+					}
+				}
+			}
+
+			for _, c := range tt.mustNotCall {
+				if f.called(c.method, c.path) {
+					t.Errorf("walk should have stopped before %s %s", c.method, c.path)
+				}
+			}
+		})
+	}
+}
+
+// Every non-OK row — not just the blocking one — has to be actionable, because
+// the user can move the cursor onto any of them.
+func TestEveryFailedRowIsActionable(t *testing.T) {
+	scenarios := map[string]*fakeTransport{
+		"unreachable": newFake().with("GET /v1/email/init", 503, initUnreachable),
+		"too old":     newFake().with("GET /v1/email/init", 503, initTooOld),
+		"model":       newFake().with("GET /v1/email/init", 503, initModelMissing),
+		"mailbox":     newFake().with("GET /v1/email/connectors", 200, connectorsNone),
+		"no send":     newFake().with("GET /v1/email/connectors", 200, connectorsNoSend),
+		"sidecar":     newFake().with("GET /daemon/v1/agents", 200, agentsStopped),
+	}
+	for name, f := range scenarios {
+		t.Run(name, func(t *testing.T) {
+			rep := Check(context.Background(), f, EmailConfig())
+			for _, row := range rep.Rows {
+				switch row.State {
+				case StateFailed:
+					assertRealCommand(t, row)
+					if row.Detail == "" {
+						t.Errorf("failed row %q says nothing about what went wrong", row.Key)
+					}
+					if row.Remedy.Where == "" {
+						t.Errorf("failed row %q does not say where to look next", row.Key)
+					}
+				case StatePending:
+					if row.Detail == "" {
+						t.Errorf("pending row %q does not say what it is waiting on", row.Key)
+					}
+				}
+			}
+		})
+	}
+}
+
+// The daemon row must distinguish "start one" from "this one is unusable": a
+// version skew is never fixed by starting a second daemon.
+func TestDaemonRowFixDependsOnWhyItFailed(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want FixKind
+	}{
+		{"never started", &daemon.NotRunningError{Path: "/tmp/i.json"}, FixStartDaemon},
+		{"dead pid", &daemon.StaleError{Kind: daemon.StalePIDDead, Path: "/tmp/i.json", Reason: "its pid 1 is not running"}, FixStartDaemon},
+		{"port stolen", &daemon.StaleError{Kind: daemon.StaleForeign, Path: "/tmp/i.json", Reason: "served by something else"}, FixStartDaemon},
+		{"wedged", &daemon.StaleError{Kind: daemon.StaleUnresponsive, Path: "/tmp/i.json", Reason: "no answer"}, FixNone},
+		{"version skew", &daemon.VersionError{Have: "1.0", Reason: "too old"}, FixNone},
+		{"would not start", &daemon.StartError{Reason: "port bind failed"}, FixNone},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			f := newFake()
+			f.attachErr = tc.err
+			rep := Check(context.Background(), f, EmailConfig())
+			row, _ := rep.Find(KeyDaemon)
+			if row.Fix != tc.want {
+				t.Errorf("fix = %v, want %v (%s)", row.Fix, tc.want, row.Detail)
+			}
+			assertRealCommand(t, row)
+		})
+	}
+}
+
+func TestProvisionOutcomeComesFromTheFinalLine(t *testing.T) {
+	cases := []struct {
+		name    string
+		status  int
+		body    string
+		wantOK  bool
+		wantIn  string
+		wantCmd string
+	}{
+		{
+			name:   "success",
+			status: 200,
+			body: "→ Email triage model: Gemma-4-E4B-it-GGUF\n" +
+				"→ Pulling Gemma-4-E4B-it-GGUF via Lemonade…\n" +
+				"✓ Gemma-4-E4B-it-GGUF downloaded.\n" +
+				"✓ Provisioning complete. Re-run GET /v1/email/init to confirm readiness.\n",
+			wantOK: true,
+		},
+		{
+			// A committed 200 cannot change status mid-stream, so a failure
+			// arrives as HTTP 200 with a ✗ final line.
+			name:   "failed inside a committed 200",
+			status: 200,
+			body: "→ Email triage model: Gemma-4-E4B-it-GGUF\n" +
+				"✓ Lemonade reachable\n" +
+				"✗ Provisioning failed: ConnectionError: connection refused\n" +
+				"✗ The model was not downloaded. Check the Lemonade Server logs, then retry.\n",
+			wantOK:  false,
+			wantIn:  "not downloaded",
+			wantCmd: "gaia init",
+		},
+		{
+			name:    "refused before streaming",
+			status:  503,
+			body:    "✗ Local Lemonade Server is not reachable at http://localhost:8000/api/v1.\n",
+			wantOK:  false,
+			wantIn:  "not reachable",
+			wantCmd: "lemonade-server serve",
+		},
+		{
+			name:    "ends saying nothing",
+			status:  200,
+			body:    "",
+			wantOK:  false,
+			wantCmd: "gaia init",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			f := newFake()
+			f.streamStatus, f.streamBody = tc.status, tc.body
+
+			var seen []string
+			res := Provision(context.Background(), f, EmailConfig(), func(l string) { seen = append(seen, l) })
+
+			if res.OK != tc.wantOK {
+				t.Fatalf("OK = %v, want %v (final: %q)", res.OK, tc.wantOK, res.Final)
+			}
+			if !f.called("POST", "/v1/email/init") {
+				t.Error("provisioning did not POST /v1/email/init")
+			}
+			if len(seen) != len(res.Lines) {
+				t.Errorf("streamed %d lines to the caller but recorded %d", len(seen), len(res.Lines))
+			}
+			if tc.wantIn != "" && !strings.Contains(res.Final+res.Diagnosis.String(), tc.wantIn) {
+				t.Errorf("outcome does not mention %q: final=%q diag=%q", tc.wantIn, res.Final, res.Diagnosis)
+			}
+			if tc.wantCmd != "" && res.Diagnosis.Command != tc.wantCmd {
+				t.Errorf("remedy command = %q, want %q", res.Diagnosis.Command, tc.wantCmd)
+			}
+		})
+	}
+}
+
+func TestProvisionSurfacesATransportFailure(t *testing.T) {
+	f := newFake()
+	f.streamErr = &daemon.RequestError{Op: "stream the download", Detail: "connection refused"}
+
+	res := Provision(context.Background(), f, EmailConfig(), nil)
+	if res.OK {
+		t.Fatal("a transport failure reported success")
+	}
+	if res.Diagnosis.Command != "lemonade-server serve" {
+		t.Errorf("remedy = %q, want the lemonade command", res.Diagnosis.Command)
+	}
+}
+
+// A generic agent with no extras gets the four generic rows and nothing
+// email-specific — the mailbox check belongs behind the extras hook.
+func TestGenericAgentHasNoMailboxRow(t *testing.T) {
+	f := newFake()
+	f.bodies["GET /daemon/v1/agents"] = Response{Status: 200,
+		Body: []byte(strings.ReplaceAll(agentsRunning, `"email"`, `"analyst"`))}
+	f.bodies["GET /v1/analyst/init"] = Response{Status: 200, Body: []byte(initReady)}
+
+	rep := Check(context.Background(), f, Config{AgentID: "analyst", AgentName: "Analyst"})
+	if len(rep.Rows) != 4 {
+		t.Fatalf("generic agent got %d rows, want 4: %s", len(rep.Rows), rep)
+	}
+	if _, ok := rep.Find(KeyMailbox); ok {
+		t.Error("generic agent should not get the email mailbox row")
+	}
+	if !rep.Ready() {
+		t.Errorf("expected ready:\n%s", rep)
+	}
+	if f.called("GET", "/v1/analyst/connectors") {
+		t.Error("generic agent must not probe the email connectors route")
+	}
+}
+
+func TestCheckSurfacesATransportError(t *testing.T) {
+	f := newFake()
+	f.errs["GET /v1/email/init"] = &daemon.RequestError{
+		Op: "call the agent", Detail: "context deadline exceeded"}
+
+	rep := Check(context.Background(), f, EmailConfig())
+	row, _ := rep.Find(KeyLemonade)
+	if row.State != StateFailed {
+		t.Fatalf("state = %s, want failed", row.State.Word())
+	}
+	assertRealCommand(t, row)
+	if !strings.Contains(row.Detail, "did not respond") {
+		t.Errorf("a timeout should be diagnosed as one, got %q", row.Detail)
+	}
+}
+
+func TestReportSummary(t *testing.T) {
+	rep := Check(context.Background(), newFake().with("GET /v1/email/init", 503, initUnreachable), EmailConfig())
+	if got := rep.Summary(); got != "2 of 5 ready" {
+		t.Errorf("summary = %q, want %q", got, "2 of 5 ready")
+	}
+	ready := Check(context.Background(), newFake(), EmailConfig())
+	if got := ready.Summary(); got != "ready" {
+		t.Errorf("summary = %q, want %q", got, "ready")
+	}
+}
+
+// Sanity: the fake never hands out something the real transport would not.
+var _ Transport = (*fakeTransport)(nil)
+
+func TestErrorsAsWiringForDaemonTypes(t *testing.T) {
+	// Guards the ladder's errors.As chain against a future refactor that wraps
+	// daemon errors — a wrapped NotRunningError must still map to `daemon start`.
+	wrapped := fmt.Errorf("attach failed: %w", &daemon.NotRunningError{Path: "/tmp/i.json"})
+	d := Ladder{AgentID: "email"}.Error("reach the background service", wrapped)
+	if d.Command != "gaia daemon start" {
+		t.Fatalf("wrapped NotRunningError diagnosed as %q", d.Command)
+	}
+}
+
+func TestUnknownStateNeverRendersAsReady(t *testing.T) {
+	rep := Check(context.Background(), newFake().with("GET /v1/email/init", 200, initUnknownVersion), EmailConfig())
+	if rep.Ready() {
+		t.Fatal("a report with an indeterminate row reported itself ready")
+	}
+	if rep.Blocked() {
+		t.Fatal("an indeterminate row must not block the launch")
+	}
+	row, _ := rep.Find(KeyLemonade)
+	if row.State.Marker() == StateOK.Marker() {
+		t.Fatal("unknown must not render with the ok marker")
+	}
+	if !strings.Contains(row.Detail, "no version") {
+		t.Errorf("unknown row does not explain itself: %q", row.Detail)
+	}
+}
+
+// Live-captured shape: an indeterminate Local AI row sitting ABOVE a genuinely
+// missing model. The cursor must land on the failure, not on the row with
+// nothing to do.
+func TestFocusPrefersTheFailureOverAnIndeterminateRow(t *testing.T) {
+	f := newFake().with("GET /v1/email/init", 503, initUnknownVersionModelMissing)
+	rep := Check(context.Background(), f, EmailConfig())
+
+	lemonade, _ := rep.Find(KeyLemonade)
+	if lemonade.State != StateUnknown {
+		t.Fatalf("lemonade row = %s, want unknown", lemonade.State.Word())
+	}
+	idx := rep.FirstAttention()
+	if idx < 0 || rep.Rows[idx].Key != KeyModel {
+		t.Fatalf("attention is on %q, want the model row\n%s", rep.Rows[idx].Key, rep)
+	}
+}
+
+// A mailbox with no account email must still read as connected, not as the
+// store's internal sentinel and not as an empty string.
+func TestConnectedMailboxWithoutAnAccountEmail(t *testing.T) {
+	f := newFake().with("GET /v1/email/connectors", 200, connectorsNoEmail)
+	rep := Check(context.Background(), f, EmailConfig())
+
+	row, _ := rep.Find(KeyMailbox)
+	if row.State != StateOK {
+		t.Fatalf("mailbox row = %s, want ok\n%s", row.State.Word(), rep)
+	}
+	if !strings.Contains(row.Line, "Gmail") || !strings.Contains(row.Line, "can send") {
+		t.Errorf("mailbox line = %q", row.Line)
+	}
+	if strings.Contains(row.Line, "default") {
+		t.Errorf("the store sentinel leaked into the UI: %q", row.Line)
+	}
+}
+
+func TestConfigForAddsTheEmailExtrasOnlyForEmail(t *testing.T) {
+	if got := ConfigFor("email", "Email"); len(got.Extras) != 1 || got.Extras[0].Key != KeyMailbox {
+		t.Errorf("email config has extras %+v, want the mailbox check", got.Extras)
+	}
+	if got := ConfigFor("analyst", "Analyst"); len(got.Extras) != 0 {
+		t.Errorf("a generic agent got email extras: %+v", got.Extras)
+	}
+	if got := ConfigFor("analyst", ""); got.AgentName != "Analyst" {
+		t.Errorf("missing display name = %q, want it derived from the id", got.AgentName)
+	}
+}

--- a/tui/internal/ui/preflight/check_test.go
+++ b/tui/internal/ui/preflight/check_test.go
@@ -197,6 +197,7 @@ func (f *fakeTransport) called(method, path string) bool {
 // something outside this set sends the user somewhere that does not work, which
 // is worse than no remedy at all.
 var realCommands = []string{
+	"gaia daemon status",
 	"gaia daemon start",
 	"gaia daemon restart",
 	"gaia daemon start-agent ",
@@ -237,6 +238,8 @@ func TestCheck(t *testing.T) {
 		wantBlocker string
 		// wantIn asserts substrings on the blocking row's rendered remedy.
 		wantIn []string
+		// wantNotIn asserts what the remedy must NOT say.
+		wantNotIn []string
 		// wantFix is the fix the blocking row offers.
 		wantFix FixKind
 		// mustNotCall names paths the walk must not reach (stop at first failure).
@@ -365,8 +368,14 @@ func TestCheck(t *testing.T) {
 				KeyModel: StateOK, KeyMailbox: StateFailed,
 			},
 			wantBlocker: KeyMailbox,
-			wantIn:      []string{"gaia connectors connect google", "installed:email"},
-			wantFix:     FixConnectMailbox,
+			wantIn: []string{
+				"gaia connectors connect google", "installed:email",
+				// The union, not just the send scope: --scopes REPLACES the
+				// provider defaults, so a short list authorizes a mailbox the
+				// agent can no longer read.
+				"openid", "https://www.googleapis.com/auth/gmail.modify",
+			},
+			wantFix: FixConnectMailbox,
 		},
 		{
 			name: "mailbox connected but send not granted",
@@ -377,10 +386,12 @@ func TestCheck(t *testing.T) {
 			wantBlocker: KeyMailbox,
 			wantIn: []string{
 				"you@gmail.com", "send not allowed",
-				"gaia connectors grants grant google installed:email",
+				"gaia connectors connect google --grant-agent installed:email",
+				"https://www.googleapis.com/auth/gmail.modify",
 				"https://www.googleapis.com/auth/gmail.send",
 			},
-			wantFix: FixConnectMailbox,
+			wantNotIn: []string{"grants grant"},
+			wantFix:   FixConnectMailbox,
 		},
 		{
 			// present:false must NOT be reported as "download the model" when the
@@ -457,6 +468,11 @@ func TestCheck(t *testing.T) {
 				for _, want := range tt.wantIn {
 					if !strings.Contains(text, want) {
 						t.Errorf("blocking row does not mention %q; it says: %s", want, text)
+					}
+				}
+				for _, unwanted := range tt.wantNotIn {
+					if strings.Contains(text, unwanted) {
+						t.Errorf("blocking row must not mention %q; it says: %s", unwanted, text)
 					}
 				}
 			}
@@ -615,8 +631,14 @@ func TestProvisionSurfacesATransportFailure(t *testing.T) {
 	if res.OK {
 		t.Fatal("a transport failure reported success")
 	}
-	if res.Diagnosis.Command != "lemonade-server serve" {
-		t.Errorf("remedy = %q, want the lemonade command", res.Diagnosis.Command)
+	// The TUI only ever dials the daemon, so a refused connection here is the
+	// daemon being unreachable — telling the user to start Lemonade would send
+	// them to the one process that is not involved.
+	if res.Diagnosis.Command != "gaia daemon status" {
+		t.Errorf("remedy = %q, want the daemon command", res.Diagnosis.Command)
+	}
+	if strings.Contains(res.Diagnosis.Cause, "Lemonade") {
+		t.Errorf("a daemon transport failure was blamed on Lemonade: %q", res.Diagnosis.Cause)
 	}
 }
 
@@ -654,7 +676,7 @@ func TestCheckSurfacesATransportError(t *testing.T) {
 		t.Fatalf("state = %s, want failed", row.State.Word())
 	}
 	assertRealCommand(t, row)
-	if !strings.Contains(row.Detail, "did not respond") {
+	if !strings.Contains(row.Detail, "did not finish in time") {
 		t.Errorf("a timeout should be diagnosed as one, got %q", row.Detail)
 	}
 }
@@ -744,5 +766,83 @@ func TestConfigForAddsTheEmailExtrasOnlyForEmail(t *testing.T) {
 	}
 	if got := ConfigFor("analyst", ""); got.AgentName != "Analyst" {
 		t.Errorf("missing display name = %q, want it derived from the id", got.AgentName)
+	}
+}
+
+// The relay answers 503 with `{"detail": ...}` and NO readiness object when the
+// sidecar dies between the agents listing and this probe. Decoded into value
+// structs that read as "Lemonade unreachable" — the wrong subject AND the wrong
+// remedy, pointing away from the process that actually died.
+func TestARelayErrorIsNotReportedAsLemonadeBeingDown(t *testing.T) {
+	f := newFake().with("GET /v1/email/init", 503,
+		`{"detail":"agent 'email' is registered but its sidecar is not running (POST /daemon/v1/agents/email/ensure), then retry."}`)
+
+	rep := Check(context.Background(), f, EmailConfig())
+	row, _ := rep.Find(KeyLemonade)
+
+	if row.State != StateFailed {
+		t.Fatalf("state = %s, want failed", row.State.Word())
+	}
+	if strings.Contains(row.Remedy.Command, "lemonade-server") {
+		t.Errorf("a dead sidecar was blamed on Lemonade: %q", row.Remedy.Command)
+	}
+	if !strings.Contains(row.Remedy.Command, "start-agent") {
+		t.Errorf("remedy = %q, want the sidecar restart", row.Remedy.Command)
+	}
+	if strings.Contains(row.Line, "not running at ") && !strings.Contains(row.Line, "http") {
+		t.Errorf("the row shows an empty base URL: %q", row.Line)
+	}
+	assertRealCommand(t, row)
+}
+
+// `d` on the model row has to show the body the probe actually saw, even when
+// an earlier row is what failed.
+func TestTheModelRowKeepsItsRawAnswerWhenLemonadeFails(t *testing.T) {
+	f := newFake().with("GET /v1/email/init", 503, initUnreachable)
+	rep := Check(context.Background(), f, EmailConfig())
+
+	row, _ := rep.Find(KeyModel)
+	if !strings.Contains(row.Raw, "lemonade") {
+		t.Errorf("the model row lost the probe body it was answered with: %q", row.Raw)
+	}
+	if row.Detail == "" {
+		t.Error("the model row does not say what it is waiting on")
+	}
+}
+
+// The connect remedy must request the SAME scope union the sidecar's own
+// /configure builds — --scopes replaces the provider defaults, so a short list
+// authorizes a mailbox the agent cannot read.
+func TestConnectCommandRequestsTheFullScopeUnion(t *testing.T) {
+	for provider, want := range map[string][]string{
+		"google": {
+			"openid", "email", "profile",
+			"https://www.googleapis.com/auth/gmail.modify",
+			"https://www.googleapis.com/auth/gmail.send",
+		},
+		"microsoft": {
+			"openid", "offline_access", "https://graph.microsoft.com/User.Read",
+			"https://graph.microsoft.com/Mail.ReadWrite",
+			"https://graph.microsoft.com/Mail.Send",
+		},
+	} {
+		cmd := connectCommand(provider)
+		for _, scope := range want {
+			if !strings.Contains(cmd, scope) {
+				t.Errorf("%s connect command is missing %q: %s", provider, scope, cmd)
+			}
+		}
+		if !strings.Contains(cmd, "--grant-agent "+emailAgentGrantID) {
+			t.Errorf("%s connect command does not grant the agent: %s", provider, cmd)
+		}
+		if strings.Contains(cmd, "grants grant") {
+			t.Errorf("%s uses the overwrite-scopes path: %s", provider, cmd)
+		}
+	}
+}
+
+func TestNonASCIIAgentIDDoesNotCorruptTheDisplayName(t *testing.T) {
+	if got := ConfigFor("émail", "").AgentName; got != "Émail" {
+		t.Errorf("display name = %q, want %q", got, "Émail")
 	}
 }

--- a/tui/internal/ui/preflight/check_test.go
+++ b/tui/internal/ui/preflight/check_test.go
@@ -120,6 +120,10 @@ type fakeTransport struct {
 	streamBody   string
 	streamErr    error
 
+	// ensureFn overrides EnsureAgent so a test can hold the call open and prove
+	// the screen's context really reaches it.
+	ensureFn func(context.Context) error
+
 	calls []call
 }
 
@@ -155,7 +159,12 @@ func (f *fakeTransport) Start(context.Context) (DaemonInfo, error) {
 	return f.info, nil
 }
 
-func (f *fakeTransport) EnsureAgent(context.Context, string) error { return f.ensureErr }
+func (f *fakeTransport) EnsureAgent(ctx context.Context, _ string) error {
+	if f.ensureFn != nil {
+		return f.ensureFn(ctx)
+	}
+	return f.ensureErr
+}
 
 func (f *fakeTransport) Do(_ context.Context, method, path string, _ []byte) (Response, error) {
 	key := method + " " + path
@@ -844,5 +853,39 @@ func TestConnectCommandRequestsTheFullScopeUnion(t *testing.T) {
 func TestNonASCIIAgentIDDoesNotCorruptTheDisplayName(t *testing.T) {
 	if got := ConfigFor("émail", "").AgentName; got != "Émail" {
 		t.Errorf("display name = %q, want %q", got, "Émail")
+	}
+}
+
+// The three questions an indeterminate row answers differently. Pinned as a
+// test because "unknown does not block" is one refactor away from becoming
+// "unknown passes", which is the exact dishonesty this state exists to prevent.
+func TestIndeterminateIsNeitherReadyNorBlocking(t *testing.T) {
+	unknown := Check(context.Background(),
+		newFake().with("GET /v1/email/init", 200, initUnknownVersion), EmailConfig())
+	broken := Check(context.Background(),
+		newFake().with("GET /v1/email/init", 503, initUnreachable), EmailConfig())
+	ready := Check(context.Background(), newFake(), EmailConfig())
+
+	for _, tc := range []struct {
+		name                  string
+		rep                   Report
+		wantReady, wantBlocks bool
+	}{
+		{"proven ready", ready, true, false},
+		{"indeterminate", unknown, false, false},
+		{"proven broken", broken, false, true},
+	} {
+		if got := tc.rep.Ready(); got != tc.wantReady {
+			t.Errorf("%s: Ready() = %v, want %v", tc.name, got, tc.wantReady)
+		}
+		if got := tc.rep.Blocked(); got != tc.wantBlocks {
+			t.Errorf("%s: Blocked() = %v, want %v", tc.name, got, tc.wantBlocks)
+		}
+	}
+
+	// And the unknown row is visibly distinct from an ok one, without colour.
+	row, _ := unknown.Find(KeyLemonade)
+	if row.State.Marker() == StateOK.Marker() || row.State.Word() == StateOK.Word() {
+		t.Error("an indeterminate row is indistinguishable from a passing one")
 	}
 }

--- a/tui/internal/ui/preflight/example_test.go
+++ b/tui/internal/ui/preflight/example_test.go
@@ -1,0 +1,52 @@
+package preflight_test
+
+import (
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/amd/gaia/tui/internal/daemon"
+	"github.com/amd/gaia/tui/internal/ui/preflight"
+)
+
+// Example_mounting is the integration contract, compiled.
+//
+// It mirrors exactly what root.RootModel has to do to put the gate on the launch
+// path: build it for the agent being launched, forward window size and messages
+// to it, and act on the three messages it emits. If this stops compiling, the
+// wiring in root/model.go is stale.
+func Example_mounting() {
+	agentID, agentName := "email", "Email"
+	logf := func(string, ...any) {}
+
+	gate := preflight.New(
+		preflight.NewDaemonTransport(daemon.New(daemon.Options{Logf: logf})),
+		preflight.ConfigFor(agentID, agentName),
+		preflight.Options{Logf: logf},
+	)
+
+	// The host owns the screen; Init starts the probes.
+	var cmd tea.Cmd = gate.Init()
+	_ = cmd
+
+	// Forwarding: the gate is a plain tea.Model.
+	updated, _ := gate.Update(tea.WindowSizeMsg{Width: 80, Height: 24})
+	gate = updated.(preflight.Model)
+	_ = gate.View()
+
+	// Acting on what it emits.
+	handle := func(msg tea.Msg) string {
+		switch msg := msg.(type) {
+		case preflight.ProceedMsg:
+			return "launch " + msg.AgentID
+		case preflight.CancelMsg:
+			return "back to the hub from " + msg.AgentID
+		case preflight.ConnectMailboxMsg:
+			return "open the connector flow for " + msg.Provider
+		}
+		return ""
+	}
+	_ = handle
+
+	// Tearing it down must cancel whatever it started (a model pull outlives a
+	// keypress).
+	gate.Cancel()
+}

--- a/tui/internal/ui/preflight/ladder.go
+++ b/tui/internal/ui/preflight/ladder.go
@@ -59,9 +59,18 @@ type Ladder struct {
 
 func (l Ladder) agent() string {
 	if l.AgentID == "" {
-		return "<agent-id>"
+		return "the agent"
 	}
 	return l.AgentID
+}
+
+// agentCommand builds an agent-scoped command, falling back to one that needs
+// no id. A remedy a user cannot copy verbatim is not a remedy.
+func (l Ladder) agentCommand(verb, fallback string) string {
+	if l.AgentID == "" {
+		return fallback
+	}
+	return verb + " " + l.AgentID
 }
 
 // daemonLog is the daemon's own log path, resolved for embedding in a remedy.
@@ -135,12 +144,7 @@ func (l Ladder) Error(op string, err error) Diagnosis {
 
 	// 2. Context deadlines: the caller gave up, which is not the same as refused.
 	if errors.Is(err, context.DeadlineExceeded) {
-		return Diagnosis{
-			Cause:   op + " timed out.",
-			Remedy:  "Check the local model server is running and responsive on its expected port.",
-			Command: "lemonade-server serve",
-			Where:   daemonLog(),
-		}
+		return l.transport(op, "timed out")
 	}
 	if errors.Is(err, context.Canceled) {
 		return Diagnosis{
@@ -149,12 +153,50 @@ func (l Ladder) Error(op string, err error) Diagnosis {
 		}
 	}
 
-	// 3. Everything else: read the message with the text ladder.
+	// 3. Everything else is a Go transport error, and the TUI dials exactly one
+	// host: the daemon on loopback. So "connection refused" here means the
+	// DAEMON is unreachable — never Lemonade, which this process never talks to
+	// directly. Routing it through the body ladder would answer
+	// "start lemonade-server" to a daemon that moved to a new port.
 	var reqErr *daemon.RequestError
 	if errors.As(err, &reqErr) {
-		return l.Text(op, reqErr.Detail)
+		return l.transport(op, reqErr.Detail)
 	}
-	return l.Text(op, err.Error())
+	return l.transport(op, err.Error())
+}
+
+// transport diagnoses a failure to REACH the daemon, as opposed to something a
+// service told us. Kept separate from Text on purpose: the same words mean
+// different things depending on who produced them.
+func (l Ladder) transport(op, text string) Diagnosis {
+	body := strings.ToLower(text)
+
+	switch {
+	case containsAny(body, "refused", "connection reset", "no such host", "connect:", "eof"):
+		return Diagnosis{
+			Cause:   "The GAIA background service stopped answering — it may have restarted on a new port.",
+			Remedy:  "Check it, then press r to re-check.",
+			Command: "gaia daemon status",
+			Where:   daemonLog(),
+		}
+	case containsAny(body, "timed out", "timeout", "deadline exceeded", "context canceled"):
+		return Diagnosis{
+			Cause:   op + " did not finish in time.",
+			Remedy:  "Check the background service is healthy, then press r to re-check.",
+			Command: "gaia daemon status",
+			Where:   daemonLog(),
+		}
+	}
+	cause := op + " failed."
+	if strings.TrimSpace(text) != "" {
+		cause = fmt.Sprintf("%s failed: %s", op, strings.TrimSpace(text))
+	}
+	return Diagnosis{
+		Cause:   cause,
+		Remedy:  "Check the background service, then press r to re-check.",
+		Command: "gaia daemon status",
+		Where:   daemonLog(),
+	}
 }
 
 // Status diagnoses a response the daemon (or a relayed sidecar) actually
@@ -177,7 +219,7 @@ func (l Ladder) Status(op string, status int, body string) Diagnosis {
 			Cause: fmt.Sprintf("The background service does not know the agent %q.", l.agent()),
 			Remedy: "Install it, then check it is registered. " +
 				detailSuffix(trimmed),
-			Command: "gaia hub install " + l.agent(),
+			Command: l.agentCommand("gaia hub install", "gaia daemon agents"),
 			Where:   daemonLog(),
 		}
 	case http.StatusServiceUnavailable:
@@ -189,14 +231,20 @@ func (l Ladder) Status(op string, status int, body string) Diagnosis {
 		return Diagnosis{
 			Cause:   op + " is not ready yet.",
 			Remedy:  "Start the agent's sidecar, then re-check.",
-			Command: "gaia daemon start-agent " + l.agent(),
+			Command: l.agentCommand("gaia daemon start-agent", "gaia daemon agents"),
 			Where:   l.sidecarLog(),
 		}
 	case http.StatusBadGateway:
+		// A 502 whose body says the relay itself gave up mid-response is NOT a
+		// dead sidecar — it is the daemon refusing to hold a long buffered call
+		// (a model pull) open. Restarting the sidecar would fix nothing.
+		if containsAny(strings.ToLower(trimmed), "mid-response", "readtimeout", "read timeout") {
+			return l.Text(op, trimmed)
+		}
 		return Diagnosis{
 			Cause:   fmt.Sprintf("The background service could not reach the %s agent. %s", l.agent(), detailSuffix(trimmed)),
 			Remedy:  "Restart the agent's sidecar, then re-check.",
-			Command: "gaia daemon start-agent " + l.agent(),
+			Command: l.agentCommand("gaia daemon start-agent", "gaia daemon agents"),
 			Where:   l.sidecarLog(),
 		}
 	}
@@ -205,7 +253,7 @@ func (l Ladder) Status(op string, status int, body string) Diagnosis {
 		return Diagnosis{
 			Cause:   fmt.Sprintf("%s failed inside the %s agent. %s", op, l.agent(), detailSuffix(trimmed)),
 			Remedy:  "Read the agent's log, then restart its sidecar.",
-			Command: "gaia daemon start-agent " + l.agent(),
+			Command: l.agentCommand("gaia daemon start-agent", "gaia daemon agents"),
 			Where:   l.sidecarLog(),
 		}
 	}
@@ -241,7 +289,15 @@ func (l Ladder) Text(op, text string) Diagnosis {
 			Command: "gaia init",
 			Where:   "https://lemonade-server.ai",
 		}
-	case containsAny(body, "not downloaded", "model", "download"):
+	case containsAny(body, "dropped the connection mid-response", "did not answer"):
+		return Diagnosis{
+			Cause: "The background service gave up relaying the agent's answer. A large " +
+				"model download exceeds what it will hold open.",
+			Remedy:  "Download the model in a terminal instead, then press r to re-check.",
+			Command: "gaia init",
+			Where:   daemonLog(),
+		}
+	case containsAny(body, "not downloaded", "not present", "download"):
 		return Diagnosis{
 			Cause:   "The AI model is not downloaded.",
 			Remedy:  "Download it once — every GAIA agent reuses the same model.",
@@ -257,14 +313,18 @@ func (l Ladder) Text(op, text string) Diagnosis {
 		}
 	}
 
+	// Fallback: something answered, but with nothing this ladder recognises.
+	// The answer came from the agent's sidecar, so restarting it is the honest
+	// next step — never a remedy-less dead end.
 	cause := op + " failed."
-	if text != "" {
+	if strings.TrimSpace(text) != "" {
 		cause = fmt.Sprintf("%s failed: %s", op, strings.TrimSpace(text))
 	}
 	return Diagnosis{
-		Cause:  cause,
-		Remedy: "Re-check with r; if it keeps failing, read the log below.",
-		Where:  daemonLog(),
+		Cause:   cause,
+		Remedy:  "Restart the agent's sidecar, then press r to re-check.",
+		Command: l.agentCommand("gaia daemon start-agent", "gaia daemon agents"),
+		Where:   l.sidecarLog(),
 	}
 }
 

--- a/tui/internal/ui/preflight/ladder.go
+++ b/tui/internal/ui/preflight/ladder.go
@@ -1,0 +1,292 @@
+package preflight
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/amd/gaia/tui/internal/daemon"
+)
+
+// Diagnosis is what a failed call means, what to do about it, and where to look
+// next. It is the unit the readiness rows are built from, and it is deliberately
+// usable outside this screen: the chat view needs the same mapping for a failure
+// that happens mid-run, and re-deriving it there would let the two disagree.
+type Diagnosis struct {
+	// Cause names what failed, in the user's terms — never an HTTP status.
+	Cause string
+	// Remedy names what to do about it.
+	Remedy string
+	// Command is the exact command that fixes it, or "" when there is none.
+	Command string
+	// Where names the log, file, or page to read next.
+	Where string
+}
+
+// AsRemedy converts a diagnosis into a row remedy.
+func (d Diagnosis) AsRemedy() Remedy {
+	return Remedy{Action: d.Remedy, Command: d.Command, Where: d.Where}
+}
+
+// String is the one-line form, for logs and for chat's mid-run error line.
+func (d Diagnosis) String() string {
+	parts := []string{d.Cause}
+	if d.Remedy != "" {
+		parts = append(parts, d.Remedy)
+	}
+	if d.Command != "" {
+		parts = append(parts, "run: "+d.Command)
+	}
+	if d.Where != "" {
+		parts = append(parts, "look: "+d.Where)
+	}
+	return strings.Join(parts, " — ")
+}
+
+// Ladder maps a failed call to a Diagnosis, most specific cause first.
+//
+// Ported from the email agent's playground `diagnose` (playground_html.py) and
+// extended with the daemon's own typed errors, which the browser never sees. The
+// ordering is the point: "Lemonade is not running" and "the model is missing"
+// both surface as a 502 with a body, and answering "the call timed out" to
+// either sends the user down the wrong path.
+type Ladder struct {
+	// AgentID names the sidecar in remedies like `gaia daemon start-agent <id>`.
+	AgentID string
+}
+
+func (l Ladder) agent() string {
+	if l.AgentID == "" {
+		return "<agent-id>"
+	}
+	return l.AgentID
+}
+
+// daemonLog is the daemon's own log path, resolved for embedding in a remedy.
+func daemonLog() string {
+	p, err := daemon.LogPath()
+	if err != nil {
+		return "~/.gaia/host/daemon.log"
+	}
+	return p
+}
+
+func (l Ladder) sidecarLog() string {
+	return fmt.Sprintf("~/.gaia/agents/%s/logs/", l.agent())
+}
+
+// Error diagnoses a transport or client error. op names the call in the user's
+// terms, e.g. "reach the background service".
+func (l Ladder) Error(op string, err error) Diagnosis {
+	if err == nil {
+		return Diagnosis{Cause: op + " failed for an unrecorded reason", Where: daemonLog()}
+	}
+
+	// 1. The daemon's own typed errors: they already know exactly what failed.
+	var notRunning *daemon.NotRunningError
+	if errors.As(err, &notRunning) {
+		return Diagnosis{
+			Cause:   "The GAIA background service is not running.",
+			Remedy:  "Start it, then the checks continue automatically.",
+			Command: "gaia daemon start",
+			Where:   daemonLog(),
+		}
+	}
+	var version *daemon.VersionError
+	if errors.As(err, &version) {
+		return Diagnosis{
+			Cause: fmt.Sprintf("The running background service speaks host API v%s, "+
+				"which this build cannot use.", version.Have),
+			Remedy:  "Restart it so it comes up on the version this app expects.",
+			Command: "gaia daemon restart",
+			Where:   daemonLog(),
+		}
+	}
+	var stale *daemon.StaleError
+	if errors.As(err, &stale) {
+		switch stale.Kind {
+		case daemon.StaleUnresponsive:
+			return Diagnosis{
+				Cause:   "The background service is running but not answering.",
+				Remedy:  "Reclaim it with a restart; it will not be killed from here.",
+				Command: "gaia daemon restart",
+				Where:   daemonLog(),
+			}
+		default:
+			return Diagnosis{
+				Cause:   "The recorded background service cannot be trusted (" + stale.Reason + ").",
+				Remedy:  "Reclaim it with a restart.",
+				Command: "gaia daemon restart",
+				Where:   stale.Path,
+			}
+		}
+	}
+	var start *daemon.StartError
+	if errors.As(err, &start) {
+		return Diagnosis{
+			Cause:   "The background service would not start (" + start.Reason + ").",
+			Remedy:  "Run it in a terminal to see the failure directly.",
+			Command: "gaia daemon start",
+			Where:   daemonLog(),
+		}
+	}
+
+	// 2. Context deadlines: the caller gave up, which is not the same as refused.
+	if errors.Is(err, context.DeadlineExceeded) {
+		return Diagnosis{
+			Cause:   op + " timed out.",
+			Remedy:  "Check the local model server is running and responsive on its expected port.",
+			Command: "lemonade-server serve",
+			Where:   daemonLog(),
+		}
+	}
+	if errors.Is(err, context.Canceled) {
+		return Diagnosis{
+			Cause:  op + " was cancelled.",
+			Remedy: "Press r to run the checks again.",
+		}
+	}
+
+	// 3. Everything else: read the message with the text ladder.
+	var reqErr *daemon.RequestError
+	if errors.As(err, &reqErr) {
+		return l.Text(op, reqErr.Detail)
+	}
+	return l.Text(op, err.Error())
+}
+
+// Status diagnoses a response the daemon (or a relayed sidecar) actually
+// answered with. body is the raw response body — the sidecar's `detail` or
+// `hint` is the most actionable text available, so it is preferred over any
+// generic status wording.
+func (l Ladder) Status(op string, status int, body string) Diagnosis {
+	trimmed := strings.TrimSpace(body)
+
+	switch status {
+	case http.StatusUnauthorized:
+		return Diagnosis{
+			Cause:   "The background service rejected this app's token.",
+			Remedy:  "Restart it to mint a fresh one — the token rotates on every restart.",
+			Command: "gaia daemon restart",
+			Where:   daemonLog(),
+		}
+	case http.StatusNotFound:
+		return Diagnosis{
+			Cause: fmt.Sprintf("The background service does not know the agent %q.", l.agent()),
+			Remedy: "Install it, then check it is registered. " +
+				detailSuffix(trimmed),
+			Command: "gaia hub install " + l.agent(),
+			Where:   daemonLog(),
+		}
+	case http.StatusServiceUnavailable:
+		// The sidecar's own not-ready answer. Its hint is the best remedy there
+		// is, so run the text ladder over it rather than inventing wording.
+		if trimmed != "" {
+			return l.Text(op, trimmed)
+		}
+		return Diagnosis{
+			Cause:   op + " is not ready yet.",
+			Remedy:  "Start the agent's sidecar, then re-check.",
+			Command: "gaia daemon start-agent " + l.agent(),
+			Where:   l.sidecarLog(),
+		}
+	case http.StatusBadGateway:
+		return Diagnosis{
+			Cause:   fmt.Sprintf("The background service could not reach the %s agent. %s", l.agent(), detailSuffix(trimmed)),
+			Remedy:  "Restart the agent's sidecar, then re-check.",
+			Command: "gaia daemon start-agent " + l.agent(),
+			Where:   l.sidecarLog(),
+		}
+	}
+
+	if status >= 500 {
+		return Diagnosis{
+			Cause:   fmt.Sprintf("%s failed inside the %s agent. %s", op, l.agent(), detailSuffix(trimmed)),
+			Remedy:  "Read the agent's log, then restart its sidecar.",
+			Command: "gaia daemon start-agent " + l.agent(),
+			Where:   l.sidecarLog(),
+		}
+	}
+	if status >= 400 {
+		return Diagnosis{
+			Cause:   fmt.Sprintf("%s was refused by the %s agent. %s", op, l.agent(), detailSuffix(trimmed)),
+			Remedy:  "Check the agent is installed and registered.",
+			Command: "gaia daemon agents",
+			Where:   l.sidecarLog(),
+		}
+	}
+	return l.Text(op, trimmed)
+}
+
+// Text is the message ladder itself: specific causes before generic ones,
+// mirroring the email playground's `diagnose` so the TUI and the browser never
+// disagree about what a given failure means.
+func (l Ladder) Text(op, text string) Diagnosis {
+	body := strings.ToLower(text)
+
+	switch {
+	case containsAny(body, "not reachable", "refused", "connection error", "connect:", "no such host"):
+		return Diagnosis{
+			Cause:   "The local model server (Lemonade) is not running.",
+			Remedy:  "Start it, then press r to re-check.",
+			Command: "lemonade-server serve",
+			Where:   "https://amd-gaia.ai/docs/guides/install",
+		}
+	case containsAny(body, "older than the required", "min_version", "upgrade it"):
+		return Diagnosis{
+			Cause:   "The local model server is older than this agent requires.",
+			Remedy:  "Upgrade it, then re-check.",
+			Command: "gaia init",
+			Where:   "https://lemonade-server.ai",
+		}
+	case containsAny(body, "not downloaded", "model", "download"):
+		return Diagnosis{
+			Cause:   "The AI model is not downloaded.",
+			Remedy:  "Download it once — every GAIA agent reuses the same model.",
+			Command: "gaia init",
+			Where:   "https://amd-gaia.ai/docs/guides/install",
+		}
+	case containsAny(body, "timed out", "timeout", "deadline exceeded"):
+		return Diagnosis{
+			Cause:   "The local model server did not respond in time.",
+			Remedy:  "Check it is running on the port GAIA expects.",
+			Command: "lemonade-server serve",
+			Where:   daemonLog(),
+		}
+	}
+
+	cause := op + " failed."
+	if text != "" {
+		cause = fmt.Sprintf("%s failed: %s", op, strings.TrimSpace(text))
+	}
+	return Diagnosis{
+		Cause:  cause,
+		Remedy: "Re-check with r; if it keeps failing, read the log below.",
+		Where:  daemonLog(),
+	}
+}
+
+func containsAny(haystack string, needles ...string) bool {
+	for _, n := range needles {
+		if strings.Contains(haystack, n) {
+			return true
+		}
+	}
+	return false
+}
+
+// detailSuffix quotes an upstream detail without letting an empty body produce
+// a dangling sentence.
+func detailSuffix(body string) string {
+	body = strings.TrimSpace(body)
+	if body == "" {
+		return ""
+	}
+	const limit = 240
+	if len(body) > limit {
+		body = body[:limit] + "…"
+	}
+	return "It said: " + body
+}

--- a/tui/internal/ui/preflight/ladder_test.go
+++ b/tui/internal/ui/preflight/ladder_test.go
@@ -1,0 +1,162 @@
+package preflight
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/amd/gaia/tui/internal/daemon"
+)
+
+// The ladder's whole value is picking the RIGHT cause. These cases are the ones
+// where a plausible-looking wrong answer sends the user to the wrong process.
+func TestLadderPicksTheRightSubject(t *testing.T) {
+	l := Ladder{AgentID: "email"}
+
+	cases := []struct {
+		name     string
+		diagnose func() Diagnosis
+		wantCmd  string
+		wantIn   string
+		wantNot  string
+	}{
+		{
+			// A Go transport error can only come from the daemon: this process
+			// never opens a socket to Lemonade.
+			name: "refused connection to the daemon",
+			diagnose: func() Diagnosis {
+				return l.Error("reach the agent", errors.New("dial tcp 127.0.0.1:51230: connect: connection refused"))
+			},
+			wantCmd: "gaia daemon status",
+			wantIn:  "background service",
+			wantNot: "Lemonade",
+		},
+		{
+			// The same words in a RESPONSE BODY are the sidecar telling us about
+			// Lemonade, and mean the opposite.
+			name: "sidecar says Lemonade is not reachable",
+			diagnose: func() Diagnosis {
+				return l.Text("check the local AI", "Local Lemonade Server is not reachable at http://localhost:8000")
+			},
+			wantCmd: "lemonade-server serve",
+			wantIn:  "local model server",
+		},
+		{
+			name: "version too old beats the model rung",
+			diagnose: func() Diagnosis {
+				return l.Text("check the local AI", "Lemonade 8.0.1 is older than the required 8.1.0 — upgrade it")
+			},
+			wantCmd: "gaia init",
+			wantIn:  "older than",
+			wantNot: "not downloaded",
+		},
+		{
+			name: "the relay giving up on a long pull is not a missing model",
+			diagnose: func() Diagnosis {
+				return l.Text("download the model", "sidecar for agent 'email' dropped the connection mid-response on /v1/email/init (ReadTimeout)")
+			},
+			wantCmd: "gaia init",
+			wantIn:  "gave up relaying",
+		},
+		{
+			name: "a wrong-contract daemon is never fixed by starting another",
+			diagnose: func() Diagnosis {
+				return l.Error("attach", &daemon.VersionError{Have: "1.0", Reason: "predates the relay"})
+			},
+			wantCmd: "gaia daemon restart",
+			wantIn:  "v1.0",
+		},
+		{
+			name:     "401 is a rotated token, not a permissions problem",
+			diagnose: func() Diagnosis { return l.Status("call the agent", 401, "") },
+			wantCmd:  "gaia daemon restart",
+			wantIn:   "token",
+		},
+		{
+			name:     "404 means the agent is not registered",
+			diagnose: func() Diagnosis { return l.Status("call the agent", 404, `{"detail":"unknown agent"}`) },
+			wantCmd:  "gaia hub install email",
+			wantIn:   "email",
+		},
+		{
+			name:     "502 from a dead sidecar points at the sidecar",
+			diagnose: func() Diagnosis { return l.Status("call the agent", 502, `{"detail":"sidecar did not answer"}`) },
+			wantCmd:  "gaia daemon start-agent email",
+			wantIn:   "email agent",
+		},
+		{
+			// Same status, different subject: the relay gave up on a long
+			// buffered call. Restarting the sidecar would fix nothing.
+			name: "502 from the relay giving up is not a dead sidecar",
+			diagnose: func() Diagnosis {
+				return l.Status("download the model", 502,
+					`{"detail":"sidecar for agent 'email' dropped the connection mid-response (ReadTimeout)"}`)
+			},
+			wantCmd: "gaia init",
+			wantIn:  "gave up relaying",
+			wantNot: "start-agent",
+		},
+		{
+			name:     "an unrecognised body still names a next step",
+			diagnose: func() Diagnosis { return l.Text("check the local AI", "<html>gateway</html>") },
+			wantCmd:  "gaia daemon start-agent email",
+			wantIn:   "sidecar",
+		},
+		{
+			name:     "a cancelled context is not an error to fix",
+			diagnose: func() Diagnosis { return l.Error("check the local AI", context.Canceled) },
+			wantIn:   "cancelled",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			d := tc.diagnose()
+			all := d.String()
+			if tc.wantCmd != "" && d.Command != tc.wantCmd {
+				t.Errorf("command = %q, want %q (%s)", d.Command, tc.wantCmd, all)
+			}
+			if tc.wantIn != "" && !strings.Contains(all, tc.wantIn) {
+				t.Errorf("diagnosis does not mention %q: %s", tc.wantIn, all)
+			}
+			if tc.wantNot != "" && strings.Contains(all, tc.wantNot) {
+				t.Errorf("diagnosis wrongly mentions %q: %s", tc.wantNot, all)
+			}
+			if d.Cause == "" {
+				t.Error("a diagnosis with no cause tells the user nothing")
+			}
+		})
+	}
+}
+
+// Every diagnosis has to name what to do and where to look, or it is just an
+// error message with extra steps.
+func TestEveryDiagnosisIsActionable(t *testing.T) {
+	l := Ladder{AgentID: "email"}
+	for _, status := range []int{400, 401, 403, 404, 500, 502, 503} {
+		d := l.Status("call the agent", status, "")
+		if d.Cause == "" || d.Remedy == "" || d.Where == "" {
+			t.Errorf("HTTP %d produced an incomplete diagnosis: %+v", status, d)
+		}
+		if strings.Contains(d.Cause, "HTTP") {
+			t.Errorf("HTTP %d leaked a status code to the user: %q", status, d.Cause)
+		}
+	}
+}
+
+// A remedy a user cannot copy verbatim is not a remedy, so no diagnosis may
+// contain a placeholder — including one built without an agent id.
+func TestNoDiagnosisEverPrintsAPlaceholder(t *testing.T) {
+	for _, l := range []Ladder{{}, {AgentID: "email"}} {
+		for _, status := range []int{400, 401, 404, 500, 502, 503} {
+			d := l.Status("call the agent", status, "")
+			if strings.ContainsAny(d.Command, "<>") {
+				t.Errorf("HTTP %d (agent %q) produced an uncopyable command: %q", status, l.AgentID, d.Command)
+			}
+			if d.Remedy == "" {
+				t.Errorf("HTTP %d (agent %q) says nothing to do", status, l.AgentID)
+			}
+		}
+	}
+}

--- a/tui/internal/ui/preflight/live_test.go
+++ b/tui/internal/ui/preflight/live_test.go
@@ -1,0 +1,90 @@
+package preflight
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/x/ansi"
+
+	"github.com/amd/gaia/tui/internal/daemon"
+)
+
+// TestLiveReadiness runs the real gate against whatever this machine actually
+// has, through the real daemon client. It SKIPS when no daemon is attachable,
+// so it is a no-op in CI and a real end-to-end check on a developer box.
+//
+// It asserts contract shape, never readiness: a machine with no mailbox
+// connected is a perfectly valid state for this test to observe. What it proves
+// is that the paths, headers, and JSON shapes this package sends are the ones
+// the daemon and the sidecar actually accept — which no fake can prove.
+func TestLiveReadiness(t *testing.T) {
+	tr := NewDaemonTransport(daemon.New(daemon.Options{
+		Logf: func(format string, args ...any) { t.Logf(format, args...) },
+	}))
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	if _, err := tr.Attach(ctx); err != nil {
+		t.Skipf("no attachable GAIA daemon on this machine: %v", err)
+	}
+
+	rep := Check(ctx, tr, EmailConfig())
+	t.Logf("\n%s", rep)
+
+	if len(rep.Rows) != 5 {
+		t.Fatalf("expected 5 rows, got %d", len(rep.Rows))
+	}
+	for _, row := range rep.Rows {
+		if row.State == StateFailed {
+			assertRealCommand(t, row)
+		}
+		if row.Line == "" {
+			t.Errorf("row %q rendered no status line", row.Key)
+		}
+	}
+
+	m := New(tr, EmailConfig(), Options{ManualProceed: true})
+	updated, _ := m.Update(tea.WindowSizeMsg{Width: 80, Height: 24})
+	updated, _ = updated.(Model).Update(reportMsg{rep: rep})
+	screen := ansi.Strip(updated.(Model).View())
+	t.Logf("\n%s", screen)
+	assertFits(t, splitLines(screen), 80, 24)
+}
+
+// TestColdMachineThroughTheRealClient is the first-run state: no daemon has ever
+// registered, so ~/.gaia/host/instance.json does not exist. It runs the REAL
+// daemon client (no fake) and needs no daemon, so it is deterministic in CI —
+// and it is the one path a developer box, which always has a warm instance.json,
+// can never reproduce on its own.
+func TestColdMachineThroughTheRealClient(t *testing.T) {
+	t.Setenv(daemon.EnvHome, t.TempDir())
+
+	// Nothing is launched here: Check only ever attaches, so the client's start
+	// path is never reached.
+	tr := NewDaemonTransport(daemon.New(daemon.Options{
+		Logf: func(format string, args ...any) { t.Logf(format, args...) },
+	}))
+	rep := Check(context.Background(), tr, EmailConfig())
+	t.Logf("\n%s", rep)
+
+	if len(rep.Rows) != 5 {
+		t.Fatalf("cold machine produced %d rows, want 5", len(rep.Rows))
+	}
+	row, _ := rep.Find(KeyDaemon)
+	if row.State != StateFailed {
+		t.Fatalf("daemon row on a cold machine = %s, want failed", row.State.Word())
+	}
+	if row.Fix != FixStartDaemon {
+		t.Errorf("a never-started daemon does not offer to start one")
+	}
+	assertRealCommand(t, row)
+	for _, other := range rep.Rows[1:] {
+		if other.State != StatePending {
+			t.Errorf("row %q is %s on a machine with no daemon; nothing else is knowable",
+				other.Key, other.State.Word())
+		}
+	}
+}

--- a/tui/internal/ui/preflight/model.go
+++ b/tui/internal/ui/preflight/model.go
@@ -2,6 +2,7 @@ package preflight
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/charmbracelet/bubbles/spinner"
@@ -33,6 +34,9 @@ const (
 	// defaultReadyHold is how long an all-green screen is held so the user sees
 	// what was verified before chat replaces it.
 	defaultReadyHold = 800 * time.Millisecond
+	// unknownHold is the longer hold used when nothing failed but something
+	// could not be verified — long enough to read what went unproven.
+	unknownHold = 2500 * time.Millisecond
 )
 
 type phase int
@@ -169,20 +173,27 @@ type proceedTickMsg struct{}
 
 // --- commands --------------------------------------------------------------
 
-func (m Model) checkCmd() tea.Cmd {
-	t, cfg := m.t, m.cfg
-	return func() tea.Msg {
-		ctx, cancel := context.WithTimeout(context.Background(), checkTimeout)
-		defer cancel()
-		return reportMsg{rep: Check(ctx, t, cfg)}
-	}
+// begin builds the context for a piece of background work and parks its cancel
+// on the model, so Cancel() stops EVERYTHING the screen started — not just a
+// download. An abandoned ensure would otherwise keep spawning a sidecar minutes
+// after the user left.
+func (m *Model) begin(timeout time.Duration) context.Context {
+	m.Cancel()
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	m.cancel = cancel
+	return ctx
 }
 
-func (m Model) startDaemonCmd() tea.Cmd {
+func (m *Model) checkCmd() tea.Cmd {
+	ctx := m.begin(checkTimeout)
+	t, cfg := m.t, m.cfg
+	return func() tea.Msg { return reportMsg{rep: Check(ctx, t, cfg)} }
+}
+
+func (m *Model) startDaemonCmd() tea.Cmd {
+	ctx := m.begin(startTimeout)
 	t := m.t
 	return func() tea.Msg {
-		ctx, cancel := context.WithTimeout(context.Background(), startTimeout)
-		defer cancel()
 		if _, err := t.Start(ctx); err != nil {
 			return fixDoneMsg{key: KeyDaemon, err: err}
 		}
@@ -190,11 +201,10 @@ func (m Model) startDaemonCmd() tea.Cmd {
 	}
 }
 
-func (m Model) ensureAgentCmd() tea.Cmd {
+func (m *Model) ensureAgentCmd() tea.Cmd {
+	ctx := m.begin(ensureTimeout)
 	t, cfg := m.t, m.cfg
 	return func() tea.Msg {
-		ctx, cancel := context.WithTimeout(context.Background(), ensureTimeout)
-		defer cancel()
 		if err := t.EnsureAgent(ctx, cfg.AgentID); err != nil {
 			return fixDoneMsg{key: KeySidecar, err: err}
 		}
@@ -202,21 +212,53 @@ func (m Model) ensureAgentCmd() tea.Cmd {
 	}
 }
 
-func waitProvision(ch chan provisionEvent) tea.Cmd {
+func waitProvision(ch chan provisionEvent, cfg Config) tea.Cmd {
 	return func() tea.Msg {
 		ev, ok := <-ch
-		if !ok {
-			return provisionMsg{ch: ch, event: provisionEvent{done: true}}
+		if ok {
+			return provisionMsg{ch: ch, event: ev}
 		}
-		return provisionMsg{ch: ch, event: ev}
+		// The producer closed without a terminal event: the only way here is a
+		// cancelled or timed-out pull. Say so — an empty "Download failed." with
+		// no cause and no remedy is exactly the silent failure the rules forbid.
+		return provisionMsg{ch: ch, event: provisionEvent{
+			done: true,
+			result: ProvisionResult{
+				Final: "✗ the download stopped before it finished",
+				Diagnosis: Diagnosis{
+					Cause:   "The model download was cancelled, or ran past the time limit.",
+					Remedy:  "Download it in a terminal instead, then press r to re-check.",
+					Command: "gaia init",
+					Where:   fmt.Sprintf("~/.gaia/agents/%s/logs/", cfg.AgentID),
+				},
+			},
+		}}
+	}
+}
+
+// send delivers ev, preferring delivery over an already-cancelled context.
+//
+// A plain `select { case ch <- ev: case <-ctx.Done(): }` picks UNIFORMLY when
+// both are ready, so a pull that finished exactly as its deadline expired lost
+// its result half the time — and the screen then had a failure with no cause
+// and no remedy. The non-blocking attempt first makes delivery deterministic
+// whenever the buffer has room; the fallback still refuses to park forever on a
+// reader that is gone.
+func send(ctx context.Context, ch chan provisionEvent, ev provisionEvent) {
+	select {
+	case ch <- ev:
+		return
+	default:
+	}
+	select {
+	case ch <- ev:
+	case <-ctx.Done():
 	}
 }
 
 func (m Model) startProvision() (Model, tea.Cmd) {
 	ch := make(chan provisionEvent, 64)
-	ctx, cancel := context.WithTimeout(context.Background(), provisionTimeout)
-	m.Cancel()
-	m.cancel = cancel
+	ctx := m.begin(provisionTimeout)
 	m.provisionCh = ch
 	// The daemon relay BUFFERS non-SSE responses (src/gaia/daemon/relay.py), so
 	// the sidecar's progress lines all arrive at the end of the pull rather than
@@ -230,19 +272,11 @@ func (m Model) startProvision() (Model, tea.Cmd) {
 	go func() {
 		defer close(ch)
 		res := Provision(ctx, t, cfg, func(line string) {
-			// Never block on a screen that stopped reading — a cancelled gate
-			// must not park this goroutine for the length of a model pull.
-			select {
-			case ch <- provisionEvent{line: line}:
-			case <-ctx.Done():
-			}
+			send(ctx, ch, provisionEvent{line: line})
 		})
-		select {
-		case ch <- provisionEvent{done: true, result: res}:
-		case <-ctx.Done():
-		}
+		send(ctx, ch, provisionEvent{done: true, result: res})
 	}()
-	return m, tea.Batch(waitProvision(ch), m.spin.Tick)
+	return m, tea.Batch(waitProvision(ch, m.cfg), m.spin.Tick)
 }
 
 // --- update ----------------------------------------------------------------
@@ -271,13 +305,28 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		} else {
 			m.focus = 0
 		}
-		if m.rep.Ready() && !m.opts.ManualProceed {
+		if !m.rep.Blocked() && !m.opts.ManualProceed {
+			// Nothing failed. Indeterminate rows do not block the launch — the
+			// sidecar itself does not treat an unadvertised version as fatal, and
+			// making the user press enter on EVERY launch against such a server
+			// would train them to press it without reading. They are held longer
+			// and named, not silently skipped.
+			hold := m.opts.ReadyHold
+			if !m.rep.Ready() {
+				hold = unknownHold
+				m.note = "Starting anyway — " + m.unverifiedSummary()
+			}
 			m.phase = phaseDone
-			return m, tea.Tick(m.opts.ReadyHold, func(time.Time) tea.Msg { return proceedTickMsg{} })
+			return m, tea.Tick(hold, func(time.Time) tea.Msg { return proceedTickMsg{} })
 		}
 		return m, nil
 
 	case proceedTickMsg:
+		// A tick already in flight when the user pressed esc or r must not
+		// launch the agent they backed out of.
+		if m.phase != phaseDone {
+			return m, nil
+		}
 		return m, m.proceed()
 
 	case fixDoneMsg:
@@ -299,7 +348,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		if !msg.event.done {
 			m.provisionLine = msg.event.line
-			return m, waitProvision(msg.ch)
+			return m, waitProvision(msg.ch, m.cfg)
 		}
 		m.provisionCh = nil
 		m.Cancel()
@@ -327,12 +376,15 @@ func (m Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	case "ctrl+c":
 		// Matches the hub and chat: ctrl+c leaves the app, not just the screen.
 		m.Cancel()
-		m.provisionCh = nil
+		m.provisionCh, m.phase = nil, phaseIdle
 		return m, tea.Quit
 
 	case "esc", "q":
 		m.Cancel()
-		m.provisionCh = nil
+		// Back to idle, not left in phaseProvisioning/phaseDone: Busy() would
+		// otherwise stay true forever and a re-shown gate would refuse every key.
+		m.provisionCh, m.phase = nil, phaseIdle
+		m.note = ""
 		agentID := m.cfg.AgentID
 		return m, func() tea.Msg { return CancelMsg{AgentID: agentID} }
 
@@ -363,9 +415,15 @@ func (m Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return m, tea.Batch(m.checkCmd(), m.spin.Tick)
 
 	case "enter":
-		if m.Busy() || m.rep.Blocked() {
+		if m.Busy() {
 			return m, nil
 		}
+		if blocker, blocked := m.rep.Blocker(); blocked {
+			m.note = fmt.Sprintf("%s cannot start yet: %s is %s. Fix that row first.",
+				m.cfg.AgentName, blocker.Label, blocker.Line)
+			return m, nil
+		}
+		m.phase = phaseIdle
 		return m, m.proceed()
 
 	case "f":
@@ -404,6 +462,17 @@ func (m Model) applyFix() (tea.Model, tea.Cmd) {
 		}
 		return m, nil
 	}
+}
+
+// unverifiedSummary names what could not be proved, for the line shown while an
+// indeterminate report is handed off.
+func (m Model) unverifiedSummary() string {
+	for _, row := range m.rep.Rows {
+		if row.State == StateUnknown {
+			return row.Label + " could not be verified (" + row.Line + ")."
+		}
+	}
+	return "not everything could be verified."
 }
 
 func (m Model) proceed() tea.Cmd {

--- a/tui/internal/ui/preflight/model.go
+++ b/tui/internal/ui/preflight/model.go
@@ -1,0 +1,414 @@
+package preflight
+
+import (
+	"context"
+	"time"
+
+	"github.com/charmbracelet/bubbles/spinner"
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+// ProceedMsg tells the host every precondition is satisfied (or the user
+// accepted an indeterminate one) and the agent may be launched.
+type ProceedMsg struct{ AgentID string }
+
+// CancelMsg tells the host the user backed out of the launch.
+type CancelMsg struct{ AgentID string }
+
+// ConnectMailboxMsg asks the host to open the connector flow for Provider. The
+// gate deliberately does not run OAuth itself: that flow is its own screen, and
+// owning it here would fork it.
+type ConnectMailboxMsg struct {
+	AgentID  string
+	Provider string
+}
+
+// Timeouts for the work the screen kicks off. Each is bounded so a wedged
+// daemon or sidecar surfaces as an actionable row instead of a frozen screen.
+const (
+	checkTimeout     = 90 * time.Second
+	startTimeout     = 60 * time.Second
+	ensureTimeout    = 15 * time.Minute
+	provisionTimeout = 60 * time.Minute
+	// defaultReadyHold is how long an all-green screen is held so the user sees
+	// what was verified before chat replaces it.
+	defaultReadyHold = 800 * time.Millisecond
+)
+
+type phase int
+
+const (
+	phaseChecking phase = iota
+	phaseIdle
+	phaseFixing
+	phaseProvisioning
+	phaseDone
+)
+
+// Options tunes the screen. The zero value is valid.
+type Options struct {
+	// ReadyHold is how long an all-ready report is shown before ProceedMsg.
+	// Defaults to 800ms.
+	ReadyHold time.Duration
+	// ManualProceed keeps the screen up until the user presses enter, even when
+	// everything is ready. Used by tests and by `--debug`.
+	ManualProceed bool
+	// Logf receives diagnostics. Never given a token.
+	Logf func(format string, args ...any)
+}
+
+// Model is the readiness gate screen.
+type Model struct {
+	cfg  Config
+	t    Transport
+	opts Options
+
+	rep     Report
+	phase   phase
+	focus   int
+	details bool
+	// note is a transient line under the rows: what a fix did, or why it failed.
+	note string
+
+	width, height int
+	spin          spinner.Model
+
+	provisionCh   chan provisionEvent
+	provisionLine string
+	cancel        context.CancelFunc
+}
+
+// New builds the gate for one agent.
+func New(t Transport, cfg Config, opts Options) Model {
+	if opts.ReadyHold == 0 {
+		opts.ReadyHold = defaultReadyHold
+	}
+	if opts.Logf == nil {
+		opts.Logf = func(string, ...any) {}
+	}
+	cfg = cfg.withDefaults()
+
+	s := spinner.New()
+	s.Spinner = spinner.Dot
+
+	return Model{
+		cfg:    cfg,
+		t:      t,
+		opts:   opts,
+		rep:    Report{AgentID: cfg.AgentID, AgentName: cfg.AgentName, Rows: checkingRows(cfg)},
+		phase:  phaseChecking,
+		width:  80,
+		height: 24,
+		spin:   s,
+	}
+}
+
+// checkingRows is the first frame: the shape of the answer before any of it is
+// known, so the screen does not jump as rows arrive.
+func checkingRows(cfg Config) []Row {
+	rows := blankRows(cfg)
+	rows[0].State = StateChecking
+	rows[0].Line = "checking…"
+	return rows
+}
+
+func (m Model) Init() tea.Cmd {
+	return tea.Batch(m.checkCmd(), m.spin.Tick)
+}
+
+// Report is the current readiness answer — for an integrator's status line or
+// control-API snapshot.
+func (m Model) Report() Report { return m.rep }
+
+// Ready reports whether every precondition passed.
+func (m Model) Ready() bool { return m.rep.Ready() }
+
+// Busy reports whether a probe or a fix is in flight.
+func (m Model) Busy() bool {
+	return m.phase == phaseChecking || m.phase == phaseFixing || m.phase == phaseProvisioning
+}
+
+// FocusKey is the row the user is on, for snapshots and tests.
+func (m Model) FocusKey() string {
+	if m.focus < 0 || m.focus >= len(m.rep.Rows) {
+		return ""
+	}
+	return m.rep.Rows[m.focus].Key
+}
+
+// AgentID is the agent this gate is guarding.
+func (m Model) AgentID() string { return m.cfg.AgentID }
+
+// Cancel stops any in-flight probe or fix. The host calls it when tearing the
+// screen down so a model pull does not keep writing into a dead screen.
+func (m *Model) Cancel() {
+	if m.cancel != nil {
+		m.cancel()
+		m.cancel = nil
+	}
+}
+
+// --- messages --------------------------------------------------------------
+
+type reportMsg struct{ rep Report }
+type fixDoneMsg struct {
+	key  string
+	err  error
+	note string
+}
+type provisionEvent struct {
+	line   string
+	done   bool
+	result ProvisionResult
+}
+type provisionMsg struct {
+	ch    chan provisionEvent
+	event provisionEvent
+}
+type proceedTickMsg struct{}
+
+// --- commands --------------------------------------------------------------
+
+func (m Model) checkCmd() tea.Cmd {
+	t, cfg := m.t, m.cfg
+	return func() tea.Msg {
+		ctx, cancel := context.WithTimeout(context.Background(), checkTimeout)
+		defer cancel()
+		return reportMsg{rep: Check(ctx, t, cfg)}
+	}
+}
+
+func (m Model) startDaemonCmd() tea.Cmd {
+	t := m.t
+	return func() tea.Msg {
+		ctx, cancel := context.WithTimeout(context.Background(), startTimeout)
+		defer cancel()
+		if _, err := t.Start(ctx); err != nil {
+			return fixDoneMsg{key: KeyDaemon, err: err}
+		}
+		return fixDoneMsg{key: KeyDaemon, note: "Background service started."}
+	}
+}
+
+func (m Model) ensureAgentCmd() tea.Cmd {
+	t, cfg := m.t, m.cfg
+	return func() tea.Msg {
+		ctx, cancel := context.WithTimeout(context.Background(), ensureTimeout)
+		defer cancel()
+		if err := t.EnsureAgent(ctx, cfg.AgentID); err != nil {
+			return fixDoneMsg{key: KeySidecar, err: err}
+		}
+		return fixDoneMsg{key: KeySidecar, note: cfg.AgentName + " agent started."}
+	}
+}
+
+func waitProvision(ch chan provisionEvent) tea.Cmd {
+	return func() tea.Msg {
+		ev, ok := <-ch
+		if !ok {
+			return provisionMsg{ch: ch, event: provisionEvent{done: true}}
+		}
+		return provisionMsg{ch: ch, event: ev}
+	}
+}
+
+func (m Model) startProvision() (Model, tea.Cmd) {
+	ch := make(chan provisionEvent, 64)
+	ctx, cancel := context.WithTimeout(context.Background(), provisionTimeout)
+	m.Cancel()
+	m.cancel = cancel
+	m.provisionCh = ch
+	// The daemon relay BUFFERS non-SSE responses (src/gaia/daemon/relay.py), so
+	// the sidecar's progress lines all arrive at the end of the pull rather than
+	// as it runs. Promise minutes, not a progress bar, until the relay streams
+	// text/plain too.
+	m.provisionLine = "downloading the model — the first pull takes several minutes"
+	m.phase = phaseProvisioning
+	m.note = ""
+
+	t, cfg := m.t, m.cfg
+	go func() {
+		defer close(ch)
+		res := Provision(ctx, t, cfg, func(line string) {
+			// Never block on a screen that stopped reading — a cancelled gate
+			// must not park this goroutine for the length of a model pull.
+			select {
+			case ch <- provisionEvent{line: line}:
+			case <-ctx.Done():
+			}
+		})
+		select {
+		case ch <- provisionEvent{done: true, result: res}:
+		case <-ctx.Done():
+		}
+	}()
+	return m, tea.Batch(waitProvision(ch), m.spin.Tick)
+}
+
+// --- update ----------------------------------------------------------------
+
+func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.WindowSizeMsg:
+		m.width, m.height = msg.Width, msg.Height
+		return m, nil
+
+	case spinner.TickMsg:
+		if !m.Busy() {
+			return m, nil
+		}
+		var cmd tea.Cmd
+		m.spin, cmd = m.spin.Update(msg)
+		return m, cmd
+
+	case reportMsg:
+		m.rep = msg.rep
+		m.phase = phaseIdle
+		// The rows now say everything the "…re-checking" note did.
+		m.note = ""
+		if idx := m.rep.FirstAttention(); idx >= 0 {
+			m.focus = idx
+		} else {
+			m.focus = 0
+		}
+		if m.rep.Ready() && !m.opts.ManualProceed {
+			m.phase = phaseDone
+			return m, tea.Tick(m.opts.ReadyHold, func(time.Time) tea.Msg { return proceedTickMsg{} })
+		}
+		return m, nil
+
+	case proceedTickMsg:
+		return m, m.proceed()
+
+	case fixDoneMsg:
+		if msg.err != nil {
+			d := Ladder{AgentID: m.cfg.AgentID}.Error("apply that fix", msg.err)
+			m.note = "Fix failed. " + d.String()
+			m.phase = phaseIdle
+			return m, nil
+		}
+		m.note = msg.note + " Re-checking…"
+		m.phase = phaseChecking
+		return m, tea.Batch(m.checkCmd(), m.spin.Tick)
+
+	case provisionMsg:
+		if msg.ch != m.provisionCh {
+			// A late delivery from a cancelled pull: ignore it rather than let
+			// it drive the screen that replaced it.
+			return m, nil
+		}
+		if !msg.event.done {
+			m.provisionLine = msg.event.line
+			return m, waitProvision(msg.ch)
+		}
+		m.provisionCh = nil
+		m.Cancel()
+		res := msg.event.result
+		if res.OK {
+			m.note = "Download complete. Re-checking…"
+			m.phase = phaseChecking
+			return m, tea.Batch(m.checkCmd(), m.spin.Tick)
+		}
+		m.phase = phaseIdle
+		m.note = "Download failed. " + res.Diagnosis.String()
+		if res.Diagnosis.Cause == "" {
+			m.note = "Download failed. " + res.Final
+		}
+		return m, nil
+
+	case tea.KeyMsg:
+		return m.handleKey(msg)
+	}
+	return m, nil
+}
+
+func (m Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	switch msg.String() {
+	case "ctrl+c":
+		// Matches the hub and chat: ctrl+c leaves the app, not just the screen.
+		m.Cancel()
+		m.provisionCh = nil
+		return m, tea.Quit
+
+	case "esc", "q":
+		m.Cancel()
+		m.provisionCh = nil
+		agentID := m.cfg.AgentID
+		return m, func() tea.Msg { return CancelMsg{AgentID: agentID} }
+
+	case "d":
+		m.details = !m.details
+		return m, nil
+
+	case "up", "k":
+		if m.focus > 0 {
+			m.focus--
+		}
+		return m, nil
+
+	case "down", "j":
+		if m.focus < len(m.rep.Rows)-1 {
+			m.focus++
+		}
+		return m, nil
+
+	case "r":
+		if m.Busy() {
+			return m, nil
+		}
+		m.note = ""
+		m.details = false
+		m.phase = phaseChecking
+		m.rep.Rows = checkingRows(m.cfg)
+		return m, tea.Batch(m.checkCmd(), m.spin.Tick)
+
+	case "enter":
+		if m.Busy() || m.rep.Blocked() {
+			return m, nil
+		}
+		return m, m.proceed()
+
+	case "f":
+		if m.Busy() {
+			return m, nil
+		}
+		return m.applyFix()
+	}
+	return m, nil
+}
+
+func (m Model) applyFix() (tea.Model, tea.Cmd) {
+	if m.focus < 0 || m.focus >= len(m.rep.Rows) {
+		return m, nil
+	}
+	row := m.rep.Rows[m.focus]
+	switch row.Fix {
+	case FixStartDaemon:
+		m.phase = phaseFixing
+		m.note = "Starting the background service…"
+		return m, tea.Batch(m.startDaemonCmd(), m.spin.Tick)
+	case FixStartSidecar:
+		m.phase = phaseFixing
+		m.note = "Starting the " + m.cfg.AgentName + " agent…"
+		return m, tea.Batch(m.ensureAgentCmd(), m.spin.Tick)
+	case FixPullModel:
+		return m.startProvision()
+	case FixConnectMailbox:
+		agentID, provider := m.cfg.AgentID, row.Provider
+		return m, func() tea.Msg {
+			return ConnectMailboxMsg{AgentID: agentID, Provider: provider}
+		}
+	default:
+		if row.Remedy.Command != "" {
+			m.note = "Nothing here can be fixed safely from the TUI — run: " + row.Remedy.Command
+		}
+		return m, nil
+	}
+}
+
+func (m Model) proceed() tea.Cmd {
+	agentID := m.cfg.AgentID
+	return func() tea.Msg { return ProceedMsg{AgentID: agentID} }
+}
+
+func (m Model) View() string { return m.render() }

--- a/tui/internal/ui/preflight/model_test.go
+++ b/tui/internal/ui/preflight/model_test.go
@@ -1,6 +1,7 @@
 package preflight
 
 import (
+	"context"
 	"strings"
 	"testing"
 	"time"
@@ -201,5 +202,143 @@ func TestCtrlCQuitsTheApp(t *testing.T) {
 	}
 	if _, ok := cmd().(tea.QuitMsg); !ok {
 		t.Fatalf("ctrl+c produced %T, want tea.QuitMsg", cmd())
+	}
+}
+
+// A tick scheduled by a ready report must not launch an agent the user backed
+// out of in the 800 ms before it fired.
+func TestProceedTickAfterCancelDoesNotLaunch(t *testing.T) {
+	f := newFake()
+	m := New(f, EmailConfig(), Options{ReadyHold: time.Second})
+	updated, cmd := m.Update(reportMsg{rep: Check(t.Context(), f, EmailConfig())})
+	m = updated.(Model)
+	if cmd == nil {
+		t.Fatal("a ready report did not schedule the hand-off")
+	}
+
+	updated, _ = m.Update(tea.KeyMsg{Type: tea.KeyEsc})
+	m = updated.(Model)
+
+	if _, tick := m.Update(proceedTickMsg{}); tick != nil {
+		t.Fatalf("a stale tick launched the agent after esc: %T", tick())
+	}
+}
+
+// esc must leave the screen usable: a phase left at "provisioning" makes Busy()
+// true forever and a re-shown gate rejects every key.
+func TestCancelLeavesTheScreenUsable(t *testing.T) {
+	f := newFake().with("GET /v1/email/init", 503, initModelMissing)
+	m := newModel(t, f)
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'f'}})
+	m = updated.(Model)
+	if !m.Busy() {
+		t.Fatal("the download did not mark the screen busy")
+	}
+
+	updated, _ = m.Update(tea.KeyMsg{Type: tea.KeyEsc})
+	m = updated.(Model)
+	if m.Busy() {
+		t.Error("after esc the screen is still busy, so r/f/enter would be refused")
+	}
+
+	// And the keys really do work again.
+	if _, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'r'}}); cmd == nil {
+		t.Error("r was refused on a screen the user came back to")
+	}
+}
+
+// A pull that ends without a terminal event still owes the user a cause and a
+// remedy — "Download failed." with nothing after it is the failure mode the
+// fail-loudly rule exists to prevent.
+func TestAClosedProvisionChannelStillExplainsItself(t *testing.T) {
+	f := newFake().with("GET /v1/email/init", 503, initModelMissing)
+	m := newModel(t, f)
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'f'}})
+	m = updated.(Model)
+
+	ch := m.provisionCh
+	if ch == nil {
+		t.Fatal("no provisioning channel")
+	}
+	// Simulate the producer closing without delivering a result.
+	closed := make(chan provisionEvent)
+	close(closed)
+	msg := waitProvision(closed, m.cfg)
+	ev, ok := msg().(provisionMsg)
+	if !ok {
+		t.Fatalf("waitProvision produced %T", msg())
+	}
+	if !ev.event.done {
+		t.Fatal("a closed channel did not produce a terminal event")
+	}
+	if ev.event.result.Diagnosis.Cause == "" || ev.event.result.Diagnosis.Command == "" {
+		t.Fatalf("a closed channel produced an empty diagnosis: %+v", ev.event.result.Diagnosis)
+	}
+
+	updated, _ = m.Update(provisionMsg{ch: m.provisionCh, event: ev.event})
+	m = updated.(Model)
+	note := strings.Join(strings.Fields(ansi.Strip(m.View())), " ")
+	if !strings.Contains(note, "gaia init") {
+		t.Errorf("the failed download does not tell the user what to run:\n%s", note)
+	}
+}
+
+// The terminal result must survive a context that expired at the same moment —
+// a uniform select would drop it half the time.
+func TestSendPrefersDeliveryOverACancelledContext(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	for i := 0; i < 200; i++ {
+		ch := make(chan provisionEvent, 1)
+		send(ctx, ch, provisionEvent{done: true, result: ProvisionResult{OK: true}})
+		select {
+		case ev := <-ch:
+			if !ev.done {
+				t.Fatal("delivered the wrong event")
+			}
+		default:
+			t.Fatalf("iteration %d: the result was dropped despite a free buffer", i)
+		}
+	}
+}
+
+// Pressing enter on a blocked report must say why, not silently do nothing.
+func TestEnterOnABlockedReportSaysWhy(t *testing.T) {
+	f := newFake().with("GET /v1/email/connectors", 200, connectorsNone)
+	m := newModel(t, f)
+
+	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	m = updated.(Model)
+	if cmd != nil {
+		t.Fatalf("enter proceeded past a blocked report: %T", cmd())
+	}
+	screen := strings.Join(strings.Fields(ansi.Strip(m.View())), " ")
+	if !strings.Contains(screen, "cannot start yet") || !strings.Contains(screen, "Mailbox") {
+		t.Errorf("enter was a silent no-op:\n%s", screen)
+	}
+}
+
+// Nothing failed but something could not be verified: the launch proceeds (the
+// sidecar does not treat it as fatal) while naming what went unproven.
+func TestAnIndeterminateReportProceedsButSaysWhatItCouldNotVerify(t *testing.T) {
+	f := newFake().with("GET /v1/email/init", 200, initUnknownVersion)
+	m := New(f, EmailConfig(), Options{ReadyHold: time.Millisecond})
+	updated, _ := m.Update(tea.WindowSizeMsg{Width: 80, Height: 24})
+	updated, cmd := updated.(Model).Update(reportMsg{rep: Check(t.Context(), f, EmailConfig())})
+	m = updated.(Model)
+
+	if cmd == nil {
+		t.Fatal("an unblocked report did not schedule the hand-off")
+	}
+	if m.Ready() {
+		t.Fatal("an indeterminate row was counted as ready")
+	}
+	screen := strings.Join(strings.Fields(ansi.Strip(m.View())), " ")
+	if !strings.Contains(screen, "Starting anyway") || !strings.Contains(screen, "Local AI") {
+		t.Errorf("the hand-off does not name what could not be verified:\n%s", screen)
+	}
+	if _, ok := cmd().(proceedTickMsg); !ok {
+		t.Fatalf("scheduled %T", cmd())
 	}
 }

--- a/tui/internal/ui/preflight/model_test.go
+++ b/tui/internal/ui/preflight/model_test.go
@@ -1,0 +1,205 @@
+package preflight
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/x/ansi"
+
+	"github.com/amd/gaia/tui/internal/daemon"
+)
+
+// settle applies a fresh Check result the way Init's command would.
+func settle(t *testing.T, m Model, f *fakeTransport) Model {
+	t.Helper()
+	updated, _ := m.Update(reportMsg{rep: Check(t.Context(), f, EmailConfig())})
+	return updated.(Model)
+}
+
+func newModel(t *testing.T, f *fakeTransport) Model {
+	t.Helper()
+	m := New(f, EmailConfig(), Options{ManualProceed: true, ReadyHold: time.Millisecond})
+	updated, _ := m.Update(tea.WindowSizeMsg{Width: 80, Height: 24})
+	return settle(t, updated.(Model), f)
+}
+
+func TestFixStartsTheDaemonThenRechecks(t *testing.T) {
+	f := newFake()
+	f.attachErr = &daemon.NotRunningError{Path: "/tmp/instance.json"}
+
+	m := newModel(t, f)
+	if m.FocusKey() != KeyDaemon {
+		t.Fatalf("focus = %q, want the daemon row", m.FocusKey())
+	}
+
+	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'f'}})
+	m = updated.(Model)
+	if !m.Busy() {
+		t.Error("pressing f did not show the screen as busy")
+	}
+	if cmd == nil {
+		t.Fatal("pressing f produced no command")
+	}
+
+	// The fix succeeded (the fake clears its attach error), so the screen must
+	// re-check rather than claim success on its own.
+	// Run the real fix command, so the fake actually performs the start.
+	updated, cmd = m.Update(m.startDaemonCmd()())
+	m = updated.(Model)
+	if !m.Busy() {
+		t.Error("a successful fix did not trigger a re-check")
+	}
+	if !strings.Contains(ansi.Strip(m.View()), "Re-checking") {
+		t.Errorf("the screen does not say it is re-checking:\n%s", m.View())
+	}
+	_ = cmd
+
+	m = settle(t, m, f)
+	if row, _ := m.Report().Find(KeyDaemon); row.State != StateOK {
+		t.Errorf("after the fix the daemon row is %s:\n%s", row.State.Word(), m.Report())
+	}
+}
+
+func TestAFailedFixExplainsItselfInsteadOfSilentlyRetrying(t *testing.T) {
+	f := newFake()
+	f.attachErr = &daemon.NotRunningError{Path: "/tmp/instance.json"}
+	m := newModel(t, f)
+
+	updated, _ := m.Update(fixDoneMsg{
+		key: KeyDaemon,
+		err: &daemon.StartError{Reason: "the `gaia` CLI is not on PATH"},
+	})
+	m = updated.(Model)
+
+	// Flattened: the note wraps, so an assertion on raw lines would be about
+	// where the wrap fell rather than about what the screen says.
+	screen := strings.Join(strings.Fields(ansi.Strip(m.View())), " ")
+	if m.Busy() {
+		t.Error("a failed fix left the screen spinning")
+	}
+	for _, want := range []string{"Fix failed", "not on PATH", "gaia daemon start"} {
+		if !strings.Contains(screen, want) {
+			t.Errorf("screen does not show %q:\n%s", want, screen)
+		}
+	}
+}
+
+func TestFixDownloadsTheModelAndUsesTheFinalLine(t *testing.T) {
+	f := newFake().with("GET /v1/email/init", 503, initModelMissing)
+	f.streamBody = "→ Pulling Gemma-4-E4B-it-GGUF…\n✓ Provisioning complete.\n"
+
+	m := newModel(t, f)
+	if m.FocusKey() != KeyModel {
+		t.Fatalf("focus = %q, want the model row", m.FocusKey())
+	}
+
+	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'f'}})
+	m = updated.(Model)
+	if cmd == nil {
+		t.Fatal("pressing f on a missing model produced no command")
+	}
+	if !strings.Contains(ansi.Strip(m.View()), "Leaving this screen cancels the download") {
+		t.Errorf("the download state does not tell the user what leaving does:\n%s", m.View())
+	}
+
+	// Drain the provisioning channel the way the runtime would.
+	ch := m.provisionCh
+	if ch == nil {
+		t.Fatal("no provisioning channel was opened")
+	}
+	deadline := time.After(5 * time.Second)
+	for {
+		select {
+		case ev, ok := <-ch:
+			if !ok {
+				t.Fatal("the provisioning channel closed without a terminal event")
+			}
+			updated, _ := m.Update(provisionMsg{ch: ch, event: ev})
+			m = updated.(Model)
+			if ev.done {
+				if !ev.result.OK {
+					t.Fatalf("provisioning failed: %+v", ev.result)
+				}
+				if !m.Busy() {
+					t.Error("a successful download did not trigger a re-check")
+				}
+				return
+			}
+		case <-deadline:
+			t.Fatal("provisioning never produced a terminal event")
+		}
+	}
+}
+
+func TestALateProvisionEventCannotDriveTheScreen(t *testing.T) {
+	f := newFake().with("GET /v1/email/init", 503, initModelMissing)
+	m := newModel(t, f)
+
+	stale := make(chan provisionEvent, 1)
+	updated, _ := m.Update(provisionMsg{ch: stale, event: provisionEvent{
+		done:   true,
+		result: ProvisionResult{OK: true},
+	}})
+	m = updated.(Model)
+
+	if m.Busy() {
+		t.Error("an event from a cancelled download restarted the checks")
+	}
+	if row, _ := m.Report().Find(KeyModel); row.State != StateFailed {
+		t.Errorf("a stale event changed the report: model row is %s", row.State.Word())
+	}
+}
+
+func TestRecheckResetsTheScreen(t *testing.T) {
+	f := newFake().with("GET /daemon/v1/agents", 200, agentsStopped)
+	m := newModel(t, f)
+
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'d'}})
+	m = updated.(Model)
+	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'r'}})
+	m = updated.(Model)
+
+	if cmd == nil {
+		t.Fatal("r produced no command")
+	}
+	if !m.Busy() {
+		t.Error("r did not put the screen back into checking")
+	}
+	if m.details {
+		t.Error("r left the details pane open over a screen that is being re-read")
+	}
+	if !strings.Contains(ansi.Strip(m.View()), "checking") {
+		t.Errorf("the re-checking screen does not say so:\n%s", m.View())
+	}
+}
+
+func TestCancelStopsInFlightWork(t *testing.T) {
+	f := newFake().with("GET /v1/email/init", 503, initModelMissing)
+	// A body that never completes would block the goroutine; an empty one is
+	// enough to prove Cancel tears the channel reference down.
+	m := newModel(t, f)
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'f'}})
+	m = updated.(Model)
+
+	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEsc})
+	m = updated.(Model)
+	if m.provisionCh != nil {
+		t.Error("esc left the provisioning channel attached")
+	}
+	if _, ok := cmd().(CancelMsg); !ok {
+		t.Fatalf("esc produced %T, want CancelMsg", cmd())
+	}
+}
+
+func TestCtrlCQuitsTheApp(t *testing.T) {
+	m := newModel(t, newFake())
+	_, cmd := m.Update(tea.KeyMsg{Type: tea.KeyCtrlC})
+	if cmd == nil {
+		t.Fatal("ctrl+c produced no command")
+	}
+	if _, ok := cmd().(tea.QuitMsg); !ok {
+		t.Fatalf("ctrl+c produced %T, want tea.QuitMsg", cmd())
+	}
+}

--- a/tui/internal/ui/preflight/model_test.go
+++ b/tui/internal/ui/preflight/model_test.go
@@ -2,6 +2,7 @@ package preflight
 
 import (
 	"context"
+	"errors"
 	"strings"
 	"testing"
 	"time"
@@ -340,5 +341,59 @@ func TestAnIndeterminateReportProceedsButSaysWhatItCouldNotVerify(t *testing.T) 
 	}
 	if _, ok := cmd().(proceedTickMsg); !ok {
 		t.Fatalf("scheduled %T", cmd())
+	}
+}
+
+// Leaving the screen must cancel work that is ALREADY RUNNING, not just detach
+// from it. An abandoned ensure keeps a sidecar-spawning request alive for its
+// full 15-minute budget — the user sees a process start minutes after they
+// walked away.
+func TestCancelStopsAnInFlightFix(t *testing.T) {
+	f := newFake().with("GET /daemon/v1/agents", 200, agentsStopped)
+
+	started := make(chan struct{})
+	finished := make(chan error, 1)
+	f.ensureFn = func(ctx context.Context) error {
+		close(started)
+		<-ctx.Done() // a real ensure blocks here for as long as the daemon takes
+		finished <- ctx.Err()
+		return ctx.Err()
+	}
+
+	m := newModel(t, f)
+	if m.FocusKey() != KeySidecar {
+		t.Fatalf("focus = %q, want the sidecar row", m.FocusKey())
+	}
+
+	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'f'}})
+	m = updated.(Model)
+	if cmd == nil {
+		t.Fatal("pressing f produced no command")
+	}
+	// The runtime executes a batch's children; do the same so the ensure is
+	// genuinely in flight when esc arrives.
+	if batch, ok := cmd().(tea.BatchMsg); ok {
+		for _, c := range batch {
+			go c() //nolint:errcheck // the message is irrelevant; the call is the point
+		}
+	} else {
+		t.Fatalf("f produced %T, want a batch", cmd())
+	}
+
+	select {
+	case <-started:
+	case <-time.After(5 * time.Second):
+		t.Fatal("the ensure never started")
+	}
+
+	m.Update(tea.KeyMsg{Type: tea.KeyEsc})
+
+	select {
+	case err := <-finished:
+		if !errors.Is(err, context.Canceled) {
+			t.Errorf("the in-flight fix ended with %v, want a cancellation", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("esc did not cancel the in-flight fix — it is still running")
 	}
 }

--- a/tui/internal/ui/preflight/provision.go
+++ b/tui/internal/ui/preflight/provision.go
@@ -1,0 +1,106 @@
+package preflight
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+)
+
+// maxProvisionLines bounds the retained progress transcript.
+const maxProvisionLines = 200
+
+// ProvisionResult is the outcome of a model pull.
+type ProvisionResult struct {
+	// OK is the authoritative outcome. See Provision for why it is read from
+	// the final line and not from the HTTP status.
+	OK bool
+	// Final is the last non-empty progress line — the one that carries ✓ or ✗.
+	Final string
+	// Lines is the last maxProvisionLines progress lines, in order, for the
+	// details pane.
+	Lines []string
+	// Diagnosis is set when the pull failed, so the caller has a remedy rather
+	// than a transcript.
+	Diagnosis Diagnosis
+}
+
+// Provision runs POST /v1/<agent>/init and streams the sidecar's progress lines
+// to onLine as they arrive.
+//
+// The outcome is read from the FINAL line, not from the status code: once the
+// sidecar has committed a streamed 200 the status can no longer change, so a
+// pull that fails half-way still arrives as "200 OK" with a ✗ line. A 503 before
+// any streaming (Lemonade unreachable) is a real status and is handled as one.
+//
+// onLine may be nil. It is called from the calling goroutine.
+func Provision(ctx context.Context, t Transport, cfg Config, onLine func(string)) ProvisionResult {
+	cfg = cfg.withDefaults()
+	l := Ladder{AgentID: cfg.AgentID}
+
+	stream, err := t.Stream(ctx, http.MethodPost, "/v1/"+cfg.AgentID+"/init", nil)
+	if err != nil {
+		return ProvisionResult{
+			Diagnosis: l.Error("download the AI model", err),
+			Final:     "✗ the download could not be started",
+		}
+	}
+	defer stream.Body.Close()
+
+	res := ProvisionResult{}
+	scanner := bufio.NewScanner(stream.Body)
+	// Progress lines are short; the cap only guards against a non-line-oriented
+	// body being read into memory without bound.
+	scanner.Buffer(make([]byte, 0, 64*1024), 1<<20)
+	for scanner.Scan() {
+		line := strings.TrimRight(scanner.Text(), "\r")
+		if strings.TrimSpace(line) == "" {
+			continue
+		}
+		// Keep a bounded tail: the final line is what decides the outcome, and a
+		// pull that narrates for an hour must not grow this without bound.
+		res.Lines = append(res.Lines, line)
+		if len(res.Lines) > maxProvisionLines {
+			res.Lines = res.Lines[len(res.Lines)-maxProvisionLines:]
+		}
+		res.Final = line
+		if onLine != nil {
+			onLine(line)
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		d := l.Error("download the AI model", err)
+		res.Diagnosis = d
+		res.Final = "✗ the download stopped early: " + err.Error()
+		return res
+	}
+
+	// A pre-stream failure (the sidecar refusing before it commits a 200) is the
+	// one case where the status is the truth.
+	if stream.Status != http.StatusOK {
+		res.Diagnosis = l.Status("download the AI model", stream.Status, strings.Join(res.Lines, "\n"))
+		if res.Final == "" {
+			res.Final = fmt.Sprintf("✗ the agent refused the download (HTTP %d)", stream.Status)
+		}
+		return res
+	}
+
+	switch {
+	case strings.HasPrefix(res.Final, "✓"):
+		res.OK = true
+	case res.Final == "":
+		res.Diagnosis = Diagnosis{
+			Cause:   "The download ended without saying whether it worked.",
+			Remedy:  "Press r to re-check whether the model landed, then retry.",
+			Command: "gaia init",
+			Where:   fmt.Sprintf("~/.gaia/agents/%s/logs/", cfg.AgentID),
+		}
+		res.Final = "✗ the download ended with no result"
+	default:
+		// ✗ or ⚠ — run the failing line through the ladder so the user gets a
+		// remedy, not just the sidecar's narration.
+		res.Diagnosis = l.Text("download the AI model", res.Final)
+	}
+	return res
+}

--- a/tui/internal/ui/preflight/report.go
+++ b/tui/internal/ui/preflight/report.go
@@ -1,0 +1,276 @@
+// Package preflight is the TUI's readiness gate: the screen that tells a user
+// why an agent cannot start and what to press to fix it.
+//
+// It answers four generic preconditions — the daemon is up and speaks our
+// contract, the agent's sidecar is running, the local model server is reachable
+// at a compatible version, and the model is downloaded — plus any number of
+// per-agent extra checks (for email: a mailbox that is both connected AND
+// granted send). Every answer is machine-readable already; this package turns
+// those answers into one row per precondition with a state, a human line, and a
+// remedy that names a real command.
+//
+// Two rules the rest of the package exists to enforce:
+//
+//   - `unknown` is not `ok`. GET /v1/<agent>/init reports `compatible: null`
+//     when Lemonade does not advertise a version. That is an indeterminate
+//     check, not a pass, and it renders as its own state.
+//   - No raw HTTP status ever reaches the user. Ladder maps a failed call to
+//     {cause, remedy, where-to-look}, specific causes before generic ones.
+package preflight
+
+import (
+	"fmt"
+	"strings"
+)
+
+// State is a precondition's answer. Pending and Unknown are deliberately
+// distinct from OK: "not checked yet" and "could not be determined" are both
+// failures to prove readiness, and neither may render as a checkmark.
+type State int
+
+const (
+	// StatePending — not probed yet, or gated behind an earlier failure.
+	StatePending State = iota
+	// StateChecking — a probe is in flight.
+	StateChecking
+	// StateOK — proved ready.
+	StateOK
+	// StateUnknown — probed, but the answer was indeterminate. NOT a pass.
+	StateUnknown
+	// StateFailed — proved not ready.
+	StateFailed
+)
+
+// Marker is the text signal for a state. Colour is additive only: these markers
+// are the primary signal so the screen reads on a monochrome terminal.
+func (s State) Marker() string {
+	switch s {
+	case StateOK:
+		return "[ok]"
+	case StateFailed:
+		return "[!]"
+	case StateUnknown:
+		return "[?]"
+	case StateChecking:
+		return "[..]"
+	default:
+		return "[ ]"
+	}
+}
+
+// Word is the state as a lowercase word, for logs, snapshots, and tests.
+func (s State) Word() string {
+	switch s {
+	case StateOK:
+		return "ok"
+	case StateFailed:
+		return "failed"
+	case StateUnknown:
+		return "unknown"
+	case StateChecking:
+		return "checking"
+	default:
+		return "pending"
+	}
+}
+
+// FixKind is the action a row's `f` key performs. FixNone means no fix is both
+// safe and obvious from here — the row still carries a command the user can run.
+type FixKind int
+
+const (
+	// FixNone — nothing safe to do from the TUI; follow the remedy command.
+	FixNone FixKind = iota
+	// FixStartDaemon — start-or-attach the GAIA daemon.
+	FixStartDaemon
+	// FixStartSidecar — ask the daemon to spawn-or-attach the agent sidecar.
+	FixStartSidecar
+	// FixPullModel — POST /v1/<agent>/init and stream provisioning progress.
+	FixPullModel
+	// FixConnectMailbox — hand off to the connector flow (Stage 4).
+	FixConnectMailbox
+)
+
+// Label is the key hint shown next to `f`.
+func (k FixKind) Label() string {
+	switch k {
+	case FixStartDaemon:
+		return "start it for me"
+	case FixStartSidecar:
+		return "start the agent"
+	case FixPullModel:
+		return "download it now"
+	case FixConnectMailbox:
+		return "connect a mailbox"
+	default:
+		return ""
+	}
+}
+
+// Remedy is what to do about a row that is not OK. Per the fail-loudly rule
+// every remedy names what to do (Action), how (Command, when one exists), and
+// where to look next (Where).
+type Remedy struct {
+	Action  string
+	Command string
+	Where   string
+}
+
+// Empty reports whether there is nothing to tell the user.
+func (r Remedy) Empty() bool {
+	return r.Action == "" && r.Command == "" && r.Where == ""
+}
+
+// Row is one precondition.
+type Row struct {
+	// Key is the stable identifier (KeyDaemon, KeySidecar, ...).
+	Key string
+	// Label is the human name shown in the left column.
+	Label string
+	// State is the answer.
+	State State
+	// Line is the one-line human status, e.g. "running (pid 41822)".
+	Line string
+	// Detail is an optional sentence of context under a failure.
+	Detail string
+	// Remedy is what to do about it. Empty when State is OK.
+	Remedy Remedy
+	// Fix is what `f` does on this row, FixNone when nothing is safe.
+	Fix FixKind
+	// Provider is the mailbox provider a FixConnectMailbox targets.
+	Provider string
+	// Raw is the probe's raw answer (JSON body or error text), shown by `d`.
+	Raw string
+}
+
+// NeedsAttention reports whether the row is anything other than proved ready.
+func (r Row) NeedsAttention() bool { return r.State != StateOK }
+
+// Stable row keys. The first four are generic to any sidecar agent that
+// implements GET /v1/<agent>/init; KeyMailbox is email-specific and arrives
+// through Config.Extras.
+const (
+	KeyDaemon   = "daemon"
+	KeySidecar  = "sidecar"
+	KeyLemonade = "lemonade"
+	KeyModel    = "model"
+	KeyMailbox  = "mailbox"
+)
+
+// Report is the whole readiness answer: one row per precondition, in dependency
+// order.
+type Report struct {
+	AgentID   string
+	AgentName string
+	Rows      []Row
+}
+
+// Ready reports whether every precondition proved OK. An indeterminate row is
+// not ready — `compatible: null` is not a pass.
+func (r Report) Ready() bool {
+	if len(r.Rows) == 0 {
+		return false
+	}
+	for _, row := range r.Rows {
+		if row.State != StateOK {
+			return false
+		}
+	}
+	return true
+}
+
+// Blocked reports whether at least one precondition proved NOT ready. A report
+// that is neither Ready nor Blocked has only indeterminate rows: the user may
+// proceed, but the screen must say what could not be verified.
+func (r Report) Blocked() bool {
+	for _, row := range r.Rows {
+		if row.State == StateFailed {
+			return true
+		}
+	}
+	return false
+}
+
+// OKCount is how many preconditions proved ready.
+func (r Report) OKCount() int {
+	n := 0
+	for _, row := range r.Rows {
+		if row.State == StateOK {
+			n++
+		}
+	}
+	return n
+}
+
+// Summary is the top-right status, e.g. "2 of 5 ready".
+func (r Report) Summary() string {
+	if r.Ready() {
+		return "ready"
+	}
+	return fmt.Sprintf("%d of %d ready", r.OKCount(), len(r.Rows))
+}
+
+// FirstAttention is the index of the row the user should act on: the first
+// FAILED row when there is one, otherwise the first row that is not OK.
+//
+// The order matters. An indeterminate row can sit above a real failure — a
+// Lemonade that answers without advertising a version, above a model that is
+// genuinely missing — and focusing the indeterminate one would put the cursor
+// on the row with nothing to do.
+func (r Report) FirstAttention() int {
+	for i, row := range r.Rows {
+		if row.State == StateFailed {
+			return i
+		}
+	}
+	for i, row := range r.Rows {
+		if row.NeedsAttention() {
+			return i
+		}
+	}
+	return -1
+}
+
+// Find returns the row with the given key.
+func (r Report) Find(key string) (Row, bool) {
+	for _, row := range r.Rows {
+		if row.Key == key {
+			return row, true
+		}
+	}
+	return Row{}, false
+}
+
+// Blocker returns the first failed row, or false when nothing failed. It is what
+// an integrator logs or shows in a one-line status when preflight refuses.
+func (r Report) Blocker() (Row, bool) {
+	for _, row := range r.Rows {
+		if row.State == StateFailed {
+			return row, true
+		}
+	}
+	return Row{}, false
+}
+
+// String renders the report as plain text — for `--debug` logs and for the
+// headless callers that never mount the screen.
+func (r Report) String() string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "%s preflight: %s\n", r.AgentName, r.Summary())
+	for _, row := range r.Rows {
+		fmt.Fprintf(&b, "  %-4s %-20s %s\n", row.State.Marker(), row.Label, row.Line)
+		if row.State == StateOK {
+			continue
+		}
+		if row.Remedy.Action != "" {
+			fmt.Fprintf(&b, "        %s\n", row.Remedy.Action)
+		}
+		if row.Remedy.Command != "" {
+			fmt.Fprintf(&b, "        run: %s\n", row.Remedy.Command)
+		}
+		if row.Remedy.Where != "" {
+			fmt.Fprintf(&b, "        look: %s\n", row.Remedy.Where)
+		}
+	}
+	return b.String()
+}

--- a/tui/internal/ui/preflight/report.go
+++ b/tui/internal/ui/preflight/report.go
@@ -16,6 +16,26 @@
 //     check, not a pass, and it renders as its own state.
 //   - No raw HTTP status ever reaches the user. Ladder maps a failed call to
 //     {cause, remedy, where-to-look}, specific causes before generic ones.
+//
+// # What an indeterminate row does, and why that is not the gate going soft
+//
+// Three separate questions get three separate answers, and conflating them is
+// what makes a gate either dishonest or useless:
+//
+//   - Is it proven ready?   Report.Ready() — false for an unknown row, always.
+//   - Is it proven broken?  Report.Blocked() — false for an unknown row.
+//   - Does the launch stop? Only on Blocked.
+//
+// So an unknown row renders `[?]`, keeps Ready() false, is named on screen
+// while the agent starts, and does not stop the launch. The alternative —
+// demanding a keypress every time — was rejected deliberately: the condition is
+// one the user cannot fix (their Lemonade build simply does not report a
+// version), so the prompt would fire on every single launch forever. A prompt
+// that always fires and never means anything is dismissed reflexively, and it
+// devalues every other prompt in the product. The signal is kept; the ritual is
+// not.
+//
+// A row that is genuinely broken still blocks, and no keystroke moves past it.
 package preflight
 
 import (

--- a/tui/internal/ui/preflight/rotation_test.go
+++ b/tui/internal/ui/preflight/rotation_test.go
@@ -1,0 +1,279 @@
+package preflight
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/amd/gaia/tui/internal/daemon"
+)
+
+// fakeHost is a daemon-shaped HTTP server plus the instance.json that points at
+// it. Unlike fakeTransport, this drives the REAL daemon client — discovery,
+// the two-check trust rule, the version gate, and the 401 replay — so it is the
+// only thing in this package that can prove the adapter uses them correctly.
+type fakeHost struct {
+	t   *testing.T
+	srv *httptest.Server
+	dir string
+
+	mu       sync.Mutex
+	token    string
+	pid      int
+	rotateOn string // path that triggers a restart-mid-check, once
+	rotated  bool
+	unauthed int
+	seen     []string
+}
+
+func newFakeHost(t *testing.T) *fakeHost {
+	t.Helper()
+	dir := t.TempDir()
+	t.Setenv(daemon.EnvHome, dir)
+
+	h := &fakeHost{t: t, dir: dir, token: "token-A", pid: 4242}
+	h.srv = httptest.NewServer(http.HandlerFunc(h.handle))
+	t.Cleanup(h.srv.Close)
+	h.writeInstance()
+	return h
+}
+
+func (h *fakeHost) port() int {
+	u, err := url.Parse(h.srv.URL)
+	if err != nil {
+		h.t.Fatalf("parse server URL: %v", err)
+	}
+	p, err := strconv.Atoi(u.Port())
+	if err != nil {
+		h.t.Fatalf("parse port: %v", err)
+	}
+	return p
+}
+
+// writeInstance records the CURRENT token and pid, exactly as a daemon does on
+// every start — which is what makes a restart recoverable at all.
+func (h *fakeHost) writeInstance() {
+	h.mu.Lock()
+	inst := map[string]any{
+		"pid": h.pid, "port": h.port(), "token": h.token,
+		"host": "127.0.0.1", "api_version": "1.1", "service": "gaia-daemon",
+		"started_at": 1750000000.0,
+	}
+	h.mu.Unlock()
+
+	raw, err := json.Marshal(inst)
+	if err != nil {
+		h.t.Fatalf("marshal instance: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(h.dir, "instance.json"), raw, 0o600); err != nil {
+		h.t.Fatalf("write instance.json: %v", err)
+	}
+}
+
+// restart simulates what a `gaia daemon restart` does to a client holding a
+// live token: a new pid, a new token, and a rewritten registry file.
+func (h *fakeHost) restart(token string, pid int) {
+	h.mu.Lock()
+	h.token, h.pid = token, pid
+	h.mu.Unlock()
+	h.writeInstance()
+}
+
+func (h *fakeHost) handle(w http.ResponseWriter, r *http.Request) {
+	h.mu.Lock()
+	h.seen = append(h.seen, r.Method+" "+r.URL.Path)
+	trigger := h.rotateOn != "" && !h.rotated && r.URL.Path == h.rotateOn
+	if trigger {
+		h.rotated = true
+	}
+	h.mu.Unlock()
+
+	// The daemon went down and came back up between two calls of one check.
+	if trigger {
+		h.restart("token-B", 5353)
+	}
+
+	h.mu.Lock()
+	token, pid := h.token, h.pid
+	h.mu.Unlock()
+
+	if r.Header.Get("Authorization") != "Bearer "+token {
+		h.mu.Lock()
+		h.unauthed++
+		h.mu.Unlock()
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte(`{"detail":"invalid or expired client token"}`))
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	if r.Method == http.MethodPost && r.URL.Path == "/v1/email/init" {
+		w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+		_, _ = w.Write([]byte("✓ already downloaded.\n✓ Provisioning complete.\n"))
+		return
+	}
+
+	switch r.URL.Path {
+	case "/daemon/v1/status":
+		fmt.Fprintf(w, `{"service":"gaia-daemon","pid":%d}`, pid)
+	case "/daemon/v1/agents":
+		_, _ = w.Write([]byte(agentsRunning))
+	case "/v1/email/init":
+		_, _ = w.Write([]byte(initReady))
+	case "/v1/email/connectors":
+		_, _ = w.Write([]byte(connectorsReady))
+	default:
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(`{"detail":"no such route"}`))
+	}
+}
+
+func (h *fakeHost) unauthorizedCount() int {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	return h.unauthed
+}
+
+// transport builds the real adapter over the real client, with liveness faked
+// so the test can move the pid without spawning processes.
+func (h *fakeHost) transport() Transport {
+	return NewDaemonTransport(daemon.New(daemon.Options{
+		PIDAlive: func(int) bool { return true },
+		Logf:     func(format string, args ...any) { h.t.Logf(format, args...) },
+	}))
+}
+
+// The daemon token rotates on EVERY daemon restart, and a restart also changes
+// the pid the registry records. This is the failure mode most likely to bite in
+// the real world — a sibling process restarts the daemon while the gate is
+// open — and it must recover silently rather than surface a 401.
+func TestTokenRotationMidCheckRecovers(t *testing.T) {
+	h := newFakeHost(t)
+	// The restart lands between the daemon probe and the agents listing, so the
+	// gate is holding a token that has already been invalidated.
+	h.rotateOn = "/daemon/v1/agents"
+
+	tr := h.transport()
+	rep := Check(context.Background(), tr, EmailConfig())
+
+	if !rep.Ready() {
+		t.Fatalf("a mid-check daemon restart broke the report:\n%s", rep)
+	}
+	if got := h.unauthorizedCount(); got != 1 {
+		// Exactly one: the call that raced the restart. More means the refreshed
+		// instance was thrown away and every later call re-discovered it.
+		t.Errorf("saw %d unauthorized calls, want exactly 1", got)
+	}
+
+	// A second pass must report the NEW pid — the gate re-reads the registry
+	// rather than trusting what it cached before the restart.
+	rep = Check(context.Background(), tr, EmailConfig())
+	if !rep.Ready() {
+		t.Fatalf("the report after the restart is not ready:\n%s", rep)
+	}
+	row, _ := rep.Find(KeyDaemon)
+	if !strings.Contains(row.Line, "5353") {
+		t.Errorf("daemon row still reports the pre-restart pid: %q", row.Line)
+	}
+	if h.unauthorizedCount() != 1 {
+		t.Errorf("the second pass hit another 401: the rotated token was not kept")
+	}
+}
+
+// The same rotation during the RELAYED call, which is the path a mid-run chat
+// turn takes too.
+func TestTokenRotationOnARelayedCallRecovers(t *testing.T) {
+	h := newFakeHost(t)
+	h.rotateOn = "/v1/email/init"
+
+	rep := Check(context.Background(), h.transport(), EmailConfig())
+	if !rep.Ready() {
+		t.Fatalf("a rotation on the relayed readiness call broke the report:\n%s", rep)
+	}
+	if got := h.unauthorizedCount(); got != 1 {
+		t.Errorf("saw %d unauthorized calls, want exactly 1", got)
+	}
+}
+
+// A daemon that goes away and does NOT come back must fail loudly with the
+// daemon's own remedy — never as a raw 401, and never blamed on Lemonade.
+func TestADaemonThatDiesMidCheckFailsLoudly(t *testing.T) {
+	h := newFakeHost(t)
+	tr := h.transport()
+
+	if rep := Check(context.Background(), tr, EmailConfig()); !rep.Ready() {
+		t.Fatalf("baseline is not ready:\n%s", rep)
+	}
+	h.srv.Close() // the daemon is gone; instance.json still points at its port
+
+	rep := Check(context.Background(), tr, EmailConfig())
+	row, _ := rep.Find(KeyDaemon)
+	if row.State != StateFailed {
+		t.Fatalf("a dead daemon left the daemon row at %s:\n%s", row.State.Word(), rep)
+	}
+	assertRealCommand(t, row)
+	if strings.Contains(row.Remedy.Command, "lemonade") {
+		t.Errorf("a dead daemon was blamed on Lemonade: %q", row.Remedy.Command)
+	}
+	if strings.Contains(row.Detail, "401") || strings.Contains(row.Line, "401") {
+		t.Errorf("a raw status code reached the user: %q / %q", row.Line, row.Detail)
+	}
+}
+
+// relocate is a daemon restart that lands on a DIFFERENT port — the case a
+// cached instance survives but must not be trusted through.
+func (h *fakeHost) relocate(token string, pid int) {
+	h.srv.Close()
+	h.srv = httptest.NewServer(http.HandlerFunc(h.handle))
+	h.t.Cleanup(h.srv.Close)
+	h.mu.Lock()
+	h.token, h.pid = token, pid
+	h.mu.Unlock()
+	h.writeInstance()
+}
+
+// A failed call must not poison every later one. The gate caches the verified
+// instance between calls (the daemon client is stateless by design), so a
+// daemon that moved to a new port has to invalidate that cache on failure —
+// otherwise every subsequent call keeps dialling a port nothing is listening on
+// and the user is stuck until they restart the app.
+//
+// Provision is the path that shows it: unlike Check it does not re-attach
+// first, so it is the one that would keep using a dead record.
+func TestATransportFailureIsNotSticky(t *testing.T) {
+	h := newFakeHost(t)
+	tr := h.transport()
+
+	if rep := Check(context.Background(), tr, EmailConfig()); !rep.Ready() {
+		t.Fatalf("baseline is not ready:\n%s", rep)
+	}
+
+	h.relocate("token-C", 6464)
+
+	// Nothing can know the daemon moved until a call fails, so the first attempt
+	// after the move is expected to fail — loudly, with a real remedy.
+	first := Provision(context.Background(), tr, EmailConfig(), nil)
+	if first.OK {
+		t.Skip("the moved daemon answered on the first try; nothing to prove here")
+	}
+	if first.Diagnosis.Command == "" {
+		t.Errorf("the failure after a move has no remedy: %+v", first.Diagnosis)
+	}
+
+	// The second attempt must recover: the stale record is gone and the client
+	// re-reads the registry the restarted daemon rewrote.
+	second := Provision(context.Background(), tr, EmailConfig(), nil)
+	if !second.OK {
+		t.Fatalf("the gate never recovered from a daemon that moved: final=%q diag=%s",
+			second.Final, second.Diagnosis)
+	}
+}

--- a/tui/internal/ui/preflight/transport.go
+++ b/tui/internal/ui/preflight/transport.go
@@ -1,0 +1,199 @@
+package preflight
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/amd/gaia/tui/internal/daemon"
+)
+
+// DaemonInfo is what the readiness screen needs to know about a live daemon.
+// It never carries the client token.
+type DaemonInfo struct {
+	PID        int
+	Port       int
+	APIVersion string
+}
+
+// Response is a buffered answer from the daemon or a relayed sidecar route.
+type Response struct {
+	Status int
+	Body   []byte
+}
+
+// Stream is an answer whose body is read incrementally — the provisioning
+// progress of POST /v1/<agent>/init. The caller owns Body and must close it.
+type Stream struct {
+	Status int
+	Body   io.ReadCloser
+}
+
+// Transport is every call the readiness gate makes. It exists so Check and the
+// screen are testable against the real response shapes without a daemon, and so
+// this package never learns the daemon's auth rules — those already live in
+// internal/daemon and are reused verbatim.
+type Transport interface {
+	// Attach returns the live daemon if one is running and speaks a contract
+	// this build can use. It never starts one.
+	Attach(ctx context.Context) (DaemonInfo, error)
+	// Start starts-or-attaches the daemon. This is the `f` fix on a daemon row.
+	Start(ctx context.Context) (DaemonInfo, error)
+	// EnsureAgent asks the daemon to spawn-or-attach the agent's sidecar.
+	EnsureAgent(ctx context.Context, agentID string) error
+	// Do issues an authenticated request against the daemon's control plane
+	// ("/daemon/v1/...") or its agent relay ("/v1/<agent>/...").
+	Do(ctx context.Context, method, path string, body []byte) (Response, error)
+	// Stream issues a request whose body is consumed as it arrives.
+	Stream(ctx context.Context, method, path string, body []byte) (Stream, error)
+}
+
+// Connect+header timeouts for the provisioning stream. A model pull can run for
+// many minutes, so only the handshake is bounded here; the caller's context
+// bounds the rest.
+const (
+	streamConnectTimeout = 10 * time.Second
+	streamHeaderTimeout  = 120 * time.Second
+)
+
+// daemonTransport adapts internal/daemon's client to Transport.
+//
+// It caches the verified instance between calls because the daemon client is
+// stateless by design and hands back the (possibly refreshed) instance whose
+// token authorized each call — the token rotates on every daemon restart, so the
+// refreshed one must replace the old one rather than be discarded.
+type daemonTransport struct {
+	c *daemon.Client
+
+	mu   sync.Mutex
+	inst *daemon.Instance
+}
+
+// NewDaemonTransport wraps a daemon client for the readiness gate.
+func NewDaemonTransport(c *daemon.Client) Transport {
+	return &daemonTransport{c: c}
+}
+
+func (t *daemonTransport) set(inst *daemon.Instance) {
+	t.mu.Lock()
+	t.inst = inst
+	t.mu.Unlock()
+}
+
+func (t *daemonTransport) get() *daemon.Instance {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return t.inst
+}
+
+// verify applies BOTH version gates: the MAJOR contract check and the MINOR
+// floor that introduced the agent relay. Without the floor check every relayed
+// call 404s, which would surface as "the agent is not installed" — a wrong
+// answer with a wrong remedy.
+func verify(inst *daemon.Instance) error {
+	return inst.CheckAgentsFloor()
+}
+
+func info(inst *daemon.Instance) DaemonInfo {
+	return DaemonInfo{PID: inst.PID, Port: inst.Port, APIVersion: inst.APIVersion}
+}
+
+func (t *daemonTransport) Attach(ctx context.Context) (DaemonInfo, error) {
+	inst, err := t.c.Attach(ctx)
+	if err != nil {
+		return DaemonInfo{}, err
+	}
+	if err := verify(inst); err != nil {
+		return DaemonInfo{}, err
+	}
+	t.set(inst)
+	return info(inst), nil
+}
+
+func (t *daemonTransport) Start(ctx context.Context) (DaemonInfo, error) {
+	inst, err := t.c.StartOrAttach(ctx)
+	if err != nil {
+		return DaemonInfo{}, err
+	}
+	if err := verify(inst); err != nil {
+		return DaemonInfo{}, err
+	}
+	t.set(inst)
+	return info(inst), nil
+}
+
+func (t *daemonTransport) EnsureAgent(ctx context.Context, agentID string) error {
+	inst, err := t.c.EnsureAgent(ctx, agentID)
+	if err != nil {
+		return err
+	}
+	t.set(inst)
+	return nil
+}
+
+// instance returns the verified instance, attaching first when this is the
+// first call. It never starts a daemon: starting one is a user-visible action
+// that belongs to the daemon row's `f` key, not to an incidental probe.
+func (t *daemonTransport) instance(ctx context.Context) (*daemon.Instance, error) {
+	if inst := t.get(); inst != nil {
+		return inst, nil
+	}
+	if _, err := t.Attach(ctx); err != nil {
+		return nil, err
+	}
+	return t.get(), nil
+}
+
+func (t *daemonTransport) do(ctx context.Context, method, path, accept string, body []byte, httpClient *http.Client) (int, io.ReadCloser, error) {
+	inst, err := t.instance(ctx)
+	if err != nil {
+		return 0, nil, err
+	}
+	header := http.Header{"Accept": []string{accept}}
+	if body != nil {
+		header.Set("Content-Type", "application/json")
+	}
+	resp, fresh, err := t.c.Do(ctx, inst, daemon.Request{
+		Method:     method,
+		Path:       path,
+		Body:       body,
+		Header:     header,
+		HTTPClient: httpClient,
+		Op:         "call " + method + " " + path + " through the background service",
+	})
+	if fresh != nil {
+		t.set(fresh)
+	}
+	if err != nil {
+		return 0, nil, err
+	}
+	return resp.StatusCode, resp.Body, nil
+}
+
+func (t *daemonTransport) Do(ctx context.Context, method, path string, body []byte) (Response, error) {
+	status, rc, err := t.do(ctx, method, path, "application/json", body, nil)
+	if err != nil {
+		return Response{}, err
+	}
+	defer rc.Close()
+	raw, rerr := io.ReadAll(io.LimitReader(rc, 1<<20))
+	if rerr != nil {
+		return Response{}, &daemon.RequestError{
+			Op:     "read the answer to " + method + " " + path,
+			Detail: rerr.Error(),
+		}
+	}
+	return Response{Status: status, Body: raw}, nil
+}
+
+func (t *daemonTransport) Stream(ctx context.Context, method, path string, body []byte) (Stream, error) {
+	// The provisioning verb answers text/plain, not JSON.
+	status, rc, err := t.do(ctx, method, path, "text/plain", body,
+		daemon.StreamHTTPClient(streamConnectTimeout, streamHeaderTimeout))
+	if err != nil {
+		return Stream{}, err
+	}
+	return Stream{Status: status, Body: rc}, nil
+}

--- a/tui/internal/ui/preflight/transport.go
+++ b/tui/internal/ui/preflight/transport.go
@@ -50,12 +50,16 @@ type Transport interface {
 	Stream(ctx context.Context, method, path string, body []byte) (Stream, error)
 }
 
-// Connect+header timeouts for the provisioning stream. A model pull can run for
-// many minutes, so only the handshake is bounded here; the caller's context
-// bounds the rest.
+// Connect+header timeouts for the provisioning stream.
+//
+// The header budget is deliberately huge because the daemon relay BUFFERS every
+// non-SSE response (relay.py reads the whole upstream body before answering),
+// so NO response header arrives until the model pull has finished. A handshake
+// timeout here would abort every real download and blame the wrong thing. The
+// caller's context is what actually bounds the pull.
 const (
 	streamConnectTimeout = 10 * time.Second
-	streamHeaderTimeout  = 120 * time.Second
+	streamHeaderTimeout  = 60 * time.Minute
 )
 
 // daemonTransport adapts internal/daemon's client to Transport.
@@ -103,6 +107,10 @@ func info(inst *daemon.Instance) DaemonInfo {
 func (t *daemonTransport) Attach(ctx context.Context) (DaemonInfo, error) {
 	inst, err := t.c.Attach(ctx)
 	if err != nil {
+		// Drop the cached instance: a failed attach means the record we were
+		// using is no longer trustworthy, and reusing it would send the next
+		// call to a port the daemon may have left.
+		t.set(nil)
 		return DaemonInfo{}, err
 	}
 	if err := verify(inst); err != nil {
@@ -167,6 +175,9 @@ func (t *daemonTransport) do(ctx context.Context, method, path, accept string, b
 		t.set(fresh)
 	}
 	if err != nil {
+		// Force a fresh attach next time rather than retrying against an
+		// instance that just failed to answer.
+		t.set(nil)
 		return 0, nil, err
 	}
 	return resp.StatusCode, resp.Body, nil

--- a/tui/internal/ui/preflight/view.go
+++ b/tui/internal/ui/preflight/view.go
@@ -1,0 +1,385 @@
+package preflight
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/charmbracelet/lipgloss"
+)
+
+// Colour is ADDITIVE here. Every state is already carried by its text marker
+// ([ok] / [!] / [?] / [ ] / [..]) and by the words in the line, so the screen
+// reads identically on a monochrome terminal, over a pipe, or to a user who
+// cannot distinguish red from green.
+var (
+	titleStyle   = lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("150"))
+	summaryStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("243"))
+	dividerStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("238"))
+	labelStyle   = lipgloss.NewStyle().Foreground(lipgloss.Color("252"))
+	dimStyle     = lipgloss.NewStyle().Foreground(lipgloss.Color("243"))
+	okStyle      = lipgloss.NewStyle().Foreground(lipgloss.Color("42"))
+	failStyle    = lipgloss.NewStyle().Foreground(lipgloss.Color("196"))
+	unknownStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("214"))
+	keyStyle     = lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("39"))
+	noteStyle    = lipgloss.NewStyle().Foreground(lipgloss.Color("214"))
+	cmdStyle     = lipgloss.NewStyle().Foreground(lipgloss.Color("150"))
+)
+
+const (
+	indentW = 2
+	cursorW = 2
+	markerW = 6
+	minW    = 40
+	minH    = 10
+)
+
+func stateStyle(s State) lipgloss.Style {
+	switch s {
+	case StateOK:
+		return okStyle
+	case StateFailed:
+		return failStyle
+	case StateUnknown:
+		return unknownStyle
+	default:
+		return dimStyle
+	}
+}
+
+func (m Model) dims() (w, h, labelW, lineW int) {
+	w, h = m.width, m.height
+	if w < minW {
+		w = minW
+	}
+	if h < minH {
+		h = minH
+	}
+	labelW = w - 60
+	if labelW < 12 {
+		labelW = 12
+	}
+	if labelW > 20 {
+		labelW = 20
+	}
+	lineW = w - indentW - cursorW - markerW - labelW - 1
+	if lineW < 12 {
+		lineW = 12
+	}
+	return w, h, labelW, lineW
+}
+
+func (m Model) render() string {
+	w, h, labelW, lineW := m.dims()
+
+	head := m.header(w)
+	div := strings.Repeat("─", w-2*indentW)
+	foot := m.footer(w)
+
+	// header + divider + divider + footer are fixed chrome; everything else has
+	// to fit in what is left. A readiness screen that itself does not fit at
+	// 80x24 is self-defeating, so the body is trimmed, never the footer.
+	budget := h - 4
+	if budget < 1 {
+		budget = 1
+	}
+
+	var body []string
+	if m.details {
+		body = m.detailLines(w, budget)
+	} else {
+		body = m.rowLines(labelW, lineW, w, budget)
+	}
+	if len(body) > budget {
+		body = body[:budget]
+	}
+
+	out := []string{head, pad(dividerStyle.Render(div))}
+	out = append(out, body...)
+	out = append(out, pad(dividerStyle.Render(div)), foot)
+	return strings.Join(out, "\n")
+}
+
+func (m Model) header(w int) string {
+	left := fmt.Sprintf("Getting %s ready", m.cfg.AgentName)
+	right := m.rep.Summary()
+	if m.phase == phaseChecking {
+		right = "checking…"
+	}
+	gap := w - 2*indentW - lipgloss.Width(left) - lipgloss.Width(right)
+	if gap < 1 {
+		return pad(titleStyle.Render(truncate(left, w-2*indentW)))
+	}
+	return pad(titleStyle.Render(left) + strings.Repeat(" ", gap) + summaryStyle.Render(right))
+}
+
+func (m Model) footer(w int) string {
+	keys := [][2]string{}
+	if fix := m.focusedFix(); fix != FixNone && !m.Busy() {
+		keys = append(keys, [2]string{"f", fix.Label()})
+	}
+	keys = append(keys, [2]string{"r", "re-check"})
+	keys = append(keys, [2]string{"d", "details"})
+	if !m.rep.Blocked() && !m.rep.Ready() && !m.Busy() {
+		keys = append(keys, [2]string{"enter", "start anyway"})
+	}
+	keys = append(keys, [2]string{"esc", "back"})
+
+	parts := make([]string, 0, len(keys))
+	for _, k := range keys {
+		parts = append(parts, keyStyle.Render(k[0])+" "+dimStyle.Render(k[1]))
+	}
+	return pad(truncateStyled(strings.Join(parts, dimStyle.Render(" · ")), w-2*indentW))
+}
+
+func (m Model) focusedFix() FixKind {
+	if m.focus < 0 || m.focus >= len(m.rep.Rows) {
+		return FixNone
+	}
+	return m.rep.Rows[m.focus].Fix
+}
+
+// rowLines renders the checklist plus the focused row's remedy block. Only the
+// focused row expands: five expanded remedies would not fit 24 rows, and a wall
+// of advice is how a user stops reading any of it.
+//
+// When the terminal is too short, the remedy block shrinks first and the
+// checklist keeps every row — a gate that hides the precondition it is
+// reporting on is worse than one that hides the advice about it.
+func (m Model) rowLines(labelW, lineW, w, budget int) []string {
+	checklist, remedy, focusAt := m.checklistLines(labelW, lineW, w)
+	trailer := m.trailerLines(w)
+
+	available := budget - len(checklist) - len(trailer)
+	if available < 0 {
+		// Not even the checklist fits: drop the trailer, then rows.
+		trailer = nil
+		if budget < len(checklist) {
+			return checklist[:budget]
+		}
+		available = budget - len(checklist)
+	}
+	if len(remedy) > available {
+		if available > 0 {
+			remedy = append(remedy[:available-1:available-1],
+				dimStyle.Render(strings.Repeat(" ", indentW+cursorW+markerW)+"…press d for the raw answer"))
+		} else {
+			remedy = nil
+		}
+	}
+
+	out := make([]string, 0, len(checklist)+len(remedy)+len(trailer))
+	out = append(out, checklist[:focusAt+1]...)
+	out = append(out, remedy...)
+	out = append(out, checklist[focusAt+1:]...)
+	return append(out, trailer...)
+}
+
+// checklistLines returns one line per row, the focused row's remedy block, and
+// the index the remedy block belongs after.
+func (m Model) checklistLines(labelW, lineW, w int) (checklist, remedy []string, focusAt int) {
+	remedyIndent := indentW + cursorW + markerW
+	remedyW := w - remedyIndent - indentW
+	focusAt = len(m.rep.Rows) - 1
+
+	for i, row := range m.rep.Rows {
+		focused := i == m.focus
+		cursor := "  "
+		if focused && !m.rep.Ready() {
+			cursor = "> "
+		}
+		st := stateStyle(row.State)
+		marker := st.Render(fmt.Sprintf("%-*s", markerW-1, row.State.Marker())) + " "
+		label := labelStyle.Render(fmt.Sprintf("%-*s", labelW, truncate(row.Label, labelW)))
+
+		line := row.Line
+		if row.State == StateChecking {
+			line = m.spin.View() + " " + line
+		}
+		if row.State == StatePending && row.Detail != "" {
+			line = row.Line + "  " + row.Detail
+		}
+		body := st.Render(truncate(line, lineW))
+		if row.State == StateOK || row.State == StatePending {
+			body = dimStyle.Render(truncate(line, lineW))
+		}
+		checklist = append(checklist, pad(cursor+marker+label+body))
+
+		if !focused || row.State == StateOK || row.State == StatePending {
+			continue
+		}
+		focusAt = i
+		remedy = indentAll(m.remedyLines(row, remedyW), remedyIndent)
+	}
+	return checklist, remedy, focusAt
+}
+
+// trailerLines is what sits under the checklist: the download's progress line,
+// the outcome of the last fix, or the hand-off note on an all-ready screen.
+func (m Model) trailerLines(w int) []string {
+	switch {
+	case m.phase == phaseProvisioning:
+		return []string{
+			"",
+			pad(noteStyle.Render(truncate(m.spin.View()+" "+m.provisionLine, w-2*indentW))),
+			pad(dimStyle.Render("Leaving this screen cancels the download.")),
+		}
+	case m.note != "":
+		return append([]string{""}, indentAll(wrap(m.note, w-2*indentW), indentW)...)
+	case m.rep.Ready():
+		return []string{"", pad(dimStyle.Render("Starting " + m.cfg.AgentName + "…"))}
+	}
+	return nil
+}
+
+func (m Model) remedyLines(row Row, w int) []string {
+	out := []string{}
+	if row.Detail != "" {
+		for _, l := range wrap(row.Detail, w) {
+			out = append(out, dimStyle.Render(l))
+		}
+	}
+	if row.Remedy.Action != "" {
+		for _, l := range wrap(row.Remedy.Action, w) {
+			out = append(out, labelStyle.Render(l))
+		}
+	}
+	if row.Remedy.Command != "" {
+		for i, l := range wrap(row.Remedy.Command, w-7) {
+			prefix := dimStyle.Render("run:   ")
+			if i > 0 {
+				prefix = "       "
+			}
+			out = append(out, prefix+cmdStyle.Render(l))
+		}
+	}
+	if row.Remedy.Where != "" {
+		for i, l := range wrap(row.Remedy.Where, w-7) {
+			prefix := dimStyle.Render("look:  ")
+			if i > 0 {
+				prefix = "       "
+			}
+			out = append(out, prefix+dimStyle.Render(l))
+		}
+	}
+	if row.Fix != FixNone {
+		out = append(out, keyStyle.Render("f")+" "+dimStyle.Render(row.Fix.Label()))
+	}
+	return out
+}
+
+// detailLines is `d`: the raw answer behind the focused row, so a user filing a
+// bug can copy exactly what the probe saw.
+func (m Model) detailLines(w, budget int) []string {
+	if m.focus < 0 || m.focus >= len(m.rep.Rows) {
+		return []string{pad(dimStyle.Render("no row selected"))}
+	}
+	row := m.rep.Rows[m.focus]
+	out := []string{
+		pad(labelStyle.Render(fmt.Sprintf("%s — %s", row.Label, row.State.Word()))),
+		"",
+	}
+	raw := row.Raw
+	if strings.TrimSpace(raw) == "" {
+		raw = "(this check recorded no raw answer)"
+	}
+	for _, l := range wrap(raw, w-2*indentW) {
+		out = append(out, pad(dimStyle.Render(l)))
+		if len(out) >= budget {
+			break
+		}
+	}
+	return out
+}
+
+// --- text helpers ----------------------------------------------------------
+
+func pad(s string) string { return strings.Repeat(" ", indentW) + s }
+
+func indentAll(lines []string, n int) []string {
+	prefix := strings.Repeat(" ", n)
+	out := make([]string, 0, len(lines))
+	for _, l := range lines {
+		out = append(out, prefix+l)
+	}
+	return out
+}
+
+// truncate cuts a plain (ANSI-free) string to w display columns.
+func truncate(s string, w int) string {
+	if w <= 0 {
+		return ""
+	}
+	if lipgloss.Width(s) <= w {
+		return s
+	}
+	runes := []rune(s)
+	for len(runes) > 0 && lipgloss.Width(string(runes))+1 > w {
+		runes = runes[:len(runes)-1]
+	}
+	return string(runes) + "…"
+}
+
+// truncateStyled cuts a string that may already carry ANSI styling. It only
+// drops whole segments, so it never leaves a half-written escape sequence.
+func truncateStyled(s string, w int) string {
+	if lipgloss.Width(s) <= w {
+		return s
+	}
+	parts := strings.Split(s, " ")
+	out := ""
+	for _, p := range parts {
+		candidate := out
+		if candidate != "" {
+			candidate += " "
+		}
+		candidate += p
+		if lipgloss.Width(candidate) > w {
+			break
+		}
+		out = candidate
+	}
+	return out
+}
+
+// wrap breaks text into lines of at most w columns, on word boundaries where it
+// can and mid-token when a single token (a URL, a long command) is longer.
+func wrap(s string, w int) []string {
+	if w < 8 {
+		w = 8
+	}
+	var out []string
+	for _, paragraph := range strings.Split(s, "\n") {
+		line := ""
+		for _, word := range strings.Fields(paragraph) {
+			for lipgloss.Width(word) > w {
+				if line != "" {
+					out = append(out, line)
+					line = ""
+				}
+				runes := []rune(word)
+				cut := len(runes)
+				for cut > 0 && lipgloss.Width(string(runes[:cut])) > w {
+					cut--
+				}
+				out = append(out, string(runes[:cut]))
+				word = string(runes[cut:])
+			}
+			switch {
+			case line == "":
+				line = word
+			case lipgloss.Width(line)+1+lipgloss.Width(word) <= w:
+				line += " " + word
+			default:
+				out = append(out, line)
+				line = word
+			}
+		}
+		if line != "" {
+			out = append(out, line)
+		}
+	}
+	if len(out) == 0 {
+		return []string{""}
+	}
+	return out
+}

--- a/tui/internal/ui/preflight/view.go
+++ b/tui/internal/ui/preflight/view.go
@@ -225,7 +225,9 @@ func (m Model) trailerLines(w int) []string {
 		}
 	case m.note != "":
 		return append([]string{""}, indentAll(wrap(m.note, w-2*indentW), indentW)...)
-	case m.rep.Ready():
+	case m.phase == phaseDone:
+		// Only when a hand-off is actually scheduled — under ManualProceed
+		// nothing is starting, and saying so would be a lie.
 		return []string{"", pad(dimStyle.Render("Starting " + m.cfg.AgentName + "…"))}
 	}
 	return nil

--- a/tui/internal/ui/preflight/view_test.go
+++ b/tui/internal/ui/preflight/view_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"strings"
 	"testing"
+	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/x/ansi"
@@ -111,7 +112,6 @@ func TestRenderAllReadyAt80x24(t *testing.T) {
 		"Lemonade 8.1.10",
 		"Gemma-4-E4B-it-GGUF · 16K context",
 		"you@gmail.com (Gmail) · can send",
-		"Starting Email…",
 	} {
 		if !strings.Contains(screen, want) {
 			t.Errorf("screen does not show %q:\n%s", want, screen)
@@ -120,6 +120,30 @@ func TestRenderAllReadyAt80x24(t *testing.T) {
 	if strings.Contains(screen, "[!]") {
 		t.Errorf("an all-ready screen shows a failure marker:\n%s", screen)
 	}
+	// This capture is under ManualProceed, where nothing is being launched, so
+	// the hand-off line must be absent — claiming "Starting Email…" while the
+	// screen just sits there is a lie the user would wait on.
+	if strings.Contains(screen, "Starting Email") {
+		t.Errorf("ManualProceed screen claims it is starting the agent:\n%s", screen)
+	}
+}
+
+// The auto-proceed path is where "Starting Email…" is true.
+func TestReadyScreenSaysItIsStartingOnlyWhenItIs(t *testing.T) {
+	f := newFake()
+	m := New(f, EmailConfig(), Options{ReadyHold: time.Millisecond})
+	updated, _ := m.Update(tea.WindowSizeMsg{Width: 80, Height: 24})
+	updated, cmd := updated.(Model).Update(reportMsg{rep: Check(context.Background(), f, EmailConfig())})
+	m = updated.(Model)
+
+	if cmd == nil {
+		t.Fatal("a ready report did not schedule the hand-off")
+	}
+	screen := ansi.Strip(m.View())
+	if !strings.Contains(screen, "Starting Email…") {
+		t.Errorf("the auto-proceed screen does not say what happens next:\n%s", screen)
+	}
+	assertFits(t, splitLines(screen), 80, 24)
 }
 
 // The screen has to survive every failure mode, not just the one that fits.
@@ -209,7 +233,10 @@ func TestKeysDriveTheRightActions(t *testing.T) {
 		if !ok {
 			t.Fatalf("f produced %T, want ConnectMailboxMsg", cmd())
 		}
-		if msg.Provider != "google" || msg.AgentID != "email" {
+		// No provider: with nothing connected, choosing Gmail vs Outlook is the
+		// user's call and belongs to the connector flow. Naming one here would
+		// walk an Outlook user into a Google sign-in.
+		if msg.Provider != "" || msg.AgentID != "email" {
 			t.Errorf("connect message = %+v", msg)
 		}
 	})

--- a/tui/internal/ui/preflight/view_test.go
+++ b/tui/internal/ui/preflight/view_test.go
@@ -1,0 +1,304 @@
+package preflight
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/x/ansi"
+
+	"github.com/amd/gaia/tui/internal/daemon"
+)
+
+// renderAt drives the model to a settled report and returns the plain-text
+// screen at the given size. Styling is stripped so the assertions are about
+// what a monochrome terminal shows — colour must never be the only signal.
+func renderAt(t *testing.T, f *fakeTransport, w, h int) (Model, []string) {
+	t.Helper()
+	m := New(f, EmailConfig(), Options{ManualProceed: true})
+	updated, _ := m.Update(tea.WindowSizeMsg{Width: w, Height: h})
+	m = updated.(Model)
+	updated, _ = m.Update(reportMsg{rep: Check(context.Background(), f, EmailConfig())})
+	m = updated.(Model)
+	return m, strings.Split(ansi.Strip(m.View()), "\n")
+}
+
+func assertFits(t *testing.T, lines []string, w, h int) {
+	t.Helper()
+	if len(lines) > h {
+		t.Errorf("screen is %d rows, does not fit %d:\n%s", len(lines), h, strings.Join(lines, "\n"))
+	}
+	for i, l := range lines {
+		if got := ansi.StringWidth(l); got > w {
+			t.Errorf("line %d is %d columns, does not fit %d: %q", i, got, w, l)
+		}
+	}
+}
+
+func joined(lines []string) string { return strings.Join(lines, "\n") }
+
+func splitLines(screen string) []string { return strings.Split(screen, "\n") }
+
+// countMarkedRows counts checklist rows by their state marker — the text signal
+// that has to survive every width.
+func countMarkedRows(lines []string) int {
+	n := 0
+	for _, l := range lines {
+		for _, marker := range []string{"[ok]", "[!]", "[?]", "[ ]", "[..]"} {
+			if strings.Contains(l, marker) {
+				n++
+				break
+			}
+		}
+	}
+	return n
+}
+
+func TestRenderAllFailedAt80x24(t *testing.T) {
+	f := newFake()
+	f.attachErr = &daemon.NotRunningError{Path: "/Users/you/.gaia/host/instance.json"}
+
+	m, lines := renderAt(t, f, 80, 24)
+	screen := joined(lines)
+	t.Logf("\n%s", screen)
+
+	assertFits(t, lines, 80, 24)
+
+	// Every row is present and legible without colour.
+	for _, want := range []string{
+		"Getting Email ready",
+		"Background service",
+		"Email agent",
+		"Local AI",
+		"AI model",
+		"Mailbox",
+	} {
+		if !strings.Contains(screen, want) {
+			t.Errorf("screen does not show %q:\n%s", want, screen)
+		}
+	}
+	// The failure is marked in TEXT, carries a remedy, and offers its fix key.
+	for _, want := range []string{"[!]", "gaia daemon start", "f start it for me", "esc back"} {
+		if !strings.Contains(screen, want) {
+			t.Errorf("screen does not show %q:\n%s", want, screen)
+		}
+	}
+	// Rows that could not be checked say so — never a blank that reads as fine.
+	if !strings.Contains(screen, "checked once") {
+		t.Errorf("pending rows do not say what they are waiting on:\n%s", screen)
+	}
+	if m.Ready() {
+		t.Error("model reports ready with a failed daemon")
+	}
+}
+
+func TestRenderAllReadyAt80x24(t *testing.T) {
+	m, lines := renderAt(t, newFake(), 80, 24)
+	screen := joined(lines)
+	t.Logf("\n%s", screen)
+
+	assertFits(t, lines, 80, 24)
+
+	if !m.Ready() {
+		t.Fatalf("expected ready:\n%s", m.Report())
+	}
+	for _, want := range []string{
+		"ready",
+		"[ok]",
+		"running (pid 41822)",
+		"0.5.0",
+		"Lemonade 8.1.10",
+		"Gemma-4-E4B-it-GGUF · 16K context",
+		"you@gmail.com (Gmail) · can send",
+		"Starting Email…",
+	} {
+		if !strings.Contains(screen, want) {
+			t.Errorf("screen does not show %q:\n%s", want, screen)
+		}
+	}
+	if strings.Contains(screen, "[!]") {
+		t.Errorf("an all-ready screen shows a failure marker:\n%s", screen)
+	}
+}
+
+// The screen has to survive every failure mode, not just the one that fits.
+func TestRenderFitsEveryScenarioAt80x24(t *testing.T) {
+	scenarios := map[string]*fakeTransport{
+		"lemonade unreachable": newFake().with("GET /v1/email/init", 503, initUnreachable),
+		"lemonade too old":     newFake().with("GET /v1/email/init", 503, initTooOld),
+		"version unknown":      newFake().with("GET /v1/email/init", 200, initUnknownVersion),
+		"model missing":        newFake().with("GET /v1/email/init", 503, initModelMissing),
+		"no mailbox":           newFake().with("GET /v1/email/connectors", 200, connectorsNone),
+		"send not granted":     newFake().with("GET /v1/email/connectors", 200, connectorsNoSend),
+		"sidecar stopped":      newFake().with("GET /daemon/v1/agents", 200, agentsStopped),
+		"not installed":        newFake().with("GET /daemon/v1/agents", 200, agentsEmpty),
+	}
+	for name, f := range scenarios {
+		t.Run(name, func(t *testing.T) {
+			_, lines := renderAt(t, f, 80, 24)
+			t.Logf("\n%s", joined(lines))
+			assertFits(t, lines, 80, 24)
+		})
+	}
+}
+
+// A narrow or short terminal must still show the checklist and the key hints —
+// the footer is the last thing to go, never the first.
+func TestRenderSurvivesSmallTerminals(t *testing.T) {
+	sizes := []struct{ w, h int }{{80, 24}, {60, 20}, {50, 14}, {40, 12}, {30, 10}}
+	f := newFake().with("GET /v1/email/init", 503, initUnreachable)
+	for _, s := range sizes {
+		_, lines := renderAt(t, f, s.w, s.h)
+		w, h := s.w, s.h
+		if w < minW {
+			w = minW
+		}
+		if h < minH {
+			h = minH
+		}
+		assertFits(t, lines, w, h)
+		screen := joined(lines)
+		if !strings.Contains(screen, "esc") {
+			t.Errorf("%dx%d lost the key hints:\n%s", s.w, s.h, screen)
+		}
+		// The promise: the remedy shrinks, the checklist never does. Labels
+		// themselves may be truncated on a narrow terminal — a missing ROW is the
+		// failure, a shortened label is not.
+		if got := countMarkedRows(lines); got != 5 {
+			t.Errorf("%dx%d shows %d checklist rows, want 5:\n%s", s.w, s.h, got, screen)
+		}
+	}
+}
+
+// `d` shows the raw probe answer — what a user pastes into a bug report.
+func TestDetailsShowsTheRawAnswer(t *testing.T) {
+	f := newFake().with("GET /v1/email/init", 503, initModelMissing)
+	m, _ := renderAt(t, f, 80, 24)
+
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'d'}})
+	m = updated.(Model)
+	screen := ansi.Strip(m.View())
+
+	if !strings.Contains(screen, "not downloaded") {
+		t.Errorf("details does not show the raw hint:\n%s", screen)
+	}
+	assertFits(t, strings.Split(screen, "\n"), 80, 24)
+}
+
+func TestKeysDriveTheRightActions(t *testing.T) {
+	t.Run("esc cancels", func(t *testing.T) {
+		m, _ := renderAt(t, newFake(), 80, 24)
+		_, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEsc})
+		if cmd == nil {
+			t.Fatal("esc produced no command")
+		}
+		if _, ok := cmd().(CancelMsg); !ok {
+			t.Fatalf("esc produced %T, want CancelMsg", cmd())
+		}
+	})
+
+	t.Run("f on a mailbox row hands off to the connector flow", func(t *testing.T) {
+		f := newFake().with("GET /v1/email/connectors", 200, connectorsNone)
+		m, _ := renderAt(t, f, 80, 24)
+		if m.FocusKey() != KeyMailbox {
+			t.Fatalf("focus = %q, want the first row needing attention", m.FocusKey())
+		}
+		_, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'f'}})
+		msg, ok := cmd().(ConnectMailboxMsg)
+		if !ok {
+			t.Fatalf("f produced %T, want ConnectMailboxMsg", cmd())
+		}
+		if msg.Provider != "google" || msg.AgentID != "email" {
+			t.Errorf("connect message = %+v", msg)
+		}
+	})
+
+	t.Run("f on a row with no safe fix says what to run instead", func(t *testing.T) {
+		f := newFake().with("GET /v1/email/init", 503, initUnreachable)
+		m, _ := renderAt(t, f, 80, 24)
+		updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'f'}})
+		m = updated.(Model)
+		if !strings.Contains(ansi.Strip(m.View()), "lemonade-server serve") {
+			t.Errorf("pressing f on an unfixable row said nothing useful:\n%s", m.View())
+		}
+	})
+
+	t.Run("enter is refused while a check is blocked", func(t *testing.T) {
+		f := newFake().with("GET /v1/email/connectors", 200, connectorsNone)
+		m, _ := renderAt(t, f, 80, 24)
+		_, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+		if cmd != nil {
+			t.Fatalf("enter proceeded past a blocked report: %T", cmd())
+		}
+	})
+
+	t.Run("enter proceeds when only an indeterminate row remains", func(t *testing.T) {
+		f := newFake().with("GET /v1/email/init", 200, initUnknownVersion)
+		m, _ := renderAt(t, f, 80, 24)
+		_, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+		if cmd == nil {
+			t.Fatal("enter did nothing on an unknown-but-not-blocked report")
+		}
+		if _, ok := cmd().(ProceedMsg); !ok {
+			t.Fatalf("enter produced %T, want ProceedMsg", cmd())
+		}
+	})
+
+	t.Run("up and down move the cursor", func(t *testing.T) {
+		m, _ := renderAt(t, newFake(), 80, 24)
+		updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyDown})
+		m = updated.(Model)
+		if m.FocusKey() != KeySidecar {
+			t.Errorf("focus after down = %q, want %q", m.FocusKey(), KeySidecar)
+		}
+		updated, _ = m.Update(tea.KeyMsg{Type: tea.KeyUp})
+		m = updated.(Model)
+		if m.FocusKey() != KeyDaemon {
+			t.Errorf("focus after up = %q, want %q", m.FocusKey(), KeyDaemon)
+		}
+	})
+}
+
+// An all-ready report auto-proceeds; nothing else does.
+func TestAutoProceedOnlyWhenReady(t *testing.T) {
+	f := newFake()
+	m := New(f, EmailConfig(), Options{ReadyHold: 1})
+	updated, cmd := m.Update(reportMsg{rep: Check(context.Background(), f, EmailConfig())})
+	m = updated.(Model)
+	if cmd == nil {
+		t.Fatal("a ready report did not schedule the hand-off to chat")
+	}
+	if _, ok := cmd().(proceedTickMsg); !ok {
+		t.Fatalf("ready report scheduled %T", cmd())
+	}
+	_, cmd = m.Update(proceedTickMsg{})
+	if _, ok := cmd().(ProceedMsg); !ok {
+		t.Fatalf("the hold produced %T, want ProceedMsg", cmd())
+	}
+
+	blocked := newFake().with("GET /v1/email/connectors", 200, connectorsNone)
+	m2 := New(blocked, EmailConfig(), Options{ReadyHold: 1})
+	_, cmd = m2.Update(reportMsg{rep: Check(context.Background(), blocked, EmailConfig())})
+	if cmd != nil {
+		t.Fatalf("a blocked report scheduled %T", cmd())
+	}
+}
+
+func TestRenderWrapsLongRemediesInsteadOfOverflowing(t *testing.T) {
+	// The mailbox remedy is the longest string the screen ever shows: a full
+	// `gaia connectors connect` line with a scope URL.
+	f := newFake().with("GET /v1/email/connectors", 200, connectorsNone)
+	_, lines := renderAt(t, f, 80, 24)
+	screen := joined(lines)
+	assertFits(t, lines, 80, 24)
+
+	// Wrapping must not lose the command: the whole thing has to be readable.
+	flat := strings.Join(strings.Fields(screen), " ")
+	if !strings.Contains(flat, "gaia connectors connect google --grant-agent installed:email") {
+		t.Errorf("the connect command did not survive wrapping:\n%s", screen)
+	}
+	if !strings.Contains(flat, "https://www.googleapis.com/auth/gmail.send") {
+		t.Errorf("the scope did not survive wrapping:\n%s", screen)
+	}
+}

--- a/tui/internal/ui/root/introspect.go
+++ b/tui/internal/ui/root/introspect.go
@@ -19,6 +19,14 @@ func (m RootModel) ControlSnapshot() control.Snapshot {
 		snap.VisibleAgentIDs = m.hub.VisibleAgentIDs()
 		snap.Filtering = m.hub.IsFiltering()
 		snap.Overlay = m.hub.Overlay()
+	case viewPreflight:
+		snap.View = "preflight"
+		if m.preflight != nil {
+			snap.Agent = m.preflight.AgentID()
+		}
+		if m.connect != nil {
+			snap.Overlay = "connect-mailbox"
+		}
 	case viewChat:
 		snap.View = "chat"
 		if m.chat != nil {

--- a/tui/internal/ui/root/model.go
+++ b/tui/internal/ui/root/model.go
@@ -11,12 +11,16 @@ import (
 	"github.com/amd/gaia/tui/internal/ui/chat"
 	"github.com/amd/gaia/tui/internal/ui/components"
 	"github.com/amd/gaia/tui/internal/ui/hub"
+	"github.com/amd/gaia/tui/internal/ui/preflight"
 )
 
 type view int
 
 const (
 	viewHub view = iota
+	// viewPreflight is the readiness gate every daemon-backed launch passes
+	// through before chat opens.
+	viewPreflight
 	viewChat
 )
 
@@ -31,6 +35,25 @@ type RootModel struct {
 	width      int
 	height     int
 	debug      bool
+
+	// preflight is the gate currently on screen, nil when there is none.
+	preflight *preflight.Model
+	// pending is the agent that gate is guarding — launched only on ProceedMsg.
+	pending *catalog.Agent
+	// connect is the mailbox hand-off shown over the gate, nil when there is none.
+	connect *connectHandoff
+	// pfTransport is built on first launch and reused for the session.
+	pfTransport preflight.Transport
+	pfOpts      preflight.Options
+}
+
+// WithPreflight points the readiness gate at a specific transport and tunes its
+// options. Tests use it to drive the gate against a fake daemon; a real session
+// leaves it alone and gets the daemon transport.
+func (m RootModel) WithPreflight(t preflight.Transport, opts preflight.Options) RootModel {
+	m.pfTransport = t
+	m.pfOpts = opts
+	return m
 }
 
 func NewRootModel(cat *catalog.Catalog, debug bool) RootModel {
@@ -73,6 +96,8 @@ func (m RootModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			updated, cmd := m.hub.Update(msg)
 			m.hub = updated.(hub.HubModel)
 			return m, cmd
+		case viewPreflight:
+			return m.updatePreflight(msg)
 		case viewChat:
 			if m.chat != nil {
 				updated, cmd := m.chat.Update(msg)
@@ -84,7 +109,25 @@ func (m RootModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, nil
 
 	case hub.LaunchAgentMsg:
-		return m.launchAgent(msg.Agent)
+		return m.beginPreflight(msg.Agent)
+
+	case preflight.ProceedMsg:
+		if !m.gateIsFor(msg.AgentID) {
+			return m, nil
+		}
+		return m.proceedFromGate()
+
+	case preflight.CancelMsg:
+		if !m.gateIsFor(msg.AgentID) {
+			return m, nil
+		}
+		return m.cancelFromGate()
+
+	case preflight.ConnectMailboxMsg:
+		if !m.gateIsFor(msg.AgentID) {
+			return m, nil
+		}
+		return m.openConnectHandoff(msg.Provider)
 
 	case chat.ReturnToHubMsg:
 		return m.returnToHub(msg.AgentID)
@@ -105,6 +148,11 @@ func (m RootModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.showHelp = false
 			return m, nil
 		}
+		// The mailbox hand-off owns every key while it is up, the way the hub's
+		// modals do — otherwise esc would cancel the launch behind it.
+		if m.activeView == viewPreflight && m.connect != nil {
+			return m.handleConnectKey(msg)
+		}
 	}
 
 	// The hub's async results go to the hub whatever is on screen. They are
@@ -121,6 +169,11 @@ func (m RootModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		updated, cmd := m.hub.Update(msg)
 		m.hub = updated.(hub.HubModel)
 		return m, cmd
+	case viewPreflight:
+		// Everything the gate started answers with a message this package cannot
+		// name — the probe result, a fix outcome, download progress, the hold
+		// tick — so the gate gets the whole default stream, spinner ticks and all.
+		return m.updatePreflight(msg)
 	case viewChat:
 		if m.chat != nil {
 			updated, cmd := m.chat.Update(msg)
@@ -138,6 +191,13 @@ func (m RootModel) View() string {
 	switch m.activeView {
 	case viewHub:
 		base = m.hub.View()
+	case viewPreflight:
+		switch {
+		case m.connect != nil:
+			base = m.connect.view(m.width, m.height)
+		case m.preflight != nil:
+			base = m.preflight.View()
+		}
 	case viewChat:
 		if m.chat != nil {
 			base = m.chat.View()

--- a/tui/internal/ui/root/preflight.go
+++ b/tui/internal/ui/root/preflight.go
@@ -1,0 +1,402 @@
+package root
+
+import (
+	"fmt"
+	"strings"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+
+	"github.com/amd/gaia/tui/internal/catalog"
+	"github.com/amd/gaia/tui/internal/daemon"
+	"github.com/amd/gaia/tui/internal/ui/preflight"
+)
+
+// beginPreflight puts the readiness gate between the hub and the chat.
+//
+// The gate runs on EVERY launch and nothing is remembered between them. Each row
+// is a fact with no expiry notice — the daemon can be killed, its client token
+// rotates on every restart, Lemonade can unload the model, a mailbox grant can be
+// revoked from the web — so a cached pass would open a chat that cannot answer
+// while claiming it had been verified. An all-green pass costs one attach plus two
+// relayed GETs and is held ~800ms; that is the price of the answer being true now.
+func (m RootModel) beginPreflight(agent catalog.Agent) (tea.Model, tea.Cmd) {
+	if agent.Transport != catalog.TransportDaemon {
+		// Every precondition the gate reports is probed THROUGH the daemon relay
+		// (GET /v1/<agent>/init). A subprocess agent has no relay and no
+		// registered sidecar, so the gate could only answer "not installed" —
+		// four wrong rows with four wrong remedies, over a launch that works.
+		return m.launchAgent(agent)
+	}
+
+	gate := preflight.New(m.preflightTransport(), preflight.ConfigFor(agent.ID, agent.Name), m.preflightOptions())
+	m.preflight = &gate
+	m.pending = &agent
+	m.connect = nil
+	m.activeView = viewPreflight
+
+	cmds := []tea.Cmd{gate.Init()}
+	if m.width > 0 && m.height > 0 {
+		cmds = append(cmds, m.sizeCmd())
+	}
+	return m, tea.Batch(cmds...)
+}
+
+// preflightTransport builds the gate's transport on first use and keeps it for
+// the session: it caches the daemon instance whose token authorized the last
+// call, and that token rotates on every daemon restart. Building it lazily also
+// keeps a session that never launches anything from constructing a daemon client.
+func (m *RootModel) preflightTransport() preflight.Transport {
+	if m.pfTransport == nil {
+		m.pfTransport = preflight.NewDaemonTransport(daemon.New(daemon.Options{Logf: m.logf}))
+	}
+	return m.pfTransport
+}
+
+// preflightOptions returns the gate's options. ManualProceed is deliberately NOT
+// wired to --debug: the gate's footer only offers `enter` while a report is
+// neither blocked nor ready, so holding an all-green screen would leave a debug
+// user on a green wall whose only advertised keys are re-check and back.
+func (m RootModel) preflightOptions() preflight.Options {
+	opts := m.pfOpts
+	if opts.Logf == nil {
+		opts.Logf = m.logf
+	}
+	return opts
+}
+
+// gateIsFor reports whether the gate on screen is the one that sent this
+// message. A ProceedMsg from a gate the user already backed out of must not
+// launch anything — the hold tick that produced it can still be in flight.
+func (m RootModel) gateIsFor(agentID string) bool {
+	return m.activeView == viewPreflight && m.preflight != nil &&
+		m.pending != nil && m.pending.ID == agentID
+}
+
+// closeGate tears the gate down, cancelling what it started: a re-check, a
+// sidecar start, a model pull.
+//
+// It does NOT stop the FIRST probe. preflight.Model.Init has a value receiver, so
+// the cancel func for the check it launches is parked on a copy that dies with
+// the call, and the model this host keeps has none. That probe therefore runs to
+// its own 90s timeout after the user leaves; its result is dropped by
+// updatePreflight rather than allowed to drive whatever is on screen. Fixing it
+// properly needs a pointer-receiver initialiser in the preflight package.
+func (m *RootModel) closeGate() {
+	if m.preflight != nil {
+		m.preflight.Cancel()
+		m.preflight = nil
+	}
+	m.pending = nil
+	m.connect = nil
+}
+
+func (m RootModel) proceedFromGate() (tea.Model, tea.Cmd) {
+	agent := *m.pending
+	m.closeGate()
+	// Back to the hub FIRST. launchAgent stays where it is and reports the reason
+	// when a client cannot be built, and "where it is" has to be a screen that
+	// still renders — the gate is gone by now.
+	m.activeView = viewHub
+	return m.launchAgent(agent)
+}
+
+// cancelFromGate returns to the hub. The hub model is untouched while the gate is
+// up, so its tab and highlighted row are exactly where the user left them.
+func (m RootModel) cancelFromGate() (tea.Model, tea.Cmd) {
+	rep := m.preflight.Report()
+	m.closeGate()
+	m.activeView = viewHub
+
+	// Backing out of a gate that had a real blocker leaves the user staring at a
+	// hub that looks like nothing happened. Say which row stopped it.
+	if blocker, blocked := rep.Blocker(); blocked {
+		// One line, and no trailing call to action: the hub truncates its status
+		// row at the terminal width, and a hint that gets cut mid-word is worse
+		// than the footer's own "enter run".
+		m.hub.SetStatus(fmt.Sprintf("%s did not start — %s is %s",
+			rep.AgentName, blocker.Label, blocker.Line))
+	}
+
+	var cmds []tea.Cmd
+	if m.width > 0 && m.height > 0 {
+		cmds = append(cmds, m.sizeCmd())
+	}
+	return m, tea.Batch(cmds...)
+}
+
+func (m RootModel) sizeCmd() tea.Cmd {
+	w, h := m.width, m.height
+	return func() tea.Msg { return tea.WindowSizeMsg{Width: w, Height: h} }
+}
+
+// updatePreflight forwards a message to the gate, then refuses any result that
+// turns out to belong to a gate the user already left.
+//
+// The gate's async results are unexported types, so they cannot be filtered
+// before the fact — a probe started for agent A and answered after the user
+// backed out and launched agent B lands on B's gate. Its report is exported and
+// names its agent, so the check is done after the update: a report for the wrong
+// agent is dropped along with whatever command it wanted to run. Without this, an
+// all-green report for A drives B's screen, and B's gate hands off — opening a
+// chat for an agent nothing ever probed, which is the one outcome this gate
+// exists to prevent.
+func (m RootModel) updatePreflight(msg tea.Msg) (tea.Model, tea.Cmd) {
+	if m.preflight == nil {
+		return m, nil
+	}
+	updated, cmd := m.preflight.Update(msg)
+	gate := updated.(preflight.Model)
+	if id := gate.Report().AgentID; id != "" && m.pending != nil && id != m.pending.ID {
+		return m, nil
+	}
+	m.preflight = &gate
+	return m, cmd
+}
+
+// --- the mailbox hand-off ---------------------------------------------------
+
+// connectHandoff is what ConnectMailboxMsg turns into.
+//
+// The TUI has no connector screen, and half of one would be worse than none:
+// OAuth already has a working implementation behind `gaia connectors`, and a
+// second one here would fork the flow that owns tokens, scopes and grants. So the
+// gate hands over the exact command — the one the mailbox row already computed,
+// with the scope union and the agent grant in it — and re-checks when the user
+// comes back. Swallowing the request, or answering it with "coming soon", would
+// leave the user on a screen that names a problem and no way past it.
+type connectHandoff struct {
+	agentName string
+	// provider is the mailbox to reconnect. Empty means the user has nothing
+	// connected and the choice of provider is still theirs.
+	provider string
+	row      preflight.Row
+	haveRow  bool
+}
+
+func (m RootModel) openConnectHandoff(provider string) (tea.Model, tea.Cmd) {
+	rep := m.preflight.Report()
+	row, ok := rep.Find(preflight.KeyMailbox)
+	m.connect = &connectHandoff{
+		agentName: rep.AgentName,
+		provider:  provider,
+		row:       row,
+		haveRow:   ok,
+	}
+	return m, nil
+}
+
+// handleConnectKey owns every key while the hand-off is up.
+func (m RootModel) handleConnectKey(key tea.KeyMsg) (tea.Model, tea.Cmd) {
+	switch key.String() {
+	case "ctrl+c":
+		// Same as everywhere else: ctrl+c leaves the app, not just the screen. The
+		// view goes back to the hub so the last frame is never a view whose model
+		// has just been torn out from under it.
+		m.closeGate()
+		m.activeView = viewHub
+		return m, tea.Quit
+	case "r":
+		// Dismiss, then let the gate's own `r` do the re-check — the screen that
+		// owns the probes owns the re-check too.
+		m.connect = nil
+		return m.updatePreflight(key)
+	case "esc", "q":
+		m.connect = nil
+		return m, nil
+	}
+	return m, nil
+}
+
+var (
+	connectTitle   = lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("150"))
+	connectDim     = lipgloss.NewStyle().Foreground(lipgloss.Color("243"))
+	connectDivider = lipgloss.NewStyle().Foreground(lipgloss.Color("238"))
+	connectText    = lipgloss.NewStyle().Foreground(lipgloss.Color("252"))
+	connectCmd     = lipgloss.NewStyle().Foreground(lipgloss.Color("150"))
+	connectKey     = lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("39"))
+)
+
+// outlookSetupDoc is where the Outlook path continues. It is a doc, not a
+// command, because Outlook needs a one-time Microsoft app registration (or the
+// device-code flow) before any connect command can succeed — and the mailbox
+// row's Gmail scopes are wrong for Microsoft, so "swap google for microsoft"
+// would hand the user a command that fails.
+const outlookSetupDoc = "https://amd-gaia.ai/docs/connectors/microsoft"
+
+func (h connectHandoff) view(width, height int) string {
+	w := width
+	if w < 40 {
+		w = 40
+	}
+
+	title := fmt.Sprintf("Connect a mailbox for %s", h.agentName)
+	if h.provider != "" {
+		title = fmt.Sprintf("Reconnect %s for %s", providerLabel(h.provider), h.agentName)
+	}
+
+	head := []string{
+		"  " + connectTitle.Render(title),
+		"  " + connectDivider.Render(strings.Repeat("─", w-4)),
+	}
+	var body []block
+	cur := dropContext
+	add := func(style lipgloss.Style, text string, indent int) {
+		prefix := strings.Repeat(" ", indent)
+		for _, line := range wrapLines(text, w-indent-2) {
+			body = append(body, block{line: prefix + style.Render(line), drop: cur})
+		}
+	}
+	blank := func() { body = append(body, block{line: "", drop: cur}) }
+
+	if h.row.Detail != "" {
+		add(connectDim, h.row.Detail, 2)
+		blank()
+	}
+
+	switch {
+	case !h.haveRow || h.row.Remedy.Command == "":
+		// The gate asked for a mailbox and recorded no command to get one. That is
+		// a bug, and it must not read as a shrug.
+		add(connectText, "The readiness check asked for a mailbox connection but recorded no "+
+			"command for it. Report that, then connect from a terminal:", 2)
+		cur = dropNever
+		add(connectCmd, "gaia connectors list", 4)
+		cur = dropContext
+		add(connectDim, "look:  https://amd-gaia.ai/docs/guides/email", 4)
+
+	case h.provider != "":
+		add(connectText, "This cannot be done from here — it opens a browser sign-in. Run this in "+
+			"another terminal, then come back and press r.", 2)
+		// The command is printed verbatim, so if the check produced one for a
+		// different provider than the mailbox it is talking about, say so rather
+		// than let the title vouch for it.
+		if named := providerFromCommand(h.row.Remedy.Command); named != "" && named != h.provider {
+			cur = dropNever
+			add(connectText, fmt.Sprintf(
+				"Heads up: the check produced a %s command for a %s mailbox. Check it before "+
+					"running it, and report it.", providerLabel(named), providerLabel(h.provider)), 2)
+		}
+		cur = dropNever
+		blank()
+		add(connectCmd, h.row.Remedy.Command, 4)
+		cur = dropContext
+		if h.row.Remedy.Where != "" {
+			blank()
+			add(connectDim, "look:  "+h.row.Remedy.Where, 4)
+		}
+
+	default:
+		// Provider is empty: nothing is connected, so the choice is the user's.
+		// Both paths are named, and neither is a command that would fail.
+		add(connectText, "This cannot be done from here — it opens a browser sign-in. "+
+			"Pick one, run it in another terminal, then come back and press r.", 2)
+		offered := providerFromCommand(h.row.Remedy.Command)
+		heading := "Run this:"
+		if offered != "" {
+			heading = providerLabel(offered) + " — one command, about a minute:"
+		}
+		cur = dropNever
+		blank()
+		add(connectText, heading, 2)
+		add(connectCmd, h.row.Remedy.Command, 4)
+		if offered != "microsoft" {
+			cur = dropAlternative
+			blank()
+			add(connectText, "Outlook — needs a one-time Microsoft app setup first:", 2)
+			add(connectDim, outlookSetupDoc, 4)
+		}
+	}
+
+	foot := "  " + connectKey.Render("r") + " " + connectDim.Render("re-check") +
+		connectDim.Render(" · ") + connectKey.Render("esc") + " " + connectDim.Render("back to the checks")
+
+	out := append(head, fitBody(body, height-len(head)-2)...)
+	return strings.Join(append(out, "", foot), "\n")
+}
+
+// Which lines the hand-off gives up first when the terminal is too short. The
+// command sits in the MIDDLE of the screen, so trimming by position — from
+// either end — can eat the one thing the user came here for. Lines are dropped
+// by what they are instead.
+const (
+	// dropNever is the command itself and the sentence that introduces it.
+	dropNever = iota
+	// dropAlternative is the second way to do it (the Outlook pointer).
+	dropAlternative
+	// dropContext is explanation: why this is needed, where to read more.
+	dropContext
+)
+
+// block is one rendered line plus how readily it can be dropped.
+type block struct {
+	line string
+	drop int
+}
+
+// fitBody drops whole categories of line, least important first, until the body
+// fits room rows. Below that it hard-trims and lets the caller's footer stand —
+// a terminal that short is under every size this app supports.
+func fitBody(body []block, room int) []string {
+	if room < 1 {
+		room = 1
+	}
+	for prio := dropContext; prio > dropNever && len(body) > room; prio-- {
+		kept := body[:0:0]
+		for _, b := range body {
+			if b.drop != prio {
+				kept = append(kept, b)
+			}
+		}
+		body = kept
+	}
+	lines := make([]string, 0, len(body))
+	for _, b := range body {
+		lines = append(lines, b.line)
+	}
+	if len(lines) > room {
+		lines = lines[:room]
+	}
+	return lines
+}
+
+// providerFromCommand reads the connector id out of a
+// `gaia connectors connect <id> …` command, so the heading above a command can
+// never name a provider the command does not use.
+func providerFromCommand(cmd string) string {
+	fields := strings.Fields(cmd)
+	for i, f := range fields {
+		if f == "connect" && i+1 < len(fields) {
+			return fields[i+1]
+		}
+	}
+	return ""
+}
+
+func providerLabel(provider string) string {
+	switch provider {
+	case "google":
+		return "Gmail"
+	case "microsoft":
+		return "Outlook"
+	default:
+		return provider
+	}
+}
+
+// wrapLines wraps plain text to w columns, hard-breaking a single token that is
+// longer than the line — a connect command with full OAuth scope URLs in it must
+// be readable in full, never truncated.
+func wrapLines(s string, w int) []string {
+	if w < 8 {
+		w = 8
+	}
+	rendered := lipgloss.NewStyle().Width(w).Render(s)
+	lines := strings.Split(strings.TrimRight(rendered, "\n"), "\n")
+	for i := range lines {
+		// Width() pads every line to w; the padding would show up as trailing
+		// whitespace in a captured screen.
+		lines[i] = strings.TrimRight(lines[i], " ")
+	}
+	return lines
+}

--- a/tui/test/oneshot_readiness_test.go
+++ b/tui/test/oneshot_readiness_test.go
@@ -1,0 +1,392 @@
+package test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/amd/gaia/tui/internal/client"
+	"github.com/amd/gaia/tui/internal/daemon"
+	"github.com/amd/gaia/tui/internal/ui"
+	"github.com/amd/gaia/tui/internal/ui/preflight"
+)
+
+// Issue #2483: `gaia tui run <id> --query …` used to hang forever with nothing
+// on either stream when a precondition was unmet. These tests cover the two
+// halves of the fix — the headless readiness check, and the deadline that
+// catches what a readiness check cannot.
+
+// lemonadeDown is the exact repro condition: background service and sidecar up,
+// the local model server refusing connections.
+func lemonadeDown() *gateTransport {
+	g := readyGateTransport()
+	g.initStatus = http.StatusServiceUnavailable
+	g.initBody = map[string]any{
+		"ready": false,
+		"lemonade": map[string]any{
+			"reachable": false, "base_url": "http://localhost:8000/api/v1",
+			"min_version": "8.1.0",
+		},
+		"model": map[string]any{"id": "Gemma-4-E4B-it-GGUF", "present": false},
+		"hint":  "Lemonade Server is not reachable at http://localhost:8000/api/v1",
+	}
+	return g
+}
+
+// flatten collapses every run of whitespace, so an assertion is about what was
+// said rather than where a renderer happened to wrap it.
+func flatten(s string) string { return strings.Join(strings.Fields(s), " ") }
+
+func emailConfig() preflight.Config { return preflight.ConfigFor("email", "Email") }
+
+// The one-shot must refuse, name the unmet precondition, and name the command
+// that fixes it — the interactive gate is never rendered, because a script has
+// nobody to press a key.
+func TestOneShotReadinessRefusesAndNamesTheRemedy(t *testing.T) {
+	var errW bytes.Buffer
+	rep := ui.ReportReadiness(context.Background(), lemonadeDown(), emailConfig(), &errW)
+
+	if !rep.Blocked() {
+		t.Fatalf("an unreachable model server must block the run:\n%s", rep)
+	}
+	msg := flatten(errW.String())
+	for _, want := range []string{
+		"Local AI",                            // which precondition
+		"not running at",                      // what is wrong with it
+		"run: lemonade-server serve",          // how to fix it
+		"Nothing was sent to the Email agent", // and that nothing half-ran
+	} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("the refusal is missing %q:\n%s", want, errW.String())
+		}
+	}
+	// No keystroke advice can be acted on from a script, so the refusal must at
+	// least end by telling the reader to re-run it.
+	if !strings.Contains(msg, "re-run") {
+		t.Errorf("the refusal never tells the caller what to do next:\n%s", errW.String())
+	}
+}
+
+// The two paths must not drift: whatever the gate shows a human for a condition
+// is what the one-shot prints for the same condition.
+func TestOneShotRefusalMatchesTheInteractiveGate(t *testing.T) {
+	var errW bytes.Buffer
+	ui.ReportReadiness(context.Background(), lemonadeDown(), emailConfig(), &errW)
+	headless := flatten(errW.String())
+
+	d := newRootDriver(t, lemonadeDown(), 100, 40)
+	d.launchEmail()
+	gate := d.flat()
+
+	blocker, ok := preflight.Check(context.Background(), lemonadeDown(), emailConfig()).Blocker()
+	if !ok {
+		t.Fatal("the check reported no blocker for an unreachable model server")
+	}
+	for _, want := range []string{blocker.Line, blocker.Detail, blocker.Remedy.Command} {
+		if want == "" {
+			t.Fatalf("the blocker row is missing a field the user needs: %+v", blocker)
+		}
+		if !strings.Contains(headless, flatten(want)) {
+			t.Errorf("the one-shot refusal dropped %q:\n%s", want, errW.String())
+		}
+		if !strings.Contains(gate, flatten(want)) {
+			t.Errorf("the gate no longer shows %q, so the two paths have drifted:\n%s", want, d.screen())
+		}
+	}
+}
+
+// A healthy machine must be left alone: nothing blocks, and the check prints
+// nothing that could pollute a caller's log.
+func TestOneShotReadinessIsSilentWhenEverythingIsReady(t *testing.T) {
+	var errW bytes.Buffer
+	rep := ui.ReportReadiness(context.Background(), readyGateTransport(), emailConfig(), &errW)
+
+	if rep.Blocked() || !rep.Ready() {
+		t.Fatalf("a healthy machine must pass the check:\n%s", rep)
+	}
+	if errW.String() != "" {
+		t.Errorf("a passing check must stay quiet, got:\n%s", errW.String())
+	}
+}
+
+// An indeterminate row is named but does not refuse — the same rule the gate
+// follows, so a Lemonade that does not advertise its version cannot become a
+// wall a script can never get past.
+func TestOneShotReadinessProceedsPastAnUnverifiableRow(t *testing.T) {
+	g := readyGateTransport()
+	lemonade := g.initBody["lemonade"].(map[string]any)
+	delete(lemonade, "compatible")
+	delete(lemonade, "version")
+
+	var errW bytes.Buffer
+	rep := ui.ReportReadiness(context.Background(), g, emailConfig(), &errW)
+
+	if rep.Blocked() {
+		t.Fatalf("an unverifiable row must not refuse the run:\n%s", rep)
+	}
+	if !strings.Contains(errW.String(), "could not be verified") {
+		t.Errorf("what went unproven must still be said:\n%s", errW.String())
+	}
+}
+
+// --- a stand-in for the real daemon relay -----------------------------------
+
+// relayDaemon is the daemon side of a one-shot: the control plane, the agent
+// relay, and a /query that can be made to stall. It is paired with an
+// instance.json in an isolated GAIA_DAEMON_HOME, so a test never touches — or
+// starts — the developer's own daemon.
+type relayDaemon struct {
+	srv *httptest.Server
+	// home is the isolated GAIA_DAEMON_HOME, for handing to a child process.
+	home string
+	opts relayOptions
+	// release ends a stall when the test is over, so no handler outlives it.
+	release chan struct{}
+
+	mu sync.Mutex
+	// queries counts POSTs to /v1/email/query — what proves a refusal really
+	// sent nothing rather than sending and discarding the answer.
+	queries int
+}
+
+func (d *relayDaemon) queryCount() int {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	return d.queries
+}
+
+// relayOptions is the fake's whole configuration. It is fixed before the server
+// starts: a handler runs on its own goroutine, so anything set afterwards would
+// be a data race, not a test knob.
+type relayOptions struct {
+	// initStatus / initBody are the answer to GET /v1/email/init. The zero value
+	// means "everything ready".
+	initStatus int
+	initBody   map[string]any
+	// stallQuery holds the query stream open without ever sending a byte.
+	stallQuery bool
+}
+
+func newRelayDaemon(t *testing.T, opts relayOptions) *relayDaemon {
+	t.Helper()
+
+	if opts.initStatus == 0 {
+		opts.initStatus = http.StatusOK
+	}
+	if opts.initBody == nil {
+		opts.initBody = readyGateTransport().initBody
+	}
+	d := &relayDaemon{home: t.TempDir(), opts: opts, release: make(chan struct{})}
+	t.Setenv(daemon.EnvHome, d.home)
+
+	d.srv = httptest.NewServer(http.HandlerFunc(d.handle))
+	// Order matters: Close waits for in-flight handlers, so a stall has to be
+	// released BEFORE it runs. Cleanups run last-registered-first.
+	t.Cleanup(d.srv.Close)
+	t.Cleanup(func() { close(d.release) })
+
+	u, err := url.Parse(d.srv.URL)
+	if err != nil {
+		t.Fatalf("parse server URL: %v", err)
+	}
+	port, err := strconv.Atoi(u.Port())
+	if err != nil {
+		t.Fatalf("parse server port: %v", err)
+	}
+	raw, err := json.Marshal(daemon.Instance{
+		PID: os.Getpid(), Port: port, Token: "test-token",
+		Host: daemon.DefaultHost, APIVersion: "1.1", Service: daemon.ServiceID,
+	})
+	if err != nil {
+		t.Fatalf("marshal instance: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(d.home, "instance.json"), raw, 0o600); err != nil {
+		t.Fatalf("write instance.json: %v", err)
+	}
+	return d
+}
+
+func (d *relayDaemon) handle(w http.ResponseWriter, r *http.Request) {
+	switch {
+	case r.URL.Path == daemon.APIPrefix+"/status":
+		writeJSON(w, map[string]any{"service": daemon.ServiceID, "pid": os.Getpid()})
+
+	case r.URL.Path == daemon.APIPrefix+"/agents":
+		writeJSON(w, map[string]any{"agents": []map[string]any{
+			{"agent_id": "email", "state": "running", "pid": os.Getpid(),
+				"agent_version": "0.5.0", "api_version": "1.0"},
+		}})
+
+	case strings.HasSuffix(r.URL.Path, "/ensure"):
+		writeJSON(w, map[string]any{"agent_id": "email", "state": "running"})
+
+	case strings.HasSuffix(r.URL.Path, "/init"):
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(d.opts.initStatus)
+		_ = json.NewEncoder(w).Encode(d.opts.initBody)
+
+	case strings.HasSuffix(r.URL.Path, "/connectors"):
+		writeJSON(w, readyGateTransport().connectors)
+
+	case strings.HasSuffix(r.URL.Path, "/query"):
+		d.mu.Lock()
+		d.queries++
+		d.mu.Unlock()
+		if !d.opts.stallQuery {
+			w.WriteHeader(http.StatusNotImplemented)
+			writeJSON(w, map[string]any{"detail": "this fake only stalls"})
+			return
+		}
+		// Accepted, headers flushed — and then silence. The relay's own read
+		// watchdog is reset by any traffic, so nothing below the caller's
+		// deadline would ever end this.
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		if f, ok := w.(http.Flusher); ok {
+			f.Flush()
+		}
+		select {
+		case <-d.release:
+		case <-r.Context().Done():
+		}
+
+	default:
+		w.WriteHeader(http.StatusNotFound)
+		writeJSON(w, map[string]any{"detail": "no route " + r.URL.Path})
+	}
+}
+
+// The whole command, as a user runs it: with the model server down it must exit
+// non-zero in seconds, say what is wrong on stderr, and leave stdout empty.
+func TestRunQueryRefusesInSecondsWhenAPreconditionIsUnmet(t *testing.T) {
+	gaiaBin, binDir := buildBinaries(t)
+
+	d := newRelayDaemon(t, relayOptions{
+		initStatus: http.StatusServiceUnavailable,
+		initBody:   lemonadeDown().initBody,
+	})
+
+	cmd := exec.Command(gaiaBin, "run", "email", "--query", "triage my inbox")
+	cmd.Env = append(os.Environ(),
+		"PATH="+binDir+string(os.PathListSeparator)+os.Getenv("PATH"),
+		daemon.EnvHome+"="+d.home)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout, cmd.Stderr = &stdout, &stderr
+
+	started := time.Now()
+	err := cmd.Run()
+	elapsed := time.Since(started)
+
+	if err == nil {
+		t.Fatalf("an unmet precondition exited 0\nstderr:\n%s", stderr.String())
+	}
+	if elapsed > 30*time.Second {
+		t.Errorf("took %s to refuse — a script cannot tell that from a hang", elapsed)
+	}
+	if stdout.String() != "" {
+		t.Errorf("stdout must stay empty so `> answer.txt` never captures a failure, got %q", stdout.String())
+	}
+	for _, want := range []string{"not ready", "Local AI", "lemonade-server serve"} {
+		if !strings.Contains(stderr.String(), want) {
+			t.Errorf("stderr is missing %q:\n%s", want, stderr.String())
+		}
+	}
+	if strings.Contains(stdout.String(), altScreenEnter) || strings.Contains(stderr.String(), altScreenEnter) {
+		t.Error("the refusal opened the alt screen; a script has nobody to press a key")
+	}
+	// The refusal promises "Nothing was sent to the Email agent". Prove it.
+	if n := d.queryCount(); n != 0 {
+		t.Errorf("the run sent %d quer(ies) after refusing — the message is a lie", n)
+	}
+}
+
+// The other half of the fix, end to end through the real command: a daemon that
+// accepts the query and never answers must be abandoned at the bound, not waited
+// on. --timeout is what makes that bound testable — and raisable by a caller
+// whose agent legitimately runs longer than the default.
+func TestRunQueryAbandonsAStalledAgentAtTheTimeout(t *testing.T) {
+	gaiaBin, binDir := buildBinaries(t)
+
+	d := newRelayDaemon(t, relayOptions{stallQuery: true})
+
+	cmd := exec.Command(gaiaBin, "run", "email", "--query", "triage my inbox", "--timeout", "3s")
+	cmd.Env = append(os.Environ(),
+		"PATH="+binDir+string(os.PathListSeparator)+os.Getenv("PATH"),
+		daemon.EnvHome+"="+d.home)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout, cmd.Stderr = &stdout, &stderr
+
+	started := time.Now()
+	err := cmd.Run()
+	elapsed := time.Since(started)
+
+	if err == nil {
+		t.Fatalf("a turn that never got an answer exited 0\nstderr:\n%s", stderr.String())
+	}
+	if elapsed > 60*time.Second {
+		t.Errorf("took %s to abandon a 3s turn — the bound is not being applied", elapsed)
+	}
+	if !strings.Contains(stderr.String(), "gave up") {
+		t.Errorf("stderr does not report the deadline:\n%s", stderr.String())
+	}
+	if stdout.String() != "" {
+		t.Errorf("stdout = %q, want empty", stdout.String())
+	}
+	if n := d.queryCount(); n != 1 {
+		t.Errorf("the agent was queried %d times, want exactly 1", n)
+	}
+}
+
+// The case a readiness check alone does not cover, over the real SSE transport:
+// the deadline is what turns a stalled stream into a reportable failure.
+func TestOneShotAgainstAStallingDaemonHitsTheDeadline(t *testing.T) {
+	newRelayDaemon(t, relayOptions{stallQuery: true})
+
+	c := client.NewSSEClient("email", daemon.New(daemon.Options{
+		PIDAlive: func(int) bool { return true },
+		// A failed attach must never fall through to the production launcher and
+		// start a real daemon on the machine running the tests.
+		StartCommand: func(context.Context) (*exec.Cmd, error) {
+			return nil, fmt.Errorf("this test must never start a real daemon")
+		},
+	}), client.SSEOptions{})
+	defer c.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	var out, errW bytes.Buffer
+	done := make(chan ui.OneShotResult, 1)
+	started := time.Now()
+	go func() { done <- ui.RunOneShot(ctx, c, "triage my inbox", &out, &errW) }()
+
+	select {
+	case res := <-done:
+		if res.ExitCode == 0 {
+			t.Errorf("a stalled turn exited 0; stderr:\n%s", errW.String())
+		}
+		if out.String() != "" {
+			t.Errorf("stdout must stay empty when nothing was answered, got %q", out.String())
+		}
+		if !strings.Contains(errW.String(), "gave up") {
+			t.Errorf("stderr does not report the deadline:\n%s", errW.String())
+		}
+		if elapsed := time.Since(started); elapsed > 30*time.Second {
+			t.Errorf("took %s to give up on a 2s deadline", elapsed)
+		}
+	case <-time.After(60 * time.Second):
+		t.Fatal("the one-shot hung against a stalling daemon — this is issue #2483")
+	}
+}

--- a/tui/test/preflight_gate_test.go
+++ b/tui/test/preflight_gate_test.go
@@ -1,0 +1,814 @@
+package test
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/charmbracelet/bubbles/spinner"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/x/ansi"
+
+	"github.com/amd/gaia/tui/internal/catalog"
+	"github.com/amd/gaia/tui/internal/daemon"
+	"github.com/amd/gaia/tui/internal/ui/hub"
+	"github.com/amd/gaia/tui/internal/ui/preflight"
+	"github.com/amd/gaia/tui/internal/ui/root"
+)
+
+// These tests cover the seam between the hub and the readiness gate: that a
+// launch goes through the gate, that the gate's three answers land where they
+// should, and that a failing precondition never reaches chat.
+
+// --- a preflight transport under test control -------------------------------
+
+// gateTransport answers the four calls the gate makes, from canned bodies. It
+// exists so the seam can be driven without a daemon, a sidecar, or Lemonade.
+type gateTransport struct {
+	attachErr error
+	// agentState is the state reported for the agent in /daemon/v1/agents.
+	// Empty means the agent is not listed at all.
+	agentState string
+	// initStatus and initBody are the answer to GET /v1/<agent>/init.
+	initStatus int
+	initBody   map[string]any
+	// initByAgent overrides the init answer per agent id, so one gate can be
+	// green while another is blocked.
+	initByAgent map[string]initAnswer
+	// connectors is the answer to GET /v1/<agent>/connectors.
+	connectors map[string]any
+
+	starts  int
+	ensures int
+}
+
+func readyGateTransport() *gateTransport {
+	return &gateTransport{
+		agentState: "running",
+		initStatus: http.StatusOK,
+		initBody: map[string]any{
+			"ready": true,
+			"lemonade": map[string]any{
+				"reachable": true, "base_url": "http://localhost:8000/api/v1",
+				"version": "8.2.0", "min_version": "8.1.0", "compatible": true,
+			},
+			"model": map[string]any{
+				"id": "Gemma-4-E4B-it-GGUF", "present": true, "ctx_size": 32768,
+			},
+		},
+		connectors: map[string]any{
+			"agent_id": "email",
+			"providers": []map[string]any{
+				{"provider": "google", "connected": true, "account_email": "user@gmail.com",
+					"can_send": true, "scopes": []string{"gmail.send"}},
+			},
+		},
+	}
+}
+
+func (g *gateTransport) Attach(context.Context) (preflight.DaemonInfo, error) {
+	if g.attachErr != nil {
+		return preflight.DaemonInfo{}, g.attachErr
+	}
+	return preflight.DaemonInfo{PID: 4242, Port: 13337, APIVersion: "1.1"}, nil
+}
+
+func (g *gateTransport) Start(ctx context.Context) (preflight.DaemonInfo, error) {
+	g.starts++
+	g.attachErr = nil
+	return g.Attach(ctx)
+}
+
+func (g *gateTransport) EnsureAgent(context.Context, string) error {
+	g.ensures++
+	g.agentState = "running"
+	return nil
+}
+
+func (g *gateTransport) Do(_ context.Context, _, path string, _ []byte) (preflight.Response, error) {
+	switch {
+	case path == daemon.APIPrefix+"/agents":
+		agents := []map[string]any{}
+		if g.agentState != "" {
+			pid := 5150
+			for _, id := range []string{"email", "analyst"} {
+				agents = append(agents, map[string]any{
+					"agent_id": id, "state": g.agentState, "pid": pid,
+					"agent_version": "0.5.0", "api_version": "1.0",
+				})
+			}
+		}
+		return jsonResponse(http.StatusOK, map[string]any{"agents": agents})
+	case strings.HasSuffix(path, "/init"):
+		if answer, ok := g.initByAgent[agentFromPath(path)]; ok {
+			return jsonResponse(answer.status, answer.body)
+		}
+		return jsonResponse(g.initStatus, g.initBody)
+	case strings.HasSuffix(path, "/connectors"):
+		return jsonResponse(http.StatusOK, g.connectors)
+	}
+	return preflight.Response{}, fmt.Errorf("gateTransport: no canned answer for %s", path)
+}
+
+func (g *gateTransport) Stream(context.Context, string, string, []byte) (preflight.Stream, error) {
+	return preflight.Stream{}, fmt.Errorf("gateTransport: streaming is not wired in this test")
+}
+
+// initAnswer is one agent's canned /init reply.
+type initAnswer struct {
+	status int
+	body   map[string]any
+}
+
+// agentFromPath pulls the agent id out of "/v1/<agent>/init".
+func agentFromPath(path string) string {
+	parts := strings.Split(strings.Trim(path, "/"), "/")
+	if len(parts) >= 2 {
+		return parts[1]
+	}
+	return ""
+}
+
+func jsonResponse(status int, body map[string]any) (preflight.Response, error) {
+	raw, err := json.Marshal(body)
+	if err != nil {
+		return preflight.Response{}, err
+	}
+	return preflight.Response{Status: status, Body: raw}, nil
+}
+
+// modelMissing turns the transport into the commonest real failure: everything
+// up and running, the model never downloaded.
+func (g *gateTransport) modelMissing() *gateTransport {
+	g.initStatus = http.StatusServiceUnavailable
+	g.initBody = map[string]any{
+		"ready": false,
+		"lemonade": map[string]any{
+			"reachable": true, "base_url": "http://localhost:8000/api/v1",
+			"version": "8.2.0", "min_version": "8.1.0", "compatible": true,
+		},
+		"model": map[string]any{"id": "Gemma-4-E4B-it-GGUF", "present": false},
+		"hint":  "the model is not downloaded yet",
+	}
+	return g
+}
+
+// mailboxMissing leaves every generic row green with no mailbox connected — the
+// state that asks the host to open a connector flow.
+func (g *gateTransport) mailboxMissing() *gateTransport {
+	g.connectors = map[string]any{"agent_id": "email", "providers": []map[string]any{}}
+	return g
+}
+
+// --- a root driver ----------------------------------------------------------
+
+type rootDriver struct {
+	t   *testing.T
+	m   root.RootModel
+	cat *catalog.Catalog
+	tr  preflight.Transport
+}
+
+// transport is the fake the gate is pointed at, for asserting what the gate did
+// or did not ask the daemon to do.
+func (d *rootDriver) transport() *gateTransport {
+	g, ok := d.tr.(*gateTransport)
+	if !ok {
+		d.t.Fatalf("the driver's transport is %T, not a gateTransport", d.tr)
+	}
+	return g
+}
+
+// newRootDriver builds a root model whose gate is pointed at g, with the ready
+// hold squeezed to keep the tests fast.
+func newRootDriver(t *testing.T, g preflight.Transport, w, h int) *rootDriver {
+	t.Helper()
+	return newRootDriverOpts(t, g, w, h, preflight.Options{ReadyHold: time.Millisecond})
+}
+
+// newRootDriverOpts is newRootDriver with the gate's options spelled out —
+// ManualProceed keeps an all-green gate on screen so it can be looked at.
+func newRootDriverOpts(t *testing.T, g preflight.Transport, w, h int, opts preflight.Options) *rootDriver {
+	t.Helper()
+	cat := catalog.NewCatalog()
+	cat.MarkInstalled("email", "0.5.0")
+	m := root.NewRootModelWithHub(cat, nil, false).WithPreflight(g, opts)
+	d := &rootDriver{t: t, m: m, cat: cat, tr: g}
+	d.send(windowSize(w, h))
+	return d
+}
+
+func (d *rootDriver) send(msg tea.Msg) {
+	d.t.Helper()
+	updated, cmd := d.m.Update(msg)
+	d.m = updated.(root.RootModel)
+	d.pump(cmd)
+}
+
+// sendNoPump delivers one message and hands back the command it produced WITHOUT
+// running it — for the tests where the point is work that is still in flight.
+func (d *rootDriver) sendNoPump(msg tea.Msg) tea.Cmd {
+	d.t.Helper()
+	updated, cmd := d.m.Update(msg)
+	d.m = updated.(root.RootModel)
+	return cmd
+}
+
+// pump runs every command the model produced, feeding results back in.
+func (d *rootDriver) pump(cmd tea.Cmd) {
+	d.t.Helper()
+	queue := []tea.Cmd{cmd}
+	for steps := 0; len(queue) > 0; steps++ {
+		if steps > maxPumpSteps {
+			d.t.Fatalf("command loop did not settle after %d steps", maxPumpSteps)
+		}
+		next := queue[0]
+		queue = queue[1:]
+		if next == nil {
+			continue
+		}
+		msg := next()
+		if msg == nil {
+			continue
+		}
+		if batch, ok := msg.(tea.BatchMsg); ok {
+			queue = append(queue, batch...)
+			continue
+		}
+		// A spinner re-arms its own tick for as long as the screen is busy, and
+		// the cursor blinks forever. Real Bubble Tea keeps ticking; a test loop
+		// must not. Routing of a spinner tick is asserted on its own below.
+		if isCursorBlink(msg) || isSpinnerTick(msg) {
+			continue
+		}
+		updated, follow := d.m.Update(msg)
+		d.m = updated.(root.RootModel)
+		queue = append(queue, follow)
+	}
+}
+
+func isSpinnerTick(msg tea.Msg) bool {
+	_, ok := msg.(spinner.TickMsg)
+	return ok
+}
+
+func (d *rootDriver) screen() string { return stripAnsi(d.m.View()) }
+
+// flat is the screen with every run of whitespace collapsed, so an assertion is
+// about what the screen says rather than where a line happened to wrap.
+func (d *rootDriver) flat() string {
+	return strings.Join(strings.Fields(d.screen()), " ")
+}
+
+func (d *rootDriver) view() string { return d.m.ControlSnapshot().View }
+
+// launchEmail sends the message the hub sends when the user presses enter on an
+// installed, daemon-backed agent.
+func (d *rootDriver) launchEmail() {
+	d.t.Helper()
+	agent := d.cat.Get("email")
+	if agent == nil {
+		d.t.Fatal("the email agent is missing from the catalog")
+	}
+	if agent.Transport != catalog.TransportDaemon {
+		d.t.Fatalf("email transport = %s, want daemon — the gate only guards relayed agents", agent.Transport)
+	}
+	d.send(hub.LaunchAgentMsg{Agent: *agent})
+}
+
+// --- the seam ---------------------------------------------------------------
+
+// The bug this whole change exists to fix: a launch used to go straight to chat.
+func TestLaunchingAnAgentShowsPreflightNotChat(t *testing.T) {
+	// A gate that is still checking: the daemon answer is what the screen is
+	// waiting on, so the first frame must be the gate.
+	g := readyGateTransport()
+	d := newRootDriver(t, g, 80, 24)
+
+	// Deliberately unpumped: the point is the FIRST frame after the launch, not
+	// where the checks eventually land.
+	updated, _ := d.m.Update(hub.LaunchAgentMsg{Agent: *d.cat.Get("email")})
+	d.m = updated.(root.RootModel)
+
+	if got := d.view(); got != "preflight" {
+		t.Fatalf("view after launch = %q, want preflight", got)
+	}
+	screen := d.flat()
+	if !strings.Contains(screen, "Getting Email ready") {
+		t.Errorf("the gate is not what got rendered:\n%s", d.screen())
+	}
+	if strings.Contains(screen, "Welcome to GAIA") {
+		t.Error("chat opened without passing the gate")
+	}
+	if snap := d.m.ControlSnapshot(); snap.Agent != "email" {
+		t.Errorf("snapshot agent = %q, want email", snap.Agent)
+	}
+}
+
+// An all-green gate hands off on its own. It must reach chat — through the same
+// launch path the hub used to call directly.
+func TestAnAllGreenGateReachesChat(t *testing.T) {
+	d := newRootDriver(t, readyGateTransport(), 80, 24)
+	d.launchEmail()
+
+	if got := d.view(); got != "chat" {
+		t.Fatalf("view after an all-green gate = %q, want chat\n%s", got, d.screen())
+	}
+	if snap := d.m.ControlSnapshot(); snap.Agent != "email" {
+		t.Errorf("chat agent = %q, want email", snap.Agent)
+	}
+	if !strings.Contains(d.flat(), "Email") {
+		t.Errorf("the chat view does not name the agent:\n%s", d.screen())
+	}
+	if got := d.cat.Get("email").Status; got != catalog.StatusActive {
+		t.Errorf("catalog status after launch = %s, want active", got)
+	}
+}
+
+// A proved-broken precondition must hold the user on the gate with something to
+// do about it — and must not start the agent behind that failure.
+func TestAFailingPreconditionKeepsTheUserOnTheGate(t *testing.T) {
+	d := newRootDriver(t, readyGateTransport().modelMissing(), 80, 24)
+	d.launchEmail()
+
+	if got := d.view(); got != "preflight" {
+		t.Fatalf("view with a missing model = %q, want preflight\n%s", got, d.screen())
+	}
+	screen := d.flat()
+	for _, want := range []string{
+		"AI model",          // the row
+		"not downloaded",    // what is wrong
+		"run: gaia init",    // the remedy command
+		"f download it now", // the one-key fix
+	} {
+		if !strings.Contains(screen, want) {
+			t.Errorf("the gate does not show %q:\n%s", want, d.screen())
+		}
+	}
+
+	// enter must not talk its way past a real blocker.
+	d.send(keyEnter())
+	if got := d.view(); got != "preflight" {
+		t.Fatalf("enter past a blocked gate landed on %q", got)
+	}
+	if !strings.Contains(d.flat(), "cannot start yet") {
+		t.Errorf("enter on a blocked gate said nothing:\n%s", d.screen())
+	}
+	// "Did not launch" is about the agent, not just the view: nothing may have
+	// asked the daemon to spawn a sidecar behind that failure.
+	if g := d.transport(); g.ensures != 0 || g.starts != 0 {
+		t.Errorf("a blocked gate started things anyway: %d ensures, %d daemon starts", g.ensures, g.starts)
+	}
+	if got := d.cat.Get("email").Status; got == catalog.StatusActive {
+		t.Error("a blocked gate marked the agent active")
+	}
+}
+
+// `f` on a stopped sidecar is the gate's most-used fix. Root has to carry the
+// fix's result back to it, or the screen spins forever on work that finished.
+func TestFixingAStoppedSidecarFromTheGateReachesChat(t *testing.T) {
+	g := readyGateTransport()
+	g.agentState = "stopped"
+	d := newRootDriver(t, g, 80, 24)
+	d.launchEmail()
+
+	screen := d.flat()
+	if !strings.Contains(screen, "installed, not started") {
+		t.Fatalf("the gate does not report the stopped sidecar:\n%s", d.screen())
+	}
+	if !strings.Contains(screen, "f start the agent") {
+		t.Errorf("the stopped-sidecar row offers no fix:\n%s", d.screen())
+	}
+
+	d.send(key("f"))
+	if g.ensures != 1 {
+		t.Fatalf("f asked the daemon to start the agent %d times, want 1", g.ensures)
+	}
+	// The fix re-checks and everything else was already green, so it hands off.
+	if got := d.view(); got != "chat" {
+		t.Fatalf("after the fix the gate landed on %q, want chat\n%s", got, d.screen())
+	}
+}
+
+// esc backs out to a hub that still has a highlighted row (#2481), and says why
+// the launch did not happen.
+func TestCancellingTheGateReturnsToAUsableHub(t *testing.T) {
+	d := newRootDriver(t, readyGateTransport().modelMissing(), 80, 24)
+
+	// Drive the hub the way a user does, so the selection under test is a real
+	// one rather than one the test set up.
+	d.selectInHub("email")
+	before := d.m.ControlSnapshot()
+	d.send(keyEnter())
+	if got := d.view(); got != "preflight" {
+		t.Fatalf("enter in the hub landed on %q, want preflight", got)
+	}
+
+	d.send(keyEsc())
+	snap := d.m.ControlSnapshot()
+	if snap.View != "hub" {
+		t.Fatalf("esc from the gate landed on %q, want hub\n%s", snap.View, d.screen())
+	}
+	if snap.SelectedAgentID == "" {
+		t.Error("the hub came back with nothing selected")
+	}
+	if snap.SelectedAgentID != before.SelectedAgentID {
+		t.Errorf("selection moved across the gate: %q → %q", before.SelectedAgentID, snap.SelectedAgentID)
+	}
+	if snap.HubTabIndex != before.HubTabIndex {
+		t.Errorf("tab moved across the gate: %d → %d", before.HubTabIndex, snap.HubTabIndex)
+	}
+	if !strings.Contains(d.flat(), "did not start") {
+		t.Errorf("the hub does not say why the launch stopped:\n%s", d.screen())
+	}
+	if got := d.cat.Get("email").Status; got == catalog.StatusActive {
+		t.Error("a cancelled launch left the agent marked active")
+	}
+}
+
+// selectInHub moves the hub cursor onto agentID using only keys and the control
+// snapshot — the same surface automation drives.
+func (d *rootDriver) selectInHub(agentID string) {
+	d.t.Helper()
+	for tab := 0; tab < 6; tab++ {
+		snap := d.m.ControlSnapshot()
+		for i, id := range snap.VisibleAgentIDs {
+			if id != agentID {
+				continue
+			}
+			for j := 0; j < i; j++ {
+				d.send(keyDown())
+			}
+			if got := d.m.ControlSnapshot().SelectedAgentID; got != agentID {
+				d.t.Fatalf("selecting %q landed on %q", agentID, got)
+			}
+			return
+		}
+		d.send(keyTab())
+	}
+	d.t.Fatalf("no tab in the hub lists %q", agentID)
+}
+
+// A gate that has been left must not launch the agent afterwards: the hold tick
+// it scheduled can still be in flight.
+func TestALateProceedFromAnAbandonedGateLaunchesNothing(t *testing.T) {
+	d := newRootDriver(t, readyGateTransport().modelMissing(), 80, 24)
+	d.launchEmail()
+	d.send(keyEsc())
+	if got := d.view(); got != "hub" {
+		t.Fatalf("esc landed on %q, want hub", got)
+	}
+
+	d.send(preflight.ProceedMsg{AgentID: "email"})
+	if got := d.view(); got != "hub" {
+		t.Fatalf("a late ProceedMsg opened %q", got)
+	}
+	if got := d.cat.Get("email").Status; got == catalog.StatusActive {
+		t.Error("a late ProceedMsg launched the agent anyway")
+	}
+}
+
+// analystAgent is a second daemon-backed agent, for the two-gates race below.
+func analystAgent() catalog.Agent {
+	return catalog.Agent{
+		ID: "analyst", Name: "Analyst", Status: catalog.StatusInstalled,
+		Transport: catalog.TransportDaemon,
+	}
+}
+
+// The nastiest race in this seam: a probe started for one agent, answered after
+// the user backed out and launched another. Its report must not drive the second
+// agent's gate — an all-green report for A would otherwise green-light B and open
+// a chat for an agent nothing ever probed.
+func TestAnAbandonedGatesReportCannotGreenLightAnotherAgent(t *testing.T) {
+	g := readyGateTransport()
+	// Email would pass; Analyst is blocked on its model. So if Email's stale
+	// report reaches Analyst's gate, it turns a blocked screen into a launch.
+	g.initByAgent = map[string]initAnswer{
+		"analyst": {status: http.StatusServiceUnavailable, body: readyGateTransport().modelMissing().initBody},
+	}
+	d := newRootDriver(t, g, 80, 24)
+
+	// Gate 1 for email, its probe captured and NOT run yet — this is the in-flight
+	// probe the user walks away from.
+	emailProbe := d.sendNoPump(hub.LaunchAgentMsg{Agent: *d.cat.Get("email")})
+	d.send(keyEsc())
+
+	// Gate 2 for a different agent, blocked and waiting for the user.
+	d.send(hub.LaunchAgentMsg{Agent: analystAgent()})
+	if got := d.view(); got != "preflight" {
+		t.Fatalf("the second launch landed on %q, want preflight\n%s", got, d.screen())
+	}
+
+	// Email's probe finally answers, into Analyst's gate.
+	d.pump(emailProbe)
+
+	if got := d.view(); got != "preflight" {
+		t.Fatalf("a stale report launched %q\n%s", got, d.screen())
+	}
+	screen := d.flat()
+	if !strings.Contains(screen, "Getting Analyst ready") {
+		t.Errorf("the gate is no longer the one that was on screen:\n%s", d.screen())
+	}
+	// The Mailbox row exists only in email's report: seeing it here means the
+	// stale report was adopted.
+	if strings.Contains(screen, "Mailbox") {
+		t.Errorf("email's rows are being shown on the Analyst gate:\n%s", d.screen())
+	}
+	if !strings.Contains(screen, "not downloaded") {
+		t.Errorf("Analyst's own blocked row was replaced:\n%s", d.screen())
+	}
+	if got := d.cat.Get("email").Status; got == catalog.StatusActive {
+		t.Error("the abandoned gate launched email anyway")
+	}
+}
+
+// A subprocess agent has no daemon relay, so the gate has nothing to probe and
+// must not invent four failures over a launch that works.
+func TestASubprocessAgentIsNotGated(t *testing.T) {
+	d := newRootDriver(t, readyGateTransport(), 80, 24)
+	d.send(hub.LaunchAgentMsg{Agent: catalog.Agent{
+		ID: "bash", Name: "Bash", Status: catalog.StatusInstalled,
+		Transport: catalog.TransportSubprocess, BinaryPath: "/bin/echo",
+	}})
+	if got := d.view(); got != "chat" {
+		t.Fatalf("a subprocess launch landed on %q, want chat\n%s", got, d.screen())
+	}
+}
+
+// --- the mailbox hand-off ---------------------------------------------------
+
+// ConnectMailboxMsg must produce a real instruction. The TUI has no connector
+// screen, so the honest answer is the exact command plus a way back.
+func TestConnectMailboxNamesTheCommandToRun(t *testing.T) {
+	d := newRootDriver(t, readyGateTransport().mailboxMissing(), 80, 24)
+	d.launchEmail()
+
+	if got := d.view(); got != "preflight" {
+		t.Fatalf("an unconnected mailbox landed on %q, want preflight\n%s", got, d.screen())
+	}
+	d.send(key("f"))
+
+	snap := d.m.ControlSnapshot()
+	if snap.Overlay != "connect-mailbox" {
+		t.Fatalf("f on the mailbox row produced overlay %q\n%s", snap.Overlay, d.screen())
+	}
+	screen := d.flat()
+	for _, want := range []string{
+		"Connect a mailbox for Email",
+		"gaia connectors connect google",
+		"--grant-agent installed:email",
+		"gmail.send",
+		"Outlook",
+		"https://amd-gaia.ai/docs/connectors/microsoft",
+		"r re-check",
+	} {
+		if !strings.Contains(screen, want) {
+			t.Errorf("the hand-off does not show %q:\n%s", want, d.screen())
+		}
+	}
+	// The gate's own advice for this row is "press f to choose" — repeating it
+	// here would send the user back around the loop they just came through.
+	if strings.Contains(screen, "press f to choose") {
+		t.Errorf("the hand-off tells the user to press f again:\n%s", d.screen())
+	}
+	if strings.Contains(strings.ToLower(screen), "coming soon") {
+		t.Errorf("the hand-off is a dead end:\n%s", d.screen())
+	}
+}
+
+// A mailbox that is connected but cannot send is a different failure with a
+// different command, and the hand-off must name that provider's own command
+// rather than a chooser.
+func TestConnectMailboxForAConnectedProviderShowsThatProvider(t *testing.T) {
+	g := readyGateTransport()
+	g.connectors = map[string]any{
+		"agent_id": "email",
+		"providers": []map[string]any{
+			{"provider": "microsoft", "connected": true, "account_email": "user@outlook.com",
+				"can_send": false, "scopes": []string{"Mail.Read"}},
+		},
+	}
+	d := newRootDriver(t, g, 80, 24)
+	d.launchEmail()
+	d.send(key("f"))
+
+	screen := d.flat()
+	if !strings.Contains(screen, "Reconnect Outlook for Email") {
+		t.Errorf("the hand-off does not name the connected provider:\n%s", d.screen())
+	}
+	if !strings.Contains(screen, "gaia connectors connect microsoft") {
+		t.Errorf("the hand-off does not name the Outlook command:\n%s", d.screen())
+	}
+	if strings.Contains(screen, "connect google") {
+		t.Errorf("the hand-off offers Gmail to an Outlook user:\n%s", d.screen())
+	}
+}
+
+// On a terminal too short for the whole hand-off, the command is the last thing
+// that may be dropped — a screen that keeps the explanation and loses the fix
+// names a problem and takes away the answer.
+func TestAShortTerminalKeepsTheHandoffCommand(t *testing.T) {
+	for _, rows := range []int{24, 16, 12, 10} {
+		d := newRootDriver(t, readyGateTransport().mailboxMissing(), 80, 24)
+		d.launchEmail()
+		d.send(key("f"))
+		d.send(windowSize(80, rows))
+
+		screen := d.screen()
+		if got := len(strings.Split(screen, "\n")); got > rows {
+			t.Errorf("at %d rows the hand-off renders %d lines:\n%s", rows, got, screen)
+		}
+		flat := strings.Join(strings.Fields(screen), " ")
+		// The whole command, scopes included — a half-command is worse than none.
+		for _, want := range []string{
+			"gaia connectors connect google --grant-agent installed:email",
+			"gmail.send",
+			"esc back to the checks",
+		} {
+			if !strings.Contains(flat, want) {
+				t.Errorf("at %d rows the hand-off lost %q:\n%s", rows, want, screen)
+			}
+		}
+	}
+}
+
+// If the check ever produces a command for a different provider than the mailbox
+// it is describing, the screen must not let its own title vouch for it.
+func TestAMismatchedProviderCommandIsFlagged(t *testing.T) {
+	g := readyGateTransport()
+	// A provider the connect-command builder has no scope list for: it falls back
+	// to the Google command, which is not what this mailbox needs.
+	g.connectors = map[string]any{
+		"agent_id": "email",
+		"providers": []map[string]any{
+			{"provider": "yahoo", "connected": true, "account_email": "user@yahoo.com",
+				"can_send": false, "scopes": []string{}},
+		},
+	}
+	d := newRootDriver(t, g, 80, 24)
+	d.launchEmail()
+	d.send(key("f"))
+
+	flat := d.flat()
+	if !strings.Contains(flat, "Heads up") {
+		t.Errorf("a Gmail command under a yahoo mailbox is presented as correct:\n%s", d.screen())
+	}
+	if !strings.Contains(flat, "report it") {
+		t.Errorf("the mismatch is not reportable:\n%s", d.screen())
+	}
+}
+
+// esc dismisses the hand-off back to the gate — not out of the launch behind it.
+func TestEscFromTheHandoffReturnsToTheGate(t *testing.T) {
+	d := newRootDriver(t, readyGateTransport().mailboxMissing(), 80, 24)
+	d.launchEmail()
+	d.send(key("f"))
+	d.send(keyEsc())
+
+	snap := d.m.ControlSnapshot()
+	if snap.View != "preflight" || snap.Overlay != "" {
+		t.Fatalf("esc from the hand-off left view=%q overlay=%q, want the bare gate",
+			snap.View, snap.Overlay)
+	}
+	if !strings.Contains(d.flat(), "Getting Email ready") {
+		t.Errorf("esc did not come back to the gate:\n%s", d.screen())
+	}
+}
+
+// r from the hand-off re-checks, so a user who just connected a mailbox in
+// another terminal is not told to press anything else.
+func TestRFromTheHandoffRechecksAndProceeds(t *testing.T) {
+	g := readyGateTransport().mailboxMissing()
+	d := newRootDriver(t, g, 80, 24)
+	d.launchEmail()
+	d.send(key("f"))
+
+	// The user connects the mailbox in another terminal.
+	g.connectors = readyGateTransport().connectors
+	d.send(key("r"))
+
+	if got := d.view(); got != "chat" {
+		t.Fatalf("re-checking a fixed mailbox landed on %q, want chat\n%s", got, d.screen())
+	}
+}
+
+// --- routing and layout ----------------------------------------------------
+
+// The gate is a spinner-driven screen. If ticks and resizes do not reach it, it
+// freezes mid-check and a resized terminal renders at the old size.
+func TestTheGateGetsSpinnerAndResizeMessages(t *testing.T) {
+	d := newRootDriver(t, readyGateTransport(), 80, 24)
+
+	// Unpumped on purpose: this is the gate mid-check, which is the state whose
+	// spinner the user actually watches.
+	updated, _ := d.m.Update(hub.LaunchAgentMsg{Agent: *d.cat.Get("email")})
+	d.m = updated.(root.RootModel)
+	if !strings.Contains(d.flat(), "checking") {
+		t.Fatalf("the gate is not mid-check:\n%s", d.screen())
+	}
+
+	before := d.screen()
+	spun := false
+	for i := 0; i < 12 && !spun; i++ {
+		updated, _ := d.m.Update(spinner.TickMsg{Time: time.Now()})
+		d.m = updated.(root.RootModel)
+		spun = d.screen() != before
+	}
+	if !spun {
+		t.Errorf("spinner ticks do not reach the gate — it renders frozen:\n%s", d.screen())
+	}
+
+	d.send(windowSize(120, 40))
+	for _, line := range strings.Split(d.screen(), "\n") {
+		if w := ansi.StringWidth(line); w > 120 {
+			t.Fatalf("after a resize a line is %d columns wide", w)
+		}
+	}
+	if !strings.Contains(d.screen(), strings.Repeat("─", 100)) {
+		t.Errorf("the gate did not widen with the terminal:\n%s", d.screen())
+	}
+}
+
+// The gate defaults to 80x24 internally, so a launch that forgets to hand it the
+// real terminal size renders narrow on a wide terminal and nothing else fails.
+func TestTheGateIsBornAtTheTerminalSize(t *testing.T) {
+	d := newRootDriver(t, readyGateTransport().modelMissing(), 100, 30)
+	d.launchEmail()
+
+	if got := d.view(); got != "preflight" {
+		t.Fatalf("view = %q, want preflight", got)
+	}
+	if !strings.Contains(d.screen(), strings.Repeat("─", 96)) {
+		t.Errorf("the gate rendered narrower than the 100-column terminal:\n%s", d.screen())
+	}
+}
+
+// The hub was fixed to fit the minimum terminal; the gate in front of it has to
+// fit too, in every state a user can be in.
+//
+// Row count alone is a tautology here — both views clamp themselves to the height
+// they are given, so they can always "fit" by dropping the very thing the user
+// needs. Each case therefore names what has to still be on screen at 80x24.
+func TestEveryGateStateFitsEightyByTwentyFour(t *testing.T) {
+	cases := []struct {
+		name  string
+		build func() *gateTransport
+		keys  []tea.KeyMsg
+		// hold keeps an all-green gate on screen; without it the case would
+		// measure the chat view the gate hands off to.
+		hold bool
+		// wants is what must survive the fit at the minimum size.
+		wants []string
+	}{
+		{name: "all ready", build: readyGateTransport, hold: true,
+			wants: []string{"Getting Email ready", "ready", "Mailbox", "esc back"}},
+		{name: "model missing", build: func() *gateTransport { return readyGateTransport().modelMissing() },
+			wants: []string{"AI model", "not downloaded", "run: gaia init", "esc back"}},
+		{name: "model missing, details", build: func() *gateTransport { return readyGateTransport().modelMissing() },
+			keys:  []tea.KeyMsg{key("d")},
+			wants: []string{"AI model — failed", "esc back"}},
+		{name: "mailbox missing", build: func() *gateTransport { return readyGateTransport().mailboxMissing() },
+			wants: []string{"Mailbox", "not connected", "gaia connectors connect google", "esc back"}},
+		{name: "mailbox hand-off", build: func() *gateTransport { return readyGateTransport().mailboxMissing() },
+			keys:  []tea.KeyMsg{key("f")},
+			wants: []string{"Connect a mailbox for Email", "gmail.send", "esc back to the checks"}},
+		{name: "daemon down", build: func() *gateTransport {
+			g := readyGateTransport()
+			g.attachErr = &daemon.NotRunningError{Path: "/tmp/instance.json"}
+			return g
+		}, wants: []string{"Background service", "not running", "f start it for me", "esc back"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			opts := preflight.Options{ReadyHold: time.Millisecond, ManualProceed: tc.hold}
+			d := newRootDriverOpts(t, tc.build(), 80, 24, opts)
+			d.launchEmail()
+			for _, k := range tc.keys {
+				d.send(k)
+			}
+			if got := d.view(); got != "preflight" {
+				t.Fatalf("this case is not measuring the gate — view = %q\n%s", got, d.screen())
+			}
+			lines := strings.Split(d.screen(), "\n")
+			if len(lines) > 24 {
+				t.Errorf("renders %d lines into 24 rows:\n%s", len(lines), d.screen())
+			}
+			for i, line := range lines {
+				if w := ansi.StringWidth(line); w > 80 {
+					t.Errorf("line %d is %d columns wide: %q", i, w, line)
+				}
+			}
+			flat := strings.Join(strings.Fields(d.screen()), " ")
+			for _, want := range tc.wants {
+				if !strings.Contains(flat, want) {
+					t.Errorf("at 80x24 the screen lost %q:\n%s", want, d.screen())
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
Every way the daemon path can fail — daemon down, token rotated, version gate, model missing, mailbox not connected — reached the user as a raw HTTP status, discovered one wall at a time. The gate reports all of it as checkable rows, each with a remedy.

Its own review found remedies that damaged what they claimed to fix: the mailbox rows named commands that **overwrite** an agent's existing scopes, so following the advice turned "connected, can read, cannot send" into "can send, cannot read" — and the row then went green over a mailbox that was strictly worse off. A relay 503 also decoded as "Lemonade unreachable", sending users to a component that was not the problem.

An unverifiable condition renders as unknown and keeps the check failing, but no longer demands a keypress the user cannot act on — a prompt shown on every launch that nobody can satisfy just trains people to dismiss prompts.

### Test plan
- [ ] `cd tui && make lint && go test ./... -count=1 -race`
- [ ] Each row's remedy names a command that exists and does not reduce existing access
- [ ] A version the server does not advertise renders as unknown, not as a pass
- [ ] Renders inside 80x24
