### PR TITLE
fix(email): paginate the triage scan and report truncation honestly

### DIFF
--- a/hub/agents/email/python/CHANGELOG.md
+++ b/hub/agents/email/python/CHANGELOG.md
@@ -104,6 +104,21 @@ contract version is tracked separately as
   a larger length bound (`THREAD_SUMMARY_CHAR_LIMIT`, 700 vs. the
   single-message 300): several messages' decisions plus a new open ask plus
   a meeting time cannot fit in the single-message cap.
+- **The triage scan now actually follows pagination, and `scan_truncated`
+  tells the truth (#2634).** Raising the scan's `max_messages` above one
+  provider page used to do nothing — `triage_inbox_impl` issued a single
+  `list_messages` call and never followed the returned `nextPageToken`, so
+  asking for 500 messages still returned 100. Worse, the attention view's
+  `scan_truncated` was computed as `len(results) >= max_messages`, which
+  flips to "not truncated" the moment a request exceeds one page of real
+  mail — exactly when the scan is least complete. The scan now pages until
+  `max_messages` is collected or the mailbox is exhausted, de-duplicating
+  message ids across pages and clamping the accumulator client-side (Outlook's
+  continuation ignores `max_results` entirely). `scan_truncated` is now
+  derived solely from whether the last-fetched page's own cursor says more
+  mail exists, never from comparing request/response length — a mailbox
+  whose size exactly equals the request now correctly reports no truncation,
+  instead of the length-only formula's false positive.
 - **`POST /autonomy/run` refuses instead of silently no-oping while autonomy
   is `off` (#2528).** Previously the route returned HTTP 200 with the same
   empty-report shape whether autonomy was disabled or had genuinely run and

--- a/hub/agents/email/python/gaia_agent_email/tools/attention_tools.py
+++ b/hub/agents/email/python/gaia_agent_email/tools/attention_tools.py
@@ -160,9 +160,11 @@ def _scan_one_backend(
         "items": items,
         "scanned": len(results),
         "total_unread": _fetch_total_unread(backend),
-        # Mirrors detect_waiting_on_you_impl's own truncation heuristic: a
-        # scan that returned exactly the ceiling likely didn't see everything.
-        "scan_truncated": len(results) >= max_messages
+        # Honest signal (#2634): driven by triage_inbox_impl's own paging
+        # cursor, never by "did we hit max_messages" alone — that formula
+        # is wrong the instant a mailbox's true size exactly equals the
+        # ceiling (nothing missed, but the length check still fires).
+        "scan_truncated": triage["scan_truncated"]
         or bool(waiting.get("scan_truncated")),
     }
 

--- a/hub/agents/email/python/gaia_agent_email/tools/read_tools.py
+++ b/hub/agents/email/python/gaia_agent_email/tools/read_tools.py
@@ -937,6 +937,79 @@ def _apply_session_preferences(
     return out
 
 
+def _list_all_stubs(
+    gmail,
+    *,
+    label_ids: Optional[List[str]],
+    max_messages: int,
+) -> Dict[str, Any]:
+    """Page through ``gmail.list_messages`` until ``max_messages`` unique
+    stubs are collected or the backend has no more (#2634).
+
+    ``nextPageToken`` is followed verbatim across calls — for Outlook that
+    token IS the ``@odata.nextLink`` absolute URL, so re-deriving params
+    instead of passing it straight back would silently restart at page 1.
+    Never trusts a page to honour ``max_results``: Outlook's continuation
+    ignores it entirely and can hand back more than requested, so the
+    accumulator is clamped to ``max_messages`` after every page. Message
+    ids are de-duplicated across pages — a mailbox has no snapshot
+    isolation, so the same id can legitimately reappear on two pages if
+    the mailbox mutates mid-scan.
+
+    Each call requests ``max_results=`` however many messages are still
+    wanted, never a fixed page-size constant (a fixed constant would ask
+    for more than the caller's own budget on a later page).
+
+    A page-2+ failure propagates (never a silent partial result) — this
+    function adds no try/except around ``list_messages``, so whatever the
+    backend raises reaches the caller unchanged, consistent with the
+    fail-loud rule the rest of this package follows.
+
+    Returns ``{"stubs": [...], "scanned": int, "scan_truncated": bool,
+    "resultSizeEstimate": Any}``. ``scan_truncated`` is derived solely from
+    the last-fetched page's own cursor — never from ``len(stubs) >=
+    max_messages`` alone, which is honest only by coincidence and wrong
+    the moment a mailbox's true size exactly equals the request.
+    """
+    labels = list(label_ids) if label_ids else ["INBOX"]
+    stubs: List[Dict[str, Any]] = []
+    seen_ids: set = set()
+    page_token: Optional[str] = None
+    next_token: Optional[str] = None
+    result_size_estimate: Any = None
+    first_page = True
+
+    while len(stubs) < max_messages:
+        remaining = max_messages - len(stubs)
+        listing = gmail.list_messages(
+            label_ids=labels,
+            max_results=remaining,
+            page_token=page_token,
+        )
+        if first_page:
+            result_size_estimate = listing.get("resultSizeEstimate")
+            first_page = False
+        for stub in listing.get("messages", []) or []:
+            mid = stub.get("id")
+            if mid in seen_ids:
+                continue
+            seen_ids.add(mid)
+            stubs.append(stub)
+        if len(stubs) > max_messages:
+            stubs = stubs[:max_messages]
+        next_token = listing.get("nextPageToken")
+        if not next_token:
+            break
+        page_token = next_token
+
+    return {
+        "stubs": stubs,
+        "scanned": len(stubs),
+        "scan_truncated": bool(next_token),
+        "resultSizeEstimate": result_size_estimate,
+    }
+
+
 def triage_inbox_impl(
     gmail,
     *,
@@ -991,11 +1064,18 @@ def triage_inbox_impl(
     Returns a summary listing per-message classifications + a bucketed
     view via ``group_by_category``. Also passes through the listing call's
     raw ``resultSizeEstimate`` (whatever the backend reports — a real
-    mailbox estimate for Gmail, ``None`` for Outlook, #2584) so a caller
+    mailbox estimate for Gmail, ``None`` for Outlook, #2584) and an honest
+    ``scan_truncated`` (#2634 — True only when the backend's own paging
+    cursor says more mail exists beyond what was collected) so a caller
     like ``pre_scan_inbox_impl`` can report scan coverage without a second
     round-trip. ``label_ids`` defaults to ``["INBOX"]`` (this tool's
     existing behavior); a caller wanting a narrower query (e.g. unread-only
     for coverage honesty) can override it.
+
+    The listing itself pages via ``_list_all_stubs`` (#2634) until
+    ``max_messages`` is collected or the mailbox is exhausted — previously
+    this issued a single ``list_messages`` call and silently capped
+    coverage at one provider page regardless of what was requested.
     """
     # Local import breaks a real import cycle: calendar_tools imports
     # DEFAULT_BODY_LIMIT_CHARS from this module at module scope, so importing
@@ -1006,12 +1086,12 @@ def triage_inbox_impl(
     with log_tool_call(
         "triage_inbox", {"max_messages": max_messages}, debug=debug
     ) as st:
-        listing = gmail.list_messages(
-            label_ids=list(label_ids) if label_ids else ["INBOX"],
-            max_results=max_messages,
+        listing = _list_all_stubs(
+            gmail, label_ids=label_ids, max_messages=max_messages
         )
+        stubs = listing["stubs"]
         results: List[Dict[str, Any]] = []
-        for stub in listing.get("messages", []):
+        for stub in stubs:
             msg = gmail.get_message(stub["id"])
             payload_headers = {
                 (h.get("name") or "").lower(): h.get("value", "")
@@ -1114,7 +1194,7 @@ def triage_inbox_impl(
                 try:
                     progress(
                         len(results),
-                        len(listing.get("messages", [])),
+                        len(stubs),
                         payload_headers.get("subject", "") or "(no subject)",
                     )
                 except Exception as exc:  # noqa: BLE001
@@ -1128,7 +1208,8 @@ def triage_inbox_impl(
         return {
             "results": results,
             "grouped": grouped,
-            "resultSizeEstimate": listing.get("resultSizeEstimate"),
+            "resultSizeEstimate": listing["resultSizeEstimate"],
+            "scan_truncated": listing["scan_truncated"],
         }
 
 

--- a/hub/agents/email/python/tests/test_attention_tools.py
+++ b/hub/agents/email/python/tests/test_attention_tools.py
@@ -234,8 +234,27 @@ class TestCoverageHonesty:
         assert out["coverage"]["degraded"] is False
         assert out["coverage"].get("mailbox_errors") is None
 
-    def test_scan_truncated_when_ceiling_hit(self):
+    def test_scan_truncated_false_when_ceiling_exactly_matches_mailbox_size(self):
+        """Regression guard (#2634): hitting the ceiling is NOT the same as
+        mail remaining unseen. This mailbox has exactly 1 message and the
+        ceiling is 1 -- nothing was missed, so scan_truncated must be False.
+        The pre-fix formula (``len(results) >= max_messages``) said True
+        here for the wrong reason; FakeGmailBackend never signals a real
+        next page, so this is also the only honest answer it can give.
+        """
         gmail = _backend(_PLAIN_UNCONFIDENT)
+        out = build_attention_view_impl({"google": gmail}, max_messages=1)
+        assert out["coverage"]["scan_truncated"] is False
+
+    def test_scan_truncated_true_when_backend_signals_more_pages(self):
+        """FakeGmailBackend itself never pages (#2634's R1c keeps the
+        shared fixture single-page-only), so this minimal test-local
+        override reports a truthy ``nextPageToken`` on its first call to
+        prove ``build_attention_view_impl`` surfaces a genuine "more mail
+        exists" signal end to end, not just "did we hit the ceiling".
+        """
+        gmail = _MorePagesGmailBackend(user_email=USER_EMAIL)
+        gmail.add_message(_PLAIN_UNCONFIDENT)
         out = build_attention_view_impl({"google": gmail}, max_messages=1)
         assert out["coverage"]["scan_truncated"] is True
 
@@ -251,6 +270,30 @@ class TestCoverageHonesty:
 class _RaisingGmailBackend(FakeGmailBackend):
     def list_messages(self, **kwargs):
         raise ConnectorsError("token expired")
+
+
+class _MorePagesGmailBackend(FakeGmailBackend):
+    """Reports a truthy ``nextPageToken`` on its first ``list_messages``
+    call only (#2634). ``FakeGmailBackend`` itself always returns
+    ``nextPageToken: None`` -- it is shared by ~13 test files and is
+    deliberately NOT taught real pagination here. Returning the token only
+    once (regardless of what ``page_token`` a caller passes back) means a
+    caller that never needs a second page never triggers one; a caller
+    that DOES ask again gets an honestly-exhausted response instead of the
+    same page forever.
+    """
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+        self._paged_once = False
+
+    def list_messages(self, **kwargs: Any) -> Dict[str, Any]:
+        out = super().list_messages(**kwargs)
+        if not self._paged_once and out["messages"]:
+            out = dict(out)
+            out["nextPageToken"] = "more"
+            self._paged_once = True
+        return out
 
 
 class TestPartialAndTotalMailboxFailure:

--- a/hub/agents/email/python/tests/test_rest_spam_verdict.py
+++ b/hub/agents/email/python/tests/test_rest_spam_verdict.py
@@ -132,8 +132,8 @@ def test_heuristic_confident_spam_verdict_wins():
 
 def _fake_gmail(message):
     class _FakeGmail:
-        def list_messages(self, label_ids=None, max_results=25):
-            return {"messages": [{"id": message["id"]}]}
+        def list_messages(self, label_ids=None, max_results=25, page_token=None):
+            return {"messages": [{"id": message["id"]}], "nextPageToken": None}
 
         def get_message(self, message_id):
             return message

--- a/tests/unit/agents/email/test_triage_pagination_2634.py
+++ b/tests/unit/agents/email/test_triage_pagination_2634.py
@@ -209,9 +209,7 @@ class TestDedupAcrossPages:
             def __init__(self) -> None:
                 self.calls = 0
 
-            def list_messages(
-                self, *, label_ids=None, max_results=25, page_token=None
-            ):
+            def list_messages(self, *, label_ids=None, max_results=25, page_token=None):
                 self.calls += 1
                 if self.calls == 1:
                     return {
@@ -246,9 +244,7 @@ class TestClientSideClamp:
             def __init__(self) -> None:
                 self.calls: List[int] = []
 
-            def list_messages(
-                self, *, label_ids=None, max_results=25, page_token=None
-            ):
+            def list_messages(self, *, label_ids=None, max_results=25, page_token=None):
                 self.calls.append(max_results)
                 # Always returns 30, regardless of what max_results asked
                 # for -- mirrors Outlook's $top-baked-into-page-1 behavior
@@ -277,7 +273,7 @@ class TestClientSideClamp:
 
 class TestOutlookVerbatimContinuation:
     def test_second_call_hits_the_literal_nextlink_from_page_one(self):
-        """"Params are not re-derived" is intent, not a test on its own --
+        """ "Params are not re-derived" is intent, not a test on its own --
         a test could pass on "a second page was fetched" while still
         reconstructing (and corrupting) the query. Assert the literal URL.
         """

--- a/tests/unit/agents/email/test_triage_pagination_2634.py
+++ b/tests/unit/agents/email/test_triage_pagination_2634.py
@@ -1,0 +1,394 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""
+Acceptance tests for the triage-scan pagination fix (#2634).
+
+Bug: ``triage_inbox_impl`` issued exactly one ``list_messages`` call and
+never followed ``nextPageToken``, so raising ``max_messages`` above one
+provider page never widened scan coverage -- ask for 500 and get 100.
+Worse, ``scan_truncated`` (``attention_tools.py``) was computed as
+``len(results) >= max_messages``, which reports "not truncated" the
+instant a request exceeds one page of real mail -- exactly the moment the
+scan is MORE incomplete, not less.
+
+These tests exercise ``_list_all_stubs`` (the extracted pagination loop,
+``read_tools.py``) directly against the issue's own ``PagingFake`` --
+zero classification mocking needed, per the plan's A2 -- plus an Outlook
+verbatim-nextLink check via ``LiveOutlookBackend`` and a fail-loud check
+for a mid-pagination backend error.
+
+Per the plan's adversarial reflection (R1c): the shared ``FakeGmailBackend``
+fixture (used by ~13 test files) is deliberately NOT taught pagination
+here. ``PagingFake`` and small test-local doubles cover every acceptance
+criterion instead.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+import httpx
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[4]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+pytest.importorskip("gaia_agent_email")  # noqa: E402
+from gaia_agent_email.outlook_backend import LiveOutlookBackend  # noqa: E402
+from gaia_agent_email.tools.read_tools import (  # noqa: E402
+    _list_all_stubs,
+    triage_inbox_impl,
+)
+
+from gaia.connectors.errors import ConnectorsError  # noqa: E402
+
+# ---------------------------------------------------------------------------
+# PagingFake -- verbatim from the issue body (#2634), mirroring Gmail: it
+# honours maxResults up to its own page ceiling, then pages. Extended only
+# with a ``calls`` log so tests can assert how many list_messages
+# round-trips happened, matching the issue's own "Assertions" checklist.
+# ---------------------------------------------------------------------------
+
+
+class PagingFake:
+    """Mirrors Gmail: honours maxResults up to a page ceiling, then pages."""
+
+    PAGE = 100
+
+    def __init__(self, total: int = 250) -> None:
+        self.ids = [f"m{i:03d}" for i in range(total)]
+        self.calls: List[Dict[str, Any]] = []
+
+    def list_messages(
+        self,
+        *,
+        label_ids: Optional[List[str]] = None,
+        max_results: int = 25,
+        page_token: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        self.calls.append(
+            {
+                "label_ids": label_ids,
+                "max_results": max_results,
+                "page_token": page_token,
+            }
+        )
+        start = int(page_token or 0)
+        end = min(start + min(max_results, self.PAGE), len(self.ids))
+        return {
+            "messages": [{"id": i, "threadId": i} for i in self.ids[start:end]],
+            "nextPageToken": str(end) if end < len(self.ids) else None,
+            "resultSizeEstimate": len(self.ids),
+        }
+
+
+class _RaisingAfterNCallsFake(PagingFake):
+    """Like ``PagingFake`` but raises ``ConnectorsError`` once the call
+    count reaches ``fail_on_call`` -- proves a mid-pagination backend
+    failure propagates instead of returning a silent partial result.
+    """
+
+    def __init__(self, total: int = 250, *, fail_on_call: int = 2) -> None:
+        super().__init__(total)
+        self._fail_on_call = fail_on_call
+
+    def list_messages(self, **kwargs: Any) -> Dict[str, Any]:
+        if len(self.calls) + 1 >= self._fail_on_call:
+            self.calls.append({"failed": True, **kwargs})
+            raise ConnectorsError("simulated mid-pagination backend failure")
+        return super().list_messages(**kwargs)
+
+
+# ---------------------------------------------------------------------------
+# The truth table: the issue's own three rows, plus the adversarial
+# reflection's fourth row (C1) -- the only one that falsifies a fix which
+# still derives scan_truncated from len(results) >= max_messages.
+# ---------------------------------------------------------------------------
+
+
+class TestTruthTable:
+    def test_request_200_of_250_scanned_200_truncated_true(self):
+        fake = PagingFake(total=250)
+        out = _list_all_stubs(fake, label_ids=["INBOX"], max_messages=200)
+        assert out["scanned"] == 200
+        assert out["scan_truncated"] is True
+
+    def test_request_500_of_250_scanned_250_truncated_false(self):
+        """The issue's own regression guard: today's formula reports False
+        here for the WRONG reason (100 >= 500 is False by arithmetic
+        coincidence on a single unpaginated page, not because the mailbox
+        was ever confirmed exhausted)."""
+        fake = PagingFake(total=250)
+        out = _list_all_stubs(fake, label_ids=["INBOX"], max_messages=500)
+        assert out["scanned"] == 250
+        assert out["scan_truncated"] is False
+
+    def test_request_50_of_250_scanned_50_truncated_true(self):
+        fake = PagingFake(total=250)
+        out = _list_all_stubs(fake, label_ids=["INBOX"], max_messages=50)
+        assert out["scanned"] == 50
+        assert out["scan_truncated"] is True
+
+    def test_request_200_of_exactly_200_scanned_200_truncated_false(self):
+        """THE regression-guard row (adversarial reflection C1). Two full
+        100-message pages exhaust a 200-message mailbox exactly at the
+        ceiling. The naive ``len(results) >= max_messages`` formula
+        returns True here (200 >= 200) -- wrong, since nothing was
+        missed: the second page's own ``nextPageToken`` is None. Only a
+        formula driven by the last page's own cursor gets this right.
+        Every other row in this table passes under BOTH formulas -- this
+        is the only one that falsifies a fix that paginates correctly but
+        leaves the length-only truncation check in place.
+        """
+        fake = PagingFake(total=200)
+        out = _list_all_stubs(fake, label_ids=["INBOX"], max_messages=200)
+        assert out["scanned"] == 200
+        assert out["scan_truncated"] is False, (
+            "scan_truncated must be False when the mailbox is exhausted "
+            "exactly at max_messages -- got True, which means the "
+            "signal is still driven by len(results) >= max_messages "
+            "instead of the backend's own paging cursor"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Pagination actually happens (and stops issuing calls once it should)
+# ---------------------------------------------------------------------------
+
+
+class TestPaginationHappens:
+    def test_at_least_two_list_messages_calls_for_200_of_250(self):
+        fake = PagingFake(total=250)
+        _list_all_stubs(fake, label_ids=["INBOX"], max_messages=200)
+        assert len(fake.calls) >= 2, (
+            f"expected >=2 list_messages calls to collect 200 of 250 "
+            f"messages at 100/page; got {len(fake.calls)}"
+        )
+
+    def test_single_call_when_mailbox_fits_in_one_page(self):
+        """A mailbox smaller than both max_messages and the page ceiling
+        must not trigger a second call -- the single-page path stays
+        exactly as cheap as before."""
+        fake = PagingFake(total=30)
+        out = _list_all_stubs(fake, label_ids=["INBOX"], max_messages=100)
+        assert len(fake.calls) == 1
+        assert out["scanned"] == 30
+        assert out["scan_truncated"] is False
+
+    def test_requested_max_results_shrinks_never_a_fixed_page_size(self):
+        """Each call requests exactly how many messages are still wanted,
+        never a fixed page-size constant -- a fixed constant would also
+        regress test_pre_scan_budget_reclaim.py's literal
+        max_results_seen == 20 assertion (#2634 C3)."""
+        fake = PagingFake(total=250)
+        _list_all_stubs(fake, label_ids=["INBOX"], max_messages=150)
+        requested = [c["max_results"] for c in fake.calls]
+        assert requested == [150, 50], (
+            f"expected each call to request the REMAINING budget (150, "
+            f"then 50 after the first page's 100 messages), not a fixed "
+            f"page-size constant; got {requested}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Dedup across pages (#2634 C2)
+# ---------------------------------------------------------------------------
+
+
+class TestDedupAcrossPages:
+    def test_message_reappearing_on_a_later_page_is_counted_once(self):
+        """A mailbox has no snapshot isolation -- the same id can
+        legitimately reappear on two pages if the mailbox mutates
+        mid-scan. A naive concat-across-pages loop would classify and
+        count it twice."""
+
+        class _OverlappingPagesFake:
+            def __init__(self) -> None:
+                self.calls = 0
+
+            def list_messages(
+                self, *, label_ids=None, max_results=25, page_token=None
+            ):
+                self.calls += 1
+                if self.calls == 1:
+                    return {
+                        "messages": [{"id": "m1"}, {"id": "m2"}],
+                        "nextPageToken": "p2",
+                        "resultSizeEstimate": 3,
+                    }
+                # Page 2 re-returns m2 (mid-scan mutation) plus one
+                # genuinely new id.
+                return {
+                    "messages": [{"id": "m2"}, {"id": "m3"}],
+                    "nextPageToken": None,
+                    "resultSizeEstimate": 3,
+                }
+
+        fake = _OverlappingPagesFake()
+        out = _list_all_stubs(fake, label_ids=["INBOX"], max_messages=10)
+        ids = [s["id"] for s in out["stubs"]]
+        assert ids == ["m1", "m2", "m3"], f"expected unique ids in order, got {ids}"
+        assert out["scanned"] == 3
+
+
+# ---------------------------------------------------------------------------
+# Client-side clamp -- never trust the backend to honour the request
+# (#2634 C3, Outlook's continuation ignores max_results entirely)
+# ---------------------------------------------------------------------------
+
+
+class TestClientSideClamp:
+    def test_overlarge_page_is_clamped_to_max_messages(self):
+        class _IgnoresMaxResultsFake:
+            def __init__(self) -> None:
+                self.calls: List[int] = []
+
+            def list_messages(
+                self, *, label_ids=None, max_results=25, page_token=None
+            ):
+                self.calls.append(max_results)
+                # Always returns 30, regardless of what max_results asked
+                # for -- mirrors Outlook's $top-baked-into-page-1 behavior
+                # on the continuation link.
+                return {
+                    "messages": [{"id": f"m{i}"} for i in range(30)],
+                    "nextPageToken": None,
+                    "resultSizeEstimate": 30,
+                }
+
+        fake = _IgnoresMaxResultsFake()
+        out = _list_all_stubs(fake, label_ids=["INBOX"], max_messages=10)
+        assert len(out["stubs"]) == 10, (
+            f"expected the accumulator clamped to max_messages=10 even "
+            f"though the backend returned 30; got {len(out['stubs'])}"
+        )
+        assert out["scanned"] == 10
+        assert fake.calls == [10]
+
+
+# ---------------------------------------------------------------------------
+# Outlook: the continuation token is an absolute @odata.nextLink URL and
+# must be followed verbatim, never re-derived (#2634 C5)
+# ---------------------------------------------------------------------------
+
+
+class TestOutlookVerbatimContinuation:
+    def test_second_call_hits_the_literal_nextlink_from_page_one(self):
+        """"Params are not re-derived" is intent, not a test on its own --
+        a test could pass on "a second page was fetched" while still
+        reconstructing (and corrupting) the query. Assert the literal URL.
+        """
+        next_link = (
+            "https://graph.microsoft.com/v1.0/me/mailFolders/inbox/messages"
+            "?$skiptoken=abcDEF123"
+        )
+
+        requests_seen: List[httpx.Request] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            requests_seen.append(request)
+            if str(request.url) == next_link:
+                return httpx.Response(
+                    200, json={"value": [{"id": "m2", "conversationId": "c2"}]}
+                )
+            return httpx.Response(
+                200,
+                json={
+                    "value": [{"id": "m1", "conversationId": "c1"}],
+                    "@odata.nextLink": next_link,
+                },
+            )
+
+        transport = httpx.MockTransport(handler)
+        client = httpx.Client(transport=transport)
+        backend = LiveOutlookBackend(lambda: "GRAPH-TOKEN-1", http_client=client)
+
+        out = _list_all_stubs(backend, label_ids=["INBOX"], max_messages=5)
+
+        assert out["scanned"] == 2
+        assert [s["id"] for s in out["stubs"]] == ["m1", "m2"]
+        assert len(requests_seen) == 2
+        assert str(requests_seen[1].url) == next_link, (
+            "the second request must hit the literal nextLink URL "
+            f"returned by page 1, not a re-derived query; got "
+            f"{requests_seen[1].url!r}"
+        )
+        assert out["scan_truncated"] is False  # page 2 carries no further link
+
+
+# ---------------------------------------------------------------------------
+# Fail-loud: a mid-pagination backend error must never yield a partial
+# result (#2634 A1)
+# ---------------------------------------------------------------------------
+
+
+class TestMidPaginationFailureIsNeverSilent:
+    def test_failure_on_second_page_propagates_not_a_partial_result(self):
+        fake = _RaisingAfterNCallsFake(total=250, fail_on_call=2)
+        with pytest.raises(ConnectorsError):
+            _list_all_stubs(fake, label_ids=["INBOX"], max_messages=200)
+        # Page 1 succeeded (100 messages); page 2 raised. Nothing about
+        # that partial success is returned to the caller.
+        assert len(fake.calls) == 2
+
+    def test_failure_on_second_page_means_zero_classification_calls(self):
+        """triage_inbox_impl collects every stub across every page BEFORE
+        classifying any of them, so a page-2 failure means get_message is
+        never called at all -- not even for page 1's messages."""
+
+        class _GetMessageRecorder(_RaisingAfterNCallsFake):
+            def __init__(self, *args: Any, **kwargs: Any) -> None:
+                super().__init__(*args, **kwargs)
+                self.get_message_calls: List[str] = []
+
+            def get_message(self, message_id: str) -> Dict[str, Any]:
+                self.get_message_calls.append(message_id)
+                raise AssertionError(
+                    "get_message must never be called when pagination "
+                    "itself fails before classification starts"
+                )
+
+        fake = _GetMessageRecorder(total=250, fail_on_call=2)
+        with pytest.raises(ConnectorsError):
+            triage_inbox_impl(fake, max_messages=200)
+        assert fake.get_message_calls == []
+
+
+# ---------------------------------------------------------------------------
+# Wiring check: triage_inbox_impl (not just the extracted helper) actually
+# uses the paginated listing end to end.
+# ---------------------------------------------------------------------------
+
+
+class _PagingGmailWithBodies(PagingFake):
+    """``PagingFake`` plus a minimal ``get_message`` so the full
+    ``triage_inbox_impl`` classify loop can run against it -- proves the
+    extracted ``_list_all_stubs`` helper is actually wired into the tool,
+    not just correct in isolation."""
+
+    def get_message(self, message_id: str) -> Dict[str, Any]:
+        return {
+            "id": message_id,
+            "threadId": message_id,
+            "labelIds": ["INBOX"],
+            "snippet": "",
+            "payload": {
+                "headers": [
+                    {"name": "Subject", "value": f"Subject {message_id}"},
+                    {"name": "From", "value": "sender@example.com"},
+                ],
+                "body": {},
+            },
+        }
+
+
+class TestTriageInboxImplWiring:
+    def test_triage_inbox_impl_scans_past_one_page(self):
+        fake = _PagingGmailWithBodies(total=250)
+        out = triage_inbox_impl(fake, max_messages=200)
+        assert len(out["results"]) == 200
+        assert out["scan_truncated"] is True
+        assert len(fake.calls) >= 2

--- a/tests/unit/agents/test_email_llm_triage.py
+++ b/tests/unit/agents/test_email_llm_triage.py
@@ -255,8 +255,8 @@ class TestTriageInboxImplWiring:
         (e.g. an auto-generated anonymous sender) needs no LLM call at all."""
 
         class _SingleMessageGmail:
-            def list_messages(self, label_ids=None, max_results=25):
-                return {"messages": [{"id": "spam-1"}]}
+            def list_messages(self, label_ids=None, max_results=25, page_token=None):
+                return {"messages": [{"id": "spam-1"}], "nextPageToken": None}
 
             def get_message(self, msg_id):
                 return {


### PR DESCRIPTION
Closes #2634

Asking the inbox scan to look at more mail didn't work. The number was passed faithfully all the way down and then the scan read a single provider page and stopped — ask for 500, get 100. The worse half was the "I didn't see everything" warning: it was computed as `len(results) >= max_messages`, so *raising* the limit switched the warning off at exactly the moment the scan was more incomplete than before. Anything trusting that flag to qualify an "inbox is clear" claim was being quietly misled — the defect class #2584 was filed to end.

The scan now follows the provider's paging cursor until it has what was asked for or the mailbox is exhausted, and the truncation flag is derived from that cursor — a statement about whether mail actually remains unseen, not arithmetic on the request.

## Test plan

- [x] Gated command (`tests/unit/agents/email/ -k 'prescan or pre_scan or attention or pagination or truncat'`) — **81 passed**, up from 68
- [x] Broader sweep across both email test trees — **2242 passed, 0 failed**
- [x] `python util/lint.py --all` — every hard gate passes (mypy warn-only, pre-existing)
- [x] Red-for-the-right-reason: reverting the two source files and calling the real pre-fix API gives `triage_inbox_impl(250 msgs, max_messages=200)` → **100 results from 1 listing call**, and `build_attention_view_impl(1 msg, max_messages=1)` → **`scan_truncated=True` when nothing was missed**
- [x] The four-row truth table, against a fake that pages the way Gmail does (100/page):

| request | scanned | `scan_truncated` | why |
|---|---|---|---|
| 200 of 250 | 200 | True | 50 remain |
| 500 of 250 | 250 | False | mailbox exhausted |
| 50 of 250 | 50 | True | under the ceiling, more remain |
| **200 of exactly 200** | 200 | **False** | **nothing missed** |

The last row is the one that matters. Under the old formula it reports `True` (`200 >= 200`) while nothing was actually missed — so it is the only row that distinguishes a real fix from a length-check that happens to agree on the other three.

<details>
<summary>Loop details and scope</summary>

- The paging cursor is passed back **verbatim**. For Outlook it *is* the `@odata.nextLink` absolute URL, so re-deriving parameters would silently restart at page 1.
- **Message ids are de-duplicated across pages.** A mailbox has no snapshot isolation, so the same id can legitimately reappear on two pages if mail arrives mid-scan — without this, it would be fetched and classified twice and inflate the scanned count.
- **The accumulator is clamped after every page**, because a page cannot be trusted to honour `max_results` — Outlook's continuation ignores it entirely. Each call also asks for however many are still wanted rather than a fixed page size.
- **A page-2+ failure propagates.** No try/except is added around the listing call, so a mid-pagination provider error surfaces rather than returning a quiet partial result, consistent with the fail-loud rule. There is a test locking that in as intentional.

**Deliberately not in scope:** #2638 (read-mail coverage) is sequenced after #2643, because dropping `UNREAD` rebinds the per-message body fetch from "bounded by unread count" to "always the scan ceiling" — roughly 10× more fetches for a tidy inbox until the metadata-first fetch lands. No contract/OpenAPI/spec change: the flag being fixed already exists on the attention envelope. The shared `FakeGmailBackend` was left single-page-only; pagination is exercised by a self-contained fake instead.

**One existing test's expectation was inverted, deliberately.** `test_scan_truncated_when_ceiling_hit` used a 1-message mailbox at a ceiling of 1 and asserted `True` — which was only ever true *because of the bug*. It is now `test_scan_truncated_false_when_ceiling_exactly_matches_mailbox_size`, and a new test covers the `True` path for the right reason, via a minimal local backend that signals a real next page. The `True` case is not lost; it is tested honestly.

Two ad-hoc test doubles also gained the `page_token` parameter the real backend Protocol has always declared. Those are two-line signature completions — no assertion in either file was touched.
</details>
