### PR TITLE
ci(email): run the triage eval on PRs that touch the email agent

### DIFF
--- a/.github/workflows/test_email_agent_eval.yml
+++ b/.github/workflows/test_email_agent_eval.yml
@@ -1,7 +1,8 @@
 # Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
 # SPDX-License-Identifier: MIT
 
-# Nightly + manual offline eval for the email-triage agent (#1112).
+# Offline eval for the email-triage agent (#1112) — weekly, on email PRs,
+# on demand, and as a release gate via workflow_call.
 #
 # Drives the email-triage throughput/quality benchmark over the committed
 # SYNTHETIC corpus (tests/fixtures/email/) via FakeGmailBackend — never a live
@@ -9,29 +10,34 @@
 # / 50-email latency / peak memory, #1277) gates and the categorization-accuracy
 # / phishing-precision numbers, logs them, and uploads the full gate report.
 #
-# MIXED MODE. The gate bars + the single on/off switch live in ONE committed
+# SINGLE SOURCE. The gate bars + the single on/off switch live in ONE committed
 # source each — the threshold manifests under tests/fixtures/email/, read here
 # only through the harness loaders (no thresholds are hardcoded in this YAML):
-#   - tests/fixtures/email/quality_gate_thresholds.json  (FP<5% / FN<2% — report mode)
-#   - tests/fixtures/email/perf_gate_thresholds.json      (TTFT / tps / latency / mem — ENFORCING)
-#   - tests/fixtures/email/drafting_gate_thresholds.json  (draft-approval >=70%, #1269 — ENFORCING)
-#   - tests/fixtures/email/briefing_gate_thresholds.json  (briefing quality, #1951 — ENFORCING)
+#   - tests/fixtures/email/quality_gate_thresholds.json      (FP<5% / FN<2%, #1278)
+#   - tests/fixtures/email/perf_gate_thresholds.json         (TTFT / tps / latency / mem, #1277)
+#   - tests/fixtures/email/drafting_gate_thresholds.json     (draft-approval >=70%, #1269)
+#   - tests/fixtures/email/briefing_gate_thresholds.json     (briefing quality, #1951)
+#   - tests/fixtures/email/action_items_gate_thresholds.json (P/R/F1, #1949)
 #
-# NOTE: the perf (#1277), drafting (#1269) and briefing (#1951) gates now ship
-# enforce:TRUE — a bar/quality breach fails the build (no report-mode fallback).
-# Only the FP/FN quality gate remains report mode. The judged evals (drafting,
-# briefing) hard-require ANTHROPIC_API_KEY: a missing key fails the build (exit 1,
-# no silent skip — CLAUDE.md fail-loudly), never an un-judged pass. See the
-# briefing block near the end of this job.
+# ALL FIVE CURRENTLY SHIP `enforce: false` — every gate is in REPORT MODE. #2038
+# ("unblock v0.4.0 — calibrate perf bars, report-mode unvalidated judge gates")
+# flipped perf, drafting and briefing to false and this header was not updated
+# with it; the paragraphs below used to claim they were ENFORCING and were wrong
+# from #2038 until this line was written. Read the manifests, not this comment,
+# if the two ever disagree again — `git grep '"enforce"' tests/fixtures/email/`.
 #
-# CI keys off each gate's `should_fail` (= enforce and not passed). The perf,
-# drafting, and briefing manifests now ship `enforce: true`, so a breach in any
-# of them fails the build. The FP/FN quality manifest still ships
-# `enforce: false` — its gate machinery runs, logs, and uploads, but a breach
-# stays green (categorization accuracy is still ~0.40, so the FP/FN bars are not
-# yet meaningful). Enforcement is toggled IN THE MANIFEST (data, not this
-# workflow); flip the FP/FN manifest to `enforce: true` once #1266
-# (categorization) / #1271 (phishing) land. No edit to this file is needed then.
+# CI keys off each gate's `should_fail` (= enforce AND not passed). With enforce
+# false everywhere, `should_fail` is never true, so a breached BAR cannot fail any
+# run on any trigger today. What still fails the build, on every trigger, is the
+# class of things that mean the eval could not prove anything: a missing
+# ANTHROPIC_API_KEY, an errored or unjudged case, a judge transport error, or a
+# harness crash (CLAUDE.md fail-loudly — never an un-judged pass).
+#
+# Enforcement is toggled IN THE MANIFEST (data, not this workflow): flip a gate's
+# `"enforce"` to true and it blocks the weekly, the release AND the PR at once.
+# No edit to this file is needed. The bars become meaningful gate-by-gate as
+# #1266 (categorization) / #1271 (phishing) land and the judged evals accumulate
+# a stable baseline.
 #
 # NOTE on accuracy gates: categorization >=85% (#1266) and phishing precision
 # >=90% (#1271) do not yet have committed threshold manifests (they are owned by
@@ -39,18 +45,82 @@
 # precision the benchmark already emits, but does not gate on them — there is no
 # committed bar to read, and inventing one in YAML would violate the single-source
 # rule above. They become gating once their manifests land and this gate-reader is
-# pointed at them. Draft-approval >=70% (#1269) DOES now have a committed manifest
-# (tests/fixtures/email/drafting_gate_thresholds.json, enforce:true) — it is
-# scored by the voice-drafting eval step below (#1607 / #1948) and now enforcing:
-# a draft-approval breach fails the build, and a missing judge credential also
-# fails it (eval_drafting_report.py exits 1 — no silent skip).
+# pointed at them. Draft-approval >=70% (#1269) DOES have a committed manifest
+# (tests/fixtures/email/drafting_gate_thresholds.json) — it is scored by the
+# voice-drafting eval step below (#1607 / #1948) and reported, not enforced
+# (enforce:false, per #2038: no stable judged baseline yet). A missing judge
+# credential still fails the build (eval_drafting_report.py exits 1 — no silent
+# skip).
 #
 # Self-hosted: this needs a running Lemonade Server on AMD hardware, so it runs
 # on the [self-hosted, Windows, stx] pool. The install-lemonade action pins the
 # runner to the expected LEMONADE_VERSION (installs if missing, reconciles if
 # drifted) and ensure-lemonade-running.ps1 starts + warms the server before the
 # eval. Serial execution across the eval workflows is enforced by the shared
