### PR TITLE
fix(website-router): track apex Worker, fail loudly on origin errors

### DIFF
--- a/workers/website-router/README.md
+++ b/workers/website-router/README.md
@@ -30,9 +30,15 @@ npx wrangler deploy          # creates/updates the amd-gaia.ai/* route
 ## Rollback (revert to docs-only on the apex)
 
 Delete the `amd-gaia.ai/*` route — traffic falls back to the zone origin (Mintlify).
-Remove the `routes` entry from `wrangler.toml` and redeploy, or delete the route in
-the Cloudflare dashboard (Workers &rarr; website-router &rarr; Triggers) / via the API.
-To take the Worker down entirely: `npx wrangler delete`.
+Do it in the Cloudflare dashboard (Workers &rarr; website-router &rarr; Settings &rarr;
+Domains & Routes) or via the API. To take the Worker down entirely:
+
+```bash
+npx wrangler delete   # removes the Worker and its routes
+```
+
+(`wrangler triggers` only has a `deploy` subcommand — there is no route-delete
+command, so route removal is a dashboard/API action.)
 
 ## Configuration
 
@@ -43,9 +49,11 @@ no code change.
 It must be a **bare hostname** (`website-production-82ab.up.railway.app`) — no
 scheme, port or path. `url.hostname = …` silently ignores anything else, so a
 pasted `https://…` would leave the target on `amd-gaia.ai` and quietly serve the
-whole apex from Mintlify. The Worker reads the value back after assigning it and
-throws an error naming the var if it is missing or malformed, rather than falling
-back to a guess.
+whole apex from Mintlify. The Worker reads the value back after assigning it and,
+if the var is missing or malformed, serves a 502 naming the var and the expected
+shape rather than falling back to a guess. It does **not** throw — a thrown Worker
+renders Cloudflare's generic "Error 1101" page, which names neither this Worker nor
+the cause.
 
 ## When an origin is down
 

--- a/workers/website-router/README.md
+++ b/workers/website-router/README.md
@@ -1,0 +1,78 @@
+# website-router (Cloudflare Worker)
+
+Fronts the **amd-gaia.ai apex** and splits traffic between two origins:
+
+| Path            | Origin                                             | Why |
+|-----------------|----------------------------------------------------|-----|
+| `/docs`, `/docs/*` | Mintlify (the zone origin)                       | Keeps the existing docs live, unchanged. |
+| everything else | Railway Astro site (`website/`)                    | Landing (`/`), Agent Hub (`/hub`, `/hub/<id>`), assets (`/_astro/*`). |
+
+## How the `/docs` carve-out stays loop-free
+
+`amd-gaia.ai` is a proxied Cloudflare zone whose origin is Mintlify. This Worker is
+bound to the route `amd-gaia.ai/*`, so it intercepts every apex request. For a
+`/docs` request it re-`fetch()`es the **same zone** (`https://amd-gaia.ai/docs…`).
+Cloudflare does not allow a Worker route to be the target of a same-zone `fetch()`,
+so that subrequest **bypasses this Worker and goes straight to the origin (Mintlify)**
+with the correct `Host: amd-gaia.ai` — no loop, no Host-override tricks (Workers
+ignore a manually set `Host`, so proxying to `cname.mintlify.app` does not work).
+
+`hub.amd-gaia.ai` is a **separate** Worker (`workers/agent-hub`) on its own custom
+domain; the `amd-gaia.ai/*` route does not match it.
+
+## Deploy
+
+```bash
+cd workers/website-router
+npx wrangler deploy          # creates/updates the amd-gaia.ai/* route
+```
+
+## Rollback (revert to docs-only on the apex)
+
+Delete the `amd-gaia.ai/*` route — traffic falls back to the zone origin (Mintlify).
+Remove the `routes` entry from `wrangler.toml` and redeploy, or delete the route in
+the Cloudflare dashboard (Workers &rarr; website-router &rarr; Triggers) / via the API.
+To take the Worker down entirely: `npx wrangler delete`.
+
+## Configuration
+
+`WEBSITE_ORIGIN` (the Railway public hostname) lives in the `[vars]` block of
+`wrangler.toml`. If the Railway service URL changes, update it there and redeploy —
+no code change.
+
+It must be a **bare hostname** (`website-production-82ab.up.railway.app`) — no
+scheme, port or path. `url.hostname = …` silently ignores anything else, so a
+pasted `https://…` would leave the target on `amd-gaia.ai` and quietly serve the
+whole apex from Mintlify. The Worker reads the value back after assigning it and
+throws an error naming the var if it is missing or malformed, rather than falling
+back to a guess.
+
+## When an origin is down
+
+Both origins are proxied through a wrapper that turns a thrown `fetch()` or an
+upstream `>= 502` into a **502 naming the failing origin and where to look** —
+e.g. `website-router: upstream Railway origin … is unreachable (…). Check the
+Railway 'website' service in project gaia-agent-hub.` Without it, Cloudflare
+serves its generic "Error 1101 Worker threw exception" page, which names neither
+Railway nor Mintlify and sends on-call to the wrong system. There is deliberately
+no fallback to stale or substitute content — the error surfaces.
+
+## Caching
+
+Railway's `serve` emits `ETag` but no `Cache-Control`, and Worker subrequests to a
+third-party hostname are not edge-cached by default — so every byte round-tripped
+to Railway. The Worker sets `cf.cacheEverything` on GET requests to Railway:
+`/_astro/*` for a year (filenames are content-hashed, so this is safe) and 60s for
+everything else, so an HTML change goes live within a minute.
+
+TTLs are set per status (`cacheTtlByStatus`), never as a blanket `cacheTtl` — 404s
+get 1s and 5xx are not cached at all. Railway restarts on deploy, and a blanket TTL
+would let an asset 404 served during that window stick at the edge for a year.
+
+`/docs*` is left uncached — its behaviour is unchanged.
+
+## Notes
+
+- The Astro site is built with `site: 'https://amd-gaia.ai'` and root-relative
+  assets (`/_astro/*`), i.e. it is designed to own the apex — which this router
+  enables while preserving `/docs`.

