### PR TITLE
fix(installer): repair the Lemonade download URLs and add macOS support

### DIFF
--- a/.github/workflows/test_unit.yml
+++ b/.github/workflows/test_unit.yml
@@ -131,6 +131,15 @@ jobs:
           echo ""
           pytest tests/integration/test_database_agent.py -v --tb=short
 
+      - name: Run Lemonade release-asset resolution test
+        env:
+          GAIA_MEMORY_DISABLED: "1"
+        run: |
+          echo "=== Resolving Lemonade installer URLs against live upstream ==="
+          echo "Catches an upstream asset rename before it 404s gaia init"
+          echo ""
+          pytest tests/integration/test_lemonade_release_assets.py -v --tb=short
+
       - name: Run daemon integration tests
         env:
           GAIA_MEMORY_DISABLED: "1"

--- a/docs/reference/cli.mdx
+++ b/docs/reference/cli.mdx
@@ -298,7 +298,7 @@ GAIA works with Lemonade Server in two modes:
 </Tabs>
 
 <Warning>
-**Platform Support:** Automatic installation supports Windows (MSI) and Linux (DEB) only. macOS users should install Lemonade Server manually from [lemonade-server.ai](https://www.lemonade-server.ai).
+**Platform Support:** Automatic installation supports Windows (MSI), Linux (`ppa:lemonade-team/stable`, Ubuntu 24.04+), and macOS on Apple Silicon (`.pkg`, requires admin rights). Intel Macs and other architectures have no upstream Lemonade build — install manually from [lemonade-server.ai](https://www.lemonade-server.ai).
 </Warning>
 
 <Tip>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,7 @@ markers = [
     "gmail_live: marks tests that hit the live Gmail API (requires GAIA_GMAIL_LIVE_ACCOUNT env var; never in CI)",
     "real_model: marks tests that require a real Lemonade model server and real model inference (self-hosted runner only; see #1297)",
     "distributed_seams: marks the consolidated daemon<->sidecar seam contract suite (V2-19 / #2180); deterministic, runs in normal CI, skips seams not yet merged",
+    "network: marks tests that hit a live external endpoint (runs in CI; auto-skips when unreachable or GAIA_SKIP_NETWORK_TESTS=1)",
 ]
 testpaths = ["tests"]
 python_files = ["test_*.py"]

--- a/src/gaia/installer/init_command.py
+++ b/src/gaia/installer/init_command.py
@@ -705,7 +705,7 @@ class InitCommand:
             self._print_error(
                 f"Platform '{platform_name}' is not supported for automatic installation."
             )
-            self._print("   GAIA init only supports Windows and Linux.")
+            self._print("   GAIA init only supports Windows, Linux, and macOS.")
             self._print(
                 "   Please install Lemonade Server manually from: https://www.lemonade-server.ai"
             )
@@ -988,6 +988,14 @@ class InitCommand:
             True on success, False on failure
         """
         self._print("")
+
+        # macOS has no scripted uninstall, but `installer -pkg` upgrades in place —
+        # calling uninstall() would only print removal instructions the user
+        # doesn't need.
+        if self.installer.system == "darwin":
+            self._print(f"   Upgrading Lemonade v{old_version} in place...")
+            return self._install_lemonade()
+
         if RICH_AVAILABLE and self.console:
             self.console.print(
                 f"   [bold]Uninstalling[/bold] Lemonade [red]v{old_version}[/red]..."
@@ -1043,7 +1051,12 @@ class InitCommand:
                 plain_label = _re.sub(r"\[.*?\]", "", label)
                 self._print(f"   {plain_label}")
 
-            if installer_path is not None and not self.yes:
+            # macOS installs run headless via `installer -pkg`; only the MSI pops a window.
+            if (
+                installer_path is not None
+                and not self.yes
+                and self.installer.system == "windows"
+            ):
                 if RICH_AVAILABLE and self.console:
                     self.console.print()
                     self.console.print(

--- a/src/gaia/installer/lemonade_installer.py
+++ b/src/gaia/installer/lemonade_installer.py
@@ -791,6 +791,17 @@ class LemonadeInstaller:
                     f"Retry manually: {manual_cmd}"
                 ),
             )
+        except KeyboardInterrupt:
+            # Ctrl-C at the sudo prompt is BaseException — without this it escapes
+            # every caller's `except Exception` as a raw traceback.
+            return InstallResult(
+                success=False,
+                error=(
+                    "Installation cancelled at the administrator prompt. "
+                    f"To install without sudo prompting, run 'sudo -v' first, "
+                    f"or install manually: {manual_cmd}"
+                ),
+            )
         except FileNotFoundError as e:
             return InstallResult(
                 success=False, error=f"Required command not found: {e}"
@@ -903,6 +914,11 @@ class LemonadeInstaller:
                             "configure passwordless sudo, or run gaia init as root."
                         ),
                     )
+            elif not is_root:
+                self._announce(
+                    "Administrator rights are required to add the Lemonade PPA — "
+                    "sudo will ask for your password."
+                )
 
             env = os.environ.copy()
             if non_interactive:

--- a/src/gaia/installer/lemonade_installer.py
+++ b/src/gaia/installer/lemonade_installer.py
@@ -5,13 +5,14 @@
 Lemonade Server Installer
 
 Handles detection, download, and installation of Lemonade Server
-from GitHub releases for Windows and Linux platforms.
+from GitHub releases for Windows, Linux, and macOS.
 """
 
 import logging
 import os
 import platform
 import re
+import shlex
 import shutil
 import subprocess
 import tempfile
@@ -37,6 +38,30 @@ except ImportError:
 
 # GitHub release URL patterns
 GITHUB_RELEASE_BASE = "https://github.com/lemonade-sdk/lemonade/releases/download"
+GITHUB_RELEASE_TAG_BASE = "https://github.com/lemonade-sdk/lemonade/releases/tag"
+
+# Upstream .deb assets carry a distro infix: lemonade-server_<ver>-debian13_<arch>.deb
+LINUX_DEB_DISTRO_TAG = "debian13"
+
+# platform.machine() varies by OS/libc for the same hardware.
+DEB_ARCH_BY_MACHINE = {
+    "x86_64": "amd64",
+    "amd64": "amd64",
+    "aarch64": "arm64",
+    "arm64": "arm64",
+}
+
+
+class LemonadeAssetError(RuntimeError):
+    """A release asset could not be verified.
+
+    ``definitive`` distinguishes "upstream says it's gone" (fatal) from
+    "we couldn't ask" (a network or proxy failure the real download may survive).
+    """
+
+    def __init__(self, message: str, definitive: bool):
+        super().__init__(message)
+        self.definitive = definitive
 
 
 @dataclass
@@ -95,6 +120,7 @@ class LemonadeInstaller:
         self.progress_callback = progress_callback
         self.minimal = minimal
         self.system = platform.system().lower()
+        self.machine = platform.machine().lower()
         self.console = console
 
     def _print_status(self, message: str, style: str = "dim"):
@@ -104,6 +130,13 @@ class LemonadeInstaller:
         elif not self.console:
             # Only log if no console provided (to avoid duplicate output)
             log.debug(message)
+
+    def _announce(self, message: str) -> None:
+        """Print a message the user must see, console or not."""
+        if self.console and RICH_AVAILABLE:
+            self.console.print(f"   [yellow]{message}[/yellow]")
+        else:
+            print(f"   {message}")
 
     def refresh_path_from_registry(self) -> None:
         """Refresh PATH from Windows registry after MSI install."""
@@ -221,15 +254,31 @@ class LemonadeInstaller:
         except (ValueError, IndexError):
             return None
 
+    @property
+    def release_page_url(self) -> str:
+        """Upstream release page — the authoritative list of published assets."""
+        return f"{GITHUB_RELEASE_TAG_BASE}/v{self.target_version}"
+
+    def _deb_arch(self) -> str:
+        """Map platform.machine() to the Debian arch used in upstream asset names."""
+        arch = DEB_ARCH_BY_MACHINE.get(self.machine)
+        if arch is None:
+            raise RuntimeError(
+                f"Architecture '{self.machine}' has no Lemonade Linux package. "
+                f"Upstream v{self.target_version} publishes amd64 (x86_64) and "
+                f"arm64 (aarch64) .deb assets only — see {self.release_page_url}."
+            )
+        return arch
+
     def get_download_url(self) -> str:
         """
-        Get the download URL for the current platform.
+        Get the download URL for the current platform and architecture.
 
         Returns:
             Download URL for the installer
 
         Raises:
-            RuntimeError: If platform is not supported
+            RuntimeError: If the platform or architecture is not supported
         """
         version = self.target_version
 
@@ -241,28 +290,107 @@ class LemonadeInstaller:
                 # Full installer
                 return f"{GITHUB_RELEASE_BASE}/v{version}/lemonade.msi"
         elif self.system == "linux":
-            # Linux DEB - filename includes version (no minimal variant yet)
-            # Note: v10.0.0+ changed naming from lemonade_ to lemonade-server_
+            # Linux DEB - no minimal variant yet.
+            # Note: v10.0.0+ changed naming from lemonade_ to lemonade-server_,
+            # and the asset carries a distro infix (see LINUX_DEB_DISTRO_TAG).
             return (
-                f"{GITHUB_RELEASE_BASE}/v{version}/lemonade-server_{version}_amd64.deb"
+                f"{GITHUB_RELEASE_BASE}/v{version}/lemonade-server_"
+                f"{version}-{LINUX_DEB_DISTRO_TAG}_{self._deb_arch()}.deb"
             )
+        elif self.system == "darwin":
+            # The .pkg ships arm64-only binaries and installs cleanly on Intel,
+            # so an unguarded install would only fail later at "Bad CPU type".
+            if self.machine not in ("arm64", "aarch64"):
+                raise RuntimeError(
+                    f"Architecture '{self.machine}' has no Lemonade macOS package. "
+                    f"Upstream v{self.target_version} publishes an Apple-Silicon-only "
+                    f".pkg — see {self.release_page_url}.\n"
+                    "On an Apple Silicon Mac this means Python is running under "
+                    "Rosetta; re-run GAIA with a native arm64 Python."
+                )
+            return f"{GITHUB_RELEASE_BASE}/v{version}/Lemonade-{version}-Darwin.pkg"
         else:
             raise RuntimeError(
                 f"Platform '{self.system}' is not supported. "
-                "GAIA init only supports Windows and Linux."
+                "GAIA init only supports Windows, Linux, and macOS."
             )
 
     def get_installer_filename(self) -> str:
-        """Get the installer filename for the current platform."""
-        if self.system == "windows":
-            if self.minimal:
-                return "lemonade-server-minimal.msi"
-            else:
-                return "lemonade.msi"
-        elif self.system == "linux":
-            return f"lemonade-server_{self.target_version}_amd64.deb"
-        else:
-            raise RuntimeError(f"Platform '{self.system}' is not supported.")
+        """Get the installer filename for the current platform.
+
+        Derived from the download URL so the two can never drift apart.
+        """
+        return self.get_download_url().rsplit("/", 1)[-1]
+
+    def _missing_asset_error(self, url: str, detail: str) -> str:
+        """Error for an asset upstream no longer serves — a rename or a pulled release."""
+        return (
+            f"Lemonade v{self.target_version} installer asset {detail}.\n"
+            f"  URL:      {url}\n"
+            f"  Platform: {self.system}/{self.machine}\n"
+            "Upstream may have renamed or dropped this asset. Check the published "
+            f"asset list at {self.release_page_url}. If it moved, report it at "
+            "https://github.com/amd/gaia/issues — maintainers: update "
+            "LEMONADE_VERSION (src/gaia/version.py) or the asset-name pattern in "
+            "src/gaia/installer/lemonade_installer.py."
+        )
+
+    def _unreachable_asset_error(self, url: str, detail: str) -> str:
+        """Error for a network/proxy failure — says nothing about the asset itself."""
+        return (
+            f"Could not reach the Lemonade download server ({detail}).\n"
+            f"  URL: {url}\n"
+            "Check your network connection or proxy settings and retry."
+        )
+
+    def verify_download_url(self, url: Optional[str] = None, timeout: int = 30) -> str:
+        """Confirm the constructed asset URL resolves before attempting a download.
+
+        Args:
+            url: URL to check (defaults to the URL for this platform/arch)
+            timeout: Seconds to wait for the HEAD request
+
+        Returns:
+            The verified URL
+
+        Raises:
+            LemonadeAssetError: If the URL does not return HTTP 200. ``definitive``
+                is True only when upstream positively reports the asset gone
+                (404/410); transient network or proxy failures set it False.
+        """
+        url = url or self.get_download_url()
+        request = urllib.request.Request(
+            url, method="HEAD", headers={"User-Agent": "GAIA-Installer/1.0"}
+        )
+        try:
+            with urllib.request.urlopen(request, timeout=timeout) as response:
+                status = getattr(response, "status", None) or response.getcode()
+        except urllib.error.HTTPError as e:
+            if e.code in (404, 410):
+                raise LemonadeAssetError(
+                    self._missing_asset_error(url, f"was not found (HTTP {e.code})"),
+                    definitive=True,
+                ) from e
+            # A proxy or WAF can reject HEAD while serving the GET fine.
+            raise LemonadeAssetError(
+                self._unreachable_asset_error(url, f"HTTP {e.code} {e.reason}"),
+                definitive=False,
+            ) from e
+        except urllib.error.URLError as e:
+            raise LemonadeAssetError(
+                self._unreachable_asset_error(url, str(e.reason)), definitive=False
+            ) from e
+        except TimeoutError as e:
+            raise LemonadeAssetError(
+                self._unreachable_asset_error(url, f"timed out after {timeout}s"),
+                definitive=False,
+            ) from e
+
+        if status != 200:
+            raise LemonadeAssetError(
+                self._unreachable_asset_error(url, f"HTTP {status}"), definitive=False
+            )
+        return url
 
     def download_installer(self, dest_dir: Optional[str] = None) -> Path:
         """
@@ -277,7 +405,15 @@ class LemonadeInstaller:
         Raises:
             RuntimeError: If download fails
         """
+        # Pre-flight the asset so an upstream rename fails here — with the URL and
+        # where to find the real asset list — instead of mid-download.
         url = self.get_download_url()
+        try:
+            self.verify_download_url(url)
+        except LemonadeAssetError as e:
+            if e.definitive:
+                raise
+            log.warning("Could not pre-flight %s; downloading anyway: %s", url, e)
         filename = self.get_installer_filename()
 
         if dest_dir:
@@ -295,7 +431,8 @@ class LemonadeInstaller:
                     log.debug(f"Removed existing installer at {dest_path}")
                 except PermissionError:
                     # File is locked, use a unique filename instead
-                    unique_name = f"lemonade_{uuid.uuid4().hex[:8]}.msi"
+                    suffix = Path(filename).suffix
+                    unique_name = f"lemonade_{uuid.uuid4().hex[:8]}{suffix}"
                     dest_path = Path(tempfile.gettempdir()) / unique_name
                     log.debug(f"Using unique filename: {dest_path}")
 
@@ -326,11 +463,10 @@ class LemonadeInstaller:
 
         except urllib.error.HTTPError as e:
             if e.code == 404:
-                raise RuntimeError(
-                    f"Lemonade v{self.target_version} not found. "
-                    "Please check https://github.com/lemonade-sdk/lemonade/releases "
-                    "for available versions."
-                )
+                raise LemonadeAssetError(
+                    self._missing_asset_error(url, "was not found (HTTP 404)"),
+                    definitive=True,
+                ) from e
             raise RuntimeError(f"Download failed: HTTP {e.code} - {e.reason}")
         except urllib.error.URLError as e:
             raise RuntimeError(f"Download failed: {e.reason}")
@@ -351,6 +487,12 @@ class LemonadeInstaller:
                 return self._install_windows(installer_path, silent)
             elif self.system == "linux":
                 return self._install_via_ppa(non_interactive=silent)
+            elif self.system == "darwin":
+                if installer_path is None or not installer_path.exists():
+                    return InstallResult(
+                        success=False, error=f"Installer not found: {installer_path}"
+                    )
+                return self._install_macos(installer_path, non_interactive=silent)
             else:
                 return InstallResult(
                     success=False, error=f"Platform '{self.system}' is not supported"
@@ -555,6 +697,128 @@ class LemonadeInstaller:
         except Exception as e:
             return InstallResult(success=False, error=str(e))
 
+    def _install_macos(
+        self, installer_path: Path, non_interactive: bool = False
+    ) -> InstallResult:
+        """Install on macOS with `installer -pkg <path> -target /`.
+
+        The .pkg writes to /Applications, /usr/local/bin and /Library/Launch*,
+        so it needs admin rights. The sudo requirement is announced before sudo
+        is ever invoked — never a bare, unexplained password prompt.
+        """
+        manual_cmd = f"sudo installer -pkg {shlex.quote(str(installer_path))} -target /"
+        is_root = hasattr(os, "geteuid") and os.geteuid() == 0
+        sudo_prefix = [] if is_root else ["sudo"]
+
+        try:
+            if not is_root:
+                cached = subprocess.run(
+                    ["sudo", "-n", "true"],
+                    capture_output=True,
+                    text=True,
+                    timeout=5,
+                    stdin=subprocess.DEVNULL,
+                    check=False,
+                )
+                if cached.returncode != 0:
+                    if non_interactive:
+                        return InstallResult(
+                            success=False,
+                            error=(
+                                "Installing Lemonade on macOS requires administrator "
+                                "rights, but this run is non-interactive and sudo "
+                                "needs a password.\n"
+                                "Run 'sudo -v' first and retry, or install manually:\n"
+                                f"  {manual_cmd}"
+                            ),
+                        )
+                    # Must reach the user even with no Rich console (gaia install
+                    # --lemonade constructs the installer without one).
+                    self._announce(
+                        "Administrator rights are required to install Lemonade — "
+                        "sudo will ask for your password."
+                    )
+
+            cmd = sudo_prefix + [
+                "installer",
+                "-pkg",
+                str(installer_path),
+                "-target",
+                "/",
+            ]
+            self._print_status(f"Running: {' '.join(cmd)}")
+            result = subprocess.run(
+                cmd, capture_output=True, text=True, timeout=600, check=False
+            )
+
+            if result.returncode != 0:
+                return InstallResult(
+                    success=False,
+                    error=(
+                        f"installer failed with code {result.returncode}:\n"
+                        f"{(result.stdout + result.stderr).strip()}\n"
+                        f"Retry manually: {manual_cmd}"
+                    ),
+                )
+
+            # `installer` can exit 0 while MDM or a blocked payload leaves nothing
+            # behind, so trust the probe rather than the exit code.
+            verify = self.check_installation()
+            if not verify.installed:
+                return InstallResult(
+                    success=False,
+                    error=(
+                        "installer reported success but Lemonade was not found "
+                        "afterwards (looked for lemond/lemonade in /usr/local/bin "
+                        "and /Applications/lemonade-app.app).\n"
+                        f"Probe error: {verify.error}\n"
+                        f"Try installing manually: {manual_cmd}"
+                    ),
+                )
+
+            installed_version = verify.version or self.target_version
+            return InstallResult(
+                success=True,
+                version=installed_version,
+                message=f"Installed Lemonade v{installed_version}",
+            )
+
+        except subprocess.TimeoutExpired:
+            return InstallResult(
+                success=False,
+                error=(
+                    "macOS installer timed out after 600s. "
+                    f"Retry manually: {manual_cmd}"
+                ),
+            )
+        except FileNotFoundError as e:
+            return InstallResult(
+                success=False, error=f"Required command not found: {e}"
+            )
+
+    @staticmethod
+    def _uninstall_macos() -> InstallResult:
+        """macOS: the upstream .pkg ships no uninstaller, so say so and hand over steps.
+
+        Paths and pkgutil identifiers come from the v11.5.0 .pkg BOMs.
+        """
+        return InstallResult(
+            success=False,
+            error=(
+                "Automatic uninstall is not supported on macOS — the Lemonade .pkg "
+                "ships no uninstaller. Remove it manually:\n"
+                "  sudo launchctl bootout system "
+                "/Library/LaunchDaemons/com.lemonade.server.plist\n"
+                "  sudo rm -f /Library/LaunchDaemons/com.lemonade.server.plist "
+                "/Library/LaunchAgents/com.lemonade.tray.plist\n"
+                "  sudo rm -rf /Applications/lemonade-app.app\n"
+                "  sudo rm -f /usr/local/bin/lemonade /usr/local/bin/lemond "
+                "/usr/local/bin/lemonade-tray\n"
+                "  pkgutil --pkgs | grep '^com.lemonade.server' | "
+                "xargs -n1 sudo pkgutil --forget"
+            ),
+        )
+
     @staticmethod
     def _check_linux_version() -> Optional[str]:
         """
@@ -729,7 +993,7 @@ class LemonadeInstaller:
 
     def is_platform_supported(self) -> bool:
         """Check if the current platform is supported for installation."""
-        return self.system in ("windows", "linux")
+        return self.system in ("windows", "linux", "darwin")
 
     def get_platform_name(self) -> str:
         """Get a friendly name for the current platform."""
@@ -757,6 +1021,8 @@ class LemonadeInstaller:
                 return self._uninstall_windows(silent)
             elif self.system == "linux":
                 return self._uninstall_linux()
+            elif self.system == "darwin":
+                return self._uninstall_macos()
             else:
                 return InstallResult(
                     success=False, error=f"Platform '{self.system}' is not supported"

--- a/tests/fixtures/lemonade_assets.py
+++ b/tests/fixtures/lemonade_assets.py
@@ -1,0 +1,46 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+"""Shared target matrix for the Lemonade installer asset tests.
+
+One table, two consumers — the hermetic shape tests
+(``tests/unit/test_lemonade_download_urls.py``) and the live resolution test
+(``tests/integration/test_lemonade_release_assets.py``) — so the pairs we
+assert on can never drift apart.
+"""
+
+from unittest.mock import patch
+
+from gaia.installer.lemonade_installer import LemonadeInstaller
+from gaia.version import LEMONADE_VERSION
+
+# (platform.system(), platform.machine(), minimal, expected asset filename)
+SUPPORTED_TARGETS = [
+    ("Windows", "AMD64", False, "lemonade.msi"),
+    ("Windows", "AMD64", True, "lemonade-server-minimal.msi"),
+    (
+        "Linux",
+        "x86_64",
+        False,
+        f"lemonade-server_{LEMONADE_VERSION}-debian13_amd64.deb",
+    ),
+    (
+        "Linux",
+        "aarch64",
+        False,
+        f"lemonade-server_{LEMONADE_VERSION}-debian13_arm64.deb",
+    ),
+    # Apple Silicon only — the .pkg payload is arm64, with no Intel build upstream.
+    ("Darwin", "arm64", False, f"Lemonade-{LEMONADE_VERSION}-Darwin.pkg"),
+]
+
+
+def make_installer(
+    system: str, machine: str, minimal: bool = False
+) -> LemonadeInstaller:
+    """Build an installer as if running on the given platform/architecture."""
+    with (
+        patch("platform.system", return_value=system),
+        patch("platform.machine", return_value=machine),
+    ):
+        return LemonadeInstaller(target_version=LEMONADE_VERSION, minimal=minimal)

--- a/tests/integration/test_lemonade_release_assets.py
+++ b/tests/integration/test_lemonade_release_assets.py
@@ -1,0 +1,74 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+"""Resolve the Lemonade installer URLs against the live upstream release.
+
+The unit tests assert URL *shape* with a mocked HTTP layer, which proves we
+built a string — not that GitHub will serve it. This test HEADs the real
+asset for every platform/arch pair at the pinned ``LEMONADE_VERSION``, so an
+upstream rename fails in CI instead of 404ing the first user whose install
+actually downloads the asset.
+
+Skips when GitHub is unreachable (offline dev box) or ``GAIA_SKIP_NETWORK_TESTS``
+is set. CI runners always have network, so it runs there.
+"""
+
+import os
+import urllib.error
+import urllib.request
+
+import pytest
+
+from gaia.version import LEMONADE_VERSION
+from tests.fixtures.lemonade_assets import SUPPORTED_TARGETS, make_installer
+
+
+def _github_reachable() -> bool:
+    request = urllib.request.Request(
+        "https://github.com",
+        method="HEAD",
+        headers={"User-Agent": "GAIA-Installer/1.0"},
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=10):
+            return True
+    except urllib.error.HTTPError:
+        return True  # Reached GitHub; the status code doesn't matter here.
+    except (urllib.error.URLError, TimeoutError):
+        return False
+
+
+@pytest.fixture(scope="module")
+def require_github_network():
+    """Skip offline, but never silently pass in CI — a blip there is a real signal."""
+    if os.environ.get("GAIA_SKIP_NETWORK_TESTS"):
+        pytest.skip("GAIA_SKIP_NETWORK_TESTS is set")
+    if not _github_reachable():
+        if os.environ.get("CI"):
+            pytest.fail("github.com unreachable in CI - cannot verify release assets")
+        pytest.skip("github.com unreachable - skipping live asset check")
+
+
+@pytest.mark.network
+def test_every_supported_target_resolves(require_github_network):
+    """Every installer URL GAIA can build must return HTTP 200 upstream."""
+    failures = []
+    for system, machine, minimal, expected_asset in SUPPORTED_TARGETS:
+        installer = make_installer(system, machine, minimal)
+        url = installer.get_download_url()
+        if not url.endswith(expected_asset):
+            failures.append(
+                f"{system}/{machine}: built {url}, expected {expected_asset}"
+            )
+            continue
+        try:
+            installer.verify_download_url(timeout=30)
+        except RuntimeError as e:
+            failures.append(f"{system}/{machine}: {e}")
+
+    assert not failures, (
+        f"Lemonade v{LEMONADE_VERSION} installer assets did not resolve upstream. "
+        "Upstream likely renamed an asset - check "
+        f"https://github.com/lemonade-sdk/lemonade/releases/tag/v{LEMONADE_VERSION}\n"
+        + "\n".join(failures)
+    )

--- a/tests/unit/test_init_command.py
+++ b/tests/unit/test_init_command.py
@@ -77,8 +77,15 @@ class TestLemonadeInstaller(unittest.TestCase):
 
     @patch("platform.system")
     def test_is_platform_supported_macos(self, mock_system):
-        """Test platform support on macOS (not supported)."""
+        """Test platform support on macOS."""
         mock_system.return_value = "Darwin"
+        installer = LemonadeInstaller()
+        self.assertTrue(installer.is_platform_supported())
+
+    @patch("platform.system")
+    def test_is_platform_supported_unknown(self, mock_system):
+        """Test platform support on an unsupported OS."""
+        mock_system.return_value = "FreeBSD"
         installer = LemonadeInstaller()
         self.assertFalse(installer.is_platform_supported())
 
@@ -94,7 +101,7 @@ class TestLemonadeInstaller(unittest.TestCase):
     @patch("platform.system")
     def test_get_download_url_unsupported(self, mock_system):
         """Test download URL raises error for unsupported platform."""
-        mock_system.return_value = "Darwin"
+        mock_system.return_value = "FreeBSD"
         installer = LemonadeInstaller(target_version="9.1.4")
         with self.assertRaises(RuntimeError) as ctx:
             installer.get_download_url()

--- a/tests/unit/test_lemonade_download_urls.py
+++ b/tests/unit/test_lemonade_download_urls.py
@@ -1,0 +1,172 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+"""Shape tests for the Lemonade installer download URLs.
+
+These are hermetic: they assert the URL/filename built for every (platform,
+arch) pair we claim to support, and that unsupported ones fail loudly. A
+mocked HTTP layer only proves we *called* something, so the companion test
+``tests/integration/test_lemonade_release_assets.py`` resolves the same URLs
+against the live upstream release — that is the one that catches an asset
+rename (the .deb gained a ``debian13`` infix and the old name now 404s).
+"""
+
+import urllib.error
+from unittest.mock import patch
+
+import pytest
+
+from gaia.installer.lemonade_installer import LemonadeAssetError
+from gaia.version import LEMONADE_VERSION
+from tests.fixtures.lemonade_assets import SUPPORTED_TARGETS
+from tests.fixtures.lemonade_assets import make_installer as _installer
+
+
+class TestDownloadUrlShape:
+    """The URL/filename we build for each supported target."""
+
+    @pytest.mark.parametrize(
+        "system,machine,minimal,expected_asset",
+        SUPPORTED_TARGETS,
+        ids=lambda v: str(v),
+    )
+    def test_url_ends_with_expected_asset(
+        self, system, machine, minimal, expected_asset
+    ):
+        installer = _installer(system, machine, minimal)
+        url = installer.get_download_url()
+        assert url == (
+            "https://github.com/lemonade-sdk/lemonade/releases/download/"
+            f"v{LEMONADE_VERSION}/{expected_asset}"
+        )
+
+    @pytest.mark.parametrize(
+        "system,machine,minimal,expected_asset",
+        SUPPORTED_TARGETS,
+        ids=lambda v: str(v),
+    )
+    def test_filename_matches_url_basename(
+        self, system, machine, minimal, expected_asset
+    ):
+        installer = _installer(system, machine, minimal)
+        assert installer.get_installer_filename() == expected_asset
+
+    def test_linux_deb_carries_distro_infix(self):
+        """Regression guard: the infix-less name 404s upstream."""
+        url = _installer("Linux", "x86_64").get_download_url()
+        assert "-debian13_amd64.deb" in url
+        assert f"lemonade-server_{LEMONADE_VERSION}_amd64.deb" not in url
+
+    def test_macos_yields_pkg(self):
+        url = _installer("Darwin", "arm64").get_download_url()
+        assert url.endswith(".pkg")
+
+    def test_intel_mac_raises_rather_than_installing_arm64_binaries(self):
+        """The .pkg payload is arm64-only and installs happily on Intel."""
+        installer = _installer("Darwin", "x86_64")
+        with pytest.raises(RuntimeError) as exc:
+            installer.get_download_url()
+        message = str(exc.value)
+        assert "x86_64" in message
+        assert "Apple-Silicon-only" in message
+
+    def test_unsupported_arch_raises_naming_the_arch(self):
+        installer = _installer("Linux", "armv7l")
+        with pytest.raises(RuntimeError) as exc:
+            installer.get_download_url()
+        message = str(exc.value)
+        assert "armv7l" in message
+        assert "amd64" in message and "arm64" in message
+        assert f"releases/tag/v{LEMONADE_VERSION}" in message
+
+    def test_unsupported_platform_raises(self):
+        installer = _installer("FreeBSD", "x86_64")
+        with pytest.raises(RuntimeError, match="not supported"):
+            installer.get_download_url()
+
+
+class TestVerifyDownloadUrl:
+    """verify_download_url turns an upstream rename into an actionable error."""
+
+    def test_404_raises_with_url_version_and_asset_list(self):
+        installer = _installer("Linux", "x86_64")
+        url = installer.get_download_url()
+        error = urllib.error.HTTPError(url, 404, "Not Found", {}, None)
+
+        with patch("urllib.request.urlopen", side_effect=error):
+            with pytest.raises(LemonadeAssetError) as exc:
+                installer.verify_download_url()
+
+        message = str(exc.value)
+        assert exc.value.definitive is True
+        assert url in message
+        assert LEMONADE_VERSION in message
+        assert f"releases/tag/v{LEMONADE_VERSION}" in message
+
+    def test_unreachable_host_blames_the_network_not_a_rename(self):
+        installer = _installer("Darwin", "arm64")
+        with patch(
+            "urllib.request.urlopen",
+            side_effect=urllib.error.URLError("nodename nor servname provided"),
+        ):
+            with pytest.raises(LemonadeAssetError) as exc:
+                installer.verify_download_url()
+
+        message = str(exc.value)
+        assert exc.value.definitive is False
+        assert installer.get_download_url() in message
+        assert "network" in message or "proxy" in message
+        assert "renamed" not in message
+
+    def test_timeout_is_wrapped_not_leaked(self):
+        installer = _installer("Linux", "x86_64")
+        with patch("urllib.request.urlopen", side_effect=TimeoutError()):
+            with pytest.raises(LemonadeAssetError) as exc:
+                installer.verify_download_url(timeout=1)
+        assert exc.value.definitive is False
+
+    def test_missing_asset_writes_nothing_to_disk(self, tmp_path):
+        """The 404 must stop the download before the file is created."""
+        installer = _installer("Linux", "x86_64")
+        url = installer.get_download_url()
+        error = urllib.error.HTTPError(url, 404, "Not Found", {}, None)
+
+        with patch("urllib.request.urlopen", side_effect=error):
+            with pytest.raises(LemonadeAssetError):
+                installer.download_installer(dest_dir=str(tmp_path))
+
+        assert list(tmp_path.iterdir()) == []
+
+    def test_head_rejection_falls_through_to_the_real_download(self, tmp_path):
+        """A proxy that 403s HEAD must not block a GET that would succeed."""
+        installer = _installer("Linux", "x86_64")
+        url = installer.get_download_url()
+        payload = b"deb-bytes"
+
+        class _Response:
+            headers = {"content-length": str(len(payload))}
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *exc):
+                return False
+
+            def read(self, _size):
+                nonlocal payload
+                chunk, payload = payload, b""
+                return chunk
+
+        calls = []
+
+        def _urlopen(request, timeout=None):
+            calls.append(request.get_method())
+            if request.get_method() == "HEAD":
+                raise urllib.error.HTTPError(url, 403, "Forbidden", {}, None)
+            return _Response()
+
+        with patch("urllib.request.urlopen", side_effect=_urlopen):
+            dest = installer.download_installer(dest_dir=str(tmp_path))
+
+        assert calls == ["HEAD", "GET"]
+        assert dest.read_bytes() == b"deb-bytes"

--- a/tests/unit/test_lemonade_macos_install.py
+++ b/tests/unit/test_lemonade_macos_install.py
@@ -1,0 +1,218 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+"""Control-flow tests for the macOS Lemonade install path.
+
+Nobody can run `installer -pkg … -target /` in CI, so these pin the parts a
+reviewer would otherwise have to take on faith: the exact argv, when sudo is
+prefixed, that the elevation warning is printed *before* sudo is invoked, and
+that every failure mode returns a loud InstallResult instead of a half-install.
+"""
+
+import subprocess
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from gaia.installer.lemonade_installer import LemonadeInfo
+from tests.fixtures.lemonade_assets import make_installer
+
+PKG = Path("/tmp/Lemonade-11.5.0-Darwin.pkg")
+
+
+def _completed(returncode=0, stdout="", stderr=""):
+    return subprocess.CompletedProcess(
+        args=[], returncode=returncode, stdout=stdout, stderr=stderr
+    )
+
+
+@pytest.fixture
+def installer():
+    return make_installer("Darwin", "arm64")
+
+
+@pytest.fixture(autouse=True)
+def _non_root():
+    """Pin euid — a root CI container would otherwise skip every sudo branch."""
+    with patch("os.geteuid", return_value=501):
+        yield
+
+
+@pytest.fixture
+def installed_ok():
+    """check_installation() reporting a healthy install."""
+    return LemonadeInfo(installed=True, version="11.5.0", path="/usr/local/bin/lemond")
+
+
+class TestSudoHandling:
+    def test_non_interactive_without_cached_sudo_refuses_before_installing(
+        self, installer
+    ):
+        """--yes must not hang on a hidden password prompt."""
+        with patch("subprocess.run", return_value=_completed(returncode=1)) as run:
+            result = installer._install_macos(PKG, non_interactive=True)
+
+        assert result.success is False
+        assert "sudo -v" in result.error
+        # Only the `sudo -n true` probe ran; installer was never invoked.
+        assert run.call_count == 1
+        assert run.call_args_list[0].args[0] == ["sudo", "-n", "true"]
+
+    def test_interactive_announces_elevation_before_invoking_sudo(
+        self, installer, installed_ok
+    ):
+        """The user is told sudo is coming — not surprised by a bare prompt."""
+        events = []
+
+        def _run(cmd, **_kwargs):
+            events.append(("run", cmd[0]))
+            return _completed(returncode=1 if cmd[:2] == ["sudo", "-n"] else 0)
+
+        with (
+            patch("subprocess.run", side_effect=_run),
+            patch.object(
+                type(installer),
+                "_announce",
+                lambda _self, msg: events.append(("announce", msg)),
+            ),
+            patch.object(
+                type(installer), "check_installation", return_value=installed_ok
+            ),
+        ):
+            result = installer._install_macos(PKG, non_interactive=False)
+
+        assert result.success is True
+        kinds = [kind for kind, _ in events]
+        announce_at = kinds.index("announce")
+        install_at = [
+            i for i, (k, v) in enumerate(events) if k == "run" and v == "sudo"
+        ][-1]
+        assert announce_at < install_at, f"warning must precede sudo: {events}"
+
+    def test_cached_sudo_skips_the_warning(self, installer, installed_ok):
+        """No prompt is coming, so don't cry wolf."""
+        announced = []
+        with (
+            patch("subprocess.run", return_value=_completed(0)),
+            patch.object(
+                type(installer), "_announce", lambda _self, msg: announced.append(msg)
+            ),
+            patch.object(
+                type(installer), "check_installation", return_value=installed_ok
+            ),
+        ):
+            installer._install_macos(PKG, non_interactive=False)
+
+        assert announced == []
+
+    def test_root_does_not_prefix_sudo(self, installer, installed_ok):
+        with (
+            patch("os.geteuid", return_value=0),
+            patch("subprocess.run", return_value=_completed(0)) as run,
+            patch.object(
+                type(installer), "check_installation", return_value=installed_ok
+            ),
+        ):
+            installer._install_macos(PKG, non_interactive=False)
+
+        assert run.call_count == 1  # no sudo probe needed
+        assert run.call_args_list[0].args[0] == [
+            "installer",
+            "-pkg",
+            str(PKG),
+            "-target",
+            "/",
+        ]
+
+
+class TestInstallerInvocation:
+    def test_argv_shape_matches_installer_8(self, installer, installed_ok):
+        """`installer -pkg <path> -target /` — order matters to installer(8)."""
+        with (
+            patch("subprocess.run", return_value=_completed(0)) as run,
+            patch.object(
+                type(installer), "check_installation", return_value=installed_ok
+            ),
+        ):
+            installer._install_macos(PKG, non_interactive=False)
+
+        argv = run.call_args_list[-1].args[0]
+        assert argv == ["sudo", "installer", "-pkg", str(PKG), "-target", "/"]
+
+    def test_nonzero_exit_surfaces_output_and_manual_command(self, installer):
+        def _run(cmd, **_kwargs):
+            if cmd[:2] == ["sudo", "-n"]:
+                return _completed(0)
+            return _completed(returncode=1, stderr="installer: Package Authoring Error")
+
+        with patch("subprocess.run", side_effect=_run):
+            result = installer._install_macos(PKG, non_interactive=False)
+
+        assert result.success is False
+        assert "Package Authoring Error" in result.error
+        assert "sudo installer -pkg" in result.error
+
+    def test_exit_zero_but_nothing_installed_is_a_failure(self, installer):
+        """installer(8) can exit 0 under MDM while installing nothing."""
+        missing = LemonadeInfo(installed=False, error="not found")
+        with (
+            patch("subprocess.run", return_value=_completed(0)),
+            patch.object(type(installer), "check_installation", return_value=missing),
+        ):
+            result = installer._install_macos(PKG, non_interactive=False)
+
+        assert result.success is False
+        assert "installer reported success but Lemonade was not found" in result.error
+
+    def test_success_reports_the_probed_version_not_the_target(self, installer):
+        probed = LemonadeInfo(
+            installed=True, version="11.4.0", path="/usr/local/bin/lemond"
+        )
+        with (
+            patch("subprocess.run", return_value=_completed(0)),
+            patch.object(type(installer), "check_installation", return_value=probed),
+        ):
+            result = installer._install_macos(PKG, non_interactive=False)
+
+        assert result.success is True
+        assert result.version == "11.4.0"
+
+    def test_ctrl_c_at_the_prompt_is_a_clean_cancel(self, installer):
+        """KeyboardInterrupt is BaseException — it must not escape as a traceback."""
+        with patch("subprocess.run", side_effect=KeyboardInterrupt()):
+            result = installer._install_macos(PKG, non_interactive=False)
+
+        assert result.success is False
+        assert "cancelled" in result.error.lower()
+
+    def test_timeout_is_reported_with_a_retry_command(self, installer):
+        with patch(
+            "subprocess.run",
+            side_effect=subprocess.TimeoutExpired(cmd="installer", timeout=600),
+        ):
+            result = installer._install_macos(PKG, non_interactive=False)
+
+        assert result.success is False
+        assert "timed out" in result.error
+        assert "sudo installer -pkg" in result.error
+
+
+class TestInstallRouting:
+    def test_darwin_routes_to_macos_installer(self, installer):
+        with (
+            patch.object(
+                type(installer), "_install_macos", return_value=MagicMock(success=True)
+            ) as macos,
+            patch.object(Path, "exists", return_value=True),
+        ):
+            installer.install(PKG, silent=False)
+        macos.assert_called_once()
+
+    def test_missing_pkg_fails_before_invoking_installer(self, installer):
+        with patch("subprocess.run") as run:
+            result = installer.install(Path("/tmp/nope.pkg"), silent=True)
+
+        assert result.success is False
+        assert "Installer not found" in result.error
+        run.assert_not_called()

--- a/util/check_doc_versions.py
+++ b/util/check_doc_versions.py
@@ -118,9 +118,10 @@ def build_lemonade_patterns(version: str) -> list[tuple[str, str]]:
             rf"lemonade(?:-sdk)?/lemonade/releases/download/v(?P<version>{semver})/",
             "Lemonade GitHub release URL",
         ),
-        # Filenames: lemonade-server-minimal.msi or lemonade-server_<VERSION>_amd64.deb
+        # Filenames: lemonade-server_<VERSION>-<distro>_<arch>.deb (distro infix optional
+        # so pre-rename references are still version-checked)
         (
-            rf"lemonade(?:-server)?_(?P<version>{semver})_amd64\.deb",
+            rf"lemonade(?:-server)?_(?P<version>{semver})(?:-[a-z0-9]+)?_(?:amd64|arm64)\.deb",
             "Lemonade .deb filename",
         ),
         # Release page links: releases/tag/v<VERSION>


### PR DESCRIPTION
GAIA builds a Lemonade installer URL that no longer exists: upstream renamed the Linux `.deb` to carry a distro infix, so the `lemonade-server_11.5.0_amd64.deb` we construct returns 404 (the real asset is `lemonade-server_11.5.0-debian13_amd64.deb`). Nothing in the CLI reaches that path today — Linux installs have gone through the PPA since #910 — but it is public API with nothing verifying it, and the same code had no macOS branch at all even though upstream ships a `.pkg`, and no arm64 branch even though upstream ships an arm64 `.deb`. After this, every URL GAIA can build resolves, macOS on Apple Silicon installs via `installer -pkg` with the sudo requirement stated before any prompt appears, and the next upstream rename surfaces as an error naming the URL and the asset list instead of a 404 mid-download.

Verified against the live `v11.5.0` release:

| Platform | Arch | Asset | HTTP |
|---|---|---|---|
| linux | x86_64 | `lemonade-server_11.5.0_amd64.deb` *(before this PR)* | **404** |
| linux | x86_64 | `lemonade-server_11.5.0-debian13_amd64.deb` | 200 |
| linux | aarch64 | `lemonade-server_11.5.0-debian13_arm64.deb` | 200 |
| darwin | arm64 | `Lemonade-11.5.0-Darwin.pkg` | 200 |
| windows | AMD64 | `lemonade.msi` | 200 |
| windows | AMD64 | `lemonade-server-minimal.msi` | 200 |

Intel Macs are rejected rather than served that `.pkg` — its payload binaries are arm64-only (`lipo -archs /usr/local/bin/lemond` → `arm64`) but it installs happily on Intel, so an unguarded install would exit 0 and only fail later at "Bad CPU type in executable".

## Not yet proven on hardware

The `-debian13` infix is still a hardcoded assumption, just a verified one. Three claims here rest on asset resolution and mocked control flow, not on a completed install:

- **No macOS install has ever been executed.** The `.pkg` URL resolves and the `installer -pkg <path> -target /` argv is pinned by unit tests, but nobody has run it to completion. First Mac install is unproven.
- **No Linux arm64 install has ever been executed.** The arm64 `.deb` resolves; the PPA path that Linux actually uses is unchanged by this PR.
- **The macOS uninstall text is derived from the v11.5.0 `.pkg` BOMs**, not from running the removal steps.

What *is* guarded: `tests/integration/test_lemonade_release_assets.py` HEADs every URL this code can build and runs in CI as its own step in `test_unit.yml` (triggered by `src/**`/`tests/**`, so a `LEMONADE_VERSION` bump fires it). It skips with `GAIA_SKIP_NETWORK_TESTS=1` or when offline, but **fails rather than skips when `CI` is set**, so a network blip cannot pass silently. Verified it catches a hypothetical future rename by pointing the builder at `debian14`/`ubuntu2404` and at a renamed macOS asset — all three raised with `definitive=True`.

## Test plan

- [ ] `pytest tests/unit/test_lemonade_download_urls.py -v` — URL/filename shape for every supported (platform, arch) pair; unsupported arch, Intel Mac, and unsupported OS each raise; a 404 writes nothing to disk; a HEAD-rejecting proxy still falls through to a working GET
- [ ] `pytest tests/unit/test_lemonade_macos_install.py -v` — installer(8) argv, sudo prefixing, elevation warning ordering, Ctrl-C cancel, exit-0-but-nothing-installed, timeout
- [ ] `pytest tests/integration/test_lemonade_release_assets.py -v` — HEADs every constructed URL against the live release; the test that would have caught the rename
- [ ] `pytest tests/unit/ -k "lemonade or installer"` — 440 passed (2 unrelated `test_hub_installer.py` failures reproduce on `main`; they need `pip`/`uv` in the venv)
- [ ] `python util/lint.py --black --isort` and `python util/check_doc_versions.py`
- [ ] On a real Apple Silicon Mac: `gaia init` end to end, confirm the sudo warning appears *before* the password prompt and that `lemonade-server` is usable afterwards