### PR TITLE
fix(agents): truncate large tool results to valid JSON

### DIFF
--- a/src/gaia/agents/base/agent.py
+++ b/src/gaia/agents/base/agent.py
@@ -2796,9 +2796,7 @@ Do NOT wrap conversational replies in JSON.
         totals = {key: len(items) for key, items in lists.items()}
 
         def render() -> str:
-            dropped_any = any(
-                len(items) < totals[key] for key, items in lists.items()
-            )
+            dropped_any = any(len(items) < totals[key] for key, items in lists.items())
             if is_root_list:
                 payload: Any = list(lists["__root__"])
                 if dropped_any:

--- a/src/gaia/agents/base/agent.py
+++ b/src/gaia/agents/base/agent.py
@@ -41,6 +41,7 @@ from gaia.llm.lemonade_client import (
     DEFAULT_MODEL_NAME,
     GPU_CTX_SIZE,
     is_context_overflow_error,
+    truncation_budget,
 )
 
 if TYPE_CHECKING:
@@ -2340,12 +2341,13 @@ Do NOT wrap conversational replies in JSON.
         if isinstance(tool_result, (dict, list)):
             # Use custom encoder to handle bytes and other non-serializable types
             result_str = json.dumps(tool_result, default=self._json_serialize_fallback)
-            if (
-                len(result_str) > 30000
-            ):  # Threshold for truncation (appropriate for 32K context)
-                # Truncate large results to prevent overwhelming the LLM
+            threshold, target = truncation_budget(self.device)
+            if len(result_str) > threshold:
+                # Truncate large results to prevent overwhelming the LLM. The
+                # result is re-parsed just below, so this path must always
+                # come back as valid JSON (#2620).
                 truncated_str = self._truncate_large_content(
-                    tool_result, max_chars=20000  # Increased for 32K context
+                    tool_result, max_chars=target, as_json=True
                 )
                 try:
                     truncated_result = json.loads(truncated_str)
@@ -2355,6 +2357,16 @@ Do NOT wrap conversational replies in JSON.
                 # Notify user about truncation
                 self.console.print_info(
                     f"Note: Large result ({len(result_str)} chars) truncated for LLM context"
+                )
+                # SilentConsole.print_info is a no-op, so every packaged/sidecar
+                # agent needs the real logger to make truncation diagnosable.
+                logger.warning(
+                    "Tool result for %s truncated: %d chars exceeded the %d-char "
+                    "cap for this device profile (target %d)",
+                    tool_name,
+                    len(result_str),
+                    threshold,
+                    target,
                 )
                 if self.debug:
                     print(f"[DEBUG] Tool result truncated from {len(result_str)} chars")
@@ -2544,6 +2556,9 @@ Do NOT wrap conversational replies in JSON.
         if isinstance(tool_output, str):
             text_content = tool_output
         else:
+            # Prose call site: text_content is spliced into a message's text
+            # field, never json.loads'd -- stays on the default prose path,
+            # not the JSON-safe envelope (#2620, reflection C2).
             text_content = self._truncate_large_content(tool_output, max_chars=2000)
 
         if not isinstance(text_content, str):
@@ -2638,10 +2653,26 @@ Do NOT wrap conversational replies in JSON.
 
         return "<non-serializable>"
 
-    def _truncate_large_content(self, content: Any, max_chars: int = 2000) -> str:
+    def _truncate_large_content(
+        self, content: Any, max_chars: int = 20000, as_json: bool = False
+    ) -> str:
         """
         Truncate large content to prevent overwhelming the LLM.
-        Defaults to 20000 chars which is appropriate for 32K token context window.
+
+        Defaults to 20000 chars, appropriate for the NPU's 32K token context
+        window (``_handle_large_tool_result`` scales this per device profile
+        via ``truncation_budget``). Whole list items are dropped from the end
+        rather than slicing the serialized text, so the result never cuts
+        through the middle of a record (#2620).
+
+        Set ``as_json=True`` when the caller will ``json.loads`` the result
+        (today, only ``_handle_large_tool_result``) -- its last-resort
+        fallback then wraps the sliced text in a JSON envelope so the output
+        always parses. Prose callers (spliced directly into an LLM prompt
+        string, e.g. ``_create_tool_message``) get the plain slice they
+        always got: wrapping prose in an escaped JSON blob would waste an
+        already-tight budget on punctuation the reader never needed
+        (reflection C2).
         """
 
         # If we have test_results in the output we don't want to
