### PR TITLE
fix(daemon): detect a sidecar that is alive but has stopped serving

### DIFF
--- a/hub/agents/email/python/CHANGELOG.md
+++ b/hub/agents/email/python/CHANGELOG.md
@@ -344,15 +344,16 @@ contract version is tracked separately as
   instead of the length-only formula's false positive.
 - **A slow credential-store read no longer takes the whole sidecar down.**
   `GET /v1/email/connectors` read the OS credential store directly on the
-  asyncio event loop. That read can block without bound — on macOS a keychain
-  access by a binary the keychain ACL does not recognize raises an
-  authorization prompt, and a daemon-spawned background process never gets it
-  answered — so a single request wedged *every* route in the process,
-  `/health` included, while the process stayed alive and its supervisor went on
-  reporting it "running". Confirmed against the published 0.5.0 binary with a
-  stack sample: the loop's main thread sat in `SecItemCopyMatching`. The read
-  now runs off the loop, so a stuck credential store costs one request instead
-  of the entire sidecar.
+  asyncio event loop, and that read has no bounded worst case — on macOS it can
+  sit in `SecItemCopyMatching` waiting on an authorization decision a background
+  process never receives, and a corrupted or contended store can stall it too.
+  On the loop, a stall like that costs the whole process rather than one
+  request: nothing else can be scheduled until it returns, so every route stops
+  answering, `/health` included, while the process stays alive and its
+  supervisor goes on reporting it "running". Seen in the field on one machine
+  and captured with a stack sample of the parked loop. The read now runs off the
+  loop, so however long the credential store takes, the rest of the sidecar
+  keeps answering.
 
 - **`POST /autonomy/run` refuses instead of silently no-oping while autonomy
   is `off` (#2528).** Previously the route returned HTTP 200 with the same

--- a/hub/agents/email/python/CHANGELOG.md
+++ b/hub/agents/email/python/CHANGELOG.md
@@ -342,6 +342,18 @@ contract version is tracked separately as
   mail exists, never from comparing request/response length — a mailbox
   whose size exactly equals the request now correctly reports no truncation,
   instead of the length-only formula's false positive.
+- **A slow credential-store read no longer takes the whole sidecar down.**
+  `GET /v1/email/connectors` read the OS credential store directly on the
+  asyncio event loop. That read can block without bound — on macOS a keychain
+  access by a binary the keychain ACL does not recognize raises an
+  authorization prompt, and a daemon-spawned background process never gets it
+  answered — so a single request wedged *every* route in the process,
+  `/health` included, while the process stayed alive and its supervisor went on
+  reporting it "running". Confirmed against the published 0.5.0 binary with a
+  stack sample: the loop's main thread sat in `SecItemCopyMatching`. The read
+  now runs off the loop, so a stuck credential store costs one request instead
+  of the entire sidecar.
+
 - **`POST /autonomy/run` refuses instead of silently no-oping while autonomy
   is `off` (#2528).** Previously the route returned HTTP 200 with the same
   empty-report shape whether autonomy was disabled or had genuinely run and

--- a/hub/agents/email/python/gaia_agent_email/connector_routes.py
+++ b/hub/agents/email/python/gaia_agent_email/connector_routes.py
@@ -24,6 +24,7 @@ callback route. It only starts the flow and waits for it.
 
 from __future__ import annotations
 
+import asyncio
 import logging
 from typing import Any, Dict, List, Optional
 
@@ -97,9 +98,8 @@ def _can_send(provider: str) -> bool:
         return False
 
 
-@router.get("/connectors")
-async def list_email_connectors() -> Dict[str, Any]:
-    """Status of the mailbox connectors the email agent can send from."""
+def _read_connector_status() -> Dict[str, Any]:
+    """Blocking read of the connector store. Never call this on the event loop."""
     from gaia.connectors.api import connected_mailbox_providers, get_connection
 
     connected = set(connected_mailbox_providers())
@@ -116,6 +116,15 @@ async def list_email_connectors() -> Dict[str, Any]:
             }
         )
     return {"agent_id": EMAIL_AGENT_ID, "providers": providers}
+
+
+@router.get("/connectors")
+async def list_email_connectors() -> Dict[str, Any]:
+    """Status of the mailbox connectors the email agent can send from."""
+    # Off-loop: these reads hit the OS credential store, which can block
+    # indefinitely on a keychain authorization prompt the user never sees. On
+    # the loop that wedges every route in the process, including /health.
+    return await asyncio.to_thread(_read_connector_status)
 
 
 def _mail_scopes_for_provider(provider: str) -> tuple:

--- a/hub/agents/email/python/tests/test_connectors_does_not_wedge_loop.py
+++ b/hub/agents/email/python/tests/test_connectors_does_not_wedge_loop.py
@@ -2,16 +2,18 @@
 # SPDX-License-Identifier: MIT
 """A slow credential-store read must not take the whole sidecar down.
 
-``GET /v1/email/connectors`` reads the OS credential store. That read can block
-for an unbounded time — on macOS a keychain access by a binary the keychain ACL
-does not know raises an authorization prompt, and a daemon-spawned background
-process never gets it answered. Reproduced against the published 0.5.0 binary:
-one such request blocked ``SecItemCopyMatching`` on the asyncio event loop, so
-EVERY route stopped answering — including ``/health`` — while the process
-stayed alive and the daemon went on reporting it "running".
+``GET /v1/email/connectors`` reads the OS credential store. That read has no
+bounded worst case: on macOS a keychain access can sit in ``SecItemCopyMatching``
+waiting on an authorization decision that a background process never gets, and
+a corrupted or contended store can stall it too.
 
-The guard is that the blocking read happens off the event loop, so a stuck
-credential store costs one request instead of the entire process.
+Run on the event loop, a stall like that does not cost one request — it costs
+the whole process, ``/health`` included, because nothing else can be scheduled
+until it returns. That is what makes it invisible to a supervisor: the process
+stays alive and keeps its port, so it looks healthy while serving nothing.
+
+The guard is that the read happens off the loop, so however long the credential
+store takes, it costs one request and the rest of the sidecar keeps answering.
 """
 
 from __future__ import annotations

--- a/hub/agents/email/python/tests/test_connectors_does_not_wedge_loop.py
+++ b/hub/agents/email/python/tests/test_connectors_does_not_wedge_loop.py
@@ -1,0 +1,96 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""A slow credential-store read must not take the whole sidecar down.
+
+``GET /v1/email/connectors`` reads the OS credential store. That read can block
+for an unbounded time — on macOS a keychain access by a binary the keychain ACL
+does not know raises an authorization prompt, and a daemon-spawned background
+process never gets it answered. Reproduced against the published 0.5.0 binary:
+one such request blocked ``SecItemCopyMatching`` on the asyncio event loop, so
+EVERY route stopped answering — including ``/health`` — while the process
+stayed alive and the daemon went on reporting it "running".
+
+The guard is that the blocking read happens off the event loop, so a stuck
+credential store costs one request instead of the entire process.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+import time
+
+import pytest
+
+pytest.importorskip("gaia_agent_email")
+pytest.importorskip("fastapi")
+pytest.importorskip("httpx")
+
+# Long enough that a loop-blocking implementation cannot finish inside the
+# concurrent probe's timeout, short enough not to slow the suite when the
+# healthy path (a fast store) is taken.
+_STORE_STALL_SECONDS = 3.0
+_PROBE_TIMEOUT_SECONDS = 1.5
+
+# The middleware serves loopback Hosts only; a non-loopback Host is rejected 400
+# as a DNS-rebinding attempt.
+_BASE_URL = "http://127.0.0.1:8131"
+
+
+def test_health_still_answers_while_connector_store_is_stuck(monkeypatch):
+    """/health must answer while /v1/email/connectors sits in a stuck store read."""
+    import httpx
+    from gaia_agent_email import caller_auth, server
+
+    # Build with caller auth off so the connectors route is reachable without
+    # minting a token; the wedge under test is upstream of authentication.
+    monkeypatch.delenv(caller_auth.TOKEN_ENV_VAR, raising=False)
+    monkeypatch.delenv(caller_auth.TOKEN_FILE_ENV_VAR, raising=False)
+    app = server.build_app()
+
+    entered = threading.Event()
+    entered_at: list = []
+
+    def _stuck_store():
+        entered_at.append(time.monotonic())
+        entered.set()
+        time.sleep(_STORE_STALL_SECONDS)
+        return []
+
+    # Patched at its source module: the route imports it inside the call.
+    monkeypatch.setattr("gaia.connectors.api.connected_mailbox_providers", _stuck_store)
+
+    async def scenario() -> None:
+        transport = httpx.ASGITransport(app=app)
+        async with httpx.AsyncClient(transport=transport, base_url=_BASE_URL) as c:
+            connectors = asyncio.create_task(c.get("/v1/email/connectors"))
+
+            # Wait until the stuck read is actually in flight, so the probe
+            # below measures the wedge and not a race against request startup.
+            deadline = time.monotonic() + 5.0
+            while not entered.is_set() and time.monotonic() < deadline:
+                await asyncio.sleep(0.01)
+            assert entered.is_set(), "connectors route never reached the store read"
+
+            health = await c.get("/health")
+            assert health.status_code == 200
+            assert health.json()["service"] == "gaia-agent-email"
+
+            # The real assertion is WHEN it answered, not that it eventually
+            # did. A loop-blocking read cannot be observed while it blocks —
+            # the probe, its timeout, and this coroutine are all frozen with
+            # it — so completion alone proves nothing and the elapsed time
+            # since the read began is the only honest discriminator. Served
+            # off the loop this is milliseconds; served on it, it cannot come
+            # back before the read finishes.
+            served_after = time.monotonic() - entered_at[0]
+            assert served_after < _PROBE_TIMEOUT_SECONDS, (
+                f"/health was served {served_after:.2f}s after the credential "
+                f"read began, i.e. only once the read finished — the read is "
+                f"blocking the event loop and wedging every other route"
+            )
+
+            resp = await asyncio.wait_for(connectors, timeout=_STORE_STALL_SECONDS + 5.0)
+            assert resp.status_code == 200
+
+    asyncio.run(scenario())

--- a/src/gaia/daemon/connections_routes.py
+++ b/src/gaia/daemon/connections_routes.py
@@ -13,7 +13,7 @@ Loud, typed errors map to distinct statuses:
 - unknown agent → 404
 - provider not granted to the agent → 403 (the grant model is the source of
   truth; the daemon refuses to forward an ungranted connector)
