### PR TITLE
fix(ci): run the Gemma consolidation eval in bash, not PowerShell

### DIFF
--- a/.github/workflows/test_eval_agent_gemma_consolidation.yml
+++ b/.github/workflows/test_eval_agent_gemma_consolidation.yml
@@ -145,27 +145,32 @@ jobs:
     # upload too — so an overrun costs an hour of runner time AND the evidence.
     # 150 buys real headroom; drop it once a few runs establish the true wall time.
     timeout-minutes: 150
+    defaults:
+      run:
+        # The lemonade-eval pool is WINDOWS (real Ryzen AI hardware + Lemonade),
+        # where the default shell is PowerShell — but every step below is bash
+        # (`set -euo pipefail`, `trap`, `&`, `curl … > /dev/null`). Without this
+        # the first step dies on `source: not recognized` and the job has never
+        # once gone green. Git Bash ships on the runner, so pin it explicitly.
+        shell: bash
     steps:
       - name: Checkout
         uses: actions/checkout@v7
 
-      - name: Set up Python
-        uses: actions/setup-python@v7
+      # Cross-platform venv (uv) — the same action the other Windows evals on
+      # this pool use. It appends the venv's bin dir (Scripts\ on Windows, bin/
+      # on POSIX) to GITHUB_PATH, so the hand-rolled `source .venv/bin/activate`
+      # this replaces — a POSIX-only path — cannot strand the job again.
+      #
+      # [dev] + [eval] for the eval harness and the Anthropic judge deps;
+      # [ui] for fastapi/uvicorn + the RAG deps gaia.ui.server imports at boot
+      # ([dev] alone fails at import), [api] for the connectors layer.
+      - name: Set up Python + dependencies in isolated venv
+        uses: ./.github/actions/setup-venv
         with:
+          venv-name: '.venv-agent-eval'
           python-version: '3.10'
-          cache: 'pip'
-
-      - name: Install dependencies in isolated venv
-        run: |
-          python -m venv .venv-agent-eval
-          source .venv-agent-eval/bin/activate
-          python -m pip install --upgrade pip
-          # [dev] + [eval] for the eval harness and the Anthropic judge deps;
-          # [ui] for fastapi/uvicorn + the RAG deps gaia.ui.server imports at boot
-          # ([dev] alone fails at import), [api] for the connectors layer.
-          pip install -e ".[dev,eval,ui,api]"
-          # Make the venv bin available to subsequent workflow steps.
-          echo "$PWD/.venv-agent-eval/bin" >> "$GITHUB_PATH"
+          install-package: '-e .[dev,eval,ui,api]'
 
       - name: Preflight — judge key, baselines, Lemonade
         env:


### PR DESCRIPTION
The Gemma consolidation eval has never gone green since it landed, and the reason was hidden until this week: the `lemonade-eval` pool is Windows, where the default shell is PowerShell, but every step in this workflow is bash. Step one died on `source : The term 'source' is not recognized as the name of a cmdlet` before installing a single dependency. Until now every run showed up as `cancelled` — the pool was starved and jobs aged out after 24h — so the actual defect never surfaced. With the pool freed up the runs finally execute, and they fail here instead. The practical effect is that no PR touching an LLM-affecting path has had a real eval gate behind it.

Two changes: pin the job's default shell to bash (Git Bash ships on the runner, and the sibling Windows workflows already use `shell: bash`), and replace the hand-rolled `python -m venv` + `source .venv-agent-eval/bin/activate` with the shared `setup-venv` action the other Windows evals on this pool use. That action resolves `Scripts\` vs `bin/` per OS and appends the right one to `GITHUB_PATH`, so a POSIX-only venv path cannot strand the job again.

## Test plan

- [x] `yaml.safe_load` parses the workflow; `agent-eval` carries `defaults.run.shell: bash`, and the step list is unchanged apart from the venv swap
- [x] `setup-venv` confirmed cross-platform — `create-venv-windows` appends `$VENV_PATH\Scripts`, `create-venv-linux` appends `$VENV_PATH/bin`, both to `GITHUB_PATH`
- [x] Remaining steps re-read for Windows safety under Git Bash: `set -euo pipefail`, `trap … EXIT`, background `&`, `kill -0`, `curl … > /dev/null` all hold
- [ ] **The real gate: this workflow going green on the runner.** It has no successful run to diff against, so CI here is the first proof. If it fails past the install step, that is a *new* failure this PR newly exposed — not a regression from it.
