### PR TITLE
fix(tui): name the binary the user actually invoked, and fix the setup hint

### DIFF
--- a/tui/internal/cli/root.go
+++ b/tui/internal/cli/root.go
@@ -3,6 +3,8 @@ package cli
 import (
 	"fmt"
 	"os"
+	"path/filepath"
+	"strings"
 
 	"github.com/spf13/cobra"
 
@@ -11,8 +13,30 @@ import (
 
 var debug bool
 
+const defaultBinaryName = "gaia-tui"
+
+// binaryName derives the command name from argv[0]. The installer ships this as
+// `gaia-tui` because the Python CLI owns `gaia`, so a hardcoded name would print
+// usage lines for a command the user does not have.
+func binaryName(argv0 string) string {
+	name := filepath.Base(strings.TrimSpace(argv0))
+	if ext := filepath.Ext(name); strings.EqualFold(ext, ".exe") {
+		name = strings.TrimSuffix(name, ext)
+	}
+	switch name {
+	case "", ".", "..", "/", `\`:
+		return defaultBinaryName
+	}
+	// Cobra takes the command name from the first word of Use, so a name with
+	// whitespace in it would be silently truncated.
+	if strings.ContainsAny(name, " \t") {
+		return defaultBinaryName
+	}
+	return name
+}
+
 var rootCmd = &cobra.Command{
-	Use:   "gaia",
+	Use:   defaultBinaryName,
 	Short: "GAIA Terminal Agent Hub",
 	Long:  "Terminal-native hub for browsing, launching, and chatting with GAIA agents.",
 	// A one-line refusal followed by 20 lines of command listing pushes the
@@ -39,12 +63,13 @@ func init() {
 // Execute runs the CLI.
 //
 // A leading `tui` word is accepted and dropped. This binary is addressed as
-// `gaia tui …` everywhere it is documented, but its own root command is `gaia`,
-// so without this `gaia tui install email` — the exact line the docs and the
-// install refusal tell people to run — would fail with "unknown command". Both
-// spellings work; only the first argument is considered, so an agent named
-// "tui" is unaffected.
+// `gaia tui …` everywhere it is documented, but its own root command is the
+// binary's own name, so without this `gaia tui install email` — the exact line
+// the docs and the install refusal tell people to run — would fail with
+// "unknown command". Both spellings work; only the first argument is
+// considered, so an agent named "tui" is unaffected.
 func Execute() error {
+	rootCmd.Use = binaryName(os.Args[0])
 	args := os.Args[1:]
 	if len(args) > 0 && args[0] == "tui" {
 		rootCmd.SetArgs(args[1:])

--- a/tui/internal/cli/root_test.go
+++ b/tui/internal/cli/root_test.go
@@ -1,0 +1,70 @@
+package cli
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// The installer ships this binary as `gaia-tui`, so a hardcoded `gaia` in the
+// usage lines told users to type a command they do not have. Every name below
+// is one the binary can genuinely be invoked under.
+func TestBinaryName(t *testing.T) {
+	tests := []struct {
+		name  string
+		argv0 string
+		want  string
+	}{
+		{"installed name", "gaia-tui", "gaia-tui"},
+		{"absolute path", "/usr/local/bin/gaia-tui", "gaia-tui"},
+		{"relative path", filepath.Join("build", "gaia-tui"), "gaia-tui"},
+		{"dot-slash", "./gaia-tui", "gaia-tui"},
+		{"renamed by the user", "/opt/bin/gaia-hub", "gaia-hub"},
+		{"go run temp binary", "/tmp/go-build123/b001/exe/gaia", "gaia"},
+		{"exe suffix", "gaia-tui.exe", "gaia-tui"},
+		{"exe suffix with path", "/opt/GAIA/gaia-tui.exe", "gaia-tui"},
+		{"exe suffix uppercase", "GAIA-TUI.EXE", "GAIA-TUI"},
+		{"empty argv", "", defaultBinaryName},
+		{"whitespace argv", "   ", defaultBinaryName},
+		{"bare dot", ".", defaultBinaryName},
+		{"parent dir", "..", defaultBinaryName},
+		{"root slash", "/", defaultBinaryName},
+		{"name with a space", "/opt/My Tools/gaia tui", defaultBinaryName},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := binaryName(tt.argv0); got != tt.want {
+				t.Errorf("binaryName(%q) = %q, want %q", tt.argv0, got, tt.want)
+			}
+		})
+	}
+}
+
+// A `.exe` suffix is stripped, but a name that merely ends in something else is
+// left alone — `gaia-tui.dev` is a legitimate binary name, not a Windows one.
+func TestBinaryNameOnlyStripsExe(t *testing.T) {
+	if got := binaryName("gaia-tui.dev"); got != "gaia-tui.dev" {
+		t.Errorf("binaryName stripped a non-.exe extension: got %q", got)
+	}
+}
+
+// The end-to-end proof that argv[0] reaches the help text lives in
+// tui/test/cli_name_test.go, which runs the real binary under several names.
+func TestUsageNamesTheInvokedBinary(t *testing.T) {
+	original := rootCmd.Use
+	t.Cleanup(func() { rootCmd.Use = original })
+
+	rootCmd.Use = binaryName("/usr/local/bin/gaia-tui")
+	usage := rootCmd.UsageString()
+	if !strings.Contains(usage, "gaia-tui [flags]") {
+		t.Errorf("root usage does not name the invoked binary:\n%s", usage)
+	}
+
+	listCmd, _, err := rootCmd.Find([]string{"list"})
+	if err != nil {
+		t.Fatalf("find list command: %v", err)
+	}
+	if path := listCmd.CommandPath(); !strings.HasPrefix(path, "gaia-tui ") {
+		t.Errorf("subcommand path = %q, want it to start with %q", path, "gaia-tui ")
+	}
+}

--- a/tui/internal/daemon/client.go
+++ b/tui/internal/daemon/client.go
@@ -248,7 +248,10 @@ func gaiaDaemonStart(ctx context.Context) (*exec.Cmd, error) {
 	bin, err := exec.LookPath("gaia")
 	if err != nil {
 		return nil, &StartError{Reason: "the `gaia` CLI is not on PATH, so the daemon cannot be launched. " +
-			"Install GAIA (`pip install -e .` in the repo, or the released wheel) and retry"}
+			"Install GAIA with `curl -fsSL https://amd-gaia.ai/install.sh | sh` " +
+			"(on Windows: `irm https://amd-gaia.ai/install.ps1 | iex`), or `pip install amd-gaia` " +
+			"into the Python environment on your PATH, then retry. " +
+			"From a clone of the repo, `pip install -e .` works too"}
 	}
 	return exec.CommandContext(ctx, bin, "daemon", "start"), nil
 }

--- a/tui/internal/daemon/daemon_test.go
+++ b/tui/internal/daemon/daemon_test.go
@@ -345,7 +345,7 @@ func TestEnsureAgentRejectsMinorBelowAgentsFloor(t *testing.T) {
 	if !asError(err, &ve) {
 		t.Fatalf("expected *VersionError, got %#v (%v)", err, err)
 	}
-	if !strings.Contains(err.Error(), "v1.1+") {
+	if !strings.Contains(err.Error(), "v1.1") {
 		t.Errorf("error must name the required floor: %v", err)
 	}
 	if f.sawPath("POST " + APIPrefix + "/agents/email/ensure") {
@@ -931,5 +931,70 @@ func TestGaiaDaemonStartMissingCLIRemediation(t *testing.T) {
 	installer := strings.Index(msg, "https://amd-gaia.ai/install.sh")
 	if repoPath >= 0 && repoPath < installer {
 		t.Errorf("the repo-only remediation leads the message:\n%s", msg)
+	}
+}
+
+// TestVersionErrorNamesBothVersions pins the two halves of a skew message.
+// Naming only what was found ("speaks host API v1") leaves the user unable to
+// tell whether their core is too old or too new.
+func TestVersionErrorNamesBothVersions(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		version string
+	}{
+		{"below the agents floor", "1.0"},
+		{"minor omitted entirely", "1"},
+		{"major skew", "2.0"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			inst := &Instance{APIVersion: tc.version}
+			err := inst.CheckAgentsFloor()
+			if err == nil {
+				t.Fatalf("v%s must not pass the agents floor", tc.version)
+			}
+			var ve *VersionError
+			if !asError(err, &ve) {
+				t.Fatalf("expected *VersionError, got %#v", err)
+			}
+
+			if ve.Have != tc.version {
+				t.Errorf("Have = %q, want %q", ve.Have, tc.version)
+			}
+			if ve.Want != RequiredAPIVersion() {
+				t.Errorf("Want = %q, want %q", ve.Want, RequiredAPIVersion())
+			}
+
+			msg := err.Error()
+			for _, want := range []string{"v" + tc.version, "v" + RequiredAPIVersion()} {
+				if !strings.Contains(msg, want) {
+					t.Errorf("message does not name %q:\n%s", want, msg)
+				}
+			}
+
+			// The version is a property of the installed core, so a restart
+			// relaunches the same one. Telling the user to restart loops forever.
+			if !strings.Contains(msg, "pip install --upgrade amd-gaia") {
+				t.Errorf("message does not name the upgrade that clears this:\n%s", msg)
+			}
+			if !strings.Contains(msg, "brings the same one back") {
+				t.Errorf("message does not say a restart cannot clear this:\n%s", msg)
+			}
+		})
+	}
+}
+
+// RequiredAPIVersion is what the message promises the user; if it drifts from
+// the constants the floor check uses, the message sends them to a wrong version.
+func TestRequiredAPIVersionMatchesTheFloorItChecks(t *testing.T) {
+	major, minor, err := parseAPIVersion(RequiredAPIVersion())
+	if err != nil {
+		t.Fatalf("RequiredAPIVersion() is unparseable: %v", err)
+	}
+	if major != RequiredAPIMajor || minor != RequiredAgentsMinor {
+		t.Errorf("RequiredAPIVersion() = %q, but the floor is %d.%d",
+			RequiredAPIVersion(), RequiredAPIMajor, RequiredAgentsMinor)
+	}
+	if err := (&Instance{APIVersion: RequiredAPIVersion()}).CheckAgentsFloor(); err != nil {
+		t.Errorf("the version the message tells users to install must pass: %v", err)
 	}
 }

--- a/tui/internal/daemon/daemon_test.go
+++ b/tui/internal/daemon/daemon_test.go
@@ -902,3 +902,34 @@ func TestDoFailsWhenTheRefreshedTokenIsAlsoRejected(t *testing.T) {
 		t.Errorf("error should explain the auth failure: %v", err)
 	}
 }
+
+// TestGaiaDaemonStartMissingCLIRemediation guards the first error a newcomer
+// hits. Someone who downloaded only this binary has no clone, so a remediation
+// that leads with `pip install -e .` points at a workflow they cannot perform.
+func TestGaiaDaemonStartMissingCLIRemediation(t *testing.T) {
+	t.Setenv("PATH", t.TempDir())
+
+	_, err := gaiaDaemonStart(context.Background())
+	if err == nil {
+		t.Fatal("expected an error with `gaia` absent from PATH")
+	}
+	msg := err.Error()
+
+	for _, want := range []string{
+		"https://amd-gaia.ai/install.sh",
+		"https://amd-gaia.ai/install.ps1",
+		"pip install amd-gaia",
+	} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("remediation is missing %q:\n%s", want, msg)
+		}
+	}
+
+	// The contributor path may stay as a trailing note, but it must not be the
+	// headline a newcomer reads first.
+	repoPath := strings.Index(msg, "pip install -e .")
+	installer := strings.Index(msg, "https://amd-gaia.ai/install.sh")
+	if repoPath >= 0 && repoPath < installer {
+		t.Errorf("the repo-only remediation leads the message:\n%s", msg)
+	}
+}