-# `lemonade-eval` concurrency group (below), NOT by a runner label.
+# `lemonade-eval` concurrency group (now on the JOB — see the note there), NOT
+# by a runner label.
+#
+# ── PULL-REQUEST COVERAGE (#2695 fallout) ─────────────────────────────────────
+# Until this trigger existed, a PR could change the email agent's system prompt,
+# tools, or triage behavior and merge with ZERO LLM-behavior evidence: pytest and
+# the non-LLM integration suites went green and nothing ran an eval. #2695
+# (bundled skills, merged as bbf69fd6) is the proof — it injected three Agent
+# Skills into the system prompt by default and re-sized the bulk-triage envelope
+# budget, having already blown the 16,384-token window once at 16,602 tokens
+# during development. It landed at 16,106 — 278 tokens of headroom, established
+# by a single manual run and pinned by nothing in CI.
+#
+# The `pull_request` trigger below closes that. Three things keep it affordable
+# on a scarce, strictly-serial runner pool:
+#
+#   1. PATHS. It fires only on PRs touching the email agent's own code, its
+#      corpus/threshold manifests, the eval machinery that scores it, the skills
+#      runtime that injects text into its system prompt, or this workflow and the
+#      composite actions it runs. Deliberately NOT `src/gaia/agents/base/**` or
+#      `src/gaia/llm/**`: those are cross-agent surfaces already covered by
+#      test_eval_agent_gemma_consolidation.yml, and adding them here would roughly
+#      double the load on the single Lemonade slot. For a core-only change that
+#      you suspect moves email behavior, `workflow_dispatch` this workflow against
+#      the branch.
+#   2. SUPERSEDING. PR runs share a per-PR concurrency group with
+#      cancel-in-progress, so rapid pushes never stack up 90-minute jobs.
+#   3. LIMIT. PR runs triage 20 emails, not 50 — same slice the release gate uses.
+#
+# COST TO THE RELEASE PATH, STATED PLAINLY. The `lemonade-eval` group holds one
+# running plus one pending run; a newly-queued run CANCELS the previously pending
+# one. Adding ~1 PR run/day to that group therefore makes it possible for a
+# release-gate or weekly call to be evicted while pending. That is the price of
+# pre-merge coverage on a single-slot pool, and it is bounded, not hidden:
+# per-PR cancel-in-progress collapses repeated pushes to one run, and
+# weekly_eval.yml now treats a non-success (not merely a 'failure') callee as a
+# reportable outcome so an eviction cannot pass as a clean run. Making the same
+# eviction visible in publish.yml / release_agent_email.yml is tracked separately.
+# It cuts the other way too: a PR run can itself be evicted while pending, which
+# leaves that PR with no eval and no auto-requeue. Re-run the job from the Checks
+# tab if the coverage matters for the change under review.
+#
+# A PR RUN IS ADVISORY, AND THAT IS NOT A TRIGGER-SCOPED CHOICE. Per the enforce
+# state above, no gate blocks anything on any trigger right now, so a PR run is
+# report mode for free. There is deliberately NO "report only on PRs" override
+# here: it would break the single-source rule, and — with every manifest at
+# enforce:false — the only exits it could soften are the fail-loudly ones. To make
+# a gate block a PR, flip its manifest's `"enforce"` to true; it then blocks the
+# weekly, the release AND the PR together, which is the right coupling.
+#
+# WHAT MAKES THE ADVISORY RESULT VISIBLE. A breached bar under enforce:false is a
+# GREEN step with no annotation — evidence that exists only inside an artifact
+# nobody opens is not coverage. The "Gate verdicts" step near the end of this job
+# therefore parses the gate reports the eval writes to eval-out/ and republishes
+# every gate's pass/fail into the job summary, raising a `::warning::` per breach.
+# That, not the exit code, is the PR-facing signal today.
+#
+# FORKS. The job does not run for fork PRs — pointing a self-hosted runner at
+# unreviewed fork code is not acceptable, and a fork PR carries no
+# ANTHROPIC_API_KEY, so it could only ever produce an un-judged result.
+# test_eval_agent_gemma_consolidation.yml reaches the same end by having no
+# `pull_request` trigger at all; this workflow needs one, so the guard is explicit
+# in the job's `if:`. A fork PR touching the email agent needs a maintainer to
+# push the branch into this repo and re-run.
 
 name: Email Agent Eval (offline, report mode)
 
@@ -61,6 +131,31 @@ on:
   # release_agent_email.yml eval-gate — so daily cadence here is unnecessary.)
   schedule:
     - cron: '17 7 * * 1'
+  # Pre-merge coverage for email-agent behavior changes — see the PULL-REQUEST
+  # COVERAGE block in the header for why these paths and not more. Advisory
+  # (report mode) by default; `ready_for_review` is in `types` so undrafting a PR
+  # triggers the run that the draft state skipped.
+  pull_request:
+    branches: [ main ]
+    types: [opened, synchronize, reopened, ready_for_review]
+    paths:
+      # The agent itself — prompts, tools, triage/condense, bundled skills, and
+      # the packaging/eval_*_report.py gate readers this workflow invokes.
+      - 'hub/agents/email/python/**'
+      # The synthetic corpus, ground truth, and every committed threshold
+      # manifest the gates are read from.
+      - 'tests/fixtures/email/**'
+      # The skills runtime injects skill bodies into the agent's system prompt
+      # and charges them against the triage context budget (#2695).
+      - 'src/gaia/skills/**'
+      # The gate machinery this workflow executes: gaia.eval.performance,
+      # draft_quality, action_item_quality, briefing_quality and the threshold
+      # loaders. A change here moves the verdict without touching the agent.
+      - 'src/gaia/eval/**'
+      - '.github/workflows/test_email_agent_eval.yml'
+      - '.github/actions/setup-venv/**'
+      - '.github/actions/install-lemonade/**'
+      - 'installer/scripts/ensure-lemonade-running.ps1'
   # Manual trigger, with a knob for repeat experiments (variance).
   workflow_dispatch:
     inputs:
@@ -102,14 +197,32 @@ on:
         default: '1'
     secrets:
       ANTHROPIC_API_KEY:
-        description: 'Judge credential for the drafting / action-item / briefing judged evals — REQUIRED; absent → those evals fail loudly (exit 1), never a skip.'
+        description: 'Judge credential for the drafting / action-item / briefing judged evals — REQUIRED; absent → the preflight step fails the run before any eval spend, never a skip. (Declared optional only so the call site does not have to name it when using `secrets: inherit`.)'
         required: false
 
 concurrency:
-  # Share the single Lemonade backend slot with the other self-hosted evals so
-  # two runs never race-evict each other's model (see CLAUDE.md: evals serial).
-  group: lemonade-eval
-  cancel-in-progress: false
+  # PER-INVOCATION SUPERSEDING — NOT the serial slot. The `lemonade-eval` group
+  # that serializes this against the other self-hosted evals moved to the JOB
+  # below; it is deliberately NOT repeated here, because a workflow run holding a
+  # group at the workflow level while its only job waits on the same group at the
+  # job level is a self-deadlock.
+  #
+  # This group exists so a rapid re-push to a PR cancels the 90-minute run it
+  # superseded instead of queueing a second one behind it.
+  #
+  # The non-PR key is `github.run_id`, deliberately, NOT `github.ref`. A called
+  # reusable workflow's `concurrency` is evaluated in the CALLER's context — this
+  # repo has the scar to prove it (weekly_eval.yml: a caller holding the group the
+  # callee needed produced the phantom-job bug, every Weekly Eval run 2026-07-09..19
+  # dying in <60s and filing issue #2026 on a no-op). So this expression is live on
+  # the release path too, and keying it to the run id makes each release/weekly run
+  # the sole member of its own group: it can never queue behind, cancel, or be
+  # cancelled by anything. A PR key is the PR number so successive pushes to the
+  # SAME PR share one group and supersede each other.
+  group: email-agent-eval-${{ github.event.pull_request.number || github.run_id }}
+  # PR runs only. A weekly/dispatch/release run is never cancelled by a newer one
+  # (and, being alone in its group, has nothing to be cancelled by).
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 permissions:
   contents: read
@@ -119,7 +232,12 @@ env:
   # workflow_dispatch AND workflow_call — on a reusable call github.event.inputs
   # is empty. On schedule `inputs` is null and each falls back to its default.
   EMAIL_EVAL_MODEL: ${{ inputs.model || 'Gemma-4-E4B-it-GGUF' }}
-  EMAIL_EVAL_LIMIT: ${{ inputs.limit || '50' }}
+  # PR runs triage 20 emails, not 50 — the same slice release_agent_email.yml
+  # passes. TTFT/throughput are per-token and count-independent, and the three
+  # judge evals run their own fixed-size seed corpora, so the only thing 20 costs
+  # is categorization-accuracy sample size. It buys back ~19 min of a scarce,
+  # strictly-serial runner slot on every email PR.
+  EMAIL_EVAL_LIMIT: ${{ inputs.limit || (github.event_name == 'pull_request' && '20') || '50' }}
   EMAIL_EVAL_EXPERIMENTS: ${{ inputs.experiments || '1' }}
   GAIA_MEMORY_DISABLED: "1"
   PYTHONIOENCODING: "utf-8"
@@ -155,10 +273,66 @@ jobs:
     # The event_name guard keeps the pull_request dereference off schedule /
     # workflow_dispatch / workflow_call runs, where that context is absent.
     runs-on: ${{ fromJSON(github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'stx-test') && '["self-hosted","Windows","stx-test"]' || '["self-hosted","Windows","stx"]') }}
+    # THE SERIAL SLOT. Same group name as email_scorecard_refresh.yml and
+    # test_eval_agent_gemma_consolidation.yml — `lemonade-eval`, exactly — so at
+    # most one eval touches the single Lemonade backend at a time (CLAUDE.md: at
+    # most one `gaia eval agent` process, period). Two concurrent runs
+    # race-evict each other's model and produce chaotic ctx/model_load failures.
+    #
+    # It lives on the JOB rather than the workflow now, purely so the workflow
+    # level is free for the per-PR superseding group above. Concurrency groups are
+    # repository-wide and shared between job-level and workflow-level declarations
+    # ("only a single job OR WORKFLOW using the same concurrency group will run at
+    # a time"), so serialization against those sibling workflows is unchanged.
+    #
+    # Do NOT also declare `lemonade-eval` at the workflow level of this file: the
+    # run would hold the group while its only job waited for it — a self-deadlock,
+    # and the same shape as the phantom-job bug weekly_eval.yml documents.
+    concurrency:
+      group: lemonade-eval
+      cancel-in-progress: false
+    # PR guard (no-op for schedule / workflow_dispatch / workflow_call):
+    #   - fork PRs never reach the self-hosted pool, and could only produce an
+    #     un-judged result anyway (no ANTHROPIC_API_KEY) — see the header;
+    #   - drafts skip the 90-minute run until marked ready (or labeled
+    #     `ready_for_ci`), matching test_email_agent.yml;
+    #   - `skip-email-eval` is the documented opt-OUT for an email PR that
+    #     provably cannot move behavior (docs, comments, packaging metadata).
+    #     It is opt-OUT on purpose: an opt-IN label would leave the default at
+    #     "no coverage", which is the gap this trigger exists to close.
+    # Kept flat-indented on purpose: a YAML folded scalar preserves newlines on
+    # more-indented lines, and an `if:` expression must fold to a single line.
+    if: >-
+      github.event_name != 'pull_request' ||
+      (github.event.pull_request.head.repo.full_name == github.repository &&
+      (github.event.pull_request.draft == false ||
+      contains(github.event.pull_request.labels.*.name, 'ready_for_ci')) &&
+      !contains(github.event.pull_request.labels.*.name, 'skip-email-eval'))
     timeout-minutes: 90
     steps:
       - name: Checkout
         uses: actions/checkout@v7
+
+      # Fail-fast preflight. The three judged evals (drafting / action-item /
+      # briefing) each hard-require the judge credential and exit 1 without it —
+      # but only after the ~40-minute benchmark has already run. Checking it here
+      # turns "burn 40 minutes of the single serial Lemonade slot, then die" into
+      # "die in 10 seconds", which matters much more now that PRs queue for that
+      # slot too. Fails on EVERY trigger — a run that cannot judge cannot produce
+      # evidence (CLAUDE.md: fail loudly, no silent skip).
+      # Deliberately NOT a Lemonade check: the "Start Lemonade Server" step below
+      # is already that preflight and throws when the server is not ready.
+      - name: Preflight — judge credential
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+        run: |
+          # Single-quoted: a backtick in a double-quoted PowerShell string is the
+          # escape character and would eat the markdown ticks.
+          if ([string]::IsNullOrWhiteSpace($env:ANTHROPIC_API_KEY)) {
+            Write-Host '::error::ANTHROPIC_API_KEY is not set. The drafting, action-item and briefing evals score with the Claude judge (src/gaia/eval/claude.py) and exit 1 without it, so this run could only ever produce an un-judged result. Add the ANTHROPIC_API_KEY repository secret, or pass `secrets: inherit` from the calling workflow.'
+            exit 1
+          }
+          Write-Host "Judge credential present."
 
       - name: Setup Python Environment
         uses: ./.github/actions/setup-venv