@@ -2652,21 +2683,15 @@ Do NOT wrap conversational replies in JSON.
         ):
             return json.dumps(content, default=self._json_serialize_fallback)
 
-        # Convert to string (use compact JSON first to check size)
-        if isinstance(content, (dict, list)):
-            compact_str = json.dumps(content, default=self._json_serialize_fallback)
-            # Only use indented format if we need to truncate anyway
-            content_str = (
-                json.dumps(content, indent=2, default=self._json_serialize_fallback)
-                if len(compact_str) > max_chars
-                else compact_str
-            )
-        else:
+        if not isinstance(content, (dict, list)):
             content_str = str(content)
+            if len(content_str) <= max_chars:
+                return content_str
+            return self._truncate_fallback_text(content_str, max_chars, as_json)
 
-        # Return as-is if within limits
-        if len(content_str) <= max_chars:
-            return content_str
+        compact_str = json.dumps(content, default=self._json_serialize_fallback)
+        if len(compact_str) <= max_chars:
+            return compact_str
 
         # For responses with chunks (e.g., search results, document retrieval)
         if (
@@ -2701,36 +2726,116 @@ Do NOT wrap conversational replies in JSON.
                 truncated, indent=2, default=self._json_serialize_fallback
             )
 
-        # For Jira responses, keep first 3 issues
-        if (
-            isinstance(content, dict)
-            and "issues" in content
-            and isinstance(content["issues"], list)
-        ):
-            truncated = {
-                **content,
-                "issues": content["issues"][:3],
-                "truncated": True,
-                "total": len(content["issues"]),
-            }
-            return json.dumps(
-                truncated, indent=2, default=self._json_serialize_fallback
-            )[:max_chars]
+        # Dict/list content (Jira "issues", email "messages"/"awaiting_reply",
+        # a bare list, ...): drop whole trailing items -- never slice inside
+        # one -- so the result always re-serializes cleanly (#2620).
+        dropped = self._drop_items_to_fit(content, max_chars)
+        if dropped is not None:
+            return dropped
 
-        # For lists, keep first 3 items
-        if isinstance(content, list):
-            truncated = (
-                content[:3] + [{"truncated": f"{len(content) - 3} more"}]
-                if len(content) > 3
-                else content
+        # Last resort: no list to trim (a scalar-only dict), or the single
+        # surviving item still doesn't fit -- see _drop_items_to_fit.
+        return self._truncate_fallback_text(compact_str, max_chars, as_json)
+
+    def _truncate_fallback_text(self, text: str, max_chars: int, as_json: bool) -> str:
+        """Last-resort slice when there is no whole item left to drop.
+
+        ``as_json`` callers get a JSON envelope (``json.dumps`` escapes the
+        slice, so the result always parses); prose callers get the plain
+        mid-slice they always got (#2620, reflection C2).
+        """
+        if as_json:
+            envelope_overhead = len(
+                json.dumps(
+                    {"truncated": True, "original_chars": len(text), "content": ""},
+                    default=self._json_serialize_fallback,
+                )
             )
+            budget = max(0, max_chars - envelope_overhead)
             return json.dumps(
-                truncated, indent=2, default=self._json_serialize_fallback
-            )[:max_chars]
+                {
+                    "truncated": True,
+                    "original_chars": len(text),
+                    "content": text[:budget],
+                },
+                default=self._json_serialize_fallback,
+            )
 
-        # Simple truncation
         half = max_chars // 2 - 20
