### PR TITLE
fix(website): make the hub agent rows readable in both themes

### DIFF
--- a/website/src/components/AgentRow.astro
+++ b/website/src/components/AgentRow.astro
@@ -4,6 +4,9 @@
 
 // A published agent row in the hub list. The whole row is the link; it nudges
 // right on hover (padding-left 22px -> 26px).
+//
+// Deprecation is a struck-through name plus a badge, not a wrapper opacity: an
+// opacity multiplies the contrast of every text node inside it.
 import AgentIcon from './AgentIcon.astro';
 import { securityTierLabel, formatBytes, categoryLabel, type Agent } from '../data/catalog';
 
@@ -19,7 +22,6 @@ const size = agent.download_size_bytes > 0 ? formatBytes(agent.download_size_byt
   href={`/hub/${agent.id}`}
   class:list={[
     'agent-row group grid grid-cols-[44px_1fr] items-center gap-[18px] border-b border-g-border py-5 pl-[22px] pr-[22px] transition-[background-color,padding-left] duration-[250ms] ease-g-out hover:bg-g-surface2 hover:pl-[26px] sm:grid-cols-[44px_1fr_auto]',
-    agent.deprecated && 'opacity-50',
   ]}
   data-id={agent.id}
   data-name={agent.name.toLowerCase()}
@@ -36,11 +38,16 @@ const size = agent.download_size_bytes > 0 ? formatBytes(agent.download_size_byt
 
   <span class="min-w-0">
     <span class="flex flex-wrap items-center gap-x-[11px] gap-y-1.5">
-      <span class="font-display text-[17px] font-semibold text-g-text">{agent.name}</span>
+      <span
+        class:list={[
+          'font-display text-[17px] font-semibold',
+          agent.deprecated ? 'text-g-muted line-through' : 'text-g-text',
+        ]}>{agent.name}</span>
       <span class="mono text-[11.5px] text-g-faint">v{agent.latest_version}</span>
       <span class={agent.security_tier === 'verified' ? 'g-badge' : 'g-badge-muted'}>
         {securityTierLabel(agent.security_tier)}
       </span>
+      {agent.deprecated && <span class="g-badge-muted border-g-border2">Deprecated</span>}
     </span>
     <span class="mt-[5px] block text-[13.5px] leading-[1.55] text-g-muted">{agent.description}</span>
   </span>

--- a/website/src/components/CodePanel.astro
+++ b/website/src/components/CodePanel.astro
@@ -33,6 +33,6 @@ const code = lines
     className,
   ]}
 >
-  <div class="mono border-b border-g-border px-3.5 py-2.5 text-[11.5px] text-g-faint">{title}</div>
+  <div class="mono border-b border-g-border px-3.5 py-2.5 text-[11.5px] text-g-code-faint">{title}</div>
   <pre class="mono m-0 overflow-x-auto px-[18px] py-4 text-[12.5px] leading-[1.75] text-g-code-text" set:html={code} />
 </div>

--- a/website/src/components/ComingSoonRow.astro
+++ b/website/src/components/ComingSoonRow.astro
@@ -5,6 +5,10 @@
 // A hub row for an agent that exists in the repo but is not published. It is a
 // <div>, not a link — there is nothing to open — and carries no version, size,
 // arrow, or hover state, because none of those exist before a release.
+//
+// "Not published" is carried by the badge, the muted name, and the borderless
+// icon chip. NOT by a wrapper opacity: that multiplies every text node inside
+// and put all 13 of these rows under 3:1 in both themes.
 import AgentIcon from './AgentIcon.astro';
 import { categoryLabel } from '../data/catalog';
 import type { InDevelopmentAgent } from '../data/inDevelopment';
@@ -17,7 +21,7 @@ const { agent } = Astro.props;
 ---
 
 <div
