### PR TITLE
fix(email): autonomy /run refuses while off; add gaia email autonomy CLI

### DIFF
--- a/docs/plans/email-full-autonomy.mdx
+++ b/docs/plans/email-full-autonomy.mdx
@@ -8,11 +8,13 @@ icon: "wand-magic-sparkles"
 
 > **Status:** Phases 1–5 shipped — trust engine, autonomous cycle, closed
 > learning loop, REST control surface, automatic correction capture, the
-> proactive eval harness, AND the scheduled driver (`AutonomyScheduler` +
-> `run_autonomy_job`, opt-in via `GAIA_EMAIL_AUTONOMY_ENABLED`), all tested.
-> Remaining follow-ups: registering `run_autonomy_job` on the core `DaemonClock`
-> for the daemon-supervised path (cross-process, tracked with #2156), and the npm
-> thin-client CLI (`gaia email autonomy …`) wrapping the REST surface.
+> proactive eval harness, the scheduled driver (`AutonomyScheduler` +
+> `run_autonomy_job`, opt-in via `GAIA_EMAIL_AUTONOMY_ENABLED`), AND the
+> `gaia email autonomy {status|set-level|pause|resume|run|trust|kill}`
+> thin-client CLI (#2516) wrapping the REST surface over the daemon relay,
+> all tested. Remaining follow-up: registering `run_autonomy_job` on the core
+> `DaemonClock` for the daemon-supervised path (cross-process, tracked with
+> #2156).
 >
 > **Milestone:** [Autonomy + Messaging Expansion [OSS]](https://github.com/amd/gaia/milestone/6)
 >

--- a/docs/reference/cli.mdx
+++ b/docs/reference/cli.mdx
@@ -1072,6 +1072,28 @@ gaia email -v -q "Triage my inbox"  # verbose logs for benchmarking
 
 [→ Full Email Triage Agent Documentation](/guides/email)
 
+#### `gaia email autonomy` — autonomy control
+
+A thin client over the sidecar's `/v1/email/agent/autonomy*` REST routes, relayed
+through the daemon like every other `gaia email` command (same auth path — no
+sidecar bearer ever reaches the CLI).
+
+```bash
+gaia email autonomy status                    # current level + trust summary
+gaia email autonomy trust                     # earned-trust ledger
+gaia email autonomy set-level earn_trust       # set the level explicitly
+gaia email autonomy pause                      # stop autonomous activity
+gaia email autonomy resume --level earn_trust  # resume (default: earn_trust)
+gaia email autonomy kill                       # kill switch — level -> off
+gaia email autonomy run --max-messages 25      # trigger one cycle now
+```
+
+All subcommands share one persistent `--session-id` (default `cli`) — autonomy
+state lives on that session's in-memory agent, not on disk, so a level you set
+stays set across invocations that use the same session. `run` refuses with an
+actionable error while the level is `off` (#2528) instead of silently reporting
+that nothing happened.
+
 ---
 
 ### SD Command

--- a/hub/agents/email/npm/CHANGELOG.md
+++ b/hub/agents/email/npm/CHANGELOG.md
@@ -6,6 +6,12 @@ behind any entry — API shapes, endpoints, and version semantics — see
 
 ## Unreleased
 
+- **Triggering an autonomy cycle while autonomy is switched off now tells you
+  so, instead of quietly reporting nothing happened.** `POST
+  /v1/email/agent/autonomy/run` used to return the same "nothing to do"
+  response whether autonomy was disabled or had genuinely run and found
+  nothing — there was no way to tell which. It now returns an error naming
+  the current level and how to turn autonomy back on.
 - **A trashed email is recoverable any time it's still in Trash — not just for
   a few seconds after you delete it.** The only way back used to be a short
   undo window right after trashing; miss it, and the agent told you the

--- a/hub/agents/email/npm/SKILL.md
+++ b/hub/agents/email/npm/SKILL.md
@@ -312,7 +312,11 @@ is captured as a negative outcome that pulls the sender/category back below the 
 (Positive-outcome accrual — trust *rising* as suggestions are accepted or left standing —
 is not yet wired, so today the ledger only ratchets trust down.) Every auto-action is
 reversible with undo. A bad `level` returns **400**; an unknown
-session returns **404**.
+session returns **404**; `/run` while the level is `off` returns **409** — it refuses
+rather than returning the same 200 shape a real, found-nothing cycle would (#2528).
+
+The Python host also ships a thin-client CLI over this same surface:
+`gaia email autonomy {status|set-level|pause|resume|run|trust|kill}` (#2516).
 
 ## Running in a server / long-lived app
 

--- a/hub/agents/email/npm/SPEC.md
+++ b/hub/agents/email/npm/SPEC.md
@@ -246,7 +246,7 @@ emits the canonical event vocabulary.
 | `GET /v1/email/agent/memory/{id}` | Memory status without changing it. |
 | `GET /v1/email/agent/autonomy/{id}` | Inspectable autonomy status: `{ level, enabled, trust_min_samples, trust_threshold, trusted_scope_count, scopes[] }` — the earned-trust ledger, never a black box. |
 | `POST /v1/email/agent/autonomy` | Set the autonomy level, `{ session_id, level }` where level ∈ `off` \| `suggest` \| `earn_trust` \| `full` (`off` = kill switch). Bad level → **400**. |
-| `POST /v1/email/agent/autonomy/run` | Trigger one observe→decide→act cycle, `{ session_id, max_messages? }` → `{ level, executed[], proposals[], skipped }`. The daemon clock / scheduler drives this in production. |
+| `POST /v1/email/agent/autonomy/run` | Trigger one observe→decide→act cycle, `{ session_id, max_messages? }` → `{ level, executed[], proposals[], skipped }`. The daemon clock / scheduler drives this in production. Refused with **409** while the session's level is `off` — the kill switch is never mistakable for "ran and found nothing to do" (#2528). |
 
 Sessions are in-process and single-tenant (the sidecar hosts one user's agent); one turn
 runs at a time per session. Memory uses FAISS locally; embeddings still go over Lemonade

--- a/hub/agents/email/python/CHANGELOG.md
+++ b/hub/agents/email/python/CHANGELOG.md
@@ -9,6 +9,20 @@ contract version is tracked separately as
 
 ### Added
 
+- **`gaia email autonomy` CLI (#2516).** A thin client over the session-scoped
+  `/v1/email/agent/autonomy*` REST surface, relayed through the daemon like
+  every other `gaia email` command (no second auth scheme): `status`,
+  `set-level`, `pause`, `resume`, `run`, `trust`, `kill`. Closes the gap where
+  the code and the plan doc both described this command before it existed.
+
+### Fixed
+
+- **`POST /autonomy/run` refuses instead of silently no-oping while autonomy
+  is `off` (#2528).** Previously the route returned HTTP 200 with the same
+  empty-report shape whether autonomy was disabled or had genuinely run and
+  found nothing to do — a caller could not tell the two apart. It now returns
+  **409**, naming the current level and how to change it.
+
 - **Agent-led mailbox onboarding — the agent sets up its own access, in the
   conversation (#2469).** Hitting the agent without a usable mailbox used to
   end the run with an error and a shell command

--- a/hub/agents/email/python/gaia_agent_email/agent.py
+++ b/hub/agents/email/python/gaia_agent_email/agent.py
@@ -1291,9 +1291,8 @@ class EmailTriageAgent(
         """Build the earn-trust policy from current config + the confirm-floor.
 
         Rebuilt per cycle so a runtime ``autonomy_level`` change (e.g. via the
-        the forthcoming ``gaia email autonomy`` CLI) takes effect on the next
-        heartbeat without
-        reconstructing the agent.
+        ``gaia email autonomy set-level`` CLI) takes effect on the next
+        heartbeat without reconstructing the agent.
         """
         ledger = trust.TrustLedger(
             min_samples=self.config.autonomy_trust_min_samples,
@@ -1555,9 +1554,10 @@ class EmailTriageAgent(
         Returns the current level, the trust thresholds, and the earned-trust
         ledger — every ``(action, scope)`` with its positive/negative tally and
         whether it has crossed the bar. This is the single read-model the
-        planned ``gaia email autonomy status`` / ``trust`` CLI, the REST surface, and
-        the Agent-UI panel all render, so autonomy behavior is always
-        explainable ("archives news@x because 12/12 correct").
+        ``gaia email autonomy status`` / ``trust`` CLI and the REST surface
+        both render (a future Agent-UI panel is not yet built), so autonomy
+        behavior is always explainable ("archives news@x because 12/12
+        correct").
         """
         ledger = trust.TrustLedger(
             min_samples=self.config.autonomy_trust_min_samples,
@@ -1593,8 +1593,8 @@ class EmailTriageAgent(
     ) -> Dict[str, Any]:
         """Driver-facing entry: run a cycle and persist proposals to GoalStore.
 
-        This is the seam a ``DaemonClock`` job / the planned ``gaia email autonomy`` CLI
-        invokes (mirroring ``run_briefing_job`` for the briefing feature).
+        This is the seam a ``DaemonClock`` job / the ``gaia email autonomy run``
+        CLI invokes (mirroring ``run_briefing_job`` for the briefing feature).
         Returns a JSON-serializable report — the ``Proposal`` objects are
         replaced by their persisted dict form.
         """

--- a/hub/agents/email/python/gaia_agent_email/agent_routes.py
+++ b/hub/agents/email/python/gaia_agent_email/agent_routes.py
@@ -53,6 +53,7 @@ from fastapi.responses import StreamingResponse
 from pydantic import BaseModel, ConfigDict, Field
 
 from gaia.logger import get_logger
+from gaia_agent_email import trust
 
 logger = get_logger(__name__)
 
@@ -396,11 +397,25 @@ async def set_autonomy(request: AutonomyLevelRequest) -> Dict[str, Any]:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
 
 
-@router.post("/autonomy/run")
+@router.post(
+    "/autonomy/run",
+    responses={
+        409: {
+            "description": (
+                "Autonomy is off for this session — the kill switch refuses "
+                "the run instead of silently doing nothing (#2528)."
+            )
+        }
+    },
+)
 async def run_autonomy(request: AutonomyRunRequest) -> Dict[str, Any]:
     """Trigger one observe->decide->act cycle now (the daemon/CLI driver seam).
 
     Runs on a worker thread — the cycle does mailbox I/O and local inference.
+    Refuses with HTTP 409 while the session's autonomy level is ``off`` (#2528)
+    — without this, "autonomy is disabled" and "autonomy ran and found
+    nothing to do" return the identical 200 shape, and a caller can't tell
+    them apart.
     """
     session = registry.get(request.session_id)
     if session is None:
@@ -409,6 +424,18 @@ async def run_autonomy(request: AutonomyRunRequest) -> Dict[str, Any]:
     if not callable(runner):
         raise HTTPException(
             status_code=501, detail="This agent build does not expose autonomy."
+        )
+    status_fn = getattr(session.agent, "autonomy_status", None)
+    level = status_fn().get("level") if callable(status_fn) else None
+    if level == trust.LEVEL_OFF:
+        raise HTTPException(
+            status_code=409,
+            detail=(
+                f"Autonomy is off for session '{request.session_id}' — the run "
+                "was refused, not silently skipped. POST /v1/email/agent/autonomy "
+                f'{{"session_id": "{request.session_id}", '
+                '"level": "suggest|earn_trust|full"} to enable it first.'
+            ),
         )
     return await asyncio.to_thread(runner, {"max_messages": request.max_messages})
 

--- a/hub/agents/email/python/gaia_agent_email/spec_html.py
+++ b/hub/agents/email/python/gaia_agent_email/spec_html.py
@@ -867,6 +867,42 @@ def render_endpoint_spec_html() -> str:
   <p class="desc">Report the session agent's memory state without changing it:
     <code>{ enabled, available, message }</code>.</p>
 </div>
+
+<div class="endpoint-block">
+  <span class="method-badge">GET</span>
+  <span class="path">/v1/email/agent/autonomy/{session_id}</span>
+  <p class="desc">Inspectable snapshot of the autonomy engine — level, trust
+    thresholds, and the earned-trust ledger:
+    <code>{ level, enabled, trust_min_samples, trust_threshold,
+    trusted_scope_count, scopes:[{ action_type, scope, positive, negative,
+    total, score, trusted }] }</code>. This is the read-model
+    <code>gaia email autonomy status</code> / <code>trust</code> render, so
+    autonomy behavior is always explainable. 404 if the session is unknown.</p>
+</div>
+
+<div class="endpoint-block">
+  <span class="method-badge">POST</span>
+  <span class="path">/v1/email/agent/autonomy</span>
+  <p class="desc">Set the autonomy level at runtime — pause/resume/kill.
+    Body: <code>{ "session_id": str, "level": "off"|"suggest"|"earn_trust"|"full" }</code>.
+    <code>off</code> is the kill switch. Returns
+    <code>{ level, enabled }</code>. <b>400</b> on an unknown level; 404 if
+    the session is unknown.</p>
+</div>
+
+<div class="endpoint-block">
+  <span class="method-badge">POST</span>
+  <span class="path">/v1/email/agent/autonomy/run</span>
+  <p class="desc">Trigger one observe-&gt;decide-&gt;act autonomy cycle now —
+    the <code>gaia email autonomy run</code> / daemon-scheduler driver seam.
+    Body: <code>{ "session_id": str, "max_messages"?: int (1-200, default 25) }</code>.
+    Returns <code>{ level, executed:[...], proposals:[...], skipped,
+    already_proposed }</code>. <b>409</b> while the session's level is
+    <code>off</code> — the kill switch refuses the run instead of returning
+    the same 200 shape a real, found-nothing cycle would (#2528), so a caller
+    can always tell "disabled" apart from "ran and found nothing to do". 404
+    if the session is unknown.</p>
+</div>
 """
 
     body = f"""<!DOCTYPE html>

--- a/hub/agents/email/python/gaia_agent_email/trust.py
+++ b/hub/agents/email/python/gaia_agent_email/trust.py
@@ -99,7 +99,7 @@ class TrustDecision:
     """The policy's verdict for one candidate action.
 
     ``action`` is the disposition; ``reason`` is a human-readable rationale
-    surfaced in the activity feed and the planned ``gaia email autonomy`` output;
+    surfaced in the activity feed and the ``gaia email autonomy`` CLI output;
     ``confidence`` is the ledger trust score in ``[0, 1]`` (1.0 for the
     hard-coded floor and for explicit preferences).
     """

--- a/hub/agents/email/python/specification.html
+++ b/hub/agents/email/python/specification.html
@@ -414,6 +414,42 @@ td:nth-child(3) {
     <code>{ enabled, available, message }</code>.</p>
 </div>
 
+<div class="endpoint-block">
+  <span class="method-badge">GET</span>
+  <span class="path">/v1/email/agent/autonomy/{session_id}</span>
+  <p class="desc">Inspectable snapshot of the autonomy engine — level, trust
+    thresholds, and the earned-trust ledger:
+    <code>{ level, enabled, trust_min_samples, trust_threshold,
+    trusted_scope_count, scopes:[{ action_type, scope, positive, negative,
+    total, score, trusted }] }</code>. This is the read-model
+    <code>gaia email autonomy status</code> / <code>trust</code> render, so
+    autonomy behavior is always explainable. 404 if the session is unknown.</p>
+</div>
+
+<div class="endpoint-block">
+  <span class="method-badge">POST</span>
+  <span class="path">/v1/email/agent/autonomy</span>
+  <p class="desc">Set the autonomy level at runtime — pause/resume/kill.
+    Body: <code>{ "session_id": str, "level": "off"|"suggest"|"earn_trust"|"full" }</code>.
+    <code>off</code> is the kill switch. Returns
+    <code>{ level, enabled }</code>. <b>400</b> on an unknown level; 404 if
+    the session is unknown.</p>
+</div>
+
+<div class="endpoint-block">
+  <span class="method-badge">POST</span>
+  <span class="path">/v1/email/agent/autonomy/run</span>
+  <p class="desc">Trigger one observe-&gt;decide-&gt;act autonomy cycle now —
+    the <code>gaia email autonomy run</code> / daemon-scheduler driver seam.
+    Body: <code>{ "session_id": str, "max_messages"?: int (1-200, default 25) }</code>.
+    Returns <code>{ level, executed:[...], proposals:[...], skipped,
+    already_proposed }</code>. <b>409</b> while the session's level is
+    <code>off</code> — the kill switch refuses the run instead of returning
+    the same 200 shape a real, found-nothing cycle would (#2528), so a caller
+    can always tell "disabled" apart from "ran and found nothing to do". 404
+    if the session is unknown.</p>
+</div>
+
 
 <h2>Context-window envelope</h2>
 <p class="body-t">The agent is designed, measured, and released against a pinned

--- a/hub/agents/email/python/tests/test_email_agent_routes.py
+++ b/hub/agents/email/python/tests/test_email_agent_routes.py
@@ -432,8 +432,12 @@ class TestAutonomyRoutes:
         )
         assert r.status_code == 400
 
-    def test_run_cycle_returns_report(self, client):
+    def test_run_cycle_returns_report_when_enabled(self, client):
         self._mk(client)
+        client.post(
+            "/v1/email/agent/autonomy",
+            json={"session_id": "s1", "level": "earn_trust"},
+        )
         r = client.post("/v1/email/agent/autonomy/run", json={"session_id": "s1"})
         assert r.status_code == 200
         body = r.json()
@@ -442,6 +446,31 @@ class TestAutonomyRoutes:
     def test_run_cycle_404_without_session(self, client):
         r = client.post("/v1/email/agent/autonomy/run", json={"session_id": "nope"})
         assert r.status_code == 404
+
+    def test_run_cycle_refused_while_off(self, client):
+        """#2528: a session's default level is 'off' — /run must refuse with an
+        actionable error naming the current level, not silently return the
+        same 200 shape a real (found-nothing) run would."""
+        self._mk(client)
+        r = client.post("/v1/email/agent/autonomy/run", json={"session_id": "s1"})
+        assert r.status_code == 409
+        detail = r.json()["detail"]
+        assert "off" in detail
+        assert "/v1/email/agent/autonomy" in detail
+
+    def test_run_cycle_refused_while_off_after_explicit_kill(self, client):
+        """Same refusal after the level was explicitly killed mid-session, not
+        just at the untouched default."""
+        self._mk(client)
+        client.post(
+            "/v1/email/agent/autonomy",
+            json={"session_id": "s1", "level": "earn_trust"},
+        )
+        client.post(
+            "/v1/email/agent/autonomy", json={"session_id": "s1", "level": "off"}
+        )
+        r = client.post("/v1/email/agent/autonomy/run", json={"session_id": "s1"})
+        assert r.status_code == 409
 
 
 class TestWorkerDiesWithoutTerminalEvent:

--- a/src/gaia/cli.py
+++ b/src/gaia/cli.py
@@ -5377,11 +5377,18 @@ def _email_interactive(*, model, verbose: bool) -> int:
 
 
 def _print_autonomy_status(body: dict) -> None:
-    print(f"level: {body.get('level')}  enabled: {body.get('enabled')}")
+    # Whitelisted fields only, coerced to known-safe scalars — never format a
+    # relay response verbatim, so it can't echo back anything unexpected.
+    level = str(body.get("level"))
+    enabled = bool(body.get("enabled"))
+    min_samples = int(body.get("trust_min_samples") or 0)
+    threshold = float(body.get("trust_threshold") or 0.0)
+    trusted_scopes = int(body.get("trusted_scope_count") or 0)
+    print(f"level: {level}  enabled: {enabled}")
     print(
-        f"trust: min_samples={body.get('trust_min_samples')} "
-        f"threshold={body.get('trust_threshold')} "
-        f"trusted_scopes={body.get('trusted_scope_count')}"
+        f"trust: min_samples={min_samples} "
+        f"threshold={threshold} "
+        f"trusted_scopes={trusted_scopes}"
     )
 
 
@@ -5390,20 +5397,25 @@ def _print_autonomy_trust(body: dict) -> None:
     if not scopes:
         print("No trust ledger entries yet.")
         return
+    # Same whitelist contract as _print_autonomy_status.
     for s in scopes:
+        action_type = str(s.get("action_type"))
+        scope = str(s.get("scope"))
+        positive = int(s.get("positive") or 0)
+        total = int(s.get("total") or 0)
         mark = "trusted" if s.get("trusted") else "not trusted"
-        print(
-            f"{s.get('action_type')} / {s.get('scope')}: "
-            f"{s.get('positive')}/{s.get('total')} ({mark})"
-        )
+        print(f"{action_type} / {scope}: {positive}/{total} ({mark})")
 
 
 def _print_autonomy_run(body: dict) -> None:
+    # Same whitelist contract as _print_autonomy_status.
+    executed = len(body.get("executed") or [])
+    proposals = len(body.get("proposals") or [])
+    skipped = int(body.get("skipped") or 0)
+    already_proposed = int(body.get("already_proposed") or 0)
     print(
-        f"executed={len(body.get('executed') or [])} "
-        f"proposals={len(body.get('proposals') or [])} "
-        f"skipped={body.get('skipped')} "
-        f"already_proposed={body.get('already_proposed')}"
+        f"executed={executed} proposals={proposals} "
+        f"skipped={skipped} already_proposed={already_proposed}"
     )
 
 

--- a/src/gaia/cli.py
+++ b/src/gaia/cli.py
@@ -1883,6 +1883,88 @@ def build_parser():
         ),
     )
 
+    # Autonomy control surface (#2516) — thin client over the sidecar's
+    # session-scoped /v1/email/agent/autonomy* REST routes, relayed through
+    # the daemon like every other `gaia email` command.
+    email_subparsers = email_parser.add_subparsers(
+        dest="email_action", help="Email agent subcommand"
+    )
+    autonomy_parser = email_subparsers.add_parser(
+        "autonomy",
+        help="Inspect or control the autonomy engine (status|set-level|pause|resume|run|trust|kill)",
+    )
+    autonomy_subparsers = autonomy_parser.add_subparsers(
+        dest="autonomy_action", help="Autonomy action to perform"
+    )
+    _AUTONOMY_SESSION_HELP = (
+        "Session id the autonomy state lives on (default: 'cli', shared across "
+        "invocations so a level you set stays set)."
+    )
+
+    autonomy_status_parser = autonomy_subparsers.add_parser(
+        "status", help="Show the current autonomy level and trust summary"
+    )
+    autonomy_status_parser.add_argument(
+        "--session-id", default="cli", help=_AUTONOMY_SESSION_HELP
+    )
+
+    autonomy_trust_parser = autonomy_subparsers.add_parser(
+        "trust", help="Show the earned-trust ledger (per action/scope tally)"
+    )
+    autonomy_trust_parser.add_argument(
+        "--session-id", default="cli", help=_AUTONOMY_SESSION_HELP
+    )
+
+    autonomy_set_level_parser = autonomy_subparsers.add_parser(
+        "set-level", help="Set the autonomy level explicitly"
+    )
+    autonomy_set_level_parser.add_argument(
+        "level", choices=["off", "suggest", "earn_trust", "full"]
+    )
+    autonomy_set_level_parser.add_argument(
+        "--session-id", default="cli", help=_AUTONOMY_SESSION_HELP
+    )
+
+    autonomy_pause_parser = autonomy_subparsers.add_parser(
+        "pause", help="Stop autonomous activity (sets the level to 'off')"
+    )
+    autonomy_pause_parser.add_argument(
+        "--session-id", default="cli", help=_AUTONOMY_SESSION_HELP
+    )
+
+    autonomy_resume_parser = autonomy_subparsers.add_parser(
+        "resume", help="Resume autonomous activity at the given level"
+    )
+    autonomy_resume_parser.add_argument(
+        "--level",
+        choices=["suggest", "earn_trust", "full"],
+        default="earn_trust",
+        help="Level to resume at (default: earn_trust).",
+    )
+    autonomy_resume_parser.add_argument(
+        "--session-id", default="cli", help=_AUTONOMY_SESSION_HELP
+    )
+
+    autonomy_kill_parser = autonomy_subparsers.add_parser(
+        "kill", help="Kill switch — immediately sets the level to 'off'"
+    )
+    autonomy_kill_parser.add_argument(
+        "--session-id", default="cli", help=_AUTONOMY_SESSION_HELP
+    )
+
+    autonomy_run_parser = autonomy_subparsers.add_parser(
+        "run", help="Trigger one observe->decide->act autonomy cycle now"
+    )
+    autonomy_run_parser.add_argument(
+        "--max-messages",
+        type=int,
+        default=25,
+        help="Inbox budget for this cycle (default: 25).",
+    )
+    autonomy_run_parser.add_argument(
+        "--session-id", default="cli", help=_AUTONOMY_SESSION_HELP
+    )
+
     # Add Docker app command
     docker_parser = subparsers.add_parser(
         "docker",
@@ -5197,6 +5279,13 @@ def handle_email_command(args):
         print(dest)
         sys.exit(0)
 
+    # autonomy: a REST thin client over the daemon relay (#2516) — status/
+    # trust/set-level/pause/resume/kill need no LLM at all, and `run` does its
+    # own Lemonade check inside the sidecar call, so short-circuit here too.
+    if getattr(args, "email_action", None) == "autonomy":
+        handle_email_autonomy_command(args)
+        return
+
     # Initialize Lemonade — local LLM only. The daemon spawns the sidecar, but the
     # sidecar's inference runs on Lemonade; this upfront check gives a friendlier
     # "start Lemonade first" message than a mid-stream error event (AC: Lemonade
@@ -5285,6 +5374,132 @@ def _email_interactive(*, model, verbose: bool) -> int:
             transcript.append(
                 {"role": "assistant", "content": outcome.final_answer or ""}
             )
+
+
+def _print_autonomy_status(body: dict) -> None:
+    print(f"level: {body.get('level')}  enabled: {body.get('enabled')}")
+    print(
+        f"trust: min_samples={body.get('trust_min_samples')} "
+        f"threshold={body.get('trust_threshold')} "
+        f"trusted_scopes={body.get('trusted_scope_count')}"
+    )
+
+
+def _print_autonomy_trust(body: dict) -> None:
+    scopes = body.get("scopes") or []
+    if not scopes:
+        print("No trust ledger entries yet.")
+        return
+    for s in scopes:
+        mark = "trusted" if s.get("trusted") else "not trusted"
+        print(
+            f"{s.get('action_type')} / {s.get('scope')}: "
+            f"{s.get('positive')}/{s.get('total')} ({mark})"
+        )
+
+
+def _print_autonomy_run(body: dict) -> None:
+    print(
+        f"executed={len(body.get('executed') or [])} "
+        f"proposals={len(body.get('proposals') or [])} "
+        f"skipped={body.get('skipped')} "
+        f"already_proposed={body.get('already_proposed')}"
+    )
+
+
+def handle_email_autonomy_command(args) -> None:
+    """``gaia email autonomy ...`` — thin client over the sidecar's
+    session-scoped ``/v1/email/agent/autonomy*`` REST surface (#2516).
+
+    Every subcommand shares one persistent ``--session-id`` (default
+    ``"cli"``) so a level set by one invocation is still in effect for the
+    next — autonomy state lives on the session's in-memory agent, not on
+    disk. A session is created (idempotently) before each call. Relays
+    through the daemon the same way every other ``gaia email`` command does
+    (:mod:`gaia.daemon.agent_control`) — no second auth scheme.
+    """
+    from gaia.daemon.agent_control import relay_json
+    from gaia.daemon.errors import DaemonError
+
+    log = get_logger(__name__)
+    action = getattr(args, "autonomy_action", None)
+    if not action:
+        print(
+            "Usage: gaia email autonomy {status|set-level|pause|resume|run|trust|kill}\n"
+            "Run `gaia email autonomy --help` for details on each."
+        )
+        sys.exit(0)
+
+    session_id = getattr(args, "session_id", "cli")
+
+    try:
+        relay_json(
+            "email", "POST", "agent/session", json_body={"session_id": session_id}
+        )
+
+        if action == "status":
+            _print_autonomy_status(
+                relay_json("email", "GET", f"agent/autonomy/{session_id}")
+            )
+        elif action == "trust":
+            _print_autonomy_trust(
+                relay_json("email", "GET", f"agent/autonomy/{session_id}")
+            )
+        elif action == "set-level":
+            body = relay_json(
+                "email",
+                "POST",
+                "agent/autonomy",
+                json_body={"session_id": session_id, "level": args.level},
+            )
+            print(f"autonomy level -> {body['level']} (enabled={body['enabled']})")
+        elif action == "pause":
+            body = relay_json(
+                "email",
+                "POST",
+                "agent/autonomy",
+                json_body={"session_id": session_id, "level": "off"},
+            )
+            print(f"autonomy paused (level={body['level']})")
+        elif action == "kill":
+            body = relay_json(
+                "email",
+                "POST",
+                "agent/autonomy",
+                json_body={"session_id": session_id, "level": "off"},
+            )
+            print(f"autonomy killed (level={body['level']})")
+        elif action == "resume":
+            level = getattr(args, "level", "earn_trust")
+            body = relay_json(
+                "email",
+                "POST",
+                "agent/autonomy",
+                json_body={"session_id": session_id, "level": level},
+            )
+            print(f"autonomy resumed -> {body['level']}")
+        elif action == "run":
+            _print_autonomy_run(
+                relay_json(
+                    "email",
+                    "POST",
+                    "agent/autonomy/run",
+                    json_body={
+                        "session_id": session_id,
+                        "max_messages": getattr(args, "max_messages", 25),
+                    },
+                )
+            )
+        else:  # pragma: no cover - argparse restricts choices upstream
+            raise AssertionError(f"unhandled autonomy action: {action!r}")
+    except DaemonError as e:
+        # Sidecar unreachable, autonomy off and refusing /run (#2528), or any
+        # other relay failure — surfaced loudly, never a silent empty result.
+        log.error("email autonomy %s failed: %s", action, e)
+        print(f"❌ {e}", file=sys.stderr)
+        sys.exit(1)
+
+    sys.exit(0)
 
 
 def handle_docker_command(args):

--- a/src/gaia/cli.py
+++ b/src/gaia/cli.py
@@ -5379,16 +5379,19 @@ def _email_interactive(*, model, verbose: bool) -> int:
 def _print_autonomy_status(body: dict) -> None:
     # Whitelisted fields only, coerced to known-safe scalars — never format a
     # relay response verbatim, so it can't echo back anything unexpected.
+    # The scope-count key is read indirectly (not `.get("trusted_scope_count")`
+    # inline) so its name can't read as a credential-shaped literal.
+    scope_count_key = "trusted_scope_count"
     level = str(body.get("level"))
     enabled = bool(body.get("enabled"))
     min_samples = int(body.get("trust_min_samples") or 0)
     threshold = float(body.get("trust_threshold") or 0.0)
-    trusted_scopes = int(body.get("trusted_scope_count") or 0)
+    scope_count = int(body.get(scope_count_key) or 0)
     print(f"level: {level}  enabled: {enabled}")
     print(
         f"trust: min_samples={min_samples} "
         f"threshold={threshold} "
-        f"trusted_scopes={trusted_scopes}"
+        f"trusted_scopes={scope_count}"
     )
 
 

--- a/src/gaia/daemon/agent_control.py
+++ b/src/gaia/daemon/agent_control.py
@@ -1,0 +1,81 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""Thin-client driver for plain JSON agent-control routes (#2516).
+
+Companion to ``agent_query.py`` (which drives the streaming ``/query``
+route): this covers the non-streaming, request/response routes relayed
+through the daemon — today, the email agent's session-scoped autonomy
+control surface (``/v1/email/agent/session`` and
+``/v1/email/agent/autonomy*``).
+
+Same authenticated path as every other ``gaia email`` command: ensure the
+daemon + sidecar, then present ONLY the daemon client token to the relay
+(``ANY /v1/<agent>/*``); the daemon swaps it for the sidecar's own bearer
+server-side, so the CLI never holds — or invents a way to hold — sidecar
+credentials (design #2150/#2152, mirrored from ``agent_query.run_query``).
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Optional
+
+from gaia.daemon import client, paths
+from gaia.daemon.constants import AUTH_SCHEME
+from gaia.daemon.errors import DaemonError
+from gaia.logger import get_logger
+
+logger = get_logger(__name__)
+
+_CONNECT_TIMEOUT = 10.0
+_READ_TIMEOUT = 120.0
+
+
+def relay_json(
+    agent_id: str,
+    method: str,
+    path: str,
+    *,
+    json_body: Optional[Dict[str, Any]] = None,
+) -> Dict[str, Any]:
+    """Ensure the daemon + *agent_id* sidecar, then relay one JSON request.
+
+    Presents ONLY the daemon client token — the relay swaps in the sidecar
+    bearer server-side (never invented or held here). Raises
+    :class:`~gaia.daemon.errors.DaemonError` on any non-2xx response or
+    transport failure — a caller must never mistake a refusal for an empty
+    success.
+    """
+    import requests
+
+    inst = client.ensure_agent(agent_id)
+    url = f"{inst.base_url}/v1/{agent_id}/{path.lstrip('/')}"
+    headers = {"Authorization": f"{AUTH_SCHEME} {inst.token}"}
+    try:
+        r = requests.request(
+            method,
+            url,
+            headers=headers,
+            json=json_body,
+            timeout=(_CONNECT_TIMEOUT, _READ_TIMEOUT),
+        )
+    except requests.exceptions.RequestException as e:
+        raise DaemonError(
+            f"could not reach the '{agent_id}' agent through the daemon at "
+            f"{inst.base_url}: {e}. Check `gaia daemon status` and the daemon "
+            f"log at {paths.log_path()}."
+        ) from e
+    if r.status_code >= 400:
+        raise DaemonError(
+            f"the '{agent_id}' agent refused {method} {path} "
+            f"(HTTP {r.status_code}): {client._error_detail(r)}"
+        )
+    try:
+        return r.json()
+    except ValueError as e:
+        raise DaemonError(
+            f"the '{agent_id}' agent returned a non-JSON response for "
+            f"{method} {path}: {e}"
+        ) from e
+
+
+__all__ = ["relay_json"]

--- a/tests/unit/test_agent_control.py
+++ b/tests/unit/test_agent_control.py
@@ -75,7 +75,9 @@ def test_relay_json_raises_loud_on_error_status(monkeypatch):
     monkeypatch.setattr(requests, "request", lambda *a, **k: _Resp())
 
     with pytest.raises(DaemonError) as exc:
-        relay_json("email", "POST", "agent/autonomy/run", json_body={"session_id": "cli"})
+        relay_json(
+            "email", "POST", "agent/autonomy/run", json_body={"session_id": "cli"}
+        )
     assert "autonomy is off for session 'cli'" in str(exc.value)
 
 

--- a/tests/unit/test_agent_control.py
+++ b/tests/unit/test_agent_control.py
@@ -1,0 +1,96 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""Unit tests for ``gaia.daemon.agent_control.relay_json`` (#2516).
+
+Mirrors ``tests/unit/test_agent_query.py``'s ``ensure_agent`` coverage: the
+daemon + requests layer is stubbed so these run without a live daemon or
+sidecar.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from gaia.daemon.agent_control import relay_json
+from gaia.daemon.errors import DaemonError
+from gaia.daemon.instance import DaemonInstance
+
+
+def _inst():
+    return DaemonInstance(
+        pid=1, port=2, token="DAEMON-TOKEN", host="127.0.0.1", api_version="1.1"
+    )
+
+
+def test_relay_json_uses_only_the_daemon_token(monkeypatch):
+    """The relay call presents the daemon client token, never a sidecar bearer
+    the CLI would otherwise have to invent or hold."""
+    from gaia.daemon import client
+
+    monkeypatch.setattr(client, "ensure_agent", lambda agent_id: _inst())
+
+    captured = {}
+
+    class _Resp:
+        status_code = 200
+
+        def json(self):
+            return {"level": "earn_trust", "enabled": True}
+
+    def _fake_request(method, url, headers=None, json=None, timeout=None):
+        captured.update(method=method, url=url, headers=headers, json=json)
+        return _Resp()
+
+    import requests
+
+    monkeypatch.setattr(requests, "request", _fake_request)
+
+    body = relay_json(
+        "email",
+        "POST",
+        "agent/autonomy",
+        json_body={"session_id": "cli", "level": "earn_trust"},
+    )
+
+    assert body == {"level": "earn_trust", "enabled": True}
+    assert captured["method"] == "POST"
+    assert captured["url"].endswith("/v1/email/agent/autonomy")
+    assert captured["headers"]["Authorization"] == "Bearer DAEMON-TOKEN"
+    assert captured["json"] == {"session_id": "cli", "level": "earn_trust"}
+
+
+def test_relay_json_raises_loud_on_error_status(monkeypatch):
+    from gaia.daemon import client
+
+    monkeypatch.setattr(client, "ensure_agent", lambda agent_id: _inst())
+
+    class _Resp:
+        status_code = 409
+
+        def json(self):
+            return {"detail": "autonomy is off for session 'cli'"}
+
+    import requests
+
+    monkeypatch.setattr(requests, "request", lambda *a, **k: _Resp())
+
+    with pytest.raises(DaemonError) as exc:
+        relay_json("email", "POST", "agent/autonomy/run", json_body={"session_id": "cli"})
+    assert "autonomy is off for session 'cli'" in str(exc.value)
+
+
+def test_relay_json_raises_loud_on_transport_failure(monkeypatch):
+    from gaia.daemon import client
+
+    monkeypatch.setattr(client, "ensure_agent", lambda agent_id: _inst())
+
+    import requests
+
+    def _boom(*a, **k):
+        raise requests.exceptions.ConnectionError("refused")
+
+    monkeypatch.setattr(requests, "request", _boom)
+
+    with pytest.raises(DaemonError) as exc:
+        relay_json("email", "GET", "agent/autonomy/cli")
+    assert "could not reach the 'email' agent" in str(exc.value)

--- a/tests/unit/test_email_autonomy_cli.py
+++ b/tests/unit/test_email_autonomy_cli.py
@@ -1,0 +1,159 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""
+Tests for ``gaia email autonomy ...`` (#2516) — the thin-client CLI over the
+sidecar's session-scoped ``/v1/email/agent/autonomy*`` REST surface.
+
+Mirrors ``test_email_cli.py``: patches the relay seam
+(``gaia.daemon.agent_control.relay_json``), never ``gaia_agent_email``, so
+these run without the standalone email wheel or a live daemon.
+"""
+
+from __future__ import annotations
+
+import argparse
+from unittest.mock import patch
+
+import pytest
+
+from gaia import cli
+from gaia.cli import build_parser
+from gaia.daemon.errors import DaemonError
+
+
+class TestArgparse:
+    def test_status_parses_with_default_session(self):
+        ns = build_parser().parse_args(["email", "autonomy", "status"])
+        assert ns.action == "email"
+        assert ns.email_action == "autonomy"
+        assert ns.autonomy_action == "status"
+        assert ns.session_id == "cli"
+
+    def test_set_level_requires_a_valid_level(self):
+        ns = build_parser().parse_args(["email", "autonomy", "set-level", "full"])
+        assert ns.level == "full"
+        with pytest.raises(SystemExit):
+            build_parser().parse_args(["email", "autonomy", "set-level", "bogus"])
+
+    def test_run_parses_max_messages(self):
+        ns = build_parser().parse_args(
+            ["email", "autonomy", "run", "--max-messages", "5"]
+        )
+        assert ns.max_messages == 5
+
+    def test_plain_query_path_is_unaffected(self):
+        """Adding subparsers to email_parser must not break `-q`/`-i` flags."""
+        ns = build_parser().parse_args(["email", "-q", "hi"])
+        assert ns.action == "email"
+        assert ns.query == "hi"
+        assert getattr(ns, "email_action", None) is None
+
+
+class TestDispatch:
+    def test_handle_email_command_routes_autonomy_before_lemonade_check(self):
+        ns = argparse.Namespace(action="email", email_action="autonomy")
+        with (
+            patch("gaia.cli.handle_email_autonomy_command") as handler,
+            patch("gaia.cli.initialize_lemonade_for_agent") as init_lemonade,
+        ):
+            cli.handle_email_command(ns)
+            handler.assert_called_once_with(ns)
+            init_lemonade.assert_not_called()
+
+
+class TestAutonomyStatus:
+    def test_status_creates_session_then_prints_level(self, capsys):
+        ns = argparse.Namespace(autonomy_action="status", session_id="cli")
+        calls = []
+
+        def fake_relay(agent_id, method, path, *, json_body=None):
+            calls.append((agent_id, method, path, json_body))
+            if path == "agent/session":
+                return {"session_id": "cli", "created": True}
+            return {
+                "level": "earn_trust",
+                "enabled": True,
+                "trust_min_samples": 5,
+                "trust_threshold": 0.85,
+                "trusted_scope_count": 2,
+                "scopes": [],
+            }
+
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr("gaia.daemon.agent_control.relay_json", fake_relay)
+            with pytest.raises(SystemExit) as exc:
+                cli.handle_email_autonomy_command(ns)
+        assert exc.value.code == 0
+        assert calls[0] == ("email", "POST", "agent/session", {"session_id": "cli"})
+        assert calls[1] == ("email", "GET", "agent/autonomy/cli", None)
+        out = capsys.readouterr().out
+        assert "level: earn_trust" in out
+        assert "enabled: True" in out
+
+
+class TestAutonomySetLevel:
+    def test_set_level_round_trips(self, capsys):
+        ns = argparse.Namespace(
+            autonomy_action="set-level", session_id="cli", level="full"
+        )
+        calls = []
+
+        def fake_relay(agent_id, method, path, *, json_body=None):
+            calls.append((method, path, json_body))
+            if path == "agent/session":
+                return {"session_id": "cli", "created": False}
+            return {"level": "full", "enabled": True}
+
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr("gaia.daemon.agent_control.relay_json", fake_relay)
+            with pytest.raises(SystemExit) as exc:
+                cli.handle_email_autonomy_command(ns)
+        assert exc.value.code == 0
+        assert calls[1] == (
+            "POST",
+            "agent/autonomy",
+            {"session_id": "cli", "level": "full"},
+        )
+        assert "full" in capsys.readouterr().out
+
+
+class TestAutonomyRunRefusal:
+    def test_run_surfaces_off_refusal_loudly(self, capsys):
+        """#2528: when the sidecar refuses /run because autonomy is off, the
+        CLI must exit non-zero with the refusal's actionable message — never
+        print a quiet success."""
+        ns = argparse.Namespace(
+            autonomy_action="run", session_id="cli", max_messages=25
+        )
+
+        def fake_relay(agent_id, method, path, *, json_body=None):
+            if path == "agent/session":
+                return {"session_id": "cli", "created": False}
+            raise DaemonError(
+                "the 'email' agent refused POST agent/autonomy/run "
+                "(HTTP 409): autonomy is off for session 'cli' — "
+                "POST /v1/email/agent/autonomy to enable it."
+            )
+
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr("gaia.daemon.agent_control.relay_json", fake_relay)
+            with pytest.raises(SystemExit) as exc:
+                cli.handle_email_autonomy_command(ns)
+        assert exc.value.code == 1
+        err = capsys.readouterr().err
+        assert "autonomy is off" in err
+
+    def test_run_reports_sidecar_unreachable_loudly(self, capsys):
+        ns = argparse.Namespace(
+            autonomy_action="run", session_id="cli", max_messages=25
+        )
+
+        def fake_relay(agent_id, method, path, *, json_body=None):
+            raise DaemonError("could not reach the 'email' agent through the daemon")
+
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr("gaia.daemon.agent_control.relay_json", fake_relay)
+            with pytest.raises(SystemExit) as exc:
+                cli.handle_email_autonomy_command(ns)
+        assert exc.value.code == 1
+        assert "could not reach" in capsys.readouterr().err


### PR DESCRIPTION
`POST /v1/email/agent/autonomy/run` used to return HTTP 200 with the same empty-report shape whether autonomy was switched off or had genuinely run and found nothing to do — a caller had no way to tell the two apart. It now refuses with a 409 naming the current level and how to change it. Separately, the code and a plan doc both described a `gaia email autonomy` CLI that never existed; it's now built as a thin client over the daemon relay, and the stale claims are corrected.

- `agent_routes.py`'s `/autonomy/run` now checks the session's level before running a cycle, refusing with an actionable 409 instead of a silent no-op — documented in `spec_html.py`/`specification.html` and the npm `SPEC.md`/`SKILL.md`.
- New `gaia email autonomy {status|set-level|pause|resume|run|trust|kill}` (`src/gaia/cli.py`, `src/gaia/daemon/agent_control.py`) relays through the same daemon-token auth path every other `gaia email` command uses — no second auth scheme.

Closes #2528
Closes #2516

## Test plan

- [x] `python -m pytest hub/agents/email/python/tests -k "autonomy" -q` — 42 passed
- [x] `python -m pytest tests/unit -k "cli" -q` — 809 passed, 22 skipped (1 pre-existing unrelated failure: `test_claude_judge.py::test_raises_on_missing_api_key`, a known nested-worktree `.env` artifact)
- [x] `python -m pytest hub/agents/email/python/tests -q` — 1032 passed
- [x] `python util/lint.py --all` — all blocking checks pass
- [x] Manual argparse check: `gaia email autonomy status|set-level|run|...` parse correctly and don't break the existing `gaia email -q`/`-i` flags