### PR TITLE
feat(agents): serve agent init from a declaration, not hand-written routes

### DIFF
--- a/docs/reference/cli.mdx
+++ b/docs/reference/cli.mdx
@@ -2400,9 +2400,9 @@ gaia tui status                           # background service + what is install
 | `gaia tui list [--installed]` | List agents with version, install state, download size, and security tier. `--installed` reads the local `~/.gaia/agents/*/.installed` sentinels and never touches the network. |
 | `gaia tui install <id> [--version X] [--trust]` | Install an agent and wait for it to finish. |
 | `gaia tui uninstall <id>` | Stop the agent's sidecar, verify it is gone, remove its install directory. |
-| `gaia tui run <id> [--query "…"] [--model M]` | Run an agent. `--query` is a genuine one-shot. |
+| `gaia tui run <id> [--query "…"] [--model M] [--timeout D]` | Run an agent. `--query` is a genuine one-shot, checked and bounded (`--timeout`, default 15m). |
 | `gaia tui status` | Whether the background service is running, which sidecars it knows, and what is installed. |
-| `gaia tui chat --agent <id>` \| `--subprocess <cmd>` | Chat with an agent by catalog id, or with a binary you spawn directly. |
+| `gaia tui chat --agent <id>` \| `--subprocess <cmd>` | Chat with an agent by catalog id, or with a binary you spawn directly. With `--agent --query` it is the same one-shot `gaia tui run --query` is, `--timeout` included. |
 | `gaia tui hub` | The hub screen explicitly (same as bare `gaia tui`). |
 
 Install and uninstall are served by the GAIA daemon
