### PR TITLE
fix(email): strip infrastructure banners and quoted trails before every prompt path

### DIFF
--- a/hub/agents/email/python/CHANGELOG.md
+++ b/hub/agents/email/python/CHANGELOG.md
@@ -152,6 +152,26 @@ contract version is tracked separately as
   paragraphs following it were removed. `_BLANK_LINE_RE` is now CRLF-tolerant
   (`\r?\n[ \t]*\r?\n`); the removal cap itself, the bounded scan window, and
   every existing hard-negative case are unchanged.
+- **Banner stripping now reaches every path that builds a prompt from a raw
+  body, including a banner's copies inside a quoted reply trail (#2647,
+  #2653).** #2642 only protected the two thread/read rendering paths;
+  `summarize_message`, the LLM triage follow-up, and meeting-request
+  detection each built their own prompt straight from the decoded body, so
+  a leading banner could still reach the model on those three. All three
+  now call `normalize_email_body` before wrapping the body, same as the
+  read paths. Separately, a live sweep found the bigger source of banner
+  leakage: Outlook inlines the entire prior conversation into every reply,
+  so a banner stripped from one message's own top-of-body still showed up
+  a dozen times inside later replies' quoted trails — enough that one real
+  thread summary named the banner text ("AMD General") as if it were a
+  participant. `_thread_message_blocks` (used only by the two thread-SUMMARY
+  renderers, never a raw-content display tool) now also drops the quoted
+  trail via new `body_normalize.strip_quoted_trail` — reusing
+  `voice_profile.strip_quoted_text`, with a fallback to the original body
+  when a message's sole content is a quote, so a bare "+1" reply is never
+  turned into an empty block. On a 10-message thread with full-history
+  quoting this cut the transcript from 6,131 to 1,967 characters (68%
+  smaller) as a side effect of removing the duplication.
 - **The autonomy kill switch now pre-empts a cycle already running, instead
   of only affecting the next one (#2624).** A kill fired a second into a
   25-message run used to be confirmed as "off" while the run carried on and

--- a/hub/agents/email/python/gaia_agent_email/body_normalize.py
+++ b/hub/agents/email/python/gaia_agent_email/body_normalize.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: MIT
 """Strip known mail-infrastructure banners from an inbound body before it
 reaches the model (#2642), plus the shared quoted-reply-chain and
-signature-block reduction (#2643 lever 4).
+signature-block reduction (#2643 lever 4, #2653).
 
 Conservative by design: recognizes a small, enumerable set of banner
 openers, only at the true top of a body, with a capped removal. A body that
@@ -10,34 +10,34 @@ merely discusses one of these phrases (rather than opening with it) is left
 untouched — see the hard-negative tests in
 ``tests/test_body_normalize_2642.py``.
 
-``normalize_email_body`` (banner + delimiter scrub) is called from
-``tools.read_tools._thread_message_blocks`` and ``_format_message_for_llm``,
-on the raw decoded body, before ``wrap_untrusted_body``. Banner stripping is
-NOT yet wired into ``tools.summarize_tools``, ``tools.llm_triage``, or
-``tools.calendar_tools`` — each builds its own LLM prompt directly from a
-decoded body, and extending it there changes triage/classification output
-for every message, which needs a ``gaia eval agent`` run first (tracked in
-#2647). The delimiter scrub alone (``scrub_delimiter_tokens``) IS safe
-everywhere — a ``<<<TOKEN>>>``-shaped string is never legitimate content —
-so those three paths call it directly before their own
-``wrap_untrusted_body``.
+``normalize_email_body`` (banner + delimiter scrub) is called from every
+body-to-prompt path in this agent: ``tools.read_tools._thread_message_blocks``
+and ``_format_message_for_llm``, plus (#2647) the three prompt builders that
+used to bypass it — ``tools.summarize_tools._build_user_prompt``,
+``tools.llm_triage._build_user_prompt``, and
+``tools.calendar_tools._build_llm_user_prompt``. All five call it on the raw
+decoded body, before ``wrap_untrusted_body``.
 
-``strip_reply_chain_and_signature`` (#2643) is the SHARED seam this module
-and ``voice_profile.py`` were converging toward: rather than a second
-implementation of quote/signature detection, it reuses
-``voice_profile.strip_quoted_text`` (quote-chain removal) and
-``voice_profile._SIGNOFF_RE`` / ``_SIGNOFF_SCAN_LINES`` (the existing
-signoff-phrase detector, originally built for voice-profile STYLE analysis
-in ``analyze_sent_bodies``) to ALSO cut the trailing signature block. Wired
-ONLY into ``tools.read_tools.triage_inbox_impl``'s classifier-escalation
-body — the LLM classification path, where quoted history and a signature
-block are boilerplate that cost tokens without changing the category
-decision. Deliberately NOT wired into the read-tool display paths
-(``get_message`` / ``get_thread`` / ``summarize_thread`` /
-``_format_message_for_llm`` / ``_thread_message_blocks``) — a user asking to
-read a message wants to see the whole thing, quoted chain included; only the
-LLM's OWN classification input is reduced. This is an eval-affecting
-surface (unlike the rest of #2643): it changes body text the model reads.
+``strip_reply_chain_and_signature`` (#2643) and ``strip_quoted_trail``
+(#2653) are the SHARED seam this module and ``voice_profile.py`` were
+converging toward: rather than a second implementation of quote detection,
+both reuse ``voice_profile.strip_quoted_text``.
+``strip_reply_chain_and_signature`` ALSO cuts the trailing signature block
+(via ``voice_profile._SIGNOFF_RE`` / ``_SIGNOFF_SCAN_LINES``, the existing
+signoff-phrase detector originally built for voice-profile STYLE analysis in
+``analyze_sent_bodies``) and is wired ONLY into
+``tools.read_tools.triage_inbox_impl``'s classifier-escalation body — the
+LLM classification path, where quoted history and a signature block are
+boilerplate that cost tokens without changing the category decision.
+``strip_quoted_trail`` cuts only the quote chain (no signature) and is wired
+ONLY into ``tools.read_tools._thread_message_blocks`` — used exclusively by
+the two thread-SUMMARY renderers (``_format_thread_for_summary`` and
+``summarize_thread_impl``), never by a raw-content display tool. Both are
+deliberately NOT wired into ``get_message`` / ``get_thread`` /
+``_format_message_for_llm`` — a user asking to read a message wants to see
+the whole thing, quoted chain included; only the LLM's own summarization or
+classification input is reduced. Both are eval-affecting surfaces (unlike
+the rest of #2643): they change body text the model reads.
 """
 
 from __future__ import annotations
@@ -190,6 +190,41 @@ def normalize_email_body(body: str) -> str:
     removal_end = max(match.end(), _capped_removal_end(window))
     removal_end = min(removal_end, len(window))
     return rest[removal_end:]
+
+
+def strip_quoted_trail(body: str) -> str:
+    """Drop the inlined quoted reply/forward trail from ``body`` for a
+    thread-summary transcript (#2653).
+
+    A banner stripped from a message's own top-of-body by
+    ``normalize_email_body`` still reappears inside every later reply's
+    quoted copy of that message — Outlook (and most clients) inline the
+    entire prior conversation as ``>``-prefixed plaintext. Cutting that
+    trail removes the duplicated banners as a side effect, without adding
+    any new banner pattern, and frees per-message body budget that would
+    otherwise re-read the same content once per reply.
+
+    Reuses ``voice_profile.strip_quoted_text`` — the same seam
+    ``strip_reply_chain_and_signature`` draws on — rather than a second
+    quote-chain detector. Unlike that function, this one does NOT also cut
+    a trailing signature block: a thread summary isn't token-constrained
+    the way the classifier-escalation path is, so only the actual
+    duplication (the quoted trail) is removed.
+
+    Falls back to the original ``body`` when stripping would leave
+    nothing: a message whose sole content is a quote (e.g. a bare forward,
+    or a reply that is entirely quoted context) must still produce a
+    non-empty transcript block rather than silently losing that content.
+    """
+    if not body:
+        return body
+
+    # Deferred import: same module-load-order reason as
+    # strip_reply_chain_and_signature above.
+    from gaia_agent_email.voice_profile import strip_quoted_text
+
+    stripped = strip_quoted_text(body).strip()
+    return stripped if stripped else body
 
 
 def strip_reply_chain_and_signature(body: str) -> str:

--- a/hub/agents/email/python/gaia_agent_email/tools/calendar_tools.py
+++ b/hub/agents/email/python/gaia_agent_email/tools/calendar_tools.py
@@ -32,7 +32,7 @@ from dataclasses import dataclass, field
 from datetime import datetime, timedelta, timezone
 from typing import Any, Callable, Dict, List, Mapping, Optional, Tuple
 
-from gaia_agent_email.body_normalize import scrub_delimiter_tokens
+from gaia_agent_email.body_normalize import normalize_email_body
 from gaia_agent_email.tools.envelope import _envelope_err, _envelope_ok
 from gaia_agent_email.tools.read_tools import DEFAULT_BODY_LIMIT_CHARS
 from gaia_agent_email.verbose import log_tool_call
@@ -410,7 +410,7 @@ def _build_llm_user_prompt(subject: str, body: str) -> str:
     # prompt is trained to treat as data.
     from gaia_agent_email.tools.read_tools import wrap_untrusted_body
 
-    clipped = scrub_delimiter_tokens((body or "").strip())[:DEFAULT_BODY_LIMIT_CHARS]
+    clipped = normalize_email_body((body or "").strip())[:DEFAULT_BODY_LIMIT_CHARS]
     return (
         "Does this email ask to schedule a meeting?\n\n"
         f"Subject: {subject}\n"

--- a/hub/agents/email/python/gaia_agent_email/tools/llm_triage.py
+++ b/hub/agents/email/python/gaia_agent_email/tools/llm_triage.py
@@ -27,7 +27,7 @@ import json
 import re
 from typing import Any, Callable, List, Mapping, Optional
 
-from gaia_agent_email.body_normalize import scrub_delimiter_tokens
+from gaia_agent_email.body_normalize import normalize_email_body
 from gaia_agent_email.tools.triage_heuristics import ALL_CATEGORIES
 
 from gaia.logger import get_logger
@@ -181,7 +181,7 @@ def _build_user_prompt(
         f"Classify this email.\n\n"
         f"Subject: {subject}\n"
         f"From: {sender}\n"
-        f"Body:\n{wrap_untrusted_body(scrub_delimiter_tokens((body or '').strip()))}\n"
+        f"Body:\n{wrap_untrusted_body(normalize_email_body((body or '').strip()))}\n"
     )
 
 

--- a/hub/agents/email/python/gaia_agent_email/tools/read_tools.py
+++ b/hub/agents/email/python/gaia_agent_email/tools/read_tools.py
@@ -25,6 +25,7 @@ from typing import Any, Callable, Dict, List, Mapping, Optional, Tuple
 
 from gaia_agent_email.body_normalize import (
     normalize_email_body,
+    strip_quoted_trail,
     strip_reply_chain_and_signature,
 )
 from gaia_agent_email.config import default_inbox_scan_ceiling
@@ -358,13 +359,20 @@ def _thread_message_blocks(
     duplicate formatting to drift.
 
     Returns ``(blocks, decoded_bodies)`` — ``decoded_bodies`` is each message's
-    decoded, stripped, PRE-truncation body in the same order. A caller that
-    needs one message's own body (e.g. the #2641 meeting-signal scan over
-    the newest message) reuses ``decoded_bodies[-1]`` instead of paying for a
-    second MIME decode of the same payload — which would also feed the
-    heuristic the rendered block's header/delimiter framing rather than the
-    plain body, risking a false match against e.g. the ``Date:`` header's
-    own ``HH:MM:SS``.
+    decoded, banner-stripped, PRE-quote-strip, PRE-truncation body in the same
+    order. A caller that needs one message's own body (e.g. the #2641
+    meeting-signal scan over the newest message) reuses ``decoded_bodies[-1]``
+    instead of paying for a second MIME decode of the same payload — which
+    would also feed the heuristic the rendered block's header/delimiter
+    framing rather than the plain body, risking a false match against e.g.
+    the ``Date:`` header's own ``HH:MM:SS``. The RENDERED block body is
+    additionally quote-trail-stripped (#2653, ``strip_quoted_trail``) — this
+    function is used exclusively by the two thread-SUMMARY renderers, where
+    every earlier message's own block already carries its own content, so an
+    inlined quoted copy of it in a later reply is pure duplication (and, per
+    #2653, where a stripped banner reappears). ``decoded_bodies`` stays
+    quote-INTACT so the #2641 meeting-signal scan and any other reuse of the
+    return value are unaffected by this change.
     """
     total = total_count if total_count is not None else len(messages)
     blocks: List[str] = []
@@ -380,9 +388,12 @@ def _thread_message_blocks(
         body = (body or "").strip()
         body = normalize_email_body(body)  # strip infra banners (#2642)
         decoded_bodies.append(body)
-        rendered_body = body
-        if per_message_body_limit > 0 and len(body) > per_message_body_limit:
-            rendered_body = body[:per_message_body_limit] + "\n...[truncated]"
+        transcript_body = strip_quoted_trail(body)  # drop inlined quote trail (#2653)
+        rendered_body = transcript_body
+        if per_message_body_limit > 0 and len(transcript_body) > per_message_body_limit:
+            rendered_body = (
+                transcript_body[:per_message_body_limit] + "\n...[truncated]"
+            )
         blocks.append(
             f"--- Message {idx} of {total} ---\n"
             f"From: {headers.get('from', '')}\n"

--- a/hub/agents/email/python/gaia_agent_email/tools/summarize_tools.py
+++ b/hub/agents/email/python/gaia_agent_email/tools/summarize_tools.py
@@ -24,7 +24,7 @@ from __future__ import annotations
 
 from typing import Any, Dict, List, Optional
 
-from gaia_agent_email.body_normalize import scrub_delimiter_tokens
+from gaia_agent_email.body_normalize import normalize_email_body
 from gaia_agent_email.gmail_backend import decode_message_body
 from gaia_agent_email.tools.envelope import _envelope_err, _envelope_ok
 from gaia_agent_email.tools.read_tools import wrap_untrusted_body
@@ -110,7 +110,7 @@ def _build_user_prompt(
         "Summarize this email.\n\n"
         f"Subject: {subject}\n"
         f"From: {sender}\n"
-        f"Body:\n{wrap_untrusted_body(scrub_delimiter_tokens((body or '').strip()))}\n"
+        f"Body:\n{wrap_untrusted_body(normalize_email_body((body or '').strip()))}\n"
     )
 
 

--- a/hub/agents/email/python/tests/test_body_normalize_2647.py
+++ b/hub/agents/email/python/tests/test_body_normalize_2647.py
@@ -1,0 +1,116 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""Tests for #2647: extend banner stripping (not just the delimiter scrub,
+which #2642/test_body_normalize_2642.py already covers) to the three prompt
+builders that build an LLM prompt directly from a raw decoded body —
+``summarize_tools._build_user_prompt``, ``llm_triage._build_user_prompt``,
+and ``calendar_tools._build_llm_user_prompt``.
+
+Each assertion targets the CONSTRUCTED PROMPT (deterministic), never model
+output, per the issue's acceptance criteria.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[5]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+pytest.importorskip("gaia_agent_email")
+
+from gaia_agent_email.tools.calendar_tools import (  # noqa: E402
+    _build_llm_user_prompt as _calendar_build_llm_user_prompt,
+)
+from gaia_agent_email.tools.llm_triage import (  # noqa: E402
+    _build_user_prompt as _triage_build_user_prompt,
+)
+from gaia_agent_email.tools.summarize_tools import (  # noqa: E402
+    _build_user_prompt as _summarize_build_user_prompt,
+)
+
+_AMD_GENERAL_BANNER = "AMD General"
+_EXTERNAL_SOURCE_BANNER = (
+    "Caution: This message originated from an External Source. Use proper "
+    "caution\nwhen opening attachments, clicking links, or responding."
+)
+_SUBSTANTIVE_MSG = (
+    "Not a problem. Just remember to assign the issue to yourself, and keep "
+    "the\npull request in draft until CI is clean."
+)
+
+
+class TestSummarizePromptDropsBanners:
+    def test_amd_general_banner_does_not_reach_summarize_prompt(self):
+        body = f"{_AMD_GENERAL_BANNER}\n\n{_SUBSTANTIVE_MSG}"
+        prompt = _summarize_build_user_prompt("Subject", "dev@example.invalid", body)
+        assert _AMD_GENERAL_BANNER not in prompt
+        assert "keep the\npull request in draft until CI is clean" in prompt
+
+    def test_external_source_banner_does_not_reach_summarize_prompt(self):
+        body = f"{_EXTERNAL_SOURCE_BANNER}\n\nok, great! Thanks so much!"
+        prompt = _summarize_build_user_prompt("Subject", "dev@example.invalid", body)
+        assert "originated from an External Source" not in prompt
+        assert "ok, great! Thanks so much!" in prompt
+
+
+class TestTriageClassificationPromptDropsBanners:
+    def test_amd_general_banner_does_not_reach_triage_prompt(self):
+        body = f"{_AMD_GENERAL_BANNER}\n\n{_SUBSTANTIVE_MSG}"
+        prompt = _triage_build_user_prompt("Subject", "dev@example.invalid", body)
+        assert _AMD_GENERAL_BANNER not in prompt
+        assert "keep the\npull request in draft until CI is clean" in prompt
+
+    def test_external_source_banner_does_not_reach_triage_prompt(self):
+        body = f"{_EXTERNAL_SOURCE_BANNER}\n\nok, great! Thanks so much!"
+        prompt = _triage_build_user_prompt("Subject", "dev@example.invalid", body)
+        assert "originated from an External Source" not in prompt
+        assert "ok, great! Thanks so much!" in prompt
+
+
+class TestCalendarMeetingDetectionPromptDropsBanners:
+    def test_amd_general_banner_does_not_reach_calendar_prompt(self):
+        body = f"{_AMD_GENERAL_BANNER}\n\n{_SUBSTANTIVE_MSG}"
+        prompt = _calendar_build_llm_user_prompt("Subject", body)
+        assert _AMD_GENERAL_BANNER not in prompt
+        assert "keep the\npull request in draft until CI is clean" in prompt
+
+    def test_external_source_banner_does_not_reach_calendar_prompt(self):
+        body = f"{_EXTERNAL_SOURCE_BANNER}\n\nok, great! Thanks so much!"
+        prompt = _calendar_build_llm_user_prompt("Subject", body)
+        assert "originated from an External Source" not in prompt
+        assert "ok, great! Thanks so much!" in prompt
+
+
+class TestHardNegativePreservedAcrossAllThreePaths:
+    """A body legitimately ABOUT one of these phrases (not opening with the
+    literal banner) must survive intact on every one of the three paths —
+    the same hard negative #2642 already proves for the thread path."""
+
+    _BODY = (
+        "Quick question - our vendor's mail gateway keeps adding that "
+        "'external source' caution banner to every reply. Is there a way to "
+        "suppress it for trusted partners?"
+    )
+
+    def test_summarize_prompt_preserves_hard_negative(self):
+        prompt = _summarize_build_user_prompt(
+            "Subject", "dev@example.invalid", self._BODY
+        )
+        assert self._BODY in prompt
+
+    def test_triage_prompt_preserves_hard_negative(self):
+        prompt = _triage_build_user_prompt("Subject", "dev@example.invalid", self._BODY)
+        assert self._BODY in prompt
+
+    def test_calendar_prompt_preserves_hard_negative(self):
+        prompt = _calendar_build_llm_user_prompt("Subject", self._BODY)
+        assert self._BODY in prompt
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/hub/agents/email/python/tests/test_thread_quote_strip_2653.py
+++ b/hub/agents/email/python/tests/test_thread_quote_strip_2653.py
@@ -1,0 +1,375 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""Tests for #2653: banner stripping misses banners inside Outlook quoted
+reply trails.
+
+A banner stripped from a message's own top-of-body (#2642) still reappears
+inside the inlined quoted trail of every later reply in a thread, so a
+thread summary can name a classification banner ("AMD General") as a
+participant. This module covers the fix: ``_thread_message_blocks``
+(``tools/read_tools.py``) now cuts the quoted trail out of each rendered
+block via ``body_normalize.strip_quoted_trail`` — reusing
+``voice_profile.strip_quoted_text``, never a second quote-chain detector.
+
+Covered:
+- AC1/AC2: the transcript sent to ``chat.send_messages`` for a multi-reply
+  thread summary contains no classification-banner string, asserted on the
+  constructed prompt (deterministic), never generated prose.
+- AC3: content that exists ONLY in a quoted trail is not lost — a bare
+  "+1" above a quoted question survives, and a message whose SOLE content
+  is a quote does not collapse to an empty block.
+- AC4: per-message/transcript body budget measurably improves on a long
+  thread — before/after sizes recorded in the assertion.
+- AC5 (regression guard): ``strip_quoted_text`` itself, and its existing
+  Sent-mail voice-profile caller path, are unaffected — see
+  ``tests/test_email_voice_profile.py::TestStripQuotedText`` (unchanged,
+  still green) and the sanity check below.
+
+Fixtures use only synthetic ``example.invalid`` addresses and invented
+content — never a real thread (see the plan's Privacy constraint). Uses the
+Gmail-style single-line ``On <date>, <name> <<addr>> wrote:`` attribution
+that ``voice_profile._ATTRIBUTION_RE`` recognizes.
+"""
+
+from __future__ import annotations
+
+import base64
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any, Dict, List
+
+import pytest
+
+# parents[0] = tests/, [1] = email/, [2] = python/, [3] = agents/, [4] = hub/,
+# [5] = repo-root.
+_REPO_ROOT = Path(__file__).resolve().parents[5]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+pytest.importorskip("gaia_agent_email")
+
+from gaia_agent_email import body_normalize  # noqa: E402
+from gaia_agent_email.tools.read_tools import (  # noqa: E402
+    _thread_message_blocks,
+    summarize_thread_impl,
+)
+
+from tests.fixtures.email.fake_gmail import FakeGmailBackend  # noqa: E402
+
+_AMD_GENERAL_BANNER = "AMD General"
+
+
+def _b64url(text: str) -> str:
+    return base64.urlsafe_b64encode(text.encode("utf-8")).decode("ascii").rstrip("=")
+
+
+def _msg(
+    msg_id: str,
+    *,
+    thread_id: str,
+    sender: str,
+    body: str,
+    internal_date_ms: int,
+    date_header: str,
+    subject: str = "Contributing to GAIA",
+) -> Dict[str, Any]:
+    return {
+        "id": msg_id,
+        "threadId": thread_id,
+        "labelIds": ["INBOX"],
+        "snippet": body[:200],
+        "internalDate": str(internal_date_ms),
+        "payload": {
+            "mimeType": "text/plain",
+            "filename": "",
+            "headers": [
+                {"name": "Subject", "value": subject},
+                {"name": "From", "value": sender},
+                {"name": "To", "value": "user@example.invalid"},
+                {"name": "Date", "value": date_header},
+            ],
+            "body": {"data": _b64url(body), "size": len(body)},
+        },
+        "sizeEstimate": len(body),
+    }
+
+
+def _build_backend(messages: List[Dict[str, Any]]) -> FakeGmailBackend:
+    gmail = FakeGmailBackend(user_email="user@example.invalid")
+    for msg in messages:
+        gmail.add_message(msg)
+    return gmail
+
+
+class _CapturingChat:
+    """Records every ``send_messages`` call — the fits path issues exactly
+    one, carrying the full transcript as the user-turn prompt."""
+
+    def __init__(self, *, text: str = "thread summary") -> None:
+        self.calls: List[Dict[str, Any]] = []
+        self._text = text
+
+    def send_messages(self, messages, system_prompt="", **kwargs):
+        content = messages[0].get("content", "") if messages else ""
+        self.calls.append({"system_prompt": system_prompt, "content": content})
+        return SimpleNamespace(text=self._text)
+
+
+_THREAD_ID = "thread-2653-quoted-banner"
+_BASE_MS = 1_800_000_000_000
+
+_M1_BODY = (
+    f"{_AMD_GENERAL_BANNER}\n\n"
+    "There are quite a number of ways that you could help out, from "
+    "testing to reviewing pull requests."
+)
+_M2_BODY = (
+    "Thanks, I'll start with code review.\n\n"
+    "On Wed, Jul 22, 2026 at 6:50 PM, Iniewicz, Tomasz "
+    "<maintainer@example.invalid> wrote:\n"
+    f"> {_AMD_GENERAL_BANNER}\n"
+    ">\n"
+    "> There are quite a number of ways that you could help out, from "
+    "testing to reviewing pull requests.\n"
+)
+_M3_BODY = (
+    "+1\n\n"
+    "On Wed, Jul 22, 2026 at 7:10 PM, dev2@example.invalid wrote:\n"
+    "> Thanks, I'll start with code review.\n"
+    ">\n"
+    "> On Wed, Jul 22, 2026 at 6:50 PM, Iniewicz, Tomasz "
+    "<maintainer@example.invalid> wrote:\n"
+    f"> > {_AMD_GENERAL_BANNER}\n"
+    "> >\n"
+    "> > There are quite a number of ways that you could help out, from "
+    "testing to reviewing pull requests.\n"
+)
+
+_MULTI_REPLY_THREAD = [
+    _msg(
+        "m1",
+        thread_id=_THREAD_ID,
+        sender="Iniewicz, Tomasz <maintainer@example.invalid>",
+        body=_M1_BODY,
+        internal_date_ms=_BASE_MS,
+        date_header="Wed, 22 Jul 2026 18:50:00 -0700",
+    ),
+    _msg(
+        "m2",
+        thread_id=_THREAD_ID,
+        sender="dev2@example.invalid",
+        body=_M2_BODY,
+        internal_date_ms=_BASE_MS + 20 * 60_000,
+        date_header="Wed, 22 Jul 2026 19:10:00 -0700",
+    ),
+    _msg(
+        "m3",
+        thread_id=_THREAD_ID,
+        sender="dev3@example.invalid",
+        body=_M3_BODY,
+        internal_date_ms=_BASE_MS + 40 * 60_000,
+        date_header="Wed, 22 Jul 2026 19:30:00 -0700",
+    ),
+]
+
+
+class TestThreadSummaryPromptExcludesQuotedBanner:
+    """AC1/AC2: the banner reappears in every reply's quoted trail
+    (2 extra occurrences beyond m1's own, stripped by #2642 already); the
+    fix must remove all of them from the constructed prompt."""
+
+    def test_banner_absent_from_prompt_across_every_message(self):
+        # Sanity: the fixture actually reproduces the defect shape — the
+        # banner appears in the RAW bodies of m2 and m3 (inside their
+        # quoted trail), not just m1's own top-of-body.
+        assert _AMD_GENERAL_BANNER in _M2_BODY
+        assert _AMD_GENERAL_BANNER in _M3_BODY
+
+        gmail = _build_backend(_MULTI_REPLY_THREAD)
+        chat = _CapturingChat()
+        summarize_thread_impl(gmail, chat, thread_id=_THREAD_ID)
+
+        assert len(chat.calls) == 1
+        prompt = chat.calls[0]["content"]
+        assert _AMD_GENERAL_BANNER not in prompt, (
+            "quoted-trail copies of the banner must be stripped, not just "
+            "the leading one in m1's own body"
+        )
+
+    def test_every_message_from_header_still_reaches_the_prompt(self):
+        """The real per-message From/Date headers (the actual participant
+        identity) survive stripping — only the inlined BODY quote is cut,
+        never the structural envelope a summary needs to attribute content
+        correctly."""
+        gmail = _build_backend(_MULTI_REPLY_THREAD)
+        chat = _CapturingChat()
+        summarize_thread_impl(gmail, chat, thread_id=_THREAD_ID)
+        prompt = chat.calls[0]["content"]
+        assert "maintainer@example.invalid" in prompt
+        assert "dev2@example.invalid" in prompt
+        assert "dev3@example.invalid" in prompt
+
+    def test_own_new_content_of_each_reply_survives(self):
+        gmail = _build_backend(_MULTI_REPLY_THREAD)
+        chat = _CapturingChat()
+        summarize_thread_impl(gmail, chat, thread_id=_THREAD_ID)
+        prompt = chat.calls[0]["content"]
+        assert "testing to reviewing pull requests" in prompt
+        assert "Thanks, I'll start with code review." in prompt
+        assert "+1" in prompt
+
+    def test_block_count_unchanged(self):
+        ordered = sorted(_MULTI_REPLY_THREAD, key=lambda m: int(m["internalDate"]))
+        blocks, _decoded = _thread_message_blocks(ordered, per_message_body_limit=4000)
+        assert len(blocks) == 3
+        assert "--- Message 1 of 3 ---" in blocks[0]
+        assert "--- Message 3 of 3 ---" in blocks[2]
+
+
+class TestContentPreservationAgainstOverAggressiveStripping:
+    """AC3 — content that exists ONLY in a quoted trail is not lost."""
+
+    def test_bare_plus_one_above_quoted_question_survives(self):
+        body = (
+            "+1\n\n"
+            "On Wed, Jul 22, 2026 at 7:10 PM, dev2@example.invalid wrote:\n"
+            "> Are we all still on for Thursday's sync?\n"
+        )
+        out = body_normalize.strip_quoted_trail(body)
+        assert out.strip() == "+1"
+
+    def test_message_whose_sole_content_is_a_quote_does_not_become_empty(self):
+        """A message with NO original content above the attribution line —
+        e.g. a bare forward — must not collapse to an empty transcript
+        block; the fallback keeps the original (quote included) rather
+        than silently dropping the message's only content."""
+        body = (
+            "On Wed, Jul 22, 2026 at 7:10 PM, dev2@example.invalid wrote:\n"
+            "> Are we all still on for Thursday's sync?\n"
+        )
+        out = body_normalize.strip_quoted_trail(body)
+        assert out.strip(), "stripping a quote-only body must not yield an empty result"
+        assert "Thursday's sync" in out
+
+    def test_block_for_quote_only_message_is_not_empty(self):
+        solo = _msg(
+            "quote-only-1",
+            thread_id="thread-quote-only",
+            sender="dev2@example.invalid",
+            body=(
+                "On Wed, Jul 22, 2026 at 7:10 PM, dev3@example.invalid "
+                "wrote:\n> Are we all still on for Thursday's sync?\n"
+            ),
+            internal_date_ms=_BASE_MS,
+            date_header="Wed, 22 Jul 2026 19:10:00 -0700",
+        )
+        blocks, _decoded = _thread_message_blocks([solo], per_message_body_limit=4000)
+        assert len(blocks) == 1
+        assert "Thursday's sync" in blocks[0]
+
+    def test_plain_reply_with_no_quote_is_unaffected(self):
+        body = "Can you review the attached proposal before our call tomorrow?"
+        assert body_normalize.strip_quoted_trail(body) == body
+
+    def test_empty_body_returns_empty(self):
+        assert body_normalize.strip_quoted_trail("") == ""
+
+
+class TestTranscriptBudgetImprovement:
+    """AC4 — per-message body budget measurably improves on a long thread.
+
+    Builds a 10-message thread where each reply inlines the ENTIRE prior
+    conversation as a quoted trail (the realistic Outlook shape) and
+    compares the actual (quote-stripped) transcript size against the size
+    the same blocks would carry with banner-stripping alone (the #2642
+    behavior), computed independently via ``normalize_email_body`` over the
+    same decoded bodies.
+    """
+
+    @staticmethod
+    def _build_long_thread(n: int) -> List[Dict[str, Any]]:
+        messages = []
+        quoted_so_far = ""
+        for i in range(n):
+            sender = f"dev{i}@example.invalid"
+            new_content = f"Reply number {i}: sounds good, moving forward."
+            if quoted_so_far:
+                body = (
+                    f"{new_content}\n\n"
+                    f"On Wed, Jul 22, 2026 at {6 + i}:00 PM, prior@example.invalid "
+                    "wrote:\n" + quoted_so_far
+                )
+            else:
+                body = new_content
+            messages.append(
+                _msg(
+                    f"m{i}",
+                    thread_id="thread-2653-long",
+                    sender=sender,
+                    body=body,
+                    internal_date_ms=_BASE_MS + i * 60_000,
+                    date_header=f"Wed, 22 Jul 2026 {6 + i}:00:00 -0700",
+                )
+            )
+            # Next message quotes THIS entire body, one quote level deeper.
+            quoted_so_far = "\n".join(f"> {line}" for line in body.splitlines())
+        return messages
+
+    def test_transcript_shrinks_measurably_on_a_long_thread(self):
+        messages = self._build_long_thread(10)
+        ordered = sorted(messages, key=lambda m: int(m["internalDate"]))
+
+        # AFTER: the actual production path (quote trail stripped).
+        blocks_after, _decoded = _thread_message_blocks(
+            ordered, per_message_body_limit=0
+        )
+        after_total = sum(len(b) for b in blocks_after)
+
+        # BEFORE: what #2642 alone (banner-strip, no quote-strip) would have
+        # produced for the same decoded bodies — computed independently via
+        # normalize_email_body, not by re-running a reverted code path.
+        from gaia_agent_email.gmail_backend import decode_message_body
+
+        before_total = 0
+        for msg in ordered:
+            payload = msg.get("payload") or {}
+            raw_body, _ = decode_message_body(payload)
+            normalized = body_normalize.normalize_email_body((raw_body or "").strip())
+            before_total += len(normalized)
+
+        assert after_total < before_total, (
+            f"quote-trail stripping did not shrink the transcript: "
+            f"before={before_total} after={after_total}"
+        )
+        # Record the actual numbers for the PR's evidence (not just a
+        # direction check) — a long thread with O(N) quote duplication
+        # should shrink substantially, not marginally.
+        reduction_pct = (before_total - after_total) / before_total * 100
+        assert reduction_pct > 50, (
+            f"expected a substantial reduction on a 10-message thread with "
+            f"full-history quoting; got before={before_total} "
+            f"after={after_total} ({reduction_pct:.1f}% reduction)"
+        )
+
+
+class TestStripQuotedTextRegressionGuard:
+    """AC5 — ``strip_quoted_text`` and its existing Sent-mail voice-profile
+    caller are unaffected by this change; ``strip_quoted_trail`` reuses it
+    rather than forking it."""
+
+    def test_strip_quoted_trail_delegates_to_the_shared_strip_quoted_text(self):
+        from gaia_agent_email.voice_profile import strip_quoted_text
+
+        body = (
+            "Sounds good, see you then.\n\n"
+            "On Mon, Jun 2, 2026 at 9:00 AM Maria <m@x.com> wrote:\n"
+            "> Are we still on for Thursday?\n"
+        )
+        assert (
+            body_normalize.strip_quoted_trail(body) == strip_quoted_text(body).strip()
+        )
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
Three prompt builders (`summarize_message`, the LLM triage follow-up, and meeting-request detection) built their prompt directly from the raw decoded body, so a mail-infrastructure banner (e.g. a sensitivity marking read as the sender's name) could still reach the model on those paths even though #2642 already protected thread/read rendering. Separately, a live sweep found the bigger leak: Outlook inlines the entire prior conversation into every reply, so a banner stripped from one message's own top-of-body kept reappearing inside later replies' quoted trails — enough that a thread summary once named the banner text as if it were a participant.

Before: those three prompts, and every quoted-trail copy of a message in a thread summary, could carry the raw banner text. After: all five body-to-prompt paths call `normalize_email_body`, and the thread-summary transcript drops the inlined quote trail (reusing the existing `strip_quoted_text`, not a new detector), with a fallback so a message whose sole content is a quote never collapses to an empty block. On a 10-message thread with full-history quoting this cut the transcript from 6,131 to 1,967 characters (68% smaller).

## Test plan

- [x] `PYTHON_KEYRING_BACKEND=keyring.backends.null.Keyring pytest hub/agents/email/python/tests/ tests/unit/agents/email/ tests/unit/email/ -q` — 2278 passed
- [x] New tests assert on the constructed prompt/transcript (deterministic), not model output, per both issues' acceptance criteria
- [x] Content-preservation case covered explicitly: a bare "+1" above a quoted question survives; a message whose sole content is a quote does not become an empty block
- [x] Existing `strip_quoted_text` Sent-mail voice-profile suite (`test_email_voice_profile.py`) reruns green — unaffected
- [x] `black`/`isort`/`flake8` clean on every changed file (repo lint doesn't cover `hub/`, run directly)
- [ ] `gaia eval agent` run against the affected triage/summarize categories — deferred to the dispatcher per this session's constraints

Closes #2647
Closes #2653