### PR TITLE
feat(tui): tool-confirmation modal for destructive/external actions

### DIFF
--- a/tui/internal/cli/agents.go
+++ b/tui/internal/cli/agents.go
@@ -303,7 +303,11 @@ var runCmd = &cobra.Command{
 		if err := checkModelSupported(args[0], runModel); err != nil {
 			return err
 		}
-		code, err := ui.RunAgent(args[0], runQuery, runModel, debug, runTimeout)
+		ctrl, err := controlOptionsForAgentRun(cmd, runQuery != "")
+		if err != nil {
+			return err
+		}
+		code, err := ui.RunAgent(args[0], runQuery, runModel, debug, runTimeout, ctrl)
 		if err != nil {
 			return err
 		}

--- a/tui/internal/cli/chat.go
+++ b/tui/internal/cli/chat.go
@@ -46,7 +46,11 @@ var chatCmd = &cobra.Command{
 			}
 		}
 		if agentID != "" {
-			code, err := ui.RunAgent(agentID, query, chatModel, debug, chatTimeout)
+			ctrl, err := controlOptionsForAgentRun(cmd, query != "")
+			if err != nil {
+				return err
+			}
+			code, err := ui.RunAgent(agentID, query, chatModel, debug, chatTimeout, ctrl)
 			if err != nil {
 				return err
 			}

--- a/tui/internal/cli/control.go
+++ b/tui/internal/cli/control.go
@@ -46,3 +46,31 @@ func controlOptions(enabled bool, port int, explicitPort bool) (*control.Options
 		Version: version,
 	}, nil
 }
+
+// agentControlOptions is controlOptions plus the one restriction specific to an
+// agent launch (`chat --agent`, `run <id>`): a --query run answers and exits
+// before any session exists for an assistant to attach to. Accepting --control
+// there would just move the silent no-op #2512 fixes one call deeper instead of
+// closing it, so the combination is refused rather than quietly starting no
+// server.
+func agentControlOptions(enabled bool, port int, explicitPort, oneShot bool) (*control.Options, error) {
+	opts, err := controlOptions(enabled, port, explicitPort)
+	if err != nil {
+		return nil, err
+	}
+	if opts != nil && oneShot {
+		return nil, fmt.Errorf(
+			"--control / --control-port is not supported with --query: a one-shot run answers " +
+				"and exits before any session exists for an assistant to attach to. Drop --query " +
+				"to open the interactive chat, or drop --control")
+	}
+	return opts, nil
+}
+
+// controlOptionsForAgentRun reads this command's flags for an agent launch
+// (`chat --agent`, `run <id>`) — the interactive case binds the control API
+// exactly like the bare root command and `chat --subprocess` (control.go was
+// only ever wired for those two paths); the one-shot case refuses it loudly.
+func controlOptionsForAgentRun(cmd *cobra.Command, oneShot bool) (*control.Options, error) {
+	return agentControlOptions(controlEnabled, controlPort, cmd.Flags().Changed("control-port"), oneShot)
+}

--- a/tui/internal/cli/control_test.go
+++ b/tui/internal/cli/control_test.go
@@ -77,3 +77,61 @@ func TestControlPortAcceptsAUsablePort(t *testing.T) {
 		t.Errorf("got %+v, want port 8770", opts)
 	}
 }
+
+// TestAgentControlOptionsThreadsThroughForInteractive pins #2512: `chat --agent`
+// and `run <id>` used to accept --control-port and silently drop it — RunAgent
+// had no parameter to receive it at all, so nothing bound and nothing was
+// written to disk. This proves the decision function a real interactive launch
+// consults actually returns a bound port, the same "silent no-op" class
+// TestExplicitZeroPortStillEnablesControl pins for the bare root command.
+func TestAgentControlOptionsThreadsThroughForInteractive(t *testing.T) {
+	opts, err := agentControlOptions(false, 8815, true, false /* interactive: no --query */)
+	if err != nil {
+		t.Fatalf("agentControlOptions: %v", err)
+	}
+	if opts == nil {
+		t.Fatal("--agent ... --control-port 8815 (interactive) silently disabled the control API")
+	}
+	if opts.Port != 8815 {
+		t.Errorf("Port = %d, want 8815", opts.Port)
+	}
+}
+
+// TestAgentControlOptionsOffByDefault mirrors TestControlOffByDefault for the
+// --agent decision function: neither flag passed must never bind a port.
+func TestAgentControlOptionsOffByDefault(t *testing.T) {
+	opts, err := agentControlOptions(false, 0, false, false)
+	if err != nil {
+		t.Fatalf("agentControlOptions: %v", err)
+	}
+	if opts != nil {
+		t.Error("the control API must be off unless asked for")
+	}
+}
+
+// TestAgentControlOptionsRejectsOneShot: a --query run answers and exits before
+// any session exists for an assistant to attach to, so accepting --control there
+// would just move the silent no-op one call deeper instead of closing it. Loud
+// refusal, never an accepted-and-ignored flag.
+func TestAgentControlOptionsRejectsOneShot(t *testing.T) {
+	_, err := agentControlOptions(true, 0, false, true /* --query set */)
+	if err == nil {
+		t.Fatal("--control combined with --query was silently accepted")
+	}
+	if !strings.Contains(err.Error(), "--query") {
+		t.Errorf("error should name --query so the fix is obvious: %v", err)
+	}
+}
+
+// TestAgentControlOptionsOneShotWithoutControlIsUnaffected: --query alone (the
+// overwhelmingly common case) must not be penalized by a check that only exists
+// for the --control combination.
+func TestAgentControlOptionsOneShotWithoutControlIsUnaffected(t *testing.T) {
+	opts, err := agentControlOptions(false, 0, false, true /* --query set */)
+	if err != nil {
+		t.Fatalf("a bare one-shot with no --control must not be refused: %v", err)
+	}
+	if opts != nil {
+		t.Errorf("got %+v, want nil (control was never requested)", opts)
+	}
+}

