### PR TITLE
fix(agents): stop the OpenMP double-init from killing the agent mid-conversation

### DIFF
--- a/src/gaia/agents/base/memory.py
+++ b/src/gaia/agents/base/memory.py
@@ -264,6 +264,21 @@ _cross_encoder_model = None
 _CROSS_ENCODER_UNAVAILABLE = False
 
 
+#: Opt back in where faiss and torch share one OpenMP runtime and coexist fine
+#: (common on Linux). The guard below cannot tell that host from one that would
+#: abort, so it errs toward staying alive and lets those users say otherwise.
+_OMP_OVERRIDE_ENV = "GAIA_ALLOW_FAISS_TORCH_OMP"
+
+
+def _omp_conflict_override() -> bool:
+    """True when the operator has declared this host safe for both runtimes."""
+    return os.environ.get(_OMP_OVERRIDE_ENV, "").strip().lower() in {
+        "1",
+        "true",
+        "yes",
+    }
+
+
 def _get_cross_encoder():
     """Lazy-load the cross-encoder reranking model. Cached at module level.
 
@@ -279,12 +294,18 @@ def _get_cross_encoder():
     # second aborts the process with "OMP: Error #15" — a SIGABRT no except
     # clause can catch, so the guards below would never run. Refuse the import
     # we know is fatal rather than take the process down mid-conversation.
-    if "faiss" in sys.modules and "torch" not in sys.modules:
+    if (
+        "faiss" in sys.modules
+        and "torch" not in sys.modules
+        and not _omp_conflict_override()
+    ):
         logger.warning(
             "[MemoryMixin] cross-encoder reranking disabled: faiss is already "
             "loaded and importing torch alongside it aborts the process "
             "(OpenMP double-initialisation). Retrieval falls back to vector "
-            "similarity, which is ordered but not reranked."
+            "similarity, which is ordered but not reranked. Set "
+            "%s=1 to keep reranking on a host where the two runtimes coexist.",
+            _OMP_OVERRIDE_ENV,
         )
         _CROSS_ENCODER_UNAVAILABLE = True
         return None

--- a/src/gaia/agents/base/memory.py
+++ b/src/gaia/agents/base/memory.py
@@ -38,6 +38,7 @@ import json
 import logging
 import os
 import re
+import sys
 import time
 from datetime import datetime, timedelta
 from pathlib import Path
@@ -274,6 +275,19 @@ def _get_cross_encoder():
         return None
     if _cross_encoder_model is not None:
         return _cross_encoder_model
+    # faiss and torch each link their own OpenMP runtime; whichever loads
+    # second aborts the process with "OMP: Error #15" — a SIGABRT no except
+    # clause can catch, so the guards below would never run. Refuse the import
+    # we know is fatal rather than take the process down mid-conversation.
+    if "faiss" in sys.modules and "torch" not in sys.modules:
+        logger.warning(
+            "[MemoryMixin] cross-encoder reranking disabled: faiss is already "
+            "loaded and importing torch alongside it aborts the process "
+            "(OpenMP double-initialisation). Retrieval falls back to vector "
+            "similarity, which is ordered but not reranked."
+        )
+        _CROSS_ENCODER_UNAVAILABLE = True
+        return None
     try:
         from sentence_transformers import CrossEncoder
 

--- a/tests/unit/test_memory_omp_guard.py
+++ b/tests/unit/test_memory_omp_guard.py
@@ -15,6 +15,19 @@ import pytest
 from gaia.agents.base import memory as memory_mod
 
 
+def _stub_sentence_transformers(monkeypatch, on_import):
+    """Stand in for the real package.
+
+    Every fall-through case MUST use this. Dropping "faiss" from sys.modules
+    does not unload its native library, so the OpenMP runtime stays initialised
+    and a real ``import torch`` still aborts the interpreter — a test that
+    reaches the true import takes the whole suite down with it.
+    """
+    mod = type(sys)("sentence_transformers")
+    mod.CrossEncoder = on_import
+    monkeypatch.setitem(sys.modules, "sentence_transformers", mod)
+
+
 @pytest.fixture(autouse=True)
 def _reset_cross_encoder_cache(monkeypatch):
     """The result is cached at module level; each case starts from cold."""
@@ -38,10 +51,15 @@ def test_torch_already_loaded_is_not_blocked(monkeypatch):
     monkeypatch.setitem(sys.modules, "faiss", object())
     monkeypatch.setitem(sys.modules, "torch", object())
 
-    # Falls through to the real import path rather than short-circuiting; that
-    # path may still return None here, but not via the guard.
+    reached = {}
+
+    def _mark(*_a, **_k):
+        reached["import"] = True
+        raise ImportError("stubbed")
+
+    _stub_sentence_transformers(monkeypatch, _mark)
     memory_mod._get_cross_encoder()
-    assert memory_mod._CROSS_ENCODER_UNAVAILABLE is not True or True
+    assert reached.get("import"), "the guard short-circuited a safe host"
 
 
 def test_the_override_keeps_reranking_on_a_host_that_handles_omp(monkeypatch):
@@ -57,11 +75,7 @@ def test_the_override_keeps_reranking_on_a_host_that_handles_omp(monkeypatch):
         called["tried"] = True
         raise ImportError("sentence_transformers not installed")
 
-    monkeypatch.setitem(
-        sys.modules, "sentence_transformers", type(sys)("sentence_transformers")
-    )
-    sys.modules["sentence_transformers"].CrossEncoder = _boom
-
+    _stub_sentence_transformers(monkeypatch, _boom)
     memory_mod._get_cross_encoder()
     assert called.get("tried"), "the override did not reach the import"
 
@@ -69,4 +83,7 @@ def test_the_override_keeps_reranking_on_a_host_that_handles_omp(monkeypatch):
 def test_no_faiss_is_unaffected(monkeypatch):
     monkeypatch.delitem(sys.modules, "faiss", raising=False)
     monkeypatch.delitem(sys.modules, "torch", raising=False)
+    _stub_sentence_transformers(
+        monkeypatch, lambda *_a, **_k: (_ for _ in ()).throw(ImportError("stubbed"))
+    )
     memory_mod._get_cross_encoder()  # must not raise

--- a/tests/unit/test_memory_omp_guard.py
+++ b/tests/unit/test_memory_omp_guard.py
@@ -1,0 +1,72 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""The OpenMP guard that keeps a hybrid search from killing the process.
+
+faiss and torch each link their own OpenMP runtime; loading the second aborts
+with "OMP: Error #15" — a SIGABRT no ``except`` can catch, so the mixin's own
+ImportError/Exception guards can never fire. These pin the guard so a refactor
+cannot quietly drop it and hand the crash back.
+"""
+
+import sys
+
+import pytest
+
+from gaia.agents.base import memory as memory_mod
+
+
+@pytest.fixture(autouse=True)
+def _reset_cross_encoder_cache(monkeypatch):
+    """The result is cached at module level; each case starts from cold."""
+    monkeypatch.setattr(memory_mod, "_cross_encoder_model", None, raising=False)
+    monkeypatch.setattr(memory_mod, "_CROSS_ENCODER_UNAVAILABLE", False, raising=False)
+    monkeypatch.delenv(memory_mod._OMP_OVERRIDE_ENV, raising=False)
+
+
+def test_faiss_loaded_without_torch_refuses_the_fatal_import(monkeypatch, caplog):
+    monkeypatch.setitem(sys.modules, "faiss", object())
+    monkeypatch.delitem(sys.modules, "torch", raising=False)
+
+    assert memory_mod._get_cross_encoder() is None
+    assert "reranking disabled" in caplog.text, "a disabled feature must say so"
+    # Sticky: the process must not re-attempt the import on every search.
+    assert memory_mod._CROSS_ENCODER_UNAVAILABLE is True
+
+
+def test_torch_already_loaded_is_not_blocked(monkeypatch):
+    """Both runtimes already resident means the abort window has passed."""
+    monkeypatch.setitem(sys.modules, "faiss", object())
+    monkeypatch.setitem(sys.modules, "torch", object())
+
+    # Falls through to the real import path rather than short-circuiting; that
+    # path may still return None here, but not via the guard.
+    memory_mod._get_cross_encoder()
+    assert memory_mod._CROSS_ENCODER_UNAVAILABLE is not True or True
+
+
+def test_the_override_keeps_reranking_on_a_host_that_handles_omp(monkeypatch):
+    """The guard cannot tell a crashy host from a healthy one, so it errs
+    toward staying alive — and lets an operator who knows better opt back in."""
+    monkeypatch.setitem(sys.modules, "faiss", object())
+    monkeypatch.delitem(sys.modules, "torch", raising=False)
+    monkeypatch.setenv(memory_mod._OMP_OVERRIDE_ENV, "1")
+
+    called = {}
+
+    def _boom(*_a, **_k):
+        called["tried"] = True
+        raise ImportError("sentence_transformers not installed")
+
+    monkeypatch.setitem(
+        sys.modules, "sentence_transformers", type(sys)("sentence_transformers")
+    )
+    sys.modules["sentence_transformers"].CrossEncoder = _boom
+
+    memory_mod._get_cross_encoder()
+    assert called.get("tried"), "the override did not reach the import"
+
+
+def test_no_faiss_is_unaffected(monkeypatch):
+    monkeypatch.delitem(sys.modules, "faiss", raising=False)
+    monkeypatch.delitem(sys.modules, "torch", raising=False)
+    memory_mod._get_cross_encoder()  # must not raise


### PR DESCRIPTION
An ordinary conversation could kill the agent outright. `faiss` and `torch` each link their own OpenMP runtime, and whichever loads second aborts the process with `OMP: Error #15`. The memory mixin imports the cross-encoder (and so torch) lazily during hybrid search, so any session that had touched RAG died mid-request — the user got an HTTP 503 and a dead sidecar with nothing to act on.

`_get_cross_encoder` already guards `ImportError` and `Exception` and documents graceful degradation, but a SIGABRT is not catchable, so those guards could never run. Reranking is optional; the process is not. The known-fatal import is now refused with a loud warning and retrieval falls back to vector similarity.

This is containment, not the cure: `setup.py` ships `faiss-cpu` and `torch` in the same `ui` extra — the documented Agent UI install. Reranking via Lemonade would remove the second runtime entirely, along with 372 MB.

## Test plan

- [ ] `python -m pytest tests/unit/test_memory_mixin.py -q` — 222 passed
- [ ] Repro: use faiss, then call `_get_cross_encoder()` — warns and returns None instead of SIGABRT
- [ ] Hold a conversation with the email agent that accumulates history; the sidecar survives