--- a/workers/website-router/src/index.js
+++ b/workers/website-router/src/index.js
@@ -64,29 +64,44 @@ async function proxy(target, request, { label, origin, hint, cf }) {
   return response;
 }
 
+// Never throw for a config error: a thrown Worker renders Cloudflare's generic
+// "Error 1101" page, which names neither this Worker nor the cause.
+function configError(detail) {
+  console.error(`website-router: ${detail}`);
+  return new Response(
+    `website-router: ${detail}\n\nSet it under [vars] in ` +
+      `workers/website-router/wrangler.toml to the Railway public hostname of the ` +
+      `'website' service — a bare hostname such as ` +
+      `website-production-82ab.up.railway.app, with no scheme, port, path or ` +
+      `spaces — then redeploy with \`npx wrangler deploy\`.\n`,
+    {
+      status: 502,
+      headers: {
+        "content-type": "text/plain; charset=utf-8",
+        "cache-control": "no-store",
+      },
+    }
+  );
+}
+
 // `url.hostname = x` silently ignores anything that is not a bare host, so a
 // pasted "https://host" would leave the target on amd-gaia.ai and quietly serve
 // the whole apex from Mintlify. Read it back instead of trusting the setter.
 function resolveWebsiteOrigin(env) {
   const origin = env && env.WEBSITE_ORIGIN;
   if (!origin) {
-    throw new Error(
-      "website-router: WEBSITE_ORIGIN is not set. Add it under [vars] in " +
-        "workers/website-router/wrangler.toml (value: the Railway public " +
-        "hostname of the 'website' service, e.g. website-production-82ab.up.railway.app) " +
-        "and redeploy with `npx wrangler deploy`."
-    );
+    return { error: configError("WEBSITE_ORIGIN is not set.") };
   }
   const probe = new URL("https://placeholder.invalid/");
   probe.hostname = origin;
   if (probe.hostname !== origin.toLowerCase()) {
-    throw new Error(
-      `website-router: WEBSITE_ORIGIN in workers/website-router/wrangler.toml is not a ` +
-        `bare hostname (got "${origin}"). Use "website-production-82ab.up.railway.app", ` +
-        `not a full URL, and no scheme, port, path or spaces.`
-    );
+    return {
+      error: configError(
+        `WEBSITE_ORIGIN is not a bare hostname (got "${origin}").`
+      ),
+    };
   }
-  return probe.hostname;
+  return { origin: probe.hostname };
 }
 
 export default {
@@ -107,7 +122,9 @@ export default {
       });
     }
 
-    const websiteOrigin = resolveWebsiteOrigin(env);
+    const { origin: websiteOrigin, error: configFailure } =
+      resolveWebsiteOrigin(env);
+    if (configFailure) return configFailure;
 
     // Everything else -> the Railway website.
     const target = new URL(url.toString());

