### PR TITLE
feat(cpp): MCP server registry — resolve server ids from mcp.json

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -140,6 +140,7 @@ add_library(gaia_core
     src/lemonade_client.cpp
     src/agent.cpp
     src/mcp_client.cpp
+    src/mcp_registry.cpp
     src/security.cpp
     src/sse_parser.cpp
     src/process.cpp
@@ -305,6 +306,7 @@ if(GAIA_BUILD_TESTS)
         tests/test_agent.cpp
         tests/test_agent_vlm.cpp
         tests/test_mcp_client.cpp
+        tests/test_mcp_registry.cpp
         tests/test_console.cpp
         tests/test_lemonade_client.cpp
         tests/test_clean_console.cpp

--- a/cpp/include/gaia/agent.h
+++ b/cpp/include/gaia/agent.h
@@ -23,6 +23,7 @@
 #include "json_utils.h"
 #include "lemonade_client.h"
 #include "mcp_client.h"
+#include "mcp_registry.h"
 #include "security.h"
 #include "tool_registry.h"
 #include "types.h"
@@ -78,6 +79,26 @@ public:
     /// @param config Config with "command" and optional "args"
     /// @return true if connection succeeded
     bool connectMcpServer(const std::string& name, const json& config);
+
+    /// Connect to an MCP server named by its configured id, resolving the
+    /// launch config through MCPRegistry (`$GAIA_CONFIG_DIR`, else `~/.gaia`).
+    /// This is what backs a skill declaring `mcp:connect:<id>`.
+    ///
+    /// Resolution failures throw rather than returning false: an id that
+    /// cannot be resolved means the caller asked for capability that is not
+    /// there, and silently continuing produces an agent that has quietly lost
+    /// its tools. Connection failures keep the connectMcpServer() contract and
+    /// return false after printing the error.
+    ///
+    /// @param id Server id as it appears under "mcpServers" in the config file
+    /// @return true if connection succeeded
+    /// @throws MCPRegistryError if the id is unknown, no config file exists,
+    ///         the config is malformed, or the entry is not launchable.
+    bool connectMcpServerById(const std::string& id);
+
+    /// connectMcpServerById() against an explicit registry (tests, embedders
+    /// that keep their MCP config somewhere other than the config directory).
+    bool connectMcpServerById(const std::string& id, const MCPRegistry& registry);
 
     /// Disconnect from an MCP server.
     void disconnectMcpServer(const std::string& name);

--- a/cpp/include/gaia/mcp_registry.h
+++ b/cpp/include/gaia/mcp_registry.h
@@ -1,0 +1,199 @@
+// Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: MIT
+//
+// MCP server registry — resolves a server *id* to a launchable server config.
+// Reads the same on-disk format the Python runtime uses:
+//   - src/gaia/mcp/client/config.py       (MCPConfig, the read path)
+//   - src/gaia/connectors/mcp_server.py   (McpServerHandler, the write path)
+//
+// A server whose config carries literal values is reachable from both runtimes
+// after being configured once. See the keyring note on resolve() for the one
+// case that is Python-only today.
+
+#pragma once
+
+#include <map>
+#include <mutex>
+#include <optional>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+#include <nlohmann/json.hpp>
+
+#include "gaia/export.h"
+
+namespace gaia {
+
+using json = nlohmann::json;
+
+#ifdef _MSC_VER
+#pragma warning(push)
+#pragma warning(disable : 4275)  // exported type derives from non-exported std::runtime_error
+#endif
+
+/// Raised when the registry cannot hand back a launchable server config:
+/// no config file, malformed JSON, unknown id, disabled entry, or an entry
+/// whose credentials this runtime cannot resolve.
+///
+/// Every message names the id (when there is one), the paths searched, and
+/// what the caller can do about it. A skill that silently loses its MCP tools
+/// produces an agent confidently claiming it cannot do something it was
+/// configured to do, so nothing here degrades quietly.
+class GAIA_API MCPRegistryError : public std::runtime_error {
+public:
+    using std::runtime_error::runtime_error;
+};
+
+#ifdef _MSC_VER
+#pragma warning(pop)
+#endif
+
+/// Read-only registry over the `mcpServers` map on disk.
+///
+/// File shape (identical to Python's, and to the Anthropic/Claude convention):
+/// @code
+///   {
+///     "mcpServers": {
+///       "mcp-github": {
+///         "command": "npx",
+///         "args": ["-y", "@modelcontextprotocol/server-github"],
+///         "env": {"GITHUB_TOKEN": "ghp_..."},
+///         "description": "GitHub repository access"
+///       }
+///     }
+///   }
+/// @endcode
+/// Ids are whatever the file uses; servers added by `gaia connectors` are keyed
+/// by their catalog id (`mcp-github`, `mcp-tavily`, `mcp-memory`, `mcp-git`).
+/// Unknown top-level keys are ignored, so the package-shipped descriptor at
+/// `src/gaia/mcp/mcp.json` (which also carries `clients`, `tools`, …) loads
+/// unchanged. `servers` is accepted as an alias for `mcpServers`, matching
+/// Python's `MCPConfig._read_servers()`.
+///
+/// Search paths, lowest precedence first, under the config directory
+/// (`$GAIA_CONFIG_DIR`, else `~/.gaia`):
+///   1. `mcp.json`         — accepted for hand-written configs
+///   2. `mcp_servers.json` — what `gaia connectors` writes and the Python
+///                           runtime reads; wins on conflicting ids
+///
+/// Two deliberate deviations from Python, both of which split the two runtimes
+/// if you rely on them:
+///   - Python's MCP path always reads `~/.gaia/mcp_servers.json` and does not
+///     honor `GAIA_CONFIG_DIR`; pointing it elsewhere makes this registry read
+///     a file Python will not.
+///   - Python does not read `mcp.json` from the config directory, so an id that
+///     lives only there resolves in C++ and is invisible to Python. Prefer
+///     `mcp_servers.json` for anything both runtimes must see.
+///
+/// Unlike Python, the C++ registry deliberately does **not** pick up an
+/// `mcp_servers.json` from the current working directory: this registry
+/// launches subprocesses, and a native binary that spawns commands named by a
+/// file in whatever directory it happens to be started from is an attack
+/// surface an OEM-shipped agent should not have.
+///
+/// Usage:
+/// @code
+///   MCPRegistry registry;
+///   json config = registry.require("mcp-github");  // throws with the available ids
+///   agent.connectMcpServer("mcp-github", config);
+/// @endcode
+class GAIA_API MCPRegistry {
+public:
+    /// Construct over the default search paths (see class docs).
+    MCPRegistry();
+
+    /// Construct over explicit files, lowest precedence first (tests, embedders).
+    /// @throws std::invalid_argument if `searchPaths` is empty.
+    explicit MCPRegistry(std::vector<std::string> searchPaths);
+
+    /// The config directory: `$GAIA_CONFIG_DIR` when set and non-empty,
+    /// otherwise `~/.gaia` (`%USERPROFILE%\.gaia` on Windows).
+    static std::string configDir();
+
+    /// Files the default-constructed registry reads, lowest precedence first.
+    static std::vector<std::string> defaultSearchPaths();
+
+    /// Look up a server id.
+    /// @return The entry with `command`, `args` and `env` normalized (`args`
+    ///         an array of strings, `env` an object of strings, both present
+    ///         even when the file omits them) and every other key it carried
+    ///         left intact — ready for `MCPClient::fromConfig()` /
+    ///         `Agent::connectMcpServer()`. `std::nullopt` when no entry with
+    ///         that id exists.
+    /// @throws MCPRegistryError if no config file exists, a config file is
+    ///         malformed, or the entry exists but is not launchable: missing
+    ///         `command`, `disabled: true`, a non-stdio `type`, or a `$keyring`
+    ///         credential reference. That last one is how `gaia connectors`
+    ///         stores secrets, so servers configured with one (`mcp-github`,
+    ///         `mcp-tavily`) are Python-only until the C++ runtime grows
+    ///         keychain support.
+    std::optional<json> resolve(const std::string& id) const;
+
+    /// Like resolve(), but an unknown id is an error naming the id, the paths
+    /// searched, and the ids that *are* available.
+    /// @throws MCPRegistryError always, when the id cannot be resolved.
+    json require(const std::string& id) const;
+
+    /// True when the entry is marked `"disabled": true`. Lets a caller walk
+    /// listServers() and skip switched-off servers instead of taking the throw
+    /// from resolve().
+    /// @throws MCPRegistryError if the id is unknown, or on any load failure.
+    bool isDisabled(const std::string& id) const;
+
+    /// All configured server ids, sorted, including entries marked `disabled`.
+    /// @throws MCPRegistryError if no config file exists or one is malformed.
+    std::vector<std::string> listServers() const;
+
+    /// The file entries are read from — the highest-precedence file that
+    /// exists. When none exists, the path the user should create
+    /// (`<configDir>/mcp_servers.json` for a default-constructed registry).
+    std::string configPath() const;
+
+    /// Every path this registry searches, lowest precedence first.
+    const std::vector<std::string>& searchPaths() const { return searchPaths_; }
+
+    /// True when at least one searched file exists. Use this to probe before
+    /// calling resolve() on a machine with no MCP config at all.
+    /// @throws MCPRegistryError if a path cannot be stat'd (e.g. permissions) —
+    ///         "could not tell" is not the same answer as "not configured".
+    bool configExists() const;
+
+    /// Drop the cached parse so the next call re-reads from disk.
+    void reload();
+
+    // Holds a mutex guarding the parse cache, so instances are pinned.
+    MCPRegistry(const MCPRegistry&) = delete;
+    MCPRegistry& operator=(const MCPRegistry&) = delete;
+
+private:
+    /// Parse the search paths into servers_. Caller must hold mutex_.
+    void ensureLoadedLocked() const;
+
+    /// Validate and normalize one raw entry into a launchable config.
+    /// Caller must hold mutex_.
+    /// @throws MCPRegistryError with an actionable message.
+    json normalizeEntry(const std::string& id, const json& entry) const;
+
+    /// Build the "not configured, here is what is" error. Caller must hold mutex_.
+    MCPRegistryError unknownIdError(const std::string& id) const;
+
+    /// fs::exists() that turns an un-stat-able path into a loud error.
+    static bool pathExists(const std::string& path);
+
+    /// "searched: a, b" — reused by every error message.
+    std::string searchedPathsSuffix() const;
+
+    /// The file a user should write to: the highest-precedence search path.
+    std::string writeTargetPath() const;
+
+    std::vector<std::string> searchPaths_;
+
+    mutable std::mutex mutex_;
+    mutable bool loaded_ = false;
+    mutable std::map<std::string, json> servers_;
+    /// id -> the file it came from, so errors name the file the reader must edit.
+    mutable std::map<std::string, std::string> entrySource_;
+};
+
+} // namespace gaia

--- a/cpp/src/agent.cpp
+++ b/cpp/src/agent.cpp
@@ -469,6 +469,17 @@ bool Agent::connectMcpServer(const std::string& name, const json& config) {
     }
 }
 
