### PR TITLE
fix(email): meeting proposal in a confidently-classified message no longer vanishes from needs_you

### DIFF
--- a/hub/agents/email/python/CHANGELOG.md
+++ b/hub/agents/email/python/CHANGELOG.md
@@ -9,6 +9,22 @@ contract version is tracked separately as
 
 ### Fixed
 
+- **A meeting proposal in a confidently-classified message vanished from the
+  view the TUI renders on open (#2580).** `is_meeting_request` was wired into
+  the scan by #2589, but the `needs_you` worklist (#2743, which replaced the
+  #2582 `/attention` fetch as the TUI's on-open source) only kept the flag for
+  messages already routed into `urgent`/`actionable` by category, and dropped
+  it entirely for anything reaching `needs_review`. A message the category
+  heuristic confidently calls FYI/PERSONAL — e.g. Gmail's own
+  `CATEGORY_PERSONAL` label on a colleague's message — kept
+  `is_meeting_request=True` from the scan but was silently counted only under
+  `informational_count`, reproducing the original grounding incident
+  ("Any chance to meet this Thursday at 9am?" reported under "0 actionable
+  items") on current `main`. `is_meeting_request` now vetoes the
+  informational/suggested-archives routing the same way an unconfident guess
+  already does, and a meeting-flagged item keeps its `meeting_request` kind
+  through `needs_review` instead of being downgraded to a generic
+  "needs review" row.
 - **`search_messages` stated a wrong, unstable count for a result set it
   received intact (#2756).** Asked "how many messages from X in the last two
   weeks", the agent ran the right query, got every matching row back, then

--- a/hub/agents/email/python/gaia_agent_email/tools/read_tools.py
+++ b/hub/agents/email/python/gaia_agent_email/tools/read_tools.py
@@ -1796,7 +1796,12 @@ def _build_needs_you_view(
         candidates.append({**item, "kind": kind})
         _remember(item.get("message_id"))
     for item in needs_review:
-        candidates.append({**item, "kind": "needs_review"})
+        # #2580: a meeting-flagged item must keep that kind even when it
+        # reaches needs_you via needs_review, same as the urgent/actionable
+        # loops above — otherwise the TUI renders a generic "check this"
+        # instead of naming the proposed time.
+        kind = "meeting_request" if item.get("is_meeting_request") else "needs_review"
+        candidates.append({**item, "kind": kind})
         _remember(item.get("message_id"))
 
     for w in waiting_on_you or []:
@@ -2003,7 +2008,13 @@ def pre_scan_inbox_impl(
             elif category == CATEGORY_NEEDS_RESPONSE:
                 actionable.append({**base, "why": why})
             elif category == CATEGORY_PROMOTIONAL:
-                if needs_review_decision(r):
+                # is_meeting_request is an additional veto (#2580) — a
+                # genuine time proposal must not be silently archived just
+                # because the category heuristic is confident about
+                # PROMOTIONAL. Mirrors attention_tools._scan_one_backend,
+                # which already checks is_meeting_request independent of
+                # category.
+                if needs_review_decision(r) or base["is_meeting_request"]:
                     needs_review_ranked.append(
                         (_needs_review_sort_key(r), {**base, "why": why})
                     )
@@ -2017,7 +2028,11 @@ def pre_scan_inbox_impl(
                 # to the terminal FYI-placeholder fallback). Routed through
                 # needs_review_decision (shared with the attention-view
                 # aggregator, #2582) rather than a local confidence check.
-                if needs_review_decision(r):
+                # is_meeting_request is an additional veto (#2580) — a
+                # confident FYI/PERSONAL message can still be a real ask,
+                # and letting it through would make FILTER_TEST_NO_MEETING_
+                # PROPOSAL below a false claim about the message it tags.
+                if needs_review_decision(r) or base["is_meeting_request"]:
                     needs_review_ranked.append(
                         (_needs_review_sort_key(r), {**base, "why": why})
                     )

--- a/tests/unit/agents/email/test_pre_scan_meeting_detection.py
+++ b/tests/unit/agents/email/test_pre_scan_meeting_detection.py
@@ -307,6 +307,29 @@ class TestGroundingIncidentSurfacesAsNeedingReply:
             f"informational with no other trace: {out}"
         )
 
+    def test_incident_message_needs_no_llm_classifier(self):
+        # pre_scan_inbox_impl has no ``classifier`` parameter and never
+        # passes one to triage_inbox_impl (read_tools.py:1164-1165's own
+        # docstring: "pre_scan_inbox_impl never wires a classifier") — so
+        # CATEGORY_URGENT/NEEDS_RESPONSE are structurally unreachable here
+        # regardless of config, matching the real incident's own log line
+        # ("12 decided by heuristic, 0 escalated to the LLM"). This fix
+        # must clear the incident on that exact heuristic-only condition,
+        # not merely when something upstream supplies a classifier —
+        # detect_meeting_request_heuristic needs no LLM call to fire.
+        gmail = self._gmail_with_incident_message(
+            label_ids=["INBOX", "CATEGORY_PERSONAL"]
+        )
+        triage = triage_inbox_impl(gmail, max_messages=50)
+        by_id = {r["id"]: r for r in triage["results"]}
+        assert by_id["incident_msg"]["source"] == "heuristic", (
+            "expected the incident message resolved with zero LLM "
+            f"escalation, got {by_id['incident_msg']!r}"
+        )
+        out = pre_scan_inbox_impl(gmail, max_messages=50)
+        matches = [i for i in out["needs_you"] if i.get("message_id") == "incident_msg"]
+        assert matches and matches[0]["kind"] == "meeting_request"
+
     def test_incident_message_surfaces_in_needs_you(self):
         gmail = self._gmail_with_incident_message(
             label_ids=["INBOX", "CATEGORY_PERSONAL"]

--- a/tests/unit/agents/email/test_pre_scan_meeting_detection.py
+++ b/tests/unit/agents/email/test_pre_scan_meeting_detection.py
@@ -33,6 +33,9 @@ if str(_REPO_ROOT) not in sys.path:
 
 pytest.importorskip("gaia_agent_email")  # noqa: E402
 from gaia_agent_email.tools import read_tools  # noqa: E402
+from gaia_agent_email.tools.attention_tools import (  # noqa: E402
+    build_attention_view_impl,
+)
 from gaia_agent_email.tools.read_tools import (  # noqa: E402
     pre_scan_inbox_impl,
     triage_inbox_impl,
@@ -247,6 +250,105 @@ class TestPreScanCarriesMeetingFlag:
             + out["needs_review"]
         )
         assert any(i.get("is_meeting_request") is True for i in all_items)
+
+
+class TestGroundingIncidentSurfacesAsNeedingReply:
+    """End-to-end regression for the #2580 epic's grounding incident.
+
+    On 2026-07-28, on ``main``, a colleague's message combining a direct
+    question with an informal meeting-time proposal — "Did you have a
+    chance to look through the code and get a pull request? Any chance to
+    meet this Thursday at 9am?" — was classified confidently FYI and
+    reported under "0 actionable items" (12 scanned, 12 by heuristic, 0
+    escalated to the LLM). #2589 wired ``detect_meeting_request_heuristic``
+    into the scan; #2743 built the ``needs_you`` worklist the TUI actually
+    renders on open (replacing the #2582 ``/attention`` fetch — see
+    ``tui/internal/ui/chat/model.go``'s ``preScanFetchedMsg`` comment).
+
+    That left a gap: ``_build_needs_you_view`` only relabels an item
+    already routed into ``urgent``/``actionable`` by CATEGORY, and its
+    ``needs_review`` loop dropped ``is_meeting_request`` entirely. A
+    message the category heuristic confidently calls FYI/PERSONAL (e.g.
+    Gmail's own ``CATEGORY_PERSONAL`` label — the plausible real shape of
+    the incident message) kept ``is_meeting_request=True`` from the scan
+    but was silently invisible in the view the TUI reads on open — the
+    incident, reproduced verbatim on current ``main``.
+    """
+
+    INCIDENT_TEXT = (
+        "Did you have a chance to look through the code and get a pull "
+        "request? Any chance to meet this Thursday at 9am?"
+    )
+
+    def _gmail_with_incident_message(self, *, label_ids: List[str]) -> FakeGmailBackend:
+        gmail = FakeGmailBackend()
+        gmail.add_message(
+            _msg(
+                "incident_msg",
+                subject="Quick check-in",
+                sender="colleague@example.com",
+                label_ids=label_ids,
+                snippet=self.INCIDENT_TEXT,
+            )
+        )
+        return gmail
+
+    def test_incident_message_is_not_silently_informational(self):
+        # Gmail's own Personal-tab label makes the category heuristic
+        # commit confident=True unconditionally (triage_heuristics.py rule
+        # 5) — isolating whether is_meeting_request alone can save the
+        # message from the bare-count bucket.
+        gmail = self._gmail_with_incident_message(
+            label_ids=["INBOX", "CATEGORY_PERSONAL"]
+        )
+        out = pre_scan_inbox_impl(gmail, max_messages=50)
+        assert out["informational_count"] == 0, (
+            "the incident message must not be silently counted as "
+            f"informational with no other trace: {out}"
+        )
+
+    def test_incident_message_surfaces_in_needs_you(self):
+        gmail = self._gmail_with_incident_message(
+            label_ids=["INBOX", "CATEGORY_PERSONAL"]
+        )
+        out = pre_scan_inbox_impl(gmail, max_messages=50)
+        # The #2580 acceptance criterion, directly: it must surface as
+        # needing a reply, not disappear under "0 actionable items".
+        assert (
+            out["needs_you_total"] >= 1
+        ), f"expected the incident message to surface in needs_you: {out}"
+        matches = [i for i in out["needs_you"] if i.get("message_id") == "incident_msg"]
+        assert matches, f"incident_msg not present in needs_you: {out['needs_you']}"
+        assert matches[0]["kind"] == "meeting_request", (
+            "expected kind='meeting_request' so the TUI can name the "
+            f"proposed time, got {matches[0]!r}"
+        )
+
+    def test_meeting_flag_survives_needs_review_routing(self):
+        # No category-label signal at all -> unconfident FYI -> needs_review
+        # by the pre-existing #2584/#2743 path. The meeting flag must not
+        # be discarded there either (needs_review previously always tagged
+        # kind="needs_review", regardless of is_meeting_request).
+        gmail = self._gmail_with_incident_message(label_ids=["INBOX"])
+        out = pre_scan_inbox_impl(gmail, max_messages=50)
+        matches = [i for i in out["needs_you"] if i.get("message_id") == "incident_msg"]
+        assert matches, f"incident_msg not present in needs_you: {out['needs_you']}"
+        assert (
+            matches[0]["kind"] == "meeting_request"
+        ), f"needs_review routing must not discard the meeting flag: {matches[0]!r}"
+
+    def test_incident_message_via_attention_view(self):
+        # The originally-shipped #2582 mechanism — still reachable via
+        # GET /v1/email/attention even though the TUI no longer calls it on
+        # open (#2743) — must keep catching this. Regression guard so a
+        # future change to attention_tools.py can't quietly reopen it.
+        gmail = self._gmail_with_incident_message(
+            label_ids=["INBOX", "CATEGORY_PERSONAL"]
+        )
+        out = build_attention_view_impl({"google": gmail}, max_messages=50)
+        matches = [i for i in out["items"] if i.get("message_id") == "incident_msg"]
+        assert matches, f"incident_msg missing from attention view: {out['items']}"
+        assert matches[0]["kind"] == "meeting_request"
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes #2580
Follow-up: #2770 (first-contact direct-question gap, filed separately by design)

Opening the email agent is supposed to show what needs a reply, unprompted — that's the whole point of #2580. It doesn't, for one specific and real shape of message: on 2026-07-28, a colleague's "Did you have a chance to look through the code and get a pull request? Any chance to meet this Thursday at 9am?" was classified confidently FYI and reported under "0 actionable items", while a promotional newsletter was surfaced as a suggested archive. #2589 already taught the scan to detect the meeting proposal (`is_meeting_request`), but the worklist the TUI actually renders on open (`needs_you`, built by #2743) only kept that flag for messages already routed into urgent/actionable by category — a confidently-FYI/PERSONAL message lost it, reproducing the incident verbatim on current `main`. This restores it: `is_meeting_request` now vetoes the informational/archive routing the same way an unconfident guess already does, and it survives the needs_review path instead of being downgraded to a generic "check this" row.

The fix reaches every reader of `needs_you` — the on-open card and the `pre_scan_inbox` tool the model calls mid-conversation. Confirmed live: asking "did anyone email me proposing to meet, that I haven't replied to?" calls `pre_scan_inbox` → `triage_inbox` → `detect_waiting_on_you`, the exact call graph this PR touches. Asking "what meetings are coming up?" instead calls `list_calendar_events` — a different tool, real Google Calendar data, untouched by this fix — confirmed from the sidecar log, not assumed.

**One known gap, stated plainly:** this closes the incident via its meeting-proposal half. A message with only a direct question — no meeting proposal, no prior thread history — still has no path to `needs_you`; the inbound waiting-on-you detector (#2604) requires corroborating thread history by design, which a first-contact message can never have. Filed as #2770 to decide on purpose, not silently assumed away.

## Test plan

- [ ] `pytest tests/unit/agents/email/test_pre_scan_meeting_detection.py -v` — new `TestGroundingIncidentSurfacesAsNeedingReply` (4 tests) replays the incident's exact wording end to end through `pre_scan_inbox_impl` and `build_attention_view_impl`; `test_incident_message_needs_no_llm_classifier` pins the fix to the zero-LLM-escalation condition the real incident logged (12 by heuristic, 0 to the LLM)
- [ ] `pytest tests/unit/agents/email/ tests/unit/email/ hub/agents/email/python/tests/ tests/unit/agents/test_email_agent.py tests/test_email_openapi_conformance.py -q` — 2613 passed, no regressions
- [ ] `pytest hub/agents/email/python/tests/ tests/unit/ -q` — full suite per the repo testing contract: 10511 passed, 8 pre-existing failures unrelated to this change (missing optional `fitz` dep, CLI-binary-on-PATH checks, a documented pre-existing `.env` artifact, hub-installer wheel tests) — none touch `read_tools.py` or the email agent
- [ ] `python util/lint.py --all` — clean (black/isort/pylint/flake8/bandit all pass; 1 pre-existing non-blocking MyPy warning category, unrelated files)
- [ ] Live TUI evidence on a real, dual-provider mailbox (Google + Microsoft) — see below

## Evidence

Driven on a Ryzen AI NPU box, source build (`gaia daemon start-agent email --mode dev`, `src:` verified pointed at this branch's commit). Runtime-resolved condition, stated plainly, not a fallback: `gemma4-it-e2b-FLM` on the NPU at ctx 32768 — the default this hardware resolves to (`resolve_default_email_model`, #1439).

**The fixed call graph is exercised live by a natural question, not just the on-open card** — "did anyone email me proposing to meet or schedule a call, that I haven't replied to?":
```
Here are the messages in your inbox that are waiting on a reply from you:
• From tomasz.testingiewicz@outlook.com — "Re: Partnership intro — moving this across"
• From tomasz.testingiewicz@outlook.com — "Re: Revised deck — need your numbers by Tuesday"
• From tomasz.testingiewicz@outlook.com — "Re: Northgate migration — phase 2 sequencing"
• From tomasz.testingiewicz@outlook.com — "Re: 30 minutes next week?"
• From tomasz.testingiewicz@outlook.com — "Re: Fieldstone MSA — counter-signature needed before Friday"
  46.1s · ttft 0.5s · ~191 tokens · 4.2 tok/s · 2 steps · 1 tools
```
Sidecar log for this turn: `tool_call name=pre_scan_inbox` → `tool_call name=triage_inbox` → `tool_call name=detect_waiting_on_you` — the exact call graph this PR fixes, confirmed from the log rather than inferred from the answer. It also surfaced a message ("Re: 30 minutes next week?") outside the visible top-5 card, confirming the call reaches beyond the capped display. By contrast, asking "what meetings are coming up?" instead calls `list_calendar_events` — a different tool, real Google Calendar data, untouched by this fix (see the collapsed note below).

**On-open attention card — unprompted, no query sent:**
```
┌─ Inbox ──────────────────────────────────────────────────────────────────┐
│   NEEDS YOU                                                        5 of 38│
│   1  REPLY  tomasz.testingiewicz@ou… Re: Partnership intro — moving this across
│      0s ago · waiting 0d on your reply
│   2  REPLY  tomasz.testingiewicz@ou… Re: Revised deck — need your numbers by Tuesday
│      0s ago · waiting 0d on your reply
│   3  REPLY  tomasz.testingiewicz@ou… Re: Northgate migration — phase 2 sequencing
│      0s ago · waiting 0d on your reply
│   4  REPLY  tomasz.testingiewicz@ou… Re: Fieldstone MSA — counter-signature needed before Friday
│      0s ago · waiting 0d on your reply
│   5  REPLY  Tomasz Testingiewicz     Your account has been suspended — click here to verify
│      1h ago · flagged as phishing — Looks like personal correspondence
│      +33 more
│   21 filtered — none of them proposed a meeting.
│   50 inbox messages scanned.
└────────────────────────────────────────────────────────────────────────┘
```
The waiting-on-you detector (#2604) is live and correctly naming real inbound threads. This mailbox's natural top-50 scan window didn't contain a live `is_meeting_request=True` example to additionally show surfacing here.

<!-- PLANTED-INCIDENT-CAPTURE-PLACEHOLDER -->

**Zero-mutation id-set diff — both connected providers, full session:**
```
[google] <primary account> — 16 buckets (inbox 1408, starred 4, unread 729, drafts 0, + 12 labels incl. SENT/IMPORTANT/TRASH/SPAM/CATEGORY_*): every one identical id-set before → after
[microsoft] <account> — inbox 543, unread 21, sent 40: identical before → after
RESULT: ZERO DRIFT across every connected provider and bucket
```
Between snapshots: 4 on-open attention-card renders + 5 chat turns (calendar query ×3, waiting-on-you query, one more), all read-only.

<details>
<summary>Note on a related, separately-tracked finding (not from this fix)</summary>

While probing "what meetings are coming up?" (3 repeated runs, `list_calendar_events`, identical each time), every meeting was reported with `Organizer: <primary account>` — the user's own address, on all three. That's a real, correctly-read field being mislabeled in prose, not an invented value — a different mechanism and a different code path (`list_calendar_events`, untouched by this PR) than anything here. Passed along for #2766's investigation; not fixed or claimed as fixed in this PR.
</details>