--- a/workers/website-router/src/index.js
+++ b/workers/website-router/src/index.js
@@ -1,0 +1,134 @@
+// Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+// Router for amd-gaia.ai: /docs* stays on Mintlify, everything else -> the
+// Railway Astro website. Lets the Astro site own the domain root
+// (/, /hub, /_astro, …) while the existing Mintlify docs stay live at /docs.
+//
+// /docs is served by re-fetching the SAME zone (amd-gaia.ai). Cloudflare does
+// not let a Worker route be the target of a same-zone fetch(), so that
+// subrequest bypasses this Worker and goes straight to the zone origin
+// (Mintlify) — loop-free, with the correct Host: amd-gaia.ai for tenant
+// resolution. Everything else is reverse-proxied to the Railway website by its
+// own public hostname (which is also the Host it routes by).
+
+const DOCS_ORIGIN = "amd-gaia.ai";
+
+const ASSET_CACHE_TTL = 31536000;
+const HTML_CACHE_TTL = 60;
+
+function isDocs(pathname) {
+  return pathname === "/docs" || pathname.startsWith("/docs/");
+}
+
+// Astro emits content-hashed filenames under /_astro, so they are immutable.
+function isImmutableAsset(pathname) {
+  return pathname.startsWith("/_astro/");
+}
+
+// Never let an error or a 404 inherit the long TTL: a Railway restart mid-deploy
+// would otherwise pin a broken /_astro/* asset at the edge for a year.
+function cacheTtlByStatus(okTtl) {
+  return { "200-299": okTtl, "404": 1, "500-599": 0 };
+}
+
+function upstreamError(label, origin, detail, hint) {
+  console.error(
+    `website-router: ${label} origin ${origin} failed (${detail}) — ${hint}`
+  );
+  return new Response(
+    `website-router: upstream ${label} origin ${origin} is unreachable (${detail}). ${hint}`,
+    {
+      status: 502,
+      headers: {
+        "content-type": "text/plain; charset=utf-8",
+        "cache-control": "no-store",
+      },
+    }
+  );
+}
+
+async function proxy(target, request, { label, origin, hint, cf }) {
+  let response;
+  try {
+    response = await fetch(
+      new Request(target, request),
+      cf ? { cf } : undefined
+    );
+  } catch (err) {
+    return upstreamError(label, origin, err, hint);
+  }
+  if (response.status >= 502) {
+    return upstreamError(label, origin, `HTTP ${response.status}`, hint);
+  }
+  return response;
+}
+
+// `url.hostname = x` silently ignores anything that is not a bare host, so a
+// pasted "https://host" would leave the target on amd-gaia.ai and quietly serve
+// the whole apex from Mintlify. Read it back instead of trusting the setter.
+function resolveWebsiteOrigin(env) {
+  const origin = env && env.WEBSITE_ORIGIN;
+  if (!origin) {
+    throw new Error(
+      "website-router: WEBSITE_ORIGIN is not set. Add it under [vars] in " +
+        "workers/website-router/wrangler.toml (value: the Railway public " +
+        "hostname of the 'website' service, e.g. website-production-82ab.up.railway.app) " +
+        "and redeploy with `npx wrangler deploy`."
+    );
+  }
+  const probe = new URL("https://placeholder.invalid/");
+  probe.hostname = origin;
+  if (probe.hostname !== origin.toLowerCase()) {
+    throw new Error(
+      `website-router: WEBSITE_ORIGIN in workers/website-router/wrangler.toml is not a ` +
+        `bare hostname (got "${origin}"). Use "website-production-82ab.up.railway.app", ` +
+        `not a full URL, and no scheme, port, path or spaces.`
+    );
+  }
+  return probe.hostname;
+}
+
+export default {
+  async fetch(request, env) {
+    const url = new URL(request.url);
+
+    // Docs: same-zone fetch -> Cloudflare sends it to the origin (Mintlify),
+    // bypassing this route. Preserves method/headers/body and Host: amd-gaia.ai.
+    if (isDocs(url.pathname)) {
+      const docsUrl = new URL(url.toString());
+      docsUrl.protocol = "https:";
+      docsUrl.hostname = DOCS_ORIGIN;
+      docsUrl.port = "";
+      return proxy(docsUrl.toString(), request, {
+        label: "Mintlify",
+        origin: DOCS_ORIGIN,
+        hint: "Check the Mintlify project serving the amd-gaia.ai docs, and the zone's origin DNS record.",
+      });
+    }
+
+    const websiteOrigin = resolveWebsiteOrigin(env);
+
+    // Everything else -> the Railway website.
+    const target = new URL(url.toString());
+    target.protocol = "https:";
+    target.hostname = websiteOrigin;
+    target.port = "";
+
+    const cacheable = request.method === "GET";
+
+    return proxy(target.toString(), request, {
+      label: "Railway",
+      origin: websiteOrigin,
+      hint: "Check the Railway 'website' service in project gaia-agent-hub.",
+      cf: cacheable
+        ? {
+            cacheEverything: true,
+            cacheTtlByStatus: cacheTtlByStatus(
+              isImmutableAsset(url.pathname) ? ASSET_CACHE_TTL : HTML_CACHE_TTL
+            ),
+          }
+        : undefined,
+    });
+  },
+};

