### PR TITLE
fix(tui): sanitize agent error text

### DIFF
--- a/tui/internal/ui/chat/canonical.go
+++ b/tui/internal/ui/chat/canonical.go
@@ -162,7 +162,7 @@ func (m ChatModel) handleCanonicalEvent(evt interface{}) (ChatModel, tea.Cmd, bo
 	case event.CanonicalErrorEvent:
 		m.flushBuffer()
 		m.resolveConfirmationOnTurnEnd()
-		m.messages = append(m.messages, Message{Role: RoleError, Content: e.Detail})
+		m.messages = append(m.messages, Message{Role: RoleError, Content: sanitizeErrorText(e.Detail)})
 		m.drainPendingAttention()
 		m.streaming = false
 		m.activity = nil

--- a/tui/internal/ui/chat/canonical_test.go
+++ b/tui/internal/ui/chat/canonical_test.go
@@ -2,6 +2,7 @@ package chat
 
 import (
 	"context"
+	"errors"
 	"strings"
 	"testing"
 
@@ -204,6 +205,47 @@ func TestCanonicalErrorEndsTurnAndKeepsPartialText(t *testing.T) {
 	}
 	if !sawError {
 		t.Errorf("the actionable detail must be surfaced verbatim: %+v", m.messages)
+	}
+}
+
+func TestRoleErrorProducersSanitizeControlBytesPreserveNewlines(t *testing.T) {
+	malicious := "first\tvalue\r\nsecond\x1b]52;c;Y2xpcGJvYXJk\x07third\x1b[31mred\x1b[0m\x7f"
+	tests := []struct {
+		name  string
+		event interface{}
+	}{
+		{"canonical error", event.CanonicalErrorEvent{Type: "error", Detail: malicious}},
+		{"legacy agent error", event.AgentErrorEvent{Type: "agent_error", Content: malicious}},
+		{"legacy error", event.ErrorEvent{Type: "error", Content: malicious}},
+		{"transport error", errMsg{err: errors.New(malicious)}},
+		{"question delivery error", questionFailedMsg{err: errors.New(malicious)}},
+		{"confirmation delivery error", confirmActionResultMsg{Action: "send_draft", err: errors.New(malicious)}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m, _ := newTestModel(t)
+			switch tt.event.(type) {
+			case errMsg, questionFailedMsg, confirmActionResultMsg:
+				updated, _ := m.Update(tt.event)
+				m = updated.(ChatModel)
+			default:
+				updated, _ := m.handleEvent(tt.event)
+				m = updated.(ChatModel)
+			}
+			last := m.messages[len(m.messages)-1]
+			if last.Role != RoleError {
+				t.Fatalf("unexpected role %v", last.Role)
+			}
+			for _, control := range []rune{'\x1b', '\x07', '\r', '\t', '\x7f'} {
+				if strings.ContainsRune(last.Content, control) {
+					t.Errorf("control byte %U reached Message.Content: %q", control, last.Content)
+				}
+			}
+			if !strings.Contains(last.Content, "first value\nsecond") {
+				t.Errorf("message text or newline lost during sanitization: %q", last.Content)
+			}
+		})
 	}
 }
 

