### PR TITLE
refactor(memory): rename synthesis Skill dataclass to DistilledProcedure

### DIFF
--- a/docs/plans/skill-synthesis.mdx
+++ b/docs/plans/skill-synthesis.mdx
@@ -103,9 +103,9 @@ new model, no new store engine.
      of ≥ MIN_OCCURRENCES
                                  │
                                  ▼
-  3. DISTILL  distill_cluster(cluster, llm) → Skill | None     PROPOSED
+  3. DISTILL  distill_cluster(cluster, llm) → DistilledProcedure|None PROPOSED
      one low-temp LLM call per cluster (DISTILL_SYSTEM_PROMPT);
-     Skill.parse() validates; literal "SKIP" → None
+     DistilledProcedure.parse() validates; literal "SKIP" → None
                                  │
                                  ▼
   4. STORE    reconcile_and_store(candidate, store)            PROPOSED
@@ -242,11 +242,11 @@ The pipeline *emits* a `SKILL.md`; it does **not** define the format. The format
 **references** that schema and never redefines a field.
 
 The subtlety — and the single most important correctness point — is the split
-between **what the LLM emits** and **what `Skill.parse()` injects**. The guiding
+between **what the LLM emits** and **what `DistilledProcedure.parse()` injects**. The guiding
 rule: **the LLM emits only the fields it *derives* from the learned procedure;
 fixed constants are injected, never emitted.** So `DISTILL_SYSTEM_PROMPT` asks the
 model for an **intermediate** frontmatter of four learned fields, and a
