### PR TITLE
fix(email): catch the contract guards up to schema 2.6, and de-race the heartbeat test

### DIFF
--- a/hub/agents/email/python/tests/test_query_resume_2469.py
+++ b/hub/agents/email/python/tests/test_query_resume_2469.py
@@ -30,7 +30,7 @@ class _AskingFakeAgent:
 
     QUESTION = "Which mailbox should I connect?"
 
-    def __init__(self, allow_free_text: bool = False):
+    def __init__(self, allow_free_text: bool = False, timeout_seconds: int = 10):
         self.conversation_history = []
         self.console = None
         self.can_answer_questions = False  # the route sets it from the request
@@ -38,6 +38,10 @@ class _AskingFakeAgent:
         self.allow_free_text = allow_free_text
         self.answer = None
         self.asked = threading.Event()
+        # How long the run stays parked. A test that waits for something the
+        # parked run emits must outlast the interval that emits it — see
+        # test_stream_heartbeats_while_a_question_is_pending.
+        self.timeout_seconds = timeout_seconds
 
     def process_query(self, query, max_steps=None):
         from gaia_agent_email import question as q
@@ -53,7 +57,7 @@ class _AskingFakeAgent:
                     q.Option("microsoft", "Outlook", "An outlook.com account."),
                 ),
                 allow_free_text=self.allow_free_text,
-                timeout_seconds=10,
+                timeout_seconds=self.timeout_seconds,
             )
         except q.InputUnansweredError as exc:
             self.console.print_error(str(exc))
