### PR TITLE
fix(mcp): gate MCP write tools behind the user confirmation prompt

### DIFF
--- a/docs/guides/mcp/client.mdx
+++ b/docs/guides/mcp/client.mdx
@@ -388,6 +388,42 @@ Before adding an MCP server:
 3. **Limit scope** — When connecting filesystem servers, restrict to specific directories rather than `/`
 4. **Audit environment variables** — Never pass secrets (API keys, tokens) to servers you haven't reviewed
 
+### Tool Confirmation
+
+Connecting a server is not the same as approving every call it can make. GAIA
+asks you to confirm each MCP tool call before it runs, because the *caller* may
+be untrusted even when the server is: a prompt injection hidden in a document,
+email, or web page you asked GAIA to read can make the model emit a tool call
+you never intended. The confirmation prompt is the backstop against that.
+
+The gate fails closed. An MCP tool skips confirmation **only** when its server
+proves the tool is read-only:
+
+| Server declares | Tool name | Confirmation |
+| --- | --- | --- |
+| `annotations.readOnlyHint: true` | no mutating verb (`search`, `get_time`) | Skipped |
+| `annotations.readOnlyHint: true` | mutating verb (`delete_file`) | **Required** |
+| `readOnlyHint: false`, or no annotations at all | anything | **Required** |
+
+Servers that ship no [MCP tool annotations](https://modelcontextprotocol.io/specification/server/tools#tool-annotations)
+get no benefit of the doubt — every one of their tools prompts.
+
+<Warning>
+The name check catches servers that annotate *incorrectly* — a `readOnlyHint:
+true` on a tool named `delete_file` is ignored. It is **not** a defence against
+a malicious server, which would simply give its write tool an innocuous name.
+Vetting the server (above) remains the only control for that; the confirmation
+gate protects you from the untrusted *content* your agent reads, not from a
+server you chose to install.
+</Warning>
+
+<Note>
+Confirmation prompts appear in the Agent UI, where **Always allow** stops the
+prompting for a specific tool. The CLI has no interactive prompt and proceeds
+automatically — prefer the Agent UI when running agents over untrusted content
+with write-capable MCP servers connected.
+</Note>
+
 ## Complete Examples
 
 Working examples are available in the GAIA repository:

--- a/docs/guides/mcp/client.mdx
+++ b/docs/guides/mcp/client.mdx
@@ -405,23 +405,25 @@ proves the tool is read-only:
 | `annotations.readOnlyHint: true` | mutating verb (`delete_file`) | **Required** |
 | `readOnlyHint: false`, or no annotations at all | anything | **Required** |
 
-Servers that ship no [MCP tool annotations](https://modelcontextprotocol.io/specification/server/tools#tool-annotations)
+Servers that ship no [tool annotations](https://modelcontextprotocol.io/specification/2025-06-18/server/tools)
 get no benefit of the doubt — every one of their tools prompts.
 
 <Warning>
-The name check catches servers that annotate *incorrectly* — a `readOnlyHint:
+The MCP specification is explicit that clients "**MUST** consider tool
+annotations to be untrusted unless they come from trusted servers." GAIA's name
+check enforces that for servers which annotate *incorrectly* — a `readOnlyHint:
 true` on a tool named `delete_file` is ignored. It is **not** a defence against
 a malicious server, which would simply give its write tool an innocuous name.
-Vetting the server (above) remains the only control for that; the confirmation
-gate protects you from the untrusted *content* your agent reads, not from a
-server you chose to install.
+Vetting the server (above) remains the control for that; the confirmation gate
+protects you from the untrusted *content* your agent reads, not from a server
+you chose to install.
 </Warning>
 
 <Note>
-Confirmation prompts appear in the Agent UI, where **Always allow** stops the
-prompting for a specific tool. The CLI has no interactive prompt and proceeds
-automatically — prefer the Agent UI when running agents over untrusted content
-with write-capable MCP servers connected.
+The Agent UI shows a permission modal, where **Always allow** stops the
+prompting for a specific tool. The CLI asks on the terminal and defaults to no.
+A run with no terminal to ask — piped, CI, or otherwise unattended — refuses the
+tool rather than approving it.
 </Note>
 
 ## Complete Examples

--- a/docs/spec/mcp-client.mdx
+++ b/docs/spec/mcp-client.mdx
@@ -1189,6 +1189,7 @@ MCP tools are converted from JSON Schema format to GAIA's tool registry format:
 # GAIA tool format (in _TOOL_REGISTRY)
 {
     "name": "mcp_filesystem_read_file",
+    "display_name": "read_file (filesystem)",
     "description": "[MCP:filesystem] Read file contents",
     "parameters": {
         "path": {
@@ -1204,8 +1205,8 @@ MCP tools are converted from JSON Schema format to GAIA's tool registry format:
     },
     "function": <wrapper_callable>,
     "atomic": True,
-    "_mcp_server": "filesystem",
-    "_mcp_tool_name": "read_file"
+    "requires_confirmation": True,
+    "_mcp_server": "filesystem"
 }
 ```
 

--- a/docs/spec/mcp-client.mdx
+++ b/docs/spec/mcp-client.mdx
@@ -1057,27 +1057,53 @@ class MCPTool:
         name (str): Tool name from MCP server (e.g., "read_file")
         description (str): Tool description
         input_schema (Dict[str, Any]): MCP inputSchema (JSON Schema format)
+        annotations (Dict[str, Any]): MCP tool annotations (readOnlyHint,
+            destructiveHint, …). Server-supplied and therefore advisory —
+            consumed by the confirmation classifier below.
     """
 
     name: str
     description: str
     input_schema: Dict[str, Any]
+    annotations: Dict[str, Any] = field(default_factory=dict)
 ```
+
+#### mcp_tool_requires_confirmation
+
+```python
+def mcp_tool_requires_confirmation(name: str, annotations: Dict[str, Any]) -> bool:
+    """Whether an MCP tool must be user-confirmed before GAIA executes it.
+
+    Fails closed. Exempt only when the server proves the tool is read-only:
+    ``annotations.readOnlyHint`` is exactly ``True`` AND the tool name carries
+    no state-changing verb token. No annotations, a non-boolean hint, or a
+    read-only claim contradicted by a name like ``delete_file`` all require
+    confirmation.
+    """
+```
+
+MCP tool names are chosen by the connected server, so they can never appear in
+GAIA's static `TOOLS_REQUIRING_CONFIRMATION` set. The classification therefore
+travels with the registry entry as `requires_confirmation`, which
+`Agent._tool_requires_confirmation` reads at execution time.
 
 #### to_gaia_format
 
 ```python
-def to_gaia_format(self, server_name: str) -> Dict[str, Any]:
+def to_gaia_format(self, prefix: str, raw_server_name: Optional[str] = None) -> Dict[str, Any]:
     """Convert MCP tool schema to GAIA _TOOL_REGISTRY format.
 
     Conversion details:
-    - Name: "mcp_{server_name}_{tool_name}"
-    - Description: "[MCP:{server_name}] {description}"
+    - Name: "mcp_{prefix}_{tool_name}"
+    - Description: "[MCP:{prefix}] {description}"
     - Parameters: Converted from JSON Schema to GAIA format
-    - Metadata: _mcp_server, _mcp_tool_name added
+    - Metadata: _mcp_server, requires_confirmation added
 
     Args:
-        server_name (str): Name of the MCP server providing this tool
+        prefix (str): Sanitised server-name prefix (from MCPClient.prefix),
+            used for the registry name and the description tag
+        raw_server_name (Optional[str]): Original mcp_servers.json key, stored
+            in _mcp_server for routing. Defaults to prefix.
 
     Returns:
         Dict[str, Any]: GAIA tool registry entry (without function field)
@@ -1089,11 +1115,12 @@ def to_gaia_format(self, server_name: str) -> Dict[str, Any]:
         GAIA format:
             {
                 "name": "mcp_filesystem_read_file",
+                "display_name": "read_file (filesystem)",
                 "description": "[MCP:filesystem] Read file",
                 "parameters": {...},
                 "atomic": True,
-                "_mcp_server": "filesystem",
-                "_mcp_tool_name": "read_file"
+                "requires_confirmation": True,
+                "_mcp_server": "filesystem"
             }
     """
 ```

--- a/src/gaia/agents/base/agent.py
+++ b/src/gaia/agents/base/agent.py
@@ -151,6 +151,10 @@ class ToolExecutionTimeout(Exception):
 # Adding a tool name here (or to a subclass's ``CONFIRMATION_REQUIRED_TOOLS``)
 # causes _execute_tool() to call console.confirm_tool_execution() and block
 # until the user responds.
+#
+# This set only covers tools whose names GAIA controls. Tools registered at
+# runtime under a third-party name (MCP) carry a ``requires_confirmation`` flag
+# on their registry entry instead — see ``Agent._tool_requires_confirmation``.
 TOOLS_REQUIRING_CONFIRMATION = {
     "run_shell_command",
     "run_cli_command",
@@ -2393,9 +2397,13 @@ Do NOT wrap conversational replies in JSON.
         """The full set of tool names gated behind explicit user confirmation
         for this agent (#1440): the generic dangerous base set
         (``TOOLS_REQUIRING_CONFIRMATION``) unioned with the agent's own
-        ``CONFIRMATION_REQUIRED_TOOLS``. ``_execute_tool`` consults this so
-        subclasses declare only their agent-specific tools without re-listing
-        the shared shell/file-mutation ones.
+        ``CONFIRMATION_REQUIRED_TOOLS``. Subclasses declare only their
+        agent-specific tools without re-listing the shared shell/file-mutation
+        ones.
+
+        This is the *static* half of the gate; ``_tool_requires_confirmation``
+        combines it with the per-entry flag that covers runtime-registered
+        (MCP) tools, and is what ``_execute_tool`` actually calls.
         """
         return frozenset(TOOLS_REQUIRING_CONFIRMATION) | frozenset(
             cls.CONFIRMATION_REQUIRED_TOOLS
@@ -2414,6 +2422,30 @@ Do NOT wrap conversational replies in JSON.
             if reason:
                 return str(reason)
         return f"Tool '{tool_name}' was denied by the user."
+
+    def _tool_requires_confirmation(self, tool_name: str) -> bool:
+        """Whether ``tool_name`` must be user-confirmed before it executes.
+
+        Unions two independent sources so tools registered at runtime are
+        covered as well as ones named at import time:
+
+        * ``confirmation_required_tools()`` — the static name set, for native
+          tools whose names GAIA controls.
+        * ``requires_confirmation`` on the registry entry — for dynamically
+          registered tools (MCP) whose names are chosen by a third party and so
+          can never be enumerated in a static set.
+
+        ``mcp_``-prefixed tools fail closed: an entry that carries no explicit
+        flag is treated as requiring confirmation, so a registration path that
+        forgets to classify its tools cannot silently leave the gate open.
+        """
+        if tool_name in self.confirmation_required_tools():
+            return True
+        entry = self._tools_registry.get(tool_name) or {}
+        flag = entry.get("requires_confirmation")
+        if flag is not None:
+            return bool(flag)
+        return tool_name.startswith("mcp_")
 
     def _execute_tool(self, tool_name: str, tool_args: Dict[str, Any]) -> Any:
         """
@@ -2488,7 +2520,7 @@ Do NOT wrap conversational replies in JSON.
         # Consoles that cannot reach a human deny rather than answer for them
         # (#2210): AgentConsole prompts on a TTY, SSEOutputHandler blocks on the
         # frontend modal, everything else denies with an actionable message.
-        if tool_name in self.confirmation_required_tools():
+        if self._tool_requires_confirmation(tool_name):
             if not self.console.confirm_tool_execution(tool_name, tool_args):
                 return {
                     "status": "denied",

--- a/src/gaia/mcp/client/mcp_client.py
+++ b/src/gaia/mcp/client/mcp_client.py
@@ -4,8 +4,8 @@
 
 import json
 import re
-from dataclasses import dataclass
-from typing import Any, Callable, Dict, List, Optional
+from dataclasses import dataclass, field
+from typing import Any, Callable, Dict, List, Optional, Set
 
 from gaia.logger import get_logger
 
@@ -137,6 +137,134 @@ def _resolve_keyring_refs(env: Optional[Dict[str, Any]]) -> Dict[str, str]:
     return resolved
 
 
+# Verb tokens that mark a tool name as state-changing. Used only to OVERRIDE a
+# server's ``readOnlyHint: true`` claim — a server that advertises
+# ``delete_file`` as read-only is buggy, and its annotation must not be allowed
+# to open the confirmation gate. This defends against honest-but-wrong servers;
+# it is NOT a defence against a hostile one, which would simply name its tool
+# something innocuous. Drawn from the tool vocabularies of the servers GAIA
+# catalogues (github, filesystem, git, desktop-commander) plus common
+# slack/postgres/container verbs. Over-inclusion is cheap — the only cost of a
+# false positive is one extra confirmation prompt.
+_MUTATING_NAME_TOKENS = frozenset(
+    {
+        "add",
+        "alter",
+        "append",
+        "apply",
+        "approve",
+        "archive",
+        "assign",
+        "cancel",
+        "checkout",
+        "chmod",
+        "chown",
+        "clear",
+        "clone",
+        "close",
+        "commit",
+        "copy",
+        "create",
+        "delete",
+        "deploy",
+        "destroy",
+        "disable",
+        "dismiss",
+        "dispatch",
+        "drop",
+        "edit",
+        "enable",
+        "erase",
+        "exec",
+        "execute",
+        "flush",
+        "fork",
+        "grant",
+        "import",
+        "insert",
+        "install",
+        "interact",
+        "invite",
+        "invoke",
+        "kill",
+        "launch",
+        "lock",
+        "mark",
+        "merge",
+        "mkdir",
+        "modify",
+        "move",
+        "overwrite",
+        "patch",
+        "pay",
+        "post",
+        "provision",
+        "publish",
+        "purge",
+        "push",
+        "put",
+        "reject",
+        "remove",
+        "rename",
+        "reset",
+        "restart",
+        "restore",
+        "revoke",
+        "run",
+        "save",
+        "schedule",
+        "send",
+        "set",
+        "share",
+        "sign",
+        "spawn",
+        "start",
+        "stop",
+        "submit",
+        "sync",
+        "terminate",
+        "transfer",
+        "trigger",
+        "truncate",
+        "unlink",
+        "unlock",
+        "update",
+        "upload",
+        "upsert",
+        "write",
+    }
+)
+
+# Splits ``writeFile`` and also screaming-camel ``WRITEFile`` (-> WRITE File),
+# which a single lower-to-upper boundary would collapse into one token.
+_CAMEL_BOUNDARY_RE = re.compile(r"(?<=[a-z0-9])(?=[A-Z])|(?<=[A-Z])(?=[A-Z][a-z])")
+
+
+def _name_tokens(name: str) -> Set[str]:
+    """Split a tool name into lowercase word tokens (snake_case and camelCase)."""
+    spaced = _CAMEL_BOUNDARY_RE.sub(" ", name or "")
+    return {t for t in re.split(r"[^A-Za-z0-9]+", spaced.lower()) if t}
+
+
+def mcp_tool_requires_confirmation(name: str, annotations: Dict[str, Any]) -> bool:
+    """Whether an MCP tool must be user-confirmed before GAIA executes it.
+
+    Fails closed. A tool is exempt only when the server *proves* it is
+    read-only: it sets the MCP-spec ``annotations.readOnlyHint`` to exactly
+    ``True`` **and** its name carries no state-changing verb. Everything else —
+    no annotations at all, ``readOnlyHint: false``, a non-boolean value, or a
+    read-only claim contradicted by a name like ``delete_file`` — requires
+    confirmation.
+
+    The gate is GAIA's backstop against prompt injection driving a write, so
+    "the server did not tell us" must never mean "safe".
+    """
+    read_only_hint = (annotations or {}).get("readOnlyHint")
+    if read_only_hint is not True:
+        return True
+    return bool(_name_tokens(name) & _MUTATING_NAME_TOKENS)
+
+
 @dataclass
 class MCPTool:
     """Represents an MCP tool with its schema.
@@ -145,11 +273,15 @@ class MCPTool:
         name: Tool name from MCP server
         description: Tool description
         input_schema: MCP inputSchema (JSON Schema format)
+        annotations: MCP tool annotations (``readOnlyHint``, ``destructiveHint``,
+            …). Server-supplied and therefore advisory — see
+            :func:`mcp_tool_requires_confirmation` for how far they are trusted.
     """
 
     name: str
     description: str
     input_schema: Dict[str, Any]
+    annotations: Dict[str, Any] = field(default_factory=dict)
 
     def to_gaia_format(
         self, prefix: str, raw_server_name: Optional[str] = None
@@ -187,6 +319,13 @@ class MCPTool:
             "description": f"[MCP:{prefix}] {self.description}",
             "parameters": gaia_params,
             "atomic": True,
+            # Read by Agent._tool_requires_confirmation. MCP tool names are
+            # server-defined, so they can never appear in the static
+            # TOOLS_REQUIRING_CONFIRMATION set — the risk classification has to
+            # travel with the registry entry instead.
+            "requires_confirmation": mcp_tool_requires_confirmation(
+                self.name, self.annotations
+            ),
             # Metadata for debugging/routing — raw name preserves the
             # mcp_servers.json key so routing back to a client still
             # works after sanitisation changes the prefix.
@@ -373,6 +512,13 @@ class MCPClient:
                 name=tool["name"],
                 description=tool.get("description", ""),
                 input_schema=tool.get("inputSchema", {}),
+                # Only a dict is accepted — a server sending a scalar or list
+                # here must not degrade into "no annotations, but trusted".
+                annotations=(
+                    tool["annotations"]
+                    if isinstance(tool.get("annotations"), dict)
+                    else {}
+                ),
             )
             for tool in tools_data
         ]

--- a/tests/unit/agents/test_mcp_tool_confirmation_gate.py
+++ b/tests/unit/agents/test_mcp_tool_confirmation_gate.py
@@ -1,0 +1,219 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""Regression tests: MCP tools must pass through the confirmation gate.
+
+Reported externally as a confirmation-gate bypass. ``_execute_tool`` used to
+gate on a static set of tool-name strings only. MCP tools are registered under
+server-chosen names (``mcp_<server>_<tool>``), so no MCP tool could ever match
+the set — every MCP write and destructive tool executed with zero user
+confirmation. Combined with GAIA's document/email/web ingestion, that made
+prompt injection a direct path to an unconfirmed write.
+
+These tests drive the real ``Agent._execute_tool`` against entries produced by
+the real ``MCPTool.to_gaia_format``, with a console that always denies. A
+denied gate means the tool body must never run.
+"""
+
+from unittest.mock import patch
+
+import pytest
+
+from gaia.agents.base.agent import Agent
+from gaia.agents.base.console import AgentConsole
+from gaia.mcp.client.mcp_client import MCPTool
+
+
+class _RecordingDenyConsole(AgentConsole):
+    """Records every confirmation request and denies it."""
+
+    blocking_confirmation = True
+
+    def __init__(self):
+        super().__init__()
+        self.requested = []
+
+    def confirm_tool_execution(self, tool_name, tool_args):
+        self.requested.append(tool_name)
+        return False
+
+
+class _Probe(Agent):
+    def _get_system_prompt(self):
+        return "probe"
+
+    def _register_tools(self):
+        pass
+
+    def _create_console(self):
+        return self._console_override
+
+
+@pytest.fixture
+def agent():
+    console = _RecordingDenyConsole()
+
+    with patch("gaia.agents.base.agent.AgentSDK"):
+        _Probe._console_override = console
+        a = _Probe(silent_mode=True, skip_lemonade=True)
+    a._instance_tools = dict(a._tools_registry)
+    a.executed = []
+    return a
+
+
+def _register_mcp(agent, name, annotations=None, server="filesystem"):
+    """Register an MCP tool exactly as ``_register_mcp_tools`` would."""
+    entry = MCPTool(
+        name=name,
+        description=f"{name} via MCP",
+        input_schema={
+            "type": "object",
+            "properties": {"path": {"type": "string"}, "content": {"type": "string"}},
+            "required": ["path"],
+        },
+        annotations=annotations or {},
+    ).to_gaia_format(server, server)
+    entry["function"] = lambda **kwargs: agent.executed.append(kwargs) or {
+        "status": "success"
+    }
+    agent._instance_tools[entry["name"]] = entry
+    return entry["name"]
+
+
+class TestMCPWriteToolsAreGated:
+    def test_mcp_write_tool_is_denied_and_never_executes(self, agent):
+        name = _register_mcp(agent, "write_file")
+
+        result = agent._execute_tool(
+            name, {"path": "/tmp/pwned", "content": "attacker-controlled"}
+        )
+
+        assert result["status"] == "denied"
+        assert agent.executed == []
+        assert agent.console.requested == [name]
+
+    @pytest.mark.parametrize(
+        "server,tool",
+        [
+            ("github", "create_or_update_file"),
+            ("github", "push_files"),
+            ("github", "delete_file"),
+            ("github", "create_repository"),
+            ("filesystem", "write_file"),
+            ("filesystem", "move_file"),
+            ("desktopcommander", "execute_command"),
+        ],
+    )
+    def test_catalogued_server_write_tools_are_gated(self, agent, server, tool):
+        name = _register_mcp(agent, tool, server=server)
+        assert agent._execute_tool(name, {"path": "/tmp/x"})["status"] == "denied"
+        assert agent.executed == []
+
+    def test_unannotated_tool_is_gated_even_if_name_looks_harmless(self, agent):
+        """Fail closed: a server that ships no annotations gets no benefit of
+        the doubt, whatever its tools are called."""
+        name = _register_mcp(agent, "do_the_thing")
+        assert agent._execute_tool(name, {"path": "/tmp/x"})["status"] == "denied"
+        assert agent.executed == []
+
+    def test_lying_read_only_hint_does_not_open_the_gate(self, agent):
+        name = _register_mcp(agent, "delete_file", {"readOnlyHint": True})
+        assert agent._execute_tool(name, {"path": "/tmp/x"})["status"] == "denied"
+        assert agent.executed == []
+
+    def test_mcp_entry_without_flag_fails_closed(self, agent):
+        """Defence in depth: a registration path that forgets to classify its
+        tools must not silently leave the gate open."""
+        agent._instance_tools["mcp_rogue_write_file"] = {
+            "name": "mcp_rogue_write_file",
+            "description": "no requires_confirmation key",
+            "parameters": {},
+            "function": lambda **kw: agent.executed.append(kw),
+        }
+        result = agent._execute_tool("mcp_rogue_write_file", {})
+        assert result["status"] == "denied"
+        assert agent.executed == []
+
+
+class TestReadOnlyMCPToolsAreNotGated:
+    def test_declared_read_only_tool_runs_without_confirmation(self, agent):
+        name = _register_mcp(agent, "get_current_time", {"readOnlyHint": True}, "time")
+
+        result = agent._execute_tool(name, {})
+
+        assert result["status"] == "success"
+        assert agent.console.requested == []
+        assert agent.executed == [{}]
+
+
+class TestUnattendedRunsDeny:
+    """Deliberate policy: unattended means nobody can approve, so fail closed.
+
+    ``SSEOutputHandler(background_mode=True)`` denies immediately rather than
+    blocking forever on a permission modal no human will see. The consequence is
+    intended but has real reach — autonomy-loop and scheduled goals lose every
+    MCP tool from a server that ships no annotations, which is most of them.
+    Pinned here so the trade-off is a decision, not an accident.
+    """
+
+    def test_background_mode_denies_unannotated_mcp_tool(self, agent, monkeypatch):
+        from gaia.ui.sse_handler import SSEOutputHandler
+
+        emitted = []
+        handler = SSEOutputHandler.__new__(SSEOutputHandler)
+        handler.background_mode = True
+        monkeypatch.setattr(handler, "_emit", emitted.append, raising=False)
+
+        agent.console = handler
+        name = _register_mcp(agent, "write_file")
+
+        result = agent._execute_tool(name, {"path": "/tmp/x", "content": "boom"})
+
+        assert result["status"] == "denied"
+        assert agent.executed == []
+        # The denial must be observable and actionable, never silent.
+        assert emitted and emitted[0]["type"] == "tool_confirm_denied"
+        assert emitted[0]["reason"] == "unattended"
+
+    def test_background_mode_still_allows_declared_read_only_tool(
+        self, agent, monkeypatch
+    ):
+        """Read-only MCP tools keep working unattended — the capability loss is
+        scoped to tools the server never proved safe."""
+        from gaia.ui.sse_handler import SSEOutputHandler
+
+        handler = SSEOutputHandler.__new__(SSEOutputHandler)
+        handler.background_mode = True
+        monkeypatch.setattr(handler, "_emit", lambda _e: None, raising=False)
+
+        agent.console = handler
+        name = _register_mcp(agent, "get_current_time", {"readOnlyHint": True}, "time")
+
+        assert agent._execute_tool(name, {})["status"] == "success"
+
+
+class TestUnprefixedAliasCannotBypass:
+    def test_alias_resolution_happens_before_the_gate(self, agent):
+        """Local models often drop the ``mcp_<server>_`` prefix. Resolution must
+        run first, or calling the bare name would skip the gate."""
+        _register_mcp(agent, "write_file", server="acme")
+
+        result = agent._execute_tool(
+            "write_file", {"path": "/tmp/x", "content": "boom"}
+        )
+
+        assert result["status"] == "denied"
+        assert agent.executed == []
+
+
+class TestNativeToolsStillGated:
+    def test_static_set_behaviour_is_unchanged(self, agent):
+        agent._instance_tools["write_file"] = {
+            "name": "write_file",
+            "description": "native write",
+            "parameters": {"path": {"type": "string", "required": True}},
+            "function": lambda path: agent.executed.append(path),
+        }
+        assert agent._execute_tool("write_file", {"path": "/tmp/x"})["status"] == (
+            "denied"
+        )
+        assert agent.executed == []

--- a/tests/unit/agents/test_tool_not_found_error.py
+++ b/tests/unit/agents/test_tool_not_found_error.py
@@ -42,6 +42,12 @@ def _make_agent_with_tools(tool_names):
             "description": "stub",
             "parameters": {},
             "function": lambda **kwargs: {"status": "success"},
+            # These tests exercise name resolution, not the confirmation gate.
+            # ``mcp_``-prefixed entries fail closed when they carry no verdict,
+            # so stub them the way ``MCPTool.to_gaia_format`` stamps a tool the
+            # server proved read-only; otherwise the call is denied before
+            # resolution is ever reached.
+            "requires_confirmation": False,
         }
         for name in tool_names
     }

--- a/tests/unit/mcp/client/test_mcp_tool_risk_classification.py
+++ b/tests/unit/mcp/client/test_mcp_tool_risk_classification.py
@@ -1,0 +1,255 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""Unit tests for MCP tool risk classification.
+
+MCP tool names are chosen by the connected server, so they can never appear in
+GAIA's static ``TOOLS_REQUIRING_CONFIRMATION`` set. The classification instead
+travels with the registry entry as ``requires_confirmation``, computed here.
+
+The invariant under test is **fail closed**: a tool is exempt from the
+confirmation gate only when the server proves it is read-only. Silence,
+ambiguity, or a read-only claim contradicted by the tool's own name all mean
+"confirm".
+"""
+
+import pytest
+
+from gaia.mcp.client.mcp_client import MCPTool, mcp_tool_requires_confirmation
+
+
+def _tool(name, annotations=None):
+    return MCPTool(
+        name=name,
+        description=f"{name} description",
+        input_schema={"type": "object", "properties": {}, "required": []},
+        annotations=annotations if annotations is not None else {},
+    )
+
+
+class TestFailClosedDefaults:
+    """Anything the server does not prove read-only requires confirmation."""
+
+    @pytest.mark.parametrize(
+        "annotations",
+        [
+            {},  # server sent no annotations at all
+            {"destructiveHint": False},  # unrelated hints don't exempt
+            {"readOnlyHint": False},
+            {"readOnlyHint": None},
+            {"readOnlyHint": "true"},  # string, not boolean — not proof
+            {"readOnlyHint": 1},  # truthy but not True — not proof
+        ],
+        ids=[
+            "no-annotations",
+            "unrelated-hint",
+            "explicitly-not-read-only",
+            "null-hint",
+            "string-hint",
+            "truthy-non-bool-hint",
+        ],
+    )
+    def test_unproven_read_only_requires_confirmation(self, annotations):
+        assert mcp_tool_requires_confirmation("search_docs", annotations) is True
+
+    def test_missing_annotations_dict_requires_confirmation(self):
+        assert mcp_tool_requires_confirmation("search_docs", None) is True
+
+
+class TestReadOnlyExemption:
+    """A server that declares read-only for a read-shaped tool is believed."""
+
+    @pytest.mark.parametrize(
+        "name",
+        ["get_current_time", "search", "list_repositories", "readFile", "describe_db"],
+    )
+    def test_declared_read_only_is_exempt(self, name):
+        assert mcp_tool_requires_confirmation(name, {"readOnlyHint": True}) is False
+
+
+class TestNameOverridesReadOnlyClaim:
+    """A mutating verb in the name outranks a ``readOnlyHint: true`` claim.
+
+    A server advertising ``delete_file`` as read-only is buggy or hostile;
+    either way its annotation must not open the gate.
+    """
+
+    @pytest.mark.parametrize(
+        "name",
+        [
+            "write_file",
+            "delete_file",
+            "create_repository",
+            "push_files",
+            "execute_command",
+            "move_file",
+            "send_message",
+            "run_query",
+            "update_issue",
+            "commit",
+        ],
+    )
+    def test_snake_case_mutating_name_still_confirms(self, name):
+        assert mcp_tool_requires_confirmation(name, {"readOnlyHint": True}) is True
+
+    @pytest.mark.parametrize(
+        "name",
+        [
+            "writeFile",
+            "deleteBranch",
+            "createOrUpdateFile",
+            "executeCommand",
+            "WRITEFile",  # screaming camel — must not collapse to one token
+            "POSTMessage",
+        ],
+    )
+    def test_camel_case_mutating_name_still_confirms(self, name):
+        """Token splitting must handle camelCase — many MCP servers use it."""
+        assert mcp_tool_requires_confirmation(name, {"readOnlyHint": True}) is True
+
+    @pytest.mark.parametrize(
+        "name",
+        [
+            # desktop-commander renamed execute_command to these — the exact
+            # RCE tools named in the vulnerability report.
+            "start_process",
+            "interact_with_process",
+            # github
+            "fork_repository",
+            "approve_pull_request",
+            "submit_pending_pull_request_review",
+            "assign_copilot_to_issue",
+            "lock_issue",
+            "transfer_issue",
+            "mark_all_notifications_read",
+            # git / filesystem
+            "git_checkout",
+            "clone_repository",
+            "copy_file",
+            "mkdir",
+            "chmod",
+            # slack
+            "slack_post_message",
+            "post_comment",
+            # postgres
+            "alter_table",
+            "grant_privileges",
+            "restore_backup",
+            # containers / workflows
+            "restart_container",
+            "stop_container",
+            "launch_app",
+            "trigger_workflow",
+            # misc real-world destructive verbs
+            "disable_user",
+            "provision_vm",
+            "invite_user",
+            "share_document",
+            "cancel_order",
+            "sign_transaction",
+            "pay_invoice",
+            "flush_cache",
+            "clear_index",
+            "sync_folder",
+            "import_data",
+            "archive_thread",
+            "dismiss_notification",
+        ],
+    )
+    def test_real_world_server_verbs_are_covered(self, name):
+        """Regression for the false-negative surface: these are actual tool
+        names shipped by widely-used MCP servers. A ``readOnlyHint: true`` on
+        any of them must not open the gate."""
+        assert mcp_tool_requires_confirmation(name, {"readOnlyHint": True}) is True
+
+    def test_substring_match_does_not_false_positive(self):
+        """``list_updates`` contains 'update' as a token and is treated as
+        mutating; ``forward`` merely *contains* the letters of no verb token and
+        must stay exempt. Tokenisation, not substring search."""
+        assert (
+            mcp_tool_requires_confirmation("forward", {"readOnlyHint": True}) is False
+        )
+        assert (
+            mcp_tool_requires_confirmation("setting", {"readOnlyHint": True}) is False
+        )
+
+
+class TestRegistryEntry:
+    """``to_gaia_format`` must stamp the flag onto the registry entry."""
+
+    def test_unannotated_tool_entry_requires_confirmation(self):
+        entry = _tool("write_file").to_gaia_format("filesystem")
+        assert entry["name"] == "mcp_filesystem_write_file"
+        assert entry["requires_confirmation"] is True
+
+    def test_declared_read_only_tool_entry_is_exempt(self):
+        entry = _tool("get_current_time", {"readOnlyHint": True}).to_gaia_format("time")
+        assert entry["requires_confirmation"] is False
+
+    def test_every_amd_catalogued_write_tool_is_gated(self):
+        """The write/destructive tools of the MCP servers GAIA catalogues must
+        all be gated even though none of them appears in any static set."""
+        catalogued_writes = [
+            "create_or_update_file",
+            "push_files",
+            "delete_file",
+            "create_repository",
+            "create_pull_request",
+            "fork_repository",
+            "write_file",
+            "edit_file",
+            "move_file",
+            "create_directory",
+            "execute_command",
+            "edit_block",
+        ]
+        for name in catalogued_writes:
+            entry = _tool(name).to_gaia_format("srv")
+            assert entry["requires_confirmation"] is True, name
+
+
+class TestListToolsCapturesAnnotations:
+    """Annotations must survive the ``tools/list`` parse, or every tool would
+    silently fall back to 'no annotations'."""
+
+    def _client_with_tools(self, tools_payload):
+        from unittest.mock import Mock
+
+        from gaia.mcp.client.mcp_client import MCPClient
+
+        client = MCPClient.__new__(MCPClient)
+        client.name = "srv"
+        client._tools = None
+        client.transport = Mock()
+        client.transport.send_request.return_value = {
+            "result": {"tools": tools_payload}
+        }
+        return client
+
+    def test_annotations_are_parsed(self):
+        client = self._client_with_tools(
+            [
+                {
+                    "name": "get_time",
+                    "description": "d",
+                    "inputSchema": {},
+                    "annotations": {"readOnlyHint": True},
+                }
+            ]
+        )
+        assert client.list_tools()[0].annotations == {"readOnlyHint": True}
+
+    @pytest.mark.parametrize("bad", ["readonly", ["readOnlyHint"], 1, None])
+    def test_non_dict_annotations_degrade_to_gated_not_trusted(self, bad):
+        client = self._client_with_tools(
+            [
+                {
+                    "name": "get_time",
+                    "description": "d",
+                    "inputSchema": {},
+                    "annotations": bad,
+                }
+            ]
+        )
+        tool = client.list_tools()[0]
+        assert tool.annotations == {}
+        assert tool.to_gaia_format("srv")["requires_confirmation"] is True


### PR DESCRIPTION
Connecting any MCP server to GAIA gave every one of its tools a free pass on the confirmation prompt — including file writes, repo deletes and shell execution. The guardrail matches a fixed list of tool names, and MCP tool names are supplied by the connected server, so no MCP tool could ever match it. That made a prompt injection in a document, email or web page the agent was asked to read a direct path to a write the user never approved. MCP tools now carry their own risk classification and prompt unless the server proves the tool is read-only, so they are gated the same way GAIA's own write tools are.

Reported via responsible disclosure. Reproduced on `main` before the fix and confirmed closed after, against a live MCP server.

Builds directly on #2210: that change made consoles deny rather than answer for an absent human, and this one makes MCP tools reach that gate in the first place. The two together mean an injected MCP write is refused on the CLI and prompts in the Agent UI, instead of running silently on both.

A tool is exempt only when its server sets the MCP-spec `readOnlyHint` to `true` **and** its name carries no mutating verb — so a server that ships no annotations gets no benefit of the doubt, and a `readOnlyHint: true` on a tool named `delete_file` is ignored. Note this defends against servers that annotate incorrectly, not against a malicious server, which could simply name its write tool something innocuous; vetting the server remains the control for that.

## Test plan

- [ ] `python -m pytest tests/unit/mcp/client/test_mcp_tool_risk_classification.py tests/unit/agents/test_mcp_tool_confirmation_gate.py -q` (65 tests)
- [ ] `python -m pytest tests/unit/mcp/ tests/unit/agents/ -q` — no new failures vs. the pre-existing baseline
- [ ] Connect an MCP server exposing a write tool, ask an agent to use it in the Agent UI, confirm the permission modal appears and that denying it prevents the write
- [ ] Connect a server declaring `readOnlyHint: true` on a read tool, confirm it still runs with no prompt
- [ ] Confirm calling the tool by its short name (`write_file` rather than `mcp_<server>_write_file`) is also gated
- [ ] Confirm an unattended run (no TTY) refuses an unannotated MCP write tool rather than running it
- [ ] `python util/lint.py --all`
