### PR TITLE
fix(email): resolve relative snooze/schedule times agent-side

### DIFF
--- a/hub/agents/email/python/CHANGELOG.md
+++ b/hub/agents/email/python/CHANGELOG.md
@@ -53,6 +53,21 @@ contract version is tracked separately as
 
 ### Fixed
 
+- **Snoozing/scheduling by ordinary phrases like "tomorrow morning" now
+  actually works (#2526).** `schedule_send`/`snooze_message` used to hand
+  relative-time phrases straight to a strict ISO-8601 parser, which failed
+  and told the user in chat to supply ISO-8601 themselves — with an example
+  timestamp that was already in the past. No scheduled job was ever created.
+  The agent now resolves "tomorrow morning", "next monday", "in 3 hours",
+  "this evening", "tomorrow at 7" (and similar) itself before calling the
+  scheduling tools, anchored to the local time of the machine/process the
+  agent runs on (the same convention naive ISO-8601 timestamps already used
+  here — not UTC, not a per-user setting). A phrase that still can't be
+  resolved fails with a proposed concrete time (tomorrow 09:00 local)
+  instead of demanding a format. `cancel_scheduled_job` also now accepts a
+  1-based position ("2", "second") from the most recently shown
+  `list_scheduled_jobs` listing, since the user has no way to know the raw
+  job id from chat.
 - **A trashed message is recoverable any time it's still in Trash, not just
   for a few seconds (#2523).** The only restore path (`restore_message`) was
   gated by a short undo window and a live `action_id`; once either was gone,

--- a/hub/agents/email/python/gaia_agent_email/tools/schedule_tools.py
+++ b/hub/agents/email/python/gaia_agent_email/tools/schedule_tools.py
@@ -42,8 +42,8 @@ import time
 from datetime import datetime, timedelta
 from typing import Any, Dict, Optional, Tuple
 
-from gaia_agent_email.tools.envelope import _envelope_err, _envelope_ok
 from gaia_agent_email import action_store, schedule_store
+from gaia_agent_email.tools.envelope import _envelope_err, _envelope_ok
 from gaia_agent_email.verbose import log_tool_call
 
 from gaia.agents.base.tools import tool
@@ -133,9 +133,7 @@ def _resolve_relative_time(raw: str, now: datetime) -> Optional[datetime]:
     if not text:
         return None
 
-    m = re.fullmatch(
-        r"in\s+(\d+)\s*(second|sec|minute|min|hour|hr|day)s?", text
-    )
+    m = re.fullmatch(r"in\s+(\d+)\s*(second|sec|minute|min|hour|hr|day)s?", text)
     if m:
         amount = int(m.group(1))
         unit_seconds = _RELATIVE_UNIT_SECONDS[m.group(2)]
@@ -154,9 +152,7 @@ def _resolve_relative_time(raw: str, now: datetime) -> Optional[datetime]:
         hour, minute = _TIME_OF_DAY.get(period or "morning", (9, 0))
         return _at_time_of_day(base, hour, minute)
 
-    m = re.fullmatch(
-        r"(tomorrow|today)\s+at\s+(\d{1,2})(?::(\d{2}))?\s*(am|pm)?", text
-    )
+    m = re.fullmatch(r"(tomorrow|today)\s+at\s+(\d{1,2})(?::(\d{2}))?\s*(am|pm)?", text)
     if m:
         day_word, hour_str, minute_str, meridiem = m.groups()
         base = now + timedelta(days=1) if day_word == "tomorrow" else now
@@ -406,7 +402,9 @@ def _resolve_cancel_target(db, ref: str) -> str:
     )
 
 
-def cancel_scheduled_job_impl(db, *, job_id: str, debug: bool = False) -> Dict[str, Any]:
+def cancel_scheduled_job_impl(
+    db, *, job_id: str, debug: bool = False
+) -> Dict[str, Any]:
     """Cancel a pending job. ``job_id`` may be an exact id OR a 1-based
     position/ordinal from the most recent listing. Loud on anything not
     cancellable."""

--- a/hub/agents/email/python/gaia_agent_email/tools/schedule_tools.py
+++ b/hub/agents/email/python/gaia_agent_email/tools/schedule_tools.py
@@ -19,13 +19,28 @@ Ordering invariant (Adversarial B2): backend call FIRST, job row only on
 success — a job for an action that never happened is a state-corruption
 class. Cancelling is a loud operation: cancelling a job that already fired
 (or doesn't exist) is an error, never a silent no-op.
+
+Relative-time resolution (#2526): ``send_at``/``until`` accept common
+relative phrases ("tomorrow morning", "next monday", "in 3 hours", "this
+evening") resolved agent-side by :func:`_resolve_relative_time` BEFORE
+``_parse_future_ts`` ever sees them — the agent must own turning natural
+language into a timestamp, not hand that problem back to the user in chat.
+Resolution is anchored to "local time", which here means exactly what naive
+ISO-8601 timestamps already meant in this module: the OS ``TZ`` of the
+machine/process the agent runs on (``datetime.now()`` / ``time.time()``),
+never UTC and never a per-user profile setting — there is no such setting in
+this codebase today. A phrase that resolves to neither a known relative
+pattern nor strict ISO-8601 fails with an actionable error that proposes a
+concrete, always-future time (tomorrow 09:00 local) instead of demanding
+ISO-8601 from a person in a chat window.
 """
 
 from __future__ import annotations
 
+import re
 import time
-from datetime import datetime
-from typing import Any, Dict, Optional
+from datetime import datetime, timedelta
+from typing import Any, Dict, Optional, Tuple
 
 from gaia_agent_email.tools.envelope import _envelope_err, _envelope_ok
 from gaia_agent_email import action_store, schedule_store
@@ -39,29 +54,194 @@ from gaia.logger import get_logger
 log = get_logger(__name__)
 
 
-def _parse_future_ts(value: str, *, now: Optional[float] = None) -> float:
-    """Parse an ISO-8601 timestamp into epoch seconds; must be in the future.
+# Default clock times for a bare time-of-day word, 24h local.
+_TIME_OF_DAY = {
+    "morning": (9, 0),
+    "noon": (12, 0),
+    "afternoon": (14, 0),
+    "evening": (18, 0),
+    "night": (20, 0),
+    "midnight": (0, 0),
+}
 
-    Naive timestamps are interpreted in the machine's local timezone (the
-    scheduler compares against local ``time.time()``). Raises ``ValueError``
-    with an actionable message on bad format or a non-future time.
+_WEEKDAYS = {
+    "monday": 0,
+    "tuesday": 1,
+    "wednesday": 2,
+    "thursday": 3,
+    "friday": 4,
+    "saturday": 5,
+    "sunday": 6,
+}
+
+_RELATIVE_UNIT_SECONDS = {
+    "second": 1,
+    "sec": 1,
+    "minute": 60,
+    "min": 60,
+    "hour": 3600,
+    "hr": 3600,
+    "day": 86400,
+}
+
+# Small ordinals/positions so "cancel the second one" can refer to the
+# most recently shown listing without the user knowing a raw job id (#2526).
+_POSITION_WORDS = {
+    "first": 1,
+    "1st": 1,
+    "second": 2,
+    "2nd": 2,
+    "third": 3,
+    "3rd": 3,
+    "fourth": 4,
+    "4th": 4,
+    "fifth": 5,
+    "5th": 5,
+}
+
+
+def _at_time_of_day(base: datetime, hour: int, minute: int = 0) -> datetime:
+    return base.replace(hour=hour, minute=minute, second=0, microsecond=0)
+
+
+def _parse_clock(
+    hour_str: str, minute_str: Optional[str], meridiem: Optional[str]
+) -> Tuple[int, int]:
+    hour = int(hour_str)
+    minute = int(minute_str) if minute_str else 0
+    if meridiem:
+        meridiem = meridiem.lower()
+        if meridiem == "pm" and hour != 12:
+            hour += 12
+        elif meridiem == "am" and hour == 12:
+            hour = 0
+    # Bare hour, no am/pm: treat as the common casual-speech default (a
+    # morning/daytime hour), e.g. "tomorrow at 7" -> 07:00, not 19:00.
+    return hour % 24, minute
+
+
+def _resolve_relative_time(raw: str, now: datetime) -> Optional[datetime]:
+    """Resolve a relative-time phrase into a concrete local ``datetime``.
+
+    Returns ``None`` when ``raw`` matches no known pattern — the caller then
+    falls back to strict ISO-8601 parsing. ``now`` must be the SAME local
+    wall-clock convention the rest of this module uses for naive timestamps
+    (machine/process ``TZ``); callers pass an injected ``now`` in tests so
+    resolution is deterministic, never dependent on the real clock.
+    """
+    text = raw.strip().lower()
+    if not text:
+        return None
+
+    m = re.fullmatch(
+        r"in\s+(\d+)\s*(second|sec|minute|min|hour|hr|day)s?", text
+    )
+    if m:
+        amount = int(m.group(1))
+        unit_seconds = _RELATIVE_UNIT_SECONDS[m.group(2)]
+        return now + timedelta(seconds=amount * unit_seconds)
+
+    m = re.fullmatch(
+        r"(tomorrow|today|tonight)"
+        r"(?:\s+(morning|afternoon|evening|night|noon|midnight))?",
+        text,
+    )
+    if m:
+        day_word, period = m.group(1), m.group(2)
+        base = now + timedelta(days=1) if day_word == "tomorrow" else now
+        if day_word == "tonight":
+            period = period or "night"
+        hour, minute = _TIME_OF_DAY.get(period or "morning", (9, 0))
+        return _at_time_of_day(base, hour, minute)
+
+    m = re.fullmatch(
+        r"(tomorrow|today)\s+at\s+(\d{1,2})(?::(\d{2}))?\s*(am|pm)?", text
+    )
+    if m:
+        day_word, hour_str, minute_str, meridiem = m.groups()
+        base = now + timedelta(days=1) if day_word == "tomorrow" else now
+        hour, minute = _parse_clock(hour_str, minute_str, meridiem)
+        return _at_time_of_day(base, hour, minute)
+
+    m = re.fullmatch(r"this\s+(morning|afternoon|evening|night)", text)
+    if m:
+        hour, minute = _TIME_OF_DAY[m.group(1)]
+        candidate = _at_time_of_day(now, hour, minute)
+        if candidate <= now:
+            candidate += timedelta(days=1)
+        return candidate
+
+    m = re.fullmatch(
+        r"next\s+(monday|tuesday|wednesday|thursday|friday|saturday|sunday)"
+        r"(?:\s+at\s+(\d{1,2})(?::(\d{2}))?\s*(am|pm)?)?",
+        text,
+    )
+    if m:
+        weekday_name, hour_str, minute_str, meridiem = m.groups()
+        target_weekday = _WEEKDAYS[weekday_name]
+        days_ahead = (target_weekday - now.weekday()) % 7
+        # "next X" means a week out even said on X itself, not "later today".
+        days_ahead = days_ahead or 7
+        base = now + timedelta(days=days_ahead)
+        if hour_str:
+            hour, minute = _parse_clock(hour_str, minute_str, meridiem)
+        else:
+            hour, minute = _TIME_OF_DAY["morning"]
+        return _at_time_of_day(base, hour, minute)
+
+    return None
+
+
+def _propose_time(now: datetime) -> datetime:
+    """A concrete, always-future fallback time: tomorrow 09:00 local.
+
+    Never a stale/past example — computed off the injected/actual ``now``,
+    not a hardcoded literal (the observed defect suggested a timestamp that
+    was already in the past by the time the user read it).
+    """
+    return _at_time_of_day(now + timedelta(days=1), 9, 0)
+
+
+def _parse_future_ts(value: str, *, now: Optional[float] = None) -> float:
+    """Resolve a relative phrase or ISO-8601 timestamp into epoch seconds;
+    must be in the future.
+
+    Tries :func:`_resolve_relative_time` first ("tomorrow morning", "next
+    monday", "in 3 hours", ...); falls back to strict ISO-8601. Naive
+    timestamps (relative or ISO) are interpreted in the machine's local
+    timezone (the scheduler compares against local ``time.time()``). Raises
+    ``ValueError`` with an actionable message — proposing a concrete future
+    time — on bad format or a non-future time.
     """
     raw = (value or "").strip()
+    now_s = time.time() if now is None else now
+    now_dt = datetime.fromtimestamp(now_s)
+    proposal = _propose_time(now_dt).isoformat(timespec="minutes")
+
     if not raw:
         raise ValueError(
-            "no time given. Pass an ISO-8601 timestamp, e.g. "
-            "'2026-07-02T09:00' or '2026-07-02T09:00:00+02:00'."
+            "no time given. Try a phrase like 'tomorrow morning' or 'in 3 "
+            "hours', or an ISO-8601 timestamp, e.g. "
+            f"'{proposal}'."
         )
-    iso = raw[:-1] + "+00:00" if raw.endswith("Z") else raw
-    try:
-        dt = datetime.fromisoformat(iso)
-    except ValueError as exc:
-        raise ValueError(
-            f"could not parse {value!r} as an ISO-8601 timestamp "
-            f"({exc}). Use e.g. '2026-07-02T09:00'."
-        ) from exc
-    ts = dt.timestamp()  # naive -> local time; aware -> exact instant
-    now_s = time.time() if now is None else now
+
+    resolved = _resolve_relative_time(raw, now_dt)
+    if resolved is not None:
+        ts = resolved.timestamp()
+    else:
+        iso = raw[:-1] + "+00:00" if raw.endswith("Z") else raw
+        try:
+            dt = datetime.fromisoformat(iso)
+        except ValueError:
+            raise ValueError(
+                f"couldn't work out a time from {value!r}. Try a phrase "
+                "like 'tomorrow morning', 'next monday', 'in 3 hours', or "
+                f"'this evening' — or an exact ISO-8601 timestamp like "
+                f"'{proposal}'. If tomorrow at 09:00 ({proposal}) works, "
+                "just say so and I'll use that."
+            ) from None
+        ts = dt.timestamp()  # naive -> local time; aware -> exact instant
+
     if ts <= now_s:
         raise ValueError(
             f"{value!r} is not in the future (it is at or before now). "
@@ -201,20 +381,48 @@ def snooze_message_impl(
         }
 
 
+def _resolve_cancel_target(db, ref: str) -> str:
+    """Resolve a cancel target: an exact job_id, or a 1-based position /
+    ordinal ("2", "second") into the CURRENT pending listing — the same
+    due_at order ``list_scheduled_jobs`` shows (#2526). A user who just saw
+    a listing has no way to know the raw job id; letting them say "cancel
+    the second one" avoids demanding it.
+    """
+    text = (ref or "").strip()
+    position: Optional[int] = None
+    if text.isdigit() and len(text) <= 3:
+        position = int(text)
+    elif text.lower() in _POSITION_WORDS:
+        position = _POSITION_WORDS[text.lower()]
+    if position is None:
+        return text
+    pending = schedule_store.list_jobs(db, status=schedule_store.STATUS_PENDING)
+    if 1 <= position <= len(pending):
+        return pending[position - 1]["job_id"]
+    raise ValueError(
+        f"there is no job at position {position} in the current pending "
+        f"list ({len(pending)} pending). Call list_scheduled_jobs to see "
+        "current jobs and their ids/positions."
+    )
+
+
 def cancel_scheduled_job_impl(db, *, job_id: str, debug: bool = False) -> Dict[str, Any]:
-    """Cancel a pending job. Loud on anything not cancellable."""
+    """Cancel a pending job. ``job_id`` may be an exact id OR a 1-based
+    position/ordinal from the most recent listing. Loud on anything not
+    cancellable."""
     with log_tool_call("cancel_scheduled_job", {"job_id": job_id}, debug=debug) as st:
-        if schedule_store.cancel_job(db, job_id=job_id):
-            st["result_summary"] = {"cancelled": job_id}
-            return {"job_id": job_id, "cancelled": True}
-        job = schedule_store.get_job(db, job_id=job_id)
+        resolved_id = _resolve_cancel_target(db, job_id)
+        if schedule_store.cancel_job(db, job_id=resolved_id):
+            st["result_summary"] = {"cancelled": resolved_id}
+            return {"job_id": resolved_id, "cancelled": True}
+        job = schedule_store.get_job(db, job_id=resolved_id)
         if job is None:
             raise ValueError(
-                f"no scheduled job with id {job_id!r}. Use list_scheduled_jobs "
-                "to see pending jobs."
+                f"no scheduled job with id {resolved_id!r}. Use "
+                "list_scheduled_jobs to see pending jobs."
             )
         raise ValueError(
-            f"job {job_id!r} is {job['status']} and can no longer be "
+            f"job {resolved_id!r} is {job['status']} and can no longer be "
             "cancelled — only pending jobs can be."
         )
 
@@ -298,10 +506,14 @@ class ScheduleToolsMixin:
             """Schedule an email to be sent at a future time. Requires user
             confirmation at creation; the send then fires unattended.
 
-            ``send_at`` is an ISO-8601 timestamp (e.g. '2026-07-02T09:00');
-            it must be in the future. ``mailbox`` (optional) chooses which
-            account sends when multiple are connected. Cancellable before it
-            fires via cancel_scheduled_job.
+            ``send_at`` accepts a relative phrase in the user's own words —
+            'tomorrow morning', 'next monday', 'in 3 hours', 'this evening',
+            'tomorrow at 7' — or an ISO-8601 timestamp (e.g.
+            '2026-07-02T09:00'); either way it must resolve to a future
+            local time. Resolve the phrase yourself; never ask the user for
+            ISO-8601. ``mailbox`` (optional) chooses which account sends
+            when multiple are connected. Cancellable before it fires via
+            cancel_scheduled_job.
             """
             try:
                 backend = agent._send_backend(mailbox or None)
@@ -329,9 +541,13 @@ class ScheduleToolsMixin:
             """Snooze a message: remove it from INBOX now and bring it back at
             a future time.
 
-            ``until`` is an ISO-8601 timestamp (e.g. '2026-07-02T09:00'); it
-            must be in the future. ``mailbox`` (optional) routes when multiple
-            mailboxes are connected. Cancellable before it fires via
+            ``until`` accepts a relative phrase in the user's own words —
+            'tomorrow morning', 'next monday', 'in 3 hours', 'this evening',
+            'tomorrow at 7' — or an ISO-8601 timestamp (e.g.
+            '2026-07-02T09:00'); either way it must resolve to a future
+            local time. Resolve the phrase yourself; never ask the user for
+            ISO-8601. ``mailbox`` (optional) routes when multiple mailboxes
+            are connected. Cancellable before it fires via
             cancel_scheduled_job (cancelling keeps the message archived).
             """
             try:
@@ -356,6 +572,9 @@ class ScheduleToolsMixin:
         def cancel_scheduled_job(job_id: str) -> str:
             """Cancel a pending scheduled send or snooze before it fires.
 
+            ``job_id`` may be the exact job id, OR a 1-based position/ordinal
+            ('2', 'second') from the most recently shown
+            list_scheduled_jobs listing — the user rarely knows the raw id.
             Cancelling a scheduled send leaves the draft in the mailbox;
             cancelling a snooze leaves the message archived.
             """

--- a/hub/agents/email/python/tests/test_email_schedule_relative_time_2526.py
+++ b/hub/agents/email/python/tests/test_email_schedule_relative_time_2526.py
@@ -43,7 +43,6 @@ from gaia_agent_email.tools.schedule_tools import (  # noqa: E402
 )
 
 from gaia.database.mixin import DatabaseMixin  # noqa: E402
-
 from tests.fixtures.email.fake_gmail import FakeGmailBackend  # noqa: E402
 
 
@@ -210,7 +209,9 @@ class TestCancelByPosition:
         assert out["cancelled"] is True
         assert out["job_id"] == second["job_id"]
 
-        assert schedule_store.get_job(db, job_id=second["job_id"])["status"] == "cancelled"
+        assert (
+            schedule_store.get_job(db, job_id=second["job_id"])["status"] == "cancelled"
+        )
         assert schedule_store.get_job(db, job_id=first["job_id"])["status"] == "pending"
 
     def test_cancel_position_out_of_range_is_loud(self, tmp_path):

--- a/hub/agents/email/python/tests/test_email_schedule_relative_time_2526.py
+++ b/hub/agents/email/python/tests/test_email_schedule_relative_time_2526.py
@@ -1,0 +1,219 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""
+Relative-time resolution for schedule_send / snooze_message (#2526).
+
+The agent used to hand relative phrases ("tomorrow morning") straight to
+``_parse_future_ts``, which only accepts strict ISO-8601 — so it demanded
+ISO-8601 formatting from the user in chat, and (verified against the DB)
+created NO scheduled job at all. These tests assert the PERSISTED job row,
+not just a tool return value, because that was precisely what silently
+didn't happen.
+
+Every phrase is resolved against an INJECTED "now" (never the real clock) so
+resolution is deterministic. "now" is expressed as a naive local datetime —
+the same "machine/process local timezone" convention ``_parse_future_ts``
+already used for naive ISO timestamps (see schedule_tools.py docstring):
+local time is whatever the host's OS ``TZ`` resolves to, not UTC and not a
+per-user profile setting.
+"""
+
+from __future__ import annotations
+
+import sys
+import time
+from datetime import datetime
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[5]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+pytest.importorskip("gaia_agent_email")
+
+from gaia_agent_email import schedule_store  # noqa: E402
+from gaia_agent_email.tools.schedule_tools import (  # noqa: E402
+    _parse_future_ts,
+    _resolve_relative_time,
+    cancel_scheduled_job_impl,
+    list_scheduled_jobs_impl,
+    snooze_message_impl,
+)
+
+from gaia.database.mixin import DatabaseMixin  # noqa: E402
+
+from tests.fixtures.email.fake_gmail import FakeGmailBackend  # noqa: E402
+
+
+class _DB(DatabaseMixin):
+    pass
+
+
+def _make_db(tmp_path: Path) -> _DB:
+    db = _DB()
+    db.init_db(str(tmp_path / "state.db"))
+    schedule_store.init_schema(db)
+    from gaia_agent_email import action_store
+
+    action_store.init_schema(db)
+    return db
+
+
+def _inbox_message(message_id: str = "msg_1") -> dict:
+    return {
+        "id": message_id,
+        "threadId": f"thread_{message_id}",
+        "labelIds": ["INBOX", "UNREAD"],
+        "internalDate": str(int(time.time() * 1000)),
+        "snippet": "hello",
+        "payload": {
+            "headers": [
+                {"name": "From", "value": "Boss <boss@example.com>"},
+                {"name": "Subject", "value": "Need your input"},
+            ],
+        },
+    }
+
+
+# A fixed injected "now": Tuesday 2026-07-28 08:00 local. Deterministic —
+# never derived from the real clock.
+_NOW_DT = datetime(2026, 7, 28, 8, 0, 0)
+_NOW_S = _NOW_DT.timestamp()
+
+
+class TestRelativePhrasesResolve:
+    """A spread of phrases resolve to a concrete future local datetime."""
+
+    @pytest.mark.parametrize(
+        "phrase,expected",
+        [
+            ("tomorrow morning", datetime(2026, 7, 29, 9, 0)),
+            ("in 2 hours", datetime(2026, 7, 28, 10, 0)),
+            ("in 3 hours", datetime(2026, 7, 28, 11, 0)),
+            ("next Monday", datetime(2026, 8, 3, 9, 0)),
+            ("this evening", datetime(2026, 7, 28, 18, 0)),
+            ("tomorrow at 7", datetime(2026, 7, 29, 7, 0)),
+        ],
+    )
+    def test_phrase_resolves(self, phrase, expected):
+        resolved = _resolve_relative_time(phrase, _NOW_DT)
+        assert resolved == expected, f"{phrase!r} -> {resolved}, want {expected}"
+
+    def test_case_insensitive(self):
+        assert _resolve_relative_time("TOMORROW MORNING", _NOW_DT) == datetime(
+            2026, 7, 29, 9, 0
+        )
+
+
+class TestUtcDayBoundary:
+    """'tomorrow morning' near a UTC-day boundary must still resolve to the
+    correct LOCAL day, not accidentally roll an extra day via UTC math."""
+
+    def test_tomorrow_morning_near_utc_midnight(self):
+        # 23:30 local, which is a different calendar date in UTC for most
+        # timezones — if resolution ever leaked through UTC conversion, the
+        # "tomorrow" here would land on the wrong local date.
+        now_local = datetime(2026, 7, 28, 23, 30, 0)
+        resolved = _resolve_relative_time("tomorrow morning", now_local)
+        assert resolved == datetime(2026, 7, 29, 9, 0, 0)
+
+
+class TestPersistedJobRow:
+    """The observed failure created no scheduled_jobs row at all — assert
+    the persisted row, not just the tool's return value."""
+
+    def test_tomorrow_morning_snooze_creates_persisted_job(self, tmp_path):
+        db = _make_db(tmp_path)
+        backend = FakeGmailBackend(user_email="me@example.com")
+        backend.add_message(_inbox_message("msg_1"))
+
+        assert schedule_store.list_jobs(db, status=schedule_store.STATUS_PENDING) == []
+
+        result = snooze_message_impl(
+            backend,
+            db,
+            message_id="msg_1",
+            until="tomorrow morning",
+            mailbox="google",
+            now=_NOW_S,
+        )
+
+        job_id = result["job_id"]
+        row = schedule_store.get_job(db, job_id=job_id)
+        assert row is not None, "no scheduled job row was persisted"
+        assert row["status"] == "pending"
+        assert row["kind"] == schedule_store.KIND_SNOOZE
+        fired_dt = datetime.fromtimestamp(row["due_at"])
+        assert fired_dt == datetime(2026, 7, 29, 9, 0, 0)
+        # And the message actually left INBOX now, per snooze semantics.
+        assert "INBOX" not in backend.get_message("msg_1")["labelIds"]
+
+
+class TestShortIntervalSchedulesAllowed:
+    """#2537 needs jobs that fire in seconds/minutes to verify on hardware
+    without waiting hours — 'in 2 minutes' must resolve to a near-future
+    timestamp, not be rejected as too soon."""
+
+    def test_in_minutes_resolves_close_to_now(self):
+        resolved = _resolve_relative_time("in 2 minutes", _NOW_DT)
+        assert resolved == datetime(2026, 7, 28, 8, 2, 0)
+
+    def test_in_seconds_resolves_close_to_now(self):
+        resolved = _resolve_relative_time("in 30 seconds", _NOW_DT)
+        assert resolved == datetime(2026, 7, 28, 8, 0, 30)
+
+
+class TestUnresolvablePhrase:
+    """A phrase that can't be resolved must fail with an actionable message
+    that PROPOSES a concrete time — never a bare 'give me ISO-8601' demand."""
+
+    def test_unresolvable_phrase_proposes_concrete_time(self):
+        with pytest.raises(ValueError) as excinfo:
+            _parse_future_ts("whenever is convenient I guess", now=_NOW_S)
+        message = str(excinfo.value)
+        # Must offer an actual next-step time, not just reject.
+        assert "2026-07-29" in message, message
+        assert "09:00" in message, message
+
+    def test_unresolvable_phrase_does_not_only_demand_iso(self):
+        with pytest.raises(ValueError) as excinfo:
+            _parse_future_ts("sometime soonish", now=_NOW_S)
+        message = str(excinfo.value).lower()
+        # It may still mention ISO-8601 as an option, but must not be the
+        # only path offered — a concrete proposed time must also appear.
+        assert "tomorrow" in message or "09:00" in message, message
+
+
+class TestCancelByPosition:
+    """Cancelling should work from a position in the just-shown listing —
+    the user has no way to know the raw job id from chat."""
+
+    def test_cancel_second_job_by_position(self, tmp_path):
+        db = _make_db(tmp_path)
+        backend = FakeGmailBackend(user_email="me@example.com")
+        backend.add_message(_inbox_message("msg_1"))
+        backend.add_message(_inbox_message("msg_2"))
+
+        first = snooze_message_impl(
+            backend, db, message_id="msg_1", until="in 2 hours", now=_NOW_S
+        )
+        second = snooze_message_impl(
+            backend, db, message_id="msg_2", until="in 3 hours", now=_NOW_S
+        )
+
+        listing = list_scheduled_jobs_impl(db)["pending"]
+        assert [j["job_id"] for j in listing] == [first["job_id"], second["job_id"]]
+
+        out = cancel_scheduled_job_impl(db, job_id="2")
+        assert out["cancelled"] is True
+        assert out["job_id"] == second["job_id"]
+
+        assert schedule_store.get_job(db, job_id=second["job_id"])["status"] == "cancelled"
+        assert schedule_store.get_job(db, job_id=first["job_id"])["status"] == "pending"
+
+    def test_cancel_position_out_of_range_is_loud(self, tmp_path):
+        db = _make_db(tmp_path)
+        with pytest.raises(ValueError, match="no job at position"):
+            cancel_scheduled_job_impl(db, job_id="5")


### PR DESCRIPTION
Snoozing or scheduling with an ordinary phrase like "tomorrow morning" used to fail outright: the agent handed the formatting problem back to the user, demanding ISO-8601, and offered a stale example timestamp already in the past — with no scheduled job ever created. The agent now resolves relative phrases itself ("tomorrow morning", "next monday", "in 3 hours", "this evening", "tomorrow at 7") into a concrete timestamp before calling the scheduling tools, anchored to the local time of the machine/process the agent runs on — the same convention naive ISO-8601 timestamps already used here (not UTC, not a per-user setting, since none exists in this codebase). A phrase that still can't be resolved now fails with a proposed concrete future time instead of demanding a format. Also fixed cheaply: `cancel_scheduled_job` now accepts a 1-based position ("2", "second") from the most recently shown listing, since a user has no way to know the raw job id from chat.

Closes #2526

### Test plan
- [x] `python -m pytest hub/agents/email/python/tests -k "snooze or schedul" -q` — 50 passed
- [x] `python -m pytest hub/agents/email/python/tests/test_email_schedule_relative_time_2526.py -q` — new tests: phrase resolution, UTC-day-boundary correctness, **persisted job row** assertion for "tomorrow morning" (the observed defect was that no row was ever written), short-interval ("in 2 minutes") resolution for #2537, unresolvable-phrase actionable message, cancel-by-position
- [x] `python -m pytest hub/agents/email/python/tests -q` — full email suite, 1045 passed
- [x] `black`/`isort`/`flake8` clean on both changed files (hub/ isn't covered by `util/lint.py`, checked manually)

Note: this changes `schedule_send`/`snooze_message`/`cancel_scheduled_job` tool docstrings, which can affect eval behavior — flagging per repo convention rather than running `gaia eval`.