@@ -298,8 +302,15 @@ def test_a_caller_that_cannot_answer_gets_an_error_not_a_pause(live_server, monk
 
 
 def test_stream_heartbeats_while_a_question_is_pending(live_server, monkeypatch):
-    """The paused stream keeps talking, so a client watchdog does not abandon it."""
-    fake = _AskingFakeAgent()
+    """The paused stream keeps talking, so a client watchdog does not abandon it.
+
+    The park has to outlast the heartbeat interval. At the default 10s it ties
+    _HEARTBEAT_SECONDS exactly: the question times out, the agent thread ends,
+    and the stream closes in the same instant the first keepalive is due —
+    whichever timer wins decides the test. That coin-flip passed on developer
+    machines and failed in CI.
+    """
+    fake = _AskingFakeAgent(timeout_seconds=int(query_routes._HEARTBEAT_SECONDS * 3))
     monkeypatch.setattr(query_routes, "build_query_agent", lambda **kw: fake)
 
     run_id = str(uuid.uuid4())

--- a/tests/test_email_openapi_conformance.py
+++ b/tests/test_email_openapi_conformance.py
@@ -959,6 +959,12 @@ def test_all_documented_paths_covered(committed_spec):
         # the cancel route is covered there too.
         ("post", "/v1/email/query"),
         ("post", "/v1/email/query/{run_id}/cancel"),
+        # Mid-run question resume (schema 2.6, #2469). Answering resumes the
+        # ORIGINAL stream, so there is no JSON body schema to conform to here
+        # either; behavioral conformance (resume, unknown run 404, stale
+        # request_id 409, the non-answering caller, keepalives while parked)
+        # lives in hub/agents/email/python/tests/test_query_resume_2469.py.
+        ("post", "/v1/email/query/{run_id}/respond"),
         # OAuth forward-OUT intake (schema 2.5, #2154). The daemon delivers
         # short-lived connector tokens here; behavioral conformance (auth,
         # unknown-provider, empty-token, metadata-only responses, withdraw)

--- a/tests/unit/agents/email/test_contract_schema.py
+++ b/tests/unit/agents/email/test_contract_schema.py
@@ -332,7 +332,7 @@ def test_result_summary_required():
 
 
 def test_schema_version_unchanged_by_multi_inbox():
-    """Schema 2.5 is the current frozen contract version.
+    """Schema 2.6 is the current frozen contract version.
 
     2.1 was additive over the 2.0 5-bucket taxonomy (no triage shape change):
     it added inbox search (#1781), mailbox actions (#1779), the calendar
@@ -344,11 +344,15 @@ def test_schema_version_unchanged_by_multi_inbox():
     streaming agent-loop surface (POST /v1/email/query + cancel) — no existing
     shape changed. 2.5 is additive over 2.4 (#2154): the OAuth forward-OUT
     intake surface (POST/GET/DELETE /v1/connections) the daemon delivers
-    short-lived connector tokens to — no existing shape changed. If this fails,
-    someone changed the version unexpectedly; that requires an explicit version
-    negotiation, not a drive-by edit.
+    short-lived connector tokens to — no existing shape changed. 2.6 is additive
+    over 2.5 (#2469): the agent can ask the user a question MID-RUN and carry on
+    from the answer — a non-terminal ``needs_input`` SSE event plus POST
+    /v1/email/query/{run_id}/respond, which resumes the original stream. No
+    existing shape changed. If this fails, someone changed the version
+    unexpectedly; that requires an explicit version negotiation, not a drive-by
+    edit.
     """
-    assert SCHEMA_VERSION == "2.5"
+    assert SCHEMA_VERSION == "2.6"
 
 
 def test_triage_result_gained_no_new_required_field():

--- a/tests/unit/agents/test_email_agent.py
+++ b/tests/unit/agents/test_email_agent.py
@@ -215,6 +215,10 @@ class TestToolRegistry:
         "get_briefing",
         "list_tasks",
         "extract_action_items",
+        # Agent-led mailbox onboarding (#2496) — the agent diagnoses and repairs
+        # its own access in the conversation instead of handing out a command.
+        "check_mailbox_access",
+        "setup_mailbox_access",
     }
 
     def test_every_expected_tool_is_registered(self, agent):


### PR DESCRIPTION
**Email Agent Unit Tests is red on `main`**, which fails the v0.23.0 release PR (#2374). Three failures, all traceable to #2469 landing without its guards updated.

#2469 shipped mid-run questions and bumped `SCHEMA_VERSION` to 2.6. `contract.py` documents the bump in full — the non-terminal `needs_input` event and `POST /v1/email/query/{run_id}/respond`. Two freeze guards still described 2.5, and the new route had no entry in the covered-paths set. Both fired **correctly**; they were simply never caught up. This updates them and carries the 2.6 rationale across in the same style as 2.1–2.5, so the guards still mean something.

**The third one was a real bug in the test, not a slow runner.** `test_stream_heartbeats_while_a_question_is_pending` parked the fake agent with `timeout_seconds=10` while `_HEARTBEAT_SECONDS = 10.0`. Those two timers tie: the question times out, the agent thread ends and the stream closes, in the same instant the first keepalive comes due — and the stream loop `break`s as soon as the thread dies. Whichever timer won decided the test. It won on developer machines and lost in CI (the log shows it failing 10.2s after the previous test passed).

The park is now three heartbeat intervals, derived from `_HEARTBEAT_SECONDS` itself so it cannot drift back into a tie if the interval changes.

### Test plan

- [x] `pytest tests/unit/agents/email/test_contract_schema.py tests/test_email_openapi_conformance.py` — 88 passed
- [x] `pytest tests/unit/agents/email/ tests/unit/email/` — 780 passed
- [x] `pytest hub/agents/email/python/tests/test_query_resume_2469.py` — 7 passed
- [x] Heartbeat test run 3× — 10.72s / 10.67s / 10.70s, passing each time (it still exits on the first keepalive; it just no longer races teardown)
- [x] `python util/lint.py --black --isort` — clean
- [x] Confirmed all three fail on `main` before this change

Note the respond route's behavioral conformance already exists in `test_query_resume_2469.py` (resume, unknown-run 404, stale request_id 409, non-answering caller, keepalives) — the covered-paths entry points at it rather than adding a duplicate.