### PR TITLE
fix(agent): recover from context overflow on NPU/FastFlowLM

### DIFF
--- a/.github/workflows/test_unit.yml
+++ b/.github/workflows/test_unit.yml
@@ -77,8 +77,10 @@ jobs:
           # exists. It ships in the [ui]/[rag] extras, which this job does not install.
           # cvss is required by tests/unit/test_cvss4.py and test_findings_to_sarif.py
           # (the security-audit scorer); it lives in the [dev] extra, not [api].
+          # responses is required by tests/unit/test_lemonade_error_classification.py
+          # — same story as cvss: declared in [dev], and this job installs [api].
           uv pip install --system pytest pytest-cov pytest-asyncio pytest-mock pytest-timeout \
-                                  pyfakefs keyring httpx respx matplotlib pymupdf cvss
+                                  pyfakefs keyring httpx respx matplotlib pymupdf cvss responses
           uv pip install --system -e ".[api]"
 
       - name: Validate packaging integrity
@@ -194,7 +196,7 @@ jobs:
       - name: Install dependencies
         run: |
           uv pip install --system pytest pytest-asyncio pytest-mock pytest-timeout \
-                                  pyfakefs keyring httpx respx matplotlib pymupdf cvss
+                                  pyfakefs keyring httpx respx matplotlib pymupdf cvss responses
           uv pip install --system -e ".[api]"
 
       - name: Validate packaging integrity

--- a/src/gaia/agents/base/agent.py
+++ b/src/gaia/agents/base/agent.py
@@ -37,7 +37,11 @@ from gaia.agents.base.tools import _TOOL_REGISTRY
 
 # First-party imports
 from gaia.chat.sdk import AgentConfig, AgentSDK
-from gaia.llm.lemonade_client import DEFAULT_MODEL_NAME, GPU_CTX_SIZE
+from gaia.llm.lemonade_client import (
+    DEFAULT_MODEL_NAME,
+    GPU_CTX_SIZE,
+    is_context_overflow_error,
+)
 
 if TYPE_CHECKING:
     from gaia.agents.base.goal_store import Goal, Proposal
@@ -3269,11 +3273,7 @@ Do NOT wrap conversational replies in JSON.
                     except Exception as e:
                         logger.error(f"Unexpected error during streaming: {e}")
                         err_text = str(e).lower()
-                        is_ctx_overflow = (
-                            "exceed_context_size" in err_text
-                            or "exceeds the available context size" in err_text
-                            or "got too long" in err_text
-                        )
+                        is_ctx_overflow = is_context_overflow_error(err_text)
                         # See non-streaming branch for explanation: re-raise
                         # if model was loaded with the wrong (small) ctx so
                         # the chat helper can reload it at 32K.
@@ -3409,14 +3409,12 @@ Do NOT wrap conversational replies in JSON.
                             print(f"[DEBUG] Error calling LLM: {e}")
                         logger.error(f"Unexpected error calling LLM: {e}")
 
-                        # Did we hit a context-overflow mid-loop? Detect by
-                        # substring (typed exceptions get wrapped by AgentSDK).
+                        # Did we hit a context-overflow mid-loop? Classify by
+                        # structure-then-text since typed exceptions get
+                        # wrapped by AgentSDK and the backend's error shape
+                        # varies (llama.cpp vs. FastFlowLM, #2513).
                         err_text = str(e).lower()
-                        is_ctx_overflow = (
-                            "exceed_context_size" in err_text
-                            or "exceeds the available context size" in err_text
-                            or "got too long" in err_text
-                        )
+                        is_ctx_overflow = is_context_overflow_error(err_text)
                         # Detect "wrong ctx size loaded" — substring match on
                         # error text first (when raw payload is preserved),
                         # then probe Lemonade health if substring missed

--- a/src/gaia/llm/lemonade_client.py
+++ b/src/gaia/llm/lemonade_client.py
@@ -531,6 +531,71 @@ class InsufficientDiskSpaceError(LemonadeClientError):
     """Raised when there's not enough disk space for model download."""
 
 
