### PR TITLE
docs(connectors): document which Google scopes to declare in the Console

### DIFF
--- a/docs/connectors/google.mdx
+++ b/docs/connectors/google.mdx
@@ -118,7 +118,74 @@ yourself — there's no need to verify the app for personal use.
   consent, so GAIA will eventually prompt you to reconnect. This is a
   Google policy for unverified test apps, not a GAIA bug — just reconnect
   when it happens (see [Common issues](#error-400-invalid_grant-after-a-long-while)).
+  Google waives this limit only when the connection's *only* scopes are a
+  subset of `openid` / `email` / `profile` — any Gmail or Calendar scope
+  (which GAIA's agents always request) means the 7-day limit applies to
+  you.
 </Warning>
+
+### Declare scopes under Data access
+
+Every scope GAIA can request must also be **declared** on the consent
+screen — a separate step from anything you type into a `gaia` command,
+and easy to miss because nothing in the flow above mentions it.
+
+<Warning>
+  **Exact click path not verified for this guide** — flagged for a human
+  pass, tracked in [#2602](https://github.com/amd/gaia/issues/2602). Open
+  [**Google Auth Platform → Data
+  access**](https://console.cloud.google.com/auth/scopes) and use its
+  scope picker to add each entry from the table below. If the tab's exact
+  label or control has moved since this was written, look for wherever
+  the console lets you register OAuth scopes for the consent screen — the
+  goal is that every scope your agents will request ends up listed there.
+</Warning>
+
+You only need to declare the scopes the agents you actually use will
+request — the [Email Triage agent](/guides/email) needs `gmail.modify`,
+`gmail.send`, `calendar.events`, and `calendar.readonly`; `openid` /
+`email` / `profile` are requested on every connection regardless of
+agent.
+
+<!-- google-scopes:start -->
+| Scope | Tier | What it buys |
+|---|---|---|
+| `openid` | Non-sensitive | Verify your identity |
+| `email` | Non-sensitive | See your email address |
+| `profile` | Non-sensitive | See your basic profile |
+| `https://www.googleapis.com/auth/gmail.readonly` | Restricted | Read your email |
+| `https://www.googleapis.com/auth/gmail.send` | Sensitive | Send email on your behalf |
+| `https://www.googleapis.com/auth/gmail.modify` | Restricted | Read, modify, and send email on your behalf |
+| `https://www.googleapis.com/auth/calendar.readonly` | Sensitive | Read your calendar events |
+| `https://www.googleapis.com/auth/calendar.events` | Sensitive | Manage your calendar events |
+| `https://www.googleapis.com/auth/drive.readonly` | Restricted | Read your Google Drive files |
+| `https://www.googleapis.com/auth/drive.file` | Non-sensitive | Manage Drive files this app creates — no built-in GAIA agent requests this today |
+<!-- google-scopes:end -->
+
+**Tiers, sourced from Google's own tables:** [Gmail
+scopes](https://developers.google.com/workspace/gmail/api/auth/scopes)
+and [Drive
+scopes](https://developers.google.com/workspace/drive/api/guides/api-specific-auth).
+Two corrections worth flagging if you've seen older guidance:
+`gmail.readonly` and `drive.readonly` are **Restricted** — the same
+strictest tier as `gmail.modify` — not "Sensitive"; read-only buys no
+verification relief. `drive.file` is **Non-sensitive**, which is why
+Google recommends it as the default per-file Drive scope. Google
+publishes no tier table for Calendar; `calendar.events` /
+`calendar.readonly` are listed as Sensitive based on the Console UI's own
+grouping, not an authoritative Google document.
+
+A Testing-status app shows the "Google hasn't verified this app" warning
+for *any* Sensitive or Restricted scope regardless of whether it's
+declared here — so seeing that warning doesn't by itself tell you a
+scope is missing from Data access.
+
+**Unverified:** whether Google actually refuses OAuth consent in Testing
+mode for a scope that's requested in the authorization URL but not
+declared under Data access has not been checked end-to-end for this
+guide — tracked in [#2602](https://github.com/amd/gaia/issues/2602).
+Declaring every scope you'll use removes the question either way, so do
+that regardless of the answer.
 
 ## Step 4 — Create the OAuth client
 
@@ -195,38 +262,57 @@ you connect"** with a default-on checkbox per installed agent that
 declares Google access, and checked agents receive their declared scopes
 the moment the OAuth flow completes. Uncheck an agent to withhold its
 grant, and adjust or revoke any grant later under the tile's
-**Per-agent grants** section. On the CLI you grant explicitly:
+**Per-agent grants** section.
 
-**Chat agent — read-only Gmail:**
+On the CLI, lead with `--grant-agent` — GAIA reads the scopes the agent
+already declares in its own code, so there's no list to type out or keep
+in sync:
+
+**Email Triage agent — the full mailbox + calendar scope set** it needs
+to read, organize, draft/send, and manage events:
+
+```bash
+gaia connectors connect google --grant-agent installed:email
+```
+
+One command both authorizes those scopes with Google **and** grants them
+to the agent — the same thing the Agent UI's **Connect** button does.
+Naming the agent is enough; GAIA rejects `--grant-agent` outright for an
+agent that declares no Google scopes, rather than silently granting
+nothing.
+
+**Chat agent — a narrower, read-only Gmail grant:** the chat agent
+declares no fixed Google requirement, so grant it explicit scopes
+instead:
 
 ```bash
 gaia connectors grants grant google builtin:chat \
   --scopes https://www.googleapis.com/auth/gmail.readonly
 ```
 
-**Email Triage agent — the full mailbox + calendar scope set** it needs
-to read, organize, draft/send, and manage events:
-
-```bash
-gaia connectors grants grant google installed:email \
-  --scopes https://www.googleapis.com/auth/gmail.modify \
-           https://www.googleapis.com/auth/gmail.send \
-           https://www.googleapis.com/auth/calendar.events \
-           https://www.googleapis.com/auth/calendar.readonly
-```
+<Note>
+  `gmail.readonly` is a **Restricted** scope — the same tier as
+  `gmail.modify` (see [Scopes to declare in your
+  Console](#declare-scopes-under-data-access)). Read-only narrows what the
+  agent can *do*, not which verification tier Google applies.
+</Note>
 
 <Note>
-  The Agent UI's **Connect** / **Reconnect** flow for the Email Triage
-  agent both authorizes these scopes with Google **and** grants them to the
-  agent for you. On the CLI you do both steps yourself — authorize the
-  scopes with `gaia connectors connect google --scopes …`, then run the
-  `grants grant` above. The [Email Triage guide's CLI tab](/guides/email#setup)
-  has the full sequence; the grant is also the fix when you hit
+  **`--scopes` is a two-command path, and it does not union with the
+  connection's default scopes.** Authorize with `gaia connectors connect
+  google --scopes …` first, then grant the same list with `gaia connectors
+  grants grant google <agent> --scopes …` (the `grants grant` example
+  above assumes the scope was already authorized on a prior connect). A
+  hand-typed list that omits `openid` can still connect but resolve to
+  `Connected as default` instead of your real address — one reason
+  `--grant-agent` is the recommended path for any agent that supports it.
+  The [Email Triage guide's CLI tab](/guides/email#setup) has the full
+  two-command sequence; a missing grant either way surfaces as
   `AGENT_NOT_GRANTED`.
 </Note>
 
-The default scopes a connection is established with are listed in the
-spec at
+The default scopes a connection is established with, and every scope an
+agent may request, are listed in the spec at
 [`src/gaia/connectors/catalog/google.py`](https://github.com/amd/gaia/blob/main/src/gaia/connectors/catalog/google.py).
 
 ## Common issues
@@ -265,6 +351,41 @@ which GAIA can't provide because it picks an ephemeral port.
 
 Add yourself as a test user (Step 3, "Add yourself as a test user").
 Apps in Testing mode only allow listed test users.
+
+### `Something went wrong` / `accounts.google.com/info/unknownerror` after you click Allow
+
+Google's own opaque failure page, shown **after** you complete the
+consent screen — not the "Google hasn't verified this app" interstitial
+from Step 5. GAIA never sees why: the browser lands on Google's error
+page instead of coming back to GAIA's loopback callback, so the callback
+handler never runs and the CLI/UI just times out after two minutes
+(`OAuth flow ... timed out after 120s. Restart the flow.`) — that
+message will not name the real cause.
+
+Nothing found while researching this guide ties this error page
+authoritatively to one cause for a loopback (Desktop-app) OAuth flow.
+Check these, roughly in order of how often they're reported for this
+exact error text:
+
+1. **Third-party cookies blocked in the browser.** The most concrete
+   reported match for this literal error page — though most reports are
+   for Google Identity Services JS sign-in widgets embedded in a web
+   page, not a Desktop-app loopback redirect, so treat this as a lead
+   rather than a confirmed cause here. Allow third-party cookies for
+   `accounts.google.com` and retry.
+2. **A stale or mismatched OAuth parameter** — `redirect_uri`, `state`,
+   or PKCE `code_challenge` that no longer matches what GAIA sent.
+   Restart the flow from GAIA rather than re-using an old consent tab.
+3. **Double-clicking Allow, or finishing consent in a second tab/window**
+   after the original flow's state already expired. Restart the flow and
+   complete it in a single tab.
+4. **A transient Google-side incident.** Wait a few minutes and retry.
+
+**Unverified:** whether an undeclared Restricted or Sensitive scope
+(missing from [Data access](#declare-scopes-under-data-access)) can
+itself trigger this page has not been confirmed end-to-end — see the
+note in that section. Don't assume adding a Data access declaration
+fixes this without testing it.
 
 ### `Error 400: invalid_grant` after a long while
 

--- a/docs/connectors/google.mdx
+++ b/docs/connectors/google.mdx
@@ -147,7 +147,7 @@ request — the [Email Triage agent](/guides/email) needs `gmail.modify`,
 `email` / `profile` are requested on every connection regardless of
 agent.
 
-<!-- google-scopes:start -->
+{/* google-scopes:start */}
 | Scope | Tier | What it buys |
 |---|---|---|
 | `openid` | Non-sensitive | Verify your identity |
@@ -160,7 +160,7 @@ agent.
 | `https://www.googleapis.com/auth/calendar.events` | Sensitive | Manage your calendar events |
 | `https://www.googleapis.com/auth/drive.readonly` | Restricted | Read your Google Drive files |
 | `https://www.googleapis.com/auth/drive.file` | Non-sensitive | Manage Drive files this app creates — no built-in GAIA agent requests this today |
-<!-- google-scopes:end -->
+{/* google-scopes:end */}
 
 **Tiers, sourced from Google's own tables:** [Gmail
 scopes](https://developers.google.com/workspace/gmail/api/auth/scopes)

--- a/docs/guides/email.mdx
+++ b/docs/guides/email.mdx
@@ -80,21 +80,13 @@ There are two ways to connect Google depending on how you use GAIA.
 
     Both flags are required together — Google rejects token requests that omit the secret even for Desktop-app PKCE clients.
 
-    **Step 2 — Sign in and grant the email agent in one command.** Pass the
-    email agent's scopes explicitly with `--scopes` (a bare
-    `gaia connectors connect google` requests only the default
-    `openid`/`email`/`profile` and mailbox calls would later fail with a scope
-    error), and add `--grant-agent installed:email` so the same scopes are
-    granted to the agent in the same flow — no separate `grants grant` step, and
-    the connect/grant scopes can never drift:
+    **Step 2 — Sign in and grant the email agent in one command.**
+    `--grant-agent installed:email` alone is enough — GAIA reads the scopes
+    the email agent already declares and authorizes + grants them in the
+    same flow, so there's no `--scopes` list to type out or keep in sync:
 
     ```bash
-    gaia connectors connect google \
-      --grant-agent installed:email \
-      --scopes https://www.googleapis.com/auth/gmail.modify \
-               https://www.googleapis.com/auth/gmail.send \
-               https://www.googleapis.com/auth/calendar.events \
-               https://www.googleapis.com/auth/calendar.readonly
+    gaia connectors connect google --grant-agent installed:email
     ```
 
     The command prints an authorization URL. Open it in a browser **on the
@@ -104,10 +96,17 @@ There are two ways to connect Google depending on how you use GAIA.
     scope, and the flow finishes.
 
     <Note>
-    Prefer to do it in two explicit steps? Run `gaia connectors connect google
-    --scopes …` first, then `gaia connectors grants grant google installed:email
-    --scopes …` with the **same** scopes. `--grant-agent` just folds those into
-    one flow (which is what the Agent UI does).
+    Want a narrower grant instead? Pass `--scopes` explicitly — but note it
+    does **not** union with the provider's default scopes, so a hand-typed
+    list that omits `openid` can still connect while resolving to `Connected
+    as default` instead of your real address. Prefer two explicit steps
+    instead of the combined flow? Run `gaia connectors connect google
+    --scopes …` first (authorize), then `gaia connectors grants grant google
+    installed:email --scopes …` (grant) with a matching list — `--grant-agent`
+    just runs both steps together and derives the scopes for you. See the
+    [Google connector guide's scope
+    table](/connectors/google#declare-scopes-under-data-access) for what each
+    scope buys.
     </Note>
 
     Skip this and the first email tool call fails with

--- a/docs/runbooks/google-oauth-client.md
+++ b/docs/runbooks/google-oauth-client.md
@@ -114,9 +114,15 @@ What breaks during rotation:
 
 ## Verification submission
 
-Sensitive scopes (`gmail.*`, `drive.*`, etc.) require Google's
-verification before unverified users can authorize. Until then, only
-test users listed on the consent screen can complete the OAuth flow.
+Sensitive and Restricted scopes (`gmail.send`, `calendar.*` are
+Sensitive; `gmail.modify`, `gmail.readonly`, and `drive.readonly` are the
+stricter **Restricted** tier — read-only buys no relief there) require
+Google's verification before unverified users can authorize. `drive.file`
+is Non-sensitive and needs no verification. See the full tier table and
+sources at [`docs/connectors/google.mdx` → Declare scopes under Data
+access](../connectors/google.mdx#declare-scopes-under-data-access). Until
+verified, only test users listed on the consent screen can complete the
+OAuth flow.
 
 - **In-Cloud-Console flow:** Google Auth Platform → **Audience** →
   "Publish app" (old path: OAuth consent screen → "PUBLISH APP") → follow
@@ -128,7 +134,10 @@ test users listed on the consent screen can complete the OAuth flow.
 - **Test-mode token expiry:** while the app stays in Testing status,
   Google expires each test user's refresh token roughly **7 days** after
   consent, so testers must periodically reconnect. This is a Google policy
-  for unverified test apps, not a GAIA bug.
+  for unverified test apps, not a GAIA bug. Google waives it only when the
+  *only* scopes requested are a subset of `openid` / `email` / `profile`
+  — this client always requests Gmail/Calendar scopes, so the 7-day limit
+  applies here.
 
 ## Local development without a published client
 

--- a/src/gaia/connectors/providers/google.py
+++ b/src/gaia/connectors/providers/google.py
@@ -45,6 +45,8 @@ SCOPE_DESCRIPTIONS: dict[str, str] = {
     "https://www.googleapis.com/auth/userinfo.email": "See your email address",
     "https://www.googleapis.com/auth/userinfo.profile": "See your basic profile",
     "openid": "Verify your identity",
+    "email": "See your email address",
+    "profile": "See your basic profile",
 }
 
 
@@ -93,6 +95,7 @@ class GoogleOAuthProvider:
             raise OAuthClientNotConfiguredError(
                 "google",
                 provider_label="Google",
+                # Missing the Data access step; see docs/connectors/google.mdx until #2594 restructures this.
                 console_steps=(
                     "  1. Create or pick a project at "
                     "https://console.cloud.google.com\n"

--- a/tests/unit/connectors/test_google_console_scope_docs_drift.py
+++ b/tests/unit/connectors/test_google_console_scope_docs_drift.py
@@ -10,10 +10,11 @@ module-level ``pytest.importorskip("gaia_agent_email")`` that would silently
 disable this guard in any CI job that doesn't install the email wheel.
 
 The Console list lives in a fenced block bounded by
-``<!-- google-scopes:start -->`` / ``<!-- google-scopes:end -->`` so this test
-never scrapes freeform prose for scope strings — three of the ten scopes are
-the bare words ``openid``, ``email``, and ``profile``, and "email" alone
-appears repeatedly as ordinary prose elsewhere on the page.
+``{/* google-scopes:start */}`` / ``{/* google-scopes:end */}`` (MDX comment
+syntax — HTML comments aren't valid MDX) so this test never scrapes freeform
+prose for scope strings — three of the ten scopes are the bare words
+``openid``, ``email``, and ``profile``, and "email" alone appears repeatedly
+as ordinary prose elsewhere on the page.
 """
 
 from __future__ import annotations
@@ -25,8 +26,8 @@ from gaia.connectors.catalog.google import GOOGLE_SPEC
 
 _GOOGLE_MDX = Path(__file__).resolve().parents[3] / "docs" / "connectors" / "google.mdx"
 
-_START_MARKER = "<!-- google-scopes:start -->"
-_END_MARKER = "<!-- google-scopes:end -->"
+_START_MARKER = "{/* google-scopes:start */}"
+_END_MARKER = "{/* google-scopes:end */}"
 
 _VALID_TIERS = {"Restricted", "Sensitive", "Non-sensitive"}
 

--- a/tests/unit/connectors/test_google_console_scope_docs_drift.py
+++ b/tests/unit/connectors/test_google_console_scope_docs_drift.py
@@ -1,0 +1,109 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""Drift guard: the Console-facing scope list in ``docs/connectors/google.mdx``
+must stay in lock-step with ``GOOGLE_SPEC.available_scopes`` (issue #2602).
+
+Modeled on ``test_catalog_docs_url.py`` (a catalog <-> ``docs/connectors/*.mdx``
+cross-check with no optional-package dependency), not on
+``test_email_scope_drift.py`` — that file does no markdown parsing and carries a
+module-level ``pytest.importorskip("gaia_agent_email")`` that would silently
+disable this guard in any CI job that doesn't install the email wheel.
+
+The Console list lives in a fenced block bounded by
+``<!-- google-scopes:start -->`` / ``<!-- google-scopes:end -->`` so this test
+never scrapes freeform prose for scope strings — three of the ten scopes are
+the bare words ``openid``, ``email``, and ``profile``, and "email" alone
+appears repeatedly as ordinary prose elsewhere on the page.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from gaia.connectors.catalog.google import GOOGLE_SPEC
+
+_GOOGLE_MDX = Path(__file__).resolve().parents[3] / "docs" / "connectors" / "google.mdx"
+
+_START_MARKER = "<!-- google-scopes:start -->"
+_END_MARKER = "<!-- google-scopes:end -->"
+
+_VALID_TIERS = {"Restricted", "Sensitive", "Non-sensitive"}
+
+_ROW_RE = re.compile(r"^\|\s*`([^`]+)`\s*\|\s*([^|]+?)\s*\|")
+
+
+def _scopes_block() -> str:
+    text = _GOOGLE_MDX.read_text(encoding="utf-8")
+    assert _START_MARKER in text and _END_MARKER in text, (
+        f"docs/connectors/google.mdx is missing the {_START_MARKER!r} / "
+        f"{_END_MARKER!r} markers around the Console scope table"
+    )
+    start = text.index(_START_MARKER) + len(_START_MARKER)
+    end = text.index(_END_MARKER)
+    assert start < end, "google-scopes markers appear out of order"
+    return text[start:end]
+
+
+def _parse_scope_rows() -> list[tuple[str, str]]:
+    """Return ``(scope, tier)`` pairs for every data row in the scope table.
+
+    Only rows whose first cell is a backtick-quoted literal are treated as
+    data rows — this skips the header row and the ``---`` separator row
+    without needing a markdown parser.
+    """
+    rows = []
+    for line in _scopes_block().splitlines():
+        match = _ROW_RE.match(line.strip())
+        if match:
+            rows.append((match.group(1), match.group(2)))
+    return rows
+
+
+def test_registry_has_available_scopes():
+    """Guard against a false-negative pass if ``available_scopes`` is empty."""
+    assert GOOGLE_SPEC.available_scopes, "GOOGLE_SPEC.available_scopes is empty"
+
+
+def test_docs_scope_table_is_not_empty():
+    """Guard against a false-negative pass if the markers wrap nothing parseable."""
+    assert _parse_scope_rows(), (
+        "no scope rows parsed between the google-scopes markers in "
+        "docs/connectors/google.mdx - check the table syntax"
+    )
+
+
+def test_documented_scopes_match_available_scopes():
+    """The Console list must equal ``available_scopes`` exactly, not just contain it.
+
+    9 of the 10 scopes are declared by some shipped agent; only ``drive.file``
+    has zero consumers today. A containment check would let a genuinely new,
+    undocumented scope slip through as long as the existing ones were still
+    listed. Equality catches that.
+    """
+    documented = {scope for scope, _tier in _parse_scope_rows()}
+    expected = set(GOOGLE_SPEC.available_scopes)
+    assert documented == expected, (
+        "docs/connectors/google.mdx Console scope list has drifted from "
+        "GOOGLE_SPEC.available_scopes:\n"
+        f"  documented but not in available_scopes: {sorted(documented - expected)}\n"
+        f"  in available_scopes but not documented: {sorted(expected - documented)}"
+    )
+
+
+def test_every_documented_scope_has_exactly_one_valid_tier():
+    """Every row must land in exactly one of the three published tiers.
+
+    The set-equality test above only catches a missing/extra scope, not a
+    scope whose tier cell is blank, typo'd, or duplicated across rows.
+    """
+    rows = _parse_scope_rows()
+    scopes = [scope for scope, _tier in rows]
+    assert len(scopes) == len(
+        set(scopes)
+    ), f"a scope appears more than once in the Console table: {scopes}"
+    offenders = {scope: tier for scope, tier in rows if tier not in _VALID_TIERS}
+    assert not offenders, (
+        f"scopes with an unrecognized tier label (expected one of "
+        f"{sorted(_VALID_TIERS)}): {offenders}"
+    )


### PR DESCRIPTION
Closes #2602

The Google setup guide walked you through creating a project, enabling APIs, filling in a consent form and making a client — then never said which permissions to declare on that consent screen. Every scope string in the docs appeared only as an argument to a command you type, and there is a whole console tab where those same strings must be registered that the guide never mentioned. #2603 made that worse by merging this morning: the CLI now derives scopes automatically, so those command examples — the only place the docs exposed the strings at all — no longer show them. This adds the missing step, generated from the connector catalog rather than hand-typed, with a test that fails if the two drift apart.

**It also corrects three scope tiers that were wrong.** The most consequential: `gmail.readonly` is **Restricted**, the same strictest tier as `gmail.modify` — the guide offered it as the lighter "read-only" option, implying a verification relief it does not buy.

| Scope | Was documented as | Google actually classifies it |
|---|---|---|
| `gmail.readonly` | Sensitive (implied lighter) | **Restricted** |
| `drive.readonly` | — | **Restricted** |
| `drive.file` | — | **Non-sensitive** |

Verified against [Gmail](https://developers.google.com/workspace/gmail/api/auth/scopes) and [Drive](https://developers.google.com/workspace/drive/api/guides/api-specific-auth) scope tables directly. Google publishes no tier table for Calendar, so those two are labelled from secondary sources and the doc says so rather than implying an authority it doesn't have.

## Test plan

- [x] `pytest tests/unit/connectors/ -q` → **647 passed, 6 skipped**
- [x] `python util/lint.py --all` → **exit 0**
- [x] **The drift guard actually guards** — mutation-tested, evidence below
- [ ] **Human, on a live Google project:** follow the revised Step 3 using only this guide's scope list, screenshot the **Data access** tab showing exactly those scopes, and connect the email agent

### Evidence — the guard fails when the docs drift

A drift test that passes vacuously is worse than no test, so it was verified by breaking the doc two ways and confirming the *right* assertion fires each time:

```
MUTATION 1 — delete the gmail.send row from the doc's scope table
FAILED test_documented_scopes_match_available_scopes

MUTATION 2 — relabel a tier to a bogus value
FAILED test_every_documented_scope_has_exactly_one_valid_tier
   assert not {'…/auth/gmail.readonly': 'Wibble'}
```

Doc restored clean afterwards. The guard parses only between `<!-- google-scopes:start -->` / `<!-- google-scopes:end -->` markers — three of the ten scopes are the bare words `openid`, `email`, `profile`, and "email" appears nine times as ordinary prose in that guide, so scraping page text would have produced false signals in both directions.

⚠️ **Note on CI:** `test_unit.yml` has a draft gate, so `Unit Tests` does not run while this PR is draft — it shows as *absent*, not failed. Green checks on the draft do **not** include the drift guard.

<details>
<summary>What is deliberately left unverified, and why</summary>

Two claims are flagged in the doc with a literal `**Unverified:**` lead-in rather than asserted:

1. Whether a Testing-mode app is actually refused an undeclared restricted scope. Research found no Google source tying this to the observed failure; the nearest official statement covers a *previously-registered-then-removed* scope, which is a different case.
2. Whether the `accounts.google.com/info/unknownerror` page reproduces by removing a scope declaration.

The troubleshooting entry therefore lists candidate causes to check — blocked third-party cookies, `redirect_uri` mismatch, state/nonce replay — rather than naming a diagnosis. It also records that GAIA surfaces this as a plain timeout, because consent completes but the callback never arrives, so the CLI error will not name the real cause. That wording is generic enough for #2594 to adopt as the third cause in its loopback-timeout list, which currently has two, both pre-consent.

The exact Data-access click path is written generically ("open Data access and add each scope listed above") with an inline warning, rather than inventing button labels from memory — the guide already carries a warning that Google restructured this console in 2024–2025, so invented UI steps rot fast, and a confidently wrong console step is the precise failure this issue exists to fix.

Also fixed: `docs/guides/email.mdx` claimed `--grant-agent` "just folds in" a hand-typed `--scopes` list — false since #2610 merged this morning. Corrected surgically, nothing else in that tab restructured.
</details>
