### PR TITLE
fix(security): launch MCP servers without a shell, protect ~/.gaia from agent writes

### DIFF
--- a/.security-suppressions.json
+++ b/.security-suppressions.json
@@ -9,11 +9,6 @@
       "path": "src/gaia/agents/tools/shell_tools.py",
       "rule": "B602",
       "justification": "Sandboxed shell tool. Every command (and each pipeline segment) is validated against a whitelist via _validate_command before execution; shell=True is enabled ONLY on Windows so cmd.exe can resolve built-ins (dir/cd/type) and pipes that Git-for-Windows tools rely on. Converting to args-list would break piped/whitelisted commands the tool exists to run."
-    },
-    {
-      "path": "src/gaia/mcp/client/transports/stdio.py",
-      "rule": "B602",
-      "justification": "Legacy from_command() API accepts a full shell command STRING (documented contract, e.g. commands using pipes/env-expansion) and needs shell parsing. Command is caller-supplied SDK config, not external/untrusted input; modern from_config() passes an args list and runs shell=False."
     }
   ]
 }

--- a/docs/sdk/sdks/mcp.mdx
+++ b/docs/sdk/sdks/mcp.mdx
@@ -341,7 +341,7 @@ if "error" in result:
 | Method | Description |
 |--------|-------------|
 | `from_config(name, config)` | Create client from config dict |
-| `from_command(name, command)` | Create client (legacy, shell string) |
+| `from_command(name, command)` | Create client from a command line (legacy; tokenized, never shell-interpreted) |
 | `connect()` | Connect to server. Returns `bool`. |
 | `disconnect()` | Disconnect |
 | `list_tools()` | List available tools (cached). Returns `list[MCPTool]`. |

--- a/docs/spec/mcp-client.mdx
+++ b/docs/spec/mcp-client.mdx
@@ -1000,10 +1000,13 @@ def connect(self) -> bool:
     Raises:
         ValueError: If a single-string command is blank, has unbalanced
             quotes, or carries unquoted shell syntax (";", "|", "&&", ">",
-            "`", "$(", ...). Such syntax is rejected rather than passed
-            through as literal argv text — split the program from its
-            arguments using `args` instead. The same characters *inside a
-            quoted argument* are ordinary text and are accepted.
+            "$(", ...). Such syntax is rejected rather than passed through
+            as literal argv text — split the program from its arguments
+            using `args` instead. The same characters *inside a quoted
+            argument* are ordinary text and are accepted. A backtick is the
+            exception: it is rejected wherever it appears, because it never
+            forms a token of its own and quoting state cannot be recovered
+            after tokenizing. Pass such a value via `args`.
 
     Note:
         Returns True without starting new process if already connected.
@@ -1393,7 +1396,7 @@ gaia mcp test-client <name>
 gaia mcp remove <name>
 ```
 
-The CLI accepts a full command line for convenience and converts it to the config format internally. The command is tokenized, not run through a shell, so unquoted shell syntax (`;`, `|`, `&&`, `>`, backticks) is rejected rather than interpreted.
+The CLI accepts a full command line for convenience and converts it to the config format internally. The command is tokenized, not run through a shell, so unquoted shell syntax (`;`, `|`, `&&`, `>`) — and a backtick anywhere in the string — is rejected rather than interpreted. Use the config format's `args` list for values that must contain those characters.
 
 See [CLI Reference](/reference/cli#mcp-client) for complete documentation.
 

--- a/docs/spec/mcp-client.mdx
+++ b/docs/spec/mcp-client.mdx
@@ -946,7 +946,8 @@ class StdioTransport(MCPTransport):
     via stdin/stdout using JSON-RPC messages.
 
     Attributes:
-        command (str): Shell command to start server
+        command (str): Program to start the server
+        args (list[str] | None): Arguments passed to the program
         timeout (int): Request timeout in seconds
         debug (bool): Debug logging enabled
         _process (subprocess.Popen): Subprocess instance
@@ -957,14 +958,25 @@ class StdioTransport(MCPTransport):
 #### Constructor
 
 ```python
-def __init__(self, command: str, timeout: int = 30, debug: bool = False):
+def __init__(
+    self,
+    command: str,
+    args: list[str] | None = None,
+    env: dict[str, str] | None = None,
+    timeout: int = 30,
+    debug: bool = False,
+):
     """Create stdio transport.
 
     Args:
-        command (str): Shell command to start the MCP server
-            Examples:
-            - "npx @modelcontextprotocol/server-filesystem /tmp"
-            - "python -m my_mcp_server"
+        command (str): Program to start the MCP server, e.g. "npx".
+            A full command line ("npx -y @scope/server") is also accepted and
+            tokenized into an argv list — it is never run through a shell.
+            `~` and environment variables in that string are still expanded.
+        args (list[str] | None): Arguments for the program, e.g.
+            ["-y", "@modelcontextprotocol/server-filesystem", "/tmp"]
+        env (dict[str, str] | None): Extra environment variables, merged
+            over the current process environment
         timeout (int): Request timeout in seconds (default: 30)
         debug (bool): Enable debug logging (default: False)
     """
