### PR TITLE
fix(website): reach the hero terminal, marquee, and code blocks by keyboard

### DIFF
--- a/website/src/components/CodePanel.astro
+++ b/website/src/components/CodePanel.astro
@@ -34,5 +34,14 @@ const code = lines
   ]}
 >
   <div class="mono border-b border-g-border px-3.5 py-2.5 text-[11.5px] text-g-code-faint">{title}</div>
-  <pre class="mono m-0 overflow-x-auto px-[18px] py-4 text-[12.5px] leading-[1.75] text-g-code-text" set:html={code} />
+  {/* Focusable because it scrolls horizontally. role="group" rather than
+      "region" so N panels on a page don't become N landmarks; group still
+      carries the name a focusable scroll container needs. */}
+  <pre
+    tabindex="0"
+    role="group"
+    aria-label={title}
+    class="mono m-0 overflow-x-auto px-[18px] py-4 text-[12.5px] leading-[1.75] text-g-code-text"
+    set:html={code}
+  />
 </div>

--- a/website/src/components/Footer.astro
+++ b/website/src/components/Footer.astro
@@ -26,7 +26,7 @@ const LINKS = [
       </p>
     </div>
 
-    <nav class="flex flex-wrap gap-x-7 gap-y-2">
+    <nav aria-label="Footer" class="flex flex-wrap gap-x-7 gap-y-2">
       {LINKS.map((l) => (
         <a
           href={l.href}

--- a/website/src/components/Header.astro
+++ b/website/src/components/Header.astro
@@ -24,7 +24,7 @@ const NAV = [
   class="fixed inset-x-0 top-0 z-50 border-b border-g-border bg-g-hdr"
   style="backdrop-filter: blur(14px); -webkit-backdrop-filter: blur(14px);"
 >
-  <nav class="g-shell flex h-[66px] items-center justify-between">
+  <nav aria-label="Main" class="g-shell flex h-[66px] items-center justify-between">
     <!-- Wordmark -->
     <a href="/" class="flex items-baseline gap-2">
       <span class="font-display text-[18px] font-semibold tracking-[-0.02em] text-g-text">GAIA</span>

--- a/website/src/components/InstallMethods.astro
+++ b/website/src/components/InstallMethods.astro
@@ -15,12 +15,17 @@ interface Props {
 
 const { agent } = Astro.props;
 const methods = installMethods(agent);
+
+// The tablist is only rendered for 2+ methods, so the panel roles have to be
+// gated on the same condition — a lone role="tabpanel" with an
+// aria-labelledby pointing at a tab that was never rendered is a broken widget.
+const hasTabs = methods.length > 1;
 ---
 
 <div data-install-methods>
   {/* The switcher only makes sense with 2+ methods. A single-method agent (e.g.
       an npm-only sidecar) just shows its command — no lone, inert tab button. */}
-  {methods.length > 1 && (
+  {hasTabs && (
     <div
       role="tablist"
       aria-label={`How to install ${agent.name}`}
@@ -45,9 +50,9 @@ const methods = installMethods(agent);
 
   {methods.map((m, i) => (
     <div
-      role="tabpanel"
+      role={hasTabs ? 'tabpanel' : undefined}
       id={`im-panel-${m.key}`}
-      aria-labelledby={`im-tab-${m.key}`}
+      aria-labelledby={hasTabs ? `im-tab-${m.key}` : undefined}
       data-im-panel={m.key}
       hidden={i !== 0}
     >
@@ -55,7 +60,9 @@ const methods = installMethods(agent);
           the controls inside them key off g-code-text rather than the page palette. */}
       <div class="g-cmd gap-2.5 px-4 py-3.5 text-[13px]">
         <span class="select-none text-g-gold" aria-hidden="true">$</span>
-        <code class="min-w-0 flex-1 overflow-x-auto whitespace-pre bg-transparent p-0">{m.command}</code>
+        {/* Focusable: it scrolls horizontally at narrow widths, and a scroll
+            region no keyboard user can reach hides the tail of the command. */}
+        <code tabindex="0" class="min-w-0 flex-1 overflow-x-auto whitespace-pre bg-transparent p-0">{m.command}</code>
         <button
           type="button"
           data-im-copy={m.command}
@@ -65,6 +72,9 @@ const methods = installMethods(agent);
           <span class="im-copy-label select-none">copy</span>
         </button>
       </div>
+      {/* The button keeps a stable name (it has to say WHICH command it copies),
+          so the outcome is announced here instead. */}
+      <p class="im-copy-status sr-only" role="status"></p>
       {m.note && <p class="mt-2 text-[12.5px] text-g-faint">{m.note}</p>}
     </div>
   ))}
@@ -100,6 +110,10 @@ const methods = installMethods(agent);
 
     root.querySelectorAll<HTMLButtonElement>('.im-copy').forEach((btn) => {
       let revert: number | undefined;
+      const status = btn.closest('[data-im-panel]')?.querySelector('.im-copy-status');
+      const announce = (msg: string) => {
+        if (status) status.textContent = msg;
+      };
       btn.addEventListener('click', async () => {
         const label = btn.querySelector('.im-copy-label');
         try {
@@ -117,14 +131,22 @@ const methods = installMethods(agent);
             sel?.removeAllRanges();
             sel?.addRange(range);
           }
+          announce('Copying was blocked. The command is selected — press Control or Command + C to copy it.');
           clearTimeout(revert);
-          revert = window.setTimeout(() => { if (label) label.textContent = 'copy'; }, 2600);
+          revert = window.setTimeout(() => {
+            if (label) label.textContent = 'copy';
+            announce('');
+          }, 2600);
           return;
         }
+        announce('Install command copied to the clipboard.');
         if (!label) return;
         label.textContent = 'copied';
         clearTimeout(revert);
-        revert = window.setTimeout(() => (label.textContent = 'copy'), 1600);
+        revert = window.setTimeout(() => {
+          label.textContent = 'copy';
+          announce('');
+        }, 1600);
       });
     });
   });

--- a/website/src/components/InstallMethods.astro
+++ b/website/src/components/InstallMethods.astro
@@ -72,12 +72,16 @@ const hasTabs = methods.length > 1;
           <span class="im-copy-label select-none">copy</span>
         </button>
       </div>
-      {/* The button keeps a stable name (it has to say WHICH command it copies),
-          so the outcome is announced here instead. */}
-      <p class="im-copy-status sr-only" role="status"></p>
       {m.note && <p class="mt-2 text-[12.5px] text-g-faint">{m.note}</p>}
     </div>
   ))}
+
+  {/* One status node for the whole switcher, outside the panels: the copy
+      button keeps a stable name (it has to say WHICH command it copies), so the
+      outcome is announced here — and a live region inside a `hidden` panel is
+      not in the a11y tree until its tab is selected, which makes the first
+      announcement after a tab switch unreliable. */}
+  <p class="im-copy-status sr-only" role="status"></p>
 </div>
 
 <script>
@@ -108,12 +112,18 @@ const hasTabs = methods.length > 1;
       });
     });
 
