### PR TITLE
feat(email,skills): bundled skills + account-keyed skill-set selection

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -120,6 +120,7 @@
                     "group": "Build & Extend",
                     "pages": [
                       "guides/custom-agent",
+                      "guides/composing-skills",
                       "guides/hub-publishing"
                     ]
                   },

--- a/docs/guides/composing-skills.mdx
+++ b/docs/guides/composing-skills.mdx
@@ -1,0 +1,250 @@
+---
+title: "Composing Skills and Skill Sets"
+description: "Bundle several Agent Skills with your agent and activate a different set per launch"
+icon: "layer-group"
+---
+
+An agent that does one job needs one set of instructions. An agent that does the
+same job in two different contexts needs two — and hardcoding `load_skill` calls
+forces you to pick one, or to ship two agents.
+
+**Skill sets** solve that. You bundle a small library of skills with your agent,
+group them into named sets in `gaia-agent.yaml`, and let exactly one set activate
+per launch — chosen explicitly, or by whatever runtime signal your agent already
+has.
+
+This guide builds a worked example: a code-review agent that reviews differently
+for a library than for an application.
+
+<Info>
+  **Prerequisites:** you have an agent package with a `gaia-agent.yaml` — see
+  [Custom Agents](/guides/custom-agent). Background on the format itself is in
+  [Agent Skills](/spec/agent-skills) and [Skill Format](/plans/skill-format).
+</Info>
+
+## 1. Bundle the skills
+
+Put each skill in its own directory inside your importable package, so the wheel
+and any frozen binary ship it:
+
+```
+my_agent/
+├── __init__.py
+├── agent.py
+└── skills/
+    ├── review-basics/SKILL.md
+    ├── api-compatibility/SKILL.md
+    ├── changelog-discipline/SKILL.md
+    └── ux-regression/SKILL.md
+```
+
+<Warning>
+  A `skills/` folder *beside* your package rather than inside it works from a
+  source checkout and then vanishes from an installed wheel — the classic
+  works-on-my-machine failure. Keep it inside the package and declare it as
+  package data (`[tool.setuptools.package-data]`), plus `--add-data` if you freeze
+  a binary.
+</Warning>
+
+A skill is a `SKILL.md`: frontmatter plus a Markdown body. Keep the body short —
+it is injected into the system prompt when the skill loads, and every token it
+takes is a token your tool results no longer have.
+
+```markdown
+---
+name: api-compatibility
+description: Check a change for breaking API surface. Use when reviewing a diff that touches public functions, classes, or types.
+version: 0.1.0
+metadata:
+  gaia:
+    tools_required:
+      - read_file
+      - search_code
+---
+
+# API Compatibility
+
+A change is breaking if an existing caller stops compiling or starts behaving
+differently. Removed or renamed public symbols, narrowed parameter types,
+widened return types, and changed defaults all qualify.
+
+- Identify the public surface the diff touches, then find its callers with
+  `search_code` before judging severity.
+- A new required parameter is breaking; a new optional one is not.
+- Report each finding as `<symbol> · <what breaks> · <who calls it>`.
+```
+
+`tools_required` names registry tools the skill's recipe *consumes* — it does not
+grant anything. A name your agent has not registered is logged at load time, so a
+skill that cannot execute its own recipe is diagnosable rather than silently
+useless.
+
+## 2. Declare the sets
+
+Three top-level keys in `gaia-agent.yaml`:
+
+```yaml
+id: my-agent
+name: My Review Agent
+version: 0.1.0
+language: python
+
+# Always on, whichever set is active.
+skills:
+  - review-basics
+
+# Named, mutually exclusive. Exactly ONE is active per launch.
+skill_sets:
+  library:
+    - api-compatibility
+    - changelog-discipline
+  application:
+    - ux-regression
+    - changelog-discipline
+
+# Applies when nothing selects a set.
+default_skill_set: application
+```
+
+`changelog-discipline` is in both sets — sets overlap, they do not partition. The
+one thing a set may **not** do is re-declare a skill that is already in the
+always-on `skills:` list; that contradiction fails to parse.
+
+An entry is a plain name or a mapping:
+
+```yaml
+skill_sets:
+  library:
+    - api-compatibility                # required (the default)
+    - name: changelog-discipline
+      version: ">=0.1.0"               # recorded, not yet resolved
+      required: false                  # missing ⇒ logged and skipped
+```
+
+## 3. Point the agent at both
+
+```python
+from pathlib import Path
+from typing import ClassVar, List, Optional
+
+from gaia.agents.base.agent import Agent
+
+_HERE = Path(__file__).resolve().parent
+
+
+class MyReviewAgent(Agent):
+    # Highest-precedence discovery root: the skills you bundle always win over a
+    # same-named user or Claude Code copy.
+    SKILL_DIRS: ClassVar[List[str]] = [str(_HERE / "skills")]
+    # Opt in to the declarative blocks.
+    SKILL_MANIFEST: ClassVar[Optional[str]] = str(_HERE / "gaia-agent.yaml")
+```
+
+That is enough. `Agent.__init__` resolves a set and loads it — the always-on
+skills plus that set's, in declaration order.
+
+## 4. Choose the set at runtime
+
+Selection resolves in one order, every time:
+
+<Steps>
+<Step title="Explicit — `skill_set=`">
+  `MyReviewAgent(skill_set="library")`, which your CLI surfaces as
+  `--skill-set library`. Highest precedence, and never second-guessed.
+</Step>
+<Step title="Your selector hook">
+  Override `select_skill_set()` to answer from state the agent already has.
+</Step>
+<Step title="`default_skill_set`">
+  The manifest's declared default.
+</Step>
+</Steps>
+
+The hook is one method:
+
+```python
+    def select_skill_set(self) -> Optional[str]:
+        """Pick a set from the repository being reviewed."""
+        kind = self.detect_project_kind()      # your own logic
+        if kind is None:
+            # Unknown is a real answer. Returning None resolves the manifest's
+            # default explicitly — never guess a set.
+            return None
+        return "library" if kind == "library" else "application"
+```
+
+<Warning>
+  **Never guess, and never fall back.** A name neither the manifest declares
+  raises `SkillSetError` listing the valid sets — whether it came from
+  `--skill-set` or from your hook. An agent running with the wrong capability
+  bundle is worse than one that refuses to start, and a hook that returns a set
+  it invented is a wiring bug, not a reason to improvise.
+</Warning>
+
+## 5. Verify what actually loaded
+
+```python
+agent = MyReviewAgent(skill_set="library")
+
+agent.active_skill_set        # 'library'
+sorted(agent.loaded_skills)   # ['api-compatibility', 'changelog-discipline', 'review-basics']
+```
+
+The startup log names the set, the rule that chose it, and every skill that
+loaded:
+
+```
+Skill set 'library' active (chosen by: explicit) — loaded 3 of 3 declared
+skill(s): review-basics, api-compatibility, changelog-discipline
+```
+
+And from the CLI:
+
+```bash
+gaia skill list          # every discovered skill, with its root and precedence
+gaia skill info api-compatibility
+```
+
+Switching sets mid-session is one call — the previous set's skills are unloaded
+first, so a stale set never lingers in the prompt:
+
+```python
+agent.load_skill_set("application")
+```
+
+## Budget the set
+
+Loading a set injects each body into the system prompt. Three skills of ~250
+tokens each is ~750 tokens gone from a window your tool results were already
+using — enough to overflow a tight context and turn a working run into a
+`context_length_exceeded` error.
+
+Two habits keep it safe:
+
+- **Keep bodies short.** Procedure and judgement calls, not prose. If a skill
+  needs reference material, put it in a file the body links to — resources load
+  only when the agent actually reads them.
+- **Subtract the cost where you budget context.** If your agent sizes a
+  tool-result envelope against the window, take the loaded set's cost out of that
+  budget. The email agent's bulk-triage path does exactly this.
+
+## A shipped example
+
+The [email agent](https://github.com/amd/gaia/tree/main/hub/agents/email) is the
+reference consumer. It bundles six instruction-only skills and declares two sets —
+`personal` (triage, newsletter digests, travel itineraries) and `work` (triage,
+meeting scheduling, action-item extraction, escalation routing), with
+`inbox-triage` in both.
+
+Its selector keys off the connected mailbox: a personal Microsoft account
+activates `personal`, a work/school account activates `work`. A Gmail mailbox
+carries no equivalent signal, so its kind is unknown, the selector returns `None`,
+and the manifest's default applies — explicitly, never by assuming a work mailbox
+is personal.
+
+## Related
+
+- [Agent Skills](/spec/agent-skills#skill-sets) — architecture, discovery, selection
+- [Skill Format](/plans/skill-format#manifest-side-grammar-skills-skill_sets-default_skill_set) — the full field grammar
+- [Custom Agents](/guides/custom-agent) — building the agent the skills attach to
+- [CLI Reference → Skills](/reference/cli#skills) — `gaia skill list|info|create|import|export`

--- a/docs/guides/email.mdx
+++ b/docs/guides/email.mdx
@@ -398,9 +398,12 @@ The set is chosen in this order:
 
 **Gmail resolves to the default.** Google has no equivalent of the Microsoft
 tenant claim, so a Gmail mailbox's kind is genuinely unknown and the declared
-default applies — it is never inferred to be personal from the mailbox contents.
-If you drive a work Gmail account, set `GAIA_EMAIL_ACCOUNT_TYPE=work` (or pass
-`--skill-set work`).
+default applies. In practice that means a *work* Gmail mailbox gets the
+`personal` set — by declared default, and logged, rather than by anything
+inferring the kind from your mail. **If you drive a work Gmail account, set
+`GAIA_EMAIL_ACCOUNT_TYPE=work` or pass `--skill-set work`.** The same holds for a
+Microsoft mailbox connected before this shipped: it carries no recorded kind
+until you reconnect it.
 
 Inspect what loaded with `gaia skill list`, or read the startup log line naming
 the active set and the rule that chose it. Full mechanism:

--- a/docs/guides/email.mdx
+++ b/docs/guides/email.mdx
@@ -394,6 +394,14 @@ The set is chosen in this order:
    a work/school account activates `work`. The kind is derived from the id_token
    `tid` claim when the mailbox is connected and stored with the connection, so
    nothing is re-derived per run. Pin it with `GAIA_EMAIL_ACCOUNT_TYPE=work`.
+
+   <Note>
+   Microsoft is now two connectors — `microsoft` (personal) and `microsoft_work`
+   — and the email agent only declares `microsoft` so far
+   ([#2629](https://github.com/amd/gaia/issues/2629) tracks wiring the work one).
+   Until that lands, the automatic `work` path is not reachable through this
+   agent: pin the set with `GAIA_EMAIL_ACCOUNT_TYPE=work` or `--skill-set work`.
+   </Note>
 3. **`default_skill_set`** (`personal`) — applies when the kind is unknown.
 
 **Gmail resolves to the default.** Google has no equivalent of the Microsoft

--- a/docs/guides/email.mdx
+++ b/docs/guides/email.mdx
@@ -372,6 +372,40 @@ When the calendar tools run (`list_calendar_events`, `accept_invite`, `decline_i
 (Google calendar scope was skipped during consent). Without an explicit provider setting the
 agent used to pick Google and fail. It now picks Outlook correctly.
 
+## Skill sets: personal vs work mailbox
+
+The agent bundles six **Agent Skills** — short playbooks it loads into its own
+prompt — and activates one **set** of them per launch, so the same agent behaves
+appropriately for the mailbox in front of it:
+
+| Set | Skills |
+|---|---|
+| `personal` (default) | `inbox-triage`, `newsletter-digest`, `travel-itinerary` |
+| `work` | `inbox-triage`, `meeting-scheduling`, `action-item-extraction`, `escalation-routing` |
+
+`inbox-triage` is in both — sets overlap rather than partition.
+
+The set is chosen in this order:
+
+1. **Explicit** — `gaia-agent-email serve --skill-set work`, or
+   `GAIA_EMAIL_SKILL_SET=work`. An undeclared name fails at startup naming the
+   valid sets; it never falls back.
+2. **Mailbox account type** — a personal Microsoft account activates `personal`,
+   a work/school account activates `work`. The kind is derived from the id_token
+   `tid` claim when the mailbox is connected and stored with the connection, so
+   nothing is re-derived per run. Pin it with `GAIA_EMAIL_ACCOUNT_TYPE=work`.
+3. **`default_skill_set`** (`personal`) — applies when the kind is unknown.
+
+**Gmail resolves to the default.** Google has no equivalent of the Microsoft
+tenant claim, so a Gmail mailbox's kind is genuinely unknown and the declared
+default applies — it is never inferred to be personal from the mailbox contents.
+If you drive a work Gmail account, set `GAIA_EMAIL_ACCOUNT_TYPE=work` (or pass
+`--skill-set work`).
+
+Inspect what loaded with `gaia skill list`, or read the startup log line naming
+the active set and the rule that chose it. Full mechanism:
+[Composing skills and skill sets](/guides/composing-skills).
+
 ## Dev mode: run the email agent from source
 
 The Agent UI talks to the email agent as an out-of-process **sidecar** — a

--- a/docs/plans/skill-format.mdx
+++ b/docs/plans/skill-format.mdx
@@ -157,6 +157,75 @@ The field name **`tools_required` is locked** as the cross-spec contract with
 | `metadata.gaia.tools` | list | no | Provided `@tool` declarations. Default: none (instruction-only). |
 | `metadata.gaia.tools_required` | list | no | Registry tool names consumed (recipe contract). Default: `[]`. |
 
+### Manifest-side grammar: `skills`, `skill_sets`, `default_skill_set`
+
+The fields above describe one skill. An **agent** declares which skills it
+composes in its `gaia-agent.yaml`, using three top-level keys
+([#2466](https://github.com/amd/gaia/issues/2466)):
+
+```yaml
+# Always-on: loaded on every launch, whichever set is active.
+skills:
+  - mailbox-hygiene                 # plain-string form
+  - name: incident-review           # mapping form
+    version: ">=0.1.0"
+    required: false
+
+# Named, mutually-exclusive bundles. Exactly ONE is active per launch.
+skill_sets:
+  personal: [inbox-triage, newsletter-digest]
+  work: [inbox-triage, meeting-scheduling]
+
+# Required whenever skill_sets is non-empty.
+default_skill_set: personal
+```
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `skills` | list | no | Always-on skill references. Default: `[]`. |
+| `skill_sets` | map | no | Set name → skill references. Default: `{}`. |
+| `default_skill_set` | string | only when `skill_sets` is non-empty | Which set applies when nothing selects one. |
+
+Each entry in `skills` or a set's list is either a **skill name** or a mapping:
+
+| Key | Type | Required | Description |
+|---|---|---|---|
+| `name` | string | yes | A skill name per [naming](#naming). |
+| `version` | string | no | SemVer or range. **Recorded, not resolved** in this phase — see below. |
+| `required` | bool | no | Default `true`. A missing `required: false` skill is logged and skipped; a missing required one fails the launch. |
+
+**Set names** use the same slug shape as skill names, capped at 32 chars:
+`^[a-z0-9]([a-z0-9-]{0,30}[a-z0-9])?$`.
+
+**Sets overlap; they do not partition.** The same skill may appear in several
+sets — that is how a shared capability stays available across contexts. What a
+set may *not* do is re-declare a skill already in the always-on `skills:` list;
+that is a contradiction (an always-on skill loads for every set) and fails to
+parse.
+
+Every malformed shape fails at manifest-parse time with a message naming the
+fix — a list that repeats a name, an empty set, a `default_skill_set` naming an
+undeclared set, an unrecognized key in a reference mapping, a non-boolean
+`required`. There is no partial acceptance: an agent either declares a coherent
+set of skills or does not load.
+
+<Note>
+**`version:` is a declaration surface only in this phase.** It is parsed,
+validated as a non-empty string, and surfaced — but no constraint solving
+happens until [#2467](https://github.com/amd/gaia/issues/2467) can install
+versioned skills from the marketplace. Until then, a bundled skill's version is
+whatever the agent package ships. This mirrors how `network:` permissions are
+recorded but not enforced in Phase 1.
+</Note>
+
+Selection semantics — the order a set is chosen in, the selector hook, and the
+fail-loud behaviour on an undeclared name — belong to the integration surface and
+live in [Agent Skills → Skill sets](/spec/agent-skills#skill-sets). The grammar
+above is implemented once, in
+[`gaia/skills/sets.py`](https://github.com/amd/gaia/blob/main/src/gaia/skills/sets.py),
+and consumed by both the manifest validator and the runtime, so the two cannot
+drift.
+
 ### Naming
 
 Skill names follow the Agent Skills rule: `^[a-z0-9]+(-[a-z0-9]+)*$`, ≤64 chars,
@@ -410,8 +479,10 @@ build against `OpenClawAdapter`.
   [Correcting the prior spec](#correcting-the-prior-spec)).
 - **Agent Manifest ([#462](https://github.com/amd/gaia/issues/462))** — a
   `gaia-agent.yaml` references skills by name + version range; `SKILL.md` is the
-  skill-level complement. The `skills:` block and its resolution live in
-  [Agent Skills → Agent Hub integration](/spec/agent-skills#agent-hub-integration).
+  skill-level complement. The keys are specified in
+  [manifest-side grammar](#manifest-side-grammar-skills-skill_sets-default_skill_set)
+  above; how a set is selected per launch is in
+  [Agent Skills → Skill sets](/spec/agent-skills#skill-sets).
 - **Agent bundles** — skill packaging relates to the existing agent bundle format
   (`.zip` + `bundle.json`, `BUNDLE_FORMAT_VERSION = 1`,
   [`export_import.py:40`](https://github.com/amd/gaia/blob/main/src/gaia/installer/export_import.py)).

--- a/docs/plans/skill-format.mdx
+++ b/docs/plans/skill-format.mdx
@@ -194,8 +194,12 @@ Each entry in `skills` or a set's list is either a **skill name** or a mapping:
 | `version` | string | no | SemVer or range. **Recorded, not resolved** in this phase — see below. |
 | `required` | bool | no | Default `true`. A missing `required: false` skill is logged and skipped; a missing required one fails the launch. |
 
-**Set names** use the same slug shape as skill names, capped at 32 chars:
-`^[a-z0-9]([a-z0-9-]{0,30}[a-z0-9])?$`.
+**Set names** use the same slug shape as skill names, capped at 32 chars — a
+lowercase alphanumeric start and end with internal hyphens:
+
+```
+^[a-z0-9]([a-z0-9-]{0,30}[a-z0-9])?$
+```
 
 **Sets overlap; they do not partition.** The same skill may appear in several
 sets — that is how a shared capability stays available across contexts. What a

--- a/docs/plans/skill-format.mdx
+++ b/docs/plans/skill-format.mdx
@@ -5,7 +5,7 @@ icon: "puzzle-piece"
 ---
 
 <Info>
-  **Grounds on (exists today):** [`src/gaia/skills/`](https://github.com/amd/gaia/tree/main/src/gaia/skills) — the shipped runtime: `format.py` (parser/writer/validator), `manager.py` (`SkillManager`, discovery + precedence), `loader.py` (`<skill>/<tool>` registration), `permissions.py` (grammar + connector bridge), `cli.py` (`gaia skill`) · [`src/gaia/agents/base/agent.py`](https://github.com/amd/gaia/blob/main/src/gaia/agents/base/agent.py) (`Agent.load_skill`, `unload_skill`, `SKILL_DIRS`, `skill_manager`, `loaded_skills`) · [`src/gaia/agents/base/tools.py`](https://github.com/amd/gaia/blob/main/src/gaia/agents/base/tools.py) (`@tool`, `_TOOL_REGISTRY`) · [`src/gaia/agents/registry.py`](https://github.com/amd/gaia/blob/main/src/gaia/agents/registry.py) (`KNOWN_TOOLS`, `namespaced_agent_id`) · [`src/gaia/connectors/providers/base.py`](https://github.com/amd/gaia/blob/main/src/gaia/connectors/providers/base.py) (`ConnectorRequirement`) · [`src/gaia/ui/routers/agents.py`](https://github.com/amd/gaia/blob/main/src/gaia/ui/routers/agents.py) (`/api/agents`, the panel to mirror)
+  **Grounds on (exists today):** [`src/gaia/skills/`](https://github.com/amd/gaia/tree/main/src/gaia/skills) — the shipped runtime: `format.py` (parser/writer/validator), `manager.py` (`SkillManager`, discovery + precedence), `loader.py` (`<skill>/<tool>` registration), `permissions.py` (grammar + connector bridge), `cli.py` (`gaia skill`), `sets.py` (the `skills:` / `skill_sets:` grammar) · [`src/gaia/agents/base/agent.py`](https://github.com/amd/gaia/blob/main/src/gaia/agents/base/agent.py) (`Agent.load_skill`, `unload_skill`, `SKILL_DIRS`, `skill_manager`, `loaded_skills`, `SKILL_MANIFEST`, `load_skill_set`, `select_skill_set`) · [`src/gaia/agents/base/tools.py`](https://github.com/amd/gaia/blob/main/src/gaia/agents/base/tools.py) (`@tool`, `_TOOL_REGISTRY`) · [`src/gaia/agents/registry.py`](https://github.com/amd/gaia/blob/main/src/gaia/agents/registry.py) (`KNOWN_TOOLS`, `namespaced_agent_id`) · [`src/gaia/connectors/providers/base.py`](https://github.com/amd/gaia/blob/main/src/gaia/connectors/providers/base.py) (`ConnectorRequirement`) · [`src/gaia/ui/routers/agents.py`](https://github.com/amd/gaia/blob/main/src/gaia/ui/routers/agents.py) (`/api/agents`, the panel to mirror)
 
   **Still proposed (not written yet):** the `/api/skills` router and Agent UI panel, `gaia skill install|remove|search|publish|update` (marketplace, [#2467](https://github.com/amd/gaia/issues/2467)), `gaia skill migrate` (Phase 3), the permission sandbox for local-capability domains, and tier-ceiling enforcement ([#1019](https://github.com/amd/gaia/issues/1019)). Every such symbol is marked **PROPOSED** where it appears.
 </Info>
@@ -935,6 +935,13 @@ phases are additive. Each phase holds the prior floor until it lands.
 - **`gaia.skills.permissions`** — the `<domain>:<level>[:scope]` grammar, the
   connector bridge for `network`/`mcp`, and the loud refusal of local-capability
   domains.
+- **`gaia.skills.sets`** ([#2466](https://github.com/amd/gaia/issues/2466)) — the
+  declarative `skills:` / `skill_sets:` / `default_skill_set:` manifest grammar
+  (see [Manifest-side grammar](#manifest-side-grammar-skills-skill_sets-default_skill_set)),
+  parsed once and shared by `gaia.hub.manifest` and the base `Agent`, plus
+  per-launch selection (`SKILL_MANIFEST`, `select_skill_set`, `load_skill_set`).
+  An undeclared set name raises `SkillSetError` rather than falling back. The
+  email agent is the reference consumer.
 - **`Agent.load_skill` / `unload_skill` / `SKILL_DIRS` / `skill_manager` /
   `loaded_skills`** — plus `get_skills_system_prompt()`, auto-discovered by
   `_get_mixin_prompts()`, which returns `""` when no skill is loaded so every
@@ -1052,8 +1059,11 @@ Only the enforcement, REST/UI, and marketplace layers are greenfield.
 | Tool registration | `register_skill_tools`, `unregister_skill_tools` (`<skill>/<tool>`, no partial load) | `skills/loader.py` | **Exists** (#888) |
 | Permission grammar + bridge | `Permission`, `parse_permissions`, `connector_requirements`, `refuse_unbridged_permissions`, `CONNECTOR_BRIDGED_DOMAINS`, `LOCAL_CAPABILITY_DOMAINS` | `skills/permissions.py` | **Exists** (#888) — bridge only |
 | Agent integration | `load_skill`, `unload_skill`, `SKILL_DIRS`, `skill_manager`, `loaded_skills`, `get_skills_system_prompt` | `agents/base/agent.py` | **Exists** (#888) |
+| Skill-set grammar | `SkillRef`, `SkillSets`, `SkillSetResolution`, `parse_skill_sets` | `skills/sets.py` | **Exists** (#2466) — `skills:` / `skill_sets:` / `default_skill_set:` |
+| Manifest wiring | `AgentManifest.skill_sets` | `hub/manifest.py` | **Exists** (#2466) — malformed blocks raise `ManifestError` |
+| Skill-set selection | `SKILL_MANIFEST`, `skill_sets`, `select_skill_set`, `resolve_skill_set`, `load_skill_set`, `active_skill_set` | `agents/base/agent.py` | **Exists** (#2466) — one set per launch |
 | CLI | `gaia skill list\|info\|create\|import\|export` | `skills/cli.py` | **Exists** (#888) |
-| Errors | `SkillError`, `SkillValidationError`, `SkillNotFoundError`, `SkillPermissionError` | `skills/errors.py` | **Exists** (#888) |
+| Errors | `SkillError`, `SkillValidationError`, `SkillNotFoundError`, `SkillPermissionError`, `SkillSetError` | `skills/errors.py` | **Exists** (#888, #2466) |
 | **Permission sandbox / tier-ceiling enforcement** | — | **NOT FOUND** | **Greenfield — PROPOSED** (#1019) |
 | **`/api/skills` router + UI panel** | — | **NOT FOUND** | **Greenfield — PROPOSED** |
 | **`gaia skill install\|remove\|search\|publish\|update\|migrate`** | — | **NOT FOUND** | **Greenfield — PROPOSED** (#2467 / Phase 3) |

--- a/docs/spec/agent-skills.mdx
+++ b/docs/spec/agent-skills.mdx
@@ -10,13 +10,16 @@ icon: "puzzle-piece"
 **Shipped:** the `gaia.skills` runtime — `SKILL.md` parser + validator, the three
 discovery roots with auditable precedence, progressive disclosure,
 `<skill>/<tool>` tool registration, `Agent.load_skill` / `unload_skill`, and
-`gaia skill list|info|create|import|export`.
+`gaia skill list|info|create|import|export`. Plus the declarative
+`skills:` / `skill_sets:` manifest blocks and per-launch
+[skill-set selection](#skill-sets) ([#2466](https://github.com/amd/gaia/issues/2466)),
+whose reference consumer is the email agent.
 
 **Still proposed:** the permission sandbox and tier-ceiling enforcement
 ([#1019](https://github.com/amd/gaia/issues/1019)), the skill marketplace and
 `install`/`remove`/`search`/`publish`
-([#2467](https://github.com/amd/gaia/issues/2467)), the `/api/skills` router and
-Agent UI panel, and the `skills:` block in `gaia-agent.yaml`.
+([#2467](https://github.com/amd/gaia/issues/2467)), and the `/api/skills` router
+and Agent UI panel.
 
 This spec defines the **architecture and integration model** for skills. The
 on-disk `SKILL.md` schema (full field reference, permission grammar, tier
@@ -251,10 +254,10 @@ agent reads or executes them — not at trigger time.
 
 A skill is never globally active. It is scoped to an agent two ways:
 
-- **Declared** — the agent calls `load_skill` (typically in `_register_tools`),
-  and points `SKILL_DIRS` at any `skills/` folder it bundles. Resolving a
-  `skills:` block in [`gaia-agent.yaml`](#agent-hub-integration) declaratively is
-  proposed, not shipped.
+- **Declared** — either imperatively, by calling `load_skill` (typically in
+  `_register_tools`), or declaratively, via the `skills:` / `skill_sets:` blocks
+  in [`gaia-agent.yaml`](#skill-sets). Either way the agent points `SKILL_DIRS`
+  at any `skills/` folder it bundles.
 - **Granted** — a skill carrying connector-bridged permissions contributes
   `ConnectorRequirement`s to the agent, reusing the per-agent grant model from the
   connectors framework. An agent only ever sees skills explicitly in scope (least
@@ -317,6 +320,122 @@ Agent UI panel and is not yet available. This matches Claude Code's dual-invocat
 standard's `allowed-tools`/`disallowed-tools` keys are parsed but **not** used as
 a permission mechanism (see [Skill Format](/plans/skill-format#adopted-base-agent-skills-standard)) —
 GAIA's permissions come from `metadata.gaia`.
+
+## Skill sets
+
+One agent, more than one job. The same email assistant should behave differently
+against a personal mailbox than against a work one; the same code agent should
+carry different conventions in different repositories. Hardcoding `load_skill`
+calls forces the author to pick one behaviour, or to ship two agents.
+
+A **skill set** is a *named, mutually-exclusive bundle of skills, exactly one of
+which is active per launch*. It is declared in `gaia-agent.yaml`, layered on top
+of an always-on `skills:` list:
+
+```yaml
+# Always-on — loaded for every launch, whichever set is active.
+skills:
+  - mailbox-hygiene
+
+# Named bundles. Exactly ONE is active per launch.
+skill_sets:
+  personal: [inbox-triage, newsletter-digest, travel-itinerary]
+  work: [inbox-triage, meeting-scheduling, action-item-extraction]
+
+default_skill_set: personal
+```
+
+The field grammar (reference shapes, `version`, `required`, set-name rules, and
+every fail-loud parse error) is specified in
+[Skill Format](/plans/skill-format#manifest-side-grammar-skills-skill_sets-default_skill_set).
+This section owns *selection*.
+
+**Sets overlap; they are not a partition.** `inbox-triage` above belongs to both
+sets — a shared capability stays available in every context it applies to. Only
+the always-on list is exclusive: a set may not re-declare a skill that is already
+always on.
+
+### Selection order
+
+<Steps>
+<Step title="Explicit — the generic override">
+The `skill_set=` argument to `Agent.__init__`, surfaced by an agent's entry point
+as `--skill-set <name>`. Highest precedence, and **never second-guessed** — an
+explicit request is not re-examined against agent state.
+</Step>
+<Step title="The agent's selector hook">
+`Agent.select_skill_set() -> str | None`. Override it to key the active set off
+something the agent already knows — a connected account's type, a workspace mode,
+a device profile. Returning `None` means "no opinion" and defers to the default.
+Consulted only when nothing explicit was passed.
+</Step>
+<Step title="`default_skill_set`">
+The manifest's declared default. Required whenever `skill_sets` is non-empty, so
+a launch that selects nothing still resolves a set **explicitly** rather than
+running with an arbitrary one.
+</Step>
+</Steps>
+
+`resolve_skill_set()` returns which set won *and which rule chose it*
+(`explicit` / `selector` / `default` / `none`), so "why is this set active?" is
+answerable from a log line rather than by reading code.
+
+<Warning>
+**An undeclared set name never falls back.** Whether it came from `--skill-set`
+or from a selector hook, a name the agent does not declare raises
+`SkillSetError` naming the valid sets. Launching with the wrong capability
+bundle is worse than not launching — a work mailbox quietly handed the personal
+set is precisely the silent-wrong-answer this indirection exists to prevent
+(GAIA's [no-silent-fallbacks](https://github.com/amd/gaia/blob/main/CLAUDE.md)
+rule).
+
+The same applies to a *missing* signal. If a selector cannot determine the
+context, it must return `None` — which resolves the declared default explicitly —
+rather than guess a set.
+</Warning>
+
+### Loading
+
+`load_skill_set()` runs at the end of `Agent.__init__` and loads the always-on
+list plus the resolved set, in declaration order, each through the same
+`load_skill` path (and therefore the same permission gate). A skill declared
+`required: false` that no discovery root provides is logged and skipped; every
+other failure propagates.
+
+Calling it again with a different name **switches** sets: skills the previous
+resolution loaded and the new one does not declare are unloaded first, so a stale
+set never bleeds into the prompt. `active_skill_set` is the current answer, or
+`None` for an agent that declares no sets — which is every agent that has not
+adopted the blocks, whose behaviour is unchanged.
+
+<Note>
+**A skill body costs context.** Loading a set injects each skill's Markdown body
+into the system prompt, which is prompt budget the agent's own tool results no
+longer have. An agent with a tight context envelope must account for the loaded
+set's cost, not assume it is free — the email agent's bulk-triage path subtracts
+it from its result-envelope budget for exactly this reason. Budget the set, and
+keep bodies short.
+</Note>
+
+### Reference consumer: the email agent
+
+The email agent ([`hub/agents/email/`](https://github.com/amd/gaia/tree/main/hub/agents/email))
+is the shipped worked example. It bundles six instruction-only skills and declares
+two sets — `personal` (triage, newsletter digests, travel itineraries) and `work`
+(triage, meeting scheduling, action-item extraction, escalation routing) — with
+`inbox-triage` deliberately in both.
+
+Its selector maps the connected mailbox's account type onto a set: a personal
+Microsoft account gets `personal`, a work/school account gets `work`. The kind is
+derived at connect time from the id_token `tid` claim (personal accounts always
+carry the well-known consumers tenant; work/school accounts carry the
+organization's Entra tenant id) and recorded on the connection, so no agent
+re-derives it. A Gmail mailbox has no equivalent claim, so its kind is genuinely
+unknown and the selector returns `None` — the manifest's `default_skill_set`
+applies, explicitly.
+
+For a step-by-step author walkthrough see
+[Composing skills and skill sets](/guides/composing-skills).
 
 ## Permission & security model
 
@@ -411,10 +530,9 @@ agent packages from the [Agent Hub Restructure](/spec/agent-hub-restructure).
 agents that use them. Major = breaking tool-signature or permission change;
 minor = additive; patch = fixes. Agent manifests pin ranges.
 
-**The `gaia-agent.yaml` link (proposed).** An agent declares the skills it
-composes. This extends the manifest from the restructure spec with a `skills:`
-block. Nothing reads it yet — a shipped agent composes skills by calling
-`load_skill` and setting `SKILL_DIRS`:
+**The `gaia-agent.yaml` link.** An agent declares the skills it composes in its
+manifest, and the base `Agent` resolves and loads them at startup — see
+[Skill sets](#skill-sets):
 
 ```yaml
 id: web
@@ -436,9 +554,16 @@ interfaces:
   api_server: true
 ```
 
-The hub would resolve a `skills:` block at install time the way `dependencies:`
-resolves agent-to-agent links today: topological install order, highest version
-satisfying all constraints, fail-loud on conflict or circular dependency.
+Set `SKILL_MANIFEST` to the manifest's path to opt in; `SKILL_DIRS` still points
+at any bundled `skills/` folder. An agent that sets neither is unaffected.
+
+**Install-time resolution is still proposed.** Today a declared skill must be
+resolvable from a discovery root — bundled with the agent, or already in
+`~/.gaia/skills/` — and `version:` is recorded but not solved. Having the hub
+resolve a `skills:` block at *install* time the way `dependencies:` resolves
+agent-to-agent links (topological order, highest version satisfying all
+constraints, fail-loud on conflict or cycle) arrives with the marketplace
+([#2467](https://github.com/amd/gaia/issues/2467)).
 
 ## Agent Skills / Claude Code compatibility
 
@@ -497,6 +622,7 @@ standard intentionally leaves open.
 ## Related
 
 - [Skill Format](/plans/skill-format) — `SKILL.md` schema, permission grammar, tiers, CLI
+- [Composing skills and skill sets](/guides/composing-skills) — author walkthrough
 - [CLI Reference → Skills](/reference/cli#skills) — `gaia skill list|info|create|import|export`
 - [Agent Hub Restructure](/spec/agent-hub-restructure) — `gaia-agent.yaml`, packaging, distribution
 - [Agent Hub](/plans/agent-hub) — marketplace vision

--- a/hub/agents/email/npm/CHANGELOG.md
+++ b/hub/agents/email/npm/CHANGELOG.md
@@ -6,6 +6,7 @@ behind any entry — API shapes, endpoints, and version semantics — see
 
 ## Unreleased
 
+<<<<<<< HEAD
 - **The agent can now tell you which inbound mail is waiting on your reply —
   not just which of your own messages went unanswered.** Previously the agent
   could only flag sent mail nobody replied to; a colleague's "did you get a
@@ -34,6 +35,21 @@ behind any entry — API shapes, endpoints, and version semantics — see
   still uses your exact wording when you hand it over yourself. Sending is
   unchanged — every draft still needs your confirmation before it goes out
   (#2524).
+=======
+- **The agent now works differently for a personal mailbox than for a work one.**
+  It used to bring exactly the same instincts to both: the same triage advice for
+  a mailbox full of newsletters and flight confirmations as for one full of
+  meeting invites and things people are waiting on you for. It now ships six
+  built-in skills and turns on one set of them per run — `personal` (inbox triage,
+  newsletter digests, trip itineraries) or `work` (inbox triage, meeting
+  scheduling, action items, escalation). For an Outlook mailbox it picks the set
+  itself from the kind of Microsoft account you connected. Gmail doesn't say which
+  kind it is, so a Gmail mailbox gets `personal` unless you pin one — start the
+  sidecar with `extraArgs: ["--skill-set", "work"]` or
+  `env: { GAIA_EMAIL_SKILL_SET: "work" }`. This changes how the agent approaches
+  your mail, not what it can do: same endpoints, same tools, same permissions, no
+  schema bump (#2466).
+>>>>>>> 7f92c02f (docs(email): document bundled skills and account-keyed skill sets)
 - **A trashed email is recoverable any time it's still in Trash — not just for
   a few seconds after you delete it.** The only way back used to be a short
   undo window right after trashing; miss it, and the agent told you the

--- a/hub/agents/email/npm/CHANGELOG.md
+++ b/hub/agents/email/npm/CHANGELOG.md
@@ -6,7 +6,6 @@ behind any entry — API shapes, endpoints, and version semantics — see
 
 ## Unreleased
 
-<<<<<<< HEAD
 - **The agent can now tell you which inbound mail is waiting on your reply —
   not just which of your own messages went unanswered.** Previously the agent
   could only flag sent mail nobody replied to; a colleague's "did you get a
@@ -35,7 +34,6 @@ behind any entry — API shapes, endpoints, and version semantics — see
   still uses your exact wording when you hand it over yourself. Sending is
   unchanged — every draft still needs your confirmation before it goes out
   (#2524).
-=======
 - **The agent now works differently for a personal mailbox than for a work one.**
   It used to bring exactly the same instincts to both: the same triage advice for
   a mailbox full of newsletters and flight confirmations as for one full of
@@ -49,7 +47,6 @@ behind any entry — API shapes, endpoints, and version semantics — see
   `env: { GAIA_EMAIL_SKILL_SET: "work" }`. This changes how the agent approaches
   your mail, not what it can do: same endpoints, same tools, same permissions, no
   schema bump (#2466).
->>>>>>> 7f92c02f (docs(email): document bundled skills and account-keyed skill sets)
 - **A trashed email is recoverable any time it's still in Trash — not just for
   a few seconds after you delete it.** The only way back used to be a short
   undo window right after trashing; miss it, and the agent told you the

--- a/hub/agents/email/npm/README.md
+++ b/hub/agents/email/npm/README.md
@@ -139,9 +139,11 @@ and turns on one **set** of them per run:
   and deciding what needs escalating.
 
 It picks the set automatically for an Outlook mailbox — a personal Microsoft
-account gets the personal set, a work or school account gets the work set. Gmail
-doesn't tell anyone which kind it is, so a Gmail mailbox gets the personal set
-unless you say otherwise.
+account gets the personal set, a work or school account gets the work set. Two
+mailboxes need you to say which you want: Gmail, which doesn't expose the kind at
+all, and a work or school Microsoft account, whose connector the agent doesn't
+offer yet ([#2629](https://github.com/amd/gaia/issues/2629)). Both fall back to
+the personal set until you pin one.
 
 To pin it yourself, start the sidecar with the set you want:
 

--- a/hub/agents/email/npm/README.md
+++ b/hub/agents/email/npm/README.md
@@ -127,6 +127,36 @@ GAIA connector store.)
 Want to try it without writing code? Run `npx @amd-gaia/agent-email playground`
 for a local page to test triage, drafting, and a live send.
 
+## Personal mailbox vs work mailbox
+
+The agent behaves differently depending on the kind of mailbox it's connected to.
+It ships six built-in **skills** — short playbooks it loads into its own thinking —
+and turns on one **set** of them per run:
+
+- **Personal** (the default): inbox triage, newsletter digests, and building a trip
+  itinerary out of scattered booking confirmations.
+- **Work**: inbox triage, meeting scheduling, pulling action items out of threads,
+  and deciding what needs escalating.
+
+It picks the set automatically for an Outlook mailbox — a personal Microsoft
+account gets the personal set, a work or school account gets the work set. Gmail
+doesn't tell anyone which kind it is, so a Gmail mailbox gets the personal set
+unless you say otherwise.
+
+To pin it yourself, start the sidecar with the set you want:
+
+```ts
+const sidecar = await startSidecar({
+  binaryPath,
+  port: 8131,
+  extraArgs: ["--skill-set", "work"], // or env: { GAIA_EMAIL_SKILL_SET: "work" }
+});
+```
+
+This changes how the agent *approaches* your mail, not what it's allowed to do —
+the tools, permissions, and API are identical either way. Full detail in
+[`SPEC.md`](https://github.com/amd/gaia/blob/agent-pkg-email-v0.5.0/hub/agents/email/npm/SPEC.md).
+
 ## How it works
 
 Three pieces, all on your own machine — no cloud, no separate GAIA install:

--- a/hub/agents/email/npm/SKILL.md
+++ b/hub/agents/email/npm/SKILL.md
@@ -12,6 +12,14 @@ talks to it over local HTTP. There is **no Python** and no separate GAIA install
 
 Follow these steps to wire it into an app.
 
+> **This file is NOT one of the agent's own skills.** It is the integration
+> playbook — how *you* wire this npm package into an app. The sidecar separately
+> bundles six **Agent Skills** at `gaia_agent_email/skills/<name>/SKILL.md`, which
+> are instructions the *email agent itself* loads into its own prompt at runtime.
+> Same filename, different artifact: don't load those into your assistant, and
+> don't ship this one as an agent skill. See
+> [Skill sets](#skill-sets--pin-the-agents-behaviour-for-a-work-mailbox) below.
+
 ## 1. Install
 
 ```bash
@@ -325,6 +333,45 @@ rather than returning the same 200 shape a real, found-nothing cycle would (#252
 The Python host also ships a thin-client CLI over this same surface:
 `gaia email autonomy {status|set-level|pause|resume|run|trust|kill}` (#2516).
 
+## Skill sets — pin the agent's behaviour for a work mailbox
+
+The agent bundles six Agent Skills and activates one **set** per launch, so it
+approaches a personal mailbox differently from a work one. Nothing in the API
+changes — same endpoints, same tools, same permissions — only how the agent
+reasons about the mail.
+
+| Set | Skills it loads |
+|-----|-----------------|
+| `personal` (default) | `inbox-triage`, `newsletter-digest`, `travel-itinerary` |
+| `work` | `inbox-triage`, `meeting-scheduling`, `action-item-extraction`, `escalation-routing` |
+
+**It usually chooses for itself.** For an Outlook mailbox, GAIA records at connect
+time whether the Microsoft account is personal or work/school (from the `tid`
+tenant claim in the OAuth `id_token`), and the agent maps that onto the matching
+set. **Gmail carries no equivalent claim**, so a Gmail-only mailbox has an unknown
+kind and resolves through the manifest default — `personal`. A work Gmail mailbox
+is therefore something you should pin explicitly.
+
+Two ways to pin it at spawn time, both via `startSidecar` — use either, not both:
+
+```ts
+const sidecar = await startSidecar({
+  binaryPath,
+  port: 8131,
+  // CLI flag: validated against the declared sets, so a typo fails at startup.
+  extraArgs: ["--skill-set", "work"],
+  // Env var, equivalent — and the form to use if you spawn the binary yourself:
+  // env: { GAIA_EMAIL_SKILL_SET: "work" },
+});
+```
+
+Either one pins the set for **every** session that sidecar serves and overrides the
+mailbox-derived choice. To let the agent do the mapping but tell it what kind of
+mailbox it has, set `GAIA_EMAIL_ACCOUNT_TYPE` to `personal` or `work` instead.
+
+Only `personal` and `work` are declared. An undeclared name never silently falls
+back — the sidecar refuses to start and names the valid sets.
+
 ## Running in a server / long-lived app
 
 - **`fetchBinary` is a build step**, not per request (network + SHA verify). Run it
@@ -424,6 +471,11 @@ Until then the binary boots, but the first `triage` returns **HTTP 502**.
   routes for them yet, so don't look for `client.scheduleSend()` /
   `client.snooze()` / a voice, follow-up, or waiting-on-you method — they
   don't exist (and none of these moves `SCHEMA_VERSION`).
+- **A Gmail mailbox always gets the `personal` skill set unless you pin one.** The
+  set is normally derived from the Microsoft account kind, and Gmail exposes no
+  equivalent signal — so pass `--skill-set work` (or `GAIA_EMAIL_SKILL_SET=work`)
+  for a work Gmail mailbox, or the agent won't load the meeting / action-item /
+  escalation skills. This affects judgement only; no endpoint or tool changes.
 - **ESM-only.** `require("@amd-gaia/agent-email")` fails; use `import` / dynamic
   `import()`.
 

--- a/hub/agents/email/npm/SPEC.md
+++ b/hub/agents/email/npm/SPEC.md
@@ -711,9 +711,11 @@ Three consequences worth knowing:
 
 - **Gmail has no equivalent claim**, so a Gmail-only mailbox has no account type to
   read. The kind is genuinely **unknown**, and the manifest's `default_skill_set`
-  applies **explicitly** — a work mailbox is never silently treated as personal by
-  assumption. Pin `GAIA_EMAIL_ACCOUNT_TYPE` or `--skill-set` when the mailbox kind
-  matters.
+  applies. Be clear about what that means: a *work* Gmail mailbox does get the
+  `personal` set — not because anything inferred it from the mailbox, but because
+  that is the declared default, and the resolution is logged. Nothing guesses;
+  nothing is silent; the default is still a default. **Pin
+  `GAIA_EMAIL_ACCOUNT_TYPE=work` or `--skill-set work` for a work Gmail mailbox.**
 - **The kind is recorded when the connection is made.** A Microsoft mailbox
   connected before this feature shipped carries no `account_type` until it is
   reconnected, so it too resolves through the default.

--- a/hub/agents/email/npm/SPEC.md
+++ b/hub/agents/email/npm/SPEC.md
@@ -553,7 +553,9 @@ await dev.client.triage({ payload: { /* … */ } });
 
 The `serve` CLI (`gaia_agent_email.server:main`) accepts `--host`, `--port`
 (rejects the reserved 4001), `--reload` (import-string app + watches the package
-dir; add `--reload-dir` for your core checkout), `--dev` (implies `--reload`), and
+dir; add `--reload-dir` for your core checkout), `--dev` (implies `--reload`),
+`--skill-set <name>` (pin a bundled [skill set](#skill-sets-2466) for every session
+instead of letting the mailbox's account type choose), and
 `--print-openapi`. Running without `GAIA_EMAIL_SIDECAR_TOKEN` disables the caller
 token (local dev only, logged loudly); Host/Origin protection still applies.
 Auto-reload resets in-process `/v1/email/agent/*` sessions — irrelevant to the
@@ -635,6 +637,121 @@ The full GAIA email agent does more on the live mailbox
 (label, move, mark spam) and calendar (detect / conflicts); those remaining actions are
 connector-gated by definition and are **not exposed through this package's REST API
 yet**.
+
+## Skill sets (#2466)
+
+The agent bundles six **Agent Skills** and activates one named **set** of them per
+launch, so a personal mailbox and a work mailbox get different judgement out of the
+same binary — newsletters and trip itineraries for one, meetings and action items
+for the other.
+
+> **Two different files in this package are named `SKILL.md`. They are not the
+> same kind of artifact.**
+>
+> - [`SKILL.md`](./SKILL.md), beside this file, is the **integration playbook** —
+>   instructions for an AI coding assistant helping a developer wire this npm
+>   package into an app.
+> - `gaia_agent_email/skills/<name>/SKILL.md`, inside the sidecar, are **Agent
+>   Skills** — instructions the *email agent itself* loads into its own prompt at
+>   runtime to do email work better.
+>
+> Different audience, different format. Everything in this section is about the
+> second kind; nothing here changes the integration playbook.
+
+### The bundled skills
+
+Each is a Markdown procedure (`skills/<name>/SKILL.md` in the sidecar), loaded into
+the agent's system prompt when its set is active:
+
+| Skill | What it makes the agent better at |
+|-------|-----------------------------------|
+| `inbox-triage` | Sorting an inbox into what needs a reply, what needs a decision, and what is just noise. |
+| `newsletter-digest` | Condensing newsletters and bulk mail into one short digest, then clearing them out. |
+| `travel-itinerary` | Assembling scattered booking confirmations into one chronological itinerary. |
+| `meeting-scheduling` | Turning meeting requests into calendar decisions — accept, decline, or propose another time. |
+| `action-item-extraction` | Pulling the concrete commitments out of a thread: who owes what, by when. |
+| `escalation-routing` | Deciding what needs attention now, what can wait, and what belongs to someone else. |
+
+### The two sets
+
+Declared in the agent's `gaia-agent.yaml`; **exactly one is active per launch**:
+
+| Set | Skills |
+|-----|--------|
+| `personal` (`default_skill_set`) | `inbox-triage`, `newsletter-digest`, `travel-itinerary` |
+| `work` | `inbox-triage`, `meeting-scheduling`, `action-item-extraction`, `escalation-routing` |
+
+`inbox-triage` is in **both** — sets **overlap**, they do not partition. (A skill
+that should load for every set belongs in the manifest's top-level `skills:` list
+instead; this agent declares none.)
+
+### Resolution order
+
+1. **Explicit request** — the `--skill-set` flag or `GAIA_EMAIL_SKILL_SET`. Wins
+   over everything.
+2. **The agent's selector** — `EmailTriageAgent.select_skill_set()` maps the
+   connected mailbox's account type onto a set: `personal` → `personal`, `work` →
+   `work`.
+3. **`default_skill_set`** from the manifest (`personal`), used when the account
+   type is unknown.
+
+An **undeclared set name never falls back** — it raises at startup naming the valid
+sets, per GAIA's no-silent-fallbacks rule. `--skill-set` additionally rejects an
+undeclared name at argument-parse time.
+
+### How the account type is derived
+
+At connect time GAIA classifies a **Microsoft** account from the `tid` (tenant id)
+claim of its OAuth `id_token`: the well-known consumers tenant means a personal
+account (Outlook.com / Hotmail / Live), any other tenant id means a work or school
+(Entra ID) account. The result is stored on the connection and exposed as
+`account_type` (`"personal"` / `"work"`) by the GAIA connector store.
+
+Three consequences worth knowing:
+
+- **Gmail has no equivalent claim**, so a Gmail-only mailbox has no account type to
+  read. The kind is genuinely **unknown**, and the manifest's `default_skill_set`
+  applies **explicitly** — a work mailbox is never silently treated as personal by
+  assumption. Pin `GAIA_EMAIL_ACCOUNT_TYPE` or `--skill-set` when the mailbox kind
+  matters.
+- **The kind is recorded when the connection is made.** A Microsoft mailbox
+  connected before this feature shipped carries no `account_type` until it is
+  reconnected, so it too resolves through the default.
+- **No new permission or scope** is involved — the claim is already in the token
+  the connect flow receives.
+
+### Configuration
+
+| Surface | Values | Effect |
+|---------|--------|--------|
+| `--skill-set <name>` (sidecar `serve`) | a declared set name | Pins the set for **every** agent session this sidecar serves. Validated against the manifest; exported as `GAIA_EMAIL_SKILL_SET` so per-request sessions see it. |
+| `GAIA_EMAIL_SKILL_SET` | a declared set name | Same effect, as an env var. Backs `EmailAgentConfig.skill_set`. |
+| `GAIA_EMAIL_ACCOUNT_TYPE` | `personal` \| `work` | Pins the **mailbox kind** instead of the set, letting the selector do the mapping. Backs `EmailAgentConfig.account_type`. An invalid value raises rather than being ignored. |
+
+From this package, either one reaches the sidecar through `startSidecar`:
+
+```ts
+const sidecar = await startSidecar({
+  binaryPath,
+  port: 8131,
+  extraArgs: ["--skill-set", "work"],        // the CLI flag …
+  // env: { GAIA_EMAIL_SKILL_SET: "work" }, // … or the env var. Equivalent.
+});
+```
+
+### What skill sets do NOT change
+
+The bundled skills are **instruction-only**: none declares `tools:` or
+`permissions:`, so activating a set changes only what the agent knows how to do
+well, never what it is *able* to do.
+
+- The agent's tool count is unchanged (59), and so is every tool's behaviour.
+- The REST and MCP contracts are unchanged — no new endpoints, no schema bump, and
+  `SCHEMA_VERSION` does not move.
+- The connector surface and the permission model are unchanged.
+
+Relocating the agent's tool implementations into skills is separate future work
+(#2672) and has **not** happened.
 
 ## Browser / Electron renderer (`./client`)
 

--- a/hub/agents/email/npm/SPEC.md
+++ b/hub/agents/email/npm/SPEC.md
@@ -716,6 +716,13 @@ Three consequences worth knowing:
   that is the declared default, and the resolution is logged. Nothing guesses;
   nothing is silent; the default is still a default. **Pin
   `GAIA_EMAIL_ACCOUNT_TYPE=work` or `--skill-set work` for a work Gmail mailbox.**
+- **The work path is not reachable through this agent yet.** GAIA now splits
+  Microsoft into two connectors — `microsoft` (personal, `consumers` authority)
+  and `microsoft_work` — and only `microsoft` is in this agent's
+  `REQUIRED_CONNECTORS` ([#2629](https://github.com/amd/gaia/issues/2629) tracks
+  the rest). The derivation reads both connectors, so it starts working the moment
+  that lands; until then, pin `work` explicitly. The `tid` classification itself is
+  already correct for either.
 - **The kind is recorded when the connection is made.** A Microsoft mailbox
   connected before this feature shipped carries no `account_type` until it is
   reconnected, so it too resolves through the default.

--- a/hub/agents/email/python/CHANGELOG.md
+++ b/hub/agents/email/python/CHANGELOG.md
@@ -393,9 +393,11 @@ contract version is tracked separately as
   `GAIA_EMAIL_SKILL_SET` (`EmailAgentConfig.skill_set`) override it outright,
   while `GAIA_EMAIL_ACCOUNT_TYPE` (`EmailAgentConfig.account_type`) pins the kind
   instead. A Gmail-only mailbox has no equivalent claim, so its kind is genuinely
-  unknown and the manifest's `default_skill_set: personal` applies **explicitly**
-  — a work mailbox is never silently treated as personal — and an undeclared set
-  name raises naming the valid sets rather than falling back. The skills declare
+  unknown and the manifest's `default_skill_set: personal` applies — which does
+  mean a *work Gmail* mailbox lands on the personal set, by declared default and
+  with a log line, not by anything inferring the kind from the mailbox; pin
+  `GAIA_EMAIL_ACCOUNT_TYPE=work` for that case. An undeclared set name raises
+  naming the valid sets rather than falling back. The skills declare
   no `tools:` and no `permissions:`, so `tools_count` stays 59 and the REST/MCP
   contract, connector surface, and `SCHEMA_VERSION` are all unchanged; relocating
   the agent's tool implementations into skills is separate work (#2672).

--- a/hub/agents/email/python/CHANGELOG.md
+++ b/hub/agents/email/python/CHANGELOG.md
@@ -377,6 +377,28 @@ contract version is tracked separately as
   `EmailTriageAgent`'s existing methods now delegate to. The confirm floor is unchanged and
   still inviolable at every level — broadening the candidate map cannot make a floor tool
   auto-executable.
+- **Bundled Agent Skills, and the active set keyed to the mailbox kind (#2466).**
+  The agent brought identical instincts to every mailbox — the same triage
+  judgement for one full of newsletters and booking confirmations as for one full
+  of meeting invites and outstanding commitments. It now bundles six
+  instruction-only skills under `gaia_agent_email/skills/<name>/SKILL.md` —
+  `inbox-triage`, `newsletter-digest`, `travel-itinerary`, `meeting-scheduling`,
+  `action-item-extraction`, `escalation-routing` — and `gaia-agent.yaml` groups
+  them into two sets: `personal` (triage + newsletters + travel) and `work`
+  (triage + meetings + action items + escalation), with `inbox-triage` in both
+  because sets overlap rather than partition. Exactly one set is active per
+  launch. `EmailTriageAgent.select_skill_set()` maps the connected mailbox's
+  account type onto a set — the kind GAIA now derives from the Microsoft
+  `id_token` `tid` claim at connect time — and `--skill-set` /
+  `GAIA_EMAIL_SKILL_SET` (`EmailAgentConfig.skill_set`) override it outright,
+  while `GAIA_EMAIL_ACCOUNT_TYPE` (`EmailAgentConfig.account_type`) pins the kind
+  instead. A Gmail-only mailbox has no equivalent claim, so its kind is genuinely
+  unknown and the manifest's `default_skill_set: personal` applies **explicitly**
+  — a work mailbox is never silently treated as personal — and an undeclared set
+  name raises naming the valid sets rather than falling back. The skills declare
+  no `tools:` and no `permissions:`, so `tools_count` stays 59 and the REST/MCP
+  contract, connector surface, and `SCHEMA_VERSION` are all unchanged; relocating
+  the agent's tool implementations into skills is separate work (#2672).
 
 - **Agent-led mailbox onboarding — the agent sets up its own access, in the
   conversation (#2469).** Hitting the agent without a usable mailbox used to

--- a/hub/agents/email/python/_build_hooks.py
+++ b/hub/agents/email/python/_build_hooks.py
@@ -1,0 +1,56 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""Build-time staging of ``gaia-agent.yaml`` into the installed package.
+
+``gaia-agent.yaml`` lives at the package **root** — it is the hub artifact the
+Worker reads on publish, and the version stamper, capability matrix, and R2
+publisher all address it there. But the agent reads it at *runtime* to resolve its
+declared skill sets (#2466), and in an installed wheel there is no directory above
+``gaia_agent_email/`` to read it from: ``package-data`` globs cannot reach outside
+the package they belong to.
+
+So the wheel build copies it in. ``build_py`` is the standard hook for exactly
+this, and it runs for every install path — ``pip install .``,
+``pip install git+…#subdirectory=…``, ``python -m build``, and an editable
+install — so no separate packaging step has to remember.
+
+Wired via ``[tool.setuptools.cmdclass]`` in ``pyproject.toml``. There is
+deliberately no second committed copy of the manifest: one authored file, staged
+at build time, so the two can never drift.
+"""
+
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+
+from setuptools.command.build_py import build_py as _build_py
+
+_PACKAGE = "gaia_agent_email"
+_MANIFEST = "gaia-agent.yaml"
+
+
+class build_py(_build_py):  # noqa: N801 — setuptools requires this exact name
+    """``build_py`` that stages the agent manifest inside the package."""
+
+    def run(self) -> None:
+        super().run()
+        self._stage_agent_manifest()
+
+    def _stage_agent_manifest(self) -> None:
+        source = Path(__file__).resolve().parent / _MANIFEST
+        if not source.is_file():
+            # Fail the build rather than ship a package whose agent cannot be
+            # constructed — the runtime raises ManifestError on a missing
+            # manifest, which would turn an install into an unusable agent.
+            raise FileNotFoundError(
+                f"{_MANIFEST} not found next to pyproject.toml ({source}). It is "
+                "required: the built package stages it inside "
+                f"{_PACKAGE}/ so the agent can resolve its declared skill sets "
+                "at runtime."
+            )
+
+        target_dir = Path(self.build_lib) / _PACKAGE
+        target_dir.mkdir(parents=True, exist_ok=True)
+        shutil.copyfile(source, target_dir / _MANIFEST)
+        self.announce(f"staged {_MANIFEST} into {_PACKAGE}/", level=2)

--- a/hub/agents/email/python/gaia-agent.yaml
+++ b/hub/agents/email/python/gaia-agent.yaml
@@ -49,3 +49,30 @@ interfaces:
   pipe: true
   api_server: true
   mcp_server: true
+
+# Agent Skills (#2466). Bundled instruction-only skills live in
+# gaia_agent_email/skills/<name>/SKILL.md and are loaded from there — that folder
+# is this agent's highest-precedence discovery root (SKILL_DIRS).
+#
+# Exactly ONE set is active per launch. EmailTriageAgent.select_skill_set() maps
+# the connected mailbox's account type onto a set (personal Microsoft account →
+# personal, work/school → work); `--skill-set` and GAIA_EMAIL_SKILL_SET override
+# it, and default_skill_set applies when the kind cannot be determined — which is
+# every Gmail-only mailbox, since Gmail has no equivalent of the Microsoft
+# id_token `tid` claim.
+#
+# `inbox-triage` appears in both sets deliberately: sets overlap, they do not
+# partition. Anything that should load for every set belongs in a top-level
+# `skills:` list instead.
+skill_sets:
+  personal:
+    - inbox-triage
+    - newsletter-digest
+    - travel-itinerary
+  work:
+    - inbox-triage
+    - meeting-scheduling
+    - action-item-extraction
+    - escalation-routing
+
+default_skill_set: personal

--- a/hub/agents/email/python/gaia_agent_email/agent.py
+++ b/hub/agents/email/python/gaia_agent_email/agent.py
@@ -101,10 +101,51 @@ from gaia.agents.registry import get_embedding_model_for_device
 from gaia.connectors.errors import ConnectorsError
 from gaia.connectors.formatting import format_connector_error
 from gaia.connectors.providers.base import ConnectorRequirement
+from gaia.connectors.providers.microsoft import (
+    ACCOUNT_TYPE_PERSONAL,
+    ACCOUNT_TYPE_WORK,
+)
 from gaia.database.mixin import DatabaseMixin
 from gaia.logger import get_logger
 
 logger = get_logger(__name__)
+
+# Agent Skills (#2466). The bundled skills always sit inside the package, so one
+# path covers every distribution. ``gaia-agent.yaml`` is the hub artifact and
+# lives at the *package root* in a source checkout, so the frozen sidecar and the
+# wheel get a copy staged inside the package instead — hence two candidates.
+_SKILLS_DIR = Path(__file__).resolve().parent / "skills"
+_MANIFEST_CANDIDATES = (
+    # Packaged: staged into the package (frozen sidecar --add-data, wheel
+    # package-data).
+    Path(__file__).resolve().parent / "gaia-agent.yaml",
+    # Source checkout / editable install: the canonical hub artifact.
+    Path(__file__).resolve().parent.parent / "gaia-agent.yaml",
+)
+
+
+# Mailbox account type → the skill set it activates (#2466). The set names must
+# exist in gaia-agent.yaml's ``skill_sets:`` block; a test keeps the two in
+# lock-step. An account type absent from this map fails loudly rather than
+# picking a set for it.
+ACCOUNT_TYPE_SKILL_SETS = {
+    ACCOUNT_TYPE_PERSONAL: "personal",
+    ACCOUNT_TYPE_WORK: "work",
+}
+
+
+def _locate_agent_manifest() -> Path:
+    """Absolute path to this package's ``gaia-agent.yaml``.
+
+    Returns the first candidate that exists. When none does, returns the
+    packaged location so the framework's own "Manifest not found: <path>" error
+    names a path a packager can act on — a missing manifest must fail loudly at
+    agent construction, never quietly disable every declared skill.
+    """
+    for candidate in _MANIFEST_CANDIDATES:
+        if candidate.is_file():
+            return candidate
+    return _MANIFEST_CANDIDATES[0]
 
 
 class _UnavailableCalendarBackend:
@@ -668,6 +709,14 @@ class EmailTriageAgent(
     # stops the cycle early.
     AUTONOMY_MAX_CONSECUTIVE_FAILURES = 3
 
+    # Agent Skills (#2466). The bundled ``skills/`` folder is this agent's
+    # highest-precedence discovery root; ``gaia-agent.yaml`` declares which
+    # skills each set activates. Both resolve from this module's own location so
+    # a source checkout, an installed wheel, and the frozen sidecar all find
+    # them.
+    SKILL_DIRS: ClassVar[List[str]] = [str(_SKILLS_DIR)]
+    SKILL_MANIFEST: ClassVar[Optional[str]] = str(_locate_agent_manifest())
+
     def __init__(self, config: Optional[EmailAgentConfig] = None):
         config = config or EmailAgentConfig()
         config.validate()
@@ -827,6 +876,9 @@ class EmailTriageAgent(
             min_context_size=(
                 config.ctx_size if config.ctx_size is not None else 32768
             ),
+            # Explicit skill-set override (--skill-set / GAIA_EMAIL_SKILL_SET).
+            # Beats select_skill_set() below; an undeclared name fails loudly.
+            skill_set=config.skill_set,
         )
 
         # Surface the degraded-memory state where the user actually is
@@ -900,6 +952,50 @@ class EmailTriageAgent(
         if profile is None:
             return _SYSTEM_PROMPT
         return _SYSTEM_PROMPT + "\n" + render_style_guidance(profile)
+
+    # -- Skill-set selection (#2466) ---------------------------------------
+
+    def select_skill_set(self) -> Optional[str]:
+        """Map the connected mailbox's account type onto a skill set.
+
+        A personal mailbox gets the personal set (newsletters, travel); a
+        work/school mailbox gets the work set (meetings, action items,
+        escalation). The kind comes from the Microsoft id_token ``tid`` claim
+        recorded at connect time, or from an explicit ``account_type`` config /
+        ``GAIA_EMAIL_ACCOUNT_TYPE``.
+
+        Returns ``None`` when the kind is unknown — a Gmail-only mailbox has no
+        Microsoft tenant to inspect. The framework then resolves the manifest's
+        ``default_skill_set`` explicitly. It is never treated as personal by
+        assumption: a work mailbox silently given the personal set is exactly the
+        wrong-capabilities failure this indirection exists to prevent.
+
+        ``--skill-set`` / ``config.skill_set`` overrides this entirely.
+        """
+        account_type = self.config.resolve_account_type()
+        if account_type is None:
+            logger.info(
+                "No mailbox account type could be determined (no connected "
+                "Microsoft mailbox, or a Gmail-only mailbox, which has no "
+                "equivalent claim) — falling through to the manifest's default "
+                "skill set. Set GAIA_EMAIL_ACCOUNT_TYPE or --skill-set to pin "
+                "one."
+            )
+            return None
+        skill_set = ACCOUNT_TYPE_SKILL_SETS.get(account_type)
+        if skill_set is None:
+            # A new account type reached this map without a set to go with it.
+            raise ConfigurationError(
+                f"Mailbox account type {account_type!r} has no skill set mapped "
+                f"to it. Known mappings: "
+                f"{', '.join(f'{k}->{v}' for k, v in ACCOUNT_TYPE_SKILL_SETS.items())}"
+                ". Pass --skill-set explicitly, or add the mapping in "
+                "gaia_agent_email/agent.py."
+            )
+        logger.info(
+            "Mailbox account type is %r → skill set %r", account_type, skill_set
+        )
+        return skill_set
 
     # -- Runtime memory control (#1666) ------------------------------------
 

--- a/hub/agents/email/python/gaia_agent_email/config.py
+++ b/hub/agents/email/python/gaia_agent_email/config.py
@@ -127,6 +127,11 @@ def default_inbox_scan_ceiling() -> int:
     return value
 
 
+# Microsoft-family connector ids, in registry order (#2628 split the single
+# ``microsoft`` connector into a personal one and ``microsoft_work``). The
+# account kind is recorded on whichever the user connected.
+_MICROSOFT_CONNECTOR_IDS = ("microsoft", "microsoft_work")
+
 SKILL_SET_ENV = "GAIA_EMAIL_SKILL_SET"
 ACCOUNT_TYPE_ENV = "GAIA_EMAIL_ACCOUNT_TYPE"
 
@@ -364,8 +369,13 @@ class EmailAgentConfig:
 
         Resolution order:
           1. An explicit ``account_type`` (config field / ``GAIA_EMAIL_ACCOUNT_TYPE``).
-          2. The kind recorded on the connected Microsoft mailbox, derived from
-             the id_token ``tid`` claim at connect time.
+          2. The kind recorded on a connected Microsoft mailbox, derived from the
+             id_token ``tid`` claim at connect time. Both Microsoft connectors are
+             consulted in registry order (#2628 split ``microsoft`` — personal,
+             ``consumers`` authority — from ``microsoft_work``); the first with a
+             recorded kind wins. Today only ``microsoft`` is in this agent's
+             ``REQUIRED_CONNECTORS``, so ``microsoft_work`` is checked purely so
+             this keeps working when #2629 wires it up.
           3. ``None`` — unknown.
 
         ``None`` is a real answer, not a failure: a Gmail-only mailbox has no
@@ -383,7 +393,11 @@ class EmailAgentConfig:
         if self.account_type:
             return self.account_type
         try:
-            connection = get_connection("microsoft") or {}
+            for connector_id in _MICROSOFT_CONNECTOR_IDS:
+                recorded = (get_connection(connector_id) or {}).get("account_type")
+                if recorded:
+                    return recorded
+            return None
         except ConnectorsError as e:
             # The connection store is unreadable (no keyring backend, corrupt
             # blob). The kind is unknown, which the caller handles explicitly.
@@ -395,7 +409,6 @@ class EmailAgentConfig:
                 e,
             )
             return None
-        return connection.get("account_type") or None
 
     def resolved_db_path(self) -> str:
         """Return the SQLite path with ``$HOME`` expanded.

--- a/hub/agents/email/python/gaia_agent_email/config.py
+++ b/hub/agents/email/python/gaia_agent_email/config.py
@@ -370,8 +370,15 @@ class EmailAgentConfig:
 
         ``None`` is a real answer, not a failure: a Gmail-only mailbox has no
         Microsoft tenant to inspect, so there is nothing to classify. The caller
-        must then resolve a skill set through the manifest's ``default_skill_set``
-        explicitly, rather than treating an unknown mailbox as personal.
+        then resolves through the manifest's ``default_skill_set`` — a declared
+        default, reached explicitly and logged, rather than a kind inferred from
+        the mailbox.
+
+        Note this reads the Microsoft connection regardless of ``mail_provider``:
+        the account kind describes the *user*, not which mailbox this run happens
+        to read, so a Gmail-filtered run on a machine with a work Microsoft
+        account still resolves ``work``. Set ``account_type`` explicitly if that
+        is not what you want.
         """
         if self.account_type:
             return self.account_type

--- a/hub/agents/email/python/gaia_agent_email/config.py
+++ b/hub/agents/email/python/gaia_agent_email/config.py
@@ -22,6 +22,11 @@ from urllib.parse import urlparse
 
 from gaia.agents.base.agent import default_max_steps
 from gaia.connectors.api import connected_mailbox_providers, get_connection
+from gaia.connectors.errors import ConnectorsError
+from gaia.connectors.providers.microsoft import ACCOUNT_TYPES
+from gaia.logger import get_logger
+
+logger = get_logger(__name__)
 
 
 class ConfigurationError(ValueError):
@@ -120,6 +125,41 @@ def default_inbox_scan_ceiling() -> int:
             "default."
         )
     return value
+
+
+SKILL_SET_ENV = "GAIA_EMAIL_SKILL_SET"
+ACCOUNT_TYPE_ENV = "GAIA_EMAIL_ACCOUNT_TYPE"
+
+
+def default_skill_set() -> Optional[str]:
+    """Read an explicit skill-set override from ``GAIA_EMAIL_SKILL_SET``.
+
+    ``None`` (unset) means "let the agent resolve one" — the account-type
+    selector, then the manifest's ``default_skill_set``. The name itself is
+    validated by the framework against the manifest's declared sets, so a typo
+    fails at startup naming the valid names rather than here with less context.
+    """
+    return os.environ.get(SKILL_SET_ENV, "").strip() or None
+
+
+def default_account_type() -> Optional[str]:
+    """Read an explicit account kind from ``GAIA_EMAIL_ACCOUNT_TYPE``.
+
+    ``personal`` or ``work``; unset means "derive it from the connected
+    mailbox". A malformed value raises rather than being ignored — an operator
+    who set it meant to pin the behaviour, and silently discarding the value
+    would activate the wrong skill set.
+    """
+    raw = os.environ.get(ACCOUNT_TYPE_ENV, "").strip().lower()
+    if not raw:
+        return None
+    if raw not in ACCOUNT_TYPES:
+        raise ConfigurationError(
+            f"{ACCOUNT_TYPE_ENV}={raw!r} is not a valid account type. Use one "
+            f"of: {', '.join(ACCOUNT_TYPES)}, or unset it to derive the kind "
+            "from the connected mailbox."
+        )
+    return raw
 
 
 @dataclass
@@ -233,6 +273,14 @@ class EmailAgentConfig:
     autonomy_level: str = "off"
     autonomy_trust_min_samples: int = 5
     autonomy_trust_threshold: float = 0.85
+    # Agent Skills (#2466). ``skill_set`` is the explicit override (the
+    # ``--skill-set`` flag / GAIA_EMAIL_SKILL_SET) and beats everything.
+    # ``account_type`` pins the mailbox kind the selector maps to a set; unset
+    # means "derive it from the connected mailbox" — the Microsoft id_token
+    # ``tid`` claim recorded at connect time. Gmail has no equivalent claim, so a
+    # Gmail-only mailbox resolves through the manifest's ``default_skill_set``.
+    skill_set: Optional[str] = field(default_factory=default_skill_set)
+    account_type: Optional[str] = field(default_factory=default_account_type)
 
     def validate(self) -> None:
         """Run startup-time invariants. Called from the agent's __init__.
@@ -304,6 +352,43 @@ class EmailAgentConfig:
                 f"EmailAgentConfig.autonomy_trust_threshold must be in (0, 1], "
                 f"got {self.autonomy_trust_threshold!r}."
             )
+        if self.account_type is not None and self.account_type not in ACCOUNT_TYPES:
+            raise ConfigurationError(
+                f"EmailAgentConfig.account_type must be one of "
+                f"{list(ACCOUNT_TYPES)} or None, got {self.account_type!r}. "
+                "Leave it None to derive the kind from the connected mailbox."
+            )
+
+    def resolve_account_type(self) -> Optional[str]:
+        """The mailbox kind that keys skill-set selection (#2466).
+
+        Resolution order:
+          1. An explicit ``account_type`` (config field / ``GAIA_EMAIL_ACCOUNT_TYPE``).
+          2. The kind recorded on the connected Microsoft mailbox, derived from
+             the id_token ``tid`` claim at connect time.
+          3. ``None`` — unknown.
+
+        ``None`` is a real answer, not a failure: a Gmail-only mailbox has no
+        Microsoft tenant to inspect, so there is nothing to classify. The caller
+        must then resolve a skill set through the manifest's ``default_skill_set``
+        explicitly, rather than treating an unknown mailbox as personal.
+        """
+        if self.account_type:
+            return self.account_type
+        try:
+            connection = get_connection("microsoft") or {}
+        except ConnectorsError as e:
+            # The connection store is unreadable (no keyring backend, corrupt
+            # blob). The kind is unknown, which the caller handles explicitly.
+            logger.warning(
+                "Could not read the Microsoft connection to derive the account "
+                "type (%s) — the mailbox kind is unknown, so the manifest's "
+                "default skill set applies. Set GAIA_EMAIL_ACCOUNT_TYPE to pin "
+                "it.",
+                e,
+            )
+            return None
+        return connection.get("account_type") or None
 
     def resolved_db_path(self) -> str:
         """Return the SQLite path with ``$HOME`` expanded.

--- a/hub/agents/email/python/gaia_agent_email/context_budget.py
+++ b/hub/agents/email/python/gaia_agent_email/context_budget.py
@@ -122,18 +122,39 @@ def active_profile_ctx_size() -> int:
     return profile_ctx_size(device)
 
 
+# Chars per token for prose-heavy Markdown, measured on real hardware: the
+# verbatim 60-email envelope was 23,965 chars → ~11.4K tokens (see
+# ``estimate_tokens_json``). ``estimate_tokens``' chars//4 prose ratio therefore
+# under-counts by ~2x, which is fine for a *capacity* estimate and wrong for a
+# *budget subtraction* — under-crediting the skill cost is how the post-tool turn
+# 400s. Round pessimistically, always.
+_SKILL_BODY_CHARS_PER_TOKEN = 2.1
+
+
 def skill_prompt_tokens(agent) -> int:
     """Token cost of the Agent Skills bodies loaded into *agent*'s prompt.
 
-    Zero when the agent has no skills loaded, which keeps every pre-#2466
-    budget calculation byte-identical. Measured off the rendered fragment the
-    agent actually injects, so a trimmed or extended skill body is reflected
-    without touching a constant.
+    Zero when the agent has no skills loaded, which keeps every pre-#2466 budget
+    calculation byte-identical. Measured off the rendered fragment the agent
+    actually injects, so a trimmed or extended skill body is reflected without
+    touching a constant.
+
+    Deliberately pessimistic (``_SKILL_BODY_CHARS_PER_TOKEN``, not
+    ``estimate_tokens``): this figure is *subtracted* from the envelope, so an
+    under-count silently hands the tool result budget the prompt is already
+    using. Over-crediting costs exemplar slots; under-crediting costs a 400.
     """
     render = getattr(agent, "get_skills_system_prompt", None)
     if not callable(render):
         return 0
-    return estimate_tokens(render())
+    fragment = render()
+    if not fragment:
+        return 0
+    # Never below the generic estimate — this is a floor, not a replacement.
+    return max(
+        estimate_tokens(fragment),
+        int(len(fragment) / _SKILL_BODY_CHARS_PER_TOKEN) + 1,
+    )
 
 
 def estimate_tokens(text: str) -> int:

--- a/hub/agents/email/python/gaia_agent_email/context_budget.py
+++ b/hub/agents/email/python/gaia_agent_email/context_budget.py
@@ -59,9 +59,11 @@ def thread_budget_tokens() -> int:
     )
 
 
-def envelope_budget_tokens(ctx_size: Optional[int] = None) -> int:
+def envelope_budget_tokens(
+    ctx_size: Optional[int] = None, extra_fixed_tokens: int = 0
+) -> int:
     """Usable token budget for a tool-result envelope re-read on the agent
-    loop's next turn (#2087, #2514).
+    loop's next turn (#2087, #2514, #2466).
 
     ``ctx_size`` (default ``CONTEXT_TARGET_TOKENS``, the eval harness's
     pinned 16K target) minus the agent-loop fixed prompt cost (system prompt
@@ -74,9 +76,23 @@ def envelope_budget_tokens(ctx_size: Optional[int] = None) -> int:
     body budget (#2514) — passes the active profile's window explicitly,
     e.g. ``envelope_budget_tokens(ctx_size=active_profile_ctx_size())``:
     GPU/CPU 65536, NPU 32768 (``gaia.llm.lemonade_client``).
+
+    ``extra_fixed_tokens`` accounts for prompt text this launch carries that
+    ``_AGENT_LOOP_FIXED_TOKENS`` does not model — today, the bodies of the
+    loaded Agent Skills (#2466), which vary by which skill set is active. It is
+    a *subtraction from the envelope*, never an increase in the ctx: every token
+    a skill adds to the prompt is a token the tool result must give back, or the
+    post-tool turn overflows the window. Measured, not guessed — see
+    :func:`skill_prompt_tokens`.
     """
     base = CONTEXT_TARGET_TOKENS if ctx_size is None else ctx_size
-    return max(0, base - _AGENT_LOOP_FIXED_TOKENS - _RESPONSE_RESERVE_TOKENS)
+    return max(
+        0,
+        base
+        - _AGENT_LOOP_FIXED_TOKENS
+        - _RESPONSE_RESERVE_TOKENS
+        - max(0, extra_fixed_tokens),
+    )
 
 
 def active_profile_ctx_size() -> int:
@@ -104,6 +120,20 @@ def active_profile_ctx_size() -> int:
             "`gaia config set default_device gpu`."
         ) from exc
     return profile_ctx_size(device)
+
+
+def skill_prompt_tokens(agent) -> int:
+    """Token cost of the Agent Skills bodies loaded into *agent*'s prompt.
+
+    Zero when the agent has no skills loaded, which keeps every pre-#2466
+    budget calculation byte-identical. Measured off the rendered fragment the
+    agent actually injects, so a trimmed or extended skill body is reflected
+    without touching a constant.
+    """
+    render = getattr(agent, "get_skills_system_prompt", None)
+    if not callable(render):
+        return 0
+    return estimate_tokens(render())
 
 
 def estimate_tokens(text: str) -> int:

--- a/hub/agents/email/python/gaia_agent_email/server.py
+++ b/hub/agents/email/python/gaia_agent_email/server.py
@@ -203,21 +203,25 @@ def build_app():
 app = build_app()
 
 
-def _declared_skill_sets() -> list[str]:
-    """Skill-set names this build declares, for --skill-set help and validation.
+def _read_declared_skill_sets() -> list[str]:
+    """Skill-set names this build declares. Raises if the manifest is unreadable."""
+    from gaia.hub.manifest import parse as parse_manifest
 
-    Reads the agent's own manifest. Returns ``[]`` if it cannot be read — the
-    flag's *validation* still runs at agent construction, where the framework
-    raises with the authoritative list, so an unreadable manifest degrades the
-    help text and nothing else.
+    from gaia_agent_email.agent import EmailTriageAgent
+
+    return list(parse_manifest(EmailTriageAgent.SKILL_MANIFEST).skill_sets.set_names)
+
+
+def _declared_skill_sets() -> list[str]:
+    """Declared set names for the ``--skill-set`` help string, or ``[]``.
+
+    Help-text only, so an unreadable manifest degrades the wording rather than
+    breaking ``--help``. **Never use this to validate a requested name** — a
+    swallowed read error would turn validation into "accept anything". Use
+    :func:`_read_declared_skill_sets`, which raises.
     """
     try:
-        from gaia.hub.manifest import parse as parse_manifest
-
-        from gaia_agent_email.agent import EmailTriageAgent
-
-        manifest = parse_manifest(EmailTriageAgent.SKILL_MANIFEST)
-        return list(manifest.skill_sets.set_names)
+        return _read_declared_skill_sets()
     except Exception as e:  # noqa: BLE001 — help text only
         log.debug("Could not read declared skill sets for --skill-set help: %s", e)
         return []
@@ -287,21 +291,36 @@ def main(argv=None) -> int:
     if args.port == 4001:
         parser.error("port 4001 is reserved and must never be used")
 
-    if args.skill_set:
-        declared = _declared_skill_sets()
-        if declared and args.skill_set not in declared:
+    # Validate a pinned skill set here, at startup, rather than letting the first
+    # session fail — and validate the env-var form identically to the flag, since
+    # the docs tell integrators the two are equivalent. The flag wins when both
+    # are set.
+    requested_set = args.skill_set or os.environ.get(SKILL_SET_ENV, "").strip()
+    if requested_set:
+        source = (
+            "--skill-set" if args.skill_set else f"{SKILL_SET_ENV} in the environment"
+        )
+        try:
+            declared = _read_declared_skill_sets()
+        except Exception as exc:  # noqa: BLE001 — re-raised as a CLI error below
             parser.error(
-                f"--skill-set {args.skill_set!r} is not declared by this agent. "
-                f"Valid sets: {', '.join(declared)}."
+                f"{source} requested skill set {requested_set!r}, but this "
+                f"build's declared sets could not be read: {exc}"
+            )
+        if requested_set not in declared:
+            parser.error(
+                f"{source} requested skill set {requested_set!r}, which this "
+                f"agent does not declare. Valid sets: {', '.join(declared)}."
             )
         # Every agent session is built per-request inside the app (which is
         # constructed at import time), so the override travels by env var —
         # inherited by the --reload child process too.
-        os.environ[SKILL_SET_ENV] = args.skill_set
+        os.environ[SKILL_SET_ENV] = requested_set
         log.info(
-            "Email sidecar: skill set pinned to %r for every session "
+            "Email sidecar: skill set pinned to %r via %s for every session "
             "(overrides mailbox account-type selection).",
-            args.skill_set,
+            requested_set,
+            source,
         )
 
     reload = bool(args.reload or args.dev)

--- a/hub/agents/email/python/gaia_agent_email/server.py
+++ b/hub/agents/email/python/gaia_agent_email/server.py
@@ -35,6 +35,10 @@ import os
 import sys
 from pathlib import Path
 
+# How --skill-set reaches the per-request agent sessions (#2466): via the env var
+# EmailAgentConfig.skill_set reads. Imported so the two cannot drift.
+from gaia_agent_email.config import SKILL_SET_ENV
+
 logging.basicConfig(
     level=logging.INFO,
     format="%(asctime)s %(levelname)s %(name)s: %(message)s",
@@ -199,6 +203,26 @@ def build_app():
 app = build_app()
 
 
+def _declared_skill_sets() -> list[str]:
+    """Skill-set names this build declares, for --skill-set help and validation.
+
+    Reads the agent's own manifest. Returns ``[]`` if it cannot be read — the
+    flag's *validation* still runs at agent construction, where the framework
+    raises with the authoritative list, so an unreadable manifest degrades the
+    help text and nothing else.
+    """
+    try:
+        from gaia.hub.manifest import parse as parse_manifest
+
+        from gaia_agent_email.agent import EmailTriageAgent
+
+        manifest = parse_manifest(EmailTriageAgent.SKILL_MANIFEST)
+        return list(manifest.skill_sets.set_names)
+    except Exception as e:  # noqa: BLE001 — help text only
+        log.debug("Could not read declared skill sets for --skill-set help: %s", e)
+        return []
+
+
 def _add_serve_args(parser: argparse.ArgumentParser) -> None:
     parser.add_argument("--host", default=DEFAULT_HOST, help="Bind host.")
     parser.add_argument("--port", type=int, default=DEFAULT_PORT, help="Bind port.")
@@ -222,6 +246,15 @@ def _add_serve_args(parser: argparse.ArgumentParser) -> None:
         action="store_true",
         help="Developer mode: implies --reload and logs the caller-token-off "
         "banner. For local iteration only — never ship this.",
+    )
+    parser.add_argument(
+        "--skill-set",
+        default=None,
+        metavar="NAME",
+        help="Activate this bundled skill set for every agent session instead "
+        "of the one the connected mailbox's account type selects. Valid names "
+        "come from gaia-agent.yaml's skill_sets: block "
+        f"({', '.join(_declared_skill_sets()) or 'none declared'}).",
     )
     parser.add_argument(
         "--print-openapi",
@@ -253,6 +286,23 @@ def main(argv=None) -> int:
 
     if args.port == 4001:
         parser.error("port 4001 is reserved and must never be used")
+
+    if args.skill_set:
+        declared = _declared_skill_sets()
+        if declared and args.skill_set not in declared:
+            parser.error(
+                f"--skill-set {args.skill_set!r} is not declared by this agent. "
+                f"Valid sets: {', '.join(declared)}."
+            )
+        # Every agent session is built per-request inside the app (which is
+        # constructed at import time), so the override travels by env var —
+        # inherited by the --reload child process too.
+        os.environ[SKILL_SET_ENV] = args.skill_set
+        log.info(
+            "Email sidecar: skill set pinned to %r for every session "
+            "(overrides mailbox account-type selection).",
+            args.skill_set,
+        )
 
     reload = bool(args.reload or args.dev)
     if reload and getattr(sys, "frozen", False):

--- a/hub/agents/email/python/gaia_agent_email/skills/action-item-extraction/SKILL.md
+++ b/hub/agents/email/python/gaia_agent_email/skills/action-item-extraction/SKILL.md
@@ -1,0 +1,53 @@
+---
+name: action-item-extraction
+description: Pull the concrete commitments out of a thread — who owes what, by when. Use when the user asks what they need to do, what they promised, what is outstanding, or for action items from a conversation.
+version: 0.1.0
+metadata:
+  gaia:
+    tools_required:
+      - extract_action_items
+      - get_thread
+      - summarize_thread
+      - list_tasks
+      - check_followups
+---
+
+# Action Item Extraction
+
+An action item has an **owner**, a **verb**, and ideally a **date**. Anything
+missing an owner and a verb is discussion, not an action item.
+
+## Procedure
+
+1. **Read the whole thread, not the last message.** `get_thread`, then
+   `extract_action_items`. A commitment made early is often only confirmed
+   later.
+2. **Attribute every item to a named participant** — the user, or a specific
+   other person. "The team will follow up" is not an action item; drop it or
+   name who.
+3. **Separate what the user owes from what the user is owed.** These get acted
+   on completely differently.
+4. **Check for existing tracking** with `list_tasks` and `check_followups`
+   before proposing a new item, so the same commitment is not recorded twice.
+
+## Reporting
+
+Two lists, in this order, longest-overdue first:
+
+**You owe** — `<verb the deliverable> · to <person> · by <date or "no date">`
+**You're owed** — `<person> · <what> · by <date or "no date">`
+
+Then, if anything qualifies, one short list of items whose deadline has passed.
+No preamble, no restatement of the thread.
+
+## Judgement calls
+
+- **A question is not an action item** unless answering it was explicitly
+  promised.
+- **"No date" is a real value.** Never invent a deadline to make an item look
+  complete — an undated commitment is exactly the one that gets dropped, and
+  saying so is the useful output.
+- **Superseded items are closed.** If a later message says a task moved or was
+  dropped, that is the current state.
+- **Conditional commitments stay conditional** — record the condition rather
+  than the promise.

--- a/hub/agents/email/python/gaia_agent_email/skills/action-item-extraction/SKILL.md
+++ b/hub/agents/email/python/gaia_agent_email/skills/action-item-extraction/SKILL.md
@@ -14,40 +14,24 @@ metadata:
 
 # Action Item Extraction
 
-An action item has an **owner**, a **verb**, and ideally a **date**. Anything
-missing an owner and a verb is discussion, not an action item.
+An action item has an **owner**, a **verb**, and ideally a **date**. Without an
+owner and a verb it is discussion, not an action item.
 
-## Procedure
+- Read the whole thread (`get_thread`, then `extract_action_items`) — a
+  commitment made early is often only confirmed later.
+- Attribute every item to a named person. "The team will follow up" is not an
+  action item; name who, or drop it.
+- Separate what the user owes from what the user is owed. They get handled
+  completely differently.
+- Check `list_tasks` and `check_followups` before proposing a new item, so the
+  same commitment is not tracked twice.
 
-1. **Read the whole thread, not the last message.** `get_thread`, then
-   `extract_action_items`. A commitment made early is often only confirmed
-   later.
-2. **Attribute every item to a named participant** — the user, or a specific
-   other person. "The team will follow up" is not an action item; drop it or
-   name who.
-3. **Separate what the user owes from what the user is owed.** These get acted
-   on completely differently.
-4. **Check for existing tracking** with `list_tasks` and `check_followups`
-   before proposing a new item, so the same commitment is not recorded twice.
-
-## Reporting
-
-Two lists, in this order, longest-overdue first:
-
+**Report** two lists, longest-overdue first:
 **You owe** — `<verb the deliverable> · to <person> · by <date or "no date">`
 **You're owed** — `<person> · <what> · by <date or "no date">`
+Then anything already past its deadline. No preamble.
 
-Then, if anything qualifies, one short list of items whose deadline has passed.
-No preamble, no restatement of the thread.
-
-## Judgement calls
-
-- **A question is not an action item** unless answering it was explicitly
-  promised.
-- **"No date" is a real value.** Never invent a deadline to make an item look
-  complete — an undated commitment is exactly the one that gets dropped, and
-  saying so is the useful output.
-- **Superseded items are closed.** If a later message says a task moved or was
-  dropped, that is the current state.
-- **Conditional commitments stay conditional** — record the condition rather
-  than the promise.
+A question is not an action item unless answering it was promised. "No date" is a
+real value — never invent a deadline; the undated commitment is the one that gets
+dropped, and saying so is the useful output. A superseded item is closed. A
+conditional commitment keeps its condition.

--- a/hub/agents/email/python/gaia_agent_email/skills/escalation-routing/SKILL.md
+++ b/hub/agents/email/python/gaia_agent_email/skills/escalation-routing/SKILL.md
@@ -1,0 +1,55 @@
+---
+name: escalation-routing
+description: Decide which messages need attention now, which can wait, and which belong to someone else. Use when the user asks what is urgent, what needs escalating, what they should look at first, or who should handle something.
+version: 0.1.0
+metadata:
+  gaia:
+    tools_required:
+      - triage_inbox
+      - get_thread
+      - add_star
+      - label_message
+      - draft_reply
+      - check_followups
+---
+
+# Escalation Routing
+
+Urgency is a property of **consequence and deadline**, not of tone. Route each
+message to one of: **now**, **today**, **this week**, or **not the user's**.
+
+## Procedure
+
+1. **Start from the triage pass** (`triage_inbox`), then read only the
+   candidates for **now** in full.
+2. **Score on two axes**, independently:
+   - *Consequence* — what breaks if this is missed?
+   - *Deadline* — when does it break?
+   Only messages high on both are **now**.
+3. **Check whether it is already moving.** `check_followups` and the thread
+   itself — a message someone else has already answered is not an escalation.
+4. **Name the right owner.** If the request belongs to another person or team,
+   say so and offer a forward. Do not send it — `draft_reply` and wait.
+5. **Mark what you routed** with `add_star` or `label_message` so the ordering
+   survives the conversation.
+
+## Reporting
+
+Order strictly by when action is needed, most urgent first. One line each:
+
+`now · <sender> · <what breaks and when>`
+
+Then the **not yours** list, each with the owner you identified. Say how many
+you looked at. If nothing is urgent, say "nothing needs attention today" and
+stop — a routing report that manufactures urgency is worse than none.
+
+## Judgement calls
+
+- **Tone is not evidence.** Capital letters, "ASAP", and red flags are the
+  sender's opinion of their own priority.
+- **A deadline in the message beats an inferred one**, and no deadline means
+  not **now** unless the consequence is severe on its own.
+- **Escalating everything is the same as escalating nothing.** If more than a
+  handful land in **now**, the bar was set wrong — re-score.
+- **Never act on a message you routed to someone else.** Naming the owner is
+  the action.

--- a/hub/agents/email/python/gaia_agent_email/skills/escalation-routing/SKILL.md
+++ b/hub/agents/email/python/gaia_agent_email/skills/escalation-routing/SKILL.md
@@ -15,41 +15,24 @@ metadata:
 
 # Escalation Routing
 
-Urgency is a property of **consequence and deadline**, not of tone. Route each
-message to one of: **now**, **today**, **this week**, or **not the user's**.
+Urgency is **consequence and deadline**, not tone. Route each message to **now**,
+**today**, **this week**, or **not the user's**.
 
-## Procedure
+- Start from `triage_inbox`; read in full only the candidates for **now**.
+- Score two axes independently: what breaks if this is missed, and when. Only
+  high on both is **now**.
+- Check it is not already moving (`check_followups`, the thread itself). A
+  message someone else answered is not an escalation.
+- If it belongs to another person or team, name them and offer a forward —
+  `draft_reply`, never send. Mark what you routed with `add_star` / `label_message`
+  so the ordering outlives the conversation.
 
-1. **Start from the triage pass** (`triage_inbox`), then read only the
-   candidates for **now** in full.
-2. **Score on two axes**, independently:
-   - *Consequence* — what breaks if this is missed?
-   - *Deadline* — when does it break?
-   Only messages high on both are **now**.
-3. **Check whether it is already moving.** `check_followups` and the thread
-   itself — a message someone else has already answered is not an escalation.
-4. **Name the right owner.** If the request belongs to another person or team,
-   say so and offer a forward. Do not send it — `draft_reply` and wait.
-5. **Mark what you routed** with `add_star` or `label_message` so the ordering
-   survives the conversation.
-
-## Reporting
-
-Order strictly by when action is needed, most urgent first. One line each:
-
+**Report** strictly by when action is needed:
 `now · <sender> · <what breaks and when>`
+Then the **not yours** list with the owner you identified, and how many you
+looked at. If nothing is urgent, say "nothing needs attention today" and stop.
 
-Then the **not yours** list, each with the owner you identified. Say how many
-you looked at. If nothing is urgent, say "nothing needs attention today" and
-stop — a routing report that manufactures urgency is worse than none.
-
-## Judgement calls
-
-- **Tone is not evidence.** Capital letters, "ASAP", and red flags are the
-  sender's opinion of their own priority.
-- **A deadline in the message beats an inferred one**, and no deadline means
-  not **now** unless the consequence is severe on its own.
-- **Escalating everything is the same as escalating nothing.** If more than a
-  handful land in **now**, the bar was set wrong — re-score.
-- **Never act on a message you routed to someone else.** Naming the owner is
-  the action.
+Capitals and "ASAP" are the sender's opinion of their own priority. A stated
+deadline beats an inferred one; no deadline means not **now** unless the
+consequence is severe alone. Escalating everything is escalating nothing — if
+more than a handful land in **now**, re-score. Naming the owner *is* the action.

--- a/hub/agents/email/python/gaia_agent_email/skills/inbox-triage/SKILL.md
+++ b/hub/agents/email/python/gaia_agent_email/skills/inbox-triage/SKILL.md
@@ -18,36 +18,16 @@ metadata:
 
 Triage answers one question per message: **does a human have to act on this?**
 
-## Procedure
+- Scan first (`pre_scan_inbox`, then `triage_inbox`); never open messages one by
+  one to build a picture.
+- Buckets, in order: needs a reply · needs a decision · for information · noise.
+- Open only what the category can't settle. Sender + subject usually decide it.
+- Act on the reversible end only — mark read, star, label, archive. Reply, send,
+  and delete are proposals the user confirms.
 
-1. **Scan before reading.** `pre_scan_inbox` for the shape of the backlog,
-   then `triage_inbox` for the categorised pass. Never open messages one by one
-   to build a picture — that burns the context budget and misses the pattern.
-2. **Sort into four buckets**, in this order:
-   - **Needs a reply** — a person is waiting on the user specifically.
-   - **Needs a decision** — no reply required, but an action or choice is.
-   - **For information** — worth knowing, nothing owed.
-   - **Noise** — bulk, automated, or already-handled mail.
-3. **Open only what the category can't settle.** If the sender and subject
-   already decide the bucket, don't fetch the body.
-4. **Act on the safe end only.** Marking read, starring, labelling, and
-   archiving are reversible — do them. Replying, sending, and deleting are not
-   — propose those and let the user confirm.
+**Report** the reply-needed count first, then one line each: sender, what they
+want, how old. Summarise the rest as counts. Nothing needing a reply is a
+one-sentence answer.
 
-## Reporting
-
-Lead with the count that matters: how many need a reply. Then list them, one
-line each — sender, what they want, and how old the request is. Summarise the
-rest as counts, not lists. A triage report that lists 40 newsletters has buried
-the two messages that mattered.
-
-If nothing needs a reply, say exactly that in one sentence and stop.
-
-## Judgement calls
-
-- **Age beats volume.** A four-day-old direct question outranks twenty
-  minutes-old bulk messages.
-- **A thread the user already replied to is usually handled** — check before
-  flagging it as waiting.
-- **Never infer urgency from the sender's own words.** "URGENT" in a subject
-  line is a claim, not a fact.
+Age beats volume. A thread the user already answered is handled. "URGENT" in a
+subject line is a claim, not a fact.

--- a/hub/agents/email/python/gaia_agent_email/skills/inbox-triage/SKILL.md
+++ b/hub/agents/email/python/gaia_agent_email/skills/inbox-triage/SKILL.md
@@ -1,0 +1,53 @@
+---
+name: inbox-triage
+description: Sort an inbox into what needs a reply, what needs a decision, and what is just noise. Use when the user asks to triage, catch up on, clean up, or make sense of their inbox.
+version: 0.1.0
+metadata:
+  gaia:
+    tools_required:
+      - pre_scan_inbox
+      - triage_inbox
+      - get_message
+      - archive_message
+      - label_message
+      - add_star
+      - mark_read
+---
+
+# Inbox Triage
+
+Triage answers one question per message: **does a human have to act on this?**
+
+## Procedure
+
+1. **Scan before reading.** `pre_scan_inbox` for the shape of the backlog,
+   then `triage_inbox` for the categorised pass. Never open messages one by one
+   to build a picture — that burns the context budget and misses the pattern.
+2. **Sort into four buckets**, in this order:
+   - **Needs a reply** — a person is waiting on the user specifically.
+   - **Needs a decision** — no reply required, but an action or choice is.
+   - **For information** — worth knowing, nothing owed.
+   - **Noise** — bulk, automated, or already-handled mail.
+3. **Open only what the category can't settle.** If the sender and subject
+   already decide the bucket, don't fetch the body.
+4. **Act on the safe end only.** Marking read, starring, labelling, and
+   archiving are reversible — do them. Replying, sending, and deleting are not
+   — propose those and let the user confirm.
+
+## Reporting
+
+Lead with the count that matters: how many need a reply. Then list them, one
+line each — sender, what they want, and how old the request is. Summarise the
+rest as counts, not lists. A triage report that lists 40 newsletters has buried
+the two messages that mattered.
+
+If nothing needs a reply, say exactly that in one sentence and stop.
+
+## Judgement calls
+
+- **Age beats volume.** A four-day-old direct question outranks twenty
+  minutes-old bulk messages.
+- **A thread the user already replied to is usually handled** — check before
+  flagging it as waiting.
+- **Never infer urgency from the sender's own words.** "URGENT" in a subject
+  line is a claim, not a fact.

--- a/hub/agents/email/python/gaia_agent_email/skills/meeting-scheduling/SKILL.md
+++ b/hub/agents/email/python/gaia_agent_email/skills/meeting-scheduling/SKILL.md
@@ -16,40 +16,23 @@ metadata:
 
 # Meeting Scheduling
 
-Every meeting request resolves to one of three answers: **yes**, **no**, or
-**not then**. Get to one of the three; never leave it open.
+Every request resolves to **yes**, **no**, or **not then**. Reach one of the
+three; never leave it open.
 
-## Procedure
+- Confirm it is a request (`detect_meeting_request`) — a date in an email is not
+  an invitation.
+- Check before answering: `detect_calendar_conflicts` for the slot,
+  `list_calendar_events` for the surrounding day. A free slot wedged between two
+  calls is worth flagging.
+- Free and relevant → recommend accepting. Conflicting → offer at most three
+  genuinely free alternatives. Not the user's concern → recommend declining with
+  a one-line reason.
+- Accepting, declining, and proposing all notify the organiser: `draft_reply`,
+  show it, wait. Never RSVP because the slot looked free.
 
-1. **Confirm it is a request.** `detect_meeting_request` — an email mentioning a
-   date is not necessarily asking for a meeting.
-2. **Check the calendar before answering.** `detect_calendar_conflicts` for the
-   proposed slot, and `list_calendar_events` for the surrounding day. A slot
-   that is technically free but wedged between two other meetings is worth
-   flagging.
-3. **Pick the answer:**
-   - Free and clearly relevant → recommend accepting.
-   - Conflicting → offer the nearest genuinely free alternatives, at most three.
-   - Not relevant to the user → recommend declining, with a one-line reason.
-4. **Accepting or declining an invitation notifies the organiser** — always
-   confirm with the user first. Same for a reply that proposes a new time:
-   `draft_reply`, show it, wait.
+**Report** request, verdict, reason — in that order. Include the time zone
+whenever participants are not obviously in one.
 
-## Reporting
-
-State the request, the verdict, and the reason in that order:
-
-> Thursday 14:00, 30 min, project sync — **conflicts** with an existing call at
-> 14:00. Nearest free: Thu 15:30, Fri 10:00.
-
-Include the time zone whenever the participants are not obviously in one.
-
-## Judgement calls
-
-- **A time range is not a time.** "Sometime Thursday" needs a proposal, not an
-  acceptance.
-- **Recurring requests need the whole series checked**, not just the first
-  instance.
-- **Working hours are a constraint, not a suggestion** — do not propose a slot
-  outside the pattern the user's own calendar shows.
-- **Never accept on the user's behalf** because the slot looks free.
+A time range is not a time; "sometime Thursday" needs a proposal. Recurring
+requests need the whole series checked. Do not propose a slot outside the working
+pattern the user's own calendar shows.

--- a/hub/agents/email/python/gaia_agent_email/skills/meeting-scheduling/SKILL.md
+++ b/hub/agents/email/python/gaia_agent_email/skills/meeting-scheduling/SKILL.md
@@ -1,0 +1,55 @@
+---
+name: meeting-scheduling
+description: Turn meeting requests in email into calendar decisions — accept, decline, or propose another time. Use when a message asks to meet, when the user asks about invitations, or when checking whether a proposed time is free.
+version: 0.1.0
+metadata:
+  gaia:
+    tools_required:
+      - detect_meeting_request
+      - detect_calendar_conflicts
+      - list_calendar_events
+      - create_event_from_email
+      - accept_invite
+      - decline_invite
+      - draft_reply
+---
+
+# Meeting Scheduling
+
+Every meeting request resolves to one of three answers: **yes**, **no**, or
+**not then**. Get to one of the three; never leave it open.
+
+## Procedure
+
+1. **Confirm it is a request.** `detect_meeting_request` — an email mentioning a
+   date is not necessarily asking for a meeting.
+2. **Check the calendar before answering.** `detect_calendar_conflicts` for the
+   proposed slot, and `list_calendar_events` for the surrounding day. A slot
+   that is technically free but wedged between two other meetings is worth
+   flagging.
+3. **Pick the answer:**
+   - Free and clearly relevant → recommend accepting.
+   - Conflicting → offer the nearest genuinely free alternatives, at most three.
+   - Not relevant to the user → recommend declining, with a one-line reason.
+4. **Accepting or declining an invitation notifies the organiser** — always
+   confirm with the user first. Same for a reply that proposes a new time:
+   `draft_reply`, show it, wait.
+
+## Reporting
+
+State the request, the verdict, and the reason in that order:
+
+> Thursday 14:00, 30 min, project sync — **conflicts** with an existing call at
+> 14:00. Nearest free: Thu 15:30, Fri 10:00.
+
+Include the time zone whenever the participants are not obviously in one.
+
+## Judgement calls
+
+- **A time range is not a time.** "Sometime Thursday" needs a proposal, not an
+  acceptance.
+- **Recurring requests need the whole series checked**, not just the first
+  instance.
+- **Working hours are a constraint, not a suggestion** — do not propose a slot
+  outside the pattern the user's own calendar shows.
+- **Never accept on the user's behalf** because the slot looks free.

--- a/hub/agents/email/python/gaia_agent_email/skills/newsletter-digest/SKILL.md
+++ b/hub/agents/email/python/gaia_agent_email/skills/newsletter-digest/SKILL.md
@@ -14,35 +14,19 @@ metadata:
 
 # Newsletter Digest
 
-Bulk mail is read in aggregate or not at all. The goal is one digest the user
-can skim in under a minute, then an empty folder.
+Bulk mail is read in aggregate or not at all. Produce one digest the user can
+skim in under a minute, then clear the folder.
 
-## Procedure
+- Gather by shape, not by guess: `search_messages` over the provider's bulk
+  categories and unsubscribe-bearing senders.
+- Summarise **per source**, one line covering everything they sent — five
+  messages from one sender become one line.
+- Pull out what is actually actionable (a dated event, an expiring notice, a
+  receipt) and name it separately. That is not digest material.
+- Then `archive_message_batch`; label first if the user wants them findable.
 
-1. **Gather by shape, not by guess.** Use `search_messages` with the provider's
-   own bulk categories and unsubscribe-bearing senders. Don't classify a
-   message as a newsletter because its subject looks promotional.
-2. **Summarise per source, not per message.** One line per sender covering
-   everything they sent in the window. Five messages from one source become one
-   line.
-3. **Keep what is actually actionable.** A dated event, an expiring account
-   notice, or a receipt is not digest material — pull it out and name it
-   separately.
-4. **Then clear.** Archive in batches with `archive_message_batch`, and label
-   first if the user wants them findable later. Archiving is reversible;
-   deleting is not — never delete bulk mail on your own initiative.
+**Report** the count and window ("18 newsletters since Monday"), the per-source
+lines oldest-first, then the actionable items and what you archived.
 
-## Reporting
-
-Open with the count and the window ("18 newsletters since Monday"). Then the
-per-source lines, longest-standing first. End with anything you pulled out as
-actionable, and say plainly what you archived.
-
-## Judgement calls
-
-- **A digest with more than about a dozen lines is a list, not a digest** —
-  group harder.
-- **Say nothing about a source that sent nothing worth a line.** Count it,
-  don't describe it.
-- **Never unsubscribe on the user's behalf** — surface the option and let them
-  decide.
+More than a dozen lines is a list, not a digest — group harder. Never delete
+bulk mail and never unsubscribe on the user's behalf.

--- a/hub/agents/email/python/gaia_agent_email/skills/newsletter-digest/SKILL.md
+++ b/hub/agents/email/python/gaia_agent_email/skills/newsletter-digest/SKILL.md
@@ -1,0 +1,48 @@
+---
+name: newsletter-digest
+description: Condense newsletters, promotions, and other bulk mail into one short digest and clear them out. Use when the user asks what they missed in their subscriptions, wants a digest of bulk mail, or asks to clean up promotions.
+version: 0.1.0
+metadata:
+  gaia:
+    tools_required:
+      - search_messages
+      - summarize_message
+      - summarize_thread
+      - archive_message_batch
+      - label_message_batch
+---
+
+# Newsletter Digest
+
+Bulk mail is read in aggregate or not at all. The goal is one digest the user
+can skim in under a minute, then an empty folder.
+
+## Procedure
+
+1. **Gather by shape, not by guess.** Use `search_messages` with the provider's
+   own bulk categories and unsubscribe-bearing senders. Don't classify a
+   message as a newsletter because its subject looks promotional.
+2. **Summarise per source, not per message.** One line per sender covering
+   everything they sent in the window. Five messages from one source become one
+   line.
+3. **Keep what is actually actionable.** A dated event, an expiring account
+   notice, or a receipt is not digest material — pull it out and name it
+   separately.
+4. **Then clear.** Archive in batches with `archive_message_batch`, and label
+   first if the user wants them findable later. Archiving is reversible;
+   deleting is not — never delete bulk mail on your own initiative.
+
+## Reporting
+
+Open with the count and the window ("18 newsletters since Monday"). Then the
+per-source lines, longest-standing first. End with anything you pulled out as
+actionable, and say plainly what you archived.
+
+## Judgement calls
+
+- **A digest with more than about a dozen lines is a list, not a digest** —
+  group harder.
+- **Say nothing about a source that sent nothing worth a line.** Count it,
+  don't describe it.
+- **Never unsubscribe on the user's behalf** — surface the option and let them
+  decide.

--- a/hub/agents/email/python/gaia_agent_email/skills/travel-itinerary/SKILL.md
+++ b/hub/agents/email/python/gaia_agent_email/skills/travel-itinerary/SKILL.md
@@ -1,0 +1,50 @@
+---
+name: travel-itinerary
+description: Assemble scattered booking confirmations into one chronological itinerary. Use when the user asks about an upcoming trip, their flight or hotel details, or wants an itinerary built from their email.
+version: 0.1.0
+metadata:
+  gaia:
+    tools_required:
+      - search_messages
+      - get_message
+      - summarize_message
+      - list_calendar_events
+      - create_event_from_email
+---
+
+# Travel Itinerary
+
+A trip arrives as a dozen unrelated confirmations from different senders. The
+job is one timeline, in the traveller's local order, with nothing invented.
+
+## Procedure
+
+1. **Find the bookings.** `search_messages` for confirmation-shaped mail in the
+   trip window: flights, trains, lodging, car hire, tickets.
+2. **Read each confirmation once** and pull only: what it is, the date and time,
+   the location, and the reference number.
+3. **Order by departure time, not by when the email arrived.**
+4. **Cross-check the calendar** with `list_calendar_events` before offering to
+   add anything — a booking already on the calendar must not be duplicated.
+5. **Offer, then add.** Use `create_event_from_email` only for entries the user
+   confirms.
+
+## Reporting
+
+One line per segment, in time order:
+
+`Tue 14 Mar · 08:40 · Flight · <origin> → <destination> · ref <code>`
+
+Then, separately, anything you could not resolve: a segment with no return leg,
+two bookings that overlap, a gap with no lodging. Name the gap; do not fill it.
+
+## Judgement calls
+
+- **Never invent a detail to complete the timeline.** A missing gate, terminal,
+  or seat is reported as missing.
+- **Later confirmations supersede earlier ones** for the same reference — a
+  changed flight has two emails, and only the latest is true.
+- **Times are the local time at each location** unless the confirmation says
+  otherwise. Say which zone when a segment crosses one.
+- **Cancellations count.** A cancelled booking must not appear as a live
+  segment.

--- a/hub/agents/email/python/gaia_agent_email/skills/travel-itinerary/SKILL.md
+++ b/hub/agents/email/python/gaia_agent_email/skills/travel-itinerary/SKILL.md
@@ -14,37 +14,21 @@ metadata:
 
 # Travel Itinerary
 
-A trip arrives as a dozen unrelated confirmations from different senders. The
-job is one timeline, in the traveller's local order, with nothing invented.
+A trip arrives as a dozen unrelated confirmations. Produce one timeline, with
+nothing invented.
 
-## Procedure
+- `search_messages` for confirmation-shaped mail in the trip window: flights,
+  trains, lodging, car hire, tickets.
+- Per confirmation, keep only: what it is, date and time, location, reference.
+- Order by departure time, never by when the email arrived.
+- Check `list_calendar_events` before offering to add anything — never duplicate
+  a booking already on the calendar. Add only what the user confirms.
 
-1. **Find the bookings.** `search_messages` for confirmation-shaped mail in the
-   trip window: flights, trains, lodging, car hire, tickets.
-2. **Read each confirmation once** and pull only: what it is, the date and time,
-   the location, and the reference number.
-3. **Order by departure time, not by when the email arrived.**
-4. **Cross-check the calendar** with `list_calendar_events` before offering to
-   add anything — a booking already on the calendar must not be duplicated.
-5. **Offer, then add.** Use `create_event_from_email` only for entries the user
-   confirms.
-
-## Reporting
-
-One line per segment, in time order:
-
+**Report** one line per segment, in time order:
 `Tue 14 Mar · 08:40 · Flight · <origin> → <destination> · ref <code>`
+Then, separately, what you could not resolve: a leg with no return, an overlap,
+a night with no lodging. Name the gap; do not fill it.
 
-Then, separately, anything you could not resolve: a segment with no return leg,
-two bookings that overlap, a gap with no lodging. Name the gap; do not fill it.
-
-## Judgement calls
-
-- **Never invent a detail to complete the timeline.** A missing gate, terminal,
-  or seat is reported as missing.
-- **Later confirmations supersede earlier ones** for the same reference — a
-  changed flight has two emails, and only the latest is true.
-- **Times are the local time at each location** unless the confirmation says
-  otherwise. Say which zone when a segment crosses one.
-- **Cancellations count.** A cancelled booking must not appear as a live
-  segment.
+Never invent a detail to complete the timeline. A later confirmation supersedes
+an earlier one for the same reference. Times are local to each location — say
+which zone when a segment crosses one. A cancelled booking is not a segment.

--- a/hub/agents/email/python/gaia_agent_email/tools/read_tools.py
+++ b/hub/agents/email/python/gaia_agent_email/tools/read_tools.py
@@ -33,6 +33,7 @@ from gaia_agent_email.context_budget import (
     active_profile_ctx_size,
     envelope_budget_tokens,
     estimate_tokens_json,
+    skill_prompt_tokens,
 )
 from gaia_agent_email.gmail_backend import decode_message_body
 from gaia_agent_email.tools.envelope import _envelope_err, _envelope_ok
@@ -2289,7 +2290,13 @@ class ReadToolsMixin:
                     log.debug("triage: host signature unreadable (%s)", exc)
 
                 return _envelope_ok(
-                    condense_triage_result(agent._triage_all_backends(**kwargs))
+                    condense_triage_result(
+                        agent._triage_all_backends(**kwargs),
+                        # Loaded skill bodies are prompt text the agent re-reads
+                        # on the post-tool turn (#2466) — give the envelope back
+                        # what they cost, or the turn overflows the window.
+                        extra_fixed_tokens=skill_prompt_tokens(agent),
+                    )
                 )
             except ConnectorsError as exc:
                 return _envelope_err(format_connector_error(exc))

--- a/hub/agents/email/python/gaia_agent_email/tools/triage_condense.py
+++ b/hub/agents/email/python/gaia_agent_email/tools/triage_condense.py
@@ -44,7 +44,10 @@ def _estimate_envelope_tokens(envelope: Dict[str, Any]) -> int:
 
 
 def condense_triage_result(
-    result: Dict[str, Any], *, budget_tokens: int | None = None
+    result: Dict[str, Any],
+    *,
+    budget_tokens: int | None = None,
+    extra_fixed_tokens: int = 0,
 ) -> Dict[str, Any]:
     """Bound the bulk-triage result envelope to the agent-loop ctx budget.
 
@@ -57,9 +60,13 @@ def condense_triage_result(
     preserved verbatim because it already carries the complete id-to-category
     map compactly, so no verdict is truly lost — only its verbose per-message
     fields (subject / from / rationale).
+
+    ``extra_fixed_tokens`` shrinks the budget by prompt text this launch carries
+    beyond the modelled fixed cost — the loaded skill bodies (#2466). Ignored
+    when ``budget_tokens`` is given explicitly, which is the tests' seam.
     """
     if budget_tokens is None:
-        budget_tokens = envelope_budget_tokens()
+        budget_tokens = envelope_budget_tokens(extra_fixed_tokens=extra_fixed_tokens)
 
     if _estimate_envelope_tokens(result) <= budget_tokens:
         return result

--- a/hub/agents/email/python/packaging/freeze.py
+++ b/hub/agents/email/python/packaging/freeze.py
@@ -25,6 +25,10 @@ Design notes / gotchas baked in (see README.md for the why):
   (``classify_email_llm`` / ``summarize_email_llm`` etc.); collect the whole
   ``gaia_agent_email`` package so the triage path is present in the freeze.
 - ``gaia.connectors`` discovers providers dynamically; collect it explicitly.
+- The bundled Agent Skills (``gaia_agent_email/skills/*/SKILL.md``) and
+  ``gaia-agent.yaml`` are DATA, invisible to the import analyzer -> ``--add-data``.
+  Without them the frozen sidecar starts with no skills and no declared skill
+  sets (#2466).
 - We deliberately do NOT ``--collect-submodules gaia`` (the whole core package
   pulls every agent + RAG + torch and explodes the binary). Static analysis from
   the email router pulls only the reachable core modules.
@@ -39,6 +43,7 @@ Design notes / gotchas baked in (see README.md for the why):
 from __future__ import annotations
 
 import argparse
+import os
 import shutil
 import sys
 import time
@@ -52,6 +57,17 @@ REPO_ROOT = HERE.parents[4]
 # Editable installs are invisible to PyInstaller's static analyzer, so point it
 # at the source roots directly: the email package and the core ``src`` tree.
 PATHEX = [REPO_ROOT / "hub" / "agents" / "email" / "python", REPO_ROOT / "src"]
+
+# Data the import analyzer cannot see (#2466). Each entry is
+# ``(source path, destination directory inside the bundle)``; the destination
+# mirrors where ``gaia_agent_email.agent`` looks for it at runtime.
+PKG_ROOT = REPO_ROOT / "hub" / "agents" / "email" / "python"
+ADD_DATA = [
+    (PKG_ROOT / "gaia_agent_email" / "skills", "gaia_agent_email/skills"),
+    # Staged INSIDE the package: at runtime the frozen agent has no package-root
+    # directory above itself, so the source-checkout location does not exist.
+    (PKG_ROOT / "gaia-agent.yaml", "gaia_agent_email"),
+]
 
 # Heavy ML stack reached only via the lazily-imported triage import graph. Real
 # triage uses Lemonade over HTTP (no in-process torch), so these are excluded to
@@ -134,6 +150,14 @@ def build(onefile: bool = False, clean: bool = True) -> Path:
         "--collect-submodules",
         "pydantic",
     ]
+    for source, dest in ADD_DATA:
+        if not source.exists():
+            raise SystemExit(
+                f"freeze: required bundle data is missing: {source}. The frozen "
+                "sidecar would start with no bundled skills / no declared skill "
+                "sets. Restore the file or update ADD_DATA."
+            )
+        args += ["--add-data", f"{source}{os.pathsep}{dest}"]
     for mod in EXCLUDES:
         args += ["--exclude-module", mod]
     if onefile:

--- a/hub/agents/email/python/pyproject.toml
+++ b/hub/agents/email/python/pyproject.toml
@@ -49,3 +49,11 @@ test = ["pytest"]
 
 [tool.setuptools.packages.find]
 include = ["gaia_agent_email*"]
+
+# Bundled Agent Skills (#2466) are data, not modules — without this they are
+# absent from an installed wheel and SKILL_DIRS points at nothing. gaia-agent.yaml
+# is listed for the packaged layout (the release pipeline stages a copy inside the
+# package); in a source checkout the agent resolves the canonical one at the
+# package root.
+[tool.setuptools.package-data]
+gaia_agent_email = ["skills/*/SKILL.md", "skills/*/*.py", "gaia-agent.yaml"]

--- a/hub/agents/email/python/pyproject.toml
+++ b/hub/agents/email/python/pyproject.toml
@@ -51,9 +51,14 @@ test = ["pytest"]
 include = ["gaia_agent_email*"]
 
 # Bundled Agent Skills (#2466) are data, not modules — without this they are
-# absent from an installed wheel and SKILL_DIRS points at nothing. gaia-agent.yaml
-# is listed for the packaged layout (the release pipeline stages a copy inside the
-# package); in a source checkout the agent resolves the canonical one at the
-# package root.
+# absent from an installed wheel and SKILL_DIRS points at nothing.
 [tool.setuptools.package-data]
 gaia_agent_email = ["skills/*/SKILL.md", "skills/*/*.py", "gaia-agent.yaml"]
+
+# gaia-agent.yaml lives at the package ROOT (the hub artifact), but the agent
+# reads it at runtime and an installed wheel has no directory above
+# gaia_agent_email/ — package-data cannot reach outside its own package. The
+# build_py hook copies it in, so every install path ships it from the single
+# authored file. See _build_hooks.py.
+[tool.setuptools.cmdclass]
+build_py = "_build_hooks.build_py"

--- a/hub/agents/email/python/tests/test_skill_sets_2466.py
+++ b/hub/agents/email/python/tests/test_skill_sets_2466.py
@@ -1,0 +1,396 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""Bundled skills + account-keyed skill-set selection (#2466).
+
+Cold-state discipline: every agent here is built with ``tmp_path``-scoped
+databases and a ``SkillManager`` whose user and Claude-import roots point at
+empty tmp directories. Nothing reads the developer's ``~/.gaia/skills`` or the
+repo's ``.claude/skills``, so a skill only resolves if this package really ships
+it — which is the whole claim under test.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+import yaml
+
+from gaia.connectors.providers.microsoft import (
+    ACCOUNT_TYPE_PERSONAL,
+    ACCOUNT_TYPE_WORK,
+)
+from gaia.skills import SkillManager
+from gaia.skills.errors import SkillSetError
+
+from gaia_agent_email.agent import (
+    ACCOUNT_TYPE_SKILL_SETS,
+    EmailTriageAgent,
+    _locate_agent_manifest,
+)
+from gaia_agent_email.config import (
+    ACCOUNT_TYPE_ENV,
+    SKILL_SET_ENV,
+    ConfigurationError,
+    EmailAgentConfig,
+)
+
+_PKG_ROOT = Path(__file__).resolve().parents[1]
+_MANIFEST = _PKG_ROOT / "gaia-agent.yaml"
+_SKILLS_DIR = _PKG_ROOT / "gaia_agent_email" / "skills"
+
+
+class _MinimalMailBackend:
+    def list_messages(self, *args, **kwargs):
+        return []
+
+    def get_message(self, *args, **kwargs):
+        return {}
+
+
+class _MinimalCalendarBackend:
+    def list_events(self, *args, **kwargs):
+        return []
+
+
+def _isolated_manager(tmp_path: Path) -> SkillManager:
+    """A manager whose only populated root is the package's bundled skills."""
+    return SkillManager(
+        agent_skill_dirs=EmailTriageAgent.SKILL_DIRS,
+        user_skills_root=tmp_path / "cold-user-root" / "skills",
+        claude_skill_dirs=[tmp_path / "cold-claude-root" / "skills"],
+    )
+
+
+def _build_agent(tmp_path, monkeypatch, **config_kwargs) -> EmailTriageAgent:
+    monkeypatch.setenv("GAIA_MEMORY_DISABLED", "1")
+    monkeypatch.delenv(SKILL_SET_ENV, raising=False)
+    monkeypatch.delenv(ACCOUNT_TYPE_ENV, raising=False)
+    config = EmailAgentConfig(
+        model_id="test-model",
+        gmail_backend=_MinimalMailBackend(),
+        calendar_backend=_MinimalCalendarBackend(),
+        db_path=str(tmp_path / "state.db"),
+        memory_db_path=str(tmp_path / "memory.db"),
+        silent_mode=True,
+        start_scheduler=False,
+        **config_kwargs,
+    )
+    manager = _isolated_manager(tmp_path)
+    with patch("gaia.agents.base.agent.AgentSDK") as mock_sdk:
+        mock_sdk.return_value = MagicMock()
+        with patch.object(
+            EmailTriageAgent, "skill_manager", property(lambda self: manager)
+        ):
+            return EmailTriageAgent(config=config)
+
+
+# ----------------------------------------------------------------------
+# The bundled skills ship, and the manifest matches them
+# ----------------------------------------------------------------------
+
+
+def test_every_declared_skill_is_actually_bundled():
+    """A set naming a skill this package does not ship would fail at launch."""
+    declared = yaml.safe_load(_MANIFEST.read_text(encoding="utf-8"))
+    names = {
+        name for entries in declared["skill_sets"].values() for name in entries
+    } | set(declared.get("skills") or [])
+
+    for name in sorted(names):
+        assert (
+            _SKILLS_DIR / name / "SKILL.md"
+        ).is_file(), f"skill_sets names {name!r} but gaia_agent_email/skills/{name}/SKILL.md is missing"
+
+
+def test_no_bundled_skill_is_orphaned():
+    """A shipped skill no set references is dead weight in the package."""
+    declared = yaml.safe_load(_MANIFEST.read_text(encoding="utf-8"))
+    referenced = {
+        name for entries in declared["skill_sets"].values() for name in entries
+    } | set(declared.get("skills") or [])
+    on_disk = {p.parent.name for p in _SKILLS_DIR.glob("*/SKILL.md")}
+    assert on_disk == referenced
+
+
+def test_bundled_skills_are_instruction_only(tmp_path):
+    """v1 ships no new tool or permission surface (#2466 non-goals).
+
+    A skill that declared tools would change the agent's tool count, and one
+    that declared a permission would change its connector requirements — both
+    belong to later phases.
+    """
+    manager = _isolated_manager(tmp_path)
+    discovered = manager.list_skills()
+    assert manager.discovery_errors == {}
+    assert len(discovered) == 6
+
+    for summary in discovered:
+        skill = manager.load(summary.name)
+        assert skill.gaia.tools == [], f"{skill.name} declares tools"
+        assert skill.gaia.permissions == [], f"{skill.name} declares permissions"
+        assert skill.body.strip(), f"{skill.name} has an empty body"
+        assert "Use when" in skill.description, (
+            f"{skill.name}'s description carries no trigger phrase, so the model "
+            "cannot judge when it applies"
+        )
+
+
+def test_declared_tools_required_all_exist_in_the_agents_registry(tmp_path, monkeypatch):
+    """A skill whose recipe names a tool this agent lacks cannot be executed."""
+    agent = _build_agent(tmp_path, monkeypatch)
+    manager = _isolated_manager(tmp_path)
+    registry = agent._tools_registry
+
+    for summary in manager.list_skills():
+        skill = manager.load(summary.name)
+        missing = [t for t in skill.gaia.tools_required if t not in registry]
+        assert not missing, f"{skill.name} requires unregistered tool(s): {missing}"
+
+
+def test_the_manifest_is_locatable_from_a_source_checkout():
+    assert _locate_agent_manifest() == _MANIFEST
+    assert Path(EmailTriageAgent.SKILL_MANIFEST).is_file()
+
+
+def test_the_frozen_binary_bundles_the_skills_and_the_manifest():
+    """The freeze must stage both as data — the import analyzer cannot see them.
+
+    Without this the frozen sidecar starts with an empty bundled root and no
+    declared sets, which no unit test running from a checkout would notice.
+    """
+    # Loaded by path: ``packaging`` resolves to the installed distribution.
+    import importlib.util
+
+    spec = importlib.util.spec_from_file_location(
+        "email_freeze", _PKG_ROOT / "packaging" / "freeze.py"
+    )
+    freeze = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(freeze)
+
+    staged = {(src.name, dest) for src, dest in freeze.ADD_DATA}
+    assert ("skills", "gaia_agent_email/skills") in staged
+    assert ("gaia-agent.yaml", "gaia_agent_email") in staged
+    for source, _dest in freeze.ADD_DATA:
+        assert source.exists(), f"freeze stages {source}, which does not exist"
+
+
+# ----------------------------------------------------------------------
+# Selection
+# ----------------------------------------------------------------------
+
+
+def _declared_sets():
+    """The manifest's parsed declarations, read the way the framework reads them."""
+    from gaia.hub.manifest import parse as parse_manifest
+
+    return parse_manifest(EmailTriageAgent.SKILL_MANIFEST).skill_sets
+
+
+def test_manifest_declarations():
+    sets = _declared_sets()
+    assert sets.set_names == ["personal", "work"]
+    assert sets.default_set == "personal"
+    personal = [ref.name for ref in sets.skills_for("personal")]
+    work = [ref.name for ref in sets.skills_for("work")]
+    assert personal == ["inbox-triage", "newsletter-digest", "travel-itinerary"]
+    assert work == [
+        "inbox-triage",
+        "meeting-scheduling",
+        "action-item-extraction",
+        "escalation-routing",
+    ]
+    # The overlap is the point: sets are not a partition.
+    assert set(personal) & set(work) == {"inbox-triage"}
+
+
+def test_account_type_map_only_names_declared_sets():
+    sets = _declared_sets()
+    assert set(ACCOUNT_TYPE_SKILL_SETS) == {ACCOUNT_TYPE_PERSONAL, ACCOUNT_TYPE_WORK}
+    for account_type, set_name in ACCOUNT_TYPE_SKILL_SETS.items():
+        assert set_name in sets.set_names, (
+            f"account type {account_type!r} maps to skill set {set_name!r}, "
+            "which gaia-agent.yaml does not declare"
+        )
+
+
+@pytest.mark.parametrize(
+    "account_type, expected_set, expected_skills",
+    [
+        (
+            ACCOUNT_TYPE_PERSONAL,
+            "personal",
+            {"inbox-triage", "newsletter-digest", "travel-itinerary"},
+        ),
+        (
+            ACCOUNT_TYPE_WORK,
+            "work",
+            {
+                "inbox-triage",
+                "meeting-scheduling",
+                "action-item-extraction",
+                "escalation-routing",
+            },
+        ),
+    ],
+)
+def test_account_type_selects_its_set_and_nothing_else(
+    tmp_path, monkeypatch, account_type, expected_set, expected_skills
+):
+    agent = _build_agent(tmp_path, monkeypatch, account_type=account_type)
+
+    assert agent.select_skill_set() == expected_set
+    assert agent.active_skill_set == expected_set
+    assert set(agent.loaded_skills) == expected_skills
+
+
+def test_the_other_sets_skills_are_absent_from_the_prompt(tmp_path, monkeypatch):
+    agent = _build_agent(tmp_path, monkeypatch, account_type=ACCOUNT_TYPE_WORK)
+    prompt = agent.system_prompt
+
+    assert "meeting-scheduling" in prompt
+    assert "newsletter-digest" not in prompt
+    assert "travel-itinerary" not in prompt
+
+
+def test_explicit_skill_set_overrides_the_account_type(tmp_path, monkeypatch):
+    agent = _build_agent(
+        tmp_path, monkeypatch, account_type=ACCOUNT_TYPE_WORK, skill_set="personal"
+    )
+    assert agent.active_skill_set == "personal"
+    assert "meeting-scheduling" not in agent.loaded_skills
+
+
+def test_unknown_skill_set_fails_loudly_listing_the_valid_ones(tmp_path, monkeypatch):
+    with pytest.raises(SkillSetError) as excinfo:
+        _build_agent(tmp_path, monkeypatch, skill_set="buisness")
+    assert "Valid sets: personal, work" in str(excinfo.value)
+
+
+def test_a_gmail_only_mailbox_resolves_the_default_set(tmp_path, monkeypatch):
+    """Gmail carries no Microsoft tenant, so the kind is genuinely unknown.
+
+    The default set must then apply *explicitly* — a work mailbox must never be
+    silently treated as personal because the signal was missing.
+    """
+    monkeypatch.setattr(
+        "gaia_agent_email.config.get_connection", lambda provider: None
+    )
+    agent = _build_agent(tmp_path, monkeypatch)
+
+    assert agent.config.resolve_account_type() is None
+    assert agent.select_skill_set() is None
+    assert agent.active_skill_set == "personal"  # the manifest's default_skill_set
+
+
+def test_a_derived_account_type_drives_the_set(tmp_path, monkeypatch):
+    """With nothing pinned, the kind recorded on the connection decides."""
+    monkeypatch.setattr(
+        "gaia_agent_email.config.get_connection",
+        lambda provider: (
+            {"account_type": ACCOUNT_TYPE_WORK} if provider == "microsoft" else None
+        ),
+    )
+    agent = _build_agent(tmp_path, monkeypatch)
+
+    assert agent.config.resolve_account_type() == ACCOUNT_TYPE_WORK
+    assert agent.active_skill_set == "work"
+
+
+def test_an_explicit_account_type_beats_the_connection(tmp_path, monkeypatch):
+    monkeypatch.setattr(
+        "gaia_agent_email.config.get_connection",
+        lambda provider: {"account_type": ACCOUNT_TYPE_WORK},
+    )
+    config = EmailAgentConfig(account_type=ACCOUNT_TYPE_PERSONAL)
+    assert config.resolve_account_type() == ACCOUNT_TYPE_PERSONAL
+
+
+def test_an_unreadable_connection_store_reports_unknown(monkeypatch):
+    """No keyring backend ⇒ unknown kind, not a crash and not a guess."""
+    from gaia.connectors.errors import ConnectorsError
+
+    def boom(provider):
+        raise ConnectorsError("no keyring backend available")
+
+    monkeypatch.setattr("gaia_agent_email.config.get_connection", boom)
+    assert EmailAgentConfig().resolve_account_type() is None
+
+
+def test_switching_sets_at_runtime_replaces_the_previous_one(tmp_path, monkeypatch):
+    agent = _build_agent(tmp_path, monkeypatch, account_type=ACCOUNT_TYPE_PERSONAL)
+    assert agent.active_skill_set == "personal"
+
+    agent.load_skill_set("work")
+
+    assert agent.active_skill_set == "work"
+    assert "newsletter-digest" not in agent.loaded_skills
+    assert "meeting-scheduling" in agent.loaded_skills
+
+
+# ----------------------------------------------------------------------
+# Config + env plumbing
+# ----------------------------------------------------------------------
+
+
+def test_skill_set_env_var_populates_the_config(monkeypatch):
+    monkeypatch.setenv(SKILL_SET_ENV, "work")
+    assert EmailAgentConfig().skill_set == "work"
+    monkeypatch.setenv(SKILL_SET_ENV, "   ")
+    assert EmailAgentConfig().skill_set is None
+
+
+def test_account_type_env_var_populates_the_config(monkeypatch):
+    monkeypatch.setenv(ACCOUNT_TYPE_ENV, "WORK")
+    assert EmailAgentConfig().account_type == ACCOUNT_TYPE_WORK
+
+
+def test_a_malformed_account_type_env_var_fails_loudly(monkeypatch):
+    monkeypatch.setenv(ACCOUNT_TYPE_ENV, "corporate")
+    with pytest.raises(ConfigurationError, match="not a valid account type"):
+        EmailAgentConfig()
+
+
+def test_a_malformed_account_type_field_fails_validation():
+    with pytest.raises(ConfigurationError, match="account_type must be one of"):
+        EmailAgentConfig(account_type="corporate").validate()
+
+
+# ----------------------------------------------------------------------
+# The --skill-set flag
+# ----------------------------------------------------------------------
+
+
+def test_skill_set_flag_exports_the_env_var(monkeypatch):
+    """The flag has to survive into the per-request agent sessions.
+
+    The app is built at import time and sessions are constructed per request, so
+    an argparse value that stayed in ``main()``'s locals would be silently
+    ignored.
+    """
+    import os
+
+    from gaia_agent_email import server
+
+    monkeypatch.delenv(SKILL_SET_ENV, raising=False)
+
+    with patch("uvicorn.run") as run:
+        assert server.main(["serve", "--skill-set", "work", "--port", "8199"]) == 0
+    assert run.called
+    assert os.environ[SKILL_SET_ENV] == "work"
+    assert EmailAgentConfig().skill_set == "work"
+
+
+def test_skill_set_flag_rejects_an_undeclared_name(capsys):
+    from gaia_agent_email import server
+
+    with pytest.raises(SystemExit):
+        server.main(["serve", "--skill-set", "buisness"])
+    assert "Valid sets: personal, work" in capsys.readouterr().err
+
+
+def test_skill_set_flag_help_lists_the_declared_sets():
+    from gaia_agent_email.server import _declared_skill_sets
+
+    assert _declared_skill_sets() == ["personal", "work"]

--- a/hub/agents/email/python/tests/test_skill_sets_2466.py
+++ b/hub/agents/email/python/tests/test_skill_sets_2466.py
@@ -468,7 +468,7 @@ def test_the_whole_post_tool_turn_fits_the_window_with_skills_loaded(
     condensed = condense_triage_result(result, extra_fixed_tokens=cost)
     envelope_tokens = estimate_tokens_json(json.dumps(condensed, default=str))
 
-    assert envelope_tokens <= envelope_budget_tokens(cost)
+    assert envelope_tokens <= envelope_budget_tokens(extra_fixed_tokens=cost)
 
     # The prompt the model re-reads on the post-tool turn, end to end.
     prompt_tokens = estimate_tokens(agent.system_prompt)

--- a/hub/agents/email/python/tests/test_skill_sets_2466.py
+++ b/hub/agents/email/python/tests/test_skill_sets_2466.py
@@ -330,6 +330,58 @@ def test_switching_sets_at_runtime_replaces_the_previous_one(tmp_path, monkeypat
 
 
 # ----------------------------------------------------------------------
+# Context budget: skills cost prompt tokens the tool result must give back
+# ----------------------------------------------------------------------
+
+
+def test_loaded_skills_shrink_the_triage_envelope_budget(tmp_path, monkeypatch):
+    """A skill body is prompt text the post-tool turn re-reads.
+
+    Regression guard: at the pinned 16,384-token envelope, adding the personal
+    set's skill bodies to the system prompt without taking them back out of the
+    tool-result budget pushed a limit-12 triage request to 16,602 tokens and the
+    run 400'd with ``context_length_exceeded``. Measured on hardware, not
+    theorised.
+    """
+    from gaia_agent_email.context_budget import (
+        envelope_budget_tokens,
+        skill_prompt_tokens,
+    )
+
+    agent = _build_agent(tmp_path, monkeypatch, account_type=ACCOUNT_TYPE_WORK)
+    cost = skill_prompt_tokens(agent)
+
+    assert cost > 0, "the work set loads four skill bodies; they cannot be free"
+    assert envelope_budget_tokens(extra_fixed_tokens=cost) == (
+        envelope_budget_tokens() - cost
+    )
+
+
+def test_the_bundled_skill_bodies_stay_within_their_prompt_budget(tmp_path):
+    """Cap the per-set prompt cost so a future edit can't quietly refill the ctx.
+
+    The envelope the triage tool has left is ``6144 - <set cost>``; a set costing
+    more than ~1,500 tokens starves the bulk-triage result envelope on the
+    16K-ctx hardware this agent targets.
+    """
+    from gaia.hub.manifest import parse as parse_manifest
+    from gaia_agent_email.context_budget import estimate_tokens
+
+    manager = _isolated_manager(tmp_path)
+    bodies = {s.name: manager.load(s.name).body for s in manager.list_skills()}
+    sets = parse_manifest(EmailTriageAgent.SKILL_MANIFEST).skill_sets
+
+    for name in sets.set_names:
+        cost = sum(
+            estimate_tokens(bodies[ref.name]) for ref in sets.skills_for(name)
+        )
+        assert cost <= 1500, (
+            f"skill set {name!r} costs ~{cost} prompt tokens, over the 1500 cap "
+            "— trim the SKILL.md bodies or shrink the set"
+        )
+
+
+# ----------------------------------------------------------------------
 # Config + env plumbing
 # ----------------------------------------------------------------------
 

--- a/hub/agents/email/python/tests/test_skill_sets_2466.py
+++ b/hub/agents/email/python/tests/test_skill_sets_2466.py
@@ -11,6 +11,7 @@ it — which is the whole claim under test.
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -152,6 +153,65 @@ def test_declared_tools_required_all_exist_in_the_agents_registry(tmp_path, monk
 def test_the_manifest_is_locatable_from_a_source_checkout():
     assert _locate_agent_manifest() == _MANIFEST
     assert Path(EmailTriageAgent.SKILL_MANIFEST).is_file()
+
+
+def test_the_manifest_is_locatable_from_an_installed_wheel_layout(monkeypatch):
+    """In a wheel there is no directory above the package to read it from.
+
+    ``package-data`` globs cannot reach outside their own package, so the build
+    stages a copy INSIDE ``gaia_agent_email/``. If only that copy exists, the
+    resolver must still find it — otherwise every ``pip install`` produces an
+    agent that cannot be constructed at all.
+    """
+    import tempfile
+
+    from gaia_agent_email import agent as agent_module
+
+    with tempfile.TemporaryDirectory() as raw:
+        root = Path(raw)
+        in_package = root / "gaia_agent_email" / "gaia-agent.yaml"
+        in_package.parent.mkdir(parents=True)
+        in_package.write_text(_MANIFEST.read_text(encoding="utf-8"), encoding="utf-8")
+        # Only the packaged copy exists — the checkout location does not.
+        assert not (root / "gaia-agent.yaml").exists()
+
+        monkeypatch.setattr(
+            agent_module,
+            "_MANIFEST_CANDIDATES",
+            (in_package, root / "gaia-agent.yaml"),
+        )
+        assert agent_module._locate_agent_manifest() == in_package
+
+
+def test_the_build_stages_the_manifest_into_the_package(tmp_path):
+    """The build_py hook is what makes the wheel layout above exist."""
+    import importlib.util
+
+    spec = importlib.util.spec_from_file_location(
+        "email_build_hooks", _PKG_ROOT / "_build_hooks.py"
+    )
+    hooks = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(hooks)
+
+    class _FakeBuildPy(hooks.build_py):
+        def __init__(self, build_lib):
+            self.build_lib = str(build_lib)
+
+        def announce(self, msg, level=1):
+            pass
+
+    _FakeBuildPy(tmp_path)._stage_agent_manifest()
+
+    staged = tmp_path / "gaia_agent_email" / "gaia-agent.yaml"
+    assert staged.is_file()
+    assert staged.read_text(encoding="utf-8") == _MANIFEST.read_text(encoding="utf-8")
+
+
+def test_pyproject_wires_the_build_hook_and_the_skill_package_data():
+    """Both halves are required; either one missing breaks a wheel install."""
+    text = (_PKG_ROOT / "pyproject.toml").read_text(encoding="utf-8")
+    assert 'build_py = "_build_hooks.build_py"' in text
+    assert "skills/*/SKILL.md" in text
 
 
 def test_the_frozen_binary_bundles_the_skills_and_the_manifest():
@@ -357,6 +417,86 @@ def test_loaded_skills_shrink_the_triage_envelope_budget(tmp_path, monkeypatch):
     )
 
 
+def test_the_whole_post_tool_turn_fits_the_window_with_skills_loaded(
+    tmp_path, monkeypatch
+):
+    """The behavioural claim, not the arithmetic identity.
+
+    Reproduces the shape of the real 400: system prompt (with the work set's
+    bodies) + a condensed triage envelope + the response reserve must all fit
+    ``CONTEXT_TARGET_TOKENS``. Sizing the envelope against a fixed cost that
+    predates skills is what pushed a limit-12 request to 16,602 tokens against a
+    16,384 window.
+
+    Sized at ``DEFAULT_INBOX_SCAN_CEILING`` — the per-call ceiling a real
+    interactive triage can reach. (Well beyond it the envelope's ``grouped``
+    verdict map alone exceeds the budget and the condenser cannot trim it; that
+    floor is independent of skills — it is identical with zero skill cost — so it
+    is not this change's to fix.)
+    """
+    from gaia_agent_email.config import DEFAULT_INBOX_SCAN_CEILING
+    from gaia_agent_email.context_budget import (
+        CONTEXT_TARGET_TOKENS,
+        _RESPONSE_RESERVE_TOKENS,
+        envelope_budget_tokens,
+        estimate_tokens,
+        estimate_tokens_json,
+        skill_prompt_tokens,
+    )
+    from gaia_agent_email.tools.triage_condense import condense_triage_result
+
+    agent = _build_agent(tmp_path, monkeypatch, account_type=ACCOUNT_TYPE_WORK)
+    cost = skill_prompt_tokens(agent)
+
+    # A triage result well over the envelope budget, so the condenser must act.
+    n = DEFAULT_INBOX_SCAN_CEILING
+    result = {
+        "results": [
+            {
+                "id": f"{i:032x}",
+                "subject": f"Subject line number {i} with some realistic length",
+                "from": f"sender{i}@example.invalid",
+                "category": "FYI",
+                "rationale": "A rationale sentence of the kind the classifier emits.",
+            }
+            for i in range(n)
+        ],
+        "grouped": {f"{i:032x}": "FYI" for i in range(n)},
+        "total": n,
+    }
+
+    condensed = condense_triage_result(result, extra_fixed_tokens=cost)
+    envelope_tokens = estimate_tokens_json(json.dumps(condensed, default=str))
+
+    assert envelope_tokens <= envelope_budget_tokens(cost)
+
+    # The prompt the model re-reads on the post-tool turn, end to end.
+    prompt_tokens = estimate_tokens(agent.system_prompt)
+    total = prompt_tokens + envelope_tokens + _RESPONSE_RESERVE_TOKENS
+    assert total <= CONTEXT_TARGET_TOKENS, (
+        f"post-tool turn would be ~{total} tokens against a "
+        f"{CONTEXT_TARGET_TOKENS} window (prompt {prompt_tokens} + envelope "
+        f"{envelope_tokens} + reserve {_RESPONSE_RESERVE_TOKENS})"
+    )
+
+
+def test_the_skill_cost_estimate_is_pessimistic(tmp_path, monkeypatch):
+    """A budget SUBTRACTION must never under-count.
+
+    ``estimate_tokens``' chars//4 prose ratio under-counts real Markdown by
+    roughly 2x (the module's own measured figure is ~2.1 chars/token). Crediting
+    the envelope only half of what the skills actually cost is how the turn
+    overflows anyway.
+    """
+    from gaia_agent_email.context_budget import estimate_tokens, skill_prompt_tokens
+
+    agent = _build_agent(tmp_path, monkeypatch, account_type=ACCOUNT_TYPE_WORK)
+    fragment = agent.get_skills_system_prompt()
+
+    assert skill_prompt_tokens(agent) >= estimate_tokens(fragment)
+    assert skill_prompt_tokens(agent) >= int(len(fragment) / 2.1)
+
+
 def test_the_bundled_skill_bodies_stay_within_their_prompt_budget(tmp_path):
     """Cap the per-set prompt cost so a future edit can't quietly refill the ctx.
 
@@ -446,3 +586,43 @@ def test_skill_set_flag_help_lists_the_declared_sets():
     from gaia_agent_email.server import _declared_skill_sets
 
     assert _declared_skill_sets() == ["personal", "work"]
+
+
+def test_an_invalid_env_var_is_rejected_at_startup_like_the_flag(monkeypatch, capsys):
+    """The docs call the env var equivalent to the flag — so it must validate.
+
+    Left unchecked, ``GAIA_EMAIL_SKILL_SET=buisness`` started a healthy-looking
+    sidecar whose every session then raised on construction.
+    """
+    from gaia_agent_email import server
+
+    monkeypatch.setenv(SKILL_SET_ENV, "buisness")
+    with pytest.raises(SystemExit):
+        server.main(["serve"])
+    assert "Valid sets: personal, work" in capsys.readouterr().err
+
+
+def test_a_valid_env_var_is_accepted_at_startup(monkeypatch):
+    from gaia_agent_email import server
+
+    monkeypatch.setenv(SKILL_SET_ENV, "work")
+    with patch("uvicorn.run") as run:
+        assert server.main(["serve", "--port", "8198"]) == 0
+    assert run.called
+
+
+def test_an_unreadable_manifest_cannot_wave_a_requested_set_through(monkeypatch, capsys):
+    """Validation must fail loudly, not degrade to "accept anything".
+
+    The help-text helper swallows read errors by design; using it to validate
+    would mean a build with an unreadable manifest accepts any name.
+    """
+    from gaia_agent_email import server
+
+    def boom():
+        raise RuntimeError("manifest unreadable")
+
+    monkeypatch.setattr(server, "_read_declared_skill_sets", boom)
+    with pytest.raises(SystemExit):
+        server.main(["serve", "--skill-set", "work"])
+    assert "could not be read" in capsys.readouterr().err

--- a/hub/agents/email/python/tests/test_triage_condense.py
+++ b/hub/agents/email/python/tests/test_triage_condense.py
@@ -107,6 +107,49 @@ class TestEnvelopeBudget:
         assert 0 < budget < CONTEXT_TARGET_TOKENS
 
 
+class TestSkillBodyAllowance:
+    """Loaded Agent Skills are prompt text the post-tool turn re-reads (#2466).
+
+    Before this accounting existed, the personal set's ~700 tokens of skill body
+    pushed a limit-12 triage request to 16,602 tokens against a 16,384 window and
+    the run 400'd with ``context_length_exceeded``. Every token a skill adds to
+    the prompt has to come out of the envelope, or the turn overflows.
+    """
+
+    def test_extra_fixed_tokens_shrink_the_envelope_one_for_one(self):
+        assert envelope_budget_tokens(extra_fixed_tokens=700) == envelope_budget_tokens() - 700
+
+    def test_zero_extra_is_byte_identical_to_the_pre_skills_budget(self):
+        assert envelope_budget_tokens(extra_fixed_tokens=0) == 6144
+        assert envelope_budget_tokens() == 6144
+
+    def test_a_negative_value_never_widens_the_envelope(self):
+        assert envelope_budget_tokens(extra_fixed_tokens=-5000) == 6144
+
+    def test_condense_honours_the_skill_allowance(self):
+        result = _make_result(20)
+        tight = condense_triage_result(result, extra_fixed_tokens=4000)
+        loose = condense_triage_result(result, extra_fixed_tokens=0)
+        assert _estimate_envelope_tokens(tight) <= envelope_budget_tokens(extra_fixed_tokens=4000)
+        assert len(tight.get("results", [])) <= len(loose.get("results", []))
+
+    def test_skill_prompt_tokens_measures_the_rendered_fragment(self):
+        from gaia_agent_email.context_budget import skill_prompt_tokens
+
+        class _NoSkills:
+            def get_skills_system_prompt(self):
+                return ""
+
+        class _WithSkills:
+            def get_skills_system_prompt(self):
+                return "==== LOADED SKILLS ====\n" + ("word " * 400)
+
+        assert skill_prompt_tokens(_NoSkills()) == 0
+        assert skill_prompt_tokens(_WithSkills()) > 300
+        # An agent predating the skills runtime has no renderer at all.
+        assert skill_prompt_tokens(object()) == 0
+
+
 class TestJsonCalibrationPin:
     """Pins the #2087 CI failure: at limit 60 the post-tool turn 400'd at
     19,815 tokens vs 16,384 because the prose estimator (chars//4) said the

--- a/src/gaia/agents/base/agent.py
+++ b/src/gaia/agents/base/agent.py
@@ -1147,38 +1147,74 @@ Do NOT wrap conversational replies in JSON.
         worse than one that refuses to launch.
 
         Called automatically at the end of ``Agent.__init__``. Call it again with
-        a different name to switch sets mid-session — skills from the previous
-        set are unloaded first, so the two never overlap.
+        a different name to switch sets mid-session; the previous set's skills are
+        unloaded once the new set has loaded, so the two never overlap.
+
+        **All-or-nothing.** A failure part-way through leaves the agent exactly as
+        it was — the previous set still loaded, ``active_skill_set`` still
+        accurate. A half-switched agent reporting one set while carrying another's
+        skills is worse than a raised error.
+
+        Note the switch is not sticky: a later bare ``load_skill_set()`` re-runs
+        the full resolution and returns to whatever that yields (the explicit
+        ``skill_set`` passed to ``__init__``, else the hook, else the default).
+        Pass the name again to stay on it.
         """
         from gaia.skills.errors import SkillNotFoundError
 
         declarations = self.skill_sets
+        explicit = requested if requested is not None else self._requested_skill_set
         if not declarations:
+            if (explicit or "").strip():
+                # Never drop an explicit request on the floor — resolve() raises
+                # with the actionable "this agent declares no skill_sets" message.
+                declarations.resolve(requested=explicit)
             return {}
 
         resolution = self.resolve_skill_set(requested)
         wanted = {ref.name for ref in resolution.skills}
+        previously_loaded = list(self._skill_set_loaded or [])
 
-        # Switching sets: drop what the PREVIOUS resolution loaded and this one
-        # does not declare, so a stale set never bleeds into the prompt. Scoped
-        # to set-loaded names only — a skill the agent loaded itself via
-        # ``load_skill`` is not a set's to unload.
-        for stale in [n for n in (self._skill_set_loaded or []) if n not in wanted]:
-            self.unload_skill(stale)
-
+        # Load the new set BEFORE dropping the old one, and track what this call
+        # actually brought in, so a failure can be undone completely.
         loaded: Dict[str, "Skill"] = {}
-        for ref in resolution.skills:
-            try:
-                loaded[ref.name] = self.load_skill(ref.name)
-            except SkillNotFoundError:
-                if ref.required:
-                    raise
-                logger.warning(
-                    "Optional skill '%s' (skill set '%s') was not found in any "
-                    "discovery root — continuing without it.",
-                    ref.name,
-                    resolution.name,
-                )
+        newly_loaded: List[str] = []
+        try:
+            for ref in resolution.skills:
+                already_present = ref.name in self.loaded_skills
+                try:
+                    loaded[ref.name] = self.load_skill(ref.name)
+                except SkillNotFoundError:
+                    if ref.required:
+                        raise
+                    logger.warning(
+                        "Optional skill '%s' (skill set '%s') was not found in "
+                        "any discovery root — continuing without it.",
+                        ref.name,
+                        resolution.name,
+                    )
+                    continue
+                if not already_present:
+                    newly_loaded.append(ref.name)
+        except Exception:
+            # Roll back to the pre-call state: drop only what this call added,
+            # and leave _active_skill_set / _skill_set_loaded untouched so the
+            # agent keeps reporting the set it is actually carrying.
+            for name in newly_loaded:
+                self.unload_skill(name)
+            logger.error(
+                "Skill set '%s' failed to load; the agent is unchanged and skill "
+                "set '%s' remains active.",
+                resolution.name,
+                self._active_skill_set or "(none)",
+            )
+            raise
+
+        # The new set is fully loaded — now retire the previous one's leftovers.
+        # Scoped to set-loaded names, so a skill the agent loaded itself via
+        # ``load_skill`` is never a set's to unload.
+        for stale in [n for n in previously_loaded if n not in wanted]:
+            self.unload_skill(stale)
 
         self._active_skill_set = resolution.name
         self._skill_set_loaded = list(loaded)

--- a/src/gaia/agents/base/agent.py
+++ b/src/gaia/agents/base/agent.py
@@ -319,6 +319,9 @@ class Agent(abc.ABC):
     _skill_sets: Optional[Any] = None
     _requested_skill_set: Optional[str] = None
     _active_skill_set: Optional[str] = None
+    # Names the last ``load_skill_set`` loaded, so switching sets unloads only
+    # what a set brought in — never a skill the agent loaded itself.
+    _skill_set_loaded: Optional[List[str]] = None
 
     # Define state constants
     STATE_PLANNING = "PLANNING"
@@ -1154,11 +1157,13 @@ Do NOT wrap conversational replies in JSON.
             return {}
 
         resolution = self.resolve_skill_set(requested)
-        wanted = {ref.name: ref for ref in resolution.skills}
+        wanted = {ref.name for ref in resolution.skills}
 
-        # Switching sets: drop anything the previous resolution loaded that the
-        # new one does not declare, so a stale set never bleeds into the prompt.
-        for stale in [name for name in self.loaded_skills if name not in wanted]:
+        # Switching sets: drop what the PREVIOUS resolution loaded and this one
+        # does not declare, so a stale set never bleeds into the prompt. Scoped
+        # to set-loaded names only — a skill the agent loaded itself via
+        # ``load_skill`` is not a set's to unload.
+        for stale in [n for n in (self._skill_set_loaded or []) if n not in wanted]:
             self.unload_skill(stale)
 
         loaded: Dict[str, "Skill"] = {}
@@ -1176,6 +1181,7 @@ Do NOT wrap conversational replies in JSON.
                 )
 
         self._active_skill_set = resolution.name
+        self._skill_set_loaded = list(loaded)
         logger.info(
             "Skill set '%s' active (chosen by: %s) — loaded %d of %d declared "
             "skill(s): %s",

--- a/src/gaia/agents/base/agent.py
+++ b/src/gaia/agents/base/agent.py
@@ -47,7 +47,7 @@ from gaia.llm.lemonade_client import (
 if TYPE_CHECKING:
     from gaia.agents.base.goal_store import Goal, Proposal
     from gaia.connectors.providers.base import ConnectorRequirement
-    from gaia.skills import Skill, SkillManager
+    from gaia.skills import Skill, SkillManager, SkillSetResolution, SkillSets
 
 # Set up logging
 logging.basicConfig(level=logging.INFO)
@@ -314,6 +314,12 @@ class Agent(abc.ABC):
     _skill_manager: Optional[Any] = None
     _loaded_skills: Optional[Dict[str, Any]] = None
 
+    # Skill sets (#2466): the parsed manifest declarations, the explicit
+    # ``--skill-set`` request, and the set that actually resolved.
+    _skill_sets: Optional[Any] = None
+    _requested_skill_set: Optional[str] = None
+    _active_skill_set: Optional[str] = None
+
     # Define state constants
     STATE_PLANNING = "PLANNING"
     STATE_EXECUTING_PLAN = "EXECUTING_PLAN"
@@ -342,6 +348,12 @@ class Agent(abc.ABC):
     # so the skills it ships always win over a same-named user or Claude Code
     # copy. Empty = the agent bundles no skills.
     SKILL_DIRS: ClassVar[List[str]] = []
+
+    # Path to this agent's ``gaia-agent.yaml`` (issue #2466). When set, the base
+    # ``__init__`` reads its ``skills:`` / ``skill_sets:`` blocks and loads the
+    # resolved set at startup. ``None`` = no declarative skills; the agent may
+    # still call ``load_skill`` directly.
+    SKILL_MANIFEST: ClassVar[Optional[str]] = None
 
     # Agent-specific tools that must be gated behind explicit user confirmation
     # (#1440). Subclasses override this to declare their own destructive/external
@@ -432,6 +444,7 @@ Do NOT wrap conversational replies in JSON.
         min_context_size: int = 32768,
         skip_lemonade: bool = False,
         device: Optional[str] = None,
+        skill_set: Optional[str] = None,
     ):
         """
         Initialize the Agent with LLM client.
@@ -458,6 +471,12 @@ Do NOT wrap conversational replies in JSON.
             min_context_size: Minimum context size required for this agent (default: 32768).
             skip_lemonade: If True, skip Lemonade server initialization (default: False).
                           Use this when connecting to a different OpenAI-compatible backend.
+            skill_set: Explicit skill set to activate (the generic
+                          ``--skill-set`` override, #2466). Highest precedence —
+                          beats the agent's ``select_skill_set()`` hook and the
+                          manifest's ``default_skill_set``. An undeclared name
+                          fails loudly, naming the valid sets. Only meaningful
+                          when ``SKILL_MANIFEST`` declares ``skill_sets:``.
             device: Runtime device selector ('cpu', 'gpu', 'npu') chosen by the
                           user (Agent UI dropdown / CLI --device). Validated against
                           detected hardware at startup via LemonadeManager.ensure_ready;
@@ -466,6 +485,9 @@ Do NOT wrap conversational replies in JSON.
         Note: Uses local LLM server by default unless use_claude or use_chatgpt is True.
         """
         self.device = device
+        # Stored before _register_tools so an agent's selector hook and the
+        # post-registration skill-set load both see the explicit request.
+        self._requested_skill_set = skill_set
         self.error_history = []  # Store error history for learning
         self.conversation_history = (
             []
@@ -556,6 +578,11 @@ Do NOT wrap conversational replies in JSON.
         # Register tools for this agent (may call rebuild_system_prompt via MCP loading;
         # _response_format_template must be set above before this call).
         self._register_tools()
+
+        # Declarative skills (#2466). After _register_tools so a skill's tools
+        # land on top of the agent's own registry (and survive a subclass's
+        # ``_snapshot_tools()``), and so a skill body can reference them.
+        self.load_skill_set()
 
         # Note: system_prompt is now a lazy @property that composes on first access.
         # Tool descriptions and response format are added in _compose_system_prompt().
@@ -1040,6 +1067,125 @@ Do NOT wrap conversational replies in JSON.
         self.rebuild_system_prompt()
         logger.info("Unloaded skill '%s'", name)
         return True
+
+    # ------------------------------------------------------------------
+    # Skill sets (issue #2466) — declarative, per-launch skill bundles
+    # ------------------------------------------------------------------
+
+    @property
+    def skill_sets(self) -> "SkillSets":
+        """This agent's parsed ``skills:`` / ``skill_sets:`` declarations.
+
+        Read once from :attr:`SKILL_MANIFEST` and cached. Falsy (and empty) when
+        the agent declares no manifest — so nothing changes for an agent that
+        does not use skills.
+
+        Raises:
+            ManifestError: ``SKILL_MANIFEST`` is set but missing or malformed.
+                A packaged agent whose own manifest cannot be read is broken,
+                not degraded.
+        """
+        if getattr(self, "_skill_sets", None) is None:
+            from gaia.skills.sets import SkillSets
+
+            manifest_path = self.SKILL_MANIFEST
+            if not manifest_path:
+                self._skill_sets = SkillSets()
+            else:
+                from gaia.hub.manifest import parse as parse_manifest
+
+                self._skill_sets = parse_manifest(manifest_path).skill_sets
+        return self._skill_sets
+
+    @property
+    def active_skill_set(self) -> Optional[str]:
+        """The skill set this agent resolved at startup, or ``None``."""
+        return getattr(self, "_active_skill_set", None)
+
+    def select_skill_set(self) -> Optional[str]:
+        """Selector hook: which skill set fits this launch's runtime state?
+
+        The framework calls this when no explicit ``skill_set`` was passed.
+        Override it to key the active set off something the agent already knows
+        — a connected account's type, a workspace mode, a device profile.
+        Returning ``None`` means "no opinion", which defers to the manifest's
+        ``default_skill_set``. Returning a name this agent does not declare
+        fails loudly rather than falling back.
+        """
+        return None
+
+    def resolve_skill_set(
+        self, requested: Optional[str] = None
+    ) -> "SkillSetResolution":
+        """Resolve the active set: *requested* → :meth:`select_skill_set` → default.
+
+        Args:
+            requested: Explicit override. Defaults to the ``skill_set`` argument
+                passed to ``__init__``.
+
+        Raises:
+            SkillSetError: the resolved name is not a declared set.
+        """
+        declarations = self.skill_sets
+        explicit = requested if requested is not None else self._requested_skill_set
+        # Only consult the hook when nothing explicit was asked for — an
+        # explicit request must never be second-guessed by agent state.
+        selected = None if (explicit or "").strip() else self.select_skill_set()
+        return declarations.resolve(requested=explicit, selected=selected)
+
+    def load_skill_set(self, requested: Optional[str] = None) -> Dict[str, "Skill"]:
+        """Resolve and load this agent's declared skills. Returns what loaded.
+
+        A no-op returning ``{}`` when the agent declares no skills. Otherwise it
+        loads the always-on ``skills:`` list plus the resolved set, in
+        declaration order. A skill declared ``required: false`` that is missing
+        from every discovery root is logged and skipped; every other failure
+        propagates, because an agent launched with the wrong capabilities is
+        worse than one that refuses to launch.
+
+        Called automatically at the end of ``Agent.__init__``. Call it again with
+        a different name to switch sets mid-session — skills from the previous
+        set are unloaded first, so the two never overlap.
+        """
+        from gaia.skills.errors import SkillNotFoundError
+
+        declarations = self.skill_sets
+        if not declarations:
+            return {}
+
+        resolution = self.resolve_skill_set(requested)
+        wanted = {ref.name: ref for ref in resolution.skills}
+
+        # Switching sets: drop anything the previous resolution loaded that the
+        # new one does not declare, so a stale set never bleeds into the prompt.
+        for stale in [name for name in self.loaded_skills if name not in wanted]:
+            self.unload_skill(stale)
+
+        loaded: Dict[str, "Skill"] = {}
+        for ref in resolution.skills:
+            try:
+                loaded[ref.name] = self.load_skill(ref.name)
+            except SkillNotFoundError:
+                if ref.required:
+                    raise
+                logger.warning(
+                    "Optional skill '%s' (skill set '%s') was not found in any "
+                    "discovery root — continuing without it.",
+                    ref.name,
+                    resolution.name,
+                )
+
+        self._active_skill_set = resolution.name
+        logger.info(
+            "Skill set '%s' active (chosen by: %s) — loaded %d of %d declared "
+            "skill(s): %s",
+            resolution.name or "(none)",
+            resolution.source,
+            len(loaded),
+            len(resolution.skills),
+            ", ".join(loaded) or "(none)",
+        )
+        return loaded
 
     def get_skills_system_prompt(self) -> str:
         """Render the loaded skills' bodies as a system-prompt fragment.

--- a/src/gaia/connectors/api.py
+++ b/src/gaia/connectors/api.py
@@ -375,9 +375,14 @@ def list_connections() -> List[Dict[str, Any]]:
     """
     Return all stored connections as a list of summary dicts.
 
-    Each entry: ``{provider, account_email, scopes, connected_at}``.
-    Refresh tokens are NEVER included in the return value — only the
-    metadata callers need to display "Connected as <email>".
+    Each entry: ``{provider, account_email, scopes, connected_at,
+    account_type}``. Refresh tokens are NEVER included in the return value —
+    only the metadata callers need to display "Connected as <email>".
+
+    ``account_type`` is ``"personal"`` / ``"work"`` when the provider could
+    derive it at connect time (Microsoft, from the id_token ``tid`` claim,
+    #2466), and ``None`` otherwise — including for every Google connection,
+    which has no equivalent notion.
     """
     out: List[Dict[str, Any]] = []
     for provider in _store_list():
@@ -414,6 +419,7 @@ def list_connections() -> List[Dict[str, Any]]:
                 "account_email": blob.get("account_email"),
                 "scopes": blob.get("scopes", []),
                 "connected_at": blob.get("connected_at"),
+                "account_type": blob.get("account_type"),
             }
         )
     return out

--- a/src/gaia/connectors/api.py
+++ b/src/gaia/connectors/api.py
@@ -66,6 +66,7 @@ from gaia.connectors.store import (
 from gaia.connectors.store import list_connections as _store_list
 from gaia.connectors.store import (
     load_connection,
+    peek_connection,
 )
 from gaia.connectors.tokens import get_or_refresh
 
@@ -447,6 +448,7 @@ def import_forwarded_connection(
     refresh_token: str,
     scopes: List[str],
     account_email: str = "",
+    account_type: Optional[str] = None,
     grant_agents: Optional[List[str]] = None,
     required_scopes: Optional[List[str]] = None,
     connected_at: Optional[float] = None,
@@ -536,6 +538,13 @@ def import_forwarded_connection(
 
     # 6. Persist the connection (refresh_token + metadata) → ``<provider>:default``
     #    keyed by the forwarded client's hash so the tripwire passes coherently.
+    #    ``save_connection`` rewrites the whole blob, so the account kind must be
+    #    threaded through explicitly or a forwarded grant silently downgrades an
+    #    already-classified mailbox to unknown (#2466). A caller that knows the
+    #    kind passes it; otherwise the stored value carries over.
+    resolved_account_type = account_type or (
+        (peek_connection(provider) or {}).get("account_type")
+    )
     save_connection(
         provider=provider,
         account_email=account,
@@ -543,6 +552,7 @@ def import_forwarded_connection(
         scopes=list(scopes),
         client_id_hash=prov.client_id_hash,
         connected_at=connected_at,
+        account_type=resolved_account_type,
     )
 
     # 7. Evict any stale access-token cache entry so the next get_or_refresh
@@ -742,7 +752,6 @@ def connected_mailbox_providers() -> list[str]:
     # imports a no-op. Mirrors the pattern in _require_mcp_server_for_activation.
     import gaia.connectors.catalog  # noqa: F401  # pylint: disable=unused-import
     from gaia.connectors.registry import REGISTRY
-    from gaia.connectors.store import peek_connection
 
     result: list[str] = []
     for spec in REGISTRY.all():

--- a/src/gaia/connectors/flow.py
+++ b/src/gaia/connectors/flow.py
@@ -109,12 +109,32 @@ class _PendingFlow:
 _pending: dict[str, _PendingFlow] = {}
 
 
+def _decode_id_token_claims(id_token: str) -> Dict[str, Any]:
+    """
+    Base64url-decode an id_token's payload segment and return its claims.
+
+    Best-effort and unvalidated — the signature is not checked, so callers may
+    only use the result for display labels and local classification, never for
+    authorization. Returns ``{}`` for a malformed or absent token.
+    """
+    try:
+        _, payload_b64, _ = id_token.split(".")
+    except (AttributeError, ValueError):
+        return {}
+    # base64url, no padding — pad up to a multiple of 4.
+    padded = payload_b64 + "=" * (-len(payload_b64) % 4)
+    try:
+        claims = json.loads(base64.urlsafe_b64decode(padded).decode("ascii"))
+    except (ValueError, UnicodeDecodeError):
+        return {}
+    return claims if isinstance(claims, dict) else {}
+
+
 def _decode_email_from_id_token(id_token: str) -> Optional[str]:
     """
     Extract the user's email from an id_token payload.
 
-    Best-effort — base64url-decode the middle segment, parse JSON, check
-    claims in priority order:
+    Checks claims in priority order:
       1. ``email`` — present in Google id_tokens and most OIDC providers.
       2. ``preferred_username`` — Microsoft identity platform (personal
          Outlook.com accounts and Azure AD work/school accounts).
@@ -123,20 +143,38 @@ def _decode_email_from_id_token(id_token: str) -> Optional[str]:
     Production validation is deferred to the userinfo endpoint; this is a
     quick path for display on the OAuth success page.
     """
-    try:
-        _, payload_b64, _ = id_token.split(".")
-    except ValueError:
-        return None
-    # base64url, no padding — pad up to a multiple of 4.
-    padded = payload_b64 + "=" * (-len(payload_b64) % 4)
-    try:
-        payload = json.loads(base64.urlsafe_b64decode(padded).decode("ascii"))
-    except (ValueError, UnicodeDecodeError):
-        return None
-    email = (
-        payload.get("email") or payload.get("preferred_username") or payload.get("upn")
-    )
+    claims = _decode_id_token_claims(id_token)
+    email = claims.get("email") or claims.get("preferred_username") or claims.get("upn")
     return email if isinstance(email, str) else None
+
+
+def _resolve_account_type(provider, id_token: str) -> Optional[str]:
+    """Classify the signed-in account from the id_token, if the provider can.
+
+    Duck-typed on ``provider.classify_account_type(claims)`` (Microsoft derives
+    ``personal`` vs ``work`` from the ``tid`` claim, #2466). Returns ``None`` when
+    the provider has no notion of account type or the token carries no usable
+    claim — an unknown kind is recorded as unknown, never guessed. Never raises:
+    the account kind is metadata, and failing to derive it must not fail a
+    connect that otherwise succeeded.
+    """
+    classify = getattr(provider, "classify_account_type", None)
+    if not callable(classify):
+        return None
+    claims = _decode_id_token_claims(id_token or "")
+    if not claims:
+        return None
+    try:
+        account_type = classify(claims)
+    except Exception as e:  # noqa: BLE001 — metadata only, must not fail connect
+        logger.warning(
+            "flow: account-type classification for %s failed (%s); recording "
+            "it as unknown",
+            getattr(provider, "provider_id", "?"),
+            e,
+        )
+        return None
+    return account_type if isinstance(account_type, str) and account_type else None
 
 
 async def _resolve_account_email(provider, id_token: str, access_token: str) -> str:
@@ -485,6 +523,7 @@ async def _exchange_code_for_tokens(flow: _PendingFlow, code: str) -> Dict[str, 
     account_email = await _resolve_account_email(
         provider, payload.get("id_token", ""), payload.get("access_token", "")
     )
+    account_type = _resolve_account_type(provider, payload.get("id_token", ""))
 
     save_connection(
         provider=flow.provider_id,
@@ -496,6 +535,7 @@ async def _exchange_code_for_tokens(flow: _PendingFlow, code: str) -> Dict[str, 
         # concept of a tenant (e.g. Google), which save_connection omits
         # from the blob entirely (A7-style contract).
         tenant=getattr(provider, "tenant", None),
+        account_type=account_type,
     )
 
     # No separate state-cache write needed — the keyring blob written
@@ -703,6 +743,7 @@ async def poll_device_flow(
     account_email = await _resolve_account_email(
         provider, payload.get("id_token", ""), payload.get("access_token", "")
     )
+    account_type = _resolve_account_type(provider, payload.get("id_token", ""))
 
     save_connection(
         provider=provider_id,
@@ -711,6 +752,7 @@ async def poll_device_flow(
         scopes=scopes_list,
         client_id_hash=provider.client_id_hash,
         tenant=getattr(provider, "tenant", None),
+        account_type=account_type,
     )
 
     if grant_agents:

--- a/src/gaia/connectors/providers/microsoft.py
+++ b/src/gaia/connectors/providers/microsoft.py
@@ -94,6 +94,7 @@ _PROVIDER_LABELS: dict[str, str] = {
     "microsoft_work": "Microsoft Work or School",
 }
 
+
 def account_type_for_tenant(tenant_id: str | None) -> str | None:
     """Classify a Microsoft account from its id_token ``tid`` claim.
 

--- a/src/gaia/connectors/providers/microsoft.py
+++ b/src/gaia/connectors/providers/microsoft.py
@@ -69,6 +69,22 @@ logger = logging.getLogger(__name__)
 # builds valid URLs instead of a bare "None" segment.
 _FALLBACK_TENANT = "common"
 
+# The well-known "consumers" tenant. Every personal Microsoft account (Outlook.com
+# / Hotmail / Live) carries this exact GUID in its id_token ``tid`` claim; a
+# work/school account carries its organization's Entra tenant id instead. This is
+# the canonical, exact discriminator between the two kinds of account — unlike the
+# ``mail`` vs ``userPrincipalName`` shape, which only *usually* differs and would
+# misclassify silently. It is a property of the signed-in ACCOUNT, independent of
+# which tenant the app signed in against.
+# https://learn.microsoft.com/en-us/entra/identity-platform/id-token-claims-reference
+_MSA_TENANT_ID = "9188040d-6c67-4c5b-b112-36a304b66dad"
+
+# Account kinds derived from ``tid``. Consumed by agents that behave differently
+# for a personal vs a work mailbox (e.g. the email agent's skill sets, #2466).
+ACCOUNT_TYPE_PERSONAL = "personal"
+ACCOUNT_TYPE_WORK = "work"
+ACCOUNT_TYPES = (ACCOUNT_TYPE_PERSONAL, ACCOUNT_TYPE_WORK)
+
 # Display labels for known connector ids — used only in the not-configured
 # error's copy. Falls back to a title-cased id for anything unlisted (e.g. a
 # future fourth Microsoft audience, or a test's throwaway spec) so adding a
@@ -77,6 +93,25 @@ _PROVIDER_LABELS: dict[str, str] = {
     "microsoft": "Microsoft Personal",
     "microsoft_work": "Microsoft Work or School",
 }
+
+def account_type_for_tenant(tenant_id: str | None) -> str | None:
+    """Classify a Microsoft account from its id_token ``tid`` claim.
+
+    Args:
+        tenant_id: The ``tid`` claim value, or ``None`` when the token carried
+            none (e.g. a device-code response with no decodable id_token).
+
+    Returns:
+        ``"personal"`` for the well-known consumers tenant, ``"work"`` for any
+        other tenant GUID, or ``None`` when *tenant_id* is absent/blank. ``None``
+        means "unknown" — callers must handle it explicitly rather than assuming
+        a kind.
+    """
+    tid = (tenant_id or "").strip().lower()
+    if not tid:
+        return None
+    return ACCOUNT_TYPE_PERSONAL if tid == _MSA_TENANT_ID else ACCOUNT_TYPE_WORK
+
 
 # Plain-language descriptions for the AgentUI consent dialog, mirroring the
 # Google provider's SCOPE_DESCRIPTIONS. The router/CLI render these strings;
@@ -125,6 +160,18 @@ class MicrosoftOAuthProvider:
     userinfo_url: str = (
         "https://graph.microsoft.com/v1.0/me?$select=mail,userPrincipalName"
     )
+
+    @staticmethod
+    def classify_account_type(claims: dict) -> str | None:
+        """Derive ``personal`` / ``work`` from an id_token's claims (#2466).
+
+        Duck-typed hook: ``flow.py`` calls this when the provider defines it, so
+        the account kind is recorded on the connection at connect time and no
+        agent has to re-derive it (or make a Graph call) later. Reads only the
+        ``tid`` claim; returns ``None`` when it is absent, which callers must
+        treat as unknown.
+        """
+        return account_type_for_tenant(claims.get("tid"))
 
     @staticmethod
     def parse_account_email(userinfo: dict) -> str | None:

--- a/src/gaia/connectors/store.py
+++ b/src/gaia/connectors/store.py
@@ -315,6 +315,7 @@ def save_connection(
     client_id_hash: str,
     connected_at: Optional[float] = None,
     tenant: Optional[str] = None,
+    account_type: Optional[str] = None,
 ) -> None:
     """
     Atomically persist a connection record to the keyring.
@@ -340,6 +341,15 @@ def save_connection(
     ``save_provider_credentials``'s A7 contract) so a legacy blob with no
     recorded tenant is distinguishable from one that recorded a value —
     ``load_connection`` treats the two very differently.
+
+    ``account_type`` records what KIND of account signed in when the provider
+    can tell (Microsoft derives ``personal`` / ``work`` from the id_token ``tid``
+    claim, #2466). Distinct from ``tenant``, which records the authority the app
+    signed in *against*: the ``common`` authority admits both kinds, so the two
+    answer different questions. Omitted from the blob when ``None`` — an absent
+    key means "unknown", which readers must handle explicitly rather than
+    assuming a kind. Callers that re-save an existing connection (e.g.
+    refresh-token rotation) MUST pass both values through or they are lost.
     """
     verify_keyring_backend()
 
@@ -352,6 +362,8 @@ def save_connection(
     }
     if tenant is not None:
         blob["tenant"] = tenant
+    if account_type:
+        blob["account_type"] = account_type
     payload = json.dumps(blob, sort_keys=True)
     # v1 single-account per provider (per A10): the keyring KEY is always
     # built with DEFAULT_ACCOUNT; ``account_email`` lives in the metadata

--- a/src/gaia/connectors/tokens.py
+++ b/src/gaia/connectors/tokens.py
@@ -185,6 +185,9 @@ async def get_or_refresh(
                 client_id_hash=provider.client_id_hash,
                 connected_at=stored.get("connected_at"),
                 tenant=stored.get("tenant") or getattr(provider, "tenant", None),
+                # Carry the derived account kind across rotation — it comes from
+                # the connect-time id_token, which a refresh does not re-issue.
+                account_type=stored.get("account_type"),
             )
 
         entry.access_token = new_access

--- a/src/gaia/hub/manifest.py
+++ b/src/gaia/hub/manifest.py
@@ -29,6 +29,8 @@ from typing import Any, Dict, List, Optional, Union
 import yaml
 
 from gaia.agents.registry import _RESERVED_BUILTIN_IDS
+from gaia.skills.errors import SkillValidationError
+from gaia.skills.sets import SkillSets, parse_skill_sets
 
 # ---------------------------------------------------------------------------
 # Validation vocabulary
@@ -222,6 +224,11 @@ class AgentManifest:
     required_connections: List[str] = field(default_factory=list)
     interfaces: Interfaces = field(default_factory=Interfaces)
 
+    # Agent Skills declarations (#2466): the always-on ``skills:`` list, the
+    # named ``skill_sets:`` bundles, and ``default_skill_set:``. Empty (falsy)
+    # when the manifest declares none — the grammar is additive.
+    skill_sets: SkillSets = field(default_factory=SkillSets)
+
     # Provenance — set by :func:`parse`; not part of the YAML.
     source_path: Optional[Path] = None
 
@@ -298,6 +305,7 @@ class AgentManifest:
             _validate_semver(data["min_gaia_version"], "min_gaia_version", where)
 
         permissions = _validate_permissions(data.get("permissions"), where)
+        skill_sets = _parse_skill_sets(data, where)
         requirements = _parse_requirements(data.get("requirements"), where)
         interfaces = _parse_interfaces(data.get("interfaces"), where)
         python_cfg = _parse_python(data.get("python"), where)
@@ -342,6 +350,7 @@ class AgentManifest:
                 data.get("required_connections"), "required_connections", where
             ),
             interfaces=interfaces,
+            skill_sets=skill_sets,
             source_path=src,
         )
 
@@ -431,6 +440,19 @@ def _validate_semver(value: Any, field_name: str, where: str) -> None:
             f"Use MAJOR.MINOR.PATCH (e.g. '0.1.0' or '1.2.3-rc.1'). "
             f"See https://semver.org."
         )
+
+
+def _parse_skill_sets(data: Dict[str, Any], where: str) -> SkillSets:
+    """Parse ``skills:`` / ``skill_sets:`` / ``default_skill_set:`` (#2466).
+
+    The grammar lives in :mod:`gaia.skills.sets` so the runtime and the manifest
+    validator can never disagree; this only re-raises as :class:`ManifestError`
+    so a manifest author sees one error type.
+    """
+    try:
+        return parse_skill_sets(data, where=where)
+    except SkillValidationError as e:
+        raise ManifestError(f"gaia-agent.yaml{where}: {e}") from e
 
 
 def _validate_permissions(raw: Any, where: str) -> List[str]:

--- a/src/gaia/skills/__init__.py
+++ b/src/gaia/skills/__init__.py
@@ -33,6 +33,7 @@ from gaia.skills.errors import (
     SkillError,
     SkillNotFoundError,
     SkillPermissionError,
+    SkillSetError,
     SkillValidationError,
 )
 from gaia.skills.format import (
@@ -70,6 +71,15 @@ from gaia.skills.permissions import (
     parse_permissions,
     refuse_unbridged_permissions,
 )
+from gaia.skills.sets import (
+    DEFAULT_SET_KEY,
+    SKILL_SETS_KEY,
+    SKILLS_KEY,
+    SkillRef,
+    SkillSetResolution,
+    SkillSets,
+    parse_skill_sets,
+)
 
 __all__ = [
     # Format
@@ -96,6 +106,14 @@ __all__ = [
     "get_default_manager",
     "reset_default_manager",
     "user_skills_dir",
+    # Skill sets (issue #2466)
+    "SkillRef",
+    "SkillSets",
+    "SkillSetResolution",
+    "parse_skill_sets",
+    "SKILLS_KEY",
+    "SKILL_SETS_KEY",
+    "DEFAULT_SET_KEY",
     # Tools
     "register_skill_tools",
     "unregister_skill_tools",
@@ -111,4 +129,5 @@ __all__ = [
     "SkillValidationError",
     "SkillNotFoundError",
     "SkillPermissionError",
+    "SkillSetError",
 ]

--- a/src/gaia/skills/errors.py
+++ b/src/gaia/skills/errors.py
@@ -30,6 +30,14 @@ class SkillNotFoundError(SkillError):
     """No skill of that name exists in any discovery root."""
 
 
+class SkillSetError(SkillError):
+    """A skill set was requested that the agent does not declare.
+
+    Never downgraded to the default set — selecting the wrong capability bundle
+    silently is worse than not launching.
+    """
+
+
 class SkillPermissionError(SkillError):
     """The skill declares a permission this phase cannot honor.
 

--- a/src/gaia/skills/sets.py
+++ b/src/gaia/skills/sets.py
@@ -283,8 +283,18 @@ def _parse_ref_list(
     raw: Any, field_name: str, where: str, *, allow_empty: bool = True
 ) -> Tuple[SkillRef, ...]:
     """Parse a list of skill references (plain strings and/or mappings)."""
-    if raw is None:
+    # A bare ``work:`` key with nothing indented under it parses as None. For a
+    # set that is the same authoring mistake as an empty list — checked before
+    # the None shortcut, or the emptiness error below is unreachable.
+    if raw is None and allow_empty:
         return ()
+    if raw is None:
+        raise SkillValidationError(
+            f"'{field_name}:'{where} names no skills. A skill set must list at "
+            f"least one skill (a bare '{field_name.split('.')[-1]}:' key with "
+            f"nothing under it parses as empty), or be removed. "
+            f"See {_SETS_DOCS_URL}."
+        )
     if isinstance(raw, str) or not isinstance(raw, Sequence):
         raise SkillValidationError(
             f"'{field_name}:'{where} must be a list of skill names (or "

--- a/src/gaia/skills/sets.py
+++ b/src/gaia/skills/sets.py
@@ -1,0 +1,389 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""
+Declarative skill sets — the ``skills:`` / ``skill_sets:`` manifest grammar.
+
+An agent declares two things in its ``gaia-agent.yaml``:
+
+* ``skills:`` — always-on skills, loaded on every launch.
+* ``skill_sets:`` — named, mutually-exclusive bundles. Exactly **one** is
+  active per launch, chosen by :meth:`SkillSets.resolve`.
+
+Example::
+
+    skills:
+      - mailbox-hygiene            # always on
+
+    skill_sets:
+      personal: [inbox-triage, newsletter-digest]
+      work: [inbox-triage, meeting-scheduling]
+
+    default_skill_set: personal
+
+Selection order (:meth:`SkillSets.resolve`) is explicit request → agent-supplied
+selector → ``default_skill_set``. An unknown name never falls back to the
+default: it raises :class:`~gaia.skills.errors.SkillSetError` naming the valid
+sets (GAIA's no-silent-fallbacks rule, ``CLAUDE.md``).
+
+This module is pure data + validation — it neither reads the filesystem nor
+loads a skill, so both the manifest validator (:mod:`gaia.hub.manifest`) and the
+base :class:`~gaia.agents.base.agent.Agent` can share it.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Mapping, Optional, Sequence, Tuple
+
+from gaia.skills.errors import DOCS_URL, SkillSetError, SkillValidationError
+
+# Set names use the same slug shape as skill names so a set can be typed on a
+# command line without quoting: lowercase alphanumeric with internal hyphens.
+SET_NAME_PATTERN = re.compile(r"^[a-z0-9]([a-z0-9-]{0,30}[a-z0-9])?$")
+
+# Manifest keys this module owns. ``gaia.hub.manifest`` delegates all three.
+SKILLS_KEY = "skills"
+SKILL_SETS_KEY = "skill_sets"
+DEFAULT_SET_KEY = "default_skill_set"
+
+# Recognized keys in the mapping form of a skill reference.
+_REF_KEYS = frozenset({"name", "version", "required"})
+
+_SETS_DOCS_URL = f"{DOCS_URL}#skill-sets"
+
+# Where a resolved set name came from. Surfaced in logs and asserted by tests so
+# "which rule picked this set" is never guesswork.
+SOURCE_EXPLICIT = "explicit"
+SOURCE_SELECTOR = "selector"
+SOURCE_DEFAULT = "default"
+SOURCE_NONE = "none"
+
+
+@dataclass(frozen=True)
+class SkillRef:
+    """One entry in a ``skills:`` list or a ``skill_sets:`` bundle.
+
+    ``version`` is a **declaration surface only** in this phase: it is parsed,
+    validated as a string, and surfaced, but no constraint solving happens until
+    the marketplace phase (#2467) can install versioned skills. ``required:
+    false`` marks an optional enhancement — a missing optional skill is logged
+    and skipped, a missing required one fails the launch.
+    """
+
+    name: str
+    version: Optional[str] = None
+    required: bool = True
+
+
+@dataclass(frozen=True)
+class SkillSetResolution:
+    """The outcome of :meth:`SkillSets.resolve`.
+
+    ``name`` is the active set (``None`` when the agent declares no sets),
+    ``skills`` is the always-on list followed by that set's list in declaration
+    order, and ``source`` records which rule chose it (one of
+    ``explicit``/``selector``/``default``/``none``).
+    """
+
+    name: Optional[str]
+    skills: Tuple[SkillRef, ...]
+    source: str
+
+
+@dataclass(frozen=True)
+class SkillSets:
+    """A parsed, validated ``skills:`` + ``skill_sets:`` declaration.
+
+    Build with :func:`parse_skill_sets`; the constructor does not validate.
+    An agent that declares neither block gets the empty instance, which is
+    falsy — so every existing agent keeps its current behaviour exactly.
+    """
+
+    always: Tuple[SkillRef, ...] = ()
+    sets: Mapping[str, Tuple[SkillRef, ...]] = field(default_factory=dict)
+    default_set: Optional[str] = None
+
+    def __bool__(self) -> bool:
+        return bool(self.always or self.sets)
+
+    @property
+    def set_names(self) -> List[str]:
+        """Declared set names, in manifest declaration order."""
+        return list(self.sets)
+
+    def skills_for(self, name: Optional[str]) -> Tuple[SkillRef, ...]:
+        """Always-on skills plus the named set's skills, in declaration order.
+
+        Raises:
+            SkillSetError: *name* is not a declared set.
+        """
+        if name is None:
+            return self.always
+        if name not in self.sets:
+            raise SkillSetError(self._unknown_set_message(name))
+        return self.always + tuple(self.sets[name])
+
+    def resolve(
+        self,
+        *,
+        requested: Optional[str] = None,
+        selected: Optional[str] = None,
+    ) -> SkillSetResolution:
+        """Pick the active set: *requested* → *selected* → ``default_skill_set``.
+
+        Args:
+            requested: An explicit choice (a ``--skill-set`` flag or config
+                field). Highest precedence; an unknown value always raises.
+            selected: The agent's selector-hook answer, used only when
+                *requested* is ``None``. An unknown value raises too — a
+                selector that computed a name this agent does not declare is a
+                wiring bug, not a reason to guess.
+
+        Raises:
+            SkillSetError: an unknown set name, or a *requested* name on an
+                agent that declares no sets.
+        """
+        requested = (requested or "").strip() or None
+        selected = (selected or "").strip() or None
+
+        if not self.sets:
+            if requested:
+                raise SkillSetError(
+                    f"Skill set {requested!r} was requested but this agent "
+                    "declares no 'skill_sets:' block, so there is nothing to "
+                    "select. Drop the --skill-set argument, or add a "
+                    f"'skill_sets:' block to its gaia-agent.yaml. "
+                    f"See {_SETS_DOCS_URL}."
+                )
+            return SkillSetResolution(None, self.always, SOURCE_NONE)
+
+        for candidate, source in (
+            (requested, SOURCE_EXPLICIT),
+            (selected, SOURCE_SELECTOR),
+            (self.default_set, SOURCE_DEFAULT),
+        ):
+            if candidate is None:
+                continue
+            if candidate not in self.sets:
+                raise SkillSetError(self._unknown_set_message(candidate, source))
+            return SkillSetResolution(
+                candidate, self.always + tuple(self.sets[candidate]), source
+            )
+
+        # Unreachable via parse_skill_sets (a non-empty skill_sets block requires
+        # default_skill_set), but a hand-built SkillSets could get here.
+        raise SkillSetError(
+            "No skill set could be resolved: nothing was requested, the "
+            "selector returned nothing, and no 'default_skill_set' is "
+            f"declared. Declared sets: {', '.join(self.set_names)}. Set "
+            f"'{DEFAULT_SET_KEY}:' in gaia-agent.yaml. See {_SETS_DOCS_URL}."
+        )
+
+    def _unknown_set_message(self, name: str, source: str = SOURCE_EXPLICIT) -> str:
+        valid = ", ".join(self.set_names) or "(none)"
+        origin = {
+            SOURCE_EXPLICIT: "Skill set",
+            SOURCE_SELECTOR: "The agent's skill-set selector returned skill set",
+            SOURCE_DEFAULT: f"'{DEFAULT_SET_KEY}' names skill set",
+        }.get(source, "Skill set")
+        return (
+            f"{origin} {name!r} is not declared by this agent. Valid sets: "
+            f"{valid}. Pass one of those names, or add {name!r} to the "
+            f"'{SKILL_SETS_KEY}:' block in gaia-agent.yaml. "
+            f"See {_SETS_DOCS_URL}."
+        )
+
+
+def parse_skill_sets(data: Any, *, where: str = "") -> SkillSets:
+    """Parse and validate the ``skills:`` / ``skill_sets:`` blocks of a manifest.
+
+    Args:
+        data: The full manifest mapping (already YAML-loaded). Keys other than
+            ``skills``, ``skill_sets``, and ``default_skill_set`` are ignored.
+        where: Location suffix for error messages, e.g. ``" in /path/to.yaml"``.
+
+    Returns:
+        A validated :class:`SkillSets`. Empty (and falsy) when the manifest
+        declares neither block.
+
+    Raises:
+        SkillValidationError: any malformed entry. Nothing is partially
+            accepted — a manifest either declares a coherent set of skills or
+            fails to load.
+    """
+    if data is None:
+        return SkillSets()
+    if not isinstance(data, Mapping):
+        raise SkillValidationError(
+            f"Cannot read skill declarations{where}: expected a mapping, got "
+            f"{type(data).__name__}. See {_SETS_DOCS_URL}."
+        )
+
+    always = _parse_ref_list(data.get(SKILLS_KEY), SKILLS_KEY, where)
+    always_names = {ref.name for ref in always}
+
+    raw_sets = data.get(SKILL_SETS_KEY)
+    sets: Dict[str, Tuple[SkillRef, ...]] = {}
+    if raw_sets is not None:
+        if not isinstance(raw_sets, Mapping):
+            raise SkillValidationError(
+                f"'{SKILL_SETS_KEY}:'{where} must be a mapping of set name → "
+                f"list of skills, got {type(raw_sets).__name__}. "
+                f"See {_SETS_DOCS_URL}."
+            )
+        for set_name, raw_list in raw_sets.items():
+            if not isinstance(set_name, str) or not SET_NAME_PATTERN.match(set_name):
+                raise SkillValidationError(
+                    f"'{SKILL_SETS_KEY}:'{where} has invalid set name "
+                    f"{set_name!r}. Use lowercase letters, digits, and internal "
+                    f"hyphens (1–32 chars), e.g. 'work'. See {_SETS_DOCS_URL}."
+                )
+            refs = _parse_ref_list(
+                raw_list, f"{SKILL_SETS_KEY}.{set_name}", where, allow_empty=False
+            )
+            clash = sorted(ref.name for ref in refs if ref.name in always_names)
+            if clash:
+                raise SkillValidationError(
+                    f"'{SKILL_SETS_KEY}.{set_name}'{where} re-declares skill(s) "
+                    f"already in the always-on '{SKILLS_KEY}:' list: "
+                    f"{', '.join(clash)}. An always-on skill loads for every "
+                    f"set — remove it from the set, or from '{SKILLS_KEY}:' if "
+                    f"it is set-specific. See {_SETS_DOCS_URL}."
+                )
+            sets[set_name] = refs
+
+    default_set = data.get(DEFAULT_SET_KEY)
+    if default_set is not None and not isinstance(default_set, str):
+        raise SkillValidationError(
+            f"'{DEFAULT_SET_KEY}:'{where} must be a string naming one of the "
+            f"declared skill sets, got {type(default_set).__name__}. "
+            f"See {_SETS_DOCS_URL}."
+        )
+    default_set = (default_set or "").strip() or None
+
+    if sets and default_set is None:
+        raise SkillValidationError(
+            f"'{SKILL_SETS_KEY}:'{where} declares set(s) "
+            f"{', '.join(sets)} but no '{DEFAULT_SET_KEY}:'. Add "
+            f"'{DEFAULT_SET_KEY}: <name>' so a launch that selects nothing "
+            f"still resolves a set explicitly. See {_SETS_DOCS_URL}."
+        )
+    if default_set is not None and default_set not in sets:
+        valid = ", ".join(sets) or "(none declared)"
+        raise SkillValidationError(
+            f"'{DEFAULT_SET_KEY}: {default_set}'{where} does not name a "
+            f"declared skill set. Valid sets: {valid}. See {_SETS_DOCS_URL}."
+        )
+
+    return SkillSets(always=always, sets=sets, default_set=default_set)
+
+
+def _parse_ref_list(
+    raw: Any, field_name: str, where: str, *, allow_empty: bool = True
+) -> Tuple[SkillRef, ...]:
+    """Parse a list of skill references (plain strings and/or mappings)."""
+    if raw is None:
+        return ()
+    if isinstance(raw, str) or not isinstance(raw, Sequence):
+        raise SkillValidationError(
+            f"'{field_name}:'{where} must be a list of skill names (or "
+            f"mappings with 'name'), got {type(raw).__name__}. "
+            f"See {_SETS_DOCS_URL}."
+        )
+    if not raw and not allow_empty:
+        raise SkillValidationError(
+            f"'{field_name}:'{where} is empty. A skill set must name at least "
+            f"one skill, or be removed. See {_SETS_DOCS_URL}."
+        )
+
+    refs: List[SkillRef] = []
+    seen: Dict[str, int] = {}
+    for index, entry in enumerate(raw):
+        ref = _parse_ref(entry, f"{field_name}[{index}]", where)
+        if ref.name in seen:
+            raise SkillValidationError(
+                f"'{field_name}:'{where} lists skill {ref.name!r} twice "
+                f"(entries {seen[ref.name]} and {index}). Remove the "
+                f"duplicate. See {_SETS_DOCS_URL}."
+            )
+        seen[ref.name] = index
+        refs.append(ref)
+    return tuple(refs)
+
+
+def _parse_ref(entry: Any, field_name: str, where: str) -> SkillRef:
+    """Parse one reference: ``"name"`` or ``{name, version?, required?}``."""
+    if isinstance(entry, str):
+        return SkillRef(name=_validated_name(entry, field_name, where))
+
+    if not isinstance(entry, Mapping):
+        raise SkillValidationError(
+            f"'{field_name}'{where} must be a skill name or a mapping with a "
+            f"'name' key, got {type(entry).__name__}. See {_SETS_DOCS_URL}."
+        )
+
+    unknown = sorted(set(entry) - _REF_KEYS)
+    if unknown:
+        raise SkillValidationError(
+            f"'{field_name}'{where} has unrecognized key(s): "
+            f"{', '.join(str(k) for k in unknown)}. Valid keys: "
+            f"{', '.join(sorted(_REF_KEYS))}. See {_SETS_DOCS_URL}."
+        )
+
+    name = _validated_name(entry.get("name"), field_name, where)
+
+    version = entry.get("version")
+    if version is not None and not (isinstance(version, str) and version.strip()):
+        raise SkillValidationError(
+            f"'{field_name}.version'{where} must be a non-empty string (a "
+            f"version or range, e.g. '>=1.0.0'), got {version!r}. "
+            f"See {_SETS_DOCS_URL}."
+        )
+
+    required = entry.get("required", True)
+    if not isinstance(required, bool):
+        raise SkillValidationError(
+            f"'{field_name}.required'{where} must be true or false, got "
+            f"{required!r}. See {_SETS_DOCS_URL}."
+        )
+
+    return SkillRef(
+        name=name,
+        version=version.strip() if isinstance(version, str) else None,
+        required=required,
+    )
+
+
+def _validated_name(value: Any, field_name: str, where: str) -> str:
+    from gaia.skills.format import NAME_PATTERN
+
+    if not isinstance(value, str) or not value.strip():
+        raise SkillValidationError(
+            f"'{field_name}'{where} is missing a skill name. Every entry needs "
+            f"a non-empty 'name'. See {_SETS_DOCS_URL}."
+        )
+    name = value.strip()
+    if not NAME_PATTERN.match(name):
+        raise SkillValidationError(
+            f"'{field_name}'{where} names skill {name!r}, which is not a valid "
+            "skill name. Use lowercase letters, digits, and internal hyphens "
+            f"(e.g. 'inbox-triage'). See {_SETS_DOCS_URL}."
+        )
+    return name
+
+
+__all__ = [
+    "SkillRef",
+    "SkillSets",
+    "SkillSetResolution",
+    "parse_skill_sets",
+    "SET_NAME_PATTERN",
+    "SKILLS_KEY",
+    "SKILL_SETS_KEY",
+    "DEFAULT_SET_KEY",
+    "SOURCE_EXPLICIT",
+    "SOURCE_SELECTOR",
+    "SOURCE_DEFAULT",
+    "SOURCE_NONE",
+]

--- a/tests/unit/connectors/test_account_type.py
+++ b/tests/unit/connectors/test_account_type.py
@@ -1,0 +1,220 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""
+Microsoft account-type derivation from the id_token ``tid`` claim (#2466).
+
+Personal Microsoft accounts always carry the well-known consumers tenant;
+work/school accounts carry their organization's Entra tenant id. That makes the
+classification exact rather than heuristic, and — because it comes from a token
+claim — testable end to end with synthetic id_tokens and no live account.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+
+import pytest
+
+from gaia.connectors.flow import (
+    _decode_email_from_id_token,
+    _decode_id_token_claims,
+    _resolve_account_type,
+)
+from gaia.connectors.providers.microsoft import (
+    _MSA_TENANT_ID,
+    ACCOUNT_TYPE_PERSONAL,
+    ACCOUNT_TYPE_WORK,
+    MicrosoftOAuthProvider,
+    account_type_for_tenant,
+)
+from gaia.connectors.store import peek_connection, save_connection
+
+_WORK_TENANT = "72f988bf-86f1-41af-91ab-2d7cd011db47"
+
+
+def _id_token(**claims) -> str:
+    """A synthetic (unsigned) id_token carrying the given claims."""
+
+    def seg(payload: dict) -> str:
+        raw = json.dumps(payload).encode("utf-8")
+        return base64.urlsafe_b64encode(raw).decode("ascii").rstrip("=")
+
+    return f"{seg({'alg': 'none'})}.{seg(claims)}.signature"
+
+
+# ----------------------------------------------------------------------
+# tid → account type
+# ----------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "tenant, expected",
+    [
+        (_MSA_TENANT_ID, ACCOUNT_TYPE_PERSONAL),
+        (_MSA_TENANT_ID.upper(), ACCOUNT_TYPE_PERSONAL),
+        (f"  {_MSA_TENANT_ID}  ", ACCOUNT_TYPE_PERSONAL),
+        (_WORK_TENANT, ACCOUNT_TYPE_WORK),
+        (None, None),
+        ("", None),
+        ("   ", None),
+    ],
+)
+def test_account_type_for_tenant(tenant, expected):
+    assert account_type_for_tenant(tenant) == expected
+
+
+def test_msa_tenant_is_the_documented_consumers_guid():
+    """Pin the constant — a typo here misclassifies every personal account."""
+    assert _MSA_TENANT_ID == "9188040d-6c67-4c5b-b112-36a304b66dad"
+
+
+@pytest.mark.parametrize(
+    "claims, expected",
+    [
+        ({"tid": _MSA_TENANT_ID}, ACCOUNT_TYPE_PERSONAL),
+        ({"tid": _WORK_TENANT}, ACCOUNT_TYPE_WORK),
+        ({"oid": "abc"}, None),
+        ({}, None),
+    ],
+)
+def test_provider_classify_account_type(claims, expected):
+    assert MicrosoftOAuthProvider.classify_account_type(claims) == expected
+
+
+# ----------------------------------------------------------------------
+# id_token decoding
+# ----------------------------------------------------------------------
+
+
+def test_decode_id_token_claims_round_trip():
+    claims = _decode_id_token_claims(
+        _id_token(tid=_WORK_TENANT, preferred_username="user@example.com")
+    )
+    assert claims["tid"] == _WORK_TENANT
+    assert claims["preferred_username"] == "user@example.com"
+
+
+@pytest.mark.parametrize("token", ["", "not-a-jwt", "a.b", "a.!!!not-base64!!!.c"])
+def test_decode_id_token_claims_tolerates_garbage(token):
+    assert _decode_id_token_claims(token) == {}
+
+
+def test_email_extraction_still_works_after_the_refactor():
+    """The claim-priority order (#1275) must be unchanged."""
+    assert (
+        _decode_email_from_id_token(_id_token(email="a@example.com")) == "a@example.com"
+    )
+    assert (
+        _decode_email_from_id_token(_id_token(preferred_username="b@example.com"))
+        == "b@example.com"
+    )
+    assert (
+        _decode_email_from_id_token(_id_token(upn="c@example.com")) == "c@example.com"
+    )
+    assert _decode_email_from_id_token(_id_token(tid=_WORK_TENANT)) is None
+    assert _decode_email_from_id_token("garbage") is None
+
+
+# ----------------------------------------------------------------------
+# The flow-layer hook
+# ----------------------------------------------------------------------
+
+
+class _NoClassifyProvider:
+    provider_id = "google"
+
+
+class _ExplodingProvider:
+    provider_id = "microsoft"
+
+    @staticmethod
+    def classify_account_type(claims):
+        raise RuntimeError("boom")
+
+
+@pytest.mark.parametrize(
+    "tid, expected",
+    [(_MSA_TENANT_ID, ACCOUNT_TYPE_PERSONAL), (_WORK_TENANT, ACCOUNT_TYPE_WORK)],
+)
+def test_resolve_account_type_from_a_microsoft_id_token(tid, expected):
+    provider = MicrosoftOAuthProvider(client_id="test-client")
+    assert _resolve_account_type(provider, _id_token(tid=tid)) == expected
+
+
+def test_resolve_account_type_is_none_for_a_provider_without_the_hook():
+    """Google has no tenant to inspect — unknown, not guessed."""
+    assert (
+        _resolve_account_type(_NoClassifyProvider(), _id_token(email="a@b.c")) is None
+    )
+
+
+def test_resolve_account_type_is_none_without_a_decodable_token():
+    provider = MicrosoftOAuthProvider(client_id="test-client")
+    assert _resolve_account_type(provider, "") is None
+    assert _resolve_account_type(provider, "garbage") is None
+    assert _resolve_account_type(provider, _id_token(email="a@b.c")) is None
+
+
+def test_a_broken_classifier_never_fails_the_connect():
+    assert (
+        _resolve_account_type(_ExplodingProvider(), _id_token(tid=_WORK_TENANT)) is None
+    )
+
+
+# ----------------------------------------------------------------------
+# Persistence
+# ----------------------------------------------------------------------
+
+
+def test_account_type_persists_on_the_connection_blob():
+    save_connection(
+        provider="microsoft",
+        account_email="user@contoso.com",
+        refresh_token="rt",
+        scopes=["openid"],
+        client_id_hash="hash",
+        account_type=ACCOUNT_TYPE_WORK,
+    )
+    assert peek_connection("microsoft")["account_type"] == ACCOUNT_TYPE_WORK
+
+
+def test_an_unknown_account_type_leaves_the_key_absent():
+    """A Google connection records no kind at all — readers see 'unknown'."""
+    save_connection(
+        provider="google",
+        account_email="user@gmail.com",
+        refresh_token="rt",
+        scopes=["openid"],
+        client_id_hash="hash",
+    )
+    blob = peek_connection("google")
+    assert "account_type" not in blob
+    assert blob.get("account_type") is None
+
+
+def test_refresh_token_rotation_preserves_the_account_type():
+    """A rotation re-saves the blob; losing the kind would silently reclassify."""
+    save_connection(
+        provider="microsoft",
+        account_email="user@contoso.com",
+        refresh_token="rt-1",
+        scopes=["openid"],
+        client_id_hash="hash",
+        account_type=ACCOUNT_TYPE_WORK,
+    )
+    stored = peek_connection("microsoft")
+
+    save_connection(
+        provider="microsoft",
+        account_email=stored["account_email"],
+        refresh_token="rt-2",
+        scopes=stored["scopes"],
+        client_id_hash="hash",
+        connected_at=stored["connected_at"],
+        account_type=stored.get("account_type"),
+    )
+
+    rotated = peek_connection("microsoft")
+    assert rotated["refresh_token"] == "rt-2"
+    assert rotated["account_type"] == ACCOUNT_TYPE_WORK

--- a/tests/unit/connectors/test_account_type.py
+++ b/tests/unit/connectors/test_account_type.py
@@ -193,28 +193,91 @@ def test_an_unknown_account_type_leaves_the_key_absent():
     assert blob.get("account_type") is None
 
 
-def test_refresh_token_rotation_preserves_the_account_type():
-    """A rotation re-saves the blob; losing the kind would silently reclassify."""
+def test_refresh_token_rotation_preserves_the_account_type(monkeypatch):
+    """Drive the REAL rotation path, not a hand-rolled copy of it.
+
+    ``tokens.get_or_refresh`` re-saves the whole blob when the provider rotates
+    the refresh token. Asserting on a locally-repeated ``save_connection`` would
+    pass even if the production call dropped the argument — the "mocks prove we
+    called it, not that the call is valid" trap from CLAUDE.md.
+    """
+    import asyncio
+
+    from gaia.connectors import tokens
+
     save_connection(
         provider="microsoft",
         account_email="user@contoso.com",
         refresh_token="rt-1",
         scopes=["openid"],
-        client_id_hash="hash",
+        client_id_hash="test-hash",
         account_type=ACCOUNT_TYPE_WORK,
     )
-    stored = peek_connection("microsoft")
 
-    save_connection(
-        provider="microsoft",
-        account_email=stored["account_email"],
-        refresh_token="rt-2",
-        scopes=stored["scopes"],
-        client_id_hash="hash",
-        connected_at=stored["connected_at"],
-        account_type=stored.get("account_type"),
-    )
+    class _Provider:
+        provider_id = "microsoft"
+        client_id_hash = "test-hash"
 
+    async def _fake_refresh(provider, refresh_token):
+        assert refresh_token == "rt-1"
+        return "access-2", "rt-2", 3600  # rotated refresh token
+
+    monkeypatch.setattr(tokens, "get_provider", lambda p: _Provider())
+    monkeypatch.setattr(tokens, "_refresh_token", _fake_refresh)
+
+    token = asyncio.run(tokens.get_or_refresh("microsoft"))
+
+    assert token == "access-2"
     rotated = peek_connection("microsoft")
     assert rotated["refresh_token"] == "rt-2"
     assert rotated["account_type"] == ACCOUNT_TYPE_WORK
+
+
+def test_a_forwarded_connection_does_not_erase_a_recorded_account_type(monkeypatch):
+    """``import_forwarded_connection`` rewrites the blob from scratch (#1292 Path A).
+
+    Without carrying the kind through, an OEM/Electron host forwarding its own
+    grant for an already-classified work mailbox would reset it to unknown — and
+    the email agent would silently drop to the personal skill set.
+    """
+    from gaia.connectors import api
+
+    save_connection(
+        provider="microsoft",
+        account_email="user@contoso.com",
+        refresh_token="rt-1",
+        scopes=["openid", "https://graph.microsoft.com/Mail.ReadWrite"],
+        client_id_hash="old-hash",
+        account_type=ACCOUNT_TYPE_WORK,
+    )
+
+    api.import_forwarded_connection(
+        provider="microsoft",
+        client_id="forwarded-client",
+        client_secret="forwarded-secret",
+        refresh_token="rt-forwarded",
+        scopes=["openid", "https://graph.microsoft.com/Mail.ReadWrite"],
+        account_email="user@contoso.com",
+        required_scopes=[],
+    )
+
+    blob = peek_connection("microsoft")
+    assert blob["refresh_token"] == "rt-forwarded"
+    assert blob["account_type"] == ACCOUNT_TYPE_WORK
+
+
+def test_a_forwarded_connection_can_state_the_account_type(monkeypatch):
+    """A host that knows the kind can supply it — nothing was recorded before."""
+    from gaia.connectors import api
+
+    api.import_forwarded_connection(
+        provider="microsoft",
+        client_id="forwarded-client",
+        client_secret="forwarded-secret",
+        refresh_token="rt-forwarded",
+        scopes=["openid"],
+        account_email="user@contoso.com",
+        account_type=ACCOUNT_TYPE_WORK,
+        required_scopes=[],
+    )
+    assert peek_connection("microsoft")["account_type"] == ACCOUNT_TYPE_WORK

--- a/tests/unit/test_skill_sets.py
+++ b/tests/unit/test_skill_sets.py
@@ -316,6 +316,7 @@ class _StubAgent:
     _skill_sets = None
     _requested_skill_set = None
     _active_skill_set = None
+    _skill_set_loaded = None
 
     skill_manager = Agent.skill_manager
     skill_sets = Agent.skill_sets
@@ -455,6 +456,27 @@ def test_agent_switching_sets_unloads_the_previous_one(tmp_path, bundled):
     assert sorted(agent.loaded_skills) == ["inbox-triage", "meeting-scheduling"]
     assert "newsletter-digest" not in agent.get_skills_system_prompt()
     assert "meeting-scheduling" in agent.get_skills_system_prompt()
+
+
+def test_switching_sets_leaves_a_hand_loaded_skill_alone(tmp_path, bundled):
+    """A skill the agent loaded itself is not a set's to unload."""
+    agent = _agent(
+        tmp_path,
+        bundled,
+        skill_sets={
+            "personal": ["newsletter-digest"],
+            "work": ["meeting-scheduling"],
+        },
+        default_skill_set="personal",
+    )
+    agent.load_skill_set()
+    agent.load_skill("inbox-triage")  # not in any set — loaded imperatively
+
+    agent.load_skill_set("work")
+
+    assert "inbox-triage" in agent.loaded_skills
+    assert "newsletter-digest" not in agent.loaded_skills
+    assert "meeting-scheduling" in agent.loaded_skills
 
 
 def test_agent_missing_required_skill_fails_loudly(tmp_path, bundled):

--- a/tests/unit/test_skill_sets.py
+++ b/tests/unit/test_skill_sets.py
@@ -201,6 +201,12 @@ def test_skills_for_prepends_the_always_on_list():
             "not a valid",
         ),
         ({"skills": "inbox-triage"}, "must be a list"),
+        # A bare `work:` key with nothing indented under it — the likeliest
+        # authoring slip, and it must not validate into a set that loads nothing.
+        (
+            {"skill_sets": {"work": None}, "default_skill_set": "work"},
+            "names no skills",
+        ),
     ],
 )
 def test_malformed_declarations_fail_loudly(blocks, expected):
@@ -514,6 +520,84 @@ def test_agent_without_a_manifest_loads_nothing(tmp_path, bundled):
     assert agent.load_skill_set() == {}
     assert agent.loaded_skills == {}
     assert agent.get_skills_system_prompt() == ""
+
+
+def test_explicit_request_on_a_set_less_agent_is_never_discarded(tmp_path, bundled):
+    """The request must raise, not evaporate.
+
+    An agent with no declarations is falsy, and an early return on that would
+    drop the user's explicit ``--skill-set`` with no error and no log line — the
+    exact silent fallback the spec says cannot happen.
+    """
+    agent = _StubAgent(
+        isolated_manager(tmp_path, agent_skill_dirs=[bundled]), skill_set="work"
+    )
+    with pytest.raises(SkillSetError, match="declares no 'skill_sets:' block"):
+        agent.load_skill_set()
+
+    # And passed directly, not just via the constructor.
+    plain = _StubAgent(isolated_manager(tmp_path, agent_skill_dirs=[bundled]))
+    with pytest.raises(SkillSetError, match="declares no 'skill_sets:' block"):
+        plain.load_skill_set("work")
+
+
+def test_a_failed_switch_leaves_the_agent_exactly_as_it_was(tmp_path, bundled):
+    """All-or-nothing: a half-switched agent lies about what it is carrying.
+
+    Loading the new set before retiring the old one, and rolling back what this
+    call added, keeps ``active_skill_set``, the prompt, and the internal
+    tracking mutually consistent after a failure.
+    """
+    agent = _agent(
+        tmp_path,
+        bundled,
+        skill_sets={
+            "personal": ["inbox-triage", "newsletter-digest"],
+            "work": ["meeting-scheduling", "not-bundled-anywhere"],
+        },
+        default_skill_set="personal",
+    )
+    agent.load_skill_set()
+    before = sorted(agent.loaded_skills)
+    assert before == ["inbox-triage", "newsletter-digest"]
+
+    with pytest.raises(Exception, match="not-bundled-anywhere"):
+        agent.load_skill_set("work")
+
+    # Still the personal set, in full, and nothing from 'work' left behind.
+    assert agent.active_skill_set == "personal"
+    assert sorted(agent.loaded_skills) == before
+    prompt = agent.get_skills_system_prompt()
+    assert "meeting-scheduling" not in prompt
+    assert "newsletter-digest" in prompt
+
+    # And the failure did not corrupt tracking: a later successful switch still
+    # retires exactly the personal set.
+    agent.load_skill_set("personal")
+    assert agent.active_skill_set == "personal"
+    assert sorted(agent.loaded_skills) == before
+
+
+def test_two_agents_keep_their_own_sets(tmp_path, bundled):
+    """Skill-set state is per instance — a sibling must not see it."""
+    blocks = dict(
+        skill_sets={
+            "personal": ["newsletter-digest"],
+            "work": ["meeting-scheduling"],
+        },
+        default_skill_set="personal",
+    )
+    first = _agent(tmp_path, bundled, skill_set="personal", **blocks)
+    second = _agent(tmp_path, bundled, skill_set="work", **blocks)
+    first.load_skill_set()
+    second.load_skill_set()
+
+    assert first.active_skill_set == "personal"
+    assert second.active_skill_set == "work"
+    assert list(first.loaded_skills) == ["newsletter-digest"]
+    assert list(second.loaded_skills) == ["meeting-scheduling"]
+    assert "meeting-scheduling" not in first.get_skills_system_prompt()
+    assert "newsletter-digest" not in second.get_skills_system_prompt()
 
 
 # ----------------------------------------------------------------------

--- a/tests/unit/test_skill_sets.py
+++ b/tests/unit/test_skill_sets.py
@@ -1,0 +1,554 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""
+Skill sets — manifest grammar + per-launch resolution (issue #2466).
+
+Every test runs from a cold state: the manifest, the bundled skills root, and
+the user/Claude-import roots all live under ``tmp_path``, so nothing here reads
+the developer's real ``~/.gaia/skills`` or the repo's ``.claude/skills``. That is
+the hidden-state rule from CLAUDE.md — a skill that only resolves because a
+previous run left it lying around is not a passing test.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+import yaml
+
+from gaia.hub.manifest import AgentManifest, ManifestError
+from gaia.skills.errors import SkillSetError, SkillValidationError
+from gaia.skills.sets import (
+    SOURCE_DEFAULT,
+    SOURCE_EXPLICIT,
+    SOURCE_NONE,
+    SOURCE_SELECTOR,
+    SkillSets,
+    parse_skill_sets,
+)
+
+from .skills_helpers import isolated_manager, write_skill_dir
+
+# ----------------------------------------------------------------------
+# Fixtures
+# ----------------------------------------------------------------------
+
+_BASE_MANIFEST = {
+    "id": "demo",
+    "name": "Demo",
+    "version": "0.1.0",
+    "description": "A demo agent.",
+    "author": "AMD",
+    "license": "MIT",
+    "language": "python",
+}
+
+
+def _manifest(**skill_blocks) -> AgentManifest:
+    """Parse a minimal manifest with the given skill blocks layered on."""
+    return AgentManifest.from_dict({**_BASE_MANIFEST, **skill_blocks})
+
+
+def _two_set_manifest() -> AgentManifest:
+    return _manifest(
+        skill_sets={
+            "personal": ["inbox-triage", "newsletter-digest"],
+            "work": ["inbox-triage", "meeting-scheduling"],
+        },
+        default_skill_set="personal",
+    )
+
+
+def _skill_text(name: str) -> str:
+    return (
+        f"---\nname: {name}\n"
+        f"description: Test skill {name}. Use when exercising skill sets.\n"
+        f"---\n\n# {name.title()}\n\nBody of {name}.\n"
+    )
+
+
+@pytest.fixture
+def bundled(tmp_path: Path) -> Path:
+    """An agent-bundled skills root holding every skill the tests declare."""
+    root = tmp_path / "pkg" / "skills"
+    for name in (
+        "always-on",
+        "inbox-triage",
+        "newsletter-digest",
+        "meeting-scheduling",
+    ):
+        write_skill_dir(root, name, _skill_text(name))
+    return root
+
+
+# ----------------------------------------------------------------------
+# Manifest parsing — the additive grammar
+# ----------------------------------------------------------------------
+
+
+def test_manifest_without_skill_blocks_is_empty_and_falsy():
+    manifest = _manifest()
+    assert not manifest.skill_sets
+    assert manifest.skill_sets.always == ()
+    assert manifest.skill_sets.set_names == []
+    assert manifest.skill_sets.default_set is None
+
+
+def test_parse_accepts_string_and_mapping_refs():
+    sets = parse_skill_sets(
+        {
+            "skills": ["always-on"],
+            "skill_sets": {
+                "work": [
+                    "inbox-triage",
+                    {
+                        "name": "meeting-scheduling",
+                        "version": ">=0.1.0",
+                        "required": False,
+                    },
+                ]
+            },
+            "default_skill_set": "work",
+        }
+    )
+    assert [ref.name for ref in sets.always] == ["always-on"]
+    work = sets.sets["work"]
+    assert [ref.name for ref in work] == ["inbox-triage", "meeting-scheduling"]
+    assert work[0].required is True and work[0].version is None
+    assert work[1].required is False and work[1].version == ">=0.1.0"
+
+
+def test_manifest_preserves_declaration_order_of_sets():
+    manifest = _manifest(
+        skill_sets={"work": ["inbox-triage"], "personal": ["newsletter-digest"]},
+        default_skill_set="work",
+    )
+    assert manifest.skill_sets.set_names == ["work", "personal"]
+
+
+def test_skills_for_prepends_the_always_on_list():
+    sets = parse_skill_sets(
+        {
+            "skills": ["always-on"],
+            "skill_sets": {"work": ["inbox-triage"]},
+            "default_skill_set": "work",
+        }
+    )
+    assert [r.name for r in sets.skills_for("work")] == ["always-on", "inbox-triage"]
+
+
+@pytest.mark.parametrize(
+    "blocks, expected",
+    [
+        ({"skill_sets": ["work"]}, "must be a mapping"),
+        ({"skill_sets": {"work": []}, "default_skill_set": "work"}, "is empty"),
+        ({"skill_sets": {"work": ["inbox-triage"]}}, "default_skill_set"),
+        (
+            {"skill_sets": {"work": ["inbox-triage"]}, "default_skill_set": "personal"},
+            "does not name a declared skill set",
+        ),
+        (
+            {"skill_sets": {"Work": ["inbox-triage"]}, "default_skill_set": "Work"},
+            "invalid set name",
+        ),
+        (
+            {
+                "skill_sets": {"work": ["inbox-triage", "inbox-triage"]},
+                "default_skill_set": "work",
+            },
+            "twice",
+        ),
+        (
+            {
+                "skills": ["inbox-triage"],
+                "skill_sets": {"work": ["inbox-triage"]},
+                "default_skill_set": "work",
+            },
+            "already in the always-on",
+        ),
+        (
+            {
+                "skill_sets": {"work": [{"name": "x", "requird": False}]},
+                "default_skill_set": "work",
+            },
+            "unrecognized key",
+        ),
+        (
+            {
+                "skill_sets": {"work": [{"name": "x", "required": "yes"}]},
+                "default_skill_set": "work",
+            },
+            "must be true or false",
+        ),
+        (
+            {
+                "skill_sets": {"work": [{"name": "x", "version": 1}]},
+                "default_skill_set": "work",
+            },
+            "must be a non-empty string",
+        ),
+        (
+            {
+                "skill_sets": {"work": [{"version": "1.0.0"}]},
+                "default_skill_set": "work",
+            },
+            "missing a skill name",
+        ),
+        (
+            {"skill_sets": {"work": ["Inbox_Triage"]}, "default_skill_set": "work"},
+            "not a valid",
+        ),
+        ({"skills": "inbox-triage"}, "must be a list"),
+    ],
+)
+def test_malformed_declarations_fail_loudly(blocks, expected):
+    with pytest.raises(SkillValidationError, match=expected):
+        parse_skill_sets(blocks)
+    # The same failure must reach a manifest author as a ManifestError.
+    with pytest.raises(ManifestError, match=expected):
+        _manifest(**blocks)
+
+
+def test_manifest_error_names_the_file():
+    path = "/tmp/does-not-matter/gaia-agent.yaml"
+    with pytest.raises(ManifestError, match=path):
+        AgentManifest.from_dict(
+            {**_BASE_MANIFEST, "skill_sets": {"work": []}, "default_skill_set": "work"},
+            source=path,
+        )
+
+
+# ----------------------------------------------------------------------
+# Resolution order
+# ----------------------------------------------------------------------
+
+
+def test_resolution_order_explicit_then_selector_then_default():
+    sets = _two_set_manifest().skill_sets
+
+    default = sets.resolve()
+    assert (default.name, default.source) == ("personal", SOURCE_DEFAULT)
+
+    selector = sets.resolve(selected="work")
+    assert (selector.name, selector.source) == ("work", SOURCE_SELECTOR)
+
+    explicit = sets.resolve(requested="work", selected="personal")
+    assert (explicit.name, explicit.source) == ("work", SOURCE_EXPLICIT)
+
+
+def test_resolution_returns_only_the_selected_sets_skills():
+    sets = _two_set_manifest().skill_sets
+    assert [r.name for r in sets.resolve(requested="work").skills] == [
+        "inbox-triage",
+        "meeting-scheduling",
+    ]
+    assert [r.name for r in sets.resolve(requested="personal").skills] == [
+        "inbox-triage",
+        "newsletter-digest",
+    ]
+
+
+def test_blank_request_is_treated_as_unset():
+    sets = _two_set_manifest().skill_sets
+    assert sets.resolve(requested="  ", selected="work").source == SOURCE_SELECTOR
+
+
+@pytest.mark.parametrize(
+    "kwargs, expected",
+    [
+        ({"requested": "buisness"}, "Skill set 'buisness' is not declared"),
+        ({"selected": "buisness"}, "selector returned skill set 'buisness'"),
+    ],
+)
+def test_unknown_set_fails_loudly_listing_valid_sets(kwargs, expected):
+    sets = _two_set_manifest().skill_sets
+    with pytest.raises(SkillSetError) as excinfo:
+        sets.resolve(**kwargs)
+    message = str(excinfo.value)
+    assert expected in message
+    assert "Valid sets: personal, work" in message
+
+
+def test_requesting_a_set_on_an_agent_with_none_fails_loudly():
+    with pytest.raises(SkillSetError, match="declares no 'skill_sets:' block"):
+        _manifest(skills=["always-on"]).skill_sets.resolve(requested="work")
+
+
+def test_no_sets_declared_resolves_to_the_always_on_list():
+    resolution = _manifest(skills=["always-on"]).skill_sets.resolve()
+    assert resolution.name is None
+    assert resolution.source == SOURCE_NONE
+    assert [r.name for r in resolution.skills] == ["always-on"]
+
+
+def test_hand_built_sets_without_a_default_fail_loudly():
+    # parse_skill_sets rejects this shape; a programmatic caller must too.
+    with pytest.raises(SkillSetError, match="No skill set could be resolved"):
+        SkillSets(sets={"work": ()}).resolve()
+
+
+# ----------------------------------------------------------------------
+# Agent integration — only the selected set registers
+# ----------------------------------------------------------------------
+
+
+def _write_manifest(tmp_path: Path, **skill_blocks) -> Path:
+    path = tmp_path / "gaia-agent.yaml"
+    path.write_text(
+        yaml.safe_dump({**_BASE_MANIFEST, **skill_blocks}, sort_keys=False),
+        encoding="utf-8",
+    )
+    return path
+
+
+class _StubAgent:
+    """Drives the real skill-set methods without booting the LLM stack."""
+
+    from gaia.agents.base.agent import Agent
+
+    REQUIRED_CONNECTORS: list = []
+    SKILL_DIRS: list = []
+    SKILL_MANIFEST = None
+    _instance_tools = None
+    _loaded_skills = None
+    _skill_sets = None
+    _requested_skill_set = None
+    _active_skill_set = None
+
+    skill_manager = Agent.skill_manager
+    skill_sets = Agent.skill_sets
+    active_skill_set = Agent.active_skill_set
+    loaded_skills = Agent.loaded_skills
+    _tools_registry = Agent._tools_registry
+    _format_tools_for_prompt = Agent._format_tools_for_prompt
+    load_skill = Agent.load_skill
+    unload_skill = Agent.unload_skill
+    select_skill_set = Agent.select_skill_set
+    resolve_skill_set = Agent.resolve_skill_set
+    load_skill_set = Agent.load_skill_set
+    get_skills_system_prompt = Agent.get_skills_system_prompt
+
+    def __init__(self, manager, *, manifest=None, skill_set=None):
+        self._skill_manager = manager
+        self.SKILL_MANIFEST = str(manifest) if manifest else None
+        self._requested_skill_set = skill_set
+        self.rebuilt = 0
+
+    def rebuild_system_prompt(self):
+        self.rebuilt += 1
+
+
+def _agent(tmp_path, bundled, *, skill_set=None, **skill_blocks) -> _StubAgent:
+    return _StubAgent(
+        isolated_manager(tmp_path, agent_skill_dirs=[bundled]),
+        manifest=_write_manifest(tmp_path, **skill_blocks),
+        skill_set=skill_set,
+    )
+
+
+def test_agent_loads_only_the_default_set(tmp_path, bundled):
+    agent = _agent(
+        tmp_path,
+        bundled,
+        skill_sets={
+            "personal": ["inbox-triage", "newsletter-digest"],
+            "work": ["inbox-triage", "meeting-scheduling"],
+        },
+        default_skill_set="personal",
+    )
+
+    loaded = agent.load_skill_set()
+
+    assert sorted(loaded) == ["inbox-triage", "newsletter-digest"]
+    assert sorted(agent.loaded_skills) == ["inbox-triage", "newsletter-digest"]
+    assert "meeting-scheduling" not in agent.loaded_skills
+    assert agent.active_skill_set == "personal"
+
+
+def test_agent_explicit_skill_set_beats_the_selector_hook(tmp_path, bundled):
+    agent = _agent(
+        tmp_path,
+        bundled,
+        skill_set="work",
+        skill_sets={
+            "personal": ["newsletter-digest"],
+            "work": ["meeting-scheduling"],
+        },
+        default_skill_set="personal",
+    )
+    agent.select_skill_set = lambda: "personal"
+
+    agent.load_skill_set()
+
+    assert agent.active_skill_set == "work"
+    assert list(agent.loaded_skills) == ["meeting-scheduling"]
+
+
+def test_agent_selector_hook_beats_the_default(tmp_path, bundled):
+    agent = _agent(
+        tmp_path,
+        bundled,
+        skill_sets={
+            "personal": ["newsletter-digest"],
+            "work": ["meeting-scheduling"],
+        },
+        default_skill_set="personal",
+    )
+    agent.select_skill_set = lambda: "work"
+
+    agent.load_skill_set()
+
+    assert agent.active_skill_set == "work"
+    assert list(agent.loaded_skills) == ["meeting-scheduling"]
+
+
+def test_agent_always_on_skills_load_for_every_set(tmp_path, bundled):
+    blocks = dict(
+        skills=["always-on"],
+        skill_sets={
+            "personal": ["newsletter-digest"],
+            "work": ["meeting-scheduling"],
+        },
+        default_skill_set="personal",
+    )
+    for requested, extra in (
+        ("personal", "newsletter-digest"),
+        ("work", "meeting-scheduling"),
+    ):
+        agent = _agent(tmp_path, bundled, skill_set=requested, **blocks)
+        agent.load_skill_set()
+        assert sorted(agent.loaded_skills) == sorted(["always-on", extra])
+
+
+def test_agent_unknown_skill_set_fails_loudly_and_loads_nothing(tmp_path, bundled):
+    agent = _agent(
+        tmp_path,
+        bundled,
+        skill_set="buisness",
+        skill_sets={"personal": ["newsletter-digest"], "work": ["meeting-scheduling"]},
+        default_skill_set="personal",
+    )
+
+    with pytest.raises(SkillSetError, match="Valid sets: personal, work"):
+        agent.load_skill_set()
+
+    assert agent.loaded_skills == {}
+    assert agent.active_skill_set is None
+
+
+def test_agent_switching_sets_unloads_the_previous_one(tmp_path, bundled):
+    agent = _agent(
+        tmp_path,
+        bundled,
+        skill_sets={
+            "personal": ["inbox-triage", "newsletter-digest"],
+            "work": ["inbox-triage", "meeting-scheduling"],
+        },
+        default_skill_set="personal",
+    )
+    agent.load_skill_set()
+
+    agent.load_skill_set("work")
+
+    assert sorted(agent.loaded_skills) == ["inbox-triage", "meeting-scheduling"]
+    assert "newsletter-digest" not in agent.get_skills_system_prompt()
+    assert "meeting-scheduling" in agent.get_skills_system_prompt()
+
+
+def test_agent_missing_required_skill_fails_loudly(tmp_path, bundled):
+    agent = _agent(
+        tmp_path,
+        bundled,
+        skill_sets={"work": ["not-bundled-anywhere"]},
+        default_skill_set="work",
+    )
+    with pytest.raises(Exception, match="not-bundled-anywhere"):
+        agent.load_skill_set()
+
+
+def test_agent_missing_optional_skill_is_skipped(tmp_path, bundled):
+    agent = _agent(
+        tmp_path,
+        bundled,
+        skill_sets={
+            "work": [
+                "meeting-scheduling",
+                {"name": "not-bundled-anywhere", "required": False},
+            ]
+        },
+        default_skill_set="work",
+    )
+
+    loaded = agent.load_skill_set()
+
+    assert list(loaded) == ["meeting-scheduling"]
+    assert agent.active_skill_set == "work"
+
+
+def test_agent_without_a_manifest_loads_nothing(tmp_path, bundled):
+    agent = _StubAgent(isolated_manager(tmp_path, agent_skill_dirs=[bundled]))
+    assert agent.load_skill_set() == {}
+    assert agent.loaded_skills == {}
+    assert agent.get_skills_system_prompt() == ""
+
+
+# ----------------------------------------------------------------------
+# The real Agent.__init__ path
+# ----------------------------------------------------------------------
+
+
+def test_agent_init_loads_the_resolved_set(tmp_path, bundled):
+    """A real ``Agent`` subclass resolves and loads its set during __init__."""
+    from gaia.agents.base.agent import Agent
+
+    manifest = _write_manifest(
+        tmp_path,
+        skill_sets={
+            "personal": ["newsletter-digest"],
+            "work": ["meeting-scheduling"],
+        },
+        default_skill_set="personal",
+    )
+    manager = isolated_manager(tmp_path, agent_skill_dirs=[bundled])
+
+    class _Harness(Agent):
+        SKILL_MANIFEST = str(manifest)
+
+        def __init__(self, **kwargs):
+            self._skill_manager = manager
+            super().__init__(skip_lemonade=True, silent_mode=True, **kwargs)
+
+        def _register_tools(self):
+            pass
+
+    with patch("gaia.agents.base.agent.AgentSDK", return_value=MagicMock()):
+        agent = _Harness()
+        assert agent.active_skill_set == "personal"
+        assert list(agent.loaded_skills) == ["newsletter-digest"]
+        assert "Body of newsletter-digest" in agent.system_prompt
+
+        override = _Harness(skill_set="work")
+        assert override.active_skill_set == "work"
+        assert list(override.loaded_skills) == ["meeting-scheduling"]
+
+        with pytest.raises(SkillSetError, match="Valid sets: personal, work"):
+            _Harness(skill_set="buisness")
+
+
+def test_agent_init_without_a_manifest_is_unchanged(tmp_path):
+    """The default path must not read any skills root at all."""
+    from gaia.agents.base.agent import Agent
+
+    class _Plain(Agent):
+        def _register_tools(self):
+            pass
+
+    with patch("gaia.agents.base.agent.AgentSDK", return_value=MagicMock()):
+        agent = _Plain(skip_lemonade=True, silent_mode=True)
+
+    assert agent.loaded_skills == {}
+    assert agent.active_skill_set is None
+    assert agent.get_skills_system_prompt() == ""
+    assert agent._skill_manager is None


### PR DESCRIPTION
The email agent behaved identically whether you pointed it at a personal mailbox or a work one, so its guidance had to be vague enough for both and was sharp for neither — and there was no way for *any* agent to carry more than one interchangeable capability set. It now bundles six Agent Skills and turns on one set per launch: a personal mailbox gets triage, newsletter digests, and travel itineraries; a work mailbox gets triage, meeting scheduling, action-item extraction, and escalation routing. The mailbox kind comes from the Microsoft account type recorded at connect (previously nothing anywhere recorded it), `--skill-set` pins a set explicitly, and a Gmail-only mailbox — which carries no equivalent signal — resolves the declared default rather than being assumed personal. The framework half is generic: any agent gets `skill_sets:` in its manifest and a selector hook; email is the reference consumer.

**Stacked on #2669** (the Phase 1 skills runtime). Base retargets to `main` when that merges; needs a rebase onto `main` before merge either way.

**One regression found and fixed by measuring, not reasoning.** Loading the personal set pushed a 12-message triage request to 16,602 tokens against the pinned 16,384-token window and the run died with `context_length_exceeded` — the bulk-triage condenser sized its result envelope against a fixed prompt cost that predated skills, so the skill bodies were charged twice. The envelope budget now subtracts the measured cost of whatever set is loaded, and the six bodies are trimmed to about half their original length. The same run completes at 16,106 tokens. An agent with no skills loaded gets a byte-identical budget to before.

## `skill_sets` grammar

```yaml
skills:                              # always on, whichever set is active
  - mailbox-hygiene
  - name: incident-review            # mapping form
    version: ">=0.1.0"               # recorded, not resolved (until #2467)
    required: false                  # missing => logged and skipped

skill_sets:                          # exactly ONE is active per launch
  personal: [inbox-triage, newsletter-digest, travel-itinerary]
  work: [inbox-triage, meeting-scheduling, action-item-extraction]

default_skill_set: personal          # required when skill_sets is non-empty
```

Resolution: explicit `--skill-set` / `skill_set=` -> the agent's `select_skill_set()` hook -> `default_skill_set`. An undeclared name raises `SkillSetError` naming the valid sets, from either the flag or the hook — it never falls back. Sets overlap (`inbox-triage` is in both, deliberately); a set may not re-declare an always-on skill.

## Test plan

- [ ] `python -m pytest tests/unit/test_skill_sets.py tests/unit/connectors/test_account_type.py -q` — 63 tests: manifest parse, resolution from all four sources, unknown-set-fails-loud, only-the-selected-set-registers, `tid` -> account type for both branches via synthetic id_tokens, cold-start from `tmp_path`-scoped roots.
- [ ] `python -m pytest hub/agents/email/python/tests/ -q` — 1062 pass, including the new `test_skill_sets_2466.py` (27) covering Gmail-resolves-to-default, the envelope-budget accounting, a cap on per-set prompt cost, and that the freeze stages the skills + manifest as data.
- [ ] `python -m pytest tests/unit/ -q` — 2216 pass (one pre-existing PATH-only failure in `test_cli_smoke.py::test_gaia_binary_on_path`, passes with the venv `bin` on `PATH`).
- [ ] `python util/lint.py --all` — all 10 checks pass.
- [ ] `gaia-agent-email serve --skill-set work` starts and pins the set; `--skill-set buisness` exits naming `personal, work`.
- [ ] Verify the eval on a box where the triage harness completes — see below.

## Eval status — read before merging

`gaia eval benchmark` (the email triage harness, which drives `EmailTriageAgent.process_query`) reproduced and then cleared the context overflow above: 15,837 input tokens with skills disabled, 16,602 → **overflow** with skills before the budget fix, 16,106 → clean after it. That is the signal the eval was needed for, and it is what drove the fix.

It did **not** produce a comparable triage-accuracy scorecard. On this machine both arms — with and without skills — end with `no triage results found in agent conversation`: Gemma-4-E4B returns its tool-choice reasoning as prose instead of emitting the call, and the local daemon broker rotates ports mid-run. Both failures reproduce identically with skills disabled, so neither is caused by this change, but it means the accuracy comparison against `tests/fixtures/email/baseline_accuracy.json` (category accuracy 0.796, tolerance 5pp) still needs a run on hardware where the harness completes. Please gate the merge on that rather than on my token-count evidence alone.

Closes #2466


---

## Review round

An adversarial review pass found seven real defects, all fixed in `3dc9d0d0` with tests. Two were install-breaking and worth calling out:

- **A pip-installed wheel could not construct the agent at all.** `package-data` globs cannot reach outside their own package, so `gaia-agent.yaml` — which lives at the package root because the hub publisher reads it there — was absent from the wheel, and the runtime raised `ManifestError` on every construction. A `build_py` hook now stages it into the package on every install path, from the single authored file (no committed second copy to drift). Verified against a real built wheel: `gaia_agent_email/gaia-agent.yaml` plus all six `SKILL.md` files are present.
- **A failed mid-session set switch corrupted the agent.** Stale skills were unloaded *before* the new set loaded, so one missing skill left the agent reporting set A while carrying part of set B — with the difference untracked and therefore unloadable for the life of the instance. The switch is now all-or-nothing.

Also fixed: an explicit `skill_set` was silently discarded on an agent declaring no sets (contradicting this PR's own spec text); `import_forwarded_connection` erased a recorded Microsoft `account_type`, dropping a work mailbox to the personal set; the skill cost credited back to the triage envelope used a prose estimator that under-counts real Markdown ~2×, handing the envelope budget the prompt was already using; a bare `work:` key under `skill_sets` parsed into a set that loads nothing; and `GAIA_EMAIL_SKILL_SET` was never validated, so a typo started a healthy-looking sidecar whose every session then failed.

### One pre-existing bug found, deliberately not fixed here

At ~300 messages the bulk-triage result envelope is **~10,127 tokens against a 6,144 budget** — the `grouped` verdict map alone is ~9,924 tokens and `condense_triage_result` never trims it. This is **independent of this PR**: the number is identical with zero skill cost. It only bites above the shipped `DEFAULT_INBOX_SCAN_CEILING` (100), i.e. when `GAIA_EMAIL_TRIAGE_MAX_MESSAGES` is lifted — which the eval harness does. Worth its own issue; the new budget test is scoped to the shipped ceiling so it doesn't paper over it.
