### PR TITLE
feat(email-agent): broaden autonomy candidates, add undo surface and per-message decisions

### DIFF
--- a/hub/agents/email/npm/CHANGELOG.md
+++ b/hub/agents/email/npm/CHANGELOG.md
@@ -6,6 +6,20 @@ behind any entry — API shapes, endpoints, and version semantics — see
 
 ## Unreleased
 
+- **Full autonomy now does more than archive, explains its decisions, and can be undone.**
+  Previously the proactive `earn_trust`/`full` loop only ever archived low-signal mail —
+  every other reversible action the trust model already declared (marking mail read,
+  starring, labeling) was unreachable, the run report never said *why* a message was held
+  back, and there was no way to undo an auto-executed action other than the archive-only
+  `undo_archive_batch` tool. Now: FYI mail is marked read instead of archived (it stays
+  visible, just no longer sits unread); `POST /v1/email/agent/autonomy/run` returns a new
+  `decisions[]` field explaining every candidate's outcome and reason, including "held back
+  for confirmation" and "held back — provider-flagged IMPORTANT"; and a new
+  `POST /v1/email/agent/autonomy/undo` reverses any auto-executed action and records the
+  correction against its trust scope, the same negative-feedback loop `undo_archive_batch`
+  already gave archives. The destructive floor (send/forward/permanent-delete/RSVP/quarantine)
+  is unaffected — it was already inviolable and stays that way at every level (#2529).
+
 - **The agent sets up your mailbox itself, in the conversation.** Before, hitting
   the email agent without a working mailbox produced an error and a shell command
   to go run somewhere else — a dead end for anyone in a terminal or chat window.

--- a/hub/agents/email/npm/SKILL.md
+++ b/hub/agents/email/npm/SKILL.md
@@ -281,10 +281,12 @@ session — an overlapping `/query` returns **409**. See `SPEC.md` for the full 
 
 ### Full autonomy (`/v1/email/agent/autonomy/*`)
 
-The agent can run **proactively** at the `earn_trust` level: it archives low-signal mail
-on its own **where your explicit preferences already sanction it** (a low-priority sender,
-or a category you default to archive), drafts replies for review, and **always asks before
-anything destructive** (send / forward / permanent-delete / RSVP).
+The agent can run **proactively** at the `earn_trust` level: it archives low-signal
+(promotional/spam) mail and marks FYI mail read on its own **where your explicit
+preferences already sanction it** (a low-priority sender, or a category you default to
+archive) or a sender/category has earned enough trust, and **always asks before anything
+destructive** (send / forward / permanent-delete / RSVP) — reply drafting is not yet wired
+into this proactive loop (the policy layer supports it, but no candidate reaches it today).
 Turn it on and inspect the earned trust:
 
 ```js
@@ -299,19 +301,23 @@ const r = await fetch(`${base}/v1/email/agent/autonomy/run`, {
   method: "POST", headers: { "content-type": "application/json" },
   body: JSON.stringify({ session_id: "s1", max_messages: 25 }),
 });
-const report = await r.json();   // { level, executed:[…], proposals:[…], skipped }
+const report = await r.json();
+// { level, executed:[…], proposals:[…], decisions:[…], skipped }
+// decisions[] explains EVERY candidate considered: { message_id, tool, action, outcome, reason, sender }
 
 // Inspect the earned-trust ledger — autonomy is never a black box
 const status = await (await fetch(`${base}/v1/email/agent/autonomy/s1`)).json();
 // { level, enabled, trust_min_samples, trust_threshold, trusted_scope_count, scopes:[…] }
 ```
 
-The agent **learns from your corrections**: undoing an auto-archive (`undo_archive_batch`)
-is captured as a negative outcome that pulls the sender/category back below the trust bar.
-(Positive-outcome accrual — trust *rising* as suggestions are accepted or left standing —
-is not yet wired, so today the ledger only ratchets trust down.) Every auto-action is
-reversible with undo. A bad `level` returns **400**; an unknown
-session returns **404**.
+The agent **learns from your corrections**: undoing an auto-executed action —
+`POST /v1/email/agent/autonomy/undo` with `{ session_id, action_id }` from the `executed[]`
+entry, or the conversational `undo_archive_batch` tool for a batch archive — is captured as
+a negative outcome that pulls the sender/category back below the trust bar. (Positive-outcome
+accrual — trust *rising* as suggestions are accepted or left standing — is not yet wired, so
+today the ledger only ratchets trust down.) Every auto-action is reversible with undo. A bad
+`level` returns **400**; an unknown session returns **404**; undoing an unknown/expired
+`action_id` returns **409**.
 
 ## Running in a server / long-lived app
 

--- a/hub/agents/email/npm/SPEC.md
+++ b/hub/agents/email/npm/SPEC.md
@@ -246,21 +246,25 @@ emits the canonical event vocabulary.
 | `GET /v1/email/agent/memory/{id}` | Memory status without changing it. |
 | `GET /v1/email/agent/autonomy/{id}` | Inspectable autonomy status: `{ level, enabled, trust_min_samples, trust_threshold, trusted_scope_count, scopes[] }` — the earned-trust ledger, never a black box. |
 | `POST /v1/email/agent/autonomy` | Set the autonomy level, `{ session_id, level }` where level ∈ `off` \| `suggest` \| `earn_trust` \| `full` (`off` = kill switch). Bad level → **400**. |
-| `POST /v1/email/agent/autonomy/run` | Trigger one observe→decide→act cycle, `{ session_id, max_messages? }` → `{ level, executed[], proposals[], skipped }`. The daemon clock / scheduler drives this in production. |
+| `POST /v1/email/agent/autonomy/run` | Trigger one observe→decide→act cycle, `{ session_id, max_messages? }` → `{ level, executed[], proposals[], decisions[], skipped }`. `decisions[]` (#2529) is a per-message log — `{ message_id, tool, action, outcome, reason, sender }` for every candidate considered, whatever the outcome — so a held-back decision (importance guard, confirm floor) is explained, not silent. The daemon clock / scheduler drives this in production. |
+| `POST /v1/email/agent/autonomy/undo` | Reverse one auto-executed action and record the correction against its trust scope, `{ session_id, action_id }` → `{ action_id, action_type, message_id, undone, correction_captured }` (#2529). `action_id` comes from a prior `executed[]` entry. Unknown/expired/already-undone id → **409**; an action_type with no reversal implemented → **400**. `correction_captured` is `false` (mutation still reversed) when `action_id` wasn't an autonomy-executed action. |
 
 Sessions are in-process and single-tenant (the sidecar hosts one user's agent); one turn
 runs at a time per session. Memory uses FAISS locally; embeddings still go over Lemonade
 HTTP, so the frozen binary stays free of torch/transformers.
 
 **Full autonomy (earn-trust).** At `earn_trust` the agent auto-executes only *reversible*
-actions (archive/label/mark-read), and only where your explicit preferences sanction it
+actions — today `archive` (promotional/spam mail) and `mark_read` (FYI mail: useful context
+stays visible, but doesn't sit unread) — and only where your explicit preferences sanction it
 (a low-priority sender, or a category defaulted to archive) or a sender/category has crossed
 the trust bar (`autonomy_trust_min_samples` decisions at ≥ `autonomy_trust_threshold`
 accuracy); everything else is proposed. The destructive floor — send, forward,
 permanent-delete, RSVP, quarantine — **always requires confirmation, at every level**.
-Undoing an auto-action feeds the trust ledger as a correction (a negative outcome), so
-trust ratchets *down* on a mistake; positive-outcome accrual that would let a scope cross
-the bar through earned trust is not yet wired. See `docs/plans/email-full-autonomy.mdx`.
+Undoing an auto-action — via `POST .../autonomy/undo`, or the conversational
+`undo_archive_batch` tool for a batch archive — feeds the trust ledger as a correction (a
+negative outcome), so trust ratchets *down* on a mistake; positive-outcome accrual that would
+let a scope cross the bar through earned trust is not yet wired. See
+`docs/plans/email-full-autonomy.mdx`.
 
 ### Mailbox actions (archive / quarantine, schema 2.1)
 

--- a/hub/agents/email/python/CAPABILITY_MATRIX.md
+++ b/hub/agents/email/python/CAPABILITY_MATRIX.md
@@ -76,7 +76,7 @@ python hub/agents/email/python/packaging/capability_matrix.py
   - `followups`: enforce=False, acceptance_enforce=None, wired=False
   - `perf`: enforce=False, acceptance_enforce=None, wired=True
   - `quality`: enforce=False, acceptance_enforce=True, wired=True
-- Additionally served but **out of the frozen contract** (footnote context, not guarded machinery): `agent_routes.py` 8 session routes, `connector_routes.py` 4 OAuth routes, `server.py` 2 inline probes -- ~36 total routes served by the sidecar.
+- Additionally served but **out of the frozen contract** (footnote context, not guarded machinery): `agent_routes.py` 12 session routes (includes the autonomy control surface, #2529), `connector_routes.py` 4 OAuth routes, `server.py` 2 inline probes -- ~43 total routes served by the sidecar.
 
 ## MCP Scope Decision
 

--- a/hub/agents/email/python/CHANGELOG.md
+++ b/hub/agents/email/python/CHANGELOG.md
@@ -9,6 +9,24 @@ contract version is tracked separately as
 
 ### Added
 
+- **The autonomy trust model can now be exercised end to end — broader candidates, an undo
+  surface, and per-message decisions (#2529).** The proactive `earn_trust`/`full` loop's
+  candidate generator (`_autonomy_candidate`) only ever proposed `archive`, so the rest of
+  the declared reversible-action set, the nine-tool confirm floor, and the importance guard
+  were unreachable and unverifiable from outside. Now: FYI mail maps to `mark_read` instead
+  of `archive` (useful context stays visible, but no longer sits unread — PROMOTIONAL/spam
+  mail is unaffected, it still archives); `_run_email_autonomy_cycle`'s report gains a
+  `decisions` list — one entry per candidate considered (`message_id`, `tool`, `action`,
+  `outcome`, `reason`, `sender`) — so a held-back decision explains itself instead of only
+  being counted; and a new `EmailTriageAgent.undo_autonomy_action(action_id)` (exposed as
+  `POST /v1/email/agent/autonomy/undo`) reverses any auto-executed action and records a
+  negative outcome against its trust scope, generalizing the archive-only
+  `undo_archive_batch` correction path via a new `organize_tools.undo_reversible_action_impl`
+  and two pure `trust.py` functions (`record_autonomy_outcome`, `note_autonomy_undo`) that
+  `EmailTriageAgent`'s existing methods now delegate to. The confirm floor is unchanged and
+  still inviolable at every level — broadening the candidate map cannot make a floor tool
+  auto-executable.
+
 - **Agent-led mailbox onboarding — the agent sets up its own access, in the
   conversation (#2469).** Hitting the agent without a usable mailbox used to
   end the run with an error and a shell command

--- a/hub/agents/email/python/gaia_agent_email/agent.py
+++ b/hub/agents/email/python/gaia_agent_email/agent.py
@@ -1293,10 +1293,16 @@ class EmailTriageAgent(
     def _autonomy_candidate(row: Dict[str, Any]) -> Optional[tuple]:
         """Map a triage result to a candidate ``(tool, action_type)`` or None.
 
-        Phase 2 only proposes/auto-executes the clearest reversible action —
-        archiving low-signal mail (promotional / FYI / spam). Phishing is left
-        to the ``quarantine_phishing_message`` floor tool; urgent / needs-response
-        / personal mail is never auto-touched. Reply drafting lands in Phase 3.
+        Spam and promotional mail are low-value clutter — archiving removes
+        them from the inbox. FYI mail is different: it's useful context worth
+        keeping visible, so it is never archived here, but it also needs no
+        reply, so mark_read clears the unread flag without hiding it (#2529 —
+        closes the gap between this map and the broader
+        ``trust.REVERSIBLE_AUTO_ACTIONS`` set the trust model already
+        declares). Phishing is left to the ``quarantine_phishing_message``
+        floor tool; urgent / needs-response / personal mail is never
+        auto-touched by ANY candidate, not just archive. Reply drafting lands
+        in a future phase.
         """
         from gaia_agent_email.tools.triage_heuristics import (
             CATEGORY_FYI,
@@ -1306,8 +1312,10 @@ class EmailTriageAgent(
         if row.get("is_phishing"):
             return None
         category = (row.get("category") or "").strip().upper()
-        if row.get("is_spam") or category in (CATEGORY_FYI, CATEGORY_PROMOTIONAL):
+        if row.get("is_spam") or category == CATEGORY_PROMOTIONAL:
             return ("archive_message", "archive")
+        if category == CATEGORY_FYI:
+            return ("mark_read", "mark_read")
         return None
 
     def _run_email_autonomy_cycle(
@@ -1322,6 +1330,14 @@ class EmailTriageAgent(
         ``proposals`` list holds ``Proposal`` objects the caller persists via
         :meth:`propose`. Kept side-effect-pure of GoalStore so it is unit-testable
         without touching ``~/.gaia/goals.db``.
+
+        ``report["decisions"]`` (#2529) is a per-message observability log —
+        one entry for every row that produced a candidate, whatever the
+        outcome (auto/draft/suggest/confirm) — so the guards that decide
+        NOT to act (the confirm floor, the importance guard) are as visible
+        as the ones that do. A row the candidate map never considered at all
+        (no signal, e.g. urgent/needs-response/personal mail) has no
+        ``decisions`` entry; it only bumps ``skipped``, same as before.
         """
         from gaia_agent_email.tools.read_tools import extract_sender_email
         from gaia_agent_email.tools.triage_heuristics import LABEL_IMPORTANT
@@ -1333,6 +1349,7 @@ class EmailTriageAgent(
             "level": self.config.autonomy_level,
             "executed": [],
             "proposals": [],
+            "decisions": [],
             "skipped": 0,
             "already_proposed": 0,
         }
@@ -1363,6 +1380,19 @@ class EmailTriageAgent(
                 is_important=is_important,
             )
             message_id = row.get("id")
+            # #2529: log what was considered, what was decided, and why —
+            # for EVERY candidate, not just the ones held back. Computed once
+            # here so it can't drift from the branch-specific handling below.
+            report["decisions"].append(
+                {
+                    "message_id": message_id,
+                    "tool": tool_name,
+                    "action": action_type,
+                    "outcome": decision.action,
+                    "reason": decision.reason,
+                    "sender": sender,
+                }
+            )
             if decision.action == "auto":
                 executed = self._autonomy_execute(action_type, row)
                 # Index the action so a later undo is attributed to this scope
@@ -1428,29 +1458,40 @@ class EmailTriageAgent(
         Only reversible actions reach here (the policy guarantees it). Returns
         the impl's result (carrying the ``action_id`` undo handle).
         """
-        from gaia_agent_email.tools.organize_tools import archive_message_impl
-
-        if action_type != "archive":
-            raise ValueError(
-                f"_autonomy_execute: no executor for action_type {action_type!r}. "
-                "The policy admitted an action the executor does not implement — "
-                "add an executor branch before widening the candidate map."
-            )
-        import uuid as _uuid
+        from gaia_agent_email.tools.organize_tools import (
+            archive_message_impl,
+            mark_read_impl,
+        )
 
         message_id = row.get("id")
         provider = row.get("mailbox") or self._provider_for_message(message_id, None)
         backend = self._backends[provider]
-        # Mint a batch_id so the auto-archive is undoable via undo_archive_batch
-        # (the same handle the REST/UI undo surface uses) — and undoing it feeds
-        # the learning loop as a correction.
-        return archive_message_impl(
-            backend,
-            self,
-            message_id=message_id,
-            mailbox=provider,
-            batch_id=_uuid.uuid4().hex,
-            debug=bool(getattr(self.config, "debug", False)),
+        debug = bool(getattr(self.config, "debug", False))
+
+        if action_type == "archive":
+            # Mint a batch_id so the auto-archive is undoable via
+            # undo_archive_batch (the same handle the REST/UI undo surface
+            # uses) — and undoing it feeds the learning loop as a correction.
+            return archive_message_impl(
+                backend,
+                self,
+                message_id=message_id,
+                mailbox=provider,
+                batch_id=uuid.uuid4().hex,
+                debug=debug,
+            )
+        if action_type == "mark_read":
+            return mark_read_impl(
+                backend,
+                self,
+                message_id=message_id,
+                mailbox=provider,
+                debug=debug,
+            )
+        raise ValueError(
+            f"_autonomy_execute: no executor for action_type {action_type!r}. "
+            "The policy admitted an action the executor does not implement — "
+            "add an executor branch before widening the candidate map."
         )
 
     def on_heartbeat(
@@ -1487,16 +1528,17 @@ class EmailTriageAgent(
         promotional category both learn from the same choice). This is how the
         agent "learns from your patterns": enough positives lift a scope over
         the trust bar and the next cycle acts silently; a correction pulls it
-        back below and the agent returns to asking.
+        back below and the agent returns to asking. Thin wrapper over
+        :func:`trust.record_autonomy_outcome`, which is the pure ``db``-over
+        version any ``DatabaseMixin`` holder can call (#2529).
         """
-        for scope in (
-            trust.sender_scope(sender) if sender else "",
-            trust.category_scope(category) if category else "",
-        ):
-            if scope:
-                trust.TrustLedger.record_outcome(
-                    self, action_type=action_type, scope=scope, positive=positive
-                )
+        trust.record_autonomy_outcome(
+            self,
+            action_type=action_type,
+            positive=positive,
+            sender=sender,
+            category=category,
+        )
 
     def note_action_undone(self, action_id: str) -> bool:
         """Capture a correction: an auto-executed action the user undid.
@@ -1505,18 +1547,46 @@ class EmailTriageAgent(
         negative outcome is recorded for its scope and the index row is marked
         resolved (so one undo is never counted twice). Returns True when a
         correction was captured, False when the id was not an autonomy action.
+        Thin wrapper over :func:`trust.note_autonomy_undo` (#2529).
         """
-        row = trust.lookup_autonomy_action(self, action_id=action_id)
-        if row is None:
-            return False
-        self.record_autonomy_outcome(
-            action_type=row["action_type"],
-            positive=False,
-            sender=row.get("sender") or "",
-            category=row.get("category") or "",
+        return trust.note_autonomy_undo(self, action_id=action_id)
+
+    def undo_autonomy_action(self, action_id: str) -> Dict[str, Any]:
+        """Undo one action and feed the correction to the trust ledger (#2529).
+
+        The general-purpose undo the REST autonomy surface uses to let a
+        caller reverse an auto-executed action, whatever its type: it
+        reverses the underlying mailbox mutation via
+        :func:`organize_tools.undo_reversible_action_impl`, then records a
+        negative outcome against the action's scope via
+        :meth:`note_action_undone` — but only when ``action_id`` was indexed
+        as an autonomy decision (:func:`trust.record_autonomy_action`).
+        Undoing a manually-executed action still reverses the mutation but
+        reports ``correction_captured: False``, the same tolerance
+        ``note_action_undone`` already has for a non-autonomy id.
+
+        Without this, the ledger can only ever ratchet trust up — no undo
+        could reach it for anything but a batch archive via the
+        conversational ``undo_archive_batch`` tool. Raises ``RuntimeError``
+        if ``action_id`` is unknown, already undone, or outside the undo
+        window; raises ``ValueError`` if its ``action_type`` has no reversal
+        implemented (both propagate — never a silent no-op).
+        """
+        from gaia_agent_email.tools.organize_tools import undo_reversible_action_impl
+
+        window = int(getattr(self.config, "undo_window_seconds", 120))
+        result = undo_reversible_action_impl(
+            self._backend_for_action,
+            self,
+            action_id=action_id,
+            window_seconds=window,
+            debug=bool(getattr(self.config, "debug", False)),
         )
-        trust.mark_autonomy_action_resolved(self, action_id=action_id)
-        return True
+        # Only AFTER the mutation is confirmed reversed — mirrors the ordering
+        # undo_archive_batch's tool closure already uses (capture the
+        # correction once the restore actually happened, never before).
+        result["correction_captured"] = self.note_action_undone(action_id)
+        return result
 
     def set_autonomy_level(self, level: str) -> Dict[str, Any]:
         """Change the autonomy level at runtime (pause / resume / kill switch).

--- a/hub/agents/email/python/gaia_agent_email/agent_routes.py
+++ b/hub/agents/email/python/gaia_agent_email/agent_routes.py
@@ -45,7 +45,6 @@ import asyncio
 import json
 import queue
 import threading
-import time
 from typing import Any, Dict, List, Optional, Tuple
 
 from fastapi import APIRouter, HTTPException
@@ -248,6 +247,13 @@ class AutonomyRunRequest(_Strict):
     )
 
 
+class AutonomyUndoRequest(_Strict):
+    session_id: str = Field(..., description="Session whose autonomy action to undo.")
+    action_id: str = Field(
+        ..., description="The action_id from a prior autonomy/run 'executed' entry."
+    )
+
+
 # ---------------------------------------------------------------------------
 # Endpoints
 # ---------------------------------------------------------------------------
@@ -411,6 +417,32 @@ async def run_autonomy(request: AutonomyRunRequest) -> Dict[str, Any]:
             status_code=501, detail="This agent build does not expose autonomy."
         )
     return await asyncio.to_thread(runner, {"max_messages": request.max_messages})
+
+
+@router.post("/autonomy/undo")
+async def undo_autonomy(request: AutonomyUndoRequest) -> Dict[str, Any]:
+    """Undo one autonomy-executed action, feeding a correction to the trust
+    ledger (#2529).
+
+    Without this the ledger can only ever ratchet trust up — no undo could
+    reach it except through the archive-only, conversational
+    ``undo_archive_batch`` tool. Runs on a worker thread (mailbox I/O).
+    """
+    session = registry.get(request.session_id)
+    if session is None:
+        raise HTTPException(status_code=404, detail="No such session.")
+    undo_fn = getattr(session.agent, "undo_autonomy_action", None)
+    if not callable(undo_fn):
+        raise HTTPException(
+            status_code=501,
+            detail="This agent build does not expose autonomy undo.",
+        )
+    try:
+        return await asyncio.to_thread(undo_fn, request.action_id)
+    except RuntimeError as exc:
+        raise HTTPException(status_code=409, detail=str(exc)) from exc
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
 
 
 @router.post("/confirm-tool")

--- a/hub/agents/email/python/gaia_agent_email/tools/organize_tools.py
+++ b/hub/agents/email/python/gaia_agent_email/tools/organize_tools.py
@@ -17,8 +17,8 @@ from __future__ import annotations
 import uuid
 from typing import Any, Dict, List, Optional
 
-from gaia_agent_email.tools.envelope import _envelope_err, _envelope_ok
 from gaia_agent_email import action_store
+from gaia_agent_email.tools.envelope import _envelope_err, _envelope_ok
 from gaia_agent_email.verbose import log_tool_call
 
 from gaia.agents.base.tools import tool
@@ -374,6 +374,91 @@ def undo_archive_batch_impl(
         }
 
 
+# Toggle actions the autonomy candidate map can auto-execute, reversed by
+# calling the opposite backend method directly (#2529). ``archive`` is NOT
+# here — it is handled by a dedicated branch in
+# ``undo_reversible_action_impl`` that routes through
+# ``undo_archive_batch_impl`` using the row's own ``batch_id`` (every
+# autonomy archive mints a unique one, so "undo this action" and "undo this
+# batch" coincide for a solo auto-archive). Extend this table — or add a
+# branch like ``archive``'s for anything that needs prior-state restoration —
+# when the autonomy candidate map grows a new auto-executable action_type; an
+# unhandled type fails loudly rather than pretending the undo succeeded.
+_TOGGLE_UNDO_OPS: Dict[str, str] = {
+    "mark_read": "mark_unread",
+    "mark_unread": "mark_read",
+    "add_star": "remove_star",
+    "remove_star": "add_star",
+}
+
+
+def undo_reversible_action_impl(
+    resolve_backend,
+    db,
+    *,
+    action_id: str,
+    window_seconds: int,
+    debug: bool = False,
+) -> Dict[str, Any]:
+    """Undo one action recorded in ``email_actions`` by its ``action_id``.
+
+    Complements ``undo_archive_batch_impl`` (archive-only, batch-shaped) and
+    ``delete_tools.restore_message_impl`` (trash-only): this is the general
+    single-action undo for the rest of the reversible-action set autonomy can
+    execute (#2529) — without it, the earned-trust ledger can only ever
+    ratchet up, because no undo can reach it for anything but a batch
+    archive. ``resolve_backend(row: dict) -> backend`` routes per-message,
+    same as the other undo impls in this module.
+
+    Fails loudly: an unknown/expired/already-undone ``action_id`` raises
+    ``RuntimeError``; an ``action_type`` with no reversal wired here raises
+    ``ValueError`` rather than silently no-op'ing.
+    """
+    with log_tool_call(
+        "undo_reversible_action", {"action_id": action_id}, debug=debug
+    ) as st:
+        row = action_store.fetch_undoable(
+            db, action_id=action_id, window_seconds=window_seconds
+        )
+        if row is None:
+            raise RuntimeError(
+                f"undo window has expired ({window_seconds} s) or action_id "
+                f"{action_id!r} is unknown or already undone."
+            )
+        action_type = row["action_type"]
+        message_id = row["message_id"]
+        if action_type == "archive":
+            batch_result = undo_archive_batch_impl(
+                resolve_backend,
+                db,
+                batch_id=row["batch_id"],
+                window_seconds=window_seconds,
+                debug=debug,
+            )
+            undone = batch_result["restored"] > 0
+        else:
+            reverse_op = _TOGGLE_UNDO_OPS.get(action_type)
+            if reverse_op is None:
+                raise ValueError(
+                    f"undo_reversible_action: no reversal implemented for "
+                    f"action_type {action_type!r}. Add one to "
+                    "_TOGGLE_UNDO_OPS (or a dedicated branch, like 'archive') "
+                    "before this action type can be auto-executed by the "
+                    "autonomy candidate map."
+                )
+            backend = resolve_backend(row)
+            getattr(backend, reverse_op)(message_id)
+            action_store.mark_undone(db, action_id=action_id)
+            undone = True
+        st["result_summary"] = {"action_id": action_id, "undone": undone}
+        return {
+            "action_id": action_id,
+            "action_type": action_type,
+            "message_id": message_id,
+            "undone": undone,
+        }
+
+
 # ---------------------------------------------------------------------------
 # Mixin
 # ---------------------------------------------------------------------------
@@ -435,9 +520,7 @@ def _coerce_ids(message_ids):
         if s.startswith("[") and s.endswith("]"):
             s = s[1:-1]
         return [
-            cleaned
-            for x in s.replace(";", ",").split(",")
-            if (cleaned := _clean_id(x))
+            cleaned for x in s.replace(";", ",").split(",") if (cleaned := _clean_id(x))
         ]
     return []
 

--- a/hub/agents/email/python/gaia_agent_email/trust.py
+++ b/hub/agents/email/python/gaia_agent_email/trust.py
@@ -322,7 +322,7 @@ def note_autonomy_undo(db, *, action_id: str) -> bool:
     outcome for its scope and marks the index row resolved (so the same undo
     can't be counted twice). Returns True when a correction was captured,
     False when ``action_id`` was not an autonomy action (e.g. the user undid
-    something they did manually themselves) — a no-op, not an error.
+    something they did manually) — a no-op, not an error.
     """
     row = lookup_autonomy_action(db, action_id=action_id)
     if row is None:

--- a/hub/agents/email/python/gaia_agent_email/trust.py
+++ b/hub/agents/email/python/gaia_agent_email/trust.py
@@ -283,6 +283,62 @@ def sender_scope(sender: str) -> str:
 
 
 # ---------------------------------------------------------------------------
+# Correction capture (#2529) — pure ``db``-over functions so any
+# ``DatabaseMixin`` holder can record a trust signal, not only a live
+# ``EmailTriageAgent``. ``EmailTriageAgent.record_autonomy_outcome`` /
+# ``note_action_undone`` are thin wrappers around these two.
+# ---------------------------------------------------------------------------
+
+
+def record_autonomy_outcome(
+    db,
+    *,
+    action_type: str,
+    positive: bool,
+    sender: str = "",
+    category: str = "",
+) -> None:
+    """Record one trust signal against both the sender and category scope.
+
+    The outcome is recorded against BOTH scopes (whichever are non-empty) so
+    trust accrues at whichever granularity recurs — a specific sender AND its
+    category both learn from the same decision.
+    """
+    for scope in (
+        sender_scope(sender) if sender else "",
+        category_scope(category) if category else "",
+    ):
+        if scope:
+            TrustLedger.record_outcome(
+                db, action_type=action_type, scope=scope, positive=positive
+            )
+
+
+def note_autonomy_undo(db, *, action_id: str) -> bool:
+    """Capture a correction: an auto-executed action that was undone.
+
+    Looks up ``action_id`` in the attribution index; if it was recorded as an
+    autonomy decision (:func:`record_autonomy_action`), records a negative
+    outcome for its scope and marks the index row resolved (so the same undo
+    can't be counted twice). Returns True when a correction was captured,
+    False when ``action_id`` was not an autonomy action (e.g. the user undid
+    something they did manually themselves) — a no-op, not an error.
+    """
+    row = lookup_autonomy_action(db, action_id=action_id)
+    if row is None:
+        return False
+    record_autonomy_outcome(
+        db,
+        action_type=row["action_type"],
+        positive=False,
+        sender=row.get("sender") or "",
+        category=row.get("category") or "",
+    )
+    mark_autonomy_action_resolved(db, action_id=action_id)
+    return True
+
+
+# ---------------------------------------------------------------------------
 # Auto-archive safety guard (#2426)
 # ---------------------------------------------------------------------------
 

--- a/hub/agents/email/python/packaging/capability_matrix.py
+++ b/hub/agents/email/python/packaging/capability_matrix.py
@@ -539,9 +539,10 @@ def render_markdown(matrix: CapabilityMatrix) -> str:
         )
     lines.append(
         "- Additionally served but **out of the frozen contract** (footnote "
-        "context, not guarded machinery): `agent_routes.py` 8 session routes, "
-        "`connector_routes.py` 4 OAuth routes, `server.py` 2 inline probes "
-        "-- ~36 total routes served by the sidecar."
+        "context, not guarded machinery): `agent_routes.py` 12 session routes "
+        "(includes the autonomy control surface, #2529), `connector_routes.py` "
+        "4 OAuth routes, `server.py` 2 inline probes "
+        "-- ~43 total routes served by the sidecar."
     )
     lines.append("")
 

--- a/hub/agents/email/python/tests/test_email_agent_routes.py
+++ b/hub/agents/email/python/tests/test_email_agent_routes.py
@@ -116,6 +116,23 @@ class _FakeAgent:
             "skipped": 0,
         }
 
+    def undo_autonomy_action(self, action_id: str) -> dict:
+        """Routing-only fake — no real ledger logic, matching the style of
+        run_autonomy_cycle/autonomy_status above. Two sentinel ids let route
+        tests drive the RuntimeError -> 409 / ValueError -> 400 mapping
+        without a real trust ledger."""
+        if action_id == "raise-runtime":
+            raise RuntimeError("undo window has expired")
+        if action_id == "raise-value":
+            raise ValueError("bad action_id")
+        return {
+            "action_id": action_id,
+            "action_type": "archive",
+            "message_id": "m1",
+            "undone": True,
+            "correction_captured": True,
+        }
+
     def close_db(self) -> None:
         self.closed = True
 
@@ -442,6 +459,45 @@ class TestAutonomyRoutes:
     def test_run_cycle_404_without_session(self, client):
         r = client.post("/v1/email/agent/autonomy/run", json={"session_id": "nope"})
         assert r.status_code == 404
+
+    def test_undo_returns_report(self, client):
+        self._mk(client)
+        r = client.post(
+            "/v1/email/agent/autonomy/undo",
+            json={"session_id": "s1", "action_id": "a1"},
+        )
+        assert r.status_code == 200
+        body = r.json()
+        assert "undone" in body
+        assert "correction_captured" in body
+
+    def test_undo_404_without_session(self, client):
+        r = client.post(
+            "/v1/email/agent/autonomy/undo",
+            json={"session_id": "nope", "action_id": "a1"},
+        )
+        # An unmatched path 404s too — pin the actual detail text so this
+        # only goes green once the route exists AND does its own session
+        # lookup (matching the "No such session." convention used by every
+        # other route in this file), not by accident of the path missing.
+        assert r.status_code == 404
+        assert r.json()["detail"] == "No such session."
+
+    def test_undo_409_on_runtime_error(self, client):
+        self._mk(client)
+        r = client.post(
+            "/v1/email/agent/autonomy/undo",
+            json={"session_id": "s1", "action_id": "raise-runtime"},
+        )
+        assert r.status_code == 409
+
+    def test_undo_400_on_value_error(self, client):
+        self._mk(client)
+        r = client.post(
+            "/v1/email/agent/autonomy/undo",
+            json={"session_id": "s1", "action_id": "raise-value"},
+        )
+        assert r.status_code == 400
 
 
 class TestWorkerDiesWithoutTerminalEvent:

--- a/hub/agents/email/python/tests/test_email_autonomy_cycle.py
+++ b/hub/agents/email/python/tests/test_email_autonomy_cycle.py
@@ -71,6 +71,32 @@ def _promo_message(message_id: str, sender: str) -> dict:
     }
 
 
+def _fyi_message(message_id: str, sender: str) -> dict:
+    """A message the heuristic classifies confidently as FYI.
+
+    The ``CATEGORY_UPDATES`` label is the mechanical FYI signal, so no LLM
+    classifier is needed to reach a confident category. Subject/snippet are
+    deliberately benign (no deadline/commitment wording) so the confident-FYI
+    short-circuit is not vetoed by the #2113 commitment-signal guard.
+    """
+    internal_ms = int(time.time() * 1000)
+    return {
+        "id": message_id,
+        "threadId": f"thread_{message_id}",
+        "labelIds": ["INBOX", "UNREAD", "CATEGORY_UPDATES"],
+        "internalDate": str(internal_ms),
+        "snippet": "Your order has shipped and is on its way.",
+        "payload": {
+            "headers": [
+                {"name": "From", "value": f"Shop <{sender}>"},
+                {"name": "Subject", "value": "Your order has shipped"},
+                {"name": "Message-ID", "value": f"<{message_id}@x.com>"},
+                {"name": "Date", "value": "Mon, 12 Jun 2026 10:00:00 +0000"},
+            ],
+        },
+    }
+
+
 def _urgent_message(message_id: str, sender: str) -> dict:
     internal_ms = int(time.time() * 1000)
     return {
@@ -326,6 +352,31 @@ def test_triage_row_carries_label_ids(tmp_path):
 
 
 # ---------------------------------------------------------------------------
+# #2529 — candidate map narrowing: FYI mail is marked read, not archived
+# ---------------------------------------------------------------------------
+
+
+def test_full_level_marks_fyi_message_read_not_archived(tmp_path):
+    """FYI mail (useful context, no action needed) is narrowed off the
+    archive candidate and onto mark_read instead (#2529): it stays visible in
+    the inbox but no longer sits unread. PROMOTIONAL mail is unaffected — it
+    keeps archiving (see test_full_level_archives_immediately)."""
+    sender = "shop@retailer.com"
+    agent = _build_agent(tmp_path, [_fyi_message("f1", sender)], level=LEVEL_FULL)
+    report = agent._run_email_autonomy_cycle()
+
+    assert len(report["executed"]) == 1
+    entry = report["executed"][0]
+    assert entry["action"] == "mark_read"
+    assert entry["message_id"] == "f1"
+    assert "action_id" in entry  # undo handle recorded
+
+    labels = agent._gmail.get_message("f1").get("labelIds", [])
+    assert "INBOX" in labels  # stays in the inbox
+    assert "UNREAD" not in labels  # but no longer unread
+
+
+# ---------------------------------------------------------------------------
 # Hook + driver contract
 # ---------------------------------------------------------------------------
 
@@ -502,6 +553,128 @@ def test_undo_tool_captures_correction_end_to_end(tmp_path):
         agent, action_type="archive", scope=sender_scope(sender)
     )
     assert stats["negative"] == 1
+
+
+# ---------------------------------------------------------------------------
+# #2529 — the run report explains WHY, per message (the "decisions" log)
+# ---------------------------------------------------------------------------
+
+
+def test_decisions_report_explains_important_message_suggest(tmp_path):
+    """#2426/#2529: the report must not just hold back an auto-archive on a
+    provider-IMPORTANT message — it must say, per message, why. This is the
+    per-decision observability log the guard was previously silent about."""
+    agent = _build_agent(
+        tmp_path, [_security_important_message("s1")], level=LEVEL_FULL
+    )
+    report = agent._run_email_autonomy_cycle()
+
+    decisions = [d for d in report["decisions"] if d["message_id"] == "s1"]
+    assert len(decisions) == 1, report["decisions"]
+    decision = decisions[0]
+    assert decision["tool"] == "archive_message"
+    assert decision["action"] == "archive"
+    assert decision["outcome"] == "suggest"
+    assert "IMPORTANT" in decision["reason"]
+    assert decision["sender"] == "no-reply@accounts.google.com"
+
+
+def test_decisions_report_holds_confirm_gated_candidate(tmp_path):
+    """A candidate mapped to a confirm-gated tool must never auto-execute at
+    any level — driven directly since the real candidate generator never
+    proposes one of the nine confirm-floor tools (archive/mark_read never
+    are). Proves the floor holds AND is reported, not just asserted."""
+    agent = _build_agent(
+        tmp_path, [_promo_message("m1", "deals@shop.com")], level=LEVEL_FULL
+    )
+    with patch.object(
+        EmailTriageAgent,
+        "_autonomy_candidate",
+        staticmethod(lambda row: ("send_now", "send")),
+    ):
+        report = agent._run_email_autonomy_cycle()
+
+    assert report["executed"] == []
+    assert report["proposals"] == []
+    decisions = [d for d in report["decisions"] if d["message_id"] == "m1"]
+    assert len(decisions) == 1, report["decisions"]
+    decision = decisions[0]
+    assert decision["outcome"] == "confirm"
+    assert "confirmation" in decision["reason"].lower()
+
+
+def test_decisions_report_marks_draft_and_never_auto_sends(tmp_path):
+    """Reply/forward composition is always a draft, never sent unattended, at
+    any autonomy level — and the report says so per message. Same direct-
+    monkeypatch technique as the confirm-floor test above."""
+    agent = _build_agent(
+        tmp_path, [_promo_message("m1", "deals@shop.com")], level=LEVEL_FULL
+    )
+    with patch.object(
+        EmailTriageAgent,
+        "_autonomy_candidate",
+        staticmethod(lambda row: ("draft_reply", "draft_reply")),
+    ):
+        report = agent._run_email_autonomy_cycle()
+
+    assert report["executed"] == []
+    assert len(report["proposals"]) == 1
+    decisions = [d for d in report["decisions"] if d["message_id"] == "m1"]
+    assert len(decisions) == 1, report["decisions"]
+    assert decisions[0]["outcome"] == "draft"
+
+
+# ---------------------------------------------------------------------------
+# #2529 — general-purpose undo surface (undo_autonomy_action)
+# ---------------------------------------------------------------------------
+
+
+def test_undo_autonomy_action_lowers_trust_for_archive(tmp_path):
+    """The new general-purpose undo path does the same job the archive-only
+    undo_archive_batch tool already proves in
+    test_undo_tool_captures_correction_end_to_end — for the archive action."""
+    sender = "deals@shop.com"
+    agent = _build_agent(tmp_path, [_promo_message("m1", sender)], level=LEVEL_FULL)
+    report = agent._run_email_autonomy_cycle()
+    action_id = report["executed"][0]["action_id"]
+
+    result = agent.undo_autonomy_action(action_id)
+
+    assert result["undone"] is True
+    assert result["correction_captured"] is True
+
+    stats = TrustLedger.get_stats(
+        agent, action_type="archive", scope=sender_scope(sender)
+    )
+    assert stats["negative"] == 1
+    assert "INBOX" in agent._gmail.get_message("m1").get("labelIds", [])
+
+
+def test_undo_autonomy_action_lowers_trust_for_mark_read(tmp_path):
+    """Same as above, for the mark_read action the narrowed FYI candidate
+    (#2529) now produces — the general undo path must generalize beyond
+    archive, not just work for it."""
+    sender = "shop@retailer.com"
+    agent = _build_agent(tmp_path, [_fyi_message("f1", sender)], level=LEVEL_FULL)
+    report = agent._run_email_autonomy_cycle()
+    action_id = report["executed"][0]["action_id"]
+
+    result = agent.undo_autonomy_action(action_id)
+
+    assert result["undone"] is True
+    assert result["correction_captured"] is True
+
+    stats = TrustLedger.get_stats(
+        agent, action_type="mark_read", scope=sender_scope(sender)
+    )
+    assert stats["negative"] == 1
+    assert "UNREAD" in agent._gmail.get_message("f1").get("labelIds", [])
+
+
+def test_undo_autonomy_action_unknown_id_raises(tmp_path):
+    agent = _build_agent(tmp_path, [], level=LEVEL_OFF)
+    with pytest.raises(RuntimeError):
+        agent.undo_autonomy_action("not-a-real-action-id")
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
The proactive autonomy loop's candidate generator only ever proposed `archive`, so the rest of the trust model — the reversible-action set, the nine-tool confirm floor, the importance guard — could never be exercised end to end, and there was no way to undo an auto-executed action to feed a correction back into the trust ledger. This closes that gap: FYI mail now maps to `mark_read` instead of `archive` (useful context stays visible but doesn't sit unread); the run report gains a per-message `decisions` log explaining every auto/draft/suggest/confirm outcome and why; and a new `POST /v1/email/agent/autonomy/undo` route reverses any auto-executed action and records the correction against its trust scope. The confirm floor is untouched and still inviolable at every level.

Closes #2529

## Test plan

- [x] `python -m pytest hub/agents/email/python/tests -k "autonomy or trust or candidate" -q` — 131 passed (120 pre-existing + 11 new, all red before the implementation, green after)
- [x] Full email-agent suite: `python -m pytest hub/agents/email/python/tests -q` — 1036 passed
- [x] `python hub/agents/email/python/packaging/capability_matrix.py --check` — up to date after regen
- [x] `python hub/agents/email/python/gaia_agent_email/export_openapi.py --check` — unaffected (this surface is out of the frozen contract)
- [x] `python util/lint.py --all` — 10/11 passed, 1 non-blocking MyPy warning (pre-existing, unrelated to this change)