### PR TITLE
fix(connectors): surface a browser that never launched

### DIFF
--- a/src/gaia/connectors/flow.py
+++ b/src/gaia/connectors/flow.py
@@ -269,7 +269,12 @@ async def start_authorization(
     # all concurrent SSE streams).
     async def _open_browser():
         try:
-            await loop.run_in_executor(None, webbrowser.open, authorization_url)
+            # Returns False rather than raising when no browser is registered —
+            # the normal case on headless Ubuntu, WSL and SSH sessions. Ignoring
+            # it leaves the user watching a "check your browser" message forever.
+            opened = await loop.run_in_executor(
+                None, webbrowser.open, authorization_url
+            )
         except Exception as e:
             # Best-effort — the authorization_url is also returned to
             # the caller for a copy-paste fallback.
@@ -277,6 +282,12 @@ async def start_authorization(
                 "flow: webbrowser.open failed (%s); fall back "
                 "to copy-paste of authorization_url",
                 e,
+            )
+            return
+        if not opened:
+            logger.warning(
+                "flow: no browser could be launched on this host; the user must "
+                "open authorization_url themselves"
             )
 
     asyncio.ensure_future(_open_browser())

--- a/tests/unit/connectors/test_flow.py
+++ b/tests/unit/connectors/test_flow.py
@@ -21,6 +21,7 @@ Coverage:
 from __future__ import annotations
 
 import asyncio
+import logging
 from urllib.parse import parse_qs, urlparse
 
 import httpx
@@ -397,3 +398,50 @@ class TestDecodeEmailFromIdToken:
 
     def test_empty_string_returns_none(self):
         assert _decode_email_from_id_token("") is None
+
+
+class TestBrowserLaunchReporting:
+    """A launch that never happened must not look like one that did.
+
+    ``webbrowser.open`` returns False when no browser is registered — the normal
+    case on headless Ubuntu, WSL and SSH — rather than raising. Only the raising
+    case was handled, so the caller went on telling the user to check a browser
+    that was never opened, and nothing recorded that the copy-paste URL had
+    become the only way through.
+    """
+
+    @respx.mock
+    async def test_a_browser_that_never_opened_is_reported(
+        self, google_provider, monkeypatch, caplog
+    ):
+        monkeypatch.setattr("webbrowser.open", lambda *_, **__: False)
+        _mock_token_endpoint()
+
+        with caplog.at_level(logging.WARNING, logger="gaia.connectors.flow"):
+            info = await start_authorization("google", scopes=["openid"])
+            # The launch is fire-and-forget and runs in an executor thread, so
+            # yield long enough for it to finish rather than a bare sleep(0).
+            for _ in range(50):
+                if any("no browser" in r.message for r in caplog.records):
+                    break
+                await asyncio.sleep(0.01)
+
+        assert "authorization_url" in info, "the fallback URL must still be returned"
+        assert any(
+            "no browser could be launched" in r.message for r in caplog.records
+        ), f"a failed launch went unreported: {[r.message for r in caplog.records]}"
+
+    @respx.mock
+    async def test_a_successful_launch_stays_quiet(
+        self, google_provider, monkeypatch, caplog
+    ):
+        monkeypatch.setattr("webbrowser.open", lambda *_, **__: True)
+        _mock_token_endpoint()
+
+        with caplog.at_level(logging.WARNING, logger="gaia.connectors.flow"):
+            await start_authorization("google", scopes=["openid"])
+            await asyncio.sleep(0.1)
+
+        assert not any(
+            "no browser could be launched" in r.message for r in caplog.records
+        ), "a browser that opened fine was reported as failed"


### PR DESCRIPTION
On headless Ubuntu, WSL, or over SSH, connecting a mailbox could tell the user "opening your browser to sign in" while no browser had opened and nothing said so. `webbrowser.open()` returns `False` when no browser is registered rather than raising, and only exceptions were being handled — so the launch failed silently. The authorization URL was already printed as a fallback, but nothing signalled that the fallback had become the only way through. The `False` return is now caught and logged. macOS and Windows are unaffected.

## Test plan

- [ ] `python -m pytest tests/unit/connectors/ -q` — 608 passed, 6 skipped
- [ ] On a host with no browser (headless Linux / SSH), start a mailbox connect and confirm the log names the failed launch and the authorization URL is still offered
- [ ] On macOS or Windows, confirm the browser still opens and no warning is logged