### PR TITLE
fix(tui): dedup attention rows and stop the card interrupting turns

### DIFF
--- a/tui/internal/ui/cards/attention.go
+++ b/tui/internal/ui/cards/attention.go
@@ -69,16 +69,32 @@ func isAttentionEnvelope(data json.RawMessage) bool {
 // outer width. Exported (unlike the /query card renderers) because it is
 // invoked directly by the chat model on open, not through Render()'s
 // tool_result dispatch.
-func RenderEmailAttention(data json.RawMessage, width int) string {
+//
+// seen is the set of message_ids a card rendered earlier in the same turn
+// already showed (pass nil, or use Render, for a standalone render with no
+// dedup). An item whose id is already in seen is skipped; every non-empty id
+// this call renders is returned so a later card can be threaded against it
+// too. An item with no message_id is never treated as a duplicate.
+func RenderEmailAttention(data json.RawMessage, width int, seen map[string]bool) (string, []string) {
 	var a emailAttention
 	if err := json.Unmarshal(data, &a); err != nil {
-		return renderInvalid("email_attention", err.Error(), data, width)
+		return renderInvalid("email_attention", err.Error(), data, width), nil
 	}
 	if k := strings.TrimSpace(a.Kind); k != "" && k != "email_attention" {
-		return renderInvalid("email_attention", "kind is "+k+", expected email_attention", data, width)
+		return renderInvalid("email_attention", "kind is "+k+", expected email_attention", data, width), nil
 	}
 	if !isAttentionEnvelope(data) {
-		return renderInvalid("email_attention", "payload carries no attention-view fields", data, width)
+		return renderInvalid("email_attention", "payload carries no attention-view fields", data, width), nil
+	}
+
+	hadItems := len(a.Items) > 0
+	var ids []string
+	a.Items, ids = dedupByMessageID(a.Items, func(it attentionItem) string { return it.MessageID }, seen)
+	if hadItems && len(a.Items) == 0 {
+		// Every item was already shown by an earlier card this turn -- this
+		// card would add nothing, so (unlike a genuinely empty scan) it does
+		// not render at all rather than claiming "Nothing needs you".
+		return "", nil
 	}
 
 	b := newBox(a.title(), width)
@@ -88,7 +104,7 @@ func RenderEmailAttention(data json.RawMessage, width int) string {
 
 	if len(a.Items) == 0 {
 		a.renderEmpty(b)
-		return b.render()
+		return b.render(), ids
 	}
 
 	sections := []struct {
@@ -128,7 +144,7 @@ func RenderEmailAttention(data json.RawMessage, width int) string {
 		b.blank()
 		b.addWrapped("  ", footer)
 	}
-	return b.render()
+	return b.render(), ids
 }
 
 // title must be identifiable on its own — the pre-scan card can appear in the same transcript.

--- a/tui/internal/ui/cards/attention.go
+++ b/tui/internal/ui/cards/attention.go
@@ -116,8 +116,7 @@ func RenderEmailAttention(data json.RawMessage, width int) string {
 	}
 	// An item whose kind the server introduced after this client was built
 	// still gets shown — under a generic header — rather than silently
-	// dropped from the card. It inherits the running counter too: it is a
-	// fifth section, not a reset back to row 1 (#2631).
+	// dropped from the card. It inherits the running counter, not a reset.
 	if other := a.itemsOfUnknownKind(sections); len(other) > 0 {
 		if shownAny {
 			b.blank()
@@ -132,11 +131,7 @@ func RenderEmailAttention(data json.RawMessage, width int) string {
 	return b.render()
 }
 
-// title names both what this card is and what it actually looked at. Plain
-// "Attention · N scanned" is a tautology that reads as generic status noise
-// next to the pre-scan card's own "Inbox · N scanned" — when both cards can
-// appear in the same transcript, each has to be identifiable on its own
-// (#2631).
+// title must be identifiable on its own — the pre-scan card can appear in the same transcript.
 func (a emailAttention) title() string {
 	return fmt.Sprintf("Needs you · %d inbox messages scanned", a.Coverage.Scanned)
 }
@@ -219,11 +214,7 @@ func (a emailAttention) renderEmpty(b *box) {
 // the closing footer so a populated card cannot be read as "this is
 // everything" either.
 //
-// Scanned counts every inbox message the scan looked at, read and unread
-// alike — it is never itself an unread count, so "unread" must always
-// modify TotalUnread specifically, never appear as if it qualified Scanned
-// (the #2635 defect read "N of M unread scanned", overstating unread
-// coverage by conflating the two).
+// "unread" must modify TotalUnread only — Scanned counts read mail too.
 func (a emailAttention) coverageLine() string {
 	c := a.Coverage
 	line := itoa(c.Scanned) + " inbox messages scanned"
@@ -242,12 +233,7 @@ func (a emailAttention) coverageFooterLine() string {
 	return a.coverageLine() + "."
 }
 
-// section draws one bucket and returns the running row number, threading a
-// counter across every call the way emailprescan.go's section() already
-// does — so a message's row number is unique and increasing across the
-// WHOLE card, not just within its own section (#2631; row numbers restarting
-// per section made "archive number 2" ambiguous when two sections each had
-// their own row 2).
+// section draws one bucket and returns the running row number — numbers must stay unique across the whole card, not just within one section.
 func (a emailAttention) section(b *box, label string, items []attentionItem, start int) int {
 	show := len(items)
 	if show > maxAttentionSectionRows {

--- a/tui/internal/ui/cards/attention.go
+++ b/tui/internal/ui/cards/attention.go
@@ -102,6 +102,7 @@ func RenderEmailAttention(data json.RawMessage, width int) string {
 	}
 
 	shownAny := false
+	row := 0
 	for _, sec := range sections {
 		items := a.itemsOfKind(sec.kind)
 		if len(items) == 0 {
@@ -110,17 +111,18 @@ func RenderEmailAttention(data json.RawMessage, width int) string {
 		if shownAny {
 			b.blank()
 		}
-		a.section(b, sec.label, items)
+		row = a.section(b, sec.label, items, row)
 		shownAny = true
 	}
 	// An item whose kind the server introduced after this client was built
 	// still gets shown — under a generic header — rather than silently
-	// dropped from the card.
+	// dropped from the card. It inherits the running counter too: it is a
+	// fifth section, not a reset back to row 1 (#2631).
 	if other := a.itemsOfUnknownKind(sections); len(other) > 0 {
 		if shownAny {
 			b.blank()
 		}
-		a.section(b, "OTHER", other)
+		row = a.section(b, "OTHER", other, row)
 	}
 
 	if footer := a.coverageFooterLine(); footer != "" {
@@ -130,8 +132,13 @@ func RenderEmailAttention(data json.RawMessage, width int) string {
 	return b.render()
 }
 
+// title names both what this card is and what it actually looked at. Plain
+// "Attention · N scanned" is a tautology that reads as generic status noise
+// next to the pre-scan card's own "Inbox · N scanned" — when both cards can
+// appear in the same transcript, each has to be identifiable on its own
+// (#2631).
 func (a emailAttention) title() string {
-	return fmt.Sprintf("Attention · %d scanned", a.Coverage.Scanned)
+	return fmt.Sprintf("Needs you · %d inbox messages scanned", a.Coverage.Scanned)
 }
 
 func (a emailAttention) itemsOfKind(kind string) []attentionItem {
@@ -211,11 +218,17 @@ func (a emailAttention) renderEmpty(b *box) {
 // looked at — used both by the empty state and, when items ARE present, as
 // the closing footer so a populated card cannot be read as "this is
 // everything" either.
+//
+// Scanned counts every inbox message the scan looked at, read and unread
+// alike — it is never itself an unread count, so "unread" must always
+// modify TotalUnread specifically, never appear as if it qualified Scanned
+// (the #2635 defect read "N of M unread scanned", overstating unread
+// coverage by conflating the two).
 func (a emailAttention) coverageLine() string {
 	c := a.Coverage
-	line := itoa(c.Scanned) + " scanned"
+	line := itoa(c.Scanned) + " inbox messages scanned"
 	if c.TotalUnread != nil {
-		line = itoa(c.Scanned) + " of " + itoa(*c.TotalUnread) + " unread scanned"
+		line += " · " + itoa(*c.TotalUnread) + " unread"
 	}
 	if c.ScanTruncated {
 		line += " (of the " + itoa(c.Scanned) + " most recent — older mail may exist)"
@@ -229,7 +242,13 @@ func (a emailAttention) coverageFooterLine() string {
 	return a.coverageLine() + "."
 }
 
-func (a emailAttention) section(b *box, label string, items []attentionItem) {
+// section draws one bucket and returns the running row number, threading a
+// counter across every call the way emailprescan.go's section() already
+// does — so a message's row number is unique and increasing across the
+// WHOLE card, not just within its own section (#2631; row numbers restarting
+// per section made "archive number 2" ambiguous when two sections each had
+// their own row 2).
+func (a emailAttention) section(b *box, label string, items []attentionItem, start int) int {
 	show := len(items)
 	if show > maxAttentionSectionRows {
 		show = maxAttentionSectionRows
@@ -240,7 +259,9 @@ func (a emailAttention) section(b *box, label string, items []attentionItem) {
 	}
 	b.sectionHeader(label, count)
 
-	for n, it := range items[:show] {
+	n := start
+	for _, it := range items[:show] {
+		n++
 		sender := displaySender(it.Sender)
 		if it.Kind == "action_item" && strings.TrimSpace(it.Sender) == "" {
 			sender = "(action item)"
@@ -248,7 +269,7 @@ func (a emailAttention) section(b *box, label string, items []attentionItem) {
 		if it.Mailbox != "" {
 			sender = mailboxLabel(it.Mailbox) + " · " + sender
 		}
-		b.row(n+1, sender, it.Subject)
+		b.row(n, sender, it.Subject)
 		detail := it.Why
 		if it.DueHint != "" {
 			detail = strings.TrimSuffix(detail, ".") + " — due " + it.DueHint
@@ -260,4 +281,5 @@ func (a emailAttention) section(b *box, label string, items []attentionItem) {
 	if extra := len(items) - show; extra > 0 {
 		b.add(rationaleIndent + "+" + itoa(extra) + " more")
 	}
+	return n
 }

--- a/tui/internal/ui/cards/attention_test.go
+++ b/tui/internal/ui/cards/attention_test.go
@@ -2,6 +2,8 @@ package cards
 
 import (
 	"os"
+	"reflect"
+	"regexp"
 	"strings"
 	"testing"
 )
@@ -66,7 +68,7 @@ func TestAttentionPopulated(t *testing.T) {
 
 	assertWidth(t, out, width80)
 	assertContains(t, out,
-		"Attention · 42 scanned",
+		"Needs you · 42 inbox messages scanned",
 		"MEETING PROPOSALS", "WAITING ON YOU", "NEEDS REVIEW", "ACTION ITEMS",
 		"Sarah Chen", "Team sync",
 		"looks like it's proposing a meeting or a time to talk",
@@ -74,9 +76,22 @@ func TestAttentionPopulated(t *testing.T) {
 		"Send the Q3 report",
 		"due Friday",
 		// Coverage footer under a populated card -- never presented as
-		// whole-mailbox complete.
-		"42 of 100 unread scanned",
+		// whole-mailbox complete. The unit is named (#2635): "42" is how many
+		// messages were scanned, "100" is a separately-labelled unread count.
+		"42 inbox messages scanned",
+		"100 unread",
 	)
+}
+
+func TestAttentionTitleStatesItsPurpose(t *testing.T) {
+	// The bare "Attention · N scanned" title is a tautology: it already
+	// contains a number and the word "scanned" before any fix, so a loose
+	// substring check would pass even without the rename actually happening
+	// (#2631 reflection C7). Assert the full new string, and that the old
+	// prefix is gone.
+	out := Render("email_attention", raw(t, populatedAttention), width80)
+	assertContains(t, out, "Needs you · 42 inbox messages scanned")
+	assertNotContains(t, out, "Attention ·")
 }
 
 func TestAttentionEmptyStateIsHonest(t *testing.T) {
@@ -88,7 +103,10 @@ func TestAttentionEmptyStateIsHonest(t *testing.T) {
 		"Nothing needs you.",
 		// Must state what was covered, including the truncation admission --
 		// never an unqualified whole-mailbox claim (#2584 lesson, one layer up).
-		"200 of 512 unread scanned",
+		// The unit is named (#2635): "200" is how many were scanned, "512" is
+		// a separately-labelled unread count -- not "200 of 512 unread".
+		"200 inbox messages scanned",
+		"512 unread",
 		"of the 200 most recent",
 		"older mail may",
 	)
@@ -171,6 +189,123 @@ func TestAttentionCapsSectionAtMaxRows(t *testing.T) {
 	out := Render("email_attention", raw(t, payload), width80)
 	t.Logf("\n%s", plain(out))
 	assertContains(t, out, "+3 more")
+}
+
+// ---------------------------------------------------------------------------
+// #2635 -- coverage units. `unread` may only qualify a genuinely-unread
+// number; the numerator's unit (inbox messages scanned, which can include
+// read mail) must always be named. Fixtures follow the issue's own table.
+// ---------------------------------------------------------------------------
+
+const coverage100Of557Attention = `{
+  "kind": "email_attention",
+  "items": [],
+  "coverage": {"scanned": 100, "total_unread": 557, "scan_truncated": false, "degraded": false, "mailbox_errors": null},
+  "generated_at": "x",
+  "cache_age_seconds": 0.0,
+  "stale": false
+}`
+
+const coverage100NoTotalUnreadAttention = `{
+  "kind": "email_attention",
+  "items": [],
+  "coverage": {"scanned": 100, "total_unread": null, "scan_truncated": false, "degraded": false, "mailbox_errors": null},
+  "generated_at": "x",
+  "cache_age_seconds": 0.0,
+  "stale": false
+}`
+
+const coverageZeroScannedAttention = `{
+  "kind": "email_attention",
+  "items": [],
+  "coverage": {"scanned": 0, "total_unread": 557, "scan_truncated": false, "degraded": false, "mailbox_errors": null},
+  "generated_at": "x",
+  "cache_age_seconds": 0.0,
+  "stale": false
+}`
+
+func TestCoverageLineNamesTheScannedUnit(t *testing.T) {
+	out := Render("email_attention", raw(t, coverage100Of557Attention), width80)
+	t.Logf("\n%s", plain(out))
+
+	assertContains(t, out, "100 inbox messages scanned", "557 unread")
+	assertNotContains(t, out, "100 of 557 unread scanned")
+	if scannedDirectlyModifiedByUnread(t, out, 100) {
+		t.Errorf("the Scanned count is directly described as \"unread\" -- it can include read mail:\n%s", plain(out))
+	}
+}
+
+func TestCoverageLineOmitsUnreadWhenTotalUnreadUnknown(t *testing.T) {
+	// Outlook's connector does not report a total-unread count -- rather than
+	// invent one, the line must simply not mention "unread" at all.
+	out := Render("email_attention", raw(t, coverage100NoTotalUnreadAttention), width80)
+	t.Logf("\n%s", plain(out))
+
+	assertContains(t, out, "100 inbox messages scanned")
+	assertNotContains(t, out, "unread")
+}
+
+func TestCoverageLineZeroScannedStaysHonest(t *testing.T) {
+	// Scanned: 0 goes through the empty-state branch (renderEmpty), which
+	// still calls coverageLine() -- the banned phrase from the issue itself
+	// ("no mail needs you") does not exist anywhere in the code (renderEmpty
+	// emits "Nothing needs you."), so asserting its absence would never be
+	// able to fail. Assert the concrete old defect string instead
+	// (#2631 reflection C5).
+	out := Render("email_attention", raw(t, coverageZeroScannedAttention), width80)
+	t.Logf("\n%s", plain(out))
+
+	assertContains(t, out, "0 inbox messages scanned", "Nothing needs you.")
+	assertNotContains(t, out, "0 of 557 unread scanned")
+}
+
+// scannedDirectlyModifiedByUnread reports whether "unread" describes the
+// Scanned count itself -- directly, or through "of <N> " -- rather than a
+// genuinely separate unread number. A fix that merely reorders the old
+// defect ("557 unread, 100 scanned") must still pass; one that keeps
+// "100 of 557 unread" or introduces "100 unread" must not (#2631 reflection A3).
+func scannedDirectlyModifiedByUnread(t *testing.T, rendered string, scanned int) bool {
+	t.Helper()
+	re := regexp.MustCompile(itoa(scanned) + `\s+(of\s+\d+\s+)?unread`)
+	return re.MatchString(plain(rendered))
+}
+
+// ---------------------------------------------------------------------------
+// #2631 -- row numbers must run continuously across every section, including
+// the unknown-kind OTHER section, never restarting at 1 per section.
+// ---------------------------------------------------------------------------
+
+// multiSectionAttentionForNumbering has one item in each of the four known
+// sections plus one of an unrecognised kind, which must still render under
+// OTHER (attention.go:116-118) and inherit the running counter rather than
+// restart it (#2631 reflection A1).
+const multiSectionAttentionForNumbering = `{
+  "kind": "email_attention",
+  "items": [
+    {"kind": "meeting_request", "message_id": "m1", "sender": "a@example.com", "subject": "Meeting proposal", "why": "x"},
+    {"kind": "waiting_on_you", "message_id": "m2", "sender": "b@example.com", "subject": "Waiting reply", "why": "x"},
+    {"kind": "needs_review", "message_id": "m3", "sender": "c@example.com", "subject": "Review this", "why": "x"},
+    {"kind": "action_item", "message_id": "m4", "sender": "d@example.com", "subject": "Do this thing", "why": "x"},
+    {"kind": "some_future_kind", "message_id": "m5", "sender": "e@example.com", "subject": "Unknown kind item", "why": "x"}
+  ],
+  "coverage": {"scanned": 5, "total_unread": 5, "scan_truncated": false, "degraded": false, "mailbox_errors": null},
+  "generated_at": "x",
+  "cache_age_seconds": 0.0,
+  "stale": false
+}`
+
+func TestAttentionRowNumbersRunContinuouslyAcrossAllSections(t *testing.T) {
+	out := Render("email_attention", raw(t, multiSectionAttentionForNumbering), width80)
+	t.Logf("\n%s", plain(out))
+
+	got := rowNumbers(t, out)
+	want := []int{1, 2, 3, 4, 5}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("row numbers = %v, want %v -- numbering must run continuously across every section, including OTHER", got, want)
+	}
+	// The unknown kind must still render, under a generic header, rather
+	// than being silently dropped.
+	assertContains(t, out, "OTHER", "Unknown kind item")
 }
 
 func TestAttentionRendererReferencesNoMutatingCall(t *testing.T) {

--- a/tui/internal/ui/cards/cards.go
+++ b/tui/internal/ui/cards/cards.go
@@ -25,24 +25,53 @@ import (
 //
 // width is the total width the card may occupy, borders included.
 func Render(renderKey string, data json.RawMessage, width int) string {
+	rendered, _ := RenderDeduped(renderKey, data, width, nil)
+	return rendered
+}
+
+// RenderDeduped draws a card exactly like Render, except for the two email
+// card types (email_pre_scan, email_attention): an item whose message_id is
+// already in seen is skipped rather than shown a second time, and every
+// message_id this card ends up showing is returned so a caller rendering
+// more than one card in one turn can thread the accumulated set into the
+// next call. Every other render key returns no ids and behaves exactly like
+// Render. seen may be nil, equivalent to Render (nothing is deduped).
+func RenderDeduped(renderKey string, data json.RawMessage, width int, seen map[string]bool) (rendered string, ids []string) {
 	key := strings.TrimSpace(renderKey)
 	if key == "" {
-		return renderUnsupported("(none)", data, width)
+		return renderUnsupported("(none)", data, width), nil
 	}
 	switch key {
 	case "email_pre_scan":
-		return renderEmailPreScan(data, width)
+		return renderEmailPreScan(data, width, seen)
 	case "email_attention":
-		return RenderEmailAttention(data, width)
+		return RenderEmailAttention(data, width, seen)
 	case "table":
-		return renderTable(data, width)
+		return renderTable(data, width), nil
 	case "key_value":
-		return renderKeyValue(data, width)
+		return renderKeyValue(data, width), nil
 	case "list":
-		return renderList(data, width)
+		return renderList(data, width), nil
 	case "image":
-		return renderImage(data, width)
+		return renderImage(data, width), nil
 	default:
-		return renderUnsupported(key, data, width)
+		return renderUnsupported(key, data, width), nil
 	}
+}
+
+// dedupByMessageID drops items whose id is already in seen (an item with an
+// empty id is never treated as a duplicate) and returns the surviving items
+// plus the non-empty ids they carry.
+func dedupByMessageID[T any](items []T, id func(T) string, seen map[string]bool) (kept []T, ids []string) {
+	for _, it := range items {
+		mid := strings.TrimSpace(id(it))
+		if mid != "" && seen[mid] {
+			continue
+		}
+		kept = append(kept, it)
+		if mid != "" {
+			ids = append(ids, mid)
+		}
+	}
+	return kept, ids
 }

--- a/tui/internal/ui/cards/emailprescan.go
+++ b/tui/internal/ui/cards/emailprescan.go
@@ -167,19 +167,42 @@ func isPreScanEnvelope(data json.RawMessage) bool {
 	return false
 }
 
-func renderEmailPreScan(data json.RawMessage, width int) string {
+// renderEmailPreScan draws the inbox pre-scan card.
+//
+// seen is the set of message_ids a card rendered earlier in the same turn
+// already showed (nil for a standalone render with no dedup). An item whose
+// id is already in seen is skipped; every non-empty id this call renders is
+// returned so a later card can be threaded against it too. An item with no
+// message_id is never treated as a duplicate.
+func renderEmailPreScan(data json.RawMessage, width int, seen map[string]bool) (string, []string) {
 	var p emailPreScan
 	if err := json.Unmarshal(data, &p); err != nil {
-		return renderInvalid("email_pre_scan", err.Error(), data, width)
+		return renderInvalid("email_pre_scan", err.Error(), data, width), nil
 	}
 	if k := strings.TrimSpace(p.Kind); k != "" && k != "email_pre_scan" {
-		return renderInvalid("email_pre_scan", "kind is "+k+", expected email_pre_scan", data, width)
+		return renderInvalid("email_pre_scan", "kind is "+k+", expected email_pre_scan", data, width), nil
 	}
 	// `null` and `{}` both unmarshal cleanly into the zero envelope, which would
 	// render as "Nothing needs you" — a malformed payload telling the user their
 	// inbox is clear. Require the envelope to actually be one.
 	if !isPreScanEnvelope(data) {
-		return renderInvalid("email_pre_scan", "payload carries no pre-scan fields", data, width)
+		return renderInvalid("email_pre_scan", "payload carries no pre-scan fields", data, width), nil
+	}
+
+	hadItems := !p.isEmpty()
+	var ids, moreIDs []string
+	byMessageID := func(it preScanItem) string { return it.MessageID }
+	p.Urgent, ids = dedupByMessageID(p.Urgent, byMessageID, seen)
+	p.Actionable, moreIDs = dedupByMessageID(p.Actionable, byMessageID, seen)
+	ids = append(ids, moreIDs...)
+	p.NeedsReview, moreIDs = dedupByMessageID(p.NeedsReview, byMessageID, seen)
+	ids = append(ids, moreIDs...)
+	p.SuggestedArchives, moreIDs = dedupByMessageID(p.SuggestedArchives, byMessageID, seen)
+	ids = append(ids, moreIDs...)
+	if hadItems && p.isEmpty() {
+		// Every item was already shown by an earlier card this turn -- this
+		// card would add nothing, so it does not render at all.
+		return "", nil
 	}
 
 	totals := p.totalsOrDerived()
@@ -190,7 +213,7 @@ func renderEmailPreScan(data json.RawMessage, width int) string {
 
 	if p.isEmpty() {
 		p.renderEmpty(b, totals)
-		return b.render()
+		return b.render(), ids
 	}
 
 	itemRows := [][]int{
@@ -245,7 +268,7 @@ func renderEmailPreScan(data json.RawMessage, width int) string {
 			b.addWrapped("  ", line)
 		}
 	}
-	return b.render()
+	return b.render(), ids
 }
 
 // renderMailboxErrors draws the per-account warning banner. A broken grant on

--- a/tui/internal/ui/cards/emailprescan_test.go
+++ b/tui/internal/ui/cards/emailprescan_test.go
@@ -288,6 +288,41 @@ func TestPreScanNeedsReviewOnlyIsNotEmptyState(t *testing.T) {
 	assertNotContains(t, out, "Nothing needs you.")
 }
 
+// ---------------------------------------------------------------------------
+// #2631 -- RenderDeduped's seen threading. The chat model only ever calls
+// this with the pre-scan card rendering first (seen still empty), but the
+// primitive is shared with the attention card and must behave correctly
+// when a pre-scan section is the one losing an item, not just the other way
+// round -- exercised directly here rather than relying on ordering that
+// happens to hold true today.
+// ---------------------------------------------------------------------------
+
+const preScanTwoSectionsOneItemEach = `{
+  "kind": "email_pre_scan",
+  "urgent": [
+    {"message_id":"u1","sender":"a@x.com","subject":"UrgentDup","why":"r1"}
+  ],
+  "actionable": [
+    {"message_id":"a1","sender":"b@x.com","subject":"ActionableUnique","why":"r2"}
+  ],
+  "suggested_archives": [],
+  "needs_review": [],
+  "totals": {"urgent": 1, "actionable": 1, "informational": 0, "suggested_archives": 0, "needs_review": 0}
+}`
+
+func TestPreScanRenderDedupedDropsSeenItemAndEmptiedSection(t *testing.T) {
+	seen := map[string]bool{"u1": true}
+	out, ids := RenderDeduped("email_pre_scan", raw(t, preScanTwoSectionsOneItemEach), width80, seen)
+	t.Logf("\n%s", plain(out))
+
+	assertNotContains(t, out, "URGENT", "UrgentDup")
+	assertContains(t, out, "NEEDS A REPLY", "ActionableUnique")
+
+	if len(ids) != 1 || ids[0] != "a1" {
+		t.Errorf(`returned ids = %v, want exactly ["a1"] -- u1 was already seen and must not be re-added`, ids)
+	}
+}
+
 func TestDisplaySender(t *testing.T) {
 	for _, tc := range []struct{ in, want string }{
 		{`"Sarah Chen" <sarah@example.com>`, "Sarah Chen"},

--- a/tui/internal/ui/cards/testdata_test.go
+++ b/tui/internal/ui/cards/testdata_test.go
@@ -2,6 +2,8 @@ package cards
 
 import (
 	"encoding/json"
+	"regexp"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -146,4 +148,35 @@ func raw(t *testing.T, s string) json.RawMessage {
 		t.Fatalf("fixture is not valid JSON: %s", s)
 	}
 	return json.RawMessage(s)
+}
+
+// rowNumberPattern matches a rendered card's numbered-row gutter once a
+// line's border and leading whitespace are trimmed away: digits, then AT
+// LEAST TWO spaces, then the sender column (box.row: " NN  sender  subject").
+// The coverage/footer line (coverageLine's "N inbox messages scanned...")
+// also starts with digits, but has exactly ONE space after them, so it does
+// not match -- this is what makes the pattern usable to tell a real row from
+// the footer, instead of a substring check that cannot (#2631 reflection C4).
+var rowNumberPattern = regexp.MustCompile(`^(\d+)\s{2,}\S`)
+
+// rowNumbers scrapes every numbered row's index out of a rendered card, in
+// render order, so a test can assert on the real sequence (e.g. with
+// reflect.DeepEqual) instead of a substring check that cannot tell
+// [1,2,3,4] apart from [1,1,2,4] (#2631 reflection C4).
+func rowNumbers(t *testing.T, rendered string) []int {
+	t.Helper()
+	var got []int
+	for _, line := range strings.Split(plain(rendered), "\n") {
+		body := strings.TrimSpace(strings.Trim(line, "│"))
+		m := rowNumberPattern.FindStringSubmatch(body)
+		if m == nil {
+			continue
+		}
+		n, err := strconv.Atoi(m[1])
+		if err != nil {
+			t.Fatalf("row number %q did not parse: %v", m[1], err)
+		}
+		got = append(got, n)
+	}
+	return got
 }

--- a/tui/internal/ui/chat/attention_init_test.go
+++ b/tui/internal/ui/chat/attention_init_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/x/ansi"
 
 	"github.com/amd/gaia/tui/internal/client"
 	"github.com/amd/gaia/tui/internal/event"
@@ -263,10 +264,13 @@ func TestAttentionFetchAppendsImmediatelyWhenNotStreaming(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// #2631 -- one coherent surface. When a pre-scan card has already rendered
-// this session, the attention card is redundant (both describe "what needs
-// you" from different taxonomies over roughly the same inbox state) and is
-// suppressed rather than shown a second time.
+// #2631 -- shared items render once. The pre-scan and attention cards do not
+// share a taxonomy (meeting_request/waiting_on_you/action_item exist only on
+// the attention card), so a duplicate is resolved per item, not by
+// suppressing whichever card renders second -- that would throw away
+// meeting proposals and action items the attention card exists to surface.
+// Whole-card suppression only happens as a side effect of every one of a
+// card's items turning out to be a duplicate.
 // ---------------------------------------------------------------------------
 
 const preScanCardForSuppressionTest = `{
@@ -280,90 +284,171 @@ const preScanCardForSuppressionTest = `{
   "totals": {"urgent": 1, "actionable": 0, "informational": 0, "suggested_archives": 0, "needs_review": 0}
 }`
 
-func TestAttentionCardSuppressedWhenPreScanAlreadyRenderedThisSession(t *testing.T) {
-	m, _ := newTestModel(t)
-	m.messages = append(m.messages, Message{
-		Role:   RoleCard,
-		Render: "email_pre_scan",
-		Data:   json.RawMessage(preScanCardForSuppressionTest),
-	})
+const preScanWithSharedAndUnique = `{
+  "kind": "email_pre_scan",
+  "urgent": [
+    {"message_id":"MSG_A","sender":"a@example.com","subject":"F-Bombs","why":"urgent"}
+  ],
+  "actionable": [
+    {"message_id":"MSG_B","sender":"b@example.com","subject":"PreScanOnlySubject","why":"needs a reply"}
+  ],
+  "suggested_archives": [],
+  "needs_review": [],
+  "totals": {"urgent": 1, "actionable": 1, "informational": 0, "suggested_archives": 0, "needs_review": 0}
+}`
 
-	updated, _ := m.Update(attentionFetchedMsg{data: json.RawMessage(sampleAttentionJSON)})
+const attentionWithSharedAndUnique = `{
+  "kind":"email_attention",
+  "items":[
+    {"kind":"waiting_on_you","message_id":"MSG_A","sender":"a@example.com","subject":"F-Bombs","why":"waiting"},
+    {"kind":"action_item","message_id":"MSG_C","sender":"c@example.com","subject":"AttentionOnlySubject","why":"open item"}
+  ],
+  "coverage":{"scanned":2,"total_unread":2},
+  "generated_at":"x","cache_age_seconds":0.0,"stale":false
+}`
+
+const attentionAllDuplicateOfPreScan = `{
+  "kind":"email_attention",
+  "items":[
+    {"kind":"waiting_on_you","message_id":"MSG_A","sender":"a@example.com","subject":"F-Bombs (attention copy)","why":"still waiting"}
+  ],
+  "coverage":{"scanned":1,"total_unread":1},
+  "generated_at":"x","cache_age_seconds":0.0,"stale":false
+}`
+
+const attentionActionItemsWithNullMessageID = `{
+  "kind":"email_attention",
+  "items":[
+    {"kind":"action_item","message_id":null,"sender":"a@example.com","subject":"Renew the domain","why":"expires Friday"},
+    {"kind":"action_item","message_id":null,"sender":"b@example.com","subject":"Approve the invoice","why":"awaiting sign-off"}
+  ],
+  "coverage":{"scanned":2,"total_unread":2},
+  "generated_at":"x","cache_age_seconds":0.0,"stale":false
+}`
+
+// preScanWithNullMessageIDItem's own urgent item also has no message_id --
+// the pre-scan card renders first, so this is what proves a missing id from
+// an EARLIER card can't poison a later card's missing-id items either: if
+// dedup ever keyed on the empty string, this card's own null id would enter
+// the turn's seen set and the attention card's null-id items would come out
+// looking like duplicates of it.
+const preScanWithNullMessageIDItem = `{
+  "kind": "email_pre_scan",
+  "urgent": [
+    {"message_id":null,"sender":"legal@example.com","subject":"Follow up with Legal","why":"urgent"}
+  ],
+  "actionable": [],
+  "suggested_archives": [],
+  "needs_review": [],
+  "totals": {"urgent": 1, "actionable": 0, "informational": 0, "suggested_archives": 0, "needs_review": 0}
+}`
+
+// renderOverlappingTurn drives one real turn where a pre-scan card renders
+// mid-stream and an attention fetch resolves during that same turn -- so it
+// buffers and drains right after the reply, per #2639 -- the one shape in
+// which these two card types can ever land in the same turn. It returns the
+// fully rendered, ANSI-stripped transcript, exercising the real
+// updateViewport/renderMessage wiring rather than a re-implementation of it.
+func renderOverlappingTurn(t *testing.T, preScanData, attentionData json.RawMessage) string {
+	t.Helper()
+	m, _ := newTestModel(t)
+	m.width, m.height = 100, 60
+	m.resize()
+
+	updated, _ := m.Update(sendQueryMsg{query: "triage my inbox"})
 	m = updated.(ChatModel)
 
-	if hasAttentionCard(m) {
-		t.Errorf("attention card rendered even though a pre-scan card already covered this session; messages: %+v", m.messages)
+	m = feed(t, m, event.CanonicalToolResultEvent{
+		Type: "tool_result", Tool: "pre_scan_inbox",
+		Render: "email_pre_scan", Data: preScanData,
+	})
+
+	updated2, _ := m.Update(attentionFetchedMsg{data: attentionData})
+	m = updated2.(ChatModel)
+
+	m = feed(t, m, event.CanonicalFinalEvent{Type: "final", Answer: "here is your triage"})
+
+	return ansi.Strip(m.viewport.View())
+}
+
+// #2631 -- when every item an attention card would show is a duplicate of
+// something the turn's pre-scan card already rendered, the attention card
+// ends up with nothing left to say and is suppressed. This is the only case
+// where dropping the whole card is correct, and it falls out of the
+// per-item logic rather than a separate whole-card check.
+func TestAttentionCardSuppressedWhenEveryItemAlreadyShownByPreScan(t *testing.T) {
+	view := renderOverlappingTurn(t,
+		json.RawMessage(preScanCardForSuppressionTest),
+		json.RawMessage(attentionAllDuplicateOfPreScan))
+	t.Logf("\n%s", view)
+
+	if !strings.Contains(view, "F-Bombs") {
+		t.Error("the surviving pre-scan card lost its own content")
 	}
-	if len(m.messages) != 1 {
-		t.Errorf("expected only the pre-scan card to remain, got %d messages: %+v", len(m.messages), m.messages)
+	if strings.Contains(view, "attention copy") {
+		t.Error("the duplicate attention item rendered even though its message_id was already shown by the pre-scan card")
+	}
+	if strings.Contains(view, "Needs you") {
+		t.Error("attention card title rendered even though every one of its items was a duplicate -- the whole card should be suppressed")
 	}
 }
 
-// TestOverlappingTurnRendersEachSharedSubjectOnce is the #2631 "no message id
-// twice" acceptance criterion, read literally off the issue: an attention
-// envelope and a pre-scan envelope sharing a message must not both draw it.
-//
-// The chosen fix (plan's Adversarial Reflection, Option B) suppresses the
-// WHOLE attention card once a pre-scan card has rendered, rather than
-// merging the two card types into one combined render. That means the
-// shared subject renders exactly once (via the surviving pre-scan card) and
-// the pre-scan-only subject is untouched -- but an attention-only subject
-// does not render AT ALL in this turn, because the whole card it lived in
-// was suppressed, not merged.
-//
-// That is the design's own documented trade-off ("what B gives up" in the
-// plan), not a bug this test papers over: it is asserted here explicitly,
-// both ways, rather than claiming a per-item merge that was not built.
-func TestOverlappingTurnRendersEachSharedSubjectOnceAndDropsAttentionOnlyContent(t *testing.T) {
-	m, _ := newTestModel(t)
-	m.width, m.height = 100, 30
+// TestOverlappingTurnDedupsSharedItemButKeepsBothCardsUniqueContent is the
+// #2631 "no message id twice" acceptance criterion, read literally off the
+// issue: an attention envelope and a pre-scan envelope sharing a message
+// must not both draw it. Unlike the whole-card-suppression design this
+// replaces, each card's own unique content survives: the shared subject
+// renders exactly once, the pre-scan-only subject is untouched, and the
+// attention-only subject (a taxonomy the pre-scan card has no equivalent
+// for) still renders too. A section left with nothing after dedup is
+// dropped, not shown with a hollow "0" count.
+func TestOverlappingTurnDedupsSharedItemButKeepsBothCardsUniqueContent(t *testing.T) {
+	view := renderOverlappingTurn(t,
+		json.RawMessage(preScanWithSharedAndUnique),
+		json.RawMessage(attentionWithSharedAndUnique))
+	t.Logf("\n%s", view)
 
-	const preScanWithSharedAndUnique = `{
-	  "kind": "email_pre_scan",
-	  "urgent": [
-	    {"message_id":"MSG_A","sender":"a@example.com","subject":"F-Bombs","why":"urgent"}
-	  ],
-	  "actionable": [
-	    {"message_id":"MSG_B","sender":"b@example.com","subject":"PreScanOnlySubject","why":"needs a reply"}
-	  ],
-	  "suggested_archives": [],
-	  "needs_review": [],
-	  "totals": {"urgent": 1, "actionable": 1, "informational": 0, "suggested_archives": 0, "needs_review": 0}
-	}`
-	m.messages = append(m.messages, Message{
-		Role:   RoleCard,
-		Render: "email_pre_scan",
-		Data:   json.RawMessage(preScanWithSharedAndUnique),
-	})
-
-	const attentionWithSharedAndUnique = `{
-	  "kind":"email_attention",
-	  "items":[
-	    {"kind":"waiting_on_you","message_id":"MSG_A","sender":"a@example.com","subject":"F-Bombs","why":"waiting"},
-	    {"kind":"action_item","message_id":"MSG_C","sender":"c@example.com","subject":"AttentionOnlySubject","why":"open item"}
-	  ],
-	  "coverage":{"scanned":2,"total_unread":2},
-	  "generated_at":"x","cache_age_seconds":0.0,"stale":false
-	}`
-	updated, _ := m.Update(attentionFetchedMsg{data: json.RawMessage(attentionWithSharedAndUnique)})
-	m = updated.(ChatModel)
-
-	var sb strings.Builder
-	for i := range m.messages {
-		sb.WriteString(m.renderMessage(&m.messages[i]))
-		sb.WriteString("\n")
-	}
-	rendered := sb.String()
-	t.Logf("\n%s", rendered)
-
-	if n := strings.Count(rendered, "F-Bombs"); n != 1 {
+	if n := strings.Count(view, "F-Bombs"); n != 1 {
 		t.Errorf("shared subject rendered %d times, want exactly 1", n)
 	}
-	if !strings.Contains(rendered, "PreScanOnlySubject") {
-		t.Error("the surviving pre-scan card lost its own unique content")
+	if !strings.Contains(view, "PreScanOnlySubject") {
+		t.Error("the pre-scan card lost its own unique content")
 	}
-	if strings.Contains(rendered, "AttentionOnlySubject") {
-		t.Error("attention-only subject rendered even though the whole attention card should be suppressed -- if this now passes, re-check whether suppression narrowed to per-item and update this test's assumptions")
+	if !strings.Contains(view, "AttentionOnlySubject") {
+		t.Error("the attention card's own unique content was dropped -- per-item dedup must not suppress the whole card when it still has something to say")
+	}
+	if strings.Contains(view, "WAITING ON YOU") {
+		t.Error("the WAITING ON YOU section should have been dropped -- its only item was deduped away, so an empty section must not render")
+	}
+	if !strings.Contains(view, "ACTION ITEMS") {
+		t.Error("the ACTION ITEMS section, whose one item is not a duplicate, should still render")
+	}
+	if !strings.Contains(view, "Needs you") {
+		t.Error("the attention card itself should still render -- it still has real content (the action item)")
+	}
+}
+
+// #2631 -- action items legitimately carry no message_id (they are not tied
+// to one specific message), so an empty id must never be treated as a
+// duplicate: not of a real id already in play, not of another empty-id item
+// in the very same card, and -- the sharpest case -- not of an empty id an
+// EARLIER card in the same turn also carried. The pre-scan fixture here has
+// its own null-id item specifically to prove that last case: seen must never
+// gain an "" entry that a later card's null-id items could collide with.
+func TestAttentionItemsWithNoMessageIDAreNeverDedupedAsDuplicates(t *testing.T) {
+	view := renderOverlappingTurn(t,
+		json.RawMessage(preScanWithNullMessageIDItem),
+		json.RawMessage(attentionActionItemsWithNullMessageID))
+	t.Logf("\n%s", view)
+
+	if !strings.Contains(view, "Follow up with Legal") {
+		t.Error("the pre-scan card's own null-message_id item was dropped")
+	}
+	if !strings.Contains(view, "Renew the domain") {
+		t.Error("a null-message_id action item was dropped -- an empty id must never be treated as a duplicate")
+	}
+	if !strings.Contains(view, "Approve the invoice") {
+		t.Error("a second null-message_id action item was dropped -- empty ids must not be deduped against each other either")
 	}
 }
 

--- a/tui/internal/ui/chat/attention_init_test.go
+++ b/tui/internal/ui/chat/attention_init_test.go
@@ -5,11 +5,13 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strings"
 	"testing"
 
 	tea "github.com/charmbracelet/bubbletea"
 
 	"github.com/amd/gaia/tui/internal/client"
+	"github.com/amd/gaia/tui/internal/event"
 )
 
 // fakeAttentionClient satisfies both client.AgentClient and
@@ -131,6 +133,237 @@ func TestAttentionFetchedMsgAppendsCardMessage(t *testing.T) {
 	}
 	if string(got.Data) != sampleAttentionJSON {
 		t.Errorf("Data = %s, want %s", got.Data, sampleAttentionJSON)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// #2639 -- turn ordering. A fetch that resolves while a turn is in flight
+// must be held, not spliced between the question and its reply, and must
+// never be silently lost however the turn ends.
+// ---------------------------------------------------------------------------
+
+// hasAttentionCard reports whether an email_attention RoleCard message is
+// anywhere in the transcript.
+func hasAttentionCard(m ChatModel) bool {
+	for _, msg := range m.messages {
+		if msg.Role == RoleCard && msg.Render == "email_attention" {
+			return true
+		}
+	}
+	return false
+}
+
+func TestAttentionFetchResolvingMidTurnIsBufferedThenAppendedAfterReply(t *testing.T) {
+	m, _ := newTestModel(t)
+
+	// The user starts a turn before the on-open attention fetch has resolved.
+	updated, _ := m.Update(sendQueryMsg{query: "triage my inbox"})
+	m = updated.(ChatModel)
+
+	// The fetch resolves now, mid-turn -- it must not land between the
+	// question just asked and its answer (#2639).
+	updated2, _ := m.Update(attentionFetchedMsg{data: json.RawMessage(sampleAttentionJSON)})
+	m = updated2.(ChatModel)
+
+	if len(m.messages) != 1 {
+		t.Fatalf("attention card landed mid-turn instead of being buffered; got %d messages: %+v", len(m.messages), m.messages)
+	}
+	if m.pendingAttention == nil {
+		t.Fatal("fetch result was dropped instead of buffered")
+	}
+
+	// The turn completes.
+	m = feed(t, m, event.CanonicalFinalEvent{Type: "final", Answer: "here is your triage"})
+
+	if len(m.messages) != 3 {
+		t.Fatalf("got %d messages, want 3 ([User, Assistant, Card]): %+v", len(m.messages), m.messages)
+	}
+	wantRoles := []MessageRole{RoleUser, RoleAssistant, RoleCard}
+	for i, want := range wantRoles {
+		if m.messages[i].Role != want {
+			t.Errorf("messages[%d].Role = %v, want %v", i, m.messages[i].Role, want)
+		}
+	}
+	if m.messages[2].Render != "email_attention" {
+		t.Errorf("messages[2].Render = %q, want email_attention -- the buffered card must not be lost", m.messages[2].Render)
+	}
+	if m.pendingAttention != nil {
+		t.Error("pendingAttention was not cleared after draining")
+	}
+}
+
+func TestPendingAttentionDrainedOnCtrlCCancel(t *testing.T) {
+	// Ctrl+C ends the turn without ever reaching CanonicalFinalEvent or
+	// doneMsg -- a drain hooked only on the happy path would orphan the
+	// buffered card here (#2631 reflection C2).
+	m, _ := newTestModel(t)
+	updated, _ := m.Update(sendQueryMsg{query: "triage my inbox"})
+	m = updated.(ChatModel)
+	m.pendingAttention = json.RawMessage(sampleAttentionJSON)
+
+	updated2, _ := m.handleKey(tea.KeyMsg{Type: tea.KeyCtrlC})
+	m = updated2.(ChatModel)
+
+	if !hasAttentionCard(m) {
+		t.Errorf("buffered attention card was lost on Ctrl+C cancel; messages: %+v", m.messages)
+	}
+	if m.pendingAttention != nil {
+		t.Error("pendingAttention was not cleared after draining")
+	}
+}
+
+func TestPendingAttentionDrainedOnEscCancel(t *testing.T) {
+	m, _ := newTestModel(t)
+	updated, _ := m.Update(sendQueryMsg{query: "triage my inbox"})
+	m = updated.(ChatModel)
+	m.pendingAttention = json.RawMessage(sampleAttentionJSON)
+
+	updated2, _ := m.handleKey(tea.KeyMsg{Type: tea.KeyEsc})
+	m = updated2.(ChatModel)
+
+	if !hasAttentionCard(m) {
+		t.Errorf("buffered attention card was lost on Esc cancel; messages: %+v", m.messages)
+	}
+}
+
+func TestPendingAttentionDrainedOnErrMsg(t *testing.T) {
+	// A transport-level error (e.g. the POST that starts a turn fails) also
+	// ends the turn without reaching CanonicalFinalEvent or doneMsg.
+	m, _ := newTestModel(t)
+	updated, _ := m.Update(sendQueryMsg{query: "triage my inbox"})
+	m = updated.(ChatModel)
+	m.pendingAttention = json.RawMessage(sampleAttentionJSON)
+
+	updated2, _ := m.Update(errMsg{err: errors.New("transport dropped")})
+	m = updated2.(ChatModel)
+
+	if !hasAttentionCard(m) {
+		t.Errorf("buffered attention card was lost on errMsg; messages: %+v", m.messages)
+	}
+}
+
+func TestAttentionFetchAppendsImmediatelyWhenNotStreaming(t *testing.T) {
+	// With no user query in flight (the #2582 on-open case), the fetch
+	// resolving must still render right away -- it must not regress into
+	// always buffering.
+	m, _ := newTestModel(t)
+	if m.streaming {
+		t.Fatal("test setup: model must start out not streaming")
+	}
+
+	updated, _ := m.Update(attentionFetchedMsg{data: json.RawMessage(sampleAttentionJSON)})
+	m = updated.(ChatModel)
+
+	if !hasAttentionCard(m) {
+		t.Fatal("attention card did not render immediately when no turn was in flight")
+	}
+	if m.pendingAttention != nil {
+		t.Error("nothing should be buffered when the fetch resolves outside a turn")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// #2631 -- one coherent surface. When a pre-scan card has already rendered
+// this session, the attention card is redundant (both describe "what needs
+// you" from different taxonomies over roughly the same inbox state) and is
+// suppressed rather than shown a second time.
+// ---------------------------------------------------------------------------
+
+const preScanCardForSuppressionTest = `{
+  "kind": "email_pre_scan",
+  "urgent": [
+    {"message_id":"MSG_A","sender":"a@example.com","subject":"F-Bombs","why":"urgent"}
+  ],
+  "actionable": [],
+  "suggested_archives": [],
+  "needs_review": [],
+  "totals": {"urgent": 1, "actionable": 0, "informational": 0, "suggested_archives": 0, "needs_review": 0}
+}`
+
+func TestAttentionCardSuppressedWhenPreScanAlreadyRenderedThisSession(t *testing.T) {
+	m, _ := newTestModel(t)
+	m.messages = append(m.messages, Message{
+		Role:   RoleCard,
+		Render: "email_pre_scan",
+		Data:   json.RawMessage(preScanCardForSuppressionTest),
+	})
+
+	updated, _ := m.Update(attentionFetchedMsg{data: json.RawMessage(sampleAttentionJSON)})
+	m = updated.(ChatModel)
+
+	if hasAttentionCard(m) {
+		t.Errorf("attention card rendered even though a pre-scan card already covered this session; messages: %+v", m.messages)
+	}
+	if len(m.messages) != 1 {
+		t.Errorf("expected only the pre-scan card to remain, got %d messages: %+v", len(m.messages), m.messages)
+	}
+}
+
+// TestOverlappingTurnRendersEachSharedSubjectOnce is the #2631 "no message id
+// twice" acceptance criterion, read literally off the issue: an attention
+// envelope and a pre-scan envelope sharing a message must not both draw it.
+//
+// The chosen fix (plan's Adversarial Reflection, Option B) suppresses the
+// WHOLE attention card once a pre-scan card has rendered, rather than
+// merging the two card types into one combined render. That means the
+// shared subject renders exactly once (via the surviving pre-scan card) and
+// the pre-scan-only subject is untouched -- but an attention-only subject
+// does not render AT ALL in this turn, because the whole card it lived in
+// was suppressed, not merged.
+//
+// That is the design's own documented trade-off ("what B gives up" in the
+// plan), not a bug this test papers over: it is asserted here explicitly,
+// both ways, rather than claiming a per-item merge that was not built.
+func TestOverlappingTurnRendersEachSharedSubjectOnceAndDropsAttentionOnlyContent(t *testing.T) {
+	m, _ := newTestModel(t)
+	m.width, m.height = 100, 30
+
+	const preScanWithSharedAndUnique = `{
+	  "kind": "email_pre_scan",
+	  "urgent": [
+	    {"message_id":"MSG_A","sender":"a@example.com","subject":"F-Bombs","why":"urgent"}
+	  ],
+	  "actionable": [
+	    {"message_id":"MSG_B","sender":"b@example.com","subject":"PreScanOnlySubject","why":"needs a reply"}
+	  ],
+	  "suggested_archives": [],
+	  "needs_review": [],
+	  "totals": {"urgent": 1, "actionable": 1, "informational": 0, "suggested_archives": 0, "needs_review": 0}
+	}`
+	m.messages = append(m.messages, Message{
+		Role:   RoleCard,
+		Render: "email_pre_scan",
+		Data:   json.RawMessage(preScanWithSharedAndUnique),
+	})
+
+	const attentionWithSharedAndUnique = `{
+	  "kind":"email_attention",
+	  "items":[
+	    {"kind":"waiting_on_you","message_id":"MSG_A","sender":"a@example.com","subject":"F-Bombs","why":"waiting"},
+	    {"kind":"action_item","message_id":"MSG_C","sender":"c@example.com","subject":"AttentionOnlySubject","why":"open item"}
+	  ],
+	  "coverage":{"scanned":2,"total_unread":2},
+	  "generated_at":"x","cache_age_seconds":0.0,"stale":false
+	}`
+	updated, _ := m.Update(attentionFetchedMsg{data: json.RawMessage(attentionWithSharedAndUnique)})
+	m = updated.(ChatModel)
+
+	var sb strings.Builder
+	for i := range m.messages {
+		sb.WriteString(m.renderMessage(&m.messages[i]))
+		sb.WriteString("\n")
+	}
+	rendered := sb.String()
+	t.Logf("\n%s", rendered)
+
+	if n := strings.Count(rendered, "F-Bombs"); n != 1 {
+		t.Errorf("shared subject rendered %d times, want exactly 1", n)
+	}
+	if !strings.Contains(rendered, "PreScanOnlySubject") {
+		t.Error("the surviving pre-scan card lost its own unique content")
+	}
+	if strings.Contains(rendered, "AttentionOnlySubject") {
+		t.Error("attention-only subject rendered even though the whole attention card should be suppressed -- if this now passes, re-check whether suppression narrowed to per-item and update this test's assumptions")
 	}
 }
 

--- a/tui/internal/ui/chat/canonical.go
+++ b/tui/internal/ui/chat/canonical.go
@@ -121,6 +121,8 @@ func (m ChatModel) handleCanonicalEvent(evt interface{}) (ChatModel, tea.Cmd, bo
 			Steps:     usage.Steps,
 			ToolsUsed: usage.ToolsUsed,
 		})
+		// Drain here, not on doneMsg: streaming flips false in THIS handler, and doneMsg fires later, after a second query could already be in flight.
+		m.drainPendingAttention()
 		m.streaming = false
 		m.activity = nil
 		// The turn is over, so any question it was waiting on is dead. Leaving
@@ -142,6 +144,7 @@ func (m ChatModel) handleCanonicalEvent(evt interface{}) (ChatModel, tea.Cmd, bo
 		m.flushBuffer()
 		m.resolveConfirmationOnTurnEnd()
 		m.messages = append(m.messages, Message{Role: RoleError, Content: e.Detail})
+		m.drainPendingAttention()
 		m.streaming = false
 		m.activity = nil
 		m.question = nil

--- a/tui/internal/ui/chat/canonical_test.go
+++ b/tui/internal/ui/chat/canonical_test.go
@@ -130,7 +130,7 @@ func TestCanonicalToolCallAndResult(t *testing.T) {
 	if card.Render != "table" {
 		t.Errorf("card render = %q, want table", card.Render)
 	}
-	if rendered := m.renderMessage(card); !strings.Contains(rendered, "a@b.c") {
+	if rendered := m.renderMessage(card, nil); !strings.Contains(rendered, "a@b.c") {
 		t.Errorf("table card did not draw its row:\n%s", rendered)
 	}
 }

--- a/tui/internal/ui/chat/cards_test.go
+++ b/tui/internal/ui/chat/cards_test.go
@@ -64,7 +64,7 @@ func TestToolResultWithRenderDrawsACard(t *testing.T) {
 		t.Errorf("card = {render:%q tool:%q}, want {email_pre_scan pre_scan_inbox}", card.Render, card.ToolName)
 	}
 
-	rendered := ansi.Strip(m.renderMessage(card))
+	rendered := ansi.Strip(m.renderMessage(card, nil))
 	t.Logf("\n%s", rendered)
 	for _, want := range []string{"Inbox · 9 scanned", "URGENT", "Sarah Chen", "asked for a reply by Friday"} {
 		if !strings.Contains(rendered, want) {
@@ -88,7 +88,7 @@ func TestUnknownRenderStillDrawsACard(t *testing.T) {
 	})
 
 	card := lastCard(t, m)
-	rendered := ansi.Strip(m.renderMessage(&card))
+	rendered := ansi.Strip(m.renderMessage(&card, nil))
 	t.Logf("\n%s", rendered)
 	if !strings.Contains(rendered, "Unsupported card type") {
 		t.Errorf("unknown render did not degrade to the generic card:\n%s", rendered)
@@ -145,7 +145,7 @@ func TestCardFitsAn80ColumnTerminal(t *testing.T) {
 		Render: "email_pre_scan", Data: json.RawMessage(prescanPayload),
 	})
 
-	rendered := func() string { c := lastCard(t, m); return ansi.Strip(m.renderMessage(&c)) }()
+	rendered := func() string { c := lastCard(t, m); return ansi.Strip(m.renderMessage(&c, nil)) }()
 	for i, line := range strings.Split(rendered, "\n") {
 		if w := ansi.StringWidth(line); w > 80 {
 			t.Errorf("card line %d is %d columns wide, overflowing an 80-column terminal: %q", i, w, line)

--- a/tui/internal/ui/chat/message.go
+++ b/tui/internal/ui/chat/message.go
@@ -55,6 +55,23 @@ func (m *Message) renderCard(w int) string {
 	return m.cardCache
 }
 
+// renderCardDeduped draws the card at w like renderCard, but skips any item
+// whose message_id is already in seen and folds the ids it ends up showing
+// into seen -- so a caller drawing more than one card in a turn threads the
+// accumulated set across calls. Always recomputes rather than using the width
+// cache: this card's visible content can legitimately differ call to call as
+// seen grows while sibling cards in the same turn are drawn. seen may be nil,
+// equivalent to renderCard.
+func (m *Message) renderCardDeduped(w int, seen map[string]bool) string {
+	rendered, ids := cards.RenderDeduped(m.Render, m.Data, w, seen)
+	if seen != nil {
+		for _, id := range ids {
+			seen[id] = true
+		}
+	}
+	return rendered
+}
+
 type ActivityItem struct {
 	Kind    string // "thinking", "tool", "step", "status"
 	Content string

--- a/tui/internal/ui/chat/model.go
+++ b/tui/internal/ui/chat/model.go
@@ -142,6 +142,9 @@ type ChatModel struct {
 	queryStart   time.Time // tracks when the current query started
 	firstEvent   bool      // whether we've received the first event this turn
 	ttft         time.Duration
+
+	// pendingAttention buffers a fetch resolved mid-turn until that turn ends, so it never lands between a question and its reply.
+	pendingAttention json.RawMessage
 }
 
 func NewChatModel(c client.AgentClient, agentName string, initialQuery string, debug bool) ChatModel {
@@ -225,6 +228,38 @@ func (m ChatModel) fetchAttention() tea.Cmd {
 	}
 }
 
+// appendAttentionCard skips the render when a pre-scan card already covered this session — the two surfaces would otherwise duplicate every shared message.
+func (m *ChatModel) appendAttentionCard(data json.RawMessage) {
+	if m.hasPreScanCard() {
+		return
+	}
+	m.messages = append(m.messages, Message{
+		Role:   RoleCard,
+		Render: "email_attention",
+		Data:   data,
+	})
+}
+
+// hasPreScanCard reports whether an email_pre_scan card has rendered anywhere in the session so far.
+func (m ChatModel) hasPreScanCard() bool {
+	for i := range m.messages {
+		if m.messages[i].Role == RoleCard && m.messages[i].Render == "email_pre_scan" {
+			return true
+		}
+	}
+	return false
+}
+
+// drainPendingAttention appends a buffered attention card now that its turn has ended, whichever way it ended.
+func (m *ChatModel) drainPendingAttention() {
+	if m.pendingAttention == nil {
+		return
+	}
+	data := m.pendingAttention
+	m.pendingAttention = nil
+	m.appendAttentionCard(data)
+}
+
 func (m ChatModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	var cmds []tea.Cmd
 
@@ -246,11 +281,12 @@ func (m ChatModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, waitForEvent(m.events)
 
 	case attentionFetchedMsg:
-		m.messages = append(m.messages, Message{
-			Role:   RoleCard,
-			Render: "email_attention",
-			Data:   msg.data,
-		})
+		if m.streaming {
+			// Buffer -- appending now would land the card between this turn's question and its reply.
+			m.pendingAttention = msg.data
+			return m, nil
+		}
+		m.appendAttentionCard(msg.data)
 		m.updateViewport()
 		return m, nil
 
@@ -297,6 +333,7 @@ func (m ChatModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			Role:    RoleError,
 			Content: msg.err.Error(),
 		})
+		m.drainPendingAttention()
 		m.activity = nil
 		m.updateViewport()
 		return m, nil
@@ -418,6 +455,7 @@ func (m ChatModel) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 				Role:    RoleStatus,
 				Content: "cancelled",
 			})
+			m.drainPendingAttention()
 			m.updateViewport()
 			return m, nil
 		}
@@ -436,6 +474,7 @@ func (m ChatModel) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 				Role:    RoleStatus,
 				Content: "cancelled",
 			})
+			m.drainPendingAttention()
 			m.updateViewport()
 			return m, nil
 		}

--- a/tui/internal/ui/chat/model.go
+++ b/tui/internal/ui/chat/model.go
@@ -228,26 +228,14 @@ func (m ChatModel) fetchAttention() tea.Cmd {
 	}
 }
 
-// appendAttentionCard skips the render when a pre-scan card already covered this session — the two surfaces would otherwise duplicate every shared message.
+// appendAttentionCard appends the attention card. Cross-card duplicate items
+// are resolved at render time (see Message.renderCard), not here.
 func (m *ChatModel) appendAttentionCard(data json.RawMessage) {
-	if m.hasPreScanCard() {
-		return
-	}
 	m.messages = append(m.messages, Message{
 		Role:   RoleCard,
 		Render: "email_attention",
 		Data:   data,
 	})
-}
-
-// hasPreScanCard reports whether an email_pre_scan card has rendered anywhere in the session so far.
-func (m ChatModel) hasPreScanCard() bool {
-	for i := range m.messages {
-		if m.messages[i].Role == RoleCard && m.messages[i].Render == "email_pre_scan" {
-			return true
-		}
-	}
-	return false
 }
 
 // drainPendingAttention appends a buffered attention card now that its turn has ended, whichever way it ended.

--- a/tui/internal/ui/chat/model.go
+++ b/tui/internal/ui/chat/model.go
@@ -795,9 +795,18 @@ func (m *ChatModel) updateViewport() {
 		sb.WriteString("\n")
 	}
 
+	// seen accumulates message_ids across cards within one turn so a second
+	// card doesn't redraw an item its turn's first card already showed. It
+	// resets at each RoleUser message: a new turn's mail can legitimately
+	// repeat an id an earlier turn's card already rendered (still urgent on
+	// the next scan is not a duplicate), so dedup must not span turns.
+	seen := make(map[string]bool)
 	for i := range m.messages {
+		if m.messages[i].Role == RoleUser {
+			seen = make(map[string]bool)
+		}
 		// By index, not by value: rendering a card memoizes onto the message.
-		sb.WriteString(m.renderMessage(&m.messages[i]))
+		sb.WriteString(m.renderMessage(&m.messages[i], seen))
 		sb.WriteString("\n")
 	}
 
@@ -868,7 +877,10 @@ func (m ChatModel) wrapForPane(s string) string {
 	return components.WrapText(s, m.cardWidth())
 }
 
-func (m ChatModel) renderMessage(msg *Message) string {
+// renderMessage draws one message. seen threads cross-card dedup for the
+// RoleCard case (see Message.renderCardDeduped); pass nil for a standalone
+// render with no dedup.
+func (m ChatModel) renderMessage(msg *Message, seen map[string]bool) string {
 	switch msg.Role {
 	case RoleUser:
 		// A free-text answer to a mid-run question lands here and can be long.
@@ -915,7 +927,7 @@ func (m ChatModel) renderMessage(msg *Message) string {
 		return panel
 
 	case RoleCard:
-		return msg.renderCard(m.cardWidth())
+		return msg.renderCardDeduped(m.cardWidth(), seen)
 
 	case RoleError:
 		panelWidth := m.width - 4


### PR DESCRIPTION
Closes #2631
Closes #2635
Closes #2639

Asking the terminal UI to triage your inbox drew two stacked cards that partly said the same thing. One message appeared in both, numbered `1` in the first and `2` in the second, so "archive 2" was ambiguous — and nothing on screen explained why there were two cards. The card that appears when you first open the agent could also land *in the middle* of a question you had just typed, so the transcript read question → an unrelated 100-message inbox scan → answer. Separately the coverage line claimed "100 of 557 unread scanned" when those 100 were a mix of read and unread mail, overstating unread coverage by roughly double.

Now: a message appears once per turn, row numbers run straight through each card, each card says what it is and what it actually looked at, and the on-open scan waits for a turn in progress to finish instead of cutting into it.

## Test plan

- [x] `cd tui && go build ./... && go vet ./... && go test ./...` — all 14 packages pass, 128 tests in the two touched packages
- [x] #2635 coverage-units table asserted for `(100, 557)`, `(100, nil)` (Outlook — no unread claim at all) and `(0, 557)`, plus a regex guard that `Scanned`'s own digits are never followed by "unread"
- [x] Row numbers scraped from the rendered card and compared with `reflect.DeepEqual` against the real sequence — a substring check passes against `[1,1,2,4]`, so it could not have caught this
- [x] Turn ordering driven through the actual `updateViewport` path with a real event sequence, not a test-side reimplementation
- [x] **Mutation-tested.** Each production behaviour was reverted one at a time and the suite re-run, confirming only the corresponding test fails:

| Mutation | Result |
|---|---|
| `updateViewport` passes `nil` instead of the threaded seen-set | the two dedup tests fail, nothing else |
| dedup skip disabled | same two fail, nothing else |
| null-`message_id` carve-out removed | the carve-out test fails, nothing else |
| the `CanonicalFinalEvent` drain removed | the mid-turn ordering test fails |
| the Ctrl+C drain removed | only the Ctrl+C test fails — the Esc test stays green, proving each test gates its own call site |

<details>
<summary>Design notes, and one thing mutation testing caught</summary>

**Two cards, deduped per item — not one merged card.** #2631's criterion allows either one coherent surface or two whose distinct purpose is stated. Two-plus-dedup was chosen because the attention card can be served from a **stale cache** while the pre-scan is always freshly computed; one merged card with a single row counter would present cached and fresh facts as equally current, and there was no reconciliation rule for a message whose state changed between the two fetches. The two also use different taxonomies — `meeting_request`, `waiting_on_you` and `action_item` exist only on the attention side — so suppressing that card wholesale would discard meeting proposals and action items, i.e. exactly the signal it was built to surface. Whole-card suppression now happens only when *every* item is a duplicate, and falls out of the per-item logic rather than being a special path.

**Items with no `message_id` are never treated as duplicates.** `action_item` entries legitimately carry `message_id: null`, so keying on id alone would drop all of them.

**The seen-set resets at each user message,** scoping dedup to one turn. Without that, a message still urgent on turn 5 would silently vanish because turn 1's card had already shown it once.

**Mutation testing caught a vacuous test.** Removing the null-id carve-out initially left the suite green — the fixture wasn't actually exercising the hazard, because two null ids inside one card can't collide (the seen-set isn't mutated mid-card); only cross-card poisoning is reachable. The fixture was corrected so the pre-scan card also carries a null-id item, after which the mutation failed as it should. Without that step the guard would have shipped proving nothing.

**Two known cosmetic/unreachable limits:** a fully-suppressed attention card leaves one stray blank line, since each message unconditionally gets a trailing newline whether or not it rendered to empty (pre-existing pattern, shared with the unknown-card-kind fallback). And the seen-set reset also fires on a mid-turn question-answer, not just a genuine new query — unreachable today, because the attention fetch is a one-shot at open and can only ever pair with the first turn's pre-scan card; it would matter only if that fetch became repeatable.
</details>
