### PR TITLE
docs(plans): preserve the TUI packaging design and binary-distribution plan

### DIFF
--- a/docs/superpowers/plans/2026-07-25-gaia-binary-distribution-phase1.md
+++ b/docs/superpowers/plans/2026-07-25-gaia-binary-distribution-phase1.md
@@ -1,0 +1,1830 @@
+# GAIA Binary Distribution — Phase 1 Implementation Plan
+
+> **Partly superseded since this was written (2026-07-25).** Two changes landed
+> that overlap it, so re-verify current state before starting a task:
+> - #2522 added a `build-tui` job to `publish.yml` that attaches the six targets
+>   to the GitHub Release with a `SHA256SUMS`, plus an `install_tui()` in
+>   `installer/scripts/install.sh` — which is Linux-only, so the darwin builds
+>   still have no install path.
+> - #2530 publishes the hub as a `type: component` package to the R2 catalog
+>   (`hub/components/terminal-hub/gaia-agent.yaml`), which is the artifact-store
+>   half this plan describes.
+>
+> Still true as of writing this note: no release carries a `gaia-<os>-<arch>`
+> asset, the hub catalog holds only `email`, `gaia tui` exits 2, and
+> `amd-gaia.ai/install.sh` returns 200 but installs the Python side only — so
+> the plan's premise (the binary is not obtainable) holds even though some
+> plumbing exists.
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `gaia` — the Go binary — installable in one command from a published, hash-verified artifact, and take the `gaia` name without breaking a single command anyone runs today.
+
+**Architecture:** `build_tui.yml` already cross-compiles six targets and throws them away as 14-day CI artifacts. This plan changes their destination: a generated manifest (`platform → {sha256, size, urls[]}`) published to the hub artifact store with GitHub Releases as a same-hash mirror, consumed by a ~100-line POSIX shell / PowerShell installer served from the URL the website has advertised (and 404'd) for months. The rename rides along, made safe by a forwarding shim in cobra's root command that hands unknown subcommands to `gaia-dev` rather than dead-ending.
+
+**Tech Stack:** Go 1.x + cobra (`tui/`), GitHub Actions, Python `setup.py` console_scripts, POSIX sh + PowerShell, Astro (`website/`), pytest, `go test`.
+
+## Global Constraints
+
+- **No Claude attribution anywhere** — not in commits, code comments, docs, or PR text. No `Co-Authored-By: Claude` trailers.
+- **No silent fallbacks.** A hash mismatch, an exhausted mirror list, or an unsupported platform is a hard error naming what failed, what to do, and where to look. Never "use it anyway."
+- **A shipped remedy command must actually parse.** Run every command string you put in user-facing text before committing it. Enforced by `tests/unit/test_remedy_commands_are_runnable.py`.
+- **Never judge a command's success through a pipe.** Use `cmd > /tmp/out.txt 2>&1; echo "exit=$?"` and check `$?` on its own line.
+- **`amd-gaia.ai` links inside `src/gaia/` must keep the `/docs/` prefix** (enforced by `tests/unit/test_amd_gaia_urls.py`). Exception: `/install.sh` and `/install.ps1` are allowlisted at the site root — which is exactly what Task 6 publishes.
+- **Nothing large downloads without an explicit yes and a stated size** (spec §1.3). Applies to every artifact except the `gaia` binary itself, whose consent is the install command the user ran.
+- **Release builds are stripped** — `-ldflags="-s -w"`. Size target 15 MB, current ~16.5 MB (darwin/arm64).
+- **Platform key format is `<goos>-<goarch>`** using Go's names (`darwin-arm64`, `linux-amd64`, `windows-amd64`), matching `build_tui.yml`'s existing matrix. Do **not** use the npm-style `darwin-arm64`/`win32-x64` mix from `binaries.lock.json`.
+
+**Do not touch in this plan:** `docs/guides/email.mdx`, `docs/docs.json`. Other sessions own them.
+
+---
+
+## File Structure
+
+| File | Responsibility | Task |
+|---|---|---|
+| `tui/internal/cli/root.go` | root command; `--version` wiring; the unknown-command forwarder | 1, 7 |
+| `tui/internal/cli/forward.go` | **new** — resolve and exec `gaia-dev`, or explain what replaced the command | 7 |
+| `tui/internal/cli/forward_test.go` | **new** — forwarder unit tests | 7 |
+| `tui/internal/cli/root_test.go` | **new** — `--version` and arg-routing tests | 1 |
+| `util/gen_binary_manifest.py` | **new** — walk built binaries, emit `manifest.json` with sha256 + size + mirror URLs | 3 |
+| `tests/unit/test_gen_binary_manifest.py` | **new** — manifest generator tests | 3 |
+| `.github/workflows/build_tui.yml` | add release-asset upload + manifest generation + publish | 2, 3, 4 |
+| `installer/scripts/get-gaia.sh` | **new** — POSIX installer: resolve platform, read manifest, verify, install | 5 |
+| `installer/scripts/get-gaia.ps1` | **new** — Windows equivalent | 5 |
+| `tests/unit/test_get_gaia_script.py` | **new** — installer script tests against a local fixture manifest | 5 |
+| `website/public/install.sh`, `install.ps1` | published copies, generated at deploy time | 6 |
+| `.github/workflows/deploy_website.yml` | copy the installers into `public/` before build | 6 |
+| `setup.py:333-337` | drop `gaia`, add `gaia-dev`, keep `gaia-cli` as deprecated | 8 |
+| `tui/internal/daemon/client.go:245-254` | stop resolving the engine by `PATH` | 9 |
+| `src/gaia/apps/webui/services/backend-installer.cjs` | `findGaiaBin()` must not silently resolve the Go binary | 10 |
+| `tests/unit/test_remedy_commands_are_runnable.py` | un-invert the guardrail so it fails on stale remedies | 11 |
+
+---
+
+## Task 0: Verify the two unexecuted cobra claims
+
+Spec §6.4 flags two structural reads of cobra source that were never run. Both drive later tasks. This is a five-minute task and it gates Task 1 and Task 7.
+
+**Files:** none modified.
+
+**Interfaces:**
+- Produces: a confirmed or refuted answer for (a) whether `gaia hub install email` reaches `hubCmd` with `ArbitraryArgs` and silently ignores the extra words, and (b) whether `gaia --version` errors.
+
+- [ ] **Step 1: Run both probes, redirecting (never piping)**
+
+```bash
+cd tui
+go run ./cmd/gaia hub install email > /tmp/gaia-hub.txt 2>&1; echo "exit=$?"; cat /tmp/gaia-hub.txt
+go run ./cmd/gaia --version          > /tmp/gaia-ver.txt 2>&1; echo "exit=$?"; cat /tmp/gaia-ver.txt
+go run ./cmd/gaia version            > /tmp/gaia-vsub.txt 2>&1; echo "exit=$?"; cat /tmp/gaia-vsub.txt
+```
+
+- [ ] **Step 2: Record the outcomes in the plan file**
+
+Append a short "Task 0 results" block to this document with the three exit codes and outputs.
+
+Expected, per the audit: `--version` exits non-zero with `unknown flag: --version` (cobra only registers the flag when `rootCmd.Version != ""`, and `root.go` never sets it). `version` as a subcommand works. `hub install email` is the consequential one — if `hubCmd` accepts and ignores `install email`, a user following an old doc gets the browsing TUI instead of an install, silently.
+
+- [ ] **Step 3: Commit the results**
+
+```bash
+git add docs/superpowers/plans/2026-07-25-gaia-binary-distribution-phase1.md
+git commit -m "docs(plan): record cobra behaviour probes for phase 1"
+```
+
+---
+
+## Task 1: Make `gaia --version` work
+
+A published artifact needs a version the user can read back, and the installer script asserts on it in Task 5.
+
+**Files:**
+- Modify: `tui/internal/cli/root.go:14-28`
+- Test: `tui/internal/cli/root_test.go` (create)
+
+**Interfaces:**
+- Consumes: `version`, `commit`, `date` package vars from `tui/internal/cli/version.go:9-13`, already injected by `build_tui.yml` via `-X`.
+- Produces: `gaia --version` prints the same string as `gaia version` and exits 0.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tui/internal/cli/root_test.go`:
+
+```go
+package cli
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func TestVersionFlagIsRegistered(t *testing.T) {
+	if rootCmd.Version == "" {
+		t.Fatal("rootCmd.Version is empty, so cobra never registers --version")
+	}
+}
+
+func TestVersionFlagPrintsVersion(t *testing.T) {
+	var out bytes.Buffer
+	rootCmd.SetOut(&out)
+	rootCmd.SetErr(&out)
+	rootCmd.SetArgs([]string{"--version"})
+	defer func() {
+		rootCmd.SetArgs(nil)
+		rootCmd.SetOut(nil)
+		rootCmd.SetErr(nil)
+	}()
+
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("--version returned an error: %v", err)
+	}
+	if !strings.Contains(out.String(), version) {
+		t.Fatalf("--version output %q does not contain version %q", out.String(), version)
+	}
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cd tui && go test ./internal/cli/ -run TestVersionFlag -v > /tmp/t.txt 2>&1; echo "exit=$?"; cat /tmp/t.txt`
+Expected: FAIL — `rootCmd.Version is empty, so cobra never registers --version`
+
+- [ ] **Step 3: Set the version and its template**
+
+In `tui/internal/cli/root.go`, inside `func init()` (after line 31's existing flag registration), add:
+
+```go
+	// cobra only registers --version when Version is non-empty. Keep the text
+	// identical to `gaia version` so both spellings agree.
+	rootCmd.Version = version
+	rootCmd.SetVersionTemplate(
+		fmt.Sprintf("gaia %s (commit: %s, built: %s)\n", version, commit, date))
+```
+
+`fmt` is already imported at `root.go:4`.
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `cd tui && go test ./internal/cli/ -run TestVersionFlag -v > /tmp/t.txt 2>&1; echo "exit=$?"; cat /tmp/t.txt`
+Expected: PASS, both tests.
+
+- [ ] **Step 5: Confirm both spellings agree in a real build**
+
+```bash
+cd tui
+go run ./cmd/gaia --version > /tmp/a.txt 2>&1; echo "exit=$?"
+go run ./cmd/gaia version   > /tmp/b.txt 2>&1; echo "exit=$?"
+diff /tmp/a.txt /tmp/b.txt; echo "diff-exit=$?"
+```
+Expected: both exit 0, `diff-exit=0`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add tui/internal/cli/root.go tui/internal/cli/root_test.go
+git commit -m "fix(tui): register --version so the flag works, not just the subcommand"
+```
+
+---
+
+## Task 2: Publish the binaries as GitHub Release assets
+
+Smallest useful step and the mirror leg of §3.3. No user-visible change; unblocks Tasks 3–5.
+
+**Files:**
+- Modify: `.github/workflows/build_tui.yml` (add a `release` job after `size-check`)
+
+**Interfaces:**
+- Produces: on a `v*` tag, assets named `gaia-<goos>-<goarch>[.exe]` attached to the GitHub Release, one per matrix target.
+
+- [ ] **Step 1: Add the tag trigger**
+
+In `.github/workflows/build_tui.yml`, extend the `on:` block (currently lines 10-23) with:
+
+```yaml
+  push:
+    tags:
+      - 'v*'
+```
+
+Keep the existing `branches: [main]` push trigger and its `paths:` filter. Note that a tag push has no `paths` filter, which is intended — a release must build regardless of what changed.
+
+- [ ] **Step 2: Add the release job**
+
+Append to `.github/workflows/build_tui.yml`:
+
+```yaml
+  release:
+    name: Attach binaries to the release
+    needs: [build, size-check]
+    if: startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Download all platform artifacts
+        uses: actions/download-artifact@v8
+        with:
+          pattern: gaia-*
+          path: release-assets
+          merge-multiple: true
+
+      - name: List what will be uploaded
+        run: |
+          ls -la release-assets/ > /tmp/assets.txt 2>&1; echo "exit=$?"
+          cat /tmp/assets.txt
+          COUNT=$(ls release-assets/ | wc -l)
+          echo "asset count: $COUNT"
+          if [ "$COUNT" -lt 6 ]; then
+            echo "::error::expected 6 platform binaries, found $COUNT"
+            exit 1
+          fi
+
+      - name: Upload to the release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: release-assets/*
+          fail_on_unmatched_files: true
+```
+
+The count gate is deliberate: a silently-missing platform is how a user on that platform gets a 404 from the installer instead of an error naming their platform.
+
+- [ ] **Step 3: Validate the workflow parses**
+
+Run: `cd /Users/kovtcharov/Work/gaia && python -c "import yaml,sys; yaml.safe_load(open('.github/workflows/build_tui.yml'))" > /tmp/y.txt 2>&1; echo "exit=$?"; cat /tmp/y.txt`
+Expected: exit=0, no output.
+
+- [ ] **Step 4: Dry-run the job logic locally**
+
+```bash
+mkdir -p /tmp/release-assets && cd /tmp/release-assets
+for p in linux-amd64 linux-arm64 darwin-amd64 darwin-arm64 windows-amd64 windows-arm64; do touch "gaia-$p"; done
+COUNT=$(ls | wc -l); echo "count=$COUNT"
+rm -rf /tmp/release-assets
+```
+Expected: `count=6`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add .github/workflows/build_tui.yml
+git commit -m "ci(tui): publish the six platform binaries as release assets"
+```
+
+---
+
+## Task 3: Generate the binary manifest
+
+The manifest is the contract every installer and the future self-update path reads. It must carry a real byte count — `binaries.lock.json` shipping `"size": 0` is the bug that makes the consent rule (§1.3) unenforceable.
+
+**Files:**
+- Create: `util/gen_binary_manifest.py`
+- Test: `tests/unit/test_gen_binary_manifest.py`
+- Modify: `.github/workflows/build_tui.yml` (release job)
+
+**Interfaces:**
+- Consumes: a directory of files named `gaia-<goos>-<goarch>[.exe]` (Task 2's `release-assets/`).
+- Produces: `build_manifest(assets_dir: Path, version: str, hub_base: str, gh_base: str) -> dict` and a CLI writing `manifest.json`. Schema:
+
+```json
+{
+  "schemaVersion": 1,
+  "component": "gaia",
+  "version": "0.1.0",
+  "platforms": {
+    "darwin-arm64": {
+      "sha256": "<64 hex chars>",
+      "size": 17301504,
+      "filename": "gaia-darwin-arm64",
+      "urls": ["<hub url>", "<github url>"]
+    }
+  }
+}
+```
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/unit/test_gen_binary_manifest.py`:
+
+```python
+import hashlib
+import json
+import pytest
+
+from util.gen_binary_manifest import build_manifest, UnknownPlatformError
+
+HUB = "https://hub.amd-gaia.ai/bin/gaia"
+GH = "https://github.com/amd/gaia/releases/download"
+
+
+def _write(tmp_path, name, payload=b"binary-bytes"):
+    p = tmp_path / name
+    p.write_bytes(payload)
+    return p
+
+
+def test_manifest_records_real_sha256_and_size(tmp_path):
+    payload = b"some binary content"
+    _write(tmp_path, "gaia-darwin-arm64", payload)
+
+    m = build_manifest(tmp_path, "0.1.0", HUB, GH)
+    entry = m["platforms"]["darwin-arm64"]
+
+    assert entry["sha256"] == hashlib.sha256(payload).hexdigest()
+    assert entry["size"] == len(payload)
+    assert entry["size"] > 0
+
+
+def test_manifest_lists_hub_first_then_github_mirror(tmp_path):
+    _write(tmp_path, "gaia-linux-amd64")
+
+    m = build_manifest(tmp_path, "0.1.0", HUB, GH)
+    urls = m["platforms"]["linux-amd64"]["urls"]
+
+    assert len(urls) == 2
+    assert urls[0] == f"{HUB}/0.1.0/gaia-linux-amd64"
+    assert urls[1] == f"{GH}/v0.1.0/gaia-linux-amd64"
+
+
+def test_windows_exe_suffix_is_stripped_from_the_platform_key(tmp_path):
+    _write(tmp_path, "gaia-windows-amd64.exe")
+
+    m = build_manifest(tmp_path, "0.1.0", HUB, GH)
+
+    assert "windows-amd64" in m["platforms"]
+    assert m["platforms"]["windows-amd64"]["filename"] == "gaia-windows-amd64.exe"
+
+
+def test_unrecognised_filename_raises_rather_than_being_skipped(tmp_path):
+    _write(tmp_path, "gaia-solaris-sparc")
+
+    with pytest.raises(UnknownPlatformError) as exc:
+        build_manifest(tmp_path, "0.1.0", HUB, GH)
+
+    assert "solaris-sparc" in str(exc.value)
+
+
+def test_empty_directory_raises(tmp_path):
+    with pytest.raises(ValueError) as exc:
+        build_manifest(tmp_path, "0.1.0", HUB, GH)
+
+    assert "no binaries" in str(exc.value).lower()
+
+
+def test_manifest_is_deterministic(tmp_path):
+    _write(tmp_path, "gaia-linux-amd64")
+    _write(tmp_path, "gaia-darwin-arm64")
+
+    a = json.dumps(build_manifest(tmp_path, "0.1.0", HUB, GH), sort_keys=True)
+    b = json.dumps(build_manifest(tmp_path, "0.1.0", HUB, GH), sort_keys=True)
+
+    assert a == b
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cd /Users/kovtcharov/Work/gaia && python -m pytest tests/unit/test_gen_binary_manifest.py -v > /tmp/t.txt 2>&1; echo "exit=$?"; tail -20 /tmp/t.txt`
+Expected: FAIL — `ModuleNotFoundError: No module named 'util.gen_binary_manifest'`
+
+- [ ] **Step 3: Write the implementation**
+
+Create `util/gen_binary_manifest.py`:
+
+```python
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""Generate the `gaia` binary manifest consumed by the installers.
+
+One entry per platform: the SHA-256 every client verifies against, a real byte
+count so the install screen can state a size before downloading, and an ordered
+mirror list (hub first, GitHub Releases second) sharing that single hash.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import sys
+from pathlib import Path
+
+SCHEMA_VERSION = 1
+COMPONENT = "gaia"
+
+# Go's own GOOS-GOARCH names, matching build_tui.yml's matrix.
+KNOWN_PLATFORMS = {
+    "linux-amd64",
+    "linux-arm64",
+    "darwin-amd64",
+    "darwin-arm64",
+    "windows-amd64",
+    "windows-arm64",
+}
+
+
+class UnknownPlatformError(ValueError):
+    """A built artifact does not map to a known platform key."""
+
+
+def _sha256_and_size(path: Path) -> tuple[str, int]:
+    digest = hashlib.sha256()
+    size = 0
+    with path.open("rb") as fh:
+        for chunk in iter(lambda: fh.read(1024 * 1024), b""):
+            digest.update(chunk)
+            size += len(chunk)
+    return digest.hexdigest(), size
+
+
+def _platform_key(filename: str) -> str:
+    stem = filename[: -len(".exe")] if filename.endswith(".exe") else filename
+    if not stem.startswith("gaia-"):
+        raise UnknownPlatformError(
+            f"{filename!r} does not match the expected 'gaia-<goos>-<goarch>' shape. "
+            f"Check the -o flag in .github/workflows/build_tui.yml."
+        )
+    key = stem[len("gaia-") :]
+    if key not in KNOWN_PLATFORMS:
+        raise UnknownPlatformError(
+            f"{filename!r} resolves to platform {key!r}, which is not in KNOWN_PLATFORMS. "
+            f"If a target was added to build_tui.yml, add it here too; known: "
+            f"{sorted(KNOWN_PLATFORMS)}"
+        )
+    return key
+
+
+def build_manifest(assets_dir: Path, version: str, hub_base: str, gh_base: str) -> dict:
+    """Build the manifest dict for every binary in ``assets_dir``.
+
+    Raises loudly on an unknown filename or an empty directory — a silently
+    skipped platform reaches users as a 404 from the installer.
+    """
+    assets_dir = Path(assets_dir)
+    files = sorted(p for p in assets_dir.iterdir() if p.is_file())
+    if not files:
+        raise ValueError(
+            f"no binaries found in {assets_dir}. The release job downloads them "
+            f"from the build matrix artifacts; check that step ran."
+        )
+
+    platforms: dict[str, dict] = {}
+    for path in files:
+        key = _platform_key(path.name)
+        sha256, size = _sha256_and_size(path)
+        platforms[key] = {
+            "sha256": sha256,
+            "size": size,
+            "filename": path.name,
+            "urls": [
+                f"{hub_base.rstrip('/')}/{version}/{path.name}",
+                f"{gh_base.rstrip('/')}/v{version}/{path.name}",
+            ],
+        }
+
+    return {
+        "schemaVersion": SCHEMA_VERSION,
+        "component": COMPONENT,
+        "version": version,
+        "platforms": dict(sorted(platforms.items())),
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("assets_dir", type=Path)
+    parser.add_argument("--version", required=True, help="release version without a leading v")
+    parser.add_argument("--hub-base", default="https://hub.amd-gaia.ai/bin/gaia")
+    parser.add_argument("--gh-base", default="https://github.com/amd/gaia/releases/download")
+    parser.add_argument("--out", type=Path, required=True)
+    args = parser.parse_args(argv)
+
+    manifest = build_manifest(args.assets_dir, args.version, args.hub_base, args.gh_base)
+    args.out.write_text(json.dumps(manifest, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    print(f"wrote {args.out} with {len(manifest['platforms'])} platforms")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `cd /Users/kovtcharov/Work/gaia && python -m pytest tests/unit/test_gen_binary_manifest.py -v > /tmp/t.txt 2>&1; echo "exit=$?"; tail -20 /tmp/t.txt`
+Expected: PASS, 6 tests.
+
+- [ ] **Step 5: Wire it into the release job**
+
+In `.github/workflows/build_tui.yml`, inside the `release` job, add between "List what will be uploaded" and "Upload to the release":
+
+```yaml
+      - uses: actions/checkout@v7
+        with:
+          path: repo
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.x"
+
+      - name: Generate the binary manifest
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          python repo/util/gen_binary_manifest.py release-assets \
+            --version "$VERSION" \
+            --out release-assets/manifest.json > /tmp/gen.txt 2>&1
+          echo "exit=$?"
+          cat /tmp/gen.txt
+```
+
+The manifest lands inside `release-assets/`, so the existing upload step attaches it to the release alongside the binaries.
+
+Note the ordering constraint: the asset-count gate in Task 2 runs *before* this step, so it counts 6 binaries and not 7. Do not move the manifest generation above it.
+
+- [ ] **Step 6: Run lint**
+
+Run: `cd /Users/kovtcharov/Work/gaia && python util/lint.py --black --isort > /tmp/l.txt 2>&1; echo "exit=$?"; tail -5 /tmp/l.txt`
+Expected: exit=0.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add util/gen_binary_manifest.py tests/unit/test_gen_binary_manifest.py .github/workflows/build_tui.yml
+git commit -m "feat(ci): generate a hash-and-size manifest for the gaia binary"
+```
+
+---
+
+## Task 4: Publish the manifest and binaries to the hub artifact store
+
+**Files:**
+- Modify: `.github/workflows/build_tui.yml` (release job)
+
+**Interfaces:**
+- Consumes: `release-assets/manifest.json` and the six binaries from Task 3.
+- Produces: `GET https://hub.amd-gaia.ai/bin/gaia/manifest.json` and per-platform objects at the `urls[0]` paths the manifest advertises.
+
+- [ ] **Step 1: Read the existing publish contract**
+
+Read `.github/workflows/release_agent_email.yml` — specifically its publish job. It POSTs each artifact to the Agent Hub Worker's `/publish` with `Bearer $GAIA_HUB_TOKEN`, and `/publish` is immutable per filename: re-publishing identical bytes is a verified 409 no-op, different bytes under a published name fails. Reuse that call shape exactly; do not invent a second upload mechanism.
+
+- [ ] **Step 2: Add the publish step, gated on an environment**
+
+In the `release` job, before "Upload to the release":
+
+```yaml
+      - name: Publish to the hub artifact store
+        env:
+          GAIA_HUB_TOKEN: ${{ secrets.GAIA_HUB_TOKEN }}
+          GAIA_HUB_BASE_URL: ${{ vars.GAIA_HUB_BASE_URL || 'https://hub.amd-gaia.ai' }}
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          set -e
+          for f in release-assets/*; do
+            NAME=$(basename "$f")
+            if [ "$NAME" = "manifest.json" ]; then KEY="bin/gaia/manifest.json"; else KEY="bin/gaia/$VERSION/$NAME"; fi
+            curl -sS -X POST \
+              -H "Authorization: Bearer $GAIA_HUB_TOKEN" \
+              -H "X-Object-Key: $KEY" \
+              --data-binary "@$f" \
+              "$GAIA_HUB_BASE_URL/publish" \
+              -o /tmp/pub.txt -w "http_code=%{http_code}\n"
+            echo "published $KEY exit=$?"
+            cat /tmp/pub.txt
+          done
+```
+
+Add `environment: agent-publish` to the `release` job so a human approves before anything is published, matching `release_agent_email.yml`.
+
+**Verify the header name and object-key convention against `workers/agent-hub/src/` before running this** — the exact header the Worker reads was not confirmed while writing this plan, and a wrong header name fails at publish time with a 4xx rather than at review time.
+
+- [ ] **Step 3: Post-publish verification — fetch back what was published**
+
+Add after the publish step:
+
+```yaml
+      - name: Verify every published object matches the manifest
+        run: |
+          set -e
+          BASE="${GAIA_HUB_BASE_URL:-https://hub.amd-gaia.ai}"
+          python - <<'PY' > /tmp/verify.txt 2>&1
+          import hashlib, json, sys, urllib.request
+          m = json.load(open("release-assets/manifest.json"))
+          bad = []
+          for key, entry in m["platforms"].items():
+              url = entry["urls"][0]
+              with urllib.request.urlopen(url, timeout=60) as r:
+                  data = r.read()
+              got = hashlib.sha256(data).hexdigest()
+              if got != entry["sha256"]:
+                  bad.append(f"{key}: manifest {entry['sha256']} != fetched {got}")
+              elif len(data) != entry["size"]:
+                  bad.append(f"{key}: manifest size {entry['size']} != fetched {len(data)}")
+              else:
+                  print(f"ok {key}")
+          if bad:
+              print("MISMATCH:"); [print(" ", b) for b in bad]; sys.exit(1)
+          PY
+          echo "exit=$?"
+          cat /tmp/verify.txt
+```
+
+This is the step that catches a publish that half-succeeded. Without it, the manifest can advertise a hash the store does not serve, and the first person to find out is a user whose install fails verification.
+
+- [ ] **Step 4: Validate the workflow parses**
+
+Run: `cd /Users/kovtcharov/Work/gaia && python -c "import yaml; yaml.safe_load(open('.github/workflows/build_tui.yml'))" > /tmp/y.txt 2>&1; echo "exit=$?"; cat /tmp/y.txt`
+Expected: exit=0.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add .github/workflows/build_tui.yml
+git commit -m "ci(tui): publish the gaia binary and manifest to the hub artifact store"
+```
+
+---
+
+## Task 5: The install script
+
+~100 lines of POSIX sh that resolve the platform, read the manifest, try each mirror in order, verify the hash, and install to `~/.gaia/bin/`. Plus the PowerShell twin.
+
+**Files:**
+- Create: `installer/scripts/get-gaia.sh`, `installer/scripts/get-gaia.ps1`
+- Test: `tests/unit/test_get_gaia_script.py`
+
+**Interfaces:**
+- Consumes: the manifest schema from Task 3.
+- Produces: `~/.gaia/bin/gaia`, executable, hash-verified; exit 0 on success, non-zero with a named reason otherwise.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/unit/test_get_gaia_script.py`:
+
+```python
+import hashlib
+import json
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+SCRIPT = Path(__file__).resolve().parents[2] / "installer" / "scripts" / "get-gaia.sh"
+
+
+def _run(env, *args):
+    return subprocess.run(
+        ["sh", str(SCRIPT), *args],
+        capture_output=True,
+        text=True,
+        env={**os.environ, **env},
+    )
+
+
+@pytest.fixture
+def fake_release(tmp_path):
+    """A local file:// 'mirror' holding one binary and a manifest describing it."""
+    store = tmp_path / "store"
+    store.mkdir()
+    payload = b"#!/bin/sh\necho fake-gaia\n"
+    binary = store / "gaia-linux-amd64"
+    binary.write_bytes(payload)
+
+    manifest = {
+        "schemaVersion": 1,
+        "component": "gaia",
+        "version": "0.1.0",
+        "platforms": {
+            "linux-amd64": {
+                "sha256": hashlib.sha256(payload).hexdigest(),
+                "size": len(payload),
+                "filename": "gaia-linux-amd64",
+                "urls": [binary.as_uri()],
+            }
+        },
+    }
+    (store / "manifest.json").write_text(json.dumps(manifest))
+    return store
+
+
+@pytest.mark.skipif(shutil.which("sh") is None, reason="POSIX sh required")
+def test_installs_and_verifies(tmp_path, fake_release):
+    home = tmp_path / "home"
+    r = _run(
+        {
+            "GAIA_MANIFEST_URL": (fake_release / "manifest.json").as_uri(),
+            "GAIA_INSTALL_HOME": str(home),
+            "GAIA_FORCE_PLATFORM": "linux-amd64",
+        }
+    )
+    assert r.returncode == 0, r.stderr
+    installed = home / "bin" / "gaia"
+    assert installed.exists()
+    assert os.access(installed, os.X_OK)
+
+
+@pytest.mark.skipif(shutil.which("sh") is None, reason="POSIX sh required")
+def test_hash_mismatch_refuses_to_install(tmp_path, fake_release):
+    manifest_path = fake_release / "manifest.json"
+    m = json.loads(manifest_path.read_text())
+    m["platforms"]["linux-amd64"]["sha256"] = "0" * 64
+    manifest_path.write_text(json.dumps(m))
+
+    home = tmp_path / "home"
+    r = _run(
+        {
+            "GAIA_MANIFEST_URL": manifest_path.as_uri(),
+            "GAIA_INSTALL_HOME": str(home),
+            "GAIA_FORCE_PLATFORM": "linux-amd64",
+        }
+    )
+    assert r.returncode != 0
+    assert "checksum" in (r.stderr + r.stdout).lower()
+    assert not (home / "bin" / "gaia").exists()
+
+
+@pytest.mark.skipif(shutil.which("sh") is None, reason="POSIX sh required")
+def test_unsupported_platform_names_the_platform(tmp_path, fake_release):
+    home = tmp_path / "home"
+    r = _run(
+        {
+            "GAIA_MANIFEST_URL": (fake_release / "manifest.json").as_uri(),
+            "GAIA_INSTALL_HOME": str(home),
+            "GAIA_FORCE_PLATFORM": "solaris-sparc",
+        }
+    )
+    assert r.returncode != 0
+    assert "solaris-sparc" in (r.stderr + r.stdout)
+
+
+@pytest.mark.skipif(shutil.which("sh") is None, reason="POSIX sh required")
+def test_reports_the_size_before_downloading(tmp_path, fake_release):
+    home = tmp_path / "home"
+    r = _run(
+        {
+            "GAIA_MANIFEST_URL": (fake_release / "manifest.json").as_uri(),
+            "GAIA_INSTALL_HOME": str(home),
+            "GAIA_FORCE_PLATFORM": "linux-amd64",
+        }
+    )
+    assert r.returncode == 0
+    assert "MB" in (r.stdout + r.stderr) or "bytes" in (r.stdout + r.stderr)
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cd /Users/kovtcharov/Work/gaia && python -m pytest tests/unit/test_get_gaia_script.py -v > /tmp/t.txt 2>&1; echo "exit=$?"; tail -20 /tmp/t.txt`
+Expected: FAIL — the script does not exist.
+
+- [ ] **Step 3: Write the installer**
+
+Create `installer/scripts/get-gaia.sh`:
+
+```sh
+#!/bin/sh
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+#
+# Install the `gaia` binary. Resolves this machine's platform, reads the
+# published manifest, downloads from the first mirror that answers, and
+# verifies the SHA-256 before installing. A mismatch is fatal — there is no
+# "install it anyway" path.
+#
+#   curl -fsSL https://amd-gaia.ai/install.sh | sh
+#
+# Env overrides (used by the tests):
+#   GAIA_MANIFEST_URL    where the manifest lives
+#   GAIA_INSTALL_HOME    install root (default: $HOME/.gaia)
+#   GAIA_FORCE_PLATFORM  skip uname detection
+
+set -eu
+
+MANIFEST_URL="${GAIA_MANIFEST_URL:-https://hub.amd-gaia.ai/bin/gaia/manifest.json}"
+INSTALL_HOME="${GAIA_INSTALL_HOME:-$HOME/.gaia}"
+BIN_DIR="$INSTALL_HOME/bin"
+
+die() { echo "error: $*" >&2; exit 1; }
+
+need() {
+    command -v "$1" >/dev/null 2>&1 || die "$1 is required but not installed."
+}
+
+detect_platform() {
+    if [ -n "${GAIA_FORCE_PLATFORM:-}" ]; then
+        echo "$GAIA_FORCE_PLATFORM"
+        return
+    fi
+    os=$(uname -s)
+    arch=$(uname -m)
+    case "$os" in
+        Linux)  goos=linux ;;
+        Darwin) goos=darwin ;;
+        *)      die "unsupported operating system: $os. GAIA publishes linux, darwin and windows builds; see https://github.com/amd/gaia/releases" ;;
+    esac
+    case "$arch" in
+        x86_64|amd64)  goarch=amd64 ;;
+        arm64|aarch64) goarch=arm64 ;;
+        *)             die "unsupported architecture: $arch. GAIA publishes amd64 and arm64 builds; see https://github.com/amd/gaia/releases" ;;
+    esac
+    echo "${goos}-${goarch}"
+}
+
+fetch() {
+    # fetch <url> <dest>; returns non-zero without printing on failure so the
+    # caller can try the next mirror.
+    if command -v curl >/dev/null 2>&1; then
+        curl -fsSL "$1" -o "$2" 2>/dev/null
+    else
+        wget -q -O "$2" "$1" 2>/dev/null
+    fi
+}
+
+sha256_of() {
+    if command -v sha256sum >/dev/null 2>&1; then
+        sha256sum "$1" | cut -d' ' -f1
+    elif command -v shasum >/dev/null 2>&1; then
+        shasum -a 256 "$1" | cut -d' ' -f1
+    else
+        die "neither sha256sum nor shasum is available, so the download cannot be verified. Install one and retry."
+    fi
+}
+
+json_field() {
+    # json_field <file> <platform> <field> — no jq dependency.
+    sed -n "s/.*\"$2\"[[:space:]]*:[[:space:]]*{\([^}]*\)}.*/\1/p" "$1" |
+        sed -n "s/.*\"$3\"[[:space:]]*:[[:space:]]*\"\{0,1\}\([^\",]*\)\"\{0,1\}.*/\1/p" |
+        head -1
+}
+
+json_urls() {
+    sed -n "s/.*\"$2\"[[:space:]]*:[[:space:]]*{\([^}]*\)}.*/\1/p" "$1" |
+        tr ',' '\n' | sed -n 's/.*"\(https\{0,1\}:[^"]*\|file:[^"]*\)".*/\1/p'
+}
+
+command -v uname >/dev/null 2>&1 || die "uname is required."
+need sed
+
+PLATFORM=$(detect_platform)
+TMP=$(mktemp -d)
+trap 'rm -rf "$TMP"' EXIT INT TERM
+
+echo "Resolving the GAIA manifest..."
+fetch "$MANIFEST_URL" "$TMP/manifest.json" ||
+    die "could not read the release manifest at $MANIFEST_URL. Check your connection, or download a binary directly from https://github.com/amd/gaia/releases"
+
+EXPECTED_SHA=$(json_field "$TMP/manifest.json" "$PLATFORM" sha256)
+EXPECTED_SIZE=$(json_field "$TMP/manifest.json" "$PLATFORM" size)
+[ -n "$EXPECTED_SHA" ] ||
+    die "no build published for platform $PLATFORM. Published platforms are listed at https://github.com/amd/gaia/releases"
+
+SIZE_MB=$(( ${EXPECTED_SIZE:-0} / 1024 / 1024 ))
+echo "Downloading gaia for $PLATFORM (${SIZE_MB} MB, ${EXPECTED_SIZE} bytes)"
+
+DOWNLOADED=0
+for url in $(json_urls "$TMP/manifest.json" "$PLATFORM"); do
+    echo "  trying $url"
+    if fetch "$url" "$TMP/gaia"; then DOWNLOADED=1; break; fi
+    echo "  ...unavailable, trying the next mirror"
+done
+[ "$DOWNLOADED" -eq 1 ] ||
+    die "every mirror failed for $PLATFORM. Check your connection or a proxy, then retry; binaries are also at https://github.com/amd/gaia/releases"
+
+ACTUAL_SHA=$(sha256_of "$TMP/gaia")
+if [ "$ACTUAL_SHA" != "$EXPECTED_SHA" ]; then
+    die "checksum mismatch for $PLATFORM.
+  expected $EXPECTED_SHA
+  actual   $ACTUAL_SHA
+Refusing to install. This is a corrupted download or a tampered file. Retrying is safe; if it fails twice, report it at https://github.com/amd/gaia/issues"
+fi
+
+mkdir -p "$BIN_DIR"
+chmod +x "$TMP/gaia"
+mv "$TMP/gaia" "$BIN_DIR/gaia"
+
+echo "Installed gaia to $BIN_DIR/gaia"
+case ":$PATH:" in
+    *":$BIN_DIR:"*) echo "Run: gaia" ;;
+    *) echo "Add it to your PATH:  export PATH=\"$BIN_DIR:\$PATH\""
+       echo "Then run: gaia" ;;
+esac
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `cd /Users/kovtcharov/Work/gaia && python -m pytest tests/unit/test_get_gaia_script.py -v > /tmp/t.txt 2>&1; echo "exit=$?"; tail -30 /tmp/t.txt`
+Expected: PASS, 4 tests.
+
+- [ ] **Step 5: Shellcheck it**
+
+Run: `cd /Users/kovtcharov/Work/gaia && shellcheck -s sh installer/scripts/get-gaia.sh > /tmp/sc.txt 2>&1; echo "exit=$?"; cat /tmp/sc.txt`
+Expected: exit=0. If `shellcheck` is not installed, install it or note the skip explicitly — do not silently pass.
+
+- [ ] **Step 6: Write the PowerShell twin**
+
+Create `installer/scripts/get-gaia.ps1`:
+
+```powershell
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+#
+# Install the `gaia` binary on Windows. Same contract as get-gaia.sh: resolve
+# the platform, read the manifest, try each mirror, verify SHA-256 before
+# installing. A mismatch is fatal.
+#
+#   irm https://amd-gaia.ai/install.ps1 | iex
+
+$ErrorActionPreference = 'Stop'
+
+$ManifestUrl = if ($env:GAIA_MANIFEST_URL) { $env:GAIA_MANIFEST_URL }
+               else { 'https://hub.amd-gaia.ai/bin/gaia/manifest.json' }
+$InstallHome = if ($env:GAIA_INSTALL_HOME) { $env:GAIA_INSTALL_HOME }
+               else { Join-Path $env:USERPROFILE '.gaia' }
+$BinDir = Join-Path $InstallHome 'bin'
+
+function Get-Platform {
+    if ($env:GAIA_FORCE_PLATFORM) { return $env:GAIA_FORCE_PLATFORM }
+    switch ($env:PROCESSOR_ARCHITECTURE) {
+        'AMD64' { return 'windows-amd64' }
+        'ARM64' { return 'windows-arm64' }
+        default {
+            throw "unsupported architecture: $($env:PROCESSOR_ARCHITECTURE). " +
+                  "GAIA publishes amd64 and arm64 builds; see https://github.com/amd/gaia/releases"
+        }
+    }
+}
+
+$platform = Get-Platform
+
+Write-Host 'Resolving the GAIA manifest...'
+try {
+    $manifest = Invoke-RestMethod -Uri $ManifestUrl -UseBasicParsing
+} catch {
+    throw "could not read the release manifest at $ManifestUrl. Check your connection or " +
+          "proxy, or download a binary directly from https://github.com/amd/gaia/releases"
+}
+
+$entry = $manifest.platforms.$platform
+if (-not $entry) {
+    throw "no build published for platform $platform. Published platforms are listed at " +
+          "https://github.com/amd/gaia/releases"
+}
+
+$sizeMb = [math]::Round($entry.size / 1MB, 1)
+Write-Host "Downloading gaia for $platform ($sizeMb MB, $($entry.size) bytes)"
+
+$tmp = Join-Path ([System.IO.Path]::GetTempPath()) ([System.Guid]::NewGuid().ToString())
+New-Item -ItemType Directory -Path $tmp -Force | Out-Null
+$dest = Join-Path $tmp 'gaia.exe'
+
+try {
+    $downloaded = $false
+    foreach ($url in $entry.urls) {
+        Write-Host "  trying $url"
+        try {
+            Invoke-WebRequest -Uri $url -OutFile $dest -UseBasicParsing
+            $downloaded = $true
+            break
+        } catch {
+            Write-Host '  ...unavailable, trying the next mirror'
+        }
+    }
+    if (-not $downloaded) {
+        throw "every mirror failed for $platform. Check your connection or a proxy, then " +
+              "retry; binaries are also at https://github.com/amd/gaia/releases"
+    }
+
+    $actual = (Get-FileHash -Path $dest -Algorithm SHA256).Hash.ToLower()
+    if ($actual -ne $entry.sha256.ToLower()) {
+        throw @"
+checksum mismatch for $platform.
+  expected $($entry.sha256)
+  actual   $actual
+Refusing to install. This is a corrupted download or a tampered file. Retrying is safe;
+if it fails twice, report it at https://github.com/amd/gaia/issues
+"@
+    }
+
+    New-Item -ItemType Directory -Path $BinDir -Force | Out-Null
+    Move-Item -Path $dest -Destination (Join-Path $BinDir 'gaia.exe') -Force
+} finally {
+    Remove-Item -Path $tmp -Recurse -Force -ErrorAction SilentlyContinue
+}
+
+Write-Host "Installed gaia to $BinDir\gaia.exe"
+if ($env:Path -notlike "*$BinDir*") {
+    Write-Host "Add it to your PATH:  `$env:Path = `"$BinDir;`$env:Path`""
+}
+Write-Host 'Then run: gaia'
+```
+
+- [ ] **Step 6b: Verify the PowerShell parses**
+
+On Windows, or with `pwsh` available:
+
+```bash
+pwsh -NoProfile -Command "\$null = [System.Management.Automation.Language.Parser]::ParseFile('installer/scripts/get-gaia.ps1', [ref]\$null, [ref]\$errs); if (\$errs) { \$errs; exit 1 }" > /tmp/ps.txt 2>&1; echo "exit=$?"; cat /tmp/ps.txt
+```
+Expected: exit=0. If `pwsh` is unavailable on this machine, say so explicitly and mark this step as verified-in-CI rather than silently skipping it.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add installer/scripts/get-gaia.sh installer/scripts/get-gaia.ps1 tests/unit/test_get_gaia_script.py
+git commit -m "feat(installer): add a hash-verifying one-line installer for the gaia binary"
+```
+
+---
+
+## Task 6: Serve the installers at the advertised URLs
+
+`website/src/pages/index.astro:76` and `docs/quickstart.mdx:111,133` have advertised `https://amd-gaia.ai/install.sh` and `install.ps1` for months. Nothing publishes them. They 404.
+
+**Files:**
+- Modify: `.github/workflows/deploy_website.yml`
+- Test: `tests/unit/test_get_gaia_script.py` (add one test)
+
+**Interfaces:**
+- Produces: `https://amd-gaia.ai/install.sh` and `/install.ps1` serving Task 5's scripts.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/unit/test_get_gaia_script.py`:
+
+```python
+import re
+
+REPO = Path(__file__).resolve().parents[2]
+
+
+def test_deploy_workflow_copies_the_installers_into_public():
+    wf = (REPO / ".github" / "workflows" / "deploy_website.yml").read_text()
+    assert "get-gaia.sh" in wf, (
+        "deploy_website.yml does not copy installer/scripts/get-gaia.sh into "
+        "website/public/install.sh, so https://amd-gaia.ai/install.sh 404s"
+    )
+    assert "get-gaia.ps1" in wf
+
+
+def test_advertised_install_urls_match_what_is_published():
+    """Every advertised install URL must be one the deploy step actually creates."""
+    published = {"install.sh", "install.ps1"}
+    advertised = set()
+    for rel in ("website/src/pages/index.astro", "docs/quickstart.mdx"):
+        text = (REPO / rel).read_text()
+        advertised |= set(re.findall(r"amd-gaia\.ai/(install\.[a-z0-9]+)", text))
+    assert advertised, "no install URLs found — did the docs change shape?"
+    assert advertised <= published, f"advertised but never published: {advertised - published}"
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cd /Users/kovtcharov/Work/gaia && python -m pytest tests/unit/test_get_gaia_script.py -k install -v > /tmp/t.txt 2>&1; echo "exit=$?"; tail -20 /tmp/t.txt`
+Expected: FAIL on the first test — `get-gaia.sh` is not in the deploy workflow.
+
+- [ ] **Step 3: Add the copy step**
+
+In `.github/workflows/deploy_website.yml`, immediately before the site build step:
+
+```yaml
+      - name: Publish the install scripts at the advertised URLs
+        run: |
+          set -e
+          mkdir -p website/public
+          cp installer/scripts/get-gaia.sh  website/public/install.sh
+          cp installer/scripts/get-gaia.ps1 website/public/install.ps1
+          ls -l website/public/install.* > /tmp/pub.txt 2>&1; echo "exit=$?"
+          cat /tmp/pub.txt
+```
+
+Copying at deploy time rather than committing duplicates keeps one source of truth — the scripts the tests exercise are the scripts users download.
+
+- [ ] **Step 3b: Resolve the collision with the existing venv installer**
+
+`installer/scripts/install.sh` is a *different* script — it installs `uv`, builds `~/.gaia/venv`, and pip-installs `amd-gaia`. It has never been published, but it shares the name this task is now claiming at the site root. Two things must happen so the two do not get confused for each other:
+
+1. **The user-facing URL serves the user-facing thing.** `/install.sh` is `get-gaia.sh`. This is the point of the task.
+2. **The venv installer is relabelled as developer setup, not deleted.** Update its header comment to say so, and update the "Next steps" text it prints — `install.sh:205` and `install.ps1:161` currently tell the user to run `gaia init`, which after Task 8 does not exist. It becomes `gaia-dev init`.
+
+Verify the new advice parses before committing:
+
+```bash
+cd /Users/kovtcharov/Work/gaia && gaia-dev init --help > /tmp/i.txt 2>&1; echo "exit=$?"; head -3 /tmp/i.txt
+```
+Expected: exit=0.
+
+Do **not** repoint `installer/scripts/install.sh` at the Go binary in this task. It is the developer venv path and Phase 1 is not changing what developers get.
+
+- [ ] **Step 4: Run to verify both tests pass**
+
+Run: `cd /Users/kovtcharov/Work/gaia && python -m pytest tests/unit/test_get_gaia_script.py -v > /tmp/t.txt 2>&1; echo "exit=$?"; tail -20 /tmp/t.txt`
+Expected: PASS, 6 tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add .github/workflows/deploy_website.yml tests/unit/test_get_gaia_script.py
+git commit -m "fix(website): publish install.sh and install.ps1 at the URLs the docs advertise"
+```
+
+---
+
+## Task 7: The forwarding shim
+
+Spec §6.2. Without it, day one of the rename breaks `gaia init` — the first command in the quickstart — for every existing user, along with ~1,800 doc references and ~650 runtime remedy strings.
+
+**Files:**
+- Create: `tui/internal/cli/forward.go`, `tui/internal/cli/forward_test.go`
+- Modify: `tui/internal/cli/root.go` (Execute)
+
+**Interfaces:**
+- Consumes: nothing from earlier tasks.
+- Produces:
+  - `func forwardToDev(args []string, lookPath func(string) (string, error), exec func(string, []string) error) error`
+  - `var errNoDevCLI = errors.New(...)`
+  - `func replacementFor(command string) (string, bool)` — maps a retired command to its replacement sentence.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tui/internal/cli/forward_test.go`:
+
+```go
+package cli
+
+import (
+	"errors"
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+func TestForwardsUnknownCommandToDevCLI(t *testing.T) {
+	var gotBin string
+	var gotArgs []string
+
+	err := forwardToDev(
+		[]string{"eval", "agent", "--category", "rag_quality"},
+		func(name string) (string, error) { return "/usr/bin/" + name, nil },
+		func(bin string, args []string) error { gotBin, gotArgs = bin, args; return nil },
+	)
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if gotBin != "/usr/bin/gaia-dev" {
+		t.Fatalf("forwarded to %q, want /usr/bin/gaia-dev", gotBin)
+	}
+	if strings.Join(gotArgs, " ") != "eval agent --category rag_quality" {
+		t.Fatalf("forwarded args %q, arguments must pass through verbatim", gotArgs)
+	}
+}
+
+func TestWithoutDevCLIItExplainsTheReplacement(t *testing.T) {
+	err := forwardToDev(
+		[]string{"init"},
+		func(string) (string, error) { return "", exec.ErrNotFound },
+		func(string, []string) error { t.Fatal("must not exec when gaia-dev is absent"); return nil },
+	)
+
+	if err == nil {
+		t.Fatal("expected an error when gaia-dev is absent")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "gaia doctor") {
+		t.Fatalf("error %q must name what replaced `gaia init`", msg)
+	}
+}
+
+func TestUnknownAndUnmappedCommandStillFailsLoudly(t *testing.T) {
+	err := forwardToDev(
+		[]string{"nonsense-command"},
+		func(string) (string, error) { return "", exec.ErrNotFound },
+		func(string, []string) error { return nil },
+	)
+
+	if !errors.Is(err, errNoDevCLI) {
+		t.Fatalf("got %v, want errNoDevCLI", err)
+	}
+	if !strings.Contains(err.Error(), "nonsense-command") {
+		t.Fatalf("error %q must name the command the user typed", err.Error())
+	}
+}
+
+func TestReplacementsAreKnownForTheRetiredCommands(t *testing.T) {
+	for _, cmd := range []string{"init", "chat", "hub", "daemon"} {
+		if _, ok := replacementFor(cmd); !ok {
+			t.Errorf("no replacement sentence for retired command %q", cmd)
+		}
+	}
+}
+
+func TestEmptyArgsIsNotForwarded(t *testing.T) {
+	err := forwardToDev(nil, nil, func(string, []string) error {
+		t.Fatal("must not exec with no command")
+		return nil
+	})
+	if err == nil {
+		t.Fatal("expected an error for an empty command")
+	}
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cd tui && go test ./internal/cli/ -run "Forward|Replacement|EmptyArgs" -v > /tmp/t.txt 2>&1; echo "exit=$?"; cat /tmp/t.txt`
+Expected: FAIL — `undefined: forwardToDev`
+
+- [ ] **Step 3: Write the implementation**
+
+Create `tui/internal/cli/forward.go`:
+
+```go
+package cli
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"syscall"
+)
+
+// errNoDevCLI is returned when a command this binary does not implement is
+// typed on a machine that has no gaia-dev to forward it to.
+var errNoDevCLI = errors.New("gaia-dev is not installed")
+
+const devCLI = "gaia-dev"
+
+// replacements maps a command that used to live on the Python `gaia` to the
+// sentence telling a user what to do instead. Only user-facing commands appear
+// here; developer commands forward to gaia-dev and need no entry.
+var replacements = map[string]string{
+	"init":      "setup is built in now — press `c` in `gaia`, or run `gaia doctor`",
+	"chat":      "run an agent instead: `gaia run <agent-id>`, or press enter on it in `gaia`",
+	"hub":       "`gaia list`, `gaia install <id>` and `gaia uninstall <id>` replace it",
+	"daemon":    "`gaia status` shows the background service; `gaia daemon` controls it",
+	"install":   "`gaia install <agent-id>` installs an agent; setup is `gaia doctor`",
+	"uninstall": "`gaia uninstall <agent-id>` removes one agent",
+	"connectors": "accounts are connected from inside the agent that uses them — " +
+		"run the agent and follow its prompts",
+}
+
+// replacementFor returns the guidance sentence for a retired command.
+func replacementFor(command string) (string, bool) {
+	s, ok := replacements[command]
+	return s, ok
+}
+
+// execve replaces this process with bin. Separated so tests can substitute it.
+func execve(bin string, args []string) error {
+	return syscall.Exec(bin, append([]string{bin}, args...), os.Environ())
+}
+
+// forwardToDev handles a command this binary does not implement.
+//
+// On a developer machine it hands the arguments to gaia-dev verbatim. On a user
+// machine — where gaia-dev does not exist — it fails loudly, naming what
+// replaced the command when we know, and never guessing.
+func forwardToDev(
+	args []string,
+	lookPath func(string) (string, error),
+	execFn func(string, []string) error,
+) error {
+	if len(args) == 0 {
+		return fmt.Errorf("no command given")
+	}
+	command := args[0]
+
+	if lookPath != nil {
+		if bin, err := lookPath(devCLI); err == nil {
+			fmt.Fprintf(os.Stderr,
+				"note: `gaia %s` is a developer command; forwarding to %s. "+
+					"Run it as `%s %s` in future.\n",
+				command, devCLI, devCLI, command)
+			return execFn(bin, args)
+		}
+	}
+
+	if hint, ok := replacementFor(command); ok {
+		return fmt.Errorf("`gaia %s` is no longer a command — %s", command, hint)
+	}
+
+	return fmt.Errorf(
+		"%w, so `gaia %s` cannot run. It is a developer command: install the "+
+			"developer tools in a checkout (`uv pip install -e \".[dev]\"`) and run "+
+			"`%s %s`",
+		errNoDevCLI, command, devCLI, command)
+}
+
+// lookPathFunc is the indirection point for tests at the Execute boundary.
+var lookPathFunc = exec.LookPath
+```
+
+- [ ] **Step 4: Run to verify the tests pass**
+
+Run: `cd tui && go test ./internal/cli/ -run "Forward|Replacement|EmptyArgs" -v > /tmp/t.txt 2>&1; echo "exit=$?"; cat /tmp/t.txt`
+Expected: PASS, 5 tests.
+
+- [ ] **Step 5: Wire it into Execute**
+
+Replace `tui/internal/cli/root.go`'s `Execute` body (lines 47-53) with:
+
+```go
+func Execute() error {
+	args := os.Args[1:]
+	if len(args) > 0 && args[0] == "tui" {
+		args = args[1:]
+		rootCmd.SetArgs(args)
+	}
+
+	// A command we do not implement is not an error yet: on a developer machine
+	// it belongs to gaia-dev. Only the flagless, non-help case is forwarded, so
+	// `gaia --help` and bare `gaia` keep their own behaviour.
+	if len(args) > 0 && !strings.HasPrefix(args[0], "-") {
+		if _, _, err := rootCmd.Find(args); err != nil {
+			return forwardToDev(args, lookPathFunc, execve)
+		}
+	}
+
+	return rootCmd.Execute()
+}
+```
+
+Add `"strings"` to the import block at `root.go:3-10`.
+
+- [ ] **Step 6: Test the wiring end to end**
+
+```bash
+cd tui
+go build -o /tmp/gaia-test ./cmd/gaia > /tmp/b.txt 2>&1; echo "build-exit=$?"; cat /tmp/b.txt
+PATH=/usr/bin:/bin /tmp/gaia-test init > /tmp/i.txt 2>&1; echo "exit=$?"; cat /tmp/i.txt
+PATH=/usr/bin:/bin /tmp/gaia-test list > /tmp/l.txt 2>&1; echo "exit=$?"; head -3 /tmp/l.txt
+```
+Expected: `init` exits non-zero and mentions `gaia doctor`; `list` runs its own command and does not forward.
+
+- [ ] **Step 7: Run the whole package's tests and vet**
+
+Run: `cd tui && go test ./... -count=1 > /tmp/t.txt 2>&1; echo "exit=$?"; tail -20 /tmp/t.txt && go vet ./... > /tmp/v.txt 2>&1; echo "vet-exit=$?"; cat /tmp/v.txt`
+Expected: both exit 0.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add tui/internal/cli/forward.go tui/internal/cli/forward_test.go tui/internal/cli/root.go
+git commit -m "feat(tui): forward unknown commands to gaia-dev instead of dead-ending"
+```
+
+**Note for the implementer:** `syscall.Exec` does not exist on Windows. If `go vet` or the build fails on a Windows target, split `execve` into `forward_unix.go` and `forward_windows.go` with build tags, using `exec.Command` + `cmd.Run()` + `os.Exit(cmd.ProcessState.ExitCode())` on Windows. Do not paper over it with a runtime check.
+
+---
+
+## Task 8: Move the console scripts
+
+**Files:**
+- Modify: `setup.py:333-337`
+- Test: `tests/unit/test_console_scripts.py` (create)
+
+**Interfaces:**
+- Produces: `gaia-dev` and `gaia-mcp` console scripts; `gaia-cli` retained as a deprecated alias; **no** `gaia`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/unit/test_console_scripts.py`:
+
+```python
+import re
+from pathlib import Path
+
+SETUP = Path(__file__).resolve().parents[2] / "setup.py"
+
+
+def _console_scripts() -> dict[str, str]:
+    text = SETUP.read_text()
+    block = re.search(r'"console_scripts":\s*\[(.*?)\]', text, re.S)
+    assert block, "console_scripts block not found in setup.py"
+    scripts = {}
+    for line in block.group(1).splitlines():
+        m = re.search(r'"([\w-]+)\s*=\s*([\w.:]+)"', line)
+        if m:
+            scripts[m.group(1)] = m.group(2)
+    return scripts
+
+
+def test_pip_does_not_install_a_command_named_gaia():
+    """`gaia` belongs to the Go binary. Two programs with one name is the bug."""
+    assert "gaia" not in _console_scripts()
+
+
+def test_gaia_dev_is_the_developer_cli():
+    assert _console_scripts().get("gaia-dev") == "gaia.cli:main"
+
+
+def test_gaia_cli_alias_is_retained_for_migration():
+    assert _console_scripts().get("gaia-cli") == "gaia.cli:main"
+
+
+def test_gaia_mcp_is_unchanged():
+    assert _console_scripts().get("gaia-mcp") == "gaia.mcp.mcp_bridge:main"
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cd /Users/kovtcharov/Work/gaia && python -m pytest tests/unit/test_console_scripts.py -v > /tmp/t.txt 2>&1; echo "exit=$?"; tail -20 /tmp/t.txt`
+Expected: FAIL on the first two — `gaia` is present and `gaia-dev` is absent.
+
+- [ ] **Step 3: Edit setup.py**
+
+Replace `setup.py:333-338`:
+
+```python
+        "console_scripts": [
+            # `gaia` is the Go binary (tui/). This package must not install a
+            # second program under that name — see
+            # docs/superpowers/specs/2026-07-25-tui-packaging-design.md
+            "gaia-dev = gaia.cli:main",
+            "gaia-cli = gaia.cli:main",  # deprecated alias, retained for migration
+            "gaia-mcp = gaia.mcp.mcp_bridge:main",
+        ]
+    },
+```
+
+- [ ] **Step 4: Run to verify they pass**
+
+Run: `cd /Users/kovtcharov/Work/gaia && python -m pytest tests/unit/test_console_scripts.py -v > /tmp/t.txt 2>&1; echo "exit=$?"; tail -20 /tmp/t.txt`
+Expected: PASS, 4 tests.
+
+- [ ] **Step 5: Verify a real install produces the right commands**
+
+```bash
+cd /Users/kovtcharov/Work/gaia
+python -m pip install -e . --no-deps -q > /tmp/pi.txt 2>&1; echo "exit=$?"; tail -5 /tmp/pi.txt
+command -v gaia-dev > /tmp/w.txt 2>&1; echo "gaia-dev-exit=$?"; cat /tmp/w.txt
+```
+Expected: `gaia-dev-exit=0`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add setup.py tests/unit/test_console_scripts.py
+git commit -m "feat(cli): rename the Python entry point to gaia-dev and stop shipping gaia"
+```
+
+---
+
+## Task 9: Stop resolving the engine by PATH
+
+Spec §2.3. `tui/internal/daemon/client.go:246-254` runs `exec.LookPath("gaia")` and then `gaia daemon start`. After Task 8 that resolves to the Go binary itself. Its remedy text also advises `pip install -e .`, which is now wrong.
+
+**Files:**
+- Modify: `tui/internal/daemon/client.go:245-254`
+- Test: `tui/internal/daemon/client_test.go` (extend)
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: `gaiaDaemonStart` resolves `gaia-dev` explicitly and never `gaia`.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `tui/internal/daemon/client_test.go` (create if absent, `package daemon`):
+
+```go
+package daemon
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestDaemonLauncherNeverResolvesTheNameGaia(t *testing.T) {
+	src, err := os.ReadFile("client.go")
+	if err != nil {
+		t.Fatalf("cannot read client.go: %v", err)
+	}
+	if strings.Contains(string(src), `LookPath("gaia")`) {
+		t.Fatal(`client.go still calls LookPath("gaia"), which now resolves to the Go binary itself`)
+	}
+}
+
+func TestDaemonLauncherRemedyDoesNotAdvisePipInstallDashE(t *testing.T) {
+	src, _ := os.ReadFile("client.go")
+	if strings.Contains(string(src), "pip install -e .") {
+		t.Fatal("client.go advises `pip install -e .`, which is not how a user gets the daemon")
+	}
+}
+
+func TestGaiaDaemonStartResolvesGaiaDev(t *testing.T) {
+	dir := t.TempDir()
+	stub := filepath.Join(dir, "gaia-dev")
+	if err := os.WriteFile(stub, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", dir)
+
+	cmd, err := gaiaDaemonStart(t.Context())
+	if err != nil {
+		t.Fatalf("gaiaDaemonStart returned %v with gaia-dev on PATH", err)
+	}
+	if filepath.Base(cmd.Path) != "gaia-dev" {
+		t.Fatalf("launcher resolved %q, want gaia-dev", cmd.Path)
+	}
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cd tui && go test ./internal/daemon/ -run "Launcher|GaiaDaemonStart" -v > /tmp/t.txt 2>&1; echo "exit=$?"; cat /tmp/t.txt`
+Expected: FAIL on all three.
+
+- [ ] **Step 3: Fix the launcher**
+
+Replace `tui/internal/daemon/client.go:245-254`:
+
+```go
+// gaiaDaemonStart builds the default launcher command.
+//
+// Resolves `gaia-dev` explicitly, never `gaia` — `gaia` is this binary, and
+// asking the OS to find it produces a process that execs a subcommand it does
+// not have.
+func gaiaDaemonStart(ctx context.Context) (*exec.Cmd, error) {
+	bin, err := exec.LookPath("gaia-dev")
+	if err != nil {
+		return nil, &StartError{Reason: "the GAIA background service is not installed, " +
+			"so it cannot be started. Run `gaia doctor` to install it"}
+	}
+	return exec.CommandContext(ctx, bin, "daemon", "start"), nil
+}
+```
+
+- [ ] **Step 4: Run to verify they pass**
+
+Run: `cd tui && go test ./internal/daemon/ -v > /tmp/t.txt 2>&1; echo "exit=$?"; tail -20 /tmp/t.txt`
+Expected: PASS.
+
+- [ ] **Step 5: Verify the remedy actually parses**
+
+`gaia doctor` does not exist until Phase 3. Until it does, the remedy must name something that works today. Change the message to `Run \`gaia-dev daemon start\`` and add a `TODO`-free note in the spec's §9.6 list instead. Then re-run:
+
+```bash
+cd /Users/kovtcharov/Work/gaia && gaia-dev daemon --help > /tmp/d.txt 2>&1; echo "exit=$?"; head -5 /tmp/d.txt
+```
+Expected: exit=0. **If it does not parse, the remedy is wrong and must be changed before commit** — this is the exact failure class CLAUDE.md names.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add tui/internal/daemon/client.go tui/internal/daemon/client_test.go
+git commit -m "fix(tui): resolve gaia-dev for the daemon launcher, never gaia"
+```
+
+---
+
+## Task 10: Stop `findGaiaBin()` resolving the wrong program
+
+The highest-severity item in the rename audit, because it fails **silently**.
+
+**Files:**
+- Modify: `src/gaia/apps/webui/services/backend-installer.cjs`
+- Test: `tests/electron/` (follow the existing Jest layout there)
+
+**Interfaces:**
+- Produces: `findGaiaBin()` returns only a venv-resident `gaia-dev`, never a `gaia` found on `PATH`.
+
+- [ ] **Step 1: Read the current implementation**
+
+```bash
+cd /Users/kovtcharov/Work/gaia && grep -n "findGaiaBin" -A 30 src/gaia/apps/webui/services/backend-installer.cjs > /tmp/f.txt 2>&1; echo "exit=$?"; cat /tmp/f.txt
+```
+
+- [ ] **Step 2: Write the failing test**
+
+Create `tests/electron/backend-installer-find-gaia-bin.test.cjs` (the directory uses `.test.cjs`; match it). Match the module-loading style already used by the other files in `tests/electron/` — if they use `jest.mock` for `fs`, do the same rather than introducing a second pattern:
+
+```js
+const path = require('path');
+const os = require('os');
+const fs = require('fs');
+
+const { findGaiaBin } = require('../../src/gaia/apps/webui/services/backend-installer.cjs');
+
+describe('findGaiaBin', () => {
+  let tmpHome;
+
+  beforeEach(() => {
+    tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), 'gaia-test-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpHome, { recursive: true, force: true });
+    delete process.env.GAIA_HOME;
+    delete process.env.PATH_OVERRIDE_FOR_TEST;
+  });
+
+  it('resolves the venv gaia-dev by absolute path', () => {
+    const binDir = path.join(tmpHome, 'venv', process.platform === 'win32' ? 'Scripts' : 'bin');
+    fs.mkdirSync(binDir, { recursive: true });
+    const exe = path.join(binDir, process.platform === 'win32' ? 'gaia-dev.exe' : 'gaia-dev');
+    fs.writeFileSync(exe, '#!/bin/sh\nexit 0\n', { mode: 0o755 });
+    process.env.GAIA_HOME = tmpHome;
+
+    expect(findGaiaBin()).toBe(exe);
+  });
+
+  it('returns null rather than a `gaia` found on PATH', () => {
+    // A Go `gaia` on PATH must never satisfy this resolver: it is a different
+    // program and calling `gaia init` on it does not do what this caller wants.
+    const decoyDir = path.join(tmpHome, 'decoy');
+    fs.mkdirSync(decoyDir, { recursive: true });
+    const decoy = path.join(decoyDir, process.platform === 'win32' ? 'gaia.exe' : 'gaia');
+    fs.writeFileSync(decoy, '#!/bin/sh\nexit 0\n', { mode: 0o755 });
+    process.env.GAIA_HOME = tmpHome;
+    process.env.PATH = `${decoyDir}${path.delimiter}${process.env.PATH}`;
+
+    expect(findGaiaBin()).toBeNull();
+  });
+
+  it('returns null when nothing is installed, rather than guessing', () => {
+    process.env.GAIA_HOME = tmpHome;
+    expect(findGaiaBin()).toBeNull();
+  });
+});
+```
+
+If `findGaiaBin` is not currently exported from `backend-installer.cjs`, add it to that file's `module.exports` as part of Step 4 — the resolver is already a named unit and testing it directly is cheaper than driving the whole installer.
+
+- [ ] **Step 3: Run to verify it fails**
+
+Run: `cd /Users/kovtcharov/Work/gaia && npx jest tests/electron --testPathPattern backend-installer > /tmp/t.txt 2>&1; echo "exit=$?"; tail -20 /tmp/t.txt`
+
+- [ ] **Step 4: Fix the resolver**
+
+Change `findGaiaBin()` to look only at the absolute venv path and the `gaia-dev` name. Delete any `PATH` search for `gaia`. If nothing is found, return null and let the caller report it — do not fall back.
+
+- [ ] **Step 5: Run to verify it passes**
+
+Run: `cd /Users/kovtcharov/Work/gaia && npx jest tests/electron --testPathPattern backend-installer > /tmp/t.txt 2>&1; echo "exit=$?"; tail -20 /tmp/t.txt`
+
+- [ ] **Step 6: Update the `gaia init` call site**
+
+`backend-installer.cjs` invokes `["init", "--profile", "minimal", "--yes"]` on the resolved binary. With `gaia-dev` that still parses. Verify:
+
+```bash
+cd /Users/kovtcharov/Work/gaia && gaia-dev init --help > /tmp/i.txt 2>&1; echo "exit=$?"; head -5 /tmp/i.txt
+```
+Expected: exit=0.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/gaia/apps/webui/services/backend-installer.cjs tests/electron/
+git commit -m "fix(ui): resolve gaia-dev in the backend installer, never a PATH gaia"
+```
+
+---
+
+## Task 11: Un-invert the remedy guardrail
+
+`tests/unit/test_remedy_commands_are_runnable.py` currently passes *because* remedies are stale — it certifies the bug. CLAUDE.md's "a shipped remedy must actually parse" rule depends on this file being right.
+
+**Files:**
+- Modify: `tests/unit/test_remedy_commands_are_runnable.py`
+
+**Interfaces:**
+- Produces: a test that fails when any user-facing remedy string names a command the argparse surface rejects.
+
+- [ ] **Step 1: Read it and find the inversion**
+
+```bash
+cd /Users/kovtcharov/Work/gaia && cat tests/unit/test_remedy_commands_are_runnable.py > /tmp/g.txt 2>&1; echo "exit=$?"; cat /tmp/g.txt
+```
+
+Identify why a stale remedy does not fail it — typically an over-broad skip, a `pytest.xfail`, or an allowlist that swallowed the failing cases.
+
+- [ ] **Step 2: Write a test that proves the guardrail bites**
+
+Add a negative test to the same file — the pattern `pypi.yml` already uses for `verify_wheel_dist.py`:
+
+```python
+def test_the_guardrail_actually_bites():
+    """Plant a remedy naming a command that does not exist; the checker must reject it."""
+    from tests.unit.test_remedy_commands_are_runnable import remedy_parses  # adjust to the real symbol
+
+    assert remedy_parses("gaia-dev init --profile minimal") is True
+    assert remedy_parses("gaia-dev definitely-not-a-command") is False
+```
+
+Adjust the imported symbol to whatever the file actually exposes; if it exposes nothing importable, extract the check into a module-level function first, then test it.
+
+- [ ] **Step 3: Run to verify the negative case fails today**
+
+Run: `cd /Users/kovtcharov/Work/gaia && python -m pytest tests/unit/test_remedy_commands_are_runnable.py -v > /tmp/t.txt 2>&1; echo "exit=$?"; tail -30 /tmp/t.txt`
+
+- [ ] **Step 4: Fix the checker so it rejects unknown commands**
+
+Remove the inversion. The checker must parse each remedy string against the real argparse surface and fail on a non-zero parse.
+
+- [ ] **Step 5: Run and fix every remedy it now catches**
+
+Run: `cd /Users/kovtcharov/Work/gaia && python -m pytest tests/unit/test_remedy_commands_are_runnable.py -v > /tmp/t.txt 2>&1; echo "exit=$?"; tail -40 /tmp/t.txt`
+
+Expect a batch of failures naming stale remedies. Fix each by changing the string to a command that parses. **Do not add to an allowlist.** Known-wrong remedies to expect, from the freeze study: `src/gaia/hub/installer.py:401-441` and `src/gaia/installer/init_command.py:435-470`.
+
+- [ ] **Step 6: Run the full unit suite**
+
+Run: `cd /Users/kovtcharov/Work/gaia && python -m pytest tests/unit/ -q > /tmp/t.txt 2>&1; echo "exit=$?"; tail -20 /tmp/t.txt`
+Expected: exit=0.
+
+- [ ] **Step 7: Lint and commit**
+
+```bash
+cd /Users/kovtcharov/Work/gaia
+python util/lint.py --all > /tmp/l.txt 2>&1; echo "exit=$?"; tail -5 /tmp/l.txt
+git add tests/unit/test_remedy_commands_are_runnable.py src/gaia/
+git commit -m "fix(tests): make the remedy guardrail fail on stale commands instead of certifying them"
+```
+
+---
+
+## Task 12: Phase 1 acceptance
+
+**Files:** none modified. This is the gate.
+
+- [ ] **Step 1: Build and install from the real script against a local manifest**
+
+```bash
+cd /Users/kovtcharov/Work/gaia/tui
+go build -ldflags="-s -w" -o /tmp/store/gaia-$(go env GOOS)-$(go env GOARCH) ./cmd/gaia > /tmp/b.txt 2>&1; echo "exit=$?"
+cd /Users/kovtcharov/Work/gaia
+python util/gen_binary_manifest.py /tmp/store --version 0.0.0-local \
+  --hub-base "file:///tmp/store" --gh-base "file:///tmp/store" \
+  --out /tmp/store/manifest.json > /tmp/m.txt 2>&1; echo "exit=$?"; cat /tmp/m.txt
+GAIA_MANIFEST_URL="file:///tmp/store/manifest.json" GAIA_INSTALL_HOME=/tmp/gaia-home \
+  sh installer/scripts/get-gaia.sh > /tmp/inst.txt 2>&1; echo "exit=$?"; cat /tmp/inst.txt
+```
+
+Note the manifest's `urls[0]` will be `file:///tmp/store/0.0.0-local/gaia-...`, which does not exist. Either place the binary at that path first or pass `--hub-base "file:///tmp"` such that the constructed path resolves. Confirm the installed file runs:
+
+```bash
+/tmp/gaia-home/bin/gaia --version > /tmp/v.txt 2>&1; echo "exit=$?"; cat /tmp/v.txt
+```
+Expected: exit=0, prints a version.
+
+- [ ] **Step 2: Confirm the consent rule is observable**
+
+The installer must have printed a size before downloading. Check `/tmp/inst.txt` contains an MB figure. If it printed `0 MB`, the manifest size is wrong and Task 3 regressed.
+
+- [ ] **Step 3: Confirm tamper rejection**
+
+```bash
+python - <<'PY'
+import json, pathlib
+p = pathlib.Path("/tmp/store/manifest.json")
+m = json.loads(p.read_text())
+for e in m["platforms"].values():
+    e["sha256"] = "0" * 64
+p.write_text(json.dumps(m))
+PY
+GAIA_MANIFEST_URL="file:///tmp/store/manifest.json" GAIA_INSTALL_HOME=/tmp/gaia-home2 \
+  sh installer/scripts/get-gaia.sh > /tmp/tamper.txt 2>&1; echo "exit=$?"; cat /tmp/tamper.txt
+```
+Expected: **non-zero exit**, the word `checksum`, and no file at `/tmp/gaia-home2/bin/gaia`.
+
+- [ ] **Step 4: Confirm no command a user knows is dead**
+
+```bash
+PATH=/usr/bin:/bin /tmp/gaia-home/bin/gaia init  > /tmp/c1.txt 2>&1; echo "exit=$?"; cat /tmp/c1.txt
+PATH=/usr/bin:/bin /tmp/gaia-home/bin/gaia chat  > /tmp/c2.txt 2>&1; echo "exit=$?"; cat /tmp/c2.txt
+```
+Expected: both fail with a sentence naming the replacement — never "unknown command".
+
+- [ ] **Step 5: Full test suite + lint**
+
+```bash
+cd /Users/kovtcharov/Work/gaia
+python -m pytest tests/unit/ -q > /tmp/py.txt 2>&1; echo "pytest-exit=$?"; tail -10 /tmp/py.txt
+python util/lint.py --all      > /tmp/l.txt  2>&1; echo "lint-exit=$?";   tail -5  /tmp/l.txt
+cd tui && go test ./... -count=1 > /tmp/go.txt 2>&1; echo "go-exit=$?"; tail -10 /tmp/go.txt
+```
+Expected: all three exit 0.
+
+- [ ] **Step 6: Clean up scratch files**
+
+```bash
+rm -rf /tmp/store /tmp/gaia-home /tmp/gaia-home2 /tmp/gaia-test /tmp/release-assets
+```
+
+- [ ] **Step 7: Commit any final fixes**
+
+---
+
+## Not in this plan
+
+| Deferred | Where |
+|---|---|
+| Porting the management layer to Go | Phase 2 plan — gated on the launch contract being written down (spec §9.4 risk 2) |
+| Homebrew / winget / apt, desktop installers, the stage-0 readiness row, `gaia doctor` | Phase 3 plan |
+| Removing the agent-as-command surface, the doc sweep, `gaia tui` prefix deprecation | Phase 4 plan — gated on the capability-loss ledger (spec §9.3) |
+| Code-signing the binary | Blocked externally: `.signpath/policies/gaia.policy` is scoped to `nsis-installer` artifacts and would reject a bare executable (spec §3.5) |

