### PR TITLE
fix(tui): restore the attention card on direct chat --agent launches

### DIFF
--- a/tui/internal/ui/app.go
+++ b/tui/internal/ui/app.go
@@ -232,7 +232,7 @@ func RunAgent(agentID, query, model string, debug bool, timeout time.Duration, c
 		return res.ExitCode, nil
 	}
 
-	model_ := chat.NewChatModel(c, agent.Name, "", debug)
+	model_ := chat.NewChatModelForCatalogAgent(c, agent.ID, agent.Name, debug)
 	if err := run(model_, debug, ctrl); err != nil {
 		return 1, err
 	}

--- a/tui/internal/ui/chat/agentid_test.go
+++ b/tui/internal/ui/chat/agentid_test.go
@@ -1,0 +1,37 @@
+package chat
+
+import "testing"
+
+// RunAgent (the direct `chat --agent` launch) used to construct the model
+// with the display name in the id slot, so the value reaching m.agentID was
+// "Email" instead of the catalog id "email". This pins both launch paths
+// against that regression: a test that only covers the hub path would not
+// have caught it.
+func TestChatModelAgentIDIsCatalogIDNotDisplayNameForBothLaunchPaths(t *testing.T) {
+	cases := []struct {
+		name string
+		m    ChatModel
+	}{
+		{"direct-CLI (RunAgent)", NewChatModelForCatalogAgent(&nullClient{}, "email", "Email", false)},
+		{"hub launch", NewChatModelFromHub(&nullClient{}, "email", "Email", false)},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.m.AgentID(); got != "email" {
+				t.Errorf("AgentID() = %q, want the catalog id %q, not the display name", got, "email")
+			}
+			if got := tc.m.ControlSnapshot().Agent; got != "email" {
+				t.Errorf("ControlSnapshot().Agent = %q, want %q -- the loopback control API reports this", got, "email")
+			}
+		})
+	}
+}
+
+// A direct launch has no RootModel underneath it to handle ReturnToHubMsg, so
+// it must never claim it can return to a hub -- see CanReturnToHub.
+func TestNewChatModelForCatalogAgentDoesNotEnableHubReturn(t *testing.T) {
+	m := NewChatModelForCatalogAgent(&nullClient{}, "email", "Email", false)
+	if m.CanReturnToHub() {
+		t.Fatal("a direct-CLI launch must not enable hub-return")
+	}
+}

--- a/tui/internal/ui/chat/attention_init_test.go
+++ b/tui/internal/ui/chat/attention_init_test.go
@@ -94,6 +94,26 @@ func TestFetchAttentionSkippedWhenInitialQueryPresent(t *testing.T) {
 	}
 }
 
+// newAttentionTestModel above hand-sets m.agentID after construction, which
+// would mask a regression in how RunAgent actually builds the model. This
+// drives the real constructor RunAgent calls, with a display name that
+// differs in case from the id, the way the catalog's real "email"/"Email"
+// entry does.
+func TestFetchAttentionOnOpenViaDirectCLIConstructionUsesCatalogID(t *testing.T) {
+	c := &fakeAttentionClient{data: json.RawMessage(sampleAttentionJSON)}
+	m := NewChatModelForCatalogAgent(c, "email", "Email", false)
+	m.width, m.height = 100, 30
+
+	cmd := m.Init()
+	found := findBatchedMsg(cmd, func(msg tea.Msg) bool {
+		_, ok := msg.(attentionFetchedMsg)
+		return ok
+	})
+	if found == nil {
+		t.Fatal("Init() did not dispatch an attention fetch through the direct-CLI construction path (RunAgent)")
+	}
+}
+
 func TestFetchAttentionSkippedForNonEmailAgent(t *testing.T) {
 	c := &fakeAttentionClient{data: json.RawMessage(sampleAttentionJSON)}
 	m := newAttentionTestModel(t, c, "code", "")
@@ -102,6 +122,32 @@ func TestFetchAttentionSkippedForNonEmailAgent(t *testing.T) {
 	_ = findBatchedMsg(cmd, func(tea.Msg) bool { return false })
 	if c.fetchCalls != 0 {
 		t.Errorf("attention fetch was called %d times for a non-email agent; want 0", c.fetchCalls)
+	}
+}
+
+// The id gate used to fail silently: an agent whose client could serve the
+// attention view but whose agentID happened not to match got no fetch and no
+// explanation. attentionGateMismatch names that condition so it can be
+// logged instead of swallowed.
+func TestAttentionGateMismatchDetectsFetcherClientWithWrongAgentID(t *testing.T) {
+	cases := []struct {
+		name    string
+		agentID string
+		client  client.AgentClient
+		want    bool
+	}{
+		{"matching id, fetcher client", "email", &fakeAttentionClient{}, false},
+		{"mismatched id, fetcher client", "code", &fakeAttentionClient{}, true},
+		{"mismatched id, no fetcher", "code", &nullClient{}, false},
+		{"matching id, no fetcher", "email", &nullClient{}, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			m := newAttentionTestModel(t, tc.client, tc.agentID, "")
+			if got := m.attentionGateMismatch(); got != tc.want {
+				t.Errorf("attentionGateMismatch() = %v, want %v", got, tc.want)
+			}
+		})
 	}
 }
 

