### PR TITLE
fix(connectors,email): a bare reconnect no longer guts a mailbox

### DIFF
--- a/.github/workflows/build_tui.yml
+++ b/.github/workflows/build_tui.yml
@@ -12,12 +12,26 @@ on:
     branches: [ main ]
     paths:
       - 'tui/**'
+      # The Python side of the email-scope drift guard (#2730 D2a) — a
+      # one-sided edit to the source-of-truth scope constants (or the shared
+      # fixture both sides diff against) must still run the Go test that
+      # checks connectScopes against them, or drift ships silently.
+      - 'hub/agents/email/python/gaia_agent_email/scopes.py'
+      - 'hub/agents/email/python/gaia_agent_email/outlook_scopes.py'
+      - 'tests/fixtures/connectors/email_scopes.json'
       - '.github/workflows/build_tui.yml'
   pull_request:
     branches: [ main ]
     types: [opened, synchronize, reopened, ready_for_review]
     paths:
       - 'tui/**'
+      # The Python side of the email-scope drift guard (#2730 D2a) — a
+      # one-sided edit to the source-of-truth scope constants (or the shared
+      # fixture both sides diff against) must still run the Go test that
+      # checks connectScopes against them, or drift ships silently.
+      - 'hub/agents/email/python/gaia_agent_email/scopes.py'
+      - 'hub/agents/email/python/gaia_agent_email/outlook_scopes.py'
+      - 'tests/fixtures/connectors/email_scopes.json'
       - '.github/workflows/build_tui.yml'
   merge_group:
   workflow_dispatch:

--- a/.github/workflows/test_email_agent_unit.yml
+++ b/.github/workflows/test_email_agent_unit.yml
@@ -33,6 +33,17 @@ on:
       - 'tests/test_email_openapi_conformance.py'
       - 'tests/unit/test_email_sidecar_devmode_app.py'
       - 'tests/unit/test_email_sidecar_server_wiring.py'
+      # The Go side of the email-scope drift guard (#2730 D2a) — a one-sided
+      # TUI edit must still run the Python guard that diffs it against the
+      # shared fixture, or drift ships silently.
+      - 'tui/internal/ui/preflight/**'
+      - 'tests/fixtures/connectors/email_scopes.json'
+      # forward.py mints/forwards the email sidecar's OAuth credential;
+      # connectors.py's authorize route resolves the same scopes (#2730).
+      - 'src/gaia/daemon/**'
+      - 'src/gaia/ui/routers/connectors.py'
+      - 'tests/unit/test_daemon_forward.py'
+      - 'tests/unit/test_daemon_remedy_commands.py'
       - 'setup.py'
       - 'pyproject.toml'
       - '.github/workflows/test_email_agent_unit.yml'
@@ -57,6 +68,17 @@ on:
       - 'tests/test_email_openapi_conformance.py'
       - 'tests/unit/test_email_sidecar_devmode_app.py'
       - 'tests/unit/test_email_sidecar_server_wiring.py'
+      # The Go side of the email-scope drift guard (#2730 D2a) — a one-sided
+      # TUI edit must still run the Python guard that diffs it against the
+      # shared fixture, or drift ships silently.
+      - 'tui/internal/ui/preflight/**'
+      - 'tests/fixtures/connectors/email_scopes.json'
+      # forward.py mints/forwards the email sidecar's OAuth credential;
+      # connectors.py's authorize route resolves the same scopes (#2730).
+      - 'src/gaia/daemon/**'
+      - 'src/gaia/ui/routers/connectors.py'
+      - 'tests/unit/test_daemon_forward.py'
+      - 'tests/unit/test_daemon_remedy_commands.py'
       - 'setup.py'
       - 'pyproject.toml'
       - '.github/workflows/test_email_agent_unit.yml'
@@ -133,6 +155,8 @@ jobs:
           echo "  - tests/test_email_openapi_conformance.py  OpenAPI spec conformance"
           echo "  - tests/unit/test_email_sidecar_devmode_app.py + _server_wiring.py"
           echo "      Agent UI dev-mode contract (packaging/server.py shim + build_app)"
+          echo "  - tests/unit/test_daemon_forward.py + test_daemon_remedy_commands.py"
+          echo "      OAuth forward-out to the email sidecar + its remedy strings (#2730)"
           echo ""
           python -m pytest \
             tests/unit/agents/email/ \
@@ -143,6 +167,8 @@ jobs:
             tests/test_email_openapi_conformance.py \
             tests/unit/test_email_sidecar_devmode_app.py \
             tests/unit/test_email_sidecar_server_wiring.py \
+            tests/unit/test_daemon_forward.py \
+            tests/unit/test_daemon_remedy_commands.py \
             -v --tb=short
 
       - name: Test summary

--- a/hub/agents/email/npm/CHANGELOG.md
+++ b/hub/agents/email/npm/CHANGELOG.md
@@ -6,6 +6,20 @@ behind any entry — API shapes, endpoints, and version semantics — see
 
 ## Unreleased
 
+- **Reconnecting your mailbox with no flags — the exact command GAIA's own
+  error message told you to run — could silently wipe your permissions
+  instead of fixing them.** A bare `gaia connectors connect google` (or the
+  same reconnect from a first-time self-repair conversation) used to fall
+  back to identity-only sign-in scopes whenever it wasn't told exactly what
+  to ask for, overwriting a working mail-plus-calendar connection with
+  nothing usable. That path now fails with a clear, copy-pasteable command
+  instead of guessing, and every surface — the CLI, the Agent UI, this
+  package's own connector setup, and the in-chat self-repair flow — now asks
+  for the same scopes so none of them can quietly narrow what another one
+  granted. Separately, calendar access is now clearly **optional**: a mailbox
+  missing only calendar permission still triages, drafts, and sends normally,
+  and calendar tools name the exact scope to add instead of taking the whole
+  mailbox down with them (#2730).
 - **The agent can now tell you which inbound mail is waiting on your reply —
   not just which of your own messages went unanswered.** Previously the agent
   could only flag sent mail nobody replied to; a colleague's "did you get a

--- a/hub/agents/email/npm/README.md
+++ b/hub/agents/email/npm/README.md
@@ -124,6 +124,12 @@ is forwarded to the agent by the daemon — sidecar contract 2.5, #2154; a stand
 integrator using this package is unaffected and resolves the mailbox from the local
 GAIA connector store.)
 
+Mail is **required**; calendar is **requested but optional** — consent asks for
+both up front so you're never prompted twice, but declining calendar (or
+connecting with an older, mail-only grant) still leaves you with a fully
+working triage/reply/send mailbox. Calendar tools fail loudly, naming the
+exact scope to add, only when you actually try to use one.
+
 Want to try it without writing code? Run `npx @amd-gaia/agent-email playground`
 for a local page to test triage, drafting, and a live send.
 

