### PR TITLE
fix(hub): mark the email agent verified so first install is not refused

### DIFF
--- a/docs/guides/hub-publishing.mdx
+++ b/docs/guides/hub-publishing.mdx
@@ -183,13 +183,20 @@ interfaces:                  # the ways your agent can be used (see "Standalone 
 ```
 
 <Note>
-A few fields are **not** yours to set: `download_size_bytes` is measured by the
-server when you publish. `security_tier` defaults to `experimental` and only
-becomes `community` / `verified` through review — setting it yourself does nothing
-(the example agents set `experimental` just to be explicit). `permissions` is
-optional. The website turns all of these into the install switcher, platform
-badges, and requirement/permission/tier cards automatically — you don't build any
-of that.
+`download_size_bytes` is **not** yours to set — the server measures it when you
+publish. `permissions` is optional.
+
+`security_tier` **is** read from your manifest, and it matters. Omit it and you get
+the most restrictive tier (`experimental`), which means users can only install your
+agent by passing an explicit `--trust` opt-in. The value you write is what the hub
+publishes for whatever version becomes the new latest; publishing an *older* version
+leaves the displayed tier alone. What stops you from simply claiming `verified` is
+the review gate, not the parser — publishing goes through a maintainer, and the tier
+you declare is part of what gets reviewed. The example agents declare `experimental`
+because that is genuinely their tier.
+
+The website turns all of these into the install switcher, platform badges, and
+requirement/permission/tier cards automatically — you don't build any of that.
 </Note>
 
 **How GAIA actually finds your agent.** After someone installs your package, GAIA

--- a/docs/reference/cli.mdx
+++ b/docs/reference/cli.mdx
@@ -2386,10 +2386,10 @@ gaia hub uninstall email           # stops the sidecar first, then removes the d
   by both `install` and `uninstall`.
 - **Trust gate.** Any agent outside the `verified` security tier runs
   third-party code on your machine, so it is refused (HTTP 403) until you pass
-  `--trust`. `email` is `experimental`, so `gaia hub install email` alone fails
-  with the remedy named. Nothing infers the opt-in for you, and there is no
-  bypass — a client (TUI, UI) renders this as a "Trust & Install" confirmation
-  and retries with `trusted: true`.
+  `--trust`, with the remedy named in the error. A manifest that omits
+  `security_tier` counts as `experimental` and is gated the same way. Nothing
+  infers the opt-in for you, and there is no bypass — a client (TUI, UI) renders
+  this as a "Trust & Install" confirmation and retries with `trusted: true`.
 - Requires the daemon extras (`pip install "amd-gaia[ui]"`), same as `gaia daemon`.
 
 <Note>
@@ -2682,10 +2682,10 @@ gaia hub uninstall email           # stops the sidecar first, then removes the d
   by both `install` and `uninstall`.
 - **Trust gate.** Any agent outside the `verified` security tier runs
   third-party code on your machine, so it is refused (HTTP 403) until you pass
-  `--trust`. `email` is `experimental`, so `gaia hub install email` alone fails
-  with the remedy named. Nothing infers the opt-in for you, and there is no
-  bypass — a client (TUI, UI) renders this as a "Trust & Install" confirmation
-  and retries with `trusted: true`.
+  `--trust`, with the remedy named in the error. A manifest that omits
+  `security_tier` counts as `experimental` and is gated the same way. Nothing
+  infers the opt-in for you, and there is no bypass — a client (TUI, UI) renders
+  this as a "Trust & Install" confirmation and retries with `trusted: true`.
 - Requires the daemon extras (`pip install "amd-gaia[ui]"`), same as `gaia daemon`.
 
 <Note>

--- a/hub/agents/email/python/gaia-agent.yaml
+++ b/hub/agents/email/python/gaia-agent.yaml
@@ -11,6 +11,9 @@ npm_package: "@amd-gaia/agent-email"
 playground_url: "http://127.0.0.1:8131/v1/email/playground"
 
 category: productivity
+# Must stay declared: an omitted tier defaults to `experimental`, which makes
+# `gaia agent install email` refuse without an explicit `--trust` opt-in.
+security_tier: verified
 tags: [email, gmail, calendar, triage]
 icon: mail
 # tools_count = the number of internal @tool-decorated agent-loop functions

--- a/src/gaia/daemon/sidecars/install.py
+++ b/src/gaia/daemon/sidecars/install.py
@@ -499,7 +499,8 @@ def start_install(
     (``gaia hub install <id> --trust`` / a UI "Trust & Install" confirmation). It
     defaults to False and is never inferred: a non-verified package runs
     third-party code on the user's machine, so the refusal has to be the
-    default. ``email`` is in the ``experimental`` tier, so it needs it.
+    default. A manifest that omits ``security_tier`` counts as ``experimental``
+    and is gated the same way.
 
     Raises:
         UnsupervisedAgentError: reserved built-in id.

--- a/tests/unit/test_daemon_hub_routes.py
+++ b/tests/unit/test_daemon_hub_routes.py
@@ -194,8 +194,8 @@ def _auth(token="secret-tok"):
 
 def _post_install(client, agent_id="email", *, trusted=True, **body):
     """POST an install. Defaults to trusted=True because the fixture agent is
-    in the ``experimental`` tier, like the real email agent — the refusal path
-    is asserted explicitly in its own tests."""
+    in the ``experimental`` tier — the refusal path is asserted explicitly in its
+    own tests."""
     return client.post(
         f"/daemon/v1/agents/{agent_id}/install",
         headers=_auth(),

--- a/tests/unit/test_hub_manifest.py
+++ b/tests/unit/test_hub_manifest.py
@@ -3,12 +3,16 @@
 """Unit tests for the gaia-agent.yaml manifest parser/validator (#1091)."""
 
 import textwrap
+from pathlib import Path
 
 import pytest
 import yaml
 
 from gaia.hub import AgentManifest, ManifestError, parse
-from gaia.hub.manifest import DEFAULT_SECURITY_TIER
+from gaia.hub.installer import VERIFIED_TIER, ensure_trust_ack, requires_trust_ack
+from gaia.hub.manifest import DEFAULT_SECURITY_TIER, VALID_SECURITY_TIERS
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
 
 # ---------------------------------------------------------------------------
 # Fixtures / builders
@@ -571,3 +575,59 @@ def test_real_world_yaml_text(tmp_path):
     assert m.id == "chatty"
     assert m.requirements.min_memory_gb == 8
     assert m.interfaces.mcp_server is True
+
+
+# ---------------------------------------------------------------------------
+# Shipped manifests
+#
+# Mirrors the Worker's equivalent block (workers/agent-hub/test/manifest.test.ts):
+# parse the manifests this repo actually publishes, with the parser that runs in
+# production. Without this, a bad edit to a shipped manifest is only caught by
+# the release job that tries to publish it.
+# ---------------------------------------------------------------------------
+
+SHIPPED_AGENT_MANIFESTS = sorted(
+    (REPO_ROOT / "hub" / "agents").glob("*/python/gaia-agent.yaml")
+)
+
+
+def test_shipped_agent_manifests_are_discoverable():
+    """A path typo above would silently parametrize zero manifests."""
+    assert SHIPPED_AGENT_MANIFESTS, f"no shipped manifests under {REPO_ROOT}/hub/agents"
+
+
+@pytest.mark.parametrize(
+    "manifest_path", SHIPPED_AGENT_MANIFESTS, ids=lambda p: p.parent.parent.name
+)
+def test_shipped_agent_manifest_parses(manifest_path):
+    # The id is not asserted against the directory name: some agents ship a
+    # registry id that differs deliberately (analyst -> data, browser -> web).
+    m = parse(manifest_path)
+    assert m.id
+    assert m.security_tier in VALID_SECURITY_TIERS
+
+
+def test_email_agent_declares_the_verified_tier():
+    """The email manifest omitted ``security_tier``, so it published as
+    ``experimental`` — and a non-verified agent refuses to install without an
+    explicit trust opt-in, making ``gaia agent install email`` fail for a
+    first-time user of AMD's own agent.
+    """
+    path = REPO_ROOT / "hub" / "agents" / "email" / "python" / "gaia-agent.yaml"
+
+    assert "security_tier" in yaml.safe_load(path.read_text(encoding="utf-8")), (
+        "gaia-agent.yaml must declare security_tier explicitly — an omitted tier "
+        f"defaults to {DEFAULT_SECURITY_TIER!r}, which forces `--trust` on install"
+    )
+    assert parse(path).security_tier == VERIFIED_TIER
+
+
+def test_email_agent_installs_without_a_trust_opt_in():
+    """The tier only matters through the install gate, so assert the gate itself
+    rather than just the parsed value (the min_lemonade_version lesson above).
+    """
+    path = REPO_ROOT / "hub" / "agents" / "email" / "python" / "gaia-agent.yaml"
+    raw = yaml.safe_load(path.read_text(encoding="utf-8"))
+
+    assert requires_trust_ack(raw) is False
+    ensure_trust_ack("email", raw, trusted=False)  # must not raise

--- a/tui/test/fakedaemon_test.go
+++ b/tui/test/fakedaemon_test.go
@@ -204,8 +204,8 @@ func (f *fakeDaemon) handleInstall(w http.ResponseWriter, r *http.Request) {
 	}
 	f.mu.Unlock()
 
-	// Mirrors the real daemon: `email` is in the experimental tier, so an
-	// install without an explicit opt-in is a 403 naming --trust.
+	// Mirrors the real daemon for a non-verified agent: an install without an
+	// explicit opt-in is a 403 naming --trust.
 	if !trusted {
 		w.WriteHeader(http.StatusForbidden)
 		writeJSON(w, map[string]any{"detail": "installing 'email' runs code AMD has not verified. " +


### PR DESCRIPTION
Installing AMD’s own agent from AMD’s own hub currently errors: `gaia agent install email` raises `TrustRequiredError` unless the user adds `--trust`, and `/hub/email` tells them "Experimental — review the source before installing." The cause is that `hub/agents/email/python/gaia-agent.yaml` never declared `security_tier`, and an omitted tier resolves to the most restrictive value in all three parsers that mirror each other — so the live catalog publishes a reviewed, eval-scored (83.4/100) agent as `experimental` with `author: AMD`. Declaring `security_tier: verified` clears the install gate and stops the hub page warning users off it. The publishing guide made this worse by telling authors the field "only becomes `community` / `verified` through review — setting it yourself does nothing", which is not true for the version that becomes latest, where the manifest value is authoritative; anyone attempting this fix would have been told it was pointless.

**What the maintainer is signing off:** this is a trust decision, not a code change. `verified` is the only tier that installs without an explicit `--trust` opt-in, so merging asserts AMD stands behind this agent’s code running on a user’s machine with their privileges. The parser will not stop anyone declaring `verified` — the review gate is the only thing that makes the claim legitimate, which is precisely why it needs a human yes.

**Takes effect on the next publish only.** The manifest change does not alter the live catalog — that is rebuilt at publish time, so it needs a republish of the email package to reach `hub.amd-gaia.ai`. In practice that means the next release: artifacts are immutable per filename (`workers/agent-hub/src/publish.ts:245` 409s a re-upload), so a republish carries a new version. **The version bump is deliberately not in this PR:** `stamp_version.py` owns a coordinated bump across the manifest, `pyproject.toml`, `package.json`, `binaries.lock.json` (`agentVersion` + `baseUrl`), the `architecture.html` badge and the pinned doc links, and its `--check` gate in `release_agent_email.yml` fails unless every reference agrees. That belongs in the release PR.

Known follow-up, not touched here: the tier *description* strings in `website/src/data/catalog.ts:362-363` describe a Python sandbox and a publisher-signing scheme that do not exist. PR #2689 owns that file. Fixing the tier here means the inaccurate `experimental` string stops rendering for the only published agent, which is the cheaper half of that fix.

### Test plan

- [x] `python -m pytest tests/unit/ -k "hub or manifest or installer"` — 606 passed. The 3 failures (`test_install_real_wheel_lands_in_site_packages_and_is_importable`, `test_default_run_pip_falls_back_to_python_pip_when_uv_missing`, `test_hub_installed_wheel_agent_importable_in_fresh_process`) are pre-existing: they fail identically on a stashed clean tree, all three from a real `pip install` subprocess in the local sandbox.
- [x] `python util/lint.py --black --isort` — both pass.
- [x] The edited manifest round-trips through the real production parsers, not a stub: `gaia.hub.manifest.parse` returns `security_tier: 'verified'`, and `gaia.hub.installer.requires_trust_ack` returns `False` with `ensure_trust_ack(trusted=False)` no longer raising — i.e. the install proceeds without `--trust`.
- [x] The Worker parser accepts it too: `npx vitest run test/manifest.test.ts` in `workers/agent-hub` — 31 passed.
- [x] The publish-precedence claim was exercised rather than only read: driving the real `upsertVersion` / `toIndexEntry` proves the manifest value wins for whatever version becomes latest (no sticky-value trap), and that backfilling an **older** version correctly leaves the latest tier alone.
- [x] `stamp_version.py --check` still passes at 0.5.0 — the manifest edit does not disturb the release version gate.
- [x] `go build ./...` and `go test ./test/... ./internal/catalog/...` in `tui/` pass.
- [x] Reviewer: confirm the tier claim is one a maintainer is willing to publish under — the review gate, not the parser, is what makes `verified` legitimate.


---

### Independent verification (not the author)

- `security_tier: verified` is declared and **parses through the real parser**; `DEFAULT_SECURITY_TIER` confirms the value it would otherwise fall back to is `experimental`, which is the whole bug.
- **The precedence claim holds.** `workers/agent-hub/src/catalog.ts:90` resolves `base?.security_tier ?? existing?.security_tier ?? manifest.security_tier`, with `base = useNew ? manifest : null` and `useNew = latest === manifest.version` (`:74-75`). So on a **new latest version** the freshly parsed manifest wins outright — there is no sticky-value trap, and this edit will take effect on republish.
- **The doc sweep is complete.** Zero surviving instances of *"setting it yourself does nothing"* or *"only becomes … through review"* across `docs/` and `hub/`. That mattered: the old guide actively told publishers this fix was pointless.
- `pytest -k "hub_manifest or hub_catalog or hub_installer"` — **203 passed**, 64 skipped. Two failures in `test_hub_installer.py` (`test_install_real_wheel_lands_in_site_packages_and_is_importable`, `test_default_run_pip_falls_back_to_python_pip_when_uv_missing`) are **pre-existing and environmental** — they fail identically on current `main`, verified.

**What this does not settle, because it is not a testing question:** whether the agent *should* be `verified`. Merging means `gaia agent install email` stops requiring `--trust` and the hub page stops telling visitors to review the source first. The mechanism is correct; the security posture is the maintainer's call. Note also that the catalog only changes on the **next publish**, not on merge.