--- a/tui/internal/ui/chat/model.go
+++ b/tui/internal/ui/chat/model.go
@@ -345,7 +345,7 @@ func (m ChatModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.err = msg.err
 		m.messages = append(m.messages, Message{
 			Role:    RoleError,
-			Content: msg.err.Error(),
+			Content: sanitizeErrorText(msg.err.Error()),
 		})
 		m.drainPendingAttention()
 		m.activity = nil
@@ -370,7 +370,7 @@ func (m ChatModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case questionFailedMsg:
 		m.messages = append(m.messages, Message{
 			Role:    RoleError,
-			Content: msg.err.Error(),
+			Content: sanitizeErrorText(msg.err.Error()),
 		})
 		m.updateViewport()
 		return m, nil
@@ -403,7 +403,7 @@ func (m ChatModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if msg.err != nil {
 			m.messages = append(m.messages, Message{
 				Role:    RoleError,
-				Content: fmt.Sprintf("could not deliver the %s decision for '%s': %v", word, msg.Action, msg.err),
+				Content: sanitizeErrorText(fmt.Sprintf("could not deliver the %s decision for '%s': %v", word, msg.Action, msg.err)),
 			})
 		} else {
 			m.messages = append(m.messages, Message{
@@ -740,7 +740,7 @@ func (m ChatModel) handleEvent(evt interface{}) (tea.Model, tea.Cmd) {
 	case event.AgentErrorEvent:
 		m.messages = append(m.messages, Message{
 			Role:    RoleError,
-			Content: e.Content,
+			Content: sanitizeErrorText(e.Content),
 		})
 		m.streaming = false
 		m.activity = nil
@@ -750,7 +750,7 @@ func (m ChatModel) handleEvent(evt interface{}) (tea.Model, tea.Cmd) {
 	case event.ErrorEvent:
 		m.messages = append(m.messages, Message{
 			Role:    RoleError,
-			Content: e.Content,
+			Content: sanitizeErrorText(e.Content),
 		})
 		m.streaming = false
 		m.activity = nil

--- a/tui/internal/ui/chat/sanitize.go
+++ b/tui/internal/ui/chat/sanitize.go
@@ -6,11 +6,11 @@ import (
 	"github.com/charmbracelet/x/ansi"
 )
 
-// sanitizeErrorText makes a tool-supplied string safe for the RoleError sink.
+// sanitizeErrorText makes an untrusted string safe for the RoleError sink.
 //
 // Unlike the card path (box.add -> cards.clean()), model.go's RoleError case
 // renders "[!] " + msg.Content through a bare lipgloss style with no
-// scrubbing of its own — so a tool error reaching Message.Content unsanitized
+// scrubbing of its own — so error text reaching Message.Content unsanitized
 // can carry a live ANSI escape or control byte onto the terminal.
 // cards.clean() cannot be reused as-is: it maps newlines to spaces, which
 // would flatten the sidecar's `gaia connectors connect ...` remedy onto one


### PR DESCRIPTION
## Summary

Sanitize agent and transport error text before the TUI renders it, preventing terminal control sequences from reaching the terminal or clipboard.

## Why

Canonical error details and several legacy and delivery-failure paths bypassed the existing error sanitizer. A malformed error could therefore emit ANSI CSI, OSC 52, C0, or DEL bytes; all `RoleError` producers now share the sanitizer while preserving newlines in actionable remedies.

## Linked issue

Closes #2725

## Changes

- Route canonical, legacy, transport, question-delivery, and confirmation-delivery errors through `sanitizeErrorText`.
- Cover real CSI, OSC 52, C0, DEL, CR, tab, and newline behavior across every previously unsanitized producer.

## Test plan

- [x] `cd tui && go test ./internal/ui/chat/... -count=1`
- [x] `cd tui && go test ./... -count=1`
- [x] `cd tui && go vet ./...`
- [x] `cd tui && go build ./...`

## Evidence

The focused regression checks the raw terminal-bound text because a screenshot cannot demonstrate the absence of non-printing control bytes:

```text
$ go test ./internal/ui/chat/... -run TestRoleErrorProducersSanitizeControlBytesPreserveNewlines -count=1
ok  github.com/amd/gaia/tui/internal/ui/chat
```

- [ ] **Agent exposed in the Agent UI** — N/A; this changes the terminal TUI, not the browser Agent UI.
- [ ] **MCP tools / servers** — N/A; no MCP surface changed.
- [x] **CLI** — the regression above exercises every affected terminal-bound error path with real control bytes.
- [ ] **HTTP API / REST** — N/A; no HTTP surface changed.

## Checklist

- [x] I have linked a GitHub issue above (`Closes #N` / `Fixes #N` / `Refs #N`).
- [x] I have described **why** this change is being made, not just what changed.
- [x] I have run the applicable Go formatting, tests, vet, and build checks locally.
- [x] I have attached **real-world evidence matched to the surface I changed** (see Evidence above), or marked each surface N/A.
- [x] Documentation is unchanged because this corrects terminal sanitization without changing a documented command or workflow.