--- a/tui/internal/client/client.go
+++ b/tui/internal/client/client.go
@@ -35,3 +35,19 @@ type AgentResponder interface {
 type TranscriptResetter interface {
 	ResetTranscript()
 }
+
+// AgentConfirmer is implemented by transports that can resolve a
+// needs_confirmation pause under the resume model (spec §5: the event carries
+// a non-empty confirm_url and the run stays paused server-side awaiting it).
+//
+// No shipped sidecar sets confirm_url today — every current agent speaks the
+// stateless stop-and-hand-off model, where needs_confirmation is immediately
+// terminal and there is nothing to resume. A transport still implements this
+// so a future resume-model peer is not left unreachable by the client; the UI
+// only calls it when the triggering event actually carried a confirm_url.
+type AgentConfirmer interface {
+	// Confirm delivers the user's decision for runID's pending confirmation.
+	// It returns an actionable error if the run is gone (the pause expired) or
+	// is not waiting on a confirmation.
+	Confirm(ctx context.Context, runID string, approved bool) error
+}

--- a/tui/internal/client/sse.go
+++ b/tui/internal/client/sse.go
@@ -497,6 +497,78 @@ type respondRequest struct {
 	Value     string `json:"value"`
 }
 
+// Confirm delivers an approve/deny decision for a needs_confirmation pause
+// under the resume model (spec §5). The path is the deterministic one the
+// spec documents for a confirm_url — "/v1/<agent>/query/{run_id}/confirm" —
+// built here rather than trusting a server-supplied confirm_url string
+// verbatim, exactly like Respond and cancelRun build their own paths instead
+// of taking one off the wire.
+//
+// No shipped sidecar implements this route today: the email agent's `/query`
+// speaks the stateless stop-and-hand-off model, where needs_confirmation ends
+// the run immediately and there is no server-side pause to resume. Calling
+// this against that sidecar gets a 404, handled below like any other
+// already-ended run — the same shape Respond already handles, not a new
+// failure class.
+func (s *SSEClient) Confirm(ctx context.Context, runID string, approved bool) error {
+	s.mu.Lock()
+	inst := s.inst
+	active := s.active
+	s.mu.Unlock()
+	if inst == nil || active == nil {
+		return fmt.Errorf(
+			"there is no live '%s' run to confirm — the run had already ended. Nothing was sent either way",
+			s.agentID)
+	}
+	if active.runID != runID {
+		return fmt.Errorf(
+			"the '%s' run this decision was for is no longer the active one — a new turn started first. Nothing was sent",
+			s.agentID)
+	}
+
+	payload, err := json.Marshal(confirmRequest{Approved: approved})
+	if err != nil {
+		return fmt.Errorf("could not encode the confirmation decision for '%s': %w", s.agentID, err)
+	}
+
+	resp, _, err := s.daemon.Do(ctx, inst, daemon.Request{
+		Method: http.MethodPost,
+		Path: fmt.Sprintf("/v1/%s/query/%s/confirm",
+			url.PathEscape(s.agentID), url.PathEscape(runID)),
+		Body: payload,
+		Header: http.Header{
+			"Content-Type": []string{"application/json"},
+		},
+		HTTPClient: s.cancelHTTP,
+		Op:         fmt.Sprintf("deliver the '%s' agent's confirmation decision", s.agentID),
+	})
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	switch resp.StatusCode {
+	case http.StatusOK:
+		return nil
+	case http.StatusNotFound:
+		return fmt.Errorf(
+			"the '%s' run had already ended (no confirm endpoint to resume, or the run finished first), "+
+				"so the decision arrived too late. Nothing was sent either way",
+			s.agentID)
+	case http.StatusConflict:
+		return fmt.Errorf(
+			"the '%s' agent is no longer waiting on that confirmation — it already resolved. Nothing was sent",
+			s.agentID)
+	default:
+		return fmt.Errorf("delivering the '%s' agent's confirmation decision failed (%s)",
+			s.agentID, daemon.ErrorDetail(resp))
+	}
+}
+
+type confirmRequest struct {
+	Approved bool `json:"approved"`
+}
+
 // cancelRun asks the relay to drop a run we are abandoning.
 //
 // Best-effort: the sidecar may already be gone. It owns its own background
@@ -656,5 +728,6 @@ func newRunID() (string, error) {
 var (
 	_ AgentClient        = (*SSEClient)(nil)
 	_ AgentResponder     = (*SSEClient)(nil)
+	_ AgentConfirmer     = (*SSEClient)(nil)
 	_ TranscriptResetter = (*SSEClient)(nil)
 )

--- a/tui/internal/client/sse_test.go
+++ b/tui/internal/client/sse_test.go
@@ -52,8 +52,15 @@ type fakeRelay struct {
 	queries     []queryRequest
 	rawBodies   []string
 	cancelled   []string
+	confirmed   []confirmCall
 	auths       []string
 	versionHits int
+}
+
+// confirmCall is one recorded POST .../query/{run_id}/confirm.
+type confirmCall struct {
+	runID    string
+	approved bool
 }
 
 func newFakeRelay(t *testing.T) *fakeRelay {
@@ -148,6 +155,22 @@ func (f *fakeRelay) handle(w http.ResponseWriter, r *http.Request) {
 		parts := strings.Split(r.URL.Path, "/")
 		f.mu.Lock()
 		f.cancelled = append(f.cancelled, parts[len(parts)-2])
+		f.mu.Unlock()
+		w.WriteHeader(http.StatusOK)
+
+	case strings.HasSuffix(r.URL.Path, "/confirm"):
+		// No shipped sidecar has this route (the resume model is unimplemented
+		// anywhere — spec §5, D1 unsigned); this fake exists purely so the
+		// CLIENT's request construction and response handling are tested, the
+		// same way TestSSEClientCancelPostsToCancelEndpoint tests /cancel.
+		parts := strings.Split(r.URL.Path, "/")
+		var body confirmRequest
+		raw, _ := io.ReadAll(r.Body)
+		if err := json.Unmarshal(raw, &body); err != nil {
+			f.t.Errorf("confirm body is not valid JSON: %v (%s)", err, raw)
+		}
+		f.mu.Lock()
+		f.confirmed = append(f.confirmed, confirmCall{runID: parts[len(parts)-2], approved: body.Approved})
 		f.mu.Unlock()
 		w.WriteHeader(http.StatusOK)
 
@@ -773,6 +796,106 @@ func TestSSEClientCancelPostsToCancelEndpoint(t *testing.T) {
 
 	if tr := c.Transcript(); len(tr) != 0 {
 		t.Errorf("a cancelled turn must not be appended to the transcript: %+v", tr)
+	}
+}
+
+// Confirm posts to the deterministic .../query/{run_id}/confirm path (spec §5)
+// with {"approved": bool} — built from the client's own knowledge, never a
+// server-supplied confirm_url string, exactly like Respond and cancelRun build
+// their own paths. No shipped sidecar has this route; this test is about the
+// CLIENT half of the resume model being correct and ready, not about it being
+// exercised against a real peer today.
+func TestSSEClientConfirmPostsApprovedFlag(t *testing.T) {
+	f := newFakeRelay(t)
+	started := make(chan struct{})
+	release := make(chan struct{})
+	f.stream = func(w http.ResponseWriter, flush func(), _ queryRequest) {
+		frame(w, `{"type":"status","message":"thinking"}`)
+		flush()
+		close(started)
+		<-release
+	}
+
+	c := f.client(t)
+	defer c.Close()
+
+	ctx := context.Background()
+	ch, err := c.Send(ctx, "send it")
+	if err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+	if _, ok := <-ch; !ok {
+		t.Fatal("expected the status event before confirming")
+	}
+	<-started
+
+	runID := f.lastQuery().RunID
+	if err := c.Confirm(context.Background(), runID, true); err != nil {
+		t.Fatalf("Confirm: %v", err)
+	}
+
+	f.mu.Lock()
+	got := append([]confirmCall(nil), f.confirmed...)
+	f.mu.Unlock()
+	if len(got) != 1 || got[0].runID != runID || !got[0].approved {
+		t.Errorf("confirmed = %+v, want one call for run %q approved=true", got, runID)
+	}
+
+	close(release)
+	for range ch {
+	}
+}
+
+// A decision for a run that is no longer the active one (a new turn started,
+// or this one already ended) must be refused locally — never sent as if it
+// still meant something.
+func TestSSEClientConfirmRefusesAStaleRun(t *testing.T) {
+	f := newFakeRelay(t)
+	started := make(chan struct{})
+	release := make(chan struct{})
+	f.stream = func(w http.ResponseWriter, flush func(), _ queryRequest) {
+		frame(w, `{"type":"status","message":"thinking"}`)
+		flush()
+		close(started)
+		<-release
+	}
+
+	c := f.client(t)
+	defer c.Close()
+
+	ch, err := c.Send(context.Background(), "send it")
+	if err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+	if _, ok := <-ch; !ok {
+		t.Fatal("expected the status event")
+	}
+	<-started
+
+	if err := c.Confirm(context.Background(), "some-other-run-id", true); err == nil {
+		t.Error("a confirmation for a non-active run was silently accepted")
+	}
+	f.mu.Lock()
+	n := len(f.confirmed)
+	f.mu.Unlock()
+	if n != 0 {
+		t.Error("a stale confirmation must never reach the wire")
+	}
+
+	close(release)
+	for range ch {
+	}
+}
+
+// Confirm before any run has ever been sent must refuse locally too — the
+// zero-value client has nothing to confirm.
+func TestSSEClientConfirmWithNoActiveRunIsRefused(t *testing.T) {
+	f := newFakeRelay(t)
+	c := f.client(t)
+	defer c.Close()
+
+	if err := c.Confirm(context.Background(), "run-1", true); err == nil {
+		t.Error("Confirm with no active run was silently accepted")
 	}
 }
 

--- a/tui/internal/ui/app.go
+++ b/tui/internal/ui/app.go
@@ -142,8 +142,13 @@ func run(model tea.Model, debug bool, ctrl *control.Options) error {
 // the transport exercisable from a script, from CI, and against a live daemon.
 // timeout bounds that turn; it is ignored by the interactive path, where a person
 // can see what is happening and press ctrl+c.
+//
+// ctrl is only honoured on the interactive path (query == ""): a one-shot has no
+// session for the control API to attach to, so the caller is expected to have
+// already refused that combination (see cli.agentControlOptions) rather than
+// pass a non-nil ctrl through here.
 // Returns the process exit code.
-func RunAgent(agentID, query, model string, debug bool, timeout time.Duration) (int, error) {
+func RunAgent(agentID, query, model string, debug bool, timeout time.Duration, ctrl *control.Options) (int, error) {
 	cat := catalog.NewCatalog()
 	cat.DiscoverBinaries()
 
@@ -222,11 +227,9 @@ func RunAgent(agentID, query, model string, debug bool, timeout time.Duration) (
 		return res.ExitCode, nil
 	}
 
-	prepareTerminal()
 	model_ := chat.NewChatModel(c, agent.Name, "", debug)
-	p := tea.NewProgram(model_, tea.WithAltScreen())
-	if _, err := p.Run(); err != nil {
-		return 1, fmt.Errorf("TUI error: %w", err)
+	if err := run(model_, debug, ctrl); err != nil {
+		return 1, err
 	}
 	return 0, nil
 }

--- a/tui/internal/ui/chat/canonical.go
+++ b/tui/internal/ui/chat/canonical.go
@@ -21,6 +21,16 @@ const answerTimeout = 15 * time.Second
 // questionFailedMsg reports that an answer never reached the agent.
 type questionFailedMsg struct{ err error }
 
+// confirmActionResultMsg reports the outcome of delivering an approve/deny
+// decision over the resume-model confirm seam (client.AgentConfirmer). Only
+// produced when the triggering event carried a confirm_url — see
+// (ChatModel).confirmAction.
+type confirmActionResultMsg struct {
+	Action   string
+	Approved bool
+	err      error
+}
+
 // handleCanonicalEvent renders the canonical `/query` SSE vocabulary — what the
 // daemon transport streams. handled is false for anything else, so the legacy
 // in-process types (used by the subprocess transport) fall through untouched.
@@ -72,14 +82,23 @@ func (m ChatModel) handleCanonicalEvent(evt interface{}) (ChatModel, tea.Cmd, bo
 		})
 
 	case event.CanonicalNeedsConfirmationEvent:
-		// The approval UI is a later phase. Until then the pause is surfaced as a
-		// message the user can actually read — never swallowed — and the run
-		// continues to its own terminal event.
+		// The pause goes to the permanent transcript — never swallowed — AND to
+		// the interactive modal, which owns the keyboard until the user answers
+		// or the 30s client-side timeout auto-denies. The status line stays
+		// durable in scrollback even after the modal resolves and clears (see
+		// CanonicalFinalEvent below): the modal is the CURRENT decision surface,
+		// this line is the permanent record of it.
 		line := "confirmation needed: " + e.Action
 		if summary := strings.TrimSpace(e.Summary); summary != "" {
 			line += " — " + summary
 		}
 		m.messages = append(m.messages, Message{Role: RoleStatus, Content: "[!] " + line})
+
+		cm := components.NewConfirmationModel(e.RunID, e.Action, e.Summary, e.ConfirmURL)
+		cm.SetWidth(m.cardWidth())
+		m.confirmation = &cm
+		m.updateViewport()
+		return m, tea.Batch(waitForEvent(m.events), components.StartConfirmationTimeout(e.RunID)), true
 
 	case event.CanonicalFinalEvent:
 		usage := event.CanonicalUsageOf(e)
@@ -108,6 +127,11 @@ func (m ChatModel) handleCanonicalEvent(evt interface{}) (ChatModel, tea.Cmd, bo
 		// the panel up would swallow every keystroke into a question nobody is
 		// listening to — the composer becomes unreachable and Esc quits the app.
 		m.question = nil
+		// Same reasoning for a still-pending confirmation — and on the current
+		// email sidecar this is the ORDINARY case, not an edge one: the stateless
+		// D1 stub sends this final refusal in the same stream read the
+		// needs_confirmation event arrived on, before a human can plausibly react.
+		m.resolveConfirmationOnTurnEnd()
 		if usage.Steps > 0 {
 			m.totalSteps = usage.Steps
 		}
@@ -116,6 +140,7 @@ func (m ChatModel) handleCanonicalEvent(evt interface{}) (ChatModel, tea.Cmd, bo
 
 	case event.CanonicalErrorEvent:
 		m.flushBuffer()
+		m.resolveConfirmationOnTurnEnd()
 		m.messages = append(m.messages, Message{Role: RoleError, Content: e.Detail})
 		m.streaming = false
 		m.activity = nil
@@ -190,6 +215,100 @@ func (m ChatModel) answerQuestion(requestID, value string) tea.Cmd {
 			return questionFailedMsg{err: err}
 		}
 		return nil
+	}
+}
+
+// resolveConfirmationOnTurnEnd clears a still-pending confirmation when the
+// run's own terminal event gets there first — which, against the current
+// email sidecar's stateless D1 stub, is the NORMAL case: `needs_confirmation`
+// is immediately followed, in the same stream read, by a synthesized `final`
+// refusal (docs/spec/agent-ui-query-sse-contract.md §5). Leaving the modal up
+// would trap every keystroke in a decision that can no longer change anything
+// — the composer becomes unreachable, exactly the bug m.question=nil already
+// fixes for a mid-run question. The permanent transcript line added when the
+// event first arrived (not the modal) is the durable record of what happened.
+func (m *ChatModel) resolveConfirmationOnTurnEnd() {
+	if m.confirmation == nil {
+		return
+	}
+	if m.confirmation.Pending() {
+		m.messages = append(m.messages, Message{
+			Role: RoleStatus,
+			Content: "[!] confirmation for '" + m.confirmation.Action() +
+				"' resolved: denied — the run ended before it could be answered. Nothing was sent.",
+		})
+	}
+	m.confirmation = nil
+}
+
+// resolveConfirmationDecision records a confirmation's outcome — from a
+// keypress or the 30s timeout — in the activity log and the permanent
+// transcript, then attempts live delivery when (and only when) the triggering
+// event carried a confirm_url.
+func (m ChatModel) resolveConfirmationDecision(msg components.ConfirmationDecidedMsg) (tea.Model, tea.Cmd) {
+	outcome, success := confirmationOutcomeText(msg)
+	m.activity = append(m.activity, ActivityItem{
+		Kind:    "confirm",
+		Content: "confirm " + msg.Action + ": " + outcome,
+		Done:    true,
+		Success: &success,
+	})
+	m.messages = append(m.messages, Message{
+		Role:    RoleStatus,
+		Content: "[!] confirmation for '" + msg.Action + "' resolved: " + outcome,
+	})
+	m.confirmation = nil
+	m.updateViewport()
+
+	if msg.ConfirmURL == "" {
+		// The stateless model (what every shipped sidecar speaks today): there is
+		// no channel to deliver a decision to, so there is nothing further to do
+		// — recording the outcome above is the whole job.
+		return m, nil
+	}
+	return m, m.confirmAction(msg.RunID, msg.Action, msg.Approved)
+}
+
+// confirmationOutcomeText is the one-line outcome recorded for a resolved
+// confirmation. Never claims delivery that cannot happen: an approval with no
+// confirm_url is recorded as exactly that, not as "approved" — see
+// ConfirmationModel's doc comment for why (ui/oneshot.go's writeWithheld
+// already draws this line for the one-shot surface; this is the same rule
+// applied here).
+func confirmationOutcomeText(msg components.ConfirmationDecidedMsg) (text string, success bool) {
+	switch {
+	case msg.TimedOut:
+		return "denied (30s timeout — no response)", false
+	case msg.Approved && msg.ConfirmURL != "":
+		return "approved — delivering", true
+	case msg.Approved:
+		return "approved, but this transport has no live approval channel yet " +
+			"(no confirm_url on the event) — nothing was actually sent", false
+	default:
+		return "denied — nothing sent", false
+	}
+}
+
+// confirmAction delivers the user's decision on the transport's out-of-band
+// confirm seam. Only reachable when the triggering event carried a
+// confirm_url — the resume model (spec §5). No shipped sidecar sets that
+// field today, so this path exists for forward compatibility and is not
+// exercised against the current email agent; see ConfirmationModel's doc
+// comment for the full picture.
+func (m ChatModel) confirmAction(runID, action string, approved bool) tea.Cmd {
+	confirmer, ok := m.client.(client.AgentConfirmer)
+	if !ok {
+		return func() tea.Msg {
+			return confirmActionResultMsg{Action: action, Approved: approved, err: fmt.Errorf(
+				"this agent connection cannot deliver a confirmation decision; " +
+					"relaunch the agent through the GAIA daemon transport")}
+		}
+	}
+	return func() tea.Msg {
+		ctx, cancel := context.WithTimeout(context.Background(), answerTimeout)
+		defer cancel()
+		err := confirmer.Confirm(ctx, runID, approved)
+		return confirmActionResultMsg{Action: action, Approved: approved, err: err}
 	}
 }
 

--- a/tui/internal/ui/chat/confirmation_test.go
+++ b/tui/internal/ui/chat/confirmation_test.go
@@ -1,0 +1,363 @@
+package chat
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/amd/gaia/tui/internal/event"
+	"github.com/amd/gaia/tui/internal/ui/components"
+)
+
+// confirmingClient records the out-of-band confirm decisions the chat model
+// delivers, for the resume-model (confirm_url-present) path only.
+type confirmingClient struct {
+	nullClient
+	calls []struct {
+		runID    string
+		approved bool
+	}
+	err error
+}
+
+func (c *confirmingClient) Confirm(_ context.Context, runID string, approved bool) error {
+	c.calls = append(c.calls, struct {
+		runID    string
+		approved bool
+	}{runID, approved})
+	return c.err
+}
+
+func needsConfirmation(confirmURL string) event.CanonicalNeedsConfirmationEvent {
+	return event.CanonicalNeedsConfirmationEvent{
+		Type: "needs_confirmation", RunID: "run-1", Action: "send_draft",
+		Summary: `Send reply to alice@example.com — subject "Re: invoice"?`, ConfirmURL: confirmURL,
+	}
+}
+
+// The modal must actually go up, and it must not end the turn on its own — the
+// email sidecar sends its own terminal event right after, but the client does
+// not assume that; it reads whatever the stream sends next.
+func TestNeedsConfirmationPutsUpTheModal(t *testing.T) {
+	m, _ := newTestModel(t)
+	m.streaming = true
+
+	m = feed(t, m, needsConfirmation(""))
+
+	if !m.streaming {
+		t.Error("needs_confirmation must not end the turn on its own")
+	}
+	if m.confirmation == nil {
+		t.Fatal("the confirmation modal was not put up")
+	}
+	if m.confirmation.RunID() != "run-1" || m.confirmation.Action() != "send_draft" {
+		t.Errorf("modal lost the event's identity: runID=%q action=%q",
+			m.confirmation.RunID(), m.confirmation.Action())
+	}
+	view := m.View()
+	for _, want := range []string{"send_draft", "alice@example.com", "WRITE"} {
+		if !strings.Contains(view, want) {
+			t.Errorf("modal not rendered in chat (missing %q):\n%s", want, view)
+		}
+	}
+}
+
+// While the confirmation is pending, keys drive it rather than the composer —
+// mirrors TestKeysRouteToThePendingQuestion for the confirmation modal.
+func TestKeysRouteToThePendingConfirmation(t *testing.T) {
+	m, _ := newTestModel(t)
+	m.streaming = true
+	m = feed(t, m, needsConfirmation(""))
+
+	updated, cmd := m.handleKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("x")})
+	m = updated.(ChatModel)
+	if cmd != nil {
+		t.Error("an unrecognized key must not resolve the confirmation")
+	}
+	if m.confirmation == nil || !m.confirmation.Pending() {
+		t.Fatal("the confirmation must still be pending")
+	}
+	if got := m.input.Value(); got != "" {
+		t.Errorf("the keystroke leaked into the composer: %q", got)
+	}
+}
+
+// Denying is always real: nothing was ever going to be sent, so there is
+// nothing to deliver — the outcome is recorded and the modal clears.
+func TestDenyingClearsTheModalAndRecordsOutcome(t *testing.T) {
+	m, _ := newTestModel(t)
+	m.streaming = true
+	m = feed(t, m, needsConfirmation(""))
+
+	updated, cmd := m.handleKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("n")})
+	m = updated.(ChatModel)
+	if cmd == nil {
+		t.Fatal("denying produced no command")
+	}
+	msg, ok := cmd().(components.ConfirmationDecidedMsg)
+	if !ok {
+		t.Fatalf("expected ConfirmationDecidedMsg, got %#v", cmd())
+	}
+	updatedModel, cmd2 := m.Update(msg)
+	m = updatedModel.(ChatModel)
+
+	if m.confirmation != nil {
+		t.Error("a resolved confirmation must clear")
+	}
+	if cmd2 != nil {
+		t.Error("denying with no confirm_url must not attempt delivery")
+	}
+	last := m.messages[len(m.messages)-1]
+	if last.Role != RoleStatus || !strings.Contains(last.Content, "denied") {
+		t.Errorf("the denial was not recorded: %+v", last)
+	}
+	if len(m.activity) == 0 {
+		t.Fatal("the activity panel must show the confirmation result")
+	}
+	act := m.activity[len(m.activity)-1]
+	if act.Kind != "confirm" || act.Success == nil || *act.Success {
+		t.Errorf("activity item wrong: %+v", act)
+	}
+}
+
+// Esc means DENY for this modal — unlike a plain question, where Esc cancels
+// the whole turn. That is the issue's explicit keyboard contract.
+func TestEscDeniesTheConfirmationRatherThanCancellingTheTurn(t *testing.T) {
+	m, _ := newTestModel(t)
+	m.streaming = true
+	m.cancelFn = func() { t.Error("Esc on a pending confirmation must not cancel the turn") }
+	m = feed(t, m, needsConfirmation(""))
+
+	updated, cmd := m.handleKey(tea.KeyMsg{Type: tea.KeyEsc})
+	m = updated.(ChatModel)
+	if cmd == nil {
+		t.Fatal("Esc produced no decision")
+	}
+	msg := cmd().(components.ConfirmationDecidedMsg)
+	if msg.Approved {
+		t.Error("Esc must never approve")
+	}
+	if !m.streaming {
+		t.Error("Esc-as-deny must not cancel the turn — only the confirmation resolves")
+	}
+}
+
+// Approving with no confirm_url (the shipping email sidecar's stateless D1
+// contract, always) must not claim delivery it cannot make — see
+// ConfirmationModel's doc comment and ui/oneshot.go's writeWithheld, which
+// draws the identical line for the one-shot surface.
+func TestApprovingWithNoConfirmURLDoesNotClaimDelivery(t *testing.T) {
+	c := &confirmingClient{}
+	m := NewChatModel(c, "email", "", false)
+	m.width, m.height = 100, 30
+	m.streaming = true
+	m = feed(t, m, needsConfirmation(""))
+
+	updated, cmd := m.handleKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("y")})
+	m = updated.(ChatModel)
+	msg := cmd().(components.ConfirmationDecidedMsg)
+	updatedModel, cmd2 := m.Update(msg)
+	m = updatedModel.(ChatModel)
+
+	if cmd2 != nil {
+		t.Error("no confirm_url means no channel to deliver on — nothing should be attempted")
+	}
+	if len(c.calls) != 0 {
+		t.Errorf("Confirm() was called with no confirm_url on the event: %v", c.calls)
+	}
+	last := m.messages[len(m.messages)-1]
+	if strings.Contains(last.Content, "approved,") == false || strings.Contains(last.Content, "nothing was actually sent") == false {
+		t.Errorf("an unfulfillable approval must say so, not claim success: %q", last.Content)
+	}
+}
+
+// Under the (currently unimplemented anywhere) resume model, an event that DOES
+// carry a confirm_url gets a real delivery attempt through AgentConfirmer.
+func TestApprovingWithConfirmURLDeliversViaConfirmer(t *testing.T) {
+	c := &confirmingClient{}
+	m := NewChatModel(c, "email", "", false)
+	m.width, m.height = 100, 30
+	m.streaming = true
+	m = feed(t, m, needsConfirmation("/v1/email/query/run-1/confirm"))
+
+	updated, cmd := m.handleKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("y")})
+	m = updated.(ChatModel)
+	msg := cmd().(components.ConfirmationDecidedMsg)
+	if msg.ConfirmURL == "" {
+		t.Fatal("the decision lost the confirm_url")
+	}
+	_, cmd2 := m.Update(msg)
+	if cmd2 == nil {
+		t.Fatal("approving with a confirm_url must attempt delivery")
+	}
+	result := cmd2()
+	deliveryMsg, ok := result.(confirmActionResultMsg)
+	if !ok {
+		t.Fatalf("expected confirmActionResultMsg, got %#v", result)
+	}
+	if deliveryMsg.err != nil {
+		t.Fatalf("delivery failed: %v", deliveryMsg.err)
+	}
+	if len(c.calls) != 1 || c.calls[0].runID != "run-1" || !c.calls[0].approved {
+		t.Errorf("Confirm() calls = %+v, want one for run-1 approved=true", c.calls)
+	}
+}
+
+// A failed delivery is surfaced, never swallowed.
+func TestFailedConfirmDeliveryIsSurfaced(t *testing.T) {
+	c := &confirmingClient{err: errors.New("the 'email' run had already ended")}
+	m := NewChatModel(c, "email", "", false)
+	m.width, m.height = 100, 30
+	m.streaming = true
+	m = feed(t, m, needsConfirmation("/v1/email/query/run-1/confirm"))
+
+	updated, cmd := m.handleKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("y")})
+	m = updated.(ChatModel)
+	msg := cmd().(components.ConfirmationDecidedMsg)
+	_, cmd2 := m.Update(msg)
+	result := cmd2().(confirmActionResultMsg)
+
+	updated2, _ := m.Update(result)
+	m = updated2.(ChatModel)
+	last := m.messages[len(m.messages)-1]
+	if last.Role != RoleError || !strings.Contains(last.Content, "already ended") {
+		t.Errorf("delivery failure not surfaced: %+v", last)
+	}
+}
+
+// A turn that ends while a confirmation is up must take the modal down with
+// it — mirrors TestTerminalEventClearsThePendingQuestion. This is the ORDINARY
+// case against the current email sidecar: needs_confirmation is immediately
+// followed by a final refusal in the same stream read.
+func TestTerminalEventClearsThePendingConfirmation(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		evt  interface{}
+	}{
+		{"final", event.CanonicalFinalEvent{Type: "final", Answer: "needs your explicit confirmation. Nothing has been sent."}},
+		{"error", event.CanonicalErrorEvent{Type: "error", Detail: "the run failed"}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			m, _ := newTestModel(t)
+			m.streaming = true
+			m = feed(t, m, needsConfirmation(""))
+			if m.confirmation == nil {
+				t.Fatal("the confirmation was not put up")
+			}
+			m = feed(t, m, tc.evt)
+
+			if m.confirmation != nil {
+				t.Fatal("the confirmation outlived the turn it belonged to")
+			}
+			// The durable record survived even though the modal did not.
+			found := false
+			for _, msg := range m.messages {
+				if strings.Contains(msg.Content, "resolved: denied") {
+					found = true
+				}
+			}
+			if !found {
+				t.Errorf("no durable resolution line in the transcript: %+v", m.messages)
+			}
+			// The composer takes text again.
+			updated, _ := m.handleKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("h")})
+			if got := updated.(ChatModel).input.Value(); got != "h" {
+				t.Errorf("composer value = %q, want \"h\" — keystrokes are still trapped", got)
+			}
+		})
+	}
+}
+
+// A confirmation resolved by the run ending first must not ALSO leave an
+// activity item behind — resolveConfirmationDecision (the keypress/timeout
+// path) is what adds it, and the turn-end path takes a different, simpler
+// route on purpose (see resolveConfirmationOnTurnEnd).
+func TestTerminalEventDoesNotDoubleRecordTheOutcome(t *testing.T) {
+	m, _ := newTestModel(t)
+	m.streaming = true
+	m = feed(t, m, needsConfirmation(""))
+	m = feed(t, m, event.CanonicalFinalEvent{Type: "final", Answer: "declined"})
+
+	count := 0
+	for _, msg := range m.messages {
+		if strings.Contains(msg.Content, "resolved:") {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Errorf("expected exactly one resolution line, got %d: %+v", count, m.messages)
+	}
+}
+
+// The 30s client-side timeout resolves to deny and clears the modal — this
+// exercises the message ChatModel.Update actually receives from
+// components.StartConfirmationTimeout, not just the component in isolation.
+func TestConfirmationTimeoutDeniesAndClearsModal(t *testing.T) {
+	m, _ := newTestModel(t)
+	m.streaming = true
+	m = feed(t, m, needsConfirmation(""))
+
+	updated, cmd := m.Update(components.ConfirmationTimeoutMsg{RunID: "run-1"})
+	m = updated.(ChatModel)
+	if cmd == nil {
+		t.Fatal("the timeout tick produced no decision")
+	}
+	msg := cmd().(components.ConfirmationDecidedMsg)
+	if !msg.TimedOut || msg.Approved {
+		t.Errorf("decision = %+v, want TimedOut=true Approved=false", msg)
+	}
+	updated2, _ := m.Update(msg)
+	m = updated2.(ChatModel)
+	if m.confirmation != nil {
+		t.Error("the modal must clear once the timeout resolves it")
+	}
+	last := m.messages[len(m.messages)-1]
+	if !strings.Contains(last.Content, "timeout") {
+		t.Errorf("the timeout warning was not recorded: %q", last.Content)
+	}
+}
+
+// A timeout tick for a confirmation that already resolved (or belongs to a
+// superseded run) must be dropped, not misapplied.
+func TestStaleConfirmationTimeoutIsDropped(t *testing.T) {
+	m, _ := newTestModel(t)
+	m.streaming = true
+	m = feed(t, m, needsConfirmation(""))
+	m = feed(t, m, event.CanonicalFinalEvent{Type: "final", Answer: "declined"})
+	if m.confirmation != nil {
+		t.Fatal("setup: the confirmation should already be cleared")
+	}
+
+	updated, cmd := m.Update(components.ConfirmationTimeoutMsg{RunID: "run-1"})
+	m = updated.(ChatModel)
+	if cmd != nil {
+		t.Error("a stale timeout must not produce a decision")
+	}
+	if m.confirmation != nil {
+		t.Error("a stale timeout must not resurrect the modal")
+	}
+}
+
+// Ctrl+C still works as the universal way out while a confirmation is up.
+func TestCtrlCWhilePendingConfirmationCancelsTheTurn(t *testing.T) {
+	m, _ := newTestModel(t)
+	m.streaming = true
+	cancelled := false
+	m.cancelFn = func() { cancelled = true }
+	m = feed(t, m, needsConfirmation(""))
+
+	updated, _ := m.handleKey(tea.KeyMsg{Type: tea.KeyCtrlC})
+	m = updated.(ChatModel)
+	if !cancelled {
+		t.Error("Ctrl+C must still cancel the turn while a confirmation is pending")
+	}
+	if m.confirmation != nil {
+		t.Error("Ctrl+C must take the confirmation down with the turn")
+	}
+	if m.streaming {
+		t.Error("the turn must be marked stopped")
+	}
+}

--- a/tui/internal/ui/chat/model.go
+++ b/tui/internal/ui/chat/model.go
@@ -120,6 +120,12 @@ type ChatModel struct {
 	// not to the composer.
 	question *components.QuestionModel
 
+	// confirmation is the pending needs_confirmation modal, if any. Non-nil
+	// means a destructive/external tool call is asking for approval — every
+	// key except Ctrl+C goes to it (including Esc, which means "deny" here,
+	// not "cancel the turn" — see handleKey).
+	confirmation *components.ConfirmationModel
+
 	connected    bool
 	totalSteps   int
 	initialQuery string
@@ -212,6 +218,7 @@ func (m ChatModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.events = nil
 		m.cancelFn = nil
 		m.question = nil
+		m.confirmation = nil
 		m.flushBuffer()
 		m.activity = nil
 		m.updateViewport()
@@ -222,6 +229,7 @@ func (m ChatModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.events = nil
 		m.cancelFn = nil
 		m.question = nil
+		m.confirmation = nil
 		m.err = msg.err
 		m.messages = append(m.messages, Message{
 			Role:    RoleError,
@@ -254,6 +262,45 @@ func (m ChatModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.updateViewport()
 		return m, nil
 
+	case components.ConfirmationTimeoutMsg:
+		if m.confirmation == nil {
+			// Already resolved (the run's own final/error got there first, the
+			// overwhelmingly common case against the current stateless email
+			// sidecar) or the turn moved on. Dropping is correct — nothing to warn.
+			return m, nil
+		}
+		c, cmd := m.confirmation.ResolveTimeout(msg)
+		m.confirmation = &c
+		return m, cmd
+
+	case components.ConfirmationDecidedMsg:
+		if m.confirmation == nil || m.confirmation.RunID() != msg.RunID {
+			// Stale — a decision for a confirmation that is no longer up (already
+			// resolved by the run ending first, or superseded). Drop it, same as a
+			// stale question answer.
+			return m, nil
+		}
+		return m.resolveConfirmationDecision(msg)
+
+	case confirmActionResultMsg:
+		word := "denied"
+		if msg.Approved {
+			word = "approved"
+		}
+		if msg.err != nil {
+			m.messages = append(m.messages, Message{
+				Role:    RoleError,
+				Content: fmt.Sprintf("could not deliver the %s decision for '%s': %v", word, msg.Action, msg.err),
+			})
+		} else {
+			m.messages = append(m.messages, Message{
+				Role:    RoleStatus,
+				Content: fmt.Sprintf("[!] %s decision for '%s' delivered", word, msg.Action),
+			})
+		}
+		m.updateViewport()
+		return m, nil
+
 	case spinner.TickMsg:
 		if m.streaming {
 			var cmd tea.Cmd
@@ -275,6 +322,16 @@ func (m ChatModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 }
 
 func (m ChatModel) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	// A pending confirmation owns the keyboard too, but UNLIKE a question, Esc
+	// belongs to it: the issue's contract is "Esc denies", not "Esc cancels the
+	// turn". Ctrl+C is still the universal way out.
+	if m.confirmation != nil && msg.Type != tea.KeyCtrlC {
+		c, cmd := m.confirmation.Update(msg)
+		m.confirmation = &c
+		m.updateViewport()
+		return m, cmd
+	}
+
 	// A pending question owns the keyboard: the run is blocked on it, so a
 	// keystroke that fell through to the composer would go nowhere. Ctrl+C and
 	// Esc still cancel the turn — abandoning a question must stay possible.
@@ -294,6 +351,7 @@ func (m ChatModel) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			m.cancelFn = nil
 			m.activity = nil
 			m.question = nil
+			m.confirmation = nil
 			m.messages = append(m.messages, Message{
 				Role:    RoleStatus,
 				Content: "cancelled",
@@ -311,6 +369,7 @@ func (m ChatModel) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			m.cancelFn = nil
 			m.activity = nil
 			m.question = nil
+			m.confirmation = nil
 			m.messages = append(m.messages, Message{
 				Role:    RoleStatus,
 				Content: "cancelled",
@@ -445,6 +504,7 @@ func (m *ChatModel) CancelActiveTurn() {
 	m.streaming = false
 	m.events = nil
 	m.question = nil
+	m.confirmation = nil
 }
 
 func (m ChatModel) handleEvent(evt interface{}) (tea.Model, tea.Cmd) {
@@ -631,6 +691,9 @@ func (m *ChatModel) resize() {
 	if m.question != nil {
 		m.question.SetWidth(m.cardWidth())
 	}
+	if m.confirmation != nil {
+		m.confirmation.SetWidth(m.cardWidth())
+	}
 	m.updateViewport()
 }
 
@@ -654,6 +717,11 @@ func (m *ChatModel) updateViewport() {
 	// blank screen reads as a hang.
 	if m.streaming {
 		sb.WriteString(m.renderLiveRegion())
+		sb.WriteString("\n")
+	}
+
+	if m.confirmation != nil {
+		sb.WriteString(m.confirmation.View())
 		sb.WriteString("\n")
 	}
 
@@ -889,6 +957,15 @@ func (m ChatModel) renderActivityItem(item ActivityItem) string {
 			return "  " + successStyle.Render("[ok] ") + toolNameStyle.Render(content)
 		}
 		return "  " + activityStyle.Render("[..] ") + toolNameStyle.Render(content)
+
+	case "confirm":
+		// Always added already-resolved (see resolveConfirmationDecision) — a
+		// confirmation has no separate "in progress" activity line, since the
+		// modal itself is the in-progress view.
+		if item.Success != nil && !*item.Success {
+			return "  " + failStyle.Render("[x] ") + toolNameStyle.Render(content)
+		}
+		return "  " + successStyle.Render("[ok] ") + toolNameStyle.Render(content)
 
 	case "status":
 		return "       " + lipgloss.NewStyle().Foreground(lipgloss.Color("214")).Render(content)

--- a/tui/internal/ui/components/confirmation.go
+++ b/tui/internal/ui/components/confirmation.go
@@ -1,0 +1,303 @@
+package components
+
+import (
+	"strings"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+)
+
+// RiskTier classifies a confirmation-gated action for the badge on the modal.
+//
+// Only Write and Destructive are ever reachable from a live
+// event.CanonicalNeedsConfirmationEvent: a `read` tool never asks for
+// confirmation in the first place (nothing to gate), and a tool the sidecar
+// refuses outright is a governance BLOCK, which rides the canonical `error`
+// event, not `needs_confirmation` (spec §6.2, `policy_alert` -> `error`). Read
+// and Denied are still real, tested values — this is a complete, reusable
+// classification, not one trimmed to fit only what the wire happens to send
+// today.
+type RiskTier int
+
+const (
+	RiskRead RiskTier = iota
+	RiskWrite
+	RiskDestructive
+	RiskDenied
+)
+
+var (
+	badgeReadStyle = lipgloss.NewStyle().Bold(true).
+			Foreground(lipgloss.Color("230")).Background(lipgloss.Color("114")).Padding(0, 1)
+	badgeWriteStyle = lipgloss.NewStyle().Bold(true).
+			Foreground(lipgloss.Color("230")).Background(lipgloss.Color("33")).Padding(0, 1)
+	badgeDestructiveStyle = lipgloss.NewStyle().Bold(true).
+				Foreground(lipgloss.Color("230")).Background(lipgloss.Color("196")).Padding(0, 1)
+	badgeDeniedStyle = lipgloss.NewStyle().Bold(true).
+				Foreground(lipgloss.Color("252")).Background(lipgloss.Color("238")).Padding(0, 1)
+)
+
+// Badge is the short label shown on the modal. Colour is decoration only —
+// each tier's word is also distinct, so the badge is legible with colour
+// stripped (the same accessibility rule components.QuestionModel documents).
+func (t RiskTier) Badge() string {
+	switch t {
+	case RiskRead:
+		return badgeReadStyle.Render("READ")
+	case RiskWrite:
+		return badgeWriteStyle.Render("WRITE")
+	case RiskDestructive:
+		return badgeDestructiveStyle.Render("DESTRUCTIVE")
+	case RiskDenied:
+		return badgeDeniedStyle.Render("BLOCKED")
+	default:
+		return badgeDeniedStyle.Render("UNKNOWN")
+	}
+}
+
+// confirmationRiskTiers classifies the nine tools the email agent gates on
+// confirmation (agent.CONFIRMATION_REQUIRED_TOOLS in
+// hub/agents/email/python/gaia_agent_email/agent.py). send/schedule/forward and
+// the calendar RSVP actions are Write — external or state-changing, but not
+// destructive on their own terms. permanent_delete and quarantine are
+// Destructive: one is irreversible by name, the other pulls a message out of
+// the inbox on the agent's own judgment about a security threat, where a false
+// positive hides real mail.
+var confirmationRiskTiers = map[string]RiskTier{
+	"send_now":                    RiskWrite,
+	"send_draft":                  RiskWrite,
+	"schedule_send":               RiskWrite,
+	"forward_message":             RiskWrite,
+	"accept_invite":               RiskWrite,
+	"decline_invite":              RiskWrite,
+	"create_event_from_email":     RiskWrite,
+	"permanent_delete":            RiskDestructive,
+	"quarantine_phishing_message": RiskDestructive,
+}
+
+// ClassifyActionRisk returns the risk tier for a confirmation-gated action
+// name. An action this client has never heard of still made the sidecar ask
+// for confirmation, so it defaults to the MORE cautious tier — failing open to
+// Write would understate a risk this build simply does not recognize yet.
+func ClassifyActionRisk(action string) RiskTier {
+	if tier, ok := confirmationRiskTiers[action]; ok {
+		return tier
+	}
+	return RiskDestructive
+}
+
+// ConfirmState is where a confirmation sits in its state machine:
+// pending -> approved / denied / timed-out. Once resolved it stays resolved —
+// see ConfirmationModel.Update.
+type ConfirmState int
+
+const (
+	ConfirmationPending ConfirmState = iota
+	ConfirmationApproved
+	ConfirmationDenied
+	ConfirmationTimedOut
+)
+
+// ConfirmationTimeout is how long the modal waits before auto-denying. Client-
+// side and independent of the transport: the current email sidecar's
+// stateless D1 stub ends the run with its own refusal within the same stream
+// read the `needs_confirmation` event arrived on (no server-side wait at all),
+// so this bound matters most for a future resume-model peer that genuinely
+// parks the run — see docs/spec/agent-ui-query-sse-contract.md §5.
+const ConfirmationTimeout = 30 * time.Second
+
+// ConfirmationTimeoutMsg is the client-side auto-deny tick for one
+// confirmation. RunID lets a stale timer — left over from a confirmation that
+// already resolved, or was superseded by a newer one on the same run — be
+// told apart from the one it was started for.
+type ConfirmationTimeoutMsg struct{ RunID string }
+
+// StartConfirmationTimeout schedules the auto-deny tick for one confirmation.
+func StartConfirmationTimeout(runID string) tea.Cmd {
+	return tea.Tick(ConfirmationTimeout, func(time.Time) tea.Msg {
+		return ConfirmationTimeoutMsg{RunID: runID}
+	})
+}
+
+// ConfirmationDecidedMsg is emitted once a confirmation resolves — by key or
+// by the 30s timeout — carrying what the caller needs to record the outcome
+// and, when a live channel exists, deliver it.
+type ConfirmationDecidedMsg struct {
+	RunID  string
+	Action string
+	// ConfirmURL is only ever non-empty under the resume model (spec §5),
+	// which no shipped sidecar implements today — see the doc comment on
+	// ConfirmationModel.
+	ConfirmURL string
+	Approved   bool
+	// TimedOut records that the decision came from the 30s auto-deny rather
+	// than an explicit 'n'/Esc, so the caller can show the distinct warning
+	// the issue's acceptance criteria require.
+	TimedOut bool
+}
+
+// ConfirmationModel renders a needs_confirmation pause: the gated action, its
+// summary, a risk-tier badge, and a y/n/Esc prompt that auto-denies after
+// ConfirmationTimeout.
+//
+// Approving here does not by itself deliver anything. The shipping email
+// sidecar's `/query` contract is the stateless stop-and-hand-off model (spec
+// §5, D1): `needs_confirmation` is immediately followed, in the same stream
+// read, by a synthesized `final` refusal — there is no server-side pause and
+// no confirm endpoint to resume it (`ConfirmURL` is always empty). Denying is
+// therefore always real (nothing was ever going to be sent either way);
+// approving only becomes real delivery once a peer implements the resume
+// model documented in the spec — the caller checks ConfirmURL before treating
+// Approved as anything more than the user's recorded intent. Inventing a fake
+// delivery path here is exactly the mistake ui/oneshot.go's writeWithheld
+// already documents avoiding for the one-shot surface.
+type ConfirmationModel struct {
+	runID      string
+	action     string
+	summary    string
+	confirmURL string
+	tier       RiskTier
+	state      ConfirmState
+	width      int
+}
+
+// NewConfirmationModel builds the modal for one needs_confirmation event.
+func NewConfirmationModel(runID, action, summary, confirmURL string) ConfirmationModel {
+	return ConfirmationModel{
+		runID:      runID,
+		action:     action,
+		summary:    summary,
+		confirmURL: confirmURL,
+		tier:       ClassifyActionRisk(action),
+		state:      ConfirmationPending,
+		width:      76,
+	}
+}
+
+func (m ConfirmationModel) RunID() string       { return m.runID }
+func (m ConfirmationModel) Action() string      { return m.action }
+func (m ConfirmationModel) State() ConfirmState { return m.state }
+func (m ConfirmationModel) Tier() RiskTier      { return m.tier }
+func (m ConfirmationModel) Pending() bool       { return m.state == ConfirmationPending }
+
+// confirmationBorderCols is how many columns the rounded border itself adds
+// (1 left + 1 right) on top of the style's Width — which lipgloss treats as
+// the padded-content box, border excluded. Left uncorrected, a modal asked
+// for width w renders at w+2, quietly breaking the "fits the terminal"
+// contract at exactly the edge a narrow pane most needs it — see #2518, the
+// ragged-wrap defect in a neighbouring card this modal must not repeat.
+const confirmationBorderCols = 2
+
+// SetWidth fits the panel to w: View() never renders a line wider than w.
+func (m *ConfirmationModel) SetWidth(w int) {
+	if w < 24 {
+		w = 24
+	}
+	m.width = w
+}
+
+// Update handles one key while the confirmation is pending. Only y/Y (approve)
+// and n/N/Esc (deny) resolve it; every other key is swallowed so nothing
+// approves — or denies — by accident. Once resolved, further input is a no-op:
+// a decision is made once.
+func (m ConfirmationModel) Update(msg tea.Msg) (ConfirmationModel, tea.Cmd) {
+	if m.state != ConfirmationPending {
+		return m, nil
+	}
+	key, ok := msg.(tea.KeyMsg)
+	if !ok {
+		return m, nil
+	}
+	switch key.String() {
+	case "y", "Y":
+		return m.decide(ConfirmationApproved, false)
+	case "n", "N", "esc":
+		return m.decide(ConfirmationDenied, false)
+	}
+	return m, nil
+}
+
+// ResolveTimeout applies the 30s auto-deny, but only if this confirmation is
+// still pending and msg was started for THIS run — a stale timer for an
+// already-resolved or superseded confirmation must not fire a second decision.
+func (m ConfirmationModel) ResolveTimeout(msg ConfirmationTimeoutMsg) (ConfirmationModel, tea.Cmd) {
+	if m.state != ConfirmationPending || msg.RunID != m.runID {
+		return m, nil
+	}
+	return m.decide(ConfirmationDenied, true)
+}
+
+func (m ConfirmationModel) decide(state ConfirmState, timedOut bool) (ConfirmationModel, tea.Cmd) {
+	if timedOut {
+		state = ConfirmationTimedOut
+	}
+	m.state = state
+	decided := ConfirmationDecidedMsg{
+		RunID:      m.runID,
+		Action:     m.action,
+		ConfirmURL: m.confirmURL,
+		Approved:   state == ConfirmationApproved,
+		TimedOut:   timedOut,
+	}
+	return m, func() tea.Msg { return decided }
+}
+
+var (
+	confirmationPanelStyle = lipgloss.NewStyle().
+				Border(lipgloss.RoundedBorder()).
+				BorderForeground(lipgloss.Color("196")).
+				Padding(0, 1)
+
+	confirmationTitleStyle = lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("196"))
+	confirmationBodyStyle  = lipgloss.NewStyle().Foreground(lipgloss.Color("252"))
+	confirmationWarnStyle  = lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("214"))
+	confirmationHintStyle  = lipgloss.NewStyle().Foreground(lipgloss.Color("243")).Italic(true)
+	confirmationOkStyle    = lipgloss.NewStyle().Foreground(lipgloss.Color("42"))
+	confirmationNoStyle    = lipgloss.NewStyle().Foreground(lipgloss.Color("196"))
+)
+
+// View renders the panel. Wrapping happens here and only here, exactly like
+// QuestionModel.View — handing the wrapped result to a width-constrained style
+// as well would re-wrap already-wrapped lines and shear the border.
+func (m ConfirmationModel) View() string {
+	inner := m.width - 4
+	if inner < 16 {
+		inner = 16
+	}
+
+	var lines []string
+	lines = append(lines, m.tier.Badge()+" "+confirmationTitleStyle.Render("Confirm: "+m.action))
+	lines = append(lines, "")
+
+	summary := m.summary
+	if summary == "" {
+		summary = "Run '" + m.action + "'?"
+	}
+	lines = append(lines, confirmationBodyStyle.Render(WrapText(summary, inner)))
+
+	if m.tier == RiskDestructive {
+		lines = append(lines, "")
+		lines = append(lines, confirmationWarnStyle.Render(WrapText(
+			"This is a destructive action and may not be reversible.", inner)))
+	}
+
+	lines = append(lines, "")
+	lines = append(lines, m.resultOrHint(inner))
+
+	return confirmationPanelStyle.Width(m.width - confirmationBorderCols).Render(strings.Join(lines, "\n"))
+}
+
+func (m ConfirmationModel) resultOrHint(inner int) string {
+	switch m.state {
+	case ConfirmationApproved:
+		return confirmationOkStyle.Render("approved")
+	case ConfirmationDenied:
+		return confirmationNoStyle.Render("denied")
+	case ConfirmationTimedOut:
+		return confirmationWarnStyle.Render(WrapText("timed out after 30s with no response — denied", inner))
+	default:
+		return confirmationHintStyle.Render(WrapText(
+			"y approve · n/esc deny · auto-denies in 30s if you do nothing", inner))
+	}
+}

--- a/tui/internal/ui/components/confirmation_test.go
+++ b/tui/internal/ui/components/confirmation_test.go
@@ -1,0 +1,292 @@
+package components
+
+import (
+	"strconv"
+	"strings"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+// --- state machine: pending -> approved / denied / timed-out ---------------
+
+func TestConfirmationStartsPending(t *testing.T) {
+	m := NewConfirmationModel("run-1", "send_draft", "Send reply to alice@example.com", "")
+	if !m.Pending() {
+		t.Fatalf("state = %v, want Pending", m.State())
+	}
+}
+
+func TestConfirmationYApproves(t *testing.T) {
+	m := NewConfirmationModel("run-1", "send_draft", "Send reply to alice@example.com", "")
+	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("y")})
+	if updated.State() != ConfirmationApproved {
+		t.Errorf("state = %v, want Approved", updated.State())
+	}
+	if cmd == nil {
+		t.Fatal("approving produced no command")
+	}
+	msg, ok := cmd().(ConfirmationDecidedMsg)
+	if !ok {
+		t.Fatalf("expected ConfirmationDecidedMsg, got %#v", cmd())
+	}
+	if !msg.Approved || msg.TimedOut {
+		t.Errorf("decided msg = %+v, want Approved=true TimedOut=false", msg)
+	}
+	if msg.RunID != "run-1" || msg.Action != "send_draft" {
+		t.Errorf("decided msg lost identity: %+v", msg)
+	}
+}
+
+func TestConfirmationCapitalYApproves(t *testing.T) {
+	m := NewConfirmationModel("run-1", "send_draft", "", "")
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("Y")})
+	if updated.State() != ConfirmationApproved {
+		t.Errorf("state = %v, want Approved", updated.State())
+	}
+}
+
+func TestConfirmationNDenies(t *testing.T) {
+	m := NewConfirmationModel("run-1", "permanent_delete", "Delete the message from spam@example.com", "")
+	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("n")})
+	if updated.State() != ConfirmationDenied {
+		t.Errorf("state = %v, want Denied", updated.State())
+	}
+	msg := cmd().(ConfirmationDecidedMsg)
+	if msg.Approved {
+		t.Error("'n' must never approve")
+	}
+}
+
+func TestConfirmationEscDenies(t *testing.T) {
+	m := NewConfirmationModel("run-1", "permanent_delete", "", "")
+	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEsc})
+	if updated.State() != ConfirmationDenied {
+		t.Errorf("state = %v, want Denied", updated.State())
+	}
+	msg := cmd().(ConfirmationDecidedMsg)
+	if msg.Approved {
+		t.Error("Esc must never approve")
+	}
+}
+
+// No other key may approve or deny by accident — a stray keystroke while the
+// user is mid-thought must not silently make an irreversible decision.
+func TestConfirmationOtherKeysDoNothing(t *testing.T) {
+	for _, key := range []tea.KeyMsg{
+		{Type: tea.KeyRunes, Runes: []rune("x")},
+		{Type: tea.KeyRunes, Runes: []rune("1")},
+		{Type: tea.KeyRunes, Runes: []rune(" ")},
+		{Type: tea.KeyEnter},
+		{Type: tea.KeyTab},
+		{Type: tea.KeyUp},
+	} {
+		m := NewConfirmationModel("run-1", "send_draft", "", "")
+		updated, cmd := m.Update(key)
+		if updated.State() != ConfirmationPending {
+			t.Errorf("key %v resolved the confirmation to %v; only y/n/esc may", key, updated.State())
+		}
+		if cmd != nil {
+			t.Errorf("key %v produced a command; only y/n/esc may", key)
+		}
+	}
+}
+
+func TestConfirmationTimeoutDeniesWithWarning(t *testing.T) {
+	m := NewConfirmationModel("run-1", "send_now", "Send to bob@example.com", "")
+	updated, cmd := m.ResolveTimeout(ConfirmationTimeoutMsg{RunID: "run-1"})
+	if updated.State() != ConfirmationTimedOut {
+		t.Fatalf("state = %v, want TimedOut", updated.State())
+	}
+	if cmd == nil {
+		t.Fatal("the timeout produced no decision")
+	}
+	msg := cmd().(ConfirmationDecidedMsg)
+	if msg.Approved {
+		t.Error("a timeout must never resolve to approved")
+	}
+	if !msg.TimedOut {
+		t.Error("the decision must record that it came from the timeout, so the UI can warn")
+	}
+}
+
+// A timer for a DIFFERENT (superseded) confirmation must never resolve this one.
+func TestConfirmationTimeoutIgnoresAnotherRun(t *testing.T) {
+	m := NewConfirmationModel("run-1", "send_now", "", "")
+	updated, cmd := m.ResolveTimeout(ConfirmationTimeoutMsg{RunID: "run-2"})
+	if updated.State() != ConfirmationPending {
+		t.Errorf("state = %v, want still Pending (the timer was for a different run)", updated.State())
+	}
+	if cmd != nil {
+		t.Error("a stale timer must not produce a decision")
+	}
+}
+
+// Once resolved, further keys and a late timeout are no-ops — a decision is
+// made once.
+func TestConfirmationResolvedIgnoresFurtherInput(t *testing.T) {
+	m := NewConfirmationModel("run-1", "send_now", "", "")
+	m, _ = m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("y")})
+	if m.State() != ConfirmationApproved {
+		t.Fatalf("setup: state = %v, want Approved", m.State())
+	}
+
+	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("n")})
+	if updated.State() != ConfirmationApproved {
+		t.Errorf("a resolved confirmation flipped to %v on a further key", updated.State())
+	}
+	if cmd != nil {
+		t.Error("a resolved confirmation must not emit a second decision")
+	}
+
+	updated, cmd = m.ResolveTimeout(ConfirmationTimeoutMsg{RunID: "run-1"})
+	if updated.State() != ConfirmationApproved {
+		t.Errorf("a resolved confirmation flipped to %v on a late timeout", updated.State())
+	}
+	if cmd != nil {
+		t.Error("a resolved confirmation must not emit a second decision from a late timeout")
+	}
+}
+
+// --- risk tiers --------------------------------------------------------
+
+func TestClassifyActionRiskKnownActions(t *testing.T) {
+	for action, want := range map[string]RiskTier{
+		"send_now":                    RiskWrite,
+		"send_draft":                  RiskWrite,
+		"schedule_send":               RiskWrite,
+		"forward_message":             RiskWrite,
+		"accept_invite":               RiskWrite,
+		"decline_invite":              RiskWrite,
+		"create_event_from_email":     RiskWrite,
+		"permanent_delete":            RiskDestructive,
+		"quarantine_phishing_message": RiskDestructive,
+	} {
+		if got := ClassifyActionRisk(action); got != want {
+			t.Errorf("ClassifyActionRisk(%q) = %v, want %v", action, got, want)
+		}
+	}
+}
+
+// An action this client has never heard of still gated the sidecar on
+// confirmation, so it gets the MORE cautious tier, not less.
+func TestClassifyActionRiskUnknownDefaultsToDestructive(t *testing.T) {
+	if got := ClassifyActionRisk("some_future_tool"); got != RiskDestructive {
+		t.Errorf("unknown action classified as %v, want RiskDestructive (fail cautious)", got)
+	}
+}
+
+// Risk-tier -> badge/appearance mapping for all four tiers, including the two
+// (Read, Denied) that a live needs_confirmation event never actually carries —
+// the type is a complete, reusable classification, not one built to fit only
+// what the wire happens to send today.
+func TestRiskTierBadgesAreDistinctForAllFourTiers(t *testing.T) {
+	badges := map[RiskTier]string{}
+	for _, tier := range []RiskTier{RiskRead, RiskWrite, RiskDestructive, RiskDenied} {
+		b := tier.Badge()
+		if strings.TrimSpace(b) == "" {
+			t.Errorf("tier %v has an empty badge", tier)
+		}
+		badges[tier] = b
+	}
+	seen := map[string]RiskTier{}
+	for tier, b := range badges {
+		if other, dup := seen[b]; dup {
+			t.Errorf("tiers %v and %v render the same badge %q", tier, other, b)
+		}
+		seen[b] = tier
+	}
+}
+
+func TestRiskTierBadgeWords(t *testing.T) {
+	for tier, want := range map[RiskTier]string{
+		RiskRead:        "READ",
+		RiskWrite:       "WRITE",
+		RiskDestructive: "DESTRUCTIVE",
+		RiskDenied:      "BLOCKED",
+	} {
+		if b := tier.Badge(); !strings.Contains(b, want) {
+			t.Errorf("Badge() for %v = %q, want it to contain %q", tier, b, want)
+		}
+	}
+}
+
+// --- rendering -----------------------------------------------------------
+
+func TestConfirmationViewShowsActionSummaryAndBadge(t *testing.T) {
+	m := NewConfirmationModel("run-1", "send_draft", `Send reply to alice@example.com — subject "Re: invoice"?`, "")
+	view := stripANSI(m.View())
+	for _, want := range []string{"send_draft", "alice@example.com", "WRITE"} {
+		if !strings.Contains(view, want) {
+			t.Errorf("view missing %q:\n%s", want, view)
+		}
+	}
+}
+
+// The destructive tier carries a visible extra warning the write tier does not.
+func TestDestructiveTierShowsExtraWarning(t *testing.T) {
+	write := stripANSI(NewConfirmationModel("run-1", "send_draft", "x", "").View())
+	destructive := stripANSI(NewConfirmationModel("run-1", "permanent_delete", "x", "").View())
+
+	if strings.Contains(write, "cannot be") {
+		t.Errorf("write tier should not show the irreversibility warning:\n%s", write)
+	}
+	if !strings.Contains(destructive, "cannot be") && !strings.Contains(destructive, "not be reversible") {
+		t.Errorf("destructive tier must show an extra warning:\n%s", destructive)
+	}
+}
+
+func TestConfirmationHintNamesTheKeysAndTimeout(t *testing.T) {
+	view := stripANSI(NewConfirmationModel("run-1", "send_draft", "x", "").View())
+	for _, want := range []string{"y approve", "n/esc deny", "30s"} {
+		if !strings.Contains(view, want) {
+			t.Errorf("hint missing %q:\n%s", want, view)
+		}
+	}
+}
+
+// Rendering at a narrow width must not panic and must not wrap raggedly — every
+// line at or under the effective width (see #2518, a ragged-wrap defect in a
+// neighbouring card this modal must not repeat). SetWidth floors at 24 — below
+// that a bordered, padded panel has no room left for readable text — so a
+// request under the floor is checked against the floor, not the raw ask.
+func TestConfirmationRendersLegiblyAtNarrowWidths(t *testing.T) {
+	for _, width := range []int{20, 24, 32, 40, 60, 80} {
+		t.Run(strconv.Itoa(width), func(t *testing.T) {
+			defer func() {
+				if r := recover(); r != nil {
+					t.Fatalf("View() panicked at width %d: %v", width, r)
+				}
+			}()
+			effective := width
+			if effective < 24 {
+				effective = 24
+			}
+			m := NewConfirmationModel("run-1", "permanent_delete",
+				"Permanently delete the message from a-very-long-sender-address@example-corp.com with subject "+
+					`"Re: Re: Re: quarterly numbers and the follow up nobody asked for"?`, "")
+			m.SetWidth(width)
+			view := stripANSI(m.View())
+			for _, line := range strings.Split(view, "\n") {
+				if w := len([]rune(line)); w > effective {
+					t.Errorf("width %d (effective %d): line is %d cols: %q", width, effective, w, line)
+				}
+			}
+		})
+	}
+}
+
+func TestConfirmationViewDoesNotPanicWhenResolved(t *testing.T) {
+	for _, state := range []ConfirmState{ConfirmationApproved, ConfirmationDenied, ConfirmationTimedOut} {
+		m := NewConfirmationModel("run-1", "send_draft", "x", "")
+		switch state {
+		case ConfirmationApproved:
+			m, _ = m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("y")})
+		case ConfirmationDenied:
+			m, _ = m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("n")})
+		case ConfirmationTimedOut:
+			m, _ = m.ResolveTimeout(ConfirmationTimeoutMsg{RunID: "run-1"})
+		}
+		_ = m.View() // must not panic
+	}
+}

