### PR TITLE
fix(daemon): unbreak Unit Tests on main — remedy docstring names an unparseable command

### DIFF
--- a/src/gaia/daemon/sidecars/fetch.py
+++ b/src/gaia/daemon/sidecars/fetch.py
@@ -13,8 +13,8 @@ Two verified sources, checked in order; there is NO 'use it anyway' path:
    on POSIX. Source 2 is a repo-checkout/npm-package convenience: the lock is
    NOT wheel package data, so on a pip install the Hub install (source 1, which
    verifies against the hub manifest) is the only path — an absent lock reports
-   "not installed" with the `gaia hub install` remedy, never a broken-install
-   error.
+   "not installed" with the `gaia hub install <id>` remedy, never a
+   broken-install error.
 
 A tampered/truncated binary is rejected before it can ever be spawned.
 


### PR DESCRIPTION
**Unit Tests has been red on `main` since 09:40 today**, failing every PR with it. This is a one-line fix.

`test_daemon_remedy_commands` scrapes every `` `gaia …` `` out of `src/gaia/daemon/sidecars/*.py` and parses it with the real CLI parser — the point being that a remedy must never name a command that doesn't work. A module docstring named the remedy *family* without its required agent id, so the parser exited 2:

```
Failed: `gaia hub install` is not a valid command (exit 2)
```

`<id>` is the placeholder the scraper substitutes with a real agent, so the command is still genuinely parsed (`gaia hub install email`) rather than skipped — the check is preserved, not silenced. The `*` form would have skipped it, which is why I didn't use it.

### Test plan

- [x] `pytest tests/unit/test_daemon_remedy_commands.py` — 6 passed (was 1 failed, 5 passed)
- [x] Diff is 2 lines in one docstring; no behaviour change

### Not covered here

Two other checks are also red on `main` and are **not** fixed by this:

- **`build_tui.yml` Test** — `check_test.go:1603` fails with `row "model" remedy names a command that does not exist on this machine: "gaia kill"`. The Go test checks that remedy commands exist on `PATH`, but that job never installs the Python `gaia` CLI, so it passes locally and fails in CI. Needs a fix in the workflow (or the test's existence check).
- **Verify external URLs** — `amd-gaia.ai/docs/{guides,quickstart,reference/faq,releases,sdk}` all 404. That's the live docs site, not this repo.