@@ -977,13 +989,21 @@ def connect(self) -> bool:
     """Launch the MCP server subprocess.
 
     Uses subprocess.Popen with:
-    - shell=True
+    - shell=False, always — the command is resolved to an argv list first
     - stdin/stdout/stderr pipes
     - text mode with UTF-8 encoding
     - Line buffering (bufsize=1)
 
     Returns:
         bool: True if process started successfully
+
+    Raises:
+        ValueError: If a single-string command is blank, has unbalanced
+            quotes, or carries unquoted shell syntax (";", "|", "&&", ">",
+            "`", "$(", ...). Such syntax is rejected rather than passed
+            through as literal argv text — split the program from its
+            arguments using `args` instead. The same characters *inside a
+            quoted argument* are ordinary text and are accepted.
 
     Note:
         Returns True without starting new process if already connected.
@@ -1353,7 +1373,7 @@ The `env` field passes variables directly to the subprocess without shell expans
 ## CLI Commands
 
 ```bash
-# Add server (shell command string - converted to config format internally)
+# Add server (command line - tokenized into the config format internally)
 gaia mcp add <name> "<command>"
 
 # Examples
@@ -1373,7 +1393,7 @@ gaia mcp test-client <name>
 gaia mcp remove <name>
 ```
 
-The CLI accepts shell command strings for convenience and converts them to the config format internally.
+The CLI accepts a full command line for convenience and converts it to the config format internally. The command is tokenized, not run through a shell, so unquoted shell syntax (`;`, `|`, `&&`, `>`, backticks) is rejected rather than interpreted.
 
 See [CLI Reference](/reference/cli#mcp-client) for complete documentation.
 

--- a/src/gaia/mcp/client/mcp_client.py
+++ b/src/gaia/mcp/client/mcp_client.py
@@ -224,12 +224,18 @@ class MCPClient:
 
         Args:
             name: Friendly name for this server
-            command: Shell command to start the server
+            command: Command line to start the server, e.g. ``"npx -y server"``.
+                Tokenized into an argv list, never run through a shell — prefer
+                :meth:`from_config` with an explicit ``args`` list.
             timeout: Request timeout in seconds
             debug: Enable debug logging
 
         Returns:
             MCPClient: Configured client instance
+
+        Raises:
+            ValueError: If ``command`` contains shell syntax, which would not be
+                interpreted. Pass the program and its arguments separately.
         """
         transport = StdioTransport(command, timeout=timeout, debug=debug)
         return cls(name, transport, debug=debug)

--- a/src/gaia/mcp/client/transports/stdio.py
+++ b/src/gaia/mcp/client/transports/stdio.py
@@ -4,6 +4,7 @@
 
 import json
 import os
+import shlex
 import shutil
 import signal
 import subprocess
@@ -16,6 +17,65 @@ from .base import MCPTransport
 
 logger = get_logger(__name__)
 