+# Phrases indicating a backend rejected a request because the prompt plus
+# conversation history exceeded the loaded model's context window.
+# Case-insensitive; matched against the backend's own error message once
+# extracted from a Lemonade error envelope (see ``is_context_overflow_error``
+# below). A new backend's overflow wording only needs a new entry here, not
+# a new classification branch (#2513: FastFlowLM's "Max length reached!"
+# matched none of the original llama.cpp-only phrasings, so the agent's
+# trim-and-retry recovery never engaged on NPU).
+CONTEXT_OVERFLOW_PHRASES = (
+    "exceed_context_size",
+    "exceeds the available context size",
+    "got too long",
+    "max length reached",
+)
+
+
+def _extract_backend_error_message(error_text: str) -> Optional[str]:
+    """Pull the backend's own ``message`` out of a Lemonade JSON error
+    envelope embedded in *error_text*, preferring the nested
+    ``details.response.error`` shape used for backend-wrapped failures
+    (e.g. FastFlowLM) over the outer envelope. Returns ``None`` when no
+    envelope can be located/parsed so the caller falls back to scanning
+    the raw text.
+    """
+    start = error_text.find("{")
+    if start == -1:
+        return None
+    try:
+        payload = json.loads(error_text[start:])
+    except (TypeError, ValueError):
+        return None
+    if not isinstance(payload, dict):
+        return None
+    err = payload.get("error")
+    if not isinstance(err, dict):
+        return None
+    nested = None
+    details = err.get("details")
+    if isinstance(details, dict):
+        response = details.get("response")
+        if isinstance(response, dict):
+            nested = response.get("error")
+    source = nested if isinstance(nested, dict) else err
+    message = source.get("message")
+    return str(message) if message else None
+
+
+def is_context_overflow_error(error_text: str) -> bool:
+    """Classify a stringified backend error as context overflow.
+
+    Structure first, text second: when *error_text* embeds a Lemonade JSON
+    error envelope, phrase-matching runs against just that envelope's own
+    message — so unrelated text elsewhere (e.g. an echoed request body)
+    can't produce a false positive. Falls back to scanning the raw text
+    when no envelope can be parsed, which keeps non-JSON backend phrasings
+    working. Shared by the agent loop's streaming and non-streaming retry
+    paths so every backend benefits from one classifier (#2513).
+    """
+    if not error_text:
+        return False
+    message = _extract_backend_error_message(error_text)
+    haystack = (message or error_text).lower()
+    return any(phrase in haystack for phrase in CONTEXT_OVERFLOW_PHRASES)
+
+
 @dataclass
 class DownloadTask:
     """Represents an ongoing model download."""
@@ -1530,15 +1595,32 @@ class LemonadeClient:
             raise last_error
 
     def _execute_with_auto_download(
-        self, api_call: Callable, model: str, auto_download: bool = True
+        self,
+        api_call: Callable,
+        model: str,
+        auto_download: bool = True,
+        *,
+        error: Exception,
     ):
         """
-        Execute an API call with auto-download retry logic.
+        Recover from a failed API call by auto-downloading/loading the
+        model — but ONLY when *error* is actually the missing-model
+        condition this exists for.
+
+        Every caller invokes this from an ``except`` block after
+        ``api_call()`` already failed once; *error* is that failure.
+        This used to retry ``api_call()`` unconditionally before even
+        looking at *error*, so any failure — context overflow included —
+        silently repeated the identical request. #2513 measured that as
+        two identical 400s per turn on the NPU/FastFlowLM backend.
+        Anything that isn't a missing-model error is re-raised immediately
+        instead of retried.
 
         Args:
             api_call: Function to call (should raise exception if model not loaded)
             model: Model name
             auto_download: Whether to auto-download on model error
+            error: The exception the caller's own first attempt raised
 
         Returns:
             Result of api_call()
@@ -1546,29 +1628,27 @@ class LemonadeClient:
         Raises:
             ModelDownloadCancelledError: If user cancels download
             InsufficientDiskSpaceError: If not enough disk space
-            LemonadeClientError: If download/load fails
+            LemonadeClientError: If download/load fails, or if *error* is
+                not a missing-model error (re-raised unchanged)
         """