+bool Agent::connectMcpServerById(const std::string& id) {
+    MCPRegistry registry;
+    return connectMcpServerById(id, registry);
+}
+
+bool Agent::connectMcpServerById(const std::string& id, const MCPRegistry& registry) {
+    // require() throws MCPRegistryError naming the id, the paths searched, and
+    // the ids that are available — deliberately not swallowed here.
+    return connectMcpServer(id, registry.require(id));
+}
+
 json Agent::callMcpTool(const std::string& serverName, const std::string& toolName, const json& args) {
     auto it = mcpClients_.find(serverName);
     if (it == mcpClients_.end()) {

--- a/cpp/src/mcp_registry.cpp
+++ b/cpp/src/mcp_registry.cpp
@@ -1,0 +1,373 @@
+// Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+#include "gaia/mcp_registry.h"
+
+#include <cstdlib>
+#include <filesystem>
+#include <fstream>
+#include <sstream>
+
+namespace fs = std::filesystem;
+
+namespace gaia {
+
+namespace {
+
+/// Join a list of strings with ", " (empty list -> `empty`).
+std::string joinOr(const std::vector<std::string>& items, const char* empty) {
+    if (items.empty()) return empty;
+    std::ostringstream oss;
+    for (size_t i = 0; i < items.size(); ++i) {
+        if (i > 0) oss << ", ";
+        oss << items[i];
+    }
+    return oss.str();
+}
+
+/// Human-readable JSON type name, for shape errors.
+const char* typeName(const json& v) {
+    if (v.is_object()) return "object";
+    if (v.is_array())  return "array";
+    if (v.is_string()) return "string";
+    if (v.is_number()) return "number";
+    if (v.is_boolean()) return "boolean";
+    if (v.is_null())   return "null";
+    return "value";
+}
+
+/// Stringify an env value the way Python's MCPClient does (`str(value)`), so a
+/// server started from either runtime sees byte-identical values.
+std::string pythonStr(const json& value) {
+    if (value.is_boolean()) return value.get<bool>() ? "True" : "False";
+    return value.dump();
+}
+
+} // anonymous namespace
+
+// ---------------------------------------------------------------------------
+// Construction / search paths
+// ---------------------------------------------------------------------------
+
+std::string MCPRegistry::configDir() {
+    const char* configured = std::getenv("GAIA_CONFIG_DIR");  // NOLINT(concurrency-mt-unsafe)
+    if (configured && *configured) return configured;
+#ifdef _WIN32
+    const char* profile = std::getenv("USERPROFILE");  // NOLINT(concurrency-mt-unsafe)
+    std::string home = profile ? profile : "C:\\Users\\Default";
+    return home + "\\.gaia";
+#else
+    const char* home = std::getenv("HOME");  // NOLINT(concurrency-mt-unsafe)
+    std::string h = home ? home : "/tmp";
+    return h + "/.gaia";
+#endif
+}
+
+std::vector<std::string> MCPRegistry::defaultSearchPaths() {
+    fs::path dir(configDir());
+    // Lowest precedence first: `mcp_servers.json` is the file `gaia connectors`
+    // maintains and the Python runtime reads, so it wins over `mcp.json`.
+    return {(dir / "mcp.json").string(), (dir / "mcp_servers.json").string()};
+}
+
+MCPRegistry::MCPRegistry() : MCPRegistry(defaultSearchPaths()) {}
+
+MCPRegistry::MCPRegistry(std::vector<std::string> searchPaths)
+    : searchPaths_(std::move(searchPaths)) {
+    if (searchPaths_.empty()) {
+        throw std::invalid_argument(
+            "MCPRegistry requires at least one search path; pass "
+            "MCPRegistry::defaultSearchPaths() for the standard locations.");
+    }
+}
+
+std::string MCPRegistry::searchedPathsSuffix() const {
+    return "searched: " + joinOr(searchPaths_, "(none)");
+}
+
+std::string MCPRegistry::writeTargetPath() const {
+    return searchPaths_.back();
+}
+
+/// fs::exists() clears `ec` when the file simply is not there, so a set `ec`
+/// means we could not tell — which is not the same as "not configured".
+bool MCPRegistry::pathExists(const std::string& path) {
+    std::error_code ec;
+    bool present = fs::exists(path, ec);
+    if (ec) {
+        throw MCPRegistryError(
+            "Could not check for an MCP server config at " + path + ": " + ec.message() +
+            ". Fix the permissions on that path, or point GAIA_CONFIG_DIR somewhere readable.");
+    }
+    return present;
+}
+
+std::string MCPRegistry::configPath() const {
+    for (auto it = searchPaths_.rbegin(); it != searchPaths_.rend(); ++it) {
+        if (pathExists(*it)) return *it;
+    }
+    return writeTargetPath();
+}
+
+bool MCPRegistry::configExists() const {
+    for (const auto& path : searchPaths_) {
+        if (pathExists(path)) return true;
+    }
+    return false;
+}
+
+void MCPRegistry::reload() {
+    std::lock_guard<std::mutex> lock(mutex_);
+    loaded_ = false;
+    servers_.clear();
+    entrySource_.clear();
+}
+
+// ---------------------------------------------------------------------------
+// Loading
+// ---------------------------------------------------------------------------
+
+void MCPRegistry::ensureLoadedLocked() const {
+    if (loaded_) return;
+
+    std::map<std::string, json> merged;
+    std::map<std::string, std::string> sources;
+    bool foundAnyFile = false;
+
+    for (const auto& path : searchPaths_) {
+        if (!pathExists(path)) continue;
+
+        std::ifstream in(path);
+        if (!in) {
+            throw MCPRegistryError(
+                "MCP server config at " + path + " exists but could not be opened. "
+                "Check the file's permissions.");
+        }
+
+        json data;
+        try {
+            // Strict parse: json::parse() rejects trailing content, which
+            // operator>> silently discards. A half-written config must be a
+            // loud error here, exactly as it is on the Python side.
+            data = json::parse(in);
+        } catch (const json::parse_error& e) {
+            throw MCPRegistryError(
+                "MCP server config at " + path + " is not valid JSON: " + e.what() +
+                ". Fix the file, or delete it and re-add the server with "
+                "`gaia connectors`.");
+        }
+
+        if (!data.is_object()) {
+            throw MCPRegistryError(
+                "MCP server config at " + path + " must be a JSON object with an "
+                "\"mcpServers\" key, got " + typeName(data) + ".");
+        }
+
+        // `servers` is accepted as an alias, matching Python's MCPConfig.
+        const char* key = data.contains("mcpServers") ? "mcpServers"
+                        : data.contains("servers")    ? "servers"
+                                                      : nullptr;
+        if (key == nullptr) {
+            throw MCPRegistryError(
+                "MCP server config at " + path + " has no \"mcpServers\" key. "
+                "Expected {\"mcpServers\": {\"<id>\": {\"command\": ..., \"args\": [...]}}}.");
+        }
+
+        const json& servers = data[key];
+        if (!servers.is_object()) {
+            throw MCPRegistryError(
+                "MCP server config at " + path + ": \"" + key + "\" must be an object "
+                "mapping server ids to configs, got " + typeName(servers) + ".");
+        }
+
+        for (const auto& item : servers.items()) {
+            merged[item.key()] = item.value();   // later file wins
+            sources[item.key()] = path;          // so errors name the right file
+        }
+        foundAnyFile = true;
+    }
+
+    if (!foundAnyFile) {
+        throw MCPRegistryError(
+            "No MCP server configuration found (" + searchedPathsSuffix() + "). "
+            "Add a server with `gaia connectors`, create " + writeTargetPath() +
+            " with {\"mcpServers\": {\"<id>\": {\"command\": \"...\", \"args\": [...]}}}, "
+            "or point GAIA_CONFIG_DIR at the directory that holds it.");
+    }
+
+    servers_ = std::move(merged);
+    entrySource_ = std::move(sources);
+    loaded_ = true;
+}
+
+// ---------------------------------------------------------------------------
+// Entry validation
+// ---------------------------------------------------------------------------
+
+json MCPRegistry::normalizeEntry(const std::string& id, const json& entry) const {
+    auto sourceIt = entrySource_.find(id);
+    const std::string where =
+        sourceIt == entrySource_.end() ? std::string() : " (from " + sourceIt->second + ")";
+
+    if (!entry.is_object()) {
+        throw MCPRegistryError(
+            "MCP server '" + id + "' must be a JSON object with a \"command\" key, got " +
+            typeName(entry) + where + ".");
+    }
+
+    if (entry.contains("disabled")) {
+        if (!entry["disabled"].is_boolean()) {
+            throw MCPRegistryError(
+                "MCP server '" + id + "': \"disabled\" must be true or false, got " +
+                typeName(entry["disabled"]) + where + ".");
+        }
+        if (entry["disabled"].get<bool>()) {
+            throw MCPRegistryError(
+                "MCP server '" + id + "' is disabled" + where +
+                ". Set \"disabled\": false to use it, or drop the key entirely.");
+        }
+    }
+
+    // Same gate as Python's MCPClientManager: stdio is the only transport
+    // either runtime speaks. Saying so beats "has no usable command", which
+    // sends the reader off fixing the wrong line.
+    if (entry.contains("type")) {
+        if (!entry["type"].is_string()) {
+            throw MCPRegistryError(
+                "MCP server '" + id + "': \"type\" must be a string, got " +
+                typeName(entry["type"]) + where + ".");
+        }
+        const std::string transport = entry["type"].get<std::string>();
+        if (transport != "stdio") {
+            throw MCPRegistryError(
+                "MCP server '" + id + "' uses the '" + transport + "' transport" + where +
+                ", and GAIA's MCP client only speaks stdio. Configure a stdio command for "
+                "this server, or drop it from the config.");
+        }
+    }
+
+    if (!entry.contains("command") || !entry["command"].is_string() ||
+        entry["command"].get<std::string>().empty()) {
+        throw MCPRegistryError(
+            "MCP server '" + id + "' has no usable \"command\"" + where +
+            ". Every entry needs a non-empty command string, e.g. "
+            "{\"command\": \"npx\", \"args\": [\"-y\", \"server-github\"]}.");
+    }
+
+    // Keep every key the entry carried and normalize the ones we launch with,
+    // so nothing a caller (or a future GAIA version) put in the file is
+    // dropped on the floor here.
+    json out = entry;
+
+    json args = json::array();
+    if (entry.contains("args")) {
+        if (!entry["args"].is_array()) {
+            throw MCPRegistryError(
+                "MCP server '" + id + "': \"args\" must be an array of strings, got " +
+                typeName(entry["args"]) + where + ".");
+        }
+        size_t index = 0;
+        for (const auto& arg : entry["args"]) {
+            if (!arg.is_string()) {
+                throw MCPRegistryError(
+                    "MCP server '" + id + "': args[" + std::to_string(index) +
+                    "] must be a string, got " + typeName(arg) + where + ".");
+            }
+            args.push_back(arg);
+            ++index;
+        }
+    }
+    out["args"] = std::move(args);
+
+    json env = json::object();
+    if (entry.contains("env")) {
+        if (!entry["env"].is_object()) {
+            throw MCPRegistryError(
+                "MCP server '" + id + "': \"env\" must be an object of string values, got " +
+                typeName(entry["env"]) + where + ".");
+        }
+        for (const auto& kv : entry["env"].items()) {
+            const json& value = kv.value();
+            if (value.is_string()) {
+                env[kv.key()] = value;
+            } else if (value.is_number() || value.is_boolean()) {
+                // Env values are strings to the OS; accept both spellings.
+                env[kv.key()] = pythonStr(value);
+            } else if (value.is_object() && value.contains("$keyring")) {
+                throw MCPRegistryError(
+                    "MCP server '" + id + "' keeps its \"" + kv.key() +
+                    "\" value in the OS keyring (reference " + value["$keyring"].dump() +
+                    ")" + where + ", and this runtime has no keychain support — passing the "
+                    "reference through would hand the server a bogus credential. Launch this "
+                    "server from the Python runtime, which resolves keyring references.");
+            } else {
+                throw MCPRegistryError(
+                    "MCP server '" + id + "': env[\"" + kv.key() +
+                    "\"] must be a string, got " + typeName(value) + where + ".");
+            }
+        }
+    }
+    out["env"] = std::move(env);
+
+    return out;
+}
+
+// ---------------------------------------------------------------------------
+// Lookup
+// ---------------------------------------------------------------------------
+
+MCPRegistryError MCPRegistry::unknownIdError(const std::string& id) const {
+    std::vector<std::string> available;
+    available.reserve(servers_.size());
+    for (const auto& kv : servers_) available.push_back(kv.first);  // std::map: sorted
+
+    std::string message =
+        "MCP server '" + id + "' is not configured (" + searchedPathsSuffix() + "). ";
+    if (available.empty()) {
+        message += "No servers are configured at all. Add one with `gaia connectors`, or "
+                   "write it into " + writeTargetPath() + ".";
+    } else {
+        message += "Available ids: " + joinOr(available, "(none)") + ". Add '" + id +
+                   "' with `gaia connectors`, or write it into " + writeTargetPath() + ".";
+    }
+    return MCPRegistryError(message);
+}
+
+std::optional<json> MCPRegistry::resolve(const std::string& id) const {
+    std::lock_guard<std::mutex> lock(mutex_);
+    ensureLoadedLocked();
+    auto it = servers_.find(id);
+    if (it == servers_.end()) return std::nullopt;
+    return normalizeEntry(id, it->second);
+}
+
+json MCPRegistry::require(const std::string& id) const {
+    std::lock_guard<std::mutex> lock(mutex_);
+    ensureLoadedLocked();
+
+    auto it = servers_.find(id);
+    if (it == servers_.end()) throw unknownIdError(id);
+    return normalizeEntry(id, it->second);
+}
+
+bool MCPRegistry::isDisabled(const std::string& id) const {
+    std::lock_guard<std::mutex> lock(mutex_);
+    ensureLoadedLocked();
+
+    auto it = servers_.find(id);
+    if (it == servers_.end()) throw unknownIdError(id);
+    const json& entry = it->second;
+    return entry.is_object() && entry.contains("disabled") &&
+           entry["disabled"].is_boolean() && entry["disabled"].get<bool>();
+}
+
+std::vector<std::string> MCPRegistry::listServers() const {
+    std::lock_guard<std::mutex> lock(mutex_);
+    ensureLoadedLocked();
+    std::vector<std::string> ids;
+    ids.reserve(servers_.size());
+    for (const auto& kv : servers_) ids.push_back(kv.first);  // std::map: already sorted
+    return ids;
+}
+
+} // namespace gaia

--- a/cpp/tests/fixtures/mcp_servers_python.json
+++ b/cpp/tests/fixtures/mcp_servers_python.json
@@ -1,0 +1,39 @@
+{
+  "mcpServers": {
+    "mcp-github": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "@modelcontextprotocol/server-github"
+      ],
+      "env": {
+        "GITHUB_TOKEN": {
+          "$keyring": "gaia.connections:mcp-github:GITHUB_TOKEN"
+        }
+      },
+      "disabled": false
+    },
+    "mcp-memory": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "@modelcontextprotocol/server-memory"
+      ],
+      "env": {},
+      "disabled": false
+    },
+    "gaia-bridge": {
+      "command": "python",
+      "args": [
+        "-m",
+        "gaia.mcp.mcp_bridge"
+      ],
+      "env": {
+        "LEMONADE_BASE_URL": "http://localhost:13305/api/v1",
+        "GAIA_MCP_HOST": "localhost",
+        "GAIA_MCP_PORT": "8765"
+      },
+      "description": "GAIA MCP Server for exposing AI agents to third-party applications"
+    }
+  }
+}

