### PR TITLE
fix(email): briefing carries a structured breakdown, not one sentence

### DIFF
--- a/hub/agents/email/python/CHANGELOG.md
+++ b/hub/agents/email/python/CHANGELOG.md
@@ -53,6 +53,19 @@ contract version is tracked separately as
 
 ### Fixed
 
+- **The inbox briefing carries a structured breakdown instead of one padded
+  sentence (#2525).** `get_briefing` already returned the full
+  `email_pre_scan` envelope (urgent/actionable messages, counts, applied
+  preferences) — the tool's own docstring was the bug: it told the model to
+  "write a short framing sentence, do not recite the JSON" as if a card
+  rendered the details, but unlike `pre_scan_inbox` no card renders a
+  briefing, so that one sentence was the entire answer. `summarize_briefing`
+  now computes the breakdown in code (total scanned, urgency/category
+  counts, the individual urgent/actionable messages, and named applied
+  preferences) so the reply can never assert an urgency judgement the
+  pre-scan classification did not itself make; the tool docstring and system
+  prompt now point the model at that computed `data.summary` instead of
+  asking it to compress everything away.
 - **A trashed message is recoverable any time it's still in Trash, not just
   for a few seconds (#2523).** The only restore path (`restore_message`) was
   gated by a short undo window and a live `action_id`; once either was gone,

--- a/hub/agents/email/python/gaia_agent_email/agent.py
+++ b/hub/agents/email/python/gaia_agent_email/agent.py
@@ -272,7 +272,13 @@ have nothing to add beyond the card, still write the one framing sentence.
 BRIEFING & TASKS:
 - For a daily briefing / morning brief / "summarize my inbox for today",
   call ``get_briefing`` — NOT ``pre_scan_inbox``. The briefing is the
-  dedicated tool for that ask; do not fall back to a raw pre-scan.
+  dedicated tool for that ask; do not fall back to a raw pre-scan. Unlike
+  pre-scan, no card renders the briefing — your reply is the whole answer.
+  Use the tool's precomputed ``data.summary``: state its ``headline``, list
+  each ``highlights`` entry individually (not just a count), say plainly
+  when ``needs_attention`` is false, and name every ``preferences_applied``
+  entry. Never assert an urgency judgement ``data.summary`` did not itself
+  compute.
 - For "extract action items" / "what do I need to do from my inbox", call
   ``extract_action_items`` — it scans your recent mail and captures the
   to-dos even if you have not triaged yet.

--- a/hub/agents/email/python/gaia_agent_email/briefing.py
+++ b/hub/agents/email/python/gaia_agent_email/briefing.py
@@ -189,6 +189,76 @@ def persist_briefing(record: Dict[str, Any], path: Optional[Path] = None) -> Pat
     return dest
 
 
+def summarize_briefing(envelope: Dict[str, Any]) -> Dict[str, Any]:
+    """Deterministic, testable breakdown of a pre-scan envelope (#2525).
+
+    ``get_briefing`` was returning the full ``email_pre_scan`` envelope but
+    telling the model to collapse it into "one short framing sentence" —
+    unlike ``pre_scan_inbox``, no card renders for the briefing, so that
+    sentence was the entire user-visible answer. Every field the envelope
+    already computed (urgency counts, the individual urgent/actionable
+    messages, applied preferences) was silently discarded.
+
+    This function reads that breakdown directly off the envelope's own
+    counts and lists — it never infers or judges anything the classifier did
+    not already decide, so a ``needs_attention`` of ``False`` is only ever
+    true when the pre-scan itself found zero urgent/actionable messages.
+    Missing/legacy envelope shapes degrade to zero counts rather than
+    raising, since a stale persisted record may predate this field.
+    """
+    totals = envelope.get("totals") or {}
+    urgent_n = int(totals.get("urgent", 0) or 0)
+    actionable_n = int(totals.get("actionable", 0) or 0)
+    informational_n = int(
+        totals.get("informational", envelope.get("informational_count", 0)) or 0
+    )
+    archive_n = int(totals.get("suggested_archives", 0) or 0)
+    total_scanned = urgent_n + actionable_n + informational_n + archive_n
+
+    needs_attention = urgent_n > 0 or actionable_n > 0
+    if needs_attention:
+        headline = (
+            f"{total_scanned} messages scanned: {urgent_n} urgent, "
+            f"{actionable_n} waiting on a reply."
+        )
+    else:
+        headline = (
+            f"Nothing needs attention — {total_scanned} messages scanned, "
+            "all informational."
+        )
+
+    highlights = [
+        {**item, "urgency": "urgent"} for item in envelope.get("urgent") or []
+    ] + [{**item, "urgency": "actionable"} for item in envelope.get("actionable") or []]
+
+    prefs = envelope.get("preferences_applied") or {}
+    preferences_applied = [
+        f"priority sender: {sender}" for sender in prefs.get("priority_senders") or []
+    ]
+    preferences_applied += [
+        f"low priority sender: {sender}"
+        for sender in prefs.get("low_priority_senders") or []
+    ]
+    preferences_applied += [
+        f"{category} default: {default}"
+        for category, default in (prefs.get("category_defaults") or {}).items()
+    ]
+
+    return {
+        "total_scanned": total_scanned,
+        "breakdown": {
+            "urgent": urgent_n,
+            "actionable": actionable_n,
+            "informational": informational_n,
+            "suggested_archives": archive_n,
+        },
+        "needs_attention": needs_attention,
+        "headline": headline,
+        "highlights": highlights,
+        "preferences_applied": preferences_applied,
+    }
+
+
 def load_latest_briefing(path: Optional[Path] = None) -> Optional[Dict[str, Any]]:
     """Return the latest persisted briefing record, or ``None`` if no
     briefing has been generated yet.
@@ -375,4 +445,5 @@ __all__ = [
     "persist_briefing",
     "run_briefing_job",
     "seconds_until_next_run",
+    "summarize_briefing",
 ]

--- a/hub/agents/email/python/gaia_agent_email/tools/briefing_tools.py
+++ b/hub/agents/email/python/gaia_agent_email/tools/briefing_tools.py
@@ -58,14 +58,26 @@ class BriefingToolsMixin:
             "morning brief", or "what's my inbox summary for today". Returns
             the most recent scheduled briefing if one has been generated;
             otherwise generates a fresh briefing now over every connected
-            mailbox and persists it. The payload is the same
-            ``email_pre_scan`` envelope the triage card renders — write a short
-            framing sentence, do not recite the JSON.
+            mailbox and persists it.
+
+            Unlike ``pre_scan_inbox``, no card renders for this tool's result
+            — your reply IS the briefing, so do not pad it into one sentence.
+            ``data.summary`` is already computed for you (never compute or
+            guess your own urgency judgement): state ``data.summary.headline``
+            in your own words, then list each entry in
+            ``data.summary.highlights`` individually (subject + sender), not
+            just the count. If ``data.summary.needs_attention`` is false, say
+            plainly that nothing needs attention. Name every entry in
+            ``data.summary.preferences_applied`` (e.g. "using your low
+            priority: ..."), matching the pre-scan card's behavior. Never
+            assert an urgency conclusion that ``data.summary`` /
+            ``data.briefing`` did not itself compute.
             """
             try:
                 from gaia_agent_email.briefing import (
                     load_latest_briefing,
                     persist_briefing,
+                    summarize_briefing,
                 )
 
                 record = load_latest_briefing()
@@ -78,6 +90,11 @@ class BriefingToolsMixin:
                         "briefing": envelope,
                     }
                     persist_briefing(record)
+                # Computed fresh on every call (never trust a persisted
+                # "summary" as current) so a briefing generated before #2525
+                # still gets the structured breakdown on read.
+                record = dict(record)
+                record["summary"] = summarize_briefing(record.get("briefing") or {})
                 return _envelope_ok(record)
             except ConnectorsError as exc:
                 return _envelope_err(format_connector_error(exc))

--- a/hub/agents/email/python/tests/test_briefing_task_tools_2110.py
+++ b/hub/agents/email/python/tests/test_briefing_task_tools_2110.py
@@ -113,6 +113,42 @@ def test_get_briefing_cold_generates(host, monkeypatch, tmp_path):
     assert (tmp_path / "brief.json").exists()  # persisted
 
 
+def test_get_briefing_includes_structured_summary(host, monkeypatch, tmp_path):
+    # #2525 — the tool result must carry a computed breakdown (counts,
+    # individual highlighted messages, applied preferences), not leave the
+    # model to collapse everything into one sentence.
+    import gaia_agent_email.briefing as briefing
+
+    monkeypatch.setattr(briefing, "briefing_path", lambda: tmp_path / "brief.json")
+    host._pre_scan_all_backends = lambda *, max_messages: {
+        "kind": "email_pre_scan",
+        "urgent": [
+            {
+                "message_id": "u1",
+                "sender": "boss@corp.example",
+                "subject": "Server down",
+            }
+        ],
+        "actionable": [],
+        "informational_count": 24,
+        "suggested_archives": [],
+        "preferences_applied": {
+            "priority_senders": ["boss@corp.example"],
+            "low_priority_senders": [],
+            "category_defaults": {},
+        },
+        "totals": {"urgent": 1, "actionable": 0, "informational": 24},
+    }
+    fn = _tool(host, "get_briefing")
+    out = json.loads(fn(max_messages=10))
+
+    summary = out["data"]["summary"]
+    assert summary["breakdown"]["urgent"] == 1
+    assert summary["needs_attention"] is True
+    assert summary["highlights"][0]["message_id"] == "u1"
+    assert "priority sender: boss@corp.example" in summary["preferences_applied"]
+
+
 def test_get_briefing_returns_persisted_when_present(host, monkeypatch, tmp_path):
     import gaia_agent_email.briefing as briefing
 

--- a/hub/agents/email/python/tests/test_email_briefing.py
+++ b/hub/agents/email/python/tests/test_email_briefing.py
@@ -33,6 +33,7 @@ from gaia_agent_email.briefing import (
     persist_briefing,
     run_briefing_job,
     seconds_until_next_run,
+    summarize_briefing,
 )
 
 
@@ -300,3 +301,147 @@ def test_persist_briefing_is_atomic_and_loadable(tmp_path):
     persist_briefing(record, path=dest)
     assert load_latest_briefing(path=dest) == record
     assert not dest.with_suffix(".json.tmp").exists()
+
+
+# ---------------------------------------------------------------------------
+# #2525 — the briefing must carry a structured breakdown, not just a count.
+#
+# The pre-scan envelope already has the urgency/category counts, the
+# individual urgent/actionable items, and the applied preferences — the bug
+# was that the LLM was told to collapse all of it into "one short framing
+# sentence" and discard the rest. ``summarize_briefing`` computes the
+# breakdown deterministically (in code, not by the model) so the headline can
+# never assert an urgency judgement the classification did not itself make.
+# ---------------------------------------------------------------------------
+
+
+def _mixed_envelope() -> dict:
+    return {
+        "kind": "email_pre_scan",
+        "urgent": [
+            {
+                "message_id": "u1",
+                "thread_id": "t-u1",
+                "sender": "boss@corp.example",
+                "subject": "Server down — need you now",
+                "why": "urgent keyword + escalation",
+            }
+        ],
+        "actionable": [
+            {
+                "message_id": "a1",
+                "thread_id": "t-a1",
+                "sender": "alice@corp.example",
+                "subject": "Can you review this by EOD?",
+                "why": "needs a reply",
+            }
+        ],
+        "informational_count": 23,
+        "suggested_archives": [
+            {
+                "message_id": "s1",
+                "thread_id": "t-s1",
+                "sender": "deals@shop.example",
+                "subject": "50% off this weekend!",
+                "reason": "promotional",
+            }
+        ],
+        "suggested_drafts": [],
+        "preferences_applied": {
+            "priority_senders": ["boss@corp.example"],
+            "low_priority_senders": ["newsletters@techcrunch.com"],
+            "category_defaults": {},
+        },
+        "totals": {
+            "urgent": 1,
+            "actionable": 1,
+            "informational": 23,
+            "suggested_archives": 1,
+        },
+    }
+
+
+def _all_informational_envelope() -> dict:
+    return {
+        "kind": "email_pre_scan",
+        "urgent": [],
+        "actionable": [],
+        "informational_count": 25,
+        "suggested_archives": [],
+        "suggested_drafts": [],
+        "preferences_applied": {
+            "priority_senders": [],
+            "low_priority_senders": [],
+            "category_defaults": {},
+        },
+        "totals": {
+            "urgent": 0,
+            "actionable": 0,
+            "informational": 25,
+            "suggested_archives": 0,
+        },
+    }
+
+
+def test_briefing_summary_reports_all_three_counts():
+    summary = summarize_briefing(_mixed_envelope())
+
+    assert summary["breakdown"] == {
+        "urgent": 1,
+        "actionable": 1,
+        "informational": 23,
+        "suggested_archives": 1,
+    }
+    assert summary["total_scanned"] == 26
+    assert summary["needs_attention"] is True
+
+
+def test_briefing_summary_all_informational_states_it_plainly():
+    summary = summarize_briefing(_all_informational_envelope())
+
+    assert summary["needs_attention"] is False
+    assert summary["total_scanned"] == 25
+    assert summary["breakdown"]["informational"] == 25
+    # The headline must plainly say nothing needs attention, not pad it.
+    assert "nothing" in summary["headline"].lower()
+    assert "25" in summary["headline"]
+
+
+def test_briefing_summary_surfaces_messages_individually():
+    summary = summarize_briefing(_mixed_envelope())
+
+    # Not just a count — the actual urgent + actionable messages, individually.
+    subjects = {item["subject"] for item in summary["highlights"]}
+    assert subjects == {"Server down — need you now", "Can you review this by EOD?"}
+    urgencies = {item["message_id"]: item["urgency"] for item in summary["highlights"]}
+    assert urgencies == {"u1": "urgent", "a1": "actionable"}
+
+
+def test_briefing_summary_names_applied_preferences():
+    summary = summarize_briefing(_mixed_envelope())
+
+    assert "priority sender: boss@corp.example" in summary["preferences_applied"]
+    assert (
+        "low priority sender: newsletters@techcrunch.com"
+        in summary["preferences_applied"]
+    )
+
+
+def test_briefing_summary_never_asserts_unset_urgency():
+    # An envelope where the classifier found nothing urgent/actionable must
+    # never be summarized as needing attention, no matter what informational
+    # count is present — the honesty rule from #2525.
+    summary = summarize_briefing(_all_informational_envelope())
+    assert summary["needs_attention"] is False
+    assert summary["breakdown"]["urgent"] == 0
+    assert summary["breakdown"]["actionable"] == 0
+
+
+def test_briefing_summary_tolerates_missing_optional_fields():
+    # A stub/legacy envelope missing keys (e.g. a bare {"kind": "x"} persisted
+    # by an older build) must not crash the summary — it degrades to zeros.
+    summary = summarize_briefing({"kind": "x"})
+    assert summary["total_scanned"] == 0
+    assert summary["needs_attention"] is False
+    assert summary["highlights"] == []
+    assert summary["preferences_applied"] == []


### PR DESCRIPTION
Closes #2525

The inbox briefing was collapsing to a single padded sentence ("no urgent items, 25 general information") even though the tool result already carried the full breakdown — urgency/category counts, the individual urgent and actionable messages, and applied preferences. The `get_briefing` tool's own docstring was the actual bug: it told the model to "write a short framing sentence, do not recite the JSON" as if a card rendered the details the way `pre_scan_inbox`'s does, but no card renders a briefing, so that one sentence was the whole answer. `get_briefing` now returns a `data.summary` computed in code (never by the model) — total scanned, counts by category, the individual highlighted messages, and named applied preferences — and the tool docstring + system prompt point the model at it instead of asking it to compress everything away.

## Test plan

- [x] `python -m pytest hub/agents/email/python/tests -k "briefing" -q` — 42 passed (35 pre-existing + 7 new for `summarize_briefing`, plus 1 tool-wiring test)
- [x] `python -m pytest hub/agents/email/python/tests -q` — 1037 passed, no regressions
- [x] `python util/lint.py --all` — all blocking checks pass (black/isort/pylint/flake8/bandit); pre-existing mypy warnings only, none in touched files

<details>
<summary>Notes for reviewers</summary>

- Root cause was the **prompt layer**, not the tool's data: `pre_scan_inbox_impl` / `merge_pre_scan_backends` already return urgent/actionable/informational/suggested_archives with counts and applied preferences — `get_briefing` just wrapped that envelope and told the model to discard it into one sentence.
- Did not touch `tui/`, `read_tools.py`, `preference_tools.py`, `calendar_tools.py`, or `agent_routes.py` per scope. No new render card was needed — the fix is a computed `data.summary` field the model reads, not a rendering change.
- This touches a tool docstring and the system prompt, both LLM-affecting surfaces — per repo policy an eval (`gaia eval agent`) may be warranted before merge; none was run here (explicitly out of scope for this change).
- New defect noticed but **not** fixed here (out of scope): `hub/agents/email/python/gaia_agent_email/briefing.py`'s `run_briefing_job`/`persist_briefing` path (the scheduled-briefing / REST `GET /v1/email/briefing` surface) does not get the new `summary` field — only the agent-loop `get_briefing` tool does. If the REST pull surface or a future TUI card wants the same breakdown, `summarize_briefing()` is already factored out and reusable there.

</details>
