### PR TITLE
fix(email): stop leaking classifier internals into triage card rationale

### DIFF
--- a/hub/agents/email/python/gaia_agent_email/tools/triage_heuristics.py
+++ b/hub/agents/email/python/gaia_agent_email/tools/triage_heuristics.py
@@ -107,8 +107,11 @@ class HeuristicResult:
     category without LLM consultation. ``confident=False`` means the
     heuristic returned a best-guess fallback (e.g., ``informational``)
     and the caller should escalate to the LLM. The ``reason`` field is
-    the source-of-truth for verbose-mode logging -- it tells the operator
-    exactly which rule fired.
+    rendered verbatim to the user as the attention card's "why" line
+    (#2744) -- it MUST read as a fact about the message (sender type,
+    a deadline, an urgency signal) and never as a classifier-internal
+    trace (a raw label constant, "escalating", "LLM", "heuristic", or a
+    ``--`` separator).
     """
 
     category: str
@@ -338,6 +341,26 @@ def _has_commitment_signal(subject_lower: str, body_lower: str) -> bool:
     return False
 
 
+# What each of IMPORTANT/STARRED means to the user who reads the "why"
+# line -- a flag they (or Gmail's significance model, echoing their own
+# behavior) set on the message, never the fact that it's being escalated.
+_MATCHED_LABEL_PHRASES = {
+    LABEL_IMPORTANT: "flagged as important",
+    LABEL_STARRED: "starred",
+}
+
+
+def _important_starred_reason(matched_labels: List[str]) -> str:
+    """Render the user-facing reason for the IMPORTANT/STARRED escalation.
+
+    The only ``reason`` built at runtime rather than as a source literal
+    (#2744) -- which of the two flags is set genuinely varies per message,
+    so it can't be a fixed string the way the other branches' reasons are.
+    """
+    phrases = [_MATCHED_LABEL_PHRASES[label] for label in matched_labels]
+    return " and ".join(phrases).capitalize()
+
+
 def classify_category_heuristic(
     subject: str,
     sender: str,
@@ -410,10 +433,7 @@ def classify_category_heuristic(
                 spam_confident=spam_confident,
                 is_phishing=is_phishing,
                 confident=False,
-                reason=(
-                    "Gmail CATEGORY_PROMOTIONS label set but body has a "
-                    "deadline/commitment signal -- escalating to LLM"
-                ),
+                reason="Looks like a promotional email, but mentions a deadline",
                 matched_label_ids=(LABEL_CATEGORY_PROMOTIONS,),
             )
         return HeuristicResult(
@@ -421,7 +441,7 @@ def classify_category_heuristic(
             is_spam=is_spam,
             spam_confident=spam_confident,
             confident=True,
-            reason="Gmail CATEGORY_PROMOTIONS label set",
+            reason="Looks like a promotional email",
             matched_label_ids=(LABEL_CATEGORY_PROMOTIONS,),
         )
 
@@ -436,10 +456,7 @@ def classify_category_heuristic(
                 spam_confident=spam_confident,
                 is_phishing=is_phishing,
                 confident=False,
-                reason=(
-                    "Gmail CATEGORY_SOCIAL label set but body has a "
-                    "deadline/commitment signal -- escalating to LLM"
-                ),
+                reason="Looks like a social media notification, but mentions a deadline",
                 matched_label_ids=(LABEL_CATEGORY_SOCIAL,),
             )
         return HeuristicResult(
@@ -447,7 +464,7 @@ def classify_category_heuristic(
             is_spam=is_spam,
             spam_confident=spam_confident,
             confident=True,
-            reason="Gmail CATEGORY_SOCIAL label set",
+            reason="Looks like a social media notification",
             matched_label_ids=(LABEL_CATEGORY_SOCIAL,),
         )
 
@@ -464,10 +481,7 @@ def classify_category_heuristic(
                 spam_confident=spam_confident,
                 is_phishing=is_phishing,
                 confident=False,
-                reason=(
-                    "Gmail CATEGORY_UPDATES label set but body has a "
-                    "deadline/commitment signal -- escalating to LLM"
-                ),
+                reason="Looks like an automated update, but mentions a deadline",
                 matched_label_ids=(LABEL_CATEGORY_UPDATES,),
             )
         return HeuristicResult(
@@ -475,7 +489,7 @@ def classify_category_heuristic(
             is_spam=is_spam,
             spam_confident=spam_confident,
             confident=True,
-            reason="Gmail CATEGORY_UPDATES label set",
+            reason="Looks like an automated update",
             matched_label_ids=(LABEL_CATEGORY_UPDATES,),
         )
 
@@ -488,7 +502,7 @@ def classify_category_heuristic(
             spam_confident=spam_confident,
             is_phishing=is_phishing,
             confident=True,
-            reason="Gmail CATEGORY_PERSONAL label set",
+            reason="Looks like personal correspondence",
             matched_label_ids=(LABEL_CATEGORY_PERSONAL,),
         )
 
@@ -503,7 +517,7 @@ def classify_category_heuristic(
                 spam_confident=spam_confident,
                 is_phishing=is_phishing,
                 confident=True,
-                reason=f"subject contains promotional keyword '{kw}'",
+                reason="Looks like a promotional email",
             )
 
     # 7. Automated-sender fallback -- newsletters, alert bots, etc.
@@ -521,10 +535,7 @@ def classify_category_heuristic(
                     spam_confident=spam_confident,
                     is_phishing=is_phishing,
                     confident=False,
-                    reason=(
-                        f"sender contains automated-sender keyword '{kw}' but "
-                        "subject has urgent signal -- escalating to LLM"
-                    ),
+                    reason="Automated sender, but subject signals urgency",
                 )
             return HeuristicResult(
                 category=CATEGORY_FYI,
@@ -532,7 +543,7 @@ def classify_category_heuristic(
                 spam_confident=spam_confident,
                 is_phishing=is_phishing,
                 confident=True,
-                reason=f"sender contains automated-sender keyword '{kw}'",
+                reason="Automated or no-reply sender",
             )
 
     # 8. Built-in IMPORTANT / STARRED labels -- Gmail has decided this is
@@ -552,7 +563,7 @@ def classify_category_heuristic(
             spam_confident=spam_confident,
             is_phishing=is_phishing,
             confident=False,
-            reason=f"Gmail flagged as {', '.join(matched)} -- escalating to LLM",
+            reason=_important_starred_reason(matched),
             matched_label_ids=tuple(matched),
         )
 
@@ -573,10 +584,7 @@ def classify_category_heuristic(
                 spam_confident=spam_confident,
                 is_phishing=is_phishing,
                 confident=False,
-                reason=(
-                    "List-Unsubscribe header present but body has a "
-                    "deadline/commitment signal -- escalating to LLM"
-                ),
+                reason="Looks like a newsletter, but mentions a deadline",
             )
         return HeuristicResult(
             category=CATEGORY_PROMOTIONAL,
@@ -584,7 +592,7 @@ def classify_category_heuristic(
             spam_confident=spam_confident,
             is_phishing=is_phishing,
             confident=True,
-            reason="List-Unsubscribe header present (RFC 2369 bulk-mail signal)",
+            reason="Looks like a newsletter",
         )
 
     # 9. No high-confidence heuristic matched -- escalate. Category is
@@ -600,7 +608,7 @@ def classify_category_heuristic(
         spam_confident=False,
         is_phishing=is_phishing,
         confident=False,
-        reason="no heuristic match -- escalating to LLM",
+        reason="No clear signal from the sender or subject",
     )
 
 

--- a/hub/agents/email/python/tests/test_commitment_veto_2113.py
+++ b/hub/agents/email/python/tests/test_commitment_veto_2113.py
@@ -74,7 +74,9 @@ def test_promotions_with_commitment_escalates():
         ),
     )
     assert r.confident is False  # escalated to LLM, not confidently archived
-    assert "deadline/commitment signal" in r.reason
+    # #2744: the reason is a fact about the message (it mentions a
+    # deadline), never the classifier's internal control-flow term.
+    assert "mentions a deadline" in r.reason
 
 
 def test_ordinary_promo_still_confident_archive():
@@ -96,7 +98,7 @@ def test_updates_budget_alert_escalates():
         body="Heads up: you have exceeded your budget for this month.",
     )
     assert r.confident is False
-    assert "deadline/commitment signal" in r.reason
+    assert "mentions a deadline" in r.reason
 
 
 def test_ordinary_update_still_confident_fyi():

--- a/hub/agents/email/python/tests/test_list_unsubscribe_signal_2643.py
+++ b/hub/agents/email/python/tests/test_list_unsubscribe_signal_2643.py
@@ -43,7 +43,9 @@ class TestListUnsubscribeSupplementarySignal:
         )
         assert r.confident is True
         assert r.category == CATEGORY_PROMOTIONAL
-        assert "list-unsubscribe" in r.reason.lower()
+        # #2744: a fact about the message (it reads like a newsletter),
+        # never the RFC 2369 header name that triggered it.
+        assert "newsletter" in r.reason.lower()
 
     def test_no_list_unsubscribe_no_other_signal_still_escalates(self):
         """Sanity: the flag is what makes the difference, not an unrelated change."""
@@ -130,7 +132,7 @@ class TestListUnsubscribeCommitmentVeto:
             has_list_unsubscribe=True,
         )
         assert r.confident is False
-        assert "deadline/commitment signal" in r.reason
+        assert "mentions a deadline" in r.reason
 
     def test_list_unsubscribe_without_commitment_signal_is_confident(self):
         r = classify_category_heuristic(
@@ -190,7 +192,11 @@ class TestListUnsubscribeCategoryFallbackNeverWins:
         )
         assert r.confident is True
         assert r.category == CATEGORY_PROMOTIONAL
-        assert "promotional keyword" in r.reason
+        # #2744: rule 6's reason text (a fact: this looks promotional) must
+        # win over rule 8.5's ("looks like a newsletter") -- proves
+        # precedence without asserting the retired internal keyword-match
+        # wording.
+        assert r.reason == "Looks like a promotional email"
 
     def test_automated_sender_fallback_still_takes_priority(self):
         """Rule 7 (automated sender) fires before the header check -- the
@@ -205,4 +211,6 @@ class TestListUnsubscribeCategoryFallbackNeverWins:
         )
         assert r.confident is True
         assert r.category == CATEGORY_FYI
