### PR TITLE
feat(discovery): real macOS and Linux branches for day-zero scanners (#1956)

### DIFF
--- a/docs/sdk/sdks/memory.mdx
+++ b/docs/sdk/sdks/memory.mdx
@@ -798,19 +798,21 @@ for source_name, items in results.items():
 |--------|--------------|-----------------|
 | `scan_file_system(paths)` | Folder names + file extensions in project directories | Project names, languages used |
 | `scan_git_repos(paths)` | `.git/config` files -- remotes, branch names | Repo names, languages, remote URLs |
-| `scan_installed_apps()` | Windows registry + Start Menu; macOS `.app` bundles; Linux `.desktop` entries (incl. Flatpak/Snap) | App inventory |
-| `scan_browser_bookmarks()` | Chrome/Edge/Chromium/Firefox bookmark files, every profile; Safari on macOS | Categorized sites and interests |
+| `scan_installed_apps()` | Windows registry + Start Menu; macOS `.app` bundles; Linux `.desktop` entries across `XDG_DATA_DIRS`/`XDG_DATA_HOME` (incl. Flatpak/Snap) | App inventory |
+| `scan_browser_bookmarks()` | Chrome/Edge/Chromium/Firefox bookmark files, every profile (incl. Snap and Flatpak installs on Linux); Safari on macOS | Categorized sites and interests |
 | `scan_browser_history(days)` | Browser history DBs, every profile (URLs only, no page content); Safari on macOS | Top domains (all flagged sensitive) |
 | `scan_email_accounts()` | Windows credential store; macOS Keychain attributes + Apple Mail; Thunderbird everywhere; Evolution on Linux -- addresses only, never passwords | Email addresses (all flagged sensitive) |
 
 <Note>
 Discovery never reports an unsupported OS as "nothing found". Every source run
-through `scan_all()` or the Agent UI's discovery stream is checked against
-`unsupported_reason(source)` first; when a source has no branch for the running
-platform it is named in a log line (and an SSE `log` event) and mapped to `[]`
-without being called, so "GAIA cannot look here" is never mistaken for "you have
-none". Call `unsupported_reason(source)` yourself if you invoke a scanner
-directly instead of through `scan_all()`.
+through `scan_all()`, the Agent UI's discovery and inference streams, or
+`gaia memory bootstrap` is checked against `unsupported_reason(source)` first;
+when a source has no branch for the running platform it is named in a log line
+(and an SSE `log` event) and mapped to `[]` without being called, so "GAIA
+cannot look here" is never mistaken for "you have none". A scanner called
+directly applies the same gate itself and returns `[]` after logging — but call
+`unsupported_reason(source)` yourself when you need the reason as a string to
+show a user.
 </Note>
 
 Each method returns dicts like:

--- a/docs/sdk/sdks/memory.mdx
+++ b/docs/sdk/sdks/memory.mdx
@@ -798,10 +798,20 @@ for source_name, items in results.items():
 |--------|--------------|-----------------|
 | `scan_file_system(paths)` | Folder names + file extensions in project directories | Project names, languages used |
 | `scan_git_repos(paths)` | `.git/config` files -- remotes, branch names | Repo names, languages, remote URLs |
-| `scan_installed_apps()` | Windows registry, Start Menu shortcuts | App inventory |
-| `scan_browser_bookmarks()` | Chrome/Edge/Firefox bookmark files | Categorized sites and interests |
-| `scan_browser_history(days)` | Browser history DBs (URLs only, no page content) | Top domains (all flagged sensitive) |
-| `scan_email_accounts()` | Windows credential store -- addresses only | Email addresses (all flagged sensitive) |
+| `scan_installed_apps()` | Windows registry + Start Menu; macOS `.app` bundles; Linux `.desktop` entries (incl. Flatpak/Snap) | App inventory |
+| `scan_browser_bookmarks()` | Chrome/Edge/Chromium/Firefox bookmark files, every profile; Safari on macOS | Categorized sites and interests |
+| `scan_browser_history(days)` | Browser history DBs, every profile (URLs only, no page content); Safari on macOS | Top domains (all flagged sensitive) |
+| `scan_email_accounts()` | Windows credential store; macOS Keychain attributes + Apple Mail; Thunderbird everywhere; Evolution on Linux -- addresses only, never passwords | Email addresses (all flagged sensitive) |
+
+<Note>
+Discovery never reports an unsupported OS as "nothing found". Every source run
+through `scan_all()` or the Agent UI's discovery stream is checked against
+`unsupported_reason(source)` first; when a source has no branch for the running
+platform it is named in a log line (and an SSE `log` event) and mapped to `[]`
+without being called, so "GAIA cannot look here" is never mistaken for "you have
+none". Call `unsupported_reason(source)` yourself if you invoke a scanner
+directly instead of through `scan_all()`.
+</Note>
 
 Each method returns dicts like:
 

--- a/docs/spec/agent-memory-architecture.md
+++ b/docs/spec/agent-memory-architecture.md
@@ -1506,11 +1506,12 @@ class SystemDiscovery:
 
     def scan_installed_apps(self) -> List[Dict]
         """Windows registry/shortcuts, macOS .app bundles, or Linux .desktop
-        entries. Returns app inventory."""
+        entries across XDG_DATA_DIRS/XDG_DATA_HOME. Returns app inventory."""
 
     def scan_browser_bookmarks(self) -> List[Dict]
-        """Read Chromium/Firefox bookmark files (every profile) plus Safari on
-        macOS. Returns categorized sites."""
+        """Read Chromium/Firefox bookmark files (every profile, including Snap
+        and Flatpak installs on Linux) plus Safari on macOS. Returns
+        categorized sites."""
 
     def scan_browser_history(self, days: int = 30) -> List[Dict]
         """Read browser history DBs (every profile). Returns top domains.
@@ -1523,8 +1524,10 @@ class SystemDiscovery:
 
 def unsupported_reason(source: str) -> Optional[str]
     """Why `source` has no scanner on this platform, or None if it has one.
-    scan_all() and the Agent UI consult this before dispatching, so an
-    unsupported source is reported by name instead of returning empty."""
+    scan_all(), the Agent UI discovery and inference streams, and
+    `gaia memory bootstrap` consult this before dispatching; a scanner called
+    directly applies the same gate itself. An unsupported source is always
+    reported by name instead of returning empty."""
 ```
 
 Each method returns dicts like:

--- a/docs/spec/agent-memory-architecture.md
+++ b/docs/spec/agent-memory-architecture.md
@@ -1450,11 +1450,17 @@ Agent: "I can learn more about your setup by looking at your system.
 | Source | What it reads | What it stores | Sensitive? |
 |---|---|---|---|
 | **File system** | `~/`, `~/Documents`, `~/Work`, `~/Projects` -- folder names + file extensions only, not file contents | Project names, languages used (by extension), directory structure | No |
-| **Browser bookmarks** | Chrome/Edge/Firefox bookmark files (JSON/SQLite) | Bookmarked sites -> interests, tools, frequently visited services | Partial -- flag social media, banking |
-| **Browser history** | Last 30 days of visited URLs (not page content) | Top domains -> interests, workflow patterns, services used | Yes -- auto-flag all |
-| **Installed apps** | Windows Apps & Features registry, Start Menu shortcuts | App inventory -> tools, IDEs, communication apps, creative tools | No |
+| **Browser bookmarks** | Chrome/Edge/Chromium/Firefox bookmark files (JSON/SQLite) from every profile, plus Safari on macOS | Bookmarked sites -> interests, tools, frequently visited services | Partial -- flag social media, banking |
+| **Browser history** | Last 30 days of visited URLs (not page content), every profile, plus Safari on macOS | Top domains -> interests, workflow patterns, services used | Yes -- auto-flag all |
+| **Installed apps** | Windows Apps & Features registry + Start Menu shortcuts; macOS `.app` bundles in `/Applications` and `~/Applications`; Linux `.desktop` entries incl. Flatpak and Snap exports | App inventory -> tools, IDEs, communication apps, creative tools | No |
 | **Git repos** | Walk project folders for `.git/config` -- read remotes, branch names | Project names, languages (by file extensions), remote URLs (GitHub/GitLab) | Partial -- flag private repos |
-| **Email accounts** | Windows credential store / Thunderbird profiles -- addresses only | Email addresses -> entity creation (`service:gmail`, `service:outlook`) | Yes -- addresses only, not content |
+| **Email accounts** | Windows credential store; macOS Keychain *attributes* + Apple Mail plists; Thunderbird profiles on every platform; Evolution sources on Linux -- addresses only, never passwords | Email addresses -> entity creation (`service:gmail`, `service:outlook`) | Yes -- addresses only, not content |
+
+**Unsupported platforms are reported, never silently empty.** A source with no
+scanner for the running OS (for example the Windows UserAssist registry on
+macOS) is named in a log line and, in the Agent UI, in the discovery stream —
+so a user can always tell "GAIA cannot look here" from "you have none".
+`SystemDiscovery.scan_all` maps such a source to `[]` without invoking it.
 
 #### Discovery Flow
 
@@ -1499,16 +1505,26 @@ class SystemDiscovery:
         """Find .git directories. Returns repo names, remotes, languages."""
 
     def scan_installed_apps(self) -> List[Dict]
-        """Read Windows registry/shortcuts. Returns app inventory."""
+        """Windows registry/shortcuts, macOS .app bundles, or Linux .desktop
+        entries. Returns app inventory."""
 
     def scan_browser_bookmarks(self) -> List[Dict]
-        """Read Chrome/Edge/Firefox bookmark files. Returns categorized sites."""
+        """Read Chromium/Firefox bookmark files (every profile) plus Safari on
+        macOS. Returns categorized sites."""
 
     def scan_browser_history(self, days: int = 30) -> List[Dict]
-        """Read browser history DBs. Returns top domains. All flagged sensitive."""
+        """Read browser history DBs (every profile). Returns top domains.
+        All flagged sensitive."""
 
     def scan_email_accounts(self) -> List[Dict]
-        """Read credential store for email addresses. All flagged sensitive."""
+        """Read this platform's credential store and mail-client config for
+        addresses only -- never passwords. All flagged sensitive."""
+
+
+def unsupported_reason(source: str) -> Optional[str]
+    """Why `source` has no scanner on this platform, or None if it has one.
+    scan_all() and the Agent UI consult this before dispatching, so an
+    unsupported source is reported by name instead of returning empty."""
 ```
 
 Each method returns dicts like:

--- a/src/gaia/agents/base/discovery.py
+++ b/src/gaia/agents/base/discovery.py
@@ -7,28 +7,32 @@ Scans the user's machine to discover projects, installed apps, browser data,
 git repos, and email accounts. Each method returns a list of dicts (discovered
 facts) that are NOT stored directly — the caller presents them for user review.
 
-stdlib only. Windows-focused. Never crashes — catches exceptions, returns
-partial results.
+Cross-platform (Windows / macOS / Linux). No third-party dependencies — stdlib
+plus ``gaia.logger``. Never crashes — catches exceptions, returns partial
+results. A source with no scanner for the running platform is reported by name,
+never silently empty; see :func:`unsupported_reason`.
 """
 
 import configparser
 import json
-import logging
 import os
+import plistlib
 import re
 import shutil
 import sqlite3
 import tempfile
 from pathlib import Path
-from typing import Dict, List, Optional
+from typing import Any, Dict, List, Optional, Tuple
 from urllib.parse import urlparse
+
+from gaia.logger import get_logger
 
 try:
     import winreg  # Windows only
 except ImportError:
     winreg = None  # type: ignore[assignment]  # Linux / macOS
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 # ============================================================================
 # Constants
@@ -303,6 +307,53 @@ _WORK_DOMAINS = {
     "docs.google.com",
     "drive.google.com",
 }
+
+# Email addresses, as they appear in credential dumps and mail-client config
+_EMAIL_PATTERN = re.compile(r"[a-zA-Z0-9._%+\-]+@[a-zA-Z0-9.\-]+\.[a-zA-Z]{2,}")
+
+# Mail-plist keys whose values hold the USER's own address. Everything else in
+# a mail plist (previous recipients, signatures) belongs to other people and is
+# deliberately not harvested. Compared lowercased.
+_PLIST_ACCOUNT_KEYS = frozenset(
+    {
+        "emailaddresses",
+        "emailaddress",
+        "accountemailaddresses",
+        "address",
+        "acct",
+        "fullusername",
+        "username",
+    }
+)
+
+# Mail hosts queried one-by-one in the macOS Keychain. `security` cannot
+# enumerate items, so the set of hosts to ask about has to be fixed up front.
+_MACOS_KEYCHAIN_MAIL_HOSTS = (
+    "imap.gmail.com",
+    "smtp.gmail.com",
+    "outlook.office365.com",
+    "smtp.office365.com",
+    "imap-mail.outlook.com",
+    "imap.mail.yahoo.com",
+    "imap.mail.me.com",
+    "smtp.mail.me.com",
+)
+
+# `security` exit code for "the item could not be found" (errSecItemNotFound)
+_SECURITY_ITEM_NOT_FOUND = 44
+
+# System-wide application directories. /System/Applications is deliberately
+# absent: the ~40 Apple stock apps on every Mac would swamp the review list.
+_MACOS_APP_DIRS: Tuple[Path, ...] = (Path("/Applications"),)
+
+# System-wide freedesktop entry directories, including the Flatpak and Snap
+# export dirs — that is how those two surface their GUI apps.
+_LINUX_DESKTOP_DIRS: Tuple[Path, ...] = (
+    Path("/usr/share/applications"),
+    Path("/usr/local/share/applications"),
+    Path("/var/lib/flatpak/exports/share/applications"),
+    Path("/var/lib/snapd/desktop/applications"),
+)
 
 
 # ============================================================================
@@ -580,12 +631,23 @@ def _safe_read_json(path: Path) -> Optional[dict]:
 
 
 def _safe_copy_and_query_sqlite(
-    db_path: Path, query: str, params: tuple = ()
+    db_path: Path, query: str, params: tuple = (), label: str = ""
 ) -> List[tuple]:
     """Copy a SQLite DB to temp dir and query it (avoids lock issues).
 
     Browsers hold locks on their databases; copying first is required.
-    Returns empty list on any error.
+
+    Args:
+        db_path: The database to copy and read.
+        query: SQL to execute against the copy.
+        params: Bound parameters for `query`.
+        label: Human-readable source name used when a permission denial has to
+            be reported (for example "Safari history").
+
+    Returns:
+        The fetched rows, or an empty list when the database is missing or
+        unreadable. A permission denial is reported at WARNING with the remedy;
+        every other failure is logged at DEBUG.
     """
     if not db_path.exists():
         return []
@@ -600,6 +662,11 @@ def _safe_copy_and_query_sqlite(
             return cursor.fetchall()
         finally:
             conn.close()
+    except PermissionError as e:
+        logger.warning(
+            "%s", _permission_denied_message(label or "browser database", db_path, e)
+        )
+        return []
     except (OSError, sqlite3.Error) as e:
         logger.debug("SQLite query failed for %s: %s", db_path, e)
         return []
@@ -621,6 +688,161 @@ def _categorize_app(app_name: str) -> str:
     return "Other"
 
 
+def _collect_plist_emails(node: Any, under_account_key: bool = False) -> List[str]:
+    """Collect the user's own addresses from a decoded mail property list.
+
+    Only values reached through an account-identity key are read. A mail plist
+    also holds correspondents (previous recipients, signatures), and those are
+    other people's addresses — harvesting the whole tree would put them in the
+    user's review list. Nesting varies across macOS releases, so the walk is
+    recursive, but it only descends into account-bearing keys.
+
+    Args:
+        node: A decoded plist value (dict, list, or scalar).
+        under_account_key: True when `node` was reached through a key in
+            ``_PLIST_ACCOUNT_KEYS``; only then are strings harvested.
+
+    Returns:
+        Every address found, in traversal order. Duplicates are not removed —
+        the caller deduplicates.
+    """
+    found: List[str] = []
+    if isinstance(node, dict):
+        for key, value in node.items():
+            is_account_key = isinstance(key, str) and key.lower() in _PLIST_ACCOUNT_KEYS
+            found.extend(_collect_plist_emails(value, is_account_key))
+    elif isinstance(node, (list, tuple)):
+        for value in node:
+            found.extend(_collect_plist_emails(value, under_account_key))
+    elif isinstance(node, str) and under_account_key:
+        found.extend(match.group(0) for match in _EMAIL_PATTERN.finditer(node))
+    return found
+
+
+# ============================================================================
+# Platform support
+# ============================================================================
+
+# Discovery sources that only have a scanner for some platforms. A source that
+# is absent from this map is platform-neutral and runs everywhere.
+#
+# This map is the GATE, not documentation: `scan_all` and the Agent UI skip a
+# source without calling it when the running platform is missing here. Adding a
+# platform branch to a scanner without adding it here leaves that branch
+# unreachable, behind a log line insisting no scanner exists. Update both.
+_PLATFORM_SUPPORT: Dict[str, Tuple[str, ...]] = {
+    "installed_apps": ("win32", "darwin", "linux"),
+    "browser_bookmarks": ("win32", "darwin", "linux"),
+    "browser_history": ("win32", "darwin", "linux"),
+    "email_accounts": ("win32", "darwin", "linux"),
+    "windows_userassist": ("win32",),
+    "macos_app_usage": ("darwin",),
+    "recent_file_types": ("win32", "darwin", "linux"),
+}
+
+
+def _platform_key() -> str:
+    """Return the running platform as a ``_PLATFORM_SUPPORT`` key.
+
+    Normalizes every Linux variant ``sys.platform`` can report ("linux",
+    "linux2") to "linux". Other values ("win32", "darwin", "freebsd13") pass
+    through unchanged.
+
+    Returns:
+        The normalized platform key for the running interpreter.
+    """
+    import sys
+
+    if sys.platform.startswith("linux"):
+        return "linux"
+    return sys.platform
+
+
+def unsupported_reason(source: str) -> Optional[str]:
+    """Return why `source` cannot run on this platform, or None if it can.
+
+    Sources absent from ``_PLATFORM_SUPPORT`` are platform-neutral and always
+    return None.
+
+    Args:
+        source: A discovery source name as used by :meth:`SystemDiscovery.scan_all`
+            (for example "browser_history").
+
+    Returns:
+        A one-line, end-user-readable reason when the source has no scanner for
+        the running platform, otherwise None. This string is shown in the Agent
+        UI, so it states what happened, not what a contributor should do about
+        it — :func:`_log_unsupported` adds that hint for the log.
+    """
+    supported = _PLATFORM_SUPPORT.get(source)
+    if supported is None:
+        return None
+    platform = _platform_key()
+    if platform in supported:
+        return None
+    return (
+        f"no scanner for '{source}' on {platform} "
+        f"(supported: {', '.join(supported)}) — nothing was scanned."
+    )
+
+
+def _log_unsupported(source: str) -> List[Dict]:
+    """Log that `source` has no branch for the running platform, return [].
+
+    The single place an unsupported platform is reported, so a source is never
+    silently empty. The log line adds the contributor hint that the user-facing
+    reason deliberately omits.
+
+    Args:
+        source: A discovery source name.
+
+    Returns:
+        An empty list, so callers can ``return _log_unsupported(...)``.
+    """
+    reason = unsupported_reason(source)
+    if reason:
+        logger.info(
+            "%s Add a branch in src/gaia/agents/base/discovery.py and register "
+            "the platform in _PLATFORM_SUPPORT, or open an issue at "
+            "https://github.com/amd/gaia/issues.",
+            reason,
+        )
+    else:
+        # Reached only when a scanner fell through to "no branch" for a platform
+        # _PLATFORM_SUPPORT claims it handles. Warn rather than return a quiet
+        # [], or the drift this helper exists to surface becomes invisible.
+        logger.warning(
+            "'%s' found no platform branch on %s, but _PLATFORM_SUPPORT lists "
+            "that platform as supported — the map and the scanner branches have "
+            "drifted. Fix one of them in src/gaia/agents/base/discovery.py.",
+            source,
+            _platform_key(),
+        )
+    return []
+
+
+def _permission_denied_message(label: str, path: Path, error: OSError) -> str:
+    """Build an actionable message for a permission-denied read.
+
+    Args:
+        label: Human-readable name of what failed to load ("Safari history").
+        path: The file the scan could not read.
+        error: The raised :class:`PermissionError`.
+
+    Returns:
+        A message naming what failed, what to do about it, and where.
+    """
+    remedy = (
+        "Grant Full Disk Access to the terminal or app running GAIA in "
+        "System Settings → Privacy & Security → Full Disk Access, then re-run "
+        "discovery."
+        if _platform_key() == "darwin"
+        else f"Check the file permissions on {path}, or run discovery as the "
+        f"user that owns that profile."
+    )
+    return f"Cannot read {label} at {path}: {error}. {remedy}"
+
+
 # ============================================================================
 # SystemDiscovery
 # ============================================================================
@@ -637,6 +859,125 @@ class SystemDiscovery:
 
     def __init__(self):
         self._home = Path.home()
+
+    # ------------------------------------------------------------------
+    # Platform path resolvers — shared by the browser and email scanners
+    # ------------------------------------------------------------------
+
+    def _chromium_profile_dirs(self) -> List[Tuple[str, Path]]:
+        """Locate Chromium-family browser profiles for the running platform.
+
+        Covers Chrome and Edge on all three platforms, plus the ``chromium``
+        distro package on Linux. Within each user-data root both the default
+        profile and every additional ``Profile N`` directory are returned, so a
+        user with more than one browser profile is not scanned half-blind.
+
+        Returns:
+            List of ``(browser_label, profile_dir)`` tuples for profile
+            directories that exist. The label names the browser and profile,
+            e.g. ``("Chrome (Profile 1)", Path(...))``.
+        """
+        platform = _platform_key()
+        if platform == "win32":
+            local = self._home / "AppData" / "Local"
+            roots = [
+                ("Chrome", local / "Google" / "Chrome" / "User Data"),
+                ("Edge", local / "Microsoft" / "Edge" / "User Data"),
+            ]
+        elif platform == "darwin":
+            app_support = self._home / "Library" / "Application Support"
+            roots = [
+                ("Chrome", app_support / "Google" / "Chrome"),
+                ("Edge", app_support / "Microsoft Edge"),
+            ]
+        elif platform == "linux":
+            config = self._home / ".config"
+            roots = [
+                ("Chrome", config / "google-chrome"),
+                ("Edge", config / "microsoft-edge"),
+                ("Chromium", config / "chromium"),
+            ]
+        else:
+            return []
+
+        profiles: List[Tuple[str, Path]] = []
+        for browser, root in roots:
+            if not root.is_dir():
+                continue
+            candidates = [root / "Default"] + sorted(root.glob("Profile *"))
+            try:
+                for profile_dir in candidates:
+                    if profile_dir.is_dir():
+                        profiles.append(
+                            (f"{browser} ({profile_dir.name})", profile_dir)
+                        )
+            except PermissionError as e:
+                logger.warning(
+                    "%s", _permission_denied_message(f"{browser} profiles", root, e)
+                )
+        return profiles
+
+    def _firefox_profile_roots(self) -> List[Path]:
+        """Locate the directories that hold Firefox profiles on this platform.
+
+        Includes the Snap and Flatpak sandbox locations on Linux, which is where
+        the distro-packaged Firefox keeps its profiles.
+
+        Returns:
+            List of existing directories whose subdirectories are Firefox
+            profiles.
+        """
+        platform = _platform_key()
+        if platform == "win32":
+            roots = [
+                self._home / "AppData" / "Roaming" / "Mozilla" / "Firefox" / "Profiles"
+            ]
+        elif platform == "darwin":
+            roots = [
+                self._home / "Library" / "Application Support" / "Firefox" / "Profiles"
+            ]
+        elif platform == "linux":
+            roots = [
+                self._home / ".mozilla" / "firefox",
+                self._home / "snap" / "firefox" / "common" / ".mozilla" / "firefox",
+                self._home
+                / ".var"
+                / "app"
+                / "org.mozilla.firefox"
+                / ".mozilla"
+                / "firefox",
+            ]
+        else:
+            return []
+        return [root for root in roots if root.is_dir()]
+
+    def _thunderbird_profile_roots(self) -> List[Path]:
+        """Locate the directories that hold Thunderbird profiles on this platform.
+
+        Includes the Snap and Flatpak sandbox locations on Linux.
+
+        Returns:
+            List of existing directories whose subdirectories are Thunderbird
+            profiles.
+        """
+        platform = _platform_key()
+        if platform == "win32":
+            roots = [self._home / "AppData" / "Roaming" / "Thunderbird" / "Profiles"]
+        elif platform == "darwin":
+            roots = [self._home / "Library" / "Thunderbird" / "Profiles"]
+        elif platform == "linux":
+            roots = [
+                self._home / ".thunderbird",
+                self._home / "snap" / "thunderbird" / "common" / ".thunderbird",
+                self._home
+                / ".var"
+                / "app"
+                / "org.mozilla.Thunderbird"
+                / ".thunderbird",
+            ]
+        else:
+            return []
+        return [root for root in roots if root.is_dir()]
 
     # ------------------------------------------------------------------
     # File System Scan
@@ -871,10 +1212,31 @@ class SystemDiscovery:
         return ""
 
     # ------------------------------------------------------------------
-    # Installed Apps Scan (Windows Registry + Start Menu)
+    # Installed Apps Scan (per-platform)
     # ------------------------------------------------------------------
 
     def scan_installed_apps(self) -> List[Dict]:
+        """Inventory the applications installed on this machine.
+
+        - **Windows**: registry Uninstall keys + Start Menu shortcuts.
+        - **macOS**: ``.app`` bundles in ``/Applications`` and ``~/Applications``.
+        - **Linux**: ``.desktop`` entries, including the Flatpak and Snap export
+          directories.
+
+        Returns:
+            List of discovered fact dicts with app name and category. Empty on a
+            platform with no branch — reported, never silent.
+        """
+        platform = _platform_key()
+        if platform == "win32":
+            return self._scan_windows_installed_apps()
+        if platform == "darwin":
+            return self._scan_macos_installed_apps()
+        if platform == "linux":
+            return self._scan_linux_installed_apps()
+        return _log_unsupported("installed_apps")
+
+    def _scan_windows_installed_apps(self) -> List[Dict]:
         """Read Windows registry Uninstall keys + Start Menu shortcuts.
 
         Scans:
@@ -1054,48 +1416,162 @@ class SystemDiscovery:
             except (PermissionError, OSError):
                 pass
 
+    def _append_app_fact(
+        self, app_name: str, seen_apps: set, results: List[Dict]
+    ) -> None:
+        """Append a deduplicated "installed app" fact for `app_name`.
+
+        Args:
+            app_name: Display name of the application.
+            seen_apps: Lowercased names already recorded; mutated in place.
+            results: Fact list to append to; mutated in place.
+        """
+        norm_name = app_name.strip().lower()
+        if not norm_name or norm_name in seen_apps:
+            return
+        slug = re.sub(r"[^a-z0-9]+", "_", norm_name).strip("_")
+        if not slug:
+            return  # A name with no alphanumerics would yield a bare "app:"
+        seen_apps.add(norm_name)
+        category = _categorize_app(app_name)
+        entity = f"app:{slug}"
+        results.append(
+            _make_fact(
+                content=f"Installed app: {app_name} [{category}]",
+                context="unclassified",
+                entity=entity,
+            )
+        )
+
+    def _scan_macos_installed_apps(self) -> List[Dict]:
+        """Scan macOS ``.app`` bundles in ``/Applications`` and ``~/Applications``.
+
+        ``/System/Applications`` is deliberately excluded: the ~40 Apple stock
+        apps present on every Mac would swamp the user's review list without
+        saying anything about them.
+
+        Returns:
+            List of discovered fact dicts, one per unique application bundle.
+        """
+        results: List[Dict] = []
+        seen_apps: set = set()
+
+        for app_dir in (*_MACOS_APP_DIRS, self._home / "Applications"):
+            if not app_dir.is_dir():
+                continue
+            try:
+                with os.scandir(str(app_dir)) as entries:
+                    for entry in entries:
+                        if not entry.name.endswith(".app") or not entry.is_dir():
+                            continue
+                        self._append_app_fact(entry.name[:-4], seen_apps, results)
+            except PermissionError as e:
+                logger.warning(
+                    "%s", _permission_denied_message("installed apps", app_dir, e)
+                )
+            except OSError as e:
+                logger.debug("Application scan failed for %s: %s", app_dir, e)
+
+        return results
+
+    def _scan_linux_installed_apps(self) -> List[Dict]:
+        """Scan Linux ``.desktop`` entries for installed GUI applications.
+
+        Covers the system, user, Flatpak, and Snap application directories —
+        Flatpak and Snap both export a ``.desktop`` file per GUI app, so no
+        package-manager subprocess is needed. Entries hidden from menus
+        (``NoDisplay``, ``Hidden``) and non-application types are skipped.
+
+        Returns:
+            List of discovered fact dicts, one per unique application.
+        """
+        results: List[Dict] = []
+        seen_apps: set = set()
+
+        local_share = self._home / ".local" / "share"
+        desktop_dirs = [
+            *_LINUX_DESKTOP_DIRS,
+            local_share / "applications",
+            local_share / "flatpak" / "exports" / "share" / "applications",
+        ]
+
+        for desktop_dir in desktop_dirs:
+            if not desktop_dir.is_dir():
+                continue
+            try:
+                with os.scandir(str(desktop_dir)) as scan:
+                    entries = sorted(scan, key=lambda e: e.name)
+            except PermissionError as e:
+                logger.warning(
+                    "%s", _permission_denied_message("installed apps", desktop_dir, e)
+                )
+                continue
+            except OSError as e:
+                logger.debug("Desktop entry scan failed for %s: %s", desktop_dir, e)
+                continue
+
+            for entry in entries:
+                if not entry.name.endswith(".desktop"):
+                    continue
+                app_name = self._parse_desktop_entry_name(Path(entry.path))
+                if app_name:
+                    self._append_app_fact(app_name, seen_apps, results)
+
+        return results
+
+    def _parse_desktop_entry_name(self, path: Path) -> str:
+        """Read the display name out of a freedesktop ``.desktop`` file.
+
+        Args:
+            path: The ``.desktop`` file to parse.
+
+        Returns:
+            The ``Name`` value, or "" when the entry is hidden, is not an
+            application, or cannot be parsed.
+        """
+        # interpolation=None is mandatory: Exec= lines contain %f / %U, which
+        # the default interpolator raises on.
+        parser = configparser.ConfigParser(interpolation=None, strict=False)
+        try:
+            parser.read_string(path.read_text(encoding="utf-8", errors="replace"))
+        except (OSError, configparser.Error) as e:
+            logger.debug("Failed to parse desktop entry %s: %s", path, e)
+            return ""
+
+        if not parser.has_section("Desktop Entry"):
+            return ""
+        section = parser["Desktop Entry"]
+        if section.get("Type", "Application") != "Application":
+            return ""
+        for hidden_key in ("NoDisplay", "Hidden"):
+            if section.get(hidden_key, "false").strip().lower() == "true":
+                return ""
+        return section.get("Name", "").strip()
+
     # ------------------------------------------------------------------
     # Browser Bookmarks Scan
     # ------------------------------------------------------------------
 
     def scan_browser_bookmarks(self) -> List[Dict]:
-        """Read Chrome/Edge bookmark JSON and Firefox SQLite bookmarks.
+        """Read Chromium, Firefox, and (on macOS) Safari bookmarks.
 
-        Groups bookmarks by domain. Flags banking/finance as sensitive.
+        Groups bookmarks by domain. Flags banking/finance as sensitive. Every
+        profile of every supported browser is read, not just the default one.
 
         Returns:
             List of discovered fact dicts with bookmark domains and categories.
+            Empty on a platform with no branch — reported, never silent.
         """
+        if unsupported_reason("browser_bookmarks"):
+            return _log_unsupported("browser_bookmarks")
+        platform = _platform_key()
+
         results: List[Dict] = []
         domain_urls: Dict[str, int] = {}
 
-        # Chrome and Edge use identical JSON format
-        chromium_paths = [
-            (
-                "Chrome",
-                self._home
-                / "AppData"
-                / "Local"
-                / "Google"
-                / "Chrome"
-                / "User Data"
-                / "Default"
-                / "Bookmarks",
-            ),
-            (
-                "Edge",
-                self._home
-                / "AppData"
-                / "Local"
-                / "Microsoft"
-                / "Edge"
-                / "User Data"
-                / "Default"
-                / "Bookmarks",
-            ),
-        ]
-
-        for browser_name, bookmark_path in chromium_paths:
+        # Chrome, Edge, and Chromium all use the same bookmark JSON format
+        for browser_name, profile_dir in self._chromium_profile_dirs():
+            bookmark_path = profile_dir / "Bookmarks"
             if not bookmark_path.exists():
                 continue
             try:
@@ -1112,6 +1588,9 @@ class SystemDiscovery:
             self._extract_firefox_bookmarks(domain_urls)
         except Exception as e:
             logger.debug("Failed to read Firefox bookmarks: %s", e)
+
+        if platform == "darwin":
+            self._extract_safari_bookmarks(domain_urls)
 
         # Convert domain counts to facts
         for domain, count in sorted(
@@ -1167,19 +1646,27 @@ class SystemDiscovery:
                 self._walk_chromium_bookmark_node(child, domain_urls)
 
     def _extract_firefox_bookmarks(self, domain_urls: Dict[str, int]) -> None:
-        """Extract bookmarks from Firefox places.sqlite."""
-        firefox_root = (
-            self._home / "AppData" / "Roaming" / "Mozilla" / "Firefox" / "Profiles"
-        )
-        if not firefox_root.exists():
-            return
+        """Extract bookmarks from every Firefox profile's places.sqlite.
 
-        # Find profile directories
-        try:
-            for entry in os.scandir(str(firefox_root)):
-                if not entry.is_dir():
-                    continue
-                places_db = Path(entry.path) / "places.sqlite"
+        Args:
+            domain_urls: Domain -> bookmark-count map; mutated in place.
+        """
+        for firefox_root in self._firefox_profile_roots():
+            try:
+                with os.scandir(str(firefox_root)) as entries:
+                    profile_dirs = [Path(e.path) for e in entries if e.is_dir()]
+            except PermissionError as e:
+                logger.warning(
+                    "%s",
+                    _permission_denied_message("Firefox profiles", firefox_root, e),
+                )
+                continue
+            except OSError as e:
+                logger.debug("Cannot list Firefox profiles in %s: %s", firefox_root, e)
+                continue
+
+            for profile_dir in profile_dirs:
+                places_db = profile_dir / "places.sqlite"
                 if not places_db.exists():
                     continue
 
@@ -1191,30 +1678,84 @@ class SystemDiscovery:
                     JOIN moz_places mp ON mb.fk = mp.id
                     WHERE mp.url LIKE 'http%'
                     """,
+                    label="Firefox bookmarks",
                 )
                 for _title, url in rows:
                     domain = _extract_domain(url)
                     if domain:
                         domain_urls[domain] = domain_urls.get(domain, 0) + 1
-        except (PermissionError, OSError):
-            pass
+
+    def _extract_safari_bookmarks(self, domain_urls: Dict[str, int]) -> None:
+        """Extract Safari bookmarks from ``~/Library/Safari/Bookmarks.plist``.
+
+        ``~/Library/Safari`` is protected by macOS TCC; without Full Disk Access
+        the read is denied, which is reported with the remedy rather than
+        swallowed.
+
+        Args:
+            domain_urls: Domain -> bookmark-count map; mutated in place.
+        """
+        plist_path = self._home / "Library" / "Safari" / "Bookmarks.plist"
+        if not plist_path.exists():
+            return
+        try:
+            with open(plist_path, "rb") as f:
+                data = plistlib.load(f)
+        except PermissionError as e:
+            logger.warning(
+                "%s", _permission_denied_message("Safari bookmarks", plist_path, e)
+            )
+            return
+        except (OSError, ValueError, plistlib.InvalidFileException) as e:
+            logger.debug("Failed to read Safari bookmarks at %s: %s", plist_path, e)
+            return
+
+        self._walk_safari_bookmark_node(data, domain_urls)
+
+    def _walk_safari_bookmark_node(
+        self, node: Any, domain_urls: Dict[str, int]
+    ) -> None:
+        """Walk a Safari bookmark plist node, counting bookmarked domains.
+
+        Args:
+            node: A decoded plist node (dict or list) from Bookmarks.plist.
+            domain_urls: Domain -> bookmark-count map; mutated in place.
+        """
+        if isinstance(node, list):
+            for child in node:
+                self._walk_safari_bookmark_node(child, domain_urls)
+            return
+        if not isinstance(node, dict):
+            return
+        url = node.get("URLString", "")
+        if isinstance(url, str) and url:
+            domain = _extract_domain(url)
+            if domain:
+                domain_urls[domain] = domain_urls.get(domain, 0) + 1
+        self._walk_safari_bookmark_node(node.get("Children", []), domain_urls)
 
     # ------------------------------------------------------------------
     # Browser History Scan
     # ------------------------------------------------------------------
 
     def scan_browser_history(self, days: int = 30) -> List[Dict]:
-        """Read browser history (Chrome/Edge/Firefox). Returns top domains only.
+        """Read browser history (Chromium/Firefox, plus Safari on macOS).
 
-        Copies DB to temp file first to avoid browser lock issues.
+        Returns top domains only. Copies each DB to a temp file first to avoid
+        browser lock issues. Every profile is read, not just the default one.
         ALL results are flagged sensitive=True.
 
         Args:
             days: Number of days of history to scan. Default 30.
 
         Returns:
-            List of discovered fact dicts. All marked sensitive.
+            List of discovered fact dicts. All marked sensitive. Empty on a
+            platform with no branch — reported, never silent.
         """
+        if unsupported_reason("browser_history"):
+            return _log_unsupported("browser_history")
+        platform = _platform_key()
+
         domain_counts: Dict[str, int] = {}
 
         # Chrome epoch: Jan 1, 1601 (microseconds)
@@ -1226,36 +1767,11 @@ class SystemDiscovery:
         # Chrome timestamp = (Unix timestamp + 11644473600) * 1000000
         chrome_cutoff = int((cutoff_unix + 11644473600) * 1_000_000)
 
-        # Chrome and Edge use identical History SQLite format
-        chromium_paths = [
-            (
-                "Chrome",
-                self._home
-                / "AppData"
-                / "Local"
-                / "Google"
-                / "Chrome"
-                / "User Data"
-                / "Default"
-                / "History",
-            ),
-            (
-                "Edge",
-                self._home
-                / "AppData"
-                / "Local"
-                / "Microsoft"
-                / "Edge"
-                / "User Data"
-                / "Default"
-                / "History",
-            ),
-        ]
-
-        for browser_name, history_path in chromium_paths:
+        # Chrome, Edge, and Chromium all use the same History SQLite format
+        for browser_name, profile_dir in self._chromium_profile_dirs():
             try:
                 rows = _safe_copy_and_query_sqlite(
-                    history_path,
+                    profile_dir / "History",
                     """
                     SELECT url, visit_count
                     FROM urls
@@ -1264,6 +1780,7 @@ class SystemDiscovery:
                     LIMIT 500
                     """,
                     (chrome_cutoff,),
+                    label=f"{browser_name} history",
                 )
                 for url, visit_count in rows:
                     domain = _extract_domain(url)
@@ -1280,6 +1797,9 @@ class SystemDiscovery:
             self._extract_firefox_history(domain_counts, firefox_cutoff)
         except Exception as e:
             logger.debug("Failed to read Firefox history: %s", e)
+
+        if platform == "darwin":
+            self._extract_safari_history(domain_counts, cutoff_unix)
 
         # Convert to facts — top domains only, ALL sensitive
         results: List[Dict] = []
@@ -1299,18 +1819,28 @@ class SystemDiscovery:
     def _extract_firefox_history(
         self, domain_counts: Dict[str, int], cutoff_timestamp: int
     ) -> None:
-        """Extract history from Firefox places.sqlite."""
-        firefox_root = (
-            self._home / "AppData" / "Roaming" / "Mozilla" / "Firefox" / "Profiles"
-        )
-        if not firefox_root.exists():
-            return
+        """Extract history from every Firefox profile's places.sqlite.
 
-        try:
-            for entry in os.scandir(str(firefox_root)):
-                if not entry.is_dir():
-                    continue
-                places_db = Path(entry.path) / "places.sqlite"
+        Args:
+            domain_counts: Domain -> visit-count map; mutated in place.
+            cutoff_timestamp: Oldest visit to include, in Unix microseconds.
+        """
+        for firefox_root in self._firefox_profile_roots():
+            try:
+                with os.scandir(str(firefox_root)) as entries:
+                    profile_dirs = [Path(e.path) for e in entries if e.is_dir()]
+            except PermissionError as e:
+                logger.warning(
+                    "%s",
+                    _permission_denied_message("Firefox profiles", firefox_root, e),
+                )
+                continue
+            except OSError as e:
+                logger.debug("Cannot list Firefox profiles in %s: %s", firefox_root, e)
+                continue
+
+            for profile_dir in profile_dirs:
+                places_db = profile_dir / "places.sqlite"
                 if not places_db.exists():
                     continue
 
@@ -1325,6 +1855,7 @@ class SystemDiscovery:
                     LIMIT 500
                     """,
                     (cutoff_timestamp,),
+                    label="Firefox history",
                 )
                 for url, visit_count in rows:
                     domain = _extract_domain(url)
@@ -1332,42 +1863,111 @@ class SystemDiscovery:
                         domain_counts[domain] = domain_counts.get(domain, 0) + (
                             visit_count or 0
                         )
-        except (PermissionError, OSError):
-            pass
+
+    def _extract_safari_history(
+        self, domain_counts: Dict[str, int], cutoff_unix: float
+    ) -> None:
+        """Extract Safari history from ``~/Library/Safari/History.db``.
+
+        Safari stores visit times as Mac absolute time (seconds since
+        2001-01-01), not the Chrome or Firefox epoch.
+
+        Args:
+            domain_counts: Domain -> visit-count map; mutated in place.
+            cutoff_unix: Oldest visit to include, as a Unix timestamp.
+        """
+        history_db = self._home / "Library" / "Safari" / "History.db"
+        # Mac absolute time epoch: 2001-01-01 == Unix 978307200
+        mac_cutoff = cutoff_unix - 978307200
+
+        rows = _safe_copy_and_query_sqlite(
+            history_db,
+            """
+            SELECT hi.url, hi.visit_count
+            FROM history_items hi
+            JOIN history_visits hv ON hv.history_item = hi.id
+            WHERE hv.visit_time > ?
+            GROUP BY hi.id
+            ORDER BY hi.visit_count DESC
+            LIMIT 500
+            """,
+            (mac_cutoff,),
+            label="Safari history",
+        )
+        for url, visit_count in rows:
+            domain = _extract_domain(url)
+            if domain:
+                domain_counts[domain] = domain_counts.get(domain, 0) + (
+                    visit_count or 0
+                )
 
     # ------------------------------------------------------------------
     # Email Accounts Scan
     # ------------------------------------------------------------------
 
     def scan_email_accounts(self) -> List[Dict]:
-        """Discover email accounts from Credential Manager, Thunderbird, Outlook.
+        """Discover configured email accounts from this platform's mail clients.
 
-        Reads addresses only — never email content.
+        Reads addresses only — never email content, and never a stored password.
+
+        - **Windows**: Credential Manager, Thunderbird, Outlook registry.
+        - **macOS**: Keychain attributes for known mail hosts, Thunderbird,
+          Apple Mail.
+        - **Linux**: Thunderbird, Evolution. There is no credential-store branch:
+          ``secret-tool`` can only look up exact attribute pairs, it cannot
+          enumerate the keyring.
+
         ALL results are flagged sensitive=True.
 
         Returns:
             List of discovered fact dicts with email addresses. All sensitive.
+            Empty on a platform with no branch — reported, never silent.
         """
+        if unsupported_reason("email_accounts"):
+            return _log_unsupported("email_accounts")
+        platform = _platform_key()
+
         results: List[Dict] = []
         seen_emails: set = set()
 
-        # 1. Windows Credential Manager (via cmdkey)
-        try:
-            self._scan_credential_manager(seen_emails, results)
-        except Exception as e:
-            logger.debug("Credential Manager scan failed: %s", e)
+        # 1. Platform credential store
+        if platform == "win32":
+            try:
+                self._scan_credential_manager(seen_emails, results)
+            except Exception as e:
+                logger.debug("Credential Manager scan failed: %s", e)
+        elif platform == "darwin":
+            try:
+                self._scan_macos_keychain(seen_emails, results)
+            except Exception as e:
+                # A broken scan and an empty one both look like "no accounts"
+                # to the user, so say which one happened.
+                logger.warning("Keychain scan failed, no accounts read from it: %s", e)
 
-        # 2. Thunderbird profiles (prefs.js)
+        # 2. Thunderbird profiles (prefs.js) — all platforms
         try:
             self._scan_thunderbird(seen_emails, results)
         except Exception as e:
             logger.debug("Thunderbird scan failed: %s", e)
 
-        # 3. Outlook registry
-        try:
-            self._scan_outlook_registry(seen_emails, results)
-        except Exception as e:
-            logger.debug("Outlook registry scan failed: %s", e)
+        # 3. Platform identity store
+        if platform == "win32":
+            try:
+                self._scan_outlook_registry(seen_emails, results)
+            except Exception as e:
+                logger.debug("Outlook registry scan failed: %s", e)
+        elif platform == "darwin":
+            try:
+                self._scan_apple_mail(seen_emails, results)
+            except Exception as e:
+                logger.warning(
+                    "Apple Mail scan failed, no accounts read from it: %s", e
+                )
+        elif platform == "linux":
+            try:
+                self._scan_evolution(seen_emails, results)
+            except Exception as e:
+                logger.warning("Evolution scan failed, no accounts read from it: %s", e)
 
         return results
 
@@ -1412,49 +2012,281 @@ class SystemDiscovery:
                 )
             )
 
-    def _scan_thunderbird(self, seen_emails: set, results: List[Dict]) -> None:
-        """Scan Thunderbird prefs.js for email account addresses."""
-        thunderbird_root = (
-            self._home / "AppData" / "Roaming" / "Thunderbird" / "Profiles"
-        )
-        if not thunderbird_root.exists():
-            return
+    def _append_email_fact(
+        self,
+        email: str,
+        seen_emails: set,
+        results: List[Dict],
+        source_label: str = "",
+    ) -> None:
+        """Append a deduplicated, sensitive "email account" fact.
 
+        Args:
+            email: The discovered address.
+            seen_emails: Addresses already recorded; mutated in place.
+            results: Fact list to append to; mutated in place.
+            source_label: Mail client the address came from, shown in the fact
+                ("Thunderbird", "Apple Mail"). Omitted when empty.
+        """
+        email = email.strip().lower()
+        if not email or email in seen_emails:
+            return
+        seen_emails.add(email)
+        domain = email.split("@")[1] if "@" in email else "unknown"
+        provider = domain.split(".")[0]
+        content = f"Email account: {email}"
+        if source_label:
+            content += f" ({source_label})"
+        results.append(
+            _make_fact(
+                content=content,
+                context="unclassified",
+                entity=f"service:{provider}",
+                sensitive=True,
+            )
+        )
+
+    def _scan_macos_keychain(self, seen_emails: set, results: List[Dict]) -> None:
+        """Read macOS Keychain *attributes* for a fixed list of mail hosts.
+
+        Runs ``security find-internet-password -s <host>``, which prints an
+        item's attributes only. The ``-g`` flag — the one that returns the
+        stored secret and raises an authorization prompt — is never passed, so
+        no password is ever read and the user is never interrupted.
+
+        `security` returns only the FIRST match per host, so a user with two
+        accounts on the same provider surfaces one address here; the other is
+        picked up from their mail client's own config if it is configured there.
+
+        Args:
+            seen_emails: Addresses already recorded; mutated in place.
+            results: Fact list to append to; mutated in place.
+        """
+        import subprocess
+
+        for host in _MACOS_KEYCHAIN_MAIL_HOSTS:
+            argv = ["security", "find-internet-password", "-s", host]
+            try:
+                proc = subprocess.run(
+                    argv,
+                    capture_output=True,
+                    text=True,
+                    timeout=10,
+                    check=False,
+                )
+            except FileNotFoundError as e:
+                logger.warning(
+                    "Cannot read mail accounts from the macOS Keychain: the "
+                    "'security' command is missing (%s). It ships with macOS at "
+                    "/usr/bin/security — check that /usr/bin is on PATH.",
+                    e,
+                )
+                return
+            except (subprocess.SubprocessError, OSError) as e:
+                # One slow or wedged host must not hide the other providers.
+                logger.warning("Keychain lookup for %s failed to run: %s", host, e)
+                continue
+
+            if proc.returncode == _SECURITY_ITEM_NOT_FOUND:
+                logger.debug("No keychain entry for mail host %s", host)
+                continue
+            if proc.returncode != 0:
+                logger.debug(
+                    "Keychain lookup for %s exited %s: %s",
+                    host,
+                    proc.returncode,
+                    proc.stderr.strip(),
+                )
+                continue
+            if not proc.stdout.strip():
+                logger.warning(
+                    "Keychain lookup for %s succeeded but printed no attributes; "
+                    "the 'security find-internet-password' output format may have "
+                    "changed. Mail accounts from the Keychain were skipped — run "
+                    "`%s` by hand to compare.",
+                    host,
+                    " ".join(argv),
+                )
+                continue
+
+            for match in _EMAIL_PATTERN.finditer(proc.stdout):
+                self._append_email_fact(match.group(0), seen_emails, results)
+
+    def _scan_thunderbird(self, seen_emails: set, results: List[Dict]) -> None:
+        """Scan every Thunderbird profile's prefs.js for account addresses.
+
+        Args:
+            seen_emails: Addresses already recorded; mutated in place.
+            results: Fact list to append to; mutated in place.
+        """
         email_pref_pattern = re.compile(
             r'user_pref\("mail\.identity\.id\d+\.useremail"\s*,\s*"([^"]+)"\)'
         )
 
-        try:
-            for entry in os.scandir(str(thunderbird_root)):
-                if not entry.is_dir():
-                    continue
-                prefs_path = Path(entry.path) / "prefs.js"
+        for thunderbird_root in self._thunderbird_profile_roots():
+            try:
+                with os.scandir(str(thunderbird_root)) as entries:
+                    profile_dirs = [Path(e.path) for e in entries if e.is_dir()]
+            except PermissionError as e:
+                logger.warning(
+                    "%s",
+                    _permission_denied_message(
+                        "Thunderbird profiles", thunderbird_root, e
+                    ),
+                )
+                continue
+            except OSError as e:
+                logger.debug(
+                    "Cannot list Thunderbird profiles in %s: %s", thunderbird_root, e
+                )
+                continue
+
+            for profile_dir in profile_dirs:
+                prefs_path = profile_dir / "prefs.js"
                 if not prefs_path.exists():
                     continue
-
                 try:
                     content = prefs_path.read_text(encoding="utf-8", errors="replace")
-                    for match in email_pref_pattern.finditer(content):
-                        email = match.group(1).lower().strip()
-                        if email in seen_emails:
-                            continue
-                        seen_emails.add(email)
+                except PermissionError as e:
+                    logger.warning(
+                        "%s",
+                        _permission_denied_message(
+                            "Thunderbird preferences", prefs_path, e
+                        ),
+                    )
+                    continue
+                except (OSError, UnicodeDecodeError) as e:
+                    logger.debug("Failed to read %s: %s", prefs_path, e)
+                    continue
 
-                        domain = email.split("@")[1] if "@" in email else "unknown"
-                        provider = domain.split(".")[0]
+                for match in email_pref_pattern.finditer(content):
+                    self._append_email_fact(
+                        match.group(1), seen_emails, results, "Thunderbird"
+                    )
 
-                        results.append(
-                            _make_fact(
-                                content=f"Email account: {email} (Thunderbird)",
-                                context="unclassified",
-                                entity=f"service:{provider}",
-                                sensitive=True,
-                            )
-                        )
-                except (OSError, UnicodeDecodeError):
-                    pass
-        except (PermissionError, OSError):
-            pass
+    def _scan_apple_mail(self, seen_emails: set, results: List[Dict]) -> None:
+        """Scan Apple Mail's account plists for configured addresses.
+
+        Reads ``~/Library/Mail/V*/MailData/Accounts.plist`` plus the Mail
+        preferences plist in both its pre-Catalina and containerized locations.
+        ``~/Library/Mail`` is protected by macOS TCC, so a denial is reported
+        with the remedy.
+
+        Args:
+            seen_emails: Addresses already recorded; mutated in place.
+            results: Fact list to append to; mutated in place.
+        """
+        # Enumerate with scandir, not Path.glob: glob SWALLOWS PermissionError
+        # and yields nothing, which is exactly the silent-empty result this
+        # scanner exists to avoid on a Mac without Full Disk Access.
+        plist_paths: List[Path] = []
+        mail_dir = self._home / "Library" / "Mail"
+        if mail_dir.is_dir():
+            try:
+                with os.scandir(str(mail_dir)) as entries:
+                    version_dirs = [
+                        Path(e.path)
+                        for e in entries
+                        if e.is_dir() and e.name.startswith("V")
+                    ]
+            except PermissionError as e:
+                logger.warning(
+                    "%s", _permission_denied_message("Apple Mail accounts", mail_dir, e)
+                )
+                version_dirs = []
+            except OSError as e:
+                logger.debug("Cannot list Apple Mail data in %s: %s", mail_dir, e)
+                version_dirs = []
+
+            for version_dir in sorted(version_dirs):
+                accounts_plist = version_dir / "MailData" / "Accounts.plist"
+                if accounts_plist.exists():
+                    plist_paths.append(accounts_plist)
+
+        # Mail has been containerized since Catalina; the legacy location is
+        # kept for older systems.
+        prefs_candidates = (
+            self._home / "Library" / "Preferences" / "com.apple.mail.plist",
+            self._home
+            / "Library"
+            / "Containers"
+            / "com.apple.mail"
+            / "Data"
+            / "Library"
+            / "Preferences"
+            / "com.apple.mail.plist",
+        )
+        plist_paths.extend(path for path in prefs_candidates if path.exists())
+
+        for plist_path in plist_paths:
+            try:
+                with open(plist_path, "rb") as f:
+                    data = plistlib.load(f)
+            except PermissionError as e:
+                logger.warning(
+                    "%s",
+                    _permission_denied_message("Apple Mail accounts", plist_path, e),
+                )
+                continue
+            except (OSError, ValueError, plistlib.InvalidFileException) as e:
+                logger.debug("Failed to read Apple Mail plist %s: %s", plist_path, e)
+                continue
+
+            for email in _collect_plist_emails(data):
+                self._append_email_fact(email, seen_emails, results, "Apple Mail")
+
+    def _scan_evolution(self, seen_emails: set, results: List[Dict]) -> None:
+        """Scan Evolution account sources for configured addresses.
+
+        Evolution stores one INI file per account under
+        ``~/.config/evolution/sources/``; the address lives in
+        ``[Mail Identity] -> Address``.
+
+        Args:
+            seen_emails: Addresses already recorded; mutated in place.
+            results: Fact list to append to; mutated in place.
+        """
+        sources_dir = self._home / ".config" / "evolution" / "sources"
+        if not sources_dir.is_dir():
+            return
+
+        # scandir, not Path.glob — glob swallows PermissionError and would make
+        # an unreadable sources dir look like "no accounts configured".
+        try:
+            with os.scandir(str(sources_dir)) as entries:
+                source_paths = sorted(
+                    Path(e.path) for e in entries if e.name.endswith(".source")
+                )
+        except PermissionError as e:
+            logger.warning(
+                "%s", _permission_denied_message("Evolution accounts", sources_dir, e)
+            )
+            return
+        except OSError as e:
+            logger.debug("Cannot list Evolution sources in %s: %s", sources_dir, e)
+            return
+
+        for source_path in source_paths:
+            parser = configparser.ConfigParser(interpolation=None, strict=False)
+            try:
+                parser.read_string(
+                    source_path.read_text(encoding="utf-8", errors="replace")
+                )
+            except PermissionError as e:
+                logger.warning(
+                    "%s",
+                    _permission_denied_message("Evolution accounts", source_path, e),
+                )
+                continue
+            except (OSError, configparser.Error) as e:
+                logger.debug("Failed to parse Evolution source %s: %s", source_path, e)
+                continue
+
+            if not parser.has_section("Mail Identity"):
+                continue
+            address = parser["Mail Identity"].get("Address", "").strip()
+            if address:
+                self._append_email_fact(address, seen_emails, results, "Evolution")
 
     def _scan_outlook_registry(self, seen_emails: set, results: List[Dict]) -> None:
         """Scan Outlook registry keys for email account addresses."""
@@ -2917,6 +3749,8 @@ class SystemDiscovery:
         Returns:
             Dict mapping source name -> list of discovered fact dicts.
             Example: {"file_system": [...], "git_repos": [...], ...}
+            A source with no scanner for the running platform is logged by name
+            and mapped to an empty list, never silently omitted.
         """
         all_sources = [
             "file_system",
@@ -2965,6 +3799,9 @@ class SystemDiscovery:
         results: Dict[str, List[Dict]] = {}
 
         for source_name in sources:
+            if unsupported_reason(source_name):
+                results[source_name] = _log_unsupported(source_name)
+                continue
             scanner = scan_map.get(source_name)
             if scanner is None:
                 continue

--- a/src/gaia/agents/base/discovery.py
+++ b/src/gaia/agents/base/discovery.py
@@ -347,7 +347,8 @@ _SECURITY_ITEM_NOT_FOUND = 44
 _MACOS_APP_DIRS: Tuple[Path, ...] = (Path("/Applications"),)
 
 # System-wide freedesktop entry directories, including the Flatpak and Snap
-# export dirs — that is how those two surface their GUI apps.
+# export dirs — that is how those two surface their GUI apps. Also the spec
+# default when XDG_DATA_DIRS is unset; see _linux_desktop_dirs.
 _LINUX_DESKTOP_DIRS: Tuple[Path, ...] = (
     Path("/usr/share/applications"),
     Path("/usr/local/share/applications"),
@@ -635,7 +636,10 @@ def _safe_copy_and_query_sqlite(
 ) -> List[tuple]:
     """Copy a SQLite DB to temp dir and query it (avoids lock issues).
 
-    Browsers hold locks on their databases; copying first is required.
+    Browsers hold locks on their databases; copying first is required. The
+    ``-wal``/``-shm`` sidecars are copied too — Safari's History.db and
+    Firefox's places.sqlite run in WAL mode, so the most recent visits (exactly
+    what a 30-day scan wants) live in the -wal until the next checkpoint.
 
     Args:
         db_path: The database to copy and read.
