### PR TITLE
fix(hub): carry requirements.min_lemonade_version through the manifest parser

### DIFF
--- a/docs/guides/hub-publishing.mdx
+++ b/docs/guides/hub-publishing.mdx
@@ -170,6 +170,9 @@ python:
 
 requirements:                # what a machine needs to run it (shown as cards on your page)
   min_memory_gb: 8
+  min_lemonade_version: "10.2.0"  # optional: the oldest Lemonade Server your
+                                  # agent works with, so a too-old backend is
+                                  # reported as such instead of failing oddly
   platforms: [win-x64, linux-x64, darwin-arm64]
 
 interfaces:                  # the ways your agent can be used (see "Standalone sidecars")

--- a/docs/spec/agent-hub-restructure.mdx
+++ b/docs/spec/agent-hub-restructure.mdx
@@ -104,6 +104,8 @@ models: [Qwen3.5-35B-A3B-GGUF]
 
 requirements:
   min_memory_gb: 8
+  min_lemonade_version: "10.2.0"   # optional; SemVer. The backend floor a
+                                   # readiness check compares against.
   platforms: [win-x64, linux-x64, darwin-arm64]
 
 interfaces:

--- a/hub/agents/email/python/gaia-agent.yaml
+++ b/hub/agents/email/python/gaia-agent.yaml
@@ -36,7 +36,7 @@ requirements:
   # Minimum Lemonade Server version the triage stack needs. Mirrors
   # gaia_agent_email.version.MIN_LEMONADE_VERSION (the runtime source of truth
   # for the GET /v1/email/init readiness check); a test keeps the two in
-  # lock-step. `gaia init` reads this manifest value for the install path.
+  # lock-step.
   min_lemonade_version: "10.2.0"
   platforms: [win-x64, linux-x64, darwin-arm64]
 

--- a/src/gaia/hub/compatibility.py
+++ b/src/gaia/hub/compatibility.py
@@ -166,6 +166,7 @@ def _coerce_requirements(requirements: Any) -> Requirements:
             min_memory_gb=requirements.get("min_memory_gb"),
             min_disk_gb=requirements.get("min_disk_gb"),
             min_context_size=requirements.get("min_context_size"),
+            min_lemonade_version=requirements.get("min_lemonade_version"),
             platforms=list(requirements.get("platforms") or []),
             npu=bool(requirements.get("npu", False)),
             gpu_vram_gb=requirements.get("gpu_vram_gb"),

--- a/src/gaia/hub/manifest.py
+++ b/src/gaia/hub/manifest.py
@@ -120,11 +120,18 @@ class ManifestError(ValueError):
 
 @dataclass
 class Requirements:
-    """System requirements block from ``requirements:``."""
+    """System requirements block from ``requirements:``.
+
+    ``min_lemonade_version`` is the minimum Lemonade Server version the agent
+    needs. It is what a readiness check compares the running server against, so
+    an agent that declares it can report "your backend is too old" instead of
+    failing later with something less specific.
+    """
 
     min_memory_gb: Optional[float] = None
     min_disk_gb: Optional[float] = None
     min_context_size: Optional[int] = None
+    min_lemonade_version: Optional[str] = None
     platforms: List[str] = field(default_factory=list)
     npu: bool = False
     gpu_vram_gb: Optional[float] = None
@@ -530,6 +537,10 @@ def _parse_requirements(raw: Any, where: str) -> Requirements:
     if raw is None:
         return Requirements()
     data = _require_mapping(raw, "requirements", where)
+    if data.get("min_lemonade_version") is not None:
+        _validate_semver(
+            data["min_lemonade_version"], "requirements.min_lemonade_version", where
+        )
     return Requirements(
         min_memory_gb=_parse_number(
             data.get("min_memory_gb"), "requirements.min_memory_gb", where
@@ -547,6 +558,7 @@ def _parse_requirements(raw: Any, where: str) -> Requirements:
                 0,
             )
         ),
+        min_lemonade_version=data.get("min_lemonade_version"),
         platforms=_validate_platforms(
             data.get("platforms"), "requirements.platforms", where
         ),

