### PR TITLE
fix(ci): validate the STX CMake cache instead of trusting bin/cmake.exe

### DIFF
--- a/.github/scripts/CppBuildTools.ps1
+++ b/.github/scripts/CppBuildTools.ps1
@@ -1,0 +1,305 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+<#
+.SYNOPSIS
+    Cache-validation and install helpers for the C++ toolchain on self-hosted runners.
+
+.DESCRIPTION
+    Dot-sourced by .github/scripts/Ensure-CppBuildTools.ps1 and covered by
+    .github/scripts/tests/CppBuildTools.Tests.ps1. Every function here is pure
+    path/exit-code logic so the decision that broke the STX runner (issue #2817)
+    can be unit tested off Windows.
+
+    Targets Windows PowerShell 5.1 -- the STX job runs `shell: powershell`.
+#>
+
+function Test-IsWindowsHost {
+    # $IsWindows exists in PowerShell 6+. Windows PowerShell 5.1 predates it and
+    # only ever runs on Windows.
+    if (Get-Variable -Name IsWindows -ErrorAction SilentlyContinue) {
+        return [bool](Get-Variable -Name IsWindows -ValueOnly)
+    }
+    return $true
+}
+
+function Get-CMakeExeName {
+    if (Test-IsWindowsHost) { return 'cmake.exe' }
+    return 'cmake'
+}
+
+function Get-CppToolsRoot {
+    <#
+    .SYNOPSIS
+        Directory the job installs its C++ toolchain into.
+
+    .DESCRIPTION
+        Deliberately NOT $env:TEMP. Windows Temp cleanup on the self-hosted STX
+        runner deleted half of a cached CMake install and left the rest, which is
+        what issue #2817 was. RUNNER_TOOL_CACHE lives under the runner's work
+        directory, is not swept by the OS, and persists between jobs.
+    #>
+    if (-not [string]::IsNullOrWhiteSpace($env:GAIA_CI_TOOLS_DIR)) {
+        return $env:GAIA_CI_TOOLS_DIR
+    }
+    if (-not [string]::IsNullOrWhiteSpace($env:RUNNER_TOOL_CACHE)) {
+        return (Join-Path $env:RUNNER_TOOL_CACHE 'gaia-cpp')
+    }
+    throw ("No persistent tools directory available: neither GAIA_CI_TOOLS_DIR nor " +
+           "RUNNER_TOOL_CACHE is set. Set GAIA_CI_TOOLS_DIR to a directory the runner " +
+           "keeps between jobs (do NOT use TEMP -- see issue #2817), or run this from a " +
+           "GitHub Actions job where RUNNER_TOOL_CACHE is defined.")
+}
+
+function Get-CMakeInstallDir {
+    # Single source of truth for the install path: the cache lookup in
+    # Ensure-CppBuildTools.ps1 and the extraction in Install-CMake must agree, or
+    # the cache silently never hits and every run re-downloads.
+    param(
+        [Parameter(Mandatory)][string]$Version,
+        [Parameter(Mandatory)][string]$ToolsRoot
+    )
+    return (Join-Path $ToolsRoot "cmake-$Version-windows-x86_64")
+}
+
+function Get-W64DevkitInstallDir {
+    param([Parameter(Mandatory)][string]$ToolsRoot)
+    return (Join-Path $ToolsRoot 'w64devkit')
+}
+
+function Reset-ToolDirectory {
+    <#
+    .SYNOPSIS
+        Delete a tool directory so a re-extraction starts from empty.
+
+    .DESCRIPTION
+        Without this, Expand-Archive -Force merges into whatever survived, so a
+        partially deleted install can persist across runs forever.
+    #>
+    param([Parameter(Mandatory)][AllowEmptyString()][string]$Path)
+
+    if ([string]::IsNullOrWhiteSpace($Path)) {
+        throw "Reset-ToolDirectory: refusing to delete an empty path."
+    }
+    $full = [System.IO.Path]::GetFullPath($Path)
+    $parent = [System.IO.Path]::GetDirectoryName($full)
+    if ([string]::IsNullOrEmpty($parent)) {
+        throw "Reset-ToolDirectory: refusing to delete filesystem root '$full'."
+    }
+    if (Test-Path -LiteralPath $full) {
+        Write-Host "Removing stale tool directory: $full"
+        Remove-Item -LiteralPath $full -Recurse -Force
+    }
+}
+
+function Find-CMakeModulesDir {
+    <#
+    .SYNOPSIS
+        Locate <install root>/share/cmake-<major.minor>/Modules, or return $null.
+
+    .DESCRIPTION
+        Requires CMakeSystemSpecificInformation.cmake specifically, because that is
+        the file CMake itself looks for when it resolves CMAKE_ROOT. A directory
+        that exists but has been partially emptied is as broken as a missing one.
+    #>
+    param([Parameter(Mandatory)][string]$InstallRoot)
+
+    $shareDir = Join-Path $InstallRoot 'share'
+    if (-not (Test-Path -LiteralPath $shareDir -PathType Container)) { return $null }
+
+    $candidates = Get-ChildItem -LiteralPath $shareDir -Directory -Filter 'cmake-*' -ErrorAction SilentlyContinue
+    foreach ($candidate in $candidates) {
+        $modules = Join-Path $candidate.FullName 'Modules'
+        $sentinel = Join-Path $modules 'CMakeSystemSpecificInformation.cmake'
+        if (Test-Path -LiteralPath $sentinel -PathType Leaf) { return $modules }
+    }
+    return $null
+}
+
+function Invoke-ToolProbe {
+    <#
+    .SYNOPSIS
+        Run a tool and return its exit code plus combined stdout/stderr.
+
+    .DESCRIPTION
+        $ErrorActionPreference is forced to Continue for the duration: in Windows
+        PowerShell 5.1, merging a native command's stderr with 2>&1 turns each
+        stderr line into an ErrorRecord, which under 'Stop' would abort the probe
+        on harmless tool chatter.
+    #>
+    param(
+        [Parameter(Mandatory)][string]$Exe,
+        [string[]]$Arguments = @()
+    )
+
+    $previous = $ErrorActionPreference
+    $ErrorActionPreference = 'Continue'
+    try {
+        $output = & $Exe @Arguments 2>&1 | Out-String
+        return [PSCustomObject]@{ ExitCode = $LASTEXITCODE; Output = $output }
+    } finally {
+        $ErrorActionPreference = $previous
+    }
+}
+
+function Test-ToolInstallation {
+    <#
+    .SYNOPSIS
+        $true when <BinDir>/<ExecutableName> exists and exits 0 for a version probe.
+    #>
+    param(
+        [Parameter(Mandatory)][string]$BinDir,
+        [Parameter(Mandatory)][string]$ExecutableName,
+        [string[]]$VersionArgs = @('--version')
+    )
+
+    $exe = Join-Path $BinDir $ExecutableName
+    if (-not (Test-Path -LiteralPath $exe -PathType Leaf)) {
+        Write-Host "  probe: $exe is missing"
+        return $false
+    }
+    try {
+        $probe = Invoke-ToolProbe -Exe $exe -Arguments $VersionArgs
+    } catch {
+        Write-Host "  probe: $exe could not be executed -- $($_.Exception.Message)"
+        return $false
+    }
+    if ($probe.ExitCode -ne 0) {
+        Write-Host "  probe: '$ExecutableName $($VersionArgs -join ' ')' exited $($probe.ExitCode)"
+        return $false
+    }
+    return $true
+}
+
+function Test-CMakeInstallation {
+    <#
+    .SYNOPSIS
+        $true only when a CMake install can actually configure a project.
+
+    .DESCRIPTION
+        Checks the Modules tree, NOT just bin/cmake.exe, and NOT just the exit code.
+        CMAKE_ROOT resolves to share/cmake-<major.minor>, so an install with bin/
+        but no Modules/ dies at configure time with
+        "CMake Error: Could not find CMAKE_ROOT !!!". Windows Temp cleanup produced
+        exactly that half-install on the STX runner and a cmake.exe-only check kept
+        declaring it healthy, blocking every cpp/** PR (issue #2817).
+
+        Exit codes cannot detect this: a CMake missing its Modules tree prints the
+        CMAKE_ROOT error to stderr and still exits 0, for both `--version` and
+        `--help-module-list` (measured on 4.4.2). So both signals are required --
+        the Modules tree must be on disk AND CMake must not report a broken root.
+        Requiring both also means an unusual install layout or a reworded CMake
+        error still leaves one signal standing.
+
+        Do not simplify this back to `Test-Path cmake.exe` or to an exit-code check.
+    #>
+    param([Parameter(Mandatory)][string]$BinDir)
+
+    if (-not (Test-ToolInstallation -BinDir $BinDir -ExecutableName (Get-CMakeExeName))) {
+        return $false
+    }
+
+    $installRoot = Split-Path -Parent $BinDir
+    $modules = Find-CMakeModulesDir -InstallRoot $installRoot
+    if (-not $modules) {
+        Write-Host "  probe: no populated share/cmake-*/Modules under $installRoot (CMAKE_ROOT would be unresolvable)"
+        return $false
+    }
+
+    $probe = Invoke-ToolProbe -Exe (Join-Path $BinDir (Get-CMakeExeName)) -Arguments @('--version')
+    if ($probe.Output -match 'Could not find CMAKE_ROOT|Modules directory not found') {
+        Write-Host "  probe: cmake reports a broken CMAKE_ROOT despite modules at $modules"
+        return $false
+    }
+
+    Write-Host "  probe: CMAKE_ROOT modules found at $modules"
+    return $true
+}
+
+function Install-CMake {
+    <#
+    .SYNOPSIS
+        Download and extract a pinned CMake into $ToolsRoot, replacing any stale copy.
+    #>
+    param(
+        [Parameter(Mandatory)][string]$Version,
+        [Parameter(Mandatory)][string]$ToolsRoot
+    )
+
+    $installDir = Get-CMakeInstallDir -Version $Version -ToolsRoot $ToolsRoot
+    $archiveName = Split-Path -Leaf $installDir
+    $binDir = Join-Path $installDir 'bin'
+
+    New-Item -ItemType Directory -Path $ToolsRoot -Force | Out-Null
+    $zip = Join-Path $ToolsRoot "$archiveName.zip"
+    if (Test-Path -LiteralPath $zip) { Remove-Item -LiteralPath $zip -Force }
+
+    # Download before deleting the old copy: a network failure then leaves the
+    # previous install intact instead of destroying a working toolchain.
+    $url = "https://github.com/Kitware/CMake/releases/download/v$Version/$archiveName.zip"
+    Write-Host "Downloading CMake v$Version from $url"
+    Invoke-WebRequest -Uri $url -OutFile $zip -UseBasicParsing
+
+    Reset-ToolDirectory -Path $installDir
+    Write-Host "Extracting to $installDir"
+    Expand-Archive -LiteralPath $zip -DestinationPath $ToolsRoot -Force
+    Remove-Item -LiteralPath $zip -Force
+
+    if (-not (Test-CMakeInstallation -BinDir $binDir)) {
+        throw ("CMake v$Version was downloaded and extracted to $installDir but the install " +
+               "is still incomplete. Delete that directory on the runner and re-run; if it " +
+               "recurs, the tools root ($ToolsRoot) is being swept by something.")
+    }
+    Write-Host "CMake v$Version installed at $binDir"
+    return $binDir
+}
+
+function Install-W64Devkit {
+    <#
+    .SYNOPSIS
+        Download and extract a pinned w64devkit (MinGW-w64) into $ToolsRoot.
+    #>
+    param(
+        [Parameter(Mandatory)][string]$Version,
+        [Parameter(Mandatory)][string]$ToolsRoot
+    )
+
+    $installDir = Get-W64DevkitInstallDir -ToolsRoot $ToolsRoot
+    $binDir = Join-Path $installDir 'bin'
+
+    New-Item -ItemType Directory -Path $ToolsRoot -Force | Out-Null
+    $installer = Join-Path $ToolsRoot "w64devkit-x64-$Version.7z.exe"
+    if (Test-Path -LiteralPath $installer) { Remove-Item -LiteralPath $installer -Force }
+
+    $url = "https://github.com/skeeto/w64devkit/releases/download/v$Version/w64devkit-x64-$Version.7z.exe"
+    Write-Host "Downloading w64devkit (MinGW-w64) v$Version from $url"
+    Invoke-WebRequest -Uri $url -OutFile $installer -UseBasicParsing
+
+    Reset-ToolDirectory -Path $installDir
+    Write-Host "Extracting to $installDir"
+    & $installer "-o$ToolsRoot" -y | Out-Null
+    Remove-Item -LiteralPath $installer -Force
+
+    if (-not (Test-ToolInstallation -BinDir $binDir -ExecutableName 'g++.exe')) {
+        throw ("w64devkit v$Version was downloaded and extracted to $installDir but g++ is " +
+               "missing or not runnable. Delete that directory on the runner and re-run.")
+    }
+    Write-Host "w64devkit v$Version installed at $binDir"
+    return $binDir
+}
+
+function Add-PathEntry {
+    <#
+    .SYNOPSIS
+        Prepend a directory to PATH for this process and for later workflow steps.
+    #>
+    param([Parameter(Mandatory)][string]$Directory)
+
+    $env:PATH = "$Directory$([System.IO.Path]::PathSeparator)$env:PATH"
+    if (-not [string]::IsNullOrWhiteSpace($env:GITHUB_PATH)) {
+        # AppendAllText writes UTF-8 without a BOM; Add-Content/Out-File on
+        # Windows PowerShell 5.1 would write ANSI or inject a mid-file BOM.
+        [System.IO.File]::AppendAllText($env:GITHUB_PATH, $Directory + [Environment]::NewLine)
+    }
+    Write-Host "PATH += $Directory"
+}

