### PR TITLE
fix(tui): a consequential readiness check now holds the screen

### DIFF
--- a/docs/reference/cli.mdx
+++ b/docs/reference/cli.mdx
@@ -2520,6 +2520,25 @@ ctrl+c.
   with `d` and `delete`, which made "go back" a destructive action.
 </Note>
 
+#### Waiting on a consequential readiness problem
+
+Most readiness rows that cannot be verified are named on screen and the
+launch continues — the sidecar itself does not treat them as fatal (an
+unadvertised Lemonade version, for instance). A handful are consequential
+enough to hold instead: right now, a model loaded into a smaller context
+window than this machine's profile expects, since a document-sized request
+against it comes back `context_length_exceeded` rather than an answer. When
+that happens the screen waits for `enter` instead of proceeding on its own,
+and the notice lists every such row at once if more than one applies.
+
+If that classification is ever wrong for your setup, restore the old
+behaviour — name it, don't hold — until a release changes the
+classification itself:
+
+```bash
+GAIA_TUI_NO_GATE=1 gaia tui
+```
+
 #### Theme (light vs dark terminals)
 
 The hub asks the terminal for its background colour on startup and picks a

--- a/docs/reference/cli.mdx
+++ b/docs/reference/cli.mdx
@@ -2531,14 +2531,6 @@ against it comes back `context_length_exceeded` rather than an answer. When
 that happens the screen waits for `enter` instead of proceeding on its own,
 and the notice lists every such row at once if more than one applies.
 
-If that classification is ever wrong for your setup, restore the old
-behaviour — name it, don't hold — until a release changes the
-classification itself:
-
-```bash
-GAIA_TUI_NO_GATE=1 gaia tui
-```
-
 #### Theme (light vs dark terminals)
 
 The hub asks the terminal for its background colour on startup and picks a

--- a/tui/README.md
+++ b/tui/README.md
@@ -51,7 +51,17 @@ server is reachable at a compatible version, the model is downloaded, plus any
 per-agent checks. Each row shows what failed and the command that fixes it.
 
 A check that cannot be determined renders `[?]` rather than a checkmark, and
-never counts as ready.
+never counts as ready. Most of those are named on screen and the launch
+continues — the sidecar itself does not treat them as fatal. A handful are
+consequential enough to hold instead: right now, a model loaded into a
+smaller context window than this machine's profile expects, since a
+document-sized request against it fails. If that classification is ever
+wrong for your setup, `GAIA_TUI_NO_GATE=1` restores the old behaviour (name
+it, don't hold) until a release changes the classification itself:
+
+```bash
+GAIA_TUI_NO_GATE=1 gaia
+```
 
 ## Theming
 

--- a/tui/README.md
+++ b/tui/README.md
@@ -55,13 +55,8 @@ never counts as ready. Most of those are named on screen and the launch
 continues — the sidecar itself does not treat them as fatal. A handful are
 consequential enough to hold instead: right now, a model loaded into a
 smaller context window than this machine's profile expects, since a
-document-sized request against it fails. If that classification is ever
-wrong for your setup, `GAIA_TUI_NO_GATE=1` restores the old behaviour (name
-it, don't hold) until a release changes the classification itself:
-
-```bash
-GAIA_TUI_NO_GATE=1 gaia
-```
+document-sized request against it fails. When that happens the screen waits
+for `enter` instead of proceeding on its own.
 
 ## Theming
 

--- a/tui/internal/ui/preflight/check.go
+++ b/tui/internal/ui/preflight/check.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/amd/gaia/tui/internal/daemon"
+	"github.com/amd/gaia/tui/internal/ui/status"
 )
 
 // ExtraCheck is a per-agent precondition appended after the four generic ones.
@@ -166,6 +167,9 @@ func checkDaemon(ctx context.Context, t Transport, cfg Config, rep *Report) Stat
 	if err != nil {
 		d := l.Error("reach the background service", err)
 		row.State = StateFailed
+		// The daemon is not agent-repairable — nothing downstream of it can be
+		// checked, so there is no partial conversation to hand off to.
+		row.Disposition = status.DispositionHalt
 		row.Line = "not running"
 		row.Detail = d.Cause
 		row.Remedy = d.AsRemedy()
@@ -230,11 +234,15 @@ func checkSidecar(ctx context.Context, t Transport, cfg Config, rep *Report) Sta
 	l := Ladder{AgentID: cfg.AgentID}
 	row := Row{Key: KeySidecar}
 
+	// KeySidecar is not agent-repairable — every branch below is Halt, never
+	// Notify: the agent itself is not up, so there is no partial conversation
+	// for it to repair.
 	resp, err := t.Do(ctx, http.MethodGet, daemon.APIPrefix+"/agents", nil)
 	if err != nil {
 		d := l.Error("list the agents the background service supervises", err)
 		row.State, row.Line, row.Detail, row.Remedy, row.Raw =
 			StateFailed, "cannot be listed", d.Cause, d.AsRemedy(), err.Error()
+		row.Disposition = status.DispositionHalt
 		return row.commit(rep)
 	}
 	row.Raw = string(resp.Body)
@@ -242,12 +250,14 @@ func checkSidecar(ctx context.Context, t Transport, cfg Config, rep *Report) Sta
 		d := l.Status("list the supervised agents", resp.Status, string(resp.Body))
 		row.State, row.Line, row.Detail, row.Remedy =
 			StateFailed, "cannot be listed", d.Cause, d.AsRemedy()
+		row.Disposition = status.DispositionHalt
 		return row.commit(rep)
 	}
 
 	var body agentsBody
 	if err := json.Unmarshal(resp.Body, &body); err != nil {
 		row.State, row.Line = StateFailed, "unreadable answer"
+		row.Disposition = status.DispositionHalt
 		row.Detail = "The background service answered with something this build cannot read."
 		row.Remedy = Remedy{
 			Action:  "Restart it so both sides speak the same contract.",
@@ -267,6 +277,7 @@ func checkSidecar(ctx context.Context, t Transport, cfg Config, rep *Report) Sta
 			return row.commit(rep)
 		}
 		row.State = StateFailed
+		row.Disposition = status.DispositionHalt
 		row.Line = "installed, not started"
 		row.Detail = fmt.Sprintf("The %s agent is registered but its state is %q.", cfg.AgentName, a.State)
 		row.Fix = FixStartSidecar
@@ -279,6 +290,7 @@ func checkSidecar(ctx context.Context, t Transport, cfg Config, rep *Report) Sta
 	}
 
 	row.State = StateFailed
+	row.Disposition = status.DispositionHalt
 	row.Line = "not installed"
 	row.Detail = fmt.Sprintf("The background service has no agent registered as %q.", cfg.AgentID)
 	row.Remedy = Remedy{
@@ -342,11 +354,16 @@ func checkInit(ctx context.Context, t Transport, cfg Config, rep *Report) State 
 	lemonade := Row{Key: KeyLemonade}
 	model := Row{Key: KeyModel}
 
+	// KeyLemonade is not agent-repairable — every StateFailed branch below is
+	// Halt. The one StateUnknown branch (an unadvertised version) is the
+	// BLOCKER-1 guard: Notify, because it fires on every launch against such a
+	// server forever, and a blanket halt there is not shippable.
 	resp, err := t.Do(ctx, http.MethodGet, "/v1/"+cfg.AgentID+"/init", nil)
 	if err != nil {
 		d := l.Error("check whether the local AI is ready", err)
 		lemonade.State, lemonade.Line, lemonade.Detail, lemonade.Remedy, lemonade.Raw =
 			StateFailed, "cannot be checked", d.Cause, d.AsRemedy(), err.Error()
+		lemonade.Disposition = status.DispositionHalt
 		setRow(rep, lemonade)
 		return StateFailed
 	}
@@ -359,6 +376,7 @@ func checkInit(ctx context.Context, t Transport, cfg Config, rep *Report) State 
 		d := l.Status("check whether the local AI is ready", resp.Status, raw)
 		lemonade.State, lemonade.Line, lemonade.Detail, lemonade.Remedy =
 			StateFailed, "cannot be checked", d.Cause, d.AsRemedy()
+		lemonade.Disposition = status.DispositionHalt
 		setRow(rep, lemonade)
 		return StateFailed
 	}
@@ -384,6 +402,7 @@ func checkInit(ctx context.Context, t Transport, cfg Config, rep *Report) State 
 		}
 		lemonade.State, lemonade.Line, lemonade.Detail, lemonade.Remedy =
 			StateFailed, "cannot be checked", d.Cause, d.AsRemedy()
+		lemonade.Disposition = status.DispositionHalt
 		setRow(rep, lemonade)
 		return StateFailed
 	}
@@ -393,6 +412,7 @@ func checkInit(ctx context.Context, t Transport, cfg Config, rep *Report) State 
 	case !body.Lemonade.Reachable:
 		d := l.Text("reach the local model server", firstNonEmpty(body.hint(), "not reachable"))
 		lemonade.State = StateFailed
+		lemonade.Disposition = status.DispositionHalt
 		lemonade.Line = "not running at " + body.Lemonade.BaseURL
 		lemonade.Detail = "GAIA needs a local model server. It runs on your machine; no message text ever leaves it."
 		lemonade.Remedy = d.AsRemedy()
@@ -423,6 +443,7 @@ func checkInit(ctx context.Context, t Transport, cfg Config, rep *Report) State 
 		// have. The sidecar's own hint is the only thing that distinguishes the
 		// two, and it orders this before the version check — so does this.
 		lemonade.State = StateFailed
+		lemonade.Disposition = status.DispositionHalt
 		lemonade.Line = "running, but not answering properly"
 		lemonade.Detail = body.hint()
 		lemonade.Remedy = lemonadeRestartRemedy()
@@ -431,6 +452,7 @@ func checkInit(ctx context.Context, t Transport, cfg Config, rep *Report) State 
 
 	case body.Lemonade.Compatible != nil && !*body.Lemonade.Compatible:
 		lemonade.State = StateFailed
