### PR TITLE
fix(email): ship with Agent Skills off until the eval gate covers them

### DIFF
--- a/docs/guides/composing-skills.mdx
+++ b/docs/guides/composing-skills.mdx
@@ -226,21 +226,33 @@ Two habits keep it safe:
   only when the agent actually reads them.
 - **Subtract the cost where you budget context.** If your agent sizes a
   tool-result envelope against the window, take the loaded set's cost out of that
-  budget. The email agent's bulk-triage path does exactly this.
+  budget. The email agent's bulk-triage path does exactly this — and measure the
+  result: its three-skill `personal` set costs ~1,334 prompt tokens, cutting that
+  envelope from 6,144 to 4,810 (the four-skill `work` set, to 4,070). Losing a
+  fifth to a third of the room for tool results is why its sets are currently
+  switched off pending an eval.
 
-## A shipped example
+## A worked example in the tree
 
 The [email agent](https://github.com/amd/gaia/tree/main/hub/agents/email) is the
-reference consumer. It bundles six instruction-only skills and declares two sets —
-`personal` (triage, newsletter digests, travel itineraries) and `work` (triage,
-meeting scheduling, action-item extraction, escalation routing), with
-`inbox-triage` in both.
+reference implementation of this pattern. It bundles six instruction-only skills
+and its manifest carries two sets — `personal` (triage, newsletter digests,
+travel itineraries) and `work` (triage, meeting scheduling, action-item
+extraction, escalation routing), with `inbox-triage` in both — plus a selector
+that keys off the connected mailbox: a personal Microsoft account picks
+`personal`, a work/school account picks `work`. A Gmail mailbox carries no
+equivalent signal, so its kind is unknown, the selector returns `None`, and the
+manifest's default applies — explicitly, never by assuming a work mailbox is
+personal.
 
-Its selector keys off the connected mailbox: a personal Microsoft account
-activates `personal`, a work/school account activates `work`. A Gmail mailbox
-carries no equivalent signal, so its kind is unknown, the selector returns `None`,
-and the manifest's default applies — explicitly, never by assuming a work mailbox
-is personal.
+<Note>
+  Read it as a code reference, not as "skills are on by default in a shipped
+  agent": the email agent's `skill_sets:` and `default_skill_set:` blocks are
+  **commented out** in `gaia-agent.yaml` pending an eval that shows the skills
+  help, so on the shipped binary it loads no skills at all. The wiring is what's
+  worth copying; whether to turn it on is an eval question for your own agent
+  too.
+</Note>
 
 ## Related
 

--- a/docs/guides/email.mdx
+++ b/docs/guides/email.mdx
@@ -443,49 +443,40 @@ When the calendar tools run (`list_calendar_events`, `accept_invite`, `decline_i
 (Google calendar scope was skipped during consent). Without an explicit provider setting the
 agent used to pick Google and fail. It now picks Outlook correctly.
 
-## Skill sets: personal vs work mailbox
+## Skill sets: disabled
 
-The agent bundles six **Agent Skills** — short playbooks it loads into its own
-prompt — and activates one **set** of them per launch, so the same agent behaves
-appropriately for the mailbox in front of it:
+<Warning>
+**Agent Skills are switched off for the email agent.** The `skill_sets:` and
+`default_skill_set:` blocks in `hub/agents/email/python/gaia-agent.yaml` are
+commented out, so the agent loads **zero** skills: `active_skill_set` is `None`
+and `loaded_skills` is empty. They were turned on by default with no eval run
+behind them, and an active `personal` set cost ~1,334 prompt tokens — cutting
+the bulk-triage result envelope from 6144 to 4810 (`work`, to 4070). The agent
+is back to its full 6144-token envelope.
+</Warning>
 
-| Set | Skills |
-|---|---|
-| `personal` (default) | `inbox-triage`, `newsletter-digest`, `travel-itinerary` |
-| `work` | `inbox-triage`, `meeting-scheduling`, `action-item-extraction`, `escalation-routing` |
+The agent still *bundles* six instruction-only skills at
+`gaia_agent_email/skills/<name>/SKILL.md` — `inbox-triage`, `newsletter-digest`,
+`travel-itinerary`, `meeting-scheduling`, `action-item-extraction`,
+`escalation-routing` — and the selection machinery
+(`EmailTriageAgent.select_skill_set()`, the account-type mapping,
+`GAIA_EMAIL_SKILL_SET`, `--skill-set`) is all still there. It is simply inert
+while no sets are declared.
 
-`inbox-triage` is in both — sets overlap rather than partition.
+Pinning a set is therefore a startup error, not a silent no-op:
 
-The set is chosen in this order:
+```console
+$ gaia-agent-email serve --skill-set personal
+gaia-agent-email: error: --skill-set requested skill set 'personal', but this
+agent declares no skill sets — Agent Skills are switched off in this build. Drop
+the option, or uncomment the 'skill_sets:' and 'default_skill_set:' blocks in
+gaia-agent.yaml.
+```
 
-1. **Explicit** — `gaia-agent-email serve --skill-set work`, or
-   `GAIA_EMAIL_SKILL_SET=work`. An undeclared name fails at startup naming the
-   valid sets; it never falls back.
-2. **Mailbox account type** — a personal Microsoft account activates `personal`,
-   a work/school account activates `work`. The kind is derived from the id_token
-   `tid` claim when the mailbox is connected and stored with the connection, so
-   nothing is re-derived per run. Pin it with `GAIA_EMAIL_ACCOUNT_TYPE=work`.
-
-   <Note>
-   Microsoft is now two connectors — `microsoft` (personal) and `microsoft_work`
-   — and the email agent only declares `microsoft` so far
-   ([#2629](https://github.com/amd/gaia/issues/2629) tracks wiring the work one).
-   Until that lands, the automatic `work` path is not reachable through this
-   agent: pin the set with `GAIA_EMAIL_ACCOUNT_TYPE=work` or `--skill-set work`.
-   </Note>
-3. **`default_skill_set`** (`personal`) — applies when the kind is unknown.
-
-**Gmail resolves to the default.** Google has no equivalent of the Microsoft
-tenant claim, so a Gmail mailbox's kind is genuinely unknown and the declared
-default applies. In practice that means a *work* Gmail mailbox gets the
-`personal` set — by declared default, and logged, rather than by anything
-inferring the kind from your mail. **If you drive a work Gmail account, set
-`GAIA_EMAIL_ACCOUNT_TYPE=work` or pass `--skill-set work`.** The same holds for a
-Microsoft mailbox connected before this shipped: it carries no recorded kind
-until you reconnect it.
-
-Inspect what loaded with `gaia skill list`, or read the startup log line naming
-the active set and the rule that chose it. Full mechanism:
+To re-enable, uncomment **both** blocks together — a non-empty `skill_sets:`
+with no `default_skill_set:` fails validation — and run the eval before
+shipping it on. `gaia skill list` shows what is discoverable; the startup log
+names what actually loaded. Full mechanism:
 [Composing skills and skill sets](/guides/composing-skills).
 
 ## Dev mode: run the email agent from source

--- a/docs/spec/agent-skills.mdx
+++ b/docs/spec/agent-skills.mdx
@@ -13,7 +13,8 @@ discovery roots with auditable precedence, progressive disclosure,
 `gaia skill list|info|create|import|export`. Plus the declarative
 `skills:` / `skill_sets:` manifest blocks and per-launch
 [skill-set selection](#skill-sets) ([#2466](https://github.com/amd/gaia/issues/2466)),
-whose reference consumer is the email agent.
+whose reference implementation is the email agent (which currently ships with its
+sets commented out — see [below](#reference-implementation-the-email-agent)).
 
 **Still proposed:** the permission sandbox and tier-ceiling enforcement
 ([#1019](https://github.com/amd/gaia/issues/1019)), the skill marketplace and
@@ -413,17 +414,26 @@ adopted the blocks, whose behaviour is unchanged.
 into the system prompt, which is prompt budget the agent's own tool results no
 longer have. An agent with a tight context envelope must account for the loaded
 set's cost, not assume it is free — the email agent's bulk-triage path subtracts
-it from its result-envelope budget for exactly this reason. Budget the set, and
-keep bodies short.
+it from its result-envelope budget for exactly this reason — and its three-skill
+`personal` set still cut that envelope from 6,144 tokens to 4,810 (the four-skill
+`work` set, to 4,070). Budget the set, and keep bodies short.
 </Note>
 
-### Reference consumer: the email agent
+### Reference implementation: the email agent
 
 The email agent ([`hub/agents/email/`](https://github.com/amd/gaia/tree/main/hub/agents/email))
-is the shipped worked example. It bundles six instruction-only skills and declares
-two sets — `personal` (triage, newsletter digests, travel itineraries) and `work`
-(triage, meeting scheduling, action-item extraction, escalation routing) — with
-`inbox-triage` deliberately in both.
+is the worked example in the tree. It bundles six instruction-only skills and its
+manifest carries two sets — `personal` (triage, newsletter digests, travel
+itineraries) and `work` (triage, meeting scheduling, action-item extraction,
+escalation routing) — with `inbox-triage` deliberately in both.
+
+<Warning>
+**It ships with those blocks commented out**, pending an eval that shows the
+skills improve triage, so the released agent resolves no set and loads no skills
+— `active_skill_set is None`, `loaded_skills == {}`, and a `--skill-set` request
+is a startup error. Treat it as a wiring reference, not as evidence that a
+shipped agent has a set active.
+</Warning>
 
 Its selector maps the connected mailbox's account type onto a set: a personal
 Microsoft account gets `personal`, a work/school account gets `work`. The kind is

--- a/hub/agents/email/npm/CHANGELOG.md
+++ b/hub/agents/email/npm/CHANGELOG.md
@@ -13,6 +13,14 @@ behind any entry — API shapes, endpoints, and version semantics — see
   follow-up referring to something an earlier turn surfaced has something
   to resolve against. Leave it unset and nothing changes (#2829, schema
   2.12).
+- **The agent's built-in skills ship switched off, so the whole context window
+  goes back to your mail.** The six skills below are still in the package, but
+  no set is active and none of them loads: nothing yet shows they make triage
+  better, and an active set was consuming most of the room the agent had for
+  bulk-triage results. A personal and a work mailbox get identical behaviour
+  again, and `--skill-set` / `GAIA_EMAIL_SKILL_SET` now fail at startup saying
+  there are no sets to pick rather than quietly doing nothing. Nothing else
+  changes — same endpoints, same tools, same permissions.
 - **One inbox triage card instead of two that disagreed.** Asking the agent
   to triage your inbox used to draw two summary boxes from two separate scans
   at different depths — one might say "nothing needs you" while the other,
@@ -72,19 +80,14 @@ behind any entry — API shapes, endpoints, and version semantics — see
   still uses your exact wording when you hand it over yourself. Sending is
   unchanged — every draft still needs your confirmation before it goes out
   (#2524).
-- **The agent now works differently for a personal mailbox than for a work one.**
-  It used to bring exactly the same instincts to both: the same triage advice for
-  a mailbox full of newsletters and flight confirmations as for one full of
-  meeting invites and things people are waiting on you for. It now ships six
-  built-in skills and turns on one set of them per run — `personal` (inbox triage,
-  newsletter digests, trip itineraries) or `work` (inbox triage, meeting
-  scheduling, action items, escalation). For an Outlook mailbox it picks the set
-  itself from the kind of Microsoft account you connected. Gmail doesn't say which
-  kind it is, so a Gmail mailbox gets `personal` unless you pin one — start the
-  sidecar with `extraArgs: ["--skill-set", "work"]` or
-  `env: { GAIA_EMAIL_SKILL_SET: "work" }`. This changes how the agent approaches
-  your mail, not what it can do: same endpoints, same tools, same permissions, no
-  schema bump (#2466).
+- **Six built-in skills, and the groundwork for treating a personal mailbox
+  differently from a work one — shipped switched off.** The skills (`personal`:
+  inbox triage, newsletter digests, trip itineraries; `work`: inbox triage,
+  meeting scheduling, action items, escalation) and the machinery that picks a
+  set from the kind of Microsoft account you connected are in the package, but
+  no set is declared, so none of it is active — see the first entry above.
+  Turning it on is a change inside the agent; nothing in your integration
+  changes either way (#2466).
 - **Opt-in preview: small on-device models can now decide phishing flags and
   triage categories instead of keyword rules.** Turn it on with
   `GAIA_EMAIL_USE_SLM=true` on the sidecar (or `use_slm=True` in config).

--- a/hub/agents/email/npm/README.md
+++ b/hub/agents/email/npm/README.md
@@ -135,34 +135,21 @@ for a local page to test triage, drafting, and a live send.
 
 ## Personal mailbox vs work mailbox
 
-The agent behaves differently depending on the kind of mailbox it's connected to.
-It ships six built-in **skills** — short playbooks it loads into its own thinking —
-and turns on one **set** of them per run:
+The package ships six built-in **skills** — short playbooks the agent can load into
+its own thinking — grouped into a `personal` set (inbox triage, newsletter digests,
+trip itineraries) and a `work` set (inbox triage, meeting scheduling, action items,
+escalation).
 
-- **Personal** (the default): inbox triage, newsletter digests, and building a trip
-  itinerary out of scattered booking confirmations.
-- **Work**: inbox triage, meeting scheduling, pulling action items out of threads,
-  and deciding what needs escalating.
+**They are switched off in this release.** Nothing is loaded at launch and a
+personal and a work mailbox get identical behaviour, because there is no eval
+evidence yet that the skills improve triage. The skill files stay in the package,
+inert, and the agent's full context window goes to your mail instead of to skill
+text.
 
-It picks the set automatically for an Outlook mailbox — a personal Microsoft
-account gets the personal set, a work or school account gets the work set. Two
-mailboxes need you to say which you want: Gmail, which doesn't expose the kind at
-all, and a work or school Microsoft account, whose connector the agent doesn't
-offer yet ([#2629](https://github.com/amd/gaia/issues/2629)). Both fall back to
-the personal set until you pin one.
-
-To pin it yourself, start the sidecar with the set you want:
-
-```ts
-const sidecar = await startSidecar({
-  binaryPath,
-  port: 8131,
-  extraArgs: ["--skill-set", "work"], // or env: { GAIA_EMAIL_SKILL_SET: "work" }
-});
-```
-
-This changes how the agent *approaches* your mail, not what it's allowed to do —
-the tools, permissions, and API are identical either way. Full detail in
+Nothing for you to do or change: there is no set to pin, and passing
+`--skill-set` / `GAIA_EMAIL_SKILL_SET` fails at startup saying so rather than
+quietly doing nothing. Re-enabling is a change inside the agent, not in your
+integration. Full detail in
 [`SPEC.md`](https://github.com/amd/gaia/blob/agent-pkg-email-v0.5.0/hub/agents/email/npm/SPEC.md).
 
 ## How it works

--- a/hub/agents/email/npm/SKILL.md
+++ b/hub/agents/email/npm/SKILL.md
@@ -15,10 +15,11 @@ Follow these steps to wire it into an app.
 > **This file is NOT one of the agent's own skills.** It is the integration
 > playbook — how *you* wire this npm package into an app. The sidecar separately
 > bundles six **Agent Skills** at `gaia_agent_email/skills/<name>/SKILL.md`, which
-> are instructions the *email agent itself* loads into its own prompt at runtime.
-> Same filename, different artifact: don't load those into your assistant, and
-> don't ship this one as an agent skill. See
-> [Skill sets](#skill-sets--pin-the-agents-behaviour-for-a-work-mailbox) below.
+> are instructions the *email agent itself* would load into its own prompt at
+> runtime — currently **disabled**, so none of them loads. Same filename,
+> different artifact: don't load those into your assistant, and don't ship this
+> one as an agent skill. See
+> [Skill sets](#skill-sets--disabled-in-this-release) below.
 
 ## 1. Install
 
@@ -342,44 +343,25 @@ rather than returning the same 200 shape a real, found-nothing cycle would (#252
 The Python host also ships a thin-client CLI over this same surface:
 `gaia email autonomy {status|set-level|pause|resume|run|trust|kill}` (#2516).
 
-## Skill sets — pin the agent's behaviour for a work mailbox
+## Skill sets — disabled in this release
 
-The agent bundles six Agent Skills and activates one **set** per launch, so it
-approaches a personal mailbox differently from a work one. Nothing in the API
-changes — same endpoints, same tools, same permissions — only how the agent
-reasons about the mail.
+The sidecar bundles six Agent Skills (`personal`: `inbox-triage`,
+`newsletter-digest`, `travel-itinerary`; `work`: `inbox-triage`,
+`meeting-scheduling`, `action-item-extraction`, `escalation-routing`), but the
+agent's manifest currently declares **no sets**, so **none of them loads**. A
+personal and a work mailbox get identical behaviour. This is deliberate: the
+skills are held back until an eval run shows they improve triage.
 
-| Set | Skills it loads |
-|-----|-----------------|
-| `personal` (default) | `inbox-triage`, `newsletter-digest`, `travel-itinerary` |
-| `work` | `inbox-triage`, `meeting-scheduling`, `action-item-extraction`, `escalation-routing` |
+What that means for your integration:
 
-**It usually chooses for itself.** For an Outlook mailbox, GAIA records at connect
-time whether the Microsoft account is personal or work/school (from the `tid`
-tenant claim in the OAuth `id_token`), and the agent maps that onto the matching
-set. **Gmail carries no equivalent claim**, so a Gmail-only mailbox has an unknown
-kind and resolves through the manifest default — `personal`. A work Gmail mailbox
-is therefore something you should pin explicitly.
-
-Two ways to pin it at spawn time, both via `startSidecar` — use either, not both:
-
-```ts
-const sidecar = await startSidecar({
-  binaryPath,
-  port: 8131,
-  // CLI flag: validated against the declared sets, so a typo fails at startup.
-  extraArgs: ["--skill-set", "work"],
-  // Env var, equivalent — and the form to use if you spawn the binary yourself:
-  // env: { GAIA_EMAIL_SKILL_SET: "work" },
-});
-```
-
-Either one pins the set for **every** session that sidecar serves and overrides the
-mailbox-derived choice. To let the agent do the mapping but tell it what kind of
-mailbox it has, set `GAIA_EMAIL_ACCOUNT_TYPE` to `personal` or `work` instead.
-
-Only `personal` and `work` are declared. An undeclared name never silently falls
-back — the sidecar refuses to start and names the valid sets.
+- **Do not pass `--skill-set` or `GAIA_EMAIL_SKILL_SET`.** Any value fails at
+  startup with `... but this agent declares no skill sets — Agent Skills are
+  switched off in this build.` There is no working name. This is fail-loud
+  behaviour, not a bug to work around.
+- `GAIA_EMAIL_ACCOUNT_TYPE` still validates but selects nothing.
+- Nothing in the API changes either way — same endpoints, same tools, same
+  permissions. Re-enabling happens inside the agent's `gaia-agent.yaml`; your
+  code does not change.
 
 ## Running in a server / long-lived app
 
@@ -480,11 +462,9 @@ Until then the binary boots, but the first `triage` returns **HTTP 502**.
   routes for them yet, so don't look for `client.scheduleSend()` /
   `client.snooze()` / a voice, follow-up, or waiting-on-you method — they
   don't exist (and none of these moves `SCHEMA_VERSION`).
-- **A Gmail mailbox always gets the `personal` skill set unless you pin one.** The
-  set is normally derived from the Microsoft account kind, and Gmail exposes no
-  equivalent signal — so pass `--skill-set work` (or `GAIA_EMAIL_SKILL_SET=work`)
-  for a work Gmail mailbox, or the agent won't load the meeting / action-item /
-  escalation skills. This affects judgement only; no endpoint or tool changes.
+- **`--skill-set` / `GAIA_EMAIL_SKILL_SET` always fail right now.** Agent Skills
+  are disabled in this release, so the agent declares no sets and every name is
+  invalid. Don't wire either into your spawn options.
 - **ESM-only.** `require("@amd-gaia/agent-email")` fails; use `import` / dynamic
   `import()`.
 

--- a/hub/agents/email/npm/SPEC.md
+++ b/hub/agents/email/npm/SPEC.md
@@ -554,8 +554,8 @@ await dev.client.triage({ payload: { /* … */ } });
 The `serve` CLI (`gaia_agent_email.server:main`) accepts `--host`, `--port`
 (rejects the reserved 4001), `--reload` (import-string app + watches the package
 dir; add `--reload-dir` for your core checkout), `--dev` (implies `--reload`),
-`--skill-set <name>` (pin a bundled [skill set](#skill-sets-2466) for every session
-instead of letting the mailbox's account type choose), and
+`--skill-set <name>` (accepted but currently unusable — the agent declares no
+[skill sets](#skill-sets-2466), so any value errors at startup), and
 `--print-openapi`. Running without `GAIA_EMAIL_SIDECAR_TOKEN` disables the caller
 token (local dev only, logged loudly); Host/Origin protection still applies.
 Auto-reload resets in-process `/v1/email/agent/*` sessions — irrelevant to the
@@ -654,10 +654,30 @@ yet**.
 
 ## Skill sets (#2466)
 
-The agent bundles six **Agent Skills** and activates one named **set** of them per
-launch, so a personal mailbox and a work mailbox get different judgement out of the
-same binary — newsletters and trip itineraries for one, meetings and action items
-for the other.
+**Status: disabled. The agent loads zero skills.** It bundles six **Agent Skills**
+and the machinery to activate one named **set** of them per launch, but the
+`skill_sets:` and `default_skill_set:` blocks in `gaia-agent.yaml` are commented
+out pending an eval run that shows the skills improve triage. Concretely, on the
+shipped binary:
+
+- `active_skill_set` is `None` and `loaded_skills` is empty; no skill text reaches
+  the system prompt.
+- A personal and a work mailbox get identical behaviour.
+- `--skill-set` / `GAIA_EMAIL_SKILL_SET` **fail loudly** at startup — the agent
+  declares no sets, so there is no valid name to pass: *"requested skill set
+  'personal', but this agent declares no skill sets — Agent Skills are switched
+  off in this build. Drop the option, or uncomment the 'skill_sets:' and
+  'default_skill_set:' blocks in gaia-agent.yaml."* That is the
+  no-silent-fallbacks rule working, not a bug.
+- The bulk-triage result envelope is back to its full **6144 tokens**
+  (16384 − 9216 − 1024), the pre-skills value; the `personal` set had cut it to
+  4810 and `work` to 4070.
+- Nothing else moves: same endpoints, same tools, same permissions, same
+  `SCHEMA_VERSION`.
+
+Re-enabling is uncommenting those two manifest blocks — both together, since a
+non-empty `skill_sets:` without a `default_skill_set:` is a parse error. The rest
+of this section describes what the machinery does *when enabled*.
 
 > **Two different files in this package are named `SKILL.md`. They are not the
 > same kind of artifact.**
@@ -666,16 +686,16 @@ for the other.
 >   instructions for an AI coding assistant helping a developer wire this npm
 >   package into an app.
 > - `gaia_agent_email/skills/<name>/SKILL.md`, inside the sidecar, are **Agent
->   Skills** — instructions the *email agent itself* loads into its own prompt at
->   runtime to do email work better.
+>   Skills** — instructions the *email agent itself* would load into its own
+>   prompt at runtime (none load today, per the status above).
 >
 > Different audience, different format. Everything in this section is about the
 > second kind; nothing here changes the integration playbook.
 
 ### The bundled skills
 
-Each is a Markdown procedure (`skills/<name>/SKILL.md` in the sidecar), loaded into
-the agent's system prompt when its set is active:
+Each is a Markdown procedure (`skills/<name>/SKILL.md` in the sidecar). All six
+still ship in the binary; none currently loads:
 
 | Skill | What it makes the agent better at |
 |-------|-----------------------------------|
@@ -686,9 +706,10 @@ the agent's system prompt when its set is active:
 | `action-item-extraction` | Pulling the concrete commitments out of a thread: who owes what, by when. |
 | `escalation-routing` | Deciding what needs attention now, what can wait, and what belongs to someone else. |
 
-### The two sets
+### The two sets (currently commented out)
 
-Declared in the agent's `gaia-agent.yaml`; **exactly one is active per launch**:
+These are the sets `gaia-agent.yaml` declares when the blocks are uncommented;
+**exactly one would be active per launch**:
 
 | Set | Skills |
 |-----|--------|
@@ -699,7 +720,7 @@ Declared in the agent's `gaia-agent.yaml`; **exactly one is active per launch**:
 that should load for every set belongs in the manifest's top-level `skills:` list
 instead; this agent declares none.)
 
-### Resolution order
+### Resolution order (inert while the blocks are commented out)
 
 1. **Explicit request** — the `--skill-set` flag or `GAIA_EMAIL_SKILL_SET`. Wins
    over everything.
@@ -710,63 +731,24 @@ instead; this agent declares none.)
    type is unknown.
 
 An **undeclared set name never falls back** — it raises at startup naming the valid
-sets, per GAIA's no-silent-fallbacks rule. `--skill-set` additionally rejects an
-undeclared name at argument-parse time.
+sets, per GAIA's no-silent-fallbacks rule. With no sets declared *every* name is
+undeclared, which is why `--skill-set` currently always errors.
 
-### How the account type is derived
-
-At connect time GAIA classifies a **Microsoft** account from the `tid` (tenant id)
-claim of its OAuth `id_token`: the well-known consumers tenant means a personal
-account (Outlook.com / Hotmail / Live), any other tenant id means a work or school
-(Entra ID) account. The result is stored on the connection and exposed as
-`account_type` (`"personal"` / `"work"`) by the GAIA connector store.
-
-Three consequences worth knowing:
-
-- **Gmail has no equivalent claim**, so a Gmail-only mailbox has no account type to
-  read. The kind is genuinely **unknown**, and the manifest's `default_skill_set`
-  applies. Be clear about what that means: a *work* Gmail mailbox does get the
-  `personal` set — not because anything inferred it from the mailbox, but because
-  that is the declared default, and the resolution is logged. Nothing guesses;
-  nothing is silent; the default is still a default. **Pin
-  `GAIA_EMAIL_ACCOUNT_TYPE=work` or `--skill-set work` for a work Gmail mailbox.**
-- **The work path is not reachable through this agent yet.** GAIA now splits
-  Microsoft into two connectors — `microsoft` (personal, `consumers` authority)
-  and `microsoft_work` — and only `microsoft` is in this agent's
-  `REQUIRED_CONNECTORS` ([#2629](https://github.com/amd/gaia/issues/2629) tracks
-  the rest). The derivation reads both connectors, so it starts working the moment
-  that lands; until then, pin `work` explicitly. The `tid` classification itself is
-  already correct for either.
-- **The kind is recorded when the connection is made.** A Microsoft mailbox
-  connected before this feature shipped carries no `account_type` until it is
-  reconnected, so it too resolves through the default.
-- **No new permission or scope** is involved — the claim is already in the token
-  the connect flow receives.
-
-### Configuration
-
-| Surface | Values | Effect |
-|---------|--------|--------|
-| `--skill-set <name>` (sidecar `serve`) | a declared set name | Pins the set for **every** agent session this sidecar serves. Validated against the manifest; exported as `GAIA_EMAIL_SKILL_SET` so per-request sessions see it. |
-| `GAIA_EMAIL_SKILL_SET` | a declared set name | Same effect, as an env var. Backs `EmailAgentConfig.skill_set`. |
-| `GAIA_EMAIL_ACCOUNT_TYPE` | `personal` \| `work` | Pins the **mailbox kind** instead of the set, letting the selector do the mapping. Backs `EmailAgentConfig.account_type`. An invalid value raises rather than being ignored. |
-
-From this package, either one reaches the sidecar through `startSidecar`:
-
-```ts
-const sidecar = await startSidecar({
-  binaryPath,
-  port: 8131,
-  extraArgs: ["--skill-set", "work"],        // the CLI flag …
-  // env: { GAIA_EMAIL_SKILL_SET: "work" }, // … or the env var. Equivalent.
-});
-```
+`GAIA_EMAIL_ACCOUNT_TYPE` (`personal` | `work`) still pins the mailbox kind and
+still rejects an invalid value, but with no sets declared it selects nothing. The
+account type itself is unaffected by any of this: GAIA classifies a **Microsoft**
+account at connect time from the `tid` (tenant id) claim of its OAuth `id_token`
+— the well-known consumers tenant means personal, any other tenant means work or
+school — and stores it on the connection as `account_type`. Gmail carries no
+equivalent claim, so a Gmail mailbox has no account type at all. No new permission
+or scope is involved; the claim is already in the token the connect flow receives.
 
 ### What skill sets do NOT change
 
 The bundled skills are **instruction-only**: none declares `tools:` or
-`permissions:`, so activating a set changes only what the agent knows how to do
-well, never what it is *able* to do.
+`permissions:`, so activating a set would change only what the agent knows how to
+do well, never what it is *able* to do. Disabling them therefore removes no
+capability:
 
 - The agent's tool count is unchanged (59), and so is every tool's behaviour.
 - The REST and MCP contracts are unchanged — no new endpoints, no schema bump, and

--- a/hub/agents/email/python/CHANGELOG.md
+++ b/hub/agents/email/python/CHANGELOG.md
@@ -19,6 +19,29 @@ contract version is tracked separately as
   rejected, `409`); a session id the sidecar has never seen arriving with
   prior conversation history (e.g. the sidecar restarted mid-conversation)
   gets a one-time notice instead of silently starting over.
+### Changed
+
+- **Agent Skills ship disabled for this agent, pending eval evidence (#2695
+  follow-up).** The `skill_sets:` and `default_skill_set: personal` blocks in
+  `gaia-agent.yaml` are commented out, so `parse_manifest(...).skill_sets` is
+  empty, `load_skill_set()` early-returns, and the agent launches with
+  `loaded_skills == {}` / `active_skill_set is None`. Skills were turned on by
+  default with no eval run behind them, and an active `personal` set cost ~1,334
+  prompt tokens — shrinking the bulk-triage result envelope from 6144 to 4810
+  (the `work` set, to 4070). `envelope_budget_tokens()` is back to **6144**
+  (16384 − 9216 − 1024), byte-identical to pre-skills. Nothing was deleted: the six
+  `gaia_agent_email/skills/<name>/SKILL.md` bodies still ship in the wheel and
+  the frozen binary, and `SKILL_DIRS`, `select_skill_set()`,
+  `ACCOUNT_TYPE_SKILL_SETS`, `GAIA_EMAIL_SKILL_SET`, `--skill-set`, and the
+  `skill_prompt_tokens` accounting are all intact but inert. With no sets
+  declared, a pinned set is a startup error rather than a silent no-op —
+  `--skill-set personal` exits with "…requested skill set 'personal', but this
+  agent declares no skill sets — Agent Skills are switched off in this build.
+  Drop the option, or uncomment the 'skill_sets:' and 'default_skill_set:'
+  blocks in gaia-agent.yaml." Re-enabling is uncommenting those two blocks
+  **together**; a non-empty `skill_sets:` with no `default_skill_set:` is a
+  validation error. `tools_count` (65), the REST/MCP contract, the connector
+  surface, and `SCHEMA_VERSION` are unaffected.
 
 ### Fixed
 
@@ -533,6 +556,9 @@ contract version is tracked separately as
   still inviolable at every level — broadening the candidate map cannot make a floor tool
   auto-executable.
 - **Bundled Agent Skills, and the active set keyed to the mailbox kind (#2466).**
+  **Ships disabled** — the manifest blocks are commented out, so none of the
+  behaviour below is active; see *Changed* above. The rest of this entry
+  describes what the machinery does once they are uncommented.
   The agent brought identical instincts to every mailbox — the same triage
   judgement for one full of newsletters and booking confirmations as for one full
   of meeting invites and outstanding commitments. It now bundles six

--- a/hub/agents/email/python/CHANGELOG.md
+++ b/hub/agents/email/python/CHANGELOG.md
@@ -61,6 +61,13 @@ contract version is tracked separately as
   could have confirmed one, and an attendee named for an event the tool
   result shows has none; both leave a correctly-reported organizer and an
   honest "no attendees" alone.
+- **A pinned `GAIA_EMAIL_SKILL_SET` leaked across tests, failing suites that
+  never mention skills.** The variable was set process-wide by the skill-set
+  tests and never cleared, so every later agent construction requested a set
+  that no longer exists once skills ship disabled — surfacing as unrelated
+  trash/restore, undo, and zero-connector failures rather than as a skills
+  problem. The fixture now scopes and restores it, so the fail-loud
+  `SkillSetError` fires only where a set is genuinely requested.
 - **`get_thread` invented messages, senders, and timestamps that were never
   in the mailbox (#2765).** Asked to catch up on a conversation, the agent
   could hand back a duplicated message, another replaced by a repeat of an

--- a/hub/agents/email/python/gaia-agent.yaml
+++ b/hub/agents/email/python/gaia-agent.yaml
@@ -53,9 +53,21 @@ interfaces:
   api_server: true
   mcp_server: true
 
-# Agent Skills (#2466). Bundled instruction-only skills live in
-# gaia_agent_email/skills/<name>/SKILL.md and are loaded from there — that folder
-# is this agent's highest-precedence discovery root (SKILL_DIRS).
+# Agent Skills (#2466) — DISABLED pending eval validation (#2695 follow-up).
+#
+# The skills below are still shipped: gaia_agent_email/skills/<name>/SKILL.md,
+# SKILL_DIRS, select_skill_set(), the account-type mapping, and the
+# context-budget accounting are all intact but inert. Re-enabling is exactly
+# "uncomment the two blocks below" — nothing else to restore.
+#
+# Why off: no eval evidence backs the prompt cost. The personal set costs ~1,334
+# prompt tokens, cutting the bulk-triage result envelope from 6144 to 4810 (work,
+# to 4070); commented out, envelope_budget_tokens() is back to 6144, the
+# pre-skills value. Turn these back on only with an eval run behind them
+# (CLAUDE.md: "Run agent evals when changing LLM-affecting code paths").
+#
+# BOTH blocks must be uncommented together — parse_skill_sets() rejects a
+# non-empty skill_sets: with no default_skill_set:.
 #
 # Exactly ONE set is active per launch. EmailTriageAgent.select_skill_set() maps
 # the connected mailbox's account type onto a set (personal Microsoft account →
@@ -67,15 +79,16 @@ interfaces:
 # `inbox-triage` appears in both sets deliberately: sets overlap, they do not
 # partition. Anything that should load for every set belongs in a top-level
 # `skills:` list instead.
-skill_sets:
-  personal:
-    - inbox-triage
-    - newsletter-digest
-    - travel-itinerary
-  work:
-    - inbox-triage
-    - meeting-scheduling
-    - action-item-extraction
-    - escalation-routing
-
-default_skill_set: personal
+#
+# skill_sets:
+#   personal:
+#     - inbox-triage
+#     - newsletter-digest
+#     - travel-itinerary
+#   work:
+#     - inbox-triage
+#     - meeting-scheduling
+#     - action-item-extraction
+#     - escalation-routing
+#
+# default_skill_set: personal

--- a/hub/agents/email/python/gaia_agent_email/server.py
+++ b/hub/agents/email/python/gaia_agent_email/server.py
@@ -307,6 +307,15 @@ def main(argv=None) -> int:
                 f"{source} requested skill set {requested_set!r}, but this "
                 f"build's declared sets could not be read: {exc}"
             )
+        if not declared:
+            # This build ships with gaia-agent.yaml's skill_sets: commented out,
+            # so there is nothing to pin. Say that, rather than "Valid sets: ".
+            parser.error(
+                f"{source} requested skill set {requested_set!r}, but this "
+                "agent declares no skill sets — Agent Skills are switched off "
+                "in this build. Drop the option, or uncomment the 'skill_sets:' "
+                "and 'default_skill_set:' blocks in gaia-agent.yaml."
+            )
         if requested_set not in declared:
             parser.error(
                 f"{source} requested skill set {requested_set!r}, which this "

--- a/hub/agents/email/python/tests/conftest.py
+++ b/hub/agents/email/python/tests/conftest.py
@@ -8,14 +8,43 @@ can never silently short-circuit another test's fake ``requests.get``
 (order-dependent flakiness).
 
 Also pins every test to the SLM-unavailable path so the suite stays hermetic —
-see :func:`_hermetic_slm_classifiers`.
+see :func:`_hermetic_slm_classifiers` — and contains the one process-global
+environment write the sidecar makes, see
+:func:`_contain_the_skill_set_env_var`.
 """
+
+import os
 
 import pytest
 
 # ScriptedConsole / FakeAgent live in onboarding_fakes.py, NOT here — see that
 # module's docstring for why a bare `from conftest import ...` is unsafe
 # under CI's multi-root pytest invocation (test_email_agent.yml).
+
+
+@pytest.fixture(autouse=True)
+def _contain_the_skill_set_env_var():
+    """Undo any ``GAIA_EMAIL_SKILL_SET`` a test leaves behind in ``os.environ``.
+
+    ``server.main()`` pins a requested skill set by writing straight into
+    ``os.environ`` — that is how the override reaches the per-request agent
+    sessions, so it is deliberate and must not be softened. It does mean
+    ``monkeypatch`` cannot undo it: ``delenv(..., raising=False)`` records
+    nothing when the variable was already unset, so the write outlives the test
+    and every later ``EmailTriageAgent`` is constructed with that set requested.
+
+    The shipped manifest declares no sets, so a leaked value is a
+    ``SkillSetError`` at construction — raised in whichever unrelated test file
+    happens to build an agent next.
+    """
+    from gaia_agent_email.config import SKILL_SET_ENV
+
+    original = os.environ.get(SKILL_SET_ENV)
+    yield
+    if original is None:
+        os.environ.pop(SKILL_SET_ENV, None)
+    else:
+        os.environ[SKILL_SET_ENV] = original
 
 
 @pytest.fixture(autouse=True)

--- a/hub/agents/email/python/tests/test_skill_sets_2466.py
+++ b/hub/agents/email/python/tests/test_skill_sets_2466.py
@@ -2,6 +2,19 @@
 # SPDX-License-Identifier: MIT
 """Bundled skills + account-keyed skill-set selection (#2466).
 
+Two layers, deliberately separated:
+
+* **What this agent ships today** — ``gaia-agent.yaml`` has its ``skill_sets:``
+  and ``default_skill_set:`` blocks commented out, so no skill loads at launch.
+  ``test_shipped_*`` below pins that: zero skills, no active set, the envelope
+  budget back at its pre-skills 6144, and a loud failure for ``--skill-set``.
+* **How the machinery behaves when a set IS declared** — generic framework
+  behaviour (selection, overrides, runtime switching, budget arithmetic) that
+  the product decision above does not change. Those tests run against the
+  ``declared_sets`` fixture: the shipped manifest with the two blocks switched
+  back on. Keeping them means re-enabling stays a one-line manifest edit with
+  full coverage already behind it, instead of a rewrite of this file.
+
 Cold-state discipline: every agent here is built with ``tmp_path``-scoped
 databases and a ``SkillManager`` whose user and Claude-import roots point at
 empty tmp directories. Nothing reads the developer's ``~/.gaia/skills`` or the
@@ -64,6 +77,40 @@ def _isolated_manager(tmp_path: Path) -> SkillManager:
     )
 
 
+# The sets the shipped manifest carries, commented out. Mirrored here so the
+# framework tests below keep exercising the real bundled skills, and so
+# re-enabling the manifest blocks lands on coverage that already passes.
+_FIXTURE_SKILL_SETS = {
+    "personal": ["inbox-triage", "newsletter-digest", "travel-itinerary"],
+    "work": [
+        "inbox-triage",
+        "meeting-scheduling",
+        "action-item-extraction",
+        "escalation-routing",
+    ],
+}
+_FIXTURE_DEFAULT_SET = "personal"
+
+
+@pytest.fixture
+def declared_sets(tmp_path, monkeypatch) -> Path:
+    """Point the agent at a manifest that DOES declare skill sets.
+
+    The shipped manifest declares none (skills are off pending eval
+    validation), so the generic set machinery would have nothing to resolve.
+    This writes the shipped manifest with the two blocks switched back on and
+    repoints ``SKILL_MANIFEST`` at it — every consumer reads that attribute at
+    call time, including ``server._read_declared_skill_sets``.
+    """
+    data = yaml.safe_load(_MANIFEST.read_text(encoding="utf-8"))
+    data["skill_sets"] = _FIXTURE_SKILL_SETS
+    data["default_skill_set"] = _FIXTURE_DEFAULT_SET
+    path = tmp_path / "declared-sets-gaia-agent.yaml"
+    path.write_text(yaml.safe_dump(data, sort_keys=False), encoding="utf-8")
+    monkeypatch.setattr(EmailTriageAgent, "SKILL_MANIFEST", str(path))
+    return path
+
+
 def _build_agent(tmp_path, monkeypatch, **config_kwargs) -> EmailTriageAgent:
     monkeypatch.setenv("GAIA_MEMORY_DISABLED", "1")
     monkeypatch.delenv(SKILL_SET_ENV, raising=False)
@@ -93,26 +140,53 @@ def _build_agent(tmp_path, monkeypatch, **config_kwargs) -> EmailTriageAgent:
 
 
 def test_every_declared_skill_is_actually_bundled():
-    """A set naming a skill this package does not ship would fail at launch."""
-    declared = yaml.safe_load(_MANIFEST.read_text(encoding="utf-8"))
-    names = {
-        name for entries in declared["skill_sets"].values() for name in entries
-    } | set(declared.get("skills") or [])
+    """A set naming a skill this package does not ship would fail at launch.
+
+    Checked against the sets the manifest would declare once re-enabled, so
+    deleting a SKILL.md while the blocks are commented out still fails here
+    rather than at the first launch after someone uncomments them.
+    """
+    names = {name for entries in _FIXTURE_SKILL_SETS.values() for name in entries}
 
     for name in sorted(names):
         assert (
             _SKILLS_DIR / name / "SKILL.md"
-        ).is_file(), f"skill_sets names {name!r} but gaia_agent_email/skills/{name}/SKILL.md is missing"
+        ).is_file(), f"skill set names {name!r} but gaia_agent_email/skills/{name}/SKILL.md is missing"
 
 
 def test_no_bundled_skill_is_orphaned():
     """A shipped skill no set references is dead weight in the package."""
-    declared = yaml.safe_load(_MANIFEST.read_text(encoding="utf-8"))
-    referenced = {
-        name for entries in declared["skill_sets"].values() for name in entries
-    } | set(declared.get("skills") or [])
+    referenced = {name for entries in _FIXTURE_SKILL_SETS.values() for name in entries}
     on_disk = {p.parent.name for p in _SKILLS_DIR.glob("*/SKILL.md")}
     assert on_disk == referenced
+
+
+def test_the_fixture_sets_match_the_commented_out_manifest_blocks():
+    """``_FIXTURE_SKILL_SETS`` is the manifest's commented-out text, mirrored.
+
+    If the two drift, the framework tests below stop covering what re-enabling
+    would actually switch on — which is the whole reason they use a fixture.
+    Parsed from the commented block so this cannot rot silently.
+    """
+    lines = _MANIFEST.read_text(encoding="utf-8").splitlines()
+    start = next(
+        (i for i, line in enumerate(lines) if line.strip() == "# skill_sets:"), None
+    )
+    assert start is not None, (
+        "the commented-out '# skill_sets:' block is gone from gaia-agent.yaml — "
+        "if skills were re-enabled, update this file's shipped-state tests"
+    )
+    # From that anchor on, every comment line is the commented YAML block.
+    block = yaml.safe_load(
+        "\n".join(
+            line[2:] if line.startswith("# ") else ""
+            for line in lines[start:]
+            if line.startswith("#")
+        )
+    )
+
+    assert block["skill_sets"] == _FIXTURE_SKILL_SETS
+    assert block["default_skill_set"] == _FIXTURE_DEFAULT_SET
 
 
 def test_bundled_skills_are_instruction_only(tmp_path):
@@ -237,6 +311,98 @@ def test_the_frozen_binary_bundles_the_skills_and_the_manifest():
 
 
 # ----------------------------------------------------------------------
+# What this agent actually ships: Agent Skills OFF
+#
+# The manifest's skill_sets:/default_skill_set: blocks are commented out
+# pending eval validation. These tests pin that shipped state — they are the
+# ones that must fail if someone re-enables the blocks without an eval behind
+# them. Everything below this section uses the ``declared_sets`` fixture and
+# covers the generic machinery, which the product decision does not change.
+# ----------------------------------------------------------------------
+
+
+def test_shipped_manifest_declares_no_skill_sets():
+    from gaia.hub.manifest import parse as parse_manifest
+
+    sets = parse_manifest(EmailTriageAgent.SKILL_MANIFEST).skill_sets
+
+    assert not sets, "the shipped manifest re-enabled skill sets"
+    assert sets.set_names == []
+    assert sets.default_set is None
+
+
+def test_shipped_agent_loads_zero_skills(tmp_path, monkeypatch):
+    """The behavioural claim: nothing reaches the prompt.
+
+    Built with a work mailbox — the account type that WOULD select the 'work'
+    set — so this fails if selection is still wired through to a load.
+    """
+    agent = _build_agent(tmp_path, monkeypatch, account_type=ACCOUNT_TYPE_WORK)
+
+    assert agent.loaded_skills == {}
+    assert agent.active_skill_set is None
+    assert not agent.get_skills_system_prompt()
+    for name in ("inbox-triage", "meeting-scheduling", "newsletter-digest"):
+        assert name not in agent.system_prompt
+
+
+def test_shipped_agent_envelope_budget_is_the_pre_skills_6144(tmp_path, monkeypatch):
+    """The regression this change exists to undo.
+
+    The personal set cost ~1,334 prompt tokens, cutting this envelope from 6144
+    to 4810 (the work set, to 4070). With no skills loaded the skill cost is 0
+    and the budget is byte-identical to its pre-#2466 value.
+    """
+    from gaia_agent_email.context_budget import (
+        envelope_budget_tokens,
+        skill_prompt_tokens,
+    )
+
+    agent = _build_agent(tmp_path, monkeypatch, account_type=ACCOUNT_TYPE_WORK)
+
+    assert skill_prompt_tokens(agent) == 0
+    assert envelope_budget_tokens() == 6144
+    assert envelope_budget_tokens(extra_fixed_tokens=skill_prompt_tokens(agent)) == 6144
+
+
+def test_shipped_agent_rejects_an_explicit_skill_set(tmp_path, monkeypatch):
+    """``--skill-set personal`` must fail loudly, not silently load nothing.
+
+    No sets are declared, so there is nothing to honour. Quietly ignoring the
+    request would leave the caller believing a set is active (CLAUDE.md's
+    no-silent-fallbacks rule).
+    """
+    with pytest.raises(SkillSetError) as excinfo:
+        _build_agent(tmp_path, monkeypatch, skill_set="personal")
+
+    message = str(excinfo.value)
+    assert "declares no 'skill_sets:' block" in message
+    assert "gaia-agent.yaml" in message
+
+
+def test_shipped_sidecar_rejects_a_pinned_skill_set_with_an_actionable_error(capsys):
+    """The same refusal at the CLI boundary, where the empty list would
+    otherwise render as a contentless "Valid sets: "."""
+    from gaia_agent_email import server
+
+    with pytest.raises(SystemExit):
+        server.main(["serve", "--skill-set", "personal"])
+
+    err = capsys.readouterr().err
+    assert "declares no skill sets" in err
+    assert "uncomment" in err
+
+
+def test_the_skills_are_still_bundled_even_though_none_load(tmp_path):
+    """Off, not removed — re-enabling is a manifest edit, not a re-add."""
+    manager = _isolated_manager(tmp_path)
+
+    assert {s.name for s in manager.list_skills()} == {
+        name for entries in _FIXTURE_SKILL_SETS.values() for name in entries
+    }
+
+
+# ----------------------------------------------------------------------
 # Selection
 # ----------------------------------------------------------------------
 
@@ -248,7 +414,7 @@ def _declared_sets():
     return parse_manifest(EmailTriageAgent.SKILL_MANIFEST).skill_sets
 
 
-def test_manifest_declarations():
+def test_manifest_declarations(declared_sets):
     sets = _declared_sets()
     assert sets.set_names == ["personal", "work"]
     assert sets.default_set == "personal"
@@ -265,13 +431,13 @@ def test_manifest_declarations():
     assert set(personal) & set(work) == {"inbox-triage"}
 
 
-def test_account_type_map_only_names_declared_sets():
+def test_account_type_map_only_names_declared_sets(declared_sets):
     sets = _declared_sets()
     assert set(ACCOUNT_TYPE_SKILL_SETS) == {ACCOUNT_TYPE_PERSONAL, ACCOUNT_TYPE_WORK}
     for account_type, set_name in ACCOUNT_TYPE_SKILL_SETS.items():
         assert set_name in sets.set_names, (
             f"account type {account_type!r} maps to skill set {set_name!r}, "
-            "which gaia-agent.yaml does not declare"
+            "which the manifest does not declare"
         )
 
 
@@ -296,7 +462,7 @@ def test_account_type_map_only_names_declared_sets():
     ],
 )
 def test_account_type_selects_its_set_and_nothing_else(
-    tmp_path, monkeypatch, account_type, expected_set, expected_skills
+    tmp_path, monkeypatch, declared_sets, account_type, expected_set, expected_skills
 ):
     agent = _build_agent(tmp_path, monkeypatch, account_type=account_type)
 