+# Operator characters shlex isolates into their own token when unquoted. A
+# token made only of these was shell syntax; quoted uses stay inside a larger
+# token and are inert under shell=False, so they are left alone.
+_SHELL_OPERATOR_CHARS = frozenset(";|&<>()")
+
+_FIX_HINT = (
+    'Split the program from its arguments instead: {"command": "npx", '
+    '"args": ["-y", "@scope/server"]}. See docs/spec/mcp-client.mdx.'
+)
+
+
+def _split_command_string(command: str) -> List[str]:
+    """Split a single-string server command into an argv list.
+
+    Args:
+        command: Full command line, e.g. ``"npx -y @scope/server"``.
+
+    Returns:
+        List[str]: argv tokens, program first, with ``~`` and environment
+        variables expanded the way the shell used to expand them.
+
+    Raises:
+        ValueError: If the string is blank, unparseable, or carries shell
+            syntax that would no longer be interpreted.
+    """
+    # Windows: double the backslashes so POSIX quoting rules apply without
+    # eating path separators. Matches what CommandLineToArgvW would produce.
+    raw = command.replace("\\", "\\\\") if os.name == "nt" else command
+
+    lexer = shlex.shlex(raw, posix=True, punctuation_chars=True)
+    lexer.whitespace_split = True
+    try:
+        tokens = list(lexer)
+    except ValueError as exc:
+        raise ValueError(
+            f"MCP server command could not be parsed ({exc}): {command!r}. "
+            f"Check for unbalanced quotes. {_FIX_HINT}"
+        ) from exc
+
+    if not tokens:
+        raise ValueError(
+            f"MCP server command is empty: {command!r}. Set 'command' to the "
+            f'program to run, e.g. "npx". {_FIX_HINT}'
+        )
+
+    for token in tokens:
+        # Backticks never form their own token, so check them per-token.
+        if set(token) <= _SHELL_OPERATOR_CHARS or "`" in token:
+            raise ValueError(
+                f"MCP server command contains shell syntax ({token!r}): "
+                f"{command!r}. GAIA launches MCP servers without a shell, so this "
+                f"would be passed through as literal text rather than interpreted. "
+                f"{_FIX_HINT}"
+            )
+
+    # The shell used to expand these; do it here so existing configs using
+    # ~ or $VAR/%VAR% keep resolving instead of reaching the child literally.
+    return [os.path.expandvars(os.path.expanduser(token)) for token in tokens]
+
 
 class StdioTransport(MCPTransport):
     """Stdio-based transport using subprocess for MCP servers.
@@ -23,9 +83,12 @@ class StdioTransport(MCPTransport):
     This transport launches MCP servers as subprocesses and communicates
     via stdin/stdout using JSON-RPC messages.
 
-    Supports two modes:
-    1. Legacy: command string with shell=True (e.g., "npx -y server")
-    2. Modern: command + args list with shell=False (more secure, matches Anthropic format)
+    Servers are always launched with ``shell=False``. Two input shapes are
+    accepted:
+
+    1. Legacy: a single command string (e.g. ``"npx -y server"``), tokenized
+       here into an argv list rather than handed to a shell.
+    2. Modern: ``command`` plus an ``args`` list (matches the Anthropic format).
 
     Args:
         command: Base command to start the MCP server (e.g., "npx" or "python")
@@ -51,28 +114,47 @@ class StdioTransport(MCPTransport):
         self._process: Optional[subprocess.Popen] = None
         self._request_id = 0
 
+    def _build_argv(self) -> List[str]:
+        """Resolve this transport's command into an argv list for ``shell=False``.
+
+        Returns:
+            List[str]: Program path (resolved via PATH when possible) plus args.
+
+        Raises:
+            ValueError: If a single-string command cannot be tokenized safely.
+        """
+        if self.args:
+            program, extra = self.command, list(self.args)
+        else:
+            tokens = _split_command_string(self.command)
+            program, extra = tokens[0], tokens[1:]
+
+        # Resolve via PATH (handles Windows .cmd/.bat extensions). Keep this —
+        # Popen needs the .cmd suffix to launch npx-style shims with shell=False.
+        resolved = shutil.which(program)
+        return [resolved or program] + extra
+
     def connect(self) -> bool:
         """Launch the MCP server subprocess.
 
         Returns:
             bool: True if process started successfully
