### PR TITLE
feat(skills): SKILL.md loader, validator, discovery + gaia skill CLI core

### DIFF
--- a/docs/plans/skill-format.mdx
+++ b/docs/plans/skill-format.mdx
@@ -5,17 +5,17 @@ icon: "puzzle-piece"
 ---
 
 <Info>
-  **Grounds on (exists today):** [`src/gaia/agents/base/tools.py`](https://github.com/amd/gaia/blob/main/src/gaia/agents/base/tools.py) (`@tool`, `_TOOL_REGISTRY`) · [`src/gaia/agents/registry.py`](https://github.com/amd/gaia/blob/main/src/gaia/agents/registry.py) (`KNOWN_TOOLS`, `namespaced_agent_id`) · [`src/gaia/connectors/providers/base.py`](https://github.com/amd/gaia/blob/main/src/gaia/connectors/providers/base.py) (`ConnectorRequirement`) · [`src/gaia/ui/routers/agents.py`](https://github.com/amd/gaia/blob/main/src/gaia/ui/routers/agents.py) (`/api/agents`, the panel to mirror)
+  **Grounds on (exists today):** [`src/gaia/skills/`](https://github.com/amd/gaia/tree/main/src/gaia/skills) — the shipped runtime: `format.py` (parser/writer/validator), `manager.py` (`SkillManager`, discovery + precedence), `loader.py` (`<skill>/<tool>` registration), `permissions.py` (grammar + connector bridge), `cli.py` (`gaia skill`) · [`src/gaia/agents/base/agent.py`](https://github.com/amd/gaia/blob/main/src/gaia/agents/base/agent.py) (`Agent.load_skill`, `unload_skill`, `SKILL_DIRS`, `skill_manager`, `loaded_skills`) · [`src/gaia/agents/base/tools.py`](https://github.com/amd/gaia/blob/main/src/gaia/agents/base/tools.py) (`@tool`, `_TOOL_REGISTRY`) · [`src/gaia/agents/registry.py`](https://github.com/amd/gaia/blob/main/src/gaia/agents/registry.py) (`KNOWN_TOOLS`, `namespaced_agent_id`) · [`src/gaia/connectors/providers/base.py`](https://github.com/amd/gaia/blob/main/src/gaia/connectors/providers/base.py) (`ConnectorRequirement`) · [`src/gaia/ui/routers/agents.py`](https://github.com/amd/gaia/blob/main/src/gaia/ui/routers/agents.py) (`/api/agents`, the panel to mirror)
 
-  **Proposed runtime (not written yet):** the `gaia.skills` loader, the `gaia skill` CLI, and the `/api/skills` router. Every such symbol is marked **PROPOSED** where it appears.
+  **Still proposed (not written yet):** the `/api/skills` router and Agent UI panel, `gaia skill install|remove|search|publish|update` (marketplace, [#2467](https://github.com/amd/gaia/issues/2467)), `gaia skill migrate` (Phase 3), the permission sandbox for local-capability domains, and tier-ceiling enforcement ([#1019](https://github.com/amd/gaia/issues/1019)). Every such symbol is marked **PROPOSED** where it appears.
 </Info>
 
 <Note>
 **Component:** the `SKILL.md` field grammar — the on-disk contract for GAIA's skill ecosystem (issue [#691](https://github.com/amd/gaia/issues/691)).
 
-**Module:** `gaia.skills` — **PROPOSED, greenfield.** No loader, CLI, or registry code exists. The contract is grounded on the live tool registry in `gaia.agents.base.tools`.
+**Module:** `gaia.skills` — **shipped** ([#888](https://github.com/amd/gaia/issues/888)). The parser, validator, discovery, tool loader, permission grammar, and `gaia skill list|info|create|import|export` all exist. The contract is grounded on the live tool registry in `gaia.agents.base.tools`.
 
-**Status:** **Format = decided** (this revision). **Runtime = proposed.** The companion [Agent Skills](/spec/agent-skills) spec owns the *integration surface* (discovery, scoping, progressive disclosure); this document is authoritative for the *field grammar*.
+**Status:** **Format = decided.** **Runtime = Phase 1 shipped**; enforcement (sandbox, tier ceilings), the REST/UI surface, and the marketplace verbs remain proposed. The companion [Agent Skills](/spec/agent-skills) spec owns the *integration surface* (discovery, scoping, progressive disclosure); this document is authoritative for the *field grammar*.
 
 **Target consumers:** [#887](https://github.com/amd/gaia/issues/887) (skill auto-synthesis), [#553](https://github.com/amd/gaia/issues/553) (self-improving agent), [#1451](https://github.com/amd/gaia/issues/1451) (tool-loader Part 3), [#647](https://github.com/amd/gaia/issues/647) (skill marketplace), [#648](https://github.com/amd/gaia/issues/648) (OEM bundling), [#462](https://github.com/amd/gaia/issues/462) (Agent Manifest).
 </Note>
@@ -170,19 +170,33 @@ unique within a discovery root; precedence between roots is defined in
 Permissions follow `<domain>:<level>` with an optional `:scope` qualifier. There
 are no implicit grants — a skill declares every domain it touches.
 
-| Domain | Levels | Maps to |
-|---|---|---|
-| `filesystem` | `read`, `write`, `none` | Local-capability domain (new; enforced by the skill sandbox). |
-| `network` | `read`, `write`, `none` | Connector scope (see bridge below). |
-| `shell` | `execute`, `none` | Local-capability domain (new). |
-| `mcp` | `connect`, `none` | Connector scope (MCP-server connectors). |
-| `env` | `read`, `none` | Environment beyond declared `env_vars`. |
-| `database` | `read`, `write`, `none` | Local-capability domain (new). |
-| `desktop` | `control`, `none` | Local-capability domain (new). |
+| Domain | Levels | Maps to | Runtime state |
+|---|---|---|---|
+| `network` | `read`, `write`, `none` | Connector scope (see bridge below). | **Bridged** — resolves to a `ConnectorRequirement` |
+| `mcp` | `connect`, `none` | Connector scope (MCP-server connectors). | **Bridged** — resolves to a `ConnectorRequirement` |
+| `filesystem` | `read`, `write`, `none` | Local-capability domain (new; needs the skill sandbox). | **Refused at load** |
+| `shell` | `execute`, `none` | Local-capability domain (new). | **Refused at load** |
+| `database` | `read`, `write`, `none` | Local-capability domain (new). | **Refused at load** |
+| `desktop` | `control`, `none` | Local-capability domain (new). | **Refused at load** |
+| `env` | `read`, `none` | Environment beyond declared `env_vars`. | **Refused at load** |
 
 Scopes narrow a grant: `filesystem:read:~/.gaia/data/**`,
 `network:read:*.brave.com`, `shell:execute:git,npm`. An unscoped grant covers
-the whole domain.
+the whole domain — except `mcp:connect`, where a scope is mandatory (below).
+Grammar violations — an empty entry, a missing level, an unknown domain, or a
+level the domain does not define — fail loudly at parse time.
+
+<Warning>
+**A local-capability permission is refused, not sandboxed.** Until the sandbox
+lands ([#1019](https://github.com/amd/gaia/issues/1019)), loading a skill that
+declares `filesystem` / `shell` / `database` / `desktop` / `env` raises
+`SkillPermissionError` naming the offending grants. GAIA will not load a grant it
+cannot enforce, and will not pretend to enforce one.
+
+`<domain>:none` is inert in both directions: it produces no requirement and never
+triggers a refusal, because an explicit *denial* asks for less than the default.
+`filesystem:none` therefore loads fine.
+</Warning>
 
 #### Bridge to the connector grant model — no parallel ledger
 
@@ -195,17 +209,46 @@ inventing a second grant system:
   `ConnectorRequirement(connector_id, scopes, reason)`
   ([`connectors/providers/base.py:23`](https://github.com/amd/gaia/blob/main/src/gaia/connectors/providers/base.py)) —
   the same frozen primitive agents already declare via
-  `REQUIRED_CONNECTORS` ([`agent.py:295`](https://github.com/amd/gaia/blob/main/src/gaia/agents/base/agent.py)).
+  `REQUIRED_CONNECTORS` ([`agent.py:297`](https://github.com/amd/gaia/blob/main/src/gaia/agents/base/agent.py)).
   The skill's `permissions` become the agent's connector requirements when the
-  skill is scoped in.
+  skill is loaded — appended to a **per-instance** copy, never to the ClassVar, so
+  one agent's skill cannot leak requirements into a sibling.
 - `filesystem:*`, `shell:*`, `database:*`, `desktop:*`, `env:*` are **new
-  local-capability domains** with no connector equivalent. They are enforced by
-  the skill sandbox (PROPOSED — see [Phased build](#phased-build)).
+  local-capability domains** with no connector equivalent. Until the skill sandbox
+  lands (PROPOSED — see [Phased build](#phased-build)) a skill declaring one is
+  refused outright.
 
 Per-agent scoping reuses the `namespaced_agent_id` keying
 (`builtin:` / `custom:sha256:` / `installed:`,
 [`registry.py:392`](https://github.com/amd/gaia/blob/main/src/gaia/agents/registry.py))
 that already isolates agent grants today.
+
+#### Two decisions the runtime made where this spec was ambiguous
+
+The bridge above did not say what happens when a permission's scope has no
+counterpart in the connector catalog. The implementation
+([`permissions.py`](https://github.com/amd/gaia/blob/main/src/gaia/skills/permissions.py))
+settled both cases, and these are now part of the contract:
+
+1. **`mcp:connect` must name a catalog connector.** A bare `mcp:connect` is a
+   validation error, not a wildcard — the error lists the available connector ids
+   and points at `gaia connectors list`. So is `mcp:connect:<unknown-id>`. An
+   unscoped MCP grant would mean "connect to any MCP server", which is exactly the
+   ambient authority the permission model exists to prevent.
+2. **An unmatched `network:*` scope resolves to a reserved `network`
+   pseudo-connector-id.** Nothing in the catalog represents raw outbound HTTP, so
+   `network:read:*.brave.com` becomes
+   `ConnectorRequirement(connector_id="network", scopes=("read:*.brave.com",), …)`.
+   If the scope *does* name a real catalog connector, the requirement targets that
+   connector instead.
+
+<Warning>
+**The `network` pseudo-requirement is a declaration surface, not enforcement.** It
+records what egress a skill asked for so `gaia skill info` and a future egress
+policy can read it. **Phase 1 does not enforce network egress** — a loaded skill's
+code can reach any host its process can. Do not treat a
+`network:read:*.brave.com` grant as a firewall.
+</Warning>
 
 ### Security tiers
 
@@ -228,16 +271,18 @@ version bump.
 is a **run-time, per-action** verdict. Security tiers are an **install-time trust
 ladder** that sets the *ceiling* a skill's permissions may reach. They are
 complementary, not the same axis: a `verified` skill still has each action
-adjudicated at run time by governance. This tier system is **greenfield** — it
-does not exist in code yet.
+adjudicated at run time by governance. The tier **field** ships (parsed, defaulted
+to `experimental`, surfaced by `gaia skill info`, and reset to `experimental` on
+`gaia skill import`), but the **ceiling it implies is not yet enforced** — see
+[Phase 2](#phased-build).
 </Note>
 
 ### Tool registration
 
-A skill's `tools` map onto the existing decorator and registry. On load
-(PROPOSED), the runtime registers each `@tool` under a `<skill-name>/<tool-name>`
-namespace into `_TOOL_REGISTRY` to prevent collisions when an agent composes
-multiple skills — the same namespacing
+A skill's `tools` map onto the existing decorator and registry. On load, the
+runtime imports the skill's `tools.py` and registers each `@tool` under a
+`<skill-name>/<tool-name>` namespace into `_TOOL_REGISTRY` to prevent collisions
+when an agent composes multiple skills — the same namespacing
 [Agent Skills](/spec/agent-skills#scoping-into-an-agent) describes. The skill's
 `tools.py` uses the standard `@tool` decorator unchanged:
 
@@ -251,27 +296,63 @@ def search_web(query: str, max_results: int = 5) -> dict:
     ...
 ```
 
-The loader validates that every `tools` entry has a matching `@tool` function,
-parameter names/types match the signature, and the return is JSON-serializable —
-**failing loudly** (no partial load) on mismatch, as
-[Agent Skills](/spec/agent-skills#scoping-into-an-agent) requires.
+**The manifest is the contract, in both directions.** The loader rejects the skill
+— registering nothing — when any of these holds:
+
+| Mismatch | Why it fails |
+|---|---|
+| A declared tool has no `@tool` function | The manifest advertises capability the code does not deliver. If the function exists but is undecorated, the error says so. |
+| `tools.py` registers a tool the manifest does not declare | The manifest is what a user audits before granting; an undeclared tool is an unaudited one. |
+| Parameter names differ from the signature | The error names which side each stray parameter came from. |
+| A parameter's `required` flag contradicts the signature's default | Silent drift between docs and behavior. |
+| A parameter's declared `type` contradicts the annotation | Only checked when the decorator could infer a type — an un-inferable annotation has nothing to contradict. |
+| `tools` declared but no `tools.py` on disk | Either add the module or drop `tools` to make it instruction-only. |
+| `tools.py` fails to import | The error names the exception and points at `requirements.dependencies`. |
+
+Every failure restores `_TOOL_REGISTRY` (and `sys.modules`) byte-for-byte — there
+is **no partial load**, as [Agent Skills](/spec/agent-skills#scoping-into-an-agent)
+requires. Shipping a `tools.py` while declaring no `tools` is not an error: the
+module is simply not imported, and the skill loads instruction-only.
 
 ### CLI
 
-The acceptance-required trio plus the natural neighbors. **All PROPOSED** — no
-`gaia skill` subcommand exists in [`cli.py`](https://github.com/amd/gaia/blob/main/src/gaia/cli.py) yet.
+**Shipped verbs** ([`gaia/skills/cli.py`](https://github.com/amd/gaia/blob/main/src/gaia/skills/cli.py)) —
+authoring and local management. Full flag reference in
+[CLI Reference → Skills](/reference/cli#skills).
 
 ```bash
-gaia skill list                       # acceptance #5
-gaia skill install web-research        # acceptance #5
-gaia skill install some-skill --allow-experimental
-gaia skill remove web-research         # acceptance #5
-gaia skill info web-research
-gaia skill search "web search"
-gaia skill update web-research
-gaia skill migrate ./hermes-skill/ --from auto   # see Compatibility
-gaia skill publish ./my-skill/         # marketplace (#647)
+gaia skill list [--json] [--root agent-bundled|user|claude-import]
+gaia skill info <name> [--json] [--body]
+gaia skill create <name> [--dir DIR] [--description TEXT] [--with-tools] [--force]
+gaia skill import <folder|zip|https-url> [--name NAME] [--force]
+gaia skill export <name> [--output FILE.zip]
 ```
+
+Exit codes are distinct so scripts can branch: `0` ok, `2` usage, `3` not found,
+`4` invalid (including a discovery root containing a malformed skill).
+
+**Still PROPOSED** — the registry/marketplace verbs belong to
+[#2467](https://github.com/amd/gaia/issues/2467) /
+[#647](https://github.com/amd/gaia/issues/647), and `migrate` to Phase 3:
+
+```bash
+gaia skill install web-research        # PROPOSED — marketplace
+gaia skill install some-skill --allow-experimental   # PROPOSED
+gaia skill remove web-research         # PROPOSED — marketplace
+gaia skill search "web search"         # PROPOSED — marketplace
+gaia skill update web-research         # PROPOSED — marketplace
+gaia skill publish ./my-skill/         # PROPOSED — marketplace
+gaia skill migrate ./hermes-skill/ --from auto   # PROPOSED — Phase 3
+```
+
+<Note>
+**The proposed verbs are absent, not stubbed.** `gaia skill install` is not a
+command that prints "not implemented" — it does not parse, so a user cannot
+discover a verb that cannot work. [#691](https://github.com/amd/gaia/issues/691)'s
+acceptance asked for `list`/`install`/`remove`: `list` shipped, and
+`import`/`export` cover the local half of install/remove without a registry. The
+registry-backed pair lands with the marketplace.
+</Note>
 
 ### Agent UI dashboard support
 
@@ -289,8 +370,11 @@ POST   /api/skills/install         # install from registry/path                P
 DELETE /api/skills/{name}          # remove                                    PROPOSED
 ```
 
-There is **no `/api/skills` router today** — the dashboard is greenfield and
-degrades to empty until the loader lands (see [Off-states](#off-states-safe-floors)).
+There is **no `/api/skills` router today** — the dashboard is greenfield. The data
+it needs now exists (`SkillManager.list_skills()`, and `gaia skill list --json` /
+`gaia skill info --json` already emit the list and detail shapes), so the router is
+a thin wrapper rather than new machinery. Until it ships the panel is absent, not
+broken (see [Off-states](#off-states-safe-floors)).
 
 ### Cross-format compatibility & migration
 
@@ -344,6 +428,17 @@ build against `OpenClawAdapter`.
 Six worked examples. The three for existing agents (acceptance #6) declare only
 tool names that exist in the current registry. All parse as YAML; tool skills
 round-trip against their `tools.py`.
+
+<Warning>
+**Several examples declare permissions Phase 1 refuses.** `rag-search` (4a) and
+`file-operations` (4c) declare `filesystem:*`, and the migrated `git-status` (6)
+declares `shell:execute:git`. These are **valid manifests** — they parse and
+validate — but `load_skill` refuses them until the sandbox lands
+([#1019](https://github.com/amd/gaia/issues/1019)), because GAIA will not load a
+grant it cannot enforce. They are kept here as the format's target state; the
+examples that load **today** are the instruction-only ones (1, 3) and the
+`network`/`mcp`-scoped ones (2, 4b).
+</Warning>
 
 <AccordionGroup>
 <Accordion title="1. Minimal instruction-only skill (bare standard)">
@@ -647,9 +742,12 @@ breaks because a GAIA feature is absent.
 | **Bare standard skill** (only `name` + `description`) | Loads as an **instruction-only** skill: `security_tier: experimental`, no tools, no permissions. The most restrictive defaults. Matches [Agent Skills → compatibility rule](/spec/agent-skills#manifest-format). |
 | **No `metadata.gaia` block** | All GAIA fields take their omitted-defaults (above). A standard runtime ignores `metadata.gaia` entirely → lossless both directions. |
 | **`compatibility` / `allowed-tools` present** | Ignored (not part of GAIA's adopted base). The skill still parses. |
-| **`tools_required` names a tool unknown to the framework** | **Fails loudly** at validation — an actionable error names the unresolvable tool, matching the `tools`↔`tools.py` and tier-ceiling checks and GAIA's fail-loudly policy. (A name that is *valid but simply not active in the current agent's registry* is scoping, not a defect: it is omitted from selection and logged, never silently invented — see [Open question 1](#open-questions).) |
-| **Loader not yet shipped** (today) | The format is an inert contract — nothing reads it, so nothing can misbehave. `/api/skills`, the registry, and `migrate` degrade to absent. |
-| **Tier signal unavailable** | Falls to `experimental` — the most-restrictive tier — never to a more-permissive default. |
+| **`tools_required` names a tool unknown to the framework** | **Not yet checked.** The Phase 1 validator coerces `tools_required` to strings and stops there — no catalog lookup runs, because the active registry is assembled dynamically (see [Open question 1](#open-questions)). The field is inert until #1451 consumes it. When the check does land, an unknown name **fails loudly**; a name that is *valid but simply not active in the current agent's registry* stays scoping, not a defect — omitted from selection and logged, never silently invented. |
+| **Skill directory fails to parse** | Skipped from discovery **and surfaced** — logged at ERROR, listed in `SkillManager.discovery_errors`, printed by `gaia skill list`, which exits `4`. Never quietly missing. |
+| **Two roots ship the same skill `name`** | The higher-precedence copy wins and the loser stays visible via `SkillManager.shadowed()` / `gaia skill info`. Precedence is auditable, not silent. |
+| **A skill body references a file outside its own directory** | Rejected — `SkillManager.resource_path` refuses traversal, as does `.zip` import. |
+| **Enforcement layers not yet shipped** | `/api/skills`, the registry, `migrate`, tier ceilings, and the sandbox degrade to **absent**, not permissive: an unenforceable permission refuses the load rather than loading unguarded. |
+| **Tier signal unavailable** | Falls to `experimental` — the most-restrictive tier — never to a more-permissive default. Imported skills are re-stamped `experimental` regardless of the tier they claim. |
 
 **Future-gated phases are additive with precedence.** The `tools_required`
 signal that #1451 consumes returns `[]` cleanly until #887 lands
@@ -690,10 +788,18 @@ OpenClaw `metadata.openclaw`).
 - **`compatibility` and `allowed-tools` are not part of GAIA's base.** The prior
   reliance on `allowed-tools` for permission scoping is removed; permissions come
   from `metadata.gaia.permissions`.
-- **Every runtime symbol is greenfield.** `SkillManager`, `gaia.skills`,
-  `load_skill()`, `~/.gaia/skills/`, the registry REST API, and `/api/skills` do
-  **not** exist in code (verified absent on `main`). They are a contract for
-  unwritten code, marked PROPOSED throughout.
+- **The five-root discovery list is superseded by three.** Project-local
+  `./.gaia/skills/` and the registry-lock root are deferred — see
+  [Agent Skills → Discovery](/spec/agent-skills#discovery-locations).
+- **Still greenfield, still PROPOSED:** the permission sandbox and tier-ceiling
+  enforcement, `/api/skills` and the UI panel, and
+  `gaia skill install|remove|search|publish|update|migrate`. Do not build against
+  these.
+
+**No longer a retraction — these now exist** ([#888](https://github.com/amd/gaia/issues/888)):
+`gaia.skills`, `SkillManager`, `Agent.load_skill`, `~/.gaia/skills/`, and
+`gaia skill list|info|create|import|export`. An earlier revision of this document
+said they were "verified absent on `main`"; that is no longer true.
 </Warning>
 
 ---
@@ -708,7 +814,7 @@ speed. The bar:
 | **Cross-spec field-name match** | Headline (contract) | `tools_required` (and every other emitted field) is byte-identical across #887, #1451, and this spec — zero drift. |
 | **Lossless round-trip** | Correctness | A bare agentskills.io skill loads in GAIA unchanged; a GAIA skill's standard fields parse in a standard runtime with `metadata.gaia` ignored, no parse break. |
 | **Migration fidelity** | Correctness | `gaia skill migrate` output validates against this schema and lands `experimental`. |
-| **No hallucinated runtime** | Grounding | Every cited symbol resolves on `main` or is marked PROPOSED. (Met by this revision.) |
+| **No hallucinated runtime** | Grounding | Every cited symbol resolves on `main` or is marked PROPOSED. (Met — the Phase 1 symbols now resolve in `src/gaia/skills/`.) |
 | **Example validity** | Grounding | Every example parses as YAML; each tool skill's `tools` block round-trips against its `tools.py`. |
 | **Acceptance coverage** | Completeness | 100% of #691's acceptance criteria map to a section (see [Traceability](#acceptance-criteria-traceability)). |
 
@@ -716,10 +822,10 @@ speed. The bar:
 
 ## Phased build
 
-The format (Phase 0) is decided in this PR; the runtime is greenfield and ships
-in additive phases. Each phase holds the prior floor until it lands.
+The format (Phase 0) and the runtime core (Phase 1) have shipped; the remaining
+phases are additive. Each phase holds the prior floor until it lands.
 
-### Phase 0 — Format contract (this revision)
+### Phase 0 — Format contract (**SHIPPED**)
 
 **Success criteria:**
 - Schema decided: adopted base + `metadata.gaia`; `tools` vs `tools_required`
@@ -731,29 +837,58 @@ in additive phases. Each phase holds the prior floor until it lands.
   registry tool names.
 - Traceability covers 100% of #691 acceptance criteria.
 
-### Phase 1 — Loader, validator, CLI core (PROPOSED)
+### Phase 1 — Loader, validator, discovery, CLI core (**SHIPPED**, [#888](https://github.com/amd/gaia/issues/888))
 
-`gaia.skills` parses + validates `metadata.gaia`, registers `tools` under the
-`<skill>/<tool>` namespace into `_TOOL_REGISTRY`, and ships
-`gaia skill list|install|remove`. Discovery roots per
-[Agent Skills](/spec/agent-skills#discovery-loading-and-scoping).
+**What landed:**
 
-**Success criteria:**
-- A tool skill loads and its tools register and call.
-- A bare standard skill loads instruction-only.
-- Validation fails **loudly** on a tools/`tools.py` mismatch or a permission that
-  exceeds the tier ceiling — no partial load.
+- **`gaia.skills.format`** — `SKILL.md` parser, writer, and validator (`Skill`,
+  `SkillTool`, `SkillRequirements`, `GaiaMetadata`, `parse_skill`,
+  `parse_skill_file`, `parse_skill_metadata`, `validate_skill`). Round-trip is
+  identity: unknown top-level keys, other `metadata.<vendor>` namespaces, and
+  unknown `metadata.gaia` keys are all preserved, so passing a foreign skill
+  through GAIA loses nothing. `compatibility` / `allowed-tools` /
+  `disallowed-tools` parse and are ignored, exactly as specified above.
+- **`gaia.skills.manager`** — `SkillManager` over **three** roots
+  (`agent-bundled` → `user` → `claude-import`), progressive disclosure
+  (`discover` = frontmatter, `load` = + body, `resource_path` = on-demand files,
+  traversal-checked), auditable shadowing (`shadowed()`), surfaced parse failures
+  (`discovery_errors`), and optional hot-reload via `start_watching()`.
+- **`gaia.skills.loader`** — imports `tools.py` and registers each `@tool` as
+  `<skill>/<tool>` in `_TOOL_REGISTRY`, cross-checking the manifest against the
+  real signatures. **No partial load:** any failure restores the registry
+  byte-for-byte.
+- **`gaia.skills.permissions`** — the `<domain>:<level>[:scope]` grammar, the
+  connector bridge for `network`/`mcp`, and the loud refusal of local-capability
+  domains.
+- **`Agent.load_skill` / `unload_skill` / `SKILL_DIRS` / `skill_manager` /
+  `loaded_skills`** — plus `get_skills_system_prompt()`, auto-discovered by
+  `_get_mixin_prompts()`, which returns `""` when no skill is loaded so every
+  existing agent's prompt stays byte-identical.
+- **`gaia skill list|info|create|import|export`.**
 
-### Phase 2 — Permission enforcement + tier ceilings + connector bridge (PROPOSED)
+**Success criteria — met:**
+- A tool skill loads and its tools register and call under `<skill>/<tool>`.
+- A bare standard skill loads instruction-only at `security_tier: experimental`.
+- Validation fails **loudly** on a `tools`↔`tools.py` mismatch — missing tool,
+  undeclared extra, parameter-name mismatch, required/optional flip, or type
+  contradiction — with no partial load.
 
-`<domain>:<level>` enforced by the sandbox; `network`/`mcp` permissions resolve
-to `ConnectorRequirement` at scope-time; tier ceiling enforced; `experimental`
-sandbox.
+**Deliberately deferred out of Phase 1:** tier-ceiling enforcement (a permission
+above its tier still loads if its domain is bridged), the project-local
+`./.gaia/skills/` root, the registry-lock root, and network-egress enforcement.
+
+### Phase 2 — Permission enforcement + tier ceilings + sandbox (PROPOSED, [#1019](https://github.com/amd/gaia/issues/1019))
+
+The **connector bridge shipped early**, in Phase 1: `network:*` / `mcp:connect`
+already resolve to `ConnectorRequirement` at load-time. What remains is
+*enforcement* — the sandbox that makes local-capability domains loadable at all,
+tier ceilings, and network-egress policy over the declared `network` requirements.
 
 **Success criteria:**
 - A skill requesting a permission above its tier ceiling fails to load.
-- A `network:*` / `mcp:connect` permission produces the matching connector grant
-  requirement; `filesystem`/`shell`/`database`/`desktop` route to the sandbox.
+- `filesystem`/`shell`/`database`/`desktop`/`env` route to the sandbox and **load**
+  instead of being refused.
+- A declared `network:<level>:<scope>` actually constrains egress.
 
 ### Phase 3 — Agent UI dashboard + migration (PROPOSED)
 
@@ -804,17 +939,23 @@ implementation-level questions for whoever builds the runtime:
    `experimental`? (Also open in
    [Agent Skills → Open questions](/spec/agent-skills#open-questions); resolve in
    one place.)
-5. **`docs/spec/` relocation.** #691 acceptance says "documented in
-   `docs/spec/`"; this doc stays in `docs/plans/` until the loader ships. Does the
-   move to `docs/spec/` (and the `docs.json` update) happen with Phase 1, or
-   earlier?
+5. ~~**`docs/spec/` relocation.**~~ **Settled with Phase 1: this document stays in
+   `docs/plans/`.** [Agent Skills](/spec/agent-skills) is the spec surface — it
+   already lives in `docs/spec/` and satisfies #691's "documented in `docs/spec/`"
+   acceptance. Moving this doc too would split the field grammar from the
+   architecture across two directories for no reader benefit, and would break every
+   inbound `/plans/skill-format` link, including the ones the runtime's own error
+   messages emit (`FORMAT_DOCS_URL` in
+   [`skills/errors.py`](https://github.com/amd/gaia/blob/main/src/gaia/skills/errors.py)
+   points at `https://amd-gaia.ai/docs/plans/skill-format`). Revisit only if the
+   two documents ever merge.
 
 ---
 
 ## Current state of the code
 
-The format is grounded on real primitives; the skill runtime is **entirely
-greenfield**.
+The format is grounded on real primitives, and the Phase 1 runtime now **exists**.
+Only the enforcement, REST/UI, and marketplace layers are greenfield.
 
 | Area | Symbol / fact | `file:line` | State |
 |---|---|---|---|
@@ -831,7 +972,17 @@ greenfield**.
 | Agents UI router | `/api/agents` list/detail/export/import | `ui/routers/agents.py:130`, `:174`, `:184`, `:222` | **Exists** — `/api/skills` mirrors it |
 | Bundle format | `.zip` + `bundle.json`, `BUNDLE_FORMAT_VERSION = 1` | `installer/export_import.py:40` | **Exists** |
 | Builder template | scaffolds `agent.py`, emits no `SKILL.md` | `agents/builder/template.py` | **Exists** |
-| **Skill loader / `SkillManager` / `gaia.skills` / `load_skill` / `gaia skill` CLI / `~/.gaia/skills/` loader / `/api/skills`** | — | **NOT FOUND** | **Greenfield — PROPOSED** |
+| Skill parser / validator | `Skill`, `parse_skill`, `parse_skill_file`, `parse_skill_metadata`, `validate_skill` | `skills/format.py` | **Exists** (#888) |
+| Discovery + precedence | `SkillManager`, `SkillRoot`, `ROOT_AGENT_BUNDLED`/`ROOT_USER`/`ROOT_CLAUDE_IMPORT`, `user_skills_dir()` | `skills/manager.py` | **Exists** (#888) — 3 roots |
+| Tool registration | `register_skill_tools`, `unregister_skill_tools` (`<skill>/<tool>`, no partial load) | `skills/loader.py` | **Exists** (#888) |
+| Permission grammar + bridge | `Permission`, `parse_permissions`, `connector_requirements`, `refuse_unbridged_permissions`, `CONNECTOR_BRIDGED_DOMAINS`, `LOCAL_CAPABILITY_DOMAINS` | `skills/permissions.py` | **Exists** (#888) — bridge only |
+| Agent integration | `load_skill`, `unload_skill`, `SKILL_DIRS`, `skill_manager`, `loaded_skills`, `get_skills_system_prompt` | `agents/base/agent.py` | **Exists** (#888) |
+| CLI | `gaia skill list\|info\|create\|import\|export` | `skills/cli.py` | **Exists** (#888) |
+| Errors | `SkillError`, `SkillValidationError`, `SkillNotFoundError`, `SkillPermissionError` | `skills/errors.py` | **Exists** (#888) |
+| **Permission sandbox / tier-ceiling enforcement** | — | **NOT FOUND** | **Greenfield — PROPOSED** (#1019) |
+| **`/api/skills` router + UI panel** | — | **NOT FOUND** | **Greenfield — PROPOSED** |
+| **`gaia skill install\|remove\|search\|publish\|update\|migrate`** | — | **NOT FOUND** | **Greenfield — PROPOSED** (#2467 / Phase 3) |
+| **Project-local `./.gaia/skills/` + registry-lock root** | — | **NOT FOUND** | **Deferred — PROPOSED** |
 
 ---
 
@@ -868,9 +1019,9 @@ verbatim, mapped to its section and what it guarantees a consumer.
 
 | #691 acceptance criterion | Section | What it guarantees |
 |---|---|---|
-| ☐ SKILL.md spec documented in `docs/spec/` | This doc (kept in `docs/plans/` until the loader ships — see [Open question 5](#open-questions)) | A single authoritative field grammar. |
-| ☐ Permission model defined with granular `domain:level` syntax | [Permission model](#permission-model) | `<domain>:<level>:scope` grammar + the `ConnectorRequirement` bridge — no parallel grant ledger. |
-| ☐ Security tiers defined with promotion path | [Security tiers](#security-tiers) | Three install-time tiers + `experimental→community→verified`, distinct from run-time governance. |
-| ☐ Agent UI configuration dashboard has skills management panel | [Agent UI dashboard support](#agent-ui-dashboard-support) | A `/api/skills` shape mirroring the live `/api/agents` panel (PROPOSED). |
-| ☐ CLI: `gaia skill list`, `install`, `remove` | [CLI](#cli) | The required trio, specified (PROPOSED). |
-| ☐ Example skills written for 3 existing agents | [Example skills](#example-skills) 4a–4c | `rag-search`, `web-research`, `file-operations` — each using only real registry tool names. |
+| ☑ SKILL.md spec documented in `docs/spec/` | [Agent Skills](/spec/agent-skills) is the `docs/spec/` surface; this doc stays in `docs/plans/` as the field grammar — settled, see [Open question 5](#open-questions) | A single authoritative field grammar. |
+| ☑ Permission model defined with granular `domain:level` syntax | [Permission model](#permission-model) | `<domain>:<level>:scope` grammar + the `ConnectorRequirement` bridge — no parallel grant ledger. Grammar and bridge **implemented**; enforcement of local-capability domains deferred (they refuse). |
+| ☑ Security tiers defined with promotion path | [Security tiers](#security-tiers) | Three install-time tiers + `experimental→community→verified`, distinct from run-time governance. Field **implemented**; ceilings deferred to Phase 2. |
+| ☐ Agent UI configuration dashboard has skills management panel | [Agent UI dashboard support](#agent-ui-dashboard-support) | A `/api/skills` shape mirroring the live `/api/agents` panel (**PROPOSED** — Phase 3). |
+| ◐ CLI: `gaia skill list`, `install`, `remove` | [CLI](#cli) | `list` **shipped**, alongside `info`/`create`/`import`/`export`. `install`/`remove` need the registry and land with the marketplace ([#2467](https://github.com/amd/gaia/issues/2467)). |
+| ☑ Example skills written for 3 existing agents | [Example skills](#example-skills) 4a–4c | `rag-search`, `web-research`, `file-operations` — each using only real registry tool names. |

--- a/docs/reference/cli.mdx
+++ b/docs/reference/cli.mdx
@@ -2033,6 +2033,162 @@ Manage agent memory: run day-zero onboarding and view memory statistics.
 
 ---
 
+## Skills
+
+<Card title="Agent Skills Spec" icon="puzzle-piece" href="/spec/agent-skills">
+  Portable `SKILL.md` capabilities — instructions, optional typed tools, and resources an agent loads only when relevant
+</Card>
+
+Author and manage agent skills. A skill is a directory whose only required file is `SKILL.md`; GAIA implements the [Agent Skills](https://agentskills.io) open standard, so a Claude Code skill loads unchanged.
+
+```bash
+gaia skill {list,info,create,import,export} [OPTIONS]
+```
+
+Skills are discovered from three roots, highest precedence first:
+
+| Root label | Location | Writable? |
+|------------|----------|:---------:|
+| `agent-bundled` | An agent package's own `skills/` directory | No |
+| `user` | `~/.gaia/skills/` (honors `GAIA_CONFIG_DIR`) | **Yes** — where `create` and `import` install |
+| `claude-import` | `./.claude/skills/` then `~/.claude/skills/` | No — read-only Claude Code import |
+
+### Subcommands
+
+| Action | Description |
+|--------|-------------|
+| `list` | List every discovered skill with its version, tier, root, and provided tools |
+| `info <name>` | Show one skill's manifest in detail |
+| `create <name>` | Scaffold a new skill directory |
+| `import <source>` | Copy a skill folder, `.zip`, or URL into `~/.gaia/skills/` |
+| `export <name>` | Export a skill to a `.zip` bundle |
+
+<Tabs>
+  <Tab title="list">
+    ```bash
+    gaia skill list [--json] [--root ROOT]
+    ```
+
+    | Option | Description |
+    |--------|-------------|
+    | `--json` | Emit JSON instead of a table (includes roots, shadowed copies, and parse errors) |
+    | `--root` | Only show skills from one root: `agent-bundled` \| `user` \| `claude-import` |
+
+    ```
+    NAME                         VERSION    TIER          ROOT           TOOLS
+    demo-skill                   0.1.0      experimental  user           example_tool
+    gaia-testing                 -          experimental  claude-import  -
+    ```
+
+    A skill shadowed by a higher-precedence copy of the same name is reported on stderr rather than hidden. A skill directory that fails to parse is listed with its error and the command exits `4`.
+  </Tab>
+
+  <Tab title="info">
+    ```bash
+    gaia skill info <name> [--json] [--body]
+    ```
+
+    | Option | Description |
+    |--------|-------------|
+    | `--json` | Emit JSON (including the full frontmatter) instead of text |
+    | `--body` | Also print the Markdown instructions |
+
+    Shows path, root, license, security tier, declared permissions, the tools the skill **provides** (namespaced `<skill>/<tool>`), the registry tools it **consumes** (`tools_required`), and any lower-precedence copies it shadows.
+  </Tab>
+
+  <Tab title="create">
+    ```bash
+    gaia skill create <name> [OPTIONS]
+    ```
+
+    | Option | Description |
+    |--------|-------------|
+    | `--dir` | Parent directory for the new skill (default: `~/.gaia/skills`) |
+    | `--description` | Description / trigger signal — the text the model reads to decide relevance |
+    | `--with-tools` | Also scaffold `tools.py` with an example `@tool` function |
+    | `--force` | Overwrite an existing skill directory |
+
+    Names must be lowercase-with-hyphens and match the directory name. The scaffold is validated through the real parser before it is written, so `create` can never emit a `SKILL.md` that `info` rejects.
+  </Tab>
+
+  <Tab title="import">
+    ```bash
+    gaia skill import <folder|zip|https-url> [OPTIONS]
+    ```
+
+    | Option | Description |
+    |--------|-------------|
+    | `--name` | Install under this name instead of the source's |
+    | `--force` | Overwrite an existing installed skill |
+
+    Copies into `~/.gaia/skills/`. **Imported skills re-earn trust:** the security tier is reset to `experimental` regardless of what the source claims, and the reset is reported. `.zip` bundles are checked for path traversal before extraction.
+  </Tab>
+
+  <Tab title="export">
+    ```bash
+    gaia skill export <name> [--output FILE.zip]
+    ```
+
+    | Option | Description |
+    |--------|-------------|
+    | `--output` | Destination `.zip` (default: `./<name>.zip`) |
+
+    Bundles the whole skill directory. Import it elsewhere with `gaia skill import <file>.zip`.
+  </Tab>
+</Tabs>
+
+**Examples:**
+
+<CodeGroup>
+```bash Scaffold a skill with tools
+gaia skill create web-research --with-tools \
+  --description "Search the web. Use when the user asks about current events."
+gaia skill info web-research --body
+```
+
+```bash See what's discoverable
+gaia skill list
+gaia skill list --root user            # only your own skills
+gaia skill list --json | jq '.roots'   # where GAIA looked
+```
+
+```bash Adopt a Claude Code skill
+gaia skill list --root claude-import   # what's already visible read-only
+gaia skill import ~/.claude/skills/my-skill    # take ownership, resets to experimental
+```
+
+```bash Share a skill
+gaia skill export web-research --output ./web-research.zip
+gaia skill import ./web-research.zip --name web-research-copy
+```
+</CodeGroup>
+
+**Exit codes:** `0` success · `2` missing/unknown subcommand · `3` skill not found · `4` invalid skill (bad manifest, name collision without `--force`, or a discovery root containing a malformed skill).
+
+### Loading a skill into an agent
+
+Skills are never globally active — an agent loads one explicitly, and its tools register under a `<skill-name>/<tool>` namespace:
+
+```python
+class WebAgent(Agent):
+    SKILL_DIRS = ["<package>/skills"]     # optional: bundle your own skills
+
+    def _register_tools(self):
+        self.load_skill("web-research")   # tools land under 'web-research/'
+```
+
+<Warning>
+**A skill declaring a local-capability permission is refused, not sandboxed.** `network` and `mcp` permissions bridge to the connector grant model and load fine. `filesystem`, `shell`, `database`, `desktop`, and `env` need the permission sandbox, which is deferred ([#1019](https://github.com/amd/gaia/issues/1019)) — until then `load_skill` fails with an actionable error rather than loading the skill unenforced.
+</Warning>
+
+<Note>
+`gaia skill install`, `remove`, `search`, `publish`, and `migrate` are **not implemented** and do not parse — they need the skill registry and land with the marketplace ([#2467](https://github.com/amd/gaia/issues/2467)). Use `import` / `export` for local distribution.
+</Note>
+
+[→ Agent Skills Spec](/spec/agent-skills) · [→ Skill Format Reference](/plans/skill-format)
+
+---
+
 ## Schedule
 
 Run a prompt on a recurring cron schedule and route its output to a sink. Schedules are stored in `~/.gaia/schedules.toml` (hand-editable). The `daemon` action runs a long-lived scheduler that fires each enabled schedule when due.
@@ -2117,7 +2273,7 @@ gaia schedule add \
 ```
 
 <Note>
-`--skill` is not yet implemented — `gaia schedule add --skill` is rejected with an error at add time pending the skill format ([#888](https://github.com/amd/gaia/issues/888)). Use `--prompt` for now.
+`--skill` is not yet implemented — `gaia schedule add --skill` is rejected with an error at add time. The [skills runtime](#skills) has shipped ([#888](https://github.com/amd/gaia/issues/888)), but the scheduler is not wired to it yet. Use `--prompt` for now.
 </Note>
 
 ---
@@ -3017,6 +3173,9 @@ For more help, see:
   </Card>
   <Card title="Agent Memory" icon="brain" href="/guides/memory">
     Persistent memory across sessions
+  </Card>
+  <Card title="Agent Skills" icon="puzzle-piece" href="/spec/agent-skills">
+    Portable SKILL.md capabilities
   </Card>
 </CardGroup>
 

--- a/docs/spec/agent-skills.mdx
+++ b/docs/spec/agent-skills.mdx
@@ -5,7 +5,18 @@ icon: "puzzle-piece"
 ---
 
 <Note>
-**Tracking issue:** [#285](https://github.com/amd/gaia/issues/285) · **Milestone:** Agent Hub Platform [OSS] · **Status:** Draft
+**Tracking issue:** [#285](https://github.com/amd/gaia/issues/285) · **Milestone:** Agent Hub Platform [OSS] · **Status:** **Phase 1 shipped** ([#888](https://github.com/amd/gaia/issues/888)) — remainder proposed
+
+**Shipped:** the `gaia.skills` runtime — `SKILL.md` parser + validator, the three
+discovery roots with auditable precedence, progressive disclosure,
+`<skill>/<tool>` tool registration, `Agent.load_skill` / `unload_skill`, and
+`gaia skill list|info|create|import|export`.
+
+**Still proposed:** the permission sandbox and tier-ceiling enforcement
+([#1019](https://github.com/amd/gaia/issues/1019)), the skill marketplace and
+`install`/`remove`/`search`/`publish`
+([#2467](https://github.com/amd/gaia/issues/2467)), the `/api/skills` router and
+Agent UI panel, and the `skills:` block in `gaia-agent.yaml`.
 
 This spec defines the **architecture and integration model** for skills. The
 on-disk `SKILL.md` schema (full field reference, permission grammar, tier
@@ -150,8 +161,8 @@ typed tools, security tier, requirements — defined in full in
 |-------|:---------------------:|:----:|----------------------|
 | `name` | required | required | — |
 | `description` | required | required | — |
-| `license` | optional | optional | `MIT` (GAIA skills are always MIT) |
-| `version` (top-level) | — | recommended (superset) | `0.0.0` (unversioned, blocks publishing) |
+| `license` | optional | optional | unset (`gaia skill create` scaffolds `MIT`; GAIA's own skills are always MIT) |
+| `version` (top-level) | — | recommended (superset) | unset — reported as unversioned; publishing will require it |
 | `metadata.gaia.permissions` | — | optional | none (instruction-only) |
 | `metadata.gaia.tools` | — | optional | none (instruction-only) |
 | `metadata.gaia.security_tier` | — | optional | `experimental` |
@@ -183,19 +194,37 @@ third-party formats nested under `metadata.<vendor>`.
 
 ### Discovery locations
 
-Skills are discovered from these roots, highest precedence first. A later root
-never overrides a skill of the same `name` found earlier.
+**v1 ships three roots**, highest precedence first. A later root never overrides
+a skill of the same `name` found earlier.
 
-| Precedence | Location | Scope |
-|:----------:|----------|-------|
-| 1 | `./.gaia/skills/<name>/` | This project / working directory |
-| 2 | Agent-bundled `skills/<name>/` | Shipped inside an agent package |
-| 3 | `~/.gaia/skills/<name>/` | This user, all projects |
-| 4 | Registry-installed (`~/.gaia/skills/`, lock-tracked) | Installed via `gaia skill install` |
-| 5 | `./.claude/skills/` and `~/.claude/skills/` | **Read-only import** for Claude Code compatibility |
+| Precedence | Location | Root label | Scope |
+|:----------:|----------|------------|-------|
+| 1 | Agent-bundled `skills/<name>/` | `agent-bundled` | Shipped inside an agent package; read-only. Declared by the agent's `SKILL_DIRS`. |
+| 2 | `~/.gaia/skills/<name>/` | `user` | This user, all projects. The **writable** root — where `gaia skill create` and `gaia skill import` install. Honors `GAIA_CONFIG_DIR`. |
+| 3 | `./.claude/skills/` then `~/.claude/skills/` | `claude-import` | **Read-only import** for Claude Code compatibility. |
 
-Roots 1–4 are native GAIA. Root 5 lets an existing Claude Code skill library
-work in GAIA with zero migration (see [Compatibility](#agent-skills--claude-code-compatibility)).
+Roots 1–2 are native GAIA. Root 3 lets an existing Claude Code skill library work
+in GAIA with zero migration (see [Compatibility](#agent-skills--claude-code-compatibility)).
+
+Precedence is **auditable, not silent**: a shadowed lower-precedence copy stays
+visible via `SkillManager.shadowed()` and is reported by `gaia skill list` and
+`gaia skill info`. A skill directory that fails to parse is likewise surfaced
+(`SkillManager.discovery_errors`, a non-zero exit from `gaia skill list`) rather
+than quietly omitted.
+
+<Note>
+**Deferred to a later phase — not dropped:**
+
+- **Project-local `./.gaia/skills/`.** A per-working-directory native root. It
+  would slot in *above* the user root, so adding it later only ever narrows
+  scope; nothing authored against v1 changes meaning.
+- **The registry-lock root** (`~/.gaia/skills/` tracked by
+  `skill-lock.json`). It belongs with `gaia skill install`, which is part of the
+  marketplace phase ([#2467](https://github.com/amd/gaia/issues/2467)). Until
+  then the user root is a plain directory with no lockfile.
+
+Do not add either to the runtime without updating this table.
+</Note>
 
 ### Progressive disclosure
 
@@ -222,34 +251,69 @@ agent reads or executes them — not at trigger time.
 
 A skill is never globally active. It is scoped to an agent two ways:
 
-- **Declared** — the agent's [`gaia-agent.yaml`](#agent-hub-integration) lists a
-  `skills:` block. These are available to every session of that agent.
-- **Granted** — a skill carrying permissions must be granted to the agent,
-  reusing the per-agent grant model from the connectors framework. An agent only
-  ever sees skills explicitly in scope (least privilege); discovery does not
-  imply activation.
+- **Declared** — the agent calls `load_skill` (typically in `_register_tools`),
+  and points `SKILL_DIRS` at any `skills/` folder it bundles. Resolving a
+  `skills:` block in [`gaia-agent.yaml`](#agent-hub-integration) declaratively is
+  proposed, not shipped.
+- **Granted** — a skill carrying connector-bridged permissions contributes
+  `ConnectorRequirement`s to the agent, reusing the per-agent grant model from the
+  connectors framework. An agent only ever sees skills explicitly in scope (least
+  privilege); discovery does not imply activation.
 
 At runtime an agent resolves its skill set, then loads each per the disclosure
 levels above:
 
 ```python
 class WebAgent(Agent):
+    SKILL_DIRS = ["<path to this package>/skills"]   # optional: bundled root
+
     def _register_tools(self):
-        self.load_skill("web-research")     # declared in gaia-agent.yaml
+        self.load_skill("web-research")     # tools land under 'web-research/'
         self.load_skill("incident-review")  # instruction-only, no permissions
 ```
 
-`load_skill` resolves the directory by precedence, validates the manifest against
-its security tier, registers any tools under a `<skill-name>/<tool>` namespace to
-avoid collisions, and makes the body available to the disclosure pipeline. A
-manifest whose declared tools don't match its `tools.py`, or whose permissions
-exceed its tier ceiling, **fails loudly** — it does not load with a subset.
+**`Agent.load_skill(name, *, manager=None) -> Skill`** does exactly this, in this
+order:
+
+1. Resolves `name` across the roots by precedence (`SKILL_DIRS` → `~/.gaia/skills`
+   → read-only `.claude/skills`) using the agent's lazily-built
+   `skill_manager`. Pass `manager=` to resolve against a different `SkillManager`.
+2. Parses and validates the manifest, body included.
+3. **Gates permissions before anything is registered** — a refused skill leaves
+   no tools and no prompt fragment behind (see [Permission &
+   security model](#permission--security-model)).
+4. Registers the skill's `@tool` functions from `tools.py` under
+   `<skill-name>/<tool>`, so two skills may both provide `search_web`.
+5. Merges any resolved `ConnectorRequirement`s into `REQUIRED_CONNECTORS` —
+   **per instance**, never mutating the ClassVar, so one agent's skill never leaks
+   requirements into a sibling.
+6. Rebuilds the system prompt, injecting the body via
+   `get_skills_system_prompt()`.
+
+Loading is **idempotent** (a second `load_skill` of the same name returns the
+already-loaded `Skill`) and **reversible** — `unload_skill(name)` removes the
+tools and the prompt fragment, returning `True` if the skill was loaded.
+`loaded_skills` is the `{name: Skill}` view of what is currently active.
+
+A manifest whose declared tools don't match its `tools.py` **fails loudly** and
+loads nothing: not a missing tool, an undeclared extra tool, a parameter-name
+mismatch, a required/optional flip, or a type contradiction. There is **no
+partial load** — the tool registry is restored byte-for-byte on any failure.
+
+<Note>
+**Tier ceilings are not yet enforced.** Every skill's `security_tier` is parsed,
+surfaced, and reset to `experimental` on import, but the ceiling that would reject
+a permission exceeding the tier arrives with the permission sandbox
+([#1019](https://github.com/amd/gaia/issues/1019)). Phase 1 gates on *domain*
+(below), not on tier.
+</Note>
 
 ### Invocation
 
 Once a skill is in scope, it is triggered either by the **model** (description
-match — automatic) or **explicitly** by the user (`/web-research`, or
-`load_skill` in code). This matches Claude Code's dual-invocation model. The
+match — automatic) or **explicitly** by the user. `load_skill` in code is the
+shipped explicit path; a user-facing `/web-research` slash command follows the
+Agent UI panel and is not yet available. This matches Claude Code's dual-invocation model. The
 standard's `allowed-tools`/`disallowed-tools` keys are parsed but **not** used as
 a permission mechanism (see [Skill Format](/plans/skill-format#adopted-base-agent-skills-standard)) —
 GAIA's permissions come from `metadata.gaia`.
@@ -260,19 +324,66 @@ Instruction-only skills carry no code, but they are not free of risk — a body 
 injected into the model's context and can attempt prompt injection. Tool skills
 carry the full risk of the code they run. The model gates both.
 
+<Warning>
+**The shipped rule: connector-bridged permissions only. Everything else is
+refused, not faked.**
+
+| Domain | Levels | Phase 1 behavior |
+|---|---|---|
+| `network` | `read`, `write`, `none` | **Bridged** — resolves to a `ConnectorRequirement`. |
+| `mcp` | `connect`, `none` | **Bridged** — resolves to a `ConnectorRequirement`. |
+| `filesystem` | `read`, `write` | **Refused** — needs the sandbox. |
+| `shell` | `execute` | **Refused** — needs the sandbox. |
+| `database` | `read`, `write` | **Refused** — needs the sandbox. |
+| `desktop` | `control` | **Refused** — needs the sandbox. |
+| `env` | `read` | **Refused** — needs the sandbox. |
+| *any* | `none` | **Inert** — grants nothing, so it neither refuses nor produces a requirement. |
+
+A skill declaring **any** local-capability permission raises
+`SkillPermissionError` at load time, naming the offending grants and pointing at
+[#1019](https://github.com/amd/gaia/issues/1019). It is never silently loaded and
+never wrapped in a sandbox that does not exist — an unenforceable grant is a
+refusal, not a warning. To load such a skill today, drop those permissions and use
+the agent's own tools for local access.
+
+`<domain>:none` is an explicit *denial* — it asks for nothing, so it is always
+inert: `filesystem:none` loads fine and produces no requirement. Refusing it
+would reject a skill for declaring **less** than the default.
+</Warning>
+
+**How the bridge resolves.** There is no second grant ledger — a bridged
+permission becomes the same `ConnectorRequirement` an agent already declares via
+`REQUIRED_CONNECTORS`:
+
+- **`mcp:connect:<connector-id>`** → a requirement for that connector. The scope
+  is **mandatory** and must name a connector in the live catalog: a bare
+  `mcp:connect`, or one naming an unknown id, fails loudly with the available ids
+  and a pointer to `gaia connectors list`.
+- **`network:<level>:<scope>`** where the scope names a catalog connector → a
+  requirement for that connector, scoped to the level.
+- **`network:<level>[:<scope>]`** with no matching catalog connector → a
+  requirement against the reserved `network` pseudo-connector-id. This is a
+  **declaration surface only**: it records the egress the skill asks for so
+  `gaia skill info` and a future egress policy can read it. **Phase 1 does not
+  enforce network egress.**
+
 **Security tiers gate what a skill may do.** Every skill resolves to one of
 `verified` / `community` / `experimental` (defaulting to `experimental`). The
-tier sets the permission ceiling and the grant behavior — auto-grant, prompt at
-install, or sandboxed — exactly as defined in
+tier is designed to set the permission ceiling and the grant behavior — auto-grant,
+prompt at install, or sandboxed — as defined in
 [Skill Format → Permission model and Security tiers](/plans/skill-format#permission-model).
 Highlights as they apply at the agent boundary:
 
-| Concern | How it's handled |
-|---------|------------------|
-| Tool permissions | Declared `permissions` (e.g. `network:read`, `filesystem:write:./out/**`) enforced by the skill sandbox; cannot exceed the tier ceiling |
-| Per-agent least privilege | An agent receives a skill's tools only after the skill is both in scope **and** granted; no ambient activation |
-| Instruction-only bodies | Loaded as context, surfaced for review; treated as untrusted input, never as system-level instructions |
-| Untrusted imports | Skills imported from `.claude/skills/` or migrated from elsewhere default to `experimental` — sandboxed, explicit opt-in — regardless of any tier they claim |
+| Concern | How it's handled | State |
+|---------|------------------|-------|
+| Bridged permissions | `network:*` / `mcp:connect` become per-agent `ConnectorRequirement`s | Shipped (declaration; egress not enforced) |
+| Local-capability permissions | `filesystem` / `shell` / `database` / `desktop` / `env` refuse the load outright | Shipped (refusal); enforcement deferred |
+| Per-agent least privilege | An agent receives a skill's tools only after the skill is explicitly loaded; no ambient activation. Tools are namespaced and instance-scoped | Shipped |
+| Instruction-only bodies | Loaded as context under a `==== LOADED SKILLS ====` prompt fragment; treated as untrusted input, never as system-level instructions | Shipped |
+| Untrusted imports | `gaia skill import` stamps `security_tier: experimental` regardless of the tier the skill claims, and reports the reset | Shipped |
+| Resource escape | A skill may only read files inside its own directory; `SkillManager.resource_path` rejects traversal, as does `.zip` import | Shipped |
+| Tier ceiling | A permission above the tier's ceiling should fail the load | **Deferred** ([#1019](https://github.com/amd/gaia/issues/1019)) |
+| Signing / audit | Per-tier signing and audit before promotion | **Deferred** (marketplace, [#2467](https://github.com/amd/gaia/issues/2467)) |
 
 This ties the skill layer to the broader
 [security model](/plans/security-model): skills are a grant surface, audited and
@@ -285,19 +396,25 @@ agent packages from the [Agent Hub Restructure](/spec/agent-hub-restructure).
 
 **Distribution.** A skill ships one of two ways:
 
-- **Standalone** in the skill registry — installed with `gaia skill install
-  <name>`, lock-tracked in `~/.gaia/skills/skill-lock.json`. The CLI is specified
-  in [Skill Format → CLI](/plans/skill-format#cli); the registry/marketplace is
-  downstream ([#647](https://github.com/amd/gaia/issues/647)).
+- **Standalone** — today via `gaia skill import <folder|zip|url>` into
+  `~/.gaia/skills/`, and `gaia skill export <name>` to produce the bundle. A
+  registry-backed `gaia skill install <name>` with a
+  `~/.gaia/skills/skill-lock.json` is **proposed** and belongs to the marketplace
+  phase ([#2467](https://github.com/amd/gaia/issues/2467),
+  [#647](https://github.com/amd/gaia/issues/647)); see
+  [Skill Format → CLI](/plans/skill-format#cli).
 - **Bundled** inside an agent package's `skills/` directory — version-pinned to
-  that agent, no separate install.
+  that agent, no separate install. Shipped: the agent points `SKILL_DIRS` at it and
+  the folder becomes the highest-precedence root.
 
 **Versioning.** Skills are SemVer'd independently of the framework and of the
 agents that use them. Major = breaking tool-signature or permission change;
 minor = additive; patch = fixes. Agent manifests pin ranges.
 
-**The `gaia-agent.yaml` link.** An agent declares the skills it composes. This
-extends the manifest from the restructure spec with a `skills:` block:
+**The `gaia-agent.yaml` link (proposed).** An agent declares the skills it
+composes. This extends the manifest from the restructure spec with a `skills:`
+block. Nothing reads it yet — a shipped agent composes skills by calling
+`load_skill` and setting `SKILL_DIRS`:
 
 ```yaml
 id: web
@@ -319,7 +436,7 @@ interfaces:
   api_server: true
 ```
 
-The hub resolves a `skills:` block at install time the way `dependencies:`
+The hub would resolve a `skills:` block at install time the way `dependencies:`
 resolves agent-to-agent links today: topological install order, highest version
 satisfying all constraints, fail-loud on conflict or circular dependency.
 
@@ -347,11 +464,11 @@ ignored by runtimes that don't understand it rather than breaking the parse.
 | Required fields | `name`, `description` | same |
 | Instructions body | ✓ | ✓ (progressively disclosed) |
 | Bundled scripts/resources | ✓ | ✓ |
-| Invocation control / subagent exec | ✓ (Claude Code) | honored on import |
-| Typed tool declarations | — | `tools:` → `@tool` registry |
-| Granular permissions | coarse (`allowed-tools`) | `<domain>:<level>` scoped grants |
-| Security tiers | — | `verified` / `community` / `experimental` |
-| Signing / audit | — | per-tier (see [Skill Format → Security tiers](/plans/skill-format#security-tiers)) |
+| Invocation control (`allowed-tools`) | ✓ (Claude Code) | **parsed and ignored** — never a permission mechanism; preserved verbatim on round-trip |
+| Typed tool declarations | — | `tools:` → `@tool` registry, namespaced `<skill>/<tool>` |
+| Granular permissions | coarse (`allowed-tools`) | `<domain>:<level>[:scope]` grants — bridged for `network`/`mcp`, refused for local capabilities |
+| Security tiers | — | `verified` / `community` / `experimental` (declared + reset on import; ceilings deferred) |
+| Signing / audit | — | per-tier — **deferred** to the marketplace phase (see [Skill Format → Security tiers](/plans/skill-format#security-tiers)) |
 
 The principle: **be a strict superset of the open standard.** Anything that runs
 as an Agent Skills skill runs in GAIA; GAIA adds the enforcement and typing the
@@ -380,6 +497,7 @@ standard intentionally leaves open.
 ## Related
 
 - [Skill Format](/plans/skill-format) — `SKILL.md` schema, permission grammar, tiers, CLI
+- [CLI Reference → Skills](/reference/cli#skills) — `gaia skill list|info|create|import|export`
 - [Agent Hub Restructure](/spec/agent-hub-restructure) — `gaia-agent.yaml`, packaging, distribution
 - [Agent Hub](/plans/agent-hub) — marketplace vision
 - [Security Model](/plans/security-model) — grants, audit trail, sandboxing

--- a/setup.py
+++ b/setup.py
@@ -103,6 +103,7 @@ setup(
         "gaia.connectors",
         "gaia.connectors.catalog",
         "gaia.connectors.providers",
+        "gaia.skills",
     ],
     package_data={
         "gaia.eval": [

--- a/src/gaia/agents/base/agent.py
+++ b/src/gaia/agents/base/agent.py
@@ -271,6 +271,11 @@ class Agent(abc.ABC):
     # both render paths and the ``_openai_tools`` property.
     _active_tool_filter: Optional[List[str]] = None
 
+    # Skills (#888): lazily built manager + the skills loaded into this agent.
+    # Instance-level once set, so one agent's skills never leak into a sibling.
+    _skill_manager: Optional[Any] = None
+    _loaded_skills: Optional[Dict[str, Any]] = None
+
     # Define state constants
     STATE_PLANNING = "PLANNING"
     STATE_EXECUTING_PLAN = "EXECUTING_PLAN"
@@ -293,6 +298,12 @@ class Agent(abc.ABC):
 
     # Registry reads this to include dynamic MCP consumers in the Settings "Active for" panel.
     CONSUMES_MCP_SERVERS: ClassVar[bool] = False
+
+    # Agent-bundled skill directories (issue #888) — the highest-precedence
+    # discovery root. A packaged agent points this at its own ``skills/`` folder
+    # so the skills it ships always win over a same-named user or Claude Code
+    # copy. Empty = the agent bundles no skills.
+    SKILL_DIRS: ClassVar[List[str]] = []
 
     # Agent-specific tools that must be gated behind explicit user confirmation
     # (#1440). Subclasses override this to declare their own destructive/external
@@ -855,6 +866,158 @@ Do NOT wrap conversational replies in JSON.
         # Recompose the full system prompt via _compose_system_prompt() so that
         # mixin prompts, tool descriptions, and response format are all included.
         self._system_prompt_cache = self._compose_system_prompt()
+
+    # ------------------------------------------------------------------
+    # Skills (issue #888) — SKILL.md capabilities loaded at runtime
+    # ------------------------------------------------------------------
+
+    @property
+    def skill_manager(self):
+        """This agent's :class:`~gaia.skills.manager.SkillManager`.
+
+        Built lazily over the v1 discovery roots, with the agent's own
+        ``SKILL_DIRS`` as the highest-precedence root.
+        """
+        if getattr(self, "_skill_manager", None) is None:
+            from gaia.skills import SkillManager
+
+            self._skill_manager = SkillManager(agent_skill_dirs=self.SKILL_DIRS)
+        return self._skill_manager
+
+    @property
+    def loaded_skills(self) -> Dict[str, Any]:
+        """``{name: Skill}`` for every skill loaded into this agent."""
+        if getattr(self, "_loaded_skills", None) is None:
+            self._loaded_skills = {}
+        return self._loaded_skills
+
+    def load_skill(self, name: str, *, manager=None):
+        """Load a skill by name and scope it into this agent.
+
+        Resolves ``name`` across the discovery roots (agent-bundled →
+        ``~/.gaia/skills`` → read-only ``.claude/skills``), validates the
+        manifest, registers any tools the skill provides under the
+        ``<skill-name>/<tool>`` namespace, and injects its Markdown body into
+        the system prompt.
+
+        Args:
+            name: The skill's ``name`` (== its directory name).
+            manager: Optional :class:`~gaia.skills.manager.SkillManager` to
+                resolve against; defaults to :attr:`skill_manager`.
+
+        Returns:
+            The loaded :class:`~gaia.skills.format.Skill`.
+
+        Raises:
+            SkillNotFoundError: no discovery root contains that skill.
+            SkillValidationError: the manifest is invalid or contradicts
+                ``tools.py``. Nothing is registered.
+            SkillPermissionError: the skill declares a local-capability
+                permission (``filesystem``/``shell``/``database``/``desktop``/
+                ``env``), which this phase refuses rather than loading
+                unenforced.
+
+        Example:
+            class WebAgent(Agent):
+                def _register_tools(self):
+                    self.load_skill("web-research")
+        """
+        from gaia.skills import connector_requirements, refuse_unbridged_permissions
+        from gaia.skills.loader import register_skill_tools, unregister_skill_tools
+
+        resolver = manager if manager is not None else self.skill_manager
+
+        if name in self.loaded_skills:
+            logger.debug("Skill '%s' is already loaded for this agent", name)
+            return self.loaded_skills[name]
+
+        skill = resolver.load(name)
+
+        # Permission gate BEFORE any registration: a refused skill must not
+        # leave tools or prompt fragments behind.
+        permissions = skill.parsed_permissions()
+        refuse_unbridged_permissions(permissions, skill_name=skill.name)
+        requirements = connector_requirements(permissions, skill_name=skill.name)
+
+        registered = register_skill_tools(skill)
+        try:
+            if registered and self._instance_tools is not None:
+                self._instance_tools.update(registered)
+
+            if requirements:
+                # Shadow the ClassVar per instance — never mutate it, or one
+                # agent's skill would leak requirements into every sibling.
+                existing = list(self.REQUIRED_CONNECTORS)
+                for requirement in requirements:
+                    if requirement not in existing:
+                        existing.append(requirement)
+                self.REQUIRED_CONNECTORS = existing
+
+            self.loaded_skills[name] = skill
+            self.rebuild_system_prompt()
+        except Exception:
+            unregister_skill_tools(skill.name)
+            self.loaded_skills.pop(name, None)
+            raise
+
+        # tools_required names registry tools the skill CONSUMES. A name that is
+        # valid but not active in this agent is scoping, not a defect — log it so
+        # a skill that quietly can't run its recipe is diagnosable.
+        inactive = [t for t in skill.gaia.tools_required if t not in self._tools_registry]
+        if inactive:
+            logger.info(
+                "Skill '%s' expects tool(s) %s, which this agent does not have "
+                "registered — its instructions may not be fully executable here.",
+                skill.name,
+                ", ".join(inactive),
+            )
+
+        logger.info(
+            "Loaded skill '%s' (tier=%s, root=%s, %d tool(s), %d connector "
+            "requirement(s))",
+            skill.name,
+            skill.security_tier,
+            skill.root,
+            len(registered),
+            len(requirements),
+        )
+        return skill
+
+    def unload_skill(self, name: str) -> bool:
+        """Remove a loaded skill's tools and body. Returns True if it was loaded."""
+        from gaia.skills.loader import unregister_skill_tools
+
+        if name not in self.loaded_skills:
+            return False
+
+        removed = unregister_skill_tools(name)
+        if self._instance_tools is not None:
+            for key in removed:
+                self._instance_tools.pop(key, None)
+        self.loaded_skills.pop(name, None)
+        self.rebuild_system_prompt()
+        logger.info("Unloaded skill '%s'", name)
+        return True
+
+    def get_skills_system_prompt(self) -> str:
+        """Render the loaded skills' bodies as a system-prompt fragment.
+
+        Auto-discovered by ``_get_mixin_prompts()``, so a skill's instructions
+        reach the model as soon as it is loaded. Returns "" when no skill is
+        loaded, keeping every existing agent's prompt byte-identical.
+        """
+        skills = getattr(self, "_loaded_skills", None)
+        if not skills:
+            return ""
+
+        sections = []
+        for skill in skills.values():
+            if not skill.body:
+                continue
+            sections.append(f"--- SKILL: {skill.name} ---\n{skill.body}")
+        if not sections:
+            return ""
+        return "==== LOADED SKILLS ====\n" + "\n\n".join(sections)
 
     def list_tools(self, verbose: bool = True) -> None:
         """

--- a/src/gaia/agents/base/agent.py
+++ b/src/gaia/agents/base/agent.py
@@ -963,7 +963,9 @@ Do NOT wrap conversational replies in JSON.
         # tools_required names registry tools the skill CONSUMES. A name that is
         # valid but not active in this agent is scoping, not a defect — log it so
         # a skill that quietly can't run its recipe is diagnosable.
-        inactive = [t for t in skill.gaia.tools_required if t not in self._tools_registry]
+        inactive = [
+            t for t in skill.gaia.tools_required if t not in self._tools_registry
+        ]
         if inactive:
             logger.info(
                 "Skill '%s' expects tool(s) %s, which this agent does not have "

--- a/src/gaia/agents/base/agent.py
+++ b/src/gaia/agents/base/agent.py
@@ -46,6 +46,7 @@ from gaia.llm.lemonade_client import (
 if TYPE_CHECKING:
     from gaia.agents.base.goal_store import Goal, Proposal
     from gaia.connectors.providers.base import ConnectorRequirement
+    from gaia.skills import Skill, SkillManager
 
 # Set up logging
 logging.basicConfig(level=logging.INFO)
@@ -872,7 +873,7 @@ Do NOT wrap conversational replies in JSON.
     # ------------------------------------------------------------------
 
     @property
-    def skill_manager(self):
+    def skill_manager(self) -> "SkillManager":
         """This agent's :class:`~gaia.skills.manager.SkillManager`.
 
         Built lazily over the v1 discovery roots, with the agent's own
@@ -885,13 +886,15 @@ Do NOT wrap conversational replies in JSON.
         return self._skill_manager
 
     @property
-    def loaded_skills(self) -> Dict[str, Any]:
+    def loaded_skills(self) -> Dict[str, "Skill"]:
         """``{name: Skill}`` for every skill loaded into this agent."""
         if getattr(self, "_loaded_skills", None) is None:
             self._loaded_skills = {}
         return self._loaded_skills
 
-    def load_skill(self, name: str, *, manager=None):
+    def load_skill(
+        self, name: str, *, manager: Optional["SkillManager"] = None
+    ) -> "Skill":
         """Load a skill by name and scope it into this agent.
 
         Resolves ``name`` across the discovery roots (agent-bundled →

--- a/src/gaia/cli.py
+++ b/src/gaia/cli.py
@@ -2029,8 +2029,8 @@ def build_parser():
     s_add_what.add_argument("--prompt", help="One-shot prompt to run on each fire")
     s_add_what.add_argument(
         "--skill",
-        help="Skill to run — not supported yet (blocked on #888); "
-        "rejected at add time. Use --prompt instead.",
+        help="Skill to run — the scheduler is not wired to the skills runtime "
+        "yet; rejected at add time. Use --prompt instead.",
     )
     s_add.add_argument(
         "--sink",
@@ -3093,6 +3093,12 @@ Examples:
 
     connectors_cli.add_subparser(subparsers)
 
+    # Skills runtime (issue #888) — SKILL.md discovery, scaffolding, and
+    # import/export. The subparser tree lives in gaia.skills.cli.
+    from gaia.skills import cli as skills_cli
+
+    skills_cli.add_subparser(subparsers)
+
     # Persistent CLI config (~/.gaia/config.json) — e.g. a default model so
     # users don't have to pass --model on every chat/llm/prompt (issue #98).
     config_parser = subparsers.add_parser(
@@ -3233,17 +3239,18 @@ def _handle_schedule(args):
     store = TomlScheduleStore()
 
     if action == "add":
-        # --skill schedules would register fine but raise on every fire
-        # (skill-format resolution is blocked on #888) — reject up front.
+        # --skill schedules would register fine but raise on every fire: the
+        # skills runtime exists, the scheduler just doesn't invoke it yet.
         if getattr(args, "skill", None):
             print(
-                f"❌ Cannot add schedule {args.name!r}: --skill is not supported yet "
-                "(skill-format resolution is blocked on #888), so a skill-backed "
-                "schedule would never produce output.\n"
+                f"❌ Cannot add schedule {args.name!r}: --skill is not supported yet. "
+                "The skills runtime ships (see 'gaia skill list'), but the scheduler "
+                "is not wired to it, so a skill-backed schedule would never produce "
+                "output.\n"
                 "Use --prompt instead, e.g.:\n"
                 f'  gaia schedule add --name {args.name} --cron "{args.cron}" '
                 '--prompt "<text>"\n'
-                "Track progress: https://github.com/amd/gaia/issues/888",
+                "Track progress: https://github.com/amd/gaia/issues/1019",
                 file=sys.stderr,
             )
             sys.exit(1)
@@ -4748,6 +4755,13 @@ Let me know your answer!
         from gaia.connectors import cli as connectors_cli  # pylint: disable=reimported
 
         rc = connectors_cli.handle(args)
+        sys.exit(rc)
+
+    # Handle Skills command (issue #888)
+    if args.action == "skill":
+        from gaia.skills import cli as skills_cli  # pylint: disable=reimported
+
+        rc = skills_cli.handle(args)
         sys.exit(rc)
 
     # Handle Diagnostics command

--- a/src/gaia/schedule/runner.py
+++ b/src/gaia/schedule/runner.py
@@ -16,14 +16,16 @@ log = get_logger(__name__)
 def resolve_input(schedule: Schedule) -> str:
     """Return the prompt text to send to the agent for this schedule.
 
-    ``--skill`` resolution depends on the agentskills.io skill format (#888),
-    which has not landed yet; fail loudly rather than guess.
+    The skills runtime (``gaia.skills``) ships, but the scheduler is not wired
+    to it — a scheduled skill has no agent to load into. Fail loudly rather
+    than guess at a prompt.
     """
     if schedule.prompt:
         return schedule.prompt
     raise NotImplementedError(
-        f"schedule {schedule.name!r} uses --skill {schedule.skill!r}, but skill-format "
-        f"resolution is not available yet (blocked on #888). Use --prompt for now."
+        f"schedule {schedule.name!r} uses --skill {schedule.skill!r}, but the "
+        "scheduler cannot run skills yet. Re-create it with --prompt: "
+        f"gaia schedule add --name {schedule.name} --cron '<expr>' --prompt '<text>'"
     )
 
 

--- a/src/gaia/skills/__init__.py
+++ b/src/gaia/skills/__init__.py
@@ -1,0 +1,114 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""
+GAIA skills runtime — parse, discover, and load ``SKILL.md`` capabilities.
+
+The format is the `Agent Skills <https://agentskills.io>`_ open standard, so a
+plain Claude Code skill loads unchanged; GAIA layers typed tools, a permission
+grammar, and security tiers under ``metadata.gaia``.
+
+Quick start::
+
+    from gaia.skills import SkillManager
+
+    manager = SkillManager()
+    for skill in manager.list_skills():
+        print(skill.name, "-", skill.description)
+
+    skill = manager.load("web-research")   # body + validation
+
+From an agent::
+
+    class WebAgent(Agent):
+        def _register_tools(self):
+            self.load_skill("web-research")   # tools land under 'web-research/'
+
+Phase 1 (issue #888) bridges connector-backed permissions only. A skill
+declaring a local-capability permission (``filesystem``, ``shell``,
+``database``, ``desktop``, ``env``) is refused — see
+:mod:`gaia.skills.permissions`.
+"""
+
+from gaia.skills.errors import (
+    SkillError,
+    SkillNotFoundError,
+    SkillPermissionError,
+    SkillValidationError,
+)
+from gaia.skills.format import (
+    DEFAULT_SECURITY_TIER,
+    MAX_DESCRIPTION_LENGTH,
+    MAX_NAME_LENGTH,
+    SECURITY_TIERS,
+    SKILL_FILENAME,
+    SKILL_TOOLS_FILENAME,
+    GaiaMetadata,
+    Skill,
+    SkillRequirements,
+    SkillTool,
+    parse_skill,
+    parse_skill_file,
+    parse_skill_metadata,
+    validate_skill,
+)
+from gaia.skills.loader import register_skill_tools, unregister_skill_tools
+from gaia.skills.manager import (
+    ROOT_AGENT_BUNDLED,
+    ROOT_CLAUDE_IMPORT,
+    ROOT_USER,
+    SkillManager,
+    SkillRoot,
+    get_default_manager,
+    reset_default_manager,
+    user_skills_dir,
+)
+from gaia.skills.permissions import (
+    CONNECTOR_BRIDGED_DOMAINS,
+    LOCAL_CAPABILITY_DOMAINS,
+    Permission,
+    connector_requirements,
+    parse_permissions,
+    refuse_unbridged_permissions,
+)
+
+__all__ = [
+    # Format
+    "Skill",
+    "SkillTool",
+    "SkillRequirements",
+    "GaiaMetadata",
+    "parse_skill",
+    "parse_skill_file",
+    "parse_skill_metadata",
+    "validate_skill",
+    "SKILL_FILENAME",
+    "SKILL_TOOLS_FILENAME",
+    "SECURITY_TIERS",
+    "DEFAULT_SECURITY_TIER",
+    "MAX_NAME_LENGTH",
+    "MAX_DESCRIPTION_LENGTH",
+    # Discovery
+    "SkillManager",
+    "SkillRoot",
+    "ROOT_AGENT_BUNDLED",
+    "ROOT_USER",
+    "ROOT_CLAUDE_IMPORT",
+    "get_default_manager",
+    "reset_default_manager",
+    "user_skills_dir",
+    # Tools
+    "register_skill_tools",
+    "unregister_skill_tools",
+    # Permissions
+    "Permission",
+    "parse_permissions",
+    "connector_requirements",
+    "refuse_unbridged_permissions",
+    "CONNECTOR_BRIDGED_DOMAINS",
+    "LOCAL_CAPABILITY_DOMAINS",
+    # Errors
+    "SkillError",
+    "SkillValidationError",
+    "SkillNotFoundError",
+    "SkillPermissionError",
+]

--- a/src/gaia/skills/cli.py
+++ b/src/gaia/skills/cli.py
@@ -1,0 +1,505 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""
+CLI for ``gaia skill {list|info|create|import|export}``.
+
+``install`` / ``search`` / ``publish`` belong to the marketplace phase
+(issue #2467) and are deliberately absent — not even as stubs, so a user never
+discovers a verb that cannot work.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import sys
+import tempfile
+import zipfile
+from pathlib import Path
+from typing import Optional
+
+from gaia.logger import get_logger
+from gaia.skills.errors import SkillError, SkillNotFoundError, SkillValidationError
+from gaia.skills.format import (
+    SKILL_FILENAME,
+    SKILL_TOOLS_FILENAME,
+    GaiaMetadata,
+    Skill,
+    SkillTool,
+    parse_skill_file,
+)
+from gaia.skills.manager import SkillManager
+
+log = get_logger(__name__)
+
+EXIT_OK = 0
+EXIT_USAGE = 2
+EXIT_NOT_FOUND = 3
+EXIT_INVALID = 4
+
+_DEFAULT_DESCRIPTION = (
+    "Describe what this skill does and when the model should use it. "
+    "This text is the trigger signal."
+)
+
+
+def add_subparser(subparsers: argparse._SubParsersAction) -> None:
+    """Register ``gaia skill`` and its subcommands."""
+    p = subparsers.add_parser(
+        "skill",
+        help="Author and manage agent skills (SKILL.md capabilities)",
+        description=(
+            "Discover, inspect, scaffold, import, and export SKILL.md skills. "
+            "Skills are discovered from agent-bundled skills/, ~/.gaia/skills/, "
+            "and (read-only) .claude/skills/."
+        ),
+    )
+    sub = p.add_subparsers(
+        dest="skill_action", metavar="<subcommand>", help="Subcommand"
+    )
+
+    p_list = sub.add_parser("list", help="List every discovered skill and its root")
+    p_list.add_argument(
+        "--json",
+        action="store_true",
+        dest="as_json",
+        help="Emit JSON instead of a table",
+    )
+    p_list.add_argument(
+        "--root",
+        default=None,
+        help="Only show skills from this discovery root "
+        "(agent-bundled | user | claude-import)",
+    )
+
+    p_info = sub.add_parser("info", help="Show one skill's manifest in detail")
+    p_info.add_argument("name", help="Skill name (== its directory name)")
+    p_info.add_argument(
+        "--json", action="store_true", dest="as_json", help="Emit JSON instead of text"
+    )
+    p_info.add_argument(
+        "--body", action="store_true", help="Also print the Markdown instructions"
+    )
+
+    p_create = sub.add_parser("create", help="Scaffold a new skill directory")
+    p_create.add_argument("name", help="Skill name (lowercase-with-hyphens)")
+    p_create.add_argument(
+        "--dir",
+        dest="directory",
+        default=None,
+        help="Parent directory for the new skill (default: ~/.gaia/skills)",
+    )
+    p_create.add_argument(
+        "--description", default=None, help="Description / trigger signal"
+    )
+    p_create.add_argument(
+        "--with-tools",
+        action="store_true",
+        help=f"Also scaffold {SKILL_TOOLS_FILENAME} with an example @tool function",
+    )
+    p_create.add_argument(
+        "--force", action="store_true", help="Overwrite an existing skill directory"
+    )
+
+    p_import = sub.add_parser(
+        "import",
+        help="Copy a skill folder, .zip, or URL into ~/.gaia/skills/ (stamped experimental)",
+    )
+    p_import.add_argument(
+        "source", help="Path to a skill directory or .zip, or an https URL"
+    )
+    p_import.add_argument(
+        "--name", default=None, help="Install under this name instead of the source's"
+    )
+    p_import.add_argument(
+        "--force", action="store_true", help="Overwrite an existing installed skill"
+    )
+
+    p_export = sub.add_parser("export", help="Export a skill to a .zip bundle")
+    p_export.add_argument("name", help="Skill name to export")
+    p_export.add_argument(
+        "--output", default=None, help="Destination .zip (default: ./<name>.zip)"
+    )
+
+
+def handle(args: argparse.Namespace) -> int:
+    """Dispatch a parsed ``gaia skill ...`` command. Returns an exit code."""
+    action = getattr(args, "skill_action", None)
+    if action is None:
+        sys.stderr.write("gaia skill: missing subcommand. Try 'gaia skill --help'.\n")
+        return EXIT_USAGE
+
+    handlers = {
+        "list": _handle_list,
+        "info": _handle_info,
+        "create": _handle_create,
+        "import": _handle_import,
+        "export": _handle_export,
+    }
+    handler = handlers.get(action)
+    if handler is None:
+        sys.stderr.write(f"gaia skill: unknown subcommand {action!r}\n")
+        return EXIT_USAGE
+
+    if getattr(args, "as_json", False):
+        # stdout carries machine-readable JSON; keep log lines off it.
+        from gaia.logger import route_console_logging_to_stderr
+
+        route_console_logging_to_stderr()
+
+    try:
+        return handler(args)
+    except SkillNotFoundError as exc:
+        sys.stderr.write(f"❌ {exc}\n")
+        return EXIT_NOT_FOUND
+    except SkillValidationError as exc:
+        sys.stderr.write(f"❌ {exc}\n")
+        return EXIT_INVALID
+    except SkillError as exc:
+        sys.stderr.write(f"❌ {exc}\n")
+        return EXIT_INVALID
+
+
+def _manager() -> SkillManager:
+    return SkillManager()
+
+
+def _handle_list(args: argparse.Namespace) -> int:
+    manager = _manager()
+    skills = manager.list_skills()
+    if args.root:
+        skills = [s for s in skills if s.root == args.root]
+    errors = manager.discovery_errors
+
+    if getattr(args, "as_json", False):
+        payload = {
+            "roots": [
+                {"label": r.label, "path": str(r.path), "exists": r.path.is_dir()}
+                for r in manager.roots
+            ],
+            "skills": [_skill_summary(s) for s in skills],
+            "shadowed": [_skill_summary(s) for s in manager.shadowed()],
+            "errors": errors,
+        }
+        print(json.dumps(payload, indent=2))
+        return EXIT_INVALID if errors else EXIT_OK
+
+    if not skills:
+        print("No skills found. Searched:")
+        for root in manager.roots:
+            mark = "" if root.path.is_dir() else "  (missing)"
+            print(f"  {root.label:<14} {root.path}{mark}")
+        print("\nCreate one with: gaia skill create my-skill")
+    else:
+        print(f"{'NAME':<28} {'VERSION':<10} {'TIER':<13} {'ROOT':<14} TOOLS")
+        for skill in skills:
+            tools = ", ".join(skill.tool_names) or "-"
+            print(
+                f"{skill.name:<28} {skill.version or '-':<10} "
+                f"{skill.security_tier:<13} {skill.root or '-':<14} {tools}"
+            )
+
+    for shadow in manager.shadowed():
+        print(
+            f"  ↳ '{shadow.name}' in {shadow.directory} is shadowed by the "
+            f"higher-precedence copy",
+            file=sys.stderr,
+        )
+
+    if errors:
+        print(f"\n{len(errors)} skill folder(s) failed to load:", file=sys.stderr)
+        for path, message in errors.items():
+            print(f"  {path}: {message}", file=sys.stderr)
+        return EXIT_INVALID
+    return EXIT_OK
+
+
+def _handle_info(args: argparse.Namespace) -> int:
+    manager = _manager()
+    skill = manager.load(args.name)
+
+    if getattr(args, "as_json", False):
+        payload = _skill_summary(skill)
+        payload["frontmatter"] = skill.to_frontmatter()
+        if getattr(args, "body", False):
+            payload["body"] = skill.body
+        print(json.dumps(payload, indent=2, default=str))
+        return EXIT_OK
+
+    print(f"{skill.name}  {skill.version or '(unversioned)'}")
+    print(f"  {skill.description}")
+    print(f"  path         : {skill.directory}")
+    print(f"  root         : {skill.root}{' (read-only)' if skill.read_only else ''}")
+    print(f"  license      : {skill.license or '-'}")
+    print(f"  security tier: {skill.security_tier}")
+    print(f"  permissions  : {', '.join(skill.gaia.permissions) or 'none'}")
+    if skill.gaia.tools:
+        print("  provides     :")
+        for tool in skill.gaia.tools:
+            params = ", ".join(
+                f"{n}{'' if spec.get('required') else '?'}"
+                for n, spec in tool.parameters.items()
+            )
+            print(f"    {skill.name}/{tool.name}({params})  {tool.description}")
+    else:
+        print("  provides     : (instruction-only)")
+    if skill.gaia.tools_required:
+        print(f"  consumes     : {', '.join(skill.gaia.tools_required)}")
+
+    shadowed = manager.shadowed(skill.name)
+    for shadow in shadowed:
+        print(f"  shadows      : {shadow.directory} ({shadow.root})")
+
+    if getattr(args, "body", False) and skill.body:
+        print("\n--- instructions ---")
+        print(skill.body)
+    return EXIT_OK
+
+
+def _handle_create(args: argparse.Namespace) -> int:
+    parent = Path(args.directory) if args.directory else _manager().user_root
+    target = parent / args.name
+
+    if target.exists() and not args.force:
+        sys.stderr.write(
+            f"❌ {target} already exists. Pass --force to overwrite it, or pick "
+            "another name.\n"
+        )
+        return EXIT_INVALID
+
+    gaia_meta = GaiaMetadata()
+    if args.with_tools:
+        gaia_meta.tools = [
+            SkillTool(
+                name="example_tool",
+                description="Replace this with what your tool does.",
+                parameters={"text": {"type": "string", "required": True}},
+                returns={"type": "object"},
+            )
+        ]
+
+    skill = Skill(
+        name=args.name,
+        description=args.description or _DEFAULT_DESCRIPTION,
+        version="0.1.0",
+        license="MIT",
+        gaia=gaia_meta,
+        body=_scaffold_body(args.name, with_tools=args.with_tools),
+    )
+    # Validate the scaffold through the real parser before writing it, so
+    # 'gaia skill create' can never emit a SKILL.md that 'gaia skill info' rejects.
+    from gaia.skills.format import parse_skill
+
+    parse_skill(skill.to_markdown(), source=f"<scaffold {args.name}>")
+
+    if target.exists() and args.force:
+        shutil.rmtree(target)
+    target.mkdir(parents=True)
+    skill.write(target / SKILL_FILENAME)
+    if args.with_tools:
+        (target / SKILL_TOOLS_FILENAME).write_text(_SCAFFOLD_TOOLS, encoding="utf-8")
+
+    print(f"✅ Created skill '{args.name}' at {target}")
+    print(f"   Edit {target / SKILL_FILENAME}, then: gaia skill info {args.name}")
+    return EXIT_OK
+
+
+def _handle_import(args: argparse.Namespace) -> int:
+    manager = _manager()
+    destination_root = manager.user_root
+
+    with tempfile.TemporaryDirectory(prefix="gaia-skill-import-") as tmp:
+        source_dir = _materialize_source(args.source, Path(tmp))
+        skill = parse_skill_file(source_dir, check_directory_name=False)
+        name = args.name or skill.name
+        target = destination_root / name
+
+        if target.exists():
+            if not args.force:
+                sys.stderr.write(
+                    f"❌ Skill '{name}' is already installed at {target}. Pass "
+                    "--force to replace it.\n"
+                )
+                return EXIT_INVALID
+            shutil.rmtree(target)
+
+        shutil.copytree(source_dir, target)
+        # Imported skills re-earn trust: stamp experimental regardless of claim.
+        imported = parse_skill_file(target, check_directory_name=False)
+        imported.name = name
+        previous_tier = imported.gaia.security_tier
+        imported.gaia.security_tier = "experimental"
+        imported.write(target / SKILL_FILENAME)
+
+    print(f"✅ Imported skill '{name}' into {target}")
+    if previous_tier != "experimental":
+        print(
+            f"   Security tier reset: {previous_tier} → experimental "
+            "(imported skills re-earn trust)."
+        )
+    print(f"   Inspect it with: gaia skill info {name}")
+    return EXIT_OK
+
+
+def _handle_export(args: argparse.Namespace) -> int:
+    manager = _manager()
+    skill = manager.load(args.name)
+    source = skill.directory
+    if source is None:  # pragma: no cover - discovery always sets a path
+        raise SkillNotFoundError(f"Skill '{args.name}' has no directory on disk.")
+
+    output = Path(args.output) if args.output else Path.cwd() / f"{skill.name}.zip"
+    output.parent.mkdir(parents=True, exist_ok=True)
+
+    with zipfile.ZipFile(output, "w", zipfile.ZIP_DEFLATED) as bundle:
+        for path in sorted(source.rglob("*")):
+            if path.is_file():
+                bundle.write(path, arcname=f"{skill.name}/{path.relative_to(source)}")
+
+    print(f"✅ Exported skill '{skill.name}' to {output}")
+    print(f"   Import it elsewhere with: gaia skill import {output}")
+    return EXIT_OK
+
+
+# ----------------------------------------------------------------------
+# Helpers
+# ----------------------------------------------------------------------
+
+
+def _skill_summary(skill: Skill) -> dict:
+    return {
+        "name": skill.name,
+        "description": skill.description,
+        "version": skill.version,
+        "license": skill.license,
+        "security_tier": skill.security_tier,
+        "root": skill.root,
+        "read_only": skill.read_only,
+        "path": str(skill.directory) if skill.directory else None,
+        "instruction_only": skill.is_instruction_only,
+        "tools": [skill.namespaced_tool_name(n) for n in skill.tool_names],
+        "tools_required": list(skill.gaia.tools_required),
+        "permissions": list(skill.gaia.permissions),
+    }
+
+
+def _materialize_source(source: str, workdir: Path) -> Path:
+    """Return a directory containing the source skill, downloading/unzipping."""
+    if source.startswith(("http://", "https://")):
+        archive = _download(source, workdir / "download.zip")
+        return _unpack(archive, workdir / "unpacked")
+
+    path = Path(source).expanduser()
+    if path.is_dir():
+        return path
+    if path.suffix == ".zip" and path.is_file():
+        return _unpack(path, workdir / "unpacked")
+
+    raise SkillValidationError(
+        f"Cannot import {source!r}: it is neither a directory, a .zip bundle, nor an "
+        "https URL. Point 'gaia skill import' at a skill folder containing "
+        f"{SKILL_FILENAME}, at a .zip produced by 'gaia skill export', or at a URL "
+        "serving one."
+    )
+
+
+def _download(url: str, destination: Path) -> Path:
+    import requests
+
+    log.info("Downloading skill bundle from %s", url)
+    try:
+        response = requests.get(url, timeout=60, stream=True)
+        response.raise_for_status()
+    except requests.RequestException as exc:
+        raise SkillError(
+            f"Could not download {url}: {exc}. Check the URL and your network, then "
+            "retry — or download the .zip yourself and pass the local path."
+        ) from exc
+
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    with destination.open("wb") as handle:
+        for chunk in response.iter_content(chunk_size=65536):
+            handle.write(chunk)
+    return destination
+
+
+def _unpack(archive: Path, destination: Path) -> Path:
+    """Extract a skill .zip, rejecting path traversal, and return its root."""
+    destination.mkdir(parents=True, exist_ok=True)
+    try:
+        with zipfile.ZipFile(archive) as bundle:
+            for member in bundle.namelist():
+                resolved = (destination / member).resolve()
+                if (
+                    destination.resolve() not in resolved.parents
+                    and resolved != destination.resolve()
+                ):
+                    raise SkillValidationError(
+                        f"Refusing to extract {archive}: entry {member!r} escapes the "
+                        "destination directory. The bundle is malformed or hostile."
+                    )
+            bundle.extractall(destination)
+    except zipfile.BadZipFile as exc:
+        raise SkillValidationError(
+            f"{archive} is not a valid .zip bundle: {exc}. Export it with "
+            "'gaia skill export <name>' and retry."
+        ) from exc
+
+    return _find_skill_root(destination, archive)
+
+
+def _find_skill_root(directory: Path, origin: Path) -> Path:
+    """Locate the directory holding SKILL.md inside an extracted bundle."""
+    if (directory / SKILL_FILENAME).is_file():
+        return directory
+    candidates = sorted(directory.glob(f"*/{SKILL_FILENAME}"))
+    if len(candidates) == 1:
+        return candidates[0].parent
+    if not candidates:
+        raise SkillValidationError(
+            f"No {SKILL_FILENAME} found in {origin}. A skill bundle must contain "
+            f"{SKILL_FILENAME} at its root or one level down."
+        )
+    names = ", ".join(c.parent.name for c in candidates)
+    raise SkillValidationError(
+        f"{origin} contains more than one skill ({names}). Import them one at a time "
+        "by extracting the bundle and pointing 'gaia skill import' at a single folder."
+    )
+
+
+def _scaffold_body(name: str, *, with_tools: bool) -> str:
+    title = name.replace("-", " ").title()
+    if with_tools:
+        return (
+            f"# {title}\n\n"
+            "Explain when the model should reach for this skill and how to use its "
+            "tools.\n\n"
+            f"1. Call `{name}/example_tool` with the text to process.\n"
+            "2. Summarize the result for the user.\n"
+        )
+    return (
+        f"# {title}\n\n"
+        "Write the procedure the model should follow. Keep it concrete — numbered "
+        "steps beat prose.\n\n"
+        "1. First step.\n2. Second step.\n3. What 'done' looks like.\n"
+    )
+
+
+_SCAFFOLD_TOOLS = '''# Tools provided by this skill.
+# Every function here must have a matching entry in metadata.gaia.tools —
+# a mismatch makes the skill fail to load (by design, no partial loads).
+
+from gaia.agents.base.tools import tool
+
+
+@tool
+def example_tool(text: str) -> dict:
+    """Replace this with what your tool does."""
+    return {"echo": text}
+'''
+
+
+def resolve_manager(agent_skill_dirs: Optional[list] = None) -> SkillManager:
+    """Build a manager for embedders that need the CLI's root configuration."""
+    return SkillManager(agent_skill_dirs=agent_skill_dirs or [])

--- a/src/gaia/skills/errors.py
+++ b/src/gaia/skills/errors.py
@@ -1,0 +1,40 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""
+Error types for the skills runtime.
+
+Every error names three things (GAIA's fail-loudly rule): *what failed*, *what
+the caller should do*, and *where to look next*. Callers that catch these are
+expected to surface the message verbatim — never to substitute a default.
+"""
+
+from __future__ import annotations
+
+DOCS_URL = "https://amd-gaia.ai/docs/spec/agent-skills"
+FORMAT_DOCS_URL = "https://amd-gaia.ai/docs/plans/skill-format"
+
+
+class SkillError(Exception):
+    """Base class for every skills-runtime failure."""
+
+
+class SkillValidationError(SkillError):
+    """A ``SKILL.md`` is malformed, incomplete, or contradicts its ``tools.py``.
+
+    Raised before anything is registered so a rejected skill never leaves a
+    partial load behind.
+    """
+
+
+class SkillNotFoundError(SkillError):
+    """No skill of that name exists in any discovery root."""
+
+
+class SkillPermissionError(SkillError):
+    """The skill declares a permission this phase cannot honor.
+
+    Phase 1 bridges only connector-backed domains (``network``, ``mcp``). A
+    local-capability domain (``filesystem``, ``shell``, ``database``,
+    ``desktop``, ``env``) needs the Phase 2 sandbox, so the skill is refused
+    outright rather than loaded without enforcement.
+    """

--- a/src/gaia/skills/format.py
+++ b/src/gaia/skills/format.py
@@ -1,0 +1,677 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""
+``SKILL.md`` parser, writer, and validator.
+
+The on-disk contract is the `Agent Skills <https://agentskills.io>`_ base
+(``name``, ``description``, optional ``license`` / ``metadata``) plus GAIA's
+two additions: a top-level ``version`` and everything else nested under
+``metadata.gaia``. A bare standard skill — only ``name`` and ``description`` —
+loads as a valid instruction-only skill with the most conservative defaults
+(``security_tier: experimental``, no tools, no permissions).
+
+Round-trip is identity: ``parse(write(parse(text)))`` equals ``parse(text)``.
+Unknown top-level keys, other ``metadata.<vendor>`` namespaces, and unknown
+``metadata.gaia`` keys are all preserved so nothing is lost by passing a
+foreign skill through GAIA.
+
+The standard's ``compatibility`` and ``allowed-tools`` keys parse but are
+**ignored** — they overlap ``metadata.gaia`` and are not a permission
+mechanism. See ``docs/plans/skill-format.mdx``.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Optional
+
+import yaml
+
+from gaia.logger import get_logger
+from gaia.skills.errors import FORMAT_DOCS_URL, SkillValidationError
+from gaia.skills.permissions import Permission, parse_permissions
+
+log = get_logger(__name__)
+
+#: The one required file in a skill directory.
+SKILL_FILENAME = "SKILL.md"
+
+#: Optional module providing the skill's own ``@tool`` functions.
+SKILL_TOOLS_FILENAME = "tools.py"
+
+SECURITY_TIERS: tuple[str, ...] = ("verified", "community", "experimental")
+DEFAULT_SECURITY_TIER = "experimental"
+
+MAX_NAME_LENGTH = 64
+MAX_DESCRIPTION_LENGTH = 1024
+
+NAME_PATTERN = re.compile(r"^[a-z0-9]+(-[a-z0-9]+)*$")
+
+# Official SemVer 2.0.0 pattern (semver.org).
+SEMVER_PATTERN = re.compile(
+    r"^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)"
+    r"(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)"
+    r"(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?"
+    r"(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$"
+)
+
+#: Standard keys GAIA parses but deliberately ignores (see module docstring).
+IGNORED_STANDARD_KEYS = ("compatibility", "allowed-tools", "disallowed-tools")
+
+_FRONTMATTER_RE = re.compile(
+    r"^---[ \t]*\r?\n(.*?)\r?\n---[ \t]*(?:\r?\n|$)", re.DOTALL
+)
+
+
+@dataclass
+class SkillRequirements:
+    """``metadata.gaia.requirements`` — all advisory in Phase 1."""
+
+    model: Optional[str] = None
+    context: Optional[str] = None
+    python: Optional[str] = None
+    dependencies: list[str] = field(default_factory=list)
+    node_dependencies: list[str] = field(default_factory=list)
+    env_vars: list[str] = field(default_factory=list)
+    hardware: dict[str, Any] = field(default_factory=dict)
+    #: Requirement keys GAIA does not model, preserved verbatim for round-trip.
+    extra: dict[str, Any] = field(default_factory=dict)
+
+    def is_empty(self) -> bool:
+        """True when no constraint is declared (the omitted-default state)."""
+        return self == SkillRequirements()
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize back to the frontmatter shape, omitting empty fields."""
+        out: dict[str, Any] = {}
+        for key in ("model", "context", "python"):
+            value = getattr(self, key)
+            if value is not None:
+                out[key] = value
+        for key in ("dependencies", "node_dependencies", "env_vars"):
+            value = getattr(self, key)
+            if value:
+                out[key] = list(value)
+        if self.hardware:
+            out["hardware"] = dict(self.hardware)
+        out.update(self.extra)
+        return out
+
+    @classmethod
+    def from_dict(cls, data: Any, *, skill_name: str) -> "SkillRequirements":
+        """Build from the frontmatter mapping, failing loudly on a bad shape."""
+        if data is None:
+            return cls()
+        if not isinstance(data, dict):
+            raise SkillValidationError(
+                f"Skill '{skill_name}': metadata.gaia.requirements must be a mapping, "
+                f"got {type(data).__name__}. Example: "
+                "'requirements: {python: \">=3.10\"}'. "
+                f"See {FORMAT_DOCS_URL}#the-metadatagaia-namespace"
+            )
+
+        known = {
+            "model",
+            "context",
+            "python",
+            "dependencies",
+            "node_dependencies",
+            "env_vars",
+            "hardware",
+        }
+        for key in ("dependencies", "node_dependencies", "env_vars"):
+            value = data.get(key)
+            if value is not None and not isinstance(value, list):
+                raise SkillValidationError(
+                    f"Skill '{skill_name}': metadata.gaia.requirements.{key} must be a "
+                    f"list, got {type(value).__name__}. "
+                    f"See {FORMAT_DOCS_URL}#the-metadatagaia-namespace"
+                )
+        hardware = data.get("hardware") or {}
+        if not isinstance(hardware, dict):
+            raise SkillValidationError(
+                f"Skill '{skill_name}': metadata.gaia.requirements.hardware must be a "
+                f"mapping, got {type(hardware).__name__}. "
+                f"See {FORMAT_DOCS_URL}#the-metadatagaia-namespace"
+            )
+
+        return cls(
+            model=data.get("model"),
+            context=data.get("context"),
+            python=data.get("python"),
+            dependencies=list(data.get("dependencies") or []),
+            node_dependencies=list(data.get("node_dependencies") or []),
+            env_vars=list(data.get("env_vars") or []),
+            hardware=dict(hardware),
+            extra={k: v for k, v in data.items() if k not in known},
+        )
+
+
+@dataclass
+class SkillTool:
+    """One entry of ``metadata.gaia.tools`` — a tool the skill *provides*.
+
+    Distinct from ``tools_required``, which names registry tools the skill
+    *consumes*. Never conflate the two.
+    """
+
+    name: str
+    description: str = ""
+    #: ``{param_name: {"type": ..., "required": ..., "default": ...}}``
+    parameters: dict[str, dict[str, Any]] = field(default_factory=dict)
+    returns: Optional[dict[str, Any]] = None
+    atomic: bool = False
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize back to the frontmatter shape."""
+        out: dict[str, Any] = {"name": self.name}
+        if self.description:
+            out["description"] = self.description
+        out["parameters"] = {k: dict(v) for k, v in self.parameters.items()}
+        if self.returns is not None:
+            out["returns"] = dict(self.returns)
+        if self.atomic:
+            out["atomic"] = self.atomic
+        return out
+
+    @classmethod
+    def from_dict(cls, data: Any, *, skill_name: str) -> "SkillTool":
+        """Build from a frontmatter entry, failing loudly on a bad shape."""
+        if not isinstance(data, dict):
+            raise SkillValidationError(
+                f"Skill '{skill_name}': each metadata.gaia.tools entry must be a "
+                f"mapping with a 'name', got {type(data).__name__}. "
+                f"See {FORMAT_DOCS_URL}#the-metadatagaia-namespace"
+            )
+        name = data.get("name")
+        if not name or not isinstance(name, str):
+            raise SkillValidationError(
+                f"Skill '{skill_name}': a metadata.gaia.tools entry is missing its "
+                "'name'. Every declared tool must name the @tool function in "
+                f"{SKILL_TOOLS_FILENAME} that implements it. "
+                f"See {FORMAT_DOCS_URL}#tool-registration"
+            )
+
+        raw_params = data.get("parameters") or {}
+        if not isinstance(raw_params, dict):
+            raise SkillValidationError(
+                f"Skill '{skill_name}': tool '{name}' has 'parameters' of type "
+                f"{type(raw_params).__name__}; it must be a mapping of "
+                "parameter name to {type, required, default}. "
+                f"See {FORMAT_DOCS_URL}#the-metadatagaia-namespace"
+            )
+        parameters: dict[str, dict[str, Any]] = {}
+        for param_name, spec in raw_params.items():
+            if not isinstance(spec, dict):
+                raise SkillValidationError(
+                    f"Skill '{skill_name}': tool '{name}' parameter "
+                    f"'{param_name}' must be a mapping like "
+                    "'{type: string, required: true}', got "
+                    f"{type(spec).__name__}. "
+                    f"See {FORMAT_DOCS_URL}#the-metadatagaia-namespace"
+                )
+            parameters[param_name] = dict(spec)
+
+        returns = data.get("returns")
+        if returns is not None and not isinstance(returns, dict):
+            raise SkillValidationError(
+                f"Skill '{skill_name}': tool '{name}' has 'returns' of type "
+                f"{type(returns).__name__}; it must be a mapping like "
+                f"'{{type: object}}'. See {FORMAT_DOCS_URL}#the-metadatagaia-namespace"
+            )
+
+        return cls(
+            name=name,
+            description=data.get("description", "") or "",
+            parameters=parameters,
+            returns=dict(returns) if returns is not None else None,
+            atomic=bool(data.get("atomic", False)),
+        )
+
+
+@dataclass
+class GaiaMetadata:
+    """The ``metadata.gaia`` namespace. Omit it entirely for a bare skill."""
+
+    security_tier: str = DEFAULT_SECURITY_TIER
+    permissions: list[str] = field(default_factory=list)
+    requirements: SkillRequirements = field(default_factory=SkillRequirements)
+    tools: list[SkillTool] = field(default_factory=list)
+    tools_required: list[str] = field(default_factory=list)
+    #: ``metadata.gaia`` keys GAIA does not model, preserved for round-trip.
+    extra: dict[str, Any] = field(default_factory=dict)
+
+    def is_default(self) -> bool:
+        """True when every field holds its omitted-default value."""
+        return self == GaiaMetadata()
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize back to the frontmatter shape, omitting defaults."""
+        out: dict[str, Any] = {}
+        if self.security_tier != DEFAULT_SECURITY_TIER:
+            out["security_tier"] = self.security_tier
+        if self.permissions:
+            out["permissions"] = list(self.permissions)
+        if not self.requirements.is_empty():
+            out["requirements"] = self.requirements.to_dict()
+        if self.tools:
+            out["tools"] = [t.to_dict() for t in self.tools]
+        if self.tools_required:
+            out["tools_required"] = list(self.tools_required)
+        out.update(self.extra)
+        return out
+
+    @classmethod
+    def from_dict(cls, data: Any, *, skill_name: str) -> "GaiaMetadata":
+        """Build from the ``metadata.gaia`` mapping, failing loudly on a bad shape."""
+        if data is None:
+            return cls()
+        if not isinstance(data, dict):
+            raise SkillValidationError(
+                f"Skill '{skill_name}': metadata.gaia must be a mapping, got "
+                f"{type(data).__name__}. Omit it entirely for an instruction-only "
+                f"skill. See {FORMAT_DOCS_URL}#the-metadatagaia-namespace"
+            )
+
+        tier = data.get("security_tier", DEFAULT_SECURITY_TIER)
+        if tier not in SECURITY_TIERS:
+            raise SkillValidationError(
+                f"Skill '{skill_name}': metadata.gaia.security_tier is {tier!r}, which "
+                f"is not one of {', '.join(SECURITY_TIERS)}. Omit the field to take "
+                f"the safe default ('{DEFAULT_SECURITY_TIER}'). "
+                f"See {FORMAT_DOCS_URL}#security-tiers"
+            )
+
+        permissions = data.get("permissions") or []
+        if not isinstance(permissions, list):
+            raise SkillValidationError(
+                f"Skill '{skill_name}': metadata.gaia.permissions must be a list of "
+                f"'<domain>:<level>[:scope]' strings, got {type(permissions).__name__}. "
+                f"See {FORMAT_DOCS_URL}#permission-model"
+            )
+
+        tools = data.get("tools") or []
+        if not isinstance(tools, list):
+            raise SkillValidationError(
+                f"Skill '{skill_name}': metadata.gaia.tools must be a list, got "
+                f"{type(tools).__name__}. Each entry declares one @tool function this "
+                f"skill provides. See {FORMAT_DOCS_URL}#tools-vs-tools_required"
+            )
+
+        tools_required = data.get("tools_required") or []
+        if not isinstance(tools_required, list):
+            raise SkillValidationError(
+                f"Skill '{skill_name}': metadata.gaia.tools_required must be a list of "
+                f"registry tool names, got {type(tools_required).__name__}. "
+                f"See {FORMAT_DOCS_URL}#tools-vs-tools_required"
+            )
+
+        known = {
+            "security_tier",
+            "permissions",
+            "requirements",
+            "tools",
+            "tools_required",
+        }
+        return cls(
+            security_tier=tier,
+            permissions=[str(p) for p in permissions],
+            requirements=SkillRequirements.from_dict(
+                data.get("requirements"), skill_name=skill_name
+            ),
+            tools=[SkillTool.from_dict(t, skill_name=skill_name) for t in tools],
+            tools_required=[str(t) for t in tools_required],
+            extra={k: v for k, v in data.items() if k not in known},
+        )
+
+
+@dataclass
+class Skill:
+    """A parsed ``SKILL.md``: frontmatter + Markdown body.
+
+    Location fields (``path``, ``root``, ``read_only``) describe *where* the
+    skill came from, not *what* it is, so they are excluded from equality —
+    that is what makes round-trip identity meaningful across directories.
+    """
+
+    name: str
+    description: str
+    body: str = ""
+    license: Optional[str] = None
+    version: Optional[str] = None
+    gaia: GaiaMetadata = field(default_factory=GaiaMetadata)
+    #: Other ``metadata.<vendor>`` namespaces (hermes, openclaw, …), preserved.
+    other_metadata: dict[str, Any] = field(default_factory=dict)
+    #: Top-level keys GAIA does not model — including the deliberately ignored
+    #: ``compatibility`` / ``allowed-tools`` — preserved for round-trip.
+    extra_fields: dict[str, Any] = field(default_factory=dict)
+
+    # --- provenance (never part of equality) ---
+    path: Optional[Path] = field(default=None, compare=False, repr=False)
+    root: Optional[str] = field(default=None, compare=False, repr=False)
+    read_only: bool = field(default=False, compare=False, repr=False)
+
+    # ------------------------------------------------------------------
+    # Derived views
+    # ------------------------------------------------------------------
+
+    @property
+    def directory(self) -> Optional[Path]:
+        """The skill's directory, or ``None`` when parsed from a string."""
+        return self.path.parent if self.path else None
+
+    @property
+    def security_tier(self) -> str:
+        """Install-time trust tier; ``experimental`` unless declared."""
+        return self.gaia.security_tier
+
+    @property
+    def is_instruction_only(self) -> bool:
+        """True when the skill ships instructions and no tools of its own."""
+        return not self.gaia.tools
+
+    @property
+    def tool_names(self) -> list[str]:
+        """Unqualified names of the tools this skill provides."""
+        return [t.name for t in self.gaia.tools]
+
+    def namespaced_tool_name(self, tool_name: str) -> str:
+        """Return ``<skill-name>/<tool>`` — the registry key used on load."""
+        return f"{self.name}/{tool_name}"
+
+    @property
+    def tools_path(self) -> Optional[Path]:
+        """Path to the skill's ``tools.py``, if the skill is on disk."""
+        directory = self.directory
+        return directory / SKILL_TOOLS_FILENAME if directory else None
+
+    def parsed_permissions(self) -> list[Permission]:
+        """Parse the declared permission strings (fails loudly on bad grammar)."""
+        return parse_permissions(self.gaia.permissions, skill_name=self.name)
+
+    # ------------------------------------------------------------------
+    # Serialization
+    # ------------------------------------------------------------------
+
+    def to_frontmatter(self) -> dict[str, Any]:
+        """Build the frontmatter mapping in canonical key order."""
+        out: dict[str, Any] = {"name": self.name, "description": self.description}
+        if self.license is not None:
+            out["license"] = self.license
+        if self.version is not None:
+            out["version"] = self.version
+
+        metadata: dict[str, Any] = {}
+        gaia_block = self.gaia.to_dict()
+        if gaia_block or not self.gaia.is_default():
+            metadata["gaia"] = gaia_block
+        metadata.update(self.other_metadata)
+        if metadata:
+            out["metadata"] = metadata
+
+        out.update(self.extra_fields)
+        return out
+
+    def to_markdown(self) -> str:
+        """Render the skill back to ``SKILL.md`` text."""
+        frontmatter = yaml.safe_dump(
+            self.to_frontmatter(),
+            sort_keys=False,
+            default_flow_style=False,
+            allow_unicode=True,
+        )
+        body = self.body.strip("\n")
+        return (
+            f"---\n{frontmatter}---\n\n{body}\n" if body else f"---\n{frontmatter}---\n"
+        )
+
+    def write(self, path: Optional[Path] = None) -> Path:
+        """Write the skill to ``path`` (default: its own ``path``)."""
+        target = Path(path) if path is not None else self.path
+        if target is None:
+            raise ValueError(
+                "Skill.write() needs a destination: this Skill was parsed from a "
+                "string, so it has no path of its own. Pass path=<dir>/SKILL.md."
+            )
+        target = Path(target)
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(self.to_markdown(), encoding="utf-8")
+        return target
+
+
+# ----------------------------------------------------------------------
+# Parsing
+# ----------------------------------------------------------------------
+
+
+def parse_skill(text: str, *, source: str = "<string>") -> Skill:
+    """Parse ``SKILL.md`` text into a :class:`Skill`.
+
+    Args:
+        text: The full file contents (frontmatter + Markdown body).
+        source: Where the text came from, quoted in error messages.
+
+    Raises:
+        SkillValidationError: on missing/malformed frontmatter or a field that
+            violates the schema. Nothing partial is ever returned.
+    """
+    if not isinstance(text, str):
+        raise SkillValidationError(
+            f"{source}: expected SKILL.md text, got {type(text).__name__}."
+        )
+
+    stripped = text.lstrip("﻿")
+    match = _FRONTMATTER_RE.match(stripped)
+    if not match:
+        raise SkillValidationError(
+            f"{source}: no YAML frontmatter found. A SKILL.md must open with a '---' "
+            "line, the YAML fields, and a closing '---' line, e.g.:\n"
+            "  ---\n  name: my-skill\n  description: What it does and when to use it.\n"
+            f"  ---\nSee {FORMAT_DOCS_URL}#adopted-base-agent-skills-standard"
+        )
+
+    raw_yaml = match.group(1)
+    body = stripped[match.end() :]
+
+    try:
+        frontmatter = yaml.safe_load(raw_yaml)
+    except yaml.YAMLError as exc:
+        raise SkillValidationError(
+            f"{source}: the YAML frontmatter is invalid: {exc}. Fix the YAML syntax "
+            f"(watch for tabs and unquoted ':'). See {FORMAT_DOCS_URL}"
+        ) from exc
+
+    if frontmatter is None:
+        frontmatter = {}
+    if not isinstance(frontmatter, dict):
+        raise SkillValidationError(
+            f"{source}: the frontmatter must be a YAML mapping of fields, got "
+            f"{type(frontmatter).__name__}. See {FORMAT_DOCS_URL}"
+        )
+
+    name = frontmatter.get("name")
+    if not name or not isinstance(name, str):
+        raise SkillValidationError(
+            f"{source}: required field 'name' is missing or not a string. Add "
+            "'name: <skill-directory-name>' to the frontmatter. "
+            f"See {FORMAT_DOCS_URL}#naming"
+        )
+
+    description = frontmatter.get("description")
+    if not description or not isinstance(description, str):
+        raise SkillValidationError(
+            f"{source}: required field 'description' is missing or not a string. It is "
+            "the trigger signal the model reads to decide relevance — say what the "
+            "skill does and when to use it. "
+            f"See {FORMAT_DOCS_URL}#adopted-base-agent-skills-standard"
+        )
+
+    for key in ("license", "version"):
+        value = frontmatter.get(key)
+        if value is not None and not isinstance(value, str):
+            raise SkillValidationError(
+                f"{source}: field '{key}' must be a string, got "
+                f"{type(value).__name__}. Quote it if it looks numeric "
+                f'(e.g. version: "1.0.0"). See {FORMAT_DOCS_URL}'
+            )
+
+    raw_metadata = frontmatter.get("metadata") or {}
+    if not isinstance(raw_metadata, dict):
+        raise SkillValidationError(
+            f"{source}: field 'metadata' must be a mapping of vendor namespaces "
+            f"(e.g. 'metadata: {{gaia: {{...}}}}'), got {type(raw_metadata).__name__}. "
+            f"See {FORMAT_DOCS_URL}#the-metadatagaia-namespace"
+        )
+
+    present_ignored = [k for k in IGNORED_STANDARD_KEYS if k in frontmatter]
+    if present_ignored:
+        log.debug(
+            "%s: ignoring standard key(s) %s — they are not part of GAIA's adopted "
+            "base and are never a permission mechanism; permissions come from "
+            "metadata.gaia.permissions.",
+            source,
+            ", ".join(present_ignored),
+        )
+
+    known_top_level = {"name", "description", "license", "version", "metadata"}
+    skill = Skill(
+        name=name,
+        description=description,
+        body=body.strip("\n"),
+        license=frontmatter.get("license"),
+        version=frontmatter.get("version"),
+        gaia=GaiaMetadata.from_dict(raw_metadata.get("gaia"), skill_name=name),
+        other_metadata={k: v for k, v in raw_metadata.items() if k != "gaia"},
+        extra_fields={k: v for k, v in frontmatter.items() if k not in known_top_level},
+    )
+
+    validate_skill(skill, source=source)
+    return skill
+
+
+def parse_skill_file(
+    path: Path | str,
+    *,
+    root: Optional[str] = None,
+    read_only: bool = False,
+    check_directory_name: bool = True,
+) -> Skill:
+    """Parse a ``SKILL.md`` from disk.
+
+    Args:
+        path: Either the ``SKILL.md`` file or the directory containing it.
+        root: Label of the discovery root this skill came from.
+        read_only: True for imported roots (``.claude/skills/``).
+        check_directory_name: Enforce ``name`` == directory name.
+
+    Raises:
+        SkillValidationError: if the file is missing or fails validation.
+    """
+    path = Path(path)
+    skill_file = path / SKILL_FILENAME if path.is_dir() else path
+
+    if not skill_file.is_file():
+        raise SkillValidationError(
+            f"No {SKILL_FILENAME} at {skill_file}. A skill is a directory whose only "
+            f"required file is {SKILL_FILENAME}. Create one with "
+            f"'gaia skill create <name>'. See {FORMAT_DOCS_URL}"
+        )
+
+    try:
+        text = skill_file.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError) as exc:
+        raise SkillValidationError(
+            f"Could not read {skill_file}: {exc}. Check the file's permissions and "
+            "that it is UTF-8 encoded."
+        ) from exc
+
+    skill = parse_skill(text, source=str(skill_file))
+    skill.path = skill_file
+    skill.root = root
+    skill.read_only = read_only
+
+    if check_directory_name:
+        directory_name = skill_file.parent.name
+        if skill.name != directory_name:
+            raise SkillValidationError(
+                f"{skill_file}: frontmatter says name: {skill.name!r} but the "
+                f"directory is named {directory_name!r}. The two must match — rename "
+                f"the directory to '{skill.name}' or change the frontmatter to "
+                f"'name: {directory_name}'. See {FORMAT_DOCS_URL}#naming"
+            )
+
+    return skill
+
+
+def parse_skill_metadata(
+    path: Path | str,
+    *,
+    root: Optional[str] = None,
+    read_only: bool = False,
+) -> Skill:
+    """Parse only the frontmatter of a ``SKILL.md``, dropping the body.
+
+    Level 1 of progressive disclosure: discovery keeps every skill's metadata
+    resident but never pays for its instructions until the skill triggers.
+    """
+    path = Path(path)
+    skill_file = path / SKILL_FILENAME if path.is_dir() else path
+    skill = parse_skill_file(skill_file, root=root, read_only=read_only)
+    skill.body = ""
+    return skill
+
+
+# ----------------------------------------------------------------------
+# Validation
+# ----------------------------------------------------------------------
+
+
+def validate_skill(skill: Skill, *, source: str = "<skill>") -> None:
+    """Validate a parsed skill's fields. Raises on the first violation.
+
+    Checks the schema-level invariants only — the ``tools`` ↔ ``tools.py``
+    cross-check needs the module and lives in :mod:`gaia.skills.loader`.
+    """
+    if len(skill.name) > MAX_NAME_LENGTH:
+        raise SkillValidationError(
+            f"{source}: name {skill.name!r} is {len(skill.name)} characters; the limit "
+            f"is {MAX_NAME_LENGTH}. Shorten it (and its directory name to match). "
+            f"See {FORMAT_DOCS_URL}#naming"
+        )
+
+    if not NAME_PATTERN.match(skill.name):
+        raise SkillValidationError(
+            f"{source}: name {skill.name!r} is not a valid skill name. Use lowercase "
+            "letters and digits separated by single hyphens (e.g. 'web-research') — "
+            "no uppercase, underscores, spaces, or leading/trailing/consecutive "
+            f"hyphens. See {FORMAT_DOCS_URL}#naming"
+        )
+
+    if len(skill.description) > MAX_DESCRIPTION_LENGTH:
+        raise SkillValidationError(
+            f"{source}: description is {len(skill.description)} characters; the limit "
+            f"is {MAX_DESCRIPTION_LENGTH}. It is a trigger signal, not documentation — "
+            "move the detail into the Markdown body. "
+            f"See {FORMAT_DOCS_URL}#adopted-base-agent-skills-standard"
+        )
+
+    if skill.version is not None and not SEMVER_PATTERN.match(skill.version):
+        raise SkillValidationError(
+            f"{source}: version {skill.version!r} is not valid SemVer. Use "
+            "MAJOR.MINOR.PATCH (e.g. '1.0.0'); omit the field if the skill is "
+            f"unversioned. See {FORMAT_DOCS_URL}#field-reference"
+        )
+
+    # Parsing the permission strings is the validation — bad grammar raises here.
+    skill.parsed_permissions()
+
+    declared = [t.name for t in skill.gaia.tools]
+    duplicates = {n for n in declared if declared.count(n) > 1}
+    if duplicates:
+        raise SkillValidationError(
+            f"{source}: metadata.gaia.tools declares {', '.join(sorted(duplicates))} "
+            "more than once. Each tool name must be unique within a skill. "
+            f"See {FORMAT_DOCS_URL}#tool-registration"
+        )

--- a/src/gaia/skills/loader.py
+++ b/src/gaia/skills/loader.py
@@ -1,0 +1,292 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""
+Level 2 of progressive disclosure: import a skill's ``tools.py`` and register
+its tools into ``_TOOL_REGISTRY`` under the ``<skill-name>/<tool>`` namespace.
+
+Two invariants drive this module:
+
+- **The manifest is the contract.** Every tool declared in
+  ``metadata.gaia.tools`` must exist in ``tools.py`` with a matching signature
+  (parameter names, requiredness, and inferred types). A mismatch is a defect,
+  not a warning.
+- **No partial load.** Any failure restores ``_TOOL_REGISTRY`` byte-for-byte to
+  its pre-import state, so a rejected skill never leaves half its tools behind.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import re
+import sys
+import threading
+from pathlib import Path
+from types import ModuleType
+from typing import Any, Optional
+
+from gaia.agents.base.tools import _TOOL_REGISTRY
+from gaia.logger import get_logger
+from gaia.skills.errors import FORMAT_DOCS_URL, SkillValidationError
+from gaia.skills.format import SKILL_TOOLS_FILENAME, Skill, SkillTool
+
+log = get_logger(__name__)
+
+# Import + registry mutation must not interleave across threads: the diff-based
+# capture below assumes nothing else writes to _TOOL_REGISTRY mid-import.
+_IMPORT_LOCK = threading.RLock()
+
+_MODULE_NAME_SAFE = re.compile(r"[^0-9a-zA-Z_]")
+
+
+def register_skill_tools(skill: Skill) -> dict[str, dict[str, Any]]:
+    """Import ``tools.py`` and register the skill's tools, namespaced.
+
+    Args:
+        skill: A validated skill with a ``path`` on disk.
+
+    Returns:
+        The registry entries that were added, keyed by ``<skill>/<tool>``. Empty
+        for an instruction-only skill.
+
+    Raises:
+        SkillValidationError: if ``tools.py`` is missing, fails to import, or
+            contradicts the declared ``metadata.gaia.tools``. The registry is
+            left exactly as it was found.
+    """
+    if not skill.gaia.tools:
+        tools_path = skill.tools_path
+        if tools_path is not None and tools_path.is_file():
+            log.debug(
+                "Skill '%s' ships %s but declares no metadata.gaia.tools; not "
+                "importing it — the manifest is the contract.",
+                skill.name,
+                SKILL_TOOLS_FILENAME,
+            )
+        return {}
+
+    tools_path = skill.tools_path
+    if tools_path is None:
+        raise SkillValidationError(
+            f"Skill '{skill.name}' declares tools but was parsed from a string, so "
+            f"there is no {SKILL_TOOLS_FILENAME} to import. Load the skill from its "
+            "directory instead (SkillManager.load / Agent.load_skill)."
+        )
+    if not tools_path.is_file():
+        declared = ", ".join(t.name for t in skill.gaia.tools)
+        raise SkillValidationError(
+            f"Skill '{skill.name}' declares tools ({declared}) but has no "
+            f"{SKILL_TOOLS_FILENAME} at {tools_path}. Add the module with a @tool "
+            "function per declared entry, or remove metadata.gaia.tools to make it an "
+            f"instruction-only skill. See {FORMAT_DOCS_URL}#tool-registration"
+        )
+
+    module_name = f"gaia_skill_{_MODULE_NAME_SAFE.sub('_', skill.name)}_tools"
+
+    with _IMPORT_LOCK:
+        before = dict(_TOOL_REGISTRY)
+        previous_module = sys.modules.get(module_name)
+        skill_dir = str(tools_path.parent)
+        added_syspath = skill_dir not in sys.path
+
+        try:
+            if added_syspath:
+                sys.path.insert(0, skill_dir)
+            module = _import_tools_module(module_name, tools_path, skill)
+            # A skill tool may share an unqualified name with a registry tool
+            # (a skill providing ``search_web`` alongside BrowserToolsMixin is
+            # exactly what the ``<skill>/<tool>`` namespace exists for), and the
+            # decorator overwrites that key. Compare identity, not presence, so
+            # the overwrite is detected and the original is restored below.
+            discovered = {
+                name: entry
+                for name, entry in _TOOL_REGISTRY.items()
+                if name not in before or entry is not before[name]
+            }
+            _validate_declared_tools(skill, discovered, module, tools_path)
+            namespaced = _namespace_entries(skill, discovered)
+        except BaseException:
+            # No partial load: put the registry (and sys.modules) back untouched.
+            _TOOL_REGISTRY.clear()
+            _TOOL_REGISTRY.update(before)
+            _restore_module(module_name, previous_module)
+            raise
+        finally:
+            if added_syspath and skill_dir in sys.path:
+                sys.path.remove(skill_dir)
+
+        # Swap the unqualified keys the decorator wrote for namespaced ones.
+        _TOOL_REGISTRY.clear()
+        _TOOL_REGISTRY.update(before)
+        _TOOL_REGISTRY.update(namespaced)
+
+    log.info(
+        "Registered %d tool(s) from skill '%s': %s",
+        len(namespaced),
+        skill.name,
+        ", ".join(sorted(namespaced)),
+    )
+    return namespaced
+
+
+def unregister_skill_tools(skill_name: str) -> list[str]:
+    """Remove every ``<skill_name>/<tool>`` entry from the registry.
+
+    Returns the removed keys. Used by hot-reload and by rollback paths.
+    """
+    prefix = f"{skill_name}/"
+    with _IMPORT_LOCK:
+        removed = [key for key in _TOOL_REGISTRY if key.startswith(prefix)]
+        for key in removed:
+            del _TOOL_REGISTRY[key]
+    if removed:
+        log.debug("Unregistered %d tool(s) for skill '%s'", len(removed), skill_name)
+    return removed
+
+
+def _import_tools_module(
+    module_name: str, tools_path: Path, skill: Skill
+) -> ModuleType:
+    """Import ``tools.py`` as a standalone module, failing loudly."""
+    spec = importlib.util.spec_from_file_location(module_name, tools_path)
+    if spec is None or spec.loader is None:
+        raise SkillValidationError(
+            f"Skill '{skill.name}': Python could not build an import spec for "
+            f"{tools_path}. Check that the file has a .py extension and is readable."
+        )
+
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    try:
+        spec.loader.exec_module(module)
+    except Exception as exc:
+        raise SkillValidationError(
+            f"Skill '{skill.name}': importing {tools_path} raised "
+            f"{type(exc).__name__}: {exc}. Fix the module (its imports must resolve "
+            "in the running environment — declare third-party packages under "
+            "metadata.gaia.requirements.dependencies and install them), then reload "
+            "the skill."
+        ) from exc
+    return module
+
+
+def _restore_module(module_name: str, previous: Optional[ModuleType]) -> None:
+    """Undo the ``sys.modules`` entry created for a failed import."""
+    if previous is not None:
+        sys.modules[module_name] = previous
+    else:
+        sys.modules.pop(module_name, None)
+
+
+def _validate_declared_tools(
+    skill: Skill,
+    discovered: dict[str, dict[str, Any]],
+    module: ModuleType,
+    tools_path: Path,
+) -> None:
+    """Cross-check ``metadata.gaia.tools`` against the imported module."""
+    declared_names = {t.name for t in skill.gaia.tools}
+
+    missing = sorted(declared_names - set(discovered))
+    if missing:
+        undecorated = [
+            name for name in missing if callable(getattr(module, name, None))
+        ]
+        hint = (
+            f" {', '.join(undecorated)} exist(s) but is not decorated — add "
+            "'@tool' from gaia.agents.base.tools."
+            if undecorated
+            else f" Define one @tool function per declared entry in {tools_path}."
+        )
+        raise SkillValidationError(
+            f"Skill '{skill.name}' declares tool(s) {', '.join(missing)} that "
+            f"{SKILL_TOOLS_FILENAME} does not register.{hint} Nothing was loaded. "
+            f"See {FORMAT_DOCS_URL}#tool-registration"
+        )
+
+    undeclared = sorted(set(discovered) - declared_names)
+    if undeclared:
+        raise SkillValidationError(
+            f"Skill '{skill.name}': {SKILL_TOOLS_FILENAME} registers tool(s) "
+            f"{', '.join(undeclared)} that the manifest does not declare. Add them to "
+            "metadata.gaia.tools (the manifest is the contract users audit) or remove "
+            f"them from the module. Nothing was loaded. "
+            f"See {FORMAT_DOCS_URL}#tool-registration"
+        )
+
+    for declared in skill.gaia.tools:
+        _validate_signature(skill, declared, discovered[declared.name], tools_path)
+
+
+def _validate_signature(
+    skill: Skill,
+    declared: SkillTool,
+    actual: dict[str, Any],
+    tools_path: Path,
+) -> None:
+    """Compare one declared tool against the signature the decorator inferred."""
+    actual_params: dict[str, dict[str, Any]] = actual.get("parameters", {})
+
+    declared_names = set(declared.parameters)
+    actual_names = set(actual_params)
+
+    if declared_names != actual_names:
+        only_manifest = sorted(declared_names - actual_names)
+        only_code = sorted(actual_names - declared_names)
+        detail = []
+        if only_manifest:
+            detail.append(
+                f"declared but absent from the function: {', '.join(only_manifest)}"
+            )
+        if only_code:
+            detail.append(f"in the function but undeclared: {', '.join(only_code)}")
+        raise SkillValidationError(
+            f"Skill '{skill.name}': tool '{declared.name}' parameters do not match "
+            f"{tools_path} — {'; '.join(detail)}. Make metadata.gaia.tools mirror the "
+            f"function signature exactly. Nothing was loaded. "
+            f"See {FORMAT_DOCS_URL}#tool-registration"
+        )
+
+    for param_name, declared_spec in declared.parameters.items():
+        actual_spec = actual_params[param_name]
+
+        declared_required = bool(declared_spec.get("required", False))
+        actual_required = bool(actual_spec.get("required", False))
+        if declared_required != actual_required:
+            expected = "required" if actual_required else "optional"
+            raise SkillValidationError(
+                f"Skill '{skill.name}': tool '{declared.name}' parameter "
+                f"'{param_name}' is declared "
+                f"{'required' if declared_required else 'optional'} but the function "
+                f"in {tools_path} makes it {expected} "
+                f"({'no default' if actual_required else 'has a default'}). Set "
+                f"'required: {str(actual_required).lower()}' or change the signature. "
+                f"Nothing was loaded."
+            )
+
+        declared_type = declared_spec.get("type")
+        actual_type = actual_spec.get("type", "unknown")
+        # "unknown" means the decorator could not infer a type from the
+        # annotation — there is nothing to contradict, so it is not a mismatch.
+        if declared_type and actual_type != "unknown" and declared_type != actual_type:
+            raise SkillValidationError(
+                f"Skill '{skill.name}': tool '{declared.name}' parameter "
+                f"'{param_name}' is declared type '{declared_type}' but the function "
+                f"in {tools_path} annotates it as '{actual_type}'. Align the manifest "
+                f"with the signature. Nothing was loaded."
+            )
+
+
+def _namespace_entries(
+    skill: Skill, discovered: dict[str, dict[str, Any]]
+) -> dict[str, dict[str, Any]]:
+    """Re-key the discovered entries under ``<skill-name>/<tool>``."""
+    namespaced: dict[str, dict[str, Any]] = {}
+    for tool_name, entry in discovered.items():
+        key = skill.namespaced_tool_name(tool_name)
+        namespaced[key] = {
+            **entry,
+            "name": key,
+            "display_name": f"{tool_name} ({skill.name})",
+            "skill": skill.name,
+        }
+    return namespaced

--- a/src/gaia/skills/loader.py
+++ b/src/gaia/skills/loader.py
@@ -28,6 +28,7 @@ from gaia.agents.base.tools import _TOOL_REGISTRY
 from gaia.logger import get_logger
 from gaia.skills.errors import FORMAT_DOCS_URL, SkillValidationError
 from gaia.skills.format import SKILL_TOOLS_FILENAME, Skill, SkillTool
+from gaia.skills.permissions import refuse_unbridged_permissions
 
 log = get_logger(__name__)
 
@@ -49,10 +50,17 @@ def register_skill_tools(skill: Skill) -> dict[str, dict[str, Any]]:
         for an instruction-only skill.
 
     Raises:
+        SkillPermissionError: if the skill declares a local-capability
+            permission this phase cannot enforce.
         SkillValidationError: if ``tools.py`` is missing, fails to import, or
             contradicts the declared ``metadata.gaia.tools``. The registry is
             left exactly as it was found.
     """
+    # Re-gated here, not only in Agent.load_skill: this is the function that
+    # actually hands a skill executable reach, so the refusal must hold no
+    # matter which entry point a caller uses.
+    refuse_unbridged_permissions(skill.parsed_permissions(), skill_name=skill.name)
+
     if not skill.gaia.tools:
         tools_path = skill.tools_path
         if tools_path is not None and tools_path.is_file():

--- a/src/gaia/skills/manager.py
+++ b/src/gaia/skills/manager.py
@@ -1,0 +1,405 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""
+Skill discovery, precedence, and progressive disclosure.
+
+**Three roots in v1** (issue #888 trims the spec's five), highest precedence
+first:
+
+===  ==========================================  ==========================
+ #    Root                                        Notes
+===  ==========================================  ==========================
+ 1    Agent-bundled ``skills/<name>/``            Shipped inside an agent package
+ 2    ``~/.gaia/skills/<name>/``                  This user, all projects
+ 3    ``./.claude/skills/`` + ``~/.claude/skills/``  Read-only Claude Code import
+===  ==========================================  ==========================
+
+A later root **never** overrides a same-named skill found in an earlier one;
+the shadowed copy stays visible via :meth:`SkillManager.shadowed` so precedence
+is auditable rather than silent.
+
+Project-local ``./.gaia/skills/`` and the registry-lock root are deferred to a
+later phase — do not add them here without updating ``docs/spec/agent-skills``.
+
+Progressive disclosure: :meth:`discover` parses frontmatter only (level 1),
+:meth:`load` adds the Markdown body (level 2), and :meth:`resource_path`
+resolves bundled files on demand (level 3).
+"""
+
+from __future__ import annotations
+
+import os
+import threading
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Callable, Iterable, Optional
+
+from gaia.logger import get_logger
+from gaia.skills.errors import (
+    DOCS_URL,
+    SkillError,
+    SkillNotFoundError,
+    SkillValidationError,
+)
+from gaia.skills.format import (
+    SKILL_FILENAME,
+    Skill,
+    parse_skill_file,
+    parse_skill_metadata,
+)
+
+log = get_logger(__name__)
+
+#: Discovery-root labels, highest precedence first.
+ROOT_AGENT_BUNDLED = "agent-bundled"
+ROOT_USER = "user"
+ROOT_CLAUDE_IMPORT = "claude-import"
+
+#: Environment override for the user root's parent (shared with the rest of GAIA).
+GAIA_CONFIG_DIR_ENV = "GAIA_CONFIG_DIR"
+
+
+@dataclass(frozen=True)
+class SkillRoot:
+    """One discovery location, with its precedence label and write policy."""
+
+    label: str
+    path: Path
+    read_only: bool = False
+
+    def __str__(self) -> str:
+        return f"{self.label}:{self.path}"
+
+
+def user_skills_dir() -> Path:
+    """Return ``~/.gaia/skills`` (honoring ``GAIA_CONFIG_DIR``).
+
+    Read at call time, not import time, so tests can point it at a tmp_path
+    without reloading the module.
+    """
+    base = os.getenv(GAIA_CONFIG_DIR_ENV) or str(Path.home() / ".gaia")
+    return Path(base) / "skills"
+
+
+def claude_skills_dirs(project_dir: Optional[Path] = None) -> list[Path]:
+    """Return the read-only Claude Code import roots (project, then user)."""
+    project = Path(project_dir) if project_dir is not None else Path.cwd()
+    return [project / ".claude" / "skills", Path.home() / ".claude" / "skills"]
+
+
+class SkillManager:
+    """Discovers skills across the v1 roots and loads them by precedence."""
+
+    def __init__(
+        self,
+        *,
+        agent_skill_dirs: Optional[Iterable[Path | str]] = None,
+        user_skills_root: Optional[Path | str] = None,
+        claude_skill_dirs: Optional[Iterable[Path | str]] = None,
+        project_dir: Optional[Path | str] = None,
+        include_claude_roots: bool = True,
+    ) -> None:
+        """Build a manager over the v1 discovery roots.
+
+        Args:
+            agent_skill_dirs: Agent-bundled ``skills/`` directories (precedence 1).
+            user_skills_root: Overrides ``~/.gaia/skills`` (precedence 2).
+            claude_skill_dirs: Overrides the ``.claude/skills`` roots (precedence 3).
+            project_dir: Working directory used to locate ``./.claude/skills``.
+            include_claude_roots: Set False to skip the read-only import roots.
+        """
+        self._agent_dirs = [Path(p) for p in (agent_skill_dirs or [])]
+        self._user_root = (
+            Path(user_skills_root) if user_skills_root is not None else None
+        )
+        self._project_dir = Path(project_dir) if project_dir is not None else None
+        self._include_claude = include_claude_roots
+        self._claude_dirs = (
+            [Path(p) for p in claude_skill_dirs]
+            if claude_skill_dirs is not None
+            else None
+        )
+
+        self._lock = threading.RLock()
+        self._metadata: Optional[dict[str, Skill]] = None
+        self._shadowed: dict[str, list[Skill]] = {}
+        self._errors: dict[str, str] = {}
+        self._watchers: list = []
+        self._on_change: Optional[Callable[[], None]] = None
+
+    # ------------------------------------------------------------------
+    # Roots
+    # ------------------------------------------------------------------
+
+    @property
+    def user_root(self) -> Path:
+        """The writable user root — where ``gaia skill import`` installs."""
+        return self._user_root if self._user_root is not None else user_skills_dir()
+
+    @property
+    def roots(self) -> list[SkillRoot]:
+        """Every discovery root, highest precedence first."""
+        roots = [
+            SkillRoot(ROOT_AGENT_BUNDLED, Path(d), read_only=True)
+            for d in self._agent_dirs
+        ]
+        roots.append(SkillRoot(ROOT_USER, self.user_root, read_only=False))
+        if self._include_claude:
+            claude = (
+                self._claude_dirs
+                if self._claude_dirs is not None
+                else claude_skills_dirs(self._project_dir)
+            )
+            roots.extend(
+                SkillRoot(ROOT_CLAUDE_IMPORT, Path(d), read_only=True) for d in claude
+            )
+        return roots
+
+    # ------------------------------------------------------------------
+    # Discovery (progressive disclosure level 1 — metadata only)
+    # ------------------------------------------------------------------
+
+    def discover(self, *, force: bool = False) -> dict[str, Skill]:
+        """Scan every root and return ``{name: metadata-only Skill}``.
+
+        Results are cached; pass ``force=True`` (or call :meth:`reload`) to
+        rescan. Frontmatter only — bodies are not read here.
+        """
+        with self._lock:
+            if self._metadata is not None and not force:
+                return dict(self._metadata)
+
+            found: dict[str, Skill] = {}
+            shadowed: dict[str, list[Skill]] = {}
+            errors: dict[str, str] = {}
+
+            for root in self.roots:
+                if not root.path.is_dir():
+                    log.debug("Skill root %s does not exist — skipping", root)
+                    continue
+                log.debug("Scanning skill root %s", root)
+                for entry in sorted(root.path.iterdir()):
+                    if not entry.is_dir() or not (entry / SKILL_FILENAME).is_file():
+                        continue
+                    try:
+                        skill = parse_skill_metadata(
+                            entry, root=root.label, read_only=root.read_only
+                        )
+                    except SkillError as exc:
+                        errors[str(entry)] = str(exc)
+                        log.error("Skipping invalid skill at %s: %s", entry, exc)
+                        continue
+
+                    if skill.name in found:
+                        shadowed.setdefault(skill.name, []).append(skill)
+                        log.debug(
+                            "Skill '%s' in %s is shadowed by the copy in root '%s' "
+                            "(higher precedence)",
+                            skill.name,
+                            root,
+                            found[skill.name].root,
+                        )
+                        continue
+                    found[skill.name] = skill
+
+            self._metadata = found
+            self._shadowed = shadowed
+            self._errors = errors
+            log.info(
+                "Discovered %d skill(s) across %d root(s); %d shadowed, %d invalid",
+                len(found),
+                len(self.roots),
+                sum(len(v) for v in shadowed.values()),
+                len(errors),
+            )
+            return dict(found)
+
+    def reload(self) -> dict[str, Skill]:
+        """Drop the discovery cache and rescan every root."""
+        return self.discover(force=True)
+
+    def list_skills(self) -> list[Skill]:
+        """Every discovered skill's metadata, sorted by name."""
+        return sorted(self.discover().values(), key=lambda s: s.name)
+
+    @property
+    def discovery_errors(self) -> dict[str, str]:
+        """``{skill_dir: message}`` for directories that failed to parse.
+
+        Surfaced by ``gaia skill list`` (and logged at ERROR) so a malformed
+        skill is visibly broken rather than quietly missing.
+        """
+        self.discover()
+        return dict(self._errors)
+
+    def shadowed(self, name: Optional[str] = None) -> list[Skill]:
+        """Lower-precedence copies that lost to a same-named skill."""
+        self.discover()
+        if name is not None:
+            return list(self._shadowed.get(name, []))
+        return [s for copies in self._shadowed.values() for s in copies]
+
+    # ------------------------------------------------------------------
+    # Resolution + loading
+    # ------------------------------------------------------------------
+
+    def get(self, name: str) -> Skill:
+        """Return the metadata-only skill for ``name`` (level 1)."""
+        skills = self.discover()
+        if name not in skills:
+            raise SkillNotFoundError(self._not_found_message(name))
+        return skills[name]
+
+    def resolve_path(self, name: str) -> Path:
+        """Return the winning skill's directory."""
+        skill = self.get(name)
+        directory = skill.directory
+        if directory is None:  # pragma: no cover - discovery always sets a path
+            raise SkillNotFoundError(self._not_found_message(name))
+        return directory
+
+    def load(self, name: str) -> Skill:
+        """Fully parse the winning skill, body included (level 2).
+
+        Raises:
+            SkillNotFoundError: no root contains a skill of that name.
+            SkillValidationError: the skill exists but fails validation.
+        """
+        metadata = self.get(name)
+        assert metadata.path is not None  # discovery always sets it
+        skill = parse_skill_file(
+            metadata.path, root=metadata.root, read_only=metadata.read_only
+        )
+        log.debug(
+            "Loaded skill '%s' from root '%s' (%s, tier=%s, %d tool(s))",
+            skill.name,
+            skill.root,
+            skill.path,
+            skill.security_tier,
+            len(skill.gaia.tools),
+        )
+        return skill
+
+    def resource_path(self, name: str, relative: str) -> Path:
+        """Resolve a bundled resource inside a skill (level 3).
+
+        Raises:
+            SkillValidationError: if ``relative`` escapes the skill directory or
+                names a file the skill does not ship.
+        """
+        directory = self.resolve_path(name).resolve()
+        candidate = (directory / relative).resolve()
+        if candidate != directory and directory not in candidate.parents:
+            raise SkillValidationError(
+                f"Resource {relative!r} escapes skill '{name}' at {directory}. A skill "
+                "may only read files inside its own directory."
+            )
+        if not candidate.exists():
+            raise SkillValidationError(
+                f"Skill '{name}' has no resource {relative!r} (looked in {directory}). "
+                "Check the path referenced by the skill body."
+            )
+        return candidate
+
+    # ------------------------------------------------------------------
+    # Hot reload
+    # ------------------------------------------------------------------
+
+    def start_watching(self, on_change: Optional[Callable[[], None]] = None) -> int:
+        """Watch every existing root and drop the cache on any change.
+
+        Args:
+            on_change: Optional callback fired after the cache is invalidated.
+
+        Returns:
+            The number of roots actually being watched (missing roots are
+            skipped — a root that appears later is picked up on the next
+            explicit :meth:`reload`).
+        """
+        from gaia.utils.file_watcher import WATCHDOG_AVAILABLE, FileWatcher
+
+        if not WATCHDOG_AVAILABLE:
+            raise SkillError(
+                "Skill hot-reload needs the 'watchdog' package, which is not "
+                "installed. Install it with: pip install 'watchdog>=2.1.0' (or "
+                "uv pip install -e '.[dev]'), or call SkillManager.reload() manually."
+            )
+
+        self._on_change = on_change
+        self.stop_watching()
+        for root in self.roots:
+            if not root.path.is_dir():
+                continue
+            watcher = FileWatcher(
+                directory=root.path,
+                on_created=self._handle_change,
+                on_modified=self._handle_change,
+                on_deleted=self._handle_change,
+                extensions=[".md", ".py"],
+                recursive=True,
+            )
+            watcher.start()
+            self._watchers.append(watcher)
+            log.info("Watching skill root %s for changes", root)
+        return len(self._watchers)
+
+    def stop_watching(self) -> None:
+        """Stop every root watcher. Safe to call when not watching."""
+        for watcher in self._watchers:
+            watcher.stop()
+        self._watchers = []
+
+    @property
+    def is_watching(self) -> bool:
+        """True while at least one root watcher is running."""
+        return any(w.is_running for w in self._watchers)
+
+    def _handle_change(self, path: str) -> None:
+        """Invalidate the discovery cache after a filesystem event."""
+        log.info("Skill root change detected (%s) — invalidating discovery cache", path)
+        with self._lock:
+            self._metadata = None
+        if self._on_change is not None:
+            self._on_change()
+
+    # ------------------------------------------------------------------
+    # Internals
+    # ------------------------------------------------------------------
+
+    def _not_found_message(self, name: str) -> str:
+        known = sorted(self.discover())
+        roots = ", ".join(str(r.path) for r in self.roots)
+        known_text = ", ".join(known) if known else "(none discovered)"
+        message = (
+            f"No skill named {name!r}. Searched: {roots}. Available: {known_text}. "
+            f"Create one with 'gaia skill create {name}', import an existing folder "
+            f"with 'gaia skill import <path>', or run 'gaia skill list'. See {DOCS_URL}"
+        )
+        if self._errors:
+            message += (
+                f" Note: {len(self._errors)} skill folder(s) failed to parse — run "
+                "'gaia skill list' to see them."
+            )
+        return message
+
+
+_DEFAULT_MANAGER: Optional[SkillManager] = None
+_DEFAULT_LOCK = threading.Lock()
+
+
+def get_default_manager() -> SkillManager:
+    """Return the process-wide manager over the default roots."""
+    global _DEFAULT_MANAGER  # pylint: disable=global-statement
+    with _DEFAULT_LOCK:
+        if _DEFAULT_MANAGER is None:
+            _DEFAULT_MANAGER = SkillManager()
+        return _DEFAULT_MANAGER
+
+
+def reset_default_manager() -> None:
+    """Drop the process-wide manager (used by tests and by root changes)."""
+    global _DEFAULT_MANAGER  # pylint: disable=global-statement
+    with _DEFAULT_LOCK:
+        if _DEFAULT_MANAGER is not None:
+            _DEFAULT_MANAGER.stop_watching()
+        _DEFAULT_MANAGER = None

--- a/src/gaia/skills/permissions.py
+++ b/src/gaia/skills/permissions.py
@@ -1,0 +1,268 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""
+The ``<domain>:<level>[:scope]`` permission grammar and its connector bridge.
+
+Phase 1 (issue #888) honors **connector-bridged domains only**:
+
+- ``mcp:connect:<connector-id>`` and ``network:<level>[:scope]`` resolve to the
+  existing :class:`~gaia.connectors.providers.base.ConnectorRequirement` — the
+  same primitive agents already declare via ``REQUIRED_CONNECTORS``. There is no
+  second grant ledger.
+- ``filesystem`` / ``shell`` / ``database`` / ``desktop`` / ``env`` are
+  local-capability domains with no connector equivalent. They need the Phase 2
+  sandbox, so a skill declaring one is **refused** — never loaded unenforced.
+
+``network`` has no catalog connector in Phase 1 (nothing in the connector
+catalog represents raw outbound HTTP). Unless the permission scope names a real
+catalog connector, the requirement is emitted against the reserved pseudo-id
+``network``; it records the declared egress so ``gaia skill info`` and the
+Phase 2 egress policy can consume it. Phase 1 declares, it does not enforce.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import Iterable, Sequence
+
+from gaia.connectors.providers.base import ConnectorRequirement
+from gaia.logger import get_logger
+from gaia.skills.errors import (
+    FORMAT_DOCS_URL,
+    SkillPermissionError,
+    SkillValidationError,
+)
+
+log = get_logger(__name__)
+
+# Reserved pseudo connector id for declared raw outbound HTTP (see module docstring).
+NETWORK_CONNECTOR_ID = "network"
+
+# <domain>: {allowed levels}
+DOMAIN_LEVELS: dict[str, frozenset[str]] = {
+    "filesystem": frozenset({"read", "write", "none"}),
+    "network": frozenset({"read", "write", "none"}),
+    "shell": frozenset({"execute", "none"}),
+    "mcp": frozenset({"connect", "none"}),
+    "env": frozenset({"read", "none"}),
+    "database": frozenset({"read", "write", "none"}),
+    "desktop": frozenset({"control", "none"}),
+}
+
+#: Domains that map onto the connector grant model — supported in Phase 1.
+CONNECTOR_BRIDGED_DOMAINS = frozenset({"network", "mcp"})
+
+#: Domains that need the Phase 2 sandbox — refused in Phase 1.
+LOCAL_CAPABILITY_DOMAINS = frozenset(DOMAIN_LEVELS) - CONNECTOR_BRIDGED_DOMAINS
+
+_TOKEN_RE = re.compile(r"^[a-z][a-z0-9_]*$")
+
+
+@dataclass(frozen=True)
+class Permission:
+    """One parsed ``<domain>:<level>[:scope]`` grant."""
+
+    domain: str
+    level: str
+    scope: str | None = None
+
+    def __str__(self) -> str:
+        base = f"{self.domain}:{self.level}"
+        return f"{base}:{self.scope}" if self.scope else base
+
+    @property
+    def is_connector_bridged(self) -> bool:
+        """True when this domain maps onto the connector grant model."""
+        return self.domain in CONNECTOR_BRIDGED_DOMAINS
+
+    @property
+    def grants_nothing(self) -> bool:
+        """True for an explicit ``<domain>:none`` denial — inert either way."""
+        return self.level == "none"
+
+    @property
+    def is_local_capability(self) -> bool:
+        """True when this needs the (deferred) Phase 2 sandbox.
+
+        ``<domain>:none`` is excluded: an explicit denial asks for no capability,
+        so refusing it would reject a skill for declaring *less* than the default.
+        """
+        return self.domain in LOCAL_CAPABILITY_DOMAINS and not self.grants_nothing
+
+    @classmethod
+    def parse(cls, raw: str, *, skill_name: str = "<unknown>") -> "Permission":
+        """Parse one permission string, failing loudly on any malformed part."""
+        if not isinstance(raw, str) or not raw.strip():
+            raise SkillValidationError(
+                f"Skill '{skill_name}' declares an empty permission. "
+                "Each entry of metadata.gaia.permissions must be a "
+                "'<domain>:<level>[:scope]' string, e.g. 'network:read:*.brave.com'. "
+                f"Grammar: {FORMAT_DOCS_URL}#permission-model"
+            )
+
+        parts = raw.strip().split(":", 2)
+        if len(parts) < 2:
+            raise SkillValidationError(
+                f"Skill '{skill_name}' declares permission {raw!r}, which is missing "
+                "its level. Use '<domain>:<level>[:scope]', e.g. 'network:read' or "
+                f"'mcp:connect:mcp-tavily'. Grammar: {FORMAT_DOCS_URL}#permission-model"
+            )
+
+        domain, level = parts[0].strip(), parts[1].strip()
+        scope = parts[2].strip() if len(parts) == 3 and parts[2].strip() else None
+
+        if domain not in DOMAIN_LEVELS:
+            raise SkillValidationError(
+                f"Skill '{skill_name}' declares permission {raw!r} with unknown domain "
+                f"{domain!r}. Valid domains: {', '.join(sorted(DOMAIN_LEVELS))}. "
+                f"Grammar: {FORMAT_DOCS_URL}#permission-model"
+            )
+        if not _TOKEN_RE.match(level) or level not in DOMAIN_LEVELS[domain]:
+            raise SkillValidationError(
+                f"Skill '{skill_name}' declares permission {raw!r} with level "
+                f"{level!r}, which {domain!r} does not define. Valid levels for "
+                f"{domain!r}: {', '.join(sorted(DOMAIN_LEVELS[domain]))}. "
+                f"Grammar: {FORMAT_DOCS_URL}#permission-model"
+            )
+
+        return cls(domain=domain, level=level, scope=scope)
+
+
+def parse_permissions(
+    raw: Iterable[str], *, skill_name: str = "<unknown>"
+) -> list[Permission]:
+    """Parse every permission string of a skill, preserving declaration order."""
+    return [Permission.parse(entry, skill_name=skill_name) for entry in raw]
+
+
+def refuse_unbridged_permissions(
+    permissions: Sequence[Permission], *, skill_name: str
+) -> None:
+    """Refuse a skill that needs a local capability Phase 1 cannot enforce.
+
+    Raises:
+        SkillPermissionError: if any permission is in a local-capability domain.
+    """
+    unbridged = [p for p in permissions if p.is_local_capability]
+    if not unbridged:
+        return
+
+    declared = ", ".join(str(p) for p in unbridged)
+    raise SkillPermissionError(
+        f"Skill '{skill_name}' declares local-capability permission(s): {declared}. "
+        "GAIA's skills runtime bridges connector-backed permissions only "
+        f"({', '.join(sorted(CONNECTOR_BRIDGED_DOMAINS))}); the sandbox that enforces "
+        f"{', '.join(sorted(LOCAL_CAPABILITY_DOMAINS))} is deferred to a later phase, "
+        "so this skill is refused rather than loaded without enforcement. "
+        "To load it now, drop those permissions and use the agent's own tools for "
+        "local access, or wait for the permission sandbox. "
+        f"See {FORMAT_DOCS_URL}#permission-model and "
+        "https://github.com/amd/gaia/issues/1019 (Phase 2)."
+    )
+
+
+def to_connector_requirement(
+    permission: Permission,
+    *,
+    skill_name: str,
+    catalog_ids: Sequence[str] | None = None,
+) -> ConnectorRequirement | None:
+    """Resolve one connector-bridged permission to a ``ConnectorRequirement``.
+
+    Args:
+        permission: A parsed permission. Local-capability domains return ``None``
+            (they are refused earlier by :func:`refuse_unbridged_permissions`).
+        skill_name: Used in the requirement's ``reason`` and in error messages.
+        catalog_ids: Known connector ids. Defaults to the live connector catalog.
+
+    Returns:
+        The requirement, or ``None`` for ``<domain>:none`` and non-bridged domains.
+
+    Raises:
+        SkillValidationError: if an ``mcp:connect`` permission does not name a
+            connector present in the catalog.
+    """
+    if permission.level == "none" or not permission.is_connector_bridged:
+        return None
+
+    if catalog_ids is None:
+        catalog_ids = _catalog_ids()
+
+    if permission.domain == "mcp":
+        if not permission.scope:
+            raise SkillValidationError(
+                f"Skill '{skill_name}' declares 'mcp:connect' without naming a "
+                "connector. Scope it to a connector id, e.g. "
+                "'mcp:connect:mcp-tavily'. Available connectors: "
+                f"{', '.join(sorted(catalog_ids)) or '(catalog unavailable)'}. "
+                "Run 'gaia connectors list' to see them."
+            )
+        if permission.scope not in catalog_ids:
+            raise SkillValidationError(
+                f"Skill '{skill_name}' declares 'mcp:connect:{permission.scope}', but "
+                f"no connector with id {permission.scope!r} exists in the catalog. "
+                f"Available: {', '.join(sorted(catalog_ids)) or '(catalog unavailable)'}. "
+                "Run 'gaia connectors list' to see them."
+            )
+        return ConnectorRequirement(
+            connector_id=permission.scope,
+            scopes=(),
+            reason=f"Skill '{skill_name}' connects to the '{permission.scope}' MCP server.",
+        )
+
+    # network:<level>[:scope]
+    scope = permission.scope or "*"
+    if permission.scope and permission.scope in catalog_ids:
+        return ConnectorRequirement(
+            connector_id=permission.scope,
+            scopes=(permission.level,),
+            reason=f"Skill '{skill_name}' needs {permission.level} access via "
+            f"the '{permission.scope}' connector.",
+        )
+
+    log.debug(
+        "Skill '%s': network permission %s has no catalog connector; recording it "
+        "against the reserved '%s' pseudo-connector (declaration only — Phase 1 "
+        "does not enforce egress).",
+        skill_name,
+        permission,
+        NETWORK_CONNECTOR_ID,
+    )
+    return ConnectorRequirement(
+        connector_id=NETWORK_CONNECTOR_ID,
+        scopes=(f"{permission.level}:{scope}",),
+        reason=f"Skill '{skill_name}' declares {permission.level} network access to {scope}.",
+    )
+
+
+def connector_requirements(
+    permissions: Sequence[Permission],
+    *,
+    skill_name: str,
+    catalog_ids: Sequence[str] | None = None,
+) -> list[ConnectorRequirement]:
+    """Resolve every bridged permission to a de-duplicated requirement list."""
+    if catalog_ids is None:
+        catalog_ids = _catalog_ids()
+
+    resolved: list[ConnectorRequirement] = []
+    for permission in permissions:
+        requirement = to_connector_requirement(
+            permission, skill_name=skill_name, catalog_ids=catalog_ids
+        )
+        if requirement is not None and requirement not in resolved:
+            resolved.append(requirement)
+    return resolved
+
+
+def _catalog_ids() -> tuple[str, ...]:
+    """Return every connector id in the live catalog.
+
+    Imports ``gaia.connectors.catalog`` for its side effect — that module is
+    what populates the process-level ``REGISTRY`` singleton.
+    """
+    import gaia.connectors.catalog  # noqa: F401  # pylint: disable=unused-import
+    from gaia.connectors.registry import REGISTRY
+
+    return tuple(spec.id for spec in REGISTRY.all())

--- a/tests/fixtures/skills/README.md
+++ b/tests/fixtures/skills/README.md
@@ -1,0 +1,15 @@
+# Skill fixtures
+
+Sample `SKILL.md` folders used by `tests/unit/test_skills_*.py` (issue #888).
+
+| Fixture | What it proves |
+|---|---|
+| `bare-standard/` | A bare agentskills.io skill (only `name` + `description`) loads instruction-only with conservative defaults. |
+| `web-search/` | A GAIA tool skill: `metadata.gaia.tools` matching a real `tools.py`, plus a connector-bridged `network:read` permission. |
+| `triage-support-ticket/` | A recipe skill that consumes registry tools via `tools_required` (the #887/#1451 contract). |
+| `tool-mismatch/` | Declares a tool `tools.py` does not register — must fail loudly with no partial load. |
+| `local-capability/` | Declares `filesystem:write` — must be refused as deferred to a later phase. |
+| `incident-review/` | A Claude Code skill (with `allowed-tools` / `compatibility`) copied into a `.claude/skills/` root to prove read-only import. |
+
+Tests copy these into a `tmp_path` root rather than reading them in place, so no
+test ever touches the developer's real `~/.gaia/skills/`.

--- a/tests/fixtures/skills/bare-standard/SKILL.md
+++ b/tests/fixtures/skills/bare-standard/SKILL.md
@@ -1,0 +1,10 @@
+---
+name: bare-standard
+description: Walk through a production incident postmortem. Use when the user mentions an outage, incident, or postmortem.
+---
+
+# Incident Review
+
+1. Establish the timeline from first alert to resolution.
+2. Separate root cause from contributing factors.
+3. Draft action items with owners — never "the team".

--- a/tests/fixtures/skills/incident-review/SKILL.md
+++ b/tests/fixtures/skills/incident-review/SKILL.md
@@ -1,0 +1,12 @@
+---
+name: incident-review
+description: Run an incident postmortem. Stands in for a Claude Code skill library imported read-only from .claude/skills/.
+allowed-tools: Read, Write, Bash
+compatibility: ">=1.0"
+---
+
+# Incident Review
+
+1. Establish the timeline from first alert to resolution.
+2. Separate root cause from contributing factors.
+3. Draft action items with owners.

--- a/tests/fixtures/skills/local-capability/SKILL.md
+++ b/tests/fixtures/skills/local-capability/SKILL.md
@@ -1,0 +1,14 @@
+---
+name: local-capability
+description: Writes files on the local workspace. Used to prove Phase 1 refuses local-capability permissions.
+version: 0.1.0
+metadata:
+  gaia:
+    security_tier: community
+    permissions:
+      - filesystem:write:./**
+---
+
+# Local Capability
+
+Loading this skill must be refused until the permission sandbox ships.

--- a/tests/fixtures/skills/tool-mismatch/SKILL.md
+++ b/tests/fixtures/skills/tool-mismatch/SKILL.md
@@ -1,0 +1,22 @@
+---
+name: tool-mismatch
+description: Declares a tool its tools.py never registers. Used to prove validation fails loudly with no partial load.
+version: 0.1.0
+metadata:
+  gaia:
+    tools:
+      - name: present_tool
+        description: A tool that does exist
+        parameters:
+          text: {type: string, required: true}
+        returns: {type: object}
+      - name: missing_tool
+        description: A tool tools.py never registers
+        parameters:
+          text: {type: string, required: true}
+        returns: {type: object}
+---
+
+# Tool Mismatch
+
+Loading this skill must fail — and must leave `present_tool` unregistered too.

--- a/tests/fixtures/skills/tool-mismatch/tools.py
+++ b/tests/fixtures/skills/tool-mismatch/tools.py
@@ -1,0 +1,11 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""Registers only one of the two tools the manifest declares — on purpose."""
+
+from gaia.agents.base.tools import tool
+
+
+@tool
+def present_tool(text: str) -> dict:
+    """A tool that does exist."""
+    return {"text": text}

--- a/tests/fixtures/skills/triage-support-ticket/SKILL.md
+++ b/tests/fixtures/skills/triage-support-ticket/SKILL.md
@@ -1,0 +1,17 @@
+---
+name: triage-support-ticket
+description: Triage an inbound support ticket end to end. Use when the user pastes a support ticket or asks to triage one.
+version: 0.2.0
+metadata:
+  gaia:
+    tools_required:
+      - query_documents
+      - read_file
+      - remember
+---
+
+# Triage a Support Ticket
+
+1. Pull matching policy docs with `query_documents`.
+2. Read any attached log with `read_file`.
+3. Record the disposition with `remember` for follow-up.

--- a/tests/fixtures/skills/web-search/SKILL.md
+++ b/tests/fixtures/skills/web-search/SKILL.md
@@ -1,0 +1,27 @@
+---
+name: web-search
+description: Search the web via the Brave Search API. Use when the user asks about current events or external facts.
+license: MIT
+version: 1.0.0
+metadata:
+  gaia:
+    security_tier: verified
+    permissions:
+      - network:read:*.brave.com
+    requirements:
+      python: ">=3.10"
+      env_vars:
+        - BRAVE_API_KEY
+    tools:
+      - name: search_web
+        description: Search the web for current information
+        parameters:
+          query: {type: string, required: true}
+          max_results: {type: integer, required: false}
+        returns: {type: object}
+---
+
+# Web Search
+
+A self-contained Brave Search wrapper — `search_web` is this skill's own `@tool`,
+backed by the skill's `tools.py`.

--- a/tests/fixtures/skills/web-search/tools.py
+++ b/tests/fixtures/skills/web-search/tools.py
@@ -1,0 +1,11 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""Tools provided by the ``web-search`` fixture skill."""
+
+from gaia.agents.base.tools import tool
+
+
+@tool
+def search_web(query: str, max_results: int = 5) -> dict:
+    """Search the web for current information."""
+    return {"query": query, "results": [], "max_results": max_results}

--- a/tests/unit/cli/test_cli_schedule.py
+++ b/tests/unit/cli/test_cli_schedule.py
@@ -95,8 +95,8 @@ def test_add_prompt_constructs_schedule_from_parsed_args(parser, mock_store, cap
     assert "0 7 * * 1-5" in out
 
 
-def test_add_skill_variant_is_rejected_until_888(parser, mock_store, capsys):
-    """A --skill schedule would register but never fire, so `add` rejects it (#888)."""
+def test_add_skill_variant_is_rejected(parser, mock_store, capsys):
+    """A --skill schedule would register but never fire, so `add` rejects it."""
     args = _parse(
         parser,
         [
@@ -120,7 +120,7 @@ def test_add_skill_variant_is_rejected_until_888(parser, mock_store, capsys):
     err = capsys.readouterr().err
     assert "--skill is not supported yet" in err
     assert "--prompt" in err  # names the workaround
-    assert "888" in err  # points at the tracking issue
+    assert "1019" in err  # points at the tracking issue
 
 
 def test_add_default_sink_without_to_has_empty_sink_args(parser, mock_store):

--- a/tests/unit/cli/test_stub_surface_gates.py
+++ b/tests/unit/cli/test_stub_surface_gates.py
@@ -146,7 +146,7 @@ class TestScheduleAddSkillRejected:
         err = capsys.readouterr().err
         assert "--skill is not supported yet" in err
         assert "--prompt" in err
-        assert "888" in err
+        assert "1019" in err  # points at the tracking issue
         store_add.assert_not_called()
 
     def test_prompt_add_still_works(self, mocker, capsys):

--- a/tests/unit/skills_helpers.py
+++ b/tests/unit/skills_helpers.py
@@ -1,0 +1,54 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""
+Shared helpers for the skills unit tests (issue #888).
+
+Every helper works off ``tmp_path`` so a test never reads or writes the
+developer's real ``~/.gaia/skills`` or ``~/.claude/skills`` — the cold-state
+rule from CLAUDE.md.
+"""
+
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+
+FIXTURES = Path(__file__).resolve().parents[1] / "fixtures" / "skills"
+
+
+def copy_fixture(name: str, into: Path, *, as_name: str | None = None) -> Path:
+    """Copy a fixture skill into ``into``, optionally under a different name."""
+    source = FIXTURES / name
+    if not source.is_dir():  # pragma: no cover - guards a typo in a test
+        raise AssertionError(f"No skill fixture named {name!r} in {FIXTURES}")
+    target = into / (as_name or source.name)
+    target.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copytree(source, target)
+    return target
+
+
+def write_skill_dir(root: Path, name: str, text: str, tools: str | None = None) -> Path:
+    """Write a one-off skill directory inline (for negative-path tests)."""
+    directory = root / name
+    directory.mkdir(parents=True, exist_ok=True)
+    (directory / "SKILL.md").write_text(text, encoding="utf-8")
+    if tools is not None:
+        (directory / "tools.py").write_text(tools, encoding="utf-8")
+    return directory
+
+
+def isolated_manager(tmp_path: Path, **kwargs):
+    """A :class:`SkillManager` whose roots are all inside ``tmp_path``.
+
+    Claude-import roots are pointed at an empty tmp directory rather than
+    disabled, so precedence tests exercise the real three-root ordering.
+    """
+    from gaia.skills.manager import SkillManager
+
+    user_root = kwargs.pop("user_skills_root", tmp_path / "gaia-home" / "skills")
+    claude_dirs = kwargs.pop("claude_skill_dirs", [tmp_path / "claude" / "skills"])
+    return SkillManager(
+        user_skills_root=user_root,
+        claude_skill_dirs=claude_dirs,
+        **kwargs,
+    )

--- a/tests/unit/test_schedule_daemon.py
+++ b/tests/unit/test_schedule_daemon.py
@@ -209,13 +209,13 @@ class TestRunnerFire:
         mock_dispatch.assert_called_once_with("file", {"path": "/tmp/x.md"}, "out")
 
     def test_fire_skill_only_raises_not_implemented(self, mocker):
-        # --skill resolution is blocked on #888; fire must fail loudly, never
+        # The scheduler cannot run skills yet; fire must fail loudly, never
         # reach the agent or the sink.
         mock_sdk_cls = mocker.patch(_AGENT_SDK)
         mock_dispatch = mocker.patch.object(runner.sinks, "dispatch")
 
         sched = Schedule(name="s", cron="* * * * *", skill="my-skill")
-        with pytest.raises(NotImplementedError, match="#888"):
+        with pytest.raises(NotImplementedError, match="cannot run skills yet"):
             runner.fire(sched)
 
         mock_sdk_cls.return_value.send.assert_not_called()
@@ -235,5 +235,5 @@ class TestResolveInput:
 
     def test_skill_raises_not_implemented(self):
         sched = Schedule(name="s", cron="* * * * *", skill="sk")
-        with pytest.raises(NotImplementedError, match="skill-format"):
+        with pytest.raises(NotImplementedError, match="cannot run skills yet"):
             runner.resolve_input(sched)

--- a/tests/unit/test_skills_cli.py
+++ b/tests/unit/test_skills_cli.py
@@ -1,0 +1,490 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""
+Tests for ``gaia skill {list|info|create|import|export}`` (issue #888).
+
+Two layers, both exercising the shipped CLI rather than a reimplementation:
+
+- **In-process** — the real argparse tree from ``gaia.skills.cli.add_subparser``
+  plus the real ``handle()`` dispatch, so every verb, flag, and exit code is
+  covered cheaply.
+- **Subprocess** — a handful of ``gaia skill …`` runs through ``gaia.cli`` that
+  prove the top-level wiring works in the binary a user actually types
+  (``test_real_cli_*``).
+
+Every run starts cold: ``GAIA_CONFIG_DIR`` and the working directory point at
+``tmp_path``, so no test reads or writes the developer's real ``~/.gaia/skills``
+or ``~/.claude/skills``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import subprocess
+import sys
+import zipfile
+from pathlib import Path
+
+import pytest
+
+from gaia.skills import cli as skills_cli
+from tests.unit.skills_helpers import copy_fixture
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+@pytest.fixture
+def skills_dir(tmp_path, monkeypatch):
+    """A cold ``~/.gaia/skills`` under tmp_path, with the CWD isolated too."""
+    home = tmp_path / "gaia-home"
+    skills = home / "skills"
+    skills.mkdir(parents=True)
+    workdir = tmp_path / "workdir"
+    workdir.mkdir()
+
+    monkeypatch.setenv("GAIA_CONFIG_DIR", str(home))
+    monkeypatch.chdir(workdir)
+    # A fake HOME keeps ~/.claude/skills out of discovery on the dev machine.
+    monkeypatch.setenv("HOME", str(tmp_path / "fake-home"))
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: tmp_path / "fake-home"))
+    (tmp_path / "fake-home").mkdir(exist_ok=True)
+    return skills
+
+
+@pytest.fixture
+def run(skills_dir, capsys):
+    """Parse and dispatch ``gaia skill …`` in-process; return (rc, out, err)."""
+
+    def _run(*args: str):
+        parser = argparse.ArgumentParser(prog="gaia")
+        subparsers = parser.add_subparsers(dest="action")
+        skills_cli.add_subparser(subparsers)
+        parsed = parser.parse_args(["skill", *args])
+        rc = skills_cli.handle(parsed)
+        captured = capsys.readouterr()
+        return rc, captured.out, captured.err
+
+    return _run
+
+
+# ----------------------------------------------------------------------
+# list
+# ----------------------------------------------------------------------
+
+
+def test_list_from_a_cold_state(run):
+    rc, out, _ = run("list")
+    assert rc == 0
+    assert "No skills found" in out
+    assert "gaia skill create my-skill" in out
+
+
+def test_list_shows_discovered_skills(run, skills_dir):
+    copy_fixture("web-search", skills_dir)
+    copy_fixture("bare-standard", skills_dir)
+
+    rc, out, _ = run("list")
+    assert rc == 0
+    assert "web-search" in out
+    assert "bare-standard" in out
+    assert "verified" in out
+    assert "search_web" in out
+
+
+def test_list_json_is_machine_readable(run, skills_dir):
+    copy_fixture("web-search", skills_dir)
+    rc, out, _ = run("list", "--json")
+    assert rc == 0
+
+    payload = json.loads(out)
+    assert [s["name"] for s in payload["skills"]] == ["web-search"]
+    (skill,) = payload["skills"]
+    assert skill["security_tier"] == "verified"
+    assert skill["tools"] == ["web-search/search_web"]
+    assert skill["permissions"] == ["network:read:*.brave.com"]
+    assert skill["instruction_only"] is False
+    assert payload["roots"][0]["label"] == "user"
+
+
+def test_list_reports_a_broken_skill_and_exits_nonzero(run, skills_dir):
+    copy_fixture("bare-standard", skills_dir)
+    broken = skills_dir / "broken"
+    broken.mkdir()
+    (broken / "SKILL.md").write_text("not a skill\n", encoding="utf-8")
+
+    rc, out, err = run("list")
+    assert rc != 0
+    assert "bare-standard" in out  # the good one still lists
+    assert "failed to load" in err
+    assert "broken" in err
+
+
+def test_list_surfaces_shadowed_copies(run, skills_dir, tmp_path):
+    """Precedence is auditable, not silent."""
+    claude = tmp_path / "fake-home" / ".claude" / "skills"
+    copy_fixture("bare-standard", claude)
+    copy_fixture("bare-standard", skills_dir)
+
+    rc, out, err = run("list")
+    assert rc == 0
+    assert out.count("bare-standard") == 1
+    assert "is shadowed by the higher-precedence copy" in err
+
+
+def test_list_filters_by_root(run, skills_dir):
+    copy_fixture("web-search", skills_dir)
+    rc, out, _ = run("list", "--root", "claude-import")
+    assert rc == 0
+    assert "web-search" not in out
+
+
+# ----------------------------------------------------------------------
+# info
+# ----------------------------------------------------------------------
+
+
+def test_info_shows_the_manifest(run, skills_dir):
+    copy_fixture("web-search", skills_dir)
+    rc, out, _ = run("info", "web-search")
+    assert rc == 0
+    assert "web-search  1.0.0" in out
+    assert "security tier: verified" in out
+    assert "network:read:*.brave.com" in out
+    assert "web-search/search_web(query, max_results?)" in out
+
+
+def test_info_marks_an_instruction_only_skill(run, skills_dir):
+    copy_fixture("bare-standard", skills_dir)
+    _, out, _ = run("info", "bare-standard")
+    assert "(instruction-only)" in out
+
+
+def test_info_shows_tools_required(run, skills_dir):
+    copy_fixture("triage-support-ticket", skills_dir)
+    _, out, _ = run("info", "triage-support-ticket")
+    assert "consumes     : query_documents, read_file, remember" in out
+
+
+def test_info_body_flag_prints_instructions(run, skills_dir):
+    copy_fixture("bare-standard", skills_dir)
+    _, out, _ = run("info", "bare-standard", "--body")
+    assert "Establish the timeline" in out
+
+
+def test_info_json(run, skills_dir):
+    copy_fixture("web-search", skills_dir)
+    _, out, _ = run("info", "web-search", "--json")
+    payload = json.loads(out)
+    assert payload["name"] == "web-search"
+    assert payload["frontmatter"]["metadata"]["gaia"]["security_tier"] == "verified"
+
+
+def test_info_on_a_missing_skill_exits_not_found(run):
+    rc, _, err = run("info", "nope")
+    assert rc == 3
+    assert "No skill named 'nope'" in err
+    assert "gaia skill create nope" in err
+
+
+def test_info_on_a_claude_imported_skill_marks_it_read_only(run, tmp_path):
+    claude = tmp_path / "fake-home" / ".claude" / "skills"
+    copy_fixture("incident-review", claude)
+
+    rc, out, _ = run("info", "incident-review")
+    assert rc == 0
+    assert "root         : claude-import (read-only)" in out
+    assert "security tier: experimental" in out
+    assert "(instruction-only)" in out
+
+
+# ----------------------------------------------------------------------
+# create
+# ----------------------------------------------------------------------
+
+
+def test_create_scaffolds_a_valid_skill(run, skills_dir):
+    rc, out, _ = run("create", "my-skill")
+    assert rc == 0
+    assert "Created skill 'my-skill'" in out
+    assert (skills_dir / "my-skill" / "SKILL.md").is_file()
+    # The scaffold must survive the real reader.
+    assert run("info", "my-skill")[0] == 0
+
+
+def test_create_with_tools_scaffolds_a_loadable_pair(run, skills_dir):
+    from gaia.skills import (
+        parse_skill_file,
+        register_skill_tools,
+        unregister_skill_tools,
+    )
+
+    rc, _, _ = run(
+        "create",
+        "tool-skill",
+        "--with-tools",
+        "--description",
+        "Echo text back. Use when the user asks to echo something.",
+    )
+    assert rc == 0
+    directory = skills_dir / "tool-skill"
+    assert (directory / "tools.py").is_file()
+    assert "tool-skill/example_tool(text)" in run("info", "tool-skill")[1]
+
+    # The scaffolded manifest and module must agree — otherwise the first thing
+    # a new author does is hit a validation error.
+    skill = parse_skill_file(directory)
+    try:
+        assert set(register_skill_tools(skill)) == {"tool-skill/example_tool"}
+    finally:
+        unregister_skill_tools("tool-skill")
+
+
+def test_create_rejects_an_invalid_name(run):
+    rc, _, err = run("create", "Not_Valid")
+    assert rc == 4
+    assert "not a valid skill name" in err
+
+
+def test_create_refuses_to_clobber(run):
+    run("create", "dup")
+    rc, _, err = run("create", "dup")
+    assert rc == 4
+    assert "--force" in err
+
+
+def test_create_force_overwrites(run, skills_dir):
+    run("create", "dup")
+    rc, _, _ = run("create", "dup", "--force", "--description", "Second take.")
+    assert rc == 0
+    assert "Second take." in (skills_dir / "dup" / "SKILL.md").read_text(
+        encoding="utf-8"
+    )
+
+
+def test_create_into_an_explicit_dir(run, tmp_path):
+    target = tmp_path / "bundled"
+    rc, _, _ = run("create", "bundled-skill", "--dir", str(target))
+    assert rc == 0
+    assert (target / "bundled-skill" / "SKILL.md").is_file()
+
+
+# ----------------------------------------------------------------------
+# export / import
+# ----------------------------------------------------------------------
+
+
+def test_export_then_import_round_trips(run, skills_dir, tmp_path):
+    copy_fixture("web-search", skills_dir)
+    bundle = tmp_path / "web-search.zip"
+
+    rc, out, _ = run("export", "web-search", "--output", str(bundle))
+    assert rc == 0
+    assert "Exported skill 'web-search'" in out
+    with zipfile.ZipFile(bundle) as archive:
+        names = set(archive.namelist())
+    assert {"web-search/SKILL.md", "web-search/tools.py"} <= names
+
+    shutil.rmtree(skills_dir / "web-search")
+    rc, out, _ = run("import", str(bundle))
+    assert rc == 0
+    assert "Imported skill 'web-search'" in out
+    assert (skills_dir / "web-search" / "tools.py").is_file()
+
+
+def test_import_resets_the_security_tier_to_experimental(run, skills_dir, tmp_path):
+    source = tmp_path / "incoming"
+    copy_fixture("web-search", source)
+
+    rc, out, _ = run("import", str(source / "web-search"))
+    assert rc == 0
+    assert "verified → experimental" in out
+    assert "security tier: experimental" in run("info", "web-search")[1]
+
+
+def test_import_a_claude_code_skill(run, skills_dir, tmp_path):
+    """A .claude/skills folder installs into ~/.gaia/skills unchanged."""
+    claude = tmp_path / "project" / ".claude" / "skills"
+    copy_fixture("incident-review", claude)
+
+    rc, out, _ = run("import", str(claude / "incident-review"))
+    assert rc == 0
+    assert "Imported skill 'incident-review'" in out
+    assert (skills_dir / "incident-review" / "SKILL.md").is_file()
+    assert run("info", "incident-review")[0] == 0
+
+
+def test_import_with_a_new_name(run, skills_dir, tmp_path):
+    source = tmp_path / "incoming"
+    copy_fixture("bare-standard", source)
+
+    rc, _, _ = run("import", str(source / "bare-standard"), "--name", "renamed")
+    assert rc == 0
+    installed = (skills_dir / "renamed" / "SKILL.md").read_text(encoding="utf-8")
+    assert "name: renamed" in installed
+    assert run("info", "renamed")[0] == 0
+
+
+def test_import_refuses_to_clobber_without_force(run, tmp_path):
+    source = tmp_path / "incoming"
+    copy_fixture("bare-standard", source)
+    run("import", str(source / "bare-standard"))
+
+    rc, _, err = run("import", str(source / "bare-standard"))
+    assert rc == 4
+    assert "--force" in err
+
+    assert run("import", str(source / "bare-standard"), "--force")[0] == 0
+
+
+def test_import_rejects_a_nonexistent_source(run, tmp_path):
+    rc, _, err = run("import", str(tmp_path / "ghost"))
+    assert rc == 4
+    assert "neither a directory" in err
+
+
+def test_import_rejects_a_folder_without_a_manifest(run, tmp_path):
+    empty = tmp_path / "empty-skill"
+    empty.mkdir()
+    rc, _, err = run("import", str(empty))
+    assert rc == 4
+    assert "No SKILL.md" in err
+
+
+def test_import_rejects_a_traversing_zip(run, tmp_path):
+    bundle = tmp_path / "evil.zip"
+    with zipfile.ZipFile(bundle, "w") as archive:
+        archive.writestr("../escaped/SKILL.md", "---\nname: x\ndescription: d\n---\n")
+    rc, _, err = run("import", str(bundle))
+    assert rc == 4
+    assert "escapes the destination" in err
+
+
+def test_export_of_a_missing_skill_exits_not_found(run):
+    rc, _, _ = run("export", "ghost")
+    assert rc == 3
+
+
+def test_export_defaults_to_the_working_directory(run, skills_dir, tmp_path):
+    copy_fixture("bare-standard", skills_dir)
+    rc, _, _ = run("export", "bare-standard")
+    assert rc == 0
+    assert (tmp_path / "workdir" / "bare-standard.zip").is_file()
+
+
+# ----------------------------------------------------------------------
+# Dispatch
+# ----------------------------------------------------------------------
+
+
+def test_missing_subcommand_returns_usage(run):
+    parser = argparse.ArgumentParser(prog="gaia")
+    subparsers = parser.add_subparsers(dest="action")
+    skills_cli.add_subparser(subparsers)
+    assert skills_cli.handle(parser.parse_args(["skill"])) == 2
+
+
+def test_unknown_subcommand_returns_usage():
+    args = argparse.Namespace(skill_action="publish")
+    assert skills_cli.handle(args) == 2
+
+
+def test_skills_package_ships_in_the_wheel():
+    """``setup.py`` lists packages explicitly — an omission ships a CLI that
+    raises ImportError on the user's machine while passing every dev-mode test."""
+    import ast
+
+    tree = ast.parse((REPO_ROOT / "setup.py").read_text(encoding="utf-8"))
+    declared = next(
+        {ast.literal_eval(e) for e in node.value.elts}
+        for node in ast.walk(tree)
+        if isinstance(node, ast.keyword) and node.arg == "packages"
+    )
+    assert "gaia.skills" in declared
+
+    on_disk = {
+        ".".join(p.parent.relative_to(REPO_ROOT / "src").parts)
+        for p in (REPO_ROOT / "src").rglob("__init__.py")
+    }
+    assert on_disk == declared, (
+        "src/gaia packages and setup.py's explicit list have drifted; add the new "
+        f"package(s) to setup.py: {sorted(on_disk - declared)}"
+    )
+
+
+# ----------------------------------------------------------------------
+# The real binary — proves the top-level `gaia skill` wiring
+# ----------------------------------------------------------------------
+
+
+def _real_cli(*args: str, home: Path, cwd: Path):
+    env = {
+        "PATH": "/usr/bin:/bin:/usr/sbin:/sbin",
+        "HOME": str(home / "fake-home"),
+        "GAIA_CONFIG_DIR": str(home / "gaia-home"),
+        "PYTHONPATH": str(REPO_ROOT / "src"),
+        "GAIA_MEMORY_DISABLED": "1",
+    }
+    return subprocess.run(
+        [sys.executable, "-m", "gaia.cli", "skill", *args],
+        capture_output=True,
+        text=True,
+        env=env,
+        cwd=str(cwd),
+        check=False,
+        timeout=300,
+    )
+
+
+@pytest.mark.slow
+def test_real_cli_create_list_info_export_import(tmp_path):
+    """One end-to-end pass over every verb through the real `gaia` entry point."""
+    (tmp_path / "fake-home").mkdir()
+    (tmp_path / "gaia-home" / "skills").mkdir(parents=True)
+    workdir = tmp_path / "workdir"
+    workdir.mkdir()
+
+    created = _real_cli("create", "smoke-skill", home=tmp_path, cwd=workdir)
+    assert created.returncode == 0, created.stderr
+    assert "Created skill 'smoke-skill'" in created.stdout
+
+    listed = _real_cli("list", "--json", home=tmp_path, cwd=workdir)
+    assert listed.returncode == 0, listed.stderr
+    # --json must keep stdout free of log lines.
+    assert [s["name"] for s in json.loads(listed.stdout)["skills"]] == ["smoke-skill"]
+
+    info = _real_cli("info", "smoke-skill", home=tmp_path, cwd=workdir)
+    assert info.returncode == 0, info.stderr
+    assert "smoke-skill  0.1.0" in info.stdout
+
+    exported = _real_cli("export", "smoke-skill", home=tmp_path, cwd=workdir)
+    assert exported.returncode == 0, exported.stderr
+    bundle = workdir / "smoke-skill.zip"
+    assert bundle.is_file()
+
+    shutil.rmtree(tmp_path / "gaia-home" / "skills" / "smoke-skill")
+    imported = _real_cli("import", str(bundle), home=tmp_path, cwd=workdir)
+    assert imported.returncode == 0, imported.stderr
+    assert (tmp_path / "gaia-home" / "skills" / "smoke-skill" / "SKILL.md").is_file()
+
+
+@pytest.mark.slow
+def test_real_cli_help_lists_only_the_phase_1_verbs(tmp_path):
+    (tmp_path / "fake-home").mkdir()
+    result = _real_cli("--help", home=tmp_path, cwd=tmp_path)
+    assert result.returncode == 0, result.stderr
+    for verb in ("list", "info", "create", "import", "export"):
+        assert verb in result.stdout
+    # The marketplace verbs belong to #2467 — not discoverable yet.
+    for verb in ("publish", "search", "install"):
+        assert f"    {verb}" not in result.stdout
+
+
+@pytest.mark.slow
+def test_real_cli_missing_skill_exit_code(tmp_path):
+    (tmp_path / "fake-home").mkdir()
+    (tmp_path / "gaia-home" / "skills").mkdir(parents=True)
+    result = _real_cli("info", "ghost", home=tmp_path, cwd=tmp_path)
+    assert result.returncode == 3
+    assert "No skill named 'ghost'" in result.stderr

--- a/tests/unit/test_skills_format.py
+++ b/tests/unit/test_skills_format.py
@@ -1,0 +1,352 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""
+Unit tests for the ``SKILL.md`` parser, writer, and validator (issue #888).
+
+Covers the acceptance criteria that live at the format layer: round-trip
+identity, the bare agentskills.io skill, the ignored standard keys, and every
+loud-failure path (name↔directory mismatch, bad SemVer, over-long description,
+malformed permissions).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from gaia.skills import (
+    DEFAULT_SECURITY_TIER,
+    MAX_DESCRIPTION_LENGTH,
+    Skill,
+    SkillValidationError,
+    parse_skill,
+    parse_skill_file,
+    parse_skill_metadata,
+)
+from tests.unit.skills_helpers import FIXTURES, copy_fixture, write_skill_dir
+
+BARE = """---
+name: bare-standard
+description: Walk through a production incident postmortem. Use when the user mentions an outage.
+---
+
+# Incident Review
+
+1. Establish the timeline.
+"""
+
+FULL = """---
+name: web-search
+description: Search the web via the Brave Search API.
+license: MIT
+version: 1.0.0
+metadata:
+  gaia:
+    security_tier: verified
+    permissions:
+      - network:read:*.brave.com
+    requirements:
+      python: ">=3.10"
+      dependencies:
+        - requests>=2.31
+      env_vars:
+        - BRAVE_API_KEY
+      hardware: {npu: optional}
+    tools:
+      - name: search_web
+        description: Search the web for current information
+        parameters:
+          query: {type: string, required: true}
+          max_results: {type: integer, required: false}
+        returns: {type: object}
+        atomic: true
+    tools_required:
+      - remember
+  hermes:
+    category: research
+---
+
+# Web Search
+
+Search first, then fetch the best result.
+"""
+
+
+# ----------------------------------------------------------------------
+# Round-trip identity — acceptance criterion #1
+# ----------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("text", [BARE, FULL], ids=["bare", "full"])
+def test_round_trip_is_identity(text):
+    """parse → write → parse yields an identical Skill."""
+    first = parse_skill(text)
+    second = parse_skill(first.to_markdown())
+    assert second == first
+
+
+@pytest.mark.parametrize("text", [BARE, FULL], ids=["bare", "full"])
+def test_round_trip_is_byte_stable_after_one_pass(text):
+    """A second write produces byte-identical output — no drift on re-save."""
+    once = parse_skill(text).to_markdown()
+    twice = parse_skill(once).to_markdown()
+    assert twice == once
+
+
+@pytest.mark.parametrize(
+    "fixture",
+    ["bare-standard", "web-search", "triage-support-ticket", "local-capability"],
+)
+def test_every_fixture_round_trips(fixture):
+    skill = parse_skill_file(FIXTURES / fixture)
+    assert parse_skill(skill.to_markdown()) == skill
+
+
+def test_round_trip_preserves_foreign_metadata_namespaces():
+    skill = parse_skill(FULL)
+    assert skill.other_metadata == {"hermes": {"category": "research"}}
+    assert parse_skill(skill.to_markdown()).other_metadata == skill.other_metadata
+
+
+def test_round_trip_ignores_but_preserves_standard_extras():
+    """`compatibility` / `allowed-tools` parse, are ignored, and survive a write."""
+    text = BARE.replace(
+        "---\n\n# Incident",
+        'allowed-tools: Read, Write\ncompatibility: ">=1.0"\n---\n\n# Incident',
+    )
+    skill = parse_skill(text)
+    assert skill.extra_fields["allowed-tools"] == "Read, Write"
+    # Ignored means: not a permission mechanism.
+    assert skill.gaia.permissions == []
+    assert parse_skill(skill.to_markdown()) == skill
+
+
+def test_write_and_reparse_from_disk(tmp_path):
+    skill = parse_skill(FULL)
+    path = skill.write(tmp_path / "web-search" / "SKILL.md")
+    assert parse_skill_file(path) == skill
+
+
+def test_write_without_destination_fails_loudly():
+    skill = parse_skill(BARE)
+    with pytest.raises(ValueError, match="needs a destination"):
+        skill.write()
+
+
+# ----------------------------------------------------------------------
+# Bare agentskills.io skill — acceptance criterion #2
+# ----------------------------------------------------------------------
+
+
+def test_bare_standard_skill_loads_instruction_only():
+    skill = parse_skill(BARE)
+    assert skill.is_instruction_only
+    assert skill.security_tier == DEFAULT_SECURITY_TIER == "experimental"
+    assert skill.gaia.tools == []
+    assert skill.gaia.permissions == []
+    assert skill.gaia.tools_required == []
+    assert skill.version is None
+    assert skill.body.startswith("# Incident Review")
+
+
+def test_bare_skill_does_not_gain_a_gaia_block_on_write():
+    """A standard skill stays standard — GAIA never stamps defaults into it."""
+    written = parse_skill(BARE).to_markdown()
+    assert "metadata" not in written
+    assert "security_tier" not in written
+
+
+def test_gaia_fields_parse_into_typed_metadata():
+    skill = parse_skill(FULL)
+    assert skill.security_tier == "verified"
+    assert skill.gaia.permissions == ["network:read:*.brave.com"]
+    assert skill.gaia.requirements.python == ">=3.10"
+    assert skill.gaia.requirements.env_vars == ["BRAVE_API_KEY"]
+    assert skill.gaia.requirements.hardware == {"npu": "optional"}
+    assert skill.gaia.tools_required == ["remember"]
+
+    (declared,) = skill.gaia.tools
+    assert declared.name == "search_web"
+    assert declared.atomic is True
+    assert declared.parameters["query"] == {"type": "string", "required": True}
+    assert skill.tool_names == ["search_web"]
+    assert skill.namespaced_tool_name("search_web") == "web-search/search_web"
+
+
+def test_metadata_only_parse_drops_the_body(tmp_path):
+    """Progressive disclosure level 1 keeps metadata resident, not instructions."""
+    copy_fixture("web-search", tmp_path)
+    skill = parse_skill_metadata(tmp_path / "web-search")
+    assert skill.name == "web-search"
+    assert skill.description
+    assert skill.body == ""
+    assert skill.tool_names == ["search_web"]
+
+
+# ----------------------------------------------------------------------
+# Loud failures
+# ----------------------------------------------------------------------
+
+
+def test_missing_frontmatter_fails_loudly():
+    with pytest.raises(SkillValidationError, match="no YAML frontmatter"):
+        parse_skill("# Just markdown\n")
+
+
+def test_invalid_yaml_fails_loudly():
+    with pytest.raises(SkillValidationError, match="invalid"):
+        parse_skill("---\nname: x\n  bad: [indent\n---\n\nbody\n")
+
+
+def test_missing_name_fails_loudly():
+    with pytest.raises(SkillValidationError, match="'name' is missing"):
+        parse_skill("---\ndescription: something\n---\n\nbody\n")
+
+
+def test_missing_description_fails_loudly():
+    with pytest.raises(SkillValidationError, match="'description' is missing"):
+        parse_skill("---\nname: thing\n---\n\nbody\n")
+
+
+@pytest.mark.parametrize(
+    "name",
+    ["Web-Search", "web_search", "-web", "web-", "web--search", "web search", "wéb"],
+)
+def test_invalid_names_fail_loudly(name):
+    with pytest.raises(SkillValidationError, match="not a valid skill name"):
+        parse_skill(f"---\nname: {name}\ndescription: d\n---\n\nbody\n")
+
+
+def test_over_long_name_fails_loudly():
+    name = "a" * 65
+    with pytest.raises(SkillValidationError, match="the limit is 64"):
+        parse_skill(f"---\nname: {name}\ndescription: d\n---\n\nbody\n")
+
+
+def test_over_long_description_fails_loudly():
+    description = "x" * (MAX_DESCRIPTION_LENGTH + 1)
+    with pytest.raises(SkillValidationError, match="the limit is 1024"):
+        parse_skill(f"---\nname: ok\ndescription: {description}\n---\n\nbody\n")
+
+
+@pytest.mark.parametrize("version", ["1.0", "v1.0.0", "1.0.0.0", "latest", "01.0.0"])
+def test_bad_semver_fails_loudly(version):
+    with pytest.raises(SkillValidationError, match="not valid SemVer"):
+        parse_skill(
+            f'---\nname: ok\ndescription: d\nversion: "{version}"\n---\n\nbody\n'
+        )
+
+
+@pytest.mark.parametrize("version", ["0.0.0", "1.0.0", "1.2.3-rc.1", "1.2.3+build.5"])
+def test_valid_semver_accepted(version):
+    skill = parse_skill(
+        f'---\nname: ok\ndescription: d\nversion: "{version}"\n---\n\nbody\n'
+    )
+    assert skill.version == version
+
+
+def test_name_directory_mismatch_fails_loudly(tmp_path):
+    write_skill_dir(tmp_path, "not-the-name", BARE)
+    with pytest.raises(SkillValidationError, match="but the directory is named"):
+        parse_skill_file(tmp_path / "not-the-name")
+
+
+def test_name_directory_match_accepted(tmp_path):
+    write_skill_dir(tmp_path, "bare-standard", BARE)
+    assert parse_skill_file(tmp_path / "bare-standard").name == "bare-standard"
+
+
+def test_missing_skill_file_fails_loudly(tmp_path):
+    (tmp_path / "empty").mkdir()
+    with pytest.raises(SkillValidationError, match="No SKILL.md"):
+        parse_skill_file(tmp_path / "empty")
+
+
+@pytest.mark.parametrize(
+    "tier_line,expected",
+    [
+        ("security_tier: nuclear", "not one of"),
+        ("permissions: network:read", "must be a list"),
+        ("tools: 3", "must be a list"),
+        ("tools_required: query_documents", "must be a list"),
+        ("requirements: []", "must be a mapping"),
+    ],
+)
+def test_malformed_gaia_block_fails_loudly(tier_line, expected):
+    text = f"---\nname: ok\ndescription: d\nmetadata:\n  gaia:\n    {tier_line}\n---\n\nbody\n"
+    with pytest.raises(SkillValidationError, match=expected):
+        parse_skill(text)
+
+
+@pytest.mark.parametrize(
+    "permission,expected",
+    [
+        ("networkread", "missing its level"),
+        ("teleport:read", "unknown domain"),
+        ("network:teleport", "does not define"),
+        ("shell:read", "does not define"),
+    ],
+)
+def test_malformed_permission_fails_loudly(permission, expected):
+    text = (
+        "---\nname: ok\ndescription: d\nmetadata:\n  gaia:\n    permissions:\n"
+        f"      - {permission}\n---\n\nbody\n"
+    )
+    with pytest.raises(SkillValidationError, match=expected):
+        parse_skill(text)
+
+
+def test_duplicate_tool_names_fail_loudly():
+    text = (
+        "---\nname: ok\ndescription: d\nmetadata:\n  gaia:\n    tools:\n"
+        "      - name: dup\n        parameters: {}\n"
+        "      - name: dup\n        parameters: {}\n---\n\nbody\n"
+    )
+    with pytest.raises(SkillValidationError, match="more than once"):
+        parse_skill(text)
+
+
+def test_tool_entry_without_name_fails_loudly():
+    text = (
+        "---\nname: ok\ndescription: d\nmetadata:\n  gaia:\n    tools:\n"
+        "      - description: nameless\n---\n\nbody\n"
+    )
+    with pytest.raises(SkillValidationError, match="missing its 'name'"):
+        parse_skill(text)
+
+
+def test_numeric_version_fails_loudly_with_a_quoting_hint():
+    with pytest.raises(SkillValidationError, match="Quote it"):
+        parse_skill("---\nname: ok\ndescription: d\nversion: 1.0\n---\n\nbody\n")
+
+
+def test_error_messages_name_what_to_do():
+    """Fail-loudly rule: every message points at a fix and a doc."""
+    with pytest.raises(SkillValidationError) as excinfo:
+        parse_skill("---\nname: Bad_Name\ndescription: d\n---\n\nbody\n")
+    message = str(excinfo.value)
+    assert "web-research" in message  # what a good name looks like
+    assert "skill-format" in message  # where to look next
+
+
+def test_crlf_frontmatter_parses():
+    skill = parse_skill(BARE.replace("\n", "\r\n"))
+    assert skill.name == "bare-standard"
+
+
+def test_skill_equality_ignores_provenance(tmp_path):
+    """Two copies in different roots are the same Skill — that is what makes
+    round-trip identity meaningful across directories."""
+    a = parse_skill(BARE)
+    b = parse_skill(BARE)
+    b.path = tmp_path / "elsewhere" / "SKILL.md"
+    b.root = "user"
+    b.read_only = True
+    assert a == b
+
+
+def test_skill_dataclass_is_constructible_directly():
+    """Downstream issues build Skills in code — keep the constructor usable."""
+    skill = Skill(name="hand-made", description="Built in code.")
+    assert skill.is_instruction_only
+    assert skill.security_tier == "experimental"
+    assert parse_skill(skill.to_markdown()) == skill

--- a/tests/unit/test_skills_manager.py
+++ b/tests/unit/test_skills_manager.py
@@ -1,0 +1,685 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""
+Unit tests for skill discovery, precedence, permissions, tool registration, and
+``Agent.load_skill`` (issue #888).
+
+Every test runs from a cold state: roots live under ``tmp_path`` and the real
+``~/.gaia/skills`` / ``~/.claude/skills`` are never read or written.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from gaia.agents.base.tools import _TOOL_REGISTRY
+from gaia.skills import (
+    Permission,
+    SkillManager,
+    SkillNotFoundError,
+    SkillPermissionError,
+    SkillValidationError,
+    connector_requirements,
+    refuse_unbridged_permissions,
+    register_skill_tools,
+    unregister_skill_tools,
+    user_skills_dir,
+)
+from gaia.skills.manager import (
+    ROOT_AGENT_BUNDLED,
+    ROOT_CLAUDE_IMPORT,
+    ROOT_USER,
+)
+from tests.unit.skills_helpers import copy_fixture, isolated_manager, write_skill_dir
+
+
+@pytest.fixture(autouse=True)
+def _clean_tool_registry():
+    """Restore ``_TOOL_REGISTRY`` after any test that registers skill tools."""
+    before = dict(_TOOL_REGISTRY)
+    yield
+    _TOOL_REGISTRY.clear()
+    _TOOL_REGISTRY.update(before)
+
+
+@pytest.fixture
+def roots(tmp_path):
+    """Three empty, isolated discovery roots."""
+    agent = tmp_path / "agent-pkg" / "skills"
+    user = tmp_path / "gaia-home" / "skills"
+    claude = tmp_path / "claude" / "skills"
+    for path in (agent, user, claude):
+        path.mkdir(parents=True)
+    return {"agent": agent, "user": user, "claude": claude}
+
+
+def make_manager(roots):
+    return SkillManager(
+        agent_skill_dirs=[roots["agent"]],
+        user_skills_root=roots["user"],
+        claude_skill_dirs=[roots["claude"]],
+    )
+
+
+# ----------------------------------------------------------------------
+# Discovery + roots
+# ----------------------------------------------------------------------
+
+
+def test_cold_state_discovers_nothing(roots):
+    manager = make_manager(roots)
+    assert manager.list_skills() == []
+    assert manager.discovery_errors == {}
+
+
+def test_root_order_is_agent_then_user_then_claude(roots):
+    labels = [r.label for r in make_manager(roots).roots]
+    assert labels == [ROOT_AGENT_BUNDLED, ROOT_USER, ROOT_CLAUDE_IMPORT]
+
+
+def test_only_three_roots_in_v1(tmp_path):
+    """Project-local ./.gaia/skills and the registry-lock root are deferred."""
+    manager = isolated_manager(tmp_path)
+    paths = [str(r.path) for r in manager.roots]
+    assert not any(p.endswith("/.gaia/skills") and "gaia-home" not in p for p in paths)
+    assert len(manager.roots) == 2  # user + one claude root when no agent dirs
+
+
+def test_user_root_honors_gaia_config_dir(monkeypatch, tmp_path):
+    monkeypatch.setenv("GAIA_CONFIG_DIR", str(tmp_path / "custom"))
+    assert user_skills_dir() == tmp_path / "custom" / "skills"
+
+
+def test_discovers_skills_from_every_root(roots):
+    copy_fixture("bare-standard", roots["user"])
+    copy_fixture("web-search", roots["agent"])
+    copy_fixture("incident-review", roots["claude"], as_name="incident-review")
+
+    manager = make_manager(roots)
+    found = {s.name: s.root for s in manager.list_skills()}
+    assert found == {
+        "bare-standard": ROOT_USER,
+        "web-search": ROOT_AGENT_BUNDLED,
+        "incident-review": ROOT_CLAUDE_IMPORT,
+    }
+
+
+def test_claude_import_is_read_only(roots):
+    copy_fixture("incident-review", roots["claude"])
+    skill = make_manager(roots).get("incident-review")
+    assert skill.read_only is True
+    assert skill.root == ROOT_CLAUDE_IMPORT
+    # A bare Claude Code skill imports as instruction-only with safe defaults.
+    assert skill.is_instruction_only
+    assert skill.security_tier == "experimental"
+
+
+def test_claude_skill_with_allowed_tools_is_not_granted_permissions(roots):
+    copy_fixture("incident-review", roots["claude"])
+    skill = make_manager(roots).load("incident-review")
+    assert skill.extra_fields["allowed-tools"] == "Read, Write, Bash"
+    assert skill.gaia.permissions == []
+
+
+# ----------------------------------------------------------------------
+# Precedence — acceptance criterion #7
+# ----------------------------------------------------------------------
+
+
+def test_lower_precedence_root_never_overrides(roots):
+    """Same name in all three roots: the agent-bundled copy wins."""
+    for root, description in (
+        ("agent", "AGENT copy"),
+        ("user", "USER copy"),
+        ("claude", "CLAUDE copy"),
+    ):
+        write_skill_dir(
+            roots[root],
+            "shared",
+            f"---\nname: shared\ndescription: {description}\n---\n\n# {description}\n",
+        )
+
+    manager = make_manager(roots)
+    winner = manager.get("shared")
+    assert winner.root == ROOT_AGENT_BUNDLED
+    assert winner.description == "AGENT copy"
+
+    shadowed = {s.root for s in manager.shadowed("shared")}
+    assert shadowed == {ROOT_USER, ROOT_CLAUDE_IMPORT}
+    assert manager.load("shared").body.strip() == "# AGENT copy"
+
+
+def test_user_root_beats_claude_import(roots):
+    for root, description in (("user", "USER copy"), ("claude", "CLAUDE copy")):
+        write_skill_dir(
+            roots[root],
+            "shared",
+            f"---\nname: shared\ndescription: {description}\n---\n\nbody\n",
+        )
+    manager = make_manager(roots)
+    assert manager.get("shared").root == ROOT_USER
+    assert [s.root for s in manager.shadowed("shared")] == [ROOT_CLAUDE_IMPORT]
+
+
+def test_shadowed_skills_are_listed_once(roots):
+    for root in ("agent", "user"):
+        write_skill_dir(
+            roots[root], "shared", "---\nname: shared\ndescription: d\n---\n\nbody\n"
+        )
+    manager = make_manager(roots)
+    assert [s.name for s in manager.list_skills()] == ["shared"]
+
+
+# ----------------------------------------------------------------------
+# Errors + caching
+# ----------------------------------------------------------------------
+
+
+def test_missing_skill_raises_with_actionable_message(roots):
+    copy_fixture("bare-standard", roots["user"])
+    manager = make_manager(roots)
+    with pytest.raises(SkillNotFoundError) as excinfo:
+        manager.load("no-such-skill")
+    message = str(excinfo.value)
+    assert "gaia skill create no-such-skill" in message
+    assert "bare-standard" in message  # lists what IS available
+
+
+def test_invalid_skill_is_reported_not_silently_dropped(roots):
+    copy_fixture("bare-standard", roots["user"])
+    write_skill_dir(roots["user"], "broken", "not a skill file\n")
+
+    manager = make_manager(roots)
+    assert [s.name for s in manager.list_skills()] == ["bare-standard"]
+    errors = manager.discovery_errors
+    assert len(errors) == 1
+    assert "broken" in next(iter(errors))
+
+
+def test_reload_picks_up_a_new_skill(roots):
+    manager = make_manager(roots)
+    assert manager.list_skills() == []
+    copy_fixture("bare-standard", roots["user"])
+    assert manager.list_skills() == []  # cached
+    assert [s.name for s in manager.reload().values()] == ["bare-standard"]
+
+
+def test_resource_path_resolves_bundled_files(roots):
+    skill_dir = copy_fixture("web-search", roots["user"])
+    (skill_dir / "reference").mkdir()
+    (skill_dir / "reference" / "syntax.md").write_text("# Syntax\n", encoding="utf-8")
+
+    manager = make_manager(roots)
+    assert manager.resource_path("web-search", "reference/syntax.md").is_file()
+
+
+def test_resource_path_rejects_traversal(roots):
+    copy_fixture("web-search", roots["user"])
+    manager = make_manager(roots)
+    with pytest.raises(SkillValidationError, match="escapes skill"):
+        manager.resource_path("web-search", "../../etc/passwd")
+
+
+def test_resource_path_rejects_missing_file(roots):
+    copy_fixture("web-search", roots["user"])
+    with pytest.raises(SkillValidationError, match="no resource"):
+        make_manager(roots).resource_path("web-search", "nope.md")
+
+
+# ----------------------------------------------------------------------
+# Permissions — acceptance criterion #5
+# ----------------------------------------------------------------------
+
+
+def test_local_capability_permission_is_refused_with_an_actionable_error():
+    permissions = [Permission.parse("filesystem:write", skill_name="x")]
+    with pytest.raises(SkillPermissionError) as excinfo:
+        refuse_unbridged_permissions(permissions, skill_name="x")
+    message = str(excinfo.value)
+    assert "deferred to a later phase" in message
+    assert "filesystem" in message
+    assert "1019" in message  # where to look next
+
+
+@pytest.mark.parametrize(
+    "permission",
+    [
+        "filesystem:read",
+        "shell:execute",
+        "database:write",
+        "desktop:control",
+        "env:read",
+    ],
+)
+def test_every_local_capability_domain_is_refused(permission):
+    parsed = [Permission.parse(permission, skill_name="x")]
+    with pytest.raises(SkillPermissionError):
+        refuse_unbridged_permissions(parsed, skill_name="x")
+
+
+@pytest.mark.parametrize(
+    "permission",
+    ["network:read", "network:write:*.brave.com", "mcp:connect:mcp-tavily"],
+)
+def test_connector_bridged_permissions_are_allowed(permission):
+    parsed = [Permission.parse(permission, skill_name="x")]
+    refuse_unbridged_permissions(parsed, skill_name="x")  # must not raise
+
+
+def test_network_permission_resolves_to_a_connector_requirement():
+    parsed = [Permission.parse("network:read:*.brave.com", skill_name="web-search")]
+    (requirement,) = connector_requirements(parsed, skill_name="web-search")
+    assert requirement.connector_id == "network"
+    assert requirement.scopes == ("read:*.brave.com",)
+    assert "web-search" in requirement.reason
+
+
+def test_mcp_permission_resolves_to_the_named_connector():
+    parsed = [Permission.parse("mcp:connect:mcp-tavily", skill_name="research")]
+    (requirement,) = connector_requirements(parsed, skill_name="research")
+    assert requirement.connector_id == "mcp-tavily"
+
+
+def test_unscoped_mcp_connect_fails_loudly():
+    parsed = [Permission.parse("mcp:connect", skill_name="research")]
+    with pytest.raises(SkillValidationError, match="without naming a connector"):
+        connector_requirements(parsed, skill_name="research")
+
+
+def test_mcp_connect_to_an_unknown_connector_fails_loudly():
+    parsed = [Permission.parse("mcp:connect:not-a-connector", skill_name="research")]
+    with pytest.raises(SkillValidationError, match="no connector with id"):
+        connector_requirements(parsed, skill_name="research")
+
+
+def test_none_level_produces_no_requirement():
+    parsed = [Permission.parse("network:none", skill_name="x")]
+    assert connector_requirements(parsed, skill_name="x") == []
+
+
+@pytest.mark.parametrize("permission", ["filesystem:none", "shell:none", "env:none"])
+def test_explicit_local_capability_denial_is_not_refused(permission):
+    """``<domain>:none`` asks for *less* than the default — refusing it would
+    reject a skill for being explicit about what it does not need."""
+    parsed = [Permission.parse(permission, skill_name="x")]
+    refuse_unbridged_permissions(parsed, skill_name="x")  # must not raise
+    assert connector_requirements(parsed, skill_name="x") == []
+
+
+def test_a_none_denial_alongside_a_real_grant_still_refuses():
+    parsed = [
+        Permission.parse("filesystem:none", skill_name="x"),
+        Permission.parse("shell:execute", skill_name="x"),
+    ]
+    with pytest.raises(SkillPermissionError, match="shell:execute"):
+        refuse_unbridged_permissions(parsed, skill_name="x")
+
+
+def test_permission_round_trips_through_str():
+    assert str(Permission.parse("network:read:*.brave.com", skill_name="x")) == (
+        "network:read:*.brave.com"
+    )
+
+
+# ----------------------------------------------------------------------
+# Tool registration — acceptance criteria #3 and #4
+# ----------------------------------------------------------------------
+
+
+def test_tools_register_under_the_skill_namespace(roots):
+    copy_fixture("web-search", roots["user"])
+    skill = make_manager(roots).load("web-search")
+
+    registered = register_skill_tools(skill)
+    assert set(registered) == {"web-search/search_web"}
+    assert "web-search/search_web" in _TOOL_REGISTRY
+    # The unqualified name must NOT leak into the global registry.
+    assert "search_web" not in registered
+
+    entry = _TOOL_REGISTRY["web-search/search_web"]
+    assert entry["name"] == "web-search/search_web"
+    assert entry["skill"] == "web-search"
+    assert entry["parameters"]["query"]["required"] is True
+    assert entry["function"](query="amd", max_results=2)["query"] == "amd"
+
+
+def test_a_skill_tool_may_shadow_an_existing_registry_name(roots):
+    """The ``<skill>/<tool>`` namespace exists so a skill can provide a tool the
+    framework already has — loading must not clobber or drop either one."""
+    original = {"name": "search_web", "description": "the framework's", "parameters": {}}
+    _TOOL_REGISTRY["search_web"] = original
+
+    copy_fixture("web-search", roots["user"])
+    skill = make_manager(roots).load("web-search")
+    registered = register_skill_tools(skill)
+
+    assert set(registered) == {"web-search/search_web"}
+    # The framework's tool survives untouched…
+    assert _TOOL_REGISTRY["search_web"] is original
+    # …and the skill's is reachable under its namespace.
+    assert _TOOL_REGISTRY["web-search/search_web"]["skill"] == "web-search"
+
+
+def test_unregister_removes_only_that_skills_tools(roots):
+    copy_fixture("web-search", roots["user"])
+    skill = make_manager(roots).load("web-search")
+    register_skill_tools(skill)
+    assert unregister_skill_tools("web-search") == ["web-search/search_web"]
+    assert "web-search/search_web" not in _TOOL_REGISTRY
+
+
+def test_instruction_only_skill_registers_no_tools(roots):
+    copy_fixture("bare-standard", roots["user"])
+    skill = make_manager(roots).load("bare-standard")
+    assert register_skill_tools(skill) == {}
+
+
+def test_tools_mismatch_fails_loudly_with_no_partial_load(roots):
+    """The headline acceptance criterion: a declared tool tools.py never
+    registers rejects the whole skill and leaves the registry untouched."""
+    copy_fixture("tool-mismatch", roots["user"])
+    skill = make_manager(roots).load("tool-mismatch")
+    before = dict(_TOOL_REGISTRY)
+
+    with pytest.raises(SkillValidationError) as excinfo:
+        register_skill_tools(skill)
+
+    message = str(excinfo.value)
+    assert "missing_tool" in message
+    assert "Nothing was loaded" in message
+    # No partial load: neither the missing tool nor its valid sibling landed.
+    assert _TOOL_REGISTRY == before
+    assert "tool-mismatch/present_tool" not in _TOOL_REGISTRY
+    assert "present_tool" not in _TOOL_REGISTRY
+
+
+def test_undeclared_tool_in_module_fails_loudly(roots):
+    write_skill_dir(
+        roots["user"],
+        "extra-tool",
+        "---\nname: extra-tool\ndescription: d\nmetadata:\n  gaia:\n    tools:\n"
+        "      - name: declared\n        parameters:\n          text: {type: string, required: true}\n"
+        "---\n\nbody\n",
+        tools=(
+            "from gaia.agents.base.tools import tool\n\n\n"
+            "@tool\ndef declared(text: str) -> dict:\n"
+            '    """Declared."""\n    return {}\n\n\n'
+            "@tool\ndef sneaky(text: str) -> dict:\n"
+            '    """Undeclared."""\n    return {}\n'
+        ),
+    )
+    skill = make_manager(roots).load("extra-tool")
+    before = dict(_TOOL_REGISTRY)
+    with pytest.raises(SkillValidationError, match="does not declare"):
+        register_skill_tools(skill)
+    assert _TOOL_REGISTRY == before
+
+
+def test_signature_parameter_mismatch_fails_loudly(roots):
+    write_skill_dir(
+        roots["user"],
+        "bad-params",
+        "---\nname: bad-params\ndescription: d\nmetadata:\n  gaia:\n    tools:\n"
+        "      - name: echo\n        parameters:\n          message: {type: string, required: true}\n"
+        "---\n\nbody\n",
+        tools=(
+            "from gaia.agents.base.tools import tool\n\n\n"
+            "@tool\ndef echo(text: str) -> dict:\n"
+            '    """Echo."""\n    return {}\n'
+        ),
+    )
+    skill = make_manager(roots).load("bad-params")
+    with pytest.raises(SkillValidationError, match="parameters do not match"):
+        register_skill_tools(skill)
+
+
+def test_signature_requiredness_mismatch_fails_loudly(roots):
+    write_skill_dir(
+        roots["user"],
+        "bad-required",
+        "---\nname: bad-required\ndescription: d\nmetadata:\n  gaia:\n    tools:\n"
+        "      - name: echo\n        parameters:\n          text: {type: string, required: false}\n"
+        "---\n\nbody\n",
+        tools=(
+            "from gaia.agents.base.tools import tool\n\n\n"
+            "@tool\ndef echo(text: str) -> dict:\n"
+            '    """Echo."""\n    return {}\n'
+        ),
+    )
+    skill = make_manager(roots).load("bad-required")
+    with pytest.raises(SkillValidationError, match="declared optional"):
+        register_skill_tools(skill)
+
+
+def test_signature_type_mismatch_fails_loudly(roots):
+    write_skill_dir(
+        roots["user"],
+        "bad-type",
+        "---\nname: bad-type\ndescription: d\nmetadata:\n  gaia:\n    tools:\n"
+        "      - name: echo\n        parameters:\n          text: {type: integer, required: true}\n"
+        "---\n\nbody\n",
+        tools=(
+            "from gaia.agents.base.tools import tool\n\n\n"
+            "@tool\ndef echo(text: str) -> dict:\n"
+            '    """Echo."""\n    return {}\n'
+        ),
+    )
+    skill = make_manager(roots).load("bad-type")
+    with pytest.raises(SkillValidationError, match="annotates it as 'string'"):
+        register_skill_tools(skill)
+
+
+def test_declared_tools_without_a_tools_module_fails_loudly(roots):
+    write_skill_dir(
+        roots["user"],
+        "no-module",
+        "---\nname: no-module\ndescription: d\nmetadata:\n  gaia:\n    tools:\n"
+        "      - name: echo\n        parameters: {}\n---\n\nbody\n",
+    )
+    skill = make_manager(roots).load("no-module")
+    with pytest.raises(SkillValidationError, match="has no tools.py"):
+        register_skill_tools(skill)
+
+
+def test_a_raising_tools_module_fails_loudly_without_partial_load(roots):
+    write_skill_dir(
+        roots["user"],
+        "boom",
+        "---\nname: boom\ndescription: d\nmetadata:\n  gaia:\n    tools:\n"
+        "      - name: echo\n        parameters: {}\n---\n\nbody\n",
+        tools=(
+            "from gaia.agents.base.tools import tool\n\n\n"
+            "@tool\ndef echo() -> dict:\n"
+            '    """Echo."""\n    return {}\n\n\n'
+            "raise RuntimeError('exploding module')\n"
+        ),
+    )
+    skill = make_manager(roots).load("boom")
+    before = dict(_TOOL_REGISTRY)
+    with pytest.raises(SkillValidationError, match="exploding module"):
+        register_skill_tools(skill)
+    assert _TOOL_REGISTRY == before
+
+
+# ----------------------------------------------------------------------
+# Agent.load_skill
+# ----------------------------------------------------------------------
+
+
+class _StubAgent:
+    """Exercises ``Agent.load_skill`` without booting the LLM stack.
+
+    Binds the real unbound methods so the test covers the shipped code, not a
+    reimplementation of it.
+    """
+
+    from gaia.agents.base.agent import Agent
+
+    REQUIRED_CONNECTORS: list = []
+    SKILL_DIRS: list = []
+    _instance_tools = None
+    _skill_manager = None
+    _loaded_skills = None
+
+    skill_manager = Agent.skill_manager
+    loaded_skills = Agent.loaded_skills
+    _tools_registry = Agent._tools_registry
+    load_skill = Agent.load_skill
+    unload_skill = Agent.unload_skill
+    get_skills_system_prompt = Agent.get_skills_system_prompt
+
+    def __init__(self):
+        self.rebuilt = 0
+
+    def rebuild_system_prompt(self):
+        self.rebuilt += 1
+
+
+def test_agent_load_skill_registers_namespaced_tools_and_injects_body(roots):
+    copy_fixture("web-search", roots["user"])
+    agent = _StubAgent()
+
+    skill = agent.load_skill("web-search", manager=make_manager(roots))
+
+    assert skill.name == "web-search"
+    assert "web-search/search_web" in _TOOL_REGISTRY
+    assert agent.loaded_skills["web-search"] is skill
+    assert agent.rebuilt == 1
+
+    prompt = agent.get_skills_system_prompt()
+    assert "==== LOADED SKILLS ====" in prompt
+    assert "--- SKILL: web-search ---" in prompt
+    assert "A self-contained Brave Search wrapper" in prompt
+
+
+def test_agent_load_skill_bridges_permissions_to_connector_requirements(roots):
+    copy_fixture("web-search", roots["user"])
+    agent = _StubAgent()
+    agent.load_skill("web-search", manager=make_manager(roots))
+
+    ids = [r.connector_id for r in agent.REQUIRED_CONNECTORS]
+    assert ids == ["network"]
+    # The ClassVar must not be mutated — that would leak into sibling agents.
+    assert _StubAgent.REQUIRED_CONNECTORS == []
+
+
+def test_agent_load_skill_refuses_local_capability_permissions(roots):
+    copy_fixture("local-capability", roots["user"])
+    agent = _StubAgent()
+
+    with pytest.raises(SkillPermissionError, match="deferred to a later phase"):
+        agent.load_skill("local-capability", manager=make_manager(roots))
+
+    assert agent.loaded_skills == {}
+    assert agent.get_skills_system_prompt() == ""
+    assert agent.rebuilt == 0
+
+
+def test_agent_load_skill_logs_unavailable_tools_required(roots, caplog):
+    """A recipe skill whose registry tools are inactive here loads, but says so —
+    scoping, not a defect (the tool universe is assembled dynamically)."""
+    import logging
+
+    copy_fixture("triage-support-ticket", roots["user"])
+    agent = _StubAgent()
+    agent._instance_tools = {}
+
+    with caplog.at_level(logging.INFO, logger="gaia.agents.base.agent"):
+        agent.load_skill("triage-support-ticket", manager=make_manager(roots))
+
+    assert "triage-support-ticket" in agent.loaded_skills
+    assert "query_documents" in caplog.text
+
+
+def test_agent_load_skill_instruction_only(roots):
+    copy_fixture("bare-standard", roots["user"])
+    agent = _StubAgent()
+    skill = agent.load_skill("bare-standard", manager=make_manager(roots))
+    assert skill.is_instruction_only
+    assert "Establish the timeline" in agent.get_skills_system_prompt()
+
+
+def test_agent_load_skill_is_idempotent(roots):
+    copy_fixture("bare-standard", roots["user"])
+    agent = _StubAgent()
+    manager = make_manager(roots)
+    first = agent.load_skill("bare-standard", manager=manager)
+    second = agent.load_skill("bare-standard", manager=manager)
+    assert first is second
+    assert agent.rebuilt == 1
+
+
+def test_agent_load_skill_leaves_nothing_behind_on_tool_mismatch(roots):
+    copy_fixture("tool-mismatch", roots["user"])
+    agent = _StubAgent()
+    before = dict(_TOOL_REGISTRY)
+
+    with pytest.raises(SkillValidationError):
+        agent.load_skill("tool-mismatch", manager=make_manager(roots))
+
+    assert agent.loaded_skills == {}
+    assert _TOOL_REGISTRY == before
+
+
+def test_agent_unload_skill_removes_tools_and_body(roots):
+    copy_fixture("web-search", roots["user"])
+    agent = _StubAgent()
+    agent.load_skill("web-search", manager=make_manager(roots))
+
+    assert agent.unload_skill("web-search") is True
+    assert "web-search/search_web" not in _TOOL_REGISTRY
+    assert agent.get_skills_system_prompt() == ""
+    assert agent.unload_skill("web-search") is False
+
+
+def test_agent_load_skill_updates_an_instance_tool_snapshot(roots):
+    copy_fixture("web-search", roots["user"])
+    agent = _StubAgent()
+    agent._instance_tools = {}
+    agent.load_skill("web-search", manager=make_manager(roots))
+    assert "web-search/search_web" in agent._instance_tools
+
+
+def test_agent_skill_manager_uses_bundled_dirs(tmp_path):
+    class Bundled(_StubAgent):
+        SKILL_DIRS = [str(tmp_path / "bundled")]
+
+    manager = Bundled().skill_manager
+    assert manager.roots[0].label == ROOT_AGENT_BUNDLED
+    assert manager.roots[0].path == tmp_path / "bundled"
+
+
+def test_agent_without_skills_adds_nothing_to_the_prompt():
+    """Existing agents' prompts stay byte-identical until a skill is loaded."""
+    assert _StubAgent().get_skills_system_prompt() == ""
+
+
+# ----------------------------------------------------------------------
+# Hot reload
+# ----------------------------------------------------------------------
+
+
+def test_hot_reload_invalidates_the_cache_on_change(roots):
+    manager = make_manager(roots)
+    assert manager.list_skills() == []
+
+    watched = manager.start_watching()
+    try:
+        assert watched == 3
+        assert manager.is_watching
+        copy_fixture("bare-standard", roots["user"])
+        _wait_for(lambda: [s.name for s in manager.list_skills()] == ["bare-standard"])
+    finally:
+        manager.stop_watching()
+    assert not manager.is_watching
+
+
+def _wait_for(predicate, timeout: float = 10.0) -> None:
+    import time
+
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        if predicate():
+            return
+        time.sleep(0.1)
+    raise AssertionError("Condition not met before the timeout")

--- a/tests/unit/test_skills_manager.py
+++ b/tests/unit/test_skills_manager.py
@@ -537,6 +537,7 @@ class _StubAgent:
     skill_manager = Agent.skill_manager
     loaded_skills = Agent.loaded_skills
     _tools_registry = Agent._tools_registry
+    _format_tools_for_prompt = Agent._format_tools_for_prompt
     load_skill = Agent.load_skill
     unload_skill = Agent.unload_skill
     get_skills_system_prompt = Agent.get_skills_system_prompt
@@ -635,14 +636,43 @@ def test_agent_load_skill_leaves_nothing_behind_on_tool_mismatch(roots):
 
 
 def test_agent_unload_skill_removes_tools_and_body(roots):
+    """Unloading must leave no orphaned tool schema on any surface the model
+    sees — the global registry, the agent's snapshot, or the rendered prompt."""
     copy_fixture("web-search", roots["user"])
     agent = _StubAgent()
+    agent._instance_tools = {}
     agent.load_skill("web-search", manager=make_manager(roots))
 
+    # Precondition: the tool really is visible everywhere before the unload.
+    assert "web-search/search_web" in _TOOL_REGISTRY
+    assert "web-search/search_web" in agent._instance_tools
+    assert "web-search/search_web" in agent._format_tools_for_prompt()
+
     assert agent.unload_skill("web-search") is True
+
     assert "web-search/search_web" not in _TOOL_REGISTRY
+    assert "web-search/search_web" not in agent._instance_tools
+    # The rendered tool block is what reaches the model — nothing may linger.
+    assert "web-search" not in agent._format_tools_for_prompt()
     assert agent.get_skills_system_prompt() == ""
+    assert agent.loaded_skills == {}
     assert agent.unload_skill("web-search") is False
+
+
+def test_agent_can_reload_a_skill_after_unloading_it(roots):
+    """Unload must not poison the module cache — a re-load re-registers cleanly."""
+    copy_fixture("web-search", roots["user"])
+    agent = _StubAgent()
+    manager = make_manager(roots)
+
+    agent.load_skill("web-search", manager=manager)
+    agent.unload_skill("web-search")
+    agent.load_skill("web-search", manager=manager)
+
+    assert "web-search/search_web" in _TOOL_REGISTRY
+    assert (
+        _TOOL_REGISTRY["web-search/search_web"]["function"](query="x")["query"] == "x"
+    )
 
 
 def test_agent_load_skill_updates_an_instance_tool_snapshot(roots):
@@ -653,13 +683,18 @@ def test_agent_load_skill_updates_an_instance_tool_snapshot(roots):
     assert "web-search/search_web" in agent._instance_tools
 
 
-def test_agent_skill_manager_uses_bundled_dirs(tmp_path):
+def test_agent_skill_manager_uses_bundled_dirs(tmp_path, monkeypatch):
+    # Point the default user root at tmp_path: the lazily-built manager would
+    # otherwise resolve the developer's real ~/.gaia/skills.
+    monkeypatch.setenv("GAIA_CONFIG_DIR", str(tmp_path / "gaia-home"))
+
     class Bundled(_StubAgent):
         SKILL_DIRS = [str(tmp_path / "bundled")]
 
     manager = Bundled().skill_manager
     assert manager.roots[0].label == ROOT_AGENT_BUNDLED
     assert manager.roots[0].path == tmp_path / "bundled"
+    assert manager.user_root == tmp_path / "gaia-home" / "skills"
 
 
 def test_agent_without_skills_adds_nothing_to_the_prompt():

--- a/tests/unit/test_skills_manager.py
+++ b/tests/unit/test_skills_manager.py
@@ -346,7 +346,11 @@ def test_tools_register_under_the_skill_namespace(roots):
 def test_a_skill_tool_may_shadow_an_existing_registry_name(roots):
     """The ``<skill>/<tool>`` namespace exists so a skill can provide a tool the
     framework already has — loading must not clobber or drop either one."""
-    original = {"name": "search_web", "description": "the framework's", "parameters": {}}
+    original = {
+        "name": "search_web",
+        "description": "the framework's",
+        "parameters": {},
+    }
     _TOOL_REGISTRY["search_web"] = original
 
     copy_fixture("web-search", roots["user"])

--- a/tests/unit/test_skills_manager.py
+++ b/tests/unit/test_skills_manager.py
@@ -372,6 +372,15 @@ def test_unregister_removes_only_that_skills_tools(roots):
     assert "web-search/search_web" not in _TOOL_REGISTRY
 
 
+def test_the_refusal_cannot_be_bypassed_via_the_low_level_api(roots):
+    """``register_skill_tools`` is where a skill gains executable reach, so the
+    local-capability refusal holds there too — not only in ``Agent.load_skill``."""
+    copy_fixture("local-capability", roots["user"])
+    skill = make_manager(roots).load("local-capability")
+    with pytest.raises(SkillPermissionError, match="deferred to a later phase"):
+        register_skill_tools(skill)
+
+
 def test_instruction_only_skill_registers_no_tools(roots):
     copy_fixture("bare-standard", roots["user"])
     skill = make_manager(roots).load("bare-standard")


### PR DESCRIPTION
Nothing in GAIA could read a `SKILL.md` before this. An agent gained capability only by shipping new Python, so a user who wanted a new one had no path short of forking the agent — and the large library of skills already published for Claude Code and friends was unreachable. Now a folder with a `SKILL.md` drops into `~/.gaia/skills/` and any agent loads it at runtime with `agent.load_skill("name")`, and an existing `.claude/skills/` library is discovered read-only with zero migration (this repo's own 11 skills load unchanged). This is Phase 1 of #1019 — the layer #2466, #2467, #2468, #893, and #692 are all blocked on.

Scoped deliberately so no sandbox is needed to ship it: a skill may add instructions and reach connector-backed services, and one declaring a local-capability permission (`filesystem`/`shell`/`database`/`desktop`/`env`) is **refused with an actionable error** rather than loaded without enforcement. `network:*` and `mcp:connect` resolve to the existing `ConnectorRequirement` — no second grant ledger.

### Decisions taken where the specs were silent

- `mcp:connect` must be scoped to a catalog connector id (`mcp:connect:mcp-tavily`); a bare one fails loudly listing the available ids. A `network:*` permission that names no catalog connector resolves against a reserved `network` pseudo-id — a **declaration** surface only, since Phase 1 does not enforce egress.
- `<domain>:none` is inert in both directions: it grants nothing, so it neither refuses nor produces a requirement.
- `tools_required` names that aren't in the current agent's registry are logged, not fatal — the tool universe is assembled dynamically from mixins, so absence is scoping, not a manifest defect (the open question in `skill-format.mdx`).
- Discovery trims the spec's five roots to three; project-local `./.gaia/skills/` and the registry-lock root are marked deferred in the spec, not deleted.
- `src/gaia/schedule/runner.py` and the `gaia schedule add --skill` gate told users their problem was "blocked on #888" — a claim this PR makes false on merge. Reworded to point at #1019, where wiring the scheduler to the skills runtime actually lives; that is why those files (and their two tests) are in the diff.
- Three of `skill-format.mdx`'s own example skills (`rag-search`, `file-operations`, migrated `git-status`) declare local-capability permissions and are therefore refused today. The doc now marks which examples load rather than quietly rewriting their permissions.

### Test plan

- [ ] `python -m pytest tests/unit/test_skills_format.py tests/unit/test_skills_manager.py tests/unit/test_skills_cli.py -q` — 150 tests, one per acceptance-criterion bullet
- [ ] Round-trip identity: `parse → write → parse` on every fixture, and byte-stability on a second write
- [ ] A bare agentskills.io skill (only `name` + `description`) loads instruction-only at `security_tier: experimental`; writing it back does **not** stamp a `metadata.gaia` block into it
- [ ] `load_skill` registers tools as `<skill>/<tool>` and injects the body — including when the skill's unqualified tool name collides with one the framework already registered
- [ ] A manifest that contradicts `tools.py` (missing tool, undeclared extra, parameter/requiredness/type mismatch, raising module) leaves `_TOOL_REGISTRY` byte-identical — assert on the whole dict, not just the absent key
- [ ] A `filesystem:write` skill is refused via `Agent.load_skill` **and** via the lower-level `register_skill_tools`
- [ ] Precedence: the same skill in all three roots resolves to the agent-bundled copy; the shadowed copies stay visible via `SkillManager.shadowed()` and in `gaia skill list`
- [ ] Real CLI, cold `GAIA_CONFIG_DIR`: `gaia skill create` → `list` → `info` → `export` → `import` into a second home, plus `--json` stdout parsing cleanly with logs on stderr
- [ ] `python -m pytest tests/unit/ -q` — the 16 failures on this machine reproduce identically on an untouched `main` checkout (macOS `/private/var` sandbox paths, network-dependent hub installer, missing faiss, venv-not-on-PATH)
- [ ] `python util/lint.py --all` clean

Closes #888