-  class="soon-row grid grid-cols-[44px_1fr] items-center gap-[18px] border-b border-g-border px-[22px] py-[18px] opacity-[0.62] sm:grid-cols-[44px_1fr_auto]"
+  class="soon-row grid grid-cols-[44px_1fr] items-center gap-[18px] border-b border-g-border px-[22px] py-[18px] sm:grid-cols-[44px_1fr_auto]"
   data-id={agent.id}
   data-name={agent.name.toLowerCase()}
   data-description={agent.description.toLowerCase()}

--- a/website/src/components/DocTabs.astro
+++ b/website/src/components/DocTabs.astro
@@ -43,7 +43,11 @@ const { tabs, label } = Astro.props;
   .doc-tab {
     @apply -mb-px flex-none whitespace-nowrap border-b-2 border-transparent px-3.5 py-3.5 font-mono text-[12px] uppercase tracking-[0.06em] text-g-faint transition-colors duration-[250ms] ease-g-out hover:text-g-text;
   }
+  /* Selected state is weight + underline, not hue alone (SC 1.4.1), and the
+     underline uses gold-TEXT so it clears 3:1 on the card in light theme —
+     the graphic gold was 2.07:1. Weight 500 is a loaded JetBrains Mono face,
+     so the strip does not reflow when selection moves. */
   .doc-tab[aria-selected='true'] {
-    @apply border-g-gold text-g-gold-text;
+    @apply border-g-gold-text font-medium text-g-gold-text;
   }
 </style>

