### PR TITLE
fix(tui): make the terminal hub readable on a light terminal background

### DIFF
--- a/docs/reference/cli.mdx
+++ b/docs/reference/cli.mdx
@@ -2520,6 +2520,22 @@ ctrl+c.
   with `d` and `delete`, which made "go back" a destructive action.
 </Note>
 
+#### Theme (light vs dark terminals)
+
+The hub asks the terminal for its background colour on startup and picks a
+light or dark palette to match, so text stays readable either way. Over SSH,
+inside tmux, or in a CI log where the terminal never answers that query, force
+a mode instead of guessing:
+
+```bash
+GAIA_TUI_THEME=light gaia tui    # or: dark
+```
+
+<Note>
+  `GAIA_TUI_THEME` also accepts `auto` (the default) to re-enable
+  detection.
+</Note>
+
 ---
 
 ### TUI Control API

--- a/tui/README.md
+++ b/tui/README.md
@@ -53,6 +53,27 @@ per-agent checks. Each row shows what failed and the command that fixes it.
 A check that cannot be determined renders `[?]` rather than a checkmark, and
 never counts as ready.
 
+## Theming
+
+The hub adapts to your terminal automatically — it asks the terminal for its
+background colour at startup and picks a light or dark palette to match.
+
+Some terminals never answer that query (SSH, tmux, a CI log). Force a mode
+with `GAIA_TUI_THEME`:
+
+```bash
+GAIA_TUI_THEME=light gaia    # or dark; unset or "auto" = detect
+```
+
 ## Documentation
 
 Full command reference: <https://amd-gaia.ai/docs/reference/cli>
+
+## Contributing
+
+New colours are added to `internal/ui/theme` and addressed by role
+(`theme.Text`, `theme.Danger`, `theme.Accent`…) — never a raw
+`lipgloss.Color("NNN")` in a screen file. Keep package-level colour vars as
+`lipgloss.Style` values and call `.Render()` where the string is actually
+used; a `.Render()` called at package-init time bakes in a string before
+`theme.Init()` has picked light or dark, so it never changes again.

--- a/tui/go.mod
+++ b/tui/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/charmbracelet/lipgloss v1.1.1-0.20250404203927-76690c660834
 	github.com/charmbracelet/x/ansi v0.11.6
 	github.com/charmbracelet/x/term v0.2.2
+	github.com/muesli/termenv v0.16.0
 	github.com/spf13/cobra v1.10.2
 	golang.org/x/sys v0.38.0
 )