@@ -233,16 +407,19 @@ jobs:
 
       # =================================================================
       # BEGIN voice-drafting quality eval (#1607 feature / #1269 metric /
-      # #1948 tracking) — ADDITIVE, self-contained block. Enforcing.
+      # #1948 tracking) — ADDITIVE, self-contained block. Report mode.
       #
       # Judge-scored draft quality over the committed drafting seed corpus with
       # the #1607 voice profile active (Lemonade, FakeGmailBackend — drafting
       # only, nothing is ever sent); a Claude judge scores each draft against
       # the case rubric. The aggregate draft_approval_rate is compared to the
       # committed manifest tests/fixtures/email/drafting_gate_thresholds.json
-      # (enforce:true) — same single-source rule as the gates above. A breach
-      # fails the build; a missing judge credential ALSO fails it
-      # (eval_drafting_report.py exits 1 — no silent skip, CLAUDE.md fail-loudly).
+      # — same single-source rule as the gates above. The manifest currently ships
+      # enforce:false (#2038), so a breach is REPORTED (see the "Gate verdicts"
+      # step) rather than failing the build; flip `enforce` there to make it
+      # block. A missing judge credential fails the run on every trigger (the
+      # preflight step, and eval_drafting_report.py itself exits 1 — no silent
+      # skip, CLAUDE.md fail-loudly).
       #
       # Runs AFTER the triage benchmark in the same job, so Lemonade access stays
       # strictly serial (CLAUDE.md: evals serial).
@@ -297,7 +474,8 @@ jobs:
 
       # =================================================================
       # BEGIN daily-briefing summary-quality eval (#1608 feature / #1951
-      # tracking) — ADDITIVE, self-contained block. ENFORCING gate.
+      # tracking) — ADDITIVE, self-contained block. Report mode (was ENFORCING
+      # until #2038 flipped the manifest).
       #
       # Judge-scored briefing quality: the REAL scheduled-briefing path
       # (gaia_agent_email.briefing.run_briefing_job -> pre_scan_inbox_impl)
@@ -306,21 +484,25 @@ jobs:
       # Claude judge scores each briefing against the case inbox + rubric on
       # faithfulness / must-include recall / hallucination-free / grouping. The
       # aggregate is compared to the committed manifest
-      #   tests/fixtures/email/briefing_gate_thresholds.json  (enforce:true)
+      #   tests/fixtures/email/briefing_gate_thresholds.json  (enforce:false)
       # via gaia.eval.briefing_quality — same single-source rule as the gates
       # above: no thresholds inlined in this YAML; tune the bars in the manifest
       # (data, not code).
       #
-      # This gate BLOCKS: a quality breach, any errored/unjudged case, a missing
-      # judge credential, or a judge transport error all fail the build. There
-      # is deliberately NO report-mode fallback and NO silent skip — if the eval
-      # cannot prove the briefing is good, the pipeline goes red.
+      # NO SILENT SKIP: any errored/unjudged case, a missing judge credential, or
+      # a judge transport error fails the build on every trigger — if the eval
+      # cannot prove anything, the pipeline goes red. The QUALITY BAR itself is
+      # currently reported, not enforced: this manifest was flipped to
+      # enforce:false by #2038 along with perf and drafting (this comment claimed
+      # otherwise until the PR trigger landed). Flip `enforce` back to true in the
+      # manifest to restore blocking; breaches are surfaced meanwhile by the
+      # "Gate verdicts" step.
       #
       # Runs AFTER the drafting eval in the same job, so Lemonade access stays
       # strictly serial (CLAUDE.md: evals serial). Keep this block
       # self-contained so concurrent edits to this workflow merge cleanly.
       # =================================================================
-      - name: Daily-briefing summary-quality eval (judge-scored, enforcing gate)
+      - name: Daily-briefing summary-quality eval (judge-scored)
         env:
           # Judge credential for gaia.eval.claude.ClaudeClient — REQUIRED. This
           # gate has no report-mode fallback: an absent key fails the build.
@@ -340,6 +522,33 @@ jobs:
           path: eval-out/
           if-no-files-found: warn
 
+      # =================================================================
+      # GATE VERDICTS — the reporting half of report mode.
+      #
+      # Every gate manifest ships enforce:false, so a breached bar exits 0: the eval
+      # steps are GREEN and the number lives only inside the uploaded artifact. Without
+      # this step the PR trigger would add a check that cannot say "this got
+      # worse" — exactly the silent degradation CLAUDE.md forbids. eval_summary.py
+      # reads the gate reports the eval already wrote and republishes every
+      # verdict into the job summary, one ::warning:: per breach.
+      #
+      # Runs on EVERY trigger, not just PRs: the weekly and the release gate have
+      # the same blind spot and get the same evidence.
+      #
+      # `if: always()` so the verdict is written even when an earlier step
+      # (preflight / Lemonade / benchmark) failed the job — a reviewer needs to see
+      # WHICH stage died, and "no gate report was produced" stated out loud beats a
+      # bare red X. The script carries no gate semantics — it never turns a passing
+      # run red over a breach, nor rescues a failing one. The `throw` below is not a
+      # gate either: a nonzero exit means the REPORTER itself broke (missing venv,
+      # missing file), which is a real failure and must not pass quietly.
+      # =================================================================
+      - name: Gate verdicts (job summary)
+        if: always()
+        run: |
+          python hub/agents/email/python/packaging/eval_summary.py eval-out
+          if ($LASTEXITCODE -ne 0) { throw "eval summary failed" }
+
       - name: Eval summary
         if: always()
         run: |
@@ -352,8 +561,13 @@ jobs:
           Write-Host "(FP/FN) and performance gates from the committed threshold"
           Write-Host "manifests under tests/fixtures/email/."
           Write-Host ""