--- a/tests/unit/agents/email/test_init_endpoint.py
+++ b/tests/unit/agents/email/test_init_endpoint.py
@@ -398,20 +398,28 @@ def test_version_meets_min(found, minimum, expected):
 
 
 def test_min_lemonade_version_locksteps_with_manifest():
-    # ONE source of truth: the runtime constant and the gaia-agent.yaml manifest
-    # value `gaia init` reads MUST match, or readiness and install disagree.
+    """The runtime constant and the PARSED manifest value must agree.
+
+    Deliberately routed through ``gaia.hub.manifest.parse`` rather than
+    ``yaml.safe_load``. Comparing raw YAML text to the constant proves the two
+    files agree with each other while saying nothing about whether the value
+    survives parsing — and for a long time it did not: ``Requirements`` had no
+    ``min_lemonade_version`` field, so the parser dropped it and this test
+    stayed green over a declaration that reached no consumer.
+    """
     import gaia_agent_email
-    import yaml
     from gaia_agent_email.version import MIN_LEMONADE_VERSION as RUNTIME_MIN
+
+    from gaia.hub.manifest import parse
 
     manifest_path = (
         Path(gaia_agent_email.__file__).resolve().parents[1] / "gaia-agent.yaml"
     )
-    manifest = yaml.safe_load(manifest_path.read_text(encoding="utf-8"))
-    declared = manifest["requirements"]["min_lemonade_version"]
+    declared = parse(manifest_path).requirements.min_lemonade_version
     assert declared == RUNTIME_MIN, (
-        f"gaia-agent.yaml min_lemonade_version ({declared!r}) != "
-        f"version.MIN_LEMONADE_VERSION ({RUNTIME_MIN!r}) — keep in lock-step."
+        f"gaia-agent.yaml min_lemonade_version parsed as {declared!r} != "
+        f"version.MIN_LEMONADE_VERSION ({RUNTIME_MIN!r}). If this is None, the "
+        f"manifest parser is dropping the field rather than the two drifting."
     )
 
 

--- a/tests/unit/test_hub_manifest.py
+++ b/tests/unit/test_hub_manifest.py
@@ -404,6 +404,80 @@ def test_negative_memory_raises():
         AgentManifest.from_dict(data)
 
 
+# ---------------------------------------------------------------------------
+# requirements.min_lemonade_version
+#
+# This block exists because the field was declared in a shipped manifest and
+# silently dropped by the parser for months. A test that only compares the YAML
+# text to a constant cannot catch that — it proves two files agree while the
+# value reaches nobody. These assert the parsed object actually carries it.
+# ---------------------------------------------------------------------------
+
+
+def test_min_lemonade_version_survives_parsing():
+    data = dict(VALID_PYTHON_MANIFEST)
+    data["requirements"] = dict(data["requirements"], min_lemonade_version="10.2.0")
+
+    parsed = AgentManifest.from_dict(data)
+
+    assert parsed.requirements.min_lemonade_version == "10.2.0"
+
+
+def test_min_lemonade_version_survives_a_round_trip_through_yaml(tmp_path):
+    """The path a real agent takes: YAML on disk → parse → consumer."""
+    data = dict(VALID_PYTHON_MANIFEST)
+    data["requirements"] = dict(data["requirements"], min_lemonade_version="11.5.0")
+    path = tmp_path / "gaia-agent.yaml"
+    path.write_text(yaml.safe_dump(data), encoding="utf-8")
+
+    assert parse(path).requirements.min_lemonade_version == "11.5.0"
+
+
+def test_min_lemonade_version_is_optional():
+    """Most agents declare no backend floor; that is not an error."""
+    data = dict(VALID_PYTHON_MANIFEST)
+    data["requirements"] = {
+        k: v for k, v in data["requirements"].items() if k != "min_lemonade_version"
+    }
+
+    assert AgentManifest.from_dict(data).requirements.min_lemonade_version is None
+
+
+def test_absent_requirements_block_leaves_min_lemonade_version_none():
+    data = dict(VALID_PYTHON_MANIFEST)
+    data.pop("requirements")
+
+    assert AgentManifest.from_dict(data).requirements.min_lemonade_version is None
+
+
+def test_dict_to_requirements_coercion_keeps_min_lemonade_version():
+    """The second dict → Requirements path must not drop it either.
+
+    ``check_compatibility`` accepts a raw mapping and coerces it. That converter
+    is a separate parse path from the manifest one, and a field added to only
+    half of them is the same silent drop with a different entry point.
+    """
+    from gaia.hub.compatibility import _coerce_requirements
+
+    coerced = _coerce_requirements({"min_lemonade_version": "10.2.0"})
+
+    assert coerced.min_lemonade_version == "10.2.0"
+
+
+def test_malformed_min_lemonade_version_raises():
+    """A floor nothing can compare against is worse than none — fail loudly.
+
+    A readiness check that cannot parse the declared minimum reports the
+    version gate as indeterminate, so a typo here would silently disable the
+    very check the field exists to drive.
+    """
+    data = dict(VALID_PYTHON_MANIFEST)
+    data["requirements"] = dict(data["requirements"], min_lemonade_version="10.2")
+
+    with pytest.raises(ManifestError, match="min_lemonade_version"):
+        AgentManifest.from_dict(data)
+
+
 def test_bool_tools_count_raises():
     data = dict(VALID_PYTHON_MANIFEST, tools_count=True)
     with pytest.raises(ManifestError, match="tools_count"):