--- a/cpp/tests/test_mcp_registry.cpp
+++ b/cpp/tests/test_mcp_registry.cpp
@@ -1,0 +1,668 @@
+// Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+#include <gtest/gtest.h>
+#include <gaia/agent.h>
+#include <gaia/mcp_client.h>
+#include <gaia/mcp_registry.h>
+
+#include <atomic>
+#include <cstdlib>
+#include <filesystem>
+#include <fstream>
+#include <map>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include <nlohmann/json.hpp>
+
+using json = nlohmann::json;
+using namespace gaia;
+namespace fs = std::filesystem;
+
+namespace {
+
+/// Set (value != nullptr) or clear an environment variable, portably.
+void setEnvVar(const char* key, const char* value) {
+#ifdef _WIN32
+    _putenv_s(key, value ? value : "");
+#else
+    if (value) {
+        setenv(key, value, 1);  // NOLINT(concurrency-mt-unsafe)
+    } else {
+        unsetenv(key);  // NOLINT(concurrency-mt-unsafe)
+    }
+#endif
+}
+
+/// True when `haystack` contains `needle` — keeps the error-message
+/// assertions readable.
+::testing::AssertionResult contains(const std::string& haystack, const std::string& needle) {
+    if (haystack.find(needle) != std::string::npos) return ::testing::AssertionSuccess();
+    return ::testing::AssertionFailure() << "expected to find \"" << needle
+                                         << "\" in:\n" << haystack;
+}
+
+} // namespace
+
+// ---------------------------------------------------------------------------
+// Fixture — every test gets its own temp config directory
+// ---------------------------------------------------------------------------
+
+class MCPRegistryTest : public ::testing::Test {
+protected:
+    fs::path dir;
+    std::string savedConfigDir;
+    bool hadConfigDir = false;
+
+    void SetUp() override {
+        // Per-test directory: ctest runs these as concurrent processes, and a
+        // shared temp dir means one test's TearDown deletes another's config.
+        const auto* info = ::testing::UnitTest::GetInstance()->current_test_info();
+        dir = fs::temp_directory_path() /
+              ("gaia_mcp_registry_test_" + std::string(info ? info->name() : "unnamed"));
+        fs::remove_all(dir);
+        fs::create_directories(dir);
+
+        if (const char* existing = std::getenv("GAIA_CONFIG_DIR")) {
+            hadConfigDir = true;
+            savedConfigDir = existing;
+        }
+        // Start from a clean slate so a developer who exports GAIA_CONFIG_DIR
+        // does not run a different suite from CI.
+        setEnvVar("GAIA_CONFIG_DIR", nullptr);
+    }
+
+    void TearDown() override {
+        setEnvVar("GAIA_CONFIG_DIR", hadConfigDir ? savedConfigDir.c_str() : nullptr);
+        fs::remove_all(dir);
+    }
+
+    /// Write raw text to <dir>/<name> and return the path.
+    std::string writeFile(const std::string& name, const std::string& contents) const {
+        fs::path path = dir / name;
+        std::ofstream out(path);
+        out << contents;
+        out.close();
+        EXPECT_TRUE(out.good()) << "failed to write " << path.string();
+        return path.string();
+    }
+
+    /// A registry over a single explicit file inside the temp dir.
+    static MCPRegistry over(const std::string& path) {
+        return MCPRegistry(std::vector<std::string>{path});
+    }
+
+    /// Two servers, one of them carrying args + env.
+    std::string writeSampleConfig(const std::string& name = "mcp_servers.json") const {
+        return writeFile(name, R"({
+          "mcpServers": {
+            "github": {
+              "command": "npx",
+              "args": ["-y", "@modelcontextprotocol/server-github"],
+              "env": {"GITHUB_TOKEN": "ghp_example"},
+              "description": "GitHub repository access"
+            },
+            "time": {
+              "command": "uvx",
+              "args": ["mcp-server-time"]
+            }
+          }
+        })");
+    }
+
+    /// Path to the repo's Python-side descriptor, or empty when this is a
+    /// standalone `cpp/` checkout without the Python tree.
+    static fs::path packagedMcpJson() {
+        fs::path repoRoot = fs::path(GAIA_TEST_FIXTURES_DIR)  // <repo>/cpp/tests/fixtures
+                                .parent_path()                // <repo>/cpp/tests
+                                .parent_path()                // <repo>/cpp
+                                .parent_path();               // <repo>
+        fs::path candidate = repoRoot / "src" / "gaia" / "mcp" / "mcp.json";
+        std::error_code ec;
+        return fs::exists(candidate, ec) ? candidate : fs::path();
+    }
+};
+
+// ---------------------------------------------------------------------------
+// Resolution
+// ---------------------------------------------------------------------------
+
+TEST_F(MCPRegistryTest, ResolvesKnownId) {
+    MCPRegistry registry = over(writeSampleConfig());
+
+    auto config = registry.resolve("github");
+    ASSERT_TRUE(config.has_value());
+    EXPECT_EQ((*config)["command"], "npx");
+    EXPECT_EQ((*config)["args"], json::array({"-y", "@modelcontextprotocol/server-github"}));
+    EXPECT_EQ((*config)["env"]["GITHUB_TOKEN"], "ghp_example");
+    EXPECT_EQ((*config)["description"], "GitHub repository access");
+}
+
+TEST_F(MCPRegistryTest, ResolvedConfigIsAcceptedByMCPClientFromConfig) {
+    MCPRegistry registry = over(writeSampleConfig());
+
+    // The whole point of the registry: what it returns is directly launchable.
+    EXPECT_NO_THROW({
+        MCPClient client = MCPClient::fromConfig("github", registry.require("github"));
+        EXPECT_EQ(client.name(), "github");
+    });
+}
+
+TEST_F(MCPRegistryTest, NormalizesMissingArgsAndEnvToEmpty) {
+    MCPRegistry registry = over(writeFile(
+        "mcp_servers.json", R"({"mcpServers": {"bare": {"command": "run-me"}}})"));
+
+    json config = registry.require("bare");
+    EXPECT_EQ(config["command"], "run-me");
+    EXPECT_TRUE(config["args"].is_array());
+    EXPECT_TRUE(config["args"].empty());
+    EXPECT_TRUE(config["env"].is_object());
+    EXPECT_TRUE(config["env"].empty());
+}
+
+TEST_F(MCPRegistryTest, ListServersReturnsSortedIds) {
+    MCPRegistry registry = over(writeSampleConfig());
+    EXPECT_EQ(registry.listServers(), (std::vector<std::string>{"github", "time"}));
+}
+
+TEST_F(MCPRegistryTest, AcceptsServersKeyAlias) {
+    MCPRegistry registry = over(writeFile(
+        "mcp_servers.json", R"({"servers": {"time": {"command": "uvx"}}})"));
+    EXPECT_EQ(registry.require("time")["command"], "uvx");
+}
+
+TEST_F(MCPRegistryTest, IgnoresUnknownTopLevelKeys) {
+    // The packaged descriptor also carries "clients", "tools", "rateLimits", …
+    MCPRegistry registry = over(writeFile("mcp.json", R"({
+      "mcpServers": {"time": {"command": "uvx"}},
+      "clients": {"custom": {"supported": true}},
+      "tools": {"gaia.query": {"description": "…"}},
+      "version": "1.0.0"
+    })"));
+    EXPECT_EQ(registry.require("time")["command"], "uvx");
+}
+
+// ---------------------------------------------------------------------------
+// Fail-loudly paths
+// ---------------------------------------------------------------------------
+
+TEST_F(MCPRegistryTest, UnknownIdRaisesListingAvailableIds) {
+    std::string path = writeSampleConfig();
+    MCPRegistry registry = over(path);
+
+    EXPECT_FALSE(registry.resolve("slack").has_value());
+
+    try {
+        registry.require("slack");
+        FAIL() << "expected MCPRegistryError";
+    } catch (const MCPRegistryError& e) {
+        const std::string msg = e.what();
+        EXPECT_TRUE(contains(msg, "slack"));   // the id asked for
+        EXPECT_TRUE(contains(msg, path));      // where we looked
+        EXPECT_TRUE(contains(msg, "github"));  // what is actually available
+        EXPECT_TRUE(contains(msg, "time"));
+    }
+}
+
+TEST_F(MCPRegistryTest, UnknownIdWithEmptyConfigStillNamesThePath) {
+    std::string path = writeFile("mcp_servers.json", R"({"mcpServers": {}})");
+    MCPRegistry registry = over(path);
+
+    try {
+        registry.require("github");
+        FAIL() << "expected MCPRegistryError";
+    } catch (const MCPRegistryError& e) {
+        const std::string msg = e.what();
+        EXPECT_TRUE(contains(msg, "github"));
+        EXPECT_TRUE(contains(msg, path));
+        EXPECT_TRUE(contains(msg, "No servers are configured"));
+    }
+}
+
+TEST_F(MCPRegistryTest, MissingConfigFileRaisesNamingEverySearchedPath) {
+    std::string a = (dir / "mcp.json").string();
+    std::string b = (dir / "mcp_servers.json").string();
+    MCPRegistry registry(std::vector<std::string>{a, b});
+
+    EXPECT_FALSE(registry.configExists());
+
+    try {
+        registry.resolve("github");
+        FAIL() << "expected MCPRegistryError";
+    } catch (const MCPRegistryError& e) {
+        const std::string msg = e.what();
+        EXPECT_TRUE(contains(msg, a));
+        EXPECT_TRUE(contains(msg, b));
+        EXPECT_TRUE(contains(msg, "GAIA_CONFIG_DIR"));
+    }
+}
+
+TEST_F(MCPRegistryTest, MalformedJsonRaisesWithParseErrorAndPath) {
+    std::string path = writeFile("mcp_servers.json", R"({"mcpServers": {"github": })");
+    MCPRegistry registry = over(path);
+
+    try {
+        registry.listServers();
+        FAIL() << "expected MCPRegistryError";
+    } catch (const MCPRegistryError& e) {
+        const std::string msg = e.what();
+        EXPECT_TRUE(contains(msg, path));
+        EXPECT_TRUE(contains(msg, "parse error"));  // nlohmann's own diagnostic
+    }
+}
+
+TEST_F(MCPRegistryTest, TrailingContentAfterTheJsonObjectRaises) {
+    // A half-overwritten config parses "fine" with operator>>, which discards
+    // everything after the first value. Python's json.load errors on it, so
+    // this must too — otherwise the two runtimes disagree about corruption.
+    std::string path = writeFile("mcp_servers.json",
+                                 R"({"mcpServers": {"time": {"command": "uvx"}}} trailing junk)");
+    MCPRegistry registry = over(path);
+
+    try {
+        registry.listServers();
+        FAIL() << "expected MCPRegistryError";
+    } catch (const MCPRegistryError& e) {
+        EXPECT_TRUE(contains(e.what(), path));
+        EXPECT_TRUE(contains(e.what(), "parse error"));
+    }
+}
+
+TEST_F(MCPRegistryTest, MissingMcpServersKeyRaises) {
+    std::string path = writeFile("mcp_servers.json", R"({"version": "1.0.0"})");
+    MCPRegistry registry = over(path);
+
+    try {
+        registry.listServers();
+        FAIL() << "expected MCPRegistryError";
+    } catch (const MCPRegistryError& e) {
+        EXPECT_TRUE(contains(e.what(), "mcpServers"));
+        EXPECT_TRUE(contains(e.what(), path));
+    }
+}
+
+TEST_F(MCPRegistryTest, EntryWithoutCommandRaises) {
+    MCPRegistry registry = over(writeFile(
+        "mcp_servers.json", R"({"mcpServers": {"broken": {"args": ["x"]}}})"));
+
+    try {
+        registry.require("broken");
+        FAIL() << "expected MCPRegistryError";
+    } catch (const MCPRegistryError& e) {
+        EXPECT_TRUE(contains(e.what(), "broken"));
+        EXPECT_TRUE(contains(e.what(), "command"));
+    }
+}
+
+TEST_F(MCPRegistryTest, DisabledServerRaisesRatherThanVanishing) {
+    MCPRegistry registry = over(writeFile("mcp_servers.json", R"({
+      "mcpServers": {"github": {"command": "npx", "disabled": true}}
+    })"));
+
+    // Still listed — the id exists, it is just switched off. Resolving it is
+    // an error, so a skill declaring mcp:connect:github cannot lose its tools
+    // without anyone noticing.
+    EXPECT_EQ(registry.listServers(), (std::vector<std::string>{"github"}));
+
+    try {
+        registry.require("github");
+        FAIL() << "expected MCPRegistryError";
+    } catch (const MCPRegistryError& e) {
+        EXPECT_TRUE(contains(e.what(), "github"));
+        EXPECT_TRUE(contains(e.what(), "disabled"));
+    }
+}
+
+TEST_F(MCPRegistryTest, NonStdioTransportRaisesNamingTheTransport) {
+    // Same gate as Python's MCPClientManager. Without it the reader gets
+    // "has no usable command" and goes off fixing the wrong line.
+    MCPRegistry registry = over(writeFile("mcp_servers.json", R"({
+      "mcpServers": {"remote": {"type": "sse", "url": "https://example.invalid/sse"}}
+    })"));
+
+    try {
+        registry.require("remote");
+        FAIL() << "expected MCPRegistryError";
+    } catch (const MCPRegistryError& e) {
+        EXPECT_TRUE(contains(e.what(), "sse"));
+        EXPECT_TRUE(contains(e.what(), "stdio"));
+    }
+}
+
+TEST_F(MCPRegistryTest, ResolveThrowsForAPresentButUnlaunchableEntry) {
+    // resolve() returns nullopt only for "no such id". An entry that exists
+    // but cannot be launched is an error, not an absence.
+    MCPRegistry registry = over(writeFile("mcp_servers.json", R"({
+      "mcpServers": {"off": {"command": "npx", "disabled": true},
+                     "headless": {"args": ["x"]}}
+    })"));
+
+    EXPECT_THROW(registry.resolve("off"), MCPRegistryError);
+    EXPECT_THROW(registry.resolve("headless"), MCPRegistryError);
+    EXPECT_FALSE(registry.resolve("absent").has_value());
+}
+
+TEST_F(MCPRegistryTest, IsDisabledLetsCallersSkipInsteadOfCatching) {
+    MCPRegistry registry = over(writeFile("mcp_servers.json", R"({
+      "mcpServers": {"off": {"command": "npx", "disabled": true},
+                     "on": {"command": "uvx"}}
+    })"));
+
+    EXPECT_TRUE(registry.isDisabled("off"));
+    EXPECT_FALSE(registry.isDisabled("on"));
+    EXPECT_THROW(registry.isDisabled("absent"), MCPRegistryError);
+}
+
+TEST_F(MCPRegistryTest, UnrecognizedEntryKeysArePreservedNotDropped) {
+    MCPRegistry registry = over(writeFile("mcp_servers.json", R"({
+      "mcpServers": {"x": {"command": "run", "cwd": "/srv/project", "timeout": 90}}
+    })"));
+
+    json config = registry.require("x");
+    EXPECT_EQ(config["cwd"], "/srv/project");
+    EXPECT_EQ(config["timeout"], 90);
+}
+
+TEST_F(MCPRegistryTest, NonBooleanDisabledRaisesInsteadOfThrowingAJsonTypeError) {
+    MCPRegistry registry = over(writeFile(
+        "mcp_servers.json",
+        R"({"mcpServers": {"github": {"command": "npx", "disabled": "yes"}}})"));
+
+    try {
+        registry.require("github");
+        FAIL() << "expected MCPRegistryError";
+    } catch (const MCPRegistryError& e) {
+        EXPECT_TRUE(contains(e.what(), "disabled"));
+    }
+}
+
+TEST_F(MCPRegistryTest, KeyringEnvReferenceRaisesActionableError) {
+    // What `gaia connectors` writes for a secret env value — the C++ runtime
+    // has no keychain support, so passing the reference string through as the
+    // token would hand the server a bogus credential.
+    MCPRegistry registry = over(writeFile("mcp_servers.json", R"({
+      "mcpServers": {
+        "github": {
+          "command": "npx",
+          "env": {"GITHUB_TOKEN": {"$keyring": "gaia.connections:github:GITHUB_TOKEN"}}
+        }
+      }
+    })"));
+
+    try {
+        registry.require("github");
+        FAIL() << "expected MCPRegistryError";
+    } catch (const MCPRegistryError& e) {
+        EXPECT_TRUE(contains(e.what(), "GITHUB_TOKEN"));
+        EXPECT_TRUE(contains(e.what(), "keyring"));
+    }
+}
+
+TEST_F(MCPRegistryTest, NonStringArgRaisesNamingTheIndex) {
+    MCPRegistry registry = over(writeFile(
+        "mcp_servers.json", R"({"mcpServers": {"x": {"command": "run", "args": ["a", 7]}}})"));
+
+    try {
+        registry.require("x");
+        FAIL() << "expected MCPRegistryError";
+    } catch (const MCPRegistryError& e) {
+        EXPECT_TRUE(contains(e.what(), "args[1]"));
+    }
+}
+
+TEST_F(MCPRegistryTest, NonStringEnvValuesStringifyExactlyAsPythonDoes) {
+    // Python's MCPClient does str(value) — booleans come out "True"/"False",
+    // so a server started from either runtime sees identical bytes.
+    MCPRegistry registry = over(writeFile(
+        "mcp_servers.json",
+        R"({"mcpServers": {"x": {"command": "run",
+                                 "env": {"PORT": 8765, "DEBUG": true, "QUIET": false}}}})"));
+
+    json config = registry.require("x");
+    EXPECT_EQ(config["env"]["PORT"], "8765");
+    EXPECT_EQ(config["env"]["DEBUG"], "True");
+    EXPECT_EQ(config["env"]["QUIET"], "False");
+}
+
+TEST_F(MCPRegistryTest, EmptySearchPathListIsRejected) {
+    EXPECT_THROW(MCPRegistry(std::vector<std::string>{}), std::invalid_argument);
+}
+
+TEST_F(MCPRegistryTest, ConcurrentReadersShareOneParse) {
+    // The lazy parse cache is the reason this class holds a mutex; exercise it.
+    MCPRegistry registry = over(writeSampleConfig());
+
+    std::vector<std::thread> threads;
+    std::atomic<int> resolved{0};
+    for (int i = 0; i < 8; ++i) {
+        threads.emplace_back([&registry, &resolved, i] {
+            for (int n = 0; n < 50; ++n) {
+                if (i % 4 == 0) {
+                    registry.reload();
+                } else if (registry.resolve("github").has_value() &&
+                           registry.listServers().size() == 2) {
+                    resolved.fetch_add(1);
+                }
+            }
+        });
+    }
+    for (auto& t : threads) t.join();
+    EXPECT_GT(resolved.load(), 0);
+}
+
+// ---------------------------------------------------------------------------
+// Config directory resolution
+// ---------------------------------------------------------------------------
+
+TEST_F(MCPRegistryTest, GaiaConfigDirOverrideIsHonored) {
+    writeSampleConfig();
+    setEnvVar("GAIA_CONFIG_DIR", dir.string().c_str());
+
+    EXPECT_EQ(MCPRegistry::configDir(), dir.string());
+
+    MCPRegistry registry;  // default search paths
+    EXPECT_EQ(registry.configPath(), (dir / "mcp_servers.json").string());
+    EXPECT_EQ(registry.require("github")["command"], "npx");
+}
+
+TEST_F(MCPRegistryTest, EmptyGaiaConfigDirFallsBackToHomeDotGaia) {
+    setEnvVar("GAIA_CONFIG_DIR", "");
+    EXPECT_TRUE(contains(MCPRegistry::configDir(), ".gaia"));
+}
+
+TEST_F(MCPRegistryTest, McpServersJsonWinsOverMcpJson) {
+    writeFile("mcp.json",
+              R"({"mcpServers": {"github": {"command": "from-mcp-json"},
+                                 "only-in-mcp-json": {"command": "kept"}}})");
+    writeFile("mcp_servers.json",
+              R"({"mcpServers": {"github": {"command": "from-mcp-servers-json"}}})");
+    setEnvVar("GAIA_CONFIG_DIR", dir.string().c_str());
+
+    MCPRegistry registry;
+    // Conflicting ids resolve to the connectors-maintained file …
+    EXPECT_EQ(registry.require("github")["command"], "from-mcp-servers-json");
+    // … but entries only present in mcp.json are not dropped.
+    EXPECT_EQ(registry.require("only-in-mcp-json")["command"], "kept");
+}
+
+TEST_F(MCPRegistryTest, EntryErrorNamesTheFileTheEntryCameFrom) {
+    std::string lowPrecedence = writeFile(
+        "mcp.json", R"({"mcpServers": {"broken": {"args": ["x"]}}})");
+    writeFile("mcp_servers.json", R"({"mcpServers": {"time": {"command": "uvx"}}})");
+    setEnvVar("GAIA_CONFIG_DIR", dir.string().c_str());
+
+    MCPRegistry registry;
+    try {
+        registry.require("broken");
+        FAIL() << "expected MCPRegistryError";
+    } catch (const MCPRegistryError& e) {
+        // Not the highest-precedence file that happens to exist — the one the
+        // reader actually has to edit.
+        EXPECT_TRUE(contains(e.what(), lowPrecedence));
+    }
+}
+
+TEST_F(MCPRegistryTest, ConfigPathNamesTheFileToCreateWhenNoneExists) {
+    setEnvVar("GAIA_CONFIG_DIR", dir.string().c_str());
+    MCPRegistry registry;
+    EXPECT_FALSE(registry.configExists());
+    EXPECT_EQ(registry.configPath(), (dir / "mcp_servers.json").string());
+}
+
+TEST_F(MCPRegistryTest, ReloadPicksUpAFileWrittenAfterFirstRead) {
+    std::string path = writeFile("mcp_servers.json",
+                                 R"({"mcpServers": {"time": {"command": "uvx"}}})");
+    MCPRegistry registry = over(path);
+    EXPECT_EQ(registry.listServers(), (std::vector<std::string>{"time"}));
+
+    writeFile("mcp_servers.json",
+              R"({"mcpServers": {"time": {"command": "uvx"}, "github": {"command": "npx"}}})");
+    registry.reload();
+    EXPECT_EQ(registry.listServers(), (std::vector<std::string>{"github", "time"}));
+}
+
+// ---------------------------------------------------------------------------
+// Python interop — one configuration, both runtimes
+// ---------------------------------------------------------------------------
+
+TEST_F(MCPRegistryTest, ResolvesEntryInTheShapePythonWrites) {
+    // Checked-in fixture mirroring McpServerHandler.configure()'s output:
+    // catalog-prefixed ids, command / args / env / disabled, and the $keyring
+    // env block it writes for secret values.
+    fs::path fixture = fs::path(GAIA_TEST_FIXTURES_DIR) / "mcp_servers_python.json";
+    ASSERT_TRUE(fs::exists(fixture)) << fixture.string();
+
+    MCPRegistry registry = over(fixture.string());
+    EXPECT_EQ(registry.listServers(),
+              (std::vector<std::string>{"gaia-bridge", "mcp-github", "mcp-memory"}));
+
+    json memory = registry.require("mcp-memory");
+    EXPECT_EQ(memory["command"], "npx");
+    EXPECT_EQ(memory["args"], json::array({"-y", "@modelcontextprotocol/server-memory"}));
+    EXPECT_TRUE(memory["env"].empty());
+    EXPECT_FALSE(registry.isDisabled("mcp-memory"));
+
+    json bridge = registry.require("gaia-bridge");
+    EXPECT_EQ(bridge["command"], "python");
+    EXPECT_EQ(bridge["args"], json::array({"-m", "gaia.mcp.mcp_bridge"}));
+    EXPECT_EQ(bridge["env"]["GAIA_MCP_PORT"], "8765");
+    EXPECT_EQ(bridge["description"],
+              "GAIA MCP Server for exposing AI agents to third-party applications");
+}
+
+TEST_F(MCPRegistryTest, ConnectorsSecretBackedServerIsRefusedNotSilentlyMisconfigured) {
+    // `gaia connectors configure mcp-github` stores GITHUB_TOKEN in the OS
+    // keyring. The C++ runtime has no keychain, so this server is Python-only —
+    // and says so, instead of launching npx with a literal "$keyring" string
+    // as the token and failing somewhere inside GitHub's API.
+    fs::path fixture = fs::path(GAIA_TEST_FIXTURES_DIR) / "mcp_servers_python.json";
+    MCPRegistry registry = over(fixture.string());
+
+    try {
+        registry.require("mcp-github");
+        FAIL() << "expected MCPRegistryError";
+    } catch (const MCPRegistryError& e) {
+        EXPECT_TRUE(contains(e.what(), "mcp-github"));
+        EXPECT_TRUE(contains(e.what(), "GITHUB_TOKEN"));
+        EXPECT_TRUE(contains(e.what(), "keyring"));
+    }
+}
+
+TEST_F(MCPRegistryTest, ResolvesThePackagedPythonMcpJson) {
+    fs::path packaged = packagedMcpJson();
+    if (packaged.empty()) {
+        GTEST_SKIP() << "src/gaia/mcp/mcp.json not present (standalone cpp/ checkout)";
+    }
+
+    // The real file the Python runtime ships, unmodified — extra top-level
+    // keys and all.
+    MCPRegistry registry = over(packaged.string());
+    json bridge = registry.require("gaia-bridge");
+    EXPECT_EQ(bridge["command"], "python");
+    EXPECT_EQ(bridge["args"], json::array({"-m", "gaia.mcp.mcp_bridge"}));
+    EXPECT_EQ(bridge["env"]["LEMONADE_BASE_URL"], "http://localhost:13305/api/v1");
+    EXPECT_EQ(bridge["env"]["GAIA_MCP_HOST"], "localhost");
+    EXPECT_EQ(bridge["env"]["GAIA_MCP_PORT"], "8765");
+}
+
+// ---------------------------------------------------------------------------
+// env actually reaches the launched server process
+// ---------------------------------------------------------------------------
+
+TEST_F(MCPRegistryTest, EnvValuesReachTheStdioTransportChildProcess) {
+#ifdef _WIN32
+    GTEST_SKIP() << "POSIX-only: uses /bin/sh to echo the child's environment";
+#else
+    // A one-shot MCP-ish server: read a request line, answer with the value of
+    // the env var the registry config asked for.
+    fs::path script = dir / "echo_env_server.sh";
+    {
+        std::ofstream out(script);
+        out << "read _line\n"
+            << "printf '{\"jsonrpc\":\"2.0\",\"id\":0,\"result\":{\"seen\":\"%s\"}}\\n'"
+               " \"$GAIA_TEST_MCP_ENV\"\n";
+    }
+
+    MCPRegistry registry = over(writeFile("mcp_servers.json", R"({
+      "mcpServers": {
+        "echo": {
+          "command": "/bin/sh",
+          "args": ["SCRIPT"],
+          "env": {"GAIA_TEST_MCP_ENV": "from-mcp-json"}
+        }
+      }
+    })"));
+    // Patch the script path in (raw string above keeps the JSON readable).
+    json config = registry.require("echo");
+    config["args"][0] = script.string();
+
+    std::vector<std::string> args;
+    for (const auto& arg : config["args"]) args.push_back(arg.get<std::string>());
+    std::map<std::string, std::string> env;
+    for (const auto& kv : config["env"].items()) env[kv.key()] = kv.value().get<std::string>();
+
+    StdioTransport transport(config["command"].get<std::string>(), args, env, 10, false);
+    ASSERT_TRUE(transport.connect());
+    json response = transport.sendRequest("ping");
+    transport.disconnect();
+
+    EXPECT_EQ(response["result"]["seen"], "from-mcp-json");
+#endif
+}
+
+// ---------------------------------------------------------------------------
+// Agent::connectMcpServerById
+// ---------------------------------------------------------------------------
+
+TEST_F(MCPRegistryTest, AgentConnectByIdRaisesOnUnknownId) {
+    MCPRegistry registry = over(writeSampleConfig());
+    Agent agent;
+
+    try {
+        agent.connectMcpServerById("slack", registry);
+        FAIL() << "expected MCPRegistryError";
+    } catch (const MCPRegistryError& e) {
+        EXPECT_TRUE(contains(e.what(), "slack"));
+        EXPECT_TRUE(contains(e.what(), "github"));
+    }
+}
+
+TEST_F(MCPRegistryTest, AgentConnectByIdRaisesWhenNoConfigExists) {
+    MCPRegistry registry = over((dir / "does_not_exist.json").string());
+    Agent agent;
+
+    EXPECT_THROW(agent.connectMcpServerById("github", registry), MCPRegistryError);
+}
+
+TEST_F(MCPRegistryTest, AgentConnectByIdReturnsFalseWhenTheServerFailsToLaunch) {
+    // Resolution succeeds; the launch does not. That is a connection failure,
+    // not a configuration failure, so it keeps connectMcpServer()'s bool contract.
+    MCPRegistry registry = over(writeFile("mcp_servers.json", R"({
+      "mcpServers": {"ghost": {"command": "gaia-no-such-mcp-server-binary"}}
+    })"));
+    Agent agent;
+
+    EXPECT_FALSE(agent.connectMcpServerById("ghost", registry));
+}

