### PR TITLE
fix(connectors): derive --grant-agent scopes from the agent's own declaration

### DIFF
--- a/hub/agents/email/python/gaia_agent_email/forwarded_credentials.py
+++ b/hub/agents/email/python/gaia_agent_email/forwarded_credentials.py
@@ -181,12 +181,18 @@ def get_forwarded_token(provider: str, scopes: List[str]) -> str:
         )
     missing = [s for s in scopes if s not in cred.scopes]
     if missing:
+        # Union of currently-held and newly-required scopes, not just the
+        # missing ones — `--grant-agent` REPLACES the grant (grants.grant_agent
+        # overwrites rather than unions), so a "missing-only" suggestion would
+        # silently drop the scopes already held on reconnect (#2603).
+        suggested = sorted(set(cred.scopes) | set(scopes))
         raise ConnectorsError(
             f"the forwarded '{provider}' token does not cover the required "
             f"scopes {missing}. Reconnect with those scopes in one command: "
-            f"`gaia connectors connect {provider} --scopes {' '.join(missing)} "
-            f"--grant-agent installed:email` (or Settings -> Connections in the "
-            "Agent UI) so the daemon can forward a token that covers them."
+            f"`gaia connectors connect {provider} --scopes "
+            f"{' '.join(suggested)} --grant-agent installed:email` (or "
+            "Settings -> Connections in the Agent UI) so the daemon can "
+            "forward a token that covers them."
         )
     return cred.access_token
 

--- a/hub/agents/email/python/tests/test_forwarded_credentials.py
+++ b/hub/agents/email/python/tests/test_forwarded_credentials.py
@@ -77,15 +77,17 @@ def test_missing_credential_error_names_the_cli_not_just_the_ui():
 
 
 def test_scope_short_error_names_the_missing_scopes_in_the_cli_command():
-    # The reconnect command must carry the ACTUAL missing scopes, not a
-    # placeholder, and must not print an unexpanded '{provider}' literal.
+    # The reconnect command must suggest the UNION of currently-held and
+    # newly-required scopes, not just the missing ones — since --grant-agent
+    # REPLACES the grant, a "missing-only" suggestion would silently drop
+    # s1 on reconnect (#2603). Must not print an unexpanded '{provider}' literal.
     forwarded_credentials.set_forwarded(
         "google", access_token="tok", scopes=["s1"], expires_at=_FUTURE
     )
     with pytest.raises(ConnectorsError) as exc:
         forwarded_credentials.get_forwarded_token("google", ["s1", "s2"])
     msg = str(exc.value)
-    assert "gaia connectors connect google --scopes s2 --grant-agent" in msg
+    assert "gaia connectors connect google --scopes s1 s2 --grant-agent" in msg
     assert "{provider}" not in msg  # f-string bug regression guard
 
 

--- a/src/gaia/connectors/api.py
+++ b/src/gaia/connectors/api.py
@@ -38,7 +38,10 @@ from gaia.connectors.errors import (
     AuthRequiredError,
     ConfigurationError,
     ConnectorsError,
+    NoDeclaredScopesError,
     ScopeMismatchError,
+    ScopeNotAllowedError,
+    UnknownAgentError,
 )
 from gaia.connectors.events import emit_change
 from gaia.connectors.flow import (
@@ -85,6 +88,73 @@ _DEFAULT_REQUIRED_SCOPES_BY_PROVIDER: dict[str, tuple[str, ...]] = {
         "https://www.googleapis.com/auth/calendar.events",
     ),
 }