-        try:
-            return api_call()
-        except Exception as e:
-            # Check if this is a model loading error and auto_download is enabled
-            if auto_download and self._is_model_error(e):
-                self.log.info(
-                    f"{_emoji('📥', '[AUTO-DOWNLOAD]')} Model '{model}' not loaded, "
-                    f"attempting auto-download and load..."
-                )
+        if not (auto_download and self._is_model_error(error)):
+            # Not the missing-model condition this recovery is for --
+            # retrying would just repeat the same failing request.
+            raise error
 
-                # Load model with auto-download (includes prompt, validation, etc.)
-                self.load_model(model, timeout=60, auto_download=True)
+        self.log.info(
+            f"{_emoji('📥', '[AUTO-DOWNLOAD]')} Model '{model}' not loaded, "
+            f"attempting auto-download and load..."
+        )
 
-                # Retry the API call
-                self.log.info(
-                    f"{_emoji('🔄', '[RETRY]')} Retrying API call with model: {model}"
-                )
-                return api_call()
+        # Load model with auto-download (includes prompt, validation, etc.)
+        self.load_model(model, timeout=60, auto_download=True)
 
-            # Re-raise original error
-            raise
+        # Retry the API call
+        self.log.info(
+            f"{_emoji('🔄', '[RETRY]')} Retrying API call with model: {model}"
+        )
+        return api_call()
 
     def chat_completions(
         self,
@@ -1725,10 +1805,13 @@ class LemonadeClient:
             # Execute with auto-download retry logic
             try:
                 return _make_request()
-            except (requests.exceptions.RequestException, LemonadeClientError):
-                # Use helper to handle auto-download and retry
+            except (requests.exceptions.RequestException, LemonadeClientError) as e:
+                # Use helper to handle auto-download and retry. Passing the
+                # already-caught error lets it skip the retry entirely for
+                # non-missing-model failures (#2513) instead of repeating
+                # the identical request first.
                 return self._execute_with_auto_download(
-                    _make_request, model, auto_download
+                    _make_request, model, auto_download, error=e
                 )
 
     def _stream_chat_completions_with_openai(
@@ -2035,9 +2118,12 @@ class LemonadeClient:
         # Execute with auto-download retry logic
         try:
             return _make_request()
-        except (requests.exceptions.RequestException, LemonadeClientError):
-            # Use helper to handle auto-download and retry
-            return self._execute_with_auto_download(_make_request, model, auto_download)
+        except (requests.exceptions.RequestException, LemonadeClientError) as e:
+            # Use helper to handle auto-download and retry (#2513: only
+            # when *e* is actually the missing-model condition).
+            return self._execute_with_auto_download(
+                _make_request, model, auto_download, error=e
+            )
 
     def _stream_completions_with_openai(
         self,

--- a/tests/unit/agents/test_parse_error_recovery.py
+++ b/tests/unit/agents/test_parse_error_recovery.py
@@ -193,6 +193,38 @@ class TestProcessQueryRecoversOnContextOverflow:
             assert "exceeds the available context size" not in text
             assert "Traceback" not in text
 
+    def test_flm_context_overflow_after_retry_gives_friendly_fallback(self, agent):
+        """#2513 work item 3: once the FastFlowLM 400 is reachable, an
+        exhausted retry must render the SAME "I had to trim the
+        conversation" message the llama.cpp path already has -- not the
+        generic "Sorry, I ran into an unexpected problem" wrapper, and not
+        a leaked "Max length reached!" backend string.
+        """
+        agent.streaming = False
+        agent._is_loaded_ctx_too_small = lambda: False
+        flm_error_text = (
+            "Error in chat completions (status 400): "
+            '{"error":{"code":400,"details":{"backend":"FastFlowLM",'
+            '"response":{"error":{"code":400,"message":"Max length reached!",'
+            '"type":"model_error"}}},"message":"Max length reached!",'
+            '"status_code":400,"type":"model_error"}}'
+        )
+        responses = [RuntimeError(flm_error_text), RuntimeError(flm_error_text)]
+        chat = MagicMock()
+
+        def _send(*_, **__):
+            raise responses.pop(0)
+
+        chat.send_messages = MagicMock(side_effect=_send)
+        agent.chat = chat
+        result = agent.process_query("x", max_steps=5)
+        # ``process_query`` returns ``{"status": ..., "result": <final_answer>, ...}``
+        text = result["result"] if isinstance(result, dict) else str(result)
+        assert text, "expected the friendly trim-exhausted fallback text"
+        assert "I had to trim the conversation" in text
+        assert "Max length reached" not in text
+        assert "Sorry, I ran into" not in text
+
     def test_wrong_ctx_loaded_reraises_for_model_reload(self, agent):
         """When the probe reports a too-small loaded ctx, the overflow is
         re-raised so the chat helper can reload the model — instead of being
@@ -244,10 +276,11 @@ class TestProcessQueryRecoversOnContextOverflow:
         assert any(
             e.get("type") == "llm_context_overflow_trimmed" for e in agent.error_history
         )
-        text = result.get("response") if isinstance(result, dict) else str(result)
-        if text:
-            assert "Max length reached" not in text
-            assert "Sorry, I ran into" not in text
+        # ``process_query`` returns ``{"status": ..., "result": <final_answer>, ...}``
+        text = result["result"] if isinstance(result, dict) else str(result)
+        assert text, "expected the retried answer to reach the user"
+        assert "Max length reached" not in text
+        assert "Sorry, I ran into" not in text
 
 
 class TestProcessQueryRecoversOnContextOverflowStreaming:
@@ -290,10 +323,11 @@ class TestProcessQueryRecoversOnContextOverflowStreaming:
         assert any(
             e.get("type") == "llm_context_overflow_trimmed" for e in agent.error_history
         )
-        text = result.get("response") if isinstance(result, dict) else str(result)
-        if text:
-            assert "Max length reached" not in text
-            assert "Sorry, I ran into" not in text
+        # ``process_query`` returns ``{"status": ..., "result": <final_answer>, ...}``
+        text = result["result"] if isinstance(result, dict) else str(result)
+        assert text, "expected the retried streamed answer to reach the user"
+        assert "Max length reached" not in text
+        assert "Sorry, I ran into" not in text
 
 
 class TestRepairInvalidJsonEscapes:

--- a/tests/unit/agents/test_parse_error_recovery.py
+++ b/tests/unit/agents/test_parse_error_recovery.py
@@ -220,6 +220,81 @@ class TestProcessQueryRecoversOnContextOverflow:
             e.get("type") == "llm_context_overflow_trimmed" for e in agent.error_history
         )
 
+    def test_flm_context_overflow_non_streaming_triggers_trim_and_retry(self, agent):
+        """#2513: the exact FastFlowLM 400 must trigger the same trim-and-
+        retry recovery as the llama.cpp phrasings above. Before the fix,
+        "Max length reached!" matched none of the llama.cpp-only substrings,
+        so this recovery was unreachable on the NPU backend.
+        """
+        agent.streaming = False
+        agent._is_loaded_ctx_too_small = lambda: False
+        good = json.dumps({"thought": "ok", "answer": "Here you go."})
+        flm_error_text = (
+            "Error in chat completions (status 400): "
+            '{"error":{"code":400,"details":{"backend":"FastFlowLM",'
+            '"response":{"error":{"code":400,"message":"Max length reached!",'
+            '"type":"model_error"}}},"message":"Max length reached!",'
+            '"status_code":400,"type":"model_error"}}'
+        )
+        chat = self._stub_chat_with_exception_then_answer(
+            agent, RuntimeError(flm_error_text), good
+        )
+        result = agent.process_query("anything", max_steps=5)
+        assert chat.send_messages.call_count == 2
+        assert any(
+            e.get("type") == "llm_context_overflow_trimmed" for e in agent.error_history
+        )
+        text = result.get("response") if isinstance(result, dict) else str(result)
+        if text:
+            assert "Max length reached" not in text
+            assert "Sorry, I ran into" not in text
+
+
+class TestProcessQueryRecoversOnContextOverflowStreaming:
+    """Same trim-and-retry recovery as ``TestProcessQueryRecoversOnContextOverflow``,
+    exercised on the streaming path -- #2513 fixed both call sites, which had
+    duplicated the same stale llama.cpp-only substring check.
+    """
+
+    @staticmethod
+    def _chunk(text, is_complete=False):
+        from types import SimpleNamespace
+
+        return SimpleNamespace(text=text, is_complete=is_complete, stats={})
+
+    def test_flm_context_overflow_streaming_triggers_trim_and_retry(self, agent):
+        """First streamed call raises the FastFlowLM 400, second succeeds."""
+        agent.streaming = True
+        agent._is_loaded_ctx_too_small = lambda: False
+        flm_error_text = (
+            "Error in chat completions (status 400): "
+            '{"error":{"code":400,"details":{"backend":"FastFlowLM",'
+            '"response":{"error":{"code":400,"message":"Max length reached!",'
+            '"type":"model_error"}}},"message":"Max length reached!",'
+            '"status_code":400,"type":"model_error"}}'
+        )
+        good_stream = [self._chunk("Here you go.", is_complete=False)]
+        call_count = {"n": 0}
+
+        def _send_stream(*_, **__):
+            call_count["n"] += 1
+            if call_count["n"] == 1:
+                raise RuntimeError(flm_error_text)
+            return iter(good_stream)
+
+        agent.chat.send_messages_stream = MagicMock(side_effect=_send_stream)
+
+        result = agent.process_query("anything", max_steps=5)
+
+        assert call_count["n"] == 2
+        assert any(
+            e.get("type") == "llm_context_overflow_trimmed" for e in agent.error_history
+        )
+        text = result.get("response") if isinstance(result, dict) else str(result)
+        if text:
+            assert "Max length reached" not in text
+            assert "Sorry, I ran into" not in text
+
 
 class TestRepairInvalidJsonEscapes:
     """Helper that doubles invalid JSON backslash escapes (e.g. Windows paths).

--- a/tests/unit/test_lemonade_error_classification.py
+++ b/tests/unit/test_lemonade_error_classification.py
@@ -575,3 +575,210 @@ class TestLoadModelCorruptRouting:
 
         mock_delete.assert_not_called()
         mock_pull.assert_not_called()
+
+
+# ── #2513: context-overflow classification must work across backends ────
+#
+# The agent's trim-and-retry recovery only engages when this classifier
+# returns True. Before #2513 the check was three llama.cpp-only substrings
+# duplicated at both agent.py call sites (streaming and non-streaming), so
+# FastFlowLM's "Max length reached!" (the NPU backend) matched neither copy
+# and the recovery silently never ran.
+
+from unittest.mock import MagicMock
+
+import responses as _responses
+
+from gaia.llm.lemonade_client import is_context_overflow_error
+
+# Verbatim payload from issue #2513, measured live on an NPU/FastFlowLM box.
+_FLM_OVERFLOW_JSON = (
+    '{"error":{"code":400,"details":{"backend":"FastFlowLM",'
+    '"response":{"error":{"code":400,"message":"Max length reached!",'
+    '"type":"model_error"}}},"message":"Max length reached!",'
+    '"status_code":400,"type":"model_error"}}'
+)
+_FLM_OVERFLOW_TEXT = f"Error in chat completions (status 400): {_FLM_OVERFLOW_JSON}"
+
+
+def test_flm_overflow_payload_classifies_as_overflow() -> None:
+    """The exact FastFlowLM 400 from #2513 must classify as overflow."""
+    assert is_context_overflow_error(_FLM_OVERFLOW_TEXT) is True
+
+
+def test_flm_overflow_payload_is_case_insensitive() -> None:
+    assert is_context_overflow_error(_FLM_OVERFLOW_TEXT.upper()) is True
+
+
+@pytest.mark.parametrize(
+    "phrase",
+    [
+        "exceed_context_size",
+        "exceeds the available context size",
+        "got too long",
+    ],
+)
+def test_existing_llamacpp_phrasings_still_classify(phrase: str) -> None:
+    """No regression: the three original llama.cpp phrasings still match
+    when they arrive as plain (non-JSON) error text, same as before #2513.
+    """
+    text = f"Error in chat completions (status 400): request {phrase} for model X"
+    assert is_context_overflow_error(text) is True
+
+
+def test_llamacpp_json_envelope_still_classifies() -> None:
+    """The structured llama.cpp envelope shape also classifies via the
+    JSON-aware extraction path, not just the raw-text fallback."""
+    text = (
+        "Error in chat completions (status 400): "
+        '{"error": {"type": "exceed_context_size", '
+        '"message": "request (42000 tokens) exceeds the available '
+        'context size (4096 tokens)", "n_ctx": 4096}}'
+    )
+    assert is_context_overflow_error(text) is True
+
+
+def test_unrelated_400_does_not_classify_as_overflow() -> None:
+    """A malformed-request 400 must keep its current (non-overflow) behaviour."""
+    text = (
+        "Error in chat completions (status 400): "
+        '{"error": {"code": 400, "message": "Invalid request: '
+        '\'messages\' field is required", "type": "invalid_request_error"}}'
+    )
+    assert is_context_overflow_error(text) is False
+
+
+def test_structure_first_ignores_phrase_outside_json_envelope() -> None:
+    """A phrase appearing only OUTSIDE the parsed JSON message must not
+    produce a false positive -- structure wins over a naive whole-text scan.
+    """
+    text = (
+        'user note: "the wait got too long" '
+        '{"error": {"message": "Invalid parameter: temperature out of range", '
+        '"type": "invalid_request_error"}}'
+    )
+    assert is_context_overflow_error(text) is False
+
+
+def test_empty_text_does_not_classify() -> None:
+    assert is_context_overflow_error("") is False
+
+
+def test_non_json_text_falls_back_to_raw_scan() -> None:
+    """Plain-text (non-JSON) backend errors still match via the fallback."""
+    assert is_context_overflow_error("the model said max length reached") is True
+
+
+# ── #2513: auto-download retry must not blindly repeat non-model errors ──
+#
+# ``_execute_with_auto_download`` used to retry ANY error unconditionally
+# before even checking what it was -- doubling every failure, context
+# overflow included. The issue measured this as two identical 400s with
+# identical body sizes per turn.
+
+
+class TestExecuteWithAutoDownloadNarrowing:
+    """Only the missing-model condition this helper exists for gets a retry."""
+
+    def test_context_overflow_error_is_not_retried(self) -> None:
+        client = _client()
+        api_call = MagicMock()
+        error = LemonadeClientError(_FLM_OVERFLOW_TEXT)
+
+        with patch.object(client, "load_model") as mock_load:
+            with pytest.raises(LemonadeClientError) as exc_info:
+                client._execute_with_auto_download(
+                    api_call, "gemma4-it-e2b-FLM", True, error=error
+                )
+
+        # The SAME error is re-raised -- not a fresh one from a retry.
+        assert exc_info.value is error
+        api_call.assert_not_called()
+        mock_load.assert_not_called()
+
+    def test_missing_model_error_is_still_retried(self) -> None:
+        client = _client()
+        api_call = MagicMock(return_value={"choices": [{"message": {"content": "ok"}}]})
+        error = LemonadeClientError("model not loaded")
+
+        with patch.object(client, "load_model") as mock_load:
+            result = client._execute_with_auto_download(
+                api_call, "gemma4-it-e2b-FLM", True, error=error
+            )
+
+        assert result == {"choices": [{"message": {"content": "ok"}}]}
+        mock_load.assert_called_once()
+        api_call.assert_called_once()
+
+    def test_auto_download_disabled_re_raises_even_for_missing_model(self) -> None:
+        """``auto_download=False`` must still skip the retry -- the flag is
+        an explicit opt-out, not just a hint."""
+        client = _client()
+        api_call = MagicMock()
+        error = LemonadeClientError("model not loaded")
+
+        with patch.object(client, "load_model") as mock_load:
+            with pytest.raises(LemonadeClientError):
+                client._execute_with_auto_download(
+                    api_call, "gemma4-it-e2b-FLM", False, error=error
+                )
+
+        api_call.assert_not_called()
+        mock_load.assert_not_called()
+
+    @_responses.activate
+    def test_context_overflow_produces_exactly_one_http_request(self) -> None:
+        """End-to-end through ``chat_completions()``: a context-overflow 400
+        must not double the HTTP request -- #2513's measured symptom was
+        two identical 400s with identical body sizes per failure.
+        """
+        _responses.add(
+            _responses.POST,
+            "http://localhost:13305/api/v1/chat/completions",
+            body=_FLM_OVERFLOW_JSON,
+            status=400,
+        )
+        client = _client()
+        with (
+            patch.object(client, "_ensure_model_loaded"),
+            patch.object(client, "load_model") as mock_load,
+        ):
+            with pytest.raises(LemonadeClientError):
+                client.chat_completions(
+                    model="gemma4-it-e2b-FLM",
+                    messages=[{"role": "user", "content": "hi"}],
+                )
+        assert len(_responses.calls) == 1, (
+            "context-overflow 400 must not be retried -- "
+            f"saw {len(_responses.calls)} HTTP request(s)"
+        )
+        mock_load.assert_not_called()
+
+    @_responses.activate
+    def test_missing_model_still_retries_over_http(self) -> None:
+        """A genuine missing-model 400 still triggers the auto-download
+        load + one retried HTTP request (unchanged behaviour)."""
+        _responses.add(
+            _responses.POST,
+            "http://localhost:13305/api/v1/chat/completions",
+            json={"error": {"message": "model not loaded", "type": "model_not_loaded"}},
+            status=400,
+        )
+        _responses.add(
+            _responses.POST,
+            "http://localhost:13305/api/v1/chat/completions",
+            json={"choices": [{"message": {"content": "ok"}, "finish_reason": "stop"}]},
+            status=200,
+        )
+        client = _client()
+        with (
+            patch.object(client, "_ensure_model_loaded"),
+            patch.object(client, "load_model") as mock_load,
+        ):
+            result = client.chat_completions(
+                model="gemma4-it-e2b-FLM",
+                messages=[{"role": "user", "content": "hi"}],
+            )
+        assert result["choices"][0]["message"]["content"] == "ok"
+        assert len(_responses.calls) == 2
+        mock_load.assert_called_once()


### PR DESCRIPTION
On NPU (FastFlowLM backend), the agent's context-overflow trim-and-retry recovery never engaged — it only recognized llama.cpp's English error phrasings, so FastFlowLM's "Max length reached!" fell through to a generic "try again in a moment" for what is actually a deterministic, recoverable failure. Classification now parses the backend's JSON error envelope first and falls back to phrase matching, so a new backend only needs a phrase added to one shared list. A related bug where the auto-download retry silently repeated every failed request once — doubling the load of every overflow (and other) failure — is narrowed alongside it.

Closes #2513

## Test plan

- [x] `python -m pytest tests/unit/ -k "overflow or lemonade or agent_error" -q` — 282 passed, 58 skipped, 0 failed
- [x] `python util/lint.py --all` — all critical gates pass (black, isort, pylint, flake8, bandit); only pre-existing non-blocking MyPy warnings
- [x] Test-first proof: reverted the two source files and reran the new tests against unpatched code — they fail exactly as the issue describes (retry never engages, call count 1 instead of 2), then pass again with the fix restored
- [ ] `gaia eval agent` — not run for this change (Lemonade is single-tenant; the orchestrator runs evals serially). This touches agent-loop error classification, which GAIA's CLAUDE.md gates behind an eval — recommend `--category error_recovery` as the closest scenario match before merge