### PR TITLE
feat(email): guided Outlook mailbox setup — walk, verify, and answer questions in chat

### DIFF
--- a/.github/workflows/release_agent_email.yml
+++ b/.github/workflows/release_agent_email.yml
@@ -176,6 +176,28 @@ jobs:
           uv venv .venv-freeze --python 3.12
           uv pip install --python .venv-freeze -e ".[api]" -e hub/agents/email/python pyinstaller
 
+      # #2590: hub/agents/email/python's declared floor (amd-gaia[api]>=0.22.0)
+      # cannot express "needs gaia.connectors.setup_routes" — that module
+      # ships in a core release that does not exist yet, and a floor naming
+      # an unreleased version makes the package uninstallable everywhere
+      # (verified: `uv pip install --dry-run -e . -e hub/agents/email/python`
+      # with the floor bumped to 0.23.0 produces ResolutionImpossible). This
+      # step is the real gate instead: it fails the release loudly if the
+      # core actually being frozen into this binary doesn't have the module,
+      # rather than letting it ship and ImportError on every guided-Outlook-
+      # setup call (the #2112 failure mode). Bump the pyproject/manifest
+      # floor to the release that ships setup_routes once one exists, and
+      # this check becomes redundant with that (harmless to keep either way).
+      - name: Verify resolved core exposes gaia.connectors.setup_routes (#2590)
+        shell: bash
+        run: |
+          set -euo pipefail
+          PY=.venv-freeze/$([ "$RUNNER_OS" = "Windows" ] && echo Scripts || echo bin)/python
+          "$PY" -c "import gaia.connectors.setup_routes" || {
+            echo "::error::the resolved amd-gaia core does not expose gaia.connectors.setup_routes — the guided Outlook setup (#2590) would ImportError on every setup_mailbox_access call for Microsoft. Do not release gaia-agent-email from a core checkout that lacks this module."
+            exit 1
+          }
+
       - name: Freeze one-file binary
         shell: bash
         run: |

--- a/hub/agents/email/python/gaia-agent.yaml
+++ b/hub/agents/email/python/gaia-agent.yaml
@@ -23,14 +23,14 @@ icon: mail
 tools_count: 63
 
 language: python
-min_gaia_version: "0.22.0"
+min_gaia_version: "0.23.0"
 models: [Gemma-4-E4B-it-GGUF]
 
 python:
   entry_module: gaia_agent_email
   entry_class: EmailTriageAgent
   dependencies:
-    - "amd-gaia>=0.22.0"
+    - "amd-gaia>=0.23.0"
 
 requirements:
   min_memory_gb: 8

--- a/hub/agents/email/python/gaia-agent.yaml
+++ b/hub/agents/email/python/gaia-agent.yaml
@@ -23,14 +23,16 @@ icon: mail
 tools_count: 63
 
 language: python
-min_gaia_version: "0.23.0"
+# NOTE (#2590): stays at 0.22.0, not the setup_routes floor — see the
+# comment on the dependencies floor in pyproject.toml.
+min_gaia_version: "0.22.0"
 models: [Gemma-4-E4B-it-GGUF]
 
 python:
   entry_module: gaia_agent_email
   entry_class: EmailTriageAgent
   dependencies:
-    - "amd-gaia>=0.23.0"
+    - "amd-gaia>=0.22.0"
 
 requirements:
   min_memory_gb: 8

--- a/hub/agents/email/python/gaia_agent_email/agent.py
+++ b/hub/agents/email/python/gaia_agent_email/agent.py
@@ -90,7 +90,7 @@ from gaia.agents.base.memory import (
 )
 from gaia.agents.base.tools import _TOOL_REGISTRY
 from gaia.agents.registry import get_embedding_model_for_device
-from gaia.connectors.errors import AuthRequiredError, ConnectorsError
+from gaia.connectors.errors import ConnectorsError
 from gaia.connectors.formatting import format_connector_error
 from gaia.connectors.providers.base import ConnectorRequirement
 from gaia.database.mixin import DatabaseMixin
@@ -895,15 +895,24 @@ class EmailTriageAgent(
         return result
 
     def _mailbox_target_guard(self, user_input: str) -> Optional[Dict[str, Any]]:
-        """Reject a request that explicitly targets an unavailable mailbox (#2164).
+        """Reject a request that targets a mailbox the SESSION has ruled out (#2164).
 
         With only Google connected, "check my Outlook inbox" used to run the
-        inbox tool against Gmail and present that as the answer. When the query
-        names a provider that is not connected (or is filtered out by the
-        session's mailbox selection), surface the connectors framework's
-        actionable error BEFORE any tool runs — never substitute another
-        mailbox. Queries naming no provider keep the default
-        every-connected-mailbox behavior untouched.
+        inbox tool against Gmail and present that as the answer — never
+        substitute another mailbox for the one the query actually named.
+        Queries naming no provider keep the default every-connected-mailbox
+        behavior untouched.
+
+        A targeted provider that is simply NOT CONNECTED YET is deliberately
+        NOT rejected here (#2590): this guard used to return a canned "go to
+        Settings" message before the agent loop even ran, which meant
+        ``setup_mailbox_access`` — the guided walkthrough this whole feature
+        exists to offer — was never reached no matter how the user phrased
+        the request. Falling through here lets the loop run and the agent
+        offer to connect it. Only a genuine intent CONFLICT — the session is
+        pinned to a different mailbox via ``mail_provider`` — is still a
+        pre-flight rejection; that is not a missing-setup problem a tool call
+        can fix.
         """
         targeted = _detect_targeted_mailboxes(user_input or "")
         if not targeted:
@@ -913,15 +922,10 @@ class EmailTriageAgent(
         problems: List[str] = []
         for provider in sorted(targeted):
             if provider not in available:
-                problems.append(
-                    format_connector_error(
-                        AuthRequiredError(
-                            AuthRequiredError.Reason.NOT_CONNECTED,
-                            provider=provider,
-                        )
-                    )
-                )
-            elif selected_filter and provider != selected_filter:
+                # Not connected — fall through to the agent loop rather than
+                # rejecting; see the docstring. Not a `problems` entry.
+                continue
+            if selected_filter and provider != selected_filter:
                 problems.append(
                     f"This session is pinned to the {selected_filter!r} mailbox, "
                     f"but the request targets {provider!r}. Clear the mailbox "

--- a/hub/agents/email/python/gaia_agent_email/mailbox_state.py
+++ b/hub/agents/email/python/gaia_agent_email/mailbox_state.py
@@ -45,6 +45,32 @@ PROVIDERS = ("google", "microsoft")
 #: Human names — the user picked "Gmail", not "google".
 PROVIDER_LABELS = {"google": "Gmail", "microsoft": "Outlook"}
 
+#: User/model-facing vocabulary -> canonical provider id (#2590). This
+#: agent's own copy says "Gmail" and "Outlook" everywhere (``provider_label``
+#: above) — a model that hears "Outlook" has every reason to pass that word
+#: back as the ``provider`` argument, not the internal id ``"microsoft"``.
+#: Validating against ``PROVIDERS`` directly rejected exactly the word the
+#: product itself teaches, with a message that named that same word as
+#: supported — resolve aliases FIRST, before any validation happens.
+PROVIDER_ALIASES: Dict[str, str] = {
+    "microsoft": "microsoft",
+    "outlook": "microsoft",
+    "outlook.com": "microsoft",
+    "hotmail": "microsoft",
+    "live": "microsoft",
+    "office365": "microsoft",
+    "o365": "microsoft",
+    "microsoft 365": "microsoft",
+    "entra": "microsoft",
+    "exchange": "microsoft",
+    "google": "google",
+    "gmail": "google",
+    "gmail.com": "google",
+    "googlemail": "google",
+    "google workspace": "google",
+    "gsuite": "google",
+}
+
 STATE_OK = "ok"
 STATE_NOT_CONNECTED = "not_connected"
 STATE_NOT_GRANTED = "agent_not_granted"
@@ -66,6 +92,19 @@ REPAIRABLE = (
 def provider_label(provider: str) -> str:
     """Return the human name for *provider* (``google`` → ``Gmail``)."""
     return PROVIDER_LABELS.get(provider, provider)
+
+
+def resolve_provider(value: str) -> Optional[str]:
+    """Normalize a user/model-supplied provider string to a canonical id.
+
+    Accepts both the internal id (``"google"`` / ``"microsoft"``) and the
+    vocabulary this agent's own copy uses everywhere (``provider_label``'s
+    ``"Gmail"`` / ``"Outlook"``), plus common real-world aliases (see
+    ``PROVIDER_ALIASES``). Case- and whitespace-insensitive. Returns
+    ``None`` for anything unrecognized — never raises, so a caller renders
+    its own actionable rejection rather than getting a bare exception.
+    """
+    return PROVIDER_ALIASES.get((value or "").strip().lower())
 
 
 def required_scopes(provider: str) -> List[str]:
@@ -286,6 +325,7 @@ def best_repair_target(states: List[Dict[str, Any]]) -> Optional[Dict[str, Any]]
 __all__ = [
     "AGENT_ID",
     "PROVIDERS",
+    "PROVIDER_ALIASES",
     "PROVIDER_LABELS",
     "REPAIRABLE",
     "STATE_ERROR",
@@ -299,5 +339,6 @@ __all__ = [
     "inspect_provider",
     "provider_label",
     "required_scopes",
+    "resolve_provider",
     "survey",
 ]

--- a/hub/agents/email/python/gaia_agent_email/tools/onboarding_tools.py
+++ b/hub/agents/email/python/gaia_agent_email/tools/onboarding_tools.py
@@ -117,6 +117,17 @@ def _oauth_client_gap(provider: str) -> Optional[str]:
     return None
 
 
+def _needs_client_secret(provider: str) -> bool:
+    """Whether *provider*'s token endpoint accepts a client secret at all.
+
+    Microsoft's route here is a public PKCE client — per the identity
+    platform docs it must NOT send one (``providers/microsoft.py``) — so
+    asking Outlook users for a secret is not just unnecessary, it is asking
+    for a credential that Microsoft never issues for this client type.
+    """
+    return provider == "google"
+
+
 def _collect_oauth_client(agent: Any, provider: str) -> Dict[str, str]:
     """Ask for the OAuth client credentials, but only the ones actually missing.
 
@@ -127,25 +138,28 @@ def _collect_oauth_client(agent: Any, provider: str) -> Dict[str, str]:
         return {}
 
     label = ms.provider_label(provider)
+    wants_secret = _needs_client_secret(provider)
     _status(
         agent,
         f"{label} needs an OAuth client before I can sign you in.",
     )
 
+    id_and_secret = "ID and secret" if wants_secret else "ID"
     proceed = ask(
         agent,
         (
-            f"To connect {label} I need an OAuth client ID and secret that you "
+            f"To connect {label} I need an OAuth client {id_and_secret} that you "
             "create once in your provider console — GAIA does not ship one yet, "
             "so this part I genuinely cannot do for you. The walkthrough is at "
-            f"{_OAUTH_DOCS_URL}. They're stored in your OS keychain, never sent "
-            "anywhere but the provider. Do you have them to hand?"
+            f"{_OAUTH_DOCS_URL}. It's stored in your OS keychain, never sent "
+            "anywhere but the provider. Do you have it to hand?"
         ),
         options=(
             Option(
                 _YES,
-                "I have them",
-                "You'll paste the client ID, then the secret. Takes a few seconds.",
+                "I have it",
+                f"You'll paste the client {id_and_secret.lower()}. Takes a few "
+                "seconds.",
             ),
             Option(
                 _NO,
@@ -169,18 +183,20 @@ def _collect_oauth_client(agent: Any, provider: str) -> Dict[str, str]:
             "(for Google it ends in .apps.googleusercontent.com).",
             allow_free_text=True,
         )
-    config["client_secret"] = ask(
-        agent,
-        f"Now the {label} OAuth client secret. It goes straight into your "
-        "OS keychain.",
-        allow_free_text=True,
-        sensitive=True,
-    )
-    if gap == "client_secret":
-        # Re-saving requires the id alongside the secret; reuse the stored one.
-        from gaia.connectors.providers import get as get_provider
+    if wants_secret:
+        config["client_secret"] = ask(
+            agent,
+            f"Now the {label} OAuth client secret. It goes straight into your "
+            "OS keychain.",
+            allow_free_text=True,
+            sensitive=True,
+        )
+        if gap == "client_secret":
+            # Re-saving requires the id alongside the secret; reuse the stored
+            # one.
+            from gaia.connectors.providers import get as get_provider
 
-        config["client_id"] = getattr(get_provider(provider), "client_id", "")
+            config["client_id"] = getattr(get_provider(provider), "client_id", "")
     return config
 
 
@@ -272,6 +288,14 @@ _CLIENT_FIRST_BLURB = (
     "First you'll paste an OAuth client ID and secret you create once in your "
     "provider console — GAIA does not ship one. Then your browser opens."
 )
+#: Microsoft's client is public-PKCE (no secret) and this route signs in with
+#: a short code, not a browser redirect — reusing ``_CLIENT_FIRST_BLURB``
+#: here would repeat the exact secret-mention bug this feature exists to fix.
+_CLIENT_FIRST_BLURB_NO_SECRET = (
+    "First I'll walk you through creating an OAuth client ID — GAIA does not "
+    "ship one, and this route needs no secret. Then you'll sign in with a "
+    "short code instead of a browser."
+)
 
 
 def _go_blurb(provider: str, when_client_ready: str) -> str:
@@ -283,7 +307,9 @@ def _go_blurb(provider: str, when_client_ready: str) -> str:
     """
     if _oauth_client_gap(provider) is None:
         return when_client_ready
-    return _CLIENT_FIRST_BLURB
+    if _needs_client_secret(provider):
+        return _CLIENT_FIRST_BLURB
+    return _CLIENT_FIRST_BLURB_NO_SECRET
 
 
 def _confirm_repair(agent: Any, state: Dict[str, Any]) -> bool:

--- a/hub/agents/email/python/gaia_agent_email/tools/onboarding_tools.py
+++ b/hub/agents/email/python/gaia_agent_email/tools/onboarding_tools.py
@@ -145,19 +145,22 @@ def _collect_oauth_client(agent: Any, provider: str) -> Dict[str, str]:
     )
 
     id_and_secret = "ID and secret" if wants_secret else "ID"
+    pronoun = "them" if wants_secret else "it"
+    stored_as = "They're" if wants_secret else "It's"
+    have_label = "I have them" if wants_secret else "I have it"
     proceed = ask(
         agent,
         (
             f"To connect {label} I need an OAuth client {id_and_secret} that you "
             "create once in your provider console — GAIA does not ship one yet, "
             "so this part I genuinely cannot do for you. The walkthrough is at "
-            f"{_OAUTH_DOCS_URL}. It's stored in your OS keychain, never sent "
-            "anywhere but the provider. Do you have it to hand?"
+            f"{_OAUTH_DOCS_URL}. {stored_as} stored in your OS keychain, never "
+            f"sent anywhere but the provider. Do you have {pronoun} to hand?"
         ),
         options=(
             Option(
                 _YES,
-                "I have it",
+                have_label,
                 f"You'll paste the client {id_and_secret.lower()}. Takes a few "
                 "seconds.",
             ),

--- a/hub/agents/email/python/gaia_agent_email/tools/onboarding_tools.py
+++ b/hub/agents/email/python/gaia_agent_email/tools/onboarding_tools.py
@@ -51,7 +51,7 @@ from gaia.logger import get_logger
 log = get_logger(__name__)
 
 #: Where a user goes to create the OAuth client they still have to supply.
-_OAUTH_DOCS_URL = "https://amd-gaia.ai/docs/guides/email"
+OAUTH_DOCS_URL = "https://amd-gaia.ai/docs/guides/email"
 
 #: Bound on the browser sign-in wait. Must exceed ``flow._FLOW_TIMEOUT_SECONDS``
 #: (120s) so the flow's own timeout is the one that fires, with its own message.
@@ -82,7 +82,7 @@ def _scope_labels(provider: str, scopes: List[str]) -> str:
     return "; ".join(labels) if labels else "the mailbox permissions it needs"
 
 
-def _status(agent: Any, message: str) -> None:
+def narrate(agent: Any, message: str) -> None:
     """Narrate a step to the live stream, if the surface has a console."""
     console = getattr(agent, "console", None)
     printer = getattr(console, "print_info", None)
@@ -140,7 +140,7 @@ def _collect_oauth_client(agent: Any, provider: str) -> Dict[str, str]:
 
     label = ms.provider_label(provider)
     wants_secret = _needs_client_secret(provider)
-    _status(
+    narrate(
         agent,
         f"{label} needs an OAuth client before I can sign you in.",
     )
@@ -155,7 +155,7 @@ def _collect_oauth_client(agent: Any, provider: str) -> Dict[str, str]:
             f"To connect {label} I need an OAuth client {id_and_secret} that you "
             "create once in your provider console — GAIA does not ship one yet, "
             "so this part I genuinely cannot do for you. The walkthrough is at "
-            f"{_OAUTH_DOCS_URL}. {stored_as} stored in your OS keychain, never "
+            f"{OAUTH_DOCS_URL}. {stored_as} stored in your OS keychain, never "
             f"sent anywhere but the provider. Do you have {pronoun} to hand?"
         ),
         options=(
@@ -176,7 +176,7 @@ def _collect_oauth_client(agent: Any, provider: str) -> Dict[str, str]:
     if proceed != _YES:
         raise _Declined(
             f"OK — nothing changed. Create a Desktop OAuth client for {label} "
-            f"({_OAUTH_DOCS_URL}), then ask me again and I'll take it from there."
+            f"({OAUTH_DOCS_URL}), then ask me again and I'll take it from there."
         )
 
     config: Dict[str, str] = {}
@@ -208,7 +208,20 @@ class _Declined(Exception):
     """The user said no. Not an error — a complete, respected answer."""
 
 
-def _connect_scopes(provider: str, agent_scopes: List[str]) -> List[str]:
+def _walkthrough_stuck_exc() -> type:
+    """Lazily return ``setup_walkthrough.WalkthroughStuck``.
+
+    A plain top-of-file import would be circular: ``setup_walkthrough``
+    imports ``connect_scopes``/``narrate``/``OAUTH_DOCS_URL`` from THIS
+    module. Deferring the import to call time (used only inside an
+    ``except`` clause) breaks the cycle without duplicating the class.
+    """
+    from gaia_agent_email.tools.setup_walkthrough import WalkthroughStuck
+
+    return WalkthroughStuck
+
+
+def connect_scopes(provider: str, agent_scopes: List[str]) -> List[str]:
     """The provider's catalog scopes plus the ones this agent needs, deduped.
 
     Mirrors what ``gaia connectors connect`` requests, so a mailbox connected
@@ -249,7 +262,7 @@ def _run_oauth(agent: Any, provider: str) -> Dict[str, Any]:
         # the mailbox as "default" instead of the address the user just signed
         # in with. The grant below stays narrow — identity is for the
         # connection, not for the agent.
-        "scopes": _connect_scopes(provider, scopes),
+        "scopes": connect_scopes(provider, scopes),
         # Committing the grant inside the same flow is what stops the
         # connected-but-unusable dead end this whole feature exists to remove.
         "grant_agents": {ms.AGENT_ID: scopes},
@@ -265,7 +278,7 @@ def _run_oauth(agent: Any, provider: str) -> Dict[str, Any]:
             "Retry, or connect from Settings → Connections in the Agent UI."
         )
 
-    _status(
+    narrate(
         agent,
         f"Opening your browser to sign in to {label}. If it didn't open, use "
         f"this link (valid for 2 minutes): {auth_url}",
@@ -286,6 +299,54 @@ def _run_oauth(agent: Any, provider: str) -> Dict[str, Any]:
     # idempotent and covers a provider path that ignores it.
     grant_agent(provider, ms.AGENT_ID, granted)
     return state
+
+
+def _run_connect(agent: Any, provider: str) -> None:
+    """Run whichever sign-in *provider* actually uses.
+
+    Microsoft goes through the guided device-code walkthrough (#2590) — no
+    client secret, no browser required. Every other provider keeps the
+    existing browser-loopback path.
+    """
+    if provider == "microsoft":
+        _run_microsoft_setup(agent)
+    else:
+        _run_oauth(agent, provider)
+
+
+def _run_microsoft_setup(agent: Any) -> Dict[str, Any]:
+    """First-time Microsoft connect: walk the guided setup if the OAuth
+    client isn't configured yet, then sign in with a device code.
+
+    Reuses ``_oauth_client_gap`` — the SAME check ``_collect_oauth_client``
+    uses — so "is a client already configured" has exactly one answer, not
+    two that could disagree. A mailbox that already has a client configured
+    (e.g. a reconnect) skips straight to sign-in — never re-walked.
+    """
+    from gaia.connectors._loop import run_sync
+    from gaia.connectors.handler import configure
+    from gaia.connectors.setup_routes import get_route
+    from gaia_agent_email.tools import setup_walkthrough as sw
+
+    gap = _oauth_client_gap("microsoft")
+    if gap is not None:
+        route = get_route("microsoft")
+        if route is None:
+            # Defensive — unreachable while setup_routes.ROUTES is exactly
+            # {"microsoft": MS_PERSONAL}. A future route removal must still
+            # fail as a legible message, never a crash or a silent no-op.
+            raise RuntimeError(
+                "No guided walkthrough exists for Microsoft yet. Connect from "
+                f"Settings → Connections in the Agent UI, or see {OAUTH_DOCS_URL}."
+            )
+        collected, _trace = sw.run_setup_walkthrough(agent, route)
+        run_sync(
+            configure(
+                "microsoft",
+                {"client_id": collected["client_id"], "save_only": True},
+            )
+        )
+    return sw.run_device_oauth(agent, "microsoft")
 
 
 _CLIENT_FIRST_BLURB = (
@@ -538,6 +599,13 @@ def _setup_mailbox_access(agent: Any, wanted: str) -> str:
                 ),
             }
         )
+    except _walkthrough_stuck_exc() as exc:
+        # A defined, honest handoff (design §3) — not a failure. The
+        # exception's own message is the user-facing text (mirrors
+        # _Declined), so it is shown directly rather than improvised here.
+        return _envelope_ok(
+            {"changed": False, "declined": False, "stuck": True, "message": str(exc)}
+        )
 
 
 def _setup_flow(agent: Any, wanted: str) -> str:
@@ -617,9 +685,9 @@ def _setup_flow(agent: Any, wanted: str) -> str:
         from gaia.connectors.grants import grant_agent
 
         grant_agent(provider, ms.AGENT_ID, ms.required_scopes(provider))
-        _status(agent, f"Allowed this agent to use {label}.")
+        narrate(agent, f"Allowed this agent to use {label}.")
     else:
-        _run_oauth(agent, provider)
+        _run_connect(agent, provider)
 
     final = ms.inspect_provider(provider, probe=True)
     if final["state"] != ms.STATE_OK:

--- a/hub/agents/email/python/gaia_agent_email/tools/onboarding_tools.py
+++ b/hub/agents/email/python/gaia_agent_email/tools/onboarding_tools.py
@@ -33,7 +33,7 @@ flow entirely; nothing else here changes.
 
 from __future__ import annotations
 
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Tuple
 
 from gaia_agent_email import mailbox_state as ms
 from gaia_agent_email.question import (
@@ -466,6 +466,37 @@ def _choose_provider(agent: Any, states: List[Dict[str, Any]]) -> str:
     return answer
 
 
+def _normalize_provider_arg(provider: str) -> Tuple[str, Optional[str]]:
+    """Resolve the ``setup_mailbox_access`` tool's ``provider`` argument.
+
+    A live model hears "Outlook" — ``provider_label`` uses that word
+    everywhere in this agent's own copy — and has every reason to pass it
+    straight back as the argument, not the internal id ``"microsoft"``.
+    Validating the raw string against ``ms.PROVIDERS`` rejected exactly that
+    word with a message that ALSO named it as supported ("I don't support
+    'outlook'. I can connect Gmail or Outlook.") — a rejection that
+    contradicts itself in one sentence. Resolve aliases via
+    ``ms.resolve_provider`` FIRST, so the canonical/friendly split is
+    invisible to the caller.
+
+    Returns ``(wanted, error)``: ``wanted`` is ``""`` when *provider* was
+    empty (let the flow pick), else the resolved canonical id. ``error`` is
+    ``None`` on success, else a message safe to return directly — one that
+    never names, as an accepted option, a word that would itself be
+    rejected if passed back in.
+    """
+    raw = (provider or "").strip()
+    if not raw:
+        return "", None
+    resolved = ms.resolve_provider(raw)
+    if resolved is None:
+        return "", (
+            f"I can set up {' or '.join(ms.provider_label(p) for p in ms.PROVIDERS)} "
+            f"— I didn't recognise {raw!r}."
+        )
+    return resolved, None
+
+
 class OnboardingToolsMixin:
     """Registers the mailbox self-service tools.
 
@@ -527,9 +558,12 @@ class OnboardingToolsMixin:
             immediately without asking anything.
 
             Args:
-                provider: Optional — 'google' or 'microsoft' to target one
-                    mailbox. Omit to let the flow pick the one that needs the
-                    least work, or ask the user when nothing is connected.
+                provider: Optional — which mailbox to target. Accepts the
+                    friendly names users actually say ('Gmail', 'Outlook',
+                    'Office 365', 'Hotmail', 'Exchange', ...) as well as the
+                    internal ids ('google', 'microsoft') — case-insensitive.
+                    Omit to let the flow pick the one that needs the least
+                    work, or ask the user when nothing is connected.
 
             Returns:
                 JSON envelope. On success ``{"ok": true, "data": {"changed":
@@ -537,12 +571,9 @@ class OnboardingToolsMixin:
                 ``message`` back to the user. On refusal or failure ``{"ok":
                 false, "error": "<what to tell the user>"}``.
             """
-            wanted = (provider or "").strip().lower()
-            if wanted and wanted not in ms.PROVIDERS:
-                return _envelope_err(
-                    f"I don't support {provider!r}. I can connect "
-                    f"{' or '.join(ms.provider_label(p) for p in ms.PROVIDERS)}."
-                )
+            wanted, provider_error = _normalize_provider_arg(provider)
+            if provider_error is not None:
+                return _envelope_err(provider_error)
             try:
                 return _setup_mailbox_access(agent, wanted)
             except InputUnsupportedError as exc:

--- a/hub/agents/email/python/gaia_agent_email/tools/onboarding_tools.py
+++ b/hub/agents/email/python/gaia_agent_email/tools/onboarding_tools.py
@@ -45,6 +45,7 @@ from gaia_agent_email.question import (
 from gaia_agent_email.tools.envelope import _envelope_err, _envelope_ok
 
 from gaia.agents.base.tools import tool
+from gaia.connectors.errors import GrantAfterConnectError
 from gaia.logger import get_logger
 
 log = get_logger(__name__)
@@ -516,6 +517,27 @@ def _setup_mailbox_access(agent: Any, wanted: str) -> str:
         return _setup_flow(agent, wanted)
     except _Declined as exc:
         return _envelope_ok({"changed": False, "declined": True, "message": str(exc)})
+    except GrantAfterConnectError as exc:
+        # save_connection commits BEFORE the grant does (flow.py), so this is
+        # NOT "nothing was changed" — the mailbox connected; only the local
+        # permission write failed. .reason is authored/constructed by GAIA
+        # (agent id, provider, a local OSError-style message) and never
+        # carries a credential, so — unlike the generic catch-all in
+        # setup_mailbox_access — showing it is safe.
+        label = ms.provider_label(exc.provider)
+        return _envelope_ok(
+            {
+                "changed": True,
+                "provider": exc.provider,
+                "account_email": None,
+                "state": ms.STATE_NOT_GRANTED,
+                "message": (
+                    f"{label} is connected now, but I couldn't allow myself "
+                    f"to use it: {exc.reason} Try again, or grant it manually "
+                    "from Settings → Connections in the Agent UI."
+                ),
+            }
+        )
 
 
 def _setup_flow(agent: Any, wanted: str) -> str:

--- a/hub/agents/email/python/gaia_agent_email/tools/setup_walkthrough.py
+++ b/hub/agents/email/python/gaia_agent_email/tools/setup_walkthrough.py
@@ -1,0 +1,97 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""Guided Outlook mailbox setup — device-code sign-in and step walkthrough (#2590).
+
+Extends, rather than rewrites, ``onboarding_tools`` (#2469): the scripted
+repair conversation stays there, this module holds the walkthrough that
+conversation hands off to for a first-time Microsoft connect. Kept separate
+because ``onboarding_tools.py`` is already ~600 lines scoped to *repair*, and
+the guided walkthrough is a different concern.
+
+**Outlook only.** No ``google_personal`` route, no account-kind interview, no
+resumability — see ``gaia.connectors.setup_routes`` and the #2590 plan for
+why those are out of scope here.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+
+from gaia_agent_email import mailbox_state as ms
+from gaia_agent_email.tools.onboarding_tools import _connect_scopes, _status
+
+from gaia.logger import get_logger
+
+log = get_logger(__name__)
+
+#: How far past the device code's own advertised lifetime to hold the wait
+#: open. NOT the loopback flow's 150s constant — that exists specifically to
+#: sit just above the LOOPBACK flow's 120s bound, and reusing it here would
+#: cancel a 900s-lived device code at 150s: a user who approves at T+300s
+#: (well within the code's real life) gets nothing, and the single-use code
+#: is burnt. This is slack on top of poll_device_flow's OWN expires_in-based
+#: deadline, not a substitute for deriving it.
+_DEVICE_POLL_GRACE_SECONDS = 30
+
+#: Fallback if a provider response is missing (or zeroes) expires_in.
+#: Matches poll_device_flow's own default so the two never disagree.
+_DEFAULT_EXPIRES_IN_SECONDS = 900
+
+
+def run_device_oauth(agent: Any, provider: str) -> Dict[str, Any]:
+    """Run the device-code flow and grant the result to this agent.
+
+    Mirrors ``onboarding_tools._run_oauth`` but for the browserless
+    device-code path: no OAuth client secret, no loopback port, works on a
+    machine with no browser at all. Returns the same state-dict shape
+    ``_run_oauth`` does, so callers (``onboarding_tools._setup_flow``) treat
+    the two interchangeably.
+    """
+    from gaia.connectors._loop import run_sync
+    from gaia.connectors.flow import poll_device_flow, start_device_flow
+    from gaia.connectors.grants import grant_agent
+
+    label = ms.provider_label(provider)
+    scopes = ms.required_scopes(provider)
+    connect_scopes = _connect_scopes(provider, scopes)
+
+    started = run_sync(start_device_flow(provider, connect_scopes))
+    user_code = started.get("user_code", "")
+    verification_uri = started.get("verification_uri", "")
+
+    _status(
+        agent,
+        started.get("message")
+        or (
+            f"To sign in to {label}, go to {verification_uri} and enter the "
+            f"code {user_code}. It's valid for a few minutes — no browser "
+            "needed on this machine."
+        ),
+    )
+
+    expires_in = int(started.get("expires_in") or _DEFAULT_EXPIRES_IN_SECONDS)
+    poll_timeout = expires_in + _DEVICE_POLL_GRACE_SECONDS
+
+    state = run_sync(
+        poll_device_flow(
+            provider,
+            started["device_code"],
+            scopes=connect_scopes,
+            interval=int(started.get("interval") or 5),
+            expires_in=expires_in,
+            # Committing the grant inside the same flow is what stops the
+            # connected-but-unusable dead end this feature exists to remove —
+            # mirrors _run_oauth's grant_agents on the loopback path.
+            grant_agents={ms.AGENT_ID: scopes},
+        ),
+        timeout=poll_timeout,
+    )
+    granted = list(state.get("scopes") or scopes)
+    # poll_device_flow already committed the grant via grant_agents; this is
+    # idempotent and covers a provider path that ignores it — same
+    # belt-and-suspenders pattern as _run_oauth.
+    grant_agent(provider, ms.AGENT_ID, granted)
+    return state
+
+
+__all__ = ["run_device_oauth"]

--- a/hub/agents/email/python/gaia_agent_email/tools/setup_walkthrough.py
+++ b/hub/agents/email/python/gaia_agent_email/tools/setup_walkthrough.py
@@ -11,6 +11,17 @@ the guided walkthrough is a different concern.
 **Outlook only.** No ``google_personal`` route, no account-kind interview, no
 resumability — see ``gaia.connectors.setup_routes`` and the #2590 plan for
 why those are out of scope here.
+
+**Navigation prompts keep free text (and the FAQ lane) for the WHOLE route
+here** — Microsoft has no client secret, and the Application (client) ID is
+public by design, so there is nothing on this route worth hiding from the
+TUI's cleartext echo. The Google route (#2594) will carry real secrets
+through its later steps; ITS navigation prompts must drop free text from the
+key-creation step onward so an open box right after the portal displays a
+secret never invites pasting it into scrollback (the TUI renders typed text
+in cleartext unless a prompt is marked ``sensitive``). That rule does not
+apply here — do not port it into this module without re-deriving it for a
+route that actually has something to hide.
 """
 
 from __future__ import annotations
@@ -176,12 +187,46 @@ def _collect_credential(agent: Any, step: Step) -> str:
     return value
 
 
-def _ask_nav(agent: Any, step: Step) -> str:
+#: Bound on FAQ-answering turns before the driver stops trying to match and
+#: just re-asks plainly. Never changes allow_free_text or the option set —
+#: an options-less prompt must never lose free text (AC8); this bound only
+#: controls when the driver stops attempting to answer.
+_FAQ_MAX_TURNS = 3
+
+#: Single authored constant for "that didn't match any FAQ" — never composed
+#: or paraphrased per-question, which is what would let a small local model
+#: invent an answer instead of admitting it doesn't have one.
+_FAQ_NO_MATCH = (
+    "I don't have a written answer for that one. Say \"I'm stuck\" and I'll "
+    "hand you off to the full guide, or \"Done\" once you've finished this "
+    "step."
+)
+
+
+def _faq_answer(step: Step, route: SetupRoute, question: str) -> Optional[str]:
+    """Match *question* against *step*'s FAQ, then *route*'s, by keyword.
+
+    Selection, never composition (design §5): the returned string, if any,
+    IS a ``QA.answer`` verbatim — never reworded, prefixed, or summarized.
+    """
+    needle = (question or "").strip().casefold()
+    for qa in step.faq:
+        if any(hint.casefold() in needle for hint in qa.question_hints):
+            return qa.answer
+    for qa in route.faq:
+        if any(hint.casefold() in needle for hint in qa.question_hints):
+            return qa.answer
+    return None
+
+
+def _ask_nav(agent: Any, step: Step, route: SetupRoute) -> str:
     """Ask the Done / I'm-stuck navigation question for a non-credential step.
 
-    ``allow_free_text=False`` with exactly two options, never zero (AC8) —
-    the FAQ lane (increment 6) adds free text back on top of this, it never
-    replaces the options.
+    ``allow_free_text=True`` with exactly two options, never zero (AC8): a
+    free-text answer that isn't a Done/Stuck match is treated as a genuine
+    question and run through the FAQ lane (design §5), then the SAME
+    question is re-asked with the SAME options and free text still enabled —
+    never ``allow_free_text=False`` on an options-less prompt.
     """
     options = (
         Option(_DONE, "Done", "I've finished this step — move to the next one."),
@@ -189,13 +234,23 @@ def _ask_nav(agent: Any, step: Step) -> str:
             _STUCK, "I'm stuck", "Show me the written guide instead, and stop here."
         ),
     )
-    return ask(
-        agent,
-        f"Done with: {step.title}?",
-        options=options,
-        allow_free_text=False,
-        timeout_seconds=_STEP_TIMEOUT_SECONDS,
-    )
+    question = f"Done with: {step.title}?"
+    turns = 0
+    while True:
+        raw = ask(
+            agent,
+            question,
+            options=options,
+            allow_free_text=True,
+            timeout_seconds=_STEP_TIMEOUT_SECONDS,
+        )
+        if raw in (_DONE, _STUCK):
+            return raw
+        turns += 1
+        answer = _faq_answer(step, route, raw)
+        narrate(agent, answer if answer is not None else _FAQ_NO_MATCH)
+        if turns >= _FAQ_MAX_TURNS:
+            turns = 0
 
 
 def run_setup_walkthrough(
@@ -230,7 +285,7 @@ def run_setup_walkthrough(
             trace.append({"step_id": step.id, "verified": step.verifiable})
             continue
 
-        answer = _ask_nav(agent, step)
+        answer = _ask_nav(agent, step, route)
         if answer == _STUCK:
             raise WalkthroughStuck(step, route)
         trace.append({"step_id": step.id, "verified": False})

--- a/hub/agents/email/python/gaia_agent_email/tools/setup_walkthrough.py
+++ b/hub/agents/email/python/gaia_agent_email/tools/setup_walkthrough.py
@@ -15,11 +15,18 @@ why those are out of scope here.
 
 from __future__ import annotations
 
-from typing import Any, Dict
+import re
+from typing import Any, Dict, List, Optional, Tuple
 
 from gaia_agent_email import mailbox_state as ms
-from gaia_agent_email.tools.onboarding_tools import _connect_scopes, _status
+from gaia_agent_email.question import Option, ask
+from gaia_agent_email.tools.onboarding_tools import (
+    OAUTH_DOCS_URL,
+    connect_scopes,
+    narrate,
+)
 
+from gaia.connectors.setup_routes import SIGN_IN_DEVICE_CODE, Step, SetupRoute, steps_for
 from gaia.logger import get_logger
 
 log = get_logger(__name__)
@@ -53,13 +60,13 @@ def run_device_oauth(agent: Any, provider: str) -> Dict[str, Any]:
 
     label = ms.provider_label(provider)
     scopes = ms.required_scopes(provider)
-    connect_scopes = _connect_scopes(provider, scopes)
+    scopes_to_request = connect_scopes(provider, scopes)
 
-    started = run_sync(start_device_flow(provider, connect_scopes))
+    started = run_sync(start_device_flow(provider, scopes_to_request))
     user_code = started.get("user_code", "")
     verification_uri = started.get("verification_uri", "")
 
-    _status(
+    narrate(
         agent,
         started.get("message")
         or (
@@ -76,7 +83,7 @@ def run_device_oauth(agent: Any, provider: str) -> Dict[str, Any]:
         poll_device_flow(
             provider,
             started["device_code"],
-            scopes=connect_scopes,
+            scopes=scopes_to_request,
             interval=int(started.get("interval") or 5),
             expires_in=expires_in,
             # Committing the grant inside the same flow is what stops the
@@ -94,4 +101,145 @@ def run_device_oauth(agent: Any, provider: str) -> Dict[str, Any]:
     return state
 
 
-__all__ = ["run_device_oauth"]
+# ---------------------------------------------------------------------------
+# The step driver — walks route.steps, one at a time, for the device-code
+# path only (steps_for(..., sign_in=SIGN_IN_DEVICE_CODE) already drops the
+# loopback-only redirect-URI step; see gaia.connectors.setup_routes).
+# ---------------------------------------------------------------------------
+
+_DONE = "done"
+_STUCK = "stuck"
+
+#: Longer than question.py's DEFAULT_TIMEOUT_SECONDS (240s) — a first-timer
+#: finding a specific portal setting routinely exceeds four minutes; timing
+#: out mid-walk would abort the whole thing over a slow click, not a real
+#: problem.
+_STEP_TIMEOUT_SECONDS = 480
+
+#: Said ONCE, at the first non-verifiable step — never repeated per step.
+_CANNOT_SEE_PORTAL_NOTICE = (
+    "A heads up: I can't see your screen or your provider's portal — I can "
+    "only tell you what to click and check what I can. Say \"I'm stuck\" any "
+    "time and I'll hand you off to the written guide instead."
+)
+
+#: Microsoft's Application (client) ID is always a GUID. Authored constant —
+#: never an f-string interpolating what the user pasted, so a shape-check
+#: failure can never echo a credential back into the transcript.
+_GUID_RE = re.compile(
+    r"^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$"
+)
+_CLIENT_ID_SHAPE_ERROR = (
+    "That doesn't look like an Application (client) ID — it should be a GUID "
+    "like 11112222-bbbb-3333-cccc-4444dddd5555. Copy it again from the app's "
+    "Overview page and paste just that."
+)
+
+
+class WalkthroughStuck(Exception):
+    """The user asked for help partway through the guided walkthrough.
+
+    Not a failure — a defined, honest handoff (design §3: "[I'm stuck] has a
+    defined handler ... do not improvise it"). The message IS the user-facing
+    text (mirrors onboarding_tools._Declined), so a caller need only str() it.
+    """
+
+    def __init__(self, step: Step, route: SetupRoute):
+        self.step = step
+        self.route = route
+        super().__init__(
+            f"No problem — here's the written guide instead: {OAUTH_DOCS_URL}. "
+            "Nothing you've done so far was undone. Ask me again when you're "
+            "ready to pick back up."
+        )
+
+
+def _shape_check_client_id(value: str) -> Optional[str]:
+    if _GUID_RE.match((value or "").strip()):
+        return None
+    return _CLIENT_ID_SHAPE_ERROR
+
+
+def _collect_credential(agent: Any, step: Step) -> str:
+    """Ask for *step*'s credential value — a plain free-text prompt, never
+    the navigation lane's Done/I'm-stuck options (design §4: a credential
+    prompt must never receive the FAQ lane, and this is how that is
+    structural rather than a rule someone has to remember)."""
+    prompt = f"Paste the value for: {step.title}."
+    value = ask(agent, prompt, allow_free_text=True, sensitive=False)
+    if step.id == "client_id":
+        error = _shape_check_client_id(value)
+        while error is not None:
+            narrate(agent, error)
+            value = ask(agent, prompt, allow_free_text=True, sensitive=False)
+            error = _shape_check_client_id(value)
+    return value
+
+
+def _ask_nav(agent: Any, step: Step) -> str:
+    """Ask the Done / I'm-stuck navigation question for a non-credential step.
+
+    ``allow_free_text=False`` with exactly two options, never zero (AC8) —
+    the FAQ lane (increment 6) adds free text back on top of this, it never
+    replaces the options.
+    """
+    options = (
+        Option(_DONE, "Done", "I've finished this step — move to the next one."),
+        Option(
+            _STUCK, "I'm stuck", "Show me the written guide instead, and stop here."
+        ),
+    )
+    return ask(
+        agent,
+        f"Done with: {step.title}?",
+        options=options,
+        allow_free_text=False,
+        timeout_seconds=_STEP_TIMEOUT_SECONDS,
+    )
+
+
+def run_setup_walkthrough(
+    agent: Any, route: SetupRoute
+) -> Tuple[Dict[str, str], List[Dict[str, Any]]]:
+    """Walk *route*'s device-code steps one at a time.
+
+    Returns ``(collected, trace)``: ``collected`` maps credential step id ->
+    the value entered (e.g. ``{"client_id": "..."}``); ``trace`` has one
+    ``{"step_id", "verified"}`` entry per step, in order, appended REGARDLESS
+    of what got narrated — the testable signal that no step ever claims
+    unearned verification (design §3).
+
+    Raises ``WalkthroughStuck`` if the user asks for help; the caller ends
+    the flow honestly rather than continuing to improvise.
+    """
+    trace: List[Dict[str, Any]] = []
+    collected: Dict[str, str] = {}
+    told_cannot_see = False
+
+    for step in steps_for(route, sign_in=SIGN_IN_DEVICE_CODE):
+        narrate(agent, f"{step.title}\n{step.instruction}")
+        if not step.verifiable and not told_cannot_see:
+            narrate(agent, _CANNOT_SEE_PORTAL_NOTICE)
+            told_cannot_see = True
+
+        if step.collects_credential:
+            value = _collect_credential(agent, step)
+            collected[step.id] = value
+            # Reached only once the shape check above has already passed —
+            # verified is never claimed for a step this route can't check.
+            trace.append({"step_id": step.id, "verified": step.verifiable})
+            continue
+
+        answer = _ask_nav(agent, step)
+        if answer == _STUCK:
+            raise WalkthroughStuck(step, route)
+        trace.append({"step_id": step.id, "verified": False})
+
+    return collected, trace
+
+
+__all__ = [
+    "WalkthroughStuck",
+    "run_device_oauth",
+    "run_setup_walkthrough",
+]

--- a/hub/agents/email/python/gaia_agent_email/tools/setup_walkthrough.py
+++ b/hub/agents/email/python/gaia_agent_email/tools/setup_walkthrough.py
@@ -171,17 +171,25 @@ def _shape_check_client_id(value: str) -> Optional[str]:
     return _CLIENT_ID_SHAPE_ERROR
 
 
-def _collect_credential(agent: Any, step: Step) -> str:
+def _collect_credential(agent: Any, step: Step, route: SetupRoute) -> str:
     """Ask for *step*'s credential value — a plain free-text prompt, never
-    the navigation lane's Done/I'm-stuck options (design §4: a credential
-    prompt must never receive the FAQ lane, and this is how that is
-    structural rather than a rule someone has to remember)."""
+    the navigation lane's Done/I'm-stuck OPTIONS (a credential prompt keeps
+    zero options throughout; this is structural, not a rule to remember).
+
+    On a shape-check failure it DOES try the FAQ lookup — Azure's Overview
+    blade shows three GUIDs side by side (Application client ID, Object ID,
+    Directory/tenant ID) and a shape check can't tell them apart, so a user
+    who asks "which one?" must get answered, not just re-shown the same
+    generic error. A genuine GUID never matches an FAQ hint (the hints are
+    English words), so this can never misfire on a real value.
+    """
     prompt = f"Paste the value for: {step.title}."
     value = ask(agent, prompt, allow_free_text=True, sensitive=False)
     if step.id == "client_id":
         error = _shape_check_client_id(value)
         while error is not None:
-            narrate(agent, error)
+            answer = _faq_answer(step, route, value)
+            narrate(agent, answer if answer is not None else error)
             value = ask(agent, prompt, allow_free_text=True, sensitive=False)
             error = _shape_check_client_id(value)
     return value
@@ -278,7 +286,7 @@ def run_setup_walkthrough(
             told_cannot_see = True
 
         if step.collects_credential:
-            value = _collect_credential(agent, step)
+            value = _collect_credential(agent, step, route)
             collected[step.id] = value
             # Reached only once the shape check above has already passed —
             # verified is never claimed for a step this route can't check.

--- a/hub/agents/email/python/pyproject.toml
+++ b/hub/agents/email/python/pyproject.toml
@@ -14,13 +14,21 @@ requires-python = ">=3.10"
 # AND keyring automatically — the email REST router's import chain needs keyring
 # at module load and at request time (connected_mailbox_providers). Closes the
 # "consumer forgot [api]" half of #1617.
-# Floor: 0.23.0 is the first core release shipping
-# gaia.connectors.setup_routes, imported by tools/setup_walkthrough.py for
-# the guided Outlook setup (#2590) — same failure mode as #2112
-# (get_embedding_model_for_device, which needed 0.22.0). Raising the floor
-# again here rather than adding a second min-version check keeps this file
-# the single source of truth. tests/test_dependency_floor.py guards it.
-dependencies = ["amd-gaia[api]>=0.23.0"]
+# Floor: 0.22.0 is the first core release shipping
+# gaia.agents.registry.get_embedding_model_for_device, imported at agent
+# start (#2112). tests/test_dependency_floor.py guards this floor.
+#
+# NOTE (#2590): tools/setup_walkthrough.py now also imports
+# gaia.connectors.setup_routes, a core module that ships in the NEXT core
+# release, not 0.22.0. The floor CANNOT be bumped to reflect that yet — core
+# on this branch is still 0.22.0 and no higher version is published, so a
+# naive bump makes this package uninstallable everywhere (verified: a cold
+# `pip install -e .[dev,api] -e hub/agents/email/python` produces
+# ResolutionImpossible). Raise this floor to the release that actually
+# contains setup_routes once it is cut; until then the real protection is
+# the publish-time gate in .github/workflows/release_agent_email.yml, which
+# refuses to publish a build whose resolved core lacks the module.
+dependencies = ["amd-gaia[api]>=0.22.0"]
 
 # Console script for the REST sidecar — the fast dev-iteration entry point.
 # `gaia-agent-email serve --reload` runs the same app the frozen binary serves,

--- a/hub/agents/email/python/pyproject.toml
+++ b/hub/agents/email/python/pyproject.toml
@@ -14,10 +14,13 @@ requires-python = ">=3.10"
 # AND keyring automatically — the email REST router's import chain needs keyring
 # at module load and at request time (connected_mailbox_providers). Closes the
 # "consumer forgot [api]" half of #1617.
-# Floor: 0.22.0 is the first core release shipping
-# gaia.agents.registry.get_embedding_model_for_device, imported at agent
-# start (#2112). tests/test_dependency_floor.py guards this floor.
-dependencies = ["amd-gaia[api]>=0.22.0"]
+# Floor: 0.23.0 is the first core release shipping
+# gaia.connectors.setup_routes, imported by tools/setup_walkthrough.py for
+# the guided Outlook setup (#2590) — same failure mode as #2112
+# (get_embedding_model_for_device, which needed 0.22.0). Raising the floor
+# again here rather than adding a second min-version check keeps this file
+# the single source of truth. tests/test_dependency_floor.py guards it.
+dependencies = ["amd-gaia[api]>=0.23.0"]
 
 # Console script for the REST sidecar — the fast dev-iteration entry point.
 # `gaia-agent-email serve --reload` runs the same app the frozen binary serves,

--- a/hub/agents/email/python/tests/conftest.py
+++ b/hub/agents/email/python/tests/conftest.py
@@ -9,38 +9,10 @@ can never silently short-circuit another test's fake ``requests.get``
 """
 
 import pytest
-from gaia_agent_email import question as q
 
-
-class ScriptedConsole:
-    """Records every question asked and replies from a fixed script.
-
-    Shared by every mailbox-onboarding test module (#2469, #2590) so the real
-    ``question.ask()`` — its casefold option-matching, its strict-rejection
-    ``ValueError``, its sensitive-echo suppression — always runs unmodified.
-    A second, drifted copy of this fake is how a test module stops exercising
-    that behaviour without anyone noticing.
-    """
-
-    def __init__(self, answers):
-        self.answers = list(answers)
-        self.asked = []
-        self.info = []
-
-    def request_user_input_blocking(self, **kwargs):
-        self.asked.append(kwargs)
-        if not self.answers:
-            return q.NO_RESPONSE
-        return self.answers.pop(0)
-
-    def print_info(self, message):
-        self.info.append(message)
-
-
-class FakeAgent:
-    def __init__(self, answers=(), can_answer_questions=True):
-        self.console = ScriptedConsole(answers)
-        self.can_answer_questions = can_answer_questions
+# ScriptedConsole / FakeAgent live in onboarding_fakes.py, NOT here — see that
+# module's docstring for why a bare `from conftest import ...` is unsafe
+# under CI's multi-root pytest invocation (test_email_agent.yml).
 
 
 @pytest.fixture(autouse=True)

--- a/hub/agents/email/python/tests/conftest.py
+++ b/hub/agents/email/python/tests/conftest.py
@@ -9,6 +9,38 @@ can never silently short-circuit another test's fake ``requests.get``
 """
 
 import pytest
+from gaia_agent_email import question as q
+
+
+class ScriptedConsole:
+    """Records every question asked and replies from a fixed script.
+
+    Shared by every mailbox-onboarding test module (#2469, #2590) so the real
+    ``question.ask()`` — its casefold option-matching, its strict-rejection
+    ``ValueError``, its sensitive-echo suppression — always runs unmodified.
+    A second, drifted copy of this fake is how a test module stops exercising
+    that behaviour without anyone noticing.
+    """
+
+    def __init__(self, answers):
+        self.answers = list(answers)
+        self.asked = []
+        self.info = []
+
+    def request_user_input_blocking(self, **kwargs):
+        self.asked.append(kwargs)
+        if not self.answers:
+            return q.NO_RESPONSE
+        return self.answers.pop(0)
+
+    def print_info(self, message):
+        self.info.append(message)
+
+
+class FakeAgent:
+    def __init__(self, answers=(), can_answer_questions=True):
+        self.console = ScriptedConsole(answers)
+        self.can_answer_questions = can_answer_questions
 
 
 @pytest.fixture(autouse=True)

--- a/hub/agents/email/python/tests/onboarding_fakes.py
+++ b/hub/agents/email/python/tests/onboarding_fakes.py
@@ -1,0 +1,53 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""Shared fakes for the mailbox-onboarding test modules (#2469, #2590).
+
+A uniquely-named module, NOT ``conftest.py`` — CI (``test_email_agent.yml``)
+runs pytest over several roots in one command (this dir,
+``tests/unit/email/``, ``tests/unit/agents/email/``, ...). Under prepend
+import mode every one of those directories lands on ``sys.path``, so a bare
+``from conftest import ...`` is ambiguous across roots and whichever
+same-named ``conftest.py`` sys.path resolves first wins — silently importing
+the WRONG fakes (or failing outright) for every root but one. ``conftest.py``
+itself is fine (pytest discovers it per-directory, never imported by name);
+only an explicit cross-file import of it is the trap. A uniquely-named
+module has no such collision.
+"""
+
+from __future__ import annotations
+
+from gaia_agent_email import question as q
+
+
+class ScriptedConsole:
+    """Records every question asked and replies from a fixed script.
+
+    Shared by every mailbox-onboarding test module (#2469, #2590) so the real
+    ``question.ask()`` — its casefold option-matching, its strict-rejection
+    ``ValueError``, its sensitive-echo suppression — always runs unmodified.
+    A second, drifted copy of this fake is how a test module stops exercising
+    that behaviour without anyone noticing.
+    """
+
+    def __init__(self, answers):
+        self.answers = list(answers)
+        self.asked = []
+        self.info = []
+
+    def request_user_input_blocking(self, **kwargs):
+        self.asked.append(kwargs)
+        if not self.answers:
+            return q.NO_RESPONSE
+        return self.answers.pop(0)
+
+    def print_info(self, message):
+        self.info.append(message)
+
+
+class FakeAgent:
+    def __init__(self, answers=(), can_answer_questions=True):
+        self.console = ScriptedConsole(answers)
+        self.can_answer_questions = can_answer_questions
+
+
+__all__ = ["FakeAgent", "ScriptedConsole"]

--- a/hub/agents/email/python/tests/test_dependency_floor.py
+++ b/hub/agents/email/python/tests/test_dependency_floor.py
@@ -12,11 +12,28 @@ doesn't cover, one of these fails.
 
 The guided Outlook walkthrough (#2590) adds a second such import:
 ``gaia_agent_email.tools.setup_walkthrough`` imports ``gaia.connectors.
-setup_routes``, a brand-new core module. Core is 0.22.0 today, so a floor
-left at 0.22.0 would let a fresh resolver pick a core that predates
-``setup_routes`` and ImportError on every call to ``setup_mailbox_access``
-for Microsoft — exactly how #2112 burned. The floor here is bumped to the
-release that will actually contain it.
+setup_routes``, a brand-new core module that ships in the NEXT core
+release, not the current 0.22.0. **The pyproject floor cannot be bumped to
+express that yet** — a dependency declaration can only name a released
+version, and bumping it to an unreleased one makes the package
+uninstallable everywhere:
+
+    $ uv pip install --dry-run -e . -e hub/agents/email/python
+    × No solution found when resolving dependencies:
+    ╰─▶ Because only amd-gaia<0.23.0 is available and
+        gaia-agent-email==0.5.0 depends on amd-gaia[api]>=0.23.0, we can
+        conclude that gaia-agent-email==0.5.0 cannot be used. And because
+        only gaia-agent-email==0.5.0 is available and you require
+        gaia-agent-email, we can conclude that your requirements are
+        unsatisfiable.
+
+So the floor here stays at 0.22.0 (bump it once the release containing
+``setup_routes`` is cut) and this file only asserts the module is
+importable against whatever core IS resolved locally — it does not, and
+cannot, guard the published-sidecar-vs-old-core case. That gate belongs at
+publish time instead: see the core-version check in
+``.github/workflows/release_agent_email.yml``, which refuses to publish a
+build whose resolved core lacks ``gaia.connectors.setup_routes``.
 """
 
 from __future__ import annotations
@@ -29,12 +46,6 @@ EMAIL_ROOT = Path(__file__).resolve().parents[1]
 # First core release shipping gaia.agents.registry.get_embedding_model_for_device
 # (introduced by commit 89db99d6, first tagged in v0.22.0).
 REQUIRED_FLOOR = (0, 22, 0)
-
-# First core release that will ship gaia.connectors.setup_routes (#2590).
-# Core is 0.22.0 as of this change; this names the NEXT release, matching
-# the pattern flow.py already uses elsewhere for the 'common' tenant default
-# ("since v0.23.0").
-REQUIRED_FLOOR_SETUP_ROUTES = (0, 23, 0)
 
 
 def _floor_tuple(version: str) -> tuple[int, ...]:
@@ -63,23 +74,14 @@ def test_pyproject_floor_covers_registry_symbol():
 
 
 def test_setup_walkthrough_module_imports_and_setup_routes_symbol_exists():
-    """The import chain that will burn exactly like #2112 if the floor lags."""
+    """The import chain that would burn like #2112 IF the pyproject floor
+    could express it. It can't (see module docstring) — this only proves
+    the module resolves against whatever core is installed locally; the
+    real cross-version guard is the publish-time gate, not this test."""
     import gaia_agent_email.tools.setup_walkthrough  # noqa: F401
     from gaia.connectors.setup_routes import ROUTES
 
     assert "microsoft" in ROUTES
-
-
-def test_pyproject_floor_covers_setup_routes():
-    pyproject = (EMAIL_ROOT / "pyproject.toml").read_text(encoding="utf-8")
-    match = re.search(r'"amd-gaia\[api\]>=([0-9.]+)"', pyproject)
-    assert match, "pyproject.toml must declare an amd-gaia[api]>=X.Y.Z floor"
-    assert _floor_tuple(match.group(1)) >= REQUIRED_FLOOR_SETUP_ROUTES, (
-        f"amd-gaia floor {match.group(1)} predates gaia.connectors.setup_routes "
-        "(first shipped in 0.23.0); a fresh resolver may select a core that "
-        "ImportErrors on every guided-Outlook-setup call (#2590, same failure "
-        "mode as #2112)"
-    )
 
 
 def test_manifest_floors_match_pyproject():

--- a/hub/agents/email/python/tests/test_dependency_floor.py
+++ b/hub/agents/email/python/tests/test_dependency_floor.py
@@ -9,6 +9,14 @@ core and the agent dies at startup with ImportError (#2112). These tests
 pin the floor to the symbol so the two can't silently drift apart again:
 if the floor is lowered, or the agent grows an import the declared floor
 doesn't cover, one of these fails.
+
+The guided Outlook walkthrough (#2590) adds a second such import:
+``gaia_agent_email.tools.setup_walkthrough`` imports ``gaia.connectors.
+setup_routes``, a brand-new core module. Core is 0.22.0 today, so a floor
+left at 0.22.0 would let a fresh resolver pick a core that predates
+``setup_routes`` and ImportError on every call to ``setup_mailbox_access``
+for Microsoft — exactly how #2112 burned. The floor here is bumped to the
+release that will actually contain it.
 """
 
 from __future__ import annotations
@@ -21,6 +29,12 @@ EMAIL_ROOT = Path(__file__).resolve().parents[1]
 # First core release shipping gaia.agents.registry.get_embedding_model_for_device
 # (introduced by commit 89db99d6, first tagged in v0.22.0).
 REQUIRED_FLOOR = (0, 22, 0)
+
+# First core release that will ship gaia.connectors.setup_routes (#2590).
+# Core is 0.22.0 as of this change; this names the NEXT release, matching
+# the pattern flow.py already uses elsewhere for the 'common' tenant default
+# ("since v0.23.0").
+REQUIRED_FLOOR_SETUP_ROUTES = (0, 23, 0)
 
 
 def _floor_tuple(version: str) -> tuple[int, ...]:
@@ -45,6 +59,26 @@ def test_pyproject_floor_covers_registry_symbol():
         "gaia.agents.registry.get_embedding_model_for_device (first shipped in "
         "0.22.0); a fresh resolver may select a core that ImportErrors at "
         "agent start (#2112)"
+    )
+
+
+def test_setup_walkthrough_module_imports_and_setup_routes_symbol_exists():
+    """The import chain that will burn exactly like #2112 if the floor lags."""
+    import gaia_agent_email.tools.setup_walkthrough  # noqa: F401
+    from gaia.connectors.setup_routes import ROUTES
+
+    assert "microsoft" in ROUTES
+
+
+def test_pyproject_floor_covers_setup_routes():
+    pyproject = (EMAIL_ROOT / "pyproject.toml").read_text(encoding="utf-8")
+    match = re.search(r'"amd-gaia\[api\]>=([0-9.]+)"', pyproject)
+    assert match, "pyproject.toml must declare an amd-gaia[api]>=X.Y.Z floor"
+    assert _floor_tuple(match.group(1)) >= REQUIRED_FLOOR_SETUP_ROUTES, (
+        f"amd-gaia floor {match.group(1)} predates gaia.connectors.setup_routes "
+        "(first shipped in 0.23.0); a fresh resolver may select a core that "
+        "ImportErrors on every guided-Outlook-setup call (#2590, same failure "
+        "mode as #2112)"
     )
 
 

--- a/hub/agents/email/python/tests/test_mailbox_onboarding_2469.py
+++ b/hub/agents/email/python/tests/test_mailbox_onboarding_2469.py
@@ -250,6 +250,51 @@ def test_not_granted_is_fixed_locally_with_no_browser(connectors):
     assert connectors["grants"], "the grant was never written"
 
 
+def test_success_message_quotes_the_terminal_probe_not_a_mid_flow_value(
+    connectors, monkeypatch
+):
+    """#2590 AC5: success is reported only after the TERMINAL
+    inspect_provider(probe=True) call. Plant a differing mid-flow value (the
+    account email the INITIAL survey() saw) and assert the final message
+    quotes the LAST call's value, not a cached earlier one."""
+    connectors["connection"] = _connection(email="stale@example.com")
+    connectors["granted"] = False
+    agent = _FakeAgent(answers=["yes"])
+
+    calls = {"n": 0}
+    real_get_connection = connectors["connection"]
+
+    def get_connection(provider):
+        if provider != "google":
+            return None
+        calls["n"] += 1
+        # First call: the INITIAL ms.survey(probe=True) inside _setup_flow.
+        # Every call after: the grant has landed and the account is now the
+        # REAL one — the terminal inspect_provider() call must see this.
+        if calls["n"] == 1:
+            return real_get_connection
+        return _connection(email="current@example.com")
+
+    monkeypatch.setattr("gaia.connectors.api.get_connection", get_connection)
+
+    def after_grant(provider, agent_id, scopes):
+        connectors["granted"] = True
+
+    import gaia.connectors.grants as grants
+
+    original = grants.grant_agent
+    grants.grant_agent = lambda p, a, s: (original(p, a, s), after_grant(p, a, s))[0]
+    try:
+        out = _run(agent)
+    finally:
+        grants.grant_agent = original
+
+    assert out["ok"] is True
+    assert out["data"]["account_email"] == "current@example.com"
+    assert "current@example.com" in out["data"]["message"]
+    assert "stale@example.com" not in out["data"]["message"]
+
+
 def test_reauth_required_says_the_sign_in_stopped_working(connectors):
     from gaia.connectors.errors import ConnectionRevokedError
 

--- a/hub/agents/email/python/tests/test_mailbox_onboarding_2469.py
+++ b/hub/agents/email/python/tests/test_mailbox_onboarding_2469.py
@@ -23,6 +23,8 @@ import json
 import time
 
 import pytest
+from conftest import FakeAgent as _FakeAgent
+from conftest import ScriptedConsole as _ScriptedConsole
 from gaia_agent_email import mailbox_state as ms
 from gaia_agent_email import question as q
 from gaia_agent_email.tools import onboarding_tools as ob
@@ -34,32 +36,8 @@ GMAIL_SCOPES = [
 
 
 # ---------------------------------------------------------------------------
-# Fakes
+# Fakes — shared with every onboarding test module, see conftest.py.
 # ---------------------------------------------------------------------------
-
-
-class _ScriptedConsole:
-    """Records every question asked and replies from a fixed script."""
-
-    def __init__(self, answers):
-        self.answers = list(answers)
-        self.asked = []
-        self.info = []
-
-    def request_user_input_blocking(self, **kwargs):
-        self.asked.append(kwargs)
-        if not self.answers:
-            return q.NO_RESPONSE
-        return self.answers.pop(0)
-
-    def print_info(self, message):
-        self.info.append(message)
-
-
-class _FakeAgent:
-    def __init__(self, answers=(), can_answer_questions=True):
-        self.console = _ScriptedConsole(answers)
-        self.can_answer_questions = can_answer_questions
 
 
 def _connection(scopes=None, email="kalin@example.com", error=None):

--- a/hub/agents/email/python/tests/test_mailbox_onboarding_2469.py
+++ b/hub/agents/email/python/tests/test_mailbox_onboarding_2469.py
@@ -23,8 +23,8 @@ import json
 import time
 
 import pytest
-from conftest import FakeAgent as _FakeAgent
-from conftest import ScriptedConsole as _ScriptedConsole
+from onboarding_fakes import FakeAgent as _FakeAgent
+from onboarding_fakes import ScriptedConsole as _ScriptedConsole
 from gaia_agent_email import mailbox_state as ms
 from gaia_agent_email import question as q
 from gaia_agent_email.tools import onboarding_tools as ob

--- a/hub/agents/email/python/tests/test_mailbox_onboarding_2469.py
+++ b/hub/agents/email/python/tests/test_mailbox_onboarding_2469.py
@@ -421,6 +421,39 @@ def test_a_fix_that_did_not_fix_it_is_reported_as_failure(connectors):
     assert "still isn't usable" in out["error"]
 
 
+def test_connected_but_grant_failed_is_reported_honestly_not_as_nothing_changed(
+    connectors,
+):
+    """#2590: save_connection runs before the grant commits. If the grant
+    write fails the connection IS persisted — the generic catch-all used to
+    say "Nothing was changed", which is false. It must say what actually
+    happened: connected, not yet permitted."""
+    from gaia.connectors.errors import GrantAfterConnectError
+
+    connectors["connection"] = None
+
+    async def failing_complete_authorization(flow_id):
+        raise GrantAfterConnectError(
+            "google", ms.AGENT_ID, reason="disk full"
+        )
+
+    import gaia.connectors.flow as flow_mod
+
+    monkeypatch = pytest.MonkeyPatch()
+    monkeypatch.setattr(flow_mod, "complete_authorization", failing_complete_authorization)
+    try:
+        agent = _FakeAgent(answers=["google", "yes"])
+        out = _run(agent)
+    finally:
+        monkeypatch.undo()
+
+    assert out["ok"] is True
+    assert out["data"]["changed"] is True
+    assert "connected" in out["data"]["message"].lower()
+    assert "nothing was changed" not in out["data"]["message"].lower()
+    assert "disk full" in out["data"]["message"]
+
+
 # ---------------------------------------------------------------------------
 # Surfaces that cannot ask
 # ---------------------------------------------------------------------------

--- a/hub/agents/email/python/tests/test_mailbox_onboarding_outlook_2590.py
+++ b/hub/agents/email/python/tests/test_mailbox_onboarding_outlook_2590.py
@@ -303,3 +303,57 @@ def test_a_working_google_mailbox_is_never_dragged_into_microsoft_setup(
     assert out["ok"] is True
     assert out["data"]["provider"] == "google"
     assert agent.console.asked == [], "a working Gmail mailbox must stay quiet"
+
+
+def test_naming_microsoft_reaches_its_setup_even_though_google_is_usable(
+    ms_connectors, monkeypatch
+):
+    """The other half of the real-world blocker: EXPLICITLY naming the
+    unconnected provider must reach ITS walkthrough, not the
+    already-usable-mailbox short-circuit that answers when nothing is named.
+    ``_setup_flow(agent, wanted="microsoft")`` takes the `if wanted:` branch
+    directly — it never evaluates ``first_usable``, which only runs in the
+    no-target ``else`` branch — so this is a structural guarantee, not a
+    coincidence of test data."""
+    from gaia_agent_email import mailbox_state as ms
+
+    ms_connectors["connection"] = None  # microsoft: not connected
+    ms_connectors["client_id"] = ""
+    google_scopes = ms.required_scopes("google")
+
+    def get_connection(provider):
+        if provider == "google":
+            return {
+                "provider": "google",
+                "account_email": "kalin@gmail.com",
+                "scopes": list(google_scopes),
+                "connected_at": 1,
+            }
+        # microsoft: starts unconnected, but the device-flow stub above
+        # (ms_connectors's own poll_device_flow) updates
+        # ms_connectors["connection"] once the walkthrough succeeds — the
+        # terminal inspect_provider(probe=True) call must see that, not a
+        # permanently-None override.
+        return ms_connectors["connection"]
+
+    def check_agent_grant(provider, agent_id, scopes):
+        if provider == "google":
+            return True
+        return ms_connectors["granted"]
+
+    monkeypatch.setattr("gaia.connectors.api.get_connection", get_connection)
+    monkeypatch.setattr("gaia.connectors.grants.check_agent_grant", check_agent_grant)
+    monkeypatch.setattr(
+        "gaia.connectors.api.get_access_token_sync", lambda **kw: "token"
+    )
+
+    agent = _FakeAgent(answers=["yes", *_WALKTHROUGH_DONE_ANSWERS, VALID_GUID])
+
+    out = _run(agent, provider="microsoft")
+
+    assert out["ok"] is True, out
+    # NOT the "nothing to set up" message a Google short-circuit would give.
+    assert "nothing to set up" not in out["data"]["message"].lower()
+    assert out["data"]["provider"] == "microsoft"
+    assert out["data"]["account_email"] == "kalin@outlook.com"
+    assert ms_connectors["device_started"], "the microsoft walkthrough never ran"

--- a/hub/agents/email/python/tests/test_mailbox_onboarding_outlook_2590.py
+++ b/hub/agents/email/python/tests/test_mailbox_onboarding_outlook_2590.py
@@ -1,0 +1,193 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""Guided Outlook mailbox onboarding (#2590) — Microsoft-only.
+
+Two bugs this replaces:
+
+1. Setting up Outlook asked for a client secret Microsoft's public-client PKCE
+   route never issues, so the prompt was impossible to answer honestly.
+2. The setup flow could only fail as one opaque "connect your mailbox" prompt
+   — no walkthrough, no verification, no browserless sign-in.
+
+``_ScriptedConsole`` / ``_FakeAgent`` are copied verbatim from
+``test_mailbox_onboarding_2469.py`` (not imported — this tree has no
+``tests/__init__.py``) so the real ``question.ask()`` resolves options,
+enforces strict rejection, and suppresses sensitive echoes exactly as it does
+in production; a hand-rolled fake ``ask`` would not reproduce that.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from gaia_agent_email import mailbox_state as ms
+from gaia_agent_email import question as q
+from gaia_agent_email.tools import onboarding_tools as ob
+
+OUTLOOK_SCOPES = [
+    "https://graph.microsoft.com/Mail.ReadWrite",
+    "https://graph.microsoft.com/Mail.Send",
+]
+
+
+# ---------------------------------------------------------------------------
+# Fakes — verbatim copy, see module docstring.
+# ---------------------------------------------------------------------------
+
+
+class _ScriptedConsole:
+    """Records every question asked and replies from a fixed script."""
+
+    def __init__(self, answers):
+        self.answers = list(answers)
+        self.asked = []
+        self.info = []
+
+    def request_user_input_blocking(self, **kwargs):
+        self.asked.append(kwargs)
+        if not self.answers:
+            return q.NO_RESPONSE
+        return self.answers.pop(0)
+
+    def print_info(self, message):
+        self.info.append(message)
+
+
+class _FakeAgent:
+    def __init__(self, answers=(), can_answer_questions=True):
+        self.console = _ScriptedConsole(answers)
+        self.can_answer_questions = can_answer_questions
+
+
+def _connection(scopes=None, email="kalin@outlook.com", error=None):
+    entry = {
+        "provider": "microsoft",
+        "account_email": email,
+        "scopes": list(OUTLOOK_SCOPES if scopes is None else scopes),
+        "connected_at": 1,
+    }
+    if error:
+        entry["error"] = error
+    return entry
+
+
+@pytest.fixture()
+def ms_connectors(monkeypatch):
+    """Drive every connector call the flow makes for microsoft, no keyring/network."""
+
+    state = {
+        "connection": None,
+        "granted": False,
+        "token_error": None,
+        "grants": [],
+        "configured": [],
+        "completed": [],
+        "client_id": "11112222-bbbb-3333-cccc-4444dddd5555",
+        "timeouts": [],
+    }
+
+    def get_connection(provider):
+        return state["connection"] if provider == "microsoft" else None
+
+    def check_agent_grant(provider, agent_id, scopes):
+        return state["granted"]
+
+    def get_access_token_sync(**kwargs):
+        if state["token_error"] is not None:
+            raise state["token_error"]
+        return "token"
+
+    def grant_agent(provider, agent_id, scopes):
+        state["grants"].append((provider, agent_id, tuple(scopes)))
+
+    class _Provider:
+        provider_id = "microsoft"
+
+        @property
+        def client_id(self):
+            return state["client_id"]
+
+        @property
+        def client_secret(self):
+            return ""  # Microsoft public-client PKCE — never a secret.
+
+    def get_provider(provider_id):
+        from gaia.connectors.errors import ConfigurationError
+
+        if not state["client_id"]:
+            raise ConfigurationError("GAIA_MICROSOFT_CLIENT_ID is not set")
+        return _Provider()
+
+    async def configure(connector_id, config):
+        state["configured"].append((connector_id, config))
+        return {"status": "saved", "connector_id": connector_id}
+
+    def run_sync(coro, *, timeout=30.0):
+        import asyncio
+
+        state["timeouts"].append(timeout)
+        return asyncio.run(coro)
+
+    monkeypatch.setattr("gaia.connectors.api.get_connection", get_connection)
+    monkeypatch.setattr("gaia.connectors.grants.check_agent_grant", check_agent_grant)
+    monkeypatch.setattr(
+        "gaia.connectors.api.get_access_token_sync", get_access_token_sync
+    )
+    monkeypatch.setattr("gaia.connectors.grants.grant_agent", grant_agent)
+    monkeypatch.setattr("gaia.connectors.providers.get", get_provider)
+    monkeypatch.setattr("gaia.connectors.handler.configure", configure)
+    monkeypatch.setattr("gaia.connectors._loop.run_sync", run_sync)
+    return state
+
+
+def _run(agent, provider="microsoft"):
+    return json.loads(ob._setup_mailbox_access(agent, provider))
+
+
+def _questions(agent):
+    return [a["message"] for a in agent.console.asked]
+
+
+# ---------------------------------------------------------------------------
+# Increment 1 — Outlook is never asked for a client secret.
+# ---------------------------------------------------------------------------
+
+
+def test_reauth_with_client_already_configured_never_mentions_secret(ms_connectors):
+    """``gap is None`` case: the client is already on disk (reconnect path).
+
+    Reaches ``_collect_oauth_client`` with nothing missing, so it should ask
+    nothing at all about credentials — and definitely never mention a secret.
+    """
+    from gaia.connectors.errors import ConnectionRevokedError
+
+    ms_connectors["connection"] = _connection()
+    ms_connectors["granted"] = True
+    ms_connectors["token_error"] = ConnectionRevokedError("microsoft")
+    agent = _FakeAgent(answers=["no"])  # decline the reconnect offer
+
+    _run(agent)
+
+    assert not any("secret" in a["message"].lower() for a in agent.console.asked)
+
+
+def test_declining_client_setup_with_no_client_configured_never_mentions_secret(
+    ms_connectors,
+):
+    """``gap == "client_id"`` case: nothing configured yet, still no secret talk."""
+    ms_connectors["connection"] = None
+    ms_connectors["client_id"] = ""
+    # "yes" confirms the repair; "no" declines at the credentials question.
+    agent = _FakeAgent(answers=["yes", "no"])
+
+    _run(agent, provider="microsoft")
+
+    assert not any("secret" in a["message"].lower() for a in agent.console.asked)
+    # Nor asked to provide one via any option description offered along the way
+    # (truthfully saying "no secret needed" is fine and expected — see the
+    # plan's lifted seven-day-expiry constraint; the bug was ASKING for one).
+    for call in agent.console.asked:
+        for opt in call.get("options") or []:
+            desc = opt.get("description", "").lower()
+            assert "paste" not in desc or "secret" not in desc

--- a/hub/agents/email/python/tests/test_mailbox_onboarding_outlook_2590.py
+++ b/hub/agents/email/python/tests/test_mailbox_onboarding_outlook_2590.py
@@ -24,8 +24,8 @@ from __future__ import annotations
 import json
 
 import pytest
-from conftest import FakeAgent as _FakeAgent
-from conftest import ScriptedConsole as _ScriptedConsole
+from onboarding_fakes import FakeAgent as _FakeAgent
+from onboarding_fakes import ScriptedConsole as _ScriptedConsole
 from gaia_agent_email.tools import onboarding_tools as ob
 
 OUTLOOK_SCOPES = [

--- a/hub/agents/email/python/tests/test_mailbox_onboarding_outlook_2590.py
+++ b/hub/agents/email/python/tests/test_mailbox_onboarding_outlook_2590.py
@@ -9,11 +9,12 @@ Two bugs this replaces:
 2. The setup flow could only fail as one opaque "connect your mailbox" prompt
    — no walkthrough, no verification, no browserless sign-in.
 
-``_ScriptedConsole`` / ``_FakeAgent`` are copied verbatim from
-``test_mailbox_onboarding_2469.py`` (not imported — this tree has no
-``tests/__init__.py``) so the real ``question.ask()`` resolves options,
-enforces strict rejection, and suppresses sensitive echoes exactly as it does
-in production; a hand-rolled fake ``ask`` would not reproduce that.
+``_ScriptedConsole`` / ``_FakeAgent`` are shared with
+``test_mailbox_onboarding_2469.py`` via ``conftest.py`` so the real
+``question.ask()`` resolves options, enforces strict rejection, and
+suppresses sensitive echoes exactly as it does in production — a hand-rolled
+fake ``ask`` would not reproduce that, and a second drifted copy of the fake
+would silently stop testing it.
 """
 
 from __future__ import annotations
@@ -21,43 +22,14 @@ from __future__ import annotations
 import json
 
 import pytest
-from gaia_agent_email import mailbox_state as ms
-from gaia_agent_email import question as q
+from conftest import FakeAgent as _FakeAgent
+from conftest import ScriptedConsole as _ScriptedConsole
 from gaia_agent_email.tools import onboarding_tools as ob
 
 OUTLOOK_SCOPES = [
     "https://graph.microsoft.com/Mail.ReadWrite",
     "https://graph.microsoft.com/Mail.Send",
 ]
-
-
-# ---------------------------------------------------------------------------
-# Fakes — verbatim copy, see module docstring.
-# ---------------------------------------------------------------------------
-
-
-class _ScriptedConsole:
-    """Records every question asked and replies from a fixed script."""
-
-    def __init__(self, answers):
-        self.answers = list(answers)
-        self.asked = []
-        self.info = []
-
-    def request_user_input_blocking(self, **kwargs):
-        self.asked.append(kwargs)
-        if not self.answers:
-            return q.NO_RESPONSE
-        return self.answers.pop(0)
-
-    def print_info(self, message):
-        self.info.append(message)
-
-
-class _FakeAgent:
-    def __init__(self, answers=(), can_answer_questions=True):
-        self.console = _ScriptedConsole(answers)
-        self.can_answer_questions = can_answer_questions
 
 
 def _connection(scopes=None, email="kalin@outlook.com", error=None):

--- a/hub/agents/email/python/tests/test_mailbox_onboarding_outlook_2590.py
+++ b/hub/agents/email/python/tests/test_mailbox_onboarding_outlook_2590.py
@@ -1,13 +1,15 @@
 # Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
 # SPDX-License-Identifier: MIT
-"""Guided Outlook mailbox onboarding (#2590) — Microsoft-only.
+"""Guided Outlook mailbox onboarding (#2590) — Microsoft-only, end to end.
 
-Two bugs this replaces:
+Three bugs this replaces:
 
 1. Setting up Outlook asked for a client secret Microsoft's public-client PKCE
    route never issues, so the prompt was impossible to answer honestly.
 2. The setup flow could only fail as one opaque "connect your mailbox" prompt
    — no walkthrough, no verification, no browserless sign-in.
+3. A user with a working mailbox could still be dragged into setup — #2469's
+   whole point was to stop that.
 
 ``_ScriptedConsole`` / ``_FakeAgent`` are shared with
 ``test_mailbox_onboarding_2469.py`` via ``conftest.py`` so the real
@@ -30,6 +32,12 @@ OUTLOOK_SCOPES = [
     "https://graph.microsoft.com/Mail.ReadWrite",
     "https://graph.microsoft.com/Mail.Send",
 ]
+VALID_GUID = "11112222-bbbb-3333-cccc-4444dddd5555"
+
+# The device-code route's nav steps, in order — Done answers walk straight
+# through; see gaia.connectors.setup_routes.MS_PERSONAL /
+# steps_for(sign_in="device_code").
+_WALKTHROUGH_DONE_ANSWERS = ["done", "done", "done", "done"]
 
 
 def _connection(scopes=None, email="kalin@outlook.com", error=None):
@@ -54,9 +62,11 @@ def ms_connectors(monkeypatch):
         "token_error": None,
         "grants": [],
         "configured": [],
-        "completed": [],
-        "client_id": "11112222-bbbb-3333-cccc-4444dddd5555",
+        "device_started": [],
+        "device_polled": [],
+        "client_id": VALID_GUID,
         "timeouts": [],
+        "poll_result": None,
     }
 
     def get_connection(provider):
@@ -93,7 +103,46 @@ def ms_connectors(monkeypatch):
 
     async def configure(connector_id, config):
         state["configured"].append((connector_id, config))
+        if config.get("client_id"):
+            state["client_id"] = config["client_id"]
         return {"status": "saved", "connector_id": connector_id}
+
+    async def start_device_flow(provider, scopes):
+        state["device_started"].append((provider, list(scopes)))
+        return {
+            "provider_id": provider,
+            "scopes": list(scopes),
+            "device_code": "DEV-CODE",
+            "user_code": "ABCD-EFGH",
+            "verification_uri": "https://microsoft.com/devicelogin",
+            "expires_in": 900,
+            "interval": 5,
+            "message": "Go to https://microsoft.com/devicelogin and enter ABCD-EFGH",
+        }
+
+    async def poll_device_flow(
+        provider, device_code, *, scopes, interval, expires_in, grant_agents=None
+    ):
+        state["device_polled"].append(
+            {
+                "provider": provider,
+                "device_code": device_code,
+                "scopes": list(scopes),
+                "grant_agents": grant_agents,
+            }
+        )
+        result = state["poll_result"] or {
+            "provider": provider,
+            "account_email": "kalin@outlook.com",
+            "scopes": list(scopes),
+            "connected_at": 1,
+        }
+        # Mirror what a real successful device-code connect does: the
+        # mailbox is now connected and granted, so the tail-end
+        # inspect_provider(probe=True) call reports it usable.
+        state["connection"] = _connection(scopes=list(scopes))
+        state["granted"] = True
+        return result
 
     def run_sync(coro, *, timeout=30.0):
         import asyncio
@@ -109,6 +158,8 @@ def ms_connectors(monkeypatch):
     monkeypatch.setattr("gaia.connectors.grants.grant_agent", grant_agent)
     monkeypatch.setattr("gaia.connectors.providers.get", get_provider)
     monkeypatch.setattr("gaia.connectors.handler.configure", configure)
+    monkeypatch.setattr("gaia.connectors.flow.start_device_flow", start_device_flow)
+    monkeypatch.setattr("gaia.connectors.flow.poll_device_flow", poll_device_flow)
     monkeypatch.setattr("gaia.connectors._loop.run_sync", run_sync)
     return state
 
@@ -122,15 +173,15 @@ def _questions(agent):
 
 
 # ---------------------------------------------------------------------------
-# Increment 1 — Outlook is never asked for a client secret.
+# Never asked for a client secret — the whole walk, every state.
 # ---------------------------------------------------------------------------
 
 
 def test_reauth_with_client_already_configured_never_mentions_secret(ms_connectors):
     """``gap is None`` case: the client is already on disk (reconnect path).
 
-    Reaches ``_collect_oauth_client`` with nothing missing, so it should ask
-    nothing at all about credentials — and definitely never mention a secret.
+    Declining here never reaches the walkthrough or device sign-in at all —
+    still worth asserting nothing about a secret is ever said.
     """
     from gaia.connectors.errors import ConnectionRevokedError
 
@@ -147,19 +198,108 @@ def test_reauth_with_client_already_configured_never_mentions_secret(ms_connecto
 def test_declining_client_setup_with_no_client_configured_never_mentions_secret(
     ms_connectors,
 ):
-    """``gap == "client_id"`` case: nothing configured yet, still no secret talk."""
+    """``gap == "client_id"`` case: nothing configured yet — say [I'm stuck]
+    right away rather than complete the walkthrough."""
     ms_connectors["connection"] = None
     ms_connectors["client_id"] = ""
-    # "yes" confirms the repair; "no" declines at the credentials question.
-    agent = _FakeAgent(answers=["yes", "no"])
+    # "yes" confirms the repair; "stuck" ends the walkthrough on step one.
+    agent = _FakeAgent(answers=["yes", "stuck"])
 
-    _run(agent, provider="microsoft")
+    out = _run(agent, provider="microsoft")
 
+    assert out["ok"] is True
+    assert out["data"]["stuck"] is True
     assert not any("secret" in a["message"].lower() for a in agent.console.asked)
-    # Nor asked to provide one via any option description offered along the way
-    # (truthfully saying "no secret needed" is fine and expected — see the
-    # plan's lifted seven-day-expiry constraint; the bug was ASKING for one).
+    # Nor via any option description offered along the way (truthfully saying
+    # "no secret needed" is fine — the bug was ASKING for one).
     for call in agent.console.asked:
         for opt in call.get("options") or []:
             desc = opt.get("description", "").lower()
             assert "paste" not in desc or "secret" not in desc
+    assert ms_connectors["configured"] == [], "getting stuck must change nothing"
+
+
+def test_full_walkthrough_and_device_connect_never_mentions_secret_either(
+    ms_connectors,
+):
+    """AC1, asserted end to end: a COMPLETE first-time Outlook connect —
+    walkthrough + device-code sign-in — never once asks for a secret."""
+    ms_connectors["connection"] = None
+    ms_connectors["client_id"] = ""
+    agent = _FakeAgent(
+        answers=["yes", *_WALKTHROUGH_DONE_ANSWERS, VALID_GUID]
+    )
+
+    out = _run(agent, provider="microsoft")
+
+    assert out["ok"] is True, out
+    assert out["data"]["changed"] is True
+    assert out["data"]["account_email"] == "kalin@outlook.com"
+    assert not any("secret" in a["message"].lower() for a in agent.console.asked)
+    for call in agent.console.asked:
+        for opt in call.get("options") or []:
+            desc = opt.get("description", "").lower()
+            assert "paste" not in desc or "secret" not in desc
+    # The collected client id was actually used to configure the provider.
+    _, config = ms_connectors["configured"][0]
+    assert config["client_id"] == VALID_GUID
+    assert "client_secret" not in config
+    assert ms_connectors["device_started"], "device-code sign-in never ran"
+
+
+# ---------------------------------------------------------------------------
+# A working mailbox is never re-interviewed (#2469's core guarantee).
+# ---------------------------------------------------------------------------
+
+
+def test_already_usable_microsoft_mailbox_is_never_walked_through_setup(
+    ms_connectors,
+):
+    ms_connectors["connection"] = _connection()
+    ms_connectors["granted"] = True
+    agent = _FakeAgent()
+
+    out = _run(agent, provider="microsoft")
+
+    assert out["ok"] is True
+    assert out["data"]["changed"] is False
+    assert agent.console.asked == [], "a working mailbox must not be interrupted"
+
+
+def test_a_working_google_mailbox_is_never_dragged_into_microsoft_setup(
+    ms_connectors, monkeypatch
+):
+    """#2590's the-walkthrough-hooks-at-_choose_provider requirement: a user
+    with ANY working mailbox is never shown a walkthrough question, even if
+    they have an abandoned Microsoft attempt sitting around."""
+    from gaia_agent_email import mailbox_state as ms
+
+    ms_connectors["connection"] = None  # microsoft: not connected
+    google_scopes = ms.required_scopes("google")
+
+    def get_connection(provider):
+        if provider == "google":
+            return {
+                "provider": "google",
+                "account_email": "kalin@gmail.com",
+                "scopes": list(google_scopes),
+                "connected_at": 1,
+            }
+        return None
+
+    def check_agent_grant(provider, agent_id, scopes):
+        return provider == "google"
+
+    monkeypatch.setattr("gaia.connectors.api.get_connection", get_connection)
+    monkeypatch.setattr("gaia.connectors.grants.check_agent_grant", check_agent_grant)
+    monkeypatch.setattr(
+        "gaia.connectors.api.get_access_token_sync", lambda **kw: "token"
+    )
+
+    agent = _FakeAgent()
+
+    out = _run(agent, provider="")  # no target named — the "pick the best" path
+
+    assert out["ok"] is True
+    assert out["data"]["provider"] == "google"
+    assert agent.console.asked == [], "a working Gmail mailbox must stay quiet"

--- a/hub/agents/email/python/tests/test_mailbox_provider_aliases_2590.py
+++ b/hub/agents/email/python/tests/test_mailbox_provider_aliases_2590.py
@@ -1,0 +1,163 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""Mailbox provider vocabulary normalization (#2590 real-world blocker).
+
+The bug: ``setup_mailbox_access(provider="outlook")`` rejected with "I don't
+support 'outlook'. I can connect Gmail or Outlook." — a rejection that names
+the exact word it just rejected. A live model hears "Outlook" (this agent's
+OWN copy uses that word everywhere, via ``provider_label``) and has no reason
+to guess the internal id ``"microsoft"`` instead; the tool's docstring didn't
+even tell it to. Invisible to unit tests that pass canonical ids directly —
+only a live model, using the vocabulary the product itself teaches it,
+produces this.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from gaia_agent_email import mailbox_state as ms
+from gaia_agent_email.tools import onboarding_tools as ob
+from onboarding_fakes import FakeAgent as _FakeAgent
+
+# ---------------------------------------------------------------------------
+# mailbox_state.resolve_provider — pure normalization
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "alias,expected",
+    [
+        # Canonical ids still resolve.
+        ("google", "google"),
+        ("microsoft", "microsoft"),
+        # Microsoft's real-world vocabulary.
+        ("outlook", "microsoft"),
+        ("Outlook", "microsoft"),
+        ("  outlook  ", "microsoft"),
+        ("OUTLOOK", "microsoft"),
+        ("outlook.com", "microsoft"),
+        ("hotmail", "microsoft"),
+        ("live", "microsoft"),
+        ("office365", "microsoft"),
+        ("o365", "microsoft"),
+        ("microsoft 365", "microsoft"),
+        ("entra", "microsoft"),
+        ("exchange", "microsoft"),
+        # Google's real-world vocabulary.
+        ("gmail", "google"),
+        ("Gmail", "google"),
+        ("gmail.com", "google"),
+        ("googlemail", "google"),
+        ("google workspace", "google"),
+        ("gsuite", "google"),
+    ],
+)
+def test_every_alias_resolves_to_its_canonical_provider(alias, expected):
+    assert ms.resolve_provider(alias) == expected
+
+
+@pytest.mark.parametrize("bogus", ["yahoo", "protonmail", "", "  ", "icloud"])
+def test_unknown_values_are_still_rejected(bogus):
+    assert ms.resolve_provider(bogus) is None
+
+
+def test_provider_label_of_every_alias_target_is_itself_a_resolvable_alias():
+    """Regression test for the exact self-contradiction bug: whatever
+    provider_label() would show the user for a canonical id must ALSO
+    resolve back through resolve_provider — otherwise a message built from
+    provider_label() could show a word that gets rejected as input."""
+    for provider in ms.PROVIDERS:
+        label = ms.provider_label(provider)
+        assert ms.resolve_provider(label) == provider, (
+            f"provider_label({provider!r}) == {label!r}, but "
+            f"resolve_provider({label!r}) != {provider!r} — the label GAIA "
+            "shows the user would be rejected if echoed back as input."
+        )
+
+
+# ---------------------------------------------------------------------------
+# onboarding_tools._normalize_provider_arg — what the real tool calls first
+# ---------------------------------------------------------------------------
+#
+# The ``setup_mailbox_access`` tool itself is a closure registered per-agent
+# instance (``_register_onboarding_tools``), not a module attribute, so it
+# cannot be invoked directly in a unit test. ``_normalize_provider_arg`` is
+# the extracted, directly-testable piece that closure calls FIRST — the
+# exact code path the live-model repro hit.
+
+
+def test_outlook_alias_resolves_to_the_canonical_provider_id():
+    """The live-model repro, exactly as it happened: the model passes the
+    word the product's OWN copy taught it ('Outlook'), not the internal id."""
+    wanted, error = ob._normalize_provider_arg("outlook")
+    assert error is None
+    assert wanted == "microsoft"
+
+
+def test_gmail_alias_resolves_to_the_canonical_provider_id():
+    wanted, error = ob._normalize_provider_arg("Gmail")
+    assert error is None
+    assert wanted == "google"
+
+
+def test_unrecognized_provider_is_still_rejected():
+    wanted, error = ob._normalize_provider_arg("yahoo")
+    assert wanted == ""
+    assert error is not None
+    assert "yahoo" in error
+
+
+def test_rejection_message_never_names_a_string_it_would_itself_reject():
+    """The regression test for the self-contradiction bug: the message must
+    not claim to support (or list as an option) any word that, if passed
+    right back in as ``provider``, would ALSO be rejected."""
+    _wanted, error = ob._normalize_provider_arg("yahoo")
+
+    assert error is not None
+    for provider in ms.PROVIDERS:
+        label = ms.provider_label(provider)
+        if label in error:
+            assert ms.resolve_provider(label) == provider, (
+                f"rejection message contains {label!r}, which does not "
+                "resolve back to the provider it names — the exact "
+                "self-contradiction this test guards against"
+            )
+
+
+def test_omitted_provider_still_lets_the_flow_pick():
+    """No behavior change for the empty-string case — 'let the flow pick'."""
+    wanted, error = ob._normalize_provider_arg("")
+    assert error is None
+    assert wanted == ""
+
+
+def test_whitespace_only_provider_still_lets_the_flow_pick():
+    wanted, error = ob._normalize_provider_arg("   ")
+    assert error is None
+    assert wanted == ""
+
+
+# ---------------------------------------------------------------------------
+# End-to-end through _setup_mailbox_access — the alias actually drives setup
+# ---------------------------------------------------------------------------
+
+
+def test_outlook_alias_reaches_setup_flow_targeting_microsoft(monkeypatch):
+    """Confirms the resolved id, not the raw alias, is what reaches the
+    scripted flow — a alias that resolved but wasn't actually PASSED THROUGH
+    would still break the walkthrough."""
+    calls = []
+
+    def fake_setup_flow(agent, wanted):
+        calls.append(wanted)
+        return json.dumps({"ok": True, "data": {"changed": False}})
+
+    monkeypatch.setattr(ob, "_setup_flow", fake_setup_flow)
+    wanted, error = ob._normalize_provider_arg("outlook")
+    assert error is None
+
+    ob._setup_mailbox_access(_FakeAgent(), wanted)
+
+    assert calls == ["microsoft"]

--- a/hub/agents/email/python/tests/test_mailbox_target_guard.py
+++ b/hub/agents/email/python/tests/test_mailbox_target_guard.py
@@ -98,30 +98,42 @@ def google_only_agent(tmp_path, monkeypatch):
         agent.close_db()
 
 
-def test_outlook_target_with_only_google_errors_before_any_tool(
+def test_unconnected_target_is_not_rejected_and_reaches_the_loop(
     google_only_agent, monkeypatch
 ):
-    """#2164: 'check my Outlook inbox' with only Google connected must return
-    the connectors NOT_CONNECTED error — and never touch the Gmail backend or
-    enter the agent loop."""
+    """#2590 regression: 'check my Outlook inbox' with only Google connected
+    used to be rejected here with a canned "go to Settings" message BEFORE
+    the agent loop ran — which meant setup_mailbox_access (the guided
+    walkthrough) could never be reached no matter how the request was
+    phrased. A provider that is simply not connected yet must fall through
+    to the loop instead, so the agent can offer to connect it."""
     from gaia.agents.base.agent import Agent
 
     agent, backend = google_only_agent
+    sentinel = {"status": "success", "result": "loop ran"}
+    monkeypatch.setattr(Agent, "process_query", lambda self, *a, **k: sentinel)
 
-    def _loop_must_not_run(self, *args, **kwargs):
-        raise AssertionError(
-            "agent loop ran for an unconnected-provider request — the "
-            "pre-flight guard did not fire"
-        )
+    assert agent.process_query("check my Outlook inbox") is sentinel
+    # Still never silently substituted Gmail for the named-but-unconnected
+    # provider — the loop decides what to do (e.g. offer setup), not the
+    # guard picking a different mailbox.
+    assert backend.calls == []
 
-    monkeypatch.setattr(Agent, "process_query", _loop_must_not_run)
 
-    result = agent.process_query("check my Outlook inbox")
+def test_provider_named_while_another_is_connected_still_reaches_the_loop(
+    google_only_agent, monkeypatch
+):
+    """#2590: naming an unconnected provider while a DIFFERENT provider is
+    already connected-and-usable must still reach the loop for the named
+    provider — not be swallowed by the guard, and not silently answered
+    from the already-usable mailbox instead."""
+    from gaia.agents.base.agent import Agent
 
-    assert result["status"] == "failed"
-    assert "NOT_CONNECTED" in result["result"]
-    assert "microsoft" in result["result"]
-    # The misleading substitution: no Gmail call may have happened.
+    agent, backend = google_only_agent  # only google connected/usable
+    sentinel = {"status": "success", "result": "loop ran"}
+    monkeypatch.setattr(Agent, "process_query", lambda self, *a, **k: sentinel)
+
+    assert agent.process_query("please set up my outlook mailbox") is sentinel
     assert backend.calls == []
 
 
@@ -148,20 +160,53 @@ def test_connected_provider_target_passes_through(google_only_agent, monkeypatch
     assert agent.process_query("check my gmail inbox") is sentinel
 
 
-def test_guard_error_is_surfaced_on_the_console(google_only_agent, monkeypatch):
-    """The message must reach the console (the SSE stream renders console
-    events, not the return value)."""
-    agent, _ = google_only_agent
-    printed = []
-    monkeypatch.setattr(
-        agent.console, "print_error", lambda msg: printed.append(msg), raising=False
+def _build_pinned_agent(tmp_path, monkeypatch):
+    """Both providers connected, session pinned to google — the ONE case the
+    guard still rejects pre-flight (#2164's actual intent-conflict purpose,
+    unaffected by #2590)."""
+    from gaia_agent_email.agent import EmailTriageAgent
+    from gaia_agent_email.config import EmailAgentConfig
+
+    gmail = _RecordingMailBackend()
+    outlook = _RecordingMailBackend()
+    cfg = EmailAgentConfig(
+        gmail_backend=gmail,
+        outlook_backend=outlook,
+        mail_provider="google",
+        calendar_backend=_MinimalCalendarBackend(),
+        db_path=str(tmp_path / "state.db"),
+        memory_db_path=str(tmp_path / "memory.db"),
+        silent_mode=True,
+        start_scheduler=False,
     )
+    monkeypatch.setenv("GAIA_MEMORY_DISABLED", "1")
+    with patch("gaia.agents.base.agent.AgentSDK") as mock_sdk:
+        mock_sdk.return_value = MagicMock()
+        agent = EmailTriageAgent(config=cfg)
+    return agent, gmail, outlook
 
-    agent.process_query("check my Outlook inbox")
 
-    assert len(printed) == 1
-    assert "NOT_CONNECTED" in printed[0]
-    assert "microsoft" in printed[0]
+def test_guard_error_is_surfaced_on_the_console(tmp_path, monkeypatch):
+    """The message must reach the console (the SSE stream renders console
+    events, not the return value). Uses the pinned-mailbox conflict — the
+    only case the guard still rejects pre-flight; an unconnected target no
+    longer does (#2590)."""
+    agent, gmail, outlook = _build_pinned_agent(tmp_path, monkeypatch)
+    try:
+        printed = []
+        monkeypatch.setattr(
+            agent.console, "print_error", lambda msg: printed.append(msg), raising=False
+        )
+
+        agent.process_query("check my Outlook inbox")
+
+        assert len(printed) == 1
+        assert "pinned" in printed[0]
+        assert "microsoft" in printed[0]
+        assert gmail.calls == []
+        assert outlook.calls == []
+    finally:
+        agent.close_db()
 
 
 def test_session_pinned_to_other_mailbox_errors(tmp_path, monkeypatch):

--- a/hub/agents/email/python/tests/test_setup_walkthrough.py
+++ b/hub/agents/email/python/tests/test_setup_walkthrough.py
@@ -255,3 +255,119 @@ def test_im_stuck_ends_the_walkthrough_honestly():
     # improvise a substitute response.
     assert "amd-gaia.ai" in str(exc.value)
     assert "account_type" not in str(exc.value)  # the step's id, not its title
+
+
+# ---------------------------------------------------------------------------
+# FAQ lane — selection, never composition. Navigation prompts only.
+# ---------------------------------------------------------------------------
+
+
+def test_a_step_level_faq_answer_is_emitted_byte_for_byte():
+    """The invariant, asserted end-to-end: what got printed IS the authored
+    QA.answer — imported from the real route, compared with ==, not `in`. A
+    function-level test of the lookup alone would pass even if the driver
+    prepended something like "Good question — "."""
+    register_step = next(s for s in sr.MS_PERSONAL.steps if s.id == "register")
+    qa = register_step.faq[0]
+    assert "which account" in qa.question_hints
+
+    agent = _FakeAgent(
+        answers=[
+            "which account should I use?",
+            "done",
+            "done",
+            "done",
+            "done",
+            _VALID_GUID,
+        ]
+    )
+
+    sw.run_setup_walkthrough(agent, sr.MS_PERSONAL)
+
+    # List membership on a list of strings is Python `==` per element — the
+    # exact-match check the plan requires, not a substring `in` check that
+    # would also pass if the driver had prepended something to it.
+    assert qa.answer in agent.console.info
+
+
+def test_a_route_level_faq_answer_is_reachable_from_any_step():
+    """The client-secret FAQ lives on the ROUTE, not any one step — it must
+    still resolve when asked during a step with no matching step-level FAQ."""
+    route_qa = next(qa for qa in sr.MS_PERSONAL.faq if "secret" in qa.question_hints)
+
+    agent = _FakeAgent(
+        answers=[
+            "done",  # register
+            "do I need a client secret for this?",  # account_type — no step FAQ
+            "done",
+            "done",
+            "done",
+            _VALID_GUID,
+        ]
+    )
+
+    sw.run_setup_walkthrough(agent, sr.MS_PERSONAL)
+
+    assert route_qa.answer in agent.console.info
+
+
+def test_an_unmatched_question_returns_the_authored_no_match_string():
+    agent = _FakeAgent(
+        answers=[
+            "what is the airspeed velocity of an unladen swallow?",
+            "done",
+            "done",
+            "done",
+            "done",
+            _VALID_GUID,
+        ]
+    )
+
+    sw.run_setup_walkthrough(agent, sr.MS_PERSONAL)
+
+    assert sw._FAQ_NO_MATCH in agent.console.info
+
+
+def test_faq_turn_re_asks_with_the_same_options_and_free_text_still_enabled():
+    """A credential prompt is never given the FAQ lane (zero options), and no
+    NAVIGATION prompt is ever re-issued with allow_free_text=False and zero
+    options — asserted across the whole scripted walk, not one call."""
+    agent = _FakeAgent(
+        answers=[
+            "a question nobody wrote an answer for",
+            "done",
+            "done",
+            "done",
+            "done",
+            _VALID_GUID,
+        ]
+    )
+
+    sw.run_setup_walkthrough(agent, sr.MS_PERSONAL)
+
+    for call in agent.console.asked:
+        if call["allow_free_text"] is False:
+            assert call["options"], "allow_free_text=False with zero options"
+        # Every navigation prompt (has options) keeps allow_free_text True —
+        # the FAQ lane is never silently withdrawn mid-walk.
+        if call["options"]:
+            assert call["allow_free_text"] is True
+
+
+def test_credential_prompt_is_never_given_the_faq_lane():
+    """The credential ask has zero options — a free-text answer there is
+    ALWAYS taken as the literal value, never routed through FAQ matching."""
+    weird_but_literal_value = "why do you need this?"
+    agent = _FakeAgent(
+        answers=["done", "done", "done", "done", weird_but_literal_value, _VALID_GUID]
+    )
+
+    collected, _trace = sw.run_setup_walkthrough(agent, sr.MS_PERSONAL)
+
+    # It was rejected by the SHAPE CHECK (not a GUID), not silently
+    # reinterpreted as a question — the walkthrough asked again and got the
+    # real value next.
+    assert collected["client_id"] == _VALID_GUID
+    assert not any(
+        "which account" in m or sw._FAQ_NO_MATCH in m for m in agent.console.info
+    )

--- a/hub/agents/email/python/tests/test_setup_walkthrough.py
+++ b/hub/agents/email/python/tests/test_setup_walkthrough.py
@@ -13,7 +13,7 @@ and the single-use code is burnt for a user who did everything right.
 from __future__ import annotations
 
 import pytest
-from conftest import FakeAgent as _FakeAgent
+from onboarding_fakes import FakeAgent as _FakeAgent
 from gaia.connectors import setup_routes as sr
 from gaia_agent_email.tools import setup_walkthrough as sw
 

--- a/hub/agents/email/python/tests/test_setup_walkthrough.py
+++ b/hub/agents/email/python/tests/test_setup_walkthrough.py
@@ -1,0 +1,157 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""Device-code sign-in glue for guided mailbox onboarding (#2590).
+
+The critical detail: the wait must be bound on the device code's OWN
+advertised ``expires_in`` (Microsoft defaults to 900s), never the 150s
+constant that exists specifically because the LOOPBACK flow's own bound is
+120s. Copying that constant here means: poll cancelled at 150s, user
+approves at T+300s (well within the code's real 900s life), nothing saves,
+and the single-use code is burnt for a user who did everything right.
+"""
+
+from __future__ import annotations
+
+import pytest
+from conftest import FakeAgent as _FakeAgent
+from gaia_agent_email.tools import setup_walkthrough as sw
+
+PROVIDER = "microsoft"
+OUTLOOK_SCOPES = [
+    "https://graph.microsoft.com/Mail.ReadWrite",
+    "https://graph.microsoft.com/Mail.Send",
+]
+
+
+@pytest.fixture()
+def device_flow(monkeypatch):
+    state = {
+        "started": None,
+        "polled": None,
+        "grants": [],
+        "timeouts": [],
+        "poll_result": {
+            "provider": PROVIDER,
+            "account_email": "kalin@outlook.com",
+            "scopes": OUTLOOK_SCOPES,
+            "connected_at": 1,
+        },
+    }
+
+    async def start_device_flow(provider, scopes):
+        state["started"] = (provider, list(scopes))
+        return {
+            "provider_id": provider,
+            "scopes": list(scopes),
+            "device_code": "DEV-CODE",
+            "user_code": "ABCD-EFGH",
+            "verification_uri": "https://microsoft.com/devicelogin",
+            "expires_in": 900,
+            "interval": 5,
+            "message": "Go to https://microsoft.com/devicelogin and enter ABCD-EFGH",
+        }
+
+    async def poll_device_flow(provider, device_code, *, scopes, interval, expires_in, grant_agents=None):
+        state["polled"] = {
+            "provider": provider,
+            "device_code": device_code,
+            "scopes": list(scopes),
+            "interval": interval,
+            "expires_in": expires_in,
+            "grant_agents": grant_agents,
+        }
+        return state["poll_result"]
+
+    def grant_agent(provider, agent_id, scopes):
+        state["grants"].append((provider, agent_id, tuple(scopes)))
+
+    def run_sync(coro, *, timeout=30.0):
+        import asyncio
+
+        state["timeouts"].append(timeout)
+        return asyncio.run(coro)
+
+    monkeypatch.setattr("gaia.connectors.flow.start_device_flow", start_device_flow)
+    monkeypatch.setattr("gaia.connectors.flow.poll_device_flow", poll_device_flow)
+    monkeypatch.setattr("gaia.connectors.grants.grant_agent", grant_agent)
+    monkeypatch.setattr("gaia.connectors._loop.run_sync", run_sync)
+    return state
+
+
+def test_narrates_the_user_code_and_verification_url(device_flow):
+    agent = _FakeAgent()
+
+    sw.run_device_oauth(agent, PROVIDER)
+
+    assert any("ABCD-EFGH" in m for m in agent.console.info)
+    assert any("devicelogin" in m for m in agent.console.info)
+
+
+def test_poll_timeout_is_derived_from_the_codes_own_expires_in(device_flow):
+    """AC2: the run_sync timeout for the POLL call must come from the device
+    code's own expires_in — never the 150s loopback-flow constant."""
+    agent = _FakeAgent()
+
+    sw.run_device_oauth(agent, PROVIDER)
+
+    # Two run_sync calls: start_device_flow (default timeout), then
+    # poll_device_flow (the one under test).
+    assert len(device_flow["timeouts"]) == 2
+    poll_timeout = device_flow["timeouts"][-1]
+    assert poll_timeout != 150
+    assert poll_timeout > 900, "must comfortably exceed the code's own 900s life"
+
+
+def test_poll_timeout_tracks_a_shorter_expires_in_too(device_flow, monkeypatch):
+    """Not hardcoded to 900 either — genuinely derived per call."""
+
+    async def short_start_device_flow(provider, scopes):
+        return {
+            "provider_id": provider,
+            "scopes": list(scopes),
+            "device_code": "DEV-CODE",
+            "user_code": "WXYZ-1234",
+            "verification_uri": "https://microsoft.com/devicelogin",
+            "expires_in": 60,
+            "interval": 5,
+            "message": "",
+        }
+
+    monkeypatch.setattr(
+        "gaia.connectors.flow.start_device_flow", short_start_device_flow
+    )
+    agent = _FakeAgent()
+
+    sw.run_device_oauth(agent, PROVIDER)
+
+    poll_timeout = device_flow["timeouts"][-1]
+    assert poll_timeout != 150
+    assert 60 < poll_timeout < 900
+
+
+def test_grants_the_agent_after_a_successful_poll(device_flow):
+    agent = _FakeAgent()
+
+    state = sw.run_device_oauth(agent, PROVIDER)
+
+    assert state["account_email"] == "kalin@outlook.com"
+    assert device_flow["polled"]["grant_agents"] == {
+        "installed:email": OUTLOOK_SCOPES
+    }
+    # Belt-and-suspenders explicit grant, mirroring _run_oauth's own pattern.
+    assert device_flow["grants"]
+    provider, agent_id, scopes = device_flow["grants"][0]
+    assert provider == PROVIDER
+    assert agent_id == "installed:email"
+
+
+def test_scopes_sent_to_the_device_flow_include_identity_scopes(device_flow):
+    """Mirrors _connect_scopes — without identity scopes the account shows as
+    "default" instead of the real address, the same #2469 divergence bug."""
+    agent = _FakeAgent()
+
+    sw.run_device_oauth(agent, PROVIDER)
+
+    started_scopes = device_flow["started"][1]
+    for scope in OUTLOOK_SCOPES:
+        assert scope in started_scopes

--- a/hub/agents/email/python/tests/test_setup_walkthrough.py
+++ b/hub/agents/email/python/tests/test_setup_walkthrough.py
@@ -354,20 +354,66 @@ def test_faq_turn_re_asks_with_the_same_options_and_free_text_still_enabled():
             assert call["allow_free_text"] is True
 
 
-def test_credential_prompt_is_never_given_the_faq_lane():
-    """The credential ask has zero options — a free-text answer there is
-    ALWAYS taken as the literal value, never routed through FAQ matching."""
-    weird_but_literal_value = "why do you need this?"
+def test_a_genuine_question_at_the_credential_step_gets_its_authored_answer():
+    """Azure's Overview blade shows THREE GUIDs side by side (Application
+    client ID, Object ID, Directory/tenant ID) — a shape check can't tell
+    them apart, so this is the one place a guided walkthrough answering
+    questions genuinely earns its keep. A question-shaped answer must get
+    its authored FAQ answer and a re-ask, not the generic shape error."""
+    client_id_step = next(s for s in sr.MS_PERSONAL.steps if s.id == "client_id")
+    qa = next(
+        qa
+        for qa in client_id_step.faq
+        if any(h in qa.question_hints for h in ("which id", "tenant"))
+    )
     agent = _FakeAgent(
-        answers=["done", "done", "done", "done", weird_but_literal_value, _VALID_GUID]
+        answers=[
+            "done",
+            "done",
+            "done",
+            "done",
+            "which id is it? there are three on this page",
+            _VALID_GUID,
+        ]
     )
 
     collected, _trace = sw.run_setup_walkthrough(agent, sr.MS_PERSONAL)
 
-    # It was rejected by the SHAPE CHECK (not a GUID), not silently
-    # reinterpreted as a question — the walkthrough asked again and got the
-    # real value next.
     assert collected["client_id"] == _VALID_GUID
-    assert not any(
-        "which account" in m or sw._FAQ_NO_MATCH in m for m in agent.console.info
+    assert qa.answer in agent.console.info
+    # The generic shape error was never shown for a question-shaped answer.
+    assert sw._CLIENT_ID_SHAPE_ERROR not in agent.console.info
+
+
+def test_a_malformed_credential_value_still_gets_the_shape_error():
+    """A value that ISN'T a question (doesn't match any FAQ hint) is still
+    treated as a malformed literal, not silently swallowed by the FAQ lane."""
+    bogus = "xxxxxxxx-not-a-guid-at-all"
+    agent = _FakeAgent(
+        answers=["done", "done", "done", "done", bogus, _VALID_GUID]
     )
+
+    collected, _trace = sw.run_setup_walkthrough(agent, sr.MS_PERSONAL)
+
+    assert collected["client_id"] == _VALID_GUID
+    assert sw._CLIENT_ID_SHAPE_ERROR in agent.console.info
+    assert not any(bogus in m for m in agent.console.info)
+
+
+def test_credential_prompt_still_has_zero_options_with_the_faq_lane_added():
+    """The FAQ lookup on the credential step is a lookup, not a lane change —
+    the prompt itself stays a plain free-text ask, never gains Done/Stuck
+    options (which would let a real client ID collide with an option value)."""
+    agent = _FakeAgent(
+        answers=["done", "done", "done", "done", "what's a tenant id?", _VALID_GUID]
+    )
+
+    sw.run_setup_walkthrough(agent, sr.MS_PERSONAL)
+
+    credential_calls = [
+        c for c in agent.console.asked if c["message"].startswith("Paste the value")
+    ]
+    assert len(credential_calls) == 2  # the question turn, then the real value
+    for call in credential_calls:
+        assert call["options"] == []
+        assert call["allow_free_text"] is True

--- a/hub/agents/email/python/tests/test_setup_walkthrough.py
+++ b/hub/agents/email/python/tests/test_setup_walkthrough.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 import pytest
 from conftest import FakeAgent as _FakeAgent
+from gaia.connectors import setup_routes as sr
 from gaia_agent_email.tools import setup_walkthrough as sw
 
 PROVIDER = "microsoft"
@@ -21,6 +22,8 @@ OUTLOOK_SCOPES = [
     "https://graph.microsoft.com/Mail.ReadWrite",
     "https://graph.microsoft.com/Mail.Send",
 ]
+
+_VALID_GUID = "11112222-bbbb-3333-cccc-4444dddd5555"
 
 
 @pytest.fixture()
@@ -146,7 +149,7 @@ def test_grants_the_agent_after_a_successful_poll(device_flow):
 
 
 def test_scopes_sent_to_the_device_flow_include_identity_scopes(device_flow):
-    """Mirrors _connect_scopes — without identity scopes the account shows as
+    """Mirrors connect_scopes — without identity scopes the account shows as
     "default" instead of the real address, the same #2469 divergence bug."""
     agent = _FakeAgent()
 
@@ -155,3 +158,100 @@ def test_scopes_sent_to_the_device_flow_include_identity_scopes(device_flow):
     started_scopes = device_flow["started"][1]
     for scope in OUTLOOK_SCOPES:
         assert scope in started_scopes
+
+
+# ---------------------------------------------------------------------------
+# The step driver — walks route.steps, narrates, traces, shape-checks.
+# ---------------------------------------------------------------------------
+
+
+def _device_code_steps():
+    return sr.steps_for(sr.MS_PERSONAL, sign_in=sr.SIGN_IN_DEVICE_CODE)
+
+
+def test_walks_every_device_code_step_in_order_and_skips_the_redirect_uri():
+    steps = _device_code_steps()
+    assert [s.id for s in steps] == [
+        "register",
+        "account_type",
+        "public_client_flows",
+        "permissions",
+        "client_id",
+    ]
+    agent = _FakeAgent(answers=["done", "done", "done", "done", _VALID_GUID])
+
+    collected, trace = sw.run_setup_walkthrough(agent, sr.MS_PERSONAL)
+
+    for step in steps:
+        assert any(step.title in m for m in agent.console.info)
+    # The redirect-URI step is loopback-only — never narrated on this route.
+    redirect_step = next(s for s in sr.MS_PERSONAL.steps if s.loopback_only)
+    assert not any(redirect_step.title in m for m in agent.console.info)
+    assert collected["client_id"] == _VALID_GUID
+
+
+def test_every_step_appends_a_trace_entry_never_claiming_unearned_verification():
+    agent = _FakeAgent(answers=["done", "done", "done", "done", _VALID_GUID])
+
+    _, trace = sw.run_setup_walkthrough(agent, sr.MS_PERSONAL)
+
+    steps = _device_code_steps()
+    assert [t["step_id"] for t in trace] == [s.id for s in steps]
+    for step, entry in zip(steps, trace):
+        if not step.verifiable:
+            assert entry["verified"] is False, entry
+    # The one verifiable step (client_id) IS traced verified once its shape
+    # check passes.
+    assert trace[-1] == {"step_id": "client_id", "verified": True}
+
+
+def test_cannot_see_portal_notice_is_said_exactly_once_at_the_first_step():
+    agent = _FakeAgent(answers=["done", "done", "done", "done", _VALID_GUID])
+
+    sw.run_setup_walkthrough(agent, sr.MS_PERSONAL)
+
+    mentions = [m for m in agent.console.info if "can't see your screen" in m]
+    assert len(mentions) == 1
+
+
+def test_client_id_shape_check_rejects_a_non_guid_without_echoing_it():
+    bogus = "not-even-close-to-a-guid"
+    agent = _FakeAgent(answers=["done", "done", "done", "done", bogus, _VALID_GUID])
+
+    collected, trace = sw.run_setup_walkthrough(agent, sr.MS_PERSONAL)
+
+    assert collected["client_id"] == _VALID_GUID
+    # The shape-check failure message is an AUTHORED CONSTANT — it must never
+    # echo back the value the user pasted (that is how a credential re-enters
+    # the transcript).
+    assert not any(bogus in m for m in agent.console.info)
+    assert any("doesn't look like an Application" in m for m in agent.console.info)
+
+
+def test_credential_prompt_never_offers_done_stuck_options():
+    """AC8 half: a credential ask is a plain free-text prompt, never the
+    navigation lane's Done/I'm-stuck options."""
+    agent = _FakeAgent(answers=["done", "done", "done", "done", _VALID_GUID])
+
+    sw.run_setup_walkthrough(agent, sr.MS_PERSONAL)
+
+    credential_call = agent.console.asked[-1]
+    assert credential_call["options"] == []
+    assert credential_call["allow_free_text"] is True
+
+
+def test_im_stuck_ends_the_walkthrough_honestly():
+    agent = _FakeAgent(answers=["done", "stuck"])
+
+    with pytest.raises(sw.WalkthroughStuck) as exc:
+        sw.run_setup_walkthrough(agent, sr.MS_PERSONAL)
+
+    assert exc.value.step.id == "account_type"
+    # No further steps were narrated past the one the user got stuck on.
+    later_titles = [s.title for s in _device_code_steps()[2:]]
+    assert not any(title in m for title in later_titles for m in agent.console.info)
+    # The exception's own message is what gets shown to the user (matching
+    # the existing _Declined pattern) — it must name the doc link and never
+    # improvise a substitute response.
+    assert "amd-gaia.ai" in str(exc.value)
+    assert "account_type" not in str(exc.value)  # the step's id, not its title

--- a/src/gaia/connectors/errors.py
+++ b/src/gaia/connectors/errors.py
@@ -49,6 +49,7 @@ class OAuthClientNotConfiguredError(ConfigurationError):
     ):
         self.provider_id = provider_id
         self.provider_label = provider_label
+        self.console_steps = console_steps
         super().__init__(
             self._build_message(
                 provider_id, provider_label, console_steps, docs, example

--- a/src/gaia/connectors/errors.py
+++ b/src/gaia/connectors/errors.py
@@ -214,3 +214,55 @@ class FlowTimeoutError(ConnectorsError):
 
 class FlowInProgressError(ConnectorsError):
     """Another OAuth flow is already pending; only one at a time is supported."""
+
+
+class OAuthProviderError(ConnectorsError):
+    """A provider's OAuth endpoint rejected a request, with a structured reason.
+
+    Replaces raising ``ConnectorsError`` with the entire unbounded
+    ``response.text`` interpolated into the message (the literal #2590 bug):
+    ``error`` / ``error_description`` are the RFC 6749 / AADSTS fields the
+    provider actually returned, each truncated so a malformed or oversized
+    body can never reach model context unbounded — see
+    ``flow.classify_oauth_exception``, which is the only code meant to
+    inspect these fields programmatically.
+    """
+
+    _MAX_FIELD_LEN = 300
+
+    def __init__(
+        self,
+        provider: str,
+        *,
+        error: str = "",
+        error_description: str = "",
+        status_code: int | None = None,
+    ):
+        self.provider = provider
+        self.error = (error or "")[: self._MAX_FIELD_LEN]
+        self.error_description = (error_description or "")[: self._MAX_FIELD_LEN]
+        self.status_code = status_code
+        detail = self.error_description or self.error or "no error detail returned"
+        status = f" ({status_code})" if status_code else ""
+        super().__init__(f"{provider} OAuth request was rejected{status}: {detail}")
+
+
+class GrantAfterConnectError(ConnectorsError):
+    """A connection was persisted but the agent grant that should follow it failed.
+
+    Deliberately its own type — never merged into a generic ``ConnectorsError``
+    — so a caller that must not echo an arbitrary exception's text (it might
+    carry a credential) can still tell apart "the connection itself is fine,
+    only the grant write failed" from every other failure, and report that
+    honestly instead of a blanket "nothing was changed." See
+    ``onboarding_tools._setup_mailbox_access``.
+    """
+
+    def __init__(self, provider: str, agent_id: str, *, reason: str):
+        self.provider = provider
+        self.agent_id = agent_id
+        self.reason = reason
+        super().__init__(
+            f"Connected {provider!r} but failed to grant it to agent "
+            f"{agent_id!r}: {reason}."
+        )

--- a/src/gaia/connectors/flow.py
+++ b/src/gaia/connectors/flow.py
@@ -47,6 +47,8 @@ from gaia.connectors.errors import (
     ConnectorsError,
     ConsentDeniedError,
     FlowTimeoutError,
+    GrantAfterConnectError,
+    OAuthProviderError,
 )
 from gaia.connectors.events import emit
 from gaia.connectors.pkce import compute_code_challenge, generate_code_verifier
@@ -417,12 +419,15 @@ async def _commit_grants(flow: _PendingFlow) -> None:
         try:
             grant_agent(flow.provider_id, agent_id, list(agent_scopes))
         except Exception as e:
-            raise ConnectorsError(
-                f"Connected {flow.provider_id!r} but failed to grant it to "
-                f"agent {agent_id!r}: {e}. The connection was saved; grant the "
-                f"agent manually from Settings → Connectors, or via "
-                f"`gaia connectors grants grant {flow.provider_id} {agent_id} "
-                f"--scopes {' '.join(agent_scopes)}`."
+            raise GrantAfterConnectError(
+                flow.provider_id,
+                agent_id,
+                reason=(
+                    f"{e}. The connection was saved; grant the agent manually "
+                    f"from Settings → Connectors, or via `gaia connectors "
+                    f"grants grant {flow.provider_id} {agent_id} --scopes "
+                    f"{' '.join(agent_scopes)}`"
+                ),
             ) from e
         await emit(
             "connector.grant.changed",
@@ -451,9 +456,20 @@ async def _exchange_code_for_tokens(flow: _PendingFlow, code: str) -> Dict[str, 
         response = await client.post(provider.token_url, data=body)
 
     if response.status_code != 200:
-        raise ConnectorsError(
-            f"Token exchange for {flow.provider_id} failed with status "
-            f"{response.status_code}: {response.text}. See docs/security/connections.mdx."
+        # Structured, bounded fields (#2590) — the previous behaviour
+        # interpolated the ENTIRE unbounded response.text into the message,
+        # so a caller that must not echo arbitrary exception text (it might
+        # ultimately carry provider-chosen content) had no way to report the
+        # failure at all short of a bare type name.
+        try:
+            err_payload = response.json()
+        except Exception:  # noqa: BLE001 — body may be empty/non-JSON
+            err_payload = {}
+        raise OAuthProviderError(
+            flow.provider_id,
+            error=err_payload.get("error", ""),
+            error_description=err_payload.get("error_description", response.text[:300]),
+            status_code=response.status_code,
         )
     payload = response.json()
     refresh_token = payload.get("refresh_token")
@@ -646,11 +662,18 @@ async def poll_device_flow(
                     f"Device-code sign-in for {provider_id} was declined."
                 )
             else:
-                raise ConnectorsError(
-                    f"Device-code polling for {provider_id} failed: "
-                    f"{err or resp.status_code}: "
-                    f"{err_payload.get('error_description', resp.text[:200])}. "
-                    "See docs/security/connections.mdx."
+                # Structured, bounded fields (#2590) — see OAuthProviderError.
+                # This is where an admin-consent-required rejection
+                # (AADSTS65001) actually surfaces during polling; a bare
+                # ConnectorsError with the response text glued in gave
+                # classify_oauth_exception nothing to inspect.
+                raise OAuthProviderError(
+                    provider_id,
+                    error=err,
+                    error_description=err_payload.get(
+                        "error_description", resp.text[:300]
+                    ),
+                    status_code=resp.status_code,
                 )
             if _time.monotonic() >= deadline:
                 raise FlowTimeoutError(
@@ -685,11 +708,14 @@ async def poll_device_flow(
             try:
                 grant_agent(provider_id, agent_id, list(agent_scopes))
             except Exception as e:
-                raise ConnectorsError(
-                    f"Connected {provider_id!r} via device code but failed to "
-                    f"grant it to agent {agent_id!r}: {e}. Grant it manually "
-                    f"with `gaia connectors grants grant {provider_id} "
-                    f"{agent_id} --scopes {' '.join(agent_scopes)}`."
+                raise GrantAfterConnectError(
+                    provider_id,
+                    agent_id,
+                    reason=(
+                        f"{e}. Grant it manually with `gaia connectors grants "
+                        f"grant {provider_id} {agent_id} --scopes "
+                        f"{' '.join(agent_scopes)}`"
+                    ),
                 ) from e
 
     await emit(
@@ -712,3 +738,57 @@ async def poll_device_flow(
         "scopes": scopes_list,
         "connected_at": _time.time(),
     }
+
+
+# ---------------------------------------------------------------------------
+# Classification (#2590) — turn a raised OAuth failure into "which setup step
+# to redo", never into raw provider text reaching model context.
+# ---------------------------------------------------------------------------
+
+#: Marker Microsoft uses for "this account's tenant requires an admin to
+#: approve the app" — the one AADSTS code this route can actually produce
+#: (see setup_routes.MS_PERSONAL's public_client_flows / permissions steps).
+_ADMIN_CONSENT_MARKER = "AADSTS65001"
+
+
+def classify_oauth_exception(exc: Exception) -> tuple[str, str]:
+    """Classify a raised OAuth failure into ``(category, guidance)``.
+
+    ``category`` is one of ``authorization_declined``, ``expired_token``,
+    ``access_denied``, ``admin_consent_required``, or ``unrecognized``.
+    ``guidance`` names the setup step to redo where one is known.
+
+    Classifies ONLY what this route can actually produce (#2590 design §6) —
+    anything else is reported from ``OAuthProviderError``'s own BOUNDED
+    ``error`` / ``error_description`` fields, never ``str(exc)``: a provider
+    error body is not something GAIA generates, so nothing here may assume
+    it is safe to echo unbounded.
+    """
+    if isinstance(exc, ConsentDeniedError):
+        return "authorization_declined", (
+            "Sign-in was declined at the consent screen. Redo the sign-in "
+            "step and approve the requested permissions."
+        )
+    if isinstance(exc, FlowTimeoutError):
+        return "expired_token", (
+            "The sign-in code expired before it was approved. Redo the "
+            "sign-in step and enter the code promptly."
+        )
+    if isinstance(exc, OAuthProviderError):
+        error = exc.error
+        description = exc.error_description
+        if error == "access_denied":
+            return "access_denied", (
+                "Access was denied. Redo the sign-in step and approve the "
+                "requested permissions."
+            )
+        if error == "admin_consent_required" or _ADMIN_CONSENT_MARKER in description:
+            return "admin_consent_required", (
+                "This account's organization requires an administrator to "
+                "approve the app before it can sign in. Redo the "
+                "permissions step with an account that can grant consent, "
+                "or ask an administrator to approve it."
+            )
+        bounded = description or error or "no further detail was returned"
+        return "unrecognized", f"The provider rejected the request: {bounded}"
+    return "unrecognized", "The sign-in failed for an unrecognized reason."

--- a/src/gaia/connectors/providers/microsoft.py
+++ b/src/gaia/connectors/providers/microsoft.py
@@ -38,6 +38,7 @@ from typing import Iterable, Sequence
 from urllib.parse import urlencode
 
 from gaia.connectors.errors import OAuthClientNotConfiguredError
+from gaia.connectors.setup_routes import MS_PERSONAL, render_console_steps
 
 # Default login tenant. ``common`` accepts personal AND work/school accounts.
 # Overridable via GAIA_MICROSOFT_TENANT (a single-tenant Entra id, or
@@ -159,18 +160,12 @@ class MicrosoftOAuthProvider:
             raise OAuthClientNotConfiguredError(
                 "microsoft",
                 provider_label="Microsoft",
-                console_steps=(
-                    "  1. Register an app at https://portal.azure.com -> "
-                    "Microsoft Entra ID -> App registrations\n"
-                    "  2. Set the supported account type to 'any account' "
-                    "('common' audience — personal + work/school), and add a "
-                    "http://localhost redirect URI under Authentication -> "
-                    "Mobile & desktop applications\n"
-                    "  3. Add the Microsoft Graph delegated permissions you need "
-                    "(e.g. Mail.ReadWrite, Mail.Send, Calendars.ReadWrite)\n"
-                    "  4. Copy the Application (client) ID — this is a public "
-                    "(PKCE) client, so no client secret is needed"
-                ),
+                # Derived from setup_routes.MS_PERSONAL — the SAME steps drive
+                # the interactive guided walkthrough (#2590). Five hand-copies
+                # of this walkthrough have drifted apart in production before
+                # (#2116: a missing enable-APIs step produced a 403 on first
+                # use); rendering from one source is how that stops recurring.
+                console_steps=render_console_steps(MS_PERSONAL),
                 example=(
                     "  For the email agent, copy-paste (bash) after creating the "
                     "client above:\n"

--- a/src/gaia/connectors/setup_routes.py
+++ b/src/gaia/connectors/setup_routes.py
@@ -192,6 +192,27 @@ MS_PERSONAL = SetupRoute(
             ),
             verifiable=True,
             collects_credential=True,
+            faq=(
+                # The Overview blade shows THREE GUIDs side by side — a
+                # shape check alone can't tell them apart, and pasting the
+                # wrong one passes validation cleanly, then fails later in a
+                # way that points nowhere near the real mistake.
+                QA(
+                    question_hints=(
+                        "which id",
+                        "three",
+                        "tenant",
+                        "object",
+                        "directory",
+                    ),
+                    answer=(
+                        "The Overview page shows three GUIDs — copy the one "
+                        "labeled 'Application (client) ID'. The other two, "
+                        "'Object ID' and 'Directory (tenant) ID', look the "
+                        "same shape but are not what I need here."
+                    ),
+                ),
+            ),
         ),
     ),
     faq=(

--- a/src/gaia/connectors/setup_routes.py
+++ b/src/gaia/connectors/setup_routes.py
@@ -57,6 +57,14 @@ class Step:
     #: must never be re-issued with ``allow_free_text=False`` on an
     #: options-less prompt, and must never receive the FAQ lane at all.
     collects_credential: bool = False
+    #: True for a step that ONLY the browser-loopback sign-in needs (e.g. a
+    #: redirect URI). The device-code grant (RFC 8628) has no redirect at
+    #: all — sending a device-code user through a redirect-URI step is not
+    #: harmless filler, it is a wasted step this feature exists to remove.
+    #: ``render_console_steps(sign_in="device_code")`` and the interactive
+    #: walkthrough driver both filter these out; the CLI-facing rendering
+    #: (``sign_in="loopback"``, the default) keeps them.
+    loopback_only: bool = False
     faq: Tuple[QA, ...] = ()
 
 
@@ -73,11 +81,21 @@ class SetupRoute:
 # ---------------------------------------------------------------------------
 # Microsoft — personal + work/school (the ``common`` tenant)
 # ---------------------------------------------------------------------------
-# Step instructions are the SAME text as the four steps previously
-# hand-maintained in ``providers.microsoft.OAuthClientNotConfiguredError``'s
-# ``console_steps`` — that field is now derived from this route via
-# ``render_console_steps`` (see ``providers/microsoft.py``), so the two
-# cannot drift the way five earlier copies did (#2116).
+# ``providers.microsoft.OAuthClientNotConfiguredError``'s ``console_steps`` is
+# derived from this route via ``render_console_steps`` (see
+# ``providers/microsoft.py``), so the CLI-facing text and the interactive
+# walkthrough cannot drift the way five earlier hand-copies did (#2116).
+#
+# The device-code grant (RFC 8628) — the sign-in this PR wires up — has no
+# redirect at all, so ``redirect_uri`` is ``loopback_only``: the interactive
+# walkthrough must never send a device-code user to configure it. It DOES
+# need the app marked as a public client (``public_client_flows``), which the
+# Authentication -> Mobile & desktop platform also sets as a side effect —
+# but relying on that side effect silently is how a registration that skips
+# it fails device code with ``AADSTS7000218`` ("client_secret is required"),
+# a spectacularly confusing error for a route that has no secret. Naming it
+# as its own step makes it a step GAIA can actually walk the user through
+# instead of an implicit side effect of a different one.
 
 MS_PERSONAL = SetupRoute(
     id="ms_personal",
@@ -104,15 +122,45 @@ MS_PERSONAL = SetupRoute(
             ),
         ),
         Step(
-            id="account_type_redirect",
-            title="Set the account type and redirect URI",
+            id="account_type",
+            title="Set the supported account type",
             instruction=(
                 "Set the supported account type to 'any account' ('common' "
-                "audience — personal + work/school), and add a "
-                "http://localhost redirect URI under Authentication -> "
+                "audience — personal + work/school)"
+            ),
+            verifiable=False,
+        ),
+        Step(
+            id="redirect_uri",
+            title="Add a redirect URI",
+            instruction=(
+                "Add a http://localhost redirect URI under Authentication -> "
                 "Mobile & desktop applications"
             ),
             verifiable=False,
+            loopback_only=True,
+        ),
+        Step(
+            id="public_client_flows",
+            title="Allow public client flows",
+            instruction=(
+                "Turn on 'Allow public client flows' under Authentication -> "
+                "Advanced settings — this marks the app as a public client, "
+                "which is what lets you sign in with a short code instead of "
+                "a client secret"
+            ),
+            verifiable=False,
+            faq=(
+                QA(
+                    question_hints=("why", "what does this do", "public client"),
+                    answer=(
+                        "It tells Microsoft this app can't keep a secret safe "
+                        "(it runs on your machine, not a server), so sign-in "
+                        "uses a short code instead — the same reason GAIA "
+                        "never asks you for one."
+                    ),
+                ),
+            ),
         ),
         Step(
             id="permissions",
@@ -163,6 +211,12 @@ MS_PERSONAL = SetupRoute(
 #: module docstring for why the other routes are out of scope.
 ROUTES: Dict[str, SetupRoute] = {"microsoft": MS_PERSONAL}
 
+#: Sign-in mechanisms ``render_console_steps`` and the walkthrough driver
+#: know how to filter for.
+SIGN_IN_LOOPBACK = "loopback"
+SIGN_IN_DEVICE_CODE = "device_code"
+_VALID_SIGN_INS = (SIGN_IN_LOOPBACK, SIGN_IN_DEVICE_CODE)
+
 
 def get_route(provider: str) -> Optional[SetupRoute]:
     """Return the guided walkthrough for *provider*, or ``None`` if it has none.
@@ -174,7 +228,24 @@ def get_route(provider: str) -> Optional[SetupRoute]:
     return ROUTES.get(provider)
 
 
-def render_console_steps(route: SetupRoute) -> str:
+def steps_for(
+    route: SetupRoute, *, sign_in: str = SIGN_IN_LOOPBACK
+) -> Tuple[Step, ...]:
+    """Return *route*'s steps filtered for *sign_in*.
+
+    ``sign_in="device_code"`` drops every ``loopback_only`` step (a redirect
+    URI the device-code grant never uses); ``sign_in="loopback"`` (the
+    default) keeps everything — the CLI-facing text covers whichever route
+    the user ends up taking.
+    """
+    if sign_in not in _VALID_SIGN_INS:
+        raise ValueError(f"sign_in must be one of {_VALID_SIGN_INS}, got {sign_in!r}")
+    if sign_in == SIGN_IN_DEVICE_CODE:
+        return tuple(s for s in route.steps if not s.loopback_only)
+    return route.steps
+
+
+def render_console_steps(route: SetupRoute, *, sign_in: str = SIGN_IN_LOOPBACK) -> str:
     """Render *route*'s steps as the numbered plain-text block used in
     ``OAuthClientNotConfiguredError.console_steps`` — the CLI-facing error a
     user sees before any interactive walkthrough is even possible.
@@ -182,8 +253,9 @@ def render_console_steps(route: SetupRoute) -> str:
     This is the single rendering function for that text; nothing else may
     hand-maintain a second copy of it (see the module docstring).
     """
+    steps = steps_for(route, sign_in=sign_in)
     return "\n".join(
-        f"  {i}. {step.instruction}" for i, step in enumerate(route.steps, start=1)
+        f"  {i}. {step.instruction}" for i, step in enumerate(steps, start=1)
     )
 
 
@@ -191,8 +263,11 @@ __all__ = [
     "QA",
     "MS_PERSONAL",
     "ROUTES",
+    "SIGN_IN_DEVICE_CODE",
+    "SIGN_IN_LOOPBACK",
     "SetupRoute",
     "Step",
     "get_route",
     "render_console_steps",
+    "steps_for",
 ]

--- a/src/gaia/connectors/setup_routes.py
+++ b/src/gaia/connectors/setup_routes.py
@@ -1,0 +1,198 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""Authored setup-walkthrough content for guided mailbox onboarding (#2590).
+
+The problem this replaces: connecting Outlook meant sending someone to
+Microsoft's developer portal with a single paragraph of instructions and no
+way to tell whether they actually got it right. This module is the single
+source of truth for what the walkthrough says, step by step, so the content
+lives in ONE place — not duplicated across the OAuth-not-configured error
+message, a docs page, and an agent prompt that could each drift.
+
+**Outlook only.** This is a deliberate scope cut (#2590 adversarial review):
+``google_personal`` and every other route earn their own PR. ``ROUTES`` has
+exactly one entry.
+
+No ``resolve_route`` / interview function here — the provider alone selects
+the route (``ROUTES[provider]``), because the only question that decides it
+("Gmail or Outlook?") is already asked elsewhere
+(``onboarding_tools._choose_provider``). A provider with no route must get a
+defined, user-legible answer from ``get_route`` (``None``) — never a
+``KeyError`` — so a caller can render "no guided walkthrough yet" instead of
+crashing.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, Optional, Tuple
+
+
+@dataclass(frozen=True)
+class QA:
+    """One authored FAQ answer, matched by keyword against a free-text question.
+
+    ``answer`` is emitted to the user VERBATIM — the walkthrough driver must
+    never paraphrase, prepend, or otherwise compose it. That is what keeps a
+    small local model from inventing setup guidance.
+    """
+
+    question_hints: Tuple[str, ...]
+    answer: str
+
+
+@dataclass(frozen=True)
+class Step:
+    """One step of a guided setup walkthrough."""
+
+    id: str
+    title: str
+    instruction: str
+    #: Whether GAIA can check this step actually succeeded (offline shape
+    #: check or a live probe) rather than taking the user's word for it.
+    verifiable: bool
+    #: Whether this step's answer is a credential, not a navigation choice.
+    #: Gates the free-text FAQ lane off entirely (see
+    #: ``gaia_agent_email.tools.setup_walkthrough``) — a credential prompt
+    #: must never be re-issued with ``allow_free_text=False`` on an
+    #: options-less prompt, and must never receive the FAQ lane at all.
+    collects_credential: bool = False
+    faq: Tuple[QA, ...] = ()
+
+
+@dataclass(frozen=True)
+class SetupRoute:
+    """A complete guided walkthrough for one provider."""
+
+    id: str
+    provider: str
+    steps: Tuple[Step, ...]
+    faq: Tuple[QA, ...] = ()
+
+
+# ---------------------------------------------------------------------------
+# Microsoft — personal + work/school (the ``common`` tenant)
+# ---------------------------------------------------------------------------
+# Step instructions are the SAME text as the four steps previously
+# hand-maintained in ``providers.microsoft.OAuthClientNotConfiguredError``'s
+# ``console_steps`` — that field is now derived from this route via
+# ``render_console_steps`` (see ``providers/microsoft.py``), so the two
+# cannot drift the way five earlier copies did (#2116).
+
+MS_PERSONAL = SetupRoute(
+    id="ms_personal",
+    provider="microsoft",
+    steps=(
+        Step(
+            id="register",
+            title="Register an app",
+            instruction=(
+                "Register an app at https://portal.azure.com -> Microsoft "
+                "Entra ID -> App registrations"
+            ),
+            verifiable=False,
+            faq=(
+                QA(
+                    question_hints=("sign in", "which account", "microsoft account"),
+                    answer=(
+                        "Use whichever Microsoft account you want to sign in "
+                        "with when you connect the mailbox — it doesn't have "
+                        "to be a special admin account for a personal "
+                        "Outlook.com sign-in."
+                    ),
+                ),
+            ),
+        ),
+        Step(
+            id="account_type_redirect",
+            title="Set the account type and redirect URI",
+            instruction=(
+                "Set the supported account type to 'any account' ('common' "
+                "audience — personal + work/school), and add a "
+                "http://localhost redirect URI under Authentication -> "
+                "Mobile & desktop applications"
+            ),
+            verifiable=False,
+        ),
+        Step(
+            id="permissions",
+            title="Add the Microsoft Graph permissions",
+            instruction=(
+                "Add the Microsoft Graph delegated permissions you need "
+                "(e.g. Mail.ReadWrite, Mail.Send, Calendars.ReadWrite)"
+            ),
+            verifiable=False,
+            faq=(
+                QA(
+                    question_hints=("admin consent", "grant consent", "why"),
+                    answer=(
+                        "Not for a personal account — these are delegated "
+                        "permissions, so you approve them yourself the first "
+                        "time you sign in. Admin consent only comes up on a "
+                        "work/school tenant whose administrator has locked "
+                        "down app consent."
+                    ),
+                ),
+            ),
+        ),
+        Step(
+            id="client_id",
+            title="Copy the Application (client) ID",
+            instruction=(
+                "Copy the Application (client) ID — this is a public (PKCE) "
+                "client, so no client secret is needed"
+            ),
+            verifiable=True,
+            collects_credential=True,
+        ),
+    ),
+    faq=(
+        QA(
+            question_hints=("client secret", "secret"),
+            answer=(
+                "No — this app registration is a public client (PKCE), and "
+                "Microsoft's own rules say a public client must never send a "
+                "client secret. GAIA only needs the Application (client) ID "
+                "you copy in the last step."
+            ),
+        ),
+    ),
+)
+
+#: Provider id -> its guided walkthrough. Outlook only in this PR — see the
+#: module docstring for why the other routes are out of scope.
+ROUTES: Dict[str, SetupRoute] = {"microsoft": MS_PERSONAL}
+
+
+def get_route(provider: str) -> Optional[SetupRoute]:
+    """Return the guided walkthrough for *provider*, or ``None`` if it has none.
+
+    Never raises — a provider with no route is a normal, expected case (every
+    provider except Microsoft, today), and the caller renders a defined
+    "no guided walkthrough yet" response rather than crashing.
+    """
+    return ROUTES.get(provider)
+
+
+def render_console_steps(route: SetupRoute) -> str:
+    """Render *route*'s steps as the numbered plain-text block used in
+    ``OAuthClientNotConfiguredError.console_steps`` — the CLI-facing error a
+    user sees before any interactive walkthrough is even possible.
+
+    This is the single rendering function for that text; nothing else may
+    hand-maintain a second copy of it (see the module docstring).
+    """
+    return "\n".join(
+        f"  {i}. {step.instruction}" for i, step in enumerate(route.steps, start=1)
+    )
+
+
+__all__ = [
+    "QA",
+    "MS_PERSONAL",
+    "ROUTES",
+    "SetupRoute",
+    "Step",
+    "get_route",
+    "render_console_steps",
+]

--- a/tests/unit/connectors/test_microsoft_provider.py
+++ b/tests/unit/connectors/test_microsoft_provider.py
@@ -92,6 +92,27 @@ class TestRegistry:
         assert "Settings" in msg
         assert "Connections" in msg
 
+    def test_console_steps_do_not_diverge_from_the_guided_walkthrough(
+        self, monkeypatch
+    ):
+        """#2116 canonical failure: a hand-copied console-steps walkthrough
+        drifted from reality and produced a 403 on first use. console_steps
+        must be DERIVED from setup_routes.MS_PERSONAL, not a second copy of
+        it — assert the exception's steps and the route's steps agree."""
+        from gaia.connectors.errors import OAuthClientNotConfiguredError
+        from gaia.connectors.setup_routes import MS_PERSONAL, render_console_steps
+
+        monkeypatch.delenv("GAIA_MICROSOFT_CLIENT_ID", raising=False)
+        monkeypatch.delenv("GAIA_MICROSOFT_CLIENT_SECRET", raising=False)
+        with pytest.raises(OAuthClientNotConfiguredError) as exc:
+            providers.get("microsoft")
+
+        assert exc.value.console_steps == render_console_steps(MS_PERSONAL)
+        # And every step's actual instruction text is present verbatim — not
+        # just an independently-worded summary that happens to be 4 lines too.
+        for step in MS_PERSONAL.steps:
+            assert step.instruction in exc.value.console_steps
+
     def test_microsoft_loads_from_keyring_without_env(self, monkeypatch):
         from gaia.connectors.store import save_provider_credentials
 

--- a/tests/unit/connectors/test_microsoft_provider.py
+++ b/tests/unit/connectors/test_microsoft_provider.py
@@ -108,10 +108,26 @@ class TestRegistry:
             providers.get("microsoft")
 
         assert exc.value.console_steps == render_console_steps(MS_PERSONAL)
-        # And every step's actual instruction text is present verbatim — not
-        # just an independently-worded summary that happens to be 4 lines too.
+        # The CLI-facing text is explicitly the LOOPBACK rendering (covers
+        # whichever route the user ends up taking) — pin that explicitly, not
+        # just the default, so a default-flip can't silently change which
+        # steps a CLI user sees.
+        assert exc.value.console_steps == render_console_steps(
+            MS_PERSONAL, sign_in="loopback"
+        )
+        # Every LOOPBACK step's instruction text is present verbatim — not
+        # just an independently-worded summary that happens to match.
         for step in MS_PERSONAL.steps:
             assert step.instruction in exc.value.console_steps
+        # And the device-code rendering must genuinely differ: it drops the
+        # loopback-only redirect-URI step device code never uses (#2590) —
+        # the console text and the guided walkthrough are two DIFFERENT
+        # (but both route-derived) renderings, not one flat unfiltered dump.
+        device_rendering = render_console_steps(MS_PERSONAL, sign_in="device_code")
+        assert device_rendering != exc.value.console_steps
+        redirect_step = next(s for s in MS_PERSONAL.steps if s.loopback_only)
+        assert redirect_step.instruction not in device_rendering
+        assert redirect_step.instruction in exc.value.console_steps
 
     def test_microsoft_loads_from_keyring_without_env(self, monkeypatch):
         from gaia.connectors.store import save_provider_credentials

--- a/tests/unit/connectors/test_oauth_error_classification.py
+++ b/tests/unit/connectors/test_oauth_error_classification.py
@@ -1,0 +1,237 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""Structured OAuth failures + their classification (#2590).
+
+Before this, ``flow.py`` raised ``ConnectorsError`` with the ENTIRE unbounded
+``response.text`` interpolated into the message, with no JSON parse — no
+exception in the codebase exposed ``error`` / ``error_description`` as
+fields a caller could inspect without risking that raw text (which could,
+in principle, carry anything the provider chose to send back) reaching
+model context via ``str(exc)``.
+
+Every exception used here is built the SAME WAY ``flow.py`` builds it — via
+the real ``start_device_flow`` / ``poll_device_flow`` coroutines against a
+mocked HTTP layer — never hand-fed as a bare tuple. A classifier tested only
+against synthetic tuples would be unit-green and production-blind to a real
+response shape it never saw.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from gaia.connectors import flow as flow_mod
+from gaia.connectors.errors import (
+    ConnectorsError,
+    ConsentDeniedError,
+    FlowTimeoutError,
+    OAuthProviderError,
+)
+from gaia.connectors.flow import classify_oauth_exception
+
+MAIL_READ = "https://graph.microsoft.com/Mail.Read"
+
+
+@pytest.fixture(autouse=True)
+def _ms_env(monkeypatch):
+    monkeypatch.setenv("GAIA_MICROSOFT_CLIENT_ID", "test-client-id")
+    monkeypatch.delenv("GAIA_MICROSOFT_CLIENT_SECRET", raising=False)
+    monkeypatch.delenv("GAIA_MICROSOFT_TENANT", raising=False)
+    from gaia.connectors import providers
+
+    providers._registry.clear()
+    yield
+    providers._registry.clear()
+
+
+@pytest.fixture(autouse=True)
+def _instant_sleep(monkeypatch):
+    async def _no_wait(_seconds):
+        return None
+
+    monkeypatch.setattr(flow_mod.asyncio, "sleep", _no_wait)
+
+
+class _FakeResp:
+    def __init__(self, status_code, payload=None, text=""):
+        self.status_code = status_code
+        self._payload = payload
+        self.text = text
+
+    def json(self):
+        if self._payload is None:
+            raise ValueError("no json body")
+        return self._payload
+
+
+class _FakeAsyncClient:
+    _queue: list = []
+
+    def __init__(self, *args, **kwargs):
+        pass
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc):
+        return False
+
+    async def post(self, url, data=None, **kwargs):
+        return _FakeAsyncClient._queue.pop(0)
+
+
+def _install_responses(monkeypatch, responses):
+    _FakeAsyncClient._queue = list(responses)
+    monkeypatch.setattr(flow_mod.httpx, "AsyncClient", _FakeAsyncClient)
+
+
+# ---------------------------------------------------------------------------
+# Real exceptions, built the way flow.py builds them.
+# ---------------------------------------------------------------------------
+
+
+def test_declined_device_signin_classifies_as_authorization_declined(monkeypatch):
+    _install_responses(
+        monkeypatch, [_FakeResp(400, {"error": "authorization_declined"})]
+    )
+    with pytest.raises(ConsentDeniedError) as exc:
+        asyncio.run(flow_mod.poll_device_flow("microsoft", "DEV", scopes=[MAIL_READ]))
+
+    category, guidance = classify_oauth_exception(exc.value)
+    assert category == "authorization_declined"
+    assert "sign-in" in guidance.lower() or "consent" in guidance.lower()
+
+
+def test_expired_device_code_classifies_as_expired_token(monkeypatch):
+    _install_responses(monkeypatch, [_FakeResp(400, {"error": "expired_token"})])
+    with pytest.raises(FlowTimeoutError) as exc:
+        asyncio.run(flow_mod.poll_device_flow("microsoft", "DEV", scopes=[MAIL_READ]))
+
+    category, guidance = classify_oauth_exception(exc.value)
+    assert category == "expired_token"
+    assert "expired" in guidance.lower()
+
+
+def test_unrecognized_device_poll_error_raises_a_structured_exception(monkeypatch):
+    """The bug this replaces: a bare ConnectorsError with the full response
+    body interpolated — no structured error/error_description a caller could
+    inspect without str(exc)."""
+    _install_responses(
+        monkeypatch,
+        [
+            _FakeResp(
+                400,
+                {
+                    "error": "invalid_grant",
+                    "error_description": "AADSTS65001: the user or administrator "
+                    "has not consented to use the application",
+                },
+            )
+        ],
+    )
+    with pytest.raises(OAuthProviderError) as exc:
+        asyncio.run(flow_mod.poll_device_flow("microsoft", "DEV", scopes=[MAIL_READ]))
+
+    assert exc.value.error == "invalid_grant"
+    assert "AADSTS65001" in exc.value.error_description
+    # Still a ConnectorsError — existing `except ConnectorsError` callers
+    # (onboarding_tools, the CLI) keep working unchanged.
+    assert isinstance(exc.value, ConnectorsError)
+
+
+def test_admin_consent_required_names_the_permissions_step(monkeypatch):
+    _install_responses(
+        monkeypatch,
+        [
+            _FakeResp(
+                400,
+                {
+                    "error": "invalid_grant",
+                    "error_description": "AADSTS65001: admin consent required",
+                },
+            )
+        ],
+    )
+    with pytest.raises(OAuthProviderError) as exc:
+        asyncio.run(flow_mod.poll_device_flow("microsoft", "DEV", scopes=[MAIL_READ]))
+
+    category, guidance = classify_oauth_exception(exc.value)
+    assert category == "admin_consent_required"
+    assert "permission" in guidance.lower() or "consent" in guidance.lower()
+
+
+def test_unrecognized_reason_reports_only_bounded_fields_never_str_exc(monkeypatch):
+    """A provider error the classifier does not recognise must still never
+    leak the exception's raw, unbounded message text — only the structured
+    (and length-bounded) fields."""
+    huge_body = "x" * 5000
+    _install_responses(
+        monkeypatch,
+        [_FakeResp(400, {"error": "server_error", "error_description": huge_body})],
+    )
+    with pytest.raises(OAuthProviderError) as exc:
+        asyncio.run(flow_mod.poll_device_flow("microsoft", "DEV", scopes=[MAIL_READ]))
+
+    category, guidance = classify_oauth_exception(exc.value)
+    assert category == "unrecognized"
+    # The exception's OWN fields are bounded...
+    assert len(exc.value.error_description) < 1000
+    # ...and the guidance text is built from those bounded fields, never the
+    # raw 5000-char body.
+    assert len(guidance) < 1000
+
+
+def test_loopback_token_exchange_failure_is_structured_not_raw_text(monkeypatch):
+    """flow.py's OTHER raise site (the browser/loopback exchange) gets the
+    same treatment — this was the literally-named bug location."""
+    from gaia.connectors.flow import _PendingFlow
+
+    class _FakeClient:
+        def __init__(self, *a, **k):
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *exc):
+            return False
+
+        async def post(self, url, data=None, **kwargs):
+            return _FakeResp(
+                400,
+                {"error": "invalid_grant", "error_description": "code expired"},
+                text="raw unbounded body should never be interpolated here",
+            )
+
+    monkeypatch.setattr(flow_mod.httpx, "AsyncClient", _FakeClient)
+
+    class _Prov:
+        provider_id = "microsoft"
+        token_url = "https://example/token"
+        client_id_hash = "abc"
+
+        def token_request_body(self, **kw):
+            return {}
+
+    monkeypatch.setattr(flow_mod, "get_provider", lambda pid: _Prov())
+
+    async def _run():
+        flow = _PendingFlow(
+            flow_id="f1",
+            provider_id="microsoft",
+            scopes=[MAIL_READ],
+            code_verifier="v",
+            state="s",
+            redirect_uri="http://127.0.0.1/callback",
+            runner=None,
+            future=asyncio.get_event_loop().create_future(),
+        )
+        await flow_mod._exchange_code_for_tokens(flow, "code")
+
+    with pytest.raises(OAuthProviderError) as exc:
+        asyncio.run(_run())
+
+    assert exc.value.error == "invalid_grant"
+    assert exc.value.error_description == "code expired"

--- a/tests/unit/connectors/test_setup_routes.py
+++ b/tests/unit/connectors/test_setup_routes.py
@@ -35,14 +35,30 @@ def test_route_has_exactly_one_credential_collecting_step():
     assert credential_steps[0].id == "client_id"
 
 
-def test_no_step_or_route_faq_mentions_a_client_secret_as_required():
+_SECRET_REQUIRED_PHRASES = (
+    "you need a secret",
+    "you'll need a secret",
+    "you need a client secret",
+    "you'll need a client secret",
+    "requires a secret",
+    "requires a client secret",
+    "must provide a secret",
+    "must provide a client secret",
+)
+
+
+def test_no_step_or_route_faq_ever_says_a_secret_is_required():
     """Microsoft's route is public PKCE — the walkthrough must never suggest
-    the user needs a secret, even in FAQ answers."""
-    for step in sr.MS_PERSONAL.steps:
-        for qa in step.faq:
-            assert "client secret" not in qa.answer.lower()
-    for qa in sr.MS_PERSONAL.faq:
-        assert "you need" not in qa.answer.lower() or "secret" not in qa.answer.lower()
+    the user needs a secret, even in FAQ answers. Truthfully reassuring that
+    NO secret is needed is fine and expected (plan's lifted constraint) —
+    only a claim that one IS required is the bug."""
+    all_faqs = [qa for step in sr.MS_PERSONAL.steps for qa in step.faq]
+    all_faqs += list(sr.MS_PERSONAL.faq)
+    assert all_faqs, "expected at least one authored FAQ answer to check"
+    for qa in all_faqs:
+        answer = qa.answer.lower()
+        for phrase in _SECRET_REQUIRED_PHRASES:
+            assert phrase not in answer, (qa.answer, phrase)
 
 
 def test_steps_are_immutable():
@@ -70,3 +86,51 @@ def test_console_steps_text_matches_each_step_instruction_verbatim():
     rendered = sr.render_console_steps(sr.MS_PERSONAL)
     for step in sr.MS_PERSONAL.steps:
         assert step.instruction in rendered
+
+
+# ---------------------------------------------------------------------------
+# Device-code (RFC 8628) has no redirect — the walkthrough must not send a
+# device-code user to configure one, but the CLI-facing text (which covers
+# whichever route the user takes) keeps it.
+# ---------------------------------------------------------------------------
+
+
+def test_route_has_exactly_one_loopback_only_step_the_redirect_uri():
+    loopback_only = [s for s in sr.MS_PERSONAL.steps if s.loopback_only]
+    assert len(loopback_only) == 1
+    assert loopback_only[0].id == "redirect_uri"
+
+
+def test_device_code_rendering_drops_the_redirect_uri_step():
+    device_rendering = sr.render_console_steps(
+        sr.MS_PERSONAL, sign_in=sr.SIGN_IN_DEVICE_CODE
+    )
+    redirect_step = next(s for s in sr.MS_PERSONAL.steps if s.loopback_only)
+    assert redirect_step.instruction not in device_rendering
+
+
+def test_loopback_rendering_is_the_default_and_keeps_the_redirect_uri():
+    default_rendering = sr.render_console_steps(sr.MS_PERSONAL)
+    loopback_rendering = sr.render_console_steps(
+        sr.MS_PERSONAL, sign_in=sr.SIGN_IN_LOOPBACK
+    )
+    redirect_step = next(s for s in sr.MS_PERSONAL.steps if s.loopback_only)
+    assert default_rendering == loopback_rendering
+    assert redirect_step.instruction in default_rendering
+
+
+def test_device_code_route_has_an_explicit_public_client_flows_step():
+    """Relying on 'adding a Mobile & desktop platform sets this implicitly'
+    is how a registration that skips it fails device code with the
+    confusing AADSTS7000218 ('client_secret is required') — name the step."""
+    steps = sr.steps_for(sr.MS_PERSONAL, sign_in=sr.SIGN_IN_DEVICE_CODE)
+    ids = [s.id for s in steps]
+    assert "public_client_flows" in ids
+    assert "redirect_uri" not in ids
+
+
+def test_steps_for_rejects_an_unknown_sign_in_mechanism():
+    import pytest
+
+    with pytest.raises(ValueError):
+        sr.steps_for(sr.MS_PERSONAL, sign_in="carrier-pigeon")

--- a/tests/unit/connectors/test_setup_routes.py
+++ b/tests/unit/connectors/test_setup_routes.py
@@ -1,0 +1,72 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""Authored setup-walkthrough content (#2590) — Outlook only, this PR.
+
+Two things are worth defending:
+
+1. There is exactly one source of truth for the Microsoft console walkthrough
+   text. Five copies of this walkthrough have drifted apart in production
+   once already (#2116: a missing enable-APIs step produced a 403 on first
+   use) — the guard here asserts the two never diverge again.
+2. Route lookup fails safely: an unknown provider returns ``None``, never a
+   crash, so callers can render a defined "no guided walkthrough yet"
+   response instead.
+"""
+
+from __future__ import annotations
+
+from gaia.connectors import setup_routes as sr
+
+
+def test_microsoft_route_is_registered():
+    assert sr.get_route("microsoft") is sr.MS_PERSONAL
+    assert sr.ROUTES["microsoft"] is sr.MS_PERSONAL
+
+
+def test_unknown_provider_returns_none_not_a_crash():
+    assert sr.get_route("google") is None
+    assert sr.get_route("does-not-exist") is None
+
+
+def test_route_has_exactly_one_credential_collecting_step():
+    """The Microsoft client ID — never a secret (this is the whole point)."""
+    credential_steps = [s for s in sr.MS_PERSONAL.steps if s.collects_credential]
+    assert len(credential_steps) == 1
+    assert credential_steps[0].id == "client_id"
+
+
+def test_no_step_or_route_faq_mentions_a_client_secret_as_required():
+    """Microsoft's route is public PKCE — the walkthrough must never suggest
+    the user needs a secret, even in FAQ answers."""
+    for step in sr.MS_PERSONAL.steps:
+        for qa in step.faq:
+            assert "client secret" not in qa.answer.lower()
+    for qa in sr.MS_PERSONAL.faq:
+        assert "you need" not in qa.answer.lower() or "secret" not in qa.answer.lower()
+
+
+def test_steps_are_immutable():
+    import dataclasses
+
+    assert dataclasses.is_dataclass(sr.Step)
+    step = sr.MS_PERSONAL.steps[0]
+    try:
+        step.title = "changed"
+    except dataclasses.FrozenInstanceError:
+        pass
+    else:
+        raise AssertionError("Step must be frozen")
+
+
+def test_render_console_steps_numbers_every_step_in_order():
+    rendered = sr.render_console_steps(sr.MS_PERSONAL)
+    lines = rendered.split("\n  ")
+    # First line keeps its leading spaces from the join; strip for the check.
+    numbers = [ln.split(".", 1)[0].strip() for ln in rendered.strip().split("\n")]
+    assert numbers == [str(i + 1) for i in range(len(sr.MS_PERSONAL.steps))]
+
+
+def test_console_steps_text_matches_each_step_instruction_verbatim():
+    rendered = sr.render_console_steps(sr.MS_PERSONAL)
+    for step in sr.MS_PERSONAL.steps:
+        assert step.instruction in rendered


### PR DESCRIPTION
Part of #2590. The Gmail half is #2594.

Connecting Outlook to GAIA could not be completed honestly: the agent asked for a client secret that Microsoft's public-client sign-in never issues, so the prompt had no correct answer and the setup dead-ended there. Now GAIA walks the Azure app registration one step at a time, checks each step it genuinely can, answers questions from written text instead of improvising, and signs in with a short code — which also means it works on a machine with no browser at all.

Two things worth a reviewer's attention beyond the feature. `flow.py` no longer interpolates an entire unbounded OAuth response body into an exception message, which was reaching model context via the tool envelope; failures now carry bounded, structured fields. And a connection that saves but whose grant write fails is reported as *connected, not yet permitted* rather than the previous — and false — "nothing was changed."

## Test plan

- [ ] `python -m pytest hub/agents/email/python/tests/ tests/unit/connectors/ -q` → 1789 passed, 6 pre-existing skips
- [ ] `python util/lint.py --all` → clean on every file touched
- [ ] Real-world: device-code connect against a live Outlook mailbox, evidence attached below before this leaves draft
- [ ] Cold dependency resolve (`uv pip install --dry-run -e . -e hub/agents/email/python`) succeeds — guards the floor problem described below

## Claims that are reasoned, not observed

Stated explicitly so the evidence below is not read as covering more than it does:

- The **"Allow public client flows" step**: its necessity rests on Microsoft's documented `AADSTS7000218` behaviour. The test account's app registration is already a public client, so no real-world run here exercises the case where that toggle is off.
- **Azure's Overview blade showing three look-alike GUIDs** (Application, Object, Directory) — the reason the client-ID prompt answers a question instead of just rejecting a bad paste — is from portal documentation, not a live click-through.
- Reusing an existing app registration means the **portal-registration steps themselves are not exercised** by real-world testing; only the paste-onward path is.

## A note on the dependency floor

An earlier revision bumped `amd-gaia[api]` to `>=0.23.0` so the new core module would be guaranteed present. That makes the package uninstallable everywhere — core is `0.22.0` and `0.23.0` does not exist, so a cold resolve fails outright and every CI workflow installing the sidecar would have gone red. A dependency floor cannot express "the next unreleased version." The floor stays at `>=0.22.0`, and the real protection moved to a publish-time gate in `release_agent_email.yml` that refuses to release against a core lacking `gaia.connectors.setup_routes` — the boundary where that failure actually lives.