-- sidecar not running → 503
+- sidecar not running, or alive but no longer answering → 503
 - sidecar rejected/dropped the forward → 502
 """
 
@@ -27,7 +27,11 @@ from starlette.concurrency import run_in_threadpool
 
 from gaia.daemon.constants import API_PREFIX
 from gaia.daemon.forward import ForwardDeliveryError, NotGrantedError
-from gaia.daemon.sidecars.errors import SidecarNotRunningError, UnknownAgentError
+from gaia.daemon.sidecars.errors import (
+    SidecarNotRunningError,
+    SidecarUnresponsiveError,
+    UnknownAgentError,
+)
 
 
 def build_connections_router(token: str, registry, forwarder):
@@ -37,17 +41,19 @@ def build_connections_router(token: str, registry, forwarder):
     require_token = build_require_token(token)
     router = APIRouter(dependencies=[Depends(require_token)])
 
-    def _connection(agent_id: str):
+    async def _connection(agent_id: str):
         try:
-            return registry.connection(agent_id)
+            # Off-loop: connection() probes the sidecar's /health, and a blocking
+            # probe here would wedge the daemon exactly like the sidecar it checks.
+            return await run_in_threadpool(registry.connection, agent_id)
         except UnknownAgentError as e:
             raise HTTPException(status_code=404, detail=str(e)) from e
-        except SidecarNotRunningError as e:
+        except (SidecarNotRunningError, SidecarUnresponsiveError) as e:
             raise HTTPException(status_code=503, detail=str(e)) from e
 
     @router.post(f"{API_PREFIX}/agents/{{agent_id}}/connections/forward")
     async def forward_all(agent_id: str) -> dict:
-        base_url, bearer = _connection(agent_id)
+        base_url, bearer = await _connection(agent_id)
         try:
             return await run_in_threadpool(
                 forwarder.forward_all, agent_id, base_url=base_url, bearer=bearer
@@ -59,7 +65,7 @@ def build_connections_router(token: str, registry, forwarder):
 
     @router.post(f"{API_PREFIX}/agents/{{agent_id}}/connections/{{provider}}/forward")
     async def forward_provider(agent_id: str, provider: str) -> dict:
-        base_url, bearer = _connection(agent_id)
+        base_url, bearer = await _connection(agent_id)
         try:
             return await run_in_threadpool(
                 forwarder.forward_provider,
@@ -77,7 +83,7 @@ def build_connections_router(token: str, registry, forwarder):
 
     @router.delete(f"{API_PREFIX}/agents/{{agent_id}}/connections/{{provider}}")
     async def withdraw(agent_id: str, provider: str) -> dict:
-        base_url, bearer = _connection(agent_id)
+        base_url, bearer = await _connection(agent_id)
         try:
             return await run_in_threadpool(
                 forwarder.withdraw,

--- a/src/gaia/daemon/relay.py
+++ b/src/gaia/daemon/relay.py
@@ -36,8 +36,9 @@ stops occupying the single-tenant LLM slot. Best-effort by design: the sidecar
 may already be dead, so transport failures are logged, never raised.
 
 Loud errors, no silent fallbacks: unknown agent → 404 naming the registered
-ids; registered-but-not-running → 503 naming the ensure remedy; upstream
-unreachable mid-flight → 502 carrying the transport error.
+ids; registered-but-not-running, or alive but no longer answering its own
+``/health`` → 503 naming the remedy; upstream unreachable mid-flight → 502
+carrying the transport error.
 """
 
 from __future__ import annotations
@@ -52,8 +53,13 @@ from typing import Optional
 import httpx
 from fastapi import APIRouter, Depends, HTTPException, Request
 from fastapi.responses import Response, StreamingResponse
+from starlette.concurrency import run_in_threadpool
 
-from gaia.daemon.sidecars.errors import SidecarNotRunningError, UnknownAgentError
+from gaia.daemon.sidecars.errors import (
+    SidecarNotRunningError,
+    SidecarUnresponsiveError,
+    UnknownAgentError,
+)
 from gaia.logger import get_logger
 
 logger = get_logger(__name__)
@@ -266,10 +272,12 @@ def build_relay_router(token: str, registry):
     @router.api_route("/v1/{agent_id}/{path:path}", methods=RELAY_METHODS)
     async def relay(agent_id: str, path: str, request: Request):
         try:
-            base_url, bearer = registry.connection(agent_id)
+            # Off-loop: connection() probes the sidecar's /health, and a blocking
+            # probe here would wedge the daemon exactly like the sidecar it checks.
+            base_url, bearer = await run_in_threadpool(registry.connection, agent_id)
         except UnknownAgentError as e:
             raise HTTPException(status_code=404, detail=str(e)) from e
-        except SidecarNotRunningError as e:
+        except (SidecarNotRunningError, SidecarUnresponsiveError) as e:
             raise HTTPException(status_code=503, detail=str(e)) from e
 
         body = await request.body()

--- a/src/gaia/daemon/sidecars/errors.py
+++ b/src/gaia/daemon/sidecars/errors.py
@@ -86,6 +86,18 @@ class SidecarNotRunningError(SidecarError):
     """The agent is registered but has no running sidecar to talk to."""
 
 
+class SidecarUnresponsiveError(SidecarError):
+    """The sidecar process is alive but no longer answering its own /health.
+
+    Distinct from :class:`SidecarNotRunningError` (no process) and
+    :class:`HealthTimeoutError` (never came up at all): the process passed its
+    startup handshake and has since stopped serving — a blocked event loop, a
+    wedged credential-store read, or a hung dependency. The process being alive
+    is why this cannot be detected by ``poll()``, and why the startup health
+    check alone reports it as healthy forever.
+    """
+
+
 class CapacityError(SidecarError):
     """Starting another sidecar would exceed the live-sidecar cap."""
 

