### PR TITLE
fix(email): a conversation now survives its turns — session_id on /query

### DIFF
--- a/docs/guides/email-integration.mdx
+++ b/docs/guides/email-integration.mdx
@@ -394,7 +394,7 @@ curl -s -X POST http://127.0.0.1:4200/v1/email/triage \
 
 ```json
 {
-  "schema_version": "2.11",
+  "schema_version": "2.12",
   "request_kind": "single",
   "result": {
     "category": "URGENT",

--- a/docs/guides/email.mdx
+++ b/docs/guides/email.mdx
@@ -572,7 +572,7 @@ isolated, and dogfoods the exact binary shipped to integrators.
 `GAIA_EMAIL_AGENT_MODE` only selects which *process* answers (`user` default /
 `dev`); there is no in-process fallback. Two surfaces run through it:
 
-- **The `/v1/email/*` REST surface** — the full REST contract (schema 2.11; init
+- **The `/v1/email/*` REST surface** — the full REST contract (schema 2.12; init
   readiness probe + provisioning, triage,
   batch triage, search, inbox pre-scan, scheduled daily briefing, draft/send +
   confirm — attachments included, archive/unarchive, quarantine/unquarantine,
@@ -603,7 +603,7 @@ from the one already running is a loud conflict (stop it first), never a silent
 restart.
 
 **Chat tool surface (in-app email agent):** the sidecar-backed chat agent exposes
-the tools the REST contract (schema 2.11) serves today — inbox pre-scan, search,
+the tools the REST contract (schema 2.12) serves today — inbox pre-scan, search,
 calendar view, and archive + undo. Tools that have no REST route yet (labels,
 stars, mark-read, move, trash/delete, summarize, profile, preferences, forward,
 send, scheduled send / snooze) are not exposed in the chat agent until their

--- a/docs/spec/agent-ui-query-sse-contract.md
+++ b/docs/spec/agent-ui-query-sse-contract.md
@@ -65,7 +65,8 @@ net-new agent instrumentation.
   ],
   "model": "Gemma-4-E4B-it-GGUF",
   "provider": "lemonade",
-  "max_steps": 20
+  "max_steps": 20,
+  "session_id": "3c1b9e2a-...-uuidv4"
 }
 ```
 
@@ -80,6 +81,7 @@ net-new agent instrumentation.
 | `provider` | string | no | LLM provider override (`lemonade` / `claude` / `openai`). Omitted ⇒ sidecar default. |
 | `max_steps` | integer ≥ 1 | no | Agent-loop step ceiling. Omitted ⇒ the sidecar's configured default. |
 | `can_answer_questions` | boolean | no | Whether **this caller** can render a `needs_input` event and POST the answer (§5.1). **Send only to a peer at contract ≥ 2.6** — an older sidecar 422s the unknown field (see §7). Defaults to **false** — the safe answer. A caller that cannot answer would otherwise park the run until the question times out, which is indistinguishable from a hang. When false, a step that would ask instead fails immediately with what the user should do on that surface. |
+| `session_id` | string, `^[A-Za-z0-9_-]{1,128}$` | no | Opaque conversation id, host-minted once per conversation and reused across turns (#2829). **Send only to a peer at contract ≥ 2.12** — an older sidecar 422s the unknown field (see §7). Omitted ⇒ today's stateless behaviour: a throwaway agent per call. Present ⇒ the run resolves the SAME agent every other turn on this id used, so a reference to something an earlier turn surfaced (e.g. "reply to number 1") can resolve. See §2.4. |
 
 ```jsonc
 // JSON Schema (draft 2020-12) — request body
@@ -106,7 +108,8 @@ net-new agent instrumentation.
     "model":     { "type": "string" },
     "provider":  { "type": "string" },
     "max_steps": { "type": "integer", "minimum": 1 },
-    "can_answer_questions": { "type": "boolean", "default": false }
+    "can_answer_questions": { "type": "boolean", "default": false },
+    "session_id": { "type": "string", "pattern": "^[A-Za-z0-9_-]{1,128}$" }
   }
 }
 ```
@@ -126,6 +129,18 @@ The host owns the transcript (§0.9) and passes the relevant slice as `context`.
 The sidecar stays **stateless** and never reads other sessions back over the
 `/host/v1/*` callback (§0.11 scoping forbids it anyway). A pushed slice and a
 pulled one therefore can't disagree.
+
+**Unless `session_id` is sent (#2829, schema 2.12).** Then the run resolves a
+real, persistent agent keyed on that id instead of a throwaway one, so
+whatever the agent itself accumulates outside `conversation_history` (e.g. a
+just-surfaced reference an in-process tool cached) survives to the next turn.
+`context` is still pushed and still REPLACES the agent's
+`conversation_history` every turn — it is never read back from the sidecar —
+so the two mechanisms complement rather than duplicate each other: `context`
+is the host-owned transcript, the session is the agent's own working state.
+A `session_id` the sidecar has never seen (e.g. it restarted mid-conversation
+— the session registry is in-memory) is surfaced as a one-time `status`
+event, never a silent cold start.
 
 ---
 

--- a/hub/agents/email/npm/CHANGELOG.md
+++ b/hub/agents/email/npm/CHANGELOG.md
@@ -6,6 +6,13 @@ behind any entry — API shapes, endpoints, and version semantics — see
 
 ## Unreleased
 
+- **`query()` can now carry a conversation forward.** `EmailQueryRequest`
+  gains an optional `session_id`: set it once and reuse it on every turn of
+  a conversation (e.g. `crypto.randomUUID()`), and the sidecar resolves the
+  SAME agent each time instead of a throwaway one per call — so a
+  follow-up referring to something an earlier turn surfaced has something
+  to resolve against. Leave it unset and nothing changes (#2829, schema
+  2.12).
 - **One inbox triage card instead of two that disagreed.** Asking the agent
   to triage your inbox used to draw two summary boxes from two separate scans
   at different depths — one might say "nothing needs you" while the other,

--- a/hub/agents/email/npm/SPEC.md
+++ b/hub/agents/email/npm/SPEC.md
@@ -2,7 +2,7 @@
 
 Detailed reference for `@amd-gaia/agent-email`. For a quick start, see
 [`README.md`](./README.md); for an AI-assisted integration walkthrough, see
-[`SKILL.md`](./SKILL.md). This client pins `SCHEMA_VERSION` **2.11**, matching
+[`SKILL.md`](./SKILL.md). This client pins `SCHEMA_VERSION` **2.12**, matching
 the sidecar's current contract — every schema bump since 2.4 has been additive
 (see `contract.py`'s own per-version changelog for the full log), so nothing
 here is a breaking upgrade for an existing integration.
@@ -836,10 +836,12 @@ Every schema since 2.4 has been additive over the one before it (see
 each): OAuth-forward `/v1/connections` (2.5, #2154), mid-run `needs_input` +
 `/query/{run_id}/respond` (2.6, #2469), the read-only attention view (2.8,
 #2582), `EmailPreScanResult.total_inbox` (2.9, #2638/#2643),
-`AttentionCoverage.message_errors` (2.10, #2716), and — current,
-`SCHEMA_VERSION = "2.11"` — the pre-scan `needs_you` worklist view
-(`NeedsYouItem[]`) plus the filtered-remainder `BulkSummary` (#2743, see
-below).
+`AttentionCoverage.message_errors` (2.10, #2716), the pre-scan `needs_you`
+worklist view (`NeedsYouItem[]`) plus the filtered-remainder `BulkSummary`
+(2.11, #2743, see below), and — current, `SCHEMA_VERSION = "2.12"` —
+`EmailQueryRequest.session_id`: an optional conversation id that resolves the
+same agent across turns sharing it, instead of a throwaway per-call agent
+(#2829).
 
 They are hand-written (vs. generated from `/openapi.json`) because the contract is
 small and version-gated, keeping the published package free of a typegen build

--- a/hub/agents/email/npm/src/lifecycle.ts
+++ b/hub/agents/email/npm/src/lifecycle.ts
@@ -322,7 +322,7 @@ function majorOf(version: string): number {
 }
 
 export interface VersionCheckOptions {
-  /** The apiVersion the client was built against. Default SCHEMA_VERSION ("2.11"). */
+  /** The apiVersion the client was built against. Default SCHEMA_VERSION ("2.12"). */
   expectedApiVersion?: string;
 }
 

--- a/hub/agents/email/npm/src/types.ts
+++ b/hub/agents/email/npm/src/types.ts
@@ -48,10 +48,15 @@
  * raw scan results. `NeedsYouItem.kind` reuses `AttentionItemKind` (extended
  * with "urgent" / "needs_response") rather than a new enum. No existing
  * field changed, so 2.4 consumers keep working (additive).
+ * Schema 2.12 (additive over 2.11, #2829): `EmailQueryRequest` gains an
+ * optional `session_id` — when the host sends it, the run resolves the SAME
+ * agent every other turn on that id used, instead of a throwaway per-call
+ * agent, so a reference to something an earlier turn surfaced can resolve.
+ * Omitted -> unchanged behaviour. No existing field changed (additive).
  */
 
 /** Frozen contract version echoed by the server's `/version` endpoint. */
-export const SCHEMA_VERSION = "2.11" as const;
+export const SCHEMA_VERSION = "2.12" as const;
 
 /**
  * The five-bucket triage taxonomy (schema 2.0 — contract.py: EmailCategory).
@@ -928,6 +933,16 @@ export interface EmailQueryRequest {
    * which then get an immediate actionable refusal instead.
    */
   can_answer_questions?: boolean;
+  /**
+   * Opaque conversation id (schema 2.12, #2829). Omitted -> a throwaway
+   * per-call agent, exactly like before. Present -> the run resolves the
+   * SAME agent every other turn on this id used, so a reference to
+   * something an earlier turn surfaced can resolve. Mint one per
+   * conversation and reuse it (e.g. `crypto.randomUUID()`) — the sidecar
+   * keys a real, stateful agent off it, so the caller controls
+   * conversation boundaries, not the server.
+   */
+  session_id?: string;
 }
 
 /** Progress narration (also carries folded step/thinking/plan lines). */