+    // One status node shared by every method's copy button. Clear then re-assert
+    // next frame: copying twice writes the same string, and an unchanged live
+    // region is not reliably re-announced — so the second copy would be silent.
+    const status = root.querySelector('.im-copy-status');
+    const announce = (msg: string) => {
+      if (!status) return;
+      status.textContent = '';
+      if (msg) requestAnimationFrame(() => { status.textContent = msg; });
+    };
+
     root.querySelectorAll<HTMLButtonElement>('.im-copy').forEach((btn) => {
       let revert: number | undefined;
-      const status = btn.closest('[data-im-panel]')?.querySelector('.im-copy-status');
-      const announce = (msg: string) => {
-        if (status) status.textContent = msg;
-      };
       btn.addEventListener('click', async () => {
         const label = btn.querySelector('.im-copy-label');
         try {

--- a/website/src/components/Marquee.astro
+++ b/website/src/components/Marquee.astro
@@ -6,6 +6,10 @@
 // keyframe loops seamlessly; the second copy is decorative and hidden from
 // assistive tech. The .g-marquee-track hook is what tokens.css stops under
 // prefers-reduced-motion (the strip has no static resting state).
+//
+// Because a stopped track would leave everything past the wrapper's right edge
+// unreachable, reduced motion also reflows it into a wrapped list — see the
+// scoped style block below. Removing the motion must not remove the content.
 
 interface Props {
   items: string[];
@@ -19,23 +23,43 @@ const MASK = 'linear-gradient(90deg, transparent, #000 8%, #000 92%, transparent
 ---
 
 <div
-  class:list={['overflow-hidden border-y border-g-border', className]}
+  class:list={['g-marquee overflow-hidden border-y border-g-border', className]}
   style={`-webkit-mask-image:${MASK}; mask-image:${MASK};`}
 >
   <div class="g-marquee-track flex w-max animate-g-marquee">
-    <ul class="flex" aria-label={label}>
-      {items.map((item) => (
-        <li class="mono inline-flex items-center gap-2.5 whitespace-nowrap px-[26px] py-[15px] text-[12.5px] text-g-muted">
-          <span class="text-g-gold-text" aria-hidden="true">▹</span>{item}
-        </li>
-      ))}
-    </ul>
-    <ul class="flex" aria-hidden="true">
-      {items.map((item) => (
-        <li class="mono inline-flex items-center gap-2.5 whitespace-nowrap px-[26px] py-[15px] text-[12.5px] text-g-muted">
-          <span class="text-g-gold-text" aria-hidden="true">▹</span>{item}
-        </li>
-      ))}
-    </ul>
+    {/* Copy 0 carries the content; copy 1 exists only to make -50% seamless. */}
+    {[0, 1].map((copy) => (
+      <ul class="flex" aria-label={copy === 0 ? label : undefined} aria-hidden={copy === 1 ? 'true' : undefined} data-marquee-copy={copy}>
+        {items.map((item) => (
+          <li class="mono inline-flex items-center gap-2.5 whitespace-nowrap px-[26px] py-[15px] text-[12.5px] text-g-muted">
+            <span class="text-g-gold-text" aria-hidden="true">▹</span>{item}
+          </li>
+        ))}
+      </ul>
+    ))}
   </div>
 </div>
+
+<style>
+  /* Reduced motion stops the track (tokens.css), which would clip everything
+     past the wrapper. Reflow into a full-width wrapped list instead, drop the
+     duplicate copy, and clear the edge-fade mask so no item is faded out. */
+  @media (prefers-reduced-motion: reduce) {
+    .g-marquee {
+      -webkit-mask-image: none !important;
+      mask-image: none !important;
+    }
+    .g-marquee-track {
+      width: 100%;
+      flex-wrap: wrap;
+      justify-content: center;
+    }
+    .g-marquee-track > ul {
+      flex-wrap: wrap;
+      justify-content: center;
+    }
+    .g-marquee-track > [data-marquee-copy='1'] {
+      display: none;
+    }
+  }
+</style>

--- a/website/src/components/Terminal.astro
+++ b/website/src/components/Terminal.astro
@@ -82,7 +82,7 @@ const transcript = `${LINES.map(renderLine).join('<br>')}<span class="tok-key" a
     data-lines={JSON.stringify(LINES)}
     tabindex="0"
     role="region"
-    aria-label="Illustrative terminal session: the email agent triages an inbox on-device. A scripted demo, not captured output."
+    aria-label="Illustrative terminal session — a scripted email-triage demo, not captured output."
     class="mono h-[268px] overflow-y-auto px-[18px] pb-[22px] pt-[18px] text-[13px] leading-[1.85] text-g-code-text"
     set:html={transcript}
   />

--- a/website/src/components/Terminal.astro
+++ b/website/src/components/Terminal.astro
@@ -54,7 +54,9 @@ const renderLine = (segments: Segment[]) => {
     .join('');
 };
 
-const transcript = `${LINES.map(renderLine).join('<br>')}<span class="tok-key">â–Š</span>`;
+// The cursor is aria-hidden: now that the transcript is exposed to assistive
+// tech, a block glyph read as "â–Š" is noise. Kept in sync with paint() below.
+const transcript = `${LINES.map(renderLine).join('<br>')}<span class="tok-key" aria-hidden="true">â–Š</span>`;
 ---
 
 <div
@@ -71,11 +73,16 @@ const transcript = `${LINES.map(renderLine).join('<br>')}<span class="tok-key">â
     <span class="mono ml-auto rounded-g-badge border border-g-gold-dim px-1.5 py-0.5 text-[10px] uppercase tracking-[0.08em] text-g-gold">local</span>
   </div>
 
+  {/* The box scrolls (the transcript is taller than 268px, much taller when it
+      wraps on a phone), so it must be focusable to be keyboard-scrollable â€” and
+      it must not be role="img", which would hide the transcript, including the
+      "no email content left the device" payoff, from assistive tech. */}
   <div
     data-terminal
     data-lines={JSON.stringify(LINES)}
-    role="img"
-    aria-label="Illustrative terminal session: the email agent triages an inbox on-device."
+    tabindex="0"
+    role="region"
+    aria-label="Illustrative terminal session: the email agent triages an inbox on-device. A scripted demo, not captured output."
     class="mono h-[268px] overflow-y-auto px-[18px] pb-[22px] pt-[18px] text-[13px] leading-[1.85] text-g-code-text"
     set:html={transcript}
   />
@@ -99,6 +106,11 @@ const transcript = `${LINES.map(renderLine).join('<br>')}<span class="tok-key">â
     const lines: Segment[][] = JSON.parse(el.dataset.lines || '[]');
     if (!lines.length) return;
 
+    // The server-rendered transcript, complete. Restored the moment the region
+    // takes focus so a keyboard or screen-reader user reads the whole session
+    // instead of whatever prefix the loop happens to be on.
+    const fullHtml = el.innerHTML;
+
     let lineIdx = 0;
     let segIdx = 0;
     let charIdx = 0;
@@ -112,7 +124,7 @@ const transcript = `${LINES.map(renderLine).join('<br>')}<span class="tok-key">â
     };
 
     const paint = () => {
-      el.innerHTML = `${built}<span class="tok-key">â–Š</span>`;
+      el.innerHTML = `${built}<span class="tok-key" aria-hidden="true">â–Š</span>`;
       el.scrollTop = el.scrollHeight;
     };
 
@@ -164,6 +176,14 @@ const transcript = `${LINES.map(renderLine).join('<br>')}<span class="tok-key">â
     built = '';
     paint();
     timer = window.setTimeout(tick, 600);
+
+    el.addEventListener('focus', () => {
+      // Keyboard visits only â€” a stray mouse click must not kill the demo.
+      if (!el.matches(':focus-visible')) return;
+      clearTimeout(timer);
+      el.innerHTML = fullHtml;
+      el.scrollTop = 0;
+    });
 
     window.addEventListener('pagehide', () => clearTimeout(timer));
   });

--- a/website/src/components/ThemeToggle.astro
+++ b/website/src/components/ThemeToggle.astro
@@ -1,27 +1,35 @@
 ---
 // Copyright(C) 2024-2026 Advanced Micro Devices, Inc. All rights reserved.
 // SPDX-License-Identifier: MIT
+
+// Which icon shows is driven by html[data-theme], which Layout.astro sets
+// pre-paint — so the button is never an empty box, even if this component's
+// script never runs. aria-pressed is added by the script, because without it
+// the button doesn't toggle anything and claiming a state would be a lie.
 ---
 <button
   id="theme-toggle"
   type="button"
-  aria-label="Toggle color theme"
+  aria-label="Dark theme"
   class="rounded-g-btn border border-transparent p-2 text-g-muted transition-colors hover:border-g-border hover:text-g-text"
 >
-  <!-- sun (shown in dark mode) -->
-  <svg data-icon="sun" class="w-4 h-4 hidden" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" aria-hidden="true"><circle cx="12" cy="12" r="4"/><path d="M12 2v2m0 16v2M4.93 4.93l1.41 1.41m11.32 11.32 1.41 1.41M2 12h2m16 0h2M4.93 19.07l1.41-1.41M17.66 6.34l1.41-1.41"/></svg>
-  <!-- moon (shown in light mode) -->
-  <svg data-icon="moon" class="w-4 h-4 hidden" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" aria-hidden="true"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg>
+  <svg data-icon="sun" class="w-4 h-4" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" aria-hidden="true"><circle cx="12" cy="12" r="4"/><path d="M12 2v2m0 16v2M4.93 4.93l1.41 1.41m11.32 11.32 1.41 1.41M2 12h2m16 0h2M4.93 19.07l1.41-1.41M17.66 6.34l1.41-1.41"/></svg>
+  <svg data-icon="moon" class="w-4 h-4" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" aria-hidden="true"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg>
 </button>
+
+<style>
+  /* Sun in dark mode, moon otherwise — including when data-theme is absent, so
+     one icon is always painted. */
+  :global(html[data-theme='dark']) #theme-toggle [data-icon='moon'],
+  :global(html:not([data-theme='dark'])) #theme-toggle [data-icon='sun'] {
+    display: none;
+  }
+</style>
 
 <script>
   const btn = document.getElementById('theme-toggle')!;
-  const sun = btn.querySelector('[data-icon="sun"]')!;
-  const moon = btn.querySelector('[data-icon="moon"]')!;
   const render = () => {
-    const dark = document.documentElement.dataset.theme === 'dark';
-    sun.classList.toggle('hidden', !dark);
-    moon.classList.toggle('hidden', dark);
+    btn.setAttribute('aria-pressed', String(document.documentElement.dataset.theme === 'dark'));
   };
   btn.addEventListener('click', () => {
     const next = document.documentElement.dataset.theme === 'dark' ? 'light' : 'dark';

--- a/website/src/components/WayCard.astro
+++ b/website/src/components/WayCard.astro
@@ -34,7 +34,9 @@ const { n, icon, who, title, body, code, cta, href, external = false } = Astro.p
   <h3 class="g-h-card">{title}</h3>
   <p class="g-body mb-5 mt-2.5">{body}</p>
 
-  <div class="g-cmd-plain mt-auto overflow-x-auto text-[12px]">
+  {/* Focusable: the command overflows at narrow widths, and a scroll region no
+      keyboard user can reach hides the tail of it. */}
+  <div tabindex="0" class="g-cmd-plain mt-auto overflow-x-auto text-[12px]">
     <span class="text-g-gold" aria-hidden="true">$</span>
     <span class="whitespace-nowrap">{code}</span>
   </div>

--- a/website/src/pages/hub/[id].astro
+++ b/website/src/pages/hub/[id].astro
@@ -204,7 +204,7 @@ const requirementRows = [
           {hasTabs && <DocTabs tabs={docTabs} label={`${agent.name} documentation`} />}
 
           <div class="px-6 py-7">
-            <article
+            <div
               role={hasTabs ? 'tabpanel' : undefined}
               aria-labelledby={hasTabs ? 'doctab-readme' : undefined}
               id="docpanel-readme"
@@ -213,34 +213,34 @@ const requirementRows = [
             >
               <h2 class="sr-only">About {agent.name}</h2>
               <div set:html={readmeHtml} />
-            </article>
+            </div>
             {specHtml && (
-              <article role="tabpanel" id="docpanel-spec" aria-labelledby="doctab-spec" data-doc-panel="spec" class="doc max-w-[70ch]" hidden>
+              <div role="tabpanel" id="docpanel-spec" aria-labelledby="doctab-spec" data-doc-panel="spec" class="doc max-w-[70ch]" hidden>
                 <div set:html={specHtml} />
-              </article>
+              </div>
             )}
             {skillHtml && (
-              <article role="tabpanel" id="docpanel-skill" aria-labelledby="doctab-skill" data-doc-panel="skill" class="doc max-w-[70ch]" hidden>
+              <div role="tabpanel" id="docpanel-skill" aria-labelledby="doctab-skill" data-doc-panel="skill" class="doc max-w-[70ch]" hidden>
                 <div set:html={skillHtml} />
-              </article>
+              </div>
             )}
             {evaluationHtml && (
-              <article role="tabpanel" id="docpanel-evaluation" aria-labelledby="doctab-evaluation" data-doc-panel="evaluation" class="doc max-w-[70ch]" hidden>
+              <div role="tabpanel" id="docpanel-evaluation" aria-labelledby="doctab-evaluation" data-doc-panel="evaluation" class="doc max-w-[70ch]" hidden>
                 <div set:html={evaluationHtml} />
-              </article>
+              </div>
             )}
             {capabilityMatrixHtml && (
-              <article role="tabpanel" id="docpanel-capability_matrix" aria-labelledby="doctab-capability_matrix" data-doc-panel="capability_matrix" class="doc max-w-[70ch]" hidden>
+              <div role="tabpanel" id="docpanel-capability_matrix" aria-labelledby="doctab-capability_matrix" data-doc-panel="capability_matrix" class="doc max-w-[70ch]" hidden>
                 <div set:html={capabilityMatrixHtml} />
-              </article>
+              </div>
             )}
             {changelogHtml && (
-              <article role="tabpanel" id="docpanel-changelog" aria-labelledby="doctab-changelog" data-doc-panel="changelog" class="doc max-w-[70ch]" hidden>
+              <div role="tabpanel" id="docpanel-changelog" aria-labelledby="doctab-changelog" data-doc-panel="changelog" class="doc max-w-[70ch]" hidden>
                 <div set:html={changelogHtml} />
-              </article>
+              </div>
             )}
             {scorecardHtml && (
-              <article role="tabpanel" id="docpanel-scorecard" aria-labelledby="doctab-scorecard" data-doc-panel="scorecard" class="doc max-w-[70ch]" hidden>
+              <div role="tabpanel" id="docpanel-scorecard" aria-labelledby="doctab-scorecard" data-doc-panel="scorecard" class="doc max-w-[70ch]" hidden>
                 {agent.eval_scorecard_url && (
                   <p class="text-[13px] text-g-faint">
                     {hasScore && <span>Aggregate score <strong class="text-g-text">{scoreDisplay} / 100</strong>. </span>}
@@ -248,7 +248,7 @@ const requirementRows = [
                   </p>
                 )}
                 <div set:html={scorecardHtml} />
-              </article>
+              </div>
             )}
             {packageFiles.length > 0 && (
               <section role="tabpanel" id="docpanel-files" aria-labelledby="doctab-files" data-doc-panel="files" hidden>

--- a/website/src/pages/hub/[id].astro
+++ b/website/src/pages/hub/[id].astro
@@ -330,20 +330,25 @@ const requirementRows = [
                 class="g-cmd pg-copy group mt-2.5 w-full border-g-border text-left transition-colors hover:border-g-gold-dim"
               >
                 <span class="select-none text-g-gold" aria-hidden="true">$</span>
-                <span class="min-w-0 flex-1 truncate">npx {agent.npm_package} playground</span>
+                <span data-pg-cmd class="min-w-0 flex-1 truncate">npx {agent.npm_package} playground</span>
                 <span class="pg-copy-label flex-none select-none text-[11px] text-g-code-text/70 group-hover:text-g-gold">copy</span>
               </button>
+              <p data-pg-copy-status class="sr-only" role="status"></p>
               <a
                 href={agent.playground_url}
                 target="_blank"
                 rel="noopener"
                 data-pg-open
                 aria-disabled="true"
+                aria-describedby="pg-status"
                 class="mt-2.5 flex items-center justify-center rounded-g-btn border border-g-border px-4 py-2 text-[13px] font-medium text-g-faint transition-colors"
               >
                 Open playground
               </a>
-              <p data-pg-status class="mt-2.5 text-[11px] text-g-faint">Checking if it's running…</p>
+              {/* role="status": the sidecar coming up, and a blocked click, are
+                  both silent otherwise. aria-describedby ties the reason the
+                  link is disabled to the link itself. */}
+              <p id="pg-status" data-pg-status role="status" class="mt-2.5 text-[11px] text-g-faint">Checking if it's running…</p>
             </SidebarCard>
           </div>
         )}
@@ -495,25 +500,36 @@ const requirementRows = [
   const pg = document.querySelector('[data-playground]');
   if (pg) {
     const copyBtn = pg.querySelector<HTMLButtonElement>('[data-pg-copy]');
+    const copyStatus = pg.querySelector<HTMLElement>('[data-pg-copy-status]');
     let revert: number | undefined;
     copyBtn?.addEventListener('click', async () => {
+      const label = copyBtn.querySelector('.pg-copy-label');
+      const reset = (ms: number) => {
+        clearTimeout(revert);
+        revert = window.setTimeout(() => {
+          if (label) label.textContent = 'copy';
+          if (copyStatus) copyStatus.textContent = '';
+        }, ms);
+      };
       try {
         await navigator.clipboard.writeText(copyBtn.dataset.pgCopy || '');
-        const label = copyBtn.querySelector('.pg-copy-label');
-        if (label) {
-          label.textContent = 'copied';
-          clearTimeout(revert);
-          revert = window.setTimeout(() => (label.textContent = 'copy'), 1600);
-        }
+        if (label) label.textContent = 'copied';
+        if (copyStatus) copyStatus.textContent = 'Command copied to the clipboard.';
+        reset(1600);
       } catch {
-        // Same non-secure-origin / permission case as InstallMethods: tell the
-        // user instead of leaving them to paste stale clipboard contents.
-        const label = copyBtn.querySelector('.pg-copy-label');
-        if (label) {
-          label.textContent = 'select & copy';
-          clearTimeout(revert);
-          revert = window.setTimeout(() => (label.textContent = 'copy'), 2600);
+        // Same non-secure-origin / permission case as InstallMethods: select the
+        // command so "select & copy" is an instruction the page has honoured.
+        if (label) label.textContent = 'select & copy';
+        const cmd = copyBtn.querySelector('[data-pg-cmd]');
+        if (cmd) {
+          const range = document.createRange();
+          range.selectNodeContents(cmd);
+          const sel = getSelection();
+          sel?.removeAllRanges();
+          sel?.addRange(range);
         }
+        if (copyStatus) copyStatus.textContent = 'Copying was blocked. The command is selected — press Control or Command + C to copy it.';
+        reset(2600);
       }
     });
 
@@ -523,7 +539,19 @@ const requirementRows = [
     let healthUrl = '';
     try { healthUrl = new URL(pgUrl).origin + '/health'; } catch { /* invalid */ }
 
-    const setRunning = (up: boolean) => {
+    // A blocked-click message survives a few idle polls, but never a real state
+    // change — the status is the link's aria-describedby, so it must not claim
+    // "can't open it yet" once the link has actually gone live.
+    let holdUntil = 0;
+    let lastUp: boolean | null = null;
+
+    // Only write when the text actually changes: role="status" is polite-live,
+    // and re-asserting the same string every 3s is what makes a region chatty.
+    const say = (msg: string) => {
+      if (status && status.textContent !== msg) status.textContent = msg;
+    };
+
+    const setRunning = (up: boolean, quiet = false) => {
       if (open) {
         open.setAttribute('aria-disabled', up ? 'false' : 'true');
         open.classList.toggle('border-g-gold-dim', up);
@@ -531,11 +559,18 @@ const requirementRows = [
         open.classList.toggle('text-g-faint', !up);
         open.classList.toggle('border-g-border', !up);
       }
-      if (status) status.textContent = up
-        ? 'Running — opens in a new tab.'
-        : 'Not running yet — run the command above, then this lights up.';
+      const changed = up !== lastUp;
+      lastUp = up;
+      if (quiet) return;
+      if (changed || Date.now() >= holdUntil) {
+        say(up
+          ? 'Running — opens in a new tab.'
+          : 'Not running yet — run the command above, then this lights up.');
+      }
     };
-    setRunning(false);
+    // Style the link now, but leave "Checking if it's running…" up until the
+    // first probe resolves rather than announcing a verdict we don't have yet.
+    setRunning(false, true);
 
     // Block the click until the sidecar is up (avoids a confusing connection error).
     open?.addEventListener('click', (e) => {
@@ -543,6 +578,10 @@ const requirementRows = [
         e.preventDefault();
         copyBtn?.classList.add('animate-g-pulse');
         setTimeout(() => copyBtn?.classList.remove('animate-g-pulse'), 600);
+        // The pulse is the only feedback a sighted user gets, and reduced motion
+        // crushes it to nothing — so say it in text as well.
+        holdUntil = Date.now() + 5000;
+        say("Can't open it yet — copy the command above and run it first, then this link lights up.");
       }
     });
 

--- a/website/src/pages/hub/[id].astro
+++ b/website/src/pages/hub/[id].astro
@@ -501,6 +501,12 @@ const requirementRows = [
   if (pg) {
     const copyBtn = pg.querySelector<HTMLButtonElement>('[data-pg-copy]');
     const copyStatus = pg.querySelector<HTMLElement>('[data-pg-copy-status]');
+    // Clear then re-assert, so copying twice is announced twice.
+    const announceCopy = (msg: string) => {
+      if (!copyStatus) return;
+      copyStatus.textContent = '';
+      if (msg) requestAnimationFrame(() => { copyStatus.textContent = msg; });
+    };
     let revert: number | undefined;
     copyBtn?.addEventListener('click', async () => {
       const label = copyBtn.querySelector('.pg-copy-label');
@@ -508,13 +514,13 @@ const requirementRows = [
         clearTimeout(revert);
         revert = window.setTimeout(() => {
           if (label) label.textContent = 'copy';
-          if (copyStatus) copyStatus.textContent = '';
+          announceCopy('');
         }, ms);
       };
       try {
         await navigator.clipboard.writeText(copyBtn.dataset.pgCopy || '');
         if (label) label.textContent = 'copied';
-        if (copyStatus) copyStatus.textContent = 'Command copied to the clipboard.';
+        announceCopy('Command copied to the clipboard.');
         reset(1600);
       } catch {
         // Same non-secure-origin / permission case as InstallMethods: select the
@@ -528,7 +534,7 @@ const requirementRows = [
           sel?.removeAllRanges();
           sel?.addRange(range);
         }
-        if (copyStatus) copyStatus.textContent = 'Copying was blocked. The command is selected — press Control or Command + C to copy it.';
+        announceCopy('Copying was blocked. The command is selected — press Control or Command + C to copy it.');
         reset(2600);
       }
     });

--- a/website/src/pages/hub/index.astro
+++ b/website/src/pages/hub/index.astro
@@ -87,23 +87,32 @@ const stats = [
       </label>
     </div>
 
-    <!-- List -->
+    <!-- Filter and search results change silently on screen, so they are
+         announced here. -->
+    <p id="hub-status" class="sr-only" role="status"></p>
+
+    <!-- List. Both groups are real lists, so a screen reader announces how many
+         agents there are instead of reading loose rows. -->
     <div id="hub-list" class="mt-[22px] overflow-hidden rounded-g-card border border-g-border bg-g-surface">
-      {agents.map((agent) => <AgentRow agent={agent} />)}
+      <ul aria-label="Published agents">
+        {agents.map((agent) => <li><AgentRow agent={agent} /></li>)}
+      </ul>
 
       <div id="hub-no-published" class="hidden border-b border-g-border px-[22px] py-[30px] text-[13.5px] text-g-faint">
         No published agent matches your search.
       </div>
 
       <div id="hub-soon-divider" class="flex items-center gap-[11px] border-b border-g-border px-[22px] py-4">
-        <span class="g-label tracking-[0.14em]">In development</span>
+        <h2 id="hub-soon-heading" class="g-label tracking-[0.14em]">In development</h2>
         <span class="h-px flex-1 bg-g-border" aria-hidden="true"></span>
         <span id="hub-soon-count" class="mono text-[11px] text-g-faint">
           {soon.length === 1 ? '1 agent' : `${soon.length} agents`}
         </span>
       </div>
 
-      {soon.map((agent) => <ComingSoonRow agent={agent} />)}
+      <ul aria-labelledby="hub-soon-heading">
+        {soon.map((agent) => <li><ComingSoonRow agent={agent} /></li>)}
+      </ul>
 
       <div id="hub-empty" class="hidden px-[22px] py-11 text-center text-[14px] text-g-muted">
         No agents match your search.
@@ -113,7 +122,7 @@ const stats = [
     <!-- Publish CTA -->
     <div class="mt-11 flex flex-wrap items-center justify-between gap-6 rounded-g-card border border-dashed border-g-border2 p-[30px]">
       <div>
-        <h3 class="font-display text-[20px] font-semibold tracking-[-0.015em]">Publish your own agent.</h3>
+        <h2 class="font-display text-[20px] font-semibold tracking-[-0.015em]">Publish your own agent.</h2>
         <p class="mt-2 max-w-[520px] text-[14px] leading-[1.6] text-g-muted">
           Scaffold it with the SDK, open a pull request against the hub manifest, and it lands
           here — versioned and immutable, installable by anyone in one command.
@@ -137,12 +146,29 @@ const stats = [
     const soon = Array.from(document.querySelectorAll('.soon-row'));
     const pills = Array.from(document.querySelectorAll('[data-filter]'));
     const search = document.getElementById('hub-search');
-    const list = document.getElementById('hub-list');
     const noPublished = document.getElementById('hub-no-published');
     const divider = document.getElementById('hub-soon-divider');
     const soonCount = document.getElementById('hub-soon-count');
     const empty = document.getElementById('hub-empty');
+    const status = document.getElementById('hub-status');
     let category = 'all';
+
+    // The rows sit inside two <ul>s, so the hairline sequence has to be spelled
+    // out rather than read off hub-list's children.
+    const hairlines = [...published, noPublished, divider, ...soon, empty];
+
+    let announceTimer;
+    const announce = (publishedVisible, soonVisible) => {
+      clearTimeout(announceTimer);
+      // Debounced: one message per pause in typing, not one per keystroke.
+      announceTimer = setTimeout(() => {
+        const plural = (n, word) => `${n} ${word}${n === 1 ? '' : 's'}`;
+        status.textContent =
+          publishedVisible + soonVisible === 0
+            ? 'No agents match your search.'
+            : `${plural(publishedVisible, 'published agent')}, ${plural(soonVisible, 'agent')} in development.`;
+      }, 350);
+    };
 
     const matches = (row, q) => {
       const catOk = category === 'all' || row.dataset.category === category;
@@ -154,7 +180,7 @@ const stats = [
       return catOk && qOk;
     };
 
-    function apply() {
+    function apply(notify) {
       const q = (search.value || '').trim().toLowerCase();
       let publishedVisible = 0;
       let soonVisible = 0;
@@ -179,10 +205,11 @@ const stats = [
 
       // The container draws the outer border, so the last visible row must not
       // draw a second hairline on top of it.
-      const children = Array.from(list.children);
-      children.forEach((el) => (el.style.borderBottomWidth = ''));
-      const lastVisible = children.filter((el) => !el.classList.contains('hidden')).pop();
+      hairlines.forEach((el) => (el.style.borderBottomWidth = ''));
+      const lastVisible = hairlines.filter((el) => !el.classList.contains('hidden')).pop();
       if (lastVisible) lastVisible.style.borderBottomWidth = '0';
+
+      if (notify) announce(publishedVisible, soonVisible);
     }
 
     pills.forEach((pill) =>
@@ -192,11 +219,11 @@ const stats = [
           p.classList.toggle('g-pill-active', p === pill);
           p.setAttribute('aria-pressed', String(p === pill));
         });
-        apply();
+        apply(true);
       })
     );
     pills.forEach((p) => p.setAttribute('aria-pressed', String(p.classList.contains('g-pill-active'))));
-    search.addEventListener('input', apply);
-    apply();
+    search.addEventListener('input', () => apply(true));
+    apply(false);
   })();
 </script>


### PR DESCRIPTION
The hero terminal was both halves of a bad pattern at once: a scroll region no keyboard user could enter — 85px of the transcript clipped at 1280px, 325px at 375px — and a `role="img"` that hid the entire session from assistive tech, including the "no email content left the device" line the demo exists to make. Before, a keyboard user simply could not reach the bottom of the site's primary hero and a screen-reader user got one summarising sentence instead of the session; now the region is focusable and named, the transcript is exposed, and the typing loop settles to the complete transcript on keyboard focus so it reads as text rather than a shifting buffer. In the same spirit, `prefers-reduced-motion` used to freeze the capability marquee mid-track and leave only 2 of 8 capabilities reachable on a phone — the accommodation cost its own users content — so it now reflows into a wrapped list and shows all 8. Alongside those: three hand-authored code blocks are keyboard-scrollable, a `role="tabpanel"` that named a tab which was never rendered no longer lies, four previously silent state changes are announced, both `<nav>` landmarks are named, the theme toggle exposes its state and can no longer render as an empty box, and `/hub` gets correct heading nesting and list semantics.

**Scope:** all contrast findings (F1/F2/F4/F5/F10) are deliberately untouched — a sibling PR owns `tokens.css`, `global.css`, `ComingSoonRow`, `AgentRow`, `DocTabs`. `Layout.astro` is **not** in this diff, so the sibling's `--g-gold` → `--g-focus` swap at `Layout.astro:154` cannot conflict. Worth knowing when merging: this PR adds 5 new focusable elements, so that focus-ring change now applies to more of the page than when it was written.

**Two deliberate deviations from the audit's suggested fixes**, both to avoid a worse outcome:
- F6 suggested replacing the copy button's static `aria-label` so its name could change. The name has to say *which* command it copies, so it is kept stable and the outcome is announced in a separate `role="status"` node instead.
- F15 suggested one list of 14 rows. Published and in-development agents are two distinct groups with a heading between them, so they ship as two named lists (1 + 13) rather than one.

## Test plan

```
cd website && npm install
HUB_CATALOG_URL=https://hub.amd-gaia.ai npx astro build
npx serve dist -l 4326
```

- [x] `npx astro check` → 0 errors, 0 warnings (4 pre-existing hints)
- [x] `npx vitest run` → 32 passing
- [x] axe-core 4.10, 3 pages × 2 themes × {1440, 375}px × {normal, reduced} motion = 24 runs: `landmark-unique` 6→0 nodes, `scrollable-region-focusable` 6→0. Only `color-contrast` (sibling PR) and one pre-existing `aria-allowed-role` on `<article role="tabpanel">` (F11, unassigned) remain
- [x] Stricter than axe: scan every element for `overflow:auto/scroll` with real overflow, `tabIndex < 0` and no focusable descendant → **0 on all three pages at 375px**
- [x] Tab to the hero terminal: focusable with a visible ring, ArrowDown/End scroll the full range, transcript completes to `[final] no email content left the device`, and all four triage categories are in the accessible text
- [x] Click the terminal with a mouse: the typing animation keeps running (only keyboard focus settles it)
- [x] Reduced motion at 1440/768/375px: **8 of 8** capabilities visible, no edge-fade clipping. Normal motion still animates as one masked row with the duplicate copy intact
- [x] `/hub` search: `#hub-status` announces "1 published agent, 13 agents in development" / "No agents match your search."; row hairlines still collapse on the last visible row after the `<ul>`/`<li>` change (last computed border `0px`, others `1px`)
- [x] `/hub/email` playground, driven against a stubbed sidecar: down → "Not running yet…" → blocked click replies in text and survives an idle poll → sidecar comes up → hold breaks, link enables, status corrects to "Running — opens in a new tab." Zero redundant writes to the region between polls
- [x] Copy twice in a row: the region clears and re-asserts, so both presses announce
- [x] Theme toggle: `aria-pressed` tracks dark/light, exactly one icon paints in both themes and with `data-theme` absent
- [x] Multi-method install switcher (build against a catalog entry with no `npm_package` to get 3 methods): 1 tablist, roving `tabindex`, exclusive `aria-selected`, every `aria-controls`/`aria-labelledby` resolves, Arrow keys wrap both directions, and exactly **one** copy status region — outside the panels
- [x] No page-level horizontal scroll: `documentElement.scrollWidth === clientWidth` across all 36 page/theme/width/motion combinations

## Needs a human with a real screen reader before merge

Everything above is DOM, ARIA-tree and computed-style measurement. None of it proves how VoiceOver/NVDA/JAWS actually speak. Please check:

1. **Hero terminal in browse mode.** Arrow-key reading does not move DOM focus, so the settle-on-focus path never fires — a reader browsing the hero may catch a partial transcript mid-typing-loop. This is the weakest point in the PR. If it reads badly, the fix is to make the animated node `aria-hidden` and ship a static visually-hidden transcript beside it.
2. **Terminal landmark name and exit.** Does "Illustrative terminal session — a scripted email-triage demo, not captured output." read sensibly in the landmark rota, and can the user get out of the region easily?
3. **The four announcements actually fire, once each:** hub search/filter results, copy outcome, playground liveness, blocked playground click. Confirm the copy message is not double-spoken because of the clear-then-re-assert.
4. **`aria-describedby` on "Open playground"** — is the status read *with* the link, and does the disabled→enabled transition get announced without repeating on every 3s poll?
5. **Theme toggle** — "Dark theme, toggle button, pressed/not pressed" or equivalent, in both states.
6. **`/hub` lists** — are "Published agents, list, 1 item" and "In development, list, 13 items" announced, and does the count update sensibly after filtering?
7. **Install switcher on a single-method agent** — confirm no phantom tab panel is announced (this is F7; verified absent in the DOM, unverified aurally).



---

### Browser verification (not the author) — headless Chromium + axe, vs a `main` baseline

Built current `main` (`d5ae430d`) alongside this branch and ran the full axe ruleset on both.

**F13 (unnamed `<nav>` landmarks) is verified fixed** — `landmark-unique` was present on all three pages on `main` and is **gone on all three** here.

**The ARIA tabs implementation is genuinely correct**, not merely role-decorated: `aria-labelledby="doctab-readme"` resolves to a real element, there are 7 tabs under 1 tablist, and pressing **ArrowRight moves focus Readme → Spec**, so the roving-tabindex contract works.

**One defect found and fixed in this PR (`7606c730`).** axe reported `aria-allowed-role` on `#docpanel-readme`: the seven doc panels were hosted on `<article>`, which carries an implicit `article` role, making `role="tabpanel"` invalid on it. Present on `main` too, so pre-existing rather than introduced — but squarely in this PR's dimension, and a role a validator rejects is one an assistive technology may also reject. All seven panels now use `<div>`.

Re-audited after the fix:

| Page | before | after |
| --- | --- | --- |
| `/hub/email/` | 4 (`aria-allowed-role` 1, contrast 3) | **3** (contrast only) |

The keyboard contract is unchanged after the change (`DIV`, role intact, label target resolves, ArrowRight still moves focus). The residual colour-contrast counts on `/` and `/hub/` belong to #2711, which is a separate branch and not merged here.

**Still needs a human:** anything depending on a real screen reader (VoiceOver/NVDA) — live-region announcements in particular. axe cannot assert that a change is *announced*, only that the markup permits it.



**Four more boxes measured in headless Chromium:**

- **Keyboard-reachable scroll regions:** scanned every element on `/` for `overflow: auto|scroll` *with real overflow*, then checked for `tabIndex < 0` and no focusable descendant. **None found** — no scrollable region is stranded from the keyboard.
- **Reduced motion (F8):** with `prefers-reduced-motion: reduce`, **8 of 8** capabilities render at 1440px, 768px and 375px — full list present (`Triage, Organize, Reply & send, Calendar, Follow-ups, Daily briefing, Plain-language requests, Action items`). Reduced motion removes the animation without removing content, which was the finding.
- **Live region (F6):** `#hub-status` is a `role="status"` and updates as described — typing `email` → *"1 published agent, 1 agent in development."*, typing a non-matching string → *"No agents match your search."*, clearing → *"1 published agent, 13 agents in development."*
- **No page-level horizontal scroll:** `documentElement.scrollWidth === clientWidth` across **all 36 combinations** — 3 pages x 3 widths (1440/768/390) x 2 themes x 2 motion preferences. Zero overflow anywhere.



**Final two boxes measured:**

- **Playground, sidecar down:** the "Open playground" link is disabled (no `href`/`aria-disabled`), and the explanatory note renders — *"Not running yet — run the command above, then this lights up."* So the blocked state is both visually and programmatically conveyed rather than a dead link.
- **Copy twice:** instrumented the live regions with a `MutationObserver` rather than sampling, and captured the full timeline — `103ms "Install command copied to the clipboard."` → `1704ms "(empty)"` → `2780ms "Install command copied to the clipboard."`. The region genuinely **clears and re-asserts**, so a screen reader announces both presses. (A coarse 1.2s poll makes this look like it never clears, because it lands before the 1704ms reset — worth knowing if anyone re-tests this by hand.)
