### PR TITLE
fix(code): route orchestrated tool calls through the confirmation gate

### DIFF
--- a/.github/workflows/test_code_agent.yml
+++ b/.github/workflows/test_code_agent.yml
@@ -104,9 +104,13 @@ jobs:
 
           # Validators and write-guardrail tests (moved here from tests/unit and
           # tests/ root during the hub migration; keep them gated).
+          # test_tool_executor_confirmation.py pins the orchestrator to the
+          # user-confirmation gate; it is the regression guard for that bypass,
+          # so it has to run here or it guards nothing. Fast, no LLM needed.
           python -m pytest \
             hub/agents/code/python/tests/test_code_validators.py \
             hub/agents/code/python/tests/test_file_io_guardrails.py \
+            hub/agents/code/python/tests/test_tool_executor_confirmation.py \
             -v --tb=short
 
       - name: Run Code Agent Integration Tests

--- a/docs/guides/code.mdx
+++ b/docs/guides/code.mdx
@@ -359,6 +359,16 @@ The `--trace` flag saves a complete trace with detailed information:
   </Accordion>
 </AccordionGroup>
 
+### Tools that ask before running
+
+Shell and file-mutating tools — `run_cli_command`, `write_file`, `edit_file` and the
+rest of GAIA's confirmation set — prompt for approval before they execute. In the
+Agent UI that's a permission dialog; on the CLI they run straight through.
+
+Declining cancels the step and stops the run: the agent reports which tool was
+refused rather than re-planning and asking again. Approve it on a re-run, or reword
+the request so it doesn't need that tool.
+
 ## External Information Lookup
 
 The agent can optionally use web search (Perplexity) when `PERPLEXITY_API_KEY` is set in `.env` to unblock documentation or best-practice questions.

--- a/hub/agents/code/python/gaia_agent_code/agent.py
+++ b/hub/agents/code/python/gaia_agent_code/agent.py
@@ -20,7 +20,6 @@ from typing import Any, Callable, Dict, Optional
 from gaia.agents.base.agent import Agent
 from gaia.agents.base.api_agent import ApiAgent
 from gaia.agents.base.console import AgentConsole, SilentConsole
-from gaia.agents.base.tools import _TOOL_REGISTRY
 from gaia.agents.tools.code_index_tools import CodeIndexToolsMixin
 from gaia.security import PathValidator
 
