### PR TITLE
fix(website): stop offering Intel Macs a DMG they cannot run

### DIFF
--- a/website/src/components/DownloadButton.astro
+++ b/website/src/components/DownloadButton.astro
@@ -4,11 +4,12 @@
 
 // OS-detecting download CTA for the GAIA Agent UI (the Electron desktop app).
 // It names the Agent UI explicitly because it is no longer the only front
-// door — the terminal hub installs via TerminalHubCta.astro.
+// door — the terminal hub installs via the one-line installer.
 // Progressive enhancement: with no JS it links to the GitHub releases page
-// (always works). JS detects the OS to set the label, then best-effort fetches
-// the latest release to deep-link the right installer + show the version.
-// Falls back gracefully at every step.
+// (always works). JS resolves the platform we actually ship an installer for
+// (see scripts/download-target.ts — macOS is Apple Silicon only), then
+// best-effort fetches the latest release to deep-link that installer + show the
+// version. Anything unresolved keeps the releases page.
 
 interface Props {
   variant?: 'primary' | 'secondary';
@@ -36,46 +37,41 @@ const sizeCls = size === 'lg' ? 'px-6 py-3 text-[14px]' : 'px-3.5 py-1.5 text-[1
 </a>
 
 <script>
-  (() => {
+  import {
+    resolveDownloadTarget,
+    TARGET_ASSETS,
+    TARGET_LABELS,
+  } from '../scripts/download-target';
+
+  (async () => {
     const els = document.querySelectorAll<HTMLAnchorElement>('[data-download-cta]');
     if (!els.length) return;
 
-    const detectOS = (): 'windows' | 'macos' | 'linux' | null => {
-      const ua = navigator.userAgent;
-      if (/Windows/i.test(ua)) return 'windows';
-      if (/Mac/i.test(ua) && !/iPhone|iPad|iPod/i.test(ua)) return 'macos';
-      if (/Linux/i.test(ua) && !/Android/i.test(ua)) return 'linux';
-      return null;
-    };
-
-    const os = detectOS();
-    const osLabel = { windows: 'Windows', macos: 'macOS', linux: 'Linux' } as const;
-    els.forEach((el) => {
-      const label = el.querySelector('[data-dl-label]');
-      if (os && label) label.textContent = `Agent UI for ${osLabel[os]}`;
-    });
-
-    // Best-effort: latest version + the installer asset matching this OS.
-    fetch('https://api.github.com/repos/amd/gaia/releases/latest')
-      .then((r) => (r.ok ? r.json() : null))
-      .then((rel) => {
-        if (!rel) return;
-        const ver: string = rel.tag_name;
-        const assets: { name: string; browser_download_url: string }[] = rel.assets || [];
-        const pick = (re: RegExp) => assets.find((a) => re.test(a.name))?.browser_download_url;
-        const url =
-          os === 'windows' ? pick(/x64-setup\.exe$/)
-          : os === 'macos' ? pick(/arm64\.dmg$/)
-          : os === 'linux' ? pick(/\.AppImage$/)
-          : undefined;
+    try {
+      const target = await resolveDownloadTarget(navigator);
+      if (target) {
         els.forEach((el) => {
-          if (url) el.href = url;
-          const v = el.querySelector('[data-dl-version]');
-          if (v && ver) v.textContent = ver;
+          const label = el.querySelector('[data-dl-label]');
+          if (label) label.textContent = `Agent UI for ${TARGET_LABELS[target]}`;
         });
-      })
-      .catch(() => {
-        /* keep the releases-page fallback */
+      }
+
+      // Best-effort: latest version + the installer asset for that target.
+      const res = await fetch('https://api.github.com/repos/amd/gaia/releases/latest');
+      if (!res.ok) return;
+      const rel = await res.json();
+      const ver: string = rel.tag_name;
+      const assets: { name: string; browser_download_url: string }[] = rel.assets || [];
+      const url = target
+        ? assets.find((a) => TARGET_ASSETS[target].test(a.name))?.browser_download_url
+        : undefined;
+      els.forEach((el) => {
+        if (url) el.href = url;
+        const v = el.querySelector('[data-dl-version]');
+        if (v && ver) v.textContent = ver;
       });
+    } catch {
+      /* keep the releases-page fallback */
+    }
   })();
 </script>

--- a/website/src/components/DownloadButton.astro
+++ b/website/src/components/DownloadButton.astro
@@ -43,35 +43,37 @@ const sizeCls = size === 'lg' ? 'px-6 py-3 text-[14px]' : 'px-3.5 py-1.5 text-[1
     TARGET_LABELS,
   } from '../scripts/download-target';
 
-  (async () => {
+  (() => {
     const els = document.querySelectorAll<HTMLAnchorElement>('[data-download-cta]');
     if (!els.length) return;
 
-    try {
-      const target = await resolveDownloadTarget(navigator);
-      if (target) {
-        els.forEach((el) => {
-          const label = el.querySelector('[data-dl-label]');
-          if (label) label.textContent = `Agent UI for ${TARGET_LABELS[target]}`;
-        });
-      }
-
-      // Best-effort: latest version + the installer asset for that target.
-      const res = await fetch('https://api.github.com/repos/amd/gaia/releases/latest');
-      if (!res.ok) return;
-      const rel = await res.json();
-      const ver: string = rel.tag_name;
-      const assets: { name: string; browser_download_url: string }[] = rel.assets || [];
-      const url = target
-        ? assets.find((a) => TARGET_ASSETS[target].test(a.name))?.browser_download_url
-        : undefined;
+    const setText = (selector: string, text: string) =>
       els.forEach((el) => {
-        if (url) el.href = url;
-        const v = el.querySelector('[data-dl-version]');
-        if (v && ver) v.textContent = ver;
+        const node = el.querySelector(selector);
+        if (node) node.textContent = text;
       });
-    } catch {
-      /* keep the releases-page fallback */
-    }
+
+    // Kept independent: a stalled architecture probe must not withhold the
+    // version, and a failed release fetch must not withhold the label. Either
+    // one resolving to null just leaves the releases-page href in place.
+    const targetPromise = resolveDownloadTarget(navigator).catch(() => null);
+    const releasePromise = fetch('https://api.github.com/repos/amd/gaia/releases/latest')
+      .then((r) => (r.ok ? r.json() : null))
+      .catch(() => null);
+
+    targetPromise.then((target) => {
+      if (target) setText('[data-dl-label]', `Agent UI for ${TARGET_LABELS[target]}`);
+    });
+
+    releasePromise.then((rel) => {
+      if (rel?.tag_name) setText('[data-dl-version]', rel.tag_name);
+    });
+
+    Promise.all([targetPromise, releasePromise]).then(([target, rel]) => {
+      if (!target || !rel) return;
+      const assets: { name: string; browser_download_url: string }[] = rel.assets || [];
+      const url = assets.find((a) => TARGET_ASSETS[target].test(a.name))?.browser_download_url;
+      if (url) els.forEach((el) => (el.href = url));
+    });
   })();
 </script>

--- a/website/src/components/EntryPoints.astro
+++ b/website/src/components/EntryPoints.astro
@@ -3,11 +3,9 @@
 // SPDX-License-Identifier: MIT
 
 // The two ways to run GAIA, given peer billing: the Agent UI (Electron desktop
-// app) and the terminal hub (the Go binary in tui/). Both are becoming hub
-// components published to the catalog, so this deliberately carries no install
-// command and no release-asset deep link — the Agent UI CTA is the existing
-// OS-detecting DownloadButton, and the terminal hub points at the Hub, which is
-// where its catalog entry will render its own versions, platforms and sizes.
+// app) and the terminal hub (the Go binary in tui/). The Agent UI CTA is the
+// OS-detecting DownloadButton; the terminal hub carries the one-line installer
+// until its hub component entry is published.
 //
 // Naming is the product's own: "Agent UI" and "terminal hub" (cobra Short
 // "GAIA Terminal Agent Hub"). Never "Agent TUI" — it appears nowhere.

--- a/website/src/components/EntryPoints.astro
+++ b/website/src/components/EntryPoints.astro
@@ -12,10 +12,10 @@
 // Naming is the product's own: "Agent UI" and "terminal hub" (cobra Short
 // "GAIA Terminal Agent Hub"). Never "Agent TUI" — it appears nowhere.
 //
-// Until the terminal hub's catalog entry lands, the only true way to obtain it
-// is a source build, so BOTH the CTA and the note point at the CLI reference.
-// Pointing the CTA at /hub would strand the visitor on a list of agents that
-// contains no terminal hub. Repoint it at the component page once that ships.
+// The terminal-hub CTA points at the quickstart, which carries the one-line
+// installer per platform. It must not point at the CLI reference (a command
+// list for a binary the visitor does not have), at /hub (a list of agents that
+// contains no terminal hub), or at /hub/terminal-hub (unpublished, 404).
 
 import DownloadButton from './DownloadButton.astro';
 
@@ -26,7 +26,9 @@ interface Props {
 
 const { class: className = '', align = 'left' } = Astro.props;
 
-const TUI_DOCS = 'https://amd-gaia.ai/docs/reference/cli#terminal-hub-gaia-tui';
+const QUICKSTART = 'https://amd-gaia.ai/docs/quickstart';
+const INSTALL_SH = 'curl -fsSL https://amd-gaia.ai/install.sh | sh';
+const INSTALL_PS1 = 'irm https://amd-gaia.ai/install.ps1 | iex';
 const centered = align === 'center';
 ---
 
@@ -34,7 +36,7 @@ const centered = align === 'center';
   <div class:list={['flex flex-wrap gap-3', centered && 'justify-center']}>
     <DownloadButton variant="primary" size="lg" />
     <a
-      href={TUI_DOCS}
+      href={QUICKSTART}
       target="_blank"
       rel="noopener noreferrer"
       class="g-btn g-btn-secondary px-6 py-3 text-[15px]"
@@ -45,13 +47,15 @@ const centered = align === 'center';
     <div class="min-w-0">
       <dt class="g-label text-g-gold-text">Agent UI</dt>
       <dd class="mono mt-1 text-[11.5px] leading-[1.6] text-g-faint">
-        Desktop app · Windows, macOS, Linux
+        Desktop app · Windows, Linux, macOS (Apple Silicon)
       </dd>
     </div>
     <div class="min-w-0">
       <dt class="g-label text-g-gold-text">Terminal hub</dt>
       <dd class="mono mt-1 text-[11.5px] leading-[1.6] text-g-faint">
-        Single Go binary · needs the GAIA CLI · source build
+        One-line installer
+        <span class="block"><code class="bg-transparent p-0">{INSTALL_SH}</code></span>
+        <span class="block">Windows: <code class="bg-transparent p-0">{INSTALL_PS1}</code></span>
       </dd>
     </div>
   </dl>

--- a/website/src/pages/index.astro
+++ b/website/src/pages/index.astro
@@ -67,12 +67,12 @@ const WAYS = [
   },
 ];
 
-// Counts come from the CAPABILITY_MATRIX.md of the PUBLISHED release (the hub
-// catalog's `capability_matrix`), not the working tree — the repo copy runs ahead
-// of what anyone can install (it already says 22 verbs for an unreleased version).
+// Names the surfaces, never their counts. The catalog carries the published
+// CAPABILITY_MATRIX.md as raw markdown, so there is no field to derive a count
+// from — and a hardcoded one goes stale on the agent's next release.
 const INTEGRATION_POINTS = [
-  'Local REST sidecar (18 verbs)',
-  'MCP server (4 tools)',
+  'Local REST sidecar',
+  'MCP server',
   'CLI + pipe interfaces',
   'SDK: RAG · vision · tools · voice',
 ];
@@ -86,7 +86,7 @@ const INSTALLS = [
   {
     label: 'npm',
     cmd: 'npm install -g @amd-gaia/agent-ui',
-    note: 'The Agent UI, also packaged as an installer for Windows, macOS, and Linux.',
+    note: 'The Agent UI as a browser app. A separate desktop installer covers Windows, Linux, and Apple Silicon Macs.',
   },
   {
     label: 'model',

--- a/website/src/scripts/download-target.test.ts
+++ b/website/src/scripts/download-target.test.ts
@@ -1,0 +1,91 @@
+// Copyright(C) 2024-2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+import { describe, expect, it } from 'vitest';
+import {
+  detectOS,
+  resolveDownloadTarget,
+  TARGET_ASSETS,
+  type NavigatorLike,
+} from './download-target';
+
+const UA = {
+  win: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0 Safari/537.36',
+  mac: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0 Safari/537.36',
+  macSafari:
+    'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/18.0 Safari/605.1.15',
+  linux: 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0 Safari/537.36',
+  ipad: 'Mozilla/5.0 (iPad; CPU OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Mobile/15E148 Safari/604.1',
+  android: 'Mozilla/5.0 (Linux; Android 14; Pixel 8) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0 Mobile Safari/537.36',
+};
+
+const nav = (userAgent: string, architecture?: string | Error): NavigatorLike => ({
+  userAgent,
+  userAgentData:
+    architecture === undefined
+      ? undefined
+      : {
+          getHighEntropyValues: async () => {
+            if (architecture instanceof Error) throw architecture;
+            return { architecture };
+          },
+        },
+});
+
+describe('detectOS', () => {
+  it('reads the OS off the user agent', () => {
+    expect(detectOS(UA.win)).toBe('windows');
+    expect(detectOS(UA.mac)).toBe('macos');
+    expect(detectOS(UA.linux)).toBe('linux');
+  });
+
+  it('does not treat iPadOS as macOS or Android as Linux', () => {
+    expect(detectOS(UA.ipad)).toBeNull();
+    expect(detectOS(UA.android)).toBeNull();
+  });
+});
+
+describe('resolveDownloadTarget', () => {
+  it('resolves Windows and Linux without needing client hints', async () => {
+    await expect(resolveDownloadTarget(nav(UA.win))).resolves.toBe('windows');
+    await expect(resolveDownloadTarget(nav(UA.linux))).resolves.toBe('linux');
+  });
+
+  it('resolves a Mac only when the hints confirm Apple Silicon', async () => {
+    await expect(resolveDownloadTarget(nav(UA.mac, 'arm'))).resolves.toBe('macos-arm64');
+  });
+
+  it('refuses an Intel Mac — there is no darwin-x64 build', async () => {
+    await expect(resolveDownloadTarget(nav(UA.mac, 'x86'))).resolves.toBeNull();
+  });
+
+  it('refuses a Mac whose architecture cannot be read', async () => {
+    // Safari and Firefox expose no userAgentData, and Chromium masks the arch in
+    // the UA string, so the CTA must keep its releases-page fallback.
+    await expect(resolveDownloadTarget(nav(UA.macSafari))).resolves.toBeNull();
+    await expect(resolveDownloadTarget(nav(UA.mac, new Error('refused')))).resolves.toBeNull();
+  });
+
+  it('resolves nothing for an unknown platform', async () => {
+    await expect(resolveDownloadTarget(nav(UA.ipad, 'arm'))).resolves.toBeNull();
+  });
+});
+
+describe('TARGET_ASSETS', () => {
+  // The v0.22.0 release asset list, verbatim.
+  const assets = [
+    'gaia-agent-ui-0.22.0-amd64.deb',
+    'gaia-agent-ui-0.22.0-arm64.dmg',
+    'gaia-agent-ui-0.22.0-arm64.dmg.blockmap',
+    'gaia-agent-ui-0.22.0-x64-setup.exe',
+    'gaia-agent-ui-0.22.0-x64-setup.exe.blockmap',
+    'gaia-agent-ui-0.22.0-x86_64.AppImage',
+  ];
+
+  it('picks one real installer per target and never a blockmap', () => {
+    const pick = (re: RegExp) => assets.filter((a) => re.test(a));
+    expect(pick(TARGET_ASSETS.windows)).toEqual(['gaia-agent-ui-0.22.0-x64-setup.exe']);
+    expect(pick(TARGET_ASSETS['macos-arm64'])).toEqual(['gaia-agent-ui-0.22.0-arm64.dmg']);
+    expect(pick(TARGET_ASSETS.linux)).toEqual(['gaia-agent-ui-0.22.0-x86_64.AppImage']);
+  });
+});

--- a/website/src/scripts/download-target.ts
+++ b/website/src/scripts/download-target.ts
@@ -1,0 +1,60 @@
+// Copyright(C) 2024-2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+// Which Agent UI installer the download CTA is allowed to deep-link to.
+//
+// macOS is arm64-only (src/gaia/apps/webui/electron-builder.yml builds one dmg,
+// arch: [arm64]) and Rosetta translates x64 -> arm, not the reverse, so an Intel
+// Mac cannot run it. Chromium also masks the architecture in the UA string on
+// Apple Silicon, so a Mac resolves to a target ONLY when the client hints
+// confirm `arm`; anything else resolves to null and the caller keeps its
+// releases-page href, which lets the visitor pick for themselves.
+
+export type DownloadTarget = 'windows' | 'macos-arm64' | 'linux';
+
+export interface UserAgentDataLike {
+  getHighEntropyValues?(hints: string[]): Promise<{ architecture?: string }>;
+}
+
+export interface NavigatorLike {
+  userAgent: string;
+  userAgentData?: UserAgentDataLike;
+}
+
+export const TARGET_LABELS: Record<DownloadTarget, string> = {
+  windows: 'Windows',
+  'macos-arm64': 'macOS (Apple Silicon)',
+  linux: 'Linux',
+};
+
+// Anchored so the `.blockmap` siblings in the release assets never match.
+export const TARGET_ASSETS: Record<DownloadTarget, RegExp> = {
+  windows: /x64-setup\.exe$/,
+  'macos-arm64': /arm64\.dmg$/,
+  linux: /\.AppImage$/,
+};
+
+export function detectOS(userAgent: string): 'windows' | 'macos' | 'linux' | null {
+  if (/Windows/i.test(userAgent)) return 'windows';
+  if (/Mac/i.test(userAgent) && !/iPhone|iPad|iPod/i.test(userAgent)) return 'macos';
+  if (/Linux/i.test(userAgent) && !/Android/i.test(userAgent)) return 'linux';
+  return null;
+}
+
+export async function resolveDownloadTarget(
+  nav: NavigatorLike,
+): Promise<DownloadTarget | null> {
+  const os = detectOS(nav.userAgent);
+  if (os === 'windows' || os === 'linux') return os;
+  if (os !== 'macos') return null;
+
+  const uaData = nav.userAgentData;
+  if (!uaData?.getHighEntropyValues) return null;
+  try {
+    const hints = await uaData.getHighEntropyValues(['architecture']);
+    return hints?.architecture === 'arm' ? 'macos-arm64' : null;
+  } catch {
+    // Hints can be refused; an unknown architecture is not Apple Silicon.
+    return null;
+  }
+}


### PR DESCRIPTION
An Intel Mac visitor who clicked the landing page's download CTA got the arm64 DMG — the only mac artifact we build — and nothing they could run, because Rosetta translates x64 to arm and not the reverse. The CTA now deep-links a macOS installer only when the browser's client hints confirm Apple Silicon, and otherwise leaves the visitor on the GitHub releases page to choose for themselves; the entry point reads "macOS (Apple Silicon)", matching what the hub page has always rendered for the same platform string. Three copy claims ride along: the per-agent verb/tool counts lose their hardcoded numbers so they cannot go stale on the next agent release, the npm command no longer reads as though the package *is* the desktop installer, and "Get the terminal hub" points at the quickstart's one-line installer instead of a command reference for a binary the visitor does not have.

Three things a reviewer should weigh:

- **The fallback is the common path on Macs, by design.** `architecture` is a high-entropy client hint, so it needs the async `getHighEntropyValues()` and does not exist at all in Safari or Firefox. Those visitors get the plain "Download the Agent UI" button and the releases page — deliberately, because the alternative is guessing an architecture and handing half of them a file that cannot run. Apple Silicon users on Chrome/Edge still get the one-click DMG.
- **The terminal-hub copy depends on #2708.** The note shows both one-liners, but today `install.sh` is gated to Linux (`installer/scripts/install.sh:42`) and `install.ps1` has no terminal-hub step. #2708 fixes both; until it lands this copy runs ahead of the scripts on macOS and Windows. It is still strictly better than pointing newcomers at a CLI reference for a binary they do not have, and it does not point at `/hub/terminal-hub`, which 404s.
- **The verb counts are worded so they cannot rot, not re-counted.** Updating 18 → 22 would just re-arm the bug at the next release. The catalog's `capability_matrix` carries the published `CAPABILITY_MATRIX.md` as raw markdown, so deriving a number means regex-parsing prose that already contradicts itself (that document says "16" in one sentence and "18" in another). Naming the surfaces without asserting a count is the durable fix. A structured count field on the catalog would let a real number render again; that is a `catalog.ts` / worker change, out of scope here.

Test plan:

- [x] `cd website && npm install && npx astro check` → 0 errors, 0 warnings, 0 hints
- [x] `npx vitest run` → 40 passing (32 existing + 8 new in `src/scripts/download-target.test.ts`)
- [x] `HUB_CATALOG_URL=https://hub.amd-gaia.ai npm run build` → 3 pages · `npm run check:agents` → snapshot up to date
- [x] Headless Chromium against `astro preview`, every CTA on `/`, `/hub/`, `/hub/email/`: Apple Silicon → "Agent UI for macOS (Apple Silicon)" + `…-arm64.dmg`; hints report `x86` → "Download the Agent UI" + `releases/latest`; no `userAgentData` → same; hints rejected → same; hints never settle → same, and the version badge still renders
- [x] **On a real Intel Mac** (cannot be simulated here): Safari and Chrome both land on `releases/latest`, never on a `.dmg` URL
- [x] URLs: `https://amd-gaia.ai/docs/quickstart` 200 · `https://amd-gaia.ai/install.sh` 302 → `raw.githubusercontent.com/amd/gaia/main/installer/scripts/install.sh` · `https://amd-gaia.ai/install.ps1` 302 → `…/install.ps1` · `https://github.com/amd/gaia/releases/latest` 302 → `v0.22.0`
- [x] Landing page at 390px wide: no horizontal overflow


---

### Independent verification (not the author), macOS

- **The premise is confirmed against the real release.** `gh release view v0.22.0` publishes exactly one mac artifact — `gaia-agent-ui-0.22.0-arm64.dmg` (plus its blockmap). There is no `darwin-x64` build, so an Intel Mac visitor really was being handed something unrunnable.
- `src/scripts/download-target.test.ts` — **8 passed**, and the cases cover the failure modes that matter rather than just the happy path: *"refuses an Intel Mac — there is no darwin-x64 build"*, *"refuses a Mac whose architecture cannot be read"* (the Safari/Firefox case, where `userAgentData` is undefined and the fallback becomes the real path), *"does not treat iPadOS as macOS or Android as Linux"*, and *"picks one real installer per target and never a blockmap"* — worth noting, since the release does ship a `.dmg.blockmap` that would be a broken download.
- Full suite **40 passed** (32 before, so 8 net new). `npx astro check` 0 errors, 0 warnings. Build produces 3 pages from the live catalog.
- **CTA targets resolve:** `https://amd-gaia.ai/install.sh` and `/install.ps1` both 302 → 200; `/docs/quickstart` 200. The comment at `EntryPoints.astro:13-16` records why it avoids `/hub` (*"contains no terminal hub"*) and `/hub/terminal-hub` (*"unpublished, 404"*) — both correct today.
- **The stale verb count is removed, not merely corrected.** `'Local REST sidecar (18 verbs)'` is gone; the copy no longer asserts a number, so it cannot rot at the next release. That is the durable fix rather than `18 → 22`.

No issues found.



**Both remaining boxes verified in headless Chromium**, simulating each visitor by overriding `navigator.userAgentData`:

| Simulated visitor | CTA label | Target |
| --- | --- | --- |
| Apple Silicon (`architecture: 'arm'`) | "Agent UI for macOS **(Apple Silicon)** v0.22.0" | direct `.dmg` deep link |
| Intel Mac (`architecture: 'x86'`) | "Download the Agent UI v0.22.0" | `releases/latest` |
| Mac with `userAgentData` **undefined** (Safari / Firefox) | "Download the Agent UI v0.22.0" | `releases/latest` |

The third row is the important one: on the browsers where the architecture API does not exist, it falls through to the releases page rather than dead-ending, and the label only claims "Apple Silicon" once that has actually been confirmed.

Landing page at **390px**: `scrollWidth === clientWidth` (390 = 390) — no horizontal overflow.
