### PR TITLE
fix(tui): unbreak build_tui on main — allowlist the bare-host remedy

### DIFF
--- a/tui/internal/ui/preflight/check_test.go
+++ b/tui/internal/ui/preflight/check_test.go
@@ -319,6 +319,10 @@ func realCommands() []string {
 		"gaia connectors connect ",
 		"gaia connectors grants grant ",
 		"gaia connectors list",
+		// Reached only when the machine cannot name Lemonade's launcher
+		// (lemonadeRestartRemedy, !l.Found) — so it fires on a runner with no
+		// Lemonade installed and never on a developer box that has one.
+		"gaia kill",
 	}
 	l := resolveLemonade()
 	for _, cmd := range []string{l.Start, l.Restart} {
@@ -327,6 +331,25 @@ func realCommands() []string {
 		}
 	}
 	return fixed
+}
+
+// The remedy for a host that cannot name Lemonade's launcher only fires where
+// nothing is installed — a CI runner, never a developer box with Lemonade on
+// it. So the rows that reach it pass locally and fail only in CI, which is how
+// "gaia kill" stayed missing from realCommands(). Resolving against a simulated
+// bare Linux host puts that answer in reach of a local `go test`.
+func TestTheBareHostRemedyIsARealCommand(t *testing.T) {
+	orig := realHostProbe
+	realHostProbe = func() hostProbe { return fakeHostFor("linux", nil, nil, map[string]string{}) }
+	defer func() { realHostProbe = orig }()
+
+	if l := resolveLemonade(); l.Found {
+		t.Fatalf("a host with nothing installed resolved a launcher: %+v", l)
+	}
+	assertRealCommand(t, Row{
+		Key:    KeyLemonade,
+		Remedy: lemonadeRestartRemedy(),
+	})
 }
 
 func assertRealCommand(t *testing.T, row Row) {


### PR DESCRIPTION
**`build_tui.yml` has been red on `main` since this morning**, and it fails every TUI PR with it (#2544 and #2530 both hit exactly this).

`lemonadeRestartRemedy` emits `gaia kill` when the machine cannot work out how Lemonade is launched. That branch is reachable only where nothing is installed — so it fires on a CI runner and never on a developer box that has Lemonade. `realCommands()` did not list the command, so two rows asserted a remedy the allowlist rejected:

```
check_test.go:777:  row "lemonade" remedy names a command that does not exist on this machine: "gaia kill"
check_test.go:1603: row "model"    remedy names a command that does not exist on this machine: "gaia kill"
```

`gaia kill` is a real command — `src/gaia/cli.py` registers it, and it is in the CLI reference. The allowlist was simply missing it, so this widens the list rather than weakening a check.

**The second half matters more than the one-line fix.** This was invisible locally: the two failing tests pass on any machine with Lemonade, which is every developer machine. The new test resolves against a *simulated* bare Linux host via the existing `realHostProbe` seam, so the next remedy added behind that branch fails a local `go test` instead of waiting for CI to say so.

### Test plan

- [x] `go test ./internal/ui/preflight/ -count=1` — ok
- [x] `go test ./... -count=1` — all 13 packages ok
- [x] `go vet ./...` — clean
- [x] Reproduced the CI failure locally with the simulated host, confirmed the emitted command is exactly `gaia kill`
- [x] Removing the allowlist entry makes the new test fail with the same message CI printed — so it guards the real thing, not a tautology