### PR DESCRIPTION
An agent could declare the minimum Lemonade Server version it needs and **nothing would ever read it**. The email manifest has carried `requirements.min_lemonade_version: "10.2.0"` for months, but `Requirements` had no such field, so the parser dropped it silently. Any readiness check built on that declaration reported the version gate as indeterminate instead of enforcing it — so a user on a too-old backend got a vague downstream failure rather than "your Lemonade is older than this agent needs."

A comment sitting on the declaration claimed *"`gaia init` reads this manifest value for the install path."* It does not. `gaia init` reads a hardcoded per-profile table in `installer/init_command.py` and never opens a manifest. That comment is most of the reason nobody noticed the field was going nowhere, so it is **deleted** rather than reworded.

## The test is the real fix

The lockstep test meant to guard this compared raw YAML text to the runtime constant. It proved two files agreed with each other while the value reached no consumer — **it would still have passed if the parser deleted the field entirely, which is exactly what happened.** It now asserts through `gaia.hub.manifest.parse`, and its failure message distinguishes "the two drifted" from "the parser ate it."

Verified by reverting the parser fix and confirming the new tests go red with `min_lemonade_version=None` named in the assertion output — then restoring.

## Test plan

- [x] `python -m pytest tests/unit/test_hub_manifest.py` — 84 pass (6 new)
- [x] `python -m pytest tests/unit/agents/email/test_init_endpoint.py` — 43 pass, incl. the rewritten lockstep test
- [x] **Regression baseline**: same 7 test files run serially on this branch and on stashed-clean `main` produce **byte-identical** failure sets (9 each, all pre-existing), with `+6 passed` on this branch — exactly the 6 new tests
- [x] `python util/lint.py --all` — exit 0
- [x] Confirmed no manifest anywhere declares a value the new SemVer validation would reject (email's `"10.2.0"` is the only declaration in the repo)
- [x] Confirmed no caller constructs `Requirements(...)` positionally, so inserting a field mid-dataclass is safe

## Notes for the reviewer

- **A malformed value now raises** instead of being accepted. A floor nothing can parse silently disables the check the field exists to drive, so it fails loudly like `min_gaia_version` already does.
- **Two converters, not one.** `compatibility._coerce_requirements` builds `Requirements` from a raw dict and dropped the field identically. A field added to only half the parse paths is the same bug with a different entry point, so it is carried through both, with a test.
- **`gaia init` is deliberately untouched.** Making it read manifests is not a rename: its table is keyed by *profile* (`minimal`, `rag`, `npu`, `all`), several profiles map to no manifest at all, `all` would need the max across many agents, and `gaia init` runs *before* agents are installed — so the manifest usually is not on disk yet. That is a resolution design with a real chicken-and-egg and needs its own change. The honest split is probably: `gaia init` owns the install-time floor, each manifest owns its runtime floor, and the invariant worth testing is that the installed version clears every agent's floor — which `test_shipped_lemonade_pin_satisfies_the_agent_floor` already does for email and could be generalized to all manifests.