--- a/hub/agents/email/npm/SKILL.md
+++ b/hub/agents/email/npm/SKILL.md
@@ -232,6 +232,15 @@ the connected-but-not-granted case needs no browser at all (a local permission w
 and connecting Google still requires the user to supply their own OAuth client ID and
 secret, so expect a `sensitive: true` question on that path.
 
+**Mail-required, calendar-optional (#2730).** Every setup/reconnect path — this
+self-repair flow included — requests the full mail + calendar scope union at
+consent time, but only the mail scopes gate whether the flow reports success. A
+user who declines calendar still ends up with a working mailbox; calendar
+tools raise their own actionable error, naming the exact scope, the first time
+one is actually called. Do not "fix" a self-repair flow that requests only
+mail scopes — that narrower request is the bug this issue removed, not a
+simplification to reintroduce.
+
 ## Stateful agent surface (`/v1/email/agent/*`, 0.4.0)
 
 Everything above is **stateless** — you send a payload, the sidecar analyzes it, no

--- a/hub/agents/email/npm/SPEC.md
+++ b/hub/agents/email/npm/SPEC.md
@@ -598,6 +598,20 @@ An endpoint that works on the **content you pass in the request** is **standalon
 on the live Gmail/Outlook mailbox or calendar** requires the **Google or Microsoft
 connector** (OAuth), configured in GAIA under *Settings → Connectors*.
 
+**Mail is required; calendar is requested but optional (#2730).** Every connect
+path (GAIA's Agent UI, the CLI, and this sidecar's own `/configure` route) asks
+for the full mail + calendar scope union up front, so accepting everything at
+once never means a second consent round-trip. But only the mail scopes
+(`gmail.modify`/`gmail.send` on Google, `Mail.ReadWrite`/`Mail.Send` on
+Outlook) gate whether the mailbox works at all — a connection that declined
+calendar, or was granted before calendar scopes existed, still triages, drafts,
+and sends. Calendar tools (`listCalendarEvents`, `createCalendarEvent`,
+`respondToCalendarEvent`) are the only ones that require the calendar scopes,
+and they fail loudly — naming the exact missing scope and the reconnect
+command — rather than silently no-opping. This is the request/enforce split:
+what's *asked for* at consent time is wider than what's *required* to mint a
+working token.
+
 `send` resolves its OAuth token from the **local GAIA connector store**
 (`gaia.connectors`) on the host — `EmailSendRequest` has **no `access_token`
 field** (`provider` is only a routing hint). There is **no way to pass or forward a

--- a/hub/agents/email/python/CHANGELOG.md
+++ b/hub/agents/email/python/CHANGELOG.md
@@ -7,8 +7,42 @@ contract version is tracked separately as
 
 ## [Unreleased]
 
+### Fixed
+
+- **A reconnect with no explicit `--scopes` could silently overwrite a working
+  mail+calendar connection with identity-only sign-in scopes (#2730).**
+  `list(scopes) or list(provider.default_scopes)` at four `gaia.connectors`
+  entry points meant an empty scope request against a provider that already
+  had a connection or an agent grant silently fell back to
+  `openid`/`email`/`profile` — including via the exact command GAIA's own
+  error text told a user to run. That fallback is now rejected with an
+  actionable error whenever prior state exists; a genuine first-time connect
+  is unaffected. `connect_scopes()`'s own silent `except Exception` (reading
+  the credentialed `OAuthProvider`'s `default_scopes`, unreachable before an
+  OAuth client is configured — exactly the state a first-time self-repair
+  runs in) now reads the catalog spec's `default_scopes` instead, which needs
+  no credentials and removes the failure case rather than papering over it.
+- **The daemon's forward-out mint was all-or-nothing: a connection missing
+  even one optional (calendar) scope lost mail too (#2730).**
+  `ConnectionForwarder.forward_provider` now mints against each agent's
+  declared REQUIRED subset only (`scopes.py::REQUIRED_SCOPES` — mail only;
+  calendar is requested at consent but never gates the mint), and reports the
+  sidecar the intersection of the connection's real stored scopes with the
+  ledger grant, never the ledger's raw claim (a shared connection widened by
+  a different agent can no longer over-grant this one).
+
 ### Added
 
+- **`scopes.py`/`outlook_scopes.py` gained `REQUIRED_SCOPES` (mail only) —
+  the request/enforce split (#2730).** `ALL_SCOPES` (mail + calendar) is what
+  every connect path requests at consent; `REQUIRED_SCOPES` is the narrower
+  subset the daemon's forward-out mint enforces. `mailbox_state.py` gained
+  `requested_scopes()` alongside the existing `required_scopes()` gate, so
+  the in-chat self-repair flow requests the same full union every other
+  surface does instead of narrowing an existing connection on autonomous
+  repair. A checked-in fixture
+  (`tests/fixtures/connectors/email_scopes.json`) now guards both the Python
+  and the TUI's Go scope lists against drifting apart.
 - **Inbox scans go metadata-first, cutting per-message cost so the default scan size can
   rise from 25 to 50 (#2643).** Every scanned message used to cost one full-body fetch
   regardless of whether the heuristic ever read the body — `pre_scan_inbox` and the

--- a/hub/agents/email/python/gaia_agent_email/connector_routes.py
+++ b/hub/agents/email/python/gaia_agent_email/connector_routes.py
@@ -118,29 +118,32 @@ async def list_email_connectors() -> Dict[str, Any]:
     return {"agent_id": EMAIL_AGENT_ID, "providers": providers}
 
 
-def _mail_scopes_for_provider(provider: str) -> tuple:
-    """Return the mail-send scopes for ``provider`` (no calendar scopes)."""
+def _all_scopes_for_provider(provider: str) -> tuple:
+    """Return the FULL requested scope set for ``provider`` — mail + calendar
+    (#2730 D3). Every connect path requests this same union so none of them
+    can silently narrow a connection that already has calendar; only the
+    daemon's forward-out mint narrows to what it actually enforces."""
     if provider == "google":
-        from gaia_agent_email.scopes import GMAIL_SCOPES
+        from gaia_agent_email.scopes import ALL_SCOPES
 
-        return GMAIL_SCOPES
+        return ALL_SCOPES
     # microsoft
-    from gaia_agent_email.outlook_scopes import OUTLOOK_MAIL_SCOPES
+    from gaia_agent_email.outlook_scopes import OUTLOOK_ALL_SCOPES
 
-    return OUTLOOK_MAIL_SCOPES
+    return OUTLOOK_ALL_SCOPES
 
 
 def _build_scope_union(provider: str) -> List[str]:
-    """Return default_scopes ∪ mail_scopes for ``provider``, order-preserving, no dups."""
+    """Return default_scopes ∪ ALL_SCOPES for ``provider``, order-preserving, no dups."""
     import gaia.connectors.catalog  # noqa: F401 — populates registry
     from gaia.connectors.registry import REGISTRY
 
     # _require_supported already validated provider, so REGISTRY.get won't KeyError.
     spec = REGISTRY.get(provider)
     base = list(spec.default_scopes)
-    mail = list(_mail_scopes_for_provider(provider))
+    agent_scopes = list(_all_scopes_for_provider(provider))
     seen: set = set(base)
-    for s in mail:
+    for s in agent_scopes:
         if s not in seen:
             base.append(s)
             seen.add(s)
@@ -157,8 +160,9 @@ async def configure_email_connector(
     browser and stands up its own loopback callback; call ``/complete`` next.
 
     When the caller omits ``scopes``, the framework receives
-    ``default_scopes ∪ mail_scopes`` so the resulting grant includes send
-    permission — not just identity scopes. Explicit scopes are honored unchanged.
+    ``default_scopes ∪ ALL_SCOPES`` (mail + calendar) so the resulting
+    connection is never narrower than what the Agent UI would have granted
+    for the same account (#2730 D3). Explicit scopes are honored unchanged.
     """
     _require_supported(provider)
     from gaia.connectors.handler import configure

--- a/hub/agents/email/python/gaia_agent_email/connector_routes.py
+++ b/hub/agents/email/python/gaia_agent_email/connector_routes.py
@@ -167,7 +167,10 @@ async def configure_email_connector(
         "client_id": body.client_id,
         "client_secret": body.client_secret,
     }
-    if body.scopes is not None:
+    # ``not body.scopes`` (not ``is not None``) so an explicit empty list
+    # takes the union path too, instead of slipping through to configure()'s
+    # own empty-scopes handling as a bare "[]" (#2730 site 13).
+    if body.scopes:
         config["scopes"] = body.scopes
     else:
         config["scopes"] = _build_scope_union(provider)

--- a/hub/agents/email/python/gaia_agent_email/forwarded_credentials.py
+++ b/hub/agents/email/python/gaia_agent_email/forwarded_credentials.py
@@ -49,6 +49,24 @@ FORWARDED_MODE_ENV_VAR = "GAIA_EMAIL_FORWARDED_CREDENTIALS"
 _EXPIRY_BUFFER_SECONDS = 30.0
 
 
+def _all_scopes_for(provider: str) -> List[str]:
+    """The FULL requested scope set for *provider* (#2730 D3/AC-9a) — used
+    only to render a copy-pasteable remedy command. Deliberately ALL_SCOPES,
+    never REQUIRED_SCOPES: printing the narrower enforced-only set here
+    would reproduce the exact silent-narrowing defect this issue removes —
+    a user who follows the remedy would end up with LESS than what a
+    same-account connect from any other surface would have granted them."""
+    if provider == "google":
+        from gaia_agent_email.scopes import ALL_SCOPES
+
+        return list(ALL_SCOPES)
+    if provider == "microsoft":
+        from gaia_agent_email.outlook_scopes import OUTLOOK_ALL_SCOPES
+
+        return list(OUTLOOK_ALL_SCOPES)
+    return []
+
+
 @dataclass(frozen=True)
 class _ForwardedCredential:
     """One provider's forwarded access token + metadata. No refresh token."""
@@ -168,7 +186,8 @@ def get_forwarded_token(provider: str, scopes: List[str]) -> str:
             f"no forwarded '{provider}' credential is available to the email "
             "sidecar. The connection may not be granted to this agent, or it was "
             "revoked/withdrawn. Connect and grant it in one command — no Agent UI "
-            f"required: `gaia connectors connect {provider} --scopes <scopes> "
+            f"required: `gaia connectors connect {provider} --scopes "
+            f"{' '.join(_all_scopes_for(provider))} "
             "--grant-agent installed:email`, or use Settings -> Connections in "
             "the Agent UI. The daemon forwards a token on the next use."
         )
@@ -177,7 +196,8 @@ def get_forwarded_token(provider: str, scopes: List[str]) -> str:
             f"the forwarded '{provider}' access token has expired and the daemon "
             "has not re-forwarded a fresh one yet. Retry in a moment; if it "
             f"persists, reconnect with `gaia connectors connect {provider} "
-            "--scopes <scopes>` (or Settings -> Connections in the Agent UI)."
+            f"--scopes {' '.join(_all_scopes_for(provider))}` (or Settings -> "
+            "Connections in the Agent UI)."
         )
     missing = [s for s in scopes if s not in cred.scopes]
     if missing:

--- a/hub/agents/email/python/gaia_agent_email/mailbox_state.py
+++ b/hub/agents/email/python/gaia_agent_email/mailbox_state.py
@@ -108,10 +108,12 @@ def resolve_provider(value: str) -> Optional[str]:
 
 
 def required_scopes(provider: str) -> List[str]:
-    """The mail scopes this agent needs from *provider*.
+    """The mail scopes this agent needs from *provider* — the usability GATE.
 
     Calendar scopes are deliberately excluded: a user who only wants triage
-    should not be forced to hand over their calendar to get it.
+    should not be forced to hand over their calendar to get it. This stays
+    the narrow set self-repair CHECKS against; :func:`requested_scopes` is
+    the wider set it now ASKS for (#2730 D1/D3) — request vs. enforce.
     """
     if provider == "google":
         from gaia_agent_email.scopes import GMAIL_SCOPES
@@ -121,6 +123,30 @@ def required_scopes(provider: str) -> List[str]:
         from gaia_agent_email.outlook_scopes import OUTLOOK_MAIL_SCOPES
 
         return list(OUTLOOK_MAIL_SCOPES)
+    raise ValueError(
+        f"Unknown mailbox provider {provider!r}. Supported: {', '.join(PROVIDERS)}."
+    )
+
+
+def requested_scopes(provider: str) -> List[str]:
+    """The FULL scope set this agent requests from *provider* at consent time
+    — mail + calendar (#2730 D3).
+
+    Wider than :func:`required_scopes` on purpose: every connect path
+    (CLI, Agent UI, this agent's own self-repair) must request the same
+    union, or whichever one requests less silently narrows an existing
+    connection the moment it reconnects. Declining calendar at the consent
+    screen is still fine — :func:`required_scopes` is what self-repair
+    actually gates on.
+    """
+    if provider == "google":
+        from gaia_agent_email.scopes import ALL_SCOPES
+
+        return list(ALL_SCOPES)
+    if provider == "microsoft":
+        from gaia_agent_email.outlook_scopes import OUTLOOK_ALL_SCOPES
+
+        return list(OUTLOOK_ALL_SCOPES)
     raise ValueError(
         f"Unknown mailbox provider {provider!r}. Supported: {', '.join(PROVIDERS)}."
     )

--- a/hub/agents/email/python/gaia_agent_email/outlook_scopes.py
+++ b/hub/agents/email/python/gaia_agent_email/outlook_scopes.py
@@ -45,10 +45,19 @@ OUTLOOK_MAIL_SCOPES: tuple[str, ...] = (
 # Google side splits GMAIL_SCOPES from CALENDAR_SCOPES.
 OUTLOOK_CALENDAR_SCOPES: tuple[str, ...] = (SCOPE_CALENDARS_READWRITE,)
 
+# Request vs. enforce (#2730 D1), mirroring scopes.py's Google-side split.
+# OUTLOOK_ALL_SCOPES is what every connect path REQUESTS at consent;
+# OUTLOOK_REQUIRED_SCOPES (mail only) is what the daemon's forward-out mint
+# ENFORCES — a user who declines calendar still gets a working mailbox.
+OUTLOOK_ALL_SCOPES: tuple[str, ...] = OUTLOOK_MAIL_SCOPES + OUTLOOK_CALENDAR_SCOPES
+OUTLOOK_REQUIRED_SCOPES: tuple[str, ...] = OUTLOOK_MAIL_SCOPES
+
 
 __all__ = [
+    "OUTLOOK_ALL_SCOPES",
     "OUTLOOK_CALENDAR_SCOPES",
     "OUTLOOK_MAIL_SCOPES",
+    "OUTLOOK_REQUIRED_SCOPES",
     "SCOPE_CALENDARS_READWRITE",
     "SCOPE_MAIL_READWRITE",
     "SCOPE_MAIL_SEND",

--- a/hub/agents/email/python/gaia_agent_email/scopes.py
+++ b/hub/agents/email/python/gaia_agent_email/scopes.py
@@ -6,6 +6,14 @@ OAuth scope constants for the Email Triage Agent (#962).
 Single source of truth — REQUIRED_CONNECTORS, the per-tool credential calls,
 the test fixtures, and the catalog ``available_scopes`` declaration all read
 from these constants so they cannot drift.
+
+Request vs. enforce (#2730 D1): ``ALL_SCOPES`` (mail + calendar) is what
+every connect path REQUESTS at consent, so a user who says yes to everything
+is never asked twice. ``REQUIRED_SCOPES`` (mail only) is what the daemon's
+forward-out mint ENFORCES — calendar is optional, not required, so a user who
+declines it (or connects with an older, mail-only grant) still gets a working
+mailbox instead of losing mail too. Calendar tools fail loudly, naming the
+exact missing scope, when the enforcement gap bites at use time.
 """
 
 from __future__ import annotations
@@ -65,3 +73,8 @@ CALENDAR_SCOPES: tuple[str, ...] = (
 # to grant ALL of these on first connect, so the agent can then request
 # narrower per-call subsets without re-prompting.
 ALL_SCOPES: tuple[str, ...] = GMAIL_SCOPES + CALENDAR_SCOPES
+
+# What the daemon's forward-out mint enforces (#2730 D1) — mail only. Calendar
+# is requested (ALL_SCOPES) but never gates the mint, so a calendar-less
+# connection still forwards a working mailbox instead of losing mail too.
+REQUIRED_SCOPES: tuple[str, ...] = GMAIL_SCOPES

--- a/hub/agents/email/python/gaia_agent_email/tools/onboarding_tools.py
+++ b/hub/agents/email/python/gaia_agent_email/tools/onboarding_tools.py
@@ -224,22 +224,26 @@ def _walkthrough_stuck_exc() -> type:
 def connect_scopes(provider: str, agent_scopes: List[str]) -> List[str]:
     """The provider's catalog scopes plus the ones this agent needs, deduped.
 
-    Mirrors what ``gaia connectors connect`` requests, so a mailbox connected
-    through the agent is not weaker than the same mailbox connected from a
-    shell — the divergence that left accounts showing as "default".
-    """
-    defaults: List[str] = []
-    try:
-        from gaia.connectors.providers import get as get_provider
+    Mirrors what ``connector_routes._build_scope_union`` (the sidecar's own
+    connect route) and the TUI's ``connectScopes`` request, so a mailbox
+    connected through the agent is not weaker than the same mailbox
+    connected from any other surface — the divergence that left accounts
+    showing as "default".
 
-        defaults = list(getattr(get_provider(provider), "default_scopes", ()) or ())
-    except Exception as exc:  # noqa: BLE001 — mail scopes alone still connect
-        log.warning(
-            "onboarding: no catalog default_scopes for %s (%s); connecting with "
-            "the agent's scopes only — the account email may be unavailable",
-            provider,
-            exc,
-        )
+    Reads the CATALOG spec's ``default_scopes`` (``gaia.connectors.registry
+    .REGISTRY``), not the credentialed ``OAuthProvider`` instance
+    (``gaia.connectors.providers.get``): the catalog entry is static and
+    resolvable before any OAuth client is configured, which is exactly the
+    state self-repair runs in on a first-time connect — this call and the
+    one that collects+saves the client credentials happen in the same
+    ``configure()`` round-trip (#2730). Using the credentialed provider here
+    was the actual bug the previous ``except Exception`` was silently
+    papering over on every first connect.
+    """
+    import gaia.connectors.catalog  # noqa: F401 — populates the registry
+    from gaia.connectors.registry import REGISTRY
+
+    defaults = list(REGISTRY.get(provider).default_scopes or ())
     merged = list(defaults)
     for scope in agent_scopes:
         if scope not in merged:
@@ -256,18 +260,16 @@ def _run_oauth(agent: Any, provider: str) -> Dict[str, Any]:
     label = ms.provider_label(provider)
     scopes = ms.required_scopes(provider)
 
-    config: Dict[str, Any] = {
-        # Authorize the provider's own identity scopes alongside the mail ones.
-        # Without them the token cannot name the account, so every surface shows
-        # the mailbox as "default" instead of the address the user just signed
-        # in with. The grant below stays narrow — identity is for the
-        # connection, not for the agent.
-        "scopes": connect_scopes(provider, scopes),
-        # Committing the grant inside the same flow is what stops the
-        # connected-but-unusable dead end this whole feature exists to remove.
-        "grant_agents": {ms.AGENT_ID: scopes},
-    }
-    config.update(_collect_oauth_client(agent, provider))
+    # Collect the OAuth client FIRST (#2730): connect_scopes() now fails
+    # loudly when the provider isn't configured yet (no more silent
+    # "connect with mail scopes only" degrade), so it must not run before
+    # the client-collection step that makes the provider resolvable.
+    config: Dict[str, Any] = dict(_collect_oauth_client(agent, provider))
+    config["scopes"] = connect_scopes(provider, ms.requested_scopes(provider))
+    # Committing the grant inside the same flow is what stops the
+    # connected-but-unusable dead end this whole feature exists to remove.
+    # required_scopes() stays the usability gate, not the request above.
+    config["grant_agents"] = {ms.AGENT_ID: scopes}
 
     started = run_sync(configure(provider, config))
     auth_url = started.get("authorization_url") or ""

--- a/hub/agents/email/python/gaia_agent_email/tools/setup_walkthrough.py
+++ b/hub/agents/email/python/gaia_agent_email/tools/setup_walkthrough.py
@@ -71,7 +71,9 @@ def run_device_oauth(agent: Any, provider: str) -> Dict[str, Any]:
 
     label = ms.provider_label(provider)
     scopes = ms.required_scopes(provider)
-    scopes_to_request = connect_scopes(provider, scopes)
+    # Request the FULL union (#2730 D3) — see onboarding_tools._run_oauth for
+    # why this must not narrow to required_scopes() alone.
+    scopes_to_request = connect_scopes(provider, ms.requested_scopes(provider))
 
     started = run_sync(start_device_flow(provider, scopes_to_request))
     user_code = started.get("user_code", "")

--- a/hub/agents/email/python/tests/test_connector_routes.py
+++ b/hub/agents/email/python/tests/test_connector_routes.py
@@ -1,0 +1,94 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""
+``POST /v1/email/connectors/{provider}/configure`` scope resolution (#2730
+site 13).
+
+An explicit empty ``scopes: []`` in the request body must take the same
+``default_scopes ∪ ALL_SCOPES`` union path an omitted ``scopes`` field does —
+not slip through as a literal ``[]`` that would then hit
+``oauth_pkce.configure``'s own D0 empty-scopes guard (or, pre-#2730, silently
+narrow the connection to the provider's identity-only defaults).
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+# parents[0] = tests/, [5] = repo-root
+_REPO_ROOT = Path(__file__).resolve().parents[5]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+pytest.importorskip("gaia_agent_email")
+pytest.importorskip("fastapi")
+
+from fastapi import FastAPI  # noqa: E402
+from fastapi.testclient import TestClient  # noqa: E402
+from gaia_agent_email import connector_routes  # noqa: E402
+
+
+@pytest.fixture
+def client():
+    app = FastAPI()
+    app.include_router(connector_routes.router)
+    return TestClient(app)
+
+
+def test_explicit_empty_scopes_takes_the_union_path(client, monkeypatch):
+    captured = {}
+
+    async def _fake_configure(provider, config):
+        captured["config"] = config
+        return {"flow_id": "f1", "authorization_url": "https://auth.example"}
+
+    monkeypatch.setattr("gaia.connectors.handler.configure", _fake_configure)
+
+    resp = client.post(
+        "/v1/email/connectors/google/configure",
+        json={"client_id": "id", "client_secret": "secret", "scopes": []},
+    )
+    assert resp.status_code == 200, resp.text
+    assert captured["config"]["scopes"] == connector_routes._build_scope_union(
+        "google"
+    )
+    assert captured["config"]["scopes"] != []
+
+
+def test_omitted_scopes_takes_the_same_union_path(client, monkeypatch):
+    captured = {}
+
+    async def _fake_configure(provider, config):
+        captured["config"] = config
+        return {"flow_id": "f1", "authorization_url": "https://auth.example"}
+
+    monkeypatch.setattr("gaia.connectors.handler.configure", _fake_configure)
+
+    resp = client.post(
+        "/v1/email/connectors/google/configure",
+        json={"client_id": "id", "client_secret": "secret"},
+    )
+    assert resp.status_code == 200, resp.text
+    assert captured["config"]["scopes"] == connector_routes._build_scope_union(
+        "google"
+    )
+
+
+def test_explicit_nonempty_scopes_is_honored_unchanged(client, monkeypatch):
+    captured = {}
+
+    async def _fake_configure(provider, config):
+        captured["config"] = config
+        return {"flow_id": "f1", "authorization_url": "https://auth.example"}
+
+    monkeypatch.setattr("gaia.connectors.handler.configure", _fake_configure)
+
+    resp = client.post(
+        "/v1/email/connectors/google/configure",
+        json={"client_id": "id", "client_secret": "secret", "scopes": ["openid"]},
+    )
+    assert resp.status_code == 200, resp.text
+    assert captured["config"]["scopes"] == ["openid"]

--- a/hub/agents/email/python/tests/test_forwarded_credentials.py
+++ b/hub/agents/email/python/tests/test_forwarded_credentials.py
@@ -91,6 +91,34 @@ def test_scope_short_error_names_the_missing_scopes_in_the_cli_command():
     assert "{provider}" not in msg  # f-string bug regression guard
 
 
+def test_missing_credential_error_interpolates_real_all_scopes_not_a_placeholder():
+    """#2730 D3/AC-9a: sites 16-17's `--scopes <scopes>` placeholder becomes
+    the real ALL_SCOPES (mail + calendar) union — never REQUIRED_SCOPES,
+    which would reproduce the exact silent-narrowing bug this issue removes."""
+    from gaia_agent_email.scopes import ALL_SCOPES
+
+    with pytest.raises(ConnectorsError) as exc:
+        forwarded_credentials.get_forwarded_token("google", ["s1"])
+    msg = str(exc.value)
+    assert "<scope" not in msg
+    for scope in ALL_SCOPES:
+        assert scope in msg
+
+
+def test_expired_token_error_interpolates_real_all_scopes_not_a_placeholder():
+    from gaia_agent_email.scopes import ALL_SCOPES
+
+    forwarded_credentials.set_forwarded(
+        "google", access_token="tok", scopes=["s1"], expires_at=_PAST
+    )
+    with pytest.raises(ConnectorsError) as exc:
+        forwarded_credentials.get_forwarded_token("google", ["s1"])
+    msg = str(exc.value)
+    assert "<scope" not in msg
+    for scope in ALL_SCOPES:
+        assert scope in msg
+
+
 def test_get_expired_token_raises_loudly():
     forwarded_credentials.set_forwarded(
         "google", access_token="tok", scopes=["s1"], expires_at=_PAST

--- a/hub/agents/email/python/tests/test_forwarded_credentials.py
+++ b/hub/agents/email/python/tests/test_forwarded_credentials.py
@@ -145,6 +145,36 @@ def test_reforward_overwrites_expired_and_recovers(monkeypatch):
     assert forwarded_credentials.get_forwarded_token("google", ["s1"]) == "fresh"
 
 
+def test_calendar_only_gap_names_the_missing_calendar_scope_with_a_real_command():
+    """AC-13 unit half (#2730). D5 makes this path newly reachable in normal
+    operation: before this PR a calendar-less connection failed the mint
+    outright (total outage, mail included) — a calendar tool's own error
+    never had a chance to fire. After D5, mail keeps working and calendar
+    tools fail individually, so the quality of THIS error is now
+    load-bearing where it used to be unreachable. A forwarded credential
+    carrying only mail scopes, asked for calendar scopes, must raise loudly
+    naming the exact missing calendar scope(s) with a copy-pasteable
+    command — never a placeholder."""
+    from gaia_agent_email.scopes import CALENDAR_SCOPES, GMAIL_SCOPES
+
+    forwarded_credentials.set_forwarded(
+        "google", access_token="tok", scopes=list(GMAIL_SCOPES), expires_at=_FUTURE
+    )
+    with pytest.raises(ConnectorsError) as exc:
+        forwarded_credentials.get_forwarded_token("google", list(CALENDAR_SCOPES))
+    msg = str(exc.value)
+    for scope in CALENDAR_SCOPES:
+        assert scope in msg
+    assert "<scope" not in msg
+    assert "gaia connectors connect google --scopes" in msg
+    assert "--grant-agent installed:email" in msg
+    # The command must still cover the mail scopes already held — --scopes
+    # REPLACES rather than adds, so a calendar-only suggestion would drop
+    # working mail access on reconnect.
+    for scope in GMAIL_SCOPES:
+        assert scope in msg
+
+
 def test_get_scope_short_token_raises_and_names_missing():
     forwarded_credentials.set_forwarded(
         "google", access_token="tok", scopes=["s1"], expires_at=_FUTURE

--- a/hub/agents/email/python/tests/test_mailbox_onboarding_2469.py
+++ b/hub/agents/email/python/tests/test_mailbox_onboarding_2469.py
@@ -84,6 +84,7 @@ def connectors(monkeypatch):
 
     class _Provider:
         provider_id = "google"
+        default_scopes = ("openid", "https://www.googleapis.com/auth/userinfo.email")
 
         @property
         def client_id(self):
@@ -401,6 +402,30 @@ def test_oauth_flow_grants_the_agent_in_the_same_pass(connectors):
     assert max(connectors["timeouts"]) > 120
     # The copy-paste fallback is offered before the 2-minute wait, not after.
     assert any("https://accounts/auth" in m for m in agent.console.info)
+
+
+def test_walkthrough_reauth_requests_the_full_union_not_just_mail(connectors):
+    """AC-12 (#2730): given an existing google connection carrying ALL_SCOPES,
+    self-repair's OAuth request must be default ∪ ALL_SCOPES (mail +
+    calendar) — not the mail-only union it sent before. Sending mail-only
+    here is exactly what silently drops an existing calendar grant on
+    reconnect. ``required_scopes()`` (the GRANT) stays unchanged — it is the
+    usability gate, not the request."""
+    from gaia_agent_email.scopes import ALL_SCOPES
+
+    connectors["connection"] = _connection(scopes=ALL_SCOPES)
+    agent = _FakeAgent(answers=["yes"])
+
+    ob._run_oauth(agent, "google")
+
+    assert len(connectors["configured"]) == 1
+    _, config = connectors["configured"][0]
+    requested = set(config["scopes"])
+    for scope in ALL_SCOPES:
+        assert scope in requested, (scope, requested)
+    # required_scopes() is still the mail-only GATE — the grant, unchanged.
+    assert config["grant_agents"] == {ms.AGENT_ID: GMAIL_SCOPES}
+    assert ms.required_scopes("google") == GMAIL_SCOPES
 
 
 def test_missing_oauth_client_is_explained_before_it_is_asked_for(connectors):

--- a/src/gaia/connectors/api.py
+++ b/src/gaia/connectors/api.py
@@ -82,14 +82,16 @@ logger = logging.getLogger(__name__)
 # agent actually requests a token.
 _DEFAULT_REQUIRED_SCOPES_BY_PROVIDER: dict[str, tuple[str, ...]] = {
     # Built-in Email Triage Agent (#962) mailbox union — MUST equal
-    # gaia_agent_email/scopes.py's ALL_SCOPES (#2730 site 6: this used to
-    # omit calendar.readonly, silently accepting a forwarded connection that
-    # could not satisfy every calendar tool).
+    # gaia_agent_email/scopes.py's REQUIRED_SCOPES (mail only). Calendar is
+    # DELIBERATELY absent (#2730 D1): this gates whether a forwarded
+    # connection (Path A, #1292) is usable at import time, and calendar is
+    # requested but never required, mirroring the same enforcement the
+    # daemon's forward-out mint applies. Requiring it here would reject a
+    # mail-only forwarded connection outright — the exact all-or-nothing
+    # failure this issue removes, just relocated to the import boundary.
     "google": (
         "https://www.googleapis.com/auth/gmail.modify",  # from gaia_agent_email/scopes.py
         "https://www.googleapis.com/auth/gmail.send",  # from gaia_agent_email/scopes.py
-        "https://www.googleapis.com/auth/calendar.events",  # from gaia_agent_email/scopes.py
-        "https://www.googleapis.com/auth/calendar.readonly",  # from gaia_agent_email/scopes.py
     ),
 }
 

--- a/src/gaia/connectors/api.py
+++ b/src/gaia/connectors/api.py
@@ -216,10 +216,12 @@ def _authorize_access(
     if missing:
         raise AuthRequiredError(
             AuthRequiredError.Reason.CONNECTION_MISSING_SCOPES,
-            # The connection's current scopes ∪ what's now missing — never
-            # just the missing subset (#2730 D0): `--scopes` REPLACES rather
-            # than adds, so a remedy naming only the gap would drop whatever
-            # the connection legitimately already has.
+            # granted ∪ missing — NEVER just the missing subset. `--scopes`
+            # REPLACES the connection's scopes rather than adding to them
+            # (flow.py: `list(scopes) or list(provider.default_scopes)`),
+            # so a remedy naming only the gap would authorize an account
+            # that has lost everything it already had (#2730 D0). Do not
+            # "simplify" this to `missing` alone — that reintroduces the bug.
             full_scopes=sorted(granted_scopes | set(missing)),
             provider=provider,
             agent_id=resolved_agent,

--- a/src/gaia/connectors/api.py
+++ b/src/gaia/connectors/api.py
@@ -81,11 +81,15 @@ logger = logging.getLogger(__name__)
 # ``get_access_token`` still enforces per-agent scope coverage at the point an
 # agent actually requests a token.
 _DEFAULT_REQUIRED_SCOPES_BY_PROVIDER: dict[str, tuple[str, ...]] = {
-    # Built-in Email Triage Agent (#962) mailbox union.
+    # Built-in Email Triage Agent (#962) mailbox union — MUST equal
+    # gaia_agent_email/scopes.py's ALL_SCOPES (#2730 site 6: this used to
+    # omit calendar.readonly, silently accepting a forwarded connection that
+    # could not satisfy every calendar tool).
     "google": (
-        "https://www.googleapis.com/auth/gmail.modify",
-        "https://www.googleapis.com/auth/gmail.send",
-        "https://www.googleapis.com/auth/calendar.events",
+        "https://www.googleapis.com/auth/gmail.modify",  # from gaia_agent_email/scopes.py
+        "https://www.googleapis.com/auth/gmail.send",  # from gaia_agent_email/scopes.py
+        "https://www.googleapis.com/auth/calendar.events",  # from gaia_agent_email/scopes.py
+        "https://www.googleapis.com/auth/calendar.readonly",  # from gaia_agent_email/scopes.py
     ),
 }
 

--- a/src/gaia/connectors/api.py
+++ b/src/gaia/connectors/api.py
@@ -216,6 +216,11 @@ def _authorize_access(
     if missing:
         raise AuthRequiredError(
             AuthRequiredError.Reason.CONNECTION_MISSING_SCOPES,
+            # The connection's current scopes ∪ what's now missing — never
+            # just the missing subset (#2730 D0): `--scopes` REPLACES rather
+            # than adds, so a remedy naming only the gap would drop whatever
+            # the connection legitimately already has.
+            full_scopes=sorted(granted_scopes | set(missing)),
             provider=provider,
             agent_id=resolved_agent,
             missing_scopes=missing,

--- a/src/gaia/connectors/cli.py
+++ b/src/gaia/connectors/cli.py
@@ -370,6 +370,43 @@ def _handle_connect(args: argparse.Namespace) -> int:
         provider = get_provider(args.connector_id)
         scopes = sorted(set(declared_scopes) | set(provider.default_scopes))
         grant_agents = {grant_agent: declared_scopes}
+    elif not explicit_scopes:
+        # Bare `connect` — no --scopes, no --grant-agent (#2730 D0/AC-8). This
+        # is the exact command GAIA's own error text tells a user to run, so
+        # it must not silently narrow an existing connection. Derive the
+        # request from whatever agents already hold a grant for this
+        # connector, the same declared-scopes machinery --grant-agent uses,
+        # rather than requiring --grant-agent up front before it applies.
+        from gaia.connectors.grants import list_agent_grants
+
+        granted_agent_ids = sorted(list_agent_grants(args.connector_id).keys())
+        if granted_agent_ids:
+            from gaia.agents.registry import AgentRegistry
+            from gaia.connectors.registry import REGISTRY
+            from gaia.hub.installer import register_installed_sidecars
+
+            registry = AgentRegistry()
+            registry.discover()
+            register_installed_sidecars(registry)
+            resolved = resolve_declared_scopes(
+                registry, args.connector_id, granted_agent_ids
+            )
+            declared: set = set()
+            for agent_scopes in resolved.values():
+                declared.update(agent_scopes)
+            # The catalog spec's default_scopes (not the raw OAuthProvider's)
+            # — the same source connector_routes._build_scope_union and the
+            # TUI's connectScopes union against, so a bare connect matches
+            # what every other surface would request for the same account.
+            catalog_defaults = REGISTRY.get(args.connector_id).default_scopes
+            scopes = sorted(declared | set(catalog_defaults))
+        else:
+            # No granted agent to derive a union from. Send nothing and let
+            # start_authorization's own D0 guard decide: raise loudly if a
+            # connection already exists (never guess a narrower list), or
+            # fall back to default_scopes for a genuine first-time connect.
+            scopes = []
+        grant_agents = None
     else:
         scopes = explicit_scopes
         # One-flow connect + grant: authorize the scopes AND grant them to the

--- a/src/gaia/connectors/errors.py
+++ b/src/gaia/connectors/errors.py
@@ -250,8 +250,11 @@ class ScopeMismatchError(ConnectorsError):
         prov = self.provider or "connection"
         pid = self.provider or "<provider>"
         missing = ", ".join(self.missing_scopes) or "<none>"
-        # Currently-granted ∪ required — never just the missing subset
-        # (#2730 D0): `--scopes` REPLACES rather than adds.
+        # granted ∪ required — NEVER just the missing subset. `--scopes`
+        # REPLACES the connection's scopes rather than adding to them, so a
+        # remedy naming only the gap would authorize an account that has
+        # lost everything it already had (#2730 D0). Do not "simplify" this
+        # to `missing_scopes` alone — that reintroduces the bug.
         full_scopes = sorted(set(self.granted) | set(self.required))
         return (
             f"The {prov} stored connection is missing required scopes "

--- a/src/gaia/connectors/errors.py
+++ b/src/gaia/connectors/errors.py
@@ -32,10 +32,10 @@ class OAuthClientNotConfiguredError(ConfigurationError):
     GAIA ships no OAuth credentials — each user creates their own client once in
     the provider's cloud console, then registers it. The message is
     self-documenting for a headless CLI user (the console setup steps plus the
-    exact ``gaia connectors ...`` commands) and also names the Agent UI path, so
-    whoever hits it can unblock themselves without leaving the terminal. Inherits
-    :class:`ConfigurationError` so the CLI (exit 3) and the UI router (HTTP 503)
-    keep handling it unchanged.
+    exact ``gaia connectors`` commands to run) and also names the Agent UI
+    path, so whoever hits it can unblock themselves without leaving the
+    terminal. Inherits :class:`ConfigurationError` so the CLI (exit 3) and
+    the UI router (HTTP 503) keep handling it unchanged.
     """
 
     def __init__(
@@ -77,8 +77,9 @@ class OAuthClientNotConfiguredError(ConfigurationError):
             f"Then register the client and sign in — no Agent UI required:\n"
             f"  gaia connectors configure {pid} --client-id <ID> "
             f"--client-secret <SECRET>\n"
-            f"  gaia connectors connect {pid} --scopes <scope> ... "
-            f"--grant-agent <agent-id>\n"
+            f"  gaia connectors connect {pid} --grant-agent <agent-id>\n"
+            f"  (omitting --scopes derives them from the agent's own "
+            f"declaration; pass --scopes explicitly for a narrower set)\n"
             f"{example_block}"
             f"(Power users / CI can instead set {env_prefix}_CLIENT_ID and "
             f"{env_prefix}_CLIENT_SECRET in the environment before launching "
@@ -115,39 +116,78 @@ class AuthRequiredError(ConnectorsError):
         provider: str = "",
         agent_id: str | None = None,
         missing_scopes: Iterable[str] | None = None,
+        full_scopes: Iterable[str] | None = None,
         message: str | None = None,
     ):
         self.reason = reason
         self.provider = provider
         self.agent_id = agent_id
         self.missing_scopes = list(missing_scopes or [])
+        # The scope-complete list a printed remedy command should carry
+        # (#2730 D0) — never just the missing subset, since `--scopes`
+        # REPLACES the connection's scopes rather than adding to them.
+        # Falls back to missing_scopes for reasons where that already IS
+        # the full wanted set (e.g. AGENT_NOT_GRANTED, raised before any
+        # scope is known to be missing from the connection itself).
+        self.full_scopes = list(full_scopes or missing_scopes or [])
         super().__init__(message or self._default_message())
 
     def _default_message(self) -> str:
         prov = self.provider or "the connection"
+        # A single clean token for the connector-id position in printed
+        # commands (never a multi-word Python expression split across
+        # backticks — AC-9a's remedy scanner parses these as real argv).
+        pid = self.provider or "<provider>"
         if self.reason is AuthRequiredError.Reason.NOT_CONNECTED:
             return (
                 f"No {prov} connection. Connect via Settings → Connections in "
                 "AgentUI, or run `gaia connectors connect "
-                f"{self.provider or '<provider>'}`. "
+                f"{pid}`. "
                 "See docs/sdk/infrastructure/connections.mdx."
             )
         if self.reason is AuthRequiredError.Reason.AGENT_NOT_GRANTED:
             agent = self.agent_id or "this agent"
+            if self.full_scopes:
+                command = (
+                    f"`gaia connectors grants grant {pid} "
+                    f"{agent} --scopes {' '.join(self.full_scopes)}`"
+                )
+            else:
+                # No scope list was supplied at the raise site — name the
+                # gap rather than print an unfillable placeholder. Not
+                # backtick-wrapped: the bare "grants grant" subcommand alone
+                # has no positional args and is a command FAMILY, not a
+                # literal invocation, so it must not read as one.
+                command = (
+                    "the gaia connectors grants grant command with the scopes "
+                    "this call actually needs (none were supplied to this "
+                    "error — that is a caller bug, not something to guess a "
+                    "command for)"
+                )
             return (
                 f"Agent '{agent}' has no grant for {prov}. Grant the required "
-                "scopes in Settings → Connections, or run "
-                f"`gaia connectors grants grant {self.provider or '<provider>'} "
-                f"{agent} --scopes <scope> ...`. "
+                f"scopes in Settings → Connections, or run {command}. "
                 "See docs/sdk/infrastructure/connections.mdx."
             )
         if self.reason is AuthRequiredError.Reason.CONNECTION_MISSING_SCOPES:
             scopes = ", ".join(self.missing_scopes) or "<unknown>"
+            if self.full_scopes:
+                command = (
+                    f"`gaia connectors connect {pid} "
+                    f"--scopes {' '.join(self.full_scopes)}`"
+                )
+            else:
+                # Not backtick-wrapped, same reason as the AGENT_NOT_GRANTED
+                # branch above: no positional args, not a literal invocation.
+                command = (
+                    "the gaia connectors connect command with the full scope "
+                    "list this connection needs (none was supplied to this "
+                    "error)"
+                )
             return (
                 f"The {prov} connection lacks required scopes ({scopes}). "
                 "Reconnect with the missing scopes from Settings → Connections, "
-                f"or run `gaia connectors connect {self.provider or '<provider>'} "
-                "--scopes <scope> ...`. "
+                f"or run {command}. "
                 "See docs/sdk/infrastructure/connections.mdx."
             )
         if self.reason is AuthRequiredError.Reason.REAUTH_REQUIRED:
@@ -155,7 +195,7 @@ class AuthRequiredError(ConnectorsError):
                 f"The stored {prov} credentials are no longer valid (client "
                 "rotation or remote revocation). Reconnect from Settings → "
                 f"Connections, or run `gaia connectors connect "
-                f"{self.provider or '<provider>'}`. "
+                f"{pid}`. "
                 "See docs/runbooks/google-oauth-client.md."
             )
         if self.reason is AuthRequiredError.Reason.TENANT_MISMATCH:
@@ -163,7 +203,7 @@ class AuthRequiredError(ConnectorsError):
                 f"The stored {prov} connection was authenticated against a "
                 "different Microsoft tenant than the connector currently "
                 "resolves to. Reconnect from Settings → Connections, or run "
-                f"`gaia connectors connect {self.provider or '<provider>'}`. "
+                f"`gaia connectors connect {pid}`. "
                 "See docs/connectors/microsoft.mdx."
             )
         # Fallback — should be unreachable since Reason is a closed enum.
@@ -208,12 +248,17 @@ class ScopeMismatchError(ConnectorsError):
 
     def _default_message(self) -> str:
         prov = self.provider or "connection"
+        pid = self.provider or "<provider>"
         missing = ", ".join(self.missing_scopes) or "<none>"
+        # Currently-granted ∪ required — never just the missing subset
+        # (#2730 D0): `--scopes` REPLACES rather than adds.
+        full_scopes = sorted(set(self.granted) | set(self.required))
         return (
             f"The {prov} stored connection is missing required scopes "
             f"({missing}). Reconnect with the missing scopes via Settings → "
             f"Connections, or run `gaia connectors connect "
-            f"{self.provider or '<provider>'} --scopes <scope> ...`. "
+            f"{pid} --scopes "
+            f"{' '.join(full_scopes) or '<none>'}`. "
             "See docs/sdk/infrastructure/connections.mdx."
         )
 

--- a/src/gaia/connectors/flow.py
+++ b/src/gaia/connectors/flow.py
@@ -52,6 +52,7 @@ from gaia.connectors.errors import (
 )
 from gaia.connectors.events import emit
 from gaia.connectors.pkce import compute_code_challenge, generate_code_verifier
+from gaia.connectors.prior_state import resolve_or_reject_empty_scopes
 from gaia.connectors.providers import get as get_provider
 from gaia.connectors.store import save_connection
 
@@ -218,7 +219,9 @@ async def start_authorization(
             await _teardown_flow(stale_id)
 
     provider = get_provider(provider_id)
-    scopes_list = list(scopes) or list(provider.default_scopes)
+    scopes_list = resolve_or_reject_empty_scopes(
+        provider_id, scopes, provider.default_scopes
+    )
 
     code_verifier = generate_code_verifier()
     challenge = compute_code_challenge(code_verifier)
@@ -568,7 +571,9 @@ async def start_device_flow(provider_id: str, scopes: Iterable[str]) -> Dict[str
             "Use start_authorization (browser loopback) instead. See "
             "docs/security/connections.mdx."
         )
-    scopes_list = list(scopes) or list(provider.default_scopes)
+    scopes_list = resolve_or_reject_empty_scopes(
+        provider_id, scopes, provider.default_scopes
+    )
     body = provider.device_code_request_body(scopes_list)
 
     async with httpx.AsyncClient(timeout=15.0) as client:
@@ -643,7 +648,9 @@ async def poll_device_flow(
     import time as _time
 
     provider = get_provider(provider_id)
-    scopes_list = list(scopes) or list(provider.default_scopes)
+    scopes_list = resolve_or_reject_empty_scopes(
+        provider_id, scopes, provider.default_scopes
+    )
     body = provider.device_token_request_body(device_code)
     poll_interval = max(int(interval), 1)
     deadline = _time.monotonic() + max(int(expires_in), poll_interval)

--- a/src/gaia/connectors/flow.py
+++ b/src/gaia/connectors/flow.py
@@ -448,6 +448,28 @@ async def _commit_grants(flow: _PendingFlow) -> None:
         )
 
 
+def _resolve_granted_scopes(
+    payload: Dict[str, Any], requested: "list[str]"
+) -> "list[str]":
+    """The scopes a token-exchange response actually granted (#2730 D6).
+
+    Per RFC 6749 §5.1 the token endpoint returns ``scope`` only when the
+    granted set differs from what was requested; its absence means "as
+    requested." Google's granular-consent screen lets a user untick Calendar
+    while approving Gmail, so trusting the request unconditionally (what this
+    code did before) records a connection that lies about carrying scopes the
+    user declined — every downstream coverage check then passes against a
+    fabricated record instead of catching the shortfall here, loudly, with an
+    actionable message.
+    """
+    raw = payload.get("scope") or ""
+    returned = raw.split()
+    if not returned:
+        return list(requested)
+    requested_set = set(requested)
+    return [s for s in returned if s in requested_set]
+
+
 async def _exchange_code_for_tokens(flow: _PendingFlow, code: str) -> Dict[str, Any]:
     """Run the token-exchange step and persist the connection."""
     provider = get_provider(flow.provider_id)
@@ -488,12 +510,13 @@ async def _exchange_code_for_tokens(flow: _PendingFlow, code: str) -> Dict[str, 
     account_email = await _resolve_account_email(
         provider, payload.get("id_token", ""), payload.get("access_token", "")
     )
+    granted_scopes = _resolve_granted_scopes(payload, flow.scopes)
 
     save_connection(
         provider=flow.provider_id,
         account_email=account_email or "default",
         refresh_token=refresh_token,
-        scopes=flow.scopes,
+        scopes=granted_scopes,
         client_id_hash=provider.client_id_hash,
         # D8: record the minting authority — None for providers with no
         # concept of a tenant (e.g. Google), which save_connection omits
@@ -521,7 +544,7 @@ async def _exchange_code_for_tokens(flow: _PendingFlow, code: str) -> Dict[str, 
     state_dict = {
         "provider": flow.provider_id,
         "account_email": account_email or "default",
-        "scopes": flow.scopes,
+        "scopes": granted_scopes,
         "connected_at": _time.time(),
     }
     # Emit both the new framework event-name (matches the SSE router
@@ -710,12 +733,13 @@ async def poll_device_flow(
     account_email = await _resolve_account_email(
         provider, payload.get("id_token", ""), payload.get("access_token", "")
     )
+    granted_scopes = _resolve_granted_scopes(payload, scopes_list)
 
     save_connection(
         provider=provider_id,
         account_email=account_email,
         refresh_token=refresh_token,
-        scopes=scopes_list,
+        scopes=granted_scopes,
         client_id_hash=provider.client_id_hash,
         tenant=getattr(provider, "tenant", None),
     )
@@ -749,12 +773,12 @@ async def poll_device_flow(
         "device-flow: connected provider=%s account=%s scopes=%d",
         provider_id,
         account_email,
-        len(scopes_list),
+        len(granted_scopes),
     )
     return {
         "provider": provider_id,
         "account_email": account_email,
-        "scopes": scopes_list,
+        "scopes": granted_scopes,
         "connected_at": _time.time(),
     }
 

--- a/src/gaia/connectors/oauth_pkce.py
+++ b/src/gaia/connectors/oauth_pkce.py
@@ -200,11 +200,16 @@ class OAuthPkceHandler:
                 )
             return {"status": "saved", "connector_id": spec.id}
 
-        scopes = config.get("scopes") or list(spec.default_scopes)
-
         if "flow_id" in config and "code" in config:
-            # Caller has already handled the browser step.
+            # Caller has already handled the browser step. No scopes to
+            # resolve here — the flow already started with its own.
             return await complete_authorization(config["flow_id"])
+
+        from gaia.connectors.prior_state import resolve_or_reject_empty_scopes
+
+        scopes = resolve_or_reject_empty_scopes(
+            provider_id, config.get("scopes") or [], spec.default_scopes
+        )
 
         # Validate that a client_secret is available before starting the
         # flow.  Google requires it even for Desktop PKCE clients (#1592

--- a/src/gaia/connectors/prior_state.py
+++ b/src/gaia/connectors/prior_state.py
@@ -1,0 +1,99 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""
+Shared "does this connector already have state a blind reconnect could
+silently destroy" predicate (#2730 D0).
+
+One definition, used by every connect/authorize/configure entry point that
+must decide whether an empty scope request is a genuine first-time connect
+(safe to fall back to the provider's default scopes) or a reconnect of
+something that already carries consent (which must fail loudly instead of
+guessing). Checking connection-existence and grant-existence independently
+at each call site is how a connected-but-not-yet-granted account raised at
+one path and silently narrowed at another.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Iterable, List
+
+logger = logging.getLogger(__name__)
+
+
+def has_prior_state(provider_id: str) -> bool:
+    """True when *provider_id* already has a stored connection OR any agent
+    grant.
+
+    Either one alone is enough: a connection with no grant yet is still
+    consented state a silent scope substitution would blow away, and a
+    grant surviving a revoked/cleared connection is state a reconnect must
+    not silently narrow either.
+    """
+    from gaia.connectors.grants import load_grants
+    from gaia.connectors.store import peek_connection
+
+    if peek_connection(provider_id) is not None:
+        return True
+    return bool(load_grants().get(provider_id))
+
+
+def _current_scope_count(provider_id: str) -> int:
+    """Best-effort size of the scope set *provider_id* currently carries,
+    across its stored connection and every agent's grant — used only to make
+    the D0 rejection message concrete, never to decide anything."""
+    from gaia.connectors.grants import load_grants
+    from gaia.connectors.store import peek_connection
+
+    current: set = set()
+    conn = peek_connection(provider_id)
+    if conn:
+        current.update(conn.get("scopes", []))
+    for scopes in load_grants().get(provider_id, {}).values():
+        current.update(scopes)
+    return len(current)
+
+
+def resolve_or_reject_empty_scopes(
+    provider_id: str, requested_scopes: Iterable[str], default_scopes: Iterable[str]
+) -> List[str]:
+    """Replace ``list(scopes) or list(provider.default_scopes)`` at every
+    (re)connect entry point (#2730 D0).
+
+    An empty *requested_scopes* used to silently fall back to the provider's
+    identity-only *default_scopes* — including on a RECONNECT of a provider
+    that already carries real mailbox scopes, gutting the connection with no
+    warning. Now: an empty request against a provider with prior state (an
+    existing connection or agent grant) is a loud, actionable error instead
+    of a guess. An empty request with no prior state is a genuine first-time
+    connect, so the ``default_scopes`` fallback still applies there — logged,
+    not silent.
+    """
+    from gaia.connectors.errors import ConnectorsError
+
+    scopes_list = list(requested_scopes)
+    if scopes_list:
+        return scopes_list
+
+    if has_prior_state(provider_id):
+        raise ConnectorsError(
+            f"Reconnecting {provider_id!r} with no scopes would drop the "
+            f"{_current_scope_count(provider_id)} scope(s) this connection "
+            "currently carries. Specify the full scope list explicitly, "
+            "e.g.:\n"
+            f"  gaia connectors connect {provider_id} --scopes <scope> ... "
+            "--grant-agent <agent-id>\n"
+            "See docs/sdk/infrastructure/connections.mdx."
+        )
+
+    default_list = list(default_scopes)
+    logger.info(
+        "connectors: no scopes requested and no prior state for %s; falling "
+        "back to default_scopes (%d)",
+        provider_id,
+        len(default_list),
+    )
+    return default_list
+
+
+__all__ = ["has_prior_state", "resolve_or_reject_empty_scopes"]

--- a/src/gaia/connectors/prior_state.py
+++ b/src/gaia/connectors/prior_state.py
@@ -38,10 +38,12 @@ def has_prior_state(provider_id: str) -> bool:
     return bool(load_grants().get(provider_id))
 
 
-def _current_scope_count(provider_id: str) -> int:
-    """Best-effort size of the scope set *provider_id* currently carries,
-    across its stored connection and every agent's grant — used only to make
-    the D0 rejection message concrete, never to decide anything."""
+def _current_scopes_and_agents(provider_id: str) -> "tuple[set, List[str]]":
+    """The scope set *provider_id* currently carries — across its stored
+    connection and every agent's grant — plus the agent ids already granted
+    it. Used to build a copy-pasteable rejection command, never a placeholder
+    (a printed remedy with an unfilled ``<scope>`` slot is the exact defect
+    this issue exists to remove — see ``errors.py`` / ``forward.py``)."""
     from gaia.connectors.grants import load_grants
     from gaia.connectors.store import peek_connection
 
@@ -49,9 +51,10 @@ def _current_scope_count(provider_id: str) -> int:
     conn = peek_connection(provider_id)
     if conn:
         current.update(conn.get("scopes", []))
-    for scopes in load_grants().get(provider_id, {}).values():
+    grants_for_provider = load_grants().get(provider_id, {})
+    for scopes in grants_for_provider.values():
         current.update(scopes)
-    return len(current)
+    return current, sorted(grants_for_provider.keys())
 
 
 def resolve_or_reject_empty_scopes(
@@ -76,13 +79,30 @@ def resolve_or_reject_empty_scopes(
         return scopes_list
 
     if has_prior_state(provider_id):
+        current_scopes, agent_ids = _current_scopes_and_agents(provider_id)
+        if current_scopes:
+            command = (
+                f"gaia connectors connect {provider_id} --scopes "
+                f"{' '.join(sorted(current_scopes))}"
+            )
+            if agent_ids:
+                command += f" --grant-agent {agent_ids[0]}"
+            how = f"Run the scope-complete command that restores it:\n  {command}\n"
+        else:
+            # A connection or grant exists but carries no readable scopes — a
+            # degenerate state no scope-complete command can be reconstructed
+            # from. Point at the connector's catalog rather than print a
+            # placeholder that could not actually be run as-is.
+            how = (
+                f"No prior scopes could be read back for {provider_id!r} to "
+                "reconstruct a command from — reconnect with the exact scopes "
+                "this account needs; see the connector's available_scopes "
+                "via `gaia connectors status --json`.\n"
+            )
         raise ConnectorsError(
             f"Reconnecting {provider_id!r} with no scopes would drop the "
-            f"{_current_scope_count(provider_id)} scope(s) this connection "
-            "currently carries. Specify the full scope list explicitly, "
-            "e.g.:\n"
-            f"  gaia connectors connect {provider_id} --scopes <scope> ... "
-            "--grant-agent <agent-id>\n"
+            f"{len(current_scopes)} scope(s) this connection currently "
+            f"carries. {how}"
             "See docs/sdk/infrastructure/connections.mdx."
         )
 

--- a/src/gaia/connectors/providers/base.py
+++ b/src/gaia/connectors/providers/base.py
@@ -28,15 +28,24 @@ class ConnectorRequirement:
     ``"google"``). Frozen + hashable so it can live in sets and serve as a
     dict key. ``scopes`` is normalized to a tuple in ``__post_init__`` so two
     requirements built from different list instances compare equal.
+
+    ``required_scopes`` (#2730 D5) is the subset actually ENFORCED at token-
+    mint time — ``scopes`` stays what is REQUESTED at consent. Left unset (or
+    passed empty), it defaults to ``scopes``, so every existing construction
+    site keeps today's all-required semantics unchanged.
     """
 
     connector_id: str
     scopes: Sequence[str]
     reason: str = field(default="")
+    required_scopes: Sequence[str] = field(default_factory=tuple)
 
     def __post_init__(self):
         # Frozen dataclass — bypass setattr via object.__setattr__.
         object.__setattr__(self, "scopes", tuple(self.scopes))
+        object.__setattr__(
+            self, "required_scopes", tuple(self.required_scopes) or self.scopes
+        )
 
 
 @runtime_checkable

--- a/src/gaia/daemon/forward.py
+++ b/src/gaia/daemon/forward.py
@@ -214,15 +214,41 @@ class ConnectionForwarder:
                 f"{', '.join(spec.forward_providers) or 'none'}."
             )
         requirement = self._requirement(spec, provider)
+        if requirement is None:
+            # Every forwarding spec MUST declare a ConnectorRequirement for
+            # each of its forward_providers (#2730) — without one there is no
+            # real scope list to print, and the mint below falls back to
+            # trusting the ledger's raw claim (today's pre-#2730 behaviour)
+            # instead of an explicitly-declared required subset. That is a
+            # silent regression waiting to happen the next time a forwarding
+            # sidecar is added without one; log it loudly so it is visible.
+            logger.warning(
+                "forward-out: agent '%s' has no ConnectorRequirement declared "
+                "for '%s' in its AgentSidecarSpec.required_connections; minting "
+                "against the full ledger claim instead of a declared required "
+                "subset. Add one so this provider's remedy can name real "
+                "scopes and its mint can narrow to what is actually required.",
+                agent_id,
+                provider,
+            )
         granted = self._granted_scopes(provider, grant_agent_id)
         if granted is None:
-            full_scopes = " ".join(requirement.scopes) if requirement else "<scopes>"
+            if requirement is not None:
+                scope_command = (
+                    f"  gaia connectors connect {provider} --scopes "
+                    f"{' '.join(requirement.scopes)} --grant-agent {grant_agent_id}\n"
+                )
+            else:
+                scope_command = (
+                    f"agent '{agent_id}' declares no ConnectorRequirement for "
+                    f"'{provider}' — add one to its AgentSidecarSpec.required_connections "
+                    "before this remedy can name real scopes.\n"
+                )
             raise NotGrantedError(
                 f"agent '{agent_id}' ({grant_agent_id}) has no grant for "
                 f"'{provider}'. Connect the account and grant the agent in one "
                 f"command — no Agent UI required:\n"
-                f"  gaia connectors connect {provider} --scopes {full_scopes} "
-                f"--grant-agent {grant_agent_id}\n"
+                f"{scope_command}"
                 f"(`gaia connectors connect {provider}` prints the full OAuth-client "
                 f"setup if the connector isn't configured yet.) In the Agent UI you "
                 f"can instead use Settings -> Connections."

--- a/src/gaia/daemon/forward.py
+++ b/src/gaia/daemon/forward.py
@@ -42,6 +42,7 @@ from __future__ import annotations
 
 from typing import Callable, Dict, List, Optional, Tuple
 
+from gaia.connectors.providers.base import ConnectorRequirement
 from gaia.daemon.sidecars.errors import UnknownAgentError
 from gaia.daemon.sidecars.spec import AgentSidecarSpec
 from gaia.logger import get_logger
@@ -82,6 +83,7 @@ class ConnectionForwarder:
         connected_providers: Optional[Callable[[], List[str]]] = None,
         http_post: Optional[Callable[..., object]] = None,
         http_delete: Optional[Callable[..., object]] = None,
+        get_connection: Optional[Callable[[str], Optional[dict]]] = None,
     ):
         self._specs = dict(specs)
         self._mint = mint or self._default_mint
@@ -91,6 +93,17 @@ class ConnectionForwarder:
         )
         self._http_post = http_post or self._default_http_post
         self._http_delete = http_delete or self._default_http_delete
+        # (#2730 D5) The connection's own real scopes — reported alongside the
+        # ledger grant so a forward never claims scope coverage the STORED
+        # token doesn't actually have. Injectable so tests never touch the
+        # real keyring.
+        self._get_connection = get_connection or self._default_get_connection
+
+    @staticmethod
+    def _default_get_connection(provider: str) -> Optional[dict]:
+        from gaia.connectors.api import get_connection
+
+        return get_connection(provider)
 
     # -- default seams (production wiring) ---------------------------------
 
@@ -157,6 +170,19 @@ class ConnectionForwarder:
         scopes = self._list_grants(provider).get(grant_agent_id)
         return list(scopes) if scopes else None
 
+    def _requirement(
+        self, spec: AgentSidecarSpec, provider: str
+    ) -> Optional[ConnectorRequirement]:
+        """The per-agent ``ConnectorRequirement`` declaring what *provider*
+        requests/requires for this agent, or ``None`` when the spec declares
+        no requirement (#2730 D5) — the ~14 pre-existing specs with no
+        ``required_connections`` entry keep today's all-of-the-ledger mint
+        unchanged rather than narrowing to an undeclared subset."""
+        for cr in spec.required_connections:
+            if cr.connector_id == provider:
+                return cr
+        return None
+
     # -- forwarding --------------------------------------------------------
 
     def forward_provider(
@@ -168,6 +194,16 @@ class ConnectionForwarder:
         agent (the daemon never forwards a credential the user did not grant). A
         mint failure from a revoked/absent connection re-raises the connectors
         error AND withdraws any stale forward from the sidecar.
+
+        The mint (#2730 D5) is scoped to the agent's REQUIRED subset for
+        *provider* — not the whole ledger claim — so an optional (e.g.
+        calendar) scope the connection lacks degrades that capability loudly
+        at use time instead of taking mail down with it. What gets reported
+        to the sidecar is the intersection of the connection's REAL stored
+        scopes with the ledger grant: never wider than what this agent was
+        actually granted (the connection may be shared with other agents
+        that widened it), and never wider than what the mint's bearer token
+        can really be used for.
         """
         spec = self._spec(agent_id)
         grant_agent_id = self._grant_agent_id(spec)
@@ -177,22 +213,26 @@ class ConnectionForwarder:
                 f"'{agent_id}'. Forwardable: "
                 f"{', '.join(spec.forward_providers) or 'none'}."
             )
+        requirement = self._requirement(spec, provider)
         granted = self._granted_scopes(provider, grant_agent_id)
         if granted is None:
+            full_scopes = " ".join(requirement.scopes) if requirement else "<scopes>"
             raise NotGrantedError(
                 f"agent '{agent_id}' ({grant_agent_id}) has no grant for "
                 f"'{provider}'. Connect the account and grant the agent in one "
                 f"command — no Agent UI required:\n"
-                f"  gaia connectors connect {provider} --scopes <scopes> "
+                f"  gaia connectors connect {provider} --scopes {full_scopes} "
                 f"--grant-agent {grant_agent_id}\n"
                 f"(`gaia connectors connect {provider}` prints the full OAuth-client "
                 f"setup if the connector isn't configured yet.) In the Agent UI you "
                 f"can instead use Settings -> Connections."
             )
 
+        required = list(requirement.required_scopes) if requirement else granted
+
         try:
             token, expires_at = self._mint(
-                provider=provider, scopes=granted, agent_id=grant_agent_id
+                provider=provider, scopes=required, agent_id=grant_agent_id
             )
         except Exception as e:
             # A revoked / not-connected mint is loud here; also withdraw any
@@ -215,18 +255,32 @@ class ConnectionForwarder:
                 )
             raise
 
-        self._post_forward(base_url, bearer, provider, token, granted, expires_at)
+        if requirement is not None:
+            # Report the connection's REAL scopes intersected with the
+            # ledger grant — never the ledger's raw (possibly over-claiming)
+            # value. See the docstring above; only exercised for specs that
+            # actually declare a requirement, so specs that don't stay on
+            # today's exact (ledger-only) behavior.
+            connection = self._get_connection(provider)
+            connection_scopes = connection.get("scopes", []) if connection else []
+            forwarded_scopes = [s for s in connection_scopes if s in granted]
+        else:
+            forwarded_scopes = granted
+
+        self._post_forward(
+            base_url, bearer, provider, token, forwarded_scopes, expires_at
+        )
         logger.info(
             "forward-out: forwarded '%s' access token to agent '%s' (%d scopes, "
             "expires_at=%.0f)",
             provider,
             agent_id,
-            len(granted),
+            len(forwarded_scopes),
             expires_at,
         )
         return {
             "provider": provider,
-            "scopes": granted,
+            "scopes": forwarded_scopes,
             "expires_at": expires_at,
             "forwarded": True,
         }

--- a/src/gaia/daemon/sidecars/spec.py
+++ b/src/gaia/daemon/sidecars/spec.py
@@ -121,9 +121,11 @@ _EMAIL_FORWARDED_MODE_ENV_VAR = "GAIA_EMAIL_FORWARDED_CREDENTIALS"
 # Connector scopes the email sidecar needs (#2408). Transcribed as literals —
 # not imported — so core never depends on the hub wheel (server.py:621-629).
 # MUST equal gaia_agent_email/scopes.py's ALL_SCOPES (GMAIL_SCOPES +
-# CALENDAR_SCOPES) and outlook_scopes.py's OUTLOOK_MAIL_SCOPES +
-# OUTLOOK_CALENDAR_SCOPES. Guarded against drift by
-# tests/unit/connectors/test_email_scope_drift.py.
+# CALENDAR_SCOPES) / REQUIRED_SCOPES (GMAIL_SCOPES) and outlook_scopes.py's
+# OUTLOOK_ALL_SCOPES / OUTLOOK_REQUIRED_SCOPES. Guarded against drift by
+# tests/unit/connectors/test_email_scope_drift.py. ``scopes`` is what the
+# daemon REQUESTS at consent; ``required_scopes`` (#2730 D5) is the narrower
+# subset the forward-out mint ENFORCES — calendar is requested but optional.
 _EMAIL_REQUIRED_CONNECTIONS = (
     ConnectorRequirement(
         connector_id="google",
@@ -133,6 +135,10 @@ _EMAIL_REQUIRED_CONNECTIONS = (
             "https://www.googleapis.com/auth/calendar.events",  # from gaia_agent_email/scopes.py
             "https://www.googleapis.com/auth/calendar.readonly",  # from gaia_agent_email/scopes.py
         ),
+        required_scopes=(
+            "https://www.googleapis.com/auth/gmail.modify",  # from gaia_agent_email/scopes.py
+            "https://www.googleapis.com/auth/gmail.send",  # from gaia_agent_email/scopes.py
+        ),
     ),
     ConnectorRequirement(
         connector_id="microsoft",
@@ -140,6 +146,10 @@ _EMAIL_REQUIRED_CONNECTIONS = (
             "https://graph.microsoft.com/Mail.ReadWrite",  # from gaia_agent_email/outlook_scopes.py
             "https://graph.microsoft.com/Mail.Send",  # from gaia_agent_email/outlook_scopes.py
             "https://graph.microsoft.com/Calendars.ReadWrite",  # from gaia_agent_email/outlook_scopes.py
+        ),
+        required_scopes=(
+            "https://graph.microsoft.com/Mail.ReadWrite",  # from gaia_agent_email/outlook_scopes.py
+            "https://graph.microsoft.com/Mail.Send",  # from gaia_agent_email/outlook_scopes.py
         ),
     ),
 )

--- a/src/gaia/ui/routers/connectors.py
+++ b/src/gaia/ui/routers/connectors.py
@@ -349,6 +349,24 @@ def _resolve_grant_scopes(
         ) from e
 
 
+def _widen_empty_scopes(
+    scopes: List[str], grant_map: Dict[str, List[str]]
+) -> List[str]:
+    """Same contract as the CLI's bare ``connect`` (#2730 D0/AC-8): an empty
+    ``scopes`` body must not silently reach ``start_authorization`` narrower
+    than what the request's own ``grant_agents`` already declare. When the
+    caller supplied scopes explicitly, or resolved no grant map at all,
+    return unchanged — ``start_authorization``'s own D0 guard decides the
+    genuinely-empty case (raise on an existing connection, fall back to
+    ``default_scopes`` on a real first connect)."""
+    if scopes or not grant_map:
+        return scopes
+    union: set = set()
+    for agent_scopes in grant_map.values():
+        union.update(agent_scopes)
+    return sorted(union)
+
+
 def _connector_summary(connector_id: str) -> Dict[str, Any]:
     """Build a summary dict for one connector: spec fields + live state.
 
@@ -852,7 +870,9 @@ async def authorize(
     grant_map = _resolve_grant_scopes(request, connector_id, body.grant_agents)
     try:
         return await connections.start_authorization(
-            connector_id, scopes=body.scopes, grant_agents=grant_map or None
+            connector_id,
+            scopes=_widen_empty_scopes(body.scopes, grant_map),
+            grant_agents=grant_map or None,
         )
     except ConnectorsError as e:
         raise _raise_http_for(e) from e
@@ -884,7 +904,9 @@ async def authorize_device(
     """
     grant_map = _resolve_grant_scopes(request, connector_id, body.grant_agents)
     try:
-        info = await connections.start_device_flow(connector_id, scopes=body.scopes)
+        info = await connections.start_device_flow(
+            connector_id, scopes=_widen_empty_scopes(body.scopes, grant_map)
+        )
     except ConnectorsError as e:
         raise _raise_http_for(e) from e
 

--- a/tests/fixtures/connectors/email_scopes.json
+++ b/tests/fixtures/connectors/email_scopes.json
@@ -1,0 +1,49 @@
+{
+  "_source": "hub/agents/email/python/gaia_agent_email/scopes.py and outlook_scopes.py — hand-maintained, guarded by tests/unit/connectors/test_email_scope_drift.py (Python) and tui/internal/ui/preflight/check_test.go (Go). Edit the source constants first, then this fixture, then let the guards confirm agreement.",
+  "google": {
+    "agent_scopes": {
+      "required": [
+        "https://www.googleapis.com/auth/gmail.modify",
+        "https://www.googleapis.com/auth/gmail.send"
+      ],
+      "optional": [
+        "https://www.googleapis.com/auth/calendar.events",
+        "https://www.googleapis.com/auth/calendar.readonly"
+      ]
+    },
+    "identity_scopes": {
+      "catalog": ["openid", "email", "profile"],
+      "provider": ["openid", "https://www.googleapis.com/auth/userinfo.email"]
+    },
+    "connect_union": [
+      "openid",
+      "email",
+      "profile",
+      "https://www.googleapis.com/auth/gmail.modify",
+      "https://www.googleapis.com/auth/gmail.send",
+      "https://www.googleapis.com/auth/calendar.events",
+      "https://www.googleapis.com/auth/calendar.readonly"
+    ]
+  },
+  "microsoft": {
+    "agent_scopes": {
+      "required": [
+        "https://graph.microsoft.com/Mail.ReadWrite",
+        "https://graph.microsoft.com/Mail.Send"
+      ],
+      "optional": ["https://graph.microsoft.com/Calendars.ReadWrite"]
+    },
+    "identity_scopes": {
+      "catalog": ["openid", "offline_access", "https://graph.microsoft.com/User.Read"],
+      "provider": ["openid", "offline_access", "https://graph.microsoft.com/User.Read"]
+    },
+    "connect_union": [
+      "openid",
+      "offline_access",
+      "https://graph.microsoft.com/User.Read",
+      "https://graph.microsoft.com/Mail.ReadWrite",
+      "https://graph.microsoft.com/Mail.Send",
+      "https://graph.microsoft.com/Calendars.ReadWrite"
+    ]
+  }
+}

--- a/tests/unit/connectors/test_api.py
+++ b/tests/unit/connectors/test_api.py
@@ -150,6 +150,12 @@ class TestScopeCoverage:
             )
         assert exc.value.reason is AuthRequiredError.Reason.CONNECTION_MISSING_SCOPES
         assert "gmail.send" in exc.value.missing_scopes
+        # #2730 D0/AC-9a: the remedy command must be the connection's real
+        # current scopes UNIONED with what's missing — never just the
+        # missing subset (--scopes replaces rather than adds) and never a
+        # <scope> placeholder.
+        assert set(exc.value.full_scopes) == {"gmail.readonly", "gmail.send"}
+        assert "<scope" not in str(exc.value)
 
 
 class TestPublicSurface:

--- a/tests/unit/connectors/test_cli.py
+++ b/tests/unit/connectors/test_cli.py
@@ -237,6 +237,87 @@ class TestConnectGrantAgent:
         assert rc == 0
         assert captured["grant_agents"] is None
 
+    def test_bare_connect_with_existing_grant_derives_declared_union(self, monkeypatch):
+        """AC-8 (#2730): the command GAIA's own error text tells a user to
+        run — `gaia connectors connect google` with NO flags — must not
+        silently narrow an existing grant to identity-only scopes. With
+        installed:email already granted, it authorizes
+        declared ∪ default_scopes (7 scopes for google)."""
+        TestConnectGrantAgent._install_fake_agent_registry(
+            monkeypatch,
+            [
+                "https://www.googleapis.com/auth/gmail.modify",
+                "https://www.googleapis.com/auth/gmail.send",
+                "https://www.googleapis.com/auth/calendar.events",
+                "https://www.googleapis.com/auth/calendar.readonly",
+            ],
+        )
+        from gaia.connectors.grants import grant_agent
+
+        grant_agent(
+            "google",
+            "installed:email",
+            ["https://www.googleapis.com/auth/gmail.modify"],
+        )
+
+        captured = {}
+
+        async def _fake_start(connector_id, *, scopes, grant_agents=None):
+            captured["scopes"] = sorted(scopes)
+            captured["grant_agents"] = grant_agents
+            return {"flow_id": "F1", "authorization_url": "https://auth.example"}
+
+        async def _fake_complete(flow_id):
+            return {"account_email": "alice@example.com"}
+
+        monkeypatch.setattr("gaia.connectors.api.start_authorization", _fake_start)
+        monkeypatch.setattr(
+            "gaia.connectors.api.complete_authorization", _fake_complete
+        )
+
+        rc, _out, err = _run("connectors", "connect", "google")
+        assert rc == 0, err
+        assert captured["scopes"] == sorted(
+            {
+                "openid",
+                "email",
+                "profile",
+                "https://www.googleapis.com/auth/gmail.modify",
+                "https://www.googleapis.com/auth/gmail.send",
+                "https://www.googleapis.com/auth/calendar.events",
+                "https://www.googleapis.com/auth/calendar.readonly",
+            }
+        )
+        assert len(captured["scopes"]) == 7
+        # Bare connect never grants — it only authorizes.
+        assert captured["grant_agents"] is None
+
+    def test_bare_connect_with_no_grants_defers_to_start_authorization(
+        self, monkeypatch
+    ):
+        """No agent holds a grant for this connector, so the CLI has nothing
+        to derive a scope union from. It must NOT guess a narrower list
+        itself — it sends nothing and lets `start_authorization`'s own D0
+        guard decide (raise on an existing connection, or fall back to
+        default_scopes for a genuine first-time connect)."""
+        captured = {}
+
+        async def _fake_start(connector_id, *, scopes, grant_agents=None):
+            captured["scopes"] = list(scopes)
+            return {"flow_id": "F1", "authorization_url": "https://auth.example"}
+
+        async def _fake_complete(flow_id):
+            return {"account_email": "bob@example.com"}
+
+        monkeypatch.setattr("gaia.connectors.api.start_authorization", _fake_start)
+        monkeypatch.setattr(
+            "gaia.connectors.api.complete_authorization", _fake_complete
+        )
+
+        rc, _out, err = _run("connectors", "connect", "google")
+        assert rc == 0, err
+        assert captured["scopes"] == []
+
 
 class TestStatus:
     def test_status_empty(self):

--- a/tests/unit/connectors/test_device_flow.py
+++ b/tests/unit/connectors/test_device_flow.py
@@ -233,6 +233,30 @@ class TestPollDeviceFlow:
         # just the loopback path.
         assert blob["tenant"] == "consumers"
 
+    def test_narrower_returned_scope_is_what_gets_persisted(self, monkeypatch):
+        """D6/AC-10 (#2730), device-flow path: the connection must record
+        what the token endpoint actually returned, not the full request."""
+        other_scope = "https://graph.microsoft.com/Calendars.ReadWrite"
+        payload = self._success_payload()
+        payload["scope"] = MAIL_READ  # the calendar scope was declined
+        _install_responses(monkeypatch, [_FakeResp(200, payload)])
+
+        result = asyncio.run(
+            flow_mod.poll_device_flow(
+                "microsoft",
+                "DEV",
+                scopes=[MAIL_READ, other_scope],
+                interval=1,
+                expires_in=900,
+            )
+        )
+        assert result["scopes"] == [MAIL_READ]
+
+        from gaia.connectors.store import peek_connection
+
+        blob = peek_connection("microsoft")
+        assert blob["scopes"] == [MAIL_READ]
+
     def test_grant_agents_committed_on_success(self, monkeypatch):
         _install_responses(monkeypatch, [_FakeResp(200, self._success_payload())])
         asyncio.run(

--- a/tests/unit/connectors/test_email_scope_drift.py
+++ b/tests/unit/connectors/test_email_scope_drift.py
@@ -136,9 +136,18 @@ class TestAgentScopesAgreeAcrossSurfaces:
             assert (set(agent["required"]) | set(agent["optional"])) <= union
             assert union == set(fixture[provider]["connect_union"])
 
-    def test_default_required_scopes_by_provider_matches_all_scopes(self):
-        from gaia_agent_email.scopes import ALL_SCOPES
+    def test_default_required_scopes_by_provider_matches_required_scopes_not_all(self):
+        """#2730 D1: this gates a forwarded connection's usability at
+        ``import_forwarded_connection`` time — the same mail-only
+        enforcement the daemon's forward-out mint applies (D5). It must NOT
+        equal ALL_SCOPES: requiring calendar here would reject a mail-only
+        forwarded connection outright, the same all-or-nothing failure this
+        issue removes, just relocated to the import boundary."""
+        from gaia_agent_email.scopes import ALL_SCOPES, REQUIRED_SCOPES
 
         from gaia.connectors.api import _DEFAULT_REQUIRED_SCOPES_BY_PROVIDER
 
-        assert set(_DEFAULT_REQUIRED_SCOPES_BY_PROVIDER["google"]) == set(ALL_SCOPES)
+        assert set(_DEFAULT_REQUIRED_SCOPES_BY_PROVIDER["google"]) == set(
+            REQUIRED_SCOPES
+        )
+        assert set(_DEFAULT_REQUIRED_SCOPES_BY_PROVIDER["google"]) != set(ALL_SCOPES)

--- a/tests/unit/connectors/test_email_scope_drift.py
+++ b/tests/unit/connectors/test_email_scope_drift.py
@@ -18,37 +18,53 @@ that this file shows PASSED, not SKIPPED.
 
 from __future__ import annotations
 
+import json
+from pathlib import Path
+
 import pytest
 
 pytest.importorskip("gaia_agent_email")
 
+# tests/unit/connectors/ -> repo root is 3 parents up.
+_FIXTURE_PATH = (
+    Path(__file__).resolve().parents[2]
+    / "fixtures"
+    / "connectors"
+    / "email_scopes.json"
+)
 
-def test_google_scopes_match_source_of_truth():
-    from gaia_agent_email.scopes import ALL_SCOPES
 
+def _load_fixture() -> dict:
+    with open(_FIXTURE_PATH, encoding="utf-8") as f:
+        return json.load(f)
+
+
+def _required_connections_by_provider():
     from gaia.daemon.sidecars.spec import builtin_specs
 
     email_spec = builtin_specs()["email"]
-    by_provider = {
-        cr.connector_id: set(cr.scopes) for cr in email_spec.required_connections
-    }
-    assert by_provider.get("google") == set(ALL_SCOPES)
+    return {cr.connector_id: cr for cr in email_spec.required_connections}
+
+
+def test_google_scopes_match_source_of_truth():
+    from gaia_agent_email.scopes import ALL_SCOPES, REQUIRED_SCOPES
+
+    by_provider = _required_connections_by_provider()
+    cr = by_provider["google"]
+    assert set(cr.scopes) == set(ALL_SCOPES)
+    assert set(cr.required_scopes) == set(REQUIRED_SCOPES)
 
 
 def test_microsoft_scopes_match_source_of_truth():
     from gaia_agent_email.outlook_scopes import (
-        OUTLOOK_CALENDAR_SCOPES,
-        OUTLOOK_MAIL_SCOPES,
+        OUTLOOK_ALL_SCOPES,
+        OUTLOOK_REQUIRED_SCOPES,
     )
 
-    from gaia.daemon.sidecars.spec import builtin_specs
-
-    email_spec = builtin_specs()["email"]
-    by_provider = {
-        cr.connector_id: set(cr.scopes) for cr in email_spec.required_connections
-    }
-    expected = set(OUTLOOK_MAIL_SCOPES) | set(OUTLOOK_CALENDAR_SCOPES)
-    assert by_provider.get("microsoft") == expected
+    by_provider = _required_connections_by_provider()
+    cr = by_provider["microsoft"]
+    assert set(cr.scopes) == set(OUTLOOK_ALL_SCOPES)
+    assert set(cr.required_scopes) == set(OUTLOOK_REQUIRED_SCOPES)
 
 
 def test_namespaced_id_matches_source_of_truth():
@@ -58,3 +74,71 @@ def test_namespaced_id_matches_source_of_truth():
 
     email_spec = builtin_specs()["email"]
     assert email_spec.grant_agent_id == AGENT_NAMESPACED_ID
+
+
+# ---------------------------------------------------------------------------
+# AC-1 — agent (mailbox) scopes agree across every surface. Identity scopes
+# are deliberately NOT folded into this check: the catalog spec's
+# default_scopes and the raw OAuthProvider's default_scopes legitimately
+# differ in literal form today (#2730 checkpoint-1 finding, tracked as its
+# own follow-up) — lumping them together would make this guard either fail
+# spuriously or get written loosely enough to miss real agent-scope drift.
+# ---------------------------------------------------------------------------
+
+
+class TestAgentScopesAgreeAcrossSurfaces:
+    def test_google_source_matches_fixture(self):
+        from gaia_agent_email.scopes import (
+            ALL_SCOPES,
+            CALENDAR_SCOPES,
+            GMAIL_SCOPES,
+            REQUIRED_SCOPES,
+        )
+
+        fixture = _load_fixture()["google"]["agent_scopes"]
+        assert set(GMAIL_SCOPES) == set(fixture["required"])
+        assert set(CALENDAR_SCOPES) == set(fixture["optional"])
+        assert set(REQUIRED_SCOPES) == set(fixture["required"])
+        assert set(ALL_SCOPES) == set(fixture["required"]) | set(fixture["optional"])
+
+    def test_microsoft_source_matches_fixture(self):
+        from gaia_agent_email.outlook_scopes import (
+            OUTLOOK_ALL_SCOPES,
+            OUTLOOK_CALENDAR_SCOPES,
+            OUTLOOK_MAIL_SCOPES,
+            OUTLOOK_REQUIRED_SCOPES,
+        )
+
+        fixture = _load_fixture()["microsoft"]["agent_scopes"]
+        assert set(OUTLOOK_MAIL_SCOPES) == set(fixture["required"])
+        assert set(OUTLOOK_CALENDAR_SCOPES) == set(fixture["optional"])
+        assert set(OUTLOOK_REQUIRED_SCOPES) == set(fixture["required"])
+        assert set(OUTLOOK_ALL_SCOPES) == set(fixture["required"]) | set(
+            fixture["optional"]
+        )
+
+    def test_daemon_sidecar_spec_matches_fixture(self):
+        by_provider = _required_connections_by_provider()
+        fixture = _load_fixture()
+        for provider in ("google", "microsoft"):
+            cr = by_provider[provider]
+            agent = fixture[provider]["agent_scopes"]
+            assert set(cr.scopes) == set(agent["required"]) | set(agent["optional"])
+            assert set(cr.required_scopes) == set(agent["required"])
+
+    def test_build_scope_union_agent_portion_matches_fixture(self):
+        from gaia_agent_email.connector_routes import _build_scope_union
+
+        fixture = _load_fixture()
+        for provider in ("google", "microsoft"):
+            union = set(_build_scope_union(provider))
+            agent = fixture[provider]["agent_scopes"]
+            assert (set(agent["required"]) | set(agent["optional"])) <= union
+            assert union == set(fixture[provider]["connect_union"])
+
+    def test_default_required_scopes_by_provider_matches_all_scopes(self):
+        from gaia_agent_email.scopes import ALL_SCOPES
+
+        from gaia.connectors.api import _DEFAULT_REQUIRED_SCOPES_BY_PROVIDER
+
+        assert set(_DEFAULT_REQUIRED_SCOPES_BY_PROVIDER["google"]) == set(ALL_SCOPES)

--- a/tests/unit/connectors/test_errors.py
+++ b/tests/unit/connectors/test_errors.py
@@ -106,6 +106,44 @@ class TestAuthRequiredErrorReason:
         # "reconnect", or "authenticate again". Must direct user to act.
         assert any(token in msg for token in ("reauth", "re-auth", "reconnect"))
 
+    def test_connection_missing_scopes_prints_the_real_scope_complete_command(self):
+        """#2730 D0/AC-9a: the printed remedy must be copy-pasteable — the
+        connection's current scopes UNIONED with what's now missing, never
+        just the missing subset (--scopes REPLACES, it doesn't add) and
+        never a <scope>/<scopes> placeholder."""
+        err = AuthRequiredError(
+            AuthRequiredError.Reason.CONNECTION_MISSING_SCOPES,
+            provider="google",
+            missing_scopes=["gmail.send"],
+            full_scopes=["gmail.modify", "gmail.send"],
+        )
+        msg = str(err)
+        assert "<scope" not in msg
+        assert "--scopes gmail.modify gmail.send" in msg
+
+    def test_agent_not_granted_prints_the_real_scope_complete_command(self):
+        err = AuthRequiredError(
+            AuthRequiredError.Reason.AGENT_NOT_GRANTED,
+            provider="google",
+            agent_id="installed:email",
+            missing_scopes=["gmail.modify", "gmail.send"],
+        )
+        msg = str(err)
+        assert "<scope" not in msg
+        assert "--scopes gmail.modify gmail.send" in msg
+
+    def test_agent_not_granted_with_no_scopes_supplied_names_the_gap_not_a_placeholder(
+        self,
+    ):
+        """Degenerate caller-bug case: no scope list at all. Must not fall
+        back to an unfillable <scope> placeholder."""
+        err = AuthRequiredError(
+            AuthRequiredError.Reason.AGENT_NOT_GRANTED,
+            provider="google",
+            agent_id="installed:email",
+        )
+        assert "<scope" not in str(err)
+
 
 class TestScopeMismatchError:
     def test_required_and_granted_attributes_set(self):
@@ -133,6 +171,18 @@ class TestScopeMismatchError:
             provider="google",
         )
         assert sorted(err.missing_scopes) == ["b", "c"]
+
+    def test_message_prints_the_real_scope_complete_command_not_a_placeholder(self):
+        """#2730 D0/AC-9a: granted ∪ required, never a <scope> placeholder —
+        --scopes REPLACES the connection's scopes rather than adding to them."""
+        err = ScopeMismatchError(
+            required=["gmail.modify", "gmail.send"],
+            granted=["gmail.modify"],
+            provider="google",
+        )
+        msg = str(err)
+        assert "<scope" not in msg
+        assert "--scopes gmail.modify gmail.send" in msg
 
 
 class TestRateLimitedError:
@@ -232,16 +282,18 @@ class TestOAuthClientNotConfiguredError:
         # Exact CLI commands, spec-driven off provider_id.
         assert "gaia connectors configure google --client-id" in s
         # connect authorizes scopes AND grants the agent in one flow (#2347):
-        # --grant-agent folds in the grant so scopes can't drift.
-        assert "gaia connectors connect google --scopes" in s
-        assert "--grant-agent <agent-id>" in s
+        # --grant-agent folds in the grant so scopes can't drift. No --scopes
+        # placeholder (#2730 AC-9a) — omitting it derives the declared scopes.
+        assert "gaia connectors connect google --grant-agent <agent-id>" in s
+        assert "<scope" not in s
         assert "amd-gaia.ai/docs/connectors/google" in s
         # UI path named too.
         assert "Settings -> Connections -> Google" in s
 
     def test_example_block_is_optional(self):
         # Omitting the example drops the copy-paste block but keeps the generic
-        # command template (connect --scopes ... --grant-agent).
+        # command template (connect --grant-agent, no --scopes placeholder).
         s = str(self._err(example=None))
         assert "For the email agent" not in s
-        assert "gaia connectors connect google --scopes <scope> ... --grant-agent" in s
+        assert "gaia connectors connect google --grant-agent <agent-id>" in s
+        assert "<scope" not in s

--- a/tests/unit/connectors/test_flow.py
+++ b/tests/unit/connectors/test_flow.py
@@ -113,6 +113,104 @@ class TestSuccessPath:
         assert result["scopes"] == ["openid"]
 
 
+class TestGrantedScopesTruthfulness:
+    """D6/AC-10 (#2730): the connection record must carry the scopes the
+    token endpoint actually returned, not the ones GAIA asked for. Google's
+    granular-consent screen lets a user untick Calendar while approving
+    Gmail — before this fix the connection blob claimed the full request
+    regardless, so a coverage check would pass against a fabricated record
+    and the user hit an opaque provider 403 instead of GAIA's actionable
+    error."""
+
+    @respx.mock
+    async def test_narrower_returned_scope_is_what_gets_persisted(
+        self, google_provider
+    ):
+        requested = [
+            "openid",
+            "https://www.googleapis.com/auth/gmail.modify",
+            "https://www.googleapis.com/auth/gmail.send",
+            "https://www.googleapis.com/auth/calendar.events",
+            "https://www.googleapis.com/auth/calendar.readonly",
+        ]
+        respx.post("https://oauth2.googleapis.com/token").mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "access_token": "fresh-access",
+                    "refresh_token": "fresh-refresh",
+                    "expires_in": 3600,
+                    # The user declined calendar at the consent screen.
+                    "scope": "openid https://www.googleapis.com/auth/gmail.modify "
+                    "https://www.googleapis.com/auth/gmail.send",
+                    "id_token": (
+                        "header." "eyJlbWFpbCI6ICJhbGljZUBleGFtcGxlLmNvbSJ9" ".sig"
+                    ),
+                },
+            )
+        )
+        respx.route(host="127.0.0.1").pass_through()
+
+        from gaia.connectors.store import peek_connection
+
+        info = await start_authorization("google", scopes=requested)
+        params = parse_qs(urlparse(info["authorization_url"]).query)
+        redirect_uri = params["redirect_uri"][0]
+        state = params["state"][0]
+        async with httpx.AsyncClient() as c:
+            await c.get(f"{redirect_uri}?code=ok&state={state}")
+        result = await asyncio.wait_for(
+            complete_authorization(info["flow_id"]), timeout=2.0
+        )
+
+        expected_granted = {
+            "openid",
+            "https://www.googleapis.com/auth/gmail.modify",
+            "https://www.googleapis.com/auth/gmail.send",
+        }
+        assert set(result["scopes"]) == expected_granted
+        blob = peek_connection("google")
+        assert set(blob["scopes"]) == expected_granted
+        assert "https://www.googleapis.com/auth/calendar.events" not in blob["scopes"]
+
+    @respx.mock
+    async def test_omitted_scope_field_keeps_the_requested_list(self, google_provider):
+        """RFC 6749 §5.1: an absent ``scope`` means "as requested," not
+        "nothing was granted" — the requested list must be kept, not
+        dropped to empty."""
+        respx.post("https://oauth2.googleapis.com/token").mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "access_token": "fresh-access",
+                    "refresh_token": "fresh-refresh",
+                    "expires_in": 3600,
+                    # No "scope" key at all.
+                    "id_token": (
+                        "header." "eyJlbWFpbCI6ICJhbGljZUBleGFtcGxlLmNvbSJ9" ".sig"
+                    ),
+                },
+            )
+        )
+        respx.route(host="127.0.0.1").pass_through()
+
+        from gaia.connectors.store import peek_connection
+
+        info = await start_authorization("google", scopes=["openid", "email"])
+        params = parse_qs(urlparse(info["authorization_url"]).query)
+        redirect_uri = params["redirect_uri"][0]
+        state = params["state"][0]
+        async with httpx.AsyncClient() as c:
+            await c.get(f"{redirect_uri}?code=ok&state={state}")
+        result = await asyncio.wait_for(
+            complete_authorization(info["flow_id"]), timeout=2.0
+        )
+
+        assert set(result["scopes"]) == {"openid", "email"}
+        blob = peek_connection("google")
+        assert set(blob["scopes"]) == {"openid", "email"}
+
+
 class TestTenantRecordedOnConnect:
     """D8 (#2628): the loopback exchange must record the minting authority
     on the connection blob — the very first place a tenant value exists to

--- a/tests/unit/connectors/test_oauth_pkce.py
+++ b/tests/unit/connectors/test_oauth_pkce.py
@@ -182,6 +182,37 @@ class TestConfigure:
         assert "email" in called_scopes
 
     @pytest.mark.asyncio
+    async def test_empty_scopes_against_existing_connection_raises(
+        self, monkeypatch, tmp_path
+    ):
+        """D0 (#2730): ``configure`` with no scopes must not silently narrow
+        an existing connection to the provider's identity-only defaults."""
+        monkeypatch.setattr("gaia.connectors.grants.Path.home", lambda: tmp_path)
+        monkeypatch.setenv("GAIA_GOOGLE_CLIENT_ID", "test.apps.example")
+        monkeypatch.setenv("GAIA_GOOGLE_CLIENT_SECRET", "GOCSPX-test")
+        from gaia.connectors.providers import _registry
+        from gaia.connectors.providers import get as get_provider
+        from gaia.connectors.store import save_connection
+
+        _registry.clear()
+        save_connection(
+            provider="google",
+            account_email="alice@example.com",
+            refresh_token="seed",
+            scopes=["https://www.googleapis.com/auth/gmail.modify"],
+            client_id_hash=get_provider("google").client_id_hash,
+        )
+        spec = _make_spec()
+        handler = OAuthPkceHandler()
+
+        with patch(
+            "gaia.connectors.oauth_pkce.start_authorization",
+            new=AsyncMock(side_effect=AssertionError("must not start a flow")),
+        ):
+            with pytest.raises(ConnectorsError):
+                await handler.configure(spec, {})
+
+    @pytest.mark.asyncio
     async def test_first_run_persists_client_credentials(self, monkeypatch):
         # First-time setup path: client_id + client_secret in config land
         # in the keyring, the cached provider instance is evicted so the

--- a/tests/unit/connectors/test_providers.py
+++ b/tests/unit/connectors/test_providers.py
@@ -69,6 +69,22 @@ class TestConnectorRequirement:
         req = ConnectorRequirement(connector_id="google", scopes=["a", "b"], reason="r")
         assert isinstance(req.scopes, tuple)
 
+    def test_required_scopes_defaults_to_scopes(self):
+        """#2730 D5 mitigation: every existing construction site (~14 of
+        them) builds a ConnectorRequirement without ``required_scopes`` —
+        this proves they keep today's all-required semantics unchanged
+        rather than assuming it."""
+        req = ConnectorRequirement(connector_id="google", scopes=["a", "b"])
+        assert req.required_scopes == ("a", "b")
+
+    def test_required_scopes_can_narrow_the_scopes(self):
+        req = ConnectorRequirement(
+            connector_id="google", scopes=["a", "b"], required_scopes=["a"]
+        )
+        assert req.scopes == ("a", "b")
+        assert req.required_scopes == ("a",)
+        assert isinstance(req.required_scopes, tuple)
+
 
 class TestRegistry:
     def test_get_unknown_provider_raises_keyerror(self):

--- a/tests/unit/connectors/test_router_connectors.py
+++ b/tests/unit/connectors/test_router_connectors.py
@@ -382,6 +382,49 @@ class TestAuthorizeGrantAgents:
         )
         assert resp.status_code == 400
 
+    def test_authorize_empty_scopes_with_grant_agents_widens_to_declared_union(
+        self, ui_api_client, monkeypatch
+    ):
+        """D0/AC-8 (#2730), router half: an omitted ``scopes`` body must not
+        reach ``start_authorization`` empty when ``grant_agents`` names an
+        agent — that would either raise (a connection already exists) or,
+        worse, silently fall back to the provider's identity-only defaults
+        on a first connect, ignoring what the caller actually asked to
+        grant."""
+        mock_start = AsyncMock(
+            return_value={"flow_id": "f1", "authorization_url": "https://auth"}
+        )
+        monkeypatch.setattr("gaia.connectors.start_authorization", mock_start)
+        ui_api_client.app.state.agent_registry = make_fake_agent_registry(
+            "installed:email", "google", self._SCOPES
+        )
+
+        resp = ui_api_client.post(
+            "/api/connectors/google/authorize",
+            json={"grant_agents": ["installed:email"]},
+            headers=UI_HEADER,
+        )
+        assert resp.status_code == 200, resp.text
+        _, kwargs = mock_start.call_args
+        assert kwargs["scopes"] == self._SCOPES
+
+    def test_authorize_empty_scopes_with_no_grant_agents_passes_through_empty(
+        self, ui_api_client, monkeypatch
+    ):
+        """No grant_agents to derive a union from — the router must not
+        guess either; it defers to start_authorization's own D0 guard."""
+        mock_start = AsyncMock(
+            return_value={"flow_id": "f1", "authorization_url": "https://auth"}
+        )
+        monkeypatch.setattr("gaia.connectors.start_authorization", mock_start)
+
+        resp = ui_api_client.post(
+            "/api/connectors/google/authorize", json={}, headers=UI_HEADER
+        )
+        assert resp.status_code == 200, resp.text
+        _, kwargs = mock_start.call_args
+        assert kwargs["scopes"] == []
+
     def test_configure_resolves_grant_agents_into_config(
         self, ui_api_client, monkeypatch
     ):

--- a/tests/unit/connectors/test_scope_silent_fallback.py
+++ b/tests/unit/connectors/test_scope_silent_fallback.py
@@ -1,0 +1,180 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""
+D0 (#2730): an empty scope list on a (re)connect must never silently become
+the provider's identity-only ``default_scopes``.
+
+``list(scopes) or list(provider.default_scopes)`` at four sites
+(``flow.start_authorization``, ``flow.start_device_flow``,
+``flow.poll_device_flow``, ``oauth_pkce.configure``) meant a bare
+``gaia connectors connect google`` — the EXACT command GAIA's own error text
+told a user to run — silently overwrote a working mail+calendar connection
+with three identity-only scopes (``openid email profile``), because the
+daemon's grant ledger was never touched by the same call. This regression-
+locks the fix: an empty request against a provider with prior state (an
+existing connection OR an agent grant) now raises loudly and never reaches
+``save_connection``; an empty request with no prior state (a genuine
+first-time connect) still falls back to ``default_scopes``.
+
+Pure ``src/gaia/connectors/**`` — no ``gaia_agent_email`` import — so a
+connectors-only contributor's CI run catches a D0 regression without the
+email wheel installed (#2408's ``gaia_agent_code`` also calls
+``get_access_token``).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from gaia.connectors.errors import ConnectorsError
+from gaia.connectors.providers import _registry as _provider_registry
+
+
+@pytest.fixture(autouse=True)
+def _google_env(monkeypatch):
+    monkeypatch.setenv("GAIA_GOOGLE_CLIENT_ID", "test.apps.example")
+    monkeypatch.setenv("GAIA_GOOGLE_CLIENT_SECRET", "test-secret")
+    _provider_registry.clear()
+    yield
+    _provider_registry.clear()
+
+
+def _seed_connection(scopes):
+    from gaia.connectors.providers import get as get_provider
+    from gaia.connectors.store import save_connection
+
+    save_connection(
+        provider="google",
+        account_email="alice@example.com",
+        refresh_token="seed-refresh",
+        scopes=list(scopes),
+        client_id_hash=get_provider("google").client_id_hash,
+    )
+
+
+def _seed_grant_only():
+    from gaia.connectors.grants import grant_agent
+
+    grant_agent(
+        "google", "installed:email", ["https://www.googleapis.com/auth/gmail.modify"]
+    )
+
+
+@pytest.fixture(autouse=True)
+def _isolated_grants(tmp_path, monkeypatch):
+    monkeypatch.setattr("gaia.connectors.grants.Path.home", lambda: tmp_path)
+
+
+# ---------------------------------------------------------------------------
+# Site 7 — flow.start_authorization
+# ---------------------------------------------------------------------------
+
+
+class TestStartAuthorizationEmptyScopes:
+    @pytest.mark.asyncio
+    async def test_empty_scopes_with_existing_connection_raises(self, monkeypatch):
+        _seed_connection(["https://www.googleapis.com/auth/gmail.modify", "openid"])
+        from gaia.connectors import store as store_mod
+        from gaia.connectors.flow import start_authorization
+
+        calls = []
+        monkeypatch.setattr(
+            store_mod,
+            "save_connection",
+            lambda **kw: calls.append(kw)
+            or pytest.fail("save_connection must not run"),
+        )
+        with pytest.raises(ConnectorsError) as exc:
+            await start_authorization("google", scopes=[])
+        assert "no scopes" in str(exc.value).lower()
+        assert "gaia connectors connect google --scopes" in str(exc.value)
+        assert calls == []
+
+    @pytest.mark.asyncio
+    async def test_empty_scopes_with_grant_only_raises(self, monkeypatch):
+        _seed_grant_only()
+        from gaia.connectors import store as store_mod
+        from gaia.connectors.flow import start_authorization
+
+        monkeypatch.setattr(
+            store_mod,
+            "save_connection",
+            lambda **kw: pytest.fail("save_connection must not run"),
+        )
+        with pytest.raises(ConnectorsError):
+            await start_authorization("google", scopes=[])
+
+    @pytest.mark.asyncio
+    async def test_empty_scopes_with_no_prior_state_falls_back_to_defaults(
+        self, monkeypatch
+    ):
+        """Genuine first-time connect — no connection, no grant. The
+        pre-#2730 fallback still applies here; only the reconnect case is
+        now rejected."""
+        from gaia.connectors.flow import start_authorization
+
+        monkeypatch.setattr("webbrowser.open", lambda *_a, **_k: True)
+        info = await start_authorization("google", scopes=[])
+        assert info["flow_id"]
+        from gaia.connectors.flow import cancel_flow
+
+        await cancel_flow(info["flow_id"])
+
+
+# ---------------------------------------------------------------------------
+# Site 8 / 9 — flow.start_device_flow / poll_device_flow (Microsoft: the only
+# provider with device_code_url configured in the catalog)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _ms_env(monkeypatch):
+    monkeypatch.setenv("GAIA_MICROSOFT_CLIENT_ID", "test-ms-client")
+    monkeypatch.delenv("GAIA_MICROSOFT_CLIENT_SECRET", raising=False)
+
+
+def _seed_ms_connection(scopes):
+    from gaia.connectors.providers import get as get_provider
+    from gaia.connectors.store import save_connection
+
+    save_connection(
+        provider="microsoft",
+        account_email="alice@example.com",
+        refresh_token="seed-refresh",
+        scopes=list(scopes),
+        client_id_hash=get_provider("microsoft").client_id_hash,
+    )
+
+
+class TestStartDeviceFlowEmptyScopes:
+    @pytest.mark.asyncio
+    async def test_empty_scopes_with_existing_connection_raises(self, monkeypatch):
+        _seed_ms_connection(["https://graph.microsoft.com/Mail.ReadWrite"])
+        import httpx
+
+        async def _boom_post(self, url, data=None, **kw):
+            pytest.fail("no HTTP call should happen before the D0 guard raises")
+
+        monkeypatch.setattr(httpx.AsyncClient, "post", _boom_post)
+        from gaia.connectors.flow import start_device_flow
+
+        with pytest.raises(ConnectorsError) as exc:
+            await start_device_flow("microsoft", scopes=[])
+        assert "no scopes" in str(exc.value).lower()
+
+
+class TestPollDeviceFlowEmptyScopes:
+    @pytest.mark.asyncio
+    async def test_empty_scopes_with_existing_connection_raises(self, monkeypatch):
+        _seed_ms_connection(["https://graph.microsoft.com/Mail.ReadWrite"])
+        import httpx
+
+        async def _boom_post(self, url, data=None, **kw):
+            pytest.fail("no HTTP call should happen before the D0 guard raises")
+
+        monkeypatch.setattr(httpx.AsyncClient, "post", _boom_post)
+        from gaia.connectors.flow import poll_device_flow
+
+        with pytest.raises(ConnectorsError) as exc:
+            await poll_device_flow("microsoft", "dc-1", scopes=[])
+        assert "no scopes" in str(exc.value).lower()

--- a/tests/unit/connectors/test_scope_silent_fallback.py
+++ b/tests/unit/connectors/test_scope_silent_fallback.py
@@ -86,8 +86,14 @@ class TestStartAuthorizationEmptyScopes:
         )
         with pytest.raises(ConnectorsError) as exc:
             await start_authorization("google", scopes=[])
-        assert "no scopes" in str(exc.value).lower()
-        assert "gaia connectors connect google --scopes" in str(exc.value)
+        message = str(exc.value)
+        assert "no scopes" in message.lower()
+        assert "gaia connectors connect google --scopes" in message
+        # The remedy must be copy-pasteable — the real scopes, never a
+        # placeholder (that is the exact defect this issue removes).
+        assert "<scope" not in message
+        assert "https://www.googleapis.com/auth/gmail.modify" in message
+        assert "openid" in message
         assert calls == []
 
     @pytest.mark.asyncio
@@ -101,8 +107,12 @@ class TestStartAuthorizationEmptyScopes:
             "save_connection",
             lambda **kw: pytest.fail("save_connection must not run"),
         )
-        with pytest.raises(ConnectorsError):
+        with pytest.raises(ConnectorsError) as exc:
             await start_authorization("google", scopes=[])
+        message = str(exc.value)
+        assert "<scope" not in message
+        assert "https://www.googleapis.com/auth/gmail.modify" in message
+        assert "--grant-agent installed:email" in message
 
     @pytest.mark.asyncio
     async def test_empty_scopes_with_no_prior_state_falls_back_to_defaults(
@@ -160,7 +170,10 @@ class TestStartDeviceFlowEmptyScopes:
 
         with pytest.raises(ConnectorsError) as exc:
             await start_device_flow("microsoft", scopes=[])
-        assert "no scopes" in str(exc.value).lower()
+        message = str(exc.value)
+        assert "no scopes" in message.lower()
+        assert "<scope" not in message
+        assert "https://graph.microsoft.com/Mail.ReadWrite" in message
 
 
 class TestPollDeviceFlowEmptyScopes:
@@ -177,4 +190,7 @@ class TestPollDeviceFlowEmptyScopes:
 
         with pytest.raises(ConnectorsError) as exc:
             await poll_device_flow("microsoft", "dc-1", scopes=[])
-        assert "no scopes" in str(exc.value).lower()
+        message = str(exc.value)
+        assert "no scopes" in message.lower()
+        assert "<scope" not in message
+        assert "https://graph.microsoft.com/Mail.ReadWrite" in message

--- a/tests/unit/test_daemon_forward.py
+++ b/tests/unit/test_daemon_forward.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import pytest
 
 from gaia.connectors.errors import AuthRequiredError
+from gaia.connectors.providers.base import ConnectorRequirement
 from gaia.daemon.forward import (
     ConnectionForwarder,
     ForwardDeliveryError,
@@ -35,6 +36,43 @@ _SPEC = AgentSidecarSpec(
     grant_agent_id="installed:email",
     forward_providers=("google", "microsoft"),
     forwarded_mode_env_var="GAIA_EMAIL_FORWARDED_CREDENTIALS",
+)
+
+# Real scope literals (#2730 D5) — must match
+# gaia_agent_email/scopes.py::ALL_SCOPES/REQUIRED_SCOPES and
+# src/gaia/daemon/sidecars/spec.py::_EMAIL_REQUIRED_CONNECTIONS["google"].
+GMAIL_MODIFY = "https://www.googleapis.com/auth/gmail.modify"
+GMAIL_SEND = "https://www.googleapis.com/auth/gmail.send"
+CALENDAR_EVENTS = "https://www.googleapis.com/auth/calendar.events"
+CALENDAR_READONLY = "https://www.googleapis.com/auth/calendar.readonly"
+ALL_SCOPES = [GMAIL_MODIFY, GMAIL_SEND, CALENDAR_EVENTS, CALENDAR_READONLY]
+REQUIRED_SCOPES = [GMAIL_MODIFY, GMAIL_SEND]
+# A scope on the shared Google connection that belongs to some OTHER agent's
+# grant entirely — never requested by email at all (AC-6c).
+DRIVE_READONLY = "https://www.googleapis.com/auth/drive.readonly"
+
+# _SPEC has no required_connections (pre-existing tests don't need one). The
+# #2730 D5 tests need a spec whose google requirement narrows required_scopes
+# below scopes (calendar requested-but-optional) — built separately so it
+# can't change what the pre-existing tests above assert against _SPEC.
+_SPEC_WITH_REQUIRED_CONNECTIONS = AgentSidecarSpec(
+    agent_id="email",
+    service_id="gaia-agent-email",
+    display_name="Email",
+    expected_api_major="2",
+    token_env_var="GAIA_EMAIL_SIDECAR_TOKEN",
+    mode_env_var="GAIA_EMAIL_AGENT_MODE",
+    cache_dir_name="email",
+    grant_agent_id="installed:email",
+    forward_providers=("google", "microsoft"),
+    forwarded_mode_env_var="GAIA_EMAIL_FORWARDED_CREDENTIALS",
+    required_connections=(
+        ConnectorRequirement(
+            connector_id="google",
+            scopes=ALL_SCOPES,
+            required_scopes=REQUIRED_SCOPES,
+        ),
+    ),
 )
 
 
@@ -68,9 +106,12 @@ def _forwarder(
     connected=("google", "microsoft"),
     mint=None,
     http=None,
+    get_connection=None,
+    spec=None,
 ):
     grants = grants or {}
     http = http or _RecordingHTTP()
+    spec = spec or _SPEC
 
     def _list_grants(provider):
         return grants.get(provider, {})
@@ -80,15 +121,45 @@ def _forwarder(
             return mint(provider=provider, scopes=scopes, agent_id=agent_id)
         return (f"token-{provider}", 1_900_000_000.0)
 
-    fwd = ConnectionForwarder(
-        {"email": _SPEC},
+    kwargs = dict(
         mint=_mint,
         list_grants=_list_grants,
         connected_providers=lambda: list(connected),
         http_post=http.post,
         http_delete=http.delete,
     )
+    # Only threaded when a test actually supplies it: ConnectionForwarder
+    # does not accept this kwarg yet (#2730 D5), and every pre-existing test
+    # below calls _forwarder() without it — they must keep passing unmodified
+    # until the seam is added.
+    if get_connection is not None:
+        kwargs["get_connection"] = get_connection
+
+    fwd = ConnectionForwarder({"email": spec}, **kwargs)
     return fwd, http
+
+
+def _scope_checking_mint(stored_scopes):
+    """A fake mint that mimics the real ``get_access_token_with_expiry_sync``
+    boundary: it raises ``AuthRequiredError(CONNECTION_MISSING_SCOPES)`` naming
+    whichever of the *requested* ``scopes`` the connection doesn't actually
+    carry (``stored_scopes``), and otherwise mints normally. Lets a test
+    assert on exactly what ``forward_provider`` requested without depending
+    on which internal mechanism (get_connection pre-check vs. mint's own
+    boundary check) the real implementation ends up using."""
+    stored = set(stored_scopes)
+
+    def _mint(*, provider, scopes, agent_id):
+        missing = [s for s in scopes if s not in stored]
+        if missing:
+            raise AuthRequiredError(
+                AuthRequiredError.Reason.CONNECTION_MISSING_SCOPES,
+                provider=provider,
+                missing_scopes=missing,
+            )
+        return (f"token-{provider}", 1_900_000_000.0)
+
+    return _mint
 
 
 # --- forward_provider -------------------------------------------------------
@@ -180,6 +251,96 @@ def test_forward_provider_delivery_failure_raises_forward_delivery_error():
             "email", "google", base_url="http://127.0.0.1:9", bearer="b"
         )
     assert "503" in str(exc.value)
+
+
+# --- forward_provider: required-scope mint + intersection forwarding
+# (#2730 D5) --------------------------------------------------------------
+
+
+def test_forward_provider_ac4_mint_scoped_to_required_subset_names_missing_scope():
+    """AC-4 (#2730): the mint must be scoped to the REQUIRED subset of scopes
+    (gmail.modify + gmail.send) — not the full 4-item ledger claim
+    (+calendar.events + calendar.readonly). The connection stores only
+    gmail.modify; the ledger grants all four. If forward_provider still fed
+    the mint the full ledger claim, the connection would be missing THREE
+    scopes (send + both calendar); scoping to the required subset means only
+    ONE is missing. Asserting the list is exactly that one item is what
+    falsifies the old all-of-the-ledger behavior."""
+    fwd, http = _forwarder(
+        grants={"google": {"installed:email": list(ALL_SCOPES)}},
+        spec=_SPEC_WITH_REQUIRED_CONNECTIONS,
+        mint=_scope_checking_mint([GMAIL_MODIFY]),
+    )
+    with pytest.raises(AuthRequiredError) as exc:
+        fwd.forward_provider(
+            "email", "google", base_url="http://127.0.0.1:9", bearer="b"
+        )
+    assert exc.value.missing_scopes == [GMAIL_SEND]
+    assert http.posts == []
+
+
+def test_forward_provider_ac6b_forwards_intersection_not_all_or_nothing():
+    """AC-6b (#2730): a connection carrying mail-only scopes with a ledger
+    claiming mail+calendar must STILL forward the mail scopes it actually
+    has, and must NOT withdraw the forward just because the optional
+    calendar scopes aren't there (no all-or-nothing mint). Falsifies an
+    implementation that keeps posting the ledger's full claim: the sidecar
+    must see exactly the mail-only intersection the connection carries, not
+    ALL_SCOPES."""
+    fwd, http = _forwarder(
+        grants={"google": {"installed:email": list(ALL_SCOPES)}},
+        get_connection=lambda provider: {"scopes": [GMAIL_MODIFY, GMAIL_SEND]},
+        spec=_SPEC_WITH_REQUIRED_CONNECTIONS,
+    )
+    result = fwd.forward_provider(
+        "email", "google", base_url="http://127.0.0.1:9", bearer="b"
+    )
+    assert result["forwarded"] is True
+    assert http.deletes == []  # no all-or-nothing withdraw
+    assert http.posts[0]["json"]["scopes"] == [GMAIL_MODIFY, GMAIL_SEND]
+
+
+def test_forward_provider_ac6b_missing_required_scope_still_raises_loudly():
+    """AC-6b (#2730) companion: a connection missing a *required* scope (not
+    merely the optional calendar scopes) must still fail loudly, naming that
+    scope, rather than the intersection logic silently forwarding whatever it
+    does have. Distinguishes this from AC-6b's main case: here gmail.send
+    itself — a required scope — is absent from the connection."""
+    fwd, http = _forwarder(
+        grants={"google": {"installed:email": list(ALL_SCOPES)}},
+        get_connection=lambda provider: {
+            "scopes": [GMAIL_MODIFY, CALENDAR_EVENTS, CALENDAR_READONLY]
+        },
+        spec=_SPEC_WITH_REQUIRED_CONNECTIONS,
+        mint=_scope_checking_mint([GMAIL_MODIFY, CALENDAR_EVENTS, CALENDAR_READONLY]),
+    )
+    with pytest.raises(AuthRequiredError) as exc:
+        fwd.forward_provider(
+            "email", "google", base_url="http://127.0.0.1:9", bearer="b"
+        )
+    assert exc.value.missing_scopes == [GMAIL_SEND]
+    assert http.posts == []
+
+
+def test_forward_provider_ac6c_forwarded_scopes_never_exceed_agent_grant():
+    """AC-6c (#2730): even when the shared Google connection carries MORE
+    scopes than this agent was granted (e.g. drive.readonly granted to some
+    other agent sharing the same connection), forwarding must be capped to
+    the intersection with THIS agent's ledger grant — never widened by
+    whatever else the connection happens to carry. Without this case an
+    implementation could satisfy AC-6b and still ship the over-grant."""
+    fwd, http = _forwarder(
+        grants={"google": {"installed:email": list(ALL_SCOPES)}},
+        get_connection=lambda provider: {"scopes": list(ALL_SCOPES) + [DRIVE_READONLY]},
+        spec=_SPEC_WITH_REQUIRED_CONNECTIONS,
+    )
+    result = fwd.forward_provider(
+        "email", "google", base_url="http://127.0.0.1:9", bearer="b"
+    )
+    assert result["forwarded"] is True
+    posted_scopes = http.posts[0]["json"]["scopes"]
+    assert sorted(posted_scopes) == sorted(ALL_SCOPES)
+    assert DRIVE_READONLY not in posted_scopes
 
 
 # --- forward_all (on-spawn push) -------------------------------------------

--- a/tests/unit/test_daemon_forward.py
+++ b/tests/unit/test_daemon_forward.py
@@ -198,8 +198,14 @@ def test_forward_provider_ungranted_raises_not_granted_and_posts_nothing():
 def test_ungranted_error_is_headless_first_and_complete():
     """This is the FIRST error a cold headless box hits on `gaia email` (#2347),
     so it must lead with the CLI (connect + grant, matching scopes), point at
-    where the OAuth-client setup surfaces, and only then mention the UI."""
-    fwd, _ = _forwarder(grants={})
+    where the OAuth-client setup surfaces, and only then mention the UI.
+
+    Uses a spec WITH a declared ConnectorRequirement (#2730 D5/MF-3/MF-4) —
+    the real production email spec always has one (verified against
+    ``builtin_specs()["email"]``), so this is the shape a real headless user
+    actually hits. The no-requirement shape is a distinct, separately-tested
+    case (see ``test_ungranted_error_with_no_declared_requirement_names_the_gap``)."""
+    fwd, _ = _forwarder(grants={}, spec=_SPEC_WITH_REQUIRED_CONNECTIONS)
     with pytest.raises(NotGrantedError) as exc:
         fwd.forward_provider(
             "email", "google", base_url="http://127.0.0.1:9", bearer="b"
@@ -210,6 +216,23 @@ def test_ungranted_error_is_headless_first_and_complete():
     assert "--grant-agent installed:email" in msg
     # CLI leads; the UI is the fallback, not the headline.
     assert msg.index("gaia connectors connect") < msg.index("Settings -> Connections")
+
+
+def test_ungranted_error_with_no_declared_requirement_names_the_gap():
+    """#2730 MF-3: a spec with no ConnectorRequirement for the provider must
+    NOT print an uncopyable `--scopes <scopes>` placeholder (AC-9a scans
+    source for exactly that literal). It must instead name the real gap —
+    the missing AgentSidecarSpec declaration — so the message stays
+    actionable without a placeholder."""
+    fwd, _ = _forwarder(grants={})  # default _SPEC has no required_connections
+    with pytest.raises(NotGrantedError) as exc:
+        fwd.forward_provider(
+            "email", "google", base_url="http://127.0.0.1:9", bearer="b"
+        )
+    msg = str(exc.value)
+    assert "<scope" not in msg
+    assert "ConnectorRequirement" in msg
+    assert "google" in msg
 
 
 def test_forward_provider_unforwardable_provider_raises():

--- a/tests/unit/test_daemon_remedy_commands.py
+++ b/tests/unit/test_daemon_remedy_commands.py
@@ -73,7 +73,20 @@ def _remedy_source_roots() -> "list[Path]":
     architecture-documentation prose (e.g. a docstring mentioning a future
     ``gaia api`` subcommand) that was never meant to be validated as a
     literal, parseable invocation — that is a materially different, wider
-    claim than AC-9a makes."""
+    claim than AC-9a makes.
+
+    NOT covered, deliberately: ``hub/agents/email/python/gaia_agent_email/**``
+    (e.g. ``onboarding_tools.py``, which does emit remedies). Two of its
+    module docstrings (``onboarding_tools.py``, ``question.py``) deliberately
+    quote the OLD placeholder-shaped UX as the bad behaviour they replaced —
+    scanning that directory would need AST-level "is this a docstring vs. a
+    live f-string" discrimination to avoid flagging its own history, which is
+    machinery disproportionate to the risk here: every remedy in that package
+    now derives its scopes from ``gaia_agent_email/scopes.py`` /
+    ``outlook_scopes.py`` (the single source of truth, #2730 D2) rather than
+    a hand-written literal, so the class of bug this scan exists to catch is
+    already structurally harder to reintroduce there. A chosen boundary, not
+    a missed one."""
     return [DAEMON_ROOT, CONNECTORS_ERRORS, FORWARDED_CREDENTIALS]
 
 

--- a/tests/unit/test_daemon_remedy_commands.py
+++ b/tests/unit/test_daemon_remedy_commands.py
@@ -25,6 +25,20 @@ import pytest
 from gaia.daemon.sidecars import install as install_svc
 
 DAEMON_SIDECARS = Path(install_svc.__file__).parent
+# src/gaia/daemon/sidecars/ -> parents[0] = src/gaia/daemon
+DAEMON_ROOT = DAEMON_SIDECARS.parents[0]
+CONNECTORS_ERRORS = DAEMON_ROOT.parent / "connectors" / "errors.py"
+# src/gaia/daemon/sidecars/install.py -> parents[3] = repo root
+_REPO_ROOT = DAEMON_SIDECARS.parents[3]
+FORWARDED_CREDENTIALS = (
+    _REPO_ROOT
+    / "hub"
+    / "agents"
+    / "email"
+    / "python"
+    / "gaia_agent_email"
+    / "forwarded_credentials.py"
+)
 
 # Any `gaia ...` invocation embedded in a user-facing string in this package.
 _GAIA_CMD = re.compile(r"`gaia ([^`]+)`")
@@ -34,8 +48,41 @@ _GAIA_CMD = re.compile(r"`gaia ([^`]+)`")
 # (`… "\n            f"…`) inside the scraped span; stitch it back together.
 _SOURCE_JOIN = re.compile(r'"\s*\n\s*f?"')
 
-# `<id>`, `{agent_id}`, `{self.spec.agent_id}` — a stand-in for a real agent id.
-_PLACEHOLDER = re.compile(r"[<{][^>}]*[>}]")
+# `<id>`, `{agent_id}`, `{self.spec.agent_id}`, `"<q>"` — a stand-in for a
+# real argument. Optional surrounding quote allowed (docstring examples like
+# `gaia email "<q>"` quote the placeholder the way a real invocation would).
+_PLACEHOLDER = re.compile(r"[\"']?[<{][^>}]*[>}][\"']?")
+
+# The literal placeholder tokens a remedy must never leave unfilled (#2730
+# AC-9a) — `--scopes <scope> ...` or `--scopes <scopes>` printed instead of
+# the real, space-separated scope list.
+_SCOPE_PLACEHOLDER = re.compile(r"<scopes?>")
+
+
+def _remedy_source_roots() -> "list[Path]":
+    """Every file/directory a user-facing `gaia connectors ...` scope remedy
+    can live in (#2730 AC-9a). Recursive over ``src/gaia/daemon/**`` — the
+    original non-recursive ``DAEMON_SIDECARS.glob('*.py')`` reached neither
+    ``forward.py`` (one directory up) nor ``connectors/errors.py`` (a
+    different package) nor the hub wheel's own remedy strings.
+
+    Used ONLY by the scope-placeholder scan below, not by
+    ``_emitted_gaia_commands`` — a plain ``<scope>``/``<scopes>`` substring
+    check is immune to false positives, but recursing the whole daemon
+    package for BACKTICK-WRAPPED ``gaia ...`` commands sweeps in unrelated
+    architecture-documentation prose (e.g. a docstring mentioning a future
+    ``gaia api`` subcommand) that was never meant to be validated as a
+    literal, parseable invocation — that is a materially different, wider
+    claim than AC-9a makes."""
+    return [DAEMON_ROOT, CONNECTORS_ERRORS, FORWARDED_CREDENTIALS]
+
+
+def _iter_remedy_source_files():
+    for root in _remedy_source_roots():
+        if root.is_file():
+            yield root
+        else:
+            yield from sorted(root.rglob("*.py"))
 
 
 def _emitted_gaia_commands() -> "set[str]":
@@ -76,6 +123,23 @@ def test_every_gaia_command_named_in_an_error_actually_parses():
         _parse(argv)
         checked += 1
     assert checked >= 6, f"only {checked} remedies checked — scraper drifted"
+
+
+def test_no_scope_placeholder_survives_in_any_remedy_source():
+    """#2730 AC-9a: no `--scopes <scope> ...` / `--scopes <scopes>` may
+    survive in any of the widened remedy-string roots (recursive
+    ``src/gaia/daemon/**``, ``src/gaia/connectors/errors.py``, and the hub
+    wheel's ``forwarded_credentials.py``). A source-text scan, not a
+    backtick-gated one: ``forward.py``'s NotGrantedError message has no
+    backticks, so ``_emitted_gaia_commands`` structurally cannot reach it —
+    this test must catch it a different way."""
+    hits = []
+    for path in _iter_remedy_source_files():
+        text = path.read_text(encoding="utf-8")
+        for match in _SCOPE_PLACEHOLDER.finditer(text):
+            line_no = text.count("\n", 0, match.start()) + 1
+            hits.append(f"{path.relative_to(_REPO_ROOT)}:{line_no}: {match.group(0)!r}")
+    assert not hits, "unfilled scope placeholder(s) found:\n" + "\n".join(hits)
 
 
 def test_gaia_kill_cannot_target_an_agent_sidecar():

--- a/tui/internal/ui/preflight/check.go
+++ b/tui/internal/ui/preflight/check.go
@@ -674,28 +674,36 @@ type connectorsBody struct {
 const emailAgentGrantID = "installed:email"
 
 // connectScopes is the EXACT scope list a reconnect must request, per provider:
-// the connector's default_scopes ∪ the agent's mail scopes, mirroring
-// connector_routes._build_scope_union.
+// the connector's default_scopes ∪ the agent's FULL requested union (mail +
+// calendar), mirroring connector_routes._build_scope_union post-#2730 D3.
+// Guarded against drift from the Python side by
+// tests/fixtures/connectors/email_scopes.json (see
+// TestConnectScopesMatchesTheSharedFixture in check_test.go) — edit the
+// fixture's connect_union alongside this map, never one without the other.
 //
 // The union is not decoration. `gaia connectors connect --scopes` REPLACES the
 // provider defaults rather than adding to them (flow.py: `list(scopes) or
-// list(provider.default_scopes)`), so a remedy naming only the send scope
-// authorizes an account the agent can no longer read — and the mailbox row
-// would then go green over a mailbox that is worse off than before.
+// list(provider.default_scopes)`), so a remedy naming only the mail scopes
+// authorizes an account with less than it had before — the exact silent
+// narrowing #2730 removes. Every connect path now requests the same wide
+// union; only the daemon's forward-out mint narrows to what it enforces.
 var connectScopes = map[string][]string{
 	"google": {
 		// catalog/google.py default_scopes
 		"openid", "email", "profile",
-		// gaia_agent_email.scopes.GMAIL_SCOPES
+		// gaia_agent_email.scopes.ALL_SCOPES (GMAIL_SCOPES + CALENDAR_SCOPES)
 		"https://www.googleapis.com/auth/gmail.modify",
 		"https://www.googleapis.com/auth/gmail.send",
+		"https://www.googleapis.com/auth/calendar.events",
+		"https://www.googleapis.com/auth/calendar.readonly",
 	},
 	"microsoft": {
 		// catalog/microsoft.py default_scopes
 		"openid", "offline_access", "https://graph.microsoft.com/User.Read",
-		// gaia_agent_email.outlook_scopes.OUTLOOK_MAIL_SCOPES
+		// gaia_agent_email.outlook_scopes.OUTLOOK_ALL_SCOPES (OUTLOOK_MAIL_SCOPES + OUTLOOK_CALENDAR_SCOPES)
 		"https://graph.microsoft.com/Mail.ReadWrite",
 		"https://graph.microsoft.com/Mail.Send",
+		"https://graph.microsoft.com/Calendars.ReadWrite",
 	},
 }
 
@@ -709,23 +717,14 @@ var sendScopes = map[string]string{
 }
 
 // connectCommand is the one command that fixes every mailbox state: it
-// re-authorizes with the mail scope union AND grants it to the agent in the same
-// flow, so the token and the grant can never disagree.
+// re-authorizes with the FULL requested union (mail + calendar) AND grants it
+// to the agent in the same flow, so the token and the grant can never
+// disagree, and never end up narrower than what the Agent UI would have
+// granted for the same account (#2730 D3).
 //
 // Deliberately NOT `gaia connectors grants grant`: that cannot add a scope the
 // stored token never carried, so on its own it would trade "cannot send" for
 // "cannot read".
-//
-// KNOWN LIMIT, and it is not this row's to fix: `--grant-agent` writes the same
-// ledger entry `grants grant` does (cli.py -> flow.py -> grants.grant_agent), so
-// whatever union is named below is what the account ends up with. This one
-// mirrors the sidecar's own connect flow (connector_routes._build_scope_union,
-// mail scopes only, "no calendar scopes") — which is NARROWER than the union the
-// agent registers as required (gaia_agent_email ALL_SCOPES = mail + calendar,
-// what the Agent UI grants). A user who connected through the Agent UI and runs
-// this command therefore keeps mail and loses calendar. Widening it here alone
-// would put the TUI and the sidecar's own flow at odds; both lists have to move
-// together.
 func connectCommand(provider string) string {
 	scopes, ok := connectScopes[provider]
 	if !ok {

--- a/tui/internal/ui/preflight/check_test.go
+++ b/tui/internal/ui/preflight/check_test.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -1449,22 +1450,87 @@ func TestTheModelRowKeepsItsRawAnswerWhenLemonadeFails(t *testing.T) {
 	}
 }
 
+// emailScopesFixture mirrors tests/fixtures/connectors/email_scopes.json —
+// the single checked-in source both this package's Go tests and
+// tests/unit/connectors/test_email_scope_drift.py's Python tests diff
+// against, so a one-sided edit to either language's scope constants fails a
+// test on whichever side moved (#2730 D2a).
+type emailScopesFixture struct {
+	Google    providerScopesFixture `json:"google"`
+	Microsoft providerScopesFixture `json:"microsoft"`
+}
+
+type providerScopesFixture struct {
+	ConnectUnion []string `json:"connect_union"`
+}
+
+// loadEmailScopesFixture reads the shared fixture from the repo root. This
+// package lives at tui/internal/ui/preflight — four levels below the root.
+func loadEmailScopesFixture(t *testing.T) emailScopesFixture {
+	t.Helper()
+	path := filepath.Join("..", "..", "..", "..", "tests", "fixtures", "connectors", "email_scopes.json")
+	raw, err := os.ReadFile(path) // #nosec G304 -- fixed relative path to a checked-in fixture
+	if err != nil {
+		t.Fatalf("could not read the shared scope fixture at %s: %v", path, err)
+	}
+	var fixture emailScopesFixture
+	if err := json.Unmarshal(raw, &fixture); err != nil {
+		t.Fatalf("could not parse the shared scope fixture: %v", err)
+	}
+	return fixture
+}
+
+func sameScopeSet(got, want []string) bool {
+	if len(got) != len(want) {
+		return false
+	}
+	set := make(map[string]bool, len(got))
+	for _, v := range got {
+		set[v] = true
+	}
+	for _, v := range want {
+		if !set[v] {
+			return false
+		}
+	}
+	return true
+}
+
+// connectScopes must equal the fixture's connect_union — structured
+// extraction diffed against a checked-in JSON value, not a regex scrape of
+// Go source (fragile against a gofmt reflow or a third provider). Drift on
+// either side (a Go edit or a Python-side scopes.py edit that updates the
+// fixture) fails here.
+func TestConnectScopesMatchesTheSharedFixture(t *testing.T) {
+	fixture := loadEmailScopesFixture(t)
+	cases := map[string][]string{
+		"google":    fixture.Google.ConnectUnion,
+		"microsoft": fixture.Microsoft.ConnectUnion,
+	}
+	for provider, want := range cases {
+		got, ok := connectScopes[provider]
+		if !ok {
+			t.Errorf("connectScopes has no entry for %q", provider)
+			continue
+		}
+		if !sameScopeSet(got, want) {
+			t.Errorf("connectScopes[%q] = %v, want (fixture connect_union) %v", provider, got, want)
+		}
+	}
+}
+
 // The connect remedy must request the SAME scope union the sidecar's own
 // /configure builds — --scopes replaces the provider defaults, so a short list
-// authorizes a mailbox the agent cannot read.
+// authorizes a mailbox the agent cannot read. Reads the shared fixture rather
+// than an inline `want` map so this test's name (which claims "the full
+// union") is actually what it asserts.
 func TestConnectCommandRequestsTheFullScopeUnion(t *testing.T) {
-	for provider, want := range map[string][]string{
-		"google": {
-			"openid", "email", "profile",
-			"https://www.googleapis.com/auth/gmail.modify",
-			"https://www.googleapis.com/auth/gmail.send",
-		},
-		"microsoft": {
-			"openid", "offline_access", "https://graph.microsoft.com/User.Read",
-			"https://graph.microsoft.com/Mail.ReadWrite",
-			"https://graph.microsoft.com/Mail.Send",
-		},
-	} {
+	fixture := loadEmailScopesFixture(t)
+	cases := map[string][]string{
+		"google":    fixture.Google.ConnectUnion,
+		"microsoft": fixture.Microsoft.ConnectUnion,
+	}
+	for provider, want := range cases {
 		cmd := connectCommand(provider)
 		for _, scope := range want {
 			if !strings.Contains(cmd, scope) {


### PR DESCRIPTION
Closes #2730

The email agent could stop working with "no forwarded 'google' credential", and the reconnect command GAIA printed on that very screen made it worse: run without `--scopes`, GAIA quietly substituted identity-only sign-in scopes and overwrote a working mail+calendar connection, while leaving the grant ledger still claiming all four scopes. The daemon then asked every five minutes for scopes the connection no longer had, failed the mint, and withdrew the working forward — so mail died along with calendar. Following the on-screen instructions was what broke the mailbox. Now a scope-less reconnect against an account that already has consent fails loudly with a copy-pasteable command instead of guessing; the connection records what Google actually granted rather than what was requested; and a missing calendar scope degrades calendar alone instead of taking the mailbox down with it.

Four threads a reviewer should weigh separately:

- **The silent fallback is gone** (`flow.py`, `oauth_pkce.py`, `cli.py`, the Agent UI authorize route, the sidecar's configure route). An empty scope list against a provider that already has a connection or a grant now raises. One shared `has_prior_state()` predicate decides it, so the surfaces cannot disagree about what "already has consent" means.
- **One source of truth for the scope lists**, with an explicit request/enforce split: `ALL_SCOPES` is what every connect path asks for, `REQUIRED_SCOPES` (mail) is what the mint enforces. A checked-in fixture is diffed from both Python and Go, so a one-sided edit fails a test instead of shipping. This answers the issue's design question: **calendar is optional, mail is required** — three module docstrings already said so; only the enforcement path disagreed.
- **The connection record stops lying.** The OAuth token response's `scope` field is now parsed and intersected with the request, so a user who unticks Calendar on Google's consent screen gets a truthful record instead of one that passes every internal check and then 403s at the API.
- **Forwarding reports the intersection** of the connection's real scopes and this agent's grant — never either alone. The Google connection is shared across agents, and on our own test hardware it carries `drive.readonly` for a different agent; reporting the raw connection would hand the email sidecar a credential described as carrying Drive access.

Microsoft had the identical divergence and is fixed here rather than filed separately — the drift guard is generic, so it fails until both providers agree.

## Test plan

- [ ] `PYTHON_KEYRING_BACKEND=keyring.backends.null.Keyring python -m pytest tests/unit/connectors/ tests/unit/test_daemon_forward.py hub/agents/email/python/tests/ -q` → 2328 passed, 6 skipped (pre-existing)
- [ ] `cd tui && go test ./... -count=1` → all packages ok
- [ ] `python util/lint.py --all` → 10/11 (MyPy warn is pre-existing) · `cd tui && go vet ./...` clean
- [ ] Drift guard proves it runs rather than skips: `pytest tests/unit/connectors/test_email_scope_drift.py -v` must show **PASSED**, not SKIPPED — it is gated on `pytest.importorskip("gaia_agent_email")`, so run `uv pip install -e hub/agents/email/python` first
- [ ] Mutation check: flip one scope in `scopes.py` → 4 Python guard tests fail; flip one in `connectScopes` → the Go guard fails; revert both
- [ ] **Real-world (not yet run):** on a Linux box, reproduce the outage from the product's own instructions on pre-fix code, then show the branch refusing with a fillable remedy and forwarding continuing

**macOS note:** `PYTHON_KEYRING_BACKEND=keyring.backends.null.Keyring` is required for any run touching `hub/agents/email/python/tests/`. Without it `test_scan_default_ceiling_2643.py` hangs indefinitely on a locked Keychain — pre-existing, reproduced on a clean tree, filed separately.

<details>
<summary>Per-criterion evidence status</summary>

Unit-evidenced: the drift guard in both languages (AC-1/AC-1b), exact missing-scope naming driven through `forward_provider` rather than the already-correct `get_access_token` (AC-4), docs (AC-5), mutation proof (AC-6a), intersection forwarding and the no-all-or-nothing mint (AC-6b/AC-6c), the seven silent-fallback sites (AC-7), bare-CLI derivation (AC-8), no surviving placeholder in either language (AC-9a/AC-9b), token-exchange truthfulness on both the loopback and device-code paths (AC-10), and self-repair no longer narrowing (AC-12).

**Not yet evidenced:** AC-2 and AC-3 (the live remedy and the readiness row returning to `[ok]`) and the live halves of AC-8 and AC-13. These need a browser OAuth consent and are the reason this PR is still a draft.

Deliberately out of scope, to be filed separately: the transient-network case where a mint failure withdraws a still-valid forward; the missing `available_scopes` ceiling on the CLI's verbatim `--scopes` branch; writing the grant ledger from actually-granted scopes; the identity-scope spelling divergence between `provider.default_scopes` and the catalog's; and the macOS Keychain hang above.

One correction to commit `39b1a207`'s message, which overstates its own finding: `get_provider()` fails when **no OAuth client is configured yet**, not on every first-time connect. Verified empirically — it constructs fine where a client already exists.
</details>
