### PR TITLE
fix(email-agent): get_thread renders a table card instead of relying on model prose

### DIFF
--- a/hub/agents/email/python/CHANGELOG.md
+++ b/hub/agents/email/python/CHANGELOG.md
@@ -9,6 +9,19 @@ contract version is tracked separately as
 
 ### Fixed
 
+- **`get_thread` invented messages, senders, and timestamps that were never
+  in the mailbox (#2765).** Asked to catch up on a conversation, the agent
+  could hand back a duplicated message, another replaced by a repeat of an
+  earlier one, a misattributed sender, and a timestamp that existed nowhere
+  in the thread — even though `get_thread`'s own payload was already
+  ordered, numbered, and carried each message's real `from`/`date` (#2531).
+  The fabrication happened in the model's own free-composed prose, on top
+  of a correct payload, so no docstring instruction alone could fix it. The
+  registered `get_thread` tool now also returns a `kind: "table"` render
+  card — the Agent UI's pre-existing generic primitive, no new client code
+  — built directly from the same per-message fields the model reads, so
+  the chat surface draws every sender and timestamp straight from the
+  mailbox instead of from the model's reconstruction of it.
 - **`search_messages` stated a wrong, unstable count for a result set it
   received intact (#2756).** Asked "how many messages from X in the last two
   weeks", the agent ran the right query, got every matching row back, then

--- a/hub/agents/email/python/gaia_agent_email/sse_translation.py
+++ b/hub/agents/email/python/gaia_agent_email/sse_translation.py
@@ -55,10 +55,14 @@ from typing import Any, Dict, List, Optional
 # Mirrors ``gaia.ui.sse_handler.SSEOutputHandler._RENDER_TOOL_TO_LANG`` — the
 # tool→card-key map that tells the host which typed ``tool_result.render`` card to
 # draw (spec §4.2, replacing the #1000 fence-injection hack). Duplicated (not
-# imported) to keep this module free of the ``gaia.ui`` import chain; the email
-# agent's only render tool today is the inbox pre-scan.
+# imported) to keep this module free of the ``gaia.ui`` import chain; a test
+# (``test_render_tool_to_lang_maps_stay_in_sync``) pins the two dicts equal so
+# this duplication can't silently drift.
 _RENDER_TOOL_TO_LANG: Dict[str, str] = {
     "pre_scan_inbox": "email_pre_scan",
+    # #2765: a generic ``table`` card (no new client code) so the thread
+    # view renders straight from tool data instead of model prose.
+    "get_thread": "table",
 }
 
 # HTTP-style status codes for the canonical ``error`` event's ``status`` field.

--- a/hub/agents/email/python/gaia_agent_email/tools/read_tools.py
+++ b/hub/agents/email/python/gaia_agent_email/tools/read_tools.py
@@ -336,6 +336,42 @@ def get_thread_impl(gmail, *, thread_id: str, debug: bool = False) -> Dict[str, 
         return {"thread_id": thread_id, "messages": out}
 
 
+def _thread_table_card(thread_result: Dict[str, Any]) -> Dict[str, Any]:
+    """Project ``get_thread_impl``'s output into a ``table`` render card (#2765).
+
+    #2765: a real 8-message thread came back from the agent with a
+    duplicated message, another message replaced by a repeat of an earlier
+    one, a misattributed sender, and a timestamp (``11:40 AM +0000``) that
+    existed nowhere in the mailbox or the tool's own trace -- i.e. the raw
+    ``get_thread_impl`` payload (already ordered/numbered/labeled per
+    #2531) was correct, and the fabrication happened in the model's own
+    free-composed prose reply, upstream of any formatting layer.
+
+    A docstring instruction alone cannot fix that -- the payload was
+    already complete and correct and the model invented anyway. So this
+    hands the chat surface a card it renders DIRECTLY from tool data
+    (``kind: "table"``, the pre-existing generic render primitive --
+    ``docs/spec/agent-ui-query-sse-contract.md`` Sec 4.3 -- no new client
+    code) instead of from the model's prose. Every cell is copied verbatim
+    from the SAME ``from``/``date``/``index`` fields the model itself
+    reads (no reformatting, no timezone conversion), so what renders on
+    screen cannot diverge from what the tool actually returned, regardless
+    of anything the model goes on to say.
+    """
+    messages = thread_result.get("messages", [])
+    subject = (messages[0].get("subject") if messages else "") or "Thread"
+    count = len(messages)
+    title = f"{subject} — {count} message{'s' if count != 1 else ''}"
+    return {
+        "kind": "table",
+        "title": title,
+        "columns": ["#", "From", "Date"],
+        "rows": [
+            [m.get("index"), m.get("from", ""), m.get("date", "")] for m in messages
+        ],
+    }
+
+
 def _thread_message_sort_key(msg: Dict[str, Any]) -> int:
     """Chronological sort key for a raw thread message.
 
@@ -2513,6 +2549,9 @@ class ReadToolsMixin:
         def get_thread(thread_id: str, mailbox: str = "") -> str:
             """Fetch every message in a thread (conversation view).
 
+            Use this to catch the user up on, recap, or answer a question
+            about one email conversation.
+
             Messages are returned sorted chronologically (oldest first) and
             each carries ``index``/``of_total`` (its 1-based position in the
             thread) — use these, not the raw list order, when listing or
@@ -2521,12 +2560,24 @@ class ReadToolsMixin:
             ``...[truncated]`` marker; messages are never dropped.
             ``mailbox`` (optional) routes when multiple mailboxes are
             connected.
+
+            The chat surface renders a table card straight from this result
+            (``kind: "table"``) showing every message's real sender and
+            timestamp, in order — do NOT re-list, re-serialize, or
+            paraphrase that list into your reply; it is already visible to
+            the user (#2765). Answer what the user actually asked — what
+            was decided, what's still open, where the conversation landed —
+            by reading each message's body, not by reciting the thread.
+            Any sender or timestamp you DO mention in your own prose must
+            be copied VERBATIM from that message's ``from``/``date``
+            field — never estimate, convert, average, or reconstruct one
+            from memory; if you are not quoting one of those fields
+            directly, do not state a sender or a time at all.
             """
             try:
                 backend = agent._backend_for_message(thread_id, mailbox or None)
-                return _envelope_ok(
-                    get_thread_impl(backend, thread_id=thread_id, debug=debug_flag)
-                )
+                result = get_thread_impl(backend, thread_id=thread_id, debug=debug_flag)
+                return _envelope_ok({**result, **_thread_table_card(result)})
             except ConnectorsError as exc:
                 return _envelope_err(format_connector_error(exc))
             except Exception as exc:

--- a/hub/agents/email/python/tests/test_get_thread_table_card_2765.py
+++ b/hub/agents/email/python/tests/test_get_thread_table_card_2765.py
@@ -1,0 +1,336 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""``get_thread`` table render-card tests for #2765.
+
+A real 8-message thread came back from the agent with a duplicated message,
+another replaced by a repeat of an earlier one, a misattributed sender, and
+an invented timestamp (``11:40 AM +0000``) that existed nowhere in the
+mailbox -- even though ``get_thread_impl``'s payload was already ordered,
+numbered, and carried each message's real ``from``/``date`` (#2531, merged
+2026-07-28, six days before this issue was filed). The fabrication happened
+in the model's own free-composed prose, upstream of the tool payload -- so a
+docstring instruction alone cannot fix it: the payload was already complete
+and correct and the model invented anyway.
+
+The fix: ``get_thread`` now hands the chat surface a ``kind: "table"`` card
+(the pre-existing generic render primitive -- no new TUI/Go code, see
+``tui/internal/ui/cards/primitives.go::renderTable``) built directly from
+the SAME per-message ``from``/``date``/``index`` fields the model reads. The
+surface draws the card straight from tool data, never from model prose, so
+a fabricated sender or timestamp is structurally impossible in the
+rendered card regardless of anything the model goes on to say.
+
+Layer isolation: ``get_thread_impl`` itself is UNCHANGED by this issue (see
+``test_get_thread_chronology_2531.py`` / ``test_read_tools_thread_budget.py``,
+both still green, unmodified) -- every test here exercises either the new
+pure ``_thread_table_card`` projection or the REGISTERED ``get_thread`` tool
+closure, which is where the card fields are merged into the envelope.
+
+Hermetic: ``FakeGmailBackend`` only, no Lemonade, no network.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any, Dict, List
+
+import pytest
+
+# parents[0] = tests/, [1] = python/, [2] = email/, [3] = agents/, [4] = hub/,
+# [5] = repo-root
+_REPO_ROOT = Path(__file__).resolve().parents[5]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+pytest.importorskip("gaia_agent_email")
+
+from gaia_agent_email.tools.read_tools import (  # noqa: E402
+    ReadToolsMixin,
+    _thread_table_card,
+    get_thread_impl,
+)
+
+from gaia.agents.base.tools import _TOOL_REGISTRY  # noqa: E402
+from tests.fixtures.email.fake_gmail import FakeGmailBackend  # noqa: E402
+
+# ---------------------------------------------------------------------------
+# Fixture helpers (mirrors test_get_thread_chronology_2531.py)
+# ---------------------------------------------------------------------------
+
+
+def _b64url(text: str) -> str:
+    return base64.urlsafe_b64encode(text.encode("utf-8")).decode("ascii").rstrip("=")
+
+
+def _msg(
+    msg_id: str,
+    *,
+    thread_id: str,
+    sender: str,
+    internal_date_ms: int,
+    date_header: str,
+    subject: str = "Contributing to GAIA",
+) -> Dict[str, Any]:
+    body = f"body of {msg_id}"
+    return {
+        "id": msg_id,
+        "threadId": thread_id,
+        "labelIds": ["INBOX"],
+        "snippet": body[:200],
+        "internalDate": str(internal_date_ms),
+        "payload": {
+            "mimeType": "text/plain",
+            "filename": "",
+            "headers": [
+                {"name": "Subject", "value": subject},
+                {"name": "From", "value": sender},
+                {"name": "To", "value": "user@example.com"},
+                {"name": "Date", "value": date_header},
+            ],
+            "body": {"data": _b64url(body), "size": len(body)},
+        },
+        "sizeEstimate": len(body),
+    }
+
+
+_ALICE = "alice@example.com"
+_BOB = "bob@example.org"
+_THREAD_ID = "thread-verbatim-card"
+
+# 5 messages, strict sent/received alternation -- the exact shape the issue
+# says makes ordering/attribution errors obvious.
+_BASE_MS = 1_800_000_000_000
+_MESSAGES: List[Dict[str, Any]] = [
+    _msg(
+        f"m{i}",
+        thread_id=_THREAD_ID,
+        sender=_ALICE if i % 2 == 1 else _BOB,
+        internal_date_ms=_BASE_MS + offset_ms,
+        date_header=date_header,
+    )
+    for i, (offset_ms, date_header) in enumerate(
+        [
+            (0, "Mon, 27 Jul 2026 18:00:00 -0700"),
+            (10 * 60_000, "Mon, 27 Jul 2026 18:10:00 -0700"),
+            (25 * 60_000, "Mon, 27 Jul 2026 18:25:00 -0700"),
+            (40 * 60_000, "Mon, 27 Jul 2026 18:40:00 -0700"),
+            (48 * 60_000, "Mon, 27 Jul 2026 18:48:00 -0700"),
+        ],
+        start=1,
+    )
+]
+
+
+def _seeded_backend(msgs: List[Dict[str, Any]]) -> FakeGmailBackend:
+    gmail = FakeGmailBackend(user_email="user@example.com")
+    for m in msgs:
+        gmail.add_message(m)
+    return gmail
+
+
+# ---------------------------------------------------------------------------
+# Minimal tool-hosting stand-in (copied pattern from
+# test_read_tools_thread_budget.py / test_search_messages_count_2756.py)
+# ---------------------------------------------------------------------------
+
+
+class _Host(ReadToolsMixin):
+    """Minimal stand-in for EmailTriageAgent's tool-hosting surface."""
+
+    def __init__(self, backend: FakeGmailBackend):
+        self._gmail = backend
+        self._backends = {"google": backend}
+        self._message_mailbox: Dict[str, str] = {}
+        self.config = SimpleNamespace(debug=False)
+
+    def _remember_message_mailbox(self, message_id, provider):
+        if message_id:
+            self._message_mailbox[message_id] = provider
+
+    def _backend_for_message(self, message_id, explicit_mailbox=None):
+        provider = explicit_mailbox or self._message_mailbox.get(message_id)
+        if provider is None:
+            if len(self._backends) == 1:
+                return next(iter(self._backends.values()))
+            raise ValueError("ambiguous mailbox in test stub")
+        backend = self._backends.get(provider)
+        if backend is None:
+            raise ValueError("mailbox not connected in test stub")
+        return backend
+
+
+def _registered_get_thread(host: _Host):
+    _TOOL_REGISTRY.clear()
+    host._register_read_tools()
+    assert "get_thread" in _TOOL_REGISTRY
+    return _TOOL_REGISTRY["get_thread"]["function"]
+
+
+def _call(get_thread, **kwargs) -> Dict[str, Any]:
+    payload = json.loads(get_thread(**kwargs))
+    assert payload["ok"] is True, payload
+    return payload["data"]
+
+
+# ---------------------------------------------------------------------------
+# _thread_table_card -- pure projection, no agent/tool machinery
+# ---------------------------------------------------------------------------
+
+
+class TestThreadTableCardProjection:
+    def test_kind_is_table(self):
+        gmail = _seeded_backend(_MESSAGES)
+        result = get_thread_impl(gmail, thread_id=_THREAD_ID)
+
+        card = _thread_table_card(result)
+
+        assert card["kind"] == "table"
+
+    def test_columns_are_hash_from_date(self):
+        gmail = _seeded_backend(_MESSAGES)
+        result = get_thread_impl(gmail, thread_id=_THREAD_ID)
+
+        card = _thread_table_card(result)
+
+        assert card["columns"] == ["#", "From", "Date"]
+
+    def test_row_count_matches_message_count(self):
+        gmail = _seeded_backend(_MESSAGES)
+        result = get_thread_impl(gmail, thread_id=_THREAD_ID)
+
+        card = _thread_table_card(result)
+
+        assert len(card["rows"]) == 5
+
+    def test_every_row_is_verbatim_from_the_source_message_no_reconstruction(self):
+        """The load-bearing assertion: each row's (index, from, date) must be
+        an EXACT copy of the corresponding message's own fields -- never a
+        reformatted, converted, or otherwise recomputed value. This is the
+        direct regression guard for #2765's invented '11:40 AM +0000': that
+        value cannot appear here because nothing in this path reformats a
+        date string, it is only ever copied.
+        """
+        gmail = _seeded_backend(_MESSAGES)
+        result = get_thread_impl(gmail, thread_id=_THREAD_ID)
+
+        card = _thread_table_card(result)
+
+        for row, message in zip(card["rows"], result["messages"]):
+            assert row == [message["index"], message["from"], message["date"]]
+
+    def test_ground_truth_cross_check_against_the_raw_seeded_headers(self):
+        """Cross-checks the card against the RAW seeded fixture headers (not
+        just against get_thread_impl's own output) -- ground truth fetched
+        independently of the code path under test, per the run's evidence
+        protocol.
+        """
+        gmail = _seeded_backend(_MESSAGES)
+        result = get_thread_impl(gmail, thread_id=_THREAD_ID)
+        card = _thread_table_card(result)
+
+        raw_by_id = {m["id"]: m for m in _MESSAGES}
+        for row, message in zip(card["rows"], result["messages"]):
+            raw = raw_by_id[message["id"]]
+            raw_headers = {
+                h["name"].lower(): h["value"] for h in raw["payload"]["headers"]
+            }
+            assert row[1] == raw_headers["from"]
+            assert row[2] == raw_headers["date"]
+
+    def test_title_names_subject_and_count(self):
+        gmail = _seeded_backend(_MESSAGES)
+        result = get_thread_impl(gmail, thread_id=_THREAD_ID)
+
+        card = _thread_table_card(result)
+
+        assert "Contributing to GAIA" in card["title"]
+        assert "5" in card["title"]
+
+    def test_empty_thread_produces_a_valid_zero_row_card(self):
+        card = _thread_table_card({"thread_id": "empty", "messages": []})
+
+        assert card["kind"] == "table"
+        assert card["rows"] == []
+
+
+# ---------------------------------------------------------------------------
+# Registered tool surface -- envelope shape + docstring contract
+# ---------------------------------------------------------------------------
+
+
+class TestRegisteredGetThreadEnvelopeCarriesTheCard:
+    def test_envelope_data_has_kind_table(self):
+        gmail = _seeded_backend(_MESSAGES)
+        host = _Host(gmail)
+        get_thread = _registered_get_thread(host)
+
+        data = _call(get_thread, thread_id=_THREAD_ID)
+
+        assert data["kind"] == "table"
+        assert data["columns"] == ["#", "From", "Date"]
+        assert len(data["rows"]) == 5
+
+    def test_full_messages_list_is_still_present_for_the_model(self):
+        """The card is additive -- the model must still get the full
+        messages (with bodies) it needs to actually answer the user's
+        question, not just the card's skeleton."""
+        gmail = _seeded_backend(_MESSAGES)
+        host = _Host(gmail)
+        get_thread = _registered_get_thread(host)
+
+        data = _call(get_thread, thread_id=_THREAD_ID)
+
+        assert "messages" in data
+        assert len(data["messages"]) == 5
+        assert all("body" in m for m in data["messages"])
+
+    def test_card_rows_match_the_messages_list_verbatim(self):
+        gmail = _seeded_backend(_MESSAGES)
+        host = _Host(gmail)
+        get_thread = _registered_get_thread(host)
+
+        data = _call(get_thread, thread_id=_THREAD_ID)
+
+        for row, message in zip(data["rows"], data["messages"]):
+            assert row == [message["index"], message["from"], message["date"]]
+
+
+class TestDocstringInstructsCardAwarenessAndVerbatimFields:
+    def test_description_mentions_verbatim(self):
+        _TOOL_REGISTRY.clear()
+        host = _Host(_seeded_backend(_MESSAGES))
+        host._register_read_tools()
+
+        description = _TOOL_REGISTRY["get_thread"]["description"] or ""
+
+        assert "VERBATIM" in description
+
+    def test_description_tells_the_model_not_to_relist_the_card(self):
+        _TOOL_REGISTRY.clear()
+        host = _Host(_seeded_backend(_MESSAGES))
+        host._register_read_tools()
+
+        description = _TOOL_REGISTRY["get_thread"]["description"] or ""
+        normalized = " ".join(description.split())
+
+        assert "already visible to the user" in normalized
+
+    def test_description_still_mentions_truncated_marker(self):
+        """Regression guard for #2073's AC4 (test_read_tools_thread_budget.py
+        S1) -- the pre-existing truncation-marker instruction must survive
+        this docstring rewrite."""
+        _TOOL_REGISTRY.clear()
+        host = _Host(_seeded_backend(_MESSAGES))
+        host._register_read_tools()
+
+        description = _TOOL_REGISTRY["get_thread"]["description"] or ""
+
+        assert "[truncated]" in description
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/hub/agents/email/python/tests/test_read_tools_thread_budget.py
+++ b/hub/agents/email/python/tests/test_read_tools_thread_budget.py
@@ -69,6 +69,7 @@ from gaia_agent_email.tools.read_tools import (  # noqa: E402
     UNTRUSTED_BODY_OPEN,
     ReadToolsMixin,
     _format_message_for_llm,
+    _thread_table_card,
     get_thread_impl,
     wrap_untrusted_body,
 )
@@ -311,6 +312,13 @@ class TestWireLevelByteIdentity:
         must equal ``_envelope_ok({...})`` byte-for-byte — not just
         structurally-equal-after-parsing. Pins AC3's "byte-identical" claim
         at the actual wire, not just dict equality.
+
+        The expected envelope now also carries the #2765 table-card fields
+        (``kind``/``title``/``columns``/``rows``), computed via the SAME
+        ``_thread_table_card`` helper production code uses — so this stays
+        a real regression pin on "the budget-shrink path doesn't corrupt
+        message content OR the card projected from it", not a hand-typed
+        guess that happens to match today's output.
         """
         from gaia_agent_email.tools.envelope import _envelope_ok
 
@@ -321,11 +329,12 @@ class TestWireLevelByteIdentity:
         get_thread = _registered_get_thread(host)
 
         actual = get_thread(thread_id="t1")
+        expected_result = {
+            "thread_id": "t1",
+            "messages": _expected_thread_output(msgs),
+        }
         expected = _envelope_ok(
-            {
-                "thread_id": "t1",
-                "messages": _expected_thread_output(msgs),
-            }
+            {**expected_result, **_thread_table_card(expected_result)}
         )
         assert actual == expected
 

--- a/hub/agents/email/python/tests/test_render_tool_to_lang_sync_2765.py
+++ b/hub/agents/email/python/tests/test_render_tool_to_lang_sync_2765.py
@@ -1,0 +1,57 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""``_RENDER_TOOL_TO_LANG`` cross-package drift guard (#2765).
+
+The tool→card-key map exists in TWO places — ``gaia.ui.sse_handler.
+SSEOutputHandler._RENDER_TOOL_TO_LANG`` (Agent UI / REST-facing) and
+``gaia_agent_email.sse_translation._RENDER_TOOL_TO_LANG`` (the sidecar's
+dependency-light canonical translator, which duplicates rather than imports
+the first to avoid pulling in the ``gaia.ui`` import chain) — with a
+source comment on both sides saying "keep both in sync". A comment is a
+hope, not a guarantee: this test converts it into a failing assertion the
+day one side is updated without the other, which is exactly the drift mode
+that would silently break card rendering on one surface while leaving the
+other correct.
+
+Kept in its own file (not ``test_sse_translation.py``, which is explicitly
+"dependency-light: no ... gaia.ui needed") so that file's stated scope
+stays true — this one alone carries the cross-package import.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+# parents[0] = tests/, [1] = python/, [2] = email/, [3] = agents/, [4] = hub/,
+# [5] = repo-root
+_REPO_ROOT = Path(__file__).resolve().parents[5]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+pytest.importorskip("gaia_agent_email")
+pytest.importorskip("gaia.ui.sse_handler")
+
+from gaia_agent_email.sse_translation import (  # noqa: E402
+    _RENDER_TOOL_TO_LANG as _SIDECAR_MAP,
+)
+
+from gaia.ui.sse_handler import SSEOutputHandler  # noqa: E402
+
+
+class TestRenderToolToLangMapsStayInSync:
+    def test_render_tool_to_lang_maps_stay_in_sync(self):
+        assert _SIDECAR_MAP == SSEOutputHandler._RENDER_TOOL_TO_LANG
+
+    def test_get_thread_is_registered_as_a_table_card_on_both_sides(self):
+        """#2765: get_thread must render a card on EITHER surface reaching
+        it -- the sidecar (TUI/REST) map and the Agent UI map both need the
+        entry, not just one."""
+        assert _SIDECAR_MAP["get_thread"] == "table"
+        assert SSEOutputHandler._RENDER_TOOL_TO_LANG["get_thread"] == "table"
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/src/gaia/ui/sse_handler.py
+++ b/src/gaia/ui/sse_handler.py
@@ -497,10 +497,14 @@ class SSEOutputHandler(OutputHandler):
     # Mapping from tool name to the card "kind" the frontend's render-card
     # registry draws (spec §4.2). Shared with the sidecar's own canonical
     # translator (``gaia_agent_email/sse_translation.py`` duplicates this map
-    # to stay dependency-light) — keep both in sync when a render tool is
-    # added.
+    # to stay dependency-light) — a test in that package
+    # (``test_render_tool_to_lang_maps_stay_in_sync``) pins the two dicts
+    # equal so the duplication can't silently drift.
     _RENDER_TOOL_TO_LANG: ClassVar[Dict[str, str]] = {
         "pre_scan_inbox": "email_pre_scan",
+        # #2765: a generic ``table`` card (no new client code) so the thread
+        # view renders straight from tool data instead of model prose.
+        "get_thread": "table",
     }
 
     def _render_card_payload(self, data: Any) -> Optional[Dict[str, Any]]:


### PR DESCRIPTION
Catching up on an email thread today depends entirely on the model composing an accurate reply from memory — nothing on screen lets a user check it against the mailbox. `get_thread` now also renders a table card straight from the tool's own data (sender, date, in order) alongside the model's reply, so who-said-what-and-when has a verbatim, checkable record next to it, independent of anything the model goes on to say.

Direct measurement (3 fresh multi-turn sessions, every field diffed against ground truth fetched straight from Gmail) did not reproduce the fabrication this issue describes, on the largest uncontaminated thread available in the test mailbox — see [the writeup on #2765](https://github.com/amd/gaia/issues/2765#issuecomment-5174187822) for the full method and its scope caveat (2 messages, not the 8 the issue documents — every corpus thread caps there once delivered). The card ships regardless: it's a real improvement to auditability whether or not fabrication is actively occurring on a given run.

### Test plan

- [x] `python -m pytest hub/agents/email/python/tests/ tests/unit/ -q` — full suite green (1702 email hub + 8819 core, 9 pre-existing unrelated failures)
- [x] `python util/lint.py --all` — clean
- [x] Live evidence, GPU/`Gemma-4-E4B-it-GGUF`/ctx 65536 (the condition this issue documents, confirmed via Lemonade's `/api/v1/health`): 3 fresh multi-turn TUI sessions on `main`, ground truth fetched directly from Gmail (bypassing the LLM) before each comparison, every field (sender/date/count/body) diffed — 3/3 exact match, no fabrication reproduced
- [x] Structural check on this branch: the table card renders correctly from the same thread — title/columns/rows all verbatim-matching ground truth

### Evidence

<details>
<summary>Ground truth (fetched directly from Gmail, bypassing the LLM)</summary>

```
--- #1/2 ---
from: Tomasz Iniewicz <tomasz.iniewicz@gmail.com>
date: Mon, 3 Aug 2026 19:45:16 -0400
subject: Re: Revised deck — need your numbers by Tuesday
body: Sounds good Sofia. Send me a consolidated list rather than one-offs
      and I'll turn the whole lot around together. T

--- #2/2 ---
from: Tomasz Testingiewicz <tomasz.testingiewicz@outlook.com>
date: Mon, 3 Aug 2026 23:54:41 +0000
subject: Re: Revised deck — need your numbers by Tuesday
body: Here's the consolidated list. Three slides are still on placeholder
      data: Slide 6 — adoption curve... Slide 9 — unit economics...
      Slide 12 — roadmap... Could you get me those by Tuesday?
```

</details>

<details>
<summary>main (before) — run 1 of 3, multi-turn, get_thread confirmed via tool-call log</summary>

```
▶ You: How many unread emails do I have right now?
╭─────────────────────────────────────────────────────────────────╮
│ You currently have 685 unread emails in your inbox. This view   │
│ was a partial scan of your mailbox, covering 50 of your total   │
│ 1,414 messages.                                                 │
╰─────────────────────────────────────────────────────────────────╯
  22.3s · ttft 0.0s · ~35 tokens · 1.6 tok/s · 2 steps · 1 tools

▶ You: Show me every message in the Revised deck thread, in order
╭─────────────────────────────────────────────────────────────────╮
│ Here is every message in the thread "Re: Revised deck — need    │
│ your numbers by Tuesday," listed in chronological order:        │
│                                                                  │
│ 1. From Tomasz Iniewicz tomasz.iniewicz@gmail.com                │
│    (Mon, Aug 3, 2026 at 7:45 PM -0400)                           │
│    Snippet: Sounds good Sofia. Send me a consolidated list       │
│    rather than one-offs and I'll turn the whole lot around       │
│    together. T                                                  │
│                                                                  │
│ 2. From Tomasz Testingiewicz tomasz.testingiewicz@outlook.com    │
│    (Mon, Aug 3, 2026 at 11:54 PM +0000)                          │
│    Snippet: Here's the consolidated list. Three slides are       │
│    still on placeholder data: Slide 6 – adoption curve...        │
╰─────────────────────────────────────────────────────────────────╯
  14.9s · ttft 0.1s · ~226 tokens · 15.2 tok/s · 3 steps · 2 tools
```

Runs 2 and 3: identical field-for-field, run 2 additionally states "This
conversation has two messages in total." — the exact ground-truth count.

</details>

<details>
<summary>this branch (after) — table card renders from the same thread</summary>

```
▶ You: Show me every message in the Revised deck thread, in order
┌─ Re: Revised deck — need your numbers by Tuesday — 2 messages ──────────────┐
│  #  From                                            Date                    │
│  ─  ───────────────────────────────────────────────  ─────────────────────  │
│  1  Tomasz Iniewicz <tomasz.iniewicz@gmail.com>       Mon, 3 Aug 2026        │
│                                                        19:45:16 -0400        │
│  2  Tomasz Testingiewicz <tomasz.testingiewicz@out...> Mon, 3 Aug 2026       │
│                                                        23:54:41 +0000        │
└───────────────────────────────────────────────────────────────────────────┘
╭───────────────────────────────────────────────────────────────────────────╮
│ Here are all the messages in the thread ... listed chronologically:        │
│ 1. From: Tomasz Iniewicz <tomasz.iniewicz@gmail.com>                        │
│    Date: Mon, 3 Aug 2026 19:45:16 -0400                                     │
│ 2. From: Tomasz Testingiewicz <tomasz.testingiewicz@outlook.com>            │
│    Date: Mon, 3 Aug 2026 23:54:41 +0000                                     │
╰───────────────────────────────────────────────────────────────────────────╯
  26.6s · ttft 0.0s · ~220 tokens · 8.3 tok/s · 3 steps · 2 tools
```

Card title, columns, and both rows are byte-verbatim against the ground
truth above.

</details>

---
Closes #2765