+
+        Raises:
+            ValueError: If the configured command cannot be tokenized safely.
+            RuntimeError: If the process dies immediately after launch.
         """
         if self._process is not None:
             logger.warning("Transport already connected")
             return True
 
-        try:
-            # Determine if we use shell mode (legacy) or args mode (modern)
-            use_shell = not self.args  # Use shell if no args provided
-            if use_shell:
-                cmd = self.command
-            else:
-                # Resolve command via PATH (handles Windows .cmd/.bat extensions)
-                resolved = shutil.which(self.command)
-                cmd = [resolved or self.command] + self.args
+        # Built outside the try so a bad command surfaces as an actionable
+        # ValueError instead of a bare "failed to start" False.
+        argv = self._build_argv()
 
+        try:
             if self.debug:
-                logger.debug(f"Starting MCP server with command: {cmd}")
+                logger.debug(f"Starting MCP server with command: {argv}")
 
             # Merge environment if provided
             merged_env = None
@@ -80,13 +162,9 @@ class StdioTransport(MCPTransport):
                 merged_env = os.environ.copy()
                 merged_env.update(self.env)
 
-            # Legacy from_command() path passes a full shell command string
-            # (documented contract) and needs shell parsing; modern from_config()
-            # passes an args list and runs shell=False. Command is caller-supplied
-            # SDK config, not external/untrusted input.
             self._process = subprocess.Popen(
-                cmd,
-                shell=use_shell,  # nosec B602 - legacy shell-string API, trusted SDK config
+                argv,
+                shell=False,
                 stdin=subprocess.PIPE,
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,

--- a/src/gaia/mcp/client/transports/stdio.py
+++ b/src/gaia/mcp/client/transports/stdio.py
@@ -63,7 +63,8 @@ def _split_command_string(command: str) -> List[str]:
         )
 
     for token in tokens:
-        # Backticks never form their own token, so check them per-token.
+        # A backtick never forms its own token, so quoting state is already
+        # lost here — reject it anywhere in the string rather than guess.
         if set(token) <= _SHELL_OPERATOR_CHARS or "`" in token:
             raise ValueError(
                 f"MCP server command contains shell syntax ({token!r}): "

--- a/src/gaia/security.py
+++ b/src/gaia/security.py
@@ -66,6 +66,50 @@ SENSITIVE_EXTENSIONS: Set[str] = {
 }
 
 
+# Subdirectories of GAIA's state tree that hold user content rather than
+# configuration. The Agent UI puts browser uploads here and makes them the
+# session's allowed path, so blanket-blocking the tree would break "save this
+# file" in a drag-and-drop session.
+GAIA_STATE_USER_CONTENT_SUBDIRS: Set[str] = {
+    "documents",
+    "chat",
+    "screenshots",
+    "eval",
+}
+
+
+def _gaia_state_dirs() -> Set[str]:
+    """Return every normalized path GAIA keeps its own state in.
+
+    Returns:
+        Set of normalized directory paths (``~/.gaia`` plus any relocation
+        set via ``GAIA_CONFIG_DIR`` or ``GAIA_HOME``).
+    """
+    candidates = [Path.home() / ".gaia"]
+    for env_var in ("GAIA_CONFIG_DIR", "GAIA_HOME"):
+        override = os.environ.get(env_var)
+        if override:
+            candidates.append(Path(os.path.expandvars(os.path.expanduser(override))))
+    return {os.path.normpath(str(c)) for c in candidates}
+
+
+def _is_gaia_user_content(norm_path: str, state_dir: str) -> bool:
+    """Whether *norm_path* is user content inside GAIA's state dir, not config.
+
+    Args:
+        norm_path: Normalized, symlink-resolved path being written to.
+        state_dir: Normalized GAIA state directory containing it.
+
+    Returns:
+        True if the first path segment below *state_dir* is user content.
+    """
+    relative = norm_path[len(state_dir) :].lstrip("\\/")
+    if not relative:
+        return False
+    first_segment = relative.replace("\\", "/").split("/", 1)[0].lower()
+    return first_segment in GAIA_STATE_USER_CONTENT_SUBDIRS
+
+
 def _get_blocked_directories() -> Set[str]:
     """Get platform-specific directories that should never be written to.
 
@@ -132,6 +176,12 @@ def _get_blocked_directories() -> Set[str]:
             ]
         )
 
+    # GAIA's own state directories. Agent file tools must never rewrite the
+    # config that decides which binaries GAIA launches (e.g. mcp_servers.json)
+    # or which paths it trusts; GAIA's internals write here directly, not
+    # through this class. GAIA_CONFIG_DIR / GAIA_HOME relocate the tree.
+    blocked.update(str(d) for d in _gaia_state_dirs())
+
     # Remove empty strings from env var failures
     blocked.discard("")
     blocked.discard(os.path.normpath(""))
@@ -141,6 +191,7 @@ def _get_blocked_directories() -> Set[str]:
 
 # Pre-compute once at module load
 BLOCKED_DIRECTORIES: Set[str] = _get_blocked_directories()
+GAIA_STATE_DIRECTORIES: Set[str] = _gaia_state_dirs()
 
 
 def _normalize_macos_symlinks(path_str: str) -> str:
@@ -439,7 +490,7 @@ class PathValidator:
         """Check if a path is blocked for write operations.
 
         Checks against:
-        1. System/blocked directories (Windows, /etc, .ssh, etc.)
+        1. System/blocked directories (Windows, /etc, .ssh, ~/.gaia, etc.)
         2. Sensitive file names (.env, credentials, keys, etc.)
         3. Sensitive file extensions (.pem, .key, .crt, etc.)
 
@@ -473,10 +524,14 @@ class PathValidator:
                     normalized_blocked.lower() if is_windows else normalized_blocked
                 )
                 if cmp_norm.startswith(cmp_blocked + os.sep) or cmp_norm == cmp_blocked:
+                    if normalized_blocked in GAIA_STATE_DIRECTORIES and (
+                        _is_gaia_user_content(norm_path, normalized_blocked)
+                    ):
+                        continue
                     return (
                         True,
                         f"Write blocked: '{real_path}' is inside protected "
-                        f"system directory '{blocked_dir}'",
+                        f"directory '{blocked_dir}'",
                     )
 
             # Check sensitive file names

--- a/tests/unit/mcp/client/test_transports.py
+++ b/tests/unit/mcp/client/test_transports.py
@@ -334,6 +334,16 @@ class TestStdioTransport:
 
         assert mock_popen.call_args[0][0] == expected
 
+    @patch("gaia.mcp.client.transports.stdio.subprocess.Popen")
+    def test_stdio_transport_rejects_backtick_even_when_quoted(self, mock_popen):
+        """Backticks are refused everywhere — tokenizing loses their quote state."""
+        transport = StdioTransport('srv --arg "a`b"')
+
+        with pytest.raises(ValueError, match="shell syntax"):
+            transport.connect()
+
+        mock_popen.assert_not_called()
+
     @patch("gaia.mcp.client.transports.stdio.shutil.which", return_value=None)
     @patch("gaia.mcp.client.transports.stdio.subprocess.Popen")
     def test_stdio_transport_keeps_quoted_value_with_spaces(self, mock_popen, _):
@@ -350,10 +360,11 @@ class TestStdioTransport:
             r"--root=C:\Program Files\data",
         ]
 
+    @patch("gaia.mcp.client.transports.stdio.os.name", "nt")
     @patch("gaia.mcp.client.transports.stdio.shutil.which", return_value=None)
     @patch("gaia.mcp.client.transports.stdio.subprocess.Popen")
-    def test_stdio_transport_preserves_backslash_paths(self, mock_popen, _):
-        """Windows path separators survive tokenizing."""
+    def test_stdio_transport_preserves_backslash_paths_on_windows(self, mock_popen, _):
+        """On Windows a backslash is a path separator, not an escape."""
         mock_process = Mock()
         mock_process.poll.return_value = None
         mock_popen.return_value = mock_process
@@ -362,6 +373,20 @@ class TestStdioTransport:
         transport.connect()
 
         assert mock_popen.call_args[0][0] == ["python", r"C:\tools\srv.py"]
+
+    @patch("gaia.mcp.client.transports.stdio.os.name", "posix")
+    @patch("gaia.mcp.client.transports.stdio.shutil.which", return_value=None)
+    @patch("gaia.mcp.client.transports.stdio.subprocess.Popen")
+    def test_stdio_transport_honours_backslash_escapes_on_posix(self, mock_popen, _):
+        """On POSIX a backslash escapes the next character, as the shell did."""
+        mock_process = Mock()
+        mock_process.poll.return_value = None
+        mock_popen.return_value = mock_process
+
+        transport = StdioTransport(r"srv /opt/my\ server/run.py")
+        transport.connect()
+
+        assert mock_popen.call_args[0][0] == ["srv", "/opt/my server/run.py"]
 
     @patch("gaia.mcp.client.transports.stdio.shutil.which", side_effect=lambda cmd: cmd)
     @patch("gaia.mcp.client.transports.stdio.subprocess.Popen")

--- a/tests/unit/mcp/client/test_transports.py
+++ b/tests/unit/mcp/client/test_transports.py
@@ -3,6 +3,7 @@
 """Unit tests for MCP transport implementations."""
 
 import json
+import os
 import sys
 from io import StringIO
 from unittest.mock import Mock, patch
@@ -235,9 +236,10 @@ class TestStdioTransport:
         # Config env should be merged
         assert passed_env["API_KEY"] == "secret123"
 
+    @patch("gaia.mcp.client.transports.stdio.shutil.which", side_effect=lambda cmd: cmd)
     @patch("gaia.mcp.client.transports.stdio.subprocess.Popen")
-    def test_stdio_transport_legacy_command_string_still_works(self, mock_popen):
-        """Test backward compat: command string without args uses shell=True."""
+    def test_stdio_transport_legacy_command_string_still_works(self, mock_popen, _):
+        """Test backward compat: a command string is tokenized, not shelled out."""
         mock_process = Mock()
         mock_process.poll.return_value = None
         mock_popen.return_value = mock_process
@@ -246,13 +248,13 @@ class TestStdioTransport:
         transport.connect()
 
         call_args = mock_popen.call_args
-        # Legacy string command uses shell=True
-        assert call_args[0][0] == "npx -y @modelcontextprotocol/server-github"
-        assert call_args[1]["shell"] is True
+        assert call_args[0][0] == ["npx", "-y", "@modelcontextprotocol/server-github"]
+        assert call_args[1]["shell"] is False
 
+    @patch("gaia.mcp.client.transports.stdio.shutil.which", side_effect=lambda cmd: cmd)
     @patch("gaia.mcp.client.transports.stdio.subprocess.Popen")
-    def test_stdio_transport_empty_args_treated_as_none(self, mock_popen):
-        """Test that empty args list is treated same as None."""
+    def test_stdio_transport_empty_args_treated_as_none(self, mock_popen, _):
+        """Test that empty args list is tokenized like a legacy command string."""
         mock_process = Mock()
         mock_process.poll.return_value = None
         mock_popen.return_value = mock_process
@@ -261,8 +263,168 @@ class TestStdioTransport:
         transport.connect()
 
         call_args = mock_popen.call_args
-        # Empty args should use shell mode like legacy
-        assert call_args[1]["shell"] is True
+        assert call_args[0][0] == ["echo", "test"]
+        assert call_args[1]["shell"] is False
+
+    @patch("gaia.mcp.client.transports.stdio.subprocess.Popen")
+    def test_stdio_transport_never_uses_shell(self, mock_popen):
+        """Every launch path must pass shell=False to Popen."""
+        mock_process = Mock()
+        mock_process.poll.return_value = None
+        mock_popen.return_value = mock_process
+
+        for transport in (
+            StdioTransport("echo"),
+            StdioTransport("echo", args=["hello"]),
+            StdioTransport("echo hello"),
+        ):
+            mock_popen.reset_mock()
+            transport.connect()
+            assert mock_popen.call_args[1]["shell"] is False
+            assert isinstance(mock_popen.call_args[0][0], list)
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            "echo hi; echo bye",
+            "echo hi && echo bye",
+            "echo hi | tee out.txt",
+            "echo hi > out.txt",
+            "echo `id`",
+            "echo $(id)",
+        ],
+    )
+    @patch("gaia.mcp.client.transports.stdio.subprocess.Popen")
+    def test_stdio_transport_rejects_shell_syntax(self, mock_popen, command):
+        """A command string with shell syntax is rejected, not silently mangled."""
+        transport = StdioTransport(command)
+
+        with pytest.raises(ValueError, match="shell syntax"):
+            transport.connect()
+
+        mock_popen.assert_not_called()
+
+    @pytest.mark.parametrize(
+        "command,expected",
+        [
+            # Shell metacharacters inside a quoted argument are inert under
+            # shell=False, so they must not be rejected.
+            (
+                'uvx mcp-postgres --dsn "postgres://u:p@h/db?ssl=1&x=2"',
+                ["uvx", "mcp-postgres", "--dsn", "postgres://u:p@h/db?ssl=1&x=2"],
+            ),
+            (
+                'python -c "import srv; srv.main()"',
+                ["python", "-c", "import srv; srv.main()"],
+            ),
+            ('srv --filter "a<b"', ["srv", "--filter", "a<b"]),
+        ],
+    )
+    @patch("gaia.mcp.client.transports.stdio.shutil.which", side_effect=lambda cmd: cmd)
+    @patch("gaia.mcp.client.transports.stdio.subprocess.Popen")
+    def test_stdio_transport_allows_quoted_metacharacters(
+        self, mock_popen, _, command, expected
+    ):
+        """Quoted shell characters are ordinary argument text, not syntax."""
+        mock_process = Mock()
+        mock_process.poll.return_value = None
+        mock_popen.return_value = mock_process
+
+        StdioTransport(command).connect()
+
+        assert mock_popen.call_args[0][0] == expected
+
+    @patch("gaia.mcp.client.transports.stdio.shutil.which", return_value=None)
+    @patch("gaia.mcp.client.transports.stdio.subprocess.Popen")
+    def test_stdio_transport_keeps_quoted_value_with_spaces(self, mock_popen, _):
+        """A quoted --flag=value with spaces stays a single argv token."""
+        mock_process = Mock()
+        mock_process.poll.return_value = None
+        mock_popen.return_value = mock_process
+
+        transport = StdioTransport(r'python --root="C:\Program Files\data"')
+        transport.connect()
+
+        assert mock_popen.call_args[0][0] == [
+            "python",
+            r"--root=C:\Program Files\data",
+        ]
+
+    @patch("gaia.mcp.client.transports.stdio.shutil.which", return_value=None)
+    @patch("gaia.mcp.client.transports.stdio.subprocess.Popen")
+    def test_stdio_transport_preserves_backslash_paths(self, mock_popen, _):
+        """Windows path separators survive tokenizing."""
+        mock_process = Mock()
+        mock_process.poll.return_value = None
+        mock_popen.return_value = mock_process
+
+        transport = StdioTransport(r"python C:\tools\srv.py")
+        transport.connect()
+
+        assert mock_popen.call_args[0][0] == ["python", r"C:\tools\srv.py"]
+
+    @patch("gaia.mcp.client.transports.stdio.shutil.which", side_effect=lambda cmd: cmd)
+    @patch("gaia.mcp.client.transports.stdio.subprocess.Popen")
+    def test_stdio_transport_expands_home_and_env_vars(self, mock_popen, _):
+        """~ and $VAR still resolve, as they did when a shell ran the command."""
+        mock_process = Mock()
+        mock_process.poll.return_value = None
+        mock_popen.return_value = mock_process
+
+        with patch.dict(os.environ, {"MCP_TEST_ROOT": "/srv/mcp"}):
+            transport = StdioTransport("python ~/mcp/server.py $MCP_TEST_ROOT")
+            transport.connect()
+
+        argv = mock_popen.call_args[0][0]
+        assert argv[1] == os.path.expanduser("~/mcp/server.py")
+        assert "~" not in argv[1]
+        assert argv[2] == "/srv/mcp"
+
+    @patch("gaia.mcp.client.transports.stdio.subprocess.Popen")
+    def test_stdio_transport_rejects_empty_command(self, mock_popen):
+        """A blank command is an actionable error, not a launch attempt."""
+        transport = StdioTransport("   ")
+
+        with pytest.raises(ValueError, match="empty"):
+            transport.connect()
+
+        mock_popen.assert_not_called()
+
+    @patch("gaia.mcp.client.transports.stdio.subprocess.Popen")
+    def test_stdio_transport_rejects_unbalanced_quotes(self, mock_popen):
+        """An unparseable command string reports why instead of failing opaquely."""
+        transport = StdioTransport('npx "unterminated')
+
+        with pytest.raises(ValueError, match="could not be parsed"):
+            transport.connect()
+
+        mock_popen.assert_not_called()
+
+    @patch("gaia.mcp.client.transports.stdio.shutil.which", return_value=None)
+    @patch("gaia.mcp.client.transports.stdio.subprocess.Popen")
+    def test_stdio_transport_keeps_quoted_path_intact(self, mock_popen, _):
+        """A quoted path with spaces stays one argv token."""
+        mock_process = Mock()
+        mock_process.poll.return_value = None
+        mock_popen.return_value = mock_process
+
+        transport = StdioTransport('"/opt/my servers/mcp" --stdio')
+        transport.connect()
+
+        assert mock_popen.call_args[0][0] == ["/opt/my servers/mcp", "--stdio"]
+
+    @patch("gaia.mcp.client.transports.stdio.shutil.which", side_effect=lambda cmd: cmd)
+    @patch("gaia.mcp.client.transports.stdio.subprocess.Popen")
+    def test_stdio_transport_args_list_is_not_tokenized(self, mock_popen, _):
+        """An explicit args entry is passed through verbatim, spaces and all."""
+        mock_process = Mock()
+        mock_process.poll.return_value = None
+        mock_popen.return_value = mock_process
+
+        transport = StdioTransport("python", args=["-c", "print('a b')"])
+        transport.connect()
+
+        assert mock_popen.call_args[0][0] == ["python", "-c", "print('a b')"]
 
     @patch("gaia.mcp.client.transports.stdio.subprocess.Popen")
     def test_read_stderr_from_dead_process(self, mock_popen):

--- a/tests/unit/test_file_write_guardrails.py
+++ b/tests/unit/test_file_write_guardrails.py
@@ -82,6 +82,10 @@ class TestBlockedDirectories:
         assert os.path.join(home, ".ssh") in BLOCKED_DIRECTORIES
         assert os.path.join(home, ".gnupg") in BLOCKED_DIRECTORIES
 
+    def test_gaia_state_dir_is_blocked(self):
+        """Verify GAIA's own state directory is blocked on every platform."""
+        assert os.path.normpath(str(Path.home() / ".gaia")) in BLOCKED_DIRECTORIES
+
     def test_get_blocked_directories_returns_set(self):
         """Verify _get_blocked_directories() returns a set of strings."""
         result = _get_blocked_directories()
