### PR TITLE
fix(ui): serve the Lemonade start hint instead of hardcoding a dead command

### DIFF
--- a/src/gaia/apps/webui/src/components/ChatView.tsx
+++ b/src/gaia/apps/webui/src/components/ChatView.tsx
@@ -1147,9 +1147,9 @@ export function ChatView({ sessionId, onCreateAgent, onAgentChange }: ChatViewPr
 
                 if (msg.includes('Lemonade') || msg.includes('LLM') || msg.includes('Could not get response')) {
                     errorContent =
-                        'Could not reach the LLM server. Make sure Lemonade Server is running:\n\n' +
-                        '```\nlemonade-server serve\n```\n\n' +
-                        'Then try sending your message again.' + issueFooter;
+                        'Could not reach the LLM server. Start Lemonade Server — on Windows from the '+
+                        'tray icon, on macOS from the Lemonade app — then try sending your '+
+                        'message again. Settings shows the exact command for this machine.' + issueFooter;
                 } else if (err instanceof TypeError || msg.includes('fetch') || msg.includes('Failed to fetch') || msg.includes('NetworkError')) {
                     errorContent =
                         'Cannot connect to the GAIA server. Make sure the backend is running:\n\n' +
@@ -1157,7 +1157,7 @@ export function ChatView({ sessionId, onCreateAgent, onAgentChange }: ChatViewPr
                 } else if (msg.includes('500')) {
                     errorContent =
                         'The server encountered an error. This usually means Lemonade Server is not running or the model failed to load.\n\n' +
-                        'Start Lemonade Server with:\n```\nlemonade-server serve\n```' + issueFooter;
+                        'Start Lemonade Server — Settings shows how to start it on this machine.' + issueFooter;
                 } else if (msg.includes('timed out') || msg.includes('timeout') || msg.includes('Timeout')) {
                     errorContent =
                         'The request timed out. The query may be too complex — try breaking it into simpler questions.\n\n' +

--- a/src/gaia/apps/webui/src/components/ConnectionBanner.tsx
+++ b/src/gaia/apps/webui/src/components/ConnectionBanner.tsx
@@ -224,7 +224,9 @@ export function ConnectionBanner({ onRetry }: { onRetry?: () => void }) {
                 <div className="connection-banner__text">
                     LLM server is not responding &mdash; it may be busy or not running.{' '}
                     <span className="connection-banner__hint">
-                        If not started, run: <code>lemonade-server serve</code>
+                        {systemStatus.start_command
+                            ? <>If not started, run: <code>{systemStatus.start_command}</code></>
+                            : (systemStatus.start_instruction ?? 'Start Lemonade Server, then retry.')}
                     </span>
                 </div>
                 {onRetry && (
@@ -370,7 +372,9 @@ export function ConnectionBanner({ onRetry }: { onRetry?: () => void }) {
                         , set ctx&#8209;size to {MIN_CONTEXT_SIZE.toLocaleString()}, or
                         restart with:{' '}
                         <code>
-                            lemonade-server serve --ctx-size {MIN_CONTEXT_SIZE}
+                            {systemStatus?.start_command
+                                ? `${systemStatus.start_command} --ctx-size ${MIN_CONTEXT_SIZE}`
+                                : `LEMONADE_CTX_SIZE=${MIN_CONTEXT_SIZE} (see Settings)`}
                         </code>
                     </span>
                 </div>

--- a/src/gaia/apps/webui/src/components/SettingsModal.tsx
+++ b/src/gaia/apps/webui/src/components/SettingsModal.tsx
@@ -239,7 +239,7 @@ export function SettingsModal() {
                                         value={status.lemonade_running ? `Running${status.lemonade_version ? ` v${status.lemonade_version}` : ''}` : 'Not Running'}
                                         ok={status.lemonade_running}
                                         hint={!status.lemonade_running
-                                            ? (status.initialized ? 'Run: lemonade-server serve' : 'Run: gaia init --profile chat')
+                                            ? (status.initialized ? (status.start_command ? `Run: ${status.start_command}` : (status.start_instruction ?? 'Start Lemonade Server')) : 'Run: gaia init --profile chat')
                                             : undefined}
                                     />
                                     <StatusRow

--- a/src/gaia/apps/webui/src/components/SettingsPage.tsx
+++ b/src/gaia/apps/webui/src/components/SettingsPage.tsx
@@ -229,7 +229,7 @@ export function SettingsPage() {
                                     value={status.lemonade_running ? `Running${status.lemonade_version ? ` v${status.lemonade_version}` : ''}` : 'Not Running'}
                                     ok={status.lemonade_running}
                                     hint={!status.lemonade_running
-                                        ? (status.initialized ? 'Run: lemonade-server serve' : 'Run: gaia init --profile chat')
+                                        ? (status.initialized ? (status.start_command ? `Run: ${status.start_command}` : (status.start_instruction ?? 'Start Lemonade Server')) : 'Run: gaia init --profile chat')
                                         : undefined}
                                 />
                                 <StatusRow

--- a/src/gaia/apps/webui/src/types/index.ts
+++ b/src/gaia/apps/webui/src/types/index.ts
@@ -448,6 +448,10 @@ export interface DownloadProgress {
 
 export interface SystemStatus {
     lemonade_running: boolean;
+    /** How to start Lemonade on this host, resolved server-side. */
+    start_instruction?: string | null;
+    /** Shell command, or null on hosts started from a GUI (tray / app). */
+    start_command?: string | null;
     model_loaded: string | null;
     embedding_model_loaded: boolean;
     disk_space_gb: number;

--- a/src/gaia/ui/models.py
+++ b/src/gaia/ui/models.py
@@ -54,6 +54,16 @@ class SystemStatus(BaseModel):
     memory_available_gb: Optional[float] = None
     initialized: bool = False
     version: str = _gaia_version
+    # How to start Lemonade ON THIS HOST, resolved server-side by
+    # gaia.llm.lemonade_launcher.describe_start_hint. Served rather than
+    # hardcoded in the UI so one rule decides it: the UI cannot know whether
+    # this machine has a modern daemon, a legacy CLI, or a tray app, and a
+    # second copy of the answer is how `lemonade-server serve` survived in the
+    # banner long after it stopped existing. ``start_command`` is None on hosts
+    # started from a GUI — there is no shell command to give, and inventing one
+    # is the bug.
+    start_instruction: Optional[str] = None
+    start_command: Optional[str] = None
     # Extended Lemonade info (settings modal)
     lemonade_version: Optional[str] = None
     model_size_gb: Optional[float] = None

--- a/src/gaia/ui/routers/system.py
+++ b/src/gaia/ui/routers/system.py
@@ -444,6 +444,18 @@ async def system_status(request: Request, db: ChatDatabase = Depends(get_db)):
     """Check system readiness (Lemonade, models, disk space)."""
     status = SystemStatus()
 
+    # Resolve how to start Lemonade on THIS host once, here, so every surface
+    # renders the same answer. Never fatal: a banner losing its hint is far
+    # better than the status endpoint failing.
+    try:
+        from gaia.llm.lemonade_launcher import describe_start_hint
+
+        hint = describe_start_hint()
+        status.start_instruction = hint.instruction
+        status.start_command = hint.command
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("system status: could not resolve the start hint: %s", exc)
+
     # Check Lemonade Server
     # Use a generous timeout (10s) because when the LLM is handling many
     # parallel requests it may take a while to respond to the health check.


### PR DESCRIPTION
The Agent UI still tells users to run `lemonade-server serve` — a command modern Lemonade removed — in the connection banner, both settings surfaces, and two chat error paths. #2497 fixed the Python side; this is the remaining surface, and the one users actually read.

The rule is deliberately **not** duplicated in TypeScript. `/api/system/status` now carries `start_instruction` and `start_command`, resolved once server-side by `describe_start_hint()`, and the UI renders whatever it is given. `start_command` is `null` on hosts started from a GUI (Windows tray, macOS app), so the banner shows prose instead of inventing a shell command. A second copy of this answer is exactly how the dead command survived in the banner for so long.

The two `ChatView` strings are in a catch block with no status in scope, so they now name no command at all and point at Settings, which has the resolved one.

## Test plan

- [ ] `python -m pytest tests/unit/chat/ui/ -q`
- [ ] `grep -rn "lemonade-server serve" src/gaia/apps/webui/src/` — no matches
- [ ] With Lemonade stopped, open the Agent UI: the banner names the command that works on this host (or prose on a GUI host), not `lemonade-server serve`