### PR TITLE
fix(tui): 'triage my inbox' draws its card under the question again

### DIFF
--- a/tui/internal/ui/chat/message.go
+++ b/tui/internal/ui/chat/message.go
@@ -39,11 +39,14 @@ type Message struct {
 	// Identity marks a RoleCard message as the ONE singular card of its
 	// kind per turn-sequence (#2743) -- today only the email pre-scan card,
 	// which can arrive from two independent sources (a typed turn's
-	// tool_result, or the on-open pre-scan fetch) that must update the SAME
-	// message in place rather than each appending its own. Empty for every
-	// other card, which always appends. Looked up by identity, not by a
-	// tracked index: `/clear` sets ChatModel.messages to nil (model.go), so
-	// a stale index would panic or silently overwrite an unrelated message.
+	// tool_result, or the on-open pre-scan fetch) that must replace the
+	// SAME logical card rather than each appending its own. A refresh moves
+	// the card to the tail of the transcript rather than updating it where
+	// it was first drawn (#2829) -- see ChatModel.upsertCard. Empty for
+	// every other card, which always appends. Looked up by identity, not by
+	// a tracked index: `/clear` sets ChatModel.messages to nil (model.go),
+	// so a stale index would panic or silently overwrite an unrelated
+	// message.
 	Identity string
 
 	// cardCache memoizes the drawn card. updateViewport re-renders every message

--- a/tui/internal/ui/chat/model.go
+++ b/tui/internal/ui/chat/model.go
@@ -283,24 +283,25 @@ func (m ChatModel) fetchPreScan() tea.Cmd {
 	}
 }
 
-// upsertCard appends a RoleCard message, or — when identity is non-empty and
-// a message already carries it — replaces that message's payload in place
-// (#2743). Looked up by identity across the CURRENT m.messages slice on
-// every call, never a tracked index: `/clear` sets m.messages to nil
-// (see the "/clear" case below), so a stale index would panic or silently
-// overwrite an unrelated message. The render cache is cleared so an
-// in-place update is never served the stale layout (Message.cardCache is
-// otherwise keyed on width alone).
+// upsertCard draws a RoleCard message at the TAIL of the transcript, first
+// removing any earlier message with the same identity (#2743, moved #2829)
+// so there is still only ever one. Moving rather than updating in place
+// matters because the earliest draw is usually the on-open pre-scan fetch,
+// which sits above every user message -- an in-place update would keep
+// refreshing that card up there even when a later turn explicitly asked for
+// one, leaving the user's own question answered by prose only with the
+// card nowhere near it. Looked up by identity across the CURRENT m.messages
+// slice on every call, never a tracked index: `/clear` sets m.messages to
+// nil (see the "/clear" case below), so a stale index would panic or
+// silently overwrite an unrelated message. Building a fresh Message (rather
+// than mutating the old one) also means the render cache — otherwise keyed
+// on width alone — is never served the old message's stale layout.
 func (m *ChatModel) upsertCard(identity, toolName, render string, data json.RawMessage) {
 	if identity != "" {
 		for i := range m.messages {
 			if m.messages[i].Role == RoleCard && m.messages[i].Identity == identity {
-				m.messages[i].ToolName = toolName
-				m.messages[i].Render = render
-				m.messages[i].Data = data
-				m.messages[i].cardCache = ""
-				m.messages[i].cardCacheWidth = 0
-				return
+				m.messages = append(m.messages[:i], m.messages[i+1:]...)
+				break
 			}
 		}
 	}

--- a/tui/internal/ui/chat/prescan_init_test.go
+++ b/tui/internal/ui/chat/prescan_init_test.go
@@ -502,3 +502,147 @@ func TestPreScanCardCacheInvalidatesOnDataChangeNotOnlyOnResize(t *testing.T) {
 		t.Errorf("render at the same width served stale cached content after an in-place data update:\n%s", rendered2)
 	}
 }