@@ -36,7 +37,6 @@ require (
 	github.com/muesli/ansi v0.0.0-20230316100256-276c6243b2f6 // indirect
 	github.com/muesli/cancelreader v0.2.2 // indirect
 	github.com/muesli/reflow v0.3.0 // indirect
-	github.com/muesli/termenv v0.16.0 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/sahilm/fuzzy v0.1.1 // indirect
 	github.com/spf13/pflag v1.0.9 // indirect

--- a/tui/internal/ui/app.go
+++ b/tui/internal/ui/app.go
@@ -20,11 +20,16 @@ import (
 	"github.com/amd/gaia/tui/internal/ui/components"
 	"github.com/amd/gaia/tui/internal/ui/preflight"
 	"github.com/amd/gaia/tui/internal/ui/root"
+	"github.com/amd/gaia/tui/internal/ui/theme"
 )
 
 // prepareTerminal does everything that has to TALK to the terminal before
 // Bubble Tea takes over stdin. Every full-screen launch path calls it.
 func prepareTerminal() {
+	// First: it caches the light/dark answer that PrimeRenderer then reads, so
+	// the markdown style and the palette can never disagree, and a
+	// GAIA_TUI_THEME override reaches both.
+	theme.Init()
 	if err := components.PrimeRenderer(); err != nil {
 		fmt.Fprintf(os.Stderr,
 			"%v — replies will be shown as plain text. Report this with `gaia diagnostics`.\n", err)

--- a/tui/internal/ui/chat/model.go
+++ b/tui/internal/ui/chat/model.go
@@ -16,6 +16,8 @@ import (
 	"github.com/amd/gaia/tui/internal/client"
 	"github.com/amd/gaia/tui/internal/event"
 	"github.com/amd/gaia/tui/internal/ui/components"
+
+	"github.com/amd/gaia/tui/internal/ui/theme"
 )
 
 // eventMsg and doneMsg carry the channel they came from. Bubble Tea cannot
@@ -40,54 +42,54 @@ type ToggleHelpMsg struct{}
 var (
 	headerStyle = lipgloss.NewStyle().
 			Bold(true).
-			Foreground(lipgloss.Color("150")).
+			Foreground(theme.AccentBright).
 			Padding(0, 1)
 
 	userStyle = lipgloss.NewStyle().
 			Bold(true).
-			Foreground(lipgloss.Color("39"))
+			Foreground(theme.Info)
 
 	assistantStyle = lipgloss.NewStyle().
-			Foreground(lipgloss.Color("252"))
+			Foreground(theme.Text)
 
 	errorStyle = lipgloss.NewStyle().
-			Foreground(lipgloss.Color("196"))
+			Foreground(theme.Danger)
 
 	activityStyle = lipgloss.NewStyle().
-			Foreground(lipgloss.Color("243"))
+			Foreground(theme.Dim)
 
 	toolNameStyle = lipgloss.NewStyle().
 			Bold(true).
-			Foreground(lipgloss.Color("75"))
+			Foreground(theme.Info)
 
 	successStyle = lipgloss.NewStyle().
-			Foreground(lipgloss.Color("42"))
+			Foreground(theme.Success)
 
 	failStyle = lipgloss.NewStyle().
-			Foreground(lipgloss.Color("196"))
+			Foreground(theme.Danger)
 
 	dividerStyle = lipgloss.NewStyle().
-			Foreground(lipgloss.Color("238"))
+			Foreground(theme.Divider)
 
 	thinkingStyle = lipgloss.NewStyle().
-			Foreground(lipgloss.Color("42"))
+			Foreground(theme.Success)
 
 	stepStyle = lipgloss.NewStyle().
 			Bold(true).
-			Foreground(lipgloss.Color("39"))
+			Foreground(theme.Info)
 
 	statusMsgStyle = lipgloss.NewStyle().
-			Foreground(lipgloss.Color("243")).
+			Foreground(theme.Dim).
 			Italic(true)
 
 	answerPanelStyle = lipgloss.NewStyle().
 				Border(lipgloss.RoundedBorder()).
-				BorderForeground(lipgloss.Color("42")).
+				BorderForeground(theme.Success).
 				Padding(0, 1)
 
 	errorPanelStyle = lipgloss.NewStyle().
 			Border(lipgloss.RoundedBorder()).
-			BorderForeground(lipgloss.Color("196")).
+			BorderForeground(theme.Danger).
 			Padding(0, 1)
 )
 
@@ -145,7 +147,7 @@ func NewChatModel(c client.AgentClient, agentName string, initialQuery string, d
 
 	sp := spinner.New()
 	sp.Spinner = spinner.Dot
-	sp.Style = lipgloss.NewStyle().Foreground(lipgloss.Color("205"))
+	sp.Style = lipgloss.NewStyle().Foreground(theme.Highlight)
 
 	vp := viewport.New(80, 20)
 	vp.SetContent("")
@@ -743,11 +745,11 @@ func (m *ChatModel) updateViewport() {
 func (m ChatModel) renderWelcome() string {
 	title := lipgloss.NewStyle().
 		Bold(true).
-		Foreground(lipgloss.Color("150")).
+		Foreground(theme.AccentBright).
 		Render("Welcome to GAIA")
 
 	agent := lipgloss.NewStyle().
-		Foreground(lipgloss.Color("252")).
+		Foreground(theme.Text).
 		Render("Connected to: " + m.agentName)
 
 	hint := activityStyle.Render("Type a message and press Enter to start chatting.\nType /help for available commands.")
@@ -968,7 +970,7 @@ func (m ChatModel) renderActivityItem(item ActivityItem) string {
 		return "  " + successStyle.Render("[ok] ") + toolNameStyle.Render(content)
 
 	case "status":
-		return "       " + lipgloss.NewStyle().Foreground(lipgloss.Color("214")).Render(content)
+		return "       " + lipgloss.NewStyle().Foreground(theme.Warning).Render(content)
 
 	default:
 		return "       " + activityStyle.Render(content)
@@ -1065,6 +1067,6 @@ func extractCommandFromArgs(raw json.RawMessage) string {
 
 func (m ChatModel) renderHeader() string {
 	title := headerStyle.Render("GAIA")
-	name := lipgloss.NewStyle().Foreground(lipgloss.Color("252")).Render(" │ " + m.agentName)
+	name := lipgloss.NewStyle().Foreground(theme.Text).Render(" │ " + m.agentName)
 	return title + name
 }

--- a/tui/internal/ui/components/confirm.go
+++ b/tui/internal/ui/components/confirm.go
@@ -3,6 +3,8 @@ package components
 import (
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
+
+	"github.com/amd/gaia/tui/internal/ui/theme"
 )
 
 type ConfirmResult int
@@ -43,19 +45,19 @@ func NewConfirmModel(id, title, message string) ConfirmModel {
 var (
 	confirmBorder = lipgloss.NewStyle().
 			Border(lipgloss.RoundedBorder()).
-			BorderForeground(lipgloss.Color("114")).
+			BorderForeground(theme.Accent).
 			Padding(1, 2)
 
 	confirmTitle = lipgloss.NewStyle().Bold(true)
 
 	btnFocused = lipgloss.NewStyle().
 			Bold(true).
-			Foreground(lipgloss.Color("230")).
-			Background(lipgloss.Color("114")).
+			Foreground(theme.OnFill).
+			Background(theme.AccentFillBG).
 			Padding(0, 2)
 
 	btnUnfocused = lipgloss.NewStyle().
-			Foreground(lipgloss.Color("245")).
+			Foreground(theme.Dim).
 			Padding(0, 2)
 )
 

--- a/tui/internal/ui/components/confirmation.go
+++ b/tui/internal/ui/components/confirmation.go
@@ -6,6 +6,8 @@ import (
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
+
+	"github.com/amd/gaia/tui/internal/ui/theme"
 )
 
 // RiskTier classifies a confirmation-gated action for the badge on the modal.
@@ -29,13 +31,13 @@ const (
 
 var (
 	badgeReadStyle = lipgloss.NewStyle().Bold(true).
-			Foreground(lipgloss.Color("230")).Background(lipgloss.Color("114")).Padding(0, 1)
+			Foreground(theme.OnFill).Background(theme.AccentFillBG).Padding(0, 1)
 	badgeWriteStyle = lipgloss.NewStyle().Bold(true).
-			Foreground(lipgloss.Color("230")).Background(lipgloss.Color("33")).Padding(0, 1)
+			Foreground(theme.OnFill).Background(theme.InfoFillBG).Padding(0, 1)
 	badgeDestructiveStyle = lipgloss.NewStyle().Bold(true).
-				Foreground(lipgloss.Color("230")).Background(lipgloss.Color("196")).Padding(0, 1)
+				Foreground(theme.OnFill).Background(theme.DangerFillBG).Padding(0, 1)
 	badgeDeniedStyle = lipgloss.NewStyle().Bold(true).
-				Foreground(lipgloss.Color("252")).Background(lipgloss.Color("238")).Padding(0, 1)
+				Foreground(theme.OnSurface).Background(theme.SurfaceBG).Padding(0, 1)
 )
 
 // Badge is the short label shown on the modal. Colour is decoration only —
@@ -246,15 +248,15 @@ func (m ConfirmationModel) decide(state ConfirmState, timedOut bool) (Confirmati
 var (
 	confirmationPanelStyle = lipgloss.NewStyle().
 				Border(lipgloss.RoundedBorder()).
-				BorderForeground(lipgloss.Color("196")).
+				BorderForeground(theme.Danger).
 				Padding(0, 1)
 
-	confirmationTitleStyle = lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("196"))
-	confirmationBodyStyle  = lipgloss.NewStyle().Foreground(lipgloss.Color("252"))
-	confirmationWarnStyle  = lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("214"))
-	confirmationHintStyle  = lipgloss.NewStyle().Foreground(lipgloss.Color("243")).Italic(true)
-	confirmationOkStyle    = lipgloss.NewStyle().Foreground(lipgloss.Color("42"))
-	confirmationNoStyle    = lipgloss.NewStyle().Foreground(lipgloss.Color("196"))
+	confirmationTitleStyle = lipgloss.NewStyle().Bold(true).Foreground(theme.Danger)
+	confirmationBodyStyle  = lipgloss.NewStyle().Foreground(theme.Text)
+	confirmationWarnStyle  = lipgloss.NewStyle().Bold(true).Foreground(theme.Warning)
+	confirmationHintStyle  = lipgloss.NewStyle().Foreground(theme.Dim).Italic(true)
+	confirmationOkStyle    = lipgloss.NewStyle().Foreground(theme.Success)
+	confirmationNoStyle    = lipgloss.NewStyle().Foreground(theme.Danger)
 )
 
 // View renders the panel. Wrapping happens here and only here, exactly like

--- a/tui/internal/ui/components/helpoverlay.go
+++ b/tui/internal/ui/components/helpoverlay.go
@@ -1,6 +1,10 @@
 package components
 
-import "github.com/charmbracelet/lipgloss"
+import (
+	"github.com/charmbracelet/lipgloss"
+
+	"github.com/amd/gaia/tui/internal/ui/theme"
+)
 
 type HelpContext int
 
@@ -11,7 +15,7 @@ const (
 
 var helpBoxStyle = lipgloss.NewStyle().
 	Border(lipgloss.RoundedBorder()).
-	BorderForeground(lipgloss.Color("114")).
+	BorderForeground(theme.Accent).
 	Padding(1, 2)
 
 // RenderHelpOverlay renders a help panel centered over a background view.

--- a/tui/internal/ui/components/question.go
+++ b/tui/internal/ui/components/question.go
@@ -7,6 +7,8 @@ import (
 	"github.com/charmbracelet/bubbles/textinput"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
+
+	"github.com/amd/gaia/tui/internal/ui/theme"
 )
 
 // QuestionModel renders a mid-run question from the agent: the question itself,
@@ -57,18 +59,18 @@ type QuestionAnsweredMsg struct {
 var (
 	questionPanelStyle = lipgloss.NewStyle().
 				Border(lipgloss.RoundedBorder()).
-				BorderForeground(lipgloss.Color("214")).
+				BorderForeground(theme.Warning).
 				Padding(0, 1)
 
-	questionTitleStyle = lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("214"))
+	questionTitleStyle = lipgloss.NewStyle().Bold(true).Foreground(theme.Warning)
 
-	questionSelectedStyle = lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("230"))
+	questionSelectedStyle = lipgloss.NewStyle().Bold(true).Foreground(theme.AccentBright)
 
-	questionOptionStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("252"))
+	questionOptionStyle = lipgloss.NewStyle().Foreground(theme.Text)
 
-	questionDescStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("245"))
+	questionDescStyle = lipgloss.NewStyle().Foreground(theme.Dim)
 
-	questionHintStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("243")).Italic(true)
+	questionHintStyle = lipgloss.NewStyle().Foreground(theme.Dim).Italic(true)
 )
 
 // NewQuestionModel builds the picker. A question with no options and no free

--- a/tui/internal/ui/components/statusbar.go
+++ b/tui/internal/ui/components/statusbar.go
@@ -5,6 +5,8 @@ import (
 	"strings"
 
 	"github.com/charmbracelet/lipgloss"
+
+	"github.com/amd/gaia/tui/internal/ui/theme"
 )
 
 type StatusBarState struct {
@@ -17,19 +19,25 @@ type StatusBarState struct {
 
 var (
 	statusBarStyle = lipgloss.NewStyle().
-			Background(lipgloss.Color("236")).
-			Foreground(lipgloss.Color("252")).
+			Background(theme.SurfaceBG).
+			Foreground(theme.OnSurface).
 			Padding(0, 1)
 
-	connectedDot    = lipgloss.NewStyle().Foreground(lipgloss.Color("42")).Render("●")
-	disconnectedDot = lipgloss.NewStyle().Foreground(lipgloss.Color("196")).Render("●")
+	connectedDotStyle    = lipgloss.NewStyle().Foreground(theme.Success)
+	disconnectedDotStyle = lipgloss.NewStyle().Foreground(theme.Danger)
 )
 
+// The dots are rendered per call, not stored pre-rendered: an AdaptiveColor
+// resolves when it is rendered, and a package-level Render() would freeze the
+// light/dark choice before theme.Init has made it.
+func connectedDot() string    { return connectedDotStyle.Render("●") }
+func disconnectedDot() string { return disconnectedDotStyle.Render("●") }
+
 func RenderStatusBar(state StatusBarState, width int) string {
-	dot := disconnectedDot
+	dot := disconnectedDot()
 	status := "disconnected"
 	if state.Connected {
-		dot = connectedDot
+		dot = connectedDot()
 		status = "connected"
 	}
 	if state.Streaming {

--- a/tui/internal/ui/hub/delegate.go
+++ b/tui/internal/ui/hub/delegate.go
@@ -10,23 +10,26 @@ import (
 	"github.com/charmbracelet/x/ansi"
 
 	"github.com/amd/gaia/tui/internal/catalog"
+	"github.com/amd/gaia/tui/internal/ui/theme"
 )
 
 var (
 	categoryStyle = lipgloss.NewStyle().
-			Foreground(lipgloss.Color("243")).
+			Foreground(theme.Dim).
 			Italic(true)
 
 	versionStyle = lipgloss.NewStyle().
-			Foreground(lipgloss.Color("238"))
+			Foreground(theme.Faint)
 
-	selectedCursor = lipgloss.NewStyle().
-			Foreground(lipgloss.Color("212")).
-			Bold(true).
-			Render("▸ ")
+	selectedCursorStyle = lipgloss.NewStyle().
+				Foreground(theme.Highlight).
+				Bold(true)
 
 	normalCursor = "  "
 )
+
+// Rendered per call — see the note on the dot helpers in styles.go.
+func selectedCursor() string { return selectedCursorStyle.Render("▸ ") }
 
 type agentDelegate struct{}
 
@@ -65,7 +68,7 @@ func (d agentDelegate) Render(w io.Writer, m list.Model, index int, item list.It
 
 	cursor := normalCursor
 	if isSelected {
-		cursor = selectedCursor
+		cursor = selectedCursor()
 	}
 
 	line1 := cursor + dot + " " + name + ver
@@ -119,15 +122,15 @@ func meta(agent catalog.Agent) string {
 func statusDotFor(status catalog.AgentStatus) string {
 	switch status {
 	case catalog.StatusActive:
-		return activeDot
+		return activeDot()
 	case catalog.StatusIdle:
-		return idleDot
+		return idleDot()
 	case catalog.StatusInstalled:
-		return installedDot
+		return installedDot()
 	case catalog.StatusAvailable:
-		return availableDot
+		return availableDot()
 	case catalog.StatusComingSoon:
-		return comingSoonDot
+		return comingSoonDot()
 	default:
 		return " "
 	}

--- a/tui/internal/ui/hub/install.go
+++ b/tui/internal/ui/hub/install.go
@@ -11,6 +11,8 @@ import (
 	"github.com/charmbracelet/lipgloss"
 
 	"github.com/amd/gaia/tui/internal/catalog"
+
+	"github.com/amd/gaia/tui/internal/ui/theme"
 )
 
 // pollInterval paces install-status polling. The daemon writes progress from a
@@ -159,17 +161,17 @@ func (s installState) done() bool {
 var (
 	installBorder = lipgloss.NewStyle().
 			Border(lipgloss.RoundedBorder()).
-			BorderForeground(lipgloss.Color("114")).
+			BorderForeground(theme.Accent).
 			Padding(1, 2)
 
 	installFailBorder = lipgloss.NewStyle().
 				Border(lipgloss.RoundedBorder()).
-				BorderForeground(lipgloss.Color("203")).
+				BorderForeground(theme.Danger).
 				Padding(1, 2)
 
-	barFill  = lipgloss.NewStyle().Foreground(lipgloss.Color("114"))
-	barEmpty = lipgloss.NewStyle().Foreground(lipgloss.Color("238"))
-	failText = lipgloss.NewStyle().Foreground(lipgloss.Color("203"))
+	barFill  = lipgloss.NewStyle().Foreground(theme.Accent)
+	barEmpty = lipgloss.NewStyle().Foreground(theme.Divider)
+	failText = lipgloss.NewStyle().Foreground(theme.Danger)
 )
 
 func (s installState) View(width int) string {

--- a/tui/internal/ui/hub/model.go
+++ b/tui/internal/ui/hub/model.go
@@ -12,6 +12,8 @@ import (
 	"github.com/amd/gaia/tui/internal/catalog"
 	"github.com/amd/gaia/tui/internal/ui/components"
 	"github.com/amd/gaia/tui/internal/vote"
+
+	"github.com/amd/gaia/tui/internal/ui/theme"
 )
 
 // compactHeightRows is the terminal height below which the ASCII logo is
@@ -586,8 +588,8 @@ func (m HubModel) line(s string, style lipgloss.Style) string {
 
 func (m HubModel) renderHeader() string {
 	if m.compact() {
-		wordmark := lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("150")).Render(" G A I A")
-		sub := lipgloss.NewStyle().Foreground(lipgloss.Color("243")).Italic(true).
+		wordmark := lipgloss.NewStyle().Bold(true).Foreground(theme.AccentBright).Render(" G A I A")
+		sub := lipgloss.NewStyle().Foreground(theme.Dim).Italic(true).
 			Render("  Local AI Agent Hub — by AMD")
 		return m.line(wordmark+sub, lipgloss.NewStyle())
 	}
@@ -596,11 +598,11 @@ func (m HubModel) renderHeader() string {
 
 	gaiaText := lipgloss.NewStyle().
 		Bold(true).
-		Foreground(lipgloss.Color("150")).
+		Foreground(theme.AccentBright).
 		Render("  G A I A")
 
 	subtitle := lipgloss.NewStyle().
-		Foreground(lipgloss.Color("243")).
+		Foreground(theme.Dim).
 		Italic(true).
 		Render("  Local AI Agent Hub — by AMD")
 
@@ -610,12 +612,12 @@ func (m HubModel) renderHeader() string {
 // colorizeRobotLogo renders the GAIA robot ASCII art with colors matching the mascot PNG.
 func colorizeRobotLogo() string {
 	// Colors from the GAIA mascot: green body, cyan eyes, dark background
-	bright := lipgloss.NewStyle().Foreground(lipgloss.Color("150")) // brightest green (body highlights)
-	body := lipgloss.NewStyle().Foreground(lipgloss.Color("114"))   // solid green (body)
-	mid := lipgloss.NewStyle().Foreground(lipgloss.Color("107"))    // muted green (mid-tone)
-	detail := lipgloss.NewStyle().Foreground(lipgloss.Color("65"))  // dark green (detail)
-	shadow := lipgloss.NewStyle().Foreground(lipgloss.Color("238")) // dark shadow
-	eye := lipgloss.NewStyle().Foreground(lipgloss.Color("51"))     // cyan (eyes)
+	bright := lipgloss.NewStyle().Foreground(theme.ArtBright) // body highlights
+	body := lipgloss.NewStyle().Foreground(theme.ArtBody)     // solid green
+	mid := lipgloss.NewStyle().Foreground(theme.ArtMid)       // mid-tone
+	detail := lipgloss.NewStyle().Foreground(theme.ArtDetail) // detail
+	shadow := lipgloss.NewStyle().Foreground(theme.ArtShadow) // shading
+	eye := lipgloss.NewStyle().Foreground(theme.ArtEye)       // eyes
 
 	lines := []string{
 		"               +=-------                 ",
@@ -726,8 +728,8 @@ func (m HubModel) renderBody() string {
 }
 
 func (m HubModel) emptyState() string {
-	dim := lipgloss.NewStyle().Foreground(lipgloss.Color("243"))
-	accent := lipgloss.NewStyle().Foreground(lipgloss.Color("150"))
+	dim := lipgloss.NewStyle().Foreground(theme.Dim)
+	accent := lipgloss.NewStyle().Foreground(theme.AccentBright)
 
 	if m.list.FilterState() != list.Unfiltered {
 		return dim.Render("\n  Nothing matches that search.  esc clears it.")
@@ -785,7 +787,7 @@ func (m HubModel) renderStatus() string {
 	// firstLine, not just truncate: ansi.Truncate does not collapse newlines,
 	// and a multi-line message (a daemon start failure quotes its launcher
 	// output) would silently break chromeHeight's one-row budget.
-	return m.line(" "+firstLine(text), lipgloss.NewStyle().Foreground(lipgloss.Color("214")))
+	return m.line(" "+firstLine(text), lipgloss.NewStyle().Foreground(theme.Warning))
 }
 
 func (m HubModel) renderFooter() string {

--- a/tui/internal/ui/hub/styles.go
+++ b/tui/internal/ui/hub/styles.go
@@ -1,13 +1,17 @@
 package hub
 
-import "github.com/charmbracelet/lipgloss"
+import (
+	"github.com/charmbracelet/lipgloss"
+
+	"github.com/amd/gaia/tui/internal/ui/theme"
+)
 
 // AMD-inspired color palette: greens and teals from the GAIA robot mascot
 var (
-	// Primary accent — muted green (matches GAIA robot)
-	accentColor = lipgloss.Color("114")
+	// Primary accent — the GAIA green (matches the robot)
+	accentColor = theme.Accent
 	// Bright accent — for selected/highlighted items
-	brightAccent = lipgloss.Color("150")
+	brightAccent = theme.AccentBright
 
 	titleStyle = lipgloss.NewStyle().
 			Bold(true).
@@ -15,12 +19,12 @@ var (
 			Padding(0, 1)
 
 	dashboardStyle = lipgloss.NewStyle().
-			Foreground(lipgloss.Color("252")).
+			Foreground(theme.Text).
 			Padding(0, 1)
 
-	installedLabel = lipgloss.NewStyle().Foreground(lipgloss.Color("252"))
-	activeLabel    = lipgloss.NewStyle().Foreground(lipgloss.Color("42")).Bold(true)
-	idleLabel      = lipgloss.NewStyle().Foreground(lipgloss.Color("214")).Bold(true)
+	installedLabel = lipgloss.NewStyle().Foreground(theme.Text)
+	activeLabel    = lipgloss.NewStyle().Foreground(theme.Success).Bold(true)
+	idleLabel      = lipgloss.NewStyle().Foreground(theme.Warning).Bold(true)
 
 	tabActive = lipgloss.NewStyle().
 			Bold(true).
@@ -29,15 +33,15 @@ var (
 			Padding(0, 2)
 
 	tabInactive = lipgloss.NewStyle().
-			Foreground(lipgloss.Color("243")).
+			Foreground(theme.Dim).
 			Padding(0, 2)
 
 	dividerStyle = lipgloss.NewStyle().
-			Foreground(lipgloss.Color("238"))
+			Foreground(theme.Divider)
 
 	statusBarStyle = lipgloss.NewStyle().
-			Background(lipgloss.Color("236")).
-			Foreground(lipgloss.Color("252")).
+			Background(theme.SurfaceBG).
+			Foreground(theme.OnSurface).
 			Padding(0, 1)
 
 	// Agent list item styles
@@ -46,21 +50,30 @@ var (
 				Bold(true)
 
 	normalItemStyle = lipgloss.NewStyle().
-			Foreground(lipgloss.Color("252"))
+			Foreground(theme.Text)
 
 	descriptionStyle = lipgloss.NewStyle().
-				Foreground(lipgloss.Color("243"))
+				Foreground(theme.Dim)
 
 	selectedDescStyle = lipgloss.NewStyle().
-				Foreground(lipgloss.Color("252"))
+				Foreground(theme.Text)
 
 	// Status dots — green for active, amber for idle, dim for installed
-	activeDot    = lipgloss.NewStyle().Foreground(lipgloss.Color("42")).Render("●")
-	idleDot      = lipgloss.NewStyle().Foreground(lipgloss.Color("214")).Render("●")
-	installedDot = lipgloss.NewStyle().Foreground(lipgloss.Color("243")).Render("●")
-	availableDot = lipgloss.NewStyle().Foreground(lipgloss.Color("243")).Render("○")
-	comingSoonDot = lipgloss.NewStyle().Foreground(lipgloss.Color("243")).Render("◌")
+	activeDotStyle     = lipgloss.NewStyle().Foreground(theme.Success)
+	idleDotStyle       = lipgloss.NewStyle().Foreground(theme.Warning)
+	installedDotStyle  = lipgloss.NewStyle().Foreground(theme.Dim)
+	availableDotStyle  = lipgloss.NewStyle().Foreground(theme.Dim)
+	comingSoonDotStyle = lipgloss.NewStyle().Foreground(theme.Dim)
 
 	voteStyle = lipgloss.NewStyle().
-			Foreground(lipgloss.Color("214"))
+			Foreground(theme.Warning)
 )
+
+// Dots are rendered per call. An AdaptiveColor resolves at Render time, so a
+// package-level Render() would freeze the light/dark choice before theme.Init
+// has made it.
+func activeDot() string     { return activeDotStyle.Render("●") }
+func idleDot() string       { return idleDotStyle.Render("●") }
+func installedDot() string  { return installedDotStyle.Render("●") }
+func availableDot() string  { return availableDotStyle.Render("○") }
+func comingSoonDot() string { return comingSoonDotStyle.Render("◌") }

--- a/tui/internal/ui/hub/trust.go
+++ b/tui/internal/ui/hub/trust.go
@@ -8,6 +8,8 @@ import (
 	"github.com/charmbracelet/lipgloss"
 
 	"github.com/amd/gaia/tui/internal/catalog"
+
+	"github.com/amd/gaia/tui/internal/ui/theme"
 )
 
 // trustDecisionMsg is the user's answer to the trust gate. Approved is true
@@ -86,28 +88,28 @@ func (m trustModel) Update(msg tea.Msg) (trustModel, tea.Cmd) {
 var (
 	trustBorder = lipgloss.NewStyle().
 			Border(lipgloss.RoundedBorder()).
-			BorderForeground(lipgloss.Color("214")).
+			BorderForeground(theme.Warning).
 			Padding(1, 2)
 
-	trustTitleStyle = lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("214"))
-	trustKeyStyle   = lipgloss.NewStyle().Foreground(lipgloss.Color("243"))
-	trustValStyle   = lipgloss.NewStyle().Foreground(lipgloss.Color("252"))
-	trustWarnStyle  = lipgloss.NewStyle().Foreground(lipgloss.Color("214"))
-	trustHintStyle  = lipgloss.NewStyle().Foreground(lipgloss.Color("243"))
+	trustTitleStyle = lipgloss.NewStyle().Bold(true).Foreground(theme.Warning)
+	trustKeyStyle   = lipgloss.NewStyle().Foreground(theme.Dim)
+	trustValStyle   = lipgloss.NewStyle().Foreground(theme.Text)
+	trustWarnStyle  = lipgloss.NewStyle().Foreground(theme.Warning)
+	trustHintStyle  = lipgloss.NewStyle().Foreground(theme.Dim)
 
 	dangerBtnFocused = lipgloss.NewStyle().
 				Bold(true).
-				Foreground(lipgloss.Color("232")).
-				Background(lipgloss.Color("214")).
+				Foreground(theme.OnFill).
+				Background(theme.WarnFillBG).
 				Padding(0, 2)
 
 	safeBtnFocused = lipgloss.NewStyle().
 			Bold(true).
-			Foreground(lipgloss.Color("230")).
-			Background(lipgloss.Color("114")).
+			Foreground(theme.OnFill).
+			Background(theme.AccentFillBG).
 			Padding(0, 2)
 
-	btnDim = lipgloss.NewStyle().Foreground(lipgloss.Color("245")).Padding(0, 2)
+	btnDim = lipgloss.NewStyle().Foreground(theme.Dim).Padding(0, 2)
 )
 
 // fixedTrustRows is everything in the box except the daemon's reason: borders,

--- a/tui/internal/ui/preflight/theming_test.go
+++ b/tui/internal/ui/preflight/theming_test.go
@@ -1,0 +1,159 @@
+package preflight
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/charmbracelet/lipgloss"
+	"github.com/muesli/termenv"
+
+	"github.com/amd/gaia/tui/internal/ui/theme"
+)
+
+// The readiness screen is where a user meets GAIA before anything else works,
+// so it is the screen these tests hold to the palette. Both assertions are
+// about the ESCAPE CODES, not the words — every other test in this package
+// strips styling on purpose, which is exactly why a colour regression could
+// never fail one of them.
+
+// renderBothModes returns the readiness screen as it reaches a truecolor
+// terminal, once assuming a light background and once a dark one.
+func renderBothModes(t *testing.T) (light, dark string) {
+	t.Helper()
+
+	// Tests do not run on a TTY, so lipgloss would otherwise strip every colour
+	// and both modes would render identically — passing for the wrong reason.
+	prevProfile := lipgloss.ColorProfile()
+	prevDark := lipgloss.HasDarkBackground()
+	lipgloss.SetColorProfile(termenv.TrueColor)
+	t.Cleanup(func() {
+		lipgloss.SetColorProfile(prevProfile)
+		lipgloss.SetHasDarkBackground(prevDark)
+	})
+
+	render := func(dark bool) string {
+		lipgloss.SetHasDarkBackground(dark)
+		f := newFake()
+		m, _ := renderAt(t, f, 100, 30)
+		return m.View()
+	}
+	return render(false), render(true)
+}
+
+func TestReadinessScreenAdaptsToBackground(t *testing.T) {
+	light, dark := renderBothModes(t)
+
+	if stripANSI(light) != stripANSI(dark) {
+		t.Fatalf("the two modes rendered different TEXT; the comparison below would be meaningless")
+	}
+	if light == dark {
+		t.Error("the readiness screen renders identically on a light and a dark " +
+			"background: its colours are not going through theme tokens")
+	}
+}
+
+// TestReadinessScreenUsesOnlyPaletteColours is the guard against a hardcoded
+// colour surviving anywhere on the screen. Anything the renderer emits has to be
+// a value theme.All() declares for the mode being rendered.
+func TestReadinessScreenUsesOnlyPaletteColours(t *testing.T) {
+	light, dark := renderBothModes(t)
+
+	for _, mode := range []struct {
+		name   string
+		screen string
+		dark   bool
+	}{{"light", light, false}, {"dark", dark, true}} {
+		var allowed []string
+		for _, c := range theme.All() {
+			hex := c.Light
+			if mode.dark {
+				hex = c.Dark
+			}
+			allowed = append(allowed, strings.ToUpper(hex))
+		}
+		for _, got := range truecolorsIn(mode.screen) {
+			if !nearAny(got, allowed) {
+				t.Errorf("%s mode emits %s, which is not in the %s palette",
+					mode.name, got, mode.name)
+			}
+		}
+	}
+}
+
+// truecolorRE matches the SGR form lipgloss emits for a 24-bit colour:
+// 38;2;R;G;B for a foreground and 48;2;R;G;B for a background.
+var truecolorRE = regexp.MustCompile(`[34]8;2;(\d{1,3});(\d{1,3});(\d{1,3})`)
+
+// ansi256RE matches the SGR form lipgloss emits when the profile can only do
+// indexed colour: 38;5;N for a foreground and 48;5;N for a background. A
+// lipgloss.Color("N") — the exact hardcoded-index bug this whole change
+// removed — emits this form even on a truecolor profile: termenv's profile
+// conversion only ever degrades a colour, never upgrades an indexed one to
+// 24-bit. Without matching this form too, the guard is blind to that
+// regression.
+var ansi256RE = regexp.MustCompile(`[34]8;5;(\d{1,3})`)
+
+func truecolorsIn(s string) []string {
+	var out []string
+	seen := map[string]bool{}
+	add := func(hex string) {
+		if !seen[hex] {
+			seen[hex] = true
+			out = append(out, hex)
+		}
+	}
+	for _, m := range truecolorRE.FindAllStringSubmatch(s, -1) {
+		var r, g, b int
+		fmt.Sscanf(m[1], "%d", &r)
+		fmt.Sscanf(m[2], "%d", &g)
+		fmt.Sscanf(m[3], "%d", &b)
+		add(fmt.Sprintf("#%02X%02X%02X", r, g, b))
+	}
+	for _, m := range ansi256RE.FindAllStringSubmatch(s, -1) {
+		var n int
+		fmt.Sscanf(m[1], "%d", &n)
+		add(hexFromANSI256(n))
+	}
+	return out
+}
+
+// hexFromANSI256 converts an indexed colour to RGB via termenv — the same
+// library lipgloss itself uses — so this test and the renderer agree on the
+// conversion by construction rather than by a hand-rolled xterm cube.
+func hexFromANSI256(n int) string {
+	c := termenv.ConvertToRGB(termenv.ANSI256Color(n))
+	return strings.ToUpper(c.Hex())
+}
+
+// nearAny allows a one-step channel drift: lipgloss converts a hex string to
+// floating-point RGB and back before emitting it, so #116329 can leave as
+// #116328. Anything further off is a colour that did not come from the palette.
+func nearAny(got string, allowed []string) bool {
+	for _, want := range allowed {
+		if maxChannelDelta(got, want) <= 2 {
+			return true
+		}
+	}
+	return false
+}
+
+func maxChannelDelta(a, b string) int {
+	worst := 0
+	for i := 1; i < 7; i += 2 {
+		var x, y int
+		fmt.Sscanf(a[i:i+2], "%x", &x)
+		fmt.Sscanf(b[i:i+2], "%x", &y)
+		if d := x - y; d > worst {
+			worst = d
+		} else if -d > worst {
+			worst = -d
+		}
+	}
+	return worst
+}
+
+var ansiRE = regexp.MustCompile(`\x1b\[[0-9;]*m`)
+
+func stripANSI(s string) string { return ansiRE.ReplaceAllString(s, "") }

--- a/tui/internal/ui/preflight/view.go
+++ b/tui/internal/ui/preflight/view.go
@@ -5,6 +5,8 @@ import (
 	"strings"
 
 	"github.com/charmbracelet/lipgloss"
+
+	"github.com/amd/gaia/tui/internal/ui/theme"
 )
 
 // Colour is ADDITIVE here. Every state is already carried by its text marker
@@ -12,17 +14,17 @@ import (
 // reads identically on a monochrome terminal, over a pipe, or to a user who
 // cannot distinguish red from green.
 var (
-	titleStyle   = lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("150"))
-	summaryStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("243"))
-	dividerStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("238"))
-	labelStyle   = lipgloss.NewStyle().Foreground(lipgloss.Color("252"))
-	dimStyle     = lipgloss.NewStyle().Foreground(lipgloss.Color("243"))
-	okStyle      = lipgloss.NewStyle().Foreground(lipgloss.Color("42"))
-	failStyle    = lipgloss.NewStyle().Foreground(lipgloss.Color("196"))
-	unknownStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("214"))
-	keyStyle     = lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("39"))
-	noteStyle    = lipgloss.NewStyle().Foreground(lipgloss.Color("214"))
-	cmdStyle     = lipgloss.NewStyle().Foreground(lipgloss.Color("150"))
+	titleStyle   = lipgloss.NewStyle().Bold(true).Foreground(theme.AccentBright)
+	summaryStyle = lipgloss.NewStyle().Foreground(theme.Dim)
+	dividerStyle = lipgloss.NewStyle().Foreground(theme.Divider)
+	labelStyle   = lipgloss.NewStyle().Foreground(theme.Text)
+	dimStyle     = lipgloss.NewStyle().Foreground(theme.Dim)
+	okStyle      = lipgloss.NewStyle().Foreground(theme.Success)
+	failStyle    = lipgloss.NewStyle().Foreground(theme.Danger)
+	unknownStyle = lipgloss.NewStyle().Foreground(theme.Warning)
+	keyStyle     = lipgloss.NewStyle().Bold(true).Foreground(theme.Info)
+	noteStyle    = lipgloss.NewStyle().Foreground(theme.Warning)
+	cmdStyle     = lipgloss.NewStyle().Foreground(theme.Accent)
 )
 
 const (

--- a/tui/internal/ui/root/preflight.go
+++ b/tui/internal/ui/root/preflight.go
@@ -10,6 +10,8 @@ import (
 	"github.com/amd/gaia/tui/internal/catalog"
 	"github.com/amd/gaia/tui/internal/daemon"
 	"github.com/amd/gaia/tui/internal/ui/preflight"
+
+	"github.com/amd/gaia/tui/internal/ui/theme"
 )
 
 // beginPreflight puts the readiness gate between the hub and the chat.
@@ -215,12 +217,12 @@ func (m RootModel) handleConnectKey(key tea.KeyMsg) (tea.Model, tea.Cmd) {
 }
 
 var (
-	connectTitle   = lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("150"))
-	connectDim     = lipgloss.NewStyle().Foreground(lipgloss.Color("243"))
-	connectDivider = lipgloss.NewStyle().Foreground(lipgloss.Color("238"))
-	connectText    = lipgloss.NewStyle().Foreground(lipgloss.Color("252"))
-	connectCmd     = lipgloss.NewStyle().Foreground(lipgloss.Color("150"))
-	connectKey     = lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("39"))
+	connectTitle   = lipgloss.NewStyle().Bold(true).Foreground(theme.AccentBright)
+	connectDim     = lipgloss.NewStyle().Foreground(theme.Dim)
+	connectDivider = lipgloss.NewStyle().Foreground(theme.Divider)
+	connectText    = lipgloss.NewStyle().Foreground(theme.Text)
+	connectCmd     = lipgloss.NewStyle().Foreground(theme.Accent)
+	connectKey     = lipgloss.NewStyle().Bold(true).Foreground(theme.Info)
 )
 
 // outlookSetupDoc is where the Outlook path continues. It is a doc, not a

--- a/tui/internal/ui/theme/contrast_test.go
+++ b/tui/internal/ui/theme/contrast_test.go
@@ -1,0 +1,482 @@
+package theme
+
+import (
+	"fmt"
+	"go/ast"
+	"go/parser"
+	gotoken "go/token"
+	"math"
+	"testing"
+
+	"github.com/charmbracelet/lipgloss"
+	"github.com/muesli/termenv"
+)
+
+// The backgrounds below are the real defaults of the three terminals GAIA is
+// tested on, plus Solarized (light and dark), which every one of them ships,
+// plus Nord — not a GAIA-tested terminal's own default, but the lightest dark
+// background in common use anywhere near this palette (Nord #2E3440 luminance
+// 0.0341 vs One Half Dark #282C34's 0.0250; GNOME Tango Dark #2E3436 and
+// Solarized Dark High-Contrast #073642 are lighter than One Half Dark too, at
+// 0.0330 and 0.0308, but both are darker than Nord, so Nord alone subsumes
+// them — a token that clears its floor against Nord clears it against those
+// two as well). One Half Dark was previously documented as "the lightest
+// common dark background", which was never true of this set and left Danger
+// and SurfaceBG failing their floors against Nord/Tango/Solarized-HC
+// undetected. Solarized Light is the darkest common light background, so a
+// token that clears its floor against both ends clears it on anything in
+// between.
+type background struct {
+	name string
+	hex  string
+	dark bool
+}
+
+var backgrounds = []background{
+	{"macOS Terminal · Basic", "#FFFFFF", false},
+	{"GNOME Terminal · light", "#FFFFFF", false},
+	{"Windows Terminal · One Half Light", "#FAFAFA", false},
+	{"Solarized Light", "#FDF6E3", false},
+
+	{"macOS Terminal · Pro", "#000000", true},
+	{"GNOME Terminal · Ubuntu", "#300A24", true},
+	{"Windows Terminal · Campbell", "#0C0C0C", true},
+	{"One Half Dark", "#282C34", true},
+	{"Solarized Dark", "#002B36", true},
+	{"Nord", "#2E3440", true},
+}
+
+type role int
+
+const (
+	// roleText carries information as words. WCAG 2.1 AA for body text.
+	roleText role = iota
+	// roleFaint is deliberately recessive text that always duplicates
+	// something stated elsewhere on the row. WCAG AA for large text.
+	roleFaint
+	// roleChrome is a rule, a bar track, or mascot shading. Not information —
+	// the floor only has to keep it from vanishing into the background.
+	roleChrome
+)
+
+func (r role) floor() float64 {
+	switch r {
+	case roleText:
+		return 4.5
+	case roleFaint:
+		return 3.0
+	default:
+		return 1.5
+	}
+}
+
+func (r role) String() string {
+	return [...]string{"text", "faint", "chrome"}[r]
+}
+
+// entry is one palette colour and the job it does.
+type entry struct {
+	name  string
+	color lipgloss.AdaptiveColor
+	role  role
+}
+
+// tokens must name every AdaptiveColor exported by the package —
+// TestEveryTokenHasAFloor enforces that, so a new colour cannot be added
+// without deciding what contrast it owes the reader.
+var tokens = []entry{
+	{"Text", Text, roleText},
+	{"Dim", Dim, roleText},
+	{"Accent", Accent, roleText},
+	{"AccentBright", AccentBright, roleText},
+	{"Success", Success, roleText},
+	{"Warning", Warning, roleText},
+	{"Danger", Danger, roleText},
+	{"Info", Info, roleText},
+	{"Highlight", Highlight, roleText},
+
+	{"Faint", Faint, roleFaint},
+
+	{"Divider", Divider, roleChrome},
+	{"ArtBright", ArtBright, roleChrome},
+	{"ArtBody", ArtBody, roleChrome},
+	{"ArtMid", ArtMid, roleChrome},
+	{"ArtDetail", ArtDetail, roleChrome},
+	{"ArtShadow", ArtShadow, roleChrome},
+	{"ArtEye", ArtEye, roleChrome},
+
+	// Fills cover the terminal background, so against it they only need to be
+	// visible as a block; legibility is the pair's job (TestFillPairs).
+	{"AccentFillBG", AccentFillBG, roleChrome},
+	{"WarnFillBG", WarnFillBG, roleChrome},
+	{"DangerFillBG", DangerFillBG, roleChrome},
+	{"InfoFillBG", InfoFillBG, roleChrome},
+	{"SurfaceBG", SurfaceBG, roleChrome},
+}
+
+// fill pairs paint their own background, so they are judged against each
+// other rather than against a terminal background. Most are body text on a
+// filled button (4.5:1); the status dots are a short word's worth of colour on
+// SurfaceBG, so they get the 3:1 roleFaint-equivalent floor instead — see
+// SurfaceBG's comment in theme.go for why that pairing is tight enough to
+// document explicitly.
+var fills = []struct {
+	name   string
+	fg, bg lipgloss.AdaptiveColor
+	floor  float64
+}{
+	{"accent button", OnFill, AccentFillBG, 4.5},
+	{"warning button", OnFill, WarnFillBG, 4.5},
+	{"danger button", OnFill, DangerFillBG, 4.5},
+	{"info button", OnFill, InfoFillBG, 4.5},
+	{"quiet surface", OnSurface, SurfaceBG, 4.5},
+
+	// components/statusbar.go paints these two directly on SurfaceBG (the
+	// connected/disconnected dot); confirmed by grep as the only tokens
+	// actually rendered there. Warning is never rendered on SurfaceBG in this
+	// codebase — hub/styles.go's idle/warning styles carry no Background — and
+	// is deliberately left out: forcing a floor for a pairing that does not
+	// exist would require either lowering SurfaceBG's own terminal-background
+	// floor or picking an amber outside the ANSI-256 cube's darkest available
+	// in-family corner (#875F00, still short of the floor this pairing would
+	// need) — both of which this file's rules forbid.
+	{"success dot on surface", Success, SurfaceBG, 3.0},
+	{"danger dot on surface", Danger, SurfaceBG, 3.0},
+}
+
+// fillForegrounds sit on a painted background, so TestFillPairs covers them
+// instead: judged against the bare terminal they would fail by design (white
+// text on a white terminal).
+var fillForegrounds = map[string]bool{"OnFill": true, "OnSurface": true}
+
+// hueFamily is the semantic colour family a token belongs to. Luminance-only
+// floors cannot see a value that clears its contrast target but rounds into a
+// DIFFERENT family once a 256-colour terminal degrades it — e.g. Accent's
+// green landing on the teal between green and Info's blue. hueFamily and
+// TestDegradationPreservesHue below exist to catch exactly that.
+type hueFamily int
+
+const (
+	hueNeutral hueFamily = iota // greys: hue is meaningless, only saturation matters
+	hueRed
+	hueAmber
+	hueGreen
+	hueCyan
+	hueBlue
+	hueMagenta
+)
+
+func (f hueFamily) String() string {
+	return [...]string{"neutral", "red", "amber", "green", "cyan", "blue", "magenta"}[f]
+}
+
+// hueArcs are [min,max] in degrees, sized from the actual hue of every value
+// in the palette (both truecolor and ANSI-256-degraded) plus margin on both
+// sides so a legitimate shade never sits at the edge. hueRed wraps past 360.
+var hueArcs = map[hueFamily][2]float64{
+	hueRed:     {348, 372},
+	hueAmber:   {20, 55},
+	hueGreen:   {65, 168},
+	hueCyan:    {173, 197},
+	hueBlue:    {197, 232},
+	hueMagenta: {290, 335},
+}
+
+// neutralSatMax is the saturation below which a colour reads as achromatic:
+// hue is undefined there, so both true neutrals and a family member that has
+// legitimately faded toward grey (ArtDetail.Light, once degraded) are fine.
+const neutralSatMax = 0.20
+
+// family declares the intended hue family for every token All() returns, next
+// to the palette table above so the intent is readable in one place.
+// TestEveryTokenHasAHueFamily enforces that nothing is missing, the same
+// discipline TestEveryTokenHasAFloor already applies to contrast.
+var family = map[string]hueFamily{
+	"Text": hueNeutral, "Dim": hueNeutral, "Faint": hueNeutral,
+	"Accent": hueGreen, "AccentBright": hueGreen, "Success": hueGreen,
+	"Warning": hueAmber, "Danger": hueRed, "Info": hueBlue, "Highlight": hueMagenta,
+	"Divider":   hueNeutral,
+	"ArtBright": hueGreen, "ArtBody": hueGreen, "ArtMid": hueGreen, "ArtDetail": hueGreen,
+	"ArtShadow": hueNeutral, "ArtEye": hueCyan,
+	"AccentFillBG": hueGreen, "WarnFillBG": hueAmber, "DangerFillBG": hueRed, "InfoFillBG": hueBlue,
+	"SurfaceBG": hueNeutral, "OnSurface": hueNeutral, "OnFill": hueNeutral,
+}
+
+// hueSat returns hex's hue in [0,360) and saturation in [0,1] (standard HSL).
+func hueSat(hex string) (hue, sat float64) {
+	r, g, b := parseHex(hex)
+	max := math.Max(r, math.Max(g, b))
+	min := math.Min(r, math.Min(g, b))
+	l := (max + min) / 2
+	if max == min {
+		return 0, 0 // achromatic: hue is undefined, sat is correctly 0
+	}
+	d := max - min
+	if l > 0.5 {
+		sat = d / (2 - max - min)
+	} else {
+		sat = d / (max + min)
+	}
+	switch max {
+	case r:
+		hue = math.Mod((g-b)/d, 6)
+	case g:
+		hue = (b-r)/d + 2
+	default:
+		hue = (r-g)/d + 4
+	}
+	hue *= 60
+	if hue < 0 {
+		hue += 360
+	}
+	return hue, sat
+}
+
+// inFamily reports whether hex's hue lands in f's arc. A neutral family
+// requires low saturation; a colour family accepts either its arc OR a
+// saturation so low the hue carries no real information (faded-to-grey is
+// not the "wrong colour" defect this test targets — a wrong SATURATED hue,
+// like teal for green, is).
+func inFamily(hex string, f hueFamily) (ok bool, hue, sat float64) {
+	hue, sat = hueSat(hex)
+	if f == hueNeutral {
+		return sat <= neutralSatMax, hue, sat
+	}
+	if sat <= neutralSatMax {
+		return true, hue, sat
+	}
+	arc := hueArcs[f]
+	h := hue
+	if arc[1] > 360 && h < arc[1]-360 {
+		h += 360 // let the wraparound (red) arc compare on one axis
+	}
+	return h >= arc[0] && h <= arc[1], hue, sat
+}
+
+func TestEveryTokenHasAHueFamily(t *testing.T) {
+	for name := range All() {
+		if _, ok := family[name]; !ok {
+			t.Errorf("theme.%s has no declared hue family in this file", name)
+		}
+	}
+}
+
+// TestDegradationPreservesHue is the regression test for the class of bug
+// where a value clears its contrast floor but a 256-colour terminal rounds it
+// into a different semantic colour's territory. The other tests in this file
+// are luminance-only and structurally cannot see that — hue is the only thing
+// that can, which is exactly why the teal-for-green regression shipped past
+// them.
+func TestDegradationPreservesHue(t *testing.T) {
+	for name, f := range family {
+		c, ok := All()[name]
+		if !ok {
+			continue // covered by TestEveryTokenHasAHueFamily
+		}
+		for _, side := range []struct {
+			mode string
+			hex  string
+		}{{"light", c.Light}, {"dark", c.Dark}} {
+			deg := degradeTo256(side.hex)
+			if ok, hue, sat := inFamily(deg, f); !ok {
+				t.Errorf("%s.%s: %s degrades to %s, hue %.1f (sat %.2f) is outside the %s family",
+					name, side.mode, side.hex, deg, hue, sat, f)
+			}
+		}
+	}
+}
+
+func TestTokenContrastOnEveryTerminalBackground(t *testing.T) {
+	for _, bg := range backgrounds {
+		for _, tk := range tokens {
+			hex := tk.color.Light
+			if bg.dark {
+				hex = tk.color.Dark
+			}
+			got := contrast(hex, bg.hex)
+			if got < tk.role.floor() {
+				t.Errorf("%s (%s, %s) on %s (%s): contrast %.2f:1, floor %.1f:1",
+					tk.name, hex, tk.role, bg.name, bg.hex, got, tk.role.floor())
+			}
+		}
+	}
+}
+
+func TestFillPairs(t *testing.T) {
+	for _, f := range fills {
+		for _, mode := range []struct {
+			name string
+			dark bool
+		}{{"light", false}, {"dark", true}} {
+			fg, bg := f.fg.Light, f.bg.Light
+			if mode.dark {
+				fg, bg = f.fg.Dark, f.bg.Dark
+			}
+			got := contrast(fg, bg)
+			if got < f.floor {
+				t.Errorf("%s in %s mode: %s on %s is %.2f:1, floor %.1f:1",
+					f.name, mode.name, fg, bg, got, f.floor)
+			}
+		}
+	}
+}
+
+// A token whose two values are identical is either an oversight or a deliberate
+// fill; anything else means one mode was never considered.
+func TestForegroundTokensAdapt(t *testing.T) {
+	for _, tk := range tokens {
+		if tk.color.Light != tk.color.Dark {
+			continue
+		}
+		switch tk.name {
+		case "AccentFillBG", "WarnFillBG", "DangerFillBG", "InfoFillBG":
+			continue // painted surfaces — same in both modes on purpose
+		}
+		t.Errorf("%s is %s in both modes: it was tuned for one background only",
+			tk.name, tk.color.Light)
+	}
+}
+
+// TestAllIsComplete parses theme.go and fails when it declares an AdaptiveColor
+// that All() does not return. All() is what the render tests check screens
+// against, so a colour missing from it is a colour nothing can police.
+func TestAllIsComplete(t *testing.T) {
+	all := All()
+	fset := gotoken.NewFileSet()
+	f, err := parser.ParseFile(fset, "theme.go", nil, 0)
+	if err != nil {
+		t.Fatalf("cannot parse theme.go: %v", err)
+	}
+	ast.Inspect(f, func(n ast.Node) bool {
+		vs, ok := n.(*ast.ValueSpec)
+		if !ok {
+			return true
+		}
+		for i, name := range vs.Names {
+			if i >= len(vs.Values) || !isAdaptiveColor(vs.Values[i]) {
+				continue
+			}
+			if _, ok := all[name.Name]; !ok {
+				t.Errorf("theme.%s is declared but All() does not return it", name.Name)
+			}
+		}
+		return true
+	})
+}
+
+// TestEveryTokenHasAFloor makes sure no palette entry escapes measurement.
+func TestEveryTokenHasAFloor(t *testing.T) {
+	covered := map[string]bool{}
+	for _, tk := range tokens {
+		covered[tk.name] = true
+	}
+	for name := range fillForegrounds {
+		covered[name] = true
+	}
+	for name := range All() {
+		if !covered[name] {
+			t.Errorf("theme.%s has no contrast floor in this file", name)
+		}
+	}
+}
+
+func isAdaptiveColor(e ast.Expr) bool {
+	cl, ok := e.(*ast.CompositeLit)
+	if !ok {
+		return false
+	}
+	sel, ok := cl.Type.(*ast.SelectorExpr)
+	return ok && sel.Sel.Name == "AdaptiveColor"
+}
+
+// --- WCAG 2.1 relative luminance and contrast ------------------------------
+
+func contrast(aHex, bHex string) float64 {
+	a, b := luminance(aHex), luminance(bHex)
+	if a < b {
+		a, b = b, a
+	}
+	return (a + 0.05) / (b + 0.05)
+}
+
+func luminance(hex string) float64 {
+	r, g, b := parseHex(hex)
+	return 0.2126*channel(r) + 0.7152*channel(g) + 0.0722*channel(b)
+}
+
+func channel(v float64) float64 {
+	if v <= 0.03928 {
+		return v / 12.92
+	}
+	return math.Pow((v+0.055)/1.055, 2.4)
+}
+
+func parseHex(hex string) (r, g, b float64) {
+	if len(hex) != 7 || hex[0] != '#' {
+		panic("theme: colour must be #RRGGBB, got " + hex)
+	}
+	v := func(s string) float64 {
+		n := 0
+		for _, c := range s {
+			n <<= 4
+			switch {
+			case c >= '0' && c <= '9':
+				n |= int(c - '0')
+			case c >= 'a' && c <= 'f':
+				n |= int(c-'a') + 10
+			case c >= 'A' && c <= 'F':
+				n |= int(c-'A') + 10
+			default:
+				panic("theme: bad hex digit in " + hex)
+			}
+		}
+		return float64(n) / 255
+	}
+	return v(hex[1:3]), v(hex[3:5]), v(hex[5:7])
+}
+
+// macOS Terminal.app has no truecolor: it advertises xterm-256color, so lipgloss
+// down-converts every hex above to the nearest of 256 fixed indices before it
+// reaches the screen. That conversion can move a colour far enough to lose the
+// contrast the table was tuned for, and it happens on one of the three terminals
+// GAIA is tested on — so the floors are re-checked against what actually lands.
+func TestPaletteSurvivesANSI256Degradation(t *testing.T) {
+	for _, bg := range backgrounds {
+		for _, tk := range tokens {
+			hex := tk.color.Light
+			if bg.dark {
+				hex = tk.color.Dark
+			}
+			got := contrast(degradeTo256(hex), bg.hex)
+			if got < tk.role.floor() {
+				t.Errorf("%s on %s: %s degrades to %s and drops to %.2f:1, floor %.1f:1",
+					tk.name, bg.name, hex, degradeTo256(hex), got, tk.role.floor())
+			}
+		}
+	}
+}
+
+func TestFillPairsSurviveANSI256Degradation(t *testing.T) {
+	for _, f := range fills {
+		for _, dark := range []bool{false, true} {
+			fg, bg := f.fg.Light, f.bg.Light
+			if dark {
+				fg, bg = f.fg.Dark, f.bg.Dark
+			}
+			got := contrast(degradeTo256(fg), degradeTo256(bg))
+			if got < f.floor {
+				t.Errorf("%s: %s on %s degrades to %s on %s and drops to %.2f:1, floor %.1f:1",
+					f.name, fg, bg, degradeTo256(fg), degradeTo256(bg), got, f.floor)
+			}
+		}
+	}
+}
+
+// degradeTo256 is the exact conversion lipgloss performs on a 256-colour
+// terminal — same library, same lookup — so this measures what lands, not an
+// approximation of it.
+func degradeTo256(hex string) string {
+	c := termenv.ANSI256.Convert(termenv.RGBColor(hex))
+	r, g, b, _ := termenv.ConvertToRGB(c).RGBA()
+	return fmt.Sprintf("#%02X%02X%02X", r>>8, g>>8, b>>8)
+}

--- a/tui/internal/ui/theme/init_test.go
+++ b/tui/internal/ui/theme/init_test.go
@@ -1,0 +1,63 @@
+package theme
+
+import (
+	"testing"
+
+	"github.com/charmbracelet/lipgloss"
+)
+
+// GAIA_TUI_THEME is the escape hatch for a terminal that never answers the
+// background-colour query — over SSH, inside tmux, in a CI log. If it did not
+// win, those users would have no way to fix an unreadable screen.
+func TestEnvOverrideWins(t *testing.T) {
+	restore := lipgloss.HasDarkBackground()
+	t.Cleanup(func() { lipgloss.SetHasDarkBackground(restore) })
+
+	for _, tc := range []struct {
+		env  string
+		want bool
+	}{
+		{"light", false},
+		{"dark", true},
+		{"LIGHT", false},
+		{"  Dark  ", true},
+	} {
+		// Start from the opposite of what we expect, so a no-op Init fails.
+		lipgloss.SetHasDarkBackground(!tc.want)
+		t.Setenv(EnvTheme, tc.env)
+		Init()
+		if got := IsDark(); got != tc.want {
+			t.Errorf("GAIA_TUI_THEME=%q: IsDark()=%v, want %v", tc.env, got, tc.want)
+		}
+	}
+}
+
+// An unset or unrecognised value must fall through to detection rather than
+// silently pinning a mode. IsDark() is defined in terms of
+// lipgloss.HasDarkBackground(), so comparing the two can never fail — this
+// pins a known mode first and asserts Init left it untouched instead.
+func TestUnknownValueFallsBackToDetection(t *testing.T) {
+	restore := lipgloss.HasDarkBackground()
+	t.Cleanup(func() { lipgloss.SetHasDarkBackground(restore) })
+
+	lipgloss.SetHasDarkBackground(false)
+	t.Setenv(EnvTheme, "chartreuse")
+	Init()
+	if IsDark() != false {
+		t.Error("an unrecognised GAIA_TUI_THEME did not fall through to detection: " +
+			"it pinned a mode instead of leaving the existing one alone")
+	}
+}
+
+func TestEveryTokenIsSixDigitHex(t *testing.T) {
+	for name, c := range All() {
+		for _, hex := range []string{c.Light, c.Dark} {
+			if len(hex) != 7 || hex[0] != '#' {
+				t.Errorf("theme.%s has %q, want #RRGGBB", name, hex)
+				continue
+			}
+			// parseHex panics on a bad digit, which is the assertion.
+			parseHex(hex)
+		}
+	}
+}

--- a/tui/internal/ui/theme/theme.go
+++ b/tui/internal/ui/theme/theme.go
@@ -1,0 +1,174 @@
+// Package theme is the single place the TUI decides what a colour means.
+//
+// Every colour here is a lipgloss.AdaptiveColor, so the same token resolves to
+// a different value depending on whether the terminal's background is light or
+// dark. Screens ask for a ROLE (theme.Text, theme.Danger) and never for a
+// number, which is what stops a palette tuned on one background from becoming
+// unreadable on the other.
+//
+// Hues follow the One Half Light / One Half Dark pair — a theme that ships with
+// Windows Terminal, GNOME Terminal and macOS Terminal, so the TUI looks native
+// rather than invented. The light values are darkened from stock One Half Light
+// because that theme, like nearly every terminal theme, sits below WCAG AA for
+// body text on a white background. contrast_test.go holds every token to a
+// measured floor against ten real terminal backgrounds.
+//
+// The guarantee covers truecolor and 256-colour terminals — the latter matters
+// because macOS Terminal is 256-colour only, so lipgloss down-converts, and the
+// tests re-check every floor on the converted value, including the floor a
+// token owes another token when one is painted on top of the other (see
+// SurfaceBG below). Below that, at 16 colours,
+// there is nothing to guarantee: every colour becomes one of the sixteen the
+// USER's theme defines, so what lands on screen is their palette, not this one.
+// A terminal reaches that tier when it is not a TTY at all (a pipe, a CI log, or
+// an SSH session on Windows, where termenv reports Ascii and CLICOLOR_FORCE
+// lifts it only as far as 16 colours).
+package theme
+
+import (
+	"os"
+	"strings"
+
+	"github.com/charmbracelet/lipgloss"
+)
+
+// EnvTheme forces a mode for terminals that never answer the background-colour
+// query — most often over SSH, inside tmux, or in a CI log. Values: light, dark,
+// auto (the default: ask the terminal, assume dark if it stays silent).
+const EnvTheme = "GAIA_TUI_THEME"
+
+// Init resolves the light/dark decision once, BEFORE Bubble Tea owns stdin.
+//
+// Detection writes an OSC query to the terminal and reads the reply; done
+// lazily, Bubble Tea consumes that reply and types it into the focused input.
+// Same constraint as components.PrimeRenderer, and it is called alongside it.
+func Init() {
+	switch strings.ToLower(strings.TrimSpace(os.Getenv(EnvTheme))) {
+	case "light":
+		lipgloss.SetHasDarkBackground(false)
+	case "dark":
+		lipgloss.SetHasDarkBackground(true)
+	default:
+		// Ask the terminal now and cache the answer. A terminal that stays
+		// silent resolves to dark, which is what the TUI has always assumed.
+		lipgloss.SetHasDarkBackground(lipgloss.HasDarkBackground())
+	}
+}
+
+// IsDark reports the mode currently in effect. Only for diagnostics — screens
+// should use the tokens, which already carry both values.
+func IsDark() bool { return lipgloss.HasDarkBackground() }
+
+// Text-carrying roles. Everything here holds at least 4.5:1 against every
+// background in contrast_test.go, so it is safe for body copy.
+var (
+	// Text is primary copy: labels, answers, values.
+	Text = lipgloss.AdaptiveColor{Light: "#1F2328", Dark: "#D4D4D4"}
+	// Dim is secondary copy: hints, descriptions, key names, detail lines.
+	Dim = lipgloss.AdaptiveColor{Light: "#57606A", Dark: "#A0A0A0"}
+	// Accent is the GAIA green: borders, brand marks, commands to run. Light's
+	// B channel is kept low (0x2D) so a 256-colour terminal rounds it to the
+	// cube's one true green, #005F00 — a higher B rounds to the teal at
+	// #005F5F instead, which reads as a different colour, not just a duller
+	// green. AccentBright also lands on #005F00; that collapse is fine, the
+	// two never sit adjacent and never distinguish one state from another.
+	Accent = lipgloss.AdaptiveColor{Light: "#1A722D", Dark: "#87D787"}
+	// AccentBright is the emphasised green: titles, the selected row.
+	AccentBright = lipgloss.AdaptiveColor{Light: "#116329", Dark: "#B5E08D"}
+	// Success means a check passed, a connection is live. Light's B channel is
+	// kept low for the same ANSI-256 reason as Accent.
+	Success = lipgloss.AdaptiveColor{Light: "#0B6E2D", Dark: "#3FD98A"}
+	// Warning means unknown, idle, or "read this before continuing".
+	Warning = lipgloss.AdaptiveColor{Light: "#8A5300", Dark: "#FFAF3F"}
+	// Danger means failed, disconnected, destructive. Dark is lighter than a
+	// plain "bright red" would need to be for body text alone: the same value
+	// is also used as the disconnected-status dot painted on SurfaceBG (see
+	// RenderStatusBar), which owes SurfaceBG.Dark 3:1, not just the terminal
+	// 4.5:1. #FF6B6B held the terminal floor but degraded to only 2.14:1 on
+	// SurfaceBG.Dark's degraded grey; #FF9C9C clears both (contrast_test.go).
+	Danger = lipgloss.AdaptiveColor{Light: "#B32020", Dark: "#FF9C9C"}
+	// Info is the blue used for keybindings, the user's own turn, tool names.
+	Info = lipgloss.AdaptiveColor{Light: "#0A5FA8", Dark: "#5FBFFF"}
+	// Highlight is the magenta cursor and spinner.
+	Highlight = lipgloss.AdaptiveColor{Light: "#A3277F", Dark: "#FF87D7"}
+)
+
+// Faint is tertiary text — a version tag next to the thing it versions
+// (delegate.go's versionStyle, its only consumer). Held to 3:1, not 4.5:1: it
+// is deliberately recessive and never carries information that is not also in
+// the row it sits on.
+var Faint = lipgloss.AdaptiveColor{Light: "#838C97", Dark: "#8A8A8A"}
+
+// Divider draws rules and the empty half of a progress bar. Non-text, so it is
+// only held to a visible-but-quiet floor. Light sits exactly on the ANSI-256
+// cube grey #AFAFAF: the original #BFC4CB has a slight cool tint that a
+// 256-colour terminal rounds unevenly per channel, landing on pale cyan
+// (#AFD7D7) instead of a grey — an exact cube entry can't drift like that.
+var Divider = lipgloss.AdaptiveColor{Light: "#AFAFAF", Dark: "#5A5A5A"}
+
+// Filled surfaces: a foreground painted on an explicit background. The pair has
+// to contrast with ITSELF — the terminal's own background is covered up — so
+// these do not vary by mode. Solid, saturated, white text: the one combination
+// that reads the same on every terminal.
+var (
+	AccentFillBG = lipgloss.AdaptiveColor{Light: "#1F7A3F", Dark: "#1F7A3F"}
+	WarnFillBG   = lipgloss.AdaptiveColor{Light: "#8A5300", Dark: "#8A5300"}
+	DangerFillBG = lipgloss.AdaptiveColor{Light: "#B32020", Dark: "#B32020"}
+	InfoFillBG   = lipgloss.AdaptiveColor{Light: "#0A5FA8", Dark: "#0A5FA8"}
+	OnFill       = lipgloss.AdaptiveColor{Light: "#FFFFFF", Dark: "#FFFFFF"}
+)
+
+// SurfaceBG is the quiet band — the status bar, an unselected button. Unlike a
+// badge it does follow the mode, and it has to stay visible against BOTH ends of
+// its mode's background range: a #303030 bar disappears on a One Half Dark
+// terminal, which is how the old status bar behaved.
+//
+// It is also the backdrop the connected/disconnected status dot (Success/
+// Danger) is painted on — components/statusbar.go builds the dot with its own
+// Foreground and only then wraps it in SurfaceBG's Background, so the dot has
+// to clear a THIRD floor beyond the two below: 3:1 against SurfaceBG itself
+// (contrast_test.go's fills, "success/danger dot on surface"), not just 4.5:1
+// as body text on the terminal. That third floor is genuinely tight —
+// SurfaceBG has to hold, at once: ≥1.5:1 against BOTH ends of its mode's
+// terminal-background range (Solarized Light and Nord are the tightest; if
+// SurfaceBG can't clear this the bar itself vanishes), ≥3:1 for the dots
+// painted on it, and ≥4.5:1 for OnSurface. Dark could not hold all three at
+// its old #4A4A4A (1.41:1 on Nord, below the 1.5 floor) without the dot moving
+// too — see Danger's comment above. Both values are exact ANSI-256 cube greys
+// (#B8B8B8 degrades to the same cube corner as the plain #AFAFAF it replaced;
+// #5F5F5F already sits on one) so degradation cannot drift them off-neutral.
+var (
+	SurfaceBG = lipgloss.AdaptiveColor{Light: "#B8B8B8", Dark: "#5F5F5F"}
+	// OnSurface.Dark is pure white rather than off-white: #E8E8E8 degrades to
+	// #D7D7D7, which on top of SurfaceBG.Dark's #5F5F5F only holds 4.44:1;
+	// #FFFFFF (degrades unchanged) holds 6.39:1 on the same pairing.
+	OnSurface = lipgloss.AdaptiveColor{Light: "#1F2328", Dark: "#FFFFFF"}
+)
+
+// Mascot shading, brightest to darkest as drawn on a dark terminal. On a light
+// terminal the ladder inverts so the same rung keeps the same emphasis. Art is
+// decorative — held only to "visible", not to a text floor.
+var (
+	ArtBright = lipgloss.AdaptiveColor{Light: "#0E5223", Dark: "#B5E08D"}
+	ArtBody   = lipgloss.AdaptiveColor{Light: "#1A722D", Dark: "#87D787"} // mirrors Accent
+	ArtMid    = lipgloss.AdaptiveColor{Light: "#4A7C22", Dark: "#87AF5F"}
+	ArtDetail = lipgloss.AdaptiveColor{Light: "#7C8F73", Dark: "#5F875F"}
+	ArtShadow = lipgloss.AdaptiveColor{Light: "#AFAFAF", Dark: "#555555"} // degradation-safe grey, see Divider
+	ArtEye    = lipgloss.AdaptiveColor{Light: "#007D8A", Dark: "#4DE8E8"}
+)
+
+// All is the whole palette, by token name. Tests use it two ways: to hold every
+// colour to a measured contrast floor, and to assert that a rendered screen
+// emits nothing outside it — which is how a stray hardcoded colour is caught.
+func All() map[string]lipgloss.AdaptiveColor {
+	return map[string]lipgloss.AdaptiveColor{
+		"Text": Text, "Dim": Dim, "Accent": Accent, "AccentBright": AccentBright,
+		"Success": Success, "Warning": Warning, "Danger": Danger, "Info": Info,
+		"Highlight": Highlight, "Faint": Faint, "Divider": Divider,
+		"AccentFillBG": AccentFillBG, "WarnFillBG": WarnFillBG,
+		"DangerFillBG": DangerFillBG, "InfoFillBG": InfoFillBG, "OnFill": OnFill,
+		"SurfaceBG": SurfaceBG, "OnSurface": OnSurface,
+		"ArtBright": ArtBright, "ArtBody": ArtBody, "ArtMid": ArtMid,
+		"ArtDetail": ArtDetail, "ArtShadow": ArtShadow, "ArtEye": ArtEye,
+	}
+}


### PR DESCRIPTION
Closes #2607

On a light terminal the hub was close to unreadable — body text sat at **1.54:1** against white, and on macOS Terminal's default profile **7 of the 9 colours it emitted** were below WCAG AA. Colours were hardcoded xterm-256 indices picked for a dark terminal, and nothing ever asked the terminal what its background actually was. They now come from `internal/ui/theme` by role, each carrying a light and a dark value, chosen from the terminal's own background at startup. **0 of 9 colours are now below their floor.**

## Before / after — real GNOME Terminal, white background

| before | after |
|---|---|
| <img src="https://raw.githubusercontent.com/amd/gaia/evidence/tui-contrast-2607/tui-contrast/before-light.png" width="460"> | <img src="https://raw.githubusercontent.com/amd/gaia/evidence/tui-contrast-2607/tui-contrast/after-light.png" width="460"> |

Dark terminals are the control — unchanged, so nothing regressed for existing users:

| before | after |
|---|---|
| <img src="https://raw.githubusercontent.com/amd/gaia/evidence/tui-contrast-2607/tui-contrast/before-dark.png" width="460"> | <img src="https://raw.githubusercontent.com/amd/gaia/evidence/tui-contrast-2607/tui-contrast/after-dark.png" width="460"> |

Same screen, same binary inputs, only the palette differs. Captured from a real `gnome-terminal` (VTE 3.52.0) on a virtual display, since the test box has no logged-in desktop.

## Two latent bugs this also fixes

- The filled confirm/deny buttons were **1.6:1 even on a dark terminal** — cream on light green. Broken in both modes.
- Seven package-level `.Render()` calls froze the light/dark choice at package-init, before detection ran. An `AdaptiveColor` resolves when it is rendered, so a pre-rendered string never adapts.

## Test plan

- [ ] `cd tui && go test ./... -count=1` — green, including the new contrast, hue and render guards
- [ ] `cd tui && gofmt -l internal/ cmd/` — clean (`internal/ui/chat/status_noise_test.go` is pre-existing on main)
- [ ] Run `gaia tui` in a light terminal (macOS Terminal "Basic", GNOME Terminal on white, Windows Terminal "One Half Light") — text is legible, status bar is a light band
- [ ] Run `gaia tui` in a dark terminal — visually unchanged from main
- [ ] `GAIA_TUI_THEME=light gaia tui` in a dark terminal forces the light palette, and vice versa
- [ ] Mutation check: revert any style to `lipgloss.Color("NNN")` and confirm `TestReadinessScreenUsesOnlyPaletteColours` fails

<details>
<summary>Measured contrast, macOS Terminal "Basic" — real binary, real 256-colour down-conversion</summary>

macOS Terminal has no truecolor, so lipgloss down-converts every value. These are the colours that actually reached the screen, captured from the real binary under a pty.

| | before | after |
|---|---|---|
| body text | `#D0D0D0` — 1.54:1 | `#080808` — 20.03:1 |
| brand green / titles | `#AFD787` — 1.63:1 | `#005F00` — 7.96:1 |
| hint text | `#767676` — 4.54:1 | `#5F5F5F` — 6.39:1 |
| mascot eyes | `#00FFFF` — 1.25:1 | `#008787` — 4.36:1 |
| **below their floor** | **7 of 9** | **0 of 9** |

Windows: verified on Windows 11 over the loopback control API. The old build emits **byte-identical colour codes for light and dark backgrounds** — direct proof it never adapted; the new build does not. No Windows Terminal pixel capture was possible (no interactive desktop session on the reachable box).

</details>

<details>
<summary>How the palette is held in place</summary>

- Every token is held to a role-appropriate floor (text 4.5:1, faint 3:1, chrome 1.5:1) against **nine real terminal backgrounds** — macOS Terminal Basic/Pro, GNOME Terminal light/Ubuntu, Windows Terminal One Half Light/Campbell, One Half Dark, Nord, Solarized light/dark.
- Each floor is re-checked on the **ANSI-256 degraded** value, because that is what a 256-colour terminal shows.
- `TestDegradationPreservesHue` catches a colour that keeps its contrast but stops meaning what it means. This caught a real defect: the light greens were degrading to **teal**, so `[ok]` would have rendered a hair from the blue used for keybindings.
- `TestReadinessScreenUsesOnlyPaletteColours` renders the real screen in both modes and fails if any colour is outside the palette — indexed or 24-bit.
- The status-bar dots are measured against the bar they sit on, not the terminal behind it.

**Boundary:** the guarantee covers truecolor and 256-colour terminals. At 16 colours every colour becomes one the user's own theme defines, so there is nothing to guarantee; that is documented in the package.

</details>