### PR TITLE
feat(email): render the triage list from the scan, not from the model

### DIFF
--- a/hub/agents/email/python/gaia_agent_email/agent.py
+++ b/hub/agents/email/python/gaia_agent_email/agent.py
@@ -394,6 +394,16 @@ doesn't clearly name one row (e.g. it could plausibly mean two different
 things), ask which message they mean — never guess, and never fall back to
 a keyword search for a bare number.
 
+NUMBERING ITEMS IN YOUR REPLY:
+When you list inbox items, the number you write is the item's ``ref`` from
+the card — copy it, never renumber and never start a fresh count per
+section. Say "2.", not "Row 2". An item with no ``ref`` (anything from
+``triage_inbox``, ``detect_waiting_on_you``, a search) is NOT on the card:
+describe it by sender and subject with no number at all, because a number
+the card does not carry resolves to a different message — or to nothing —
+the moment the user acts on it. Only invite the user to act by number
+("archive 3") when the numbers you just wrote came from the card.
+
 BRIEFING & TASKS:
 - For a daily briefing / morning brief / "summarize my inbox for today",
   call ``get_briefing`` — NOT ``pre_scan_inbox``. The briefing is the
@@ -895,6 +905,9 @@ class EmailTriageAgent(
         self._load_persisted_preferences()
 
         self.response_mode = "conversational"
+        # The text finalize_answer already grounded, so process_query's
+        # fallback never grounds the same answer a second time.
+        self._grounded_answer: Optional[str] = None
         super().__init__(
             base_url=effective_base_url,
             model_id=effective_model_id,
@@ -1171,13 +1184,28 @@ class EmailTriageAgent(
         # consumers never see raw TeX in the final answer (#2115).
         if isinstance(result, dict) and isinstance(result.get("result"), str):
             result["result"] = _normalize_plain_text_answer(result["result"])
-        if isinstance(result, dict):
-            # Single deterministic post-check hook: success-claim / negative-
-            # claim / cross-mailbox / scaffolding-leak / calendar-conflict
-            # (#2571) / attention-card (#2636) guards all live in
-            # answer_grounding.py.
+        if isinstance(result, dict) and result.get("result") != self._grounded_answer:
+            # Normally finalize_answer already grounded this text before the
+            # loop emitted it. This covers the branches that never reach that
+            # call — the loop setting an actionable answer on an internal error
+            # and returning it directly — without grounding the same text twice
+            # (the append-style guards would repeat their correction).
             result = ground_final_answer(result)
         return result
+
+    def finalize_answer(self, answer: str, conversation: Any) -> str:
+        """Ground the answer BEFORE the loop emits it (#2789).
+
+        Grounding used to run on ``process_query``'s return value, which the
+        REST/TUI stream never re-reads — so every correction fired, logged, and
+        reached nobody on the surface users actually drive.
+        """
+        grounded = ground_final_answer(
+            {"result": answer, "conversation": conversation, "status": "success"}
+        )
+        corrected = grounded.get("result")
+        self._grounded_answer = corrected if isinstance(corrected, str) else answer
+        return self._grounded_answer
 
     def _mailbox_target_guard(self, user_input: str) -> Optional[Dict[str, Any]]:
         """Reject a request that targets a mailbox the SESSION has ruled out (#2164).

--- a/hub/agents/email/python/gaia_agent_email/answer_grounding.py
+++ b/hub/agents/email/python/gaia_agent_email/answer_grounding.py
@@ -23,7 +23,7 @@ from __future__ import annotations
 import json
 import re
 import time
-from typing import Any, Dict, Iterator, List, Optional
+from typing import Any, Dict, Iterator, List, Optional, Tuple
 
 from gaia_agent_email.attention_cache import ATTENTION_CACHE_TTL_SECONDS
 from gaia_agent_email.attention_cache import peek as _peek_attention_cache
@@ -296,6 +296,169 @@ def strip_scaffolding_leaks(text: str) -> str:
     cleaned = _RAW_MESSAGE_ID_RE.sub("", cleaned)
     cleaned = decode_stray_unicode_escapes(cleaned)
     return cleaned.strip()
+
+
+# A numbered triage item at the start of a line -- the shape the list is
+# supposed to have, and the signal that this answer IS a triage list.
+# Tolerates the shapes a model reaches for around the number — a bullet, bold
+# markers, or both ("- **9.** …"). Missing one of them makes the rebuild below
+# think the reply has no list and append a second copy of it.
+_NUMBERED_ITEM_LINE_RE = re.compile(
+    r"^[ \t]*(?:[-*+•·][ \t]*)?\*{0,2}\d{1,3}\.\*{0,2}[ \t]", re.MULTILINE
+)
+
+# A numbered item that ran on mid-line instead of starting its own, e.g.
+# "...scheduling meetings: 4. Tomasz ... 5. Tomasz ...".
+_INLINE_NUMBERED_ITEM_RE = re.compile(r"(?<=\S)[ \t]+(?=\d{1,3}\.[ \t]+\S)")
+
+# A bare address on an item line. The sender is already named beside it, so
+# this renders as the address twice -- once as text, once as a mailto: link
+# the markdown renderer expands.
+# Any bare address on an item line, however the model punctuated around it.
+# An explicit mailto: link goes too — the markdown renderer expands a bare
+# address into one anyway, which is the duplication being removed.
+_ITEM_LINE_EMAIL_RE = re.compile(
+    r"[ \t]*\[?<?(?:mailto:)?[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}>?\]?"
+    r"(?:\((?:mailto:)?[^)]*\))?"
+)
+
+
+def normalize_triage_list(text: str) -> str:
+    """Give a numbered triage list the shape the skill asks for and the model
+    keeps missing: one item per line, no duplicated sender address.
+
+    Formatting a list the tool already computed is not a judgement call, so it
+    is enforced here rather than requested in the prompt — three consecutive
+    live runs showed the instruction alone does not hold. Applies only to an
+    answer that already contains a numbered item at the start of a line, so
+    ordinary prose that happens to say "in 5. Then" is untouched.
+    """
+    if not text or not _NUMBERED_ITEM_LINE_RE.search(text):
+        return text
+    out = _INLINE_NUMBERED_ITEM_RE.sub("\n", text)
+    out = "\n".join(
+        _ITEM_LINE_EMAIL_RE.sub("", line) if _NUMBERED_ITEM_LINE_RE.match(line) else line
+        for line in out.split("\n")
+    )
+    return out
+
+
+# needs_you ``kind`` → the section it belongs under, in the order refs are
+# assigned (_NEEDS_YOU_KIND_ORDER, read_tools.py), so the numbers ascend down
+# the page without the renderer sorting anything.
+_TRIAGE_SECTIONS: List[Tuple[str, Tuple[str, ...]]] = [
+    ("Waiting on your reply", ("urgent", "waiting_on_you")),
+    ("Needs a response", ("needs_response",)),
+    ("Meetings to decide", ("meeting_request",)),
+    ("Needs a manual look", ("needs_review", "action_item")),
+]
+
+
+# ``needs_you.sender`` carries a display name, an address, or both. Only the
+# name is worth a row -- an address renders twice once the markdown renderer
+# turns it into a mailto: link.
+_SENDER_EMAIL_RE = re.compile(r"\s*<?([A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,})>?")
+
+
+def _sender_label(sender: Any) -> str:
+    text = str(sender or "").strip()
+    if not text:
+        return "unknown sender"
+    match = _SENDER_EMAIL_RE.search(text)
+    if match is None:
+        return text
+    name = _SENDER_EMAIL_RE.sub(" ", text).strip(" <>|,-–—")
+    # Address-only sender: keep it (the reader still needs to know who) but as
+    # code, so the renderer cannot autolink it into a duplicate.
+    return name or f"`{match.group(1)}`"
+
+
+def _age_phrase(age_seconds: Any) -> str:
+    if not isinstance(age_seconds, (int, float)) or age_seconds < 0:
+        return ""
+    days = int(age_seconds // 86400)
+    if days >= 1:
+        return f"{days}d ago"
+    hours = int(age_seconds // 3600)
+    return f"{hours}h ago" if hours >= 1 else "just now"
+
+
+def render_needs_you_list(envelope: Dict[str, Any]) -> str:
+    """Build the numbered triage list straight from ``needs_you``.
+
+    The list is entirely determined by the tool's own output — every field is
+    already computed, and the refs are already in display order — so composing
+    it is not a judgement the model should be making. Five consecutive live
+    runs had it drop items, renumber them, merge sections, or answer with
+    totals alone; none of those are possible here.
+    """
+    items = envelope.get("needs_you") or []
+    if not items:
+        return ""
+    by_kind: Dict[str, List[Dict[str, Any]]] = {}
+    for item in items:
+        by_kind.setdefault(str(item.get("kind") or ""), []).append(item)
+
+    blocks: List[str] = []
+    for heading, kinds in _TRIAGE_SECTIONS:
+        rows = [row for kind in kinds for row in by_kind.get(kind, [])]
+        if not rows:
+            continue
+        rows.sort(key=lambda r: r.get("ref") or 0)
+        lines = [f"### {heading}", ""]
+        for row in rows:
+            who = _sender_label(row.get("sender"))
+            what = str(row.get("subject") or "").strip() or "(no subject)"
+            # ``why`` is the classifier's own reason for the row, not chat-model
+            # embellishment, so it survives the rewrite.
+            notes = [
+                n
+                for n in (_age_phrase(row.get("age_seconds")), str(row.get("why") or "").strip())
+                if n
+            ]
+            suffix = f" ({' · '.join(notes)})" if notes else ""
+            lines.append(f"{row.get('ref')}. {who} — {what}{suffix}")
+        blocks.append("\n".join(lines))
+    return "\n\n".join(blocks)
+
+
+def _lead_paragraph(text: str) -> str:
+    """The answer's opening prose — the one part still worth asking a model for.
+
+    Skips headings and any block that has already turned into a list, so a
+    reply that opens straight into items contributes no lead at all rather
+    than half a list.
+    """
+    for block in (text or "").split("\n\n"):
+        candidate = block.strip()
+        if not candidate or candidate.startswith("#"):
+            continue
+        if _NUMBERED_ITEM_LINE_RE.search(candidate):
+            break
+        return candidate
+    return ""
+
+
+def rewrite_triage_answer(
+    final_answer: str, conversation: Optional[List[Dict[str, Any]]]
+) -> str:
+    """Replace a triage reply's list with one built from the scan itself.
+
+    The categories are still model judgement — a heuristic, then the
+    ``specific-ai-triage`` SLM, then an LLM fallback, all inside
+    ``pre_scan_inbox``. What is NOT a judgement is transcribing the result,
+    and asking the chat model to do it produced invented numbering, dropped
+    items, merged sections, and once no list at all. So the chat model keeps
+    the opening sentence and this renders the rest.
+    """
+    prescan = last_tool_payload(conversation, "pre_scan_inbox")
+    if not prescan:
+        return final_answer
+    rendered = render_needs_you_list(prescan)
+    if not rendered:
+        return final_answer
+    lead = _lead_paragraph(final_answer) or _honest_prescan_summary(prescan)
+    return f"{lead}\n\n{rendered}"
 
 
 def _honest_prescan_summary(envelope: Dict[str, Any]) -> str:
@@ -693,6 +856,13 @@ def ground_final_answer(result: Dict[str, Any]) -> Dict[str, Any]:
 
     if find_scaffolding_leak(final_answer):
         final_answer = strip_scaffolding_leaks(final_answer)
+
+    final_answer = normalize_triage_list(final_answer)
+
+    # The list is tool output, not prose. Rendering it here rather than asking
+    # the model to retype it is what makes one list, correctly numbered, every
+    # time — see rewrite_triage_answer.
+    final_answer = rewrite_triage_answer(final_answer, conversation)
 
     success_claim = find_ungrounded_success_claim(final_answer, conversation)
     if success_claim:

--- a/hub/agents/email/python/gaia_agent_email/answer_grounding.py
+++ b/hub/agents/email/python/gaia_agent_email/answer_grounding.py
@@ -311,12 +311,10 @@ _NUMBERED_ITEM_LINE_RE = re.compile(
 # "...scheduling meetings: 4. Tomasz ... 5. Tomasz ...".
 _INLINE_NUMBERED_ITEM_RE = re.compile(r"(?<=\S)[ \t]+(?=\d{1,3}\.[ \t]+\S)")
 
-# A bare address on an item line. The sender is already named beside it, so
-# this renders as the address twice -- once as text, once as a mailto: link
-# the markdown renderer expands.
 # Any bare address on an item line, however the model punctuated around it.
-# An explicit mailto: link goes too — the markdown renderer expands a bare
-# address into one anyway, which is the duplication being removed.
+# The sender is already named beside it, so a bare address renders twice --
+# once as text, once as the mailto: link the markdown renderer expands. An
+# explicit mailto: link goes too, for the same reason.
 _ITEM_LINE_EMAIL_RE = re.compile(
     r"[ \t]*\[?<?(?:mailto:)?[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}>?\]?"
     r"(?:\((?:mailto:)?[^)]*\))?"
@@ -450,6 +448,15 @@ def rewrite_triage_answer(
     and asking the chat model to do it produced invented numbering, dropped
     items, merged sections, and once no list at all. So the chat model keeps
     the opening sentence and this renders the rest.
+
+    Deliberately keyed on tool PRESENCE, not on parsing the user's question:
+    any turn that calls ``pre_scan_inbox`` gets the authoritative list, even
+    for a narrower ask ("how many urgent emails do I have?"). A hand-
+    summarized partial view is exactly the failure mode this function
+    replaces, and ``pre_scan_inbox`` only ever runs when the model judged
+    the question worth a scan in the first place — so a rewrite here is
+    never wrong, only sometimes more complete than the question strictly
+    asked for.
     """
     prescan = last_tool_payload(conversation, "pre_scan_inbox")
     if not prescan:

--- a/hub/agents/email/python/gaia_agent_email/skills/inbox-triage/SKILL.md
+++ b/hub/agents/email/python/gaia_agent_email/skills/inbox-triage/SKILL.md
@@ -25,9 +25,10 @@ Triage answers one question per message: **does a human have to act on this?**
 - Act on the reversible end only — mark read, star, label, archive. Reply, send,
   and delete are proposals the user confirms.
 
-**Report** the reply-needed count first, then one line each: sender, what they
-want, how old. Summarise the rest as counts. Nothing needing a reply is a
-one-sentence answer.
+**Report** one opening sentence and stop: how many items need attention, and
+how much of the mailbox was scanned. The numbered breakdown is rendered from
+the scan itself — do not write it out, and never re-list, renumber, or
+summarise those items yourself.
 
 Age beats volume. A thread the user already answered is handled. "URGENT" in a
 subject line is a claim, not a fact.

--- a/hub/agents/email/python/gaia_agent_email/sse_translation.py
+++ b/hub/agents/email/python/gaia_agent_email/sse_translation.py
@@ -59,7 +59,11 @@ from typing import Any, Dict, List, Optional
 # (``test_render_tool_to_lang_maps_stay_in_sync``) pins the two dicts equal so
 # this duplication can't silently drift.
 _RENDER_TOOL_TO_LANG: Dict[str, str] = {
-    "pre_scan_inbox": "email_pre_scan",
+    # ``pre_scan_inbox`` deliberately draws NO card: it landed mid-turn as a
+    # partial list while the model was still writing the full triage answer,
+    # so the user read two overlapping views of one inbox and could not tell
+    # which to act on. The triage reply is the single view; refs still resolve
+    # from tool data (``resolve_needs_you_reference``), not from a render.
     # #2765: a generic ``table`` card (no new client code) so the thread
     # view renders straight from tool data instead of model prose.
     "get_thread": "table",

--- a/hub/agents/email/python/gaia_agent_email/tools/read_tools.py
+++ b/hub/agents/email/python/gaia_agent_email/tools/read_tools.py
@@ -1587,9 +1587,11 @@ PRE_SCAN_ARCHIVE_CAP = 10
 # reaches the caller via ``totals["needs_review"]``.
 PRE_SCAN_NEEDS_REVIEW_CAP = 5
 
-# #2743 — the "one card" worklist. Capped small on purpose: a triage card
-# listing 30 rows is a report, not a worklist a person can act on today.
-NEEDS_YOU_CAP = 5
+# #2743 — the "one card" worklist. Still capped well below the inbox: a
+# worklist of 30 rows is a report nobody acts on. Raised from 5 so the
+# needs-a-look bucket carries a ``ref`` too — an item the user can see but
+# not name is one they cannot ask the agent to act on.
+NEEDS_YOU_CAP = 10
 
 # Filter-test ids for BulkSummary.filter_tests (#2743) — ids, never prose
 # (see contract.py's NeedsYouItem/BulkSummary docstrings): a renderer maps

--- a/hub/agents/email/python/tests/test_answer_grounding.py
+++ b/hub/agents/email/python/tests/test_answer_grounding.py
@@ -29,6 +29,7 @@ two cannot drift apart silently.
 from __future__ import annotations
 
 import json
+import re
 import sys
 import time
 from pathlib import Path
@@ -58,6 +59,9 @@ from gaia_agent_email.answer_grounding import (  # noqa: E402
     find_unlicensed_cross_mailbox_claim,
     find_unqualified_negative_claim,
     ground_final_answer,
+    normalize_triage_list,
+    render_needs_you_list,
+    rewrite_triage_answer,
     strip_scaffolding_leaks,
     tools_called_this_turn,
 )
@@ -433,6 +437,150 @@ class TestStripScaffoldingLeaks:
     def test_leaves_clean_text_unchanged_apart_from_whitespace_trim(self):
         clean = "Two newsletters look safe to archive."
         assert strip_scaffolding_leaks(clean) == clean
+
+
+# ---------------------------------------------------------------------------
+# render_needs_you_list / rewrite_triage_answer — the triage list is rendered
+# from the scan's own needs_you view, never retyped by the model (#2789
+# follow-up: three consecutive live runs invented numbering, dropped items,
+# or merged sections when the model was asked to write the list itself).
+# ---------------------------------------------------------------------------
+
+
+def _needs_you_row(ref: int, kind: str, **overrides) -> dict:
+    base = {
+        "ref": ref,
+        "kind": kind,
+        "message_id": f"m{ref}",
+        "thread_id": f"t{ref}",
+        "sender": "Someone <someone@example.com>",
+        "subject": f"subject {ref}",
+        "age_seconds": 3600,
+        "why": "",
+        "detail": [],
+        "due_hint": None,
+        "mailbox": None,
+    }
+    base.update(overrides)
+    return base
+
+
+class TestRenderNeedsYouList:
+    def test_empty_needs_you_renders_nothing(self):
+        assert render_needs_you_list(_prescan_envelope(needs_you=[])) == ""
+        assert render_needs_you_list({}) == ""
+
+    def test_sections_appear_in_display_order_with_ascending_refs(self):
+        envelope = _prescan_envelope(
+            needs_you=[
+                _needs_you_row(1, "waiting_on_you"),
+                _needs_you_row(2, "needs_response"),
+                _needs_you_row(3, "meeting_request"),
+                _needs_you_row(4, "needs_review"),
+            ]
+        )
+        rendered = render_needs_you_list(envelope)
+        # Every section header appears, in _TRIAGE_SECTIONS order.
+        for heading in (
+            "Waiting on your reply",
+            "Needs a response",
+            "Meetings to decide",
+            "Needs a manual look",
+        ):
+            assert heading in rendered
+        assert rendered.index("Waiting on your reply") < rendered.index("Needs a response")
+        assert rendered.index("Needs a response") < rendered.index("Meetings to decide")
+        assert rendered.index("Meetings to decide") < rendered.index("Needs a manual look")
+        # Refs ascend in the order they appear on the page, unbroken.
+        seen_refs = [int(tok) for tok in re.findall(r"^(\d+)\.", rendered, re.MULTILINE)]
+        assert seen_refs == [1, 2, 3, 4]
+
+    def test_urgent_and_waiting_on_you_share_one_reply_section(self):
+        # Both kinds render as REPLY (verbForKind, tui/cards/emailprescan.go) —
+        # a separate heading per kind would split one verb into two sections.
+        envelope = _prescan_envelope(
+            needs_you=[
+                _needs_you_row(1, "urgent"),
+                _needs_you_row(2, "waiting_on_you"),
+            ]
+        )
+        rendered = render_needs_you_list(envelope)
+        assert rendered.count("Waiting on your reply") == 1
+
+    def test_each_item_carries_its_classifier_reason(self):
+        envelope = _prescan_envelope(
+            needs_you=[
+                _needs_you_row(1, "needs_response", why="flagged as phishing"),
+            ]
+        )
+        assert "flagged as phishing" in render_needs_you_list(envelope)
+
+    def test_sender_address_is_dropped_when_a_display_name_exists(self):
+        envelope = _prescan_envelope(
+            needs_you=[
+                _needs_you_row(1, "waiting_on_you", sender="Jane Doe <jane@example.com>")
+            ]
+        )
+        rendered = render_needs_you_list(envelope)
+        assert "Jane Doe" in rendered
+        assert "jane@example.com" not in rendered
+
+    def test_address_only_sender_is_kept_but_not_autolinkable(self):
+        envelope = _prescan_envelope(
+            needs_you=[_needs_you_row(1, "waiting_on_you", sender="jane@example.com")]
+        )
+        rendered = render_needs_you_list(envelope)
+        assert "`jane@example.com`" in rendered
+
+
+class TestRewriteTriageAnswer:
+    def test_no_pre_scan_tool_call_leaves_the_answer_untouched(self):
+        text = "You have no new mail today."
+        assert rewrite_triage_answer(text, conversation=[]) == text
+
+    def test_pre_scan_with_no_needs_you_items_leaves_the_answer_untouched(self):
+        conversation = [_tool_entry("pre_scan_inbox", _prescan_envelope(needs_you=[]))]
+        text = "Your inbox is clear."
+        assert rewrite_triage_answer(text, conversation) == text
+
+    def test_the_models_own_list_is_discarded_in_favor_of_the_rendered_one(self):
+        envelope = _prescan_envelope(
+            needs_you=[_needs_you_row(1, "waiting_on_you", subject="Re: Q3 roadmap")]
+        )
+        conversation = [_tool_entry("pre_scan_inbox", envelope)]
+        model_answer = (
+            "Here's your inbox — 1 item needs attention.\n\n"
+            "### Stuff\n- **9.** a row the model invented\n- **3.** a duplicate"
+        )
+        out = rewrite_triage_answer(model_answer, conversation)
+        assert "the model invented" not in out
+        assert "1." in out and "Re: Q3 roadmap" in out
+        # The opening sentence survives; only the list is replaced.
+        assert out.startswith("Here's your inbox — 1 item needs attention.")
+
+
+class TestNormalizeTriageList:
+    def test_ordinary_prose_is_untouched(self):
+        prose = "We looked at 5. Then we stopped."
+        assert normalize_triage_list(prose) == prose
+
+    def test_run_on_items_are_split_onto_their_own_line(self):
+        # normalize_triage_list only activates once the text already contains
+        # a line-start numbered item (the signal that this IS a triage list);
+        # item 3 provides that, item 4/5 are the run-on fragment being fixed.
+        text = (
+            "3. Carol: Q3 roadmap\n"
+            "These emails propose scheduling: 4.  Alice: 30 minutes? 5.  Bob: Design review"
+        )
+        out = normalize_triage_list(text)
+        assert "\n4." in out
+        assert "\n5." in out
+
+    def test_duplicated_address_is_stripped_from_a_numbered_line(self):
+        text = "1. Tomasz Testingiewicz tomasz.t@outlook.com - Re: Partnership intro"
+        out = normalize_triage_list(text)
+        assert "tomasz.t@outlook.com" not in out
+        assert "Tomasz Testingiewicz" in out
 
 
 class TestDecodeStrayUnicodeEscapes:
@@ -1077,6 +1225,50 @@ class TestProcessQueryWiring:
             ):
                 out = agent.process_query("pre-scan my inbox")
             assert out["result"] == text
+        finally:
+            agent.close_db()
+
+    def test_finalize_answer_grounds_the_text_the_loop_will_emit(self, tmp_path):
+        # #2789: grounding used to run only on process_query's return value,
+        # which the SSE/TUI stream never re-reads. finalize_answer is the
+        # hook the agent LOOP calls before it emits anything, so this must
+        # ground on its own, with no process_query involved at all.
+        agent = _build_agent(tmp_path)
+        try:
+            conversation = [{"role": "user", "content": "archive it"}]
+            out = agent.finalize_answer("The message has been archived.", conversation)
+            assert out == UNGROUNDED_SUCCESS_FALLBACK
+            assert agent._grounded_answer == UNGROUNDED_SUCCESS_FALLBACK
+        finally:
+            agent.close_db()
+
+    def test_process_query_does_not_re_ground_what_finalize_answer_already_did(
+        self, tmp_path
+    ):
+        # An append-style guard (attention-card) makes a double-fire visible: if
+        # process_query's fallback re-ran ground_final_answer on text
+        # finalize_answer already corrected, the correction would appear twice.
+        _store_attention_view(items=[_attention_item("action_item")], scanned=7)
+        agent = _build_agent(tmp_path)
+        try:
+            conversation = [{"role": "user", "content": "anything need my attention?"}]
+            grounded_by_loop = agent.finalize_answer(
+                "No urgent or actionable items found.", conversation
+            )
+            assert grounded_by_loop.count("attention card") == 1
+
+            canned = {
+                "status": "success",
+                "result": grounded_by_loop,
+                "conversation": conversation,
+                "steps_taken": 1,
+            }
+            with patch(
+                "gaia.agents.base.agent.Agent.process_query", return_value=canned
+            ):
+                out = agent.process_query("anything need my attention?")
+            assert out["result"] == grounded_by_loop
+            assert out["result"].count("attention card") == 1
         finally:
             agent.close_db()
 

--- a/hub/agents/email/python/tests/test_needs_you_2743.py
+++ b/hub/agents/email/python/tests/test_needs_you_2743.py
@@ -270,18 +270,18 @@ class TestNeedsYouOrdering:
 
 
 class TestNeedsYouCap:
-    def test_capped_at_five_with_honest_total(self):
+    def test_capped_with_honest_total(self):
         gmail = FakeGmailBackend(user_email="me@example.com")
         mapping = {}
-        for i in range(7):
+        for i in range(14):
             msg_id = f"urgent-{i}"
             gmail.add_message(_msg(msg_id, internal_date=str(1700000000000 + i)))
             mapping[msg_id] = CATEGORY_URGENT
         out = pre_scan_inbox_impl(
-            gmail, max_messages=10, slm_classifier=_slm_by_id(mapping)
+            gmail, max_messages=20, slm_classifier=_slm_by_id(mapping)
         )
-        assert len(out["needs_you"]) == NEEDS_YOU_CAP == 5
-        assert out["needs_you_total"] == 7
+        assert len(out["needs_you"]) == NEEDS_YOU_CAP == 10
+        assert out["needs_you_total"] == 14
 
 
 class TestBulkFilterTests:

--- a/hub/agents/email/python/tests/test_render_tool_to_lang_sync_2765.py
+++ b/hub/agents/email/python/tests/test_render_tool_to_lang_sync_2765.py
@@ -42,8 +42,18 @@ from gaia.ui.sse_handler import SSEOutputHandler  # noqa: E402
 
 
 class TestRenderToolToLangMapsStayInSync:
-    def test_render_tool_to_lang_maps_stay_in_sync(self):
-        assert _SIDECAR_MAP == SSEOutputHandler._RENDER_TOOL_TO_LANG
+    def test_render_tool_to_lang_maps_differ_only_by_the_pre_scan_card(self):
+        """The two maps are deliberately no longer identical: the TUI drops
+        the pre-scan card so the triage reply is its single inbox view, while
+        the Agent UI — a different surface, not retested here — keeps it.
+        Pinned as an explicit, single-key difference so any OTHER drift still
+        fails."""
+        assert set(SSEOutputHandler._RENDER_TOOL_TO_LANG) - set(_SIDECAR_MAP) == {
+            "pre_scan_inbox"
+        }
+        assert not set(_SIDECAR_MAP) - set(SSEOutputHandler._RENDER_TOOL_TO_LANG)
+        for tool, lang in _SIDECAR_MAP.items():
+            assert SSEOutputHandler._RENDER_TOOL_TO_LANG[tool] == lang
 
     def test_get_thread_is_registered_as_a_table_card_on_both_sides(self):
         """#2765: get_thread must render a card on EITHER surface reaching

--- a/hub/agents/email/python/tests/test_sse_translation.py
+++ b/hub/agents/email/python/tests/test_sse_translation.py
@@ -193,12 +193,14 @@ def test_tool_result_carries_tool_and_data():
     ]
 
 
-def test_tool_result_render_key_for_pre_scan():
+def test_pre_scan_draws_no_card():
+    """The triage reply is the single inbox view: a pre-scan card landing
+    mid-turn showed a partial list beside the answer still being written."""
     t = _tr()
     t.translate({"type": "tool_start", "tool": "pre_scan_inbox"})
     t.translate({"type": "tool_args", "tool": "pre_scan_inbox", "args": {}})
     out = t.translate({"type": "tool_result", "title": "Result", "summary": "scan"})
-    assert out[0]["render"] == "email_pre_scan"
+    assert "render" not in out[0]
 
 
 def test_tool_end_after_result_is_dropped():

--- a/src/gaia/agents/base/agent.py
+++ b/src/gaia/agents/base/agent.py
@@ -3325,7 +3325,7 @@ Do NOT wrap conversational replies in JSON.
         cancelled = getattr(self.console, "cancelled", None)
         return cancelled is not None and cancelled.is_set()
 
-    def finalize_answer(self, answer: str, conversation: Any) -> str:
+    def finalize_answer(self, answer: str, _conversation: Any) -> str:
         """Last chance to correct the final answer, BEFORE it is emitted.
 
         Runs ahead of ``console.print_final_answer``, so a subclass's

--- a/src/gaia/agents/base/agent.py
+++ b/src/gaia/agents/base/agent.py
@@ -3325,6 +3325,18 @@ Do NOT wrap conversational replies in JSON.
         cancelled = getattr(self.console, "cancelled", None)
         return cancelled is not None and cancelled.is_set()
 
+    def finalize_answer(self, answer: str, conversation: Any) -> str:
+        """Last chance to correct the final answer, BEFORE it is emitted.
+
+        Runs ahead of ``console.print_final_answer``, so a subclass's
+        correction reaches every consumer — the SSE ``answer`` event the TUI
+        renders, the CLI console, and ``process_query``'s return value — rather
+        than only the callers that re-read the return dict (#2789).
+
+        Identity by default; override to post-process.
+        """
+        return answer
+
     def process_query(
         self,
         user_input: str,
@@ -5286,7 +5298,7 @@ Do NOT wrap conversational replies in JSON.
                             "start GAIA with the `--sd` flag to enable it."
                         )
 
-                final_answer = answer_candidate
+                final_answer = self.finalize_answer(answer_candidate, conversation)
                 self.execution_state = self.STATE_COMPLETION
                 self.console.print_final_answer(final_answer, streaming=self.streaming)
                 break

--- a/tui/internal/ui/cards/bounds_test.go
+++ b/tui/internal/ui/cards/bounds_test.go
@@ -112,8 +112,8 @@ func TestPreScanHeightIsBoundedAtNarrowWidths(t *testing.T) {
 		if len(lines) > maxCardLines*2 {
 			t.Errorf("width %d produced %d lines, want at most %d", w, len(lines), maxCardLines*2)
 		}
-		if !strings.Contains(plain(out), "NEEDS YOU") {
-			t.Errorf("width %d dropped the NEEDS YOU section", w)
+		if !strings.Contains(plain(out), "NEEDS A REPLY") {
+			t.Errorf("width %d dropped the NEEDS A REPLY section", w)
 		}
 	}
 }

--- a/tui/internal/ui/cards/emailprescan.go
+++ b/tui/internal/ui/cards/emailprescan.go
@@ -249,11 +249,25 @@ func renderEmailPreScan(data json.RawMessage, width int, seen map[string]bool) (
 
 	showMailbox := p.multiMailbox()
 	footer := p.footerLines()
-	budget := maxCardRows - len(b.lines)
+	// Reserve the header + separator row each extra section costs beyond the
+	// single header the flat render used, so grouping can never push the card
+	// past maxCardRows.
+	budget := maxCardRows - len(b.lines) - (countVerbGroups(p.NeedsYou)-1)*2
 	show, keepDetail, shownFooter := p.fitNeedsYou(b, showMailbox, footer, budget)
 
-	b.sectionHeader("NEEDS YOU", p.needsYouCountLabel(show))
+	prevVerb := ""
 	for i := 0; i < show; i++ {
+		if verb := verbForKind(p.NeedsYou[i].Kind); verb != prevVerb {
+			if prevVerb != "" {
+				b.blank()
+			}
+			count := ""
+			if prevVerb == "" {
+				count = p.needsYouCountLabel(show)
+			}
+			b.sectionHeader(sectionLabelForVerb(verb), count)
+			prevVerb = verb
+		}
 		p.needsYouRow(b, p.NeedsYou[i], showMailbox, keepDetail[i])
 	}
 	if extra := p.NeedsYouTotal - show; extra > 0 {
@@ -315,6 +329,40 @@ func renderMailboxErrorBanner(b *box, errs []mailboxError) {
 // "the renderer maps kind to a verb label at render time; the wire only
 // carries the source signal"). An unrecognized kind (a future server
 // addition this client predates) still gets a verb, never a blank one.
+// sectionLabelForVerb names the group a verb heads. The wire carries only
+// provenance (kind); both the verb and this heading are render-time lookups,
+// so a future server kind still lands under a heading rather than none.
+func sectionLabelForVerb(verb string) string {
+	switch verb {
+	case "REPLY":
+		return "NEEDS A REPLY"
+	case "DECIDE":
+		return "NEEDS A DECISION"
+	case "CHECK":
+		return "WORTH A LOOK"
+	case "DO":
+		return "YOUR TASKS"
+	default:
+		return "NEEDS YOU"
+	}
+}
+
+// countVerbGroups counts the runs of same-verb items. Items arrive already
+// ordered by kind (_NEEDS_YOU_KIND_ORDER, read_tools.py), so verbs are
+// contiguous and a run count equals the number of section headers the render
+// will emit -- counting runs rather than distinct verbs keeps that true even
+// if a future ordering interleaves them.
+func countVerbGroups(items []needsYouItem) int {
+	groups, prev := 0, ""
+	for _, it := range items {
+		if v := verbForKind(it.Kind); v != prev {
+			groups++
+			prev = v
+		}
+	}
+	return groups
+}
+
 func verbForKind(kind string) string {
 	switch kind {
 	case "urgent", "waiting_on_you", "needs_response":

--- a/tui/internal/ui/cards/emailprescan_test.go
+++ b/tui/internal/ui/cards/emailprescan_test.go
@@ -20,7 +20,7 @@ func TestPreScanPopulated(t *testing.T) {
 		"┌─ Inbox ",
 		"15 inbox messages scanned",
 		// Section is one worklist, not four buckets (#2743).
-		"NEEDS YOU",
+		"NEEDS A REPLY",
 		// Verb labels, mapped from kind -- REPLY covers urgent/waiting_on_you/needs_response.
 		"REPLY",
 		// Display name is extracted from the raw From header.
@@ -54,7 +54,7 @@ func TestPreScanEmptyState(t *testing.T) {
 		"none of them named a deadline",
 	)
 	// No worklist header for a genuinely empty scan.
-	assertNotContains(t, out, "NEEDS YOU")
+	assertNotContains(t, out, "NEEDS A REPLY")
 	assertNotContains(t, out, "Nothing needs you.")
 }
 
@@ -110,7 +110,7 @@ func TestPreScanCapsHitShowsNofM(t *testing.T) {
 	// needs_you is capped at 5 server-side while needs_you_total (40)
 	// reports the true pre-cap count -- the header must read "5 of 40"
 	// rather than a bare count that implies the list is everything.
-	assertContains(t, out, "NEEDS YOU", "5 of 40")
+	assertContains(t, out, "NEEDS A REPLY", "5 of 40")
 }
 
 func TestPreScanUncappedShowsBareCount(t *testing.T) {
@@ -132,7 +132,7 @@ func TestPreScanMailboxErrorsBanner(t *testing.T) {
 		"[!] Outlook wasn't scanned: token expired",
 		"Results below are unaffected.",
 		// Results that DID arrive are still shown.
-		"NEEDS YOU", "Sarah Chen", "Prod incident",
+		"NEEDS A REPLY", "Sarah Chen", "Prod incident",
 		// Rows are tagged with their account, because more than one is in play.
 		"Gmail · Sarah Chen", "Outlook ·",
 	)
@@ -158,15 +158,15 @@ func TestPreScanMissingNeedsYouTotalFallsBackToListLength(t *testing.T) {
 	out := Render("email_pre_scan", data, width80)
 	assertWidth(t, out, width80)
 	// A missing needs_you_total decodes as its zero value (0), which is not
-	// greater than the 5 shown -- so the "NEEDS YOU" section header falls
+	// greater than the 5 shown -- so the "NEEDS A REPLY" section header falls
 	// back to a bare count rather than claiming a hidden tail that was
 	// never reported. Checked against the header specifically, not a bare
 	// " of " substring -- the bulk line's own falsifiable phrasing ("none
 	// OF them asked...") legitimately contains that substring too.
-	if headers := sectionHeaderCounts(t, plain(out), "NEEDS YOU"); headers != "5" {
-		t.Errorf("NEEDS YOU header = %q, want a bare \"5\" with no hidden tail", headers)
+	if headers := sectionHeaderCounts(t, plain(out), "NEEDS A REPLY"); headers != "5" {
+		t.Errorf("NEEDS A REPLY header = %q, want a bare \"5\" with no hidden tail", headers)
 	}
-	assertContains(t, out, "NEEDS YOU", "Sarah Chen")
+	assertContains(t, out, "NEEDS A REPLY", "Sarah Chen")
 }
 
 // sectionHeaderCounts reads the count text off a section header line (the
@@ -219,8 +219,8 @@ func TestPreScanDegradesAtNarrowWidth(t *testing.T) {
 	for _, w := range []int{20, 24, 32, 40, 60, 76, 120} {
 		out := Render("email_pre_scan", raw(t, populatedPreScan), w)
 		assertWidth(t, out, w)
-		if !strings.Contains(plain(out), "NEEDS YOU") {
-			t.Errorf("width %d dropped the NEEDS YOU section:\n%s", w, plain(out))
+		if !strings.Contains(plain(out), "NEEDS A REPLY") {
+			t.Errorf("width %d dropped the NEEDS A REPLY section:\n%s", w, plain(out))
 		}
 	}
 }

--- a/tui/internal/ui/cards/emailprescan_test.go
+++ b/tui/internal/ui/cards/emailprescan_test.go
@@ -107,9 +107,9 @@ func TestPreScanCapsHitShowsNofM(t *testing.T) {
 	t.Logf("\n%s", plain(out))
 
 	assertWidth(t, out, width80)
-	// needs_you is capped at 5 server-side while needs_you_total (40)
-	// reports the true pre-cap count -- the header must read "5 of 40"
-	// rather than a bare count that implies the list is everything.
+	// The fixture ships fewer needs_you rows (5) than needs_you_total (40)
+	// reports -- the header must read "5 of 40" rather than a bare count
+	// that implies the list is everything.
 	assertContains(t, out, "NEEDS A REPLY", "5 of 40")
 }
 

--- a/tui/internal/ui/cards/testdata_test.go
+++ b/tui/internal/ui/cards/testdata_test.go
@@ -46,9 +46,10 @@ const populatedPreScan = `{
   }
 }`
 
-// capsHitPreScan: needs_you is at its server-side cap of 5 while
-// needs_you_total reports the real pre-cap count, so the header must read
-// "5 of 40".
+// capsHitPreScan: needs_you carries fewer rows (5) than needs_you_total (40)
+// reports as the real pre-cap count -- NEEDS_YOU_CAP is 10 server-side, so
+// this fixture demonstrates the header reading "N of M" honestly whenever
+// N < M, without needing to hit the cap exactly.
 const capsHitPreScan = `{
   "kind": "email_pre_scan",
   "urgent": [], "actionable": [], "informational_count": 4,

--- a/tui/internal/ui/chat/cards_test.go
+++ b/tui/internal/ui/chat/cards_test.go
@@ -66,7 +66,7 @@ func TestToolResultWithRenderDrawsACard(t *testing.T) {
 
 	rendered := ansi.Strip(m.renderMessage(card, nil))
 	t.Logf("\n%s", rendered)
-	for _, want := range []string{"Inbox", "9 inbox messages scanned", "NEEDS YOU", "REPLY", "Sarah Chen", "asked for a reply by Friday"} {
+	for _, want := range []string{"Inbox", "9 inbox messages scanned", "NEEDS A REPLY", "REPLY", "Sarah Chen", "asked for a reply by Friday"} {
 		if !strings.Contains(rendered, want) {
 			t.Errorf("card render missing %q:\n%s", want, rendered)
 		}
@@ -129,7 +129,7 @@ func TestCardRendersInlineAboveTheLiveRegion(t *testing.T) {
 	m.updateViewport()
 
 	view := ansi.Strip(m.viewport.View())
-	cardAt := strings.Index(view, "NEEDS YOU")
+	cardAt := strings.Index(view, "NEEDS A REPLY")
 	liveAt := strings.Index(view, "archive_messages")
 	if cardAt < 0 || liveAt < 0 {
 		t.Fatalf("expected both the card and the live region in the viewport:\n%s", view)

--- a/tui/internal/ui/chat/message.go
+++ b/tui/internal/ui/chat/message.go
@@ -39,14 +39,11 @@ type Message struct {
 	// Identity marks a RoleCard message as the ONE singular card of its
 	// kind per turn-sequence (#2743) -- today only the email pre-scan card,
 	// which can arrive from two independent sources (a typed turn's
-	// tool_result, or the on-open pre-scan fetch) that must replace the
-	// SAME logical card rather than each appending its own. A refresh moves
-	// the card to the tail of the transcript rather than updating it where
-	// it was first drawn (#2829) -- see ChatModel.upsertCard. Empty for
-	// every other card, which always appends. Looked up by identity, not by
-	// a tracked index: `/clear` sets ChatModel.messages to nil (model.go),
-	// so a stale index would panic or silently overwrite an unrelated
-	// message.
+	// tool_result, or the on-open pre-scan fetch) that must update the SAME
+	// message in place rather than each appending its own. Empty for every
+	// other card, which always appends. Looked up by identity, not by a
+	// tracked index: `/clear` sets ChatModel.messages to nil (model.go), so
+	// a stale index would panic or silently overwrite an unrelated message.
 	Identity string
 
 	// cardCache memoizes the drawn card. updateViewport re-renders every message

--- a/tui/internal/ui/chat/model.go
+++ b/tui/internal/ui/chat/model.go
@@ -230,12 +230,10 @@ func (m ChatModel) Init() tea.Cmd {
 		cmds = append(cmds, func() tea.Msg {
 			return sendQueryMsg{query: m.initialQuery}
 		})
-	} else if m.agentID == preScanAgentID {
-		// Rendered with no user prompt, on open (#2743, replacing the #2582
-		// attention fetch) — but only when there's no initial query already
-		// about to run a turn, so the pre-scan card never races the answer
-		// to what the user just asked.
-		cmds = append(cmds, m.fetchPreScan())
+		// The on-open pre-scan card (#2743) is gone: it spent a Gmail scan
+		// before the user asked for anything, and showed a shallower version
+		// of what "triage my inbox" answers properly a moment later. The
+		// card still renders when a turn's own pre_scan_inbox result arrives.
 	} else if m.debug && m.preScanGateMismatch() {
 		// A client that could serve the pre-scan view but an agentID that
 		// doesn't match must not fail with no signal at all.
@@ -283,25 +281,24 @@ func (m ChatModel) fetchPreScan() tea.Cmd {
 	}
 }
 
-// upsertCard draws a RoleCard message at the TAIL of the transcript, first
-// removing any earlier message with the same identity (#2743, moved #2829)
-// so there is still only ever one. Moving rather than updating in place
-// matters because the earliest draw is usually the on-open pre-scan fetch,
-// which sits above every user message -- an in-place update would keep
-// refreshing that card up there even when a later turn explicitly asked for
-// one, leaving the user's own question answered by prose only with the
-// card nowhere near it. Looked up by identity across the CURRENT m.messages
-// slice on every call, never a tracked index: `/clear` sets m.messages to
-// nil (see the "/clear" case below), so a stale index would panic or
-// silently overwrite an unrelated message. Building a fresh Message (rather
-// than mutating the old one) also means the render cache — otherwise keyed
-// on width alone — is never served the old message's stale layout.
+// upsertCard appends a RoleCard message, or — when identity is non-empty and
+// a message already carries it — replaces that message's payload in place
+// (#2743). Looked up by identity across the CURRENT m.messages slice on
+// every call, never a tracked index: `/clear` sets m.messages to nil
+// (see the "/clear" case below), so a stale index would panic or silently
+// overwrite an unrelated message. The render cache is cleared so an
+// in-place update is never served the stale layout (Message.cardCache is
+// otherwise keyed on width alone).
 func (m *ChatModel) upsertCard(identity, toolName, render string, data json.RawMessage) {
 	if identity != "" {
 		for i := range m.messages {
 			if m.messages[i].Role == RoleCard && m.messages[i].Identity == identity {
-				m.messages = append(m.messages[:i], m.messages[i+1:]...)
-				break
+				m.messages[i].ToolName = toolName
+				m.messages[i].Render = render
+				m.messages[i].Data = data
+				m.messages[i].cardCache = ""
+				m.messages[i].cardCacheWidth = 0
+				return
 			}
 		}
 	}

--- a/tui/internal/ui/chat/prescan_init_test.go
+++ b/tui/internal/ui/chat/prescan_init_test.go
@@ -62,7 +62,10 @@ func findBatchedMsg(cmd tea.Cmd, isWanted func(tea.Msg) bool) tea.Msg {
 	return nil
 }
 
-func TestFetchPreScanOnOpenForEmailAgentWithNoInitialQuery(t *testing.T) {
+func TestNoPreScanFetchOnOpenForEmailAgent(t *testing.T) {
+	// Opening the agent must cost nothing: the on-open pre-scan spent a Gmail
+	// scan before the user had asked for anything, and showed a shallower
+	// version of what "triage my inbox" answers a moment later.
 	c := &fakePreScanClient{data: json.RawMessage(samplePreScanJSON)}
 	m := newPreScanTestModel(t, c, "email", "")
 
@@ -71,12 +74,11 @@ func TestFetchPreScanOnOpenForEmailAgentWithNoInitialQuery(t *testing.T) {
 		_, ok := msg.(preScanFetchedMsg)
 		return ok
 	})
-	if found == nil {
-		t.Fatal("Init() did not dispatch a pre-scan fetch for the email agent with no initial query")
+	if found != nil {
+		t.Fatal("Init() dispatched a pre-scan fetch on open; the email agent must open with an empty transcript")
 	}
-	fetched := found.(preScanFetchedMsg)
-	if string(fetched.data) != samplePreScanJSON {
-		t.Errorf("fetched data = %s, want %s", fetched.data, samplePreScanJSON)
+	if c.fetchCalls != 0 {
+		t.Errorf("pre-scan fetch was called %d times on open; want 0", c.fetchCalls)
 	}
 }
 
@@ -98,7 +100,7 @@ func TestFetchPreScanSkippedWhenInitialQueryPresent(t *testing.T) {
 // drives the real constructor RunAgent calls, with a display name that
 // differs in case from the id, the way the catalog's real "email"/"Email"
 // entry does.
-func TestFetchPreScanOnOpenViaDirectCLIConstructionUsesCatalogID(t *testing.T) {
+func TestNoPreScanFetchViaDirectCLIConstruction(t *testing.T) {
 	c := &fakePreScanClient{data: json.RawMessage(samplePreScanJSON)}
 	m := NewChatModelForCatalogAgent(c, "email", "Email", false)
 	m.width, m.height = 100, 30
@@ -108,8 +110,8 @@ func TestFetchPreScanOnOpenViaDirectCLIConstructionUsesCatalogID(t *testing.T) {
 		_, ok := msg.(preScanFetchedMsg)
 		return ok
 	})
-	if found == nil {
-		t.Fatal("Init() did not dispatch a pre-scan fetch through the direct-CLI construction path (RunAgent)")
+	if found != nil {
+		t.Fatal("the direct-CLI construction path (RunAgent) still fetches a pre-scan on open")
 	}
 }
 
@@ -500,149 +502,5 @@ func TestPreScanCardCacheInvalidatesOnDataChangeNotOnlyOnResize(t *testing.T) {
 	rendered2 := m.messages[0].renderCard(w)
 	if strings.Contains(rendered2, "1 inbox messages scanned") || !strings.Contains(rendered2, "9 inbox messages scanned") {
 		t.Errorf("render at the same width served stale cached content after an in-place data update:\n%s", rendered2)
-	}
-}
-
-// ---------------------------------------------------------------------------
-// #2829 -- regression fix for #2757. Anchoring "the one card" to wherever it
-// was FIRST drawn was correct for the two-cards-that-disagreed bug #2757
-// fixed, but the on-open fetch draws first, at launch -- so a later
-// user-initiated "triage my inbox" kept refreshing that card above the
-// question, leaving the question itself answered by prose only. #2485
-// (before #2757) drew a card directly under the turn that produced it; that
-// placement is restored here for a refresh, while #2757's one-card property
-// (never two) is kept.
-// ---------------------------------------------------------------------------
-
-func TestUserTriggeredPreScanRefreshMovesTheCardBelowTheQuestion(t *testing.T) {
-	m, _ := newTestModel(t)
-
-	// The on-open card, drawn before any user message exists.
-	updated, _ := m.Update(preScanFetchedMsg{data: json.RawMessage(samplePreScanJSON)})
-	m = updated.(ChatModel)
-	if len(m.messages) != 1 || m.messages[0].Role != RoleCard {
-		t.Fatalf("test setup: want the on-open card as the only message, got %+v", m.messages)
-	}
-
-	// The user explicitly asks for a triage; the turn's OWN tool_result
-	// carries a fresh email_pre_scan card.
-	updated2, _ := m.Update(sendQueryMsg{query: "triage my inbox"})
-	m = updated2.(ChatModel)
-
-	freshData := json.RawMessage(`{"kind":"email_pre_scan","urgent":[],"actionable":[],"informational_count":0,"suggested_archives":[],"suggested_drafts":[],"needs_review":[],"scanned":32,"needs_you":[],"needs_you_total":6,"bulk":{"count":0,"filter_tests":[]}}`)
-	m = feed(t, m,
-		event.CanonicalToolResultEvent{
-			Type: "tool_result", Tool: "pre_scan_inbox",
-			Render: "email_pre_scan", Data: freshData,
-		},
-		event.CanonicalFinalEvent{Type: "final", Answer: "there are 6 items requiring your attention"},
-	)
-
-	userIdx, cardIdx, cardCount := -1, -1, 0
-	for i, msg := range m.messages {
-		if msg.Role == RoleUser && userIdx == -1 {
-			userIdx = i
-		}
-		if msg.Role == RoleCard && msg.Render == "email_pre_scan" {
-			cardIdx = i
-			cardCount++
-		}
-	}
-	if cardCount != 1 {
-		t.Fatalf("got %d pre-scan cards, want exactly 1 (#2757's property, kept): %+v", cardCount, m.messages)
-	}
-	if userIdx == -1 {
-		t.Fatalf("test setup: no user message found: %+v", m.messages)
-	}
-	if cardIdx < userIdx {
-		t.Errorf("card at index %d sits BEFORE the question at index %d that asked for it: %+v", cardIdx, userIdx, m.messages)
-	}
-	if string(m.messages[cardIdx].Data) != string(freshData) {
-		t.Errorf("card data = %s, want the turn's own fresh data %s", m.messages[cardIdx].Data, freshData)
-	}
-	if m.messages[cardIdx].cardCache != "" {
-		t.Error("the moved card kept a stale render cache instead of starting fresh")
-	}
-}
-
-// A second refresh must move the (already-moved) card again, to under the
-// SECOND question -- not leave it wherever the first refresh put it.
-func TestSecondUserTriggeredPreScanRefreshMovesAgain(t *testing.T) {
-	m, _ := newTestModel(t)
-
-	updated, _ := m.Update(preScanFetchedMsg{data: json.RawMessage(samplePreScanJSON)})
-	m = updated.(ChatModel)
-
-	firstData := json.RawMessage(`{"kind":"email_pre_scan","urgent":[],"actionable":[],"informational_count":0,"suggested_archives":[],"suggested_drafts":[],"needs_review":[],"scanned":10,"needs_you":[],"needs_you_total":1,"bulk":{"count":0,"filter_tests":[]}}`)
-	updated2, _ := m.Update(sendQueryMsg{query: "triage my inbox"})
-	m = updated2.(ChatModel)
-	m = feed(t, m,
-		event.CanonicalToolResultEvent{Type: "tool_result", Tool: "pre_scan_inbox", Render: "email_pre_scan", Data: firstData},
-		event.CanonicalFinalEvent{Type: "final", Answer: "1 item"},
-	)
-
-	secondData := json.RawMessage(`{"kind":"email_pre_scan","urgent":[],"actionable":[],"informational_count":0,"suggested_archives":[],"suggested_drafts":[],"needs_review":[],"scanned":20,"needs_you":[],"needs_you_total":2,"bulk":{"count":0,"filter_tests":[]}}`)
-	updated3, _ := m.Update(sendQueryMsg{query: "triage my inbox again"})
-	m = updated3.(ChatModel)
-	secondQuestionIdx := len(m.messages) - 1
-	m = feed(t, m,
-		event.CanonicalToolResultEvent{Type: "tool_result", Tool: "pre_scan_inbox", Render: "email_pre_scan", Data: secondData},
-		event.CanonicalFinalEvent{Type: "final", Answer: "2 items"},
-	)
-
-	cardIdx, cardCount := -1, 0
-	for i, msg := range m.messages {
-		if msg.Role == RoleCard && msg.Render == "email_pre_scan" {
-			cardIdx = i
-			cardCount++
-		}
-	}
-	if cardCount != 1 {
-		t.Fatalf("got %d pre-scan cards, want exactly 1: %+v", cardCount, m.messages)
-	}
-	if cardIdx < secondQuestionIdx {
-		t.Errorf("card at index %d sits before the SECOND question at index %d -- it stayed where the first refresh left it: %+v", cardIdx, secondQuestionIdx, m.messages)
-	}
-	if string(m.messages[cardIdx].Data) != string(secondData) {
-		t.Errorf("card data = %s, want the second turn's data %s", m.messages[cardIdx].Data, secondData)
-	}
-}
-
-// /clear drops the whole transcript, including any pre-scan card wherever it
-// was; the next pre-scan (on-open or user-triggered) must still yield
-// exactly one card, not zero and not two.
-func TestClearThenFreshPreScanYieldsExactlyOneCard(t *testing.T) {
-	m, _ := newTestModel(t)
-
-	updated, _ := m.Update(preScanFetchedMsg{data: json.RawMessage(samplePreScanJSON)})
-	m = updated.(ChatModel)
-	updated2, _ := m.Update(sendQueryMsg{query: "triage my inbox"})
-	m = updated2.(ChatModel)
-	m = feed(t, m,
-		event.CanonicalToolResultEvent{
-			Type: "tool_result", Tool: "pre_scan_inbox",
-			Render: "email_pre_scan",
-			Data:   json.RawMessage(`{"kind":"email_pre_scan","urgent":[],"actionable":[],"informational_count":0,"suggested_archives":[],"suggested_drafts":[],"needs_review":[],"scanned":5,"needs_you":[],"needs_you_total":1,"bulk":{"count":0,"filter_tests":[]}}`),
-		},
-		event.CanonicalFinalEvent{Type: "final", Answer: "1 item"},
-	)
-	if !hasPreScanCard(m) {
-		t.Fatal("test setup: expected a pre-scan card before /clear")
-	}
-
-	// Mirrors model.go's "/clear" key handling.
-	m.messages = nil
-
-	updated3, _ := m.Update(preScanFetchedMsg{data: json.RawMessage(samplePreScanJSON)})
-	m = updated3.(ChatModel)
-
-	cardCount := 0
-	for _, msg := range m.messages {
-		if msg.Role == RoleCard && msg.Render == "email_pre_scan" {
-			cardCount++
-		}
-	}
-	if cardCount != 1 {
-		t.Fatalf("got %d pre-scan cards after /clear + a fresh scan, want exactly 1: %+v", cardCount, m.messages)
 	}
 }


### PR DESCRIPTION
Closes #2789

Ask the email agent to triage your inbox and what came back was a coin flip. Across one evening of live runs against a real mailbox it produced: numbering that pointed `archive 3` at a different message than the one labelled 3, items dropped, one message listed twice under a single number, addresses printed twice with a `mailto:` twin, ten items run together on one line, and — twice — no list at all, just "14 items need attention." Every one of those came from the same place: the chat model was being asked to retype a list the tools had already computed.

It doesn't anymore. The categories are still model judgement — a heuristic, then the `specific-ai-triage` SLM, then an LLM fallback, all inside `pre_scan_inbox`. Transcribing that result isn't a judgement, so the breakdown is now rendered from `needs_you`, carrying the classifier's own reason on each row. The model writes the opening sentence and nothing else.

**This also unblocks every other deterministic correction in the agent.** `ground_final_answer` ran on `process_query`'s return value, which the REST/TUI stream never re-reads — so the calendar-conflict, attention-card, invite-claim and fabricated-attendee guards all fired, logged, and reached nobody on the surface users actually drive (#2789). A `finalize_answer` hook on the base agent moves grounding ahead of the emission point, so one correction now serves the stream, the console, and the return value.

The inbox pre-scan card is gone too: it spent a Gmail scan before the user asked for anything, then reappeared mid-turn as a partial list beside the full answer still being written — two overlapping views of one inbox with no way to tell which to act on.

## Evidence

Before — same prompt, three consecutive runs:

```
Here's your inbox pre-scan — 14 items require attention, with 39 filtered out.
```
```
• Phishing Alert: Row 1 — Your account has been suspended…      ← card row 1 is "Partnership intro"
• Critical Topics: Rows 3 & 4 — server room fire alarm…         ← card rows 3 & 4 are something else
```
```
4.  Tomasz Testingiewicz tomasz.t@outlook.com mailto:tomasz.t@outlook.com - 30 minutes next week? 5.  Tomasz …
```

After:

```
Here's your inbox pre-scan — 14 items need attention, 39 filtered.

### Waiting on your reply

1. Tomasz Testingiewicz — Re: Partnership intro (2d ago · waiting 2d on your reply)
2. Tomasz Testingiewicz — Re: Northgate migration (2d ago · waiting 2d on your reply)

### Needs a response

3. Tomasz Testingiewicz — Your account has been suspended (2d ago · flagged as phishing)

### Meetings to decide

4. Tomasz Testingiewicz — 30 minutes next week? (2d ago)
```

Numbers are the `ref` values `resolve_needs_you_reference` resolves against, so `archive 3` now names exactly one message.

## Test plan

- [x] `pytest hub/agents/email/python/tests/ -q` — 1829 passed, 4 skipped
- [x] `PYTHONPATH=src pytest tests/unit/agents -q` — 1381 passed, 25 skipped
- [x] `(cd tui && go test ./...)` — all packages green
- [x] `flake8 src/gaia tests` — 0
- [x] Live TUI against a real Gmail mailbox, `triage my inbox`

<details>
<summary>Why the list is rendered rather than prompted</summary>

Both were tried. The skill was rewritten four times — naming the section order, naming the failing shape outright ("a reply that says '14 items need attention' and stops has failed"), forbidding raw addresses — and each time a live run ignored it. The two fixes that held were the ones moved into code.

Prompt text is also not free: the fuller wording pushed the post-tool envelope to 3511 tokens against a 3482 budget, and `test_the_whole_post_tool_turn_fits_the_window_with_skills_loaded` failed. Moving the mechanics into the renderer let the skill shrink from 22 lines describing a list to 4 lines saying "write one sentence, don't write the list" — and dropped ~450 tokens per turn that were being spent retyping ten rows.
</details>

<details>
<summary>Deliberately out of scope</summary>

- **The dead pre-scan card renderer** — roughly 1,765 lines in `emailprescan.go` and its tests are now unreachable from the TUI. Removing them is mechanical and belongs in its own PR.
- **The Agent UI's card** — `gaia.ui.sse_handler` still maps `pre_scan_inbox → email_pre_scan`. That surface was not retested here, so it keeps its card; the sync test now pins the difference to exactly that one key so any other drift still fails.
- **Tool consolidation** (#2835, #2836) — the ~70-tool surface is the larger cleanup this work points at.
</details>