+
+// ---------------------------------------------------------------------------
+// #2829 -- regression fix for #2757. Anchoring "the one card" to wherever it
+// was FIRST drawn was correct for the two-cards-that-disagreed bug #2757
+// fixed, but the on-open fetch draws first, at launch -- so a later
+// user-initiated "triage my inbox" kept refreshing that card above the
+// question, leaving the question itself answered by prose only. #2485
+// (before #2757) drew a card directly under the turn that produced it; that
+// placement is restored here for a refresh, while #2757's one-card property
+// (never two) is kept.
+// ---------------------------------------------------------------------------
+
+func TestUserTriggeredPreScanRefreshMovesTheCardBelowTheQuestion(t *testing.T) {
+	m, _ := newTestModel(t)
+
+	// The on-open card, drawn before any user message exists.
+	updated, _ := m.Update(preScanFetchedMsg{data: json.RawMessage(samplePreScanJSON)})
+	m = updated.(ChatModel)
+	if len(m.messages) != 1 || m.messages[0].Role != RoleCard {
+		t.Fatalf("test setup: want the on-open card as the only message, got %+v", m.messages)
+	}
+
+	// The user explicitly asks for a triage; the turn's OWN tool_result
+	// carries a fresh email_pre_scan card.
+	updated2, _ := m.Update(sendQueryMsg{query: "triage my inbox"})
+	m = updated2.(ChatModel)
+
+	freshData := json.RawMessage(`{"kind":"email_pre_scan","urgent":[],"actionable":[],"informational_count":0,"suggested_archives":[],"suggested_drafts":[],"needs_review":[],"scanned":32,"needs_you":[],"needs_you_total":6,"bulk":{"count":0,"filter_tests":[]}}`)
+	m = feed(t, m,
+		event.CanonicalToolResultEvent{
+			Type: "tool_result", Tool: "pre_scan_inbox",
+			Render: "email_pre_scan", Data: freshData,
+		},
+		event.CanonicalFinalEvent{Type: "final", Answer: "there are 6 items requiring your attention"},
+	)
+
+	userIdx, cardIdx, cardCount := -1, -1, 0
+	for i, msg := range m.messages {
+		if msg.Role == RoleUser && userIdx == -1 {
+			userIdx = i
+		}
+		if msg.Role == RoleCard && msg.Render == "email_pre_scan" {
+			cardIdx = i
+			cardCount++
+		}
+	}
+	if cardCount != 1 {
+		t.Fatalf("got %d pre-scan cards, want exactly 1 (#2757's property, kept): %+v", cardCount, m.messages)
+	}
+	if userIdx == -1 {
+		t.Fatalf("test setup: no user message found: %+v", m.messages)
+	}
+	if cardIdx < userIdx {
+		t.Errorf("card at index %d sits BEFORE the question at index %d that asked for it: %+v", cardIdx, userIdx, m.messages)
+	}
+	if string(m.messages[cardIdx].Data) != string(freshData) {
+		t.Errorf("card data = %s, want the turn's own fresh data %s", m.messages[cardIdx].Data, freshData)
+	}
+	if m.messages[cardIdx].cardCache != "" {
+		t.Error("the moved card kept a stale render cache instead of starting fresh")
+	}
+}
+
+// A second refresh must move the (already-moved) card again, to under the
+// SECOND question -- not leave it wherever the first refresh put it.
+func TestSecondUserTriggeredPreScanRefreshMovesAgain(t *testing.T) {
+	m, _ := newTestModel(t)
+
+	updated, _ := m.Update(preScanFetchedMsg{data: json.RawMessage(samplePreScanJSON)})
+	m = updated.(ChatModel)
+
+	firstData := json.RawMessage(`{"kind":"email_pre_scan","urgent":[],"actionable":[],"informational_count":0,"suggested_archives":[],"suggested_drafts":[],"needs_review":[],"scanned":10,"needs_you":[],"needs_you_total":1,"bulk":{"count":0,"filter_tests":[]}}`)
+	updated2, _ := m.Update(sendQueryMsg{query: "triage my inbox"})
+	m = updated2.(ChatModel)
+	m = feed(t, m,
+		event.CanonicalToolResultEvent{Type: "tool_result", Tool: "pre_scan_inbox", Render: "email_pre_scan", Data: firstData},
+		event.CanonicalFinalEvent{Type: "final", Answer: "1 item"},
+	)
+
+	secondData := json.RawMessage(`{"kind":"email_pre_scan","urgent":[],"actionable":[],"informational_count":0,"suggested_archives":[],"suggested_drafts":[],"needs_review":[],"scanned":20,"needs_you":[],"needs_you_total":2,"bulk":{"count":0,"filter_tests":[]}}`)
+	updated3, _ := m.Update(sendQueryMsg{query: "triage my inbox again"})
+	m = updated3.(ChatModel)
+	secondQuestionIdx := len(m.messages) - 1
+	m = feed(t, m,
+		event.CanonicalToolResultEvent{Type: "tool_result", Tool: "pre_scan_inbox", Render: "email_pre_scan", Data: secondData},
+		event.CanonicalFinalEvent{Type: "final", Answer: "2 items"},
+	)
+
+	cardIdx, cardCount := -1, 0
+	for i, msg := range m.messages {
+		if msg.Role == RoleCard && msg.Render == "email_pre_scan" {
+			cardIdx = i
+			cardCount++
+		}
+	}
+	if cardCount != 1 {
+		t.Fatalf("got %d pre-scan cards, want exactly 1: %+v", cardCount, m.messages)
+	}
+	if cardIdx < secondQuestionIdx {
+		t.Errorf("card at index %d sits before the SECOND question at index %d -- it stayed where the first refresh left it: %+v", cardIdx, secondQuestionIdx, m.messages)
+	}
+	if string(m.messages[cardIdx].Data) != string(secondData) {
+		t.Errorf("card data = %s, want the second turn's data %s", m.messages[cardIdx].Data, secondData)
+	}
+}
+
+// /clear drops the whole transcript, including any pre-scan card wherever it
+// was; the next pre-scan (on-open or user-triggered) must still yield
+// exactly one card, not zero and not two.
+func TestClearThenFreshPreScanYieldsExactlyOneCard(t *testing.T) {
+	m, _ := newTestModel(t)
+
+	updated, _ := m.Update(preScanFetchedMsg{data: json.RawMessage(samplePreScanJSON)})
+	m = updated.(ChatModel)
+	updated2, _ := m.Update(sendQueryMsg{query: "triage my inbox"})
+	m = updated2.(ChatModel)
+	m = feed(t, m,
+		event.CanonicalToolResultEvent{
+			Type: "tool_result", Tool: "pre_scan_inbox",
+			Render: "email_pre_scan",
+			Data:   json.RawMessage(`{"kind":"email_pre_scan","urgent":[],"actionable":[],"informational_count":0,"suggested_archives":[],"suggested_drafts":[],"needs_review":[],"scanned":5,"needs_you":[],"needs_you_total":1,"bulk":{"count":0,"filter_tests":[]}}`),
+		},
+		event.CanonicalFinalEvent{Type: "final", Answer: "1 item"},
+	)
+	if !hasPreScanCard(m) {
+		t.Fatal("test setup: expected a pre-scan card before /clear")
+	}
+
+	// Mirrors model.go's "/clear" key handling.
+	m.messages = nil
+
+	updated3, _ := m.Update(preScanFetchedMsg{data: json.RawMessage(samplePreScanJSON)})
+	m = updated3.(ChatModel)
+
+	cardCount := 0
+	for _, msg := range m.messages {
+		if msg.Role == RoleCard && msg.Render == "email_pre_scan" {
+			cardCount++
+		}
+	}
+	if cardCount != 1 {
+		t.Fatalf("got %d pre-scan cards after /clear + a fresh scan, want exactly 1: %+v", cardCount, m.messages)
+	}
+}