--- a/docs/superpowers/plans/2026-07-25-gaia-binary-distribution-phase1.md
+++ b/docs/superpowers/plans/2026-07-25-gaia-binary-distribution-phase1.md
@@ -1438,7 +1438,7 @@ Expected: FAIL on the first two — `gaia` is present and `gaia-dev` is absent.
 
 Replace `setup.py:333-338`:
 
-```python
+```text
         "console_scripts": [
             # `gaia` is the Go binary (tui/). This package must not install a
             # second program under that name — see

--- a/docs/superpowers/specs/2026-07-25-tui-packaging-design.md
+++ b/docs/superpowers/specs/2026-07-25-tui-packaging-design.md
@@ -1,0 +1,667 @@
+# GAIA packaging and first run — one binary, one front door
+
+Status: Design / approved in principle, not started
+Extends: [`docs/plans/tui-user-journey.md`](../../plans/tui-user-journey.md) — that document
+covers stages 1–11 of the user journey and assumes `gaia` is already running. This document
+covers **stage 0**: how `gaia` gets onto a machine at all, and what the machine looks like
+afterwards. It does not replace it.
+Related: [`docs/plans/agent-factory.md`](../../plans/agent-factory.md) (the developer flow,
+specced separately), [`docs/plans/package-publishing.mdx`](../../plans/package-publishing.mdx)
+(the registry-driven publisher this uses), [`docs/plans/desktop-installer.mdx`](../../plans/desktop-installer.mdx)
+(the installers this supersedes in part).
+
+---
+
+## 0. The finding
+
+**GAIA has no front door.** It has seven of them, and none of them works on a blank machine
+without a second command the user has to already know. There are 36 top-level CLI commands,
+9 distinct executables, and two different programs both named `gaia`. The one-line install
+the website advertises — `curl -fsSL https://amd-gaia.ai/install.sh | sh` — returns 404,
+because the script exists at `installer/scripts/install.sh` and was never published to
+`website/public/`.
+
+The fix is not another installer. It is to make **one small program the only thing a user
+ever installs**, and to make everything else something that program fetches, verifies, and
+manages. That program exists already — the Go CLI/TUI in `tui/` — and it is built by CI six
+times per commit and thrown away.
+
+Two things make this tractable now that would not have been a year ago. **Agents are already
+compiled binaries**: `release_agent_email.yml` freezes each agent per-platform, publishes it
+to the hub, and verifies the hash — no interpreter required on the target. And **the hub is
+already a verified artifact store** readable by a dumb client: plain JSON over HTTPS at
+`{hub}/index.json` and `{hub}/agents/<id>/manifest.json` (`src/gaia/hub/catalog.py:41-86`),
+with per-platform `{url, sha256}` entries. Everything below is an application of those two
+facts.
+
+---
+
+## 1. What a user's machine looks like
+
+Three things, and nothing else:
+
+| Thing | Size | Arrives when |
+|---|---|---|
+| `gaia` — the one program | ~16–17 MB | you install it |
+| each agent | ~40–90 MB | when you install that agent |
+| Lemonade Server + a model | ~4 GB | only if an agent needs local inference, and only on an explicit keypress |
+
+**No Python. No virtual environment. No `pip`. No `gaia init` to remember.**
+
+This is a change from the status quo in kind, not degree. Today a user gets a 1.1 GB Python
+environment before they can do anything, `transformers` and `accelerate` are core
+dependencies (`setup.py:59-60`) and `accelerate` requires torch — so the ~372 MB of ML stack
+that GAIA never runs in-process is not optional today, it is mandatory. Inference is HTTP to
+Lemonade Server. Nothing on the user path imports torch. The email agent's freeze config
+records this explicitly:
+
+> "Real triage talks to the local Lemonade Server over HTTP and never runs torch in-process,
+> so we EXCLUDE the ML stack to keep the binary lean (~90 MB vs ~2 GB)."
+> — `hub/agents/email/python/packaging/freeze.py`
+
+### 1.1 There is no engine
+
+An earlier draft of this design shipped a compiled Python "engine" (~73 MB measured — see
+§9.1) carrying the daemon, the setup logic, the hub installer, and connectors. **That is
+rejected.** Nothing that layer does requires Python: it supervises processes, stores
+credentials, performs OAuth, downloads files, and calls HTTP APIs. It is Python because that
+is where it was written first.
+
+**The management layer moves into the Go binary.** The user's machine never receives a Python
+runtime for any reason.
+
+**A compiled component is not a runtime.** §2.1 permits `gaia` to invoke a *frozen* binary that
+happens to have been written in Python — that is what every agent already is. The rule being
+set here is narrower and firmer than "no Python": **nothing arrives on a user's machine that
+can execute arbitrary Python, and nothing arrives that needs an interpreter to run.** A frozen
+component is subject to the same fetch, hash-verify and sentinel treatment as an agent, and to
+the same consent rule.
+
+This is the largest single piece of work in this design and §7 sequences it so that nothing
+else waits on it.
+
+### 1.2 Installing `gaia` installs nothing else
+
+**Installing the program is not installing GAIA's agents.** No channel — `curl | sh`, brew,
+winget, apt, or a desktop installer — may pre-install an agent, a model, or Lemonade. A fresh
+install is ~16–17 MB and one program, full stop.
+
+(Release builds are stripped — `build_tui.yml` builds with `-s -w` and its size-check warns
+above 15 MB; a stripped darwin/arm64 build measured 16.5 MB. An unstripped local `make build`
+is larger and is not what ships.)
+
+Agents arrive only when the user asks for one, through the TUI or the CLI. This is the
+difference between a tool you can try and a tool you have to commit to, and it is the single
+most important property of the install for a first-time user.
+
+### 1.3 The consent rule: nothing large downloads without a yes
+
+**Every download beyond the program itself states its size and its source, and waits for an
+explicit keypress.** No exceptions, and no download begins as a side effect of another action.
+
+| Download | Consent given by |
+|---|---|
+| the `gaia` program | the install command the user ran |
+| an agent (~40–90 MB) | pressing install, after the size is shown |
+| Lemonade + a model (~4 GB) | pressing the fix key, after the size is shown |
+| a component update | pressing update, after the size is shown |
+
+Three consequences that are easy to get wrong and must be built in from the start:
+
+1. **A readiness check never downloads.** It reads state and reports. Repair is a separate
+   keypress. Note that `tui/internal/ui/preflight/provision.go` already pulls a model — correct
+   for a fix key, wrong for a check (§4.3).
+2. **Sizes come from the manifest, not from guesses.** The artifact manifest carries a real
+   byte count per platform, so the number on screen is the number that downloads. This is
+   currently broken: `binaries.lock.json` ships `"size": 0` for all four platforms (§9.6).
+   Publishing a real size is a prerequisite for the install screen, not a nicety.
+3. **A download in progress is interruptible and reports what it left behind.** "Nothing was
+   installed; nothing to clean up" is a sentence the user has to be able to trust
+   (`docs/plans/tui-user-journey.md` §3 Stage 2).
+
+The rule extends past first run. A user who has used GAIA for months and asks it to check the
+setup must never discover that asking the question started a 4 GB transfer.
+
+---
+
+## 2. What the Go binary owns
+
+Exactly the capabilities that touch compiled agents or the hub:
+
+1. Browse and search the agent catalog
+2. Install / uninstall an agent
+3. Run an agent — interactive session or one-shot query
+4. Supervise agents — start, stop, status, logs
+5. **Set up the machine** — what `gaia init` does today: install Lemonade, download a model,
+   verify the result — plus check and repair it on demand
+6. Update itself and its components
+
+**Explicitly not in it:** evaluations and scorecards, agent authoring and publishing, reports
+and performance plots, test harnesses, RAG and document tooling, the web UI, the API server.
+
+**And not the per-agent commands.** `gaia email`, `gaia jira`, `gaia docker`, `gaia sd`,
+`gaia blender`, `gaia summarize`, `gaia browse`, `gaia analyze` are agents wearing a CLI
+costume. Every one already exists as a hub agent under `hub/agents/<id>/`. They are not ported
+— they are removed from the user's view, because `gaia run <id>` covers them. This is where
+most of the 36-command surface goes, and it goes without anything being reimplemented.
+
+### 2.1 One capability, one owner, one implementation
+
+**Nothing is implemented twice.** A capability belongs to exactly one of the two CLIs, and
+after this work no capability appears in both. The split is by *audience*, not by language:
+user capabilities live in `gaia`, developer capabilities live in `gaia-dev`.
+
+Where a user capability already exists in Python, there are two dispositions and a test for
+choosing between them:
+
+| Disposition | When | Consequence |
+|---|---|---|
+| **Port to Go** | most of the Python is terminal UI the TUI replaces anyway | removed from `gaia-dev` |
+| **Invoke as a component** | it is genuine domain logic with little UI, and reimplementing would duplicate hard-won behaviour | shipped as a compiled component `gaia` drives — **not** a user command and **not** a `gaia-dev` command |
+
+The second disposition is the owner's "call it rather than reimplement it," made compatible
+with §1's no-Python-runtime rule: what `gaia` invokes is a **compiled binary fetched and
+verified like an agent**, not an interpreter. If something is worth calling rather than
+porting, it is worth freezing.
+
+Either way the capability ends up in one place. A user capability that stays reachable from
+`gaia-dev` has not been separated; it has been copied.
+
+**`gaia init` is a port, not a component.** It is a user flow and belongs in `gaia`. Of its
+2,251 lines (`src/gaia/installer/init_command.py`), the large majority is terminal printing,
+interactive prompts, and profile bookkeeping — all of which the readiness ladder replaces. The
+irreducible installer logic is an estimated 550–700 lines of Go, and roughly 230 lines of
+launcher resolution already exist in `tui/internal/ui/preflight/lemonade.go:222-361`. Shipping
+it as a component would cost a separate build, its own signing, and a version handshake, to
+avoid writing less code than the handshake would take.
+
+### 2.2 Connections stay with the agent
+
+Signing in to Google is owned by the **agent**, not by `gaia`. This is how it works today —
+`hub/agents/email/python/packaging/freeze.py:112-124` bundles `gaia.connectors` into the email
+binary, so the agent runs its own OAuth flow and stores its own token.
+
+Consequences, accepted deliberately:
+
+- The Go port needs **no** OAuth code, no keyring integration, and no credential migration for
+  existing users. This is the single largest reason the port is ~3,000 lines and not ~4,500.
+- There is **no unified Connections view**. At N agents that is N browser flows and N stored
+  credentials with no one place to see or revoke them.
+- It assumes every future agent bundles the connector stack. **An agent that does not is a
+  design problem to catch at publish time, not at run time.**
+
+If the product later wants one Connections panel spanning agents, budget ~1,500 additional
+lines plus a credential migration whose feasibility on Windows is unverified (§9.4).
+
+### 2.3 The resolution rule
+
+**The Go binary never resolves anything by `PATH`.** It resolves an absolute path from an
+explicit order, or it reports that the thing is missing. No `exec.LookPath`, no scanning for
+a nearby virtual environment, no "whichever one we find first."
+
+This is the general form of the bug at `tui/internal/daemon/client.go:247`, which starts the
+background service by asking the OS to find a program called `gaia` — after the rename, it
+finds itself. Fixing that one line is not the fix. Never asking the question is the fix, and
+it is the reason two programs came to share one name in the first place.
+
+---
+
+## 3. Distribution
+
+### 3.1 One artifact, four wrappers
+
+Four channels, chosen per platform and per user. They are **thin wrappers over one signed
+release artifact per platform**, not four builds:
+
+| Channel | Audience | What it does |
+|---|---|---|
+| `curl \| sh` / `irm \| iex` | anyone on a terminal | download, verify, install to `~/.gaia/bin/` |
+| Homebrew / winget / apt | package-manager users | same artifact via the manifest |
+| DMG / MSI / deb | double-click users | same artifact, bundled |
+| — | developers | `pip install amd-gaia` ships **no** `gaia`; see §5 |
+
+Every channel's entire job is to place `gaia` on `PATH`. Everything after that is identical,
+which is what keeps four channels from becoming four behaviours.
+
+### 3.2 The hub is the artifact store — but not the catalog
+
+`gaia` ships as a **component in the hub's artifact store**, using the same manifest shape as
+an agent: platform key → `{url, sha256}`, verified download, `.installed` sentinel carrying
+the hash. This is `src/gaia/daemon/sidecars/fetch.py`'s contract, and reusing it means the
+binary, the agents, and any future component share one integrity story.
+
+**It does not appear in `index.json`** — the browsable agent catalog the TUI renders. `gaia`
+is not an agent; listing it there would have the TUI offering to install itself.
+
+Because the hub is plain JSON over HTTPS, there is **no bootstrap circularity**: a 20-line
+shell script can read the manifest with `curl` and verify with `sha256sum`. The Go client is
+not required for the first hop.
+
+### 3.3 Two mirrors, one hash
+
+The hub is primary; GitHub Releases is a mirror. The manifest lists both URLs per platform
+under **one** `sha256`:
+
+```json
+"darwin-arm64": {
+  "sha256": "a1b2c3…",
+  "urls": [
+    "https://hub.amd-gaia.ai/bin/gaia/0.x/darwin-arm64",
+    "https://github.com/amd/gaia/releases/download/v0.x/gaia-darwin-arm64"
+  ]
+}
+```
+
+The client tries them in order and verifies against the same hash either way. **A hash
+mismatch is a hard error, and exhausting both mirrors is a hard error** — there is no "use it
+anyway" path. This is not a silent fallback: it is one artifact available from two locations,
+with identical verification.
+
+Rationale: without a mirror, a hub outage blocks installing GAIA itself, not merely installing
+an agent. `publish.yml` already creates GitHub Releases with `release-assets/*`, so the mirror
+is nearly free.
+
+### 3.4 Where the publish lives
+
+`package-publishing.mdx` already locks a registry-driven publisher — `hub/packages.yaml` +
+`release.yml` + `publish_packages.yml` — with a `binary` channel that POSTs to the Agent Hub
+Worker's `/publish`. **`gaia` becomes one registry block there, not another bespoke workflow.**
+That registry's `freeze:` config assumes PyInstaller and needs a Go build variant; that is the
+only new machinery.
+
+`build_tui.yml` already cross-compiles six targets and uploads them as 14-day CI artifacts
+(`.github/workflows/build_tui.yml:96-101`). Publishing is a change of destination, not a new
+build.
+
+### 3.5 Signing
+
+Unresolved and out of this document's control, but it must be stated rather than discovered:
+
+- **The Go binary is not signed today.** `.signpath/policies/gaia.policy` is scoped to
+  `build-installers.yml` with `artifact_types: [nsis-installer]`; a bare executable would be
+  **rejected server-side**. It needs its own policy or an extended one.
+- The certificate is SignPath's OSS tier, so SmartScreen reputation accrues only after a few
+  thousand downloads. Early Windows users see a warning regardless of what is built.
+- macOS notarization is specced in `email-agent-packaging.mdx` Phase 4 with cert ownership
+  listed as an open decision. That decision blocks this too.
+
+---
+
+## 4. First run and the readiness check
+
+### 4.1 First run is not a new screen
+
+The readiness gate in `tui/internal/ui/preflight/` already walks a user from a broken machine
+to a working one, one keypress per fix. **First-run setup is one more row at the top of that
+ladder**, not a separate flow:
+
+```
+  Getting Email ready                                    1 of 5 ready
+  ─────────────────────────────────────────────────────────────────────
+    [ok]  Background service     running
+  > [!]   Local AI               not running
+          GAIA needs a local model server. It runs on your machine;
+          no email text ever leaves it.
+          f  start it for me
+    [  ]  AI model               —  (checked once Local AI is up)
+    [  ]  Mailbox                —
+  ─────────────────────────────────────────────────────────────────────
+  f  fix this  ·  r  re-check  ·  d  details  ·  esc  back
+```
+
+Checks run in dependency order and stop at the first failure, because "model not downloaded"
+is meaningless advice when the server is down. That ordering already exists and
+`/v1/email/init` already emits hints in that order.
+
+### 4.2 On demand: one check, two depths
+
+The readiness check must be reachable at any time, not only on the launch path.
+
+- **Launch depth** — fast, scoped to the agent being started, stops at the first failure.
+- **Full depth** — every installed agent, free disk, model-file integrity, and component
+  version agreement between `gaia` and its pieces.
+
+**Same rows, same wording, same fix keys, same renderer — one code path with a depth
+parameter.** Two screens would drift and eventually disagree about whether the machine is
+healthy, which is worse than having only one.
+
+Three entry points, because there are three situations:
+
+| Entry | Situation |
+|---|---|
+| `c` on the hub screen | in the TUI. Free in the current keymap (`docs/plans/tui-user-journey.md` §4 binds `↑↓jk enter / i d s b r v q ?`) |
+| `gaia doctor` | over SSH, in a script, or pasting into a bug report |
+| `/doctor` in a session | mid-conversation; a slash command, so rule R4 holds |
+
+### 4.3 Diagnose and repair are separate, always
+
+**A check never changes the machine.** It reads state and reports. Every repair sits behind an
+explicit keypress, and every repair states what it will do and how large it is *before* it
+runs. A "validate my setup" run that silently begins a 4 GB model download is the exact
+surprise that costs a tool its user's trust.
+
+Note that `tui/internal/ui/preflight/provision.go` already crosses this line — it pulls a
+model. That is correct behaviour for a fix key and incorrect for a check; the depth parameter
+must not carry repair with it.
+
+### 4.4 On a machine with nothing
+
+The full check on a fresh machine has exactly one actionable row — install what is missing —
+and every row below reads `— (checked once the above is fixed)`. This is honest, and it is why
+first-run needs no separate design.
+
+---
+
+## 5. What happens to the Python CLI
+
+### 5.1 It becomes `gaia-dev`, and it is developer-only
+
+The Python CLI is renamed `gaia-dev` and ships only to people working from a checkout. The
+existing `gaia-cli` alias (`setup.py:335`) becomes a deprecated pointer at it.
+
+`gaia-cli` is rejected as the permanent name: it reads as "the command line for gaia," which
+is precisely the confusion being eliminated. `gaia-dev` says what it is.
+
+### 5.2 `pip install amd-gaia` becomes the agent-building kit
+
+Keep the name — it is established and depended upon — and change what it *is*. When the
+management layer moves to Go and the per-agent commands are removed, what remains in the wheel
+is a library and a dev tool:
+
+- the SDK an agent is written against — base `Agent`, tool mixins, LLM clients, RAG
+- `gaia-dev` — evaluate, test, author, publish
+
+Its second audience is unchanged: developers embedding a GAIA agent in their own Python
+application.
+
+**It ships no `gaia` console script at all.** Dropping `gaia = gaia.cli:main` from
+`setup.py:333` means at most one program named `gaia` can ever exist on a machine, which
+closes the collision class rather than managing it.
+
+### 5.3 The 36 commands, resolved
+
+Most of the surface is not legacy to be deleted. It is developer tooling that was never meant
+to be on a user's machine, and it stops shipping to users automatically once users receive a
+compiled program instead of a Python package:
+
+| Group | Disposition |
+|---|---|
+| Agent-as-command (`email`, `jira`, `docker`, `sd`, `blender`, `summarize`, `browse`, `analyze`) | **Removed.** Each already exists as a hub agent; `gaia run <id>` covers it |
+| Developer tooling (`eval`, `report`, `perf-vis`, `test`, `agent`, `youtube`, `stats`) | **Stays in `gaia-dev`.** Never shipped to users |
+| Management (`hub`, `daemon`, `install`, `uninstall`, `init`, `config`) | **Ported to Go** per §2, and **removed from `gaia-dev`** — §2.1 forbids both |
+| `connectors` | **Stays with the agent** per §2.2. Not in `gaia`, not a user command |
+| Infrastructure (`api`, `mcp`, `telegram`, `schedule`, `knowledge`, `memory`, `cache`, `diagnostics`) | **Case by case** — see §9.3; several are developer or integration surfaces, not user surfaces |
+
+Applying §2.1 to the middle row is the part that is easy to get wrong: porting `gaia init` to
+Go while leaving `gaia-dev init` in place is not a separation, it is a copy — and the two will
+disagree within a release.
+
+The precise per-command verdicts, with test-coverage and doc-reference counts, live in the
+triage report referenced in §9.3. **The capability-loss ledger in that report is a required
+read before executing plan 3** — several hub agents have close to zero behavioural test
+coverage (`docs/plans/port-audit-6-agents.md:34-36`), so "the hub agent covers it" is a claim
+to verify per agent, not to assume.
+
+---
+
+## 6. The rename
+
+`gaia` is the Go binary; the Python CLI is `gaia-dev`. This is settled, and it happens **in
+Phase 1**, not at the end.
+
+**Renaming is safe early; removing is not.** The forwarding shim (§6.2) means no capability is
+lost when the name moves — every old command still reaches its implementation, with a warning.
+What must wait for Phase 4 is *deletion* of the agent-as-command surface, because that is a
+genuine capability change and it strands users if it precedes an installable replacement.
+
+Two options were weighed and rejected. Shipping the Go binary as `gaia-tui` and leaving `gaia`
+on the Python CLI avoids all churn, but leaves the name a user naturally types pointing at 36
+developer commands — the exact confusion this design exists to remove, preserved by
+construction. Shipping as `gaia` on user channels only, with developer checkouts unchanged,
+defers the churn but creates a window in which `gaia` means different things on different
+machines. The full rename with a forwarding shim costs more up front and leaves no ambiguity
+behind.
+
+What follows is the blast radius.
+
+### 6.1 Two collisions that are dangerous, not merely untidy
+
+| Command | Python meaning | Go meaning | Risk |
+|---|---|---|---|
+| `gaia uninstall` | tiered purge of the **entire** GAIA install (`src/gaia/installer/uninstall_command.py`) | remove **one agent** (`tui/internal/cli/agents.go:263`) | same word, wildly different blast radius |
+| `gaia install --lemonade` | install Lemonade Server | install **an agent** (`tui/internal/cli/agents.go:141`) | different noun entirely |
+
+Muscle memory and roughly 1,800 existing doc references point the wrong way after the rename.
+Neither may be left to fail by accident.
+
+### 6.2 The forwarding shim is required, not optional
+
+`gaia <unknown-command>` must not dead-end. When `gaia` receives a command it does not
+implement:
+
+- **On a developer machine** (`gaia-dev` present): forward to it, verbatim, with a one-line
+  deprecation notice on stderr.
+- **On a user machine** (no `gaia-dev`): a loud, specific error naming what replaced it —
+  `gaia init` → "setup is now built in; press `c` or run `gaia doctor`".
+
+Without this, day one of the rename breaks `gaia init` — the first command in
+`docs/quickstart.mdx` — for every existing user. With it, ~1,800 documentation references and
+~650 runtime remedy strings degrade to a warning and can be swept over weeks instead of in one
+commit.
+
+### 6.3 Same commit as the rename
+
+Anything in the **silent-wrong-behaviour** class, by definition:
+
+1. `tui/internal/daemon/client.go:247` — `exec.LookPath("gaia")`, which after the rename
+   resolves to the Go binary itself. Its `pip install -e .` remedy text goes at the same time.
+2. `src/gaia/apps/webui/services/backend-installer.cjs` — `findGaiaBin()` resolves the venv's
+   `gaia`; a Go `gaia` earlier on `PATH` makes it resolve the wrong program **without
+   erroring**.
+3. `setup.py:333` — drop `gaia = gaia.cli:main`.
+4. The forwarding shim (§6.2).
+5. `tests/unit/test_remedy_commands_are_runnable.py` — this is a **guardrail inversion**, not
+   a routine test update. Left unchanged it keeps passing precisely while the remedies are
+   wrong, certifying the bug. CLAUDE.md's "a shipped remedy must actually parse" rule depends
+   on this file being correct.
+
+Everything else — the doc sweep, the website, the ~650 runtime remedy strings, the
+`gaia tui …` prefix deprecation — follows, because it fails loudly.
+
+### 6.4 Verify before writing the plan
+
+Two claims in the audit are structural reads of cobra, not executed. Both are 30-second checks
+and one is the most consequential row in the table:
+
+```bash
+cd tui && go run ./cmd/gaia hub install email > /tmp/o.txt 2>&1; echo "exit=$?"; cat /tmp/o.txt
+cd tui && go run ./cmd/gaia --version              > /tmp/v.txt 2>&1; echo "exit=$?"; cat /tmp/v.txt
+```
+
+`root.go` never sets `rootCmd.Version`, so cobra skips registering `--version` entirely. Also
+unaudited: `.github/workflows/` for `gaia` invocations.
+
+---
+
+## 7. Sequencing
+
+Four phases. Each is independently shippable and independently useful, and the order exists to
+guarantee **nothing is removed before its replacement is installable**.
+
+### Phase 1 — Publish the binary, and take the name
+
+Wire `gaia` into `hub/packages.yaml`, publish to the hub artifact store with the GitHub
+Releases mirror, and stand up the `curl | sh` script at the URL the website already advertises.
+
+**The rename lands here**, with the five same-commit items in §6.3 — most importantly the
+forwarding shim, without which day one breaks `gaia init` for every existing user. Nothing is
+removed in this phase; every old command still works, with a deprecation notice.
+
+Immediately useful to anyone who already has GAIA installed — they have the Python background
+service, so the binary works against it today. Unblocks everything else.
+
+**Done when:** a person who already runs GAIA can install `gaia` in one command and use it to
+browse, install and run agents — and every command they knew before still works or tells them
+exactly what replaced it.
+
+### Phase 2 — Move the management layer into Go
+
+The port: agent install/uninstall, daemon lifecycle, Lemonade provisioning, and agent
+supervision. **~2,600–3,350 lines of new Go, ~6,000–9,000 with tests** (§9.4). Sign-in is not in
+it — §2.2 leaves that with the agent, which is the largest single reason the number is this
+small. The scheduler, model-slot broker, connection forwarding and custody migrations are out
+of scope, and `relay.py` disappears entirely rather than porting.
+
+Internal order, cheapest and safest first:
+
+1. **Catalog + install/uninstall** — low risk, and leaves the product strictly better even if
+   work stops here
+2. **Daemon lifecycle** — instance/lock/pid protocol; `tui/internal/daemon/` already has the
+   client half
+3. **Lemonade provisioning** — independent of 1 and 2, parallelisable with a different owner
+4. **Agent supervision** — the hard one. Spawn, the secret file, the Windows DACL, health and
+   version gating, tree-kill, orphan reaping. **Do it last, and do it on real Windows
+   hardware.** Prerequisite: the launch contract is written down (§9.4 risk 2)
+
+**Done when:** a machine with `gaia` and no Python can install an agent, get Lemonade and a
+model, and run the agent.
+
+### Phase 3 — Open the user channels
+
+Homebrew, winget, apt, and the desktop installers, plus the readiness ladder's stage-0 row and
+the on-demand `doctor`.
+
+**Done when:** a blank machine reaches a working agent without a doc, without a second command,
+and without an unrecoverable wall.
+
+### Phase 4 — Retire
+
+The agent-as-command surface (`gaia email`, `gaia jira`, …) is removed, the deprecation
+notices come off, and the doc sweep finishes. **Last, deliberately.** The name moved in Phase 1
+because a shim made it lossless; *removing* capability is what strands users, and it must not
+precede an installable replacement on a blank machine.
+
+Gated on the capability-loss ledger in the triage report (§9.3): a hub agent with near-zero
+behavioural test coverage is not yet a replacement for the command it supersedes.
+
+---
+
+## 8. Explicitly out of scope
+
+| Not here | Where it belongs |
+|---|---|
+| The developer / agent-authoring flow | `docs/plans/agent-factory.md` |
+| **Who may publish to the hub, and what review they get** | Needs its own spec — see §9.2 |
+| Thin agents sharing a runtime | Rejected — agents are compiled binaries; see §9.5 |
+| Conversational OAuth | #2469 |
+| Journey stages 1–11 | `docs/plans/tui-user-journey.md` |
+
+---
+
+## 9. Evidence, risks and open questions
+
+### 9.1 The measured freeze (now historical, kept for the numbers)
+
+A frozen Python engine covering the daemon, `init`, the hub installer and connectors was built
+and measured at **73 MB** on darwin-arm64, with **zero fatal module-level ML imports** across
+all four surfaces — the ML stack genuinely is reachable only lazily. The design rejects the
+engine for architectural reasons, not feasibility ones. Three findings from that work survive
+the rejection and apply to **agent** freezes, which continue:
+
+1. **Freeze size is silently build-environment-dependent.** `src/gaia/rag/sdk.py:41` imports
+   faiss at module level, reachable via a lazy chain. The 73 MB used the `[api]` extra; from
+   `[ui]`, PyInstaller silently collects faiss, pymupdf, python-docx, python-pptx and
+   sentence-transformers — tens of MB, **no warning, no build failure**. The freeze environment
+   must be pinned and CI must assert a size ceiling.
+2. **Six platforms is not real.** `linux-arm64` and `win32-arm64` have zero precedent in this
+   repo. The honest posture is 3 required + 1 best-effort, which is the shape email already
+   ships.
+3. **A wrong remedy already exists.** `src/gaia/hub/installer.py:401-441` and
+   `src/gaia/installer/init_command.py:435-470` lose two of three pip frontends under freeze
+   and print an impossible fix (measured, exit 2). Exactly CLAUDE.md's "a command that exists
+   but means something else" class.
+
+### 9.2 The trust question this design does not answer
+
+`src/gaia/hub/catalog.py:354` has `_requires_trust(security_tier)`. The field exists; the
+policy behind it does not. At the stated target of hundreds of agents, **who may publish and
+what review they receive is a harder problem than any packaging in this document.** It needs
+its own spec before third-party agents land, and this design does not pretend to cover it.
+
+### 9.3 Research inputs
+
+Three read-only reports back this document and should be read before the corresponding plan:
+
+| Report | Feeds |
+|---|---|
+| CLI triage — per-command verdicts, test coverage, doc references, **capability-loss ledger** | Phase 4 (§5.3) |
+| Rename blast radius — prioritised site table, silent-vs-loud classification | Phase 4 (§6) |
+| Engine freeze feasibility — measured sizes, import graph, per-platform build cost, signing | §9.1, agent freezes |
+
+### 9.4 The size of the Go port — measured
+
+**~2,600–3,350 lines of new Go**, or ~3,000–4,500 including error taxonomy, wiring and the CLI
+surface. At this repo's Go test ratio (17,447 source vs 16,502 test across `tui/`), budget
+**~6,000–9,000 lines total.**
+
+One subsystem disappears rather than porting: **`src/gaia/daemon/relay.py` (450 lines) is not
+needed at all.** It exists so that client credentials never reach a sidecar (`relay.py:1-41`).
+When the Go binary *is* the supervisor it already holds the bearer token, so there is nothing
+to proxy. Likewise the scheduler, the model-slot broker, connection forwarding and the custody
+migrations serve features outside the user flow and are not in scope.
+
+Ordering within the port, cheapest and safest first: catalog and install, then daemon
+lifecycle, then Lemonade provisioning (independent, parallelisable), and **agent supervision
+last**, on real Windows hardware.
+
+**Top three risks:**
+
+1. **Windows, three risks stacked.** Replicating the Windows DACL has two silent-fail-open
+   details (`PROTECTED_DACL`, verify-after-write). Detached spawn plus `taskkill /T /F`
+   tree-kill has no POSIX analogue to lean on. And `src/gaia/daemon/sidecars/ledger.py:233-245`
+   documents that orphan reaping on Windows is **already an unsolved gap in Python** — the port
+   inherits an open problem, not a solved one. Nobody on this repo appears to develop on
+   Windows, so each of these fails in the field rather than in CI.
+2. **The sidecar launch contract is undocumented and already drifting.**
+   `src/gaia/daemon/sidecars/manager.py` is the only specification, and
+   `hub/agents/email/npm/SPEC.md:59-61` is a second implementation that has already diverged —
+   it uses the environment channel, not the 0600 file. Go would be the third. The failure mode
+   is not a crash: it is a Go supervisor quietly taking the deprecated bare-env leg, putting the
+   launch secret in `/proc/<pid>/environ` on every Linux box, with nothing failing anywhere.
+   **Write the contract down before porting it**, and make the version gate at
+   `src/gaia/daemon/sidecars/spec.py:99` enforceable from both sides.
+3. **The delegation assumption is load-bearing and proven for exactly one agent.** §2.2's
+   estimate holds only because the email binary bundles the connector stack. An agent that
+   ships without it re-opens ~1,500 lines and the Windows credential migration.
+
+**Unverified, and worth a 30-minute empirical check before it drives anything:** whether Go and
+Python keyring libraries are wire-compatible on Windows (`TargetName` / UTF-16 handling). It
+does not block the current design — §2.2 means Go touches no credentials — but it is the gate
+on ever taking Connections into the host.
+
+### 9.5 Rejected: thin agents on a shared runtime
+
+Considered and dropped. Fat frozen agents duplicate a runtime N times (~90 MB each), which at
+hundreds of agents is real cost, and the alternative was a shared interpreter in a portable
+engine. **It was rejected because it reintroduces Python onto the user's machine** — the exact
+thing this design removes — to solve a disk-space problem with better levers. The lever is
+trimming what each agent's freeze includes: the email binary carries faiss, numpy and a slice
+of GAIA core it does not need at runtime. That is a per-agent build-config fix, not an
+architecture change.
+
+Note that a `kind` discriminator on the artifact manifest is still worth carrying, because
+agents will not all be Python forever.
+
+### 9.6 Known-broken today, fix regardless of this design
+
+- `https://amd-gaia.ai/install.sh` and `install.ps1` are advertised in
+  `website/src/pages/index.astro:76` and `docs/quickstart.mdx:111,133`, and **404**. Nothing in
+  `deploy_website.yml` copies `installer/scripts/install.sh` into `website/public/`.
+- `gaia --version` does not work — `tui/internal/cli/root.go` never sets `rootCmd.Version`, so
+  cobra skips registering the flag (structural read; verify per §6.4).
+- `binaries.lock.json` ships `"size": 0` for all four platforms — never populated.
+
+---
+
+*This document is `.md` under `docs/superpowers/specs/` and is deliberately not registered in
+`docs/docs.json`, matching `tui-user-journey.md`.*

--- a/util/check_doc_code.py
+++ b/util/check_doc_code.py
@@ -281,6 +281,21 @@ def check_python_syntax(source: str, filename: str = "<doc>") -> Optional[str]:
     """Return None if *source* compiles, or an error message string."""
     if _is_pseudo_code(source):
         return None
+
+    # Try the block as written before applying any excerpt heuristics. Those
+    # heuristics wrap the source in `def _doc_wrapper():` whenever a `return`
+    # appears anywhere — including one correctly indented inside a function — so
+    # a COMPLETE, valid module gets wrapped and then fails on rules that only
+    # hold at module level (`from __future__` must come first). Parsing the real
+    # source first means a whole file is judged as a whole file.
+    dedented = textwrap.dedent(source)
+    if dedented.strip():
+        try:
+            compile(dedented, filename, "exec")
+            return None
+        except SyntaxError:
+            pass  # fall through to the excerpt-normalizing path below
+
     normalized = _normalize_python_source(source)
     if not normalized.strip():
         return None


### PR DESCRIPTION
Two design documents were written for the binary-distribution work and never pushed — ~2.5k lines of rationale sitting in a Claudia worktree that is about to be deleted. This preserves them next to the three existing `docs/superpowers/` documents.

Both are honestly marked as design, not shipped (`Status: Design / approved in principle, not started`).

**The one edit I made:** the plan's premise is partly implemented now, so it gains a note at the top recording what landed since 2026-07-25 — #2522 (release assets + a Linux-only `install_tui()`) and #2530 (the hub `type: component` publish). Without it, someone picking this up would redo work.

I re-verified the parts of the premise that still hold rather than assuming: no release carries a `gaia-<os>-<arch>` asset (latest is v0.22.0), the hub catalog holds only `email`, `gaia tui` exits 2, and `amd-gaia.ai/install.sh` returns 200 but installs the Python side only. So the plan is still worth executing — just not from a clean slate.

### Test plan

- [x] `npx mintlify validate` from `docs/` — `success build validation passed`
- [x] Docs are plans under `docs/superpowers/`, not navigation-linked pages — no `docs.json` change needed (matching the three existing files there)