### PR TITLE
fix(mcp): cap the mcp dependency below 2.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -214,7 +214,10 @@ setup(
             "bpy",
         ],
         "mcp": [
-            "mcp>=1.1.0",
+            # Capped below 2.0: mcp 2.0.0 (released 2026-07-28) breaks
+            # MCPClient.connect() — the custom-agent harness went red with no
+            # code change. Lift the cap in a change that ports the client.
+            "mcp>=1.1.0,<2.0",
             "starlette",
             "uvicorn",
         ],


### PR DESCRIPTION
**The custom-agent MCP harness is red for a dependency we never chose.** `setup.py` declared `mcp>=1.1.0` with no upper bound, so pip resolved `mcp 2.0.0` the day it shipped and `MCPClient.connect()` began returning `False`.

The timeline is unambiguous — same branch, no relevant code change:

| When | Result |
|---|---|
| 07-28 02:32 | Build Installers **green** |
| **07-28 13:45** | **`mcp 2.0.0` published to PyPI** |
| 07-30 09:20 | Build Installers **red** — `assert client.connect()` → False |

`main` carries the identical unbounded pin and is only green because this workflow is release-branch triggered and hasn't run there since. So this is not specific to the release PR it currently blocks (#2374).

The cap matches `litellm>=1.35.0,<2.0` two entries down in the same file. Lifting it should be a real port of the client to the 2.x API, not a version bump — hence the comment saying so.

### Test plan

- [x] `pytest tests/fixtures/mcp/dummy_server/test_dummy_server.py tests/installer/test_custom_agent_mcp_harness.py` — 4 passed against the locally-resolved `mcp 1.27.0`
- [x] Specifier checked directly: `>=1.1.0,<2.0` admits 1.1.0 and 1.27.0, blocks 2.0.0 **and** `2.0.0rc1` (prereleases would otherwise slip through)
- [x] `setup.py` parses; `python setup.py --version` runs
- [x] Confirmed this is the only `mcp` specifier in the repo — no hub agent pyproject pins it separately