### PR TITLE
fix(llm): detect Lemonade on macOS; stop printing commands that don't work

### DIFF
--- a/src/gaia/cli.py
+++ b/src/gaia/cli.py
@@ -4054,7 +4054,16 @@ Let me know your answer!
             else:
                 print(f"❌ {result['message']}")
         else:
-            print("❌ Specify --lemonade or --port <number>")
+            # A refusal must not report success — `gaia kill && next-step`
+            # would otherwise run next-step having killed nothing.
+            print("❌ gaia kill needs a target:")
+            print("     --lemonade        stop Lemonade Server (port 13305)")
+            print("     --port <number>   kill whatever is listening on <number>")
+            print(
+                "   Both target a port. A stray GAIA process that is not "
+                "holding a port must be killed by PID."
+            )
+            sys.exit(1)
         return
 
     # Import LemonadeManager for model commands error handling
@@ -5834,8 +5843,10 @@ def handle_cache_command(args):
                 cache.clear()
                 print("✓ Context7 cache cleared")
             else:
-                print("Specify --context7 or --all to clear caches")
+                # Same refusal-must-not-report-success rule as `gaia kill`.
+                print("❌ Specify --context7 or --all to clear caches")
                 print("Run 'gaia cache clear --help' for more information")
+                sys.exit(1)
 
     except Exception as e:
         cache_log = get_logger(__name__)

--- a/src/gaia/cli.py
+++ b/src/gaia/cli.py
@@ -25,6 +25,7 @@ from gaia.llm.lemonade_client import (
     LemonadeClientError,
     _get_lemonade_config,
 )
+from gaia.llm.lemonade_launcher import describe_start_hint
 from gaia.logger import get_logger
 from gaia.perf_analysis import run_perf_visualization
 from gaia.version import version
@@ -987,7 +988,7 @@ def _launch_agent_ui(port=4200, base_url=None, log=None, debug=False, webui_dist
             print(
                 "     1. Models downloaded  : gaia init --profile chat  (first time only, ~25 GB)"
             )
-            print("     2. Lemonade running   : lemonade-server serve")
+            print(f"     2. Lemonade running   : {describe_start_hint().instruction}")
             print()
 
         import uvicorn
@@ -4130,7 +4131,8 @@ Let me know your answer!
                         "   1. Close any running GAIA commands (gaia chat, gaia code, etc.)"
                     )
                     print(
-                        "   2. Restart Lemonade Server (close window and run: lemonade-server serve)"
+                        f"   2. Restart Lemonade Server "
+                        f"({describe_start_hint().instruction})"
                     )
                     print("   3. Run: gaia download --clear-cache")
                     print()
@@ -5418,7 +5420,9 @@ def handle_sd_command(args):
         getattr(args, "use_claude", False) or getattr(args, "use_chatgpt", False)
     ):
         print("Failed to initialize Lemonade Server with required 8K context.")
-        print("Try: lemonade-server serve --ctx-size 8192")
+        print(
+            f"Restart it with an 8192 token context. {describe_start_hint(8192).instruction}"
+        )
         sys.exit(1)
 
     # Create config - ensure LLM model is set
@@ -5445,8 +5449,8 @@ def handle_sd_command(args):
     if health["status"] != "healthy":
         print(f"Error: {health.get('error', 'SD endpoint unavailable')}")
         print("Make sure Lemonade Server is running and SD model is available:")
-        print("  lemonade-server serve")
-        print("  lemonade-server pull SD-Turbo")
+        print(f"  {describe_start_hint().instruction}")
+        print("  gaia download SD-Turbo")
         sys.exit(1)
 
     print()
@@ -6354,7 +6358,9 @@ def _bootstrap_infer():
             raw_response = "".join(raw_response)
     except Exception as e:
         print(f"\n\n  ❌ LLM call failed: {e}")
-        print("  Make sure Lemonade Server is running: lemonade-server serve")
+        print(
+            f"  Make sure Lemonade Server is running. {describe_start_hint().instruction}"
+        )
         return
 
     print(" done.")

--- a/src/gaia/cli.py
+++ b/src/gaia/cli.py
@@ -25,7 +25,7 @@ from gaia.llm.lemonade_client import (
     LemonadeClientError,
     _get_lemonade_config,
 )
-from gaia.llm.lemonade_launcher import describe_start_hint
+from gaia.llm.lemonade_launcher import describe_client_hint, describe_start_hint
 from gaia.logger import get_logger
 from gaia.perf_analysis import run_perf_visualization
 from gaia.version import version
@@ -5450,7 +5450,7 @@ def handle_sd_command(args):
         print(f"Error: {health.get('error', 'SD endpoint unavailable')}")
         print("Make sure Lemonade Server is running and SD model is available:")
         print(f"  {describe_start_hint().instruction}")
-        print("  gaia download SD-Turbo")
+        print(f"  {describe_client_hint('pull', args.sd_model).instruction}")
         sys.exit(1)
 
     print()

--- a/src/gaia/code_index/sdk.py
+++ b/src/gaia/code_index/sdk.py
@@ -18,6 +18,7 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 from gaia.llm.lemonade_client import DEFAULT_EMBEDDING_MODEL
+from gaia.llm.lemonade_launcher import describe_start_hint
 
 log = logging.getLogger(__name__)
 
@@ -689,9 +690,9 @@ class CodeIndexSDK:
             raise RuntimeError(
                 f"Could not load embedding model "
                 f"{self.config.embedding_model!r}: {e}. "
-                "Verify Lemonade Server is running "
-                "(`lemonade-server serve`) and that the model is "
-                "downloaded (`gaia download <model>`)."
+                f"Verify Lemonade Server is running "
+                f"({describe_start_hint().instruction}) and that the model is "
+                f"downloaded (`gaia download <model>`)."
             ) from e
 
         self._embedder = self._llm_client

--- a/src/gaia/code_index/sdk.py
+++ b/src/gaia/code_index/sdk.py
@@ -18,7 +18,7 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 from gaia.llm.lemonade_client import DEFAULT_EMBEDDING_MODEL
-from gaia.llm.lemonade_launcher import describe_start_hint
+from gaia.llm.lemonade_launcher import describe_client_hint, describe_start_hint
 
 log = logging.getLogger(__name__)
 
@@ -322,8 +322,8 @@ class CodeIndexSDK:
                 f"Indexing aborted: all embedding calls failed for "
                 f"{len(new_chunks) + len(reused_chunks)} chunks. "
                 "Check that Lemonade Server is reachable and that "
-                f"{self.config.embedding_model!r} is loaded "
-                "(`lemonade-server load <model>` or `gaia init`)."
+                f"{self.config.embedding_model!r} is loaded. "
+                f"{describe_client_hint('load', self.config.embedding_model).instruction}"
             )
 
         embeddings = np.concatenate(embedding_parts, axis=0)
@@ -692,7 +692,8 @@ class CodeIndexSDK:
                 f"{self.config.embedding_model!r}: {e}. "
                 f"Verify Lemonade Server is running "
                 f"({describe_start_hint().instruction}) and that the model is "
-                f"downloaded (`gaia download <model>`)."
+                f"downloaded "
+                f"({describe_client_hint('pull', self.config.embedding_model).instruction})."
             ) from e
 
         self._embedder = self._llm_client

--- a/src/gaia/installer/init_command.py
+++ b/src/gaia/installer/init_command.py
@@ -34,7 +34,11 @@ except ImportError:
 from gaia.agents.base.console import AgentConsole
 from gaia.agents.install_hints import source_install_command
 from gaia.installer.lemonade_installer import LemonadeInfo, LemonadeInstaller
-from gaia.llm.lemonade_launcher import build_start_command, resolve_lemonade
+from gaia.llm.lemonade_launcher import (
+    build_start_command,
+    describe_start_hint,
+    resolve_lemonade,
+)
 from gaia.version import LEMONADE_VERSION
 
 log = logging.getLogger(__name__)
@@ -1287,24 +1291,17 @@ class InitCommand:
                 )
             else:
                 # Give the user the exact start command for their tooling
-                tooling = resolve_lemonade()
-                if tooling.found:
-                    min_ctx = INIT_PROFILES[self.profile].get("min_context_size")
-                    spec = build_start_command(tooling, min_ctx)
-                    cmd_str = " ".join(spec.argv)
-                    if spec.env:
-                        env_prefix = " ".join(f"{k}={v}" for k, v in spec.env.items())
-                        cmd_str = f"{env_prefix} {cmd_str}"
-                    if tooling.kind == "legacy":
-                        cmd_str += " &"
+                min_ctx = INIT_PROFILES[self.profile].get("min_context_size")
+                hint = describe_start_hint(min_ctx)
+                if hint.command:
+                    # We block on input() next — hand back the shell.
+                    cmd_str = f"{hint.command} &" if hint.foreground else hint.command
                     self.console.print(f"   [dim]• Run:[/dim] [cyan]{cmd_str}[/cyan]")
-                else:
                     self.console.print(
-                        "   [dim]• Run:[/dim] [cyan]lemonade-server serve &[/cyan]"
+                        "   [dim]• If command not found, open a new terminal or run:[/dim] [cyan]hash -r[/cyan]"
                     )
-                self.console.print(
-                    "   [dim]• If command not found, open a new terminal or run:[/dim] [cyan]hash -r[/cyan]"
-                )
+                else:
+                    self.console.print(f"   [dim]• {hint.instruction}[/dim]")
             self.console.print()
 
             # Wait for user to start the server
@@ -1415,7 +1412,7 @@ class InitCommand:
         except ConnectionError as e:
             self._print_error(f"Cannot reach Lemonade Server to detect hardware: {e}")
             self._print_error(
-                "Ensure Lemonade Server is running: lemonade-server serve"
+                f"Ensure Lemonade Server is running. {describe_start_hint().instruction}"
             )
             return False
         except Exception as e:
@@ -1768,7 +1765,8 @@ class InitCommand:
                 else:
                     self._print_error(f"Failed to configure {min_ctx} token context")
                     self._print_error(
-                        f"Try: lemonade-server serve --ctx-size {min_ctx}"
+                        f"Restart Lemonade Server with a {min_ctx} token context. "
+                        f"{describe_start_hint(min_ctx).instruction}"
                     )
                     return False
 

--- a/src/gaia/llm/lemonade_client.py
+++ b/src/gaia/llm/lemonade_client.py
@@ -33,6 +33,7 @@ from openai import OpenAI
 
 from gaia.llm.lemonade_launcher import (
     build_start_command,
+    describe_start_hint,
     get_installed_version,
     resolve_lemonade,
 )
@@ -3803,8 +3804,8 @@ class LemonadeClient:
             else:
                 error_msg = (
                     f"Insufficient context size: server has {reported_ctx} tokens, "
-                    f"but {required_tokens} tokens are required. "
-                    f"Restart with: {self._start_command_hint(required_tokens)}"
+                    f"but {required_tokens} tokens are required. Restart Lemonade "
+                    f"Server. {self._start_command_hint(required_tokens)}"
                 )
                 if not quiet:
                     print(f"❌ {error_msg}")
@@ -4098,18 +4099,15 @@ class LemonadeClient:
         """
         return get_installed_version(resolve_lemonade())
 
-    def _start_command_hint(self, ctx_size: Optional[int]) -> str:
-        """Render the exact start command for the installed tooling.
+    @staticmethod
+    def _start_command_hint(ctx_size: Optional[int]) -> str:
+        """Platform-accurate "here's how to start it" text for the user.
 
-        Used in user-facing guidance so modern installs aren't told to run
-        the removed ``lemonade-server`` CLI.
+        Delegates to the shared resolver so modern installs aren't told to
+        run the removed ``lemonade-server`` CLI, and so platforms started
+        from a GUI get prose instead of an invented shell command.
         """
