### PR TITLE
fix(email-agent): stop meeting/invite answers from inventing what tools never said

### DIFF
--- a/hub/agents/email/python/CHANGELOG.md
+++ b/hub/agents/email/python/CHANGELOG.md
@@ -9,6 +9,22 @@ contract version is tracked separately as
 
 ### Fixed
 
+- **Asked about upcoming meetings or calendar invites, the agent could invent
+  attendee names and invite confirmations that exist nowhere in the mailbox
+  or the tool trace (#2766).** A calendar event's real `organizer` was
+  sometimes narrated as "sent you an invite" — a real field, misread — and a
+  question like "did anyone send me a meeting invite?" could draw a
+  confident "yes" with no mutation, message, or attachment behind it.
+  `list_calendar_events` and `detect_calendar_conflicts` now surface each
+  event's real `attendees` (Google omits the key entirely once an event has
+  no one beyond the organizer; that's now normalized to `[]` instead of
+  being discarded) so there is real data to ground an attendee claim
+  against. Two new deterministic checks — the same "tool computes, model
+  reports" pattern the calendar-conflict and attention-card checks already
+  use — catch an invite claimed as sent/received when nothing this turn
+  could have confirmed one, and an attendee named for an event the tool
+  result shows has none; both leave a correctly-reported organizer and an
+  honest "no attendees" alone.
 - **A meeting proposal in a confidently-classified message vanished from the
   view the TUI renders on open (#2580).** `is_meeting_request` was wired into
   the scan by #2589, but the `needs_you` worklist (#2743, which replaced the

--- a/hub/agents/email/python/gaia_agent_email/answer_grounding.py
+++ b/hub/agents/email/python/gaia_agent_email/answer_grounding.py
@@ -476,6 +476,178 @@ def _attention_card_correction(cached: Dict[str, Any]) -> str:
 
 
 # ---------------------------------------------------------------------------
+# Guard 6 — an invite claimed as sent/received/confirmed (#2766)
+# ---------------------------------------------------------------------------
+#
+# No tool in this package can currently confirm that a genuine calendar
+# invite was sent or received — detect_meeting_request is a text heuristic
+# for PROPOSALS, never a confirmation, and list_calendar_events /
+# detect_calendar_conflicts return real events but an event existing is not
+# evidence anyone emailed an invite for it (see calendar_tools' docstrings).
+# A completion-framed invite claim is therefore always ungrounded today,
+# with one exception: create_event_from_email's own mutation legitimately
+# sends calendar invites to its attendees, so a turn that actually called it
+# licenses the claim (mirrors guard 1's "grounded when a tool ran" shape).
+
+_INVITE_CLAIM_RE = re.compile(
+    r"\binvite[sd]?\b[^.!?]{0,40}\b(?:sent|received|confirmed)\b"
+    r"|\b(?:sent|received)\b[^.!?]{0,40}\binvite[sd]?\b",
+    re.IGNORECASE,
+)
+
+# A negation anywhere in the same clause turns a claim into a (correct)
+# denial -- "no invite has been sent" must not be treated like "an invite
+# has been sent". Deliberately broad (checked over the whole clause, not a
+# fixed window) since a denial can front-load its negation far from "invite".
+_INVITE_NEGATION_RE = re.compile(
+    r"\b(?:no|not|n't|never|none|isn't|wasn't|hasn't|haven't|didn't|doesn't)\b",
+    re.IGNORECASE,
+)
+
+
+def _clause_around(text: str, start: int, end: int) -> str:
+    """The sentence-ish span of ``text`` containing ``[start, end)`` —
+    bounded by the nearest ``.``/``!``/``?`` on either side (or the string's
+    own edges). Shared by guards that need "same clause" context without
+    crossing into an unrelated sentence.
+    """
+    clause_start = (
+        max(
+            text.rfind(".", 0, start),
+            text.rfind("!", 0, start),
+            text.rfind("?", 0, start),
+        )
+        + 1
+    )
+    ends = [
+        idx
+        for idx in (text.find(".", end), text.find("!", end), text.find("?", end))
+        if idx != -1
+    ]
+    clause_end = min(ends) if ends else len(text)
+    return text[clause_start:clause_end]
+
+
+def find_ungrounded_invite_claim(
+    final_answer: Optional[str], conversation: Optional[List[Dict[str, Any]]]
+) -> Optional[str]:
+    """Return a reason when ``final_answer`` claims a calendar invite was
+    sent, received, or confirmed; ``None`` when the claim is grounded,
+    negated, or absent.
+
+    Proposals are not invites (#2766): "X proposed Thursday at 2pm" is fine,
+    "X sent you an invite" is not, unless this turn actually created one.
+    """
+    if not final_answer:
+        return None
+    match = _INVITE_CLAIM_RE.search(final_answer)
+    if not match:
+        return None
+    clause = _clause_around(final_answer, match.start(), match.end())
+    if _INVITE_NEGATION_RE.search(clause):
+        return None
+    if "create_event_from_email" in tools_called_this_turn(conversation):
+        return None
+    return f"claims an invite was sent/received/confirmed: {match.group(0)!r}"
+
+
+_INVITE_GROUNDING_CORRECTION = (
+    "\n\nNote: I don't have a way to confirm a calendar invite was actually "
+    "sent or received — what's described above may be a proposal, not a "
+    "confirmed invite."
+)
+
+
+def append_invite_grounding_correction(response_text: str) -> str:
+    """Append a correction notice to a response with an ungrounded invite
+    claim. Never edits the original text — see ``find_ungrounded_invite_claim``
+    for why this is an append, not a replace."""
+    return (response_text or "") + _INVITE_GROUNDING_CORRECTION
+
+
+# ---------------------------------------------------------------------------
+# Guard 7 — an attendee/invitee named for a calendar event this turn's own
+# tool result shows has none (#2766)
+# ---------------------------------------------------------------------------
+#
+# list_calendar_events / detect_calendar_conflicts now report each event's
+# real ``attendees`` (calendar_tools._extract_attendees) — [] when the
+# calendar has no one beyond the organizer, which #2766's live probes show
+# is true of every real event in the reference corpus. This guard is
+# deliberately narrow: it does not try to catch every way a name could leak
+# into prose (arbitrary proper-noun detection is not reliable), only the
+# bounded, checkable case where the model uses attendee/invitee vocabulary
+# for an event this turn's own tool result already proved carries none.
+
+_ATTENDEE_CLAIM_RE = re.compile(r"\battendee[s]?\b|\binvitee[s]?\b", re.IGNORECASE)
+
+
+def _any_listed_event_has_attendees(
+    conversation: Optional[List[Dict[str, Any]]],
+) -> Optional[bool]:
+    """Across every ``list_calendar_events`` / ``detect_calendar_conflicts``
+    result this turn: ``True`` if any listed event carries a non-empty
+    ``attendees``, ``False`` if every one is empty, ``None`` if neither tool
+    ran (nothing to reconcile against).
+    """
+    saw_any_tool = False
+    for entry in _tool_entries(conversation):
+        if entry.get("name") not in (
+            "list_calendar_events",
+            "detect_calendar_conflicts",
+        ):
+            continue
+        payload = _parse_tool_payload(entry.get("content"))
+        if not isinstance(payload, dict):
+            continue
+        events = payload.get("events")
+        if events is None:
+            events = payload.get("conflicts")
+        if not isinstance(events, list):
+            continue
+        saw_any_tool = True
+        for ev in events:
+            if isinstance(ev, dict) and ev.get("attendees"):
+                return True
+    return False if saw_any_tool else None
+
+
+def find_fabricated_attendee_claim(
+    final_answer: Optional[str], conversation: Optional[List[Dict[str, Any]]]
+) -> Optional[str]:
+    """Return a reason when ``final_answer`` names attendees/invitees for a
+    calendar event this turn's own tool result shows has none; ``None``
+    when neither calendar tool ran, at least one listed event actually
+    carries attendees, or the answer makes no attendee-shaped claim.
+    """
+    if not final_answer:
+        return None
+    if not _ATTENDEE_CLAIM_RE.search(final_answer):
+        return None
+    has_attendees = _any_listed_event_has_attendees(conversation)
+    if has_attendees is None or has_attendees:
+        return None
+    return (
+        "names an attendee/invitee for a calendar event whose own "
+        "attendees list is empty"
+    )
+
+
+_ATTENDEE_GROUNDING_CORRECTION = (
+    "\n\nNote: the calendar event(s) above don't list any attendees — I "
+    "can't confirm who, if anyone, is attending."
+)
+
+
+def append_attendee_grounding_correction(response_text: str) -> str:
+    """Append a correction notice to a response with a fabricated attendee
+    claim. Never edits the original text — see
+    ``find_fabricated_attendee_claim`` for why this is an append, not a
+    replace."""
+    return (response_text or "") + _ATTENDEE_GROUNDING_CORRECTION
+
+
+# ---------------------------------------------------------------------------
 # Orchestration — the single call site EmailTriageAgent.process_query uses
 # ---------------------------------------------------------------------------
 
@@ -491,14 +663,15 @@ def ground_final_answer(result: Dict[str, Any]) -> Dict[str, Any]:
     from. A replaced answer is not re-scanned by the other check: each
     fallback is already, by construction, clean of the pattern it replaces.
 
-    The calendar-conflict (#2571) and attention-card (#2636) checks run
-    last and, unlike the two above, APPEND a correction instead of
-    replacing the answer — in both cases the rest of the answer stays
-    useful and only a specific clause is unverified/contradicted. They
-    never run against text a prior contradiction check has already
-    replaced (those checks already ``return``), but they are independent
-    of each other and MUST both be allowed to fire on the same turn,
-    appending in sequence — neither may short-circuit the other.
+    The calendar-conflict (#2571), attention-card (#2636), invite-claim, and
+    fabricated-attendee (#2766) checks run last and, unlike the two above,
+    APPEND a correction instead of replacing the answer — in every case the
+    rest of the answer stays useful and only a specific clause is
+    unverified/contradicted. They never run against text a prior
+    contradiction check has already replaced (those checks already
+    ``return``), but all four are independent of each other and MUST all be
+    allowed to fire on the same turn, appending in sequence — none may
+    short-circuit another.
     """
     final_answer = result.get("result")
     if not isinstance(final_answer, str) or not final_answer:
@@ -561,16 +734,36 @@ def ground_final_answer(result: Dict[str, Any]) -> Dict[str, Any]:
                 final_answer.rstrip() + "\n\n" + _attention_card_correction(cached)
             )
 
+    invite_reason = find_ungrounded_invite_claim(final_answer, conversation)
+    if invite_reason:
+        logger.warning(
+            "email agent: appended ungrounded invite-claim correction — %s",
+            invite_reason,
+        )
+        final_answer = append_invite_grounding_correction(final_answer)
+
+    attendee_reason = find_fabricated_attendee_claim(final_answer, conversation)
+    if attendee_reason:
+        logger.warning(
+            "email agent: appended fabricated-attendee correction — %s",
+            attendee_reason,
+        )
+        final_answer = append_attendee_grounding_correction(final_answer)
+
     result["result"] = final_answer
     return result
 
 
 __all__ = [
     "UNGROUNDED_SUCCESS_FALLBACK",
+    "append_attendee_grounding_correction",
+    "append_invite_grounding_correction",
     "decode_stray_unicode_escapes",
     "find_attention_card_contradiction",
+    "find_fabricated_attendee_claim",
     "find_scaffolding_leak",
     "find_ungrounded_calendar_conflict_claim",
+    "find_ungrounded_invite_claim",
     "find_ungrounded_success_claim",
     "find_unlicensed_cross_mailbox_claim",
     "find_unqualified_negative_claim",

--- a/hub/agents/email/python/gaia_agent_email/answer_grounding.py
+++ b/hub/agents/email/python/gaia_agent_email/answer_grounding.py
@@ -496,14 +496,15 @@ _INVITE_CLAIM_RE = re.compile(
 )
 
 # A negation or hedging modal anywhere in the same clause turns a completed-
-# action claim into something else -- a (correct) denial ("no invite has
-# been sent") or a hypothetical ("an invite would be sent") -- neither of
-# which asserts what "an invite has been sent" asserts. Deliberately broad
-# (checked over the whole clause, not a fixed window) since a denial can
-# front-load its negation far from "invite".
-_INVITE_NEGATION_RE = re.compile(
+# action / positive claim into something else -- a (correct) denial ("no
+# invite has been sent", "no attendees are listed") or a hypothetical ("an
+# invite would be sent") -- neither of which asserts what the bare claim
+# asserts. Shared with guard 7 below (same concept, not invite-specific).
+# Deliberately broad (checked over the whole clause, not a fixed window)
+# since a denial can front-load its negation far from the claimed word.
+_CLAUSE_NEGATION_RE = re.compile(
     r"\b(?:no|not|n't|never|none|nobody|isn't|wasn't|hasn't|haven't|didn't"
-    r"|doesn't|would|will|might|could|should)\b",
+    r"|doesn't|don't|aren't|would|will|might|could|should)\b",
     re.IGNORECASE,
 )
 
@@ -547,7 +548,7 @@ def find_ungrounded_invite_claim(
     if not match:
         return None
     clause = _clause_around(final_answer, match.start(), match.end())
-    if _INVITE_NEGATION_RE.search(clause):
+    if _CLAUSE_NEGATION_RE.search(clause):
         return None
     if "create_event_from_email" in tools_called_this_turn(conversation):
         return None
@@ -621,11 +622,19 @@ def find_fabricated_attendee_claim(
     """Return a reason when ``final_answer`` names attendees/invitees for a
     calendar event this turn's own tool result shows has none; ``None``
     when neither calendar tool ran, at least one listed event actually
-    carries attendees, or the answer makes no attendee-shaped claim.
+    carries attendees, the answer makes no attendee-shaped claim, or the
+    claim is itself a (correct) denial -- "no attendees are listed" must not
+    be treated like "the attendees are Jane and John" (#2766: an agent
+    honestly reporting the real, empty attendee list is the desired
+    behavior, not a fabrication to correct).
     """
     if not final_answer:
         return None
-    if not _ATTENDEE_CLAIM_RE.search(final_answer):
+    match = _ATTENDEE_CLAIM_RE.search(final_answer)
+    if not match:
+        return None
+    clause = _clause_around(final_answer, match.start(), match.end())
+    if _CLAUSE_NEGATION_RE.search(clause):
         return None
     has_attendees = _any_listed_event_has_attendees(conversation)
     if has_attendees is None or has_attendees:

--- a/hub/agents/email/python/gaia_agent_email/answer_grounding.py
+++ b/hub/agents/email/python/gaia_agent_email/answer_grounding.py
@@ -495,12 +495,15 @@ _INVITE_CLAIM_RE = re.compile(
     re.IGNORECASE,
 )
 
-# A negation anywhere in the same clause turns a claim into a (correct)
-# denial -- "no invite has been sent" must not be treated like "an invite
-# has been sent". Deliberately broad (checked over the whole clause, not a
-# fixed window) since a denial can front-load its negation far from "invite".
+# A negation or hedging modal anywhere in the same clause turns a completed-
+# action claim into something else -- a (correct) denial ("no invite has
+# been sent") or a hypothetical ("an invite would be sent") -- neither of
+# which asserts what "an invite has been sent" asserts. Deliberately broad
+# (checked over the whole clause, not a fixed window) since a denial can
+# front-load its negation far from "invite".
 _INVITE_NEGATION_RE = re.compile(
-    r"\b(?:no|not|n't|never|none|isn't|wasn't|hasn't|haven't|didn't|doesn't)\b",
+    r"\b(?:no|not|n't|never|none|nobody|isn't|wasn't|hasn't|haven't|didn't"
+    r"|doesn't|would|will|might|could|should)\b",
     re.IGNORECASE,
 )
 

--- a/hub/agents/email/python/gaia_agent_email/tools/calendar_tools.py
+++ b/hub/agents/email/python/gaia_agent_email/tools/calendar_tools.py
@@ -626,6 +626,29 @@ def _event_window(event: Mapping[str, Any]) -> Optional[Tuple[datetime, datetime
         return None
 
 
+def _extract_attendees(event: Mapping[str, Any]) -> List[Dict[str, Any]]:
+    """The event's real ``attendees``, or ``[]`` when the Calendar API omits
+    the key (#2766 — every event with no one beyond the organizer omits
+    ``attendees`` entirely; ``event.get("attendees")`` is then ``None``).
+
+    Returns exactly what the backend reports — never synthesizes an entry.
+    ``response_status`` mirrors Google's own vocabulary (``needsAction`` /
+    ``declined`` / ``tentative`` / ``accepted``) unchanged, so a caller can
+    tell "invited but hasn't answered" from "confirmed" without guessing.
+    An empty return is the grounding fact this tool exists to state: no
+    attendee tool result means no attendee claim is licensed, full stop.
+    """
+    attendees = event.get("attendees") or []
+    return [
+        {
+            "email": a.get("email"),
+            "response_status": a.get("responseStatus"),
+        }
+        for a in attendees
+        if isinstance(a, Mapping) and a.get("email")
+    ]
+
+
 def intervals_overlap(a_start: Any, a_end: Any, b_start: Any, b_end: Any) -> bool:
     """Half-open ``[start, end)`` overlap test.
 
@@ -691,6 +714,7 @@ def detect_calendar_conflicts_impl(
                         "summary": ev.get("summary", ""),
                         "start": start_obj.get("dateTime") or start_obj.get("date"),
                         "end": end_obj.get("dateTime") or end_obj.get("date"),
+                        "attendees": _extract_attendees(ev),
                     }
                 )
         st["result_summary"] = {"conflict_count": len(conflicts)}
@@ -917,6 +941,10 @@ def list_calendar_events_impl(
                     "location": e.get("location"),
                     "organizer": organizer,
                     "missing_organizer": organizer is None,
+                    # Real attendees only, [] when the calendar has none
+                    # beyond the organizer (#2766) — never inferred from the
+                    # organizer or anywhere else.
+                    "attendees": _extract_attendees(e),
                 }
             )
         st["result_summary"] = {"count": len(events)}
@@ -1092,7 +1120,15 @@ class CalendarToolsMixin:
             lists events — it does NOT determine whether they conflict. For
             any question about conflicts, overlaps, or double-booking, call
             ``detect_calendar_conflicts`` instead of judging the listed
-            times yourself."""
+            times yourself.
+
+            Each event's ``attendees`` is exactly what the calendar carries —
+            often ``[]``. Never state who is attending, invited, or coming
+            unless a name/email actually appears in that event's own
+            ``attendees`` list; an empty list means say so, not guess. The
+            ``organizer`` is who created the event, not evidence that anyone
+            was sent or received an invite — never describe the organizer as
+            having "sent an invite"."""
             try:
                 return _envelope_ok(
                     list_calendar_events_impl(
@@ -1202,6 +1238,12 @@ class CalendarToolsMixin:
             heuristic; ambiguous bodies ("let's sync sometime") are escalated
             to the LLM for a judgement. If the LLM is needed but fails, this
             surfaces the error rather than guessing "not a meeting".
+
+            This tool detects a PROPOSAL, never a confirmed invite. Never say
+            an invite was "sent" or "received" from this signal alone — say
+            the sender proposed a time, and state only the sender/subject/
+            time you actually read in the message, never a name or time this
+            tool did not return.
             """
             try:
                 # Built at call time so ``agent.chat`` is initialized.
@@ -1241,10 +1283,12 @@ class CalendarToolsMixin:
             bounding the proposed meeting. Returns an envelope whose
             ``data`` has ``has_conflict`` (bool) and ``conflicts`` (the
             overlapping events, each with ``id``/``summary``/``start``/
-            ``end``). Overlap is half-open: a meeting ending exactly when
-            another begins does NOT conflict. If the calendar can't be
-            read, this surfaces the error rather than reporting a
-            reassuring "no conflicts".
+            ``end``/``attendees``). Overlap is half-open: a meeting ending
+            exactly when another begins does NOT conflict. If the calendar
+            can't be read, this surfaces the error rather than reporting a
+            reassuring "no conflicts". Never state an attendee for a
+            conflicting event unless that event's own ``attendees`` list
+            actually names them.
             """
             try:
                 return _envelope_ok(

--- a/hub/agents/email/python/tests/test_answer_grounding.py
+++ b/hub/agents/email/python/tests/test_answer_grounding.py
@@ -634,6 +634,44 @@ class TestFindFabricatedAttendeeClaim:
         assert find_fabricated_attendee_claim("", convo) is None
         assert find_fabricated_attendee_claim(None, convo) is None
 
+    @pytest.mark.parametrize(
+        "phrase",
+        [
+            "No attendees are listed for this event.",
+            "There are no attendees for this meeting.",
+            "I do not see any attendees listed.",
+            "There aren't any attendees on this one.",
+        ],
+    )
+    def test_a_correct_denial_is_not_flagged(self, phrase):
+        # #2580's independent capture: the model reads the real, populated
+        # `organizer` field correctly and only misreports what it MEANS
+        # ("organizer" != "sent you an invite" -- guard 6's job). Honestly
+        # reporting the real, EMPTY `attendees` list must never be treated
+        # like inventing a name -- "no attendees" is the desired answer.
+        convo = [_events_tool_entry("list_calendar_events", [_event()])]
+        assert find_fabricated_attendee_claim(phrase, convo) is None
+
+    def test_correctly_reporting_the_real_organizer_is_never_flagged(self):
+        # The organizer field IS populated and legitimate (unlike
+        # attendees) -- correctly describing it must trip neither this
+        # guard nor the invite-claim guard (#2580's independent finding:
+        # the model reads organizer=self correctly and only
+        # misinterprets it as "sent an invite", which is guard 6's job,
+        # not evidence this guard should fire on organizer mentions at all).
+        convo = [
+            _events_tool_entry(
+                "list_calendar_events",
+                [_event(organizer="tomasz.iniewicz@gmail.com")],
+            )
+        ]
+        text = (
+            "The organizer of this event is tomasz.iniewicz@gmail.com — "
+            "you created it yourself."
+        )
+        assert find_fabricated_attendee_claim(text, convo) is None
+        assert find_ungrounded_invite_claim(text, convo) is None
+
 
 # ---------------------------------------------------------------------------
 # ground_final_answer — the orchestration a real turn goes through

--- a/hub/agents/email/python/tests/test_answer_grounding.py
+++ b/hub/agents/email/python/tests/test_answer_grounding.py
@@ -535,6 +535,10 @@ class TestFindUngroundedInviteClaim:
             "Would you like me to send an invite for this?",
             "Alice proposed meeting Thursday at 2pm.",
             "Here are your three upcoming meetings.",
+            "The vendor said an invite would be sent soon.",
+            "Nobody has sent you an invite yet.",
+            "Three people proposed times to meet, but no invite has actually "
+            "been sent.",
         ],
     )
     def test_no_false_positive(self, phrase):

--- a/hub/agents/email/python/tests/test_answer_grounding.py
+++ b/hub/agents/email/python/tests/test_answer_grounding.py
@@ -50,8 +50,10 @@ from gaia_agent_email.answer_grounding import (  # noqa: E402
     UNGROUNDED_SUCCESS_FALLBACK,
     decode_stray_unicode_escapes,
     find_attention_card_contradiction,
+    find_fabricated_attendee_claim,
     find_scaffolding_leak,
     find_ungrounded_calendar_conflict_claim,
+    find_ungrounded_invite_claim,
     find_ungrounded_success_claim,
     find_unlicensed_cross_mailbox_claim,
     find_unqualified_negative_claim,
@@ -95,6 +97,32 @@ def _list_events_tool_entry(event_count: int) -> dict:
         "name": "list_calendar_events",
         "content": json.dumps({"ok": True, "data": {"events": events}}),
     }
+
+
+def _events_tool_entry(tool_name: str, events: list, *, key: str = "events") -> dict:
+    """A ``role: tool`` entry for ``list_calendar_events`` or
+    ``detect_calendar_conflicts`` carrying explicit event dicts (so a test
+    can control ``attendees`` directly) — same plain-JSON-string content
+    shape ``_list_events_tool_entry`` and ``_listed_event_count_from_
+    conversation`` read, generalized past a bare count.
+    """
+    return {
+        "role": "tool",
+        "name": tool_name,
+        "content": json.dumps({"ok": True, "data": {key: events}}),
+    }
+
+
+def _event(*, attendees=None, **overrides) -> dict:
+    base = {
+        "id": "evt1",
+        "summary": "Design review",
+        "start": "2026-08-06T09:00:00-04:00",
+        "end": "2026-08-06T10:00:00-04:00",
+        "attendees": attendees if attendees is not None else [],
+    }
+    base.update(overrides)
+    return base
 
 
 def _detect_conflicts_tool_entry() -> dict:
@@ -476,6 +504,134 @@ class TestFindUngroundedCalendarConflictClaim:
 
 
 # ---------------------------------------------------------------------------
+# find_ungrounded_invite_claim (#2766) — "proposals are not invites". No
+# tool here can currently confirm a genuine received/sent invite, so a
+# completion-framed invite claim is always ungrounded except when this turn
+# actually called create_event_from_email.
+# ---------------------------------------------------------------------------
+
+
+class TestFindUngroundedInviteClaim:
+    @pytest.mark.parametrize(
+        "phrase",
+        [
+            "An invite has been confirmed as sent.",
+            "Yes, Tomasz sent you invites for three meetings.",
+            "You have received a calendar invite from the vendor.",
+            "The invite was sent yesterday.",
+            "I can confirm the invite has been sent to your inbox.",
+        ],
+    )
+    def test_detects_invite_claim_with_no_grounding_tool(self, phrase):
+        reason = find_ungrounded_invite_claim(phrase, [])
+        assert reason is not None
+
+    @pytest.mark.parametrize(
+        "phrase",
+        [
+            "No invite has been sent — this is just a proposal.",
+            "None of them were flagged as formal calendar invites.",
+            "These aren't formal calendar invites, just requests to chat.",
+            "Would you like me to send an invite for this?",
+            "Alice proposed meeting Thursday at 2pm.",
+            "Here are your three upcoming meetings.",
+        ],
+    )
+    def test_no_false_positive(self, phrase):
+        assert find_ungrounded_invite_claim(phrase, []) is None
+
+    def test_grounded_when_create_event_from_email_ran_this_turn(self):
+        convo = [_tool_entry("create_event_from_email", {"event_id": "e1"})]
+        text = "I've created the event and sent an invite to the attendee."
+        assert find_ungrounded_invite_claim(text, convo) is None
+
+    def test_unrelated_tool_call_does_not_ground_the_claim(self):
+        convo = [_list_events_tool_entry(2)]
+        text = "An invite has been confirmed as sent."
+        assert find_ungrounded_invite_claim(text, convo) is not None
+
+    def test_negation_far_from_the_word_invite_still_suppresses(self):
+        text = "It's not true that an invite was sent for this one."
+        assert find_ungrounded_invite_claim(text, []) is None
+
+    def test_negation_in_a_different_sentence_does_not_suppress(self):
+        # The negation belongs to an earlier, unrelated sentence -- it must
+        # not launder a real claim in the next one.
+        text = "No urgent items today. An invite has been confirmed as sent."
+        assert find_ungrounded_invite_claim(text, []) is not None
+
+    def test_empty_or_missing_answer_never_flagged(self):
+        assert find_ungrounded_invite_claim("", []) is None
+        assert find_ungrounded_invite_claim(None, []) is None
+
+
+# ---------------------------------------------------------------------------
+# find_fabricated_attendee_claim (#2766) — "any attendee name is a
+# fabrication" when the calendar tool's own result carries none.
+# ---------------------------------------------------------------------------
+
+
+class TestFindFabricatedAttendeeClaim:
+    def test_flags_attendee_language_when_every_listed_event_is_empty(self):
+        convo = [_events_tool_entry("list_calendar_events", [_event()])]
+        text = "The attendees for this meeting are Jane Doe and John Smith."
+        reason = find_fabricated_attendee_claim(text, convo)
+        assert reason is not None
+
+    def test_flags_invitee_language_too(self):
+        convo = [_events_tool_entry("list_calendar_events", [_event()])]
+        text = "The invitees include Jane Doe."
+        assert find_fabricated_attendee_claim(text, convo) is not None
+
+    def test_not_flagged_when_a_listed_event_actually_has_attendees(self):
+        convo = [
+            _events_tool_entry(
+                "list_calendar_events",
+                [_event(attendees=[{"email": "jane@example.com"}])],
+            )
+        ]
+        text = "The attendees for this meeting are jane@example.com."
+        assert find_fabricated_attendee_claim(text, convo) is None
+
+    def test_not_flagged_when_neither_calendar_tool_ran(self):
+        text = "The attendees for this meeting are Jane Doe."
+        assert find_fabricated_attendee_claim(text, []) is None
+
+    def test_not_flagged_with_no_attendee_shaped_claim(self):
+        convo = [_events_tool_entry("list_calendar_events", [_event()])]
+        text = "You have one meeting: Design review at 9am."
+        assert find_fabricated_attendee_claim(text, convo) is None
+
+    def test_checks_detect_calendar_conflicts_results_too(self):
+        convo = [
+            _events_tool_entry("detect_calendar_conflicts", [_event()], key="conflicts")
+        ]
+        text = "The attendees include Jane Doe."
+        assert find_fabricated_attendee_claim(text, convo) is not None
+
+    def test_any_event_with_attendees_across_multiple_clears_it(self):
+        # Two events this turn; only one carries attendees -- the model may
+        # be describing THAT one, so this guard (which doesn't try to match
+        # a specific name to a specific event) stays silent.
+        convo = [
+            _events_tool_entry(
+                "list_calendar_events",
+                [
+                    _event(id="evt1"),
+                    _event(id="evt2", attendees=[{"email": "jane@example.com"}]),
+                ],
+            )
+        ]
+        text = "The attendees are jane@example.com."
+        assert find_fabricated_attendee_claim(text, convo) is None
+
+    def test_empty_or_missing_answer_never_flagged(self):
+        convo = [_events_tool_entry("list_calendar_events", [_event()])]
+        assert find_fabricated_attendee_claim("", convo) is None
+        assert find_fabricated_attendee_claim(None, convo) is None
+
+
+# ---------------------------------------------------------------------------
 # ground_final_answer — the orchestration a real turn goes through
 # ---------------------------------------------------------------------------
 
@@ -673,12 +829,79 @@ class TestGroundFinalAnswerCalendarConflict:
 
 
 # ---------------------------------------------------------------------------
-# THE composition test — the fold's single most important guarantee. Both
-# the calendar-conflict (#2571) and attention-card (#2636) checks are
-# APPEND-only and independent of each other; an early ``return`` between
-# them (a bug the reference integration actually hit once) would silently
-# suppress whichever check runs second. Both must be able to fire, in
-# sequence, on the very same turn.
+# ground_final_answer wiring for the invite-claim and fabricated-attendee
+# guards (#2766) — same append-only shape as the calendar-conflict guard
+# above, exercised through the single orchestration entry point.
+# ---------------------------------------------------------------------------
+
+
+class TestGroundFinalAnswerInviteAndAttendee:
+    def test_appends_invite_correction_without_destroying_original_text(self):
+        text = "An invite has been confirmed as sent for the ObjectWin meeting."
+        result = {"result": text, "conversation": []}
+        out = ground_final_answer(result)
+        assert text in out["result"]
+        assert "confirm" in out["result"].lower()
+        assert out["result"] != text
+
+    def test_invite_claim_grounded_by_create_event_from_email_is_untouched(self):
+        text = "I've created the event and sent an invite to the attendee."
+        result = {
+            "result": text,
+            "conversation": [
+                _tool_entry("create_event_from_email", {"event_id": "e1"})
+            ],
+        }
+        out = ground_final_answer(result)
+        assert out["result"] == text
+
+    def test_appends_attendee_correction_without_destroying_original_text(self):
+        text = "The attendees for this meeting are Jane Doe and John Smith."
+        result = {
+            "result": text,
+            "conversation": [_events_tool_entry("list_calendar_events", [_event()])],
+        }
+        out = ground_final_answer(result)
+        assert text in out["result"]
+        assert "don't list any attendees" in out["result"]
+        assert out["result"] != text
+
+    def test_attendee_claim_grounded_by_real_attendees_is_untouched(self):
+        text = "The attendees for this meeting are jane@example.com."
+        result = {
+            "result": text,
+            "conversation": [
+                _events_tool_entry(
+                    "list_calendar_events",
+                    [_event(attendees=[{"email": "jane@example.com"}])],
+                )
+            ],
+        }
+        out = ground_final_answer(result)
+        assert out["result"] == text
+
+    def test_both_corrections_compose_on_one_turn(self):
+        text = (
+            "An invite has been confirmed as sent. The attendees are Jane "
+            "Doe and John Smith."
+        )
+        result = {
+            "result": text,
+            "conversation": [_events_tool_entry("list_calendar_events", [_event()])],
+        }
+        out = ground_final_answer(result)
+        assert text in out["result"]
+        assert "confirm" in out["result"].lower()
+        assert "don't list any attendees" in out["result"]
+
+
+# ---------------------------------------------------------------------------
+# THE composition test — the fold's single most important guarantee. All
+# four APPEND-only checks (calendar-conflict #2571, attention-card #2636,
+# invite-claim and fabricated-attendee #2766) are independent of each other;
+# an early ``return`` between any two (a bug the reference integration
+# actually hit once) would silently suppress whichever check runs later.
+# All four must be able to fire, in sequence, on the very same turn.
 # ---------------------------------------------------------------------------
 
 
@@ -704,6 +927,31 @@ class TestGroundFinalAnswerComposition:
         # the other.
         assert "attention card" in out["result"].lower()
         assert "7" in out["result"]
+
+    def test_all_four_append_guards_fire_on_one_turn(self):
+        _store_attention_view(items=[_attention_item("action_item")], scanned=7)
+        text = (
+            "Here are your events: Budget sync, Design review. These two "
+            "events are back-to-back and do not conflict. No action items "
+            "right now. An invite has been confirmed as sent, and the "
+            "attendees are Jane Doe and John Smith."
+        )
+        result = {
+            "result": text,
+            "conversation": [
+                _events_tool_entry(
+                    "list_calendar_events",
+                    [_event(id="evt1"), _event(id="evt2")],
+                )
+            ],
+        }
+        out = ground_final_answer(result)
+
+        assert text in out["result"]
+        assert "detect_calendar_conflicts" in out["result"]
+        assert "attention card" in out["result"].lower()
+        assert "confirm" in out["result"].lower()
+        assert "don't list any attendees" in out["result"]
 
 
 # ---------------------------------------------------------------------------

--- a/hub/agents/email/python/tests/test_answer_grounding.py
+++ b/hub/agents/email/python/tests/test_answer_grounding.py
@@ -662,11 +662,11 @@ class TestFindFabricatedAttendeeClaim:
         convo = [
             _events_tool_entry(
                 "list_calendar_events",
-                [_event(organizer="tomasz.iniewicz@gmail.com")],
+                [_event(organizer="owner@example.com")],
             )
         ]
         text = (
-            "The organizer of this event is tomasz.iniewicz@gmail.com — "
+            "The organizer of this event is owner@example.com — "
             "you created it yourself."
         )
         assert find_fabricated_attendee_claim(text, convo) is None

--- a/hub/agents/email/python/tests/test_calendar_attendees_2766.py
+++ b/hub/agents/email/python/tests/test_calendar_attendees_2766.py
@@ -1,0 +1,264 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""Real ``attendees`` surfaced on calendar events (#2766).
+
+``list_calendar_events_impl`` and ``detect_calendar_conflicts_impl`` used to
+discard the Calendar API's own ``attendees`` field entirely — a caller (the
+model) had no structured way to know a listed event had no attendees, only
+an organizer. Asked "what meetings are coming up" or "did anyone send me an
+invite", the model then had nothing to ground an attendee/invite claim in
+except its own free composition, and #2766's live probes show it invented
+names and invite claims that appear nowhere in the mailbox.
+
+Google's Calendar API omits the ``attendees`` key entirely once an event has
+no one beyond the organizer (verified against the live API, #2766) — so
+``event.get("attendees")`` is ``None``, not ``[]``, for the common case.
+``_extract_attendees`` normalizes that to ``[]`` and passes through only
+``email``/``response_status`` for anyone who *is* listed — never invents,
+never re-derives from ``organizer``.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+pytest.importorskip("gaia_agent_email")
+
+from gaia_agent_email.tools.calendar_tools import (  # noqa: E402
+    _extract_attendees,
+    detect_calendar_conflicts_impl,
+    list_calendar_events_impl,
+)
+
+# ---------------------------------------------------------------------------
+# _extract_attendees — the pure extraction helper
+# ---------------------------------------------------------------------------
+
+
+class TestExtractAttendees:
+    def test_missing_attendees_key_returns_empty_list(self):
+        assert _extract_attendees({"summary": "Board meeting"}) == []
+
+    def test_none_attendees_value_returns_empty_list(self):
+        assert _extract_attendees({"attendees": None}) == []
+
+    def test_empty_attendees_list_returns_empty_list(self):
+        assert _extract_attendees({"attendees": []}) == []
+
+    def test_real_attendees_are_passed_through(self):
+        event = {
+            "attendees": [
+                {"email": "jane@example.com", "responseStatus": "accepted"},
+                {"email": "john@example.com", "responseStatus": "needsAction"},
+            ]
+        }
+        assert _extract_attendees(event) == [
+            {"email": "jane@example.com", "response_status": "accepted"},
+            {"email": "john@example.com", "response_status": "needsAction"},
+        ]
+
+    def test_entries_missing_email_are_dropped_not_synthesized(self):
+        event = {"attendees": [{"displayName": "no email here"}]}
+        assert _extract_attendees(event) == []
+
+    def test_non_mapping_entries_are_skipped(self):
+        event = {"attendees": ["not-a-dict", {"email": "jane@example.com"}]}
+        assert _extract_attendees(event) == [
+            {"email": "jane@example.com", "response_status": None}
+        ]
+
+
+# ---------------------------------------------------------------------------
+# list_calendar_events_impl — attendees surfaced per event
+# ---------------------------------------------------------------------------
+
+
+class _FakeCalendar:
+    def __init__(self, items):
+        self._items = items
+
+    def list_events(self, **_kwargs):
+        return {"items": self._items}
+
+
+class TestListCalendarEventsAttendees:
+    def test_event_with_no_attendees_key_reports_empty_list(self):
+        cal = _FakeCalendar(
+            [
+                {
+                    "id": "evt1",
+                    "summary": "Board meeting",
+                    "start": {"dateTime": "2026-08-13T14:00:00-04:00"},
+                    "end": {"dateTime": "2026-08-13T16:00:00-04:00"},
+                    "organizer": {"email": "me@example.com", "self": True},
+                }
+            ]
+        )
+        out = list_calendar_events_impl(cal, time_min=None, time_max=None)
+        (event,) = out["events"]
+        assert event["attendees"] == []
+
+    def test_event_with_real_attendees_reports_them(self):
+        cal = _FakeCalendar(
+            [
+                {
+                    "id": "evt1",
+                    "summary": "Design review",
+                    "start": {"dateTime": "2026-08-06T09:00:00-04:00"},
+                    "end": {"dateTime": "2026-08-06T10:00:00-04:00"},
+                    "attendees": [
+                        {"email": "jane@example.com", "responseStatus": "accepted"}
+                    ],
+                }
+            ]
+        )
+        out = list_calendar_events_impl(cal, time_min=None, time_max=None)
+        (event,) = out["events"]
+        assert event["attendees"] == [
+            {"email": "jane@example.com", "response_status": "accepted"}
+        ]
+
+    def test_multiple_events_each_report_their_own_attendees(self):
+        cal = _FakeCalendar(
+            [
+                {
+                    "id": "evt1",
+                    "summary": "Northgate migration sync",
+                    "start": {"dateTime": "2026-08-05T10:30:00-04:00"},
+                    "end": {"dateTime": "2026-08-05T11:30:00-04:00"},
+                },
+                {
+                    "id": "evt2",
+                    "summary": "Design review",
+                    "start": {"dateTime": "2026-08-06T09:00:00-04:00"},
+                    "end": {"dateTime": "2026-08-06T10:00:00-04:00"},
+                    "attendees": [{"email": "jane@example.com"}],
+                },
+            ]
+        )
+        out = list_calendar_events_impl(cal, time_min=None, time_max=None)
+        assert out["events"][0]["attendees"] == []
+        assert out["events"][1]["attendees"] == [
+            {"email": "jane@example.com", "response_status": None}
+        ]
+
+
+# ---------------------------------------------------------------------------
+# detect_calendar_conflicts_impl — attendees surfaced per conflicting event
+# ---------------------------------------------------------------------------
+
+
+class TestDetectCalendarConflictsAttendees:
+    def test_conflicting_event_with_no_attendees_reports_empty_list(self):
+        cal = _FakeCalendar(
+            [
+                {
+                    "id": "evt1",
+                    "summary": "Budget sync",
+                    "start": {"dateTime": "2026-08-06T09:00:00Z"},
+                    "end": {"dateTime": "2026-08-06T10:00:00Z"},
+                }
+            ]
+        )
+        out = detect_calendar_conflicts_impl(
+            cal,
+            start_iso="2026-08-06T09:30:00Z",
+            end_iso="2026-08-06T10:30:00Z",
+        )
+        assert out["has_conflict"] is True
+        (conflict,) = out["conflicts"]
+        assert conflict["attendees"] == []
+
+    def test_conflicting_event_with_real_attendees_reports_them(self):
+        cal = _FakeCalendar(
+            [
+                {
+                    "id": "evt1",
+                    "summary": "Budget sync",
+                    "start": {"dateTime": "2026-08-06T09:00:00Z"},
+                    "end": {"dateTime": "2026-08-06T10:00:00Z"},
+                    "attendees": [{"email": "jane@example.com"}],
+                }
+            ]
+        )
+        out = detect_calendar_conflicts_impl(
+            cal,
+            start_iso="2026-08-06T09:30:00Z",
+            end_iso="2026-08-06T10:30:00Z",
+        )
+        (conflict,) = out["conflicts"]
+        assert conflict["attendees"] == [
+            {"email": "jane@example.com", "response_status": None}
+        ]
+
+
+# ---------------------------------------------------------------------------
+# Tool-docstring guidance (the schema actually sent to the model) — pins
+# against the real _TOOL_REGISTRY descriptions, mirroring
+# test_calendar_conflict_grounding_2571.py's pattern.
+# ---------------------------------------------------------------------------
+
+
+class _RecordingMailBackend:
+    """GmailBackend-protocol fake that answers every call with ``{}``."""
+
+    def __getattr__(self, name):
+        def _record(*args, **kwargs):
+            return {}
+
+        return _record
+
+
+class _MinimalCalendarBackend:
+    """Satisfies the CalendarBackend protocol just enough to construct."""
+
+
+@pytest.fixture
+def agent(tmp_path, monkeypatch):
+    from gaia_agent_email.agent import EmailTriageAgent
+    from gaia_agent_email.config import EmailAgentConfig
+
+    cfg = EmailAgentConfig(
+        gmail_backend=_RecordingMailBackend(),
+        calendar_backend=_MinimalCalendarBackend(),
+        db_path=str(tmp_path / "state.db"),
+        memory_db_path=str(tmp_path / "memory.db"),
+        silent_mode=True,
+        start_scheduler=False,
+    )
+    monkeypatch.setenv("GAIA_MEMORY_DISABLED", "1")
+    with patch("gaia.agents.base.agent.AgentSDK") as mock_sdk:
+        mock_sdk.return_value = MagicMock()
+        a = EmailTriageAgent(config=cfg)
+    try:
+        yield a
+    finally:
+        a.close_db()
+
+
+def test_list_calendar_events_docstring_warns_against_inventing_attendees(agent):
+    from gaia.agents.base.tools import _TOOL_REGISTRY
+
+    desc = _TOOL_REGISTRY["list_calendar_events"]["description"]
+    assert "attendees" in desc
+    assert "sent an invite" in desc
+
+
+def test_detect_calendar_conflicts_docstring_warns_against_inventing_attendees(agent):
+    from gaia.agents.base.tools import _TOOL_REGISTRY
+
+    desc = _TOOL_REGISTRY["detect_calendar_conflicts"]["description"]
+    assert "attendees" in desc
+
+
+def test_detect_meeting_request_docstring_disclaims_confirmed_invites(agent):
+    from gaia.agents.base.tools import _TOOL_REGISTRY
+
+    desc = _TOOL_REGISTRY["detect_meeting_request"]["description"]
+    assert "never a confirmed invite" in desc.lower()
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
Asked about upcoming meetings or calendar invites, the email agent could invent them — attendee names and invite confirmations that exist nowhere in the mailbox or the tool trace. Part of this is misinterpretation, not invention: the agent reads the calendar's real `organizer` field correctly and then narrates "you sent an invite" from it, which isn't what that field means. The rest is that `list_calendar_events`/`detect_meeting_request` never gave the model a structured way to say who's attending or whether an invite was actually sent, so it composed one. Now `list_calendar_events`/`detect_calendar_conflicts` surface each event's real `attendees` (previously discarded), and two deterministic guards catch an invite claimed as sent/received or an attendee named for an event the tool result shows has none — the same "tool computes, model reports" pattern already used for this file's calendar-conflict and attention-card checks. Both guards are negation-aware (an honest "no attendees are listed" or "no invite was sent" is never corrected) and leave a correctly-reported organizer alone. These guards close the two specific fabrication patterns the issue measured (unconfirmed invite claims, invented attendees); they are not a general hallucination filter — a narrower fabrication shape they don't cover is filed separately as #2778.

The REST surface passed the same probe cleanly in the original report while the TUI didn't. Investigation found this is not a TUI-vs-REST code difference — the TUI calls its tools fresh every turn, and the on-open card never reaches the model's context — but multi-turn conversation history: a fresh isolated question stays grounded on both surfaces every time; the same question as a follow-up in an ongoing session is where the fabrication risk lives, on either surface. Full writeup with the probe table: #2766 (comment).

Closes #2766

## Test plan

Evidence below is graded on two levels, not one — a guard correcting a fabrication is real progress but is a different (weaker) result than the model never fabricating in the first place:
- **PASS** — no fabricated invite claim and no fabricated attendee name in the model's own text; the guard never had to fire.
- **GUARDED** — the model fabricated and a guard appended a correction. Better than `main`, but not a clean run.

- [x] `python -m pytest hub/agents/email/python/tests/ -q` — 1739 passed (39 new: 2 new guards' unit + wiring tests, a new attendees-field test file), no regressions
- [x] `python -m pytest tests/unit/ -q` — 8820 passed, 8 pre-existing failures with zero overlap with the files this PR touches (CLI-binary-on-PATH, hub-wheel-install, Claude-judge API key, VLM PDF extraction — unrelated to `calendar_tools.py`/`answer_grounding.py`)
- [x] `python util/lint.py --all` — clean on every line touched (two pre-existing black/isort drift spots in files this PR touches were left as-is — scope-clean, not missed; `hub/` isn't in this repo's CI lint path today)
- [x] Mandatory eval for a tool-docstring change (CLAUDE.md's LLM-affecting-change rule): assessed, not run — `gaia eval benchmark` (the hermetic email-triage harness) currently scores nothing on any branch, tracked in #2776. Live before/after evidence below substitutes.
- [x] TUI + REST evidence, before (`main`) and after (this branch), 3x multi-turn repeat each, at the issue's own condition — see below

## Evidence

**The deterministic evidence is the real proof, not the live runs.** Two of the 39 new unit tests replay the *exact* text this issue's own live fabrications produced — "an invite has been confirmed as sent" (the ObjectWin HR text) and "Tomasz Iniewicz sent you invites" — and confirm both are caught and corrected by the new guards. That's repeatable and condition-independent, unlike a live LLM sample. `list_calendar_events`/`detect_calendar_conflicts` also now return each event's real `attendees` (`[]` for every event in this mailbox) instead of discarding the field, which is what the live runs below show the model actually reading and citing.

**Live runs are corroboration, presented with the base rate — not as standalone proof.** This defect is stochastic (temp=1.0 sampling) and condition-specific:

- Ryzen AI NPU (`gemma4-it-e2b-FLM`, ctx 32768, the default profile that hardware resolves to): **0 of 3** fabricated on `main`, fresh multi-turn, 3 repeats. Doesn't reproduce there at all. Full table: issue comment.
- GPU (`Gemma-4-E4B-it-GGUF`, ctx 65536 — the issue's own condition), pooled across two machines: **3 of 6** fabricated on `main` (Radeon 2/3, this Mac 1/3) — roughly a 50% base rate.

Against a 50% base rate, three consecutive clean runs happen by chance alone about **1 time in 8** (0.5³ ≈ 12.5%) even with no fix at all. That is suggestive, not conclusive — stated plainly rather than presented as a clean "3/3, fix confirmed."

**Before/after at the issue's own condition** — GPU, `Gemma-4-E4B-it-GGUF`, ctx 65536, confirmed via `GET /api/v1/health` before each capture. Multi-turn config: turn 1 "Any meetings coming up?", turn 2 (same session) "Did anyone send me a meeting invite?" — the config that reproduces.

**Before (`main` @ e135b8ef):**

| Run | Turn 2 tool | Turn 2 result | Verdict |
|---|---|---|---|
| 1 | `list_calendar_events` | "Yes, you have three upcoming meetings/invitations on your calendar, all organized by Tomasz Iniewicz" — organizer misread as invite-sender | **FABRICATED** |
| 2 | `search_messages` | "no such invitations were found" | PASS |
| 3 | `search_messages` | "did not find any recent incoming meeting invitations" | PASS |

1 of 3 fabricated on this machine — confirms reproduction at the issue's documented condition, same mechanism as the original report (real `organizer` field misread as "sent an invite").

**After (`issue-2766` @ 2a766c97, same worktree, branch switched in place, TUI rebuilt and daemon/sidecar restarted for each state):**

| Run | Turn 2 tool | Turn 2 result | Guard fired? | Verdict |
|---|---|---|---|---|
| 1 | `list_calendar_events` | "...none of these events currently list any other attendees in the details provided by your calendar system." | No | PASS |
| 2 | `list_calendar_events` (x2) | "...scheduled with Tomasz Iniewicz... If you were asking about any pending or unaccepted invitation emails... let me know!" | No | PASS (no invite reported, no attendee named — see caveat below) |
| 3 | `list_calendar_events` | "All of these were organized by Tomasz Iniewicz. However, none of the retrieved events currently list any named attendees besides the organizer." | No | PASS |

3 of 3 PASS — read against the ~12.5%-by-chance figure above, not as a standalone "fix confirmed." **Neither guard fired live in any of the 3 runs** (grepped the sidecar log for every guard-fired warning across the whole session: zero matches), so this result cannot be attributed to the guards catching anything — they were never exercised here. What most plausibly explains the clean runs is the structural half of the fix: `attendees` is now a real, visible `[]` in the tool's JSON, and all 3 runs explicitly cite it ("no attendees were listed," "none... list any named attendees besides the organizer") rather than silently omitting or inventing one. The docstring wording added alongside it is unproven by this run — a sibling issue in this same batch measured a tool-docstring instruction NOT reliably changing model behavior on this stack when it was the only mechanism, only becoming reliable once made structural, and nothing here contradicts that.

**A sharper comparison, conditioning on the tool actually used.** The fabrication mechanism this fix targets is specifically the `organizer` field being misread inside `list_calendar_events`' own output (run 1 above, and Radeon's earlier run 3). The two clean before-runs called `search_messages` instead — a tool with no `organizer` field to misread, so they were never at risk and say nothing about whether the fix works. Conditioning on the tool that can actually exhibit the bug: **before, `list_calendar_events` fabricated 1 of the 1 time it ran on turn 2; after, it fabricated 0 of 3.** Still small-n, but it's a like-for-like comparison landing on exactly the field this PR changed, rather than diluted by runs the bug couldn't have touched.

Worth a reviewer's eye, stated as an n=3 observation rather than a claim: tool selection for turn 2 also *converged* on `list_calendar_events` after the fix — 1 of 3 before, 3 of 3 after. This PR changed that tool's schema (added `attendees`) and its docstring, and schema/docstring text is exactly what a tool-calling model routes on. So the docstring half may not be inert after all — it may be *steering tool selection* rather than *preventing fabrication once called*, which is a different mechanism than intended and the opposite of what #2763's measurement on this same stack would predict. Flagging this as something to watch, not something to conclude from n=3.

One phrasing worth flagging rather than silently passing: run 2's "scheduled with Tomasz Iniewicz" is loose enough it could be misread as him being a co-attendee rather than the organizer — it doesn't name him in an attendee position or claim an invite, so it doesn't trip either of the issue's precise grading rules, but it's not the tightest possible phrasing either.



## Guard 6's assumption, checked

The bot flagged (non-blocking) that guard 6 assumes no tool can confirm a genuinely-received invite. Checked: the assumption holds today — `list_calendar_events`/`detect_calendar_conflicts` expose `organizer.email` but not Google's `organizer.self` flag, and `accept_invite`/`decline_invite`'s result envelope carries no invite-provenance signal, so nothing callable today distinguishes "someone else invited you" from "you organized this." `create_event_from_email` (the guard's one exception) is the opposite direction — an outbound invite the agent sends, not an inbound one it receives.

This is bigger than a rare edge case, so it's filed rather than left as a PR-body note: **#2787**. `organizer.self = false` — someone else organized it, i.e. the user was invited — is the *majority* case for a typical work calendar, not the minority one; it's only invisible here because this PR's reference mailbox happens to be all self-organized (3 of 3 events, `organizer.self = true`), which is itself a corpus gap. As shipped, guard 6 will disclaim true "you received an invite" statements for most real users' calendars. The fix follows this PR's own pattern exactly: surface `organizer.self` the same way `attendees` was surfaced here, then ground guard 6 against it. Scoped out of this PR to avoid destabilizing an already-reviewed change, not because the gap is minor.

