### PR TITLE
feat(cpp): native OpenAI tool calling and conversational response mode

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -132,6 +132,7 @@ endif()
 # ---------------------------------------------------------------------------
 add_library(gaia_core
     src/types.cpp
+    src/model_registry.cpp
     src/image.cpp
     src/tool_registry.cpp
     src/console.cpp
@@ -309,6 +310,7 @@ if(GAIA_BUILD_TESTS)
         tests/test_lemonade_client.cpp
         tests/test_clean_console.cpp
         tests/test_tool_integration.cpp
+        tests/test_native_tool_calls.cpp
         tests/test_decision.cpp
         tests/test_security.cpp
         tests/test_sse_parser.cpp
@@ -369,6 +371,7 @@ if(GAIA_BUILD_INTEGRATION_TESTS)
         tests/integration/test_integration_wifi.cpp
         tests/integration/test_integration_health.cpp
         tests/integration/test_integration_vlm.cpp
+        tests/integration/test_integration_tool_calls.cpp
     )
 
     target_link_libraries(tests_integration PRIVATE

--- a/cpp/README.md
+++ b/cpp/README.md
@@ -314,7 +314,12 @@ toolRegistry().registerTool(
 );
 ```
 
-When the LLM returns `{"tool": "check_adapter", "tool_args": {...}}`, the agent looks up the callback and invokes it. The return value (JSON) is fed back to the LLM as the next message.
+When the LLM asks for a tool, the agent looks up the callback and invokes it, then feeds the JSON return value back to the LLM as the next message. How the model asks depends on the model:
+
+- **Native OpenAI tool calling** — the registry is sent as a `tools` array and the model replies with `tool_calls`; results go back as `role: tool` messages carrying `tool_call_id`. Parallel calls in one response all execute. Used automatically for models known to support it (`AgentConfig::nativeToolCalls`).
+- **Prompt-JSON fallback** — the model returns `{"tool": "check_adapter", "tool_args": {...}}` in its reply text and results go back as `[Result from check_adapter]:` user turns. Used for every other model.
+
+See the [API Reference](../docs/cpp/api-reference.mdx) for what each protocol sends on the wire.
 
 ### Shell Execution (`runShell`)
 

--- a/cpp/include/gaia/agent.h
+++ b/cpp/include/gaia/agent.h
@@ -120,12 +120,11 @@ public:
 
     /// Replace conversation history (for session resume).
     /// Must NOT be called while processQuery() is running (guarded by inFlight_).
-    void setHistory(std::vector<Message> history) {
-        if (inFlight_.load()) {
-            throw std::runtime_error("Cannot set history while processQuery() is running");
-        }
-        conversationHistory_ = std::move(history);
-    }
+    /// Broken native tool-call pairs are repaired on ingestion: a session file
+    /// written by another build (or hand-edited) can carry a role=tool message
+    /// whose assistant tool_calls turn is missing, which the server rejects on
+    /// the very first request of the next turn.
+    void setHistory(std::vector<Message> history);
 
     /// Request cancellation of the current processQuery() run.
     /// The agent loop checks this flag between steps and exits early
@@ -190,6 +189,9 @@ private:
     struct LlmResult {
         std::string content;
         UsageStats usage;
+        /// Native OpenAI tool calls, when the model answered with them.
+        /// Always empty on the prompt-JSON path.
+        std::vector<ToolCall> toolCalls;
     };
 
     /// Send messages to the LLM and get a response with usage stats.
@@ -206,8 +208,14 @@ private:
     /// Resolve plan parameter placeholders ($PREV.field, $STEP_N.field).
     json resolvePlanParameters(const json& toolArgs, const std::vector<json>& stepResults);
 
-    /// Compose the full system prompt from parts.
+    /// Compose the full system prompt from parts, using a live config snapshot.
     std::string composeSystemPrompt() const;
+
+    /// Compose against an explicit config. The agent loop uses this with its
+    /// turn snapshot so the prompt and the request body can never disagree
+    /// about which tool protocol is active (a concurrent setModel() would
+    /// otherwise flip one and not the other mid-turn).
+    std::string composeSystemPromptFor(const AgentConfig& cfg) const;
 
     /// Call an MCP tool with automatic reconnect on connection failure.
     json callMcpTool(const std::string& serverName, const std::string& toolName, const json& args);
@@ -253,8 +261,11 @@ private:
     // Mutex protecting config_ for concurrent setters / processQuery()
     mutable std::mutex configMutex_;
 
-    // Response format template (shared across all agents)
-    static const std::string RESPONSE_FORMAT_TEMPLATE;
+    // Response format templates (shared across all agents). Neither is sent
+    // when native tool calling is active — the model then uses the OpenAI
+    // function-calling protocol it was trained on.
+    static const std::string RESPONSE_FORMAT_TEMPLATE;              // ResponseMode::Planning
+    static const std::string CONVERSATIONAL_FORMAT_TEMPLATE;        // ResponseMode::Conversational
 };
 
 } // namespace gaia

--- a/cpp/include/gaia/lemonade_client.h
+++ b/cpp/include/gaia/lemonade_client.h
@@ -209,6 +209,17 @@ public:
                                          StreamCallback onToken,
                                          int timeoutSec = LEMONADE_REQUEST_TIMEOUT);
 
+    /// Same as above, additionally reporting native ``tool_calls`` reassembled
+    /// from the stream. A tool-calling model answers with tool_calls deltas and
+    /// no content tokens at all, so callers that support native tool calling
+    /// must use this overload or they will see an apparently empty stream.
+    /// @param outToolCalls  Filled with the accumulated calls (cleared first);
+    ///                      empty when the model replied with prose only.
+    std::string chatCompletionsStreaming(const json& requestBody,
+                                         StreamCallback onToken,
+                                         std::vector<ToolCall>& outToolCalls,
+                                         int timeoutSec = LEMONADE_REQUEST_TIMEOUT);
+
     // ---- Configuration ----
 
     const std::string& baseUrl() const { return baseUrl_; }

--- a/cpp/include/gaia/model_registry.h
+++ b/cpp/include/gaia/model_registry.h
@@ -1,0 +1,47 @@
+// Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: MIT
+//
+// Model capability registry — the C++ mirror of Python's model table.
+//
+// SOURCE OF TRUTH: ``MODELS`` in ``src/gaia/llm/lemonade_client.py``.
+// This file is a hand-maintained mirror of the ``model_id`` -> ``tool_calling``
+// column of that table. When a model is added, removed, or has its
+// ``tool_calling`` flag flipped in Python, mirror the change here in the same
+// commit. ``ModelGateTest.MirrorsThePythonModelTableExactly`` in
+// ``cpp/tests/test_native_tool_calls.cpp`` pins the current contents so a silent
+// drift shows up as a test edit in review.
+
+#pragma once
+
+#include <string>
+#include <vector>
+
+#include "gaia/export.h"
+
+namespace gaia {
+
+/// One row of the mirrored capability table.
+struct ModelCapability {
+    std::string modelId;
+    bool toolCalling;
+};
+
+/// The mirrored table, in the same order as Python's ``MODELS``.
+GAIA_API const std::vector<ModelCapability>& knownModels();
+
+/// Return true when ``modelId`` is known to support native OpenAI
+/// ``tools`` / ``tool_calls`` against the configured server.
+///
+/// Ports Python's ``is_tool_calling_model`` with ONE deliberate divergence:
+/// Python returns ``True`` for an unknown model id (its Tier-0 testing covered
+/// every Lemonade GGUF build). The C++ framework is documented to run against
+/// *any* OpenAI-compatible server — llama.cpp, Ollama, vLLM — where an
+/// unrecognised model id says nothing about tool-calling support. Guessing
+/// "yes" there sends a ``tools`` array to a server that may reject it or
+/// silently ignore it. Unknown therefore resolves to ``false``: the model keeps
+/// the prompt-JSON path that works everywhere, and a caller who knows better
+/// opts in explicitly with ``AgentConfig::nativeToolCalls =
+/// NativeToolCalls::Always``.
+GAIA_API bool isToolCallingModel(const std::string& modelId);
+
+} // namespace gaia

--- a/cpp/include/gaia/sse_parser.h
+++ b/cpp/include/gaia/sse_parser.h
@@ -17,11 +17,14 @@
 #pragma once
 
 #include <functional>
+#include <map>
 #include <string>
+#include <vector>
 
 #include <nlohmann/json.hpp>
 
 #include "gaia/export.h"
+#include "gaia/types.h"
 
 namespace gaia {
 
@@ -53,6 +56,19 @@ public:
     /// Return true if at least one token has been emitted via the callback.
     bool hasTokens() const { return hasTokens_; }
 
+    /// Native tool calls accumulated from ``choices[0].delta.tool_calls``.
+    ///
+    /// Servers fragment these across chunks: the first delta for an index
+    /// carries the id and (usually) the function name, and the JSON argument
+    /// string then arrives in arbitrary pieces. Entries are returned ordered by
+    /// their ``index`` field, which is how parallel calls are distinguished.
+    /// Valid only once done() is true — the arguments string is incomplete
+    /// before then.
+    std::vector<ToolCall> toolCalls() const;
+
+    /// Return true if any tool_calls delta has been seen.
+    bool hasToolCalls() const { return !toolCallsByIndex_.empty(); }
+
 private:
     /// Process one complete SSE line (after newline stripping).
     void processLine(const std::string& line);
@@ -60,10 +76,17 @@ private:
     /// Handle the payload of a data: SSE line.
     void processData(const std::string& payload);
 
+    /// Merge one ``delta.tool_calls`` array into the accumulator.
+    void accumulateToolCalls(const json& deltaToolCalls);
+
     TokenCallback callback_;
     std::string   buffer_;     // Accumulates partial lines across feed() calls
     bool          done_      = false;
     bool          hasTokens_ = false;
+
+    // Keyed by the delta's ``index`` so parallel calls stay separate and
+    // out-of-order chunks land in the right slot. std::map keeps index order.
+    std::map<int, ToolCall> toolCallsByIndex_;
 };
 
 } // namespace gaia

--- a/cpp/include/gaia/tool_registry.h
+++ b/cpp/include/gaia/tool_registry.h
@@ -66,6 +66,12 @@ public:
     /// Mirrors Python Agent._format_tools_for_prompt().
     std::string formatForPrompt() const;
 
+    /// Build OpenAI function-calling schemas for every *enabled* tool.
+    /// Mirrors Python Agent._build_openai_tool_schemas(). Returns a JSON array
+    /// suitable for the ``tools`` field of a /chat/completions request; the
+    /// array is empty when no tool is enabled.
+    json buildOpenAiToolSchemas() const;
+
     /// Execute a tool by name.
     /// Resolves the name if not found directly.
     /// Enforces policy, argument validation, and confirmation before invoking.

--- a/cpp/include/gaia/types.h
+++ b/cpp/include/gaia/types.h
@@ -137,11 +137,41 @@ inline std::string roleToString(MessageRole r) {
     return "unknown";
 }
 
+/// One entry of an OpenAI ``tool_calls`` array.
+///
+/// ``arguments`` is kept as the raw JSON *string* the model emitted, exactly as
+/// the wire format carries it. Decoding is explicit via parsedArgs() so a
+/// malformed payload surfaces as a thrown error at the point of use rather than
+/// as a silently-empty argument object.
+struct ToolCall {
+    std::string id;        // e.g. "call_abc123" — correlates the role=tool reply
+    std::string name;      // function.name
+    std::string arguments; // function.arguments — a JSON object encoded as a string
+
+    /// Decode ``arguments`` into a JSON object.
+    /// An empty/whitespace-only string decodes to ``{}`` (what servers emit for
+    /// a zero-argument function). Anything that is not a JSON object throws
+    /// std::runtime_error naming the tool, the id, and the offending payload.
+    json parsedArgs() const;
+
+    /// Serialize to the OpenAI ``tool_calls`` element shape.
+    json toJson() const;
+
+    /// Parse one ``tool_calls`` element. Throws std::runtime_error with an
+    /// actionable message when ``id`` or ``function.name`` is missing or blank.
+    static ToolCall fromJson(const json& j);
+};
+
 struct Message {
     MessageRole role;
     std::string content;
     std::optional<std::string> name;       // Tool name (for role=TOOL)
     std::optional<std::string> toolCallId; // Tool call ID (for role=TOOL)
+
+    /// Native OpenAI tool calls carried by an ASSISTANT message. When non-empty,
+    /// toJson() emits a spec-correct ``tool_calls`` array and sends ``content``
+    /// as JSON null if it is empty (matching Python's assistant-turn shape).
+    std::vector<ToolCall> toolCalls;
 
     /// When present, `parts` supersedes `content` on serialization:
     /// toJson() emits content as a JSON array of ContentPart. `content` is
@@ -304,6 +334,41 @@ struct Decision {
     std::string description; // hint: "Confirm and proceed"
 };
 
+// ---- Response / tool-call protocol selection ----
+
+/// Shape the agent asks the model to reply in when the prompt-JSON path is
+/// active. Mirrors Python ``Agent.response_mode``.
+///   Planning       — JSON-only replies with thought/goal/plan/tool structure.
+///   Conversational — plain text, with a bare JSON object only for tool calls.
+/// Ignored when native tool calling is active: the model then uses the OpenAI
+/// function-calling protocol and no response-format template is sent at all.
+enum class ResponseMode { Planning, Conversational };
+
+/// Whether to drive tools with the native OpenAI ``tools`` / ``tool_calls``
+/// protocol instead of the prompt-JSON envelope.
+///   Auto   — decide per model via isToolCallingModel() (default).
+///   Always — force native, whatever the model id says. Use for an
+///            OpenAI-compatible server whose model ids this build cannot know.
+///   Never  — force the prompt-JSON path.
+enum class NativeToolCalls { Auto, Always, Never };
+
+inline std::string responseModeToString(ResponseMode m) {
+    return m == ResponseMode::Conversational ? "conversational" : "planning";
+}
+
+inline std::string nativeToolCallsToString(NativeToolCalls m) {
+    switch (m) {
+        case NativeToolCalls::Auto:   return "auto";
+        case NativeToolCalls::Always: return "always";
+        case NativeToolCalls::Never:  return "never";
+    }
+    return "auto";
+}
+
+/// Throws std::invalid_argument on an unrecognized value (no silent default).
+ResponseMode responseModeFromString(const std::string& s);
+NativeToolCalls nativeToolCallsFromString(const std::string& s);
+
 struct AgentConfig {
     std::string baseUrl = defaultBaseUrl();
     std::string modelId = "Qwen3-4B-GGUF";
@@ -321,6 +386,20 @@ struct AgentConfig {
                                     // even during streaming. Used by JsonEventOutputHandler
                                     // so the TUI/WebUI gets both stream tokens AND agent events.
     double temperature = 0.7;  // LLM sampling temperature (0.0 = deterministic)
+
+    /// Reply shape requested on the prompt-JSON path. Ignored under native
+    /// tool calling.
+    ResponseMode responseMode = ResponseMode::Planning;
+
+    /// Native OpenAI tool-calling policy. Auto consults isToolCallingModel().
+    NativeToolCalls nativeToolCalls = NativeToolCalls::Auto;
+
+    /// Value sent as ``tool_choice`` when native tool calling is active.
+    /// "auto" lets the model decide; "required" forces a call; "none" disables.
+    std::string toolChoice = "auto";
+
+    /// Resolve the Auto policy against ``modelId``.
+    bool useNativeToolCalls() const;
 
     /// Validate config fields; throws std::invalid_argument on violation.
     void validate() const;

--- a/cpp/include/gaia/types.h
+++ b/cpp/include/gaia/types.h
@@ -395,7 +395,8 @@ struct AgentConfig {
     NativeToolCalls nativeToolCalls = NativeToolCalls::Auto;
 
     /// Value sent as ``tool_choice`` when native tool calling is active.
-    /// "auto" lets the model decide; "required" forces a call; "none" disables.
+    /// "auto" lets the model decide; "required" forces a call. To disable
+    /// native tool calling entirely, set nativeToolCalls = NativeToolCalls::Never.
     std::string toolChoice = "auto";
 
     /// Resolve the Auto policy against ``modelId``.

--- a/cpp/src/agent.cpp
+++ b/cpp/src/agent.cpp
@@ -6,6 +6,7 @@
 
 #include <iostream>
 #include <regex>
+#include <set>
 #include <sstream>
 #include <stdexcept>
 
@@ -31,6 +32,21 @@ You must respond ONLY in valid JSON. No text before { or after }.
 3. You may include a "plan" to show your intended steps, but always execute only the "tool" field
 4. After each tool result, you can change, skip, or add steps - the plan is a roadmap, not a script
 5. After all tools complete, provide an "answer" summarizing results
+)";
+
+// Conversational format template (mirrors Python Agent._CONVERSATIONAL_FORMAT)
+const std::string Agent::CONVERSATIONAL_FORMAT_TEMPLATE = R"(
+==== RESPONSE FORMAT ====
+Respond in plain text for normal conversation.
+
+When you need to call a tool, output ONLY a JSON object on a single line:
+{"tool": "tool_name", "tool_args": {"arg1": "value1"}}
+
+Use the full tool name exactly as registered. A name with only the
+server prefix (e.g. ending in `_mcp`) is incomplete.
+
+When responding conversationally (no tool call needed), just write plain text.
+Do NOT wrap conversational replies in JSON.
 )";
 
 Agent::Agent(const AgentConfig& config)
@@ -154,6 +170,9 @@ void Agent::setModel(const std::string& modelId) {
         std::lock_guard<std::mutex> lock(configMutex_);
         config_.modelId = modelId;
         modelEnsured_ = false;
+        // The model decides whether native tool calling is on, which decides
+        // whether the response-format template belongs in the prompt.
+        systemPromptDirty_ = true;
     }
     lemonade_.setModel(modelId);
 }
@@ -232,6 +251,15 @@ void Agent::rebuildSystemPrompt() {
 }
 
 std::string Agent::composeSystemPrompt() const {
+    AgentConfig snapshot;
+    {
+        std::lock_guard<std::mutex> lock(configMutex_);
+        snapshot = config_;
+    }
+    return composeSystemPromptFor(snapshot);
+}
+
+std::string Agent::composeSystemPromptFor(const AgentConfig& cfg) const {
     std::ostringstream oss;
 
     // Agent-specific prompt
@@ -240,14 +268,24 @@ std::string Agent::composeSystemPrompt() const {
         oss << custom << "\n\n";
     }
 
-    // Tool descriptions
+    // Tool descriptions. Kept even under native tool calling — Python does the
+    // same, and the prose list is what lets the model reason about which tool
+    // fits before emitting the call.
     std::string toolsDesc = tools_.formatForPrompt();
     if (!toolsDesc.empty()) {
         oss << "==== AVAILABLE TOOLS ====\n" << toolsDesc << "\n";
     }
 
-    // Response format
-    oss << RESPONSE_FORMAT_TEMPLATE;
+    // Response format — omitted only when the request will actually carry a
+    // `tools` array, which is what makes tool-calling models emit tool_calls
+    // instead of prose JSON. With no enabled tool there is no `tools` field, so
+    // dropping the template too would leave the model with no protocol at all.
+    const bool willSendTools = cfg.useNativeToolCalls() && !tools_.enabledTools().empty();
+    if (!willSendTools) {
+        oss << (cfg.responseMode == ResponseMode::Conversational
+                    ? CONVERSATIONAL_FORMAT_TEMPLATE
+                    : RESPONSE_FORMAT_TEMPLATE);
+    }
 
     return oss.str();
 }
@@ -255,6 +293,44 @@ std::string Agent::composeSystemPrompt() const {
 // ---- LLM Communication ----
 
 namespace {
+/// Reject stream-assembled tool calls that never received an id or a name.
+/// Sending them on would produce a tool reply with an empty ``tool_call_id``,
+/// which a spec-strict server rejects on the next request.
+void validateStreamedToolCalls(const std::vector<ToolCall>& calls) {
+    for (size_t i = 0; i < calls.size(); ++i) {
+        if (calls[i].id.empty()) {
+            throw std::runtime_error(
+                "Streamed tool_calls entry " + std::to_string(i) +
+                " never received an 'id' across the SSE deltas, so its result "
+                "cannot be correlated back to the call. Function name seen: '" +
+                calls[i].name + "'.");
+        }
+        if (calls[i].name.empty()) {
+            throw std::runtime_error(
+                "Streamed tool_calls entry " + std::to_string(i) + " (id " +
+                calls[i].id + ") never received a 'function.name', so there is "
+                "no tool to execute.");
+        }
+    }
+}
+
+/// Parse a non-streaming ``message.tool_calls`` array. Throws (with the entry
+/// echoed) rather than dropping malformed entries — a silently-skipped call
+/// looks to the loop like the model chose not to act.
+std::vector<ToolCall> parseToolCallsArray(const json& arr) {
+    std::vector<ToolCall> calls;
+    if (!arr.is_array()) {
+        throw std::runtime_error(
+            "Malformed LLM response: 'tool_calls' is a JSON " +
+            std::string(arr.type_name()) + ", expected an array.");
+    }
+    calls.reserve(arr.size());
+    for (const auto& entry : arr) {
+        calls.push_back(ToolCall::fromJson(entry));
+    }
+    return calls;
+}
+
 UsageStats extractUsage(const json& responseJson) {
     UsageStats usage;
     if (responseJson.contains("usage") && responseJson["usage"].is_object()) {
@@ -291,20 +367,57 @@ Agent::LlmResult Agent::callLlm(const std::vector<Message>& messages, const std:
 
     requestBody["messages"] = msgArray;
 
+    // Native OpenAI tool calling — the request keeps exactly its legacy shape
+    // when this is off, so non-tool-calling models see a byte-identical body.
+    const bool nativeTools = cfg.useNativeToolCalls();
+    if (nativeTools) {
+        json toolSchemas = tools_.buildOpenAiToolSchemas();
+        if (!toolSchemas.empty()) {
+            requestBody["tools"] = std::move(toolSchemas);
+            requestBody["tool_choice"] = cfg.toolChoice;
+        }
+    }
+
     if (cfg.debug) {
-        std::cerr << "[LLM] POST /chat/completions, messages=" << msgArray.size() << std::endl;
+        std::cerr << "[LLM] POST /chat/completions, messages=" << msgArray.size()
+                  << ", native_tools=" << (requestBody.contains("tools") ? "yes" : "no")
+                  << std::endl;
     }
 
     // ---- Streaming path ----
     if (config_.streaming) {
         std::string accumulated;
+        std::vector<ToolCall> streamedToolCalls;
         std::string rawResponse = lemonade_.chatCompletionsStreaming(
             requestBody,
             [this, &accumulated](const std::string& token) {
                 accumulated += token;
                 console_->printStreamToken(token);
-            }
+            },
+            streamedToolCalls
         );
+
+        // Never consume tool_calls we did not ask for. Some servers volunteer
+        // them (llama.cpp --jinja) even with no `tools` in the request; acting
+        // on that would send an assistant tool_calls turn back with no `tools`
+        // field, which strict servers reject — and would break an agent that
+        // explicitly opted out via NativeToolCalls::Never.
+        if (!nativeTools) streamedToolCalls.clear();
+
+        // A tool-calling model answers with tool_calls deltas and often no
+        // content at all, so this is checked before the empty-stream error.
+        if (!streamedToolCalls.empty()) {
+            validateStreamedToolCalls(streamedToolCalls);
+            if (!accumulated.empty()) console_->printStreamEnd();
+            UsageStats usage;
+            try {
+                usage = extractUsage(json::parse(rawResponse));
+            } catch (...) {}
+            if (cfg.debug) {
+                std::cerr << "[LLM] streamed tool_calls=" << streamedToolCalls.size() << std::endl;
+            }
+            return {accumulated, usage, std::move(streamedToolCalls)};
+        }
 
         if (!accumulated.empty()) {
             console_->printStreamEnd();
@@ -315,7 +428,7 @@ Agent::LlmResult Agent::callLlm(const std::vector<Message>& messages, const std:
                 const json responseJson = json::parse(rawResponse);
                 usage = extractUsage(responseJson);
             } catch (...) {}
-            return {accumulated, usage};
+            return {accumulated, usage, {}};
         }
 
         // Fallback: server returned a non-streaming response despite "stream":true.
@@ -325,12 +438,26 @@ Agent::LlmResult Agent::callLlm(const std::vector<Message>& messages, const std:
                 const json responseJson = json::parse(rawResponse);
                 if (responseJson.contains("choices") && !responseJson["choices"].empty()) {
                     const auto& choice = responseJson["choices"][0];
-                    if (choice.contains("message") && choice["message"].contains("content")
-                        && choice["message"]["content"].is_string()) {
-                        return {choice["message"]["content"].get<std::string>(),
-                                extractUsage(responseJson)};
+                    if (choice.contains("message")) {
+                        const auto& message = choice["message"];
+                        if (nativeTools && message.contains("tool_calls")
+                            && !message["tool_calls"].is_null()
+                            && !message["tool_calls"].empty()) {
+                            std::string text;
+                            if (message.contains("content") && message["content"].is_string()) {
+                                text = message["content"].get<std::string>();
+                            }
+                            return {text, extractUsage(responseJson),
+                                    parseToolCallsArray(message["tool_calls"])};
+                        }
+                        if (message.contains("content") && message["content"].is_string()) {
+                            return {message["content"].get<std::string>(),
+                                    extractUsage(responseJson), {}};
+                        }
                     }
                 }
+            } catch (const std::runtime_error&) {
+                throw; // malformed tool_calls — surface it, don't fall through
             } catch (...) {}
         }
 
@@ -341,24 +468,41 @@ Agent::LlmResult Agent::callLlm(const std::vector<Message>& messages, const std:
     std::string responseBody = lemonade_.chatCompletions(requestBody);
 
     // Parse response
+    json responseJson;
     try {
-        json responseJson = json::parse(responseBody);
-
-        if (responseJson.contains("choices") && !responseJson["choices"].empty()) {
-            auto& choice = responseJson["choices"][0];
-            if (choice.contains("message") && choice["message"].contains("content")
-                && choice["message"]["content"].is_string()) {
-                return {choice["message"]["content"].get<std::string>(),
-                        extractUsage(responseJson)};
-            }
-        }
-        // Include truncated response body in error for debugging
-        std::string preview = responseBody.substr(0, 200);
-        throw std::runtime_error("Unexpected LLM response format: " + preview);
+        responseJson = json::parse(responseBody);
     } catch (const json::parse_error& e) {
         std::string preview = responseBody.substr(0, 200);
-        throw std::runtime_error(std::string("Failed to parse LLM response: ") + e.what() + " | body: " + preview);
+        throw std::runtime_error(std::string("Failed to parse LLM response: ") + e.what() +
+                                 " | body: " + preview);
     }
+
+    if (responseJson.contains("choices") && !responseJson["choices"].empty()) {
+        const auto& choice = responseJson["choices"][0];
+        if (choice.contains("message")) {
+            const auto& message = choice["message"];
+            // tool_calls first: a native call carries content: null, which the
+            // content-only check below would reject as an unexpected format.
+            // Gated on nativeTools — a server that volunteers tool_calls we did
+            // not request must not knock an opted-out agent off the prompt-JSON
+            // path (its `content` is still the answer we want).
+            if (nativeTools && message.contains("tool_calls")
+                && !message["tool_calls"].is_null()
+                && !message["tool_calls"].empty()) {
+                std::string text;
+                if (message.contains("content") && message["content"].is_string()) {
+                    text = message["content"].get<std::string>();
+                }
+                return {text, extractUsage(responseJson),
+                        parseToolCallsArray(message["tool_calls"])};
+            }
+            if (message.contains("content") && message["content"].is_string()) {
+                return {message["content"].get<std::string>(), extractUsage(responseJson), {}};
+            }
+        }
+    }
+    // Include truncated response body in error for debugging
+    throw std::runtime_error("Unexpected LLM response format: " + responseBody.substr(0, 200));
 }
 
 // ---- Tool Execution ----
@@ -635,7 +779,91 @@ std::string summarizeUserInput(const std::vector<Message>& userMessages) {
     }
     return "";
 }
+
+// Loop detection: true when the previous (maxConsecutiveRepeats - 1) calls were
+// all this exact tool+args, making the pending one the Nth identical call.
+bool isRepeatedToolCall(const std::vector<std::pair<std::string, json>>& history,
+                        const std::string& toolName, const json& toolArgs,
+                        int maxConsecutiveRepeats) {
+    const int repeatThreshold = maxConsecutiveRepeats - 1;
+    // A threshold of 0 vacuously matches — preserved from the inline version
+    // this replaced. AgentConfig::validate() requires maxConsecutiveRepeats >= 2,
+    // so it is only reachable from an unvalidated hand-built config.
+    if (static_cast<int>(history.size()) < repeatThreshold) return false;
+    for (size_t i = history.size() - static_cast<size_t>(repeatThreshold);
+         i < history.size(); ++i) {
+        if (history[i].first != toolName || history[i].second != toolArgs) {
+            return false;
+        }
+    }
+    return true;
+}
+
+// Serialize a tool result for the model, clipping the middle of oversized
+// payloads so both the head and the tail survive.
+std::string truncateToolResult(const json& toolResult) {
+    std::string resultStr = toolResult.dump();
+    if (resultStr.size() > 4000) {
+        resultStr = resultStr.substr(0, 2000) + "\n...[truncated]...\n" +
+                    resultStr.substr(resultStr.size() - 1500);
+    }
+    return resultStr;
+}
+
+// Make native tool_calls and their role=tool replies consistent before the
+// history is stored. OpenAI-compatible servers reject both halves of a broken
+// pair, and history is replayed verbatim on the next turn.
+//
+// Two ways a pair breaks:
+//   - An assistant turn advertises a call that was never answered (the run was
+//     cancelled between two parallel calls).
+//   - A role=tool reply outlives the assistant turn that requested it (history
+//     pruning trims from the head).
+void repairToolCallPairing(std::vector<Message>& messages) {
+    // Pass 1: which tool_call_ids actually got a reply.
+    std::set<std::string> answered;
+    for (const auto& msg : messages) {
+        if (msg.role == MessageRole::TOOL && msg.toolCallId.has_value()) {
+            answered.insert(*msg.toolCallId);
+        }
+    }
+
+    // Pass 2: drop unanswered calls, then drop replies with no surviving call.
+    std::set<std::string> requested;
+    std::vector<Message> kept;
+    kept.reserve(messages.size());
+    for (auto& msg : messages) {
+        if (msg.role == MessageRole::ASSISTANT && !msg.toolCalls.empty()) {
+            std::vector<ToolCall> live;
+            for (auto& tc : msg.toolCalls) {
+                if (answered.count(tc.id)) {
+                    requested.insert(tc.id);
+                    live.push_back(std::move(tc));
+                }
+            }
+            msg.toolCalls = std::move(live);
+            // An assistant turn with neither content nor calls says nothing.
+            if (msg.toolCalls.empty() && msg.content.empty() && !msg.parts.has_value()) {
+                continue;
+            }
+        } else if (msg.role == MessageRole::TOOL && msg.toolCallId.has_value()) {
+            if (!requested.count(*msg.toolCallId)) {
+                continue; // its assistant turn is gone
+            }
+        }
+        kept.push_back(std::move(msg));
+    }
+    messages = std::move(kept);
+}
 } // namespace
+
+void Agent::setHistory(std::vector<Message> history) {
+    if (inFlight_.load()) {
+        throw std::runtime_error("Cannot set history while processQuery() is running");
+    }
+    repairToolCallPairing(history);
+    conversationHistory_ = std::move(history);
+}
 
 json Agent::processQueryInternal(const std::vector<Message>& userMessages, int maxSteps) {
     // Empty-input validation FIRST — no HTTP call, no /load.
@@ -741,20 +969,30 @@ json Agent::processQueryInternal(const std::vector<Message>& userMessages, int m
                 "TOOL EXECUTION FAILED!\n\n"
                 "Error: " + lastError + "\n\n"
                 "Original task: " + userInput + "\n\n"
-                "Please analyze the error and try an alternative approach.\n"
-                R"(Respond with {"thought": "...", "goal": "...", "tool": "...", "tool_args": {...}})";
+                "Please analyze the error and try an alternative approach.\n";
+            // The envelope reminder only applies to the prompt-JSON path; under
+            // native tool calling it would fight the function-calling protocol.
+            if (!cfg.useNativeToolCalls()) {
+                errorMsg.content +=
+                    R"(Respond with {"thought": "...", "goal": "...", "tool": "...", "tool_args": {...}})";
+            }
             messages.push_back(errorMsg);
 
             executionState_ = AgentState::PLANNING;
             stepResults.clear();
         }
 
+        // Recomposed each step so mid-loop tool changes are visible, but always
+        // from the turn's config snapshot — the same one callLlm() uses to
+        // decide whether to send `tools`.
+        const std::string turnSystemPrompt = composeSystemPromptFor(cfg);
+
         // Call LLM (retry once on failure).
         // Skip progress spinner when streaming — tokens serve as live progress.
         if (!config_.streaming) console_->startProgress("Thinking");
         LlmResult llmResult;
         try {
-            llmResult = callLlm(messages, systemPrompt(), cfg);
+            llmResult = callLlm(messages, turnSystemPrompt, cfg);
         } catch (const std::exception& e) {
             if (!config_.streaming) console_->stopProgress();
             console_->printWarning(std::string("LLM call failed, retrying: ") + e.what());
@@ -762,7 +1000,7 @@ json Agent::processQueryInternal(const std::vector<Message>& userMessages, int m
             // Retry once
             if (!config_.streaming) console_->startProgress("Retrying");
             try {
-                llmResult = callLlm(messages, systemPrompt(), cfg);
+                llmResult = callLlm(messages, turnSystemPrompt, cfg);
             } catch (const std::exception& e2) {
                 if (!config_.streaming) console_->stopProgress();
                 console_->printError(std::string("LLM error: ") + e2.what());
@@ -778,6 +1016,91 @@ json Agent::processQueryInternal(const std::vector<Message>& userMessages, int m
         // Debug: show response
         if (cfg.showPrompts) {
             console_->printResponse(response, "LLM Response");
+        }
+
+        // ---- Native OpenAI tool_calls branch ----
+        // Emits a spec-correct assistant turn carrying tool_calls, then one
+        // role=tool reply per call keyed by tool_call_id. Handles parallel
+        // calls: a single response may carry several.
+        if (!llmResult.toolCalls.empty()) {
+            // Decode every argument payload BEFORE running anything. A batch
+            // where call 2 is malformed must not leave call 1's side effects
+            // behind an exception that unwinds past the history write — and
+            // processQuery() is documented to report errors in "result", not
+            // to throw.
+            std::vector<json> decodedArgs;
+            decodedArgs.reserve(llmResult.toolCalls.size());
+            std::string decodeError;
+            for (const auto& tc : llmResult.toolCalls) {
+                try {
+                    decodedArgs.push_back(tc.parsedArgs());
+                } catch (const std::exception& e) {
+                    decodeError = e.what();
+                    break;
+                }
+            }
+            if (!decodeError.empty()) {
+                console_->printError("Malformed tool call: " + decodeError);
+                finalAnswer = "Unable to complete task due to LLM error: " + decodeError;
+                break;
+            }
+
+            Message nativeAssistantMsg;
+            nativeAssistantMsg.role = MessageRole::ASSISTANT;
+            nativeAssistantMsg.content = response;
+            nativeAssistantMsg.toolCalls = llmResult.toolCalls;
+            messages.push_back(nativeAssistantMsg);
+
+            // structuredEvents consumers (TUI/WebUI) expect a thought per step;
+            // a native turn's reasoning is whatever prose came with the calls.
+            if (!config_.streaming || config_.structuredEvents) {
+                console_->printThought(response);
+            }
+
+            bool loopDetected = false;
+            for (size_t i = 0; i < llmResult.toolCalls.size(); ++i) {
+                const auto& tc = llmResult.toolCalls[i];
+                if (cancelled_.load()) break;
+
+                const json& toolArgs = decodedArgs[i];
+
+                if (isRepeatedToolCall(toolCallHistory, tc.name, toolArgs,
+                                       cfg.maxConsecutiveRepeats)) {
+                    console_->printWarning("Detected repeated tool call loop. Breaking out.");
+                    finalAnswer = "Task stopped due to repeated tool call loop.";
+                    loopDetected = true;
+                    break;
+                }
+
+                console_->printToolUsage(tc.name);
+                console_->prettyPrintJson(toolArgs, "Tool Args");
+                console_->startProgress("Executing " + tc.name);
+
+                json toolResult = executeTool(tc.name, toolArgs);
+
+                console_->stopProgress();
+                console_->printToolComplete();
+                console_->prettyPrintJson(toolResult, "Tool Result");
+
+                toolCallHistory.emplace_back(tc.name, toolArgs);
+                stepResults.push_back(toolResult);
+
+                Message toolMsg;
+                toolMsg.role = MessageRole::TOOL;
+                toolMsg.name = tc.name;
+                toolMsg.toolCallId = tc.id;
+                toolMsg.content = truncateToolResult(toolResult);
+                messages.push_back(toolMsg);
+
+                if (toolResult.is_object() && toolResult.value("status", "") == "error") {
+                    ++errorCount;
+                    lastError = toolResult.value("error", "Unknown error");
+                    executionState_ = AgentState::ERROR_RECOVERY;
+                }
+            }
+
+            if (loopDetected) break;
+            continue;
         }
 
         // Add LLM response to messages
@@ -826,24 +1149,11 @@ json Agent::processQueryInternal(const std::vector<Message>& userMessages, int m
             if (toolArgs.is_null()) toolArgs = json::object();
 
             // Loop detection — same tool+args repeated maxConsecutiveRepeats times
-            {
-                int repeatThreshold = cfg.maxConsecutiveRepeats - 1;
-                if (static_cast<int>(toolCallHistory.size()) >= repeatThreshold) {
-                    bool allSame = true;
-                    for (size_t i = toolCallHistory.size() - static_cast<size_t>(repeatThreshold);
-                         i < toolCallHistory.size(); ++i) {
-                        if (toolCallHistory[i].first != toolName ||
-                            toolCallHistory[i].second != toolArgs) {
-                            allSame = false;
-                            break;
-                        }
-                    }
-                    if (allSame) {
-                        console_->printWarning("Detected repeated tool call loop. Breaking out.");
-                        finalAnswer = "Task stopped due to repeated tool call loop.";
-                        break;
-                    }
-                }
+            if (isRepeatedToolCall(toolCallHistory, toolName, toolArgs,
+                                   cfg.maxConsecutiveRepeats)) {
+                console_->printWarning("Detected repeated tool call loop. Breaking out.");
+                finalAnswer = "Task stopped due to repeated tool call loop.";
+                break;
             }
 
             console_->printToolUsage(toolName);
@@ -863,12 +1173,7 @@ json Agent::processQueryInternal(const std::vector<Message>& userMessages, int m
             Message toolMsg;
             toolMsg.role = MessageRole::TOOL;
             toolMsg.name = toolName;
-            std::string resultStr = toolResult.dump();
-            if (resultStr.size() > 4000) {
-                resultStr = resultStr.substr(0, 2000) + "\n...[truncated]...\n" +
-                            resultStr.substr(resultStr.size() - 1500);
-            }
-            toolMsg.content = resultStr;
+            toolMsg.content = truncateToolResult(toolResult);
             messages.push_back(toolMsg);
 
             // Check for error
@@ -900,17 +1205,18 @@ json Agent::processQueryInternal(const std::vector<Message>& userMessages, int m
     console_->printCompletion(stepsTaken, stepsLimit);
 
     // Store conversation history for session persistence.
-    // Convert TOOL messages to USER messages so the LLM server can replay
-    // them without requiring tool_call_id / tool_calls pairing.
+    // Prompt-JSON tool results are converted to USER messages so the LLM server
+    // can replay them without tool_call_id / tool_calls pairing. Native tool
+    // results keep their spec-correct role=tool + tool_call_id shape — the
+    // matching assistant turn carrying tool_calls is in history alongside them.
     // Strip image parts (base64 data URIs) so they don't accumulate in
     // history across turns — text-only retention by contract.
     for (auto& msg : messages) {
-        if (msg.role == MessageRole::TOOL) {
+        if (msg.role == MessageRole::TOOL && !msg.toolCallId.has_value()) {
             std::string toolName = msg.name.value_or("tool");
             msg.role = MessageRole::USER;
             msg.content = "[Result from " + toolName + "]: " + msg.content;
             msg.name = std::nullopt;
-            msg.toolCallId = std::nullopt;
         }
         if (msg.parts.has_value()) {
             msg = stripImageParts(std::move(msg));
@@ -923,6 +1229,7 @@ json Agent::processQueryInternal(const std::vector<Message>& userMessages, int m
         messages.erase(messages.begin(),
                        messages.begin() + (static_cast<int>(messages.size()) - cfg.maxHistoryMessages));
     }
+    repairToolCallPairing(messages);
     conversationHistory_ = messages;
 
     json result = {

--- a/cpp/src/lemonade_client.cpp
+++ b/cpp/src/lemonade_client.cpp
@@ -539,6 +539,16 @@ void LemonadeClient::httpPostStreaming(const std::string& path, const std::strin
 std::string LemonadeClient::chatCompletionsStreaming(const json& requestBody,
                                                       StreamCallback onToken,
                                                       int timeoutSec) {
+    std::vector<ToolCall> ignored;
+    return chatCompletionsStreaming(requestBody, std::move(onToken), ignored, timeoutSec);
+}
+
+std::string LemonadeClient::chatCompletionsStreaming(const json& requestBody,
+                                                      StreamCallback onToken,
+                                                      std::vector<ToolCall>& outToolCalls,
+                                                      int timeoutSec) {
+    outToolCalls.clear();
+
     json body = requestBody;
     body["stream"] = true;
 
@@ -559,7 +569,7 @@ std::string LemonadeClient::chatCompletionsStreaming(const json& requestBody,
 
     // If no tokens were extracted, the server may have returned an error or a
     // non-streaming response. Apply the same embedded-error check as chatCompletions().
-    if (!parser.hasTokens() && !rawBytes.empty()) {
+    if (!parser.hasTokens() && !parser.hasToolCalls() && !rawBytes.empty()) {
         try {
             const json responseJson = json::parse(rawBytes);
             if (responseJson.contains("error")) {
@@ -592,6 +602,17 @@ std::string LemonadeClient::chatCompletionsStreaming(const json& requestBody,
         }
     }
 
+    // Only a completed stream yields complete argument strings. A connection
+    // dropped mid-tool_call can leave arguments that still parse (a balanced
+    // brace lands by luck) but mean something else entirely — executing that
+    // is worse than failing.
+    if (parser.hasToolCalls() && !parser.done()) {
+        throw std::runtime_error(
+            "Stream ended before [DONE] while assembling tool_calls — the "
+            "arguments are incomplete and must not be executed. Check the "
+            "server connection and retry.");
+    }
+    outToolCalls = parser.toolCalls();
     return rawBytes;
 }
 

--- a/cpp/src/lemonade_client.cpp
+++ b/cpp/src/lemonade_client.cpp
@@ -605,7 +605,8 @@ std::string LemonadeClient::chatCompletionsStreaming(const json& requestBody,
     // Only a completed stream yields complete argument strings. A connection
     // dropped mid-tool_call can leave arguments that still parse (a balanced
     // brace lands by luck) but mean something else entirely — executing that
-    // is worse than failing.
+    // is worse than failing. Deliberately fires for the tool-less overload
+    // too: a truncated stream is a failed request whoever asked for it.
     if (parser.hasToolCalls() && !parser.done()) {
         throw std::runtime_error(
             "Stream ended before [DONE] while assembling tool_calls — the "

--- a/cpp/src/model_registry.cpp
+++ b/cpp/src/model_registry.cpp
@@ -1,0 +1,33 @@
+// Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+#include "gaia/model_registry.h"
+
+namespace gaia {
+
+const std::vector<ModelCapability>& knownModels() {
+    // Mirrors MODELS in src/gaia/llm/lemonade_client.py (see header note).
+    // gemma4-it-e2b-FLM is false because the FastFlowLM/NPU server 500s on an
+    // OpenAI ``tools`` payload; the embedders are false because they never chat.
+    static const std::vector<ModelCapability> kModels = {
+        {"Gemma-4-E4B-it-GGUF",        true},
+        {"gemma4-it-e2b-FLM",          false},
+        {"Qwen3.5-35B-A3B-GGUF",       true},
+        {"Qwen3-0.6B-GGUF",            true},
+        {"Qwen3-VL-4B-Instruct-GGUF",  true},
+        {"Qwen3-8B-GGUF",              true},
+        {"user.embeddinggemma-300m-GGUF", false},
+        {"embed-gemma-300m-FLM",       false},
+    };
+    return kModels;
+}
+
+bool isToolCallingModel(const std::string& modelId) {
+    if (modelId.empty()) return false;
+    for (const auto& m : knownModels()) {
+        if (m.modelId == modelId) return m.toolCalling;
+    }
+    return false; // Unknown model — conservative. See header for the rationale.
+}
+
+} // namespace gaia

--- a/cpp/src/session.cpp
+++ b/cpp/src/session.cpp
@@ -149,6 +149,13 @@ Message SessionStore::messageFromJson(const json& j) {
     if (j.contains("tool_call_id") && j["tool_call_id"].is_string()) {
         m.toolCallId = j["tool_call_id"].get<std::string>();
     }
+    // Native tool_calls must round-trip, or a resumed session replays role=tool
+    // messages whose originating assistant turn has lost its tool_calls array.
+    if (j.contains("tool_calls") && j["tool_calls"].is_array()) {
+        for (const auto& entry : j["tool_calls"]) {
+            m.toolCalls.push_back(ToolCall::fromJson(entry));
+        }
+    }
 
     return m;
 }

--- a/cpp/src/sse_parser.cpp
+++ b/cpp/src/sse_parser.cpp
@@ -77,6 +77,11 @@ void SseParser::processData(const std::string& payload) {
         if (!choice.contains("delta")) return;
 
         const auto& delta = choice["delta"];
+
+        if (delta.contains("tool_calls") && delta["tool_calls"].is_array()) {
+            accumulateToolCalls(delta["tool_calls"]);
+        }
+
         if (!delta.contains("content") || delta["content"].is_null()) return;
 
         const std::string token = delta["content"].get<std::string>();
@@ -87,6 +92,58 @@ void SseParser::processData(const std::string& payload) {
     } catch (...) {
         // Silently skip malformed JSON — servers occasionally send partial events
     }
+}
+
+void SseParser::accumulateToolCalls(const json& deltaToolCalls) {
+    int positional = 0;
+    for (const auto& entry : deltaToolCalls) {
+        if (!entry.is_object()) continue;
+
+        // `index` is how parallel calls stay apart across deltas. When a server
+        // omits it, fall back to the entry's position within THIS delta —
+        // servers that drop `index` send the whole array in one delta, so
+        // slotting everything at 0 would merge N calls into one mangled call.
+        int index = positional;
+        if (entry.contains("index") && entry["index"].is_number_integer()) {
+            index = entry["index"].get<int>();
+        }
+        ++positional;
+        ToolCall& tc = toolCallsByIndex_[index];
+
+        // A delta carrying an `id` is a first-or-restated call; one without is a
+        // continuation fragment. That distinction is what keeps a repeated
+        // `{"id":..,"name":"echo"}` from accumulating into "echoecho" while
+        // still reassembling a genuinely split name.
+        const bool hasId = entry.contains("id") && entry["id"].is_string() &&
+                           !entry["id"].get<std::string>().empty();
+        if (tc.id.empty() && hasId) {
+            tc.id = entry["id"].get<std::string>();
+        }
+
+        if (!entry.contains("function") || !entry["function"].is_object()) continue;
+        const auto& fn = entry["function"];
+
+        if (fn.contains("name") && fn["name"].is_string()) {
+            if (hasId) {
+                tc.name = fn["name"].get<std::string>();   // (re)statement
+            } else {
+                tc.name += fn["name"].get<std::string>();  // continuation
+            }
+        }
+        if (fn.contains("arguments") && fn["arguments"].is_string()) {
+            tc.arguments += fn["arguments"].get<std::string>();
+        }
+    }
+}
+
+std::vector<ToolCall> SseParser::toolCalls() const {
+    std::vector<ToolCall> out;
+    out.reserve(toolCallsByIndex_.size());
+    for (const auto& [index, tc] : toolCallsByIndex_) {
+        (void)index;
+        out.push_back(tc);
+    }
+    return out;
 }
 
 } // namespace gaia

--- a/cpp/src/tool_registry.cpp
+++ b/cpp/src/tool_registry.cpp
@@ -133,6 +133,67 @@ std::string ToolRegistry::formatForPrompt() const {
     return oss.str();
 }
 
+namespace {
+/// OpenAI requires function names to match ^[a-zA-Z0-9_-]{1,64}$. MCP tools are
+/// named mcp_<server>_<tool> from user-supplied server names, so a dot, space,
+/// or a long pair can silently produce a name the server rejects — 400-ing the
+/// whole request, not just that tool.
+bool isValidOpenAiFunctionName(const std::string& name) {
+    if (name.empty() || name.size() > 64) return false;
+    for (char c : name) {
+        const bool ok = (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') ||
+                        (c >= '0' && c <= '9') || c == '_' || c == '-';
+        if (!ok) return false;
+    }
+    return true;
+}
+} // namespace
+
+json ToolRegistry::buildOpenAiToolSchemas() const {
+    json schemas = json::array();
+    for (const auto& [name, tool] : tools_) {
+        if (!tool.enabled) continue;
+
+        if (!isValidOpenAiFunctionName(name)) {
+            throw std::invalid_argument(
+                "Tool '" + name + "' cannot be sent as an OpenAI function: names must "
+                "match ^[a-zA-Z0-9_-]{1,64}$ (got " + std::to_string(name.size()) +
+                " chars). Rename the tool — or, for an MCP tool, the MCP server whose "
+                "name is prefixed onto it. To keep this tool on the prompt-JSON path "
+                "instead, set AgentConfig::nativeToolCalls = NativeToolCalls::Never.");
+        }
+
+        json properties = json::object();
+        json required = json::array();
+        for (const auto& param : tool.parameters) {
+            json prop;
+            // UNKNOWN maps to "string" — the same coercion Python's
+            // _python_to_json_type applies to an unrecognized annotation.
+            prop["type"] = (param.type == ToolParamType::UNKNOWN)
+                               ? "string"
+                               : paramTypeToString(param.type);
+            if (!param.description.empty()) {
+                prop["description"] = param.description;
+            }
+            properties[param.name] = prop;
+            if (param.required) {
+                required.push_back(param.name);
+            }
+        }
+
+        schemas.push_back(json{
+            {"type", "function"},
+            {"function",
+             {{"name", name},
+              {"description", tool.description},
+              {"parameters",
+               {{"type", "object"},
+                {"properties", properties},
+                {"required", required}}}}}});
+    }
+    return schemas;
+}
+
 json ToolRegistry::executeTool(const std::string& name, const json& args) {
     const ToolInfo* tool = findTool(name);
     if (!tool) {

--- a/cpp/src/types.cpp
+++ b/cpp/src/types.cpp
@@ -3,6 +3,8 @@
 
 #include "gaia/types.h"
 
+#include "gaia/model_registry.h"
+
 #include <cstring>
 #include <fstream>
 #include <stdexcept>
@@ -81,6 +83,79 @@ ContentPart ContentPart::makeImageUrl(std::string url) {
     return p;
 }
 
+// ---- ToolCall ----
+
+json ToolCall::parsedArgs() const {
+    const auto firstNonWs = arguments.find_first_not_of(" \t\n\r");
+    if (firstNonWs == std::string::npos) {
+        return json::object(); // zero-argument function
+    }
+    json parsed;
+    try {
+        parsed = json::parse(arguments);
+    } catch (const json::parse_error& e) {
+        throw std::runtime_error(
+            "Model returned tool call '" + name + "' (id " + id +
+            ") with arguments that are not valid JSON: " + e.what() +
+            "\n  Raw arguments: " + arguments.substr(0, 400) +
+            "\n  Retry the query, or set AgentConfig::nativeToolCalls = "
+            "NativeToolCalls::Never to use the prompt-JSON path with this model.");
+    }
+    if (!parsed.is_object()) {
+        throw std::runtime_error(
+            "Model returned tool call '" + name + "' (id " + id +
+            ") whose arguments decoded to a JSON " + std::string(parsed.type_name()) +
+            ", not an object.\n  Raw arguments: " + arguments.substr(0, 400));
+    }
+    return parsed;
+}
+
+json ToolCall::toJson() const {
+    return json{{"id", id},
+                {"type", "function"},
+                {"function", {{"name", name}, {"arguments", arguments}}}};
+}
+
+ToolCall ToolCall::fromJson(const json& j) {
+    if (!j.is_object()) {
+        throw std::runtime_error(
+            "Malformed tool_calls entry: expected a JSON object, got " +
+            std::string(j.type_name()) + ".");
+    }
+    ToolCall tc;
+    if (j.contains("id") && j["id"].is_string()) {
+        tc.id = j["id"].get<std::string>();
+    }
+    if (tc.id.empty()) {
+        throw std::runtime_error(
+            "Malformed tool_calls entry: missing a non-empty string 'id'. Without "
+            "it the role=tool reply cannot be correlated back to the call.\n"
+            "  Entry: " + j.dump().substr(0, 400));
+    }
+    if (!j.contains("function") || !j["function"].is_object()) {
+        throw std::runtime_error(
+            "Malformed tool_calls entry (id " + tc.id +
+            "): missing the 'function' object.\n  Entry: " + j.dump().substr(0, 400));
+    }
+    const auto& fn = j["function"];
+    if (fn.contains("name") && fn["name"].is_string()) {
+        tc.name = fn["name"].get<std::string>();
+    }
+    if (tc.name.empty()) {
+        throw std::runtime_error(
+            "Malformed tool_calls entry (id " + tc.id +
+            "): 'function.name' is missing or empty, so there is no tool to "
+            "execute.\n  Entry: " + j.dump().substr(0, 400));
+    }
+    if (fn.contains("arguments") && fn["arguments"].is_string()) {
+        tc.arguments = fn["arguments"].get<std::string>();
+    } else if (fn.contains("arguments") && fn["arguments"].is_object()) {
+        // Some OpenAI-compatible servers send arguments pre-decoded.
+        tc.arguments = fn["arguments"].dump();
+    }
+    return tc;
+}
+
 // ---- Message ----
 
 json Message::toJson() const {
@@ -92,11 +167,23 @@ json Message::toJson() const {
             arr.push_back(p.toJson());
         }
         j["content"] = arr;
+    } else if (role == MessageRole::ASSISTANT && !toolCalls.empty() && content.empty()) {
+        // OpenAI assistant turns carrying only tool_calls send content as null.
+        j["content"] = nullptr;
     } else {
         j["content"] = content;
     }
     if (name.has_value()) j["name"] = name.value();
     if (toolCallId.has_value()) j["tool_call_id"] = toolCallId.value();
+    // tool_calls belong to assistant turns only — emitting them on a tool or
+    // user message produces a body OpenAI-compatible servers reject.
+    if (role == MessageRole::ASSISTANT && !toolCalls.empty()) {
+        json arr = json::array();
+        for (const auto& tc : toolCalls) {
+            arr.push_back(tc.toJson());
+        }
+        j["tool_calls"] = arr;
+    }
     return j;
 }
 
@@ -120,6 +207,32 @@ Message Message::fromUser(const std::string& text, const std::vector<Image>& ima
     return m;
 }
 
+// ---- Response / tool-call protocol selection ----
+
+ResponseMode responseModeFromString(const std::string& s) {
+    if (s == "planning")       return ResponseMode::Planning;
+    if (s == "conversational") return ResponseMode::Conversational;
+    throw std::invalid_argument(
+        "responseMode must be \"planning\" or \"conversational\", got \"" + s + "\"");
+}
+
+NativeToolCalls nativeToolCallsFromString(const std::string& s) {
+    if (s == "auto")   return NativeToolCalls::Auto;
+    if (s == "always") return NativeToolCalls::Always;
+    if (s == "never")  return NativeToolCalls::Never;
+    throw std::invalid_argument(
+        "nativeToolCalls must be \"auto\", \"always\" or \"never\", got \"" + s + "\"");
+}
+
+bool AgentConfig::useNativeToolCalls() const {
+    switch (nativeToolCalls) {
+        case NativeToolCalls::Always: return true;
+        case NativeToolCalls::Never:  return false;
+        case NativeToolCalls::Auto:   return isToolCallingModel(modelId);
+    }
+    return false;
+}
+
 void AgentConfig::validate() const {
     if (baseUrl.empty())
         throw std::invalid_argument("baseUrl must not be empty");
@@ -139,6 +252,13 @@ void AgentConfig::validate() const {
         throw std::invalid_argument("maxHistoryMessages must be >= 0 (0 = unlimited)");
     if (temperature < 0.0 || temperature > 2.0)
         throw std::invalid_argument("temperature must be in [0.0, 2.0]");
+    // "none" is deliberately rejected: it would declare tools, forbid their use,
+    // AND suppress the prompt-JSON template, leaving the agent no way to call
+    // anything. Set nativeToolCalls = "never" to turn native tool calling off.
+    if (toolChoice != "auto" && toolChoice != "required")
+        throw std::invalid_argument(
+            "toolChoice must be \"auto\" or \"required\", got \"" + toolChoice +
+            "\" (to disable native tool calling set nativeToolCalls = \"never\")");
 }
 
 AgentConfig AgentConfig::fromJson(const json& j) {
@@ -157,6 +277,14 @@ AgentConfig AgentConfig::fromJson(const json& j) {
     c.silentMode            = j.value("silentMode",            c.silentMode);
     c.structuredEvents      = j.value("structuredEvents",      c.structuredEvents);
     c.temperature           = j.value("temperature",           c.temperature);
+    c.toolChoice            = j.value("toolChoice",            c.toolChoice);
+    if (j.contains("responseMode")) {
+        c.responseMode = responseModeFromString(j.at("responseMode").get<std::string>());
+    }
+    if (j.contains("nativeToolCalls")) {
+        c.nativeToolCalls =
+            nativeToolCallsFromString(j.at("nativeToolCalls").get<std::string>());
+    }
     c.validate();
     return c;
 }
@@ -191,7 +319,10 @@ json AgentConfig::toJson() const {
         {"streaming",             streaming},
         {"silentMode",            silentMode},
         {"structuredEvents",      structuredEvents},
-        {"temperature",           temperature}
+        {"temperature",           temperature},
+        {"responseMode",          responseModeToString(responseMode)},
+        {"nativeToolCalls",       nativeToolCallsToString(nativeToolCalls)},
+        {"toolChoice",            toolChoice}
     };
 }
 

--- a/cpp/tests/integration/test_integration_tool_calls.cpp
+++ b/cpp/tests/integration/test_integration_tool_calls.cpp
@@ -1,0 +1,237 @@
+// Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: MIT
+//
+// Native OpenAI tool calling against a LIVE Lemonade server (issue #2794).
+//
+// A mocked server can only prove we *sent* a tools array; it can never prove
+// the server accepts its shape. These tests exist to catch a schema that a real
+// OpenAI-compatible backend rejects (the #1655 lesson in CLAUDE.md).
+//
+// Requires: lemonade-server running at GAIA_CPP_BASE_URL
+//           (default http://localhost:13305/api/v1) with a tool-calling model
+//           available. Defaults to Gemma-4-E4B-it-GGUF; override with
+//           GAIA_CPP_TOOL_MODEL.
+//
+// Build:
+//   cmake -B build -S cpp -DGAIA_BUILD_INTEGRATION_TESTS=ON
+//   cmake --build build --config Release
+// Run:
+//   ctest --test-dir build -C Release -R ToolCalls --output-on-failure
+
+#include <gtest/gtest.h>
+
+#include <gaia/agent.h>
+#include <gaia/lemonade_client.h>
+#include <gaia/model_registry.h>
+#include <gaia/tool_registry.h>
+#include <gaia/types.h>
+
+#include <algorithm>
+#include <cctype>
+#include <string>
+#include <vector>
+
+namespace {
+
+std::string toolModel() {
+    return gaia::getEnvVar("GAIA_CPP_TOOL_MODEL", "Gemma-4-E4B-it-GGUF");
+}
+
+std::string baseUrl() {
+    return gaia::getEnvVar("GAIA_CPP_BASE_URL", "http://localhost:13305/api/v1");
+}
+
+gaia::AgentConfig toolConfig(int maxSteps = 5) {
+    gaia::AgentConfig cfg;
+    cfg.baseUrl = baseUrl();
+    cfg.modelId = toolModel();
+    cfg.maxSteps = maxSteps;
+    cfg.silentMode = true;
+    cfg.temperature = 0.0;  // deterministic tool selection
+    return cfg;
+}
+
+std::string toLower(std::string s) {
+    std::transform(s.begin(), s.end(), s.begin(),
+                   [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
+    return s;
+}
+
+/// Agent exposing one unambiguous tool the model cannot answer without.
+class WeatherAgent : public gaia::Agent {
+public:
+    WeatherAgent() : Agent(toolConfig()) { init(); }
+
+    std::vector<std::string> calledCities;
+
+protected:
+    void registerTools() override {
+        toolRegistry().registerTool(
+            "get_weather", "Get the current weather for a city",
+            [this](const gaia::json& args) -> gaia::json {
+                calledCities.push_back(args.value("city", ""));
+                return gaia::json{{"city", args.value("city", "")},
+                                  {"temperature_c", 21},
+                                  {"conditions", "sunny"}};
+            },
+            {{"city", gaia::ToolParamType::STRING, true, "City name, e.g. Austin"}});
+    }
+
+    std::string getSystemPrompt() const override {
+        return "You are a weather assistant. Use the get_weather tool to answer "
+               "questions about weather. Never guess the weather yourself.";
+    }
+};
+
+} // namespace
+
+// ---------------------------------------------------------------------------
+// The emitted schema must be ACCEPTED by the server, not merely well-formed
+// ---------------------------------------------------------------------------
+
+TEST(ToolCallsIntegrationTest, EmittedToolsSchemaIsAcceptedByLemonade) {
+    // Posts the exact schema buildOpenAiToolSchemas() produces and asserts the
+    // server returns a 200 with a usable completion. A 400 here means the
+    // schema shape is wrong — the failure mode a mocked test cannot see.
+    gaia::ToolRegistry registry;
+    registry.registerTool(
+        "get_weather", "Get the current weather for a city",
+        [](const gaia::json&) -> gaia::json { return gaia::json{}; },
+        {{"city", gaia::ToolParamType::STRING, true, "City name"},
+         {"units", gaia::ToolParamType::STRING, false, "celsius or fahrenheit"}});
+    registry.registerTool(
+        "list_cities", "List known cities",
+        [](const gaia::json&) -> gaia::json { return gaia::json{}; });
+
+    gaia::LemonadeClient client(
+        gaia::LemonadeClientConfig{baseUrl(), toolModel(), 8192, false});
+    ASSERT_NO_THROW(client.ensureModelLoaded())
+        << "Lemonade must be running with " << toolModel() << " available";
+
+    gaia::json body;
+    body["model"] = toolModel();
+    body["max_tokens"] = 256;
+    body["temperature"] = 0.0;
+    body["messages"] = gaia::json::array(
+        {{{"role", "system"}, {"content", "Use tools when they apply."}},
+         {{"role", "user"}, {"content", "What is the weather in Austin?"}}});
+    body["tools"] = registry.buildOpenAiToolSchemas();
+    body["tool_choice"] = "auto";
+
+    std::string response;
+    ASSERT_NO_THROW(response = client.chatCompletions(body))
+        << "Server rejected the emitted tools schema:\n" << body["tools"].dump(2);
+
+    gaia::json parsed = gaia::json::parse(response);
+    ASSERT_TRUE(parsed.contains("choices")) << response.substr(0, 600);
+    ASSERT_FALSE(parsed["choices"].empty()) << response.substr(0, 600);
+    ASSERT_TRUE(parsed["choices"][0].contains("message")) << response.substr(0, 600);
+}
+
+TEST(ToolCallsIntegrationTest, ServerReturnsParseableToolCallsForTheSchema) {
+    gaia::ToolRegistry registry;
+    registry.registerTool(
+        "get_weather", "Get the current weather for a city",
+        [](const gaia::json&) -> gaia::json { return gaia::json{}; },
+        {{"city", gaia::ToolParamType::STRING, true, "City name, e.g. Austin"}});
+
+    gaia::LemonadeClient client(
+        gaia::LemonadeClientConfig{baseUrl(), toolModel(), 8192, false});
+    ASSERT_NO_THROW(client.ensureModelLoaded());
+
+    gaia::json body;
+    body["model"] = toolModel();
+    body["max_tokens"] = 256;
+    body["temperature"] = 0.0;
+    body["messages"] = gaia::json::array(
+        {{{"role", "system"},
+          {"content", "You are a weather assistant. Always call get_weather; never guess."}},
+         {{"role", "user"}, {"content", "What is the weather in Austin?"}}});
+    body["tools"] = registry.buildOpenAiToolSchemas();
+    body["tool_choice"] = "required";
+
+    gaia::json parsed = gaia::json::parse(client.chatCompletions(body));
+    const auto& message = parsed["choices"][0]["message"];
+    ASSERT_TRUE(message.contains("tool_calls"))
+        << "Model did not emit native tool_calls for the required tool_choice:\n"
+        << message.dump(2);
+    ASSERT_FALSE(message["tool_calls"].empty());
+
+    // Every entry must survive our strict parser — no silent skipping.
+    for (const auto& entry : message["tool_calls"]) {
+        gaia::ToolCall tc;
+        ASSERT_NO_THROW(tc = gaia::ToolCall::fromJson(entry)) << entry.dump(2);
+        EXPECT_EQ(tc.name, "get_weather");
+        gaia::json args;
+        ASSERT_NO_THROW(args = tc.parsedArgs()) << tc.arguments;
+        EXPECT_TRUE(args.contains("city")) << args.dump();
+    }
+}
+
+// ---------------------------------------------------------------------------
+// The full agent loop over native tool calls
+// ---------------------------------------------------------------------------
+
+TEST(ToolCallsIntegrationTest, AgentLoopExecutesANativeToolCallEndToEnd) {
+    WeatherAgent agent;
+    ASSERT_TRUE(agent.config().useNativeToolCalls())
+        << "Expected the native path to be active for " << toolModel();
+
+    auto result = agent.processQuery("What is the weather in Austin right now?");
+
+    ASSERT_FALSE(agent.calledCities.empty())
+        << "The model never invoked get_weather. Answer was: " << result.value("result", "");
+    EXPECT_NE(toLower(agent.calledCities[0]).find("austin"), std::string::npos)
+        << "Called with: " << agent.calledCities[0];
+
+    const std::string answer = result.value("result", "");
+    EXPECT_FALSE(answer.empty());
+    // The tool result must have reached the model — 21C / sunny came only from it.
+    EXPECT_TRUE(answer.find("21") != std::string::npos ||
+                toLower(answer).find("sunny") != std::string::npos)
+        << "Final answer did not reflect the tool result: " << answer;
+}
+
+TEST(ToolCallsIntegrationTest, StreamingAgentLoopExecutesANativeToolCall) {
+    // The streaming path reassembles tool_calls from SSE deltas — a completely
+    // separate code path from the non-streaming parse above.
+    class StreamingWeatherAgent : public WeatherAgent {
+    public:
+        StreamingWeatherAgent() {
+            gaia::AgentConfig cfg = config();
+            cfg.streaming = true;
+            setConfig(cfg);
+        }
+    };
+
+    StreamingWeatherAgent agent;
+    auto result = agent.processQuery("What is the weather in Austin right now?");
+
+    ASSERT_FALSE(agent.calledCities.empty())
+        << "Streaming path never surfaced a tool call. Answer: "
+        << result.value("result", "");
+    EXPECT_NE(toLower(agent.calledCities[0]).find("austin"), std::string::npos);
+}
+
+// ---------------------------------------------------------------------------
+// The prompt-JSON fallback still works against the same live server
+// ---------------------------------------------------------------------------
+
+TEST(ToolCallsIntegrationTest, PromptJsonPathStillWorksWhenNativeIsDisabled) {
+    class LegacyWeatherAgent : public WeatherAgent {
+    public:
+        LegacyWeatherAgent() {
+            gaia::AgentConfig cfg = config();
+            cfg.nativeToolCalls = gaia::NativeToolCalls::Never;
+            setConfig(cfg);
+        }
+    };
+
+    LegacyWeatherAgent agent;
+    ASSERT_FALSE(agent.config().useNativeToolCalls());
+    EXPECT_NE(agent.systemPrompt().find("==== RESPONSE FORMAT ===="), std::string::npos);
+
+    auto result = agent.processQuery("What is the weather in Austin right now?");
+    ASSERT_FALSE(agent.calledCities.empty())
+        << "Prompt-JSON fallback stopped working. Answer: " << result.value("result", "");
+}

--- a/cpp/tests/test_native_tool_calls.cpp
+++ b/cpp/tests/test_native_tool_calls.cpp
@@ -798,6 +798,20 @@ TEST(ResponseModeTest, InvalidEnumStringsAreRejected) {
                  std::invalid_argument);
 }
 
+// "none" is the one rejected value a user is likely to try, since OpenAI
+// accepts it. The error must point at the supported escape hatch instead.
+TEST(ResponseModeTest, ToolChoiceNoneIsRejectedAndPointsAtNever) {
+    try {
+        AgentConfig::fromJson(json{{"toolChoice", "none"}});
+        FAIL() << "expected toolChoice \"none\" to be rejected";
+    } catch (const std::invalid_argument& e) {
+        EXPECT_NE(std::string(e.what()).find("nativeToolCalls"),
+                  std::string::npos)
+            << "error should name the supported way to disable tool calling: "
+            << e.what();
+    }
+}
+
 // ---------------------------------------------------------------------------
 // History: native tool exchanges survive intact, orphans are dropped
 // ---------------------------------------------------------------------------

--- a/cpp/tests/test_native_tool_calls.cpp
+++ b/cpp/tests/test_native_tool_calls.cpp
@@ -1,0 +1,1141 @@
+// Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: MIT
+//
+// Native OpenAI tool calling (issue #2794).
+//
+// Covers the model gate, the request-body switch, parallel tool_calls, the
+// spec-correct assistant/tool message pair, streaming tool_calls delta
+// accumulation, and both response modes. Everything runs against the
+// in-process mock HTTP server or against SseParser directly — no Lemonade.
+
+#include <gtest/gtest.h>
+
+#include <gaia/agent.h>
+#include <gaia/model_registry.h>
+#include <gaia/sse_parser.h>
+#include <gaia/tool_registry.h>
+
+#include <nlohmann/json.hpp>
+
+#include <set>
+#include <string>
+#include <vector>
+
+#include "support/mock_llm_server.h"
+
+using namespace gaia;
+
+namespace {
+
+// A model id known to support native tool calls (mirrors Python MODELS).
+constexpr const char* kToolCallingModel = "Gemma-4-E4B-it-GGUF";
+// A model id known NOT to support them (the FLM/NPU build).
+constexpr const char* kNonToolCallingModel = "gemma4-it-e2b-FLM";
+
+/// Agent with two tools, used to exercise the schema and execution paths.
+class ToolAgent : public Agent {
+public:
+    using Agent::Agent;
+
+    std::vector<std::string> executed;
+
+protected:
+    void registerTools() override {
+        toolRegistry().registerTool(
+            "echo", "Echo a message back",
+            [this](const json& args) -> json {
+                executed.push_back("echo");
+                return json{{"echoed", args.value("message", "")}};
+            },
+            {{"message", ToolParamType::STRING, true, "Message to echo"}});
+
+        toolRegistry().registerTool(
+            "add", "Add two numbers",
+            [this](const json& args) -> json {
+                executed.push_back("add");
+                return json{{"sum", args.value("a", 0) + args.value("b", 0)}};
+            },
+            {{"a", ToolParamType::INTEGER, true, "First number"},
+             {"b", ToolParamType::INTEGER, false, "Second number"}});
+
+        toolRegistry().registerTool(
+            "ping", "Take no arguments",
+            [this](const json&) -> json {
+                executed.push_back("ping");
+                return json{{"pong", true}};
+            });
+    }
+
+    std::string getSystemPrompt() const override { return "You are a tool agent."; }
+
+public:
+    void initForTest() { init(); }
+};
+
+AgentConfig makeCfg(const std::string& url, const std::string& modelId) {
+    AgentConfig cfg;
+    cfg.baseUrl = url;
+    cfg.modelId = modelId;
+    cfg.maxSteps = 3;
+    cfg.silentMode = true;
+    // Pinned, not inherited: AgentConfig::streaming defaults from GAIA_STREAMING,
+    // and a streaming body carries an extra "stream" key that would break the
+    // exact-key-set assertion below.
+    cfg.streaming = false;
+    return cfg;
+}
+
+/// Non-streaming chat completion carrying native tool_calls.
+std::string toolCallsResponse(const std::string& callsJson,
+                              const std::string& content = "null") {
+    return R"({"choices":[{"message":{"role":"assistant","content":)" + content +
+           R"(,"tool_calls":)" + callsJson + "}}]}";
+}
+
+const std::string kPlainAnswer =
+    R"({"choices":[{"message":{"role":"assistant","content":"All done."}}]})";
+
+std::set<std::string> keysOf(const json& obj) {
+    std::set<std::string> keys;
+    for (auto it = obj.begin(); it != obj.end(); ++it) keys.insert(it.key());
+    return keys;
+}
+
+/// Return the system message content from a captured request body.
+std::string systemPromptOf(const json& body) {
+    for (const auto& m : body.at("messages")) {
+        if (m.value("role", "") == "system") return m.value("content", "");
+    }
+    return "";
+}
+
+} // namespace
+
+// ---------------------------------------------------------------------------
+// The isToolCallingModel gate — both directions
+// ---------------------------------------------------------------------------
+
+TEST(ModelGateTest, KnownToolCallingModelsReturnTrue) {
+    EXPECT_TRUE(isToolCallingModel("Gemma-4-E4B-it-GGUF"));
+    EXPECT_TRUE(isToolCallingModel("Qwen3-0.6B-GGUF"));
+    EXPECT_TRUE(isToolCallingModel("Qwen3-8B-GGUF"));
+    EXPECT_TRUE(isToolCallingModel("Qwen3.5-35B-A3B-GGUF"));
+    EXPECT_TRUE(isToolCallingModel("Qwen3-VL-4B-Instruct-GGUF"));
+}
+
+TEST(ModelGateTest, KnownNonToolCallingModelsReturnFalse) {
+    // The FastFlowLM/NPU build 500s on an OpenAI tools payload.
+    EXPECT_FALSE(isToolCallingModel("gemma4-it-e2b-FLM"));
+    // Embedders never chat.
+    EXPECT_FALSE(isToolCallingModel("user.embeddinggemma-300m-GGUF"));
+    EXPECT_FALSE(isToolCallingModel("embed-gemma-300m-FLM"));
+}
+
+TEST(ModelGateTest, UnknownAndEmptyModelsReturnFalse) {
+    // Divergence from Python's optimistic default — see model_registry.h.
+    EXPECT_FALSE(isToolCallingModel("Qwen3-4B-GGUF"));  // the C++ default model
+    EXPECT_FALSE(isToolCallingModel("some-random-model"));
+    EXPECT_FALSE(isToolCallingModel(""));
+}
+
+TEST(ModelGateTest, MirrorsThePythonModelTableExactly) {
+    // Pins the mirrored table so a Python-side change that is not mirrored here
+    // shows up as a test edit in review. Source of truth: MODELS in
+    // src/gaia/llm/lemonade_client.py.
+    const std::vector<std::pair<std::string, bool>> expected = {
+        {"Gemma-4-E4B-it-GGUF", true},
+        {"gemma4-it-e2b-FLM", false},
+        {"Qwen3.5-35B-A3B-GGUF", true},
+        {"Qwen3-0.6B-GGUF", true},
+        {"Qwen3-VL-4B-Instruct-GGUF", true},
+        {"Qwen3-8B-GGUF", true},
+        {"user.embeddinggemma-300m-GGUF", false},
+        {"embed-gemma-300m-FLM", false},
+    };
+    ASSERT_EQ(knownModels().size(), expected.size());
+    for (size_t i = 0; i < expected.size(); ++i) {
+        EXPECT_EQ(knownModels()[i].modelId, expected[i].first) << "at index " << i;
+        EXPECT_EQ(knownModels()[i].toolCalling, expected[i].second) << "at index " << i;
+    }
+}
+
+TEST(ModelGateTest, ConfigPolicyOverridesTheModel) {
+    AgentConfig cfg;
+
+    cfg.modelId = kNonToolCallingModel;
+    cfg.nativeToolCalls = NativeToolCalls::Auto;
+    EXPECT_FALSE(cfg.useNativeToolCalls());
+    cfg.nativeToolCalls = NativeToolCalls::Always;
+    EXPECT_TRUE(cfg.useNativeToolCalls());
+
+    cfg.modelId = kToolCallingModel;
+    cfg.nativeToolCalls = NativeToolCalls::Auto;
+    EXPECT_TRUE(cfg.useNativeToolCalls());
+    cfg.nativeToolCalls = NativeToolCalls::Never;
+    EXPECT_FALSE(cfg.useNativeToolCalls());
+}
+
+// ---------------------------------------------------------------------------
+// Request body: legacy path is untouched, native path adds tools/tool_choice
+// ---------------------------------------------------------------------------
+
+TEST(NativeToolCallsTest, NonToolCallingModelRequestBodyIsUnchanged) {
+    bench::MockLlmServer mock;
+    mock.pushResponse(kPlainAnswer);
+
+    ToolAgent agent(makeCfg(mock.baseUrl(), kNonToolCallingModel));
+    agent.initForTest();
+    agent.processQuery("hello", 1);
+
+    ASSERT_GE(mock.receivedBodies().size(), 1u);
+    json body = json::parse(mock.receivedBodies().back());
+
+    // Exactly the four legacy keys — no tools, no tool_choice.
+    EXPECT_EQ(keysOf(body),
+              (std::set<std::string>{"model", "max_tokens", "temperature", "messages"}));
+    EXPECT_FALSE(body.contains("tools"));
+    EXPECT_FALSE(body.contains("tool_choice"));
+}
+
+TEST(NativeToolCallsTest, NonToolCallingModelKeepsTheResponseFormatTemplate) {
+    bench::MockLlmServer mock;
+    mock.pushResponse(kPlainAnswer);
+
+    ToolAgent agent(makeCfg(mock.baseUrl(), kNonToolCallingModel));
+    agent.initForTest();
+    agent.processQuery("hello", 1);
+
+    const std::string prompt = systemPromptOf(json::parse(mock.receivedBodies().back()));
+    EXPECT_NE(prompt.find("==== RESPONSE FORMAT ===="), std::string::npos);
+    EXPECT_NE(prompt.find("You must respond ONLY in valid JSON"), std::string::npos);
+    EXPECT_NE(prompt.find("==== AVAILABLE TOOLS ===="), std::string::npos);
+    // Identical to what the agent exposes through its public accessor.
+    EXPECT_EQ(prompt, agent.systemPrompt());
+}
+
+TEST(NativeToolCallsTest, ToolCallingModelSendsToolsAndToolChoice) {
+    bench::MockLlmServer mock;
+    mock.pushResponse(kPlainAnswer);
+
+    ToolAgent agent(makeCfg(mock.baseUrl(), kToolCallingModel));
+    agent.initForTest();
+    agent.processQuery("hello", 1);
+
+    ASSERT_GE(mock.receivedBodies().size(), 1u);
+    json body = json::parse(mock.receivedBodies().back());
+
+    ASSERT_TRUE(body.contains("tools"));
+    ASSERT_TRUE(body["tools"].is_array());
+    EXPECT_EQ(body["tools"].size(), 3u);  // add, echo, ping
+    EXPECT_EQ(body["tool_choice"], "auto");
+
+    // Registry order is alphabetical (std::map): add, echo.
+    const auto& addFn = body["tools"][0]["function"];
+    EXPECT_EQ(body["tools"][0]["type"], "function");
+    EXPECT_EQ(addFn["name"], "add");
+    EXPECT_EQ(addFn["description"], "Add two numbers");
+    EXPECT_EQ(addFn["parameters"]["type"], "object");
+    EXPECT_EQ(addFn["parameters"]["properties"]["a"]["type"], "integer");
+    EXPECT_EQ(addFn["parameters"]["properties"]["a"]["description"], "First number");
+    // Only required params appear in "required".
+    EXPECT_EQ(addFn["parameters"]["required"], json::array({"a"}));
+
+    const auto& echoFn = body["tools"][1]["function"];
+    EXPECT_EQ(echoFn["name"], "echo");
+    EXPECT_EQ(echoFn["parameters"]["properties"]["message"]["type"], "string");
+}
+
+TEST(NativeToolCallsTest, ToolCallingModelDropsTheResponseFormatTemplate) {
+    bench::MockLlmServer mock;
+    mock.pushResponse(kPlainAnswer);
+
+    ToolAgent agent(makeCfg(mock.baseUrl(), kToolCallingModel));
+    agent.initForTest();
+    agent.processQuery("hello", 1);
+
+    const std::string prompt = systemPromptOf(json::parse(mock.receivedBodies().back()));
+    EXPECT_EQ(prompt.find("==== RESPONSE FORMAT ===="), std::string::npos);
+    // The tool list stays — it is what lets the model pick a tool.
+    EXPECT_NE(prompt.find("==== AVAILABLE TOOLS ===="), std::string::npos);
+    EXPECT_NE(prompt.find("You are a tool agent."), std::string::npos);
+}
+
+TEST(NativeToolCallsTest, NeverPolicyKeepsTheLegacyBodyForAToolCallingModel) {
+    bench::MockLlmServer mock;
+    mock.pushResponse(kPlainAnswer);
+
+    AgentConfig cfg = makeCfg(mock.baseUrl(), kToolCallingModel);
+    cfg.nativeToolCalls = NativeToolCalls::Never;
+    ToolAgent agent(cfg);
+    agent.initForTest();
+    agent.processQuery("hello", 1);
+
+    json body = json::parse(mock.receivedBodies().back());
+    EXPECT_FALSE(body.contains("tools"));
+    EXPECT_NE(systemPromptOf(body).find("==== RESPONSE FORMAT ===="), std::string::npos);
+}
+
+TEST(NativeToolCallsTest, AlwaysPolicySendsToolsForAnUnknownModel) {
+    bench::MockLlmServer mock;
+    mock.pushResponse(kPlainAnswer);
+
+    AgentConfig cfg = makeCfg(mock.baseUrl(), "some-third-party-model");
+    cfg.nativeToolCalls = NativeToolCalls::Always;
+    cfg.toolChoice = "required";
+    ToolAgent agent(cfg);
+    agent.initForTest();
+    agent.processQuery("hello", 1);
+
+    json body = json::parse(mock.receivedBodies().back());
+    ASSERT_TRUE(body.contains("tools"));
+    EXPECT_EQ(body["tool_choice"], "required");
+}
+
+TEST(NativeToolCallsTest, NoToolsRegisteredOmitsToolsAndToolChoice) {
+    bench::MockLlmServer mock;
+    mock.pushResponse(kPlainAnswer);
+
+    class Bare : public Agent { public: using Agent::Agent; };
+    Bare agent(makeCfg(mock.baseUrl(), kToolCallingModel));
+    agent.processQuery("hello", 1);
+
+    json body = json::parse(mock.receivedBodies().back());
+    EXPECT_FALSE(body.contains("tools"));
+    EXPECT_FALSE(body.contains("tool_choice"));
+}
+
+TEST(NativeToolCallsTest, DisabledToolsAreExcludedFromTheSchemas) {
+    bench::MockLlmServer mock;
+    mock.pushResponse(kPlainAnswer);
+
+    ToolAgent agent(makeCfg(mock.baseUrl(), kToolCallingModel));
+    agent.initForTest();
+    agent.toolRegistry().setEnabled("echo", false);
+    agent.processQuery("hello", 1);
+
+    json body = json::parse(mock.receivedBodies().back());
+    ASSERT_TRUE(body.contains("tools"));
+    ASSERT_EQ(body["tools"].size(), 2u);
+    EXPECT_EQ(body["tools"][0]["function"]["name"], "add");
+    EXPECT_EQ(body["tools"][1]["function"]["name"], "ping");
+}
+
+// ---------------------------------------------------------------------------
+// Executing native tool calls — single and parallel
+// ---------------------------------------------------------------------------
+
+TEST(NativeToolCallsTest, SingleToolCallIsExecutedAndAnswered) {
+    bench::MockLlmServer mock;
+    mock.pushResponse(toolCallsResponse(
+        R"([{"id":"call_1","type":"function","function":{"name":"echo","arguments":"{\"message\":\"hi\"}"}}])"));
+    mock.pushResponse(kPlainAnswer);
+
+    ToolAgent agent(makeCfg(mock.baseUrl(), kToolCallingModel));
+    agent.initForTest();
+    json result = agent.processQuery("say hi", 3);
+
+    EXPECT_EQ(agent.executed, (std::vector<std::string>{"echo"}));
+    EXPECT_EQ(result["result"], "All done.");
+
+    // The follow-up request must carry a spec-correct assistant + tool pair.
+    ASSERT_GE(mock.receivedBodies().size(), 2u);
+    json second = json::parse(mock.receivedBodies().back());
+    const auto& msgs = second.at("messages");
+
+    const json* assistant = nullptr;
+    const json* toolMsg = nullptr;
+    for (const auto& m : msgs) {
+        if (m.value("role", "") == "assistant" && m.contains("tool_calls")) assistant = &m;
+        if (m.value("role", "") == "tool") toolMsg = &m;
+    }
+    ASSERT_NE(assistant, nullptr) << second.dump(2);
+    ASSERT_NE(toolMsg, nullptr) << second.dump(2);
+
+    EXPECT_TRUE((*assistant)["content"].is_null());
+    ASSERT_EQ((*assistant)["tool_calls"].size(), 1u);
+    EXPECT_EQ((*assistant)["tool_calls"][0]["id"], "call_1");
+    EXPECT_EQ((*assistant)["tool_calls"][0]["type"], "function");
+    EXPECT_EQ((*assistant)["tool_calls"][0]["function"]["name"], "echo");
+
+    // The tool reply correlates by tool_call_id — not a "[Result from X]" user turn.
+    EXPECT_EQ((*toolMsg)["tool_call_id"], "call_1");
+    EXPECT_EQ((*toolMsg)["name"], "echo");
+    EXPECT_NE((*toolMsg)["content"].get<std::string>().find("\"echoed\":\"hi\""),
+              std::string::npos);
+}
+
+TEST(NativeToolCallsTest, ParallelToolCallsAllExecuteAndEachGetsItsOwnReply) {
+    bench::MockLlmServer mock;
+    mock.pushResponse(toolCallsResponse(
+        R"([{"id":"call_a","type":"function","function":{"name":"echo","arguments":"{\"message\":\"one\"}"}},)"
+        R"({"id":"call_b","type":"function","function":{"name":"add","arguments":"{\"a\":2,\"b\":3}"}}])"));
+    mock.pushResponse(kPlainAnswer);
+
+    ToolAgent agent(makeCfg(mock.baseUrl(), kToolCallingModel));
+    agent.initForTest();
+    json result = agent.processQuery("do both", 3);
+
+    // Both ran, in the order the model asked for.
+    EXPECT_EQ(agent.executed, (std::vector<std::string>{"echo", "add"}));
+    EXPECT_EQ(result["result"], "All done.");
+
+    json second = json::parse(mock.receivedBodies().back());
+    std::vector<std::string> toolCallIds;
+    std::vector<std::string> replyIds;
+    for (const auto& m : second.at("messages")) {
+        if (m.value("role", "") == "assistant" && m.contains("tool_calls")) {
+            for (const auto& tc : m["tool_calls"]) {
+                toolCallIds.push_back(tc["id"].get<std::string>());
+            }
+        }
+        if (m.value("role", "") == "tool") {
+            replyIds.push_back(m.at("tool_call_id").get<std::string>());
+        }
+    }
+    // One assistant turn carrying both calls, one role=tool reply per call.
+    EXPECT_EQ(toolCallIds, (std::vector<std::string>{"call_a", "call_b"}));
+    EXPECT_EQ(replyIds, (std::vector<std::string>{"call_a", "call_b"}));
+}
+
+TEST(NativeToolCallsTest, AssistantTextAlongsideToolCallsIsPreserved) {
+    bench::MockLlmServer mock;
+    mock.pushResponse(toolCallsResponse(
+        R"([{"id":"call_1","type":"function","function":{"name":"echo","arguments":"{\"message\":\"x\"}"}}])",
+        R"("Let me check that.")"));
+    mock.pushResponse(kPlainAnswer);
+
+    ToolAgent agent(makeCfg(mock.baseUrl(), kToolCallingModel));
+    agent.initForTest();
+    agent.processQuery("check", 3);
+
+    json second = json::parse(mock.receivedBodies().back());
+    for (const auto& m : second.at("messages")) {
+        if (m.value("role", "") == "assistant" && m.contains("tool_calls")) {
+            EXPECT_EQ(m["content"], "Let me check that.");
+        }
+    }
+}
+
+TEST(NativeToolCallsTest, ZeroArgumentToolCallDecodesToAnEmptyObject) {
+    bench::MockLlmServer mock;
+    mock.pushResponse(toolCallsResponse(
+        R"([{"id":"call_1","type":"function","function":{"name":"ping","arguments":""}}])"));
+    mock.pushResponse(kPlainAnswer);
+
+    ToolAgent agent(makeCfg(mock.baseUrl(), kToolCallingModel));
+    agent.initForTest();
+    agent.processQuery("ping", 3);
+
+    EXPECT_EQ(agent.executed, (std::vector<std::string>{"ping"}));
+}
+
+TEST(NativeToolCallsTest, PreDecodedArgumentObjectIsAccepted) {
+    // Some OpenAI-compatible servers send function.arguments as an object
+    // rather than a JSON-encoded string.
+    bench::MockLlmServer mock;
+    mock.pushResponse(toolCallsResponse(
+        R"([{"id":"call_1","type":"function","function":{"name":"add","arguments":{"a":4,"b":6}}}])"));
+    mock.pushResponse(kPlainAnswer);
+
+    ToolAgent agent(makeCfg(mock.baseUrl(), kToolCallingModel));
+    agent.initForTest();
+    agent.processQuery("add", 3);
+
+    EXPECT_EQ(agent.executed, (std::vector<std::string>{"add"}));
+    json second = json::parse(mock.receivedBodies().back());
+    bool sawSum = false;
+    for (const auto& m : second.at("messages")) {
+        if (m.value("role", "") == "tool") {
+            sawSum = m["content"].get<std::string>().find("\"sum\":10") != std::string::npos;
+        }
+    }
+    EXPECT_TRUE(sawSum);
+}
+
+// ---------------------------------------------------------------------------
+// Malformed tool_calls must surface, never degrade to prose parsing
+// ---------------------------------------------------------------------------
+
+TEST(NativeToolCallsTest, ToolCallMissingIdIsRejectedWithAnActionableError) {
+    json entry = json::parse(
+        R"({"type":"function","function":{"name":"echo","arguments":"{}"}})");
+    try {
+        ToolCall::fromJson(entry);
+        FAIL() << "expected a throw for a tool_calls entry with no id";
+    } catch (const std::runtime_error& e) {
+        const std::string msg = e.what();
+        EXPECT_NE(msg.find("'id'"), std::string::npos) << msg;
+        EXPECT_NE(msg.find("correlated"), std::string::npos) << msg;
+    }
+}
+
+TEST(NativeToolCallsTest, ToolCallMissingFunctionNameIsRejected) {
+    json entry = json::parse(R"({"id":"call_1","function":{"arguments":"{}"}})");
+    try {
+        ToolCall::fromJson(entry);
+        FAIL() << "expected a throw for a tool_calls entry with no function.name";
+    } catch (const std::runtime_error& e) {
+        EXPECT_NE(std::string(e.what()).find("function.name"), std::string::npos);
+    }
+}
+
+TEST(NativeToolCallsTest, MalformedArgumentsJsonThrowsNamingTheTool) {
+    ToolCall tc;
+    tc.id = "call_9";
+    tc.name = "echo";
+    tc.arguments = "{\"message\": ";  // truncated
+    try {
+        tc.parsedArgs();
+        FAIL() << "expected a throw for unparseable arguments";
+    } catch (const std::runtime_error& e) {
+        const std::string msg = e.what();
+        EXPECT_NE(msg.find("echo"), std::string::npos) << msg;
+        EXPECT_NE(msg.find("call_9"), std::string::npos) << msg;
+        // Names the escape hatch so the error is actionable.
+        EXPECT_NE(msg.find("NativeToolCalls::Never"), std::string::npos) << msg;
+    }
+}
+
+TEST(NativeToolCallsTest, NonObjectArgumentsThrow) {
+    ToolCall tc;
+    tc.id = "call_9";
+    tc.name = "echo";
+    tc.arguments = "[1,2,3]";
+    EXPECT_THROW(tc.parsedArgs(), std::runtime_error);
+}
+
+TEST(NativeToolCallsTest, MalformedToolCallsSurfaceAsAnErrorNotAProseAnswer) {
+    bench::MockLlmServer mock;
+    // Both the first attempt and the one retry return the same malformed body.
+    mock.pushResponse(toolCallsResponse(R"([{"type":"function","function":{"name":"echo"}}])"));
+    mock.pushResponse(toolCallsResponse(R"([{"type":"function","function":{"name":"echo"}}])"));
+
+    ToolAgent agent(makeCfg(mock.baseUrl(), kToolCallingModel));
+    agent.initForTest();
+    json result = agent.processQuery("go", 2);
+
+    // The loop reports the LLM error rather than silently answering with prose.
+    const std::string answer = result["result"].get<std::string>();
+    EXPECT_NE(answer.find("LLM error"), std::string::npos) << answer;
+    EXPECT_TRUE(agent.executed.empty());
+}
+
+// ---------------------------------------------------------------------------
+// Message serialization
+// ---------------------------------------------------------------------------
+
+TEST(NativeToolCallsTest, AssistantMessageSerializesToolCallsWithNullContent) {
+    Message m;
+    m.role = MessageRole::ASSISTANT;
+    m.toolCalls = {ToolCall{"call_1", "echo", R"({"message":"hi"})"}};
+
+    json j = m.toJson();
+    EXPECT_EQ(j["role"], "assistant");
+    EXPECT_TRUE(j["content"].is_null());
+    ASSERT_EQ(j["tool_calls"].size(), 1u);
+    EXPECT_EQ(j["tool_calls"][0]["id"], "call_1");
+    EXPECT_EQ(j["tool_calls"][0]["type"], "function");
+    EXPECT_EQ(j["tool_calls"][0]["function"]["name"], "echo");
+    // arguments stays a JSON-encoded *string*, per the OpenAI wire format.
+    EXPECT_TRUE(j["tool_calls"][0]["function"]["arguments"].is_string());
+}
+
+TEST(NativeToolCallsTest, MessageWithoutToolCallsHasNoToolCallsKey) {
+    Message m;
+    m.role = MessageRole::ASSISTANT;
+    m.content = "plain";
+    json j = m.toJson();
+    EXPECT_FALSE(j.contains("tool_calls"));
+    EXPECT_EQ(j["content"], "plain");
+}
+
+// ---------------------------------------------------------------------------
+// Streaming: tool_calls deltas accumulated across chunk boundaries
+// ---------------------------------------------------------------------------
+
+namespace {
+
+/// Feed a whole SSE payload to a parser one byte at a time, which is the
+/// harshest possible chunk split.
+void feedByteByByte(SseParser& parser, const std::string& sse) {
+    for (char c : sse) {
+        parser.feed(&c, 1);
+    }
+}
+
+} // namespace
+
+TEST(SseToolCallsTest, AccumulatesASingleToolCallAcrossChunks) {
+    std::string collected;
+    SseParser parser([&](const std::string& t) { collected += t; });
+
+    const std::string sse =
+        "data: {\"choices\":[{\"delta\":{\"tool_calls\":[{\"index\":0,\"id\":\"call_1\","
+        "\"type\":\"function\",\"function\":{\"name\":\"echo\",\"arguments\":\"\"}}]}}]}\n\n"
+        "data: {\"choices\":[{\"delta\":{\"tool_calls\":[{\"index\":0,"
+        "\"function\":{\"arguments\":\"{\\\"mess\"}}]}}]}\n\n"
+        "data: {\"choices\":[{\"delta\":{\"tool_calls\":[{\"index\":0,"
+        "\"function\":{\"arguments\":\"age\\\":\"}}]}}]}\n\n"
+        "data: {\"choices\":[{\"delta\":{\"tool_calls\":[{\"index\":0,"
+        "\"function\":{\"arguments\":\"\\\"hi\\\"}\"}}]}}]}\n\n"
+        "data: [DONE]\n\n";
+
+    feedByteByByte(parser, sse);
+
+    EXPECT_TRUE(parser.done());
+    EXPECT_TRUE(parser.hasToolCalls());
+    EXPECT_TRUE(collected.empty()) << "tool-call streams carry no content tokens";
+
+    auto calls = parser.toolCalls();
+    ASSERT_EQ(calls.size(), 1u);
+    EXPECT_EQ(calls[0].id, "call_1");
+    EXPECT_EQ(calls[0].name, "echo");
+    EXPECT_EQ(calls[0].arguments, R"({"message":"hi"})");
+    EXPECT_EQ(calls[0].parsedArgs()["message"], "hi");
+}
+
+TEST(SseToolCallsTest, AccumulatesParallelToolCallsByIndex) {
+    SseParser parser([](const std::string&) {});
+
+    const std::string sse =
+        "data: {\"choices\":[{\"delta\":{\"tool_calls\":["
+        "{\"index\":0,\"id\":\"call_a\",\"function\":{\"name\":\"echo\",\"arguments\":\"\"}},"
+        "{\"index\":1,\"id\":\"call_b\",\"function\":{\"name\":\"add\",\"arguments\":\"\"}}]}}]}\n\n"
+        // Interleaved argument fragments — index keeps them apart.
+        "data: {\"choices\":[{\"delta\":{\"tool_calls\":[{\"index\":1,"
+        "\"function\":{\"arguments\":\"{\\\"a\\\":1,\"}}]}}]}\n\n"
+        "data: {\"choices\":[{\"delta\":{\"tool_calls\":[{\"index\":0,"
+        "\"function\":{\"arguments\":\"{\\\"message\\\":\\\"x\\\"}\"}}]}}]}\n\n"
+        "data: {\"choices\":[{\"delta\":{\"tool_calls\":[{\"index\":1,"
+        "\"function\":{\"arguments\":\"\\\"b\\\":2}\"}}]}}]}\n\n"
+        "data: [DONE]\n\n";
+
+    feedByteByByte(parser, sse);
+
+    auto calls = parser.toolCalls();
+    ASSERT_EQ(calls.size(), 2u);
+    EXPECT_EQ(calls[0].id, "call_a");
+    EXPECT_EQ(calls[0].name, "echo");
+    EXPECT_EQ(calls[0].arguments, R"({"message":"x"})");
+    EXPECT_EQ(calls[1].id, "call_b");
+    EXPECT_EQ(calls[1].name, "add");
+    EXPECT_EQ(calls[1].arguments, R"({"a":1,"b":2})");
+    EXPECT_EQ(calls[1].parsedArgs()["b"], 2);
+}
+
+TEST(SseToolCallsTest, ReassemblesAFragmentedFunctionName) {
+    SseParser parser([](const std::string&) {});
+    const std::string sse =
+        "data: {\"choices\":[{\"delta\":{\"tool_calls\":[{\"index\":0,\"id\":\"c1\","
+        "\"function\":{\"name\":\"ec\"}}]}}]}\n\n"
+        "data: {\"choices\":[{\"delta\":{\"tool_calls\":[{\"index\":0,"
+        "\"function\":{\"name\":\"ho\",\"arguments\":\"{}\"}}]}}]}\n\n"
+        "data: [DONE]\n\n";
+
+    feedByteByByte(parser, sse);
+
+    auto calls = parser.toolCalls();
+    ASSERT_EQ(calls.size(), 1u);
+    EXPECT_EQ(calls[0].name, "echo");
+}
+
+TEST(SseToolCallsTest, RepeatedIdInLaterDeltasDoesNotDuplicate) {
+    SseParser parser([](const std::string&) {});
+    const std::string sse =
+        "data: {\"choices\":[{\"delta\":{\"tool_calls\":[{\"index\":0,\"id\":\"call_x\","
+        "\"function\":{\"name\":\"echo\",\"arguments\":\"{\"}}]}}]}\n\n"
+        "data: {\"choices\":[{\"delta\":{\"tool_calls\":[{\"index\":0,\"id\":\"call_x\","
+        "\"function\":{\"arguments\":\"}\"}}]}}]}\n\n"
+        "data: [DONE]\n\n";
+
+    feedByteByByte(parser, sse);
+
+    auto calls = parser.toolCalls();
+    ASSERT_EQ(calls.size(), 1u);
+    EXPECT_EQ(calls[0].id, "call_x");
+    EXPECT_EQ(calls[0].arguments, "{}");
+}
+
+TEST(SseToolCallsTest, ToolCallsWithoutAnIndexLandInSlotZero) {
+    SseParser parser([](const std::string&) {});
+    const std::string sse =
+        "data: {\"choices\":[{\"delta\":{\"tool_calls\":[{\"id\":\"c1\","
+        "\"function\":{\"name\":\"echo\",\"arguments\":\"{}\"}}]}}]}\n\n"
+        "data: [DONE]\n\n";
+    feedByteByByte(parser, sse);
+
+    auto calls = parser.toolCalls();
+    ASSERT_EQ(calls.size(), 1u);
+    EXPECT_EQ(calls[0].name, "echo");
+}
+
+TEST(SseToolCallsTest, ContentOnlyStreamReportsNoToolCalls) {
+    std::string collected;
+    SseParser parser([&](const std::string& t) { collected += t; });
+    const std::string sse =
+        "data: {\"choices\":[{\"delta\":{\"content\":\"Hello\"}}]}\n\n"
+        "data: {\"choices\":[{\"delta\":{\"content\":\" world\"}}]}\n\n"
+        "data: [DONE]\n\n";
+    feedByteByByte(parser, sse);
+
+    EXPECT_EQ(collected, "Hello world");
+    EXPECT_FALSE(parser.hasToolCalls());
+    EXPECT_TRUE(parser.toolCalls().empty());
+}
+
+TEST(SseToolCallsTest, MixedContentAndToolCallsBothSurvive) {
+    std::string collected;
+    SseParser parser([&](const std::string& t) { collected += t; });
+    const std::string sse =
+        "data: {\"choices\":[{\"delta\":{\"content\":\"Checking\"}}]}\n\n"
+        "data: {\"choices\":[{\"delta\":{\"tool_calls\":[{\"index\":0,\"id\":\"c1\","
+        "\"function\":{\"name\":\"echo\",\"arguments\":\"{}\"}}]}}]}\n\n"
+        "data: [DONE]\n\n";
+    feedByteByByte(parser, sse);
+
+    EXPECT_EQ(collected, "Checking");
+    ASSERT_EQ(parser.toolCalls().size(), 1u);
+    EXPECT_EQ(parser.toolCalls()[0].name, "echo");
+}
+
+// ---------------------------------------------------------------------------
+// Response modes
+// ---------------------------------------------------------------------------
+
+TEST(ResponseModeTest, PlanningIsTheDefaultAndEmitsThePlanningTemplate) {
+    AgentConfig cfg;
+    EXPECT_EQ(cfg.responseMode, ResponseMode::Planning);
+
+    bench::MockLlmServer mock;
+    mock.pushResponse(kPlainAnswer);
+    ToolAgent agent(makeCfg(mock.baseUrl(), kNonToolCallingModel));
+    agent.initForTest();
+    agent.processQuery("hi", 1);
+
+    const std::string prompt = systemPromptOf(json::parse(mock.receivedBodies().back()));
+    EXPECT_NE(prompt.find("You must respond ONLY in valid JSON"), std::string::npos);
+    EXPECT_EQ(prompt.find("Respond in plain text for normal conversation"), std::string::npos);
+}
+
+TEST(ResponseModeTest, ConversationalEmitsThePortedConversationalTemplate) {
+    bench::MockLlmServer mock;
+    mock.pushResponse(kPlainAnswer);
+
+    AgentConfig cfg = makeCfg(mock.baseUrl(), kNonToolCallingModel);
+    cfg.responseMode = ResponseMode::Conversational;
+    ToolAgent agent(cfg);
+    agent.initForTest();
+    agent.processQuery("hi", 1);
+
+    const std::string prompt = systemPromptOf(json::parse(mock.receivedBodies().back()));
+    // Byte-for-byte the lines Python's _CONVERSATIONAL_FORMAT carries.
+    EXPECT_NE(prompt.find("Respond in plain text for normal conversation."), std::string::npos);
+    EXPECT_NE(prompt.find(R"({"tool": "tool_name", "tool_args": {"arg1": "value1"}})"),
+              std::string::npos);
+    EXPECT_NE(prompt.find("Do NOT wrap conversational replies in JSON."), std::string::npos);
+    EXPECT_EQ(prompt.find("You must respond ONLY in valid JSON"), std::string::npos);
+}
+
+TEST(ResponseModeTest, ConversationalStillExecutesABareToolJsonReply) {
+    bench::MockLlmServer mock;
+    mock.pushResponse(
+        R"({"choices":[{"message":{"content":"{\"tool\":\"echo\",\"tool_args\":{\"message\":\"yo\"}}"}}]})");
+    mock.pushResponse(kPlainAnswer);
+
+    AgentConfig cfg = makeCfg(mock.baseUrl(), kNonToolCallingModel);
+    cfg.responseMode = ResponseMode::Conversational;
+    ToolAgent agent(cfg);
+    agent.initForTest();
+    json result = agent.processQuery("echo yo", 3);
+
+    EXPECT_EQ(agent.executed, (std::vector<std::string>{"echo"}));
+    EXPECT_EQ(result["result"], "All done.");
+}
+
+TEST(ResponseModeTest, NativeToolCallingSuppressesBothTemplates) {
+    bench::MockLlmServer mock;
+    mock.pushResponse(kPlainAnswer);
+
+    AgentConfig cfg = makeCfg(mock.baseUrl(), kToolCallingModel);
+    cfg.responseMode = ResponseMode::Conversational;
+    ToolAgent agent(cfg);
+    agent.initForTest();
+    agent.processQuery("hi", 1);
+
+    const std::string prompt = systemPromptOf(json::parse(mock.receivedBodies().back()));
+    EXPECT_EQ(prompt.find("==== RESPONSE FORMAT ===="), std::string::npos);
+}
+
+// ---------------------------------------------------------------------------
+// Config round-trip
+// ---------------------------------------------------------------------------
+
+TEST(ResponseModeTest, ConfigRoundTripsTheNewFields) {
+    AgentConfig cfg;
+    cfg.responseMode = ResponseMode::Conversational;
+    cfg.nativeToolCalls = NativeToolCalls::Always;
+    cfg.toolChoice = "required";
+
+    AgentConfig back = AgentConfig::fromJson(cfg.toJson());
+    EXPECT_EQ(back.responseMode, ResponseMode::Conversational);
+    EXPECT_EQ(back.nativeToolCalls, NativeToolCalls::Always);
+    EXPECT_EQ(back.toolChoice, "required");
+}
+
+TEST(ResponseModeTest, ConfigDefaultsAreUnchangedWhenFieldsAreAbsent) {
+    AgentConfig back = AgentConfig::fromJson(json{{"modelId", "m"}});
+    EXPECT_EQ(back.responseMode, ResponseMode::Planning);
+    EXPECT_EQ(back.nativeToolCalls, NativeToolCalls::Auto);
+    EXPECT_EQ(back.toolChoice, "auto");
+}
+
+TEST(ResponseModeTest, InvalidEnumStringsAreRejected) {
+    EXPECT_THROW(AgentConfig::fromJson(json{{"responseMode", "chatty"}}),
+                 std::invalid_argument);
+    EXPECT_THROW(AgentConfig::fromJson(json{{"nativeToolCalls", "sometimes"}}),
+                 std::invalid_argument);
+    EXPECT_THROW(AgentConfig::fromJson(json{{"toolChoice", "maybe"}}),
+                 std::invalid_argument);
+}
+
+// ---------------------------------------------------------------------------
+// History: native tool exchanges survive intact, orphans are dropped
+// ---------------------------------------------------------------------------
+
+TEST(NativeToolCallsTest, HistoryKeepsTheSpecCorrectToolExchange) {
+    bench::MockLlmServer mock;
+    mock.pushResponse(toolCallsResponse(
+        R"([{"id":"call_1","type":"function","function":{"name":"echo","arguments":"{\"message\":\"hi\"}"}}])"));
+    mock.pushResponse(kPlainAnswer);
+
+    ToolAgent agent(makeCfg(mock.baseUrl(), kToolCallingModel));
+    agent.initForTest();
+    agent.processQuery("say hi", 3);
+
+    bool sawAssistantToolCalls = false;
+    bool sawToolReply = false;
+    for (const auto& m : agent.history()) {
+        if (m.role == MessageRole::ASSISTANT && !m.toolCalls.empty()) {
+            sawAssistantToolCalls = true;
+            EXPECT_EQ(m.toolCalls[0].id, "call_1");
+        }
+        if (m.role == MessageRole::TOOL) {
+            sawToolReply = true;
+            ASSERT_TRUE(m.toolCallId.has_value());
+            EXPECT_EQ(*m.toolCallId, "call_1");
+            // NOT downgraded to a "[Result from echo]:" user turn.
+            EXPECT_EQ(m.content.rfind("[Result from", 0), std::string::npos);
+        }
+    }
+    EXPECT_TRUE(sawAssistantToolCalls);
+    EXPECT_TRUE(sawToolReply);
+}
+
+TEST(NativeToolCallsTest, PromptJsonToolResultsStillDowngradeToUserTurns) {
+    bench::MockLlmServer mock;
+    mock.pushResponse(
+        R"({"choices":[{"message":{"content":"{\"thought\":\"t\",\"goal\":\"g\",\"tool\":\"echo\",\"tool_args\":{\"message\":\"hi\"}}"}}]})");
+    mock.pushResponse(
+        R"({"choices":[{"message":{"content":"{\"thought\":\"t\",\"goal\":\"g\",\"answer\":\"ok\"}"}}]})");
+
+    ToolAgent agent(makeCfg(mock.baseUrl(), kNonToolCallingModel));
+    agent.initForTest();
+    agent.processQuery("say hi", 3);
+
+    bool sawDowngraded = false;
+    for (const auto& m : agent.history()) {
+        EXPECT_NE(m.role, MessageRole::TOOL) << "prompt-JSON results must not stay role=tool";
+        if (m.role == MessageRole::USER &&
+            m.content.rfind("[Result from echo]:", 0) == 0) {
+            sawDowngraded = true;
+        }
+    }
+    EXPECT_TRUE(sawDowngraded);
+}
+
+TEST(NativeToolCallsTest, PruningDropsToolRepliesWhoseAssistantTurnIsGone) {
+    bench::MockLlmServer mock;
+    mock.pushResponse(toolCallsResponse(
+        R"([{"id":"call_1","type":"function","function":{"name":"echo","arguments":"{\"message\":\"hi\"}"}}])"));
+    mock.pushResponse(kPlainAnswer);
+
+    // maxHistoryMessages=2 keeps only the tail, cutting the assistant turn that
+    // owns call_1 — its role=tool reply must not survive alone.
+    AgentConfig cfg = makeCfg(mock.baseUrl(), kToolCallingModel);
+    cfg.maxHistoryMessages = 2;
+    ToolAgent agent(cfg);
+    agent.initForTest();
+    agent.processQuery("say hi", 3);
+
+    std::set<std::string> answerable;
+    for (const auto& m : agent.history()) {
+        for (const auto& tc : m.toolCalls) answerable.insert(tc.id);
+        if (m.role == MessageRole::TOOL && m.toolCallId.has_value()) {
+            EXPECT_NE(answerable.find(*m.toolCallId), answerable.end())
+                << "orphaned tool_call_id " << *m.toolCallId << " survived pruning";
+        }
+    }
+}
+
+TEST(NativeToolCallsTest, CancelBetweenParallelCallsLeavesNoUnansweredToolCall) {
+    // The tool itself cancels the run, so the second parallel call never
+    // executes — its advertised tool_call must not linger in history.
+    class CancellingAgent : public Agent {
+    public:
+        using Agent::Agent;
+        int runs = 0;
+
+    protected:
+        void registerTools() override {
+            toolRegistry().registerTool(
+                "echo", "Echo", [this](const json&) -> json {
+                    ++runs;
+                    requestCancel();
+                    return json{{"ok", true}};
+                });
+            toolRegistry().registerTool(
+                "add", "Add", [this](const json&) -> json {
+                    ++runs;
+                    return json{{"sum", 0}};
+                });
+        }
+
+    public:
+        void initForTest() { init(); }
+    };
+
+    bench::MockLlmServer mock;
+    mock.pushResponse(toolCallsResponse(
+        R"([{"id":"call_a","type":"function","function":{"name":"echo","arguments":"{}"}},)"
+        R"({"id":"call_b","type":"function","function":{"name":"add","arguments":"{}"}}])"));
+
+    CancellingAgent agent(makeCfg(mock.baseUrl(), kToolCallingModel));
+    agent.initForTest();
+    agent.processQuery("go", 3);
+
+    EXPECT_EQ(agent.runs, 1) << "cancel must stop the second parallel call";
+
+    std::set<std::string> advertised;
+    std::set<std::string> answered;
+    for (const auto& m : agent.history()) {
+        for (const auto& tc : m.toolCalls) advertised.insert(tc.id);
+        if (m.role == MessageRole::TOOL && m.toolCallId.has_value()) {
+            answered.insert(*m.toolCallId);
+        }
+    }
+    EXPECT_EQ(advertised, answered)
+        << "every advertised tool_call must have a reply in stored history";
+    EXPECT_EQ(advertised.count("call_b"), 0u) << "the cancelled call must be dropped";
+}
+
+// ---------------------------------------------------------------------------
+// Regressions found in review
+// ---------------------------------------------------------------------------
+
+TEST(NativeToolCallsTest, MalformedArgsInABatchRunNothingAndDoNotThrow) {
+    // Call A is well-formed, call B is truncated. Decoding happens up front, so
+    // A's side effects never happen — and processQuery reports via "result"
+    // rather than throwing out of the public API.
+    bench::MockLlmServer mock;
+    const std::string body = toolCallsResponse(
+        R"([{"id":"call_a","type":"function","function":{"name":"echo","arguments":"{\"message\":\"hi\"}"}},)"
+        R"({"id":"call_b","type":"function","function":{"name":"add","arguments":"{\"a\":"}}])");
+    mock.pushResponse(body);
+    mock.pushResponse(body);
+
+    ToolAgent agent(makeCfg(mock.baseUrl(), kToolCallingModel));
+    agent.initForTest();
+
+    json result;
+    ASSERT_NO_THROW(result = agent.processQuery("go", 2));
+    EXPECT_TRUE(agent.executed.empty())
+        << "no tool may run when a sibling call in the batch is malformed";
+    EXPECT_NE(result["result"].get<std::string>().find("LLM error"), std::string::npos);
+    // The turn was still recorded — the history write must not be skipped.
+    EXPECT_FALSE(agent.history().empty());
+}
+
+TEST(NativeToolCallsTest, NeverPolicyIgnoresVolunteeredToolCalls) {
+    // llama.cpp --jinja can return tool_calls even with no `tools` in the
+    // request. An agent that opted out must stay on the prompt-JSON path.
+    bench::MockLlmServer mock;
+    mock.pushResponse(toolCallsResponse(
+        R"([{"id":"call_x","type":"function","function":{"name":"echo","arguments":"{}"}}])",
+        R"("{\"thought\":\"t\",\"goal\":\"g\",\"answer\":\"prose wins\"}")"));
+
+    AgentConfig cfg = makeCfg(mock.baseUrl(), kToolCallingModel);
+    cfg.nativeToolCalls = NativeToolCalls::Never;
+    ToolAgent agent(cfg);
+    agent.initForTest();
+    json result = agent.processQuery("hi", 2);
+
+    EXPECT_TRUE(agent.executed.empty()) << "opted-out agent must not run a volunteered call";
+    EXPECT_EQ(result["result"], "prose wins");
+    for (const auto& m : agent.history()) {
+        EXPECT_TRUE(m.toolCalls.empty()) << "no tool_calls may enter an opted-out history";
+    }
+}
+
+TEST(NativeToolCallsTest, NeverPolicySurvivesMalformedVolunteeredToolCalls) {
+    // A malformed tool_calls field must not kill a turn whose `content` is a
+    // perfectly good prompt-JSON answer.
+    bench::MockLlmServer mock;
+    mock.pushResponse(toolCallsResponse(
+        R"([{"type":"function","function":{"name":"echo"}}])",
+        R"("{\"thought\":\"t\",\"goal\":\"g\",\"answer\":\"still fine\"}")"));
+
+    AgentConfig cfg = makeCfg(mock.baseUrl(), kNonToolCallingModel);
+    cfg.nativeToolCalls = NativeToolCalls::Never;
+    ToolAgent agent(cfg);
+    agent.initForTest();
+
+    EXPECT_EQ(agent.processQuery("hi", 2)["result"], "still fine");
+}
+
+TEST(NativeToolCallsTest, NoEnabledToolsKeepsTheResponseFormatTemplate) {
+    // A tool-calling model with nothing to call gets no `tools` array, so the
+    // prompt-JSON template must stay — otherwise it has no protocol at all.
+    bench::MockLlmServer mock;
+    mock.pushResponse(kPlainAnswer);
+
+    class Bare : public Agent { public: using Agent::Agent; };
+    Bare agent(makeCfg(mock.baseUrl(), kToolCallingModel));
+    agent.processQuery("hi", 1);
+
+    json body = json::parse(mock.receivedBodies().back());
+    EXPECT_FALSE(body.contains("tools"));
+    EXPECT_NE(systemPromptOf(body).find("==== RESPONSE FORMAT ===="), std::string::npos);
+}
+
+TEST(NativeToolCallsTest, SetHistoryRepairsAnOrphanedToolMessage) {
+    bench::MockLlmServer mock;
+    mock.pushResponse(kPlainAnswer);
+    ToolAgent agent(makeCfg(mock.baseUrl(), kToolCallingModel));
+    agent.initForTest();
+
+    Message orphan;
+    orphan.role = MessageRole::TOOL;
+    orphan.name = "echo";
+    orphan.toolCallId = "call_gone";
+    orphan.content = "{}";
+    agent.setHistory({orphan});
+
+    EXPECT_TRUE(agent.history().empty())
+        << "a tool reply with no assistant tool_calls turn must not be replayed";
+}
+
+TEST(ToolSchemaTest, ToolNameThatOpenAiWouldRejectThrowsWithGuidance) {
+    ToolRegistry registry;
+    // What mcp_<server>_<tool> produces when the server name has a dot.
+    registry.registerTool("mcp_my.server_do_thing", "MCP tool",
+                          [](const json&) -> json { return json{}; });
+    try {
+        registry.buildOpenAiToolSchemas();
+        FAIL() << "expected a throw for an invalid OpenAI function name";
+    } catch (const std::invalid_argument& e) {
+        const std::string msg = e.what();
+        EXPECT_NE(msg.find("mcp_my.server_do_thing"), std::string::npos) << msg;
+        EXPECT_NE(msg.find("NativeToolCalls::Never"), std::string::npos) << msg;
+    }
+}
+
+TEST(ToolSchemaTest, OverlongToolNameIsRejected) {
+    ToolRegistry registry;
+    registry.registerTool(std::string(65, 'a'), "Long", [](const json&) -> json { return json{}; });
+    EXPECT_THROW(registry.buildOpenAiToolSchemas(), std::invalid_argument);
+}
+
+TEST(SseToolCallsTest, ParallelCallsInOneDeltaWithoutIndexDoNotMerge) {
+    // Servers that omit `index` send the whole array in a single delta. Slotting
+    // them all at 0 would concatenate the names and the argument strings.
+    SseParser parser([](const std::string&) {});
+    const std::string sse =
+        "data: {\"choices\":[{\"delta\":{\"tool_calls\":["
+        "{\"id\":\"call_a\",\"function\":{\"name\":\"echo\",\"arguments\":\"{\\\"m\\\":1}\"}},"
+        "{\"id\":\"call_b\",\"function\":{\"name\":\"add\",\"arguments\":\"{\\\"a\\\":2}\"}}]}}]}\n\n"
+        "data: [DONE]\n\n";
+    feedByteByByte(parser, sse);
+
+    auto calls = parser.toolCalls();
+    ASSERT_EQ(calls.size(), 2u) << "index-less parallel calls merged into one";
+    EXPECT_EQ(calls[0].id, "call_a");
+    EXPECT_EQ(calls[0].name, "echo");
+    EXPECT_EQ(calls[0].arguments, R"({"m":1})");
+    EXPECT_EQ(calls[1].id, "call_b");
+    EXPECT_EQ(calls[1].name, "add");
+    EXPECT_EQ(calls[1].arguments, R"({"a":2})");
+}
+
+TEST(SseToolCallsTest, ServerRepeatingIdAndNameDoesNotDuplicateTheName) {
+    // Some servers restate id AND name on every delta for a call. Appending the
+    // name blindly would produce "echoecho" and a tool-not-found on every turn.
+    SseParser parser([](const std::string&) {});
+    const std::string sse =
+        "data: {\"choices\":[{\"delta\":{\"tool_calls\":[{\"index\":0,\"id\":\"c1\","
+        "\"function\":{\"name\":\"echo\",\"arguments\":\"{\\\"m\\\":\"}}]}}]}\n\n"
+        "data: {\"choices\":[{\"delta\":{\"tool_calls\":[{\"index\":0,\"id\":\"c1\","
+        "\"function\":{\"name\":\"echo\",\"arguments\":\"1}\"}}]}}]}\n\n"
+        "data: [DONE]\n\n";
+    feedByteByByte(parser, sse);
+
+    auto calls = parser.toolCalls();
+    ASSERT_EQ(calls.size(), 1u);
+    EXPECT_EQ(calls[0].name, "echo");
+    EXPECT_EQ(calls[0].arguments, R"({"m":1})");
+}
+
+// ---------------------------------------------------------------------------
+// Tool schema builder
+// ---------------------------------------------------------------------------
+
+TEST(ToolSchemaTest, EmptyRegistryProducesAnEmptyArray) {
+    ToolRegistry registry;
+    json schemas = registry.buildOpenAiToolSchemas();
+    EXPECT_TRUE(schemas.is_array());
+    EXPECT_TRUE(schemas.empty());
+}
+
+TEST(ToolSchemaTest, ParameterlessToolGetsAnEmptyPropertiesObject) {
+    ToolRegistry registry;
+    registry.registerTool("ping", "Ping", [](const json&) -> json { return json{}; });
+
+    json schemas = registry.buildOpenAiToolSchemas();
+    ASSERT_EQ(schemas.size(), 1u);
+    const auto& params = schemas[0]["function"]["parameters"];
+    EXPECT_EQ(params["type"], "object");
+    EXPECT_TRUE(params["properties"].is_object());
+    EXPECT_TRUE(params["properties"].empty());
+    EXPECT_TRUE(params["required"].is_array());
+    EXPECT_TRUE(params["required"].empty());
+}
+
+TEST(ToolSchemaTest, UnknownParamTypeFallsBackToString) {
+    ToolRegistry registry;
+    registry.registerTool("t", "T", [](const json&) -> json { return json{}; },
+                          {{"x", ToolParamType::UNKNOWN, true, ""}});
+
+    json schemas = registry.buildOpenAiToolSchemas();
+    EXPECT_EQ(schemas[0]["function"]["parameters"]["properties"]["x"]["type"], "string");
+    // An empty description is omitted rather than sent as "".
+    EXPECT_FALSE(schemas[0]["function"]["parameters"]["properties"]["x"].contains("description"));
+}
+
+TEST(ToolSchemaTest, AllParamTypesMapToJsonSchemaTypes) {
+    ToolRegistry registry;
+    registry.registerTool("t", "T", [](const json&) -> json { return json{}; },
+                          {{"s", ToolParamType::STRING, true, ""},
+                           {"i", ToolParamType::INTEGER, true, ""},
+                           {"n", ToolParamType::NUMBER, true, ""},
+                           {"b", ToolParamType::BOOLEAN, true, ""},
+                           {"a", ToolParamType::ARRAY, true, ""},
+                           {"o", ToolParamType::OBJECT, true, ""}});
+
+    const json schemas = registry.buildOpenAiToolSchemas();
+    const auto& props = schemas[0]["function"]["parameters"]["properties"];
+    EXPECT_EQ(props["s"]["type"], "string");
+    EXPECT_EQ(props["i"]["type"], "integer");
+    EXPECT_EQ(props["n"]["type"], "number");
+    EXPECT_EQ(props["b"]["type"], "boolean");
+    EXPECT_EQ(props["a"]["type"], "array");
+    EXPECT_EQ(props["o"]["type"], "object");
+}

--- a/docs/cpp/api-reference.mdx
+++ b/docs/cpp/api-reference.mdx
@@ -70,7 +70,7 @@ cfg.nativeToolCalls = gaia::NativeToolCalls::Auto;    // default — decide per 
 cfg.nativeToolCalls = gaia::NativeToolCalls::Always;  // force native
 cfg.nativeToolCalls = gaia::NativeToolCalls::Never;   // force prompt-JSON
 
-cfg.toolChoice = "auto";  // or "required" / "none"
+cfg.toolChoice = "auto";  // or "required"
 ```
 
 `Auto` consults `gaia::isToolCallingModel(modelId)`, a mirror of the `MODELS`

--- a/docs/cpp/api-reference.mdx
+++ b/docs/cpp/api-reference.mdx
@@ -37,7 +37,64 @@ The return value on LLM failure:
 
 Your application should check the `result` field — there is no exception to catch. HTTP timeouts: 30s connection, 120s read.
 
+## Tool Calling Protocols
+
+The agent drives tools two ways. Which one it uses is decided per model.
+
+### Native OpenAI tool calling
+
+For models known to support it, the request carries an OpenAI `tools` array built
+from the tool registry plus a `tool_choice`, the response-format template is left
+out of the system prompt entirely, and the model replies with
+`choices[0].message.tool_calls`. Results go back as spec-correct `role: tool`
+messages carrying `tool_call_id`, so the model sees a well-formed tool exchange.
+Parallel calls — several `tool_calls` in one response — all execute, each with its
+own reply. Streaming works too: `tool_calls` deltas are reassembled across SSE
+chunks.
+
+### Prompt-JSON fallback
+
+For every other model the agent appends a response-format template asking for a
+JSON envelope (`{"thought": ..., "tool": ..., "tool_args": {...}}`) and recovers
+the call from the reply text. Tool results become `[Result from <tool>]:` user
+turns. This is the path every C++ agent used before native tool calling landed,
+and it is unchanged.
+
+### Choosing a protocol
+
+```cpp
+gaia::AgentConfig cfg;
+cfg.modelId = "Gemma-4-E4B-it-GGUF";
+
+cfg.nativeToolCalls = gaia::NativeToolCalls::Auto;    // default — decide per model
+cfg.nativeToolCalls = gaia::NativeToolCalls::Always;  // force native
+cfg.nativeToolCalls = gaia::NativeToolCalls::Never;   // force prompt-JSON
+
+cfg.toolChoice = "auto";  // or "required" / "none"
+```
+
+`Auto` consults `gaia::isToolCallingModel(modelId)`, a mirror of the `MODELS`
+table in `src/gaia/llm/lemonade_client.py`. **An unrecognised model id resolves to
+`false`** — the C++ framework targets any OpenAI-compatible server, where an
+unknown id says nothing about tool-calling support, so it keeps the fallback that
+works everywhere. Running a tool-calling model this build does not know? Set
+`NativeToolCalls::Always`.
+
+### Response modes
+
+`responseMode` picks the template used on the prompt-JSON path. It is ignored
+under native tool calling, which sends no template at all.
+
+| Mode | Behavior |
+|------|----------|
+| `ResponseMode::Planning` (default) | JSON-only replies with `thought` / `goal` / `plan` / `tool` structure |
+| `ResponseMode::Conversational` | Plain text for conversation, a bare `{"tool": ..., "tool_args": {...}}` object only when calling a tool |
+
 ### Malformed JSON Recovery
+
+This applies to the prompt-JSON path only — native tool calls arrive as structured
+JSON and are parsed strictly (a malformed `tool_calls` entry raises rather than
+falling back to prose parsing).
 
 Local LLMs often return imperfect JSON. The parser applies **six extraction strategies** in sequence:
 

--- a/docs/cpp/custom-agent.mdx
+++ b/docs/cpp/custom-agent.mdx
@@ -337,6 +337,10 @@ static gaia::AgentConfig makeConfig() {
     // Output suppression (see Step 6)
     cfg.silentMode  = false;  // set true to suppress all console output
 
+    // Tool-calling protocol
+    cfg.nativeToolCalls = gaia::NativeToolCalls::Auto;   // per-model (default)
+    cfg.responseMode    = gaia::ResponseMode::Planning;  // prompt-JSON reply shape
+
     return cfg;
 }
 ```
@@ -348,6 +352,11 @@ static gaia::AgentConfig makeConfig() {
 | `debug = true` | During development to trace every LLM call and tool result |
 | `showPrompts = true` | To inspect the exact system prompt sent to the model |
 | `silentMode = true` | For library/service use where you only want the JSON result |
+| `nativeToolCalls = Always` | Your server's model supports OpenAI `tools` but this build's model table doesn't list it |
+| `nativeToolCalls = Never` | Pin a tool-calling model to the prompt-JSON path |
+| `responseMode = Conversational` | Chat-shaped agents that should answer in prose, not a JSON envelope |
+
+See [Tool Calling Protocols](/cpp/api-reference#tool-calling-protocols) for what each protocol sends on the wire.
 
 ---
 


### PR DESCRIPTION
Before: every C++ agent drove tools by asking the model to emit raw JSON inside its prose, then recovered the call with six-strategy text parsing — and handed results back as `[Result from X]:` user turns, so the model never saw a well-formed tool exchange. After: models known to support it get the native OpenAI protocol they were actually trained on — a `tools` array, `tool_calls` replies (including several parallel calls in one response), and spec-correct `role: tool` messages carrying `tool_call_id`. The difference is visible in the live integration run below: on the native path the agent reports the tool's exact value (21°C), while the same agent on the prompt-JSON path hallucinates a unit conversion (75°F).

The prompt-JSON path is preserved, not replaced. It remains the fallback for every other model, and `gaia-bash` plus all five examples work unchanged with no source edits.

**One judgment call worth a reviewer's attention:** `isToolCallingModel()` mirrors the `MODELS` table in `src/gaia/llm/lemonade_client.py`, but an **unknown model id resolves to `false`** where Python optimistically returns `true`. Python's default is backed by Tier-0 testing across Lemonade GGUF builds; the C++ framework is documented to run against any OpenAI-compatible server (llama.cpp, Ollama, vLLM), where an unrecognised id says nothing about tool support. Unknown therefore keeps the fallback that works everywhere, and `NativeToolCalls::Always` is the explicit opt-in. Flag it if you'd rather match Python exactly.

## Test plan

- [x] `cmake -B build -S cpp -DGAIA_BUILD_TESTS=ON && cmake --build build && ./build/tests_mock` — **519/519 pass** (463 before this change, 56 new)
- [x] Existing `test_agent.cpp` (19 cases) and `test_tool_integration.cpp` (38 cases) pass **unchanged** — no edits to either file
- [x] Non-tool-calling model sends exactly `{model, max_tokens, temperature, messages}` and the byte-identical system prompt — pinned by an exact-key-set assertion, not a substring check
- [x] Parallel `tool_calls`, streaming delta accumulation (SSE fed **one byte at a time**), both response modes, and the model gate in both directions all covered
- [x] Live Lemonade, `Gemma-4-E4B-it-GGUF`: `cmake -B build-int -S cpp -DGAIA_BUILD_INTEGRATION_TESTS=ON && ./build-int/tests_integration --gtest_filter='ToolCallsIntegrationTest.*'` — **5/5 pass**, proving the emitted schema is *accepted*, not merely well-formed (the #1655 lesson)
- [x] `gaia-bash` end-to-end on the native path with zero source changes: asked for a file count, got the correct answer (18) via a real shell tool call
- [x] Shared-library build (`BUILD_SHARED_LIBS=ON`) and benchmark target both compile
- [ ] **`gaia eval agent` — ran, but it is not a valid signal for this change; see below**

## About the eval

Run as required, but read the caveat before weighing it: **this PR changes 0 files under `src/gaia/`.** `gaia eval agent` drives the *Python* agent stack through the Agent UI backend, which on this host was serving from an unrelated checkout entirely. The eval could not observe this change in either direction.

```
METRIC                           BASELINE    CURRENT      DELTA
--------------------------------------------------------------
Pass rate (all)                       75%        40%       -35%
Avg score                             8.4        6.9       -1.5
Scenarios                               4          5

[+] IMPROVED  known_path_read       6.7 → 9.7 (+3.0)   FAIL → PASS
[!] REGRESSED multi_step_plan       7.3 → 7.8 (+0.5)   PASS → FAIL
[~] TIME      smart_discovery       179.1s → 587.5s
[=] UNCHANGED no_tools_needed       PASS 10.0
[+] NEW       data_vs_recall_disambiguation  (not in baseline)
```

Two reasons to treat these as environment noise rather than a regression: `multi_step_plan` scored **PASS 8.4 in one run and FAIL 7.8 in another with identical code** (its score went *up* while flipping to FAIL, so it sits on the pass threshold), and `smart_discovery`'s 3.3x time blowup points at the host — the committed baseline was recorded on a Ryzen 9 9950X with Lemonade 10.2.0, this ran on different hardware. `smart_discovery` (9.5 → 3.3) is the one worth a second look, but it should be re-run on the baseline machine by someone who has it; I can't attribute it to a C++-only change.

The real LLM-behaviour evidence for this change is the live-Lemonade integration suite and the `gaia-bash` run above, both of which exercise the code this PR actually touches.

Closes #2794