--- a/hub/agents/email/npm/test/browser-entry.test.ts
+++ b/hub/agents/email/npm/test/browser-entry.test.ts
@@ -58,7 +58,7 @@ describe("browser entry (./client)", () => {
 
   it("client-entry exports SCHEMA_VERSION and request/response types (runtime const)", async () => {
     const mod = await import("../src/client-entry.js");
-    expect(mod.SCHEMA_VERSION).toBe("2.11");
+    expect(mod.SCHEMA_VERSION).toBe("2.12");
   });
 
   it("client-entry does NOT export spawnSidecar (Node-only)", async () => {

--- a/hub/agents/email/python/CHANGELOG.md
+++ b/hub/agents/email/python/CHANGELOG.md
@@ -7,6 +7,19 @@ contract version is tracked separately as
 
 ## [Unreleased]
 
+### Added
+
+- **A follow-up like "reply to number 1" can now resolve (#2829).** `POST
+  /v1/email/query` accepts an optional `session_id`: send the same id on
+  every turn of a conversation and the run resolves the SAME agent each
+  time instead of a throwaway one per call, so a reference to something an
+  earlier turn surfaced has something to resolve against. Omit it and
+  nothing changes — this is additive (schema 2.12). Two turns can never run
+  on the same session at once (a second call while one is in flight is
+  rejected, `409`); a session id the sidecar has never seen arriving with
+  prior conversation history (e.g. the sidecar restarted mid-conversation)
+  gets a one-time notice instead of silently starting over.
+
 ### Fixed
 
 - **Asked about upcoming meetings or calendar invites, the agent could invent

--- a/hub/agents/email/python/CONTRACT.md
+++ b/hub/agents/email/python/CONTRACT.md
@@ -5,7 +5,7 @@
 > **Component:** Email request/response contract (issue #1262)
 > **Module:** `gaia_agent_email.contract`
 > **Validation:** pydantic v2
-> **Schema version:** `2.11`
+> **Schema version:** `2.12`
 
 ---
 
@@ -31,7 +31,7 @@ stable shape.
 - **Fail loudly.** Every model forbids unknown fields (`extra="forbid"`). An
   off-contract payload raises a `ValidationError` naming the offending field,
   never a silently coerced result.
-- **Versioned.** `SCHEMA_VERSION` (`"2.11"`) is pinned in the module and echoed in
+- **Versioned.** `SCHEMA_VERSION` (`"2.12"`) is pinned in the module and echoed in
   every request and response so a consumer can detect a breaking change.
 
 ### Version history
@@ -57,6 +57,7 @@ the npm package accepts any higher MINOR), so the one breaking change below —
 | `2.9` | Additive (#2638/#2643): `EmailPreScanResult` gains `total_inbox` (exact whole-INBOX message count, nullable). Pre-scan now scans read + unread INBOX mail, not unread-only (#2638) — `total_unread` alone stopped being an honest scan-coverage denominator once read mail counts too, so `total_inbox` is the new one. No existing field changed, so `2.8` consumers keep working. |
 | `2.10` | Additive (#2716): `AttentionCoverage` gains `message_errors` (list of `{message_id, error}`, nullable) and `degraded` can now be `true` for a message-level gap, not only a mailbox-level one. A Gmail rate-limit that survives retry now drops the one affected message instead of failing the whole attention scan — every other message in the same mailbox is still present in `items`. No existing field changed, so `2.9` consumers keep working. |
 | `2.11` | Additive (#2743): `EmailPreScanResult` gains `needs_you` (list of `NeedsYouItem`), `needs_you_total` (int), and `bulk` (`BulkSummary`, nullable) — a single worklist view built on top of the already-classified urgent/actionable/needs_review buckets, never a second independent classification pass. `NeedsYouItem.kind` reuses the published `AttentionItemKind` enum. No existing field changed, so `2.10` consumers keep working. |
+| `2.12` | Additive (#2829): `POST /v1/email/query` gains an optional `session_id`. When the host sends it, the run resolves the SAME agent every other turn on that id used, instead of a throwaway per-turn agent — so a reference to something an earlier turn surfaced (e.g. "reply to number 1") can resolve. Omitted -> byte-for-byte the old per-turn behaviour. No existing field changed, so `2.11` consumers keep working. |
 
 ---
 
@@ -90,7 +91,7 @@ test asserts byte-for-byte equality, so drift in either place fails CI.
 
 | Field | Type | Notes |
 |---|---|---|
-| `schema_version` | string | Contract version. Defaults to `"2.11"`. |
+| `schema_version` | string | Contract version. Defaults to `"2.12"`. |
 | `payload` | `SingleEmailInput` \| `ThreadInput` | Discriminated on `kind`. |
 | `context` | `TriageContext` \| null | Optional; biases categorization/summary. |
 
@@ -262,7 +263,7 @@ single-use send-confirmation token.
 
 ```json
 {
-  "schema_version": "2.11",
+  "schema_version": "2.12",
   "payload": {
     "kind": "single",
     "principal": { "name": "Alice Example", "email": "alice@example.com" },
@@ -284,7 +285,7 @@ single-use send-confirmation token.
 
 ```json
 {
-  "schema_version": "2.11",
+  "schema_version": "2.12",
   "request_kind": "single",
   "result": {
     "category": "NEEDS_RESPONSE",
@@ -311,7 +312,7 @@ single-use send-confirmation token.
 
 ```json
 {
-  "schema_version": "2.11",
+  "schema_version": "2.12",
   "payload": {
     "kind": "thread",
     "principal": { "name": "Alice Example", "email": "alice@example.com" },
@@ -344,7 +345,7 @@ single-use send-confirmation token.
 
 ```json
 {
-  "schema_version": "2.11",
+  "schema_version": "2.12",
   "request_kind": "thread",
   "result": {
     "category": "NEEDS_RESPONSE",
@@ -371,7 +372,7 @@ triages up to `MAX_BATCH_SIZE` (**100**) emails or threads in one request: an
 
 | Field | Type | Notes |
 |---|---|---|
-| `schema_version` | string | Contract version. Defaults to `"2.11"`. |
+| `schema_version` | string | Contract version. Defaults to `"2.12"`. |
 | `items` | `(SingleEmailInput \| ThreadInput)[]` | 1–100 inputs, discriminated on `kind` — the same item shapes the single endpoint's `payload` accepts. Over 100 → `422`. |
 | `context` | `TriageContext` \| null | Optional; applied to **all** items. |
 
@@ -404,7 +405,7 @@ The MCP surface mirrors this with a `triage_email_batch` tool (the single
 
 ```json
 {
-  "schema_version": "2.11",
+  "schema_version": "2.12",
   "items": [
     {
       "kind": "single",
@@ -434,7 +435,7 @@ The MCP surface mirrors this with a `triage_email_batch` tool (the single
 
 ```json
 {
-  "schema_version": "2.11",
+  "schema_version": "2.12",
   "results": [
     {
       "index": 0,
@@ -628,9 +629,10 @@ response = parse_response(raw_response_dict)  # -> EmailTriageResponse
 ## Stability contract
 
 - **Versioned additively.** Additive, backward-compatible changes (new optional
-  fields, new endpoints) keep older consumers working; `SCHEMA_VERSION` bumps only
-  on a breaking change (renamed/removed field, new required field, taxonomy
-  change) so consumers detect it. See the [version history](#version-history).
+  fields, new endpoints) keep older consumers working; `SCHEMA_VERSION` bumps the
+  MINOR on **every** change, additive or breaking (see [Version history](#version-history)
+  above), so a consumer that gates on the MINOR always sees a bump, not only
+  when something breaks.
 - **Categories never drift.** The five-bucket taxonomy is mirrored from the
   agent's `triage_heuristics.ALL_CATEGORIES`; a unit test asserts byte-for-byte
   equality, so a taxonomy change in either place fails CI.

--- a/hub/agents/email/python/gaia_agent_email/agent_routes.py
+++ b/hub/agents/email/python/gaia_agent_email/agent_routes.py
@@ -162,7 +162,7 @@ class _SessionRegistry:
                 self._last_used[session_id] = time.monotonic()
                 return existing
             if len(self._sessions) >= self._max_sessions:
-                evicted = self._pop_lru_unlocked_locked()
+                evicted = self._claim_lru_locked()
                 if evicted is None:
                     raise RuntimeError(
                         f"cannot start a new email session: {self._max_sessions} "
@@ -187,25 +187,37 @@ class _SessionRegistry:
             self._last_used[session_id] = time.monotonic()
             return session
 
-    def _pop_lru_unlocked_locked(self) -> Optional[_AgentSession]:
-        """Pop the least-recently-used session whose ``run_lock`` is free.
+    def _claim_lru_locked(self) -> Optional[_AgentSession]:
+        """Pop the least-recently-used session whose ``run_lock`` this call
+        successfully CLAIMS (acquires and never releases).
 
-        Caller holds ``self._lock``. Returns ``None`` when every session is
-        currently mid-turn — there is nothing safe to evict, so the caller
+        Caller holds ``self._lock``. Checking ``.locked()`` and popping
+        separately is a TOCTOU race: ``get_or_create`` hands out a session
+        reference and releases ``self._lock`` *before* the caller acquires
+        ``run_lock``, so a session can look unlocked at the instant this scans
+        it and only get its lock taken a moment later by the turn that is
+        about to run on it — evicting (and closing the DB of) a session an
+        in-flight caller is about to use. Acquiring here closes that window:
+        either this call wins the lock (the session was genuinely idle, and
+        it is now permanently claimed — dead — so nothing else can acquire
+        it), or it was already taken by a real turn and is skipped, exactly
+        like ``reap()`` below. Returns ``None`` when every session is
+        currently claimed/mid-turn — nothing is safe to evict, so the caller
         must refuse the new session rather than silently exceed the cap.
         """
-        candidates = [
-            sid for sid, s in self._sessions.items() if not s.run_lock.locked()
-        ]
-        if not candidates:
-            return None
-        oldest = min(candidates, key=lambda sid: self._last_used.get(sid, 0.0))
-        session = self._sessions.pop(oldest)
-        self._last_used.pop(oldest, None)
-        return session
+        by_age = sorted(self._sessions, key=lambda sid: self._last_used.get(sid, 0.0))
+        for sid in by_age:
+            if self._sessions[sid].run_lock.acquire(blocking=False):
+                session = self._sessions.pop(sid)
+                self._last_used.pop(sid, None)
+                return session
+        return None
 
     def reap(self) -> List[str]:
-        """Evict idle-expired sessions. Never one whose ``run_lock`` is held.
+        """Evict idle-expired sessions, CLAIMING each one's ``run_lock`` (see
+        ``_claim_lru_locked``) rather than merely checking it — the same
+        TOCTOU a plain ``.locked()`` check would leave open applies here: a
+        session that looks idle can be about to start a real turn.
 
         Teardown runs OUTSIDE the lock (mirrors ``delete()``) — ``close_db()``
         can block on I/O and must not stall every other session's
@@ -218,10 +230,12 @@ class _SessionRegistry:
                 sid
                 for sid, last in self._last_used.items()
                 if now - last > self._idle_ttl_seconds
-                and not self._sessions[sid].run_lock.locked()
             ]
             for sid in expired_ids:
-                session = self._sessions.pop(sid)
+                session = self._sessions[sid]
+                if not session.run_lock.acquire(blocking=False):
+                    continue  # a real turn is starting/running — never evict
+                self._sessions.pop(sid)
                 self._last_used.pop(sid, None)
                 evicted.append(session)
         for session in evicted:

--- a/hub/agents/email/python/gaia_agent_email/agent_routes.py
+++ b/hub/agents/email/python/gaia_agent_email/agent_routes.py
@@ -45,6 +45,7 @@ import asyncio
 import json
 import queue
 import threading
+import time
 from typing import Any, Dict, List, Optional, Tuple
 
 from fastapi import APIRouter, HTTPException
@@ -117,26 +118,60 @@ class _AgentSession:
         return self.run_lock.locked()
 
 
+#: Idle-only, generous by design (#2829): a session_id now roots an agent for
+#: the life of a conversation, not one call — the reaper exists to bound that,
+#: never to time out a conversation that is still being used.
+_DEFAULT_IDLE_TTL_SECONDS = 4 * 60 * 60  # 4 hours
+
+#: Each retained EmailTriageAgent holds a WAL sqlite connection, a second
+#: memory-store DB + embedder, and connector backends — generous, but not
+#: unbounded, for a single-tenant sidecar.
+_DEFAULT_MAX_SESSIONS = 100
+
+
 class _SessionRegistry:
     """Process-local map of session_id → :class:`_AgentSession`.
 
     In-process and single-tenant by design (the sidecar hosts one user's agent).
-    Agents are built lazily on first use and torn down on eviction.
+    Agents are built lazily on first use and torn down on eviction, idle
+    timeout, or the LRU cap — never while the session's ``run_lock`` is held.
     """
 
-    def __init__(self) -> None:
+    def __init__(
+        self,
+        *,
+        idle_ttl_seconds: float = _DEFAULT_IDLE_TTL_SECONDS,
+        max_sessions: int = _DEFAULT_MAX_SESSIONS,
+    ) -> None:
         self._sessions: Dict[str, _AgentSession] = {}
+        self._last_used: Dict[str, float] = {}
         self._lock = threading.Lock()
+        self._idle_ttl_seconds = idle_ttl_seconds
+        self._max_sessions = max_sessions
 
     def get(self, session_id: str) -> Optional[_AgentSession]:
         with self._lock:
             return self._sessions.get(session_id)
 
     def get_or_create(self, session_id: str, **config_kwargs: Any) -> _AgentSession:
+        self.reap()
+        evicted: Optional[_AgentSession] = None
         with self._lock:
             existing = self._sessions.get(session_id)
             if existing is not None:
+                self._last_used[session_id] = time.monotonic()
                 return existing
+            if len(self._sessions) >= self._max_sessions:
+                evicted = self._pop_lru_unlocked_locked()
+                if evicted is None:
+                    raise RuntimeError(
+                        f"cannot start a new email session: {self._max_sessions} "
+                        "sessions are already active and none are idle enough "
+                        "to evict. Close an idle terminal/window, or wait for "
+                        "one to finish its current turn, and retry."
+                    )
+        if evicted is not None:
+            _close_agent(evicted.agent)
         # Build outside the lock — construction is slow (memory init, backends)
         # and must not block other sessions. A racing creator for the SAME id is
         # resolved below by discarding the loser's agent.
@@ -145,14 +180,58 @@ class _SessionRegistry:
             existing = self._sessions.get(session_id)
             if existing is not None:
                 _close_agent(agent)
+                self._last_used[session_id] = time.monotonic()
                 return existing
             session = _AgentSession(session_id, agent)
             self._sessions[session_id] = session
+            self._last_used[session_id] = time.monotonic()
             return session
+
+    def _pop_lru_unlocked_locked(self) -> Optional[_AgentSession]:
+        """Pop the least-recently-used session whose ``run_lock`` is free.
+
+        Caller holds ``self._lock``. Returns ``None`` when every session is
+        currently mid-turn — there is nothing safe to evict, so the caller
+        must refuse the new session rather than silently exceed the cap.
+        """
+        candidates = [
+            sid for sid, s in self._sessions.items() if not s.run_lock.locked()
+        ]
+        if not candidates:
+            return None
+        oldest = min(candidates, key=lambda sid: self._last_used.get(sid, 0.0))
+        session = self._sessions.pop(oldest)
+        self._last_used.pop(oldest, None)
+        return session
+
+    def reap(self) -> List[str]:
+        """Evict idle-expired sessions. Never one whose ``run_lock`` is held.
+
+        Teardown runs OUTSIDE the lock (mirrors ``delete()``) — ``close_db()``
+        can block on I/O and must not stall every other session's
+        ``get_or_create`` while it runs.
+        """
+        now = time.monotonic()
+        evicted: List[_AgentSession] = []
+        with self._lock:
+            expired_ids = [
+                sid
+                for sid, last in self._last_used.items()
+                if now - last > self._idle_ttl_seconds
+                and not self._sessions[sid].run_lock.locked()
+            ]
+            for sid in expired_ids:
+                session = self._sessions.pop(sid)
+                self._last_used.pop(sid, None)
+                evicted.append(session)
+        for session in evicted:
+            _close_agent(session.agent)
+        return [s.session_id for s in evicted]
 
     def delete(self, session_id: str) -> bool:
         with self._lock:
             session = self._sessions.pop(session_id, None)
+            self._last_used.pop(session_id, None)
         if session is None:
             return False
         _close_agent(session.agent)

--- a/hub/agents/email/python/gaia_agent_email/contract.py
+++ b/hub/agents/email/python/gaia_agent_email/contract.py
@@ -136,7 +136,14 @@ CATEGORY_PERSONAL = "PERSONAL"
 # that a renderer maps to a sentence, so a filter description can't
 # silently go stale when the underlying heuristic changes. No existing
 # field changed, so 2.10 consumers keep working (additive MINOR).
-SCHEMA_VERSION = "2.11"
+# 2.12 is additive over 2.11 (#2829): ``POST /v1/email/query`` gains an
+# optional ``session_id`` — when the host sends it, the run resolves the
+# SAME agent every other turn on that id used (via the session-scoped
+# registry `agent_routes._SessionRegistry`) instead of a throwaway
+# per-turn agent, so a reference to something an earlier turn surfaced can
+# resolve. Omitted -> byte-for-byte the old per-turn behaviour. No existing
+# field changed, so 2.11 consumers keep working (additive MINOR).
+SCHEMA_VERSION = "2.12"
 
 # Maximum number of items in a single batch request. Protects the single-tenant
 # local model slot from runaway batches. Enforced via Pydantic max_length.

--- a/hub/agents/email/python/gaia_agent_email/query_routes.py
+++ b/hub/agents/email/python/gaia_agent_email/query_routes.py
@@ -594,69 +594,78 @@ async def query(request: QueryRequest) -> StreamingResponse:
                 detail=f"Failed to start the email agent for this query: {exc}",
             ) from exc
 
+    # Between acquiring session.run_lock (above) and the worker thread taking
+    # ownership of it, ANY failure in this block must release the lock and
+    # deregister the run — otherwise the session is wedged at 409 forever
+    # (mirrors agent_routes.py:651-701, which covers this exact span with one
+    # guard rather than patching each call site). run_registered tracks
+    # whether ``registry.add`` actually succeeded, so a run_id COLLISION
+    # (a real, unrelated in-flight run) is reported as its own 409 without
+    # deregistering that other run.
+    run_registered = False
     try:
         handler = SSEOutputHandler()
+        run = _QueryRun(request.run_id, agent, handler)
+        try:
+            registry.add(run)
+        except KeyError as exc:
+            raise HTTPException(
+                status_code=409,
+                detail=f"run_id {request.run_id!r} is already in flight.",
+            ) from exc
+        run_registered = True
+
+        # Push the transcript slice as the agent's conversation history (spec
+        # §2.4). REPLACES, never appends — the session-scoped agent already
+        # had whatever an earlier turn left in its OWN state (memory,
+        # connectors); only conversation_history is refreshed from what the
+        # host pushes, so a later change can't silently double-count turns.
+        agent.conversation_history = [
+            {"role": item.role, "content": item.content} for item in request.context
+        ]
+        agent.console = handler
+        # Read by ``question.ask``: a caller that cannot answer must be
+        # refused at the point of asking, not parked until it times out.
+        agent.can_answer_questions = bool(request.can_answer_questions)
+        # The base agent loop observes this at each step boundary
+        # (agent.py) — the cancel endpoint sets it so tool execution stops
+        # between steps.
+        agent._cancel_event = run.cancel_event
+
+        max_steps = request.max_steps
+        user_query = request.query
+
+        def _run_agent() -> None:
+            try:
+                if max_steps is not None:
+                    run.result = agent.process_query(user_query, max_steps=max_steps)
+                else:
+                    run.result = agent.process_query(user_query)
+            except Exception as exc:  # surface loudly as a terminal error event
+                logger.exception("email /query run failed for run_id=%s", run.run_id)
+                # Lemonade-down is the most common failure; emit actionable
+                # copy (never the raw urllib3/requests repr) while leaving
+                # genuinely unexpected errors verbatim (#2139).
+                handler._emit(
+                    {"type": "agent_error", "content": _terminal_error_detail(exc)}
+                )
+            finally:
+                handler.signal_done()
+                if session is not None:
+                    session.run_lock.release()
+
+        thread = threading.Thread(target=_run_agent, daemon=True)
+        thread.start()
     except Exception as exc:
-        # Setup failed before the worker thread could take ownership of
-        # run_lock — release it so the session isn't permanently wedged at
-        # 409 (mirrors agent_routes.py:694-701).
         if session is not None:
             session.run_lock.release()
+        if run_registered:
+            registry.remove(request.run_id)
+        if isinstance(exc, HTTPException):
+            raise
         raise HTTPException(
             status_code=500, detail=f"Failed to start the query run: {exc}"
         ) from exc
-
-    run = _QueryRun(request.run_id, agent, handler)
-    try:
-        registry.add(run)
-    except KeyError as exc:
-        if session is not None:
-            session.run_lock.release()
-        raise HTTPException(
-            status_code=409,
-            detail=f"run_id {request.run_id!r} is already in flight.",
-        ) from exc
-
-    # Push the transcript slice as the agent's conversation history (spec
-    # §2.4). REPLACES, never appends — the session-scoped agent already had
-    # whatever an earlier turn left in its OWN state (memory, connectors);
-    # only conversation_history is refreshed from what the host pushes, so a
-    # later change can't silently double-count turns.
-    agent.conversation_history = [
-        {"role": item.role, "content": item.content} for item in request.context
-    ]
-    agent.console = handler
-    # Read by ``question.ask``: a caller that cannot answer must be refused at
-    # the point of asking, not parked until the question times out.
-    agent.can_answer_questions = bool(request.can_answer_questions)
-    # The base agent loop observes this at each step boundary (agent.py) — the
-    # cancel endpoint sets it so tool execution stops between steps.
-    agent._cancel_event = run.cancel_event
-
-    max_steps = request.max_steps
-    user_query = request.query
-
-    def _run_agent() -> None:
-        try:
-            if max_steps is not None:
-                run.result = agent.process_query(user_query, max_steps=max_steps)
-            else:
-                run.result = agent.process_query(user_query)
-        except Exception as exc:  # surface loudly as a terminal error event
-            logger.exception("email /query run failed for run_id=%s", run.run_id)
-            # Lemonade-down is the most common failure; emit actionable copy
-            # (never the raw urllib3/requests repr) while leaving genuinely
-            # unexpected errors verbatim — see _terminal_error_detail (#2139).
-            handler._emit(
-                {"type": "agent_error", "content": _terminal_error_detail(exc)}
-            )
-        finally:
-            handler.signal_done()
-            if session is not None:
-                session.run_lock.release()
-
-    thread = threading.Thread(target=_run_agent, daemon=True)
-    thread.start()
 
     async def _stream():
         translator = CanonicalTranslator(request.run_id)

--- a/hub/agents/email/python/gaia_agent_email/query_routes.py
+++ b/hub/agents/email/python/gaia_agent_email/query_routes.py
@@ -544,25 +544,84 @@ async def query(request: QueryRequest) -> StreamingResponse:
     if request.model:
         config_kwargs["model_id"] = request.model
 
+    # session_id resolves through the SAME session-scoped registry the
+    # stateful /v1/email/agent/* surface uses (#2829), so the agent — and
+    # anything an earlier turn set on it — persists across turns on this id.
+    # Omitted -> today's behaviour exactly: a throwaway per-turn agent.
+    session: Optional[Any] = None
+    continuity_lost = False
+    if request.session_id is not None:
+        from gaia_agent_email import agent_routes
+
+        # A session_id the registry has never seen, arriving WITH prior
+        # context, means the sidecar restarted mid-conversation (the
+        # registry is in-memory) — surfaced below, never a silent cold
+        # start. A brand-new conversation (empty context) is not continuity
+        # loss: no session was ever expected to exist yet.
+        continuity_lost = (
+            agent_routes.registry.get(request.session_id) is None
+            and len(request.context) > 0
+        )
+        try:
+            session = await asyncio.to_thread(
+                agent_routes.registry.get_or_create,
+                request.session_id,
+                **config_kwargs,
+            )
+        except Exception as exc:  # construction/capacity failure → fail loud
+            raise HTTPException(
+                status_code=502,
+                detail=f"Failed to start the email agent for this query: {exc}",
+            ) from exc
+        # One turn at a time per session (mandatory — mirrors
+        # agent_routes.py:645-649): without this, agent.console /
+        # agent._cancel_event / agent._current_query are overwritten under a
+        # running worker thread, silently misrouting one caller's stream
+        # into another's. Reachable via the ordinary Esc-then-retype path,
+        # since cancellation is cooperative.
+        if not session.run_lock.acquire(blocking=False):
+            raise HTTPException(
+                status_code=409,
+                detail="A turn is already in progress for this session.",
+            )
+        agent = session.agent
+    else:
+        try:
+            agent = await asyncio.to_thread(build_query_agent, **config_kwargs)
+        except Exception as exc:  # construction failure → fail loud, before the stream
+            raise HTTPException(
+                status_code=502,
+                detail=f"Failed to start the email agent for this query: {exc}",
+            ) from exc
+
     try:
-        agent = await asyncio.to_thread(build_query_agent, **config_kwargs)
-    except Exception as exc:  # construction failure → fail loud, before the stream
+        handler = SSEOutputHandler()
+    except Exception as exc:
+        # Setup failed before the worker thread could take ownership of
+        # run_lock — release it so the session isn't permanently wedged at
+        # 409 (mirrors agent_routes.py:694-701).
+        if session is not None:
+            session.run_lock.release()
         raise HTTPException(
-            status_code=502,
-            detail=f"Failed to start the email agent for this query: {exc}",
+            status_code=500, detail=f"Failed to start the query run: {exc}"
         ) from exc
 
-    handler = SSEOutputHandler()
     run = _QueryRun(request.run_id, agent, handler)
     try:
         registry.add(run)
     except KeyError as exc:
+        if session is not None:
+            session.run_lock.release()
         raise HTTPException(
             status_code=409,
             detail=f"run_id {request.run_id!r} is already in flight.",
         ) from exc
 
-    # Push the transcript slice as the agent's conversation history (spec §2.4).
+    # Push the transcript slice as the agent's conversation history (spec
+    # §2.4). REPLACES, never appends — the session-scoped agent already had
+    # whatever an earlier turn left in its OWN state (memory, connectors);
+    # only conversation_history is refreshed from what the host pushes, so a
+    # later change can't silently double-count turns.
     agent.conversation_history = [
         {"role": item.role, "content": item.content} for item in request.context
     ]
@@ -593,6 +652,8 @@ async def query(request: QueryRequest) -> StreamingResponse:
             )
         finally:
             handler.signal_done()
+            if session is not None:
+                session.run_lock.release()
 
     thread = threading.Thread(target=_run_agent, daemon=True)
     thread.start()
@@ -602,6 +663,19 @@ async def query(request: QueryRequest) -> StreamingResponse:
         terminated = False
         last_write = time.monotonic()
         try:
+            if continuity_lost:
+                yield _sse(
+                    {
+                        "type": "status",
+                        "message": (
+                            "conversation continuity was lost — the agent "
+                            "restarted and does not remember earlier turns in "
+                            "this session. Continuing with the pushed "
+                            "context only."
+                        ),
+                    }
+                )
+                last_write = time.monotonic()
             while True:
                 try:
                     event = handler.event_queue.get_nowait()

--- a/hub/agents/email/python/gaia_agent_email/query_routes.py
+++ b/hub/agents/email/python/gaia_agent_email/query_routes.py
@@ -229,6 +229,19 @@ class QueryRequest(_Strict):
             "the user should do on this surface."
         ),
     )
+    session_id: Optional[str] = Field(
+        default=None,
+        pattern=r"^[A-Za-z0-9_-]{1,128}$",
+        description=(
+            "Opaque conversation id, minted by the host once per conversation "
+            "(#2829). Omitted -> a fresh throwaway agent per call, exactly like "
+            "before. Present -> the run resolves the SAME agent used by every "
+            "other turn on this id (via the session-scoped registry), so a "
+            "reference to something an earlier turn surfaced can resolve. "
+            "Constrained to the charset a dict key / URL path segment / log "
+            "line tolerates."
+        ),
+    )
 
     @field_validator("run_id")
     @classmethod

--- a/hub/agents/email/python/openapi.email.json
+++ b/hub/agents/email/python/openapi.email.json
@@ -349,7 +349,7 @@
             "type": "array"
           },
           "schema_version": {
-            "default": "2.11",
+            "default": "2.12",
             "description": "Contract version. Mismatch lets a consumer fail loudly.",
             "title": "Schema Version",
             "type": "string"
@@ -374,7 +374,7 @@
             "type": "array"
           },
           "schema_version": {
-            "default": "2.11",
+            "default": "2.12",
             "description": "Echoes the contract version.",
             "title": "Schema Version",
             "type": "string"
@@ -473,7 +473,7 @@
             "title": "Provider"
           },
           "schema_version": {
-            "default": "2.11",
+            "default": "2.12",
             "description": "Contract version. Mismatch lets a consumer fail loudly.",
             "title": "Schema Version",
             "type": "string"
@@ -660,7 +660,7 @@
             "title": "Location"
           },
           "schema_version": {
-            "default": "2.11",
+            "default": "2.12",
             "description": "Echoes the contract version.",
             "title": "Schema Version",
             "type": "string"
@@ -700,7 +700,7 @@
             "type": "string"
           },
           "schema_version": {
-            "default": "2.11",
+            "default": "2.12",
             "description": "Echoes the contract version.",
             "title": "Schema Version",
             "type": "string"
@@ -731,7 +731,7 @@
             "type": "array"
           },
           "schema_version": {
-            "default": "2.11",
+            "default": "2.12",
             "description": "Echoes the contract version.",
             "title": "Schema Version",
             "type": "string"
@@ -767,7 +767,7 @@
             "title": "Provider"
           },
           "schema_version": {
-            "default": "2.11",
+            "default": "2.12",
             "description": "Contract version. Mismatch lets a consumer fail loudly.",
             "title": "Schema Version",
             "type": "string"
@@ -807,7 +807,7 @@
             "type": "boolean"
           },
           "schema_version": {
-            "default": "2.11",
+            "default": "2.12",
             "description": "Echoes the contract version.",
             "title": "Schema Version",
             "type": "string"
@@ -958,7 +958,7 @@
             "type": "string"
           },
           "schema_version": {
-            "default": "2.11",
+            "default": "2.12",
             "description": "Echoes the contract version.",
             "title": "Schema Version",
             "type": "string"
@@ -1071,7 +1071,7 @@
             "type": "string"
           },
           "schema_version": {
-            "default": "2.11",
+            "default": "2.12",
             "description": "Echoes the contract version.",
             "title": "Schema Version",
             "type": "string"
@@ -1101,7 +1101,7 @@
             "description": "The attention-view envelope."
           },
           "schema_version": {
-            "default": "2.11",
+            "default": "2.12",
             "description": "Echoes the contract version.",
             "title": "Schema Version",
             "type": "string"
@@ -1176,7 +1176,7 @@
             "type": "string"
           },
           "schema_version": {
-            "default": "2.11",
+            "default": "2.12",
             "description": "Echoes the contract version.",
             "title": "Schema Version",
             "type": "string"
@@ -1376,7 +1376,7 @@
             "type": "integer"
           },
           "schema_version": {
-            "default": "2.11",
+            "default": "2.12",
             "description": "Contract version. Mismatch lets a consumer fail loudly.",
             "title": "Schema Version",
             "type": "string"
@@ -1394,7 +1394,7 @@
             "description": "The pre-scan envelope."
           },
           "schema_version": {
-            "default": "2.11",
+            "default": "2.12",
             "description": "Echoes the contract version.",
             "title": "Schema Version",
             "type": "string"
@@ -1651,7 +1651,7 @@
             "type": "boolean"
           },
           "schema_version": {
-            "default": "2.11",
+            "default": "2.12",
             "description": "Echoes the contract version.",
             "title": "Schema Version",
             "type": "string"
@@ -1723,7 +1723,7 @@
             "title": "Query"
           },
           "schema_version": {
-            "default": "2.11",
+            "default": "2.12",
             "description": "Contract version. Mismatch lets a consumer fail loudly.",
             "title": "Schema Version",
             "type": "string"
@@ -1774,7 +1774,7 @@
             "title": "Query"
           },
           "schema_version": {
-            "default": "2.11",
+            "default": "2.12",
             "description": "Echoes the contract version.",
             "title": "Schema Version",
             "type": "string"
@@ -1995,7 +1995,7 @@
             "title": "Payload"
           },
           "schema_version": {
-            "default": "2.11",
+            "default": "2.12",
             "description": "Contract version. Mismatch lets a consumer fail loudly.",
             "title": "Schema Version",
             "type": "string"
@@ -2025,7 +2025,7 @@
             "description": "The structured analysis."
           },
           "schema_version": {
-            "default": "2.11",
+            "default": "2.12",
             "description": "Echoes the contract version.",
             "title": "Schema Version",
             "type": "string"
@@ -2191,7 +2191,7 @@
             "type": "integer"
           },
           "schema_version": {
-            "default": "2.11",
+            "default": "2.12",
             "description": "Echoes the contract version.",
             "title": "Schema Version",
             "type": "string"
@@ -2259,7 +2259,7 @@
             "type": "boolean"
           },
           "schema_version": {
-            "default": "2.11",
+            "default": "2.12",
             "description": "Echoes the contract version.",
             "title": "Schema Version",
             "type": "string"
@@ -2399,7 +2399,7 @@
             "type": "array"
           },
           "schema_version": {
-            "default": "2.11",
+            "default": "2.12",
             "description": "Echoes the contract version.",
             "title": "Schema Version",
             "type": "string"
@@ -3015,6 +3015,19 @@
             "description": "Host-minted streaming-run handle (UUIDv4). Cancellation (POST /v1/email/query/{run_id}/cancel) keys off it, so the run is cancellable from the instant the request is sent.",
             "title": "Run Id",
             "type": "string"
+          },
+          "session_id": {
+            "anyOf": [
+              {
+                "pattern": "^[A-Za-z0-9_-]{1,128}$",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Opaque conversation id, minted by the host once per conversation (#2829). Omitted -> a fresh throwaway agent per call, exactly like before. Present -> the run resolves the SAME agent used by every other turn on this id (via the session-scoped registry), so a reference to something an earlier turn surfaced can resolve. Constrained to the charset a dict key / URL path segment / log line tolerates.",
+            "title": "Session Id"
           }
         },
         "required": [
@@ -3337,7 +3350,7 @@
   "info": {
     "description": "REST surface for the GAIA Email Triage agent (/v1/email/*). Cross-implementation contract for the npm client and native builds.",
     "title": "GAIA Email Agent API",
-    "version": "2.11"
+    "version": "2.12"
   },
   "openapi": "3.1.0",
   "paths": {

--- a/hub/agents/email/python/specification.html
+++ b/hub/agents/email/python/specification.html
@@ -162,7 +162,7 @@ td:nth-child(3) {
 </head>
 <body>
 <h1>Email Triage Agent
-  <span class="version-badge">Contract schema_version: 2.11</span>
+  <span class="version-badge">Contract schema_version: 2.12</span>
 </h1>
 <p class="subtitle">
   REST endpoint specification derived from the frozen #1262 contract
@@ -499,7 +499,7 @@ td:nth-child(3) {
 </div>
 
 <div class="footer">
-  GAIA Email Triage Agent &mdash; schema_version 2.11 &mdash; amd-gaia.ai
+  GAIA Email Triage Agent &mdash; schema_version 2.12 &mdash; amd-gaia.ai
 </div>
 </body>
 </html>

--- a/hub/agents/email/python/tests/test_email_agent_routes.py
+++ b/hub/agents/email/python/tests/test_email_agent_routes.py
@@ -829,3 +829,124 @@ class TestWorkerDiesWithoutTerminalEvent:
 
         session = agent_routes.registry.get("s1")
         assert session is not None and not session.is_running()
+
+
+# ---------------------------------------------------------------------------
+# Idle-TTL reaper + LRU cap (#2829)
+#
+# session_id turned a per-turn local variable (refcount-freed) into a
+# permanent root reference in _sessions — each retained EmailTriageAgent
+# holds a WAL sqlite connection, a memory-store DB + embedder, and connector
+# backends. These operate on standalone _SessionRegistry() instances (no
+# HTTP, no shared module-global) so the clock can be controlled deterministically.
+# ---------------------------------------------------------------------------
+
+
+class TestSessionReaper:
+    def _registry(self, monkeypatch, **kwargs):
+        reg = agent_routes._SessionRegistry(**kwargs)
+        monkeypatch.setattr(
+            agent_routes, "build_session_agent", lambda **k: _FakeAgent(), raising=True
+        )
+        return reg
+
+    def test_idle_session_past_ttl_is_reaped(self, monkeypatch):
+        reg = self._registry(monkeypatch, idle_ttl_seconds=10)
+        clock = [1000.0]
+        monkeypatch.setattr(agent_routes.time, "monotonic", lambda: clock[0])
+
+        session = reg.get_or_create("s1")
+        clock[0] += 11
+        evicted = reg.reap()
+
+        assert evicted == ["s1"]
+        assert reg.get("s1") is None
+        assert session.agent.closed is True
+
+    def test_session_within_ttl_survives_a_reap_sweep(self, monkeypatch):
+        reg = self._registry(monkeypatch, idle_ttl_seconds=100)
+        clock = [1000.0]
+        monkeypatch.setattr(agent_routes.time, "monotonic", lambda: clock[0])
+
+        session = reg.get_or_create("s1")
+        clock[0] += 10
+        reg.reap()
+
+        assert reg.get("s1") is session
+
+    def test_locked_session_is_never_reaped_even_past_ttl(self, monkeypatch):
+        reg = self._registry(monkeypatch, idle_ttl_seconds=5)
+        clock = [1000.0]
+        monkeypatch.setattr(agent_routes.time, "monotonic", lambda: clock[0])
+
+        session = reg.get_or_create("s1")
+        session.run_lock.acquire()
+        try:
+            clock[0] += 1000
+            reg.reap()
+            assert reg.get("s1") is session
+        finally:
+            session.run_lock.release()
+
+    def test_get_or_create_touches_last_used_so_active_sessions_never_expire(
+        self, monkeypatch
+    ):
+        reg = self._registry(monkeypatch, idle_ttl_seconds=10)
+        clock = [1000.0]
+        monkeypatch.setattr(agent_routes.time, "monotonic", lambda: clock[0])
+
+        session = reg.get_or_create("s1")
+        for _ in range(3):
+            clock[0] += 9  # always under the TTL between touches
+            reg.get_or_create("s1")  # a "turn" — touches last_used
+        reg.reap()
+
+        assert reg.get("s1") is session
+
+    def test_lru_cap_evicts_the_oldest_unlocked_session(self, monkeypatch):
+        reg = self._registry(monkeypatch, idle_ttl_seconds=10_000, max_sessions=2)
+        clock = [1000.0]
+        monkeypatch.setattr(agent_routes.time, "monotonic", lambda: clock[0])
+
+        s1 = reg.get_or_create("s1")
+        clock[0] += 1
+        reg.get_or_create("s2")
+        clock[0] += 1
+        reg.get_or_create("s3")  # over cap -> evicts s1, the oldest unlocked
+
+        assert reg.get("s1") is None
+        assert s1.agent.closed is True
+        assert reg.get("s2") is not None
+        assert reg.get("s3") is not None
+
+    def test_lru_cap_raises_an_actionable_error_when_everything_is_locked(
+        self, monkeypatch
+    ):
+        reg = self._registry(monkeypatch, idle_ttl_seconds=10_000, max_sessions=1)
+        monkeypatch.setattr(agent_routes.time, "monotonic", lambda: 1000.0)
+
+        s1 = reg.get_or_create("s1")
+        s1.run_lock.acquire()
+        try:
+            with pytest.raises(RuntimeError, match="session"):
+                reg.get_or_create("s2")
+        finally:
+            s1.run_lock.release()
+        # Refused, not silently created past the cap.
+        assert reg.get("s2") is None
+
+    def test_delete_clears_last_used_so_a_reused_id_is_not_reaped_prematurely(
+        self, monkeypatch
+    ):
+        reg = self._registry(monkeypatch, idle_ttl_seconds=10)
+        clock = [1000.0]
+        monkeypatch.setattr(agent_routes.time, "monotonic", lambda: clock[0])
+
+        reg.get_or_create("s1")
+        reg.delete("s1")
+        clock[0] += 1
+        session = reg.get_or_create("s1")  # a brand new session under the same id
+        clock[0] += 5  # well under the TTL from the NEW session's creation
+        reg.reap()
+
+        assert reg.get("s1") is session

--- a/hub/agents/email/python/tests/test_email_agent_routes.py
+++ b/hub/agents/email/python/tests/test_email_agent_routes.py
@@ -863,6 +863,26 @@ class TestSessionReaper:
         assert reg.get("s1") is None
         assert session.agent.closed is True
 
+    def test_reaped_session_lock_is_claimed_so_a_racing_caller_fails_safe(
+        self, monkeypatch
+    ):
+        """TOCTOU pin (#2829 checkpoint 2): get_or_create hands back a
+        session reference and releases the registry lock BEFORE the caller
+        acquires run_lock. If reap() only checked `.locked()` instead of
+        claiming it, a racing caller already holding this exact reference
+        could still acquire run_lock and run against the now-closed agent.
+        The lock must be permanently unavailable once reaped."""
+        reg = self._registry(monkeypatch, idle_ttl_seconds=10)
+        clock = [1000.0]
+        monkeypatch.setattr(agent_routes.time, "monotonic", lambda: clock[0])
+
+        session = reg.get_or_create("s1")  # the racing caller's reference
+        clock[0] += 11
+        reg.reap()
+
+        assert session.agent.closed is True
+        assert session.run_lock.acquire(blocking=False) is False
+
     def test_session_within_ttl_survives_a_reap_sweep(self, monkeypatch):
         reg = self._registry(monkeypatch, idle_ttl_seconds=100)
         clock = [1000.0]
@@ -918,6 +938,21 @@ class TestSessionReaper:
         assert s1.agent.closed is True
         assert reg.get("s2") is not None
         assert reg.get("s3") is not None
+
+    def test_lru_evicted_session_lock_is_claimed_so_a_racing_caller_fails_safe(
+        self, monkeypatch
+    ):
+        """Same TOCTOU pin as the idle-reap case, for the LRU-cap path."""
+        reg = self._registry(monkeypatch, idle_ttl_seconds=10_000, max_sessions=1)
+        clock = [1000.0]
+        monkeypatch.setattr(agent_routes.time, "monotonic", lambda: clock[0])
+
+        s1 = reg.get_or_create("s1")  # the racing caller's reference
+        clock[0] += 1
+        reg.get_or_create("s2")  # over cap -> evicts s1
+
+        assert s1.agent.closed is True
+        assert s1.run_lock.acquire(blocking=False) is False
 
     def test_lru_cap_raises_an_actionable_error_when_everything_is_locked(
         self, monkeypatch

--- a/hub/agents/email/python/tests/test_query_route.py
+++ b/hub/agents/email/python/tests/test_query_route.py
@@ -658,3 +658,163 @@ def test_omitted_session_id_still_works_end_to_end(app_client, monkeypatch):
     events = _parse_sse(resp.text)
     assert _types(events)[-1] == "final"
     assert fake.seen_query == "Triage my inbox."
+
+
+# ---------------------------------------------------------------------------
+# session_id — resolution, concurrency, continuity (#2829, layer 2)
+#
+# A session_id resolves through agent_routes.registry, the SAME session
+# store the stateful /v1/email/agent/* surface uses -- so tests patch
+# agent_routes.build_session_agent (not query_routes.build_query_agent) and
+# swap agent_routes.registry for a fresh _SessionRegistry() per test, or
+# sessions leak across test files (test_email_agent_routes.py:162-168).
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def session_registry(monkeypatch):
+    from gaia_agent_email import agent_routes
+
+    fresh = agent_routes._SessionRegistry()
+    monkeypatch.setattr(agent_routes, "registry", fresh, raising=True)
+
+    built: list = []
+
+    def _factory(**kwargs):
+        agent = _HappyFakeAgent()
+        built.append(agent)
+        return agent
+
+    monkeypatch.setattr(agent_routes, "build_session_agent", _factory, raising=True)
+    return fresh, built
+
+
+def test_same_session_id_reuses_the_same_agent(app_client, session_registry):
+    registry, built = session_registry
+    resp1 = app_client.post("/v1/email/query", json=_req(session_id="s1"))
+    assert resp1.status_code == 200
+    assert _types(_parse_sse(resp1.text))[-1] == "final"
+
+    resp2 = app_client.post(
+        "/v1/email/query", json=_req(session_id="s1", query="second turn")
+    )
+    assert resp2.status_code == 200
+
+    assert len(built) == 1
+    assert registry.get("s1").agent is built[0]
+
+
+def test_different_session_ids_get_different_agents(app_client, session_registry):
+    registry, built = session_registry
+    app_client.post("/v1/email/query", json=_req(session_id="s1"))
+    app_client.post("/v1/email/query", json=_req(session_id="s2"))
+    assert len(built) == 2
+    assert registry.get("s1").agent is not registry.get("s2").agent
+
+
+def test_concurrent_calls_same_session_get_409(app_client, session_registry):
+    registry, _built = session_registry
+    session = registry.get_or_create("s1")
+    session.run_lock.acquire()
+    try:
+        resp = app_client.post("/v1/email/query", json=_req(session_id="s1"))
+        assert resp.status_code == 409
+        assert (
+            resp.json()["detail"] == "A turn is already in progress for this session."
+        )
+    finally:
+        session.run_lock.release()
+
+
+def test_setup_failure_after_lock_acquired_releases_the_lock(
+    app_client, session_registry, monkeypatch
+):
+    """Between acquiring run_lock and the worker thread owning it, any setup
+    failure must release it -- otherwise the session is wedged at 409 forever
+    (mirrors agent_routes.py:694-701)."""
+    import gaia.ui.sse_handler as sse_mod
+
+    registry, _built = session_registry
+
+    def _boom():
+        raise RuntimeError("cannot build handler")
+
+    monkeypatch.setattr(sse_mod, "SSEOutputHandler", _boom)
+    resp = app_client.post("/v1/email/query", json=_req(session_id="s1"))
+    assert resp.status_code >= 500
+    session = registry.get("s1")
+    assert session is not None
+    assert not session.run_lock.locked()
+
+
+def test_context_replaces_conversation_history_not_appends(
+    app_client, session_registry
+):
+    """Regression pin (#2829): agent.conversation_history is REPLACED by the
+    pushed context every turn, never appended to -- a later change that
+    accidentally appends would silently double-count history."""
+    registry, _built = session_registry
+    app_client.post("/v1/email/query", json=_req(session_id="s1", context=[]))
+    agent = registry.get("s1").agent
+    assert agent.seen_history == []
+
+    ctx = [
+        {"role": "user", "content": "turn one"},
+        {"role": "assistant", "content": "reply one"},
+    ]
+    app_client.post(
+        "/v1/email/query",
+        json=_req(session_id="s1", context=ctx, query="turn two"),
+    )
+    assert len(agent.conversation_history) == len(ctx)
+    assert agent.seen_history == ctx
+
+
+def test_unknown_session_with_prior_context_gets_continuity_notice(
+    app_client, session_registry
+):
+    """A session_id the registry has never seen, arriving WITH prior context,
+    means the sidecar restarted mid-conversation (the registry is in-memory).
+    That must be surfaced, never a silent cold start."""
+    resp = app_client.post(
+        "/v1/email/query",
+        json=_req(
+            session_id="s-restarted",
+            context=[
+                {"role": "user", "content": "earlier"},
+                {"role": "assistant", "content": "earlier reply"},
+            ],
+        ),
+    )
+    assert resp.status_code == 200
+    events = _parse_sse(resp.text)
+    statuses = [e.get("message", "") for e in events if e["type"] == "status"]
+    assert any("continuity" in s.lower() for s in statuses), statuses
+
+
+def test_brand_new_session_with_empty_context_gets_no_notice(
+    app_client, session_registry
+):
+    """First turn of a genuinely new conversation is NOT a continuity loss --
+    no session was ever expected to exist yet."""
+    resp = app_client.post(
+        "/v1/email/query", json=_req(session_id="s-new", context=[])
+    )
+    assert resp.status_code == 200
+    events = _parse_sse(resp.text)
+    statuses = [e.get("message", "") for e in events if e["type"] == "status"]
+    assert not any("continuity" in s.lower() for s in statuses), statuses
+
+
+def test_session_construction_failure_is_502(app_client, monkeypatch):
+    from gaia_agent_email import agent_routes
+
+    fresh = agent_routes._SessionRegistry()
+    monkeypatch.setattr(agent_routes, "registry", fresh, raising=True)
+
+    def _boom(**kwargs):
+        raise RuntimeError("cannot start agent")
+
+    monkeypatch.setattr(agent_routes, "build_session_agent", _boom, raising=True)
+    resp = app_client.post("/v1/email/query", json=_req(session_id="s1"))
+    assert resp.status_code == 502

--- a/hub/agents/email/python/tests/test_query_route.py
+++ b/hub/agents/email/python/tests/test_query_route.py
@@ -747,6 +747,61 @@ def test_setup_failure_after_lock_acquired_releases_the_lock(
     assert not session.run_lock.locked()
 
 
+def test_thread_start_failure_releases_the_lock_and_deregisters_the_run(
+    app_client, session_registry, monkeypatch
+):
+    """The realistic trigger for the lock-release guard: thread.start() can
+    raise under thread exhaustion, and the finally that releases run_lock
+    lives INSIDE _run_agent -- which never runs if start() itself raises. A
+    spot-fix on only SSEOutputHandler()/registry.add() would miss this and
+    wedge the session at 409 forever, with no recovery path (/clear ->
+    DELETE is deliberately out of scope for #2829)."""
+    run_id = str(uuid.uuid4())
+
+    # Scoped to the route's OWN worker thread only -- TestClient/anyio start
+    # their own background threads to drive the request, and those must keep
+    # working or the test can't even make the call.
+    real_thread_cls = threading.Thread
+
+    class _FailingThread(real_thread_cls):
+        def start(self):
+            if getattr(self._target, "__name__", "") == "_run_agent":
+                raise RuntimeError("can't start new thread")
+            super().start()
+
+    monkeypatch.setattr(query_routes.threading, "Thread", _FailingThread)
+    resp = app_client.post(
+        "/v1/email/query", json=_req(session_id="s1", run_id=run_id)
+    )
+    assert resp.status_code == 500
+
+    registry, _built = session_registry
+    session = registry.get("s1")
+    assert session is not None
+    assert not session.run_lock.locked()
+    # Deregistered too, or a retry with the SAME run_id hits a spurious 409.
+    assert query_routes.registry.get(run_id) is None
+
+
+def test_run_id_collision_does_not_deregister_the_other_run(
+    app_client, session_registry
+):
+    """A run_id collision is a DIFFERENT, unrelated in-flight run -- the
+    failure path must report its own 409 without deregistering that run."""
+    run_id = str(uuid.uuid4())
+    other_handler = object()
+    other_run = query_routes._QueryRun(run_id, agent=object(), handler=other_handler)
+    query_routes.registry.add(other_run)
+    try:
+        resp = app_client.post(
+            "/v1/email/query", json=_req(session_id="s1", run_id=run_id)
+        )
+        assert resp.status_code == 409
+        assert query_routes.registry.get(run_id) is other_run
+    finally:
+        query_routes.registry.remove(run_id)
+
+
 def test_context_replaces_conversation_history_not_appends(
     app_client, session_registry
 ):

--- a/hub/agents/email/python/tests/test_query_route.py
+++ b/hub/agents/email/python/tests/test_query_route.py
@@ -608,4 +608,52 @@ def test_non_lemonade_provider_is_400(app_client, monkeypatch):
     monkeypatch.setattr(query_routes, "build_query_agent", lambda **k: fake)
     resp = app_client.post("/v1/email/query", json=_req(provider="claude"))
     assert resp.status_code == 400
-    assert "local inference only" in resp.json()["detail"]
+
+
+# ---------------------------------------------------------------------------
+# session_id — schema (#2829). Omitted -> today's behaviour exactly; present
+# -> constrained to the same charset a dict key / path segment / log value
+# tolerates (agent_routes.py:395,404 use it as a URL path segment).
+# ---------------------------------------------------------------------------
+
+
+def test_session_id_is_optional_and_defaults_to_none():
+    req = query_routes.QueryRequest(query="hi", run_id=str(uuid.uuid4()), context=[])
+    assert req.session_id is None
+
+
+def test_session_id_accepts_the_documented_charset():
+    req = query_routes.QueryRequest(
+        query="hi", run_id=str(uuid.uuid4()), context=[], session_id="abc-123_XYZ"
+    )
+    assert req.session_id == "abc-123_XYZ"
+
+
+@pytest.mark.parametrize(
+    "bad_id",
+    [
+        "",  # too short (min length 1)
+        "has a space",
+        "has/slash",
+        "has.dot",
+        "x" * 129,  # over the 128 cap
+    ],
+)
+def test_session_id_rejects_characters_outside_the_charset(bad_id):
+    import pydantic
+
+    with pytest.raises(pydantic.ValidationError):
+        query_routes.QueryRequest(
+            query="hi", run_id=str(uuid.uuid4()), context=[], session_id=bad_id
+        )
+
+
+def test_omitted_session_id_still_works_end_to_end(app_client, monkeypatch):
+    """Today's behaviour, byte-for-byte: no session_id -> the old per-turn agent."""
+    fake = _HappyFakeAgent()
+    monkeypatch.setattr(query_routes, "build_query_agent", lambda **k: fake)
+    resp = app_client.post("/v1/email/query", json=_req())
+    assert resp.status_code == 200
+    events = _parse_sse(resp.text)
+    assert _types(events)[-1] == "final"
+    assert fake.seen_query == "Triage my inbox."

--- a/hub/agents/email/python/tests/test_query_route.py
+++ b/hub/agents/email/python/tests/test_query_route.py
@@ -608,6 +608,7 @@ def test_non_lemonade_provider_is_400(app_client, monkeypatch):
     monkeypatch.setattr(query_routes, "build_query_agent", lambda **k: fake)
     resp = app_client.post("/v1/email/query", json=_req(provider="claude"))
     assert resp.status_code == 400
+    assert "local inference only" in resp.json()["detail"]
 
 
 # ---------------------------------------------------------------------------

--- a/src/gaia/daemon/agent_query.py
+++ b/src/gaia/daemon/agent_query.py
@@ -258,11 +258,20 @@ def run_query(
     context: Optional[List[Dict[str, str]]] = None,
     model: Optional[str] = None,
     max_steps: Optional[int] = None,
+    session_id: Optional[str] = None,
     renderer: Optional[ConsoleRenderer] = None,
     verbose: bool = False,
 ) -> QueryOutcome:
     """Ensure the daemon + *agent_id* sidecar, stream ``POST /v1/<agent>/query``
     through the relay, and render the canonical SSE events.
+
+    ``session_id``, when given, resolves the SAME agent across calls sharing
+    it (#2829, contract 2.12) instead of a throwaway per-call agent — so a
+    caller that keeps reusing one id (e.g. an interactive REPL) gets a
+    conversation, not amnesia between turns. Omitted -> today's behaviour
+    exactly, matching ``model``/``max_steps``: left out of the payload dict
+    entirely rather than sent as ``null``, so an older sidecar's strict
+    request model never sees an unknown field.
 
     The CLI presents ONLY the daemon client token; it never learns the sidecar's
     port or bearer. Returns a :class:`QueryOutcome` whose ``exit_code`` is 0 on a
@@ -287,6 +296,8 @@ def run_query(
         payload["model"] = model
     if max_steps is not None:
         payload["max_steps"] = max_steps
+    if session_id:
+        payload["session_id"] = session_id
 
     url = f"{inst.base_url}/v1/{agent_id}/query"
     headers = {

--- a/tests/unit/agents/email/test_attention_contract.py
+++ b/tests/unit/agents/email/test_attention_contract.py
@@ -45,11 +45,12 @@ from gaia_agent_email.contract import (  # noqa: E402
 
 
 class TestSchemaVersionBump:
-    def test_schema_version_is_2_11(self):
-        # Bumped again by #2743 (EmailPreScanResult.needs_you/bulk) since
-        # this file's #2582 attention-view bump to 2.8 -- both additive, so
-        # this is a routine version-pin update, not a contract regression.
-        assert SCHEMA_VERSION == "2.11"
+    def test_schema_version_is_2_12(self):
+        # Bumped again by #2829 (POST /v1/email/query gains optional
+        # session_id) since this file's #2582 attention-view bump to 2.8 --
+        # additive like every bump before it, so this is a routine
+        # version-pin update, not a contract regression.
+        assert SCHEMA_VERSION == "2.12"
 
 
 class TestAttentionItemKind:

--- a/tests/unit/agents/email/test_contract_schema.py
+++ b/tests/unit/agents/email/test_contract_schema.py
@@ -332,7 +332,7 @@ def test_result_summary_required():
 
 
 def test_schema_version_unchanged_by_multi_inbox():
-    """Schema 2.9 is the current frozen contract version.
+    """Schema 2.12 is the current frozen contract version.
 
     2.1 was additive over the 2.0 5-bucket taxonomy (no triage shape change):
     it added inbox search (#1781), mailbox actions (#1779), the calendar
@@ -363,11 +363,15 @@ def test_schema_version_unchanged_by_multi_inbox():
     NeedsYouItem]), needs_you_total (int), and bulk (Optional[BulkSummary]) —
     a worklist view built on top of the already-classified urgent/actionable/
     needs_review buckets, never a second independent classification pass — no
-    existing field changed. If this fails, someone changed the version
-    unexpectedly; that requires an explicit version negotiation, not a
-    drive-by edit.
+    existing field changed. 2.12 is additive over 2.11 (#2829): POST
+    /v1/email/query gains an optional session_id — when the host sends it,
+    the run resolves the SAME agent every other turn on that id used
+    (instead of a throwaway per-turn agent), so a reference to something an
+    earlier turn surfaced can resolve — no existing field changed. If this
+    fails, someone changed the version unexpectedly; that requires an
+    explicit version negotiation, not a drive-by edit.
     """
-    assert SCHEMA_VERSION == "2.11"
+    assert SCHEMA_VERSION == "2.12"
 
 
 def test_triage_result_gained_no_new_required_field():

--- a/tests/unit/test_agent_query.py
+++ b/tests/unit/test_agent_query.py
@@ -181,7 +181,7 @@ def test_ensure_agent_rejects_prehistoric_daemon(monkeypatch):
 
 def _stub_ensure(monkeypatch, base_url="http://127.0.0.1:9999"):
     """Stub client.ensure_agent so run_query never touches a real daemon."""
-    from gaia.daemon import agent_query, client
+    from gaia.daemon import agent_query
     from gaia.daemon.instance import DaemonInstance
 
     inst = DaemonInstance(

--- a/tests/unit/test_agent_query.py
+++ b/tests/unit/test_agent_query.py
@@ -172,3 +172,69 @@ def test_ensure_agent_rejects_prehistoric_daemon(monkeypatch):
 
     with pytest.raises(DaemonVersionError):
         client.ensure_agent("email")
+
+
+# ---------------------------------------------------------------------------
+# run_query's payload — session_id parity with model/max_steps (#2829)
+# ---------------------------------------------------------------------------
+
+
+def _stub_ensure(monkeypatch, base_url="http://127.0.0.1:9999"):
+    """Stub client.ensure_agent so run_query never touches a real daemon."""
+    from gaia.daemon import agent_query, client
+    from gaia.daemon.instance import DaemonInstance
+
+    inst = DaemonInstance(
+        pid=1, port=9999, token="T", host="127.0.0.1", api_version="1.1"
+    )
+    monkeypatch.setattr(agent_query.client, "ensure_agent", lambda agent_id: inst)
+    return inst
+
+
+def _stub_stream_post(monkeypatch, captured):
+    """Stub requests.post to capture the JSON payload and return one 'final'
+    SSE frame, without opening a real connection."""
+    import requests
+
+    class _Resp:
+        status_code = 200
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            return False
+
+        def iter_lines(self, decode_unicode=True):
+            yield 'data: {"type": "final", "answer": "ok"}'
+            yield ""
+
+    def _fake_post(url, headers=None, json=None, stream=None, timeout=None):
+        captured["json"] = json
+        return _Resp()
+
+    monkeypatch.setattr(requests, "post", _fake_post)
+
+
+def test_run_query_omits_session_id_when_none(monkeypatch):
+    from gaia.daemon.agent_query import run_query
+
+    _stub_ensure(monkeypatch)
+    captured: dict = {}
+    _stub_stream_post(monkeypatch, captured)
+
+    run_query("email", "hi")
+
+    assert "session_id" not in captured["json"]
+
+
+def test_run_query_sends_session_id_when_given(monkeypatch):
+    from gaia.daemon.agent_query import run_query
+
+    _stub_ensure(monkeypatch)
+    captured: dict = {}
+    _stub_stream_post(monkeypatch, captured)
+
+    run_query("email", "hi", session_id="conv-123")
+
+    assert captured["json"]["session_id"] == "conv-123"

--- a/tui/internal/client/negotiate.go
+++ b/tui/internal/client/negotiate.go
@@ -52,6 +52,15 @@ const (
 	preScanContractMinor = 11
 )
 
+// sessionContract is the contract version that let /query resolve a
+// conversation's agent by session_id instead of building a throwaway one per
+// call (#2829, schema 2.12). A peer below it 422s the field, exactly like
+// can_answer_questions below 2.6 -- so it is omitted entirely.
+const (
+	sessionContractMajor = 2
+	sessionContractMinor = 12
+)
+
 // versionProbeTimeout bounds the negotiation round-trip. Short: it is a local
 // daemon relay, and the probe must never be the reason a turn feels slow. On
 // failure the client assumes the peer is old, which is the answer that keeps
@@ -64,6 +73,8 @@ type peerContract struct {
 	version string
 	// canAnswerQuestions is true only when the peer is provably >= 2.6.
 	canAnswerQuestions bool
+	// supportsSession is true only when the peer is provably >= 2.12.
+	supportsSession bool
 }
 
 // negotiate resolves the peer's contract once per client and caches it.
@@ -136,9 +147,14 @@ func (s *SSEClient) probeContract(ctx context.Context, inst *daemon.Instance) pe
 	}
 
 	supports := contractAtLeast(payload.APIVersion, questionsContractMajor, questionsContractMinor)
-	s.opts.Logf("sse: '%s' speaks contract %s (mid-run questions: %t)",
-		s.agentID, payload.APIVersion, supports)
-	return peerContract{version: payload.APIVersion, canAnswerQuestions: supports}
+	supportsSession := contractAtLeast(payload.APIVersion, sessionContractMajor, sessionContractMinor)
+	s.opts.Logf("sse: '%s' speaks contract %s (mid-run questions: %t, session: %t)",
+		s.agentID, payload.APIVersion, supports, supportsSession)
+	return peerContract{
+		version:            payload.APIVersion,
+		canAnswerQuestions: supports,
+		supportsSession:    supportsSession,
+	}
 }
 
 // contractAtLeast reports whether a "MAJOR.MINOR" version is >= the floor.

--- a/tui/internal/client/negotiate_test.go
+++ b/tui/internal/client/negotiate_test.go
@@ -279,3 +279,137 @@ func TestRemedyIsScopedForAnyAgent(t *testing.T) {
 		}
 	}
 }
+
+// ---------------------------------------------------------------------------
+// session_id negotiation (#2829, contract 2.12) — same shape as
+// can_answer_questions above: a published sidecar is routinely older than the
+// TUI talking to it, and its strict request model 422s an unknown field.
+// ---------------------------------------------------------------------------
+
+// A peer below 2.12 must never see session_id, even though it is the whole
+// point of the change: sending it to an old strict peer 422s every query.
+func TestOldPeerGetsNoSessionID(t *testing.T) {
+	f := newFakeRelay(t)
+	f.contractVersion = "2.11" // the version this exact change bumps past
+	f.strictBody = true
+	f.stream = func(w http.ResponseWriter, flush func(), _ queryRequest) {
+		frame(w, `{"type":"final","answer":"hi"}`)
+		flush()
+	}
+
+	c := f.client(t)
+	ch, err := c.Send(context.Background(), "say hi")
+	if err != nil {
+		t.Fatalf("Send against a pre-2.12 strict peer failed: %v", err)
+	}
+	if !hasFinal(collect(t, ch)) {
+		t.Error("the turn did not complete")
+	}
+	if raw := f.lastRawBody(); strings.Contains(raw, "session_id") {
+		t.Errorf("session_id was sent to a peer that rejects it: %s", raw)
+	}
+}
+
+// A peer at 2.12 gets a real session_id, and the SAME one across turns —
+// that persistence is the entire point: it is what lets the sidecar resolve
+// the same agent for a follow-up like "reply to number 1".
+func TestNewPeerGetsAStableSessionIDAcrossTurns(t *testing.T) {
+	f := newFakeRelay(t)
+	f.contractVersion = "2.12"
+	f.strictBody = true
+	f.stream = func(w http.ResponseWriter, flush func(), _ queryRequest) {
+		frame(w, `{"type":"final","answer":"hi"}`)
+		flush()
+	}
+
+	c := f.client(t)
+	for i := 0; i < 3; i++ {
+		ch, err := c.Send(context.Background(), "hi")
+		if err != nil {
+			t.Fatalf("Send #%d: %v", i, err)
+		}
+		collect(t, ch)
+	}
+
+	if len(f.queries) != 3 {
+		t.Fatalf("got %d queries, want 3", len(f.queries))
+	}
+	first := f.queries[0].SessionID
+	if first == "" {
+		t.Fatalf("session_id was omitted for a 2.12 peer: %s", f.rawBodies[0])
+	}
+	for i, q := range f.queries {
+		if q.SessionID != first {
+			t.Errorf("turn %d session_id = %q, want %q (same conversation)", i, q.SessionID, first)
+		}
+	}
+}
+
+// /clear starts a new conversation locally (no network call — ResetTranscript
+// has no error return and is called outside a tea.Cmd) — the NEXT session_id
+// must differ, or a cleared TUI transcript would still resolve the old,
+// pre-clear agent server-side.
+func TestClearMintsANewSessionIDLocally(t *testing.T) {
+	f := newFakeRelay(t)
+	f.contractVersion = "2.12"
+	f.strictBody = true
+	f.stream = func(w http.ResponseWriter, flush func(), _ queryRequest) {
+		frame(w, `{"type":"final","answer":"hi"}`)
+		flush()
+	}
+
+	c := f.client(t)
+	for i := 0; i < 2; i++ {
+		ch, err := c.Send(context.Background(), "hi")
+		if err != nil {
+			t.Fatalf("Send #%d: %v", i, err)
+		}
+		collect(t, ch)
+	}
+	firstTwo := f.queries[0].SessionID
+	if f.queries[1].SessionID != firstTwo {
+		t.Fatalf("the first two turns did not share a session_id")
+	}
+
+	c.ResetTranscript()
+
+	ch, err := c.Send(context.Background(), "hi")
+	if err != nil {
+		t.Fatalf("Send after /clear: %v", err)
+	}
+	collect(t, ch)
+	if len(f.queries) != 3 {
+		t.Fatalf("got %d queries, want 3", len(f.queries))
+	}
+	third := f.queries[2].SessionID
+	if third == "" {
+		t.Fatal("session_id was omitted on the post-clear turn")
+	}
+	if third == firstTwo {
+		t.Errorf("session_id did not change after /clear: still %q", third)
+	}
+}
+
+// A sidecar with no /version route at all (older than #2496) must still
+// work, and never receive session_id (unknown version -> assume old).
+func TestMissingVersionRouteGetsNoSessionID(t *testing.T) {
+	f := newFakeRelay(t)
+	f.contractVersion = "" // route 404s
+	f.strictBody = true
+	f.stream = func(w http.ResponseWriter, flush func(), _ queryRequest) {
+		frame(w, `{"type":"final","answer":"hi"}`)
+		flush()
+	}
+
+	c := f.client(t)
+	ch, err := c.Send(context.Background(), "say hi")
+	if err != nil {
+		t.Fatalf("Send with no /version route failed: %v", err)
+	}
+	if !hasFinal(collect(t, ch)) {
+		t.Error("the turn did not complete")
+	}
+	if raw := f.lastRawBody(); strings.Contains(raw, "session_id") {
+		t.Errorf("session_id was sent with no version negotiated: %s", raw)
+	}
+}

--- a/tui/internal/client/sse.go
+++ b/tui/internal/client/sse.go
@@ -87,6 +87,12 @@ type SSEClient struct {
 	// noticedOldPeer records that the "this agent cannot be asked anything"
 	// notice has already been shown, so it appears once per launch, not per turn.
 	noticedOldPeer bool
+	// sessionID identifies this conversation to a peer that supports it
+	// (#2829). Minted lazily on first Send (mirrors runID's own mint time,
+	// so a mint failure surfaces the same way runID's does); "" means "mint
+	// on next Send". /clear clears it here so the NEXT turn starts a new
+	// conversation server-side too, not just in the visible transcript.
+	sessionID string
 }
 
 // runHandle is the cancel side of the currently streaming run.
@@ -129,6 +135,11 @@ type queryRequest struct {
 	// and then send it explicitly — including `false`, which is a real answer
 	// the agent branches on, not an absence.
 	CanAnswerQuestions *bool `json:"can_answer_questions,omitempty"`
+	// Plain string (not a pointer, unlike CanAnswerQuestions): unlike a bool,
+	// there is no legitimate "explicit empty" session_id to distinguish from
+	// absence -- a minted id is never "", so plain omitempty is enough. Sent
+	// only once negotiation proves the peer is >= 2.12 (#2829).
+	SessionID string `json:"session_id,omitempty"`
 }
 
 // Send starts one turn. The returned channel carries the canonical event types
@@ -174,6 +185,13 @@ func (s *SSEClient) Send(ctx context.Context, query string) (<-chan interface{},
 		interactive := s.opts.Interactive
 		canAnswer = &interactive
 	}
+	var sessionID string
+	if peer.supportsSession {
+		sessionID, err = s.ensureSessionID()
+		if err != nil {
+			return nil, err
+		}
+	}
 
 	payload, err := json.Marshal(queryRequest{
 		Query:              query,
@@ -182,6 +200,7 @@ func (s *SSEClient) Send(ctx context.Context, query string) (<-chan interface{},
 		Model:              s.opts.Model,
 		MaxSteps:           s.opts.MaxSteps,
 		CanAnswerQuestions: canAnswer,
+		SessionID:          sessionID,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("could not encode the '%s' query request: %w", s.agentID, err)
@@ -694,10 +713,37 @@ func (s *SSEClient) Transcript() []Turn {
 // ResetTranscript drops the accumulated context, so the next turn starts fresh.
 // Wired to the chat screen's /clear, which would otherwise clear the visible
 // history while still pushing it as `context`.
+//
+// Also drops the session id (#2829): /clear starts a NEW conversation, and a
+// stale id would let the sidecar resolve the pre-clear agent even though the
+// visible transcript says otherwise. No network call — matches ResetTranscript
+// itself, which has no error return and is called outside a tea.Cmd
+// (model.go), so a blocking DELETE here would freeze the UI. The next Send
+// mints a fresh id lazily, exactly like the very first turn.
 func (s *SSEClient) ResetTranscript() {
 	s.mu.Lock()
 	s.transcript = nil
+	s.sessionID = ""
 	s.mu.Unlock()
+}
+
+// ensureSessionID returns this conversation's session id, minting one on
+// first use. Lazy and mutex-guarded so concurrent callers never mint two
+// (Send() itself is documented as serialized, but this stays correct either
+// way). Reuses newRunID's generator; a mint failure is reported the same way
+// a run_id mint failure already is, by Send returning the error.
+func (s *SSEClient) ensureSessionID() (string, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.sessionID != "" {
+		return s.sessionID, nil
+	}
+	id, err := newRunID()
+	if err != nil {
+		return "", fmt.Errorf("could not mint a session id: %w", err)
+	}
+	s.sessionID = id
+	return id, nil
 }
 
 // Close cancels any in-flight run and refuses further sends.

--- a/tui/internal/client/sse_test.go
+++ b/tui/internal/client/sse_test.go
@@ -209,13 +209,26 @@ func (f *fakeRelay) handle(w http.ResponseWriter, r *http.Request) {
 
 		if f.strictBody {
 			// The accepted field set is the one THIS peer's contract declares —
-			// 2.6 knows can_answer_questions, older versions do not. Modelling
-			// only one of the two would make the fake agree with the client by
-			// construction, which is how the 422 shipped in the first place.
+			// 2.6 knows can_answer_questions, 2.12 adds session_id, older
+			// versions know neither. Modelling only the newest shape would
+			// make the fake agree with the client by construction, which is
+			// how the 422 shipped in the first place (#2496).
 			dec := json.NewDecoder(strings.NewReader(string(raw)))
 			dec.DisallowUnknownFields()
 			var derr error
-			if contractAtLeast(f.contractVersion, 2, 6) {
+			switch {
+			case contractAtLeast(f.contractVersion, 2, 12):
+				var strict struct {
+					Query              string `json:"query"`
+					RunID              string `json:"run_id"`
+					Context            []Turn `json:"context"`
+					Model              string `json:"model"`
+					MaxSteps           int    `json:"max_steps"`
+					CanAnswerQuestions *bool  `json:"can_answer_questions"`
+					SessionID          string `json:"session_id"`
+				}
+				derr = dec.Decode(&strict)
+			case contractAtLeast(f.contractVersion, 2, 6):
 				var strict struct {
 					Query              string `json:"query"`
 					RunID              string `json:"run_id"`
@@ -225,7 +238,7 @@ func (f *fakeRelay) handle(w http.ResponseWriter, r *http.Request) {
 					CanAnswerQuestions *bool  `json:"can_answer_questions"`
 				}
 				derr = dec.Decode(&strict)
-			} else {
+			default:
 				var strict struct {
 					Query    string `json:"query"`
 					RunID    string `json:"run_id"`


### PR DESCRIPTION
Closes #2829

Ask the email agent something and it answers with a numbered list; ask a follow-up about "number 1" and it tells you it has no list. Same for anything else a previous turn put on screen. The agent was being thrown away and rebuilt after every single question, so nothing survived between them — `_last_needs_you_card` was `None` at the start of every turn, which is why #2761's "reply to 1" resolver could never fire on the surface users actually drive.

The session machinery to fix this already existed and is what the REST/Agent UI surface uses; the daemon→TUI path just never opted in. Now it can: `session_id` is an optional field on `POST /v1/email/query`, and when present the sidecar resolves the agent from the same session registry instead of building a throwaway one. Omit it and behaviour is byte-for-byte what it was.

Three things make that safe rather than merely working:

- **One turn at a time per session** (`409`, matching the sibling route). Sharing an agent without it lets two overlapping turns overwrite `agent.console` under a running worker thread and silently misroute one caller's stream into another's — reachable by the ordinary cancel-then-retype path, since cancellation is cooperative.
- **The TUI asks before it tells.** `SCHEMA_VERSION` goes to 2.12 and the client only sends `session_id` to a peer that reports ≥ 2.12. Request models are `extra="forbid"`, and the TUI ships from source while the sidecar ships as an installed package — so an ungated field would have 422'd *every* query against any not-yet-updated sidecar, not just session-carrying ones.
- **Sessions get cleaned up.** A session id now roots an agent (a WAL sqlite connection, a memory-store DB, an embedder) for a whole conversation rather than one call. An idle-TTL reaper plus an LRU cap bound that, and eviction claims a session's lock before tearing it down so it can never close a database out from under a live request.

## Evidence — the agent really is reused

Measured against the running sidecar, watching `init_memory` in its log (it runs inside `EmailTriageAgent.__init__`, so it counts constructions directly):

| `/query` call | cumulative `init_memory` | wall time |
|---|---|---|
| turn 1, `session_id=A` | 1 | 24.73s |
| turn 2, **same** `session_id=A` | **1** (unchanged) | **0.42s** |
| turn 3, new `session_id=B` | 2 | — |

The second turn built no agent at all — that is the whole fix. The third call confirms the registry keys on the id rather than blindly reusing whatever it has. `GET /v1/email/agent/session/A/history` returns `200` with both turns recorded.

## Test plan

- [x] `pytest hub/agents/email/python/tests/ -q` — **1777 passed, 4 skipped**
- [x] `PYTHONPATH=hub/agents/email/python pytest tests/unit/agents/email -q` — **640 passed**
- [x] `(cd tui && go test ./...)` — all packages green
- [x] Back-compat: a peer reporting 2.11 is sent no `session_id` and its queries still succeed (`negotiate_test.go`)
- [x] Full `pytest tests/unit/ -q` sweep — 8834 passed, 7 failures pre-existing on `main` and unrelated (CLI-binary-on-PATH ×3, hub-wheel-install ×2, registry-installed-import, VLM PDF extraction)

Rebased onto `162274a5`, so this now sits on top of both #2845 and #2695's skill-set work. Worth noting for the reviewer: #2695 made skill-set selection account-keyed, which a reused agent could in principle freeze — it can't, because `skill_set` resolves in `__init__` from the account type rather than per query, and both `/query` paths construct through the same `build_session_agent` seam.

<details>
<summary>Why the live run is evidence and not a CI gate</summary>

The issue's reproduction ends in an LLM-generated sentence, which can't be asserted deterministically. What pins the mechanism in CI is agent-object identity across two `/query` calls on one session id — that is the entire fix, independent of what the model says. The measurements above corroborate it on the real surface.
</details>

<details>
<summary>Deliberately out of scope</summary>

- **#2834** — recording arbitrary entities a turn surfaced so any reference resolves. This PR only makes a place for that state to live.
- **Shrinking the pushed `context`** (#2781, #1890) — now possible, but a separate measurable change; this PR keeps pushing it exactly as before so only one variable moves.
- **`/clear` ending the session server-side** — wiring it to `DELETE /session/{id}` would freeze the UI on a blocking call, report success on a failed delete, and race a cooperatively-cancelled turn into `close_db()`. `/clear` mints a new id locally instead; the reaper covers the orphan. Follow-up.
- **`cli.py`'s `gaia email` REPL** has the identical per-turn-rebuild bug. `run_query` now takes the parameter, so that fix is small — follow-up.

One consequence worth naming: TUI sessions now participate in the registry's autonomy kill-broadcast exactly as Agent UI sessions do.
</details>