-        tooling = resolve_lemonade()
-        if tooling.found:
-            spec = build_start_command(tooling, ctx_size)
-            env_prefix = " ".join(f"{k}={v}" for k, v in spec.env.items())
-            return f"{env_prefix} {' '.join(spec.argv)}".strip()
-        return f"lemonade-server serve --ctx-size {ctx_size}"
+        return describe_start_hint(ctx_size).instruction
 
     def _check_version_compatibility(
         self,
@@ -4288,7 +4286,7 @@ class LemonadeClient:
                         f"is less than recommended ({required_ctx})"
                     )
                     print(
-                        f"   For better performance, restart with: "
+                        f"   For better performance, restart Lemonade Server. "
                         f"{self._start_command_hint(required_ctx)}"
                     )
                     print("")
@@ -4299,7 +4297,7 @@ class LemonadeClient:
         if not auto_start:
             if not quiet:
                 print(f"{_emoji('❌', '[ERROR]')} Lemonade Server is not running")
-                print(f"   Start with: {self._start_command_hint(required_ctx)}")
+                print(f"   {self._start_command_hint(required_ctx)}")
             status.error = "Server not running"
             return status
 

--- a/src/gaia/llm/lemonade_launcher.py
+++ b/src/gaia/llm/lemonade_launcher.py
@@ -10,6 +10,9 @@ Modern Lemonade Server (10.7/10.8) removed the ``lemonade-server`` CLI:
   ``%LOCALAPPDATA%\\lemonade_server\\bin``.
 * Linux ships ``/usr/bin/lemonade`` (client) and ``/usr/bin/lemond``
   (daemon) managed by the ``lemond`` systemd unit.
+* macOS ships ``lemond`` (daemon) + ``lemonade`` (client) under
+  ``/usr/local/bin``, installed by the Lemonade app. There is no systemd
+  unit, so the daemon is started directly (or from the app).
 * Context size is passed via the ``LEMONADE_CTX_SIZE`` environment
   variable, NOT a ``serve --ctx-size`` flag.
 
@@ -38,8 +41,13 @@ log = logging.getLogger(__name__)
 # Legacy CLI names, in probe order. lemonade-server-dev is the pip/CI variant.
 _LEGACY_BINARIES = ("lemonade-server", "lemonade-server-dev")
 
