### PR TITLE
fix(email): normalize calendar time bounds to RFC 3339 before Google

### DIFF
--- a/hub/agents/email/python/CHANGELOG.md
+++ b/hub/agents/email/python/CHANGELOG.md
@@ -53,6 +53,17 @@ contract version is tracked separately as
 
 ### Fixed
 
+- **Calendar listing and conflict checks no longer 400 on a date-only range,
+  and never end a turn narrating a retry that didn't happen (#2517).**
+  `list_calendar_events` and `detect_calendar_conflicts` forwarded a
+  model-supplied bound like `2026-07-27` to Google verbatim; the live
+  Calendar API rejects a date-only `timeMin`/`timeMax` with a 400, so "what's
+  on my calendar the next 30 days" ran real tool calls and came back with no
+  events. Both tools now normalize `time_min`/`time_max` (and
+  `start_iso`/`end_iso`) to RFC 3339 before the request goes out — a bare
+  date or naive datetime is coerced to UTC, an already-qualified timestamp
+  passes through unchanged, and an unparseable bound raises an actionable
+  error naming what was received instead of reaching the backend at all.
 - **A trashed message is recoverable any time it's still in Trash, not just
   for a few seconds (#2523).** The only restore path (`restore_message`) was
   gated by a short undo window and a live `action_id`; once either was gone,

--- a/hub/agents/email/python/gaia_agent_email/tools/calendar_tools.py
+++ b/hub/agents/email/python/gaia_agent_email/tools/calendar_tools.py
@@ -605,7 +605,9 @@ def detect_calendar_conflicts_impl(
         debug=debug,
     ) as st:
         data = cal.list_events(
-            calendar_id=calendar_id, time_min=start_iso, time_max=end_iso
+            calendar_id=calendar_id,
+            time_min=_normalize_time_bound(start_iso, param_name="start_iso"),
+            time_max=_normalize_time_bound(end_iso, param_name="end_iso"),
         )
         conflicts: List[Dict[str, Any]] = []
         for ev in data.get("items", []):
@@ -635,6 +637,43 @@ def detect_calendar_conflicts_impl(
 DEFAULT_LIST_WINDOW_DAYS = 30
 
 
+def _normalize_time_bound(value: Optional[str], *, param_name: str) -> Optional[str]:
+    """Normalize a caller-supplied time bound to RFC 3339 before it reaches
+    the Calendar API.
+
+    Google's ``timeMin``/``timeMax`` require a timezone-qualified timestamp —
+    a bare date (``2026-07-27``) or a naive datetime 400s on the live API
+    (#2517). Both are coerced to UTC at the parsed instant (a bare date lands
+    on that day's midnight boundary). A value that already carries an
+    explicit offset (``Z`` or ``+HH:MM``) passes through byte-identical —
+    reparsing and reformatting it is unnecessary and would risk drifting from
+    what the caller asked for.
+
+    Raises ``ValueError`` naming the received value on anything unparseable
+    — never forwarded to the backend to 400 on.
+    """
+    if value is None:
+        return None
+    text = value.strip()
+    if not text:
+        raise ValueError(
+            f"{param_name}={value!r} is empty; expected an RFC 3339 "
+            "timestamp (e.g. '2026-07-27T00:00:00Z') or a bare date "
+            "(e.g. '2026-07-27')"
+        )
+    normalized_for_parse = text[:-1] + "+00:00" if text.endswith("Z") else text
+    try:
+        parsed = datetime.fromisoformat(normalized_for_parse)
+    except ValueError as exc:
+        raise ValueError(
+            f"{param_name}={value!r} is not a valid RFC 3339 timestamp or "
+            "date (expected e.g. '2026-07-27T00:00:00Z' or '2026-07-27')"
+        ) from exc
+    if parsed.tzinfo is not None:
+        return text
+    return parsed.replace(tzinfo=timezone.utc).isoformat()
+
+
 def list_calendar_events_impl(
     cal,
     *,
@@ -643,16 +682,21 @@ def list_calendar_events_impl(
     debug: bool = False,
     now: Optional[datetime] = None,
 ) -> Dict[str, Any]:
-    """List events; explicit bounds pass through unchanged.
+    """List events; bounds are normalized to RFC 3339 before reaching the
+    backend.
 
     When BOTH bounds are absent, defaults to a forward window of
     ``now → +DEFAULT_LIST_WINDOW_DAYS`` — an unbounded listing makes the
     backend expand recurring series from their first-ever instance (#2162).
+    A bare date or naive datetime is coerced to UTC (#2517) — Google 400s on
+    a date-only ``timeMin``/``timeMax``.
     """
     if time_min is None and time_max is None:
         now_dt = now if now is not None else datetime.now(timezone.utc)
         time_min = now_dt.isoformat()
         time_max = (now_dt + timedelta(days=DEFAULT_LIST_WINDOW_DAYS)).isoformat()
+    time_min = _normalize_time_bound(time_min, param_name="time_min")
+    time_max = _normalize_time_bound(time_max, param_name="time_max")
     with log_tool_call(
         "list_calendar_events",
         {"time_min": time_min, "time_max": time_max},
@@ -851,6 +895,9 @@ class CalendarToolsMixin:
                         cal, time_min=time_min, time_max=time_max, debug=debug_flag
                     )
                 )
+            except ValueError as exc:
+                # Unparseable time bound — bad caller input, no stack trace.
+                return _envelope_err(str(exc))
             except ConnectorsError as exc:
                 return _envelope_err(format_connector_error(exc))
             except Exception as exc:

--- a/hub/agents/email/python/tests/test_calendar_time_bound_normalization.py
+++ b/hub/agents/email/python/tests/test_calendar_time_bound_normalization.py
@@ -1,0 +1,156 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""Time-bound normalization for calendar list/conflict queries (#2517).
+
+A date-only bound (``timeMin=2026-07-27``) reaches the live Google Calendar
+API verbatim and 400s — proven on hardware (see the issue for the raw httpx
+request/response). ``list_calendar_events_impl`` and
+``detect_calendar_conflicts_impl`` must normalize ``time_min``/``time_max``
+(and ``start_iso``/``end_iso``) to RFC 3339 before they reach the backend,
+never forward an unparseable bound, and never swallow a backend error into
+an empty success the agent can narrate as "let me try again".
+"""
+
+from datetime import datetime, timezone
+
+import pytest
+
+pytest.importorskip("gaia_agent_email")
+
+from gaia_agent_email.tools.calendar_tools import (  # noqa: E402
+    detect_calendar_conflicts_impl,
+    list_calendar_events_impl,
+)
+
+from gaia.connectors.errors import ConnectorsError  # noqa: E402
+
+
+class RecordingCalendar:
+    """Records the kwargs of every ``list_events`` call."""
+
+    def __init__(self):
+        self.calls = []
+
+    def list_events(self, **kwargs):
+        self.calls.append(kwargs)
+        return {"items": []}
+
+
+class RaisingCalendar:
+    """Simulates a scope/permission failure from the live backend."""
+
+    def __init__(self, exc: Exception):
+        self._exc = exc
+
+    def list_events(self, **kwargs):
+        raise self._exc
+
+
+class TestListEventsDateOnlyBounds:
+    def test_date_only_bounds_normalized_to_rfc3339_utc_midnight(self):
+        cal = RecordingCalendar()
+
+        list_calendar_events_impl(cal, time_min="2026-07-27", time_max="2026-08-26")
+
+        assert cal.calls == [
+            {
+                "time_min": "2026-07-27T00:00:00+00:00",
+                "time_max": "2026-08-26T00:00:00+00:00",
+            }
+        ]
+
+    def test_naive_datetime_coerced_to_utc(self):
+        cal = RecordingCalendar()
+
+        list_calendar_events_impl(cal, time_min="2026-07-27T10:00:00", time_max=None)
+
+        assert cal.calls == [
+            {"time_min": "2026-07-27T10:00:00+00:00", "time_max": None}
+        ]
+
+    def test_valid_rfc3339_z_passes_through_byte_identical(self):
+        cal = RecordingCalendar()
+        time_min = "2026-07-27T10:00:00Z"
+        time_max = "2026-08-26T10:00:00Z"
+
+        list_calendar_events_impl(cal, time_min=time_min, time_max=time_max)
+
+        assert cal.calls == [{"time_min": time_min, "time_max": time_max}]
+
+    def test_valid_rfc3339_offset_passes_through_byte_identical(self):
+        cal = RecordingCalendar()
+        time_min = "2026-07-27T10:00:00+05:00"
+
+        list_calendar_events_impl(cal, time_min=time_min, time_max=None)
+
+        assert cal.calls == [{"time_min": time_min, "time_max": None}]
+
+    def test_unparseable_bound_raises_actionable_error(self):
+        cal = RecordingCalendar()
+
+        with pytest.raises(ValueError) as exc_info:
+            list_calendar_events_impl(cal, time_min="not-a-date", time_max=None)
+
+        message = str(exc_info.value)
+        assert "not-a-date" in message
+        assert not cal.calls  # never reached the backend
+
+    def test_backend_scope_error_propagates_not_swallowed(self):
+        cal = RaisingCalendar(
+            ConnectorsError(
+                "Calendar API returned 401. The access token may have "
+                "expired or scopes were revoked. Reconnect Google in "
+                "Settings → Connectors."
+            )
+        )
+
+        with pytest.raises(ConnectorsError):
+            list_calendar_events_impl(
+                cal, time_min="2026-07-27T00:00:00Z", time_max=None
+            )
+
+
+class TestDetectCalendarConflictsBounds:
+    def test_date_only_bounds_normalized_before_backend_call(self):
+        cal = RecordingCalendar()
+
+        detect_calendar_conflicts_impl(
+            cal, start_iso="2026-07-27", end_iso="2026-07-28"
+        )
+
+        assert cal.calls == [
+            {
+                "calendar_id": "primary",
+                "time_min": "2026-07-27T00:00:00+00:00",
+                "time_max": "2026-07-28T00:00:00+00:00",
+            }
+        ]
+
+    def test_valid_rfc3339_passes_through_byte_identical(self):
+        cal = RecordingCalendar()
+        start_iso = "2026-07-27T14:00:00Z"
+        end_iso = "2026-07-27T15:00:00Z"
+
+        detect_calendar_conflicts_impl(cal, start_iso=start_iso, end_iso=end_iso)
+
+        assert cal.calls == [
+            {
+                "calendar_id": "primary",
+                "time_min": start_iso,
+                "time_max": end_iso,
+            }
+        ]
+
+    def test_backend_scope_error_propagates_not_swallowed(self):
+        cal = RaisingCalendar(ConnectorsError("Calendar API returned 403."))
+
+        with pytest.raises(ConnectorsError):
+            detect_calendar_conflicts_impl(
+                cal,
+                start_iso="2026-07-27T14:00:00Z",
+                end_iso="2026-07-27T15:00:00Z",
+            )
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
A plain "what's on my calendar" request ran real tool calls and came back with no events. The agent's `list_calendar_events`/`detect_calendar_conflicts` tools forwarded model-supplied date-only bounds (e.g. `2026-07-27`) straight to the live Google Calendar API, which 400s on an unqualified `timeMin`/`timeMax`. Both tools now normalize bounds to RFC 3339 before the request goes out: a bare date or naive datetime is coerced to UTC, an already-qualified timestamp passes through unchanged, and an unparseable bound raises an actionable error instead of reaching the backend.

Closes #2517

## Test plan

- [x] `python -m pytest hub/agents/email/python/tests -k "calendar" -q` — 40 passed
- [x] `python -m pytest hub/agents/email/python/tests -q` — full suite, 1039 passed (no regressions)
- [x] `black --check` / `isort --check-only` on the touched files