### PR TITLE
feat(cpp): harden the coding toolbelt — stale-write rejection, ignore-aware search, persistent shell

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -144,6 +144,7 @@ add_library(gaia_core
     src/sse_parser.cpp
     src/process.cpp
     src/file_tools.cpp
+    src/ignore.cpp
     src/git_tools.cpp
     src/session.cpp
     src/repl.cpp
@@ -314,6 +315,7 @@ if(GAIA_BUILD_TESTS)
         tests/test_sse_parser.cpp
         tests/test_process.cpp
         tests/test_file_tools.cpp
+        tests/test_ignore.cpp
         tests/test_git_tools.cpp
         tests/test_session.cpp
         tests/test_repl.cpp

--- a/cpp/agents/bash/bash_tools.cpp
+++ b/cpp/agents/bash/bash_tools.cpp
@@ -35,7 +35,10 @@ ToolInfo BashTools::bashExecute() {
     info.description =
         "Execute a shell command and return its output. "
         "The command runs in the detected shell (bash preferred, sh fallback). "
-        "Output is truncated at 32 KB. Use timeout_ms to control the deadline.";
+        "The shell is persistent: a 'cd' or an exported variable stays in "
+        "effect for later commands, and the current directory is returned as "
+        "cwd. Output is truncated at 32 KB. Use timeout_ms to control the "
+        "deadline.";
     info.parameters = {
         {"command", ToolParamType::STRING, /*required=*/true,
          "The shell command to execute"},
@@ -59,52 +62,11 @@ json BashTools::doBashExecute(const json& args) {
         timeoutMs = DEFAULT_TIMEOUT_MS;
     }
 
-    // Detect the shell and build the full command
-    std::string shell = detectShell();
-    std::string fullCommand;
+    // One session per process, so cwd and exported variables survive between
+    // calls. The CONFIRM policy and the output cap below are unchanged.
+    static ShellSession session("", detectShell());
 
-#ifdef _WIN32
-    if (!shell.empty()) {
-        // Use detected bash/sh: wrap the command in shell -c "..."
-        // Escape double quotes in the command for the outer shell
-        std::string escaped = command;
-        // Replace \ with \\ and " with \" for the bash -c wrapper
-        std::string safeCmd;
-        safeCmd.reserve(escaped.size() + 16);
-        for (char c : escaped) {
-            if (c == '\\') {
-                safeCmd += "\\\\";
-            } else if (c == '"') {
-                safeCmd += "\\\"";
-            } else {
-                safeCmd += c;
-            }
-        }
-        fullCommand = shell + " -c \"" + safeCmd + "\"";
-    } else {
-        // No bash/sh available — run via cmd.exe directly
-        fullCommand = "cmd.exe /C " + command;
-    }
-#else
-    // POSIX: always use bash -c (or sh -c as fallback)
-    if (shell.empty()) {
-        shell = "sh";
-    }
-    // Escape single quotes for POSIX shell: replace ' with '\''
-    std::string safeCmd;
-    safeCmd.reserve(command.size() + 16);
-    for (char c : command) {
-        if (c == '\'') {
-            safeCmd += "'\\''";
-        } else {
-            safeCmd += c;
-        }
-    }
-    fullCommand = shell + " -c '" + safeCmd + "'";
-#endif
-
-    // Execute via ProcessRunner
-    ProcessResult result = ProcessRunner::run(fullCommand, timeoutMs, "", {}, MAX_OUTPUT_BYTES);
+    ProcessResult result = session.run(command, timeoutMs, MAX_OUTPUT_BYTES);
 
     // Truncate stdout/stderr if needed
     std::string stdoutStr = result.stdout_output;
@@ -126,6 +88,7 @@ json BashTools::doBashExecute(const json& args) {
         {"stderr", stderrStr},
         {"exit_code", result.exitCode},
         {"timed_out", result.timedOut},
+        {"cwd", session.cwd()},
     };
 }
 

--- a/cpp/agents/bash/bash_tools.cpp
+++ b/cpp/agents/bash/bash_tools.cpp
@@ -37,8 +37,9 @@ ToolInfo BashTools::bashExecute() {
         "The command runs in the detected shell (bash preferred, sh fallback). "
         "The shell is persistent: a 'cd' or an exported variable stays in "
         "effect for later commands, and the current directory is returned as "
-        "cwd. Output is truncated at 32 KB. Use timeout_ms to control the "
-        "deadline.";
+        "cwd. On Windows without a POSIX shell, commands run as a cmd.exe "
+        "script, so write a for-loop variable as %%i rather than %i. Output is "
+        "truncated at 32 KB. Use timeout_ms to control the deadline.";
     info.parameters = {
         {"command", ToolParamType::STRING, /*required=*/true,
          "The shell command to execute"},

--- a/cpp/include/gaia/file_tools.h
+++ b/cpp/include/gaia/file_tools.h
@@ -7,6 +7,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <string>
 
 #include "gaia/export.h"
@@ -14,6 +15,103 @@
 #include "gaia/types.h"
 
 namespace gaia {
+
+/// Tracks the content hash of every file an agent has read, so a later write
+/// can tell "the model is editing what it saw" from "the file moved under it".
+///
+/// No system prompt can prevent a stale write: by the time the model emits an
+/// edit, the read that justified it may be many turns old and the file may
+/// have been changed by a build step, a formatter, another agent, or the user.
+/// The tool has to catch it, so `file_write` and `file_edit` consult this
+/// tracker and refuse rather than clobber.
+///
+/// Semantics:
+///   - `file_read` records the SHA-256 of the file's full contents (not the
+///     returned slice — a line-range read still anchors the whole file).
+///   - `file_write` / `file_edit` reject when a record exists and the current
+///     contents hash differently, naming both hashes and the size change.
+///   - A file with no record is not blocked. Requiring a prior read would make
+///     the tools unusable for creating files, and an agent that never read the
+///     file has nothing stale to be wrong about.
+///   - A successful write or edit re-records the new contents, so consecutive
+///     edits to the same file work without an intervening read.
+///
+/// Thread-safe: an internal mutex guards the table.
+///
+/// Extension point: a future `lsp` tool (clangd) applies server-computed
+/// `WorkspaceEdit`s to files the model never read. It must call
+/// `recordWrite()` for each file it touches; otherwise the next `file_edit`
+/// would see the LSP's own change as third-party divergence and reject it.
+/// `forget()` is the hook for a file the tool no longer vouches for.
+class GAIA_API FileStateTracker {
+public:
+    /// The result of comparing a file's current contents to what was read.
+    struct Divergence {
+        bool diverged = false;      ///< True when a read record exists and no longer matches
+        std::string hashAtRead;     ///< Short hash captured by the last read/write
+        std::string hashNow;        ///< Short hash of the contents on disk right now
+        std::uint64_t sizeAtRead = 0;
+        std::uint64_t sizeNow = 0;
+        std::string reason;         ///< Human-readable description of the divergence
+    };
+
+    /// Process-wide tracker used by the FileIOTools callbacks.
+    static FileStateTracker& instance();
+
+    /// Record the contents an agent has just seen for `path`.
+    void recordRead(const std::string& path, const std::string& contents);
+
+    /// Record contents an agent has just written for `path`. Identical to
+    /// recordRead() but named for the call site so intent stays readable.
+    void recordWrite(const std::string& path, const std::string& contents);
+
+    /// Hash the file on disk (streamed, so a huge file costs bounded memory)
+    /// and record it. Returns the hash, or "" when the file is unreadable.
+    std::string recordFromDisk(const std::string& path);
+
+    /// Record an already-computed hash. Use this when the caller hashed the
+    /// same bytes it acted on — re-reading the file to hash it would open a
+    /// window in which the anchor describes a version nobody saw.
+    void recordHash(const std::string& path,
+                    const std::string& hash,
+                    std::uint64_t size);
+
+    /// Compare `currentContents` against the recorded read for `path`.
+    /// Returns `diverged == false` when there is no record for the path.
+    Divergence check(const std::string& path,
+                     const std::string& currentContents) const;
+
+    /// Same as check(), reading the current contents from disk. A file that
+    /// has a record but no longer exists counts as diverged.
+    Divergence checkFile(const std::string& path) const;
+
+    /// True when `path` has a recorded read or write.
+    bool hasRecord(const std::string& path) const;
+
+    /// Drop the record for `path` (e.g. the file was deleted or renamed).
+    void forget(const std::string& path);
+
+    /// Drop every record. Intended for tests and session resets.
+    void clear();
+
+    /// Number of tracked files.
+    size_t size() const;
+
+    /// Lowercase hex SHA-256 of `contents`.
+    static std::string hashContent(const std::string& contents);
+
+    /// Lowercase hex SHA-256 of the bytes of the file at `path`, streamed.
+    /// Returns "" when the file cannot be opened.
+    static std::string hashFile(const std::string& path);
+
+private:
+    FileStateTracker() = default;
+
+    struct Impl;
+    // Storage lives in the translation unit to keep <map>/<mutex> out of the
+    // public header.
+    static Impl& impl();
+};
 
 /// Pre-built file I/O tool callbacks for agents.
 /// Each static method returns a ToolInfo ready for ToolRegistry::registerTool().
@@ -27,6 +125,15 @@ namespace gaia {
 ///
 /// Or register all at once:
 ///   FileIOTools::registerAll(agent.toolRegistry());
+///
+/// Design note — room for `lsp`: these tools stay deliberately text-level.
+/// Structural edits ("rename this symbol everywhere") are a graph operation
+/// that regex cannot do correctly, and the answer is a clangd-backed `lsp`
+/// tool in a follow-on milestone, not a smarter `file_edit`. That tool slots
+/// in beside these without a rewrite because the two contracts it needs
+/// already exist here: FileStateTracker (so LSP-applied edits and model edits
+/// share one staleness ledger) and GitignoreMatcher in `gaia/ignore.h` (so
+/// both agree on which files are part of the project).
 class GAIA_API FileIOTools {
 public:
     /// Register all file I/O tools with the given registry.
@@ -34,25 +141,38 @@ public:
 
     /// file_read: Read file contents with optional line range.
     /// Args: {"path": string, "start_line"?: int, "end_line"?: int}
-    /// Returns: {"content": string, "lines": int, "path": string}
+    /// Returns: {"content": string, "lines": int, "path": string,
+    ///           "content_hash": string}
+    /// The returned content_hash anchors later edits; see FileStateTracker.
     /// On error: {"error": string}
     static ToolInfo fileRead();
 
     /// file_write: Write content to a file (creates parent dirs).
     /// Args: {"path": string, "content": string}
-    /// Returns: {"success": true, "path": string, "bytes_written": int}
+    /// Returns: {"success": true, "path": string, "bytes_written": int,
+    ///           "content_hash": string}
+    /// Rejected with {"error": ..., "stale": true} when the file changed
+    /// since it was read.
     /// On error: {"error": string}
     static ToolInfo fileWrite();
 
     /// file_edit: Surgical string replacement in a file.
     /// Args: {"path": string, "old_string": string, "new_string": string}
-    /// Returns: {"success": true, "path": string, "replacements": int}
+    /// Returns: {"success": true, "path": string, "replacements": int,
+    ///           "content_hash": string}
+    /// Rejected with {"error": ..., "stale": true} when the file changed
+    /// since it was read; a non-matching old_string returns an actionable
+    /// error rather than reporting success on a no-op.
     /// On error: {"error": string}
     static ToolInfo fileEdit();
 
     /// file_search: Search for files by glob pattern and/or content pattern.
     /// Args: {"pattern": string, "path"?: string, "content_pattern"?: string, "max_results"?: int}
-    /// Returns: {"matches": [{"path": string, "line"?: int, "context"?: string}], "total": int}
+    /// Returns: {"matches": [{"path": string, "line"?: int, "context"?: string}],
+    ///           "total": int, "ignored_skipped": int}
+    /// Paths excluded by `.gitignore` (and `.git/` itself) are skipped and
+    /// counted in ignored_skipped, so a thin result set is explained rather
+    /// than mysterious.
     /// On error: {"error": string}
     static ToolInfo fileSearch();
 
@@ -62,9 +182,6 @@ private:
     static json doFileWrite(const json& args);
     static json doFileEdit(const json& args);
     static json doFileSearch(const json& args);
-
-    /// Simple glob-style pattern matching (supports * and ? wildcards).
-    static bool matchGlob(const std::string& pattern, const std::string& text);
 };
 
 } // namespace gaia

--- a/cpp/include/gaia/ignore.h
+++ b/cpp/include/gaia/ignore.h
@@ -1,0 +1,114 @@
+// Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: MIT
+//
+// Glob matching and .gitignore evaluation for the GAIA C++ agent framework.
+//
+// Searching a real repository without ignore awareness returns build output,
+// vendored dependencies, and VCS internals. That noise poisons an agent's
+// context far more effectively than a missing result would hurt it, so every
+// file-walking tool in the framework routes through this header.
+//
+// Reused by `FileIOTools::fileSearch()`. A future `lsp` tool (clangd) and the
+// code index both need the same "which files belong to this project" answer;
+// they should call GitignoreMatcher rather than re-deriving it, so a project
+// that hides a directory hides it from every tool at once.
+
+#pragma once
+
+#include <string>
+#include <vector>
+
+#include "gaia/export.h"
+
+namespace gaia {
+
+/// Options controlling how globMatch() interprets a pattern.
+struct GAIA_API GlobOptions {
+    /// When true, `*` and `?` do not match the path separator `/`, and `**`
+    /// spans directories. When false the whole text is treated as one
+    /// segment (the right mode for matching a bare file name).
+    bool pathMode = false;
+
+    /// ASCII case-insensitive comparison.
+    bool caseInsensitive = false;
+};
+
+/// Match `text` against a glob `pattern`.
+///
+/// Supported syntax:
+///   - `*`     any run of characters (not `/` in path mode)
+///   - `?`     exactly one character (not `/` in path mode)
+///   - `**`    any run of characters including `/` (path mode only);
+///             `**/` also matches zero directories, so `**/x` matches `x`
+///   - `[abc]` `[a-z]` `[!a-z]` `[^a-z]` character classes with ranges and negation
+///   - `\x`    escapes the next character
+///
+/// Runs in O(pattern * text) via memoized backtracking, so a pathological
+/// pattern such as `*a*a*a*a*b` cannot hang the agent.
+GAIA_API bool globMatch(const std::string& pattern,
+                        const std::string& text,
+                        const GlobOptions& options = {});
+
+/// Evaluates `.gitignore` rules against paths.
+///
+/// Implements the subset of gitignore(5) that matters for source trees:
+/// comments, blank lines, escapes, trailing-space stripping, `!` negation
+/// (last matching rule wins), `dir/` directory-only rules, rules anchored by
+/// a leading or embedded `/`, and unanchored rules that match at any depth.
+///
+/// Two deliberate deviations, both in the direction of showing more rather
+/// than fewer files — a search that hides a file the user asked for is worse
+/// than one that shows an extra:
+///   - `.git/info/exclude`, the global core.excludesFile, and skip-worktree
+///     bits are not consulted; they live outside the working tree.
+///   - git refuses to re-include a file whose parent directory is excluded.
+///     Here the last matching rule simply wins, so `!keep.log` re-includes
+///     even under an ignored directory.
+class GAIA_API GitignoreMatcher {
+public:
+    GitignoreMatcher() = default;
+
+    /// Build a matcher governing `directory`: collects every `.gitignore`
+    /// from the enclosing git repository root down to `directory` itself, so
+    /// searching `repo/src` still honours `repo/.gitignore`. When `directory`
+    /// is not inside a git repository, only its own `.gitignore` is read.
+    ///
+    /// This covers everything *above* the starting directory. A caller that
+    /// walks downward must fold in each subdirectory's own `.gitignore` with
+    /// addFile() as it descends — rules are scoped to their base directory,
+    /// so adding them late is safe and cannot affect siblings.
+    static GitignoreMatcher forDirectory(const std::string& directory);
+
+    /// Add the rules in the `.gitignore` file at `gitignorePath`. Rules are
+    /// interpreted relative to the file's own directory. A missing or
+    /// unreadable file adds nothing.
+    void addFile(const std::string& gitignorePath);
+
+    /// Add rules from in-memory `.gitignore` text anchored at `baseDir`.
+    void addRules(const std::string& contents, const std::string& baseDir);
+
+    /// True when `path` is ignored. `path` may be absolute or relative;
+    /// it is canonicalized against the rule base directories. `isDirectory`
+    /// selects whether `dir/`-style rules apply to the final component.
+    bool isIgnored(const std::string& path, bool isDirectory) const;
+
+    /// True when no rules were loaded (every path is then un-ignored).
+    bool empty() const { return rules_.empty(); }
+
+    /// Number of loaded rules — surfaced so a tool can report *why* a search
+    /// came back thin instead of leaving the caller guessing.
+    size_t ruleCount() const { return rules_.size(); }
+
+private:
+    struct Rule {
+        std::string pattern;   ///< pattern with leading `!`/`/` and trailing `/` stripped
+        std::string baseDir;   ///< generic-format absolute directory the rule is anchored to
+        bool negate = false;   ///< `!pattern` — re-includes a previously ignored path
+        bool dirOnly = false;  ///< `pattern/` — matches directories only
+        bool anchored = false; ///< contains `/` other than a trailing one
+    };
+
+    std::vector<Rule> rules_;
+};
+
+} // namespace gaia

--- a/cpp/include/gaia/process.h
+++ b/cpp/include/gaia/process.h
@@ -108,7 +108,15 @@ public:
 /// cwd and environment changes from that one command are not captured; the
 /// session keeps its previous state instead of guessing.
 ///
-/// Two properties of the generated script are worth knowing:
+/// Windows without a POSIX shell: commands run as a cmd.exe batch script,
+/// because keeping `cd` and `set` requires running in the same interpreter and
+/// cmd only offers that to a script. `%VAR%` expansion is identical to a
+/// prompt, but a `for` loop variable is written `%%i` rather than `%i`, and
+/// `%1`-`%9` are the (empty) script arguments rather than literal text. When a
+/// bash is present — Git Bash, MSYS, WSL, which `BashTools::detectShell()`
+/// prefers — none of this applies and commands run as ordinary shell script.
+///
+/// Two further properties of the generated script are worth knowing:
 ///   - stdin is `/dev/null`. An interactive command (`git commit` opening an
 ///     editor, `sudo`, `npm login`) returns immediately instead of sitting
 ///     until the timeout, because a tool call has no way to answer it.

--- a/cpp/include/gaia/process.h
+++ b/cpp/include/gaia/process.h
@@ -9,6 +9,7 @@
 #pragma once
 
 #include <map>
+#include <memory>
 #include <stdexcept>
 #include <string>
 
@@ -34,7 +35,9 @@ struct GAIA_API ProcessResult {
 /// Working directory (chdir) and environment variables (setenv) are
 /// process-wide on both POSIX and Windows. Concurrent calls with
 /// different cwd/env values will interfere. Safe for concurrent use
-/// only when cwd and env are both empty (the default).
+/// only when cwd and env are both empty (the default). Use ShellSession
+/// below when you need either: it applies both inside the child shell and
+/// so never mutates the calling process.
 ///
 /// Example:
 /// @code
@@ -73,6 +76,103 @@ public:
         int timeoutMs = 30000,
         const std::string& cwd = ""
     );
+};
+
+/// A shell whose working directory and environment survive between commands.
+///
+/// `ProcessRunner::run()` is one-shot: `cd build` in one call is invisible to
+/// the next, and so is `export CC=clang`. That is materially worse than a
+/// human terminal for the build/test loop an agent spends most of its time in,
+/// and no system prompt can fix it — the state simply is not there to observe.
+/// A ShellSession keeps it.
+///
+/// The security model is unchanged. This class only preserves state; it does
+/// not decide what may run. The `bash_execute` tool that uses it keeps its
+/// `ToolPolicy::CONFIRM` policy and its output cap, both of which apply per
+/// command exactly as before.
+///
+/// Thread-safety, and why this is better than ProcessRunner::run(cwd, env):
+/// `run()` implements cwd and env with process-wide `chdir`/`setenv`, so two
+/// concurrent calls with different values corrupt each other. A ShellSession
+/// never mutates the parent process — the working directory and the variables
+/// are applied inside the child shell — so distinct sessions are safe to use
+/// concurrently. Calls on the *same* session are serialized by an internal
+/// mutex, because they share one logical shell state.
+///
+/// How the state round-trips: each call runs a small generated script that
+/// restores the session's cwd and variables, sources the command from its own
+/// file, then writes the resulting `pwd` and environment to a side file. The
+/// side file — rather than the command's own output — is what keeps the output
+/// cap honest and the captured stdout free of bookkeeping noise. A command
+/// that calls `exit` terminates the script before that bookkeeping runs, so
+/// cwd and environment changes from that one command are not captured; the
+/// session keeps its previous state instead of guessing.
+///
+/// Two properties of the generated script are worth knowing:
+///   - stdin is `/dev/null`. An interactive command (`git commit` opening an
+///     editor, `sudo`, `npm login`) returns immediately instead of sitting
+///     until the timeout, because a tool call has no way to answer it.
+///   - On POSIX a timeout kills the command's whole process group, not just
+///     the shell — a build or test command spawns children, and leaving them
+///     running is what makes a timed-out build loop worse than useless.
+///     Windows has no equivalent yet; it would need a Job Object.
+///
+/// Example:
+/// @code
+///   gaia::ShellSession shell;
+///   shell.run("cd /tmp && export BUILD=release");
+///   auto result = shell.run("pwd && echo $BUILD");  // /tmp, release
+/// @endcode
+class GAIA_API ShellSession {
+public:
+    /// @param startCwd  Initial working directory (empty = process cwd)
+    /// @param shell     Shell to run commands with. Empty means `/bin/sh` on
+    ///                  POSIX and cmd.exe on Windows. Naming a POSIX shell on
+    ///                  Windows (Git Bash, MSYS, WSL) makes the session
+    ///                  generate a shell script for it instead of a batch file.
+    explicit ShellSession(const std::string& startCwd = "",
+                          const std::string& shell = "");
+    ~ShellSession();
+
+    ShellSession(const ShellSession&) = delete;
+    ShellSession& operator=(const ShellSession&) = delete;
+    ShellSession(ShellSession&&) noexcept;
+    ShellSession& operator=(ShellSession&&) noexcept;
+
+    /// Run a command in the session, then absorb any cwd/environment change
+    /// it made. Output capping and timeout semantics match ProcessRunner::run.
+    ///
+    /// @param command         Shell command to execute
+    /// @param timeoutMs       Timeout in milliseconds (0 = no timeout)
+    /// @param maxOutputBytes  Maximum bytes captured per stream
+    ProcessResult run(const std::string& command,
+                      int timeoutMs = 30000,
+                      size_t maxOutputBytes = 65536);
+
+    /// Current working directory of the session.
+    std::string cwd() const;
+
+    /// Set the working directory. Returns false when the path is not an
+    /// existing directory (and leaves the session unchanged).
+    bool setCwd(const std::string& dir);
+
+    /// Variables the session has diverged from the parent process
+    /// environment — what a command exported, minus what was inherited.
+    std::map<std::string, std::string> environment() const;
+
+    /// Set a variable for subsequent commands in this session.
+    void setEnv(const std::string& name, const std::string& value);
+
+    /// Forget every environment change and return to the starting directory.
+    void reset();
+
+    /// Process-wide default session, so a stateless tool callback can still
+    /// participate in one continuous shell.
+    static ShellSession& shared();
+
+private:
+    struct Impl;
+    std::unique_ptr<Impl> impl_;
 };
 
 } // namespace gaia

--- a/cpp/src/file_tools.cpp
+++ b/cpp/src/file_tools.cpp
@@ -4,15 +4,407 @@
 #include "gaia/file_tools.h"
 
 #include <algorithm>
+#include <array>
+#include <cstdint>
+#include <cstring>
 #include <filesystem>
 #include <fstream>
+#include <map>
+#include <mutex>
 #include <sstream>
 #include <string>
 #include <vector>
 
+#include "gaia/ignore.h"
+
 namespace fs = std::filesystem;
 
 namespace gaia {
+
+namespace {
+
+// ---------------------------------------------------------------------------
+// SHA-256 (FIPS 180-4) — self-contained so the framework picks up no new
+// dependency for content hashing.
+// ---------------------------------------------------------------------------
+
+class Sha256 {
+public:
+    Sha256() { reset(); }
+
+    void reset() {
+        state_ = {0x6a09e667u, 0xbb67ae85u, 0x3c6ef372u, 0xa54ff53au,
+                  0x510e527fu, 0x9b05688cu, 0x1f83d9abu, 0x5be0cd19u};
+        bufferLen_ = 0;
+        totalBits_ = 0;
+    }
+
+    void update(const char* data, size_t len) {
+        totalBits_ += static_cast<std::uint64_t>(len) * 8u;
+        append(reinterpret_cast<const unsigned char*>(data), len);
+    }
+
+    std::string hex() {
+        // Pad: 0x80, zeros, then the 64-bit big-endian bit count. The padding
+        // is appended without touching totalBits_ — it is framing, not message.
+        const std::uint64_t bits = totalBits_;
+
+        std::array<unsigned char, 72> pad{};
+        pad[0] = 0x80;
+        const size_t padLen = (bufferLen_ < 56) ? (56 - bufferLen_)
+                                                : (120 - bufferLen_);
+        append(pad.data(), padLen);
+
+        std::array<unsigned char, 8> lenBytes{};
+        for (int i = 0; i < 8; ++i) {
+            lenBytes[static_cast<size_t>(i)] =
+                static_cast<unsigned char>((bits >> (56 - 8 * i)) & 0xffu);
+        }
+        append(lenBytes.data(), 8);
+
+        static const char* kHex = "0123456789abcdef";
+        std::string out;
+        out.reserve(64);
+        for (std::uint32_t word : state_) {
+            for (int shift = 24; shift >= 0; shift -= 8) {
+                const unsigned byte = (word >> shift) & 0xffu;
+                out.push_back(kHex[byte >> 4]);
+                out.push_back(kHex[byte & 0x0fu]);
+            }
+        }
+        return out;
+    }
+
+private:
+    static std::uint32_t rotr(std::uint32_t x, int n) {
+        return (x >> n) | (x << (32 - n));
+    }
+
+    void append(const unsigned char* data, size_t len) {
+        while (len > 0) {
+            const size_t take = std::min(len, size_t{64} - bufferLen_);
+            std::memcpy(buffer_.data() + bufferLen_, data, take);
+            bufferLen_ += take;
+            data += take;
+            len -= take;
+            if (bufferLen_ == 64) {
+                transform(buffer_.data());
+                bufferLen_ = 0;
+            }
+        }
+    }
+
+    void transform(const unsigned char* block) {
+        static const std::uint32_t K[64] = {
+            0x428a2f98u, 0x71374491u, 0xb5c0fbcfu, 0xe9b5dba5u, 0x3956c25bu,
+            0x59f111f1u, 0x923f82a4u, 0xab1c5ed5u, 0xd807aa98u, 0x12835b01u,
+            0x243185beu, 0x550c7dc3u, 0x72be5d74u, 0x80deb1feu, 0x9bdc06a7u,
+            0xc19bf174u, 0xe49b69c1u, 0xefbe4786u, 0x0fc19dc6u, 0x240ca1ccu,
+            0x2de92c6fu, 0x4a7484aau, 0x5cb0a9dcu, 0x76f988dau, 0x983e5152u,
+            0xa831c66du, 0xb00327c8u, 0xbf597fc7u, 0xc6e00bf3u, 0xd5a79147u,
+            0x06ca6351u, 0x14292967u, 0x27b70a85u, 0x2e1b2138u, 0x4d2c6dfcu,
+            0x53380d13u, 0x650a7354u, 0x766a0abbu, 0x81c2c92eu, 0x92722c85u,
+            0xa2bfe8a1u, 0xa81a664bu, 0xc24b8b70u, 0xc76c51a3u, 0xd192e819u,
+            0xd6990624u, 0xf40e3585u, 0x106aa070u, 0x19a4c116u, 0x1e376c08u,
+            0x2748774cu, 0x34b0bcb5u, 0x391c0cb3u, 0x4ed8aa4au, 0x5b9cca4fu,
+            0x682e6ff3u, 0x748f82eeu, 0x78a5636fu, 0x84c87814u, 0x8cc70208u,
+            0x90befffau, 0xa4506cebu, 0xbef9a3f7u, 0xc67178f2u};
+
+        std::uint32_t w[64];
+        for (int i = 0; i < 16; ++i) {
+            const size_t o = static_cast<size_t>(i) * 4;
+            w[i] = (static_cast<std::uint32_t>(block[o]) << 24) |
+                   (static_cast<std::uint32_t>(block[o + 1]) << 16) |
+                   (static_cast<std::uint32_t>(block[o + 2]) << 8) |
+                   (static_cast<std::uint32_t>(block[o + 3]));
+        }
+        for (int i = 16; i < 64; ++i) {
+            const std::uint32_t s0 =
+                rotr(w[i - 15], 7) ^ rotr(w[i - 15], 18) ^ (w[i - 15] >> 3);
+            const std::uint32_t s1 =
+                rotr(w[i - 2], 17) ^ rotr(w[i - 2], 19) ^ (w[i - 2] >> 10);
+            w[i] = w[i - 16] + s0 + w[i - 7] + s1;
+        }
+
+        std::uint32_t a = state_[0], b = state_[1], c = state_[2], d = state_[3];
+        std::uint32_t e = state_[4], f = state_[5], g = state_[6], h = state_[7];
+
+        for (int i = 0; i < 64; ++i) {
+            const std::uint32_t S1 = rotr(e, 6) ^ rotr(e, 11) ^ rotr(e, 25);
+            const std::uint32_t ch = (e & f) ^ (~e & g);
+            const std::uint32_t t1 = h + S1 + ch + K[i] + w[i];
+            const std::uint32_t S0 = rotr(a, 2) ^ rotr(a, 13) ^ rotr(a, 22);
+            const std::uint32_t maj = (a & b) ^ (a & c) ^ (b & c);
+            const std::uint32_t t2 = S0 + maj;
+
+            h = g; g = f; f = e; e = d + t1;
+            d = c; c = b; b = a; a = t1 + t2;
+        }
+
+        state_[0] += a; state_[1] += b; state_[2] += c; state_[3] += d;
+        state_[4] += e; state_[5] += f; state_[6] += g; state_[7] += h;
+    }
+
+    std::array<std::uint32_t, 8> state_{};
+    std::array<unsigned char, 64> buffer_{};
+    size_t bufferLen_ = 0;
+    std::uint64_t totalBits_ = 0;
+};
+
+/// Short prefix used in error messages — 12 hex chars is plenty to name a
+/// divergence and keeps the message readable.
+std::string shortHash(const std::string& full) {
+    return full.size() > 12 ? full.substr(0, 12) : full;
+}
+
+/// Canonical map key so "./a.txt", "a.txt" and "/abs/a.txt" share a record.
+std::string trackerKey(const std::string& path) {
+    std::error_code ec;
+    fs::path p = fs::weakly_canonical(fs::path(path), ec);
+    if (ec || p.empty()) {
+        p = fs::absolute(fs::path(path), ec);
+        if (ec) p = fs::path(path);
+    }
+    return p.generic_string();
+}
+
+/// Read a whole file as raw bytes. Returns false when it cannot be opened.
+bool readWholeFile(const std::string& path, std::string& out) {
+    std::ifstream file(path, std::ios::binary);
+    if (!file.is_open()) return false;
+    std::ostringstream buffer;
+    buffer << file.rdbuf();
+    out = buffer.str();
+    return true;
+}
+
+/// Locate a whitespace-insensitive near-match for `needle`, so a failed edit
+/// can say *why* it failed instead of just "not found".
+std::string collapseWhitespace(const std::string& s) {
+    std::string out;
+    out.reserve(s.size());
+    bool pendingSpace = false;
+    for (char c : s) {
+        if (c == ' ' || c == '\t' || c == '\r' || c == '\n') {
+            pendingSpace = !out.empty();
+            continue;
+        }
+        if (pendingSpace) {
+            out.push_back(' ');
+            pendingSpace = false;
+        }
+        out.push_back(c);
+    }
+    return out;
+}
+
+} // namespace
+
+// ---------------------------------------------------------------------------
+// FileStateTracker
+// ---------------------------------------------------------------------------
+
+struct FileStateTracker::Impl {
+    struct Record {
+        std::string hash;
+        std::uint64_t size = 0;
+    };
+    mutable std::mutex mutex;
+    std::map<std::string, Record> records;
+};
+
+FileStateTracker::Impl& FileStateTracker::impl() {
+    static Impl storage;
+    return storage;
+}
+
+FileStateTracker& FileStateTracker::instance() {
+    static FileStateTracker tracker;
+    return tracker;
+}
+
+std::string FileStateTracker::hashContent(const std::string& contents) {
+    Sha256 sha;
+    sha.update(contents.data(), contents.size());
+    return sha.hex();
+}
+
+std::string FileStateTracker::hashFile(const std::string& path) {
+    std::ifstream file(path, std::ios::binary);
+    if (!file.is_open()) return "";
+
+    Sha256 sha;
+    std::array<char, 64 * 1024> buffer{};
+    while (file.good()) {
+        file.read(buffer.data(), static_cast<std::streamsize>(buffer.size()));
+        const std::streamsize got = file.gcount();
+        if (got > 0) sha.update(buffer.data(), static_cast<size_t>(got));
+        if (got == 0) break;
+    }
+    // A read that failed part way through would otherwise be recorded as the
+    // hash of the whole file, and the anchor would name bytes that never were.
+    if (file.bad()) return "";
+    return sha.hex();
+}
+
+void FileStateTracker::recordRead(const std::string& path,
+                                  const std::string& contents) {
+    Impl& storage = impl();
+    std::lock_guard<std::mutex> lock(storage.mutex);
+    Impl::Record record;
+    record.hash = hashContent(contents);
+    record.size = static_cast<std::uint64_t>(contents.size());
+    storage.records[trackerKey(path)] = std::move(record);
+}
+
+void FileStateTracker::recordWrite(const std::string& path,
+                                   const std::string& contents) {
+    recordRead(path, contents);
+}
+
+void FileStateTracker::recordHash(const std::string& path,
+                                  const std::string& hash,
+                                  std::uint64_t size) {
+    if (hash.empty()) return;
+    Impl& storage = impl();
+    std::lock_guard<std::mutex> lock(storage.mutex);
+    Impl::Record record;
+    record.hash = hash;
+    record.size = size;
+    storage.records[trackerKey(path)] = std::move(record);
+}
+
+std::string FileStateTracker::recordFromDisk(const std::string& path) {
+    const std::string hash = hashFile(path);
+    if (hash.empty()) return "";
+
+    std::error_code ec;
+    const auto size = fs::file_size(fs::path(path), ec);
+
+    Impl& storage = impl();
+    std::lock_guard<std::mutex> lock(storage.mutex);
+    Impl::Record record;
+    record.hash = hash;
+    record.size = ec ? 0 : static_cast<std::uint64_t>(size);
+    storage.records[trackerKey(path)] = record;
+    return hash;
+}
+
+FileStateTracker::Divergence FileStateTracker::check(
+        const std::string& path, const std::string& currentContents) const {
+    Divergence result;
+
+    Impl& storage = impl();
+    std::lock_guard<std::mutex> lock(storage.mutex);
+    auto it = storage.records.find(trackerKey(path));
+    if (it == storage.records.end()) return result;
+
+    const std::string hashNow = hashContent(currentContents);
+    result.hashAtRead = shortHash(it->second.hash);
+    result.hashNow = shortHash(hashNow);
+    result.sizeAtRead = it->second.size;
+    result.sizeNow = static_cast<std::uint64_t>(currentContents.size());
+
+    if (hashNow == it->second.hash) return result;
+
+    result.diverged = true;
+    result.reason = "content hash at read " + result.hashAtRead +
+                    ", on disk now " + result.hashNow + " (" +
+                    std::to_string(result.sizeAtRead) + " -> " +
+                    std::to_string(result.sizeNow) + " bytes)";
+    return result;
+}
+
+FileStateTracker::Divergence FileStateTracker::checkFile(
+        const std::string& path) const {
+    Divergence result;
+
+    // Look the record up first: with nothing to compare against there is no
+    // reason to touch the file at all.
+    std::string recordedHash;
+    std::uint64_t recordedSize = 0;
+    {
+        Impl& storage = impl();
+        std::lock_guard<std::mutex> lock(storage.mutex);
+        auto it = storage.records.find(trackerKey(path));
+        if (it == storage.records.end()) return result;
+        recordedHash = it->second.hash;
+        recordedSize = it->second.size;
+    }
+
+    result.hashAtRead = shortHash(recordedHash);
+    result.sizeAtRead = recordedSize;
+
+    // Streamed, so checking a multi-gigabyte file costs bounded memory.
+    const std::string hashNow = hashFile(path);
+    if (hashNow.empty()) {
+        result.diverged = true;
+        result.reason = "the file was readable at hash " + result.hashAtRead +
+                        " but can no longer be read (deleted, renamed, or "
+                        "permissions changed)";
+        return result;
+    }
+
+    std::error_code ec;
+    const auto sizeNow = fs::file_size(fs::path(path), ec);
+    result.sizeNow = ec ? 0 : static_cast<std::uint64_t>(sizeNow);
+    result.hashNow = shortHash(hashNow);
+
+    if (hashNow == recordedHash) return result;
+
+    result.diverged = true;
+    result.reason = "content hash at read " + result.hashAtRead +
+                    ", on disk now " + result.hashNow + " (" +
+                    std::to_string(result.sizeAtRead) + " -> " +
+                    std::to_string(result.sizeNow) + " bytes)";
+    return result;
+}
+
+bool FileStateTracker::hasRecord(const std::string& path) const {
+    Impl& storage = impl();
+    std::lock_guard<std::mutex> lock(storage.mutex);
+    return storage.records.count(trackerKey(path)) > 0;
+}
+
+void FileStateTracker::forget(const std::string& path) {
+    Impl& storage = impl();
+    std::lock_guard<std::mutex> lock(storage.mutex);
+    storage.records.erase(trackerKey(path));
+}
+
+void FileStateTracker::clear() {
+    Impl& storage = impl();
+    std::lock_guard<std::mutex> lock(storage.mutex);
+    storage.records.clear();
+}
+
+size_t FileStateTracker::size() const {
+    Impl& storage = impl();
+    std::lock_guard<std::mutex> lock(storage.mutex);
+    return storage.records.size();
+}
+
+namespace {
+
+/// Build the rejection payload for a diverged file. Shared by write and edit
+/// so the model sees one recovery instruction, not two phrasings of it.
+json staleRejection(const std::string& path,
+                    const std::string& operation,
+                    const FileStateTracker::Divergence& divergence) {
+    return json{
+        {"error", operation + " rejected: " + path +
+                      " changed on disk after it was read — " +
+                      divergence.reason +
+                      ". Nothing was written. Re-read the file with file_read "
+                      "and reissue the change against the current contents."},
+        {"stale", true},
+        {"path", path},
+        {"hash_at_read", divergence.hashAtRead},
+        {"hash_now", divergence.hashNow},
+    };
+}
+
+} // namespace
 
 // ---------------------------------------------------------------------------
 // registerAll
@@ -34,7 +426,9 @@ ToolInfo FileIOTools::fileRead() {
     info.name = "file_read";
     info.description =
         "Read the contents of a file. Optionally specify a line range with "
-        "start_line and end_line (1-based, inclusive).";
+        "start_line and end_line (1-based, inclusive). The returned "
+        "content_hash anchors later edits: file_write and file_edit refuse to "
+        "touch the file if it changed after this read.";
     info.policy = ToolPolicy::ALLOW;
     info.parameters = {
         {"path", ToolParamType::STRING, /*required=*/true,
@@ -50,6 +444,7 @@ ToolInfo FileIOTools::fileRead() {
 
 json FileIOTools::doFileRead(const json& args) {
     static constexpr size_t kMaxReadBytes = 32 * 1024;
+    static constexpr size_t kChunkBytes = 64 * 1024;
 
     try {
         std::string path = args.value("path", "");
@@ -57,67 +452,88 @@ json FileIOTools::doFileRead(const json& args) {
             return json{{"error", "path is required"}};
         }
 
-        std::ifstream file(path);
+        // Binary, so what the model is shown is byte-for-byte what file_edit
+        // will search: a CRLF file must not read back as LF and then fail to
+        // match. One pass, so the hash anchors exactly the bytes returned —
+        // a second read could hash a version the model never saw.
+        std::ifstream file(path, std::ios::binary);
         if (!file.is_open()) {
             return json{{"error", "Cannot open file: " + path}};
         }
 
-        int startLine = args.value("start_line", 0);
-        int endLine = args.value("end_line", 0);
+        const int startLine = args.value("start_line", 0);
+        const int endLine = args.value("end_line", 0);
 
-        std::string line;
-        std::ostringstream content;
-        int lineNumber = 0;
-        int linesIncluded = 0;
-        size_t bytesRead = 0;
+        Sha256 sha;
+        std::string content;
+        std::vector<char> buffer(kChunkBytes);
+        int lineNumber = 1;        // line the next byte belongs to
+        int emittedLines = 0;      // in-range lines started so far
+        bool lineOpen = false;     // a line's first in-range byte was seen
         bool truncated = false;
+        bool lastByteWasNewline = false;
+        std::uint64_t totalBytes = 0;
 
-        while (std::getline(file, line)) {
-            ++lineNumber;
+        while (file.good()) {
+            file.read(buffer.data(), static_cast<std::streamsize>(kChunkBytes));
+            const std::streamsize got = file.gcount();
+            if (got <= 0) break;
 
-            bool inRange = true;
-            if (startLine > 0 && lineNumber < startLine) inRange = false;
-            if (endLine > 0 && lineNumber > endLine) inRange = false;
+            sha.update(buffer.data(), static_cast<size_t>(got));
+            totalBytes += static_cast<std::uint64_t>(got);
 
-            if (inRange) {
-                size_t lineBytes = line.size() + (linesIncluded > 0 ? 1 : 0);
-                if (bytesRead + lineBytes > kMaxReadBytes) {
-                    truncated = true;
-                    break;
+            for (std::streamsize i = 0; i < got; ++i) {
+                const char c = buffer[static_cast<size_t>(i)];
+                lastByteWasNewline = (c == '\n');
+
+                const bool inRange =
+                    (startLine <= 0 || lineNumber >= startLine) &&
+                    (endLine <= 0 || lineNumber <= endLine);
+
+                if (inRange && !truncated) {
+                    if (!lineOpen) {
+                        // Included lines are joined by '\n', no trailing one.
+                        if (emittedLines > 0) content.push_back('\n');
+                        ++emittedLines;
+                        lineOpen = true;
+                    }
+                    if (c != '\n') {
+                        if (content.size() < kMaxReadBytes) {
+                            content.push_back(c);
+                        } else {
+                            truncated = true;
+                        }
+                    }
                 }
-                if (linesIncluded > 0) content << '\n';
-                content << line;
-                bytesRead += lineBytes;
-                ++linesIncluded;
-            }
 
-            // Optimization: stop reading past end_line
-            if (endLine > 0 && lineNumber >= endLine) {
-                // Count remaining lines for total
-                while (std::getline(file, line)) {
+                if (c == '\n') {
+                    lineOpen = false;
                     ++lineNumber;
                 }
-                break;
             }
         }
 
-        // Count remaining lines if we truncated early
-        if (truncated) {
-            while (std::getline(file, line)) {
-                ++lineNumber;
-            }
+        if (file.bad()) {
+            return json{{"error", "Read failed part way through: " + path}};
         }
 
-        std::string result = content.str();
+        // Trailing '\n' handling: "a\nb\n" is 2 lines, "a\nb" is also 2.
+        int totalLines = lineNumber - 1;
+        if (totalBytes > 0 && !lastByteWasNewline) ++totalLines;
+
         if (truncated) {
-            result += "\n... [output truncated at 32 KB]";
+            content += "\n... [output truncated at 32 KB]";
         }
+
+        const std::string hash = sha.hex();
+        FileStateTracker::instance().recordHash(path, hash, totalBytes);
 
         return json{
-            {"content", result},
-            {"lines", lineNumber},
+            {"content", content},
+            {"lines", totalLines},
             {"path", path},
             {"truncated", truncated},
+            {"content_hash", shortHash(hash)},
         };
     } catch (const std::exception& e) {
         return json{{"error", std::string("file_read failed: ") + e.what()}};
@@ -133,7 +549,8 @@ ToolInfo FileIOTools::fileWrite() {
     info.name = "file_write";
     info.description =
         "Write content to a file. Creates parent directories if they do not "
-        "exist. Overwrites the file if it already exists.";
+        "exist. Overwrites the file if it already exists. Rejected if the file "
+        "changed on disk after the last file_read — re-read it first.";
     info.policy = ToolPolicy::CONFIRM;
     info.parameters = {
         {"path", ToolParamType::STRING, /*required=*/true,
@@ -157,6 +574,23 @@ json FileIOTools::doFileWrite(const json& args) {
         }
         const std::string& content = args["content"].get_ref<const std::string&>();
 
+        FileStateTracker& tracker = FileStateTracker::instance();
+        bool recreated = false;
+        std::error_code existsEc;
+        if (fs::exists(fs::path(path), existsEc) && !existsEc) {
+            const auto divergence = tracker.checkFile(path);
+            if (divergence.diverged) {
+                return staleRejection(path, "file_write", divergence);
+            }
+        } else if (tracker.hasRecord(path)) {
+            // Read, then deleted, now written again. There is no content to
+            // clobber so this is allowed — but someone removed that file on
+            // purpose, so say the write brought it back rather than let it
+            // look like an ordinary create.
+            recreated = true;
+            tracker.forget(path);
+        }
+
         // Create parent directories if needed
         fs::path filePath(path);
         if (filePath.has_parent_path()) {
@@ -178,11 +612,16 @@ json FileIOTools::doFileWrite(const json& args) {
         }
         file.close();
 
-        return json{
+        tracker.recordWrite(path, content);
+
+        json result{
             {"success", true},
             {"path", path},
             {"bytes_written", static_cast<int>(content.size())},
+            {"content_hash", shortHash(FileStateTracker::hashContent(content))},
         };
+        if (recreated) result["recreated"] = true;
+        return result;
     } catch (const std::exception& e) {
         return json{{"error", std::string("file_write failed: ") + e.what()}};
     }
@@ -197,7 +636,9 @@ ToolInfo FileIOTools::fileEdit() {
     info.name = "file_edit";
     info.description =
         "Perform surgical string replacement in a file. Finds all occurrences "
-        "of old_string and replaces them with new_string.";
+        "of old_string and replaces them with new_string. Rejected if the file "
+        "changed on disk after the last file_read, or if old_string does not "
+        "appear verbatim — in both cases the file is left untouched.";
     info.policy = ToolPolicy::CONFIRM;
     info.parameters = {
         {"path", ToolParamType::STRING, /*required=*/true,
@@ -225,16 +666,16 @@ json FileIOTools::doFileEdit(const json& args) {
 
         std::string newStr = args.value("new_string", "");
 
-        // Read entire file
-        std::ifstream inFile(path);
-        if (!inFile.is_open()) {
+        std::string content;
+        if (!readWholeFile(path, content)) {
             return json{{"error", "Cannot open file: " + path}};
         }
 
-        std::ostringstream buffer;
-        buffer << inFile.rdbuf();
-        std::string content = buffer.str();
-        inFile.close();
+        FileStateTracker& tracker = FileStateTracker::instance();
+        const auto divergence = tracker.check(path, content);
+        if (divergence.diverged) {
+            return staleRejection(path, "file_edit", divergence);
+        }
 
         // Replace all occurrences
         int replacements = 0;
@@ -246,7 +687,24 @@ json FileIOTools::doFileEdit(const json& args) {
         }
 
         if (replacements == 0) {
-            return json{{"error", "old_string not found in file: " + path}};
+            // A silent no-op is the failure mode this tool exists to avoid:
+            // say what did not match and what to do about it.
+            std::string hint;
+            if (collapseWhitespace(content).find(collapseWhitespace(oldStr)) !=
+                std::string::npos) {
+                hint = " A whitespace-insensitive match does exist, so the "
+                       "indentation, tabs-vs-spaces, or line endings in "
+                       "old_string differ from the file.";
+            }
+            return json{
+                {"error", "old_string not found in file: " + path +
+                              " — no replacement was made and the file is "
+                              "unchanged." + hint +
+                              " Re-read the file with file_read and copy "
+                              "old_string verbatim from its contents."},
+                {"path", path},
+                {"replacements", 0},
+            };
         }
 
         // Write back
@@ -261,10 +719,13 @@ json FileIOTools::doFileEdit(const json& args) {
         }
         outFile.close();
 
+        tracker.recordWrite(path, content);
+
         return json{
             {"success", true},
             {"path", path},
             {"replacements", replacements},
+            {"content_hash", shortHash(FileStateTracker::hashContent(content))},
         };
     } catch (const std::exception& e) {
         return json{{"error", std::string("file_edit failed: ") + e.what()}};
@@ -279,13 +740,17 @@ ToolInfo FileIOTools::fileSearch() {
     ToolInfo info;
     info.name = "file_search";
     info.description =
-        "Search for files by name pattern and/or content. The pattern is matched "
-        "against file names using simple glob wildcards (* and ?). Optionally "
-        "filter by content_pattern (substring match within file contents).";
+        "Search for files by name pattern and/or content. The pattern supports "
+        "glob wildcards (*, ?, [abc], and ** for directories); a pattern "
+        "containing '/' is matched against the path relative to the search "
+        "root, otherwise against the file name. Files excluded by .gitignore "
+        "and the .git directory are skipped. Optionally filter by "
+        "content_pattern (substring match within file contents).";
     info.policy = ToolPolicy::ALLOW;
     info.parameters = {
         {"pattern", ToolParamType::STRING, /*required=*/true,
-         "Glob pattern to match file names (e.g. '*.cpp', 'test_*')"},
+         "Glob pattern to match file names or relative paths "
+         "(e.g. '*.cpp', 'test_*', 'src/**/*.h')"},
         {"path", ToolParamType::STRING, /*required=*/false,
          "Root directory to search in (default: current directory)"},
         {"content_pattern", ToolParamType::STRING, /*required=*/false,
@@ -299,9 +764,21 @@ ToolInfo FileIOTools::fileSearch() {
 
 json FileIOTools::doFileSearch(const json& args) {
     try {
+        static constexpr size_t kMaxPatternBytes = 512;
+
         std::string pattern = args.value("pattern", "");
         if (pattern.empty()) {
             return json{{"error", "pattern is required"}};
+        }
+        if (pattern.size() > kMaxPatternBytes) {
+            // The matcher's memo table is pattern-length times path-length, so
+            // an unbounded pattern is an unbounded allocation per file.
+            return json{{"error",
+                         "pattern is " + std::to_string(pattern.size()) +
+                             " bytes; the limit is " +
+                             std::to_string(kMaxPatternBytes) +
+                             ". Use a shorter glob and filter the results, or "
+                             "pass content_pattern for a substring search."}};
         }
 
         std::string searchPath = args.value("path", ".");
@@ -317,8 +794,23 @@ json FileIOTools::doFileSearch(const json& args) {
             return json{{"error", "Search path is not a directory: " + searchPath}};
         }
 
+        // Rules governing the root are resolved up front; each subdirectory's
+        // own .gitignore is folded in as the walk reaches it. Rules are scoped
+        // to their own directory, so a nested file cannot affect a sibling.
+        GitignoreMatcher ignore = GitignoreMatcher::forDirectory(searchPath);
+
+        std::error_code rootEc;
+        fs::path root = fs::weakly_canonical(fs::path(searchPath), rootEc);
+        if (rootEc) root = fs::path(searchPath);
+
+        // A pattern with a separator addresses a path; otherwise a file name.
+        const bool pathPattern = pattern.find('/') != std::string::npos;
+        const GlobOptions globOpts{/*pathMode=*/pathPattern,
+                                   /*caseInsensitive=*/false};
+
         json matches = json::array();
         int total = 0;
+        int ignoredSkipped = 0;
 
         std::error_code ec;
         for (auto it = fs::recursive_directory_iterator(searchPath, fs::directory_options::skip_permission_denied, ec);
@@ -328,18 +820,50 @@ json FileIOTools::doFileSearch(const json& args) {
                 continue;
             }
 
+            const fs::path& entryPath = it->path();
+            const std::string filename = entryPath.filename().string();
+
+            if (it->is_directory(ec) && !ec) {
+                // .git is never interesting and is huge; it is pruned always
+                // and is not counted as an ignore-rule skip, or the counter
+                // would be non-zero on every repository and say nothing.
+                if (filename == ".git") {
+                    it.disable_recursion_pending();
+                    continue;
+                }
+                if (ignore.isIgnored(entryPath.string(), /*isDirectory=*/true)) {
+                    it.disable_recursion_pending();
+                    ++ignoredSkipped;
+                    continue;
+                }
+                ignore.addFile((entryPath / ".gitignore").string());
+                continue;
+            }
+            ec.clear();
+
             if (!it->is_regular_file(ec)) continue;
             if (ec) { ec.clear(); continue; }
 
-            std::string filename = it->path().filename().string();
-
-            if (!matchGlob(pattern, filename)) {
+            if (ignore.isIgnored(entryPath.string(), /*isDirectory=*/false)) {
+                ++ignoredSkipped;
                 continue;
             }
 
+            bool nameMatches;
+            if (pathPattern) {
+                std::error_code relEc;
+                fs::path rel = fs::relative(entryPath, root, relEc);
+                const std::string relStr =
+                    relEc ? entryPath.generic_string() : rel.generic_string();
+                nameMatches = globMatch(pattern, relStr, globOpts);
+            } else {
+                nameMatches = globMatch(pattern, filename, globOpts);
+            }
+            if (!nameMatches) continue;
+
             // If content_pattern is specified, search within file
             if (!contentPattern.empty()) {
-                std::ifstream file(it->path());
+                std::ifstream file(entryPath);
                 if (!file.is_open()) continue;
 
                 std::string line;
@@ -350,7 +874,7 @@ json FileIOTools::doFileSearch(const json& args) {
                         ++total;
                         if (static_cast<int>(matches.size()) < maxResults) {
                             json match;
-                            match["path"] = it->path().generic_string();
+                            match["path"] = entryPath.generic_string();
                             match["line"] = lineNum;
                             // Trim context to reasonable length
                             std::string context = line;
@@ -367,7 +891,7 @@ json FileIOTools::doFileSearch(const json& args) {
                 ++total;
                 if (static_cast<int>(matches.size()) < maxResults) {
                     json match;
-                    match["path"] = it->path().generic_string();
+                    match["path"] = entryPath.generic_string();
                     matches.push_back(std::move(match));
                 }
             }
@@ -376,42 +900,11 @@ json FileIOTools::doFileSearch(const json& args) {
         return json{
             {"matches", matches},
             {"total", total},
+            {"ignored_skipped", ignoredSkipped},
         };
     } catch (const std::exception& e) {
         return json{{"error", std::string("file_search failed: ") + e.what()}};
     }
-}
-
-// ---------------------------------------------------------------------------
-// matchGlob — simple glob matching (* = any chars, ? = one char)
-// ---------------------------------------------------------------------------
-
-bool FileIOTools::matchGlob(const std::string& pattern, const std::string& text) {
-    size_t pi = 0, ti = 0;
-    size_t starPi = std::string::npos, starTi = 0;
-
-    while (ti < text.size()) {
-        if (pi < pattern.size() && (pattern[pi] == '?' || pattern[pi] == text[ti])) {
-            ++pi;
-            ++ti;
-        } else if (pi < pattern.size() && pattern[pi] == '*') {
-            starPi = pi;
-            starTi = ti;
-            ++pi;
-        } else if (starPi != std::string::npos) {
-            pi = starPi + 1;
-            ++starTi;
-            ti = starTi;
-        } else {
-            return false;
-        }
-    }
-
-    while (pi < pattern.size() && pattern[pi] == '*') {
-        ++pi;
-    }
-
-    return pi == pattern.size();
 }
 
 } // namespace gaia

--- a/cpp/src/ignore.cpp
+++ b/cpp/src/ignore.cpp
@@ -1,0 +1,378 @@
+// Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+#include "gaia/ignore.h"
+
+#include <cctype>
+#include <cstdint>
+#include <filesystem>
+#include <fstream>
+#include <sstream>
+
+namespace fs = std::filesystem;
+
+namespace gaia {
+
+namespace {
+
+char foldCase(char c, bool caseInsensitive) {
+    if (!caseInsensitive) return c;
+    return static_cast<char>(
+        std::tolower(static_cast<unsigned char>(c)));
+}
+
+/// Memoized backtracking glob matcher.
+///
+/// The memo table is what keeps `*a*a*a*a*b` linear-ish instead of
+/// exponential — a search tool must never be able to hang the agent loop on a
+/// pattern the model made up.
+class GlobEngine {
+public:
+    GlobEngine(const std::string& pattern,
+               const std::string& text,
+               const GlobOptions& options)
+        : p_(pattern), t_(text), o_(options),
+          memo_((pattern.size() + 1) * (text.size() + 1), 0) {}
+
+    bool run() { return match(0, 0); }
+
+private:
+    const std::string& p_;
+    const std::string& t_;
+    const GlobOptions& o_;
+    std::vector<uint8_t> memo_;  // 0 = unknown, 1 = true, 2 = false
+
+    bool isSep(size_t ti) const {
+        return o_.pathMode && ti < t_.size() && t_[ti] == '/';
+    }
+
+    /// Parse a `[...]` class starting at p_[pi] == '['.
+    /// Returns false when the class is unterminated (caller treats `[` as a
+    /// literal). Otherwise sets `matched` and advances `nextPi` past `]`.
+    bool matchClass(size_t pi, char c, bool& matched, size_t& nextPi) const {
+        size_t i = pi + 1;
+        bool negate = false;
+        if (i < p_.size() && (p_[i] == '!' || p_[i] == '^')) {
+            negate = true;
+            ++i;
+        }
+
+        bool found = false;
+        bool first = true;
+        const char target = foldCase(c, o_.caseInsensitive);
+
+        while (i < p_.size()) {
+            if (p_[i] == ']' && !first) {
+                matched = negate ? !found : found;
+                nextPi = i + 1;
+                return true;
+            }
+            first = false;
+
+            char lo = p_[i];
+            if (lo == '\\' && i + 1 < p_.size()) {
+                ++i;
+                lo = p_[i];
+            }
+
+            // Range: a-z (a trailing '-' before ']' is a literal)
+            if (i + 2 < p_.size() && p_[i + 1] == '-' && p_[i + 2] != ']') {
+                char hi = p_[i + 2];
+                size_t consumed = 2;
+                if (hi == '\\' && i + 3 < p_.size()) {
+                    hi = p_[i + 3];
+                    consumed = 3;
+                }
+                char l = foldCase(lo, o_.caseInsensitive);
+                char h = foldCase(hi, o_.caseInsensitive);
+                if (target >= l && target <= h) found = true;
+                i += consumed + 1;
+                continue;
+            }
+
+            if (foldCase(lo, o_.caseInsensitive) == target) found = true;
+            ++i;
+        }
+
+        return false;  // unterminated
+    }
+
+    bool match(size_t pi, size_t ti) {
+        const size_t key = pi * (t_.size() + 1) + ti;
+        if (memo_[key] != 0) return memo_[key] == 1;
+
+        bool result = compute(pi, ti);
+        memo_[key] = result ? 1 : 2;
+        return result;
+    }
+
+    bool compute(size_t pi, size_t ti) {
+        if (pi == p_.size()) return ti == t_.size();
+
+        const char pc = p_[pi];
+
+        if (pc == '*') {
+            const bool doubleStar =
+                o_.pathMode && pi + 1 < p_.size() && p_[pi + 1] == '*';
+
+            if (doubleStar) {
+                size_t after = pi + 2;
+                if (after < p_.size() && p_[after] == '/') {
+                    // `**/` matches zero or more leading directories.
+                    if (match(after + 1, ti)) return true;
+                    for (size_t k = ti; k < t_.size(); ++k) {
+                        if (t_[k] == '/' && match(after + 1, k + 1)) return true;
+                    }
+                    return false;
+                }
+                for (size_t k = ti; k <= t_.size(); ++k) {
+                    if (match(after, k)) return true;
+                }
+                return false;
+            }
+
+            for (size_t k = ti; k <= t_.size(); ++k) {
+                if (match(pi + 1, k)) return true;
+                if (isSep(k)) break;  // a single `*` never crosses a separator
+            }
+            return false;
+        }
+
+        if (pc == '?') {
+            if (ti >= t_.size() || isSep(ti)) return false;
+            return match(pi + 1, ti + 1);
+        }
+
+        if (pc == '[') {
+            bool matched = false;
+            size_t nextPi = pi;
+            if (matchClass(pi, ti < t_.size() ? t_[ti] : '\0', matched, nextPi)) {
+                if (ti >= t_.size() || isSep(ti) || !matched) return false;
+                return match(nextPi, ti + 1);
+            }
+            // Unterminated class — fall through and treat '[' literally.
+        }
+
+        char literal = pc;
+        size_t nextPi = pi + 1;
+        if (pc == '\\' && pi + 1 < p_.size()) {
+            literal = p_[pi + 1];
+            nextPi = pi + 2;
+        }
+
+        if (ti >= t_.size()) return false;
+        if (foldCase(literal, o_.caseInsensitive) !=
+            foldCase(t_[ti], o_.caseInsensitive)) {
+            return false;
+        }
+        return match(nextPi, ti + 1);
+    }
+};
+
+/// Canonicalize to a generic-separator absolute path without requiring the
+/// path to exist (weakly_canonical tolerates missing tails).
+std::string normalizePath(const std::string& path) {
+    std::error_code ec;
+    fs::path p = fs::weakly_canonical(fs::path(path), ec);
+    if (ec || p.empty()) {
+        p = fs::absolute(fs::path(path), ec);
+        if (ec) p = fs::path(path);
+    }
+    std::string s = p.generic_string();
+    while (s.size() > 1 && s.back() == '/') s.pop_back();
+    return s;
+}
+
+bool pathsEqual(const std::string& a, const std::string& b) {
+#ifdef _WIN32
+    if (a.size() != b.size()) return false;
+    for (size_t i = 0; i < a.size(); ++i) {
+        if (foldCase(a[i], true) != foldCase(b[i], true)) return false;
+    }
+    return true;
+#else
+    return a == b;
+#endif
+}
+
+/// True when `path` lies strictly under directory `base`; writes the relative
+/// remainder to `rel`.
+bool relativeTo(const std::string& path, const std::string& base, std::string& rel) {
+    if (path.size() <= base.size() + 1) return false;
+    if (!pathsEqual(path.substr(0, base.size()), base)) return false;
+    if (path[base.size()] != '/') return false;
+    rel = path.substr(base.size() + 1);
+    return !rel.empty();
+}
+
+/// Strip trailing whitespace that is not backslash-escaped (gitignore(5)).
+void stripTrailingSpace(std::string& line) {
+    while (!line.empty() &&
+           (line.back() == ' ' || line.back() == '\t')) {
+        size_t backslashes = 0;
+        size_t i = line.size() - 1;
+        while (i > 0 && line[i - 1] == '\\') {
+            ++backslashes;
+            --i;
+        }
+        if (backslashes % 2 == 1) break;  // escaped — keep it
+        line.pop_back();
+    }
+}
+
+} // namespace
+
+// ---------------------------------------------------------------------------
+// globMatch
+// ---------------------------------------------------------------------------
+
+bool globMatch(const std::string& pattern,
+               const std::string& text,
+               const GlobOptions& options) {
+    GlobEngine engine(pattern, text, options);
+    return engine.run();
+}
+
+// ---------------------------------------------------------------------------
+// GitignoreMatcher
+// ---------------------------------------------------------------------------
+
+GitignoreMatcher GitignoreMatcher::forDirectory(const std::string& directory) {
+    GitignoreMatcher matcher;
+
+    std::error_code ec;
+    fs::path start = fs::weakly_canonical(fs::path(directory), ec);
+    if (ec || start.empty()) start = fs::path(directory);
+
+    // Walk up to the enclosing repository root so that searching `repo/src`
+    // still honours `repo/.gitignore`.
+    std::vector<fs::path> chain;
+    fs::path cur = start;
+    bool foundRepoRoot = false;
+    for (int depth = 0; depth < 64; ++depth) {
+        chain.push_back(cur);
+        if (fs::exists(cur / ".git", ec)) {
+            foundRepoRoot = true;
+            break;
+        }
+        fs::path parent = cur.parent_path();
+        if (parent.empty() || parent == cur) break;
+        cur = parent;
+    }
+
+    if (!foundRepoRoot) {
+        // Outside a repository, only the directory's own file applies. Walking
+        // to the filesystem root would silently apply a stranger's rules.
+        matcher.addFile((start / ".gitignore").string());
+        return matcher;
+    }
+
+    // Outermost first, so a nested .gitignore overrides its parent.
+    for (auto it = chain.rbegin(); it != chain.rend(); ++it) {
+        matcher.addFile((*it / ".gitignore").string());
+    }
+    return matcher;
+}
+
+void GitignoreMatcher::addFile(const std::string& gitignorePath) {
+    std::ifstream file(gitignorePath);
+    if (!file.is_open()) return;
+
+    std::ostringstream buffer;
+    buffer << file.rdbuf();
+
+    fs::path baseDir = fs::path(gitignorePath).parent_path();
+    if (baseDir.empty()) baseDir = fs::path(".");
+    addRules(buffer.str(), baseDir.string());
+}
+
+void GitignoreMatcher::addRules(const std::string& contents,
+                                const std::string& baseDir) {
+    const std::string base = normalizePath(baseDir);
+
+    std::istringstream stream(contents);
+    std::string line;
+    while (std::getline(stream, line)) {
+        if (!line.empty() && line.back() == '\r') line.pop_back();
+        stripTrailingSpace(line);
+        if (line.empty()) continue;
+        if (line[0] == '#') continue;
+
+        Rule rule;
+        rule.baseDir = base;
+
+        if (line[0] == '!') {
+            rule.negate = true;
+            line.erase(0, 1);
+        } else if (line.size() >= 2 && line[0] == '\\' &&
+                   (line[1] == '!' || line[1] == '#')) {
+            line.erase(0, 1);
+        }
+        if (line.empty()) continue;
+
+        if (line.back() == '/') {
+            rule.dirOnly = true;
+            line.pop_back();
+        }
+        if (line.empty()) continue;
+
+        if (line[0] == '/') {
+            rule.anchored = true;
+            line.erase(0, 1);
+        } else if (line.find('/') != std::string::npos) {
+            rule.anchored = true;
+        }
+        if (line.empty()) continue;
+
+        rule.pattern = line;
+        rules_.push_back(std::move(rule));
+    }
+}
+
+bool GitignoreMatcher::isIgnored(const std::string& path, bool isDirectory) const {
+    if (rules_.empty()) return false;
+
+    const std::string abs = normalizePath(path);
+    const GlobOptions pathOpts{/*pathMode=*/true, /*caseInsensitive=*/false};
+    const GlobOptions nameOpts{/*pathMode=*/false, /*caseInsensitive=*/false};
+
+    bool ignored = false;
+
+    for (const Rule& rule : rules_) {
+        std::string rel;
+        if (!relativeTo(abs, rule.baseDir, rel)) continue;
+
+        // Evaluate the rule against every ancestor as well as the path itself:
+        // a file inside an ignored directory is ignored.
+        bool matched = false;
+        size_t start = 0;
+        while (start <= rel.size() && !matched) {
+            size_t slash = rel.find('/', start);
+            const bool isLast = (slash == std::string::npos);
+            const std::string candidate =
+                isLast ? rel : rel.substr(0, slash);
+            const bool candidateIsDir = isLast ? isDirectory : true;
+
+            if (!rule.dirOnly || candidateIsDir) {
+                if (rule.anchored) {
+                    matched = globMatch(rule.pattern, candidate, pathOpts);
+                } else {
+                    const size_t lastSlash = candidate.find_last_of('/');
+                    const std::string name = lastSlash == std::string::npos
+                                                 ? candidate
+                                                 : candidate.substr(lastSlash + 1);
+                    matched = globMatch(rule.pattern, name, nameOpts);
+                }
+            }
+
+            if (isLast) break;
+            start = slash + 1;
+        }
+
+        if (matched) ignored = !rule.negate;  // last matching rule wins
+    }
+
+    return ignored;
+}
+
+} // namespace gaia

--- a/cpp/src/process.cpp
+++ b/cpp/src/process.cpp
@@ -5,10 +5,17 @@
 
 #include <algorithm>
 #include <array>
+#include <atomic>
+#include <cctype>
 #include <chrono>
 #include <cstdio>
 #include <cstring>
+#include <filesystem>
+#include <fstream>
 #include <memory>
+#include <mutex>
+#include <set>
+#include <sstream>
 #include <stdexcept>
 #include <string>
 #include <thread>
@@ -32,6 +39,11 @@
 #   include <sys/types.h>
 #   include <sys/wait.h>
 #   include <unistd.h>
+#   ifdef __APPLE__
+#       include <crt_externs.h>
+#   else
+extern char** environ;
+#   endif
 #endif
 
 namespace gaia {
@@ -399,7 +411,12 @@ ProcessResult runWithTimeout(const std::string& command,
     }
 
     if (pid == 0) {
-        // Child process
+        // Child process.
+        // Its own process group, so a timeout can kill the whole tree. A
+        // build or test command spawns children; killing only the shell
+        // leaves them running and holding the output pipes open.
+        setpgid(0, 0);
+
         close(stdoutPipe[0]);  // close read end
         close(stderrPipe[0]);  // close read end
 
@@ -414,6 +431,7 @@ ProcessResult runWithTimeout(const std::string& command,
     }
 
     // Parent process
+    setpgid(pid, pid);  // race-free: whichever call wins, the group exists
     close(stdoutPipe[1]);  // close write end
     close(stderrPipe[1]);  // close write end
 
@@ -436,7 +454,8 @@ ProcessResult runWithTimeout(const std::string& command,
 
         if (elapsed >= timeoutMs) {
             result.timedOut = true;
-            kill(pid, SIGKILL);
+            kill(-pid, SIGKILL);  // the whole group, not just the shell
+            kill(pid, SIGKILL);   // backstop if setpgid did not take
             waitpid(pid, nullptr, 0);
             break;
         }
@@ -590,6 +609,494 @@ std::string ProcessRunner::runOrThrow(
     }
 
     return result.stdout_output;
+}
+
+// ---------------------------------------------------------------------------
+// ShellSession
+// ---------------------------------------------------------------------------
+
+namespace {
+
+namespace sfs = std::filesystem;
+
+/// Variables that every shell rewrites on its own. Replaying them would make
+/// the session drift a little further from the parent on every command.
+const std::set<std::string>& volatileEnvNames() {
+    static const std::set<std::string> names = {
+        "_", "PWD", "OLDPWD", "SHLVL", "PS1", "PS2", "RANDOM", "SECONDS",
+        "LINENO", "PROMPT", "CD", "ERRORLEVEL", "CMDCMDLINE", "CMDEXTVERSION",
+        "__GAIA_RC", "GAIA_SHELL_STATE",
+    };
+    return names;
+}
+
+bool isValidEnvName(const std::string& name) {
+    if (name.empty()) return false;
+    if (std::isdigit(static_cast<unsigned char>(name[0]))) return false;
+    for (char c : name) {
+        if (!(std::isalnum(static_cast<unsigned char>(c)) || c == '_')) {
+            return false;
+        }
+    }
+    return true;
+}
+
+/// Snapshot the calling process's environment — the baseline a session's
+/// overrides are measured against.
+std::map<std::string, std::string> captureProcessEnv() {
+    std::map<std::string, std::string> out;
+#ifdef _WIN32
+    LPCH block = GetEnvironmentStringsA();
+    if (!block) return out;
+    for (LPCH entry = block; *entry != '\0';) {
+        const std::string item(entry);
+        entry += item.size() + 1;
+        const size_t eq = item.find('=');
+        if (eq == std::string::npos || eq == 0) continue;  // "=C:" style entries
+        out[item.substr(0, eq)] = item.substr(eq + 1);
+    }
+    FreeEnvironmentStringsA(block);
+#else
+#   ifdef __APPLE__
+    char** env = *_NSGetEnviron();
+#   else
+    char** env = environ;
+#   endif
+    for (; env && *env; ++env) {
+        const std::string item(*env);
+        const size_t eq = item.find('=');
+        if (eq == std::string::npos || eq == 0) continue;
+        out[item.substr(0, eq)] = item.substr(eq + 1);
+    }
+#endif
+    return out;
+}
+
+/// Split one `NAME=VALUE` record. Returns false when the record has no name.
+/// Names are not validated here: `ProgramFiles(x86)` is a real Windows
+/// variable, and mis-parsing it would corrupt the neighbour it sorts next to.
+bool splitEnvRecord(const std::string& record,
+                    std::map<std::string, std::string>& out) {
+    const size_t eq = record.find('=');
+    if (eq == std::string::npos || eq == 0) return false;
+    out[record.substr(0, eq)] = record.substr(eq + 1);
+    return true;
+}
+
+/// Parse the NUL-delimited environment dump the POSIX script emits.
+///
+/// NUL is the one byte an environment value cannot contain, so the record
+/// boundary is unambiguous. Line-delimited `env` output is not: a value
+/// containing a newline followed by `SOMETHING=x` is indistinguishable from a
+/// second variable, which would let a command's *data* become the session's
+/// *configuration*.
+std::map<std::string, std::string> parseEnvRecordsNul(const std::string& text) {
+    std::map<std::string, std::string> out;
+    size_t start = 0;
+    while (start < text.size()) {
+        const size_t end = text.find('\0', start);
+        const size_t stop = (end == std::string::npos) ? text.size() : end;
+        splitEnvRecord(text.substr(start, stop - start), out);
+        if (end == std::string::npos) break;
+        start = end + 1;
+    }
+    return out;
+}
+
+/// Parse cmd.exe `set` output. Windows environment values cannot contain a
+/// newline, so one line is exactly one variable and an unparseable line is
+/// dropped rather than glued onto its predecessor.
+std::map<std::string, std::string> parseEnvLines(const std::string& text) {
+    std::map<std::string, std::string> out;
+    std::istringstream stream(text);
+    std::string line;
+
+    while (std::getline(stream, line)) {
+        if (!line.empty() && line.back() == '\r') line.pop_back();
+        if (line.empty()) continue;
+        // cmd.exe lists internal "=C:" / "=ExitCode" entries; not variables.
+        if (line[0] == '=') continue;
+        splitEnvRecord(line, out);
+    }
+    return out;
+}
+
+/// Create a uniquely-named temp file and write `contents` to it.
+/// Exclusive creation on both platforms so a pre-planted symlink or file in a
+/// shared temp directory cannot be written through.
+bool writeTempFile(const std::string& extension,
+                   const std::string& contents,
+                   std::string& outPath) {
+#ifdef _WIN32
+    static std::atomic<unsigned> counter{0};
+
+    char tmpDir[MAX_PATH];
+    if (GetTempPathA(MAX_PATH, tmpDir) == 0) return false;
+
+    for (int attempt = 0; attempt < 64; ++attempt) {
+        std::ostringstream name;
+        name << tmpDir << "gaia_shell_" << GetCurrentProcessId() << "_"
+             << counter.fetch_add(1) << extension;
+        const std::string candidate = name.str();
+
+        HANDLE handle = CreateFileA(candidate.c_str(), GENERIC_WRITE, 0,
+                                    nullptr, CREATE_NEW,
+                                    FILE_ATTRIBUTE_NORMAL, nullptr);
+        if (handle == INVALID_HANDLE_VALUE) continue;
+
+        DWORD written = 0;
+        BOOL ok = TRUE;
+        if (!contents.empty()) {
+            ok = WriteFile(handle, contents.data(),
+                           static_cast<DWORD>(contents.size()), &written,
+                           nullptr);
+        }
+        CloseHandle(handle);
+        if (!ok) {
+            std::remove(candidate.c_str());
+            return false;
+        }
+        outPath = candidate;
+        return true;
+    }
+    return false;
+#else
+    (void)extension;
+    std::error_code ec;
+    sfs::path dir = sfs::temp_directory_path(ec);
+    if (ec) dir = sfs::path("/tmp");
+
+    std::string tmpl = (dir / "gaia_shell_XXXXXX").string();
+    std::vector<char> buf(tmpl.begin(), tmpl.end());
+    buf.push_back('\0');
+
+    const int fd = mkstemp(buf.data());
+    if (fd < 0) return false;
+
+    size_t offset = 0;
+    while (offset < contents.size()) {
+        const ssize_t n = write(fd, contents.data() + offset,
+                                contents.size() - offset);
+        if (n <= 0) {
+            close(fd);
+            std::remove(buf.data());
+            return false;
+        }
+        offset += static_cast<size_t>(n);
+    }
+    close(fd);
+    outPath = std::string(buf.data());
+    return true;
+#endif
+}
+
+/// Removes the temp files a command needed, however the call unwinds.
+class TempFileSet {
+public:
+    void add(const std::string& path) { paths_.push_back(path); }
+    ~TempFileSet() {
+        for (const auto& path : paths_) std::remove(path.c_str());
+    }
+
+private:
+    std::vector<std::string> paths_;
+};
+
+std::string readFileContents(const std::string& path) {
+    std::ifstream file(path, std::ios::binary);
+    if (!file.is_open()) return "";
+    std::ostringstream buffer;
+    buffer << file.rdbuf();
+    return buffer.str();
+}
+
+/// Wrap a value in single quotes for POSIX sh.
+std::string posixQuote(const std::string& value) {
+    std::string out = "'";
+    for (char c : value) {
+        if (c == '\'') {
+            out += "'\\''";
+        } else {
+            out += c;
+        }
+    }
+    out += "'";
+    return out;
+}
+
+/// Escape a value for use inside a batch file.
+///
+/// Only `%` needs escaping. `"` must be left alone: `set "K=V"` takes
+/// everything up to the *last* quote on the line, so doubling a quote is not
+/// undone — and because the session re-captures and re-emits the value, each
+/// command would double it again until the line broke.
+std::string batchQuote(const std::string& value) {
+    std::string out;
+    for (char c : value) {
+        if (c == '%') {
+            out += "%%";
+        } else {
+            out += c;
+        }
+    }
+    return out;
+}
+
+/// Forward-slash form, which every POSIX shell — including a Git Bash or MSYS
+/// shell running on Windows — accepts.
+std::string genericPath(const std::string& path) {
+    return sfs::path(path).generic_string();
+}
+
+const char* kEnvMarker = "---GAIA-ENV---";
+
+} // namespace
+
+struct ShellSession::Impl {
+    mutable std::mutex mutex;
+    std::string startCwd;
+    std::string cwd;
+    std::string shell;
+    /// True when commands run through a POSIX shell (always on POSIX; on
+    /// Windows when a bash/sh was detected). False means a cmd.exe batch file.
+    bool posixScript = true;
+    std::map<std::string, std::string> baselineEnv;
+    std::map<std::string, std::string> overrides;   ///< set or changed by the session
+    std::set<std::string> unset;                    ///< removed by the session
+
+    /// Generate the per-command script that restores state, invokes the
+    /// command file, and reports the resulting cwd + environment to
+    /// `stateFile`.
+    ///
+    /// The command lives in its own file and is sourced (`.` / `call`) rather
+    /// than pasted in here. Pasting lets a command ending in a line
+    /// continuation, or an unterminated heredoc, swallow the framework's own
+    /// bookkeeping lines — which both corrupts the reported exit code and
+    /// leaks internals into what the model reads back.
+    ///
+    /// stdin is `/dev/null`: an interactive command (`git commit` opening an
+    /// editor, `sudo`, `npm login`) would otherwise sit until the timeout.
+    std::string buildScript(const std::string& commandFile,
+                            const std::string& stateFile) const {
+        std::ostringstream s;
+        if (posixScript) {
+            s << "cd " << posixQuote(genericPath(cwd)) << " || exit 127\n";
+            for (const auto& name : unset) {
+                if (!isValidEnvName(name)) continue;
+                s << "unset " << name << "\n";
+            }
+            for (const auto& kv : overrides) {
+                if (!isValidEnvName(kv.first)) continue;
+                s << kv.first << "=" << posixQuote(kv.second) << "; export "
+                  << kv.first << "\n";
+            }
+            s << ". " << posixQuote(genericPath(commandFile))
+              << " < /dev/null\n";
+            s << "__gaia_rc=$?\n";
+            // awk's ENVIRON gives NUL-delimited records; `env` output cannot
+            // be parsed unambiguously (see parseEnvRecordsNul).
+            s << "{ pwd; printf '%s\\n' " << posixQuote(kEnvMarker)
+              << "; awk 'BEGIN { for (k in ENVIRON) printf \"%s=%s%c\", k, "
+                 "ENVIRON[k], 0 }'; } > "
+              << posixQuote(genericPath(stateFile)) << " 2>/dev/null\n";
+            s << "exit $__gaia_rc\n";
+        } else {
+            s << "@echo off\r\n";
+            s << "cd /d \"" << batchQuote(cwd) << "\"\r\n";
+            s << "if errorlevel 1 exit /b 127\r\n";
+            for (const auto& name : unset) {
+                if (!isValidEnvName(name)) continue;
+                s << "set \"" << name << "=\"\r\n";
+            }
+            for (const auto& kv : overrides) {
+                if (!isValidEnvName(kv.first)) continue;
+                s << "set \"" << kv.first << "=" << batchQuote(kv.second)
+                  << "\"\r\n";
+            }
+            s << "call \"" << commandFile << "\" <nul\r\n";
+            s << "set __GAIA_RC=%ERRORLEVEL%\r\n";
+            s << "> \"" << stateFile << "\" (\r\n";
+            s << "  cd\r\n";
+            s << "  echo " << kEnvMarker << "\r\n";
+            s << "  set\r\n";
+            s << ")\r\n";
+            s << "exit /b %__GAIA_RC%\r\n";
+        }
+        return s.str();
+    }
+
+    /// Absorb the cwd and environment the command left behind.
+    void absorbState(const std::string& stateText) {
+        const size_t markerPos = stateText.find(kEnvMarker);
+        if (markerPos == std::string::npos) return;
+
+        std::string cwdLine = stateText.substr(0, markerPos);
+        while (!cwdLine.empty() &&
+               (cwdLine.back() == '\n' || cwdLine.back() == '\r')) {
+            cwdLine.pop_back();
+        }
+        // The shell is the authority on where it ended up. On Windows with a
+        // Git Bash shell this is an MSYS path (`/c/...`) that the Win32 API
+        // does not recognise but the next script — run by the same shell —
+        // does, so it is taken as reported rather than validated away.
+        if (!cwdLine.empty()) cwd = cwdLine;
+
+        size_t envStart = markerPos + std::strlen(kEnvMarker);
+        while (envStart < stateText.size() &&
+               (stateText[envStart] == '\n' || stateText[envStart] == '\r')) {
+            ++envStart;
+        }
+        const std::string envText = stateText.substr(envStart);
+        const auto captured = posixScript ? parseEnvRecordsNul(envText)
+                                          : parseEnvLines(envText);
+        if (captured.empty()) return;
+
+        overrides.clear();
+        unset.clear();
+        for (const auto& kv : captured) {
+            if (volatileEnvNames().count(kv.first)) continue;
+            auto base = baselineEnv.find(kv.first);
+            if (base == baselineEnv.end() || base->second != kv.second) {
+                overrides[kv.first] = kv.second;
+            }
+        }
+        for (const auto& kv : baselineEnv) {
+            if (volatileEnvNames().count(kv.first)) continue;
+            if (captured.find(kv.first) == captured.end()) {
+                unset.insert(kv.first);
+            }
+        }
+    }
+};
+
+ShellSession::ShellSession(const std::string& startCwd, const std::string& shell)
+    : impl_(new Impl()) {
+    std::error_code ec;
+    sfs::path start = startCwd.empty() ? sfs::current_path(ec)
+                                       : sfs::path(startCwd);
+    if (!startCwd.empty()) {
+        sfs::path resolved = sfs::weakly_canonical(start, ec);
+        if (!ec) start = resolved;
+    }
+    if (start.empty()) start = sfs::path(".");
+    impl_->cwd = start.string();
+    impl_->startCwd = impl_->cwd;
+    impl_->baselineEnv = captureProcessEnv();
+
+#ifdef _WIN32
+    // A POSIX shell is used when one was named (the bash agent detects Git
+    // Bash / MSYS / WSL); otherwise commands run as a cmd.exe batch script.
+    impl_->shell = shell;
+    impl_->posixScript = !shell.empty();
+#else
+    impl_->shell = shell.empty() ? std::string("/bin/sh") : shell;
+    impl_->posixScript = true;
+#endif
+}
+
+ShellSession::~ShellSession() = default;
+ShellSession::ShellSession(ShellSession&&) noexcept = default;
+ShellSession& ShellSession::operator=(ShellSession&&) noexcept = default;
+
+ShellSession& ShellSession::shared() {
+    static ShellSession session;
+    return session;
+}
+
+ProcessResult ShellSession::run(const std::string& command,
+                                int timeoutMs,
+                                size_t maxOutputBytes) {
+    ProcessResult result;
+
+    if (command.empty()) {
+        result.exitCode = -1;
+        result.stderr_output = "Empty command";
+        return result;
+    }
+
+    std::lock_guard<std::mutex> lock(impl_->mutex);
+
+    // Removed however this function exits, including on a throw.
+    TempFileSet temps;
+
+    const char* scriptExt = impl_->posixScript ? ".sh" : ".cmd";
+    const std::string tempError =
+        "ShellSession: could not create a temporary file in the system temp "
+        "directory. Check that it exists and is writable.";
+
+    std::string stateFile;
+    if (!writeTempFile(".state", "", stateFile)) {
+        result.exitCode = -1;
+        result.stderr_output = tempError;
+        return result;
+    }
+    temps.add(stateFile);
+
+    // The command gets its own file so it cannot splice into the script's
+    // bookkeeping; on Windows it must be a .cmd for `call` to accept it.
+    std::string commandFile;
+    if (!writeTempFile(scriptExt, command + "\n", commandFile)) {
+        result.exitCode = -1;
+        result.stderr_output = tempError;
+        return result;
+    }
+    temps.add(commandFile);
+
+    std::string scriptFile;
+    if (!writeTempFile(scriptExt, impl_->buildScript(commandFile, stateFile),
+                       scriptFile)) {
+        result.exitCode = -1;
+        result.stderr_output = tempError;
+        return result;
+    }
+    temps.add(scriptFile);
+
+    const std::string invocation =
+        impl_->posixScript
+            ? impl_->shell + " " + posixQuote(genericPath(scriptFile))
+            : "\"" + scriptFile + "\"";
+
+    // No cwd/env arguments: the script applies both inside the child, so the
+    // calling process is never mutated and concurrent sessions cannot collide.
+    result = ProcessRunner::run(invocation, timeoutMs, "", {}, maxOutputBytes);
+
+    impl_->absorbState(readFileContents(stateFile));
+
+    return result;
+}
+
+std::string ShellSession::cwd() const {
+    std::lock_guard<std::mutex> lock(impl_->mutex);
+    return impl_->cwd;
+}
+
+bool ShellSession::setCwd(const std::string& dir) {
+    std::error_code ec;
+    sfs::path resolved = sfs::weakly_canonical(sfs::path(dir), ec);
+    if (ec) resolved = sfs::path(dir);
+    if (!sfs::is_directory(resolved, ec)) return false;
+
+    std::lock_guard<std::mutex> lock(impl_->mutex);
+    impl_->cwd = resolved.string();
+    return true;
+}
+
+std::map<std::string, std::string> ShellSession::environment() const {
+    std::lock_guard<std::mutex> lock(impl_->mutex);
+    return impl_->overrides;
+}
+
+void ShellSession::setEnv(const std::string& name, const std::string& value) {
+    std::lock_guard<std::mutex> lock(impl_->mutex);
+    impl_->overrides[name] = value;
+    impl_->unset.erase(name);
+}
+
+void ShellSession::reset() {
+    std::lock_guard<std::mutex> lock(impl_->mutex);
+    impl_->cwd = impl_->startCwd;
+    impl_->overrides.clear();
+    impl_->unset.clear();
 }
 
 } // namespace gaia

--- a/cpp/tests/test_file_tools.cpp
+++ b/cpp/tests/test_file_tools.cpp
@@ -19,9 +19,13 @@ protected:
     void SetUp() override {
         tempDir_ = fs::temp_directory_path() / "gaia_file_tools_test";
         fs::create_directories(tempDir_);
+        // The read/write anchor table is process-wide; clear it so these
+        // cases are independent of each other and of run order.
+        FileStateTracker::instance().clear();
     }
 
     void TearDown() override {
+        FileStateTracker::instance().clear();
         std::error_code ec;
         fs::remove_all(tempDir_, ec);
     }
@@ -349,4 +353,456 @@ TEST_F(FileToolsTest, ToolInfo_FileSearchParams) {
     EXPECT_FALSE(info.parameters[2].required);
     EXPECT_EQ(info.parameters[3].name, "max_results");
     EXPECT_FALSE(info.parameters[3].required);
+}
+
+// ---------------------------------------------------------------------------
+// Hardening: stale-write rejection and ignore-aware search
+//
+// Separate fixture (and separate temp directory) so the process-wide
+// FileStateTracker can be cleared without touching the cases above.
+// ---------------------------------------------------------------------------
+
+class FileToolsHardeningTest : public ::testing::Test {
+protected:
+    fs::path tempDir_;
+
+    void SetUp() override {
+        tempDir_ = fs::temp_directory_path() / "gaia_file_tools_hardening";
+        std::error_code ec;
+        fs::remove_all(tempDir_, ec);
+        fs::create_directories(tempDir_);
+        FileStateTracker::instance().clear();
+    }
+
+    void TearDown() override {
+        FileStateTracker::instance().clear();
+        std::error_code ec;
+        fs::remove_all(tempDir_, ec);
+    }
+
+    std::string writeFile(const std::string& name, const std::string& content) {
+        fs::path p = tempDir_ / name;
+        if (p.has_parent_path()) {
+            fs::create_directories(p.parent_path());
+        }
+        std::ofstream f(p, std::ios::binary);
+        f << content;
+        f.close();
+        return p.string();
+    }
+
+    std::string readFile(const std::string& path) {
+        std::ifstream f(path, std::ios::binary);
+        std::ostringstream buf;
+        buf << f.rdbuf();
+        return buf.str();
+    }
+};
+
+// --- SHA-256 -----------------------------------------------------------------
+
+TEST_F(FileToolsHardeningTest, HashContent_MatchesKnownVectors) {
+    EXPECT_EQ(FileStateTracker::hashContent(""),
+              "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855");
+    EXPECT_EQ(FileStateTracker::hashContent("abc"),
+              "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad");
+    // Spans multiple 64-byte blocks and exercises the length-padding path.
+    EXPECT_EQ(FileStateTracker::hashContent(std::string(1000, 'a')),
+              "41edece42d63e8d9bf515a9ba6932e1c20cbc9f5a5d134645adb5db1b9737ea3");
+}
+
+TEST_F(FileToolsHardeningTest, HashFile_MatchesHashContent) {
+    const std::string body(200000, 'x');  // larger than the streaming buffer
+    std::string path = writeFile("big.bin", body);
+    EXPECT_EQ(FileStateTracker::hashFile(path),
+              FileStateTracker::hashContent(body));
+    EXPECT_EQ(FileStateTracker::hashFile((tempDir_ / "absent.bin").string()), "");
+}
+
+// --- Stale-write rejection ---------------------------------------------------
+
+TEST_F(FileToolsHardeningTest, FileRead_ReturnsContentHashAndTracksFile) {
+    std::string path = writeFile("tracked.txt", "original\n");
+
+    json read = FileIOTools::fileRead().callback({{"path", path}});
+    ASSERT_FALSE(read.contains("error"));
+    ASSERT_TRUE(read.contains("content_hash"));
+    EXPECT_FALSE(read["content_hash"].get<std::string>().empty());
+    EXPECT_TRUE(FileStateTracker::instance().hasRecord(path));
+
+    // The hash anchors the whole file, not just the returned slice.
+    json ranged = FileIOTools::fileRead().callback(
+        {{"path", path}, {"start_line", 1}, {"end_line", 1}});
+    EXPECT_EQ(ranged["content_hash"], read["content_hash"]);
+}
+
+TEST_F(FileToolsHardeningTest, FileEdit_RejectsEditAgainstDivergedFile) {
+    std::string path = writeFile("race.txt", "alpha beta\n");
+
+    json read = FileIOTools::fileRead().callback({{"path", path}});
+    ASSERT_FALSE(read.contains("error"));
+
+    // Something else changes the file between the read and the edit.
+    writeFile("race.txt", "alpha beta gamma delta\n");
+
+    json result = FileIOTools::fileEdit().callback(
+        {{"path", path}, {"old_string", "alpha"}, {"new_string", "ALPHA"}});
+
+    ASSERT_TRUE(result.contains("error"));
+    EXPECT_TRUE(result.value("stale", false));
+    const std::string message = result["error"].get<std::string>();
+    EXPECT_NE(message.find("changed on disk"), std::string::npos);
+    EXPECT_NE(message.find("Nothing was written"), std::string::npos);
+    EXPECT_NE(message.find("file_read"), std::string::npos);
+
+    // The divergence is named: both hashes are reported and differ.
+    ASSERT_TRUE(result.contains("hash_at_read"));
+    ASSERT_TRUE(result.contains("hash_now"));
+    EXPECT_NE(result["hash_at_read"], result["hash_now"]);
+    EXPECT_NE(message.find(result["hash_at_read"].get<std::string>()),
+              std::string::npos);
+    EXPECT_NE(message.find(result["hash_now"].get<std::string>()),
+              std::string::npos);
+
+    // Rejected means rejected — the file is untouched.
+    EXPECT_EQ(readFile(path), "alpha beta gamma delta\n");
+}
+
+TEST_F(FileToolsHardeningTest, FileWrite_RejectsWriteAgainstDivergedFile) {
+    std::string path = writeFile("doc.txt", "v1\n");
+
+    ASSERT_FALSE(FileIOTools::fileRead().callback({{"path", path}}).contains("error"));
+    writeFile("doc.txt", "v2 from someone else\n");
+
+    json result = FileIOTools::fileWrite().callback(
+        {{"path", path}, {"content", "v3 from the model\n"}});
+
+    ASSERT_TRUE(result.contains("error"));
+    EXPECT_TRUE(result.value("stale", false));
+    EXPECT_NE(result["error"].get<std::string>().find("changed on disk"),
+              std::string::npos);
+    EXPECT_EQ(readFile(path), "v2 from someone else\n");
+}
+
+TEST_F(FileToolsHardeningTest, FileEdit_SucceedsAfterReReading) {
+    std::string path = writeFile("recover.txt", "alpha\n");
+    FileIOTools::fileRead().callback({{"path", path}});
+    writeFile("recover.txt", "alpha beta\n");
+
+    ASSERT_TRUE(FileIOTools::fileEdit()
+                    .callback({{"path", path},
+                               {"old_string", "alpha"},
+                               {"new_string", "ALPHA"}})
+                    .contains("error"));
+
+    // Re-read, then the same edit lands.
+    FileIOTools::fileRead().callback({{"path", path}});
+    json result = FileIOTools::fileEdit().callback(
+        {{"path", path}, {"old_string", "alpha"}, {"new_string", "ALPHA"}});
+
+    ASSERT_FALSE(result.contains("error"));
+    EXPECT_EQ(result["replacements"], 1);
+    EXPECT_EQ(readFile(path), "ALPHA beta\n");
+}
+
+TEST_F(FileToolsHardeningTest, FileEdit_ConsecutiveEditsNeedNoReRead) {
+    std::string path = writeFile("chain.txt", "one two three\n");
+    FileIOTools::fileRead().callback({{"path", path}});
+
+    ASSERT_FALSE(FileIOTools::fileEdit()
+                     .callback({{"path", path},
+                                {"old_string", "one"},
+                                {"new_string", "1"}})
+                     .contains("error"));
+    json second = FileIOTools::fileEdit().callback(
+        {{"path", path}, {"old_string", "two"}, {"new_string", "2"}});
+
+    ASSERT_FALSE(second.contains("error"));
+    EXPECT_EQ(readFile(path), "1 2 three\n");
+}
+
+TEST_F(FileToolsHardeningTest, FileWrite_AfterWriteFollowUpEditIsAllowed) {
+    std::string path = (tempDir_ / "fresh.txt").string();
+
+    ASSERT_FALSE(FileIOTools::fileWrite()
+                     .callback({{"path", path}, {"content", "hello world\n"}})
+                     .contains("error"));
+    json edit = FileIOTools::fileEdit().callback(
+        {{"path", path}, {"old_string", "world"}, {"new_string", "there"}});
+
+    ASSERT_FALSE(edit.contains("error"));
+    EXPECT_EQ(readFile(path), "hello there\n");
+}
+
+TEST_F(FileToolsHardeningTest, FileEdit_NonMatchingOldStringIsActionable) {
+    std::string path = writeFile("nomatch.txt", "the quick brown fox\n");
+    const std::string before = readFile(path);
+
+    json result = FileIOTools::fileEdit().callback(
+        {{"path", path}, {"old_string", "lazy dog"}, {"new_string", "cat"}});
+
+    ASSERT_TRUE(result.contains("error"));
+    const std::string message = result["error"].get<std::string>();
+    EXPECT_NE(message.find("not found"), std::string::npos);
+    EXPECT_NE(message.find("no replacement was made"), std::string::npos);
+    EXPECT_NE(message.find("file_read"), std::string::npos);
+    EXPECT_EQ(result["replacements"], 0);
+    EXPECT_EQ(readFile(path), before);
+}
+
+TEST_F(FileToolsHardeningTest, FileEdit_WhitespaceMismatchIsNamed) {
+    std::string path = writeFile("indent.py", "def main():\n    return 1\n");
+
+    json result = FileIOTools::fileEdit().callback(
+        {{"path", path},
+         {"old_string", "def main():\n        return 1"},  // wrong indentation
+         {"new_string", "def main():\n    return 2"}});
+
+    ASSERT_TRUE(result.contains("error"));
+    EXPECT_NE(result["error"].get<std::string>().find("whitespace-insensitive"),
+              std::string::npos);
+}
+
+TEST_F(FileToolsHardeningTest, FileWrite_RecreatesADeletedFile) {
+    // Read, then the file goes away (git checkout, rm, a build clean). Writing
+    // it again is a create, not a conflict — a leftover anchor must not block
+    // it forever.
+    std::string path = writeFile("gone.txt", "v1\n");
+    FileIOTools::fileRead().callback({{"path", path}});
+    std::error_code ec;
+    fs::remove(path, ec);
+
+    json result = FileIOTools::fileWrite().callback(
+        {{"path", path}, {"content", "recreated\n"}});
+
+    ASSERT_FALSE(result.contains("error")) << result.dump();
+    EXPECT_EQ(readFile(path), "recreated\n");
+}
+
+TEST_F(FileToolsHardeningTest, FileEdit_ReportsAFileThatVanishedAfterRead) {
+    std::string path = writeFile("vanished.txt", "v1\n");
+    FileIOTools::fileRead().callback({{"path", path}});
+    std::error_code ec;
+    fs::remove(path, ec);
+
+    json result = FileIOTools::fileEdit().callback(
+        {{"path", path}, {"old_string", "v1"}, {"new_string", "v2"}});
+
+    ASSERT_TRUE(result.contains("error"));
+    EXPECT_NE(result["error"].get<std::string>().find("Cannot open"),
+              std::string::npos);
+}
+
+TEST_F(FileToolsHardeningTest, FileStateTracker_ForgetDropsTheAnchor) {
+    std::string path = writeFile("forget.txt", "v1\n");
+    FileIOTools::fileRead().callback({{"path", path}});
+    writeFile("forget.txt", "v2\n");
+
+    FileStateTracker::instance().forget(path);
+    EXPECT_FALSE(FileStateTracker::instance().hasRecord(path));
+
+    // With no anchor there is nothing to be stale about.
+    json result = FileIOTools::fileEdit().callback(
+        {{"path", path}, {"old_string", "v2"}, {"new_string", "v3"}});
+    EXPECT_FALSE(result.contains("error"));
+}
+
+TEST_F(FileToolsHardeningTest, FileStateTracker_RecordsAreKeyedCanonically) {
+    std::string path = writeFile("canon.txt", "data\n");
+    FileIOTools::fileRead().callback({{"path", path}});
+
+    // The same file reached through a redundant "." segment is one record.
+    const std::string viaDot = (tempDir_ / "." / "canon.txt").string();
+    EXPECT_TRUE(FileStateTracker::instance().hasRecord(viaDot));
+    EXPECT_EQ(FileStateTracker::instance().size(), 1u);
+}
+
+// --- Ignore-aware search -----------------------------------------------------
+
+TEST_F(FileToolsHardeningTest, FileSearch_SkipsGitignoredPaths) {
+    // A realistic repo: .git, a .gitignore, vendored deps and build output.
+    fs::create_directories(tempDir_ / ".git");
+    writeFile(".gitignore", "node_modules/\nbuild/\n*.log\n");
+    writeFile("src/index.js", "export const answer = 42;\n");
+    writeFile("src/util.js", "export const noop = () => {};\n");
+    writeFile("node_modules/left-pad/index.js", "module.exports = 1;\n");
+    writeFile("node_modules/react/react.js", "module.exports = 2;\n");
+    writeFile("build/bundle.js", "/* generated */\n");
+    writeFile("debug.log", "noise\n");
+    writeFile(".git/hooks/pre-commit.js", "#!/bin/sh\n");
+
+    json result = FileIOTools::fileSearch().callback(
+        {{"pattern", "*.js"}, {"path", tempDir_.string()}});
+
+    ASSERT_FALSE(result.contains("error"));
+    EXPECT_EQ(result["total"], 2);
+    for (const auto& match : result["matches"]) {
+        const std::string path = match["path"].get<std::string>();
+        EXPECT_EQ(path.find("node_modules"), std::string::npos) << path;
+        EXPECT_EQ(path.find("/build/"), std::string::npos) << path;
+        EXPECT_EQ(path.find("/.git/"), std::string::npos) << path;
+    }
+    // The skips are reported, so a thin result set is explained.
+    EXPECT_GT(result["ignored_skipped"].get<int>(), 0);
+}
+
+TEST_F(FileToolsHardeningTest, FileSearch_ContentSearchSkipsIgnoredFiles) {
+    fs::create_directories(tempDir_ / ".git");
+    writeFile(".gitignore", "vendor/\n");
+    writeFile("src/app.ts", "const needle = 1;\n");
+    writeFile("vendor/lib.ts", "const needle = 2;\n");
+
+    json result = FileIOTools::fileSearch().callback({
+        {"pattern", "*.ts"},
+        {"path", tempDir_.string()},
+        {"content_pattern", "needle"},
+    });
+
+    ASSERT_FALSE(result.contains("error"));
+    EXPECT_EQ(result["total"], 1);
+    EXPECT_NE(result["matches"][0]["path"].get<std::string>().find("src/app.ts"),
+              std::string::npos);
+}
+
+TEST_F(FileToolsHardeningTest, FileSearch_NegatedGitignoreRuleIsHonored) {
+    fs::create_directories(tempDir_ / ".git");
+    writeFile(".gitignore", "*.log\n!keep.log\n");
+    writeFile("drop.log", "x\n");
+    writeFile("keep.log", "y\n");
+
+    json result = FileIOTools::fileSearch().callback(
+        {{"pattern", "*.log"}, {"path", tempDir_.string()}});
+
+    ASSERT_FALSE(result.contains("error"));
+    EXPECT_EQ(result["total"], 1);
+    EXPECT_NE(result["matches"][0]["path"].get<std::string>().find("keep.log"),
+              std::string::npos);
+}
+
+TEST_F(FileToolsHardeningTest, FileSearch_PathPatternsAndCharacterClasses) {
+    writeFile("src/core/agent.h", "#pragma once\n");
+    writeFile("src/core/agent.cpp", "// impl\n");
+    writeFile("include/agent.h", "#pragma once\n");
+    writeFile("test_1.cpp", "// one\n");
+    writeFile("test_x.cpp", "// x\n");
+
+    json byPath = FileIOTools::fileSearch().callback(
+        {{"pattern", "src/**/*.h"}, {"path", tempDir_.string()}});
+    ASSERT_FALSE(byPath.contains("error"));
+    EXPECT_EQ(byPath["total"], 1);
+    EXPECT_NE(byPath["matches"][0]["path"].get<std::string>().find("src/core/agent.h"),
+              std::string::npos);
+
+    json byClass = FileIOTools::fileSearch().callback(
+        {{"pattern", "test_[0-9].cpp"}, {"path", tempDir_.string()}});
+    ASSERT_FALSE(byClass.contains("error"));
+    EXPECT_EQ(byClass["total"], 1);
+}
+
+// --- Regressions found in review --------------------------------------------
+
+TEST_F(FileToolsHardeningTest, FileRead_ReturnsRawBytesSoEditsMatch) {
+    // A CRLF file must read back with its CRLFs intact: the model copies
+    // old_string out of what file_read showed it, and file_edit searches the
+    // bytes on disk. If the two disagree the edit can never match.
+    std::string path = writeFile("crlf.txt", "alpha\r\nbeta\r\n");
+
+    json read = FileIOTools::fileRead().callback({{"path", path}});
+    ASSERT_FALSE(read.contains("error"));
+    const std::string shown = read["content"].get<std::string>();
+    EXPECT_NE(shown.find("alpha\r"), std::string::npos);
+    EXPECT_EQ(read["lines"], 2);
+
+    json edit = FileIOTools::fileEdit().callback(
+        {{"path", path}, {"old_string", "alpha\r\nbeta"}, {"new_string", "one\r\ntwo"}});
+    ASSERT_FALSE(edit.contains("error")) << edit.dump();
+    EXPECT_EQ(readFile(path), "one\r\ntwo\r\n");
+}
+
+TEST_F(FileToolsHardeningTest, FileRead_HashAnchorsTheBytesItShowed) {
+    // One pass over the file: the hash must be of exactly the content
+    // returned, never of a second, later read.
+    const std::string body = "alpha\nbeta\ngamma\n";
+    std::string path = writeFile("anchor.txt", body);
+
+    json read = FileIOTools::fileRead().callback({{"path", path}});
+    ASSERT_FALSE(read.contains("error"));
+    EXPECT_EQ(read["content_hash"].get<std::string>(),
+              FileStateTracker::hashContent(body).substr(0, 12));
+}
+
+TEST_F(FileToolsHardeningTest, FileRead_LineCountsAndRanges) {
+    EXPECT_EQ(FileIOTools::fileRead()
+                  .callback({{"path", writeFile("nl.txt", "a\nb\n")}})["lines"],
+              2);
+    EXPECT_EQ(FileIOTools::fileRead()
+                  .callback({{"path", writeFile("nonl.txt", "a\nb")}})["lines"],
+              2);
+    EXPECT_EQ(FileIOTools::fileRead()
+                  .callback({{"path", writeFile("empty.txt", "")}})["lines"],
+              0);
+
+    json blanks = FileIOTools::fileRead().callback(
+        {{"path", writeFile("blanks.txt", "AAA\n\nBBB\n")}});
+    EXPECT_EQ(blanks["content"].get<std::string>(), "AAA\n\nBBB");
+}
+
+TEST_F(FileToolsHardeningTest, FileWrite_RecreationIsReported) {
+    std::string path = writeFile("resurrect.txt", "v1\n");
+    FileIOTools::fileRead().callback({{"path", path}});
+    std::error_code ec;
+    fs::remove(path, ec);
+
+    json result = FileIOTools::fileWrite().callback(
+        {{"path", path}, {"content", "back\n"}});
+
+    ASSERT_FALSE(result.contains("error"));
+    EXPECT_TRUE(result.value("recreated", false));
+
+    // An ordinary create says nothing about recreation.
+    json plain = FileIOTools::fileWrite().callback(
+        {{"path", (tempDir_ / "brand_new.txt").string()}, {"content", "x\n"}});
+    EXPECT_FALSE(plain.contains("recreated"));
+}
+
+TEST_F(FileToolsHardeningTest, FileSearch_HonorsNestedGitignoreFiles) {
+    // .gitignore files below the search root govern their own subtree only.
+    fs::create_directories(tempDir_ / ".git");
+    writeFile(".gitignore", "*.log\n");
+    writeFile("pkg/.gitignore", "generated/\n");
+    writeFile("pkg/src/main.ts", "export {};\n");
+    writeFile("pkg/generated/api.ts", "// generated\n");
+    writeFile("other/generated/keep.ts", "// a sibling, not governed\n");
+
+    json result = FileIOTools::fileSearch().callback(
+        {{"pattern", "*.ts"}, {"path", tempDir_.string()}});
+
+    ASSERT_FALSE(result.contains("error"));
+    EXPECT_EQ(result["total"], 2);
+    for (const auto& match : result["matches"]) {
+        EXPECT_EQ(match["path"].get<std::string>().find("pkg/generated"),
+                  std::string::npos);
+    }
+}
+
+TEST_F(FileToolsHardeningTest, FileSearch_GitDirectoryIsNotCountedAsAnIgnoreSkip) {
+    // The counter exists to explain a thin result set; counting the always
+    // pruned .git would make it non-zero on every repository.
+    fs::create_directories(tempDir_ / ".git");
+    writeFile("src/a.ts", "x\n");
+
+    json result = FileIOTools::fileSearch().callback(
+        {{"pattern", "*.ts"}, {"path", tempDir_.string()}});
+
+    EXPECT_EQ(result["total"], 1);
+    EXPECT_EQ(result["ignored_skipped"], 0);
+}
+
+TEST_F(FileToolsHardeningTest, FileSearch_OversizedPatternIsRejected) {
+    json result = FileIOTools::fileSearch().callback(
+        {{"pattern", std::string(600, '*')}, {"path", tempDir_.string()}});
+
+    ASSERT_TRUE(result.contains("error"));
+    EXPECT_NE(result["error"].get<std::string>().find("limit is 512"),
+              std::string::npos);
 }

--- a/cpp/tests/test_ignore.cpp
+++ b/cpp/tests/test_ignore.cpp
@@ -1,0 +1,189 @@
+// Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+#include <gtest/gtest.h>
+#include <gaia/ignore.h>
+
+#include <filesystem>
+#include <fstream>
+#include <string>
+
+namespace fs = std::filesystem;
+using namespace gaia;
+
+namespace {
+
+GlobOptions nameMode() { return GlobOptions{/*pathMode=*/false, false}; }
+GlobOptions pathMode() { return GlobOptions{/*pathMode=*/true, false}; }
+
+} // namespace
+
+// ---------------------------------------------------------------------------
+// globMatch
+// ---------------------------------------------------------------------------
+
+TEST(GlobMatchTest, StarAndQuestion) {
+    EXPECT_TRUE(globMatch("*.cpp", "main.cpp", nameMode()));
+    EXPECT_FALSE(globMatch("*.cpp", "main.h", nameMode()));
+    EXPECT_TRUE(globMatch("test_?.cpp", "test_a.cpp", nameMode()));
+    EXPECT_FALSE(globMatch("test_?.cpp", "test_ab.cpp", nameMode()));
+    EXPECT_TRUE(globMatch("*", "anything", nameMode()));
+}
+
+TEST(GlobMatchTest, CharacterClasses) {
+    EXPECT_TRUE(globMatch("file[0-9].txt", "file7.txt", nameMode()));
+    EXPECT_FALSE(globMatch("file[0-9].txt", "filex.txt", nameMode()));
+    EXPECT_TRUE(globMatch("file[!0-9].txt", "filex.txt", nameMode()));
+    EXPECT_FALSE(globMatch("file[!0-9].txt", "file7.txt", nameMode()));
+    EXPECT_TRUE(globMatch("[abc]bc", "abc", nameMode()));
+    // An unterminated class is a literal '[' — patterns from an LLM are not
+    // guaranteed well-formed and must not throw or match everything.
+    EXPECT_TRUE(globMatch("a[bc", "a[bc", nameMode()));
+}
+
+TEST(GlobMatchTest, EscapeSequences) {
+    EXPECT_TRUE(globMatch("a\\*b", "a*b", nameMode()));
+    EXPECT_FALSE(globMatch("a\\*b", "axxb", nameMode()));
+}
+
+TEST(GlobMatchTest, SingleStarDoesNotCrossSeparatorInPathMode) {
+    EXPECT_TRUE(globMatch("src/*.cpp", "src/main.cpp", pathMode()));
+    EXPECT_FALSE(globMatch("src/*.cpp", "src/deep/main.cpp", pathMode()));
+    // Without path mode the whole string is one segment.
+    EXPECT_TRUE(globMatch("src/*.cpp", "src/deep/main.cpp", nameMode()));
+}
+
+TEST(GlobMatchTest, DoubleStarSpansDirectories) {
+    EXPECT_TRUE(globMatch("src/**/*.h", "src/a/b/c.h", pathMode()));
+    EXPECT_TRUE(globMatch("src/**/*.h", "src/c.h", pathMode()));  // zero dirs
+    EXPECT_FALSE(globMatch("src/**/*.h", "other/c.h", pathMode()));
+    EXPECT_TRUE(globMatch("**/node_modules", "a/b/node_modules", pathMode()));
+    EXPECT_TRUE(globMatch("**/node_modules", "node_modules", pathMode()));
+}
+
+TEST(GlobMatchTest, PathologicalPatternTerminates) {
+    // Memoization keeps this from exploding; without it the test would hang.
+    const std::string text(64, 'a');
+    EXPECT_FALSE(globMatch("*a*a*a*a*a*a*a*a*b", text, nameMode()));
+}
+
+TEST(GlobMatchTest, CaseInsensitiveOption) {
+    GlobOptions ci{/*pathMode=*/false, /*caseInsensitive=*/true};
+    EXPECT_TRUE(globMatch("*.CPP", "main.cpp", ci));
+    EXPECT_FALSE(globMatch("*.CPP", "main.cpp", nameMode()));
+}
+
+// ---------------------------------------------------------------------------
+// GitignoreMatcher
+// ---------------------------------------------------------------------------
+
+class GitignoreTest : public ::testing::Test {
+protected:
+    fs::path root_;
+
+    void SetUp() override {
+        root_ = fs::temp_directory_path() / "gaia_ignore_test";
+        std::error_code ec;
+        fs::remove_all(root_, ec);
+        fs::create_directories(root_);
+    }
+
+    void TearDown() override {
+        std::error_code ec;
+        fs::remove_all(root_, ec);
+    }
+
+    GitignoreMatcher withRules(const std::string& rules) {
+        GitignoreMatcher matcher;
+        matcher.addRules(rules, root_.string());
+        return matcher;
+    }
+
+    std::string p(const std::string& rel) { return (root_ / rel).string(); }
+};
+
+TEST_F(GitignoreTest, EmptyMatcherIgnoresNothing) {
+    GitignoreMatcher matcher;
+    EXPECT_TRUE(matcher.empty());
+    EXPECT_FALSE(matcher.isIgnored(p("anything.txt"), false));
+}
+
+TEST_F(GitignoreTest, DirectoryRuleIgnoresContents) {
+    auto matcher = withRules("node_modules/\n");
+    EXPECT_TRUE(matcher.isIgnored(p("node_modules"), true));
+    EXPECT_TRUE(matcher.isIgnored(p("node_modules/left-pad/index.js"), false));
+    EXPECT_TRUE(matcher.isIgnored(p("packages/app/node_modules/x.js"), false));
+    EXPECT_FALSE(matcher.isIgnored(p("src/index.js"), false));
+    // A *file* named node_modules is not matched by a directory-only rule.
+    EXPECT_FALSE(matcher.isIgnored(p("node_modules"), false));
+}
+
+TEST_F(GitignoreTest, ExtensionRuleMatchesAtAnyDepth) {
+    auto matcher = withRules("*.log\n");
+    EXPECT_TRUE(matcher.isIgnored(p("debug.log"), false));
+    EXPECT_TRUE(matcher.isIgnored(p("a/b/debug.log"), false));
+    EXPECT_FALSE(matcher.isIgnored(p("a/b/debug.txt"), false));
+}
+
+TEST_F(GitignoreTest, AnchoredRuleOnlyMatchesAtRoot) {
+    auto matcher = withRules("/build\n");
+    EXPECT_TRUE(matcher.isIgnored(p("build/out.o"), false));
+    EXPECT_FALSE(matcher.isIgnored(p("src/build/out.o"), false));
+}
+
+TEST_F(GitignoreTest, NegationReincludes) {
+    auto matcher = withRules("*.log\n!keep.log\n");
+    EXPECT_TRUE(matcher.isIgnored(p("debug.log"), false));
+    EXPECT_FALSE(matcher.isIgnored(p("keep.log"), false));
+}
+
+TEST_F(GitignoreTest, CommentsBlankLinesAndTrailingSpace) {
+    auto matcher = withRules("# a comment\n\n   \nbuild   \n");
+    EXPECT_EQ(matcher.ruleCount(), 1u);
+    EXPECT_TRUE(matcher.isIgnored(p("build"), true));
+    EXPECT_FALSE(matcher.isIgnored(p("# a comment"), false));
+}
+
+TEST_F(GitignoreTest, CrlfLineEndings) {
+    auto matcher = withRules("dist/\r\n*.tmp\r\n");
+    EXPECT_TRUE(matcher.isIgnored(p("dist/app.js"), false));
+    EXPECT_TRUE(matcher.isIgnored(p("scratch.tmp"), false));
+}
+
+TEST_F(GitignoreTest, ForDirectoryWalksToRepositoryRoot) {
+    // A repository root is where .git lives; a .gitignore above it must not
+    // leak in, and one at the root must reach a nested search directory.
+    fs::create_directories(root_ / "repo" / ".git");
+    fs::create_directories(root_ / "repo" / "src" / "nested");
+    {
+        std::ofstream f(root_ / "repo" / ".gitignore");
+        f << "build/\n";
+    }
+    {
+        std::ofstream f(root_ / "repo" / "src" / ".gitignore");
+        f << "*.gen.cpp\n";
+    }
+
+    auto matcher = GitignoreMatcher::forDirectory((root_ / "repo" / "src").string());
+    EXPECT_TRUE(matcher.isIgnored((root_ / "repo" / "build" / "a.o").string(), false));
+    EXPECT_TRUE(matcher.isIgnored((root_ / "repo" / "src" / "x.gen.cpp").string(), false));
+    EXPECT_FALSE(matcher.isIgnored((root_ / "repo" / "src" / "x.cpp").string(), false));
+}
+
+TEST_F(GitignoreTest, ForDirectoryOutsideRepoUsesOnlyItsOwnFile) {
+    fs::create_directories(root_ / "loose");
+    {
+        std::ofstream f(root_ / "loose" / ".gitignore");
+        f << "secret.txt\n";
+    }
+
+    auto matcher = GitignoreMatcher::forDirectory((root_ / "loose").string());
+    EXPECT_TRUE(matcher.isIgnored((root_ / "loose" / "secret.txt").string(), false));
+    EXPECT_FALSE(matcher.isIgnored((root_ / "loose" / "public.txt").string(), false));
+}
+
+TEST_F(GitignoreTest, PathsOutsideBaseDirAreNeverIgnored) {
+    auto matcher = withRules("*.log\n");
+    EXPECT_FALSE(matcher.isIgnored((fs::temp_directory_path() / "elsewhere.log").string(),
+                                   false));
+}

--- a/cpp/tests/test_process.cpp
+++ b/cpp/tests/test_process.cpp
@@ -165,8 +165,16 @@ TEST(ProcessRunnerTest, NoTimeoutMode) {
 // ShellSession — state that survives between commands
 // ---------------------------------------------------------------------------
 
+#include <chrono>
+#include <cstdlib>
 #include <filesystem>
 #include <map>
+#include <thread>
+
+#ifndef _WIN32
+#include <csignal>
+#include <sys/types.h>
+#endif
 
 namespace fs = std::filesystem;
 
@@ -435,13 +443,34 @@ TEST_F(ShellSessionTest, TimeoutKillsTheWholeProcessTree) {
 #ifndef _WIN32
     // A build or test command spawns children; killing only the shell leaves
     // them running, which is exactly the case a persistent shell is for.
+    //
+    // The grandchild reports its own pid and is then checked with kill(pid, 0).
+    // A `pgrep -f <pattern>` probe cannot be used: the shell running the probe
+    // has the pattern in its own argv and matches itself, which is both
+    // platform-dependent and a false pass waiting to happen.
     ShellSession session;
-    auto result = session.run("sleep 971 & wait", 1000);
+    auto result = session.run("sleep 971 & echo PID=$!; wait", 1000);
     ASSERT_TRUE(result.timedOut);
 
-    auto probe = ProcessRunner::run("pgrep -f 'sleep 971' | wc -l", 10000);
-    EXPECT_NE(probe.stdout_output.find('0'), std::string::npos)
-        << "orphaned child survived: " << probe.stdout_output;
+    const size_t marker = result.stdout_output.find("PID=");
+    ASSERT_NE(marker, std::string::npos)
+        << "stdout: " << result.stdout_output;
+    const pid_t child =
+        static_cast<pid_t>(std::atoi(result.stdout_output.c_str() + marker + 4));
+    ASSERT_GT(child, 0);
+
+    // Poll briefly: the pid lingers as a zombie until its new parent reaps it.
+    // A survivor would still be sleeping 971 seconds, so a short bound
+    // separates the two cases cleanly.
+    bool alive = true;
+    for (int attempt = 0; attempt < 40 && alive; ++attempt) {
+        if (kill(child, 0) != 0) {
+            alive = false;
+            break;
+        }
+        std::this_thread::sleep_for(std::chrono::milliseconds(50));
+    }
+    EXPECT_FALSE(alive) << "orphaned child " << child << " survived the timeout";
 #else
     GTEST_SKIP() << "Windows needs a Job Object for tree kill (not implemented)";
 #endif

--- a/cpp/tests/test_process.cpp
+++ b/cpp/tests/test_process.cpp
@@ -160,3 +160,289 @@ TEST(ProcessRunnerTest, NoTimeoutMode) {
     EXPECT_FALSE(result.timedOut);
     EXPECT_NE(result.stdout_output.find("hello"), std::string::npos);
 }
+
+// ---------------------------------------------------------------------------
+// ShellSession — state that survives between commands
+// ---------------------------------------------------------------------------
+
+#include <filesystem>
+#include <map>
+
+namespace fs = std::filesystem;
+
+namespace {
+
+#ifdef _WIN32
+const char* PRINT_CWD   = "cd";
+const char* SET_VAR     = "set GAIA_SESSION_VAR=persisted_9876";
+const char* PRINT_VAR   = "echo %GAIA_SESSION_VAR%";
+#else
+const char* PRINT_CWD   = "pwd";
+const char* SET_VAR     = "export GAIA_SESSION_VAR=persisted_9876";
+const char* PRINT_VAR   = "echo $GAIA_SESSION_VAR";
+#endif
+
+std::string changeDirTo(const fs::path& dir) {
+#ifdef _WIN32
+    return "cd /d \"" + dir.string() + "\"";
+#else
+    return "cd \"" + dir.string() + "\"";
+#endif
+}
+
+class ShellSessionTest : public ::testing::Test {
+protected:
+    fs::path dirA_;
+    fs::path dirB_;
+
+    void SetUp() override {
+        fs::path root = fs::temp_directory_path() / "gaia_shell_session_test";
+        std::error_code ec;
+        fs::remove_all(root, ec);
+        dirA_ = root / "alpha_dir";
+        dirB_ = root / "beta_dir";
+        fs::create_directories(dirA_);
+        fs::create_directories(dirB_);
+    }
+
+    void TearDown() override {
+        std::error_code ec;
+        fs::remove_all(fs::temp_directory_path() / "gaia_shell_session_test", ec);
+    }
+};
+
+} // namespace
+
+TEST_F(ShellSessionTest, CwdPersistsBetweenCalls) {
+    ShellSession session;
+
+    auto moved = session.run(changeDirTo(dirA_), 10000);
+    EXPECT_EQ(moved.exitCode, 0);
+
+    auto pwd = session.run(PRINT_CWD, 10000);
+    EXPECT_EQ(pwd.exitCode, 0);
+    EXPECT_NE(pwd.stdout_output.find("alpha_dir"), std::string::npos)
+        << "stdout: " << pwd.stdout_output;
+    EXPECT_NE(session.cwd().find("alpha_dir"), std::string::npos);
+}
+
+TEST_F(ShellSessionTest, ExportedVariablePersists) {
+    ShellSession session;
+
+    EXPECT_EQ(session.run(SET_VAR, 10000).exitCode, 0);
+
+    auto echoed = session.run(PRINT_VAR, 10000);
+    EXPECT_EQ(echoed.exitCode, 0);
+    EXPECT_NE(echoed.stdout_output.find("persisted_9876"), std::string::npos)
+        << "stdout: " << echoed.stdout_output;
+
+    const auto env = session.environment();
+    ASSERT_EQ(env.count("GAIA_SESSION_VAR"), 1u);
+    EXPECT_EQ(env.at("GAIA_SESSION_VAR"), "persisted_9876");
+}
+
+TEST_F(ShellSessionTest, CwdAndVariablesCombineAcrossThreeCalls) {
+    ShellSession session;
+
+    session.run(changeDirTo(dirA_) + " && " + SET_VAR, 10000);
+    auto result = session.run(std::string(PRINT_CWD) + " && " + PRINT_VAR, 10000);
+
+    EXPECT_EQ(result.exitCode, 0);
+    EXPECT_NE(result.stdout_output.find("alpha_dir"), std::string::npos);
+    EXPECT_NE(result.stdout_output.find("persisted_9876"), std::string::npos);
+}
+
+TEST_F(ShellSessionTest, DoesNotMutateTheCallingProcess) {
+    // The bug ProcessRunner::run(cwd, env) has: process-wide chdir/setenv.
+    const fs::path before = fs::current_path();
+
+    ShellSession session;
+    session.run(changeDirTo(dirA_) + " && " + SET_VAR, 10000);
+
+    EXPECT_EQ(fs::current_path(), before);
+    EXPECT_EQ(std::getenv("GAIA_SESSION_VAR"), nullptr);
+}
+
+TEST_F(ShellSessionTest, SessionsAreIndependent) {
+    ShellSession first;
+    ShellSession second;
+
+    first.run(changeDirTo(dirA_), 10000);
+    second.run(changeDirTo(dirB_), 10000);
+
+    EXPECT_NE(first.run(PRINT_CWD, 10000).stdout_output.find("alpha_dir"),
+              std::string::npos);
+    EXPECT_NE(second.run(PRINT_CWD, 10000).stdout_output.find("beta_dir"),
+              std::string::npos);
+}
+
+TEST_F(ShellSessionTest, SetCwdAndSetEnvSeedTheSession) {
+    ShellSession session;
+
+    ASSERT_TRUE(session.setCwd(dirB_.string()));
+    session.setEnv("GAIA_SEEDED_VAR", "seed_value_42");
+
+    auto result = session.run(std::string(PRINT_CWD) + " && " +
+#ifdef _WIN32
+                                  "echo %GAIA_SEEDED_VAR%",
+#else
+                                  "echo $GAIA_SEEDED_VAR",
+#endif
+                              10000);
+
+    EXPECT_NE(result.stdout_output.find("beta_dir"), std::string::npos);
+    EXPECT_NE(result.stdout_output.find("seed_value_42"), std::string::npos);
+
+    EXPECT_FALSE(session.setCwd((dirB_ / "does_not_exist").string()));
+}
+
+TEST_F(ShellSessionTest, ResetRestoresTheStartingState) {
+    ShellSession session;
+    const std::string start = session.cwd();
+
+    session.run(changeDirTo(dirA_) + " && " + SET_VAR, 10000);
+    ASSERT_NE(session.cwd(), start);
+
+    session.reset();
+    EXPECT_EQ(session.cwd(), start);
+    EXPECT_TRUE(session.environment().empty());
+
+    auto echoed = session.run(PRINT_VAR, 10000);
+    EXPECT_EQ(echoed.stdout_output.find("persisted_9876"), std::string::npos);
+}
+
+TEST_F(ShellSessionTest, ExitCodeStderrAndOutputCapAreUnchanged) {
+    ShellSession session;
+
+    auto failed = session.run(FAIL_CMD, 10000);
+    EXPECT_NE(failed.exitCode, 0);
+
+    auto errored = session.run(STDERR_CMD, 10000);
+    EXPECT_NE(errored.stderr_output.find("error_msg"), std::string::npos);
+
+    const size_t capBytes = 256;
+    auto capped = session.run(LARGE_OUTPUT, 30000, capBytes);
+    EXPECT_LE(capped.stdout_output.size(), capBytes);
+    EXPECT_FALSE(capped.stdout_output.empty());
+}
+
+TEST_F(ShellSessionTest, TimeoutStillKillsTheCommand) {
+#ifdef _WIN32
+    const char* sleepCmd = "ping -n 60 127.0.0.1 >nul";
+#else
+    const char* sleepCmd = "sleep 60";
+#endif
+    ShellSession session;
+    auto result = session.run(sleepCmd, 1000);
+    EXPECT_TRUE(result.timedOut);
+}
+
+TEST_F(ShellSessionTest, EmptyCommandFailsGracefully) {
+    ShellSession session;
+    auto result = session.run("", 10000);
+
+    EXPECT_EQ(result.exitCode, -1);
+    EXPECT_FALSE(result.stderr_output.empty());
+}
+
+TEST_F(ShellSessionTest, StateBookkeepingDoesNotLeakIntoOutput) {
+    ShellSession session;
+    auto result = session.run(ECHO_HELLO, 10000);
+
+    EXPECT_NE(result.stdout_output.find("hello"), std::string::npos);
+    // The cwd/env probe writes to a side file, never to the captured streams.
+    EXPECT_EQ(result.stdout_output.find("GAIA-ENV"), std::string::npos);
+    EXPECT_EQ(result.stdout_output.find("PATH="), std::string::npos);
+}
+
+TEST_F(ShellSessionTest, SharedSessionIsProcessWide) {
+    ShellSession::shared().reset();
+    ShellSession::shared().run(changeDirTo(dirA_), 10000);
+    EXPECT_NE(ShellSession::shared().cwd().find("alpha_dir"), std::string::npos);
+    ShellSession::shared().reset();
+}
+
+// --- Regressions: the session must not be corruptible by command output ----
+
+TEST_F(ShellSessionTest, MultiLineExportedValueDoesNotFabricateVariables) {
+#ifndef _WIN32
+    // A value containing a line that looks like an assignment must stay part
+    // of that value. Parsing it as a second variable would let a command's
+    // data become session configuration — `PATH=/tmp/evil` on its own line
+    // would hijack PATH for every later command.
+    ShellSession session;
+    session.run("export MULTI='line1\nINJECTED=pwned\nline3'", 10000);
+
+    const auto env = session.environment();
+    EXPECT_EQ(env.count("INJECTED"), 0u);
+    ASSERT_EQ(env.count("MULTI"), 1u);
+    EXPECT_EQ(env.at("MULTI"), "line1\nINJECTED=pwned\nline3");
+
+    auto echoed = session.run("printf '%s' \"$MULTI\"", 10000);
+    EXPECT_NE(echoed.stdout_output.find("line3"), std::string::npos);
+#else
+    GTEST_SKIP() << "Windows environment values cannot contain newlines";
+#endif
+}
+
+TEST_F(ShellSessionTest, VariableWithAnUnusableNameDoesNotCorruptItsNeighbour) {
+#ifndef _WIN32
+    // Stands in for Windows' `ProgramFiles(x86)`, which sorts right next to
+    // `ProgramFiles` and used to be glued onto it.
+    ShellSession session;
+    session.run("export GAIA_NEIGHBOUR=intact", 10000);
+    session.run("env 'ZZ-BAD=hello' true", 10000);
+
+    const auto env = session.environment();
+    ASSERT_EQ(env.count("GAIA_NEIGHBOUR"), 1u);
+    EXPECT_EQ(env.at("GAIA_NEIGHBOUR"), "intact");
+    for (const auto& kv : env) {
+        EXPECT_EQ(kv.second.find("ZZ-BAD"), std::string::npos)
+            << kv.first << " = " << kv.second;
+    }
+#else
+    GTEST_SKIP() << "POSIX-only stand-in for the Windows name case";
+#endif
+}
+
+TEST_F(ShellSessionTest, TrailingBackslashCannotSpliceIntoBookkeeping) {
+    // The command lives in its own file, so a dangling line continuation
+    // cannot swallow the framework's own lines.
+    ShellSession session;
+    auto result = session.run(std::string(ECHO_HELLO) + " \\", 10000);
+
+    EXPECT_NE(result.stdout_output.find("hello"), std::string::npos);
+    EXPECT_EQ(result.stdout_output.find("gaia_rc"), std::string::npos)
+        << "stdout: " << result.stdout_output;
+    EXPECT_EQ(result.stdout_output.find("GAIA_RC"), std::string::npos);
+    EXPECT_EQ(result.exitCode, 0);
+}
+
+TEST_F(ShellSessionTest, InteractiveCommandDoesNotHangOnStdin) {
+#ifdef _WIN32
+    const char* readsStdin = "more";
+#else
+    const char* readsStdin = "cat";
+#endif
+    // stdin is /dev/null, so a command waiting for input returns immediately
+    // instead of burning the whole timeout.
+    ShellSession session;
+    auto result = session.run(readsStdin, 10000);
+    EXPECT_FALSE(result.timedOut);
+}
+
+TEST_F(ShellSessionTest, TimeoutKillsTheWholeProcessTree) {
+#ifndef _WIN32
+    // A build or test command spawns children; killing only the shell leaves
+    // them running, which is exactly the case a persistent shell is for.
+    ShellSession session;
+    auto result = session.run("sleep 971 & wait", 1000);
+    ASSERT_TRUE(result.timedOut);
+
+    auto probe = ProcessRunner::run("pgrep -f 'sleep 971' | wc -l", 10000);
+    EXPECT_NE(probe.stdout_output.find('0'), std::string::npos)
+        << "orphaned child survived: " << probe.stdout_output;
+#else
+    GTEST_SKIP() << "Windows needs a Job Object for tree kill (not implemented)";
+#endif
+}

--- a/cpp/tests/test_process.cpp
+++ b/cpp/tests/test_process.cpp
@@ -181,10 +181,16 @@ namespace fs = std::filesystem;
 namespace {
 
 #ifdef _WIN32
+// The session runs commands as a batch script, not as a prompt command line,
+// so a for-loop variable is written %%i here where ProcessRunner's
+// LARGE_OUTPUT (handed straight to `cmd /c`) writes %i. See ShellSession's
+// header: %VAR% expansion is identical, %%-loop variables and %1 are not.
+const char* SESSION_LARGE_OUTPUT = "for /L %%i in (1,1,5000) do @echo line_%%i";
 const char* PRINT_CWD   = "cd";
 const char* SET_VAR     = "set GAIA_SESSION_VAR=persisted_9876";
 const char* PRINT_VAR   = "echo %GAIA_SESSION_VAR%";
 #else
+const char* SESSION_LARGE_OUTPUT = LARGE_OUTPUT;
 const char* PRINT_CWD   = "pwd";
 const char* SET_VAR     = "export GAIA_SESSION_VAR=persisted_9876";
 const char* PRINT_VAR   = "echo $GAIA_SESSION_VAR";
@@ -329,9 +335,27 @@ TEST_F(ShellSessionTest, ExitCodeStderrAndOutputCapAreUnchanged) {
     EXPECT_NE(errored.stderr_output.find("error_msg"), std::string::npos);
 
     const size_t capBytes = 256;
-    auto capped = session.run(LARGE_OUTPUT, 30000, capBytes);
+    auto capped = session.run(SESSION_LARGE_OUTPUT, 30000, capBytes);
     EXPECT_LE(capped.stdout_output.size(), capBytes);
     EXPECT_FALSE(capped.stdout_output.empty());
+}
+
+TEST_F(ShellSessionTest, VariableReferencesInACommandStillExpand) {
+    // The session's own variables must be usable by the command that follows.
+    // This is the expansion syntax that behaves identically on both platforms
+    // and is by far the common case.
+    ShellSession session;
+    session.setEnv("GAIA_EXPAND_ME", "expanded_value_77");
+
+#ifdef _WIN32
+    auto result = session.run("echo %GAIA_EXPAND_ME%", 10000);
+#else
+    auto result = session.run("echo $GAIA_EXPAND_ME", 10000);
+#endif
+
+    EXPECT_EQ(result.exitCode, 0);
+    EXPECT_NE(result.stdout_output.find("expanded_value_77"), std::string::npos)
+        << "stdout: " << result.stdout_output;
 }
 
 TEST_F(ShellSessionTest, TimeoutStillKillsTheCommand) {

--- a/docs/cpp/bash-agent.mdx
+++ b/docs/cpp/bash-agent.mdx
@@ -168,10 +168,10 @@ The following slash commands are planned but not yet available.
 
 | Tool | Policy | Description |
 |---|---|---|
-| `file_read` | ALLOW | Read file contents with optional line range |
-| `file_write` | CONFIRM | Write/create files (creates parent dirs) |
-| `file_edit` | CONFIRM | Surgical string replacement in files |
-| `file_search` | ALLOW | Search files by glob pattern and content |
+| `file_read` | ALLOW | Read file contents with optional line range; returns a `content_hash` that anchors later edits |
+| `file_write` | CONFIRM | Write/create files (creates parent dirs); rejected if the file changed since it was read |
+| `file_edit` | CONFIRM | Surgical string replacement; rejected on a stale read or a non-matching `old_string` — never a silent no-op |
+| `file_search` | ALLOW | Search files by glob pattern and content, honouring `.gitignore` |
 | `git_status` | ALLOW | Working tree status (porcelain) |
 | `git_diff` | ALLOW | Show working-tree or staged changes |
 | `git_log` | ALLOW | Recent commit history |
@@ -181,8 +181,38 @@ The following slash commands are planned but not yet available.
 
 | Tool | Policy | Description |
 |---|---|---|
-| `bash_execute` | CONFIRM | Run bash commands with timeout and output capture |
+| `bash_execute` | CONFIRM | Run bash commands with timeout and output capture, in a persistent shell (`cd` and exported variables carry over) |
 | `env_inspect` | ALLOW | Shell version, PATH, installed tools |
+
+### Guarantees the toolbelt provides
+
+Three properties are enforced by the tools themselves, because no prompt or
+`SKILL.md` can supply them:
+
+**An edit can never be applied to a file that moved underneath it.** `file_read`
+records the SHA-256 of the file it read. If `file_write` or `file_edit` later
+finds different bytes on disk — a formatter ran, a build step regenerated the
+file, another agent touched it — the change is refused with both hashes and the
+size delta named, and nothing is written. The recovery is always the same:
+re-read the file, then reissue the change.
+
+**A non-matching `old_string` is an error, not a success.** `file_edit` reports
+that nothing was replaced and the file is unchanged. When the text differs only
+in indentation, tabs, or line endings, the error says so, which is the mistake
+worth naming out of the ones a model actually makes.
+
+**`file_search` respects `.gitignore`.** Vendored dependencies and build output
+never reach the model's context. Skipped entries are counted in
+`ignored_skipped`, so a thin result set is explained rather than mysterious.
+The pattern syntax is real globbing: `*`, `?`, `[a-z]`, and `**` for
+directories. A pattern containing `/` matches the path relative to the search
+root; otherwise it matches the file name.
+
+**`bash_execute` runs in a persistent shell.** `cd build` and `export CC=clang`
+stay in effect for later commands, and the current directory comes back as
+`cwd`. The session applies both inside the child shell rather than by changing
+the agent process, so concurrent sessions cannot corrupt each other. Its
+`CONFIRM` policy and 32 KB output cap are unchanged.
 
 <Warning>
 The following tools are planned but not yet available in this release.

--- a/docs/cpp/bash-agent.mdx
+++ b/docs/cpp/bash-agent.mdx
@@ -211,8 +211,19 @@ root; otherwise it matches the file name.
 **`bash_execute` runs in a persistent shell.** `cd build` and `export CC=clang`
 stay in effect for later commands, and the current directory comes back as
 `cwd`. The session applies both inside the child shell rather than by changing
-the agent process, so concurrent sessions cannot corrupt each other. Its
-`CONFIRM` policy and 32 KB output cap are unchanged.
+the agent process, so concurrent sessions cannot corrupt each other. stdin is
+`/dev/null`, so a command that waits for input returns instead of burning the
+timeout, and on POSIX a timeout kills the whole process group rather than
+orphaning the build it spawned. Its `CONFIRM` policy and 32 KB output cap are
+unchanged.
+
+<Note>
+  On Windows the agent uses bash when one is present (Git Bash, MSYS, WSL). With
+  no POSIX shell it falls back to a `cmd.exe` script — keeping `cd` and `set`
+  requires running in one interpreter, and cmd offers that only to a script.
+  `%VAR%` expansion is unaffected, but a `for` loop variable is written `%%i`
+  rather than `%i` there.
+</Note>
 
 <Warning>
 The following tools are planned but not yet available in this release.

--- a/docs/cpp/testing.mdx
+++ b/docs/cpp/testing.mdx
@@ -38,8 +38,9 @@ Unit tests are built by default and run without an LLM server. They cover all tw
 | Security | `test_security.cpp` | `ToolPolicy`, `validatePath`, shell-arg sanitisation, `AllowedToolsStore` |
 | SSE parser | `test_sse_parser.cpp` | OpenAI-style streaming-event parsing and recovery |
 | Lemonade client | `test_lemonade_client.cpp` | Lemonade HTTP surface (health, models, chat completions) |
-| Process runner | `test_process.cpp` | Cross-platform subprocess execution and pipes |
-| File tools | `test_file_tools.cpp` | `file_read`/`file_write`/`file_edit`/`file_search` |
+| Process runner | `test_process.cpp` | Cross-platform subprocess execution and pipes; `ShellSession` cwd/environment persistence |
+| File tools | `test_file_tools.cpp` | `file_read`/`file_write`/`file_edit`/`file_search`, stale-write rejection, ignore-aware search |
+| Ignore rules | `test_ignore.cpp` | `globMatch` patterns and `.gitignore` evaluation |
 | Git tools | `test_git_tools.cpp` | `git_status`/`git_diff`/`git_log`/`git_show` |
 | Session store | `test_session.cpp` | Session persistence (save/list/resume) |
 | REPL | `test_repl.cpp` | Interactive REPL loop and slash-command parsing |


### PR DESCRIPTION
An agent using the C++ file tools could silently corrupt a file: `file_edit` was a plain string replace with no staleness check, so an edit issued against a file that had changed since it was read clobbered it, and a non-matching `old_string` reported nothing at all. `file_search` returned everything under `node_modules/` and `build/`, and `bash_execute` forgot `cd` and every exported variable between calls. Now an edit against a diverged file is rejected with both content hashes and the size delta named, a non-matching `old_string` says the file is unchanged and why, search honours `.gitignore` (searching `cpp/` for `*.h` returns 25 project headers instead of every header under the ignored build tree), and the shell keeps its working directory and environment across commands. None of these are things a `SKILL.md` can supply — they are properties of the tool implementation, which is the point of plan decision 9.

`bash_execute` keeps its `CONFIRM` policy and 32 KB output cap; the persistent shell preserves state, it does not widen what may run. The three are shaped so a clangd-backed `lsp` tool slots in beside them later without a rewrite — it records its `WorkspaceEdit`s through the same `FileStateTracker` and asks the same `GitignoreMatcher` which files belong to the project. The headers say so.

## Test plan

Built and run on macOS-arm64 per `cpp/README.md` (`cmake -B build -DCMAKE_BUILD_TYPE=Release && cmake --build build`).

- [x] `ctest --test-dir build` — **522/522 pass** (463 before this change, +59 new)
- [x] The 22 existing `test_file_tools` cases and 11 existing `test_process` cases pass with their bodies unchanged
- [x] Stable under `./build/tests_mock --gtest_shuffle --gtest_repeat=3` (this is how the "read → delete → re-create is blocked forever" bug was found)
- [x] Driven end-to-end through the real binary, not just unit tests: `gaia-bash --mcp` with `tools/call`, verifying a `cd` + `export` in one call is visible in the next, that `file_search` skips `node_modules/`, and that an edit issued after a third party rewrites the file is rejected with the file left untouched

```
$ ctest --test-dir build
100% tests passed out of 522
Total Test time (real) =  41.34 sec

$ ./build/tests_mock --gtest_filter='FileToolsTest.*:FileToolsHardeningTest.*:ProcessRunnerTest.*:ShellSessionTest.*:GlobMatchTest.*:GitignoreTest.*'
[----------] 11 tests from ProcessRunnerTest (1066 ms total)
[----------] 17 tests from ShellSessionTest (2322 ms total)
[----------] 22 tests from FileToolsTest (7 ms total)
[----------] 25 tests from FileToolsHardeningTest (16 ms total)
[----------]  7 tests from GlobMatchTest (0 ms total)
[----------] 10 tests from GitignoreTest (2 ms total)
[==========] 92 tests from 6 test suites ran. (3869 ms total)
[  PASSED  ] 92 tests.
```

To reproduce the end-to-end check:

```bash
printf '%s\n' \
'{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"t","version":"1"}}}' \
'{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"bash_execute","arguments":{"command":"cd /tmp && export BUILD_MODE=release"}}}' \
'{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"bash_execute","arguments":{"command":"pwd; echo mode=$BUILD_MODE"}}}' \
| ./build/gaia-bash --mcp
# id 3 → stdout "/tmp\nmode=release\n", cwd "/tmp"
```

## Notes for the reviewer

An adversarial review pass found six real defects in the first cut, all fixed here and each covered by a regression test that fails without the fix — a multi-line exported value fabricating a second variable, a command ending in `\` splicing into the framework's own bookkeeping, `file_read` hashing a *different* read than the one it returned to the model, exponential quote growth in the Windows batch path, `ProgramFiles(x86)` corrupting its alphabetical neighbour on every 64-bit Windows box, and a CRLF file becoming un-editable. The SHA-256 implementation was differentially tested against `hashlib` at every padding boundary and the gitignore evaluator against real `git check-ignore` over 25 rule sets; the one divergence from git is that a `!` rule can re-include a file under an ignored directory, which is the safe direction and is documented in `ignore.h`.

Windows paths are reasoned about but untested — no Windows machine was available.

**CI:** `C++ Integration Tests (STX)` is currently red on all cpp PRs from a broken CMake cache on the self-hosted runner (#2817, fix in flight). If that is the only red check and the log shows `Could not find CMAKE_ROOT`, it is not from this PR.

Closes #2810
