### PR TITLE
fix(email): reconcile chat prose against the rendered attention card

### DIFF
--- a/hub/agents/email/python/CHANGELOG.md
+++ b/hub/agents/email/python/CHANGELOG.md
@@ -122,6 +122,22 @@ contract version is tracked separately as
   truncation it did not actually need. Fixed at every call site in
   `src/gaia/agents/base/agent.py`, benefiting every agent built on it, not
   just email.
+- **Chat prose no longer contradicts the attention card already on screen
+  (#2636, the other half of the fix above).** The bug as originally filed
+  wasn't the pre-scan guard's territory: the attention card the Go TUI
+  renders (`GET /v1/email/attention`, sections MEETING PROPOSALS/NEEDS
+  REVIEW/ACTION ITEMS) could show real items while the same turn's answer
+  said "no urgent or actionable items found" — because that view is never
+  a tool call (`build_attention_view_impl` has no `@tool` wrapper; it only
+  serves the TUI's on-open render), so the model generating the answer had
+  no way to see it. `answer_grounding` now also reconciles the final
+  answer against the same in-process cache the card was rendered from
+  (extracted into a small new `attention_cache.py` so this stays possible
+  without pulling FastAPI into the dependency-light grounding module), and
+  appends — rather than replaces — a correction naming the card and its
+  coverage when the two disagree. Declines to correct once that cache is
+  older than its own freshness window (120s), so a card the user has since
+  cleared can't get "corrected" back into looking unresolved.
 - **Thread summaries now keep the newest message's open asks (#2641).** A
   thread summary could reflect the opening question and an early reply while
   dropping the newest message entirely — even when that message carried the

--- a/hub/agents/email/python/gaia_agent_email/answer_grounding.py
+++ b/hub/agents/email/python/gaia_agent_email/answer_grounding.py
@@ -22,7 +22,11 @@ from __future__ import annotations
 
 import json
 import re
+import time
 from typing import Any, Dict, Iterator, List, Optional
+
+from gaia_agent_email.attention_cache import ATTENTION_CACHE_TTL_SECONDS
+from gaia_agent_email.attention_cache import peek as _peek_attention_cache
 
 from gaia.logger import get_logger
 
@@ -312,6 +316,125 @@ def _honest_prescan_summary(envelope: Dict[str, Any]) -> str:
 
 
 # ---------------------------------------------------------------------------
+# Guard 4 — negative claims contradicted by the cached ATTENTION CARD (#2636)
+# ---------------------------------------------------------------------------
+#
+# Unlike guard 2 above, the attention view is never a tool result in THIS
+# turn's own trace: ``build_attention_view_impl`` has no ``@tool`` wrapper
+# (#2582 built it purely for the TUI to render on open, via
+# ``GET /v1/email/attention``), so the model generating ``final_answer`` has
+# no way to see it and cannot ground itself against it on its own. The one
+# honest source of "what the user is actually looking at right now" is the
+# process-global cache that route already populated -- ``server.py`` mounts
+# both that route and the agent's ``/query`` surface on one FastAPI app, and
+# the sidecar is single-tenant by design (``_SessionRegistry``, one user's
+# mailbox per process), so there is exactly one attention view to reconcile
+# against, never one per session. This guard is therefore deliberately
+# turn-INDEPENDENT: it does not require any tool call this turn, only that a
+# cached view exists and is still fresh enough to trust.
+
+_ATTENTION_CATEGORY_NOUNS = {
+    "meeting_request": r"meetings?|meeting\s+proposals?",
+    "waiting_on_you": r"(?:messages?\s+)?waiting\s+on\s+you",
+    "needs_review": r"(?:messages?\s+(?:worth|needing)\s+(?:a\s+)?review|reviews?)",
+    "action_item": r"action\s+items?",
+}
+_ATTENTION_CATEGORY_RE = {
+    kind: re.compile(rf"\bno\b[^.!?]{{0,40}}\b(?:{noun})\b", re.IGNORECASE)
+    for kind, noun in _ATTENTION_CATEGORY_NOUNS.items()
+}
+
+_ATTENTION_CATEGORY_LABELS = {
+    "meeting_request": "meeting proposal",
+    "waiting_on_you": "message waiting on you",
+    "needs_review": "message worth a closer look",
+    "action_item": "open action item",
+}
+
+
+def _attention_card_all_clear_claim(text: str) -> bool:
+    return bool(
+        _NO_URGENT_RE.search(text)
+        or _NO_ACTIONABLE_RE.search(text)
+        or _ALL_CLEAR_RE.search(text)
+    )
+
+
+def _attention_item_counts(cached: Dict[str, Any]) -> Dict[str, int]:
+    counts: Dict[str, int] = {}
+    for item in cached.get("items") or []:
+        kind = item.get("kind") if isinstance(item, dict) else None
+        if kind:
+            counts[kind] = counts.get(kind, 0) + 1
+    return counts
+
+
+def find_attention_card_contradiction(final_answer: Optional[str]) -> Optional[str]:
+    """Return a reason when ``final_answer`` asserts absence of a category
+    the cached attention card currently shows as non-empty, ``None`` when
+    there is nothing to reconcile against or the claim is grounded.
+
+    Declines to correct once the cache is older than
+    ``ATTENTION_CACHE_TTL_SECONDS`` -- the same freshness window
+    ``GET /v1/email/attention`` itself uses to decide a cached value is too
+    old to serve without recomputing. Past that window the items the card
+    showed may already be resolved, and asserting they are still open would
+    be #2636's own dishonesty pointed the other way; declining is a refusal
+    to assert something no longer supportable, not a silent fallback.
+    """
+    if not final_answer:
+        return None
+    cached = _peek_attention_cache()
+    if cached is None:
+        return None
+    age = time.time() - cached["_computed_at"]
+    if age > ATTENTION_CACHE_TTL_SECONDS:
+        return None
+    counts = _attention_item_counts(cached)
+    if not counts:
+        return None
+
+    if _attention_card_all_clear_claim(final_answer):
+        total = sum(counts.values())
+        return f"claims no urgent/actionable items while the attention card has {total}"
+
+    for kind, pattern in _ATTENTION_CATEGORY_RE.items():
+        if counts.get(kind) and pattern.search(final_answer):
+            return f"claims no {kind} while the attention card has {counts[kind]}"
+    return None
+
+
+def _attention_card_correction(cached: Dict[str, Any]) -> str:
+    """A short correction naming the surface and its coverage, built
+    straight from the cached envelope's own counts (#2636 AC 2)."""
+    counts = _attention_item_counts(cached)
+    parts = []
+    for kind, label in _ATTENTION_CATEGORY_LABELS.items():
+        n = counts.pop(kind, 0)
+        if n:
+            parts.append(f"{n} {label}{'s' if n != 1 else ''}")
+    for kind, n in counts.items():
+        if n:
+            parts.append(f"{n} {kind}")
+    listing = ", ".join(parts) if parts else "items still open"
+
+    coverage = cached.get("coverage") or {}
+    scanned = coverage.get("scanned")
+    coverage_text = (
+        f"{scanned} messages scanned"
+        if isinstance(scanned, int)
+        else "coverage unknown"
+    )
+    age = max(0.0, time.time() - cached["_computed_at"])
+    age_text = f"{int(age)}s" if age < 60 else f"{int(age // 60)}m"
+
+    return (
+        f"(Your attention card — updated {age_text} ago, {coverage_text} — "
+        f"still shows {listing}.)"
+    )
+
+
+# ---------------------------------------------------------------------------
 # Orchestration — the single call site EmailTriageAgent.process_query uses
 # ---------------------------------------------------------------------------
 
@@ -358,6 +481,22 @@ def ground_final_answer(result: Dict[str, Any]) -> Dict[str, Any]:
         result["result"] = _honest_prescan_summary(envelope or {})
         return result
 
+    # Appended, not replaced (unlike the pre_scan guard above): the false
+    # clause here is typically one clause inside an otherwise-useful answer
+    # (e.g. a drafted reply plus a wrong aside about "no action items"), so
+    # qualifying it costs the user less than scrubbing the whole message.
+    attention_reason = find_attention_card_contradiction(final_answer)
+    if attention_reason:
+        logger.warning(
+            "email agent: appended attention-card correction — %s",
+            attention_reason,
+        )
+        cached = _peek_attention_cache()
+        if cached is not None:
+            final_answer = (
+                final_answer.rstrip() + "\n\n" + _attention_card_correction(cached)
+            )
+
     result["result"] = final_answer
     return result
 
@@ -365,6 +504,7 @@ def ground_final_answer(result: Dict[str, Any]) -> Dict[str, Any]:
 __all__ = [
     "UNGROUNDED_SUCCESS_FALLBACK",
     "decode_stray_unicode_escapes",
+    "find_attention_card_contradiction",
     "find_scaffolding_leak",
     "find_ungrounded_success_claim",
     "find_unlicensed_cross_mailbox_claim",

--- a/hub/agents/email/python/gaia_agent_email/api_routes.py
+++ b/hub/agents/email/python/gaia_agent_email/api_routes.py
@@ -2290,6 +2290,9 @@ def get_attention_backends() -> Dict[str, Any]:
 # the live scan, and every call within the freshness window reuses it.
 # ---------------------------------------------------------------------------
 
+from gaia_agent_email import attention_cache as _attention_cache_store  # noqa: E402
+from gaia_agent_email.attention_cache import ATTENTION_CACHE_TTL_SECONDS  # noqa: E402
+
 # Seconds a computed result is served verbatim (stale=False) before the next
 # call attempts a live refresh. Deliberately not parameterized by
 # max_messages — the TUI always calls this with its default, and keying the
@@ -2300,8 +2303,6 @@ def get_attention_backends() -> Dict[str, Any]:
 # not here, so ``answer_grounding.py``'s prose-vs-card contradiction guard
 # (#2636) can read the same cache without importing this FastAPI-heavy
 # module — re-exported here so existing call sites/tests are unaffected.
-from gaia_agent_email.attention_cache import ATTENTION_CACHE_TTL_SECONDS  # noqa: E402
-from gaia_agent_email import attention_cache as _attention_cache_store  # noqa: E402
 
 
 def reset_attention_cache() -> None:
@@ -2348,9 +2349,7 @@ def _get_or_refresh_attention_view(
             return _attention_view_with_age(cached, now=now, stale=True)
         raise
     _attention_cache_store.store(fresh, computed_at=now)
-    return _attention_view_with_age(
-        _attention_cache_store.peek(), now=now, stale=False
-    )
+    return _attention_view_with_age(_attention_cache_store.peek(), now=now, stale=False)
 
 
 @router.get(

--- a/hub/agents/email/python/gaia_agent_email/api_routes.py
+++ b/hub/agents/email/python/gaia_agent_email/api_routes.py
@@ -2295,17 +2295,18 @@ def get_attention_backends() -> Dict[str, Any]:
 # max_messages — the TUI always calls this with its default, and keying the
 # cache on every possible parameter combination is complexity this single-
 # consumer surface does not need yet.
-ATTENTION_CACHE_TTL_SECONDS = 120.0
-
-_attention_cache: Optional[Dict[str, Any]] = None
-_attention_cache_lock = threading.Lock()
+#
+# Storage lives in ``attention_cache.py`` (a dependency-light leaf module),
+# not here, so ``answer_grounding.py``'s prose-vs-card contradiction guard
+# (#2636) can read the same cache without importing this FastAPI-heavy
+# module — re-exported here so existing call sites/tests are unaffected.
+from gaia_agent_email.attention_cache import ATTENTION_CACHE_TTL_SECONDS  # noqa: E402
+from gaia_agent_email import attention_cache as _attention_cache_store  # noqa: E402
 
 
 def reset_attention_cache() -> None:
     """Clear the in-process attention-view cache. Test-only seam."""
-    global _attention_cache
-    with _attention_cache_lock:
-        _attention_cache = None
+    _attention_cache_store.reset()
 
 
 def _attention_view_with_age(
@@ -2328,10 +2329,8 @@ def _get_or_refresh_attention_view(
     successfully. With no prior cache at all, the failure propagates —
     there is nothing honest to fall back to.
     """
-    global _attention_cache
     now = time.time()
-    with _attention_cache_lock:
-        cached = _attention_cache
+    cached = _attention_cache_store.peek()
     if (
         cached is not None
         and (now - cached["_computed_at"]) < ATTENTION_CACHE_TTL_SECONDS
@@ -2348,10 +2347,10 @@ def _get_or_refresh_attention_view(
         if cached is not None:
             return _attention_view_with_age(cached, now=now, stale=True)
         raise
-    fresh["_computed_at"] = now
-    with _attention_cache_lock:
-        _attention_cache = fresh
-    return _attention_view_with_age(fresh, now=now, stale=False)
+    _attention_cache_store.store(fresh, computed_at=now)
+    return _attention_view_with_age(
+        _attention_cache_store.peek(), now=now, stale=False
+    )
 
 
 @router.get(

--- a/hub/agents/email/python/gaia_agent_email/attention_cache.py
+++ b/hub/agents/email/python/gaia_agent_email/attention_cache.py
@@ -1,0 +1,66 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""Process-wide cache for the attention view (#2582).
+
+Shared between the FastAPI route that serves it (``api_routes.py``) and the
+answer-grounding guard that reconciles chat prose against it
+(``answer_grounding.py``, #2636). Both consumers live in the same sidecar
+process -- ``server.py`` mounts both routers on one FastAPI app -- and the
+sidecar is single-tenant by design (``_SessionRegistry``'s own invariant in
+``agent_routes.py``: "the sidecar hosts one user's agent"), so a bare
+module-global is correct here, not a shortcut -- there is exactly one
+attention view to cache, never one per session.
+
+This module imports nothing from ``gaia_agent_email`` itself, so
+``answer_grounding.py`` (deliberately dependency-light: no LLM calls, no I/O)
+and ``api_routes.py`` (FastAPI-heavy) can both depend on it without either
+depending on the other.
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+from typing import Any, Dict, Optional
+
+# Seconds a cached attention view is treated as still describing what's on
+# screen. One meaning, two consumers: api_routes.py's /attention route uses
+# it to decide when to recompute; answer_grounding.py's contradiction guard
+# uses the SAME window to decide when it is still safe to assume the cached
+# items are still open (#2636) -- past it, the guard declines to correct
+# rather than risk asserting a since-resolved item is still there.
+ATTENTION_CACHE_TTL_SECONDS = 120.0
+
+_cache: Optional[Dict[str, Any]] = None
+_lock = threading.Lock()
+
+
+def reset() -> None:
+    """Clear the cache. Test-only seam."""
+    global _cache
+    with _lock:
+        _cache = None
+
+
+def store(record: Dict[str, Any], *, computed_at: Optional[float] = None) -> None:
+    """Replace the cached record. ``computed_at`` defaults to now."""
+    global _cache
+    stamped = dict(record)
+    stamped["_computed_at"] = time.time() if computed_at is None else computed_at
+    with _lock:
+        _cache = stamped
+
+
+def peek() -> Optional[Dict[str, Any]]:
+    """The raw cached record (including ``_computed_at``), or ``None`` when
+    nothing has been computed yet this process.
+
+    Never triggers a scan and never mutates the cache -- callers that need
+    age-qualified output (e.g. ``cache_age_seconds``) build it themselves
+    from ``_computed_at``.
+    """
+    with _lock:
+        return _cache
+
+
+__all__ = ["ATTENTION_CACHE_TTL_SECONDS", "peek", "reset", "store"]

--- a/hub/agents/email/python/tests/test_answer_grounding.py
+++ b/hub/agents/email/python/tests/test_answer_grounding.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 
 import json
 import sys
+import time
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -36,10 +37,12 @@ if str(_REPO_ROOT) not in sys.path:
 
 pytest.importorskip("gaia_agent_email")
 
+from gaia_agent_email import attention_cache  # noqa: E402
 from gaia_agent_email.agent import EmailTriageAgent, _SYSTEM_PROMPT  # noqa: E402
 from gaia_agent_email.answer_grounding import (  # noqa: E402
     UNGROUNDED_SUCCESS_FALLBACK,
     decode_stray_unicode_escapes,
+    find_attention_card_contradiction,
     find_scaffolding_leak,
     find_ungrounded_success_claim,
     find_unlicensed_cross_mailbox_claim,
@@ -83,6 +86,57 @@ def _prescan_envelope(**overrides) -> dict:
     }
     base.update(overrides)
     return base
+
+
+def _attention_item(kind: str, **overrides) -> dict:
+    base = {
+        "kind": kind,
+        "message_id": "m1",
+        "thread_id": "t1",
+        "sender": "colleague@example.com",
+        "subject": "subject",
+        "why": "why",
+    }
+    base.update(overrides)
+    return base
+
+
+def _cached_attention_view(*, items: list, scanned: int = 100) -> dict:
+    """A record shaped like ``attention_cache.peek()``'s return value --
+    i.e. what ``GET /v1/email/attention`` last computed (minus
+    ``_computed_at``, which ``_store_attention_view`` stamps separately)."""
+    return {
+        "kind": "email_attention",
+        "items": items,
+        "coverage": {
+            "scanned": scanned,
+            "total_unread": None,
+            "scan_truncated": False,
+            "degraded": False,
+        },
+        "generated_at": "2026-01-01T00:00:00+00:00",
+    }
+
+
+def _store_attention_view(
+    *, items: list, scanned: int = 100, age_seconds: float = 0.0
+) -> None:
+    """Populate ``attention_cache`` as if ``GET /v1/email/attention`` had
+    computed this view ``age_seconds`` ago. Threads ``computed_at`` through
+    explicitly -- ``attention_cache.store`` stamps "now" by default, which
+    would silently discard a deliberately-aged fixture otherwise."""
+    view = _cached_attention_view(items=items, scanned=scanned)
+    attention_cache.store(view, computed_at=time.time() - age_seconds)
+
+
+@pytest.fixture(autouse=True)
+def _clean_attention_cache():
+    """The attention cache is a process-global (#2636) -- reset it around
+    every test in this module so one test's cached view can never leak into
+    another's assertions, regardless of run order."""
+    attention_cache.reset()
+    yield
+    attention_cache.reset()
 
 
 # ---------------------------------------------------------------------------
@@ -387,6 +441,118 @@ class TestGroundFinalAnswer:
 
 
 # ---------------------------------------------------------------------------
+# find_attention_card_contradiction — reconciles prose against the cached
+# attention view (#2636), which is NEVER a tool result in this turn's own
+# trace (build_attention_view_impl has no @tool wrapper -- #2582 built it
+# purely for the TUI's on-open render), so this guard is turn-INdependent
+# by necessity: it reads the same process-global cache api_routes.py's
+# GET /v1/email/attention already serves the TUI from.
+# ---------------------------------------------------------------------------
+
+
+class TestFindAttentionCardContradiction:
+    def test_no_cache_at_all_is_never_flagged(self):
+        # Card never rendered this process -- nothing to reconcile against,
+        # not a hidden fallback (there is genuinely no known card state).
+        assert (
+            find_attention_card_contradiction("No urgent or actionable items found.")
+            is None
+        )
+
+    def test_cached_but_empty_items_is_never_flagged(self):
+        _store_attention_view(items=[])
+        assert find_attention_card_contradiction("Nothing needs you right now.") is None
+
+    def test_all_clear_claim_contradicted_by_non_empty_card(self):
+        _store_attention_view(items=[_attention_item("action_item")], scanned=7)
+        reason = find_attention_card_contradiction(
+            "No urgent or actionable items found."
+        )
+        assert reason is not None
+        assert "1" in reason
+
+    def test_category_specific_claim_contradicted(self):
+        _store_attention_view(items=[_attention_item("meeting_request")])
+        reason = find_attention_card_contradiction("No meeting proposals right now.")
+        assert reason is not None
+        assert "meeting_request" in reason
+
+    def test_grounded_claim_naming_the_real_count_is_not_flagged(self):
+        _store_attention_view(items=[_attention_item("action_item")])
+        text = "You have 1 action item to review."
+        assert find_attention_card_contradiction(text) is None
+
+    def test_stale_cache_past_ttl_declines_to_correct(self):
+        from gaia_agent_email.attention_cache import ATTENTION_CACHE_TTL_SECONDS
+
+        _store_attention_view(
+            items=[_attention_item("action_item")],
+            age_seconds=ATTENTION_CACHE_TTL_SECONDS + 1,
+        )
+        # The card may since have been cleared -- correcting from data this
+        # old would risk asserting a since-resolved item is still open,
+        # which is #2636's own dishonesty pointed the other way.
+        assert find_attention_card_contradiction("No action items right now.") is None
+
+    def test_cache_just_within_ttl_still_corrects(self):
+        from gaia_agent_email.attention_cache import ATTENTION_CACHE_TTL_SECONDS
+
+        _store_attention_view(
+            items=[_attention_item("action_item")],
+            age_seconds=ATTENTION_CACHE_TTL_SECONDS - 1,
+        )
+        assert (
+            find_attention_card_contradiction("No action items right now.") is not None
+        )
+
+    def test_empty_or_missing_answer_never_flagged(self):
+        _store_attention_view(items=[_attention_item("action_item")])
+        assert find_attention_card_contradiction("") is None
+        assert find_attention_card_contradiction(None) is None
+
+
+# ---------------------------------------------------------------------------
+# ground_final_answer wiring for the attention-card guard -- appends a
+# correction rather than replacing (unlike the pre_scan guard above): the
+# false clause here is typically one clause inside an otherwise-useful
+# answer, so scrubbing the whole message is a worse trade for the user than
+# qualifying it (#2636).
+# ---------------------------------------------------------------------------
+
+
+class TestGroundFinalAnswerAttentionCard:
+    def test_appends_correction_without_destroying_original_text(self):
+        _store_attention_view(
+            items=[_attention_item("action_item"), _attention_item("meeting_request")],
+            scanned=42,
+        )
+        result = {
+            "result": "Hi! No urgent or actionable items found.",
+            "conversation": [],
+        }
+        out = ground_final_answer(result)
+        assert "Hi! No urgent or actionable items found." in out["result"]
+        assert "attention card" in out["result"].lower()
+        assert "42" in out["result"]
+
+    def test_no_cache_leaves_the_answer_untouched(self):
+        result = {"result": "No urgent or actionable items found.", "conversation": []}
+        out = ground_final_answer(result)
+        assert out["result"] == "No urgent or actionable items found."
+
+    def test_stale_cache_leaves_the_answer_untouched(self):
+        from gaia_agent_email.attention_cache import ATTENTION_CACHE_TTL_SECONDS
+
+        _store_attention_view(
+            items=[_attention_item("action_item")],
+            age_seconds=ATTENTION_CACHE_TTL_SECONDS + 1,
+        )
+        result = {"result": "No action items right now.", "conversation": []}
+        out = ground_final_answer(result)
+        assert out["result"] == "No action items right now."
+
+
+# ---------------------------------------------------------------------------
 # Wiring — EmailTriageAgent.process_query actually calls ground_final_answer
 # ---------------------------------------------------------------------------
 
@@ -467,6 +633,33 @@ class TestProcessQueryWiring:
             ):
                 out = agent.process_query("pre-scan my inbox")
             assert out["result"] == text
+        finally:
+            agent.close_db()
+
+    def test_attention_card_contradiction_is_appended_by_the_real_override(
+        self, tmp_path
+    ):
+        # #2636: the model never called any attention-view tool this turn
+        # (there isn't one -- build_attention_view_impl has no @tool wrapper),
+        # yet the cached card the TUI already rendered this process disagrees
+        # with the answer. The real process_query override must still catch it.
+        _store_attention_view(items=[_attention_item("action_item")], scanned=7)
+        agent = _build_agent(tmp_path)
+        try:
+            canned = {
+                "status": "success",
+                "result": "No urgent or actionable items found.",
+                "conversation": [
+                    {"role": "user", "content": "anything need my attention?"}
+                ],
+                "steps_taken": 1,
+            }
+            with patch(
+                "gaia.agents.base.agent.Agent.process_query", return_value=canned
+            ):
+                out = agent.process_query("anything need my attention?")
+            assert "No urgent or actionable items found." in out["result"]
+            assert "attention card" in out["result"].lower()
         finally:
             agent.close_db()
 

--- a/hub/agents/email/python/tests/test_attention_endpoint.py
+++ b/hub/agents/email/python/tests/test_attention_endpoint.py
@@ -149,25 +149,21 @@ def test_second_call_within_ttl_reuses_cache(attention_client):
 
 
 def test_expired_cache_triggers_recompute(attention_client):
-    from gaia_agent_email import api_routes
+    from gaia_agent_email import api_routes, attention_cache
 
     first = attention_client.get("/v1/email/attention").json()["result"]
     # Force the cached entry to look older than the freshness window.
-    api_routes._attention_cache["_computed_at"] -= (
-        api_routes.ATTENTION_CACHE_TTL_SECONDS + 1
-    )
+    attention_cache.peek()["_computed_at"] -= api_routes.ATTENTION_CACHE_TTL_SECONDS + 1
     second = attention_client.get("/v1/email/attention").json()["result"]
     assert second["stale"] is False
     assert second["cache_age_seconds"] == 0.0
 
 
 def test_total_failure_with_warm_cache_falls_back_to_stale(attention_client):
-    from gaia_agent_email import api_routes
+    from gaia_agent_email import api_routes, attention_cache
 
     attention_client.get("/v1/email/attention")  # warm the cache
-    api_routes._attention_cache["_computed_at"] -= (
-        api_routes.ATTENTION_CACHE_TTL_SECONDS + 1
-    )
+    attention_cache.peek()["_computed_at"] -= api_routes.ATTENTION_CACHE_TTL_SECONDS + 1
     bad = _RaisingGmailBackend(user_email=USER_EMAIL)
     attention_client.app.dependency_overrides[api_routes.get_attention_backends] = (
         lambda: {"google": bad}


### PR DESCRIPTION
Before, the Go TUI's attention card (`GET /v1/email/attention`, sections MEETING PROPOSALS / NEEDS REVIEW / ACTION ITEMS) could show real items while the same turn's chat answer said "no urgent or actionable items found" — because that view is never a tool call the model sees (`build_attention_view_impl` has no `@tool` wrapper; it exists purely to render the on-open card), so nothing grounded the model's prose against it. This completes the half of #2636 that PR #2659 could not reach — #2659 only guarded contradictions against `pre_scan_inbox`'s own tool result, a different, narrower scan.

After: the same deterministic post-check that guards pre-scan claims now also reconciles the final answer against the process-global cache the attention card was rendered from (the TUI and the chat surface share one sidecar process). It declines to correct once that cache is older than its own 120s freshness window, so a card the user has since cleared can't get "corrected" back into looking unresolved — and it appends a correction naming the card and its coverage rather than replacing the answer outright, since the false clause is usually one aside inside an otherwise-useful response.

## Test plan
- [x] `PYTHON_KEYRING_BACKEND=keyring.backends.null.Keyring .venv-wt/bin/python -m pytest tests/unit/agents/email/ tests/unit/email/ hub/agents/email/python/tests/ -q` — 2257 passed
- [x] `.venv-wt/bin/python util/lint.py --all` — all quality gates PASS (mypy warnings pre-existing/non-blocking, unrelated to this change)
- [x] `black`/`isort`/`flake8` run directly against every changed `hub/` file (not covered by `util/lint.py`) — clean on all new/modified lines
- [x] Mutation-tested every guard: core detection, the TTL staleness bound, the no-cache passthrough, the `ground_final_answer` wiring, and the correction wording — each fix reverted alone, its test failed, then restored

Closes #2636