+
+
+def resolve_declared_scopes(
+    registry: Any, connector_id: str, agent_ids: List[str]
+) -> Dict[str, List[str]]:
+    """Resolve ``[namespaced_agent_id]`` -> ``{agent_id: declared_scopes}`` (#2603).
+
+    Each agent's scopes come from its ``REQUIRED_CONNECTORS`` declaration for
+    ``connector_id`` — the single source of truth both the CLI
+    (``gaia connectors connect --grant-agent``) and the Agent UI router's
+    ``/authorize``, ``/authorize-device``, and ``/configure`` endpoints read,
+    so the two surfaces cannot drift (#2117's original resolver, hoisted here
+    out of ``gaia.ui.routers.connectors`` so it is FastAPI-free).
+
+    ``registry`` is duck-typed — any object exposing ``.list()`` that returns
+    entries with ``.namespaced_agent_id`` and ``.required_connections``
+    (``AgentRegistry`` shaped). This module never imports ``gaia.agents``.
+
+    Fails loudly (no silent skips or truncation):
+      - an unknown agent id -> ``UnknownAgentError``;
+      - an agent that declares no scopes for ``connector_id`` -> raises
+        ``NoDeclaredScopesError`` rather than ever falling back to the
+        provider's ``default_scopes``;
+      - a declared scope outside ``REGISTRY.get(connector_id).available_scopes``
+        -> ``ScopeNotAllowedError`` naming the offending scope(s). Without
+        this ceiling, an agent's own declaration would flow straight into the
+        OAuth consent screen with no check against the catalog (#2603 C4) —
+        the registry already namespaces against a malicious custom agent
+        claiming a built-in's identity, but not against bad scope values.
+        Skipped (no ceiling enforced) only when ``connector_id`` itself is
+        not in the connector catalog — an unrelated failure surfaces later
+        at the connector lookup that every caller already performs.
+
+    Returns ``{}`` when ``agent_ids`` is empty — no resolution needed.
+    """
+    if not agent_ids:
+        return {}
+
+    by_nsid = {reg.namespaced_agent_id: reg for reg in registry.list()}
+    unknown = [nsid for nsid in agent_ids if nsid not in by_nsid]
+    if unknown:
+        raise UnknownAgentError(unknown)
+
+    from gaia.connectors.registry import REGISTRY as _CONNECTOR_REGISTRY
+
+    try:
+        available: Optional[set] = set(
+            _CONNECTOR_REGISTRY.get(connector_id).available_scopes
+        )
+    except KeyError:
+        available = None
+
+    resolved: Dict[str, List[str]] = {}
+    for nsid in agent_ids:
+        reg = by_nsid[nsid]
+        scopes: set = set()
+        for cr in reg.required_connections:
+            if cr.connector_id == connector_id:
+                scopes.update(cr.scopes)
+        if not scopes:
+            raise NoDeclaredScopesError(nsid, connector_id)
+        if available is not None:
+            disallowed = sorted(scopes - available)
+            if disallowed:
+                raise ScopeNotAllowedError(nsid, connector_id, disallowed)
+        resolved[nsid] = sorted(scopes)
+    return resolved
 
 
 def _authorize_access(
@@ -690,6 +760,7 @@ __all__ = [
     "load_activations",
     "load_grants",
     "poll_device_flow",
+    "resolve_declared_scopes",
     "revoke_agent_grant",
     "revoke_connection",
     "start_authorization",

--- a/src/gaia/connectors/cli.py
+++ b/src/gaia/connectors/cli.py
@@ -80,10 +80,12 @@ def add_subparser(subparsers: argparse._SubParsersAction) -> None:
         "--grant-agent",
         dest="grant_agent",
         help=(
-            "Also grant the requested --scopes to this namespaced agent id "
-            "(e.g. 'installed:email') in the same flow — one command instead of a "
-            "separate `grants grant`, and the scopes always match. Requires "
-            "--scopes."
+            "Also grant this connector to the named namespaced agent id (e.g. "
+            "'installed:email') in the same flow — one command instead of a "
+            "separate `grants grant`, and the scopes always match. Without "
+            "--scopes, the scopes are derived from the agent's own declared "
+            "REQUIRED_CONNECTORS; pass --scopes explicitly to grant a narrower "
+            "set instead."
         ),
     )
     p_conn.add_argument(
@@ -328,19 +330,55 @@ def _handle_connect(args: argparse.Namespace) -> int:
     if getattr(args, "device", False):
         return _handle_connect_device(args)
 
-    from gaia.connectors.api import complete_authorization, start_authorization
+    from gaia.connectors.api import (
+        complete_authorization,
+        resolve_declared_scopes,
+        start_authorization,
+    )
 
     grant_agent = getattr(args, "grant_agent", None)
-    scopes = args.scopes or []
-    if grant_agent and not scopes:
-        sys.stderr.write(
-            "gaia connectors connect: --grant-agent requires --scopes (there is "
-            "nothing to grant without them).\n"
-        )
-        return 2
-    # One-flow connect + grant: authorize the scopes AND grant them to the agent
-    # so the two can never drift (the Agent UI does this via the same path).
-    grant_agents = {grant_agent: list(scopes)} if grant_agent else None
+    explicit_scopes = args.scopes or []
+
+    if grant_agent and not explicit_scopes:
+        # Derive scopes from the agent's own REQUIRED_CONNECTORS declaration
+        # (#2603) instead of demanding the user type them out. Authorize the
+        # UNION with the provider's default_scopes (Google issues no id_token,
+        # and this provider has no userinfo fallback, without `openid` — see
+        # GoogleOAuthProvider.default_scopes) but grant exactly the declared
+        # set so the agent's own credential ceiling is never widened.
+        from gaia.agents.registry import AgentRegistry
+        from gaia.connectors.providers import get as get_provider
+        from gaia.hub.installer import register_installed_sidecars
+
+        # Three-call sequence, not two (#2408): a binary-only sidecar agent
+        # (e.g. installed:email) has no importable Python package, so
+        # discover()'s entry-point scan never sees it — only
+        # register_installed_sidecars bridges the daemon's sidecar specs into
+        # this registry.
+        registry = AgentRegistry()
+        registry.discover()
+        register_installed_sidecars(registry)
+
+        resolved = resolve_declared_scopes(registry, args.connector_id, [grant_agent])
+        declared_scopes = resolved[grant_agent]
+        provider = get_provider(args.connector_id)
+        scopes = sorted(set(declared_scopes) | set(provider.default_scopes))
+        grant_agents = {grant_agent: declared_scopes}
+    else:
+        scopes = explicit_scopes
+        # One-flow connect + grant: authorize the scopes AND grant them to the
+        # agent so the two can never drift (the Agent UI does this via the
+        # same path).
+        grant_agents = {grant_agent: list(scopes)} if grant_agent else None
+
+    if scopes:
+        # Human-readable preview before the browser opens (#2603) — the same
+        # descriptions the Agent UI's consent dialog renders for a scope.
+        from gaia.connectors.providers.google import SCOPE_DESCRIPTIONS
+
+        sys.stdout.write(f"Requesting access to {args.connector_id}:\n")
+        for scope in scopes:
+            sys.stdout.write(f"  - {SCOPE_DESCRIPTIONS.get(scope, scope)}\n")
 
     async def _run() -> str:
         info = await start_authorization(
@@ -361,7 +399,11 @@ def _handle_connect(args: argparse.Namespace) -> int:
     email = asyncio.run(_run())
     msg = f"Connected as {email}"
     if grant_agent:
-        msg += f"; granted {args.connector_id} → {grant_agent}: {', '.join(scopes)}"
+        granted_scopes = grant_agents[grant_agent]
+        msg += (
+            f"; granted {args.connector_id} → {grant_agent}: "
+            f"{', '.join(granted_scopes)}"
+        )
     sys.stdout.write(msg + "\n")
     return 0
 

--- a/src/gaia/connectors/errors.py
+++ b/src/gaia/connectors/errors.py
@@ -247,6 +247,59 @@ class OAuthProviderError(ConnectorsError):
         super().__init__(f"{provider} OAuth request was rejected{status}: {detail}")
 
 
+class UnknownAgentError(ConnectorsError):
+    """One or more requested agent ids are not registered in the agent registry.
+
+    Distinct from ``gaia.daemon.sidecars.errors.UnknownAgentError`` (a
+    ``SidecarError``, unrelated hierarchy) — this one IS a ``ConnectorsError``
+    so the CLI's blanket ``except ConnectorsError`` and the router's
+    ``ConnectorsError -> HTTPException`` mapping both catch it uniformly.
+    """
+
+    def __init__(self, agent_ids: list[str]):
+        self.agent_ids = list(agent_ids)
+        super().__init__(
+            f"Unknown agent id(s): {', '.join(self.agent_ids)}. Check the "
+            "namespaced agent id (e.g. 'installed:email') via `gaia connectors "
+            "grants list` or the Agent UI's agent picker."
+        )
+
+
+class NoDeclaredScopesError(ConnectorsError):
+    """An agent declares no ``REQUIRED_CONNECTORS`` scopes for a connector."""
+
+    def __init__(self, agent_id: str, connector_id: str):
+        self.agent_id = agent_id
+        self.connector_id = connector_id
+        super().__init__(
+            f"Agent {agent_id!r} declares no REQUIRED_CONNECTORS scopes for "
+            f"connector {connector_id!r}, so there is nothing to authorize or "
+            "grant. Pass --scopes explicitly, or check the agent's "
+            "REQUIRED_CONNECTORS declaration."
+        )
+
+
+class ScopeNotAllowedError(ConnectorsError):
+    """A declared scope is outside the connector's ``available_scopes`` ceiling.
+
+    Raised by ``resolve_declared_scopes`` so an agent's own declaration can
+    never put a scope in front of the user's consent screen that the catalog
+    entry does not explicitly allow (#2603) — a half-fix would validate agent
+    identity but not scope values.
+    """
+
+    def __init__(self, agent_id: str, connector_id: str, scopes: list[str]):
+        self.agent_id = agent_id
+        self.connector_id = connector_id
+        self.scopes = list(scopes)
+        super().__init__(
+            f"Agent {agent_id!r} declares scope(s) {', '.join(self.scopes)} for "
+            f"connector {connector_id!r} that are outside its available_scopes "
+            "catalog entry. This is a catalog/agent mismatch — file a bug "
+            "rather than widening the request."
+        )
+
+
 class GrantAfterConnectError(ConnectorsError):
     """A connection was persisted but the agent grant that should follow it failed.
 

--- a/src/gaia/connectors/providers/google.py
+++ b/src/gaia/connectors/providers/google.py
@@ -108,12 +108,17 @@ class GoogleOAuthProvider:
                     "client above:\n"
                     "    gaia connectors configure google --client-id <ID> "
                     "--client-secret <SECRET>\n"
+                    "    gaia connectors connect google --grant-agent "
+                    "installed:email\n"
+                    "  (Naming the agent is enough — GAIA reads the scopes it "
+                    "already declares, no need to type them out. To grant a "
+                    "narrower set instead, pass --scopes explicitly:\n"
                     '    SCOPES="https://www.googleapis.com/auth/gmail.modify '
                     "https://www.googleapis.com/auth/gmail.send "
                     "https://www.googleapis.com/auth/calendar.events "
                     'https://www.googleapis.com/auth/calendar.readonly"\n'
                     "    gaia connectors connect google --scopes $SCOPES "
-                    "--grant-agent installed:email"
+                    "--grant-agent installed:email)"
                 ),
                 docs="https://amd-gaia.ai/docs/connectors/google",
             )
@@ -139,6 +144,14 @@ class GoogleOAuthProvider:
         - ``prompt=consent`` — force the consent screen on every connect, so
           we always receive a refresh token (Google issues a refresh token
           ONLY on the first consent unless ``prompt=consent`` is set).
+
+        Deliberately NOT setting ``include_granted_scopes=true`` (#2603): it
+        would make ``flow.py``'s persisted ``scopes`` (what was requested)
+        diverge from what Google actually granted, which ``flow.py`` never
+        reconciles (it persists ``flow.scopes`` and never reads back
+        ``payload.get("scope")``) — GAIA's recorded scope metadata would
+        under-report real token access. See the follow-up issue for adding
+        the reconciliation this needs before turning the flag on.
         """
         return {"access_type": "offline", "prompt": "consent"}
 

--- a/src/gaia/connectors/providers/google.py
+++ b/src/gaia/connectors/providers/google.py
@@ -150,8 +150,8 @@ class GoogleOAuthProvider:
         diverge from what Google actually granted, which ``flow.py`` never
         reconciles (it persists ``flow.scopes`` and never reads back
         ``payload.get("scope")``) — GAIA's recorded scope metadata would
-        under-report real token access. See the follow-up issue for adding
-        the reconciliation this needs before turning the flag on.
+        under-report real token access. See #2605 for the reconciliation
+        this needs before turning the flag on.
         """
         return {"access_type": "offline", "prompt": "consent"}
 

--- a/src/gaia/ui/routers/connectors.py
+++ b/src/gaia/ui/routers/connectors.py
@@ -48,6 +48,7 @@ import gaia.connectors.catalog  # noqa: F401  # pylint: disable=unused-import
 from gaia.connectors.activations import list_agent_activations
 from gaia.connectors.api import activate as activate_connector_for_agent
 from gaia.connectors.api import deactivate as deactivate_connector_for_agent
+from gaia.connectors.api import resolve_declared_scopes
 from gaia.connectors.errors import (
     AuthRequiredError,
     ConfigurationError,
@@ -56,7 +57,10 @@ from gaia.connectors.errors import (
     ConsentDeniedError,
     FlowInProgressError,
     FlowTimeoutError,
+    NoDeclaredScopesError,
     ScopeMismatchError,
+    ScopeNotAllowedError,
+    UnknownAgentError,
 )
 from gaia.connectors.events import set_emitter
 from gaia.connectors.flow import _pending as _flow_pending
@@ -301,12 +305,15 @@ def _resolve_grant_scopes(
 ) -> Dict[str, List[str]]:
     """Resolve ``[namespaced_agent_id]`` → ``{agent_id: required_scopes}`` (#2117).
 
-    Each agent's scopes come from its ``REQUIRED_CONNECTORS`` declaration for
-    ``connector_id`` — the same single source of truth the forwarded-connection
-    route uses. Fails loudly (no silent skips): an unknown agent → 404; an
-    agent that declares no requirement for this connector → 400. Both would
-    otherwise produce a connect that silently grants nothing — the exact
-    dead-end this flow removes.
+    Thin wrapper over the shared ``gaia.connectors.api.resolve_declared_scopes``
+    (#2603) — the CLI's ``gaia connectors connect --grant-agent`` calls the
+    SAME function, so the two surfaces cannot drift. This wrapper's only job
+    is translating the shared resolver's exceptions into this router's HTTP
+    contract: an unknown agent → 404; an agent that declares no requirement
+    for this connector → 400; a declared scope outside the connector's
+    ``available_scopes`` → 400. All three would otherwise produce a connect
+    that silently grants nothing (or, for the scope ceiling, too much) — the
+    exact dead-end / escalation this flow removes.
     """
     if not agent_ids:
         return {}
@@ -314,32 +321,32 @@ def _resolve_grant_scopes(
     if registry is None:
         raise HTTPException(status_code=503, detail="Agent registry not initialized")
 
-    by_nsid = {reg.namespaced_agent_id: reg for reg in registry.list()}
-    unknown = [nsid for nsid in agent_ids if nsid not in by_nsid]
-    if unknown:
+    try:
+        return resolve_declared_scopes(registry, connector_id, agent_ids)
+    except UnknownAgentError as e:
         raise HTTPException(
             status_code=404,
-            detail={"error": "unknown_agent", "agent_ids": unknown},
-        )
-
-    resolved: Dict[str, List[str]] = {}
-    for nsid in agent_ids:
-        reg = by_nsid[nsid]
-        scopes: set[str] = set()
-        for cr in reg.required_connections:
-            if cr.connector_id == connector_id:
-                scopes.update(cr.scopes)
-        if not scopes:
-            raise HTTPException(
-                status_code=400,
-                detail={
-                    "error": "agent_declares_no_scopes",
-                    "agent_id": nsid,
-                    "connector_id": connector_id,
-                },
-            )
-        resolved[nsid] = sorted(scopes)
-    return resolved
+            detail={"error": "unknown_agent", "agent_ids": e.agent_ids},
+        ) from e
+    except NoDeclaredScopesError as e:
+        raise HTTPException(
+            status_code=400,
+            detail={
+                "error": "agent_declares_no_scopes",
+                "agent_id": e.agent_id,
+                "connector_id": e.connector_id,
+            },
+        ) from e
+    except ScopeNotAllowedError as e:
+        raise HTTPException(
+            status_code=400,
+            detail={
+                "error": "scope_not_allowed",
+                "agent_id": e.agent_id,
+                "connector_id": e.connector_id,
+                "scopes": e.scopes,
+            },
+        ) from e
 
 
 def _connector_summary(connector_id: str) -> Dict[str, Any]:

--- a/tests/unit/connectors/conftest.py
+++ b/tests/unit/connectors/conftest.py
@@ -13,6 +13,38 @@ from __future__ import annotations
 import pytest
 
 
+def make_fake_agent_registry(nsid: str, connector_id: str, scopes: list[str]):
+    """Minimal ``AgentRegistry`` stand-in exposing only what the shared scope
+    resolver (``gaia.connectors.api.resolve_declared_scopes``) and the
+    router's ``_resolve_grant_scopes`` read: ``.list()`` returning objects
+    with ``.namespaced_agent_id`` and ``.required_connections``.
+
+    Shared by the router tests, the CLI-facing derivation tests, and the
+    forwarded-connection tests so all three exercise one fake shape (#2603).
+    """
+    from dataclasses import dataclass, field
+    from typing import List
+
+    from gaia.connectors.providers.base import ConnectorRequirement
+
+    @dataclass
+    class FakeReg:
+        namespaced_agent_id: str
+        required_connections: List[ConnectorRequirement] = field(default_factory=list)
+
+    @dataclass
+    class FakeRegistry:
+        _regs: List[FakeReg]
+
+        def list(self):
+            return self._regs
+
+    cr = ConnectorRequirement(connector_id=connector_id, scopes=scopes)
+    return FakeRegistry(
+        _regs=[FakeReg(namespaced_agent_id=nsid, required_connections=[cr])]
+    )
+
+
 @pytest.fixture(autouse=True)
 def _autouse_in_memory_keyring(in_memory_keyring):  # noqa: F811
     """

--- a/tests/unit/connectors/test_cli.py
+++ b/tests/unit/connectors/test_cli.py
@@ -92,12 +92,91 @@ class TestConnectGrantAgent:
     """`gaia connectors connect --grant-agent` folds connect + grant into one
     flow so the scopes can never drift (#2347 UX)."""
 
-    def test_grant_agent_without_scopes_is_a_usage_error(self):
+    @staticmethod
+    def _install_fake_agent_registry(monkeypatch, declared_scopes):
+        """Stand in for `AgentRegistry() -> .discover() -> register_installed_
+        sidecars()` (#2603) with a fake that resolves ``installed:email`` to
+        *declared_scopes* for ``google``, without importing gaia_agent_email
+        or touching disk."""
+        from dataclasses import dataclass, field
+        from typing import List
+
+        from gaia.connectors.providers.base import ConnectorRequirement
+
+        @dataclass
+        class FakeReg:
+            namespaced_agent_id: str
+            required_connections: List[ConnectorRequirement] = field(
+                default_factory=list
+            )
+
+        class FakeAgentRegistry:
+            def __init__(self, *_a, **_k):
+                cr = ConnectorRequirement(
+                    connector_id="google", scopes=declared_scopes
+                )
+                self._regs = [
+                    FakeReg(
+                        namespaced_agent_id="installed:email",
+                        required_connections=[cr],
+                    )
+                ]
+
+            def discover(self):
+                pass
+
+            def list(self):
+                return self._regs
+
+        monkeypatch.setattr(
+            "gaia.agents.registry.AgentRegistry", FakeAgentRegistry
+        )
+        monkeypatch.setattr(
+            "gaia.hub.installer.register_installed_sidecars",
+            lambda registry: None,
+        )
+
+    def test_grant_agent_without_scopes_derives_declared_scopes(self, monkeypatch):
+        declared = [
+            "https://www.googleapis.com/auth/gmail.modify",
+            "https://www.googleapis.com/auth/gmail.send",
+        ]
+        self._install_fake_agent_registry(monkeypatch, declared)
+
+        captured = {}
+
+        async def _fake_start(connector_id, *, scopes, grant_agents=None):
+            captured["connector_id"] = connector_id
+            captured["scopes"] = list(scopes)
+            captured["grant_agents"] = grant_agents
+            return {"flow_id": "F1", "authorization_url": "https://auth.example"}
+
+        async def _fake_complete(flow_id):
+            return {"account_email": "alice@example.com"}
+
+        monkeypatch.setattr("gaia.connectors.api.start_authorization", _fake_start)
+        monkeypatch.setattr(
+            "gaia.connectors.api.complete_authorization", _fake_complete
+        )
+
         rc, _out, err = _run(
             "connectors", "connect", "google", "--grant-agent", "installed:email"
         )
-        assert rc == 2
-        assert "--grant-agent requires --scopes" in err
+        assert rc == 0, err
+
+        # The grant is exactly the agent's declared scopes — sorted, no `openid`.
+        assert captured["grant_agents"] == {
+            "installed:email": [
+                "https://www.googleapis.com/auth/gmail.modify",
+                "https://www.googleapis.com/auth/gmail.send",
+            ]
+        }
+        # The authorize set is the UNION with the provider's default_scopes
+        # (AC3/C3 regression guard) — `openid` must not be silently dropped,
+        # and the derived/declared scopes must still be requested too.
+        assert "openid" in captured["scopes"]
+        assert "https://www.googleapis.com/auth/gmail.modify" in captured["scopes"]
+        assert "https://www.googleapis.com/auth/gmail.send" in captured["scopes"]
 
     def test_grant_agent_passes_grant_agents_to_the_flow(self, monkeypatch):
         captured = {}
@@ -114,6 +193,15 @@ class TestConnectGrantAgent:
         monkeypatch.setattr("gaia.connectors.api.start_authorization", _fake_start)
         monkeypatch.setattr(
             "gaia.connectors.api.complete_authorization", _fake_complete
+        )
+        # --scopes is explicit here, so resolve_declared_scopes must never run.
+        def _must_not_run(*_a, **_k):
+            raise AssertionError(
+                "resolve_declared_scopes must not run when --scopes is given"
+            )
+
+        monkeypatch.setattr(
+            "gaia.connectors.api.resolve_declared_scopes", _must_not_run
         )
 
         rc, out, _err = _run(

--- a/tests/unit/connectors/test_cli.py
+++ b/tests/unit/connectors/test_cli.py
@@ -112,9 +112,7 @@ class TestConnectGrantAgent:
 
         class FakeAgentRegistry:
             def __init__(self, *_a, **_k):
-                cr = ConnectorRequirement(
-                    connector_id="google", scopes=declared_scopes
-                )
+                cr = ConnectorRequirement(connector_id="google", scopes=declared_scopes)
                 self._regs = [
                     FakeReg(
                         namespaced_agent_id="installed:email",
@@ -128,9 +126,7 @@ class TestConnectGrantAgent:
             def list(self):
                 return self._regs
 
-        monkeypatch.setattr(
-            "gaia.agents.registry.AgentRegistry", FakeAgentRegistry
-        )
+        monkeypatch.setattr("gaia.agents.registry.AgentRegistry", FakeAgentRegistry)
         monkeypatch.setattr(
             "gaia.hub.installer.register_installed_sidecars",
             lambda registry: None,
@@ -194,6 +190,7 @@ class TestConnectGrantAgent:
         monkeypatch.setattr(
             "gaia.connectors.api.complete_authorization", _fake_complete
         )
+
         # --scopes is explicit here, so resolve_declared_scopes must never run.
         def _must_not_run(*_a, **_k):
             raise AssertionError(

--- a/tests/unit/connectors/test_grant_agent_scope_derivation.py
+++ b/tests/unit/connectors/test_grant_agent_scope_derivation.py
@@ -173,9 +173,7 @@ class TestResolveDeclaredScopes:
         from gaia.connectors.errors import ScopeNotAllowedError
 
         bogus_scope = "https://www.googleapis.com/auth/fake.nonexistent.scope"
-        registry = make_fake_agent_registry(
-            "installed:email", "google", [bogus_scope]
-        )
+        registry = make_fake_agent_registry("installed:email", "google", [bogus_scope])
 
         with pytest.raises(ScopeNotAllowedError) as exc:
             resolve_declared_scopes(registry, "google", ["installed:email"])
@@ -244,7 +242,9 @@ class TestAuthorizeAndGrantScopeUnion:
 
 class TestExceptionHierarchy:
     def test_unknown_agent_error_is_a_connectors_error_not_a_sidecar_error(self):
-        from gaia.connectors.errors import ConnectorsError
+        from gaia.connectors.errors import (
+            ConnectorsError,
+        )
         from gaia.connectors.errors import (
             UnknownAgentError as ConnectorsUnknownAgentError,
         )
@@ -362,9 +362,9 @@ class TestSharedResolverCallSites:
         call = spy.call_args
         all_values = list(call.args) + list(call.kwargs.values())
         assert "google" in all_values or call.kwargs.get("connector_id") == "google"
-        assert ["installed:email"] in all_values or call.kwargs.get(
-            "agent_ids"
-        ) == ["installed:email"]
+        assert ["installed:email"] in all_values or call.kwargs.get("agent_ids") == [
+            "installed:email"
+        ]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/connectors/test_grant_agent_scope_derivation.py
+++ b/tests/unit/connectors/test_grant_agent_scope_derivation.py
@@ -1,0 +1,440 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""
+Coverage for #2603 — ``--grant-agent`` must derive scopes from the agent's own
+``REQUIRED_CONNECTORS`` declaration instead of demanding the user type
+``--scopes`` by hand.
+
+Exercises the new shared resolver ``gaia.connectors.api.resolve_declared_scopes``
+directly, its three new exception types in ``gaia.connectors.errors``
+(``UnknownAgentError``, ``NoDeclaredScopesError``, ``ScopeNotAllowedError``),
+and both call sites that must share it (the CLI's ``_handle_connect`` and the
+router's ``_resolve_grant_scopes``) so they can never drift.
+
+Hermetic: no ``gaia_agent_email`` import (``tests/unit/connectors/`` runs in a
+CI job that installs only ``-e ".[api]"`` — the email wheel is not
+importable there). Uses ``make_fake_agent_registry`` (``conftest.py``) plus
+the real Google catalog spec (``gaia.connectors.catalog.google``) for the
+``available_scopes`` ceiling checks.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import Mock
+
+import pytest
+
+from tests.unit.connectors.conftest import make_fake_agent_registry
+
+UI_HEADER = {"x-gaia-ui": "1"}
+
+
+@pytest.fixture(autouse=True)
+def fake_home(tmp_path, monkeypatch):
+    """Isolated grants/mcp_servers dirs + a configured Google provider, per
+    test — mirrors ``tests/unit/connectors/test_cli.py``'s ``fake_home``."""
+    monkeypatch.setattr("gaia.connectors.grants.Path.home", lambda: tmp_path)
+    monkeypatch.setattr("gaia.connectors.activations.Path.home", lambda: tmp_path)
+    monkeypatch.setattr("gaia.connectors.mcp_server.Path.home", lambda: tmp_path)
+    monkeypatch.setenv("GAIA_GOOGLE_CLIENT_ID", "test.apps.example")
+    monkeypatch.setenv("GAIA_GOOGLE_CLIENT_SECRET", "test-secret")
+
+    from gaia.connectors.providers import _registry
+
+    _registry.clear()
+    yield
+    _registry.clear()
+
+
+@pytest.fixture(autouse=True)
+def real_google_catalog():
+    """Trigger registration of the real Google ``ConnectorSpec`` — its
+    ``available_scopes`` already includes every scope the email agent
+    declares (gmail.modify/send, calendar.readonly/events), so the ceiling
+    check in ``resolve_declared_scopes`` needs no fake spec here."""
+    import gaia.connectors.catalog  # noqa: F401  # pylint: disable=unused-import
+
+
+def _run_cli(*argv) -> tuple[int, str, str]:
+    """Local copy of test_cli.py's ``_run`` helper — kept separate so this
+    file has no import-order dependency on test_cli.py."""
+    import sys
+    from io import StringIO
+
+    from gaia.connectors import cli as connections_cli
+
+    out = StringIO()
+    err = StringIO()
+    saved_out, saved_err = sys.stdout, sys.stderr
+    sys.stdout, sys.stderr = out, err
+    try:
+        rc = connections_cli.main(list(argv))
+    except SystemExit as e:
+        rc = e.code if isinstance(e.code, int) else 1
+    finally:
+        sys.stdout, sys.stderr = saved_out, saved_err
+    return rc, out.getvalue(), err.getvalue()
+
+
+def _stub_registry_chain(monkeypatch, regs):
+    """Monkeypatch the three-call sequence ``_handle_connect`` uses to build
+    an ``AgentRegistry`` (``AgentRegistry() -> .discover() ->
+    register_installed_sidecars()``) with a fake that returns *regs* from
+    ``.list()``. Guards against #2408 (a two-call sequence that skips
+    ``register_installed_sidecars`` makes binary-only sidecars invisible)."""
+
+    class FakeAgentRegistry:
+        def __init__(self, *_a, **_k):
+            pass
+
+        def discover(self):
+            pass
+
+        def list(self):
+            return regs
+
+    monkeypatch.setattr("gaia.agents.registry.AgentRegistry", FakeAgentRegistry)
+    monkeypatch.setattr(
+        "gaia.hub.installer.register_installed_sidecars", lambda registry: None
+    )
+
+
+# ---------------------------------------------------------------------------
+# resolve_declared_scopes — direct unit coverage
+# ---------------------------------------------------------------------------
+
+
+class TestResolveDeclaredScopes:
+    def test_resolve_declared_scopes_returns_sorted_dict(self):
+        from gaia.connectors.api import resolve_declared_scopes
+
+        registry = make_fake_agent_registry(
+            "installed:email",
+            "google",
+            [
+                "https://www.googleapis.com/auth/gmail.send",
+                "https://www.googleapis.com/auth/gmail.modify",
+            ],
+        )
+
+        result = resolve_declared_scopes(registry, "google", ["installed:email"])
+
+        assert result == {
+            "installed:email": [
+                "https://www.googleapis.com/auth/gmail.modify",
+                "https://www.googleapis.com/auth/gmail.send",
+            ]
+        }
+
+    def test_empty_agent_ids_returns_empty_dict(self):
+        from gaia.connectors.api import resolve_declared_scopes
+
+        registry = make_fake_agent_registry(
+            "installed:email", "google", ["https://www.googleapis.com/auth/gmail.send"]
+        )
+
+        assert resolve_declared_scopes(registry, "google", []) == {}
+
+    def test_unknown_agent_raises_unknown_agent_error(self):
+        from gaia.connectors.api import resolve_declared_scopes
+        from gaia.connectors.errors import UnknownAgentError
+
+        registry = make_fake_agent_registry(
+            "installed:email", "google", ["https://www.googleapis.com/auth/gmail.send"]
+        )
+
+        with pytest.raises(UnknownAgentError) as exc:
+            resolve_declared_scopes(registry, "google", ["installed:ghost"])
+
+        assert exc.value.agent_ids == ["installed:ghost"]
+
+    def test_agent_with_no_declaration_raises_no_declared_scopes_error(self):
+        from gaia.connectors.api import resolve_declared_scopes
+        from gaia.connectors.errors import NoDeclaredScopesError
+
+        # The agent declares scopes for microsoft, not google.
+        registry = make_fake_agent_registry(
+            "installed:email",
+            "microsoft",
+            ["https://graph.microsoft.com/Mail.ReadWrite"],
+        )
+
+        with pytest.raises(NoDeclaredScopesError) as exc:
+            resolve_declared_scopes(registry, "google", ["installed:email"])
+
+        assert exc.value.agent_id == "installed:email"
+        assert exc.value.connector_id == "google"
+        # Never falls back to the provider's default_scopes or anything else
+        # non-empty — the whole call raises, nothing is silently supplied.
+        assert getattr(exc.value, "scopes", None) in (None, [], ())
+
+    def test_declared_scope_outside_available_scopes_raises(self):
+        from gaia.connectors.api import resolve_declared_scopes
+        from gaia.connectors.errors import ScopeNotAllowedError
+
+        bogus_scope = "https://www.googleapis.com/auth/fake.nonexistent.scope"
+        registry = make_fake_agent_registry(
+            "installed:email", "google", [bogus_scope]
+        )
+
+        with pytest.raises(ScopeNotAllowedError) as exc:
+            resolve_declared_scopes(registry, "google", ["installed:email"])
+
+        assert exc.value.agent_id == "installed:email"
+        assert exc.value.connector_id == "google"
+        assert bogus_scope in exc.value.scopes
+
+    def test_mixed_allowed_and_disallowed_scopes_raises_not_filters(self):
+        """A partially-bad declaration raises entirely — it never silently
+        drops the disallowed scope and returns a truncated map."""
+        from gaia.connectors.api import resolve_declared_scopes
+        from gaia.connectors.errors import ScopeNotAllowedError
+
+        bogus_scope = "https://www.googleapis.com/auth/fake.nonexistent.scope"
+        registry = make_fake_agent_registry(
+            "installed:email",
+            "google",
+            ["https://www.googleapis.com/auth/gmail.modify", bogus_scope],
+        )
+
+        with pytest.raises(ScopeNotAllowedError) as exc:
+            resolve_declared_scopes(registry, "google", ["installed:email"])
+
+        assert bogus_scope in exc.value.scopes
+
+
+class TestAuthorizeAndGrantScopeUnion:
+    def test_authorize_and_grant_scopes_differ(self):
+        """The #2603 flagship math: the CLI authorizes the UNION of the
+        agent's declared scopes and the provider's default_scopes, but
+        grants exactly the declared set (no `openid` in the grant)."""
+        from gaia.connectors.api import resolve_declared_scopes
+        from gaia.connectors.providers import get as get_provider
+
+        declared_scopes = [
+            "https://www.googleapis.com/auth/gmail.modify",
+            "https://www.googleapis.com/auth/gmail.send",
+        ]
+        registry = make_fake_agent_registry(
+            "installed:email", "google", declared_scopes
+        )
+
+        declared = resolve_declared_scopes(registry, "google", ["installed:email"])[
+            "installed:email"
+        ]
+        provider = get_provider("google")
+
+        # Fixture assumption this test documents: the provider's own
+        # default_scopes includes `openid`, which the agent's declaration
+        # does not.
+        assert "openid" in provider.default_scopes
+
+        union = sorted(set(declared) | set(provider.default_scopes))
+        assert union != declared
+        assert set(union) - set(declared) == set(provider.default_scopes) - set(
+            declared
+        )
+        assert "openid" not in declared
+
+
+# ---------------------------------------------------------------------------
+# Exception-hierarchy guard — never alias the daemon-sidecar UnknownAgentError
+# ---------------------------------------------------------------------------
+
+
+class TestExceptionHierarchy:
+    def test_unknown_agent_error_is_a_connectors_error_not_a_sidecar_error(self):
+        from gaia.connectors.errors import ConnectorsError
+        from gaia.connectors.errors import (
+            UnknownAgentError as ConnectorsUnknownAgentError,
+        )
+        from gaia.daemon.sidecars.errors import (
+            UnknownAgentError as SidecarUnknownAgentError,
+        )
+
+        assert ConnectorsUnknownAgentError is not SidecarUnknownAgentError
+        assert issubclass(ConnectorsUnknownAgentError, ConnectorsError)
+
+    def test_no_declared_scopes_error_is_a_connectors_error(self):
+        from gaia.connectors.errors import ConnectorsError, NoDeclaredScopesError
+
+        assert issubclass(NoDeclaredScopesError, ConnectorsError)
+
+    def test_scope_not_allowed_error_is_a_connectors_error(self):
+        from gaia.connectors.errors import ConnectorsError, ScopeNotAllowedError
+
+        assert issubclass(ScopeNotAllowedError, ConnectorsError)
+
+
+# ---------------------------------------------------------------------------
+# CLI wiring
+# ---------------------------------------------------------------------------
+
+
+class TestCliErrorMapping:
+    def test_cli_handle_maps_unknown_agent_error_to_exit_5_not_traceback(
+        self, monkeypatch
+    ):
+        _stub_registry_chain(monkeypatch, regs=[])
+
+        def _boom(*_a, **_k):
+            from gaia.connectors.errors import UnknownAgentError
+
+            raise UnknownAgentError(["installed:ghost"])
+
+        monkeypatch.setattr("gaia.connectors.api.resolve_declared_scopes", _boom)
+
+        rc, _out, err = _run_cli(
+            "connectors", "connect", "google", "--grant-agent", "installed:ghost"
+        )
+
+        assert rc == 5
+        assert "Connectors error" in err
+        assert "installed:ghost" in err
+
+
+class TestSharedResolverCallSites:
+    def test_shared_resolver_call_through_cli(self, monkeypatch):
+        """The CLI must call the SHARED resolver, not reimplement its own
+        scope-derivation logic (#2603 AC5)."""
+        spy = Mock(return_value={"installed:email": ["s1"]})
+        monkeypatch.setattr("gaia.connectors.api.resolve_declared_scopes", spy)
+        _stub_registry_chain(monkeypatch, regs=[])
+
+        async def _fake_start(connector_id, *, scopes, grant_agents=None):
+            return {"flow_id": "F1", "authorization_url": "https://auth.example"}
+
+        async def _fake_complete(flow_id):
+            return {"account_email": "alice@example.com"}
+
+        monkeypatch.setattr("gaia.connectors.api.start_authorization", _fake_start)
+        monkeypatch.setattr(
+            "gaia.connectors.api.complete_authorization", _fake_complete
+        )
+
+        rc, _out, err = _run_cli(
+            "connectors", "connect", "google", "--grant-agent", "installed:email"
+        )
+        assert rc == 0, err
+
+        spy.assert_called_once()
+        call = spy.call_args
+        args, kwargs = call.args, call.kwargs
+        # Tolerant of positional-or-keyword: pull connector_id/agent_ids out
+        # of whichever form the implementer used.
+        all_values = list(args) + list(kwargs.values())
+        assert "google" in all_values or kwargs.get("connector_id") == "google"
+        assert ["installed:email"] in all_values or kwargs.get("agent_ids") == [
+            "installed:email"
+        ]
+
+    def test_shared_resolver_call_through_router(self, monkeypatch, ui_api_client):
+        """The router must call the SAME shared resolver (#2603 AC5)."""
+        spy = Mock(
+            return_value={
+                "installed:email": ["https://www.googleapis.com/auth/gmail.modify"]
+            }
+        )
+        monkeypatch.setattr("gaia.ui.routers.connectors.resolve_declared_scopes", spy)
+        ui_api_client.app.state.agent_registry = make_fake_agent_registry(
+            "installed:email",
+            "google",
+            ["https://www.googleapis.com/auth/gmail.modify"],
+        )
+
+        from unittest.mock import AsyncMock
+
+        monkeypatch.setattr(
+            "gaia.connectors.start_authorization",
+            AsyncMock(
+                return_value={"flow_id": "f1", "authorization_url": "https://auth"}
+            ),
+        )
+
+        resp = ui_api_client.post(
+            "/api/connectors/google/authorize",
+            json={"scopes": ["openid"], "grant_agents": ["installed:email"]},
+            headers=UI_HEADER,
+        )
+        assert resp.status_code == 200, resp.text
+
+        spy.assert_called_once()
+        call = spy.call_args
+        all_values = list(call.args) + list(call.kwargs.values())
+        assert "google" in all_values or call.kwargs.get("connector_id") == "google"
+        assert ["installed:email"] in all_values or call.kwargs.get(
+            "agent_ids"
+        ) == ["installed:email"]
+
+
+# ---------------------------------------------------------------------------
+# #2408 guard — real discovery, no fake registry, no wheel
+# ---------------------------------------------------------------------------
+
+
+class Test2408GuardRealDiscoveryNoWheel:
+    """Mirrors ``test_router_connectors.py::TestSidecarRegistrationEndToEnd``
+    but drives the CLI instead of the router. A test that plants
+    ``installed:email`` directly into a fake registry passes identically
+    whether or not the sidecar is actually wired into discovery, and proves
+    nothing about #2408 — so this test uses the REAL ``AgentRegistry`` +
+    real ``register_installed_sidecars`` + real Google catalog spec, with
+    only ``gaia.hub.installer.list_installed`` monkeypatched to report
+    ``email`` as installed.
+    """
+
+    @staticmethod
+    def _fake_installed_email():
+        from gaia.hub.installer import ARTIFACT_KIND_BINARY, InstalledAgent
+
+        return {
+            "email": InstalledAgent(
+                id="email",
+                version="0.1.0",
+                language="python",
+                installed_at="2026-01-01T00:00:00Z",
+                artifact_kind=ARTIFACT_KIND_BINARY,
+            )
+        }
+
+    def test_2408_guard_real_discovery_no_wheel(self, monkeypatch):
+        from gaia.daemon.sidecars.spec import builtin_specs
+
+        monkeypatch.setattr(
+            "gaia.hub.installer.list_installed",
+            lambda *a, **kw: self._fake_installed_email(),
+        )
+
+        captured = {}
+
+        async def _fake_start(connector_id, *, scopes, grant_agents=None):
+            captured["scopes"] = list(scopes)
+            captured["grant_agents"] = grant_agents
+            return {"flow_id": "F1", "authorization_url": "https://auth.example"}
+
+        async def _fake_complete(flow_id):
+            return {"account_email": "alice@example.com"}
+
+        monkeypatch.setattr("gaia.connectors.api.start_authorization", _fake_start)
+        monkeypatch.setattr(
+            "gaia.connectors.api.complete_authorization", _fake_complete
+        )
+
+        rc, _out, err = _run_cli(
+            "connectors", "connect", "google", "--grant-agent", "installed:email"
+        )
+        assert rc == 0, err
+
+        email_spec = builtin_specs()["email"]
+        expected_google_scopes = sorted(
+            {
+                s
+                for cr in email_spec.required_connections
+                if cr.connector_id == "google"
+                for s in cr.scopes
+            }
+        )
+        assert (
+            sorted(captured["grant_agents"]["installed:email"])
+            == expected_google_scopes
+        )

--- a/tests/unit/connectors/test_router_connectors.py
+++ b/tests/unit/connectors/test_router_connectors.py
@@ -53,11 +53,18 @@ def isolated_registry(monkeypatch, tmp_path):
             description="Google OAuth",
             default_scopes=("openid",),
             # Ceiling for resolve_declared_scopes' ScopeNotAllowedError check
-            # (#2603) — TestAuthorizeGrantAgents declares gmail.modify via
-            # make_fake_agent_registry, so it must be inside this fixture's
+            # (#2603). TestAuthorizeGrantAgents declares gmail.modify via
+            # make_fake_agent_registry; TestSidecarRegistrationEndToEnd and
+            # TestSidecarInstallNoRestart run the REAL server lifespan against
+            # the real email daemon-sidecar spec (all 4 scopes, see
+            # gaia.daemon.sidecars.spec.builtin_specs()["email"]) — every
+            # scope either exercises must be inside this fixture's
             # available_scopes or the ceiling would reject it.
             available_scopes=(
                 "https://www.googleapis.com/auth/gmail.modify",
+                "https://www.googleapis.com/auth/gmail.send",
+                "https://www.googleapis.com/auth/calendar.events",
+                "https://www.googleapis.com/auth/calendar.readonly",
                 "openid",
             ),
             oauth_provider_ref="google",

--- a/tests/unit/connectors/test_router_connectors.py
+++ b/tests/unit/connectors/test_router_connectors.py
@@ -20,6 +20,8 @@ from unittest.mock import AsyncMock
 
 import pytest
 
+from tests.unit.connectors.conftest import make_fake_agent_registry
+
 # ---------------------------------------------------------------------------
 # Fixtures
 # ---------------------------------------------------------------------------
@@ -50,6 +52,14 @@ def isolated_registry(monkeypatch, tmp_path):
             type="oauth_pkce",
             description="Google OAuth",
             default_scopes=("openid",),
+            # Ceiling for resolve_declared_scopes' ScopeNotAllowedError check
+            # (#2603) — TestAuthorizeGrantAgents declares gmail.modify via
+            # make_fake_agent_registry, so it must be inside this fixture's
+            # available_scopes or the ceiling would reject it.
+            available_scopes=(
+                "https://www.googleapis.com/auth/gmail.modify",
+                "openid",
+            ),
             oauth_provider_ref="google",
         )
     )
@@ -297,31 +307,6 @@ class TestConfigureEndpoint:
 # ---------------------------------------------------------------------------
 
 
-def _fake_registry(nsid: str, connector_id: str, scopes: list[str]):
-    """Minimal AgentRegistry stand-in for the router's scope resolution."""
-    from dataclasses import dataclass, field
-    from typing import List
-
-    from gaia.connectors.providers.base import ConnectorRequirement
-
-    @dataclass
-    class FakeReg:
-        namespaced_agent_id: str
-        required_connections: List[ConnectorRequirement] = field(default_factory=list)
-
-    @dataclass
-    class FakeRegistry:
-        _regs: List[FakeReg]
-
-        def list(self):
-            return self._regs
-
-    cr = ConnectorRequirement(connector_id=connector_id, scopes=scopes)
-    return FakeRegistry(
-        _regs=[FakeReg(namespaced_agent_id=nsid, required_connections=[cr])]
-    )
-
-
 class TestAuthorizeGrantAgents:
     _SCOPES = ["https://www.googleapis.com/auth/gmail.modify"]
 
@@ -332,7 +317,7 @@ class TestAuthorizeGrantAgents:
             return_value={"flow_id": "f1", "authorization_url": "https://auth"}
         )
         monkeypatch.setattr("gaia.connectors.start_authorization", mock_start)
-        ui_api_client.app.state.agent_registry = _fake_registry(
+        ui_api_client.app.state.agent_registry = make_fake_agent_registry(
             "installed:email", "google", self._SCOPES
         )
 
@@ -365,7 +350,7 @@ class TestAuthorizeGrantAgents:
 
     def test_authorize_unknown_agent_is_404(self, ui_api_client, monkeypatch):
         monkeypatch.setattr("gaia.connectors.start_authorization", AsyncMock())
-        ui_api_client.app.state.agent_registry = _fake_registry(
+        ui_api_client.app.state.agent_registry = make_fake_agent_registry(
             "installed:email", "google", self._SCOPES
         )
         resp = ui_api_client.post(
@@ -380,7 +365,7 @@ class TestAuthorizeGrantAgents:
     ):
         monkeypatch.setattr("gaia.connectors.start_authorization", AsyncMock())
         # The agent declares microsoft, not google — no scopes for this connector.
-        ui_api_client.app.state.agent_registry = _fake_registry(
+        ui_api_client.app.state.agent_registry = make_fake_agent_registry(
             "installed:email", "microsoft", self._SCOPES
         )
         resp = ui_api_client.post(
@@ -400,7 +385,7 @@ class TestAuthorizeGrantAgents:
             return {"configured": True, "flow_id": "f1"}
 
         monkeypatch.setattr("gaia.ui.routers.connectors.configure", fake_configure)
-        ui_api_client.app.state.agent_registry = _fake_registry(
+        ui_api_client.app.state.agent_registry = make_fake_agent_registry(
             "installed:email", "google", self._SCOPES
         )
         resp = ui_api_client.post(
@@ -648,7 +633,7 @@ class TestAuthorizeDeviceEndpoint:
             AsyncMock(return_value=dict(self._DEVICE_INFO)),
         )
         monkeypatch.setattr("gaia.connectors.poll_device_flow", AsyncMock())
-        ui_api_client.app.state.agent_registry = _fake_registry(
+        ui_api_client.app.state.agent_registry = make_fake_agent_registry(
             "installed:email",
             "microsoft",
             ["https://graph.microsoft.com/Mail.ReadWrite"],

--- a/tests/unit/connectors/test_router_forwarded.py
+++ b/tests/unit/connectors/test_router_forwarded.py
@@ -19,13 +19,13 @@ Asserts:
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field
-from typing import List
 from unittest.mock import MagicMock
 
 import httpx
 import pytest
 import respx
+
+from tests.unit.connectors.conftest import make_fake_agent_registry
 
 UI_HEADER = {"x-gaia-ui": "1"}
 
@@ -95,8 +95,8 @@ class TestForwardPost:
         # so inject the email agent's registry entry directly — this keeps the
         # router's scope-resolution check deterministic and independent of which
         # agent wheels happen to be installed in the test env.
-        ui_api_client.app.state.agent_registry = _make_fake_registry(
-            provider="google", scopes=FULL_SCOPES, nsid="installed:email"
+        ui_api_client.app.state.agent_registry = make_fake_agent_registry(
+            connector_id="google", scopes=FULL_SCOPES, nsid="installed:email"
         )
         resp = ui_api_client.post(
             "/v1/connections/google",
@@ -182,8 +182,8 @@ class TestAgentActsAfterForward:
             )
 
         respx.post("https://oauth2.googleapis.com/token").mock(side_effect=_cap)
-        ui_api_client.app.state.agent_registry = _make_fake_registry(
-            provider="google", scopes=FULL_SCOPES, nsid="installed:email"
+        ui_api_client.app.state.agent_registry = make_fake_agent_registry(
+            connector_id="google", scopes=FULL_SCOPES, nsid="installed:email"
         )
 
         resp = ui_api_client.post(
@@ -248,29 +248,6 @@ def _ms_forward_body(**overrides):
     return body
 
 
-def _make_fake_registry(provider: str, scopes: list[str], nsid: str = "builtin:test"):
-    """Return an object that mimics AgentRegistry.list() for the router's
-    scope-resolution code (``request.app.state.agent_registry``)."""
-    from gaia.connectors.providers.base import ConnectorRequirement
-
-    @dataclass
-    class FakeReg:
-        namespaced_agent_id: str
-        required_connections: List[ConnectorRequirement] = field(default_factory=list)
-
-    @dataclass
-    class FakeRegistry:
-        _regs: List[FakeReg]
-
-        def list(self):
-            return self._regs
-
-    cr = ConnectorRequirement(connector_id=provider, scopes=scopes)
-    return FakeRegistry(
-        _regs=[FakeReg(namespaced_agent_id=nsid, required_connections=[cr])]
-    )
-
-
 # ─── New test classes ─────────────────────────────────────────────────────────
 
 
@@ -324,8 +301,8 @@ class TestRouterDrivenScopeResolution:
         """Inject a registry whose builtin:test agent requires
         gmail.modify for Google.  Forward Google scopes that exclude
         gmail.modify → should raise scope_mismatch via the router resolution."""
-        fake_registry = _make_fake_registry(
-            provider="google",
+        fake_registry = make_fake_agent_registry(
+            connector_id="google",
             scopes=["https://www.googleapis.com/auth/gmail.modify"],
             nsid="builtin:test",
         )
@@ -347,8 +324,8 @@ class TestRouterDrivenScopeResolution:
     def test_scope_satisfied_via_registry_returns_201(self, ui_api_client):
         """When the forwarded scopes cover the agent's declared requirements,
         the forward succeeds even though the default map would demand more."""
-        fake_registry = _make_fake_registry(
-            provider="google",
+        fake_registry = make_fake_agent_registry(
+            connector_id="google",
             scopes=["https://www.googleapis.com/auth/gmail.modify"],
             nsid="builtin:test",
         )
@@ -395,8 +372,8 @@ class TestRouterDrivenScopeResolution:
         grants, which also collapsed required_scopes to [] when no valid grant
         ids were present.
         """
-        ui_api_client.app.state.agent_registry = _make_fake_registry(
-            provider="google",
+        ui_api_client.app.state.agent_registry = make_fake_agent_registry(
+            connector_id="google",
             scopes=["https://www.googleapis.com/auth/gmail.modify"],
             nsid="builtin:test",
         )
@@ -422,8 +399,8 @@ class TestRouterDrivenScopeResolution:
 
     def test_mixed_known_and_unknown_grant_agents_are_rejected(self, ui_api_client):
         """Every requested grant id must be valid before import."""
-        ui_api_client.app.state.agent_registry = _make_fake_registry(
-            provider="google",
+        ui_api_client.app.state.agent_registry = make_fake_agent_registry(
+            connector_id="google",
             scopes=["https://www.googleapis.com/auth/gmail.modify"],
             nsid="builtin:test",
         )


### PR DESCRIPTION
Closes #2603

Connecting a mailbox from the CLI used to demand that you type out four scope URLs by hand, copied from documentation — even though the email agent already declares exactly what it needs and the Agent UI reads that declaration to ask for everything in one consent. People typed a subset, got a connection that worked until the first calendar action, and were sent back to Google to sign in again. Now `gaia connectors connect google --grant-agent installed:email` derives the scopes from the agent's own `REQUIRED_CONNECTORS`, through the same resolver the Agent UI's Connect button uses, so the two surfaces can't drift. `--scopes` still works when you want to grant something narrower.

⚠️ **Breaking change:** `--grant-agent` without `--scopes` previously failed with exit code 2. It now succeeds and launches an interactive OAuth consent covering every scope the agent declares. Automation depending on the old error path needs updating. Note also that `grant_agent()` overwrites rather than unions, so a deliberately narrow existing grant is replaced with the full declared set on reconnect.

## Test plan

- [x] `pytest tests/unit/connectors/ tests/unit/agents/test_registry.py -q` → **687 passed, 22 skipped**
- [x] `python util/lint.py --all` → **exit 0** (all 11 gates)
- [x] **Real CLI, live** — derivation, the union, the scope preview, and both fail-loud paths, evidenced below
- [x] **Refactored router, live on a booted server** — HTTP contract unchanged
- [ ] **Live Google consent (human checkpoint — an agent cannot complete a browser consent):** run the derived command through to completion and confirm the CLI reports the real account address rather than the literal `default`

### Real-world evidence — CLI

The whole fix is observable in the authorization URL GAIA generates, *before* the browser opens, so it was verified live without completing consent. Client id and PKCE values redacted; the flow was abandoned before callback, so nothing was persisted.

**Derived scopes — `--grant-agent installed:email`, no `--scopes`:**

```
Requesting access to google:
  - Manage your calendar events
  - Read your calendar events
  - Read, modify, and send email on your behalf
  - Send email on your behalf
  - See your email address
  - Verify your identity
flow: started scopes=6 grant_agents=1
Open this URL to authorize google:
  https://accounts.google.com/o/oauth2/v2/auth?client_id=<redacted>&...&scope=...
```

Decoded `scope=` parameter — the four declared scopes **plus** the two provider defaults:

```
  https://www.googleapis.com/auth/calendar.events
  https://www.googleapis.com/auth/calendar.readonly
  https://www.googleapis.com/auth/gmail.modify
  https://www.googleapis.com/auth/gmail.send
  https://www.googleapis.com/auth/userinfo.email
  openid                          ← the regression guard: without this the account email resolves to "default"
  count: 6
```

**`#2408` mechanism, caught live on a real install** — this is why the registry needs three calls, not two:

```
registry: No agent.py in ~/.gaia/agents/email, skipping
registry: Agent discovery complete. 1 agents registered: ['builder']     ← email absent after discover()
registry: Registered sidecar agent: email (namespaced installed:email)   ← only the third call bridges it
```

**Fail-loud paths (no network, no fallback to `default_scopes`):**

```
$ gaia connectors connect google --grant-agent installed:nope
Connectors error: Unknown agent id(s): installed:nope. Check the namespaced agent id
(e.g. 'installed:email') via `gaia connectors grants list` or the Agent UI's agent picker.
exit 5

$ gaia connectors connect google --grant-agent builtin:builder
Connectors error: Agent 'builtin:builder' declares no REQUIRED_CONNECTORS scopes for
connector 'google', so there is nothing to authorize or grant. Pass --scopes explicitly,
or check the agent's REQUIRED_CONNECTORS declaration.
exit 5
```

**Explicit `--scopes` does not widen** — `--grant-agent installed:email --scopes …/gmail.readonly` produced a `scope=` parameter containing exactly `https://www.googleapis.com/auth/gmail.readonly`, one scope, no union.

### Real-world evidence — refactored router

`_resolve_grant_scopes` is now a thin wrapper over the shared resolver. Booted `gaia.ui.server` (health 200) and hit the real endpoint — both shapes identical to pre-refactor:

```
POST /api/connectors/google/authorize  {"grant_agents":["installed:nope"]}
→ HTTP 404  {"detail":{"error":"unknown_agent","agent_ids":["installed:nope"]}}

POST /api/connectors/google/authorize  {"grant_agents":["builtin:builder"]}
→ HTTP 400  {"detail":{"error":"agent_declares_no_scopes","agent_id":"builtin:builder","connector_id":"google"}}
```

Test server torn down; the pre-existing Google connection was confirmed untouched.

<details>
<summary>Design notes — three traps this had to avoid</summary>

Adversarial review found several ways the obvious implementation breaks, all verified against source before the fix was written:

- **Authorize ≠ grant.** The agent's declared set contains no `openid`, and `flow.py`'s `list(scopes) or provider.default_scopes` short-circuits on a non-empty list, so a derived set would never pick up `openid`. Google issues no `id_token` without it and this provider has no `userinfo_url` fallback, so the account email would resolve to the literal string `default`. The fix authorizes the union with `default_scopes` but grants only the declared set — visible in the evidence above as 6 authorized vs 4 granted.
- **Three-call registry construction (#2408).** Email ships as a binary-only sidecar with its entry-point block commented out, so `discover()` alone never sees it. The obvious CLI precedent omits `register_installed_sidecars()` and would have reproduced #2408 on this PR's flagship command — the log capture above shows exactly that gap being bridged.
- **A scope ceiling that was never enforced.** `available_scopes` existed but was read nowhere. That was inert while scopes came from a human typing them; once an agent's own declaration feeds the OAuth `scope` parameter, any installed agent could put arbitrary scopes in front of the consent screen. `resolve_declared_scopes` now enforces the ceiling and raises rather than silently filtering.

Two items were deliberately cut and tracked separately: #2605 (`include_granted_scopes` needs a token-response reconciliation that lives in an out-of-scope file) and #2606 (consolidating `forward_connection`, whose more-permissive contract is pinned by its own test and shouldn't change here).

Known and unchanged: the explicit `--scopes` path still does **not** union with `default_scopes`, so a hand-typed scope list can still yield `Connected as default`. That is today's behaviour, deliberately preserved — and it is part of why #2602 exists.
</details>