--- a/tui/internal/daemon/errors.go
+++ b/tui/internal/daemon/errors.go
@@ -118,8 +118,8 @@ func (e *RouteMissingError) Error() string {
 	// background service, not the Agent Hub" is the part that must survive.
 	return fmt.Sprintf(
 		"the GAIA background service is older than this GAIA: it has no %s route, so it "+
-			"cannot %s. Run `gaia daemon restart`, then retry.%s The daemon log is at %s.",
-		e.Path, e.Op, alternative, logPathForMessage())
+			"cannot %s. %s%s The daemon log is at %s.",
+		e.Path, e.Op, UpgradeCoreHint, alternative, logPathForMessage())
 }
 
 // IsRouteMissing reports whether a daemon answer describes a route the daemon

--- a/tui/internal/daemon/errors.go
+++ b/tui/internal/daemon/errors.go
@@ -54,19 +54,28 @@ func (e *StaleError) Error() string {
 }
 
 // VersionError means the running daemon speaks a contract this client cannot
-// use — a MAJOR skew, or a MINOR below the agents/relay floor. The remedy is
-// always a daemon restart: an app update replaced the client while the old
-// daemon kept running.
+// use — a MAJOR skew, or a MINOR below the agents/relay floor.
+//
+// The version is a property of the installed GAIA core, not of the running
+// process, so a restart relaunches the same one. Aligning the two means
+// upgrading the core.
 type VersionError struct {
 	Have   string
+	Want   string
 	Reason string
 }
 
 func (e *VersionError) Error() string {
 	return fmt.Sprintf(
-		"the running GAIA daemon speaks host API v%s: %s. "+
-			"Run `gaia daemon restart`, then retry.", e.Have, e.Reason)
+		"the running GAIA daemon speaks host API v%s, but this app needs v%s or newer: %s. %s",
+		e.Have, e.Want, e.Reason, UpgradeCoreHint)
 }
