### PR TITLE
feat(hub): publish the terminal hub and Agent UI as R2 hub packages

### DIFF
--- a/.claude/skills/gaia-release/SKILL.md
+++ b/.claude/skills/gaia-release/SKILL.md
@@ -211,13 +211,24 @@ These map to [CLAUDE.md](CLAUDE.md). Re-read them whenever this skill runs.
    ```
    Confirm [src/gaia/apps/webui/package.json](src/gaia/apps/webui/package.json) now reads the new version.
 
-6. **Confirm `__version__` is correct.**
+6. **Bump the hub component manifests.** The terminal hub and Agent UI publish to
+   the Agent Hub R2 catalog on a version tag, and `release_components.yml` gates
+   the tag against each manifest — R2 paths are immutable, so publishing under a
+   stale version cannot be undone. A mismatch **fails the release**, by design.
+   ```bash
+   sed -i '' "s/^version: .*/version: <version>/" \
+     hub/components/terminal-hub/gaia-agent.yaml \
+     hub/components/agent-ui/gaia-agent.yaml     # GNU sed: drop the ''
+   grep -H '^version:' hub/components/*/gaia-agent.yaml   # both must read <version>
+   ```
+
+7. **Confirm `__version__` is correct.**
    ```bash
    grep -E '^__version__' src/gaia/version.py
    ```
    The post-prior-release bump usually handles this, but a squash-merge can revert it silently. If it's wrong, edit it. If it's right but reverted later (see Phase 3), the validator will catch it.
 
-7. **Validate — both checks.** Run from the repo's activated venv (`source .venv/bin/activate` on Linux/macOS, `.venv\Scripts\activate` on Windows; the bare-`python` Microsoft Store stub will fail). If you're working from a git worktree without its own venv, run from the parent checkout's venv.
+8. **Validate — both checks.** Run from the repo's activated venv (`source .venv/bin/activate` on Linux/macOS, `.venv\Scripts\activate` on Windows; the bare-`python` Microsoft Store stub will fail). If you're working from a git worktree without its own venv, run from the parent checkout's venv.
    ```bash
    python util/validate_release_notes.py docs/releases/v<version>.mdx --tag v<version>
    (cd docs && npx -y mintlify@latest validate)   # the docs.yml `validate` job — MUST also pass
@@ -248,7 +259,9 @@ Show the diff (`git diff --stat` plus the new `.mdx` file inline). Ask: **"Appro
    ```bash
    git checkout -b v<version>-release
    git add docs/releases/v<version>.mdx docs/docs.json src/gaia/version.py \
-           src/gaia/apps/webui/package.json src/gaia/apps/webui/package-lock.json
+           src/gaia/apps/webui/package.json src/gaia/apps/webui/package-lock.json \
+           hub/components/terminal-hub/gaia-agent.yaml \
+           hub/components/agent-ui/gaia-agent.yaml
    git status              # confirm scope-clean — no drive-by edits
    git diff --cached --stat
    git commit -m "Release v<version>"

--- a/.github/workflows/release_components.yml
+++ b/.github/workflows/release_components.yml
@@ -1,0 +1,323 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+#
+# Publish the two non-agent Hub packages to the Agent Hub R2 catalog:
+#
+#   terminal-hub  (type: component, Go)         — the `gaia tui` binary, 6 targets
+#   agent-ui      (type: app, TypeScript)       — the Electron desktop installers
+#
+# Same pattern as release_agent_email.yml / release_agent_chat.yml: CI never
+# talks to R2 directly, it POSTs to the Worker's /publish endpoint, which
+# computes the SHA-256 server-side and stores each object immutably at
+# agents/<id>/<version>/<filename>. Re-running a published version is a no-op
+# (409 version_exists is reconciled by byte-comparison, not overwritten).
+#
+# Why these are Hub packages at all: the hub catalog is what the website builds
+# its download surfaces from. Before this, the terminal hub had NO user-facing
+# distribution — `docs/reference/cli.mdx` documented `gaia tui` while the only
+# way to get the binary was `cd tui && make build`.
+#
+# Ordering note: terminal-hub builds its own binaries here and has no external
+# dependency. agent-ui does NOT rebuild the Electron installers (that is
+# build-installers.yml, which runs on the same tag) — it waits for that
+# workflow to attach them to the GitHub release, then republishes them to R2.
+# The wait is bounded and fails loudly; it never publishes a partial set.
+
+name: Publish Hub Components (R2)
+
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Build and validate without publishing to R2'
+        type: boolean
+        default: true
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+env:
+  TERMINAL_HUB_MANIFEST: hub/components/terminal-hub/gaia-agent.yaml
+  AGENT_UI_MANIFEST: hub/components/agent-ui/gaia-agent.yaml
+
+jobs:
+  # ── Resolve the version once, and prove every manifest agrees with the tag ──
+  # A manifest that still says 0.22.0 under a v0.23.0 tag would publish the new
+  # binaries under the OLD immutable version path — silently, and unfixably,
+  # because the path is immutable. Fail before anything is built.
+  version:
+    name: Resolve & gate version
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.v.outputs.version }}
+      dry_run: ${{ steps.v.outputs.dry_run }}
+    steps:
+      - uses: actions/checkout@v7
+
+      - id: v
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            # A dispatch has no tag to read; take the version from the manifests
+            # themselves and default to a dry run unless explicitly disabled.
+            VERSION="$(python -c "import yaml,sys; print(yaml.safe_load(open('${TERMINAL_HUB_MANIFEST}'))['version'])")"
+            if [ "${{ github.event.inputs.dry_run }}" = "false" ]; then
+              echo "dry_run=false" >> "$GITHUB_OUTPUT"
+            else
+              echo "dry_run=true" >> "$GITHUB_OUTPUT"
+            fi
+          else
+            VERSION="${GITHUB_REF_NAME#v}"
+            echo "dry_run=false" >> "$GITHUB_OUTPUT"
+          fi
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+          echo "resolved version: ${VERSION}"
+
+      - name: Assert both manifests match the resolved version
+        shell: bash
+        env:
+          VERSION: ${{ steps.v.outputs.version }}
+        run: |
+          set -euo pipefail
+          python -m pip install --quiet pyyaml
+          fail=0
+          for m in "${TERMINAL_HUB_MANIFEST}" "${AGENT_UI_MANIFEST}"; do
+            got="$(python -c "import yaml; print(yaml.safe_load(open('${m}'))['version'])")"
+            if [ "${got}" != "${VERSION}" ]; then
+              echo "::error file=${m}::version ${got} does not match the release version ${VERSION}. Bump it — R2 paths are immutable, so publishing under a stale version cannot be undone."
+              fail=1
+            else
+              echo "✓ ${m} = ${got}"
+            fi
+          done
+          exit "${fail}"
+
+  # ── terminal-hub: build the 6 targets and publish them ──────────────────────
+  terminal-hub:
+    name: Publish terminal-hub
+    needs: version
+    runs-on: ubuntu-latest
+    environment: agent-publish
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: tui/go.mod
+          cache-dependency-path: tui/go.sum
+
+      - uses: actions/setup-python@v7
+        with:
+          python-version: '3.x'
+
+      # Cross-compile the same 6 targets build_tui.yml produces, stamped with
+      # the release version. CGO_ENABLED=0 keeps each binary static.
+      - name: Build all targets
+        shell: bash
+        env:
+          VERSION: ${{ needs.version.outputs.version }}
+        run: |
+          set -euo pipefail
+          mkdir -p bin
+          PKG=github.com/amd/gaia/tui/internal/cli
+          DATE="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+          cd tui
+          while read -r goos goarch platform; do
+            EXT=""
+            [ "${goos}" = "windows" ] && EXT=".exe"
+            CGO_ENABLED=0 GOOS="${goos}" GOARCH="${goarch}" go build \
+              -ldflags="-s -w -X ${PKG}.version=${VERSION} -X ${PKG}.commit=${GITHUB_SHA} -X ${PKG}.date=${DATE}" \
+              -o "../bin/gaia-${platform}${EXT}" ./cmd/gaia
+            echo "built gaia-${platform}${EXT}"
+          done <<'TARGETS'
+          linux   amd64 linux-x64
+          linux   arm64 linux-arm64
+          darwin  amd64 darwin-x64
+          darwin  arm64 darwin-arm64
+          windows amd64 win-x64
+          windows arm64 win-arm64
+          TARGETS
+
+      - name: Verify the built binary reports the release version
+        shell: bash
+        env:
+          VERSION: ${{ needs.version.outputs.version }}
+        run: |
+          set -euo pipefail
+          # `version` is a cobra subcommand — rootCmd sets no Version field, so
+          # `--version` is an unknown flag and exits 1.
+          # The linux-x64 build is the only one this runner can execute. A
+          # stamped-but-wrong version would otherwise only surface to a user.
+          got="$(./bin/gaia-linux-x64 version 2>&1 || true)"
+          echo "gaia version -> ${got}"
+          case "${got}" in
+            *"${VERSION}"*) echo "✓ version stamp present" ;;
+            *) echo "::error::built binary does not report ${VERSION} (got: ${got})"; exit 1 ;;
+          esac
+
+      - name: Require the publish token
+        if: needs.version.outputs.dry_run == 'false'
+        env:
+          GAIA_HUB_TOKEN: ${{ secrets.GAIA_HUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          if [ -z "${GAIA_HUB_TOKEN:-}" ]; then
+            echo "::error::missing environment secret GAIA_HUB_TOKEN on the agent-publish environment (must match the Worker's PUBLISH_TOKENS). See workers/agent-hub/README.md."
+            exit 1
+          fi
+
+      - name: Install publisher deps
+        if: needs.version.outputs.dry_run == 'false'
+        run: python -m pip install --upgrade requests pyyaml
+
+      - name: Publish to the Agent Hub (POST /publish)
+        if: needs.version.outputs.dry_run == 'false'
+        shell: bash
+        env:
+          AGENT_HUB_PUBLISH_TOKEN: ${{ secrets.GAIA_HUB_TOKEN }}
+          GAIA_HUB_PUBLISH_URL: ${{ vars.GAIA_HUB_PUBLISH_URL }}
+          GAIA_HUB_BASE_URL: ${{ vars.GAIA_HUB_BASE_URL }}
+        run: |
+          set -euo pipefail
+          # Explicit =<platform-key> on every artifact: the publisher's
+          # inference only special-cases email-agent-* filenames.
+          python hub/agents/email/python/packaging/publish_to_r2.py \
+            --base-url "${GAIA_HUB_PUBLISH_URL:-${GAIA_HUB_BASE_URL:-https://hub.amd-gaia.ai}}" \
+            --manifest "${TERMINAL_HUB_MANIFEST}" \
+            --artifact "bin/gaia-linux-x64=linux-x64" \
+            --artifact "bin/gaia-linux-arm64=linux-arm64" \
+            --artifact "bin/gaia-darwin-x64=darwin-x64" \
+            --artifact "bin/gaia-darwin-arm64=darwin-arm64" \
+            --artifact "bin/gaia-win-x64.exe=win-x64" \
+            --artifact "bin/gaia-win-arm64.exe=win-arm64" \
+            --readme tui/README.md \
+            --summary-out published.json
+          echo "=== publish summary ==="
+          cat published.json
+
+  # ── agent-ui: republish the installers build-installers.yml already made ────
+  agent-ui:
+    name: Publish agent-ui
+    needs: version
+    runs-on: ubuntu-latest
+    environment: agent-publish
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-python@v7
+        with:
+          python-version: '3.x'
+
+      # build-installers.yml runs on this same tag, so the assets may not exist
+      # yet. Wait for the full set, bounded — and fail loudly on timeout rather
+      # than publishing a partial platform set that the catalog would then
+      # advertise as complete.
+      - name: Wait for the installer assets on the release
+        if: needs.version.outputs.dry_run == 'false'
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ needs.version.outputs.version }}
+        run: |
+          set -euo pipefail
+          TAG="v${VERSION}"
+          want_exe="gaia-agent-ui-${VERSION}-x64-setup.exe"
+          want_dmg="gaia-agent-ui-${VERSION}-arm64.dmg"
+          want_app="gaia-agent-ui-${VERSION}-x86_64.AppImage"
+          deadline=$(( SECONDS + 3600 ))
+          while :; do
+            names="$(gh release view "${TAG}" --json assets --jq '.assets[].name' 2>/dev/null || true)"
+            missing=""
+            for w in "${want_exe}" "${want_dmg}" "${want_app}"; do
+              grep -qxF "${w}" <<<"${names}" || missing="${missing} ${w}"
+            done
+            if [ -z "${missing}" ]; then
+              echo "✓ all three installers present on ${TAG}"
+              break
+            fi
+            if [ "${SECONDS}" -ge "${deadline}" ]; then
+              echo "::error::timed out after 60m waiting for installer assets on ${TAG}. Missing:${missing}. build-installers.yml likely failed — check that run, then re-run this workflow. Nothing was published."
+              exit 1
+            fi
+            echo "waiting for:${missing}"
+            sleep 60
+          done
+
+      - name: Download the installers
+        if: needs.version.outputs.dry_run == 'false'
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ needs.version.outputs.version }}
+        run: |
+          set -euo pipefail
+          mkdir -p dist
+          gh release download "v${VERSION}" --dir dist \
+            --pattern "gaia-agent-ui-${VERSION}-x64-setup.exe" \
+            --pattern "gaia-agent-ui-${VERSION}-arm64.dmg" \
+            --pattern "gaia-agent-ui-${VERSION}-x86_64.AppImage"
+          ls -la dist
+
+      - name: Require the publish token
+        if: needs.version.outputs.dry_run == 'false'
+        env:
+          GAIA_HUB_TOKEN: ${{ secrets.GAIA_HUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          if [ -z "${GAIA_HUB_TOKEN:-}" ]; then
+            echo "::error::missing environment secret GAIA_HUB_TOKEN on the agent-publish environment (must match the Worker's PUBLISH_TOKENS). See workers/agent-hub/README.md."
+            exit 1
+          fi
+
+      - name: Install publisher deps
+        if: needs.version.outputs.dry_run == 'false'
+        run: python -m pip install --upgrade requests pyyaml
+
+      - name: Publish to the Agent Hub (POST /publish)
+        if: needs.version.outputs.dry_run == 'false'
+        shell: bash
+        env:
+          AGENT_HUB_PUBLISH_TOKEN: ${{ secrets.GAIA_HUB_TOKEN }}
+          GAIA_HUB_PUBLISH_URL: ${{ vars.GAIA_HUB_PUBLISH_URL }}
+          GAIA_HUB_BASE_URL: ${{ vars.GAIA_HUB_BASE_URL }}
+          VERSION: ${{ needs.version.outputs.version }}
+        run: |
+          set -euo pipefail
+          # One artifact per platform key. The .deb stays on the GitHub release
+          # for apt users — publishing it as a second linux-x64 object would
+          # make the catalog's per-platform download ambiguous.
+          python hub/agents/email/python/packaging/publish_to_r2.py \
+            --base-url "${GAIA_HUB_PUBLISH_URL:-${GAIA_HUB_BASE_URL:-https://hub.amd-gaia.ai}}" \
+            --manifest "${AGENT_UI_MANIFEST}" \
+            --artifact "dist/gaia-agent-ui-${VERSION}-x64-setup.exe=win-x64" \
+            --artifact "dist/gaia-agent-ui-${VERSION}-arm64.dmg=darwin-arm64" \
+            --artifact "dist/gaia-agent-ui-${VERSION}-x86_64.AppImage=linux-x64" \
+            --summary-out published.json
+          echo "=== publish summary ==="
+          cat published.json
+
+  # ── The website builds its Hub pages from the live index.json at deploy time,
+  # so a publish only becomes visible after a rebuild. deploy_website.yml
+  # auto-triggers on website/** only, and a hub publish touches no such file.
+  redeploy-website:
+    name: Redeploy website
+    needs: [version, terminal-hub, agent-ui]
+    if: needs.version.outputs.dry_run == 'false'
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+    steps:
+      - env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          gh workflow run deploy_website.yml --ref main
+          echo "✓ requested website redeploy (deploy_website.yml on main)"

--- a/docs/spec/agent-hub-restructure.mdx
+++ b/docs/spec/agent-hub-restructure.mdx
@@ -99,7 +99,7 @@ tags: [chat, general, personality]
 icon: message-circle
 tools_count: 0
 
-language: python
+language: python                    # python | cpp | go | typescript
 min_gaia_version: "0.18.0"
 models: [Qwen3.5-35B-A3B-GGUF]
 
@@ -116,6 +116,24 @@ interfaces:
   api_server: true
   mcp_server: true
 ```
+
+### Non-agent packages
+
+Not every hub package is an agent. `type` discriminates them, and two ship today:
+
+| Package | `type` | `language` | What it is |
+|---------|--------|------------|------------|
+| `terminal-hub` | `component` | `go` | The `gaia tui` binary — six platform builds |
+| `agent-ui` | `app` | `typescript` | The Electron desktop app installers |
+
+Their manifests live in `hub/components/<id>/gaia-agent.yaml` and publish through
+the same `POST /publish` path as an agent — `release_components.yml` builds (or
+collects) the per-platform artifacts and posts them with the manifest.
+
+Both host or drive agents rather than being one, so they declare `tools_count: 0`
+and no `models`. A catalog consumer that lists *agents* must filter on `type`;
+treating every entry as an agent would offer `gaia agent install terminal-hub`,
+which is not how either is installed.
 
 ### `pyproject.toml`
 

--- a/hub/components/agent-ui/gaia-agent.yaml
+++ b/hub/components/agent-ui/gaia-agent.yaml
@@ -14,6 +14,10 @@ license: MIT
 type: app
 language: typescript
 
+# Also on npm as a global CLI (`gaia-ui`), at the same version as the
+# installers. Both are real paths, so the hub page offers both.
+npm_package: "@amd-gaia/agent-ui"
+
 category: tools
 tags: [desktop, ui, chat, electron, rag]
 icon: monitor

--- a/hub/components/agent-ui/gaia-agent.yaml
+++ b/hub/components/agent-ui/gaia-agent.yaml
@@ -1,0 +1,43 @@
+# The Electron desktop app — the GAIA Agent UI. Published to the Agent Hub R2
+# catalog as an app (not an agent): it is a front end that talks to agents over
+# the local API, so it registers no tools and loads no model of its own.
+#
+# Version tracks src/gaia/apps/webui/package.json, which tracks the core GAIA
+# release. The publish workflow reads this file and asserts the two agree.
+id: agent-ui
+name: GAIA Agent UI
+version: 0.22.0
+description: "Desktop app for chatting with GAIA agents, with documents and RAG"
+author: AMD
+license: MIT
+
+type: app
+language: typescript
+
+category: tools
+tags: [desktop, ui, chat, electron, rag]
+icon: monitor
+
+# An app drives agents over the local API; it registers no @tool functions and
+# loads no model of its own. The agent it opens declares its own model.
+tools_count: 0
+models: []
+
+min_gaia_version: "0.22.0"
+
+requirements:
+  # The Electron shell alone. Whichever agent the user opens adds its own model
+  # footprint on top of this — this is not a floor for running inference.
+  min_memory_gb: 2
+  # macOS ships Apple Silicon only: build-installers.yml runs macos-latest
+  # (arm64) and Intel would need a macos-13 runner. Do not widen this to
+  # darwin-x64 without adding that runner — the catalog would offer a download
+  # that is never built.
+  platforms: [win-x64, linux-x64, darwin-arm64]
+
+interfaces:
+  tui: false
+  cli: false
+  pipe: false
+  api_server: false
+  mcp_server: false

--- a/hub/components/terminal-hub/gaia-agent.yaml
+++ b/hub/components/terminal-hub/gaia-agent.yaml
@@ -1,0 +1,40 @@
+# The Go/Bubble Tea terminal hub — `gaia tui`. Published to the Agent Hub R2
+# catalog as a component (not an agent): it hosts agents rather than being one,
+# so it has no tools, no models, and no agent loop.
+#
+# Version tracks the core GAIA release: the binary is stamped at build time from
+# the release tag (build_tui.yml passes -X …cli.version), and this file is the
+# single source the publish workflow reads. Both are asserted equal in CI.
+id: terminal-hub
+name: GAIA Terminal Hub
+version: 0.22.0
+description: "Browse, install, and chat with GAIA agents from the terminal"
+author: AMD
+license: MIT
+
+type: component
+language: go
+
+category: tools
+tags: [tui, terminal, cli, hub]
+icon: terminal
+
+# A component hosts agents; it registers no @tool functions and loads no model
+# of its own. The chat it drives runs against whichever agent the user opens.
+tools_count: 0
+models: []
+
+min_gaia_version: "0.22.0"
+
+requirements:
+  # The binary is statically linked with CGO_ENABLED=0 and holds no model. The
+  # floor is the terminal client alone — the agent a user opens declares its own.
+  min_memory_gb: 1
+  platforms: [win-x64, win-arm64, linux-x64, linux-arm64, darwin-x64, darwin-arm64]
+
+interfaces:
+  tui: true
+  cli: true
+  pipe: true
+  api_server: false
+  mcp_server: false

--- a/src/gaia/hub/manifest.py
+++ b/src/gaia/hub/manifest.py
@@ -53,7 +53,9 @@ _SEMVER_RE = re.compile(
 # (filesystem:read, network:write, etc.)").
 _PERMISSION_RE = re.compile(r"^[a-z][a-z0-9_]*:[a-z][a-z0-9_]*$")
 
-VALID_LANGUAGES = frozenset({"python", "cpp"})
+# go/typescript admit the two shipped non-agent packages: the Go terminal hub
+# and the Electron Agent UI. Keep in lock-step with the Worker's manifest.ts.
+VALID_LANGUAGES = frozenset({"python", "cpp", "go", "typescript"})
 
 VALID_SECURITY_TIERS = frozenset({"verified", "community", "experimental"})
 

--- a/tests/unit/test_hub_manifest.py
+++ b/tests/unit/test_hub_manifest.py
@@ -301,6 +301,15 @@ def test_invalid_language_raises():
         AgentManifest.from_dict(data)
 
 
+# cpp is covered by test_valid_cpp_manifest_parses — it needs its own `cpp:`
+# section, so it cannot ride the Python fixture here.
+@pytest.mark.parametrize("language", ["python", "go", "typescript"])
+def test_supported_languages_parse(language):
+    """go/typescript admit the terminal hub and the Agent UI as hub packages."""
+    data = dict(VALID_PYTHON_MANIFEST, language=language)
+    assert AgentManifest.from_dict(data).language == language
+
+
 def test_type_defaults_to_agent():
     data = dict(VALID_PYTHON_MANIFEST)
     assert "type" not in data

--- a/tui/README.md
+++ b/tui/README.md
@@ -1,0 +1,58 @@
+# GAIA Terminal Hub
+
+Browse, install, and chat with GAIA agents without leaving the terminal.
+
+The terminal hub is a single static Go binary. It talks to the local GAIA
+daemon over HTTP/SSE, so agents run on your machine — nothing is sent to a
+hosted service.
+
+## Install
+
+Download the binary for your platform from the Agent Hub and put it on your
+`PATH`. Building from source:
+
+```bash
+cd tui && make build     # -> tui/bin/gaia
+```
+
+## Use
+
+```bash
+gaia                                    # open the hub
+gaia list                               # what the hub offers, and what you have
+gaia list --installed                   # local only, no network call
+gaia install email --trust              # download and install an agent
+gaia run email                          # interactive chat
+gaia run email --query "triage my inbox"   # one-shot: answer on stdout
+gaia status                             # background service + installed agents
+gaia version                            # version, commit, build date
+```
+
+The binary accepts a leading `tui` word and drops it, so `gaia tui list` and
+`gaia list` are the same command. That keeps the docs' `gaia tui …` form working
+when the Python CLI dispatches to this binary.
+
+## Exit codes
+
+`gaia run --query` is scriptable:
+
+- `0` — the agent answered and nothing reported a failure
+- `1` — an error, or a tool failed and nothing recovered it (even if the agent
+  still wrote an answer, so `gaia run … && next-step` does not fire over work
+  that never happened)
+- `3` — a confirmation gate held back a destructive action this run had no way
+  to approve: nothing broke, and nothing was done
+
+## Preflight
+
+Before an agent starts, the hub checks the things that actually stop it from
+working — the daemon is up, the agent's sidecar is running, the local model
+server is reachable at a compatible version, the model is downloaded, plus any
+per-agent checks. Each row shows what failed and the command that fixes it.
+
+A check that cannot be determined renders `[?]` rather than a checkmark, and
+never counts as ready.
+
+## Documentation
+
+Full command reference: <https://amd-gaia.ai/docs/reference/cli>

--- a/website/src/data/catalog.ts
+++ b/website/src/data/catalog.ts
@@ -292,8 +292,10 @@ export function isAgent(agent: Agent): boolean {
 export function installMethods(agent: Agent): InstallMethod[] {
   // A component/app is not installed *into* GAIA and has no PyPI wheel — it is
   // downloaded per platform. `gaia agent install <id>` would not work for it.
+  // An npm package, where one exists, is a real second path (the Agent UI
+  // ships `gaia-ui` globally), so offer it alongside rather than instead.
   if (!isAgent(agent)) {
-    return [
+    const methods: InstallMethod[] = [
       {
         key: 'download',
         label: 'Download',
@@ -301,6 +303,15 @@ export function installMethods(agent: Agent): InstallMethod[] {
         note: 'Download the build for your platform from the release below.',
       },
     ];
+    if (agent.npm_package) {
+      methods.push({
+        key: 'npm',
+        label: 'npm',
+        command: `npm install -g ${agent.npm_package}`,
+        note: 'Global CLI install from npm.',
+      });
+    }
+    return methods;
   }
 
   if (agent.npm_package) {

--- a/website/src/data/catalog.ts
+++ b/website/src/data/catalog.ts
@@ -17,7 +17,12 @@
 // Nothing else in the app changes: pages consume getCatalog()/getAgent() only.
 
 export type SecurityTier = 'verified' | 'community' | 'experimental';
-export type AgentLanguage = 'python' | 'cpp';
+export type AgentLanguage = 'python' | 'cpp' | 'go' | 'typescript';
+
+// What a catalog entry IS. Agents are the default; the terminal hub publishes
+// as a component and the Agent UI as an app, so a listing that shows only
+// agents must filter on this rather than assume every entry is one.
+export type PackageType = 'agent' | 'app' | 'component';
 
 export interface AgentRequirements {
   min_memory_gb: number;
@@ -36,6 +41,9 @@ export interface Agent {
   latest_version: string;
   icon: string;
   language: AgentLanguage;
+  // Optional so the site keeps building against an index.json served before the
+  // Worker that emits `type` is deployed. Read it through packageType().
+  type?: PackageType;
   author: string;
   security_tier: SecurityTier;
   download_size_bytes: number;
@@ -196,6 +204,8 @@ export function categoryLabel(category: string): string {
 const LANGUAGE_LABELS: Record<AgentLanguage, string> = {
   python: 'Python',
   cpp: 'C++',
+  go: 'Go',
+  typescript: 'TypeScript',
 };
 
 export function languageLabel(language: AgentLanguage): string {
@@ -269,7 +279,30 @@ export interface InstallMethod {
  *  - Otherwise: the GAIA app install, a pip package for Python agents, and a
  *    source build (language-driven, the long-standing default).
  */
