### PR TITLE
fix(daemon): start the daemon clock so scheduled work can fire

### DIFF
--- a/src/gaia/daemon/app.py
+++ b/src/gaia/daemon/app.py
@@ -83,6 +83,7 @@ def create_app(
     broker=None,
     custody_auth=None,
     custody_store=None,
+    clock=None,
 ):
     """Build the FastAPI app bound to this daemon's identity.
 
@@ -106,6 +107,11 @@ def create_app(
     its OWN per-spawn secrets (bound at mint), NOT the client ``token`` — it is a
     separate surface with its own MAJOR (§0.31), so it is not behind
     ``require_token``.
+
+    *clock* (a :class:`gaia.daemon.scheduler.clock.DaemonClock`) additively
+    reports its running state, last poll time, and pending/failed job counts
+    on ``GET /daemon/v1/status`` (#2379); ``None`` (the default) leaves the
+    response exactly as it was before the clock existed.
     """
     from fastapi import Depends, FastAPI, HTTPException
 
@@ -133,7 +139,7 @@ def create_app(
     @app.get(f"{API_PREFIX}/status")
     def status(_: None = Depends(require_token)) -> dict:
         now = time.time()
-        return {
+        payload = {
             "service": SERVICE_ID,
             "api_version": DAEMON_API_VERSION,
             "pid": pid,
@@ -142,6 +148,15 @@ def create_app(
             "started_at": started_at,
             "uptime_seconds": max(0.0, now - started_at),
         }
+        if clock is not None:
+            counts = clock.job_counts()
+            payload["clock"] = {
+                "running": clock.running,
+                "last_poll_at": clock.last_poll_at,
+                "pending_jobs": counts["pending"],
+                "failed_jobs": counts["failed"],
+            }
+        return payload
 
     @app.post(f"{API_PREFIX}/shutdown")
     def shutdown(_: None = Depends(require_token)) -> dict:

--- a/src/gaia/daemon/paths.py
+++ b/src/gaia/daemon/paths.py
@@ -57,24 +57,34 @@ def custody_db_path() -> Path:
 
 
 def ensure_host_dir() -> Path:
-    """Create ``host_dir()`` if missing and return it."""
+    """Create ``host_dir()`` if missing (``0700`` on POSIX, first-touch only)
+    and return it.
+
+    The directory holds instance.json's client token, the sidecar ledger, and
+    (via ``scheduler_db_path()``) will eventually hold job recipients/subjects —
+    hardened at the point of creation for every caller, not re-chmod'd on
+    every call, so a directory a user deliberately loosened afterward isn't
+    silently re-tightened underneath them the next time any daemon path helper
+    runs.
+    """
     d = host_dir()
+    existed = d.exists()
     d.mkdir(parents=True, exist_ok=True)
+    if not existed and os.name != "nt":
+        os.chmod(d, 0o700)
     return d
 
 
 def scheduler_db_path() -> Path:
     """The daemon-owned scheduler SQLite file (single clock's job store, #2379).
 
-    Hardened beyond its sibling ``custody_db_path()``: this store will eventually
-    hold recipients and subjects (email job payloads), so every call chmods the
-    host dir ``0700`` and, on first touch, creates the file itself ``0600`` —
-    mirroring the ``atomic_write_json(mode=0o600)`` precedent above. Mode bits
-    are meaningless on Windows and skipped there.
+    Hardened beyond its sibling ``custody_db_path()``: this store will
+    eventually hold recipients and subjects (email job payloads), so the file
+    is created ``0600`` on first touch — mirroring the
+    ``atomic_write_json(mode=0o600)`` precedent above. Mode bits are
+    meaningless on Windows and skipped there.
     """
     d = ensure_host_dir()
-    if os.name != "nt":
-        os.chmod(d, 0o700)
     path = d / "scheduler.db"
     if not path.exists():
         try:

--- a/src/gaia/daemon/paths.py
+++ b/src/gaia/daemon/paths.py
@@ -63,6 +63,29 @@ def ensure_host_dir() -> Path:
     return d
 
 
+def scheduler_db_path() -> Path:
+    """The daemon-owned scheduler SQLite file (single clock's job store, #2379).
+
+    Hardened beyond its sibling ``custody_db_path()``: this store will eventually
+    hold recipients and subjects (email job payloads), so every call chmods the
+    host dir ``0700`` and, on first touch, creates the file itself ``0600`` —
+    mirroring the ``atomic_write_json(mode=0o600)`` precedent above. Mode bits
+    are meaningless on Windows and skipped there.
+    """
+    d = ensure_host_dir()
+    if os.name != "nt":
+        os.chmod(d, 0o700)
+    path = d / "scheduler.db"
+    if not path.exists():
+        try:
+            fd = os.open(str(path), os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+        except FileExistsError:
+            pass
+        else:
+            os.close(fd)
+    return path
+
+
 def atomic_write_json(path: Path, payload, mode: int = 0o600) -> None:
     """Atomically persist *payload* as JSON at *path*, default file mode 0600.
 

--- a/src/gaia/daemon/scheduler/clock.py
+++ b/src/gaia/daemon/scheduler/clock.py
@@ -87,7 +87,12 @@ class DaemonClock:
 
     def _open_db(self) -> _ClockDB:
         db = _ClockDB()
-        db.init_db(self._db_path)
+        # quiet=True: a genuinely fresh connection opens on EVERY pass by
+        # design (module docstring above), so the mixin's per-connection
+        # "Database initialized" INFO line would otherwise repeat forever at
+        # the poll cadence (~2,880 lines/day at the 30s default) rather than
+        # log a one-time startup event.
+        db.init_db(self._db_path, quiet=True)
         # Per-connection pragma — must be set on every open, unlike the schema.
         db.execute(f"PRAGMA busy_timeout = {_BUSY_TIMEOUT_MS}")
         if not self._schema_ready:

--- a/src/gaia/daemon/scheduler/clock.py
+++ b/src/gaia/daemon/scheduler/clock.py
@@ -205,14 +205,18 @@ class DaemonClock:
     def job_counts(self) -> Dict[str, int]:
         """Point-in-time pending/failed counts for ``GET /daemon/v1/status``.
 
+        A ``COUNT(*)`` per status, not a materialised row list — this backs a
+        public HTTP route any attached client can poll, so it must not become
+        an unbounded read as the job table grows.
+
         Opens its own connection (same rule as every other pass) and closes it
         before returning.
         """
         db = self._open_db()
         try:
             return {
-                "pending": len(store.list_jobs(db, status=STATUS_PENDING)),
-                "failed": len(store.list_jobs(db, status=STATUS_FAILED)),
+                "pending": store.count_jobs(db, status=STATUS_PENDING),
+                "failed": store.count_jobs(db, status=STATUS_FAILED),
             }
         finally:
             db.close_db()

--- a/src/gaia/daemon/scheduler/clock.py
+++ b/src/gaia/daemon/scheduler/clock.py
@@ -27,9 +27,11 @@ is likewise marked ``failed``, never quietly skipped.
 from __future__ import annotations
 
 import threading
+import time
 from typing import Any, Callable, Dict, List, Optional
 
 from gaia.daemon.scheduler import store
+from gaia.daemon.scheduler.models import STATUS_FAILED, STATUS_PENDING
 from gaia.database.mixin import DatabaseMixin
 from gaia.logger import get_logger
 
@@ -38,6 +40,11 @@ log = get_logger(__name__)
 # Executor signature: (job_row, db) -> None. ``db`` is the clock-owned per-pass
 # connection; executors must use it for any store writes, never a shared handle.
 JobExecutor = Callable[[Dict[str, Any], Any], None]
+
+# Generous busy_timeout (matches the daemon's custody store, #2153) so a brief
+# lock from a concurrent writer (a second driver during the migration window,
+# or a status-route job_counts() read) waits instead of raising SQLITE_BUSY.
+_BUSY_TIMEOUT_MS = 5000
 
 
 class _ClockDB(DatabaseMixin):
@@ -73,13 +80,24 @@ class DaemonClock:
         self._poll_seconds = poll_seconds
         self._stop_event = threading.Event()
         self._thread: Optional[threading.Thread] = None
+        self._schema_ready = False
+        self._last_poll_at: Optional[float] = None
 
     # -- Store bootstrap ------------------------------------------------
 
     def _open_db(self) -> _ClockDB:
         db = _ClockDB()
         db.init_db(self._db_path)
-        store.init_schema(db)
+        # Per-connection pragma — must be set on every open, unlike the schema.
+        db.execute(f"PRAGMA busy_timeout = {_BUSY_TIMEOUT_MS}")
+        if not self._schema_ready:
+            # Once per instance, not once per poll pass: at a 30s default this
+            # ran forever on every tick — a permanent disk wakeup even with no
+            # jobs. CREATE TABLE IF NOT EXISTS is idempotent either way, so a
+            # rare cross-thread double-init (first call vs. the polling thread)
+            # is harmless, just not the common case.
+            store.init_schema(db)
+            self._schema_ready = True
         return db
 
     # -- Driving --------------------------------------------------------
@@ -95,6 +113,7 @@ class DaemonClock:
             return self._fire_due_on(db, now=now)
         finally:
             db.close_db()
+            self._last_poll_at = time.time()
 
     def _fire_due_on(self, db, *, now: Optional[float]) -> Dict[str, List[str]]:
         fired: List[str] = []
@@ -151,15 +170,52 @@ class DaemonClock:
         self._thread.start()
 
     def stop(self) -> None:
-        """Signal the polling thread to exit and wait for it."""
+        """Signal the polling thread to exit and wait for it.
+
+        Never lies about having stopped: if the thread is still alive after the
+        join timeout (a ``fire_due`` pass stuck, e.g. on a wedged filesystem),
+        this logs loudly at ERROR and leaves the thread reference in place so
+        ``running`` keeps reporting True — not a silently cleared, false
+        "stopped".
+        """
         self._stop_event.set()
-        if self._thread is not None:
-            self._thread.join(timeout=self._poll_seconds + 5)
-            self._thread = None
+        if self._thread is None:
+            return
+        self._thread.join(timeout=self._poll_seconds + 5)
+        if self._thread.is_alive():
+            log.error(
+                "daemon clock: polling thread did not stop within %.1fs of the "
+                "join timeout — a fire_due pass may be stuck. Leaving it "
+                "tracked as running rather than silently clearing state.",
+                self._poll_seconds + 5,
+            )
+            return
+        self._thread = None
 
     @property
     def running(self) -> bool:
         return self._thread is not None and self._thread.is_alive()
+
+    @property
+    def last_poll_at(self) -> Optional[float]:
+        """Timestamp of the most recently completed ``fire_due`` pass, or
+        ``None`` before the first one has run."""
+        return self._last_poll_at
+
+    def job_counts(self) -> Dict[str, int]:
+        """Point-in-time pending/failed counts for ``GET /daemon/v1/status``.
+
+        Opens its own connection (same rule as every other pass) and closes it
+        before returning.
+        """
+        db = self._open_db()
+        try:
+            return {
+                "pending": len(store.list_jobs(db, status=STATUS_PENDING)),
+                "failed": len(store.list_jobs(db, status=STATUS_FAILED)),
+            }
+        finally:
+            db.close_db()
 
     def _run(self) -> None:
         # Fire immediately on start so past-due jobs from a previous daemon run

--- a/src/gaia/daemon/scheduler/store.py
+++ b/src/gaia/daemon/scheduler/store.py
@@ -150,6 +150,18 @@ def list_jobs(db, *, status: Optional[str] = None) -> List[Dict[str, Any]]:
     return [_row_to_job(r) for r in rows or ()]
 
 
+def count_jobs(db, *, status: str) -> int:
+    """``SELECT COUNT(*)`` for one status — used by the status route, which any
+    client can poll, so it must never materialise every matching row just to
+    take a length."""
+    row = db.query(
+        "SELECT COUNT(*) AS n FROM daemon_jobs WHERE status = :st",
+        {"st": status},
+        one=True,
+    )
+    return int(row["n"]) if row else 0
+
+
 def fetch_due(db, *, now: Optional[float] = None) -> List[Dict[str, Any]]:
     """Return every pending job whose ``fire_at`` is at or before ``now``.
 
@@ -277,6 +289,7 @@ def list_ledger(db, *, source: Optional[str] = None) -> List[Dict[str, Any]]:
 __all__ = [
     "DAEMON_JOBS_DDL",
     "claim_job",
+    "count_jobs",
     "fetch_due",
     "get_job",
     "init_schema",

--- a/src/gaia/daemon/server.py
+++ b/src/gaia/daemon/server.py
@@ -151,11 +151,13 @@ def _build_register(
 
     Crash-safety (#2379): ``app.py``'s lifespan calls ``on_startup()`` OUTSIDE
     its ``try``/``finally``, so if this raises, ``on_shutdown`` (the
-    ``_deregister`` hook) never runs to clean up. A ``clock.start()`` failure
-    must therefore roll back everything already done here — stop the
-    refresher and remove the ``instance.json`` just written — before
-    re-raising, so a failed startup never leaves a live polling thread or a
-    stale registry entry pointing at a daemon that is about to die.
+    ``_deregister`` hook) never runs to clean up. Either ``refresher.start()``
+    or ``clock.start()`` failing must therefore roll back everything already
+    done here — stop the refresher (safe even if it never started —
+    :meth:`ForwardRefresher.stop` is documented idempotent-when-unstarted) and
+    remove the ``instance.json`` just written — before re-raising, so a failed
+    startup never leaves a live polling thread or a stale registry entry
+    pointing at a daemon that is about to die.
     """
     from gaia.daemon.sidecars import ledger
 
@@ -170,11 +172,14 @@ def _build_register(
                 pid=pid, port=port, token=token, host=host, started_at=started_at
             )
         )
-        refresher.start()
         try:
+            refresher.start()
             clock.start()
         except Exception:
-            logger.exception("daemon: clock failed to start; rolling back registration")
+            logger.exception(
+                "daemon: startup failed after instance.json was written; "
+                "rolling back registration"
+            )
             refresher.stop()
             remove_instance(only_pid=pid)
             raise

--- a/src/gaia/daemon/server.py
+++ b/src/gaia/daemon/server.py
@@ -20,11 +20,13 @@ import secrets
 import socket
 import time
 from pathlib import Path
+from typing import Callable, Dict, Optional
 
 from gaia.daemon.app import create_app
 from gaia.daemon.constants import HOST, RESERVED_PORT
 from gaia.daemon.errors import DaemonStartError
 from gaia.daemon.instance import DaemonInstance, remove_instance, write_instance
+from gaia.daemon.scheduler.clock import DaemonClock, JobExecutor
 from gaia.logger import get_logger
 
 logger = get_logger(__name__)
@@ -126,6 +128,78 @@ def _build_registry(specs, forwarder, *, custody_auth=None, custody_base_url=Non
     )
 
 
+def _build_clock(
+    db_path: str, *, executors: Optional[Dict[str, JobExecutor]] = None
+) -> DaemonClock:
+    """The daemon's single scheduled-job clock (#2379).
+
+    *executors* ships EMPTY in production — ``run()`` below calls this with no
+    ``executors`` argument at all. This lands the clock machinery only; no job
+    kind has a registered executor yet. Wiring a real one (email briefing/send
+    and beyond) is a deliberate follow-up (see the PR description), not an
+    oversight — reconciling jobs before an executor exists would permanently
+    fail-mark every one of them on first fire.
+    """
+    return DaemonClock(db_path, executors=executors or {})
+
+
+def _build_register(
+    *, specs, pid, port, token, host, started_at, refresher, clock
+) -> Callable[[], None]:
+    """The daemon's ``on_startup`` hook: reap stale sidecars, publish
+    instance.json, then start the connector-token refresher and the job clock.
+
+    Crash-safety (#2379): ``app.py``'s lifespan calls ``on_startup()`` OUTSIDE
+    its ``try``/``finally``, so if this raises, ``on_shutdown`` (the
+    ``_deregister`` hook) never runs to clean up. A ``clock.start()`` failure
+    must therefore roll back everything already done here — stop the
+    refresher and remove the ``instance.json`` just written — before
+    re-raising, so a failed startup never leaves a live polling thread or a
+    stale registry entry pointing at a daemon that is about to die.
+    """
+    from gaia.daemon.sidecars import ledger
+
+    def _register() -> None:
+        # Reap identity-confirmed sidecar survivors of a previous daemon that
+        # died hard (SIGKILL/OOM) BEFORE serving — never adopt them silently.
+        killed = ledger.reap_stale(specs)
+        if killed:
+            logger.info("daemon: reaped stale sidecar pids %s", killed)
+        write_instance(
+            DaemonInstance(
+                pid=pid, port=port, token=token, host=host, started_at=started_at
+            )
+        )
+        refresher.start()
+        try:
+            clock.start()
+        except Exception:
+            logger.exception("daemon: clock failed to start; rolling back registration")
+            refresher.stop()
+            remove_instance(only_pid=pid)
+            raise
+        logger.info("daemon: registered instance pid=%s port=%s", pid, port)
+
+    return _register
+
+
+def _build_deregister(
+    *, registry, custody_store, pid, refresher, clock
+) -> Callable[[], None]:
+    """The daemon's ``on_shutdown`` hook: stop the refresher and the clock
+    BEFORE tearing down sidecars, so neither races a sidecar mid-teardown."""
+
+    def _deregister() -> None:
+        refresher.stop()
+        clock.stop()
+        registry.shutdown_all()
+        custody_store.close()
+        remove_instance(only_pid=pid)
+        logger.info("daemon: deregistered instance pid=%s", pid)
+
+    return _deregister
+
+
 def run(host: str = HOST) -> None:
     """Start the daemon and serve until shutdown. Blocks."""
     import uvicorn
@@ -133,8 +207,7 @@ def run(host: str = HOST) -> None:
     from gaia.daemon.custody.auth import CustodyAuth
     from gaia.daemon.custody.store import CustodyStore
     from gaia.daemon.migrate import run_migrations
-    from gaia.daemon.paths import custody_db_path
-    from gaia.daemon.sidecars import ledger
+    from gaia.daemon.paths import custody_db_path, scheduler_db_path
     from gaia.daemon.sidecars.spec import builtin_specs
 
     # One-time versioned state migration (§0.10 step 0). Runs before the port is
@@ -186,26 +259,29 @@ def run(host: str = HOST) -> None:
     # sidecar model loads route through the broker rather than racing the slot.
     os.environ[BROKER_URL_ENV_VAR] = f"http://{host}:{port}"
 
-    def _register() -> None:
-        # Reap identity-confirmed sidecar survivors of a previous daemon that
-        # died hard (SIGKILL/OOM) BEFORE serving — never adopt them silently.
-        killed = ledger.reap_stale(specs)
-        if killed:
-            logger.info("daemon: reaped stale sidecar pids %s", killed)
-        write_instance(
-            DaemonInstance(
-                pid=pid, port=port, token=token, host=host, started_at=started_at
-            )
-        )
-        refresher.start()
-        logger.info("daemon: registered instance pid=%s port=%s", pid, port)
+    # The daemon's single scheduled-job clock (#2379): built here so both the
+    # register/deregister hooks and the status route share one instance. Ships
+    # with NO executors — see _build_clock's docstring for why that is
+    # deliberate, not an oversight.
+    clock = _build_clock(str(scheduler_db_path()))
 
-    def _deregister() -> None:
-        refresher.stop()
-        registry.shutdown_all()
-        custody_store.close()
-        remove_instance(only_pid=pid)
-        logger.info("daemon: deregistered instance pid=%s", pid)
+    _register = _build_register(
+        specs=specs,
+        pid=pid,
+        port=port,
+        token=token,
+        host=host,
+        started_at=started_at,
+        refresher=refresher,
+        clock=clock,
+    )
+    _deregister = _build_deregister(
+        registry=registry,
+        custody_store=custody_store,
+        pid=pid,
+        refresher=refresher,
+        clock=clock,
+    )
 
     app = create_app(
         token=token,
@@ -219,6 +295,7 @@ def run(host: str = HOST) -> None:
         broker=broker,
         custody_auth=custody_auth,
         custody_store=custody_store,
+        clock=clock,
     )
 
     config = uvicorn.Config(

--- a/src/gaia/database/mixin.py
+++ b/src/gaia/database/mixin.py
@@ -42,13 +42,20 @@ class DatabaseMixin:
     _db: Optional[sqlite3.Connection] = None
     _in_tx: bool = False
 
-    def init_db(self, path: str = ":memory:") -> None:
+    def init_db(self, path: str = ":memory:", *, quiet: bool = False) -> None:
         """
         Initialize SQLite database.
 
         Args:
             path: Database file path, or ":memory:" for in-memory database.
                   Parent directories are created automatically.
+            quiet: Skip the "Database initialized" INFO line. Defaults to
+                   False — every existing one-shot-at-startup caller keeps
+                   today's behavior unchanged. Set True only for a caller that
+                   opens a fresh connection on a recurring cadence (e.g. a
+                   polling driver opening one per pass), where that same INFO
+                   line would otherwise become a permanent, unbounded log-noise
+                   cost rather than a one-time startup confirmation.
 
         Example:
             self.init_db("data/myagent.db")  # File-based
@@ -64,7 +71,8 @@ class DatabaseMixin:
         self._db.row_factory = sqlite3.Row
         self._db.execute("PRAGMA foreign_keys = ON")
         self._in_tx = False
-        logger.info("Database initialized: %s", path)
+        if not quiet:
+            logger.info("Database initialized: %s", path)
 
     def close_db(self) -> None:
         """

--- a/tests/integration/test_daemon_sidecars.py
+++ b/tests/integration/test_daemon_sidecars.py
@@ -465,3 +465,59 @@ def test_cli_stop_agent_unknown_id_surfaces_registered_ids(toy_env):
         assert "toy" in combined  # 404 detail lists registered ids
     finally:
         _stop(inst)
+
+
+# ---------------------------------------------------------------------------
+# The real daemon clock actually fires (#2379: DaemonClock is never started)
+# ---------------------------------------------------------------------------
+
+
+def test_real_daemon_clock_fires_a_due_pending_job(toy_env):
+    """A real daemon process starts DaemonClock (#2379): a past-due pending
+    job registered directly in the scheduler db (before the daemon is even
+    started) is picked up by the polling thread the moment the daemon starts,
+    and marked failed. No executor is wired for KIND_ONE_SHOT in this issue —
+    the clock firing the job for real is proven by the pending -> failed
+    transition, not by success."""
+    from gaia.daemon import paths as daemon_paths
+    from gaia.daemon.scheduler import store
+    from gaia.daemon.scheduler.clock import _ClockDB
+    from gaia.daemon.scheduler.models import KIND_ONE_SHOT, STATUS_FAILED
+
+    db_path = str(daemon_paths.scheduler_db_path())
+    db = _ClockDB()
+    db.init_db(db_path)
+    store.init_schema(db)
+    job_id = store.register_job(
+        db, source="test", kind=KIND_ONE_SHOT, fire_at=time.time() - 3600
+    )
+    db.close_db()
+
+    def _job_status():
+        reader = _ClockDB()
+        reader.init_db(db_path)
+        try:
+            row = store.get_job(reader, job_id=job_id)
+            return row["status"] if row else None
+        finally:
+            reader.close_db()
+
+    inst = None
+    try:
+        inst = client.start_or_attach()
+
+        assert _wait_for(
+            lambda: _job_status() == STATUS_FAILED, timeout=10.0
+        ), f"job never transitioned to failed; last status={_job_status()!r}"
+
+        r = requests.get(
+            f"{inst.base_url}{API_PREFIX}/status",
+            headers={"Authorization": f"Bearer {inst.token}"},
+            timeout=5,
+        )
+        assert r.status_code == 200, r.text
+        body = r.json()
+        assert body["clock"]["running"] is True
+        assert body["clock"]["failed_jobs"] >= 1
+    finally:
+        _stop(inst)

--- a/tests/unit/test_daemon_clock_wiring.py
+++ b/tests/unit/test_daemon_clock_wiring.py
@@ -1,0 +1,362 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""Unit tests for wiring the single daemon clock into the daemon process (#2379).
+
+The daemon builds a `DaemonClock` but the current `server.py` never starts it —
+scheduled jobs are registered in the store and then simply never fire. This file
+pins the fixed contract for the fix:
+
+- `gaia.daemon.paths.scheduler_db_path()` — the one file-backed path every
+  `DaemonClock` in the daemon process must share (never `:memory:`).
+- `gaia.daemon.server._build_clock` / `_build_register` / `_build_deregister` —
+  the wiring seams: `_build_register`'s callable starts the refresher then the
+  clock (rolling back both the refresher and `instance.json` if the clock start
+  fails), and `_build_deregister`'s callable stops everything in a fixed order.
+- `DaemonClock.stop()` must never silently claim success when its polling
+  thread fails to join — it must log loudly and leave `running` reporting
+  `True`.
+- `GET /daemon/v1/status` gains an additive `"clock"` object only when a clock
+  is passed to `create_app`.
+
+Also carries two static guard tests protecting the intended scope of this fix:
+no daemon file may import `gaia_agent_email`, and no daemon scheduler/server
+file may reference the unrelated "autonomy" scheduler concept.
+"""
+
+from __future__ import annotations
+
+import ast
+import logging
+import os
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+from gaia.daemon import instance as instance_mod
+from gaia.daemon import paths
+from gaia.daemon import server as daemon_server
+from gaia.daemon.scheduler.clock import DaemonClock
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_DAEMON_SRC = _REPO_ROOT / "src" / "gaia" / "daemon"
+
+
+@pytest.fixture()
+def daemon_home(tmp_path, monkeypatch):
+    """Isolate all daemon on-disk state under a tmp dir for one test."""
+    home = tmp_path / "host"
+    monkeypatch.setenv("GAIA_DAEMON_HOME", str(home))
+    return home
+
+
+# ---------------------------------------------------------------------------
+# gaia.daemon.paths.scheduler_db_path
+# ---------------------------------------------------------------------------
+
+
+def test_scheduler_db_path_returns_host_dir_scheduler_db(daemon_home):
+    path = paths.scheduler_db_path()
+
+    assert path == paths.host_dir() / "scheduler.db"
+    assert str(path) != ":memory:"
+
+
+def test_scheduler_db_path_creates_host_dir_0700_and_file_0600(daemon_home):
+    assert not daemon_home.exists()
+
+    path = paths.scheduler_db_path()
+
+    assert daemon_home.is_dir()
+    assert path.exists()
+    if os.name != "nt":
+        assert (os.stat(daemon_home).st_mode & 0o777) == 0o700
+        assert (os.stat(path).st_mode & 0o777) == 0o600
+
+
+def test_scheduler_db_path_does_not_clobber_an_existing_file(daemon_home):
+    first = paths.scheduler_db_path()
+    first.write_bytes(b"not-actually-empty-sqlite-bytes")
+
+    second = paths.scheduler_db_path()
+
+    assert second == first
+    assert second.read_bytes() == b"not-actually-empty-sqlite-bytes"
+
+
+# ---------------------------------------------------------------------------
+# gaia.daemon.server._build_clock
+# ---------------------------------------------------------------------------
+
+
+def test_build_clock_uses_scheduler_db_path(daemon_home):
+    """`_build_clock` opens the shared scheduler_db_path file, and with no
+    `executors` kwarg (the production call in `run()`) the mapping is empty —
+    proven black-box by a due job failing with "no executor registered"."""
+    from gaia.daemon.scheduler import store
+    from gaia.daemon.scheduler.clock import _ClockDB
+    from gaia.daemon.scheduler.models import KIND_ONE_SHOT, STATUS_FAILED
+
+    db_path = str(paths.scheduler_db_path())
+    db = _ClockDB()
+    db.init_db(db_path)
+    store.init_schema(db)
+    job_id = store.register_job(db, source="test", kind=KIND_ONE_SHOT, fire_at=1.0)
+    db.close_db()
+
+    clock = daemon_server._build_clock(db_path)  # no executors kwarg at all
+
+    result = clock.fire_due(now=10.0)
+
+    assert result == {"fired": [], "failed": [job_id]}
+    db2 = _ClockDB()
+    db2.init_db(db_path)
+    try:
+        job = store.get_job(db2, job_id=job_id)
+        assert job["status"] == STATUS_FAILED
+        assert "no executor registered" in job["error"]
+    finally:
+        db2.close_db()
+
+
+# ---------------------------------------------------------------------------
+# gaia.daemon.server._build_register
+# ---------------------------------------------------------------------------
+
+
+def test_build_register_starts_refresher_then_clock_and_writes_instance(daemon_home):
+    calls = []
+    refresher = mock.Mock()
+    refresher.start.side_effect = lambda: calls.append("refresher.start")
+    clock = mock.Mock()
+    clock.start.side_effect = lambda: calls.append("clock.start")
+
+    register = daemon_server._build_register(
+        specs={},
+        pid=4242,
+        port=55123,
+        token="tok-xyz",
+        host="127.0.0.1",
+        started_at=100.0,
+        refresher=refresher,
+        clock=clock,
+    )
+    register()
+
+    assert calls == ["refresher.start", "clock.start"]
+    inst = instance_mod.read_instance()
+    assert inst is not None
+    assert inst.pid == 4242
+    assert inst.port == 55123
+    assert inst.token == "tok-xyz"
+    assert inst.host == "127.0.0.1"
+    assert inst.started_at == 100.0
+
+
+def test_build_register_rolls_back_refresher_and_instance_on_clock_start_failure(
+    daemon_home,
+):
+    refresher = mock.Mock()
+    clock = mock.Mock()
+    clock.start.side_effect = RuntimeError("clock exploded")
+
+    register = daemon_server._build_register(
+        specs={},
+        pid=4343,
+        port=55124,
+        token="tok-abc",
+        host="127.0.0.1",
+        started_at=200.0,
+        refresher=refresher,
+        clock=clock,
+    )
+
+    with pytest.raises(RuntimeError, match="clock exploded"):
+        register()
+
+    refresher.stop.assert_called_once()
+    # instance.json was written before the clock.start() failure — it must be
+    # undone, never left stranded pointing at a daemon whose clock never ran.
+    assert instance_mod.read_instance() is None
+
+
+# ---------------------------------------------------------------------------
+# gaia.daemon.server._build_deregister
+# ---------------------------------------------------------------------------
+
+
+def test_build_deregister_calls_in_exact_order(daemon_home):
+    instance_mod.write_instance(instance_mod.DaemonInstance(pid=555, port=1, token="t"))
+
+    calls = []
+    refresher = mock.Mock()
+    refresher.stop.side_effect = lambda: calls.append("refresher.stop")
+    clock = mock.Mock()
+    clock.stop.side_effect = lambda: calls.append("clock.stop")
+    registry = mock.Mock()
+    registry.shutdown_all.side_effect = lambda: calls.append("registry.shutdown_all")
+    custody_store = mock.Mock()
+    custody_store.close.side_effect = lambda: calls.append("custody_store.close")
+
+    deregister = daemon_server._build_deregister(
+        registry=registry,
+        custody_store=custody_store,
+        pid=555,
+        refresher=refresher,
+        clock=clock,
+    )
+    deregister()
+
+    assert calls == [
+        "refresher.stop",
+        "clock.stop",
+        "registry.shutdown_all",
+        "custody_store.close",
+    ]
+    assert instance_mod.read_instance() is None
+
+
+# ---------------------------------------------------------------------------
+# DaemonClock.stop() must never silently claim success on a hung thread
+# ---------------------------------------------------------------------------
+
+
+def test_stop_logs_error_and_running_stays_true_when_thread_wont_join(tmp_path, caplog):
+    clock = DaemonClock(str(tmp_path / "clock.db"), executors={})
+
+    class _HangingThread:
+        """Stands in for a polling thread that never exits within the join
+        timeout — deterministic and instant, no real hang required."""
+
+        def join(self, timeout=None):
+            return None
+
+        def is_alive(self):
+            return True
+
+    clock._thread = _HangingThread()
+
+    with caplog.at_level(logging.ERROR, logger="gaia.daemon.scheduler.clock"):
+        clock.stop()
+
+    assert any(r.levelno >= logging.ERROR for r in caplog.records), (
+        "stop() must log loudly when the polling thread fails to join; "
+        f"captured records: {[r.getMessage() for r in caplog.records]}"
+    )
+    assert clock.running is True, (
+        "stop() must not clear internal thread state when the join failed — "
+        "running must keep reporting True, never a false 'stopped'"
+    )
+
+
+# ---------------------------------------------------------------------------
+# GET /daemon/v1/status: additive "clock" object
+# ---------------------------------------------------------------------------
+
+
+class _FakeClock:
+    def __init__(self, *, running, last_poll_at, pending, failed):
+        self.running = running
+        self.last_poll_at = last_poll_at
+        self._pending = pending
+        self._failed = failed
+
+    def job_counts(self):
+        return {"pending": self._pending, "failed": self._failed}
+
+
+def test_status_omits_clock_key_when_clock_is_none():
+    from fastapi.testclient import TestClient
+
+    from gaia.daemon.app import create_app
+
+    app = create_app(token="tok-status-a", port=1234, pid=111, started_at=0.0)
+    client = TestClient(app, raise_server_exceptions=False)
+
+    r = client.get(
+        "/daemon/v1/status", headers={"Authorization": "Bearer tok-status-a"}
+    )
+
+    assert r.status_code == 200
+    assert "clock" not in r.json()
+
+
+def test_status_includes_clock_object_when_clock_given():
+    from fastapi.testclient import TestClient
+
+    from gaia.daemon.app import create_app
+
+    fake_clock = _FakeClock(running=True, last_poll_at=12345.5, pending=2, failed=1)
+    app = create_app(
+        token="tok-status-b",
+        port=1234,
+        pid=222,
+        started_at=0.0,
+        clock=fake_clock,
+    )
+    client = TestClient(app, raise_server_exceptions=False)
+
+    r = client.get(
+        "/daemon/v1/status", headers={"Authorization": "Bearer tok-status-b"}
+    )
+
+    assert r.status_code == 200
+    body = r.json()
+    assert body["clock"] == {
+        "running": True,
+        "last_poll_at": 12345.5,
+        "pending_jobs": 2,
+        "failed_jobs": 1,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Guard tests: keep this fix scoped to daemon-clock wiring, nothing else
+# ---------------------------------------------------------------------------
+
+
+def test_no_gaia_agent_email_import_under_daemon():
+    """No file under src/gaia/daemon/ may actually import gaia_agent_email —
+    the daemon core never imports a hub agent wheel. Comments mentioning the
+    string (documenting a MUST-match constant) are fine; only real `import`/
+    `from ... import` statements are forbidden."""
+    offenders = []
+    for path in sorted(_DAEMON_SRC.rglob("*.py")):
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Import):
+                for alias in node.names:
+                    if alias.name == "gaia_agent_email" or alias.name.startswith(
+                        "gaia_agent_email."
+                    ):
+                        offenders.append(str(path))
+            elif isinstance(node, ast.ImportFrom):
+                module = node.module or ""
+                if module == "gaia_agent_email" or module.startswith(
+                    "gaia_agent_email."
+                ):
+                    offenders.append(str(path))
+
+    assert offenders == [], (
+        "src/gaia/daemon/ must never import gaia_agent_email (core cannot "
+        f"depend on a hub agent wheel); found real import statements in: "
+        f"{sorted(set(offenders))}"
+    )
+
+
+def test_no_autonomy_reference_in_scheduler_wiring():
+    """Neither server.py nor anything under daemon/scheduler/ may reference
+    the unrelated 'autonomy' scheduler concept — this fix wires the existing
+    DaemonClock only."""
+    targets = [_DAEMON_SRC / "server.py"] + sorted(
+        (_DAEMON_SRC / "scheduler").rglob("*.py")
+    )
+    offenders = [
+        str(path)
+        for path in targets
+        if path.is_file() and "autonomy" in path.read_text(encoding="utf-8").lower()
+    ]
+
+    assert offenders == [], (
+        "found a forbidden 'autonomy' reference (case-insensitive) in: " f"{offenders}"
+    )

--- a/tests/unit/test_daemon_clock_wiring.py
+++ b/tests/unit/test_daemon_clock_wiring.py
@@ -180,6 +180,33 @@ def test_build_register_rolls_back_refresher_and_instance_on_clock_start_failure
     assert instance_mod.read_instance() is None
 
 
+def test_build_register_rolls_back_instance_on_refresher_start_failure(daemon_home):
+    """The same rollback must apply one line earlier: if refresher.start()
+    itself raises (before clock.start() is ever reached), instance.json was
+    already written and must still be undone — not just on a clock failure."""
+    refresher = mock.Mock()
+    refresher.start.side_effect = RuntimeError("refresher exploded")
+    clock = mock.Mock()
+
+    register = daemon_server._build_register(
+        specs={},
+        pid=4444,
+        port=55125,
+        token="tok-def",
+        host="127.0.0.1",
+        started_at=300.0,
+        refresher=refresher,
+        clock=clock,
+    )
+
+    with pytest.raises(RuntimeError, match="refresher exploded"):
+        register()
+
+    clock.start.assert_not_called()
+    refresher.stop.assert_called_once()
+    assert instance_mod.read_instance() is None
+
+
 # ---------------------------------------------------------------------------
 # gaia.daemon.server._build_deregister
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_daemon_scheduler.py
+++ b/tests/unit/test_daemon_scheduler.py
@@ -127,3 +127,28 @@ def test_in_memory_path_rejected():
 def test_nonpositive_poll_rejected(tmp_path):
     with pytest.raises(ValueError, match="poll_seconds"):
         DaemonClock(str(tmp_path / "c.db"), executors={}, poll_seconds=0)
+
+
+def test_schema_initialized_once_not_per_poll_pass(tmp_path, monkeypatch):
+    """init_schema must run once per DaemonClock instance, not once per
+    fire_due pass (#2379) — repeated schema DDL on every poll is wasted work
+    on the daemon's single always-on clock."""
+    calls = []
+    original_init_schema = store.init_schema
+
+    def counting_init_schema(db):
+        calls.append(1)
+        return original_init_schema(db)
+
+    monkeypatch.setattr(store, "init_schema", counting_init_schema)
+
+    clock = DaemonClock(str(tmp_path / "clock.db"), executors={})
+    clock.fire_due(now=1.0)
+    clock.fire_due(now=2.0)
+    clock.fire_due(now=3.0)
+
+    assert len(calls) == 1, (
+        "init_schema must be invoked exactly once across the life of one "
+        f"DaemonClock instance, regardless of how many fire_due passes run; "
+        f"got {len(calls)} invocations"
+    )

--- a/tests/unit/test_daemon_scheduler.py
+++ b/tests/unit/test_daemon_scheduler.py
@@ -9,6 +9,8 @@ silent skip), and the atomic claim prevents a second driver from double-firing.
 
 from __future__ import annotations
 
+import logging
+import unittest
 from pathlib import Path
 
 import pytest
@@ -152,3 +154,27 @@ def test_schema_initialized_once_not_per_poll_pass(tmp_path, monkeypatch):
         f"DaemonClock instance, regardless of how many fire_due passes run; "
         f"got {len(calls)} invocations"
     )
+
+
+def test_polling_path_does_not_log_database_initialized_per_pass(tmp_path):
+    """The clock opens a brand-new connection every pass BY DESIGN (module
+    docstring: "opens its OWN SQLite connection per polling pass"), so
+    ``DatabaseMixin.init_db``'s per-connection "Database initialized" INFO
+    line would otherwise fire every 30s forever — ~2,880 lines/day on every
+    install that runs the daemon, for a clock with zero jobs (#2379).
+
+    ``assertNoLogs`` (not ``assertLogs``) is deliberate: the watched logger
+    here (``gaia.database.mixin``) is the same object that emits the record,
+    so the "assertLogs only changes the watched logger's level, not a child
+    logger's inherited level" gotcha (see ``tests/test_lemonade_client.py``'s
+    ``test_api_key_never_appears_in_logs``) does not apply — but ``assertLogs``
+    itself raises when NOTHING is captured, which is exactly the passing case
+    here, so ``assertNoLogs`` is the correct primitive for a silence
+    assertion, not an inverted ``assertLogs``.
+    """
+    clock = DaemonClock(str(tmp_path / "clock.db"), executors={})
+
+    with unittest.TestCase().assertNoLogs("gaia.database.mixin", level=logging.INFO):
+        clock.fire_due(now=1.0)
+        clock.fire_due(now=2.0)
+        clock.fire_due(now=3.0)


### PR DESCRIPTION
Closes #2379

Scheduled work in GAIA has never fired on the default daemon-supervised path. When the daemon spawns the email sidecar it sets `GAIA_DAEMON_SUPERVISED=1`, and the sidecar dutifully gates its own briefing and autonomy timers off, logging that "the daemon drives both from its reconciled clock." The daemon then never started a clock. Both sides deferred to the other and nothing ran — no briefings, no scheduled sends, no snoozes. This starts the clock for real: it gets its own hardened store, starts and stops with the daemon process, and reports its state so the next regression here is visible instead of silent.

**This deliberately attaches no jobs yet, and that is the point.** `clock.py` marks any job whose `kind` has no registered executor `failed`, and `fetch_due` only ever selects `pending` — nothing resets `failed`. Adopting the sidecar's pending jobs before an executor exists would permanently kill every queued briefing and scheduled send on the first restart, which is strictly worse than today. The executor map ships empty; #2585 carries the job-attachment work, which needs a token-safe execution seam (mailbox credentials must stay in the sidecar) and a staleness policy (nothing currently bounds how overdue a job can be, so upgrading after a long gap would fire weeks-old outbound sends at once).

Two guard tests keep this honest: `src/gaia/daemon/` must contain no import of `gaia_agent_email`, and the scheduler wiring must contain no autonomy reference — `run_autonomy_job`'s own docstring advertises the daemon clock as its future caller, so the temptation is real and adjacent.

## Test plan

- [ ] `pytest tests/unit/test_daemon_scheduler.py tests/unit/test_daemon_scheduler_migration.py tests/unit/test_daemon.py tests/unit/test_daemon_clock_wiring.py` — 34 passed
- [ ] `pytest tests/integration/test_daemon.py tests/integration/test_daemon_sidecars.py` — 20 passed, including `test_real_daemon_clock_fires_a_due_pending_job`, which starts a real daemon subprocess and polls until a due job actually fires (no bare sleep)
- [ ] `python util/lint.py --all` clean
- [ ] Both guard tests confirmed to fail on a planted violation, then reverted
- [ ] Existing `test_missing_executor_fails_loudly` passes unmodified

<details>
<summary>Evidence — real daemon start → status → shutdown</summary>

Clock running with an empty job table:

```
$ curl -s -H "Authorization: Bearer <token>" "http://127.0.0.1:<port>/daemon/v1/status"
{
    "service": "gaia-daemon",
    "api_version": "1.1",
    "pid": <pid>, "port": <port>, "host": "127.0.0.1",
    "uptime_seconds": 10.557256937026978,
    "clock": {
        "running": true,
        "last_poll_at": 1785260673.425838,
        "pending_jobs": 0,
        "failed_jobs": 0
    }
}
```

Clean shutdown, instance file removed:

```
$ curl -s -X POST -H "Authorization: Bearer <token>" ".../daemon/v1/shutdown"
{"service": "gaia-daemon", "status": "stopping", "pid": <pid>}

$ tail daemon.log
INFO | gaia.daemon.server._register   | daemon: registered instance pid=<pid> port=<port>
INFO | gaia.database.mixin.init_db    | Database initialized: <host>/scheduler.db
INFO | gaia.daemon.server._deregister | daemon: deregistered instance pid=<pid>

$ cat <host>/instance.json
cat: No such file or directory
```

```
$ pytest tests/integration/test_daemon_sidecars.py::test_real_daemon_clock_fires_a_due_pending_job -v
PASSED [100%]  1 passed in 1.62s
```

</details>

<details>
<summary>Notes for the reviewer</summary>

- **Crash-safety.** `app.py`'s lifespan calls `on_startup()` outside its `try`/`finally`, so a failure there means `on_shutdown` never runs. `_build_register` therefore rolls back both the refresher and the just-written `instance.json` before re-raising, covering a failure of either `refresher.start()` or `clock.start()`.
- **`stop()` no longer lies.** It previously cleared its thread reference whether or not the join actually completed. It now leaves the reference in place and logs at ERROR when the thread outlives the timeout, so `running` reports the truth.
- **Per-poll disk churn removed.** `_open_db()` re-ran `init_schema` on every pass — at the 30s default, a permanent disk wakeup on every install even with zero jobs. Schema init is now once per instance; `busy_timeout` is still set per connection, as it must be.
- **`_build_clock`/`_build_register`/`_build_deregister` are module-level**, mirroring the existing `_build_registry`. The old closures lived inside `run()` and were unreachable from a test, which is why this subsystem shipped unwired and unnoticed.
- **Known, unchanged:** the email autonomy cycle stays dark under daemon supervision. The sidecar gates it off and this change deliberately does not replace it — same root cause, tracked separately.
</details>
