### PR TITLE
THROWAWAY evidence probe for #2767 — do not merge

### DIFF
--- a/hub/agents/email/python/gaia_agent_email/agent.py
+++ b/hub/agents/email/python/gaia_agent_email/agent.py
@@ -2072,3 +2072,8 @@ class EmailTriageAgent(
 
 
 __all__ = ["EmailTriageAgent", "EmailAgentConfig", "AGENT_NAMESPACED_ID"]
+
+# Throwaway evidence probe for #2767 — proves the widened pull_request
+# trigger actually fires the email suites on a non-main-based PR. This
+# comment (and the PR/branches carrying it) is deleted immediately after
+# capture; it has no effect on runtime behavior.

--- a/src/gaia/agents/base/agent.py
+++ b/src/gaia/agents/base/agent.py
@@ -1,5 +1,6 @@
 # Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
 # SPDX-License-Identifier: MIT
+# Throwaway evidence probe for #2767 — deleted with the evidence branch.
 """
 Generic Agent class for building domain-specific agents.
 """


### PR DESCRIPTION
Throwaway PR used only to capture before/after CI evidence for #2767 (PR base-branch trigger gap + required checks gate). Base is intentionally not `main`. Will be closed and both branches deleted immediately after capture.