--- a/tui/internal/ui/oneshot.go
+++ b/tui/internal/ui/oneshot.go
@@ -458,10 +458,13 @@ func finishOneShot(res OneShotResult, tools *toolLedger, query string, errW io.W
 }
 
 // writeWithheld says what was not done, and does not invent a way to approve
-// it. The interactive chat cannot answer a gate either (ui/chat: "the approval
-// UI is a later phase"), and the agent's own final answer already explains the
-// route for that agent — naming a command that does not exist is how four wrong
-// remedies got shipped today.
+// it. A --query run has no session for anyone to answer a gate on, full stop.
+// The interactive chat does now have a real y/n/Esc modal (ui/chat/canonical.go,
+// components.ConfirmationModel), but it cannot DELIVER an approval either
+// against the current sidecar contract — needs_confirmation is immediately
+// terminal with no confirm_url (spec §5, D1 unsigned) — so naming a command
+// that does not exist would be the same mistake either surface can make; the
+// agent's own final answer already explains the route for that agent.
 func writeWithheld(w io.Writer, actions []string, exitCode int, confirmURL func(string) string) {
 	fmt.Fprintf(w,
 		"⛔ %s needed approval and a --query run has no way to give it, so it was NOT "+


### PR DESCRIPTION
Before: the TUI's chat view had no way to approve a destructive or external action (send, delete, forward, quarantine, calendar RSVP) — `needs_confirmation` rendered as a plain status line and the run just ended, so send did not work at all from the terminal. After: a real y/n/Esc modal shows the gated action, a risk-tier badge (write vs. destructive, with an extra warning), and auto-denies with a warning after 30s if nobody answers. Getting an assistant to actually drive and evidence that modal needed a second, smaller fix: the TUI's loopback control API silently ignored `--control`/`--control-port` on the `--agent` launch paths, so nothing could attach to a session to see it.

- `--control`/`--control-port` on `chat --agent` and `run <id>` (#2512): the flag was accepted and silently dropped — no port bound, nothing printed, no discovery file written. It now binds on the interactive path (mirroring the bare root command and `chat --subprocess`), and `--query` combined with `--control` is a loud refusal instead of a silent no-op, since a one-shot has no session to attach to.
- The confirmation modal (#1170): state machine (pending → approved/denied/timed-out), y/n/Esc keys with no accidental approval from any other key, risk-tier badges, and narrow-width rendering (fixed a real lipgloss off-by-2 border bug along the way). Denying is always real — nothing was ever going to be sent either way under the sidecar's current stateless contract. Approving is reported honestly rather than faked: the shipping email sidecar ends every `needs_confirmation` with an immediate `final` refusal and no resume endpoint exists anywhere server-side (spec D1 is unsigned), so there is nothing to deliver an approval to today — the client is wired for the documented resume model (`confirm_url`) so it isn't the blocker once #2212 (the server-side wire mechanic) lands.

## Test plan
- [x] `cd tui && go test ./...` — all packages pass
- [x] `go vet ./...` — clean
- [x] `go build -o bin/gaia ./cmd/gaia` succeeds; cross-compiles clean for `windows/amd64` and `linux/arm64` (CI's matrix)
- [x] Manual: `gaia tui chat --agent email --control-port 8815` now prints `control API listening on 127.0.0.1:8815 — token in ~/.gaia/tui/control.json` (previously silent) — full interactive drive needs a real TTY, out of scope for this sandbox
- [x] Manual: `gaia tui chat --agent email --query "hi" --control-port 8815` now refuses loudly instead of silently ignoring `--control`
- [ ] Live evidence of the modal itself (drive via the control API, approve/deny/timeout on real mail) — orchestrator to capture per the task handoff

Closes #1170
Closes #2512