+
+// UpgradeCoreHint is the remedy for any host-API skew. It says a restart is not
+// the fix, so a user who tries one does not loop on it.
+const UpgradeCoreHint = "Upgrade the installed GAIA core so it matches this app: " +
+	"`pip install --upgrade amd-gaia`, or re-run the installer from https://amd-gaia.ai. " +
+	"The version comes from the installed core, so `gaia daemon restart` brings the same one back."
 
 // StartError means we could not bring a daemon up (lock contention, launch
 // failure, or it never registered in time).

--- a/tui/internal/daemon/instance.go
+++ b/tui/internal/daemon/instance.go
@@ -37,6 +37,12 @@ const (
 	RequiredAgentsMinor = 1
 )
 
+// RequiredAPIVersion is the lowest host API this client can use, named in every
+// skew message so the user can tell whether their core is too old or too new.
+func RequiredAPIVersion() string {
+	return fmt.Sprintf("%d.%d", RequiredAPIMajor, RequiredAgentsMinor)
+}
+
 // Instance is the daemon's single-instance registry record (~/.gaia/host/instance.json,
 // mode 0600).
 type Instance struct {
@@ -145,11 +151,12 @@ func parseAPIVersion(v string) (major, minor int, err error) {
 func (i *Instance) CheckVersion() error {
 	major, _, err := parseAPIVersion(i.APIVersion)
 	if err != nil {
-		return &VersionError{Have: i.APIVersion, Reason: err.Error()}
+		return &VersionError{Have: i.APIVersion, Want: RequiredAPIVersion(), Reason: err.Error()}
 	}
 	if major != RequiredAPIMajor {
 		return &VersionError{
 			Have: i.APIVersion,
+			Want: RequiredAPIVersion(),
 			Reason: fmt.Sprintf("this client speaks MAJOR %d and cannot use MAJOR %d",
 				RequiredAPIMajor, major),
 		}
@@ -165,13 +172,13 @@ func (i *Instance) CheckAgentsFloor() error {
 	}
 	_, minor, err := parseAPIVersion(i.APIVersion)
 	if err != nil {
-		return &VersionError{Have: i.APIVersion, Reason: err.Error()}
+		return &VersionError{Have: i.APIVersion, Want: RequiredAPIVersion(), Reason: err.Error()}
 	}
 	if minor < RequiredAgentsMinor {
 		return &VersionError{
-			Have: i.APIVersion,
-			Reason: fmt.Sprintf("it predates the sidecar control plane + agent relay (needs v%d.%d+), "+
-				"so every agents route would 404", RequiredAPIMajor, RequiredAgentsMinor),
+			Have:   i.APIVersion,
+			Want:   RequiredAPIVersion(),
+			Reason: "it predates the sidecar control plane + agent relay, so every agents route would 404",
 		}
 	}
 	return nil

--- a/tui/internal/ui/preflight/check_test.go
+++ b/tui/internal/ui/preflight/check_test.go
@@ -319,6 +319,9 @@ func realCommands() []string {
 		"gaia connectors connect ",
 		"gaia connectors grants grant ",
 		"gaia connectors list",
+		// A host-API skew is fixed by upgrading the installed core, not by a
+		// restart — the version comes from the core, so a restart is a loop.
+		"pip install --upgrade amd-gaia",
 		// Reached only when the machine cannot name Lemonade's launcher
 		// (lemonadeRestartRemedy, !l.Found) — so it fires on a runner with no
 		// Lemonade installed and never on a developer box that has one.
@@ -489,12 +492,14 @@ func TestCheck(t *testing.T) {
 			name: "daemon speaks the wrong contract",
 			build: func() *fakeTransport {
 				f := newFake()
-				f.attachErr = &daemon.VersionError{Have: "1.0", Reason: "it predates the agent relay"}
+				f.attachErr = &daemon.VersionError{Have: "1.0", Want: "1.1", Reason: "it predates the agent relay"}
 				return f
 			},
 			wantStates:  map[string]State{KeyDaemon: StateFailed},
 			wantBlocker: KeyDaemon,
-			wantIn:      []string{"gaia daemon restart", "host API v1.0"},
+			// Both halves of the skew, and a remedy that can actually clear it:
+			// the version comes from the installed core, so a restart loops.
+			wantIn: []string{"host API v1.0", "v1.1", "pip install --upgrade amd-gaia"},
 			// Restarting a machine-wide daemon other clients share is not ours to do.
 			wantFix: FixNone,
 		},
@@ -874,7 +879,7 @@ func TestDaemonRowFixDependsOnWhyItFailed(t *testing.T) {
 		{"dead pid", &daemon.StaleError{Kind: daemon.StalePIDDead, Path: "/tmp/i.json", Reason: "its pid 1 is not running"}, FixStartDaemon},
 		{"port stolen", &daemon.StaleError{Kind: daemon.StaleForeign, Path: "/tmp/i.json", Reason: "served by something else"}, FixStartDaemon},
 		{"wedged", &daemon.StaleError{Kind: daemon.StaleUnresponsive, Path: "/tmp/i.json", Reason: "no answer"}, FixNone},
-		{"version skew", &daemon.VersionError{Have: "1.0", Reason: "too old"}, FixNone},
+		{"version skew", &daemon.VersionError{Have: "1.0", Want: "1.1", Reason: "too old"}, FixNone},
 		{"would not start", &daemon.StartError{Reason: "port bind failed"}, FixNone},
 	}
 	for _, tc := range cases {

--- a/tui/internal/ui/preflight/ladder.go
+++ b/tui/internal/ui/preflight/ladder.go
@@ -115,9 +115,13 @@ func (l Ladder) Error(op string, err error) Diagnosis {
 	if errors.As(err, &version) {
 		return Diagnosis{
 			Cause: fmt.Sprintf("The running background service speaks host API v%s, "+
-				"which this build cannot use.", version.Have),
-			Remedy:  "Restart it so it comes up on the version this app expects.",
-			Command: "gaia daemon restart",
+				"but this app needs v%s or newer — %s.",
+				version.Have, version.Want, version.Reason),
+			// The version comes from the installed core, so a restart relaunches
+			// the same one; saying so stops the user looping on it.
+			Remedy: "Upgrade the installed GAIA core so it matches this app, or re-run " +
+				"the installer from https://amd-gaia.ai. A restart brings the same version back.",
+			Command: "pip install --upgrade amd-gaia",
 			Where:   daemonLog(),
 		}
 	}

--- a/tui/internal/ui/preflight/ladder_test.go
+++ b/tui/internal/ui/preflight/ladder_test.go
@@ -64,11 +64,14 @@ func TestLadderPicksTheRightSubject(t *testing.T) {
 			wantIn:  "gave up relaying",
 		},
 		{
-			name: "a wrong-contract daemon is never fixed by starting another",
+			// Neither starting another daemon nor restarting this one changes the
+			// version: it comes from the installed core.
+			name: "a wrong-contract daemon is fixed by upgrading the core",
 			diagnose: func() Diagnosis {
-				return l.Error("attach", &daemon.VersionError{Have: "1.0", Reason: "predates the relay"})
+				return l.Error("attach", &daemon.VersionError{
+					Have: "1.0", Want: "1.1", Reason: "predates the relay"})
 			},
-			wantCmd: "gaia daemon restart",
+			wantCmd: "pip install --upgrade amd-gaia",
 			wantIn:  "v1.0",
 		},
 		{

--- a/tui/test/cli_name_test.go
+++ b/tui/test/cli_name_test.go
@@ -1,0 +1,86 @@
+package test
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// TestHelpNamesTheInvokedBinary runs the real binary under the name the
+// installer ships it as. A hardcoded root command printed `gaia` here, telling
+// users to type a command they do not have — the Python CLI owns `gaia`, and it
+// has none of these subcommands.
+//
+// This spawns the built binary on purpose: asserting on rootCmd.Use in-process
+// cannot catch the argv[0] wiring being dropped.
+func TestHelpNamesTheInvokedBinary(t *testing.T) {
+	gaiaBin, _ := buildBinaries(t)
+
+	suffix := ""
+	if runtime.GOOS == "windows" {
+		suffix = ".exe"
+	}
+
+	for _, name := range []string{"gaia-tui", "gaia", "gaia-hub"} {
+		t.Run(name, func(t *testing.T) {
+			installed := filepath.Join(t.TempDir(), name+suffix)
+			copyExecutable(t, gaiaBin, installed)
+
+			out, err := exec.Command(installed, "--help").CombinedOutput()
+			if err != nil {
+				t.Fatalf("%s --help: %v\n%s", name, err, out)
+			}
+			if want := name + " [flags]"; !strings.Contains(string(out), want) {
+				t.Errorf("help does not name the invoked binary (want %q):\n%s", want, out)
+			}
+
+			// Subcommand help is built from the same root name.
+			out, err = exec.Command(installed, "install", "--help").CombinedOutput()
+			if err != nil {
+				t.Fatalf("%s install --help: %v\n%s", name, err, out)
+			}
+			if want := name + " install"; !strings.Contains(string(out), want) {
+				t.Errorf("subcommand usage does not name the invoked binary (want %q):\n%s", want, out)
+			}
+		})
+	}
+}
+
+// TestLeadingTUIWordStillAccepted pins the documented `gaia tui …` spelling:
+// the first argument is dropped when it is `tui`, whatever the binary is named.
+func TestLeadingTUIWordStillAccepted(t *testing.T) {
+	gaiaBin, _ := buildBinaries(t)
+
+	suffix := ""
+	if runtime.GOOS == "windows" {
+		suffix = ".exe"
+	}
+	installed := filepath.Join(t.TempDir(), "gaia-tui"+suffix)
+	copyExecutable(t, gaiaBin, installed)
+
+	out, err := exec.Command(installed, "tui", "version").CombinedOutput()
+	if err != nil {
+		t.Fatalf("gaia-tui tui version: %v\n%s", err, out)
+	}
+	direct, err := exec.Command(installed, "version").CombinedOutput()
+	if err != nil {
+		t.Fatalf("gaia-tui version: %v\n%s", err, direct)
+	}
+	if string(out) != string(direct) {
+		t.Errorf("`tui version` and `version` diverged:\n got %q\nwant %q", out, direct)
+	}
+}
+
+func copyExecutable(t *testing.T, src, dst string) {
+	t.Helper()
+	data, err := os.ReadFile(src)
+	if err != nil {
+		t.Fatalf("read %s: %v", src, err)
+	}
+	if err := os.WriteFile(dst, data, 0o755); err != nil {
+		t.Fatalf("write %s: %v", dst, err)
+	}
+}

--- a/tui/test/cli_name_test.go
+++ b/tui/test/cli_name_test.go
@@ -58,19 +58,53 @@ func TestLeadingTUIWordStillAccepted(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		suffix = ".exe"
 	}
-	installed := filepath.Join(t.TempDir(), "gaia-tui"+suffix)
-	copyExecutable(t, gaiaBin, installed)
 
-	out, err := exec.Command(installed, "tui", "version").CombinedOutput()
-	if err != nil {
-		t.Fatalf("gaia-tui tui version: %v\n%s", err, out)
+	for _, name := range []string{"gaia-tui", "gaia"} {
+		t.Run(name, func(t *testing.T) {
+			installed := filepath.Join(t.TempDir(), name+suffix)
+			copyExecutable(t, gaiaBin, installed)
+
+			// `version` needs no daemon; `list` is the documented line and must
+			// reach the same subcommand rather than dying on "unknown command".
+			for _, sub := range []string{"version", "list"} {
+				viaTUI, _ := exec.Command(installed, "tui", sub).CombinedOutput()
+				direct, _ := exec.Command(installed, sub).CombinedOutput()
+				if string(viaTUI) != string(direct) {
+					t.Errorf("`%s tui %s` and `%s %s` diverged:\n got %q\nwant %q",
+						name, sub, name, sub, viaTUI, direct)
+				}
+				if strings.Contains(string(viaTUI), "unknown command") {
+					t.Errorf("`%s tui %s` was not recognised:\n%s", name, sub, viaTUI)
+				}
+			}
+		})
 	}
-	direct, err := exec.Command(installed, "version").CombinedOutput()
-	if err != nil {
-		t.Fatalf("gaia-tui version: %v\n%s", err, direct)
+}
+
+// TestSymlinkedBinaryNamesTheLink covers the packaging shape where a symlink on
+// PATH points at a differently-named real binary (Homebrew, /usr/local/bin).
+// argv[0] is the link the user invoked, which is the name to print — resolving
+// it to the target would print a name they do not have.
+func TestSymlinkedBinaryNamesTheLink(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink creation needs elevation on Windows")
 	}
-	if string(out) != string(direct) {
-		t.Errorf("`tui version` and `version` diverged:\n got %q\nwant %q", out, direct)
+	gaiaBin, _ := buildBinaries(t)
+
+	target := filepath.Join(t.TempDir(), "gaia-tui-v2")
+	copyExecutable(t, gaiaBin, target)
+
+	link := filepath.Join(t.TempDir(), "gaia-tui")
+	if err := os.Symlink(target, link); err != nil {
+		t.Fatalf("symlink: %v", err)
+	}
+
+	out, err := exec.Command(link, "--help").CombinedOutput()
+	if err != nil {
+		t.Fatalf("%s --help: %v\n%s", link, err, out)
+	}
+	if !strings.Contains(string(out), "gaia-tui [flags]") {
+		t.Errorf("help names the symlink target, not the link the user invoked:\n%s", out)
 	}
 }
 

--- a/tui/test/daemon_skew_test.go
+++ b/tui/test/daemon_skew_test.go
@@ -31,10 +31,14 @@ func TestAMissingDaemonRouteIsNotBlamedOnTheAgentHub(t *testing.T) {
 	if !strings.Contains(text, "older than this GAIA") {
 		t.Errorf("the error does not diagnose version skew:\n%s", text)
 	}
-	// The remedy, and it must be a command that exists (`gaia daemon restart`
-	// is a real subcommand — src/gaia/cli.py).
-	if !strings.Contains(text, "gaia daemon restart") {
+	// The remedy has to be able to fix the cause. The missing route comes from
+	// the installed core, so a restart relaunches the same one — a core this old
+	// may not even have a `daemon` subcommand to restart with.
+	if !strings.Contains(text, "pip install --upgrade amd-gaia") {
 		t.Errorf("the error gives no way to fix it:\n%s", text)
+	}
+	if !strings.Contains(text, "brings the same one back") {
+		t.Errorf("the error does not say a restart cannot fix this:\n%s", text)
 	}
 	// Where to look next.
 	if !strings.Contains(text, "daemon log") {


### PR DESCRIPTION
Four newcomer-facing text defects in the terminal hub, all found by running the binary rather than reading it. The hub ships as `gaia-tui` — the installer picks that name deliberately, because the Python CLI owns `gaia` on PATH — but its help output hardcoded `gaia`, so every usage line told users to type a command they do not have; copying `gaia list` either failed with command-not-found or reached the Python CLI, which has none of these subcommands. The first error a newcomer then hits, when the daemon cannot start, told them to `pip install -e .` "in the repo" — a workflow that assumes a clone nobody who downloaded this binary from the website has. And both version-skew messages prescribed `gaia daemon restart`, which cannot work: the API version and the available routes come from the *installed core*, so a restart relaunches the same one and the user loops — on a core old enough to trigger either message, `gaia daemon restart` is itself `invalid choice: 'daemon'`.

## Test plan

- [x] `go test ./...` in `tui/` — all packages pass; `go vet ./...` clean; `gofmt -l` clean on every file this branch touches
- [x] **Help names the invoked binary.** Same build, two names, cold `HOME`:

  ```
  BEFORE (either name)      AFTER as gaia-tui           AFTER as gaia
  Usage:                    Usage:                      Usage:
    gaia [flags]              gaia-tui-named [flags]      gaia-named [flags]
    gaia [command]            gaia-tui-named [command]    gaia-named [command]
  ```

- [x] Subcommand help follows the root name — `gaia-tui-named install --help` prints `Usage: gaia-tui-named install <agent-id> [flags]`
- [x] `gaia tui …` still works under **both** names, for `version` and the documented `list`, and is byte-identical to the un-prefixed form
- [x] **Symlink invocation names the link, not the target** — `gaia-tui -> gaia-tui-v2` prints `gaia-tui`. This is why the code reads `os.Args[0]` rather than `os.Executable()`; the guard is live on CI, which runs `go test ./...` on ubuntu, where `/proc/self/exe` resolves
- [x] Edge cases pinned by unit test: `.exe` stripping (case-insensitive), empty/whitespace argv[0], `.`, `..`, `/`, and a path containing spaces all fall back to `gaia-tui`
- [x] Coverage is not vacuous — deleting the argv[0] wiring line fails `TestHelpNamesTheInvokedBinary`, which runs the built binary instead of asserting on `rootCmd.Use` in-process
- [x] **Daemon-start error is usable by someone who only has this binary.** `HOME=$(mktemp -d) gaia-tui list`:

  Before: ``Install GAIA (`pip install -e .` in the repo, or the released wheel) and retry.``

  After: ``Install GAIA with `curl -fsSL https://amd-gaia.ai/install.sh | sh` (on Windows: `irm https://amd-gaia.ai/install.ps1 | iex`), or `pip install amd-gaia` into the Python environment on your PATH, then retry. From a clone of the repo, `pip install -e .` works too.``

- [x] Unchanged on that path: exit `1`, message on stderr, stdout empty (0 bytes), and the existing "inspect the daemon log at …" tail
- [x] Both installer URLs resolve (302 → `raw.githubusercontent.com/amd/gaia/main/installer/scripts/install.{sh,ps1}` → 200)
- [x] **Host-API skew names both versions and a remedy that works.** Rendered through the real ladder for a daemon advertising `api_version: "1"`:

  Before:
  ```
  ⚠️  The running background service speaks host API v1, which this build cannot use.
      — Restart it so it comes up on the version this app expects.
      — run: gaia daemon restart
  ```

  After:
  ```
  ⚠️  The running background service speaks host API v1, but this app needs v1.1 or newer
      — it predates the sidecar control plane + agent relay, so every agents route would 404.
      — Upgrade the installed GAIA core so it matches this app, or re-run the installer
        from https://amd-gaia.ai. A restart brings the same version back.
      — run: pip install --upgrade amd-gaia
  ```

- [x] **The missing-route skew carries the same remedy.** `RouteMissingError` diagnosed "older than this GAIA" and then said to restart; routes come from the installed core, so a restart cannot add one. Both skew paths now share one hint, and the diagnosis stays in the first clause the hub's one-row status bar truncates to
- [x] Verified on the two cores on this machine: `~/.gaia/venv/bin/gaia` (0.17.1) answers `invalid choice: 'daemon'`, so the old remedy named a command absent from exactly the state that produces the message
- [x] Unit tests assert both halves (found *and* required) for below-floor, minor-omitted, and major-skew versions, plus that each message says a restart will not clear it
- [x] A drift guard asserts `RequiredAPIVersion()` matches the constants the floor check uses **and** itself passes that check, so the message can never name a version that would still be rejected
- [x] `pip install --upgrade amd-gaia` is what the release notes and `installer/scripts/install.sh:106` already use, and satisfies the existing preflight invariant that every rendered remedy be a real single command

### Overlap with #2707

Both branches edit `tui/internal/ui/preflight/check_test.go` — #2707 adds `"gaia daemon stop-agent "` to `realCommands()`, this PR adds `"pip install --upgrade amd-gaia"` a few lines away. I trial-merged the two: git resolves it with **zero conflict markers**, both entries survive with no duplication, and the merged tree passes the full `go test ./...`. No action needed in either PR; whichever lands second needs no rebase. #2707 does not touch `instance.go`, `ladder.go`, or `ladder_test.go`, and neither branch goes near the `healthWedged` fixture.