-          Write-Host "Perf gate: ENFORCING (enforce:true) - a breach fails the build."
-          Write-Host "FP/FN quality gate: report mode (enforce:false) - a breach is logged"
-          Write-Host "+ uploaded but does NOT fail the build. Enforcement is toggled in the"
-          Write-Host "manifest (data, not this workflow) - see the header of this file."
+          Write-Host "ALL gate manifests currently ship enforce:false (report mode), so a"
+          Write-Host "breached BAR is logged, summarized and uploaded but does NOT fail the"
+          Write-Host "build - on any trigger, PRs included. See the per-gate verdicts in the"
+          Write-Host "job summary. Enforcement is toggled in the manifest (data, not this"
+          Write-Host "workflow) - see the header of this file."
+          Write-Host ""
+          Write-Host "What DOES fail the build, everywhere: a missing judge credential, an"
+          Write-Host "unreachable Lemonade, an unjudged case, or a harness crash. Report mode"
+          Write-Host "softens 'we measured and it got worse', never 'we did not measure'."
           Write-Host "================================================================"

--- a/.github/workflows/weekly_eval.yml
+++ b/.github/workflows/weekly_eval.yml
@@ -3,7 +3,7 @@
 #
 # Weekly eval sweep (#1964). Runs the email eval suite (triage + drafting +
 # action-item) once a week on the self-hosted Lemonade runner and OPENS A GITHUB
-# ISSUE if any eval fails, so a regression that the nightly report-mode run only
+# ISSUE if the eval does not pass, so a regression that the report-mode run only
 # logs is escalated into the tracker once a week instead of scrolling past.
 #
 # This calls the SAME reusable workflow the nightly and the release gates use
@@ -12,10 +12,10 @@
 # eval serial on the single Lemonade slot — this caller MUST NOT also claim it
 # (see the concurrency block below).
 #
-# "Failure" here is a real signal, never a silent skip: the action-item eval
-# REQUIRES the Claude judge (no fuzzy fallback), so a missing/broken judge, a
-# Lemonade/infra error, or an enforced (enforce:true) gate breach all fail the
-# job — which is exactly what files the issue.
+# A non-pass here is always a real signal, never a silent skip: the action-item
+# eval REQUIRES the Claude judge (no fuzzy fallback), so a missing/broken judge, a
+# Lemonade/infra error, or an enforced (enforce:true) gate breach all fail the job.
+# A CANCELLED callee counts too — see the `if:` on the notify job.
 
 name: Weekly Eval
 
@@ -49,11 +49,19 @@ jobs:
     secrets: inherit
 
   open-issue-on-failure:
-    name: Open an issue if the weekly eval failed
+    name: Open an issue if the weekly eval did not pass
     needs: email-eval
     # always() so this runs even though the needed job failed; then gate on the
