### PR TITLE
fix(email): low-priority-sender match no longer forces PROMOTIONAL

### DIFF
--- a/hub/agents/email/python/CHANGELOG.md
+++ b/hub/agents/email/python/CHANGELOG.md
@@ -9,6 +9,18 @@ contract version is tracked separately as
 
 ### Fixed
 
+- **A low-priority-sender match no longer forces a message to PROMOTIONAL
+  (#2666).** The mirror of #2632's priority-sender fix, for the direction
+  that fix explicitly left alone: `_apply_session_preferences` used to
+  override the heuristic/LLM/SLM's category outright the moment a sender
+  matched the muted list, so a genuinely urgent message from a muted sender
+  got buried as promotional — "I don't care about most of this sender's
+  mail" is not "this specific message is never urgent." The preference now
+  only tags `preference_applied` and updates the reason line for
+  salience/ordering; category is always decided by content, in both
+  directions. The `set_low_priority_sender` tool docstring (read by the
+  model) and the `pre_scan_inbox` docstring's "derived from the low-priority
+  bucket" claim are corrected to match.
 - **`search_messages` stated a wrong, unstable count for a result set it
   received intact (#2756).** Asked "how many messages from X in the last two
   weeks", the agent ran the right query, got every matching row back, then

--- a/hub/agents/email/python/gaia_agent_email/tools/preference_tools.py
+++ b/hub/agents/email/python/gaia_agent_email/tools/preference_tools.py
@@ -372,9 +372,10 @@ class PreferenceToolsMixin:
 
             Senders flagged here are tagged ``preference_applied:
             "priority_sender"`` in ``triage_inbox`` / ``pre_scan_inbox``
-            output so they can be surfaced or ordered ahead of other mail —
-            but the category (urgent, needs_response, ...) is still decided
-            entirely by the message content; this tool never overrides it.
+            output — that tag has no reader today (#2777), so it does not
+            currently reorder or highlight the sender's mail. The category
+            (urgent, needs_response, ...) is still decided entirely by the
+            message content; this tool never overrides it.
             "I care about this sender" is not "their mail is urgent" — a
             newsletter from a priority sender still classifies as whatever
             its content says. Useful for calling out high-signal senders

--- a/hub/agents/email/python/gaia_agent_email/tools/preference_tools.py
+++ b/hub/agents/email/python/gaia_agent_email/tools/preference_tools.py
@@ -487,11 +487,17 @@ class PreferenceToolsMixin:
 
         @tool
         def set_low_priority_sender(email: str) -> str:
-            """Mark a sender as always low-priority.
+            """Mark a sender as low-priority (#2666: never forces PROMOTIONAL).
 
-            Senders flagged here are classified as ``low priority`` and
-            surfaced in ``pre_scan_inbox``'s ``suggested_archives``
-            section. Useful for newsletters or bot accounts the
+            Senders flagged here are tagged ``preference_applied:
+            "low_priority_sender"`` in ``triage_inbox`` / ``pre_scan_inbox``
+            output so they can be de-prioritized behind other mail — but
+            the category (urgent, needs_response, ...) is still decided
+            entirely by the message content; this tool never overrides it.
+            "I don't care about most of this sender's mail" is not "none
+            of their mail is ever urgent" — a genuinely urgent message
+            from a low-priority sender still classifies as whatever its
+            content says. Useful for newsletters or bot accounts the
             heuristic can't recognize on its own.
 
             On a normally-provisioned install this rule is saved to the

--- a/hub/agents/email/python/gaia_agent_email/tools/read_tools.py
+++ b/hub/agents/email/python/gaia_agent_email/tools/read_tools.py
@@ -925,15 +925,16 @@ def _apply_session_preferences(
 
     Mutates a copy of ``decision`` and returns it.
 
-    Resolution rule (#2632): a priority-sender match never overrides
-    ``category`` — content (the heuristic or the LLM) decides severity,
-    a sender preference only raises salience. "I care about this sender"
-    is not "this message is urgent": a newsletter from a priority sender
-    stays exactly as low-signal as its content says, tagged with
-    ``preference_applied`` so a caller can still surface/order it earlier.
-    The low-priority-sender branch is unchanged — it still commits
-    PROMOTIONAL, since that is an explicit user request to downrank a
-    sender rather than an inferred one.
+    Resolution rule (#2632, #2666): neither a priority- nor a
+    low-priority-sender match ever overrides ``category`` — content (the
+    heuristic or the LLM) decides severity in both directions.
+    "I care about this sender" is not "this message is urgent", and
+    "I don't care about most of this sender's mail" is not "this specific
+    message is never urgent": a newsletter from a priority sender stays
+    exactly as low-signal as its content says, and a genuinely urgent
+    message from a muted sender stays exactly as urgent as its content
+    says. Both branches only tag ``preference_applied`` so a caller can
+    still surface/order the message accordingly.
 
     Safety override: a phishing-flagged message bypasses BOTH priority
     and low-priority sender preferences. A user can't safely promote a
@@ -967,11 +968,14 @@ def _apply_session_preferences(
             f"From a priority sender · category unchanged · {decision.get('rationale', '')}"
         )
     elif sender_addr and sender_addr in low_priority_senders:
-        out["category"] = CATEGORY_PROMOTIONAL
-        out["confident"] = True
         out["preference_applied"] = "low_priority_sender"
+        # #2666: a mute is a salience/ordering signal, not a content
+        # verdict -- category stays whatever content decided, so a
+        # genuinely urgent message from a muted sender still surfaces at
+        # the severity its content supports. Same rule, stated explicitly,
+        # as the priority-sender branch above.
         out["rationale"] = (
-            f"From a low-priority sender · {decision.get('rationale', '')}"
+            f"From a low-priority sender · category unchanged · {decision.get('rationale', '')}"
         )
     return out
 
@@ -1874,12 +1878,15 @@ def pre_scan_inbox_impl(
 
     Reshapes ``triage_inbox_impl`` output into a typed envelope optimized
     for a daily-driver triage card: top-N urgent, top-N actionable,
-    informational count, suggested archives derived from the low-priority
-    bucket and (when configured) from category defaults, and a needs-review
-    bucket for messages the heuristic was not confident about (#2584). The
-    caller is expected to set ``kind`` in the rendered output to
-    ``email_pre_scan`` so the chat surface can detect and render the
-    structured card component.
+    informational count, suggested archives derived from a confident
+    PROMOTIONAL classification and (when configured) from category
+    defaults, and a needs-review bucket for messages the heuristic was not
+    confident about (#2584). A low-priority-sender match does not by
+    itself route a message into suggested_archives (#2666) — only content
+    does; the preference raises salience/ordering instead. The caller is
+    expected to set ``kind`` in the rendered output to ``email_pre_scan``
+    so the chat surface can detect and render the structured card
+    component.
 
     ``session_preferences`` flow through to ``triage_inbox_impl`` so
     sender overrides shape the underlying classification, and category

--- a/hub/agents/email/python/gaia_agent_email/tools/read_tools.py
+++ b/hub/agents/email/python/gaia_agent_email/tools/read_tools.py
@@ -933,8 +933,13 @@ def _apply_session_preferences(
     message is never urgent": a newsletter from a priority sender stays
     exactly as low-signal as its content says, and a genuinely urgent
     message from a muted sender stays exactly as urgent as its content
-    says. Both branches only tag ``preference_applied`` so a caller can
-    still surface/order the message accordingly.
+    says. Both branches only tag ``preference_applied`` — today that tag
+    has no reader anywhere in this codebase (#2777); it does not reorder
+    or highlight anything in the rendered triage card. ``low_priority_senders``
+    separately has a real effect outside this function, in the autonomy
+    loop: ``TrustPolicy._explicitly_preferred`` (``trust.py``) reads the
+    raw set directly to auto-archive without confirmation. ``priority_senders``
+    has no reader anywhere outside this function.
 
     Safety override: a phishing-flagged message bypasses BOTH priority
     and low-priority sender preferences. A user can't safely promote a
@@ -969,11 +974,11 @@ def _apply_session_preferences(
         )
     elif sender_addr and sender_addr in low_priority_senders:
         out["preference_applied"] = "low_priority_sender"
-        # #2666: a mute is a salience/ordering signal, not a content
-        # verdict -- category stays whatever content decided, so a
-        # genuinely urgent message from a muted sender still surfaces at
-        # the severity its content supports. Same rule, stated explicitly,
-        # as the priority-sender branch above.
+        # #2666: category stays whatever content decided, so a genuinely
+        # urgent message from a muted sender no longer becomes an
+        # autonomy archive candidate (agent.py's _autonomy_candidate keys
+        # off category) just because the sender is muted. Same rule,
+        # stated explicitly, as the priority-sender branch above.
         out["rationale"] = (
             f"From a low-priority sender · category unchanged · {decision.get('rationale', '')}"
         )
@@ -1883,8 +1888,10 @@ def pre_scan_inbox_impl(
     defaults, and a needs-review bucket for messages the heuristic was not
     confident about (#2584). A low-priority-sender match does not by
     itself route a message into suggested_archives (#2666) — only content
-    does; the preference raises salience/ordering instead. The caller is
-    expected to set ``kind`` in the rendered output to ``email_pre_scan``
+    does. The ``preference_applied`` tag it carries instead has no reader
+    in this envelope today (#2777); it does not reorder or highlight
+    anything rendered here. The caller is expected to set ``kind`` in the
+    rendered output to ``email_pre_scan``
     so the chat surface can detect and render the structured card
     component.
 

--- a/hub/agents/email/python/tests/test_email_autonomy_cycle.py
+++ b/hub/agents/email/python/tests/test_email_autonomy_cycle.py
@@ -295,6 +295,78 @@ def test_urgent_message_never_auto_actioned_even_at_full(tmp_path):
     assert "INBOX" in agent._gmail.get_message("u1").get("labelIds", [])
 
 
+def test_muted_sender_urgent_message_never_becomes_autonomy_candidate(tmp_path):
+    """End-to-end regression for #2666's real severity claim.
+
+    Before #2666, ``_apply_session_preferences`` force-set every muted
+    sender's message to ``CATEGORY_PROMOTIONAL`` regardless of content —
+    which made ``_autonomy_candidate`` (agent.py) nominate it for archive,
+    and ``TrustPolicy._explicitly_preferred`` (trust.py) auto-execute that
+    archive unconditionally at ``earn_trust``+ the moment the sender
+    matched ``low_priority_senders`` — no ledger, no trust history, no
+    confirmation. A genuine emergency from a muted sender could be
+    silently archived with no human involved.
+
+    This pins the property one level below the unit tests on
+    ``_apply_session_preferences`` alone: the muted sender's urgent
+    message (IMPORTANT label, heuristically NEEDS_RESPONSE/unconfident —
+    the heuristic itself never emits URGENT, see #2771) must never even
+    reach ``_autonomy_candidate``'s archive branch, so
+    ``TrustPolicy.decide`` is never consulted for it at all. Uses
+    ``LEVEL_EARN_TRUST`` with a cold ledger specifically because that is
+    the exact level/path ``_explicitly_preferred`` operates on — at
+    ``LEVEL_FULL`` every reversible action auto-executes regardless of
+    preference, which would not distinguish this fix from the general
+    "urgent mail is never a candidate" property already covered above.
+    """
+    sender = "boss@company.com"
+    agent = _build_agent(
+        tmp_path,
+        [_urgent_message("u1", sender)],
+        level=LEVEL_EARN_TRUST,
+        autonomy_trust_min_samples=3,
+    )
+    agent._session_preferences["low_priority_senders"].add(sender)
+
+    report = agent._run_email_autonomy_cycle()
+
+    assert report["executed"] == []
+    assert report["proposals"] == []
+    assert report["skipped"] == 1
+    assert report["decisions"] == []  # never reached TrustPolicy.decide at all
+    # Still in the inbox, untouched.
+    assert "INBOX" in agent._gmail.get_message("u1").get("labelIds", [])
+
+
+def test_muted_sender_genuinely_promotional_message_still_auto_archives(tmp_path):
+    """The flip side of the test above: muting must keep working for mail
+    that IS genuinely promotional by content — #2666 removes the forced
+    override, not the legitimate explicit-preference fast path.
+    ``TrustPolicy._explicitly_preferred`` reads ``low_priority_senders``
+    directly (never the inert ``preference_applied`` tag, see #2777), so
+    this is unaffected by #2666 and must still auto-archive on a cold
+    ledger at ``earn_trust``.
+    """
+    sender = "deals@shop.com"
+    agent = _build_agent(
+        tmp_path,
+        [_promo_message("m1", sender)],
+        level=LEVEL_EARN_TRUST,
+        autonomy_trust_min_samples=3,
+    )
+    agent._session_preferences["low_priority_senders"].add(sender)
+
+    report = agent._run_email_autonomy_cycle()
+
+    assert len(report["executed"]) == 1
+    entry = report["executed"][0]
+    assert entry["action"] == "archive"
+    assert entry["message_id"] == "m1"
+    assert report["proposals"] == []
+    assert report["decisions"][0]["reason"] == "you set an explicit preference for this"
+    assert "INBOX" not in agent._gmail.get_message("m1").get("labelIds", [])
+
+
 def test_mixed_inbox_splits_correctly(tmp_path):
     agent = _build_agent(
         tmp_path,

--- a/hub/agents/email/python/tests/test_rationale_no_classifier_leak_2743.py
+++ b/hub/agents/email/python/tests/test_rationale_no_classifier_leak_2743.py
@@ -238,8 +238,11 @@ class TestEveryEmittedRationaleIsClean:
         }
         out = _apply_session_preferences(decision, prefs)
         assert not _reason_violations(out["rationale"]), out["rationale"]
+        # #2666 requires the rule stated explicitly ("category unchanged"),
+        # mirroring the priority-sender assertion above.
         assert (
-            out["rationale"] == "From a low-priority sender · Looks like an automated update"
+            out["rationale"]
+            == "From a low-priority sender · category unchanged · Looks like an automated update"
         )
 
     def test_force_llm_bypass_never_wraps_the_rationale(self):

--- a/tests/unit/agents/email/test_priority_sender_severity.py
+++ b/tests/unit/agents/email/test_priority_sender_severity.py
@@ -1,9 +1,10 @@
 # Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
 # SPDX-License-Identifier: MIT
 """
-Priority-sender severity regression tests (#2632).
+Priority-sender / low-priority-sender severity regression tests
+(#2632, #2666).
 
-Bug: a priority-sender match forced ``category`` to ``URGENT`` in
+Bug (#2632): a priority-sender match forced ``category`` to ``URGENT`` in
 ``_apply_session_preferences``, overriding whatever the heuristic (or the
 LLM) had already decided from the message's actual content. A Substack
 newsletter from a priority sender — Gmail's own ``CATEGORY_UPDATES`` label,
@@ -11,12 +12,22 @@ heuristically FYI — was promoted all the way to URGENT, with a reason line
 that named the heuristic's real (non-urgent) verdict right next to the
 contradicting URGENT category.
 
+Bug (#2666, the mirror direction): a low-priority-sender match forced
+``category`` to ``PROMOTIONAL`` the same way — "I don't care about most of
+this sender's mail" is not "this specific message is never urgent", so a
+genuinely urgent message from a muted sender was buried as promotional.
+
 Resolution rule under test: a sender preference may only affect metadata
 (``preference_applied``, the reason line) — it must never move ``category``.
-Content (the heuristic or the LLM) decides severity; every case here is
-exercised through ``triage_inbox_impl`` / ``pre_scan_inbox_impl`` with NO
-``classifier`` wired in, so the heuristic's own verdict is what "content
-decided" means — nothing here depends on a live LLM.
+Content (the heuristic, an SLM, or the LLM) decides severity. The
+priority-sender classes below exercise this through ``triage_inbox_impl`` /
+``pre_scan_inbox_impl`` with NO ``classifier`` wired in, so the heuristic's
+own verdict is what "content decided" means. The low-priority-sender classes
+need a genuinely URGENT verdict to prove the point, and the heuristic alone
+never produces ``CATEGORY_URGENT`` (that category is LLM/SLM-only in this
+codebase) — so those use a deterministic ``slm_classifier`` stub instead of
+a live LLM, the same technique ``test_rationale_no_classifier_leak_2743.py``
+uses for content-decided categories the heuristic can't reach on its own.
 """
 
 from __future__ import annotations
@@ -38,7 +49,10 @@ from gaia_agent_email.tools.read_tools import (  # noqa: E402
     pre_scan_inbox_impl,
     triage_inbox_impl,
 )
-from gaia_agent_email.tools.triage_heuristics import CATEGORY_FYI  # noqa: E402
+from gaia_agent_email.tools.triage_heuristics import (  # noqa: E402
+    CATEGORY_FYI,
+    CATEGORY_URGENT,
+)
 
 from tests.fixtures.email.fake_gmail import FakeGmailBackend  # noqa: E402
 
@@ -188,4 +202,163 @@ class TestPhishingSafetyOverrideStillWins:
 
         assert decision["is_phishing"] is True
         assert decision["category"] != "URGENT"
+        assert decision.get("preference_applied") == "skipped_phishing_or_spam"
+
+
+# ---------------------------------------------------------------------------
+# #2666 — the mirror direction: low-priority-sender match forcing PROMOTIONAL.
+# ---------------------------------------------------------------------------
+
+# No label/subject/sender-keyword match -> heuristic falls through to its
+# final "no clear signal" branch, confident=False. That is the only route to
+# an SLM-decided category in this codebase: the heuristic itself never
+# emits CATEGORY_URGENT (grep-verified — it's LLM/SLM-only).
+_URGENT_FROM_LOW_PRIORITY_SENDER = _msg(
+    "urgent_muted_001",
+    subject="Heads up",
+    sender="Vendor Status <status@vendor-updates.example>",
+    label_ids=["INBOX", "UNREAD"],
+    body=(
+        "Production database is down and customers are affected -- need "
+        "someone to look at this right now."
+    ),
+)
+
+_LOW_PRIORITY_ADDR = "status@vendor-updates.example"
+
+
+def _urgent_slm_classifier(*, subject, sender, body, message_id=""):
+    """Deterministic stand-in for the on-device SLM/LLM category call —
+    proves content, not the sender preference, decides severity, without
+    depending on a live model (same technique
+    ``test_rationale_no_classifier_leak_2743.py``'s ``_slm_by_id`` uses).
+    """
+    if message_id != "urgent_muted_001":
+        return None
+    return {"category": CATEGORY_URGENT, "confidence": 0.95, "source": "slm"}
+
+
+def _low_priority_gmail() -> FakeGmailBackend:
+    gmail = FakeGmailBackend()
+    gmail.add_message(_URGENT_FROM_LOW_PRIORITY_SENDER)
+    return gmail
+
+
+def _low_prefs(low_priority_senders: Optional[set] = None) -> Dict[str, Any]:
+    return {
+        "priority_senders": set(),
+        "low_priority_senders": low_priority_senders or set(),
+        "category_defaults": {},
+    }
+
+
+class TestLowPriorityMatchNeverForcesPromotional:
+    """Mirror of ``TestPriorityMatchNeverElevatesToUrgent`` for the opposite
+    direction (#2666): "I don't care about most of this sender's mail" is
+    not "this specific message is never urgent." A low-priority-sender
+    match must not force PROMOTIONAL over a content-derived category
+    either.
+    """
+
+    def test_urgent_content_survives_low_priority_match(self):
+        """AC1/AC3: content says URGENT (via the SLM stub — the heuristic
+        alone never produces URGENT); a low-priority-sender match must not
+        downgrade that to PROMOTIONAL. A muted sender's genuinely urgent
+        message still surfaces at the severity its content supports.
+        """
+        triage = triage_inbox_impl(
+            _low_priority_gmail(),
+            max_messages=25,
+            session_preferences=_low_prefs({_LOW_PRIORITY_ADDR}),
+            slm_classifier=_urgent_slm_classifier,
+        )
+        decision = triage["results"][0]
+
+        assert decision["category"] != "PROMOTIONAL"
+        assert decision["category"] == CATEGORY_URGENT
+        assert decision["preference_applied"] == "low_priority_sender"
+
+    def test_reason_line_states_the_resolution_rule(self):
+        """AC2: the resolution rule is stated in the reason line, and the
+        line must not itself assert a promotional demotion the category
+        doesn't back.
+        """
+        triage = triage_inbox_impl(
+            _low_priority_gmail(),
+            max_messages=25,
+            session_preferences=_low_prefs({_LOW_PRIORITY_ADDR}),
+            slm_classifier=_urgent_slm_classifier,
+        )
+        rationale = triage["results"][0]["rationale"]
+
+        assert "promotional" not in rationale.lower()
+        # The rule must be explicit, not merely absent: it should name that
+        # category is unaffected by the preference.
+        assert "category unchanged" in rationale.lower()
+
+    def test_no_prefs_and_low_priority_prefs_produce_the_same_category(self):
+        """AC2 acceptance example: with PREFS={} the category is unchanged
+        relative to a low-priority-sender match on the same sender — i.e.
+        the preference must not move severity in either direction.
+        """
+        baseline = triage_inbox_impl(
+            _low_priority_gmail(),
+            max_messages=25,
+            session_preferences=_low_prefs(),
+            slm_classifier=_urgent_slm_classifier,
+        )
+        with_pref = triage_inbox_impl(
+            _low_priority_gmail(),
+            max_messages=25,
+            session_preferences=_low_prefs({_LOW_PRIORITY_ADDR}),
+            slm_classifier=_urgent_slm_classifier,
+        )
+
+        assert baseline["results"][0]["category"] == with_pref["results"][0]["category"]
+
+    def test_pre_scan_still_places_urgent_muted_sender_in_urgent(self):
+        """Full pre_scan_inbox_impl path (the surface the TUI card renders
+        from): a genuinely urgent message from a muted sender must land in
+        the urgent section, not be buried in suggested_archives.
+        """
+        out = pre_scan_inbox_impl(
+            _low_priority_gmail(),
+            max_messages=25,
+            session_preferences=_low_prefs({_LOW_PRIORITY_ADDR}),
+            slm_classifier=_urgent_slm_classifier,
+        )
+
+        urgent_ids = {item["message_id"] for item in out["urgent"]}
+        archive_ids = {item["message_id"] for item in out["suggested_archives"]}
+        assert "urgent_muted_001" in urgent_ids
+        assert "urgent_muted_001" not in archive_ids
+        assert out["totals"]["urgent"] == 1
+
+
+class TestLowPriorityPhishingSafetyOverrideStillWins:
+    def test_phishing_message_from_low_priority_sender_is_not_archived(self):
+        """Regression guard: the #2666 fix must not weaken the pre-existing
+        phishing/spam safety override — a low-priority-sender match still
+        must not touch a phishing-flagged message's category (silently
+        archiving it would hide the threat from the user instead of
+        surfacing it).
+        """
+        phishing_msg = _msg(
+            "phish_muted_001",
+            subject="Verify your account now",
+            sender="Alerts <alerts@paypa1-secure.tk>",
+            label_ids=["INBOX"],
+            body="Your account has been compromised, click to verify your account.",
+        )
+        gmail = FakeGmailBackend()
+        gmail.add_message(phishing_msg)
+        addr = "alerts@paypa1-secure.tk"
+
+        triage = triage_inbox_impl(
+            gmail, max_messages=25, session_preferences=_low_prefs({addr})
+        )
+        decision = triage["results"][0]
+
+        assert decision["is_phishing"] is True
+        assert decision["category"] != "PROMOTIONAL"
         assert decision.get("preference_applied") == "skipped_phishing_or_spam"

--- a/tests/unit/agents/test_email_agent_tools.py
+++ b/tests/unit/agents/test_email_agent_tools.py
@@ -303,7 +303,13 @@ class TestPreScanInbox:
         )
         assert with_pref_decision.get("preference_applied") == "priority_sender"
 
-    def test_low_priority_sender_lands_in_archives(self, fake_gmail):
+    def test_low_priority_sender_does_not_change_category(self, fake_gmail):
+        """A sender flagged low-priority via session preference is tagged
+        for de-prioritization but never has its category overridden
+        (#2666, mirrors #2632's priority-sender direction) — content alone
+        decides severity, so the same message classifies identically with
+        and without the preference.
+        """
         first_msg = fake_gmail.get_message(list(fake_gmail._messages.keys())[0])
         first_sender = next(
             h["value"]
@@ -316,16 +322,23 @@ class TestPreScanInbox:
             "low_priority_senders": {addr},
             "category_defaults": {},
         }
-        out = pre_scan_inbox_impl(
+        baseline = triage_inbox_impl(fake_gmail, max_messages=50)
+        with_pref = triage_inbox_impl(
             fake_gmail, max_messages=50, session_preferences=prefs
         )
-        archive_senders = [
-            extract_sender_email(item["sender"]) for item in out["suggested_archives"]
-        ]
-        assert addr in archive_senders, (
-            f"low-priority sender {addr} should land in archives; "
-            f"saw archives={archive_senders}"
+        baseline_decision = next(
+            r for r in baseline["results"] if r["id"] == first_msg["id"]
         )
+        with_pref_decision = next(
+            r for r in with_pref["results"] if r["id"] == first_msg["id"]
+        )
+
+        assert with_pref_decision["category"] == baseline_decision["category"], (
+            "low-priority-sender preference must not change category; baseline="
+            f"{baseline_decision['category']!r} with_pref="
+            f"{with_pref_decision['category']!r}"
+        )
+        assert with_pref_decision.get("preference_applied") == "low_priority_sender"
 
     def test_category_default_archive_lifts_informational(self, fake_gmail):
         baseline = pre_scan_inbox_impl(fake_gmail, max_messages=50)


### PR DESCRIPTION
A muted (low-priority) sender's messages were force-classified `PROMOTIONAL` regardless of content — so a genuinely urgent message from a sender you'd muted got buried as promotional in the triage card, exactly the mirror image of #2632 (fixed for the priority-sender direction forcing `URGENT`). It went further than the card, though: at `earn_trust`+ autonomy, the forced `PROMOTIONAL` category made *every* message from a muted sender an auto-archive candidate, and the autonomy trust policy auto-executes an archive from an explicitly-muted sender unconditionally — so a real emergency from a sender you'd muted could be silently archived by the agent with no confirmation and no human in the loop. "I don't care about most of this sender's mail" is not "this specific message is never urgent."

Now `_apply_session_preferences` only tags `preference_applied` and states the rule in the reason line ("category unchanged") — content alone decides category, in both directions. A muted sender's message that content classifies as anything other than genuinely promotional never becomes an archive candidate in the first place, so the autonomy loop never sees it. One honest caveat: the `preference_applied` tag itself has no reader anywhere in the codebase for triage/pre-scan display — muting or prioritizing a sender does not reorder or highlight anything in the interactive triage card today. That's unchanged by this PR in either direction; filed as #2777 below.

Closes #2666

## Test plan

- [x] `.venv-wt/bin/python -m pytest hub/agents/email/python/tests/ tests/unit/agents/email/test_priority_sender_severity.py -q` — the issue's stated testing path, green (1697 passed)
- [x] `.venv-wt/bin/python util/lint.py --all --fix` — clean
- [x] Full `tests/unit/` suite — 10512 passed, 8 failed, 146 skipped. All 8 failures are pre-existing environment artifacts unrelated to this diff (PATH-dependent binary-shim checks, a missing `ANTHROPIC_API_KEY` in this worktree, and installer/wheel tests) — none touch `read_tools.py`, `preference_tools.py`, or any email test file.
- [x] Mandatory `gaia eval benchmark` regression check — **attempted, could not produce a usable comparison**: the harness itself scores nothing right now, on this branch or `main` (stale ctx envelope, a scoring-side id/ground-truth mismatch, and zero LLM escalation during triage — filed as #2776, not caused by this change). Confirmed independently that this fix's own branch can't be exercised by that harness anyway even when healthy: `_apply_session_preferences` only fires when session preferences are set, and the benchmark never seeds `low_priority_senders`.
- [x] `.venv-wt/bin/python -m pytest hub/agents/email/python/tests/test_email_autonomy_cycle.py -q` — end-to-end autonomy-loop regression (see below), green (42 passed). **Mutation-tested** — reverting the fix makes this test fail (confirmed: the log shows the message force-categorized `PROMOTIONAL` and forwarded to auto-archive); restoring the fix makes it pass again. This is load-bearing, not decorative.
- [x] Live-mailbox TUI verification — done, see the evidence comment on this PR. Ryzen AI APU box, `gemma4-it-e2b-FLM` / npu / ctx 32768, real mailbox, multi-turn, 3 planted-message repeats each direction. `earn_trust`+ autonomy was never enabled against the real mailbox — that safety claim is carried entirely by the unit tests above, as planned. **Confound in the live probe, stated plainly:** the planted messages were self-addressed (muted `<account>` sending to itself — the mailbox had no natural candidate, and Gmail's send API can only send as the connected account). The model's own stated reason for one result was "self-addressed, no explicit action item" — that's a real classification cue independent of this fix. So the live evidence proves, cleanly: **no muted-sender message was force-set to `PROMOTIONAL`, 3 of 3** (this PR's actual acceptance criterion). It does **not** cleanly isolate "surfaces at the severity its content supports" from "self-addressed lowered the perceived severity" — both are consistent with what was observed. The unconfounded version of this probe plants from the connected Outlook test account instead of self-addressing; noted as a follow-up improvement to the evidence method, not a gap in the fix itself.

<details>
<summary>Notes for reviewers</summary>

- Mirrors #2632's exact resolution shape: drop the forced `category`/`confident` override, keep the `preference_applied` tag, state the rule explicitly in the reason line. Two divergent resolution rules in adjacent branches of the same function would have been a worse outcome than the bug.
- Also corrects two docs that described the old forced-archive behavior as a feature: the `set_low_priority_sender` tool docstring (LLM-facing — the model reads this when deciding to call the tool, mirroring #2632's own fix to `set_priority_sender`'s docstring) and `pre_scan_inbox_impl`'s "derived from the low-priority bucket" claim.
- One pre-existing test (`test_low_priority_sender_lands_in_archives`) asserted the behavior being removed here; rewritten to assert category equality baseline-vs-with-preference, mirroring how #2632 fixed its own sibling test.
- New regression coverage lives in `tests/unit/agents/email/test_priority_sender_severity.py` (the file the issue's testing path names): a low-priority sender's message with an unambiguous urgency signal, via a deterministic `slm_classifier` stub since the heuristic itself never emits `URGENT` (confirmed via `_apply_session_preferences` + a full source grep of `triage_heuristics.py`) — proving category reflects content instead of being forced to `PROMOTIONAL`, plus the phishing-safety-override mirror.
- **Where muting still has real effect, traced precisely:** `TrustPolicy._explicitly_preferred` (`trust.py:521-547`) reads the raw `low_priority_senders` set directly (never the `preference_applied` tag) to auto-execute an `archive` action at `earn_trust`+ autonomy with no confirmation. Before this fix, the forced `PROMOTIONAL` category meant *every* muted-sender message reached that path via `_autonomy_candidate` (`agent.py:1590`, which nominates `archive` candidates purely off `category`) — after, only messages content independently classifies as promotional/spam do. `priority_senders` has **no reader anywhere** outside `_apply_session_preferences` (grep-verified against `trust.py` and `agent.py`) — the asymmetry is real: muting affects the autonomy loop, prioritizing affects nothing beyond the tag.
- **The autonomy claim above is pinned end-to-end, not just at the tag.** `test_email_autonomy_cycle.py` gained two tests driving the real chain through `_run_email_autonomy_cycle` (no mocked links): `test_muted_sender_urgent_message_never_becomes_autonomy_candidate` — an IMPORTANT-labeled urgent message from a muted sender at `earn_trust` with a cold ledger never reaches `TrustPolicy.decide` at all (`report["decisions"] == []`, `report["skipped"] == 1`, a stronger property than merely declining); and `test_muted_sender_genuinely_promotional_message_still_auto_archives` — the flip side, proving genuinely promotional mail from a muted sender still auto-archives via the legitimate explicit-preference path, unaffected by this fix. `LEVEL_EARN_TRUST` with a cold ledger is deliberate, not arbitrary: `LEVEL_FULL` auto-executes every reversible action regardless of preference, so it couldn't distinguish this fix from the general "urgent mail is never a candidate" property already covered elsewhere in the file.
- Filed #2771 as a related but separate finding from investigating this: the chat-surface triage card (`pre_scan_inbox`) structurally cannot ever place a message in its `urgent` section from content — it never wires any LLM classifier, and the heuristic alone never produces `CATEGORY_URGENT`. Not this PR's bug (unrelated to sender preferences) and not fixed here.
- Filed #2776: the `gaia eval benchmark` harness (the mandatory-eval vehicle for triage-classification changes) is currently broken three independent ways — a stale ctx envelope, a scoring join that matches zero predicted-vs-ground-truth ids, and zero real LLM escalation during a `triage_inbox` run. None of the three are caused by this PR; filed so the next triage-classification change doesn't rediscover the same dead end.
- Filed #2777: `preference_applied` has no reader for triage/pre-scan display ordering, in either direction — `set_priority_sender`/`set_low_priority_sender`'s own tool docstrings promise "surfaced/ordered ahead of other mail," which no code delivers. Not this PR's gap to close (pre-existing on both branches #2632 touched and this one), but worth tracking rather than leaving silent.

</details>






