### PR TITLE
fix(cpp): gate MCP tools behind user confirmation in the C++ SDK

### DIFF
--- a/cpp/README.md
+++ b/cpp/README.md
@@ -129,6 +129,8 @@ The agent will:
 
 Type `quit`, `exit`, or `q` to stop.
 
+> The Windows MCP tools (`mcp_windows_Shell`, `mcp_windows_Shortcut`, …) run PowerShell and drive the desktop, so the agent asks for confirmation before each call. Choose **[2] Always allow** at the prompt to approve a tool for good — the decision persists in `~/.gaia/security/allowed_tools.json`.
+
 > If the Windows MCP server fails to connect, verify that `uvx` is on your PATH and that `uvx windows-mcp` runs without errors in a separate terminal.
 
 ### Wi-Fi Troubleshooter (Registered-Tool Demo)
@@ -399,6 +401,8 @@ agent.connectMcpServer("my_server", {
 ```
 
 All tools exposed by the MCP server are automatically registered under the naming convention `mcp_<server_name>_<tool_name>`.
+
+Each discovered tool is registered with `ToolPolicy::CONFIRM` — the user is asked before it runs — **unless the server proves it read-only** (`annotations.readOnlyHint == true` *and* no state-changing verb in the tool name). MCP tool names are chosen by the server, so a static allowlist can never gate them; this classifier is what stops injected content from driving an `mcp_*_delete_file` call. A headless agent (`silentMode = true`) has no confirmation callback and is therefore denied every gated MCP tool; see the [Security Guide](../docs/cpp/security.mdx) for how to opt in deliberately.
 
 ---
 

--- a/cpp/include/gaia/agent.h
+++ b/cpp/include/gaia/agent.h
@@ -74,6 +74,12 @@ public:
     /// Connect to an MCP server and register its tools.
     /// Mirrors Python MCPClientMixin.connect_mcp_server().
     ///
+    /// Each discovered tool is registered with ToolPolicy::CONFIRM unless the
+    /// server proves it read-only — see mcpToolRequiresConfirmation() in
+    /// mcp_client.h. A silentMode agent has no confirm callback, so gated MCP
+    /// tools are denied (fail-closed) until one is installed via
+    /// setToolConfirmCallback() or the tool is pre-approved in AllowedToolsStore.
+    ///
     /// @param name Friendly name for the server
     /// @param config Config with "command" and optional "args"
     /// @return true if connection succeeded
@@ -92,8 +98,12 @@ public:
     /// Delegates to ToolRegistry::setConfirmCallback().
     void setToolConfirmCallback(ToolConfirmCallback cb);
 
-    /// Set the default policy for all tools (local and MCP) registered without an explicit policy.
-    /// Delegates to ToolRegistry::setDefaultPolicy().
+    /// Set the default policy for local tools registered without an explicit policy.
+    /// Delegates to ToolRegistry::setDefaultPolicy(). Affects only tools
+    /// registered afterwards.
+    /// For MCP tools discovered by a later connectMcpServer() call this can only
+    /// raise the classifier's verdict (ALLOW < CONFIRM < DENY) — a gated MCP
+    /// tool is never lowered back to ALLOW.
     void setDefaultPolicy(ToolPolicy policy);
 
     /// Get the output handler.

--- a/cpp/include/gaia/mcp_client.h
+++ b/cpp/include/gaia/mcp_client.h
@@ -27,6 +27,31 @@ namespace gaia {
 
 using json = nlohmann::json;
 
+/// Decide whether an MCP tool must be gated behind user confirmation.
+///
+/// Fails closed: a tool is exempt ONLY when the server proves it read-only.
+/// All of these must hold:
+///   1. the tool has a name;
+///   2. `annotations["readOnlyHint"]` is the JSON boolean `true` (a string
+///      "true", a missing key, or a non-object `annotations` does not count); and
+///   3. the tool name contains no state-changing verb.
+///
+/// Everything else — no annotations, `readOnlyHint: false`, a non-boolean
+/// value, or a read-only claim contradicted by a name like `delete_file` —
+/// requires confirmation. MCP tool names are chosen by the server, so they can
+/// never be matched against a static allowlist; this classifier is what stands
+/// between an injected `mcp_*_delete_file` call and execution.
+///
+/// Note that condition 2 trusts the server's own claim; condition 3 is the
+/// counterweight, and it only knows the verbs listed in mcp_client.cpp. Treat
+/// the exemption as protection against a careless server, not a hostile one.
+///
+/// Name matching is case-insensitive and ASCII-only. It splits snake_case,
+/// kebab-case, camelCase and screaming-camel (`WRITEFile`) names and matches
+/// verbs both as whole words and — for verbs of 4+ characters — as prefixes,
+/// so `WRITEfile`, `write2file` and `deletes` are all caught.
+GAIA_API bool mcpToolRequiresConfirmation(const std::string& toolName, const json& annotations);
+
 /// Represents an MCP tool with its JSON Schema.
 /// Mirrors Python MCPTool dataclass.
 struct GAIA_API MCPToolSchema {
@@ -34,8 +59,18 @@ struct GAIA_API MCPToolSchema {
     std::string description;
     json inputSchema; // JSON Schema for tool parameters
 
+    /// MCP tool annotations (`annotations` in the tools/list response).
+    /// Always an object: a missing or non-object value is stored as `{}`, which
+    /// classifies as "requires confirmation" — never as trusted.
+    json annotations = json::object();
+
+    /// Whether this tool must be gated behind user confirmation.
+    /// Convenience wrapper over mcpToolRequiresConfirmation().
+    bool requiresConfirmation() const;
+
     /// Convert to GAIA ToolInfo format.
     /// Mirrors Python MCPTool.to_gaia_format().
+    /// Stamps `policy = CONFIRM` unless requiresConfirmation() is false.
     ToolInfo toToolInfo(const std::string& serverName) const;
 };
 

--- a/cpp/include/gaia/types.h
+++ b/cpp/include/gaia/types.h
@@ -222,7 +222,16 @@ using StreamCallback = std::function<void(const std::string& token)>;
 
 // ---- Security Types ----
 
+// Declared in order of increasing severity — stricterPolicy() relies on it.
 enum class ToolPolicy { ALLOW, CONFIRM, DENY };
+
+/// Return the stricter of two policies. Used where a gate must never be
+/// weakened by a laxer default (e.g. MCP tool registration).
+constexpr ToolPolicy stricterPolicy(ToolPolicy a, ToolPolicy b) {
+    static_assert(ToolPolicy::ALLOW < ToolPolicy::CONFIRM && ToolPolicy::CONFIRM < ToolPolicy::DENY,
+                  "ToolPolicy must stay ordered by severity");
+    return a < b ? b : a;
+}
 
 enum class ToolConfirmResult { ALLOW_ONCE, ALWAYS_ALLOW, DENY };
 

--- a/cpp/src/agent.cpp
+++ b/cpp/src/agent.cpp
@@ -4,6 +4,7 @@
 #include "gaia/agent.h"
 #include "gaia/security.h"
 
+#include <algorithm>
 #include <iostream>
 #include <regex>
 #include <sstream>
@@ -437,8 +438,10 @@ bool Agent::connectMcpServer(const std::string& name, const json& config) {
         for (const auto& mcpTool : mcpTools) {
             ToolInfo toolInfo = mcpTool.toToolInfo(name);
 
-            // Bake the current default policy into the ToolInfo at registration time.
-            toolInfo.policy = tools_.defaultPolicy();
+            // toToolInfo() already stamped CONFIRM unless the server proved the
+            // tool read-only. That verdict is a floor: a stricter registry
+            // default may raise it, but nothing may lower it back to ALLOW.
+            toolInfo.policy = stricterPolicy(toolInfo.policy, tools_.defaultPolicy());
 
             // Capture server name and tool name; use callMcpTool for auto-reconnect
             std::string serverName = name;
@@ -449,8 +452,11 @@ bool Agent::connectMcpServer(const std::string& name, const json& config) {
 
             try {
                 tools_.registerTool(std::move(toolInfo));
-            } catch (const std::runtime_error&) {
-                // Tool already registered, skip
+            } catch (const std::runtime_error& e) {
+                // Name collision — the already-registered tool keeps its own
+                // policy, so say which one was dropped rather than swallowing it.
+                console_->printError("MCP tool '" + mcpTool.name + "' from server '" + name +
+                                     "' was not registered: " + e.what());
             }
         }
 

--- a/cpp/src/mcp_client.cpp
+++ b/cpp/src/mcp_client.cpp
@@ -6,6 +6,7 @@
 #include <chrono>
 #include <cstring>
 #include <iostream>
+#include <set>
 #include <sstream>
 #include <stdexcept>
 #include <thread>
@@ -23,7 +24,175 @@
 
 namespace gaia {
 
+// ---- MCP tool confirmation classifier ----
+
+namespace {
+
+// Verb tokens that indicate a tool changes state (filesystem, git/GitHub,
+// process execution, Slack, SQL, containers). A tool whose name contains any
+// of these is gated behind confirmation even if the server claims it is
+// read-only — a server-supplied `readOnlyHint` is a claim, not a proof.
+//
+// Sibling gate in the Python SDK: TOOLS_REQUIRING_CONFIRMATION in
+// src/gaia/agents/base/agent.py — keep the two vocabularies aligned.
+//
+// `start` and `interact` are here because desktop-commander's remote-code-
+// execution tools are named `start_process` / `interact_with_process`; `bash`,
+// `powershell`, `click` and `type` because shell and desktop-driving tools
+// often carry no conventional verb at all.
+const std::set<std::string>& mutatingVerbs() {
+    static const std::set<std::string> kVerbs = {
+        "add",        "alter",      "append",    "apply",       "approve",
+        "archive",    "assign",     "bash",      "build",       "cancel",
+        "checkout",   "chmod",      "chown",     "clear",       "click",
+        "clone",      "close",      "cmd",       "commit",      "compress",
+        "copy",       "create",     "decrypt",   "delete",      "deploy",
+        "destroy",    "disable",    "dismiss",   "downgrade",   "download",
+        "drag",       "drop",       "edit",      "enable",      "encrypt",
+        "erase",      "eval",       "exec",      "execute",     "export",
+        "extract",    "flush",      "fork",      "format",      "forward",
+        "goto",       "grant",      "import",    "insert",      "install",
+        "interact",   "invite",     "invoke",    "join",        "keystroke",
+        "kick",       "kill",       "launch",    "leave",       "merge",
+        "migrate",    "mkdir",      "modify",    "mount",       "move",
+        "navigate",   "notify",     "open",      "paste",       "patch",
+        "pin",        "post",       "powershell", "press",      "prune",
+        "publish",    "pull",       "purge",     "push",        "put",
+        "reboot",     "rebase",     "remove",    "rename",      "reopen",
+        "replace",    "reply",      "reset",     "restart",     "restore",
+        "revert",     "revoke",     "rmdir",     "rollback",    "rotate",
+        "run",        "save",       "scale",     "scroll",      "send",
+        "set",        "share",      "shell",     "shortcut",    "shutdown",
+        "spawn",      "start",      "stop",      "submit",      "subscribe",
+        "sudo",       "symlink",    "sync",      "terminate",   "touch",
+        "transfer",   "trigger",    "truncate",  "type",        "uninstall",
+        "unlink",     "unmount",    "unpin",     "unset",       "unsubscribe",
+        "update",     "upgrade",    "upload",    "upsert",      "wipe",
+        "write",
+    };
+    return kVerbs;
+}
+
+// A verb this long or longer also matches as a *prefix* ("writefile",
+// "deletes"). Shorter verbs are exact-match only — "add"/"set"/"run" as
+// prefixes would gate read-only names like `get_address` or `get_settings`.
+constexpr size_t kMinPrefixVerbLength = 4;
+
+// ASCII-only classification: gaia_core is embeddable and std::is* are
+// locale-sensitive, so a host that calls setlocale must not shift tokenization.
+bool isAsciiAlnum(char c) {
+    return (c >= '0' && c <= '9') || (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z');
+}
+bool isAsciiUpper(char c) { return c >= 'A' && c <= 'Z'; }
+bool isAsciiLower(char c) { return c >= 'a' && c <= 'z'; }
+bool isAsciiDigit(char c) { return c >= '0' && c <= '9'; }
+char toAsciiLower(char c) { return isAsciiUpper(c) ? static_cast<char>(c - 'A' + 'a') : c; }
+
+/// Lowercase candidate substrings of a tool name to match verbs against:
+/// each separator-delimited segment AND its camelCase sub-words.
+///
+/// Both are needed. The sub-words catch `writeFile` / `WRITEFile`; the whole
+/// segment catches `WRITEfile` and `write2file`, where no local rule can tell
+/// where the verb ends ("WRITEfile" splits as "writ" + "efile").
+std::vector<std::string> nameCandidates(const std::string& name) {
+    std::vector<std::string> candidates;
+    std::string segment;   // separator-delimited, e.g. "writefile"
+    std::string subToken;  // camelCase sub-word, e.g. "write"
+
+    auto flushSubToken = [&]() {
+        if (!subToken.empty()) {
+            candidates.push_back(subToken);
+            subToken.clear();
+        }
+    };
+    auto flushSegment = [&]() {
+        flushSubToken();
+        if (!segment.empty()) {
+            candidates.push_back(segment);
+            segment.clear();
+        }
+    };
+
+    for (size_t i = 0; i < name.size(); ++i) {
+        const char ch = name[i];
+
+        if (!isAsciiAlnum(ch)) { // separator: _, -, ., /, space, non-ASCII byte …
+            flushSegment();
+            continue;
+        }
+
+        if (!subToken.empty()) {
+            const char prev = name[i - 1];
+            const bool caseBoundary =
+                isAsciiUpper(ch) && (isAsciiLower(prev) ||
+                                     (isAsciiUpper(prev) && i + 1 < name.size() &&
+                                      isAsciiLower(name[i + 1])));
+            // A digit boundary splits too, so "write2file" also yields "write".
+            const bool digitBoundary = isAsciiDigit(ch) != isAsciiDigit(prev);
+            if (caseBoundary || digitBoundary) {
+                flushSubToken();
+            }
+        }
+
+        subToken.push_back(toAsciiLower(ch));
+        segment.push_back(toAsciiLower(ch));
+    }
+    flushSegment();
+
+    return candidates;
+}
+
+bool namePromisesMutation(const std::string& name) {
+    const std::vector<std::string> candidates = nameCandidates(name);
+
+    // Nothing classifiable (punctuation-only, or an all-non-ASCII name) —
+    // the name can't corroborate the server's read-only claim, so distrust it.
+    if (candidates.empty()) {
+        return true;
+    }
+
+    for (const auto& candidate : candidates) {
+        for (const auto& verb : mutatingVerbs()) {
+            if (candidate == verb) {
+                return true;
+            }
+            if (verb.size() >= kMinPrefixVerbLength && candidate.size() > verb.size() &&
+                candidate.compare(0, verb.size(), verb) == 0) {
+                return true;
+            }
+        }
+    }
+    return false;
+}
+
+} // namespace
+
+bool mcpToolRequiresConfirmation(const std::string& toolName, const json& annotations) {
+    // An unnamed tool can't be classified — treat it as unproven.
+    if (toolName.empty()) {
+        return true;
+    }
+
+    // No annotations object at all -> the server proved nothing -> confirm.
+    if (!annotations.is_object()) {
+        return true;
+    }
+
+    const auto it = annotations.find("readOnlyHint");
+    // A non-boolean readOnlyHint (e.g. the string "true") is not a proof.
+    if (it == annotations.end() || !it->is_boolean() || !it->get<bool>()) {
+        return true;
+    }
+
+    // Read-only claim present — reject it if the name says otherwise.
+    return namePromisesMutation(toolName);
+}
+
 // ---- MCPToolSchema ----
+
+bool MCPToolSchema::requiresConfirmation() const {
+    return mcpToolRequiresConfirmation(name, annotations);
+}
 
 ToolInfo MCPToolSchema::toToolInfo(const std::string& serverName) const {
     ToolInfo info;
@@ -32,6 +201,11 @@ ToolInfo MCPToolSchema::toToolInfo(const std::string& serverName) const {
     info.atomic = true;
     info.mcpServer = serverName;
     info.mcpToolName = name;
+
+    // MCP names are server-chosen, so they can never be gated by a static
+    // allowlist. Gate here, at the source, so every consumer of toToolInfo()
+    // inherits the fail-closed verdict.
+    info.policy = requiresConfirmation() ? ToolPolicy::CONFIRM : ToolPolicy::ALLOW;
 
     // Convert JSON Schema properties to ToolParameter list
     if (inputSchema.contains("properties")) {
@@ -583,6 +757,14 @@ std::vector<MCPToolSchema> MCPClient::listTools(bool refresh) {
         tool.name = toolJson.value("name", "");
         tool.description = toolJson.value("description", "");
         tool.inputSchema = toolJson.value("inputSchema", json::object());
+
+        // A missing or non-object `annotations` degrades to {} — which the
+        // classifier reads as "unproven", not as "trusted".
+        json rawAnnotations = toolJson.value("annotations", json::object());
+        if (rawAnnotations.is_object()) {
+            tool.annotations = std::move(rawAnnotations);
+        }
+
         tools.push_back(std::move(tool));
     }
 

--- a/cpp/tests/integration/test_integration_health.cpp
+++ b/cpp/tests/integration/test_integration_health.cpp
@@ -89,6 +89,13 @@ public:
         : Agent(healthTestConfig(maxSteps)) {
         init();
 
+        // MCP tools are CONFIRM-gated unless the server proves them read-only,
+        // and a silentMode agent gets no confirm callback (fail-closed). This
+        // harness exists to exercise mcp_windows_Shell, so it opts in.
+        setToolConfirmCallback([](const std::string&, const gaia::json&) {
+            return gaia::ToolConfirmResult::ALLOW_ONCE;
+        });
+
         // Connect to Windows MCP server — same as health_agent.cpp
         bool ok = connectMcpServer("windows", {
             {"command", "uvx"},

--- a/cpp/tests/test_mcp_client.cpp
+++ b/cpp/tests/test_mcp_client.cpp
@@ -2,7 +2,14 @@
 // SPDX-License-Identifier: MIT
 
 #include <gtest/gtest.h>
+#include <gaia/agent.h>
 #include <gaia/mcp_client.h>
+#include <gaia/security.h>
+#include <gaia/tool_registry.h>
+
+#include <filesystem>
+
+#include "support/mock_llm_server.h"
 
 using namespace gaia;
 
@@ -224,4 +231,392 @@ TEST(MCPClientTest, ToolsListResponseParsing) {
 
     EXPECT_EQ(tools[0].name, "Shell");
     EXPECT_EQ(tools[1].name, "Wait");
+}
+
+// ---------------------------------------------------------------------------
+// MCP confirmation gate (CWE-862)
+//
+// MCP tool names are server-chosen, so no static allowlist can gate them.
+// mcpToolRequiresConfirmation() must fail closed: exempt a tool ONLY when the
+// server proves it read-only AND the name does not contradict that claim.
+// ---------------------------------------------------------------------------
+
+namespace {
+
+json readOnly(bool value) { return json{{"readOnlyHint", value}}; }
+
+} // namespace
+
+TEST(MCPConfirmationTest, NoAnnotationsRequiresConfirmation) {
+    EXPECT_TRUE(mcpToolRequiresConfirmation("read_file", json::object()));
+    EXPECT_TRUE(mcpToolRequiresConfirmation("list_directory", json::object()));
+    // Annotations present but silent about readOnlyHint -> still unproven.
+    EXPECT_TRUE(mcpToolRequiresConfirmation("read_file", json{{"title", "Read a file"}}));
+    EXPECT_TRUE(mcpToolRequiresConfirmation("read_file", json{{"destructiveHint", false}}));
+}
+
+TEST(MCPConfirmationTest, ReadOnlyHintTrueOnReadShapedNameIsExempt) {
+    EXPECT_FALSE(mcpToolRequiresConfirmation("read_file", readOnly(true)));
+    EXPECT_FALSE(mcpToolRequiresConfirmation("list_directory", readOnly(true)));
+    EXPECT_FALSE(mcpToolRequiresConfirmation("get_file_contents", readOnly(true)));
+    EXPECT_FALSE(mcpToolRequiresConfirmation("search_repositories", readOnly(true)));
+    EXPECT_FALSE(mcpToolRequiresConfirmation("query", readOnly(true)));
+}
+
+TEST(MCPConfirmationTest, ReadOnlyHintFalseRequiresConfirmation) {
+    EXPECT_TRUE(mcpToolRequiresConfirmation("read_file", readOnly(false)));
+}
+
+TEST(MCPConfirmationTest, MutatingNameOverridesReadOnlyClaim) {
+    // A server can claim anything; the name is the tie-breaker.
+    EXPECT_TRUE(mcpToolRequiresConfirmation("delete_file", readOnly(true)));
+    EXPECT_TRUE(mcpToolRequiresConfirmation("write_file", readOnly(true)));
+    EXPECT_TRUE(mcpToolRequiresConfirmation("create_or_update_file", readOnly(true)));
+    EXPECT_TRUE(mcpToolRequiresConfirmation("Shell", readOnly(true)));
+}
+
+TEST(MCPConfirmationTest, DesktopCommanderRceToolsRequireConfirmation) {
+    // desktop-commander's RCE pair — the reason `start` and `interact` are
+    // in the mutating-verb list.
+    EXPECT_TRUE(mcpToolRequiresConfirmation("start_process", readOnly(true)));
+    EXPECT_TRUE(mcpToolRequiresConfirmation("interact_with_process", readOnly(true)));
+}
+
+TEST(MCPConfirmationTest, ShellAndDesktopDrivingToolsRequireConfirmation) {
+    // Names with no conventional verb, but full RCE / input-injection power.
+    EXPECT_TRUE(mcpToolRequiresConfirmation("bash", readOnly(true)));
+    EXPECT_TRUE(mcpToolRequiresConfirmation("powershell", readOnly(true)));
+    EXPECT_TRUE(mcpToolRequiresConfirmation("Shortcut", readOnly(true)));
+    EXPECT_TRUE(mcpToolRequiresConfirmation("Click", readOnly(true)));
+    EXPECT_TRUE(mcpToolRequiresConfirmation("Type", readOnly(true)));
+}
+
+TEST(MCPConfirmationTest, UnnamedToolRequiresConfirmation) {
+    // Empty name tokenizes to nothing — must not fall through to "exempt".
+    EXPECT_TRUE(mcpToolRequiresConfirmation("", readOnly(true)));
+    EXPECT_TRUE(mcpToolRequiresConfirmation("   ", readOnly(true)));
+
+    MCPToolSchema unnamed;
+    unnamed.annotations = readOnly(true);
+    EXPECT_EQ(unnamed.toToolInfo("srv").policy, ToolPolicy::CONFIRM);
+}
+
+TEST(MCPConfirmationTest, ConcatenatedAndInflectedVerbsAreCaught) {
+    // No local rule can split "WRITEfile" correctly ("writ" + "efile"), so
+    // whole-segment prefix matching backstops the camelCase split.
+    EXPECT_TRUE(mcpToolRequiresConfirmation("WRITEfile", readOnly(true)));
+    EXPECT_TRUE(mcpToolRequiresConfirmation("DELETEfile", readOnly(true)));
+    EXPECT_TRUE(mcpToolRequiresConfirmation("writefile", readOnly(true)));
+    EXPECT_TRUE(mcpToolRequiresConfirmation("write2file", readOnly(true)));
+    EXPECT_TRUE(mcpToolRequiresConfirmation("write2File", readOnly(true)));
+    EXPECT_TRUE(mcpToolRequiresConfirmation("deletes_branch", readOnly(true)));
+    EXPECT_TRUE(mcpToolRequiresConfirmation("removes_stale_keys", readOnly(true)));
+
+    // Known limit: inflections that drop the trailing "e" ("deletion",
+    // "removing") are not prefix-matched. Add the form to the verb list if a
+    // server ever ships one.
+    EXPECT_FALSE(mcpToolRequiresConfirmation("s3_deletion_job", readOnly(true)));
+    EXPECT_FALSE(mcpToolRequiresConfirmation("removing_stale_keys", readOnly(true)));
+}
+
+TEST(MCPConfirmationTest, ShortVerbsDoNotPrefixMatchReadOnlyNames) {
+    // Prefix matching is limited to 4+ character verbs so that read-shaped
+    // names containing "add"/"set"/"run" stay unprompted.
+    EXPECT_FALSE(mcpToolRequiresConfirmation("get_address", readOnly(true)));
+    EXPECT_FALSE(mcpToolRequiresConfirmation("get_settings", readOnly(true)));
+    EXPECT_FALSE(mcpToolRequiresConfirmation("runtime_info", readOnly(true)));
+    EXPECT_FALSE(mcpToolRequiresConfirmation("list_movies", readOnly(true)));
+}
+
+TEST(MCPConfirmationTest, NonBooleanReadOnlyHintRequiresConfirmation) {
+    EXPECT_TRUE(mcpToolRequiresConfirmation("read_file", json{{"readOnlyHint", "true"}}));
+    EXPECT_TRUE(mcpToolRequiresConfirmation("read_file", json{{"readOnlyHint", 1}}));
+    EXPECT_TRUE(mcpToolRequiresConfirmation("read_file", json{{"readOnlyHint", nullptr}}));
+    EXPECT_TRUE(mcpToolRequiresConfirmation("read_file", json{{"readOnlyHint", json::object()}}));
+}
+
+TEST(MCPConfirmationTest, NonObjectAnnotationsRequireConfirmation) {
+    EXPECT_TRUE(mcpToolRequiresConfirmation("read_file", json("readOnly")));
+    EXPECT_TRUE(mcpToolRequiresConfirmation("read_file", json(true)));
+    EXPECT_TRUE(mcpToolRequiresConfirmation("read_file", json(42)));
+    EXPECT_TRUE(mcpToolRequiresConfirmation("read_file", json(nullptr)));
+    EXPECT_TRUE(mcpToolRequiresConfirmation("read_file", json::array({"readOnlyHint"})));
+}
+
+TEST(MCPConfirmationTest, CamelCaseNamesAreTokenized) {
+    EXPECT_TRUE(mcpToolRequiresConfirmation("writeFile", readOnly(true)));
+    EXPECT_TRUE(mcpToolRequiresConfirmation("deleteBranch", readOnly(true)));
+    EXPECT_TRUE(mcpToolRequiresConfirmation("startProcess", readOnly(true)));
+    EXPECT_FALSE(mcpToolRequiresConfirmation("readFile", readOnly(true)));
+    EXPECT_FALSE(mcpToolRequiresConfirmation("listDirectory", readOnly(true)));
+}
+
+TEST(MCPConfirmationTest, ScreamingCamelAndMixedSeparatorsAreTokenized) {
+    EXPECT_TRUE(mcpToolRequiresConfirmation("WRITEFile", readOnly(true)));
+    EXPECT_TRUE(mcpToolRequiresConfirmation("DELETEFileContents", readOnly(true)));
+    EXPECT_TRUE(mcpToolRequiresConfirmation("delete-branch", readOnly(true)));
+    EXPECT_TRUE(mcpToolRequiresConfirmation("fs.write.file", readOnly(true)));
+    EXPECT_TRUE(mcpToolRequiresConfirmation("Write File", readOnly(true)));
+    EXPECT_FALSE(mcpToolRequiresConfirmation("READFile", readOnly(true)));
+    EXPECT_FALSE(mcpToolRequiresConfirmation("get-file-contents", readOnly(true)));
+}
+
+TEST(MCPConfirmationTest, ToToolInfoStampsPolicy) {
+    MCPToolSchema unproven;
+    unproven.name = "read_file";
+    EXPECT_TRUE(unproven.requiresConfirmation());
+    EXPECT_EQ(unproven.toToolInfo("fs").policy, ToolPolicy::CONFIRM);
+
+    MCPToolSchema proven;
+    proven.name = "read_file";
+    proven.annotations = readOnly(true);
+    EXPECT_FALSE(proven.requiresConfirmation());
+    EXPECT_EQ(proven.toToolInfo("fs").policy, ToolPolicy::ALLOW);
+
+    MCPToolSchema lying;
+    lying.name = "delete_file";
+    lying.annotations = readOnly(true);
+    EXPECT_EQ(lying.toToolInfo("fs").policy, ToolPolicy::CONFIRM);
+}
+
+// ---- listTools() annotation parsing ----
+
+namespace {
+
+/// Transport that replays a canned tools/list response.
+class FakeToolsListTransport : public MCPTransport {
+public:
+    explicit FakeToolsListTransport(json response) : response_(std::move(response)) {}
+
+    bool connect() override { return true; }
+    void disconnect() override {}
+    bool isConnected() const override { return true; }
+    json sendRequest(const std::string&, const json& = json::object()) override {
+        return response_;
+    }
+
+private:
+    json response_;
+};
+
+std::vector<MCPToolSchema> listToolsFrom(const json& toolsArray) {
+    json response = {{"jsonrpc", "2.0"}, {"id", 1}, {"result", {{"tools", toolsArray}}}};
+    MCPClient client("fake", std::make_unique<FakeToolsListTransport>(response));
+    return client.listTools();
+}
+
+} // namespace
+
+TEST(MCPConfirmationTest, ListToolsParsesAnnotations) {
+    auto tools = listToolsFrom(json::array({
+        {{"name", "read_file"}, {"annotations", {{"readOnlyHint", true}}}},
+        {{"name", "delete_file"}, {"annotations", {{"readOnlyHint", false}}}},
+        {{"name", "no_annotations"}},
+    }));
+
+    ASSERT_EQ(tools.size(), 3u);
+    EXPECT_EQ(tools[0].annotations, json({{"readOnlyHint", true}}));
+    EXPECT_FALSE(tools[0].requiresConfirmation());
+    EXPECT_TRUE(tools[1].requiresConfirmation());
+    EXPECT_EQ(tools[2].annotations, json::object());
+    EXPECT_TRUE(tools[2].requiresConfirmation());
+}
+
+TEST(MCPConfirmationTest, ListToolsDegradesNonObjectAnnotationsToConfirm) {
+    auto tools = listToolsFrom(json::array({
+        {{"name", "read_file"}, {"annotations", "readOnly"}},
+        {{"name", "list_dir"}, {"annotations", json::array({"readOnlyHint"})}},
+        {{"name", "get_status"}, {"annotations", nullptr}},
+    }));
+
+    ASSERT_EQ(tools.size(), 3u);
+    for (const auto& tool : tools) {
+        EXPECT_TRUE(tool.annotations.is_object()) << tool.name;
+        EXPECT_TRUE(tool.annotations.empty()) << tool.name;
+        EXPECT_TRUE(tool.requiresConfirmation()) << tool.name;
+        EXPECT_EQ(tool.toToolInfo("fake").policy, ToolPolicy::CONFIRM) << tool.name;
+    }
+}
+
+// ---- Enforcement: a denied MCP tool must not run ----
+
+namespace {
+
+/// Register an MCP-derived tool whose callback trips a canary when it runs.
+ToolInfo mcpToolWithCanary(const std::string& name, const json& annotations, bool* canary) {
+    MCPToolSchema schema;
+    schema.name = name;
+    schema.annotations = annotations;
+    ToolInfo info = schema.toToolInfo("srv");
+    info.callback = [canary](const json&) -> json {
+        *canary = true;
+        return json{{"status", "success"}};
+    };
+    return info;
+}
+
+} // namespace
+
+TEST(MCPConfirmationTest, DeniedMcpToolDoesNotExecute) {
+    bool executed = false;
+    ToolRegistry registry;
+    registry.registerTool(mcpToolWithCanary("delete_file", readOnly(true), &executed));
+
+    int prompts = 0;
+    registry.setConfirmCallback([&](const std::string&, const json&) {
+        ++prompts;
+        return ToolConfirmResult::DENY;
+    });
+
+    json result = registry.executeTool("mcp_srv_delete_file", json{{"path", "/etc/passwd"}});
+
+    EXPECT_FALSE(executed) << "denied MCP tool executed anyway";
+    EXPECT_EQ(prompts, 1);
+    EXPECT_EQ(result["status"], "error");
+}
+
+TEST(MCPConfirmationTest, McpToolWithoutConfirmCallbackFailsClosed) {
+    bool executed = false;
+    ToolRegistry registry; // headless: no confirm callback installed
+    registry.registerTool(mcpToolWithCanary("start_process", json::object(), &executed));
+
+    json result = registry.executeTool("mcp_srv_start_process", json{{"command", "rm -rf /"}});
+
+    EXPECT_FALSE(executed) << "MCP tool executed with no confirmation callback present";
+    EXPECT_EQ(result["status"], "error");
+}
+
+TEST(MCPConfirmationTest, ApprovedMcpToolExecutes) {
+    bool executed = false;
+    ToolRegistry registry;
+    registry.registerTool(mcpToolWithCanary("delete_file", json::object(), &executed));
+    registry.setConfirmCallback([](const std::string&, const json&) {
+        return ToolConfirmResult::ALLOW_ONCE;
+    });
+
+    json result = registry.executeTool("mcp_srv_delete_file", json::object());
+
+    EXPECT_TRUE(executed);
+    EXPECT_EQ(result["status"], "success");
+}
+
+// End-to-end through the agent loop: an LLM-requested MCP tool that the user
+// denies must not reach its callback. Proves the CONFIRM gate is enforced on
+// the real execution path (Agent::processQuery -> executeTool), not just when
+// ToolRegistry is driven directly.
+TEST(MCPConfirmationTest, AgentLoopDoesNotExecuteDeniedMcpTool) {
+    bench::MockLlmServer mock;
+    // Turn 1: the LLM asks for the MCP tool. Turn 2: it gives up and answers.
+    mock.pushResponse(
+        R"({"choices":[{"message":{"content":"{\"thought\":\"t\",\"goal\":\"g\",)"
+        R"(\"tool\":\"mcp_srv_delete_file\",\"tool_args\":{\"path\":\"/etc/passwd\"}}"}}]})");
+    mock.pushResponse(
+        R"({"choices":[{"message":{"content":"{\"thought\":\"t\",\"goal\":\"g\",\"answer\":\"blocked\"}"}}]})");
+
+    AgentConfig cfg;
+    cfg.baseUrl = mock.baseUrl();
+    cfg.modelId = ""; // empty skips ensureModelLoaded()
+    cfg.maxSteps = 2;
+    cfg.silentMode = true;
+
+    class Bare : public Agent {
+    public:
+        using Agent::Agent;
+    };
+    Bare agent(cfg);
+
+    // Agent installs a store rooted at the real user profile; swap in an empty
+    // one so a developer's saved "always allow" can't defeat the assertion.
+    const std::string storeDir =
+        (std::filesystem::temp_directory_path() / "gaia_mcp_gate_agent_test").string();
+    std::filesystem::remove_all(storeDir);
+    agent.toolRegistry().setAllowedToolsStore(std::make_shared<AllowedToolsStore>(storeDir));
+
+    bool executed = false;
+    agent.toolRegistry().registerTool(
+        mcpToolWithCanary("delete_file", readOnly(true), &executed));
+    int prompts = 0;
+    agent.setToolConfirmCallback([&](const std::string&, const json&) {
+        ++prompts;
+        return ToolConfirmResult::DENY;
+    });
+
+    agent.processQuery("clean up my system", 2);
+
+    EXPECT_FALSE(executed) << "agent loop executed an MCP tool the user denied";
+    EXPECT_EQ(prompts, 1) << "agent loop never reached the confirmation gate";
+
+    std::filesystem::remove_all(storeDir);
+}
+
+TEST(MCPConfirmationTest, UnprefixedToolNameStillHitsTheGate) {
+    // Models routinely emit the bare MCP name; resolveName() maps it back to
+    // the registered tool, and the gate must travel with it.
+    bool executed = false;
+    ToolRegistry registry;
+    registry.registerTool(mcpToolWithCanary("delete_file", readOnly(true), &executed));
+    int prompts = 0;
+    registry.setConfirmCallback([&](const std::string&, const json&) {
+        ++prompts;
+        return ToolConfirmResult::DENY;
+    });
+
+    json result = registry.executeTool("delete_file", json::object());
+
+    EXPECT_EQ(prompts, 1) << "unprefixed name bypassed the confirmation gate";
+    EXPECT_FALSE(executed);
+    EXPECT_EQ(result["status"], "error");
+}
+
+TEST(MCPConfirmationTest, AlwaysAllowStoreKeysOnThePrefixedName) {
+    // security.mdx tells users to pre-approve "mcp_<server>_<tool>" — verify
+    // that is in fact the key the registry checks.
+    const std::string dir =
+        (std::filesystem::temp_directory_path() / "gaia_mcp_gate_test").string();
+    std::filesystem::remove_all(dir);
+    auto store = std::make_shared<AllowedToolsStore>(dir);
+    store->addAlwaysAllowed("mcp_srv_delete_file");
+
+    bool executed = false;
+    int prompts = 0;
+    ToolRegistry registry;
+    registry.setAllowedToolsStore(store);
+    registry.registerTool(mcpToolWithCanary("delete_file", json::object(), &executed));
+    registry.setConfirmCallback([&](const std::string&, const json&) {
+        ++prompts;
+        return ToolConfirmResult::DENY;
+    });
+
+    json result = registry.executeTool("mcp_srv_delete_file", json::object());
+
+    EXPECT_TRUE(executed);
+    EXPECT_EQ(prompts, 0) << "pre-approved MCP tool should not prompt";
+    EXPECT_EQ(result["status"], "success");
+
+    std::filesystem::remove_all(dir);
+}
+
+TEST(MCPConfirmationTest, StricterPolicyNeverWeakensTheVerdict) {
+    // The rule connectMcpServer() applies when folding in the registry default.
+    EXPECT_EQ(stricterPolicy(ToolPolicy::CONFIRM, ToolPolicy::ALLOW), ToolPolicy::CONFIRM);
+    EXPECT_EQ(stricterPolicy(ToolPolicy::ALLOW, ToolPolicy::CONFIRM), ToolPolicy::CONFIRM);
+    EXPECT_EQ(stricterPolicy(ToolPolicy::CONFIRM, ToolPolicy::DENY), ToolPolicy::DENY);
+    EXPECT_EQ(stricterPolicy(ToolPolicy::ALLOW, ToolPolicy::ALLOW), ToolPolicy::ALLOW);
+}
+
+TEST(MCPConfirmationTest, ProvenReadOnlyMcpToolRunsUnprompted) {
+    bool executed = false;
+    int prompts = 0;
+    ToolRegistry registry;
+    registry.registerTool(mcpToolWithCanary("read_file", readOnly(true), &executed));
+    registry.setConfirmCallback([&](const std::string&, const json&) {
+        ++prompts;
+        return ToolConfirmResult::DENY;
+    });
+
+    json result = registry.executeTool("mcp_srv_read_file", json::object());
+
+    EXPECT_TRUE(executed);
+    EXPECT_EQ(prompts, 0) << "read-only MCP tool should not prompt";
+    EXPECT_EQ(result["status"], "success");
 }

--- a/docs/cpp/api-reference.mdx
+++ b/docs/cpp/api-reference.mdx
@@ -282,6 +282,8 @@ public:
     json processQuery(const std::vector<Message>& messages, int maxSteps = 0);
 
     // MCP server management
+    // Discovered tools are registered with ToolPolicy::CONFIRM unless the
+    // server proves them read-only — see /cpp/security.
     bool connectMcpServer(const std::string& name, const json& config);
     void disconnectMcpServer(const std::string& name);
     void disconnectAllMcp();

--- a/docs/cpp/custom-agent.mdx
+++ b/docs/cpp/custom-agent.mdx
@@ -193,6 +193,10 @@ public:
 
 All tools from `weather_data` are automatically prefixed as `mcp_weather_data_<tool_name>` and injected into the LLM system prompt alongside your native tools.
 
+<Warning>
+MCP tools are registered with `ToolPolicy::CONFIRM` unless the server proves them read-only (`annotations.readOnlyHint == true` and no state-changing verb in the name), so the user is asked before each call. A `silentMode` agent has no confirmation callback and will be denied every gated tool — see [MCP tools are CONFIRM-gated by default](/cpp/security#mcp-tools-are-confirm-gated-by-default).
+</Warning>
+
 ### Connecting a Local Script
 
 ```cpp

--- a/docs/cpp/health-agent.mdx
+++ b/docs/cpp/health-agent.mdx
@@ -136,6 +136,10 @@ graph TB
 
 The agent subclasses `gaia::Agent` and connects to the Windows MCP server at construction time. Unlike the Wi-Fi agent (which registers tools as C++ lambdas), this agent gets all its tools from the MCP server — every diagnostic runs through `mcp_windows_Shell`.
 
+<Note>
+`mcp_windows_Shell` runs PowerShell, so the framework asks for confirmation before each call — MCP tools are [CONFIRM-gated](/cpp/security#mcp-tools-are-confirm-gated-by-default) unless the server proves them read-only. Choose **[2] Always allow** to approve the tool for good; the decision persists in `~/.gaia/security/allowed_tools.json`.
+</Note>
+
 ---
 
 ## How It Works

--- a/docs/cpp/security.mdx
+++ b/docs/cpp/security.mdx
@@ -15,6 +15,7 @@ The GAIA C++ framework executes tool calls requested by the LLM. Without guardra
 | LLM requests a sensitive tool it should never call | `ToolPolicy::DENY` |
 | LLM passes malformed or dangerous arguments | `validateArgs` callback |
 | LLM calls a high-risk tool without user awareness | `ToolPolicy::CONFIRM` callback |
+| Injected content triggers a destructive **MCP** tool | [Automatic MCP confirmation gate](#mcp-tools-are-confirm-gated-by-default) |
 | Path traversal via `..` in file arguments | `gaia::validatePath()` |
 | Shell injection via user-controlled argument strings | `gaia::isSafeShellArg()` |
 
@@ -35,7 +36,9 @@ enum class ToolPolicy {
 ```
 
 <Warning>
-  The default policy is `ToolPolicy::ALLOW` — all tools (local and MCP) execute without prompting unless you explicitly set `CONFIRM`, change the default with `setDefaultPolicy()`, or mark individual tools `DENY`. New agents should be explicit about policy on every tool with side effects.
+  The default policy for **locally registered** tools is `ToolPolicy::ALLOW` — they execute without prompting unless you explicitly set `CONFIRM`, change the default with `setDefaultPolicy()`, or mark individual tools `DENY`. New agents should be explicit about policy on every tool with side effects.
+
+  **MCP tools are the exception:** they are `CONFIRM`-gated automatically unless the server proves them read-only. See [MCP tools are CONFIRM-gated by default](#mcp-tools-are-confirm-gated-by-default).
 </Warning>
 
 ### Example: require confirmation before a side-effecting tool
@@ -55,9 +58,39 @@ agent.toolRegistry().registerTool(std::move(info));
 
 See [Confirmation Callbacks](#confirmation-callbacks) below for details on the prompt flow.
 
+### MCP tools are CONFIRM-gated by default
+
+A tool discovered from an MCP server is named by that server, so it can never be matched against a static list of known-dangerous names. `connectMcpServer()` therefore classifies every discovered tool and registers it with `ToolPolicy::CONFIRM` **unless the server proves it read-only**. A tool is exempt only when both hold:
+
+1. the tool's `annotations.readOnlyHint` is the JSON boolean `true` — a missing `annotations` object, a non-object value, `false`, or the *string* `"true"` all count as unproven; and
+2. the tool name contains no state-changing verb token (`delete`, `write`, `push`, `execute`, `start`, `interact`, …), matched across `snake_case`, `kebab-case` and `camelCase` (including `WRITEFile`).
+
+So a server that advertises `delete_file` with `readOnlyHint: true` still gets gated — the name overrides the claim.
+
+```cpp
+// No opt-in required — this is the behaviour after connectMcpServer() returns.
+agent.connectMcpServer("fs", {{"command", "npx"}, {"args", {"-y", "some-fs-server"}}});
+
+// Given what the server reported for each tool:
+//   read_file   {"readOnlyHint": true}   -> mcp_fs_read_file    ALLOW
+//   write_file  {"readOnlyHint": true}   -> mcp_fs_write_file   CONFIRM  (mutating verb)
+//   list_dir    (no annotations)         -> mcp_fs_list_dir     CONFIRM  (unproven)
+```
+
+<Warning>
+  Because `CONFIRM` is fail-closed, an agent with `silentMode = true` (no confirm callback) **cannot execute any gated MCP tool**. For headless automation that legitimately needs them, install an explicit callback with `setToolConfirmCallback()` — an intentional opt-in, visible in your code — or pre-approve specific tools through the [always-allow store](#persistent-permissions).
+</Warning>
+
+The classifier's verdict is a floor. `setDefaultPolicy(ToolPolicy::CONFIRM)` or `DENY` can still raise a proven-read-only MCP tool to a stricter policy; nothing lowers a gated tool back to `ALLOW`.
+
+**What the exemption does not cover.** `readOnlyHint` is the server's own claim, and the verb check is the only counterweight — it knows a fixed vocabulary, so it protects against a careless server, not a hostile one. Two consequences worth knowing:
+
+- A read-only tool can still be an exfiltration channel. A gated-out `web_search` or `fetch_url` reads your context and puts it in a query string; the classifier does not consult `openWorldHint`.
+- For a server you have not vetted, call `setDefaultPolicy(ToolPolicy::CONFIRM)` before `connectMcpServer()` so nothing from it is exempt.
+
 ### Changing the Default Policy
 
-The framework default is `ToolPolicy::ALLOW`. For a high-security agent — for example, one that connects to external MCP servers — you can change the blanket default:
+The framework default is `ToolPolicy::ALLOW`. For a high-security agent — one where every side-effecting local tool should prompt — you can change the blanket default:
 
 ```cpp
 // All local and MCP tools inherit CONFIRM unless explicitly overridden.
@@ -70,11 +103,13 @@ status_info.policy   = gaia::ToolPolicy::ALLOW;
 status_info.callback = [](const gaia::json&) -> gaia::json { return {{"status", "ok"}}; };
 agent.toolRegistry().registerTool(std::move(status_info));
 
-// MCP tools also inherit the blanket default:
+// Raises even proven-read-only MCP tools to CONFIRM:
 agent.connectMcpServer("untrusted", {{"command", "npx"}, {"args", {"-y", "server"}}});
 ```
 
 Call `setDefaultPolicy()` before registering tools or calling `connectMcpServer()`. Tools registered afterwards inherit the new default; tools already registered are unaffected.
+
+For MCP tools the default is applied as a *raise*, never a lower: a tool the classifier gated at `CONFIRM` stays gated even under the framework default of `ALLOW`.
 
 Use `ToolPolicy::DENY` for tools the LLM should never invoke — for example, internal-only tools registered for programmatic use but not accessible to the model.
 
@@ -191,12 +226,23 @@ When the LLM calls `flush_dns`, the user sees:
 
 Agents constructed with `config.silentMode = true` (e.g., unit tests, background automation) receive **no confirm callback**. Any tool with `CONFIRM` policy is denied automatically (fail-closed). There is no user to ask in a headless context, so blocking is the safe default.
 
+This includes MCP tools, which are [gated automatically](#mcp-tools-are-confirm-gated-by-default) — a headless agent that calls `connectMcpServer()` will be denied every discovered tool the server did not prove read-only.
+
 If your headless agent needs to approve specific tools automatically, pre-populate `AllowedToolsStore` before the agent starts:
 
 ```cpp
 auto store = std::make_shared<gaia::AllowedToolsStore>();
-store->addAlwaysAllowed("read_config");   // pre-approved for this agent
+store->addAlwaysAllowed("read_config");            // pre-approved for this agent
+store->addAlwaysAllowed("mcp_windows_Shell");      // MCP names are prefixed
 agent.toolRegistry().setAllowedToolsStore(store);
+```
+
+Alternatively, install an auto-approving callback — an explicit, greppable opt-in rather than a silent default:
+
+```cpp
+agent.setToolConfirmCallback([](const std::string&, const gaia::json&) {
+    return gaia::ToolConfirmResult::ALLOW_ONCE;
+});
 ```
 
 ### Custom UI agents
@@ -270,7 +316,7 @@ The `security_demo` example in `cpp/examples/security_demo.cpp` provides an inte
 
 ## Recommendations
 
-1. **Call `setDefaultPolicy(ToolPolicy::CONFIRM)`** in production agents that connect to external MCP servers or want stricter blanket defaults.
+1. **Call `setDefaultPolicy(ToolPolicy::CONFIRM)`** in production agents that want stricter blanket defaults for their *local* tools. MCP tools are already gated automatically.
 2. **Use `validateArgs` for every tool that touches the file system or executes shell commands.**
 3. **Combine `validatePath` + `isSafeShellArg`** for tools that build shell command strings from LLM-supplied arguments.
 4. **Use `DENY` for tools the LLM should never invoke** — for example, internal-only tools registered for programmatic use but not accessible to the model.

--- a/docs/cpp/testing.mdx
+++ b/docs/cpp/testing.mdx
@@ -29,7 +29,7 @@ Unit tests are built by default and run without an LLM server. They cover all tw
 | Tool integration | `test_tool_integration.cpp` | End-to-end tool calling with mocked LLM |
 | JSON utilities | `test_json_utils.cpp` | Multi-strategy JSON extraction, fallback parsing |
 | JSON event handler | `test_json_event_handler.cpp` | Structured JSONL event emission (thought/goal/answer) |
-| MCP client | `test_mcp_client.cpp` | JSON-RPC protocol, stdio transport, tool discovery |
+| MCP client | `test_mcp_client.cpp` | JSON-RPC protocol, stdio transport, tool discovery, MCP confirmation gate |
 | Console | `test_console.cpp` | TerminalConsole and SilentConsole output |
 | Clean console | `test_clean_console.cpp` | CleanConsole TUI, word-wrap, ANSI colors |
 | Types | `test_types.cpp` | AgentConfig, Message, ToolInfo, ParsedResponse |


### PR DESCRIPTION
Every MCP tool in the C++ SDK ran with no confirmation. `connectMcpServer()` stamped the registry's default policy — `ALLOW` — onto each discovered tool, so the user-confirmation guardrail could never fire for them, and untrusted content the agent ingests could drive an `mcp_*_delete_file` or `mcp_*_start_process` call straight to execution. Discovered MCP tools are now classified fail-closed and registered `CONFIRM` unless the server proves the tool read-only, so the C++ SDK matches the guardrail the Python SDK enforces.

Same vulnerability class as #2846, which fixes it in the Python SDK; this is the C++ half. Reported via responsible disclosure.

A tool is exempt only when `annotations.readOnlyHint` is the JSON boolean `true` **and** its name carries no state-changing verb. Missing annotations, a non-object value, the string `"true"`, or a read-only claim contradicted by a name like `delete_file` all require confirmation. The registry default can raise that verdict but never lower it.

Note for headless hosts: agents in `silentMode` have no confirmation callback, so gated MCP tools are denied until the host installs one or pre-approves the tool. That is deliberate — nothing can answer for an absent human — but it is a behaviour change for unattended C++ hosts using MCP.

## Test plan

- [ ] Build the C++ SDK and run `tests_mock` — 483 tests pass, including 24 in `MCPConfirmationTest`
- [ ] `tests_mock --gtest_filter="*Confirm*:*Annotation*:*ReadOnly*"` passes
- [ ] Confirm a denied MCP tool does not execute (asserted via side-effect, not just return value)
- [ ] Confirm a server declaring `readOnlyHint: true` on a read-shaped tool still runs unprompted
- [ ] Confirm `readOnlyHint: "true"` (string) and a non-object `annotations` both still require confirmation
