### PR TITLE
docs(website): correct every deployment instruction in the README

### DIFF
--- a/website/README.md
+++ b/website/README.md
@@ -1,12 +1,16 @@
 # GAIA Website
 
-Developer-focused landing page for GAIA - Local AI Agents framework.
+Developer-focused landing page and Agent Hub for GAIA - Local AI Agents framework.
+
+Serves `amd-gaia.ai` (landing page + `/hub`). The `/docs` tab is Mintlify, a
+separate origin — see [Deployment](#deployment) for how the two are stitched
+together.
 
 ## Tech Stack
 
 - **Framework**: [Astro](https://astro.build) (static, fast)
 - **Styling**: [Tailwind CSS](https://tailwindcss.com)
-- **Hosting**: Cloudflare Pages (recommended)
+- **Hosting**: Railway (production), behind a Cloudflare Worker that owns the apex
 
 ## Development
 
@@ -14,103 +18,219 @@ Developer-focused landing page for GAIA - Local AI Agents framework.
 # Install dependencies
 npm install
 
-# Start dev server
-npm run dev
+# Start dev server (HUB_CATALOG_URL is REQUIRED — see below)
+HUB_CATALOG_URL=https://hub.amd-gaia.ai npm run dev
 
 # Build for production
-npm run build
+HUB_CATALOG_URL=https://hub.amd-gaia.ai npm run build
 
 # Preview production build
 npm run preview
+
+# Unit tests
+npm test
 ```
 
 ## Hub catalog data (`HUB_CATALOG_URL`)
 
-The Agent Hub pages (`/hub`) are built from a catalog resolved at **build time**:
+The Agent Hub pages (`/hub`) are built **entirely from the live hub catalog**,
+fetched at build time from `${HUB_CATALOG_URL}/index.json` (the agent-hub Worker,
+`workers/agent-hub/`).
 
-- **`HUB_CATALOG_URL` unset (default):** the bundled fixture
-  `src/data/index.json` is used — builds work offline.
-- **`HUB_CATALOG_URL` set:** the build fetches `${HUB_CATALOG_URL}/index.json`
-  from the agent-hub worker (`workers/agent-hub/`):
+**`HUB_CATALOG_URL` is required. There is no bundled fixture and no offline
+path.** If it is unset, or the fetch fails, or the shape is wrong, the build
+**fails loudly** — it never falls back to stale data, so the site can never drift
+from what is actually published. This is deliberate; do not add a fallback.
 
-  ```bash
-  HUB_CATALOG_URL=https://hub.amd-gaia.ai npm run build
-  ```
+```bash
+HUB_CATALOG_URL=https://hub.amd-gaia.ai npm run build
+```
 
-  If the fetch fails, the **build fails** with an actionable error — it never
-  silently falls back to the fixture. The entry shape is defined by
-  `workers/agent-hub/schemas/index.schema.json` and mirrored by the `Agent`
-  interface in `src/data/catalog.ts`.
+Consequences worth knowing before you debug a red build:
+
+- **A hub outage blocks every website build** — local, CI, and deploy alike.
+  A failing build here is often a hub problem, not a website problem. Check
+  `GET https://hub.amd-gaia.ai/health` first.
+- The entry shape is defined by `workers/agent-hub/schemas/index.schema.json`
+  and mirrored by the `Agent` interface in `src/data/catalog.ts`.
+
+### The "in development" list is a committed snapshot
+
+Unpublished agents (those in `hub/agents/<id>/` but not yet in the live catalog)
+are listed from `src/data/in-development.json` — a **committed snapshot** of the
+agent manifests, not a build-time read of `../hub/`. The Railway deploy uploads
+only `website/`, so `hub/` does not exist in the production build context.
+
+**Whenever an agent is added, removed, or renamed under `hub/agents/`, regenerate
+the snapshot from a full checkout and commit the result:**
+
+```bash
+cd website
+npm run generate:agents    # rewrite the snapshot
+npm run check:agents       # verify it matches the manifests (also run in CI)
+```
+
+See `src/data/inDevelopment.ts` and `scripts/generate-in-development.mjs` for the
+full rationale.
 
 ## Project Structure
 
 ```
 website/
-├── public/              # Static assets (favicon, robots.txt)
+├── public/                          # Static assets
+│   ├── favicon.ico
+│   ├── gaia-icon.png
+│   └── robots.txt
+├── scripts/
+│   └── generate-in-development.mjs  # Regenerates the in-development snapshot
 ├── src/
-│   ├── components/      # Astro components
+│   ├── components/                  # 21 Astro components
+│   │   ├── AgentIcon.astro
+│   │   ├── AgentRow.astro
+│   │   ├── CodePanel.astro
+│   │   ├── ComingSoonRow.astro
+│   │   ├── DocTabs.astro
+│   │   ├── DownloadButton.astro
+│   │   ├── EntryPoints.astro
+│   │   ├── Eyebrow.astro
+│   │   ├── FeaturedCard.astro
+│   │   ├── FileTree.astro
+│   │   ├── Footer.astro
 │   │   ├── Header.astro
-│   │   ├── Hero.astro
-│   │   ├── WhyNotX.astro
-│   │   ├── CodeExamples.astro
-│   │   ├── Benchmarks.astro
-│   │   ├── BuiltWith.astro
-│   │   ├── Integrations.astro
-│   │   ├── QuickStart.astro
-│   │   ├── TrustSignals.astro
-│   │   └── Footer.astro
+│   │   ├── InstallCard.astro
+│   │   ├── InstallMethods.astro
+│   │   ├── Marquee.astro
+│   │   ├── SidebarCard.astro
+│   │   ├── StarField.astro
+│   │   ├── StatBlock.astro
+│   │   ├── Terminal.astro
+│   │   ├── ThemeToggle.astro
+│   │   └── WayCard.astro
+│   ├── data/
+│   │   ├── catalog.ts               # Live hub catalog access (build-time fetch)
+│   │   ├── fileTree.ts              # Nested tree from package file listings
+│   │   ├── in-development.json      # Committed snapshot of unpublished agents
+│   │   ├── inDevelopment.ts         # Snapshot loader
+│   │   ├── markdown.ts              # Dependency-free Markdown → semantic HTML
+│   │   └── *.test.ts                # Vitest unit tests
+│   ├── design/
+│   │   ├── global.css               # Owns the @tailwind directives
+│   │   ├── tailwind-preset.mjs
+│   │   └── tokens.css               # Design tokens
 │   ├── layouts/
-│   │   └── Layout.astro # Base HTML layout
-│   └── pages/
-│       └── index.astro  # Landing page
+│   │   └── Layout.astro             # Base HTML layout
+│   ├── pages/
+│   │   ├── hub/
+│   │   │   ├── [id].astro           # Agent detail page (one per catalog entry)
+│   │   │   └── index.astro          # Agent Hub listing
+│   │   └── index.astro              # Landing page
+│   ├── scripts/
+│   │   └── starfield.js
+│   └── env.d.ts
 ├── astro.config.mjs
+├── postcss.config.mjs
+├── railway.json                     # Railway build + start commands
 ├── tailwind.config.mjs
+├── tsconfig.json
 └── package.json
 ```
 
 ## Design System
 
-- **Background**: `#0d0d0d`
-- **Card Background**: `#1e1e2e`
-- **Accent (AMD Red)**: `#ED1C24`
-- **Text**: `#e4e4e7`
-- **Muted Text**: `#a1a1aa`
-- **Font (Code)**: JetBrains Mono
+`src/design/tokens.css` is the single source of truth (shared with the Agent UI);
+`src/design/tailwind-preset.mjs` maps those variables to `g-*` Tailwind
+utilities. Read those files rather than trusting a copy — the headlines only:
+
+- **Accent**: graphic gold `#E7A33C` (`--g-gold`) — *not* AMD red
+- **Ground**: dark `#08080a` is the designed default; light `#fbfaf7` is derived
+- **Font (Display)**: Space Grotesk — headings and the wordmark only
 - **Font (UI)**: Inter
+- **Font (Code)**: JetBrains Mono
+
+Theme is set pre-paint by an inline script in `src/layouts/Layout.astro`, which
+toggles `[data-theme="dark"]`. Code panels stay dark in both themes.
 
 ## Deployment
 
-### Railway (Recommended for Quick Deploy)
+Production is **Railway** — service `website` in the Railway project
+`gaia-agent-hub`. It is *not* Cloudflare Pages.
 
-See **[RAILWAY_DEPLOY.md](./RAILWAY_DEPLOY.md)** for detailed instructions.
+### The apex is owned by a Cloudflare Worker
 
-**Quick setup:**
-1. Push code to `github.com/amd/gaia-website`
-2. Connect Railway to your GitHub repo
-3. Railway auto-detects Astro and deploys
-4. Set custom domain to `amd-gaia.ai`
+`amd-gaia.ai` is served by the `website-router` Cloudflare Worker, which splits
+traffic by path:
 
-**Auto-deploy:** Push to GitHub → Railway builds and deploys automatically
+| Path      | Origin                       |
+| --------- | ---------------------------- |
+| `/docs*`  | Mintlify (the docs site)     |
+| everything else | Railway (this Astro site) |
 
-### Cloudflare Pages (Recommended for Production)
+**Deploying this site alone does not put it on `amd-gaia.ai`.** Railway serves it
+at its own hostname; the Worker is what maps the apex onto it.
 
-1. Connect your repository to Cloudflare Pages
-2. Set build command: `npm run build`
-3. Set output directory: `dist`
-4. Deploy
+The Worker passes the Railway public hostname as a `WEBSITE_ORIGIN` variable —
+`website-production-82ab.up.railway.app` at the time of writing. **Rotating the
+Railway hostname breaks the apex until that variable is updated and the Worker
+redeployed.** The Worker's source is being brought into the repo under
+`workers/website-router/`; until that lands, its configuration lives only in
+Cloudflare, so check the dashboard to confirm the current origin.
 
-**Benefits:** Faster global CDN, unlimited bandwidth, better DDoS protection
+`hub.amd-gaia.ai` is a *separate* Worker (`workers/agent-hub/`) on its own custom
+domain, and is not affected by the apex route.
 
-### Manual Deploy
+### Automated deploys
+
+`.github/workflows/deploy_website.yml` drives `railway up --service website --ci`.
+Railway builds from `railway.json` (NIXPACKS, `npm install && npm run build`,
+served by `serve dist`) — it does **not** auto-detect Astro.
+
+Two pieces of configuration are required, and a missing one is a hard failure, not
+a degraded deploy:
+
+| What | Where | Why |
+| ---- | ----- | --- |
+| `RAILWAY_TOKEN` | GitHub repo secret | A Railway **project** token for `gaia-agent-hub`, production environment (Railway → project → Settings → Tokens). |
+| `HUB_CATALOG_URL=https://hub.amd-gaia.ai` | Railway service variable on `website` | The build has no fixture fallback, so without it the deploy **fails**. Set it in Railway → Variables. |
+
+> Both live outside this repo (GitHub secrets and the Railway dashboard), so they
+> cannot be verified from a checkout. Treat the table as the required
+> configuration and confirm it in the respective dashboard when a deploy fails.
+
+### Deploys only fire on `website/**` changes
+
+Both `deploy_website.yml` and `website-ci.yml` are path-filtered to `website/**`.
+A commit that only adds an agent under `hub/agents/` therefore **neither validates
+the in-development snapshot nor redeploys the site** — so a newly published agent
+will not appear on `/hub` on its own.
+
+Release workflows work around this by dispatching the deploy explicitly after a
+successful publish (see the "Redeploy the website to publish the new catalog
+entry" step in `.github/workflows/release_agent_email.yml`). You can do the same
+by hand:
 
 ```bash
-npm run build
+gh workflow run deploy_website.yml --ref main
+```
+
+### Rollback
+
+To take the Astro site off the apex, delete the `amd-gaia.ai/*` Worker route (in
+the Cloudflare dashboard, or `npx wrangler triggers`) — traffic falls back to the
+zone origin, Mintlify. `/docs` keeps working; `/` and `/hub` disappear. This is
+the fastest way to revert a bad website deploy without touching Railway.
+
+### Manual deploy
+
+```bash
+HUB_CATALOG_URL=https://hub.amd-gaia.ai npm run build
 # Upload contents of dist/ to your hosting provider
 ```
 
 ## Assets Needed
 
-Before launch, add these assets to `public/`:
+Open TODO — these are not yet in `public/`, which currently holds only
+`favicon.ico`, `gaia-icon.png`, and `robots.txt`. Nothing references them, so
+nothing is broken; they are polish items, not blockers.
 
 - [ ] `og-image.png` (1200x630) - Social share image
 - [ ] Integration logos (VS Code, Blender, Jira, Docker)

--- a/website/README.md
+++ b/website/README.md
@@ -127,6 +127,7 @@ website/
 │   ├── scripts/
 │   │   └── starfield.js
 │   └── env.d.ts
+├── .railwayignore                   # Excluded from the `railway up` upload
 ├── astro.config.mjs
 ├── postcss.config.mjs
 ├── railway.json                     # Railway build + start commands

--- a/website/src/data/catalog.ts
+++ b/website/src/data/catalog.ts
@@ -357,10 +357,14 @@ export function installMethods(agent: Agent): InstallMethod[] {
   return methods;
 }
 
+// Wording mirrors the Agent UI's trust gate (src/gaia/apps/webui/src/utils/hubLanes.ts)
+// so the same tier never reads differently in two places. Describe only what the
+// hub actually enforces — there is no publisher-signing scheme and no Python
+// sandbox, so neither may be implied here.
 const SECURITY_TIER_DESCRIPTIONS: Record<SecurityTier, string> = {
   verified: 'Built and reviewed by AMD.',
-  community: 'Publisher-signed but not reviewed by AMD — install with the usual third-party caution.',
-  experimental: 'Opt-in only; may run outside the Python sandbox. Review the source before installing.',
+  community: 'Community-published — not audited by AMD. Install with the usual third-party caution.',
+  experimental: 'Unreviewed and may be unstable. Review the source before installing.',
 };
 
 export function securityTierDescription(tier: SecurityTier): string {

--- a/website/src/data/catalog.ts
+++ b/website/src/data/catalog.ts
@@ -122,16 +122,16 @@ async function fetchLiveCatalog(baseUrl: string): Promise<CatalogFile> {
   } catch (e) {
     throw new Error(
       `[catalog] Failed to fetch the live catalog from ${url}: ${(e as Error).message}. ` +
-        `HUB_CATALOG_URL is set, so the build must use the live hub — it will not ` +
-        `fall back to the bundled fixture. Start the agent-hub worker (see ` +
-        `workers/agent-hub/README.md) or unset HUB_CATALOG_URL to build from the fixture.`
+        `The website has no bundled fixture — the live hub is the only source, so the ` +
+        `build cannot continue. Check that the hub is reachable, or start a local ` +
+        `agent-hub worker and point HUB_CATALOG_URL at it (workers/agent-hub/README.md).`
     );
   }
   if (!res.ok) {
     throw new Error(
       `[catalog] Live catalog request to ${url} returned HTTP ${res.status}. ` +
         `Check that the agent-hub worker is healthy (GET /health) and has at least ` +
-        `one published agent, or unset HUB_CATALOG_URL to build from the fixture.`
+        `one published agent (workers/agent-hub/README.md).`
     );
   }
   const catalog = (await res.json()) as CatalogFile;


### PR DESCRIPTION
A contributor following `website/README.md` today deploys to the wrong platform from a repo that does not exist — it prescribes Cloudflare Pages (production is Railway), tells you to push to `github.com/amd/gaia-website` (this lives in `amd/gaia`), claims Railway auto-detects Astro (`railway.json` declares the build explicitly), and links a `RAILWAY_DEPLOY.md` that was never written. Meanwhile the ten facts you actually need to deploy the site were tribal knowledge or dashboard-only state: the Railway service variable the build hard-fails without, the Cloudflare Worker that owns the apex, the `RAILWAY_TOKEN` secret, and the `website/**` path filter that silently stops hub-only commits from redeploying. After this, the README matches the real filesystem and workflows, the structure tree is generated from disk instead of invented, and those ten facts are written down where a new contributor will find them.

Two catalog errors also ended with "unset `HUB_CATALOG_URL` to build from the fixture." There is no fixture, and unsetting it trips a *different* hard failure — so a hub blip mid-deploy cost an engineer a full cycle chasing an instruction that cannot work. Separately, the hub's security-tier copy claimed community packages are "Publisher-signed" and experimental ones "may run outside the Python sandbox": neither mechanism exists anywhere in the tree, and since the one published agent is `experimental`, that false assurance is live on `amd-gaia.ai/hub/email` right now.

## Test plan

- [x] `npx astro check` — 39 files, **0 errors, 0 warnings, 0 hints**
- [x] `npx vitest run` — **32 passed** (3 files)
- [x] `HUB_CATALOG_URL=https://hub.amd-gaia.ai npm run build` — **3 pages built**
- [x] All 55 Project Structure entries stat'd against the filesystem — **0 missing**; every npm script and URL cited is real (`GET /health` probed live, HTTP 200)
- [x] Fetch-failure path proven (`HUB_CATALOG_URL=http://127.0.0.1:9`):
      `[catalog] Failed to fetch the live catalog from http://127.0.0.1:9/index.json: fetch failed. The website has no bundled fixture — the live hub is the only source, so the build cannot continue. Check that the hub is reachable, or start a local agent-hub worker and point HUB_CATALOG_URL at it (workers/agent-hub/README.md).`
- [x] HTTP-error path proven (404): `...Check that the agent-hub worker is healthy (GET /health) and has at least one published agent (workers/agent-hub/README.md).`
- [x] Unset-variable error confirmed **unchanged** and still exemplary; no fixture fallback added
- [x] Apex routing verified live: `/` → "GAIA — The Agent Factory" (Railway), `/docs` → "Welcome - GAIA SDK" (Mintlify)
- [x] `docs/` scanned for contradictions — no "Cloudflare Pages", no `gaia-website` repo reference, no stale `RAILWAY_DEPLOY.md` link anywhere

## Notes for the reviewer

- **Nothing here asserts dashboard state.** The two out-of-repo requirements (`HUB_CATALOG_URL` on the Railway service, and the Railway hostname) are written as *the documented requirement*, with an explicit note that they can't be read from a checkout. For what it's worth, both currently look right from outside — `website-production-82ab.up.railway.app` serves the site, and `/hub/email` renders catalog data, which a build could not have produced with the variable unset — but that evidences the last successful deploy, not present dashboard state, so the README does not claim it.
- **One deliberate forward reference:** the `website-router` Worker source is landing in a parallel PR, so `workers/website-router/` is not on `main` yet. Rather than cite a path that would be fiction on merge, the README describes the Worker's role (real and live on the apex today) and words the single directory mention as pending. Recheck if that PR's path changes.
- **The security-tier fix is a second commit** and is separable if you'd rather it land on its own. I aligned the wording to `src/gaia/apps/webui/src/utils/hubLanes.ts`, which already describes these tiers correctly — so this is deduplication toward an existing in-repo standard, not new product copy. Flagging it because trust language is a maintainer call: if publisher signing is on the roadmap, you may prefer to make the claim true rather than remove it.
- **Scope** is `website/README.md` + `website/src/data/catalog.ts` only. `workers/`, the workflows, `package.json`, and `railway.json` are untouched.
- **Out of scope, worth a follow-up:** `docs/railway.json` configures a Railway deploy for the docs site, but no workflow references it and `/docs` is served by Mintlify — it looks vestigial.


---

### Independent verification (not the author), macOS

- **Every file path named in the README exists.** Checked each backticked path against the tree; the only two that did not resolve as paths (`deploy_website.yml`, `website-ci.yml`) are bare filenames used in prose and in a `gh workflow run` command, which is correct usage. This was the original failure mode — the old README listed eight components that never existed — so it was worth checking one by one.
- **All four external URLs return 200:** `astro.build`, `tailwindcss.com`, `hub.amd-gaia.ai`, `hub.amd-gaia.ai/health`.
- **The catalog error path was exercised for real** by pointing `HUB_CATALOG_URL` at an unreachable host. It now says: *"The website has no bundled fixture — the live hub is the only source, so the build cannot continue. Check that the hub is reachable, or start a local agent-hub worker and point HUB_CATALOG_URL at it (workers/agent-hub/README.md)."* That is the inversion of the bug: the old text told the user to unset the variable and build from a fixture, which produced a second, different failure. The remaining `fixture` and `Cloudflare Pages` strings in the tree are negations (*"has no bundled fixture"*, *"It is **not** Cloudflare Pages"*), not survivals.

No issues found.