--- a/docs/cpp/api-reference.mdx
+++ b/docs/cpp/api-reference.mdx
@@ -283,6 +283,7 @@ public:
 
     // MCP server management
     bool connectMcpServer(const std::string& name, const json& config);
+    bool connectMcpServerById(const std::string& id);  // resolves via MCPRegistry
     void disconnectMcpServer(const std::string& name);
     void disconnectAllMcp();
 
@@ -368,6 +369,81 @@ public:
     json callTool(const std::string& toolName, const json& arguments);
 };
 ```
+
+### MCPRegistry
+
+Turns a configured server **id** into a launchable config, so an agent can connect
+to `github` without hardcoding how `github` is started.
+
+```cpp
+class MCPRegistry {
+public:
+    MCPRegistry();                                          // default search paths
+    explicit MCPRegistry(std::vector<std::string> paths);   // explicit files
+
+    static std::string configDir();                         // $GAIA_CONFIG_DIR, else ~/.gaia
+    static std::vector<std::string> defaultSearchPaths();
+
+    std::optional<json> resolve(const std::string& id) const;  // nullopt if absent
+    json require(const std::string& id) const;                 // throws if unresolvable
+    bool isDisabled(const std::string& id) const;
+    std::vector<std::string> listServers() const;
+    std::string configPath() const;
+    bool configExists() const;
+    void reload();
+};
+```
+
+It reads the same file and the same shape as the Python runtime, so a server configured
+once is reachable from both. Ids are whatever the file uses; `gaia connectors` keys
+entries by their catalog id (`mcp-github`, `mcp-tavily`, `mcp-memory`, `mcp-git`):
+
+```json
+{
+  "mcpServers": {
+    "mcp-memory": {
+      "command": "npx",
+      "args": ["-y", "@modelcontextprotocol/server-memory"],
+      "env": {},
+      "disabled": false
+    }
+  }
+}
+```
+
+```cpp
+gaia::Agent agent;
+agent.connectMcpServerById("mcp-memory");   // throws MCPRegistryError if unconfigured
+```
+
+Search paths, lowest precedence first, under `$GAIA_CONFIG_DIR` (default `~/.gaia`):
+`mcp.json`, then `mcp_servers.json` — the file `gaia connectors` maintains and the
+Python runtime reads, which wins on conflicting ids. Unknown top-level keys are ignored,
+and `servers` is accepted as an alias for `mcpServers`.
+
+Everything that cannot produce a launchable config throws `MCPRegistryError` naming the
+id, the paths searched, and the ids that *are* available: a missing file, malformed JSON,
+an unknown id, an entry marked `"disabled": true`, or a non-stdio `type`. An agent
+silently losing its MCP tools is worse than one that refuses to start.
+
+<Warning>
+**Servers with secrets are Python-only today.** `gaia connectors configure <id>` stores
+secret env values in the OS keyring and writes a `$keyring` reference into the config.
+The C++ runtime has no keychain support, so those entries (`mcp-github`, `mcp-tavily`)
+throw rather than launching the server with the reference string as the credential.
+Servers whose env values are literal — or empty — work from both runtimes.
+</Warning>
+
+Two behaviours to know about, both of which split the runtimes if you rely on them:
+
+- The Python MCP path always reads `~/.gaia/mcp_servers.json` and does **not** honor
+  `GAIA_CONFIG_DIR`. Pointing it elsewhere makes the C++ registry read a file Python won't.
+- Python does not read `mcp.json` from the config directory, so an id that lives only
+  there is invisible to it. Put anything both runtimes need in `mcp_servers.json`.
+
+Unlike the Python runtime, the C++ registry does **not** read an `mcp_servers.json` from
+the current working directory: this config names commands to spawn, and a native binary
+that trusts whichever directory it was started from is an attack surface.
 
 ---
 

--- a/docs/cpp/overview.mdx
+++ b/docs/cpp/overview.mdx
@@ -272,6 +272,7 @@ cpp/
     types.h                 # AgentConfig, Message, ToolInfo, ParsedResponse
     tool_registry.h         # Tool registration and execution
     mcp_client.h            # MCP JSON-RPC client (stdio transport)
+    mcp_registry.h          # Resolves MCP server ids from ~/.gaia/mcp_servers.json
     json_utils.h            # JSON extraction with multi-strategy fallback
     console.h               # TerminalConsole / SilentConsole output handlers
     clean_console.h         # CleanConsole — polished TUI with colors and word-wrap
@@ -279,6 +280,7 @@ cpp/
     agent.cpp               # Agent loop state machine
     tool_registry.cpp
     mcp_client.cpp          # Cross-platform subprocess + pipes
+    mcp_registry.cpp
     json_utils.cpp
     console.cpp
     clean_console.cpp
@@ -293,6 +295,7 @@ cpp/
     test_tool_registry.cpp
     test_json_utils.cpp
     test_mcp_client.cpp
+    test_mcp_registry.cpp
     test_console.cpp
     test_clean_console.cpp
     test_tool_integration.cpp


### PR DESCRIPTION
A C++ agent could only reach an MCP server whose command, args and env were hardcoded into the binary — `MCPClient::fromConfig()` takes a config *object*, and nothing in `cpp/` ever read one off disk. That works for `gaia-bash`, which knows what it connects to; it does not work for a skill-programmable agent, where a `SKILL.md` declares `mcp:connect:github` and the runtime has to turn that id into a launchable server. Now it can: `MCPRegistry` resolves ids against the same `mcpServers` map the Python runtime uses, so a server configured once with `gaia connectors` is reachable from both runtimes, and `Agent::connectMcpServerById("mcp-memory")` just works.

Nothing degrades quietly. A missing config file, malformed JSON, an unknown id, a `"disabled": true` entry, a non-stdio transport, or a `$keyring` credential the C++ runtime has no keychain to resolve each raise an error naming the id, the paths searched, and the ids that *are* available — because a skill that silently loses its tools produces an agent confidently claiming it cannot do something it was configured to do.

### Two things worth a reviewer's eye

- **The file is `mcp_servers.json`, not just `mcp.json`.** The issue names `~/.gaia/mcp.json`, but the file Python's connectors framework actually writes and reads is `~/.gaia/mcp_servers.json` (`src/gaia/connectors/mcp_server.py`, `src/gaia/mcp/client/config.py`). Since the stated goal is one config serving both runtimes, both names are searched, with `mcp_servers.json` winning on conflicting ids. The header and docs call out that an id living only in `mcp.json` is invisible to Python.
- **Secret-backed catalog servers are Python-only today.** `gaia connectors configure mcp-github` stores `GITHUB_TOKEN` in the OS keyring and writes a `$keyring` reference. C++ has no keychain, so those entries throw rather than launching `npx` with the literal reference string as the token. Follow-up tracked in #2819.

### Test plan

- [ ] `cmake -B build -DCMAKE_BUILD_TYPE=Release && cmake --build build -j8 && ctest --test-dir build` from `cpp/` — 477/477 pass, 37 of them new `MCPRegistryTest` cases
- [ ] Interop, against the real Python-side file: `MCPRegistryTest.ResolvesThePackagedPythonMcpJson` loads `src/gaia/mcp/mcp.json` unmodified and resolves `gaia-bridge` with its `env` intact; `ResolvesEntryInTheShapePythonWrites` covers the shape `McpServerHandler.configure()` writes (catalog-prefixed ids, `disabled`, `$keyring` env block)
- [ ] `env` reaches the launched process: `MCPRegistryTest.EnvValuesReachTheStdioTransportChildProcess` spawns a real stdio server and reads the value back out of its environment (POSIX; skipped on Windows)
- [ ] Fail-loudly paths assert on the error *text*, not just the throw — unknown id lists the available ids, missing file names every searched path, malformed JSON carries the parse error, and entry errors name the file the entry came from

<details>
<summary>ctest output</summary>

```
$ ctest --test-dir build -R MCPRegistryTest
...
25/37 Test  #193: MCPRegistryTest.EnvValuesReachTheStdioTransportChildProcess ..............   Passed    0.22 sec
26/37 Test  #194: MCPRegistryTest.AgentConnectByIdRaisesOnUnknownId ........................   Passed    0.01 sec
27/37 Test  #195: MCPRegistryTest.AgentConnectByIdRaisesWhenNoConfigExists .................   Passed    0.01 sec
28/37 Test  #196: MCPRegistryTest.AgentConnectByIdReturnsFalseWhenTheServerFailsToLaunch ...   Passed    0.11 sec

100% tests passed out of 37

$ ctest --test-dir build
100% tests passed out of 477

Total Test time (real) =   3.85 sec
```
</details>

> **CI note:** `C++ Integration Tests (STX)` is currently red on every `cpp` PR — broken CMake cache on the self-hosted runner (#2817, fix in flight). If that is the only failing check and the log shows `Could not find CMAKE_ROOT`, it is not this PR.

Closes #2808