@@ -266,6 +270,53 @@ class TestIsWriteBlocked:
         is_blocked, reason = validator.is_write_blocked("/etc/test_file.conf")
         assert is_blocked is True
         assert "blocked" in reason.lower()
+
+    def test_gaia_mcp_server_config_is_blocked(self, validator):
+        """Agent file tools must not be able to rewrite ~/.gaia/mcp_servers.json."""
+        target = str(Path.home() / ".gaia" / "mcp_servers.json")
+        is_blocked, reason = validator.is_write_blocked(target)
+        assert is_blocked is True
+        assert "blocked" in reason.lower()
+
+    def test_gaia_state_dir_blocked_even_when_allowlisted(self, tmp_path):
+        """The denylist wins over an allowlist entry covering ~/.gaia."""
+        gaia_dir = Path.home() / ".gaia"
+        validator = PathValidator(allowed_paths=[str(gaia_dir), str(tmp_path)])
+        is_allowed, reason = validator.validate_write(
+            str(gaia_dir / "mcp_servers.json"), prompt_user=False
+        )
+        assert is_allowed is False
+        assert "blocked" in reason.lower()
+
+    @pytest.mark.parametrize(
+        "relative",
+        [
+            "connectors/google.json",
+            "agents/custom/agent.py",
+            "cache/allowed_paths.json",
+        ],
+    )
+    def test_gaia_config_surfaces_are_blocked(self, validator, relative):
+        """Config and installed-code surfaces under ~/.gaia stay protected."""
+        target = str(Path.home() / ".gaia" / relative)
+        is_blocked, _ = validator.is_write_blocked(target)
+        assert is_blocked is True
+
+    @pytest.mark.parametrize(
+        "relative",
+        ["documents/report.pdf", "chat/uploads/notes.txt", "screenshots/shot.png"],
+    )
+    def test_gaia_user_content_dirs_remain_writable(self, validator, relative):
+        """Agent UI upload dirs are user content, not config — writes still allowed."""
+        target = str(Path.home() / ".gaia" / relative)
+        is_blocked, reason = validator.is_write_blocked(target)
+        assert is_blocked is False, reason
+
+    def test_gaia_user_content_carveout_cannot_escape(self, validator):
+        """A traversal out of a carved-out dir back into config is still blocked."""
+        target = str(Path.home() / ".gaia" / "documents" / ".." / "mcp_servers.json")
+        is_blocked, _ = validator.is_write_blocked(target)
+        assert is_blocked is True
 
     def test_regular_txt_file_not_blocked(self, validator, tmp_path):
         """Verify a regular .txt file in a safe directory is not blocked."""