+		lemonade.Disposition = status.DispositionHalt
 		lemonade.Line = fmt.Sprintf("%s is older than %s",
 			versionOr(body.Lemonade.Version, "the installed version"), body.Lemonade.MinVersion)
 		lemonade.Detail = fmt.Sprintf(
@@ -447,7 +469,13 @@ func checkInit(ctx context.Context, t Transport, cfg Config, rep *Report) State 
 	case body.Lemonade.Compatible == nil:
 		// Reachable, but it did not say which version it is. Indeterminate is
 		// not a pass: the agent's minimum cannot be verified either way.
+		//
+		// BLOCKER-1 guard: this fires on EVERY launch against such a server,
+		// forever — nothing the user does changes it. A blanket halt here
+		// would train them to press a key without reading, so this stays
+		// Notify: named on screen, not blocking. See report.go's package doc.
 		lemonade.State = StateUnknown
+		lemonade.Disposition = status.DispositionNotify
 		lemonade.Line = "running, version not advertised"
 		lemonade.Detail = fmt.Sprintf(
 			"Lemonade at %s answered but reported no version, so it cannot be verified as %s or newer.",
@@ -464,9 +492,12 @@ func checkInit(ctx context.Context, t Transport, cfg Config, rep *Report) State 
 	}
 	setRow(rep, lemonade)
 
-	// --- AI model ---------------------------------------------------------
+	// --- AI model -----------------------------------------------------------
+	// KeyModel is not agent-repairable either — a missing model blocks the
+	// same way a down daemon does.
 	if !body.Model.Present {
 		model.State = StateFailed
+		model.Disposition = status.DispositionHalt
 		model.Line = body.Model.ID + " not downloaded"
 		// The sidecar's hint here restates the line and the command; the raw body
 		// is one `d` away, so the row gets the sentence that tells the user
@@ -517,13 +548,20 @@ func checkInit(ctx context.Context, t Transport, cfg Config, rep *Report) State 
 // it. That sentence was here and it was wrong.
 //
 // It is StateUnknown, deliberately, not StateFailed: the agent works perfectly
-// for ordinary turns, so blocking the launch would be worse than the shortfall.
-// Unknown is the state this package already has for "not proven ready, not
-// proven broken" — it renders [?], keeps Ready() false, is named on screen while
-// the agent starts, and stops nothing.
+// for ordinary turns, and nothing here proves the launch broken the way a
+// down daemon does. Unknown is the state this package already has for "not
+// proven ready, not proven broken" — it renders [?] and keeps Ready() false.
+//
+// Its Disposition is Halt, though — this is the row the issue exists to fix.
+// StateUnknown normally auto-proceeds after a hold (see Disposition ==
+// Notify elsewhere in this file), but a document-sized request against a
+// short-loaded model comes back context_length_exceeded, which the user
+// feels. See internal/ui/status and RootModel's listener for what Halt does
+// with this once it leaves the row.
 func markCtxShortfall(model *Row, loaded int) {
 	target := profileCtxTarget()
 	model.State = StateUnknown
+	model.Disposition = status.DispositionHalt
 	model.Line = fmt.Sprintf("%s · %s of %s context",
 		model.Line, humanCtx(loaded), humanCtx(target))
 	model.Detail = fmt.Sprintf(
@@ -720,6 +758,13 @@ func MailboxCheck() ExtraCheck {
 	}
 }
 
+// Every StateFailed branch KeyMailbox can produce below is Disposition
+// Notify: Report.OfferableDespiteFailure treats the whole key as
+// agent-repairable (agentRepairable[KeyMailbox]), so the screen already
+// offers a single-keypress path past any mailbox failure into the
+// conversation where the agent walks the user through fixing it. Halting in
+// front of that offer would be a second prompt for one decision — see
+// TestAMailboxWhoseCredentialsAreRejectedNeverGreenLightsALaunch.
 func runMailboxCheck(ctx context.Context, t Transport, cfg Config) Row {
 	l := Ladder{AgentID: cfg.AgentID}
 	row := Row{Key: KeyMailbox, Label: "Mailbox"}
@@ -729,6 +774,7 @@ func runMailboxCheck(ctx context.Context, t Transport, cfg Config) Row {
 		d := l.Error("check which mailboxes are connected", err)
 		row.State, row.Line, row.Detail, row.Remedy, row.Raw =
 			StateFailed, "cannot be checked", d.Cause, d.AsRemedy(), err.Error()
+		row.Disposition = status.DispositionNotify
 		return row
 	}
 	row.Raw = string(resp.Body)
@@ -736,12 +782,14 @@ func runMailboxCheck(ctx context.Context, t Transport, cfg Config) Row {
 		d := l.Status("check which mailboxes are connected", resp.Status, string(resp.Body))
 		row.State, row.Line, row.Detail, row.Remedy =
 			StateFailed, "cannot be checked", d.Cause, d.AsRemedy()
+		row.Disposition = status.DispositionNotify
 		return row
 	}
 
 	var body connectorsBody
 	if err := json.Unmarshal(resp.Body, &body); err != nil {
 		row.State, row.Line = StateFailed, "unreadable answer"
+		row.Disposition = status.DispositionNotify
 		row.Detail = "The mailbox connector list could not be read."
 		row.Remedy = Remedy{
 			Action:  "Restart the agent's sidecar, then re-check.",
@@ -780,6 +828,7 @@ func runMailboxCheck(ctx context.Context, t Transport, cfg Config) Row {
 	}
 
 	row.State = StateFailed
+	row.Disposition = status.DispositionNotify
 	row.Line = "not connected"
 	row.Detail = fmt.Sprintf("%s cannot do anything until it can read a mailbox. Connecting takes about three minutes.", cfg.AgentName)
 	row.Fix = FixConnectMailbox
@@ -809,6 +858,7 @@ func runMailboxCheck(ctx context.Context, t Transport, cfg Config) Row {
 func notGrantedRow(row Row, p *connectorEntry, cfg Config) Row {
 	who := accountOr(p.AccountEmail, providerName(p.Provider))
 	row.State = StateFailed
+	row.Disposition = status.DispositionNotify
 	row.Fix = FixConnectMailbox
 	row.Provider = p.Provider
 	row.Remedy = Remedy{
@@ -1025,6 +1075,7 @@ func finishMailboxRow(row Row, res probeResult, p *connectorEntry, cfg Config) R
 
 	case probeRefused:
 		row.State = StateFailed
+		row.Disposition = status.DispositionNotify
 		row.Line = fmt.Sprintf("%s · sign-in no longer works",
 			accountOr(p.AccountEmail, providerName(p.Provider)))
 		row.Detail = fmt.Sprintf(
@@ -1042,8 +1093,12 @@ func finishMailboxRow(row Row, res probeResult, p *connectorEntry, cfg Config) R
 
 	// Inconclusive: linked and granted, but unproven. Not a pass — it renders
 	// [?], keeps Ready() false and is named on screen — and not a block either,
-	// because nothing here says the mailbox is broken.
+	// because nothing here says the mailbox is broken. This is also the
+	// BLOCKER-1 guard for 2+ linked mailboxes (probeMailbox refuses to probe
+	// when connectedCount > 1): that state is permanent for a supported,
+	// shipped configuration, so it must stay Notify, never Halt.
 	row.State = StateUnknown
+	row.Disposition = status.DispositionNotify
 	row.Line = fmt.Sprintf("%s (%s) · connected, not verified", who, providerName(p.Provider))
 	row.Detail = res.cause
 	row.Remedy = res.remedy

--- a/tui/internal/ui/preflight/check_test.go
+++ b/tui/internal/ui/preflight/check_test.go
@@ -1038,6 +1038,23 @@ func TestReportHasHalt(t *testing.T) {
 	}
 }
 
+// A row nobody assigned a Disposition to must halt, not silently proceed —
+// the exact failure shape (something not okay, nobody decided, launch
+// happens anyway) that this whole issue exists to fix, just relocated to a
+// single forgotten field. Notify is the value a row opts INTO to skip
+// holding the screen; DispositionUnset is not that, so it must hold too.
+// Built directly rather than through Check(), because check.go now declares
+// a Disposition at every branch it has today — this proves what HasHalt does
+// on a row a FUTURE branch forgets to declare one for.
+func TestHasHaltDefaultsToHaltingOnAnUndeclaredDisposition(t *testing.T) {
+	rep := Report{Rows: []Row{
+		{Key: "mystery", State: StateFailed, Disposition: status.DispositionUnset},
+	}}
+	if !rep.HasHalt() {
+		t.Fatal("a non-OK row with no declared Disposition must halt, not silently proceed")
+	}
+}
+
 // The security review found two paths that put upstream server text into a
 // row unsanitized: checkInit assigns body.hint() to Detail verbatim (the
 // modelListUnreadable branch, check.go:427), and Ladder's fallback builds a

--- a/tui/internal/ui/preflight/check_test.go
+++ b/tui/internal/ui/preflight/check_test.go
@@ -2,6 +2,7 @@ package preflight
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"os"
@@ -15,6 +16,7 @@ import (
 	"github.com/charmbracelet/x/ansi"
 
 	"github.com/amd/gaia/tui/internal/daemon"
+	"github.com/amd/gaia/tui/internal/ui/status"
 )
 
 // --- fixtures ---------------------------------------------------------------
@@ -859,6 +861,276 @@ func TestEveryFailedRowIsActionable(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+// Every non-OK row (Failed or Unknown) must declare a real Disposition —
+// DispositionUnset on such a row is a bug, not a pass, the same way an
+// unset State would be. This is the "go vet-style exhaustiveness test":
+// every branch in check.go that resolves a row to Failed or Unknown is
+// exercised here, and a new branch that forgets to set Disposition fails
+// this test rather than silently defaulting to "proceed".
+//
+// wantDisposition also locks the two BLOCKER-1 guards (the lemonade-version
+// and multi-mailbox rows must be Notify, never Halt, or a blanket rule would
+// halt on 44-100% of launches) and the one row this issue exists to fix (the
+// ctx shortfall must be Halt).
+func TestEveryNonOKRowDeclaresADisposition(t *testing.T) {
+	tests := []struct {
+		name            string
+		build           func() *fakeTransport
+		wantKey         string
+		wantDisposition status.Disposition
+	}{
+		{"daemon not running", func() *fakeTransport {
+			f := newFake()
+			f.attachErr = &daemon.NotRunningError{Path: "/tmp/instance.json"}
+			return f
+		}, KeyDaemon, status.DispositionHalt},
+		{"daemon version skew", func() *fakeTransport {
+			f := newFake()
+			f.attachErr = &daemon.VersionError{Have: "1.0", Reason: "it predates the agent relay"}
+			return f
+		}, KeyDaemon, status.DispositionHalt},
+		{"sidecar list: transport error", func() *fakeTransport {
+			f := newFake()
+			f.errs["GET /daemon/v1/agents"] = &daemon.RequestError{Op: "list agents", Detail: "boom"}
+			return f
+		}, KeySidecar, status.DispositionHalt},
+		{"sidecar list: bad status", func() *fakeTransport {
+			return newFake().with("GET /daemon/v1/agents", 500, `{"detail":"boom"}`)
+		}, KeySidecar, status.DispositionHalt},
+		{"sidecar list: unreadable json", func() *fakeTransport {
+			return newFake().with("GET /daemon/v1/agents", 200, `not json`)
+		}, KeySidecar, status.DispositionHalt},
+		{"sidecar: not started", func() *fakeTransport {
+			return newFake().with("GET /daemon/v1/agents", 200, agentsStopped)
+		}, KeySidecar, status.DispositionHalt},
+		{"sidecar: not installed", func() *fakeTransport {
+			return newFake().with("GET /daemon/v1/agents", 200, agentsEmpty)
+		}, KeySidecar, status.DispositionHalt},
+		{"lemonade: transport error", func() *fakeTransport {
+			f := newFake()
+			f.errs["GET /v1/email/init"] = &daemon.RequestError{Op: "check readiness", Detail: "boom"}
+			return f
+		}, KeyLemonade, status.DispositionHalt},
+		{"lemonade: bad status", func() *fakeTransport {
+			return newFake().with("GET /v1/email/init", 500, `{"detail":"boom"}`)
+		}, KeyLemonade, status.DispositionHalt},
+		{"lemonade: unparseable body", func() *fakeTransport {
+			return newFake().with("GET /v1/email/init", 200, `<html>not json</html>`)
+		}, KeyLemonade, status.DispositionHalt},
+		{"lemonade: unreachable", func() *fakeTransport {
+			return newFake().with("GET /v1/email/init", 503, initUnreachable)
+		}, KeyLemonade, status.DispositionHalt},
+		{"lemonade: model list unreadable", func() *fakeTransport {
+			return newFake().with("GET /v1/email/init", 503, initModelListUnreadable)
+		}, KeyLemonade, status.DispositionHalt},
+		{"lemonade: too old", func() *fakeTransport {
+			return newFake().with("GET /v1/email/init", 503, initTooOld)
+		}, KeyLemonade, status.DispositionHalt},
+		{"lemonade: version unknown — guards BLOCKER-1", func() *fakeTransport {
+			return newFake().with("GET /v1/email/init", 200, initUnknownVersion)
+		}, KeyLemonade, status.DispositionNotify},
+		{"model: missing", func() *fakeTransport {
+			return newFake().with("GET /v1/email/init", 503, initModelMissing)
+		}, KeyModel, status.DispositionHalt},
+		{"model: ctx shortfall — the reported bug", func() *fakeTransport {
+			return newFake().with("GET /v1/email/init", 200, initCtxShortfall)
+		}, KeyModel, status.DispositionHalt},
+		{"mailbox: connectors transport error", func() *fakeTransport {
+			f := newFake()
+			f.errs["GET /v1/email/connectors"] = &daemon.RequestError{Op: "list connectors", Detail: "boom"}
+			return f
+		}, KeyMailbox, status.DispositionNotify},
+		{"mailbox: connectors bad status", func() *fakeTransport {
+			return newFake().with("GET /v1/email/connectors", 500, `{"detail":"boom"}`)
+		}, KeyMailbox, status.DispositionNotify},
+		{"mailbox: connectors unreadable json", func() *fakeTransport {
+			return newFake().with("GET /v1/email/connectors", 200, `not json`)
+		}, KeyMailbox, status.DispositionNotify},
+		{"mailbox: not connected", func() *fakeTransport {
+			return newFake().with("GET /v1/email/connectors", 200, connectorsNone)
+		}, KeyMailbox, status.DispositionNotify},
+		{"mailbox: no send scope", func() *fakeTransport {
+			return newFake().with("GET /v1/email/connectors", 200, connectorsNoSend)
+		}, KeyMailbox, status.DispositionNotify},
+		{"mailbox: no grant", func() *fakeTransport {
+			return newFake().with("GET /v1/email/connectors", 200, connectorsNoGrant)
+		}, KeyMailbox, status.DispositionNotify},
+		{"mailbox: credentials rejected", func() *fakeTransport {
+			return newFake().with("POST /v1/email/search", 502, searchNoForwardedCredential)
+		}, KeyMailbox, status.DispositionNotify},
+		{"mailbox: revoked", func() *fakeTransport {
+			return newFake().with("POST /v1/email/search", 403, searchRevoked)
+		}, KeyMailbox, status.DispositionNotify},
+		{"mailbox: inconclusive, multi-linked — guards BLOCKER-1", func() *fakeTransport {
+			return newFake().with("GET /v1/email/connectors", 200, connectorsBoth)
+		}, KeyMailbox, status.DispositionNotify},
+		{"mailbox: inconclusive, relay drop", func() *fakeTransport {
+			return newFake().with("POST /v1/email/search", 502, searchRelayDown)
+		}, KeyMailbox, status.DispositionNotify},
+		{"mailbox: inconclusive, sidecar gone", func() *fakeTransport {
+			return newFake().with("POST /v1/email/search", 503, searchRelay503)
+		}, KeyMailbox, status.DispositionNotify},
+		{"mailbox: inconclusive, token lapsed", func() *fakeTransport {
+			return newFake().with("POST /v1/email/search", 502, searchTokenLapsed)
+		}, KeyMailbox, status.DispositionNotify},
+		{"mailbox: inconclusive, no read route", func() *fakeTransport {
+			return newFake().with("POST /v1/email/search", 404, `{"detail":"Not Found"}`)
+		}, KeyMailbox, status.DispositionNotify},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rep := Check(context.Background(), tt.build(), EmailConfig())
+			row, ok := rep.Find(tt.wantKey)
+			if !ok {
+				t.Fatalf("no row %q in report:\n%s", tt.wantKey, rep)
+			}
+			if row.State != StateFailed && row.State != StateUnknown {
+				t.Fatalf("row %q state = %s, want Failed or Unknown\n%s", tt.wantKey, row.State.Word(), rep)
+			}
+			if row.Disposition == status.DispositionUnset {
+				t.Fatalf("row %q (%s) has no Disposition — a non-OK row must always declare one\n%s",
+					tt.wantKey, row.State.Word(), rep)
+			}
+			if row.Disposition != tt.wantDisposition {
+				t.Errorf("row %q disposition = %v, want %v", tt.wantKey, row.Disposition, tt.wantDisposition)
+			}
+		})
+	}
+}
+
+// HasHalt is what preflight/model.go's reportMsg handler will gate the
+// screen-does-not-lie behaviour on. It must be true precisely when a Halt
+// row is present and false for a report holding only Notify rows — even
+// when those Notify rows are themselves the BLOCKER-1 guard cases.
+func TestReportHasHalt(t *testing.T) {
+	cases := []struct {
+		name  string
+		build func() *fakeTransport
+		want  bool
+	}{
+		{"all ready", newFake, false},
+		{"lemonade version unknown — Notify only", func() *fakeTransport {
+			return newFake().with("GET /v1/email/init", 200, initUnknownVersion)
+		}, false},
+		{"multi-mailbox — Notify only, guards BLOCKER-1", func() *fakeTransport {
+			return newFake().with("GET /v1/email/connectors", 200, connectorsBoth)
+		}, false},
+		{"ctx shortfall — Halt, the reported bug", func() *fakeTransport {
+			return newFake().with("GET /v1/email/init", 200, initCtxShortfall)
+		}, true},
+		{"daemon down — Halt (already blocks today)", func() *fakeTransport {
+			f := newFake()
+			f.attachErr = &daemon.NotRunningError{Path: "/tmp/instance.json"}
+			return f
+		}, true},
+	}
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			rep := Check(context.Background(), tt.build(), EmailConfig())
+			if got := rep.HasHalt(); got != tt.want {
+				t.Errorf("HasHalt() = %v, want %v\n%s", got, tt.want, rep)
+			}
+		})
+	}
+}
+
+// The security review found two paths that put upstream server text into a
+// row unsanitized: checkInit assigns body.hint() to Detail verbatim (the
+// modelListUnreadable branch, check.go:427), and Ladder's fallback builds a
+// Cause with %s — not %q — over upstream/transport text (ladder.go's
+// transport() and Text() fallbacks). Fixing those existing render paths is
+// out of scope for this issue; what matters here is the NEW surface this
+// issue adds — Outcome — which must not carry the payload through, even
+// though the row it was built from still does.
+func TestAHostileHintCannotEscapeIntoAnOutcome(t *testing.T) {
+	const payload = "\x1b[2J\x1b]0;pwned\x07"
+	hint := "Lemonade is reachable but its model list could not be read " + payload
+
+	// Built via json.Marshal, not a hand-quoted string literal: %q escapes a
+	// control byte Go's way (`\x1b`), which is not a legal JSON escape and
+	// would make json.Unmarshal fail the whole body rather than exercise the
+	// modelListUnreadable branch this test targets. Marshal escapes it the
+	// JSON way (``), which decodes back to the real byte — proven with
+	// a throwaway script before writing this fixture this way.
+	type initFixture struct {
+		Ready    bool `json:"ready"`
+		Lemonade struct {
+			Reachable  bool   `json:"reachable"`
+			BaseURL    string `json:"base_url"`
+			Version    string `json:"version"`
+			MinVersion string `json:"min_version"`
+			Compatible bool   `json:"compatible"`
+		} `json:"lemonade"`
+		Model struct {
+			ID      string `json:"id"`
+			Present bool   `json:"present"`
+		} `json:"model"`
+		Hint string `json:"hint"`
+	}
+	fixture := initFixture{Ready: false, Hint: hint}
+	fixture.Lemonade.Reachable = true
+	fixture.Lemonade.BaseURL = "http://localhost:13305/api/v1"
+	fixture.Lemonade.Version = "10.2.1"
+	fixture.Lemonade.MinVersion = "10.2.0"
+	fixture.Lemonade.Compatible = true
+	fixture.Model.ID = "Gemma-4-E4B-it-GGUF"
+	fixture.Model.Present = false
+	body, err := json.Marshal(fixture)
+	if err != nil {
+		t.Fatalf("test setup: could not marshal the fixture: %v", err)
+	}
+	f := newFake().with("GET /v1/email/init", 503, string(body))
+
+	rep := Check(context.Background(), f, EmailConfig())
+	row, ok := rep.Find(KeyLemonade)
+	if !ok {
+		t.Fatal("no lemonade row")
+	}
+	if row.State != StateFailed {
+		t.Fatalf("row state = %s, want Failed\n%s", row.State.Word(), rep)
+	}
+	if !strings.Contains(row.Detail, "\x1b") {
+		t.Fatalf("test setup: row.Detail should still carry the raw escape — that is what "+
+			"proves the sanitizing boundary is Outcome(), not the row itself: %q", row.Detail)
+	}
+
+	o := row.Outcome()
+	if strings.ContainsAny(o.Summary, "\x1b\x07") {
+		t.Fatalf("Outcome().Summary carries raw control bytes: %q", o.Summary)
+	}
+	if o.Disposition == status.DispositionUnset {
+		t.Fatal("Outcome() dropped the row's Disposition")
+	}
+}
+
+// Same boundary via the OTHER unsanitized path: a transport-error Detail
+// reaching a Cause through Ladder's %s fallback.
+func TestAHostileTransportDetailCannotEscapeIntoAnOutcome(t *testing.T) {
+	const payload = "\x1b[2J\x1b]0;pwned\x07"
+	f := newFake()
+	f.errs["GET /daemon/v1/agents"] = &daemon.RequestError{
+		Op: "list the agents the background service supervises", Detail: payload,
+	}
+
+	rep := Check(context.Background(), f, EmailConfig())
+	row, ok := rep.Find(KeySidecar)
+	if !ok {
+		t.Fatal("no sidecar row")
+	}
+	if row.State != StateFailed {
+		t.Fatalf("row state = %s, want Failed\n%s", row.State.Word(), rep)
+	}
+	if !strings.Contains(row.Detail, "\x1b") {
+		t.Fatalf("test setup: row.Detail should still carry the raw escape: %q", row.Detail)
+	}
+
+	o := row.Outcome()
+	if strings.ContainsAny(o.Summary, "\x1b\x07") {
+		t.Fatalf("Outcome().Summary carries raw control bytes: %q", o.Summary)
 	}
 }
 

--- a/tui/internal/ui/preflight/check_test.go
+++ b/tui/internal/ui/preflight/check_test.go
@@ -1983,22 +1983,28 @@ func TestAnAdequateOrUnknownWindowIsNotWarnedAbout(t *testing.T) {
 	}
 }
 
-// The shortfall row is named while the agent starts, rather than passing by in
-// the 800ms an all-green screen gets. That naming is the whole point: it is the
-// only place the user learns which inputs will fail.
-func TestTheShortfallIsNamedDuringTheHandoff(t *testing.T) {
+// The shortfall row is now DispositionHalt — the reported bug is exactly that
+// it used to name itself and pass by in the 2500ms hold an indeterminate
+// screen got, launching over an input that will fail. It now holds the
+// screen for a person instead: no tick, no claim of starting, and the number
+// the user needs (25037) still on screen — the naming was never the problem,
+// the silent proceeding was.
+func TestTheShortfallHoldsTheScreenAndStillNamesTheWindow(t *testing.T) {
 	f := newFake().with("GET /v1/email/init", 200, initCtxShortfall)
 	m := New(f, EmailConfig(), Options{ReadyHold: time.Millisecond})
 	updated, _ := m.Update(tea.WindowSizeMsg{Width: 80, Height: 24})
 	updated, cmd := updated.(Model).Update(reportMsg{rep: Check(context.Background(), f, EmailConfig())})
 	m = updated.(Model)
 
-	if cmd == nil {
-		t.Fatal("a short window stopped the hand-off; it must not block the launch")
+	if cmd != nil {
+		t.Fatalf("a Halt row scheduled a command — the launch must wait for a person, not a timer: %T", cmd())
 	}
 	screen := ansi.Strip(m.View())
-	if !strings.Contains(screen, "Starting anyway") {
-		t.Errorf("the shortfall is not named while the agent starts:\n%s", screen)
+	if strings.Contains(screen, "Starting anyway") {
+		t.Errorf("the screen still claims to be starting anyway over a Halt row:\n%s", screen)
+	}
+	if strings.Contains(screen, "Starting "+EmailConfig().AgentName+"…") {
+		t.Errorf("the screen claims to be starting while a Halt row is unresolved:\n%s", screen)
 	}
 	if !strings.Contains(screen, "25037") {
 		t.Errorf("the hand-off never shows the window that will fail:\n%s", screen)

--- a/tui/internal/ui/preflight/check_test.go
+++ b/tui/internal/ui/preflight/check_test.go
@@ -1996,8 +1996,12 @@ func TestTheShortfallHoldsTheScreenAndStillNamesTheWindow(t *testing.T) {
 	updated, cmd := updated.(Model).Update(reportMsg{rep: Check(context.Background(), f, EmailConfig())})
 	m = updated.(Model)
 
+	// cmd is no longer nil — it carries the halt Outcome the host listens
+	// for — but it must not be the tick toward an automatic ProceedMsg.
 	if cmd != nil {
-		t.Fatalf("a Halt row scheduled a command — the launch must wait for a person, not a timer: %T", cmd())
+		if _, ok := cmd().(proceedTickMsg); ok {
+			t.Fatal("a Halt row scheduled the auto-proceed tick — the launch must wait for a person, not a timer")
+		}
 	}
 	screen := ansi.Strip(m.View())
 	if strings.Contains(screen, "Starting anyway") {

--- a/tui/internal/ui/preflight/model.go
+++ b/tui/internal/ui/preflight/model.go
@@ -3,6 +3,7 @@ package preflight
 import (
 	"context"
 	"fmt"
+	"os"
 	"time"
 
 	"github.com/charmbracelet/bubbles/spinner"
@@ -38,6 +39,18 @@ const (
 	// could not be verified — long enough to read what went unproven.
 	unknownHold = 2500 * time.Millisecond
 )
+
+// EnvNoGate restores the pre-halt auto-proceed behaviour, matching the
+// existing env-override precedent (theme.EnvTheme, components.EnvStyle). A
+// TUI binary cannot be hot-patched: if a Halt classification turns out wrong
+// for someone in the field, this is their way past it until a release with
+// the fix reaches them, rather than pressing a key on every single launch.
+const EnvNoGate = "GAIA_TUI_NO_GATE"
+
+// noGateOverride reports whether EnvNoGate is set.
+func noGateOverride() bool {
+	return os.Getenv(EnvNoGate) == "1"
+}
 
 type phase int
 
@@ -307,7 +320,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.focus = 0
 		}
 		if !m.rep.Blocked() && !m.opts.ManualProceed {
-			if m.rep.HasHalt() {
+			if m.rep.HasHalt() && !noGateOverride() {
 				// Three edits together: the tick, the phase, and the note each
 				// independently claim the launch is starting.
 				m.note = "Waiting — " + m.unverifiedSummary()

--- a/tui/internal/ui/preflight/model.go
+++ b/tui/internal/ui/preflight/model.go
@@ -3,7 +3,6 @@ package preflight
 import (
 	"context"
 	"fmt"
-	"os"
 	"time"
 
 	"github.com/charmbracelet/bubbles/spinner"
@@ -39,18 +38,6 @@ const (
 	// could not be verified — long enough to read what went unproven.
 	unknownHold = 2500 * time.Millisecond
 )
-
-// EnvNoGate restores the pre-halt auto-proceed behaviour, matching the
-// existing env-override precedent (theme.EnvTheme, components.EnvStyle). A
-// TUI binary cannot be hot-patched: if a Halt classification turns out wrong
-// for someone in the field, this is their way past it until a release with
-// the fix reaches them, rather than pressing a key on every single launch.
-const EnvNoGate = "GAIA_TUI_NO_GATE"
-
-// noGateOverride reports whether EnvNoGate is set.
-func noGateOverride() bool {
-	return os.Getenv(EnvNoGate) == "1"
-}
 
 type phase int
 
@@ -320,7 +307,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.focus = 0
 		}
 		if !m.rep.Blocked() && !m.opts.ManualProceed {
-			if m.rep.HasHalt() && !noGateOverride() {
+			if m.rep.HasHalt() {
 				// Three edits together: the tick, the phase, and the note each
 				// independently claim the launch is starting.
 				m.note = "Waiting — " + m.unverifiedSummary()

--- a/tui/internal/ui/preflight/model.go
+++ b/tui/internal/ui/preflight/model.go
@@ -308,15 +308,10 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		if !m.rep.Blocked() && !m.opts.ManualProceed {
 			if m.rep.HasHalt() {
-				// A row that will actually bite the user (the reported bug: a
-				// model loaded at less than the profile's context window) does
-				// not get a timer. Three edits together, not one: no tick is
-				// scheduled below, phase stays off phaseDone so trailerLines
-				// never renders "Starting <agent>…", and the note says the
-				// launch is WAITING rather than starting anyway — removing the
-				// tick alone would still leave the screen claiming to proceed.
+				// Three edits together: the tick, the phase, and the note each
+				// independently claim the launch is starting.
 				m.note = "Waiting — " + m.unverifiedSummary()
-				return m, nil
+				return m, m.haltOutcomesCmd()
 			}
 			// Nothing failed, and nothing unproven is consequential enough to
 			// hold for. Indeterminate rows do not block the launch — the
@@ -500,6 +495,21 @@ func (m Model) unverifiedSummary() string {
 func (m Model) proceed() tea.Cmd {
 	agentID := m.cfg.AgentID
 	return func() tea.Msg { return ProceedMsg{AgentID: agentID} }
+}
+
+// haltOutcomesCmd emits one status.Outcome per HaltingRows() row, for the
+// host's listener to act on. Only reached from the HasHalt() branch above —
+// a Blocked() report never calls this, so an offerable failure (a mailbox
+// the agent repairs in conversation) never gets a second prompt in front of
+// the one it already offers.
+func (m Model) haltOutcomesCmd() tea.Cmd {
+	rows := m.rep.HaltingRows()
+	cmds := make([]tea.Cmd, 0, len(rows))
+	for _, row := range rows {
+		o := row.Outcome()
+		cmds = append(cmds, func() tea.Msg { return o })
+	}
+	return tea.Batch(cmds...)
 }
 
 func (m Model) View() string { return m.render() }

--- a/tui/internal/ui/preflight/model.go
+++ b/tui/internal/ui/preflight/model.go
@@ -55,7 +55,8 @@ type Options struct {
 	// Defaults to 800ms.
 	ReadyHold time.Duration
 	// ManualProceed keeps the screen up until the user presses enter, even when
-	// everything is ready. Used by tests and by `--debug`.
+	// everything is ready. Test-only: the sole caller of WithPreflight is
+	// test/preflight_gate_test.go, not any interactive flag.
 	ManualProceed bool
 	// Logf receives diagnostics. Never given a token.
 	Logf func(format string, args ...any)
@@ -306,7 +307,19 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.focus = 0
 		}
 		if !m.rep.Blocked() && !m.opts.ManualProceed {
-			// Nothing failed. Indeterminate rows do not block the launch — the
+			if m.rep.HasHalt() {
+				// A row that will actually bite the user (the reported bug: a
+				// model loaded at less than the profile's context window) does
+				// not get a timer. Three edits together, not one: no tick is
+				// scheduled below, phase stays off phaseDone so trailerLines
+				// never renders "Starting <agent>…", and the note says the
+				// launch is WAITING rather than starting anyway — removing the
+				// tick alone would still leave the screen claiming to proceed.
+				m.note = "Waiting — " + m.unverifiedSummary()
+				return m, nil
+			}
+			// Nothing failed, and nothing unproven is consequential enough to
+			// hold for. Indeterminate rows do not block the launch — the
 			// sidecar itself does not treat an unadvertised version as fatal, and
 			// making the user press enter on EVERY launch against such a server
 			// would train them to press it without reading. They are held longer

--- a/tui/internal/ui/preflight/model_test.go
+++ b/tui/internal/ui/preflight/model_test.go
@@ -3,7 +3,6 @@ package preflight
 import (
 	"context"
 	"errors"
-	"os"
 	"strings"
 	"testing"
 	"time"
@@ -412,57 +411,6 @@ func TestADispositionHaltRowNoLongerAutoProceeds(t *testing.T) {
 	}
 	if _, ok := cmd().(ProceedMsg); !ok {
 		t.Fatalf("enter on a Halt report produced %T, want ProceedMsg", cmd())
-	}
-}
-
-// GAIA_TUI_NO_GATE is the escape hatch: a TUI binary cannot be hot-patched,
-// so if a Halt classification is wrong in the field, this restores today's
-// auto-proceed rather than making affected users press a key on every launch
-// until a release reaches them.
-func TestGAIATUINoGateRestoresAutoProceedOverAHaltRow(t *testing.T) {
-	t.Setenv(EnvNoGate, "1")
-
-	f := newFake().with("GET /v1/email/init", 200, initCtxShortfall)
-	rep := Check(t.Context(), f, EmailConfig())
-	if !rep.HasHalt() {
-		t.Fatal("test setup: want a Halt row present")
-	}
-
-	m := New(f, EmailConfig(), Options{ReadyHold: time.Millisecond})
-	updated, _ := m.Update(tea.WindowSizeMsg{Width: 80, Height: 24})
-	updated, cmd := updated.(Model).Update(reportMsg{rep: rep})
-	m = updated.(Model)
-
-	if cmd == nil {
-		t.Fatal("GAIA_TUI_NO_GATE=1 did not schedule the hand-off")
-	}
-	if _, ok := cmd().(proceedTickMsg); !ok {
-		t.Fatalf("GAIA_TUI_NO_GATE=1 scheduled %T, want proceedTickMsg", cmd())
-	}
-	screen := strings.Join(strings.Fields(ansi.Strip(m.View())), " ")
-	if !strings.Contains(screen, "Starting anyway") {
-		t.Errorf("GAIA_TUI_NO_GATE=1 did not restore the auto-proceed copy:\n%s", screen)
-	}
-}
-
-// The default (unset) behaviour must still halt — a test that only checks
-// the override is set could pass even if the env var leaked into every run.
-func TestGAIATUINoGateUnsetStillHalts(t *testing.T) {
-	if got := os.Getenv(EnvNoGate); got != "" {
-		t.Fatalf("test setup: %s is %q in the environment, want unset", EnvNoGate, got)
-	}
-
-	f := newFake().with("GET /v1/email/init", 200, initCtxShortfall)
-	rep := Check(t.Context(), f, EmailConfig())
-
-	m := New(f, EmailConfig(), Options{ReadyHold: time.Millisecond})
-	updated, _ := m.Update(tea.WindowSizeMsg{Width: 80, Height: 24})
-	_, cmd := updated.(Model).Update(reportMsg{rep: rep})
-
-	if cmd != nil {
-		if _, ok := cmd().(proceedTickMsg); ok {
-			t.Fatal("a Halt row auto-proceeded with GAIA_TUI_NO_GATE unset")
-		}
 	}
 }
 

--- a/tui/internal/ui/preflight/model_test.go
+++ b/tui/internal/ui/preflight/model_test.go
@@ -3,6 +3,7 @@ package preflight
 import (
 	"context"
 	"errors"
+	"os"
 	"strings"
 	"testing"
 	"time"
@@ -411,6 +412,102 @@ func TestADispositionHaltRowNoLongerAutoProceeds(t *testing.T) {
 	}
 	if _, ok := cmd().(ProceedMsg); !ok {
 		t.Fatalf("enter on a Halt report produced %T, want ProceedMsg", cmd())
+	}
+}
+
+// GAIA_TUI_NO_GATE is the escape hatch: a TUI binary cannot be hot-patched,
+// so if a Halt classification is wrong in the field, this restores today's
+// auto-proceed rather than making affected users press a key on every launch
+// until a release reaches them.
+func TestGAIATUINoGateRestoresAutoProceedOverAHaltRow(t *testing.T) {
+	t.Setenv(EnvNoGate, "1")
+
+	f := newFake().with("GET /v1/email/init", 200, initCtxShortfall)
+	rep := Check(t.Context(), f, EmailConfig())
+	if !rep.HasHalt() {
+		t.Fatal("test setup: want a Halt row present")
+	}
+
+	m := New(f, EmailConfig(), Options{ReadyHold: time.Millisecond})
+	updated, _ := m.Update(tea.WindowSizeMsg{Width: 80, Height: 24})
+	updated, cmd := updated.(Model).Update(reportMsg{rep: rep})
+	m = updated.(Model)
+
+	if cmd == nil {
+		t.Fatal("GAIA_TUI_NO_GATE=1 did not schedule the hand-off")
+	}
+	if _, ok := cmd().(proceedTickMsg); !ok {
+		t.Fatalf("GAIA_TUI_NO_GATE=1 scheduled %T, want proceedTickMsg", cmd())
+	}
+	screen := strings.Join(strings.Fields(ansi.Strip(m.View())), " ")
+	if !strings.Contains(screen, "Starting anyway") {
+		t.Errorf("GAIA_TUI_NO_GATE=1 did not restore the auto-proceed copy:\n%s", screen)
+	}
+}
+
+// The default (unset) behaviour must still halt — a test that only checks
+// the override is set could pass even if the env var leaked into every run.
+func TestGAIATUINoGateUnsetStillHalts(t *testing.T) {
+	if got := os.Getenv(EnvNoGate); got != "" {
+		t.Fatalf("test setup: %s is %q in the environment, want unset", EnvNoGate, got)
+	}
+
+	f := newFake().with("GET /v1/email/init", 200, initCtxShortfall)
+	rep := Check(t.Context(), f, EmailConfig())
+
+	m := New(f, EmailConfig(), Options{ReadyHold: time.Millisecond})
+	updated, _ := m.Update(tea.WindowSizeMsg{Width: 80, Height: 24})
+	_, cmd := updated.(Model).Update(reportMsg{rep: rep})
+
+	if cmd != nil {
+		if _, ok := cmd().(proceedTickMsg); ok {
+			t.Fatal("a Halt row auto-proceeded with GAIA_TUI_NO_GATE unset")
+		}
+	}
+}
+
+// Blocked() is untouched by the Halt/Notify split: a real failure never gets
+// a tick, before or after this issue.
+func TestBlockedReportSchedulesNoTick(t *testing.T) {
+	f := newFake().with("GET /daemon/v1/agents", 200, agentsStopped)
+	rep := Check(t.Context(), f, EmailConfig())
+	if !rep.Blocked() {
+		t.Fatal("test setup: want a blocked report")
+	}
+
+	m := New(f, EmailConfig(), Options{ReadyHold: time.Millisecond})
+	updated, _ := m.Update(tea.WindowSizeMsg{Width: 80, Height: 24})
+	_, cmd := updated.(Model).Update(reportMsg{rep: rep})
+
+	if cmd != nil {
+		t.Fatalf("a blocked report scheduled %T — Blocked() must never auto-proceed", cmd())
+	}
+}
+
+// BLOCKER-1's other guard, at the model layer: 2+ linked mailboxes is a
+// StateUnknown, DispositionNotify row (report.go/check.go), so it must still
+// schedule the hold and proceed — never halt. A blanket rule here would fire
+// on every launch with 2+ mailboxes linked, forever.
+func TestMultiMailboxReportSchedulesTheHoldNotAHalt(t *testing.T) {
+	f := newFake().with("GET /v1/email/connectors", 200, connectorsBoth)
+	rep := Check(t.Context(), f, EmailConfig())
+	if rep.Blocked() || rep.Ready() {
+		t.Fatalf("test setup: want Blocked()==false && Ready()==false, got Blocked=%v Ready=%v",
+			rep.Blocked(), rep.Ready())
+	}
+	if rep.HasHalt() {
+		t.Fatal("test setup: guards BLOCKER-1 — multi-mailbox must never be a Halt row")
+	}
+
+	m := New(f, EmailConfig(), Options{ReadyHold: time.Millisecond})
+	updated, _ := m.Update(tea.WindowSizeMsg{Width: 80, Height: 24})
+	_, cmd := updated.(Model).Update(reportMsg{rep: rep})
+
+	if cmd == nil {
+		t.Fatal("a multi-mailbox report did not schedule the hand-off — BLOCKER-1 would fire on every launch with 2+ mailboxes linked")
+	}
+	if _, ok := cmd().(proceedTickMsg); !ok {
+		t.Fatalf("multi-mailbox report scheduled %T, want proceedTickMsg", cmd())
 	}
 }
 

--- a/tui/internal/ui/preflight/model_test.go
+++ b/tui/internal/ui/preflight/model_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/charmbracelet/x/ansi"
 
 	"github.com/amd/gaia/tui/internal/daemon"
+	"github.com/amd/gaia/tui/internal/ui/status"
 )
 
 // settle applies a fresh Check result the way Init's command would.
@@ -325,11 +326,23 @@ func TestEnterOnABlockedReportSaysWhy(t *testing.T) {
 
 // Nothing failed but something could not be verified: the launch proceeds (the
 // sidecar does not treat it as fatal) while naming what went unproven.
+//
+// This exercises the DispositionNotify path specifically — the unadvertised
+// Lemonade version is one of the two BLOCKER-1 guard rows. It is pinned with
+// an explicit Disposition assertion so a future change that accidentally
+// flips this row's Disposition to Halt fails HERE, with a message that says
+// why, rather than only surfacing as a silent behaviour change a user
+// reports weeks later.
 func TestAnIndeterminateReportProceedsButSaysWhatItCouldNotVerify(t *testing.T) {
 	f := newFake().with("GET /v1/email/init", 200, initUnknownVersion)
+	rep := Check(t.Context(), f, EmailConfig())
+	if row, ok := rep.Find(KeyLemonade); !ok || row.Disposition != status.DispositionNotify {
+		t.Fatalf("test setup: want the lemonade row DispositionNotify, got %+v", row)
+	}
+
 	m := New(f, EmailConfig(), Options{ReadyHold: time.Millisecond})
 	updated, _ := m.Update(tea.WindowSizeMsg{Width: 80, Height: 24})
-	updated, cmd := updated.(Model).Update(reportMsg{rep: Check(t.Context(), f, EmailConfig())})
+	updated, cmd := updated.(Model).Update(reportMsg{rep: rep})
 	m = updated.(Model)
 
 	if cmd == nil {
@@ -344,6 +357,60 @@ func TestAnIndeterminateReportProceedsButSaysWhatItCouldNotVerify(t *testing.T) 
 	}
 	if _, ok := cmd().(proceedTickMsg); !ok {
 		t.Fatalf("scheduled %T", cmd())
+	}
+}
+
+// The reported bug: a DispositionHalt row (the ctx shortfall) must not
+// auto-proceed. tea.Cmd is func() tea.Msg and Go can only compare it to nil,
+// so this asserts the absence of the automatic path behaviourally, in three
+// parts, matching the acceptance criterion exactly.
+func TestADispositionHaltRowNoLongerAutoProceeds(t *testing.T) {
+	f := newFake().with("GET /v1/email/init", 200, initCtxShortfall)
+	rep := Check(t.Context(), f, EmailConfig())
+	if rep.Blocked() || rep.Ready() {
+		t.Fatalf("test setup: want Blocked()==false && Ready()==false, got Blocked=%v Ready=%v",
+			rep.Blocked(), rep.Ready())
+	}
+	if !rep.HasHalt() {
+		t.Fatal("test setup: want a Halt row present")
+	}
+
+	m := New(f, EmailConfig(), Options{ReadyHold: time.Millisecond})
+	updated, _ := m.Update(tea.WindowSizeMsg{Width: 80, Height: 24})
+	updated, cmd := updated.(Model).Update(reportMsg{rep: rep})
+	m = updated.(Model)
+
+	// 1. Whatever cmd is, it must not be a tick toward ProceedMsg. Run it
+	// under a deadline (the idiom TestCancelStopsAnInFlightFix already uses
+	// for in-flight work) so a regression to the 2500ms tick trips the
+	// deadline instead of stalling the suite.
+	if cmd != nil {
+		done := make(chan tea.Msg, 1)
+		go func() { done <- cmd() }()
+		select {
+		case msg := <-done:
+			if _, ok := msg.(proceedTickMsg); ok {
+				t.Fatal("reportMsg with a Halt row scheduled the auto-proceed tick")
+			}
+		case <-time.After(200 * time.Millisecond):
+			t.Fatal("cmd from a Halt report did not resolve within 200ms — a regression to the 2500ms tick")
+		}
+	}
+
+	// 2. No live path to ProceedMsg survives a stale tick landing anyway.
+	if _, tick := m.Update(proceedTickMsg{}); tick != nil {
+		t.Fatalf("a stray proceedTickMsg still launched the agent after a Halt report: %T", tick())
+	}
+
+	// 3. The deliberate path — pressing enter — still works: only the
+	// automatic path was removed.
+	updated, cmd = m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	m = updated.(Model)
+	if cmd == nil {
+		t.Fatal("enter on a Halt report produced no command")
+	}
+	if _, ok := cmd().(ProceedMsg); !ok {
+		t.Fatalf("enter on a Halt report produced %T, want ProceedMsg", cmd())
 	}
 }
 

--- a/tui/internal/ui/preflight/report.go
+++ b/tui/internal/ui/preflight/report.go
@@ -30,23 +30,36 @@
 //
 //   - Is it proven ready?   Report.Ready() — false for an unknown row, always.
 //   - Is it proven broken?  Report.Blocked() — false for an unknown row.
-//   - Does the launch stop? Only on Blocked.
+//   - Does the launch stop? Depends on the row's Disposition (see Row).
 //
-// So an unknown row renders `[?]`, keeps Ready() false, is named on screen
-// while the agent starts, and does not stop the launch. The alternative —
-// demanding a keypress every time — was rejected deliberately: the condition is
-// one the user cannot fix (their Lemonade build simply does not report a
-// version), so the prompt would fire on every single launch forever. A prompt
-// that always fires and never means anything is dismissed reflexively, and it
-// devalues every other prompt in the product. The signal is kept; the ritual is
-// not.
+// So an unknown row renders `[?]` and keeps Ready() false either way. Most of
+// them — an unadvertised Lemonade version, two mailboxes linked so neither
+// can be probed — are Disposition Notify: named on screen while the agent
+// starts, launch not stopped. The alternative — demanding a keypress every
+// time — was rejected deliberately for these: the condition is one the user
+// cannot fix (their Lemonade build simply does not report a version), so the
+// prompt would fire on every single launch forever. A prompt that always
+// fires and never means anything is dismissed reflexively, and it devalues
+// every other prompt in the product. The signal is kept; the ritual is not.
 //
-// A row that is genuinely broken still blocks, and no keystroke moves past it.
+// A handful of unknown rows are Disposition Halt instead — a model loaded
+// into a context window smaller than the profile pins, where a document-sized
+// request comes back context_length_exceeded. Unlike the Notify cases, this
+// one is consequential and not something re-checking clears on its own, so it
+// holds for a person rather than proceeding silently. See internal/ui/status
+// for how a Halt row reaches the rest of the app.
+//
+// A row that is genuinely broken (StateFailed) still blocks via Report.Blocked
+// unless it is one the agent itself can repair once the conversation starts
+// (Report.OfferableDespiteFailure) — that one keystroke opens the door to the
+// repair instead of a second gate in front of it.
 package preflight
 
 import (
 	"fmt"
 	"strings"
+
+	"github.com/amd/gaia/tui/internal/ui/status"
 )
 
 // State is a precondition's answer. Pending and Unknown are deliberately
@@ -167,10 +180,49 @@ type Row struct {
 	Provider string
 	// Raw is the probe's raw answer (JSON body or error text), shown by `d`.
 	Raw string
+	// Disposition is what the checklist does when this row is not OK — Halt
+	// or Notify. Set by the check that produces the row, because the check
+	// is what knows whether being unverified will actually bite the user.
+	// DispositionUnset on a StateFailed or StateUnknown row is a bug — see
+	// TestEveryNonOKRowDeclaresADisposition.
+	Disposition status.Disposition
 }
 
 // NeedsAttention reports whether the row is anything other than proved ready.
 func (r Row) NeedsAttention() bool { return r.State != StateOK }
+
+// levelFor maps a row's State onto the status package's Level. Pending and
+// Checking are transient placeholders, not a resolved answer, so both map to
+// LevelUnset — consistent with LevelUnset never being a decided disposition
+// either.
+func levelFor(s State) status.Level {
+	switch s {
+	case StateOK:
+		return status.LevelOK
+	case StateUnknown:
+		return status.LevelUnknown
+	case StateFailed:
+		return status.LevelFailed
+	default:
+		return status.LevelUnset
+	}
+}
+
+// Outcome converts the row into the status package's shared vocabulary, for
+// anything listening for a consequential state (see internal/ui/status and
+// RootModel's listener). Summary is sanitized through status.New — Line and
+// Detail can carry upstream server text verbatim (checkInit assigns
+// body.hint() straight to Detail, and Ladder builds causes with %s over
+// upstream/transport text), and this is the boundary where that text stops
+// being trusted, even though the row itself still carries it unsanitized for
+// the existing on-screen remedy rendering.
+func (r Row) Outcome() status.Outcome {
+	summary := r.Detail
+	if summary == "" {
+		summary = r.Line
+	}
+	return status.New(r.Key, r.Label, levelFor(r.State), r.Disposition, summary)
+}
 
 // Stable row keys. The first four are generic to any sidecar agent that
 // implements GET /v1/<agent>/init; KeyMailbox is email-specific and arrives
@@ -239,6 +291,19 @@ func (r Report) OfferableDespiteFailure() bool {
 		failed = true
 	}
 	return failed
+}
+
+// HasHalt reports whether any non-OK row's Disposition is Halt. This is what
+// gates the screen-does-not-lie behaviour in preflight/model.go: a report
+// holding only Notify rows (an unadvertised Lemonade version, 2+ linked
+// mailboxes) keeps today's auto-proceed; a report with a Halt row does not.
+func (r Report) HasHalt() bool {
+	for _, row := range r.Rows {
+		if row.State != StateOK && row.Disposition == status.DispositionHalt {
+			return true
+		}
+	}
+	return false
 }
 
 // OKCount is how many preconditions proved ready.

--- a/tui/internal/ui/preflight/report.go
+++ b/tui/internal/ui/preflight/report.go
@@ -293,20 +293,38 @@ func (r Report) OfferableDespiteFailure() bool {
 	return failed
 }
 
-// HasHalt reports whether any non-OK row should hold the screen. Notify is
-// the value a row must opt INTO to auto-proceed — anything else, including a
-// forgotten DispositionUnset, holds. Inverted on purpose: the alternative
-// (require == DispositionHalt) reproduces the exact bug this issue exists to
-// fix, one field at a time — a row nobody assigned a Disposition to would
-// silently proceed instead of loudly halting. A row that IS Halt or that
-// nobody decided about both hold; only a deliberate Notify skips it.
+// needsHalt is shared by HasHalt and HaltingRows so the two can never
+// disagree about which rows count. Notify is the value a row must opt INTO
+// to auto-proceed — anything else, including a forgotten DispositionUnset,
+// holds. Inverted on purpose: the alternative (require == DispositionHalt)
+// reproduces the exact bug this issue exists to fix, one field at a time — a
+// row nobody assigned a Disposition to would silently proceed instead of
+// loudly halting.
+func (r Row) needsHalt() bool {
+	return r.State != StateOK && r.Disposition != status.DispositionNotify
+}
+
+// HasHalt reports whether any row in the report needsHalt.
 func (r Report) HasHalt() bool {
 	for _, row := range r.Rows {
-		if row.State != StateOK && row.Disposition != status.DispositionNotify {
+		if row.needsHalt() {
 			return true
 		}
 	}
 	return false
+}
+
+// HaltingRows returns the rows that needsHalt, for building the Outcomes a
+// listener sees. Emission is level-triggered: Check resolves every row in
+// one pass, so this is called once per report, not streamed per row.
+func (r Report) HaltingRows() []Row {
+	var out []Row
+	for _, row := range r.Rows {
+		if row.needsHalt() {
+			out = append(out, row)
+		}
+	}
+	return out
 }
 
 // OKCount is how many preconditions proved ready.

--- a/tui/internal/ui/preflight/report.go
+++ b/tui/internal/ui/preflight/report.go
@@ -293,13 +293,16 @@ func (r Report) OfferableDespiteFailure() bool {
 	return failed
 }
 
-// HasHalt reports whether any non-OK row's Disposition is Halt. This is what
-// gates the screen-does-not-lie behaviour in preflight/model.go: a report
-// holding only Notify rows (an unadvertised Lemonade version, 2+ linked
-// mailboxes) keeps today's auto-proceed; a report with a Halt row does not.
+// HasHalt reports whether any non-OK row should hold the screen. Notify is
+// the value a row must opt INTO to auto-proceed — anything else, including a
+// forgotten DispositionUnset, holds. Inverted on purpose: the alternative
+// (require == DispositionHalt) reproduces the exact bug this issue exists to
+// fix, one field at a time — a row nobody assigned a Disposition to would
+// silently proceed instead of loudly halting. A row that IS Halt or that
+// nobody decided about both hold; only a deliberate Notify skips it.
 func (r Report) HasHalt() bool {
 	for _, row := range r.Rows {
-		if row.State != StateOK && row.Disposition == status.DispositionHalt {
+		if row.State != StateOK && row.Disposition != status.DispositionNotify {
 			return true
 		}
 	}

--- a/tui/internal/ui/preflight/view.go
+++ b/tui/internal/ui/preflight/view.go
@@ -123,7 +123,7 @@ func (m Model) footer(w int) string {
 	keys = append(keys, [2]string{"d", "details"})
 	if !m.Busy() && !m.rep.Ready() &&
 		(!m.rep.Blocked() || m.rep.OfferableDespiteFailure()) {
-		keys = append(keys, [2]string{"enter", "start anyway"})
+		keys = append(keys, [2]string{"enter", "continue"})
 	}
 	keys = append(keys, [2]string{"esc", "back"})
 

--- a/tui/internal/ui/preflight/view_test.go
+++ b/tui/internal/ui/preflight/view_test.go
@@ -278,7 +278,7 @@ func TestKeysDriveTheRightActions(t *testing.T) {
 		f := newFake().with("GET /v1/email/connectors", 200, connectorsNone)
 		m, lines := renderAt(t, f, 80, 24)
 		screen := strings.Join(lines, "\n")
-		if !strings.Contains(screen, "start anyway") {
+		if !strings.Contains(screen, "continue") {
 			t.Errorf("a repairable mailbox hid the launch that reaches the fix:\n%s", screen)
 		}
 		if _, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter}); cmd == nil {

--- a/tui/internal/ui/root/halt.go
+++ b/tui/internal/ui/root/halt.go
@@ -1,14 +1,9 @@
 package root
 
 import (
-	"sort"
-	"strings"
-
 	tea "github.com/charmbracelet/bubbletea"
-	"github.com/charmbracelet/lipgloss"
 
 	"github.com/amd/gaia/tui/internal/ui/status"
-	"github.com/amd/gaia/tui/internal/ui/theme"
 )
 
 // Listener decides whether an Outcome should hold the screen for a person.
@@ -25,13 +20,18 @@ func haltOnDisposition(o status.Outcome) bool {
 	return o.Level != status.LevelOK && o.Disposition != status.DispositionNotify
 }
 
-// Halted reports whether a halting Outcome currently owns the screen.
-// Mirrors preflight.Model.Ready()/Busy() — an exported query over otherwise
-// unexported state.
+// Halted reports whether the active screen is holding on a consequential
+// Outcome. RootModel does not act on this itself — it neither renders
+// anything nor intercepts a key for it. The screen that raised it
+// (preflight.Model) already pauses itself and explains why; this is purely
+// a signal ControlSnapshot's Overlay exposes to automation, so it can wait
+// on "this TUI is waiting" without scraping the screen.
 func (m RootModel) Halted() bool { return len(m.halted) > 0 }
 
-// applyOutcome runs o past every listener. A dismissed StepID never halts
-// again this session; an already-tracked StepID is not added twice.
+// applyOutcome runs o past every listener. A StepID already suppressed this
+// session (the user has already proceeded past it once, see
+// suppressHalted) never halts again; an already-tracked StepID is not added
+// twice.
 func (m RootModel) applyOutcome(o status.Outcome) (tea.Model, tea.Cmd) {
 	if m.suppressed[o.StepID] {
 		return m, nil
@@ -55,89 +55,23 @@ func (m RootModel) applyOutcome(o status.Outcome) (tea.Model, tea.Cmd) {
 	return m, nil
 }
 
-// handleHaltKey owns every key while the notice is up, extending the
-// hand-ordered overlay chain showHelp and connectHandoff already use.
-// ctrl+c quits like everywhere else — the halt is raised at the moment
-// something is already wrong, the worst time to make the escape hatch need
-// two presses. enter dismisses and suppresses every currently-halted StepID
-// for the rest of the session, and does not reach the screen behind it.
-// Every other key is swallowed.
-func (m RootModel) handleHaltKey(key tea.KeyMsg) (tea.Model, tea.Cmd) {
-	switch key.String() {
-	case "ctrl+c":
-		return m, tea.Quit
-	case "enter":
-		suppressed := make(map[string]bool, len(m.suppressed)+len(m.halted))
-		for k := range m.suppressed {
-			suppressed[k] = true
-		}
-		for _, o := range m.halted {
-			suppressed[o.StepID] = true
-		}
-		m.suppressed = suppressed
-		m.halted = nil
-		return m, nil
+// suppressHalted marks every currently-halted StepID as accepted for the
+// rest of the session and clears halted. Called when the gate the Outcomes
+// belonged to proceeds (see proceedFromGate) — proceeding past a
+// consequential row IS the deliberate choice the Halt disposition exists to
+// gate, so the same row halting again on a later launch this session would
+// be the exact confirm-fatigue the Notify/Halt split exists to avoid. It
+// does not change what the screen itself asks for on the next launch — only
+// what automation is told about it.
+func (m *RootModel) suppressHalted() {
+	if len(m.halted) == 0 {
+		return
 	}
-	return m, nil
-}
-
-// orderedHaltRows returns a COPY of outcomes with a known failure ordered
-// before an unproven row — the same precedence
-// preflight.Model.unverifiedSummary already encodes, reused rather than
-// reinvented.
-func orderedHaltRows(outcomes []status.Outcome) []status.Outcome {
-	out := append([]status.Outcome{}, outcomes...)
-	sort.SliceStable(out, func(i, j int) bool {
-		return haltPrecedence(out[i].Level) < haltPrecedence(out[j].Level)
-	})
-	return out
-}
-
-func haltPrecedence(l status.Level) int {
-	switch l {
-	case status.LevelFailed:
-		return 0
-	case status.LevelUnknown:
-		return 1
-	default:
-		return 2
+	if m.suppressed == nil {
+		m.suppressed = map[string]bool{}
 	}
-}
-
-var (
-	haltBoxStyle   = lipgloss.NewStyle().Border(lipgloss.RoundedBorder()).BorderForeground(theme.Warning).Padding(1, 2)
-	haltTitleStyle = lipgloss.NewStyle().Bold(true).Foreground(theme.Warning)
-	haltLabelStyle = lipgloss.NewStyle().Bold(true).Foreground(theme.Text)
-	haltDimStyle   = lipgloss.NewStyle().Foreground(theme.Dim)
-	haltKeyStyle   = lipgloss.NewStyle().Bold(true).Foreground(theme.Info)
-)
-
-// renderHaltNotice centers the halt notice over background, the same
-// pattern components.RenderHelpOverlay uses for the help panel.
-func renderHaltNotice(outcomes []status.Outcome, background string, width, height int) string {
-	ordered := orderedHaltRows(outcomes)
-
-	var b strings.Builder
-	b.WriteString(haltTitleStyle.Render("Waiting for you"))
-	b.WriteString("\n\n")
-	for _, o := range ordered {
-		b.WriteString(haltLabelStyle.Render(o.Label))
-		if o.Summary != "" {
-			b.WriteString(": " + haltDimStyle.Render(o.Summary))
-		}
-		b.WriteString("\n")
+	for _, o := range m.halted {
+		m.suppressed[o.StepID] = true
 	}
-	b.WriteString("\n")
-	b.WriteString(haltKeyStyle.Render("enter") + " " + haltDimStyle.Render("continue anyway") +
-		haltDimStyle.Render("  ·  ") + haltKeyStyle.Render("ctrl+c") + " " + haltDimStyle.Render("quit"))
-
-	boxWidth := width - 4
-	if boxWidth > 70 {
-		boxWidth = 70
-	}
-	if boxWidth < 20 {
-		boxWidth = 20
-	}
-	box := haltBoxStyle.Width(boxWidth).Render(strings.TrimRight(b.String(), "\n"))
-	return lipgloss.Place(width, height, lipgloss.Center, lipgloss.Center, box)
+	m.halted = nil
 }

--- a/tui/internal/ui/root/halt.go
+++ b/tui/internal/ui/root/halt.go
@@ -1,0 +1,143 @@
+package root
+
+import (
+	"sort"
+	"strings"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+
+	"github.com/amd/gaia/tui/internal/ui/status"
+	"github.com/amd/gaia/tui/internal/ui/theme"
+)
+
+// Listener decides whether an Outcome should hold the screen for a person.
+// This is the subscribe seam the issue asks for: RootModel defaults to one
+// entry (haltOnDisposition) and there is no registration API beyond it.
+type Listener func(status.Outcome) bool
+
+// haltOnDisposition is the default Listener. Notify is the only Disposition
+// that skips holding — Halt, and a Disposition nobody decided, both hold.
+// Same inverted direction as preflight.Report.HasHalt, and for the same
+// reason: written the other way round, a row nobody assigned a Disposition
+// to would silently proceed instead of loudly halting.
+func haltOnDisposition(o status.Outcome) bool {
+	return o.Level != status.LevelOK && o.Disposition != status.DispositionNotify
+}
+
+// Halted reports whether a halting Outcome currently owns the screen.
+// Mirrors preflight.Model.Ready()/Busy() — an exported query over otherwise
+// unexported state.
+func (m RootModel) Halted() bool { return len(m.halted) > 0 }
+
+// applyOutcome runs o past every listener. A dismissed StepID never halts
+// again this session; an already-tracked StepID is not added twice.
+func (m RootModel) applyOutcome(o status.Outcome) (tea.Model, tea.Cmd) {
+	if m.suppressed[o.StepID] {
+		return m, nil
+	}
+	halt := false
+	for _, l := range m.listeners {
+		if l(o) {
+			halt = true
+			break
+		}
+	}
+	if !halt {
+		return m, nil
+	}
+	for _, existing := range m.halted {
+		if existing.StepID == o.StepID {
+			return m, nil
+		}
+	}
+	m.halted = append(m.halted, o)
+	return m, nil
+}
+
+// handleHaltKey owns every key while the notice is up, extending the
+// hand-ordered overlay chain showHelp and connectHandoff already use.
+// ctrl+c quits like everywhere else — the halt is raised at the moment
+// something is already wrong, the worst time to make the escape hatch need
+// two presses. enter dismisses and suppresses every currently-halted StepID
+// for the rest of the session, and does not reach the screen behind it.
+// Every other key is swallowed.
+func (m RootModel) handleHaltKey(key tea.KeyMsg) (tea.Model, tea.Cmd) {
+	switch key.String() {
+	case "ctrl+c":
+		return m, tea.Quit
+	case "enter":
+		suppressed := make(map[string]bool, len(m.suppressed)+len(m.halted))
+		for k := range m.suppressed {
+			suppressed[k] = true
+		}
+		for _, o := range m.halted {
+			suppressed[o.StepID] = true
+		}
+		m.suppressed = suppressed
+		m.halted = nil
+		return m, nil
+	}
+	return m, nil
+}
+
+// orderedHaltRows returns a COPY of outcomes with a known failure ordered
+// before an unproven row — the same precedence
+// preflight.Model.unverifiedSummary already encodes, reused rather than
+// reinvented.
+func orderedHaltRows(outcomes []status.Outcome) []status.Outcome {
+	out := append([]status.Outcome{}, outcomes...)
+	sort.SliceStable(out, func(i, j int) bool {
+		return haltPrecedence(out[i].Level) < haltPrecedence(out[j].Level)
+	})
+	return out
+}
+
+func haltPrecedence(l status.Level) int {
+	switch l {
+	case status.LevelFailed:
+		return 0
+	case status.LevelUnknown:
+		return 1
+	default:
+		return 2
+	}
+}
+
+var (
+	haltBoxStyle   = lipgloss.NewStyle().Border(lipgloss.RoundedBorder()).BorderForeground(theme.Warning).Padding(1, 2)
+	haltTitleStyle = lipgloss.NewStyle().Bold(true).Foreground(theme.Warning)
+	haltLabelStyle = lipgloss.NewStyle().Bold(true).Foreground(theme.Text)
+	haltDimStyle   = lipgloss.NewStyle().Foreground(theme.Dim)
+	haltKeyStyle   = lipgloss.NewStyle().Bold(true).Foreground(theme.Info)
+)
+
+// renderHaltNotice centers the halt notice over background, the same
+// pattern components.RenderHelpOverlay uses for the help panel.
+func renderHaltNotice(outcomes []status.Outcome, background string, width, height int) string {
+	ordered := orderedHaltRows(outcomes)
+
+	var b strings.Builder
+	b.WriteString(haltTitleStyle.Render("Waiting for you"))
+	b.WriteString("\n\n")
+	for _, o := range ordered {
+		b.WriteString(haltLabelStyle.Render(o.Label))
+		if o.Summary != "" {
+			b.WriteString(": " + haltDimStyle.Render(o.Summary))
+		}
+		b.WriteString("\n")
+	}
+	b.WriteString("\n")
+	b.WriteString(haltKeyStyle.Render("enter") + " " + haltDimStyle.Render("continue anyway") +
+		haltDimStyle.Render("  ·  ") + haltKeyStyle.Render("ctrl+c") + " " + haltDimStyle.Render("quit"))
+
+	boxWidth := width - 4
+	if boxWidth > 70 {
+		boxWidth = 70
+	}
+	if boxWidth < 20 {
+		boxWidth = 20
+	}
+	box := haltBoxStyle.Width(boxWidth).Render(strings.TrimRight(b.String(), "\n"))
+	return lipgloss.Place(width, height, lipgloss.Center, lipgloss.Center, box)
+}

--- a/tui/internal/ui/root/introspect.go
+++ b/tui/internal/ui/root/introspect.go
@@ -39,9 +39,11 @@ func (m RootModel) ControlSnapshot() control.Snapshot {
 	if m.showHelp {
 		snap.Overlay = "help"
 	}
-	// Halt wins over every other overlay — same precedence as View() and the
-	// keyboard ownership in Update. The underlying View stays whatever it
-	// already was, so /status never blinds to "unknown" while held.
+	// Halt wins over every other overlay. It draws nothing and intercepts no
+	// key — the screen that raised it (preflight.Model) already pauses
+	// itself and explains why — but automation still needs a signal, and
+	// this is it: the underlying View stays whatever it already was, so
+	// /status never blinds to "unknown" while held.
 	if m.Halted() {
 		snap.Overlay = "halt"
 	}

--- a/tui/internal/ui/root/introspect.go
+++ b/tui/internal/ui/root/introspect.go
@@ -39,5 +39,11 @@ func (m RootModel) ControlSnapshot() control.Snapshot {
 	if m.showHelp {
 		snap.Overlay = "help"
 	}
+	// Halt wins over every other overlay — same precedence as View() and the
+	// keyboard ownership in Update. The underlying View stays whatever it
+	// already was, so /status never blinds to "unknown" while held.
+	if m.Halted() {
+		snap.Overlay = "halt"
+	}
 	return snap
 }

--- a/tui/internal/ui/root/model.go
+++ b/tui/internal/ui/root/model.go
@@ -12,6 +12,7 @@ import (
 	"github.com/amd/gaia/tui/internal/ui/components"
 	"github.com/amd/gaia/tui/internal/ui/hub"
 	"github.com/amd/gaia/tui/internal/ui/preflight"
+	"github.com/amd/gaia/tui/internal/ui/status"
 )
 
 type view int
@@ -45,6 +46,19 @@ type RootModel struct {
 	// pfTransport is built on first launch and reused for the session.
 	pfTransport preflight.Transport
 	pfOpts      preflight.Options
+
+	// halted is every Outcome currently holding the screen, in arrival order
+	// (rendered in precedence order — see orderedHaltRows). Empty means
+	// nothing is halting.
+	halted []status.Outcome
+	// suppressed is every StepID a person has already dismissed this
+	// session — per-process, never persisted, so a permanently-unknown row
+	// does not re-halt on every re-check.
+	suppressed map[string]bool
+	// listeners decide whether an Outcome halts. The subscribe seam the
+	// issue asks for; defaults to one entry with no registration API beyond
+	// it.
+	listeners []Listener
 }
 
 // WithPreflight points the readiness gate at a specific transport and tunes its
@@ -61,6 +75,8 @@ func NewRootModel(cat *catalog.Catalog, debug bool) RootModel {
 		activeView: viewHub,
 		catalog:    cat,
 		debug:      debug,
+		suppressed: map[string]bool{},
+		listeners:  []Listener{haltOnDisposition},
 	}
 	// One hub client for the session: it caches the daemon instance whose token
 	// authorized the last call, and that token rotates on every daemon restart.
@@ -76,6 +92,8 @@ func NewRootModelWithHub(cat *catalog.Catalog, hc *catalog.HubClient, debug bool
 		activeView: viewHub,
 		catalog:    cat,
 		debug:      debug,
+		suppressed: map[string]bool{},
+		listeners:  []Listener{haltOnDisposition},
 	}
 	m.hub = hub.NewHubModel(cat, hc, debug)
 	return m
@@ -129,6 +147,9 @@ func (m RootModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		return m.openConnectHandoff(msg.Provider)
 
+	case status.Outcome:
+		return m.applyOutcome(msg)
+
 	case chat.ReturnToHubMsg:
 		return m.returnToHub(msg.AgentID)
 
@@ -143,6 +164,12 @@ func (m RootModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, nil
 
 	case tea.KeyMsg:
+		// The halt notice owns every key while it is up, above showHelp and
+		// connectHandoff both — it is raised at the moment something is
+		// already wrong, so it gets first claim on the keyboard.
+		if m.Halted() {
+			return m.handleHaltKey(msg)
+		}
 		if m.showHelp {
 			// Any key dismisses help overlay
 			m.showHelp = false
@@ -202,6 +229,12 @@ func (m RootModel) View() string {
 		if m.chat != nil {
 			base = m.chat.View()
 		}
+	}
+
+	// The halt notice renders above showHelp too — same precedence as the
+	// keyboard ownership in Update.
+	if m.Halted() {
+		return renderHaltNotice(m.halted, base, m.width, m.height)
 	}
 
 	if m.showHelp {

--- a/tui/internal/ui/root/model.go
+++ b/tui/internal/ui/root/model.go
@@ -47,13 +47,17 @@ type RootModel struct {
 	pfTransport preflight.Transport
 	pfOpts      preflight.Options
 
-	// halted is every Outcome currently holding the screen, in arrival order
-	// (rendered in precedence order — see orderedHaltRows). Empty means
-	// nothing is halting.
+	// halted is every Outcome the active screen is currently holding on.
+	// RootModel does not render it or intercept keys for it — the screen
+	// that raised it (preflight.Model) already pauses itself and shows its
+	// own explanation; this is purely a state flag automation reads via
+	// ControlSnapshot's Overlay. Cleared when the gate closes, whether by
+	// proceeding or backing out.
 	halted []status.Outcome
-	// suppressed is every StepID a person has already dismissed this
-	// session — per-process, never persisted, so a permanently-unknown row
-	// does not re-halt on every re-check.
+	// suppressed is every StepID the user has already proceeded past this
+	// session — per-process, never persisted, so relaunching the same agent
+	// does not report a fresh halt for a row already accepted once. It does
+	// NOT change what the screen itself asks for on each launch.
 	suppressed map[string]bool
 	// listeners decide whether an Outcome halts. The subscribe seam the
 	// issue asks for; defaults to one entry with no registration API beyond
@@ -164,12 +168,6 @@ func (m RootModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, nil
 
 	case tea.KeyMsg:
-		// The halt notice owns every key while it is up, above showHelp and
-		// connectHandoff both — it is raised at the moment something is
-		// already wrong, so it gets first claim on the keyboard.
-		if m.Halted() {
-			return m.handleHaltKey(msg)
-		}
 		if m.showHelp {
 			// Any key dismisses help overlay
 			m.showHelp = false
@@ -229,12 +227,6 @@ func (m RootModel) View() string {
 		if m.chat != nil {
 			base = m.chat.View()
 		}
-	}
-
-	// The halt notice renders above showHelp too — same precedence as the
-	// keyboard ownership in Update.
-	if m.Halted() {
-		return renderHaltNotice(m.halted, base, m.width, m.height)
 	}
 
 	if m.showHelp {

--- a/tui/internal/ui/root/preflight.go
+++ b/tui/internal/ui/root/preflight.go
@@ -97,10 +97,18 @@ func (m *RootModel) closeGate() {
 	}
 	m.pending = nil
 	m.connect = nil
+	// Whatever was halting belonged to THIS gate session — leaving it, by
+	// proceeding or backing out, resolves it. Automation's Overlay must not
+	// keep reading "halt" once the gate that raised it is gone.
+	m.halted = nil
 }
 
 func (m RootModel) proceedFromGate() (tea.Model, tea.Cmd) {
 	agent := *m.pending
+	// Before closeGate clears halted: proceeding IS the deliberate choice
+	// the halt exists to gate, so mark these StepIDs accepted for the rest
+	// of the session before the record of them is gone.
+	m.suppressHalted()
 	m.closeGate()
 	// Back to the hub FIRST. launchAgent stays where it is and reports the reason
 	// when a client cannot be built, and "where it is" has to be a screen that

--- a/tui/internal/ui/status/status.go
+++ b/tui/internal/ui/status/status.go
@@ -66,16 +66,25 @@ func New(stepID, label string, level Level, disposition Disposition, summary str
 	}
 }
 
-// Sanitize strips ANSI escape sequences and bare C0 control bytes (other
-// than \n and \t) from s. ansi.Strip alone removes escape SEQUENCES — a
-// clear-screen CSI, an OSC set-title — but leaves a lone control byte like a
-// stray BEL sitting in the string, so this does a second pass over what is
-// left.
+// Sanitize strips ANSI escape sequences and bare control bytes (other than
+// \n and \t) from s. ansi.Strip alone removes escape SEQUENCES — a
+// clear-screen CSI, an OSC set-title — but leaves a lone control byte, such
+// as a stray BEL, a raw DEL, or a valid UTF-8 encoding of a C1 control
+// (U+0080-U+009F, e.g. a single-byte-CSI trigger), sitting in the string, so
+// this does a second pass over what is left. Each of those was verified to
+// survive ansi.Strip before this function was written to catch it, rather
+// than assumed.
 func Sanitize(s string) string {
 	s = ansi.Strip(s)
 	out := make([]rune, 0, len(s))
 	for _, r := range s {
-		if r == '\n' || r == '\t' || r >= 0x20 {
+		switch {
+		case r == '\n' || r == '\t':
+			out = append(out, r)
+		case r < 0x20, r == 0x7f, r >= 0x80 && r <= 0x9f:
+			// C0, DEL, and C1 control ranges.
+			continue
+		default:
 			out = append(out, r)
 		}
 	}

--- a/tui/internal/ui/status/status.go
+++ b/tui/internal/ui/status/status.go
@@ -1,0 +1,83 @@
+// Package status is the shared vocabulary a screen uses to announce how a
+// precondition turned out, and what should happen when it is not OK. It is
+// NOT a UI event bus — see internal/event, which parses agent SSE payloads
+// and is a different thing entirely. Bubble Tea's Update loop is the only
+// dispatcher; this package just names one message shape that flows through
+// it.
+package status
+
+import "github.com/charmbracelet/x/ansi"
+
+// Level is how a precondition turned out. LevelUnset is the zero value and
+// deliberately does not compare equal to LevelOK — an Outcome{} nobody
+// finished building must read as "not OK", the same way preflight.State
+// keeps StatePending off the OK value.
+type Level int
+
+const (
+	LevelUnset Level = iota
+	LevelOK
+	// LevelUnknown — probed, but the answer was indeterminate.
+	LevelUnknown
+	LevelFailed
+)
+
+// Disposition is what the checklist does with a row that is not OK. The
+// check that produces the row declares it, because the check is what knows
+// whether being unverified will actually bite the user.
+type Disposition int
+
+const (
+	// DispositionUnset means nobody decided. A non-OK row must never carry
+	// this — see the exhaustiveness test in the preflight package.
+	DispositionUnset Disposition = iota
+	// DispositionNotify — name it on screen, expire, move on.
+	DispositionNotify
+	// DispositionHalt — hold the screen until a person decides.
+	DispositionHalt
+)
+
+// Outcome is how one precondition turned out.
+type Outcome struct {
+	// StepID is the stable identifier of the check that produced this
+	// outcome, e.g. "model" — it keys de-dup and session suppression.
+	StepID string
+	// Label is the human name, e.g. "AI model".
+	Label string
+	Level Level
+	// Disposition is what a listener should do about a non-OK Level.
+	Disposition Disposition
+	// Summary is one sanitized line of why. Build it through New, or through
+	// Sanitize directly, rather than assigning it — the text this carries
+	// usually originated on an upstream server the terminal must not trust.
+	Summary string
+}
+
+// New builds an Outcome, sanitizing summary. Upstream text — a probe's raw
+// hint, an upstream diagnosis — reaches this package unescaped; this is the
+// one place on the path to the terminal that must not assume it is inert.
+func New(stepID, label string, level Level, disposition Disposition, summary string) Outcome {
+	return Outcome{
+		StepID:      stepID,
+		Label:       label,
+		Level:       level,
+		Disposition: disposition,
+		Summary:     Sanitize(summary),
+	}
+}
+
+// Sanitize strips ANSI escape sequences and bare C0 control bytes (other
+// than \n and \t) from s. ansi.Strip alone removes escape SEQUENCES — a
+// clear-screen CSI, an OSC set-title — but leaves a lone control byte like a
+// stray BEL sitting in the string, so this does a second pass over what is
+// left.
+func Sanitize(s string) string {
+	s = ansi.Strip(s)
+	out := make([]rune, 0, len(s))
+	for _, r := range s {
+		if r == '\n' || r == '\t' || r >= 0x20 {
+			out = append(out, r)
+		}
+	}
+	return string(out)
+}

--- a/tui/internal/ui/status/status_test.go
+++ b/tui/internal/ui/status/status_test.go
@@ -54,6 +54,29 @@ func TestSanitizeStripsBareC0NotJustANSI(t *testing.T) {
 	}
 }
 
+// DEL (0x7F) is not C0 (0x00-0x1F) but is exactly as much a terminal control
+// byte, and a naive `r >= 0x20` check lets it through. Verified empirically
+// (a throwaway script) that ansi.Strip leaves it in place before writing this.
+func TestSanitizeStripsDEL(t *testing.T) {
+	got := Sanitize("hello\x7fworld")
+	if got != "helloworld" {
+		t.Fatalf("Sanitize(%q) = %q, want %q", "hello\x7fworld", got, "helloworld")
+	}
+}
+
+// C1 controls (U+0080-U+009F) are a second control range distinct from C0.
+// A VALID UTF-8 encoding of one (unlike a raw invalid byte, which would
+// decode as U+FFFD) survives both ansi.Strip and a `r >= 0x20` filter intact
+// — verified empirically before writing this test, the same way BEL and DEL
+// were checked, rather than assumed.
+func TestSanitizeStripsC1(t *testing.T) {
+	c1 := string(rune(0x9B)) // SCI, a C1 control, UTF-8 encoded as 0xC2 0x9B
+	got := Sanitize("hello" + c1 + "world")
+	if got != "helloworld" {
+		t.Fatalf("Sanitize did not strip a UTF-8-encoded C1 control: %q", got)
+	}
+}
+
 func TestSanitizePreservesNewlinesAndTabs(t *testing.T) {
 	const s = "line1\nline2\ttabbed"
 	if got := Sanitize(s); got != s {

--- a/tui/internal/ui/status/status_test.go
+++ b/tui/internal/ui/status/status_test.go
@@ -1,0 +1,84 @@
+package status
+
+import (
+	"strings"
+	"testing"
+)
+
+// The zero value of Level must not compare equal to LevelOK: a zero-value
+// Outcome{} (e.g. an uninitialised field in a struct literal that forgot to
+// set Level) must read as "not OK", never silently pass. See report.go's
+// StatePending-at-iota precedent in the preflight package, which this
+// mirrors.
+func TestLevelZeroValueIsNotOK(t *testing.T) {
+	var zero Level
+	if zero != LevelUnset {
+		t.Fatalf("Level zero value = %v, want LevelUnset", zero)
+	}
+	if zero == LevelOK {
+		t.Fatal("the zero value of Level must not equal LevelOK")
+	}
+}
+
+// Same invariant for Disposition: an unset disposition on a non-OK row must
+// never be mistaken for a deliberate choice to notify-and-proceed.
+func TestDispositionZeroValueIsUnset(t *testing.T) {
+	var zero Disposition
+	if zero != DispositionUnset {
+		t.Fatalf("Disposition zero value = %v, want DispositionUnset", zero)
+	}
+	if zero == DispositionNotify || zero == DispositionHalt {
+		t.Fatal("the zero value of Disposition must not equal a real disposition")
+	}
+}
+
+func TestSanitizeStripsANSIAndC0(t *testing.T) {
+	// Captured verbatim from the acceptance criterion: a clear-screen CSI
+	// sequence followed by an OSC set-title sequence terminated by BEL.
+	const payload = "\x1b[2J\x1b]0;pwned\x07"
+	got := Sanitize(payload)
+	if strings.ContainsAny(got, "\x1b\x07") {
+		t.Fatalf("Sanitize left control bytes in place: %q", got)
+	}
+	if got != "" {
+		t.Fatalf("Sanitize(%q) = %q, want empty — the payload carries no printable text", payload, got)
+	}
+}
+
+func TestSanitizeStripsBareC0NotJustANSI(t *testing.T) {
+	// ansi.Strip on its own leaves a bare, non-escape-sequence control byte
+	// (like a lone BEL) in place — Sanitize must go further.
+	got := Sanitize("bell\x07here")
+	if got != "bellhere" {
+		t.Fatalf("Sanitize(%q) = %q, want %q", "bell\x07here", got, "bellhere")
+	}
+}
+
+func TestSanitizePreservesNewlinesAndTabs(t *testing.T) {
+	const s = "line1\nline2\ttabbed"
+	if got := Sanitize(s); got != s {
+		t.Fatalf("Sanitize(%q) = %q, want it unchanged", s, got)
+	}
+}
+
+func TestSanitizeLeavesOrdinaryTextAlone(t *testing.T) {
+	const s = "the model is loaded with room for about 25037 tokens"
+	if got := Sanitize(s); got != s {
+		t.Fatalf("Sanitize(%q) = %q, want it unchanged", s, got)
+	}
+}
+
+// New is the constructor every caller should use, precisely so the
+// sanitization above cannot be forgotten at a call site.
+func TestNewSanitizesSummary(t *testing.T) {
+	o := New("model", "AI model", LevelUnknown, DispositionHalt, "\x1b[2J\x1b]0;pwned\x07 the rest is fine")
+	if strings.ContainsAny(o.Summary, "\x1b\x07") {
+		t.Fatalf("New did not sanitize Summary: %q", o.Summary)
+	}
+	if !strings.Contains(o.Summary, "the rest is fine") {
+		t.Fatalf("New dropped legitimate text: %q", o.Summary)
+	}
+	if o.StepID != "model" || o.Label != "AI model" || o.Level != LevelUnknown || o.Disposition != DispositionHalt {
+		t.Fatalf("New did not preserve its other fields: %+v", o)
+	}
+}

--- a/tui/test/preflight_gate_test.go
+++ b/tui/test/preflight_gate_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/amd/gaia/tui/internal/ui/hub"
 	"github.com/amd/gaia/tui/internal/ui/preflight"
 	"github.com/amd/gaia/tui/internal/ui/root"
+	"github.com/amd/gaia/tui/internal/ui/status"
 )
 
 // These tests cover the seam between the hub and the readiness gate: that a
@@ -198,6 +199,25 @@ func (g *gateTransport) mailboxCredentialsRejected() *gateTransport {
 	g.searchBody = map[string]any{
 		"detail": "no forwarded 'google' credential is available to the email sidecar. " +
 			"The connection may not be granted to this agent, or it was revoked/withdrawn.",
+	}
+	return g
+}
+
+// ctxShortfall leaves every generic row green except the model, loaded with a
+// window under the profile's target — the reported bug: an agent that works
+// for ordinary turns and fails a document-sized request. 25037 mirrors the
+// value check_test.go's initCtxShortfall fixture already relies on being
+// below profileCtxTarget() in the test environment.
+func (g *gateTransport) ctxShortfall() *gateTransport {
+	g.initBody = map[string]any{
+		"ready": true,
+		"lemonade": map[string]any{
+			"reachable": true, "base_url": "http://localhost:8000/api/v1",
+			"version": "8.2.0", "min_version": "8.1.0", "compatible": true,
+		},
+		"model": map[string]any{
+			"id": "Gemma-4-E4B-it-GGUF", "present": true, "ctx_size": 25037,
+		},
 	}
 	return g
 }
@@ -901,4 +921,206 @@ func TestEveryGateStateFitsEightyByTwentyFour(t *testing.T) {
 			}
 		})
 	}
+}
+
+// --- the halt notice ---------------------------------------------------------
+//
+// A DispositionHalt row now holds the screen for a person instead of naming
+// itself and passing by. TestACtxShortfallHaltsTheRealGate drives the real
+// Check() pipeline for the row this issue exists to fix; the rest inject a
+// synthetic status.Outcome directly, since no current check can produce two
+// simultaneous halting rows — that scenario is about the notice mechanism,
+// not about any one row.
+
+// The reported bug, through the real gate end to end: a ctx-shortfall report
+// halts instead of auto-proceeding, the control-API state says so without
+// blinding the view, and the notice names the window that will fail.
+func TestACtxShortfallHaltsTheRealGate(t *testing.T) {
+	d := newRootDriver(t, readyGateTransport().ctxShortfall(), 100, 30)
+	d.launchEmail()
+
+	if !d.m.Halted() {
+		t.Fatalf("a ctx-shortfall report did not halt:\n%s", d.screen())
+	}
+	snap := d.m.ControlSnapshot()
+	if snap.Overlay != "halt" {
+		t.Errorf("Overlay = %q, want %q", snap.Overlay, "halt")
+	}
+	if snap.View != "preflight" {
+		t.Errorf("View = %q, want %q — a halt must not blind the automation's view", snap.View, "preflight")
+	}
+	if !strings.Contains(d.flat(), "25037") {
+		t.Errorf("the notice does not show the window that will fail:\n%s", d.screen())
+	}
+
+	d.send(keyEnter())
+	if d.m.Halted() {
+		t.Error("enter did not dismiss the halt")
+	}
+	if d.m.ControlSnapshot().Overlay == "halt" {
+		t.Error("Overlay still reports halt after dismiss")
+	}
+	// The dismiss must not ALSO reach the gate behind it: still on the
+	// preflight screen, not launched into chat by the same keypress.
+	if got := d.view(); got != "preflight" {
+		t.Fatalf("view after dismissing the halt = %q, want preflight — the dismiss reached the screen behind it", got)
+	}
+}
+
+// ctrl+c quits on the FIRST press while halted, never swallowed by the
+// notice — the halt is raised at the moment something is already wrong, the
+// worst time to make the escape hatch need two presses.
+func TestCtrlCQuitsOnFirstPressWhileHalted(t *testing.T) {
+	d := newRootDriver(t, readyGateTransport().ctxShortfall(), 100, 30)
+	d.launchEmail()
+	if !d.m.Halted() {
+		t.Fatal("test setup: want the gate halted")
+	}
+
+	cmd := d.sendNoPump(tea.KeyMsg{Type: tea.KeyCtrlC})
+	if cmd == nil {
+		t.Fatal("ctrl+c while halted produced no command")
+	}
+	if _, ok := cmd().(tea.QuitMsg); !ok {
+		t.Fatalf("ctrl+c while halted produced %T, want tea.QuitMsg", cmd())
+	}
+}
+
+// Dismissing a halt suppresses that StepID for the session: pressing r
+// re-runs the checks, the row is still bad, and it must not halt a second
+// time — without this, a permanently-unknown row (this is exactly one) would
+// re-halt on every single re-check, reintroducing the confirm-fatigue the
+// whole Notify/Halt split exists to avoid for rows that cannot be halts.
+func TestReCheckDoesNotReHaltTheSameStepID(t *testing.T) {
+	d := newRootDriver(t, readyGateTransport().ctxShortfall(), 100, 30)
+	d.launchEmail()
+	if !d.m.Halted() {
+		t.Fatal("test setup: want the gate halted")
+	}
+
+	d.send(keyEnter()) // dismiss
+	if d.m.Halted() {
+		t.Fatal("test setup: dismiss did not clear the halt")
+	}
+
+	// r now reaches the gate — the notice is gone — and re-runs the same
+	// checks against the same still-bad transport.
+	d.send(key("r"))
+	if d.m.Halted() {
+		t.Error("re-checking re-halted on the same row this session already dismissed")
+	}
+	if got := d.view(); got != "preflight" {
+		t.Fatalf("view after re-check = %q, want preflight", got)
+	}
+}
+
+// A resize (not a key) must still reach the gate behind the notice — the
+// notice owns the KEYBOARD, not every message. Proven by the rendered width
+// actually narrowing, which only happens if the message reached the
+// preflight model's own Update, not just RootModel's.
+func TestNonKeyMessagesPassThroughWhileHalted(t *testing.T) {
+	d := newRootDriver(t, readyGateTransport().ctxShortfall(), 100, 30)
+	d.launchEmail()
+	if !d.m.Halted() {
+		t.Fatal("test setup: want the gate halted")
+	}
+
+	d.send(tea.WindowSizeMsg{Width: 40, Height: 20})
+	for i, line := range strings.Split(d.screen(), "\n") {
+		if w := ansi.StringWidth(line); w > 40 {
+			t.Fatalf("line %d is %d columns wide after a 40-column resize while halted — "+
+				"the resize did not reach the screen behind the notice:\n%s", i, w, d.screen())
+		}
+	}
+}
+
+// A spinner.TickMsg specifically must reach a gate that is still Busy() —
+// the acceptance criterion's literal case. sendNoPump keeps the gate's
+// Init() from running so it is still phaseChecking when the halt lands,
+// which only a synthetic Outcome can arrange (the real pipeline cannot halt
+// before its own report exists).
+func TestASpinnerTickReachesABusyGateWhileHalted(t *testing.T) {
+	d := newRootDriver(t, readyGateTransport(), 100, 30)
+	agent := d.cat.Get("email")
+	if agent == nil {
+		t.Fatal("test setup: the email agent is missing from the catalog")
+	}
+	d.sendNoPump(hub.LaunchAgentMsg{Agent: *agent})
+	if d.view() != "preflight" {
+		t.Fatalf("test setup: want preflight, got %q", d.view())
+	}
+
+	d.send(status.Outcome{
+		StepID: "synthetic", Label: "Synthetic",
+		Level: status.LevelUnknown, Disposition: status.DispositionHalt, Summary: "test",
+	})
+	if !d.m.Halted() {
+		t.Fatal("test setup: the synthetic Outcome did not halt")
+	}
+
+	if cmd := d.sendNoPump(spinner.TickMsg{}); cmd == nil {
+		t.Fatal("a spinner tick produced no command while halted — it did not reach the checking gate")
+	}
+}
+
+// Two rows can be halting at once (an unadvertised Lemonade version does not
+// halt, but a future Halt row alongside the ctx shortfall could), and one
+// dismiss must clear both. Ordered so a known failure is listed before an
+// unproven row — the same precedence unverifiedSummary already uses.
+func TestTwoSimultaneousHaltingRowsProduceOneNoticeAndOneDismissClearsBoth(t *testing.T) {
+	d := newRootDriver(t, readyGateTransport(), 100, 30)
+	d.send(status.Outcome{StepID: "a", Label: "Row A", Level: status.LevelUnknown,
+		Disposition: status.DispositionHalt, Summary: "row a is unproven"})
+	d.send(status.Outcome{StepID: "b", Label: "Row B", Level: status.LevelFailed,
+		Disposition: status.DispositionHalt, Summary: "row b is broken"})
+
+	if !d.m.Halted() {
+		t.Fatal("test setup: want halted")
+	}
+	flat := d.flat()
+	for _, want := range []string{"Row A", "Row B"} {
+		if !strings.Contains(flat, want) {
+			t.Errorf("the notice does not list %q:\n%s", want, d.screen())
+		}
+	}
+	if strings.Index(flat, "Row B") > strings.Index(flat, "Row A") {
+		t.Errorf("a known failure must be listed before an unproven row:\n%s", d.screen())
+	}
+
+	d.send(keyEnter())
+	if d.m.Halted() {
+		t.Error("one dismiss did not clear both rows")
+	}
+}
+
+// A halt reaches the app the same way from either screen it can be raised
+// from — the notice is not wired to one view.
+func TestCrossScreenHaltingWorksFromHubAndFromPreflight(t *testing.T) {
+	t.Run("hub", func(t *testing.T) {
+		d := newRootDriver(t, readyGateTransport(), 100, 30)
+		if d.view() != "hub" {
+			t.Fatalf("test setup: want hub, got %q", d.view())
+		}
+		d.send(status.Outcome{StepID: "hub-synthetic", Label: "Synthetic",
+			Level: status.LevelFailed, Disposition: status.DispositionHalt, Summary: "test"})
+		if !d.m.Halted() {
+			t.Error("a synthetic halting Outcome while in the hub did not halt")
+		}
+	})
+	t.Run("preflight", func(t *testing.T) {
+		// ManualProceed keeps an all-green gate parked on the preflight
+		// screen instead of auto-proceeding to chat during the synchronous
+		// pump — this sub-test is about the SCREEN, not the report.
+		opts := preflight.Options{ReadyHold: time.Millisecond, ManualProceed: true}
+		d := newRootDriverOpts(t, readyGateTransport(), 100, 30, opts)
+		d.launchEmail()
+		if d.view() != "preflight" {
+			t.Fatalf("test setup: want preflight, got %q", d.view())
+		}
+		d.send(status.Outcome{StepID: "preflight-synthetic", Label: "Synthetic",
+			Level: status.LevelFailed, Disposition: status.DispositionHalt, Summary: "test"})
+		if !d.m.Halted() {
+			t.Error("a synthetic halting Outcome while in preflight did not halt")
+		}
+	})
 }

--- a/tui/test/preflight_gate_test.go
+++ b/tui/test/preflight_gate_test.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/amd/gaia/tui/internal/catalog"
 	"github.com/amd/gaia/tui/internal/daemon"
+	"github.com/amd/gaia/tui/internal/ui/chat"
 	"github.com/amd/gaia/tui/internal/ui/hub"
 	"github.com/amd/gaia/tui/internal/ui/preflight"
 	"github.com/amd/gaia/tui/internal/ui/root"
@@ -458,7 +459,7 @@ func TestAMailboxWhoseCredentialsAreRejectedNeverGreenLightsALaunch(t *testing.T
 	// Never automatic — but the user may choose it. The agent repairs this state
 	// inside the conversation, so refusing the choice would hide the fix behind
 	// the gate that found the problem.
-	if !strings.Contains(screen, "start anyway") {
+	if !strings.Contains(screen, "continue") {
 		t.Errorf("the gate hid the launch that reaches the in-conversation fix:\n%s", d.screen())
 	}
 	d.send(keyEnter())
@@ -923,18 +924,21 @@ func TestEveryGateStateFitsEightyByTwentyFour(t *testing.T) {
 	}
 }
 
-// --- the halt notice ---------------------------------------------------------
+// --- the halt flag ------------------------------------------------------------
 //
-// A DispositionHalt row now holds the screen for a person instead of naming
-// itself and passing by. TestACtxShortfallHaltsTheRealGate drives the real
-// Check() pipeline for the row this issue exists to fix; the rest inject a
-// synthetic status.Outcome directly, since no current check can produce two
-// simultaneous halting rows — that scenario is about the notice mechanism,
-// not about any one row.
+// A DispositionHalt row makes the readiness screen hold itself and explain
+// why — that is entirely increment 3's doing, already covered in
+// internal/ui/preflight. What lives here is the flag RootModel derives from
+// it: a state signal for automation (ControlSnapshot's Overlay), nothing
+// drawn, nothing intercepted. TestACtxShortfallHaltsTheRealGate drives the
+// real Check() pipeline for the row this issue exists to fix; the rest
+// inject a synthetic status.Outcome directly.
 
 // The reported bug, through the real gate end to end: a ctx-shortfall report
-// halts instead of auto-proceeding, the control-API state says so without
-// blinding the view, and the notice names the window that will fail.
+// halts (Overlay reports it without blinding the view, and the screen names
+// the window that will fail), and the SAME single enter that the screen has
+// always offered is what both proceeds and clears the flag — there is no
+// separate dismiss to press first.
 func TestACtxShortfallHaltsTheRealGate(t *testing.T) {
 	d := newRootDriver(t, readyGateTransport().ctxShortfall(), 100, 30)
 	d.launchEmail()
@@ -950,26 +954,27 @@ func TestACtxShortfallHaltsTheRealGate(t *testing.T) {
 		t.Errorf("View = %q, want %q — a halt must not blind the automation's view", snap.View, "preflight")
 	}
 	if !strings.Contains(d.flat(), "25037") {
-		t.Errorf("the notice does not show the window that will fail:\n%s", d.screen())
+		t.Errorf("the screen does not show the window that will fail:\n%s", d.screen())
 	}
 
+	// One enter — the screen's own "continue" choice — both proceeds AND
+	// clears the flag. There is no separate prompt in front of it.
 	d.send(keyEnter())
+	if got := d.view(); got != "chat" {
+		t.Fatalf("enter on the holding gate = %q, want chat", got)
+	}
 	if d.m.Halted() {
-		t.Error("enter did not dismiss the halt")
+		t.Error("Halted() stayed true after the screen proceeded")
 	}
 	if d.m.ControlSnapshot().Overlay == "halt" {
-		t.Error("Overlay still reports halt after dismiss")
-	}
-	// The dismiss must not ALSO reach the gate behind it: still on the
-	// preflight screen, not launched into chat by the same keypress.
-	if got := d.view(); got != "preflight" {
-		t.Fatalf("view after dismissing the halt = %q, want preflight — the dismiss reached the screen behind it", got)
+		t.Error("Overlay still reports halt after proceeding")
 	}
 }
 
-// ctrl+c quits on the FIRST press while halted, never swallowed by the
-// notice — the halt is raised at the moment something is already wrong, the
-// worst time to make the escape hatch need two presses.
+// ctrl+c quits on the FIRST press while halted — RootModel does not
+// intercept it, so this is really proving the preflight screen's own
+// ctrl+c handling (unrelated to this issue) still works while HasHalt()
+// holds it open.
 func TestCtrlCQuitsOnFirstPressWhileHalted(t *testing.T) {
 	d := newRootDriver(t, readyGateTransport().ctxShortfall(), 100, 30)
 	d.launchEmail()
@@ -986,38 +991,68 @@ func TestCtrlCQuitsOnFirstPressWhileHalted(t *testing.T) {
 	}
 }
 
-// Dismissing a halt suppresses that StepID for the session: pressing r
-// re-runs the checks, the row is still bad, and it must not halt a second
-// time — without this, a permanently-unknown row (this is exactly one) would
-// re-halt on every single re-check, reintroducing the confirm-fatigue the
-// whole Notify/Halt split exists to avoid for rows that cannot be halts.
-func TestReCheckDoesNotReHaltTheSameStepID(t *testing.T) {
+// Re-checking a still-holding gate (r) never needed a fix here: the screen
+// was never blocked from receiving r in the first place, so hitting it
+// leaves the flag exactly as it was — still Halted(), still the same row.
+func TestReCheckOnAHoldingGateStaysHalted(t *testing.T) {
 	d := newRootDriver(t, readyGateTransport().ctxShortfall(), 100, 30)
 	d.launchEmail()
 	if !d.m.Halted() {
 		t.Fatal("test setup: want the gate halted")
 	}
 
-	d.send(keyEnter()) // dismiss
-	if d.m.Halted() {
-		t.Fatal("test setup: dismiss did not clear the halt")
-	}
-
-	// r now reaches the gate — the notice is gone — and re-runs the same
-	// checks against the same still-bad transport.
 	d.send(key("r"))
-	if d.m.Halted() {
-		t.Error("re-checking re-halted on the same row this session already dismissed")
+	if !d.m.Halted() {
+		t.Error("re-checking a row that is still genuinely bad cleared the halt")
 	}
 	if got := d.view(); got != "preflight" {
 		t.Fatalf("view after re-check = %q, want preflight", got)
 	}
 }
 
-// A resize (not a key) must still reach the gate behind the notice — the
-// notice owns the KEYBOARD, not every message. Proven by the rendered width
-// actually narrowing, which only happens if the message reached the
-// preflight model's own Update, not just RootModel's.
+// Proceeding past a halt suppresses that StepID for the rest of the
+// session: the screen still pauses on every launch (that pause is the
+// feature, not something suppression touches), but automation's "a NEW,
+// unhandled halt" signal does not fire twice for a row the user already
+// chose to proceed past once — without this, a permanently-unknown row
+// (this is exactly one) would report a fresh halt on every single relaunch,
+// reintroducing the confirm-fatigue the whole Notify/Halt split exists to
+// avoid.
+func TestProceedingPastAHaltSuppressesTheFlagForTheRestOfTheSession(t *testing.T) {
+	d := newRootDriver(t, readyGateTransport().ctxShortfall(), 100, 30)
+	d.launchEmail()
+	if !d.m.Halted() {
+		t.Fatal("test setup: want the gate halted")
+	}
+
+	d.send(keyEnter())
+	if got := d.view(); got != "chat" {
+		t.Fatalf("enter on the holding gate = %q, want chat", got)
+	}
+	if d.m.Halted() {
+		t.Error("Halted() stayed true after the screen proceeded")
+	}
+
+	d.send(chat.ReturnToHubMsg{AgentID: "email"})
+	d.launchEmail()
+
+	// The screen itself still pauses every launch on the same row —
+	// unrelated to suppression, and not something this issue changes.
+	if got := d.view(); got != "preflight" {
+		t.Fatalf("relaunch view = %q, want preflight — the screen still pauses on the same row", got)
+	}
+	// But the flag does not fire again for a row already accepted this
+	// session.
+	if d.m.Halted() {
+		t.Error("the same row set Halted() again after the user already proceeded past it this session")
+	}
+}
+
+// A resize (or any non-key message) must still reach the gate while
+// Halted() — RootModel never gates message routing on the flag, only
+// ControlSnapshot reads it. Proven by the rendered width actually
+// narrowing, which only happens if the message reached the preflight
+// model's own Update.
 func TestNonKeyMessagesPassThroughWhileHalted(t *testing.T) {
 	d := newRootDriver(t, readyGateTransport().ctxShortfall(), 100, 30)
 	d.launchEmail()
@@ -1029,7 +1064,7 @@ func TestNonKeyMessagesPassThroughWhileHalted(t *testing.T) {
 	for i, line := range strings.Split(d.screen(), "\n") {
 		if w := ansi.StringWidth(line); w > 40 {
 			t.Fatalf("line %d is %d columns wide after a 40-column resize while halted — "+
-				"the resize did not reach the screen behind the notice:\n%s", i, w, d.screen())
+				"the resize did not reach the screen:\n%s", i, w, d.screen())
 		}
 	}
 }
@@ -1063,38 +1098,8 @@ func TestASpinnerTickReachesABusyGateWhileHalted(t *testing.T) {
 	}
 }
 
-// Two rows can be halting at once (an unadvertised Lemonade version does not
-// halt, but a future Halt row alongside the ctx shortfall could), and one
-// dismiss must clear both. Ordered so a known failure is listed before an
-// unproven row — the same precedence unverifiedSummary already uses.
-func TestTwoSimultaneousHaltingRowsProduceOneNoticeAndOneDismissClearsBoth(t *testing.T) {
-	d := newRootDriver(t, readyGateTransport(), 100, 30)
-	d.send(status.Outcome{StepID: "a", Label: "Row A", Level: status.LevelUnknown,
-		Disposition: status.DispositionHalt, Summary: "row a is unproven"})
-	d.send(status.Outcome{StepID: "b", Label: "Row B", Level: status.LevelFailed,
-		Disposition: status.DispositionHalt, Summary: "row b is broken"})
-
-	if !d.m.Halted() {
-		t.Fatal("test setup: want halted")
-	}
-	flat := d.flat()
-	for _, want := range []string{"Row A", "Row B"} {
-		if !strings.Contains(flat, want) {
-			t.Errorf("the notice does not list %q:\n%s", want, d.screen())
-		}
-	}
-	if strings.Index(flat, "Row B") > strings.Index(flat, "Row A") {
-		t.Errorf("a known failure must be listed before an unproven row:\n%s", d.screen())
-	}
-
-	d.send(keyEnter())
-	if d.m.Halted() {
-		t.Error("one dismiss did not clear both rows")
-	}
-}
-
-// A halt reaches the app the same way from either screen it can be raised
-// from — the notice is not wired to one view.
+// The flag sets the same way from either screen it can be raised from — it
+// is not wired to one view.
 func TestCrossScreenHaltingWorksFromHubAndFromPreflight(t *testing.T) {
 	t.Run("hub", func(t *testing.T) {
 		d := newRootDriver(t, readyGateTransport(), 100, 30)


### PR DESCRIPTION
Closes #2715

The readiness screen used to print "Starting anyway", wait 2.5 seconds, and launch on its own
whenever a check came back unverifiable. So a model loaded at half the context window this machine
is configured for — the case where a long document comes back `context_length_exceeded` instead of
an answer — scrolled past before you could finish reading it. The footer offered `enter start
anyway · esc back`, but a timer was already running underneath it, which made the choice a race
rather than a choice. Now a check whose failure will actually affect you holds the screen until you
decide, and checks that cannot be verified but do not matter — an unadvertised Lemonade version, or
two mailboxes linked so neither can be probed — behave exactly as before. An ordinary launch gains
no keypress.

Each check declares what should happen when it is not OK: hold, or name it and move on. The rule
lives on the row that knows the answer.

## Evidence

Captured on macOS against a real Lemonade with the model deliberately loaded at 32768 while this
machine's profile pins 65536.

**Before** — the screen announced its own departure and left after 2.5s:

```
> [?]  AI model         Gemma-4-E4B-it-GGUF · 32K of 64K context
       The model is loaded with room for about 32768 tokens, but this machine's profile pins
       65536. Ordinary turns are unaffected; a long document or a large paste comes back as a
       context-length error rather than an answer.

Starting anyway — AI model could not be verified (Gemma-4-E4B-it-GGUF · 32K of 64K context).

r re-check · d details · enter start anyway · esc back
```

**After** — same condition, screen holds indefinitely:

```
> [?]  AI model         Gemma-4-E4B-it-GGUF · 32K of 64K context
       The model is loaded with room for about 32768 tokens, but this machine's profile pins
       65536. Ordinary turns are unaffected; a long document or a large paste comes back as a
       context-length error rather than an answer.

Waiting — AI model could not be verified (Gemma-4-E4B-it-GGUF · 32K of 64K context).

r re-check · d details · enter continue · esc back
```

**Healthy launch, unchanged** — with the model restored to 65536 every row is `[ok]` and the agent
starts on its own with no keypress.

## Test plan

- [ ] `cd tui && go test ./...` — green from a clean cache (`go clean -testcache` first)
- [ ] `cd tui && go vet ./...` — silent
- [ ] Load the model below the profile target, launch an agent, and confirm the readiness screen
      holds past 3 seconds instead of starting:
      `curl -s -X POST http://localhost:13305/api/v1/load -H 'Content-Type: application/json' -d '{"model_name":"Gemma-4-E4B-it-GGUF","ctx_size":32768}'`
- [ ] Restore to 65536 and confirm a fully green launch still proceeds with no keypress
- [ ] Confirm a report with two mailboxes linked, or an unadvertised Lemonade version, still
      proceeds — these must not gain a prompt
- [ ] `ctrl+c` quits on the first press while the screen is holding

<details>
<summary>Design notes and what was deliberately not built</summary>

**Bubble Tea is already the event system.** It is the Elm Architecture — every event is a `tea.Msg`
flowing into one `Update`, which is already the Redux shape. No second bus, no observables, no
channels between screens. What was missing was a typed outcome, somewhere to subscribe, and a rule.

**The halt renders nothing.** An earlier revision put a notice modal in front of the readiness
screen. In use that meant answering the same question twice — dismiss the modal, then decide again
on the screen behind it. The readiness screen already names the row, explains the consequence, and
prints the remedy, so the halt is now a state signal only: it publishes `Overlay: "halt"` so the
control API can see the TUI is waiting, and it does not draw or consume keys.

**Forgetting is fail-safe.** A row that is not OK and declares no disposition **halts**. Written the
other way round, a check added later without a disposition would silently proceed — the exact defect
this PR removes, relocated into a new field. `Notify` is the value you opt into.

**Not built:** a `GAIA_TUI_NO_GATE` escape hatch (the lockout scenario it insured against does not
exist — the worst case is one keypress per session, and a documented switch that disables a safety
gate outlives the reason for it); and a reusable checklist component (`preflight.Config` /
`ConfigFor` / `ExtraCheck` already parameterise this screen across agents — email is just one
configuration of it).

**Deliberate reversal, not an oversight.** `report.go` argued against exactly this change: a prompt
that always fires is dismissed reflexively and devalues every other prompt. That reasoning holds for
*cosmetic* unknowns and is why they still proceed. It does not hold for a halved context window,
which is measurably consequential. Two tests that locked the old behaviour were rewritten rather
than deleted, and the package docs that stated the old rule were corrected in the same change.

**Heads-up for whoever merges second:** #2707 independently adds `HasOneKeyFix()`, a hold condition
on the same `if` in `preflight/model.go`. The two are compatible in spirit — a row with a one-key
fix is arguably just a row whose disposition is Halt — and are better unified than stacked. No
dependency in either direction; whichever lands second resolves it.

</details>
