### PR TITLE
access-probe — GitHub write-access verification (merged into a throwaway branch, ignore)

### DIFF
--- a/.access-probe
+++ b/.access-probe
@@ -1,0 +1,1 @@
+temporary write-access probe


### PR DESCRIPTION
Temporary probe verifying write access from the `itomek` account. Merged into a now-deleted throwaway branch, never into main. Not a real change.