### PR DESCRIPTION
GAIA launched MCP stdio servers through `subprocess.Popen(shell=True)` whenever a server entry in `mcp_servers.json` omitted the `args` key — so the `command` string was interpreted by the shell rather than executed as a program, and anything able to write that config file could get arbitrary text run. The command is now tokenized into an argv list and `shell=False` is unconditional. Separately, `~/.gaia` was missing from the file-write denylist, so an agent's `write_file` could rewrite GAIA's own launch config; it is now protected, with the Agent UI's upload directories carved out so drag-and-drop sessions still save normally.

Two behaviour details worth a reviewer's attention:

- **Windows tokenizing is more correct than before, not just safer.** Backslashes are doubled and parsed in POSIX mode, matching `CommandLineToArgvW`. The obvious `posix=False` approach splits `--root="C:\Program Files\data"` into two mangled tokens; this doesn't. Unquoted shell operators are now rejected with an error naming the offending token and showing the `command` + `args` form to use instead — but the same characters *inside a quoted argument* (DSN query strings like `?ssl=1&x=2`, `python -c "import srv; srv.main()"`) are ordinary text and keep working. `~` and `$VAR`/`%VAR%` are expanded explicitly so configs that relied on the shell for that still resolve.
- **`~/.gaia` is blocked with carve-outs.** Config surfaces (`mcp_servers.json`, `connectors/`, `agents/`, `cache/`) are denied; `documents/`, `chat/`, `screenshots/` and `eval/` stay writable because the Agent UI stores browser uploads there and makes those the session's only allowed path. `GAIA_CONFIG_DIR` / `GAIA_HOME` relocations are covered too. Path traversal out of a carve-out is blocked (paths are realpath-resolved before the check).

The `# nosec B602` and its entry in `.security-suppressions.json` are gone rather than re-justified.

## Test plan

- [ ] `pytest tests/unit/mcp tests/unit/test_file_write_guardrails.py tests/unit/test_security_edge_cases.py tests/unit/test_check_security_gates.py tests/unit/test_file_tools.py tests/unit/test_shell_guardrails.py tests/unit/test_hub_security.py` — 508 passed locally
- [ ] `python util/check_security_gates.py` — suppressions reviewed, 0 new HIGH bandit findings
- [ ] Real-subprocess check (not mocked): a quoted command string with a space-bearing path launches a server, a config with a trailing `& echo … > file` is refused with no side-effect file, and a control run of the same string under `shell=True` *does* create the file — confirming the guard is load-bearing
- [ ] Connect a real MCP server both ways on Windows and Linux: `{"command": "npx", "args": ["-y", "@modelcontextprotocol/server-github"]}` and the legacy single-string `"npx -y @modelcontextprotocol/server-github"`
- [ ] In the Agent UI, drag in a document and ask the agent to save a file — writes to `~/.gaia/documents` still succeed