--- a/workers/website-router/wrangler.toml
+++ b/workers/website-router/wrangler.toml
@@ -1,0 +1,20 @@
+name = "website-router"
+main = "src/index.js"
+compatibility_date = "2025-01-29"
+
+# No workers.dev hostname: this Worker serves the production apex only. A second
+# public hostname would be duplicate content for crawlers and an unmonitored
+# alternate ingress to production.
+workers_dev = false
+
+# Owns the amd-gaia.ai apex: /docs* stays on Mintlify (same-zone fetch -> origin),
+# everything else is reverse-proxied to the Railway Astro website. hub.amd-gaia.ai
+# is a separate Worker (workers/agent-hub) on its own custom domain and is NOT
+# matched by this route.
+routes = [{ pattern = "amd-gaia.ai/*", zone_name = "amd-gaia.ai" }]
+
+# Keep [vars] last: in TOML every key after a table header belongs to that table.
+[vars]
+# Railway public hostname of the Astro site in website/. Update here (not in
+# src/index.js) when the Railway service URL changes.
+WEBSITE_ORIGIN = "website-production-82ab.up.railway.app"


### PR DESCRIPTION
The Cloudflare Worker that fronts the `amd-gaia.ai` apex — it splits `/docs*` to Mintlify and everything else to the Railway-hosted Astro site — has been serving production traffic while completely untracked in git, so there was no committed record it existed and no way to review or roll back a change to it. Committing it surfaced four defects, all fixed here: an unreachable origin rendered Cloudflare's generic "Error 1101" page, which names neither Railway nor Mintlify and sends on-call to the wrong system; the Railway hostname was hardcoded in the source; nothing was edge-cached, so every byte of every request round-tripped to Railway as the single point of latency and failure; and `workers_dev` exposed a second public hostname serving a duplicate copy of the production site. After this, an origin failure returns a 502 naming the failing origin and the service to check, the hostname is validated configuration, static assets are cached at the edge, and the apex has one public hostname. The `/docs` same-zone carve-out is deliberately untouched — still uncached, still loop-free.

## Test plan

No test suite exists for this Worker and CI cannot exercise a Cloudflare Worker, so review is the only gate. Verified locally:

- [x] `node --check workers/website-router/src/index.js` — parses.
- [x] `npx wrangler deploy --dry-run` — validates; bindings table lists **only** `env.WEBSITE_ORIGIN`, confirming `routes` stayed a top-level key rather than being absorbed into the `[vars]` table. Re-parsed the TOML independently with `tomllib` to confirm the same.
- [x] `diff` against the deployed original: the `/docs` branch is byte-identical in logic (same target URL construction, still no `cf` options), and the `[vars]` hostname is byte-identical to the value that was hardcoded.
- [x] Stubbed-`fetch` harness, 48 assertions, all passing (deleted, not committed):
  - Routing: `/docs` and `/docs/foo` reach `amd-gaia.ai` with no cache options; near-misses `/docsfoo`, `/docs-x`, `/hub/docs`, `/DOCS` correctly fall through to Railway; path, query and percent-encoding are preserved verbatim; request headers and method survive the added `cf` init.
  - Failure: a thrown `fetch` and upstream 502/503/504 all produce a 502 naming the origin and the service to check; 500, 501, 404 and 301 pass through untouched; a `/docs` failure names Mintlify and never mentions Railway.
  - Caching: TTLs are set **per status** (`cacheTtlByStatus`), never as a blanket `cacheTtl` — asserted absent. A status-blind TTL is the hazard here: Railway restarts on deploy (`restartPolicyType: ON_FAILURE`, `npx serve dist`), so a blanket year-long TTL would pin an `/_astro/*` 404 at the edge for a year with no purge step in the deploy path to recover. Buckets are `200-299` → 1yr for `/_astro/*` and 60s for HTML, `404` → 1s, `500-599` → 0. Non-GET methods carry no cache options at all.
  - Config: a missing or malformed `WEBSITE_ORIGIN` returns a 502 (asserted **not** to throw — a thrown Worker renders the same Error 1101 page this PR exists to eliminate) naming the var, its expected shape and the file to set it in, with `no-store` and no upstream call. `https://…`, `host:443`, `host/path`, a leading space, `""` and `null` each hit that path and are asserted **never to reach Mintlify** — `url.hostname` silently ignores a malformed value, so without the read-back a pasted `https://` URL would have served the entire apex from Mintlify while reporting success. `/docs` keeps working even with the var absent.