-        assert "automated-sender keyword" in r.reason
+        # #2744: rule 7's reason (a fact: sent by an automated address)
+        # must win over rule 8.5's ("looks like a newsletter").
+        assert r.reason == "Automated or no-reply sender"

--- a/tests/unit/email/test_triage_heuristics.py
+++ b/tests/unit/email/test_triage_heuristics.py
@@ -22,11 +22,15 @@ Critical behaviour pinned by this suite:
 
 from __future__ import annotations
 
+import ast
+import inspect
+
 # EmailTriageAgent ships as the standalone gaia-agent-email wheel (#1102);
 # skip when a framework-only env lacks it.
 import pytest  # noqa: E402
 
 pytest.importorskip("gaia_agent_email")  # noqa: E402
+from gaia_agent_email.tools import triage_heuristics as triage_heuristics_module
 from gaia_agent_email.tools.triage_heuristics import (
     ALL_CATEGORIES,
     CATEGORY_FYI,
@@ -64,7 +68,9 @@ class TestSystemLabelIDs:
         assert result.category == CATEGORY_PROMOTIONAL
         assert result.is_spam is False
         assert result.confident is True
-        assert "CATEGORY_PROMOTIONS" in result.reason
+        # #2744: the reason is a fact about the message, never the raw
+        # Gmail label constant that triggered it.
+        assert result.reason == "Looks like a promotional email"
 
     def test_social_label_marks_low_priority(self):
         result = classify_category_heuristic(
@@ -83,7 +89,8 @@ class TestSystemLabelIDs:
         )
         assert result.category == CATEGORY_FYI
         assert result.confident is True
-        assert "CATEGORY_UPDATES" in result.reason
+        # #2744: a fact about the message, never the raw label constant.
+        assert result.reason == "Looks like an automated update"
 
     def test_human_label_name_does_NOT_match(self):
         """
@@ -97,9 +104,11 @@ class TestSystemLabelIDs:
             sender="news@example.com",
             label_ids=["Promotions", "INBOX"],  # human name — should NOT fire
         )
-        # "Your weekly newsletter" matches the "newsletter" keyword in the
-        # promo-keyword fallback, so the result IS low_priority — but the
-        # ``reason`` should reflect the keyword path, not the label path.
+        # "newsletter" was deliberately dropped from the promo-keyword
+        # fallback (#1266) to avoid killing internal company newsletters,
+        # so this falls all the way through to the no-match escalation --
+        # never the CATEGORY_PROMOTIONS branch either way.
+        assert result.confident is False
         assert "CATEGORY_PROMOTIONS" not in result.reason
 
     def test_user_defined_label_does_not_match_heuristic(self):
@@ -366,7 +375,9 @@ class TestEscalation:
             label_ids=[LABEL_INBOX],
         )
         assert result.confident is False
-        assert "no heuristic match" in result.reason
+        # #2744: describes the absence of a signal, never the classifier's
+        # own escalation step.
+        assert result.reason == "No clear signal from the sender or subject"
 
     def test_important_or_starred_escalate_with_actionable_hint(self):
         result = classify_category_heuristic(
@@ -689,3 +700,309 @@ class TestDefaultActionFor:
     def test_unknown_category_suggests_none(self):
         # Graceful fallback — unknown input yields "none", not an exception.
         assert default_action_for("BOGUS_CATEGORY") == "none"
+
+
+# ---------------------------------------------------------------------------
+# User-facing rationale must never leak classifier internals (#2744)
+#
+# ``HeuristicResult.reason`` used to be documented as a verbose-mode
+# logging detail only, but it is rendered verbatim as the attention card's
+# "why" line (``pre_scan_inbox_impl`` -> ``rationale`` -> the attention
+# envelope's ``why`` field). A raw Gmail label constant (``CATEGORY_``), an
+# internal control-flow term ("escalating", "LLM", "heuristic"), or a
+# ``--`` code-style separator reads as classifier internals to a user, not
+# a fact about their message.
+# ---------------------------------------------------------------------------
+
+_BANNED_SUBSTRINGS = ("category_", "escalating", "llm", "heuristic")
+_BANNED_SEPARATOR = " -- "
+
+
+def _reason_violations(text: str) -> list:
+    """Return which banned tokens (if any) appear in a rendered reason."""
+    lowered = text.lower()
+    hits = [token for token in _BANNED_SUBSTRINGS if token in lowered]
+    if _BANNED_SEPARATOR in text:
+        hits.append(repr(_BANNED_SEPARATOR))
+    return hits
+
+
+def _reason_literals_from_source() -> list:
+    """Statically collect every ``reason=`` string literal passed to a
+    ``HeuristicResult(...)`` call in the module source.
+
+    A *static* scan -- not just exercising the branches a test author
+    thought to drive at runtime -- so a new branch added later is caught
+    by this guard the moment its literal lands, even before any test
+    happens to exercise it (#2744's own ask: "a guard that catches a
+    future regression, not just a fix for today's strings").
+    """
+    source = inspect.getsource(triage_heuristics_module)
+    tree = ast.parse(source)
+    literals: list = []
+    for node in ast.walk(tree):
+        if not (isinstance(node, ast.Call) and isinstance(node.func, ast.Name)):
+            continue
+        if node.func.id != "HeuristicResult":
+            continue
+        for kw in node.keywords:
+            if kw.arg != "reason":
+                continue
+            value = kw.value
+            if isinstance(value, ast.Constant) and isinstance(value.value, str):
+                literals.append(value.value)
+            elif isinstance(value, ast.JoinedStr):
+                # f-string: the interpolated {...} parts are opaque at
+                # parse time, but any literal text around them still is
+                # -- and still must be checked.
+                literals.extend(
+                    piece.value
+                    for piece in value.values
+                    if isinstance(piece, ast.Constant) and isinstance(piece.value, str)
+                )
+            # Anything else (e.g. a helper-function call, for a reason
+            # that must vary at runtime) isn't scannable statically -- it
+            # is covered by its own exhaustive runtime test instead (see
+            # TestEveryEmittedReasonIsClean below).
+    return literals
+
+
+class TestReasonLiteralsNeverLeakClassifierInternals:
+    """Static guard (#2744): every ``reason=`` string literal already in
+    the source must read as a fact about the message, not a step the
+    classifier took. Fails the moment a new branch's literal reuses a
+    banned token, even before any test happens to exercise that branch."""
+
+    def test_scan_finds_the_known_reason_literals(self):
+        """Sanity check on the scan itself, so a change to
+        ``classify_category_heuristic`` that stops using ``HeuristicResult(
+        reason=...)`` (breaking the scan) fails loudly here instead of
+        silently disabling the guard below."""
+        literals = _reason_literals_from_source()
+        assert len(literals) >= 13, (
+            "expected the AST scan to find every reason= literal in "
+            f"triage_heuristics.py -- got {literals!r}; either a branch "
+            "was removed or the scan itself broke"
+        )
+
+    def test_no_banned_tokens_in_source_literals(self):
+        literals = _reason_literals_from_source()
+        offenders = {text: _reason_violations(text) for text in literals}
+        offenders = {text: hits for text, hits in offenders.items() if hits}
+        assert (
+            not offenders
+        ), f"classifier internals leaked into reason text: {offenders}"
+
+
+class TestEveryEmittedReasonIsClean:
+    """Behavioral guard (#2744): drive ``classify_category_heuristic``
+    through every branch -- including the one dynamic reason (the
+    IMPORTANT/STARRED escalation, built from a helper rather than a
+    literal, so the static scan above can't see it) -- and check what it
+    actually emits at runtime, not just what the source text says."""
+
+    @staticmethod
+    def _all_reasons() -> list:
+        reasons = []
+
+        # CATEGORY_PROMOTIONS -- confident, and commitment-veto (#2113).
+        reasons.append(
+            classify_category_heuristic(
+                subject="50% off",
+                sender="deals@shop.example",
+                label_ids=[LABEL_CATEGORY_PROMOTIONS],
+            ).reason
+        )
+        reasons.append(
+            classify_category_heuristic(
+                subject="Membership renewal",
+                sender="news@club.example",
+                label_ids=[LABEL_CATEGORY_PROMOTIONS],
+                body=(
+                    "Attendance is required. Failure to attend will "
+                    "result in suspension."
+                ),
+            ).reason
+        )
+
+        # CATEGORY_SOCIAL -- confident, and commitment-veto.
+        reasons.append(
+            classify_category_heuristic(
+                subject="Alice liked your post",
+                sender="notify@social.example",
+                label_ids=[LABEL_CATEGORY_SOCIAL],
+            ).reason
+        )
+        reasons.append(
+            classify_category_heuristic(
+                subject="Group event",
+                sender="notify@social.example",
+                label_ids=[LABEL_CATEGORY_SOCIAL],
+                body="RSVP by Friday or your reserved spot will be cancelled.",
+            ).reason
+        )
+
+        # CATEGORY_UPDATES -- confident, and commitment-veto. This is
+        # #2744's own live example (Gmail CATEGORY_UPDATES + a deadline
+        # in the body).
+        reasons.append(
+            classify_category_heuristic(
+                subject="Your shipment has been delivered",
+                sender="orders@store.example",
+                label_ids=[LABEL_CATEGORY_UPDATES],
+            ).reason
+        )
+        reasons.append(
+            classify_category_heuristic(
+                subject="Your monthly spending summary",
+                sender="alerts@bank.example",
+                label_ids=[LABEL_CATEGORY_UPDATES],
+                body="Heads up: you have exceeded your budget for this month.",
+            ).reason
+        )
+
+        # CATEGORY_PERSONAL -- confident (no commitment veto on this branch).
+        reasons.append(
+            classify_category_heuristic(
+                subject="Hi",
+                sender="mom@family.example",
+                label_ids=[LABEL_CATEGORY_PERSONAL],
+            ).reason
+        )
+
+        # Subject-keyword promo fallback (no category label at all).
+        reasons.append(
+            classify_category_heuristic(
+                subject="50% off — limited time",
+                sender="deals@shop.example",
+                label_ids=[LABEL_INBOX],
+            ).reason
+        )
+
+        # Automated-sender fallback: plain, and urgent-subject escalation
+        # (#1266).
+        reasons.append(
+            classify_category_heuristic(
+                subject="Build #4219 passed — all tests green",
+                sender="noreply@ci.example.com",
+                label_ids=[LABEL_INBOX],
+            ).reason
+        )
+        reasons.append(
+            classify_category_heuristic(
+                subject="[SEV1] API latency above SLA",
+                sender="alerts@acme-corp.example.com",
+                label_ids=[LABEL_INBOX],
+            ).reason
+        )
+
+        # IMPORTANT / STARRED -- all three matched-label combinations (the
+        # one reason that's built dynamically, not from a literal).
+        reasons.append(
+            classify_category_heuristic(
+                subject="Re: budget review",
+                sender="ceo@company.example",
+                label_ids=[LABEL_INBOX, LABEL_IMPORTANT],
+            ).reason
+        )
+        reasons.append(
+            classify_category_heuristic(
+                subject="Recipe",
+                sender="x@example.com",
+                label_ids=[LABEL_STARRED],
+            ).reason
+        )
+        reasons.append(
+            classify_category_heuristic(
+                subject="Recipe",
+                sender="x@example.com",
+                label_ids=[LABEL_IMPORTANT, LABEL_STARRED],
+            ).reason
+        )
+
+        # List-Unsubscribe (#2643) -- confident, and commitment-veto.
+        reasons.append(
+            classify_category_heuristic(
+                subject="This week at Northbay Supply",
+                sender="news@northbay-supply.example",
+                label_ids=[LABEL_INBOX],
+                body="Check out what's new this week.",
+                has_list_unsubscribe=True,
+            ).reason
+        )
+        reasons.append(
+            classify_category_heuristic(
+                subject="NOTUS Weekly",
+                sender="news@notus.example",
+                label_ids=[LABEL_INBOX],
+                body=(
+                    "Your community pass renewal is due. Confirm by "
+                    "Friday or your membership will be suspended."
+                ),
+                has_list_unsubscribe=True,
+            ).reason
+        )
+
+        # No heuristic match at all -- final fallback.
+        reasons.append(
+            classify_category_heuristic(
+                subject="Re: meeting at 3pm",
+                sender="alice@company.example",
+                label_ids=[LABEL_INBOX],
+            ).reason
+        )
+
+        return reasons
+
+    def test_covers_every_known_branch(self):
+        """Sanity check on the harness itself: 16 calls above, one per
+        distinct reason value (14 call sites, 3 of which are the dynamic
+        IMPORTANT/STARRED combinations sharing one call site) -> 16
+        collected, all non-empty."""
+        reasons = self._all_reasons()
+        assert len(reasons) == 16
+        assert all(reasons), f"a branch returned an empty reason: {reasons!r}"
+
+    def test_no_banned_tokens_in_any_emitted_reason(self):
+        reasons = self._all_reasons()
+        offenders = {text: _reason_violations(text) for text in reasons}
+        offenders = {text: hits for text, hits in offenders.items() if hits}
+        assert (
+            not offenders
+        ), f"classifier internals leaked into reason text: {offenders}"
+
+    def test_updates_commitment_veto_matches_2744_example(self):
+        """#2744's own live example: Gmail CATEGORY_UPDATES + a deadline
+        in the body must read as a fact about the message, not the
+        classifier's internal trace."""
+        result = classify_category_heuristic(
+            subject="Your monthly spending summary",
+            sender="alerts@bank.example",
+            label_ids=[LABEL_CATEGORY_UPDATES],
+            body="Heads up: you have exceeded your budget for this month.",
+        )
+        assert result.confident is False
+        assert "mentions a deadline" in result.reason
+        assert not _reason_violations(result.reason)
+
+    def test_important_starred_reasons_are_distinct_and_readable(self):
+        """The one dynamically-built reason still names an observable
+        fact (what was flagged), never a step the classifier took."""
+        important_only = classify_category_heuristic(
+            subject="Re: budget review",
+            sender="ceo@company.example",
+            label_ids=[LABEL_INBOX, LABEL_IMPORTANT],
+        ).reason
+        starred_only = classify_category_heuristic(
+            subject="Recipe",
+            sender="x@example.com",
+            label_ids=[LABEL_STARRED],
+        ).reason
+        both = classify_category_heuristic(
+            subject="Recipe",
+            sender="x@example.com",
+            label_ids=[LABEL_IMPORTANT, LABEL_STARRED],
+        ).reason
+        assert len({important_only, starred_only, both}) == 3
+        for text in (important_only, starred_only, both):
+            assert not _reason_violations(text)


### PR DESCRIPTION
Before, the triage card's "why" line read the classifier's internal trace verbatim — e.g. `Gmail CATEGORY_UPDATES label set but body has a deadline/commitment signal -- escalating to LLM`, which reads as a pending action the user is still waiting on. Now it says `Looks like an automated update, but mentions a deadline` — a fact about the message, stated as something that already happened. Every rationale string across every category path (promotions, social, updates, personal, the subject-keyword and automated-sender fallbacks, IMPORTANT/STARRED, List-Unsubscribe, and the no-match escalation) is reworded the same way, and a new guard test fails the build if a future branch reintroduces a raw label constant, "escalating to LLM", or a `--` separator.

**Scope note:** this fixes the strings inside `triage_heuristics.py` only. The composition wrappers in `read_tools.py` and `attention_tools.py` still wrap the now-clean text with their own scaffolding (`[heuristic said: …]`, a `--` separator) in the priority-sender and force-LLM-bypass paths, so a card can still show some of that scaffolding until #2743 lands the other half — filed there, not re-fixed here to avoid touching files that PR owns.

**Verification note:** #2743 is concurrently rewriting the renderer these strings pass through, so a real `gaia chat --agent email` card screenshot isn't meaningful evidence yet — it would show #2743's in-progress rendering, not this change in isolation. The right evidence for a string-only change is the behavioral test asserting what `classify_category_heuristic` actually emits (below); card-level verification rides #2743's real-world run.

Closes #2744

## Test plan

- [x] `python -m pytest hub/agents/email/python/tests -q` — full hub email package suite green (one unrelated, load-sensitive flake in `test_connectors_does_not_wedge_loop.py`, confirmed passing in isolation)
- [x] `python -m pytest tests/unit/email tests/unit/agents/email -q` — full top-level email suite green
- [x] `python util/lint.py --all` — clean (black, isort, pylint, flake8, bandit, agent conventions all pass; pre-existing mypy warnings elsewhere in the repo are unrelated)
- [x] New guard test drives every branch and asserts no banned token in any emitted reason:

  ```
  tests/unit/email/test_triage_heuristics.py::TestEveryEmittedReasonIsClean::test_covers_every_known_branch PASSED
  tests/unit/email/test_triage_heuristics.py::TestEveryEmittedReasonIsClean::test_no_banned_tokens_in_any_emitted_reason PASSED
  tests/unit/email/test_triage_heuristics.py::TestEveryEmittedReasonIsClean::test_updates_commitment_veto_matches_2744_example PASSED
  tests/unit/email/test_triage_heuristics.py::TestEveryEmittedReasonIsClean::test_important_starred_reasons_are_distinct_and_readable PASSED
  ```

<details>
<summary>Every reworded string (before → after)</summary>

| Branch | Before | After |
|---|---|---|
| Promotions, confident | `Gmail CATEGORY_PROMOTIONS label set` | `Looks like a promotional email` |
| Promotions + deadline veto | `Gmail CATEGORY_PROMOTIONS label set but body has a deadline/commitment signal -- escalating to LLM` | `Looks like a promotional email, but mentions a deadline` |
| Social, confident | `Gmail CATEGORY_SOCIAL label set` | `Looks like a social media notification` |
| Social + deadline veto | `Gmail CATEGORY_SOCIAL label set but body has a deadline/commitment signal -- escalating to LLM` | `Looks like a social media notification, but mentions a deadline` |
| Updates, confident | `Gmail CATEGORY_UPDATES label set` | `Looks like an automated update` |
| Updates + deadline veto (the issue's own example) | `Gmail CATEGORY_UPDATES label set but body has a deadline/commitment signal -- escalating to LLM` | `Looks like an automated update, but mentions a deadline` |
| Personal, confident | `Gmail CATEGORY_PERSONAL label set` | `Looks like personal correspondence` |
| Subject-keyword promo fallback | `subject contains promotional keyword '{kw}'` | `Looks like a promotional email` |
| Automated-sender, confident | `sender contains automated-sender keyword '{kw}'` | `Automated or no-reply sender` |
| Automated-sender + urgent subject | `sender contains automated-sender keyword '{kw}' but subject has urgent signal -- escalating to LLM` | `Automated sender, but subject signals urgency` |
| IMPORTANT/STARRED (dynamic) | `Gmail flagged as {labels} -- escalating to LLM` | `Flagged as important` / `Starred` / `Flagged as important and starred` |
| List-Unsubscribe, confident | `List-Unsubscribe header present (RFC 2369 bulk-mail signal)` | `Looks like a newsletter` |
| List-Unsubscribe + deadline veto | `List-Unsubscribe header present but body has a deadline/commitment signal -- escalating to LLM` | `Looks like a newsletter, but mentions a deadline` |
| No match (final fallback) | `no heuristic match -- escalating to LLM` | `No clear signal from the sender or subject` |

CATEGORY_UPDATES intentionally does **not** say "newsletter" — that branch's own code comment describes its contents as receipts, shipping confirmations, and calendar updates, so "newsletter" would trade one inaccuracy for another. "Newsletter" is reserved for the List-Unsubscribe branch, which is the actual RFC 2369 mailing-list signal.

</details>