-deterministic `Skill.parse()` maps them to the canonical #691 document and adds the
+deterministic `DistilledProcedure.parse()` maps them to the canonical #691 document and adds the
 two constants:
 
 | Field | Origin | → Canonical `SKILL.md` (#691) | Why |
@@ -254,8 +254,8 @@ two constants:
 | `name` | **LLM (derived)** | `name` | Identity, derived from the cluster. Matches the rule at [`skill-format.mdx:150`](https://github.com/amd/gaia/blob/main/docs/plans/skill-format.mdx). |
 | `when_to_use` | **LLM (derived)** | `description` | **`when_to_use` is the LLM-emitted field on purpose** — it forces the model to *conclude the trigger boundaries* of the skill; `description` is too vague a label to constrain it. Its embedding is what `recall_skill(goal)` matches against. Maps to the required `description` ([`skill-format.mdx:151`](https://github.com/amd/gaia/blob/main/docs/plans/skill-format.mdx)). |
 | `tools_required` (top-level) | **LLM (derived)** | `metadata.gaia.tools_required` | The tool set the procedure actually used. #691 **locks** `tools_required` as the cross-spec recipe contract and nests it under `metadata.gaia` ([`skill-format.mdx:143`](https://github.com/amd/gaia/blob/main/docs/plans/skill-format.mdx), `:158`). |
-| `markdown_body` | **LLM (derived)** | body | The LLM writes the **full procedure — numbered steps *and* a `## Edge cases` section — inline**. `Skill.parse()` does not synthesize a separate edge-case section; the distilled body already carries it. |
-| `license: MIT`, `version: 1.0.0` | **`Skill.parse()` (fixed)** | `license`, `version` | **Fixed constants, not learned content — the LLM does *not* emit them.** `license` is always the repository license ([`skill-format.mdx:152`](https://github.com/amd/gaia/blob/main/docs/plans/skill-format.mdx)); a freshly synthesised skill is always `version: 1.0.0` (SemVer — [`skill-format.mdx:153`](https://github.com/amd/gaia/blob/main/docs/plans/skill-format.mdx)). Injecting them keeps the prompt's output surface purely dynamic and removes any chance the model emits a wrong version. |
+| `markdown_body` | **LLM (derived)** | body | The LLM writes the **full procedure — numbered steps *and* a `## Edge cases` section — inline**. `DistilledProcedure.parse()` does not synthesize a separate edge-case section; the distilled body already carries it. |
+| `license: MIT`, `version: 1.0.0` | **`DistilledProcedure.parse()` (fixed)** | `license`, `version` | **Fixed constants, not learned content — the LLM does *not* emit them.** `license` is always the repository license ([`skill-format.mdx:152`](https://github.com/amd/gaia/blob/main/docs/plans/skill-format.mdx)); a freshly synthesised skill is always `version: 1.0.0` (SemVer — [`skill-format.mdx:153`](https://github.com/amd/gaia/blob/main/docs/plans/skill-format.mdx)). Injecting them keeps the prompt's output surface purely dynamic and removes any chance the model emits a wrong version. |
 
 A synthesised recipe therefore emits a **bounded field set** — `name`,
 `description`, `license`, `version`, `metadata.gaia.tools_required`, and the body.
@@ -269,10 +269,10 @@ most-restrictive `experimental` at load time.
 This is the **one deliberate refinement** of the maintainer's pseudocode: his
 `DISTILL_SYSTEM_PROMPT` listed `version: 1.0.0` *inside* the LLM's required output
 ([#887 technical-spec comment](https://github.com/amd/gaia/issues/887#issuecomment-4321407541));
-this spec moves `version` (and `license`) to `Skill.parse()` injection because both
+this spec moves `version` (and `license`) to `DistilledProcedure.parse()` injection because both
 are fixed, not derived. The pipeline otherwise keeps the maintainer's prompt as
 written, and **(a)** treats the four learned fields as the intermediate shape,
-**(b)** specifies `Skill.parse()` as the translator to the locked schema, and
+**(b)** specifies `DistilledProcedure.parse()` as the translator to the locked schema, and
 **(c)** guarantees the emitted file validates under #691 — an explicit acceptance
 criterion (see [Acceptance criteria traceability](#acceptance-criteria-traceability)).
 
@@ -448,7 +448,7 @@ current code; these are the corrections an implementer must internalize.
 
 | Original framing | Reality on `main` | Consequence |
 |---|---|---|
-| `DISTILL_SYSTEM_PROMPT` emits `when_to_use` + top-level `tools_required` as the on-disk shape | #691 locks `description` + `metadata.gaia.tools_required` ([`skill-format.mdx:151`](https://github.com/amd/gaia/blob/main/docs/plans/skill-format.mdx), `:158`) | The prompt fields are the **intermediate** shape; `Skill.parse()` maps them. See [The format contract](#the-format-contract). |
+| `DISTILL_SYSTEM_PROMPT` emits `when_to_use` + top-level `tools_required` as the on-disk shape | #691 locks `description` + `metadata.gaia.tools_required` ([`skill-format.mdx:151`](https://github.com/amd/gaia/blob/main/docs/plans/skill-format.mdx), `:158`) | The prompt fields are the **intermediate** shape; `DistilledProcedure.parse()` maps them. See [The format contract](#the-format-contract). |
 | Scope C: *"New **tool**: `recall_skill`"* | The memory registry is exactly five tools ([`memory.py:1984`](https://github.com/amd/gaia/blob/main/src/gaia/agents/base/memory.py)+) and the planner calls recall programmatically | `recall_skill` is an **internal method**, not a sixth `@tool`. See [Decided design](#decided-design). |
 | Hook is `on_consolidation_pass` → `_consolidate_old_sessions / _reconcile_contradictions / _prune_stale` | Those names don't exist; the real pass is `_run_memory_post_init` → `reconcile_memory` + `consolidate_old_sessions` ([`memory.py:1206`](https://github.com/amd/gaia/blob/main/src/gaia/agents/base/memory.py)) | Bind `_synthesize_skills` to the **real** maintenance method. |
 | Tunables in `~/.gaia/config.toml [memory.skill_synthesis]` | Memory is configured via `~/.gaia/memory_settings.json` ([`memory.py:57`](https://github.com/amd/gaia/blob/main/src/gaia/agents/base/memory.py)) + `GAIA_MEMORY_DISABLED`; there is **no** `config.toml` `[memory]` section | Surface the thresholds on the **existing** memory-settings surface, not a new TOML section — see [Open questions](#open-questions). |
@@ -460,7 +460,7 @@ current code; these are the corrections an implementer must internalize.
 - **The intermediate frontmatter is not the on-disk schema.** A reader of the
   maintainer's `DISTILL_SYSTEM_PROMPT` must not write `when_to_use` /
   top-level `tools_required` to disk. The on-disk file is the #691 schema
-  (`description`, `metadata.gaia.tools_required`); `Skill.parse()` is the only
+  (`description`, `metadata.gaia.tools_required`); `DistilledProcedure.parse()` is the only
   bridge.
 - **`recall_skill` is not an LLM tool.** Do not register a sixth memory `@tool`;
   it would change the five-tool registry the rest of the system assumes.
@@ -510,7 +510,7 @@ mirroring the v1→v2 `ADD COLUMN` pattern
 ### Phase 1 — Detect → cluster → distill → reconcile/store (PROPOSED)
 
 `skill_synthesis.py` with `extract_sequences` / `cluster_by_goal` /
-`distill_cluster` / `Skill.parse` / `reconcile_and_store`, hooked into the
+`distill_cluster` / `DistilledProcedure.parse` / `reconcile_and_store`, hooked into the
 maintenance pass as `_synthesize_skills` after `consolidate_old_sessions`
 ([`memory.py:1233`](https://github.com/amd/gaia/blob/main/src/gaia/agents/base/memory.py)).
 Reuses the nomic-768 embedder ([`memory.py:148`](https://github.com/amd/gaia/blob/main/src/gaia/agents/base/memory.py)).
@@ -569,9 +569,9 @@ The recipe reuses `triage-support-ticket`
 so its `tools_required` resolve to real registry tools.
 
 <AccordionGroup>
-<Accordion title="A. The synthesised SKILL.md (Skill.parse output — the on-disk #691 document)">
+<Accordion title="A. The synthesised SKILL.md (DistilledProcedure.parse output — the on-disk #691 document)">
 
-What `Skill.parse()` writes after distillation — a valid #691 document. `name`,
+What `DistilledProcedure.parse()` writes after distillation — a valid #691 document. `name`,
 `description`, `license`, `version`, and `metadata.gaia.tools_required` are all the
 locked schema. Each `tools_required` name is a real registry tool (`query_documents`
 from `RAGToolsMixin`, `read_file` from `FileIOToolsMixin`, `remember` from the
@@ -606,12 +606,12 @@ metadata:
 ```
 
 </Accordion>
-<Accordion title="B. The intermediate DISTILL_SYSTEM_PROMPT output (before Skill.parse)">
+<Accordion title="B. The intermediate DISTILL_SYSTEM_PROMPT output (before DistilledProcedure.parse)">
 
 What the LLM emits — **only the four learned fields**: top-level `name`,
 `when_to_use`, `tools_required`, and a body that already contains the
 `## Edge cases` section. No `version`, no `license` — those are fixed constants.
-`Skill.parse()` maps `when_to_use → description`, `tools_required →
+`DistilledProcedure.parse()` maps `when_to_use → description`, `tools_required →
 metadata.gaia.tools_required`, and **injects the fixed `license: MIT` and
 `version: 1.0.0`** to produce example A.
 
@@ -672,7 +672,7 @@ tool-loader's `CORE ∪ SKILL ∪ SEMANTIC` union ahead of semantic results.
 # PROPOSED — at turn start, before tool selection (internal method, not an @tool)
 matches = self.recall_skill(user_goal, top_k=2)
 # matches → [
-#   Skill(
+#   DistilledProcedure(
 #     name="triage-support-ticket",
 #     when_to_use="Triage an inbound support ticket end to end. ...",
 #     body="# Triage a Support Ticket\n1. ...\n## Edge cases\n- ...",
@@ -746,7 +746,7 @@ The memory layer it builds on is real and merged; the synthesis pipeline is
 | Prompt composition | `_compose_system_prompt`, `_select_tools_for_turn` | `agent.py:591`, `:786` | **Exists** — injection seam |
 | Memory REST + dashboard | `/api/memory/*`, `X-Gaia-UI` guard, three-tab dashboard | `ui/routers/memory.py:26`, `:29`; `MemoryDashboard.tsx:267` | **Exists** — exposes procedural data |
 | `category='skill'` (a fact, not a procedure) | `VALID_CATEGORIES` includes `"skill"` | `memory_store.py:97` | **Exists** — *different concept* |
-| **`skill_synthesis.py` / `procedures` table / `extract_sequences` / `cluster_by_goal` / `distill_cluster` / `Skill.parse` / `SkillProvenance` / `reconcile_and_store` / `recall_skill` / `_synthesize_skills` / `put_skill` / `search_skills` / `supersede_skill` / `iter_sessions`** | — | **NOT FOUND** (verified absent on `main`) | **Greenfield — PROPOSED** |
+| **`skill_synthesis.py` / `procedures` table / `extract_sequences` / `cluster_by_goal` / `distill_cluster` / `DistilledProcedure.parse` / `SkillProvenance` / `reconcile_and_store` / `recall_skill` / `_synthesize_skills` / `put_skill` / `search_skills` / `supersede_skill` / `iter_sessions`** | — | **NOT FOUND** (verified absent on `main`) | **Greenfield — PROPOSED** |
 
 ---
 
@@ -779,7 +779,7 @@ guarantees a consumer. Deferrals are explicit, with the track that owns them.
 | **Scope E** — Dashboard "Procedures" tab + provenance + promote | [Phase 2 deferral](#phased-build) | **Tab build DEFERRED to #606's dashboard track**; #887 stores provenance + exposes the data. |
 | **AC** — after 3 successful similar sequences, auto-create a `SKILL.md` discoverable via `recall_skill()` | [KPIs](#kpis), [Phase 1](#phased-build) + [Phase 2](#phased-build) | The headline KPI. |
 | **AC** — recall measurably reduces tool-step count on the 4th attempt | [KPIs](#kpis), [Phase 2](#phased-build) | Measured vs the tool-loader baseline. |
-| **AC** — synthesised skills are valid agentskills.io documents (Hermes parser) | [The format contract](#the-format-contract), [Examples A–B](#examples) | `Skill.parse()` round-trip; 100% validity KPI. |
+| **AC** — synthesised skills are valid agentskills.io documents (Hermes parser) | [The format contract](#the-format-contract), [Examples A–B](#examples) | `DistilledProcedure.parse()` round-trip; 100% validity KPI. |
 | **AC** — Dashboard shows count / last-used / provenance | [Phase 2 deferral](#phased-build) | **Data exposed by #887**; *rendering* is #606's tab. |
 | **AC** — disabling a skill prevents recall | [Off-states](#off-states-as-safe-floors), [Phase 2](#phased-build) | The recall path honours `enabled = 0` (this **is** #887); the toggle UI is #606's tab. |
 | **Out of scope** — marketplace / tiers / OpenClaw shim | [Dependencies](#dependencies) | → #647 / #692. |

--- a/docs/plans/tool-loader.mdx
+++ b/docs/plans/tool-loader.mdx
@@ -431,7 +431,7 @@ stored procedure declares the exact `tools_required` for that recipe.
 
 #### How Part 3 shipped (implementation reference)
 
-**The loader stays memory-agnostic.** `recall_skill` and `Skill` are *not*
+**The loader stays memory-agnostic.** `recall_skill` and `DistilledProcedure` are *not*
 imported into `tool_loader.py` (that would be an upward dependency). Instead
 `ChatAgent` — the composition layer — flattens the recalled procedures'
 `tools_required` into a `List[str]` and passes it to `select()` via a new
@@ -442,7 +442,7 @@ never learns what a skill is.
 cost).** `recall_skill` already runs once per turn in
 `MemoryMixin._refresh_recalled_skills` (before tool selection, via the
 `process_query` → `super()` ordering). Part 3 refactors that method to cache the
-matched `Skill` objects in `self._recalled_skills` alongside the rendered
+matched `DistilledProcedure` objects in `self._recalled_skills` alongside the rendered
 prompt; `_recalled_skill_tools()` reads that cache. So the SKILL signal adds
 **no** second embed/FAISS call — TTFT is the whole point of the loader.
 

--- a/src/gaia/agents/base/memory.py
+++ b/src/gaia/agents/base/memory.py
@@ -483,9 +483,10 @@ class MemoryMixin(ProceduralMemoryMixin):
         # the composed system prompt.  Empty string = no recall = the system
         # prompt stays byte-identical to a build without procedural memory.
         self._recalled_skill_prompt = ""
-        # The matched Skill objects from the same per-turn recall (#1451): the
-        # tool loader reads their tools_required via _recalled_skill_tools as the
-        # SKILL signal.  Empty list = no recall = no SKILL signal this turn.
+        # The matched DistilledProcedure objects from the same per-turn recall
+        # (#1451): the tool loader reads their tools_required via
+        # _recalled_skill_tools as the SKILL signal.  Empty list = no recall =
+        # no SKILL signal this turn.
         self._recalled_skills = []
 
         # Step 2: Validate Lemonade embedding service connectivity.

--- a/src/gaia/agents/base/procedural_memory.py
+++ b/src/gaia/agents/base/procedural_memory.py
@@ -20,7 +20,7 @@ from typing import Dict, List, Optional, Tuple
 import numpy as np
 
 from gaia.agents.base.skill_synthesis import (
-    Skill,
+    DistilledProcedure,
     SynthesisConfig,
     cluster_by_goal,
     distill_cluster,
@@ -180,7 +180,7 @@ class ProceduralMemoryMixin:
 
     def recall_skill(
         self, goal: str, top_k: int = 2, similarity_tau: Optional[float] = None
-    ) -> List[Skill]:
+    ) -> List[DistilledProcedure]:
         """Recall stored procedures whose trigger matches ``goal`` (vector search).
 
         The RECALL half of the procedural loop and the consumer the tool-loader
@@ -215,7 +215,7 @@ class ProceduralMemoryMixin:
                 so a recalling turn reads the settings file only once.
 
         Returns:
-            Matched ``Skill`` objects (full bodies; injection truncates, the row
+            Matched ``DistilledProcedure`` objects (full bodies; injection truncates, the row
             keeps the full body), best match first; ``[]`` on any off-state.
         """
         from gaia.agents.base.memory import (
@@ -250,7 +250,7 @@ class ProceduralMemoryMixin:
             if similarity_tau is not None
             else load_synthesis_config(_load_memory_settings()).similarity_tau
         )
-        skills: List[Skill] = []
+        skills: List[DistilledProcedure] = []
         recalled_ids: List[str] = []
         for procedure_id, score in matches:
             if score < tau:
@@ -267,7 +267,7 @@ class ProceduralMemoryMixin:
                 continue
             row = rows[0]
             skills.append(
-                Skill(
+                DistilledProcedure(
                     name=row["name"],
                     when_to_use=row["when_to_use"],
                     body=row["markdown_body"],
@@ -291,7 +291,7 @@ class ProceduralMemoryMixin:
 
     def _recall_skills_for_turn(
         self, goal: str
-    ) -> Tuple[List[Skill], Optional[SynthesisConfig]]:
+    ) -> Tuple[List[DistilledProcedure], Optional[SynthesisConfig]]:
         """Recall the procedures matching ``goal`` once, with the resolved config.
 
         The single per-turn recall pass shared by both consumers:
@@ -332,7 +332,7 @@ class ProceduralMemoryMixin:
         return skills, config
 
     def _build_recalled_skills_prompt(
-        self, skills: List[Skill], config: Optional[SynthesisConfig]
+        self, skills: List[DistilledProcedure], config: Optional[SynthesisConfig]
     ) -> str:
         """Render the recalled-procedure system-prompt section from ``skills``.
 
@@ -400,7 +400,7 @@ class ProceduralMemoryMixin:
         """Recompute the per-turn recalled-skill state for ``goal``.
 
         Recalls the matching procedures **once** and caches both consumers'
-        inputs: ``self._recalled_skills`` (the matched ``Skill`` objects, read by
+        inputs: ``self._recalled_skills`` (the matched ``DistilledProcedure`` objects, read by
         the tool loader through ``_recalled_skill_tools`` — #1451) and the
         rendered ``self._recalled_skill_prompt`` (the system-prompt block, read by
         ``get_recalled_skills_system_prompt`` — #887).  The single recall keeps

--- a/src/gaia/agents/base/procedural_memory.py
+++ b/src/gaia/agents/base/procedural_memory.py
@@ -215,8 +215,9 @@ class ProceduralMemoryMixin:
                 so a recalling turn reads the settings file only once.
 
         Returns:
-            Matched ``DistilledProcedure`` objects (full bodies; injection truncates, the row
-            keeps the full body), best match first; ``[]`` on any off-state.
+            Matched ``DistilledProcedure`` objects (full bodies; injection
+            truncates, the row keeps the full body), best match first; ``[]``
+            on any off-state.
         """
         from gaia.agents.base.memory import (
             _load_memory_settings,  # deferred (cycle break)
@@ -400,8 +401,9 @@ class ProceduralMemoryMixin:
         """Recompute the per-turn recalled-skill state for ``goal``.
 
         Recalls the matching procedures **once** and caches both consumers'
-        inputs: ``self._recalled_skills`` (the matched ``DistilledProcedure`` objects, read by
-        the tool loader through ``_recalled_skill_tools`` — #1451) and the
+        inputs: ``self._recalled_skills`` (the matched ``DistilledProcedure``
+        objects, read by the tool loader through ``_recalled_skill_tools`` —
+        #1451) and the
         rendered ``self._recalled_skill_prompt`` (the system-prompt block, read by
         ``get_recalled_skills_system_prompt`` — #887).  The single recall keeps
         the loader's SKILL signal free (no second ``recall_skill``).

--- a/src/gaia/agents/base/skill_synthesis.py
+++ b/src/gaia/agents/base/skill_synthesis.py
@@ -16,8 +16,9 @@ seams and is the only stateful caller.
 
 Two corpora, one format: the on-disk #691 ``SKILL.md`` schema is *referenced*
 here, never redefined.  The LLM emits only the four *derived* fields
-(``name``, ``when_to_use``, ``tools_required``, body); ``DistilledProcedure.parse`` validates
-that intermediate shape and ``DistilledProcedure.to_skill_md`` injects the two *fixed*
+(``name``, ``when_to_use``, ``tools_required``, body);
+``DistilledProcedure.parse`` validates that intermediate shape and
+``DistilledProcedure.to_skill_md`` injects the two *fixed*
 constants (``license: MIT``, ``version: 1.0.0``) and maps to the canonical
 document.  See ``docs/plans/skill-synthesis.mdx`` "The format contract".
 
@@ -192,7 +193,8 @@ class DistilledProcedure:
                 tags / code fences by ``distill_cluster``).
 
         Returns:
-            A validated ``DistilledProcedure``, or ``None`` for ``SKIP`` / malformed input.
+            A validated ``DistilledProcedure``, or ``None`` for ``SKIP`` /
+            malformed input.
         """
         if intermediate_md is None:
             return None
@@ -537,7 +539,7 @@ def cluster_by_goal(
 def distill_cluster(
     cluster: GoalCluster, send_messages_fn: Callable
 ) -> Optional[DistilledProcedure]:
-    """DISTILL — one low-temperature LLM call turning a cluster into a ``DistilledProcedure``.
+    """DISTILL — one low-temp call turning a cluster into a procedure.
 
     Reuses the same ``self.chat.send_messages`` seam the extraction /
     consolidation passes use (no new client).  The response is stripped of think

--- a/src/gaia/agents/base/skill_synthesis.py
+++ b/src/gaia/agents/base/skill_synthesis.py
@@ -16,8 +16,8 @@ seams and is the only stateful caller.
 
 Two corpora, one format: the on-disk #691 ``SKILL.md`` schema is *referenced*
 here, never redefined.  The LLM emits only the four *derived* fields
-(``name``, ``when_to_use``, ``tools_required``, body); ``Skill.parse`` validates
-that intermediate shape and ``Skill.to_skill_md`` injects the two *fixed*
+(``name``, ``when_to_use``, ``tools_required``, body); ``DistilledProcedure.parse`` validates
+that intermediate shape and ``DistilledProcedure.to_skill_md`` injects the two *fixed*
 constants (``license: MIT``, ``version: 1.0.0``) and maps to the canonical
 document.  See ``docs/plans/skill-synthesis.mdx`` "The format contract".
 
@@ -151,12 +151,12 @@ def load_synthesis_config(settings: Optional[Dict] = None) -> SynthesisConfig:
 
 
 # ============================================================================
-# Skill — the intermediate (pre-#691) shape + the canonical mapping
+# DistilledProcedure — the intermediate (pre-#691) shape + the canonical mapping
 # ============================================================================
 
 
 @dataclass(frozen=True)
-class Skill:
+class DistilledProcedure:
     """A distilled procedure in the *intermediate* four-field shape.
 
     These are the only fields the LLM derives.  The fixed constants
@@ -178,8 +178,8 @@ class Skill:
     tools_required: List[str] = field(default_factory=list)
 
     @classmethod
-    def parse(cls, intermediate_md: str) -> Optional["Skill"]:
-        """Validate the distiller's intermediate Markdown into a ``Skill``.
+    def parse(cls, intermediate_md: str) -> Optional["DistilledProcedure"]:
+        """Validate the distiller's intermediate Markdown into a ``DistilledProcedure``.
 
         The expected shape is YAML frontmatter (``name``, ``when_to_use``,
         ``tools_required``) delimited by ``---`` lines, followed by the Markdown
@@ -192,7 +192,7 @@ class Skill:
                 tags / code fences by ``distill_cluster``).
 
         Returns:
-            A validated ``Skill``, or ``None`` for ``SKIP`` / malformed input.
+            A validated ``DistilledProcedure``, or ``None`` for ``SKIP`` / malformed input.
         """
         if intermediate_md is None:
             return None
@@ -536,12 +536,12 @@ def cluster_by_goal(
 
 def distill_cluster(
     cluster: GoalCluster, send_messages_fn: Callable
-) -> Optional[Skill]:
-    """DISTILL — one low-temperature LLM call turning a cluster into a ``Skill``.
+) -> Optional[DistilledProcedure]:
+    """DISTILL — one low-temperature LLM call turning a cluster into a ``DistilledProcedure``.
 
     Reuses the same ``self.chat.send_messages`` seam the extraction /
     consolidation passes use (no new client).  The response is stripped of think
-    tags and code fences, then validated by ``Skill.parse``.
+    tags and code fences, then validated by ``DistilledProcedure.parse``.
 
     Fail-loud split: a raised exception from ``send_messages_fn`` (Lemonade
     unreachable) propagates so the caller can skip the WHOLE pass; a structurally
@@ -553,7 +553,7 @@ def distill_cluster(
         send_messages_fn: The ``self.chat.send_messages`` callable.
 
     Returns:
-        A validated ``Skill``, or ``None`` for ``SKIP`` / malformed output.
+        A validated ``DistilledProcedure``, or ``None`` for ``SKIP`` / malformed output.
     """
     response = send_messages_fn(
         messages=[{"role": "user", "content": _build_distill_user_prompt(cluster)}],
@@ -568,7 +568,7 @@ def distill_cluster(
         raw_text = re.sub(r"^```(?:[a-zA-Z]+)?\s*", "", raw_text)
         raw_text = re.sub(r"\s*```$", "", raw_text).strip()
 
-    skill = Skill.parse(raw_text)
+    skill = DistilledProcedure.parse(raw_text)
     if skill is None:
         logger.info(
             "[skill_synthesis] no usable skill from cluster goal=%r (SKIP or malformed)",
@@ -651,7 +651,7 @@ def _nearest_enabled_procedure(
 
 
 def reconcile_and_store(
-    candidate: Skill,
+    candidate: DistilledProcedure,
     cluster: GoalCluster,
     store,
     embedding: Optional[bytes] = None,
@@ -676,7 +676,7 @@ def reconcile_and_store(
     only the *match key* moved from name to meaning — dominance is unchanged.
 
     Args:
-        candidate: The distilled ``Skill`` (intermediate fields).
+        candidate: The distilled ``DistilledProcedure`` (intermediate fields).
         cluster: The cluster it was distilled from (track record + provenance).
         store: The ``MemoryStore`` to write to.
         embedding: The ``when_to_use`` embedding BLOB — now both persisted and

--- a/tests/unit/test_chat_dynamic_tools.py
+++ b/tests/unit/test_chat_dynamic_tools.py
@@ -200,10 +200,12 @@ def test_active_state_delegates_to_loader_select():
 
 
 def _skill(name: str, tools: list[str]):
-    """A minimal recalled Skill carrying ``tools_required``."""
-    from gaia.agents.base.skill_synthesis import Skill
+    """A minimal recalled DistilledProcedure carrying ``tools_required``."""
+    from gaia.agents.base.skill_synthesis import DistilledProcedure
 
-    return Skill(name=name, when_to_use="trigger", body="# body", tools_required=tools)
+    return DistilledProcedure(
+        name=name, when_to_use="trigger", body="# body", tools_required=tools
+    )
 
 
 def test_recalled_skill_tools_flattens_and_dedupes_in_order():

--- a/tests/unit/test_memory_mixin.py
+++ b/tests/unit/test_memory_mixin.py
@@ -3640,10 +3640,10 @@ class TestRecallSkill:
 
 
 def _recalled_skill(name, body, when_to_use="trigger", tools_required=None):
-    """A Skill object as recall_skill would return it (for the pure renderer)."""
-    from gaia.agents.base.skill_synthesis import Skill
+    """A DistilledProcedure object as recall_skill would return it (for the pure renderer)."""
+    from gaia.agents.base.skill_synthesis import DistilledProcedure
 
-    return Skill(
+    return DistilledProcedure(
         name=name,
         when_to_use=when_to_use,
         body=body,
@@ -3707,7 +3707,7 @@ class TestRecallOnceProcedureCache:
     """
 
     def test_refresh_caches_recalled_skills_for_the_loader(self, mixin_host):
-        """The matched Skill objects are cached, and their tools flatten+dedupe."""
+        """The matched DistilledProcedure objects are cached, and their tools flatten+dedupe."""
         pytest.importorskip("faiss")
         _seed_procedure(
             mixin_host,

--- a/tests/unit/test_skill_synthesis.py
+++ b/tests/unit/test_skill_synthesis.py
@@ -3,7 +3,7 @@
 """Unit tests for the skill-synthesis pipeline (procedural memory, #887).
 
 Covers the pure pipeline in ``gaia.agents.base.skill_synthesis``:
-``Skill.parse`` / ``Skill.to_skill_md`` round-trip and the #691 emit/inject
+``DistilledProcedure.parse`` / ``DistilledProcedure.to_skill_md`` round-trip and the #691 emit/inject
 split, ``load_synthesis_config`` overrides, ``cluster_by_goal`` grouping at the
 cosine threshold, ``distill_cluster`` contract-shape + fail-loud split, and
 ``reconcile_and_store`` ADD / UPDATE / NOOP (never DELETE).
@@ -25,9 +25,9 @@ from gaia.agents.base.skill_synthesis import (
     DISTILL_SYSTEM_PROMPT,
     DISTILL_TEMPERATURE,
     SIMILARITY_TAU,
+    DistilledProcedure,
     GoalCluster,
     ReconcileResult,
-    Skill,
     SynthesisConfig,
     _build_distill_user_prompt,
     _nearest_enabled_procedure,
@@ -104,15 +104,15 @@ def _cluster(goal="do the thing", n=3, tools=("a", "b", "c")):
 
 
 # ===========================================================================
-# Skill.parse / to_skill_md — the emit/inject split
+# DistilledProcedure.parse / to_skill_md — the emit/inject split
 # ===========================================================================
 
 
 class TestSkillParse:
-    """Skill.parse validates the intermediate four-field shape."""
+    """DistilledProcedure.parse validates the intermediate four-field shape."""
 
     def test_parses_valid_intermediate(self):
-        skill = Skill.parse(_INTERMEDIATE_MD)
+        skill = DistilledProcedure.parse(_INTERMEDIATE_MD)
         assert skill is not None
         assert skill.name == "triage-support-ticket"
         assert skill.when_to_use.startswith("Triage an inbound support ticket")
@@ -122,15 +122,17 @@ class TestSkillParse:
         assert "license" not in skill.body
 
     def test_skip_sentinel_returns_none(self):
-        assert Skill.parse("SKIP") is None
-        assert Skill.parse("  SKIP  ") is None
+        assert DistilledProcedure.parse("SKIP") is None
+        assert DistilledProcedure.parse("  SKIP  ") is None
 
     def test_missing_frontmatter_returns_none(self):
-        assert Skill.parse("# Just a heading\n\nno frontmatter here") is None
+        assert (
+            DistilledProcedure.parse("# Just a heading\n\nno frontmatter here") is None
+        )
 
     def test_empty_returns_none(self):
-        assert Skill.parse("") is None
-        assert Skill.parse(None) is None
+        assert DistilledProcedure.parse("") is None
+        assert DistilledProcedure.parse(None) is None
 
     @pytest.mark.parametrize(
         "bad_name",
@@ -138,12 +140,12 @@ class TestSkillParse:
     )
     def test_invalid_name_rejected(self, bad_name):
         md = _INTERMEDIATE_MD.replace("triage-support-ticket", bad_name, 1)
-        assert Skill.parse(md) is None
+        assert DistilledProcedure.parse(md) is None
 
     def test_name_over_64_chars_rejected(self):
         long_name = "a" * 65
         md = _INTERMEDIATE_MD.replace("triage-support-ticket", long_name, 1)
-        assert Skill.parse(md) is None
+        assert DistilledProcedure.parse(md) is None
 
     def test_empty_when_to_use_rejected(self):
         md = """\
@@ -156,11 +158,11 @@ tools_required: [a]
 # Body
 1. step
 """
-        assert Skill.parse(md) is None
+        assert DistilledProcedure.parse(md) is None
 
     def test_empty_body_rejected(self):
         md = "---\nname: valid-name\nwhen_to_use: trigger text\ntools_required: [a]\n---\n"
-        assert Skill.parse(md) is None
+        assert DistilledProcedure.parse(md) is None
 
     def test_tools_required_defaults_to_empty_list(self):
         md = """\
@@ -172,7 +174,7 @@ when_to_use: A procedure that consumes no registry tools.
 # Body
 1. think
 """
-        skill = Skill.parse(md)
+        skill = DistilledProcedure.parse(md)
         assert skill is not None
         assert skill.tools_required == []
 
@@ -181,12 +183,12 @@ when_to_use: A procedure that consumes no registry tools.
             "tools_required: [query_documents, read_file, remember]",
             "tools_required: [1, 2, 3]",
         )
-        assert Skill.parse(md) is None
+        assert DistilledProcedure.parse(md) is None
 
     def test_tolerates_code_fence_free_intermediate(self):
-        # Skill.parse expects fence-free text (distill_cluster strips fences),
+        # DistilledProcedure.parse expects fence-free text (distill_cluster strips fences),
         # but a stray trailing newline must not break parsing.
-        skill = Skill.parse(_INTERMEDIATE_MD + "\n\n")
+        skill = DistilledProcedure.parse(_INTERMEDIATE_MD + "\n\n")
         assert skill is not None
 
 
@@ -194,7 +196,7 @@ class TestSkillToSkillMd:
     """to_skill_md injects the fixed constants and emits a valid #691 document."""
 
     def test_round_trips_to_valid_691_document(self):
-        skill = Skill.parse(_INTERMEDIATE_MD)
+        skill = DistilledProcedure.parse(_INTERMEDIATE_MD)
         doc = skill.to_skill_md()
 
         # Split frontmatter from body and parse the YAML.
@@ -215,7 +217,7 @@ class TestSkillToSkillMd:
         assert "# Triage a Support Ticket" in body
 
     def test_when_to_use_maps_to_description_not_when_to_use(self):
-        skill = Skill.parse(_INTERMEDIATE_MD)
+        skill = DistilledProcedure.parse(_INTERMEDIATE_MD)
         front = yaml.safe_load(skill.to_skill_md().split("---\n", 2)[1])
         # The on-disk schema uses `description`, never the intermediate label.
         assert "when_to_use" not in front
@@ -472,7 +474,7 @@ class TestBuildDistillUserPrompt:
 
 class TestReconcileAndStore:
     def _candidate(self, name="triage-support-ticket"):
-        return Skill(
+        return DistilledProcedure(
             name=name,
             when_to_use="Triage an inbound support ticket end to end.",
             body="# Triage\n1. step\n## Edge cases\n- escalate",
@@ -558,7 +560,7 @@ class TestReconcileAndStore:
             attempt_count=2,
             embedding=v,
         )
-        drifted = Skill(
+        drifted = DistilledProcedure(
             name="summarize-my-unread-emails",  # drifted name, same goal
             when_to_use="Summarize my unread emails.",
             body="# New\n1. better step",
@@ -606,7 +608,7 @@ class TestReconcileAndStore:
             attempt_count=50,
             embedding=v,
         )
-        drifted = Skill(
+        drifted = DistilledProcedure(
             name="summarize-my-unread-emails",
             when_to_use="Summarize my unread emails.",
             body="weaker",

--- a/tests/unit/test_skill_synthesis.py
+++ b/tests/unit/test_skill_synthesis.py
@@ -3,8 +3,9 @@
 """Unit tests for the skill-synthesis pipeline (procedural memory, #887).
 
 Covers the pure pipeline in ``gaia.agents.base.skill_synthesis``:
-``DistilledProcedure.parse`` / ``DistilledProcedure.to_skill_md`` round-trip and the #691 emit/inject
-split, ``load_synthesis_config`` overrides, ``cluster_by_goal`` grouping at the
+``DistilledProcedure.parse`` / ``DistilledProcedure.to_skill_md`` round-trip and
+the #691 emit/inject split, ``load_synthesis_config`` overrides,
+``cluster_by_goal`` grouping at the
 cosine threshold, ``distill_cluster`` contract-shape + fail-loud split, and
 ``reconcile_and_store`` ADD / UPDATE / NOOP (never DELETE).
 
@@ -36,6 +37,11 @@ from gaia.agents.base.skill_synthesis import (
     load_synthesis_config,
     reconcile_and_store,
 )
+
+try:  # The on-disk SKILL.md format (#888) — absent until that lands.
+    from gaia.skills import format as _SKILLS_FORMAT
+except ImportError:
+    _SKILLS_FORMAT = None
 
 
 @pytest.fixture
@@ -222,6 +228,30 @@ class TestSkillToSkillMd:
         # The on-disk schema uses `description`, never the intermediate label.
         assert "when_to_use" not in front
         assert "description" in front
+
+    @pytest.mark.skipif(
+        _SKILLS_FORMAT is None,
+        reason="gaia.skills (the #888 on-disk format) is not available",
+    )
+    def test_renders_a_document_the_format_validator_accepts(self):
+        """The rendered document survives the real ``gaia.skills`` validator.
+
+        ``to_skill_md`` claims its output "validates under the Agent Skills
+        format"; this asserts it against the actual parser rather than a
+        hand-rolled YAML check, so the two halves cannot drift apart silently.
+        """
+        parse_skill = _SKILLS_FORMAT.parse_skill
+        validate_skill = _SKILLS_FORMAT.validate_skill
+
+        skill = DistilledProcedure.parse(_INTERMEDIATE_MD)
+        parsed = parse_skill(skill.to_skill_md(), source="<synthesized>")
+        validate_skill(parsed, source="<synthesized>")
+
+        assert parsed.name == skill.name
+        assert parsed.description == skill.when_to_use
+        assert parsed.version == "1.0.0"
+        assert parsed.license == "MIT"
+        assert parsed.gaia.tools_required == skill.tools_required
 
 
 # ===========================================================================


### PR DESCRIPTION
Two different frozen dataclasses were both named `Skill` and both reachable from `gaia.agents.base`: the synthesis pipeline's four-field LLM-output schema and the on-disk agentskills.io file contract landing in `src/gaia/skills/` (#2669). The split is a deliberate security boundary — the model may only derive `name`/`when_to_use`/`body`/`tools_required`, never `license`, `version`, or a security tier — so both classes stay; the synthesis one becomes `DistilledProcedure`, matching its own docstring and the `procedures` corpus it feeds. Anyone importing both no longer needs an alias, and nobody can pass the wrong one.

Also adds the test `to_skill_md`'s docstring has been asserting all along: the rendered document is now round-tripped through the real `gaia.skills.format` parser + validator instead of a hand-rolled YAML check. Verified against #2669's branch — **it validates, no drift** (`tools_required` is a first-class `metadata.gaia` field there). The test skips until #2669 merges.

Part of #2671.

## Test plan

- [ ] `python -m pytest tests/unit/test_skill_synthesis.py tests/unit/test_memory_mixin.py tests/unit/test_chat_dynamic_tools.py -q` — 310+ pass, the round-trip test skips while `gaia.skills` is unmerged
- [ ] After #2669 merges, rebase and confirm `test_renders_a_document_the_format_validator_accepts` runs and passes rather than skipping
- [ ] `python -m pytest tests/unit/ -q` — no new failures vs. `origin/main` (verified: identical failure set, all pre-existing environment issues)
- [ ] `python util/lint.py --all` clean
- [ ] `grep -rn '\bSkill\b' src/gaia/agents/base/` returns only prose section headers, no class references
