### PR TITLE
fix(email-agent): search_messages states an exact, stable message count

### DIFF
--- a/hub/agents/email/python/CHANGELOG.md
+++ b/hub/agents/email/python/CHANGELOG.md
@@ -9,6 +9,20 @@ contract version is tracked separately as
 
 ### Fixed
 
+- **`search_messages` stated a wrong, unstable count for a result set it
+  received intact (#2756).** Asked "how many messages from X in the last two
+  weeks", the agent ran the right query, got every matching row back, then
+  reported a number that was both wrong and different on every run (measured:
+  12 real messages stated as 6, then 4). The registered `search_messages`
+  tool's merge layer now precomputes an exact `count` for the model to state
+  verbatim, the same remedy `check_followups` already shipped for the
+  identical failure (#2622). `truncated` is derived only from Gmail's real
+  pagination cursor, never from `len(messages) == max_results` — a sender
+  with exactly `max_results` matches and no further pages reports
+  `truncated: false`, not a coincidentally-correct guess. `operator_retry`
+  (computed by `search_messages_impl` since inception but silently dropped
+  by the wrapper) now reaches the model too, so a broadened retry query is
+  disclosed rather than presented as the user's literal search.
 - **A reconnect with no explicit `--scopes` could silently overwrite a working
   mail+calendar connection with identity-only sign-in scopes (#2730).**
   `list(scopes) or list(provider.default_scopes)` at four `gaia.connectors`

--- a/hub/agents/email/python/gaia_agent_email/tools/read_tools.py
+++ b/hub/agents/email/python/gaia_agent_email/tools/read_tools.py
@@ -874,11 +874,19 @@ def search_messages_impl(
             max_results=max_results,
             budget_tokens=budget_tokens,
         )
-        summary: Dict[str, Any] = {"count": len(out)}
+        # Real cursor only -- never len(stubs) == max_results (see
+        # _list_all_stubs's scan_truncated docstring above for why that
+        # heuristic is wrong the moment a mailbox's true size matches the ask).
+        truncated = bool(listing.get("nextPageToken"))
+        summary: Dict[str, Any] = {"count": len(out), "truncated": truncated}
         if retried_query is not None:
             summary["operator_retry"] = retried_query
         st["result_summary"] = summary
-        return {"messages": out, "operator_retry": retried_query}
+        return {
+            "messages": out,
+            "operator_retry": retried_query,
+            "truncated": truncated,
+        }
 
 
 def list_labels_impl(gmail, *, debug: bool = False) -> List[Dict[str, Any]]:
@@ -2221,6 +2229,24 @@ class ReadToolsMixin:
             every requested hit, the tool returns an actionable error instead of
             silently returning fewer hits than asked for — retry with a smaller
             ``max_results``.
+
+            Returns:
+                JSON envelope with ``{"messages": [...]}`` plus ``count`` (the
+                exact length of ``messages`` — state this number verbatim in
+                your reply rather than counting the list yourself) and
+                ``truncated`` (true when more matches exist beyond
+                ``max_results`` — say "at least N", never present N as the
+                total). REPORT EVERY ENTRY in ``messages`` individually — do
+                not summarize, merge, or quietly drop entries from a long
+                list. If ``operator_retry`` is present, the literal query you
+                passed found nothing and this is the broadened operator query
+                that was retried instead — say the search was broadened
+                before stating the count, since it may include hits (e.g. a
+                subject match) beyond what the user's literal phrase meant.
+                If ``mailbox_errors`` is present, ``count`` and ``truncated``
+                cover only the mailboxes that succeeded — say the count is
+                partial, not the complete total across every connected
+                mailbox.
             """
             try:
                 max_results = max(1, min(int(max_results or 25), 100))
@@ -2230,6 +2256,13 @@ class ReadToolsMixin:
                 per_backend = max(1, max_results // len(backends))
                 merged: List[Dict[str, Any]] = []
                 mailbox_errors: List[Dict[str, Any]] = []
+                # Computed here, not forwarded from search_messages_impl alone
+                # (#2756) -- this closure builds a fresh envelope dict and
+                # previously kept only "messages" off each backend's result,
+                # which is why operator_retry never reached the model despite
+                # being computed since inception.
+                truncated = False
+                operator_retry_query: Optional[str] = None
                 for provider, backend in backends.items():
                     if len(merged) >= max_results:
                         break
@@ -2252,6 +2285,9 @@ class ReadToolsMixin:
                             msg,
                         )
                         continue
+                    truncated = truncated or bool(result.get("truncated"))
+                    if result.get("operator_retry"):
+                        operator_retry_query = result["operator_retry"]
                     for msg in result.get("messages", []):
                         msg["mailbox"] = provider
                         agent._remember_message_mailbox(msg.get("id"), provider)
@@ -2266,7 +2302,15 @@ class ReadToolsMixin:
                             f"{e['mailbox']}: {e['error']}" for e in mailbox_errors
                         )
                     )
-                out: Dict[str, Any] = {"messages": merged[:max_results]}
+                messages = merged[:max_results]
+                out: Dict[str, Any] = {
+                    "messages": messages,
+                    # Exact, precomputed -- state this number verbatim rather
+                    # than counting the list yourself (#2756).
+                    "count": len(messages),
+                    "truncated": truncated,
+                    "operator_retry": operator_retry_query,
+                }
                 if mailbox_errors:
                     out["mailbox_errors"] = mailbox_errors
                 return _envelope_ok(out)

--- a/hub/agents/email/python/tests/test_search_messages_count_2756.py
+++ b/hub/agents/email/python/tests/test_search_messages_count_2756.py
@@ -1,0 +1,356 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""``search_messages`` precomputed count/truncated/operator_retry (#2756).
+
+The model is asked today to count/enumerate ``search_messages``'s
+``messages`` list itself and gets it wrong. This issue adds three fields
+to the envelope, computed at the WRAPPER (registered ``@tool`` closure)
+layer -- not ``search_messages_impl``, whose return value the wrapper
+today discards except for its ``"messages"`` key:
+
+- ``count``: exact, ``len(messages)`` in the same envelope.
+- ``truncated``: derived ONLY from the Gmail provider's real pagination
+  cursor (``nextPageToken``) -- NEVER from ``len(stubs) == max_results``.
+  A sender with exactly ``max_results`` matches and no ``nextPageToken``
+  must report ``truncated: False`` -- the anti-heuristic regression case
+  and the most important test below.
+- ``operator_retry``: already computed by ``search_messages_impl`` (the
+  zero-hit-then-operatorized-retry path) but currently dropped by the
+  wrapper before it reaches the model.
+
+TDD split (red/green): none of ``count``, ``truncated``, or forwarded
+``operator_retry`` exist on the registered ``search_messages`` tool today
+-- every test in this file is RED, either via a missing-key ``KeyError``
+(most tests) or an assertion that the naive ``len(stubs) == max_results``
+heuristic would satisfy but the correct cursor-derived contract does not
+(the AC2 test).
+
+Deliberately tests through the REGISTERED tool closure (never
+``search_messages_impl`` directly) -- the wrapper is what discards
+``operator_retry`` and is where ``count``/``truncated`` must be computed,
+so calling ``_impl`` alone would false-green the bug this issue fixes.
+
+Hermetic: ``FakeGmailBackend`` (and small local subclasses of it) only,
+no Lemonade, no network.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any, Dict, List, Tuple
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Path / import bootstrap (mirrors test_read_tools_list_inbox_budget_2514.py)
+# ---------------------------------------------------------------------------
+
+# parents[0] = tests/, [1] = python/, [2] = email/, [3] = agents/, [4] = hub/,
+# [5] = repo-root
+_REPO_ROOT = Path(__file__).resolve().parents[5]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+pytest.importorskip("gaia_agent_email")
+
+from gaia_agent_email.tools.read_tools import (  # noqa: E402
+    ReadToolsMixin,
+    operatorize_query,
+)
+
+from gaia.agents.base.tools import _TOOL_REGISTRY  # noqa: E402
+from tests.fixtures.email.fake_gmail import FakeGmailBackend  # noqa: E402
+
+# ---------------------------------------------------------------------------
+# Fixture helpers (adapted from test_read_tools_list_inbox_budget_2514.py)
+# ---------------------------------------------------------------------------
+
+
+def _b64url(text: str) -> str:
+    return base64.urlsafe_b64encode(text.encode("utf-8")).decode("ascii").rstrip("=")
+
+
+def _msg_with_body(msg_id: str, body_text: str, **overrides: Any) -> Dict[str, Any]:
+    """Minimal Gmail API v1 message dict with a single-part text/plain body.
+
+    Bodies are kept short (unlike the #2514 budget-test fixtures) --
+    count/truncated/operator_retry are orthogonal to envelope-budget
+    shrinkage, so these fixtures stay well clear of that code path.
+    """
+    msg: Dict[str, Any] = {
+        "id": msg_id,
+        "threadId": msg_id,
+        "labelIds": ["INBOX"],
+        "snippet": body_text[:200],
+        "internalDate": "1750000000000",
+        "payload": {
+            "mimeType": "text/plain",
+            "filename": "",
+            "headers": [
+                {"name": "Subject", "value": "Test"},
+                {"name": "From", "value": "alice@example.com"},
+                {"name": "To", "value": "user@example.com"},
+                {"name": "Date", "value": "Mon, 1 Jan 2026 00:00:00 +0000"},
+            ],
+            "body": {
+                "data": _b64url(body_text),
+                "size": len(body_text.encode("utf-8")),
+            },
+        },
+        "sizeEstimate": len(body_text),
+    }
+    msg.update(overrides)
+    return msg
+
+
+def _seed_backend(n: int, *, id_prefix: str = "m") -> FakeGmailBackend:
+    """Seed a plain ``FakeGmailBackend`` with ``n`` distinct INBOX messages."""
+    gmail = FakeGmailBackend(user_email="user@example.com")
+    base_date = 1_800_000_000_000
+    for i in range(n):
+        msg_id = f"{id_prefix}{i}"
+        gmail.add_message(
+            _msg_with_body(
+                msg_id,
+                "hello world",
+                threadId=msg_id,
+                internalDate=str(base_date - i),
+            )
+        )
+    return gmail
+
+
+class _PagedGmailBackend(FakeGmailBackend):
+    """Injects a truthy ``nextPageToken`` on every ``list_messages`` call.
+
+    Mirrors ``_MorePagesGmailBackend`` in ``test_attention_tools.py`` --
+    ``FakeGmailBackend`` itself always returns ``nextPageToken: None``, so a
+    real "more results exist" signal needs a small local override.
+    """
+
+    def list_messages(self, **kwargs: Any) -> Dict[str, Any]:
+        out = dict(super().list_messages(**kwargs))
+        out["nextPageToken"] = "more-results-token"
+        return out
+
+
+class _ExactQueryGmailBackend(FakeGmailBackend):
+    """Routes ``list_messages`` by exact query-string match.
+
+    Mirrors ``_RecordingBackend`` in ``test_search_operator_retry.py`` --
+    ``operatorize_query`` produces an ``from:(...) OR subject:(...)`` shape
+    that ``FakeGmailBackend``'s real (AND-of-tokens) query tokenizer cannot
+    parse, so these retry tests route by literal string instead.
+    """
+
+    def __init__(self, *args: Any, hits_for: Dict[str, List[str]], **kwargs: Any):
+        super().__init__(*args, **kwargs)
+        self._hits_for = hits_for
+
+    def list_messages(
+        self, *, query: Any = None, max_results: int = 25, **kwargs: Any
+    ) -> Dict[str, Any]:
+        ids = self._hits_for.get(query, [])
+        return {
+            "messages": [{"id": mid, "threadId": mid} for mid in ids[:max_results]],
+            "nextPageToken": None,
+            "resultSizeEstimate": len(ids),
+        }
+
+
+# ---------------------------------------------------------------------------
+# Minimal tool-hosting stand-in (copied as-is from
+# test_read_tools_list_inbox_budget_2514.py's ``_Host`` -- the established
+# pattern for exercising a registered read-tool closure)
+# ---------------------------------------------------------------------------
+
+
+class _Host(ReadToolsMixin):
+    """Minimal stand-in for EmailTriageAgent's tool-hosting surface."""
+
+    def __init__(self, backend: FakeGmailBackend):
+        self._gmail = backend
+        self._backends = {"google": backend}
+        self._message_mailbox: Dict[str, str] = {}
+        self.config = SimpleNamespace(debug=False)
+
+    def _remember_message_mailbox(self, message_id, provider):
+        if message_id:
+            self._message_mailbox[message_id] = provider
+
+    def _backend_for_message(self, message_id, explicit_mailbox=None):
+        provider = explicit_mailbox or self._message_mailbox.get(message_id)
+        if provider is None:
+            if len(self._backends) == 1:
+                return next(iter(self._backends.values()))
+            raise ValueError("ambiguous mailbox in test stub")
+        backend = self._backends.get(provider)
+        if backend is None:
+            raise ValueError("mailbox not connected in test stub")
+        return backend
+
+
+def _registered_search_messages(host: _Host):
+    _TOOL_REGISTRY.clear()
+    host._register_read_tools()
+    assert "search_messages" in _TOOL_REGISTRY
+    return _TOOL_REGISTRY["search_messages"]["function"]
+
+
+def _call(search_messages, **kwargs) -> Dict[str, Any]:
+    payload = json.loads(search_messages(**kwargs))
+    assert payload["ok"] is True, payload
+    return payload["data"]
+
+
+# ---------------------------------------------------------------------------
+# AC1 -- exact count under the ceiling
+# ---------------------------------------------------------------------------
+
+
+class TestCountUnderCeiling:
+    def test_count_matches_len_messages_and_is_untruncated(self):
+        gmail = _seed_backend(12)
+        host = _Host(gmail)
+        search_messages = _registered_search_messages(host)
+
+        data = _call(search_messages, query="", max_results=25)
+
+        assert data["count"] == 12
+        assert data["count"] == len(data["messages"])
+        assert data["truncated"] is False
+
+
+# ---------------------------------------------------------------------------
+# AC2 -- anti-heuristic regression: hitting the ceiling with no real cursor
+# must NOT be reported as truncated. This is the single most important
+# assertion in this file: it fails under a naive
+# ``len(stubs) == max_results`` implementation (which this exact fixture
+# satisfies -- 25 seeded messages, max_results=25) and only passes when
+# ``truncated`` is derived from the backend's real ``nextPageToken``, which
+# plain ``FakeGmailBackend`` always reports as ``None``.
+# ---------------------------------------------------------------------------
+
+
+class TestTruncatedFalseWhenCeilingExactlyMatchesNoRealCursor:
+    def test_ceiling_hit_with_no_next_page_token_is_not_truncated(self):
+        gmail = _seed_backend(25)
+        host = _Host(gmail)
+        search_messages = _registered_search_messages(host)
+
+        data = _call(search_messages, query="", max_results=25)
+
+        assert data["count"] == 25
+        # The anti-heuristic guard: len(messages) == max_results here, but
+        # the backend never signaled a real next page -- truncated must be
+        # False, not derived from the count/ceiling coincidence.
+        assert data["truncated"] is False
+
+
+# ---------------------------------------------------------------------------
+# AC2 (positive case) -- a genuine backend-signaled cursor DOES mean
+# truncated, even well under the requested ceiling.
+# ---------------------------------------------------------------------------
+
+
+class TestTruncatedTrueWhenProviderSignalsMorePages:
+    def test_real_next_page_token_marks_truncated(self):
+        gmail = _PagedGmailBackend(user_email="user@example.com")
+        for i in range(5):
+            msg_id = f"m{i}"
+            gmail.add_message(_msg_with_body(msg_id, "hello world", threadId=msg_id))
+        host = _Host(gmail)
+        search_messages = _registered_search_messages(host)
+
+        data = _call(search_messages, query="", max_results=25)
+
+        assert data["count"] == 5
+        assert data["truncated"] is True
+
+
+# ---------------------------------------------------------------------------
+# AC5 -- zero hits: count 0, empty messages, untruncated, and the retry
+# mechanism still runs (and is forwarded) even when the retry itself finds
+# nothing.
+# ---------------------------------------------------------------------------
+
+
+class TestZeroHits:
+    def test_zero_hits_reports_zero_count_and_forwards_the_attempted_retry(self):
+        literal_query = "totally absent phrase nobody sent"
+        retry_query = operatorize_query(literal_query)
+        gmail = _ExactQueryGmailBackend(user_email="user@example.com", hits_for={})
+        host = _Host(gmail)
+        search_messages = _registered_search_messages(host)
+
+        data = _call(search_messages, query=literal_query, max_results=25)
+
+        assert data["count"] == 0
+        assert data["messages"] == []
+        assert data["truncated"] is False
+        # The retry mechanism ran (the literal query has no operator and
+        # zero hits) even though it also found nothing -- the wrapper must
+        # still forward that it was attempted, not silently drop it.
+        assert data["operator_retry"] == retry_query
+
+
+# ---------------------------------------------------------------------------
+# AC3 -- operator_retry round-trips through the REGISTERED tool when the
+# retry actually finds a hit the literal query missed.
+# ---------------------------------------------------------------------------
+
+
+class TestOperatorRetryRoundTripsThroughTheRegisteredTool:
+    def test_operator_retry_forwarded_with_hits_found_on_retry(self):
+        literal_query = "Netflix promotional email"
+        retry_query = operatorize_query(literal_query)
+        gmail = _ExactQueryGmailBackend(
+            user_email="user@example.com", hits_for={retry_query: ["hit1"]}
+        )
+        gmail.add_message(_msg_with_body("hit1", "hello world", threadId="hit1"))
+        host = _Host(gmail)
+        search_messages = _registered_search_messages(host)
+
+        data = _call(search_messages, query=literal_query, max_results=25)
+
+        assert isinstance(data["operator_retry"], str)
+        assert data["operator_retry"] == retry_query
+        assert data["operator_retry"]
+        assert data["count"] == 1
+        assert len(data["messages"]) == 1
+
+
+# ---------------------------------------------------------------------------
+# AC4 -- the LLM-facing docstring must instruct the model to trust the
+# precomputed count/enumeration rather than re-deriving it. Load-bearing:
+# ``tools.py`` stores ``f.__doc__`` verbatim as the tool's description sent
+# to the model, so this wording is functionally part of the contract.
+# ---------------------------------------------------------------------------
+
+
+class TestDocstringInstructsTrustingThePrecomputedFields:
+    def test_description_mentions_state_this_number_verbatim(self):
+        _TOOL_REGISTRY.clear()
+        host = _Host(_seed_backend(1))
+        host._register_read_tools()
+
+        description = _TOOL_REGISTRY["search_messages"]["description"]
+
+        assert "state this number verbatim" in description
+
+    def test_description_mentions_report_every_entry(self):
+        _TOOL_REGISTRY.clear()
+        host = _Host(_seed_backend(1))
+        host._register_read_tools()
+
+        description = _TOOL_REGISTRY["search_messages"]["description"]
+
+        assert "REPORT EVERY ENTRY" in description
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/hub/agents/email/python/tests/test_search_messages_count_2756.py
+++ b/hub/agents/email/python/tests/test_search_messages_count_2756.py
@@ -41,7 +41,7 @@ import json
 import sys
 from pathlib import Path
 from types import SimpleNamespace
-from typing import Any, Dict, List, Tuple
+from typing import Any, Dict, List
 
 import pytest
 


### PR DESCRIPTION
Closes #2756

Ask the email agent "how many messages from X in the last two weeks?" and it returned a wrong number — and a *different* wrong number each time. Measured on a real Gmail mailbox: 12 real messages reported as 6, then as 4, while the same session could correctly list 10 of them by name. TechCrunch: 19 real, reported as 11, then 14. The search was always correct and the full result set always reached the model; it simply miscounted a list it had in front of it. The tool now counts the results itself and hands the model a finished number to state verbatim — the same remedy that fixed this exact defect in `check_followups` (#2622) and was never ported here.

The one-line version of the bug: the registered `search_messages` tool rebuilt its envelope from scratch (`out = {"messages": ...}`), reading only `messages` off the implementation and silently discarding everything else. `operator_retry` had been computed since the tool was written and has **never once** reached the model as a result. The fix lives at that merge layer, not in `search_messages_impl` — an implementation-only change would have been a no-op.

## Test plan

- [x] `pytest hub/agents/email/python/tests/test_search_messages_count_2756.py` — 7 new tests, written red-first against the **registered** tool (`_TOOL_REGISTRY["search_messages"]`), not the impl, since testing the impl in isolation false-greens exactly the gap above. Initial run failed with `KeyError: 'count'` / `KeyError: 'operator_retry'`; now 7 passed.
- [x] `pytest hub/agents/email/python/tests/` — 1633 passed.
- [x] `python util/lint.py --all` — 10/11 pass, 1 pre-existing MyPy warning (none in touched files, confirmed by diffing against `main`).
- [ ] **Live-inference check (blocked, see below).** On a real Gmail mailbox, GPU: `from:"The Neuron" newer_than:14d` (true 12) must state **12** on 3 consecutive runs, with a follow-up enumerating all 12 rows.

<details>
<summary>Why <code>truncated</code> is not <code>len(stubs) == max_results</code></summary>

It is `bool(listing.get("nextPageToken"))`, from the provider's real cursor. This file already forbids the length heuristic in its own words at `read_tools.py:994-998` — *"honest only by coincidence and wrong the moment a mailbox's true size exactly equals the request"* — and implements the correct form at `:1026-1034`. A sender with exactly 25 matches and no next page would otherwise be reported as "at least 25", a worse answer than the tool already had the data to give. There is a regression test for precisely that case.

`next_page_token` is deliberately **not** added to the envelope: no tool in this file accepts a `page_token` argument, so a propagated token is unconsumable, and merging tokens across two backends is a design `list_inbox` never solved (its wrapper hardcodes `"next_page_token": None`). Deferred with multi-mailbox aggregation.
</details>

<details>
<summary>Evidence this remedy works on this model class</summary>

The identical fix was validated on `check_followups` on 2026-08-03 (Gemma-4-E4B-it-GGUF / GPU / ctx 65536, Gmail-only): **22 stated and 22 enumerated on 6 of 6 runs** — 3 REST, 3 TUI — against a true 22. That same tool reported 13 / ~19 / ~15–16 against that same 22 in July, so #2622 is confirmed genuinely fixed rather than presumed, and the precomputed-`count` approach demonstrably reaches this model and is used.
</details>

## Scope — what this does NOT fix

**A separate, reproducible defect remains on this tool: for a large-body sender the agent returns no answer at all.** Verified on GPU/Gmail with `from:Every newer_than:14d` (15 messages, both phrasings, model-chosen `max_results` of 100 and 50): the tool call succeeds, then the agent hits the context-overflow fallback at `src/gaia/agents/base/agent.py:3758` — *"I had to trim the conversation to fit my memory…"*. A precomputed count cannot help a turn that never reaches the answering stage. Reproduced independently on two machines and two OSes, so it is not platform-specific.

That is tracked separately and is **not** addressed here. The underlying design smell is worth stating: `search_messages` ships full 4000-char message bodies for questions like "how many emails from X" that need zero body bytes. A metadata-only path would remove the overflow failure mode outright rather than mitigate it.

Multi-mailbox aggregation semantics (`count`/`truncated` across two backends, partial-failure counts) are likewise out of scope — this ran Gmail-only. The wrapper ORs `truncated` and documents that `count` covers only surviving mailboxes when `mailbox_errors` is present, so it is honest, but the contract is not designed here.
