### PR TITLE
fix(website): stop a published agent rendering twice on the hub page

### DIFF
--- a/.github/workflows/deploy_website.yml
+++ b/.github/workflows/deploy_website.yml
@@ -27,6 +27,9 @@ on:
     branches: [main]
     paths:
       - 'website/**'
+      # The hub page renders these; kept in sync with website-ci.yml's filter so
+      # an agent change can never land without the site rebuilding.
+      - 'hub/agents/**/gaia-agent.yaml'
       - '.github/workflows/deploy_website.yml'
   workflow_dispatch:
 

--- a/.github/workflows/website-ci.yml
+++ b/.github/workflows/website-ci.yml
@@ -13,15 +13,20 @@
 
 name: Website CI
 
+# The agent manifests are in the filter because the snapshot gate below is the
+# only thing that catches them drifting — and the change it exists to catch
+# (adding an agent under hub/agents/) touches nothing in website/.
 on:
   pull_request:
     paths:
       - 'website/**'
+      - 'hub/agents/**/gaia-agent.yaml'
       - '.github/workflows/website-ci.yml'
   push:
     branches: [main]
     paths:
       - 'website/**'
+      - 'hub/agents/**/gaia-agent.yaml'
       - '.github/workflows/website-ci.yml'
 
 permissions:

--- a/website/scripts/generate-in-development.mjs
+++ b/website/scripts/generate-in-development.mjs
@@ -55,16 +55,19 @@ function readManifest(dir, id) {
     if (typeof value !== 'string' || value.trim() === '') {
       throw new Error(
         `[generate-in-development] ${file} has no usable '${key}'. Every agent manifest ` +
-          `must declare name/description/category/icon — the hub list renders them ` +
+          `must declare id/name/description/category/icon — the hub list renders them ` +
           `verbatim and will not invent a placeholder.`
       );
     }
     return value.trim();
   };
