### PR TITLE
ci(windows): pin ffmpeg version to drop the gyan.dev dependency

### DIFF
--- a/.github/workflows/test_gaia_cli_windows.yml
+++ b/.github/workflows/test_gaia_cli_windows.yml
@@ -117,8 +117,13 @@ jobs:
 
           exit /b %dacl_exit%
 
+      # Pin the version: the default `release` resolves through gyan.dev, so that
+      # host 503ing fails the job outright (2026-08-05, "Cannot get latest release").
+      # An explicit version resolves from the GyanD/codexffmpeg GitHub releases API.
       - uses: FedericoCarboni/setup-ffmpeg@v3
         id: setup-ffmpeg
+        with:
+          ffmpeg-version: '8.1.2'
 
       - name: Start Lemonade Server and Run Tests
         timeout-minutes: 20


### PR DESCRIPTION
The Windows CLI test job has been going red on main for reasons that have nothing to do with GAIA: `setup-ffmpeg`'s default `release` spec resolves the version through gyan.dev, that host started 503ing on Aug 5, and the job dies at `AssertionError: Cannot get latest release` before a single test runs — it took out `abed9f1c` and `bbf69fd6`. Pinning an explicit version switches the action to the GyanD/codexffmpeg GitHub releases API (already authenticated via `github.token`), so a gyan.dev outage can no longer fail CI. It also puts the runner tool-cache check *before* any network call, which `release` made impossible — on the self-hosted Windows runner a warm cache now needs no network at all.

## Test plan

- [x] **This PR's `GAIA CLI Tests (Windows)` run passes** (the workflow is path-triggered on itself), with the runner logging `Using ffmpeg version 8.1.2 from tool cache` — the pinned lookup short-circuits on the warm tool cache with no network call, which is exactly the failure mode that broke main
- [x] Confirmed today's failure is external, not ours: `curl https://www.gyan.dev/ffmpeg/builds/release-version` → **503**

Also ran the real action (`v3` `dist/index.js`) locally on Windows to cover the cold-cache path a green runner can't exercise — same installer as the runner (`os.platform() === 'win32'` → `GyanInstaller`):

- [x] Cold cache: exit 0, `Installing ffmpeg version 8.1.2 from https://github.com/GyanD/codexffmpeg/releases/download/8.1.2/ffmpeg-8.1.2-full_build.7z` — **no gyan.dev request**; outputs `ffmpeg-version=8.1.2`, `cache-hit=false`
- [x] Downloaded + extracted binaries run: `ffmpeg -version` and `ffprobe -version` both report 8.1.2
- [x] Warm cache with an **empty** github-token: exit 0, `Found tool in cache`, `cache-hit=true`, zero network
- [x] `8.1.2` is on page 1 of the releases list the action reads, and its `ffmpeg-8.1.2-full_build.7z` asset exists