### PR DESCRIPTION
Closes #2843

Typing `triage my inbox` in the TUI stopped drawing a card. You get one prose sentence — "there are 6 items requiring your attention…" — and nothing else, however many times you ask. It worked before #2757.

#2757 was right to want exactly one pre-scan card instead of a pile of duplicates. It anchored that card to wherever it was *first* drawn, and the first draw is the on-open scan at launch — which sits above your first message. So every later triage silently refreshed a card at the top of the transcript while the question that asked for it got prose only. Now the one card moves to the turn that asked, which is what it did before #2757.

Not a data problem: the sidecar was emitting the card correctly the whole time (`render: "email_pre_scan"`, `needs_you_total: 6`) — the TUI was drawing it out of view.

## Test plan

- [ ] `cd tui && go test ./...` — green
- [ ] New Go tests: after an on-open card, a user turn carrying an `email_pre_scan` `tool_result` leaves exactly ONE card, positioned after that user message (before this change: positioned before it); `/clear` then a fresh pre-scan still yields exactly one
- [ ] Live TUI: `triage my inbox` shows the card under the question — screenshot to follow

The cross-card dedup in `renderEmailPreScan` was investigated and is **not** implicated — `seen` resets at every `RoleUser` message, so it cannot suppress across turns. Untouched here.