@@ -395,27 +394,21 @@ class CodeAgent(
                 logger.info(f"Restored working directory to: {original_cwd}")
 
     def _create_tool_executor(self) -> Callable[[str, Dict[str, Any]], Any]:
-        """Create a tool executor function that uses registered tools.
+        """Create the tool executor handed to the orchestrator.
+
+        Delegates to ``Agent._execute_tool`` so orchestrated tool calls go
+        through the same path as the agent loop's: the user-confirmation
+        guardrail, name resolution, bounded execution, and error formatting.
+        Calling the registry directly here would skip the confirmation gate
+        entirely.
 
         Returns:
             Function that executes tools by name
         """
 
         def execute_tool(tool_name: str, tool_args: Dict[str, Any]) -> Any:
-            """Execute a registered tool."""
-            if tool_name not in _TOOL_REGISTRY:
-                resolved = self._resolve_tool_name(tool_name)
-                if resolved:
-                    tool_name = resolved
-                else:
-                    return {"success": False, "error": f"Unknown tool: {tool_name}"}
-
-            tool_func = _TOOL_REGISTRY[tool_name]["function"]
-            try:
-                return tool_func(**tool_args)
-            except Exception as e:  # pylint: disable=broad-exception-caught
-                logger.exception(f"Tool execution failed: {tool_name}")
-                return {"success": False, "error": str(e)}
+            """Execute a registered tool through the gated base-agent path."""
+            return self._execute_tool(tool_name, tool_args)
 
         return execute_tool
 

--- a/hub/agents/code/python/gaia_agent_code/orchestration/checklist_executor.py
+++ b/hub/agents/code/python/gaia_agent_code/orchestration/checklist_executor.py
@@ -164,6 +164,9 @@ class ItemExecutionResult:
     error: Optional[str] = None
     error_recoverable: bool = True
     output: Dict[str, Any] = field(default_factory=dict)
+    # The user declined the tool at the confirmation prompt. Terminal by
+    # definition — retrying would just re-prompt for the same denied call.
+    denied: bool = False
 
     def to_dict(self) -> Dict[str, Any]:
         """Convert to dictionary representation."""
@@ -175,6 +178,7 @@ class ItemExecutionResult:
             "files": self.files,
             "warnings": self.warnings,
             "error": self.error,
+            "denied": self.denied,
         }
 
 
@@ -222,6 +226,11 @@ class ChecklistExecutionResult:
     def items_failed(self) -> int:
         """Count of failed items."""
         return sum(1 for r in self.item_results if not r.success)
+
+    @property
+    def denied(self) -> bool:
+        """True if any item was blocked by the user-confirmation guardrail."""
+        return any(r.denied for r in self.item_results)
 
     @property
     def summary(self) -> str:
@@ -398,12 +407,25 @@ class ChecklistExecutor:
                     )
                 )
 
-            # Collect files
+            # Collect files and warnings before any early exit below, so a
+            # stopped run still reports what the completed items produced.
             result.total_files.extend(item_result.files)
+            result.warnings.extend(item_result.warnings)
 
             # Handle errors
             if not item_result.success:
                 result.errors.append(item_result.error or "Unknown error")
+
+                # A denied tool ends the checklist regardless of stop_on_error:
+                # later items assume the denied step's side effects exist, and
+                # continuing would just queue up more prompts for the same work.
+                if item_result.denied:
+                    logger.error(
+                        "Stopping checklist: %s was denied by the user",
+                        item.template,
+                    )
+                    result.success = False
+                    break
 
                 if stop_on_error and not item_result.error_recoverable:
                     logger.error(
@@ -412,9 +434,6 @@ class ChecklistExecutor:
                     )
                     result.success = False
                     break
-
-            # Collect warnings
-            result.warnings.extend(item_result.warnings)
 
             # Handle step-through
             if step_through:
@@ -1353,6 +1372,19 @@ export default function Home() {
                         self.error_handler.reset_retry_count(item.template)
                     return result
 
+                # User denied the tool at the confirmation prompt. Terminal —
+                # retrying would re-prompt for the identical call.
+                if result.denied:
+                    logger.error(
+                        "User denied tool execution for %s: %s",
+                        item.template,
+                        result.error,
+                    )
+                    self.console.print_error(
+                        f"Step '{item.description}' was cancelled: {result.error}"
+                    )
+                    return result
+
                 # No error handler - return failure immediately
                 if not self.error_handler:
                     logger.warning(
@@ -1700,7 +1732,21 @@ if (process.env.NODE_ENV !== "production") globalForPrisma.prisma = prisma;
             )
 
         if isinstance(raw_result, dict):
-            success = raw_result.get("success", True)
+            # Tools report failure either as success=False or as the base
+            # agent's status field ("denied" from the confirmation gate,
+            # "error" from _execute_tool). Absent both, treat as success —
+            # many tools return a bare payload dict on the happy path.
+            status = raw_result.get("status")
+            denied = status == "denied"
+            success = raw_result.get("success", status not in ("denied", "error"))
+            error = raw_result.get("error") or raw_result.get("error_brief")
+            if denied:
+                error = error or f"Tool for '{item.template}' was denied by the user."
+            elif not success and error:
+                # _execute_tool's error text is addressed to the model and omits
+                # the tool name; the replanning prompt needs to know which
+                # checklist item produced it.
+                error = f"[{item.template}] {error}"
             return ItemExecutionResult(
                 template=item.template,
                 params=item.params,
@@ -1708,9 +1754,14 @@ if (process.env.NODE_ENV !== "production") globalForPrisma.prisma = prisma;
                 success=success,
                 files=raw_result.get("files", []),
                 warnings=raw_result.get("warnings", []),
-                error=raw_result.get("error"),
-                error_recoverable=raw_result.get("retryable", True),
+                error=error,
+                # A denial is a user decision, not a transient fault: never
+                # retry it and never let stop_on_error skip past it.
+                error_recoverable=(
+                    False if denied else raw_result.get("retryable", True)
+                ),
                 output=raw_result,
+                denied=denied,
             )
 
         # Unknown result type - treat as success if truthy

--- a/hub/agents/code/python/gaia_agent_code/orchestration/orchestrator.py
+++ b/hub/agents/code/python/gaia_agent_code/orchestration/orchestrator.py
@@ -318,6 +318,53 @@ class Orchestrator:
             previous_execution_errors = checklist_result.errors.copy()
             previous_validation_logs = checklist_result.validation_logs.copy()
 
+            # A required tool was blocked at the confirmation gate. Planning
+            # another checklist would re-prompt for the same work, so stop.
+            # Quote the underlying reason — a denial can be the user declining,
+            # a prompt timeout, or a governance policy, and only the first has
+            # something for the user to approve.
+            if checklist_result.denied:
+                reason = (
+                    checklist_result.errors[-1]
+                    if checklist_result.errors
+                    else "a required tool was denied."
+                )
+                denial_message = (
+                    f"Execution stopped: {reason} Nothing further was run — "
+                    "re-run once that tool is permitted, or rephrase the "
+                    "request so it is not needed."
+                )
+                logger.error(denial_message)
+                if self.console:
+                    self.console.print_error(denial_message)
+                combined_errors.append(denial_message)
+                iteration_outputs.append(
+                    {
+                        "iteration": iteration,
+                        "checklist": checklist.to_dict(),
+                        "execution": {
+                            "summary": checklist_result.summary,
+                            "success": False,
+                            "files": checklist_result.total_files,
+                            "errors": checklist_result.errors,
+                            "warnings": checklist_result.warnings,
+                            "item_results": [
+                                r.to_dict() for r in checklist_result.item_results
+                            ],
+                            "validation_logs": [
+                                log.to_dict()
+                                for log in checklist_result.validation_logs
+                            ],
+                        },
+                        "assessment": CheckpointAssessment(
+                            status="denied",
+                            reasoning=denial_message,
+                            issues=[denial_message],
+                        ).to_dict(),
+                    }
+                )
+                break
+
             logger.info("Assessing application state after iteration %d", iteration)
             if self.console:
                 self.console.print_info(

--- a/hub/agents/code/python/gaia_agent_code/tools/cli_tools.py
+++ b/hub/agents/code/python/gaia_agent_code/tools/cli_tools.py
@@ -233,6 +233,10 @@ class CLIToolsMixin:
 
         @tool(
             name="run_cli_command",
+            # Callers pass their own `timeout` (the orchestrator uses 1200s for
+            # npm/npx installs). This outer bound only backstops a hung call —
+            # it must stay above the largest inner budget or long installs die.
+            timeout=1800,
             description="Execute any CLI command (npm, python, docker, gh, etc.) with optional background execution for servers. "
             "Automatically detects startup errors and manages process lifecycle.",
             parameters={

--- a/hub/agents/code/python/gaia_agent_code/tools/error_fixing.py
+++ b/hub/agents/code/python/gaia_agent_code/tools/error_fixing.py
@@ -129,7 +129,8 @@ class ErrorFixingMixin:
             except Exception as e:
                 return {"status": "error", "error": str(e)}
 
-        @tool
+        # _fix_code_with_llm retries 3x at 600s per LLM call — 1800s worst case.
+        @tool(timeout=1900)
         def fix_code(file_path: str, error_description: str = "") -> Dict[str, Any]:
             """Fix Python code using LLM-driven analysis and correction.
 

--- a/hub/agents/code/python/gaia_agent_code/tools/web_dev_tools.py
+++ b/hub/agents/code/python/gaia_agent_code/tools/web_dev_tools.py
@@ -853,7 +853,8 @@ export function {component_name}({{ }}: {component_name}Props) {{
                     "hint": "Check that src/app/page.tsx exists and is writable",
                 }
 
-        @tool
+        # npm install of the Vitest stack runs up to 1200s internally.
+        @tool(timeout=1500)
         def setup_nextjs_testing(
             project_dir: str,
             resource_name: Optional[str] = None,
@@ -1251,7 +1252,8 @@ export function {component_name}({{ }}: {component_name}Props) {{
                     "error_type": "scaffold_generation_error",
                 }
 
-        @tool
+        # Chains prisma format/generate/db-push — up to ~3600s of inner budget.
+        @tool(timeout=3900)
         def manage_data_model(
             project_dir: str,
             model_name: str,
@@ -1656,7 +1658,8 @@ model {model_name} {{
                     "error_type": "config_error",
                 }
 
-        @tool
+        # Shells out to npm with a 600s inner budget.
+        @tool(timeout=900)
         def generate_style_tests(
             project_dir: str, resource_name: str = "Item"
         ) -> Dict[str, Any]:

--- a/hub/agents/code/python/tests/test_tool_executor_confirmation.py
+++ b/hub/agents/code/python/tests/test_tool_executor_confirmation.py
@@ -1,0 +1,468 @@
+#!/usr/bin/env python
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""Confirmation-guardrail tests for CodeAgent's orchestrator tool executor.
+
+The executor returned by ``CodeAgent._create_tool_executor`` used to call the
+tool registry directly, bypassing ``Agent._execute_tool`` and therefore the
+user-confirmation gate entirely. These tests pin the gate in place:
+
+- a denied gated tool must not run its body (asserted on a filesystem canary)
+- an MCP-registered tool reached through the same executor is gated too
+- a denial surfaces as a clear checklist failure — never a silent success,
+  never a retry loop that re-prompts the user
+- non-gated tools are unaffected
+"""
+
+import os
+import shutil
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock
+
+# Add parent directory to path
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from gaia_agent_code.agent import CodeAgent
+from gaia_agent_code.orchestration.checklist_executor import (
+    TEMPLATE_TO_TOOL,
+    ChecklistExecutor,
+)
+from gaia_agent_code.orchestration.checklist_generator import (
+    ChecklistItem,
+    GeneratedChecklist,
+)
+from gaia_agent_code.orchestration.steps.base import UserContext
+from gaia_agent_code.orchestration.steps.error_handler import (
+    ErrorHandler,
+    RecoveryAction,
+)
+
+from gaia.agents.base.agent import tool_execution_timeout
+from gaia.agents.base.console import SilentConsole
+from gaia.agents.base.tools import _TOOL_REGISTRY, tool
+
+
+class RecordingConsole(SilentConsole):
+    """Silent console that records confirmation prompts and answers `allow`."""
+
+    def __init__(self, allow: bool):
+        super().__init__()
+        self.allow = allow
+        self.prompts = []
+        self.errors = []
+
+    def confirm_tool_execution(self, tool_name, tool_args):
+        self.prompts.append((tool_name, dict(tool_args)))
+        return self.allow
+
+    def print_error(self, *args, **kwargs):
+        self.errors.append(args[0] if args else "")
+
+
+def make_context(project_dir: str) -> UserContext:
+    return UserContext(
+        user_request="Test",
+        project_dir=project_dir,
+        language="typescript",
+        project_type="fullstack",
+    )
+
+
+class TestExecutorEnforcesConfirmation(unittest.TestCase):
+    """The orchestrator executor must route through the confirmation gate."""
+
+    def setUp(self):
+        self.test_dir = tempfile.mkdtemp()
+        self.agent = CodeAgent(silent_mode=True, max_steps=5)
+        self.agent._register_tools()
+        self.agent.path_validator.add_allowed_path(self.test_dir)
+        self.console = RecordingConsole(allow=False)
+        self.agent.console = self.console
+        self.execute_tool = self.agent._create_tool_executor()
+
+    def tearDown(self):
+        if os.path.exists(self.test_dir):
+            shutil.rmtree(self.test_dir, ignore_errors=True)
+        _TOOL_REGISTRY.clear()
+
+    def test_denied_write_file_never_touches_disk(self):
+        """A denied write_file must return a denial AND create no file."""
+        canary = Path(self.test_dir) / "canary.txt"
+        self.assertFalse(canary.exists())
+
+        result = self.execute_tool(
+            "write_file", {"file_path": str(canary), "content": "pwned"}
+        )
+
+        self.assertEqual(result.get("status"), "denied")
+        self.assertIn("denied", result.get("error", "").lower())
+        # The side-effect canary is the real assertion: the body never ran.
+        self.assertFalse(canary.exists(), "write_file executed despite being denied")
+        self.assertEqual([p[0] for p in self.console.prompts], ["write_file"])
+
+    def test_denied_run_cli_command_never_executes(self):
+        """A denied shell command must not spawn a subprocess."""
+        canary = Path(self.test_dir) / "shell_canary.txt"
+        self.assertFalse(canary.exists())
+
+        args = {
+            "command": f'echo pwned > "{canary}"',
+            "working_dir": self.test_dir,
+        }
+
+        result = self.execute_tool("run_cli_command", args)
+
+        self.assertEqual(result.get("status"), "denied")
+        self.assertFalse(
+            canary.exists(), "run_cli_command executed despite being denied"
+        )
+        self.assertEqual([p[0] for p in self.console.prompts], ["run_cli_command"])
+
+        # Positive control: the very same command DOES create the canary when
+        # approved, so the assertion above cannot pass just because the shell
+        # redirect was a no-op on this platform.
+        self.agent.console = RecordingConsole(allow=True)
+        self.agent._create_tool_executor()("run_cli_command", args)
+        self.assertTrue(canary.exists(), "positive control failed to run")
+
+    def test_approved_gated_tool_still_runs(self):
+        """Approving at the prompt must let the tool through unchanged."""
+        self.agent.console = RecordingConsole(allow=True)
+        execute_tool = self.agent._create_tool_executor()
+        target = Path(self.test_dir) / "allowed.txt"
+
+        execute_tool("write_file", {"file_path": str(target), "content": "ok"})
+
+        self.assertTrue(target.exists())
+        self.assertEqual(target.read_text(encoding="utf-8"), "ok")
+
+    def test_mcp_style_tool_is_gated_when_declared(self):
+        """A co-resident MCP tool is gated once it's in the confirmation set.
+
+        CodeAgent never calls ``_snapshot_tools()``, so its registry IS the
+        process-global one — an MCP tool registered by another agent in the same
+        Agent UI process is reachable through this executor. This pins the
+        executor half of that: whatever ``confirmation_required_tools()``
+        contains is enforced here.
+
+        NOTE: nothing currently *adds* MCP tool names to that set — the base
+        ``CONFIRMATION_REQUIRED_TOOLS`` is empty and only EmailTriageAgent
+        populates it. Classifying write-capable MCP tools is the companion
+        change and is NOT in this branch; this test declares the tool
+        explicitly to stand in for it.
+        """
+        canary = Path(self.test_dir) / "mcp_canary.txt"
+        ran = []
+
+        @tool
+        def mcp_files_write_file(path: str) -> dict:
+            """MCP-style write tool registered by a co-resident agent."""
+            ran.append(path)
+            Path(path).write_text("pwned", encoding="utf-8")
+            return {"success": True}
+
+        self.assertIn("mcp_files_write_file", self.agent._tools_registry)
+
+        original = CodeAgent.CONFIRMATION_REQUIRED_TOOLS
+        CodeAgent.CONFIRMATION_REQUIRED_TOOLS = frozenset({"mcp_files_write_file"})
+        try:
+            result = self.execute_tool("mcp_files_write_file", {"path": str(canary)})
+        finally:
+            CodeAgent.CONFIRMATION_REQUIRED_TOOLS = original
+
+        self.assertEqual(result.get("status"), "denied")
+        self.assertEqual(ran, [], "MCP tool body ran despite being denied")
+        self.assertFalse(canary.exists())
+
+    def test_non_gated_tool_is_not_prompted(self):
+        """Regression: ordinary tools run without a confirmation prompt."""
+        ran = []
+
+        @tool
+        def harmless_probe(value: str) -> dict:
+            """Non-gated tool used to prove normal execution is unchanged."""
+            ran.append(value)
+            return {"success": True, "echo": value}
+
+        result = self.execute_tool("harmless_probe", {"value": "hello"})
+
+        self.assertEqual(result, {"success": True, "echo": "hello"})
+        self.assertEqual(ran, ["hello"])
+        self.assertEqual(self.console.prompts, [])
+
+    def test_unknown_tool_reports_error(self):
+        """Unknown names still fail loudly (shape now matches _execute_tool)."""
+        result = self.execute_tool("no_such_tool_xyz", {})
+
+        self.assertEqual(result.get("status"), "error")
+        self.assertIn("Unknown tool", result.get("error", ""))
+
+    def test_long_running_tools_keep_generous_timeouts(self):
+        """Tools with inner budgets above the 180s default need an override.
+
+        Routing through ``_execute_tool`` wraps every tool in
+        ``_call_tool_bounded``, whose default is ``DEFAULT_TOOL_TIMEOUT`` (180s).
+        These tools drive npm/npx/prisma or looped LLM calls that legitimately
+        run far longer, so without a ``@tool(timeout=...)`` override the guard
+        abandons real work mid-flight.
+        """
+        for name, minimum in (
+            ("run_cli_command", 1200),
+            ("setup_nextjs_testing", 1200),
+            ("manage_data_model", 1200),
+            ("generate_style_tests", 600),
+            ("fix_code", 1800),
+        ):
+            with self.subTest(tool=name):
+                self.assertGreaterEqual(self.agent._resolve_tool_timeout(name), minimum)
+
+    def test_every_checklist_tool_has_a_deliberate_timeout(self):
+        """Inversion guard: a NEW slow checklist tool must not slip through.
+
+        The per-tool list above can only re-state the tools we already fixed —
+        which is exactly how ``fix_code`` was missed. This asserts instead that
+        every tool the checklist can dispatch is *either* explicitly overridden
+        *or* named here as known-fast, so adding a slow one fails this test
+        until someone makes a decision about it.
+        """
+        # Tools that complete well inside the 180s default: pure file writes,
+        # or subprocesses with inner budgets of 60s or less.
+        KNOWN_FAST = {
+            "setup_app_styling",
+            "manage_api_endpoint",
+            "manage_react_component",
+            "update_landing_page",
+            "validate_typescript",
+            "validate_styles",
+        }
+        default = tool_execution_timeout()
+
+        for template, name in sorted(TEMPLATE_TO_TOOL.items()):
+            with self.subTest(template=template, tool=name):
+                self.assertIn(
+                    name,
+                    self.agent._tools_registry,
+                    f"{template} maps to unregistered tool {name}",
+                )
+                overridden = self.agent._resolve_tool_timeout(name) != default
+                self.assertTrue(
+                    overridden or name in KNOWN_FAST,
+                    f"Tool '{name}' (template '{template}') has no @tool(timeout=...) "
+                    f"override and is not listed as known-fast. Confirm it finishes "
+                    f"within {default:g}s or give it an explicit override.",
+                )
+
+
+class TestRealGateReachesChecklist(unittest.TestCase):
+    """End-to-end: the real gate's denial shape must reach the real executor.
+
+    The other two suites each mock one half — one drives the real
+    ``_execute_tool`` without a ChecklistExecutor, the other hand-writes the
+    denial dict. If ``Agent._execute_tool`` ever renames its denial key, both
+    stay green and the bypass silently returns. This pins the seam.
+    """
+
+    def setUp(self):
+        self.test_dir = tempfile.mkdtemp()
+        self.agent = CodeAgent(silent_mode=True, max_steps=5)
+        self.agent._register_tools()
+        self.agent.console = RecordingConsole(allow=False)
+
+    def tearDown(self):
+        if os.path.exists(self.test_dir):
+            shutil.rmtree(self.test_dir, ignore_errors=True)
+        _TOOL_REGISTRY.clear()
+
+    def test_denial_flows_from_real_gate_into_checklist_result(self):
+        executor = ChecklistExecutor(self.agent._create_tool_executor())
+        checklist = GeneratedChecklist(
+            items=[
+                ChecklistItem("create_next_app", {"project_name": "app"}, "Create"),
+                ChecklistItem("setup_prisma", {}, "Set up Prisma"),
+            ],
+            reasoning="Test",
+        )
+
+        result = executor.execute(checklist, make_context(self.test_dir))
+
+        self.assertTrue(result.denied, "real denial did not reach the checklist")
+        self.assertFalse(result.success)
+        self.assertEqual(result.items_succeeded, 0)
+        # Only the first item was attempted, and nothing was scaffolded.
+        self.assertEqual(len(result.item_results), 1)
+        self.assertFalse((Path(self.test_dir) / "node_modules").exists())
+        self.assertEqual(
+            [p[0] for p in self.agent.console.prompts], ["run_cli_command"]
+        )
+
+
+class TestDenialSurfacesThroughChecklist(unittest.TestCase):
+    """A denial must read as a clear failure, not success and not a retry."""
+
+    def setUp(self):
+        self.test_dir = tempfile.mkdtemp()
+        self.context = make_context(self.test_dir)
+        self.checklist = GeneratedChecklist(
+            items=[
+                ChecklistItem("create_next_app", {"project_name": "app"}, "Create app")
+            ],
+            reasoning="Test",
+        )
+
+    def tearDown(self):
+        if os.path.exists(self.test_dir):
+            shutil.rmtree(self.test_dir, ignore_errors=True)
+
+    def test_denial_is_a_failure_not_a_silent_success(self):
+        """`{"status": "denied"}` has no `success` key — it must not pass."""
+        executor = ChecklistExecutor(
+            lambda name, params: {
+                "status": "denied",
+                "error": "Tool 'run_cli_command' was denied by the user.",
+            }
+        )
+
+        result = executor.execute(self.checklist, self.context)
+
+        self.assertFalse(result.success)
+        self.assertTrue(result.denied)
+        self.assertEqual(result.items_succeeded, 0)
+        self.assertEqual(result.items_failed, 1)
+        self.assertTrue(any("denied" in e.lower() for e in result.errors))
+
+    def test_error_status_is_also_not_a_silent_success(self):
+        """`_execute_tool`'s error shape must not be read as success either."""
+        executor = ChecklistExecutor(
+            lambda name, params: {"status": "error", "error": "boom"}
+        )
+
+        result = executor.execute(self.checklist, self.context)
+
+        self.assertFalse(result.success)
+        self.assertFalse(result.denied)
+        # The template name is prefixed so the replanning prompt knows which
+        # item failed — _execute_tool's own messages omit the tool name.
+        self.assertEqual(result.errors, ["[create_next_app] boom"])
+
+    def test_denial_is_never_retried(self):
+        """Recovery must not re-run a denied tool and re-prompt the user."""
+        calls = []
+
+        def denying_executor(name, params):
+            calls.append(name)
+            return {"status": "denied", "error": "denied by the user"}
+
+        error_handler = MagicMock(spec=ErrorHandler)
+        error_handler.handle_error.return_value = (RecoveryAction.RETRY, None)
+
+        executor = ChecklistExecutor(denying_executor, error_handler=error_handler)
+        item = ChecklistItem("create_next_app", {"project_name": "app"}, "Create app")
+
+        result = executor._execute_item_with_recovery(item, self.context)
+
+        self.assertFalse(result.success)
+        self.assertTrue(result.denied)
+        self.assertFalse(result.error_recoverable)
+        self.assertEqual(len(calls), 1, "denied tool was retried")
+        error_handler.handle_error.assert_not_called()
+
+    def test_denial_stops_the_rest_of_the_checklist(self):
+        """Later items must not run on top of a step the user refused."""
+        calls = []
+
+        def denying_executor(name, params):
+            calls.append(name)
+            return {"status": "denied", "error": "denied by the user"}
+
+        checklist = GeneratedChecklist(
+            items=[
+                ChecklistItem("create_next_app", {"project_name": "app"}, "Create"),
+                ChecklistItem("setup_prisma", {}, "Setup Prisma"),
+            ],
+            reasoning="Test",
+        )
+        executor = ChecklistExecutor(denying_executor)
+
+        result = executor.execute(checklist, self.context)
+
+        self.assertFalse(result.success)
+        self.assertEqual(len(calls), 1, "checklist continued past a denial")
+
+    def test_success_shape_still_passes(self):
+        """Regression: the ordinary happy-path result is unchanged."""
+        executor = ChecklistExecutor(
+            lambda name, params: {"success": True, "files": ["a.ts"]}
+        )
+
+        result = executor.execute(self.checklist, self.context)
+
+        self.assertTrue(result.success)
+        self.assertFalse(result.denied)
+        self.assertEqual(result.total_files, ["a.ts"])
+
+    def test_bare_payload_dict_still_passes(self):
+        """Regression: tools returning a plain payload still count as success."""
+        executor = ChecklistExecutor(lambda name, params: {"files": ["b.ts"]})
+
+        result = executor.execute(self.checklist, self.context)
+
+        self.assertTrue(result.success)
+        self.assertFalse(result.denied)
+
+
+class TestOrchestratorStopsOnDenial(unittest.TestCase):
+    """The outer checklist loop must not re-prompt for a denied tool."""
+
+    def test_orchestrator_aborts_instead_of_replanning(self):
+        from gaia_agent_code.orchestration.orchestrator import Orchestrator
+
+        test_dir = tempfile.mkdtemp()
+        try:
+            calls = []
+
+            def denying_executor(name, params):
+                calls.append(name)
+                return {"status": "denied", "error": "denied by the user"}
+
+            llm = MagicMock()
+            orchestrator = Orchestrator(
+                tool_executor=denying_executor,
+                llm_client=llm,
+                max_checklist_loops=5,
+            )
+            checklist = GeneratedChecklist(
+                items=[
+                    ChecklistItem(
+                        "create_next_app", {"project_name": "app"}, "Create app"
+                    )
+                ],
+                reasoning="Test",
+            )
+            orchestrator.checklist_generator = MagicMock()
+            orchestrator.checklist_generator.generate_initial_checklist.return_value = (
+                checklist
+            )
+            orchestrator.checklist_generator.generate_debug_checklist.return_value = (
+                checklist
+            )
+            orchestrator._prepare_project_directory = lambda ctx: test_dir
+            orchestrator._assess_checkpoint = MagicMock()
+
+            result = orchestrator.execute(make_context(test_dir))
+
+            self.assertFalse(result.success)
+            self.assertEqual(len(calls), 1, "orchestrator replanned after a denial")
+            orchestrator._assess_checkpoint.assert_not_called()
+            self.assertTrue(
+                any("denied" in e.lower() for e in result.errors),
+                f"denial not surfaced in errors: {result.errors}",
+            )
+        finally:
+            shutil.rmtree(test_dir, ignore_errors=True)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
CodeAgent's orchestrator ran tools by pulling the callable straight out of `_TOOL_REGISTRY`, skipping `Agent._execute_tool` and with it the user-confirmation guardrail — so `run_shell_command`, `write_file` and any MCP tool registered by a co-resident agent in the same process all executed with no prompt during orchestrated runs. Orchestrated calls now take the same path as the agent loop's, so the same tools prompt whether they are invoked directly or through a checklist.

Same vulnerability class as #2846, which fixes it for MCP tools in the base agent; this is the CodeAgent half. Reported via responsible disclosure.

A denial is treated as a user decision rather than a transient fault: it is never retried, it stops the checklist, and the orchestrator stops replanning instead of queuing another prompt for the same work. Result parsing now reads the base agent's `status` field alongside the legacy `success` key, so a denied or errored call can no longer be mistaken for success by tools that return a bare payload dict.

Also fixes warnings being dropped when a checklist exits early — a stopped run now still reports what the completed items produced.

## Test plan

- [ ] `python -m pytest hub/agents/code/python/tests/test_tool_executor_confirmation.py -q` — 16 tests, 19 subtests
- [ ] Confirm a denied gated tool does not execute (asserted via side-effect, not just the return value)
- [ ] Confirm a denied item stops the checklist and is not retried by the error handler
- [ ] Confirm the orchestrator halts replanning after a denial rather than re-prompting
- [ ] Run a normal `gaia-code` generation task through the orchestrator and confirm non-gated tools are unaffected
- [ ] `python util/lint.py --all`
