### PR TITLE
feat(release): publish the terminal hub binary and install it

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -493,9 +493,60 @@ jobs:
 
   # ── Stage 5: GitHub Release ─────────────────────────────────────────
 
+  build-tui:
+    name: Build TUI binary (${{ matrix.goos }}/${{ matrix.goarch }})
+    needs: [validate]
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - { goos: linux,   goarch: amd64 }
+          - { goos: linux,   goarch: arm64 }
+          - { goos: darwin,  goarch: amd64 }
+          - { goos: darwin,  goarch: arm64 }
+          - { goos: windows, goarch: amd64 }
+          - { goos: windows, goarch: arm64 }
+    defaults:
+      run:
+        working-directory: tui
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-go@v7
+        with:
+          go-version-file: tui/go.mod
+          cache-dependency-path: tui/go.sum
+
+      # Stamped with the RELEASE TAG, not the branch name: `gaia version` is the
+      # first thing asked for in a bug report, and "main" tells nobody which
+      # build they are on.
+      - name: Build
+        env:
+          CGO_ENABLED: '0'
+          GOOS: ${{ matrix.goos }}
+          GOARCH: ${{ matrix.goarch }}
+        run: |
+          EXT=""
+          if [ "${{ matrix.goos }}" = "windows" ]; then EXT=".exe"; fi
+          PKG=github.com/amd/gaia/tui/internal/cli
+          mkdir -p ../release-assets
+          go build -ldflags="-s -w \
+            -X ${PKG}.version=${{ needs.validate.outputs.tag_name }} \
+            -X ${PKG}.commit=${{ github.sha }} \
+            -X ${PKG}.date=$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+            -o ../release-assets/gaia-${{ matrix.goos }}-${{ matrix.goarch }}${EXT} \
+            ./cmd/gaia
+
+      - name: Upload
+        uses: actions/upload-artifact@v7
+        with:
+          name: tui-${{ matrix.goos }}-${{ matrix.goarch }}
+          path: release-assets/gaia-*
+          if-no-files-found: error
+
   github-release:
     name: GitHub Release
-    needs: [validate, post-publish-smoke, publish-npm, build-desktop-installers]
+    needs: [validate, post-publish-smoke, publish-npm, build-desktop-installers, build-tui]
     if: >-
       !cancelled() &&
       needs.post-publish-smoke.result == 'success' &&
@@ -570,6 +621,25 @@ jobs:
       # artifacts to "<platform>-installer" workflow-run artifacts. Pull
       # them here and add to release-assets/ so the softprops step
       # below includes them in the published release.
+      # The terminal hub. Until these are release assets the binary exists
+      # only as a CI artifact that expires in 14 days, so nothing can install it
+      # — install.sh has no URL to fetch and the docs describe a command users
+      # cannot obtain.
+      - name: Download TUI binaries
+        uses: actions/download-artifact@v8
+        with:
+          pattern: tui-*
+          merge-multiple: true
+          path: release-assets
+
+      # A checksum file is what lets install.sh verify what it downloaded. A
+      # binary published without one can only be trusted blindly.
+      - name: Checksum TUI binaries
+        run: |
+          cd release-assets
+          sha256sum gaia-* > gaia-tui-SHA256SUMS.txt
+          cat gaia-tui-SHA256SUMS.txt
+
       - name: Download Desktop Installer (Windows NSIS)
         uses: actions/download-artifact@v8
         with:

--- a/installer/scripts/install.sh
+++ b/installer/scripts/install.sh
@@ -149,8 +149,10 @@ install_gaia() {
 add_to_path() {
     print_step "Adding GAIA to PATH..."
 
+    # Both bins: the venv holds the Python CLI, $GAIA_HOME/bin holds the
+    # terminal hub. Adding only the venv left gaia-tui installed but unreachable.
     local bin_path="$GAIA_VENV/bin"
-    local path_export="export PATH=\"\$PATH:$bin_path\""
+    local path_export="export PATH=\"\$PATH:$bin_path:$GAIA_HOME/bin\""
     local added=false
 
     # Add to .bashrc if it exists
@@ -212,6 +214,85 @@ show_next_steps() {
 }
 
 # Main installation flow
+
+# ---------------------------------------------------------------------------
+# Terminal hub (Go binary)
+# ---------------------------------------------------------------------------
+
+# Install the `gaia` terminal hub from the GitHub release.
+#
+# Separate from the Python package on purpose: this is a static binary with no
+# interpreter, and it is what a user actually runs. Failure here is reported and
+# survivable — the Python CLI is already installed by the time we get here, so a
+# release without a matching asset must not abort the whole install.
+install_tui() {
+    print_step "Installing the GAIA terminal hub"
+
+    local os arch target
+    case "$(uname -s)" in
+        Linux)  os="linux" ;;
+        Darwin) os="darwin" ;;
+        *)
+            print_warning "No terminal hub build for $(uname -s); skipping."
+            return 0
+            ;;
+    esac
+    case "$(uname -m)" in
+        x86_64|amd64)  arch="amd64" ;;
+        arm64|aarch64) arch="arm64" ;;
+        *)
+            print_warning "No terminal hub build for $(uname -m); skipping."
+            return 0
+            ;;
+    esac
+    target="gaia-${os}-${arch}"
+
+    local base="https://github.com/amd/gaia/releases/latest/download"
+    local tmp
+    tmp="$(mktemp -d)"
+    trap 'rm -rf "$tmp"' RETURN
+
+    if ! curl -fsSL "$base/$target" -o "$tmp/gaia"; then
+        print_warning "Could not download $target from the latest release."
+        print_warning "The Python CLI is installed; the terminal hub is not."
+        return 0
+    fi
+
+    # Verify before trusting. A checksum file that cannot be fetched is not a
+    # reason to install an unverified binary — it is a reason to stop.
+    if curl -fsSL "$base/gaia-tui-SHA256SUMS.txt" -o "$tmp/SHA256SUMS"; then
+        local want got
+        want="$(grep " ${target}\$" "$tmp/SHA256SUMS" | awk '{print $1}')"
+        if [ -z "$want" ]; then
+            print_warning "No checksum listed for $target; not installing it."
+            return 0
+        fi
+        if command -v sha256sum >/dev/null 2>&1; then
+            got="$(sha256sum "$tmp/gaia" | awk '{print $1}')"
+        else
+            got="$(shasum -a 256 "$tmp/gaia" | awk '{print $1}')"
+        fi
+        if [ "$want" != "$got" ]; then
+            print_error "Checksum mismatch for $target — refusing to install."
+            print_error "  expected $want"
+            print_error "  got      $got"
+            return 0
+        fi
+    else
+        print_warning "Checksum file unavailable; not installing an unverified binary."
+        return 0
+    fi
+
+    # Installed as `gaia-tui`, NOT `gaia`. The Python CLI already owns `gaia`
+    # in the venv, and this binary has no `init`, `daemon` or `connectors`
+    # subcommands — whichever won the PATH, something a user needs would stop
+    # working. The planned rename (Go takes `gaia`, Python moves to `gaia-cli`)
+    # flips this deliberately; until then the two names coexist.
+    mkdir -p "$GAIA_HOME/bin"
+    install -m 0755 "$tmp/gaia" "$GAIA_HOME/bin/gaia-tui"
+    print_success "Terminal hub installed to $GAIA_HOME/bin/gaia-tui"
+}
+
 main() {
     echo ""
     echo -e "${COLOR_CYAN}========================================${COLOR_RESET}"
@@ -228,6 +309,9 @@ main() {
 
     # Install GAIA
     install_gaia
+
+    # Install the terminal hub binary
+    install_tui
 
     # Add to PATH
     add_to_path


### PR DESCRIPTION
The Go terminal hub has never been distributed. `build_tui.yml` cross-compiles six targets and uploads them as CI artifacts with **14-day retention**, so nothing outside a workflow run can obtain one — `install.sh` has no URL to fetch, and the docs describe a `gaia` command users cannot get. Everything built on it (readiness gate, hub screen, agent install) is unreachable.

`publish.yml` now builds the six targets against the release tag and attaches them to the GitHub release with a `SHA256SUMS` file. `install.sh` downloads the right binary for the host and **verifies it** — an unavailable checksum is a reason to stop, not to install something unverified.

**Installed as `gaia-tui`, deliberately not `gaia`.** The Python CLI owns `gaia` in the venv, and this binary has no `init`, `daemon` or `connectors` subcommands; whichever won the PATH, something a user needs would break. The planned rename (Go takes `gaia`, Python moves to `gaia-cli`) flips this on purpose — until then the two names coexist.

## Test plan

- [ ] Cut a pre-release tag and confirm six `gaia-<os>-<arch>` assets plus `gaia-tui-SHA256SUMS.txt` appear on the release
- [ ] `curl -fsSL https://amd-gaia.ai/install.sh | sh` on macOS and Linux → `gaia-tui version` runs
- [ ] Corrupt a checksum locally and re-run — installer refuses and says why
- [ ] With assets absent (current state) the installer warns, installs nothing, exits 0 — **verified**