-        return f"{content_str[:half]}\n...[truncated]...\n{content_str[-half:]}"
+        return f"{text[:half]}\n...[truncated]...\n{text[-half:]}"
+
+    def _drop_items_to_fit(self, content: Any, max_chars: int) -> Optional[str]:
+        """Fit ``content`` under ``max_chars`` by dropping whole items from
+        the end of its largest list member, re-serializing through
+        ``json.dumps`` on every attempt so the result is always valid JSON
+        (#2620). Handles a bare list, or a dict with one or more
+        list-valued fields (trimming whichever field currently holds the
+        most items first, repeating across fields as needed -- reflection
+        A2).
+
+        Returns ``None`` when there is no list to trim, or when even the
+        single item surviving across every field still exceeds
+        ``max_chars`` -- the caller then falls back to a text slice rather
+        than silently discarding that last item's content (reflection C3).
+        """
+        is_root_list = isinstance(content, list)
+        if is_root_list:
+            lists: Dict[str, List[Any]] = {"__root__": list(content)}
+            base: Dict[str, Any] = {}
+        else:
+            lists = {
+                key: list(value)
+                for key, value in content.items()
+                if isinstance(value, list) and value
+            }
+            base = {key: value for key, value in content.items() if key not in lists}
+
+        if not lists:
+            return None
+
+        totals = {key: len(items) for key, items in lists.items()}
+
+        def render() -> str:
+            dropped_any = any(
+                len(items) < totals[key] for key, items in lists.items()
+            )
+            if is_root_list:
+                payload: Any = list(lists["__root__"])
+                if dropped_any:
+                    payload.append(
+                        {
+                            "truncated": True,
+                            "returned": len(lists["__root__"]),
+                            "total": totals["__root__"],
+                        }
+                    )
+            else:
+                payload = {**base, **lists}
+                if dropped_any:
+                    payload["truncated"] = True
+                    payload["truncated_fields"] = {
+                        key: {"returned": len(items), "total": totals[key]}
+                        for key, items in lists.items()
+                        if len(items) < totals[key]
+                    }
+            return json.dumps(payload, default=self._json_serialize_fallback)
+
+        result = render()
+        while len(result) > max_chars:
+            candidates = [key for key, items in lists.items() if items]
+            if not candidates:
+                return None
+            if sum(len(items) for items in lists.values()) <= 1:
+                # The last surviving item alone doesn't fit even with the
+                # marker overhead. Dropping it would silently return an
+                # empty shell; hand off to the text-slice fallback instead,
+                # which preserves a sliced fragment of it (reflection C3).
+                return None
+            largest = max(candidates, key=lambda key: len(lists[key]))
+            lists[largest].pop()
+            result = render()
+
+        return result
 
     def _namespaced_agent_id(self) -> Optional[str]:
         """Return the registry-assigned namespaced agent id, or None.
@@ -3165,6 +3270,9 @@ Do NOT wrap conversational replies in JSON.
                                 plan_context, default=self._json_serialize_fallback
                             )
                             if len(plan_context_raw) > 20000:
+                                # Prose call site: spliced into an f-string
+                                # prompt below, never json.loads'd (#2620,
+                                # reflection C2).
                                 plan_context_str = self._truncate_large_content(
                                     plan_context, max_chars=20000
                                 )
@@ -3242,7 +3350,9 @@ Do NOT wrap conversational replies in JSON.
                         "ERROR RECOVERY: Handling previous error"
                     )
 
-                    # Truncate previous outputs if too large to avoid overwhelming the LLM
+                    # Truncate previous outputs if too large to avoid overwhelming the LLM.
+                    # Prose call site: spliced into the recovery prompt below,
+                    # never json.loads'd (#2620, reflection C2).
                     truncated_outputs = (
                         self._truncate_large_content(previous_outputs, max_chars=500)
                         if previous_outputs

--- a/src/gaia/llm/lemonade_client.py
+++ b/src/gaia/llm/lemonade_client.py
@@ -21,7 +21,7 @@ import time
 from dataclasses import dataclass, field
 from enum import Enum
 from threading import Event, Thread
-from typing import Any, Callable, Dict, Generator, List, Optional, Union
+from typing import Any, Callable, Dict, Generator, List, Optional, Tuple, Union
 
 import openai  # For exception types
 import psutil
@@ -182,6 +182,31 @@ def profile_ctx_size(device: Optional[str]) -> int:
     fails the load outright.
     """
     return NPU_CTX_SIZE if (device or "").strip().lower() == "npu" else GPU_CTX_SIZE
+
+
+# ``_handle_large_tool_result``'s truncation trigger/target were tuned as a
+# flat 30000/20000 chars for the NPU's 32768 ctx (#2620). Keep that profile
+# exact and scale the same ratio to the active device's window instead of
+# inventing a new budget.
+_TRUNCATE_THRESHOLD_RATIO = 30000 / NPU_CTX_SIZE  # chars per ctx token
+_TRUNCATE_TARGET_FRACTION = 2 / 3  # 20000 / 30000
+
+
+def truncation_budget(device: Optional[str]) -> Tuple[int, int]:
+    """(threshold, target) char budget for large tool-result truncation.
+
+    Deliberately more conservative than ``profile_ctx_size``: an unset or
+    unrecognized *device* resolves to the NPU profile (today's flat
+    30000/20000), never the larger GPU one. Handing an unconfirmed device
+    the bigger budget would reopen the #1030 context-overflow class if the
+    caller turns out to actually be running on NPU — only an explicit
+    non-NPU device earns the larger allowance.
+    """
+    normalized = (device or "").strip().lower()
+    ctx = NPU_CTX_SIZE if not normalized or normalized == "npu" else GPU_CTX_SIZE
+    threshold = round(ctx * _TRUNCATE_THRESHOLD_RATIO)
+    target = round(threshold * _TRUNCATE_TARGET_FRACTION)
+    return threshold, target
 
 
 # =========================================================================