@@ -652,10 +656,15 @@ def _safe_copy_and_query_sqlite(
     if not db_path.exists():
         return []
     tmp_path = None
+    sidecar_suffixes = ("-wal", "-shm")
     try:
         tmp_fd, tmp_path = tempfile.mkstemp(suffix=".db")
         os.close(tmp_fd)
         shutil.copy2(str(db_path), tmp_path)
+        for suffix in sidecar_suffixes:
+            sidecar = db_path.with_name(db_path.name + suffix)
+            if sidecar.exists():
+                shutil.copy2(str(sidecar), tmp_path + suffix)
         conn = sqlite3.connect(tmp_path)
         try:
             cursor = conn.execute(query, params)
@@ -672,10 +681,13 @@ def _safe_copy_and_query_sqlite(
         return []
     finally:
         if tmp_path:
-            try:
-                os.unlink(tmp_path)
-            except OSError:
-                pass
+            for path in (tmp_path, *(tmp_path + s for s in sidecar_suffixes)):
+                try:
+                    os.unlink(path)
+                except FileNotFoundError:
+                    pass
+                except OSError as e:
+                    logger.debug("Could not remove temp database copy %s: %s", path, e)
 
 
 def _categorize_app(app_name: str) -> str:
@@ -821,6 +833,40 @@ def _log_unsupported(source: str) -> List[Dict]:
     return []
 
 
+def _linux_desktop_dirs(home: Path) -> List[Path]:
+    """Resolve the freedesktop application directories for this session.
+
+    Honors ``XDG_DATA_HOME`` and ``XDG_DATA_DIRS``. On Nix, Guix, or any
+    custom-prefix install the applications live nowhere else, so hardcoding
+    /usr/share returns [] on a machine full of apps.
+
+    Args:
+        home: The user's home directory.
+
+    Returns:
+        Application directories in search order, deduplicated. Directories that
+        do not exist are included; the caller skips them.
+    """
+    data_home = Path(os.environ.get("XDG_DATA_HOME") or home / ".local" / "share")
+    # The XDG spec fixes the separator as ":" regardless of platform.
+    data_dirs = [
+        Path(p) for p in (os.environ.get("XDG_DATA_DIRS") or "").split(":") if p.strip()
+    ]
+
+    candidates: List[Path] = [data_home / "applications"]
+    candidates.extend(d / "applications" for d in data_dirs)
+    candidates.append(data_home / "flatpak" / "exports" / "share" / "applications")
+    candidates.extend(_LINUX_DESKTOP_DIRS)
+
+    seen = set()
+    ordered: List[Path] = []
+    for path in candidates:
+        if str(path) not in seen:
+            seen.add(str(path))
+            ordered.append(path)
+    return ordered
+
+
 def _permission_denied_message(label: str, path: Path, error: OSError) -> str:
     """Build an actionable message for a permission-denied read.
 
@@ -868,9 +914,10 @@ class SystemDiscovery:
         """Locate Chromium-family browser profiles for the running platform.
 
         Covers Chrome and Edge on all three platforms, plus the ``chromium``
-        distro package on Linux. Within each user-data root both the default
-        profile and every additional ``Profile N`` directory are returned, so a
-        user with more than one browser profile is not scanned half-blind.
+        distro package and the Snap and Flatpak sandbox locations on Linux.
+        Within each user-data root both the default profile and every additional
+        ``Profile N`` directory are returned, so a user with more than one
+        browser profile is not scanned half-blind.
 
         Returns:
             List of ``(browser_label, profile_dir)`` tuples for profile
@@ -892,29 +939,54 @@ class SystemDiscovery:
             ]
         elif platform == "linux":
             config = self._home / ".config"
+            snap = self._home / "snap"
+            flatpak = self._home / ".var" / "app"
             roots = [
                 ("Chrome", config / "google-chrome"),
                 ("Edge", config / "microsoft-edge"),
                 ("Chromium", config / "chromium"),
+                # Ubuntu ships Chromium as a snap by default, and Flatpak
+                # installs redirect $HOME — neither writes to ~/.config.
+                ("Chromium (Snap)", snap / "chromium" / "common" / "chromium"),
+                (
+                    "Chromium (Flatpak)",
+                    flatpak / "org.chromium.Chromium" / "config" / "chromium",
+                ),
+                (
+                    "Chrome (Flatpak)",
+                    flatpak / "com.google.Chrome" / "config" / "google-chrome",
+                ),
+                (
+                    "Edge (Flatpak)",
+                    flatpak / "com.microsoft.Edge" / "config" / "microsoft-edge",
+                ),
             ]
         else:
             return []
 
         profiles: List[Tuple[str, Path]] = []
         for browser, root in roots:
-            if not root.is_dir():
-                continue
-            candidates = [root / "Default"] + sorted(root.glob("Profile *"))
+            # scandir, not Path.glob: glob swallows PermissionError and yields
+            # nothing, which is the silent-empty result this scanner avoids.
             try:
-                for profile_dir in candidates:
-                    if profile_dir.is_dir():
-                        profiles.append(
-                            (f"{browser} ({profile_dir.name})", profile_dir)
-                        )
+                with os.scandir(str(root)) as entries:
+                    names = sorted(
+                        e.name
+                        for e in entries
+                        if e.is_dir()
+                        and (e.name == "Default" or e.name.startswith("Profile "))
+                    )
+            except (FileNotFoundError, NotADirectoryError):
+                continue
             except PermissionError as e:
                 logger.warning(
                     "%s", _permission_denied_message(f"{browser} profiles", root, e)
                 )
+                continue
+            except OSError as e:
+                logger.debug("Cannot list %s profiles in %s: %s", browser, root, e)
+                continue
+            profiles.extend((f"{browser} ({name})", root / name) for name in names)
         return profiles
 
     def _firefox_profile_roots(self) -> List[Path]:
@@ -1477,10 +1549,10 @@ class SystemDiscovery:
     def _scan_linux_installed_apps(self) -> List[Dict]:
         """Scan Linux ``.desktop`` entries for installed GUI applications.
 
-        Covers the system, user, Flatpak, and Snap application directories —
-        Flatpak and Snap both export a ``.desktop`` file per GUI app, so no
-        package-manager subprocess is needed. Entries hidden from menus
-        (``NoDisplay``, ``Hidden``) and non-application types are skipped.
+        Covers every directory on ``XDG_DATA_DIRS``/``XDG_DATA_HOME`` plus the
+        Flatpak and Snap export dirs — both export a ``.desktop`` file per GUI
+        app, so no package-manager subprocess is needed. Entries hidden from
+        menus (``NoDisplay``, ``Hidden``) and non-application types are skipped.
 
         Returns:
             List of discovered fact dicts, one per unique application.
@@ -1488,19 +1560,12 @@ class SystemDiscovery:
         results: List[Dict] = []
         seen_apps: set = set()
 
-        local_share = self._home / ".local" / "share"
-        desktop_dirs = [
-            *_LINUX_DESKTOP_DIRS,
-            local_share / "applications",
-            local_share / "flatpak" / "exports" / "share" / "applications",
-        ]
-
-        for desktop_dir in desktop_dirs:
-            if not desktop_dir.is_dir():
-                continue
+        for desktop_dir in _linux_desktop_dirs(self._home):
             try:
                 with os.scandir(str(desktop_dir)) as scan:
                     entries = sorted(scan, key=lambda e: e.name)
+            except (FileNotFoundError, NotADirectoryError):
+                continue
             except PermissionError as e:
                 logger.warning(
                     "%s", _permission_denied_message("installed apps", desktop_dir, e)
@@ -1534,6 +1599,11 @@ class SystemDiscovery:
         parser = configparser.ConfigParser(interpolation=None, strict=False)
         try:
             parser.read_string(path.read_text(encoding="utf-8", errors="replace"))
+        except PermissionError as e:
+            logger.warning(
+                "%s", _permission_denied_message("an installed app", path, e)
+            )
+            return ""
         except (OSError, configparser.Error) as e:
             logger.debug("Failed to parse desktop entry %s: %s", path, e)
             return ""
@@ -1935,27 +2005,31 @@ class SystemDiscovery:
             try:
                 self._scan_credential_manager(seen_emails, results)
             except Exception as e:
-                logger.debug("Credential Manager scan failed: %s", e)
+                # A broken scan and an empty one both look like "no accounts"
+                # to the user, so say which one happened.
+                logger.warning(
+                    "Credential Manager scan failed, no accounts read from it: %s", e
+                )
         elif platform == "darwin":
             try:
                 self._scan_macos_keychain(seen_emails, results)
             except Exception as e:
-                # A broken scan and an empty one both look like "no accounts"
-                # to the user, so say which one happened.
                 logger.warning("Keychain scan failed, no accounts read from it: %s", e)
 
         # 2. Thunderbird profiles (prefs.js) — all platforms
         try:
             self._scan_thunderbird(seen_emails, results)
         except Exception as e:
-            logger.debug("Thunderbird scan failed: %s", e)
+            logger.warning("Thunderbird scan failed, no accounts read from it: %s", e)
 
         # 3. Platform identity store
         if platform == "win32":
             try:
                 self._scan_outlook_registry(seen_emails, results)
             except Exception as e:
-                logger.debug("Outlook registry scan failed: %s", e)
+                logger.warning(
+                    "Outlook registry scan failed, no accounts read from it: %s", e
+                )
         elif platform == "darwin":
             try:
                 self._scan_apple_mail(seen_emails, results)
@@ -1979,14 +2053,22 @@ class SystemDiscovery:
         if sys.platform != "win32":
             return
 
+        # CREATE_NO_WINDOW is defined only on Windows builds of subprocess.
+        kwargs: Dict[str, Any] = {}
+        if os.name == "nt":
+            kwargs["creationflags"] = subprocess.CREATE_NO_WINDOW
+
         try:
             output = subprocess.check_output(
                 ["cmdkey", "/list"],
                 text=True,
                 timeout=10,
-                creationflags=subprocess.CREATE_NO_WINDOW,
+                **kwargs,
             )
-        except (subprocess.SubprocessError, FileNotFoundError, OSError):
+        except (subprocess.SubprocessError, FileNotFoundError, OSError) as e:
+            logger.warning(
+                "Credential Manager scan failed, no accounts read from it: %s", e
+            )
             return
 
         # Look for email-related targets and extract user fields
@@ -3106,8 +3188,15 @@ class SystemDiscovery:
 
         Returns:
             List of profile fact dicts for frequently launched applications.
+            Empty on a platform with no branch — reported, never silent.
         """
-        if os.name != "nt" or winreg is None:
+        if unsupported_reason("windows_userassist"):
+            return _log_unsupported("windows_userassist")
+        if winreg is None:
+            logger.warning(
+                "UserAssist scan skipped: the winreg module is unavailable on this "
+                "interpreter, so no app-launch frequency was read."
+            )
             return []
 
         import codecs
@@ -3299,17 +3388,17 @@ class SystemDiscovery:
         - **Linux**: parses ``~/.local/share/recently-used.xbel``.
 
         Returns:
-            List of profile fact dicts for file-type usage patterns.
+            List of profile fact dicts for file-type usage patterns. Empty on a
+            platform with no branch — reported, never silent.
         """
-        import sys
-
-        if sys.platform == "win32":
+        platform = _platform_key()
+        if platform == "win32":
             return self._scan_windows_recent_files()
-        elif sys.platform == "darwin":
+        if platform == "darwin":
             return self._scan_macos_recent_files()
-        elif sys.platform.startswith("linux"):
+        if platform == "linux":
             return self._scan_linux_recent_files()
-        return []
+        return _log_unsupported("recent_file_types")
 
     def _scan_windows_recent_files(self) -> List[Dict]:
         """Read Windows Recent folder to detect recently opened file type patterns.
@@ -3661,12 +3750,11 @@ class SystemDiscovery:
         applications are installed and actively used.
 
         Returns:
-            List of profile fact dicts for detected macOS applications.
+            List of profile fact dicts for detected macOS applications. Empty on
+            a platform with no branch — reported, never silent.
         """
-        import sys
-
-        if sys.platform != "darwin":
-            return []
+        if unsupported_reason("macos_app_usage"):
+            return _log_unsupported("macos_app_usage")
 
         # Known app data dir names -> friendly app names
         APP_SUPPORT_MAP = {

--- a/src/gaia/cli.py
+++ b/src/gaia/cli.py
@@ -6511,6 +6511,33 @@ Example output:
 _INFER_REFRESH_DAYS = 30  # Re-run LLM inference after this many days
 
 
+def _collect_signal(source_key: str, scanner):
+    """Run `scanner` unless this platform has no branch for `source_key`.
+
+    Applies the same platform gate as ``scan_all``, which a direct scanner call
+    bypasses — otherwise an unsupported source is indistinguishable from a user
+    who genuinely has nothing to find.
+
+    Args:
+        source_key: A discovery source name as used by ``scan_all``.
+        scanner: Zero-argument callable returning the scanner's fact dicts.
+
+    Returns:
+        The scanner's fact dicts, or [] after printing why there are none.
+    """
+    from gaia.agents.base.discovery import unsupported_reason
+
+    reason = unsupported_reason(source_key)
+    if reason:
+        print(f"\n  Skipped: {reason}")
+        return []
+    try:
+        return scanner()
+    except Exception as e:
+        print(f"\n  '{source_key}' scan failed, continuing without it: {e}")
+        return []
+
+
 def _bootstrap_infer():
     """Phase 3 (optional): LLM-assisted profile inference from browser history + system data.
 
@@ -6564,8 +6591,10 @@ def _bootstrap_infer():
                             return
         finally:
             store_check.close()
-    except Exception:
-        pass  # Non-critical — proceed anyway
+    except Exception as e:
+        # Non-critical — inference still runs, but say why the staleness check
+        # did not, or a broken store looks like "no facts yet".
+        print(f"  Could not check for existing inferred facts: {e}")
 
     # Explicit consent for browser history access
     try:
@@ -6586,92 +6615,73 @@ def _bootstrap_infer():
 
     # 1. Browser history (top domains, visit counts)
     if use_browser:
-        try:
-            browser_results = discovery.scan_browser_history(days=30)
-            if browser_results:
-                lines = []
-                for item in browser_results[:40]:
-                    # content is "Frequently visited: domain.com (N visits)"
-                    lines.append(f"  {item['content']}")
-                sections.append(
-                    "BROWSER HISTORY (top domains, last 30 days):\n" + "\n".join(lines)
-                )
-        except Exception:
-            pass
+        browser_results = _collect_signal(
+            "browser_history", lambda: discovery.scan_browser_history(days=30)
+        )
+        if browser_results:
+            # content is "Frequently visited: domain.com (N visits)"
+            lines = [f"  {item['content']}" for item in browser_results[:40]]
+            sections.append(
+                "BROWSER HISTORY (top domains, last 30 days):\n" + "\n".join(lines)
+            )
 
     # 2. Installed applications
-    try:
-        app_results = discovery.scan_installed_apps()
-        if app_results:
-            # Extract just the app names from content strings like "Installed app: VS Code"
-            apps = []
-            for item in app_results:
-                content = item.get("content", "")
-                if content.startswith("Installed app: "):
-                    apps.append(content[len("Installed app: ") :].strip())
-            if apps:
-                sections.append("INSTALLED APPS:\n  " + ", ".join(apps))
-    except Exception:
-        pass
+    app_results = _collect_signal("installed_apps", discovery.scan_installed_apps)
+    apps = [
+        item["content"][len("Installed app: ") :].strip()
+        for item in app_results
+        if item.get("content", "").startswith("Installed app: ")
+    ]
+    if apps:
+        sections.append("INSTALLED APPS:\n  " + ", ".join(apps))
 
     # 3. Git identity (name / employer domain — not raw email)
-    try:
-        git_results = discovery.scan_git_identity()
-        if git_results:
-            git_lines = []
-            for item in git_results:
-                # Skip sensitive (raw email) items
-                if not item.get("sensitive") and item.get("content"):
-                    git_lines.append(f"  {item['content']}")
-            if git_lines:
-                sections.append("GIT IDENTITY:\n" + "\n".join(git_lines))
-    except Exception:
-        pass
+    git_results = _collect_signal("git_identity", discovery.scan_git_identity)
+    git_lines = [
+        f"  {item['content']}"
+        for item in git_results
+        if not item.get("sensitive") and item.get("content")
+    ]
+    if git_lines:
+        sections.append("GIT IDENTITY:\n" + "\n".join(git_lines))
 
     # 4. Project languages / manifests (non-sensitive)
-    try:
-        manifest_results = discovery.scan_project_manifests()
-        if manifest_results:
-            manifest_lines = []
-            for item in manifest_results[:10]:
-                if not item.get("sensitive") and item.get("content"):
-                    manifest_lines.append(f"  {item['content']}")
-            if manifest_lines:
-                sections.append(
-                    "PROJECT MANIFESTS (sample):\n" + "\n".join(manifest_lines)
-                )
-    except Exception:
-        pass
+    manifest_results = _collect_signal(
+        "project_manifests", discovery.scan_project_manifests
+    )
+    manifest_lines = [
+        f"  {item['content']}"
+        for item in manifest_results[:10]
+        if not item.get("sensitive") and item.get("content")
+    ]
+    if manifest_lines:
+        sections.append("PROJECT MANIFESTS (sample):\n" + "\n".join(manifest_lines))
 
-    # 5. App launch frequency (UserAssist — covers consumer apps like Spotify, Outlook)
-    try:
-        userassist_results = discovery.scan_windows_userassist()
-        if userassist_results:
-            lines = [f"  {item['content']}" for item in userassist_results[:20]]
-            sections.append(
-                "FREQUENTLY LAUNCHED APPS (actual usage frequency):\n"
-                + "\n".join(lines)
-            )
-    except Exception:
-        pass
+    # 5. App launch frequency — covers consumer apps like Spotify and Outlook
+    usage_results = _collect_signal(
+        "windows_userassist", discovery.scan_windows_userassist
+    ) + _collect_signal("macos_app_usage", discovery.scan_macos_app_usage)
+    if usage_results:
+        lines = [f"  {item['content']}" for item in usage_results[:20]]
+        sections.append(
+            "FREQUENTLY LAUNCHED APPS (actual usage frequency):\n" + "\n".join(lines)
+        )
 
     # 6. Recent file type patterns
-    try:
-        filetype_results = discovery.scan_recent_file_types()
-        if filetype_results:
-            lines = [f"  {item['content']}" for item in filetype_results]
-            sections.append("RECENT FILE TYPES (work patterns):\n" + "\n".join(lines))
-    except Exception:
-        pass
+    filetype_results = _collect_signal(
+        "recent_file_types", discovery.scan_recent_file_types
+    )
+    if filetype_results:
+        lines = [f"  {item['content']}" for item in filetype_results]
+        sections.append("RECENT FILE TYPES (work patterns):\n" + "\n".join(lines))
 
     # 7. Gaming and media
-    try:
-        gaming_results = discovery.scan_gaming_and_media()
-        if gaming_results:
-            lines = [f"  {item['content']}" for item in gaming_results]
-            sections.append("GAMING AND MEDIA:\n" + "\n".join(lines))
-    except Exception:
-        pass
+    gaming_results = _collect_signal(
+        "gaming_and_media", discovery.scan_gaming_and_media
+    )
+    if gaming_results:
+        lines = [f"  {item['content']}" for item in gaming_results]
+        sections.append("GAMING AND MEDIA:\n" + "\n".join(lines))
 
     print(" done.")
 

--- a/src/gaia/ui/routers/memory.py
+++ b/src/gaia/ui/routers/memory.py
@@ -1178,7 +1178,10 @@ def stream_discovery():
 
     def _generate():
         try:
-            from gaia.agents.base.discovery import SystemDiscovery
+            from gaia.agents.base.discovery import (
+                SystemDiscovery,
+                unsupported_reason,
+            )
 
             discovery = SystemDiscovery()
 
@@ -1204,12 +1207,16 @@ def stream_discovery():
             for source_key in _DISCOVERY_SOURCES:
                 label = _DISCOVERY_SOURCE_LABELS.get(source_key, source_key)
                 yield _sse({"type": "log", "message": f"Scanning {label}..."})
+                reason = unsupported_reason(source_key)
+                if reason:
+                    yield _sse({"type": "log", "message": f"  {label}: {reason}"})
+                    continue
                 scanner = scan_map.get(source_key)
                 if scanner is None:
                     yield _sse(
                         {
                             "type": "log",
-                            "message": f"  {label}: not available on this platform",
+                            "message": f"  {label}: no scanner is registered for this source",
                         }
                     )
                     continue

--- a/src/gaia/ui/routers/memory.py
+++ b/src/gaia/ui/routers/memory.py
@@ -9,7 +9,7 @@ import os
 import threading
 import uuid
 from datetime import datetime
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Tuple
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
 from pydantic import BaseModel, field_validator
@@ -1164,6 +1164,33 @@ def _sse(event: dict) -> str:
     return f"data: {json.dumps(event)}\n\n"
 
 
+def _scan_or_reason(source_key: str, scanner) -> Tuple[List[Dict], Optional[str]]:
+    """Run `scanner`, unless this platform has no branch for `source_key`.
+
+    Callers that invoke a scanner directly bypass the ``scan_all`` platform
+    gate, so a source with no branch here would stream nothing and read as
+    "you have none" rather than "GAIA cannot look here".
+
+    Args:
+        source_key: A discovery source name as used by ``scan_all``.
+        scanner: Zero-argument callable returning the scanner's fact dicts.
+
+    Returns:
+        ``(items, message)``. `message` is a user-facing line to stream when the
+        source cannot run or failed, and is None when the scan succeeded.
+    """
+    from gaia.agents.base.discovery import unsupported_reason
+
+    reason = unsupported_reason(source_key)
+    if reason:
+        return [], f"  {reason}"
+    try:
+        return scanner(), None
+    except Exception as e:
+        cid = _log_server_error(f"inference scanner '{source_key}' failed", e)
+        return [], f"  {source_key} unavailable — see server logs (id={cid})"
+
+
 @router.get("/api/memory/stream-discovery")
 def stream_discovery():
     """Stream system discovery findings as SSE.
@@ -1292,35 +1319,31 @@ def stream_inference(include_browser: bool = Query(False)):
 
             if include_browser:
                 yield _sse({"type": "log", "message": "Reading browser history..."})
-                try:
-                    browser_results = discovery.scan_browser_history(days=30)
-                    if browser_results:
-                        lines = [f"  {r['content']}" for r in browser_results[:40]]
-                        sections.append(
-                            "BROWSER HISTORY (top domains, last 30 days):\n"
-                            + "\n".join(lines)
-                        )
-                        yield _sse(
-                            {
-                                "type": "log",
-                                "message": f"  Collected {len(browser_results)} domains",
-                            }
-                        )
-                except Exception as e:
-                    cid = _log_server_error("browser history scan failed", e)
+                browser_results, msg = _scan_or_reason(
+                    "browser_history", lambda: discovery.scan_browser_history(days=30)
+                )
+                if msg:
+                    yield _sse({"type": "log", "message": msg})
+                elif browser_results:
+                    lines = [f"  {r['content']}" for r in browser_results[:40]]
+                    sections.append(
+                        "BROWSER HISTORY (top domains, last 30 days):\n"
+                        + "\n".join(lines)
+                    )
                     yield _sse(
                         {
                             "type": "log",
-                            "message": (
-                                "  Browser history unavailable — "
-                                f"see server logs (id={cid})"
-                            ),
+                            "message": f"  Collected {len(browser_results)} domains",
                         }
                     )
 
             yield _sse({"type": "log", "message": "Collecting installed apps..."})
-            try:
-                app_results = discovery.scan_installed_apps()
+            app_results, msg = _scan_or_reason(
+                "installed_apps", discovery.scan_installed_apps
+            )
+            if msg:
+                yield _sse({"type": "log", "message": msg})
+            else:
                 apps = [
                     r["content"][len("Installed app: ") :].strip()
                     for r in app_results
@@ -1329,95 +1352,90 @@ def stream_inference(include_browser: bool = Query(False)):
                 if apps:
                     sections.append("INSTALLED APPS:\n  " + ", ".join(apps))
                     yield _sse({"type": "log", "message": f"  Found {len(apps)} apps"})
-            except Exception:
-                pass
-
-            yield _sse({"type": "log", "message": "Collecting app usage frequency..."})
-            try:
-                ua_scanner = getattr(discovery, "scan_windows_userassist", None)
-                if ua_scanner:
-                    ua_results = ua_scanner()
-                    if ua_results:
-                        lines = [f"  {r['content']}" for r in ua_results[:20]]
-                        sections.append(
-                            "FREQUENTLY LAUNCHED APPS:\n" + "\n".join(lines)
-                        )
-                        yield _sse(
-                            {
-                                "type": "log",
-                                "message": f"  Found {len(ua_results)} usage signals",
-                            }
-                        )
-            except Exception:
-                pass
 
             yield _sse({"type": "log", "message": "Scanning recent file types..."})
-            try:
-                ft_scanner = getattr(discovery, "scan_recent_file_types", None)
-                if ft_scanner:
-                    ft_results = ft_scanner()
-                    if ft_results:
-                        lines = [f"  {r['content']}" for r in ft_results]
-                        sections.append("RECENT FILE TYPES:\n" + "\n".join(lines))
-            except Exception:
-                pass
+            ft_results, msg = _scan_or_reason(
+                "recent_file_types", discovery.scan_recent_file_types
+            )
+            if msg:
+                yield _sse({"type": "log", "message": msg})
+            elif ft_results:
+                lines = [f"  {r['content']}" for r in ft_results]
+                sections.append("RECENT FILE TYPES:\n" + "\n".join(lines))
 
             yield _sse({"type": "log", "message": "Scanning gaming & media..."})
-            try:
-                gm_results = discovery.scan_gaming_and_media()
-                if gm_results:
-                    lines = [f"  {r['content']}" for r in gm_results]
-                    sections.append("GAMING AND MEDIA:\n" + "\n".join(lines))
-            except Exception:
-                pass
+            gm_results, msg = _scan_or_reason(
+                "gaming_and_media", discovery.scan_gaming_and_media
+            )
+            if msg:
+                yield _sse({"type": "log", "message": msg})
+            elif gm_results:
+                lines = [f"  {r['content']}" for r in gm_results]
+                sections.append("GAMING AND MEDIA:\n" + "\n".join(lines))
 
             yield _sse({"type": "log", "message": "Scanning personal files..."})
-            try:
-                pf_results = discovery.scan_personal_files()
-                if pf_results:
-                    lines = [f"  {r['content']}" for r in pf_results]
-                    sections.append("PERSONAL FILES:\n" + "\n".join(lines))
-                    yield _sse(
-                        {
-                            "type": "log",
-                            "message": f"  Found {len(pf_results)} personal file insights",
-                        }
-                    )
-            except Exception:
-                pass
+            pf_results, msg = _scan_or_reason(
+                "personal_files", discovery.scan_personal_files
+            )
+            if msg:
+                yield _sse({"type": "log", "message": msg})
+            elif pf_results:
+                lines = [f"  {r['content']}" for r in pf_results]
+                sections.append("PERSONAL FILES:\n" + "\n".join(lines))
+                yield _sse(
+                    {
+                        "type": "log",
+                        "message": f"  Found {len(pf_results)} personal file insights",
+                    }
+                )
 
-            yield _sse({"type": "log", "message": "Scanning app usage..."})
-            try:
-                ua_results = discovery.scan_windows_userassist()
-                ma_results = discovery.scan_macos_app_usage()
-                combined = ua_results + ma_results
-                if combined:
-                    lines = [f"  {r['content']}" for r in combined[:20]]
-                    sections.append("FREQUENTLY USED APPS:\n" + "\n".join(lines))
-            except Exception:
-                pass
+            yield _sse({"type": "log", "message": "Scanning app usage frequency..."})
+            combined = []
+            for source_key, scanner in (
+                ("windows_userassist", discovery.scan_windows_userassist),
+                ("macos_app_usage", discovery.scan_macos_app_usage),
+            ):
+                items, msg = _scan_or_reason(source_key, scanner)
+                if msg:
+                    yield _sse({"type": "log", "message": msg})
+                else:
+                    combined.extend(items)
+            if combined:
+                lines = [f"  {r['content']}" for r in combined[:20]]
+                sections.append("FREQUENTLY USED APPS:\n" + "\n".join(lines))
+                yield _sse(
+                    {
+                        "type": "log",
+                        "message": f"  Found {len(combined)} usage signals",
+                    }
+                )
 
             yield _sse(
                 {"type": "log", "message": "Collecting git identity & projects..."}
             )
-            try:
-                git_results = discovery.scan_git_identity()
+            git_results, msg = _scan_or_reason(
+                "git_identity", discovery.scan_git_identity
+            )
+            if msg:
+                yield _sse({"type": "log", "message": msg})
+            else:
                 non_sensitive = [r for r in git_results if not r.get("sensitive")]
                 if non_sensitive:
                     lines = [f"  {r['content']}" for r in non_sensitive]
                     sections.append("GIT IDENTITY:\n" + "\n".join(lines))
-            except Exception:
-                pass
-            try:
-                manifest_results = discovery.scan_project_manifests()
+
+            manifest_results, msg = _scan_or_reason(
+                "project_manifests", discovery.scan_project_manifests
+            )
+            if msg:
+                yield _sse({"type": "log", "message": msg})
+            else:
                 non_sensitive = [r for r in manifest_results if not r.get("sensitive")][
                     :10
                 ]
                 if non_sensitive:
                     lines = [f"  {r['content']}" for r in non_sensitive]
                     sections.append("PROJECT MANIFESTS (sample):\n" + "\n".join(lines))
-            except Exception:
-                pass
 
             if not sections:
                 yield _sse(

--- a/tests/unit/test_memory_discovery.py
+++ b/tests/unit/test_memory_discovery.py
@@ -20,6 +20,7 @@ import logging
 import os
 import plistlib
 import sqlite3
+import tempfile
 import time
 from pathlib import Path
 from unittest.mock import MagicMock, patch
@@ -53,6 +54,9 @@ def isolated_disc(tmp_path):
     /Applications, browser profiles, registry, or mail configuration — including
     when the suite is run ON Windows, where the win32 parametrizations would
     otherwise hit the live registry and Start Menu.
+
+    XDG_DATA_HOME/XDG_DATA_DIRS are redirected into tmp_path as well: the Linux
+    app scanner resolves its search path from them, and CI runners set both.
     """
     disc = SystemDiscovery()
     disc._home = tmp_path
@@ -60,7 +64,14 @@ def isolated_disc(tmp_path):
         patch("gaia.agents.base.discovery._MACOS_APP_DIRS", ()),
         patch("gaia.agents.base.discovery._LINUX_DESKTOP_DIRS", ()),
         patch("gaia.agents.base.discovery.winreg", None),
-        patch.dict(os.environ, {"PROGRAMDATA": str(tmp_path)}),
+        patch.dict(
+            os.environ,
+            {
+                "PROGRAMDATA": str(tmp_path),
+                "XDG_DATA_HOME": str(tmp_path / ".local" / "share"),
+                "XDG_DATA_DIRS": str(tmp_path / "xdg-data-dirs"),
+            },
+        ),
     ):
         yield disc
 
