### PR TITLE
fix(ci): a PR based on any branch but main runs no unit tests, no lint and no agent suites

### DIFF
--- a/.github/scripts/check_required_status.py
+++ b/.github/scripts/check_required_status.py
@@ -197,6 +197,16 @@ def load_requirements(workflows_dir: str, exclude: Iterable[str]) -> list[Requir
     return reqs
 
 
+def is_gated_off(is_draft: bool, labels: set[str]) -> bool:
+    """True when the audited suites legitimately have not run yet, by the
+    same convention every one of them already uses:
+    `github.event.pull_request.draft == false || contains(...'ready_for_ci')`.
+    This gate mirrors that condition in Python (not a job-level `if:`) so it
+    can decide it fresh on every invocation instead of skipping itself.
+    """
+    return is_draft and "ready_for_ci" not in labels
+
+
 def _matches_any(changed_file: str, patterns: list[str]) -> bool:
     return any(fnmatch.fnmatch(changed_file, pat) for pat in patterns)
 
@@ -259,6 +269,43 @@ def fetch_changed_files(path: str) -> list[str]:
         return [line.strip() for line in f if line.strip()]
 
 
+CUSTOM_CHECK_NAME = "Required Checks Gate"
+
+
+def post_check_run(repo: str, sha: str, conclusion: str, title: str, summary: str) -> None:
+    """Create a check-run via the Checks API directly, independent of this
+    job's own native pass/fail check-run.
+
+    Why a second, API-created check-run instead of just letting the job's
+    exit code decide: GitHub Actions can only ever conclude a job as
+    success/failure/cancelled/skipped — there's no exit code for "neutral".
+    But "this PR's required suites legitimately have not run yet because
+    it's a draft" is neither a pass (nothing has been verified) nor a
+    failure (nothing is wrong) — see the redirect on #2767 that led to this:
+    a gate that skips itself in sympathy with the jobs it's auditing
+    reproduces the exact silent-green bug it exists to catch. `neutral` is
+    the one Checks API conclusion built for exactly this: visible, distinct
+    from both green and red, and does not block a merge on its own (mirrors
+    GitHub's own branch-protection semantics for a neutral required check).
+    """
+    payload = {
+        "name": CUSTOM_CHECK_NAME,
+        "head_sha": sha,
+        "status": "completed",
+        "conclusion": conclusion,
+        "output": {"title": title, "summary": summary},
+    }
+    proc = subprocess.run(
+        ["gh", "api", f"repos/{repo}/check-runs", "--input", "-"],
+        input=json.dumps(payload),
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if proc.returncode != 0:
+        raise RuntimeError(f"gh api check-runs create failed (exit {proc.returncode}): {proc.stderr.strip()}")
+
+
 def fetch_check_runs(repo: str, sha: str) -> list[CheckRun]:
     proc = subprocess.run(
         [
@@ -312,7 +359,32 @@ def main() -> int:
     parser.add_argument("--sha", required=True)
     parser.add_argument("--timeout-seconds", type=int, default=3600)
     parser.add_argument("--poll-seconds", type=int, default=30)
+    parser.add_argument("--draft", choices=["true", "false"], required=True)
+    parser.add_argument("--labels", default="", help="comma-separated PR label names")
     args = parser.parse_args()
+
+    is_draft = args.draft == "true"
+    labels = {label.strip() for label in args.labels.split(",") if label.strip()}
+
+    if is_gated_off(is_draft, labels):
+        # Deliberately NOT skipped via a job-level `if:` — see the module
+        # docstring on post_check_run for why a job that skips itself here
+        # would reproduce #2767's own bug. This branch always actually
+        # executes and always actually decides, every time it's triggered
+        # (including on a bare `labeled` event with no new commit) — so it
+        # can never get stuck showing a stale state the way the audited
+        # jobs can.
+        title = "Required suites have not run yet"
+        summary = (
+            "This PR is a draft without the `ready_for_ci` label, so the "
+            "suites this gate audits have not run (by the same convention "
+            "every audited workflow uses). Nothing has been verified — this "
+            "is not a pass. Mark the PR ready for review, or add the "
+            "`ready_for_ci` label, to require and verify them."
+        )
+        print(f"GATED OFF: {summary}")
+        post_check_run(args.repo, args.sha, "neutral", title, summary)
+        return 0
 
     requirements = load_requirements(args.workflows_dir, args.exclude)
     reserved_names = _collect_reserved_static_names(args.workflows_dir)
@@ -330,6 +402,7 @@ def main() -> int:
         print(format_report(result, elapsed))
 
         if result.is_terminal_failure:
+            details = "; ".join(f"{req.name_prefix} ({reason})" for req, reason in result.failed)
             for req, reason in result.failed:
                 print(
                     f"::error::Required check '{req.name_prefix}' (from "
@@ -337,16 +410,39 @@ def main() -> int:
                     f"failure mode issue #2767 exists to catch — a check that "
                     f"should have run for this diff did not report success."
                 )
+            post_check_run(
+                args.repo,
+                args.sha,
+                "failure",
+                "Required suites did not pass",
+                f"One or more required, path-relevant checks did not pass: {details}",
+            )
             return 1
         if result.is_fully_ok:
             print("All path-relevant required checks reported and passed.")
+            names = ", ".join(r.name_prefix for r in result.ok) or "(none required for this diff)"
+            post_check_run(
+                args.repo,
+                args.sha,
+                "success",
+                "All required suites passed",
+                f"Required and path-relevant for this diff: {names}",
+            )
             return 0
         if elapsed >= args.timeout_seconds:
+            details = ", ".join(r.name_prefix for r in result.unresolved)
             for req in result.unresolved:
                 print(
                     f"::error::Required check '{req.name_prefix}' (from "
                     f"{req.source_file}) never reported after {args.timeout_seconds}s."
                 )
+            post_check_run(
+                args.repo,
+                args.sha,
+                "failure",
+                "Required suites never reported",
+                f"Timed out after {args.timeout_seconds}s waiting on: {details}",
+            )
             return 1
         time.sleep(args.poll_seconds)
 

--- a/.github/scripts/check_required_status.py
+++ b/.github/scripts/check_required_status.py
@@ -1,0 +1,355 @@
+#!/usr/bin/env python3
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""Required Checks Gate for #2767 — aggregates PR-triggered workflows' own
+check-run state instead of hand-listing which checks "should" exist.
+
+Why derive instead of curate: GitHub Actions has no cross-workflow `needs:`,
+so an aggregating gate can only *observe* the Checks API for the PR's head
+SHA — it can't depend on other workflows' jobs directly. The set of what to
+observe is parsed straight from every workflow file's own `pull_request:`
+trigger (paths/paths-ignore) and each job's own `continue-on-error`, so a
+new workflow is covered the moment it's added, with nothing to remember to
+update here.
+
+Split into `evaluate()` (pure, unit-tested — see
+tests/unit/test_check_required_status.py) and a thin polling `main()` that
+isn't worth unit testing beyond that split.
+"""
+from __future__ import annotations
+
+import argparse
+import fnmatch
+import glob
+import json
+import os
+import subprocess
+import sys
+import time
+from dataclasses import dataclass, field
+from typing import Iterable
+
+import yaml
+
+# Conclusions the Checks API can report. `success` and `neutral` both count
+# as passing — that mirrors GitHub's own branch-protection semantics (a
+# `neutral` required check does not block a merge).
+PASSING_CONCLUSIONS = {"success", "neutral"}
+# Terminal-bad conclusions: waiting longer will never fix these, so a match
+# here ends the poll loop immediately instead of burning the full timeout.
+# `skipped` is deliberately in this set, not in PASSING_CONCLUSIONS — a
+# required, path-relevant job that reports "skipped" is exactly the #2755
+# symptom (a job whose own `if:` gate never got a fresh evaluation).
+TERMINAL_BAD_CONCLUSIONS = {"skipped", "failure", "cancelled", "timed_out", "action_required"}
+
+
+@dataclass
+class Requirement:
+    name_prefix: str
+    # Static job names ("Test", "Dependency Review") must match exactly —
+    # startswith() on a short static name would spuriously match unrelated
+    # check-runs (e.g. a bare "Test" job matching "Test Chat Agent"'s check
+    # run). Only a matrix-templated name ("Unit Tests (py${{ matrix... }})",
+    # collapsed to the prefix before the expression) needs prefix matching,
+    # since the rendered suffix isn't known statically.
+    exact: bool
+    paths: list[str] | None
+    paths_ignore: list[str] | None
+    source_file: str
+    job_id: str
+
+
+@dataclass
+class CheckRun:
+    name: str
+    status: str
+    conclusion: str | None
+
+
+@dataclass
+class EvalResult:
+    ok: list[Requirement] = field(default_factory=list)
+    # Present, still running/queued — worth another poll.
+    pending: list[Requirement] = field(default_factory=list)
+    # Absent, no matching check-run row at all yet — worth another poll
+    # (the sibling workflow may not have registered with the Checks API yet).
+    missing: list[Requirement] = field(default_factory=list)
+    # Present with a conclusion that will never change without a fresh
+    # triggering event — no point polling further.
+    failed: list[tuple[Requirement, str]] = field(default_factory=list)
+
+    @property
+    def unresolved(self) -> list[Requirement]:
+        return self.pending + self.missing
+
+    @property
+    def is_terminal_failure(self) -> bool:
+        return bool(self.failed)
+
+    @property
+    def is_fully_ok(self) -> bool:
+        return not self.pending and not self.missing and not self.failed
+
+
+def _on_block(doc: dict) -> dict | None:
+    # `on:` is a YAML 1.1 boolean-ish key; PyYAML's safe_load parses the
+    # unquoted form as the Python bool True.
+    on = doc.get("on", doc.get(True, doc.get("true")))
+    if isinstance(on, dict):
+        return on
+    return None
+
+
+def _iter_workflow_jobs(workflows_dir: str):
+    """Yield (fname, doc, job_id, job, name_tmpl, is_templated) for every job
+    in every *.yml/*.yaml file in workflows_dir, regardless of trigger type.
+    Shared between load_requirements() and _collect_reserved_static_names()
+    so both see exactly the same parse.
+    """
+    for path in sorted(glob.glob(os.path.join(workflows_dir, "*.yml"))) + sorted(
+        glob.glob(os.path.join(workflows_dir, "*.yaml"))
+    ):
+        fname = os.path.basename(path)
+        with open(path) as f:
+            try:
+                doc = yaml.safe_load(f)
+            except yaml.YAMLError as e:
+                raise ValueError(f"invalid workflow YAML at {path}: {e}") from e
+        if not isinstance(doc, dict):
+            continue
+        jobs = doc.get("jobs")
+        if not isinstance(jobs, dict):
+            continue
+        for job_id, job in jobs.items():
+            if not isinstance(job, dict):
+                continue
+            name_tmpl = job.get("name") or job_id
+            yield fname, doc, job_id, job, name_tmpl, "${{" in name_tmpl
+
+
+def _collect_reserved_static_names(workflows_dir: str) -> dict[str, str]:
+    """Map every fully-static (non-templated) job name, across every
+    workflow file with no exclusions, to its source file.
+
+    This is what makes prefix matching for matrix-templated jobs safe: a job
+    named "Test ${{ matrix.package }}" derives the candidate prefix "Test",
+    which would otherwise startswith()-match unrelated static check-runs
+    like "Test Chat Agent" — or even a same-named job in an intentionally
+    excluded workflow (build_tui.yml has its own static "Test" job). Every
+    workflow is scanned here regardless of `exclude` or trigger type,
+    because a real check-run can carry any of these names whether or not
+    its source workflow is itself a requirement.
+    """
+    reserved: dict[str, str] = {}
+    for fname, _doc, _job_id, _job, name_tmpl, is_templated in _iter_workflow_jobs(workflows_dir):
+        if not is_templated and name_tmpl:
+            reserved[name_tmpl] = fname
+    return reserved
+
+
+def load_requirements(workflows_dir: str, exclude: Iterable[str]) -> list[Requirement]:
+    """Parse every workflow with a `pull_request:` trigger into a flat list
+    of per-job requirements. A job is excluded (not required) when the
+    workflow itself has none to give: `continue-on-error: true` on that job
+    means its own author has already declared it non-blocking.
+    """
+    exclude_set = set(exclude)
+    reqs: list[Requirement] = []
+    for fname, doc, job_id, job, name_tmpl, is_templated in _iter_workflow_jobs(workflows_dir):
+        if fname in exclude_set:
+            continue
+        on = _on_block(doc)
+        if on is None:
+            continue
+        pr = on.get("pull_request")
+        if not isinstance(pr, dict):
+            # No `pull_request:` trigger at all (or a bare `pull_request:` with
+            # no filters, e.g. `on: [push, pull_request]`) -> if the key is
+            # present at all with no dict body, it means "no path filter";
+            # if pull_request isn't a trigger on this workflow, skip it.
+            if "pull_request" not in on:
+                continue
+            paths, paths_ignore = None, None
+        else:
+            paths = pr.get("paths")
+            paths_ignore = pr.get("paths-ignore")
+
+        if job.get("continue-on-error") is True:
+            continue
+        # Matrix-templated names ("Foo (${{ matrix.x }})") can't be
+        # statically expanded without evaluating GH Actions expressions;
+        # match by the static prefix before the first expression instead.
+        # A fully static name must match exactly (see the `exact` field
+        # docstring on Requirement for why).
+        prefix = name_tmpl.split("${{", 1)[0].rstrip() if is_templated else name_tmpl
+        if not prefix:
+            continue
+        reqs.append(
+            Requirement(
+                name_prefix=prefix,
+                exact=not is_templated,
+                paths=paths,
+                paths_ignore=paths_ignore,
+                source_file=fname,
+                job_id=job_id,
+            )
+        )
+    return reqs
+
+
+def _matches_any(changed_file: str, patterns: list[str]) -> bool:
+    return any(fnmatch.fnmatch(changed_file, pat) for pat in patterns)
+
+
+def is_path_relevant(req: Requirement, changed_files: list[str]) -> bool:
+    if req.paths is None and req.paths_ignore is None:
+        return True
+    if req.paths is not None:
+        return any(_matches_any(cf, req.paths) for cf in changed_files)
+    # paths-ignore only: relevant iff at least one changed file is NOT ignored.
+    return any(not _matches_any(cf, req.paths_ignore) for cf in changed_files)
+
+
+def evaluate(
+    requirements: list[Requirement],
+    changed_files: list[str],
+    check_runs: list[CheckRun],
+    reserved_names: dict[str, str] | None = None,
+) -> EvalResult:
+    reserved_names = reserved_names or {}
+    result = EvalResult()
+    for req in requirements:
+        if not is_path_relevant(req, changed_files):
+            continue
+        if req.exact:
+            matches = [cr for cr in check_runs if cr.name == req.name_prefix]
+        else:
+            # Exclude candidates that are some OTHER job's exact static
+            # name — see _collect_reserved_static_names for why this is
+            # necessary, not just defensive.
+            matches = [
+                cr
+                for cr in check_runs
+                if cr.name.startswith(req.name_prefix) and reserved_names.get(cr.name, req.source_file) == req.source_file
+            ]
+        if not matches:
+            result.missing.append(req)
+            continue
+        not_completed = [cr for cr in matches if cr.status != "completed"]
+        bad = [cr for cr in matches if cr.status == "completed" and cr.conclusion in TERMINAL_BAD_CONCLUSIONS]
+        good = [cr for cr in matches if cr.status == "completed" and cr.conclusion in PASSING_CONCLUSIONS]
+        if bad:
+            reasons = ", ".join(f"{cr.name}={cr.conclusion}" for cr in bad)
+            result.failed.append((req, reasons))
+        elif not_completed:
+            result.pending.append(req)
+        elif good:
+            result.ok.append(req)
+        else:
+            # Completed with some conclusion outside both sets (e.g. a
+            # brand-new conclusion value GitHub adds later) — fail loud
+            # rather than silently treating an unrecognized state as passing.
+            reasons = ", ".join(f"{cr.name}={cr.conclusion}" for cr in matches)
+            result.failed.append((req, f"unrecognized conclusion: {reasons}"))
+    return result
+
+
+def fetch_changed_files(path: str) -> list[str]:
+    with open(path) as f:
+        return [line.strip() for line in f if line.strip()]
+
+
+def fetch_check_runs(repo: str, sha: str) -> list[CheckRun]:
+    proc = subprocess.run(
+        [
+            "gh",
+            "api",
+            f"repos/{repo}/commits/{sha}/check-runs",
+            "--paginate",
+            "-q",
+            ".check_runs[] | {name, status, conclusion}",
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if proc.returncode != 0:
+        raise RuntimeError(
+            f"gh api check-runs lookup failed (exit {proc.returncode}): {proc.stderr.strip()}"
+        )
+    runs = []
+    for line in proc.stdout.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        obj = json.loads(line)
+        runs.append(CheckRun(name=obj["name"], status=obj["status"], conclusion=obj.get("conclusion")))
+    return runs
+
+
+def format_report(result: EvalResult, elapsed: int) -> str:
+    lines = []
+    if result.ok:
+        lines.append(f"OK ({len(result.ok)}): " + ", ".join(r.name_prefix for r in result.ok))
+    if result.pending or result.missing:
+        lines.append(
+            f"WAITING ({len(result.unresolved)}, {elapsed}s elapsed): "
+            + ", ".join(r.name_prefix for r in result.unresolved)
+        )
+    if result.failed:
+        lines.append("FAILED:")
+        for req, reason in result.failed:
+            lines.append(f"  - {req.name_prefix} (from {req.source_file}): {reason}")
+    return "\n".join(lines)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--workflows-dir", required=True)
+    parser.add_argument("--exclude", action="append", default=[])
+    parser.add_argument("--changed-files", required=True, help="path to a file, one changed path per line")
+    parser.add_argument("--repo", required=True, help="owner/repo")
+    parser.add_argument("--sha", required=True)
+    parser.add_argument("--timeout-seconds", type=int, default=3600)
+    parser.add_argument("--poll-seconds", type=int, default=30)
+    args = parser.parse_args()
+
+    requirements = load_requirements(args.workflows_dir, args.exclude)
+    reserved_names = _collect_reserved_static_names(args.workflows_dir)
+    changed_files = fetch_changed_files(args.changed_files)
+
+    print(f"Derived {len(requirements)} job requirements from {args.workflows_dir} "
+          f"(excluding {args.exclude}).")
+    print(f"PR touches {len(changed_files)} file(s).")
+
+    start = time.monotonic()
+    while True:
+        elapsed = int(time.monotonic() - start)
+        check_runs = fetch_check_runs(args.repo, args.sha)
+        result = evaluate(requirements, changed_files, check_runs, reserved_names)
+        print(format_report(result, elapsed))
+
+        if result.is_terminal_failure:
+            for req, reason in result.failed:
+                print(
+                    f"::error::Required check '{req.name_prefix}' (from "
+                    f"{req.source_file}) did not pass: {reason}. This is the "
+                    f"failure mode issue #2767 exists to catch — a check that "
+                    f"should have run for this diff did not report success."
+                )
+            return 1
+        if result.is_fully_ok:
+            print("All path-relevant required checks reported and passed.")
+            return 0
+        if elapsed >= args.timeout_seconds:
+            for req in result.unresolved:
+                print(
+                    f"::error::Required check '{req.name_prefix}' (from "
+                    f"{req.source_file}) never reported after {args.timeout_seconds}s."
+                )
+            return 1
+        time.sleep(args.poll_seconds)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/scripts/check_required_status.py
+++ b/.github/scripts/check_required_status.py
@@ -458,24 +458,28 @@ def fetch_changed_files(path: str) -> list[str]:
         return [line.strip() for line in f if line.strip()]
 
 
-CUSTOM_CHECK_NAME = "Required Checks Gate"
+CUSTOM_CHECK_NAME = "Required Checks Gate (detail)"
 
 
-def post_check_run(repo: str, sha: str, conclusion: str, title: str, summary: str) -> None:
-    """Create a check-run via the Checks API directly, independent of this
-    job's own native pass/fail check-run.
+def post_check_run(repo: str, sha: str, conclusion: str, title: str, summary: str) -> bool:
+    """Best-effort: create a check-run via the Checks API directly, richer
+    than this job's own native pass/fail conclusion (GitHub Actions can
+    only ever conclude a job as success/failure/cancelled/skipped — there's
+    no exit code for "neutral", which is what a legitimately-not-yet-required
+    draft PR needs to express without lying either direction).
 
-    Why a second, API-created check-run instead of just letting the job's
-    exit code decide: GitHub Actions can only ever conclude a job as
-    success/failure/cancelled/skipped — there's no exit code for "neutral".
-    But "this PR's required suites legitimately have not run yet because
-    it's a draft" is neither a pass (nothing has been verified) nor a
-    failure (nothing is wrong) — see the redirect on #2767 that led to this:
-    a gate that skips itself in sympathy with the jobs it's auditing
-    reproduces the exact silent-green bug it exists to catch. `neutral` is
-    the one Checks API conclusion built for exactly this: visible, distinct
-    from both green and red, and does not block a merge on its own (mirrors
-    GitHub's own branch-protection semantics for a neutral required check).
+    Deliberately NEVER the binding signal — see main()'s docstring on why.
+    Returns False (never raises) on failure so a caller can log it and
+    fall through to the native job status, which is what branch protection
+    should actually require. On a fork PR this call is expected to fail:
+    GitHub silently downgrades GITHUB_TOKEN to read-only for `pull_request`
+    (not `pull_request_target`) regardless of what `permissions:` the
+    workflow declares — confirmed live, not assumed: a real fork PR's
+    "Dependency Review" job (repo PR #2753, plain `pull_request` trigger,
+    `permissions: pull-requests: write` declared) logged
+    "GITHUB_TOKEN Permissions: Contents: read, Metadata: read,
+    PullRequests: read" — write silently dropped to read. `checks: write`
+    is downgraded the identical way, so this call 403s on every fork PR.
     """
     payload = {
         "name": CUSTOM_CHECK_NAME,
@@ -492,7 +496,15 @@ def post_check_run(repo: str, sha: str, conclusion: str, title: str, summary: st
         check=False,
     )
     if proc.returncode != 0:
-        raise RuntimeError(f"gh api check-runs create failed (exit {proc.returncode}): {proc.stderr.strip()}")
+        print(
+            f"::warning::Could not post the richer '{CUSTOM_CHECK_NAME}' status "
+            f"(exit {proc.returncode}): {proc.stderr.strip()}. Expected on fork "
+            f"PRs — GITHUB_TOKEN is read-only there regardless of the workflow's "
+            f"declared permissions. The native 'Required Checks Gate' job status "
+            f"is unaffected and is the one branch protection should require."
+        )
+        return False
+    return True
 
 
 def fetch_check_runs(repo: str, sha: str) -> list[CheckRun]:
@@ -551,6 +563,20 @@ def format_exclusions(num_enforced: int, exclusions: list[Exclusion]) -> str:
     )
 
 
+def write_step_summary(title: str, body: str) -> None:
+    """Write to this job's own Actions step summary — visible directly in
+    the workflow run's UI, needs zero permissions (unlike post_check_run),
+    and works identically on same-repo and fork PRs. This is what keeps
+    the neutral/success/failure nuance available on a fork PR even though
+    the richer, API-posted check-run can't be created there.
+    """
+    path = os.environ.get("GITHUB_STEP_SUMMARY")
+    if not path:
+        return
+    with open(path, "a") as f:
+        f.write(f"## {title}\n\n{body}\n")
+
+
 def format_report(result: EvalResult, elapsed: int) -> str:
     lines = []
     if result.ok:
@@ -568,6 +594,27 @@ def format_report(result: EvalResult, elapsed: int) -> str:
 
 
 def main() -> int:
+    """Exit code is the ONLY binding signal — the thing branch protection
+    should require is this job's own native status ("Required Checks
+    Gate"), never the richer, API-posted "Required Checks Gate (detail)"
+    check-run. That split exists because of a fork-PR gap found on this
+    issue's own PR: GITHUB_TOKEN is silently downgraded to read-only for
+    `pull_request` (not `pull_request_target`) on a fork PR regardless of
+    the workflow's declared `permissions:` — confirmed live against a real
+    fork PR (see post_check_run's docstring). A required check that can
+    only ever post via a permission forks don't have would block every
+    fork contribution to this repo, which defeats requiring it at all.
+
+    So the native exit code — always available, no special permissions,
+    identical on same-repo and fork PRs — carries the real signal in every
+    case. The three richer states (neutral/success/failure) collapse to a
+    plain pass/fail here: neutral and success both exit 0, only a genuine
+    failure or timeout exits 1. The nuance isn't dropped, just moved to a
+    channel that needs no permissions either: write_step_summary() puts it
+    in this job's own Actions summary, and post_check_run() still attempts
+    the richer, distinctly-colored check-run wherever the token allows it
+    (same-repo PRs) — best-effort, logged on failure, never fatal.
+    """
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--workflows-dir", required=True)
     parser.add_argument("--exclude", action="append", default=[])
@@ -612,7 +659,14 @@ def main() -> int:
             + exclusion_note
         )
         print(f"GATED OFF: {summary}")
+        write_step_summary(title, summary)
         post_check_run(args.repo, args.sha, "neutral", title, summary)
+        # Exits 0 (not 1): a draft PR without ready_for_ci genuinely cannot
+        # be merged regardless of check status (GitHub blocks merging any
+        # draft PR at the platform level), so there is nothing to protect
+        # by failing here — and reflexive red on every draft is exactly the
+        # noise option already rejected. The "nothing has been verified"
+        # distinction lives in the summary text above, not the exit code.
         return 0
 
     all_matchers = _collect_all_name_matchers(args.workflows_dir)
@@ -654,6 +708,7 @@ def main() -> int:
                     f"failure mode issue #2767 exists to catch — a check that "
                     f"should have run for this diff did not report success."
                 )
+            write_step_summary("Required suites did not pass", details + exclusion_note)
             post_check_run(
                 args.repo,
                 args.sha,
@@ -665,13 +720,9 @@ def main() -> int:
         if result.is_fully_ok:
             print("All path-relevant required checks reported and passed.")
             names = ", ".join(r.name_prefix for r in result.ok) or "(none required for this diff)"
-            post_check_run(
-                args.repo,
-                args.sha,
-                "success",
-                "All required suites passed",
-                f"Required and path-relevant for this diff: {names}." + exclusion_note,
-            )
+            summary = f"Required and path-relevant for this diff: {names}." + exclusion_note
+            write_step_summary("All required suites passed", summary)
+            post_check_run(args.repo, args.sha, "success", "All required suites passed", summary)
             return 0
         if elapsed >= args.timeout_seconds:
             details = ", ".join(r.name_prefix for r in result.unresolved)
@@ -680,13 +731,9 @@ def main() -> int:
                     f"::error::Required check '{req.name_prefix}' (from "
                     f"{req.source_file}) never reported after {args.timeout_seconds}s."
                 )
-            post_check_run(
-                args.repo,
-                args.sha,
-                "failure",
-                "Required suites never reported",
-                f"Timed out after {args.timeout_seconds}s waiting on: {details}." + exclusion_note,
-            )
+            summary = f"Timed out after {args.timeout_seconds}s waiting on: {details}." + exclusion_note
+            write_step_summary("Required suites never reported", summary)
+            post_check_run(args.repo, args.sha, "failure", "Required suites never reported", summary)
             return 1
         time.sleep(args.poll_seconds)
 

--- a/.github/scripts/check_required_status.py
+++ b/.github/scripts/check_required_status.py
@@ -103,8 +103,8 @@ def _on_block(doc: dict) -> dict | None:
 def _iter_workflow_jobs(workflows_dir: str):
     """Yield (fname, doc, job_id, job, name_tmpl, is_templated) for every job
     in every *.yml/*.yaml file in workflows_dir, regardless of trigger type.
-    Shared between load_requirements() and _collect_reserved_static_names()
-    so both see exactly the same parse.
+    Shared between load_requirements() and _collect_all_name_matchers() so
+    both see exactly the same parse.
     """
     for path in sorted(glob.glob(os.path.join(workflows_dir, "*.yml"))) + sorted(
         glob.glob(os.path.join(workflows_dir, "*.yaml"))
@@ -127,24 +127,59 @@ def _iter_workflow_jobs(workflows_dir: str):
             yield fname, doc, job_id, job, name_tmpl, "${{" in name_tmpl
 
 
-def _collect_reserved_static_names(workflows_dir: str) -> dict[str, str]:
-    """Map every fully-static (non-templated) job name, across every
-    workflow file with no exclusions, to its source file.
+@dataclass(frozen=True)
+class _NameMatcher:
+    pattern: str
+    exact: bool
+    source_file: str
+    job_id: str
 
-    This is what makes prefix matching for matrix-templated jobs safe: a job
-    named "Test ${{ matrix.package }}" derives the candidate prefix "Test",
-    which would otherwise startswith()-match unrelated static check-runs
-    like "Test Chat Agent" — or even a same-named job in an intentionally
-    excluded workflow (build_tui.yml has its own static "Test" job). Every
-    workflow is scanned here regardless of `exclude` or trigger type,
-    because a real check-run can carry any of these names whether or not
-    its source workflow is itself a requirement.
+
+def _collect_all_name_matchers(workflows_dir: str) -> list[_NameMatcher]:
+    """Every job in every workflow file, as a name matcher — static names
+    exact, matrix-templated names as their prefix — regardless of
+    `exclude` or trigger type.
+
+    Live evidence on #2767 (PR #2775, throwaway) is what proved a bare
+    prefix guard against static names wasn't enough: test_hub_agents.yml's
+    "Test ${{ matrix.package }}" collapses to the prefix "Test", which
+    startswith()-matched not just an unrelated static "Test Chat Agent" but
+    ALSO other matrix-templated jobs' rendered names, e.g. "Test Apps Build
+    (jira)" (from test_electron.yml's own, more specific, "Test Apps Build
+    (" prefix) and "Test MCPAgent (ubuntu-latest)". The verdict came out
+    right that time (both were legitimately failing), but the *reason*
+    attributed those failures to the wrong job. `_most_specific_owner`
+    below is the general fix: every check-run name belongs to whichever
+    matcher matches it most specifically — an exact match beats any prefix,
+    and among prefixes the longest (most specific) one wins.
     """
-    reserved: dict[str, str] = {}
-    for fname, _doc, _job_id, _job, name_tmpl, is_templated in _iter_workflow_jobs(workflows_dir):
-        if not is_templated and name_tmpl:
-            reserved[name_tmpl] = fname
-    return reserved
+    matchers = []
+    for fname, _doc, job_id, _job, name_tmpl, is_templated in _iter_workflow_jobs(workflows_dir):
+        if not name_tmpl:
+            continue
+        prefix = name_tmpl.split("${{", 1)[0].rstrip() if is_templated else name_tmpl
+        if not prefix:
+            continue
+        matchers.append(_NameMatcher(pattern=prefix, exact=not is_templated, source_file=fname, job_id=job_id))
+    return matchers
+
+
+def _most_specific_owner(name: str, matchers: list[_NameMatcher]) -> tuple[str, str] | None:
+    best: _NameMatcher | None = None
+    for m in matchers:
+        matched = name == m.pattern if m.exact else name.startswith(m.pattern)
+        if not matched:
+            continue
+        if best is None:
+            best = m
+            continue
+        # An exact match always outranks a prefix match; among prefixes,
+        # the longer (more specific) one wins.
+        best_specificity = len(best.pattern) + (1000 if best.exact else 0)
+        cand_specificity = len(m.pattern) + (1000 if m.exact else 0)
+        if cand_specificity > best_specificity:
+            best = m
+    return (best.source_file, best.job_id) if best else None
 
 
 def load_requirements(workflows_dir: str, exclude: Iterable[str]) -> list[Requirement]:
@@ -224,9 +259,9 @@ def evaluate(
     requirements: list[Requirement],
     changed_files: list[str],
     check_runs: list[CheckRun],
-    reserved_names: dict[str, str] | None = None,
+    all_matchers: list[_NameMatcher] | None = None,
 ) -> EvalResult:
-    reserved_names = reserved_names or {}
+    all_matchers = all_matchers or []
     result = EvalResult()
     for req in requirements:
         if not is_path_relevant(req, changed_files):
@@ -234,13 +269,14 @@ def evaluate(
         if req.exact:
             matches = [cr for cr in check_runs if cr.name == req.name_prefix]
         else:
-            # Exclude candidates that are some OTHER job's exact static
-            # name — see _collect_reserved_static_names for why this is
-            # necessary, not just defensive.
+            # Only accept a candidate if THIS job is its most specific owner
+            # — see _most_specific_owner for why a plain startswith() isn't
+            # enough once other prefix-mode jobs exist too.
             matches = [
                 cr
                 for cr in check_runs
-                if cr.name.startswith(req.name_prefix) and reserved_names.get(cr.name, req.source_file) == req.source_file
+                if cr.name.startswith(req.name_prefix)
+                and _most_specific_owner(cr.name, all_matchers) in (None, (req.source_file, req.job_id))
             ]
         if not matches:
             result.missing.append(req)
@@ -387,7 +423,7 @@ def main() -> int:
         return 0
 
     requirements = load_requirements(args.workflows_dir, args.exclude)
-    reserved_names = _collect_reserved_static_names(args.workflows_dir)
+    all_matchers = _collect_all_name_matchers(args.workflows_dir)
     changed_files = fetch_changed_files(args.changed_files)
 
     print(f"Derived {len(requirements)} job requirements from {args.workflows_dir} "
@@ -398,7 +434,7 @@ def main() -> int:
     while True:
         elapsed = int(time.monotonic() - start)
         check_runs = fetch_check_runs(args.repo, args.sha)
-        result = evaluate(requirements, changed_files, check_runs, reserved_names)
+        result = evaluate(requirements, changed_files, check_runs, all_matchers)
         print(format_report(result, elapsed))
 
         if result.is_terminal_failure:

--- a/.github/scripts/check_required_status.py
+++ b/.github/scripts/check_required_status.py
@@ -64,6 +64,23 @@ class CheckRun:
     name: str
     status: str
     conclusion: str | None
+    # ISO 8601 — GitHub's Checks API never deletes or overwrites a prior
+    # check-run when a job re-runs; every triggering event adds a new row.
+    # `started_at` is what lets evaluate() tell a stale result from the
+    # current one instead of treating the whole history as live.
+    started_at: str = ""
+
+
+@dataclass
+class Exclusion:
+    name_prefix: str
+    source_file: str
+    job_id: str
+    reason: str
+    # Short, stable category for the summary counts in format_exclusions —
+    # kept separate from `reason` (the free-text detail) so the count
+    # breakdown doesn't depend on parsing that string.
+    kind: str
 
 
 @dataclass
@@ -124,7 +141,18 @@ def _iter_workflow_jobs(workflows_dir: str):
             if not isinstance(job, dict):
                 continue
             name_tmpl = job.get("name") or job_id
-            yield fname, doc, job_id, job, name_tmpl, "${{" in name_tmpl
+            # A job needs prefix (not exact) matching whenever its RENDERED
+            # check-run name can vary — either its own `name:` has a
+            # `${{ }}` expression, OR it has a matrix strategy at all. The
+            # second case is easy to miss: a static `name:` with a matrix
+            # ("Audit Dependencies" + strategy.matrix.package) still gets
+            # GitHub's own auto-appended "(leg, values)" disambiguator on
+            # every rendered check-run — confirmed live on #2767's own PR
+            # (#2783), where exact-matching "Audit Dependencies" against
+            # "Audit Dependencies (example-app, ...)" never matched at all.
+            has_matrix = bool(job.get("strategy", {}).get("matrix")) if isinstance(job.get("strategy"), dict) else False
+            is_templated = "${{" in name_tmpl or has_matrix
+            yield fname, doc, job_id, job, name_tmpl, is_templated
 
 
 @dataclass(frozen=True)
@@ -182,14 +210,28 @@ def _most_specific_owner(name: str, matchers: list[_NameMatcher]) -> tuple[str, 
     return (best.source_file, best.job_id) if best else None
 
 
-def load_requirements(workflows_dir: str, exclude: Iterable[str]) -> list[Requirement]:
+def load_requirements(
+    workflows_dir: str, exclude: Iterable[str]
+) -> tuple[list[Requirement], list[Exclusion]]:
     """Parse every workflow with a `pull_request:` trigger into a flat list
-    of per-job requirements. A job is excluded (not required) when the
-    workflow itself has none to give: `continue-on-error: true` on that job
-    means its own author has already declared it non-blocking.
+    of per-job requirements, plus the jobs deliberately left OUT and why.
+
+    Two things make a job impossible to verify statically, and both get
+    excluded — but reported, not silently dropped (see Exclusion): a
+    silent exclusion is a fail-open hole inside the gate built to close
+    fail-open holes, e.g. a future job wrapped in `needs.*` dropping out of
+    the required set with nobody told.
+
+    - `continue-on-error: true` — the job's own author already declared it
+      non-blocking.
+    - an `if:` that references `needs.` — gated on another job's runtime
+      output (e.g. a dynamically discovered matrix via
+      `fromJson(needs.x.outputs.y)`), which cannot be evaluated from YAML
+      alone without executing the DAG.
     """
     exclude_set = set(exclude)
     reqs: list[Requirement] = []
+    exclusions: list[Exclusion] = []
     for fname, doc, job_id, job, name_tmpl, is_templated in _iter_workflow_jobs(workflows_dir):
         if fname in exclude_set:
             continue
@@ -209,8 +251,6 @@ def load_requirements(workflows_dir: str, exclude: Iterable[str]) -> list[Requir
             paths = pr.get("paths")
             paths_ignore = pr.get("paths-ignore")
 
-        if job.get("continue-on-error") is True:
-            continue
         # Matrix-templated names ("Foo (${{ matrix.x }})") can't be
         # statically expanded without evaluating GH Actions expressions;
         # match by the static prefix before the first expression instead.
@@ -219,6 +259,49 @@ def load_requirements(workflows_dir: str, exclude: Iterable[str]) -> list[Requir
         prefix = name_tmpl.split("${{", 1)[0].rstrip() if is_templated else name_tmpl
         if not prefix:
             continue
+
+        if job.get("continue-on-error") is True:
+            exclusions.append(
+                Exclusion(
+                    prefix,
+                    fname,
+                    job_id,
+                    "continue-on-error: true (job's own author declared it non-blocking)",
+                    kind="continue-on-error",
+                )
+            )
+            continue
+        job_if = job.get("if")
+        if isinstance(job_if, str) and "needs." in job_if:
+            exclusions.append(
+                Exclusion(
+                    prefix,
+                    fname,
+                    job_id,
+                    f"if: references needs.* ({job_if.strip()!r}) — depends on another job's runtime output, not statically verifiable",
+                    kind="needs-gated",
+                )
+            )
+            continue
+        # Unlike needs.*, this one IS statically decidable: github.ref on a
+        # pull_request event is always the PR's merge ref, never a tag ref,
+        # so a job gated on refs/tags/ can never run in PR context at all —
+        # confirmed live on #2767's own PR (build_agents.yml's "Consolidate
+        # release bundle", `if: startsWith(github.ref, 'refs/tags/v')`,
+        # sitting at conclusion=skipped on every PR run forever). Excluding
+        # it is correcting a real derivation gap, not hedging on the unknown.
+        if isinstance(job_if, str) and "refs/tags/" in job_if:
+            exclusions.append(
+                Exclusion(
+                    prefix,
+                    fname,
+                    job_id,
+                    f"if: gated on a tag ref ({job_if.strip()!r}) — can never run on a pull_request event",
+                    kind="ref-conditional",
+                )
+            )
+            continue
+
         reqs.append(
             Requirement(
                 name_prefix=prefix,
@@ -229,7 +312,7 @@ def load_requirements(workflows_dir: str, exclude: Iterable[str]) -> list[Requir
                 job_id=job_id,
             )
         )
-    return reqs
+    return reqs, exclusions
 
 
 def is_gated_off(is_draft: bool, labels: set[str]) -> bool:
@@ -253,6 +336,75 @@ def is_path_relevant(req: Requirement, changed_files: list[str]) -> bool:
         return any(_matches_any(cf, req.paths) for cf in changed_files)
     # paths-ignore only: relevant iff at least one changed file is NOT ignored.
     return any(not _matches_any(cf, req.paths_ignore) for cf in changed_files)
+
+
+def _is_pre_expansion_artifact(name: str, req: Requirement) -> bool:
+    """True when `name` is what a matrix job's check-run looks like BEFORE
+    its strategy ever expanded (job `if:` was false, e.g. still draft) —
+    confirmed live on #2767's own PRs, in two different shapes:
+
+    1. The job's own `name:` contains `${{ }}` — GitHub posts the raw,
+       un-rendered template string, e.g.
+       "Test Apps Build (${{ matrix.app.name }})".
+    2. The job's `name:` is fully static but it has a `strategy.matrix`
+       anyway — GitHub normally disambiguates each real leg by appending
+       "(leg, values)" (e.g. "Audit Dependencies (jira-app, ...)"), but a
+       job skipped before expansion posts the bare, un-suffixed name with
+       nothing appended: "Audit Dependencies", identical to the derived
+       prefix itself. A REAL run of a multi-leg matrix job can never
+       produce that bare, un-suffixed name — GitHub always appends
+       something once legs actually exist — so `name == req.name_prefix`
+       is exact and decidable, not a heuristic, for this shape.
+
+    Only meaningful for prefix-mode (non-exact) requirements; exact-mode
+    requirements have no matrix-expansion ambiguity to begin with.
+    """
+    if "${{" in name:
+        return True
+    return not req.exact and name == req.name_prefix
+
+
+def _current_matches(matches: list[CheckRun], req: Requirement) -> list[CheckRun]:
+    """Reduce a requirement's raw check-run matches to the ones that
+    represent its CURRENT state, not its full history.
+
+    GitHub never deletes or overwrites a check-run — every triggering event
+    (opened, then later labeled, then later reopened, ...) adds new rows
+    alongside the old ones. Two things fall out of that:
+
+    1. The same exact name can appear more than once (e.g. "discover-apps"
+       re-run after a draft PR is reopened). Keep only the newest per name.
+    2. A matrix job whose `if:` was false BEFORE its strategy expanded posts
+       exactly ONE check-run in its pre-expansion form (see
+       _is_pre_expansion_artifact) — confirmed live on #2767's own
+       throwaway and real PRs. That row is meaningless once the SAME job
+       has actually run for real anywhere in this SHA's history (producing
+       real, expanded rows) — so once at least one non-artifact row exists,
+       discard any artifact row OLDER than the newest non-artifact one. An
+       artifact row NEWER than every non-artifact row is kept: that's a
+       genuine re-skip (e.g. the PR went back to draft after a real pass),
+       and the gate should report that as current, not paper over it.
+
+    Deliberately not a fixed time-window ("group everything within N
+    seconds"): the observed gap between a stale skip and its real re-run
+    ranged from about a minute to several minutes on real PRs in this repo,
+    so no fixed window reliably separates "same event" from "different
+    event." Comparing by exact name + the decidable artifact rule above
+    needs no tuned constant and is exact rather than approximate.
+    """
+    latest_by_name: dict[str, CheckRun] = {}
+    for cr in matches:
+        cur = latest_by_name.get(cr.name)
+        if cur is None or cr.started_at > cur.started_at:
+            latest_by_name[cr.name] = cr
+    deduped = list(latest_by_name.values())
+
+    non_artifact = [cr for cr in deduped if not _is_pre_expansion_artifact(cr.name, req)]
+    artifact = [cr for cr in deduped if _is_pre_expansion_artifact(cr.name, req)]
+    if non_artifact:
+        newest_real_ts = max(cr.started_at for cr in non_artifact)
+        artifact = [cr for cr in artifact if cr.started_at > newest_real_ts]
+    return non_artifact + artifact
 
 
 def evaluate(
@@ -281,6 +433,7 @@ def evaluate(
         if not matches:
             result.missing.append(req)
             continue
+        matches = _current_matches(matches, req)
         not_completed = [cr for cr in matches if cr.status != "completed"]
         bad = [cr for cr in matches if cr.status == "completed" and cr.conclusion in TERMINAL_BAD_CONCLUSIONS]
         good = [cr for cr in matches if cr.status == "completed" and cr.conclusion in PASSING_CONCLUSIONS]
@@ -350,7 +503,7 @@ def fetch_check_runs(repo: str, sha: str) -> list[CheckRun]:
             f"repos/{repo}/commits/{sha}/check-runs",
             "--paginate",
             "-q",
-            ".check_runs[] | {name, status, conclusion}",
+            ".check_runs[] | {name, status, conclusion, started_at}",
         ],
         capture_output=True,
         text=True,
@@ -366,8 +519,36 @@ def fetch_check_runs(repo: str, sha: str) -> list[CheckRun]:
         if not line:
             continue
         obj = json.loads(line)
-        runs.append(CheckRun(name=obj["name"], status=obj["status"], conclusion=obj.get("conclusion")))
+        runs.append(
+            CheckRun(
+                name=obj["name"],
+                status=obj["status"],
+                conclusion=obj.get("conclusion"),
+                started_at=obj.get("started_at") or "",
+            )
+        )
     return runs
+
+
+def format_exclusions(num_enforced: int, exclusions: list[Exclusion]) -> str:
+    """Scope summary for every posted check-run, not just the exclusion
+    list itself — with three exclusion classes now, a bare list is easy to
+    skim past as a workflow evolves and the excluded set quietly grows.
+    Stating it as a ratio keeps the gate's own coverage auditable at a
+    glance: "enforced N, excluded M (kind: count, ...)".
+    """
+    total = num_enforced + len(exclusions)
+    if not exclusions:
+        return f" Enforced {num_enforced}/{total} requirement(s); none excluded."
+    by_kind: dict[str, int] = {}
+    for e in exclusions:
+        by_kind[e.kind] = by_kind.get(e.kind, 0) + 1
+    breakdown = ", ".join(f"{kind}: {count}" for kind, count in sorted(by_kind.items()))
+    items = "; ".join(f"{e.name_prefix} (from {e.source_file}): {e.reason}" for e in exclusions)
+    return (
+        f" Enforced {num_enforced}/{total} requirement(s); excluded {len(exclusions)} "
+        f"as not statically verifiable ({breakdown}): {items}."
+    )
 
 
 def format_report(result: EvalResult, elapsed: int) -> str:
@@ -402,6 +583,13 @@ def main() -> int:
     is_draft = args.draft == "true"
     labels = {label.strip() for label in args.labels.split(",") if label.strip()}
 
+    requirements, exclusions = load_requirements(args.workflows_dir, args.exclude)
+    exclusion_note = format_exclusions(len(requirements), exclusions)
+    print(exclusion_note.strip())
+    if exclusions:
+        for e in exclusions:
+            print(f"  - {e.name_prefix} (from {e.source_file}, {e.kind}): {e.reason}")
+
     if is_gated_off(is_draft, labels):
         # Deliberately NOT skipped via a job-level `if:` — see the module
         # docstring on post_check_run for why a job that skips itself here
@@ -415,14 +603,18 @@ def main() -> int:
             "This PR is a draft without the `ready_for_ci` label, so the "
             "suites this gate audits have not run (by the same convention "
             "every audited workflow uses). Nothing has been verified — this "
-            "is not a pass. Mark the PR ready for review, or add the "
-            "`ready_for_ci` label, to require and verify them."
+            "is not a pass. Two ways to require and verify them: mark the PR "
+            "ready for review, OR add the `ready_for_ci` label AND THEN close "
+            "and reopen the PR. The label alone is not enough — the audited "
+            "suites only listen for opened/synchronize/reopened/ready_for_review "
+            "events, not `labeled`, so adding the label by itself does not "
+            "re-trigger them (only this gate re-triggers on `labeled`)."
+            + exclusion_note
         )
         print(f"GATED OFF: {summary}")
         post_check_run(args.repo, args.sha, "neutral", title, summary)
         return 0
 
-    requirements = load_requirements(args.workflows_dir, args.exclude)
     all_matchers = _collect_all_name_matchers(args.workflows_dir)
     changed_files = fetch_changed_files(args.changed_files)
 
@@ -438,7 +630,23 @@ def main() -> int:
         print(format_report(result, elapsed))
 
         if result.is_terminal_failure:
-            details = "; ".join(f"{req.name_prefix} ({reason})" for req, reason in result.failed)
+            # "did not run" (stuck at skipped — needs a re-trigger) and "ran
+            # and failed" (a real failure/timeout/cancellation) are different
+            # states and need different advice, not one blanket message.
+            not_run = [(req, reason) for req, reason in result.failed if "=skipped" in reason]
+            really_failed = [(req, reason) for req, reason in result.failed if "=skipped" not in reason]
+            parts = []
+            if not_run:
+                names = "; ".join(f"{req.name_prefix} ({reason})" for req, reason in not_run)
+                parts.append(
+                    "Did not run (stuck at 'skipped', not re-evaluated for the current "
+                    f"state — add `ready_for_ci` AND close/reopen the PR to re-trigger "
+                    f"them, the label alone will not): {names}"
+                )
+            if really_failed:
+                names = "; ".join(f"{req.name_prefix} ({reason})" for req, reason in really_failed)
+                parts.append(f"Ran and did not pass: {names}")
+            details = " ".join(parts)
             for req, reason in result.failed:
                 print(
                     f"::error::Required check '{req.name_prefix}' (from "
@@ -451,7 +659,7 @@ def main() -> int:
                 args.sha,
                 "failure",
                 "Required suites did not pass",
-                f"One or more required, path-relevant checks did not pass: {details}",
+                details + exclusion_note,
             )
             return 1
         if result.is_fully_ok:
@@ -462,7 +670,7 @@ def main() -> int:
                 args.sha,
                 "success",
                 "All required suites passed",
-                f"Required and path-relevant for this diff: {names}",
+                f"Required and path-relevant for this diff: {names}." + exclusion_note,
             )
             return 0
         if elapsed >= args.timeout_seconds:
@@ -477,7 +685,7 @@ def main() -> int:
                 args.sha,
                 "failure",
                 "Required suites never reported",
-                f"Timed out after {args.timeout_seconds}s waiting on: {details}",
+                f"Timed out after {args.timeout_seconds}s waiting on: {details}." + exclusion_note,
             )
             return 1
         time.sleep(args.poll_seconds)

--- a/.github/workflows/build-electron-apps.yml
+++ b/.github/workflows/build-electron-apps.yml
@@ -15,7 +15,6 @@ on:
   push:
     branches: [main]
   pull_request:
-    branches: [main]
     types: [opened, synchronize, reopened, ready_for_review]
   merge_group:
   workflow_dispatch:

--- a/.github/workflows/build_agents.yml
+++ b/.github/workflows/build_agents.yml
@@ -26,7 +26,6 @@ on:
       - 'cpp/**'
       - '.github/workflows/build_agents.yml'
   pull_request:
-    branches: [ main ]
     types: [opened, synchronize, reopened, ready_for_review]
     paths:
       - 'cpp/**'

--- a/.github/workflows/build_cpp.yml
+++ b/.github/workflows/build_cpp.yml
@@ -19,7 +19,6 @@ on:
       - '.github/workflows/build_cpp.yml'
       - '.github/workflows/benchmark_cpp.yml'
   pull_request:
-    branches: [ main ]
     types: [opened, synchronize, reopened, ready_for_review]
     paths:
       - 'src/gaia/version.py'

--- a/.github/workflows/build_cpp_email.yml
+++ b/.github/workflows/build_cpp_email.yml
@@ -30,7 +30,6 @@ on:
       - 'cpp/agents/email/**'
       - '.github/workflows/build_cpp_email.yml'
   pull_request:
-    branches: [ main ]
     types: [opened, synchronize, reopened, ready_for_review]
     paths:
       - 'cpp/agents/email/**'

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -9,7 +9,6 @@ name: Dependency Review
 
 on:
   pull_request:
-    branches: [ main ]
     types: [opened, synchronize, reopened, ready_for_review]
   merge_group:
   workflow_dispatch:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -24,7 +24,6 @@ on:
       - '.github/dependabot.yml'
       - '.github/workflows/lint.yml'
   pull_request:
-    branches: [ main ]
     types: [opened, synchronize, reopened, ready_for_review]
     paths:
       - 'src/**'

--- a/.github/workflows/required_checks_gate.yml
+++ b/.github/workflows/required_checks_gate.yml
@@ -48,7 +48,18 @@ permissions:
 
 concurrency:
   group: required-checks-gate-${{ github.event.pull_request.number }}
-  cancel-in-progress: true
+  # NOT cancel-in-progress. Unlike the audited workflows, cancelling this
+  # one is not free: a run that gets killed before it reaches main()'s
+  # post_check_run() calls never posts a check-run for the SHA it was
+  # evaluating at all. If that cancelled run happened to be the LAST
+  # triggering event for that SHA (nothing left to supersede it and try
+  # again), the "Required Checks Gate" check silently never appears for
+  # that commit — a fourth way to fail open, inside the fix for the other
+  # three. Queuing instead of cancelling costs some run time when events
+  # arrive in a burst (e.g. this repo's auto-labeler firing right after
+  # open) but guarantees every triggering event eventually gets a real,
+  # posted verdict.
+  cancel-in-progress: false
 
 jobs:
   gate:

--- a/.github/workflows/required_checks_gate.yml
+++ b/.github/workflows/required_checks_gate.yml
@@ -1,0 +1,86 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+# Required aggregating gate (#2767). Cross-workflow `needs:` doesn't exist in
+# GitHub Actions, so this can't depend on the other workflows directly — it
+# observes the Checks API for the PR's head SHA instead, comparing what
+# actually reported against what .github/scripts/check_required_status.py
+# derives from every other workflow's own `pull_request:` path filters. That
+# derivation (not a hand-maintained list here) is what keeps this correct as
+# workflows are added — see the script's own docstring for the reasoning.
+#
+# This is the mechanism that turns a silent skip — wrong base branch, a
+# label-driven skip like #2755, or a future variant — into a visible red
+# check, because it doesn't care why a dependency didn't report, only that
+# it didn't.
+
+name: Required Checks Gate
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review, labeled]
+    # Deliberately no `branches:` filter: that filter is the exact bug this
+    # workflow exists to catch, so applying it here would just move the gap.
+
+permissions:
+  contents: read
+  checks: read
+  pull-requests: read
+
+concurrency:
+  group: required-checks-gate-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  gate:
+    name: Required Checks Gate
+    runs-on: ubuntu-latest
+    # Same condition every gated job in this repo already uses (#2755) — kept
+    # identical on purpose. Mirroring it here, rather than the gate deciding
+    # per-check whether a draft PR is "exempt", means this check shows the
+    # same honest "skipped" state everything else shows while a PR awaits
+    # `ready_for_ci`, instead of fabricating a pass for work nothing has run
+    # yet. Listening to the `labeled` event above (unlike the jobs being
+    # audited) is what lets adding `ready_for_ci` alone re-run this gate —
+    # the exact re-trigger #2755 says the audited jobs are missing.
+    if: github.event.pull_request.draft == false || contains(github.event.pull_request.labels.*.name, 'ready_for_ci')
+    timeout-minutes: 65
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: List changed files
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          gh api "repos/$REPO/pulls/$PR_NUMBER/files" --paginate -q '.[].filename' > changed_files.txt
+          echo "$(wc -l < changed_files.txt) changed file(s):"
+          cat changed_files.txt
+
+      - name: Set up Python
+        uses: actions/setup-python@v7
+        with:
+          python-version: '3.12'
+
+      - name: Install PyYAML
+        run: pip install --disable-pip-version-check pyyaml
+
+      # build_tui.yml keeps its own branches:[main] filter for now — PR #2696
+      # already widens that workflow, so excluding it here avoids this gate
+      # red-flagging a gap that PR is already closing.
+      - name: Wait for and verify required checks
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          python .github/scripts/check_required_status.py \
+            --workflows-dir .github/workflows \
+            --exclude required_checks_gate.yml \
+            --exclude build_tui.yml \
+            --changed-files changed_files.txt \
+            --repo "$REPO" \
+            --sha "$HEAD_SHA" \
+            --timeout-seconds 3600 \
+            --poll-seconds 30

--- a/.github/workflows/required_checks_gate.yml
+++ b/.github/workflows/required_checks_gate.yml
@@ -13,6 +13,25 @@
 # label-driven skip like #2755, or a future variant — into a visible red
 # check, because it doesn't care why a dependency didn't report, only that
 # it didn't.
+#
+# This job deliberately has NO job-level `if:` skipping it for draft PRs,
+# unlike every job it audits. A gate that skips itself in sympathy with the
+# jobs it's auditing reproduces this issue's exact bug inside the mechanism
+# meant to catch it: on a draft PR without `ready_for_ci` — this repo's
+# default PR state — the audited suites skip AND the gate would skip too,
+# so nothing runs, nothing is red, and the checks page still reads green
+# with no coverage behind it. Instead this job always runs and reports one
+# of three states via a self-posted check-run (see post_check_run() in the
+# script): `neutral` while the PR is legitimately not asking for CI yet,
+# `success` once the relevant suites verifiably passed, or `failure` if any
+# didn't. `neutral` is visibly distinct from both and does not block a
+# merge on its own, matching GitHub's own semantics for a neutral required
+# check — so this is legible, not noise, and not a lie.
+#
+# The job's OWN native check-run (below, named "(runner)") only reflects
+# whether the script executed without crashing — the meaningful signal for
+# branch protection to require is the self-posted "Required Checks Gate"
+# check-run the script creates via the API.
 
 name: Required Checks Gate
 
@@ -24,7 +43,7 @@ on:
 
 permissions:
   contents: read
-  checks: read
+  checks: write
   pull-requests: read
 
 concurrency:
@@ -33,17 +52,8 @@ concurrency:
 
 jobs:
   gate:
-    name: Required Checks Gate
+    name: Required Checks Gate (runner)
     runs-on: ubuntu-latest
-    # Same condition every gated job in this repo already uses (#2755) — kept
-    # identical on purpose. Mirroring it here, rather than the gate deciding
-    # per-check whether a draft PR is "exempt", means this check shows the
-    # same honest "skipped" state everything else shows while a PR awaits
-    # `ready_for_ci`, instead of fabricating a pass for work nothing has run
-    # yet. Listening to the `labeled` event above (unlike the jobs being
-    # audited) is what lets adding `ready_for_ci` alone re-run this gate —
-    # the exact re-trigger #2755 says the audited jobs are missing.
-    if: github.event.pull_request.draft == false || contains(github.event.pull_request.labels.*.name, 'ready_for_ci')
     timeout-minutes: 65
     steps:
       - uses: actions/checkout@v7
@@ -69,11 +79,13 @@ jobs:
       # build_tui.yml keeps its own branches:[main] filter for now — PR #2696
       # already widens that workflow, so excluding it here avoids this gate
       # red-flagging a gap that PR is already closing.
-      - name: Wait for and verify required checks
+      - name: Determine gate state and verify required checks
         env:
           GH_TOKEN: ${{ github.token }}
           REPO: ${{ github.repository }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          PR_DRAFT: ${{ github.event.pull_request.draft }}
+          PR_LABELS: ${{ join(github.event.pull_request.labels.*.name, ',') }}
         run: |
           python .github/scripts/check_required_status.py \
             --workflows-dir .github/workflows \
@@ -82,5 +94,7 @@ jobs:
             --changed-files changed_files.txt \
             --repo "$REPO" \
             --sha "$HEAD_SHA" \
+            --draft "$PR_DRAFT" \
+            --labels "$PR_LABELS" \
             --timeout-seconds 3600 \
             --poll-seconds 30

--- a/.github/workflows/required_checks_gate.yml
+++ b/.github/workflows/required_checks_gate.yml
@@ -20,18 +20,24 @@
 # meant to catch it: on a draft PR without `ready_for_ci` — this repo's
 # default PR state — the audited suites skip AND the gate would skip too,
 # so nothing runs, nothing is red, and the checks page still reads green
-# with no coverage behind it. Instead this job always runs and reports one
-# of three states via a self-posted check-run (see post_check_run() in the
-# script): `neutral` while the PR is legitimately not asking for CI yet,
-# `success` once the relevant suites verifiably passed, or `failure` if any
-# didn't. `neutral` is visibly distinct from both and does not block a
-# merge on its own, matching GitHub's own semantics for a neutral required
-# check — so this is legible, not noise, and not a lie.
+# with no coverage behind it. Instead this job always runs and always
+# decides — see main()'s own docstring in the script for exactly how the
+# neutral/success/failure states map onto this job's exit code.
 #
-# The job's OWN native check-run (below, named "(runner)") only reflects
-# whether the script executed without crashing — the meaningful signal for
-# branch protection to require is the self-posted "Required Checks Gate"
-# check-run the script creates via the API.
+# THE REQUIRED CHECK IS THIS JOB'S OWN NATIVE STATUS — "Required Checks
+# Gate" — not the richer "Required Checks Gate (detail)" check-run the
+# script also attempts to post. That split is deliberate: GITHUB_TOKEN is
+# silently downgraded to read-only for `pull_request` (not
+# `pull_request_target`) on a fork PR, regardless of the `permissions:`
+# declared below — confirmed live against a real fork PR in this repo
+# (#2753's "Dependency Review" job logged "GITHUB_TOKEN Permissions:
+# Contents: read, Metadata: read, PullRequests: read" despite declaring
+# `pull-requests: write`). A required check that can only post via a
+# permission forks don't have would block every fork contribution to this
+# repo — the `checks: write` below only ever works on same-repo PRs. This
+# job's own exit code needs no such permission and is identical either way,
+# so it — not the API-posted check-run — is what should be added to branch
+# protection / the merge queue's required-checks list.
 
 name: Required Checks Gate
 
@@ -41,6 +47,9 @@ on:
     # Deliberately no `branches:` filter: that filter is the exact bug this
     # workflow exists to catch, so applying it here would just move the gap.
 
+# `checks: write` only takes effect on same-repo PRs (see the header above)
+# — it lets the job attempt the richer, distinctly-colored "(detail)"
+# check-run there, best-effort, never required for the binding signal.
 permissions:
   contents: read
   checks: write
@@ -49,21 +58,20 @@ permissions:
 concurrency:
   group: required-checks-gate-${{ github.event.pull_request.number }}
   # NOT cancel-in-progress. Unlike the audited workflows, cancelling this
-  # one is not free: a run that gets killed before it reaches main()'s
-  # post_check_run() calls never posts a check-run for the SHA it was
-  # evaluating at all. If that cancelled run happened to be the LAST
-  # triggering event for that SHA (nothing left to supersede it and try
-  # again), the "Required Checks Gate" check silently never appears for
-  # that commit — a fourth way to fail open, inside the fix for the other
-  # three. Queuing instead of cancelling costs some run time when events
-  # arrive in a burst (e.g. this repo's auto-labeler firing right after
-  # open) but guarantees every triggering event eventually gets a real,
-  # posted verdict.
+  # one is not free: a run that gets killed before it finishes never
+  # produces a final exit code for the SHA it was evaluating at all. If
+  # that cancelled run happened to be the LAST triggering event for that
+  # SHA (nothing left to supersede it and try again), the required check
+  # silently never resolves for that commit — a fourth way to fail open,
+  # inside the fix for the other three. Queuing instead of cancelling costs
+  # some run time when events arrive in a burst (e.g. this repo's
+  # auto-labeler firing right after open) but guarantees every triggering
+  # event eventually gets a real, posted verdict.
   cancel-in-progress: false
 
 jobs:
   gate:
-    name: Required Checks Gate (runner)
+    name: Required Checks Gate
     runs-on: ubuntu-latest
     timeout-minutes: 65
     steps:

--- a/.github/workflows/test_agent_email_npm.yml
+++ b/.github/workflows/test_agent_email_npm.yml
@@ -15,7 +15,6 @@ on:
       - 'hub/agents/email/npm/**'
       - '.github/workflows/test_agent_email_npm.yml'
   pull_request:
-    branches: [ main ]
     types: [opened, synchronize, reopened, ready_for_review]
     paths:
       - 'hub/agents/email/npm/**'

--- a/.github/workflows/test_agent_mcp_server.yml
+++ b/.github/workflows/test_agent_mcp_server.yml
@@ -18,7 +18,6 @@ on:
       - 'setup.py'
       - '.github/workflows/test_agent_mcp_server.yml'
   pull_request:
-    branches: [ main ]
     types: [opened, synchronize, reopened, ready_for_review]
     paths:
       - 'src/gaia/version.py'

--- a/.github/workflows/test_agent_sdk.yml
+++ b/.github/workflows/test_agent_sdk.yml
@@ -19,7 +19,6 @@ on:
       - "installer/scripts/**"
       - ".github/workflows/test_agent_sdk.yml"
   pull_request:
-    branches: ["main"]
     types: [opened, synchronize, reopened, ready_for_review]
     paths:
       - 'src/gaia/version.py'

--- a/.github/workflows/test_analyst_agent.yml
+++ b/.github/workflows/test_analyst_agent.yml
@@ -17,7 +17,6 @@ on:
       - 'setup.py'
       - '.github/workflows/test_analyst_agent.yml'
   pull_request:
-    branches: [ main ]
     types: [opened, synchronize, reopened, ready_for_review]
     paths:
       - 'hub/agents/analyst/python/**'

--- a/.github/workflows/test_api.yml
+++ b/.github/workflows/test_api.yml
@@ -22,7 +22,6 @@ on:
       - 'setup.py'
       - '.github/workflows/test_api.yml'
   pull_request:
-    branches: ["main"]
     types: [opened, synchronize, reopened, ready_for_review]
     paths:
       - 'src/gaia/version.py'

--- a/.github/workflows/test_browser_agent.yml
+++ b/.github/workflows/test_browser_agent.yml
@@ -17,7 +17,6 @@ on:
       - 'setup.py'
       - '.github/workflows/test_browser_agent.yml'
   pull_request:
-    branches: [ main ]
     types: [opened, synchronize, reopened, ready_for_review]
     paths:
       - 'hub/agents/browser/python/**'

--- a/.github/workflows/test_chat_agent.yml
+++ b/.github/workflows/test_chat_agent.yml
@@ -22,7 +22,6 @@ on:
       - 'setup.py'
       - '.github/workflows/test_chat_agent.yml'
   pull_request:
-    branches: [ main ]
     types: [opened, synchronize, reopened, ready_for_review]
     paths:
       - 'hub/agents/chat/python/**'

--- a/.github/workflows/test_code_agent.yml
+++ b/.github/workflows/test_code_agent.yml
@@ -17,7 +17,6 @@ on:
       - 'setup.py'
       - '.github/workflows/test_code_agent.yml'
   pull_request:
-    branches: [ main ]
     types: [opened, synchronize, reopened, ready_for_review]
     paths:
       - 'hub/agents/code/python/**'

--- a/.github/workflows/test_connectors_demo.yml
+++ b/.github/workflows/test_connectors_demo.yml
@@ -17,7 +17,6 @@ on:
       - 'setup.py'
       - '.github/workflows/test_connectors_demo.yml'
   pull_request:
-    branches: [ main ]
     types: [opened, synchronize, reopened, ready_for_review]
     paths:
       - 'hub/agents/connectors-demo/python/**'

--- a/.github/workflows/test_distributed_seams.yml
+++ b/.github/workflows/test_distributed_seams.yml
@@ -29,7 +29,6 @@ on:
       - 'tests/unit/test_sidecar_harness.py'
       - '.github/workflows/test_distributed_seams.yml'
   pull_request:
-    branches: [ main ]
     types: [opened, synchronize, reopened, ready_for_review]
     paths:
       - 'src/gaia/daemon/**'

--- a/.github/workflows/test_docqa_agent.yml
+++ b/.github/workflows/test_docqa_agent.yml
@@ -18,7 +18,6 @@ on:
       - 'setup.py'
       - '.github/workflows/test_docqa_agent.yml'
   pull_request:
-    branches: [ main ]
     types: [opened, synchronize, reopened, ready_for_review]
     paths:
       - 'hub/agents/docqa/python/**'

--- a/.github/workflows/test_electron.yml
+++ b/.github/workflows/test_electron.yml
@@ -15,7 +15,6 @@ on:
       - 'tests/electron/**'
       - '.github/workflows/test_electron.yml'
   pull_request:
-    branches: ["main"]
     types: [opened, synchronize, reopened, ready_for_review]
     paths:
       - 'src/gaia/electron/**'

--- a/.github/workflows/test_email_agent.yml
+++ b/.github/workflows/test_email_agent.yml
@@ -28,7 +28,6 @@ on:
       - 'tests/integration/test_email_corpus_alignment.py'
       - '.github/workflows/test_email_agent.yml'
   pull_request:
-    branches: [ main ]
     types: [opened, synchronize, reopened, ready_for_review]
     paths:
       - 'hub/agents/email/python/**'

--- a/.github/workflows/test_email_agent_unit.yml
+++ b/.github/workflows/test_email_agent_unit.yml
@@ -48,7 +48,6 @@ on:
       - 'pyproject.toml'
       - '.github/workflows/test_email_agent_unit.yml'
   pull_request:
-    branches: [ main ]
     types: [opened, synchronize, reopened, ready_for_review]
     paths:
       - 'hub/agents/email/python/**'

--- a/.github/workflows/test_embeddings.yml
+++ b/.github/workflows/test_embeddings.yml
@@ -16,7 +16,6 @@ on:
       - 'setup.py'
       - '.github/workflows/test_embeddings.yml'
   pull_request:
-    branches: [ main ]
     types: [opened, synchronize, reopened, ready_for_review]
     paths:
       - 'src/gaia/version.py'

--- a/.github/workflows/test_eval.yml
+++ b/.github/workflows/test_eval.yml
@@ -20,7 +20,6 @@ on:
       - 'setup.py'
       - '.github/workflows/test_eval.yml'
   pull_request:
-    branches: ["main"]
     types: [opened, synchronize, reopened, ready_for_review]
     paths:
       - 'src/gaia/eval/**'

--- a/.github/workflows/test_examples.yml
+++ b/.github/workflows/test_examples.yml
@@ -26,7 +26,6 @@ on:
       - 'setup.py'
       - '.github/workflows/test_examples.yml'
   pull_request:
-    branches: [ main ]
     types: [opened, synchronize, reopened, ready_for_review]
     paths:
       - 'src/gaia/version.py'

--- a/.github/workflows/test_gaia_cli_linux.yml
+++ b/.github/workflows/test_gaia_cli_linux.yml
@@ -12,7 +12,6 @@ on:
   push:
     branches: [ main ]
   pull_request:
-    branches: [ main ]
     types: [opened, synchronize, reopened, ready_for_review]
   merge_group:
   workflow_dispatch:

--- a/.github/workflows/test_gaia_cli_windows.yml
+++ b/.github/workflows/test_gaia_cli_windows.yml
@@ -21,7 +21,6 @@ on:
       - "installer/scripts/**"
       - ".github/workflows/test_gaia_cli_windows.yml"
   pull_request:
-    branches: ["main"]
     types: [opened, synchronize, reopened, ready_for_review]
     paths:
       - 'src/gaia/version.py'

--- a/.github/workflows/test_hub_agents.yml
+++ b/.github/workflows/test_hub_agents.yml
@@ -32,7 +32,6 @@ on:
       - 'setup.py'
       - '.github/workflows/test_hub_agents.yml'
   pull_request:
-    branches: [ main ]
     types: [opened, synchronize, reopened, ready_for_review]
     paths:
       - 'hub/agents/blender/python/**'

--- a/.github/workflows/test_lemonade_server.yml
+++ b/.github/workflows/test_lemonade_server.yml
@@ -18,7 +18,6 @@ on:
       - 'installer/**'
       - 'tests/test_lemonade*.py'
   pull_request:
-    branches: [ main ]
     types: [opened, synchronize, reopened, ready_for_review]
     paths:
       - 'src/gaia/version.py'

--- a/.github/workflows/test_mcp.yml
+++ b/.github/workflows/test_mcp.yml
@@ -18,7 +18,6 @@ on:
       - 'setup.py'
       - '.github/workflows/test_mcp.yml'
   pull_request:
-    branches: [ main ]
     types: [opened, synchronize, reopened, ready_for_review]
     paths:
       - 'src/gaia/mcp/**'

--- a/.github/workflows/test_npu_embedder.yml
+++ b/.github/workflows/test_npu_embedder.yml
@@ -19,7 +19,6 @@ on:
       - 'tests/test_npu_flm_embedder_hw.py'
       - '.github/workflows/test_npu_embedder.yml'
   pull_request:
-    branches: [ main ]
     types: [opened, synchronize, reopened, ready_for_review]
     paths:
       - 'src/gaia/agents/registry.py'

--- a/.github/workflows/test_rag.yml
+++ b/.github/workflows/test_rag.yml
@@ -18,7 +18,6 @@ on:
       - 'setup.py'
       - '.github/workflows/test_rag.yml'
   pull_request:
-    branches: [ main ]
     types: [opened, synchronize, reopened, ready_for_review]
     paths:
       - 'src/gaia/version.py'

--- a/.github/workflows/test_routing_agent.yml
+++ b/.github/workflows/test_routing_agent.yml
@@ -18,7 +18,6 @@ on:
       - 'setup.py'
       - '.github/workflows/test_routing_agent.yml'
   pull_request:
-    branches: [ main ]
     types: [opened, synchronize, reopened, ready_for_review]
     paths:
       - 'hub/agents/routing/python/**'

--- a/.github/workflows/test_sd.yml
+++ b/.github/workflows/test_sd.yml
@@ -22,7 +22,6 @@ on:
       - "tests/integration/test_sd_integration.py"
       - "tests/unit/test_sd_mixin.py"
   pull_request:
-    branches: ["main"]
     types: [opened, synchronize, reopened, ready_for_review]
     paths:
       - 'src/gaia/version.py'

--- a/.github/workflows/test_security.yml
+++ b/.github/workflows/test_security.yml
@@ -18,7 +18,6 @@ on:
       - 'setup.py'
       - '.github/workflows/test_security.yml'
   pull_request:
-    branches: [ main ]
     types: [opened, synchronize, reopened, ready_for_review]
     paths:
       - 'src/gaia/agents/**'

--- a/.github/workflows/test_unit.yml
+++ b/.github/workflows/test_unit.yml
@@ -18,7 +18,6 @@ on:
       - 'pyproject.toml'
       - '.github/workflows/test_unit.yml'
   pull_request:
-    branches: [ main ]
     types: [opened, synchronize, reopened, ready_for_review]
     paths:
       - 'src/**'

--- a/tests/unit/test_check_required_status.py
+++ b/tests/unit/test_check_required_status.py
@@ -65,12 +65,13 @@ jobs:
       - run: echo hi
 """,
     )
-    reqs = crs.load_requirements(str(wf_dir), exclude=[])
+    reqs, exclusions = crs.load_requirements(str(wf_dir), exclude=[])
     assert len(reqs) == 1
     assert reqs[0].name_prefix == "Run Code Quality Checks"
     assert reqs[0].exact is True  # static name -> exact match, not prefix
     assert reqs[0].paths == ["src/**", "hub/**"]
     assert reqs[0].source_file == "lint.yml"
+    assert exclusions == []
 
 
 def test_load_requirements_collapses_matrix_expression_to_prefix(tmp_path):
@@ -92,7 +93,7 @@ jobs:
       - run: echo hi
 """,
     )
-    reqs = crs.load_requirements(str(wf_dir), exclude=[])
+    reqs, _exclusions = crs.load_requirements(str(wf_dir), exclude=[])
     assert reqs[0].name_prefix == "Unit Tests (py"
     assert reqs[0].exact is False  # matrix-templated -> prefix match
 
@@ -113,13 +114,17 @@ jobs:
       - run: echo hi
 """,
     )
-    assert crs.load_requirements(str(wf_dir), exclude=[]) == []
+    reqs, exclusions = crs.load_requirements(str(wf_dir), exclude=[])
+    assert reqs == []
+    assert exclusions == []
 
 
-def test_load_requirements_excludes_continue_on_error_jobs(tmp_path):
+def test_load_requirements_excludes_continue_on_error_jobs_but_reports_them(tmp_path):
     # The macOS smoke job in the real test_unit.yml is explicitly
     # continue-on-error — its own author already declared it non-blocking,
-    # so the gate must not turn it into a hard requirement.
+    # so the gate must not turn it into a hard requirement. But per the
+    # #2767 redirect, a silent exclusion is its own fail-open hole — it
+    # must show up in `exclusions`, not just vanish from `reqs`.
     wf_dir = write_workflow(
         tmp_path,
         "test_unit.yml",
@@ -141,9 +146,107 @@ jobs:
       - run: echo hi
 """,
     )
-    reqs = crs.load_requirements(str(wf_dir), exclude=[])
-    names = [r.name_prefix for r in reqs]
-    assert names == ["Unit Tests"]
+    reqs, exclusions = crs.load_requirements(str(wf_dir), exclude=[])
+    assert [r.name_prefix for r in reqs] == ["Unit Tests"]
+    assert len(exclusions) == 1
+    assert exclusions[0].name_prefix == "Unit Tests (macOS smoke)"
+    assert "continue-on-error" in exclusions[0].reason
+
+
+def test_load_requirements_excludes_needs_gated_jobs_but_reports_them(tmp_path):
+    # build-electron-apps.yml's real build-apps job: gated on ANOTHER job's
+    # runtime output (needs.discover-apps.outputs.has_apps), with its
+    # matrix ALSO dynamically generated via fromJson(needs...). Not
+    # statically verifiable at all — excluded, but named, not silent.
+    wf_dir = write_workflow(
+        tmp_path,
+        "build-electron-apps.yml",
+        """
+on:
+  pull_request:
+jobs:
+  discover-apps:
+    name: discover-apps
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo hi
+  build-apps:
+    needs: discover-apps
+    if: needs.discover-apps.outputs.has_apps == 'true'
+    name: "build-apps (${{ matrix.os }})"
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - run: echo hi
+""",
+    )
+    reqs, exclusions = crs.load_requirements(str(wf_dir), exclude=[])
+    assert [r.name_prefix for r in reqs] == ["discover-apps"]
+    assert len(exclusions) == 1
+    assert exclusions[0].name_prefix == "build-apps ("
+    assert "needs." in exclusions[0].reason
+
+
+def test_load_requirements_treats_static_name_with_matrix_as_prefix_mode(tmp_path):
+    # test_electron.yml's real dependency-audit job: name: "Audit
+    # Dependencies", no "${{ }}" anywhere, but a multi-leg matrix. GitHub
+    # still appends "(leg, values)" to every real rendered check-run, so
+    # this must be exact=False like an explicitly templated name — keying
+    # only on "${{" in the name (what the first version of this function
+    # did) missed it and let a real gate failure through to #2783.
+    wf_dir = write_workflow(
+        tmp_path,
+        "test_electron.yml",
+        """
+on:
+  pull_request:
+jobs:
+  dependency-audit:
+    name: Audit Dependencies
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        package:
+          - name: electron-framework
+          - name: jira-app
+    steps:
+      - run: echo hi
+""",
+    )
+    reqs, exclusions = crs.load_requirements(str(wf_dir), exclude=[])
+    assert len(reqs) == 1
+    assert reqs[0].name_prefix == "Audit Dependencies"
+    assert reqs[0].exact is False
+    assert exclusions == []
+
+
+def test_load_requirements_excludes_tag_ref_gated_jobs_but_reports_them(tmp_path):
+    # build_agents.yml's real "Consolidate release bundle" job: gated on
+    # `startsWith(github.ref, 'refs/tags/v')`. Unlike needs.*, this one IS
+    # statically decidable — github.ref on a pull_request event is never a
+    # tag ref — so it can be confidently excluded, not just hedged on.
+    wf_dir = write_workflow(
+        tmp_path,
+        "build_agents.yml",
+        """
+on:
+  pull_request:
+jobs:
+  release-bundle:
+    name: Consolidate release bundle
+    runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags/v')
+    steps:
+      - run: echo hi
+""",
+    )
+    reqs, exclusions = crs.load_requirements(str(wf_dir), exclude=[])
+    assert reqs == []
+    assert len(exclusions) == 1
+    assert exclusions[0].name_prefix == "Consolidate release bundle"
+    assert "refs/tags/" in exclusions[0].reason
 
 
 def test_load_requirements_honors_exclude_list(tmp_path):
@@ -162,7 +265,9 @@ jobs:
       - run: echo hi
 """,
     )
-    assert crs.load_requirements(str(wf_dir), exclude=["build_tui.yml"]) == []
+    reqs, exclusions = crs.load_requirements(str(wf_dir), exclude=["build_tui.yml"])
+    assert reqs == []
+    assert exclusions == []
 
 
 # ---------------------------------------------------------------------------
@@ -468,7 +573,7 @@ jobs:
       - run: echo hi
 """,
     )
-    reqs = crs.load_requirements(str(wf_dir), exclude=["build_tui.yml"])
+    reqs, _exclusions = crs.load_requirements(str(wf_dir), exclude=["build_tui.yml"])
     hub_req = next(r for r in reqs if r.source_file == "test_hub_agents.yml")
     matchers = crs._collect_all_name_matchers(str(wf_dir))
 
@@ -537,7 +642,7 @@ jobs:
       - run: echo hi
 """,
     )
-    reqs = crs.load_requirements(str(wf_dir), exclude=[])
+    reqs, _exclusions = crs.load_requirements(str(wf_dir), exclude=[])
     hub_req = next(r for r in reqs if r.source_file == "test_hub_agents.yml")
     matchers = crs._collect_all_name_matchers(str(wf_dir))
 
@@ -554,3 +659,231 @@ jobs:
     )
     assert not result.is_fully_ok
     assert result.missing == [hub_req]
+
+
+# ---------------------------------------------------------------------------
+# recency — GitHub never deletes a check-run; every triggering event adds
+# new rows alongside old ones. This is what caught the gate failing on its
+# own PR (#2783): a matrix job's `if:` was false BEFORE its strategy
+# expanded (still draft), so GitHub posted exactly ONE check-run with the
+# raw, un-rendered "${{ }}" template as its name and conclusion=skipped.
+# Prefix matching genuinely matches that literal string (it does start with
+# the derived prefix) — the bug was giving that stale row unconditional
+# priority over the real, later, expanded-and-passing rows sitting right
+# next to it in the same API response.
+# ---------------------------------------------------------------------------
+
+
+def test_evaluate_stale_unexpanded_matrix_skip_is_superseded_by_real_pass():
+    reqs = [_req("Test Apps Build (", exact=False)]
+    runs = [
+        # First event (opened, still draft): job skipped before its matrix
+        # ever expanded -> one row, literal template, never deleted.
+        crs.CheckRun(
+            name="Test Apps Build (${{ matrix.app.name }})",
+            status="completed",
+            conclusion="skipped",
+            started_at="2026-08-04T02:33:12Z",
+        ),
+        # Later event (reopened, after ready_for_ci): job actually ran,
+        # matrix expanded for real, each leg gets its own row.
+        crs.CheckRun(
+            name="Test Apps Build (jira)",
+            status="completed",
+            conclusion="success",
+            started_at="2026-08-04T02:38:08Z",
+        ),
+        crs.CheckRun(
+            name="Test Apps Build (example)",
+            status="completed",
+            conclusion="success",
+            started_at="2026-08-04T02:38:08Z",
+        ),
+    ]
+    result = crs.evaluate(reqs, changed_files=["x"], check_runs=runs)
+    assert (
+        result.is_fully_ok
+    ), f"stale skip should not mask the real pass: {result.failed}"
+
+
+def test_evaluate_one_real_failed_leg_still_fails_even_with_stale_skip_present():
+    # The stale unexpanded row must not distract from a REAL current
+    # failure either — recency-filtering discards the noise, not the
+    # signal.
+    reqs = [_req("Unit Tests (py", exact=False)]
+    runs = [
+        crs.CheckRun(
+            name="Unit Tests (py${{ matrix.python-version }})",
+            status="completed",
+            conclusion="skipped",
+            started_at="2026-08-04T02:33:06Z",
+        ),
+        crs.CheckRun(
+            name="Unit Tests (py3.10)",
+            status="completed",
+            conclusion="success",
+            started_at="2026-08-04T02:38:00Z",
+        ),
+        crs.CheckRun(
+            name="Unit Tests (py3.11)",
+            status="completed",
+            conclusion="failure",
+            started_at="2026-08-04T02:38:00Z",
+        ),
+    ]
+    result = crs.evaluate(reqs, changed_files=["x"], check_runs=runs)
+    assert result.is_terminal_failure
+
+
+def test_evaluate_latest_entry_still_skipped_reports_transiently_but_correctly_red():
+    # The other real shape: the real re-run hasn't posted yet at all, so
+    # the only entry that exists IS the stale-looking skip. That must
+    # still fail — there's nothing newer to prefer it over, and failing
+    # closed here (rather than guessing it'll pass eventually) is the
+    # designed behavior, not a bug. The poll loop in main() is what turns
+    # this into "keep waiting" instead of an immediate hard stop.
+    reqs = [_req("Test", exact=False)]
+    runs = [
+        crs.CheckRun(
+            name="Test ${{ matrix.package }}",
+            status="completed",
+            conclusion="skipped",
+            started_at="2026-08-04T02:33:06Z",
+        ),
+    ]
+    result = crs.evaluate(reqs, changed_files=["x"], check_runs=runs)
+    assert result.is_terminal_failure
+
+
+def test_evaluate_repeated_exact_name_keeps_only_newest():
+    # discover-apps re-ran 3 times across opened/labeled/reopened on the
+    # same SHA in real life; only the newest of the three is authoritative.
+    reqs = [_req("discover-apps")]
+    runs = [
+        crs.CheckRun(
+            name="discover-apps",
+            status="completed",
+            conclusion="skipped",
+            started_at="2026-08-04T02:33:06Z",
+        ),
+        crs.CheckRun(
+            name="discover-apps",
+            status="completed",
+            conclusion="success",
+            started_at="2026-08-04T02:34:29Z",
+        ),
+        crs.CheckRun(
+            name="discover-apps",
+            status="completed",
+            conclusion="success",
+            started_at="2026-08-04T02:37:28Z",
+        ),
+    ]
+    result = crs.evaluate(reqs, changed_files=["x"], check_runs=runs)
+    assert result.is_fully_ok
+
+
+def test_evaluate_re_skip_after_real_pass_is_reported_as_current():
+    # The inverse of the masking bug: if a job goes back to draft AFTER a
+    # real pass (label removed, say), a fresh skip newer than the old pass
+    # must NOT be silently ignored just because "a pass exists somewhere".
+    reqs = [_req("Test Apps Build (", exact=False)]
+    runs = [
+        crs.CheckRun(
+            name="Test Apps Build (jira)",
+            status="completed",
+            conclusion="success",
+            started_at="2026-08-04T02:34:00Z",
+        ),
+        crs.CheckRun(
+            name="Test Apps Build (${{ matrix.app.name }})",
+            status="completed",
+            conclusion="skipped",
+            started_at="2026-08-04T02:40:00Z",
+        ),
+    ]
+    result = crs.evaluate(reqs, changed_files=["x"], check_runs=runs)
+    assert result.is_terminal_failure
+
+
+def test_evaluate_static_name_with_matrix_pre_expansion_artifact_is_superseded():
+    # The bug that reached #2783 despite the "${{ }}" fix above: a static
+    # `name:` ("Audit Dependencies") with NO template expression, but a
+    # multi-leg strategy.matrix anyway. GitHub disambiguates real legs by
+    # appending "(leg, values)" to every rendered check-run, but a job
+    # skipped before its matrix expands posts the bare, un-suffixed name —
+    # identical to the requirement's own prefix, with no "${{" anywhere to
+    # catch it. Confirmed live: exact-matching "Audit Dependencies" never
+    # matched the real "Audit Dependencies (jira-app, ...)" runs at all
+    # until load_requirements() also treated "has a matrix" (not just "name
+    # contains ${{") as reason to use prefix matching.
+    reqs = [_req("Audit Dependencies", exact=False)]
+    runs = [
+        # Pre-expansion artifact: bare name, no suffix, from the first
+        # (still-draft) event.
+        crs.CheckRun(
+            name="Audit Dependencies",
+            status="completed",
+            conclusion="skipped",
+            started_at="2026-08-04T02:33:16Z",
+        ),
+        # Real legs, expanded, from the later (reopened) event.
+        crs.CheckRun(
+            name="Audit Dependencies (jira-app, src/gaia/apps/jira/webui)",
+            status="completed",
+            conclusion="success",
+            started_at="2026-08-04T02:38:07Z",
+        ),
+        crs.CheckRun(
+            name="Audit Dependencies (example-app, src/gaia/apps/example/webui)",
+            status="completed",
+            conclusion="success",
+            started_at="2026-08-04T02:38:07Z",
+        ),
+    ]
+    result = crs.evaluate(reqs, changed_files=["x"], check_runs=runs)
+    assert (
+        result.is_fully_ok
+    ), f"bare pre-expansion artifact should not mask the real, suffixed pass: {result.failed}"
+
+
+def test_evaluate_static_name_with_matrix_only_artifact_present_stays_failed():
+    # Same shape, but the real run genuinely hasn't posted yet — must fail
+    # closed, not silently pass just because the bare name "looks like" a
+    # normal exact-match requirement would expect.
+    reqs = [_req("Audit Dependencies", exact=False)]
+    runs = [
+        crs.CheckRun(
+            name="Audit Dependencies",
+            status="completed",
+            conclusion="skipped",
+            started_at="2026-08-04T02:33:16Z",
+        ),
+    ]
+    result = crs.evaluate(reqs, changed_files=["x"], check_runs=runs)
+    assert result.is_terminal_failure
+
+
+# ---------------------------------------------------------------------------
+# format_exclusions() — the excluded set must stay auditable at a glance as
+# more exclusion classes get added, not just a list a reader can skim past.
+# ---------------------------------------------------------------------------
+
+
+def test_format_exclusions_empty_states_the_ratio():
+    msg = crs.format_exclusions(60, [])
+    assert "60/60" in msg
+    assert "none excluded" in msg
+
+
+def test_format_exclusions_breaks_down_by_kind():
+    exclusions = [
+        crs.Exclusion("a", "f1.yml", "j1", "reason a", kind="needs-gated"),
+        crs.Exclusion("b", "f2.yml", "j2", "reason b", kind="needs-gated"),
+        crs.Exclusion("c", "f3.yml", "j3", "reason c", kind="continue-on-error"),
+    ]
+    msg = crs.format_exclusions(57, exclusions)
+    assert "57/60" in msg
+    assert "excluded 3" in msg
+    assert "needs-gated: 2" in msg
+    assert "continue-on-error: 1" in msg

--- a/tests/unit/test_check_required_status.py
+++ b/tests/unit/test_check_required_status.py
@@ -1,0 +1,466 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+"""Unit tests for .github/scripts/check_required_status.py (issue #2767).
+
+Proves the required-checks gate's core claim BY CONSTRUCTION: given a fixed
+set of workflow-derived requirements and a fixed Checks API snapshot, does
+`evaluate()` correctly classify what's OK, what's still pending, and — the
+part that matters — what's a terminal FAILURE? In particular this is where
+the #2755 "stuck at skipped" scenario is proven to turn into a fail, without
+needing a live GitHub Actions run to observe it.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+_SCRIPT_PATH = (
+    Path(__file__).resolve().parents[2]
+    / ".github"
+    / "scripts"
+    / "check_required_status.py"
+)
+_spec = importlib.util.spec_from_file_location("check_required_status", _SCRIPT_PATH)
+crs = importlib.util.module_from_spec(_spec)  # type: ignore[arg-type]
+sys.modules["check_required_status"] = crs
+_spec.loader.exec_module(crs)  # type: ignore[union-attr]
+
+
+def write_workflow(tmp_path: Path, filename: str, content: str) -> Path:
+    wf_dir = tmp_path / ".github" / "workflows"
+    wf_dir.mkdir(parents=True, exist_ok=True)
+    path = wf_dir / filename
+    path.write_text(content)
+    return wf_dir
+
+
+# ---------------------------------------------------------------------------
+# load_requirements() — derivation from real-shaped workflow YAML
+# ---------------------------------------------------------------------------
+
+
+def test_load_requirements_derives_prefix_and_paths(tmp_path):
+    wf_dir = write_workflow(
+        tmp_path,
+        "lint.yml",
+        """
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+    paths:
+      - 'src/**'
+      - 'hub/**'
+jobs:
+  lint:
+    name: Run Code Quality Checks
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo hi
+""",
+    )
+    reqs = crs.load_requirements(str(wf_dir), exclude=[])
+    assert len(reqs) == 1
+    assert reqs[0].name_prefix == "Run Code Quality Checks"
+    assert reqs[0].exact is True  # static name -> exact match, not prefix
+    assert reqs[0].paths == ["src/**", "hub/**"]
+    assert reqs[0].source_file == "lint.yml"
+
+
+def test_load_requirements_collapses_matrix_expression_to_prefix(tmp_path):
+    wf_dir = write_workflow(
+        tmp_path,
+        "test_unit.yml",
+        """
+on:
+  pull_request:
+    types: [opened, synchronize]
+jobs:
+  unit-tests:
+    name: "Unit Tests (py${{ matrix.python-version }})"
+    strategy:
+      matrix:
+        python-version: ['3.10', '3.11', '3.12']
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo hi
+""",
+    )
+    reqs = crs.load_requirements(str(wf_dir), exclude=[])
+    assert reqs[0].name_prefix == "Unit Tests (py"
+    assert reqs[0].exact is False  # matrix-templated -> prefix match
+
+
+def test_load_requirements_skips_workflows_with_no_pull_request_trigger(tmp_path):
+    wf_dir = write_workflow(
+        tmp_path,
+        "nightly.yml",
+        """
+on:
+  schedule:
+    - cron: '0 0 * * *'
+jobs:
+  nightly:
+    name: Nightly
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo hi
+""",
+    )
+    assert crs.load_requirements(str(wf_dir), exclude=[]) == []
+
+
+def test_load_requirements_excludes_continue_on_error_jobs(tmp_path):
+    # The macOS smoke job in the real test_unit.yml is explicitly
+    # continue-on-error — its own author already declared it non-blocking,
+    # so the gate must not turn it into a hard requirement.
+    wf_dir = write_workflow(
+        tmp_path,
+        "test_unit.yml",
+        """
+on:
+  pull_request:
+    types: [opened]
+jobs:
+  unit-tests:
+    name: Unit Tests
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo hi
+  unit-tests-macos:
+    name: Unit Tests (macOS smoke)
+    runs-on: macos-latest
+    continue-on-error: true
+    steps:
+      - run: echo hi
+""",
+    )
+    reqs = crs.load_requirements(str(wf_dir), exclude=[])
+    names = [r.name_prefix for r in reqs]
+    assert names == ["Unit Tests"]
+
+
+def test_load_requirements_honors_exclude_list(tmp_path):
+    wf_dir = write_workflow(
+        tmp_path,
+        "build_tui.yml",
+        """
+on:
+  pull_request:
+    branches: [ main ]
+jobs:
+  build:
+    name: Build TUI
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo hi
+""",
+    )
+    assert crs.load_requirements(str(wf_dir), exclude=["build_tui.yml"]) == []
+
+
+# ---------------------------------------------------------------------------
+# is_path_relevant()
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "paths,paths_ignore,changed,expected",
+    [
+        (None, None, ["docs/x.mdx"], True),  # no filter -> always relevant
+        (["src/**"], None, ["src/gaia/cli.py"], True),
+        (["src/**"], None, ["docs/x.mdx"], False),
+        (["hub/agents/email/**"], None, ["hub/agents/email/python/agent.py"], True),
+        (None, ["docs/**"], ["docs/x.mdx"], False),  # everything changed is ignored
+        (
+            None,
+            ["docs/**"],
+            ["docs/x.mdx", "src/gaia/cli.py"],
+            True,
+        ),  # one non-ignored file
+    ],
+)
+def test_is_path_relevant(paths, paths_ignore, changed, expected):
+    req = crs.Requirement(
+        name_prefix="X",
+        exact=True,
+        paths=paths,
+        paths_ignore=paths_ignore,
+        source_file="f.yml",
+        job_id="x",
+    )
+    assert crs.is_path_relevant(req, changed) is expected
+
+
+# ---------------------------------------------------------------------------
+# evaluate() — the core gate logic
+# ---------------------------------------------------------------------------
+
+
+def _req(prefix, paths=None, exact=True):
+    return crs.Requirement(
+        name_prefix=prefix,
+        exact=exact,
+        paths=paths,
+        paths_ignore=None,
+        source_file="f.yml",
+        job_id=prefix,
+    )
+
+
+def test_evaluate_all_present_and_passing_is_fully_ok():
+    reqs = [_req("Run Code Quality Checks"), _req("Unit Tests (py", exact=False)]
+    runs = [
+        crs.CheckRun(
+            name="Run Code Quality Checks", status="completed", conclusion="success"
+        ),
+        crs.CheckRun(
+            name="Unit Tests (py3.10)", status="completed", conclusion="success"
+        ),
+        crs.CheckRun(
+            name="Unit Tests (py3.11)", status="completed", conclusion="success"
+        ),
+    ]
+    result = crs.evaluate(reqs, changed_files=["src/gaia/cli.py"], check_runs=runs)
+    assert result.is_fully_ok
+    assert not result.is_terminal_failure
+    assert {r.name_prefix for r in result.ok} == {
+        "Run Code Quality Checks",
+        "Unit Tests (py",
+    }
+
+
+def test_evaluate_absent_check_is_pending_not_terminal():
+    # This is the PR #2599 scenario before it's had time to register: no
+    # matching check-run row exists yet. Must be retry-worthy, not an
+    # instant failure, or the gate would false-fail on every PR's first poll.
+    reqs = [_req("Test Email Agent")]
+    result = crs.evaluate(
+        reqs, changed_files=["hub/agents/email/python/x.py"], check_runs=[]
+    )
+    assert not result.is_fully_ok
+    assert not result.is_terminal_failure
+    assert result.missing == reqs
+
+
+def test_evaluate_stuck_skipped_check_is_terminal_failure():
+    # The #2755 signature: the job DID get scheduled at some point (its
+    # own draft-gate `if:` evaluated false while the PR was a draft) and
+    # never got a fresh triggering event to re-evaluate — so it sits at a
+    # completed, terminal "skipped" conclusion forever. This must fail the
+    # gate, not pass it, or the whole point of building this is moot.
+    reqs = [_req("Test Email Agent")]
+    runs = [
+        crs.CheckRun(name="Test Email Agent", status="completed", conclusion="skipped")
+    ]
+    result = crs.evaluate(
+        reqs, changed_files=["hub/agents/email/python/x.py"], check_runs=runs
+    )
+    assert result.is_terminal_failure
+    assert result.failed[0][0].name_prefix == "Test Email Agent"
+    assert "skipped" in result.failed[0][1]
+
+
+def test_evaluate_failed_check_is_terminal_failure():
+    reqs = [_req("Unit Tests (py", exact=False)]
+    runs = [
+        crs.CheckRun(
+            name="Unit Tests (py3.10)", status="completed", conclusion="failure"
+        )
+    ]
+    result = crs.evaluate(reqs, changed_files=["src/gaia/cli.py"], check_runs=runs)
+    assert result.is_terminal_failure
+
+
+def test_evaluate_in_progress_check_is_pending():
+    reqs = [_req("Unit Tests (py", exact=False)]
+    runs = [
+        crs.CheckRun(name="Unit Tests (py3.10)", status="in_progress", conclusion=None)
+    ]
+    result = crs.evaluate(reqs, changed_files=["src/gaia/cli.py"], check_runs=runs)
+    assert not result.is_fully_ok
+    assert not result.is_terminal_failure
+    assert result.pending == reqs
+
+
+def test_evaluate_neutral_conclusion_counts_as_passing():
+    reqs = [_req("Dependency Review")]
+    runs = [
+        crs.CheckRun(name="Dependency Review", status="completed", conclusion="neutral")
+    ]
+    result = crs.evaluate(reqs, changed_files=["setup.py"], check_runs=runs)
+    assert result.is_fully_ok
+
+
+def test_evaluate_ignores_path_irrelevant_requirement():
+    # The control case from #2767 itself: PR #2757 legitimately shows no
+    # "Security Tests" entries because it never touched src/gaia/agents/**.
+    # A gate that doesn't know this would false-fail every unrelated PR.
+    reqs = [_req("Security Tests (Linux)", paths=["src/gaia/agents/**"])]
+    result = crs.evaluate(reqs, changed_files=["docs/guides/chat.mdx"], check_runs=[])
+    assert result.is_fully_ok
+    assert result.ok == [] and result.missing == [] and result.failed == []
+
+
+def test_evaluate_one_bad_matrix_leg_fails_even_if_another_passed():
+    reqs = [_req("Unit Tests (py", exact=False)]
+    runs = [
+        crs.CheckRun(
+            name="Unit Tests (py3.10)", status="completed", conclusion="success"
+        ),
+        crs.CheckRun(
+            name="Unit Tests (py3.11)", status="completed", conclusion="failure"
+        ),
+    ]
+    result = crs.evaluate(reqs, changed_files=["src/gaia/cli.py"], check_runs=runs)
+    assert result.is_terminal_failure
+
+
+def test_evaluate_static_name_requires_exact_match_not_prefix():
+    # Regression guard: a real workflow (test_hub_agents.yml) has a job
+    # simply named "Test". Before `exact` existed, prefix matching meant
+    # this requirement was satisfied by ANY check-run starting with "Test"
+    # — e.g. a completely unrelated "Test Chat Agent" run — which would
+    # have silently defeated the gate for that job.
+    reqs = [_req("Test")]
+    runs = [
+        crs.CheckRun(name="Test Chat Agent", status="completed", conclusion="success")
+    ]
+    result = crs.evaluate(reqs, changed_files=["hub/agents/x.py"], check_runs=runs)
+    assert not result.is_fully_ok
+
+
+# ---------------------------------------------------------------------------
+# reserved-name safety net for matrix-templated prefixes
+#
+# This reproduces the actual collision found while building the gate:
+# test_hub_agents.yml's job is named "Test ${{ matrix.package }}", which
+# collapses to the prefix "Test". Without the reserved-names guard, that
+# prefix would startswith()-match "Test Chat Agent" (an unrelated job from
+# test_chat_agent.yml) AND the bare "Test" job that build_tui.yml's own
+# workflow happens to declare — silently marking both requirements
+# satisfied by check-runs that have nothing to do with them.
+# ---------------------------------------------------------------------------
+
+
+def test_collect_reserved_static_names_spans_every_file_ignoring_exclude(tmp_path):
+    wf_dir = write_workflow(
+        tmp_path,
+        "test_chat_agent.yml",
+        """
+on:
+  pull_request:
+jobs:
+  test:
+    name: Test Chat Agent
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo hi
+""",
+    )
+    write_workflow(
+        tmp_path,
+        "build_tui.yml",
+        """
+on:
+  pull_request:
+    branches: [ main ]
+jobs:
+  build:
+    name: Test
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo hi
+""",
+    )
+    reserved = crs._collect_reserved_static_names(str(wf_dir))
+    # Present even though build_tui.yml would normally be excluded from
+    # requirements — a real check-run can still carry that exact name.
+    assert reserved == {
+        "Test Chat Agent": "test_chat_agent.yml",
+        "Test": "build_tui.yml",
+    }
+
+
+def test_evaluate_prefix_match_excludes_names_reserved_by_other_jobs(tmp_path):
+    wf_dir = write_workflow(
+        tmp_path,
+        "test_hub_agents.yml",
+        """
+on:
+  pull_request:
+jobs:
+  test-hub-package:
+    name: "Test ${{ matrix.package }}"
+    strategy:
+      matrix:
+        package: [blender, docker]
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo hi
+""",
+    )
+    write_workflow(
+        tmp_path,
+        "test_chat_agent.yml",
+        """
+on:
+  pull_request:
+jobs:
+  test:
+    name: Test Chat Agent
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo hi
+""",
+    )
+    write_workflow(
+        tmp_path,
+        "build_tui.yml",
+        """
+on:
+  pull_request:
+    branches: [ main ]
+jobs:
+  build:
+    name: Test
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo hi
+""",
+    )
+    reqs = crs.load_requirements(str(wf_dir), exclude=["build_tui.yml"])
+    hub_req = next(r for r in reqs if r.source_file == "test_hub_agents.yml")
+    reserved = crs._collect_reserved_static_names(str(wf_dir))
+
+    # Only "Test Chat Agent" and bare "Test" exist — neither is a real
+    # rendering of "Test ${{ matrix.package }}", so without the guard the
+    # gate would wrongly call this satisfied.
+    runs = [
+        crs.CheckRun(name="Test Chat Agent", status="completed", conclusion="success"),
+        crs.CheckRun(name="Test", status="completed", conclusion="success"),
+    ]
+    result = crs.evaluate(
+        [hub_req], changed_files=["hub/x.py"], check_runs=runs, reserved_names=reserved
+    )
+    assert not result.is_fully_ok
+    assert result.missing == [hub_req]
+
+    # The real rendered name (matrix value actually substituted) is a
+    # legitimate match and must NOT be excluded by the same guard.
+    runs_real = [
+        crs.CheckRun(name="Test blender", status="completed", conclusion="success")
+    ]
+    result_real = crs.evaluate(
+        [hub_req],
+        changed_files=["hub/x.py"],
+        check_runs=runs_real,
+        reserved_names=reserved,
+    )
+    assert result_real.is_fully_ok

--- a/tests/unit/test_check_required_status.py
+++ b/tests/unit/test_check_required_status.py
@@ -887,3 +887,48 @@ def test_format_exclusions_breaks_down_by_kind():
     assert "excluded 3" in msg
     assert "needs-gated: 2" in msg
     assert "continue-on-error: 1" in msg
+
+
+# ---------------------------------------------------------------------------
+# post_check_run() / write_step_summary() — the fork-PR fix. GITHUB_TOKEN is
+# silently downgraded to read-only for `pull_request` (not
+# `pull_request_target`) on a fork PR, confirmed live against a real fork
+# PR in this repo (#2753's "Dependency Review" job logged read-only
+# permissions despite declaring pull-requests: write). post_check_run()
+# must degrade to a logged warning, never raise — a required check that can
+# only post via a permission forks don't have would block every fork PR.
+# ---------------------------------------------------------------------------
+
+
+def test_post_check_run_returns_false_not_raise_on_403(mocker):
+    # Simulates exactly the fork-PR case: gh api fails because GITHUB_TOKEN
+    # is read-only, and the caller (main()) must be able to fall through to
+    # its own exit code instead of the whole script crashing.
+    mock_run = mocker.patch("check_required_status.subprocess.run")
+    mock_run.return_value = mocker.Mock(
+        returncode=1, stderr="HTTP 403: Resource not accessible by integration"
+    )
+    ok = crs.post_check_run("amd/gaia", "abc123", "success", "title", "summary")
+    assert ok is False
+
+
+def test_post_check_run_returns_true_on_success(mocker):
+    mock_run = mocker.patch("check_required_status.subprocess.run")
+    mock_run.return_value = mocker.Mock(returncode=0, stderr="")
+    ok = crs.post_check_run("amd/gaia", "abc123", "success", "title", "summary")
+    assert ok is True
+
+
+def test_write_step_summary_noop_without_env_var(mocker, monkeypatch):
+    monkeypatch.delenv("GITHUB_STEP_SUMMARY", raising=False)
+    # Must not raise, must not try to open a nonexistent path.
+    crs.write_step_summary("title", "body")
+
+
+def test_write_step_summary_writes_when_env_var_set(tmp_path, monkeypatch):
+    summary_path = tmp_path / "summary.md"
+    monkeypatch.setenv("GITHUB_STEP_SUMMARY", str(summary_path))
+    crs.write_step_summary("All required suites passed", "Required: Test Email Agent.")
+    content = summary_path.read_text()
+    assert "All required suites passed" in content
+    assert "Required: Test Email Agent." in content

--- a/tests/unit/test_check_required_status.py
+++ b/tests/unit/test_check_required_status.py
@@ -362,19 +362,26 @@ def test_evaluate_static_name_requires_exact_match_not_prefix():
 
 
 # ---------------------------------------------------------------------------
-# reserved-name safety net for matrix-templated prefixes
+# most-specific-owner safety net for matrix-templated prefixes
 #
-# This reproduces the actual collision found while building the gate:
+# This reproduces two real collisions — one found while writing this
+# script, one found LIVE on the throwaway evidence PR (#2775) for #2767.
 # test_hub_agents.yml's job is named "Test ${{ matrix.package }}", which
-# collapses to the prefix "Test". Without the reserved-names guard, that
-# prefix would startswith()-match "Test Chat Agent" (an unrelated job from
-# test_chat_agent.yml) AND the bare "Test" job that build_tui.yml's own
-# workflow happens to declare — silently marking both requirements
-# satisfied by check-runs that have nothing to do with them.
+# collapses to the prefix "Test". A plain startswith() would match:
+#  (a) an unrelated STATIC name from another job ("Test Chat Agent", or the
+#      bare "Test" job build_tui.yml happens to declare), and
+#  (b) an unrelated OTHER PREFIX-MODE job's rendered name, e.g.
+#      "Test Apps Build (jira)" (test_electron.yml's own, more specific,
+#      "Test Apps Build (" prefix) — this one only showed up against the
+#      real repo's full file set, which is exactly why load_requirements()
+#      is exercised against real multi-file fixtures here rather than only
+#      single-job ones.
+# _most_specific_owner() is the general fix for both: every check-run name
+# belongs to whichever matcher matches it most specifically.
 # ---------------------------------------------------------------------------
 
 
-def test_collect_reserved_static_names_spans_every_file_ignoring_exclude(tmp_path):
+def test_collect_all_name_matchers_spans_every_file_ignoring_exclude(tmp_path):
     wf_dir = write_workflow(
         tmp_path,
         "test_chat_agent.yml",
@@ -404,16 +411,17 @@ jobs:
       - run: echo hi
 """,
     )
-    reserved = crs._collect_reserved_static_names(str(wf_dir))
+    matchers = crs._collect_all_name_matchers(str(wf_dir))
     # Present even though build_tui.yml would normally be excluded from
     # requirements — a real check-run can still carry that exact name.
-    assert reserved == {
-        "Test Chat Agent": "test_chat_agent.yml",
-        "Test": "build_tui.yml",
+    as_tuples = {(m.pattern, m.exact, m.source_file) for m in matchers}
+    assert as_tuples == {
+        ("Test Chat Agent", True, "test_chat_agent.yml"),
+        ("Test", True, "build_tui.yml"),
     }
 
 
-def test_evaluate_prefix_match_excludes_names_reserved_by_other_jobs(tmp_path):
+def test_evaluate_prefix_match_defers_to_more_specific_static_name(tmp_path):
     wf_dir = write_workflow(
         tmp_path,
         "test_hub_agents.yml",
@@ -462,7 +470,7 @@ jobs:
     )
     reqs = crs.load_requirements(str(wf_dir), exclude=["build_tui.yml"])
     hub_req = next(r for r in reqs if r.source_file == "test_hub_agents.yml")
-    reserved = crs._collect_reserved_static_names(str(wf_dir))
+    matchers = crs._collect_all_name_matchers(str(wf_dir))
 
     # Only "Test Chat Agent" and bare "Test" exist — neither is a real
     # rendering of "Test ${{ matrix.package }}", so without the guard the
@@ -472,7 +480,7 @@ jobs:
         crs.CheckRun(name="Test", status="completed", conclusion="success"),
     ]
     result = crs.evaluate(
-        [hub_req], changed_files=["hub/x.py"], check_runs=runs, reserved_names=reserved
+        [hub_req], changed_files=["hub/x.py"], check_runs=runs, all_matchers=matchers
     )
     assert not result.is_fully_ok
     assert result.missing == [hub_req]
@@ -486,6 +494,63 @@ jobs:
         [hub_req],
         changed_files=["hub/x.py"],
         check_runs=runs_real,
-        reserved_names=reserved,
+        all_matchers=matchers,
     )
     assert result_real.is_fully_ok
+
+
+def test_evaluate_prefix_match_defers_to_more_specific_other_prefix(tmp_path):
+    # The variant found LIVE on PR #2775: two DIFFERENT matrix-templated
+    # jobs, neither one static, where one job's rendered name happens to
+    # extend the other's prefix.
+    wf_dir = write_workflow(
+        tmp_path,
+        "test_hub_agents.yml",
+        """
+on:
+  pull_request:
+jobs:
+  test-hub-package:
+    name: "Test ${{ matrix.package }}"
+    strategy:
+      matrix:
+        package: [blender]
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo hi
+""",
+    )
+    write_workflow(
+        tmp_path,
+        "test_electron.yml",
+        """
+on:
+  pull_request:
+jobs:
+  test-apps-build:
+    name: "Test Apps Build (${{ matrix.app.name }})"
+    strategy:
+      matrix:
+        app: [{name: jira}, {name: example}]
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo hi
+""",
+    )
+    reqs = crs.load_requirements(str(wf_dir), exclude=[])
+    hub_req = next(r for r in reqs if r.source_file == "test_hub_agents.yml")
+    matchers = crs._collect_all_name_matchers(str(wf_dir))
+
+    # "Test Apps Build (jira)" starts with both "Test" and "Test Apps
+    # Build (" — the longer, more specific prefix must win, so this must
+    # NOT satisfy test_hub_agents.yml's "Test" requirement.
+    runs = [
+        crs.CheckRun(
+            name="Test Apps Build (jira)", status="completed", conclusion="success"
+        )
+    ]
+    result = crs.evaluate(
+        [hub_req], changed_files=["hub/x.py"], check_runs=runs, all_matchers=matchers
+    )
+    assert not result.is_fully_ok
+    assert result.missing == [hub_req]

--- a/tests/unit/test_check_required_status.py
+++ b/tests/unit/test_check_required_status.py
@@ -166,6 +166,31 @@ jobs:
 
 
 # ---------------------------------------------------------------------------
+# is_gated_off() — the third state (#2767 checkpoint-2 redirect)
+#
+# The gate must NOT skip itself via a job-level `if:` that mirrors the
+# audited jobs' own draft-gate, because that reproduces this issue's exact
+# bug inside the mechanism meant to catch it: nothing runs, nothing is red,
+# the checks page reads green. is_gated_off() is what main() consults
+# INSTEAD of a job-level skip, so the gate always executes and always
+# freshly decides whether to report neutral or do the real check.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "is_draft,labels,expected",
+    [
+        (True, set(), True),  # fresh draft, no label -> suites legitimately silent
+        (True, {"ready_for_ci"}, False),  # draft but opted in -> must be enforced
+        (False, set(), False),  # ready for review -> must be enforced
+        (False, {"ready_for_ci"}, False),
+    ],
+)
+def test_is_gated_off(is_draft, labels, expected):
+    assert crs.is_gated_off(is_draft, labels) is expected
+
+
+# ---------------------------------------------------------------------------
 # is_path_relevant()
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
Closes #2767
A PR based on anything but `main` ran almost no CI — no unit tests, no lint, no agent suites — and its checks page looked healthy the whole time, because `pull_request.branches: [main]` filters on the PR's *base*, not its head. Verified live just now: #2599 (merged, base a feature branch) still shows exactly 16 checks, none of them email/unit/lint; #2757 (main-based control) shows 46+ including all of them. After this change, the same class of PR gets the full suite — proven on a real throwaway PR against a non-`main` base, where 9+ suites that had run **zero** times on that base before this change all went green. A second, independent mechanism — a required checks gate — turns any *future* silent skip into a visible, named check instead of a checks page that simply omits rows.

**Building the gate found real bugs twice over — both times by replaying real API data, not by trusting synthetic tests.** Live on the throwaway PR, a bare job-name prefix (`"Test"`) was silently cross-matching *other* jobs' rendered check-run names. Fixed and covered with a unit test. Then the gate itself **failed on this very PR** — replaying #2783's actual Checks API history through the classification logic (rather than trusting the 27 tests that existed at that point) took total failures from 55 to 1, and surfaced two more real bugs no amount of reasoning from the YAML alone would have found: GitHub keeps every historical check-run for a SHA forever, so a five-minute-old stale skip was masking a fresh, real pass sitting right next to it in the same API response; and a job with a static name plus a matrix (no `${{ }}` anywhere) gets GitHub's own auto-appended `(leg, values)` disambiguator on every real run, which exact-matching on the bare name never catches. The one remaining "failure" after all three fixes is `C++ Email Agent` — a pre-existing, self-documented scaffold guard for the separate C++ email milestone (#1110), unrelated to this change.

## Test plan

- [ ] `python util/lint.py --all` clean
- [ ] `pytest tests/unit/` — 8842 passed, 146 skipped, 8 pre-existing failures unrelated to this change (binary-on-PATH / hub-wheel-install / VLM-extraction / a documented nested-worktree API-key artifact — none touch `.github/` or the files this PR adds)
- [ ] `pytest tests/unit/test_check_required_status.py` — 43 tests, all passing, proving the gate's classification logic (including every live-found bug below, and the fork-PR degrade path) by construction
- [ ] Live evidence below, captured on real throwaway and real PRs — see the collapsed sections

## What changed and why

**1. Widened the PR trigger on 34 workflows.** Removed `branches: [main]` from `pull_request:` only — `push: branches: [main]` is untouched, so main-push validation is unaffected and there's no duplicate-run risk (different event types; a feature-branch push never matched `push:` either way). This follows a pattern already used elsewhere in the repo (`docs.yml`, `pypi.yml`, `website-ci.yml`, `check_doc_links.yml`, …) rather than inventing an allowlist. `build_tui.yml` is deliberately excluded — PR #2696 already widens that one; touching it here would collide.

Audited all 34 for PR-triggered side effects before touching them: only `dependency-review.yml` does anything beyond test/lint, and only posts a PR comment on failure.

**Intended trade-off, stated plainly:** most of these 34 workflows already list their own `.github/workflows/<file>.yml` in their `paths:` filter — an existing "if you touch my CI config, re-validate me" convention, not something this PR introduced. Because this PR edits all 34 at once, essentially every one of them becomes required for *this* diff — confirmed by checking each one's `paths:`, not assumed. That's heavy by design: a workflow-config change legitimately re-validates the whole matrix. A normal single-workflow change afterward won't have this effect.

**2. A required checks gate that derives what to check instead of hand-listing it.** Cross-workflow `needs:` doesn't exist in GitHub Actions, so this can't depend on the other workflows directly — `.github/scripts/check_required_status.py` parses every workflow's own `pull_request` path filters at run time and derives what's required for a given diff, so a new workflow is covered automatically, nothing to remember to update here.

**Not a false green, not noise — always runs and always decides.** The gate deliberately does **not** carry the draft-gate `if:` the 34 audited workflows use. Mirroring that would reproduce this issue's own bug inside the fix: on a draft PR without `ready_for_ci` (this repo's default state for an open PR), the audited suites skip *and* the gate would skip too — nothing red, checks page still green, zero coverage. Instead the gate always runs, and reports through two channels — see the fork-PR section below for why there are two, and why only one of them is the thing to make required.

**The required check is the job's own native status — `Required Checks Gate` — not an API-posted one, because of a fork-PR gap found on this PR itself.** The original design self-posted a richer three-state (`neutral`/`success`/`failure`) check-run via the Checks API, needing `checks: write`. Confirmed live, not assumed: GitHub silently downgrades `GITHUB_TOKEN` to read-only for `pull_request` (not `pull_request_target`) on a fork PR regardless of what a workflow's `permissions:` block declares — inspected a real recent fork PR's job log (#2753's "Dependency Review", which declares `pull-requests: write`) and its own "Set up job" step printed `GITHUB_TOKEN Permissions: Contents: read, Metadata: read, PullRequests: read`. `checks: write` would be downgraded the identical way. A required check that can only post via a permission forks don't have would block every fork contribution to this repo — the opposite of what "required" should mean.

So the native job exit code — needs no special permissions, identical on same-repo and fork PRs — is the binding signal now, and that's what belongs in branch protection / the merge queue. `neutral` and `success` both map to exit 0 (pass): a draft PR without `ready_for_ci` can't be merged anyway regardless of check status — GitHub blocks merging any draft PR at the platform level — so there's nothing to protect by failing here, and reflexive red on every draft was already rejected as noise. Only a genuine failure or timeout exits 1. The neutral/success distinction isn't lost, just moved to two channels that need no elevated permissions either: the job's own Actions step summary (works identically on forks), and a *second*, purely informational check-run — `Required Checks Gate (detail)` — that the job still attempts to post wherever the token allows it (same-repo PRs). That call is wrapped so a 403 logs a warning and the job carries on; it's never what branch protection depends on.

**Recency: GitHub never deletes a check-run.** Every triggering event (opened, then labeled, then reopened) adds new rows alongside old ones. The gate used to give any bad match unconditional priority over good ones regardless of age. Fixed with an exact rule, not a tuned time-window — the observed gap between a stale skip and its real re-run ranged from about a minute to several minutes on real PRs in this repo, so no fixed window reliably separates "same event" from "different event." Instead: dedup by exact check-run name keeping only the newest, then discard any pre-expansion artifact older than the newest real entry for that requirement. A pre-expansion artifact is decidable two ways: a name containing literal `${{ }}` (job skipped before its matrix ever expanded), or — the one caught only by replaying real data — a name with no template at all but a matrix, where GitHub auto-suffixes every real leg with `(leg, values)`, so a real run can never produce the bare name the requirement is keyed on. A pre-expansion artifact *newer* than every real entry is kept, not discarded — that's a genuine re-skip (e.g. the PR went back to draft after a real pass), and the gate has a named test making sure that case still fails closed.

**Exclusions are reported, not silent.** Three job shapes can't be statically verified from YAML alone: `continue-on-error: true` (the job's own author already declared it non-blocking), an `if:` referencing `needs.*` (gated on another job's runtime output — e.g. `build-electron-apps.yml`'s `build-apps`, whose matrix is *also* dynamically generated via `fromJson(needs.discover-apps.outputs.matrix)`), and an `if:` gated on a tag ref (`startsWith(github.ref, 'refs/tags/...')` — unlike `needs.*`, this one is statically decidable, since `github.ref` on a `pull_request` event is never a tag ref). All three are excluded from the required set, but every posted check-run summary now states the ratio and breakdown — `"Enforced N/M requirements; excluded K (needs-gated: a, continue-on-error: b, ref-conditional: c): <name> (from <file>): <reason>; ..."` — so a future job silently dropping out of scope is visible, not a repeat of this issue's own bug with a new mechanism.

**Messaging distinguishes "did not run" from "ran and failed."** The neutral and failure summaries now say label **and** close/reopen, not label alone — the audited suites don't listen for the `labeled` event (only this gate does), so the label by itself cannot re-trigger them; #2755's own text describes close/reopen alone as sufficient, but that was observed on a non-draft PR and doesn't hold for this repo's default open-PR state (measured live, companion issue #2763, PR #2782). The failure text also splits "stuck at skipped, needs a re-trigger" from "ran and genuinely failed" — different states, different advice.

**Concurrency: queue instead of cancel.** The gate's own workflow originally used `concurrency: cancel-in-progress: true`. Live on the throwaway PR, this repo's auto-labeler fired a second `labeled` event mid-poll and cancelled the in-progress gate run before it ever posted a check-run for that SHA — benign that time only because a later run happened to supersede it and try again. If a cancelled run is ever the *last* triggering event for a SHA, the check silently never posts at all: a fourth way to fail open, shipped inside the PR meant to close the other three. Fixed by queuing instead (`cancel-in-progress: false`) — costs some run time on a burst of events, guarantees every trigger eventually gets a real, posted verdict.

## Evidence

<details>
<summary>Before — re-verified live with <code>gh pr checks</code>, not quoted from the issue</summary>

```
$ gh pr checks 2599 --repo amd/gaia   # base: tmi/2580-attention-int (not main)
16 total checks — 0 email, 0 unit, 0 lint:
Validate code examples in docs   pass
Verify external URLs             pass
Verify internal cross-references pass
build                            pass
label                            pass
auto-fix                         skipping
pr-comment                       skipping
release-notes                    skipping
validate                         pass  (x2)
Enable auto-merge...             skipping
pr-review / pr-review run        pass/skipping
pr-rereview                      skipping
issue-handler                    skipping
Mintlify Deployment              skipping

$ gh pr checks 2757 --repo amd/gaia   # base: main (control)
46+ checks, including:
Run Code Quality Checks                pass
Unit Tests (py3.10/3.11/3.12)          pass
Unit Tests (macOS smoke)               pass
Test Email Agent                       pass
Email Agent Unit Tests (py3.10/3.12)   pass
Dependency Review                      pass
...
```
</details>

<details>
<summary>After — throwaway PR (#2775, closed/deleted) against a non-main base</summary>

Base branch `evidence/2767-fake-base` (a plain, non-`main` branch), head touching `hub/agents/email/python/**` + `src/gaia/agents/base/**`. Two states captured:

**State 1 — draft, no label.** The audited suites now genuinely *register* (not absent, as before this fix) but correctly show `skipping` per their own draft-gate — this itself is new: pre-fix, a non-main-based PR wouldn't show these rows at all. The gate's self-posted check:
```
$ gh api repos/amd/gaia/commits/<sha>/check-runs -q '.check_runs[] | select(.name=="Required Checks Gate")'
{"conclusion":"neutral","output":{"title":"Required suites have not run yet",
 "summary":"This PR is a draft without the `ready_for_ci` label, so the suites
 this gate audits have not run... Mark ready for review, OR add ready_for_ci
 AND THEN close/reopen — the label alone is not enough."}}
```

**State 2 — `ready_for_ci` label added (still draft) → suites actually run.** Real `gh pr checks 2775` output, non-skipped rows:
```
SUCCESS  Test Email Agent
SUCCESS  Email Agent Unit Tests (py3.10)
SUCCESS  Email Agent Unit Tests (py3.12)
SUCCESS  Example Agents Unit Tests
SUCCESS  Run Code Quality Checks
SUCCESS  Unit Tests (py3.10)
SUCCESS  Unit Tests (py3.11)
SUCCESS  Unit Tests (py3.12)
SUCCESS  Unit Tests (macOS smoke)
SUCCESS  Security Tests (Linux)
SUCCESS  Security Tests (Windows)
SUCCESS  Dependency Review
SUCCESS  API Tests
... (39 total, all pass)
```
Nine of these are the exact suites named in the issue's own table (email / unit / lint) — all ran zero times on a non-main base before this change.

Also caught live on this same throwaway PR: adding `ready_for_ci` while still draft (no push) correctly left the audited jobs stuck at `conclusion: skipped` — since `labeled` isn't a type they listen for — and the gate (which does listen for `labeled`) reported `failure` for exactly that reason. That's the #2755 class of bug, reproduced and caught live, not constructed.
</details>

<details>
<summary>The gate failing on its own PR (#2783), and going green — the replay evidence</summary>

Real `gh api repos/amd/gaia/commits/<sha>/check-runs` output for #2783's own head SHA, replayed offline through `evaluate()` before and after each fix (script: `python -c "..."` against the actual API response, not a hand-written fixture):

```
Before recency + exclusion-reporting fixes:
ok=44 pending=4 missing=0 failed=55   # every audited job, stuck at a stale
                                       # pre-expansion skip from the very
                                       # first (still-draft) triggering event

After recency + exclusion fixes, before the "static name + matrix" fix:
ok=44 pending=4 missing=0 failed=3
  Consolidate release bundle: skipped   # tag-ref-gated — now excluded
  C++ Email Agent: failure x2           # pre-existing #1110 guard
  Audit Dependencies: skipped           # the bug this replay caught

After the "static name + matrix" fix:
ok=45 pending=4 missing=0 failed=1
  C++ Email Agent: failure x2           # the only remaining failure —
                                         # pre-existing, unrelated to this PR
```

Live check on the real PR after pushing the fix — the gate's own posted verdict, matching the replay:
```
$ gh api repos/amd/gaia/commits/88a3fd50.../check-runs -q '.check_runs[] | select(.name=="Required Checks Gate") | .output.summary'
Ran and did not pass: C++ Email Agent (windows-latest)=failure, C++ Email Agent (ubuntu-latest)=failure
Enforced 59/72 requirement(s); excluded 13 as not statically verifiable
(continue-on-error: 1, needs-gated: 11, ref-conditional: 1): build-apps
(from build-electron-apps.yml): if references needs.*...; Consolidate
release bundle (from build_agents.yml): if gated on a tag ref...; ...
```

After the fork-PR fix (both check names now exist and agree, on this same-repo PR):
```
$ gh api repos/amd/gaia/commits/036a615c.../check-runs \
    -q '.check_runs[] | select(.name | startswith("Required Checks Gate")) | {name, conclusion}'
{"name":"Required Checks Gate (detail)","conclusion":"failure"}
{"name":"Required Checks Gate","conclusion":"failure"}
```
`Required Checks Gate` (no permissions needed, works identically on forks) is the one to add to branch protection; `(detail)` is the same-repo-only, richer, best-effort companion.

**This PR does not go green on itself, and that is correct, not a bug.** `C++ Email Agent` has been red on `main` itself for months — `gh run list --workflow=build_cpp_email.yml --branch main` shows `failure` going back to at least June 3 — a pre-existing, self-documented scaffold guard for the separate C++ email milestone (#1110), unrelated to this change. This PR touches every one of the 34 widened workflow files, including `build_cpp_email.yml`, so it can't avoid becoming the one PR that surfaces this genuine, already-broken check. Making the gate ignore it would mean teaching it to special-case a real failure — exactly the kind of quiet exception this issue exists to close. A gate that went green here would be a gate that lies; one real check failing, reported accurately, is the correct outcome.
</details>

