### PR TITLE
fix(connectors): stop requiring a client secret from secretless public PKCE clients

### DIFF
--- a/src/gaia/connectors/cli.py
+++ b/src/gaia/connectors/cli.py
@@ -108,15 +108,21 @@ def add_subparser(subparsers: argparse._SubParsersAction) -> None:
         "--client-id",
         dest="client_id",
         help=(
-            "OAuth client id for an oauth_pkce connector (e.g. the Google "
-            "Desktop-app client). Persists to the keyring; requires --client-secret. "
-            "Run 'gaia connectors connect <id>' afterward to complete login."
+            "OAuth client id for an oauth_pkce connector (e.g. the Google or "
+            "Microsoft Desktop-app client). Persists to the keyring. Google "
+            "additionally needs --client-secret; other providers (e.g. "
+            "Microsoft, a public PKCE client) do not send one. Run 'gaia "
+            "connectors connect <id>' afterward to complete login."
         ),
     )
     p_cfg.add_argument(
         "--client-secret",
         dest="client_secret",
-        help="OAuth client secret (paired with --client-id; stored encrypted in the keyring)",
+        help=(
+            "OAuth client secret (paired with --client-id; stored encrypted "
+            "in the keyring). Required for Google; omit for providers that "
+            "use a secretless public PKCE client (e.g. Microsoft)."
+        ),
     )
     p_cfg.add_argument(
         "--set",

--- a/src/gaia/connectors/cli.py
+++ b/src/gaia/connectors/cli.py
@@ -502,20 +502,16 @@ def _handle_configure_client_credentials(
     provider so the next construction re-reads them. Does NOT start the PKCE
     flow — the browser login stays a separate ``gaia connectors connect``.
 
-    Both flags are required together: Google rejects token requests that omit
-    the secret even for Desktop PKCE clients, so a half-configured client would
-    fail loudly later instead of here. Mixing with ``--set`` / ``--json`` is a
-    usage error to avoid an ambiguous double-write.
+    ``--client-secret`` is only required together with ``--client-id`` for
+    providers in ``oauth_pkce.PROVIDERS_REQUIRING_CLIENT_SECRET`` (currently
+    just Google, which rejects token requests that omit the secret even for
+    Desktop PKCE clients). Public PKCE clients like Microsoft/Entra must NOT
+    send one, so a missing secret there is not an error (#1638). Mixing with
+    ``--set`` / ``--json`` is a usage error to avoid an ambiguous double-write.
     """
     if not client_id:
         sys.stderr.write(
             "gaia connectors configure: --client-secret requires --client-id.\n"
-        )
-        return 2
-    if not client_secret:
-        sys.stderr.write(
-            "gaia connectors configure: --client-id requires --client-secret "
-            "(Google requires the secret even for Desktop-app PKCE clients).\n"
         )
         return 2
     if getattr(args, "config_pairs", None) or getattr(args, "config_json", None):
@@ -526,6 +522,7 @@ def _handle_configure_client_credentials(
         return 2
 
     import gaia.connectors.catalog  # noqa: F401  # pylint: disable=unused-import
+    from gaia.connectors.oauth_pkce import PROVIDERS_REQUIRING_CLIENT_SECRET
     from gaia.connectors.providers import _registry as _provider_registry
     from gaia.connectors.registry import REGISTRY
     from gaia.connectors.store import save_provider_credentials
@@ -546,10 +543,20 @@ def _handle_configure_client_credentials(
         return 2
 
     provider_id = spec.oauth_provider_ref or spec.id
+    if not client_secret and provider_id in PROVIDERS_REQUIRING_CLIENT_SECRET:
+        sys.stderr.write(
+            "gaia connectors configure: --client-id requires --client-secret "
+            "(Google requires the secret even for Desktop-app PKCE clients).\n"
+        )
+        return 2
+
     save_provider_credentials(
         provider_id,
         client_id=client_id,
-        client_secret=client_secret,
+        # Coerce None -> "" so a secretless provider (e.g. Microsoft) never
+        # persists a null client_secret (--client-secret has no argparse
+        # default, so an omitted flag arrives as None).
+        client_secret=client_secret or "",
     )
     # Evict any cached provider instance so the next get_provider() re-reads the
     # freshly persisted creds instead of a stale id/secret.

--- a/src/gaia/connectors/oauth_pkce.py
+++ b/src/gaia/connectors/oauth_pkce.py
@@ -36,6 +36,12 @@ from gaia.connectors.tokens import get_or_refresh
 
 logger = logging.getLogger(__name__)
 
+#: Providers whose token endpoint rejects a request with no client_secret.
+#: Public PKCE clients (Microsoft/Entra) must NOT send one; default is "not
+#: required" so any provider added later defaults to the safe, public-client
+#: behavior without needing to be listed here.
+PROVIDERS_REQUIRING_CLIENT_SECRET: frozenset[str] = frozenset({"google"})
+
 
 def _validate_provider_secret(provider_id: str) -> None:
     """Raise ``ConfigurationError`` if the provider requires a client_secret
@@ -47,7 +53,7 @@ def _validate_provider_secret(provider_id: str) -> None:
     unknown providers are passed through without checking.
     """
     # Only Google Desktop PKCE clients are known to require the secret.
-    if provider_id != "google":
+    if provider_id not in PROVIDERS_REQUIRING_CLIENT_SECRET:
         return
     from gaia.connectors.providers import get as _get_provider
 

--- a/src/gaia/connectors/tokens.py
+++ b/src/gaia/connectors/tokens.py
@@ -210,12 +210,21 @@ async def _refresh_token(
         #     credentials in Settings → Connections).
         #   - Secret is present but token rejected → AuthRequiredError (fix:
         #     reconnect from Settings → Connections).
+        # Public PKCE clients (Microsoft/Entra) never have a secret — that's
+        # the correct, expected state, not a misconfiguration — so only
+        # providers in PROVIDERS_REQUIRING_CLIENT_SECRET take the
+        # config-missing branch (#1638).
         try:
             err_payload = response.json()
         except Exception:
             err_payload = {}
+        from gaia.connectors.oauth_pkce import PROVIDERS_REQUIRING_CLIENT_SECRET
+
         client_secret = getattr(provider, "client_secret", None)
-        if not client_secret:
+        if (
+            not client_secret
+            and provider.provider_id in PROVIDERS_REQUIRING_CLIENT_SECRET
+        ):
             raise ConfigurationError(
                 f"Token endpoint returned 401 for {provider.provider_id}: "
                 "client_secret is not configured. Open Settings → Connections "

--- a/tests/unit/connectors/test_cli.py
+++ b/tests/unit/connectors/test_cli.py
@@ -538,12 +538,8 @@ class TestConfigureSecretlessPublicClient:
         monkeypatch.setattr(
             oauth_pkce, "PROVIDERS_REQUIRING_CLIENT_SECRET", frozenset({"microsoft"})
         )
-        assert (
-            _run("connectors", "configure", "microsoft", "--client-id", "x")[0] == 2
-        )
-        assert (
-            _run("connectors", "configure", "google", "--client-id", "y")[0] == 0
-        )
+        assert _run("connectors", "configure", "microsoft", "--client-id", "x")[0] == 2
+        assert _run("connectors", "configure", "google", "--client-id", "y")[0] == 0
 
     def test_help_no_longer_implies_a_universal_secret_requirement(self):
         rc, out, _err = _run("connectors", "configure", "--help")

--- a/tests/unit/connectors/test_cli.py
+++ b/tests/unit/connectors/test_cli.py
@@ -545,6 +545,12 @@ class TestConfigureSecretlessPublicClient:
             _run("connectors", "configure", "google", "--client-id", "y")[0] == 0
         )
 
+    def test_help_no_longer_implies_a_universal_secret_requirement(self):
+        rc, out, _err = _run("connectors", "configure", "--help")
+        assert rc == 0
+        assert "requires --client-secret" not in out
+        assert "google" in out.lower()
+
 
 class TestDisconnect:
     def test_disconnect_idempotent(self):

--- a/tests/unit/connectors/test_cli.py
+++ b/tests/unit/connectors/test_cli.py
@@ -458,6 +458,94 @@ class TestConfigure:
         assert "--set" in err or "--json" in err
 
 
+class TestConfigureSecretlessPublicClient:
+    """#1638: ``configure`` must not demand --client-secret for providers
+    whose token endpoint rejects one (Microsoft/Entra public PKCE clients).
+    Google's requirement is unchanged.
+    """
+
+    def test_configure_microsoft_without_secret_succeeds(self, monkeypatch):
+        monkeypatch.delenv("GAIA_MICROSOFT_CLIENT_ID", raising=False)
+        monkeypatch.delenv("GAIA_MICROSOFT_CLIENT_SECRET", raising=False)
+
+        rc, out, _err = _run(
+            "connectors",
+            "configure",
+            "microsoft",
+            "--client-id",
+            "cli-test-guid",
+        )
+        assert rc == 0
+        assert "Configured microsoft" in out
+
+        from gaia.connectors.store import peek_provider_credentials
+
+        creds = peek_provider_credentials("microsoft")
+        # Exact equality, not truthiness: a loose `not creds["client_secret"]`
+        # check would pass for both "" and the None this fix must prevent.
+        assert creds == {"client_id": "cli-test-guid", "client_secret": ""}
+
+    def test_configure_google_without_secret_still_exits_2(self):
+        rc, _out, err = _run(
+            "connectors",
+            "configure",
+            "google",
+            "--client-id",
+            "id.apps.googleusercontent.com",
+        )
+        assert rc == 2
+        assert "client-secret" in err
+        assert "Google" in err or "google" in err
+
+    def test_client_secret_without_id_still_exits_2(self):
+        # Unchanged regardless of provider: --client-secret alone is a
+        # usage error.
+        rc, _out, err = _run(
+            "connectors",
+            "configure",
+            "microsoft",
+            "--client-secret",
+            "should-not-be-sent",
+        )
+        assert rc == 2
+        assert "client-id" in err
+
+    def test_configure_then_provider_resolves_without_env(self, monkeypatch):
+        """The actual payoff (#1638): after `configure microsoft
+        --client-id`, the provider resolves the id with no env var set —
+        proven at the provider-construction seam, not through `connect`
+        (which mocks start_authorization and would pass either way)."""
+        monkeypatch.delenv("GAIA_MICROSOFT_CLIENT_ID", raising=False)
+        monkeypatch.delenv("GAIA_MICROSOFT_CLIENT_SECRET", raising=False)
+
+        rc, _out, _err = _run(
+            "connectors", "configure", "microsoft", "--client-id", "cli-test-guid"
+        )
+        assert rc == 0
+
+        _registry.clear()
+        from gaia.connectors.providers import get as get_provider
+
+        assert get_provider("microsoft").client_id == "cli-test-guid"
+
+    def test_cli_reads_the_shared_constant_not_a_copy(self, monkeypatch):
+        """Structural guard: the CLI must consult
+        oauth_pkce.PROVIDERS_REQUIRING_CLIENT_SECRET directly, not a copy
+        of the rule, so flipping the shared constant moves both providers'
+        behavior together."""
+        from gaia.connectors import oauth_pkce
+
+        monkeypatch.setattr(
+            oauth_pkce, "PROVIDERS_REQUIRING_CLIENT_SECRET", frozenset({"microsoft"})
+        )
+        assert (
+            _run("connectors", "configure", "microsoft", "--client-id", "x")[0] == 2
+        )
+        assert (
+            _run("connectors", "configure", "google", "--client-id", "y")[0] == 0
+        )
+
+
 class TestDisconnect:
     def test_disconnect_idempotent(self):
         rc, _out, _err = _run("connectors", "disconnect", "google")

--- a/tests/unit/connectors/test_oauth_pkce_secret_validation.py
+++ b/tests/unit/connectors/test_oauth_pkce_secret_validation.py
@@ -38,6 +38,22 @@ def _make_spec(
     )
 
 
+class TestProvidersRequiringClientSecretConstant:
+    """#1638: the "which providers require a secret" rule must live in one
+    place (an allowlist, not a denylist) so a new provider defaults to
+    "not required" — the correct default for a public PKCE client."""
+
+    def test_google_is_in_the_allowlist(self):
+        from gaia.connectors.oauth_pkce import PROVIDERS_REQUIRING_CLIENT_SECRET
+
+        assert "google" in PROVIDERS_REQUIRING_CLIENT_SECRET
+
+    def test_microsoft_is_not_in_the_allowlist(self):
+        from gaia.connectors.oauth_pkce import PROVIDERS_REQUIRING_CLIENT_SECRET
+
+        assert "microsoft" not in PROVIDERS_REQUIRING_CLIENT_SECRET
+
+
 class TestConnectTimeSecretValidation:
     @pytest.mark.asyncio
     async def test_configure_raises_when_no_secret_and_provider_requires_it(

--- a/tests/unit/connectors/test_token_401.py
+++ b/tests/unit/connectors/test_token_401.py
@@ -171,9 +171,7 @@ class TestToken401ActionableError:
         (AuthRequiredError/REAUTH_REQUIRED), never the Google-specific
         "go configure a client_secret" ConfigurationError — that message
         tells a Microsoft user to enter a secret they must not have."""
-        respx.post(
-            "https://login.microsoftonline.com/common/oauth2/v2.0/token"
-        ).mock(
+        respx.post("https://login.microsoftonline.com/common/oauth2/v2.0/token").mock(
             return_value=httpx.Response(
                 401,
                 json={

--- a/tests/unit/connectors/test_token_401.py
+++ b/tests/unit/connectors/test_token_401.py
@@ -73,6 +73,30 @@ def seeded_connection_no_secret(google_provider_no_secret):
     yield google_provider_no_secret
 
 
+@pytest.fixture
+def microsoft_provider_no_secret(monkeypatch):
+    """A Microsoft provider with no client_secret — the correct, expected
+    state for a public PKCE client (#1638)."""
+    monkeypatch.setenv("GAIA_MICROSOFT_CLIENT_ID", "test-app-guid")
+    monkeypatch.delenv("GAIA_MICROSOFT_CLIENT_SECRET", raising=False)
+    _registry.clear()
+    from gaia.connectors.providers import get as get_provider
+
+    return get_provider("microsoft")
+
+
+@pytest.fixture
+def seeded_microsoft_connection_no_secret(microsoft_provider_no_secret):
+    save_connection(
+        provider="microsoft",
+        account_email="alice@outlook.com",
+        refresh_token="seed-refresh-token",
+        scopes=["https://graph.microsoft.com/Mail.Read"],
+        client_id_hash=microsoft_provider_no_secret.client_id_hash,
+    )
+    yield microsoft_provider_no_secret
+
+
 class TestToken401ActionableError:
     @respx.mock
     async def test_401_with_secret_present_raises_actionable_reauth(
@@ -137,3 +161,27 @@ class TestToken401ActionableError:
         )
         with pytest.raises(ConnectorsError):
             await get_or_refresh("google")
+
+    @respx.mock
+    async def test_401_for_secretless_microsoft_raises_reauth_not_config_error(
+        self, seeded_microsoft_connection_no_secret
+    ):
+        """#1638: a secretless provider (Microsoft) is the correct, expected
+        state. Its 401 must fall through to the normal reconnect advice
+        (AuthRequiredError/REAUTH_REQUIRED), never the Google-specific
+        "go configure a client_secret" ConfigurationError — that message
+        tells a Microsoft user to enter a secret they must not have."""
+        respx.post(
+            "https://login.microsoftonline.com/common/oauth2/v2.0/token"
+        ).mock(
+            return_value=httpx.Response(
+                401,
+                json={
+                    "error": "invalid_grant",
+                    "error_description": "AADSTS700082: expired refresh token.",
+                },
+            )
+        )
+        with pytest.raises(AuthRequiredError) as exc_info:
+            await get_or_refresh("microsoft")
+        assert exc_info.value.reason == AuthRequiredError.Reason.REAUTH_REQUIRED


### PR DESCRIPTION
Closes #1638

Setting up Outlook from the command line was impossible: `gaia connectors configure microsoft --client-id <id>` refused to save unless you also supplied a client secret — but Microsoft public PKCE clients don't have one, and Microsoft's own rules forbid sending it. The only CLI route was re-exporting `GAIA_MICROSOFT_CLIENT_ID` in every shell session, because nothing was ever persisted to the keyring. Now the secret is required only for the providers that actually need it (Google), so `configure` persists the client id and `connect` works with no environment variable.

The same defect had a second home that would have made the fix look broken: on **any** 401 during refresh, `tokens.py` told every secretless provider to go configure a client secret and pointed at Google's runbook. A Microsoft user following the newly-working setup path would have hit that on their first reauth — for a revoked consent, an admin block, or an MFA policy change. Both sites now read one shared allowlist, so a provider added later defaults to the safe public-client behaviour without being listed anywhere.

## Test plan

All verified on a Linux dev box against a real SecretService keyring — transcripts in the [evidence comment](https://github.com/amd/gaia/pull/2630#issuecomment-5124441603).

- [x] `python -m pytest tests/unit/connectors/ -q` — 8 new tests covering both call sites
- [x] `gaia connectors configure microsoft --client-id <guid>` exits 0 and persists `{"client_id": "<guid>", "client_secret": ""}`
- [x] `gaia connectors configure google --client-id <guid>` still exits 2 with the unchanged Google error
- [x] With `GAIA_MICROSOFT_CLIENT_ID` unset, the Microsoft provider resolves its client id from the keyring
- [x] `python util/lint.py --all`

<details>
<summary>Notes for the reviewer</summary>

Two test traps were identified during planning and deliberately avoided:

- The payoff is **not** tested through `gaia connectors connect`. The obvious pattern in `test_cli.py` monkeypatches `start_authorization`, which is exactly where credential resolution happens (`flow.py:220`) — that test would pass whether or not the fix works. It is asserted at the provider-construction seam instead.
- `test_cli_reads_the_shared_constant_not_a_copy` flips the shared frozenset and asserts both call sites move together. Every other test here is behavioural and could not distinguish "the CLI reads the shared constant" from "the CLI has its own copy that currently agrees" — which is the regression the single-source-of-truth requirement exists to prevent.

The `tokens.py` import of the constant is function-local by necessity: `oauth_pkce` imports `tokens` at module level, so a top-level import would be circular. The CLI's import is function-local too, matching the surrounding convention — `add_subparser` runs on every `gaia` invocation, so a module-level import would drag the connectors stack into unrelated commands.

Scoped to avoid a collision with #2628, which is concurrently restructuring `spec.py`, `providers/`, `catalog/`, `store.py`, `flow.py`, and `setup_routes.py`. None of those files are touched here.
</details>