--- a/tui/internal/ui/chat/model.go
+++ b/tui/internal/ui/chat/model.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"os"
 	"strings"
 	"time"
 
@@ -183,6 +184,15 @@ func NewChatModelFromHub(c client.AgentClient, agentID, agentName string, debug 
 	return m
 }
 
+// NewChatModelForCatalogAgent creates a standalone ChatModel (esc quits -- see
+// CanReturnToHub) for a real catalog agent, so agentID is the catalog id
+// rather than NewChatModel's default of the display name.
+func NewChatModelForCatalogAgent(c client.AgentClient, agentID, agentName string, debug bool) ChatModel {
+	m := NewChatModel(c, agentName, "", debug)
+	m.agentID = agentID
+	return m
+}
+
 // attentionAgentID is the one agent this on-open fetch applies to today.
 // Scoped by id rather than by capability alone so a future agent that
 // happens to reuse the AttentionFetcher interface for something unrelated
@@ -203,8 +213,24 @@ func (m ChatModel) Init() tea.Cmd {
 		// there's no initial query already about to run a turn, so the
 		// attention view never races the answer to what the user just asked.
 		cmds = append(cmds, m.fetchAttention())
+	} else if m.debug && m.attentionGateMismatch() {
+		// A client that could serve the attention view but an agentID that
+		// doesn't match must not fail with no signal at all.
+		fmt.Fprintf(os.Stderr,
+			"[DEBUG] attention fetch skipped: agentID %q has an AttentionFetcher client but does not match %q\n",
+			m.agentID, attentionAgentID)
 	}
 	return tea.Batch(cmds...)
+}
+
+// attentionGateMismatch reports whether m.client could serve the attention
+// view even though m.agentID didn't earn the fetch.
+func (m ChatModel) attentionGateMismatch() bool {
+	if m.agentID == attentionAgentID {
+		return false
+	}
+	_, hasFetcher := m.client.(client.AttentionFetcher)
+	return hasFetcher
 }
 
 // fetchAttention builds the Cmd that fetches the email agent's read-only

--- a/tui/test/smoke_test.go
+++ b/tui/test/smoke_test.go
@@ -183,6 +183,30 @@ func TestChatModelFromHub(t *testing.T) {
 	}
 }
 
+// A direct launch has no RootModel underneath it to handle ReturnToHubMsg.
+// Constructing it the way NewChatModelFromHub does (fromHub=true) would make
+// Esc dispatch that message into a program that never consumes it -- Esc
+// would silently stop quitting. This pins the direct launch's actual
+// contract: esc quits.
+func TestChatModelDirectCLILaunchQuitsOnEscInsteadOfReturningToHub(t *testing.T) {
+	m := chat.NewChatModelForCatalogAgent(nil, "email", "Email", false)
+
+	if m.CanReturnToHub() {
+		t.Fatal("a direct `chat --agent` launch must not claim it can return to a hub that isn't running")
+	}
+
+	updated, _ := m.Update(tea.WindowSizeMsg{Width: 120, Height: 40})
+	m = updated.(chat.ChatModel)
+
+	_, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEsc})
+	if cmd == nil {
+		t.Fatal("esc produced no command on a direct launch")
+	}
+	if _, ok := cmd().(tea.QuitMsg); !ok {
+		t.Fatalf("esc on a direct launch produced %T, want tea.QuitMsg", cmd())
+	}
+}
+
 func TestBinaryDiscovery(t *testing.T) {
 	cat := catalog.NewCatalog()
 	cat.DiscoverBinaries()


### PR DESCRIPTION
Launching the email agent directly with `gaia chat --agent email` never showed the on-open attention card, even though the identical Agent Hub launch worked. The direct-CLI path built the chat model with the agent's display name ("Email") in the slot the attention gate compares against the catalog id ("email"), so the check silently failed and nothing was fetched or logged. The fix threads the real catalog id through a new constructor that keeps Esc quitting the program — reusing the hub's constructor would have made Esc silently stop working, since a direct launch has no hub screen underneath it to receive that signal.

## Test plan
- [x] `go build ./...` from `tui/` — clean
- [x] `go test ./... -v` from `tui/` — all packages pass
- [x] `go vet ./...` from `tui/` — clean
- [x] `gofmt -l` on every changed file — clean
- [ ] `gaia tui chat --agent email` against a real mailbox shows the attention card on open with no prompt, and Esc quits the program
- [ ] Launching email from the Agent Hub still shows the attention card and Esc returns to the hub

Closes #2654