### PR TITLE
feat(tui): run the readiness gate on every agent launch

### DIFF
--- a/tui/internal/ui/root/introspect.go
+++ b/tui/internal/ui/root/introspect.go
@@ -19,6 +19,14 @@ func (m RootModel) ControlSnapshot() control.Snapshot {
 		snap.VisibleAgentIDs = m.hub.VisibleAgentIDs()
 		snap.Filtering = m.hub.IsFiltering()
 		snap.Overlay = m.hub.Overlay()
+	case viewPreflight:
+		snap.View = "preflight"
+		if m.preflight != nil {
+			snap.Agent = m.preflight.AgentID()
+		}
+		if m.connect != nil {
+			snap.Overlay = "connect-mailbox"
+		}
 	case viewChat:
 		snap.View = "chat"
 		if m.chat != nil {

--- a/tui/internal/ui/root/model.go
+++ b/tui/internal/ui/root/model.go
@@ -11,12 +11,16 @@ import (
 	"github.com/amd/gaia/tui/internal/ui/chat"
 	"github.com/amd/gaia/tui/internal/ui/components"
 	"github.com/amd/gaia/tui/internal/ui/hub"
+	"github.com/amd/gaia/tui/internal/ui/preflight"
 )
 
 type view int
 
 const (
 	viewHub view = iota
+	// viewPreflight is the readiness gate every daemon-backed launch passes
+	// through before chat opens.
+	viewPreflight
 	viewChat
 )
 
@@ -31,6 +35,25 @@ type RootModel struct {
 	width      int
 	height     int
 	debug      bool
+
+	// preflight is the gate currently on screen, nil when there is none.
+	preflight *preflight.Model
+	// pending is the agent that gate is guarding — launched only on ProceedMsg.
+	pending *catalog.Agent
+	// connect is the mailbox hand-off shown over the gate, nil when there is none.
+	connect *connectHandoff
+	// pfTransport is built on first launch and reused for the session.
+	pfTransport preflight.Transport
+	pfOpts      preflight.Options
+}
+
+// WithPreflight points the readiness gate at a specific transport and tunes its
+// options. Tests use it to drive the gate against a fake daemon; a real session
+// leaves it alone and gets the daemon transport.
+func (m RootModel) WithPreflight(t preflight.Transport, opts preflight.Options) RootModel {
+	m.pfTransport = t
+	m.pfOpts = opts
+	return m
 }
 
 func NewRootModel(cat *catalog.Catalog, debug bool) RootModel {
@@ -73,6 +96,8 @@ func (m RootModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			updated, cmd := m.hub.Update(msg)
 			m.hub = updated.(hub.HubModel)
 			return m, cmd
+		case viewPreflight:
+			return m.updatePreflight(msg)
 		case viewChat:
 			if m.chat != nil {
 				updated, cmd := m.chat.Update(msg)
@@ -84,7 +109,25 @@ func (m RootModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, nil
 
 	case hub.LaunchAgentMsg:
-		return m.launchAgent(msg.Agent)
+		return m.beginPreflight(msg.Agent)
+
+	case preflight.ProceedMsg:
+		if !m.gateIsFor(msg.AgentID) {
+			return m, nil
+		}
+		return m.proceedFromGate()
+
+	case preflight.CancelMsg:
+		if !m.gateIsFor(msg.AgentID) {
+			return m, nil
+		}
+		return m.cancelFromGate()
+
+	case preflight.ConnectMailboxMsg:
+		if !m.gateIsFor(msg.AgentID) {
+			return m, nil
+		}
+		return m.openConnectHandoff(msg.Provider)
 
 	case chat.ReturnToHubMsg:
 		return m.returnToHub(msg.AgentID)
@@ -105,6 +148,11 @@ func (m RootModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.showHelp = false
 			return m, nil
 		}
+		// The mailbox hand-off owns every key while it is up, the way the hub's
+		// modals do — otherwise esc would cancel the launch behind it.
+		if m.activeView == viewPreflight && m.connect != nil {
+			return m.handleConnectKey(msg)
+		}
 	}
 
 	// The hub's async results go to the hub whatever is on screen. They are
@@ -121,6 +169,11 @@ func (m RootModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		updated, cmd := m.hub.Update(msg)
 		m.hub = updated.(hub.HubModel)
 		return m, cmd
+	case viewPreflight:
+		// Everything the gate started answers with a message this package cannot
+		// name — the probe result, a fix outcome, download progress, the hold
+		// tick — so the gate gets the whole default stream, spinner ticks and all.
+		return m.updatePreflight(msg)
 	case viewChat:
 		if m.chat != nil {
 			updated, cmd := m.chat.Update(msg)
@@ -138,6 +191,13 @@ func (m RootModel) View() string {
 	switch m.activeView {
 	case viewHub:
 		base = m.hub.View()
+	case viewPreflight:
+		switch {
+		case m.connect != nil:
+			base = m.connect.view(m.width, m.height)
+		case m.preflight != nil:
+			base = m.preflight.View()
+		}
 	case viewChat:
 		if m.chat != nil {
 			base = m.chat.View()

--- a/tui/internal/ui/root/preflight.go
+++ b/tui/internal/ui/root/preflight.go
@@ -1,0 +1,323 @@
+package root
+
+import (
+	"fmt"
+	"strings"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+
+	"github.com/amd/gaia/tui/internal/catalog"
+	"github.com/amd/gaia/tui/internal/daemon"
+	"github.com/amd/gaia/tui/internal/ui/preflight"
+)
+
+// beginPreflight puts the readiness gate between the hub and the chat.
+//
+// The gate runs on EVERY launch and nothing is remembered between them. Each row
+// is a fact with no expiry notice — the daemon can be killed, its client token
+// rotates on every restart, Lemonade can unload the model, a mailbox grant can be
+// revoked from the web — so a cached pass would open a chat that cannot answer
+// while claiming it had been verified. An all-green pass costs one attach plus two
+// relayed GETs and is held ~800ms; that is the price of the answer being true now.
+func (m RootModel) beginPreflight(agent catalog.Agent) (tea.Model, tea.Cmd) {
+	if agent.Transport != catalog.TransportDaemon {
+		// Every precondition the gate reports is probed THROUGH the daemon relay
+		// (GET /v1/<agent>/init). A subprocess agent has no relay and no
+		// registered sidecar, so the gate could only answer "not installed" —
+		// four wrong rows with four wrong remedies, over a launch that works.
+		return m.launchAgent(agent)
+	}
+
+	gate := preflight.New(m.preflightTransport(), preflight.ConfigFor(agent.ID, agent.Name), m.preflightOptions())
+	m.preflight = &gate
+	m.pending = &agent
+	m.connect = nil
+	m.activeView = viewPreflight
+
+	cmds := []tea.Cmd{gate.Init()}
+	if m.width > 0 && m.height > 0 {
+		cmds = append(cmds, m.sizeCmd())
+	}
+	return m, tea.Batch(cmds...)
+}
+
+// preflightTransport builds the gate's transport on first use and keeps it for
+// the session: it caches the daemon instance whose token authorized the last
+// call, and that token rotates on every daemon restart. Building it lazily also
+// keeps a session that never launches anything from constructing a daemon client.
+func (m *RootModel) preflightTransport() preflight.Transport {
+	if m.pfTransport == nil {
+		m.pfTransport = preflight.NewDaemonTransport(daemon.New(daemon.Options{Logf: m.logf}))
+	}
+	return m.pfTransport
+}
+
+// preflightOptions returns the gate's options. ManualProceed is deliberately NOT
+// wired to --debug: the gate's footer only offers `enter` while a report is
+// neither blocked nor ready, so holding an all-green screen would leave a debug
+// user on a green wall whose only advertised keys are re-check and back.
+func (m RootModel) preflightOptions() preflight.Options {
+	opts := m.pfOpts
+	if opts.Logf == nil {
+		opts.Logf = m.logf
+	}
+	return opts
+}
+
+// gateIsFor reports whether the gate on screen is the one that sent this
+// message. A ProceedMsg from a gate the user already backed out of must not
+// launch anything — the hold tick that produced it can still be in flight.
+func (m RootModel) gateIsFor(agentID string) bool {
+	return m.activeView == viewPreflight && m.preflight != nil &&
+		m.pending != nil && m.pending.ID == agentID
+}
+
+// closeGate tears the gate down. Cancel first: the screen owns a probe, a
+// sidecar start, or a model pull, and leaving one running would keep writing
+// into a screen that no longer exists.
+func (m *RootModel) closeGate() {
+	if m.preflight != nil {
+		m.preflight.Cancel()
+		m.preflight = nil
+	}
+	m.pending = nil
+	m.connect = nil
+}
+
+func (m RootModel) proceedFromGate() (tea.Model, tea.Cmd) {
+	agent := *m.pending
+	m.closeGate()
+	// Back to the hub FIRST. launchAgent stays where it is and reports the reason
+	// when a client cannot be built, and "where it is" has to be a screen that
+	// still renders — the gate is gone by now.
+	m.activeView = viewHub
+	return m.launchAgent(agent)
+}
+
+// cancelFromGate returns to the hub. The hub model is untouched while the gate is
+// up, so its tab and highlighted row are exactly where the user left them.
+func (m RootModel) cancelFromGate() (tea.Model, tea.Cmd) {
+	rep := m.preflight.Report()
+	m.closeGate()
+	m.activeView = viewHub
+
+	// Backing out of a gate that had a real blocker leaves the user staring at a
+	// hub that looks like nothing happened. Say which row stopped it.
+	if blocker, blocked := rep.Blocker(); blocked {
+		// One line, and no trailing call to action: the hub truncates its status
+		// row at the terminal width, and a hint that gets cut mid-word is worse
+		// than the footer's own "enter run".
+		m.hub.SetStatus(fmt.Sprintf("%s did not start — %s is %s",
+			rep.AgentName, blocker.Label, blocker.Line))
+	}
+
+	var cmds []tea.Cmd
+	if m.width > 0 && m.height > 0 {
+		cmds = append(cmds, m.sizeCmd())
+	}
+	return m, tea.Batch(cmds...)
+}
+
+func (m RootModel) sizeCmd() tea.Cmd {
+	w, h := m.width, m.height
+	return func() tea.Msg { return tea.WindowSizeMsg{Width: w, Height: h} }
+}
+
+// updatePreflight forwards a message to the gate.
+func (m RootModel) updatePreflight(msg tea.Msg) (tea.Model, tea.Cmd) {
+	if m.preflight == nil {
+		return m, nil
+	}
+	updated, cmd := m.preflight.Update(msg)
+	gate := updated.(preflight.Model)
+	m.preflight = &gate
+	return m, cmd
+}
+
+// --- the mailbox hand-off ---------------------------------------------------
+
+// connectHandoff is what ConnectMailboxMsg turns into.
+//
+// The TUI has no connector screen, and half of one would be worse than none:
+// OAuth already has a working implementation behind `gaia connectors`, and a
+// second one here would fork the flow that owns tokens, scopes and grants. So the
+// gate hands over the exact command — the one the mailbox row already computed,
+// with the scope union and the agent grant in it — and re-checks when the user
+// comes back. Swallowing the request, or answering it with "coming soon", would
+// leave the user on a screen that names a problem and no way past it.
+type connectHandoff struct {
+	agentName string
+	// provider is the mailbox to reconnect. Empty means the user has nothing
+	// connected and the choice of provider is still theirs.
+	provider string
+	row      preflight.Row
+	haveRow  bool
+}
+
+func (m RootModel) openConnectHandoff(provider string) (tea.Model, tea.Cmd) {
+	rep := m.preflight.Report()
+	row, ok := rep.Find(preflight.KeyMailbox)
+	m.connect = &connectHandoff{
+		agentName: rep.AgentName,
+		provider:  provider,
+		row:       row,
+		haveRow:   ok,
+	}
+	return m, nil
+}
+
+// handleConnectKey owns every key while the hand-off is up.
+func (m RootModel) handleConnectKey(key tea.KeyMsg) (tea.Model, tea.Cmd) {
+	switch key.String() {
+	case "ctrl+c":
+		// Same as everywhere else: ctrl+c leaves the app, not just the screen.
+		m.closeGate()
+		return m, tea.Quit
+	case "r":
+		// Dismiss, then let the gate's own `r` do the re-check — the screen that
+		// owns the probes owns the re-check too.
+		m.connect = nil
+		return m.updatePreflight(key)
+	case "esc", "q":
+		m.connect = nil
+		return m, nil
+	}
+	return m, nil
+}
+
+var (
+	connectTitle   = lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("150"))
+	connectDim     = lipgloss.NewStyle().Foreground(lipgloss.Color("243"))
+	connectDivider = lipgloss.NewStyle().Foreground(lipgloss.Color("238"))
+	connectText    = lipgloss.NewStyle().Foreground(lipgloss.Color("252"))
+	connectCmd     = lipgloss.NewStyle().Foreground(lipgloss.Color("150"))
+	connectKey     = lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("39"))
+)
+
+// outlookSetupDoc is where the Outlook path continues. It is a doc, not a
+// command, because Outlook needs a one-time Microsoft app registration (or the
+// device-code flow) before any connect command can succeed — and the mailbox
+// row's Gmail scopes are wrong for Microsoft, so "swap google for microsoft"
+// would hand the user a command that fails.
+const outlookSetupDoc = "https://amd-gaia.ai/docs/connectors/microsoft"
+
+func (h connectHandoff) view(width, height int) string {
+	w := width
+	if w < 40 {
+		w = 40
+	}
+
+	title := fmt.Sprintf("Connect a mailbox for %s", h.agentName)
+	if h.provider != "" {
+		title = fmt.Sprintf("Reconnect %s for %s", providerLabel(h.provider), h.agentName)
+	}
+
+	out := []string{
+		"  " + connectTitle.Render(title),
+		"  " + connectDivider.Render(strings.Repeat("─", w-4)),
+	}
+	add := func(style lipgloss.Style, text string, indent int) {
+		prefix := strings.Repeat(" ", indent)
+		for _, line := range wrapLines(text, w-indent-2) {
+			out = append(out, prefix+style.Render(line))
+		}
+	}
+
+	if h.row.Detail != "" {
+		add(connectDim, h.row.Detail, 2)
+		out = append(out, "")
+	}
+
+	switch {
+	case !h.haveRow || h.row.Remedy.Command == "":
+		// The gate asked for a mailbox and recorded no command to get one. That is
+		// a bug, and it must not read as a shrug.
+		add(connectText, "The readiness check asked for a mailbox connection but recorded no "+
+			"command for it. Report that, then connect from a terminal:", 2)
+		add(connectCmd, "gaia connectors list", 4)
+		add(connectDim, "look:  https://amd-gaia.ai/docs/guides/email", 4)
+
+	case h.provider != "":
+		add(connectText, "This cannot be done from here — it opens a browser sign-in. Run this in "+
+			"another terminal, then come back and press r.", 2)
+		out = append(out, "")
+		add(connectCmd, h.row.Remedy.Command, 4)
+		if h.row.Remedy.Where != "" {
+			out = append(out, "")
+			add(connectDim, "look:  "+h.row.Remedy.Where, 4)
+		}
+
+	default:
+		// Provider is empty: nothing is connected, so the choice is the user's.
+		// Both paths are named, and neither is a command that would fail.
+		add(connectText, "This cannot be done from here — it opens a browser sign-in. "+
+			"Pick one, run it in another terminal, then come back and press r.", 2)
+		out = append(out, "")
+		offered := providerFromCommand(h.row.Remedy.Command)
+		heading := "Run this:"
+		if offered != "" {
+			heading = providerLabel(offered) + " — one command, about a minute:"
+		}
+		add(connectText, heading, 2)
+		add(connectCmd, h.row.Remedy.Command, 4)
+		if offered != "microsoft" {
+			out = append(out, "")
+			add(connectText, "Outlook — needs a one-time Microsoft app setup first:", 2)
+			add(connectDim, outlookSetupDoc, 4)
+		}
+	}
+
+	out = append(out, "")
+	out = append(out, "  "+connectKey.Render("r")+" "+connectDim.Render("re-check")+
+		connectDim.Render(" · ")+connectKey.Render("esc")+" "+connectDim.Render("back to the checks"))
+
+	if height > 0 && len(out) > height {
+		// Keep the footer: a screen whose only exit hint was trimmed reads as a
+		// dead end. Drop from the body instead.
+		keep := out[:height-1]
+		out = append(keep[:len(keep):len(keep)], out[len(out)-1])
+	}
+	return strings.Join(out, "\n")
+}
+
+// providerFromCommand reads the connector id out of a
+// `gaia connectors connect <id> …` command, so the heading above a command can
+// never name a provider the command does not use.
+func providerFromCommand(cmd string) string {
+	fields := strings.Fields(cmd)
+	for i, f := range fields {
+		if f == "connect" && i+1 < len(fields) {
+			return fields[i+1]
+		}
+	}
+	return ""
+}
+
+func providerLabel(provider string) string {
+	switch provider {
+	case "google":
+		return "Gmail"
+	case "microsoft":
+		return "Outlook"
+	default:
+		return provider
+	}
+}
+
+// wrapLines wraps plain text to w columns, hard-breaking a single token that is
+// longer than the line — a connect command with full OAuth scope URLs in it must
+// be readable in full, never truncated.
+func wrapLines(s string, w int) []string {
+	if w < 8 {
+		w = 8
+	}
+	rendered := lipgloss.NewStyle().Width(w).Render(s)
+	lines := strings.Split(strings.TrimRight(rendered, "\n"), "\n")
+	for i := range lines {
+		// Width() pads every line to w; the padding would show up as trailing
+		// whitespace in a captured screen.
+		lines[i] = strings.TrimRight(lines[i], " ")
+	}
+	return lines
+}

--- a/tui/internal/ui/root/preflight.go
+++ b/tui/internal/ui/root/preflight.go
@@ -73,9 +73,15 @@ func (m RootModel) gateIsFor(agentID string) bool {
 		m.pending != nil && m.pending.ID == agentID
 }
 
-// closeGate tears the gate down. Cancel first: the screen owns a probe, a
-// sidecar start, or a model pull, and leaving one running would keep writing
-// into a screen that no longer exists.
+// closeGate tears the gate down, cancelling what it started: a re-check, a
+// sidecar start, a model pull.
+//
+// It does NOT stop the FIRST probe. preflight.Model.Init has a value receiver, so
+// the cancel func for the check it launches is parked on a copy that dies with
+// the call, and the model this host keeps has none. That probe therefore runs to
+// its own 90s timeout after the user leaves; its result is dropped by
+// updatePreflight rather than allowed to drive whatever is on screen. Fixing it
+// properly needs a pointer-receiver initialiser in the preflight package.
 func (m *RootModel) closeGate() {
 	if m.preflight != nil {
 		m.preflight.Cancel()
@@ -124,13 +130,26 @@ func (m RootModel) sizeCmd() tea.Cmd {
 	return func() tea.Msg { return tea.WindowSizeMsg{Width: w, Height: h} }
 }
 
-// updatePreflight forwards a message to the gate.
+// updatePreflight forwards a message to the gate, then refuses any result that
+// turns out to belong to a gate the user already left.
+//
+// The gate's async results are unexported types, so they cannot be filtered
+// before the fact — a probe started for agent A and answered after the user
+// backed out and launched agent B lands on B's gate. Its report is exported and
+// names its agent, so the check is done after the update: a report for the wrong
+// agent is dropped along with whatever command it wanted to run. Without this, an
+// all-green report for A drives B's screen, and B's gate hands off — opening a
+// chat for an agent nothing ever probed, which is the one outcome this gate
+// exists to prevent.
 func (m RootModel) updatePreflight(msg tea.Msg) (tea.Model, tea.Cmd) {
 	if m.preflight == nil {
 		return m, nil
 	}
 	updated, cmd := m.preflight.Update(msg)
 	gate := updated.(preflight.Model)
+	if id := gate.Report().AgentID; id != "" && m.pending != nil && id != m.pending.ID {
+		return m, nil
+	}
 	m.preflight = &gate
 	return m, cmd
 }
@@ -171,8 +190,11 @@ func (m RootModel) openConnectHandoff(provider string) (tea.Model, tea.Cmd) {
 func (m RootModel) handleConnectKey(key tea.KeyMsg) (tea.Model, tea.Cmd) {
 	switch key.String() {
 	case "ctrl+c":
-		// Same as everywhere else: ctrl+c leaves the app, not just the screen.
+		// Same as everywhere else: ctrl+c leaves the app, not just the screen. The
+		// view goes back to the hub so the last frame is never a view whose model
+		// has just been torn out from under it.
 		m.closeGate()
+		m.activeView = viewHub
 		return m, tea.Quit
 	case "r":
 		// Dismiss, then let the gate's own `r` do the re-check — the screen that
@@ -213,20 +235,23 @@ func (h connectHandoff) view(width, height int) string {
 		title = fmt.Sprintf("Reconnect %s for %s", providerLabel(h.provider), h.agentName)
 	}
 
-	out := []string{
+	head := []string{
 		"  " + connectTitle.Render(title),
 		"  " + connectDivider.Render(strings.Repeat("─", w-4)),
 	}
+	var body []block
+	cur := dropContext
 	add := func(style lipgloss.Style, text string, indent int) {
 		prefix := strings.Repeat(" ", indent)
 		for _, line := range wrapLines(text, w-indent-2) {
-			out = append(out, prefix+style.Render(line))
+			body = append(body, block{line: prefix + style.Render(line), drop: cur})
 		}
 	}
+	blank := func() { body = append(body, block{line: "", drop: cur}) }
 
 	if h.row.Detail != "" {
 		add(connectDim, h.row.Detail, 2)
-		out = append(out, "")
+		blank()
 	}
 
 	switch {
@@ -235,16 +260,29 @@ func (h connectHandoff) view(width, height int) string {
 		// a bug, and it must not read as a shrug.
 		add(connectText, "The readiness check asked for a mailbox connection but recorded no "+
 			"command for it. Report that, then connect from a terminal:", 2)
+		cur = dropNever
 		add(connectCmd, "gaia connectors list", 4)
+		cur = dropContext
 		add(connectDim, "look:  https://amd-gaia.ai/docs/guides/email", 4)
 
 	case h.provider != "":
 		add(connectText, "This cannot be done from here — it opens a browser sign-in. Run this in "+
 			"another terminal, then come back and press r.", 2)
-		out = append(out, "")
+		// The command is printed verbatim, so if the check produced one for a
+		// different provider than the mailbox it is talking about, say so rather
+		// than let the title vouch for it.
+		if named := providerFromCommand(h.row.Remedy.Command); named != "" && named != h.provider {
+			cur = dropNever
+			add(connectText, fmt.Sprintf(
+				"Heads up: the check produced a %s command for a %s mailbox. Check it before "+
+					"running it, and report it.", providerLabel(named), providerLabel(h.provider)), 2)
+		}
+		cur = dropNever
+		blank()
 		add(connectCmd, h.row.Remedy.Command, 4)
+		cur = dropContext
 		if h.row.Remedy.Where != "" {
-			out = append(out, "")
+			blank()
 			add(connectDim, "look:  "+h.row.Remedy.Where, 4)
 		}
 
@@ -253,32 +291,73 @@ func (h connectHandoff) view(width, height int) string {
 		// Both paths are named, and neither is a command that would fail.
 		add(connectText, "This cannot be done from here — it opens a browser sign-in. "+
 			"Pick one, run it in another terminal, then come back and press r.", 2)
-		out = append(out, "")
 		offered := providerFromCommand(h.row.Remedy.Command)
 		heading := "Run this:"
 		if offered != "" {
 			heading = providerLabel(offered) + " — one command, about a minute:"
 		}
+		cur = dropNever
+		blank()
 		add(connectText, heading, 2)
 		add(connectCmd, h.row.Remedy.Command, 4)
 		if offered != "microsoft" {
-			out = append(out, "")
+			cur = dropAlternative
+			blank()
 			add(connectText, "Outlook — needs a one-time Microsoft app setup first:", 2)
 			add(connectDim, outlookSetupDoc, 4)
 		}
 	}
 
-	out = append(out, "")
-	out = append(out, "  "+connectKey.Render("r")+" "+connectDim.Render("re-check")+
-		connectDim.Render(" · ")+connectKey.Render("esc")+" "+connectDim.Render("back to the checks"))
+	foot := "  " + connectKey.Render("r") + " " + connectDim.Render("re-check") +
+		connectDim.Render(" · ") + connectKey.Render("esc") + " " + connectDim.Render("back to the checks")
 
-	if height > 0 && len(out) > height {
-		// Keep the footer: a screen whose only exit hint was trimmed reads as a
-		// dead end. Drop from the body instead.
-		keep := out[:height-1]
-		out = append(keep[:len(keep):len(keep)], out[len(out)-1])
+	out := append(head, fitBody(body, height-len(head)-2)...)
+	return strings.Join(append(out, "", foot), "\n")
+}
+
+// Which lines the hand-off gives up first when the terminal is too short. The
+// command sits in the MIDDLE of the screen, so trimming by position — from
+// either end — can eat the one thing the user came here for. Lines are dropped
+// by what they are instead.
+const (
+	// dropNever is the command itself and the sentence that introduces it.
+	dropNever = iota
+	// dropAlternative is the second way to do it (the Outlook pointer).
+	dropAlternative
+	// dropContext is explanation: why this is needed, where to read more.
+	dropContext
+)
+
+// block is one rendered line plus how readily it can be dropped.
+type block struct {
+	line string
+	drop int
+}
+
+// fitBody drops whole categories of line, least important first, until the body
+// fits room rows. Below that it hard-trims and lets the caller's footer stand —
+// a terminal that short is under every size this app supports.
+func fitBody(body []block, room int) []string {
+	if room < 1 {
+		room = 1
 	}
-	return strings.Join(out, "\n")
+	for prio := dropContext; prio > dropNever && len(body) > room; prio-- {
+		kept := body[:0:0]
+		for _, b := range body {
+			if b.drop != prio {
+				kept = append(kept, b)
+			}
+		}
+		body = kept
+	}
+	lines := make([]string, 0, len(body))
+	for _, b := range body {
+		lines = append(lines, b.line)
+	}
+	if len(lines) > room {
+		lines = lines[:room]
+	}
+	return lines
 }
 
 // providerFromCommand reads the connector id out of a

--- a/tui/test/preflight_gate_test.go
+++ b/tui/test/preflight_gate_test.go
@@ -1,0 +1,598 @@
+package test
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/charmbracelet/bubbles/spinner"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/x/ansi"
+
+	"github.com/amd/gaia/tui/internal/catalog"
+	"github.com/amd/gaia/tui/internal/daemon"
+	"github.com/amd/gaia/tui/internal/ui/hub"
+	"github.com/amd/gaia/tui/internal/ui/preflight"
+	"github.com/amd/gaia/tui/internal/ui/root"
+)
+
+// These tests cover the seam between the hub and the readiness gate: that a
+// launch goes through the gate, that the gate's three answers land where they
+// should, and that a failing precondition never reaches chat.
+
+// --- a preflight transport under test control -------------------------------
+
+// gateTransport answers the four calls the gate makes, from canned bodies. It
+// exists so the seam can be driven without a daemon, a sidecar, or Lemonade.
+type gateTransport struct {
+	attachErr error
+	// agentState is the state reported for the agent in /daemon/v1/agents.
+	// Empty means the agent is not listed at all.
+	agentState string
+	// initStatus and initBody are the answer to GET /v1/<agent>/init.
+	initStatus int
+	initBody   map[string]any
+	// connectors is the answer to GET /v1/<agent>/connectors.
+	connectors map[string]any
+
+	starts  int
+	ensures int
+}
+
+func readyGateTransport() *gateTransport {
+	return &gateTransport{
+		agentState: "running",
+		initStatus: http.StatusOK,
+		initBody: map[string]any{
+			"ready": true,
+			"lemonade": map[string]any{
+				"reachable": true, "base_url": "http://localhost:8000/api/v1",
+				"version": "8.2.0", "min_version": "8.1.0", "compatible": true,
+			},
+			"model": map[string]any{
+				"id": "Gemma-4-E4B-it-GGUF", "present": true, "ctx_size": 32768,
+			},
+		},
+		connectors: map[string]any{
+			"agent_id": "email",
+			"providers": []map[string]any{
+				{"provider": "google", "connected": true, "account_email": "user@gmail.com",
+					"can_send": true, "scopes": []string{"gmail.send"}},
+			},
+		},
+	}
+}
+
+func (g *gateTransport) Attach(context.Context) (preflight.DaemonInfo, error) {
+	if g.attachErr != nil {
+		return preflight.DaemonInfo{}, g.attachErr
+	}
+	return preflight.DaemonInfo{PID: 4242, Port: 13337, APIVersion: "1.1"}, nil
+}
+
+func (g *gateTransport) Start(ctx context.Context) (preflight.DaemonInfo, error) {
+	g.starts++
+	g.attachErr = nil
+	return g.Attach(ctx)
+}
+
+func (g *gateTransport) EnsureAgent(context.Context, string) error {
+	g.ensures++
+	g.agentState = "running"
+	return nil
+}
+
+func (g *gateTransport) Do(_ context.Context, _, path string, _ []byte) (preflight.Response, error) {
+	switch {
+	case path == daemon.APIPrefix+"/agents":
+		agents := []map[string]any{}
+		if g.agentState != "" {
+			pid := 5150
+			agents = append(agents, map[string]any{
+				"agent_id": "email", "state": g.agentState, "pid": pid,
+				"agent_version": "0.5.0", "api_version": "1.0",
+			})
+		}
+		return jsonResponse(http.StatusOK, map[string]any{"agents": agents})
+	case strings.HasSuffix(path, "/init"):
+		return jsonResponse(g.initStatus, g.initBody)
+	case strings.HasSuffix(path, "/connectors"):
+		return jsonResponse(http.StatusOK, g.connectors)
+	}
+	return preflight.Response{}, fmt.Errorf("gateTransport: no canned answer for %s", path)
+}
+
+func (g *gateTransport) Stream(context.Context, string, string, []byte) (preflight.Stream, error) {
+	return preflight.Stream{}, fmt.Errorf("gateTransport: streaming is not wired in this test")
+}
+
+func jsonResponse(status int, body map[string]any) (preflight.Response, error) {
+	raw, err := json.Marshal(body)
+	if err != nil {
+		return preflight.Response{}, err
+	}
+	return preflight.Response{Status: status, Body: raw}, nil
+}
+
+// modelMissing turns the transport into the commonest real failure: everything
+// up and running, the model never downloaded.
+func (g *gateTransport) modelMissing() *gateTransport {
+	g.initStatus = http.StatusServiceUnavailable
+	g.initBody = map[string]any{
+		"ready": false,
+		"lemonade": map[string]any{
+			"reachable": true, "base_url": "http://localhost:8000/api/v1",
+			"version": "8.2.0", "min_version": "8.1.0", "compatible": true,
+		},
+		"model": map[string]any{"id": "Gemma-4-E4B-it-GGUF", "present": false},
+		"hint":  "the model is not downloaded yet",
+	}
+	return g
+}
+
+// mailboxMissing leaves every generic row green with no mailbox connected — the
+// state that asks the host to open a connector flow.
+func (g *gateTransport) mailboxMissing() *gateTransport {
+	g.connectors = map[string]any{"agent_id": "email", "providers": []map[string]any{}}
+	return g
+}
+
+// --- a root driver ----------------------------------------------------------
+
+type rootDriver struct {
+	t   *testing.T
+	m   root.RootModel
+	cat *catalog.Catalog
+}
+
+// newRootDriver builds a root model whose gate is pointed at g, with the ready
+// hold squeezed to keep the tests fast.
+func newRootDriver(t *testing.T, g preflight.Transport, w, h int) *rootDriver {
+	t.Helper()
+	cat := catalog.NewCatalog()
+	cat.MarkInstalled("email", "0.5.0")
+	m := root.NewRootModelWithHub(cat, nil, false).
+		WithPreflight(g, preflight.Options{ReadyHold: time.Millisecond})
+	d := &rootDriver{t: t, m: m, cat: cat}
+	d.send(windowSize(w, h))
+	return d
+}
+
+func (d *rootDriver) send(msg tea.Msg) {
+	d.t.Helper()
+	updated, cmd := d.m.Update(msg)
+	d.m = updated.(root.RootModel)
+	d.pump(cmd)
+}
+
+// pump runs every command the model produced, feeding results back in.
+func (d *rootDriver) pump(cmd tea.Cmd) {
+	d.t.Helper()
+	queue := []tea.Cmd{cmd}
+	for steps := 0; len(queue) > 0; steps++ {
+		if steps > maxPumpSteps {
+			d.t.Fatalf("command loop did not settle after %d steps", maxPumpSteps)
+		}
+		next := queue[0]
+		queue = queue[1:]
+		if next == nil {
+			continue
+		}
+		msg := next()
+		if msg == nil {
+			continue
+		}
+		if batch, ok := msg.(tea.BatchMsg); ok {
+			queue = append(queue, batch...)
+			continue
+		}
+		// A spinner re-arms its own tick for as long as the screen is busy, and
+		// the cursor blinks forever. Real Bubble Tea keeps ticking; a test loop
+		// must not. Routing of a spinner tick is asserted on its own below.
+		if isCursorBlink(msg) || isSpinnerTick(msg) {
+			continue
+		}
+		updated, follow := d.m.Update(msg)
+		d.m = updated.(root.RootModel)
+		queue = append(queue, follow)
+	}
+}
+
+func isSpinnerTick(msg tea.Msg) bool {
+	_, ok := msg.(spinner.TickMsg)
+	return ok
+}
+
+func (d *rootDriver) screen() string { return stripAnsi(d.m.View()) }
+
+// flat is the screen with every run of whitespace collapsed, so an assertion is
+// about what the screen says rather than where a line happened to wrap.
+func (d *rootDriver) flat() string {
+	return strings.Join(strings.Fields(d.screen()), " ")
+}
+
+func (d *rootDriver) view() string { return d.m.ControlSnapshot().View }
+
+// launchEmail sends the message the hub sends when the user presses enter on an
+// installed, daemon-backed agent.
+func (d *rootDriver) launchEmail() {
+	d.t.Helper()
+	agent := d.cat.Get("email")
+	if agent == nil {
+		d.t.Fatal("the email agent is missing from the catalog")
+	}
+	if agent.Transport != catalog.TransportDaemon {
+		d.t.Fatalf("email transport = %s, want daemon — the gate only guards relayed agents", agent.Transport)
+	}
+	d.send(hub.LaunchAgentMsg{Agent: *agent})
+}
+
+// --- the seam ---------------------------------------------------------------
+
+// The bug this whole change exists to fix: a launch used to go straight to chat.
+func TestLaunchingAnAgentShowsPreflightNotChat(t *testing.T) {
+	// A gate that is still checking: the daemon answer is what the screen is
+	// waiting on, so the first frame must be the gate.
+	g := readyGateTransport()
+	d := newRootDriver(t, g, 80, 24)
+
+	// Deliberately unpumped: the point is the FIRST frame after the launch, not
+	// where the checks eventually land.
+	updated, _ := d.m.Update(hub.LaunchAgentMsg{Agent: *d.cat.Get("email")})
+	d.m = updated.(root.RootModel)
+
+	if got := d.view(); got != "preflight" {
+		t.Fatalf("view after launch = %q, want preflight", got)
+	}
+	screen := d.flat()
+	if !strings.Contains(screen, "Getting Email ready") {
+		t.Errorf("the gate is not what got rendered:\n%s", d.screen())
+	}
+	if strings.Contains(screen, "Welcome to GAIA") {
+		t.Error("chat opened without passing the gate")
+	}
+	if snap := d.m.ControlSnapshot(); snap.Agent != "email" {
+		t.Errorf("snapshot agent = %q, want email", snap.Agent)
+	}
+}
+
+// An all-green gate hands off on its own. It must reach chat — through the same
+// launch path the hub used to call directly.
+func TestAnAllGreenGateReachesChat(t *testing.T) {
+	d := newRootDriver(t, readyGateTransport(), 80, 24)
+	d.launchEmail()
+
+	if got := d.view(); got != "chat" {
+		t.Fatalf("view after an all-green gate = %q, want chat\n%s", got, d.screen())
+	}
+	if snap := d.m.ControlSnapshot(); snap.Agent != "email" {
+		t.Errorf("chat agent = %q, want email", snap.Agent)
+	}
+	if !strings.Contains(d.flat(), "Email") {
+		t.Errorf("the chat view does not name the agent:\n%s", d.screen())
+	}
+	if got := d.cat.Get("email").Status; got != catalog.StatusActive {
+		t.Errorf("catalog status after launch = %s, want active", got)
+	}
+}
+
+// A proved-broken precondition must hold the user on the gate with something to
+// do about it — and must not start the agent behind that failure.
+func TestAFailingPreconditionKeepsTheUserOnTheGate(t *testing.T) {
+	d := newRootDriver(t, readyGateTransport().modelMissing(), 80, 24)
+	d.launchEmail()
+
+	if got := d.view(); got != "preflight" {
+		t.Fatalf("view with a missing model = %q, want preflight\n%s", got, d.screen())
+	}
+	screen := d.flat()
+	for _, want := range []string{
+		"AI model",          // the row
+		"not downloaded",    // what is wrong
+		"run: gaia init",    // the remedy command
+		"f download it now", // the one-key fix
+	} {
+		if !strings.Contains(screen, want) {
+			t.Errorf("the gate does not show %q:\n%s", want, d.screen())
+		}
+	}
+
+	// enter must not talk its way past a real blocker.
+	d.send(keyEnter())
+	if got := d.view(); got != "preflight" {
+		t.Fatalf("enter past a blocked gate landed on %q", got)
+	}
+	if !strings.Contains(d.flat(), "cannot start yet") {
+		t.Errorf("enter on a blocked gate said nothing:\n%s", d.screen())
+	}
+}
+
+// esc backs out to a hub that still has a highlighted row (#2481), and says why
+// the launch did not happen.
+func TestCancellingTheGateReturnsToAUsableHub(t *testing.T) {
+	d := newRootDriver(t, readyGateTransport().modelMissing(), 80, 24)
+
+	// Drive the hub the way a user does, so the selection under test is a real
+	// one rather than one the test set up.
+	d.selectInHub("email")
+	before := d.m.ControlSnapshot()
+	d.send(keyEnter())
+	if got := d.view(); got != "preflight" {
+		t.Fatalf("enter in the hub landed on %q, want preflight", got)
+	}
+
+	d.send(keyEsc())
+	snap := d.m.ControlSnapshot()
+	if snap.View != "hub" {
+		t.Fatalf("esc from the gate landed on %q, want hub\n%s", snap.View, d.screen())
+	}
+	if snap.SelectedAgentID == "" {
+		t.Error("the hub came back with nothing selected")
+	}
+	if snap.SelectedAgentID != before.SelectedAgentID {
+		t.Errorf("selection moved across the gate: %q → %q", before.SelectedAgentID, snap.SelectedAgentID)
+	}
+	if snap.HubTabIndex != before.HubTabIndex {
+		t.Errorf("tab moved across the gate: %d → %d", before.HubTabIndex, snap.HubTabIndex)
+	}
+	if !strings.Contains(d.flat(), "did not start") {
+		t.Errorf("the hub does not say why the launch stopped:\n%s", d.screen())
+	}
+	if got := d.cat.Get("email").Status; got == catalog.StatusActive {
+		t.Error("a cancelled launch left the agent marked active")
+	}
+}
+
+// selectInHub moves the hub cursor onto agentID using only keys and the control
+// snapshot — the same surface automation drives.
+func (d *rootDriver) selectInHub(agentID string) {
+	d.t.Helper()
+	for tab := 0; tab < 6; tab++ {
+		snap := d.m.ControlSnapshot()
+		for i, id := range snap.VisibleAgentIDs {
+			if id != agentID {
+				continue
+			}
+			for j := 0; j < i; j++ {
+				d.send(keyDown())
+			}
+			if got := d.m.ControlSnapshot().SelectedAgentID; got != agentID {
+				d.t.Fatalf("selecting %q landed on %q", agentID, got)
+			}
+			return
+		}
+		d.send(keyTab())
+	}
+	d.t.Fatalf("no tab in the hub lists %q", agentID)
+}
+
+// A gate that has been left must not launch the agent afterwards: the hold tick
+// it scheduled can still be in flight.
+func TestALateProceedFromAnAbandonedGateLaunchesNothing(t *testing.T) {
+	d := newRootDriver(t, readyGateTransport().modelMissing(), 80, 24)
+	d.launchEmail()
+	d.send(keyEsc())
+	if got := d.view(); got != "hub" {
+		t.Fatalf("esc landed on %q, want hub", got)
+	}
+
+	d.send(preflight.ProceedMsg{AgentID: "email"})
+	if got := d.view(); got != "hub" {
+		t.Fatalf("a late ProceedMsg opened %q", got)
+	}
+	if got := d.cat.Get("email").Status; got == catalog.StatusActive {
+		t.Error("a late ProceedMsg launched the agent anyway")
+	}
+}
+
+// A subprocess agent has no daemon relay, so the gate has nothing to probe and
+// must not invent four failures over a launch that works.
+func TestASubprocessAgentIsNotGated(t *testing.T) {
+	d := newRootDriver(t, readyGateTransport(), 80, 24)
+	d.send(hub.LaunchAgentMsg{Agent: catalog.Agent{
+		ID: "bash", Name: "Bash", Status: catalog.StatusInstalled,
+		Transport: catalog.TransportSubprocess, BinaryPath: "/bin/echo",
+	}})
+	if got := d.view(); got != "chat" {
+		t.Fatalf("a subprocess launch landed on %q, want chat\n%s", got, d.screen())
+	}
+}
+
+// --- the mailbox hand-off ---------------------------------------------------
+
+// ConnectMailboxMsg must produce a real instruction. The TUI has no connector
+// screen, so the honest answer is the exact command plus a way back.
+func TestConnectMailboxNamesTheCommandToRun(t *testing.T) {
+	d := newRootDriver(t, readyGateTransport().mailboxMissing(), 80, 24)
+	d.launchEmail()
+
+	if got := d.view(); got != "preflight" {
+		t.Fatalf("an unconnected mailbox landed on %q, want preflight\n%s", got, d.screen())
+	}
+	d.send(key("f"))
+
+	snap := d.m.ControlSnapshot()
+	if snap.Overlay != "connect-mailbox" {
+		t.Fatalf("f on the mailbox row produced overlay %q\n%s", snap.Overlay, d.screen())
+	}
+	screen := d.flat()
+	for _, want := range []string{
+		"Connect a mailbox for Email",
+		"gaia connectors connect google",
+		"--grant-agent installed:email",
+		"gmail.send",
+		"Outlook",
+		"https://amd-gaia.ai/docs/connectors/microsoft",
+		"r re-check",
+	} {
+		if !strings.Contains(screen, want) {
+			t.Errorf("the hand-off does not show %q:\n%s", want, d.screen())
+		}
+	}
+	// The gate's own advice for this row is "press f to choose" — repeating it
+	// here would send the user back around the loop they just came through.
+	if strings.Contains(screen, "press f to choose") {
+		t.Errorf("the hand-off tells the user to press f again:\n%s", d.screen())
+	}
+	if strings.Contains(strings.ToLower(screen), "coming soon") {
+		t.Errorf("the hand-off is a dead end:\n%s", d.screen())
+	}
+}
+
+// A mailbox that is connected but cannot send is a different failure with a
+// different command, and the hand-off must name that provider's own command
+// rather than a chooser.
+func TestConnectMailboxForAConnectedProviderShowsThatProvider(t *testing.T) {
+	g := readyGateTransport()
+	g.connectors = map[string]any{
+		"agent_id": "email",
+		"providers": []map[string]any{
+			{"provider": "microsoft", "connected": true, "account_email": "user@outlook.com",
+				"can_send": false, "scopes": []string{"Mail.Read"}},
+		},
+	}
+	d := newRootDriver(t, g, 80, 24)
+	d.launchEmail()
+	d.send(key("f"))
+
+	screen := d.flat()
+	if !strings.Contains(screen, "Reconnect Outlook for Email") {
+		t.Errorf("the hand-off does not name the connected provider:\n%s", d.screen())
+	}
+	if !strings.Contains(screen, "gaia connectors connect microsoft") {
+		t.Errorf("the hand-off does not name the Outlook command:\n%s", d.screen())
+	}
+	if strings.Contains(screen, "connect google") {
+		t.Errorf("the hand-off offers Gmail to an Outlook user:\n%s", d.screen())
+	}
+}
+
+// esc dismisses the hand-off back to the gate — not out of the launch behind it.
+func TestEscFromTheHandoffReturnsToTheGate(t *testing.T) {
+	d := newRootDriver(t, readyGateTransport().mailboxMissing(), 80, 24)
+	d.launchEmail()
+	d.send(key("f"))
+	d.send(keyEsc())
+
+	snap := d.m.ControlSnapshot()
+	if snap.View != "preflight" || snap.Overlay != "" {
+		t.Fatalf("esc from the hand-off left view=%q overlay=%q, want the bare gate",
+			snap.View, snap.Overlay)
+	}
+	if !strings.Contains(d.flat(), "Getting Email ready") {
+		t.Errorf("esc did not come back to the gate:\n%s", d.screen())
+	}
+}
+
+// r from the hand-off re-checks, so a user who just connected a mailbox in
+// another terminal is not told to press anything else.
+func TestRFromTheHandoffRechecksAndProceeds(t *testing.T) {
+	g := readyGateTransport().mailboxMissing()
+	d := newRootDriver(t, g, 80, 24)
+	d.launchEmail()
+	d.send(key("f"))
+
+	// The user connects the mailbox in another terminal.
+	g.connectors = readyGateTransport().connectors
+	d.send(key("r"))
+
+	if got := d.view(); got != "chat" {
+		t.Fatalf("re-checking a fixed mailbox landed on %q, want chat\n%s", got, d.screen())
+	}
+}
+
+// --- routing and layout ----------------------------------------------------
+
+// The gate is a spinner-driven screen. If ticks and resizes do not reach it, it
+// freezes mid-check and a resized terminal renders at the old size.
+func TestTheGateGetsSpinnerAndResizeMessages(t *testing.T) {
+	d := newRootDriver(t, readyGateTransport(), 80, 24)
+
+	// Unpumped on purpose: this is the gate mid-check, which is the state whose
+	// spinner the user actually watches.
+	updated, _ := d.m.Update(hub.LaunchAgentMsg{Agent: *d.cat.Get("email")})
+	d.m = updated.(root.RootModel)
+	if !strings.Contains(d.flat(), "checking") {
+		t.Fatalf("the gate is not mid-check:\n%s", d.screen())
+	}
+
+	before := d.screen()
+	spun := false
+	for i := 0; i < 12 && !spun; i++ {
+		updated, _ := d.m.Update(spinner.TickMsg{Time: time.Now()})
+		d.m = updated.(root.RootModel)
+		spun = d.screen() != before
+	}
+	if !spun {
+		t.Errorf("spinner ticks do not reach the gate — it renders frozen:\n%s", d.screen())
+	}
+
+	d.send(windowSize(120, 40))
+	for _, line := range strings.Split(d.screen(), "\n") {
+		if w := ansi.StringWidth(line); w > 120 {
+			t.Fatalf("after a resize a line is %d columns wide", w)
+		}
+	}
+	if !strings.Contains(d.screen(), strings.Repeat("─", 100)) {
+		t.Errorf("the gate did not widen with the terminal:\n%s", d.screen())
+	}
+}
+
+// The gate defaults to 80x24 internally, so a launch that forgets to hand it the
+// real terminal size renders narrow on a wide terminal and nothing else fails.
+func TestTheGateIsBornAtTheTerminalSize(t *testing.T) {
+	d := newRootDriver(t, readyGateTransport().modelMissing(), 100, 30)
+	d.launchEmail()
+
+	if got := d.view(); got != "preflight" {
+		t.Fatalf("view = %q, want preflight", got)
+	}
+	if !strings.Contains(d.screen(), strings.Repeat("─", 96)) {
+		t.Errorf("the gate rendered narrower than the 100-column terminal:\n%s", d.screen())
+	}
+}
+
+// The hub was fixed to fit the minimum terminal; the gate in front of it has to
+// fit too, in every state a user can be in.
+func TestEveryGateStateFitsEightyByTwentyFour(t *testing.T) {
+	cases := []struct {
+		name  string
+		build func() *gateTransport
+		keys  []tea.KeyMsg
+	}{
+		{"all ready", readyGateTransport, nil},
+		{"model missing", func() *gateTransport { return readyGateTransport().modelMissing() }, nil},
+		{"model missing, details", func() *gateTransport { return readyGateTransport().modelMissing() },
+			[]tea.KeyMsg{key("d")}},
+		{"mailbox missing", func() *gateTransport { return readyGateTransport().mailboxMissing() }, nil},
+		{"mailbox hand-off", func() *gateTransport { return readyGateTransport().mailboxMissing() },
+			[]tea.KeyMsg{key("f")}},
+		{"daemon down", func() *gateTransport {
+			g := readyGateTransport()
+			g.attachErr = &daemon.NotRunningError{Path: "/tmp/instance.json"}
+			return g
+		}, nil},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			d := newRootDriver(t, tc.build(), 80, 24)
+			d.launchEmail()
+			for _, k := range tc.keys {
+				d.send(k)
+			}
+			lines := strings.Split(d.screen(), "\n")
+			if len(lines) > 24 {
+				t.Errorf("renders %d lines into 24 rows:\n%s", len(lines), d.screen())
+			}
+			for i, line := range lines {
+				if w := ansi.StringWidth(line); w > 80 {
+					t.Errorf("line %d is %d columns wide: %q", i, w, line)
+				}
+			}
+		})
+	}
+}

--- a/tui/test/preflight_gate_test.go
+++ b/tui/test/preflight_gate_test.go
@@ -36,6 +36,9 @@ type gateTransport struct {
 	// initStatus and initBody are the answer to GET /v1/<agent>/init.
 	initStatus int
 	initBody   map[string]any
+	// initByAgent overrides the init answer per agent id, so one gate can be
+	// green while another is blocked.
+	initByAgent map[string]initAnswer
 	// connectors is the answer to GET /v1/<agent>/connectors.
 	connectors map[string]any
 
@@ -92,13 +95,18 @@ func (g *gateTransport) Do(_ context.Context, _, path string, _ []byte) (preflig
 		agents := []map[string]any{}
 		if g.agentState != "" {
 			pid := 5150
-			agents = append(agents, map[string]any{
-				"agent_id": "email", "state": g.agentState, "pid": pid,
-				"agent_version": "0.5.0", "api_version": "1.0",
-			})
+			for _, id := range []string{"email", "analyst"} {
+				agents = append(agents, map[string]any{
+					"agent_id": id, "state": g.agentState, "pid": pid,
+					"agent_version": "0.5.0", "api_version": "1.0",
+				})
+			}
 		}
 		return jsonResponse(http.StatusOK, map[string]any{"agents": agents})
 	case strings.HasSuffix(path, "/init"):
+		if answer, ok := g.initByAgent[agentFromPath(path)]; ok {
+			return jsonResponse(answer.status, answer.body)
+		}
 		return jsonResponse(g.initStatus, g.initBody)
 	case strings.HasSuffix(path, "/connectors"):
 		return jsonResponse(http.StatusOK, g.connectors)
@@ -108,6 +116,21 @@ func (g *gateTransport) Do(_ context.Context, _, path string, _ []byte) (preflig
 
 func (g *gateTransport) Stream(context.Context, string, string, []byte) (preflight.Stream, error) {
 	return preflight.Stream{}, fmt.Errorf("gateTransport: streaming is not wired in this test")
+}
+
+// initAnswer is one agent's canned /init reply.
+type initAnswer struct {
+	status int
+	body   map[string]any
+}
+
+// agentFromPath pulls the agent id out of "/v1/<agent>/init".
+func agentFromPath(path string) string {
+	parts := strings.Split(strings.Trim(path, "/"), "/")
+	if len(parts) >= 2 {
+		return parts[1]
+	}
+	return ""
 }
 
 func jsonResponse(status int, body map[string]any) (preflight.Response, error) {
@@ -147,17 +170,34 @@ type rootDriver struct {
 	t   *testing.T
 	m   root.RootModel
 	cat *catalog.Catalog
+	tr  preflight.Transport
+}
+
+// transport is the fake the gate is pointed at, for asserting what the gate did
+// or did not ask the daemon to do.
+func (d *rootDriver) transport() *gateTransport {
+	g, ok := d.tr.(*gateTransport)
+	if !ok {
+		d.t.Fatalf("the driver's transport is %T, not a gateTransport", d.tr)
+	}
+	return g
 }
 
 // newRootDriver builds a root model whose gate is pointed at g, with the ready
 // hold squeezed to keep the tests fast.
 func newRootDriver(t *testing.T, g preflight.Transport, w, h int) *rootDriver {
 	t.Helper()
+	return newRootDriverOpts(t, g, w, h, preflight.Options{ReadyHold: time.Millisecond})
+}
+
+// newRootDriverOpts is newRootDriver with the gate's options spelled out —
+// ManualProceed keeps an all-green gate on screen so it can be looked at.
+func newRootDriverOpts(t *testing.T, g preflight.Transport, w, h int, opts preflight.Options) *rootDriver {
+	t.Helper()
 	cat := catalog.NewCatalog()
 	cat.MarkInstalled("email", "0.5.0")
-	m := root.NewRootModelWithHub(cat, nil, false).
-		WithPreflight(g, preflight.Options{ReadyHold: time.Millisecond})
-	d := &rootDriver{t: t, m: m, cat: cat}
+	m := root.NewRootModelWithHub(cat, nil, false).WithPreflight(g, opts)
+	d := &rootDriver{t: t, m: m, cat: cat, tr: g}
 	d.send(windowSize(w, h))
 	return d
 }
@@ -167,6 +207,15 @@ func (d *rootDriver) send(msg tea.Msg) {
 	updated, cmd := d.m.Update(msg)
 	d.m = updated.(root.RootModel)
 	d.pump(cmd)
+}
+
+// sendNoPump delivers one message and hands back the command it produced WITHOUT
+// running it — for the tests where the point is work that is still in flight.
+func (d *rootDriver) sendNoPump(msg tea.Msg) tea.Cmd {
+	d.t.Helper()
+	updated, cmd := d.m.Update(msg)
+	d.m = updated.(root.RootModel)
+	return cmd
 }
 
 // pump runs every command the model produced, feeding results back in.
@@ -309,6 +358,40 @@ func TestAFailingPreconditionKeepsTheUserOnTheGate(t *testing.T) {
 	if !strings.Contains(d.flat(), "cannot start yet") {
 		t.Errorf("enter on a blocked gate said nothing:\n%s", d.screen())
 	}
+	// "Did not launch" is about the agent, not just the view: nothing may have
+	// asked the daemon to spawn a sidecar behind that failure.
+	if g := d.transport(); g.ensures != 0 || g.starts != 0 {
+		t.Errorf("a blocked gate started things anyway: %d ensures, %d daemon starts", g.ensures, g.starts)
+	}
+	if got := d.cat.Get("email").Status; got == catalog.StatusActive {
+		t.Error("a blocked gate marked the agent active")
+	}
+}
+
+// `f` on a stopped sidecar is the gate's most-used fix. Root has to carry the
+// fix's result back to it, or the screen spins forever on work that finished.
+func TestFixingAStoppedSidecarFromTheGateReachesChat(t *testing.T) {
+	g := readyGateTransport()
+	g.agentState = "stopped"
+	d := newRootDriver(t, g, 80, 24)
+	d.launchEmail()
+
+	screen := d.flat()
+	if !strings.Contains(screen, "installed, not started") {
+		t.Fatalf("the gate does not report the stopped sidecar:\n%s", d.screen())
+	}
+	if !strings.Contains(screen, "f start the agent") {
+		t.Errorf("the stopped-sidecar row offers no fix:\n%s", d.screen())
+	}
+
+	d.send(key("f"))
+	if g.ensures != 1 {
+		t.Fatalf("f asked the daemon to start the agent %d times, want 1", g.ensures)
+	}
+	// The fix re-checks and everything else was already green, so it hands off.
+	if got := d.view(); got != "chat" {
+		t.Fatalf("after the fix the gate landed on %q, want chat\n%s", got, d.screen())
+	}
 }
 
 // esc backs out to a hub that still has a highlighted row (#2481), and says why
@@ -386,6 +469,61 @@ func TestALateProceedFromAnAbandonedGateLaunchesNothing(t *testing.T) {
 	}
 	if got := d.cat.Get("email").Status; got == catalog.StatusActive {
 		t.Error("a late ProceedMsg launched the agent anyway")
+	}
+}
+
+// analystAgent is a second daemon-backed agent, for the two-gates race below.
+func analystAgent() catalog.Agent {
+	return catalog.Agent{
+		ID: "analyst", Name: "Analyst", Status: catalog.StatusInstalled,
+		Transport: catalog.TransportDaemon,
+	}
+}
+
+// The nastiest race in this seam: a probe started for one agent, answered after
+// the user backed out and launched another. Its report must not drive the second
+// agent's gate — an all-green report for A would otherwise green-light B and open
+// a chat for an agent nothing ever probed.
+func TestAnAbandonedGatesReportCannotGreenLightAnotherAgent(t *testing.T) {
+	g := readyGateTransport()
+	// Email would pass; Analyst is blocked on its model. So if Email's stale
+	// report reaches Analyst's gate, it turns a blocked screen into a launch.
+	g.initByAgent = map[string]initAnswer{
+		"analyst": {status: http.StatusServiceUnavailable, body: readyGateTransport().modelMissing().initBody},
+	}
+	d := newRootDriver(t, g, 80, 24)
+
+	// Gate 1 for email, its probe captured and NOT run yet — this is the in-flight
+	// probe the user walks away from.
+	emailProbe := d.sendNoPump(hub.LaunchAgentMsg{Agent: *d.cat.Get("email")})
+	d.send(keyEsc())
+
+	// Gate 2 for a different agent, blocked and waiting for the user.
+	d.send(hub.LaunchAgentMsg{Agent: analystAgent()})
+	if got := d.view(); got != "preflight" {
+		t.Fatalf("the second launch landed on %q, want preflight\n%s", got, d.screen())
+	}
+
+	// Email's probe finally answers, into Analyst's gate.
+	d.pump(emailProbe)
+
+	if got := d.view(); got != "preflight" {
+		t.Fatalf("a stale report launched %q\n%s", got, d.screen())
+	}
+	screen := d.flat()
+	if !strings.Contains(screen, "Getting Analyst ready") {
+		t.Errorf("the gate is no longer the one that was on screen:\n%s", d.screen())
+	}
+	// The Mailbox row exists only in email's report: seeing it here means the
+	// stale report was adopted.
+	if strings.Contains(screen, "Mailbox") {
+		t.Errorf("email's rows are being shown on the Analyst gate:\n%s", d.screen())
+	}
+	if !strings.Contains(screen, "not downloaded") {
+		t.Errorf("Analyst's own blocked row was replaced:\n%s", d.screen())
+	}
+	if got := d.cat.Get("email").Status; got == catalog.StatusActive {
+		t.Error("the abandoned gate launched email anyway")
 	}
 }
 
@@ -468,6 +606,60 @@ func TestConnectMailboxForAConnectedProviderShowsThatProvider(t *testing.T) {
 	}
 	if strings.Contains(screen, "connect google") {
 		t.Errorf("the hand-off offers Gmail to an Outlook user:\n%s", d.screen())
+	}
+}
+
+// On a terminal too short for the whole hand-off, the command is the last thing
+// that may be dropped — a screen that keeps the explanation and loses the fix
+// names a problem and takes away the answer.
+func TestAShortTerminalKeepsTheHandoffCommand(t *testing.T) {
+	for _, rows := range []int{24, 16, 12, 10} {
+		d := newRootDriver(t, readyGateTransport().mailboxMissing(), 80, 24)
+		d.launchEmail()
+		d.send(key("f"))
+		d.send(windowSize(80, rows))
+
+		screen := d.screen()
+		if got := len(strings.Split(screen, "\n")); got > rows {
+			t.Errorf("at %d rows the hand-off renders %d lines:\n%s", rows, got, screen)
+		}
+		flat := strings.Join(strings.Fields(screen), " ")
+		// The whole command, scopes included — a half-command is worse than none.
+		for _, want := range []string{
+			"gaia connectors connect google --grant-agent installed:email",
+			"gmail.send",
+			"esc back to the checks",
+		} {
+			if !strings.Contains(flat, want) {
+				t.Errorf("at %d rows the hand-off lost %q:\n%s", rows, want, screen)
+			}
+		}
+	}
+}
+
+// If the check ever produces a command for a different provider than the mailbox
+// it is describing, the screen must not let its own title vouch for it.
+func TestAMismatchedProviderCommandIsFlagged(t *testing.T) {
+	g := readyGateTransport()
+	// A provider the connect-command builder has no scope list for: it falls back
+	// to the Google command, which is not what this mailbox needs.
+	g.connectors = map[string]any{
+		"agent_id": "email",
+		"providers": []map[string]any{
+			{"provider": "yahoo", "connected": true, "account_email": "user@yahoo.com",
+				"can_send": false, "scopes": []string{}},
+		},
+	}
+	d := newRootDriver(t, g, 80, 24)
+	d.launchEmail()
+	d.send(key("f"))
+
+	flat := d.flat()
+	if !strings.Contains(flat, "Heads up") {
+		t.Errorf("a Gmail command under a yahoo mailbox is presented as correct:\n%s", d.screen())
+	}
+	if !strings.Contains(flat, "report it") {
+		t.Errorf("the mismatch is not reportable:\n%s", d.screen())
 	}
 }
 
@@ -558,31 +750,49 @@ func TestTheGateIsBornAtTheTerminalSize(t *testing.T) {
 
 // The hub was fixed to fit the minimum terminal; the gate in front of it has to
 // fit too, in every state a user can be in.
+//
+// Row count alone is a tautology here — both views clamp themselves to the height
+// they are given, so they can always "fit" by dropping the very thing the user
+// needs. Each case therefore names what has to still be on screen at 80x24.
 func TestEveryGateStateFitsEightyByTwentyFour(t *testing.T) {
 	cases := []struct {
 		name  string
 		build func() *gateTransport
 		keys  []tea.KeyMsg
+		// hold keeps an all-green gate on screen; without it the case would
+		// measure the chat view the gate hands off to.
+		hold bool
+		// wants is what must survive the fit at the minimum size.
+		wants []string
 	}{
-		{"all ready", readyGateTransport, nil},
-		{"model missing", func() *gateTransport { return readyGateTransport().modelMissing() }, nil},
-		{"model missing, details", func() *gateTransport { return readyGateTransport().modelMissing() },
-			[]tea.KeyMsg{key("d")}},
-		{"mailbox missing", func() *gateTransport { return readyGateTransport().mailboxMissing() }, nil},
-		{"mailbox hand-off", func() *gateTransport { return readyGateTransport().mailboxMissing() },
-			[]tea.KeyMsg{key("f")}},
-		{"daemon down", func() *gateTransport {
+		{name: "all ready", build: readyGateTransport, hold: true,
+			wants: []string{"Getting Email ready", "ready", "Mailbox", "esc back"}},
+		{name: "model missing", build: func() *gateTransport { return readyGateTransport().modelMissing() },
+			wants: []string{"AI model", "not downloaded", "run: gaia init", "esc back"}},
+		{name: "model missing, details", build: func() *gateTransport { return readyGateTransport().modelMissing() },
+			keys:  []tea.KeyMsg{key("d")},
+			wants: []string{"AI model — failed", "esc back"}},
+		{name: "mailbox missing", build: func() *gateTransport { return readyGateTransport().mailboxMissing() },
+			wants: []string{"Mailbox", "not connected", "gaia connectors connect google", "esc back"}},
+		{name: "mailbox hand-off", build: func() *gateTransport { return readyGateTransport().mailboxMissing() },
+			keys:  []tea.KeyMsg{key("f")},
+			wants: []string{"Connect a mailbox for Email", "gmail.send", "esc back to the checks"}},
+		{name: "daemon down", build: func() *gateTransport {
 			g := readyGateTransport()
 			g.attachErr = &daemon.NotRunningError{Path: "/tmp/instance.json"}
 			return g
-		}, nil},
+		}, wants: []string{"Background service", "not running", "f start it for me", "esc back"}},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			d := newRootDriver(t, tc.build(), 80, 24)
+			opts := preflight.Options{ReadyHold: time.Millisecond, ManualProceed: tc.hold}
+			d := newRootDriverOpts(t, tc.build(), 80, 24, opts)
 			d.launchEmail()
 			for _, k := range tc.keys {
 				d.send(k)
+			}
+			if got := d.view(); got != "preflight" {
+				t.Fatalf("this case is not measuring the gate — view = %q\n%s", got, d.screen())
 			}
 			lines := strings.Split(d.screen(), "\n")
 			if len(lines) > 24 {
@@ -591,6 +801,12 @@ func TestEveryGateStateFitsEightyByTwentyFour(t *testing.T) {
 			for i, line := range lines {
 				if w := ansi.StringWidth(line); w > 80 {
 					t.Errorf("line %d is %d columns wide: %q", i, w, line)
+				}
+			}
+			flat := strings.Join(strings.Fields(d.screen()), " ")
+			for _, want := range tc.wants {
+				if !strings.Contains(flat, want) {
+					t.Errorf("at 80x24 the screen lost %q:\n%s", want, d.screen())
 				}
 			}
 		})


### PR DESCRIPTION
The readiness gate was built, tested and merged — and nothing imported it, so no user could reach it. Pressing enter on an installed agent still went straight to chat, and the first sign of a missing model or a disconnected mailbox was a failed turn mid-conversation. The gate now sits on the launch path.

It runs on every launch and caches nothing: the daemon can be killed, its token rotates on restart, the model server can unload the model and a mailbox grant can be revoked from the web, so a remembered pass would open a chat that cannot answer while claiming it had been verified.

Review caught the launch this seam exists to prevent — backing out of a slow check and launching a second agent let the first agent's all-green report hand off and open a chat for an agent nothing had probed. Reports now name their agent and stale ones are dropped.

### Test plan
- [ ] `cd tui && make lint && go test ./... -count=1 -race`
- [ ] Launching an agent shows the gate, not chat; proceeding reaches chat; cancelling returns to a hub with a valid selection
- [ ] Start a check, cancel, launch a different agent → the first agent's report cannot green-light the second
- [ ] A failing precondition keeps the user on the gate with a runnable command
