### PR TITLE
fix(email): surface degraded memory state and diagnose the real cause

### DIFF
--- a/hub/agents/email/python/CHANGELOG.md
+++ b/hub/agents/email/python/CHANGELOG.md
@@ -53,6 +53,17 @@ contract version is tracked separately as
 
 ### Fixed
 
+- **A failed memory startup is now visible in chat, and blames the right
+  cause (#2519).** When the embedding model wasn't reachable, memory quietly
+  disabled itself: a log line and a REST field said so, but the agent's
+  answers made it look like a missing feature ("I don't have a tool to view
+  saved preferences") rather than a broken one. The agent now prints a
+  startup warning naming the real problem and the fix. It also used to blame
+  every failure on `GAIA_MEMORY_DISABLED=1` or a stopped Lemonade — the
+  common real case is neither: Lemonade is running fine but the embedding
+  model was never pulled. The message now tells those two apart and gives
+  the matching remedy (pull the model vs. start Lemonade), since acting on
+  the wrong one wastes the user's time.
 - **A trashed message is recoverable any time it's still in Trash, not just
   for a few seconds (#2523).** The only restore path (`restore_message`) was
   gated by a short undo window and a live `action_id`; once either was gone,

--- a/hub/agents/email/python/gaia_agent_email/agent.py
+++ b/hub/agents/email/python/gaia_agent_email/agent.py
@@ -83,7 +83,11 @@ if TYPE_CHECKING:  # import-cheap: only for annotations, never at runtime
 
 from gaia.agents.base.agent import Agent
 from gaia.agents.base.console import AgentConsole
-from gaia.agents.base.memory import MemoryMixin
+from gaia.agents.base.memory import (
+    MEMORY_UNAVAILABLE_MODEL_NOT_PULLED,
+    MEMORY_UNAVAILABLE_SERVICE_UNREACHABLE,
+    MemoryMixin,
+)
 from gaia.agents.base.tools import _TOOL_REGISTRY
 from gaia.agents.registry import get_embedding_model_for_device
 from gaia.connectors.errors import AuthRequiredError, ConnectorsError
@@ -669,6 +673,19 @@ class EmailTriageAgent(
             ),
         )
 
+        # Surface the degraded-memory state where the user actually is
+        # (#2519): before this, a failed embedding connectivity probe only
+        # logged a WARNING and set a REST field nobody was looking at, so a
+        # user in chat saw the agent quietly claim it never had memory tools
+        # rather than being told memory failed to come up and how to fix it.
+        # Skip the deliberate GAIA_MEMORY_DISABLED=1 opt-out here — that's an
+        # explicit choice (used by tests/CI), not a silent degradation.
+        if getattr(self, "_memory_unavailable_reason", None) in (
+            MEMORY_UNAVAILABLE_MODEL_NOT_PULLED,
+            MEMORY_UNAVAILABLE_SERVICE_UNREACHABLE,
+        ):
+            self.console.print_warning(self.memory_unavailable_message())
+
         # Exact ctx pin (#1892): set the instance-scoped override on the
         # concrete LemonadeClient this agent chats through. Post-super(),
         # the client lives at self.chat.llm_client._backend (AgentSDK →
@@ -745,19 +762,19 @@ class EmailTriageAgent(
         """Report the current memory state without changing it.
 
         Returns ``{"enabled", "available", "message"}`` where ``available`` is
-        whether a memory store exists this session (False when disabled at startup
-        via ``GAIA_MEMORY_DISABLED`` or when Lemonade was unreachable) and
-        ``enabled`` is the effective on/off state (``available`` and not incognito).
+        whether a memory store exists this session and ``enabled`` is the
+        effective on/off state (``available`` and not incognito). When
+        unavailable, ``message`` names the REAL cause — env opt-out, the
+        embedding model never having been pulled into a running Lemonade, or
+        Lemonade itself being unreachable — via
+        ``MemoryMixin.memory_unavailable_message()`` (#2519). These are
+        distinct failures with distinct remedies; conflating them (as this
+        method used to) sends the user down the wrong fix.
         """
         available = getattr(self, "_memory_store", None) is not None
         enabled = self.is_memory_enabled()
         if not available:
-            message = (
-                "Memory is unavailable this session: it was disabled at startup "
-                "(GAIA_MEMORY_DISABLED=1) or the Lemonade embedding service was "
-                "unreachable when the agent started. Start lemonade-server and "
-                "restart the agent to enable it."
-            )
+            message = self.memory_unavailable_message()
         elif enabled:
             message = "Memory is enabled: personalization and persistence are active."
         else:

--- a/hub/agents/email/python/tests/test_email_memory.py
+++ b/hub/agents/email/python/tests/test_email_memory.py
@@ -573,3 +573,123 @@ class TestRuntimeMemoryToggle:
             assert agent.is_memory_enabled() is True
         finally:
             agent.close_db()
+
+
+# ---------------------------------------------------------------------------
+# #2519 — degraded-memory-state must be user-visible, and correctly diagnosed
+# ---------------------------------------------------------------------------
+
+
+def _build_agent_with_failing_embedder(
+    tmp_path: Path, embed_exc: Exception
+) -> EmailTriageAgent:
+    """Build an EmailTriageAgent whose embedding connectivity probe fails.
+
+    ``_get_embedder()`` succeeds (Lemonade's client object constructs fine)
+    but ``_embed_text()`` — the actual connectivity probe run by
+    ``init_memory()`` — raises *embed_exc*, exercising the same except branch
+    a real 404 model-not-found or connection failure would hit.
+    """
+    cfg = EmailAgentConfig(
+        gmail_backend=_MinimalMailBackend(),
+        calendar_backend=_MinimalCalendarBackend(),
+        db_path=str(tmp_path / "state.db"),
+        memory_db_path=str(tmp_path / "memory.db"),
+        silent_mode=True,
+        debug=False,
+        memory_enabled=True,
+    )
+    with (
+        patch("gaia.agents.base.agent.AgentSDK") as mock_sdk,
+        patch(
+            "gaia.agents.base.memory.MemoryMixin._get_embedder",
+            return_value=MagicMock(),
+        ),
+        patch(
+            "gaia.agents.base.memory.MemoryMixin._embed_text",
+            side_effect=embed_exc,
+        ),
+    ):
+        mock_sdk.return_value = MagicMock()
+        return EmailTriageAgent(config=cfg)
+
+
+class TestMemoryDegradedStateNotice:
+    """#2519: a failed embedding probe must be user-visible and correctly
+    diagnosed — not just a log line, and not blamed on the wrong cause."""
+
+    def test_model_not_pulled_produces_visible_notice(self, tmp_path, monkeypatch):
+        """Lemonade reachable but the embedding model was never pulled (the
+        real #2519 scenario: a 404 model_not_found response) — the agent
+        prints a user-visible notice AND memory_status() names the real
+        cause, not GAIA_MEMORY_DISABLED.
+        """
+        monkeypatch.delenv("GAIA_MEMORY_DISABLED", raising=False)
+        model_not_found = RuntimeError(
+            "Embedding failed: Error generating embeddings: Request failed "
+            "with status 404: {\"error\":{\"code\":\"model_not_found\","
+            "\"message\":\"Model 'user.embeddinggemma-300m-GGUF' was not "
+            'found."}}'
+        )
+        with patch(
+            "gaia.agents.base.console.AgentConsole.print_warning"
+        ) as mock_warn:
+            agent = _build_agent_with_failing_embedder(tmp_path, model_not_found)
+        try:
+            # (1) surfaced where the user is — not just logged.
+            mock_warn.assert_called_once()
+            notice = mock_warn.call_args[0][0]
+
+            # (2) names the REAL cause (model never pulled), not the wrong one.
+            assert "not been pulled" in notice
+            assert "user.embeddinggemma-300m-GGUF" in notice
+            assert "GAIA_MEMORY_DISABLED" not in notice
+
+            status = agent.memory_status()
+            assert status["available"] is False
+            assert status["enabled"] is False
+            assert "not been pulled" in status["message"]
+            assert "GAIA_MEMORY_DISABLED" not in status["message"]
+        finally:
+            agent.close_db()
+
+    def test_service_unreachable_produces_different_notice(
+        self, tmp_path, monkeypatch
+    ):
+        """A genuinely unreachable Lemonade produces a DIFFERENT message than
+        the model-not-pulled case — the remedies aren't interchangeable."""
+        monkeypatch.delenv("GAIA_MEMORY_DISABLED", raising=False)
+        connection_refused = RuntimeError(
+            "Embedding failed: Error generating embeddings: "
+            "Connection refused (localhost:13305)"
+        )
+        with patch(
+            "gaia.agents.base.console.AgentConsole.print_warning"
+        ) as mock_warn:
+            agent = _build_agent_with_failing_embedder(tmp_path, connection_refused)
+        try:
+            mock_warn.assert_called_once()
+            notice = mock_warn.call_args[0][0]
+
+            assert "unreachable" in notice
+            assert "start" in notice.lower()
+            assert "not been pulled" not in notice
+
+            status = agent.memory_status()
+            assert status["available"] is False
+            assert "unreachable" in status["message"]
+            assert "not been pulled" not in status["message"]
+        finally:
+            agent.close_db()
+
+    def test_available_embedder_emits_no_notice(self, tmp_path):
+        """When the embedder is reachable, no degraded-state notice fires."""
+        with patch(
+            "gaia.agents.base.console.AgentConsole.print_warning"
+        ) as mock_warn:
+            agent = _build_agent(tmp_path)
+        try:
+            mock_warn.assert_not_called()
+            assert agent.memory_status()["available"] is True
+        finally:
+            agent.close_db()

--- a/src/gaia/agents/base/memory.py
+++ b/src/gaia/agents/base/memory.py
@@ -53,7 +53,10 @@ from gaia.agents.base.memory_store import (
     VALID_CATEGORIES,
 )
 from gaia.agents.base.procedural_memory import ProceduralMemoryMixin
-from gaia.llm.lemonade_client import DEFAULT_EMBEDDING_MODEL
+from gaia.llm.lemonade_client import (
+    DEFAULT_EMBEDDING_CHECKPOINT,
+    DEFAULT_EMBEDDING_MODEL,
+)
 
 if TYPE_CHECKING:
     from gaia.agents.base.bootstrap import BootstrapResult
@@ -338,6 +341,36 @@ def _blob_to_embedding(blob: bytes) -> np.ndarray:
     return np.frombuffer(blob, dtype=np.float32).copy()
 
 
+#: Reason codes for why memory is unavailable this session (#2519). Distinct
+#: codes because the remedies differ: an unset env var, a model that was
+#: never pulled into a *running* Lemonade, and Lemonade not running at all
+#: are three different problems with three different fixes.
+MEMORY_UNAVAILABLE_DISABLED_BY_ENV = "disabled_by_env"
+MEMORY_UNAVAILABLE_MODEL_NOT_PULLED = "model_not_pulled"
+MEMORY_UNAVAILABLE_SERVICE_UNREACHABLE = "service_unreachable"
+
+#: Substrings that identify a Lemonade "model not found" response (the
+#: service answered, it just doesn't have this model pulled) rather than a
+#: connection failure. Matches Lemonade's own error body, e.g. status 404
+#: with ``{"error":{"code":"model_not_found", ...}}``.
+_MODEL_NOT_FOUND_MARKERS = ("model_not_found", "was not found", "404")
+
+
+def _classify_embedding_failure(exc: Exception) -> str:
+    """Classify why the embedding connectivity probe failed at startup.
+
+    Returns ``MEMORY_UNAVAILABLE_MODEL_NOT_PULLED`` when Lemonade answered
+    but rejected the embedding model as unknown (never pulled), or
+    ``MEMORY_UNAVAILABLE_SERVICE_UNREACHABLE`` for everything else (Lemonade
+    down, wrong port, connection refused/timeout, etc.) — the safer default
+    when the failure can't be positively identified as "model not pulled".
+    """
+    text = str(exc).lower()
+    if any(marker in text for marker in _MODEL_NOT_FOUND_MARKERS):
+        return MEMORY_UNAVAILABLE_MODEL_NOT_PULLED
+    return MEMORY_UNAVAILABLE_SERVICE_UNREACHABLE
+
+
 class MemoryMixin(ProceduralMemoryMixin):
     """
     Mixin that gives any Agent persistent memory across sessions (v2).
@@ -389,6 +422,12 @@ class MemoryMixin(ProceduralMemoryMixin):
         self._embedding_model = embedding_model or EMBEDDING_MODEL
         # Pre-probe default; refined from the live embedder below.
         self._embedding_dim = EMBEDDING_DIM
+        # Why memory is unavailable this session, or None while it's live.
+        # Set on every path below (#2519) so callers can report the REAL
+        # cause instead of guessing between "env var" / "not pulled" /
+        # "unreachable" after the fact.
+        self._memory_unavailable_reason: Optional[str] = None
+        self._memory_unavailable_detail: Optional[str] = None
 
         if os.environ.get("GAIA_MEMORY_DISABLED") == "1":
             logger.info(
@@ -396,6 +435,7 @@ class MemoryMixin(ProceduralMemoryMixin):
                 "skipping init"
             )
             self._memory_store = None
+            self._memory_unavailable_reason = MEMORY_UNAVAILABLE_DISABLED_BY_ENV
             self._memory_context = context
             self._auto_extract_enabled = False
             self._incognito = True
@@ -498,12 +538,24 @@ class MemoryMixin(ProceduralMemoryMixin):
                 )
             self._memory_store.set_embedder_id(self._embedding_model)
         except Exception as e:
-            logger.warning(
-                "[MemoryMixin] Lemonade embedding service unreachable — "
-                "memory v2 disabled for this session (start lemonade-server "
-                "and reload to enable). Reason: %s",
-                e,
-            )
+            reason = _classify_embedding_failure(e)
+            self._memory_unavailable_reason = reason
+            self._memory_unavailable_detail = str(e)
+            if reason == MEMORY_UNAVAILABLE_MODEL_NOT_PULLED:
+                logger.warning(
+                    "[MemoryMixin] embedding model '%s' is not pulled in "
+                    "Lemonade — memory v2 disabled for this session (pull "
+                    "the model and restart the agent to enable). Reason: %s",
+                    self._embedding_model,
+                    e,
+                )
+            else:
+                logger.warning(
+                    "[MemoryMixin] Lemonade embedding service unreachable — "
+                    "memory v2 disabled for this session (start lemonade-server "
+                    "and reload to enable). Reason: %s",
+                    e,
+                )
             # Tear down the partially-built state so no later code path tries
             # to use memory.
             self._memory_store = None
@@ -701,13 +753,13 @@ class MemoryMixin(ProceduralMemoryMixin):
 
         store = self.memory_store  # raises if init_memory() was never called
         if store is None:
+            reason = self.memory_unavailable_message() or (
+                "memory is disabled for this session"
+            )
             raise RuntimeError(
-                "Cannot run onboarding: memory is disabled for this session "
-                "(the embedding service was unreachable at agent start, or "
-                "GAIA_MEMORY_DISABLED=1 is set). Start lemonade-server and "
-                "re-create the agent, or run `gaia memory bootstrap "
-                "--chat-only`, which onboards without an embedder. See "
-                "docs/guides/memory.mdx."
+                f"Cannot run onboarding: {reason} Alternatively, run `gaia "
+                "memory bootstrap --chat-only`, which onboards without an "
+                "embedder. See docs/guides/memory.mdx."
             )
 
         return _run_bootstrap_conversation(
@@ -726,6 +778,62 @@ class MemoryMixin(ProceduralMemoryMixin):
         vec = self._embed_text(content)
         self.memory_store.store_embedding(knowledge_id, _embedding_to_blob(vec))
         self._faiss_add(knowledge_id, vec)
+
+    # ------------------------------------------------------------------
+    # Degraded-state reporting (#2519)
+    # ------------------------------------------------------------------
+
+    def memory_unavailable_message(self) -> Optional[str]:
+        """Human-readable reason + remedy for why memory is off this session.
+
+        Returns ``None`` when a memory store is live. Otherwise returns one of
+        three DISTINCT messages, keyed off the real cause recorded by
+        ``init_memory()`` — never conflates "the model was never pulled" (the
+        service is reachable and running fine) with "the service itself is
+        down" (start it), since a user who acts on the wrong one is sent down
+        the wrong remedy. Every branch also says a running session cannot
+        recover on its own — memory availability is decided once at startup.
+        """
+        if getattr(self, "_memory_store", None) is not None:
+            return None
+        reason = getattr(self, "_memory_unavailable_reason", None)
+        model = getattr(self, "_embedding_model", EMBEDDING_MODEL)
+        restart_note = (
+            "Restart the agent to pick this up — a running session cannot "
+            "recover memory on its own."
+        )
+        if reason == MEMORY_UNAVAILABLE_DISABLED_BY_ENV:
+            return (
+                "Memory is unavailable this session: disabled via "
+                "GAIA_MEMORY_DISABLED=1. Unset it and restart the agent to "
+                "enable memory."
+            )
+        if reason == MEMORY_UNAVAILABLE_MODEL_NOT_PULLED:
+            if model == EMBEDDING_MODEL:
+                remedy = (
+                    f"Pull it — POST /api/v1/pull "
+                    f'{{"model_name": "{model}", "checkpoint": '
+                    f'"{DEFAULT_EMBEDDING_CHECKPOINT}", "recipe": "llamacpp", '
+                    '"embedding": true}'
+                )
+            else:
+                remedy = f"Pull '{model}' in Lemonade"
+            return (
+                f"Memory is unavailable this session: the embedding model '{model}' "
+                "has not been pulled into Lemonade — Lemonade itself is "
+                f"running and reachable. {remedy}, then restart the agent. "
+                f"{restart_note}"
+            )
+        # MEMORY_UNAVAILABLE_SERVICE_UNREACHABLE, or an unclassified failure —
+        # treat as unreachable, the safer default (matches the pre-#2519
+        # behavior for anything we can't positively identify).
+        detail = getattr(self, "_memory_unavailable_detail", None)
+        detail_suffix = f" ({detail})" if detail else ""
+        return (
+            "Memory is unavailable this session: the Lemonade embedding service was "
+            f"unreachable at startup{detail_suffix}. Start Lemonade Server, "
+            f"then restart the agent. {restart_note}"
+        )
 
     # ------------------------------------------------------------------
     # Properties

--- a/tests/unit/test_memory_bootstrap.py
+++ b/tests/unit/test_memory_bootstrap.py
@@ -551,7 +551,7 @@ def test_mixin_wrapper_fails_loudly_when_memory_is_disabled(monkeypatch):
 
     io = ScriptedIO(_ENGINEER_ANSWERS)
 
-    with pytest.raises(RuntimeError, match="memory is disabled") as excinfo:
+    with pytest.raises(RuntimeError, match="Memory is unavailable") as excinfo:
         host.run_bootstrap_conversation(prompt_fn=io.prompt, output_fn=io.out)
 
     message = str(excinfo.value)


### PR DESCRIPTION
When the embedding model wasn't reachable, the email agent's memory quietly disabled itself: a log line and a REST field said so, but chat made it look like a missing feature ("I don't have a tool to view saved preferences") rather than a broken one. Startup now prints a visible warning in chat/TUI naming the problem and the fix. The old message also always blamed `GAIA_MEMORY_DISABLED=1` or a stopped Lemonade — in the reported case neither was true: Lemonade was running, the env var was unset, the embedding model had simply never been pulled. Startup now classifies the real cause (model never pulled vs. service unreachable vs. explicit env opt-out) and gives each its own remedy.

Note for reviewers: the `user.embeddinggemma-300m-GGUF` prefix used throughout is correct — this embedder is registered as a custom Lemonade model via checkpoint + recipe, not a built-in, so it is not the #1655 built-in-prefix bug. No changes were made to the auto-download retry logic in `lemonade_client.py` (owned by a sibling PR, #2513).

Closes #2519

## Test plan

- [x] `pytest hub/agents/email/python/tests/test_email_memory.py -q` — 27 passed, including 3 new tests for the notice/classification behavior
- [x] `pytest tests/unit -k "memory or mixin" -q` — 1110 passed, 52 skipped
- [x] `pytest hub/agents/email/python/tests -k "memory or session" -q` — 53 passed
- [x] `pytest hub/agents/email/python/tests -q` (full suite) — 1033 passed
- [x] `python util/lint.py --all` — black/isort/pylint/flake8/bandit all pass (mypy warnings are pre-existing and non-blocking)