@@ -2452,6 +2452,32 @@ stderr, and the exit code is `0` on a terminal answer / `1` on an error — so
 gaia tui run email --query "how many unread?" > answer.txt 2> progress.log
 echo $?   # 0
 ```
+
+It never waits on something that is not there. Before the query is sent, a
+one-shot over the daemon transport (the agents the background service supervises)
+runs the same readiness check the hub's launch gate runs — background service,
+sidecar, local model server, model, and for email the mailbox — and if one of
+them is not ready it prints that row and its remedy to stderr and exits non-zero.
+Against an unreachable dependency that is about a second; the ceiling is the time
+it takes to start the sidecar. Nothing is sent to the agent, and the gate screen
+is never rendered: a script has nobody to press a key. An agent that runs as a
+local subprocess has no readiness route to probe, so it is launched directly.
+
+```bash
+$ gaia tui run email --query "triage my inbox"   # with the model server down
+❌ Email is not ready — Local AI: not running at http://localhost:8000/api/v1
+   GAIA needs a local model server. It runs on your machine; no message text ever leaves it.
+…
+        run: lemonade-server serve
+$ echo $?   # 1, after about a second
+```
+
+The turn itself is bounded — 15 minutes by default, `--timeout 90s` / `--timeout
+2h` to change it — so an agent that accepts the query and then stops answering is
+reported with what to read next instead of hanging a CI job until the job's own
+timeout kills it. There is no "wait forever": `--timeout 0` is refused. Interactive
+`gaia tui run <id>` is unaffected — a person can read what arrives and press
+ctrl+c.
 
 #### Hub keys
 

--- a/docs/spec/agent-hub-restructure.mdx
+++ b/docs/spec/agent-hub-restructure.mdx
@@ -66,6 +66,7 @@ src/gaia/agents/                 src/gaia/agents/        ← framework only
 3. **Shared tool mixins promoted to framework.** RAG, FileIO, Shell, CodeIndex mixins move into `src/gaia/agents/tools/` so agents don't depend on each other for tools.
 4. **Entry-point discovery.** Agents register via the `gaia.agent` entry point group. The registry discovers installed agent wheels at startup — no hardcoded agent list.
 5. **Framework-provided generic server.** `src/gaia/agents/base/server.py` wraps any Agent into an OpenAI-compatible REST API + MCP stdio server. Agents don't implement server logic.
+6. **Inherited init.** An agent *declares* what it needs — a model id, a minimum backend version — and the framework serves `GET`/`POST /v1/<id>/init` for it. Agents don't hand-write readiness or provisioning endpoints. See [Inherited init](#inherited-init).
 
 ## Pre-requisite: Promote shared tool mixins
 
@@ -128,6 +129,69 @@ chat = "gaia_agent_chat.agent:ChatAgent"
 
 Agents with cross-agent dependencies (e.g. RoutingAgent uses CodeAgent) declare them as package dependencies: `dependencies = ["amd-gaia>=0.18.0", "gaia-agent-code>=0.1.0"]`.
 
+## Inherited init
+
+An agent that needs a model before it can answer anything should not have to
+hand-write a readiness endpoint to say so. It **declares** the requirement and
+`AgentServer` serves both verbs at `/v1/<id>/init`:
+
+| Verb | Effect | Status |
+|------|--------|--------|
+| `GET` | Read-only readiness probe. Reports backend reachability, version compatibility, and whether the declared model is downloaded — with an actionable `hint` per failure. | `200` ready · `503` not ready, **same body** either way |
+| `POST` | Provisioning. Tells an already-running backend to download the declared model, streaming newline-terminated progress. | `503` before streaming if the backend is down · otherwise a committed `200` |
+
+Declare requirements in `gaia-agent.yaml` (`models:` and
+`requirements.min_lemonade_version`), or pass them explicitly:
+
+```python
+from gaia.agents.base.readiness import AgentRequirements
+from gaia.agents.base.server import AgentServer
+
+server = AgentServer(
+    MyAgent(),
+    agent_id="my-agent",
+    requirements=AgentRequirements(
+        model_id="Gemma-4-E4B-it-GGUF",
+        min_backend_version="10.2.0",
+    ),
+)
+```
+
+An agent that declares nothing gets **no** init routes — a readiness endpoint
+that reports "ready" without having checked anything is worse than a 404,
+because a consumer would trust it.
+
+### Where the boundary sits
+
+Inherited init makes *this agent's* requirements ready: its model, against a
+backend that is already running. **Installing the backend stays with `gaia
+init`.** An agent process cannot bootstrap the server it depends on, so when
+Lemonade is unreachable both verbs fail loudly and name whose job the fix is
+rather than hanging or half-succeeding:
+
+```
+✗ The local Lemonade Server is not reachable at http://127.0.0.1:9099/api/v1.
+✗ Start it with `lemonade-server serve` (or run `gaia init`), then POST to this path again.
+✗ My Agent can't install the backend itself — that's a host prerequisite.
+```
+
+### Reading a provisioning result
+
+Once a streamed `200` is committed the HTTP status can no longer change, so a
+pull that fails half-way still arrives as `200 OK`. **The final line is the
+verdict** — `✓` success, `✗` failure, `⚠` succeeded-but-unverified. Consumers
+must read it rather than the status code; the TUI's preflight gate
+(`tui/internal/ui/preflight`) already does.
+
+Two distinctions the contract preserves deliberately, because each has a
+different remedy:
+
+- **"Could not tell" is not "missing."** If the backend answers `/health` but
+  its model list cannot be read, `present:false` means unknown — reporting it as
+  missing would send the user to re-download a model they may already have.
+- **Indeterminate is not a pass.** A backend that advertises no version yields
+  `compatible: null`, never `true`.
+
 ## Implementation Steps
 
 <Steps>
@@ -153,7 +217,7 @@ Remove agent packages from `setup.py`. Remove `gaia-emr`/`gaia-code` console scr
 Replace ~16 direct agent imports in `cli.py`, `ui/_chat_helpers.py`, `ui/agent_loop.py`, and apps with `registry.create_agent(id)`.
 </Step>
 <Step title="Add framework generic server">
-`src/gaia/agents/base/server.py` wraps any Agent into REST API + MCP server. Enables `gaia agent run <id> --api` and `--mcp`.
+`src/gaia/agents/base/server.py` wraps any Agent into REST API + MCP server. Enables `gaia agent run <id> --api` and `--mcp`, and serves the agent's [inherited init](#inherited-init) routes.
 </Step>
 <Step title="Add CI/CD workflow">
 `.github/workflows/build_agents.yml` matrix-builds the C++ agent binaries;

--- a/src/gaia/agents/base/readiness.py
+++ b/src/gaia/agents/base/readiness.py
@@ -1,0 +1,621 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""Inherited agent init: readiness probing and provisioning, declared not coded.
+
+An agent states what it needs — a model id, a minimum backend version — and gets
+``GET``/``POST /v1/<id>/init`` from :class:`~gaia.agents.base.server.AgentServer`
+for free. Before this module every agent that wanted a readiness contract had to
+hand-write both verbs; the email sidecar did, and was the only one that had them.
+
+Two verbs, deliberately asymmetric:
+
+* **GET** — read-only. Probes the backend and reports a structured status with an
+  actionable ``hint`` per failure. Never pulls, never installs, never mutates.
+* **POST** — provisioning. Tells an *already-running* backend to download the
+  declared model, streaming newline-terminated progress so a consumer can render
+  it terminal-style.
+
+**Where the boundary sits.** Inherited init makes *this agent's* requirements
+ready: its model, against a backend that is already up. Installing the backend
+itself stays with ``gaia init`` — an agent process cannot bootstrap the server it
+depends on, and pretending otherwise would turn a clear error into a hang. When
+the backend is unreachable both verbs fail loudly and name whose job the fix is;
+:func:`provision_progress` is never even reached. Do not grow an installer here.
+
+**Why the final line decides a pull, not the status code.** Once a streamed 200
+is committed the status can no longer change, so a pull that fails half-way still
+arrives as ``200 OK``. The last line carries the verdict: ``✓`` success, ``✗``
+failure, ``⚠`` succeeded-but-unverified. Consumers must read it rather than the
+status. The TUI's preflight gate already does (``tui/internal/ui/preflight``).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Iterator, List, Optional, Tuple
+
+from gaia.logger import get_logger
+
+logger = get_logger(__name__)
+
+# Fast pre-flight timeouts for the "is the backend even up?" probe. The real
+# chat path uses a long scalar timeout — correct for generation, but it also
+# governs the TCP connect, so an unreachable server would block on the OS SYN
+# timeout before erroring. A short connect leg turns "server down" into a prompt
+# answer instead of a 30s hang.
+PROBE_CONNECT_TIMEOUT = 2.0
+PROBE_READ_TIMEOUT = 5.0
+
+# A model pull is a first-download of multi-GB weights — minutes, not seconds.
+# Generous read ceiling so a slow link does not abort a real download; the
+# connect leg stays short so an unreachable server still fails fast.
+PULL_TIMEOUT = (5.0, 1800.0)
+
+
+# ---------------------------------------------------------------------------
+# The declaration
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class AgentRequirements:
+    """What an agent needs before it can serve — the whole declaration.
+
+    Args:
+        model_id: The backend model id the agent loads. ``None`` means the agent
+            has no model requirement, and the model half of the check is skipped
+            rather than reported as missing.
+        min_backend_version: Minimum Lemonade Server version. ``None`` means the
+            agent did not declare one, which is reported as an *indeterminate*
+            version check (``compatible: null``) — never as a pass.
+        base_url: Backend base URL to probe. ``None`` resolves from the
+            environment (``LEMONADE_BASE_URL``), which is what almost every
+            agent wants.
+    """
+
+    model_id: Optional[str] = None
+    min_backend_version: Optional[str] = None
+    base_url: Optional[str] = None
+
+    def declares_anything(self) -> bool:
+        """Whether this states a requirement worth serving an ``/init`` for.
+
+        A declaration of nothing must not produce a readiness endpoint. It would
+        answer ``ready: true`` the moment the backend is up, having verified
+        nothing about the agent — and a consumer would believe it. ``base_url``
+        alone does not count: it says where to look, not what is needed.
+        """
+        return bool(self.model_id or self.min_backend_version)
+
+    @classmethod
+    def from_manifest(cls, manifest: Any) -> "AgentRequirements":
+        """Derive requirements from a parsed ``gaia-agent.yaml``.
+
+        Reads the first entry of the top-level ``models:`` list and
+        ``requirements.min_lemonade_version``.
+
+        NOTE: ``gaia.hub.manifest.Requirements`` does not currently parse
+        ``min_lemonade_version`` — the email manifest declares it and the field
+        is dropped on the floor. Until the parser carries it, this returns
+        ``min_backend_version=None``, which surfaces as ``compatible: null``
+        (indeterminate) rather than a fabricated pass. Agents needing the gate
+        enforced today should construct :class:`AgentRequirements` explicitly.
+        """
+        models = getattr(manifest, "models", None) or []
+        requirements = getattr(manifest, "requirements", None)
+        return cls(
+            model_id=models[0] if models else None,
+            min_backend_version=getattr(requirements, "min_lemonade_version", None),
+        )
+
+
+# ---------------------------------------------------------------------------
+# Response models — the wire contract
+# ---------------------------------------------------------------------------
+#
+# Shape is byte-compatible with the email sidecar's existing /v1/email/init so
+# the TUI preflight gate parses both without a branch. The `lemonade` key is
+# named for the backend rather than generically because that is what shipped and
+# what every consumer already reads; renaming it would break them for cosmetics.
+
+
+def _build_models():
+    """Build the pydantic response models lazily.
+
+    Module import must stay cheap: ``gaia.agents.base.server`` imports this for
+    the dataclass alone in pipe/CLI/MCP modes, which do not pay for pydantic.
+    """
+    from pydantic import BaseModel, Field
+
+    class BackendStatus(BaseModel):
+        """Reachability AND version-compatibility of the local model server."""
+
+        reachable: bool = Field(
+            ..., description="True when the backend answered the /health probe."
+        )
+        base_url: str = Field(..., description="The /api/v1 base URL that was probed.")
+        version: Optional[str] = Field(
+            default=None,
+            description=(
+                "The backend's self-reported version (from /health). Null when "
+                "it does not advertise one."
+            ),
+        )
+        min_version: str = Field(
+            default="",
+            description=(
+                "Minimum backend version this agent declared. Empty when the "
+                "agent declared none, in which case `compatible` is null."
+            ),
+        )
+        compatible: Optional[bool] = Field(
+            default=None,
+            description=(
+                "True when version >= min_version. Null when it could not be "
+                "determined — an indeterminate check, NOT a pass."
+            ),
+        )
+
+    class ModelStatus(BaseModel):
+        """Presence (and, when cheap, loadability) of the declared model."""
+
+        id: str = Field(..., description="The model id the agent declared.")
+        present: bool = Field(
+            ..., description="True when the model is downloaded on the backend."
+        )
+        loadable: Optional[bool] = Field(
+            default=None,
+            description=(
+                "Whether the model actually loads. Not probed — forcing a load "
+                "is heavy — so this is null; `present` is the readiness signal."
+            ),
+        )
+        ctx_size: Optional[int] = Field(
+            default=None,
+            description=(
+                "The context window the model is CURRENTLY loaded at, as "
+                "reported by the backend. Null when it is not loaded right now "
+                "or the backend does not report one — never a config echo."
+            ),
+        )
+
+    class InitResponse(BaseModel):
+        """Readiness preflight for one agent's requirements.
+
+        ``ready`` is True only when the backend is reachable, at a compatible
+        version, and the declared model is present. Served as HTTP 200 when
+        ready and 503 when not, with the SAME body either way, so a consumer can
+        parse one shape and read ``hint`` for the next step.
+        """
+
+        ready: bool = Field(
+            ..., description="True when every declared requirement is satisfied."
+        )
+        lemonade: BackendStatus = Field(..., description="Backend server status.")
+        model: ModelStatus = Field(..., description="Declared model status.")
+        hint: Optional[str] = Field(
+            default=None,
+            description=(
+                "Actionable next step when not ready (what failed / what to "
+                "do). Null when ready."
+            ),
+        )
+
+    return BackendStatus, ModelStatus, InitResponse
+
+
+_MODELS: Optional[Tuple[Any, Any, Any]] = None
+
+
+def init_models() -> Tuple[Any, Any, Any]:
+    """Return ``(BackendStatus, ModelStatus, InitResponse)``, building once."""
+    global _MODELS
+    if _MODELS is None:
+        _MODELS = _build_models()
+    return _MODELS
+
+
+# ---------------------------------------------------------------------------
+# Probes — every one read-only
+# ---------------------------------------------------------------------------
+
+
+def resolve_probe_base(base_url: Optional[str]) -> str:
+    """Resolve the backend's ``/api/v1`` base URL for a probe.
+
+    An explicit ``base_url`` is normalised to end in ``/api/v1`` (callers often
+    omit it); ``None`` falls back to the env-derived default, so every probe in
+    a process targets the same server.
+    """
+    from gaia.llm.lemonade_client import _get_lemonade_config
+
+    if base_url:
+        probe_base = base_url.rstrip("/")
+        if not probe_base.endswith("/api/v1"):
+            probe_base = f"{probe_base}/api/v1"
+        return probe_base
+    _, _, probe_base = _get_lemonade_config()
+    return probe_base
+
+
+def probe_backend_health(
+    base_url: Optional[str] = None,
+) -> Tuple[bool, str, Optional[str], List[dict]]:
+    """Probe the backend's ``/health``.
+
+    Returns ``(reachable, probe_base, version, loaded_models)``. Any HTTP
+    response — even an error status — means the server is up; only a
+    connection/timeout failure counts as unreachable, because auth and model
+    errors surface later on the real call where their messages are specific.
+
+    Never raises: readiness reports values rather than failing.
+    """
+    import requests
+
+    probe_base = resolve_probe_base(base_url)
+    try:
+        resp = requests.get(
+            f"{probe_base}/health",
+            timeout=(PROBE_CONNECT_TIMEOUT, PROBE_READ_TIMEOUT),
+        )
+    except requests.exceptions.RequestException:
+        return False, probe_base, None, []
+
+    version: Optional[str] = None
+    loaded_models: List[dict] = []
+    try:
+        body = resp.json()
+        if isinstance(body, dict):
+            version = body.get("version")
+            raw_loaded = body.get("all_models_loaded", [])
+            if isinstance(raw_loaded, list):
+                loaded_models = [m for m in raw_loaded if isinstance(m, dict)]
+    except ValueError:
+        version = None
+    return True, probe_base, version, loaded_models
+
+
+def probe_model_present(probe_base: str, model_id: str) -> bool:
+    """Check whether ``model_id`` is downloaded on the backend.
+
+    Matches tolerantly via the core comparison — a ``user.``-prefixed
+    registration is listed under the stripped id, so a strict compare would
+    report a downloaded model as missing and send the user to re-pull it.
+
+    Raises ``requests.RequestException`` when the model list cannot be read. The
+    caller MUST distinguish that from "absent": they mean different things and
+    have different remedies.
+    """
+    import requests
+
+    from gaia.llm.lemonade_client import (
+        _model_ids_match,
+        lemonade_auth_headers,
+        resolve_lemonade_api_key,
+    )
+
+    resp = requests.get(
+        f"{probe_base}/models",
+        headers=lemonade_auth_headers(resolve_lemonade_api_key()),
+        timeout=(PROBE_CONNECT_TIMEOUT, PROBE_READ_TIMEOUT),
+    )
+    resp.raise_for_status()
+    body = resp.json()
+    entries = body.get("data", []) if isinstance(body, dict) else []
+    for entry in entries:
+        if isinstance(entry, dict) and _model_ids_match(entry.get("id"), model_id):
+            return True
+    return False
+
+
+def extract_loaded_ctx(loaded_models: List[dict], model_id: str) -> Optional[int]:
+    """The ctx_size the backend reports ``model_id`` loaded at, or None.
+
+    Reports only what the server says: a missing entry, missing
+    ``recipe_options``, or a non-positive value all yield None — never a config
+    echo or a guess.
+    """
+    from gaia.llm.lemonade_client import _model_ids_match
+
+    for entry in loaded_models:
+        if _model_ids_match(entry.get("model_name"), model_id) or _model_ids_match(
+            entry.get("checkpoint"), model_id
+        ):
+            recipe_options = entry.get("recipe_options")
+            if not isinstance(recipe_options, dict):
+                return None
+            ctx = recipe_options.get("ctx_size")
+            if isinstance(ctx, int) and not isinstance(ctx, bool) and ctx > 0:
+                return ctx
+            return None
+    return None
+
+
+def parse_version(version: Optional[str]) -> Optional[Tuple[int, ...]]:
+    """Parse a dotted version into a comparable int tuple, or None."""
+    if not version:
+        return None
+    try:
+        return tuple(int(p) for p in version.lstrip("v").split(".")[:3])
+    except (ValueError, IndexError, AttributeError):
+        return None
+
+
+def version_meets_min(found: Optional[str], minimum: Optional[str]) -> Optional[bool]:
+    """Whether ``found`` >= ``minimum``, or None when it cannot be told.
+
+    None means indeterminate — the server advertised nothing, the string was
+    unparseable, or the agent declared no minimum. Readiness surfaces that as
+    ``compatible: null`` so a consumer sees the check did not run, rather than
+    a fabricated pass.
+    """
+    found_t = parse_version(found)
+    min_t = parse_version(minimum)
+    if found_t is None or min_t is None:
+        return None
+    return found_t >= min_t
+
+
+def pull_model(probe_base: str, model_id: str) -> None:
+    """Tell a RUNNING backend to download ``model_id``.
+
+    Posts ONLY ``model_name`` — sending ``recipe`` for a built-in Lemonade model
+    makes it 400 (#1655), and that failure only reproduces on a cold cache, so
+    it survives every warm-machine test. Raises ``requests.RequestException`` on
+    failure; the caller surfaces it as a loud ``✗`` line.
+
+    This is the ONLY provisioning an agent process can do. It cannot install the
+    backend — see the module docstring.
+    """
+    import requests
+
+    from gaia.llm.lemonade_client import (
+        lemonade_auth_headers,
+        resolve_lemonade_api_key,
+    )
+
+    resp = requests.post(
+        f"{probe_base}/pull",
+        json={"model_name": model_id},
+        headers=lemonade_auth_headers(resolve_lemonade_api_key()),
+        timeout=PULL_TIMEOUT,
+    )
+    resp.raise_for_status()
+
+
+# ---------------------------------------------------------------------------
+# GET — readiness
+# ---------------------------------------------------------------------------
+
+
+def model_list_unreadable(hint: Optional[str]) -> bool:
+    """Whether a hint reports the one failure the structured fields cannot.
+
+    The backend answered /health but its model list read failed, so
+    ``present:false`` means "could not tell", not "missing". Only the hint
+    carries that distinction.
+    """
+    h = (hint or "").lower()
+    return "model list" in h and "could not be read" in h
+
+
+def compute_init_status(
+    requirements: AgentRequirements, agent_name: str = "This agent"
+):
+    """Probe the declared requirements and return a structured status.
+
+    Read-only — never pulls, never installs. Returns a not-ready response with
+    an actionable ``hint`` per failure rather than raising, so one route can
+    serialize the same body under both 200 and 503.
+
+    Failure order is dependency order and it matters: a version too old is
+    reported before a missing model, because upgrading the backend comes first
+    even when both are wrong. Reporting them the other way sends the user to
+    download gigabytes that the old server may then refuse to serve.
+    """
+    import requests
+
+    BackendStatus, ModelStatus, InitResponse = init_models()
+
+    model_id = requirements.model_id
+    reachable, probe_base, version, loaded_models = probe_backend_health(
+        requirements.base_url
+    )
+    compatible = (
+        version_meets_min(version, requirements.min_backend_version)
+        if reachable
+        else None
+    )
+    backend = BackendStatus(
+        reachable=reachable,
+        base_url=probe_base,
+        version=version,
+        min_version=requirements.min_backend_version or "",
+        compatible=compatible,
+    )
+
+    def _model(present: bool, ctx_size: Optional[int] = None):
+        # A model-less agent reports present=True so a consumer's "is the model
+        # downloaded?" check does not raise a failure over a model that was
+        # never required; the id says plainly that there is none.
+        return ModelStatus(
+            id=model_id or "(none required)",
+            present=present,
+            loadable=None,
+            ctx_size=ctx_size,
+        )
+
+    if not reachable:
+        return InitResponse(
+            ready=False,
+            lemonade=backend,
+            model=_model(False),
+            hint=(
+                f"The local Lemonade Server is not reachable at {probe_base} — "
+                "start it with `lemonade-server serve` (or run `gaia init`), "
+                f"then retry. {agent_name} cannot install it: that is a host "
+                "prerequisite, not something an agent can bootstrap."
+            ),
+        )
+
+    # An agent with no declared model has nothing further to check — a reachable
+    # backend at a compatible version is the whole of its readiness.
+    if not model_id:
+        if compatible is False:
+            return InitResponse(
+                ready=False,
+                lemonade=backend,
+                model=_model(False),
+                hint=_version_hint(version, requirements, agent_name),
+            )
+        return InitResponse(ready=True, lemonade=backend, model=_model(True), hint=None)
+
+    loaded_ctx = extract_loaded_ctx(loaded_models, model_id)
+
+    try:
+        present = probe_model_present(probe_base, model_id)
+    except requests.exceptions.RequestException as exc:
+        # Reachable, but the model list could not be read: `present:false` here
+        # means "could not tell", not "missing". Reporting it as missing would
+        # send the user to re-download something they may already have.
+        return InitResponse(
+            ready=False,
+            lemonade=backend,
+            model=_model(False, loaded_ctx),
+            hint=(
+                f"The backend is reachable but its model list at {probe_base}/models "
+                f"could not be read ({type(exc).__name__}: {exc}). Make sure the "
+                "server is healthy, then retry."
+            ),
+        )
+
+    model = _model(present, loaded_ctx)
+
+    if compatible is False:
+        return InitResponse(
+            ready=False,
+            lemonade=backend,
+            model=model,
+            hint=_version_hint(version, requirements, agent_name),
+        )
+
+    if not present:
+        return InitResponse(
+            ready=False,
+            lemonade=backend,
+            model=model,
+            hint=(
+                f"Model `{model_id}` is not downloaded — run `gaia init`, or POST "
+                "to this same path to pull it here, then retry."
+            ),
+        )
+
+    return InitResponse(ready=True, lemonade=backend, model=model, hint=None)
+
+
+def _version_hint(
+    version: Optional[str], requirements: AgentRequirements, agent_name: str
+) -> str:
+    return (
+        f"Lemonade {version} is older than the required "
+        f"{requirements.min_backend_version} that {agent_name} declares — "
+        "upgrade it (see https://lemonade-server.ai or run `gaia init`), then "
+        "retry."
+    )
+
+
+# ---------------------------------------------------------------------------
+# POST — provisioning
+# ---------------------------------------------------------------------------
+
+
+def provision_progress(
+    probe_base: str, model_id: str, agent_name: str = "This agent"
+) -> Iterator[str]:
+    """Yield newline-terminated progress while provisioning the declared model.
+
+    The only provisioning an agent process can do: ask an already-running
+    backend to download the model it declared, narrating each step. The caller
+    checks reachability first so it can return a truthful 503 — this generator
+    runs only once the backend is confirmed up.
+
+    The FINAL line is authoritative (``✓``/``✗``/``⚠``); see the module
+    docstring for why the status code is not.
+    """
+    import requests
+
+    def line(text: str) -> str:
+        return text + "\n"
+
+    yield line(f"→ {agent_name} requires model: {model_id}")
+    yield line(f"→ Backend reachable at {probe_base}")
+    yield line(f"→ Checking whether {model_id} is already downloaded…")
+
+    try:
+        present = probe_model_present(probe_base, model_id)
+    except requests.exceptions.RequestException as exc:
+        yield line(
+            f"✗ Could not read the backend's model list ({type(exc).__name__}: {exc})."
+        )
+        yield line(
+            "✗ Provisioning aborted — make sure the Lemonade Server is healthy, "
+            "then retry."
+        )
+        return
+
+    if present:
+        yield line(f"✓ {model_id} is already downloaded — nothing to pull.")
+        yield line("✓ Provisioning complete. Re-run GET on this path to confirm.")
+        return
+
+    yield line(f"→ Pulling {model_id} — a first download can take several minutes…")
+    try:
+        pull_model(probe_base, model_id)
+    except requests.exceptions.RequestException as exc:
+        yield line(f"✗ Provisioning failed: {type(exc).__name__}: {exc}")
+        yield line(
+            "✗ The model was not downloaded. Check the Lemonade Server logs, "
+            "then retry."
+        )
+        return
+
+    yield line(f"✓ {model_id} downloaded.")
+
+    # Verify the pull actually registered. A verify hiccup is surfaced, not
+    # swallowed, but does not by itself fail a pull the backend reported OK.
+    try:
+        if probe_model_present(probe_base, model_id):
+            yield line(f"✓ Verified {model_id} is registered with the backend.")
+        else:
+            yield line(
+                f"✗ {model_id} is still not listed after the pull — provisioning "
+                "incomplete. Check the Lemonade Server logs, then retry."
+            )
+            return
+    except requests.exceptions.RequestException as exc:
+        yield line(
+            f"⚠ The pull reported success but the model list could not be re-read "
+            f"({type(exc).__name__}). Re-run GET on this path to confirm."
+        )
+
+    yield line("✓ Provisioning complete. Re-run GET on this path to confirm.")
+
+
+def unreachable_progress(
+    probe_base: str, agent_name: str = "This agent"
+) -> Iterator[str]:
+    """The lines a provisioning request gets when the backend is down.
+
+    Yielded under a real 503 — sent BEFORE any streaming commits a 200, so the
+    status code is truthful here and the consumer does not have to parse lines
+    to learn nothing happened.
+    """
+    yield f"✗ The local Lemonade Server is not reachable at {probe_base}.\n"
+    yield (
+        "✗ Start it with `lemonade-server serve` (or run `gaia init`), then "
+        "POST to this path again.\n"
+    )
+    yield (
+        f"✗ {agent_name} can't install the backend itself — that's a host "
+        "prerequisite.\n"
+    )

--- a/src/gaia/agents/base/server.py
+++ b/src/gaia/agents/base/server.py
@@ -91,6 +91,13 @@ class AgentServer:
         model_id: OpenAI-compatible model id for the REST surface. Defaults to
             the agent's :meth:`ApiAgent.get_model_id` (or ``gaia-<classname>``).
         name: Human-readable server name (banners, MCP ``serverInfo``).
+        requirements: What the agent needs before it can serve — see
+            :class:`~gaia.agents.base.readiness.AgentRequirements`. Supplying it
+            (or a manifest that declares ``models:`` /
+            ``requirements.min_lemonade_version``) is what earns the agent
+            ``GET``/``POST /v1/<id>/init`` without hand-writing either verb.
+        agent_id: The id used in the ``/v1/<id>/init`` path. Defaults to the
+            manifest id, else a slug of the class name.
     """
 
     def __init__(
@@ -100,6 +107,8 @@ class AgentServer:
         manifest: Any = None,
         model_id: Optional[str] = None,
         name: Optional[str] = None,
+        requirements: Any = None,
+        agent_id: Optional[str] = None,
     ) -> None:
         if not isinstance(agent, Agent):
             raise TypeError(
@@ -111,6 +120,16 @@ class AgentServer:
         self.manifest = manifest
         self.model_id = model_id or self._default_model_id(agent)
         self.name = name or agent.__class__.__name__
+        self.agent_id = agent_id or self._default_agent_id(agent, manifest)
+        # An explicit declaration wins; otherwise derive from the manifest. Both
+        # absent means the agent declared nothing, and the init routes are not
+        # mounted at all — an /init that answers "ready" without having checked
+        # anything is worse than no /init.
+        if requirements is None and manifest is not None:
+            from gaia.agents.base.readiness import AgentRequirements
+
+            requirements = AgentRequirements.from_manifest(manifest)
+        self.requirements = requirements
 
     # ------------------------------------------------------------------
     # Interface gating (fail loudly)
@@ -123,6 +142,20 @@ class AgentServer:
         cls = agent.__class__.__name__
         base = cls[:-5].lower() if cls.endswith("Agent") else cls.lower()
         return f"gaia-{base}"
+
+    @staticmethod
+    def _default_agent_id(agent: Agent, manifest: Any) -> str:
+        """The id in ``/v1/<id>/init``: the manifest's, else a class-name slug.
+
+        The manifest id is authoritative because that is what the daemon relay
+        and every consumer address the agent by — deriving a different one here
+        would mount the route at a path nothing calls.
+        """
+        manifest_id = getattr(manifest, "id", None)
+        if manifest_id:
+            return str(manifest_id)
+        cls = agent.__class__.__name__
+        return cls[:-5].lower() if cls.endswith("Agent") else cls.lower()
 
     def _ensure_interface(self, interface: str) -> None:
         """Raise if *interface* is disabled by the manifest's ``interfaces``.
@@ -453,6 +486,8 @@ class AgentServer:
         async def list_tools():
             return {"tools": self._tool_definitions()}
 
+        self._mount_init_routes(app)
+
         @app.post("/v1/chat/completions")
         async def create_chat_completion(request: ChatCompletionRequest):
             if request.model != self.model_id:
@@ -505,6 +540,103 @@ class AgentServer:
             )
 
         return app
+
+    def _mount_init_routes(self, app) -> None:
+        """Mount ``GET``/``POST /v1/<id>/init`` when the agent declared needs.
+
+        An agent that declared nothing gets no routes: a readiness endpoint that
+        answers "ready" without having checked anything is worse than a 404,
+        because a consumer would trust it. The absence is logged so the reason
+        is discoverable rather than mysterious.
+        """
+        import asyncio
+
+        from fastapi import Response
+        from fastapi.concurrency import iterate_in_threadpool
+        from fastapi.responses import StreamingResponse
+
+        from gaia.agents.base import readiness
+
+        # An empty declaration is treated exactly like a missing one: a manifest
+        # with no `models:` and no minimum version states nothing to verify, and
+        # an /init built from it would answer "ready" the moment the backend is
+        # up without having checked a single thing about this agent.
+        if self.requirements is None or not self.requirements.declares_anything():
+            logger.debug(
+                "%s declared no requirements, so /v1/%s/init is not mounted. "
+                "Pass requirements=AgentRequirements(...) to AgentServer, or "
+                "declare models:/requirements: in gaia-agent.yaml, to get it.",
+                self.name,
+                self.agent_id,
+            )
+            return
+
+        _, _, InitResponse = readiness.init_models()
+        path = f"/v1/{self.agent_id}/init"
+        requirements = self.requirements
+        agent_name = self.name
+
+        @app.get(
+            path, response_model=InitResponse, responses={503: {"model": InitResponse}}
+        )
+        async def agent_init(response: Response):
+            """Readiness preflight for this agent's declared requirements.
+
+            200 when ready, 503 when not — the SAME body either way, with an
+            actionable ``hint``. Read-only: no pull, no install, no mutation.
+            """
+            status = await asyncio.to_thread(
+                readiness.compute_init_status, requirements, agent_name
+            )
+            if not status.ready:
+                response.status_code = 503
+            return status
+
+        @app.post(path, include_in_schema=False)
+        async def agent_provision() -> StreamingResponse:
+            """Provision this agent's declared model, streaming progress.
+
+            Tells an already-running backend to download the model. It cannot
+            install the backend — if that is what is missing this returns a real
+            503 and pulls nothing. Once a pull starts the response is a
+            committed 200 and the final ``✓``/``✗`` line is authoritative.
+            """
+            media_type = "text/plain; charset=utf-8"
+            model_id = requirements.model_id
+            reachable, probe_base, _version, _loaded = await asyncio.to_thread(
+                readiness.probe_backend_health, requirements.base_url
+            )
+
+            if not reachable:
+                # Fail loudly BEFORE streaming so the status code is a truthful
+                # 503 rather than a 200 the consumer must parse to disbelieve.
+                return StreamingResponse(
+                    readiness.unreachable_progress(probe_base, agent_name),
+                    media_type=media_type,
+                    status_code=503,
+                )
+
+            if not model_id:
+
+                def _nothing_to_do():
+                    yield (
+                        f"✓ {agent_name} declares no model, so there is nothing "
+                        "to provision.\n"
+                    )
+
+                return StreamingResponse(
+                    _nothing_to_do(), media_type=media_type, status_code=200
+                )
+
+            # The generator does blocking HTTP (including a long pull), so it is
+            # iterated in a worker thread and never on the event loop.
+            return StreamingResponse(
+                iterate_in_threadpool(
+                    readiness.provision_progress(probe_base, model_id, agent_name)
+                ),
+                media_type=media_type,
+                status_code=200,
+            )
 
     def _sse_stream(self, prompt: str):
         """Minimal OpenAI-compatible SSE: role chunk, content chunk, done."""

--- a/tests/unit/test_agent_readiness.py
+++ b/tests/unit/test_agent_readiness.py
@@ -1,0 +1,555 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""Unit tests for inherited agent init (``gaia.agents.base.readiness``).
+
+Covers the readiness probe, the provisioning stream, and the routes
+:class:`~gaia.agents.base.server.AgentServer` mounts from a declaration —
+without a live Lemonade server.
+
+Two properties these tests exist to defend:
+
+* **Indeterminate is never a pass.** A backend that does not advertise a
+  version, or a model list that cannot be read, must be reported as unknown —
+  not as ready, and not as missing.
+* **The agent never installs the backend.** An unreachable backend fails loudly
+  and names whose job the fix is; nothing is pulled.
+"""
+
+import pytest
+import requests
+
+from gaia.agents.base.agent import Agent
+from gaia.agents.base.readiness import (
+    AgentRequirements,
+    compute_init_status,
+    extract_loaded_ctx,
+    parse_version,
+    provision_progress,
+    resolve_probe_base,
+    version_meets_min,
+)
+from gaia.agents.base.server import AgentServer
+
+MODULE = "gaia.agents.base.readiness"
+
+
+class FakeAgent(Agent):
+    """Minimal Agent that skips the heavy LLM/Lemonade ``__init__``."""
+
+    def __init__(self):  # noqa: D401 - deliberately skip super().__init__
+        pass
+
+    def _register_tools(self):
+        pass
+
+    def process_query(self, user_input, **kwargs):
+        return {"status": "success", "result": user_input}
+
+    def get_tools_info(self):
+        return {}
+
+
+@pytest.fixture
+def reqs():
+    return AgentRequirements(model_id="Test-Model", min_backend_version="10.2.0")
+
+
+def _patch_health(monkeypatch, reachable=True, version="10.10.0", loaded=None):
+    monkeypatch.setattr(
+        f"{MODULE}.probe_backend_health",
+        lambda base_url=None: (
+            reachable,
+            "http://localhost:13305/api/v1",
+            version,
+            loaded or [],
+        ),
+    )
+
+
+def _patch_present(monkeypatch, present=True, raises=None):
+    def _probe(probe_base, model_id):
+        if raises is not None:
+            raise raises
+        return present
+
+    monkeypatch.setattr(f"{MODULE}.probe_model_present", _probe)
+
+
+# ---------------------------------------------------------------------------
+# Version comparison — indeterminate is not a pass
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "found,minimum,expected",
+    [
+        ("10.10.0", "10.2.0", True),
+        ("v10.10.0", "10.2.0", True),
+        ("10.2.0", "10.2.0", True),
+        ("10.1.9", "10.2.0", False),
+        ("9.1.4", "10.2.0", False),
+        (None, "10.2.0", None),  # server advertised nothing
+        ("not-a-version", "10.2.0", None),  # unparseable
+        ("10.10.0", None, None),  # agent declared no minimum
+    ],
+)
+def test_version_meets_min(found, minimum, expected):
+    assert version_meets_min(found, minimum) is expected
+
+
+def test_parse_version_ignores_trailing_parts():
+    assert parse_version("10.10.0.1234") == (10, 10, 0)
+
+
+# ---------------------------------------------------------------------------
+# Loaded-context extraction — report, never guess
+# ---------------------------------------------------------------------------
+
+
+def test_extract_loaded_ctx_matches_model_name():
+    loaded = [{"model_name": "Test-Model", "recipe_options": {"ctx_size": 65536}}]
+    assert extract_loaded_ctx(loaded, "Test-Model") == 65536
+
+
+def test_extract_loaded_ctx_matches_checkpoint():
+    loaded = [{"checkpoint": "Test-Model", "recipe_options": {"ctx_size": 4096}}]
+    assert extract_loaded_ctx(loaded, "Test-Model") == 4096
+
+
+@pytest.mark.parametrize(
+    "entry",
+    [
+        {"model_name": "Other-Model", "recipe_options": {"ctx_size": 4096}},
+        {"model_name": "Test-Model"},  # no recipe_options
+        {"model_name": "Test-Model", "recipe_options": {}},  # no ctx_size
+        {"model_name": "Test-Model", "recipe_options": {"ctx_size": 0}},
+        {"model_name": "Test-Model", "recipe_options": {"ctx_size": True}},  # bool
+    ],
+)
+def test_extract_loaded_ctx_returns_none_rather_than_guessing(entry):
+    assert extract_loaded_ctx([entry], "Test-Model") is None
+
+
+# ---------------------------------------------------------------------------
+# Probe base resolution
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "given,expected",
+    [
+        ("http://host:1234", "http://host:1234/api/v1"),
+        ("http://host:1234/", "http://host:1234/api/v1"),
+        ("http://host:1234/api/v1", "http://host:1234/api/v1"),
+    ],
+)
+def test_resolve_probe_base_normalises(given, expected):
+    assert resolve_probe_base(given) == expected
+
+
+# ---------------------------------------------------------------------------
+# Readiness — the failure ladder, in dependency order
+# ---------------------------------------------------------------------------
+
+
+def test_unreachable_backend_names_whose_job_the_fix_is(monkeypatch, reqs):
+    _patch_health(monkeypatch, reachable=False, version=None)
+    status = compute_init_status(reqs, "Test Agent")
+
+    assert status.ready is False
+    assert status.lemonade.reachable is False
+    # Indeterminate, not a failure: an unreachable server has no version to compare.
+    assert status.lemonade.compatible is None
+    assert "lemonade-server serve" in status.hint
+    # The boundary must be explicit — the agent cannot bootstrap the backend.
+    assert "host prerequisite" in status.hint
+
+
+def test_unreachable_backend_never_probes_for_the_model(monkeypatch, reqs):
+    _patch_health(monkeypatch, reachable=False, version=None)
+
+    def _boom(probe_base, model_id):
+        raise AssertionError("must not probe the model list on a dead backend")
+
+    monkeypatch.setattr(f"{MODULE}.probe_model_present", _boom)
+    assert compute_init_status(reqs).ready is False
+
+
+def test_version_too_old_is_reported_before_a_missing_model(monkeypatch, reqs):
+    """Upgrading the backend comes first even when the model is also missing.
+
+    The other order would send the user to download gigabytes that the old
+    server may then refuse to serve.
+    """
+    _patch_health(monkeypatch, version="10.1.0")
+    _patch_present(monkeypatch, present=False)
+
+    status = compute_init_status(reqs, "Test Agent")
+
+    assert status.ready is False
+    assert status.lemonade.compatible is False
+    assert "older than the required 10.2.0" in status.hint
+    assert "not downloaded" not in status.hint
+
+
+def test_missing_model_hint_offers_both_remedies(monkeypatch, reqs):
+    _patch_health(monkeypatch)
+    _patch_present(monkeypatch, present=False)
+
+    status = compute_init_status(reqs, "Test Agent")
+
+    assert status.ready is False
+    assert status.model.present is False
+    assert "gaia init" in status.hint
+    assert "POST" in status.hint  # the pull-it-here path
+
+
+def test_unreadable_model_list_is_not_reported_as_missing(monkeypatch, reqs):
+    """ "Could not tell" and "absent" have different remedies.
+
+    Reporting an unreadable list as a missing model sends the user to
+    re-download something they may already have.
+    """
+    _patch_health(monkeypatch)
+    _patch_present(monkeypatch, raises=requests.exceptions.ConnectionError("boom"))
+
+    status = compute_init_status(reqs, "Test Agent")
+
+    assert status.ready is False
+    assert "model list" in status.hint
+    assert "could not be read" in status.hint
+    assert "not downloaded" not in status.hint
+
+
+def test_indeterminate_version_does_not_block_readiness(monkeypatch, reqs):
+    """A server that advertises no version is unknown, not incompatible."""
+    _patch_health(monkeypatch, version=None)
+    _patch_present(monkeypatch, present=True)
+
+    status = compute_init_status(reqs, "Test Agent")
+
+    assert status.ready is True
+    assert status.lemonade.compatible is None
+
+
+def test_ready_reports_loaded_context_and_no_hint(monkeypatch, reqs):
+    _patch_health(
+        monkeypatch,
+        loaded=[{"model_name": "Test-Model", "recipe_options": {"ctx_size": 65536}}],
+    )
+    _patch_present(monkeypatch, present=True)
+
+    status = compute_init_status(reqs, "Test Agent")
+
+    assert status.ready is True
+    assert status.model.ctx_size == 65536
+    assert status.hint is None
+
+
+def test_agent_with_no_declared_model_is_ready_on_a_live_backend(monkeypatch):
+    """A model-less agent's readiness is just "the backend is up and current"."""
+    _patch_health(monkeypatch)
+
+    def _boom(probe_base, model_id):
+        raise AssertionError("must not probe a model the agent never declared")
+
+    monkeypatch.setattr(f"{MODULE}.probe_model_present", _boom)
+
+    status = compute_init_status(
+        AgentRequirements(min_backend_version="10.2.0"), "Test Agent"
+    )
+    assert status.ready is True
+
+
+def test_model_less_agent_still_fails_an_old_backend(monkeypatch):
+    _patch_health(monkeypatch, version="9.1.4")
+    status = compute_init_status(
+        AgentRequirements(min_backend_version="10.2.0"), "Test Agent"
+    )
+    assert status.ready is False
+    assert "older than the required" in status.hint
+
+
+# ---------------------------------------------------------------------------
+# Provisioning — the final line is the verdict
+# ---------------------------------------------------------------------------
+
+
+def _final(lines):
+    return [ln for ln in lines if ln.strip()][-1]
+
+
+def test_provision_skips_the_pull_when_the_model_is_present(monkeypatch):
+    _patch_present(monkeypatch, present=True)
+    monkeypatch.setattr(
+        f"{MODULE}.pull_model",
+        lambda *a: pytest.fail("must not pull a model that is already present"),
+    )
+
+    lines = list(provision_progress("http://b/api/v1", "Test-Model", "Test Agent"))
+
+    assert "already downloaded" in "".join(lines)
+    assert _final(lines).startswith("✓")
+
+
+def test_provision_pulls_then_verifies(monkeypatch):
+    calls = {"pull": 0, "present": 0}
+
+    def _present(probe_base, model_id):
+        calls["present"] += 1
+        # Absent on the pre-check, present on the post-pull verify.
+        return calls["present"] > 1
+
+    monkeypatch.setattr(f"{MODULE}.probe_model_present", _present)
+    monkeypatch.setattr(
+        f"{MODULE}.pull_model", lambda *a: calls.__setitem__("pull", calls["pull"] + 1)
+    )
+
+    lines = list(provision_progress("http://b/api/v1", "Test-Model", "Test Agent"))
+
+    assert calls["pull"] == 1
+    assert "Verified" in "".join(lines)
+    assert _final(lines).startswith("✓")
+
+
+def test_failed_pull_ends_on_a_failure_line(monkeypatch):
+    """The stream is a committed 200, so the final line has to carry the verdict."""
+    _patch_present(monkeypatch, present=False)
+
+    def _pull(probe_base, model_id):
+        raise requests.exceptions.HTTPError("400 Client Error")
+
+    monkeypatch.setattr(f"{MODULE}.pull_model", _pull)
+
+    lines = list(provision_progress("http://b/api/v1", "Test-Model", "Test Agent"))
+
+    assert _final(lines).startswith("✗")
+    assert "was not downloaded" in "".join(lines)
+
+
+def test_pull_that_does_not_register_is_a_failure_not_a_success(monkeypatch):
+    """Lemonade reporting OK is not proof the model landed."""
+    monkeypatch.setattr(f"{MODULE}.probe_model_present", lambda *a: False)
+    monkeypatch.setattr(f"{MODULE}.pull_model", lambda *a: None)
+
+    lines = list(provision_progress("http://b/api/v1", "Test-Model", "Test Agent"))
+
+    assert _final(lines).startswith("✗")
+    assert "still not listed" in "".join(lines)
+
+
+def test_unverifiable_pull_warns_rather_than_claiming_success(monkeypatch):
+    calls = {"n": 0}
+
+    def _present(probe_base, model_id):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            return False
+        raise requests.exceptions.ConnectionError("verify read failed")
+
+    monkeypatch.setattr(f"{MODULE}.probe_model_present", _present)
+    monkeypatch.setattr(f"{MODULE}.pull_model", lambda *a: None)
+
+    body = "".join(provision_progress("http://b/api/v1", "Test-Model", "Test Agent"))
+
+    assert "⚠" in body
+
+
+def test_unreadable_list_aborts_before_pulling(monkeypatch):
+    _patch_present(monkeypatch, raises=requests.exceptions.ConnectionError("boom"))
+    monkeypatch.setattr(
+        f"{MODULE}.pull_model",
+        lambda *a: pytest.fail("must not pull when the list could not be read"),
+    )
+
+    lines = list(provision_progress("http://b/api/v1", "Test-Model", "Test Agent"))
+    assert _final(lines).startswith("✗")
+
+
+# ---------------------------------------------------------------------------
+# The declaration
+# ---------------------------------------------------------------------------
+
+
+def test_from_manifest_reads_the_declared_model():
+    from gaia.hub.manifest import AgentManifest
+
+    manifest = AgentManifest.from_dict(
+        {
+            "id": "declared",
+            "name": "Declared",
+            "version": "0.1.0",
+            "description": "d",
+            "author": "AMD",
+            "license": "MIT",
+            "language": "python",
+            "models": ["Declared-Model"],
+            "interfaces": {"api_server": True},
+        }
+    )
+    assert AgentRequirements.from_manifest(manifest).model_id == "Declared-Model"
+
+
+def test_from_manifest_without_models_declares_nothing():
+    from gaia.hub.manifest import AgentManifest
+
+    manifest = AgentManifest.from_dict(
+        {
+            "id": "bare",
+            "name": "Bare",
+            "version": "0.1.0",
+            "description": "d",
+            "author": "AMD",
+            "license": "MIT",
+            "language": "python",
+            "interfaces": {"api_server": True},
+        }
+    )
+    assert AgentRequirements.from_manifest(manifest).model_id is None
+
+
+# ---------------------------------------------------------------------------
+# The routes AgentServer mounts from a declaration
+# ---------------------------------------------------------------------------
+
+
+def _client(**kwargs):
+    from fastapi.testclient import TestClient
+
+    server = AgentServer(FakeAgent(), name="Test Agent", **kwargs)
+    return TestClient(server.build_api_app(), raise_server_exceptions=False)
+
+
+def test_no_declaration_means_no_init_route():
+    """An /init that answers "ready" without checking anything is worse than a 404."""
+    assert _client().get("/v1/fake/init").status_code == 404
+
+
+def test_empty_declaration_is_treated_as_no_declaration():
+    """A manifest with no models and no minimum version declares nothing.
+
+    Mounting /init for it would answer "ready" the moment the backend is up,
+    having verified nothing about the agent — and a consumer would believe it.
+    """
+    empty = AgentRequirements()
+    assert empty.declares_anything() is False
+    assert (
+        _client(requirements=empty, agent_id="fake").get("/v1/fake/init").status_code
+        == 404
+    )
+
+
+def test_base_url_alone_does_not_count_as_a_declaration():
+    """It says where to look, not what is required."""
+    assert AgentRequirements(base_url="http://host/api/v1").declares_anything() is False
+
+
+@pytest.mark.parametrize(
+    "requirements",
+    [
+        AgentRequirements(model_id="Test-Model"),
+        AgentRequirements(min_backend_version="10.2.0"),
+    ],
+)
+def test_either_half_of_a_declaration_is_enough(requirements):
+    assert requirements.declares_anything() is True
+
+
+def test_manifest_without_models_mounts_no_init_route():
+    """The manifest path must obey the same rule as the explicit one."""
+    from gaia.hub.manifest import AgentManifest
+
+    manifest = AgentManifest.from_dict(
+        {
+            "id": "bare",
+            "name": "Bare",
+            "version": "0.1.0",
+            "description": "d",
+            "author": "AMD",
+            "license": "MIT",
+            "language": "python",
+            "interfaces": {"api_server": True},
+        }
+    )
+    from fastapi.testclient import TestClient
+
+    server = AgentServer(FakeAgent(), manifest=manifest)
+    client = TestClient(server.build_api_app(), raise_server_exceptions=False)
+    assert client.get("/v1/bare/init").status_code == 404
+
+
+def test_model_less_agent_names_that_no_model_is_required(monkeypatch):
+    _patch_health(monkeypatch)
+    status = compute_init_status(
+        AgentRequirements(min_backend_version="10.2.0"), "Test Agent"
+    )
+    assert status.ready is True
+    # present=True so a consumer's "is the model downloaded?" check does not
+    # fail over a model that was never required; the id says there is none.
+    assert status.model.present is True
+    assert status.model.id == "(none required)"
+
+
+def test_declared_requirements_mount_the_route(monkeypatch, reqs):
+    _patch_health(monkeypatch)
+    _patch_present(monkeypatch, present=True)
+
+    resp = _client(requirements=reqs, agent_id="fake").get("/v1/fake/init")
+
+    assert resp.status_code == 200
+    assert resp.json()["ready"] is True
+
+
+def test_not_ready_is_served_as_503_with_the_same_body(monkeypatch, reqs):
+    _patch_health(monkeypatch, reachable=False, version=None)
+
+    resp = _client(requirements=reqs, agent_id="fake").get("/v1/fake/init")
+
+    assert resp.status_code == 503
+    body = resp.json()
+    # Same shape as the 200 — a consumer parses one contract, not two.
+    assert body["ready"] is False
+    assert set(body) == {"ready", "lemonade", "model", "hint"}
+    assert body["hint"]
+
+
+def test_agent_id_defaults_to_the_manifest_id(reqs):
+    from gaia.hub.manifest import AgentManifest
+
+    manifest = AgentManifest.from_dict(
+        {
+            "id": "from-manifest",
+            "name": "M",
+            "version": "0.1.0",
+            "description": "d",
+            "author": "AMD",
+            "license": "MIT",
+            "language": "python",
+            "interfaces": {"api_server": True},
+        }
+    )
+    server = AgentServer(FakeAgent(), manifest=manifest, requirements=reqs)
+    assert server.agent_id == "from-manifest"
+
+
+def test_provision_route_refuses_with_503_when_the_backend_is_down(monkeypatch, reqs):
+    _patch_health(monkeypatch, reachable=False, version=None)
+    monkeypatch.setattr(
+        f"{MODULE}.pull_model",
+        lambda *a: pytest.fail("must not pull against an unreachable backend"),
+    )
+
+    resp = _client(requirements=reqs, agent_id="fake").post("/v1/fake/init")
+
+    assert resp.status_code == 503
+    assert "host prerequisite" in resp.text
+
+
+def test_provision_route_streams_progress(monkeypatch, reqs):
+    _patch_health(monkeypatch)
+    _patch_present(monkeypatch, present=True)
+
+    resp = _client(requirements=reqs, agent_id="fake").post("/v1/fake/init")
+
+    assert resp.status_code == 200
+    assert resp.text.strip().splitlines()[-1].startswith("✓")

--- a/tui/internal/cli/agents.go
+++ b/tui/internal/cli/agents.go
@@ -23,6 +23,7 @@ var (
 	installTrust      bool
 	runQuery          string
 	runModel          string
+	runTimeout        time.Duration
 )
 
 // hubClient builds a client over the real daemon, logging through --debug.
@@ -246,14 +247,19 @@ var runCmd = &cobra.Command{
 	Long: "Open the chat TUI for an installed agent.\n\n" +
 		"--query makes it a genuine non-interactive one-shot: no alt screen, the " +
 		"answer on stdout, progress on stderr, and exit 0 on a final answer / 1 on " +
-		"an error. That is what makes it usable from a script or from CI.",
+		"an error. That is what makes it usable from a script or from CI.\n\n" +
+		"A one-shot checks its preconditions first and refuses in seconds — naming " +
+		"the unmet one and the command that fixes it on stderr — rather than waiting " +
+		"on a model server that is not there. The turn itself is bounded too, so an " +
+		"agent that accepts the query and then goes quiet is reported, never waited " +
+		"on forever — raise or lower that bound with --timeout.",
 	Args:         cobra.ExactArgs(1),
 	SilenceUsage: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if err := checkModelSupported(args[0], runModel); err != nil {
 			return err
 		}
-		code, err := ui.RunAgent(args[0], runQuery, runModel, debug)
+		code, err := ui.RunAgent(args[0], runQuery, runModel, debug, runTimeout)
 		if err != nil {
 			return err
 		}
@@ -381,6 +387,8 @@ func init() {
 		"run one query non-interactively: answer on stdout, exit 0/1")
 	runCmd.Flags().StringVar(&runModel, "model", "",
 		"model id override (the agent's default is used when unset)")
+	runCmd.Flags().DurationVar(&runTimeout, "timeout", ui.DefaultOneShotTimeout,
+		"how long one --query turn may take before it is abandoned and reported (e.g. 90s, 2h)")
 
 	rootCmd.AddCommand(listCmd, installCmd, uninstallCmd, runCmd, statusCmd)
 }

--- a/tui/internal/cli/chat.go
+++ b/tui/internal/cli/chat.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"fmt"
 	"os"
+	"time"
 
 	"github.com/spf13/cobra"
 
@@ -10,10 +11,11 @@ import (
 )
 
 var (
-	subprocess string
-	query      string
-	agentID    string
-	chatModel  string
+	subprocess  string
+	query       string
+	agentID     string
+	chatModel   string
+	chatTimeout time.Duration
 )
 
 var chatCmd = &cobra.Command{
@@ -27,7 +29,7 @@ var chatCmd = &cobra.Command{
 			return fmt.Errorf("--agent and --subprocess are mutually exclusive: pick one")
 		}
 		if agentID != "" {
-			code, err := ui.RunAgent(agentID, query, chatModel, debug)
+			code, err := ui.RunAgent(agentID, query, chatModel, debug, chatTimeout)
 			if err != nil {
 				return err
 			}
@@ -56,6 +58,8 @@ func init() {
 	chatCmd.Flags().StringVar(&agentID, "agent", "", "catalog agent id to chat with (e.g. \"email\")")
 	chatCmd.Flags().StringVar(&chatModel, "model", "", "model id override (--agent only; the sidecar default is used when unset)")
 	chatCmd.Flags().StringVar(&subprocess, "subprocess", "", "command to spawn agent subprocess (e.g. \"./gaia-bash --json-events\")")
-	chatCmd.Flags().StringVar(&query, "query", "", "single query to send; with --agent this is a genuine non-interactive one-shot (answer on stdout, exit 0/1)")
+	chatCmd.Flags().StringVar(&query, "query", "", "single query to send; with --agent this is a genuine non-interactive one-shot: it refuses in seconds when a precondition is unmet, answers on stdout, and exits 0/1")
+	chatCmd.Flags().DurationVar(&chatTimeout, "timeout", ui.DefaultOneShotTimeout,
+		"how long one --query turn may take before it is abandoned and reported (--agent only)")
 	rootCmd.AddCommand(chatCmd)
 }

--- a/tui/internal/ui/app.go
+++ b/tui/internal/ui/app.go
@@ -6,13 +6,16 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
 
 	"github.com/amd/gaia/tui/internal/catalog"
 	"github.com/amd/gaia/tui/internal/client"
 	"github.com/amd/gaia/tui/internal/control"
+	"github.com/amd/gaia/tui/internal/daemon"
 	"github.com/amd/gaia/tui/internal/ui/chat"
+	"github.com/amd/gaia/tui/internal/ui/preflight"
 	"github.com/amd/gaia/tui/internal/ui/root"
 )
 
@@ -93,8 +96,10 @@ func run(model tea.Model, debug bool, ctrl *control.Options) error {
 // With query != "" this is a genuine non-interactive one-shot: no alt screen, the
 // answer on stdout, progress on stderr, and a real exit code. That is what makes
 // the transport exercisable from a script, from CI, and against a live daemon.
+// timeout bounds that turn; it is ignored by the interactive path, where a person
+// can see what is happening and press ctrl+c.
 // Returns the process exit code.
-func RunAgent(agentID, query, model string, debug bool) (int, error) {
+func RunAgent(agentID, query, model string, debug bool, timeout time.Duration) (int, error) {
 	cat := catalog.NewCatalog()
 	cat.DiscoverBinaries()
 
@@ -102,6 +107,15 @@ func RunAgent(agentID, query, model string, debug bool) (int, error) {
 	if agent == nil {
 		return 1, fmt.Errorf("no agent %q in the catalog — known ids: %s",
 			agentID, strings.Join(agentIDs(cat), ", "))
+	}
+
+	// A one-shot is always bounded — that is the whole point — so an unbounded
+	// or negative one is refused here rather than quietly turned into "forever".
+	if query != "" && timeout <= 0 {
+		return 1, fmt.Errorf(
+			"--timeout must be a positive duration, got %s: a one-shot that cannot "+
+				"time out is exactly the hang this bound exists to prevent. Pass a "+
+				"longer bound instead, e.g. --timeout 2h", timeout)
 	}
 
 	logf := func(string, ...any) {}
@@ -122,7 +136,25 @@ func RunAgent(agentID, query, model string, debug bool) (int, error) {
 	defer c.Close()
 
 	if query != "" {
-		res := RunOneShot(context.Background(), c, query, os.Stdout, os.Stderr)
+		// A one-shot runs unattended, so an unmet precondition has to be
+		// reported and refused rather than waited on. Interactive is left alone
+		// on purpose: a person can read a half-answer and press ctrl+c, and the
+		// launch that does have a gate is the hub's.
+		if agent.Transport == catalog.TransportDaemon {
+			// Only a relayed agent has the /v1/<agent>/init route the check
+			// probes. For a subprocess agent the rows could only say "not
+			// installed" — four wrong answers over a launch that works.
+			t := preflight.NewDaemonTransport(daemon.New(daemon.Options{Logf: logf}))
+			rep := ReportReadiness(context.Background(), t,
+				preflight.ConfigFor(agent.ID, agent.Name), os.Stderr)
+			if rep.Blocked() {
+				return 1, nil
+			}
+		}
+
+		ctx, cancel := context.WithTimeout(context.Background(), timeout)
+		defer cancel()
+		res := RunOneShot(ctx, c, query, os.Stdout, os.Stderr)
 		return res.ExitCode, nil
 	}
 

--- a/tui/internal/ui/oneshot.go
+++ b/tui/internal/ui/oneshot.go
@@ -2,12 +2,15 @@ package ui
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"strings"
+	"time"
 
 	"github.com/amd/gaia/tui/internal/client"
 	"github.com/amd/gaia/tui/internal/event"
+	"github.com/amd/gaia/tui/internal/ui/preflight"
 )
 
 // OneShotResult is the outcome of one non-interactive turn. It mirrors
@@ -46,9 +49,10 @@ func RunOneShot(
 		res       OneShotResult
 		streamed  strings.Builder
 		sawTokens bool
+		started   = time.Now()
 	)
 
-	for evt := range ch {
+	handle := func(evt interface{}) {
 		switch e := evt.(type) {
 		case event.CanonicalStatusEvent:
 			if msg := strings.TrimSpace(e.Message); msg != "" {
@@ -57,7 +61,7 @@ func RunOneShot(
 
 		case event.CanonicalTokenEvent:
 			if e.Delta == "" {
-				continue
+				return
 			}
 			sawTokens = true
 			streamed.WriteString(e.Delta)
@@ -139,6 +143,55 @@ func RunOneShot(
 		}
 	}
 
+	for {
+		select {
+		case evt, open := <-ch:
+			if !open {
+				// The stream closed; the terminal-event check decides.
+				return finishOneShot(res, query, errW)
+			}
+			handle(evt)
+
+		case <-ctx.Done():
+			// The caller's deadline is the only bound on a dependency that
+			// accepts the query and then goes quiet — the relay's read watchdog
+			// is reset by every heartbeat, so a wedged sidecar can keep the
+			// stream alive indefinitely without ever answering.
+			//
+			// A plain select picks UNIFORMLY when both cases are ready, so an
+			// answer that landed in the same instant as the deadline would be
+			// thrown away half the time. Everything already delivered is still
+			// the agent's answer: take that first, then give up. The drain is
+			// bounded by what is buffered right now, so a chatty stream cannot
+			// starve the deadline it is being held to.
+			for i, buffered := 0, len(ch); i < buffered; i++ {
+				select {
+				case evt, open := <-ch:
+					if !open {
+						return finishOneShot(res, query, errW)
+					}
+					handle(evt)
+				default:
+				}
+			}
+			if res.TerminalType != "" {
+				return finishOneShot(res, query, errW)
+			}
+
+			if sawTokens {
+				fmt.Fprintln(out)
+			}
+			res.TerminalType = event.CanonicalTypeError
+			res.ExitCode = 1
+			res.ErrorDetail = abandonedDetail(ctx.Err(), query, time.Since(started))
+			fmt.Fprintf(errW, "❌ %s\n", res.ErrorDetail)
+			return res
+		}
+	}
+}
+
+// finishOneShot applies the terminal-event contract to a stream that closed.
+func finishOneShot(res OneShotResult, query string, errW io.Writer) OneShotResult {
 	if res.TerminalType == "" {
 		// Exactly one terminal event is mandatory; a stream that ends without one
 		// is a failure, reported loudly rather than as an empty success.
@@ -150,4 +203,109 @@ func RunOneShot(
 		res.ExitCode = 1
 	}
 	return res
+}
+
+// Bounds on the non-interactive path. Every one of these replaced an unbounded
+// wait: a dependency that refuses is reported by the readiness rows below, but
+// one that accepts and then goes quiet is only ever caught by a deadline.
+const (
+	// readinessEnsureTimeout bounds start-or-attach of the background service and
+	// the spawn of the agent's sidecar. It matches the gate's own ensureTimeout
+	// and the daemon client's ensure budget on purpose: a first run may still
+	// fetch the sidecar binary here, and a bound tighter than the hub's would
+	// refuse a cold start the hub completes on the same machine.
+	readinessEnsureTimeout = 15 * time.Minute
+	// readinessCheckTimeout bounds the readiness probe. Same value as the gate's
+	// checkTimeout, over the same call — two paths asking the same question must
+	// not disagree about how long the answer may take.
+	readinessCheckTimeout = 90 * time.Second
+	// DefaultOneShotTimeout bounds one whole non-interactive turn. The relay
+	// reads with a 300s idle timeout per chunk and an agent loop can take several
+	// steps, so this sits well above a healthy-but-slow run — including one whose
+	// first token waits on a cold model load — while still turning a wedged
+	// stream into a reportable error instead of a silent hang. `--timeout` raises
+	// or lowers it for a run that legitimately needs longer.
+	DefaultOneShotTimeout = 15 * time.Minute
+)
+
+// ReportReadiness runs the readiness gate headlessly for the one-shot path and
+// returns what it found.
+//
+// It deliberately does NOT render the interactive gate: a script has nobody to
+// press a key. Everything it prints goes to errW — the answer's stream stays
+// clean — and the blocked report carries the same rows and remedies the gate
+// shows for the same condition, because both render the same preflight.Report.
+//
+// A report that is neither ready nor blocked (an indeterminate row) does not
+// stop the run, matching the gate: unknown is named, not refused.
+func ReportReadiness(
+	ctx context.Context,
+	t preflight.Transport,
+	cfg preflight.Config,
+	errW io.Writer,
+) preflight.Report {
+	// Start-or-attach the background service and spawn the sidecar first —
+	// exactly what the turn does on its own. Skipping it would newly refuse a
+	// scripted run on a cold machine that used to start what it needed. A
+	// failure is announced, then diagnosed by the rows, which name it with a
+	// remedy instead of a raw transport error.
+	ensureCtx, cancelEnsure := context.WithTimeout(ctx, readinessEnsureTimeout)
+	ensureErr := t.EnsureAgent(ensureCtx, cfg.AgentID)
+	cancelEnsure()
+	if ensureErr != nil {
+		// Through the ladder, so this reads like every other failure the gate
+		// reports: what failed, what to do, where to look — never a raw error.
+		d := preflight.Ladder{AgentID: cfg.AgentID}.
+			Error("start the "+cfg.AgentName+" agent", ensureErr)
+		fmt.Fprintf(errW, "⚠️  %s\n", d.String())
+	}
+
+	checkCtx, cancelCheck := context.WithTimeout(ctx, readinessCheckTimeout)
+	defer cancelCheck()
+
+	rep := preflight.Check(checkCtx, t, cfg)
+	writeReadiness(errW, rep)
+	return rep
+}
+
+// writeReadiness renders a report for a terminal that nobody is watching.
+func writeReadiness(errW io.Writer, rep preflight.Report) {
+	blocker, blocked := rep.Blocker()
+	if !blocked {
+		// Nothing failed. Anything that could not be VERIFIED is still named —
+		// the run proceeds, but silence here would read as "all clear" — and it
+		// keeps its remedy, which is the only thing that makes it fixable.
+		for _, row := range rep.Rows {
+			if !row.NeedsAttention() {
+				continue
+			}
+			fmt.Fprintf(errW, "  ⚠️  %s: %s (could not be verified — continuing)\n",
+				row.Label, row.Line)
+			if row.Remedy.Command != "" {
+				fmt.Fprintf(errW, "      run: %s\n", row.Remedy.Command)
+			}
+		}
+		return
+	}
+
+	fmt.Fprintf(errW, "❌ %s is not ready — %s: %s\n", rep.AgentName, blocker.Label, blocker.Line)
+	if blocker.Detail != "" {
+		fmt.Fprintf(errW, "   %s\n", blocker.Detail)
+	}
+	// Report.String is the preflight package's own headless renderer: every row,
+	// every remedy. Rendering the rows here instead would let the two paths drift.
+	fmt.Fprintf(errW, "\n%s\n", strings.TrimRight(rep.String(), "\n"))
+	fmt.Fprintf(errW, "\nNothing was sent to the %s agent. Fix the row above and re-run.\n", rep.AgentName)
+}
+
+// abandonedDetail says what stopped the turn, how long it ran, and where to look.
+func abandonedDetail(err error, query string, elapsed time.Duration) string {
+	if errors.Is(err, context.DeadlineExceeded) {
+		return fmt.Sprintf(
+			"gave up on the %q query after %s — the agent accepted it and then stopped "+
+				"answering. Read `gaia daemon logs` and the agent's own log under "+
+				"~/.gaia/agents/, then retry", query, elapsed.Round(time.Second))
+	}
+	return fmt.Sprintf("the %q query was cancelled after %s, before the agent answered",
+		query, elapsed.Round(time.Second))
 }

--- a/tui/internal/ui/oneshot_test.go
+++ b/tui/internal/ui/oneshot_test.go
@@ -5,7 +5,9 @@ import (
 	"context"
 	"strings"
 	"testing"
+	"time"
 
+	"github.com/amd/gaia/tui/internal/client"
 	"github.com/amd/gaia/tui/internal/event"
 )
 
@@ -176,3 +178,93 @@ func TestRunOneShotHandlesLegacyEvents(t *testing.T) {
 type errFake string
 
 func (e errFake) Error() string { return string(e) }
+
+// stallingClient accepts the query and then never says anything: the channel is
+// never written to and never closed. This is the failure a readiness check
+// cannot catch — the dependency was reachable, it just stopped answering — so
+// the caller's deadline is the only thing standing between it and a hang.
+type stallingClient struct {
+	// first is emitted before the silence, so the partial-line handling is
+	// exercised too.
+	first interface{}
+}
+
+func (s *stallingClient) Send(context.Context, string) (<-chan interface{}, error) {
+	ch := make(chan interface{}, 1)
+	if s.first != nil {
+		ch <- s.first
+	}
+	return ch, nil
+}
+
+func (s *stallingClient) Close() error { return nil }
+
+// runOneShotAsync runs a turn off the test goroutine so a hang fails the test
+// instead of wedging the suite.
+func runOneShotAsync(
+	t *testing.T,
+	ctx context.Context,
+	c client.AgentClient,
+	out, errW *bytes.Buffer,
+) OneShotResult {
+	t.Helper()
+	done := make(chan OneShotResult, 1)
+	go func() { done <- RunOneShot(ctx, c, "triage my inbox", out, errW) }()
+	select {
+	case res := <-done:
+		return res
+	case <-time.After(15 * time.Second):
+		t.Fatal("RunOneShot never returned after its context was done — this is issue #2483")
+		return OneShotResult{}
+	}
+}
+
+// The bug: an agent that accepts the query and then goes quiet used to hang
+// forever, with nothing on either stream.
+func TestRunOneShotAbandonsAStalledStreamAtTheDeadline(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 150*time.Millisecond)
+	defer cancel()
+
+	var out, errW bytes.Buffer
+	c := &stallingClient{first: event.CanonicalTokenEvent{Type: "token", Delta: "Look"}}
+	res := runOneShotAsync(t, ctx, c, &out, &errW)
+
+	if res.ExitCode != 1 {
+		t.Errorf("exit code = %d, want 1 — an abandoned turn is a failure", res.ExitCode)
+	}
+	if res.TerminalType != event.CanonicalTypeError {
+		t.Errorf("terminal = %q, want error", res.TerminalType)
+	}
+	// The partial answer keeps its own line; the diagnosis belongs on stderr.
+	if out.String() != "Look\n" {
+		t.Errorf("stdout = %q, want the streamed text terminated by a newline", out.String())
+	}
+	for _, want := range []string{"gave up", "triage my inbox", "gaia daemon logs"} {
+		if !strings.Contains(errW.String(), want) {
+			t.Errorf("stderr must say what happened and where to look, missing %q:\n%s", want, errW.String())
+		}
+	}
+}
+
+// A cancelled parent context is reported as a cancellation, not as a deadline —
+// the two send the reader to different places.
+func TestRunOneShotReportsACancelledTurnDistinctly(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	var out, errW bytes.Buffer
+	res := runOneShotAsync(t, ctx, &stallingClient{}, &out, &errW)
+
+	if res.ExitCode != 1 {
+		t.Errorf("exit code = %d, want 1", res.ExitCode)
+	}
+	if !strings.Contains(errW.String(), "cancelled") {
+		t.Errorf("stderr = %q, want it to name the cancellation", errW.String())
+	}
+	if strings.Contains(errW.String(), "gave up") {
+		t.Errorf("a cancellation must not be reported as a deadline: %q", errW.String())
+	}
+	if out.String() != "" {
+		t.Errorf("stdout = %q, want empty", out.String())
+	}
+}

--- a/tui/internal/ui/root/introspect.go
+++ b/tui/internal/ui/root/introspect.go
@@ -19,6 +19,14 @@ func (m RootModel) ControlSnapshot() control.Snapshot {
 		snap.VisibleAgentIDs = m.hub.VisibleAgentIDs()
 		snap.Filtering = m.hub.IsFiltering()
 		snap.Overlay = m.hub.Overlay()
+	case viewPreflight:
+		snap.View = "preflight"
+		if m.preflight != nil {
+			snap.Agent = m.preflight.AgentID()
+		}
+		if m.connect != nil {
+			snap.Overlay = "connect-mailbox"
+		}
 	case viewChat:
 		snap.View = "chat"
 		if m.chat != nil {

--- a/tui/internal/ui/root/model.go
+++ b/tui/internal/ui/root/model.go
@@ -11,12 +11,16 @@ import (
 	"github.com/amd/gaia/tui/internal/ui/chat"
 	"github.com/amd/gaia/tui/internal/ui/components"
 	"github.com/amd/gaia/tui/internal/ui/hub"
+	"github.com/amd/gaia/tui/internal/ui/preflight"
 )
 
 type view int
 
 const (
 	viewHub view = iota
+	// viewPreflight is the readiness gate every daemon-backed launch passes
+	// through before chat opens.
+	viewPreflight
 	viewChat
 )
 
@@ -31,6 +35,25 @@ type RootModel struct {
 	width      int
 	height     int
 	debug      bool
+
+	// preflight is the gate currently on screen, nil when there is none.
+	preflight *preflight.Model
+	// pending is the agent that gate is guarding — launched only on ProceedMsg.
+	pending *catalog.Agent
+	// connect is the mailbox hand-off shown over the gate, nil when there is none.
+	connect *connectHandoff
+	// pfTransport is built on first launch and reused for the session.
+	pfTransport preflight.Transport
+	pfOpts      preflight.Options
+}
+
+// WithPreflight points the readiness gate at a specific transport and tunes its
+// options. Tests use it to drive the gate against a fake daemon; a real session
+// leaves it alone and gets the daemon transport.
+func (m RootModel) WithPreflight(t preflight.Transport, opts preflight.Options) RootModel {
+	m.pfTransport = t
+	m.pfOpts = opts
+	return m
 }
 
 func NewRootModel(cat *catalog.Catalog, debug bool) RootModel {
@@ -73,6 +96,8 @@ func (m RootModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			updated, cmd := m.hub.Update(msg)
 			m.hub = updated.(hub.HubModel)
 			return m, cmd
+		case viewPreflight:
+			return m.updatePreflight(msg)
 		case viewChat:
 			if m.chat != nil {
 				updated, cmd := m.chat.Update(msg)
@@ -84,7 +109,25 @@ func (m RootModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, nil
 
 	case hub.LaunchAgentMsg:
-		return m.launchAgent(msg.Agent)
+		return m.beginPreflight(msg.Agent)
+
+	case preflight.ProceedMsg:
+		if !m.gateIsFor(msg.AgentID) {
+			return m, nil
+		}
+		return m.proceedFromGate()
+
+	case preflight.CancelMsg:
+		if !m.gateIsFor(msg.AgentID) {
+			return m, nil
+		}
+		return m.cancelFromGate()
+
+	case preflight.ConnectMailboxMsg:
+		if !m.gateIsFor(msg.AgentID) {
+			return m, nil
+		}
+		return m.openConnectHandoff(msg.Provider)
 
 	case chat.ReturnToHubMsg:
 		return m.returnToHub(msg.AgentID)
@@ -105,6 +148,11 @@ func (m RootModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.showHelp = false
 			return m, nil
 		}
+		// The mailbox hand-off owns every key while it is up, the way the hub's
+		// modals do — otherwise esc would cancel the launch behind it.
+		if m.activeView == viewPreflight && m.connect != nil {
+			return m.handleConnectKey(msg)
+		}
 	}
 
 	// The hub's async results go to the hub whatever is on screen. They are
@@ -121,6 +169,11 @@ func (m RootModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		updated, cmd := m.hub.Update(msg)
 		m.hub = updated.(hub.HubModel)
 		return m, cmd
+	case viewPreflight:
+		// Everything the gate started answers with a message this package cannot
+		// name — the probe result, a fix outcome, download progress, the hold
+		// tick — so the gate gets the whole default stream, spinner ticks and all.
+		return m.updatePreflight(msg)
 	case viewChat:
 		if m.chat != nil {
 			updated, cmd := m.chat.Update(msg)
@@ -138,6 +191,13 @@ func (m RootModel) View() string {
 	switch m.activeView {
 	case viewHub:
 		base = m.hub.View()
+	case viewPreflight:
+		switch {
+		case m.connect != nil:
+			base = m.connect.view(m.width, m.height)
+		case m.preflight != nil:
+			base = m.preflight.View()
+		}
 	case viewChat:
 		if m.chat != nil {
 			base = m.chat.View()

--- a/tui/internal/ui/root/preflight.go
+++ b/tui/internal/ui/root/preflight.go
@@ -1,0 +1,323 @@
+package root
+
+import (
+	"fmt"
+	"strings"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+
+	"github.com/amd/gaia/tui/internal/catalog"
+	"github.com/amd/gaia/tui/internal/daemon"
+	"github.com/amd/gaia/tui/internal/ui/preflight"
+)
+
+// beginPreflight puts the readiness gate between the hub and the chat.
+//
+// The gate runs on EVERY launch and nothing is remembered between them. Each row
+// is a fact with no expiry notice — the daemon can be killed, its client token
+// rotates on every restart, Lemonade can unload the model, a mailbox grant can be
+// revoked from the web — so a cached pass would open a chat that cannot answer
+// while claiming it had been verified. An all-green pass costs one attach plus two
+// relayed GETs and is held ~800ms; that is the price of the answer being true now.
+func (m RootModel) beginPreflight(agent catalog.Agent) (tea.Model, tea.Cmd) {
+	if agent.Transport != catalog.TransportDaemon {
+		// Every precondition the gate reports is probed THROUGH the daemon relay
+		// (GET /v1/<agent>/init). A subprocess agent has no relay and no
+		// registered sidecar, so the gate could only answer "not installed" —
+		// four wrong rows with four wrong remedies, over a launch that works.
+		return m.launchAgent(agent)
+	}
+
+	gate := preflight.New(m.preflightTransport(), preflight.ConfigFor(agent.ID, agent.Name), m.preflightOptions())
+	m.preflight = &gate
+	m.pending = &agent
+	m.connect = nil
+	m.activeView = viewPreflight
+
+	cmds := []tea.Cmd{gate.Init()}
+	if m.width > 0 && m.height > 0 {
+		cmds = append(cmds, m.sizeCmd())
+	}
+	return m, tea.Batch(cmds...)
+}
+
+// preflightTransport builds the gate's transport on first use and keeps it for
+// the session: it caches the daemon instance whose token authorized the last
+// call, and that token rotates on every daemon restart. Building it lazily also
+// keeps a session that never launches anything from constructing a daemon client.
+func (m *RootModel) preflightTransport() preflight.Transport {
+	if m.pfTransport == nil {
+		m.pfTransport = preflight.NewDaemonTransport(daemon.New(daemon.Options{Logf: m.logf}))
+	}
+	return m.pfTransport
+}
+
+// preflightOptions returns the gate's options. ManualProceed is deliberately NOT
+// wired to --debug: the gate's footer only offers `enter` while a report is
+// neither blocked nor ready, so holding an all-green screen would leave a debug
+// user on a green wall whose only advertised keys are re-check and back.
+func (m RootModel) preflightOptions() preflight.Options {
+	opts := m.pfOpts
+	if opts.Logf == nil {
+		opts.Logf = m.logf
+	}
+	return opts
+}
+
+// gateIsFor reports whether the gate on screen is the one that sent this
+// message. A ProceedMsg from a gate the user already backed out of must not
+// launch anything — the hold tick that produced it can still be in flight.
+func (m RootModel) gateIsFor(agentID string) bool {
+	return m.activeView == viewPreflight && m.preflight != nil &&
+		m.pending != nil && m.pending.ID == agentID
+}
+
+// closeGate tears the gate down. Cancel first: the screen owns a probe, a
+// sidecar start, or a model pull, and leaving one running would keep writing
+// into a screen that no longer exists.
+func (m *RootModel) closeGate() {
+	if m.preflight != nil {
+		m.preflight.Cancel()
+		m.preflight = nil
+	}
+	m.pending = nil
+	m.connect = nil
+}
+
+func (m RootModel) proceedFromGate() (tea.Model, tea.Cmd) {
+	agent := *m.pending
+	m.closeGate()
+	// Back to the hub FIRST. launchAgent stays where it is and reports the reason
+	// when a client cannot be built, and "where it is" has to be a screen that
+	// still renders — the gate is gone by now.
+	m.activeView = viewHub
+	return m.launchAgent(agent)
+}
+
+// cancelFromGate returns to the hub. The hub model is untouched while the gate is
+// up, so its tab and highlighted row are exactly where the user left them.
+func (m RootModel) cancelFromGate() (tea.Model, tea.Cmd) {
+	rep := m.preflight.Report()
+	m.closeGate()
+	m.activeView = viewHub
+
+	// Backing out of a gate that had a real blocker leaves the user staring at a
+	// hub that looks like nothing happened. Say which row stopped it.
+	if blocker, blocked := rep.Blocker(); blocked {
+		// One line, and no trailing call to action: the hub truncates its status
+		// row at the terminal width, and a hint that gets cut mid-word is worse
+		// than the footer's own "enter run".
+		m.hub.SetStatus(fmt.Sprintf("%s did not start — %s is %s",
+			rep.AgentName, blocker.Label, blocker.Line))
+	}
+
+	var cmds []tea.Cmd
+	if m.width > 0 && m.height > 0 {
+		cmds = append(cmds, m.sizeCmd())
+	}
+	return m, tea.Batch(cmds...)
+}
+
+func (m RootModel) sizeCmd() tea.Cmd {
+	w, h := m.width, m.height
+	return func() tea.Msg { return tea.WindowSizeMsg{Width: w, Height: h} }
+}
+
+// updatePreflight forwards a message to the gate.
+func (m RootModel) updatePreflight(msg tea.Msg) (tea.Model, tea.Cmd) {
+	if m.preflight == nil {
+		return m, nil
+	}
+	updated, cmd := m.preflight.Update(msg)
+	gate := updated.(preflight.Model)
+	m.preflight = &gate
+	return m, cmd
+}
+
+// --- the mailbox hand-off ---------------------------------------------------
+
+// connectHandoff is what ConnectMailboxMsg turns into.
+//
+// The TUI has no connector screen, and half of one would be worse than none:
+// OAuth already has a working implementation behind `gaia connectors`, and a
+// second one here would fork the flow that owns tokens, scopes and grants. So the
+// gate hands over the exact command — the one the mailbox row already computed,
+// with the scope union and the agent grant in it — and re-checks when the user
+// comes back. Swallowing the request, or answering it with "coming soon", would
+// leave the user on a screen that names a problem and no way past it.
+type connectHandoff struct {
+	agentName string
+	// provider is the mailbox to reconnect. Empty means the user has nothing
+	// connected and the choice of provider is still theirs.
+	provider string
+	row      preflight.Row
+	haveRow  bool
+}
+
+func (m RootModel) openConnectHandoff(provider string) (tea.Model, tea.Cmd) {
+	rep := m.preflight.Report()
+	row, ok := rep.Find(preflight.KeyMailbox)
+	m.connect = &connectHandoff{
+		agentName: rep.AgentName,
+		provider:  provider,
+		row:       row,
+		haveRow:   ok,
+	}
+	return m, nil
+}
+
+// handleConnectKey owns every key while the hand-off is up.
+func (m RootModel) handleConnectKey(key tea.KeyMsg) (tea.Model, tea.Cmd) {
+	switch key.String() {
+	case "ctrl+c":
+		// Same as everywhere else: ctrl+c leaves the app, not just the screen.
+		m.closeGate()
+		return m, tea.Quit
+	case "r":
+		// Dismiss, then let the gate's own `r` do the re-check — the screen that
+		// owns the probes owns the re-check too.
+		m.connect = nil
+		return m.updatePreflight(key)
+	case "esc", "q":
+		m.connect = nil
+		return m, nil
+	}
+	return m, nil
+}
+
+var (
+	connectTitle   = lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("150"))
+	connectDim     = lipgloss.NewStyle().Foreground(lipgloss.Color("243"))
+	connectDivider = lipgloss.NewStyle().Foreground(lipgloss.Color("238"))
+	connectText    = lipgloss.NewStyle().Foreground(lipgloss.Color("252"))
+	connectCmd     = lipgloss.NewStyle().Foreground(lipgloss.Color("150"))
+	connectKey     = lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("39"))
+)
+
+// outlookSetupDoc is where the Outlook path continues. It is a doc, not a
+// command, because Outlook needs a one-time Microsoft app registration (or the
+// device-code flow) before any connect command can succeed — and the mailbox
+// row's Gmail scopes are wrong for Microsoft, so "swap google for microsoft"
+// would hand the user a command that fails.
+const outlookSetupDoc = "https://amd-gaia.ai/docs/connectors/microsoft"
+
+func (h connectHandoff) view(width, height int) string {
+	w := width
+	if w < 40 {
+		w = 40
+	}
+
+	title := fmt.Sprintf("Connect a mailbox for %s", h.agentName)
+	if h.provider != "" {
+		title = fmt.Sprintf("Reconnect %s for %s", providerLabel(h.provider), h.agentName)
+	}
+
+	out := []string{
+		"  " + connectTitle.Render(title),
+		"  " + connectDivider.Render(strings.Repeat("─", w-4)),
+	}
+	add := func(style lipgloss.Style, text string, indent int) {
+		prefix := strings.Repeat(" ", indent)
+		for _, line := range wrapLines(text, w-indent-2) {
+			out = append(out, prefix+style.Render(line))
+		}
+	}
+
+	if h.row.Detail != "" {
+		add(connectDim, h.row.Detail, 2)
+		out = append(out, "")
+	}
+
+	switch {
+	case !h.haveRow || h.row.Remedy.Command == "":
+		// The gate asked for a mailbox and recorded no command to get one. That is
+		// a bug, and it must not read as a shrug.
+		add(connectText, "The readiness check asked for a mailbox connection but recorded no "+
+			"command for it. Report that, then connect from a terminal:", 2)
+		add(connectCmd, "gaia connectors list", 4)
+		add(connectDim, "look:  https://amd-gaia.ai/docs/guides/email", 4)
+
+	case h.provider != "":
+		add(connectText, "This cannot be done from here — it opens a browser sign-in. Run this in "+
+			"another terminal, then come back and press r.", 2)
+		out = append(out, "")
+		add(connectCmd, h.row.Remedy.Command, 4)
+		if h.row.Remedy.Where != "" {
+			out = append(out, "")
+			add(connectDim, "look:  "+h.row.Remedy.Where, 4)
+		}
+
+	default:
+		// Provider is empty: nothing is connected, so the choice is the user's.
+		// Both paths are named, and neither is a command that would fail.
+		add(connectText, "This cannot be done from here — it opens a browser sign-in. "+
+			"Pick one, run it in another terminal, then come back and press r.", 2)
+		out = append(out, "")
+		offered := providerFromCommand(h.row.Remedy.Command)
+		heading := "Run this:"
+		if offered != "" {
+			heading = providerLabel(offered) + " — one command, about a minute:"
+		}
+		add(connectText, heading, 2)
+		add(connectCmd, h.row.Remedy.Command, 4)
+		if offered != "microsoft" {
+			out = append(out, "")
+			add(connectText, "Outlook — needs a one-time Microsoft app setup first:", 2)
+			add(connectDim, outlookSetupDoc, 4)
+		}
+	}
+
+	out = append(out, "")
+	out = append(out, "  "+connectKey.Render("r")+" "+connectDim.Render("re-check")+
+		connectDim.Render(" · ")+connectKey.Render("esc")+" "+connectDim.Render("back to the checks"))
+
+	if height > 0 && len(out) > height {
+		// Keep the footer: a screen whose only exit hint was trimmed reads as a
+		// dead end. Drop from the body instead.
+		keep := out[:height-1]
+		out = append(keep[:len(keep):len(keep)], out[len(out)-1])
+	}
+	return strings.Join(out, "\n")
+}
+
+// providerFromCommand reads the connector id out of a
+// `gaia connectors connect <id> …` command, so the heading above a command can
+// never name a provider the command does not use.
+func providerFromCommand(cmd string) string {
+	fields := strings.Fields(cmd)
+	for i, f := range fields {
+		if f == "connect" && i+1 < len(fields) {
+			return fields[i+1]
+		}
+	}
+	return ""
+}
+
+func providerLabel(provider string) string {
+	switch provider {
+	case "google":
+		return "Gmail"
+	case "microsoft":
+		return "Outlook"
+	default:
+		return provider
+	}
+}
+
+// wrapLines wraps plain text to w columns, hard-breaking a single token that is
+// longer than the line — a connect command with full OAuth scope URLs in it must
+// be readable in full, never truncated.
+func wrapLines(s string, w int) []string {
+	if w < 8 {
+		w = 8
+	}
+	rendered := lipgloss.NewStyle().Width(w).Render(s)
+	lines := strings.Split(strings.TrimRight(rendered, "\n"), "\n")
+	for i := range lines {
+		// Width() pads every line to w; the padding would show up as trailing
+		// whitespace in a captured screen.
+		lines[i] = strings.TrimRight(lines[i], " ")
+	}
+	return lines
+}

--- a/tui/internal/ui/root/preflight.go
+++ b/tui/internal/ui/root/preflight.go
@@ -73,9 +73,15 @@ func (m RootModel) gateIsFor(agentID string) bool {
 		m.pending != nil && m.pending.ID == agentID
 }
 
-// closeGate tears the gate down. Cancel first: the screen owns a probe, a
-// sidecar start, or a model pull, and leaving one running would keep writing
-// into a screen that no longer exists.
+// closeGate tears the gate down, cancelling what it started: a re-check, a
+// sidecar start, a model pull.
+//
+// It does NOT stop the FIRST probe. preflight.Model.Init has a value receiver, so
+// the cancel func for the check it launches is parked on a copy that dies with
+// the call, and the model this host keeps has none. That probe therefore runs to
+// its own 90s timeout after the user leaves; its result is dropped by
+// updatePreflight rather than allowed to drive whatever is on screen. Fixing it
+// properly needs a pointer-receiver initialiser in the preflight package.
 func (m *RootModel) closeGate() {
 	if m.preflight != nil {
 		m.preflight.Cancel()
@@ -124,13 +130,26 @@ func (m RootModel) sizeCmd() tea.Cmd {
 	return func() tea.Msg { return tea.WindowSizeMsg{Width: w, Height: h} }
 }
 
-// updatePreflight forwards a message to the gate.
+// updatePreflight forwards a message to the gate, then refuses any result that
+// turns out to belong to a gate the user already left.
+//
+// The gate's async results are unexported types, so they cannot be filtered
+// before the fact — a probe started for agent A and answered after the user
+// backed out and launched agent B lands on B's gate. Its report is exported and
+// names its agent, so the check is done after the update: a report for the wrong
+// agent is dropped along with whatever command it wanted to run. Without this, an
+// all-green report for A drives B's screen, and B's gate hands off — opening a
+// chat for an agent nothing ever probed, which is the one outcome this gate
+// exists to prevent.
 func (m RootModel) updatePreflight(msg tea.Msg) (tea.Model, tea.Cmd) {
 	if m.preflight == nil {
 		return m, nil
 	}
 	updated, cmd := m.preflight.Update(msg)
 	gate := updated.(preflight.Model)
+	if id := gate.Report().AgentID; id != "" && m.pending != nil && id != m.pending.ID {
+		return m, nil
+	}
 	m.preflight = &gate
 	return m, cmd
 }
@@ -171,8 +190,11 @@ func (m RootModel) openConnectHandoff(provider string) (tea.Model, tea.Cmd) {
 func (m RootModel) handleConnectKey(key tea.KeyMsg) (tea.Model, tea.Cmd) {
 	switch key.String() {
 	case "ctrl+c":
-		// Same as everywhere else: ctrl+c leaves the app, not just the screen.
+		// Same as everywhere else: ctrl+c leaves the app, not just the screen. The
+		// view goes back to the hub so the last frame is never a view whose model
+		// has just been torn out from under it.
 		m.closeGate()
+		m.activeView = viewHub
 		return m, tea.Quit
 	case "r":
 		// Dismiss, then let the gate's own `r` do the re-check — the screen that
@@ -213,20 +235,23 @@ func (h connectHandoff) view(width, height int) string {
 		title = fmt.Sprintf("Reconnect %s for %s", providerLabel(h.provider), h.agentName)
 	}
 
-	out := []string{
+	head := []string{
 		"  " + connectTitle.Render(title),
 		"  " + connectDivider.Render(strings.Repeat("─", w-4)),
 	}
+	var body []block
+	cur := dropContext
 	add := func(style lipgloss.Style, text string, indent int) {
 		prefix := strings.Repeat(" ", indent)
 		for _, line := range wrapLines(text, w-indent-2) {
-			out = append(out, prefix+style.Render(line))
+			body = append(body, block{line: prefix + style.Render(line), drop: cur})
 		}
 	}
+	blank := func() { body = append(body, block{line: "", drop: cur}) }
 
 	if h.row.Detail != "" {
 		add(connectDim, h.row.Detail, 2)
-		out = append(out, "")
+		blank()
 	}
 
 	switch {
@@ -235,16 +260,29 @@ func (h connectHandoff) view(width, height int) string {
 		// a bug, and it must not read as a shrug.
 		add(connectText, "The readiness check asked for a mailbox connection but recorded no "+
 			"command for it. Report that, then connect from a terminal:", 2)
+		cur = dropNever
 		add(connectCmd, "gaia connectors list", 4)
+		cur = dropContext
 		add(connectDim, "look:  https://amd-gaia.ai/docs/guides/email", 4)
 
 	case h.provider != "":
 		add(connectText, "This cannot be done from here — it opens a browser sign-in. Run this in "+
 			"another terminal, then come back and press r.", 2)
-		out = append(out, "")
+		// The command is printed verbatim, so if the check produced one for a
+		// different provider than the mailbox it is talking about, say so rather
+		// than let the title vouch for it.
+		if named := providerFromCommand(h.row.Remedy.Command); named != "" && named != h.provider {
+			cur = dropNever
+			add(connectText, fmt.Sprintf(
+				"Heads up: the check produced a %s command for a %s mailbox. Check it before "+
+					"running it, and report it.", providerLabel(named), providerLabel(h.provider)), 2)
+		}
+		cur = dropNever
+		blank()
 		add(connectCmd, h.row.Remedy.Command, 4)
+		cur = dropContext
 		if h.row.Remedy.Where != "" {
-			out = append(out, "")
+			blank()
 			add(connectDim, "look:  "+h.row.Remedy.Where, 4)
 		}
 
@@ -253,32 +291,73 @@ func (h connectHandoff) view(width, height int) string {
 		// Both paths are named, and neither is a command that would fail.
 		add(connectText, "This cannot be done from here — it opens a browser sign-in. "+
 			"Pick one, run it in another terminal, then come back and press r.", 2)
-		out = append(out, "")
 		offered := providerFromCommand(h.row.Remedy.Command)
 		heading := "Run this:"
 		if offered != "" {
 			heading = providerLabel(offered) + " — one command, about a minute:"
 		}
+		cur = dropNever
+		blank()
 		add(connectText, heading, 2)
 		add(connectCmd, h.row.Remedy.Command, 4)
 		if offered != "microsoft" {
-			out = append(out, "")
+			cur = dropAlternative
+			blank()
 			add(connectText, "Outlook — needs a one-time Microsoft app setup first:", 2)
 			add(connectDim, outlookSetupDoc, 4)
 		}
 	}
 
-	out = append(out, "")
-	out = append(out, "  "+connectKey.Render("r")+" "+connectDim.Render("re-check")+
-		connectDim.Render(" · ")+connectKey.Render("esc")+" "+connectDim.Render("back to the checks"))
+	foot := "  " + connectKey.Render("r") + " " + connectDim.Render("re-check") +
+		connectDim.Render(" · ") + connectKey.Render("esc") + " " + connectDim.Render("back to the checks")
 
-	if height > 0 && len(out) > height {
-		// Keep the footer: a screen whose only exit hint was trimmed reads as a
-		// dead end. Drop from the body instead.
-		keep := out[:height-1]
-		out = append(keep[:len(keep):len(keep)], out[len(out)-1])
+	out := append(head, fitBody(body, height-len(head)-2)...)
+	return strings.Join(append(out, "", foot), "\n")
+}
+
+// Which lines the hand-off gives up first when the terminal is too short. The
+// command sits in the MIDDLE of the screen, so trimming by position — from
+// either end — can eat the one thing the user came here for. Lines are dropped
+// by what they are instead.
+const (
+	// dropNever is the command itself and the sentence that introduces it.
+	dropNever = iota
+	// dropAlternative is the second way to do it (the Outlook pointer).
+	dropAlternative
+	// dropContext is explanation: why this is needed, where to read more.
+	dropContext
+)
+
+// block is one rendered line plus how readily it can be dropped.
+type block struct {
+	line string
+	drop int
+}
+
+// fitBody drops whole categories of line, least important first, until the body
+// fits room rows. Below that it hard-trims and lets the caller's footer stand —
+// a terminal that short is under every size this app supports.
+func fitBody(body []block, room int) []string {
+	if room < 1 {
+		room = 1
 	}
-	return strings.Join(out, "\n")
+	for prio := dropContext; prio > dropNever && len(body) > room; prio-- {
+		kept := body[:0:0]
+		for _, b := range body {
+			if b.drop != prio {
+				kept = append(kept, b)
+			}
+		}
+		body = kept
+	}
+	lines := make([]string, 0, len(body))
+	for _, b := range body {
+		lines = append(lines, b.line)
+	}
+	if len(lines) > room {
+		lines = lines[:room]
+	}
+	return lines
 }
 
 // providerFromCommand reads the connector id out of a

--- a/tui/test/oneshot_readiness_test.go
+++ b/tui/test/oneshot_readiness_test.go
@@ -1,0 +1,392 @@
+package test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/amd/gaia/tui/internal/client"
+	"github.com/amd/gaia/tui/internal/daemon"
+	"github.com/amd/gaia/tui/internal/ui"
+	"github.com/amd/gaia/tui/internal/ui/preflight"
+)
+
+// Issue #2483: `gaia tui run <id> --query …` used to hang forever with nothing
+// on either stream when a precondition was unmet. These tests cover the two
+// halves of the fix — the headless readiness check, and the deadline that
+// catches what a readiness check cannot.
+
+// lemonadeDown is the exact repro condition: background service and sidecar up,
+// the local model server refusing connections.
+func lemonadeDown() *gateTransport {
+	g := readyGateTransport()
+	g.initStatus = http.StatusServiceUnavailable
+	g.initBody = map[string]any{
+		"ready": false,
+		"lemonade": map[string]any{
+			"reachable": false, "base_url": "http://localhost:8000/api/v1",
+			"min_version": "8.1.0",
+		},
+		"model": map[string]any{"id": "Gemma-4-E4B-it-GGUF", "present": false},
+		"hint":  "Lemonade Server is not reachable at http://localhost:8000/api/v1",
+	}
+	return g
+}
+
+// flatten collapses every run of whitespace, so an assertion is about what was
+// said rather than where a renderer happened to wrap it.
+func flatten(s string) string { return strings.Join(strings.Fields(s), " ") }
+
+func emailConfig() preflight.Config { return preflight.ConfigFor("email", "Email") }
+
+// The one-shot must refuse, name the unmet precondition, and name the command
+// that fixes it — the interactive gate is never rendered, because a script has
+// nobody to press a key.
+func TestOneShotReadinessRefusesAndNamesTheRemedy(t *testing.T) {
+	var errW bytes.Buffer
+	rep := ui.ReportReadiness(context.Background(), lemonadeDown(), emailConfig(), &errW)
+
+	if !rep.Blocked() {
+		t.Fatalf("an unreachable model server must block the run:\n%s", rep)
+	}
+	msg := flatten(errW.String())
+	for _, want := range []string{
+		"Local AI",                            // which precondition
+		"not running at",                      // what is wrong with it
+		"run: lemonade-server serve",          // how to fix it
+		"Nothing was sent to the Email agent", // and that nothing half-ran
+	} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("the refusal is missing %q:\n%s", want, errW.String())
+		}
+	}
+	// No keystroke advice can be acted on from a script, so the refusal must at
+	// least end by telling the reader to re-run it.
+	if !strings.Contains(msg, "re-run") {
+		t.Errorf("the refusal never tells the caller what to do next:\n%s", errW.String())
+	}
+}
+
+// The two paths must not drift: whatever the gate shows a human for a condition
+// is what the one-shot prints for the same condition.
+func TestOneShotRefusalMatchesTheInteractiveGate(t *testing.T) {
+	var errW bytes.Buffer
+	ui.ReportReadiness(context.Background(), lemonadeDown(), emailConfig(), &errW)
+	headless := flatten(errW.String())
+
+	d := newRootDriver(t, lemonadeDown(), 100, 40)
+	d.launchEmail()
+	gate := d.flat()
+
+	blocker, ok := preflight.Check(context.Background(), lemonadeDown(), emailConfig()).Blocker()
+	if !ok {
+		t.Fatal("the check reported no blocker for an unreachable model server")
+	}
+	for _, want := range []string{blocker.Line, blocker.Detail, blocker.Remedy.Command} {
+		if want == "" {
+			t.Fatalf("the blocker row is missing a field the user needs: %+v", blocker)
+		}
+		if !strings.Contains(headless, flatten(want)) {
+			t.Errorf("the one-shot refusal dropped %q:\n%s", want, errW.String())
+		}
+		if !strings.Contains(gate, flatten(want)) {
+			t.Errorf("the gate no longer shows %q, so the two paths have drifted:\n%s", want, d.screen())
+		}
+	}
+}
+
+// A healthy machine must be left alone: nothing blocks, and the check prints
+// nothing that could pollute a caller's log.
+func TestOneShotReadinessIsSilentWhenEverythingIsReady(t *testing.T) {
+	var errW bytes.Buffer
+	rep := ui.ReportReadiness(context.Background(), readyGateTransport(), emailConfig(), &errW)
+
+	if rep.Blocked() || !rep.Ready() {
+		t.Fatalf("a healthy machine must pass the check:\n%s", rep)
+	}
+	if errW.String() != "" {
+		t.Errorf("a passing check must stay quiet, got:\n%s", errW.String())
+	}
+}
+
+// An indeterminate row is named but does not refuse — the same rule the gate
+// follows, so a Lemonade that does not advertise its version cannot become a
+// wall a script can never get past.
+func TestOneShotReadinessProceedsPastAnUnverifiableRow(t *testing.T) {
+	g := readyGateTransport()
+	lemonade := g.initBody["lemonade"].(map[string]any)
+	delete(lemonade, "compatible")
+	delete(lemonade, "version")
+
+	var errW bytes.Buffer
+	rep := ui.ReportReadiness(context.Background(), g, emailConfig(), &errW)
+
+	if rep.Blocked() {
+		t.Fatalf("an unverifiable row must not refuse the run:\n%s", rep)
+	}
+	if !strings.Contains(errW.String(), "could not be verified") {
+		t.Errorf("what went unproven must still be said:\n%s", errW.String())
+	}
+}
+
+// --- a stand-in for the real daemon relay -----------------------------------
+
+// relayDaemon is the daemon side of a one-shot: the control plane, the agent
+// relay, and a /query that can be made to stall. It is paired with an
+// instance.json in an isolated GAIA_DAEMON_HOME, so a test never touches — or
+// starts — the developer's own daemon.
+type relayDaemon struct {
+	srv *httptest.Server
+	// home is the isolated GAIA_DAEMON_HOME, for handing to a child process.
+	home string
+	opts relayOptions
+	// release ends a stall when the test is over, so no handler outlives it.
+	release chan struct{}
+
+	mu sync.Mutex
+	// queries counts POSTs to /v1/email/query — what proves a refusal really
+	// sent nothing rather than sending and discarding the answer.
+	queries int
+}
+
+func (d *relayDaemon) queryCount() int {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	return d.queries
+}
+
+// relayOptions is the fake's whole configuration. It is fixed before the server
+// starts: a handler runs on its own goroutine, so anything set afterwards would
+// be a data race, not a test knob.
+type relayOptions struct {
+	// initStatus / initBody are the answer to GET /v1/email/init. The zero value
+	// means "everything ready".
+	initStatus int
+	initBody   map[string]any
+	// stallQuery holds the query stream open without ever sending a byte.
+	stallQuery bool
+}
+
+func newRelayDaemon(t *testing.T, opts relayOptions) *relayDaemon {
+	t.Helper()
+
+	if opts.initStatus == 0 {
+		opts.initStatus = http.StatusOK
+	}
+	if opts.initBody == nil {
+		opts.initBody = readyGateTransport().initBody
+	}
+	d := &relayDaemon{home: t.TempDir(), opts: opts, release: make(chan struct{})}
+	t.Setenv(daemon.EnvHome, d.home)
+
+	d.srv = httptest.NewServer(http.HandlerFunc(d.handle))
+	// Order matters: Close waits for in-flight handlers, so a stall has to be
+	// released BEFORE it runs. Cleanups run last-registered-first.
+	t.Cleanup(d.srv.Close)
+	t.Cleanup(func() { close(d.release) })
+
+	u, err := url.Parse(d.srv.URL)
+	if err != nil {
+		t.Fatalf("parse server URL: %v", err)
+	}
+	port, err := strconv.Atoi(u.Port())
+	if err != nil {
+		t.Fatalf("parse server port: %v", err)
+	}
+	raw, err := json.Marshal(daemon.Instance{
+		PID: os.Getpid(), Port: port, Token: "test-token",
+		Host: daemon.DefaultHost, APIVersion: "1.1", Service: daemon.ServiceID,
+	})
+	if err != nil {
+		t.Fatalf("marshal instance: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(d.home, "instance.json"), raw, 0o600); err != nil {
+		t.Fatalf("write instance.json: %v", err)
+	}
+	return d
+}
+
+func (d *relayDaemon) handle(w http.ResponseWriter, r *http.Request) {
+	switch {
+	case r.URL.Path == daemon.APIPrefix+"/status":
+		writeJSON(w, map[string]any{"service": daemon.ServiceID, "pid": os.Getpid()})
+
+	case r.URL.Path == daemon.APIPrefix+"/agents":
+		writeJSON(w, map[string]any{"agents": []map[string]any{
+			{"agent_id": "email", "state": "running", "pid": os.Getpid(),
+				"agent_version": "0.5.0", "api_version": "1.0"},
+		}})
+
+	case strings.HasSuffix(r.URL.Path, "/ensure"):
+		writeJSON(w, map[string]any{"agent_id": "email", "state": "running"})
+
+	case strings.HasSuffix(r.URL.Path, "/init"):
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(d.opts.initStatus)
+		_ = json.NewEncoder(w).Encode(d.opts.initBody)
+
+	case strings.HasSuffix(r.URL.Path, "/connectors"):
+		writeJSON(w, readyGateTransport().connectors)
+
+	case strings.HasSuffix(r.URL.Path, "/query"):
+		d.mu.Lock()
+		d.queries++
+		d.mu.Unlock()
+		if !d.opts.stallQuery {
+			w.WriteHeader(http.StatusNotImplemented)
+			writeJSON(w, map[string]any{"detail": "this fake only stalls"})
+			return
+		}
+		// Accepted, headers flushed — and then silence. The relay's own read
+		// watchdog is reset by any traffic, so nothing below the caller's
+		// deadline would ever end this.
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		if f, ok := w.(http.Flusher); ok {
+			f.Flush()
+		}
+		select {
+		case <-d.release:
+		case <-r.Context().Done():
+		}
+
+	default:
+		w.WriteHeader(http.StatusNotFound)
+		writeJSON(w, map[string]any{"detail": "no route " + r.URL.Path})
+	}
+}
+
+// The whole command, as a user runs it: with the model server down it must exit
+// non-zero in seconds, say what is wrong on stderr, and leave stdout empty.
+func TestRunQueryRefusesInSecondsWhenAPreconditionIsUnmet(t *testing.T) {
+	gaiaBin, binDir := buildBinaries(t)
+
+	d := newRelayDaemon(t, relayOptions{
+		initStatus: http.StatusServiceUnavailable,
+		initBody:   lemonadeDown().initBody,
+	})
+
+	cmd := exec.Command(gaiaBin, "run", "email", "--query", "triage my inbox")
+	cmd.Env = append(os.Environ(),
+		"PATH="+binDir+string(os.PathListSeparator)+os.Getenv("PATH"),
+		daemon.EnvHome+"="+d.home)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout, cmd.Stderr = &stdout, &stderr
+
+	started := time.Now()
+	err := cmd.Run()
+	elapsed := time.Since(started)
+
+	if err == nil {
+		t.Fatalf("an unmet precondition exited 0\nstderr:\n%s", stderr.String())
+	}
+	if elapsed > 30*time.Second {
+		t.Errorf("took %s to refuse — a script cannot tell that from a hang", elapsed)
+	}
+	if stdout.String() != "" {
+		t.Errorf("stdout must stay empty so `> answer.txt` never captures a failure, got %q", stdout.String())
+	}
+	for _, want := range []string{"not ready", "Local AI", "lemonade-server serve"} {
+		if !strings.Contains(stderr.String(), want) {
+			t.Errorf("stderr is missing %q:\n%s", want, stderr.String())
+		}
+	}
+	if strings.Contains(stdout.String(), altScreenEnter) || strings.Contains(stderr.String(), altScreenEnter) {
+		t.Error("the refusal opened the alt screen; a script has nobody to press a key")
+	}
+	// The refusal promises "Nothing was sent to the Email agent". Prove it.
+	if n := d.queryCount(); n != 0 {
+		t.Errorf("the run sent %d quer(ies) after refusing — the message is a lie", n)
+	}
+}
+
+// The other half of the fix, end to end through the real command: a daemon that
+// accepts the query and never answers must be abandoned at the bound, not waited
+// on. --timeout is what makes that bound testable — and raisable by a caller
+// whose agent legitimately runs longer than the default.
+func TestRunQueryAbandonsAStalledAgentAtTheTimeout(t *testing.T) {
+	gaiaBin, binDir := buildBinaries(t)
+
+	d := newRelayDaemon(t, relayOptions{stallQuery: true})
+
+	cmd := exec.Command(gaiaBin, "run", "email", "--query", "triage my inbox", "--timeout", "3s")
+	cmd.Env = append(os.Environ(),
+		"PATH="+binDir+string(os.PathListSeparator)+os.Getenv("PATH"),
+		daemon.EnvHome+"="+d.home)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout, cmd.Stderr = &stdout, &stderr
+
+	started := time.Now()
+	err := cmd.Run()
+	elapsed := time.Since(started)
+
+	if err == nil {
+		t.Fatalf("a turn that never got an answer exited 0\nstderr:\n%s", stderr.String())
+	}
+	if elapsed > 60*time.Second {
+		t.Errorf("took %s to abandon a 3s turn — the bound is not being applied", elapsed)
+	}
+	if !strings.Contains(stderr.String(), "gave up") {
+		t.Errorf("stderr does not report the deadline:\n%s", stderr.String())
+	}
+	if stdout.String() != "" {
+		t.Errorf("stdout = %q, want empty", stdout.String())
+	}
+	if n := d.queryCount(); n != 1 {
+		t.Errorf("the agent was queried %d times, want exactly 1", n)
+	}
+}
+
+// The case a readiness check alone does not cover, over the real SSE transport:
+// the deadline is what turns a stalled stream into a reportable failure.
+func TestOneShotAgainstAStallingDaemonHitsTheDeadline(t *testing.T) {
+	newRelayDaemon(t, relayOptions{stallQuery: true})
+
+	c := client.NewSSEClient("email", daemon.New(daemon.Options{
+		PIDAlive: func(int) bool { return true },
+		// A failed attach must never fall through to the production launcher and
+		// start a real daemon on the machine running the tests.
+		StartCommand: func(context.Context) (*exec.Cmd, error) {
+			return nil, fmt.Errorf("this test must never start a real daemon")
+		},
+	}), client.SSEOptions{})
+	defer c.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	var out, errW bytes.Buffer
+	done := make(chan ui.OneShotResult, 1)
+	started := time.Now()
+	go func() { done <- ui.RunOneShot(ctx, c, "triage my inbox", &out, &errW) }()
+
+	select {
+	case res := <-done:
+		if res.ExitCode == 0 {
+			t.Errorf("a stalled turn exited 0; stderr:\n%s", errW.String())
+		}
+		if out.String() != "" {
+			t.Errorf("stdout must stay empty when nothing was answered, got %q", out.String())
+		}
+		if !strings.Contains(errW.String(), "gave up") {
+			t.Errorf("stderr does not report the deadline:\n%s", errW.String())
+		}
+		if elapsed := time.Since(started); elapsed > 30*time.Second {
+			t.Errorf("took %s to give up on a 2s deadline", elapsed)
+		}
+	case <-time.After(60 * time.Second):
+		t.Fatal("the one-shot hung against a stalling daemon — this is issue #2483")
+	}
+}

--- a/tui/test/preflight_gate_test.go
+++ b/tui/test/preflight_gate_test.go
@@ -1,0 +1,598 @@
+package test
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/charmbracelet/bubbles/spinner"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/x/ansi"
+
+	"github.com/amd/gaia/tui/internal/catalog"
+	"github.com/amd/gaia/tui/internal/daemon"
+	"github.com/amd/gaia/tui/internal/ui/hub"
+	"github.com/amd/gaia/tui/internal/ui/preflight"
+	"github.com/amd/gaia/tui/internal/ui/root"
+)
+
+// These tests cover the seam between the hub and the readiness gate: that a
+// launch goes through the gate, that the gate's three answers land where they
+// should, and that a failing precondition never reaches chat.
+
+// --- a preflight transport under test control -------------------------------
+
+// gateTransport answers the four calls the gate makes, from canned bodies. It
+// exists so the seam can be driven without a daemon, a sidecar, or Lemonade.
+type gateTransport struct {
+	attachErr error
+	// agentState is the state reported for the agent in /daemon/v1/agents.
+	// Empty means the agent is not listed at all.
+	agentState string
+	// initStatus and initBody are the answer to GET /v1/<agent>/init.
+	initStatus int
+	initBody   map[string]any
+	// connectors is the answer to GET /v1/<agent>/connectors.
+	connectors map[string]any
+
+	starts  int
+	ensures int
+}
+
+func readyGateTransport() *gateTransport {
+	return &gateTransport{
+		agentState: "running",
+		initStatus: http.StatusOK,
+		initBody: map[string]any{
+			"ready": true,
+			"lemonade": map[string]any{
+				"reachable": true, "base_url": "http://localhost:8000/api/v1",
+				"version": "8.2.0", "min_version": "8.1.0", "compatible": true,
+			},
+			"model": map[string]any{
+				"id": "Gemma-4-E4B-it-GGUF", "present": true, "ctx_size": 32768,
+			},
+		},
+		connectors: map[string]any{
+			"agent_id": "email",
+			"providers": []map[string]any{
+				{"provider": "google", "connected": true, "account_email": "user@gmail.com",
+					"can_send": true, "scopes": []string{"gmail.send"}},
+			},
+		},
+	}
+}
+
+func (g *gateTransport) Attach(context.Context) (preflight.DaemonInfo, error) {
+	if g.attachErr != nil {
+		return preflight.DaemonInfo{}, g.attachErr
+	}
+	return preflight.DaemonInfo{PID: 4242, Port: 13337, APIVersion: "1.1"}, nil
+}
+
+func (g *gateTransport) Start(ctx context.Context) (preflight.DaemonInfo, error) {
+	g.starts++
+	g.attachErr = nil
+	return g.Attach(ctx)
+}
+
+func (g *gateTransport) EnsureAgent(context.Context, string) error {
+	g.ensures++
+	g.agentState = "running"
+	return nil
+}
+
+func (g *gateTransport) Do(_ context.Context, _, path string, _ []byte) (preflight.Response, error) {
+	switch {
+	case path == daemon.APIPrefix+"/agents":
+		agents := []map[string]any{}
+		if g.agentState != "" {
+			pid := 5150
+			agents = append(agents, map[string]any{
+				"agent_id": "email", "state": g.agentState, "pid": pid,
+				"agent_version": "0.5.0", "api_version": "1.0",
+			})
+		}
+		return jsonResponse(http.StatusOK, map[string]any{"agents": agents})
+	case strings.HasSuffix(path, "/init"):
+		return jsonResponse(g.initStatus, g.initBody)
+	case strings.HasSuffix(path, "/connectors"):
+		return jsonResponse(http.StatusOK, g.connectors)
+	}
+	return preflight.Response{}, fmt.Errorf("gateTransport: no canned answer for %s", path)
+}
+
+func (g *gateTransport) Stream(context.Context, string, string, []byte) (preflight.Stream, error) {
+	return preflight.Stream{}, fmt.Errorf("gateTransport: streaming is not wired in this test")
+}
+
+func jsonResponse(status int, body map[string]any) (preflight.Response, error) {
+	raw, err := json.Marshal(body)
+	if err != nil {
+		return preflight.Response{}, err
+	}
+	return preflight.Response{Status: status, Body: raw}, nil
+}
+
+// modelMissing turns the transport into the commonest real failure: everything
+// up and running, the model never downloaded.
+func (g *gateTransport) modelMissing() *gateTransport {
+	g.initStatus = http.StatusServiceUnavailable
+	g.initBody = map[string]any{
+		"ready": false,
+		"lemonade": map[string]any{
+			"reachable": true, "base_url": "http://localhost:8000/api/v1",
+			"version": "8.2.0", "min_version": "8.1.0", "compatible": true,
+		},
+		"model": map[string]any{"id": "Gemma-4-E4B-it-GGUF", "present": false},
+		"hint":  "the model is not downloaded yet",
+	}
+	return g
+}
+
+// mailboxMissing leaves every generic row green with no mailbox connected — the
+// state that asks the host to open a connector flow.
+func (g *gateTransport) mailboxMissing() *gateTransport {
+	g.connectors = map[string]any{"agent_id": "email", "providers": []map[string]any{}}
+	return g
+}
+
+// --- a root driver ----------------------------------------------------------
+
+type rootDriver struct {
+	t   *testing.T
+	m   root.RootModel
+	cat *catalog.Catalog
+}
+
+// newRootDriver builds a root model whose gate is pointed at g, with the ready
+// hold squeezed to keep the tests fast.
+func newRootDriver(t *testing.T, g preflight.Transport, w, h int) *rootDriver {
+	t.Helper()
+	cat := catalog.NewCatalog()
+	cat.MarkInstalled("email", "0.5.0")
+	m := root.NewRootModelWithHub(cat, nil, false).
+		WithPreflight(g, preflight.Options{ReadyHold: time.Millisecond})
+	d := &rootDriver{t: t, m: m, cat: cat}
+	d.send(windowSize(w, h))
+	return d
+}
+
+func (d *rootDriver) send(msg tea.Msg) {
+	d.t.Helper()
+	updated, cmd := d.m.Update(msg)
+	d.m = updated.(root.RootModel)
+	d.pump(cmd)
+}
+
+// pump runs every command the model produced, feeding results back in.
+func (d *rootDriver) pump(cmd tea.Cmd) {
+	d.t.Helper()
+	queue := []tea.Cmd{cmd}
+	for steps := 0; len(queue) > 0; steps++ {
+		if steps > maxPumpSteps {
+			d.t.Fatalf("command loop did not settle after %d steps", maxPumpSteps)
+		}
+		next := queue[0]
+		queue = queue[1:]
+		if next == nil {
+			continue
+		}
+		msg := next()
+		if msg == nil {
+			continue
+		}
+		if batch, ok := msg.(tea.BatchMsg); ok {
+			queue = append(queue, batch...)
+			continue
+		}
+		// A spinner re-arms its own tick for as long as the screen is busy, and
+		// the cursor blinks forever. Real Bubble Tea keeps ticking; a test loop
+		// must not. Routing of a spinner tick is asserted on its own below.
+		if isCursorBlink(msg) || isSpinnerTick(msg) {
+			continue
+		}
+		updated, follow := d.m.Update(msg)
+		d.m = updated.(root.RootModel)
+		queue = append(queue, follow)
+	}
+}
+
+func isSpinnerTick(msg tea.Msg) bool {
+	_, ok := msg.(spinner.TickMsg)
+	return ok
+}
+
+func (d *rootDriver) screen() string { return stripAnsi(d.m.View()) }
+
+// flat is the screen with every run of whitespace collapsed, so an assertion is
+// about what the screen says rather than where a line happened to wrap.
+func (d *rootDriver) flat() string {
+	return strings.Join(strings.Fields(d.screen()), " ")
+}
+
+func (d *rootDriver) view() string { return d.m.ControlSnapshot().View }
+
+// launchEmail sends the message the hub sends when the user presses enter on an
+// installed, daemon-backed agent.
+func (d *rootDriver) launchEmail() {
+	d.t.Helper()
+	agent := d.cat.Get("email")
+	if agent == nil {
+		d.t.Fatal("the email agent is missing from the catalog")
+	}
+	if agent.Transport != catalog.TransportDaemon {
+		d.t.Fatalf("email transport = %s, want daemon — the gate only guards relayed agents", agent.Transport)
+	}
+	d.send(hub.LaunchAgentMsg{Agent: *agent})
+}
+
+// --- the seam ---------------------------------------------------------------
+
+// The bug this whole change exists to fix: a launch used to go straight to chat.
+func TestLaunchingAnAgentShowsPreflightNotChat(t *testing.T) {
+	// A gate that is still checking: the daemon answer is what the screen is
+	// waiting on, so the first frame must be the gate.
+	g := readyGateTransport()
+	d := newRootDriver(t, g, 80, 24)
+
+	// Deliberately unpumped: the point is the FIRST frame after the launch, not
+	// where the checks eventually land.
+	updated, _ := d.m.Update(hub.LaunchAgentMsg{Agent: *d.cat.Get("email")})
+	d.m = updated.(root.RootModel)
+
+	if got := d.view(); got != "preflight" {
+		t.Fatalf("view after launch = %q, want preflight", got)
+	}
+	screen := d.flat()
+	if !strings.Contains(screen, "Getting Email ready") {
+		t.Errorf("the gate is not what got rendered:\n%s", d.screen())
+	}
+	if strings.Contains(screen, "Welcome to GAIA") {
+		t.Error("chat opened without passing the gate")
+	}
+	if snap := d.m.ControlSnapshot(); snap.Agent != "email" {
+		t.Errorf("snapshot agent = %q, want email", snap.Agent)
+	}
+}
+
+// An all-green gate hands off on its own. It must reach chat — through the same
+// launch path the hub used to call directly.
+func TestAnAllGreenGateReachesChat(t *testing.T) {
+	d := newRootDriver(t, readyGateTransport(), 80, 24)
+	d.launchEmail()
+
+	if got := d.view(); got != "chat" {
+		t.Fatalf("view after an all-green gate = %q, want chat\n%s", got, d.screen())
+	}
+	if snap := d.m.ControlSnapshot(); snap.Agent != "email" {
+		t.Errorf("chat agent = %q, want email", snap.Agent)
+	}
+	if !strings.Contains(d.flat(), "Email") {
+		t.Errorf("the chat view does not name the agent:\n%s", d.screen())
+	}
+	if got := d.cat.Get("email").Status; got != catalog.StatusActive {
+		t.Errorf("catalog status after launch = %s, want active", got)
+	}
+}
+
+// A proved-broken precondition must hold the user on the gate with something to
+// do about it — and must not start the agent behind that failure.
+func TestAFailingPreconditionKeepsTheUserOnTheGate(t *testing.T) {
+	d := newRootDriver(t, readyGateTransport().modelMissing(), 80, 24)
+	d.launchEmail()
+
+	if got := d.view(); got != "preflight" {
+		t.Fatalf("view with a missing model = %q, want preflight\n%s", got, d.screen())
+	}
+	screen := d.flat()
+	for _, want := range []string{
+		"AI model",          // the row
+		"not downloaded",    // what is wrong
+		"run: gaia init",    // the remedy command
+		"f download it now", // the one-key fix
+	} {
+		if !strings.Contains(screen, want) {
+			t.Errorf("the gate does not show %q:\n%s", want, d.screen())
+		}
+	}
+
+	// enter must not talk its way past a real blocker.
+	d.send(keyEnter())
+	if got := d.view(); got != "preflight" {
+		t.Fatalf("enter past a blocked gate landed on %q", got)
+	}
+	if !strings.Contains(d.flat(), "cannot start yet") {
+		t.Errorf("enter on a blocked gate said nothing:\n%s", d.screen())
+	}
+}
+
+// esc backs out to a hub that still has a highlighted row (#2481), and says why
+// the launch did not happen.
+func TestCancellingTheGateReturnsToAUsableHub(t *testing.T) {
+	d := newRootDriver(t, readyGateTransport().modelMissing(), 80, 24)
+
+	// Drive the hub the way a user does, so the selection under test is a real
+	// one rather than one the test set up.
+	d.selectInHub("email")
+	before := d.m.ControlSnapshot()
+	d.send(keyEnter())
+	if got := d.view(); got != "preflight" {
+		t.Fatalf("enter in the hub landed on %q, want preflight", got)
+	}
+
+	d.send(keyEsc())
+	snap := d.m.ControlSnapshot()
+	if snap.View != "hub" {
+		t.Fatalf("esc from the gate landed on %q, want hub\n%s", snap.View, d.screen())
+	}
+	if snap.SelectedAgentID == "" {
+		t.Error("the hub came back with nothing selected")
+	}
+	if snap.SelectedAgentID != before.SelectedAgentID {
+		t.Errorf("selection moved across the gate: %q → %q", before.SelectedAgentID, snap.SelectedAgentID)
+	}
+	if snap.HubTabIndex != before.HubTabIndex {
+		t.Errorf("tab moved across the gate: %d → %d", before.HubTabIndex, snap.HubTabIndex)
+	}
+	if !strings.Contains(d.flat(), "did not start") {
+		t.Errorf("the hub does not say why the launch stopped:\n%s", d.screen())
+	}
+	if got := d.cat.Get("email").Status; got == catalog.StatusActive {
+		t.Error("a cancelled launch left the agent marked active")
+	}
+}
+
+// selectInHub moves the hub cursor onto agentID using only keys and the control
+// snapshot — the same surface automation drives.
+func (d *rootDriver) selectInHub(agentID string) {
+	d.t.Helper()
+	for tab := 0; tab < 6; tab++ {
+		snap := d.m.ControlSnapshot()
+		for i, id := range snap.VisibleAgentIDs {
+			if id != agentID {
+				continue
+			}
+			for j := 0; j < i; j++ {
+				d.send(keyDown())
+			}
+			if got := d.m.ControlSnapshot().SelectedAgentID; got != agentID {
+				d.t.Fatalf("selecting %q landed on %q", agentID, got)
+			}
+			return
+		}
+		d.send(keyTab())
+	}
+	d.t.Fatalf("no tab in the hub lists %q", agentID)
+}
+
+// A gate that has been left must not launch the agent afterwards: the hold tick
+// it scheduled can still be in flight.
+func TestALateProceedFromAnAbandonedGateLaunchesNothing(t *testing.T) {
+	d := newRootDriver(t, readyGateTransport().modelMissing(), 80, 24)
+	d.launchEmail()
+	d.send(keyEsc())
+	if got := d.view(); got != "hub" {
+		t.Fatalf("esc landed on %q, want hub", got)
+	}
+
+	d.send(preflight.ProceedMsg{AgentID: "email"})
+	if got := d.view(); got != "hub" {
+		t.Fatalf("a late ProceedMsg opened %q", got)
+	}
+	if got := d.cat.Get("email").Status; got == catalog.StatusActive {
+		t.Error("a late ProceedMsg launched the agent anyway")
+	}
+}
+
+// A subprocess agent has no daemon relay, so the gate has nothing to probe and
+// must not invent four failures over a launch that works.
+func TestASubprocessAgentIsNotGated(t *testing.T) {
+	d := newRootDriver(t, readyGateTransport(), 80, 24)
+	d.send(hub.LaunchAgentMsg{Agent: catalog.Agent{
+		ID: "bash", Name: "Bash", Status: catalog.StatusInstalled,
+		Transport: catalog.TransportSubprocess, BinaryPath: "/bin/echo",
+	}})
+	if got := d.view(); got != "chat" {
+		t.Fatalf("a subprocess launch landed on %q, want chat\n%s", got, d.screen())
+	}
+}
+
+// --- the mailbox hand-off ---------------------------------------------------
+
+// ConnectMailboxMsg must produce a real instruction. The TUI has no connector
+// screen, so the honest answer is the exact command plus a way back.
+func TestConnectMailboxNamesTheCommandToRun(t *testing.T) {
+	d := newRootDriver(t, readyGateTransport().mailboxMissing(), 80, 24)
+	d.launchEmail()
+
+	if got := d.view(); got != "preflight" {
+		t.Fatalf("an unconnected mailbox landed on %q, want preflight\n%s", got, d.screen())
+	}
+	d.send(key("f"))
+
+	snap := d.m.ControlSnapshot()
+	if snap.Overlay != "connect-mailbox" {
+		t.Fatalf("f on the mailbox row produced overlay %q\n%s", snap.Overlay, d.screen())
+	}
+	screen := d.flat()
+	for _, want := range []string{
+		"Connect a mailbox for Email",
+		"gaia connectors connect google",
+		"--grant-agent installed:email",
+		"gmail.send",
+		"Outlook",
+		"https://amd-gaia.ai/docs/connectors/microsoft",
+		"r re-check",
+	} {
+		if !strings.Contains(screen, want) {
+			t.Errorf("the hand-off does not show %q:\n%s", want, d.screen())
+		}
+	}
+	// The gate's own advice for this row is "press f to choose" — repeating it
+	// here would send the user back around the loop they just came through.
+	if strings.Contains(screen, "press f to choose") {
+		t.Errorf("the hand-off tells the user to press f again:\n%s", d.screen())
+	}
+	if strings.Contains(strings.ToLower(screen), "coming soon") {
+		t.Errorf("the hand-off is a dead end:\n%s", d.screen())
+	}
+}
+
+// A mailbox that is connected but cannot send is a different failure with a
+// different command, and the hand-off must name that provider's own command
+// rather than a chooser.
+func TestConnectMailboxForAConnectedProviderShowsThatProvider(t *testing.T) {
+	g := readyGateTransport()
+	g.connectors = map[string]any{
+		"agent_id": "email",
+		"providers": []map[string]any{
+			{"provider": "microsoft", "connected": true, "account_email": "user@outlook.com",
+				"can_send": false, "scopes": []string{"Mail.Read"}},
+		},
+	}
+	d := newRootDriver(t, g, 80, 24)
+	d.launchEmail()
+	d.send(key("f"))
+
+	screen := d.flat()
+	if !strings.Contains(screen, "Reconnect Outlook for Email") {
+		t.Errorf("the hand-off does not name the connected provider:\n%s", d.screen())
+	}
+	if !strings.Contains(screen, "gaia connectors connect microsoft") {
+		t.Errorf("the hand-off does not name the Outlook command:\n%s", d.screen())
+	}
+	if strings.Contains(screen, "connect google") {
+		t.Errorf("the hand-off offers Gmail to an Outlook user:\n%s", d.screen())
+	}
+}
+
+// esc dismisses the hand-off back to the gate — not out of the launch behind it.
+func TestEscFromTheHandoffReturnsToTheGate(t *testing.T) {
+	d := newRootDriver(t, readyGateTransport().mailboxMissing(), 80, 24)
+	d.launchEmail()
+	d.send(key("f"))
+	d.send(keyEsc())
+
+	snap := d.m.ControlSnapshot()
+	if snap.View != "preflight" || snap.Overlay != "" {
+		t.Fatalf("esc from the hand-off left view=%q overlay=%q, want the bare gate",
+			snap.View, snap.Overlay)
+	}
+	if !strings.Contains(d.flat(), "Getting Email ready") {
+		t.Errorf("esc did not come back to the gate:\n%s", d.screen())
+	}
+}
+
+// r from the hand-off re-checks, so a user who just connected a mailbox in
+// another terminal is not told to press anything else.
+func TestRFromTheHandoffRechecksAndProceeds(t *testing.T) {
+	g := readyGateTransport().mailboxMissing()
+	d := newRootDriver(t, g, 80, 24)
+	d.launchEmail()
+	d.send(key("f"))
+
+	// The user connects the mailbox in another terminal.
+	g.connectors = readyGateTransport().connectors
+	d.send(key("r"))
+
+	if got := d.view(); got != "chat" {
+		t.Fatalf("re-checking a fixed mailbox landed on %q, want chat\n%s", got, d.screen())
+	}
+}
+
+// --- routing and layout ----------------------------------------------------
+
+// The gate is a spinner-driven screen. If ticks and resizes do not reach it, it
+// freezes mid-check and a resized terminal renders at the old size.
+func TestTheGateGetsSpinnerAndResizeMessages(t *testing.T) {
+	d := newRootDriver(t, readyGateTransport(), 80, 24)
+
+	// Unpumped on purpose: this is the gate mid-check, which is the state whose
+	// spinner the user actually watches.
+	updated, _ := d.m.Update(hub.LaunchAgentMsg{Agent: *d.cat.Get("email")})
+	d.m = updated.(root.RootModel)
+	if !strings.Contains(d.flat(), "checking") {
+		t.Fatalf("the gate is not mid-check:\n%s", d.screen())
+	}
+
+	before := d.screen()
+	spun := false
+	for i := 0; i < 12 && !spun; i++ {
+		updated, _ := d.m.Update(spinner.TickMsg{Time: time.Now()})
+		d.m = updated.(root.RootModel)
+		spun = d.screen() != before
+	}
+	if !spun {
+		t.Errorf("spinner ticks do not reach the gate — it renders frozen:\n%s", d.screen())
+	}
+
+	d.send(windowSize(120, 40))
+	for _, line := range strings.Split(d.screen(), "\n") {
+		if w := ansi.StringWidth(line); w > 120 {
+			t.Fatalf("after a resize a line is %d columns wide", w)
+		}
+	}
+	if !strings.Contains(d.screen(), strings.Repeat("─", 100)) {
+		t.Errorf("the gate did not widen with the terminal:\n%s", d.screen())
+	}
+}
+
+// The gate defaults to 80x24 internally, so a launch that forgets to hand it the
+// real terminal size renders narrow on a wide terminal and nothing else fails.
+func TestTheGateIsBornAtTheTerminalSize(t *testing.T) {
+	d := newRootDriver(t, readyGateTransport().modelMissing(), 100, 30)
+	d.launchEmail()
+
+	if got := d.view(); got != "preflight" {
+		t.Fatalf("view = %q, want preflight", got)
+	}
+	if !strings.Contains(d.screen(), strings.Repeat("─", 96)) {
+		t.Errorf("the gate rendered narrower than the 100-column terminal:\n%s", d.screen())
+	}
+}
+
+// The hub was fixed to fit the minimum terminal; the gate in front of it has to
+// fit too, in every state a user can be in.
+func TestEveryGateStateFitsEightyByTwentyFour(t *testing.T) {
+	cases := []struct {
+		name  string
+		build func() *gateTransport
+		keys  []tea.KeyMsg
+	}{
+		{"all ready", readyGateTransport, nil},
+		{"model missing", func() *gateTransport { return readyGateTransport().modelMissing() }, nil},
+		{"model missing, details", func() *gateTransport { return readyGateTransport().modelMissing() },
+			[]tea.KeyMsg{key("d")}},
+		{"mailbox missing", func() *gateTransport { return readyGateTransport().mailboxMissing() }, nil},
+		{"mailbox hand-off", func() *gateTransport { return readyGateTransport().mailboxMissing() },
+			[]tea.KeyMsg{key("f")}},
+		{"daemon down", func() *gateTransport {
+			g := readyGateTransport()
+			g.attachErr = &daemon.NotRunningError{Path: "/tmp/instance.json"}
+			return g
+		}, nil},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			d := newRootDriver(t, tc.build(), 80, 24)
+			d.launchEmail()
+			for _, k := range tc.keys {
+				d.send(k)
+			}
+			lines := strings.Split(d.screen(), "\n")
+			if len(lines) > 24 {
+				t.Errorf("renders %d lines into 24 rows:\n%s", len(lines), d.screen())
+			}
+			for i, line := range lines {
+				if w := ansi.StringWidth(line); w > 80 {
+					t.Errorf("line %d is %d columns wide: %q", i, w, line)
+				}
+			}
+		})
+	}
+}

--- a/tui/test/preflight_gate_test.go
+++ b/tui/test/preflight_gate_test.go
@@ -36,6 +36,9 @@ type gateTransport struct {
 	// initStatus and initBody are the answer to GET /v1/<agent>/init.
 	initStatus int
 	initBody   map[string]any
+	// initByAgent overrides the init answer per agent id, so one gate can be
+	// green while another is blocked.
+	initByAgent map[string]initAnswer
 	// connectors is the answer to GET /v1/<agent>/connectors.
 	connectors map[string]any
 
@@ -92,13 +95,18 @@ func (g *gateTransport) Do(_ context.Context, _, path string, _ []byte) (preflig
 		agents := []map[string]any{}
 		if g.agentState != "" {
 			pid := 5150
-			agents = append(agents, map[string]any{
-				"agent_id": "email", "state": g.agentState, "pid": pid,
-				"agent_version": "0.5.0", "api_version": "1.0",
-			})
+			for _, id := range []string{"email", "analyst"} {
+				agents = append(agents, map[string]any{
+					"agent_id": id, "state": g.agentState, "pid": pid,
+					"agent_version": "0.5.0", "api_version": "1.0",
+				})
+			}
 		}
 		return jsonResponse(http.StatusOK, map[string]any{"agents": agents})
 	case strings.HasSuffix(path, "/init"):
+		if answer, ok := g.initByAgent[agentFromPath(path)]; ok {
+			return jsonResponse(answer.status, answer.body)
+		}
 		return jsonResponse(g.initStatus, g.initBody)
 	case strings.HasSuffix(path, "/connectors"):
 		return jsonResponse(http.StatusOK, g.connectors)
@@ -108,6 +116,21 @@ func (g *gateTransport) Do(_ context.Context, _, path string, _ []byte) (preflig
 
 func (g *gateTransport) Stream(context.Context, string, string, []byte) (preflight.Stream, error) {
 	return preflight.Stream{}, fmt.Errorf("gateTransport: streaming is not wired in this test")
+}
+
+// initAnswer is one agent's canned /init reply.
+type initAnswer struct {
+	status int
+	body   map[string]any
+}
+
+// agentFromPath pulls the agent id out of "/v1/<agent>/init".
+func agentFromPath(path string) string {
+	parts := strings.Split(strings.Trim(path, "/"), "/")
+	if len(parts) >= 2 {
+		return parts[1]
+	}
+	return ""
 }
 
 func jsonResponse(status int, body map[string]any) (preflight.Response, error) {
@@ -147,17 +170,34 @@ type rootDriver struct {
 	t   *testing.T
 	m   root.RootModel
 	cat *catalog.Catalog
+	tr  preflight.Transport
+}
+
+// transport is the fake the gate is pointed at, for asserting what the gate did
+// or did not ask the daemon to do.
+func (d *rootDriver) transport() *gateTransport {
+	g, ok := d.tr.(*gateTransport)
+	if !ok {
+		d.t.Fatalf("the driver's transport is %T, not a gateTransport", d.tr)
+	}
+	return g
 }
 
 // newRootDriver builds a root model whose gate is pointed at g, with the ready
 // hold squeezed to keep the tests fast.
 func newRootDriver(t *testing.T, g preflight.Transport, w, h int) *rootDriver {
 	t.Helper()
+	return newRootDriverOpts(t, g, w, h, preflight.Options{ReadyHold: time.Millisecond})
+}
+
+// newRootDriverOpts is newRootDriver with the gate's options spelled out —
+// ManualProceed keeps an all-green gate on screen so it can be looked at.
+func newRootDriverOpts(t *testing.T, g preflight.Transport, w, h int, opts preflight.Options) *rootDriver {
+	t.Helper()
 	cat := catalog.NewCatalog()
 	cat.MarkInstalled("email", "0.5.0")
-	m := root.NewRootModelWithHub(cat, nil, false).
-		WithPreflight(g, preflight.Options{ReadyHold: time.Millisecond})
-	d := &rootDriver{t: t, m: m, cat: cat}
+	m := root.NewRootModelWithHub(cat, nil, false).WithPreflight(g, opts)
+	d := &rootDriver{t: t, m: m, cat: cat, tr: g}
 	d.send(windowSize(w, h))
 	return d
 }
@@ -167,6 +207,15 @@ func (d *rootDriver) send(msg tea.Msg) {
 	updated, cmd := d.m.Update(msg)
 	d.m = updated.(root.RootModel)
 	d.pump(cmd)
+}
+
+// sendNoPump delivers one message and hands back the command it produced WITHOUT
+// running it — for the tests where the point is work that is still in flight.
+func (d *rootDriver) sendNoPump(msg tea.Msg) tea.Cmd {
+	d.t.Helper()
+	updated, cmd := d.m.Update(msg)
+	d.m = updated.(root.RootModel)
+	return cmd
 }
 
 // pump runs every command the model produced, feeding results back in.
@@ -309,6 +358,40 @@ func TestAFailingPreconditionKeepsTheUserOnTheGate(t *testing.T) {
 	if !strings.Contains(d.flat(), "cannot start yet") {
 		t.Errorf("enter on a blocked gate said nothing:\n%s", d.screen())
 	}
+	// "Did not launch" is about the agent, not just the view: nothing may have
+	// asked the daemon to spawn a sidecar behind that failure.
+	if g := d.transport(); g.ensures != 0 || g.starts != 0 {
+		t.Errorf("a blocked gate started things anyway: %d ensures, %d daemon starts", g.ensures, g.starts)
+	}
+	if got := d.cat.Get("email").Status; got == catalog.StatusActive {
+		t.Error("a blocked gate marked the agent active")
+	}
+}
+
+// `f` on a stopped sidecar is the gate's most-used fix. Root has to carry the
+// fix's result back to it, or the screen spins forever on work that finished.
+func TestFixingAStoppedSidecarFromTheGateReachesChat(t *testing.T) {
+	g := readyGateTransport()
+	g.agentState = "stopped"
+	d := newRootDriver(t, g, 80, 24)
+	d.launchEmail()
+
+	screen := d.flat()
+	if !strings.Contains(screen, "installed, not started") {
+		t.Fatalf("the gate does not report the stopped sidecar:\n%s", d.screen())
+	}
+	if !strings.Contains(screen, "f start the agent") {
+		t.Errorf("the stopped-sidecar row offers no fix:\n%s", d.screen())
+	}
+
+	d.send(key("f"))
+	if g.ensures != 1 {
+		t.Fatalf("f asked the daemon to start the agent %d times, want 1", g.ensures)
+	}
+	// The fix re-checks and everything else was already green, so it hands off.
+	if got := d.view(); got != "chat" {
+		t.Fatalf("after the fix the gate landed on %q, want chat\n%s", got, d.screen())
+	}
 }
 
 // esc backs out to a hub that still has a highlighted row (#2481), and says why
@@ -386,6 +469,61 @@ func TestALateProceedFromAnAbandonedGateLaunchesNothing(t *testing.T) {
 	}
 	if got := d.cat.Get("email").Status; got == catalog.StatusActive {
 		t.Error("a late ProceedMsg launched the agent anyway")
+	}
+}
+
+// analystAgent is a second daemon-backed agent, for the two-gates race below.
+func analystAgent() catalog.Agent {
+	return catalog.Agent{
+		ID: "analyst", Name: "Analyst", Status: catalog.StatusInstalled,
+		Transport: catalog.TransportDaemon,
+	}
+}
+
+// The nastiest race in this seam: a probe started for one agent, answered after
+// the user backed out and launched another. Its report must not drive the second
+// agent's gate — an all-green report for A would otherwise green-light B and open
+// a chat for an agent nothing ever probed.
+func TestAnAbandonedGatesReportCannotGreenLightAnotherAgent(t *testing.T) {
+	g := readyGateTransport()
+	// Email would pass; Analyst is blocked on its model. So if Email's stale
+	// report reaches Analyst's gate, it turns a blocked screen into a launch.
+	g.initByAgent = map[string]initAnswer{
+		"analyst": {status: http.StatusServiceUnavailable, body: readyGateTransport().modelMissing().initBody},
+	}
+	d := newRootDriver(t, g, 80, 24)
+
+	// Gate 1 for email, its probe captured and NOT run yet — this is the in-flight
+	// probe the user walks away from.
+	emailProbe := d.sendNoPump(hub.LaunchAgentMsg{Agent: *d.cat.Get("email")})
+	d.send(keyEsc())
+
+	// Gate 2 for a different agent, blocked and waiting for the user.
+	d.send(hub.LaunchAgentMsg{Agent: analystAgent()})
+	if got := d.view(); got != "preflight" {
+		t.Fatalf("the second launch landed on %q, want preflight\n%s", got, d.screen())
+	}
+
+	// Email's probe finally answers, into Analyst's gate.
+	d.pump(emailProbe)
+
+	if got := d.view(); got != "preflight" {
+		t.Fatalf("a stale report launched %q\n%s", got, d.screen())
+	}
+	screen := d.flat()
+	if !strings.Contains(screen, "Getting Analyst ready") {
+		t.Errorf("the gate is no longer the one that was on screen:\n%s", d.screen())
+	}
+	// The Mailbox row exists only in email's report: seeing it here means the
+	// stale report was adopted.
+	if strings.Contains(screen, "Mailbox") {
+		t.Errorf("email's rows are being shown on the Analyst gate:\n%s", d.screen())
+	}
+	if !strings.Contains(screen, "not downloaded") {
+		t.Errorf("Analyst's own blocked row was replaced:\n%s", d.screen())
+	}
+	if got := d.cat.Get("email").Status; got == catalog.StatusActive {
+		t.Error("the abandoned gate launched email anyway")
 	}
 }
 
@@ -468,6 +606,60 @@ func TestConnectMailboxForAConnectedProviderShowsThatProvider(t *testing.T) {
 	}
 	if strings.Contains(screen, "connect google") {
 		t.Errorf("the hand-off offers Gmail to an Outlook user:\n%s", d.screen())
+	}
+}
+
+// On a terminal too short for the whole hand-off, the command is the last thing
+// that may be dropped — a screen that keeps the explanation and loses the fix
+// names a problem and takes away the answer.
+func TestAShortTerminalKeepsTheHandoffCommand(t *testing.T) {
+	for _, rows := range []int{24, 16, 12, 10} {
+		d := newRootDriver(t, readyGateTransport().mailboxMissing(), 80, 24)
+		d.launchEmail()
+		d.send(key("f"))
+		d.send(windowSize(80, rows))
+
+		screen := d.screen()
+		if got := len(strings.Split(screen, "\n")); got > rows {
+			t.Errorf("at %d rows the hand-off renders %d lines:\n%s", rows, got, screen)
+		}
+		flat := strings.Join(strings.Fields(screen), " ")
+		// The whole command, scopes included — a half-command is worse than none.
+		for _, want := range []string{
+			"gaia connectors connect google --grant-agent installed:email",
+			"gmail.send",
+			"esc back to the checks",
+		} {
+			if !strings.Contains(flat, want) {
+				t.Errorf("at %d rows the hand-off lost %q:\n%s", rows, want, screen)
+			}
+		}
+	}
+}
+
+// If the check ever produces a command for a different provider than the mailbox
+// it is describing, the screen must not let its own title vouch for it.
+func TestAMismatchedProviderCommandIsFlagged(t *testing.T) {
+	g := readyGateTransport()
+	// A provider the connect-command builder has no scope list for: it falls back
+	// to the Google command, which is not what this mailbox needs.
+	g.connectors = map[string]any{
+		"agent_id": "email",
+		"providers": []map[string]any{
+			{"provider": "yahoo", "connected": true, "account_email": "user@yahoo.com",
+				"can_send": false, "scopes": []string{}},
+		},
+	}
+	d := newRootDriver(t, g, 80, 24)
+	d.launchEmail()
+	d.send(key("f"))
+
+	flat := d.flat()
+	if !strings.Contains(flat, "Heads up") {
+		t.Errorf("a Gmail command under a yahoo mailbox is presented as correct:\n%s", d.screen())
+	}
+	if !strings.Contains(flat, "report it") {
+		t.Errorf("the mismatch is not reportable:\n%s", d.screen())
 	}
 }
 
@@ -558,31 +750,49 @@ func TestTheGateIsBornAtTheTerminalSize(t *testing.T) {
 
 // The hub was fixed to fit the minimum terminal; the gate in front of it has to
 // fit too, in every state a user can be in.
+//
+// Row count alone is a tautology here — both views clamp themselves to the height
+// they are given, so they can always "fit" by dropping the very thing the user
+// needs. Each case therefore names what has to still be on screen at 80x24.
 func TestEveryGateStateFitsEightyByTwentyFour(t *testing.T) {
 	cases := []struct {
 		name  string
 		build func() *gateTransport
 		keys  []tea.KeyMsg
+		// hold keeps an all-green gate on screen; without it the case would
+		// measure the chat view the gate hands off to.
+		hold bool
+		// wants is what must survive the fit at the minimum size.
+		wants []string
 	}{
-		{"all ready", readyGateTransport, nil},
-		{"model missing", func() *gateTransport { return readyGateTransport().modelMissing() }, nil},
-		{"model missing, details", func() *gateTransport { return readyGateTransport().modelMissing() },
-			[]tea.KeyMsg{key("d")}},
-		{"mailbox missing", func() *gateTransport { return readyGateTransport().mailboxMissing() }, nil},
-		{"mailbox hand-off", func() *gateTransport { return readyGateTransport().mailboxMissing() },
-			[]tea.KeyMsg{key("f")}},
-		{"daemon down", func() *gateTransport {
+		{name: "all ready", build: readyGateTransport, hold: true,
+			wants: []string{"Getting Email ready", "ready", "Mailbox", "esc back"}},
+		{name: "model missing", build: func() *gateTransport { return readyGateTransport().modelMissing() },
+			wants: []string{"AI model", "not downloaded", "run: gaia init", "esc back"}},
+		{name: "model missing, details", build: func() *gateTransport { return readyGateTransport().modelMissing() },
+			keys:  []tea.KeyMsg{key("d")},
+			wants: []string{"AI model — failed", "esc back"}},
+		{name: "mailbox missing", build: func() *gateTransport { return readyGateTransport().mailboxMissing() },
+			wants: []string{"Mailbox", "not connected", "gaia connectors connect google", "esc back"}},
+		{name: "mailbox hand-off", build: func() *gateTransport { return readyGateTransport().mailboxMissing() },
+			keys:  []tea.KeyMsg{key("f")},
+			wants: []string{"Connect a mailbox for Email", "gmail.send", "esc back to the checks"}},
+		{name: "daemon down", build: func() *gateTransport {
 			g := readyGateTransport()
 			g.attachErr = &daemon.NotRunningError{Path: "/tmp/instance.json"}
 			return g
-		}, nil},
+		}, wants: []string{"Background service", "not running", "f start it for me", "esc back"}},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			d := newRootDriver(t, tc.build(), 80, 24)
+			opts := preflight.Options{ReadyHold: time.Millisecond, ManualProceed: tc.hold}
+			d := newRootDriverOpts(t, tc.build(), 80, 24, opts)
 			d.launchEmail()
 			for _, k := range tc.keys {
 				d.send(k)
+			}
+			if got := d.view(); got != "preflight" {
+				t.Fatalf("this case is not measuring the gate — view = %q\n%s", got, d.screen())
 			}
 			lines := strings.Split(d.screen(), "\n")
 			if len(lines) > 24 {
@@ -591,6 +801,12 @@ func TestEveryGateStateFitsEightyByTwentyFour(t *testing.T) {
 			for i, line := range lines {
 				if w := ansi.StringWidth(line); w > 80 {
 					t.Errorf("line %d is %d columns wide: %q", i, w, line)
+				}
+			}
+			flat := strings.Join(strings.Fields(d.screen()), " ")
+			for _, want := range tc.wants {
+				if !strings.Contains(flat, want) {
+					t.Errorf("at 80x24 the screen lost %q:\n%s", want, d.screen())
 				}
 			}
 		})


### PR DESCRIPTION
Only one agent in the repo could tell you whether it was actually ready to work. The email sidecar hand-wrote `GET`/`POST /v1/email/init`; the other 18 hub agents had nothing, so a consumer could see the process was up but had no way to learn the model it needs was never downloaded — the failure surfaced later, mid-task, as a confusing error. Now an agent *declares* what it needs (a model id, a minimum backend version) and `AgentServer` serves both verbs for it. The response is byte-compatible with email's existing endpoint, so the TUI preflight gate parses both without a branch and email keeps serving unchanged until its swap-over lands separately.

The boundary is enforced, not just documented: inherited init makes *this agent's* requirements ready against a backend that is already running. Installing the backend stays with `gaia init` — an agent process cannot bootstrap the server it depends on, so an unreachable backend fails loudly and names whose job the fix is instead of hanging or half-succeeding.

## The failure this is designed against

**An agent that declares nothing gets no `/init` at all — not a cheerful one.**

That is the whole design rule, and it is worth stating because the cheerful version is the one that ships and then wastes somebody's afternoon. A readiness endpoint built from an empty declaration would answer `ready: true` the moment Lemonade happened to be up, having verified nothing about the agent — and a consumer would believe it. So the routes are only mounted when the agent actually declared something, whether it passed an empty declaration object or a manifest with no `models:`.

This is the same shape as several bugs already found in this project: **something reports ready, and only fails when the user tries to use it.** A mailbox row green over dead credentials; a transport reporting "Connected" before `executable file not found`; a control file naming a dead pid. A green light that was never wired to anything is worse than a red one, because it costs a debugging session to disbelieve.

Three related distinctions the contract preserves for the same reason, each with a different remedy: an unreadable model list is *"could not tell"*, never *"missing"* (reporting it as missing sends the user to re-download a model they may already have); a backend advertising no version is indeterminate, never a pass; and a version-too-old is reported *before* a missing model, so nobody downloads gigabytes an old server may then refuse to serve.

## Test plan

- [x] `python -m pytest tests/unit/test_agent_readiness.py tests/unit/test_agent_server.py` — 75 pass (48 new, 27 pre-existing, no regressions)
- [x] `python util/lint.py --all` — exit 0
- [x] Live against `lemond` v10.10.0 on port 13305, serving a test agent through `AgentServer`:
  - `GET` with model present → `200 {"ready":true,...,"ctx_size":65536}`, byte-identical to email's response for the same state
  - `GET` with backend unreachable → `503`, hint names `lemonade-server serve` and "host prerequisite"
  - `POST` with model present → `200`, correctly no-ops instead of re-pulling, final line `✓`
  - `POST` with an unknown model → committed `200` with final line `✗ Provisioning failed: HTTPError: 400` — proves the final line, not the status, carries the verdict
  - `POST` with backend unreachable → `503`, pulls nothing
- [x] A test fails the build if the model probe is ever reached on a dead backend, so an installer cannot quietly grow here later

## Follow-ups (deliberately not in this PR)

- **Email swap-over** — sequenced after the in-flight #2469 onboarding work to avoid two changes in `api_routes.py`. Email's `/init` serves unchanged meanwhile, so nothing regresses mid-flight. The dead `EmailAgentConfig.model_id or …` branch (that field is always `None`) disappears with the swap rather than being patched in a file about to change.
- **#2493 makes `requirements.min_lemonade_version` parse.** Email's manifest declares it and `gaia.hub.manifest.Requirements` was dropping it, so `AgentRequirements.from_manifest` currently reports the version gate as indeterminate rather than fabricating a pass. Once #2493 merges the value flows through automatically and the `NOTE` in that docstring should be dropped.