-    # failure result so it only fires on a real failure.
-    if: ${{ always() && needs.email-eval.result == 'failure' }}
+    # result being anything other than a clean pass.
+    #
+    # `!= 'success'` rather than `== 'failure'`: the callee's job now shares the
+    # `lemonade-eval` group with PR-triggered runs (test_email_agent_eval.yml
+    # gained a `pull_request` trigger), and that group holds one running plus one
+    # pending run — a newly-queued run cancels the pending one. An evicted weekly
+    # eval reports 'cancelled', not 'failure', so the old condition filed nothing
+    # and the week's eval vanished with zero signal. A week with no eval is a week
+    # with no evidence; say so out loud.
+    if: ${{ always() && needs.email-eval.result != 'success' }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -62,26 +70,36 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7
 
-      - name: File (or update) the eval-failure issue
+      - name: File (or update) the rolling eval-failure issue
         env:
           GH_TOKEN: ${{ github.token }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           EVENT_NAME: ${{ github.event_name }}
+          EVAL_RESULT: ${{ needs.email-eval.result }}
         run: |
           set -euo pipefail
+          # STABLE DEDUP KEY — do not reword. The rolling-issue lookup below
+          # searches on this exact title; changing it orphans the open issue and
+          # files a duplicate. The body, not the title, says what actually happened.
           TITLE="Weekly eval failure: email eval suite"
           # Idempotent label so --label never errors (create-or-update).
           gh label create eval-failure --color B60205 \
             --description "Automated weekly eval failure" --force
           BODY="$(cat <<EOF
-          The weekly email eval suite (\`test_email_agent_eval.yml\`, called by \`weekly_eval.yml\`) failed.
+          The weekly email eval suite (\`test_email_agent_eval.yml\`, called by \`weekly_eval.yml\`) did not pass.
 
           - Run: ${RUN_URL}
           - Trigger: ${EVENT_NAME}
+          - Result: \`${EVAL_RESULT}\`
 
-          The email eval REQUIRES the Claude equivalence judge (there is no fuzzy fallback), so a failure here is one of:
-          a Lemonade / infra error, the Claude judge being unavailable or broken, or an enforced (\`enforce: true\`) gate breach.
-          Open the run log above to see which stage failed (triage / drafting / action-item) and why.
+          If the result is \`failure\`: the email eval REQUIRES the Claude equivalence judge (there is no fuzzy fallback),
+          so it is one of a Lemonade / infra error, the Claude judge being unavailable or broken, or an enforced
+          (\`enforce: true\`) gate breach. Open the run log above to see which stage failed (triage / drafting /
+          action-item) and why.
+
+          If the result is \`cancelled\`: the run was most likely evicted from the shared \`lemonade-eval\` concurrency
+          slot — it holds one running plus one pending run, and a newly-queued run cancels the pending one (PR-triggered
+          email evals now queue there too). No eval ran this week; re-dispatch \`weekly_eval.yml\` when the slot is free.
           EOF
           )"
           # One rolling issue: comment on the open one if it exists, else open it.

--- a/hub/agents/email/python/packaging/eval_summary.py
+++ b/hub/agents/email/python/packaging/eval_summary.py
@@ -1,0 +1,201 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+"""Republish the email eval's gate verdicts as a GitHub job summary.
+
+Every gate manifest under ``tests/fixtures/email/`` currently ships
+``enforce: false``, so a BREACHED BAR exits 0 and produces a green step with no
+annotation -- the number only exists inside ``eval-out/*.json``, which nobody
+opens. That is not coverage. This reporter reads the gate reports the eval
+already writes and republishes every verdict into ``$GITHUB_STEP_SUMMARY``,
+raising a ``::warning::`` per breach, so an advisory result still lands in front
+of a reviewer.
+
+It is a REPORTER, not a gate: it always exits 0. Blocking stays where it belongs
+-- ``should_fail`` (= ``enforce`` and not passed), owned by the manifests and
+acted on by the ``eval_*_report.py`` scripts. Flip a manifest's ``enforce`` to
+true and that gate blocks; this summary is unaffected either way.
+
+Gate discovery is structural, not a hardcoded list: any ``*_gate`` object
+carrying a ``passed`` OR a ``skipped`` key is picked up, at any depth, from any
+report file, so a new gate shows up here for free. Both keys matter -- a skipped
+gate (``{"skipped": true, "reason": ...}``) has NO ``passed`` field and hardcodes
+``should_fail: false`` even under ``enforce: true``, so nothing else in the
+pipeline catches it. "We could not measure this" is the one verdict that must
+never be rendered as a pass.
+
+Gates in ``GATE_LABELS`` that produce no verdict at all are reported as missing
+for the same reason: a step that died before writing its report must not read as
+four passes and a silence.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Any, Iterator
+
+DEFAULT_EVAL_DIR = Path("eval-out")
+
+# The gates this workflow's four eval steps are expected to produce, in pipeline
+# order. Doubles as the EXPECTED SET: a key here with no verdict is reported as
+# missing. A gate NOT in this map is still reported, under its raw JSON key, so a
+# newly-added gate is never dropped.
+GATE_LABELS = {
+    "quality_gate": "Triage quality (FP/FN)",
+    "perf_gate": "Performance (TTFT / tps / latency / mem)",
+    "drafting_gate": "Voice-drafting approval",
+    "extraction_gate": "Action-item extraction",
+    "briefing_gate": "Daily-briefing quality",
+}
+
+
+def find_gates(node: Any, key: str = "") -> Iterator[tuple[str, dict]]:
+    """Yield ``(gate_key, gate_dict)`` for every gate object under ``node``."""
+    if isinstance(node, dict):
+        # `skipped` as well as `passed`: a skip payload omits `passed` entirely.
+        if key.endswith("_gate") and ("passed" in node or "skipped" in node):
+            yield key, node
+            return
+        for child_key, child in node.items():
+            yield from find_gates(child, child_key)
+    elif isinstance(node, list):
+        for child in node:
+            yield from find_gates(child, key)
+
+
+def collect(eval_dir: Path) -> tuple[dict[str, dict], list[str]]:
+    """Return the gates found across ``eval_dir``'s reports, and unreadable files."""
+    gates: dict[str, dict] = {}
+    unreadable: list[str] = []
+    for path in sorted(eval_dir.glob("*.json")):
+        try:
+            payload = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, ValueError) as exc:
+            # Surfaced in the summary rather than swallowed: a corrupt report is
+            # missing evidence, and reading it as "no gates" would look like a pass.
+            unreadable.append(f"{path.name}: {exc}")
+            continue
+        for key, gate in find_gates(payload):
+            if key in gates and gates[key] != gate:
+                # Two reports disagree about one gate. Keeping the first silently
+                # could let a passing duplicate mask a breach.
+                unreadable.append(
+                    f"{path.name}: conflicting verdict for '{key}' "
+                    "(another report already reported it differently)"
+                )
+                continue
+            gates.setdefault(key, gate)
+    return gates, unreadable
+
+
+def _verdict(gate: dict) -> tuple[str, str | None]:
+    """Return ``(cell, warning_detail)``; ``warning_detail`` is None when clean."""
+    if gate.get("skipped"):
+        # `passed` is meaningless when nothing was scored - never render it as a pass.
+        reason = gate.get("reason") or "no reason recorded"
+        return (
+            f"not evaluated ({reason})",
+            "was NOT evaluated, so this run proves nothing about it. Read it as missing "
+            "evidence, not as a pass.",
+        )
+    if gate.get("passed"):
+        return "pass", None
+    if gate.get("enforce"):
+        return (
+            "**BREACH** (BLOCKING)",
+            "breached an enforced bar - the build should be red.",
+        )
+    return (
+        "**BREACH** (advisory)",
+        "breached its bar. The manifest ships enforce:false, so this does NOT fail the "
+        "build - open the 'email-eval-report' artifact and treat it as a real regression "
+        "until proven otherwise.",
+    )
+
+
+def render(gates: dict[str, dict], unreadable: list[str]) -> tuple[str, list[str]]:
+    """Return ``(markdown, warnings)``."""
+    lines = ["## Email agent eval - gate verdicts", ""]
+    warnings: list[str] = []
+
+    if not gates:
+        lines += [
+            "**No gate report was produced.** The eval did not get far enough to "
+            "measure anything - read the failing step above. Do NOT read this as a pass.",
+            "",
+        ]
+        warnings.append(
+            "Email eval produced no gate report. There is no LLM-behavior evidence "
+            "for this change."
+        )
+    else:
+        lines += ["| Gate | Verdict |", "| --- | --- |"]
+        # Pipeline order for the expected gates; unknown ones (a gate added later)
+        # trail alphabetically rather than being dropped.
+        order = list(GATE_LABELS)
+        keys = sorted(
+            set(gates) | set(order),
+            key=lambda k: (order.index(k) if k in order else len(order), k),
+        )
+        for key in keys:
+            label = GATE_LABELS.get(key, key)
+            if key not in gates:
+                cell = "no verdict produced"
+                detail = (
+                    "produced no verdict at all - its eval step did not get far enough "
+                    "to write a report. Read it as missing evidence, not as a pass."
+                )
+            else:
+                cell, detail = _verdict(gates[key])
+            lines.append(f"| {label} | {cell} |")
+            if detail:
+                warnings.append(f"Email eval - {label} {detail}")
+        lines.append("")
+
+    if unreadable:
+        lines.append("Unreadable report files (evidence missing):")
+        lines += [f"- `{item}`" for item in unreadable]
+        lines.append("")
+        warnings += [
+            f"Email eval - unreadable gate report {item}" for item in unreadable
+        ]
+
+    lines += [
+        "Bars and the on/off switch live in `tests/fixtures/email/*_gate_thresholds.json`. "
+        "All of them currently ship `enforce: false`, so a breach is reported, not blocking; "
+        "flip a manifest's `enforce` to `true` to make that gate block the weekly, the "
+        "release and PRs at once.",
+        "",
+        "_The published card `hub/agents/email/npm/SCORECARD.md` is NOT regenerated by this "
+        "run - that is `email_scorecard_refresh.yml` (full 250x3 profile, ~10h)._",
+    ]
+    return "\n".join(lines), warnings
+
+
+def main(argv: list[str] | None = None) -> int:
+    argv = sys.argv[1:] if argv is None else argv
+    eval_dir = Path(argv[0]) if argv else DEFAULT_EVAL_DIR
+
+    gates, unreadable = collect(eval_dir) if eval_dir.is_dir() else ({}, [])
+    markdown, warnings = render(gates, unreadable)
+
+    for warning in warnings:
+        print(f"::warning::{warning}")
+    if gates and not warnings:
+        print(f"::notice::Email eval: all {len(gates)} gates passed.")
+
+    print(markdown)
+    summary_path = os.environ.get("GITHUB_STEP_SUMMARY")
+    if summary_path:
+        with open(summary_path, "a", encoding="utf-8") as handle:
+            handle.write(markdown + "\n")
+
+    # Reporter, never a gate -- see the module docstring.
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/hub/agents/email/python/tests/test_eval_summary.py
+++ b/hub/agents/email/python/tests/test_eval_summary.py
@@ -1,0 +1,236 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+"""Tests for the eval gate-verdict reporter (packaging/eval_summary.py).
+
+The reporter is the only thing that makes an enforce:false breach visible on a
+PR, so the cases that matter are the ones where it could quietly report nothing:
+an empty/missing eval dir, a corrupt report, a gate that was never evaluated.
+"""
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+_MODULE_PATH = Path(__file__).resolve().parents[1] / "packaging" / "eval_summary.py"
+_spec = importlib.util.spec_from_file_location("eval_summary", _MODULE_PATH)
+eval_summary = importlib.util.module_from_spec(_spec)
+sys.modules["eval_summary"] = eval_summary
+_spec.loader.exec_module(eval_summary)
+
+
+def _gate(passed=True, enforce=False, **extra):
+    return {
+        "passed": passed,
+        "enforce": enforce,
+        "should_fail": enforce and not passed,
+        **extra,
+    }
+
+
+def _skipped_gate(enforce=False):
+    """The LITERAL skip payload the producers emit.
+
+    Copied from ``gaia.eval.benchmark`` / ``draft_quality`` / ``action_item_quality``:
+    there is NO ``passed`` key, and ``should_fail`` is hardcoded False even under
+    ``enforce: true``. A hand-rolled dict with ``passed`` in it would test a shape
+    nothing produces — and did, until this fixture replaced it.
+    """
+    return {
+        "skipped": True,
+        "reason": (
+            "no quality block in any run (ground truth not provided); "
+            "FP/FN gate cannot be evaluated"
+        ),
+        "axis": "fp_rate",
+        "enforce": enforce,
+        "should_fail": False,
+    }
+
+
+def _all_expected(**overrides):
+    """A full set of expected gates, so tests isolate the property under test."""
+    gates = {key: _gate() for key in eval_summary.GATE_LABELS}
+    gates.update(overrides)
+    return gates
+
+
+def _write(tmp_path: Path, name: str, payload: dict) -> None:
+    (tmp_path / name).write_text(json.dumps(payload), encoding="utf-8")
+
+
+def test_finds_gates_at_top_level_and_nested(tmp_path):
+    """Matches the two real report shapes: top-level gates, and gates under summary."""
+    _write(
+        tmp_path, "gate_report.json", {"quality_gate": _gate(), "perf_gate": _gate()}
+    )
+    _write(
+        tmp_path, "briefing_gate_report.json", {"summary": {"briefing_gate": _gate()}}
+    )
+
+    gates, unreadable = eval_summary.collect(tmp_path)
+
+    assert set(gates) == {"quality_gate", "perf_gate", "briefing_gate"}
+    assert unreadable == []
+
+
+def test_breach_is_reported_as_a_warning_even_though_it_did_not_fail_the_build(
+    tmp_path,
+):
+    """The whole point: enforce:false exits 0, so the breach must surface here."""
+    _write(tmp_path, "gate_report.json", _all_expected(perf_gate=_gate(passed=False)))
+
+    gates, _ = eval_summary.collect(tmp_path)
+    markdown, warnings = eval_summary.render(gates, [])
+
+    assert "**BREACH** (advisory)" in markdown
+    assert len(warnings) == 1
+    assert "Performance" in warnings[0]
+
+
+def test_enforced_breach_is_labelled_blocking(tmp_path):
+    _write(
+        tmp_path,
+        "gate_report.json",
+        _all_expected(perf_gate=_gate(passed=False, enforce=True)),
+    )
+
+    gates, _ = eval_summary.collect(tmp_path)
+    markdown, warnings = eval_summary.render(gates, [])
+
+    assert "**BREACH** (BLOCKING)" in markdown
+    assert len(warnings) == 1
+
+
+def test_all_pass_produces_no_warnings(tmp_path):
+    _write(tmp_path, "gate_report.json", _all_expected())
+
+    gates, _ = eval_summary.collect(tmp_path)
+    markdown, warnings = eval_summary.render(gates, [])
+
+    assert warnings == []
+    assert markdown.count("| pass |") == len(eval_summary.GATE_LABELS)
+
+
+def test_skipped_gate_is_found_and_never_rendered_as_a_pass(tmp_path):
+    """Regression: the skip payload has no `passed` key, so it was dropped entirely.
+
+    Dropping it meant a run that measured nothing on triage quality reported
+    "all gates passed" — and the producers hardcode should_fail:False on a skip,
+    so this reporter is the only thing that can catch it.
+    """
+    _write(tmp_path, "gate_report.json", _all_expected(quality_gate=_skipped_gate()))
+
+    gates, _ = eval_summary.collect(tmp_path)
+    markdown, warnings = eval_summary.render(gates, [])
+
+    assert "quality_gate" in gates, "a skipped gate must still be discovered"
+    assert "not evaluated" in markdown
+    assert "| pass |" in markdown  # the other four still pass
+    assert len(warnings) == 1
+    assert "missing evidence, not as a pass" in warnings[0]
+
+
+def test_skip_is_flagged_even_when_the_manifest_enforces(tmp_path):
+    """The producers hardcode should_fail:False on a skip — enforce cannot save us."""
+    _write(
+        tmp_path,
+        "gate_report.json",
+        _all_expected(perf_gate=_skipped_gate(enforce=True)),
+    )
+
+    gates, _ = eval_summary.collect(tmp_path)
+    _, warnings = eval_summary.render(gates, [])
+
+    assert gates["perf_gate"]["should_fail"] is False
+    assert len(warnings) == 1
+
+
+def test_expected_gate_with_no_report_is_flagged_not_silently_omitted(tmp_path):
+    """A step that died before writing must not read as "the others passed"."""
+    _write(
+        tmp_path, "gate_report.json", {"quality_gate": _gate(), "perf_gate": _gate()}
+    )
+
+    gates, _ = eval_summary.collect(tmp_path)
+    markdown, warnings = eval_summary.render(gates, [])
+
+    assert markdown.count("no verdict produced") == 3
+    assert len(warnings) == 3
+    assert all("missing evidence" in w for w in warnings)
+
+
+def test_known_gates_are_listed_in_pipeline_order(tmp_path):
+    _write(
+        tmp_path,
+        "gate_report.json",
+        {"briefing_gate": _gate(), "quality_gate": _gate(), "perf_gate": _gate()},
+    )
+
+    gates, _ = eval_summary.collect(tmp_path)
+    markdown, _ = eval_summary.render(gates, [])
+
+    assert markdown.index("Triage quality") < markdown.index("Performance")
+    assert markdown.index("Performance") < markdown.index("Daily-briefing")
+
+
+def test_no_reports_says_so_loudly_instead_of_reporting_a_pass(tmp_path):
+    markdown, warnings = eval_summary.render({}, [])
+
+    assert "No gate report was produced" in markdown
+    assert "Do NOT read this as a pass." in markdown
+    assert len(warnings) == 1
+
+
+def test_corrupt_report_is_surfaced_not_swallowed(tmp_path):
+    (tmp_path / "gate_report.json").write_text("{not json", encoding="utf-8")
+
+    gates, unreadable = eval_summary.collect(tmp_path)
+    markdown, warnings = eval_summary.render(gates, unreadable)
+
+    assert gates == {}
+    assert len(unreadable) == 1
+    assert "Unreadable report files" in markdown
+    assert any("unreadable" in w for w in warnings)
+
+
+def test_unknown_gate_is_reported_under_its_raw_key(tmp_path):
+    """A future gate must not silently vanish from the summary."""
+    _write(tmp_path, "gate_report.json", {"phishing_gate": _gate(passed=False)})
+
+    gates, _ = eval_summary.collect(tmp_path)
+    markdown, warnings = eval_summary.render(gates, [])
+
+    assert "phishing_gate" in markdown
+    assert warnings
+
+
+def test_non_gate_objects_with_a_passed_key_are_ignored(tmp_path):
+    """Only ``*_gate`` objects are verdicts; per-case results also carry `passed`."""
+    _write(tmp_path, "gate_report.json", {"cases": [{"passed": False, "id": "c1"}]})
+
+    gates, _ = eval_summary.collect(tmp_path)
+
+    assert gates == {}
+
+
+@pytest.mark.parametrize("exists", [True, False])
+def test_main_always_exits_zero_and_appends_the_summary(
+    tmp_path, monkeypatch, exists, capsys
+):
+    """It is a reporter: it never turns a passing run red nor rescues a failing one."""
+    eval_dir = tmp_path / "eval-out"
+    if exists:
+        eval_dir.mkdir()
+        _write(eval_dir, "gate_report.json", {"perf_gate": _gate(passed=False)})
+    summary_file = tmp_path / "summary.md"
+    monkeypatch.setenv("GITHUB_STEP_SUMMARY", str(summary_file))
+
+    assert eval_summary.main([str(eval_dir)]) == 0
+
+    written = summary_file.read_text(encoding="utf-8")
+    assert "Email agent eval - gate verdicts" in written
+    assert "::warning::" in capsys.readouterr().out


### PR DESCRIPTION
Changes to the email agent could merge with no evidence they hadn't broken its behavior. The eval that would catch that only ran weekly, on demand, and at release time — never on a PR — so pytest went green and the change landed. #2695 is the proof: it injected three Agent Skills into the agent's system prompt by default and re-sized the bulk-triage envelope budget, having already blown the 16,384-token context window once at 16,602 tokens during development. It merged at 16,106 tokens — 1.7% headroom, measured by one manual run and pinned by nothing. Now a PR touching the email agent runs the real triage/drafting/action-item/briefing eval on AMD hardware and reports every gate verdict in the job summary.

It stays affordable on the single serial Lemonade slot: narrow path filters, a per-PR concurrency group that cancels superseded runs, a 20-email slice instead of 50, and no fork or draft runs.

**Advisory, not blocking — and that is not a special case for PRs.** Every gate manifest under `tests/fixtures/email/` ships `enforce: false` today, so no gate blocks anything on any trigger. A "report only on PRs" override was written and deliberately removed: with `enforce:false` everywhere, the only exits it could soften are the fail-loudly ones (missing judge credential, unjudged case, harness crash) — the inverse of report mode. To make a gate block, flip `"enforce": false` → `true` in that gate's manifest; it then blocks the weekly, the release and PRs together. What still fails a PR run loudly: a missing judge key, an unreachable Lemonade, or a benchmark that dies — which is what a #2695-style context blowout looks like.

**Scorecard staleness: deferred, not dropped.** `hub/agents/email/npm/SCORECARD.md` can only be regenerated by a ~10h full-profile run, so a per-PR "you didn't regenerate it" check would fire on every email PR and be ignored within a week. The honest place for it is the release gate, which already parses the card. Filed as #2850 rather than added here; the job summary states plainly that the card is not refreshed by this run.

## Test plan

- [ ] Workflow YAML parses and the job `if:` folds to a single-line expression (verified locally; `python -c "import yaml; yaml.safe_load(...)"`)
- [ ] Path globs match real files — all 8 verified against `git ls-files`, and the #2695 commit hits 22 of them (so it would have triggered)
- [ ] Serial group name is byte-identical to the three siblings: `git grep -n "group: lemonade-eval" .github/workflows/` returns `email_scorecard_refresh.yml`, `test_eval_agent_gemma_consolidation.yml`, `test_eval_rag.yml` and this file's job
- [ ] `python -m pytest hub/agents/email/python/tests/test_eval_summary.py` — 14 pass. The two skip-path tests fail if `find_gates` drops the `skipped` key, confirmed by reverting the predicate
- [ ] `python util/lint.py --all` clean; `black`/`isort` clean on both new files
- [ ] Every PowerShell `run:` block parses, including when decoded as ANSI (the runner writes the script without a BOM; a UTF-8 em dash would otherwise mojibake into a smart quote and terminate a string)
- [ ] After merge: open a no-op PR touching `hub/agents/email/python/**` and confirm the job queues on `lemonade-eval`, and that a second push cancels the first run
- [ ] After merge: confirm the "Gate verdicts" job summary renders and annotates