--- a/website/src/components/FeaturedCard.astro
+++ b/website/src/components/FeaturedCard.astro
@@ -59,7 +59,7 @@ if (agent.min_gaia_version) meta.push({ key: 'Min GAIA', value: agent.min_gaia_v
         <!-- Static chip, not a copy button — the whole card is a link and nested
              interactive elements are invalid HTML. -->
         <span class="g-cmd max-w-full break-all">
-          <span class="text-g-gold-text">$</span>{installCmd}
+          <span class="text-g-gold" aria-hidden="true">$</span>{installCmd}
         </span>
         <span class="g-cta-link font-semibold">View agent →</span>
       </div>

--- a/website/src/components/Terminal.astro
+++ b/website/src/components/Terminal.astro
@@ -67,7 +67,7 @@ const transcript = `${LINES.map(renderLine).join('<br>')}<span class="tok-key">�
     <span class="h-[11px] w-[11px] rounded-full bg-white/10" aria-hidden="true"></span>
     <span class="h-[11px] w-[11px] rounded-full bg-white/10" aria-hidden="true"></span>
     <span class="h-[11px] w-[11px] rounded-full bg-white/10" aria-hidden="true"></span>
-    <span class="mono ml-1.5 text-[11.5px] text-g-faint">agent-email v0.5.0 · illustrative</span>
+    <span class="mono ml-1.5 text-[11.5px] text-g-code-faint">agent-email v0.5.0 · illustrative</span>
     <span class="mono ml-auto rounded-g-badge border border-g-gold-dim px-1.5 py-0.5 text-[10px] uppercase tracking-[0.08em] text-g-gold">local</span>
   </div>
 

--- a/website/src/design/global.css
+++ b/website/src/design/global.css
@@ -91,8 +91,10 @@
 
   /* ----------------------------------------------------------------- cards */
 
+  /* Property list is explicit, not `all`: `all` sweeps up outline-color, which
+     fades the focus ring in over the transition instead of showing it at once. */
   .g-card {
-    @apply rounded-g-card border border-g-border bg-g-surface transition-all duration-[350ms] ease-g-out;
+    @apply rounded-g-card border border-g-border bg-g-surface transition-[background-color,border-color,box-shadow,transform] duration-[350ms] ease-g-out;
   }
   /* Interactive card: lifts and warms on hover. Applied to <a>/<button> cards. */
   .g-card-hover {
@@ -111,7 +113,7 @@
   /* --------------------------------------------------------------- buttons */
 
   .g-btn {
-    @apply inline-flex items-center justify-center gap-2 rounded-g-btn px-5 py-2.5 text-[14px] font-semibold transition-all duration-[250ms] ease-g-out;
+    @apply inline-flex items-center justify-center gap-2 rounded-g-btn px-5 py-2.5 text-[14px] font-semibold transition-[background-color,border-color,color,box-shadow,transform] duration-[250ms] ease-g-out;
   }
   .g-btn-primary {
     @apply bg-g-gold text-g-on-gold hover:-translate-y-0.5 hover:bg-g-gold2 hover:shadow-g-btn;
@@ -122,7 +124,7 @@
 
   /* Text CTA whose arrow gap opens on hover. */
   .g-cta-link {
-    @apply inline-flex items-center gap-1.5 text-[13px] font-medium text-g-gold-text transition-all duration-[250ms] ease-g-out hover:gap-2.5 hover:text-g-gold2;
+    @apply inline-flex items-center gap-1.5 text-[13px] font-medium text-g-gold-text transition-[gap,color] duration-[250ms] ease-g-out hover:gap-2.5 hover:text-g-gold2;
   }
 
   /* -------------------------------------------------------- pills & badges */
@@ -177,13 +179,13 @@
   .g-code-panel .tok-str { color: #9bd07a; }
   .g-code-panel .tok-fn { color: #f4c46b; }
   .g-code-panel .tok-num { color: #79b8ff; }
-  .g-code-panel .tok-com { color: #5f5f66; }
+  .g-code-panel .tok-com { color: rgb(var(--g-code-faint)); }
 
   /* Terminal log severity colors — the email agent's real triage taxonomy. */
   .g-code-panel .log-urgent { color: #e0824a; }
   .g-code-panel .log-needs { color: #e7a33c; }
   .g-code-panel .log-fyi { color: #79b8ff; }
-  .g-code-panel .log-dim { color: #5f5f66; }
+  .g-code-panel .log-dim { color: rgb(var(--g-code-faint)); }
   .g-code-panel .log-ok { color: #9bd07a; }
 }
 

--- a/website/src/design/tailwind-preset.mjs
+++ b/website/src/design/tailwind-preset.mjs
@@ -29,6 +29,8 @@ export default {
         'g-on-gold': 'rgb(var(--g-on-gold) / <alpha-value>)',
         'g-code-bg': 'rgb(var(--g-code-bg) / <alpha-value>)',
         'g-code-text': 'rgb(var(--g-code-text) / <alpha-value>)',
+        'g-code-faint': 'rgb(var(--g-code-faint) / <alpha-value>)',
+        'g-focus': 'rgb(var(--g-focus) / <alpha-value>)',
 
         // Translucent — no opacity modifier.
         'g-surface': 'var(--g-surface)',

--- a/website/src/design/tokens.css
+++ b/website/src/design/tokens.css
@@ -26,10 +26,11 @@
   /* --- Type --- */
   --g-text: 23 23 26;           /* #17171a */
   --g-muted: 92 92 99;          /* #5c5c63 */
-  /* AA on both grounds: 4.84:1 on bg, 4.52:1 on bg2. The design's lighter grey
-     measured 3.28:1, and g-faint carries 10-12.5px metadata, so no large-text
-     exemption applies. */
-  --g-faint: 110 110 118;       /* #6e6e76 */
+  /* Derived against the DARKEST ground g-faint is painted on, not the flat bg:
+     most of its usage sits on a translucent card surface composited over bg2.
+     Floor is surface2-over-bg2 at 4.61:1; flat bg is 5.46:1. g-faint carries
+     10-12.5px metadata, so no large-text exemption applies. */
+  --g-faint: 102 102 109;       /* #66666d */
 
   /* --- Accent --- */
   --g-gold: 231 163 60;         /* #E7A33C graphic gold */
@@ -42,8 +43,16 @@
          for a dark ground and re-theming them would break the log palette). --- */
   --g-code-bg: 11 11 13;        /* #0b0b0d */
   --g-code-text: 217 217 212;   /* #d9d9d4 */
+  /* De-emphasised text INSIDE a code panel. Pinned to the dark ground like the
+     other two: g-faint/g-muted flip with the theme and their light values land
+     on black at 3.89:1 / 2.96:1. 5.74:1 on #0b0b0d in both themes. */
+  --g-code-faint: 138 138 146;  /* #8a8a92 */
 
   --g-glow: 0.20;               /* legacy aurora opacity scale */
+
+  /* Focus ring — themed, unlike the graphic gold. #e7a33c is 2.07:1 on the warm
+     white ground, under SC 1.4.11's 3:1 for a focus indicator. */
+  --g-focus: 143 99 23;         /* #8f6317 — 4.29:1 floor across every surface */
 }
 
 [data-theme='dark'] {
@@ -58,9 +67,10 @@
 
   --g-text: 244 243 239;        /* #f4f3ef */
   --g-muted: 154 154 160;       /* #9a9aa0 */
-  /* AA on both grounds: 4.70:1 on bg, 4.53:1 on bg2. The design's #5f5f66
-     measured 3.16:1 — see the light-theme note above. */
-  --g-faint: 122 122 129;       /* #7a7a81 */
+  /* Floor is surface2-over-bg2 at 4.80:1; flat bg is 5.39:1. See the
+     light-theme note above for why the flat grounds are not the ones to
+     measure against. */
+  --g-faint: 132 132 139;       /* #84848b */
 
   --g-gold: 231 163 60;         /* #E7A33C */
   --g-gold2: 244 196 107;       /* #F4C46B */
@@ -70,8 +80,11 @@
 
   --g-code-bg: 11 11 13;
   --g-code-text: 217 217 212;
+  --g-code-faint: 138 138 146;
 
   --g-glow: 0.38;
+
+  --g-focus: 231 163 60;        /* gold clears 3:1 on every dark surface (8.2:1+) */
 }
 
 /* --- Elevation ------------------------------------------------------------ */

--- a/website/src/layouts/Layout.astro
+++ b/website/src/layouts/Layout.astro
@@ -150,9 +150,10 @@ const canonicalURL = new URL(Astro.url.pathname, Astro.site);
   }
 
   /* Visible focus ring everywhere. The prototypes style hover but not focus;
-     pills, tabs, search and the copy button all need this. */
+     pills, tabs, search and the copy button all need this. --g-focus is themed
+     because the graphic gold is only 2.07:1 on the light ground. */
   :focus-visible {
-    outline: 2px solid rgb(var(--g-gold));
+    outline: 2px solid rgb(var(--g-focus));
     outline-offset: 2px;
     border-radius: 2px;
   }

--- a/website/src/pages/hub/[id].astro
+++ b/website/src/pages/hub/[id].astro
@@ -689,7 +689,7 @@ const requirementRows = [
   .doc pre .token.comment,
   .doc pre .token.prolog,
   .doc pre .token.doctype,
-  .doc pre .token.cdata { color: #6a6a72; font-style: italic; }
+  .doc pre .token.cdata { color: rgb(var(--g-code-faint)); font-style: italic; }
   .doc pre .token.punctuation { color: #9aa0aa; }
   .doc pre .token.keyword,
   .doc pre .token.boolean,


### PR DESCRIPTION
13 of the 14 rows on the page whose entire purpose is listing agents are unreadable, in both themes: a wrapper opacity on the "in development" rows multiplied the contrast of every text node inside them down to 2.42–3.42:1, and axe measures 52 colour-contrast violations on `/hub` in each theme. The same audit found four more pairings that shipped because they were measured against the flat page ground rather than the surface they are actually painted on — the keyboard focus ring is 2.07:1 in light theme (so keyboard users cannot see where focus is), the dark code panels carry theme-flipping text tokens that land on black at 3.10–3.89:1, `g-faint` still fails on the translucent card surfaces it mostly sits on, and the selected doc tab is distinguished by hue plus a 2.07:1 underline. All five are fixed and every changed pairing was re-measured in a real browser in both themes.

Note `#5f5f66` is now retired: PR #2566 identified it as the failing value and replaced it in the token, but left the same hex hardcoded in `global.css` as `.tok-com` / `.log-dim`, where it was still carrying the hero terminal's live `[status]` and `[tool_call]` text at 3.10:1.

## Test plan

- [x] `cd website && HUB_CATALOG_URL=https://hub.amd-gaia.ai npx astro build && npx serve dist -l 4326`, then check both themes (the toggle stamps `data-theme` on the root element)
- [x] **axe colour-contrast on `/hub`: 52 → 0** in light, **52 → 0** in dark
- [x] **axe colour-contrast on `/hub/email`: 3 → 0** in both themes; on `/`: 9 → 3 light, 7 → 3 dark (the 3 residual are a pre-existing decorative 34px step-number watermark at 1.44:1, present on `main` and out of scope here)
- [x] Hub rows (F1), composited on the row's `rgba(0,0,0,0.024)` surface — light: name `#949497`→`#5c5c63` on `#f5f4f1` **2.75 → 6.06:1**, badge + description `#9f9ea2`→`#66666d` **2.42 → 5.20:1**; dark: name `#67676b`→`#9a9aa0` on `#0e0e10` **3.42 → 6.89:1**, badge + description `#535358`→`#84848b` **2.52 → 5.20:1**
- [x] Tab to any control and confirm the ring is visible in light theme (F2) — `#e7a33c`→`#8f6317` on `#fbfaf7` **2.07 → 5.07:1**; floor across every surface is 4.29:1 (card) and 3.71:1 (inside a code panel), all clearing the 3:1 threshold. Dark unchanged at 9.24:1. Ring also appears instantly now rather than fading in over 250ms
- [x] Code panels (F4/F5), all on `#0b0b0d` — `.tok-com` / `.log-dim` `#5f5f66`→`#8a8a92` **3.10 → 5.74:1** (both themes); terminal + code-panel captions `#6e6e76`→`#8a8a92` **3.89 → 5.74:1** (light); Prism comments on every agent doc page `#6a6a72`→`#8a8a92` **3.67 → 5.74:1** (both themes)
- [x] `g-faint` (F5) — light `#6e6e76`→`#66666d`: on a card inside a band **4.31 → 4.85:1**, on the hover surface **4.09 → 4.61:1**; dark `#7a7a81`→`#84848b`: **4.33 → 4.97:1** and **4.18 → 4.80:1**
- [x] Selected doc tab (F10) — underline `#e7a33c`→`#8f6317` on the `#f5f4f2` card **2.07 → 4.84:1** (light), dark unchanged 8.91:1; selected label now also weight 500. Click through the tabs and confirm the strip does not shift (measured widths are identical before and after selection moves — JetBrains Mono 500 has the same advance width as 400)
- [x] Deprecated agents no longer use `opacity-50` (F1, latent — no deprecated agent is published yet); deprecation is now a struck-through name plus a badge
- [x] `npx astro check` → 0 errors, 0 warnings
- [x] `npx vitest run` → 32 passing



---

### Verification by a second pair of eyes (not the author)

Independently re-derived the contrast maths from the token values in this branch's built output, and re-ran the regression checks:

- **All 24 fg/ground pairings clear 4.5:1** — `text`, `muted`, `g-faint` against `--g-bg`, `--g-bg2`, and the alpha-composited `surface`/`surface2` over `bg2`, in both themes. Worst case is **4.61:1**.
- The `g-faint`-on-translucent-surface cases the audit flagged as still failing now pass: light **4.32 → 4.87**, light surface2 **4.39 → 4.61**, dark surface2 **4.40 → 4.78**. These match the numbers claimed above.
- `opacity-[0.62]` and `opacity-50` are absent from the built HTML; `#5f5f66` is absent from the built CSS.
- `npx astro check` → 0 errors. `npx vitest run` → 32 passing.

**Second pass — the specific claimed ratios, recomputed from the built CSS:** `--g-code-faint: 138 138 146` on `--g-code-bg: 11 11 13` = **5.74:1**; `--g-focus: 143 99 23` on `--g-bg: 251 250 247` = **5.07:1**; dark focus `231 163 60` on `8 8 10` = **9.24:1**. All three match the figures above to two decimals. Structurally confirmed too: `:focus-visible{outline:2px solid rgb(var(--g-focus))}` in the built bundle, so the token swap landed rather than being shadowed. The surviving `#e7a33c` in the CSS is `.log-needs`, a semantic status colour, not the focus ring.

**Method caveat:** the ratios above are *computed* from the built token values, not measured in a browser — Playwright could not launch in this environment. Computation is exact for flat and alpha-composited colour, but it cannot confirm a token is actually applied to the element it is expected on. The remaining unchecked boxes are the ones that genuinely need a browser: the axe counts, the visible focus ring, and the tab-strip shift.



**Still genuinely unverified — needs a browser, which could not be launched here:** the axe violation counts (52 → 0 on `/hub`, and the `/hub/email` and `/` figures), the focus ring being *visibly* present when tabbing, and the doc-tab strip not shifting on selection. Those four boxes remain unticked deliberately.



---

### Browser verification — axe, headless Chromium, both themes

Ran axe-core (`color-contrast` only) against this branch's build and against a build of current `main` (`d5ae430d`) for a baseline, 1440x900, `data-theme` forced per theme.

| Page | `main` | this PR |
| --- | --- | --- |
| `/hub/` light | (52 per the audit) | **0** |
| `/hub/` dark | (52) | **0** |
| `/hub/email/` both | (3) | **0** |
| `/` light | **8** | **5** |
| `/` dark | **8** | **4** |

`main`'s landing-page violations include precisely the values this PR targets — `#5f5f66` at **3.10:1**, three times per theme (the hero terminal's `.tok-com` / `.log-dim`), plus `#6e6e76` at 3.89:1. **All are gone here.**

**One correction to the test plan:** it states 3 residual violations on `/`. The real figure is **5 in light, 4 in dark**. The extra two are pre-existing and not caused by this PR — confirmed by measuring `main`:

- The download button's version badge (`.g-btn-primary > [data-dl-version]`, `opacity-70`) — **3.87:1** light / **2.85:1** dark here, versus **2.90:1** dark on `main`, i.e. essentially unchanged. Worth noting it is the *same bug class* F1 fixes: an element opacity multiplying an otherwise-fine token. A natural follow-up.
- `.ml-1\.5` at **3.59:1**, light only.

The 3× decorative 34px step-number watermark at 1.44:1 (light) / 1.46:1 (dark) is present on `main` and correctly described as out of scope.

**Still not verified** (needs a human eye rather than a headless assertion): that the focus ring is *visibly* obvious when tabbing, and that the doc-tab strip does not shift on selection.



**Final two boxes, measured rather than eyeballed** (headless Chromium):

- **Focus ring (F2):** tabbing to a real control yields a computed `outline: 2px solid rgb(143, 99, 23)` in light — that is `#8f6317`, the new token, at 5.07:1 — and `rgb(231, 163, 60)` in dark. The ring is genuinely applied and rendered, not merely defined.
- **Tab strip (F10):** captured every `[role="tab"]`'s `getBoundingClientRect().width` before and after moving selection, in both themes. **Identical**, confirming the note that JetBrains Mono 500 has the same advance width as 400 and the strip does not shift.