--- a/tests/unit/agents/test_large_tool_result_truncation.py
+++ b/tests/unit/agents/test_large_tool_result_truncation.py
@@ -1,0 +1,338 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""
+Regression tests for large tool-result truncation (#2620).
+
+Today, an oversized tool result gets shortened by slicing the serialized
+JSON string in half and gluing the two ends back together -- almost always
+cutting through the middle of a list item, which corrupts the JSON the
+assistant reads on its next turn. These tests build realistic oversized
+payloads (Gmail/Outlook-shaped envelope items: id/threadId/sender/subject/
+snippet/labelIds) and assert:
+
+  - the truncated output always parses (AC1)
+  - only whole items are dropped, never a mid-item slice (AC2)
+  - the size cap derives from the device profile, conservatively (AC3)
+  - payloads already under the cap are returned untouched (AC4)
+  - the truncation event reaches the real module logger even when the
+    console is silent (AC5)
+  - the three prose call sites keep returning a plain string rather than a
+    JSON envelope (AC7 / reflection C2)
+"""
+
+from __future__ import annotations
+
+import ast
+import inspect
+import json
+import logging
+
+import pytest
+
+import gaia.agents.base.agent as agent_module
+from gaia.agents.base.agent import Agent
+from gaia.agents.base.console import SilentConsole
+from gaia.llm.lemonade_client import truncation_budget
+
+# ---------------------------------------------------------------------------
+# Fixtures / helpers
+# ---------------------------------------------------------------------------
+
+
+class _TestAgent(Agent):
+    """Minimal concrete Agent: no LLM/network access, no tools."""
+
+    def _get_system_prompt(self):
+        return "test"
+
+    def _register_tools(self):
+        pass
+
+
+def make_agent(**kwargs) -> _TestAgent:
+    kwargs.setdefault("silent_mode", True)
+    kwargs.setdefault("skip_lemonade", True)
+    return _TestAgent(**kwargs)
+
+
+def _email_item(i: int) -> dict:
+    """A realistic Gmail/Outlook envelope item, not filler text -- so a
+    mid-string cut actually reproduces the reported corruption."""
+    return {
+        "id": f"msg-{i:04d}",
+        "threadId": f"thread-{i:04d}",
+        "sender": f"person{i}@example.com",
+        "subject": f"Re: quarterly planning sync #{i} -- action needed by Friday",
+        "snippet": (
+            f"Hi team, following up on item {i} from yesterday's call. "
+            "Please review the attached notes and let me know if you have "
+            "any concerns before we finalize the roadmap for next quarter."
+        ),
+        "labelIds": ["INBOX", "UNREAD", "CATEGORY_PERSONAL"],
+    }
+
+
+def _messages_payload(min_chars: int = 35000, key: str = "messages") -> dict:
+    """Build ``{key: [...]}`` whose compact JSON is at least ``min_chars`` long."""
+    items = []
+    i = 0
+    while True:
+        items.append(_email_item(i))
+        if len(json.dumps({key: items})) >= min_chars:
+            return {key: items}
+        i += 1
+
+
+def _bare_list_payload(min_chars: int = 35000) -> list:
+    items = []
+    i = 0
+    while len(json.dumps(items)) < min_chars:
+        items.append(_email_item(i))
+        i += 1
+    return items
+
+
+# ---------------------------------------------------------------------------
+# AC1 -- always-valid JSON
+# ---------------------------------------------------------------------------
+
+
+class TestAlwaysValidJson:
+    def test_messages_dict(self):
+        agent = make_agent()
+        payload = _messages_payload(key="messages")
+        result = agent._truncate_large_content(payload, max_chars=20000, as_json=True)
+        parsed = json.loads(result)  # must not raise
+        assert parsed["truncated"] is True
+
+    def test_awaiting_reply_dict(self):
+        agent = make_agent()
+        payload = _messages_payload(key="awaiting_reply")
+        result = agent._truncate_large_content(payload, max_chars=20000, as_json=True)
+        parsed = json.loads(result)
+        assert parsed["truncated"] is True
+
+    def test_issues_dict_jira_shape(self):
+        agent = make_agent()
+        payload = _messages_payload(key="issues")
+        result = agent._truncate_large_content(payload, max_chars=20000, as_json=True)
+        parsed = json.loads(result)
+        assert parsed["truncated"] is True
+
+    def test_bare_list(self):
+        agent = make_agent()
+        items = _bare_list_payload()
+        result = agent._truncate_large_content(items, max_chars=20000, as_json=True)
+        parsed = json.loads(result)
+        assert isinstance(parsed, list)
+
+    def test_oversized_dict_with_no_list_member(self):
+        """The true fallback: an oversized dict of scalars, nothing to drop."""
+        agent = make_agent()
+        payload = {"summary": "x" * 40000, "count": 5}
+        result = agent._truncate_large_content(payload, max_chars=20000, as_json=True)
+        parsed = json.loads(result)
+        assert parsed["truncated"] is True
+        assert parsed["original_chars"] > 20000
+
+    def test_single_item_exceeding_budget_alone(self):
+        """Reflection C3 floor: one item alone bigger than the cap must
+        still produce parseable JSON rather than a mid-slice."""
+        agent = make_agent()
+        payload = {"messages": [{"id": "only-one", "body": "z" * 40000}]}
+        result = agent._truncate_large_content(payload, max_chars=20000, as_json=True)
+        json.loads(result)  # must not raise
+
+    def test_combined_multiple_list_fields(self):
+        """Reflection A2: multiple list-valued fields -- the largest is
+        trimmed first, repeating until the payload fits."""
+        agent = make_agent()
+        big = _messages_payload(min_chars=30000, key="messages")["messages"]
+        small = [_email_item(i) for i in range(3)]
+        payload = {"messages": big, "awaiting_reply": small}
+        result = agent._truncate_large_content(payload, max_chars=20000, as_json=True)
+        parsed = json.loads(result)
+        assert len(parsed["messages"]) < len(big)
+
+
+# ---------------------------------------------------------------------------
+# AC2 -- whole items only, dropped count reported
+# ---------------------------------------------------------------------------
+
+
+class TestWholeItemsOnly:
+    def test_surviving_items_match_originals_and_are_a_clean_prefix(self):
+        agent = make_agent()
+        payload = _messages_payload(key="messages")
+        original_items = payload["messages"]
+        result = agent._truncate_large_content(payload, max_chars=20000, as_json=True)
+        parsed = json.loads(result)
+        kept = parsed["messages"]
+
+        assert len(kept) < len(original_items)
+        # Every surviving item is byte-identical to its original counterpart
+        # -- never a prefix/suffix fragment of one.
+        assert kept == original_items[: len(kept)]
+        assert parsed["truncated"] is True
+        assert parsed["truncated_fields"]["messages"]["total"] == len(original_items)
+        assert parsed["truncated_fields"]["messages"]["returned"] == len(kept)
+
+
+# ---------------------------------------------------------------------------
+# AC3 -- cap derives from the device profile, conservatively
+# ---------------------------------------------------------------------------
+
+
+class TestDeviceProfileBudget:
+    def test_npu_unchanged(self):
+        assert truncation_budget("npu") == (30000, 20000)
+
+    def test_unset_device_gets_conservative_cap(self):
+        # Reflection C1: None must NOT earn the larger GPU budget.
+        assert truncation_budget(None) == (30000, 20000)
+
+    def test_gpu_doubles(self):
+        assert truncation_budget("gpu") == (60000, 40000)
+
+    def test_cpu_doubles(self):
+        assert truncation_budget("cpu") == (60000, 40000)
+
+    def test_no_inline_30000_literal_left_in_handle_large_tool_result(self):
+        src = inspect.getsource(Agent._handle_large_tool_result)
+        assert "30000" not in src
+
+
+# ---------------------------------------------------------------------------
+# AC4 -- under the cap is untouched
+# ---------------------------------------------------------------------------
+
+
+class TestUnderCapUntouched:
+    def test_dict_untouched_no_marker_no_log(self, caplog):
+        agent = make_agent()
+        payload = {"messages": [_email_item(0), _email_item(1)]}
+        caplog.set_level(logging.WARNING, logger="gaia.agents.base.agent")
+        caplog.clear()
+
+        result = agent._truncate_large_content(payload, max_chars=20000, as_json=True)
+
+        assert result == json.dumps(payload, default=agent._json_serialize_fallback)
+        assert "truncated" not in result
+        assert len(caplog.records) == 0
+
+    def test_list_untouched(self):
+        agent = make_agent()
+        payload = [_email_item(0), _email_item(1)]
+        result = agent._truncate_large_content(payload, max_chars=20000, as_json=True)
+        assert result == json.dumps(payload, default=agent._json_serialize_fallback)
+
+    def test_test_results_bypass_still_untouched_regardless_of_size(self):
+        # Deliberately out of scope (#2620) -- the code agent needs full
+        # failing-test output intact no matter how large.
+        agent = make_agent()
+        huge = {"test_results": "F" * 50000}
+        result = agent._truncate_large_content(huge, max_chars=100, as_json=True)
+        assert result == json.dumps(huge, default=agent._json_serialize_fallback)
+        assert len(result) > 100
+
+
+# ---------------------------------------------------------------------------
+# AC5 -- the event reaches the real logger
+# ---------------------------------------------------------------------------
+
+
+class TestLoggerReceivesWarning:
+    def test_handle_large_tool_result_logs_once_with_silent_console(self, caplog):
+        agent = make_agent(device=None)
+        assert isinstance(agent.console, SilentConsole)
+
+        caplog.set_level(logging.WARNING, logger="gaia.agents.base.agent")
+        caplog.clear()
+
+        payload = _messages_payload(key="messages")
+        original_len = len(
+            json.dumps(payload, default=agent._json_serialize_fallback)
+        )
+        conversation: list = []
+
+        notices = []
+        agent.console.print_info = lambda msg: notices.append(msg)
+
+        agent._handle_large_tool_result("list_inbox", payload, conversation)
+
+        warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+        assert len(warnings) == 1
+        message = warnings[0].getMessage()
+        assert str(original_len) in message
+        assert "30000" in message  # unset device -> NPU-conservative threshold
+        assert len(notices) == 1  # console.print_info still fires exactly once
+
+    def test_handle_large_tool_result_no_log_under_cap(self, caplog):
+        agent = make_agent(device=None)
+        caplog.set_level(logging.WARNING, logger="gaia.agents.base.agent")
+        caplog.clear()
+
+        small = {"messages": [_email_item(0)]}
+        conversation: list = []
+        result = agent._handle_large_tool_result("list_inbox", small, conversation)
+
+        assert result == small
+        assert len(caplog.records) == 0
+
+
+# ---------------------------------------------------------------------------
+# AC7 / reflection C2 -- prose call sites stay prose
+# ---------------------------------------------------------------------------
+
+
+class TestProseCallSitesStayProse:
+    def test_default_is_prose_not_json_envelope(self):
+        agent = make_agent()
+        payload = {"summary": "y" * 5000}
+        result = agent._truncate_large_content(payload, max_chars=500)
+        assert "...[truncated]..." in result
+        with pytest.raises(json.JSONDecodeError):
+            json.loads(result)
+
+    def test_create_tool_message_uses_prose_path(self):
+        # _create_tool_message (agent.py ~2547) must not opt into as_json.
+        src = inspect.getsource(Agent._create_tool_message)
+        assert "as_json=True" not in src
+
+    def test_as_json_true_used_exactly_once_in_module(self):
+        # Only _handle_large_tool_result's internal call needs guaranteed
+        # JSON; every other call site (_create_tool_message, the plan-context
+        # and error-recovery prompts) stays on the prose default. AST-based
+        # (not a text search) so a docstring mentioning the literal
+        # ``as_json=True`` spelling can't produce a false match.
+        tree = ast.parse(inspect.getsource(agent_module))
+        hits = [
+            kw
+            for node in ast.walk(tree)
+            if isinstance(node, ast.Call)
+            for kw in node.keywords
+            if kw.arg == "as_json"
+            and isinstance(kw.value, ast.Constant)
+            and kw.value.value is True
+        ]
+        assert len(hits) == 1
+
+
+# ---------------------------------------------------------------------------
+# Misc invariants (constraints section)
+# ---------------------------------------------------------------------------
+
+
+class TestSignatureAndScalarInvariants:
+    def test_max_chars_default_matches_docstring(self):
+        sig = inspect.signature(Agent._truncate_large_content)
+        assert sig.parameters["max_chars"].default == 20000
+
+    def test_short_string_passthrough(self):
+        agent = make_agent()
+        assert agent._truncate_large_content("hello", max_chars=20000) == "hello"
+
+    def test_issues_and_list_branches_no_longer_end_in_bracket_slice(self):
+        # AC6: the two latent unsafe branches are gone from the source.
+        src = inspect.getsource(Agent._truncate_large_content)
+        assert "[:max_chars]" not in src

--- a/tests/unit/agents/test_large_tool_result_truncation.py
+++ b/tests/unit/agents/test_large_tool_result_truncation.py
@@ -250,9 +250,7 @@ class TestLoggerReceivesWarning:
         caplog.clear()
 
         payload = _messages_payload(key="messages")
-        original_len = len(
-            json.dumps(payload, default=agent._json_serialize_fallback)
-        )
+        original_len = len(json.dumps(payload, default=agent._json_serialize_fallback))
         conversation: list = []
 
         notices = []


### PR DESCRIPTION
Closes #2620

Any tool result over 30,000 characters was shortened by slicing the serialized JSON in half and gluing the two ends together, which almost always cut through the middle of a record or a string — so what reached the model was not a list of anything any more, it was a blob that no longer parsed. Nothing said it had happened: the only notice went through `console.print_info`, which is a no-op under the console every packaged agent runs, so there was no log trace at all. The model then answered from the corruption, confidently. This is in the base `Agent` class, so it affected every GAIA agent, and the cap was a flat 30,000 commented "appropriate for 32K context" while a GPU profile actually has 65,536.

Large results are now shortened by dropping whole items and re-serializing, so the output always parses; the cap comes from the active device profile; and the event is logged where it can actually be seen.

## Test plan

- [x] `pytest tests/unit/agents/ -k 'truncat or large_tool'` — 25 passed (24 new; there were no tests for these functions before)
- [x] `python util/lint.py --all` — pass (mypy warn-only, 1064 pre-existing repo-wide, none in the touched functions)
- [x] Broader `tests/unit/agents/` plus the Lemonade client suites — the 6 failures present are pre-existing and unrelated, confirmed by reverting only the two touched files and re-running to identical failures
- [x] **Before/after on the real payload shape**, replaying a 44,214-char `{"messages": [...]}` envelope through the production function:

```
WITHOUT the fix:  input=44214  output=19979
                  json.loads -> JSONDecodeError: Invalid control character at: line 96 column 401 (char 9980)

WITH the fix:     input=44214  output=19966
                  json.loads -> OK, whole messages kept=18
```

The `char 9980` offset is exactly the one reported on the issue — it is `max_chars // 2 - 20`, the midpoint of the old two-ended slice, landing inside a JSON string body.

- [x] Device sizing: unset and `npu` both resolve to (30000, 20000) — unchanged from today; explicit `gpu`/`cpu` get (60000, 40000)
- [x] Truncation event captured from the module logger at WARNING with a `SilentConsole` attached, which is the condition under which it was previously invisible

<details>
<summary>Design notes and one known limitation</summary>

**An unset device gets the conservative cap, deliberately.** `profile_ctx_size(None)` returns the *larger* `GPU_CTX_SIZE`, and `device` is `None` until something threads `--device` through — so naively deriving from it would have handed an NPU box a 60,000-char budget and reopened the context-overflow class this file already guards against. `truncation_budget()` does not delegate for the unset case.

**Prose callers keep their old behaviour.** Three of the four call sites splice their result straight into an f-string prompt and never parse it (`_create_tool_message`, the plan-context prompt, the error-recovery prompt). Wrapping their output in a JSON envelope would glue escaped JSON into natural-language text, and at the error-recovery site's 500-char budget the envelope's own braces would eat much of it. The JSON-safe path is opt-in and used in exactly one place.

**Known limitation:** the invariant delivered is "parses under `json.loads`", not "RFC 8259 valid". `json.dumps` emits bare `NaN`/`Infinity` for non-finite floats, which Python accepts on the way back in but which a strict consumer would reject. Passing `allow_nan=False` would convert that into an unhandled raise on a hot path with no error boundary, which is a worse trade for a case #2620 is not about — the structural mid-string corruption is fully fixed. Left as a known edge rather than silently ignored.
</details>