+/** An entry's package type, defaulting to 'agent' as the manifest schema does. */
+export function packageType(agent: Agent): PackageType {
+  return agent.type ?? 'agent';
+}
+
+/** True for the entries that ARE agents — excludes the Agent UI and terminal hub. */
+export function isAgent(agent: Agent): boolean {
+  return packageType(agent) === 'agent';
+}
+
 export function installMethods(agent: Agent): InstallMethod[] {
+  // A component/app is not installed *into* GAIA and has no PyPI wheel — it is
+  // downloaded per platform. `gaia agent install <id>` would not work for it.
+  if (!isAgent(agent)) {
+    return [
+      {
+        key: 'download',
+        label: 'Download',
+        command: '',
+        note: 'Download the build for your platform from the release below.',
+      },
+    ];
+  }
+
   if (agent.npm_package) {
     return [
       {

--- a/workers/agent-hub/package-lock.json
+++ b/workers/agent-hub/package-lock.json
@@ -13,6 +13,7 @@
       },
       "devDependencies": {
         "@cloudflare/workers-types": "^4.20250129.0",
+        "@types/node": "^22.10.0",
         "typescript": "^5.7.3",
         "vitest": "^2.1.8",
         "wrangler": "^3.114.14"
@@ -676,9 +677,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -696,9 +694,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -716,9 +711,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -736,9 +728,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -756,9 +745,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -776,9 +762,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -796,9 +779,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -822,9 +802,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -848,9 +825,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -874,9 +848,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -900,9 +871,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -926,9 +894,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1124,9 +1089,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1141,9 +1103,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1158,9 +1117,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1175,9 +1131,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1192,9 +1145,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1209,9 +1159,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1226,9 +1173,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1243,9 +1187,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1260,9 +1201,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1277,9 +1215,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1294,9 +1229,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1311,9 +1243,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1328,9 +1257,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1427,6 +1353,16 @@
       "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "22.20.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.1.tgz",
+      "integrity": "sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
     },
     "node_modules/@vitest/expect": {
       "version": "2.1.9",
@@ -2370,6 +2306,13 @@
       "engines": {
         "node": ">=14.0"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/unenv": {
       "version": "2.0.0-rc.14",

--- a/workers/agent-hub/package.json
+++ b/workers/agent-hub/package.json
@@ -9,13 +9,14 @@
     "dev": "wrangler dev",
     "deploy": "wrangler deploy",
     "deploy:dry-run": "wrangler deploy --dry-run --outdir dist",
-    "typecheck": "tsc --noEmit",
+    "typecheck": "tsc --noEmit && tsc --noEmit -p tsconfig.test.json",
     "test": "vitest run",
     "test:watch": "vitest"
   },
   "license": "MIT",
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20250129.0",
+    "@types/node": "^22.10.0",
     "typescript": "^5.7.3",
     "vitest": "^2.1.8",
     "wrangler": "^3.114.14"

--- a/workers/agent-hub/src/catalog.ts
+++ b/workers/agent-hub/src/catalog.ts
@@ -81,6 +81,9 @@ export function upsertVersion(
     author: existing?.author ?? manifest.author,
     license: base?.license ?? existing?.license ?? manifest.license,
     language: base?.language ?? existing?.language ?? manifest.language,
+    // ?? DEFAULT_TYPE, not a guess: manifests stored before #1716 have no
+    // `type`, and "agent" is the documented default they were published under.
+    type: base?.type ?? existing?.type ?? manifest.type ?? "agent",
     category: base?.category ?? existing?.category ?? manifest.category,
     tags: base?.tags ?? existing?.tags ?? manifest.tags,
     icon: base?.icon ?? existing?.icon ?? manifest.icon,
@@ -198,6 +201,7 @@ export function toIndexEntry(
     latest_version: agent.latest_version,
     icon: agent.icon,
     language: agent.language,
+    type: agent.type ?? "agent",
     author: agent.author,
     security_tier: agent.security_tier,
     download_size_bytes: latest?.artifact.size_bytes ?? 0,

--- a/workers/agent-hub/src/manifest.ts
+++ b/workers/agent-hub/src/manifest.ts
@@ -20,7 +20,9 @@ const ID_RE = /^[a-z0-9]([a-z0-9-]{0,50}[a-z0-9])?$/;
 const SEMVER_RE =
   /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$/;
 
-const VALID_LANGUAGES = new Set(["python", "cpp"]);
+// go/typescript admit the two shipped non-agent packages: the Go terminal hub
+// and the Electron Agent UI. Keep in lock-step with manifest.py.
+const VALID_LANGUAGES = new Set(["python", "cpp", "go", "typescript"]);
 const VALID_SECURITY_TIERS = new Set(["verified", "community", "experimental"]);
 const DEFAULT_SECURITY_TIER = "experimental";
 // Multi-component discriminator (#1716). Defaults to "agent" so existing

--- a/workers/agent-hub/src/types.ts
+++ b/workers/agent-hub/src/types.ts
@@ -140,6 +140,8 @@ export interface AgentManifest {
   author: string;
   license: string;
   language: string;
+  /** Package kind: agent | app | component. Defaults to "agent" (#1716). */
+  type: string;
   category: string;
   tags: string[];
   icon: string;
@@ -185,6 +187,8 @@ export interface IndexEntry {
   latest_version: string;
   icon: string;
   language: string;
+  /** Package kind: agent | app | component. Defaults to "agent" (#1716). */
+  type: string;
   author: string;
   security_tier: string;
   download_size_bytes: number;

--- a/workers/agent-hub/test/manifest.test.ts
+++ b/workers/agent-hub/test/manifest.test.ts
@@ -1,6 +1,9 @@
 // Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
 // SPDX-License-Identifier: MIT
 
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
 import { describe, expect, it } from "vitest";
 
 import { HttpError } from "../src/http";
@@ -44,6 +47,30 @@ describe("parseManifest", () => {
     expect(() => parseManifest(`${sampleManifest()}type: plugin\n`)).toThrow(
       /agent, app, component/
     );
+  });
+
+  // The terminal hub is Go and the Agent UI is Electron/TypeScript. Before
+  // these were admitted, a non-agent component could declare type: component
+  // and still be rejected on its language.
+  it.each(["python", "cpp", "go", "typescript"])("accepts language %s", (lang) => {
+    expect(parseManifest(sampleManifest({ language: lang })).language).toBe(lang);
+  });
+
+  // Parse the manifests this repo actually publishes, with the parser the
+  // Worker runs at POST /publish. Without this, a bad edit to a shipped
+  // manifest is only caught by the release job that tries to publish it.
+  it.each([
+    ["terminal-hub", "component", "go"],
+    ["agent-ui", "app", "typescript"],
+  ])("parses the shipped %s manifest", (id, pkgType, language) => {
+    const path = fileURLToPath(
+      new URL(`../../../hub/components/${id}/gaia-agent.yaml`, import.meta.url)
+    );
+    const m = parseManifest(readFileSync(path, "utf8"));
+    expect(m.id).toBe(id);
+    expect(m.type).toBe(pkgType);
+    expect(m.language).toBe(language);
+    expect(m.requirements.platforms.length).toBeGreaterThan(0);
   });
 
   it.each([

--- a/workers/agent-hub/test/publish.test.ts
+++ b/workers/agent-hub/test/publish.test.ts
@@ -403,6 +403,36 @@ describe("POST /publish — catalog enrichment (website contract)", () => {
     expect(index.agents[0].requirements.npu).toBe("required");
   });
 
+  // type was validated on ingest but dropped before storage, so a published
+  // component was indistinguishable from an agent in the served catalog.
+  it("carries type through to manifest.json and index.json", async () => {
+    const env = makeEnv();
+    await publish(env, {
+      token: "tok_amd",
+      manifestYaml: `${sampleManifest({ id: "terminal-hub", language: "go" })}type: component\n`,
+      artifact: "binary",
+      filename: "gaia-linux-x64",
+    });
+    const stored = (await (
+      await env.bucket.get("agents/terminal-hub/manifest.json")
+    )!.json()) as { type: string };
+    expect(stored.type).toBe("component");
+    const index = (await (await env.bucket.get("index.json"))!.json()) as CatalogIndex;
+    expect(index.agents.find((a) => a.id === "terminal-hub")!.type).toBe("component");
+  });
+
+  it("defaults type to agent in index.json when the manifest omits it", async () => {
+    const env = makeEnv();
+    await publish(env, {
+      token: "tok_amd",
+      manifestYaml: sampleManifest(),
+      artifact: "wheel",
+      filename: "gaia_agent_chat-0.1.0-py3-none-any.whl",
+    });
+    const index = (await (await env.bucket.get("index.json"))!.json()) as CatalogIndex;
+    expect(index.agents[0].type).toBe("agent");
+  });
+
   it("surfaces deprecation_message in manifest.json and index.json", async () => {
     const env = makeEnv();
     const yaml =

--- a/workers/agent-hub/tsconfig.json
+++ b/workers/agent-hub/tsconfig.json
@@ -16,5 +16,8 @@
     "isolatedModules": true,
     "noEmit": true
   },
-  "include": ["src/**/*.ts", "test/**/*.ts"]
+  // src only — test/ is typechecked by tsconfig.test.json, which adds Node
+  // types. Keeping them apart is what stops a Worker handler from compiling
+  // against a Node builtin it will not have at runtime.
+  "include": ["src/**/*.ts"]
 }

--- a/workers/agent-hub/tsconfig.test.json
+++ b/workers/agent-hub/tsconfig.test.json
@@ -1,0 +1,12 @@
+// Tests run in Node (vitest.config.ts sets environment: "node"), so they may
+// use node: builtins and import.meta. The root tsconfig deliberately types
+// src/ with @cloudflare/workers-types ONLY, so that a Worker handler cannot
+// reach for a Node API that does not exist at the edge — widening it there to
+// satisfy a test would remove that guard.
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "types": ["node", "@cloudflare/workers-types"]
+  },
+  "include": ["test/**/*.ts", "src/**/*.ts"]
+}


### PR DESCRIPTION
The terminal hub is documented but cannot be obtained. `docs/reference/cli.mdx` describes `gaia tui`, yet release v0.22.0 carries no `gaia-<os>-<arch>` asset, `setup.py` has no `tui` entry point, and `install.sh` is Linux-only and installs the Python side — so the only way to get the binary is `cd tui && make build`. The Agent UI ships installers but is missing from the hub catalog the website builds its download surfaces from. After this, both publish to the Agent Hub R2 store on the same path the email agent uses, and appear in the catalog as first-class packages.

While wiring it up I found the hub's multi-component discriminator was half-connected: `type: agent | app | component` (#1716) is validated at `POST /publish` and then **dropped** — it reaches neither the stored manifest nor `index.json`. A published component was indistinguishable from an agent in the served catalog. Two new tests fail without the fix.

### Threads

- **`type` now survives to storage and the index**, defaulting to `agent` for manifests published before the field existed.
- **`go` / `typescript` admitted as languages**, kept in lock-step across the Worker and its Python mirror — a component could otherwise declare `type: component` and still be rejected on its language.
- **`release_components.yml`** builds the six terminal-hub targets and publishes them; for the Agent UI it waits (bounded, failing loudly) for `build-installers.yml` to attach the installers, then republishes them to R2. A version gate refuses to publish if a manifest disagrees with the tag — R2 paths are immutable, so a stale version cannot be undone.
- **The site no longer offers `gaia agent install <id>` for a non-agent**, which would not work.
- **`tui/README.md`** — new; it is what the hub page renders for the component, and `tui/` had no markdown at all.

### Test plan

- [x] `cd workers/agent-hub && npx vitest run` — 84 pass (6 new)
- [x] Both new `type` tests verified to **fail** with the fix reverted, pass with it
- [x] `npx tsc --noEmit` (worker) — clean
- [x] `pytest tests/unit/test_hub_{manifest,catalog,publisher,packager}.py` — 136 pass
- [x] `python util/lint.py --black --isort` — clean
- [x] `npx astro check` (website) — 0 errors
- [x] Both shipped manifests parse under the real Python parser **and** the Worker parser (a new test reads the actual files, so a bad edit fails in CI rather than at publish time)
- [x] Built the binary with the release ldflags and confirmed `gaia version` reports the stamp — this caught the workflow using `--version`, which exits 1 with `unknown flag`
- [x] Every command in the new README run against a real build, including the `tui`-prefix drop and the documented exit codes
- [ ] End-to-end publish against the live Worker — needs `GAIA_HUB_TOKEN`; `workflow_dispatch` defaults to a dry run for exactly this