### PR TITLE
fix(email): draft_reply/draft_forward compose the body, don't ask for it

### DIFF
--- a/hub/agents/email/npm/CHANGELOG.md
+++ b/hub/agents/email/npm/CHANGELOG.md
@@ -6,6 +6,17 @@ behind any entry — API shapes, endpoints, and version semantics — see
 
 ## Unreleased
 
+- **Asking the agent to draft a reply or forward now actually drafts one,
+  instead of asking you to write it.** The agent would correctly find the
+  right email, then ask you to supply the reply or forward text — the exact
+  thing you'd asked it to write. Nothing told it that composing the message
+  was its own job (that instruction only existed once it had learned your
+  writing style from enough sent mail, so it never applied to a fresh
+  mailbox). It now writes the reply or forward itself from the original
+  message plus whatever you specified (length, tone, points to hit), and
+  still uses your exact wording when you hand it over yourself. Sending is
+  unchanged — every draft still needs your confirmation before it goes out
+  (#2524).
 - **A trashed email is recoverable any time it's still in Trash — not just for
   a few seconds after you delete it.** The only way back used to be a short
   undo window right after trashing; miss it, and the agent told you the

--- a/hub/agents/email/python/CHANGELOG.md
+++ b/hub/agents/email/python/CHANGELOG.md
@@ -53,6 +53,23 @@ contract version is tracked separately as
 
 ### Fixed
 
+- **`draft_reply` / `draft_forward` actually draft instead of asking for the
+  text to draft (#2524).** Asked to draft a reply or forward, the agent
+  correctly located the source message and then asked the user to supply the
+  finished reply/forward text — the thing it was asked to write. Neither
+  tool's docstring nor the base system prompt ever told the model that
+  composing `body` is its own job; the only place that said so was the
+  voice-profile style guidance, which only appears once enough Sent-mail
+  history has been learned, so a fresh mailbox never saw it.
+  `draft_forward`'s `body` was already optional, ruling out a simple
+  required-parameter theory — this was a missing authorship contract, not a
+  schema-required-ness problem. Both tools' docstrings and the always-present
+  REPLYING/DRAFTING system-prompt section now say explicitly: the model
+  writes the body itself, from the source message plus any stated
+  constraints (length, tone, points to hit), in the same turn it resolves
+  the target — and only uses the user's own wording verbatim when they hand
+  it over explicitly. `send_draft` / `send_now` / `forward_message` remain
+  confirmation-gated; drafting still never sends.
 - **A trashed message is recoverable any time it's still in Trash, not just
   for a few seconds (#2523).** The only restore path (`restore_message`) was
   gated by a short undo window and a live `action_id`; once either was gone,

--- a/hub/agents/email/python/gaia_agent_email/agent.py
+++ b/hub/agents/email/python/gaia_agent_email/agent.py
@@ -330,6 +330,15 @@ if the reference is ambiguous the tool returns the candidate list for the user
 to pick from; if nothing matches it says so. Only when the tool reports multiple
 matches do you ask the user which one.
 
+You write the reply/forward body yourself. ``draft_reply``'s ``body`` and
+``draft_forward``'s optional ``body`` are the finished text for the draft, not
+a placeholder for the user to fill in — compose it from the source message
+plus any constraints the user gave (length, tone, points to hit) and call the
+tool with it in the SAME turn you resolve the target. Never ask the user to
+supply or dictate the wording first; that defeats the point of asking you to
+draft. Use the user's own words verbatim only when they explicitly hand you
+exact text to send.
+
 OUTPUT:
 Tool results come back as JSON envelopes ``{"ok": true, "data": ...}``
 or ``{"ok": false, "error": "..."}``. Summarize tool output briefly for

--- a/hub/agents/email/python/gaia_agent_email/tools/reply_tools.py
+++ b/hub/agents/email/python/gaia_agent_email/tools/reply_tools.py
@@ -555,6 +555,14 @@ class ReplyToolsMixin:
             or paste the exact subject first. If several messages match it lists
             them so you can pick; if none match it says so.
 
+            ``body`` is the finished reply text — you write it, in this same
+            call. Read the source message (call get_message/get_thread first if
+            you have not already seen it) and compose a reply that addresses it,
+            honoring any constraints the user stated (length, tone, points to
+            hit). Do NOT ask the user to dictate the wording before drafting —
+            that defeats the point of being asked to draft. Use the user's own
+            words verbatim only when they hand you exact text to send.
+
             ``mailbox`` (optional) names the source mailbox so the draft is
             created in the right account when multiple mailboxes are connected.
             ``attachments`` (optional) is a comma-separated list of full paths
@@ -608,6 +616,11 @@ class ReplyToolsMixin:
             message_id: str, to: str, body: str = "", mailbox: str = ""
         ) -> str:
             """Create a forward draft for a message (does NOT send).
+
+            ``body`` is an optional note prepended above the forwarded content —
+            you write it yourself from whatever the user asked for (e.g. "with a
+            one-line note"); leave it empty only for a bare forward with no note.
+            Do NOT ask the user to dictate the note before drafting.
 
             ``mailbox`` (optional) routes when multiple mailboxes are connected.
             """

--- a/hub/agents/email/python/tests/test_draft_content_authorship_2524.py
+++ b/hub/agents/email/python/tests/test_draft_content_authorship_2524.py
@@ -1,0 +1,250 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""``draft_reply`` / ``draft_forward`` ask for content instead of drafting (#2524).
+
+Asked to draft a reply or forward, the agent located the source message
+correctly (message-id resolution, #2403, already worked) and then asked the
+user to supply the finished reply/forward text — the thing it was asked to
+write. No draft was produced.
+
+Root cause: neither tool's docstring (the schema the tool-calling model
+actually sees — ``_build_openai_tool_schemas`` puts the *whole* docstring
+verbatim into the function's ``description``, and per-parameter descriptions
+are never populated, see ``gaia.agents.base.tools.tool``) nor the
+unconditional system prompt ever told the model that composing ``body`` is
+its own job. The only place that said "write the draft body yourself" was
+``voice_profile.render_style_guidance`` — appended ONLY once a voice profile
+has been learned from enough Sent-mail history (``agent.py:_get_system_prompt``),
+which does not exist for a fresh mailbox. That explains why ``draft_forward``
+asked too, even though its ``body`` parameter was already *optional*
+(``= ""``) — this was never a required-parameter problem, it was a missing
+authorship contract.
+
+The fix adds that contract in the two unconditional, always-present spots:
+the ``draft_reply`` / ``draft_forward`` docstrings and the base
+REPLYING/DRAFTING section of the system prompt.
+
+Because the actual "ask instead of draft" behavior is a choice the LLM makes
+when generating tool-call arguments, it cannot be exercised hermetically
+(no Lemonade, per repo convention for this test tier). Tests here instead
+pin the two contracts that are the direct, verifiable fix: the tool-schema
+description text the model receives, and the unconditional system-prompt
+text. Both assertions fail against the pre-fix docstrings/prompt and pass
+after. The remaining tests are regression guards on the tool's actual
+runtime behavior: explicit user text still passes through verbatim, and no
+send-capable backend method is ever reachable from a drafting call — the
+send/forward confirmation floor is untouched.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# parents[0] = tests/, [1] = python/, [2] = email/, [3] = agents/,
+# [4] = hub/, [5] = repo-root
+_REPO_ROOT = Path(__file__).resolve().parents[5]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+pytest.importorskip("gaia_agent_email")
+
+from gaia_agent_email.agent import _SYSTEM_PROMPT, EmailTriageAgent  # noqa: E402
+from gaia_agent_email.config import EmailAgentConfig  # noqa: E402
+
+from gaia.agents.base.tools import _TOOL_REGISTRY  # noqa: E402
+from tests.fixtures.email.fake_gmail import FakeGmailBackend  # noqa: E402
+
+
+class _MinimalCalendarBackend:
+    pass
+
+
+def _msg(
+    msg_id: str, *, sender: str = "boss@example.com", subject: str = "Q3 plan"
+) -> dict:
+    return {
+        "id": msg_id,
+        "threadId": msg_id,
+        "internalDate": "1700000000000",
+        "snippet": "Can you take a look at the Q3 plan and get back to me?",
+        "labelIds": ["INBOX", "UNREAD"],
+        "payload": {
+            "headers": [
+                {"name": "From", "value": sender},
+                {"name": "Subject", "value": subject},
+                {"name": "Date", "value": "Thu, 23 Jul 2026 09:00:00 +0000"},
+            ]
+        },
+    }
+
+
+def _build_agent(tmp_path: Path, backend: FakeGmailBackend) -> EmailTriageAgent:
+    """Build a hermetic EmailTriageAgent — FakeGmailBackend, no Lemonade.
+
+    Memory is disabled outright (unneeded here, and it sidesteps FAISS/
+    embedder mocking entirely) via env var, same pattern used by
+    test_email_behavioral_learning.py's ``memory_disabled=True`` path.
+    """
+    import os
+
+    cfg = EmailAgentConfig(
+        gmail_backend=backend,
+        calendar_backend=_MinimalCalendarBackend(),
+        db_path=str(tmp_path / "state.db"),
+        memory_db_path=str(tmp_path / "memory.db"),
+        silent_mode=True,
+        debug=False,
+    )
+    old = os.environ.get("GAIA_MEMORY_DISABLED")
+    os.environ["GAIA_MEMORY_DISABLED"] = "1"
+    try:
+        with patch("gaia.agents.base.agent.AgentSDK") as mock_sdk:
+            mock_sdk.return_value = MagicMock()
+            return EmailTriageAgent(config=cfg)
+    finally:
+        if old is None:
+            del os.environ["GAIA_MEMORY_DISABLED"]
+        else:
+            os.environ["GAIA_MEMORY_DISABLED"] = old
+
+
+def _call_tool(name: str, *args, **kwargs) -> dict:
+    """Invoke a registered tool by name exactly as the agent loop would."""
+    entry = _TOOL_REGISTRY.get(name)
+    assert entry is not None, f"{name} tool not registered"
+    return json.loads(entry["function"](*args, **kwargs))
+
+
+# ---------------------------------------------------------------------------
+# The actual fix: schema/prompt contracts the tool-calling model reads.
+# These fail against the pre-fix docstrings/prompt and pass after.
+# ---------------------------------------------------------------------------
+
+
+class TestBodyAuthorshipContract:
+    """The model must be told IT authors the body — not the user."""
+
+    def test_draft_reply_description_tells_model_to_write_body_itself(self, tmp_path):
+        backend = FakeGmailBackend(user_email="me@example.com")
+        backend.add_message(_msg("m1"))
+        _build_agent(tmp_path, backend)
+
+        description = _TOOL_REGISTRY["draft_reply"]["description"]
+        lowered = description.lower()
+        assert "you write it" in lowered or "compose" in lowered, (
+            "draft_reply's docstring (the schema a tool-calling model receives "
+            "as its function description, per _build_openai_tool_schemas) must "
+            "instruct the model to compose `body` itself instead of waiting on "
+            "the user to supply finished prose"
+        )
+        assert "do not ask the user" in lowered or "never ask the user" in lowered
+
+    def test_draft_forward_description_tells_model_to_write_body_itself(self, tmp_path):
+        backend = FakeGmailBackend(user_email="me@example.com")
+        backend.add_message(_msg("m1"))
+        _build_agent(tmp_path, backend)
+
+        description = _TOOL_REGISTRY["draft_forward"]["description"]
+        lowered = description.lower()
+        assert "you write it" in lowered
+        assert "do not ask the user" in lowered or "never ask the user" in lowered
+
+    def test_system_prompt_establishes_authorship_unconditionally(self):
+        """The base (always-present) system prompt, not the voice-profile
+        fragment that only exists once Sent-mail history has been learned —
+        a fresh mailbox with no learned voice profile never sees that
+        fragment (agent.py:_get_system_prompt), so the base prompt is the
+        only unconditional home for this instruction.
+        """
+        lowered = _SYSTEM_PROMPT.lower()
+        assert "you write the reply/forward body yourself" in lowered
+        assert "never ask the user to" in lowered
+
+
+# ---------------------------------------------------------------------------
+# Regression guards on actual tool behavior.
+# ---------------------------------------------------------------------------
+
+
+class TestExplicitContentHonoredVerbatim:
+    def test_draft_reply_uses_explicit_body_verbatim(self, tmp_path):
+        backend = FakeGmailBackend(user_email="me@example.com")
+        backend.add_message(_msg("m1"))
+        _build_agent(tmp_path, backend)
+
+        exact_text = "Sounds good, let's sync Thursday at 2pm."
+        result = _call_tool("draft_reply", "m1", exact_text)
+        assert result["ok"] is True
+        assert result["data"]["body_preview"] == exact_text
+
+        create_calls = [c for c in backend.transport.calls if c[0] == "create_draft"]
+        assert len(create_calls) == 1
+        assert create_calls[0][1]["body"] == exact_text
+
+    def test_draft_forward_uses_explicit_note_verbatim(self, tmp_path):
+        backend = FakeGmailBackend(user_email="me@example.com")
+        backend.add_message(_msg("m1"))
+        _build_agent(tmp_path, backend)
+
+        note = "FYI, thought this was relevant."
+        result = _call_tool("draft_forward", "m1", "colleague@example.com", note)
+        assert result["ok"] is True
+
+        create_calls = [c for c in backend.transport.calls if c[0] == "create_draft"]
+        assert len(create_calls) == 1
+        assert create_calls[0][1]["body"].startswith(note)
+
+
+class TestDraftingProducesNonEmptyDraft:
+    def test_draft_reply_with_composed_body_creates_draft(self, tmp_path):
+        """Regression guard: a body an agent COMPOSED (not user-dictated) still
+        reaches create_draft untouched — nothing downstream re-validates or
+        discards agent-authored prose.
+        """
+        backend = FakeGmailBackend(user_email="me@example.com")
+        backend.add_message(_msg("m1"))
+        _build_agent(tmp_path, backend)
+
+        composed = (
+            "Thanks for sending this over — I'll review the Q3 plan and get "
+            "back to you by end of week."
+        )
+        result = _call_tool("draft_reply", "m1", composed)
+        assert result["ok"] is True
+        assert result["data"]["draft_id"]
+        assert result["data"]["body_preview"]
+
+
+# ---------------------------------------------------------------------------
+# Drafting still NEVER sends — the confirmation floor is untouched.
+# ---------------------------------------------------------------------------
+
+
+class TestSendSurfaceUntouched:
+    def test_send_confirmation_floor_unchanged(self):
+        """send_draft/send_now stay confirm-gated; draft_reply/draft_forward
+        stay outside the confirmation floor (they were already safe — the
+        fix must not move that line either direction).
+        """
+        floor = EmailTriageAgent.CONFIRMATION_REQUIRED_TOOLS
+        assert "send_draft" in floor
+        assert "send_now" in floor
+        assert "draft_reply" not in floor
+        assert "draft_forward" not in floor
+
+    def test_no_send_capable_method_called_by_drafting(self, tmp_path):
+        backend = FakeGmailBackend(user_email="me@example.com")
+        backend.add_message(_msg("m1"))
+        _build_agent(tmp_path, backend)
+
+        _call_tool("draft_reply", "m1", "Thanks, will follow up.")
+        _call_tool("draft_forward", "m1", "colleague@example.com", "FYI")
+
+        method_names = {c[0] for c in backend.transport.calls}
+        assert "send_message" not in method_names
+        assert "send_draft" not in method_names


### PR DESCRIPTION
Asked to draft a reply or forward, the agent correctly found the source email and then asked the user to write the reply/forward text — the thing it was asked to draft. Neither tool's docstring nor the base system prompt ever told the model that composing `body` is its own job; the only place that said so (voice-profile style guidance) only appears once enough Sent-mail history has been learned, so it never applied on the fresh mailbox where this was observed. Both tools now draft from the source message plus any stated constraints (length, tone, key points), using the user's own wording verbatim only when they hand it over explicitly. Sending is untouched — `send_draft`/`send_now`/`forward_message` remain confirmation-gated.

Closes #2524

<details>
<summary>Diagnosis detail</summary>

The plan's hypothesis was that a required `body` parameter blocked the call. That's disproved by the code: `draft_forward`'s `body` was already optional (`= ""`), yet it asked too. The real fault is the docstring/schema layer — `_build_openai_tool_schemas` (`src/gaia/agents/base/agent.py:1301`) sends the **whole docstring** as the tool's `description` to the tool-calling model, and per-parameter descriptions are never populated (`gaia.agents.base.tools.tool`, `src/gaia/agents/base/tools.py:19`). Neither `draft_reply` nor `draft_forward`'s docstring (`hub/agents/email/python/gaia_agent_email/tools/reply_tools.py`) said anything about who authors `body`, and the always-present REPLYING/DRAFTING system-prompt section (`hub/agents/email/python/gaia_agent_email/agent.py`) was silent on it too — only the *conditional* voice-profile fragment said "you write it," and that's gated on a learned voice profile that doesn't exist for a new mailbox.

Fixed the docstrings and the unconditional system-prompt section — not a prompt-only band-aid, since the docstring literally *is* the schema the model receives.

This is an LLM-affecting prompt/schema change; `gaia eval agent` was intentionally **not** run here (Lemonade is single-tenant and busy with the milestone-59 sweep). The `rag_quality`/drafting-adjacent eval category should be run before merge to confirm no regression — same gate #2437 hit in this milestone.
</details>

## Test plan

- [x] `hub/agents/email/python/tests -k "draft" -q` — 23 passed
- [x] New tests fail against the pre-fix docstrings/prompt, pass after (verified by temporarily reverting the fix and re-running):
  - `test_draft_content_authorship_2524.py::TestBodyAuthorshipContract::*` (3 tests) — fail before, pass after
  - `test_draft_content_authorship_2524.py::TestExplicitContentHonoredVerbatim::*`, `TestDraftingProducesNonEmptyDraft::*`, `TestSendSurfaceUntouched::*` — regression guards, pass either way
- [x] `hub/agents/email/python/tests -q` — full suite, 1038 passed
- [x] `python util/lint.py --all --fix` — all blocking checks pass
- [ ] `gaia eval agent` — required before merge (LLM-affecting change), not run here per the milestone's serial-eval constraint