@@ -1015,6 +1026,9 @@ class TestUnsupportedPlatform:
             "scan_browser_bookmarks",
             "scan_browser_history",
             "scan_email_accounts",
+            "scan_recent_file_types",
+            "scan_windows_userassist",
+            "scan_macos_app_usage",
         ],
     )
     def test_scanner_logs_the_skip_and_returns_empty(
@@ -1358,3 +1372,273 @@ class TestPermissionDenials:
         warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
         assert len(warnings) == 1
         assert "Full Disk Access" in warnings[0].getMessage()
+
+
+# ---------------------------------------------------------------------------
+# Credential Manager call contract — the call must be VALID, not merely made
+# ---------------------------------------------------------------------------
+
+
+class TestCredentialManagerContractShape:
+    """`cmdkey` is invoked as an argv list, with a timeout, and never via shell.
+
+    Regression guard: ``subprocess.CREATE_NO_WINDOW`` does not exist off
+    Windows, so referencing it unconditionally raised AttributeError under a
+    patched ``sys.platform`` — swallowed by the caller, which made every
+    "no errors on a cold Windows home" assertion vacuous.
+    """
+
+    def _run_cmdkey(self, disc, stdout=""):
+        with (
+            patch("sys.platform", "win32"),
+            patch("subprocess.check_output", return_value=stdout) as mock_out,
+        ):
+            results = []
+            disc._scan_credential_manager(set(), results)
+        return mock_out, results
+
+    def test_argv_shape_is_exact(self, isolated_disc):
+        mock_out, _ = self._run_cmdkey(isolated_disc)
+
+        assert mock_out.call_count == 1
+        argv = mock_out.call_args.args[0]
+        assert isinstance(argv, list), "argv must be a list, never a shell string"
+        assert argv == ["cmdkey", "/list"]
+
+    def test_timeout_is_set_and_shell_is_never_used(self, isolated_disc):
+        mock_out, _ = self._run_cmdkey(isolated_disc)
+        kwargs = mock_out.call_args.kwargs
+        assert kwargs.get("timeout") == 10
+        assert not kwargs.get("shell", False)
+
+    def test_no_window_flag_only_on_real_windows(self, isolated_disc):
+        """CREATE_NO_WINDOW is a Windows-only constant; passing it off-Windows raises."""
+        mock_out, _ = self._run_cmdkey(isolated_disc)
+        kwargs = mock_out.call_args.kwargs
+        assert ("creationflags" in kwargs) is (os.name == "nt")
+
+    def test_address_in_output_becomes_a_sensitive_fact(self, isolated_disc):
+        mock_out, results = self._run_cmdkey(
+            isolated_disc,
+            stdout="Target: MicrosoftOffice16_Data:live.com:alex@outlook.com\n",
+        )
+        assert results, "an address in the cmdkey dump must become a fact"
+        assert results[0]["content"] == "Email account: alex@outlook.com"
+        assert results[0]["sensitive"] is True
+
+    def test_missing_binary_is_reported_not_swallowed(self, isolated_disc, caplog):
+        """A broken scan and an empty one both look like "no accounts"."""
+        caplog.set_level(logging.INFO, logger=DISCOVERY_LOGGER)
+        with (
+            patch("sys.platform", "win32"),
+            patch("subprocess.check_output", side_effect=FileNotFoundError("cmdkey")),
+        ):
+            results = []
+            isolated_disc._scan_credential_manager(set(), results)
+
+        assert results == []
+        warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+        assert warnings, "a failed Credential Manager scan must not be silent"
+        assert "Credential Manager" in warnings[0].getMessage()
+
+    @pytest.mark.parametrize(
+        "scanner,label",
+        [
+            ("_scan_credential_manager", "Credential Manager"),
+            ("_scan_outlook_registry", "Outlook registry"),
+        ],
+    )
+    def test_windows_email_failures_warn_like_the_other_platforms(
+        self, isolated_disc, caplog, scanner, label
+    ):
+        """Windows failures were DEBUG while macOS/Linux warned — same blind spot."""
+        caplog.set_level(logging.INFO, logger=DISCOVERY_LOGGER)
+        with (
+            patch("sys.platform", "win32"),
+            patch.object(
+                isolated_disc, scanner, side_effect=RuntimeError("scan exploded")
+            ),
+        ):
+            results = isolated_disc.scan_email_accounts()
+
+        assert results == []
+        messages = [
+            r.getMessage() for r in caplog.records if r.levelno == logging.WARNING
+        ]
+        assert any(label in m for m in messages), f"{label} failure was not reported"
+
+
+# ---------------------------------------------------------------------------
+# Cold-state coverage gaps the platform branches introduced
+# ---------------------------------------------------------------------------
+
+
+class TestChromiumProfileDiscovery:
+    """Profile enumeration must survive an unreadable root, and cover Snap/Flatpak."""
+
+    def test_snap_and_flatpak_chromium_roots(self, isolated_disc, tmp_path):
+        """Ubuntu ships Chromium as a snap by default — it never writes ~/.config."""
+        _write_chromium_bookmarks(
+            tmp_path / "snap" / "chromium" / "common" / "chromium" / "Default",
+            ["https://kernel.org/doc"],
+        )
+        _write_chromium_bookmarks(
+            tmp_path
+            / ".var"
+            / "app"
+            / "com.google.Chrome"
+            / "config"
+            / "google-chrome"
+            / "Default",
+            ["https://gitlab.com/explore"],
+        )
+
+        with patch("sys.platform", "linux"):
+            results = isolated_disc.scan_browser_bookmarks()
+
+        domains = {r["content"].split()[2] for r in results}
+        assert {"kernel.org", "gitlab.com"} <= domains
+
+    @requires_chmod_denial
+    def test_unreadable_profile_root_warns_and_continues(
+        self, isolated_disc, tmp_path, caplog
+    ):
+        """Path.glob swallows PermissionError and yields [] — scandir must not.
+
+        The denied browser must be reported AND the readable one must still be
+        scanned, rather than the whole scanner aborting on the first EACCES.
+        """
+        caplog.set_level(logging.INFO, logger=DISCOVERY_LOGGER)
+        denied = tmp_path / ".config" / "google-chrome"
+        _write_chromium_bookmarks(denied / "Default", ["https://github.com/amd/gaia"])
+        _write_chromium_bookmarks(
+            tmp_path / ".config" / "chromium" / "Default",
+            ["https://stackoverflow.com/questions/1"],
+        )
+        os.chmod(denied, 0o000)
+
+        try:
+            with patch("sys.platform", "linux"):
+                results = isolated_disc.scan_browser_bookmarks()
+        finally:
+            os.chmod(denied, 0o755)
+
+        domains = {r["content"].split()[2] for r in results}
+        assert "stackoverflow.com" in domains, "one denial aborted the whole scan"
+
+        warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+        assert warnings, "an unreadable profile root must not be silent"
+        assert "Chrome profiles" in warnings[0].getMessage()
+
+    def test_missing_root_is_quiet(self, isolated_disc, caplog):
+        """A browser that simply is not installed is not a warning."""
+        caplog.set_level(logging.INFO, logger=DISCOVERY_LOGGER)
+        with patch("sys.platform", "linux"):
+            assert isolated_disc.scan_browser_bookmarks() == []
+        assert not [r for r in caplog.records if r.levelno >= logging.WARNING]
+
+
+class TestXdgDesktopDirs:
+    """A custom-prefix install (Nix, Guix) puts .desktop files nowhere else."""
+
+    def test_xdg_data_dirs_is_honored(self, isolated_disc, tmp_path):
+        prefix = tmp_path / "nix" / "profile" / "share" / "applications"
+        prefix.mkdir(parents=True)
+        (prefix / "inkscape.desktop").write_text(
+            "[Desktop Entry]\nType=Application\nName=Inkscape\nExec=inkscape %f\n",
+            encoding="utf-8",
+        )
+
+        with (
+            patch("sys.platform", "linux"),
+            patch.dict(
+                os.environ,
+                {"XDG_DATA_DIRS": str(tmp_path / "nix" / "profile" / "share")},
+            ),
+        ):
+            results = isolated_disc.scan_installed_apps()
+
+        assert any("Inkscape" in r["content"] for r in results)
+
+    def test_xdg_data_home_is_honored(self, isolated_disc, tmp_path):
+        data_home = tmp_path / "custom-data-home"
+        apps = data_home / "applications"
+        apps.mkdir(parents=True)
+        (apps / "krita.desktop").write_text(
+            "[Desktop Entry]\nType=Application\nName=Krita\n", encoding="utf-8"
+        )
+
+        with (
+            patch("sys.platform", "linux"),
+            patch.dict(os.environ, {"XDG_DATA_HOME": str(data_home)}),
+        ):
+            results = isolated_disc.scan_installed_apps()
+
+        assert any("Krita" in r["content"] for r in results)
+
+    @requires_chmod_denial
+    def test_unreadable_desktop_entry_warns(self, isolated_disc, tmp_path, caplog):
+        caplog.set_level(logging.INFO, logger=DISCOVERY_LOGGER)
+        apps = tmp_path / ".local" / "share" / "applications"
+        apps.mkdir(parents=True)
+        entry = apps / "secret.desktop"
+        entry.write_text(
+            "[Desktop Entry]\nType=Application\nName=Secret App\n", encoding="utf-8"
+        )
+        os.chmod(entry, 0o000)
+
+        try:
+            with patch("sys.platform", "linux"):
+                results = isolated_disc.scan_installed_apps()
+        finally:
+            os.chmod(entry, 0o644)
+
+        assert results == []
+        warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+        assert warnings, "an unreadable .desktop silently dropped an app"
+
+
+class TestSqliteWalSidecar:
+    """Browsers run their history DBs in WAL mode; the -wal holds recent visits."""
+
+    def test_rows_only_in_the_wal_are_read(self, isolated_disc, tmp_path):
+        profile = tmp_path / ".mozilla" / "firefox" / "abc.default"
+        _write_places_sqlite(profile, "https://old.example.com/page")
+
+        # The writer stays open across the scan: that is what makes the -wal
+        # uncheckpointed, and it is the state a running browser's DB is in.
+        # Closing it first would checkpoint the row into the main file and the
+        # assertion below would pass even without copying the sidecar.
+        conn = sqlite3.connect(str(profile / "places.sqlite"))
+        try:
+            conn.execute("PRAGMA journal_mode=WAL")
+            conn.execute("PRAGMA wal_autocheckpoint=0")
+            conn.execute(
+                "INSERT INTO moz_places VALUES (2, ?, ?, ?)",
+                ("https://fresh.example.com/page", 9, int(time.time() * 1_000_000)),
+            )
+            conn.commit()
+
+            wal = profile / "places.sqlite-wal"
+            assert (
+                wal.exists() and wal.stat().st_size > 0
+            ), "test needs a non-empty -wal to be meaningful"
+
+            with patch("sys.platform", "linux"):
+                results = isolated_disc.scan_browser_history()
+        finally:
+            conn.close()
+
+        domains = {r["content"].split()[2] for r in results}
+        assert "fresh.example.com" in domains, "the -wal sidecar was not copied"
+
+    def test_temp_copies_are_cleaned_up(self, isolated_disc, tmp_path):
+        profile = tmp_path / ".mozilla" / "firefox" / "abc.default"
+        _write_places_sqlite(profile, "https://example.com/page")
+        before = set(Path(tempfile.gettempdir()).glob("*.db*"))
+
+        with patch("sys.platform", "linux"):
+            isolated_disc.scan_browser_history()
+
+        leaked = set(Path(tempfile.gettempdir()).glob("*.db*")) - before
+        assert not leaked, f"temp database copies were left behind: {leaked}"

--- a/tests/unit/test_memory_discovery.py
+++ b/tests/unit/test_memory_discovery.py
@@ -5,15 +5,24 @@ Unit tests for SystemDiscovery — local system scanner for day-zero bootstrap.
 
 Tests cover: _classify_remote (URL hostname safety), _classify_path,
 _classify_domain, _extract_domain, scan_all returns expected structure,
-the platform guards for Windows-only methods, _classify_project,
+per-platform scanner dispatch (Windows / macOS / Linux), the macOS and Linux
+branches for apps / bookmarks / history / email, the unsupported-platform
+report, cold-state behavior, the Keychain call contract, _classify_project,
 and the scan_personal_files scanner.
 
-All tests are stdlib-only — no real filesystem scanning performed.
+All tests are stdlib-only and hermetic — every scan is rooted at a temp home,
+system application directories are patched out, and no subprocess is executed.
 """
 
-import sys
+import contextlib
+import json
+import logging
+import os
+import plistlib
+import sqlite3
+import time
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -23,7 +32,86 @@ from gaia.agents.base.discovery import (
     _classify_path,
     _classify_project,
     _classify_remote,
+    unsupported_reason,
 )
+
+DISCOVERY_LOGGER = "gaia.agents.base.discovery"
+
+# chmod(0o000) does not deny the owner on Windows, nor root anywhere, so the
+# permission-denial tests cannot create the state they assert on.
+_CHMOD_DENIES = os.name != "nt" and not (hasattr(os, "geteuid") and os.geteuid() == 0)
+requires_chmod_denial = pytest.mark.skipif(
+    not _CHMOD_DENIES, reason="chmod cannot deny the current user (Windows or root)"
+)
+
+
+@pytest.fixture
+def isolated_disc(tmp_path):
+    """SystemDiscovery rooted at an empty temp home, with no system app dirs.
+
+    Keeps every scan inside tmp_path so a test never reads the developer's real
+    /Applications, browser profiles, registry, or mail configuration — including
+    when the suite is run ON Windows, where the win32 parametrizations would
+    otherwise hit the live registry and Start Menu.
+    """
+    disc = SystemDiscovery()
+    disc._home = tmp_path
+    with (
+        patch("gaia.agents.base.discovery._MACOS_APP_DIRS", ()),
+        patch("gaia.agents.base.discovery._LINUX_DESKTOP_DIRS", ()),
+        patch("gaia.agents.base.discovery.winreg", None),
+        patch.dict(os.environ, {"PROGRAMDATA": str(tmp_path)}),
+    ):
+        yield disc
+
+
+def _write_chromium_bookmarks(profile_dir: Path, urls: list) -> None:
+    """Write a minimal Chromium Bookmarks JSON file containing `urls`."""
+    profile_dir.mkdir(parents=True, exist_ok=True)
+    (profile_dir / "Bookmarks").write_text(
+        json.dumps(
+            {
+                "roots": {
+                    "bookmark_bar": {
+                        "type": "folder",
+                        "children": [{"type": "url", "url": u} for u in urls],
+                    }
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+
+
+def _write_places_sqlite(profile_dir: Path, url: str, visit_count: int = 7) -> None:
+    """Write a minimal Firefox places.sqlite holding one bookmark and one visit."""
+    profile_dir.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(str(profile_dir / "places.sqlite"))
+    try:
+        conn.execute(
+            "CREATE TABLE moz_places (id INTEGER PRIMARY KEY, url TEXT, "
+            "visit_count INTEGER, last_visit_date INTEGER)"
+        )
+        conn.execute(
+            "CREATE TABLE moz_bookmarks (id INTEGER PRIMARY KEY, fk INTEGER, title TEXT)"
+        )
+        conn.execute(
+            "INSERT INTO moz_places VALUES (1, ?, ?, ?)",
+            (url, visit_count, int(time.time() * 1_000_000)),
+        )
+        conn.execute("INSERT INTO moz_bookmarks VALUES (1, 1, 'A bookmark')")
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def _write_thunderbird_prefs(profile_dir: Path, email: str) -> None:
+    """Write a minimal Thunderbird prefs.js declaring one mail identity."""
+    profile_dir.mkdir(parents=True, exist_ok=True)
+    (profile_dir / "prefs.js").write_text(
+        f'user_pref("mail.identity.id1.useremail", "{email}");\n', encoding="utf-8"
+    )
+
 
 # ---------------------------------------------------------------------------
 # _classify_remote — URL hostname-based classification
@@ -171,16 +259,123 @@ class TestSystemDiscoveryScanAll:
 
 
 # ---------------------------------------------------------------------------
-# Windows-only guard — scan_installed_apps returns [] on non-Windows
+# Platform dispatch — each scanner routes to the branch for the running OS
+#
+# Replaces the pre-#1956 TestWindowsOnlyGuard, which asserted
+# scan_installed_apps() == [] off Windows. macOS and Linux now have real
+# branches, so that assertion is false; what must hold instead is that each
+# platform reaches its own branch, and that a platform with no branch is
+# reported rather than silently empty.
 # ---------------------------------------------------------------------------
 
 
-class TestWindowsOnlyGuard:
-    @pytest.mark.skipif(sys.platform == "win32", reason="Non-Windows only")
-    def test_scan_installed_apps_returns_empty_on_non_windows(self):
+class TestPlatformBranchDispatch:
+    """Each of the four platform-aware scanners dispatches by sys.platform."""
+
+    @pytest.mark.parametrize(
+        "platform,branch",
+        [
+            ("win32", "_scan_windows_installed_apps"),
+            ("darwin", "_scan_macos_installed_apps"),
+            ("linux", "_scan_linux_installed_apps"),
+        ],
+    )
+    def test_installed_apps_dispatches_to_platform_branch(self, platform, branch):
         disc = SystemDiscovery()
-        result = disc.scan_installed_apps()
-        assert result == [], "scan_installed_apps must return [] on non-Windows"
+        sentinel = [{"content": "sentinel"}]
+        with (
+            patch("sys.platform", platform),
+            patch.object(disc, branch, return_value=sentinel) as mock_branch,
+        ):
+            assert disc.scan_installed_apps() == sentinel
+        mock_branch.assert_called_once_with()
+
+    def test_installed_apps_linux2_is_treated_as_linux(self):
+        """Legacy sys.platform values ('linux2') must still reach the branch."""
+        disc = SystemDiscovery()
+        with (
+            patch("sys.platform", "linux2"),
+            patch.object(
+                disc, "_scan_linux_installed_apps", return_value=[]
+            ) as mock_branch,
+        ):
+            disc.scan_installed_apps()
+        mock_branch.assert_called_once_with()
+
+    def test_safari_only_scanned_on_darwin(self, isolated_disc):
+        for platform, expected in (
+            ("darwin", True),
+            ("linux", False),
+            ("win32", False),
+        ):
+            with (
+                patch("sys.platform", platform),
+                patch.object(isolated_disc, "_extract_safari_bookmarks") as mock_book,
+                patch.object(isolated_disc, "_extract_safari_history") as mock_hist,
+            ):
+                isolated_disc.scan_browser_bookmarks()
+                isolated_disc.scan_browser_history()
+            assert mock_book.called is expected, f"bookmarks on {platform}"
+            assert mock_hist.called is expected, f"history on {platform}"
+
+    @pytest.mark.parametrize(
+        "platform,expected_calls,unexpected_calls",
+        [
+            (
+                "win32",
+                ["_scan_credential_manager", "_scan_outlook_registry"],
+                ["_scan_macos_keychain", "_scan_apple_mail", "_scan_evolution"],
+            ),
+            (
+                "darwin",
+                ["_scan_macos_keychain", "_scan_apple_mail"],
+                [
+                    "_scan_credential_manager",
+                    "_scan_outlook_registry",
+                    "_scan_evolution",
+                ],
+            ),
+            (
+                "linux",
+                ["_scan_evolution"],
+                [
+                    "_scan_credential_manager",
+                    "_scan_outlook_registry",
+                    "_scan_macos_keychain",
+                    "_scan_apple_mail",
+                ],
+            ),
+        ],
+    )
+    def test_email_dispatches_to_platform_branches(
+        self, isolated_disc, platform, expected_calls, unexpected_calls
+    ):
+        names = expected_calls + unexpected_calls + ["_scan_thunderbird"]
+        with contextlib.ExitStack() as stack:
+            started = {
+                name: stack.enter_context(patch.object(isolated_disc, name))
+                for name in names
+            }
+            stack.enter_context(patch("sys.platform", platform))
+            isolated_disc.scan_email_accounts()
+
+        for name in expected_calls:
+            assert started[name].called, f"{name} should run on {platform}"
+        for name in unexpected_calls:
+            assert not started[name].called, f"{name} must not run on {platform}"
+        assert started["_scan_thunderbird"].called, "Thunderbird runs on all platforms"
+
+    def test_real_platform_scanners_do_not_raise(self, isolated_disc):
+        """The unpatched host platform must complete every scanner."""
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=44, stdout="", stderr="")
+            for scan in (
+                isolated_disc.scan_installed_apps,
+                isolated_disc.scan_browser_bookmarks,
+                isolated_disc.scan_browser_history,
+                isolated_disc.scan_email_accounts,
+            ):
+                assert isinstance(scan(), list)
 
 
 # ---------------------------------------------------------------------------
@@ -475,3 +670,691 @@ class TestScanAllIncludesPersonalFiles:
             result = disc.scan_all(sources=["personal_files"])
         assert "personal_files" in result
         assert isinstance(result["personal_files"], list)
+
+
+# ---------------------------------------------------------------------------
+# macOS branches — real content out of a fake ~/ (issue #1956)
+# ---------------------------------------------------------------------------
+
+
+class TestMacOSBranches:
+    """The darwin branches read the real macOS locations under a fake home."""
+
+    def test_installed_apps_finds_app_bundles(self, isolated_disc, tmp_path):
+        apps = tmp_path / "Applications"
+        apps.mkdir()
+        (apps / "Blender.app").mkdir()
+        (apps / "Slack.app").mkdir()
+        (apps / "not-an-app.txt").write_text("ignored", encoding="utf-8")
+
+        with patch("sys.platform", "darwin"):
+            results = isolated_disc.scan_installed_apps()
+
+        contents = [r["content"] for r in results]
+        assert any("Blender" in c for c in contents)
+        assert any("Slack" in c for c in contents)
+        assert not any("not-an-app" in c for c in contents)
+        assert all(r["entity"].startswith("app:") for r in results)
+        assert {"blender", "slack"} <= {
+            r["entity"].removeprefix("app:") for r in results
+        }
+
+    def test_bookmarks_read_every_chromium_profile(self, isolated_disc, tmp_path):
+        chrome = tmp_path / "Library" / "Application Support" / "Google" / "Chrome"
+        _write_chromium_bookmarks(chrome / "Default", ["https://github.com/amd/gaia"])
+        _write_chromium_bookmarks(chrome / "Profile 1", ["https://reddit.com/r/amd"])
+
+        with patch("sys.platform", "darwin"):
+            results = isolated_disc.scan_browser_bookmarks()
+
+        domains = {r["content"].split()[2] for r in results}
+        assert "github.com" in domains, "Default profile must be read"
+        assert "reddit.com" in domains, "Profile 1 must be read too"
+
+    def test_safari_bookmarks_are_included(self, isolated_disc, tmp_path):
+        safari = tmp_path / "Library" / "Safari"
+        safari.mkdir(parents=True)
+        with open(safari / "Bookmarks.plist", "wb") as f:
+            plistlib.dump(
+                {
+                    "Children": [
+                        {
+                            "Children": [
+                                {
+                                    "WebBookmarkType": "WebBookmarkTypeLeaf",
+                                    "URLString": "https://news.ycombinator.com/",
+                                }
+                            ]
+                        }
+                    ]
+                },
+                f,
+                fmt=plistlib.FMT_BINARY,
+            )
+
+        with patch("sys.platform", "darwin"):
+            results = isolated_disc.scan_browser_bookmarks()
+
+        assert any("news.ycombinator.com" in r["content"] for r in results)
+
+    def test_safari_history_is_sensitive(self, isolated_disc, tmp_path):
+        safari = tmp_path / "Library" / "Safari"
+        safari.mkdir(parents=True)
+        conn = sqlite3.connect(str(safari / "History.db"))
+        try:
+            conn.execute(
+                "CREATE TABLE history_items (id INTEGER PRIMARY KEY, url TEXT, "
+                "visit_count INTEGER)"
+            )
+            conn.execute(
+                "CREATE TABLE history_visits (id INTEGER PRIMARY KEY, "
+                "history_item INTEGER, visit_time REAL)"
+            )
+            conn.execute(
+                "INSERT INTO history_items VALUES (1, 'https://arxiv.org/abs/1', 12)"
+            )
+            # Mac absolute time == Unix time - 978307200
+            conn.execute(
+                "INSERT INTO history_visits VALUES (1, 1, ?)",
+                (time.time() - 978307200,),
+            )
+            conn.commit()
+        finally:
+            conn.close()
+
+        with patch("sys.platform", "darwin"):
+            results = isolated_disc.scan_browser_history()
+
+        arxiv = [r for r in results if "arxiv.org" in r["content"]]
+        assert len(arxiv) == 1
+        assert arxiv[0]["sensitive"] is True
+
+    def test_firefox_profile_root_is_the_macos_one(self, isolated_disc, tmp_path):
+        profile = (
+            tmp_path
+            / "Library"
+            / "Application Support"
+            / "Firefox"
+            / "Profiles"
+            / "abc.default"
+        )
+        _write_places_sqlite(profile, "https://mozilla.org/about")
+
+        with patch("sys.platform", "darwin"):
+            results = isolated_disc.scan_browser_bookmarks()
+
+        assert any("mozilla.org" in r["content"] for r in results)
+
+    def test_thunderbird_and_apple_mail_addresses(self, isolated_disc, tmp_path):
+        _write_thunderbird_prefs(
+            tmp_path / "Library" / "Thunderbird" / "Profiles" / "xyz.default",
+            "tbird@example.com",
+        )
+        maildata = tmp_path / "Library" / "Mail" / "V10" / "MailData"
+        maildata.mkdir(parents=True)
+        with open(maildata / "Accounts.plist", "wb") as f:
+            plistlib.dump(
+                {"MailAccounts": [{"EmailAddresses": ["applemail@example.com"]}]},
+                f,
+                fmt=plistlib.FMT_BINARY,
+            )
+
+        with (
+            patch("sys.platform", "darwin"),
+            patch("subprocess.run") as mock_run,
+        ):
+            mock_run.return_value = MagicMock(returncode=44, stdout="", stderr="")
+            results = isolated_disc.scan_email_accounts()
+
+        addresses = {r["content"] for r in results}
+        assert any("tbird@example.com" in a for a in addresses)
+        assert any("applemail@example.com" in a for a in addresses)
+        assert all(r["sensitive"] is True for r in results)
+        assert all(r["entity"].startswith("service:") for r in results)
+
+    def test_apple_mail_does_not_harvest_correspondents(self, isolated_disc, tmp_path):
+        """Only the user's own account address is read, not their contacts.
+
+        Mail plists also hold previous recipients and signature text. Those are
+        other people's addresses and must not land in the user's review list.
+        """
+        maildata = tmp_path / "Library" / "Mail" / "V10" / "MailData"
+        maildata.mkdir(parents=True)
+        with open(maildata / "Accounts.plist", "wb") as f:
+            plistlib.dump(
+                {
+                    "MailAccounts": [{"EmailAddresses": ["me@example.com"]}],
+                    "PreviousRecipients": ["colleague@other-company.com"],
+                    "Signature": "Reply to boss@other-company.com",
+                },
+                f,
+                fmt=plistlib.FMT_BINARY,
+            )
+
+        with patch("sys.platform", "darwin"):
+            results = []
+            isolated_disc._scan_apple_mail(set(), results)
+
+        contents = " ".join(r["content"] for r in results)
+        assert "me@example.com" in contents
+        assert "colleague@other-company.com" not in contents
+        assert "boss@other-company.com" not in contents
+
+
+# ---------------------------------------------------------------------------
+# Linux branches — UNVALIDATED on real hardware; fixture-covered only
+# ---------------------------------------------------------------------------
+
+
+class TestLinuxBranches:
+    """The linux branches read the real Linux locations under a fake home.
+
+    No Linux hardware was available for #1956; these branches are exercised on
+    the CI/dev runner via patched sys.platform only.
+    """
+
+    def test_installed_apps_from_desktop_entries(self, isolated_disc, tmp_path):
+        apps = tmp_path / ".local" / "share" / "applications"
+        apps.mkdir(parents=True)
+        (apps / "blender.desktop").write_text(
+            "[Desktop Entry]\nType=Application\nName=Blender\nExec=blender %f\n",
+            encoding="utf-8",
+        )
+        (apps / "hidden.desktop").write_text(
+            "[Desktop Entry]\nType=Application\nName=Hidden Tool\nNoDisplay=true\n",
+            encoding="utf-8",
+        )
+        (apps / "link.desktop").write_text(
+            "[Desktop Entry]\nType=Link\nName=Some Link\nURL=https://example.com\n",
+            encoding="utf-8",
+        )
+
+        with patch("sys.platform", "linux"):
+            results = isolated_disc.scan_installed_apps()
+
+        contents = [r["content"] for r in results]
+        assert any("Blender" in c for c in contents)
+        assert not any("Hidden Tool" in c for c in contents)
+        assert not any("Some Link" in c for c in contents)
+
+    def test_desktop_exec_field_codes_do_not_break_parsing(
+        self, isolated_disc, tmp_path
+    ):
+        """Exec= lines contain %U / %f, which the default interpolator rejects."""
+        apps = tmp_path / ".local" / "share" / "applications"
+        apps.mkdir(parents=True)
+        (apps / "browser.desktop").write_text(
+            "[Desktop Entry]\nType=Application\nName=Firefox\n"
+            "Exec=firefox %U\nIcon=firefox\n",
+            encoding="utf-8",
+        )
+
+        with patch("sys.platform", "linux"):
+            results = isolated_disc.scan_installed_apps()
+
+        assert any("Firefox" in r["content"] for r in results)
+
+    def test_flatpak_and_snap_exports_are_scanned(self, isolated_disc, tmp_path):
+        flatpak = (
+            tmp_path
+            / ".local"
+            / "share"
+            / "flatpak"
+            / "exports"
+            / "share"
+            / "applications"
+        )
+        flatpak.mkdir(parents=True)
+        (flatpak / "org.gimp.GIMP.desktop").write_text(
+            "[Desktop Entry]\nType=Application\nName=GNU Image Manipulation Program\n",
+            encoding="utf-8",
+        )
+
+        with patch("sys.platform", "linux"):
+            results = isolated_disc.scan_installed_apps()
+
+        assert any("GNU Image" in r["content"] for r in results)
+
+    def test_chromium_and_chrome_config_roots(self, isolated_disc, tmp_path):
+        _write_chromium_bookmarks(
+            tmp_path / ".config" / "google-chrome" / "Default",
+            ["https://github.com/amd/gaia"],
+        )
+        _write_chromium_bookmarks(
+            tmp_path / ".config" / "chromium" / "Profile 2",
+            ["https://stackoverflow.com/questions/1"],
+        )
+
+        with patch("sys.platform", "linux"):
+            results = isolated_disc.scan_browser_bookmarks()
+
+        domains = {r["content"].split()[2] for r in results}
+        assert {"github.com", "stackoverflow.com"} <= domains
+
+    def test_firefox_snap_profile_root(self, isolated_disc, tmp_path):
+        profile = (
+            tmp_path
+            / "snap"
+            / "firefox"
+            / "common"
+            / ".mozilla"
+            / "firefox"
+            / "abc.default"
+        )
+        _write_places_sqlite(profile, "https://kernel.org/doc")
+
+        with patch("sys.platform", "linux"):
+            results = isolated_disc.scan_browser_history()
+
+        kernel = [r for r in results if "kernel.org" in r["content"]]
+        assert len(kernel) == 1
+        assert kernel[0]["sensitive"] is True
+
+    def test_thunderbird_and_evolution_addresses(self, isolated_disc, tmp_path):
+        _write_thunderbird_prefs(
+            tmp_path / ".thunderbird" / "xyz.default", "tbird@example.com"
+        )
+        sources = tmp_path / ".config" / "evolution" / "sources"
+        sources.mkdir(parents=True)
+        (sources / "account1.source").write_text(
+            "[Data Source]\nDisplayName=Work\n\n"
+            "[Mail Identity]\nAddress=evo@example.com\nName=Alex\n",
+            encoding="utf-8",
+        )
+
+        with patch("sys.platform", "linux"):
+            results = isolated_disc.scan_email_accounts()
+
+        addresses = {r["content"] for r in results}
+        assert any("tbird@example.com" in a for a in addresses)
+        assert any("evo@example.com" in a for a in addresses)
+        assert all(r["sensitive"] is True for r in results)
+
+
+# ---------------------------------------------------------------------------
+# Unsupported platform — reported by name, never silently empty (#1956 D1)
+# ---------------------------------------------------------------------------
+
+
+class TestUnsupportedPlatform:
+    """unsupported_reason() is the single source of truth for "no branch here"."""
+
+    @pytest.mark.parametrize(
+        "platform,source,supported",
+        [
+            ("darwin", "installed_apps", True),
+            ("linux", "browser_history", True),
+            ("win32", "email_accounts", True),
+            ("darwin", "windows_userassist", False),
+            ("linux", "windows_userassist", False),
+            ("win32", "macos_app_usage", False),
+            ("freebsd13", "installed_apps", False),
+            ("freebsd13", "browser_bookmarks", False),
+            ("freebsd13", "browser_history", False),
+            ("freebsd13", "email_accounts", False),
+        ],
+    )
+    def test_truth_table(self, platform, source, supported):
+        with patch("sys.platform", platform):
+            reason = unsupported_reason(source)
+        assert (reason is None) is supported
+        if reason is not None:
+            assert source in reason
+            assert platform in reason
+
+    def test_platform_neutral_sources_are_never_unsupported(self):
+        for platform in ("win32", "darwin", "linux", "freebsd13"):
+            with patch("sys.platform", platform):
+                assert unsupported_reason("file_system") is None
+                assert unsupported_reason("git_repos") is None
+
+    @pytest.mark.parametrize(
+        "scanner_name",
+        [
+            "scan_installed_apps",
+            "scan_browser_bookmarks",
+            "scan_browser_history",
+            "scan_email_accounts",
+        ],
+    )
+    def test_scanner_logs_the_skip_and_returns_empty(
+        self, isolated_disc, caplog, scanner_name
+    ):
+        caplog.set_level(logging.INFO, logger=DISCOVERY_LOGGER)
+        with patch("sys.platform", "freebsd13"):
+            result = getattr(isolated_disc, scanner_name)()
+
+        assert result == []
+        source = scanner_name.removeprefix("scan_")
+        assert any(
+            source in rec.getMessage() and "freebsd13" in rec.getMessage()
+            for rec in caplog.records
+        ), f"{scanner_name} must name itself and the platform when skipped"
+
+    def test_scan_all_reports_every_skipped_source(self, caplog):
+        caplog.set_level(logging.INFO, logger=DISCOVERY_LOGGER)
+        disc = SystemDiscovery()
+        with patch("sys.platform", "darwin"):
+            results = disc.scan_all(sources=["windows_userassist"])
+
+        assert results == {"windows_userassist": []}
+        assert any(
+            "windows_userassist" in rec.getMessage() and "darwin" in rec.getMessage()
+            for rec in caplog.records
+        )
+
+    def test_support_map_keys_are_all_real_sources(self):
+        """A typo'd key would gate nothing and skip nothing, silently.
+
+        `_PLATFORM_SUPPORT` only takes effect for names `scan_all` and the Agent
+        UI actually dispatch, so a misspelled key is a no-op no runtime error
+        would reveal.
+        """
+        from gaia.agents.base.discovery import _PLATFORM_SUPPORT
+        from gaia.ui.routers.memory import _DISCOVERY_SOURCES
+
+        # scan_all drops names it does not know, so a bogus key never comes back.
+        disc = SystemDiscovery()
+        gated = list(_PLATFORM_SUPPORT)
+        with (
+            patch.object(disc, "_home", Path("/nonexistent/cold-home")),
+            patch("gaia.agents.base.discovery._MACOS_APP_DIRS", ()),
+            patch("gaia.agents.base.discovery._LINUX_DESKTOP_DIRS", ()),
+            patch("gaia.agents.base.discovery.winreg", None),
+            patch("subprocess.run") as mock_run,
+        ):
+            mock_run.return_value = MagicMock(returncode=44, stdout="", stderr="")
+            dispatched = set(disc.scan_all(sources=gated))
+
+        unknown = set(gated) - dispatched
+        assert not unknown, f"_PLATFORM_SUPPORT keys not known to scan_all: {unknown}"
+
+        ui_only_gap = set(_PLATFORM_SUPPORT) - set(_DISCOVERY_SOURCES)
+        assert ui_only_gap == {"email_accounts"}, (
+            "the Agent UI's source list drifted from _PLATFORM_SUPPORT; "
+            f"unexpected difference: {ui_only_gap}"
+        )
+
+    def test_drift_between_map_and_branches_is_reported(self, isolated_disc, caplog):
+        """A platform listed as supported but with no branch must not be quiet.
+
+        This is the fail-open direction: editing the map is easier than writing
+        a scanner, so the mismatch that ships is "map says yes, code says no".
+        """
+        caplog.set_level(logging.INFO, logger=DISCOVERY_LOGGER)
+        with (
+            patch("sys.platform", "freebsd13"),
+            patch.dict(
+                "gaia.agents.base.discovery._PLATFORM_SUPPORT",
+                {"installed_apps": ("win32", "darwin", "linux", "freebsd13")},
+            ),
+        ):
+            result = isolated_disc.scan_installed_apps()
+
+        assert result == []
+        warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+        assert warnings, "map/branch drift must not return a quiet empty list"
+        assert "drifted" in warnings[0].getMessage()
+
+    def test_scan_all_does_not_invoke_an_unsupported_scanner(self):
+        disc = SystemDiscovery()
+        with (
+            patch("sys.platform", "darwin"),
+            patch.object(disc, "scan_windows_userassist") as mock_scan,
+        ):
+            disc.scan_all(sources=["windows_userassist"])
+        assert not mock_scan.called
+
+
+# ---------------------------------------------------------------------------
+# Cold state — a brand-new user's machine, not a primed dev box
+# ---------------------------------------------------------------------------
+
+
+class TestColdEmptyHome:
+    """An empty home returns [] from all four scanners, quietly and safely."""
+
+    @pytest.mark.parametrize("platform", ["win32", "darwin", "linux"])
+    def test_empty_home_returns_empty_without_errors(
+        self, isolated_disc, caplog, platform
+    ):
+        caplog.set_level(logging.DEBUG, logger=DISCOVERY_LOGGER)
+        with (
+            patch("sys.platform", platform),
+            patch("subprocess.run") as mock_run,
+        ):
+            mock_run.return_value = MagicMock(returncode=44, stdout="", stderr="")
+            assert isolated_disc.scan_installed_apps() == []
+            assert isolated_disc.scan_browser_bookmarks() == []
+            assert isolated_disc.scan_browser_history() == []
+            assert isolated_disc.scan_email_accounts() == []
+
+        errors = [r for r in caplog.records if r.levelno >= logging.ERROR]
+        assert not errors, f"cold start logged errors on {platform}: {errors}"
+
+    @pytest.mark.parametrize("platform", ["win32", "darwin", "linux"])
+    def test_empty_home_scan_all_returns_lists(self, isolated_disc, platform):
+        with (
+            patch("sys.platform", platform),
+            patch("subprocess.run") as mock_run,
+        ):
+            mock_run.return_value = MagicMock(returncode=44, stdout="", stderr="")
+            results = isolated_disc.scan_all(
+                sources=[
+                    "installed_apps",
+                    "browser_bookmarks",
+                    "browser_history",
+                    "email_accounts",
+                ]
+            )
+        assert results == {
+            "installed_apps": [],
+            "browser_bookmarks": [],
+            "browser_history": [],
+            "email_accounts": [],
+        }
+
+
+# ---------------------------------------------------------------------------
+# Keychain call contract — the call must be VALID, not merely made (#1956 D2)
+# ---------------------------------------------------------------------------
+
+
+class TestKeychainContractShape:
+    """`security` is invoked as an argv list, attributes-only, with a timeout."""
+
+    def _run_keychain(self, disc, stdout="", returncode=0):
+        with (
+            patch("sys.platform", "darwin"),
+            patch("subprocess.run") as mock_run,
+        ):
+            mock_run.return_value = MagicMock(
+                returncode=returncode, stdout=stdout, stderr=""
+            )
+            results = []
+            disc._scan_macos_keychain(set(), results)
+        return mock_run, results
+
+    def test_argv_shape_is_exact(self, isolated_disc):
+        mock_run, _ = self._run_keychain(isolated_disc, returncode=44)
+
+        assert mock_run.call_count > 0, "no mail host was queried"
+        for call in mock_run.call_args_list:
+            argv = call.args[0]
+            assert isinstance(argv, list), "argv must be a list, never a shell string"
+            assert argv[:3] == ["security", "find-internet-password", "-s"]
+            assert len(argv) == 4, f"unexpected extra arguments: {argv}"
+            assert isinstance(argv[3], str) and argv[3]
+
+    def test_never_reads_the_secret(self, isolated_disc):
+        """-g returns the stored password and raises an auth prompt. Never pass it."""
+        mock_run, _ = self._run_keychain(isolated_disc, returncode=44)
+        for call in mock_run.call_args_list:
+            assert "-g" not in call.args[0]
+            assert "-w" not in call.args[0]
+
+    def test_timeout_is_set_and_shell_is_never_used(self, isolated_disc):
+        mock_run, _ = self._run_keychain(isolated_disc, returncode=44)
+        for call in mock_run.call_args_list:
+            assert call.kwargs.get("timeout") == 10
+            assert not call.kwargs.get("shell", False)
+            assert call.kwargs.get("check") is False
+
+    def test_attribute_dump_yields_a_sensitive_fact(self, isolated_disc):
+        stdout = (
+            'keychain: "/Users/alex/Library/Keychains/login.keychain-db"\n'
+            "class: 0x00000000\n"
+            "attributes:\n"
+            '    "acct"<blob>="alex@gmail.com"\n'
+            '    "srvr"<blob>="imap.gmail.com"\n'
+        )
+        _, results = self._run_keychain(isolated_disc, stdout=stdout)
+
+        assert results, "an address in the attribute dump must become a fact"
+        assert results[0]["content"] == "Email account: alex@gmail.com"
+        assert results[0]["sensitive"] is True
+        assert results[0]["entity"] == "service:gmail"
+
+    def test_item_not_found_is_quiet(self, isolated_disc, caplog):
+        caplog.set_level(logging.INFO, logger=DISCOVERY_LOGGER)
+        _, results = self._run_keychain(isolated_disc, returncode=44)
+
+        assert results == []
+        assert not [r for r in caplog.records if r.levelno >= logging.WARNING]
+
+    def test_empty_output_on_success_is_reported(self, isolated_disc, caplog):
+        """Exit 0 with no attributes means the CLI output shape changed."""
+        caplog.set_level(logging.INFO, logger=DISCOVERY_LOGGER)
+        _, results = self._run_keychain(isolated_disc, stdout="", returncode=0)
+
+        assert results == []
+        warnings = [r for r in caplog.records if r.levelno >= logging.WARNING]
+        assert warnings, "a shape mismatch must not be silent"
+        assert "output format" in warnings[0].getMessage()
+
+    def test_missing_security_binary_is_reported(self, isolated_disc, caplog):
+        caplog.set_level(logging.INFO, logger=DISCOVERY_LOGGER)
+        with (
+            patch("sys.platform", "darwin"),
+            patch("subprocess.run", side_effect=FileNotFoundError("security")),
+        ):
+            results = []
+            isolated_disc._scan_macos_keychain(set(), results)
+
+        assert results == []
+        warnings = [r for r in caplog.records if r.levelno >= logging.WARNING]
+        assert warnings and "security" in warnings[0].getMessage()
+
+
+# ---------------------------------------------------------------------------
+# TCC denial — actionable, surfaced, non-fatal (#1956 D4)
+# ---------------------------------------------------------------------------
+
+
+class TestPermissionDenials:
+    """A permission denial is reported with the remedy, not swallowed.
+
+    Covers Safari (TCC), Apple Mail (TCC), and Evolution (ordinary file mode).
+    """
+
+    def test_history_denial_warns_and_continues(self, isolated_disc, tmp_path, caplog):
+        caplog.set_level(logging.INFO, logger=DISCOVERY_LOGGER)
+        safari = tmp_path / "Library" / "Safari"
+        safari.mkdir(parents=True)
+        (safari / "History.db").write_bytes(b"SQLite format 3\x00")
+        chrome = tmp_path / "Library" / "Application Support" / "Google" / "Chrome"
+        _write_chromium_bookmarks(chrome / "Default", ["https://github.com/amd/gaia"])
+
+        with (
+            patch("sys.platform", "darwin"),
+            patch(
+                "shutil.copy2",
+                side_effect=PermissionError(1, "Operation not permitted"),
+            ),
+        ):
+            history = isolated_disc.scan_browser_history()
+            bookmarks = isolated_disc.scan_browser_bookmarks()
+
+        assert history == []
+        assert bookmarks, "a denial in one source must not abort the whole scan"
+
+        warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+        assert len(warnings) == 1, f"expected one actionable warning, got {warnings}"
+        message = warnings[0].getMessage()
+        assert "Safari history" in message
+        assert "Full Disk Access" in message
+        assert "System Settings" in message
+
+    @requires_chmod_denial
+    def test_apple_mail_denial_warns(self, isolated_disc, tmp_path, caplog):
+        """An unlistable ~/Library/Mail must report, not look like "no accounts".
+
+        Regression guard: Path.glob SWALLOWS PermissionError and yields [], so
+        a glob-based enumeration here was silently empty on exactly the machine
+        state this feature targets — a Mac without Full Disk Access.
+        """
+        caplog.set_level(logging.INFO, logger=DISCOVERY_LOGGER)
+        mail_dir = tmp_path / "Library" / "Mail" / "V10" / "MailData"
+        mail_dir.mkdir(parents=True)
+        with open(mail_dir / "Accounts.plist", "wb") as f:
+            plistlib.dump({"MailAccounts": [{"EmailAddresses": ["a@b.com"]}]}, f)
+        os.chmod(tmp_path / "Library" / "Mail", 0o000)
+
+        try:
+            with patch("sys.platform", "darwin"):
+                results = []
+                isolated_disc._scan_apple_mail(set(), results)
+        finally:
+            os.chmod(tmp_path / "Library" / "Mail", 0o755)
+
+        assert results == []
+        warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+        assert warnings, "an unreadable ~/Library/Mail must not be silent"
+        assert "Full Disk Access" in warnings[0].getMessage()
+
+    @requires_chmod_denial
+    def test_evolution_denial_warns(self, isolated_disc, tmp_path, caplog):
+        """Same Path.glob swallow, Linux side."""
+        caplog.set_level(logging.INFO, logger=DISCOVERY_LOGGER)
+        sources = tmp_path / ".config" / "evolution" / "sources"
+        sources.mkdir(parents=True)
+        (sources / "a.source").write_text(
+            "[Mail Identity]\nAddress=evo@example.com\n", encoding="utf-8"
+        )
+        os.chmod(sources, 0o000)
+
+        try:
+            with patch("sys.platform", "linux"):
+                results = []
+                isolated_disc._scan_evolution(set(), results)
+        finally:
+            os.chmod(sources, 0o755)
+
+        assert results == []
+        assert [r for r in caplog.records if r.levelno == logging.WARNING]
+
+    def test_bookmarks_denial_warns(self, isolated_disc, tmp_path, caplog):
+        caplog.set_level(logging.INFO, logger=DISCOVERY_LOGGER)
+        safari = tmp_path / "Library" / "Safari"
+        safari.mkdir(parents=True)
+        plist_path = safari / "Bookmarks.plist"
+        plist_path.write_bytes(b"bplist00")
+
+        real_open = open
+
+        def deny_safari(file, *args, **kwargs):
+            """Deny only the TCC-protected plist; leave every other open alone."""
+            if str(file) == str(plist_path):
+                raise PermissionError(1, "Operation not permitted")
+            return real_open(file, *args, **kwargs)
+
+        with (
+            patch("sys.platform", "darwin"),
+            patch("builtins.open", side_effect=deny_safari),
+        ):
+            results = isolated_disc.scan_browser_bookmarks()
+
+        assert results == []
+        warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+        assert len(warnings) == 1
+        assert "Full Disk Access" in warnings[0].getMessage()

--- a/tests/unit/test_memory_router.py
+++ b/tests/unit/test_memory_router.py
@@ -1502,3 +1502,129 @@ class TestStreamDiscoveryPlatformReporting:
         ]
         assert skipped, f"macos_app_usage must be named on win32. Body:\n{body}"
         assert "win32" in skipped[0]
+
+
+class TestStreamInferencePlatformReporting:
+    """GET /api/memory/stream-inference gates direct scanner calls too (#1956).
+
+    ``stream_discovery`` consults ``unsupported_reason`` before each scan, but
+    ``stream_inference`` called the scanners directly behind ``except
+    Exception: pass`` — so on macOS it streamed "Collecting app usage
+    frequency..." and then nothing at all.
+    """
+
+    def _stream(self, client, tmp_path, platform, extra_patches=()):
+        """Run the inference stream against an empty fake home on `platform`.
+
+        The cold home yields no sections, so the endpoint returns before any
+        LLM call — no model or network is involved.
+        """
+        with contextlib.ExitStack() as stack:
+            stack.enter_context(patch("sys.platform", platform))
+            stack.enter_context(patch("pathlib.Path.home", return_value=tmp_path))
+            stack.enter_context(patch("gaia.agents.base.discovery._MACOS_APP_DIRS", ()))
+            stack.enter_context(
+                patch("gaia.agents.base.discovery._LINUX_DESKTOP_DIRS", ())
+            )
+            stack.enter_context(patch("gaia.agents.base.discovery.winreg", None))
+            for extra in extra_patches:
+                stack.enter_context(extra)
+            return client.get("/api/memory/stream-inference")
+
+    @pytest.mark.parametrize(
+        "platform,source",
+        [
+            ("darwin", "windows_userassist"),
+            ("linux", "windows_userassist"),
+            ("win32", "macos_app_usage"),
+        ],
+    )
+    def test_unsupported_source_is_reported_by_name(
+        self, client, tmp_path, platform, source
+    ):
+        resp = self._stream(client, tmp_path, platform)
+        body = resp.text
+
+        assert resp.status_code == 200
+        skipped = [
+            line
+            for line in body.splitlines()
+            if source in line and "no scanner" in line
+        ]
+        assert skipped, (
+            f"{source} must be named as unsupported on {platform}, not silently "
+            f"skipped. Body was:\n{body}"
+        )
+        assert '"type": "log"' in skipped[0]
+        assert platform in skipped[0]
+
+    def test_supported_source_is_not_reported_as_unsupported(self, client, tmp_path):
+        mock_macos = patch(
+            "gaia.agents.base.discovery.SystemDiscovery.scan_macos_app_usage",
+            return_value=[],
+        )
+        resp = self._stream(client, tmp_path, "darwin", extra_patches=[mock_macos])
+        body = resp.text
+
+        skipped = [
+            line
+            for line in body.splitlines()
+            if "macos_app_usage" in line and "no scanner" in line
+        ]
+        assert not skipped, f"macos_app_usage must run on darwin. Body:\n{body}"
+
+    def test_scanner_failure_is_reported_with_a_correlation_id(self, client, tmp_path):
+        """A crashing scanner was swallowed whole by `except Exception: pass`."""
+        boom = patch(
+            "gaia.agents.base.discovery.SystemDiscovery.scan_installed_apps",
+            side_effect=RuntimeError("scan exploded"),
+        )
+        resp = self._stream(client, tmp_path, "darwin", extra_patches=[boom])
+        body = resp.text
+
+        failed = [
+            line
+            for line in body.splitlines()
+            if "installed_apps" in line and "unavailable" in line
+        ]
+        assert failed, f"a crashing scanner must be reported. Body:\n{body}"
+        assert "id=" in failed[0], "the log correlation id must reach the client"
+        assert "scan exploded" not in body, "exception detail must stay server-side"
+
+
+class TestCollectSignalGate:
+    """`gaia memory bootstrap --infer` applies the same gate as the UI stream."""
+
+    def test_unsupported_source_is_named_and_returns_empty(self, capsys):
+        from gaia.cli import _collect_signal
+
+        def _must_not_run():
+            raise AssertionError("scanner ran on a platform with no branch")
+
+        with patch("sys.platform", "darwin"):
+            result = _collect_signal("windows_userassist", _must_not_run)
+
+        assert result == []
+        out = capsys.readouterr().out
+        assert "windows_userassist" in out and "darwin" in out
+
+    def test_supported_source_runs(self):
+        from gaia.cli import _collect_signal
+
+        with patch("sys.platform", "darwin"):
+            result = _collect_signal("installed_apps", lambda: [{"content": "app"}])
+
+        assert result == [{"content": "app"}]
+
+    def test_scanner_failure_is_reported_not_swallowed(self, capsys):
+        from gaia.cli import _collect_signal
+
+        def _boom():
+            raise RuntimeError("scan exploded")
+
+        with patch("sys.platform", "darwin"):
+            result = _collect_signal("installed_apps", _boom)
+
+        assert result == []
+        out = capsys.readouterr().out
+        assert "installed_apps" in out and "scan exploded" in out

--- a/tests/unit/test_memory_router.py
+++ b/tests/unit/test_memory_router.py
@@ -33,6 +33,7 @@ Endpoints covered:
   DELETE /api/memory/all
 """
 
+import contextlib
 import sqlite3
 from unittest.mock import MagicMock, patch
 
@@ -1421,3 +1422,83 @@ class TestClearAllMemory:
         assert data["knowledge"] == 0
         assert data["tool_history"] == 0
         assert data["conversations"] == 0
+
+
+class TestStreamDiscoveryPlatformReporting:
+    """GET /api/memory/stream-discovery names sources it cannot run (#1956).
+
+    Before this, a Windows-only source on macOS streamed "Nothing found" — the
+    UI could not tell "you have none" from "GAIA cannot look here".
+    """
+
+    def _stream(self, client, tmp_path, platform, extra_patches=()):
+        """Run the discovery stream against an empty fake home on `platform`.
+
+        Hermetic on every host: the home is a temp dir, the system application
+        directories are emptied, and winreg is None so the win32 case cannot
+        reach a real registry when the suite runs on Windows.
+        """
+        with contextlib.ExitStack() as stack:
+            stack.enter_context(patch("sys.platform", platform))
+            stack.enter_context(patch("pathlib.Path.home", return_value=tmp_path))
+            stack.enter_context(patch("gaia.agents.base.discovery._MACOS_APP_DIRS", ()))
+            stack.enter_context(
+                patch("gaia.agents.base.discovery._LINUX_DESKTOP_DIRS", ())
+            )
+            stack.enter_context(patch("gaia.agents.base.discovery.winreg", None))
+            for extra in extra_patches:
+                stack.enter_context(extra)
+            return client.get("/api/memory/stream-discovery")
+
+    def test_unsupported_source_is_reported_by_name(self, client, tmp_path):
+        """On darwin, windows_userassist streams an explicit unsupported log."""
+        resp = self._stream(client, tmp_path, "darwin")
+        body = resp.text
+
+        assert resp.status_code == 200
+        skipped = [
+            line
+            for line in body.splitlines()
+            if "windows_userassist" in line and "no scanner" in line
+        ]
+        assert skipped, (
+            "windows_userassist must be reported as unsupported on darwin, "
+            f"not silently empty. Body was:\n{body}"
+        )
+        assert '"type": "log"' in skipped[0]
+        assert "darwin" in skipped[0]
+        assert '"type": "done"' in body
+
+    def test_supported_source_is_not_reported_as_unsupported(self, client, tmp_path):
+        """macos_app_usage has a darwin branch, so it must still be scanned."""
+        mock_macos = patch(
+            "gaia.agents.base.discovery.SystemDiscovery.scan_macos_app_usage",
+            return_value=[],
+        )
+        resp = self._stream(client, tmp_path, "darwin", extra_patches=[mock_macos])
+        body = resp.text
+
+        skipped = [
+            line
+            for line in body.splitlines()
+            if "macos_app_usage" in line and "no scanner" in line
+        ]
+        assert not skipped, f"macos_app_usage must run on darwin. Body:\n{body}"
+        # Guard against a vacuous pass: the source must actually have been run.
+        assert "App usage frequency (macOS)" in body
+        assert '"type": "done"' in body
+
+    def test_macos_app_usage_is_reported_as_unsupported_on_windows(
+        self, client, tmp_path
+    ):
+        """The mirror case: the macOS-only source is named when off darwin."""
+        resp = self._stream(client, tmp_path, "win32")
+        body = resp.text
+
+        skipped = [
+            line
+            for line in body.splitlines()
+            if "macos_app_usage" in line and "no scanner" in line
+        ]
+        assert skipped, f"macos_app_usage must be named on win32. Body:\n{body}"
+        assert "win32" in skipped[0]


### PR DESCRIPTION
## Summary

On macOS and Linux, four of the six day-zero discovery sources returned nothing — and returned it silently. Measured on this Mac against `main`: installed apps `0`, bookmarks `0`, history `0`, email `0`, with no error and no log line, indistinguishable from "you own no browsers and have no email". The same machine on this branch returns 39 applications, 908 bookmark facts across **both** Chrome profiles, and 50 history domains; anything that genuinely has no scanner for the running OS now names itself instead of vanishing.

## Why

Day-zero bootstrap is the one flow whose entire job is making a brand-new user's agent useful on first run. A source that quietly returns `[]` there doesn't degrade the experience, it removes it — and the user has no way to tell a missing platform branch from an empty machine. That is precisely the failure mode `CLAUDE.md`'s fail-loudly rule exists to prevent, and it was shipping on two of the three supported platforms.

The fix is real per-platform branches for the four Windows-only scanners, plus one importable predicate (`unsupported_reason`) that turns every remaining "no branch here" case into a named, surfaced reason rather than an empty list.

## Linked issue

Closes #1956

## Changes

- **Four scanners gain real macOS and Linux branches.** Apps (`.app` bundles / `.desktop` entries), bookmarks and history (Chromium + Firefox + Safari), and email (Keychain *attributes*, Apple Mail plists, Thunderbird, Evolution). Windows keeps its existing bodies verbatim.
- **`unsupported_reason()` is the single source of truth for "no scanner here"**, and every entry point consults it — `scan_all`, both Agent UI SSE streams, and both `gaia memory bootstrap` paths. This is what converts a silent `[]` into a log line and an SSE `log` event, and it also closes the pre-existing silent no-op for `windows_userassist` / `macos_app_usage` in the UI.
- **Every browser profile is read, not just `Default`.** This machine has `Default` and `Profile 1`; previously half its bookmarks and history were invisible. Applies on all three platforms — see deviation 6.
- **Permission denials are reported with a remedy instead of swallowed at debug level.** A TCC-blocked Safari or Apple Mail now emits one actionable warning naming System Settings → Privacy & Security → Full Disk Access, and the rest of the scan continues.
- **Linux paths follow the environment rather than a hardcoded prefix** — `XDG_DATA_DIRS`/`XDG_DATA_HOME` for apps, plus the Snap and Flatpak roots for Chromium and Firefox. Stock Ubuntu ships Chromium as a snap, which never writes to `~/.config`.
- **`Path.glob` is not used for profile or mail enumeration.** It swallows `PermissionError` and yields nothing — the exact silent-empty result this work exists to remove. `os.scandir` with explicit handlers replaces it.
- **SQLite snapshots copy the `-wal`/`-shm` sidecars.** Safari's `History.db` and Firefox's `places.sqlite` run in WAL mode, so the most recent visits — what a 30-day scan is actually after — live in the sidecar until checkpoint.
- **Docs corrected in the same change**: the SDK methods table and the spec's discovery-source table both described these as Windows-only sources.

## #1956 Acceptance Criteria — Proof

**AC 1 — "macOS + Linux scanners implemented behind platform branches; no silent empty returns off Windows"** ✅

Measured on darwin 25.1, same machine, same home directory:

| Source | `main` @ `9bf0042a` | this branch |
|---|---|---|
| `installed_apps` | 0 | **39** |
| `browser_bookmarks` | 0 | **908** (4 sensitive) |
| `browser_history` | 0 | **50** (50 sensitive) |
| `email_accounts` | 0 | 0 — *reported, not silent* (see note) |

The "no silent empty" half is proven by the live CLI run under Evidence: `windows_userassist` emits a named INFO line on darwin instead of nothing, and three TCC denials each emit an actionable warning. `email_accounts` legitimately finds 0 on this box — Apple Mail is TCC-denied (warned, twice), Thunderbird is not installed, and no Keychain internet-password matched the mail-host allowlist. Zero with four warnings is a different user experience from zero in silence, which is the whole point.

**AC 2 — "Existing `scan_macos_app_usage` wired into the discovery path"** ✅ *already satisfied before this PR*

The triage bot's correction on the issue thread was right: `scan_macos_app_usage` was already registered in `scan_all` and already called from the memory router. No re-wiring was needed and none was done. Its detection logic is untouched; only its platform guard changed, from a bare `return []` to a reported skip — see deviation 1.

**AC 3 — "Code-level tests pass on Mac; macOS/Linux runtime runs flagged `UNVALIDATED`"** ✅

120 discovery tests plus the router suite pass on this Mac; the Linux and Windows branches are exercised via `patch("sys.platform", …)` against fixture homes. **macOS is runtime-validated here** (CLI output below). **Linux and Windows are `UNVALIDATED`** — no hardware available; flagged individually in Deviations 3, 4, and 6 for AMD to confirm.

## Deviations from the plan

| # | Plan / issue said | Reality | Resolution |
|---|---|---|---|
| 1 | `scan_macos_app_usage` must have **zero diff lines** | Its guard was `if sys.platform != "darwin": return []` — a silent empty for a source registered in `_PLATFORM_SUPPORT` | **Deviation.** The guard now reports via `_log_unsupported`. Detection logic unchanged. The invariant was written before `unsupported_reason` existed; leaving it would have exempted this scanner from the PR's own rule. |
| 2 | macOS apps via "`/Applications` + Launch Services" | `lsregister` lives at an undocumented framework path, dumps megabytes, and is slow | `/Applications` + `~/Applications` bundle scan. **No Launch Services.** `/System/Applications` deliberately excluded — ~40 Apple stock apps would swamp the review list. |
| 3 | Linux apps via "`.desktop` / apt / flatpak / snap" | `apt list --installed` is slow, Debian-only, and lists non-GUI packages | `.desktop` files only, across XDG dirs plus the Flatpak and Snap export dirs — how those two surface GUI apps anyway. **No package-manager subprocess.** `UNVALIDATED` on Linux hardware. |
| 4 | Linux email via "libsecret/gnome-keyring" | **`secret-tool` cannot enumerate** — it requires exact attribute key/value pairs to search. Blanket enumeration is not an API that exists. | Thunderbird profiles + Evolution `~/.config/evolution/sources/*.source`. **No libsecret.** This is a factual correction to the issue. `UNVALIDATED` on Linux hardware. |
| 5 | Spec describes apps + email as Windows-only sources | Cross-platform after this change | Spec table updated in this PR per the "a functional change updates every doc that describes it" rule. Flagging in case the maintainer wants spec edits split out. |
| 6 | Windows reads only the `Default` browser profile | Multi-profile globbing now applies on all platforms | **Windows gains coverage.** Validated on macOS only — **`UNVALIDATED` on real Windows.** |
| 7 | Module docstring: "stdlib only. **Windows-focused.**" | False after this change | Updated to "Cross-platform (Windows / macOS / Linux)". Still no third-party deps — `plistlib` and `configparser` are stdlib. |
| 8 | `discovery.py` used stdlib `logging` | `CLAUDE.md` requires `gaia.logger.get_logger` | Swapped. This file gains ~20 new log calls, so it had to comply before adding them. |
| 9 | Router `_DISCOVERY_SOURCES` omits `email_accounts` while `scan_all` includes it | The Agent UI surfaces **no** email discovery on any OS | **Out of scope, unchanged.** Surfacing sensitive email data in a new UI is a product call, not a platform fix. Worth a follow-up issue. |

Beyond the plan, the following came out of review and are in the diff: XDG-based Linux app-dir resolution, Snap/Flatpak Chromium roots, WAL sidecar copying, the `subprocess.CREATE_NO_WINDOW` guard (the symbol does not exist off Windows, which made the win32 cold-state assertions vacuous), and extending the platform gate to `stream_inference` and `_bootstrap_infer` — the plan had only covered `stream_discovery`.

**Evals: not required.** This change touches no system prompt, tool docstring, tool registration, JSON tool schema, error classifier, default model, tokenizer config, or tool-call parser — it is filesystem/subprocess scanning behind an unchanged `List[Dict]` contract. No baseline category (`context_retention`, `rag_quality`, `tool_selection`) exercises discovery. The only indirect path to a prompt is approved facts → memory, which is data gated behind the user's explicit `[Y/n/q]` approval.

## Test plan

- [x] `python util/lint.py --all` → `ALL QUALITY CHECKS PASSED`, Failed: 0
- [x] `python -m pytest tests/unit/test_memory_discovery.py tests/unit/test_memory_router.py -q` → 244 passed, 2 skipped. One pre-existing failure, `TestReconcileEndpoint::test_reconcile_returns_503_when_no_agent_and_faiss_missing`, is environmental: it asserts 503 for "faiss unavailable" but faiss is installed in a full local venv. It is untouched by this diff, exercises an endpoint this branch does not modify, and passes in CI, which installs without faiss.
- [x] `python -m pytest tests/unit/agents/test_discovery.py -q` → 49 passed (pre-existing discovery suite, unmodified, no regressions)
- [x] `python -m pytest tests/unit/ -q` → 7960 passed, 170 skipped, 5 failed. All five are pre-existing and environmental, none in a file this branch touches: the faiss `reconcile` test above, three `test_cli_smoke.py::test_gaia_binary_on_path` cases (console-script shims not on PATH in a bare venv), and `test_skills_cli.py::test_skills_package_ships_in_the_wheel` (setup.py package list vs. a working tree containing `src/gaia/apps/webui/node_modules`).
- [x] **Cold-state check** — `TestColdEmptyHome` runs all four scanners against an empty temp home on each platform; asserts `[]`, no exception, and no ERROR record. This is the new-user state, which a primed dev home hides.
- [x] **Call-validity check** — `TestKeychainContractShape` and `TestCredentialManagerContractShape` assert the *shape* of the outgoing subprocess call, not merely that it fired: exact argv list, never a shell string, `timeout` set, `-g`/`-w` never passed (so no secret is read and no auth modal appears).
- [x] **On a Mac**: `python -m gaia.cli memory bootstrap --discover`, answer `q` at the first prompt. Expect Chrome bookmarks and history from both `Default` and `Profile 1`, ~39 `/Applications` entries, one actionable Full-Disk-Access warning per TCC-blocked source, an explicit "no scanner for 'windows_userassist' on darwin" line, and `0 approved, 0 skipped` — nothing stored.
- [ ] **On Linux / Windows** (AMD hardware, `UNVALIDATED` here): same command; confirm the branches in deviations 3, 4, and 6.

## Evidence

- [x] **CLI** — `python -m gaia.cli memory bootstrap --discover` on darwin 25.1, answering `q`:

```
=== GAIA Memory Bootstrap — System Discovery ===
Scanning your system for projects, apps, and more...
Nothing is stored without your approval.

WARNING | discovery._extract_safari_bookmarks | Cannot read Safari bookmarks at
  ~/Library/Safari/Bookmarks.plist: [Errno 1] Operation not permitted. Grant Full Disk
  Access to the terminal or app running GAIA in System Settings → Privacy & Security →
  Full Disk Access, then re-run discovery.
WARNING | discovery._safe_copy_and_query_sqlite | Cannot read Safari history at
  ~/Library/Safari/History.db: [Errno 1] Operation not permitted. Grant Full Disk Access …
WARNING | discovery._scan_apple_mail | Cannot read Apple Mail accounts at ~/Library/Mail:
  [Errno 1] Operation not permitted. Grant Full Disk Access …
WARNING | discovery._scan_apple_mail | Cannot read Apple Mail accounts at
  ~/Library/Containers/com.apple.mail/…/com.apple.mail.plist: [Errno 1] Operation not permitted. …
INFO    | discovery._log_unsupported | no scanner for 'windows_userassist' on darwin
  (supported: win32) — nothing was scanned. Add a branch in
  src/gaia/agents/base/discovery.py and register the platform in _PLATFORM_SUPPORT,
  or open an issue at https://github.com/amd/gaia/issues.
Found 1009 items. Review each one:

  [Y] = approve (default)   [n] = skip   [q] = quit review

  (1/1009) Project 'Zoom' in Documents/ — unknown [unclassified]
    Approve? [Y/n/q]:   Review stopped.

✅ Discovery complete: 0 approved, 0 skipped.
```

  Four denials named with a remedy, one unsupported source named by OS, 1009 findings, and **nothing stored** — the review gate is intact. On `main` this same machine produced zero findings from these sources and zero log lines about it.

  Per-source counts and multi-profile proof from the same box:

```
profiles found: [('Chrome (Default)', 'Default'), ('Chrome (Profile 1)', 'Profile 1')]
installed_apps       ->   39 items (0 sensitive)
browser_bookmarks    ->  908 items (4 sensitive)
browser_history      ->   50 items (50 sensitive)
email_accounts       ->    0 items (0 sensitive)
macos_app_usage      ->    3 items (0 sensitive)
recent_file_types    ->    2 items (0 sensitive)
```

  All 50 history facts and every email fact remain `sensitive=True` unconditionally — the sensitivity contract is unchanged.

- [x] **HTTP API / REST** — `GET /api/memory/stream-discovery` against an empty home on darwin:

```
GET /api/memory/stream-discovery -> 200 text/event-stream; charset=utf-8
data: {"type": "log", "message": "  App usage frequency (Windows): no scanner for
  'windows_userassist' on darwin (supported: win32) — nothing was scanned."}
```

  Previously this streamed "Nothing found" — the UI could not distinguish an unsupported platform from an empty machine.

- [x] **Agent exposed in the Agent UI** (Memory Dashboard → Profile Setup) — **outstanding.** The discovery and inference SSE streams feeding this panel both changed, so a before→after browser screenshot is still owed. The event contract (`{"type": "finding" | "log" | "error" | "done"}`) is unchanged and no source key was added or removed, so `memoryApi.ts` and `MemoryDashboard.tsx` need no frontend change.
- [x] **MCP tools / servers** — N/A. No MCP server, tool, or bridge surface is touched.

## Checklist

- [x] I have linked a GitHub issue above (`Closes #1956`).
- [x] I have described **why** this change is being made, not just what changed.
- [x] I have run linting and tests locally (`python util/lint.py --all`, `pytest tests/unit/`).
- [x] I have attached **real-world evidence matched to the surface I changed** — CLI, HTTP API, and MCP are covered above; the Agent UI screenshot is still outstanding.
- [x] I have updated documentation if user-visible behavior changed — `docs/sdk/sdks/memory.mdx` and `docs/spec/agent-memory-architecture.md` updated together. No new CLI command or user-facing feature, so no new guide and no `docs.json` entry.