-# macOS ships an app bundle (plus /usr/local/bin/lemond); there is no
-# installer support and no canonical probe in resolve_lemonade().
+# macOS: the Lemonade app installs the daemon + client into a standard bin
+# dir. /usr/local/bin is where the official installer puts them; the
+# Apple-Silicon Homebrew prefix is probed too.
+_MACOS_BIN_DIRS = ("/usr/local/bin", "/opt/homebrew/bin")
+_MACOS_DAEMON_NAME = "lemond"
+_MACOS_CLIENT_NAME = "lemonade"
+
 _MACOS_APP_CANDIDATES = (
     "/Applications/lemonade-app.app",
     "~/Applications/lemonade-app.app",
@@ -117,8 +125,10 @@ def resolve_lemonade() -> LemonadeTooling:
        ``shutil.which`` is never consulted.
     2. Modern tooling by CANONICAL path probe (not PATH order):
        Windows ``%LOCALAPPDATA%\\lemonade_server\\bin\\LemonadeServer.exe``,
-       Linux ``/usr/bin/lemonade``. Modern wins even when a stale legacy
-       ``lemonade-server`` binary is also on PATH.
+       Linux ``/usr/bin/lemonade``, macOS ``/usr/local/bin/lemond``
+       (falling back to ``lemond`` on PATH for a non-standard prefix).
+       Modern wins even when a stale legacy ``lemonade-server`` binary is
+       also on PATH.
     3. Legacy ``shutil.which("lemonade-server")`` (also tolerates the
        pip/CI ``lemonade-server-dev`` variant).
     """
@@ -156,6 +166,31 @@ def resolve_lemonade() -> LemonadeTooling:
                 kind="modern",
                 client_path=str(client),
                 server_launcher="/usr/bin/lemond",
+            )
+    elif system == "Darwin":
+        # Probe the daemon (what we start), not the client — the client is
+        # only needed for the version query and may be absent.
+        for bin_dir in _MACOS_BIN_DIRS:
+            daemon = Path(bin_dir) / _MACOS_DAEMON_NAME
+            if not daemon.exists():
+                continue
+            client = Path(bin_dir) / _MACOS_CLIENT_NAME
+            log.debug("Found modern Lemonade at canonical path: %s", daemon)
+            return LemonadeTooling(
+                found=True,
+                kind="modern",
+                client_path=str(client) if client.exists() else None,
+                server_launcher=str(daemon),
+            )
+        # Installed under a non-standard prefix but still on PATH.
+        daemon_on_path = shutil.which(_MACOS_DAEMON_NAME)
+        if daemon_on_path:
+            log.debug("Found modern Lemonade daemon on PATH: %s", daemon_on_path)
+            return LemonadeTooling(
+                found=True,
+                kind="modern",
+                client_path=shutil.which(_MACOS_CLIENT_NAME),
+                server_launcher=daemon_on_path,
             )
 
     for name in _LEGACY_BINARIES:
@@ -210,6 +245,8 @@ def build_start_command(tooling: LemonadeTooling, ctx_size: Optional[int]) -> St
     Modern Windows -> ``LemonadeServer.exe --silent`` with
     ``LEMONADE_CTX_SIZE`` in env. Modern Linux -> best-effort
     ``systemctl --user start lemond`` (the daemon is normally already up).
+    Modern macOS -> the ``lemond`` daemon directly; macOS has no systemd, so
+    the Linux form must never leak there.
     Legacy -> ``lemonade-server serve --ctx-size N`` (+ ``--no-tray`` on
     Windows), byte-identical to the historical argv.
 
@@ -232,6 +269,14 @@ def build_start_command(tooling: LemonadeTooling, ctx_size: Optional[int]) -> St
         if tooling.source == "env":
             # Explicit LEMONADE_SERVER_PATH override — run the named binary
             # verbatim rather than silently rerouting to systemctl.
+            return StartSpec(argv=[launcher], env=env)
+        if platform.system() == "Darwin":
+            # No systemd on macOS — start the daemon directly.
+            if not launcher:
+                raise ValueError(
+                    "Modern macOS Lemonade tooling has no server_launcher; "
+                    f"expected the {_MACOS_DAEMON_NAME!r} daemon path."
+                )
             return StartSpec(argv=[launcher], env=env)
         # Linux daemon — best-effort user-unit start; the server is
         # normally already running under systemd.
@@ -302,26 +347,19 @@ def describe_start_hint(ctx_size: Optional[int] = None) -> StartHint:
             )
         spec = build_start_command(tooling, ctx_size)
         command = _render_command(spec.argv, spec.env)
+        if system == "Darwin":
+            # The app is the normal macOS path; the daemon is the CLI way.
+            instruction = f"Start the Lemonade app from Applications, or run: {command}"
+        else:
+            instruction = f"Run: {command}"
         return StartHint(
-            instruction=f"Run: {command}",
+            instruction=instruction,
             command=command,
             foreground=spec.argv[0] != "systemctl",
         )
 
     if system == "Darwin":
-        # resolve_lemonade() has no Darwin probe, so a working macOS install
-        # still lands here — fall back to what macOS actually ships.
-        lemond = shutil.which("lemond")
-        if lemond:
-            env = {"LEMONADE_CTX_SIZE": str(ctx_size)} if ctx_size is not None else {}
-            command = _render_command([lemond], env)
-            return StartHint(
-                instruction=(
-                    f"Start the Lemonade app from Applications, or run: {command}"
-                ),
-                command=command,
-                foreground=True,
-            )
+        # macOS has no `gaia init` install path, so never suggest it here.
         if _macos_app_installed():
             return StartHint(
                 instruction="Start the Lemonade app from Applications, then retry."

--- a/src/gaia/llm/lemonade_launcher.py
+++ b/src/gaia/llm/lemonade_launcher.py
@@ -26,6 +26,7 @@ import logging
 import os
 import platform
 import re
+import shlex
 import shutil
 import subprocess
 from dataclasses import dataclass, field
@@ -36,6 +37,15 @@ log = logging.getLogger(__name__)
 
 # Legacy CLI names, in probe order. lemonade-server-dev is the pip/CI variant.
 _LEGACY_BINARIES = ("lemonade-server", "lemonade-server-dev")
+
+# macOS ships an app bundle (plus /usr/local/bin/lemond); there is no
+# installer support and no canonical probe in resolve_lemonade().
+_MACOS_APP_CANDIDATES = (
+    "/Applications/lemonade-app.app",
+    "~/Applications/lemonade-app.app",
+)
+
+_DOWNLOAD_URL = "https://lemonade-server.ai"
 
 _VERSION_RE = re.compile(r"(\d+\.\d+\.\d+)")
 
@@ -65,6 +75,23 @@ class StartSpec:
 
     argv: List[str]
     env: Dict[str, str] = field(default_factory=dict)
+
+
+@dataclass
+class StartHint:
+    """A remedy a user can actually act on to get Lemonade Server running.
+
+    ``instruction`` is always safe to print verbatim and embeds ``command``
+    when one exists. ``command`` is None whenever the platform has no start
+    command a user would run (Windows tray, macOS app) — call sites must not
+    invent one.
+    """
+
+    instruction: str
+    command: Optional[str] = None
+    # True when ``command`` occupies the terminal until the server stops, so
+    # a caller that needs the shell back can append " &".
+    foreground: bool = False
 
 
 def _classify_kind_from_name(path_str: str) -> str:
@@ -221,4 +248,94 @@ def build_start_command(tooling: LemonadeTooling, ctx_size: Optional[int]) -> St
     raise ValueError(
         f"Unknown Lemonade tooling kind {tooling.kind!r} "
         "(expected 'modern' or 'legacy')."
+    )
+
+
+def _macos_app_installed() -> bool:
+    """True if the macOS Lemonade app bundle is present."""
+    return any(Path(p).expanduser().exists() for p in _MACOS_APP_CANDIDATES)
+
+
+def _render_command(argv: List[str], env: Dict[str, str]) -> str:
+    """Render argv+env as a copy-pasteable command line for this shell.
+
+    ``shlex.join`` would wrap a Windows path in POSIX single quotes, which
+    cmd.exe cannot run — so join (and prefix env) the Windows way there.
+    """
+    items = sorted(env.items())
+    if platform.system() == "Windows":
+        rendered = subprocess.list2cmdline(argv)
+        if items:
+            prefix = " && ".join(f"set {k}={v}" for k, v in items)
+            rendered = f"{prefix} && {rendered}"
+        return rendered
+
+    rendered = shlex.join(argv)
+    if items:
+        rendered = " ".join(f"{k}={v}" for k, v in items) + f" {rendered}"
+    return rendered
+
+
+def describe_start_hint(ctx_size: Optional[int] = None) -> StartHint:
+    """Describe how to start Lemonade Server on THIS machine.
+
+    The single source of user-facing "here's how to start it" advice. It
+    never names a command that does not exist on the host: on platforms
+    started from a GUI (Windows tray, macOS app) it returns prose with
+    ``command=None`` rather than guessing a shell command, and the legacy
+    ``lemonade-server serve`` CLI is only ever named when a legacy install
+    was actually resolved.
+    """
+    tooling = resolve_lemonade()
+    system = platform.system()
+
+    if tooling.found:
+        launcher = (tooling.server_launcher or "").lower()
+        if tooling.kind == "modern" and launcher.endswith(".exe"):
+            # LemonadeServer.exe --silent is what GAIA's auto-start runs; a
+            # user starts it from the tray instead.
+            return StartHint(
+                instruction=(
+                    "Start Lemonade Server from the Lemonade tray icon, or "
+                    "search for 'Lemonade' in the Start menu."
+                )
+            )
+        spec = build_start_command(tooling, ctx_size)
+        command = _render_command(spec.argv, spec.env)
+        return StartHint(
+            instruction=f"Run: {command}",
+            command=command,
+            foreground=spec.argv[0] != "systemctl",
+        )
+
+    if system == "Darwin":
+        # resolve_lemonade() has no Darwin probe, so a working macOS install
+        # still lands here — fall back to what macOS actually ships.
+        lemond = shutil.which("lemond")
+        if lemond:
+            env = {"LEMONADE_CTX_SIZE": str(ctx_size)} if ctx_size is not None else {}
+            command = _render_command([lemond], env)
+            return StartHint(
+                instruction=(
+                    f"Start the Lemonade app from Applications, or run: {command}"
+                ),
+                command=command,
+                foreground=True,
+            )
+        if _macos_app_installed():
+            return StartHint(
+                instruction="Start the Lemonade app from Applications, then retry."
+            )
+        return StartHint(
+            instruction=(
+                f"Lemonade Server is not installed. Download it from {_DOWNLOAD_URL} "
+                "and start the Lemonade app."
+            )
+        )
+
+    return StartHint(
+        instruction=(
+            "Lemonade Server is not installed. Run `gaia init` to install it, "
+            "or set LEMONADE_SERVER_PATH to an existing install."
+        )
     )

--- a/src/gaia/llm/lemonade_launcher.py
+++ b/src/gaia/llm/lemonade_launcher.py
@@ -377,3 +377,37 @@ def describe_start_hint(ctx_size: Optional[int] = None) -> StartHint:
             "or set LEMONADE_SERVER_PATH to an existing install."
         )
     )
+
+
+# Lemonade client sub-commands GAIA points users at, mapped to the verb used
+# in the prose. `gaia download` is NOT an alternative: it takes no positional
+# model argument, so `gaia download <model>` is rejected by argparse.
+_CLIENT_ACTIONS = {"pull": "downloaded", "load": "loaded"}
+
+
+def describe_client_hint(action: str, model: str) -> StartHint:
+    """Describe how to pull/load *model* with the resolved Lemonade client.
+
+    Modern ships ``lemonade`` and legacy ships ``lemonade-server``; both take
+    ``<client> pull|load <model>``. Returns prose with ``command=None`` when
+    no client binary resolved, rather than naming one that isn't there.
+    """
+    if action not in _CLIENT_ACTIONS:
+        raise ValueError(
+            f"Unsupported Lemonade client action {action!r} "
+            f"(expected one of {sorted(_CLIENT_ACTIONS)})."
+        )
+
+    tooling = resolve_lemonade()
+    # An explicit LEMONADE_SERVER_PATH names a *server*; using it as the
+    # client would be a guess, so only a probed install yields a command.
+    if tooling.found and tooling.client_path and tooling.source == "probe":
+        command = _render_command([tooling.client_path, action, model], {})
+        return StartHint(instruction=f"Run: {command}", command=command)
+
+    return StartHint(
+        instruction=(
+            f"{model} is not {_CLIENT_ACTIONS[action]}, and no Lemonade client "
+            f"CLI was found to do it — see {_DOWNLOAD_URL}."
+        )
+    )

--- a/src/gaia/llm/lemonade_manager.py
+++ b/src/gaia/llm/lemonade_manager.py
@@ -20,6 +20,7 @@ from gaia.llm.lemonade_client import (
     LemonadeClient,
     LemonadeClientError,
 )
+from gaia.llm.lemonade_launcher import describe_start_hint
 from gaia.logger import get_logger
 
 # Allow-list mapping from detected device -> Lemonade recipe
@@ -330,13 +331,10 @@ class LemonadeManager:
             )
             print("If auto-start fails, you can start it manually by:", file=sys.stderr)
             print("  • Double-clicking the desktop shortcut, or", file=sys.stderr)
-            if min_context_size >= 32768:
-                print(
-                    f"  • Running: lemonade-server serve --ctx-size {min_context_size}",
-                    file=sys.stderr,
-                )
-            else:
-                print("  • Running: lemonade-server serve", file=sys.stderr)
+            print(
+                f"  • {describe_start_hint(min_context_size).instruction}",
+                file=sys.stderr,
+            )
             print("", file=sys.stderr)
             if min_context_size >= 32768:
                 print(
@@ -384,7 +382,7 @@ class LemonadeManager:
         print("   To fix this issue:", file=sys.stderr)
         print("   1. Stop the Lemonade server (if running)", file=sys.stderr)
         print(
-            f"   2. Restart with: lemonade-server serve --ctx-size {required_size}",
+            f"   2. {describe_start_hint(required_size).instruction}",
             file=sys.stderr,
         )
         print("", file=sys.stderr)
@@ -552,7 +550,8 @@ class LemonadeManager:
 
         Note:
             The Lemonade server must be running before calling this method.
-            Start it with: lemonade-server serve --ctx-size 32768
+            :func:`gaia.llm.lemonade_launcher.describe_start_hint` renders the
+            platform-correct way to start it.
         """
         # Callers thread config values through verbatim — an unset (None)
         # floor means the default, never a TypeError at the ctx comparison.
@@ -653,8 +652,9 @@ class LemonadeManager:
                                 return True
                             cls._log.warning(
                                 f"Lemonade running with {cls._context_size} tokens, "
-                                f"but {min_context_size} requested. "
-                                f"Restart with: lemonade-server serve --ctx-size {min_context_size}"
+                                f"but {min_context_size} requested. Restart Lemonade "
+                                f"Server. "
+                                f"{describe_start_hint(min_context_size).instruction}"
                             )
                             if not quiet:
                                 cls.print_context_message(
@@ -806,9 +806,8 @@ class LemonadeManager:
         Closes the gap left by `_try_reload_with_ctx`, which only handles the
         "model already loaded with too-small ctx" path.  When the server is
         running but idle (no model loaded, no ctx reported), this helper
-        proactively seeds it so the user does not see the legacy
-        "Restart with: lemonade-server serve --ctx-size N" message
-        (issue #839).
+        proactively seeds it so the user does not see the "restart with a
+        bigger context" message at all (issue #839).
 
         Releases `lock` for the duration of the blocking `load_model` call —
         important because `auto_download=True` means a first-run user pays a
@@ -818,8 +817,9 @@ class LemonadeManager:
 
         Raises:
             LemonadeClientError: if `load_model` fails. Carries an actionable
-                message (Lemonade / ctx_size= / lemonade-server serve) so the
-                user can recover manually if the auto-preload cannot.
+                message (Lemonade / ctx_size= / the platform's real start
+                command) so the user can recover manually if the auto-preload
+                cannot.
         """
         cls._log.info(
             "Preloading '%s' with ctx_size=%d on idle Lemonade server",
@@ -850,8 +850,8 @@ class LemonadeManager:
                 f"Failed to preload Lemonade model {DEFAULT_MODEL_NAME!r} with "
                 f"ctx_size={min_context_size} on idle server at "
                 f"{client.base_url}.\n"
-                f"To recover manually: stop the running server, then run "
-                f"'lemonade-server serve --ctx-size {min_context_size}' and "
+                f"To recover manually: stop the running server, then restart it "
+                f"({describe_start_hint(min_context_size).instruction}) and "
                 f"re-run your GAIA command.\n"
                 f"See the Lemonade server log for details "
                 f"(typical path: ~/.cache/lemonade/server.log)."

--- a/src/gaia/sd/mixin.py
+++ b/src/gaia/sd/mixin.py
@@ -31,6 +31,7 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 from gaia.llm.lemonade_client import LemonadeClient, LemonadeClientError
+from gaia.llm.lemonade_launcher import describe_client_hint
 from gaia.logger import get_logger
 
 logger = get_logger(__name__)
@@ -563,7 +564,10 @@ class SDToolsMixin:
                 return {
                     "status": "unavailable",
                     "endpoint": f"{self.sd_client.base_url}/images/generations",
-                    "error": "No SD models available. Download with: gaia download SD-Turbo",
+                    "error": (
+                        "No SD models available. "
+                        f"{describe_client_hint('pull', 'SD-Turbo').instruction}"
+                    ),
                 }
         except LemonadeClientError as e:
             return {

--- a/src/gaia/sd/mixin.py
+++ b/src/gaia/sd/mixin.py
@@ -563,7 +563,7 @@ class SDToolsMixin:
                 return {
                     "status": "unavailable",
                     "endpoint": f"{self.sd_client.base_url}/images/generations",
-                    "error": "No SD models available. Download with: lemonade-server pull SD-Turbo",
+                    "error": "No SD models available. Download with: gaia download SD-Turbo",
                 }
         except LemonadeClientError as e:
             return {

--- a/src/gaia/sd/mixin.py
+++ b/src/gaia/sd/mixin.py
@@ -87,20 +87,21 @@ class SDToolsMixin:
 
         Args:
             output_dir: Directory to save generated images (default: .gaia/cache/sd/images)
-            default_model: Default SD model (SD-Turbo for fast/default, SDXL-Base-1.0 for photorealistic)
+            default_model: Default SD model (SDXL-Turbo, the default; SD-Turbo for
+                faster/lower quality; SDXL-Base-1.0 for photorealistic)
             default_size: Default image size (None = auto: 512px for SD-1.5/Turbo, 1024px for SDXL)
             default_steps: Default inference steps (None = auto: 4 for Turbo, 20 for Base)
             default_cfg: Default CFG scale (None = auto: 1.0 for Turbo, 7.5 for Base)
 
         Example:
-            # Fast generation with defaults (SD-Turbo)
+            # Fast generation with defaults (SDXL-Turbo)
             self.init_sd()
 
             # Photorealistic with auto-settings
             self.init_sd(default_model="SDXL-Base-1.0")
 
-            # Fast stylized
-            self.init_sd(default_model="SDXL-Turbo")
+            # Faster, lower quality
+            self.init_sd(default_model="SD-Turbo")
 
             # Custom settings
             self.init_sd(default_model="SDXL-Base-1.0", default_steps=30)
@@ -564,9 +565,12 @@ class SDToolsMixin:
                 return {
                     "status": "unavailable",
                     "endpoint": f"{self.sd_client.base_url}/images/generations",
+                    # Name the model THIS instance will request, not a literal:
+                    # pulling a different one succeeds and still leaves the
+                    # user unable to generate.
                     "error": (
                         "No SD models available. "
-                        f"{describe_client_hint('pull', 'SD-Turbo').instruction}"
+                        f"{describe_client_hint('pull', self.sd_default_model).instruction}"
                     ),
                 }
         except LemonadeClientError as e:

--- a/tests/unit/test_cli_refusal_exit_codes.py
+++ b/tests/unit/test_cli_refusal_exit_codes.py
@@ -1,0 +1,87 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+"""A command that refuses to act must not report success.
+
+`gaia kill` with no target printed a ❌, did nothing, and exited 0 — so
+`gaia kill && next-step` ran next-step having killed nothing. Same shape as
+a remedy that names a command which cannot work: the user (or script) is told
+everything is fine when it is not.
+
+These run the real CLI in a subprocess, because the exit code IS the thing
+under test — calling the handler directly would not catch it.
+"""
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _run_gaia(*argv):
+    """Run `gaia <argv>` in-process-isolated and return the CompletedProcess."""
+    env = {
+        "PATH": "/usr/bin:/bin:/usr/sbin:/sbin",
+        "HOME": str(Path.home()),
+        "PYTHONPATH": str(REPO_ROOT / "src"),
+        # Keep the refusal paths from touching a real server.
+        "LEMONADE_BASE_URL": "http://localhost:1/api/v1",
+    }
+    return subprocess.run(
+        [sys.executable, "-m", "gaia.cli", *argv],
+        capture_output=True,
+        text=True,
+        cwd=str(REPO_ROOT),
+        env=env,
+        timeout=120,
+        check=False,
+    )
+
+
+@pytest.mark.parametrize(
+    "argv, must_mention",
+    [
+        (["kill"], ["--lemonade", "--port"]),
+        (["cache", "clear"], ["--context7", "--all"]),
+    ],
+)
+def test_refusal_exits_non_zero_and_names_the_accepted_flags(argv, must_mention):
+    result = _run_gaia(*argv)
+    output = result.stdout + result.stderr
+
+    assert result.returncode != 0, (
+        f"`gaia {' '.join(argv)}` refused to act but exited 0 — "
+        f"`gaia {' '.join(argv)} && next-step` would run next-step.\n{output}"
+    )
+    for flag in must_mention:
+        assert flag in output, f"refusal does not name {flag}:\n{output}"
+
+
+def test_kill_refusal_sets_expectations_about_what_it_can_target():
+    """ "Specify --lemonade or --port" sent users in circles when a stray agent
+    process held no port — the refusal now says both flags target a port."""
+    result = _run_gaia("kill")
+    output = result.stdout + result.stderr
+
+    assert "port" in output.lower()
+    assert "PID" in output, f"refusal should point at the by-PID route:\n{output}"
+
+
+def test_kill_lemonade_stays_chainable_when_nothing_is_running():
+    """`gaia kill --lemonade && ...` is a documented idiom
+    (docs/reference/troubleshooting.mdx). "Already stopped" is the desired end
+    state, so it must NOT be turned into a failure — only the no-target
+    refusal is an error."""
+    result = _run_gaia("kill", "--port", "1")  # nothing listens on port 1
+
+    assert result.returncode == 0, (
+        "killing a port with no process must stay chainable; making it "
+        "non-zero would break the documented `gaia kill --lemonade && ...`"
+    )
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/unit/test_init_command.py
+++ b/tests/unit/test_init_command.py
@@ -321,6 +321,187 @@ class TestInitCommand(unittest.TestCase):
         self.assertIs(mock_install.call_args.kwargs.get("trusted"), True)
 
 
+class TestStartRemedyIsRunnable(unittest.TestCase):
+    """`gaia init` must never hand the user a command that doesn't exist.
+
+    Every remedy below used to be the hardcoded legacy literal
+    ``lemonade-server serve`` — a CLI that modern Lemonade removed. On a
+    modern install the user was told to run something that errors out, with
+    no way forward (issue #1867). Each test pins the remedy to what the
+    resolver actually produced for a mocked *modern* install.
+    """
+
+    MODERN_LINUX = "systemctl --user start lemond"
+
+    def _modern_tooling(self):
+        from gaia.llm.lemonade_launcher import LemonadeTooling
+
+        return LemonadeTooling(
+            found=True,
+            kind="modern",
+            client_path="/usr/bin/lemonade",
+            server_launcher="/usr/bin/lemond",
+        )
+
+    def _capturing_cmd(self, profile="chat"):
+        """An InitCommand whose console writes to a buffer we can assert on."""
+        import io
+
+        from gaia.installer import init_command as ic
+
+        if not ic.RICH_AVAILABLE:
+            self.skipTest("rich not installed")
+
+        with patch("gaia.installer.init_command.LemonadeInstaller"):
+            cmd = ic.InitCommand(profile=profile, yes=False)
+        buf = io.StringIO()
+        cmd.console = ic.Console(file=buf, force_terminal=False, width=300)
+        return cmd, buf
+
+    def test_manual_start_prompt_uses_resolved_command(self):
+        """_ensure_server_running's manual prompt (auto-start failed)."""
+        from gaia.installer.init_command import INIT_PROFILES
+
+        cmd, buf = self._capturing_cmd("chat")
+        min_ctx = INIT_PROFILES["chat"].get("min_context_size")
+
+        with (
+            patch("sys.platform", "linux"),
+            patch("platform.system", return_value="Linux"),
+            patch(
+                "gaia.llm.lemonade_launcher.resolve_lemonade",
+                return_value=self._modern_tooling(),
+            ),
+            patch("gaia.llm.lemonade_client.LemonadeClient") as mock_client_cls,
+            patch.object(cmd, "_auto_start_server", return_value=False),
+            patch("builtins.input", side_effect=EOFError),
+        ):
+            mock_client_cls.return_value.health_check.side_effect = ConnectionError(
+                "refused"
+            )
+            cmd._ensure_server_running()
+
+        out = buf.getvalue()
+        self.assertIn(self.MODERN_LINUX, out)
+        self.assertNotIn("lemonade-server", out)
+        # systemctl returns immediately — backgrounding it is nonsense.
+        self.assertNotIn(f"{self.MODERN_LINUX} &", out)
+        if min_ctx:
+            self.assertIn(f"LEMONADE_CTX_SIZE={min_ctx}", out)
+
+    def test_manual_start_prompt_backgrounds_a_blocking_legacy_command(self):
+        """A real legacy install DOES block the terminal, and the prompt
+        blocks on input() right after — so that command must get '&'."""
+        from gaia.llm.lemonade_launcher import LemonadeTooling
+
+        cmd, buf = self._capturing_cmd("chat")
+
+        with (
+            patch("sys.platform", "linux"),
+            patch("platform.system", return_value="Linux"),
+            patch(
+                "gaia.llm.lemonade_launcher.resolve_lemonade",
+                return_value=LemonadeTooling(
+                    found=True,
+                    kind="legacy",
+                    client_path="/usr/local/bin/lemonade-server",
+                    server_launcher="/usr/local/bin/lemonade-server",
+                ),
+            ),
+            patch("gaia.llm.lemonade_client.LemonadeClient") as mock_client_cls,
+            patch.object(cmd, "_auto_start_server", return_value=False),
+            patch("builtins.input", side_effect=EOFError),
+        ):
+            mock_client_cls.return_value.health_check.side_effect = ConnectionError(
+                "refused"
+            )
+            cmd._ensure_server_running()
+
+        self.assertIn("/usr/local/bin/lemonade-server serve", buf.getvalue())
+        self.assertIn("&", buf.getvalue())
+
+    def test_manual_start_prompt_on_macos_does_not_invent_a_command(self):
+        """macOS resolves as not-found; the remedy must still be real."""
+        from gaia.llm.lemonade_launcher import LemonadeTooling
+
+        cmd, buf = self._capturing_cmd("chat")
+
+        with (
+            patch("sys.platform", "darwin"),
+            patch("platform.system", return_value="Darwin"),
+            patch(
+                "gaia.llm.lemonade_launcher.resolve_lemonade",
+                return_value=LemonadeTooling(found=False, kind="none"),
+            ),
+            patch("gaia.llm.lemonade_launcher.shutil.which", return_value=None),
+            patch("gaia.llm.lemonade_launcher._macos_app_installed", return_value=True),
+            patch("gaia.llm.lemonade_client.LemonadeClient") as mock_client_cls,
+            patch.object(cmd, "_auto_start_server", return_value=False),
+            patch("builtins.input", side_effect=EOFError),
+        ):
+            mock_client_cls.return_value.health_check.side_effect = ConnectionError(
+                "refused"
+            )
+            cmd._ensure_server_running()
+
+        out = buf.getvalue()
+        self.assertNotIn("lemonade-server", out)
+        self.assertIn("Lemonade app", out)
+        # No shell command was offered, so the shell-rehash tip is noise.
+        self.assertNotIn("hash -r", out)
+
+    def test_hardware_detect_connection_error_uses_resolved_command(self):
+        """_check_device_available's ConnectionError branch."""
+        cmd, buf = self._capturing_cmd("npu")
+
+        with (
+            patch("platform.system", return_value="Linux"),
+            patch(
+                "gaia.llm.lemonade_launcher.resolve_lemonade",
+                return_value=self._modern_tooling(),
+            ),
+            patch("gaia.llm.lemonade_client.LemonadeClient") as mock_client_cls,
+        ):
+            mock_client_cls.return_value.get_system_info.side_effect = ConnectionError(
+                "refused"
+            )
+            result = cmd._check_device_available()
+
+        out = buf.getvalue()
+        self.assertFalse(result)
+        self.assertIn(self.MODERN_LINUX, out)
+        self.assertNotIn("lemonade-server", out)
+
+    def test_ctx_size_failure_uses_resolved_command(self):
+        """_verify_setup's 'failed to configure N token context' branch."""
+        from gaia.installer.init_command import INIT_PROFILES
+
+        profile = next(p for p, c in INIT_PROFILES.items() if c.get("min_context_size"))
+        cmd, buf = self._capturing_cmd(profile)
+        min_ctx = INIT_PROFILES[profile]["min_context_size"]
+
+        with (
+            patch("platform.system", return_value="Linux"),
+            patch(
+                "gaia.llm.lemonade_launcher.resolve_lemonade",
+                return_value=self._modern_tooling(),
+            ),
+            patch("gaia.llm.lemonade_client.LemonadeClient") as mock_client_cls,
+            patch(
+                "gaia.llm.lemonade_manager.LemonadeManager.ensure_ready",
+                return_value=False,
+            ),
+        ):
+            mock_client_cls.return_value.health_check.return_value = {"status": "ok"}
+            result = cmd._verify_setup()
+
+        out = buf.getvalue()
+        self.assertFalse(result)
+        self.assertIn(self.MODERN_LINUX, out)
+        self.assertIn(f"LEMONADE_CTX_SIZE={min_ctx}", out)
+        self.assertNotIn("lemonade-server", out)
+
+
 class TestRunInit(unittest.TestCase):
     """Test run_init entry point function."""
 

--- a/tests/unit/test_init_command.py
+++ b/tests/unit/test_init_command.py
@@ -209,6 +209,37 @@ class TestLemonadeInstaller(unittest.TestCase):
         self.assertEqual(info.version, "10.7.0")
         self.assertEqual(info.path, r"C:\lemonade_server\bin\lemonade.exe")
 
+    @patch("gaia.installer.lemonade_installer.get_installed_version")
+    def test_check_installation_finds_macos_install(self, mock_get_version):
+        """`gaia init` reported "not installed" on a macOS box where lemond was
+        answering requests on the port GAIA itself probes (issue #1867).
+
+        Drives the REAL resolver through injected platform + filesystem probes
+        — patching resolve_lemonade here would only prove it was called, not
+        that macOS detection works.
+        """
+        from pathlib import Path
+
+        real_exists = Path.exists
+        present = {"/usr/local/bin/lemond", "/usr/local/bin/lemonade"}
+
+        mock_get_version.return_value = "10.10.0"
+        with (
+            patch("platform.system", return_value="Darwin"),
+            patch.dict("os.environ", {}, clear=True),
+            patch("shutil.which", return_value=None),
+            patch.object(
+                Path, "exists", lambda self: str(self.expanduser()) in present
+            ),
+        ):
+            info = LemonadeInstaller().check_installation()
+
+        self.assertIs(Path.exists, real_exists, "Path.exists must be restored")
+        self.assertTrue(info.installed, f"macOS install missed: {info.error}")
+        self.assertEqual(info.version, "10.10.0")
+        self.assertEqual(info.path, "/usr/local/bin/lemonade")
+        self.assertIsNone(info.error)
+
 
 class TestInstallResult(unittest.TestCase):
     """Test InstallResult dataclass."""

--- a/tests/unit/test_lemonade_launcher.py
+++ b/tests/unit/test_lemonade_launcher.py
@@ -16,6 +16,7 @@ primitives, until the fix lands.
 """
 
 import os
+from pathlib import Path
 
 import pytest
 
@@ -28,6 +29,21 @@ from gaia.llm.lemonade_launcher import (
 # Real captured modern-client output (from `lemonade --version` on Windows
 # 10.7.0) — must parse to exactly "10.7.0" via re.search(r"(\d+\.\d+\.\d+)").
 MODERN_VERSION_OUTPUT = "lemonade version 10.7.0"
+
+
+def only_these_paths_exist(mocker, *present):
+    """Make Path.exists() report True for exactly *present* and nothing else.
+
+    Lets the Windows / Linux / macOS answers all be proven on any runner: the
+    host's real filesystem never leaks into the probe, so a macOS test passes
+    on a Linux CI box and vice versa.
+    """
+    wanted = {str(Path(p).expanduser()) for p in present}
+    mocker.patch(
+        "pathlib.Path.exists",
+        autospec=True,
+        side_effect=lambda self: str(self.expanduser()) in wanted,
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -231,11 +247,16 @@ def test_build_start_command_legacy_windows_includes_no_tray(mocker):
     assert spec.env == {}
 
 
-def test_build_start_command_modern_linux_uses_systemctl():
+def test_build_start_command_modern_linux_uses_systemctl(mocker):
     """Modern Linux best-effort path: systemctl --user start lemond,
-    ctx size via LEMONADE_CTX_SIZE env var."""
+    ctx size via LEMONADE_CTX_SIZE env var.
+
+    Pins the host platform: the systemd form is Linux-only, and this assertion
+    silently depended on the runner not being macOS before the Darwin branch
+    existed."""
     from gaia.llm.lemonade_launcher import LemonadeTooling
 
+    mocker.patch("platform.system", return_value="Linux")
     tooling = LemonadeTooling(
         found=True,
         kind="modern",
@@ -301,6 +322,194 @@ def test_caller_env_merge_pattern_preserves_existing_path(mocker):
     assert merged["PATH"] == "/usr/bin:/bin"
     assert merged["SOME_OTHER_VAR"] == "keep-me"
     assert merged["LEMONADE_CTX_SIZE"] == "32768"
+
+
+# ---------------------------------------------------------------------------
+# resolve_lemonade() on macOS — the resolver reported "not installed" about a
+# Lemonade that was answering requests on the port GAIA itself probes, because
+# there was no Darwin branch at all (issue #1867).
+#
+# Every test here injects BOTH platform.system() and Path.exists(), so the
+# macOS answer is provable on a Linux/Windows runner and vice versa.
+# ---------------------------------------------------------------------------
+
+MACOS_DAEMON = "/usr/local/bin/lemond"
+MACOS_CLIENT = "/usr/local/bin/lemonade"
+
+
+def test_darwin_canonical_daemon_resolves_as_modern(mocker):
+    """The regression: macOS with lemond + lemonade installed must resolve as
+    a found, modern install — not fall through to the legacy probe."""
+    mocker.patch.dict(os.environ, {}, clear=True)
+    mocker.patch("platform.system", return_value="Darwin")
+    mocker.patch("shutil.which", return_value=None)
+    only_these_paths_exist(mocker, MACOS_DAEMON, MACOS_CLIENT)
+
+    tooling = resolve_lemonade()
+
+    assert tooling.found is True
+    assert tooling.kind == "modern"
+    assert tooling.server_launcher == MACOS_DAEMON
+    assert tooling.client_path == MACOS_CLIENT
+    assert tooling.source == "probe"
+
+
+def test_darwin_resolves_even_when_only_the_daemon_is_present(mocker):
+    """The daemon is what gets started; the client only serves the version
+    query. A missing client must not make the install invisible."""
+    mocker.patch.dict(os.environ, {}, clear=True)
+    mocker.patch("platform.system", return_value="Darwin")
+    mocker.patch("shutil.which", return_value=None)
+    only_these_paths_exist(mocker, MACOS_DAEMON)
+
+    tooling = resolve_lemonade()
+
+    assert tooling.found is True
+    assert tooling.kind == "modern"
+    assert tooling.server_launcher == MACOS_DAEMON
+    assert tooling.client_path is None
+
+
+def test_darwin_homebrew_prefix_is_probed(mocker):
+    """Apple-Silicon Homebrew installs land under /opt/homebrew/bin."""
+    mocker.patch.dict(os.environ, {}, clear=True)
+    mocker.patch("platform.system", return_value="Darwin")
+    mocker.patch("shutil.which", return_value=None)
+    only_these_paths_exist(mocker, "/opt/homebrew/bin/lemond")
+
+    tooling = resolve_lemonade()
+
+    assert tooling.found is True
+    assert tooling.server_launcher == "/opt/homebrew/bin/lemond"
+
+
+def test_darwin_daemon_found_on_path_outside_standard_prefixes(mocker):
+    """A non-standard install prefix still counts when lemond is on PATH."""
+    mocker.patch.dict(os.environ, {}, clear=True)
+    mocker.patch("platform.system", return_value="Darwin")
+    only_these_paths_exist(mocker)  # nothing at any canonical path
+    mocker.patch(
+        "shutil.which",
+        side_effect=lambda name: {
+            "lemond": "/opt/custom/lemond",
+            "lemonade": "/opt/custom/lemonade",
+        }.get(name),
+    )
+
+    tooling = resolve_lemonade()
+
+    assert tooling.found is True
+    assert tooling.kind == "modern"
+    assert tooling.server_launcher == "/opt/custom/lemond"
+    assert tooling.client_path == "/opt/custom/lemonade"
+
+
+def test_darwin_modern_wins_over_a_stale_legacy_binary_on_path(mocker):
+    """Same precedence rule as Linux/Windows: modern beats a legacy CLI that
+    happens to be on PATH."""
+    mocker.patch.dict(os.environ, {}, clear=True)
+    mocker.patch("platform.system", return_value="Darwin")
+    mocker.patch("shutil.which", return_value="/usr/local/bin/lemonade-server")
+    only_these_paths_exist(mocker, MACOS_DAEMON, MACOS_CLIENT)
+
+    tooling = resolve_lemonade()
+
+    assert tooling.kind == "modern"
+    assert tooling.server_launcher == MACOS_DAEMON
+
+
+def test_darwin_with_nothing_installed_is_still_not_found(mocker):
+    """The Darwin branch must not manufacture a phantom install."""
+    mocker.patch.dict(os.environ, {}, clear=True)
+    mocker.patch("platform.system", return_value="Darwin")
+    only_these_paths_exist(mocker)
+    mocker.patch("shutil.which", return_value=None)
+
+    tooling = resolve_lemonade()
+
+    assert tooling.found is False
+    assert tooling.kind == "none"
+
+
+def test_darwin_env_override_still_wins_and_is_used_verbatim(mocker):
+    """A user who names a binary means THAT binary — the new Darwin probe
+    must not preempt LEMONADE_SERVER_PATH."""
+    mocker.patch("platform.system", return_value="Darwin")
+    mocker.patch.dict(os.environ, {"LEMONADE_SERVER_PATH": "/opt/mine/lemond"})
+    mock_which = mocker.patch("shutil.which")
+    only_these_paths_exist(mocker, MACOS_DAEMON, MACOS_CLIENT)
+
+    tooling = resolve_lemonade()
+
+    assert tooling.source == "env"
+    assert tooling.server_launcher == "/opt/mine/lemond"
+    mock_which.assert_not_called()
+
+
+def test_darwin_probe_does_not_leak_into_linux_or_windows(mocker):
+    """The macOS bin dirs must not be probed on other platforms — a Linux box
+    with /usr/local/bin/lemond present is still resolved the Linux way."""
+    mocker.patch.dict(os.environ, {}, clear=True)
+    mocker.patch("platform.system", return_value="Linux")
+    mocker.patch("shutil.which", return_value=None)
+    # ONLY the macOS-style path exists; the Linux canonical client does not.
+    only_these_paths_exist(mocker, MACOS_DAEMON)
+
+    tooling = resolve_lemonade()
+
+    assert tooling.found is False, "macOS prefix must not satisfy the Linux probe"
+
+
+# ---------------------------------------------------------------------------
+# build_start_command() on macOS — systemctl is the Linux form and must never
+# leak to a platform that has no systemd
+# ---------------------------------------------------------------------------
+
+
+def test_build_start_command_modern_macos_starts_the_daemon_not_systemctl(mocker):
+    from gaia.llm.lemonade_launcher import LemonadeTooling
+
+    mocker.patch("platform.system", return_value="Darwin")
+    tooling = LemonadeTooling(
+        found=True,
+        kind="modern",
+        client_path=MACOS_CLIENT,
+        server_launcher=MACOS_DAEMON,
+    )
+
+    spec = build_start_command(tooling, ctx_size=32768)
+
+    assert spec.argv == [MACOS_DAEMON]
+    assert "systemctl" not in spec.argv
+    assert spec.env == {"LEMONADE_CTX_SIZE": "32768"}
+
+
+def test_build_start_command_modern_macos_without_launcher_fails_loudly(mocker):
+    """No silent fallback: a modern macOS tooling object with no daemon path
+    is a programming error, not something to guess at."""
+    from gaia.llm.lemonade_launcher import LemonadeTooling
+
+    mocker.patch("platform.system", return_value="Darwin")
+    tooling = LemonadeTooling(
+        found=True, kind="modern", client_path=MACOS_CLIENT, server_launcher=None
+    )
+
+    with pytest.raises(ValueError, match="lemond"):
+        build_start_command(tooling, ctx_size=None)
+
+
+def test_macos_end_to_end_resolve_then_start_command(mocker):
+    """The whole chain the bug broke: probe -> resolve -> start command, with
+    no mocking of resolve_lemonade itself (which would prove nothing)."""
+    mocker.patch.dict(os.environ, {}, clear=True)
+    mocker.patch("platform.system", return_value="Darwin")
+    mocker.patch("shutil.which", return_value=None)
+    only_these_paths_exist(mocker, MACOS_DAEMON, MACOS_CLIENT)
+
+    spec = build_start_command(resolve_lemonade(), ctx_size=65536)
+
+    assert spec.argv == [MACOS_DAEMON]
+    assert spec.env == {"LEMONADE_CTX_SIZE": "65536"}
 
 
 # ---------------------------------------------------------------------------
@@ -425,41 +634,35 @@ def test_start_hint_windows_renders_env_the_cmd_way_never_drops_it(mocker):
     assert hint.command.startswith("set LEMONADE_CTX_SIZE=32768 && ")
 
 
-def test_start_hint_macos_names_lemond_not_the_missing_legacy_cli(mocker):
-    """macOS: resolve_lemonade() has no Darwin probe, so it reports
-    not-found even on a working install. The remedy must still be real —
-    `lemond` (the shipped daemon), never `lemonade-server serve`."""
-    from gaia.llm.lemonade_launcher import LemonadeTooling, describe_start_hint
+def test_start_hint_macos_names_the_daemon_via_real_detection(mocker):
+    """macOS remedy on a working install, driven by the real probe — no
+    mocking of resolve_lemonade, which would only prove we called it."""
+    from gaia.llm.lemonade_launcher import describe_start_hint
 
+    mocker.patch.dict(os.environ, {}, clear=True)
     mocker.patch("platform.system", return_value="Darwin")
-    mocker.patch(
-        "gaia.llm.lemonade_launcher.resolve_lemonade",
-        return_value=LemonadeTooling(found=False, kind="none"),
-    )
-    mocker.patch(
-        "gaia.llm.lemonade_launcher.shutil.which",
-        side_effect=lambda name: "/usr/local/bin/lemond" if name == "lemond" else None,
-    )
+    mocker.patch("shutil.which", return_value=None)
+    only_these_paths_exist(mocker, MACOS_DAEMON, MACOS_CLIENT)
 
     hint = describe_start_hint(ctx_size=32768)
 
-    assert hint.command == "LEMONADE_CTX_SIZE=32768 /usr/local/bin/lemond"
+    assert hint.command == f"LEMONADE_CTX_SIZE=32768 {MACOS_DAEMON}"
     assert "lemonade-server" not in hint.instruction
+    assert "systemctl" not in hint.instruction
+    # The app is the normal macOS entry point, so name it alongside the CLI.
+    assert "Lemonade app" in hint.instruction
     assert hint.foreground is True
 
 
-def test_start_hint_macos_without_daemon_on_path_describes_the_app(mocker):
-    """macOS with the app bundle but no `lemond` on PATH: describe the app,
-    do NOT invent a shell command."""
-    from gaia.llm.lemonade_launcher import LemonadeTooling, describe_start_hint
+def test_start_hint_macos_app_installed_but_no_binaries_describes_the_app(mocker):
+    """App bundle present but no daemon on disk: describe the app, do NOT
+    invent a shell command."""
+    from gaia.llm.lemonade_launcher import describe_start_hint
 
+    mocker.patch.dict(os.environ, {}, clear=True)
     mocker.patch("platform.system", return_value="Darwin")
-    mocker.patch(
-        "gaia.llm.lemonade_launcher.resolve_lemonade",
-        return_value=LemonadeTooling(found=False, kind="none"),
-    )
-    mocker.patch("gaia.llm.lemonade_launcher.shutil.which", return_value=None)
-    mocker.patch("gaia.llm.lemonade_launcher._macos_app_installed", return_value=True)
+    mocker.patch("shutil.which", return_value=None)
+    only_these_paths_exist(mocker, "/Applications/lemonade-app.app")
 
     hint = describe_start_hint()
 
@@ -470,15 +673,12 @@ def test_start_hint_macos_without_daemon_on_path_describes_the_app(mocker):
 
 def test_start_hint_macos_nothing_installed_points_at_the_download(mocker):
     """macOS is not a `gaia init` platform — never suggest it there."""
-    from gaia.llm.lemonade_launcher import LemonadeTooling, describe_start_hint
+    from gaia.llm.lemonade_launcher import describe_start_hint
 
+    mocker.patch.dict(os.environ, {}, clear=True)
     mocker.patch("platform.system", return_value="Darwin")
-    mocker.patch(
-        "gaia.llm.lemonade_launcher.resolve_lemonade",
-        return_value=LemonadeTooling(found=False, kind="none"),
-    )
-    mocker.patch("gaia.llm.lemonade_launcher.shutil.which", return_value=None)
-    mocker.patch("gaia.llm.lemonade_launcher._macos_app_installed", return_value=False)
+    mocker.patch("shutil.which", return_value=None)
+    only_these_paths_exist(mocker)
 
     hint = describe_start_hint()
 

--- a/tests/unit/test_lemonade_launcher.py
+++ b/tests/unit/test_lemonade_launcher.py
@@ -303,5 +303,228 @@ def test_caller_env_merge_pattern_preserves_existing_path(mocker):
     assert merged["LEMONADE_CTX_SIZE"] == "32768"
 
 
+# ---------------------------------------------------------------------------
+# describe_start_hint() — the user-facing remedy must never name a command
+# that does not exist on the host (issue #1867)
+# ---------------------------------------------------------------------------
+
+
+def test_start_hint_modern_linux_names_systemctl_not_lemonade_server(mocker):
+    """Modern Linux remedy is the systemd unit, never `lemonade-server serve`."""
+    from gaia.llm.lemonade_launcher import LemonadeTooling, describe_start_hint
+
+    mocker.patch("platform.system", return_value="Linux")
+    mocker.patch(
+        "gaia.llm.lemonade_launcher.resolve_lemonade",
+        return_value=LemonadeTooling(
+            found=True,
+            kind="modern",
+            client_path="/usr/bin/lemonade",
+            server_launcher="/usr/bin/lemond",
+        ),
+    )
+
+    hint = describe_start_hint(ctx_size=32768)
+
+    assert hint.command == "LEMONADE_CTX_SIZE=32768 systemctl --user start lemond"
+    assert "lemonade-server" not in hint.instruction
+    # systemctl returns immediately — callers must not append " &".
+    assert hint.foreground is False
+
+
+def test_start_hint_legacy_still_names_lemonade_server_serve(mocker):
+    """A real legacy install DOES have the CLI — keep telling it the truth."""
+    from gaia.llm.lemonade_launcher import LemonadeTooling, describe_start_hint
+
+    mocker.patch("platform.system", return_value="Linux")
+    mocker.patch(
+        "gaia.llm.lemonade_launcher.resolve_lemonade",
+        return_value=LemonadeTooling(
+            found=True,
+            kind="legacy",
+            client_path="/usr/local/bin/lemonade-server",
+            server_launcher="/usr/local/bin/lemonade-server",
+        ),
+    )
+
+    hint = describe_start_hint(ctx_size=8192)
+
+    assert hint.command == "/usr/local/bin/lemonade-server serve --ctx-size 8192"
+    assert hint.foreground is True
+
+
+def test_start_hint_modern_windows_points_at_the_tray_not_a_shell_command(mocker):
+    """Modern Windows has no start command a user would run — the server is
+    launched from the tray icon, so emit prose and NO command."""
+    from gaia.llm.lemonade_launcher import LemonadeTooling, describe_start_hint
+
+    mocker.patch("platform.system", return_value="Windows")
+    mocker.patch(
+        "gaia.llm.lemonade_launcher.resolve_lemonade",
+        return_value=LemonadeTooling(
+            found=True,
+            kind="modern",
+            client_path=r"C:\lemonade_server\bin\lemonade.exe",
+            server_launcher=r"C:\lemonade_server\bin\LemonadeServer.exe",
+        ),
+    )
+
+    hint = describe_start_hint(ctx_size=32768)
+
+    assert hint.command is None
+    assert "lemonade-server" not in hint.instruction
+    assert "tray" in hint.instruction.lower()
+
+
+def test_start_hint_legacy_windows_path_is_joined_for_cmd_not_posix(mocker):
+    """A Windows path must not come back wrapped in POSIX single quotes —
+    `'C:\\x\\lemonade-server.exe' serve` is not runnable in cmd.exe."""
+    from gaia.llm.lemonade_launcher import LemonadeTooling, describe_start_hint
+
+    mocker.patch("platform.system", return_value="Windows")
+    mocker.patch(
+        "gaia.llm.lemonade_launcher.resolve_lemonade",
+        return_value=LemonadeTooling(
+            found=True,
+            kind="legacy",
+            client_path=r"C:\Program Files\lemonade\lemonade-server.exe",
+            server_launcher=r"C:\Program Files\lemonade\lemonade-server.exe",
+        ),
+    )
+
+    hint = describe_start_hint(ctx_size=None)
+
+    assert hint.command is not None
+    assert "'" not in hint.command
+    assert hint.command.startswith('"C:\\Program Files')
+
+
+def test_start_hint_windows_renders_env_the_cmd_way_never_drops_it(mocker):
+    """A ctx-carrying env var must survive into the rendered command on
+    Windows too — as `set VAR=...`, not the POSIX `VAR=... cmd` form (which
+    cmd.exe would treat as the program name)."""
+    from gaia.llm.lemonade_launcher import LemonadeTooling, describe_start_hint
+
+    mocker.patch("platform.system", return_value="Windows")
+    mocker.patch(
+        "gaia.llm.lemonade_launcher.resolve_lemonade",
+        return_value=LemonadeTooling(
+            found=True,
+            kind="modern",
+            client_path=r"C:\lemonade\lemonade.exe",
+            server_launcher=r"C:\lemonade\lemond",  # non-.exe modern launcher
+            source="env",
+        ),
+    )
+
+    hint = describe_start_hint(ctx_size=32768)
+
+    assert hint.command is not None
+    assert "LEMONADE_CTX_SIZE=32768" in hint.command
+    assert not hint.command.startswith("LEMONADE_CTX_SIZE")
+    assert hint.command.startswith("set LEMONADE_CTX_SIZE=32768 && ")
+
+
+def test_start_hint_macos_names_lemond_not_the_missing_legacy_cli(mocker):
+    """macOS: resolve_lemonade() has no Darwin probe, so it reports
+    not-found even on a working install. The remedy must still be real —
+    `lemond` (the shipped daemon), never `lemonade-server serve`."""
+    from gaia.llm.lemonade_launcher import LemonadeTooling, describe_start_hint
+
+    mocker.patch("platform.system", return_value="Darwin")
+    mocker.patch(
+        "gaia.llm.lemonade_launcher.resolve_lemonade",
+        return_value=LemonadeTooling(found=False, kind="none"),
+    )
+    mocker.patch(
+        "gaia.llm.lemonade_launcher.shutil.which",
+        side_effect=lambda name: "/usr/local/bin/lemond" if name == "lemond" else None,
+    )
+
+    hint = describe_start_hint(ctx_size=32768)
+
+    assert hint.command == "LEMONADE_CTX_SIZE=32768 /usr/local/bin/lemond"
+    assert "lemonade-server" not in hint.instruction
+    assert hint.foreground is True
+
+
+def test_start_hint_macos_without_daemon_on_path_describes_the_app(mocker):
+    """macOS with the app bundle but no `lemond` on PATH: describe the app,
+    do NOT invent a shell command."""
+    from gaia.llm.lemonade_launcher import LemonadeTooling, describe_start_hint
+
+    mocker.patch("platform.system", return_value="Darwin")
+    mocker.patch(
+        "gaia.llm.lemonade_launcher.resolve_lemonade",
+        return_value=LemonadeTooling(found=False, kind="none"),
+    )
+    mocker.patch("gaia.llm.lemonade_launcher.shutil.which", return_value=None)
+    mocker.patch("gaia.llm.lemonade_launcher._macos_app_installed", return_value=True)
+
+    hint = describe_start_hint()
+
+    assert hint.command is None
+    assert "lemonade-server" not in hint.instruction
+    assert "Lemonade app" in hint.instruction
+
+
+def test_start_hint_macos_nothing_installed_points_at_the_download(mocker):
+    """macOS is not a `gaia init` platform — never suggest it there."""
+    from gaia.llm.lemonade_launcher import LemonadeTooling, describe_start_hint
+
+    mocker.patch("platform.system", return_value="Darwin")
+    mocker.patch(
+        "gaia.llm.lemonade_launcher.resolve_lemonade",
+        return_value=LemonadeTooling(found=False, kind="none"),
+    )
+    mocker.patch("gaia.llm.lemonade_launcher.shutil.which", return_value=None)
+    mocker.patch("gaia.llm.lemonade_launcher._macos_app_installed", return_value=False)
+
+    hint = describe_start_hint()
+
+    assert hint.command is None
+    assert "gaia init" not in hint.instruction
+    assert "lemonade-server.ai" in hint.instruction
+
+
+def test_start_hint_not_installed_on_linux_points_at_gaia_init(mocker):
+    """Nothing installed on a supported platform: `gaia init` is the remedy,
+    not a start command for software that isn't there."""
+    from gaia.llm.lemonade_launcher import LemonadeTooling, describe_start_hint
+
+    mocker.patch("platform.system", return_value="Linux")
+    mocker.patch(
+        "gaia.llm.lemonade_launcher.resolve_lemonade",
+        return_value=LemonadeTooling(found=False, kind="none"),
+    )
+
+    hint = describe_start_hint()
+
+    assert hint.command is None
+    assert "gaia init" in hint.instruction
+    assert "lemonade-server serve" not in hint.instruction
+
+
+def test_start_hint_instruction_embeds_the_command_verbatim(mocker):
+    """`instruction` is the single string call sites print — when a command
+    exists it must contain it, so no call site has to re-render it."""
+    from gaia.llm.lemonade_launcher import LemonadeTooling, describe_start_hint
+
+    mocker.patch("platform.system", return_value="Linux")
+    mocker.patch(
+        "gaia.llm.lemonade_launcher.resolve_lemonade",
+        return_value=LemonadeTooling(
+            found=True,
+            kind="modern",
+            client_path="/usr/bin/lemonade",
+            server_launcher="/usr/bin/lemond",
+        ),
+    )
+
+    hint = describe_start_hint(ctx_size=65536)
+
+    assert hint.command in hint.instruction
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/unit/test_lemonade_manager_preload.py
+++ b/tests/unit/test_lemonade_manager_preload.py
@@ -165,18 +165,37 @@ def test_small_ctx_with_loaded_model_uses_existing_reload(mock_cls):
 def test_preload_failure_raises_actionable_and_does_not_poison_singleton(mock_cls):
     """If load_model raises, the helper re-raises a LemonadeClientError carrying
     the three actionable substrings AND `_initialized` stays False so a retry
-    will reattempt initialisation (per adversarial reflection C1)."""
+    will reattempt initialisation (per adversarial reflection C1).
+
+    The recovery command must be the one that exists on THIS machine — a
+    modern install told to run the removed ``lemonade-server`` CLI has no way
+    forward (issue #1867)."""
+    from gaia.llm.lemonade_launcher import LemonadeTooling
+
     client = _make_client_mock(_status(running=True, context_size=0, loaded_models=[]))
     client.load_model.side_effect = LemonadeClientError("server returned 500")
     mock_cls.return_value = client
 
-    with pytest.raises(LemonadeClientError) as exc_info:
+    with (
+        patch("platform.system", return_value="Linux"),
+        patch(
+            "gaia.llm.lemonade_launcher.resolve_lemonade",
+            return_value=LemonadeTooling(
+                found=True,
+                kind="modern",
+                client_path="/usr/bin/lemonade",
+                server_launcher="/usr/bin/lemond",
+            ),
+        ),
+        pytest.raises(LemonadeClientError) as exc_info,
+    ):
         LemonadeManager.ensure_ready(min_context_size=32768, quiet=True)
 
     msg = str(exc_info.value)
     assert "Lemonade" in msg
     assert "ctx_size=32768" in msg or "32768" in msg
-    assert "lemonade-server serve" in msg
+    assert "systemctl --user start lemond" in msg
+    assert "lemonade-server" not in msg
 
     # Singleton must NOT be in the broken (initialized=True, ctx=0) state.
     assert (

--- a/tests/unit/test_remedy_commands_are_runnable.py
+++ b/tests/unit/test_remedy_commands_are_runnable.py
@@ -1,0 +1,255 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+"""Remedy commands must be *runnable*, not merely well-spelled.
+
+The recurring failure this guards against is NOT a command that doesn't
+exist — it is a command that exists but rejects what the message passes it.
+`gaia download SD-Turbo` reads fine in review and passes any mocked test,
+but `gaia download` takes no positional model argument, so argparse exits 2
+and the stuck user stays stuck.
+
+So these tests parse what the remedy helpers actually emit against the real
+CLI parser, rather than asserting on the text.
+"""
+
+import re
+import shlex
+from pathlib import Path
+
+import pytest
+
+from gaia.llm.lemonade_launcher import (
+    LemonadeTooling,
+    describe_client_hint,
+    describe_start_hint,
+)
+
+MODERN_LINUX = LemonadeTooling(
+    found=True,
+    kind="modern",
+    client_path="/usr/bin/lemonade",
+    server_launcher="/usr/bin/lemond",
+)
+LEGACY = LemonadeTooling(
+    found=True,
+    kind="legacy",
+    client_path="/usr/bin/lemonade-server",
+    server_launcher="/usr/bin/lemonade-server",
+)
+NOT_FOUND = LemonadeTooling(found=False, kind="none")
+
+
+def _parser():
+    from gaia.cli import build_parser
+
+    return build_parser()
+
+
+def _assert_parses(command):
+    """A `gaia ...` command must be accepted by the real CLI parser."""
+    argv = shlex.split(command)
+    assert argv and argv[0] == "gaia", f"not a gaia command: {command!r}"
+    try:
+        _parser().parse_args(argv[1:])
+    except SystemExit as exc:
+        pytest.fail(f"CLI parser rejected remedy {command!r} (exit={exc.code})")
+
+
+# ---------------------------------------------------------------------------
+# The contract that keeps getting violated
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "argv, parses",
+    [
+        (["download"], True),
+        (["download", "--agent", "sd"], True),
+        (["download", "--clear-cache"], True),
+        (["download", "--list"], True),
+        (["init"], True),
+        # The regression: `gaia download` has NO positional model argument.
+        (["download", "SD-Turbo"], False),
+        (["download", "user.embeddinggemma-300m-GGUF"], False),
+    ],
+)
+def test_gaia_download_takes_no_positional_model(argv, parses):
+    """Pins the real contract so a future edit reintroducing
+    `gaia download <model>` fails here instead of in a user's terminal."""
+    parser = _parser()
+    if parses:
+        parser.parse_args(argv)
+    else:
+        with pytest.raises(SystemExit):
+            parser.parse_args(argv)
+
+
+# ---------------------------------------------------------------------------
+# What the remedy helpers actually emit
+# ---------------------------------------------------------------------------
+
+
+def test_model_download_remedy_uses_the_lemonade_client_not_gaia_download(mocker):
+    """Model pulls must route to the Lemonade client, which does take a
+    positional model — never to `gaia download <model>`, which does not."""
+    mocker.patch("platform.system", return_value="Linux")
+    mocker.patch(
+        "gaia.llm.lemonade_launcher.resolve_lemonade", return_value=MODERN_LINUX
+    )
+
+    hint = describe_client_hint("pull", "SD-Turbo")
+
+    assert hint.command == "/usr/bin/lemonade pull SD-Turbo"
+    assert "gaia download" not in hint.instruction
+
+
+def test_model_load_remedy_uses_the_lemonade_client(mocker):
+    mocker.patch("platform.system", return_value="Linux")
+    mocker.patch(
+        "gaia.llm.lemonade_launcher.resolve_lemonade", return_value=MODERN_LINUX
+    )
+
+    hint = describe_client_hint("load", "user.embeddinggemma-300m-GGUF")
+
+    assert hint.command == "/usr/bin/lemonade load user.embeddinggemma-300m-GGUF"
+    # `lemonade-server load` is the removed CLI's form.
+    assert "lemonade-server load" not in hint.instruction
+
+
+def test_legacy_client_keeps_its_own_binary_name(mocker):
+    """A real legacy install DOES have lemonade-server — tell it the truth."""
+    mocker.patch("platform.system", return_value="Linux")
+    mocker.patch("gaia.llm.lemonade_launcher.resolve_lemonade", return_value=LEGACY)
+
+    hint = describe_client_hint("pull", "SD-Turbo")
+
+    assert hint.command == "/usr/bin/lemonade-server pull SD-Turbo"
+
+
+def test_client_hint_without_a_resolved_client_emits_no_command(mocker):
+    """No client on disk -> prose, not an invented binary name."""
+    mocker.patch("platform.system", return_value="Linux")
+    mocker.patch("gaia.llm.lemonade_launcher.resolve_lemonade", return_value=NOT_FOUND)
+
+    hint = describe_client_hint("pull", "SD-Turbo")
+
+    assert hint.command is None
+    assert "lemonade-server pull" not in hint.instruction
+    assert "gaia download" not in hint.instruction
+
+
+def test_client_hint_ignores_a_server_only_env_override(mocker):
+    """LEMONADE_SERVER_PATH names a *server*; using it as the client would be
+    a guess, and `lemond pull X` is not a real command."""
+    mocker.patch("platform.system", return_value="Darwin")
+    mocker.patch(
+        "gaia.llm.lemonade_launcher.resolve_lemonade",
+        return_value=LemonadeTooling(
+            found=True,
+            kind="modern",
+            client_path="/opt/mine/lemond",
+            server_launcher="/opt/mine/lemond",
+            source="env",
+        ),
+    )
+
+    hint = describe_client_hint("pull", "SD-Turbo")
+
+    assert hint.command is None, "must not treat a server override as the client"
+
+
+def test_client_hint_rejects_an_unsupported_action():
+    """Fail loudly rather than rendering a subcommand the client lacks."""
+    with pytest.raises(ValueError, match="Unsupported Lemonade client action"):
+        describe_client_hint("yeet", "SD-Turbo")
+
+
+# ---------------------------------------------------------------------------
+# Any `gaia ...` a remedy helper emits must parse
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("tooling", [MODERN_LINUX, LEGACY, NOT_FOUND])
+@pytest.mark.parametrize("system", ["Linux", "Darwin", "Windows"])
+def test_remedy_helpers_never_emit_an_unparseable_gaia_command(mocker, tooling, system):
+    """Sweep every platform x tooling combination the helpers can produce and
+    parse any `gaia ...` they name."""
+    mocker.patch("platform.system", return_value=system)
+    mocker.patch("gaia.llm.lemonade_launcher.resolve_lemonade", return_value=tooling)
+    mocker.patch("gaia.llm.lemonade_launcher._macos_app_installed", return_value=False)
+
+    texts = [
+        describe_start_hint().instruction,
+        describe_start_hint(32768).instruction,
+        describe_client_hint("pull", "SD-Turbo").instruction,
+        describe_client_hint("load", "SD-Turbo").instruction,
+    ]
+
+    for text in texts:
+        for fragment in text.replace("`", " ").replace(",", " ").split("."):
+            if "gaia " not in fragment:
+                continue
+            command = "gaia " + fragment.split("gaia ", 1)[1]
+            # Only the command itself, up to the first prose break.
+            command = command.split(" to ")[0].split(" or ")[0].strip()
+            _assert_parses(command)
+
+
+# ---------------------------------------------------------------------------
+# Static guard: no NEW `gaia download <model>` may appear anywhere
+# ---------------------------------------------------------------------------
+
+# The three surviving occurrences all live in LemonadeError.user_message text,
+# which agents/base/agent.py returns to the user verbatim as the agent's answer
+# — CLAUDE.md's eval gate for LemonadeError subclasses covers them, so they
+# need a `gaia eval agent` run and are being fixed separately. Delete an entry
+# here when its site is fixed; do NOT add to this list.
+KNOWN_EVAL_GATED_SITES = {
+    "llm/providers/lemonade.py",
+    "agents/builder/agent.py",
+}
+
+_DEAD_DOWNLOAD = re.compile(r"gaia download\s+(?!-)[\w.{<]")
+
+
+def test_no_new_gaia_download_with_a_positional_model():
+    """`gaia download <model>` is rejected by argparse (see the contract test
+    above). This has now shipped three times in three PRs, so fail on a
+    fourth rather than waiting for a user to hit it."""
+    src_root = Path(__file__).resolve().parents[2] / "src" / "gaia"
+    offenders = []
+
+    for path in sorted(src_root.rglob("*.py")):
+        rel = path.relative_to(src_root).as_posix()
+        if rel in KNOWN_EVAL_GATED_SITES:
+            continue
+        for lineno, line in enumerate(
+            path.read_text(encoding="utf-8").splitlines(), start=1
+        ):
+            if line.lstrip().startswith("#"):
+                continue  # a comment explaining the bug is not the bug
+            if _DEAD_DOWNLOAD.search(line):
+                offenders.append(f"{rel}:{lineno}: {line.strip()}")
+
+    assert not offenders, (
+        "`gaia download` takes no positional model argument — these would be "
+        "rejected by argparse. Use describe_client_hint('pull', model) "
+        "instead:\n" + "\n".join(offenders)
+    )
+
+
+def test_the_known_gated_sites_still_exist():
+    """Guard the allow-list: once a site is fixed its entry must be removed,
+    otherwise the exclusion silently starts hiding a future regression."""
+    src_root = Path(__file__).resolve().parents[2] / "src" / "gaia"
+    for rel in KNOWN_EVAL_GATED_SITES:
+        text = (src_root / rel).read_text(encoding="utf-8")
+        assert _DEAD_DOWNLOAD.search(text), (
+            f"{rel} no longer contains `gaia download <model>` — remove it "
+            "from KNOWN_EVAL_GATED_SITES."
+        )
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/unit/test_sd_mixin.py
+++ b/tests/unit/test_sd_mixin.py
@@ -320,3 +320,66 @@ class TestSDToolsMixinSaveImage:
         assert "/" not in path.stem
         assert ":" not in path.stem
         assert "<" not in path.stem
+
+
+class TestSDHealthCheckRemedy:
+    """The 'no SD models' remedy must name the model this instance will ask for.
+
+    Hardcoding a literal produced a remedy that ran successfully and still left
+    the user stuck: they were told to pull SD-Turbo, did, retried, and
+    generation then requested the instance default (SDXL-Turbo) which they
+    still did not have. Right verb, wrong argument.
+    """
+
+    @pytest.fixture
+    def _modern_tooling(self):
+        from gaia.llm.lemonade_launcher import LemonadeTooling
+
+        with (
+            patch("platform.system", return_value="Linux"),
+            patch(
+                "gaia.llm.lemonade_launcher.resolve_lemonade",
+                return_value=LemonadeTooling(
+                    found=True,
+                    kind="modern",
+                    client_path="/usr/bin/lemonade",
+                    server_launcher="/usr/bin/lemond",
+                ),
+            ),
+        ):
+            yield
+
+    @pytest.mark.parametrize(
+        "configured", ["SDXL-Turbo", "SD-Turbo", "SDXL-Base-1.0", "SD-1.5"]
+    )
+    def test_remedy_names_the_configured_model(
+        self, tmp_path, mock_lemonade_client, _modern_tooling, configured
+    ):
+        mixin = SDToolsMixin()
+        mixin.init_sd(output_dir=str(tmp_path), default_model=configured)
+        mock_lemonade_client.list_sd_models.return_value = []
+
+        health = mixin.sd_health_check()
+
+        assert health["status"] == "unavailable"
+        assert f"pull {configured}" in health["error"], health["error"]
+
+    def test_remedy_follows_the_default_rather_than_a_literal(
+        self, tmp_path, mock_lemonade_client, _modern_tooling
+    ):
+        """With no explicit model, the remedy must track init_sd's default —
+        so changing that default can never leave this string behind."""
+        import inspect
+
+        default = (
+            inspect.signature(SDToolsMixin.init_sd).parameters["default_model"].default
+        )
+
+        mixin = SDToolsMixin()
+        mixin.init_sd(output_dir=str(tmp_path))
+        mock_lemonade_client.list_sd_models.return_value = []
+
+        health = mixin.sd_health_check()
+
+        assert f"pull {default}" in health["error"], health["error"]
+        assert "gaia download" not in health["error"]


### PR DESCRIPTION
GAIA told macOS users their Lemonade Server was not installed while it was answering requests on the very port GAIA probes, and told everyone else to fix a stopped server by running `lemonade-server serve` — a CLI modern Lemonade removed. Both are the same defect: **code reporting a state that reality contradicts**, then handing the user a way out that doesn't work. That reads as "GAIA is broken" rather than "that advice is stale."

**Detection.** `resolve_lemonade()` probed canonical paths for Windows and Linux only. On macOS it fell through to the legacy `lemonade-server` probe, found nothing, and returned `found=False`. `check_installation()` delegates straight to it, so `gaia init` concluded Lemonade was absent on a working machine. There is now a Darwin branch probing `/usr/local/bin/lemond` (plus the Homebrew prefix, then `lemond` on PATH). It probes the *daemon*, not the client — the daemon is what gets started; the client only serves the version query.

**Remedies.** Two resolver-backed helpers replace six hand-rolled copies of the same resolve-then-fall-back-to-legacy logic: `describe_start_hint()` for starting the server and `describe_client_hint(action, model)` for pulling/loading a model. Both return prose with no command when the platform has no command a user would run (Windows tray, macOS app, no client on disk) rather than inventing one. `lemonade-server` is only ever named when a legacy install is actually detected.

Fixing the strings without fixing detection would just have swapped one wrong answer for another: "install Lemonade" for a user who already has it running.

`build_start_command()` starts the daemon directly on Darwin — macOS has no systemd, so the Linux `systemctl` form must not leak there. `LEMONADE_SERVER_PATH` still wins and is used verbatim for the *server*; it does not double as the client. `lemonade-server` stays in the legacy probe list: it is still the correct **package** name (the MSI and .deb are `lemonade-server-*`).

## Four defect layers, each found by running the command rather than reading it

1. **Command doesn't exist** — `lemonade-server serve` on a modern install.
2. **Command exists but rejects the argument** — `gaia download SD-Turbo` exits 2; `gaia download` has no positional model argument.
3. **Command runs and still doesn't fix it** — the SD remedy hardcoded `SD-Turbo` while the mixin default is `SDXL-Turbo`, so a user pulled the wrong model successfully and stayed stuck. An exit-code check passes on this one.
4. **The tool reports success while refusing to act** — `gaia kill` with no target printed ❌, did nothing, exited 0, so `gaia kill && next-step` proceeded. Same for `gaia cache clear`. Both now exit 1, matching `gaia install`.

Layer 3 was hiding behind a stale docstring claiming the SD default was `SD-Turbo`, which made the literal look correct in review. That docstring is corrected too.

## Why an installer fix touches eight files

Every non-test file is the same dead-command fix threaded through a caller — no unrelated cleanup:

| File | Sites | What |
|---|---|---|
| `llm/lemonade_launcher.py` | — | The fix: Darwin detection + both remedy helpers |
| `installer/init_command.py` | 3 | The originally reported sites |
| `llm/lemonade_client.py` | 3 | Had its **own copy** of the legacy fallback (`_start_command_hint`), now delegating |
| `llm/lemonade_manager.py` | 5 | More copies of the dead start command in user-facing errors |
| `cli.py` | 7 | Remedies, plus the two exit-0-on-refusal bugs (layer 4) |
| `code_index/sdk.py` | 2 | `lemonade-server load <model>` **and** a `gaia download <model>` template |
| `sd/mixin.py` | 1 | `lemonade-server pull`, now naming the *configured* model |

## Audit: every surviving `lemonade-server` literal in `src/gaia`

Walked all 47. **None is a command a message tells a user to run**, with one known exception:

| Category | Count | Verdict |
|---|---|---|
| Comments / docstrings describing the legacy CLI | 25 | ✅ prose |
| Deliberate legacy probe (`which`, `_classify_kind_from_name`, legacy argv) | 3 | ✅ intentional |
| Package name (apt/PPA install + remove, MSI/.deb filenames) | 5 | ✅ correct — package name is unchanged |
| Diagnostics stating it was *not* found (`"no lemonade-server in PATH"`) | 6 | ✅ prose, remedy is `gaia init` |
| Log messages naming the process | 7 | ✅ not instructions |
| **`providers/lemonade.py:117` — "Restart cleanly: `gaia kill && lemonade-server serve`"** | 1 | ❌ dead, eval-gated (below) |

## Test plan

- [x] `pytest tests/unit/` — **31 vs 31, identical failure names**, Lemonade confirmed down across both runs
- [x] macOS detection tests inject `platform.system()` **and** `Path.exists()`, so Windows/Linux/macOS answers are provable on any runner, and drive the real resolver (patching `resolve_lemonade` would only prove it was called). 10 fail without the fix.
- [x] **Remedies parsed against the real `build_parser()`**, plus a static guard failing on any new `gaia download <model>` — verified by planting the regression
- [x] SD remedy parameterised over all four models; 4 of 5 fail against the old literal (the SD-Turbo case passes, which is why the bug was invisible)
- [x] Refusal exit codes tested by running the real CLI in a subprocess — an in-process call cannot observe an exit code. 3 of 4 fail against the old behaviour.
- [x] `python util/lint.py --all` passes

Every command this PR emits, actually run:

| Command | exit |
|---|---|
| `LEMONADE_CTX_SIZE=32768 /usr/local/bin/lemond --help` | 0 |
| `lemonade pull --help` / `SD-Turbo` registered in `lemonade list` | 0 / 0 |
| `lemonade load --help` | 0 |
| `gaia init --help` | 0 |
| `gaia download --clear-cache` (parse) | 0 |
| `hash -r` | 0 |
| `gaia kill` (no target) — was 0 | **1** |
| `gaia cache clear` (no target) — was 0 | **1** |
| `gaia kill --port 1` (nothing listening) — must stay chainable | 0 |
| `gaia download SD-Turbo` — the removed regression | **2** |
| `command -v lemonade-server` — the removed legacy CLI | **1** |

Detection, before vs after, on a Mac with `lemond` v10.10.0 healthy on 13305:

```
                      BEFORE                          AFTER
resolve_lemonade      found=False kind=none           found=True kind=modern server=/usr/local/bin/lemond
build_start_command   ValueError: no tooling found    StartSpec(argv=['/usr/local/bin/lemond'])
check_installation    installed=False                 installed=True version=10.10.0
```

- [ ] Reviewer on Windows/Linux: confirm the tray prose (Windows) and `systemctl --user start lemond` (modern Linux) read correctly in `gaia init` when auto-start fails

## Deliberately out of scope

- **`gaia kill --port <n>` with no process still exits 0.** "Already stopped" is the desired end state, and `docs/reference/troubleshooting.mdx` documents `gaia kill --lemonade && ...`, which a non-zero exit would break for the common case. Telling "nothing to kill" apart from "kill failed" needs `kill_process_by_port` to return more than a bool — a deliberate semantics change, not a drive-by. It does still print ❌ for that benign outcome, which is worth fixing separately.
- **`gaia kill` cannot target a stray agent sidecar by name or install path**, which is why the daemon's uninstall guard naming it can dead-end. The refusal now says so explicitly rather than leaving the user to retry. Whether `gaia kill` should grow that capability is a product call for the daemon owner.
- **3 `gaia download <model>` sites** in `llm/providers/lemonade.py` (×2) and `agents/builder/agent.py` — all `LemonadeError.user_message` text, returned verbatim as the agent's answer by `agents/base/agent.py:3494`, so CLAUDE.md's eval gate applies and they need a `gaia eval agent` run. Pinned in the guard's `KNOWN_EVAL_GATED_SITES`, with a second test that fails if an entry goes stale.
- `cli.py:4025` runs `subprocess(["lemonade-server", "stop"])` in `gaia kill --lemonade`. Modern `lemonade` has no `stop` subcommand, so this always falls back to the port kill — it degrades correctly, but the attempt is dead code on modern installs.
- 5 log warnings in `agents/base/` say "start lemonade-server". Fixing them means importing `gaia.llm.*` into the agent base layer, which its documented invariant forbids.
- `apps/webui/**` (TypeScript) carries the same stale string but cannot call a Python resolver; it needs a field on the status API.
- `tui/**` — owned by a sibling change.

Unrelated observation: the 3 `test_init_command.py` install-path tests do a real health probe against `localhost:13305`, so they pass or fail purely on whether Lemonade happens to be running — the sole cause of the 31-vs-34 baseline drift seen locally.
