### PR TITLE
fix(tui): show a failed tool's own error instead of an "Invalid card" box

### DIFF
--- a/tui/internal/ui/chat/canonical.go
+++ b/tui/internal/ui/chat/canonical.go
@@ -56,19 +56,38 @@ func (m ChatModel) handleCanonicalEvent(evt interface{}) (ChatModel, tea.Cmd, bo
 		m.activity = append(m.activity, ActivityItem{Kind: "tool", Content: label})
 
 	case event.CanonicalToolResultEvent:
-		m.markToolDone(e)
-		if e.Render != "" {
-			// The sidecar declared a card, so the card is the result. The email
-			// agent's pre-scan tool docstring tells the model NOT to describe the
-			// results in prose precisely because the client is expected to draw
-			// this — ignore `render` and the turn produces one vague sentence.
-			m.messages = append(m.messages, Message{
-				Role:     RoleCard,
-				ToolName: e.Tool,
-				Render:   e.Render,
-				Data:     e.Data,
-			})
+		// Only trust the failure classifier where a card was declared. Outside
+		// the render domain the sidecar's truncated, string-encoded `summary`
+		// fools it into misreading an ordinary partial-success batch as a
+		// failure (#2723) — do not widen this gate before that lands; see
+		// plan S1 / AC-5 / AC-7c for the harness that proved it.
+		if e.Render == "" {
+			m.markToolDone(e)
+			break
 		}
+		if outcome, toolErr := event.ToolOutcomeOf(e); outcome == event.ToolOutcomeFailed {
+			// ToolOutcomeFailed always ticks red here — deliberately overriding
+			// ToolOutcome's "Unknown is never a pass" doc comment, but only for
+			// this two-state presentation mapping (S3): Succeeded and Unknown
+			// both still tick green via markToolDone below.
+			m.setOpenToolOutcome(e.Tool, false)
+			m.messages = append(m.messages, Message{
+				Role:    RoleError,
+				Content: sanitizeErrorText(composeToolErrorText(e.Tool, toolErr)),
+			})
+			break
+		}
+		// The sidecar declared a card, so the card is the result. The email
+		// agent's pre-scan tool docstring tells the model NOT to describe the
+		// results in prose precisely because the client is expected to draw
+		// this — ignore `render` and the turn produces one vague sentence.
+		m.markToolDone(e)
+		m.messages = append(m.messages, Message{
+			Role:     RoleCard,
+			ToolName: e.Tool,
+			Render:   e.Render,
+			Data:     e.Data,
+		})
 
 	case event.CanonicalNeedsInputEvent:
 		// The run is parked waiting for this answer, on the stream we are still
@@ -322,8 +341,15 @@ func (m ChatModel) confirmAction(runID, action string, approved bool) tea.Cmd {
 // absent that, a delivered result counts as completed. Per-tool detail belongs
 // to the render card drawn in the transcript, not to this one-line summary.
 func (m *ChatModel) markToolDone(e event.CanonicalToolResultEvent) {
-	success := toolResultSucceeded(e.Data)
+	m.setOpenToolOutcome(e.Tool, toolResultSucceeded(e.Data))
+}
 
+// setOpenToolOutcome closes out the activity line opened by the matching
+// tool_call with an explicit success value. Shared by markToolDone (which
+// derives success from toolResultSucceeded) and the failed-render path in
+// handleCanonicalEvent (which must not: that classifier trusts the sidecar's
+// `success: true` even when the tool's own nested result says otherwise).
+func (m *ChatModel) setOpenToolOutcome(tool string, success bool) {
 	for i := len(m.activity) - 1; i >= 0; i-- {
 		item := &m.activity[i]
 		if item.Kind != "tool" || item.Done {
@@ -337,10 +363,27 @@ func (m *ChatModel) markToolDone(e event.CanonicalToolResultEvent) {
 	// A result with no matching call still has to be visible.
 	m.activity = append(m.activity, ActivityItem{
 		Kind:    "tool",
-		Content: e.Tool,
+		Content: tool,
 		Done:    true,
 		Success: &success,
 	})
+}
+
+// composeToolErrorText builds the RoleError text for a failed render tool:
+// the tool name, the error's machine-readable Code when present, then the
+// tool's own message verbatim. Kept chat-local rather than shared with
+// ui.writeToolError (D1): package ui imports ui/chat (app.go:19), so the
+// reverse import would be a cycle.
+func composeToolErrorText(tool string, te event.ToolError) string {
+	head := tool + " failed"
+	if te.Code != "" {
+		head += " — " + te.Code
+	}
+	message := strings.TrimRight(te.Message, "\n")
+	if message == "" {
+		return head + " (the tool reported no detail)"
+	}
+	return head + ": " + message
 }
 
 func toolResultSucceeded(data json.RawMessage) bool {

--- a/tui/internal/ui/chat/sanitize.go
+++ b/tui/internal/ui/chat/sanitize.go
@@ -12,9 +12,13 @@ import (
 // renders "[!] " + msg.Content through a bare lipgloss style with no
 // scrubbing of its own — so a tool error reaching Message.Content unsanitized
 // can carry a live ANSI escape or control byte onto the terminal.
-// cards.clean() cannot be reused here: it maps newlines to spaces, which
+// cards.clean() cannot be reused as-is: it maps newlines to spaces, which
 // would flatten the sidecar's `gaia connectors connect ...` remedy onto one
-// line — exactly the text this fix exists to keep readable.
+// line — exactly the text this fix exists to keep readable. This helper
+// differs from cards.clean() only there: newlines survive, tabs still become
+// a space exactly as cards.clean() does ("keep the word break, drop the
+// cursor movement"), and \r is still dropped so \r\n collapses to \n rather
+// than leaving a trailing space.
 func sanitizeErrorText(s string) string {
 	if s == "" {
 		return s
@@ -26,6 +30,8 @@ func sanitizeErrorText(s string) string {
 		switch {
 		case r == '\n':
 			return r
+		case r == '\t':
+			return ' '
 		case r < 0x20 || r == 0x7f:
 			return -1
 		}

--- a/tui/internal/ui/chat/sanitize.go
+++ b/tui/internal/ui/chat/sanitize.go
@@ -1,0 +1,34 @@
+package chat
+
+import (
+	"strings"
+
+	"github.com/charmbracelet/x/ansi"
+)
+
+// sanitizeErrorText makes a tool-supplied string safe for the RoleError sink.
+//
+// Unlike the card path (box.add -> cards.clean()), model.go's RoleError case
+// renders "[!] " + msg.Content through a bare lipgloss style with no
+// scrubbing of its own — so a tool error reaching Message.Content unsanitized
+// can carry a live ANSI escape or control byte onto the terminal.
+// cards.clean() cannot be reused here: it maps newlines to spaces, which
+// would flatten the sidecar's `gaia connectors connect ...` remedy onto one
+// line — exactly the text this fix exists to keep readable.
+func sanitizeErrorText(s string) string {
+	if s == "" {
+		return s
+	}
+	if strings.ContainsRune(s, 0x1b) {
+		s = ansi.Strip(s)
+	}
+	return strings.Map(func(r rune) rune {
+		switch {
+		case r == '\n':
+			return r
+		case r < 0x20 || r == 0x7f:
+			return -1
+		}
+		return r
+	}, s)
+}

--- a/tui/internal/ui/chat/tool_error_render_test.go
+++ b/tui/internal/ui/chat/tool_error_render_test.go
@@ -1,0 +1,259 @@
+package chat
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/charmbracelet/x/ansi"
+
+	"github.com/amd/gaia/tui/internal/event"
+)
+
+// failedPreScanEnvelope is the issue's literal AC-1 fixture: the email
+// sidecar's success:true trap around a nested, string-encoded failure.
+const failedPreScanEnvelope = `{"summary":"{\"ok\": false, \"error\": \"CONNECTOR_ERROR: All connected mailboxes failed: google: Gmail batch GET returned 429\"}","success":true,"latency_ms":395.0}`
+
+// AC-1 + AC-4: a failed render tool shows the tool's own error instead of a
+// broken card, even though the envelope's top-level "success" field lies.
+func TestFailedRenderToolShowsErrorNotCard(t *testing.T) {
+	m := feed(t, newTestChat(t),
+		event.CanonicalToolCallEvent{Type: "tool_call", Tool: "pre_scan_inbox"},
+		event.CanonicalToolResultEvent{
+			Type:   "tool_result",
+			Tool:   "pre_scan_inbox",
+			Render: "email_pre_scan",
+			Data:   json.RawMessage(failedPreScanEnvelope),
+		},
+	)
+
+	for _, msg := range m.messages {
+		if msg.Role == RoleCard {
+			t.Fatalf("a failed render tool must not produce a card: %+v", msg)
+		}
+	}
+
+	var errMsg *Message
+	for i := range m.messages {
+		if m.messages[i].Role == RoleError {
+			errMsg = &m.messages[i]
+		}
+	}
+	if errMsg == nil {
+		t.Fatal("no RoleError message was produced for the failed render tool")
+	}
+	// Asserted on Message.Content, never on rendered output: at the harness's
+	// own 80-column width this phrase wraps mid-string (see the wrap-trap
+	// note in the plan), so a rendered-text assertion here would fail a
+	// correct implementation.
+	if !strings.Contains(errMsg.Content, "CONNECTOR_ERROR") ||
+		!strings.Contains(errMsg.Content, "All connected mailboxes failed") {
+		t.Errorf("tool error text lost the actionable message: %q", errMsg.Content)
+	}
+
+	// (c) short, unwrappable negative strings — safe to assert on rendered
+	// output via the established idiom (cards_test.go:129).
+	m.updateViewport()
+	rendered := ansi.Strip(m.viewport.View())
+	if strings.Contains(rendered, "Invalid card") {
+		t.Errorf("the broken card box must not appear:\n%s", rendered)
+	}
+	if strings.Contains(rendered, "raw data:") {
+		t.Errorf("the raw JSON dump must not appear:\n%s", rendered)
+	}
+}
+
+// AC-5: the S1 gate. A failed tool with no render key must be untouched by
+// this change — this pins the guard against a future "simplification" that
+// removes the Render check and reintroduces the proven batch false positive.
+func TestFailedNonRenderToolChangesNothing(t *testing.T) {
+	data := json.RawMessage(`{"status":"error","error":"boom"}`)
+	m := feed(t, newTestChat(t),
+		event.CanonicalToolCallEvent{Type: "tool_call", Tool: "archive_message_batch"},
+		event.CanonicalToolResultEvent{Type: "tool_result", Tool: "archive_message_batch", Data: data},
+	)
+
+	for _, msg := range m.messages {
+		if msg.Role == RoleError {
+			t.Fatalf("a non-render tool result must not gain a new RoleError message: %+v", msg)
+		}
+	}
+	// "keeps its current value" — whatever today's markToolDone classifier
+	// (toolResultSucceeded) already computes, unchanged by this fix.
+	want := toolResultSucceeded(data)
+	item := m.activity[0]
+	if item.Success == nil || *item.Success != want {
+		t.Errorf("tick changed for a non-render tool: got %v, want %v (today's classifier)", item.Success, want)
+	}
+}
+
+// AC-6: an empty ToolError.Message must not render an empty [!] panel.
+func TestFailedRenderToolWithNoDetailShowsNoDetailMessage(t *testing.T) {
+	m := feed(t, newTestChat(t), event.CanonicalToolResultEvent{
+		Type:   "tool_result",
+		Tool:   "pre_scan_inbox",
+		Render: "email_pre_scan",
+		Data:   json.RawMessage(`{"ok":false}`),
+	})
+
+	var errMsg *Message
+	for i := range m.messages {
+		if m.messages[i].Role == RoleError {
+			errMsg = &m.messages[i]
+		}
+	}
+	if errMsg == nil {
+		t.Fatal("no RoleError message was produced")
+	}
+	if strings.TrimSpace(errMsg.Content) == "" {
+		t.Fatal("an empty ToolError.Message must not render an empty panel")
+	}
+	if !strings.Contains(errMsg.Content, "no detail") {
+		t.Errorf("expected the message to say the tool reported no detail, got %q", errMsg.Content)
+	}
+}
+
+// AC-7a: a failed render tool must tick red, not green.
+func TestFailedRenderToolTicksFailed(t *testing.T) {
+	m := feed(t, newTestChat(t),
+		event.CanonicalToolCallEvent{Type: "tool_call", Tool: "pre_scan_inbox"},
+		event.CanonicalToolResultEvent{
+			Type:   "tool_result",
+			Tool:   "pre_scan_inbox",
+			Render: "email_pre_scan",
+			Data:   json.RawMessage(failedPreScanEnvelope),
+		},
+	)
+
+	if len(m.activity) != 1 {
+		t.Fatalf("expected one tool activity line, got %+v", m.activity)
+	}
+	item := m.activity[0]
+	if item.Success == nil || *item.Success {
+		t.Errorf("a failed render tool must tick red, got %v", item.Success)
+	}
+}
+
+// AC-7b: a genuinely silent render payload (neither ok nor error, so
+// ToolOutcomeUnknown) keeps today's ✓ tick. Nothing pinned this before.
+func TestSilentRenderPayloadStillTicksSucceeded(t *testing.T) {
+	m := feed(t, newTestChat(t),
+		event.CanonicalToolCallEvent{Type: "tool_call", Tool: "some_tool"},
+		event.CanonicalToolResultEvent{
+			Type:   "tool_result",
+			Tool:   "some_tool",
+			Render: "some_future_card",
+			Data:   json.RawMessage(`{"latency_ms":12}`),
+		},
+	)
+
+	item := m.activity[0]
+	if item.Success == nil || !*item.Success {
+		t.Errorf("a silent payload should keep today's ✓ tick, got %v", item.Success)
+	}
+	var card *Message
+	for i := range m.messages {
+		if m.messages[i].Role == RoleCard {
+			card = &m.messages[i]
+		}
+	}
+	if card == nil {
+		t.Fatal("ToolOutcomeUnknown must still draw a card (AC-3)")
+	}
+}
+
+// AC-7c: the pre-mortem's proven false positive. A truncated, string-encoded
+// batch summary containing a per-item "error" key classifies as Failed even
+// though the operation was an ordinary partial success — but because Render
+// is empty, this change must leave it untouched (S1). #2723 is the actual
+// fix for the classifier; this test only pins that nothing here acts on it.
+func TestBatchFalsePositiveStaysHarmless(t *testing.T) {
+	truncated := `{\"succeeded\": [\"m1\", \"m2\", \"m3\"], \"failed\": [{\"message_id\": \"m4\", \"error\": \"not fou`
+	data := json.RawMessage(`{"summary":"` + truncated + `","success":true}`)
+
+	// Sanity: this fixture really does trip the classifier (otherwise the
+	// test below proves nothing about the gate).
+	if outcome, _ := event.ToolOutcomeOf(event.CanonicalToolResultEvent{Tool: "archive_message_batch", Data: data}); outcome != event.ToolOutcomeFailed {
+		t.Fatalf("fixture setup: expected the classifier to misfire as Failed, got %s", outcome)
+	}
+
+	m := feed(t, newTestChat(t),
+		event.CanonicalToolCallEvent{Type: "tool_call", Tool: "archive_message_batch"},
+		event.CanonicalToolResultEvent{Type: "tool_result", Tool: "archive_message_batch", Data: data},
+	)
+
+	for _, msg := range m.messages {
+		if msg.Role == RoleError {
+			t.Fatalf("a non-render tool must not gain a RoleError message even when the classifier misfires: %+v", msg)
+		}
+		if msg.Role == RoleCard {
+			t.Fatalf("a non-render tool must never produce a card: %+v", msg)
+		}
+	}
+	want := toolResultSucceeded(data)
+	item := m.activity[0]
+	if item.Success == nil || *item.Success != want {
+		t.Errorf("tick must stay whatever today's classifier already computes: got %v, want %v", item.Success, want)
+	}
+}
+
+// AC-8 / D3 / C1: the RoleError sink has no sanitizer of its own — control
+// bytes in a tool's own error text must not reach it. A JSON string can
+// carry a real ESC byte via a \u001b escape, so this path is live, not
+// theoretical.
+func TestFailedRenderErrorSanitizesControlBytesPreservesNewlines(t *testing.T) {
+	malicious := "line one\n\x1b[31mred\x1b[0m line two\x07 line three"
+	encoded, err := json.Marshal(malicious)
+	if err != nil {
+		t.Fatal(err)
+	}
+	data := json.RawMessage(`{"ok":false,"error":` + string(encoded) + `}`)
+
+	m := feed(t, newTestChat(t), event.CanonicalToolResultEvent{
+		Type: "tool_result", Tool: "pre_scan_inbox", Render: "email_pre_scan", Data: data,
+	})
+
+	var errMsg *Message
+	for i := range m.messages {
+		if m.messages[i].Role == RoleError {
+			errMsg = &m.messages[i]
+		}
+	}
+	if errMsg == nil {
+		t.Fatal("no RoleError message was produced")
+	}
+	if strings.ContainsRune(errMsg.Content, 0x1b) {
+		t.Errorf("ESC byte reached Message.Content: %q", errMsg.Content)
+	}
+	if strings.ContainsRune(errMsg.Content, 0x07) {
+		t.Errorf("C0 byte (BEL) reached Message.Content: %q", errMsg.Content)
+	}
+	if !strings.Contains(errMsg.Content, "\n") {
+		t.Errorf("an embedded newline must survive sanitization (the remedy command needs its own line): %q", errMsg.Content)
+	}
+	if !strings.Contains(errMsg.Content, "line one") || !strings.Contains(errMsg.Content, "line three") {
+		t.Errorf("message text lost content during sanitization: %q", errMsg.Content)
+	}
+}
+
+// AC-9: guards against overfitting to the issue's specific CONNECTOR_ERROR
+// string — any failure text must surface verbatim.
+func TestFailedRenderErrorNotHardcodedToConnectorError(t *testing.T) {
+	m := feed(t, newTestChat(t), event.CanonicalToolResultEvent{
+		Type: "tool_result", Tool: "pre_scan_inbox", Render: "email_pre_scan",
+		Data: json.RawMessage(`{"error":"disk is full"}`),
+	})
+
+	var errMsg *Message
+	for i := range m.messages {
+		if m.messages[i].Role == RoleError {
+			errMsg = &m.messages[i]
+		}
+	}
+	if errMsg == nil {
+		t.Fatal("no RoleError message was produced")
+	}
+	if !strings.Contains(errMsg.Content, "disk is full") {
+		t.Errorf("unrelated failure text must surface verbatim: %q", errMsg.Content)
+	}
+}

--- a/tui/internal/ui/chat/tool_error_render_test.go
+++ b/tui/internal/ui/chat/tool_error_render_test.go
@@ -209,7 +209,7 @@ func TestBatchFalsePositiveStaysHarmless(t *testing.T) {
 // carry a real ESC byte via a \u001b escape, so this path is live, not
 // theoretical.
 func TestFailedRenderErrorSanitizesControlBytesPreservesNewlines(t *testing.T) {
-	malicious := "line one\n\x1b[31mred\x1b[0m line two\x07 line three"
+	malicious := "archived 5\tfailed 2\r\nline three\n\x1b[31mred\x1b[0m line four\x07 line five"
 	encoded, err := json.Marshal(malicious)
 	if err != nil {
 		t.Fatal(err)
@@ -235,10 +235,25 @@ func TestFailedRenderErrorSanitizesControlBytesPreservesNewlines(t *testing.T) {
 	if strings.ContainsRune(errMsg.Content, 0x07) {
 		t.Errorf("C0 byte (BEL) reached Message.Content: %q", errMsg.Content)
 	}
+	// A tab keeps the word break (becomes a space, per cards.clean()'s
+	// convention) rather than vanishing and running the words together.
+	if strings.ContainsRune(errMsg.Content, '\t') {
+		t.Errorf("tab byte reached Message.Content: %q", errMsg.Content)
+	}
+	if !strings.Contains(errMsg.Content, "archived 5 failed 2") {
+		t.Errorf("a tab must become a space, not disappear: %q", errMsg.Content)
+	}
+	// \r\n must collapse to a single \n, not leave \r or a blank line behind.
+	if strings.ContainsRune(errMsg.Content, '\r') {
+		t.Errorf("CR byte reached Message.Content: %q", errMsg.Content)
+	}
+	if !strings.Contains(errMsg.Content, "failed 2\nline three") {
+		t.Errorf("\\r\\n must collapse to a single \\n: %q", errMsg.Content)
+	}
 	if !strings.Contains(errMsg.Content, "\n") {
 		t.Errorf("an embedded newline must survive sanitization (the remedy command needs its own line): %q", errMsg.Content)
 	}
-	if !strings.Contains(errMsg.Content, "line one") || !strings.Contains(errMsg.Content, "line three") {
+	if !strings.Contains(errMsg.Content, "archived 5") || !strings.Contains(errMsg.Content, "line five") {
 		t.Errorf("message text lost content during sanitization: %q", errMsg.Content)
 	}
 }

--- a/tui/internal/ui/chat/tool_error_render_test.go
+++ b/tui/internal/ui/chat/tool_error_render_test.go
@@ -78,12 +78,13 @@ func TestFailedNonRenderToolChangesNothing(t *testing.T) {
 			t.Fatalf("a non-render tool result must not gain a new RoleError message: %+v", msg)
 		}
 	}
-	// "keeps its current value" — whatever today's markToolDone classifier
-	// (toolResultSucceeded) already computes, unchanged by this fix.
-	want := toolResultSucceeded(data)
+	// "keeps its current value": today's markToolDone classifier
+	// (toolResultSucceeded) has no top-level "ok"/"success" bool to read from
+	// this fixture, so it defaults to true — pinned literally, not derived
+	// from the function under test.
 	item := m.activity[0]
-	if item.Success == nil || *item.Success != want {
-		t.Errorf("tick changed for a non-render tool: got %v, want %v (today's classifier)", item.Success, want)
+	if item.Success == nil || !*item.Success {
+		t.Errorf("tick changed for a non-render tool: got %v, want true (today's classifier)", item.Success)
 	}
 }
 
@@ -171,8 +172,12 @@ func TestBatchFalsePositiveStaysHarmless(t *testing.T) {
 	truncated := `{\"succeeded\": [\"m1\", \"m2\", \"m3\"], \"failed\": [{\"message_id\": \"m4\", \"error\": \"not fou`
 	data := json.RawMessage(`{"summary":"` + truncated + `","success":true}`)
 
-	// Sanity: this fixture really does trip the classifier (otherwise the
-	// test below proves nothing about the gate).
+	// Sanity, deliberately kept: this fixture must really trip the
+	// classifier, or the assertions below prove nothing about the gate. When
+	// #2723 fixes the truncation heuristic, this misfire stops happening and
+	// this Fatalf will fire — that is the point, not a flake: it forces
+	// whoever lands #2723 to come back and re-examine this gate rather than
+	// silently letting the fixture go stale. Do not delete this on a "cleanup".
 	if outcome, _ := event.ToolOutcomeOf(event.CanonicalToolResultEvent{Tool: "archive_message_batch", Data: data}); outcome != event.ToolOutcomeFailed {
 		t.Fatalf("fixture setup: expected the classifier to misfire as Failed, got %s", outcome)
 	}
@@ -190,10 +195,12 @@ func TestBatchFalsePositiveStaysHarmless(t *testing.T) {
 			t.Fatalf("a non-render tool must never produce a card: %+v", msg)
 		}
 	}
-	want := toolResultSucceeded(data)
+	// The fixture carries a top-level "success":true, which is what today's
+	// classifier (toolResultSucceeded) reads — pinned literally, not derived
+	// from the function under test.
 	item := m.activity[0]
-	if item.Success == nil || *item.Success != want {
-		t.Errorf("tick must stay whatever today's classifier already computes: got %v, want %v", item.Success, want)
+	if item.Success == nil || !*item.Success {
+		t.Errorf("tick must stay whatever today's classifier already computes: got %v, want true", item.Success)
 	}
 }
 


### PR DESCRIPTION
Closes #2721

When a mailbox scan failed, the TUI drew a box titled **"Invalid card"** followed by a dump of internal JSON, and threw away the only text in the run that said how to fix the problem — the tool's own error, ending in the exact `gaia connectors connect …` line that repairs a broken connector. The activity line made it worse by putting a green tick next to the same failed tool, so the screen was wrong in two directions at once. Now a failed card-drawing tool shows its own error text, verbatim and readable, and its tick turns red. Successful cards render exactly as before.

## Scope — narrower than the issue, deliberately

The issue's fix looks like it should apply to every failed tool. It must not, and the reason is worth a reviewer's minute.

The data the TUI receives for a tool that draws **no** card is a 300-character truncation of the tool's reply ([`sse_handler.py:1165`](src/gaia/ui/sse_handler.py)), usually cut mid-JSON. The existing failure detector then falls back to scanning that fragment for `"error"` — and a batch result carries one `"error"` key per failed item. So an ordinary "archived 3 of 4 messages" classifies as a **failure**. Verified by running real payload shapes through the real classifier.

Applying the fix ungated would therefore have pasted a wall of mid-cut JSON into the transcript over operations that mostly succeeded — a worse regression than the bug being fixed, and one that would have passed every acceptance criterion green.

So the fix is gated on the tool having declared a card. That is safe rather than arbitrary: `_render_card_payload` returns `None` on a failed envelope and the real payload otherwise ([`sse_handler.py:506-537`](src/gaia/ui/sse_handler.py)), so a **successful** card tool forwards its true structured payload and cannot reach the truncation heuristic at all. The false-positive class lives entirely outside the gate.

Two tests exist purely to stop someone removing that gate later. Please don't widen it before #2723 lands.

## Found while reviewing this

- **#2723 (p1) — already broken on `main`, unrelated to this PR.** `oneshot.go` calls the same detector ungated today, so `gaia email --query` already prints a fabricated failure and **exits 1** on mostly-successful batch operations.
- **#2724** — the deferred half: a failed tool that draws no card still shows nothing at all. Blocked on #2723.
- **#2725** — `CanonicalErrorEvent.Detail` reaches the terminal without stripping control sequences.

<details>
<summary>Two things a reviewer might otherwise flag</summary>

**Why the error text is sanitized.** The card path is already escape-safe (`box.add` → `cards.clean()`); the `RoleError` sink is not — it renders through a bare lipgloss style. Moving this payload from one to the other without scrubbing would have been a net regression in terminal safety, since `json.Unmarshal` decodes `` into a live ESC byte. Hence the new `sanitizeErrorText`, which is `cards.clean()` with newlines preserved — the sidecar's remedy command has to stay on its own line.

**Why the composer isn't shared with `oneshot.go`'s `writeToolError`.** Package `ui` imports `ui/chat`, so the reverse import would be a cycle. The classification *is* shared; only the formatting is duplicated, and the two surfaces have genuinely different output shapes.

</details>

## Test plan

- [ ] `cd tui && go test ./internal/ui/chat/... ./internal/event/... ./internal/ui/cards/...` — 179 pass, 0 fail
- [ ] `cd tui && go test ./...` — all 14 packages green, including `internal/ui` (confirms the untouched `oneshot.go` consumer is unaffected)
- [ ] `cd tui && go build ./... && go vet ./...` — clean
- [ ] Zero pre-existing tests modified or flipped — verify with `git diff main...HEAD --name-only` (three files, all new or additive)

## Evidence — the real TUI binary, before and after

A live Gmail 429 can't be summoned on demand, so instead of waiting for one, the real `gaia` TUI binary was driven against a stub daemon emitting the issue's **literal** failure envelope over canonical SSE. Same stub, two builds — `main` @ `b8a97cbb` vs the fix @ `23f906d4`. Deterministic and repeatable, which the issue's own suggested repro is not.

**Before — `main`.** The "Invalid card" box, the raw JSON dump, and the tool's actual message nowhere on screen:

![before: Invalid card box with raw JSON dump](https://raw.githubusercontent.com/amd/gaia/tmi/issue-2721-tui-failed-tool-error-evidence/testing/2726/01_before_invalid_card.png)

**After — the fix.** The tool's own error, verbatim:

![after: the tool's own CONNECTOR_ERROR text](https://raw.githubusercontent.com/amd/gaia/tmi/issue-2721-tui-failed-tool-error-evidence/testing/2726/02_after_error_shown.png)

**The activity tick, mid-stream** — `[x] pre_scan_inbox`, captured before the final event clears the work log. Previously this showed a green tick on the same failed tool:

![after: failed tick on the activity line](https://raw.githubusercontent.com/amd/gaia/tmi/issue-2721-tui-failed-tool-error-evidence/testing/2726/02b_after_failed_tick_midstream.png)

**No card suppression.** A *successful* pre-scan still renders its card exactly as before — the regression this fix most needed to avoid:

![after: successful pre-scan card renders normally](https://raw.githubusercontent.com/amd/gaia/tmi/issue-2721-tui-failed-tool-error-evidence/testing/2726/03_after_success_card.png)

<details>
<summary>Reading the frames — two stub artifacts, present identically in both</summary>

The `attention view unavailable (HTTP 404)` line and the `contract 1.0` notice are the stub daemon's own incompleteness — it implements the query stream, not the attention view or contract 2.6. They appear in the before and after frames alike, so they don't confound the comparison. The email addresses are the repo's own synthetic fixtures from `cards_test.go`; no real mailbox, credential, or token was involved.

Text frames (the definitive record for a TUI) were captured alongside every screenshot and match them exactly.

</details>