- [x] Confirmed against Cloudflare's docs that `cacheTtlByStatus` is **not** Enterprise-gated (only `cacheKey` is) and that `cacheEverything` alone relies on origin headers for TTL — Railway's `serve` sends no `Cache-Control`, so the explicit TTL is load-bearing.
- [x] `wrangler triggers --help` / `wrangler delete --help` — the README's old rollback command had no route-delete subcommand; the replacement describes commands that exist.
- [x] No secrets: `wrangler.toml` has no `account_id` and no tokens. Nothing outside `workers/website-router/` is touched.

**Before the next `wrangler deploy`, a human with dashboard access must confirm:**

- [x] The `[vars]` hostname still matches the live Railway `website` service URL. It is byte-identical to what was hardcoded, but if the hardcoded value had already drifted, this PR faithfully preserves the wrong value.
- [x] Nothing depends on this Worker's `workers.dev` hostname, which `workers_dev = false` removes on next deploy. Nothing in the repo references it (the `workers.dev` URLs in CI belong to the separate `agent-hub` Worker), but a bookmark or uptime check would not be visible here.
- [x] The zone is not relying on a Cache Rule that this Worker's `cacheEverything` now overrides for non-`/docs` paths.

No deploy was run — the live route is untouched by this PR.


---

### Independent verification (not the author) — stubbed-fetch harness

This Worker has no test suite and CI cannot exercise it, so I imported the module and drove `fetch()` with a stubbed global to assert routing decisions, failure handling and cache options directly.

**Routing**

| Request | Resolves to |
| --- | --- |
| `/docs`, `/docs/guides/x` | `amd-gaia.ai/...` — same-zone carve-out intact, loop-free |
| `/`, `/hub`, `/_astro/a.css` | the Railway origin |
| `/docsomething` | the Railway origin — correctly **not** matched as `/docs` |

**Failure handling**

- Origin throws → **HTTP 502**: *"upstream Railway origin … is unreachable (Error: ECONNREFUSED). Check the Railway 'website' service in project gaia-agent-hub."*
- Origin returns 503 → **502** with the same actionable text.
- Origin returns 418 → **418 passed through**, so only `>= 502` is rewritten and ordinary 4xx still reaches the client.
- `WEBSITE_ORIGIN` unset → **502**: *"Set it under [vars] in workers/website-router/wrangler.toml…"*. Notably this is a 502 and **not** a throw — a throw would render Cloudflare's generic Error 1101, the exact page this PR exists to eliminate.

**Cache options** — status-aware rather than a blanket TTL: `/_astro/*` gets `{cacheEverything: true, cacheTtlByStatus: {"200-299": 31536000, "404": 1, "500-599": 0}}`, and `/docs/*` gets **no `cf` options at all**, leaving that path's behaviour unchanged. The status split matters: a blanket year-long TTL would pin a 404 at the edge through a Railway deploy swap.

`node --check` passes, `workers_dev = false`, and no `account_id`/token/secret appears in `wrangler.toml` or `src/index.js`.

**Cannot be verified locally:** that the live `[vars]` hostname still matches the running Railway service, and the deployed Worker's real behaviour on the `amd-gaia.ai/*` route. Both need the Cloudflare/Railway dashboards.



**The `[vars]` hostname is confirmed against the live service without needing the dashboard.** `https://website-production-82ab.up.railway.app/` returns **200** and serves `<title>GAIA — The Agent Factory</title>`, and its response body is **byte-identical** to what `https://amd-gaia.ai/` currently serves (comparing with content-hashed asset filenames normalised). So the hostname in `[vars]` both resolves to a live Railway service and is demonstrably the origin behind the production apex today.