--- a/.github/scripts/Ensure-CppBuildTools.ps1
+++ b/.github/scripts/Ensure-CppBuildTools.ps1
@@ -1,0 +1,133 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+<#
+.SYNOPSIS
+    Make a working CMake and C++ compiler available to the rest of the job.
+
+.DESCRIPTION
+    Used by the STX self-hosted integration job in .github/workflows/build_cpp.yml.
+
+    Every candidate toolchain -- one already on PATH, one cached from a previous
+    run, one bundled with Visual Studio -- is functionally probed before it is
+    accepted. A candidate that fails the probe is discarded and the next source is
+    tried; if nothing works the tool is re-downloaded into a clean directory. If
+    that also fails the script throws rather than leaving a broken tool on PATH.
+
+.PARAMETER CMakeVersion
+    Pinned CMake version downloaded when no usable CMake is found.
+
+.PARAMETER W64DevkitVersion
+    Pinned w64devkit (MinGW-w64) version downloaded when MSVC and g++ are absent.
+
+.EXAMPLE
+    .\.github\scripts\Ensure-CppBuildTools.ps1 -CMakeVersion 3.31.4 -W64DevkitVersion 2.5.0
+#>
+
+[CmdletBinding()]
+param(
+    [string]$CMakeVersion = '3.31.4',
+    [string]$W64DevkitVersion = '2.5.0'
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+$ProgressPreference = 'SilentlyContinue'
+
+. (Join-Path $PSScriptRoot 'CppBuildTools.ps1')
+
+$toolsRoot = Get-CppToolsRoot
+Write-Host "C++ tools root: $toolsRoot"
+
+# ---------------------------------------------------------------------------
+# CMake: PATH -> previous download -> Visual Studio -> fresh download
+# ---------------------------------------------------------------------------
+$cmakeBin = $null
+
+$onPath = Get-Command cmake -ErrorAction SilentlyContinue
+if ($onPath) {
+    $candidate = Split-Path -Parent $onPath.Source
+    Write-Host "Checking CMake already on PATH: $candidate"
+    if (Test-CMakeInstallation -BinDir $candidate) {
+        Write-Host "[OK] Using CMake from PATH"
+        $cmakeBin = $candidate
+    } else {
+        Write-Host "::warning::CMake on PATH at $candidate is incomplete -- ignoring it"
+    }
+}
+
+if (-not $cmakeBin) {
+    $cached = Join-Path (Get-CMakeInstallDir -Version $CMakeVersion -ToolsRoot $toolsRoot) 'bin'
+    Write-Host "Checking cached CMake: $cached"
+    if (Test-CMakeInstallation -BinDir $cached) {
+        Write-Host "[OK] Using cached CMake"
+        $cmakeBin = $cached
+    } else {
+        Write-Host "Cached CMake is absent or incomplete -- it will be re-downloaded"
+    }
+}
+
+if (-not $cmakeBin -and (Test-IsWindowsHost)) {
+    $vswhere = Join-Path ${env:ProgramFiles(x86)} 'Microsoft Visual Studio\Installer\vswhere.exe'
+    if (Test-Path -LiteralPath $vswhere) {
+        $vsCmake = & $vswhere -latest `
+            -requires Microsoft.VisualStudio.Component.VC.CMake.Project `
+            -find "Common7\IDE\CommonExtensions\Microsoft\CMake\CMake\bin" 2>$null
+        if ($vsCmake) {
+            $vsCmake = @($vsCmake)[0]
+            Write-Host "Checking VS-bundled CMake: $vsCmake"
+            if (Test-CMakeInstallation -BinDir $vsCmake) {
+                Write-Host "[OK] Using VS-bundled CMake"
+                $cmakeBin = $vsCmake
+            } else {
+                Write-Host "::warning::VS-bundled CMake at $vsCmake is incomplete -- ignoring it"
+            }
+        }
+    }
+}
+
+if (-not $cmakeBin) {
+    $cmakeBin = Install-CMake -Version $CMakeVersion -ToolsRoot $toolsRoot
+}
+
+Add-PathEntry -Directory $cmakeBin
+
+# ---------------------------------------------------------------------------
+# C++ compiler: MSVC -> g++ on PATH -> previous download -> fresh download
+# ---------------------------------------------------------------------------
+$hasCompiler = $false
+
+if (Test-IsWindowsHost) {
+    $vswhere = Join-Path ${env:ProgramFiles(x86)} 'Microsoft Visual Studio\Installer\vswhere.exe'
+    if (Test-Path -LiteralPath $vswhere) {
+        $vsPath = & $vswhere -latest -property installationPath 2>$null
+        if ($vsPath) {
+            Write-Host "[OK] MSVC found at $(@($vsPath)[0])"
+            $hasCompiler = $true
+        }
+    }
+}
+
+if (-not $hasCompiler) {
+    $gxx = Get-Command g++ -ErrorAction SilentlyContinue
+    if ($gxx) {
+        Write-Host "[OK] g++ found on PATH at $($gxx.Source)"
+        $hasCompiler = $true
+    }
+}
+
+if (-not $hasCompiler) {
+    $cachedGxx = Join-Path (Get-W64DevkitInstallDir -ToolsRoot $toolsRoot) 'bin'
+    Write-Host "Checking cached w64devkit: $cachedGxx"
+    if (Test-ToolInstallation -BinDir $cachedGxx -ExecutableName 'g++.exe') {
+        Write-Host "[OK] Using cached w64devkit"
+        Add-PathEntry -Directory $cachedGxx
+        $hasCompiler = $true
+    } else {
+        Write-Host "Cached w64devkit is absent or incomplete -- it will be re-downloaded"
+        Add-PathEntry -Directory (Install-W64Devkit -Version $W64DevkitVersion -ToolsRoot $toolsRoot)
+        $hasCompiler = $true
+    }
+}
+
+Write-Host "Build tools ready"

--- a/.github/scripts/Ensure-CppBuildTools.ps1
+++ b/.github/scripts/Ensure-CppBuildTools.ps1
@@ -39,12 +39,22 @@ $ProgressPreference = 'SilentlyContinue'
 $toolsRoot = Get-CppToolsRoot
 Write-Host "C++ tools root: $toolsRoot"
 
+# Resolved once: Join-Path throws on a null root, and this script must not die
+# looking for Visual Studio on a machine that has none.
+$vswhere = $null
+if (-not [string]::IsNullOrWhiteSpace(${env:ProgramFiles(x86)})) {
+    $vswhere = Join-Path ${env:ProgramFiles(x86)} 'Microsoft Visual Studio\Installer\vswhere.exe'
+    if (-not (Test-Path -LiteralPath $vswhere)) { $vswhere = $null }
+}
+
 # ---------------------------------------------------------------------------
 # CMake: PATH -> previous download -> Visual Studio -> fresh download
 # ---------------------------------------------------------------------------
 $cmakeBin = $null
 
-$onPath = Get-Command cmake -ErrorAction SilentlyContinue
+# Select-Object -First 1: two cmake entries on PATH would otherwise make .Source
+# an array and $candidate an unusable joined string.
+$onPath = Get-Command cmake -CommandType Application -ErrorAction SilentlyContinue | Select-Object -First 1
 if ($onPath) {
     $candidate = Split-Path -Parent $onPath.Source
     Write-Host "Checking CMake already on PATH: $candidate"
@@ -67,21 +77,18 @@ if (-not $cmakeBin) {
     }
 }
 
-if (-not $cmakeBin -and (Test-IsWindowsHost)) {
-    $vswhere = Join-Path ${env:ProgramFiles(x86)} 'Microsoft Visual Studio\Installer\vswhere.exe'
-    if (Test-Path -LiteralPath $vswhere) {
-        $vsCmake = & $vswhere -latest `
-            -requires Microsoft.VisualStudio.Component.VC.CMake.Project `
-            -find "Common7\IDE\CommonExtensions\Microsoft\CMake\CMake\bin" 2>$null
-        if ($vsCmake) {
-            $vsCmake = @($vsCmake)[0]
-            Write-Host "Checking VS-bundled CMake: $vsCmake"
-            if (Test-CMakeInstallation -BinDir $vsCmake) {
-                Write-Host "[OK] Using VS-bundled CMake"
-                $cmakeBin = $vsCmake
-            } else {
-                Write-Host "::warning::VS-bundled CMake at $vsCmake is incomplete -- ignoring it"
-            }
+if (-not $cmakeBin -and $vswhere) {
+    $vsCmake = & $vswhere -latest `
+        -requires Microsoft.VisualStudio.Component.VC.CMake.Project `
+        -find "Common7\IDE\CommonExtensions\Microsoft\CMake\CMake\bin" 2>$null
+    if ($vsCmake) {
+        $vsCmake = @($vsCmake)[0]
+        Write-Host "Checking VS-bundled CMake: $vsCmake"
+        if (Test-CMakeInstallation -BinDir $vsCmake) {
+            Write-Host "[OK] Using VS-bundled CMake"
+            $cmakeBin = $vsCmake
+        } else {
+            Write-Host "::warning::VS-bundled CMake at $vsCmake is incomplete -- ignoring it"
         }
     }
 }
@@ -97,19 +104,16 @@ Add-PathEntry -Directory $cmakeBin
 # ---------------------------------------------------------------------------
 $hasCompiler = $false
 
-if (Test-IsWindowsHost) {
-    $vswhere = Join-Path ${env:ProgramFiles(x86)} 'Microsoft Visual Studio\Installer\vswhere.exe'
-    if (Test-Path -LiteralPath $vswhere) {
-        $vsPath = & $vswhere -latest -property installationPath 2>$null
-        if ($vsPath) {
-            Write-Host "[OK] MSVC found at $(@($vsPath)[0])"
-            $hasCompiler = $true
-        }
+if ($vswhere) {
+    $vsPath = & $vswhere -latest -property installationPath 2>$null
+    if ($vsPath) {
+        Write-Host "[OK] MSVC found at $(@($vsPath)[0])"
+        $hasCompiler = $true
     }
 }
 
 if (-not $hasCompiler) {
-    $gxx = Get-Command g++ -ErrorAction SilentlyContinue
+    $gxx = Get-Command g++ -CommandType Application -ErrorAction SilentlyContinue | Select-Object -First 1
     if ($gxx) {
         Write-Host "[OK] g++ found on PATH at $($gxx.Source)"
         $hasCompiler = $true
@@ -128,6 +132,10 @@ if (-not $hasCompiler) {
         Add-PathEntry -Directory (Install-W64Devkit -Version $W64DevkitVersion -ToolsRoot $toolsRoot)
         $hasCompiler = $true
     }
+}
+
+if (-not $hasCompiler) {
+    throw "No C++ compiler is available: MSVC, g++ on PATH, and w64devkit all failed."
 }
 
 Write-Host "Build tools ready"

--- a/.github/scripts/tests/CppBuildTools.Tests.ps1
+++ b/.github/scripts/tests/CppBuildTools.Tests.ps1
@@ -1,0 +1,211 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+<#
+.SYNOPSIS
+    Unit tests for the C++ build-tool cache validation logic (issue #2817).
+
+.DESCRIPTION
+    The STX self-hosted runner cached CMake under $env:TEMP and decided whether to
+    re-download it by testing `bin\cmake.exe` alone. Windows Temp cleanup deleted
+    `share\` and left `bin\`, so the guard saw a healthy cache, skipped the
+    re-download and put a CMake that cannot find CMAKE_ROOT on PATH. Every cpp/**
+    PR then failed at configure time.
+
+    These tests pin the repaired behaviour: a cache is valid only when the binary
+    AND its Modules tree are present AND the binary actually runs.
+
+    Runs on Linux/macOS (the fake CMake binaries are shell scripts, which Windows
+    cannot execute as `cmake.exe`). The logic under test is path/exit-code logic,
+    not Windows API logic, so it validates the decision that broke on the runner.
+
+.EXAMPLE
+    pwsh -File .github/scripts/tests/CppBuildTools.Tests.ps1
+#>
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+. (Join-Path (Split-Path -Parent $PSScriptRoot) 'CppBuildTools.ps1')
+
+$script:Passed = 0
+$script:Failed = 0
+
+function Assert-Equal {
+    param($Expected, $Actual, [string]$Name)
+    if ($Expected -eq $Actual) {
+        $script:Passed++
+        Write-Host "  [PASS] $Name"
+    } else {
+        $script:Failed++
+        Write-Host "  [FAIL] $Name (expected '$Expected', got '$Actual')"
+    }
+}
+
+function Assert-Throws {
+    param([scriptblock]$Action, [string]$Name)
+    try {
+        & $Action
+        $script:Failed++
+        Write-Host "  [FAIL] $Name (expected a terminating error, none was raised)"
+    } catch {
+        $script:Passed++
+        Write-Host "  [PASS] $Name"
+    }
+}
+
+function New-TestRoot {
+    $path = Join-Path ([System.IO.Path]::GetTempPath()) ("gaia-cpptools-test-" + [Guid]::NewGuid().ToString('N'))
+    New-Item -ItemType Directory -Path $path -Force | Out-Null
+    return $path
+}
+
+# Builds a CMake install tree that mirrors the real archive layout:
+#   <root>/bin/cmake[.exe]
+#   <root>/share/cmake-3.31/Modules/CMakeSystemSpecificInformation.cmake
+function New-FakeCMakeInstall {
+    param(
+        [Parameter(Mandatory)][string]$Root,
+        [switch]$NoBinary,
+        [switch]$NoShare,
+        [switch]$EmptyModules,
+        [switch]$BinaryFails,
+        [switch]$ReportsBrokenRoot
+    )
+
+    $binDir = Join-Path $Root 'bin'
+    New-Item -ItemType Directory -Path $binDir -Force | Out-Null
+
+    if (-not $NoBinary) {
+        $exe = Join-Path $binDir (Get-CMakeExeName)
+        $exitCode = if ($BinaryFails) { 1 } else { 0 }
+        # Real CMake prints the CMAKE_ROOT error to stderr and still exits 0
+        # (measured on 4.4.2), so the fake reproduces that exact combination.
+        $complaint = if ($ReportsBrokenRoot) {
+            "echo 'CMake Error: Could not find CMAKE_ROOT !!!' 1>&2`n"
+        } else { '' }
+        $body = "#!/bin/sh`n$complaint" + "echo 'cmake version 3.31.4'`nexit $exitCode`n"
+        Set-Content -LiteralPath $exe -Value $body -NoNewline
+        if (-not (Test-IsWindowsHost)) { & chmod '+x' $exe }
+    }
+
+    if (-not $NoShare) {
+        $modules = Join-Path (Join-Path (Join-Path $Root 'share') 'cmake-3.31') 'Modules'
+        New-Item -ItemType Directory -Path $modules -Force | Out-Null
+        if (-not $EmptyModules) {
+            Set-Content -LiteralPath (Join-Path $modules 'CMakeSystemSpecificInformation.cmake') -Value '# fake'
+        }
+    }
+
+    return $binDir
+}
+
+Write-Host "`nTest-CMakeInstallation"
+$root = New-TestRoot
+try {
+    $bin = New-FakeCMakeInstall -Root (Join-Path $root 'complete')
+    Assert-Equal $true (Test-CMakeInstallation -BinDir $bin) 'complete install is valid'
+
+    # The #2817 regression itself: bin/ survived Temp cleanup, share/ did not.
+    $bin = New-FakeCMakeInstall -Root (Join-Path $root 'no-share') -NoShare
+    Assert-Equal $false (Test-CMakeInstallation -BinDir $bin) 'binary present but share/ deleted is INVALID'
+    # Negative control: the check this replaced accepted that same broken install.
+    Assert-Equal $true (Test-Path -LiteralPath (Join-Path $bin (Get-CMakeExeName))) `
+        'negative control: the old cmake.exe-only check would have accepted it'
+
+    $bin = New-FakeCMakeInstall -Root (Join-Path $root 'empty-modules') -EmptyModules
+    Assert-Equal $false (Test-CMakeInstallation -BinDir $bin) 'Modules/ without CMakeSystemSpecificInformation.cmake is invalid'
+
+    # CMake exits 0 while printing "Could not find CMAKE_ROOT", so the text of the
+    # probe matters, not just its exit code.
+    $bin = New-FakeCMakeInstall -Root (Join-Path $root 'complains') -ReportsBrokenRoot
+    Assert-Equal $false (Test-CMakeInstallation -BinDir $bin) 'cmake reporting a broken CMAKE_ROOT is invalid even at exit 0'
+    Assert-Equal 0 (Invoke-ToolProbe -Exe (Join-Path $bin (Get-CMakeExeName)) -Arguments @('--version')).ExitCode `
+        'negative control: that same install exits 0, so an exit-code-only probe would accept it'
+
+    $bin = New-FakeCMakeInstall -Root (Join-Path $root 'no-binary') -NoBinary
+    Assert-Equal $false (Test-CMakeInstallation -BinDir $bin) 'missing binary is invalid'
+
+    $bin = New-FakeCMakeInstall -Root (Join-Path $root 'broken-binary') -BinaryFails
+    Assert-Equal $false (Test-CMakeInstallation -BinDir $bin) 'binary that exits non-zero is invalid'
+
+    Assert-Equal $false (Test-CMakeInstallation -BinDir (Join-Path $root 'does-not-exist')) 'absent directory is invalid'
+} finally {
+    Remove-Item -LiteralPath $root -Recurse -Force -ErrorAction SilentlyContinue
+}
+
+Write-Host "`nTest-ToolInstallation (generic binary probe)"
+$root = New-TestRoot
+try {
+    $bin = New-FakeCMakeInstall -Root (Join-Path $root 'ok')
+    Assert-Equal $true  (Test-ToolInstallation -BinDir $bin -ExecutableName (Get-CMakeExeName)) 'runnable binary is valid'
+    $bin = New-FakeCMakeInstall -Root (Join-Path $root 'bad') -BinaryFails
+    Assert-Equal $false (Test-ToolInstallation -BinDir $bin -ExecutableName (Get-CMakeExeName)) 'failing binary is invalid'
+} finally {
+    Remove-Item -LiteralPath $root -Recurse -Force -ErrorAction SilentlyContinue
+}
+
+Write-Host "`nInvoke-ToolProbe"
+$root = New-TestRoot
+try {
+    # Windows PowerShell 5.1 turns merged native stderr into ErrorRecords, which
+    # under $ErrorActionPreference='Stop' would abort the probe on tool chatter.
+    $bin = New-FakeCMakeInstall -Root (Join-Path $root 'noisy') -ReportsBrokenRoot
+    $saved = $ErrorActionPreference
+    $ErrorActionPreference = 'Stop'
+    try {
+        $probe = Invoke-ToolProbe -Exe (Join-Path $bin (Get-CMakeExeName)) -Arguments @('--version')
+        Assert-Equal $true ($probe.Output -match 'Could not find CMAKE_ROOT') 'captures stderr without aborting under EAP=Stop'
+        Assert-Equal 'Stop' $ErrorActionPreference 'leaves the caller ErrorActionPreference untouched'
+    } finally {
+        $ErrorActionPreference = $saved
+    }
+} finally {
+    Remove-Item -LiteralPath $root -Recurse -Force -ErrorAction SilentlyContinue
+}
+
+Write-Host "`nInstall path helpers"
+Assert-Equal (Join-Path '/tools' 'cmake-3.31.4-windows-x86_64') (Get-CMakeInstallDir -Version '3.31.4' -ToolsRoot '/tools') `
+    'cache lookup and extraction share one CMake install path'
+Assert-Equal (Join-Path '/tools' 'w64devkit') (Get-W64DevkitInstallDir -ToolsRoot '/tools') `
+    'cache lookup and extraction share one w64devkit install path'
+
+Write-Host "`nGet-CppToolsRoot"
+$savedOverride = $env:GAIA_CI_TOOLS_DIR
+$savedToolCache = $env:RUNNER_TOOL_CACHE
+try {
+    $env:GAIA_CI_TOOLS_DIR = '/tmp/explicit-tools'
+    $env:RUNNER_TOOL_CACHE = '/tmp/tool-cache'
+    Assert-Equal '/tmp/explicit-tools' (Get-CppToolsRoot) 'explicit override wins'
+
+    $env:GAIA_CI_TOOLS_DIR = ''
+    Assert-Equal (Join-Path '/tmp/tool-cache' 'gaia-cpp') (Get-CppToolsRoot) 'falls back to the runner tool cache'
+
+    $env:RUNNER_TOOL_CACHE = ''
+    Assert-Throws { Get-CppToolsRoot } 'throws instead of silently using TEMP when no persistent dir is known'
+} finally {
+    $env:GAIA_CI_TOOLS_DIR = $savedOverride
+    $env:RUNNER_TOOL_CACHE = $savedToolCache
+}
+
+Write-Host "`nReset-ToolDirectory"
+$root = New-TestRoot
+try {
+    $stale = Join-Path $root 'stale'
+    New-Item -ItemType Directory -Path (Join-Path $stale 'bin') -Force | Out-Null
+    Set-Content -LiteralPath (Join-Path (Join-Path $stale 'bin') 'leftover.txt') -Value 'x'
+    Reset-ToolDirectory -Path $stale
+    Assert-Equal $false (Test-Path -LiteralPath $stale) 'stale directory is removed before re-extraction'
+
+    Reset-ToolDirectory -Path (Join-Path $root 'never-existed')
+    Assert-Equal $true $true 'absent directory is a no-op'
+
+    Assert-Throws { Reset-ToolDirectory -Path ([System.IO.Path]::DirectorySeparatorChar.ToString()) } 'refuses to delete a filesystem root'
+} finally {
+    Remove-Item -LiteralPath $root -Recurse -Force -ErrorAction SilentlyContinue
+}
+
+Write-Host ""
+Write-Host "Passed: $script:Passed  Failed: $script:Failed"
+if ($script:Failed -gt 0) { exit 1 }
+exit 0

--- a/.github/workflows/build_cpp.yml
+++ b/.github/workflows/build_cpp.yml
@@ -15,6 +15,7 @@ on:
     paths:
       - 'src/gaia/version.py'
       - '.github/actions/install-lemonade/**'
+      - '.github/scripts/**'
       - 'cpp/**'
       - '.github/workflows/build_cpp.yml'
       - '.github/workflows/benchmark_cpp.yml'
@@ -24,6 +25,7 @@ on:
     paths:
       - 'src/gaia/version.py'
       - '.github/actions/install-lemonade/**'
+      - '.github/scripts/**'
       - 'cpp/**'
       - '.github/workflows/build_cpp.yml'
       - '.github/workflows/benchmark_cpp.yml'
@@ -39,6 +41,39 @@ permissions:
   contents: read
 
 jobs:
+  # Guards the toolchain-setup logic used by the STX job below. It cannot run on
+  # the self-hosted runner (that is the thing it protects), so the cache-validity
+  # decision is unit tested here with fake install trees.
+  toolchain-script-tests:
+    name: C++ toolchain script tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v7
+
+      # Ensure-CppBuildTools.ps1 only ever executes on the self-hosted runner, so
+      # a syntax error there would otherwise be found there. Parsing is free.
+      - name: Parse-check toolchain scripts
+        shell: pwsh
+        run: |
+          $failed = $false
+          foreach ($file in Get-ChildItem .github/scripts -Recurse -Filter *.ps1) {
+              $errors = $null
+              [System.Management.Automation.Language.Parser]::ParseFile($file.FullName, [ref]$null, [ref]$errors) | Out-Null
+              if ($errors) {
+                  $failed = $true
+                  $errors | ForEach-Object { Write-Host "$($file.Name):$($_.Extent.StartLineNumber): $($_.Message)" }
+              }
+          }
+          if ($failed) { throw "PowerShell parse errors under .github/scripts" }
+          Write-Host "All .github/scripts/*.ps1 parsed cleanly"
+
+      - name: Run CppBuildTools unit tests
+        shell: pwsh
+        run: |
+          ./.github/scripts/tests/CppBuildTools.Tests.ps1
+          if ($LASTEXITCODE -ne 0) { throw "CppBuildTools unit tests failed" }
+
   build-and-test:
     name: C++ (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
@@ -183,71 +218,16 @@ jobs:
       - name: Install Lemonade Server
         uses: ./.github/actions/install-lemonade
 
+      # Every candidate CMake is functionally probed before it is trusted -- a
+      # cached install with bin/cmake.exe but no share/cmake-*/Modules passes a
+      # Test-Path check and then fails configure with "Could not find CMAKE_ROOT"
+      # (issue #2817). Tools live in the runner tool cache, not TEMP, which
+      # Windows sweeps. See .github/scripts/CppBuildTools.ps1.
       - name: Ensure C++ build tools are available
         shell: powershell
         run: |
-          $ErrorActionPreference = "Stop"
-          $ProgressPreference = 'SilentlyContinue'
-          $cmakeVer = "3.31.4"
-          $mgwVer   = "2.5.0"
-
-          # --- CMake ---
-          # Check PATH, then previously downloaded location, then VS, then download
-          $cmakeCached = "$env:TEMP\cmake\cmake-${cmakeVer}-windows-x86_64\bin"
-          if (Get-Command cmake -ErrorAction SilentlyContinue) {
-              Write-Host "CMake found in PATH"
-          } elseif (Test-Path "$cmakeCached\cmake.exe") {
-              Write-Host "CMake found at cached location"
-              echo "$cmakeCached" >> $env:GITHUB_PATH
-          } else {
-              $vswhere = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe"
-              if (Test-Path $vswhere) {
-                  $vsCmake = & $vswhere -latest `
-                      -requires Microsoft.VisualStudio.Component.VC.CMake.Project `
-                      -find "Common7\IDE\CommonExtensions\Microsoft\CMake\CMake\bin" 2>$null
-                  if ($vsCmake -and (Test-Path "$vsCmake\cmake.exe")) {
-                      Write-Host "Using VS-bundled CMake"
-                      echo "$vsCmake" >> $env:GITHUB_PATH
-                  }
-              }
-          }
-          if (-not (Get-Command cmake -ErrorAction SilentlyContinue) -and
-              -not (Test-Path "$cmakeCached\cmake.exe")) {
-              $url = "https://github.com/Kitware/CMake/releases/download/v${cmakeVer}/cmake-${cmakeVer}-windows-x86_64.zip"
-              Write-Host "Downloading CMake v${cmakeVer}..."
-              Invoke-WebRequest -Uri $url -OutFile "$env:TEMP\cmake.zip" -UseBasicParsing
-              Expand-Archive "$env:TEMP\cmake.zip" "$env:TEMP\cmake" -Force
-              Remove-Item "$env:TEMP\cmake.zip"
-              echo "$cmakeCached" >> $env:GITHUB_PATH
-          }
-
-          # --- C++ compiler ---
-          # Check for MSVC, then g++ in PATH, then cached w64devkit, then download
-          $hasMSVC = $false
-          $vswhere = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe"
-          if (Test-Path $vswhere) {
-              $vsPath = & $vswhere -latest -property installationPath 2>$null
-              if ($vsPath) { $hasMSVC = $true; Write-Host "MSVC found" }
-          }
-          $mgwCached = "$env:TEMP\w64devkit\bin"
-          if (-not $hasMSVC) {
-              if (Get-Command g++ -ErrorAction SilentlyContinue) {
-                  Write-Host "g++ found in PATH"
-              } elseif (Test-Path "$mgwCached\g++.exe") {
-                  Write-Host "w64devkit found at cached location"
-                  echo "$mgwCached" >> $env:GITHUB_PATH
-              } else {
-                  $url = "https://github.com/skeeto/w64devkit/releases/download/v${mgwVer}/w64devkit-x64-${mgwVer}.7z.exe"
-                  Write-Host "Downloading w64devkit (MinGW-w64) v${mgwVer}..."
-                  Invoke-WebRequest -Uri $url -OutFile "$env:TEMP\w64devkit.exe" -UseBasicParsing
-                  Write-Host "Extracting w64devkit..."
-                  & "$env:TEMP\w64devkit.exe" -o"$env:TEMP" -y | Out-Null
-                  Remove-Item "$env:TEMP\w64devkit.exe"
-                  echo "$mgwCached" >> $env:GITHUB_PATH
-              }
-          }
-
-          Write-Host "Build tools ready"
+          powershell -ExecutionPolicy Bypass -File .github\scripts\Ensure-CppBuildTools.ps1 -CMakeVersion 3.31.4 -W64DevkitVersion 2.5.0
+          if ($LASTEXITCODE -ne 0) { throw "C++ build tools setup failed" }
 
       - name: Restore FetchContent cache
         uses: actions/cache@v6
@@ -403,7 +383,7 @@ jobs:
   cpp-build-summary:
     name: C++ Build Summary
     runs-on: ubuntu-latest
-    needs: [build-and-test, install-test, shared-lib-test, integration-test, benchmark]
+    needs: [toolchain-script-tests, build-and-test, install-test, shared-lib-test, integration-test, benchmark]
     if: >-
       ${{ always() && !cancelled() &&
           needs.build-and-test.result != 'cancelled' }}
@@ -411,12 +391,20 @@ jobs:
       - name: Check build results
         run: |
           echo "=== C++ Build & Test Summary ==="
+          echo "Toolchain Scripts: ${{ needs.toolchain-script-tests.result }}"
           echo "Build & Test:      ${{ needs.build-and-test.result }}"
           echo "Install Test:      ${{ needs.install-test.result }}"
           echo "Shared Lib Test:   ${{ needs.shared-lib-test.result }}"
           echo "Integration Tests: ${{ needs.integration-test.result }}"
           echo "Benchmarks:        ${{ needs.benchmark.result }}"
           echo ""
+
+          # Checked before the draft-skip exit: the toolchain script tests gate the
+          # STX setup logic and run on every event, draft or not.
+          if [[ "${{ needs.toolchain-script-tests.result }}" != "success" ]]; then
+            echo "C++ toolchain script tests failed"
+            exit 1
+          fi
 
           if [[ "${{ needs.build-and-test.result }}" == "skipped" ]]; then
             echo "All C++ jobs skipped (draft PR - add 'ready_for_ci' label to run)"
@@ -429,7 +417,9 @@ jobs:
           [[ "${{ needs.shared-lib-test.result }}" != "success" ]] && FAILED=1
           # Integration test runs on self-hosted STX hardware; treat
           # 'skipped' and 'failure' as non-blocking (warn only) since the
-          # runner may lack tools like cmake in PATH.
+          # runner can be offline, busy, or missing hardware prerequisites.
+          # Toolchain setup itself is no longer a warn-only case -- it either
+          # provides a validated CMake or fails the job loudly (issue #2817).
           if [[ "${{ needs.integration-test.result }}" == "failure" ]]; then
             echo "::warning::Integration tests failed (STX runner infrastructure issue)"
           fi


### PR DESCRIPTION
Every `cpp/**` PR has been failing the `C++ Integration Tests (STX)` check before it compiles anything — #2807, #2809 and #2816 are all red for a reason unrelated to their diffs. The self-hosted runner cached CMake under `$env:TEMP` and re-downloaded it only when `bin\cmake.exe` was missing; Windows Temp cleanup deleted `share\cmake-3.31\Modules` and left `bin\`, so the job kept trusting a CMake that cannot resolve `CMAKE_ROOT` and every run died the same way until someone cleared Temp by hand. Now each candidate toolchain is probed for the thing the build actually depends on, a failed probe falls through to a clean re-download, and tools live in the runner tool cache instead of a directory the OS sweeps.

One measurement drove the design and is worth flagging for review: **exit codes cannot detect this failure.** A CMake missing its Modules tree prints `Could not find CMAKE_ROOT` to stderr and still exits 0 — for `--version` and for `--help-module-list` (measured on 4.4.2). So the issue's suggested `cmake --version` exit-0 check would not have caught it on its own; validity requires the Modules tree on disk *and* a probe that does not report a broken root.

The stale `%TEMP%\cmake` tree on the runner is now inert — nothing reads it — so no manual cleanup is needed to make this work; deleting it just reclaims disk.

Closes #2817

## Test plan

- [ ] `pwsh -File .github/scripts/tests/CppBuildTools.Tests.ps1` passes (21/21). It asserts the exact regression: `bin/cmake.exe` present + `share/` absent reports **invalid**, both present reports **valid**, and includes negative controls showing the old `Test-Path cmake.exe` check and an exit-code-only check would both have accepted the broken install.
- [ ] New `C++ toolchain script tests` job is green (parse-checks every `.github/scripts/*.ps1`, then runs the unit tests).
- [ ] `C++ Integration Tests (STX)` on this PR gets past `Ensure C++ build tools are available` and reaches compilation. The step log should name which CMake it accepted and, if it rejected one, why.
- [ ] Reproduce the root cause on any machine: copy a `cmake` binary alone into an empty directory and run `--version` — it prints the `CMAKE_ROOT` error and exits 0.
- [ ] After merge, re-run CI on #2807, #2809 and #2816 with no changes to their diffs and confirm the STX check goes green.