### PR TITLE
fix(email-agent): kill a running autonomy cycle and keep partial reports

### DIFF
--- a/hub/agents/email/python/CHANGELOG.md
+++ b/hub/agents/email/python/CHANGELOG.md
@@ -126,7 +126,8 @@ contract version is tracked separately as
   what had actually changed short of querying the database by hand. The
   cycle now catches a per-message failure, records it in the new
   `report["errors"]` (exception type plus a redacted, length-capped
-  message — never the raw provider payload), and continues to the next
+  message — auth headers, tokens, and email addresses are stripped, never
+  the raw provider payload), and continues to the next
   message — stopping only after 3 CONSECUTIVE failures (resets on any
   success) so a systemic outage doesn't grind through the whole batch
   logging one identical error per message. A bookkeeping-call failure

--- a/hub/agents/email/python/CHANGELOG.md
+++ b/hub/agents/email/python/CHANGELOG.md
@@ -104,6 +104,36 @@ contract version is tracked separately as
   a larger length bound (`THREAD_SUMMARY_CHAR_LIMIT`, 700 vs. the
   single-message 300): several messages' decisions plus a new open ask plus
   a meeting time cannot fit in the single-message cap.
+- **The autonomy kill switch now pre-empts a cycle already running, instead
+  of only affecting the next one (#2624).** A kill fired a second into a
+  25-message run used to be confirmed as "off" while the run carried on and
+  processed all 25 — the only enabled check read a `TrustPolicy` snapshot
+  frozen before the loop started, so nothing inside it could see a kill
+  fired mid-cycle. `_run_email_autonomy_cycle` now re-reads the live
+  autonomy level immediately before each message's execute call and stops
+  the batch there, recording why in the new `report["stopped"]` field
+  (`"autonomy_off"`). Scope: this is pre-emptive for a cycle running through
+  the REST/CLI session surface on a single-worker sidecar; the scheduler
+  builds a stateless agent per fire from environment variables and is
+  unaffected by a kill issued here (tracked separately). Killing one session
+  also now stops every other live session in the process, since the caller's
+  session id is not always the one an autonomy cycle happens to be running
+  under.
+- **A single per-message failure no longer discards the whole autonomy
+  report (#2625).** A transient provider error used to propagate past the
+  whole cycle, throwing away the record of every message already archived
+  or marked read for real — the caller got a bare 500 and no way to tell
+  what had actually changed short of querying the database by hand. The
+  cycle now catches a per-message failure, records it in the new
+  `report["errors"]` (exception type plus a redacted, length-capped
+  message — never the raw provider payload), and continues to the next
+  message — stopping only after 3 CONSECUTIVE failures (resets on any
+  success) so a systemic outage doesn't grind through the whole batch
+  logging one identical error per message. A bookkeeping-call failure
+  (recording the action for undo, clearing the re-proposal guard) that
+  happens *after* a message was already mutated is logged but never
+  reclassifies that message as failed. A cycle-level failure (triage
+  itself raising) still propagates, unchanged.
 - **`POST /autonomy/run` refuses instead of silently no-oping while autonomy
   is `off` (#2528).** Previously the route returned HTTP 200 with the same
   empty-report shape whether autonomy was disabled or had genuinely run and

--- a/hub/agents/email/python/CHANGELOG.md
+++ b/hub/agents/email/python/CHANGELOG.md
@@ -115,7 +115,7 @@ contract version is tracked separately as
   (`"autonomy_off"`). Scope: this is pre-emptive for a cycle running through
   the REST/CLI session surface on a single-worker sidecar; the scheduler
   builds a stateless agent per fire from environment variables and is
-  unaffected by a kill issued here (tracked separately). Killing one session
+  unaffected by a kill issued here (#2649). Killing one session
   also now stops every other live session in the process, since the caller's
   session id is not always the one an autonomy cycle happens to be running
   under.

--- a/hub/agents/email/python/gaia_agent_email/agent.py
+++ b/hub/agents/email/python/gaia_agent_email/agent.py
@@ -1799,7 +1799,7 @@ class EmailTriageAgent(
         mid-batch. The scheduler is the documented exception — each fire
         builds its own agent from ``GAIA_EMAIL_AUTONOMY_LEVEL`` and never
         touches this instance, so a kill issued here does not reach an
-        already-scheduled run (tracked separately). Returns the applied
+        already-scheduled run (#2649). Returns the applied
         status. Raises ``ValueError`` (translated to HTTP 400 at the
         boundary) on an unknown level rather than silently ignoring it.
         """

--- a/hub/agents/email/python/gaia_agent_email/agent.py
+++ b/hub/agents/email/python/gaia_agent_email/agent.py
@@ -432,16 +432,26 @@ def _normalize_plain_text_answer(text: str) -> str:
 # Redact common credential/token shapes out of a per-row autonomy failure's
 # exception text before it leaves the process (#2625 — adversarial C5).
 # Provider/HTTP client exceptions routinely embed request/response text —
-# auth headers, cookies, tokens — in ``str(exc)``.
+# auth headers, cookies, tokens — in ``str(exc)``. The header-name branch
+# consumes an optional "Bearer " prefix AND the token/value that follows it
+# as ONE match (a bare `\S+` after the header would stop at "Bearer" itself
+# and leave the actual token untouched); the second branch catches a bare
+# "Bearer <token>" with no header name in front of it.
 _AUTONOMY_ERROR_SENSITIVE_RE = re.compile(
-    r"(authorization|bearer|cookie|set-cookie|x-api-key|api[-_]?key|"
-    r"access[-_]?token|refresh[-_]?token)\s*[:=]\s*\S+",
+    r"\b(?P<header>authorization|cookie|set-cookie|x-api-key|api[-_]?key|"
+    r"access[-_]?token|refresh[-_]?token)\b\s*[:=]\s*(?:bearer\s+)?\S+"
+    r"|\bbearer\s+\S+",
     re.IGNORECASE,
 )
 #: Hard cap on a sanitized autonomy error's message length (#2625 — C5) — the
 #: length cap alone bounds how much of a raw provider payload can leak even
 #: past the pattern redaction above.
 _AUTONOMY_ERROR_MESSAGE_MAX_LEN = 200
+
+
+def _redact_autonomy_error_match(match: "re.Match[str]") -> str:
+    header = match.group("header")
+    return f"{header}: [redacted]" if header else "[redacted]"
 
 
 def _sanitize_autonomy_error(
@@ -455,7 +465,7 @@ def _sanitize_autonomy_error(
     safe) and a redacted, length-capped rendering of its message — never the
     raw provider payload.
     """
-    text = _AUTONOMY_ERROR_SENSITIVE_RE.sub(r"\1: [redacted]", str(exc))
+    text = _AUTONOMY_ERROR_SENSITIVE_RE.sub(_redact_autonomy_error_match, str(exc))
     if len(text) > _AUTONOMY_ERROR_MESSAGE_MAX_LEN:
         text = text[:_AUTONOMY_ERROR_MESSAGE_MAX_LEN].rstrip() + "…[truncated]"
     return {"message_id": message_id, "error_type": type(exc).__name__, "error": text}
@@ -1541,13 +1551,16 @@ class EmailTriageAgent(
                     executed = self._autonomy_execute(action_type, row)
                 except Exception as exc:
                     consecutive_failures += 1
-                    report["errors"].append(_sanitize_autonomy_error(message_id, exc))
+                    sanitized_error = _sanitize_autonomy_error(message_id, exc)
+                    report["errors"].append(sanitized_error)
+                    # Log the SANITIZED text, not the raw exception — `gaia
+                    # diagnostics` can bundle log files off-box too (#2625/C5).
                     logger.warning(
                         "autonomy cycle: row %s (%s) failed: %s: %s",
                         message_id,
                         action_type,
-                        type(exc).__name__,
-                        exc,
+                        sanitized_error["error_type"],
+                        sanitized_error["error"],
                     )
                     if consecutive_failures >= self.AUTONOMY_MAX_CONSECUTIVE_FAILURES:
                         report["stopped"] = "consecutive_failures"
@@ -1583,13 +1596,15 @@ class EmailTriageAgent(
                     except Exception as exc:
                         # Logged only — the row already succeeded and stays
                         # in `executed`; an audit-trail write failing must
-                        # not un-succeed it.
+                        # not un-succeed it. Sanitized for the same reason as
+                        # the execute-failure log above (#2625/C5).
+                        sanitized = _sanitize_autonomy_error(message_id, exc)
                         logger.warning(
                             "autonomy cycle: record_autonomy_action failed "
                             "for already-executed row %s: %s: %s",
                             message_id,
-                            type(exc).__name__,
-                            exc,
+                            sanitized["error_type"],
+                            sanitized["error"],
                         )
                 # A message we once proposed and now act on is resolved — clear
                 # its re-proposal guard so the row can't linger open.
@@ -1599,12 +1614,13 @@ class EmailTriageAgent(
                             self, message_id=message_id, action_type=action_type
                         )
                     except Exception as exc:
+                        sanitized = _sanitize_autonomy_error(message_id, exc)
                         logger.warning(
                             "autonomy cycle: resolve_proposal failed for "
                             "already-executed row %s: %s: %s",
                             message_id,
-                            type(exc).__name__,
-                            exc,
+                            sanitized["error_type"],
+                            sanitized["error"],
                         )
             elif decision.action in ("suggest", "draft"):
                 # Re-proposal guard: a message already proposed and not yet acted

--- a/hub/agents/email/python/gaia_agent_email/agent.py
+++ b/hub/agents/email/python/gaia_agent_email/agent.py
@@ -443,6 +443,12 @@ _AUTONOMY_ERROR_SENSITIVE_RE = re.compile(
     r"|\bbearer\s+\S+",
     re.IGNORECASE,
 )
+# A recipient/sender address embedded in a provider exception (e.g. "delivery
+# failed for alice@example.com") is redacted too — fully, not partially
+# masked. ``message_id`` already identifies which message failed, so the
+# address adds no debugging value a caller doesn't already have, and this
+# report/log text can end up in a public bug report via `gaia diagnostics`.
+_AUTONOMY_ERROR_EMAIL_RE = re.compile(r"[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}")
 #: Hard cap on a sanitized autonomy error's message length (#2625 — C5) — the
 #: length cap alone bounds how much of a raw provider payload can leak even
 #: past the pattern redaction above.
@@ -463,9 +469,12 @@ def _sanitize_autonomy_error(
     (``agent_routes.py``'s ``/autonomy/run``) and can be shipped off-box in a
     ``gaia diagnostics`` bundle. This keeps the exception *type* (always
     safe) and a redacted, length-capped rendering of its message — never the
-    raw provider payload.
+    raw provider payload. Redaction runs BEFORE the length cap: truncating
+    first could cut a credential or address in half, leaving a mangled
+    fragment the patterns below no longer recognize (and so don't redact).
     """
     text = _AUTONOMY_ERROR_SENSITIVE_RE.sub(_redact_autonomy_error_match, str(exc))
+    text = _AUTONOMY_ERROR_EMAIL_RE.sub("[redacted-email]", text)
     if len(text) > _AUTONOMY_ERROR_MESSAGE_MAX_LEN:
         text = text[:_AUTONOMY_ERROR_MESSAGE_MAX_LEN].rstrip() + "…[truncated]"
     return {"message_id": message_id, "error_type": type(exc).__name__, "error": text}

--- a/hub/agents/email/python/gaia_agent_email/agent.py
+++ b/hub/agents/email/python/gaia_agent_email/agent.py
@@ -429,6 +429,36 @@ def _normalize_plain_text_answer(text: str) -> str:
     return _LATEX_CMD_RE.sub(_sub, text)
 
 
+# Redact common credential/token shapes out of a per-row autonomy failure's
+# exception text before it leaves the process (#2625 — adversarial C5).
+# Provider/HTTP client exceptions routinely embed request/response text —
+# auth headers, cookies, tokens — in ``str(exc)``.
+_AUTONOMY_ERROR_SENSITIVE_RE = re.compile(
+    r"(authorization|bearer|cookie|set-cookie|x-api-key|api[-_]?key|"
+    r"access[-_]?token|refresh[-_]?token)\s*[:=]\s*\S+",
+    re.IGNORECASE,
+)
+#: Hard cap on a sanitized autonomy error's message length (#2625 — C5) — the
+#: length cap alone bounds how much of a raw provider payload can leak even
+#: past the pattern redaction above.
+_AUTONOMY_ERROR_MESSAGE_MAX_LEN = 200
+
+
+def _sanitize_autonomy_error(message_id: Optional[str], exc: Exception) -> Dict[str, Any]:
+    """Redact + length-cap a per-row autonomy failure (#2625 — adversarial C5).
+
+    ``report["errors"]`` is returned verbatim as an HTTP 200 body
+    (``agent_routes.py``'s ``/autonomy/run``) and can be shipped off-box in a
+    ``gaia diagnostics`` bundle. This keeps the exception *type* (always
+    safe) and a redacted, length-capped rendering of its message — never the
+    raw provider payload.
+    """
+    text = _AUTONOMY_ERROR_SENSITIVE_RE.sub(r"\1: [redacted]", str(exc))
+    if len(text) > _AUTONOMY_ERROR_MESSAGE_MAX_LEN:
+        text = text[:_AUTONOMY_ERROR_MESSAGE_MAX_LEN].rstrip() + "…[truncated]"
+    return {"message_id": message_id, "error_type": type(exc).__name__, "error": text}
+
+
 # ---------------------------------------------------------------------------
 # Agent
 # ---------------------------------------------------------------------------
@@ -550,6 +580,14 @@ class EmailTriageAgent(
     # single turn, the agent surfaces a single batch confirm.
     ORGANIZE_BATCH_OP_THRESHOLD = 5
     ORGANIZE_BATCH_SENDER_THRESHOLD = 3
+
+    # #2625 — an unattended cycle must not grind through a systemic outage
+    # logging one identical error per message. This many CONSECUTIVE
+    # per-message `_autonomy_execute` failures (resets on any execute
+    # success; a suggest/draft/confirm/skipped row neither resets nor counts
+    # — it carries no signal about whether the mailbox backend is failing)
+    # stops the cycle early.
+    AUTONOMY_MAX_CONSECUTIVE_FAILURES = 3
 
     def __init__(self, config: Optional[EmailAgentConfig] = None):
         config = config or EmailAgentConfig()
@@ -1413,6 +1451,22 @@ class EmailTriageAgent(
         as the ones that do. A row the candidate map never considered at all
         (no signal, e.g. urgent/needs-response/personal mail) has no
         ``decisions`` entry; it only bumps ``skipped``, same as before.
+
+        Kill pre-emption (#2624): ``self.config.autonomy_level`` is re-read
+        live immediately before each row's execute call, so a kill issued
+        while this cycle is running (same session, single-worker sidecar —
+        ``agent_routes.py``'s REST/CLI surface) stops the batch instead of
+        only affecting the next one. ``report["stopped"]`` names why the
+        loop ended early (``"autonomy_off"`` or ``"consecutive_failures"``),
+        ``None`` when it ran to completion.
+
+        Partial-failure tolerance (#2625): a per-row execute failure is
+        caught, recorded in ``report["errors"]`` (sanitized —
+        :func:`_sanitize_autonomy_error`), and the cycle continues — up to
+        :data:`AUTONOMY_MAX_CONSECUTIVE_FAILURES` CONSECUTIVE failures, past
+        which a systemic outage would otherwise log one identical error per
+        remaining message. A triage-level failure (raised before this loop
+        starts) is NOT a per-message error and still propagates.
         """
         from gaia_agent_email.tools.read_tools import extract_sender_email
         from gaia_agent_email.tools.triage_heuristics import LABEL_IMPORTANT
@@ -1427,6 +1481,8 @@ class EmailTriageAgent(
             "decisions": [],
             "skipped": 0,
             "already_proposed": 0,
+            "errors": [],
+            "stopped": None,
         }
         policy = self._autonomy_policy()
         if not policy.enabled:
@@ -1435,6 +1491,7 @@ class EmailTriageAgent(
         max_messages = int(context.get("max_messages", 25))
         triage = self._triage_all_backends(max_messages=max_messages)
 
+        consecutive_failures = 0
         for row in triage.get("results", []):
             candidate = self._autonomy_candidate(row)
             if candidate is None:
@@ -1469,24 +1526,40 @@ class EmailTriageAgent(
                 }
             )
             if decision.action == "auto":
-                executed = self._autonomy_execute(action_type, row)
-                # Index the action so a later undo is attributed to this scope
-                # and lands a negative signal on the right ledger rows.
-                action_id = executed.get("action_id")
-                if action_id:
-                    trust.record_autonomy_action(
-                        self,
-                        action_id=action_id,
-                        action_type=action_type,
-                        sender=sender,
-                        category=row.get("category", ""),
+                # #2624: re-check the LIVE level, never the frozen `policy`
+                # (its `.level`/`.enabled` are copied once at construction,
+                # before this loop starts, so they can never observe a kill
+                # fired mid-cycle). A plain str attribute is read/write-
+                # atomic under the GIL, so the worst case is staleness of
+                # exactly one row.
+                if self.config.autonomy_level == trust.LEVEL_OFF:
+                    report["stopped"] = "autonomy_off"
+                    break
+                try:
+                    executed = self._autonomy_execute(action_type, row)
+                except Exception as exc:
+                    consecutive_failures += 1
+                    report["errors"].append(
+                        _sanitize_autonomy_error(message_id, exc)
                     )
-                # A message we once proposed and now act on is resolved — clear
-                # its re-proposal guard so the row can't linger open.
-                if message_id:
-                    trust.resolve_proposal(
-                        self, message_id=message_id, action_type=action_type
+                    logger.warning(
+                        "autonomy cycle: row %s (%s) failed: %s: %s",
+                        message_id,
+                        action_type,
+                        type(exc).__name__,
+                        exc,
                     )
+                    if (
+                        consecutive_failures
+                        >= self.AUTONOMY_MAX_CONSECUTIVE_FAILURES
+                    ):
+                        report["stopped"] = "consecutive_failures"
+                        break
+                    continue
+                # #2625: record the row as executed the INSTANT the mutation
+                # succeeds, before the bookkeeping calls below — a
+                # bookkeeping failure must never reclassify an already-
+                # mutated row as an error (adversarial C2/C3).
                 report["executed"].append(
                     {
                         "message_id": message_id,
@@ -1497,6 +1570,45 @@ class EmailTriageAgent(
                         **executed,
                     }
                 )
+                consecutive_failures = 0
+                # Index the action so a later undo is attributed to this scope
+                # and lands a negative signal on the right ledger rows.
+                action_id = executed.get("action_id")
+                if action_id:
+                    try:
+                        trust.record_autonomy_action(
+                            self,
+                            action_id=action_id,
+                            action_type=action_type,
+                            sender=sender,
+                            category=row.get("category", ""),
+                        )
+                    except Exception as exc:
+                        # Logged only — the row already succeeded and stays
+                        # in `executed`; an audit-trail write failing must
+                        # not un-succeed it.
+                        logger.warning(
+                            "autonomy cycle: record_autonomy_action failed "
+                            "for already-executed row %s: %s: %s",
+                            message_id,
+                            type(exc).__name__,
+                            exc,
+                        )
+                # A message we once proposed and now act on is resolved — clear
+                # its re-proposal guard so the row can't linger open.
+                if message_id:
+                    try:
+                        trust.resolve_proposal(
+                            self, message_id=message_id, action_type=action_type
+                        )
+                    except Exception as exc:
+                        logger.warning(
+                            "autonomy cycle: resolve_proposal failed for "
+                            "already-executed row %s: %s: %s",
+                            message_id,
+                            type(exc).__name__,
+                            exc,
+                        )
             elif decision.action in ("suggest", "draft"):
                 # Re-proposal guard: a message already proposed and not yet acted
                 # on must not spawn a duplicate goal every cycle. Without this,
@@ -1666,8 +1778,16 @@ class EmailTriageAgent(
     def set_autonomy_level(self, level: str) -> Dict[str, Any]:
         """Change the autonomy level at runtime (pause / resume / kill switch).
 
-        ``off`` is the kill switch — the next heartbeat is a no-op. Returns the
-        applied status. Raises ``ValueError`` (translated to HTTP 400 at the
+        ``off`` is the kill switch. For a cycle already running against THIS
+        agent object — the REST/CLI session surface on a single-worker
+        sidecar (``agent_routes.py``) — the effect is pre-emptive, not just
+        "the next heartbeat is a no-op" (#2624): ``_run_email_autonomy_cycle``
+        re-reads this live field before executing each row and stops
+        mid-batch. The scheduler is the documented exception — each fire
+        builds its own agent from ``GAIA_EMAIL_AUTONOMY_LEVEL`` and never
+        touches this instance, so a kill issued here does not reach an
+        already-scheduled run (tracked separately). Returns the applied
+        status. Raises ``ValueError`` (translated to HTTP 400 at the
         boundary) on an unknown level rather than silently ignoring it.
         """
         if level not in trust.AUTONOMY_LEVELS:

--- a/hub/agents/email/python/gaia_agent_email/agent.py
+++ b/hub/agents/email/python/gaia_agent_email/agent.py
@@ -444,7 +444,9 @@ _AUTONOMY_ERROR_SENSITIVE_RE = re.compile(
 _AUTONOMY_ERROR_MESSAGE_MAX_LEN = 200
 
 
-def _sanitize_autonomy_error(message_id: Optional[str], exc: Exception) -> Dict[str, Any]:
+def _sanitize_autonomy_error(
+    message_id: Optional[str], exc: Exception
+) -> Dict[str, Any]:
     """Redact + length-cap a per-row autonomy failure (#2625 — adversarial C5).
 
     ``report["errors"]`` is returned verbatim as an HTTP 200 body
@@ -1539,9 +1541,7 @@ class EmailTriageAgent(
                     executed = self._autonomy_execute(action_type, row)
                 except Exception as exc:
                     consecutive_failures += 1
-                    report["errors"].append(
-                        _sanitize_autonomy_error(message_id, exc)
-                    )
+                    report["errors"].append(_sanitize_autonomy_error(message_id, exc))
                     logger.warning(
                         "autonomy cycle: row %s (%s) failed: %s: %s",
                         message_id,
@@ -1549,10 +1549,7 @@ class EmailTriageAgent(
                         type(exc).__name__,
                         exc,
                     )
-                    if (
-                        consecutive_failures
-                        >= self.AUTONOMY_MAX_CONSECUTIVE_FAILURES
-                    ):
+                    if consecutive_failures >= self.AUTONOMY_MAX_CONSECUTIVE_FAILURES:
                         report["stopped"] = "consecutive_failures"
                         break
                     continue

--- a/hub/agents/email/python/gaia_agent_email/agent_routes.py
+++ b/hub/agents/email/python/gaia_agent_email/agent_routes.py
@@ -175,7 +175,9 @@ class _SessionRegistry:
                 continue
             try:
                 setter(trust.LEVEL_OFF)
-            except Exception as exc:  # pragma: no cover - defensive; must not block the rest
+            except (
+                Exception
+            ) as exc:  # pragma: no cover - defensive; must not block the rest
                 logger.warning(
                     "autonomy kill broadcast: failed to stop session %s: %s",
                     session.session_id,

--- a/hub/agents/email/python/gaia_agent_email/agent_routes.py
+++ b/hub/agents/email/python/gaia_agent_email/agent_routes.py
@@ -150,6 +150,41 @@ class _SessionRegistry:
         self.delete(session_id)
         return self.get_or_create(session_id, **config_kwargs)
 
+    def broadcast_kill(self, *, exclude: Optional[str] = None) -> List[str]:
+        """Set every OTHER live session's autonomy level to ``off`` (#2624).
+
+        A kill is a safety action, so it must not depend on the caller
+        naming the right session id: both ``/autonomy`` and
+        ``/autonomy/run`` resolve ``registry.get(session_id)`` against this
+        same process-local map, and nothing reconciles a CLI kill fired at
+        the default ``"cli"`` id against a cycle actually running under a
+        different (e.g. Agent-UI) session — that kill would return 200 and
+        leave the real cycle untouched (adversarial C4). Best-effort per
+        session: one misbehaving agent is logged and skipped rather than
+        blocking the kill for the rest. Returns the session ids actually
+        stopped.
+        """
+        with self._lock:
+            sessions = list(self._sessions.values())
+        killed: List[str] = []
+        for session in sessions:
+            if session.session_id == exclude:
+                continue
+            setter = getattr(session.agent, "set_autonomy_level", None)
+            if not callable(setter):
+                continue
+            try:
+                setter(trust.LEVEL_OFF)
+            except Exception as exc:  # pragma: no cover - defensive; must not block the rest
+                logger.warning(
+                    "autonomy kill broadcast: failed to stop session %s: %s",
+                    session.session_id,
+                    exc,
+                )
+                continue
+            killed.append(session.session_id)
+        return killed
+
 
 def _close_agent(agent: Any) -> None:
     """Best-effort teardown of an agent's DB handles on eviction."""
@@ -161,6 +196,10 @@ def _close_agent(agent: Any) -> None:
             logger.warning("agent session close_db failed: %s", exc)
 
 
+# #2624 — the kill-broadcast above only reaches sessions in THIS process's
+# map. The sidecar's ``server.py`` never passes uvicorn a ``workers>1``
+# (or an external multi-process runner), so one process == the whole
+# registry; that assumption breaks if the sidecar is ever run multi-worker.
 registry = _SessionRegistry()
 
 
@@ -388,7 +427,15 @@ async def autonomy_status(session_id: str) -> Dict[str, Any]:
 
 @router.post("/autonomy")
 async def set_autonomy(request: AutonomyLevelRequest) -> Dict[str, Any]:
-    """Set the autonomy level at runtime — pause/resume/kill (``off``)."""
+    """Set the autonomy level at runtime — pause/resume/kill (``off``).
+
+    Killing (``level="off"``) also broadcasts to every OTHER live session in
+    this process (#2624 — adversarial C4): the caller's session_id might not
+    be the one an autonomy cycle is actually running under (CLI default
+    ``"cli"`` vs. an Agent-UI session), and a kill that only reaches the
+    named session would report success while leaving the real cycle
+    untouched.
+    """
     session = registry.get(request.session_id)
     if session is None:
         raise HTTPException(status_code=404, detail="No such session.")
@@ -398,9 +445,12 @@ async def set_autonomy(request: AutonomyLevelRequest) -> Dict[str, Any]:
             status_code=501, detail="This agent build does not expose autonomy."
         )
     try:
-        return setter(request.level)
+        result = setter(request.level)
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
+    if request.level == trust.LEVEL_OFF:
+        registry.broadcast_kill(exclude=request.session_id)
+    return result
 
 
 @router.post(

--- a/hub/agents/email/python/tests/test_email_agent_routes.py
+++ b/hub/agents/email/python/tests/test_email_agent_routes.py
@@ -528,6 +528,71 @@ class TestAutonomyRoutes:
         )
         assert r.status_code == 400
 
+    def test_run_cycle_returns_200_with_partial_report_on_per_message_error(
+        self, client
+    ):
+        """#2625: a per-message failure inside the cycle must not surface as
+        a bare 500 at the HTTP boundary. ``/autonomy/run`` declares no
+        ``response_model``, so a report carrying the new ``errors``/
+        ``stopped`` keys passes through verbatim with a 200."""
+        self._mk(client)
+        client.post(
+            "/v1/email/agent/autonomy",
+            json={"session_id": "s1", "level": "full"},
+        )
+        partial_report = {
+            "level": "full",
+            "executed": [{"message_id": "m1", "action": "archive"}],
+            "proposals": [],
+            "decisions": [],
+            "skipped": 0,
+            "already_proposed": 0,
+            "errors": [
+                {
+                    "message_id": "m2",
+                    "error_type": "ConnectionError",
+                    "error": "gmail: 502 Bad Gateway",
+                }
+            ],
+            "stopped": None,
+        }
+        agent = client.built["last"]
+        agent.run_autonomy_cycle = lambda context=None: partial_report
+        r = client.post("/v1/email/agent/autonomy/run", json={"session_id": "s1"})
+        assert r.status_code == 200
+        body = r.json()
+        assert body["executed"] == partial_report["executed"]
+        assert body["errors"] == partial_report["errors"]
+        assert body["stopped"] is None
+
+    def test_kill_broadcasts_to_every_other_session(self, client):
+        """#2624/adversarial-C4: the kill can hit a different agent object
+        than the one actually running a cycle — both routes resolve against
+        the module-level registry by session_id, and nothing reconciles a
+        CLI kill fired at the default 'cli' id against a cycle running
+        under a different (e.g. Agent-UI) session. Killing one session must
+        stop every OTHER live session too, not just the one named."""
+        self._mk(client, "s1")
+        self._mk(client, "s2")
+        client.post(
+            "/v1/email/agent/autonomy",
+            json={"session_id": "s1", "level": "earn_trust"},
+        )
+        client.post(
+            "/v1/email/agent/autonomy", json={"session_id": "s2", "level": "full"}
+        )
+
+        r = client.post(
+            "/v1/email/agent/autonomy", json={"session_id": "s1", "level": "off"}
+        )
+        assert r.json()["enabled"] is False
+
+        # s2 was never explicitly killed — the broadcast must have stopped
+        # it anyway.
+        r2 = client.get("/v1/email/agent/autonomy/s2")
+        assert r2.json()["level"] == "off"
+        assert r2.json()["enabled"] is False
+
 
 class TestWorkerDiesWithoutTerminalEvent:
     """The stream must report a dead worker, not close on a blank answer.

--- a/hub/agents/email/python/tests/test_email_autonomy_cycle.py
+++ b/hub/agents/email/python/tests/test_email_autonomy_cycle.py
@@ -988,3 +988,30 @@ def test_cycle_level_failure_still_propagates(tmp_path):
     ):
         with pytest.raises(RuntimeError, match="backend down"):
             agent._run_email_autonomy_cycle()
+
+
+def test_error_report_redacts_and_truncates_sensitive_exception_text(tmp_path):
+    """#2625/adversarial-C5: ``report["errors"]`` is returned verbatim as an
+    HTTP 200 body and can be shipped off-box via ``gaia diagnostics``.
+    Provider/HTTP exceptions routinely embed request/response text — this
+    proves a bearer token embedded in the exception message is redacted and
+    an overlong message is capped, not passed through raw."""
+    messages = _ordered_promo_messages(1)
+    agent = _build_agent(tmp_path, messages, level=LEVEL_FULL)
+
+    secret_message = (
+        "502 Bad Gateway. Authorization: Bearer sekrit-token-abc123 "
+        "request-id=r1 " + ("x" * 500)
+    )
+
+    def _raise(action_type, row):
+        raise ConnectionError(secret_message)
+
+    with patch.object(agent, "_autonomy_execute", side_effect=_raise):
+        report = agent._run_email_autonomy_cycle()
+
+    assert len(report["errors"]) == 1, report["errors"]
+    error_text = report["errors"][0]["error"]
+    assert "sekrit-token-abc123" not in error_text
+    assert "[redacted]" in error_text
+    assert len(error_text) <= 220

--- a/hub/agents/email/python/tests/test_email_autonomy_cycle.py
+++ b/hub/agents/email/python/tests/test_email_autonomy_cycle.py
@@ -1015,3 +1015,51 @@ def test_error_report_redacts_and_truncates_sensitive_exception_text(tmp_path):
     assert "sekrit-token-abc123" not in error_text
     assert "[redacted]" in error_text
     assert len(error_text) <= 220
+
+
+def test_error_report_redacts_email_addresses(tmp_path):
+    """#2625/adversarial-C5 (coordinator follow-up): a recipient/sender
+    address embedded in the exception text must be redacted too, not just
+    credential headers — ``message_id`` already identifies which message
+    failed, so the address adds no debugging value a caller doesn't already
+    have."""
+    messages = _ordered_promo_messages(1)
+    agent = _build_agent(tmp_path, messages, level=LEVEL_FULL)
+
+    def _raise(action_type, row):
+        raise RuntimeError("delivery failed for alice.smith@realdomain.example")
+
+    with patch.object(agent, "_autonomy_execute", side_effect=_raise):
+        report = agent._run_email_autonomy_cycle()
+
+    assert len(report["errors"]) == 1, report["errors"]
+    error_text = report["errors"][0]["error"]
+    assert "alice.smith@realdomain.example" not in error_text
+    assert "[redacted" in error_text
+
+
+def test_error_report_redacts_email_straddling_truncation_boundary(tmp_path):
+    """#2625/adversarial-C5 (coordinator follow-up): redaction must run
+    BEFORE the length cap. Places the email so it STARTS before the cutoff
+    and ENDS after it — if truncation ran first, the cut would land mid-
+    domain, the mangled remainder ("...@realdomain.exam") would no longer
+    match a complete-TLD email pattern, and the (unredacted) local part
+    "alice.smith" would survive into the final report."""
+    from gaia_agent_email.agent import _AUTONOMY_ERROR_MESSAGE_MAX_LEN as cap
+
+    messages = _ordered_promo_messages(1)
+    agent = _build_agent(tmp_path, messages, level=LEVEL_FULL)
+
+    email = "alice.smith@realdomain.example"
+    prefix = "delivery failed: " + "z" * max(0, cap - 15 - len("delivery failed: "))
+    assert len(prefix) < cap < len(prefix) + len(email), "email must straddle the cap"
+
+    def _raise(action_type, row):
+        raise RuntimeError(prefix + email + " (additional trailing context)")
+
+    with patch.object(agent, "_autonomy_execute", side_effect=_raise):
+        report = agent._run_email_autonomy_cycle()
+
+    error_text = report["errors"][0]["error"]
+    assert "alice.smith" not in error_text
+    assert "@realdomain" not in error_text

--- a/hub/agents/email/python/tests/test_email_autonomy_cycle.py
+++ b/hub/agents/email/python/tests/test_email_autonomy_cycle.py
@@ -846,9 +846,7 @@ def test_kill_mid_cycle_stops_the_run(tmp_path):
             agent.config.autonomy_level = LEVEL_OFF
         return result
 
-    with patch.object(
-        agent, "_autonomy_execute", side_effect=_side_effecting_execute
-    ):
+    with patch.object(agent, "_autonomy_execute", side_effect=_side_effecting_execute):
         report = agent._run_email_autonomy_cycle()
 
     assert len(report["executed"]) == 3, report["executed"]

--- a/hub/agents/email/python/tests/test_email_autonomy_cycle.py
+++ b/hub/agents/email/python/tests/test_email_autonomy_cycle.py
@@ -147,6 +147,22 @@ def _security_important_message(
     }
 
 
+def _ordered_promo_messages(n: int, sender: str = "deals@shop.com") -> list:
+    """``n`` PROMOTIONAL messages (``m0``..``m{n-1}``) with strictly
+    decreasing ``internalDate``, so ``FakeGmailBackend.list_messages``'s
+    newest-first sort yields a deterministic, KNOWN row order — required to
+    pin "the Nth call" in the kill/partial-failure tests below, where wall-
+    clock ``time.time()`` timestamps from back-to-back calls could tie.
+    """
+    base_ms = int(time.time() * 1000)
+    messages = []
+    for i in range(n):
+        msg = _promo_message(f"m{i}", sender)
+        msg["internalDate"] = str(base_ms - i)
+        messages.append(msg)
+    return messages
+
+
 def _build_agent(tmp_path: Path, messages, *, level: str, **cfg_kw) -> EmailTriageAgent:
     backend = FakeGmailBackend(user_email="me@example.com")
     for msg in messages:
@@ -796,3 +812,181 @@ class TestAutonomySimulation:
         report = agent._run_email_autonomy_cycle()
         assert report["executed"] == []
         assert len(report["proposals"]) == 1
+
+
+# ---------------------------------------------------------------------------
+# #2624 — the kill switch pre-empts a running cycle
+# ---------------------------------------------------------------------------
+
+
+def test_kill_mid_cycle_stops_the_run(tmp_path):
+    """#2624: a kill fired mid-cycle must pre-empt the run in progress, not
+    only the next one. The live level is flipped to 'off' as a side effect
+    of the 3rd ``_autonomy_execute`` call (mirroring a concurrent CLI/UI
+    kill landing between messages) — the executed count must stop at 3, not
+    run the full batch of 10, and no ``email_autonomy_actions`` row may
+    exist for the un-executed messages.
+
+    This must fail against a fix that re-checks ``policy.enabled`` instead
+    of the live ``self.config.autonomy_level``: ``policy`` is constructed
+    ONCE before the loop with ``level="full"`` frozen in, so
+    ``policy.enabled`` stays True for the rest of the cycle no matter what
+    happens to the live config.
+    """
+    messages = _ordered_promo_messages(10)
+    agent = _build_agent(tmp_path, messages, level=LEVEL_FULL)
+
+    real_execute = agent._autonomy_execute
+    calls = {"n": 0}
+
+    def _side_effecting_execute(action_type, row):
+        calls["n"] += 1
+        result = real_execute(action_type, row)
+        if calls["n"] == 3:
+            agent.config.autonomy_level = LEVEL_OFF
+        return result
+
+    with patch.object(
+        agent, "_autonomy_execute", side_effect=_side_effecting_execute
+    ):
+        report = agent._run_email_autonomy_cycle()
+
+    assert len(report["executed"]) == 3, report["executed"]
+    assert report["stopped"] == "autonomy_off"
+    rows = agent.query("SELECT action_id FROM email_autonomy_actions")
+    assert len(rows) == 3, rows
+
+
+# ---------------------------------------------------------------------------
+# #2625 — a per-message failure keeps the report instead of discarding it
+# ---------------------------------------------------------------------------
+
+
+def test_partial_failure_keeps_earlier_executions_and_records_error(tmp_path):
+    """#2625: a transient per-message failure must not discard the whole
+    report. Earlier executions survive, the failure is recorded (not
+    swallowed), and the cycle continues past it to later rows."""
+    messages = _ordered_promo_messages(5)
+    agent = _build_agent(tmp_path, messages, level=LEVEL_FULL)
+
+    real_execute = agent._autonomy_execute
+    calls = {"n": 0}
+
+    def _flaky_execute(action_type, row):
+        calls["n"] += 1
+        if calls["n"] == 3:
+            raise ConnectionError("gmail: 502 Bad Gateway")
+        return real_execute(action_type, row)
+
+    with patch.object(agent, "_autonomy_execute", side_effect=_flaky_execute):
+        report = agent._run_email_autonomy_cycle()
+
+    # m0, m1 executed; m2 (3rd call) failed and is recorded, not lost; m3, m4
+    # still ran afterward — one transient error does not abandon the batch.
+    assert len(report["executed"]) == 4, report["executed"]
+    assert [e["message_id"] for e in report["executed"]] == ["m0", "m1", "m3", "m4"]
+    assert len(report["errors"]) == 1, report["errors"]
+    error = report["errors"][0]
+    assert error["message_id"] == "m2"
+    assert error["error_type"] == "ConnectionError"
+    assert "502" in error["error"]
+    assert report["stopped"] is None
+
+
+def test_stops_after_three_consecutive_failures(tmp_path):
+    """#2625: a systemic outage (every call failing) must not grind through
+    the whole batch logging one identical error per message — the cycle
+    stops after 3 CONSECUTIVE failures and records why."""
+    messages = _ordered_promo_messages(10)
+    agent = _build_agent(tmp_path, messages, level=LEVEL_FULL)
+
+    def _always_fails(action_type, row):
+        raise ConnectionError("gmail: 503 Service Unavailable")
+
+    with patch.object(agent, "_autonomy_execute", side_effect=_always_fails):
+        report = agent._run_email_autonomy_cycle()
+
+    assert report["executed"] == []
+    assert len(report["errors"]) == 3, report["errors"]
+    assert report["stopped"] == "consecutive_failures"
+
+
+def test_consecutive_failure_counter_resets_on_success(tmp_path):
+    """#2625/adversarial-C6: 'consecutive' must mean consecutive — a success
+    in between resets the counter, so fail/success/fail/success/fail (never
+    3 IN A ROW) must run the whole batch rather than stopping early. An
+    implementation that tallies TOTAL failures instead of a consecutive run
+    would wrongly stop this batch after the 3rd failure (row 5)."""
+    messages = _ordered_promo_messages(5)
+    agent = _build_agent(tmp_path, messages, level=LEVEL_FULL)
+
+    real_execute = agent._autonomy_execute
+    calls = {"n": 0}
+
+    def _alternating(action_type, row):
+        calls["n"] += 1
+        if calls["n"] % 2 == 1:  # calls 1, 3, 5 (m0, m2, m4) fail
+            raise ConnectionError("gmail: 502 Bad Gateway")
+        return real_execute(action_type, row)  # calls 2, 4 (m1, m3) succeed
+
+    with patch.object(agent, "_autonomy_execute", side_effect=_alternating):
+        report = agent._run_email_autonomy_cycle()
+
+    assert len(report["executed"]) == 2, report["executed"]
+    assert len(report["errors"]) == 3, report["errors"]
+    assert report["stopped"] is None
+
+
+def test_record_autonomy_action_failure_does_not_discard_report(tmp_path):
+    """#2625/adversarial-C2-C3: a raise from ``trust.record_autonomy_action``
+    (the audit-trail write AFTER the mailbox mutation already succeeded)
+    must not propagate past the loop and discard the whole report, and must
+    NOT reclassify the already-mutated row into ``report["errors"]`` — the
+    archive really happened. A fix that wraps only ``_autonomy_execute`` in
+    a try/except (matching just the two tests above) passes those but still
+    lets this exception escape and destroy the report — the exact #2625 gap
+    reappearing through the one call the naive tests don't probe."""
+    messages = _ordered_promo_messages(3)
+    agent = _build_agent(tmp_path, messages, level=LEVEL_FULL)
+
+    with patch(
+        "gaia_agent_email.trust.record_autonomy_action",
+        side_effect=RuntimeError("disk full"),
+    ):
+        report = agent._run_email_autonomy_cycle()
+
+    assert len(report["executed"]) == 3, report["executed"]
+    assert report["errors"] == [], report["errors"]
+    for i in range(3):
+        labels = agent._gmail.get_message(f"m{i}").get("labelIds", [])
+        assert "INBOX" not in labels, f"m{i} should really be archived"
+
+
+def test_resolve_proposal_failure_does_not_discard_report(tmp_path):
+    """Same as above for the OTHER bookkeeping call in the auto branch —
+    ``trust.resolve_proposal`` — so both calls C2 flags are covered."""
+    messages = _ordered_promo_messages(3)
+    agent = _build_agent(tmp_path, messages, level=LEVEL_FULL)
+
+    with patch(
+        "gaia_agent_email.trust.resolve_proposal",
+        side_effect=RuntimeError("disk full"),
+    ):
+        report = agent._run_email_autonomy_cycle()
+
+    assert len(report["executed"]) == 3, report["executed"]
+    assert report["errors"] == [], report["errors"]
+
+
+def test_cycle_level_failure_still_propagates(tmp_path):
+    """#2625 (decision 3): triage itself raising is NOT a per-message error
+    — it must still propagate, never be swallowed into a falsely-successful
+    empty report. Only work INSIDE the per-row loop is fault-tolerant."""
+    agent = _build_agent(
+        tmp_path, [_promo_message("m1", "deals@shop.com")], level=LEVEL_FULL
+    )
+    with patch.object(
+        agent, "_triage_all_backends", side_effect=RuntimeError("backend down")
+    ):
+        with pytest.raises(RuntimeError, match="backend down"):
+            agent._run_email_autonomy_cycle()


### PR DESCRIPTION
Closes #2624
Closes #2625

Two safety failures in the part of the email agent that acts on a mailbox unattended.

**The emergency stop didn't stop anything already running.** A kill issued 0.84s into a 25-message run was confirmed as "off" while the run carried on and processed all 25. **And a single message's transient error threw away the whole run's record** — including the record of mail it had *already* archived or marked read, which really happened and stayed that way. The caller got a bare HTTP 500 and was left believing nothing had occurred; the only way to find out what had actually changed was to query the database by hand.

Now the level is re-read between messages, so a kill stops the batch in progress and the report says why it stopped. A per-message failure becomes a recorded line item with everything already done preserved beside it, returned with a 200 instead of discarded.

## Test plan

- [x] Gate (`test_email_autonomy_cycle.py` + `test_trust.py`) — **113 passed**
- [x] Full email-agent suite — **1258 passed** (3 warnings, all from a pre-existing unrelated test that intentionally raises in a worker thread)
- [x] `python util/lint.py --all` — exit 0. That gate does not scan `hub/`, so black/isort/flake8/pylint were also run directly against the diff
- [x] `POST /autonomy/run` exercised against the real route handler, not just the underlying method — returns 200 with the partial report
- [x] **Mutation-tested, twice independently** (worker and reviewer, same mutations, same results):

| Mutation | Result |
|---|---|
| kill check routed through the frozen `TrustPolicy` instead of the live config field | `test_kill_mid_cycle_stops_the_run` fails **alone**, 37 others pass |
| sanitizer reordered to truncate-then-redact | `test_error_report_redacts_email_straddling_truncation_boundary` fails **alone**, leaking `alice.smith@rea…[truncated]` |

The first of those is the one that matters. `TrustPolicy` copies the autonomy level in its constructor, and the policy object is built once before the loop — so the obvious implementation, re-checking `policy.enabled` per row, passes every other test in the suite and still runs all 25 rows after a real kill. That is why the check reads `self.config.autonomy_level` directly.

**Not verified here:** the live CLI kill-timing pair on real hardware. Deferred to the milestone's hardware sweep; the unit test proves the executed count stops short of the batch, but not the wall-clock race.

<details>
<summary>Design decisions, and what is deliberately not in this PR</summary>

**A kill broadcasts to every other live session.** Both the kill route and the run route resolve a session by id, and nothing reconciled the two — so a kill fired with the CLI's default session id while a cycle ran under a different session (an Agent UI session, or a second CLI invocation with an explicit `--session-id`) would return 200, print success, and leave the cycle untouched. A full miss, not a race. For a safety control, stopping more than strictly necessary is the correct failure direction.

**`report["executed"]` is appended the instant the mutation succeeds** — not after the two bookkeeping calls that follow it. Those calls commit to the database and can themselves throw; with the append last, a failure *after* the mailbox was already changed would have been recorded as a row *error*, so the report would claim a message failed that was really archived. A test raises from each bookkeeping call separately, because injecting failures only via the execute call would leave that gap open while everything appeared green.

**A per-message failure continues to the next message, stopping after 3 consecutive failures** (the counter resets on a success — proved with a fail/success/fail/success/fail case). Autonomy is unattended, so one transient provider hiccup should not abandon the batch; a systemic outage should not grind through 100 messages logging 100 identical errors. A **cycle-level** failure, such as the triage call itself raising, still propagates unchanged.

**Errors are sanitized before they leave the process.** The report is returned as an HTTP body *and* written to logs that `gaia diagnostics` bundles into tarballs users attach to public bug reports. Auth headers, tokens and email addresses are redacted and the message is length-capped; redaction runs **before** the cap, since truncating first can cut a credential or address into a fragment the patterns no longer match. Exception *type* is always kept — it is safe and it is the useful part.

**Two follow-ups filed, not fixed here:**
- **#2649** — the kill switch has no effect on *scheduled* cycles. That path is stateless by design: it builds a fresh agent per fire from environment variables and never touches the session registry the CLI mutates. Genuinely separate machinery; needs a shared store or scheduler plumbing.
- **#2651** — the CLI's autonomy-run output does not yet print the new `errors` / `stopped` fields, so a CLI user hitting a partial failure still sees nothing new even though the JSON carries it. API and Agent UI consumers get them today.

**Deliberately declined:** a total-failure-*rate* guard alongside the consecutive cap. That is a new design parameter — what rate, over what window — beyond what this change committed to, and inventing a threshold silently would be worse than leaving it as a stated, undecided enhancement.
</details>