@@ -305,7 +471,9 @@ def test_account_type_selects_its_set_and_nothing_else(
     assert set(agent.loaded_skills) == expected_skills
 
 
-def test_the_other_sets_skills_are_absent_from_the_prompt(tmp_path, monkeypatch):
+def test_the_other_sets_skills_are_absent_from_the_prompt(
+    tmp_path, monkeypatch, declared_sets
+):
     agent = _build_agent(tmp_path, monkeypatch, account_type=ACCOUNT_TYPE_WORK)
     prompt = agent.system_prompt
 
@@ -314,7 +482,9 @@ def test_the_other_sets_skills_are_absent_from_the_prompt(tmp_path, monkeypatch)
     assert "travel-itinerary" not in prompt
 
 
-def test_explicit_skill_set_overrides_the_account_type(tmp_path, monkeypatch):
+def test_explicit_skill_set_overrides_the_account_type(
+    tmp_path, monkeypatch, declared_sets
+):
     agent = _build_agent(
         tmp_path, monkeypatch, account_type=ACCOUNT_TYPE_WORK, skill_set="personal"
     )
@@ -322,13 +492,17 @@ def test_explicit_skill_set_overrides_the_account_type(tmp_path, monkeypatch):
     assert "meeting-scheduling" not in agent.loaded_skills
 
 
-def test_unknown_skill_set_fails_loudly_listing_the_valid_ones(tmp_path, monkeypatch):
+def test_unknown_skill_set_fails_loudly_listing_the_valid_ones(
+    tmp_path, monkeypatch, declared_sets
+):
     with pytest.raises(SkillSetError) as excinfo:
         _build_agent(tmp_path, monkeypatch, skill_set="buisness")
     assert "Valid sets: personal, work" in str(excinfo.value)
 
 
-def test_a_gmail_only_mailbox_resolves_the_default_set(tmp_path, monkeypatch):
+def test_a_gmail_only_mailbox_resolves_the_default_set(
+    tmp_path, monkeypatch, declared_sets
+):
     """Gmail carries no Microsoft tenant, so the kind is genuinely unknown.
 
     The default set must then apply *explicitly* — a work mailbox must never be
@@ -344,7 +518,7 @@ def test_a_gmail_only_mailbox_resolves_the_default_set(tmp_path, monkeypatch):
     assert agent.active_skill_set == "personal"  # the manifest's default_skill_set
 
 
-def test_a_derived_account_type_drives_the_set(tmp_path, monkeypatch):
+def test_a_derived_account_type_drives_the_set(tmp_path, monkeypatch, declared_sets):
     """With nothing pinned, the kind recorded on the connection decides."""
     monkeypatch.setattr(
         "gaia_agent_email.config.get_connection",
@@ -378,7 +552,9 @@ def test_an_unreadable_connection_store_reports_unknown(monkeypatch):
     assert EmailAgentConfig().resolve_account_type() is None
 
 
-def test_switching_sets_at_runtime_replaces_the_previous_one(tmp_path, monkeypatch):
+def test_switching_sets_at_runtime_replaces_the_previous_one(
+    tmp_path, monkeypatch, declared_sets
+):
     agent = _build_agent(tmp_path, monkeypatch, account_type=ACCOUNT_TYPE_PERSONAL)
     assert agent.active_skill_set == "personal"
 
@@ -394,7 +570,9 @@ def test_switching_sets_at_runtime_replaces_the_previous_one(tmp_path, monkeypat
 # ----------------------------------------------------------------------
 
 
-def test_loaded_skills_shrink_the_triage_envelope_budget(tmp_path, monkeypatch):
+def test_loaded_skills_shrink_the_triage_envelope_budget(
+    tmp_path, monkeypatch, declared_sets
+):
     """A skill body is prompt text the post-tool turn re-reads.
 
     Regression guard: at the pinned 16,384-token envelope, adding the personal
@@ -418,7 +596,7 @@ def test_loaded_skills_shrink_the_triage_envelope_budget(tmp_path, monkeypatch):
 
 
 def test_the_whole_post_tool_turn_fits_the_window_with_skills_loaded(
-    tmp_path, monkeypatch
+    tmp_path, monkeypatch, declared_sets
 ):
     """The behavioural claim, not the arithmetic identity.
 
@@ -480,7 +658,7 @@ def test_the_whole_post_tool_turn_fits_the_window_with_skills_loaded(
     )
 
 
-def test_the_skill_cost_estimate_is_pessimistic(tmp_path, monkeypatch):
+def test_the_skill_cost_estimate_is_pessimistic(tmp_path, monkeypatch, declared_sets):
     """A budget SUBTRACTION must never under-count.
 
     ``estimate_tokens``' chars//4 prose ratio under-counts real Markdown by
@@ -497,7 +675,9 @@ def test_the_skill_cost_estimate_is_pessimistic(tmp_path, monkeypatch):
     assert skill_prompt_tokens(agent) >= int(len(fragment) / 2.1)
 
 
-def test_the_bundled_skill_bodies_stay_within_their_prompt_budget(tmp_path):
+def test_the_bundled_skill_bodies_stay_within_their_prompt_budget(
+    tmp_path, declared_sets
+):
     """Cap the per-set prompt cost so a future edit can't quietly refill the ctx.
 
     The envelope the triage tool has left is ``6144 - <set cost>``; a set costing
@@ -554,7 +734,7 @@ def test_a_malformed_account_type_field_fails_validation():
 # ----------------------------------------------------------------------
 
 
-def test_skill_set_flag_exports_the_env_var(monkeypatch):
+def test_skill_set_flag_exports_the_env_var(monkeypatch, declared_sets):
     """The flag has to survive into the per-request agent sessions.
 
     The app is built at import time and sessions are constructed per request, so
@@ -574,7 +754,7 @@ def test_skill_set_flag_exports_the_env_var(monkeypatch):
     assert EmailAgentConfig().skill_set == "work"
 
 
-def test_skill_set_flag_rejects_an_undeclared_name(capsys):
+def test_skill_set_flag_rejects_an_undeclared_name(capsys, declared_sets):
     from gaia_agent_email import server
 
     with pytest.raises(SystemExit):
@@ -582,13 +762,15 @@ def test_skill_set_flag_rejects_an_undeclared_name(capsys):
     assert "Valid sets: personal, work" in capsys.readouterr().err
 
 
-def test_skill_set_flag_help_lists_the_declared_sets():
+def test_skill_set_flag_help_lists_the_declared_sets(declared_sets):
     from gaia_agent_email.server import _declared_skill_sets
 
     assert _declared_skill_sets() == ["personal", "work"]
 
 
-def test_an_invalid_env_var_is_rejected_at_startup_like_the_flag(monkeypatch, capsys):
+def test_an_invalid_env_var_is_rejected_at_startup_like_the_flag(
+    monkeypatch, capsys, declared_sets
+):
     """The docs call the env var equivalent to the flag — so it must validate.
 
     Left unchecked, ``GAIA_EMAIL_SKILL_SET=buisness`` started a healthy-looking
@@ -602,7 +784,7 @@ def test_an_invalid_env_var_is_rejected_at_startup_like_the_flag(monkeypatch, ca
     assert "Valid sets: personal, work" in capsys.readouterr().err
 
 
-def test_a_valid_env_var_is_accepted_at_startup(monkeypatch):
+def test_a_valid_env_var_is_accepted_at_startup(monkeypatch, declared_sets):
     from gaia_agent_email import server
 
     monkeypatch.setenv(SKILL_SET_ENV, "work")
@@ -611,7 +793,9 @@ def test_a_valid_env_var_is_accepted_at_startup(monkeypatch):
     assert run.called
 
 
-def test_an_unreadable_manifest_cannot_wave_a_requested_set_through(monkeypatch, capsys):
+def test_an_unreadable_manifest_cannot_wave_a_requested_set_through(
+    monkeypatch, capsys
+):
     """Validation must fail loudly, not degrade to "accept anything".
 
     The help-text helper swallows read errors by design; using it to validate


### PR DESCRIPTION
Every email agent launch on `main` today loads three skill bodies into its system prompt. That costs ~1,334 prompt tokens and cuts the bulk-triage result envelope from 6144 to 4810 — a fifth of the room the agent has to hand back a tool result (the `work` set, a third: 4070) — traded for a triage quality improvement that no eval has measured. #2695 turned this on by default and it is live now. After this PR the agent resolves no skill set, loads nothing, and the envelope is back to 6144, byte-identical to pre-skills. The six skills stay in the wheel and the frozen binary, inert; re-enabling is uncommenting two blocks in `gaia-agent.yaml`, once an eval backs them.

Two things worth flagging for review:

- **`--skill-set` now fails at startup instead of quietly doing nothing.** That is the intended no-silent-fallbacks behaviour. The sidecar used to render the empty case as `Valid sets: .`; it now names the real cause and the fix.
- **`SCORECARD.md` is deliberately not regenerated, and is now accurate again.** It contains no reference to skills or a skill-adjusted budget, and its `generated_at` is 2026-07-16 — three weeks before the skills landed in bbf69fd6. Every number in it, including `tokens_per_triage` 1906.03, was measured with zero skills loaded and a full 6144 envelope. Between #2695 merging and this PR it described pre-skills behaviour while the shipped agent had a set active; with the blocks commented out the runtime matches its measurement conditions again.

The set-resolution tests move to a fixture manifest that switches the blocks back on, so the generic skill-set machinery keeps full coverage and re-enabling lands on tests that already pass, rather than on a rewrite.

## Test plan

- [ ] `python -m pytest hub/agents/email/python/tests/test_skill_sets_2466.py` — 42 passed, covering both the shipped state (zero skills, no active set, 6144 envelope, loud `--skill-set` refusal) and the generic machinery against the fixture manifest
- [ ] `python -m pytest tests/unit/test_skill_sets.py` — framework coverage, unchanged by this PR (it builds inline manifests and never reads the email agent's). One pre-existing Windows-only path-separator failure in `test_manifest_error_names_the_file`, present identically on `main`
- [ ] Confirm the shipped agent loads nothing:
      `python -c "from gaia.hub.manifest import parse; from gaia_agent_email.agent import EmailTriageAgent as A; s=parse(A.SKILL_MANIFEST).skill_sets; print(bool(s), s.set_names, s.default_set)"` → `False [] None`
- [ ] Confirm the envelope is restored:
      `python -c "from gaia_agent_email.context_budget import envelope_budget_tokens as e; print(e())"` → `6144`
- [ ] Confirm the skills still ship: six `SKILL.md` files under `gaia_agent_email/skills/` and `SKILL_DIRS` still pointing at them
- [ ] `gaia-agent-email serve --skill-set personal` exits non-zero naming the cause and the fix
- [ ] Re-enable check: uncomment both manifest blocks → the fixture-parity test confirms the sets match what the framework tests already cover

**Verified locally:** the 42 skill-set tests above; `envelope_budget_tokens()` == 6144 proven by an actual run, not by reading the code; the shipped manifest parsing to zero sets; the real `--skill-set` startup error text; and the ~1,334 / 4810 / 4070 token figures quoted throughout, measured rather than assumed (an earlier "278 tokens of headroom" figure did not reproduce and was corrected everywhere it had propagated).

**Not finished:** a full-repo baseline comparison was still running when this PR opened, so unrelated pre-existing full-suite failures are not yet distinguished from anything this change might cause. The affected test files run in isolation are byte-identical with and without this change (2 failed / 130 passed either way, both pre-existing), but CI's run against `main` is the authoritative comparison. `util/lint.py --all` could not complete locally (its tools are fetched via `uvx` and the sandbox blocks PyPI); note it lints `src/gaia` and `tests` only, and this PR changes no Python under either.