--- a/src/gaia/daemon/sidecars/manager.py
+++ b/src/gaia/daemon/sidecars/manager.py
@@ -53,7 +53,9 @@ from gaia.daemon.constants import (
 from gaia.daemon.sidecars import fetch
 from gaia.daemon.sidecars.errors import (
     HealthTimeoutError,
+    SidecarNotRunningError,
     SidecarSpawnError,
+    SidecarUnresponsiveError,
     VersionMismatchError,
 )
 from gaia.daemon.sidecars.spec import AgentSidecarSpec
@@ -66,6 +68,11 @@ _VALID_MODES = ("user", "dev")
 # Keep only the most recent N per-port sidecar logs; ephemeral ports mean a new
 # file per restart, which would otherwise accumulate without bound.
 _MAX_SIDECAR_LOGS = 5
+# Pre-relay readiness probe budget. /health touches nothing, so a healthy
+# sidecar answers in milliseconds; this only has to be long enough to survive
+# scheduling jitter, and short enough that a wedged sidecar is reported as such
+# instead of stalling the caller behind the relay's own read timeout.
+_READINESS_TIMEOUT = 2.0
 
 
 def find_free_port(host: str = _HOST) -> int:
@@ -350,6 +357,46 @@ class AgentSidecarManager:
         import requests
 
         return requests.get(url, timeout=timeout)
+
+    def check_responsive(self, timeout: float = _READINESS_TIMEOUT) -> None:
+        """Raise unless the sidecar answers ``/health`` right now.
+
+        ``is_running`` only proves the PROCESS exists. A sidecar whose event
+        loop is blocked keeps that process alive forever while serving nothing,
+        so the startup health check — which runs once and is never re-checked —
+        goes on reporting it healthy. This is the re-check, and it is
+        deliberately a single bounded probe: no retry loop, because a retry
+        would convert a hard failure into a longer hang and hide it.
+
+        Raises :class:`SidecarUnresponsiveError` (alive but not serving) or
+        :class:`SidecarNotRunningError` (process gone).
+        """
+        import requests
+
+        if not self.is_running:
+            raise SidecarNotRunningError(
+                f"{self.spec.agent_id} sidecar process is not running. Start it "
+                f"with `gaia daemon start-agent {self.spec.agent_id}`."
+            )
+        url = f"{self.base_url}/health"
+        try:
+            r = self._http_get(url, timeout=timeout)
+        except requests.exceptions.RequestException as e:
+            raise SidecarUnresponsiveError(
+                f"{self.spec.agent_id} sidecar (pid {self.pid}) is alive but did "
+                f"not answer {url} within {timeout}s ({type(e).__name__}: {e}). "
+                "It passed its startup health check, so it has stopped serving "
+                "since — typically a blocked event loop or a hung dependency. "
+                f"Restart it with `gaia daemon start-agent {self.spec.agent_id}` "
+                f"and check the sidecar log at {self._log_path or self.log_dir}."
+            ) from e
+        if r.status_code != 200:
+            raise SidecarUnresponsiveError(
+                f"{self.spec.agent_id} sidecar (pid {self.pid}) answered {url} "
+                f"with HTTP {r.status_code}, not 200. Restart it with "
+                f"`gaia daemon start-agent {self.spec.agent_id}` and check the "
+                f"sidecar log at {self._log_path or self.log_dir}."
+            )
 
     def _open_log(self, port: int):
         # Redirect the sidecar's stdout+stderr to a per-port file. A plain PIPE

--- a/src/gaia/daemon/sidecars/registry.py
+++ b/src/gaia/daemon/sidecars/registry.py
@@ -277,9 +277,14 @@ class SidecarRegistry:
 
         The relay's single server-side token source (#2150): the sidecar bearer
         never has to travel through a client to reach proxied calls. Raises
-        :class:`UnknownAgentError` (unregistered id) or
-        :class:`SidecarNotRunningError` (registered but not running) so the
+        :class:`UnknownAgentError` (unregistered id),
+        :class:`SidecarNotRunningError` (registered but not running) or
+        :class:`SidecarUnresponsiveError` (alive but no longer serving) so the
         HTTP layer can map them to distinct loud 404/503 responses.
+
+        The responsiveness probe runs here because this is the one place every
+        relayed request passes through, and a process-alive check cannot tell a
+        serving sidecar from a wedged one.
         """
         self._spec(agent_id)
         with self._lock:
@@ -291,6 +296,7 @@ class SidecarRegistry:
                 f"Start it first (`gaia daemon start-agent {agent_id}` or "
                 f"POST /daemon/v1/agents/{agent_id}/ensure), then retry."
             )
+        manager.check_responsive()
         return manager.base_url, manager.auth_token
 
     def authenticate_callback(self, credential: str) -> Optional[str]:

--- a/tests/unit/test_daemon_relay.py
+++ b/tests/unit/test_daemon_relay.py
@@ -221,6 +221,11 @@ class _FakeManager:
     def is_running(self):
         return self._running
 
+    def check_responsive(self, timeout=None):
+        """Stands in for the real readiness re-probe: a started fake serves."""
+        if not self._running:
+            raise SidecarNotRunningError(f"{self.spec.agent_id} sidecar not running")
+
     def start(self):
         self.resolved_mode = "user"
         self.pid = 4321

--- a/tests/unit/test_sidecar_alive_but_not_serving.py
+++ b/tests/unit/test_sidecar_alive_but_not_serving.py
@@ -133,3 +133,29 @@ def test_relay_connection_refuses_a_wedged_sidecar(alive_process, tmp_path):
 
     with pytest.raises(SidecarUnresponsiveError):
         registry.connection("toy")
+
+
+def test_wedged_and_dead_details_keep_the_phrases_the_tui_matches_on(
+    alive_process, tmp_path
+):
+    """These two messages are a cross-language contract, not just prose.
+
+    The TUI tells a relay-authored refusal apart from a mailbox that refused
+    something by matching these phrases (``relayGaveUp`` in
+    ``tui/internal/ui/preflight/check.go``); without that it renders a wedged
+    sidecar as a broken mailbox and offers a browser sign-in that fixes
+    nothing. Rewording either message is a real behaviour change on the Go
+    side, so it fails here — at the source — instead of only in a Go fixture.
+    """
+    from gaia.daemon.sidecars.registry import SidecarRegistry
+
+    m = _manager_bound_to(alive_process, mgr.find_free_port())
+    m.log_dir = tmp_path
+    with pytest.raises(SidecarUnresponsiveError) as wedged:
+        m.check_responsive(timeout=1.0)
+    assert "is alive but did not answer" in str(wedged.value).lower()
+
+    registry = SidecarRegistry({"toy": _TOY_SPEC})
+    with pytest.raises(SidecarNotRunningError) as dead:
+        registry.connection("toy")
+    assert "no running sidecar" in str(dead.value).lower()

--- a/tests/unit/test_sidecar_alive_but_not_serving.py
+++ b/tests/unit/test_sidecar_alive_but_not_serving.py
@@ -4,14 +4,18 @@
 
 The startup health check (``_wait_for_health``) runs once and is never
 re-checked, and ``is_running`` only asks ``poll()`` whether the PROCESS exists.
-Between them they cannot see the failure that actually shipped: the published
-email sidecar passed its health check, then blocked its event loop on a
-credential-store read and stopped answering every route — while the process
-stayed alive, so the daemon reported it "running" indefinitely and the only
-symptom was an unrelated preflight row timing out ten seconds later.
+Between them they cannot see a sidecar that came up, passed its handshake, and
+later stopped serving — a blocked event loop, a wedged credential-store read, a
+hung dependency. The process stays alive through all of it, so the daemon goes
+on reporting "running" and the only symptom is an unrelated caller timing out
+much later against a row that had nothing to do with the fault.
 
-These tests pin the re-check: a live process whose port answers nothing is a
-loud, typed, actionable failure at the moment a caller tries to use it.
+Observed in the field: an email sidecar that answered ``/health`` and
+``/version``, then stopped answering every route while its process stayed up.
+What triggers that is environment-specific and not the point — the supervision
+gap is that the daemon could not TELL, and these tests pin the re-check that
+lets it: a live process whose port answers nothing is a loud, typed, actionable
+failure at the moment a caller tries to use it.
 """
 
 from __future__ import annotations
@@ -62,7 +66,7 @@ def _manager_bound_to(proc, port: int) -> mgr.AgentSidecarManager:
 def test_alive_process_that_serves_nothing_is_not_reported_healthy(
     alive_process, tmp_path
 ):
-    """The exact shipped failure: process up, port dead, daemon says 'running'."""
+    """The shape the daemon could not see: process up, port dead, state 'running'."""
     port = mgr.find_free_port()
     m = _manager_bound_to(alive_process, port)
     m.log_dir = tmp_path

--- a/tests/unit/test_sidecar_alive_but_not_serving.py
+++ b/tests/unit/test_sidecar_alive_but_not_serving.py
@@ -1,0 +1,135 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""A sidecar that is alive but no longer serving must be reported as such.
+
+The startup health check (``_wait_for_health``) runs once and is never
+re-checked, and ``is_running`` only asks ``poll()`` whether the PROCESS exists.
+Between them they cannot see the failure that actually shipped: the published
+email sidecar passed its health check, then blocked its event loop on a
+credential-store read and stopped answering every route — while the process
+stayed alive, so the daemon reported it "running" indefinitely and the only
+symptom was an unrelated preflight row timing out ten seconds later.
+
+These tests pin the re-check: a live process whose port answers nothing is a
+loud, typed, actionable failure at the moment a caller tries to use it.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import threading
+
+import pytest
+
+from gaia.daemon.sidecars import manager as mgr
+from gaia.daemon.sidecars.errors import (
+    SidecarNotRunningError,
+    SidecarUnresponsiveError,
+)
+from gaia.daemon.sidecars.spec import AgentSidecarSpec
+
+_TOY_SPEC = AgentSidecarSpec(
+    agent_id="toy",
+    service_id="gaia-agent-toy",
+    display_name="Toy Agent",
+    expected_api_major="1",
+    token_env_var="GAIA_TOY_SIDECAR_TOKEN",
+    mode_env_var="GAIA_TOY_AGENT_MODE",
+    cache_dir_name="toy",
+)
+
+
+@pytest.fixture(name="alive_process")
+def _alive_process():
+    """A real process that stays alive and listens on nothing."""
+    proc = subprocess.Popen([sys.executable, "-c", "import time; time.sleep(300)"])
+    try:
+        yield proc
+    finally:
+        proc.kill()
+        proc.wait(timeout=10)
+
+
+def _manager_bound_to(proc, port: int) -> mgr.AgentSidecarManager:
+    m = mgr.AgentSidecarManager(_TOY_SPEC)
+    m._proc = proc
+    m.port = port
+    m.base_url = f"http://127.0.0.1:{port}"
+    return m
+
+
+def test_alive_process_that_serves_nothing_is_not_reported_healthy(
+    alive_process, tmp_path
+):
+    """The exact shipped failure: process up, port dead, daemon says 'running'."""
+    port = mgr.find_free_port()
+    m = _manager_bound_to(alive_process, port)
+    m.log_dir = tmp_path
+
+    # What the daemon used to rely on, and why it was fooled.
+    assert m.is_running is True
+
+    with pytest.raises(SidecarUnresponsiveError) as exc:
+        m.check_responsive(timeout=1.0)
+
+    message = str(exc.value)
+    # The error has to be actionable on its own: what failed, what to run, and
+    # where to look. A bare "unreachable" leaves the user where they started.
+    assert "alive" in message
+    assert str(alive_process.pid) in message
+    assert "gaia daemon start-agent toy" in message
+    assert str(tmp_path) in message
+
+
+def test_dead_process_is_reported_as_not_running_not_unresponsive(tmp_path):
+    """The two failure modes stay distinguishable — different causes, different fixes."""
+    proc = subprocess.Popen([sys.executable, "-c", ""])
+    proc.wait(timeout=10)
+
+    m = _manager_bound_to(proc, mgr.find_free_port())
+    m.log_dir = tmp_path
+
+    assert m.is_running is False
+    with pytest.raises(SidecarNotRunningError):
+        m.check_responsive(timeout=1.0)
+
+
+def test_responsive_sidecar_passes(alive_process, tmp_path, monkeypatch):
+    """A sidecar answering /health is not disturbed by the re-check."""
+    m = _manager_bound_to(alive_process, mgr.find_free_port())
+    m.log_dir = tmp_path
+
+    class _Ok:
+        status_code = 200
+
+    monkeypatch.setattr(m, "_http_get", lambda url, timeout: _Ok())
+    m.check_responsive(timeout=1.0)  # must not raise
+
+
+def test_non_200_health_is_unresponsive(alive_process, tmp_path, monkeypatch):
+    """A 503 from /health is not a pass — it is a sidecar that cannot serve."""
+    m = _manager_bound_to(alive_process, mgr.find_free_port())
+    m.log_dir = tmp_path
+
+    class _Down:
+        status_code = 503
+
+    monkeypatch.setattr(m, "_http_get", lambda url, timeout: _Down())
+    with pytest.raises(SidecarUnresponsiveError, match="503"):
+        m.check_responsive(timeout=1.0)
+
+
+def test_relay_connection_refuses_a_wedged_sidecar(alive_process, tmp_path):
+    """registry.connection() is the relay choke point — it must not hand out a
+    base_url for a sidecar that cannot answer, or every relayed call inherits
+    the wedge as an opaque timeout."""
+    from gaia.daemon.sidecars.registry import SidecarRegistry
+
+    registry = SidecarRegistry({"toy": _TOY_SPEC})
+    m = _manager_bound_to(alive_process, mgr.find_free_port())
+    m.log_dir = tmp_path
+    registry._managers["toy"] = (m, threading.Lock())
+
+    with pytest.raises(SidecarUnresponsiveError):
+        registry.connection("toy")

--- a/tui/internal/ui/oneshot.go
+++ b/tui/internal/ui/oneshot.go
@@ -545,15 +545,23 @@ func ReportReadiness(
 func writeReadiness(errW io.Writer, rep preflight.Report) {
 	blocker, blocked := rep.Blocker()
 	if !blocked {
-		// Nothing failed. Anything that could not be VERIFIED is still named —
-		// the run proceeds, but silence here would read as "all clear" — and it
-		// keeps its remedy, which is the only thing that makes it fixable.
+		// Nothing the agent needs failed. Anything that could not be VERIFIED is
+		// still named — the run proceeds, but silence here would read as "all
+		// clear" — and it keeps its remedy, which is the only thing that makes it
+		// fixable.
 		for _, row := range rep.Rows {
 			if !row.NeedsAttention() {
 				continue
 			}
-			fmt.Fprintf(errW, "  ⚠️  %s: %s (could not be verified — continuing)\n",
-				row.Label, row.Line)
+			// A row that PROVED broken is not one that "could not be verified":
+			// only an optional row reaches here failed, and the ask it gates is
+			// what will fail, so say that rather than softening it.
+			verdict := "could not be verified"
+			if row.State == preflight.StateFailed {
+				verdict = "not working; only the asks that need it will fail"
+			}
+			fmt.Fprintf(errW, "  ⚠️  %s: %s (%s — continuing)\n",
+				row.Label, row.Line, verdict)
 			if row.Remedy.Command != "" {
 				fmt.Fprintf(errW, "      run: %s\n", row.Remedy.Command)
 			}

--- a/tui/internal/ui/preflight/check.go
+++ b/tui/internal/ui/preflight/check.go
@@ -24,7 +24,11 @@ import (
 type ExtraCheck struct {
 	Key   string
 	Label string
-	Run   func(ctx context.Context, t Transport, cfg Config) Row
+	// Optional marks a check that gates a CAPABILITY rather than the launch —
+	// see Row.Optional. Its verdict is reported in full; it just does not stop
+	// the walk or refuse the run.
+	Optional bool
+	Run      func(ctx context.Context, t Transport, cfg Config) Row
 }
 
 // Config parameterises a readiness check.
@@ -101,9 +105,11 @@ func Check(ctx context.Context, t Transport, cfg Config) Report {
 
 	for _, extra := range cfg.Extras {
 		row := extra.Run(ctx, t, cfg)
-		row.Key, row.Label = extra.Key, extra.Label
+		row.Key, row.Label, row.Optional = extra.Key, extra.Label, extra.Optional
 		setRow(&rep, row)
-		if row.State == StateFailed {
+		// An optional row is reported, never a stop sign: it gates a capability
+		// the ask may not need, and halting here would hide the rows below it.
+		if row.State == StateFailed && !extra.Optional {
 			markPending(&rep)
 			return rep
 		}
@@ -121,7 +127,7 @@ func blankRows(cfg Config) []Row {
 		{Key: KeyModel, Label: "AI model"},
 	}
 	for _, extra := range cfg.Extras {
-		rows = append(rows, Row{Key: extra.Key, Label: extra.Label})
+		rows = append(rows, Row{Key: extra.Key, Label: extra.Label, Optional: extra.Optional})
 	}
 	for i := range rows {
 		rows[i].State = StatePending
@@ -272,6 +278,18 @@ func checkSidecar(ctx context.Context, t Transport, cfg Config, rep *Report) Sta
 			continue
 		}
 		if a.State == "running" {
+			live := probeSidecarAnswers(ctx, t, cfg)
+			row.Raw = strings.TrimSpace(row.Raw + "\n\n" + live.trace)
+			if !live.answered {
+				row.State = StateFailed
+				row.Line = live.line
+				row.Detail = live.cause
+				row.Remedy = live.remedy
+				// `gaia daemon start-agent` ATTACHES to a registered sidecar, so a
+				// one-key "start the agent" would report success and change nothing.
+				row.Fix = FixNone
+				return row.commit(rep)
+			}
 			row.State = StateOK
 			row.Line = describeSidecar(a.AgentVersion, a.PID)
 			return row.commit(rep)
@@ -312,6 +330,112 @@ func describeSidecar(version *string, pid *int) string {
 		parts = append(parts, "running")
 	}
 	return strings.Join(parts, " · ")
+}
+
+// sidecarProbeTimeout bounds the one call that proves the agent's own process is
+// serving. GET /v1/<agent>/health touches no mailbox, no model and no network,
+// so a healthy sidecar answers in milliseconds on loopback; past this the
+// process is not answering rather than answering slowly.
+const sidecarProbeTimeout = 10 * time.Second
+
+// sidecarLiveness is what the liveness probe established, plus the words for the
+// row it produces.
+type sidecarLiveness struct {
+	answered bool
+	// line is the row's one-liner, so the subject it names matches the cause.
+	line   string
+	cause  string
+	remedy Remedy
+	// trace is appended to Row.Raw so `d` shows the probe and what it cost.
+	trace string
+}
+
+// probeSidecarAnswers asks the agent's own process to say something.
+//
+// The daemon's agent listing reports what its REGISTRY records, and a sidecar
+// whose event loop is blocked keeps its pid, keeps its port, and serves nothing
+// — so "running" is a claim about a process, not about an agent that answers.
+// That gap is what put "cannot be checked" on the Mailbox row over an agent that
+// had stopped answering every route it has.
+//
+// ANY answer proves the loop is alive: a 404 from an agent with no health route
+// still came off it. Only a call that never produced one — a transport failure,
+// or a relay saying it could not get an answer out of the sidecar — means the
+// process is not serving.
+func probeSidecarAnswers(ctx context.Context, t Transport, cfg Config) sidecarLiveness {
+	path := "/v1/" + cfg.AgentID + "/health"
+
+	ctx, cancel := context.WithTimeout(ctx, sidecarProbeTimeout)
+	defer cancel()
+
+	start := time.Now()
+	resp, err := t.Do(ctx, http.MethodGet, path, nil)
+	took := time.Since(start)
+	trace := func(outcome string) string {
+		return fmt.Sprintf("sidecar probe: GET %s -> %s in %dms", path, outcome, took.Milliseconds())
+	}
+
+	if err != nil {
+		if !timedOut(err) {
+			// Not the agent going quiet: the TUI dials exactly one host, so a
+			// refused or reset connection is the background service itself.
+			d := Ladder{AgentID: cfg.AgentID}.Error("reach the "+cfg.AgentName+" agent", err)
+			return sidecarLiveness{
+				line:   "cannot be reached",
+				cause:  d.Cause,
+				remedy: d.AsRemedy(),
+				trace:  trace("no answer: " + err.Error()),
+			}
+		}
+		return sidecarLiveness{
+			line: "running, not answering",
+			cause: fmt.Sprintf(
+				"The background service says the %s agent is running, but the agent itself "+
+					"never replied — it took the request and held it, so every call to it hangs, "+
+					"this check included. Nothing below it can be checked until it answers.",
+				cfg.AgentName),
+			remedy: restartSidecarRemedy(cfg.AgentID),
+			trace:  trace("no answer: " + err.Error()),
+		}
+	}
+
+	detail := jsonDetail(resp.Body)
+	outcome := fmt.Sprintf("HTTP %d %s", resp.Status, strings.TrimSpace(string(resp.Body)))
+	if (resp.Status == http.StatusBadGateway || resp.Status == http.StatusServiceUnavailable) &&
+		relayGaveUp(detail) {
+		return sidecarLiveness{
+			line: "running, not answering",
+			cause: fmt.Sprintf(
+				"The background service says the %s agent is running, but it could not get an "+
+					"answer out of it. %s", cfg.AgentName, detailSuffix(firstSentence(detail))),
+			remedy: restartSidecarRemedy(cfg.AgentID),
+			trace:  trace(outcome),
+		}
+	}
+	return sidecarLiveness{answered: true, trace: trace(outcome)}
+}
+
+// restartSidecarRemedy is the fix for a sidecar that is registered but not
+// serving. It stops before it starts on purpose: `start-agent` spawns-or-ATTACHES,
+// so on its own it attaches to the very process that is stuck and reports
+// success. Only replacing the process clears it.
+func restartSidecarRemedy(agentID string) Remedy {
+	return Remedy{
+		Action: "Stop the agent, then start it again — `start-agent` on its own attaches to " +
+			"the process that is already registered, so it would change nothing.",
+		Command: fmt.Sprintf("gaia daemon stop-agent %s && gaia daemon start-agent %s", agentID, agentID),
+		Where:   fmt.Sprintf("~/.gaia/agents/%s/logs/", agentID),
+	}
+}
+
+// timedOut reports whether a call was given up on rather than refused. The
+// daemon client reports a deadline as text on its own error type rather than
+// wrapping context.DeadlineExceeded, so both forms are checked.
+func timedOut(err error) bool {
+	if errors.Is(err, context.DeadlineExceeded) {
+		return true
+	}
+	return containsAny(strings.ToLower(err.Error()), "timed out", "timeout", "deadline exceeded")
 }
 
 // ---------------------------------------------------------------------------
@@ -750,11 +874,22 @@ func connectCommand(provider string) string {
 // all — so the row went green over a mailbox whose very first read 502s. See
 // mailboxProbeBodyJSON and mailboxProbeTimeout for what that read costs and why
 // it is bounded.
+//
+// It is an OPTIONAL check (Row.Optional), which is not the same as a soft one:
+// the row still proves what it can and still fails loudly when the mailbox is
+// unusable. What it must not do is refuse the launch, because the agent's
+// capabilities do not all need a mailbox — POST /v1/<agent>/triage classifies
+// the subject and body carried IN the request ("No mail is read or sent"), so a
+// user with nothing connected must still be able to run a triage query. The
+// mailbox operations — search, send, archive, quarantine, pre-scan, briefing —
+// fail on their own, with the sidecar's own error, and this row is what warns
+// them first.
 func MailboxCheck() ExtraCheck {
 	return ExtraCheck{
-		Key:   KeyMailbox,
-		Label: "Mailbox",
-		Run:   runMailboxCheck,
+		Key:      KeyMailbox,
+		Label:    "Mailbox",
+		Optional: true,
+		Run:      runMailboxCheck,
 	}
 }
 
@@ -1117,15 +1252,18 @@ func finishMailboxRow(row Row, res probeResult, p *connectorEntry, cfg Config) R
 // answering it with a browser sign-in hides the one fix that works.
 //
 // The relay names itself in every body it authors, and this depends on that
-// wording: its two 502s say "sidecar for agent '<id>'" (relay.py) and its 503
-// says the agent "has no running sidecar to relay to"
-// (sidecars/registry.connection). Nothing on the Python side pins those strings,
-// so the fixtures in check_test.go carry them VERBATIM — a reword there breaks a
-// test here rather than silently turning a dead sidecar into a dead mailbox.
+// wording: its two 502s say "sidecar for agent '<id>'" (relay.py), its 503 for a
+// dead sidecar says the agent "has no running sidecar to relay to", and its 503
+// for a live one that stopped serving says the process "is alive but did not
+// answer" its own health route (sidecars/manager.check_responsive). Nothing on
+// the Python side pins those strings, so the fixtures in check_test.go carry
+// them VERBATIM — a reword there breaks a test here rather than silently turning
+// a wedged sidecar into a dead mailbox.
 func relayGaveUp(detail string) bool {
 	d := strings.ToLower(detail)
 	return strings.Contains(d, "sidecar for agent") ||
-		strings.Contains(d, "no running sidecar")
+		strings.Contains(d, "no running sidecar") ||
+		strings.Contains(d, "is alive but did not answer")
 }
 
 // transientCredentialGap reports whether the sidecar said the forwarded token

--- a/tui/internal/ui/preflight/check_test.go
+++ b/tui/internal/ui/preflight/check_test.go
@@ -37,6 +37,23 @@ const (
 
 	agentsEmpty = `{"agents":[]}`
 
+	// GET /v1/email/health — HealthResponse (api_routes.email_health). It touches
+	// no mailbox, no model and no network, so only a sidecar that is SERVING can
+	// produce it.
+	healthOK = `{"status":"ok"}`
+
+	// The relay's 503 for a sidecar that passed its startup handshake and has
+	// since stopped serving — the published-binary wedge: an async handler doing
+	// a blocking Keychain read parks the event loop and every route with it, pid
+	// and port intact, so the daemon's own listing keeps saying "running".
+	// VERBATIM from sidecars/manager.check_responsive, which nothing on the
+	// Python side pins — a reword there has to break a test here.
+	healthWedged = `{"detail":"email sidecar (pid 41999) is alive but did not answer ` +
+		`http://127.0.0.1:51234/health within 2.0s (ReadTimeout: ). It passed its startup ` +
+		"health check, so it has stopped serving since — typically a blocked event loop or " +
+		"a hung dependency. Restart it with `gaia daemon start-agent email` and check the " +
+		`sidecar log at ~/.gaia/agents/email/logs/email-1.log."}`
+
 	initReady = `{"ready":true,"lemonade":{"reachable":true,` +
 		`"base_url":"http://localhost:8000/api/v1","version":"8.1.10","min_version":"8.1.0",` +
 		`"compatible":true},"model":{"id":"Gemma-4-E4B-it-GGUF","present":true,"loadable":null,` +
@@ -229,6 +246,7 @@ func newFake() *fakeTransport {
 		info: DaemonInfo{PID: 41822, Port: 51230, APIVersion: "1.1"},
 		bodies: map[string]Response{
 			"GET /daemon/v1/agents":    {Status: 200, Body: []byte(agentsRunning)},
+			"GET /v1/email/health":     {Status: 200, Body: []byte(healthOK)},
 			"GET /v1/email/init":       {Status: 200, Body: []byte(initReady)},
 			"GET /v1/email/connectors": {Status: 200, Body: []byte(connectorsReady)},
 			"POST /v1/email/search":    {Status: 200, Body: []byte(searchOK)},
@@ -315,6 +333,7 @@ func realCommands() []string {
 		"gaia daemon start",
 		"gaia daemon restart",
 		"gaia daemon start-agent ",
+		"gaia daemon stop-agent ",
 		"gaia daemon agents",
 		"gaia hub install ",
 		"gaia init",
@@ -454,13 +473,18 @@ func TestCheck(t *testing.T) {
 		// wantStates is keyed by row key. Rows omitted are not asserted.
 		wantStates map[string]State
 		wantReady  bool
-		// wantBlocker is the key of the row that must be the first failure, "" for none.
+		// wantBlocker is the key of the row that must REFUSE the launch, "" for
+		// none. An optional row never refuses one, however it failed.
 		wantBlocker string
-		// wantIn asserts substrings on the blocking row's rendered remedy.
+		// wantAttention is the key of the row the user must act on. It is the
+		// blocker whenever there is one, so it defaults to wantBlocker; a failed
+		// optional row is the case where the two differ.
+		wantAttention string
+		// wantIn asserts substrings on the acted-on row's rendered remedy.
 		wantIn []string
 		// wantNotIn asserts what the remedy must NOT say.
 		wantNotIn []string
-		// wantFix is the fix the blocking row offers.
+		// wantFix is the fix the acted-on row offers.
 		wantFix FixKind
 		// mustNotCall names paths the walk must not reach (stop at first failure).
 		mustNotCall []call
@@ -517,6 +541,74 @@ func TestCheck(t *testing.T) {
 			wantIn:      []string{"gaia daemon start-agent email"},
 			wantFix:     FixStartSidecar,
 			mustNotCall: []call{{"GET", "/v1/email/init"}},
+		},
+		{
+			// THE WEDGE. The daemon's listing says "running" because the PROCESS is
+			// there; the agent itself takes the request and never answers. Blaming
+			// the mailbox for that — which is what the Mailbox row's timeout used to
+			// say — points the user at the one thing that is not broken.
+			name: "the agent is registered and running but never answers",
+			build: func() *fakeTransport {
+				f := newFake()
+				f.errs["GET /v1/email/health"] = &daemon.RequestError{
+					Op: "call GET /v1/email/health through the background service",
+					Detail: "context deadline exceeded (Client.Timeout or context " +
+						"cancellation while reading body)",
+				}
+				return f
+			},
+			wantStates: map[string]State{
+				KeyDaemon: StateOK, KeySidecar: StateFailed, KeyLemonade: StatePending,
+				KeyModel: StatePending, KeyMailbox: StatePending,
+			},
+			wantBlocker: KeySidecar,
+			wantIn: []string{
+				"running, not answering", "never replied",
+				"gaia daemon stop-agent email && gaia daemon start-agent email",
+				"~/.gaia/agents/email/logs/",
+			},
+			// The mailbox is not the subject and must not be named as one.
+			wantNotIn: []string{"mailbox", "Mailbox"},
+			// start-agent ATTACHES to a registered sidecar, so a one-key start
+			// would report success and change nothing.
+			wantFix: FixNone,
+			// And nothing downstream is probed over an agent that cannot answer.
+			mustNotCall: []call{
+				{"GET", "/v1/email/init"}, {"GET", "/v1/email/connectors"},
+				{"POST", "/v1/email/search"},
+			},
+		},
+		{
+			// Same wedge, seen by the daemon first: its pre-relay probe finds the
+			// sidecar alive but no longer serving and 503s with that verdict.
+			name: "the background service cannot get an answer out of the agent",
+			build: func() *fakeTransport {
+				return newFake().with("GET /v1/email/health", 503, healthWedged)
+			},
+			wantStates: map[string]State{
+				KeySidecar: StateFailed, KeyLemonade: StatePending, KeyMailbox: StatePending,
+			},
+			wantBlocker: KeySidecar,
+			wantIn: []string{
+				"running, not answering", "could not get an answer out of it",
+				"gaia daemon stop-agent email",
+			},
+			wantFix:     FixNone,
+			mustNotCall: []call{{"GET", "/v1/email/init"}},
+		},
+		{
+			// An agent with no health route still ANSWERED, and an answer off the
+			// event loop is the whole question. Reading a 404 as a dead agent would
+			// fail every sidecar older than this check.
+			name: "an agent without a health route still counts as answering",
+			build: func() *fakeTransport {
+				return newFake().with("GET /v1/email/health", 404, `{"detail":"Not Found"}`)
+			},
+			wantStates: map[string]State{
+				KeyDaemon: StateOK, KeySidecar: StateOK, KeyLemonade: StateOK,
+				KeyModel: StateOK, KeyMailbox: StateOK,
+			},
+			wantReady: true,
 		},
 		{
 			name: "agent not installed",
@@ -591,7 +683,10 @@ func TestCheck(t *testing.T) {
 			wantStates: map[string]State{
 				KeyModel: StateOK, KeyMailbox: StateFailed,
 			},
-			wantBlocker: KeyMailbox,
+			// Failed, named, and NOT a refusal: triage classifies the payload in
+			// the request, so a query must still be able to run.
+			wantBlocker:   "",
+			wantAttention: KeyMailbox,
 			wantIn: []string{
 				"gaia connectors connect google", "installed:email",
 				// The union, not just the send scope: --scopes REPLACES the
@@ -606,8 +701,8 @@ func TestCheck(t *testing.T) {
 			build: func() *fakeTransport {
 				return newFake().with("GET /v1/email/connectors", 200, connectorsNoSend)
 			},
-			wantStates:  map[string]State{KeyMailbox: StateFailed},
-			wantBlocker: KeyMailbox,
+			wantStates:    map[string]State{KeyMailbox: StateFailed},
+			wantAttention: KeyMailbox,
 			wantIn: []string{
 				"you@gmail.com", "sign-in has no send access",
 				"signed in without the send scope",
@@ -628,8 +723,8 @@ func TestCheck(t *testing.T) {
 			build: func() *fakeTransport {
 				return newFake().with("GET /v1/email/connectors", 200, connectorsNoGrant)
 			},
-			wantStates:  map[string]State{KeyMailbox: StateFailed},
-			wantBlocker: KeyMailbox,
+			wantStates:    map[string]State{KeyMailbox: StateFailed},
+			wantAttention: KeyMailbox,
 			wantIn: []string{
 				"you@gmail.com", "send access not granted",
 				"does include send permission",
@@ -651,7 +746,7 @@ func TestCheck(t *testing.T) {
 			wantStates: map[string]State{
 				KeyModel: StateOK, KeyMailbox: StateFailed,
 			},
-			wantBlocker: KeyMailbox,
+			wantAttention: KeyMailbox,
 			wantIn: []string{
 				"sign-in no longer works",
 				"no forwarded 'google' credential is available",
@@ -667,10 +762,10 @@ func TestCheck(t *testing.T) {
 			build: func() *fakeTransport {
 				return newFake().with("POST /v1/email/search", 403, searchRevoked)
 			},
-			wantStates:  map[string]State{KeyMailbox: StateFailed},
-			wantBlocker: KeyMailbox,
-			wantIn:      []string{"revoked upstream", "gaia connectors connect google"},
-			wantFix:     FixConnectMailbox,
+			wantStates:    map[string]State{KeyMailbox: StateFailed},
+			wantAttention: KeyMailbox,
+			wantIn:        []string{"revoked upstream", "gaia connectors connect google"},
+			wantFix:       FixConnectMailbox,
 		},
 		{
 			// The RELAY gave up, not the mailbox. Blaming the mailbox would hand the
@@ -804,21 +899,33 @@ func TestCheck(t *testing.T) {
 				if blocker.Key != tt.wantBlocker {
 					t.Fatalf("blocker = %q, want %q\n%s", blocker.Key, tt.wantBlocker, rep)
 				}
-				assertRealCommand(t, blocker)
-				if blocker.Fix != tt.wantFix {
-					t.Errorf("blocker fix = %v, want %v", blocker.Fix, tt.wantFix)
+			}
+
+			attention := tt.wantAttention
+			if attention == "" {
+				attention = tt.wantBlocker
+			}
+			if attention != "" {
+				idx := rep.FirstAttention()
+				if idx < 0 || rep.Rows[idx].Key != attention {
+					t.Fatalf("the user is pointed at %d, want the %q row\n%s", idx, attention, rep)
+				}
+				row := rep.Rows[idx]
+				assertRealCommand(t, row)
+				if row.Fix != tt.wantFix {
+					t.Errorf("%q fix = %v, want %v", row.Key, row.Fix, tt.wantFix)
 				}
 				text := fmt.Sprintf("%s %s %s %s %s",
-					blocker.Line, blocker.Detail, blocker.Remedy.Action,
-					blocker.Remedy.Command, blocker.Remedy.Where)
+					row.Line, row.Detail, row.Remedy.Action,
+					row.Remedy.Command, row.Remedy.Where)
 				for _, want := range tt.wantIn {
 					if !strings.Contains(text, want) {
-						t.Errorf("blocking row does not mention %q; it says: %s", want, text)
+						t.Errorf("the %q row does not mention %q; it says: %s", row.Key, want, text)
 					}
 				}
 				for _, unwanted := range tt.wantNotIn {
 					if strings.Contains(text, unwanted) {
-						t.Errorf("blocking row must not mention %q; it says: %s", unwanted, text)
+						t.Errorf("the %q row must not mention %q; it says: %s", row.Key, unwanted, text)
 					}
 				}
 			}
@@ -845,6 +952,7 @@ func TestEveryFailedRowIsActionable(t *testing.T) {
 		"creds dead":  newFake().with("POST /v1/email/search", 502, searchNoForwardedCredential),
 		"revoked":     newFake().with("POST /v1/email/search", 403, searchRevoked),
 		"sidecar":     newFake().with("GET /daemon/v1/agents", 200, agentsStopped),
+		"wedged":      newFake().with("GET /v1/email/health", 503, healthWedged),
 	}
 	for name, f := range scenarios {
 		t.Run(name, func(t *testing.T) {
@@ -1520,7 +1628,199 @@ func TestIndeterminateIsNeitherReadyNorBlocking(t *testing.T) {
 	}
 }
 
+// --- the agent that is running but not answering ------------------------------
+
+// The wedge, end to end: an agent whose event loop is parked keeps its pid and
+// its port, so the daemon's listing says "running" forever. Every row below it
+// then times out, and the FIRST of those used to be the Mailbox — which reported
+// "cannot be checked" and sent the user to their mailbox over an agent that had
+// stopped answering anything.
+func TestAnAgentThatNeverAnswersIsNamedInsteadOfTheMailbox(t *testing.T) {
+	f := newFake().with("GET /v1/email/health", 503, healthWedged)
+	rep := Check(context.Background(), f, EmailConfig())
+
+	sidecar, _ := rep.Find(KeySidecar)
+	if sidecar.State != StateFailed {
+		t.Fatalf("a sidecar that answers nothing = %s, want failed\n%s", sidecar.State.Word(), rep)
+	}
+	if !strings.Contains(sidecar.Line, "not answering") {
+		t.Errorf("the row does not say what is wrong: %q", sidecar.Line)
+	}
+	assertRealCommand(t, sidecar)
+	if !strings.Contains(sidecar.Remedy.Command, "stop-agent") {
+		t.Errorf("the remedy attaches to the stuck process instead of replacing it: %q",
+			sidecar.Remedy.Command)
+	}
+	if sidecar.Remedy.Where == "" {
+		t.Error("the row does not say where to look next")
+	}
+
+	// The mailbox is not asked, not accused, and says what it is waiting on.
+	mailbox, _ := rep.Find(KeyMailbox)
+	if mailbox.State != StatePending {
+		t.Fatalf("mailbox = %s, want pending — nothing about it was learned\n%s",
+			mailbox.State.Word(), rep)
+	}
+	if !strings.Contains(mailbox.Detail, sidecar.Label) {
+		t.Errorf("the mailbox row does not name what it is waiting on: %q", mailbox.Detail)
+	}
+	if strings.Contains(mailbox.Line, "cannot be checked") ||
+		strings.Contains(mailbox.Remedy.Command, "connectors connect") {
+		t.Errorf("a wedged agent was reported as a mailbox problem: %q / %q",
+			mailbox.Line, mailbox.Remedy.Command)
+	}
+	// And the blocker the user is sent to is the agent.
+	blocker, _ := rep.Blocker()
+	if blocker.Key != KeySidecar {
+		t.Errorf("blocker = %q, want the agent row\n%s", blocker.Key, rep)
+	}
+}
+
+// The probe is one bounded call and it has to be visible in `d` — including what
+// it cost, which is the only way anyone can tell whether the gate got slower.
+func TestTheLivenessProbeIsOneCallAndIsRecorded(t *testing.T) {
+	f := newFake()
+	rep := Check(context.Background(), f, EmailConfig())
+
+	row, _ := rep.Find(KeySidecar)
+	if row.State != StateOK {
+		t.Fatalf("a healthy agent = %s, want ok\n%s", row.State.Word(), rep)
+	}
+	for _, want := range []string{"sidecar probe: GET /v1/email/health", "HTTP 200", "ms"} {
+		if !strings.Contains(row.Raw, want) {
+			t.Errorf("the probe trace does not record %q:\n%s", want, row.Raw)
+		}
+	}
+	// The agents listing it started from is still there — `d` must show both.
+	if !strings.Contains(row.Raw, "agent_id") {
+		t.Errorf("the probe trace replaced the agents listing:\n%s", row.Raw)
+	}
+
+	var probes int
+	for _, c := range f.calls {
+		if c.method == "GET" && c.path == "/v1/email/health" {
+			probes++
+		}
+	}
+	if probes != 1 {
+		t.Errorf("the gate probed the agent %d times; one launch is one probe", probes)
+	}
+}
+
+// A probe that never reached the daemon is not an agent that went quiet. The
+// row's line and its cause have to name the same subject, or the user restarts
+// the wrong thing.
+func TestADaemonThatDropsTheProbeIsNotReportedAsASilentAgent(t *testing.T) {
+	f := newFake()
+	f.errs["GET /v1/email/health"] = &daemon.RequestError{
+		Op: "call GET /v1/email/health through the background service", Detail: "connection refused"}
+
+	rep := Check(context.Background(), f, EmailConfig())
+	row, _ := rep.Find(KeySidecar)
+
+	if row.State != StateFailed {
+		t.Fatalf("state = %s, want failed\n%s", row.State.Word(), rep)
+	}
+	if strings.Contains(row.Line, "not answering") {
+		t.Errorf("a dead background service was reported as a silent agent: %q", row.Line)
+	}
+	if !strings.Contains(row.Detail, "background service") {
+		t.Errorf("the row does not name what actually failed: %q", row.Detail)
+	}
+	if strings.Contains(row.Remedy.Command, "stop-agent") {
+		t.Errorf("the remedy restarts an agent over a background service that is gone: %q",
+			row.Remedy.Command)
+	}
+	assertRealCommand(t, row)
+}
+
+// A sidecar the daemon has not started is not one that stopped answering: the
+// row must keep the remedy that STARTS it, and must not pay for a probe of a
+// process that is not there.
+func TestAStoppedSidecarIsNotProbedOrDiagnosedAsWedged(t *testing.T) {
+	f := newFake().with("GET /daemon/v1/agents", 200, agentsStopped)
+	rep := Check(context.Background(), f, EmailConfig())
+
+	row, _ := rep.Find(KeySidecar)
+	if row.Fix != FixStartSidecar {
+		t.Errorf("fix = %v, want the one-key start", row.Fix)
+	}
+	if strings.Contains(row.Remedy.Command, "stop-agent") {
+		t.Errorf("a sidecar that was never started is told to stop first: %q", row.Remedy.Command)
+	}
+	if f.called("GET", "/v1/email/health") {
+		t.Error("the gate probed a sidecar the daemon says is not running")
+	}
+}
+
 // --- the mailbox: four states, four remedies ---------------------------------
+
+// A mailbox is what the email agent's MAIL operations need — not what the agent
+// needs to run. POST /v1/email/triage classifies the subject and body carried in
+// the request ("No mail is read or sent"), so `run email --query …` must still
+// work with nothing connected. The row is still a loud failure; it just does not
+// refuse the run.
+func TestAMissingMailboxDoesNotRefuseARunThatDoesNotNeedOne(t *testing.T) {
+	for name, body := range map[string]string{
+		"nothing connected":      connectorsNone,
+		"no send scope":          connectorsNoSend,
+		"the agent has no grant": connectorsNoGrant,
+	} {
+		t.Run(name, func(t *testing.T) {
+			rep := Check(context.Background(),
+				newFake().with("GET /v1/email/connectors", 200, body), EmailConfig())
+
+			if rep.Blocked() {
+				t.Errorf("a mailbox-free capability was refused over the mailbox\n%s", rep)
+			}
+			if _, blocked := rep.Blocker(); blocked {
+				t.Error("the mailbox row was reported as what refuses the launch")
+			}
+			// Not softened: still proven broken, still [!], still the row the user
+			// is pointed at, still carrying the fix.
+			row, _ := rep.Find(KeyMailbox)
+			if row.State != StateFailed {
+				t.Fatalf("mailbox = %s, want failed — it IS unusable\n%s", row.State.Word(), rep)
+			}
+			if rep.Ready() {
+				t.Error("a report with an unusable mailbox called itself ready")
+			}
+			idx := rep.FirstAttention()
+			if idx < 0 || rep.Rows[idx].Key != KeyMailbox {
+				t.Errorf("the cursor is not on the row that needs the user\n%s", rep)
+			}
+			if row.Fix != FixConnectMailbox || row.Remedy.Empty() {
+				t.Errorf("the row lost the fix that makes it actionable: fix=%v remedy=%+v",
+					row.Fix, row.Remedy)
+			}
+			assertRealCommand(t, row)
+		})
+	}
+}
+
+// The rows the agent DOES need still refuse: making the mailbox non-blocking
+// must not make anything else non-blocking.
+func TestOnlyTheMailboxRowIsExemptFromRefusingTheLaunch(t *testing.T) {
+	cases := map[string]*fakeTransport{
+		"daemon": func() *fakeTransport {
+			f := newFake()
+			f.attachErr = &daemon.NotRunningError{Path: "/tmp/i.json"}
+			return f
+		}(),
+		"sidecar":  newFake().with("GET /daemon/v1/agents", 200, agentsStopped),
+		"wedged":   newFake().with("GET /v1/email/health", 503, healthWedged),
+		"lemonade": newFake().with("GET /v1/email/init", 503, initUnreachable),
+		"model":    newFake().with("GET /v1/email/init", 503, initModelMissing),
+	}
+	for name, f := range cases {
+		t.Run(name, func(t *testing.T) {
+			rep := Check(context.Background(), f, EmailConfig())
+			if !rep.Blocked() {
+				t.Fatalf("a precondition the agent needs stopped refusing the launch\n%s", rep)
+			}
+		})
+	}
+}
 
 // The four states the connector list plus one read can tell apart. Each needs
 // its own sentence: one "reconnect your mailbox" for all of them is what makes
@@ -1793,6 +2093,23 @@ func TestRelayAuthoredAnswersAreNeverBlamedOnTheMailbox(t *testing.T) {
 	row, _ := rep.Find(KeyMailbox)
 	if row.State != StateFailed {
 		t.Errorf("the sidecar's own 503 = %s, want failed\n%s", row.State.Word(), rep)
+	}
+}
+
+// A sidecar that wedges DURING the walk — the reported failure exactly: the
+// liveness probe passed, and the process parked on a later call. The mailbox row
+// then gets the daemon's "alive but not serving" verdict, which says nothing
+// about the mailbox and must not cost the user a browser sign-in.
+func TestASidecarThatWedgesMidWalkIsNotBlamedOnTheMailbox(t *testing.T) {
+	rep := Check(context.Background(),
+		newFake().with("POST /v1/email/search", 503, healthWedged), EmailConfig())
+	row, _ := rep.Find(KeyMailbox)
+
+	if row.State != StateUnknown {
+		t.Fatalf("a wedged sidecar was reported as %s, want unknown\n%s", row.State.Word(), rep)
+	}
+	if strings.Contains(row.Remedy.Command, "connectors connect") || row.Fix == FixConnectMailbox {
+		t.Errorf("a wedged sidecar is answered with an OAuth sign-in: %q", row.Remedy.Command)
 	}
 }
 

--- a/tui/internal/ui/preflight/check_test.go
+++ b/tui/internal/ui/preflight/check_test.go
@@ -43,11 +43,11 @@ const (
 	healthOK = `{"status":"ok"}`
 
 	// The relay's 503 for a sidecar that passed its startup handshake and has
-	// since stopped serving — the published-binary wedge: an async handler doing
-	// a blocking Keychain read parks the event loop and every route with it, pid
-	// and port intact, so the daemon's own listing keeps saying "running".
-	// VERBATIM from sidecars/manager.check_responsive, which nothing on the
-	// Python side pins — a reword there has to break a test here.
+	// since stopped serving: whatever parks the event loop — a blocking call, a
+	// hung dependency — takes every route with it while pid and port stay
+	// intact, so the daemon's own listing keeps saying "running".
+	// VERBATIM from sidecars/manager.check_responsive; the phrase the row
+	// matches on is pinned Python-side too (test_sidecar_alive_but_not_serving).
 	healthWedged = `{"detail":"email sidecar (pid 41999) is alive but did not answer ` +
 		`http://127.0.0.1:51234/health within 2.0s (ReadTimeout: ). It passed its startup ` +
 		"health check, so it has stopped serving since — typically a blocked event loop or " +

--- a/tui/internal/ui/preflight/model.go
+++ b/tui/internal/ui/preflight/model.go
@@ -306,7 +306,10 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		} else {
 			m.focus = 0
 		}
-		if !m.rep.Blocked() && !m.opts.ManualProceed {
+		// A row the user can fix with one keypress holds the screen even when it
+		// does not block: the mailbox row is exactly that, and handing off past it
+		// would take `f connect a mailbox` away with the screen it was on.
+		if !m.rep.Blocked() && !m.opts.ManualProceed && !m.rep.HasOneKeyFix() {
 			if m.rep.HasHalt() {
 				// Three edits together: the tick, the phase, and the note each
 				// independently claim the launch is starting.

--- a/tui/internal/ui/preflight/report.go
+++ b/tui/internal/ui/preflight/report.go
@@ -29,8 +29,9 @@
 // what makes a gate either dishonest or useless:
 //
 //   - Is it proven ready?   Report.Ready() — false for an unknown row, always.
-//   - Is it proven broken?  Report.Blocked() — false for an unknown row.
-//   - Does the launch stop? Depends on the row's Disposition (see Row).
+//   - Is it proven broken?  A failed row — including an optional one.
+//   - Does the launch stop? Report.Blocked() for a failed row the AGENT needs
+//     (StateFailed and not Optional); for an unknown row, its Disposition.
 //
 // So an unknown row renders `[?]` and keeps Ready() false either way. Most of
 // them — an unadvertised Lemonade version, two mailboxes linked so neither
@@ -178,6 +179,14 @@ type Row struct {
 	Fix FixKind
 	// Provider is the mailbox provider a FixConnectMailbox targets.
 	Provider string
+	// Optional marks a row that gates a CAPABILITY rather than the launch: the
+	// agent starts and answers without it, and only the asks that need it fail.
+	// It is probed like any other, renders [!] when it fails, keeps Ready()
+	// false, is what FirstAttention puts the cursor on, and carries a remedy —
+	// it just does not refuse the run. The mailbox is one: email triage
+	// classifies the payload carried in the request and never reads a mailbox,
+	// so a missing mailbox must not refuse a triage query.
+	Optional bool
 	// Raw is the probe's raw answer (JSON body or error text), shown by `d`.
 	Raw string
 	// Disposition is what the checklist does when this row is not OK — Halt
@@ -257,12 +266,30 @@ func (r Report) Ready() bool {
 	return true
 }
 
-// Blocked reports whether at least one precondition proved NOT ready. A report
-// that is neither Ready nor Blocked has only indeterminate rows: the user may
-// proceed, but the screen must say what could not be verified.
+// Blocked reports whether at least one precondition of RUNNING the agent proved
+// NOT ready. A report that is neither Ready nor Blocked has nothing proven
+// broken that the agent needs: the user may proceed, but the screen must say
+// what could not be verified — or what failed without stopping the launch.
+//
+// Optional rows are excluded (see Row.Optional). They are still failures and
+// still say so; they are just failures of a capability the ask may not need, and
+// refusing every launch over one would make a mailbox-free triage impossible.
 func (r Report) Blocked() bool {
 	for _, row := range r.Rows {
-		if row.State == StateFailed {
+		if row.State == StateFailed && !row.Optional {
+			return true
+		}
+	}
+	return false
+}
+
+// HasOneKeyFix reports whether a row that still needs attention offers a fix the
+// user can apply from here. Such a row holds the screen even when nothing
+// blocks: auto-proceeding past a mailbox that is not connected would take the
+// `f` that connects it away with the screen it was on.
+func (r Report) HasOneKeyFix() bool {
+	for _, row := range r.Rows {
+		if row.NeedsAttention() && row.Fix != FixNone {
 			return true
 		}
 	}
@@ -377,11 +404,12 @@ func (r Report) Find(key string) (Row, bool) {
 	return Row{}, false
 }
 
-// Blocker returns the first failed row, or false when nothing failed. It is what
-// an integrator logs or shows in a one-line status when preflight refuses.
+// Blocker returns the first failed row that refuses the launch, or false when
+// none does. It is what an integrator logs or shows in a one-line status when
+// preflight refuses, so it mirrors Blocked and skips Optional rows.
 func (r Report) Blocker() (Row, bool) {
 	for _, row := range r.Rows {
-		if row.State == StateFailed {
+		if row.State == StateFailed && !row.Optional {
 			return row, true
 		}
 	}

--- a/tui/internal/ui/root/preflight.go
+++ b/tui/internal/ui/root/preflight.go
@@ -20,7 +20,7 @@ import (
 // is a fact with no expiry notice — the daemon can be killed, its client token
 // rotates on every restart, Lemonade can unload the model, a mailbox grant can be
 // revoked from the web — so a cached pass would open a chat that cannot answer
-// while claiming it had been verified. An all-green pass costs one attach, two
+// while claiming it had been verified. An all-green pass costs one attach, three
 // relayed GETs, and one bounded relayed mailbox read, and is held ~800ms; that is
 // the price of the answer being true now.
 func (m RootModel) beginPreflight(agent catalog.Agent) (tea.Model, tea.Cmd) {
@@ -124,14 +124,15 @@ func (m RootModel) cancelFromGate() (tea.Model, tea.Cmd) {
 	m.closeGate()
 	m.activeView = viewHub
 
-	// Backing out of a gate that had a real blocker leaves the user staring at a
-	// hub that looks like nothing happened. Say which row stopped it.
-	if blocker, blocked := rep.Blocker(); blocked {
+	// Backing out of a gate that found something leaves the user staring at a hub
+	// that looks like nothing happened. Say which row it was — the one that
+	// refused the launch, or the one the user was being asked to fix.
+	if row, found := attentionRow(rep); found {
 		// One line, and no trailing call to action: the hub truncates its status
 		// row at the terminal width, and a hint that gets cut mid-word is worse
 		// than the footer's own "enter run".
 		m.hub.SetStatus(fmt.Sprintf("%s did not start — %s is %s",
-			rep.AgentName, blocker.Label, blocker.Line))
+			rep.AgentName, row.Label, row.Line))
 	}
 
 	var cmds []tea.Cmd
@@ -139,6 +140,19 @@ func (m RootModel) cancelFromGate() (tea.Model, tea.Cmd) {
 		cmds = append(cmds, m.sizeCmd())
 	}
 	return m, tea.Batch(cmds...)
+}
+
+// attentionRow is the row worth naming after a gate the user left: the one that
+// refused the launch, or — when nothing did — the one it was asking them to fix.
+func attentionRow(rep preflight.Report) (preflight.Row, bool) {
+	if blocker, blocked := rep.Blocker(); blocked {
+		return blocker, true
+	}
+	idx := rep.FirstAttention()
+	if idx < 0 || rep.Rows[idx].State != preflight.StateFailed {
+		return preflight.Row{}, false
+	}
+	return rep.Rows[idx], true
 }
 
 func (m RootModel) sizeCmd() tea.Cmd {

--- a/tui/test/oneshot_readiness_test.go
+++ b/tui/test/oneshot_readiness_test.go
@@ -145,6 +145,39 @@ func TestOneShotReadinessProceedsPastAnUnverifiableRow(t *testing.T) {
 	}
 }
 
+// A triage query reads no mail: POST /v1/email/triage classifies the subject and
+// body carried in the request. So `run email --query …` must still work with no
+// mailbox connected — while still saying, on stderr, that the mailbox is not
+// usable and what to run about it.
+func TestOneShotRunsAMailboxFreeQueryAndStillWarnsAboutTheMailbox(t *testing.T) {
+	var errW bytes.Buffer
+	rep := ui.ReportReadiness(context.Background(),
+		readyGateTransport().mailboxMissing(), emailConfig(), &errW)
+
+	if rep.Blocked() {
+		t.Fatalf("a query that needs no mailbox was refused over the mailbox:\n%s", rep)
+	}
+	if _, blocked := rep.Blocker(); blocked {
+		t.Error("the mailbox row was reported as what refuses the run")
+	}
+	// Refused is not the same as unmentioned: the row is a failure and says so.
+	row, _ := rep.Find("mailbox")
+	if row.State != preflight.StateFailed {
+		t.Errorf("mailbox = %s, want failed — nothing about it works", row.State.Word())
+	}
+	msg := flatten(errW.String())
+	for _, want := range []string{
+		"Mailbox", "not connected", "gaia connectors connect google",
+	} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("the run said nothing about the unusable mailbox (%q):\n%s", want, errW.String())
+		}
+	}
+	if strings.Contains(msg, "Nothing was sent to the Email agent") {
+		t.Errorf("the run refused a query that needs no mailbox:\n%s", errW.String())
+	}
+}
+
 // --- a stand-in for the real daemon relay -----------------------------------
 
 // relayDaemon is the daemon side of a one-shot: the control plane, the agent

--- a/tui/test/preflight_gate_test.go
+++ b/tui/test/preflight_gate_test.go
@@ -43,6 +43,11 @@ type gateTransport struct {
 	initByAgent map[string]initAnswer
 	// connectors is the answer to GET /v1/<agent>/connectors.
 	connectors map[string]any
+	// healthStatus and healthBody are the answer to the sidecar row's liveness
+	// probe, GET /v1/<agent>/health. The daemon's listing only proves a PROCESS
+	// exists, so the gate asks the agent itself before probing anything below it.
+	healthStatus int
+	healthBody   map[string]any
 	// searchStatus and searchBody are the answer to the mailbox row's credential
 	// probe, POST /v1/<agent>/search. A connector list that says "connected and
 	// granted" is not evidence the mailbox works, so the gate reads it — and this
@@ -52,6 +57,7 @@ type gateTransport struct {
 
 	starts   int
 	ensures  int
+	healths  int
 	searches int
 }
 
@@ -84,6 +90,8 @@ func readyGateTransport() *gateTransport {
 					}},
 			},
 		},
+		healthStatus: http.StatusOK,
+		healthBody:   map[string]any{"status": "ok"},
 		searchStatus: http.StatusOK,
 		// EmailSearchResponse: `count` is required there, so a body without it is
 		// not the shape the sidecar serializes.
@@ -129,6 +137,9 @@ func (g *gateTransport) Do(_ context.Context, _, path string, _ []byte) (preflig
 			}
 		}
 		return jsonResponse(http.StatusOK, map[string]any{"agents": agents})
+	case strings.HasSuffix(path, "/health"):
+		g.healths++
+		return jsonResponse(g.healthStatus, g.healthBody)
 	case strings.HasSuffix(path, "/init"):
 		if answer, ok := g.initByAgent[agentFromPath(path)]; ok {
 			return jsonResponse(answer.status, answer.body)
@@ -190,6 +201,21 @@ func (g *gateTransport) modelMissing() *gateTransport {
 // state that asks the host to open a connector flow.
 func (g *gateTransport) mailboxMissing() *gateTransport {
 	g.connectors = map[string]any{"agent_id": "email", "providers": []map[string]any{}}
+	return g
+}
+
+// sidecarWedged is the state the daemon's agent listing cannot see: the process
+// is alive, registered and "running", and its event loop is parked, so it
+// answers nothing. The daemon's pre-relay probe reports it on the next relayed
+// call. VERBATIM from sidecars/manager.check_responsive.
+func (g *gateTransport) sidecarWedged() *gateTransport {
+	g.healthStatus = http.StatusServiceUnavailable
+	g.healthBody = map[string]any{
+		"detail": "email sidecar (pid 41999) is alive but did not answer " +
+			"http://127.0.0.1:51234/health within 2.0s (ReadTimeout: ). It passed its " +
+			"startup health check, so it has stopped serving since — typically a blocked " +
+			"event loop or a hung dependency.",
+	}
 	return g
 }
 
@@ -465,6 +491,39 @@ func TestAMailboxWhoseCredentialsAreRejectedNeverGreenLightsALaunch(t *testing.T
 	d.send(keyEnter())
 	if got := d.view(); got != "chat" {
 		t.Fatalf("enter over a repairable mailbox = %q, want chat\n%s", got, d.screen())
+	}
+}
+
+// An agent that is "running" and answers nothing must be named as such. The gate
+// used to show `[ok] Email agent 0.5.0 · running` and then blame the mailbox for
+// the timeout that followed — sending the user to the one part that was fine.
+func TestAnAgentThatAnswersNothingIsNamedOnItsOwnRow(t *testing.T) {
+	d := newRootDriver(t, readyGateTransport().sidecarWedged(), 80, 24)
+	d.launchEmail()
+
+	if got := d.view(); got != "preflight" {
+		t.Fatalf("a wedged agent landed on %q, want preflight\n%s", got, d.screen())
+	}
+	screen := d.flat()
+	for _, want := range []string{
+		"Email agent", "not answering",
+		"run: gaia daemon stop-agent email && gaia daemon start-agent email",
+		"~/.gaia/agents/email/logs/",
+	} {
+		if !strings.Contains(screen, want) {
+			t.Errorf("the gate does not show %q:\n%s", want, d.screen())
+		}
+	}
+	// The rows below it were never asked, so none of them may be blamed.
+	if strings.Contains(screen, "cannot be checked") {
+		t.Errorf("a row below the wedged agent reported a failure of its own:\n%s", d.screen())
+	}
+	if g := d.transport(); g.searches != 0 {
+		t.Errorf("the gate read the mailbox through an agent that answers nothing: %d reads", g.searches)
+	}
+	// And it never claims the agent is fine.
+	if strings.Contains(screen, "0.5.0 · running (pid") {
+		t.Errorf("the agent row still reads as healthy:\n%s", d.screen())
 	}
 }
 


### PR DESCRIPTION
The daemon reports an agent as "running" when all it knows is that a process exists — so an agent that came up, passed its startup handshake, and later stopped serving keeps its green row forever, and the user's first symptom is an unrelated preflight row timing out ten seconds later against something that was never at fault. That is what put `[!] Mailbox — cannot be checked` in front of a newcomer whose mailbox was fine. The startup health check runs once and is never repeated, and `poll()` cannot tell a serving process from a parked one, so nothing in the supervision path could see this class of failure. Now it can: the daemon re-probes readiness at the relay's single choke point and turns a wedged sidecar into an immediate, actionable 503 instead of a 300-second hang; the TUI asks the agent itself whether it answers rather than trusting the registry, so an unresponsive agent is named on its own row and the rows below it stay Pending; and a missing mailbox no longer refuses a triage query, which never reads a mailbox in the first place.

**Scope note.** The sidecar is *not* inherently broken — it serves normally against a clean agent-state directory (verified: 401 in 1.5 ms, full triage in 41 s, HTTP 200). The wedge reproduced against one contaminated `~/.gaia`. The detection gap is real regardless of trigger, and that is what this PR is for. The one sidecar change here is hardening, not a claim of a shipped defect: reading the OS credential store on the event loop costs the *whole process* rather than one request whenever that read is slow, so it now runs off the loop.

This branch also carries `docs/superpowers/specs/2026-07-30-tui-newcomer-journey-design.md` from the shared base commit of this effort, not from my own work.

## Test plan

- [x] `python -m pytest tests/unit/test_sidecar_alive_but_not_serving.py -q` — spawns a real process that stays alive and listens on nothing; asserts `is_running` is still `True` while `check_responsive` raises `SidecarUnresponsiveError`, that `registry.connection` refuses it, and that the two refusal phrases the TUI matches on (`relayGaveUp` in `check.go`) stay pinned Python-side.
- [x] `python -m pytest hub/agents/email/python/tests/test_connectors_does_not_wedge_loop.py -q` — asserts `/health` is served *while* a stuck credential read is in flight. Verified RED against the loop-blocking shape (`/health was served 3.04s after the credential read began`) and GREEN after, re-checked post-rebase.
- [x] `python -m pytest tests/unit/ -k "daemon or sidecar or relay or connector" -q` — 1406 passed, 93 skipped.
- [x] `python -m pytest hub/agents/email/python/tests/ -q` — 1511 passed. (`test_agent_version_matches_package_metadata` fails identically on pristine `origin/main` when the package is not pip-installed — pre-existing, verified in a clean worktree.)
- [x] `cd tui && go build ./... && go vet ./... && go test ./...` — 14 packages, all pass.
- [x] `python util/lint.py --black --isort` — clean.
- [x] End-to-end against a running daemon: the call that triggers a wedge times out as before, and the **next** call returns `HTTP 503 in 2.01s` naming the pid, the failed probe, the cause, `gaia daemon start-agent email`, and the exact sidecar log path — where it previously hung on the relay's 300s read timeout.


---

### Independent verification (not the author)

Re-ran on macOS against a live daemon and the freshly-upgraded Lemonade 11.5.0:

- `test_sidecar_alive_but_not_serving.py` — **6 passed**.
- `test_connectors_does_not_wedge_loop.py` — **1 passed in 3.69s**. It skips when `gaia_agent_email` is not importable (`pytest.importorskip`), which is what a plain `src`-only `PYTHONPATH` produces locally; CI installs it (`test_email_agent_unit.yml:112`), so it does run there. The 3.69s runtime confirms it genuinely exercises the wedge rather than short-circuiting.
- `cd tui && go build ./... && go vet ./... && go test ./...` — 18 packages OK.
- `python util/lint.py --black --isort` — clean.
- `pytest tests/unit/ -k "sidecar or unresponsive or manager"` — 388 passed, 82 skipped.

**The regression risk this change carries is a false positive — a healthy agent wrongly flagged as unresponsive. It does not occur.** Started the daemon from this branch in an isolated `HOME`, started the email sidecar, and it reported `email: running mode: user pid: … api: v2.4`, with a relay call returning `200 in 0.060s`.

One behaviour worth recording so it is not mistaken for a gap later: with the sidecar `SIGSTOP`ped (process alive, `Ts`), `gaia daemon status` still reports `running`. That is correct — `status` renders registry state, and the new probe fires on the paths that actually route to the sidecar (`relay.py:280`, `connections_routes.py:51`). `/v1/email/connectors` on the *daemon* port is a daemon-served route, so it answers from daemon state and is not a test of sidecar liveness.


**Both suites reproduced independently on macOS:** `pytest tests/unit/ -k "daemon or sidecar or relay or connector"` → **1406 passed, 93 skipped**, and `pytest hub/agents/email/python/tests/` → **1511 passed, 1 failed** — matching the stated figures exactly, including the single documented failure (`test_agent_version_matches_package_metadata`, which needs the package pip-installed).



**On the end-to-end wedge box:** attempted to reproduce it locally with a `SIGSTOP`-frozen sidecar behind a real daemon in an isolated `HOME`. It could not be reached — `POST /v1/email/query` is refused earlier with *"No mailbox connected — connect Google or Microsoft in Settings → Connectors before triaging."*, so the request never gets as far as the relay's responsiveness probe. Reproducing that box needs a connected mailbox (an OAuth grant), which is why it stays unticked here rather than being asserted.

Everything upstream of it is verified: the unit test that spawns a real alive-but-not-listening process passes (6/6), a healthy agent is **not** falsely flagged (relay `200 in 0.060s`), and both full suites reproduce the stated figures (1406 passed / 93 skipped, and 1511 passed with the one documented pre-existing failure).



**End-to-end wedge reproduced on macOS** against a real daemon in an isolated `HOME`, relaying through `POST /v1/email/triage` (a genuine sidecar route — `/v1/email/init` and `/v1/email/connectors` are answered by the daemon itself and do not exercise the relay).

Healthy baseline: **200 in 30.4s** (real model work). Then, with the sidecar frozen, **first call → 503 in 2.007s**, next call → **503 in 2.012s**, carrying every element the plan promises:

> `email sidecar (pid 46761) is alive but did not answer http://127.0.0.1:55903/health within 2.0s (ReadTimeout…). It passed its startup health check, so it has stopped serving since — typically a blocked event loop or a hung dependency. Restart it with 'gaia daemon start-agent email' and check the sidecar log at …/agents/email/logs/sidecar-55903.log.`

pid, the failed probe and its timeout, the cause, the remedy command, and the exact log path — all present, at the stated ~2s.

**A note for anyone re-running this:** the registered sidecar pid is a **launcher**, and the process actually serving HTTP is its child (`ppid` = the registered pid). `SIGSTOP` on the registered pid does **not** wedge the server — the child keeps answering, and the daemon correctly continues to report the agent as running. Freeze the child instead. Several earlier attempts here were invalid for exactly this reason and would have suggested the detection was not firing when it was.