-  // The id comes from the DIRECTORY, not the manifest: manifests disagree with
-  // their own folder (hub/agents/analyst declares `id: data`).
+  // Two ids, deliberately. `id` is the DIRECTORY, which manifests disagree with
+  // (hub/agents/analyst declares `id: data`). `manifestId` is what the live
+  // catalog serves once the agent publishes, so the "in development" filter can
+  // drop the row under either name.
   return {
     id,
+    manifestId: field('id'),
     name: field('name'),
     description: field('description'),
     category: field('category'),

--- a/website/src/data/in-development.json
+++ b/website/src/data/in-development.json
@@ -2,6 +2,7 @@
   "agents": [
     {
       "id": "analyst",
+      "manifestId": "data",
       "name": "Analyst Agent",
       "description": "GAIA analyst agent — structured data analysis (CSV/Excel, scratchpad SQL)",
       "category": "productivity",
@@ -9,6 +10,7 @@
     },
     {
       "id": "blender",
+      "manifestId": "blender",
       "name": "Blender",
       "description": "3D scene automation for Blender via MCP",
       "category": "creative",
@@ -16,6 +18,7 @@
     },
     {
       "id": "browser",
+      "manifestId": "web",
       "name": "Browser Agent",
       "description": "GAIA browser agent — web research (search, fetch, download)",
       "category": "research",
@@ -23,6 +26,7 @@
     },
     {
       "id": "chat",
+      "manifestId": "chat",
       "name": "Chat",
       "description": "GAIA chat agent — conversation, document Q&A (RAG), and file-system profiles",
       "category": "conversation",
@@ -30,6 +34,7 @@
     },
     {
       "id": "code",
+      "manifestId": "code",
       "name": "Code",
       "description": "Autonomous code generation — plan, write, lint, fix, and test",
       "category": "development",
@@ -37,6 +42,7 @@
     },
     {
       "id": "docker",
+      "manifestId": "docker",
       "name": "Docker",
       "description": "Container management — build, run, and inspect Docker containers",
       "category": "infrastructure",
@@ -44,6 +50,7 @@
     },
     {
       "id": "docqa",
+      "manifestId": "docqa",
       "name": "Document Q&A",
       "description": "GAIA Document Q&A agent — RAG document Q&A and indexing",
       "category": "productivity",
@@ -51,6 +58,7 @@
     },
     {
       "id": "email",
+      "manifestId": "email",
       "name": "Email Triage",
       "description": "GAIA email triage agent — read, triage, organize, and reply to Gmail/Outlook locally",
       "category": "productivity",
@@ -58,6 +66,7 @@
     },
     {
       "id": "fileio",
+      "manifestId": "fileio",
       "name": "File I/O",
       "description": "Read, write, and edit files on the local filesystem",
       "category": "productivity",
@@ -65,6 +74,7 @@
     },
     {
       "id": "jira",
+      "manifestId": "jira",
       "name": "Jira",
       "description": "Jira issue management — search, create, and update issues",
       "category": "productivity",
@@ -72,6 +82,7 @@
     },
     {
       "id": "emr",
+      "manifestId": "emr",
       "name": "Medical Intake",
       "description": "Medical intake — VLM extraction of patient forms into a records database",
       "category": "healthcare",
@@ -79,6 +90,7 @@
     },
     {
       "id": "routing",
+      "manifestId": "routing",
       "name": "Routing Agent",
       "description": "GAIA routing agent — meta-agent that routes requests to the right concrete agent",
       "category": "infrastructure",
@@ -86,6 +98,7 @@
     },
     {
       "id": "sd",
+      "manifestId": "sd",
       "name": "Stable Diffusion",
       "description": "Image generation — LLM-enhanced prompts for Stable Diffusion",
       "category": "creative",
@@ -93,6 +106,7 @@
     },
     {
       "id": "summarize",
+      "manifestId": "summarize",
       "name": "Summarizer",
       "description": "Document and text summarization — PDFs, transcripts, and email",
       "category": "productivity",

--- a/website/src/data/inDevelopment.test.ts
+++ b/website/src/data/inDevelopment.test.ts
@@ -40,10 +40,28 @@ describe('getInDevelopmentAgents', () => {
     expect(ids).not.toContain('connectors-demo');
   });
 
+  it('drops an agent the catalog publishes under its manifest id', () => {
+    // The catalog keys on the manifest `id`; the snapshot keys on the directory.
+    // hub/agents/analyst declares `id: data`, so the day it publishes the
+    // catalog says "data" while this row still says "analyst" — without the
+    // manifestId match it renders in the published grid AND here.
+    const analyst = getInDevelopmentAgents([]).find((a) => a.id === 'analyst');
+    expect(analyst?.manifestId).toBe('data');
+    expect(getInDevelopmentAgents(['data']).map((a) => a.id)).not.toContain('analyst');
+    expect(getInDevelopmentAgents(['web']).map((a) => a.id)).not.toContain('browser');
+  });
+
   it('emits no version or size, and sorts by name', () => {
     const agents = getInDevelopmentAgents(['email']);
     const keys = new Set(agents.flatMap((a) => Object.keys(a)));
-    expect([...keys].sort()).toEqual(['category', 'description', 'icon', 'id', 'name']);
+    expect([...keys].sort()).toEqual([
+      'category',
+      'description',
+      'icon',
+      'id',
+      'manifestId',
+      'name',
+    ]);
     expect(agents.map((a) => a.name)).toEqual([...agents.map((a) => a.name)].sort());
   });
 });

--- a/website/src/data/inDevelopment.ts
+++ b/website/src/data/inDevelopment.ts
@@ -24,7 +24,10 @@
 import snapshot from './in-development.json';
 
 export interface InDevelopmentAgent {
+  /** Directory name under hub/agents/. */
   id: string;
+  /** The manifest's own `id` — what the catalog serves once published. */
+  manifestId: string;
   name: string;
   description: string;
   category: string;
@@ -45,8 +48,12 @@ if (ALL.length === 0) {
  * Agents that exist in `hub/agents/` but are not in the published catalog,
  * sorted by name. Pass the ids of every published agent so a freshly published
  * one leaves this list the moment the catalog picks it up.
+ *
+ * Matched on BOTH ids: the catalog keys on the manifest `id`, this snapshot on
+ * the directory, and they disagree for some agents — matching only one would
+ * render a just-published agent in the published grid and here at once.
  */
 export function getInDevelopmentAgents(publishedIds: Iterable<string>): InDevelopmentAgent[] {
   const published = new Set(publishedIds);
-  return ALL.filter((a) => !published.has(a.id));
+  return ALL.filter((a) => !published.has(a.id) && !published.has(a.manifestId));
 }


### PR DESCRIPTION
The Agent Hub page builds its published grid from the live catalog and its "In development" list from a committed snapshot of `hub/agents/`, and the two identify agents differently — the snapshot by directory name, the catalog by the manifest `id` field. Those disagree for exactly two agents (`analyst` → `id: data`, `browser` → `id: web`), so on the day either one publishes it would render **in both sections at once** on the flagship hub page; it's invisible today only because `email` is the sole published agent and its names happen to match. Separately, the CI gate that keeps that snapshot fresh (`npm run check:agents`) was path-filtered to `website/**`, so adding an agent under `hub/agents/` — the precise change the gate exists to catch — never triggered it, and the hub page would silently omit the new agent indefinitely. Both now work: the filter matches on either id, and both website workflows watch the agent manifests.

Proven end-to-end, not just in unit tests: building the real hub page against a stub catalog that publishes `data` renders "Analyst Agent" **twice** without the fix and **once** with it.

## Test plan

- [x] `npm run check:agents` — snapshot in sync with the manifests
- [x] `npx astro check` — 0 errors, 0 warnings, 0 hints (39 files)
- [x] `npx vitest run` — 33 passed (32 baseline + 1 new regression test)
- [x] New test `drops an agent the catalog publishes under its manifest id` **fails before the fix** (`expected undefined to be 'data'`) and **passes after** — verified both directions
- [x] `HUB_CATALOG_URL=https://hub.amd-gaia.ai npm run build` — 3 pages built from the live catalog
- [x] End-to-end double-render probe against a stub catalog publishing `data`: without fix `"Analyst Agent"` ×2 + `soon-row data-id="analyst"` present; with fix ×1 and absent
- [x] Both workflow YAMLs parse; `hub/agents/**/gaia-agent.yaml` verified with picomatch to match all 18 real manifests and none of `hub/agents/README.md`, `hub/agents/*/python/agent.py`, `src/gaia/**`

The path-filter behaviour itself cannot be proven from this PR — this branch touches `website/` and the workflows, so Website CI runs here regardless. It takes a real PR touching only `hub/agents/` to demonstrate the trigger, which is the point of the change.

**Deliberate non-change:** the manifest `id` fields are left alone. Renaming `id: data` → `id: analyst` would alter a published agent identity — what the hub catalog serves and what an install command resolves — with blast radius well outside the website. That may be the right cleanup, but it's a maintainer decision, not part of this fix.