### PR TITLE
fix(security): stop LLM-supplied SQL reaching DatabaseAgent statements (CWE-89)

### DIFF
--- a/docs/sdk/mixins/database-mixin.mdx
+++ b/docs/sdk/mixins/database-mixin.mdx
@@ -41,6 +41,60 @@ class MyAgent(DatabaseAgent):
 
 **Auto-registered tools:** `db_query`, `db_insert`, `db_update`, `db_delete`, `db_tables`, `db_schema`
 
+`db_query` is read-only, and `db_update`/`db_delete` take structured conditions rather than a WHERE string — see [LLM-facing tools vs. the Python API](#llm-facing-tools-vs-the-python-api).
+
+#### LLM-facing tools vs. the Python API
+
+The mixin methods and the auto-registered tools sit at **different trust levels**, and deliberately have different shapes.
+
+| | `DatabaseMixin` methods | `DatabaseAgent` tools |
+|---|---|---|
+| Caller | Your Python code | The LLM |
+| Filter | `where` — a raw SQL fragment you write | `where` — a list of condition objects |
+| Reads | `query()` (unrestricted) | `db_query` (read-only, enforced by SQLite) |
+
+`update()`/`delete()` interpolate `where` into the statement, so it must be a literal you wrote. **Never build it from LLM output or end-user input** — bind untrusted values through `:param` placeholders inside a literal fragment instead:
+
+```python
+# Good - the fragment is a literal; the untrusted value is bound
+self.delete("sessions", "user_id = :uid", {"uid": untrusted_id})
+
+# Bad - untrusted text becomes part of the SQL
+self.delete("sessions", f"user_id = {untrusted_id}", {})
+```
+
+The LLM-facing tools don't accept a fragment at all. Each condition is an object, and GAIA builds the predicate and binds every value:
+
+```python
+db_delete("sessions", [{"column": "user_id", "op": "=", "value": 42}])
+# -> DELETE FROM sessions WHERE user_id = :__w0   params {"__w0": 42}
+```
+
+| Key | Required | Notes |
+|-----|----------|-------|
+| `column` | Yes | Must be a bare identifier (`[A-Za-z_][A-Za-z0-9_]*`) |
+| `op` | No (default `=`) | One of `=`, `!=`, `<`, `<=`, `>`, `>=`, `LIKE`, `NOT LIKE`, `IN`, `NOT IN`, `IS NULL`, `IS NOT NULL` |
+| `value` | Depends on `op` | A list for `IN`/`NOT IN` (max 900 items, SQLite's bind ceiling); omitted entirely for `IS NULL`/`IS NOT NULL` |
+
+Conditions are combined with `AND`. There is no `OR` and no nesting — an `AND` chain of allowlisted predicates can only narrow the row set, which is what makes `OR 1=1`-style payloads unrepresentable. If an agent genuinely needs `OR`, expose a domain-specific tool that runs the query you intend rather than widening the generic one.
+
+An empty condition list is **rejected** unless you pass `all_rows=True`, so a full-table update or delete is always deliberate:
+
+```python
+db_delete("logs", [], all_rows=True)   # explicit; anything less raises
+```
+
+Because the tool schema types parameters as strings, the JSON-encoded forms are
+also accepted: `where` as a JSON array, `data` as a JSON object, and `all_rows`
+as `"true"`/`"false"`. Only those exact spellings — an ambiguous value like
+`"yes"` raises rather than being guessed at.
+
+Malformed input raises `ValueError` naming the offending value and the rule, which the agent loop surfaces to the model so it can correct itself.
+
+<Note>
+These tools still give the LLM read and write access to **every** table in the database — there is no per-table authorization. Point `db_path` at a database holding only what the agent should be able to change, or override `_register_db_tools()` to expose domain-specific operations.
+</Note>
+
 #### Composing with Other Mixins
 
 `DatabaseAgent` can be extended with additional mixins for more capabilities:
@@ -114,9 +168,12 @@ class MyAgent(Agent, DatabaseMixin):
 | Method | Returns | Description |
 |--------|---------|-------------|
 | `query(sql, params, one)` | `list[dict]` or `dict` | Execute SELECT query |
+| `query_readonly(sql, params, one)` | `list[dict]` or `dict` | As `query()`, but SQLite refuses writes, DDL, `ATTACH`, and pragmas outside a schema-inspection allowlist. Raises `PermissionError` on a blocked statement. Use for any SQL not written by you. |
 | `insert(table, data)` | `int` (row ID) | Insert a row |
 | `update(table, data, where, params)` | `int` (affected count) | Update rows |
 | `delete(table, where, params)` | `int` (deleted count) | Delete rows |
+
+`insert`, `update`, and `delete` interpolate the table name — and `insert`/`update` the `data` keys — into the SQL, so all of them must be bare identifiers matching `[A-Za-z_][A-Za-z0-9_]*`; anything else raises `ValueError`. Quoted or non-ASCII identifiers that SQLite would otherwise accept are rejected. Empty `data` and a blank `where` raise as well, rather than producing a malformed statement.
 
 ### Schema & Transactions
 
@@ -208,6 +265,8 @@ self.query("SELECT * FROM users WHERE name = :name", {"name": user_input})
 # Bad - string formatting (SQL injection risk)
 self.query(f"SELECT * FROM users WHERE name = '{user_input}'")
 ```
+
+Placeholders only protect **values** — SQLite cannot bind identifiers or predicates. Those are covered separately: table and column names are validated as bare identifiers, and LLM-supplied filters go through structured conditions instead of a WHERE string. See [LLM-facing tools vs. the Python API](#llm-facing-tools-vs-the-python-api). For SQL you didn't write yourself, use `query_readonly()`.
 
 ### Initialize Schema Once
 

--- a/docs/spec/database-mixin.mdx
+++ b/docs/spec/database-mixin.mdx
@@ -77,6 +77,30 @@ rows = self.query("SELECT * FROM users")
 user = self.query("SELECT * FROM users WHERE id = :id", {"id": 42}, one=True)
 ```
 
+`query()` is a bare `execute()` — it does **not** verify the statement is a
+SELECT, so it will happily run a `DELETE`. It is for SQL you wrote yourself.
+
+```python
+def query_readonly(
+    self,
+    sql: str,
+    params: Optional[Dict[str, Any]] = None,
+    one: bool = False,
+) -> Union[List[Dict[str, Any]], Optional[Dict[str, Any]]]
+```
+
+Same signature and return contract as `query()`, but installs a SQLite
+authorizer for the duration of the call. Permitted actions are `SQLITE_SELECT`,
+`SQLITE_READ`, `SQLITE_FUNCTION`, `SQLITE_RECURSIVE`, and `SQLITE_PRAGMA`
+restricted to `table_info`, `table_xinfo`, `index_list`, `index_info`, and
+`foreign_key_list`. Everything else — writes, DDL, `ATTACH`, any other pragma —
+is denied by SQLite at statement-prepare time and re-raised as
+`PermissionError`. A genuine SQL error (missing table, corrupt file) propagates
+as its original `sqlite3` exception rather than being relabelled.
+
+Use this for any SQL that originates outside trusted Python code; `db_query` on
+`DatabaseAgent` is built on it.
+
 ### Writes
 
 ```python
@@ -89,12 +113,27 @@ def delete(self, table: str, where: str, params: Dict[str, Any]) -> int
 - `insert(table, data)` — builds `INSERT INTO table (...) VALUES (...)` from
   the data dict and returns the new row's `lastrowid`.
 - `update(table, data, where, params)` — the implementation prefixes the data
-  keys with `__set_` internally so they can't collide with the `params` used
-  in the `WHERE` clause. Returns the affected row count.
+  keys with `__set_` internally to keep them distinct from the `params` used
+  in the `WHERE` clause; a `params` key that collides with that prefix raises
+  `ValueError` rather than silently overriding the column value. Returns the
+  affected row count.
 - `delete(table, where, params)` — returns the deleted row count.
 
 Every mutation auto-commits **unless** the call is inside a `transaction()`
 block.
+
+**Validation contract.** The table name, and for `insert`/`update` every key of
+`data`, are interpolated into the statement rather than bound, so each must be
+a bare identifier matching `[A-Za-z_][A-Za-z0-9_]*`. Quoted or non-ASCII
+identifiers that SQLite would otherwise accept are rejected. `ValueError` is
+raised for an invalid identifier, empty `data`, or an empty/whitespace `where`.
+
+`where` is **not** parsed — beyond a non-blank-string check it is a trusted SQL
+fragment, interpolated verbatim so callers keep access to the full grammar
+(`expires_at < :now`, `mailbox IS NULL`, `1 = 1`). It must therefore be a
+literal written by the developer; never assemble it from LLM output or
+end-user input. Bind untrusted values through `:name` placeholders inside a
+literal fragment, or use the structured-condition tools on `DatabaseAgent`.
 
 ```python
 user_id = self.insert("users", {"name": "Alice", "email": "alice@example.com"})
@@ -209,6 +248,15 @@ class TodoAgent(Agent, DatabaseMixin):
   single coordinator agent.
 - There is no ORM layer. You work directly with SQL and dict results, which is
   intentional — it keeps the surface small and LLM-friendly.
+- Identifiers must be bare — see the validation contract under
+  [Writes](#writes). Table or column names that need quoting are not supported.
+- `query_readonly()`'s authorizer is **connection-scoped**, not call-scoped.
+  Concurrent and nested read-only calls are reference-counted, so one finishing
+  never disarms another still in flight. But the window applies to the whole
+  connection: because `init_db()` opens it with `check_same_thread=False`, a
+  *writer* on another thread sharing that connection is denied for as long as
+  any read-only call is open. Don't share one mixin instance between a
+  read-only caller and a background writer.
 
 ## Related
 

--- a/src/gaia/database/agent.py
+++ b/src/gaia/database/agent.py
@@ -3,10 +3,42 @@
 
 """DatabaseAgent - Agent with built-in database tools."""
 
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Optional, Tuple
 
 from gaia.agents.base import Agent, tool
 from gaia.database.mixin import DatabaseMixin
+from gaia.database.sql_safety import (
+    build_where,
+    coerce_bool,
+    coerce_conditions,
+    coerce_object,
+    validate_identifier,
+)
+
+
+def _resolve_where(
+    where: Any, all_rows: Any, table: str, context: str
+) -> Tuple[str, Dict[str, Any]]:
+    """Turn a tool's ``where``/``all_rows`` pair into (clause, params)."""
+    conditions = coerce_conditions(where, context)
+    verb = "delete" if context == "db_delete" else "update"
+    # Strict parse: a truthy string like "no" must not authorize a mass delete.
+    all_rows = coerce_bool(all_rows, "all_rows", context)
+    if all_rows:
+        if conditions:
+            raise ValueError(
+                f"{context}: pass either 'where' conditions or all_rows=True, "
+                f"not both. Got {len(conditions)} condition(s) with "
+                f"all_rows=True."
+            )
+        return "1 = 1", {}
+    if not conditions:
+        raise ValueError(
+            f"{context}: refusing to {verb} every row in {table!r}. Supply at "
+            f"least one condition, or pass all_rows=True to confirm a "
+            f"full-table {verb}."
+        )
+    return build_where(conditions, context=context)
 
 
 class DatabaseAgent(Agent, DatabaseMixin):
@@ -36,9 +68,20 @@ class DatabaseAgent(Agent, DatabaseMixin):
         # LLM can now use: db_query, db_insert, db_update, db_delete
 
     Security Note:
-        The db_query tool allows the LLM to execute arbitrary SELECT queries.
-        For production use, consider overriding _register_db_tools() to expose
-        only domain-specific, validated operations.
+        The LLM cannot supply raw SQL to the write tools:
+
+        - db_query is read-only. A SQLite authorizer blocks writes, DDL,
+          ATTACH, and every pragma outside a schema-inspection allowlist.
+        - db_update and db_delete take structured conditions, never a WHERE
+          string. GAIA builds the predicate and binds every value.
+        - Table and column names are validated as bare identifiers.
+        - A full-table update or delete requires an explicit all_rows=True.
+
+        Not covered: these tools still grant the LLM read and write access to
+        *every* table in the database. There is no per-table authorization.
+        Point db_path at a database that holds only what this agent should be
+        able to change, or override _register_db_tools() to expose
+        domain-specific operations instead.
     """
 
     def __init__(
@@ -65,7 +108,10 @@ class DatabaseAgent(Agent, DatabaseMixin):
         @tool
         def db_query(sql: str, params: Optional[Dict[str, Any]] = None) -> Dict:
             """
-            Execute a SELECT query and return results.
+            Execute a read-only SELECT query and return results.
+
+            Writes, DDL, and ATTACH are refused by SQLite itself. Use
+            db_insert, db_update, or db_delete to modify data.
 
             Args:
                 sql: SQL SELECT query with :param placeholders
@@ -77,7 +123,8 @@ class DatabaseAgent(Agent, DatabaseMixin):
             Example:
                 db_query("SELECT * FROM users WHERE age > :min_age", {"min_age": 18})
             """
-            rows = agent.query(sql, params or {})
+            params = coerce_object(params, "params", "db_query") if params else {}
+            rows = agent.query_readonly(sql, params)
             return {"rows": rows, "count": len(rows)}
 
         @tool
@@ -95,49 +142,82 @@ class DatabaseAgent(Agent, DatabaseMixin):
             Example:
                 db_insert("users", {"name": "Alice", "email": "alice@example.com"})
             """
+            table = validate_identifier(table, "table name", "db_insert")
+            data = coerce_object(data, "data", "db_insert")
             row_id = agent.insert(table, data)
             return {"id": row_id, "success": True}
 
         @tool
         def db_update(
-            table: str, data: Dict[str, Any], where: str, params: Dict[str, Any]
+            table: str,
+            data: Dict[str, Any],
+            where: Any,
+            all_rows: bool = False,
         ) -> Dict:
             """
-            Update rows matching a condition.
+            Update rows, where is a list of {"column","op","value"} conditions.
+
+            Conditions are combined with AND. Raw SQL is not accepted.
 
             Args:
                 table: Table name
                 data: Dictionary of column names to new values
-                where: WHERE clause with :param placeholders (without WHERE keyword)
-                params: Dictionary of parameter values for WHERE clause
+                where: List of condition objects. Each has "column", an
+                    optional "op" (default "="), and "value". Allowed ops:
+                    =, !=, <, <=, >, >=, LIKE, NOT LIKE, IN, NOT IN, IS NULL,
+                    IS NOT NULL. "IN"/"NOT IN" take a list value;
+                    "IS NULL"/"IS NOT NULL" take no value.
+                all_rows: Set true (or the string "true") to update every
+                    row. Required when where is empty, so a full-table update
+                    is always deliberate.
 
             Returns:
                 Dictionary with 'updated' (number of rows affected)
 
             Example:
-                db_update("users", {"email": "new@example.com"}, "id = :id", {"id": 42})
+                db_update("users", {"email": "new@x.com"},
+                          [{"column": "id", "op": "=", "value": 42}])
+                db_update("users", {"active": 0},
+                          [{"column": "role", "op": "IN",
+                            "value": ["guest", "trial"]},
+                           {"column": "last_seen", "op": "IS NULL"}])
+                db_update("users", {"active": 1}, [], all_rows=True)
             """
-            count = agent.update(table, data, where, params)
-            return {"updated": count}
+            table = validate_identifier(table, "table name", "db_update")
+            data = coerce_object(data, "data", "db_update")
+            clause, params = _resolve_where(where, all_rows, table, "db_update")
+            return {"updated": agent.update(table, data, clause, params)}
 
         @tool
-        def db_delete(table: str, where: str, params: Dict[str, Any]) -> Dict:
+        def db_delete(table: str, where: Any, all_rows: bool = False) -> Dict:
             """
-            Delete rows matching a condition.
+            Delete rows, where is a list of {"column","op","value"} conditions.
+
+            Conditions are combined with AND. Raw SQL is not accepted.
 
             Args:
                 table: Table name
-                where: WHERE clause with :param placeholders (without WHERE keyword)
-                params: Dictionary of parameter values for WHERE clause
+                where: List of condition objects. Each has "column", an
+                    optional "op" (default "="), and "value". Allowed ops:
+                    =, !=, <, <=, >, >=, LIKE, NOT LIKE, IN, NOT IN, IS NULL,
+                    IS NOT NULL. "IN"/"NOT IN" take a list value;
+                    "IS NULL"/"IS NOT NULL" take no value.
+                all_rows: Set true (or the string "true") to delete every
+                    row. Required when where is empty, so a full-table delete
+                    is always deliberate.
 
             Returns:
                 Dictionary with 'deleted' (number of rows deleted)
 
             Example:
-                db_delete("sessions", "expires_at < :now", {"now": "2024-01-01"})
+                db_delete("sessions", [{"column": "id", "op": "=", "value": 7}])
+                db_delete("sessions", [{"column": "expires_at", "op": "<",
+                                        "value": "2024-01-01"}])
+                db_delete("sessions", [], all_rows=True)
             """
-            count = agent.delete(table, where, params)
-            return {"deleted": count}
+            table = validate_identifier(table, "table name", "db_delete")
+            clause, params = _resolve_where(where, all_rows, table, "db_delete")
+            return {"deleted": agent.delete(table, clause, params)}
 
         @tool
         def db_tables() -> Dict:
@@ -147,7 +227,7 @@ class DatabaseAgent(Agent, DatabaseMixin):
             Returns:
                 Dictionary with 'tables' (list of table names)
             """
-            rows = agent.query(
+            rows = agent.query_readonly(
                 "SELECT name FROM sqlite_master WHERE type='table' ORDER BY name"
             )
             return {"tables": [row["name"] for row in rows]}
@@ -163,17 +243,9 @@ class DatabaseAgent(Agent, DatabaseMixin):
             Returns:
                 Dictionary with 'columns' (list of column info dicts)
             """
-            # Validate table name to prevent SQL injection
-            # (PRAGMA doesn't support parameterized queries)
-            import re
-
-            if not re.match(r"^[a-zA-Z_][a-zA-Z0-9_]*$", table):
-                return {
-                    "error": f"Invalid table name: {table}",
-                    "table": table,
-                    "columns": [],
-                }
-            rows = agent.query(f"PRAGMA table_info({table})")
+            # PRAGMA can't bind parameters, so the name is interpolated.
+            table = validate_identifier(table, "table name", "db_schema")
+            rows = agent.query_readonly(f"PRAGMA table_info({table})")
             columns = [
                 {
                     "name": row["name"],

--- a/src/gaia/database/mixin.py
+++ b/src/gaia/database/mixin.py
@@ -9,7 +9,40 @@ from contextlib import contextmanager
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Union
 
+from gaia.database.sql_safety import readonly, validate_identifier
+
 logger = logging.getLogger(__name__)
+
+
+def _require_column_map(data: Any, table: str, context: str) -> None:
+    """Reject a data mapping that can't be safely interpolated as columns."""
+    if not isinstance(data, dict):
+        raise ValueError(
+            f"{context}: 'data' must be a dict of column names to values, got "
+            f"{type(data).__name__}. Example: {{'name': 'Alice'}}."
+        )
+    if not data:
+        raise ValueError(
+            f"{context}: 'data' is empty; supply at least one column-value "
+            f"pair for table {table!r}."
+        )
+    for key in data:
+        validate_identifier(key, "column name", context)
+
+
+def _require_where(where: Any, table: str, context: str) -> None:
+    """Reject a where fragment that would produce a malformed statement."""
+    verb = "delete" if context.endswith("delete") else "update"
+    if not isinstance(where, str):
+        raise ValueError(
+            f"{context}: 'where' must be a SQL fragment string, got "
+            f"{type(where).__name__}. Example: 'id = :id'."
+        )
+    if not where.strip():
+        raise ValueError(
+            f"{context}: 'where' is empty. Pass a WHERE fragment, or '1 = 1' "
+            f"to {verb} every row in {table!r}."
+        )
 
 
 class DatabaseMixin:
@@ -37,6 +70,15 @@ class DatabaseMixin:
                 def add_item(name: str) -> dict:
                     item_id = self.insert("items", {"name": name})
                     return {"id": item_id}
+
+    Security:
+        Values are always bound. Table and column names are validated as bare
+        identifiers. The ``where`` argument to update()/delete() is a **trusted
+        SQL fragment** — it is interpolated, not bound, so it must be a literal
+        written by you, never a string built from LLM or end-user input. To
+        filter on untrusted input, bind it via :param placeholders inside a
+        literal ``where``, or use the structured-condition tools on
+        DatabaseAgent. Use query_readonly() for untrusted SQL.
     """
 
     _db: Optional[sqlite3.Connection] = None
@@ -131,6 +173,62 @@ class DatabaseMixin:
             return rows[0] if rows else None
         return rows
 
+    def query_readonly(
+        self,
+        sql: str,
+        params: Optional[Dict[str, Any]] = None,
+        one: bool = False,
+    ) -> Union[List[Dict[str, Any]], Optional[Dict[str, Any]]]:
+        """
+        Execute a query with writes and schema changes blocked by SQLite.
+
+        Use this for any SQL that originates outside trusted Python code — an
+        LLM tool call, a user-supplied filter. Writes, DDL, ATTACH, and pragmas
+        outside a read-only allowlist are refused by a SQLite authorizer rather
+        than by inspecting the statement text.
+
+        Args:
+            sql: SQL query with :param_name placeholders
+            params: Dictionary of parameter values
+            one: If True, return single row dict or None
+
+        Returns:
+            List of row dicts, or single dict/None if one=True
+
+        Raises:
+            PermissionError: If the statement attempts anything but a read.
+
+        Example:
+            rows = self.query_readonly("SELECT * FROM users WHERE id = :id",
+                                       {"id": 42})
+        """
+        self._require_db()
+        assert self._db is not None
+        denied: List[str] = []
+        mark = 0
+        try:
+            # The authorizer fires at prepare time, so fetch inside the window.
+            with readonly(self._db) as denied:
+                # Compare against a mark, not emptiness: a nested window hands
+                # back denials accumulated by the enclosing one.
+                mark = len(denied)
+                cursor = self._db.execute(sql, params or {})
+                rows = [dict(row) for row in cursor.fetchall()]
+        except sqlite3.DatabaseError as e:
+            # Classify on what the authorizer did, not on SQLite's message.
+            if len(denied) == mark:
+                raise
+            preview = sql if len(sql) <= 200 else f"{sql[:200]}..."
+            raise PermissionError(
+                f"Read-only query blocked by SQLite: {preview}. Only SELECT "
+                f"(plus PRAGMA table_info/table_xinfo/index_list/index_info/"
+                f"foreign_key_list) is permitted here. Use insert(), update(), "
+                f"or delete() to modify data."
+            ) from e
+        if one:
+            return rows[0] if rows else None
+        return rows
+
     def insert(self, table: str, data: Dict[str, Any]) -> int:
         """
         Insert a row and return its ID.
@@ -147,9 +245,16 @@ class DatabaseMixin:
                 "name": "Alice",
                 "email": "alice@example.com"
             })
+
+        Raises:
+            ValueError: If the table name or any column name is not a bare
+                identifier, or if data is empty.
         """
         self._require_db()
         assert self._db is not None
+        # Table and dict keys are interpolated into the SQL, not bound.
+        table = validate_identifier(table, "table name", "DatabaseMixin.insert")
+        _require_column_map(data, table, "DatabaseMixin.insert")
         cols = ", ".join(data.keys())
         placeholders = ", ".join(f":{k}" for k in data.keys())
         sql = f"INSERT INTO {table} ({cols}) VALUES ({placeholders})"
@@ -184,13 +289,27 @@ class DatabaseMixin:
                 "id = :id",
                 {"id": 42}
             )
+
+        Raises:
+            ValueError: If the table name or any column name is not a bare
+                identifier, or if data or where is empty.
         """
         self._require_db()
         assert self._db is not None
+        table = validate_identifier(table, "table name", "DatabaseMixin.update")
+        _require_column_map(data, table, "DatabaseMixin.update")
+        _require_where(where, table, "DatabaseMixin.update")
         # Prefix data params with __set_ to avoid collision with where params
         set_clause = ", ".join(f"{k} = :__set_{k}" for k in data.keys())
         merged_params = {f"__set_{k}": v for k, v in data.items()}
-        merged_params.update(params)
+        clashes = sorted(set(merged_params) & set(params or {}))
+        if clashes:
+            raise ValueError(
+                f"DatabaseMixin.update: where params {clashes} collide with the "
+                f"reserved __set_ prefix used for column values. Rename these "
+                f"placeholders in the where clause."
+            )
+        merged_params.update(params or {})
         sql = f"UPDATE {table} SET {set_clause} WHERE {where}"
         cursor = self._db.execute(sql, merged_params)
         if not self._in_tx:
@@ -211,11 +330,17 @@ class DatabaseMixin:
 
         Example:
             count = self.delete("sessions", "expires_at < :now", {"now": now})
+
+        Raises:
+            ValueError: If the table name is not a bare identifier, or if
+                where is empty.
         """
         self._require_db()
         assert self._db is not None
+        table = validate_identifier(table, "table name", "DatabaseMixin.delete")
+        _require_where(where, table, "DatabaseMixin.delete")
         sql = f"DELETE FROM {table} WHERE {where}"
-        cursor = self._db.execute(sql, params)
+        cursor = self._db.execute(sql, params or {})
         if not self._in_tx:
             self._db.commit()
         return cursor.rowcount

--- a/src/gaia/database/sql_safety.py
+++ b/src/gaia/database/sql_safety.py
@@ -1,0 +1,362 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+"""SQL safety primitives shared by DatabaseMixin and DatabaseAgent.
+
+SQLite binds *values*, never identifiers or predicates. Anything that reaches
+the SQL string itself — table names, column names, WHERE fragments — has to be
+validated or constructed rather than interpolated. This module is the single
+place that happens, so the guarantee can be audited in one file.
+"""
+
+import json
+import re
+import sqlite3
+import threading
+from contextlib import contextmanager
+from dataclasses import dataclass
+from typing import Any, Dict, Iterator, List, Sequence, Tuple
+
+# fullmatch, not match: `$` would also accept a trailing newline.
+_IDENTIFIER_RE = re.compile(r"[A-Za-z_][A-Za-z0-9_]*")
+
+# SQLite's default bound-variable ceiling is 999 on builds before 3.32.
+_MAX_IN_VALUES = 900
+
+# Operator allowlist for structured conditions. Deliberately closed and
+# conjunction-only: OR is the entire injection payload class ("OR 1=1"), so an
+# AND-chain of allowlisted predicates can only ever narrow the row set.
+SCALAR_OPS = ("=", "!=", "<", "<=", ">", ">=", "LIKE", "NOT LIKE")
+LIST_OPS = ("IN", "NOT IN")
+NULLARY_OPS = ("IS NULL", "IS NOT NULL")
+ALL_OPS = SCALAR_OPS + LIST_OPS + NULLARY_OPS
+
+_ALLOWED_KEYS = frozenset({"column", "op", "value"})
+
+# Types sqlite3 can bind directly.
+_BINDABLE = (type(None), bool, int, float, str, bytes)
+
+# Pragmas that only read schema metadata. PRAGMA is a single authorizer action
+# regardless of which pragma ran, so the allowlist is the only gate.
+READONLY_PRAGMAS = frozenset(
+    {"table_info", "table_xinfo", "index_list", "index_info", "foreign_key_list"}
+)
+
+# Where-params are ``__w<int>``; UPDATE's set-params are ``__set_<identifier>``.
+# The two languages diverge at character three, so they can never collide.
+_WHERE_PARAM_PREFIX = "__w"
+
+_OPS_HELP = ", ".join(ALL_OPS)
+
+
+def validate_identifier(name: Any, kind: str, context: str) -> str:
+    """Return *name* if it is a bare SQL identifier, else raise ValueError.
+
+    Args:
+        name: The candidate identifier.
+        kind: Human label for the error, e.g. ``"table name"``.
+        context: Caller name for the error, e.g. ``"db_delete"``.
+
+    Raises:
+        ValueError: If *name* is not a string matching ``[A-Za-z_][A-Za-z0-9_]*``.
+    """
+    if not isinstance(name, str):
+        raise ValueError(
+            f"{context}: {kind} must be a string, got {type(name).__name__}. "
+            f"Pass a bare identifier such as 'items'."
+        )
+    if not _IDENTIFIER_RE.fullmatch(name):
+        hint = (
+            "Call db_tables to list valid table names."
+            if kind == "table name"
+            else "Call db_schema('<table>') to list a table's columns."
+        )
+        raise ValueError(
+            f"{context}: invalid {kind} {name!r}. {kind.capitalize()}s must be "
+            f"bare identifiers matching [A-Za-z_][A-Za-z0-9_]*. {hint}"
+        )
+    return name
+
+
+def coerce_conditions(where: Any, context: str) -> List[Dict[str, Any]]:
+    """Normalize *where* to a list of condition dicts.
+
+    Accepts the list itself or its JSON encoding, because the tool schema
+    advertises this parameter as a string (see ``gaia.agents.base.tools``).
+
+    Raises:
+        ValueError: If *where* is neither form, or holds non-dict entries.
+    """
+    if isinstance(where, str):
+        try:
+            where = json.loads(where)
+        except json.JSONDecodeError as e:
+            raise ValueError(
+                f"{context}: 'where' was a string but is not valid JSON: {e}. "
+                f'Pass a list of condition objects, e.g. [{{"column": "id", '
+                f'"op": "=", "value": 42}}].'
+            ) from e
+    if where is None:
+        return []
+    if not isinstance(where, (list, tuple)):
+        raise ValueError(
+            f"{context}: 'where' must be a list of condition objects (or its "
+            f"JSON encoding), got {type(where).__name__}. Example: "
+            f'[{{"column": "id", "op": "=", "value": 42}}].'
+        )
+    for i, cond in enumerate(where):
+        if not isinstance(cond, dict):
+            raise ValueError(
+                f"{context}: condition {i} must be an object with keys "
+                f"column/op/value, got {type(cond).__name__}."
+            )
+    return list(where)
+
+
+_TRUE_SPELLINGS = frozenset({"true", "1"})
+_FALSE_SPELLINGS = frozenset({"false", "0", "none", "null", ""})
+
+
+def coerce_bool(value: Any, name: str, context: str) -> bool:
+    """Normalize a boolean flag that may arrive as its string form.
+
+    The tool schema advertises bool params as strings, so models send "true",
+    "false", "0", "1". Spellings are enumerated rather than passed through
+    ``bool()`` — a truthy string like "no" must never read as True.
+
+    Raises:
+        ValueError: If *value* is not a recognized boolean spelling.
+    """
+    if value is True or value is False:
+        return value
+    if value is None:
+        return False
+    if isinstance(value, int):
+        if value in (0, 1):
+            return value == 1
+    elif isinstance(value, str):
+        token = value.strip().lower()
+        if token in _TRUE_SPELLINGS:
+            return True
+        if token in _FALSE_SPELLINGS:
+            return False
+    raise ValueError(
+        f"{context}: {name!r} must be true or false, got {value!r}. "
+        f'Accepted: true/false (or the strings "true"/"false").'
+    )
+
+
+def coerce_object(value: Any, name: str, context: str) -> Dict[str, Any]:
+    """Normalize a mapping parameter that may arrive as its JSON encoding.
+
+    Same boundary problem as ``coerce_conditions``: the tool schema advertises
+    object params as strings, so models send JSON.
+
+    Raises:
+        ValueError: If *value* is neither a dict nor JSON encoding one.
+    """
+    if isinstance(value, str):
+        try:
+            value = json.loads(value)
+        except json.JSONDecodeError as e:
+            raise ValueError(
+                f"{context}: {name!r} was a string but is not valid JSON: {e}. "
+                f'Pass an object, e.g. {{"name": "Alice"}}.'
+            ) from e
+    if not isinstance(value, dict):
+        raise ValueError(
+            f"{context}: {name!r} must be an object mapping column names to "
+            f'values, got {type(value).__name__}. Example: {{"name": "Alice"}}.'
+        )
+    return value
+
+
+def build_where(
+    conditions: Sequence[Dict[str, Any]], *, context: str
+) -> Tuple[str, Dict[str, Any]]:
+    """Build a parameterized WHERE fragment from structured conditions.
+
+    Each condition is ``{"column": str, "op": str, "value": Any}``; ``op``
+    defaults to ``"="``. Conditions are joined with AND. Every value is bound,
+    so no caller-supplied text reaches the SQL string.
+
+    Args:
+        conditions: Condition dicts, already normalized by ``coerce_conditions``.
+        context: Caller name for error messages, e.g. ``"db_delete"``.
+
+    Returns:
+        ``(fragment, params)`` — e.g. ``("id = :__w0", {"__w0": 42})``.
+
+    Raises:
+        ValueError: On any malformed condition.
+    """
+    if not conditions:
+        raise ValueError(f"{context}: no conditions supplied.")
+
+    clauses: List[str] = []
+    params: Dict[str, Any] = {}
+
+    for i, cond in enumerate(conditions):
+        unknown = set(cond) - _ALLOWED_KEYS
+        if unknown:
+            raise ValueError(
+                f"{context}: condition {i} has unknown key(s) "
+                f"{sorted(unknown)!r}. Allowed keys: column, op, value."
+            )
+        if "column" not in cond:
+            raise ValueError(
+                f"{context}: condition {i} is missing required key 'column'."
+            )
+        column = validate_identifier(cond["column"], "column name", context)
+
+        raw_op = cond.get("op", "=")
+        if not isinstance(raw_op, str):
+            raise ValueError(
+                f"{context}: condition {i} operator must be a string, got "
+                f"{type(raw_op).__name__}. Allowed: {_OPS_HELP}."
+            )
+        # Case-folding against a closed allowlist cannot widen what's accepted.
+        op = " ".join(raw_op.upper().split())
+        if op not in ALL_OPS:
+            raise ValueError(
+                f"{context}: unsupported operator {raw_op!r} in condition {i}. "
+                f"Allowed: {_OPS_HELP}. Conditions are joined with AND; raw SQL "
+                f"is not accepted. For OR or nested logic, expose a "
+                f"domain-specific tool instead — see "
+                f"docs/sdk/mixins/database-mixin.mdx."
+            )
+
+        has_value = "value" in cond
+        if op in NULLARY_OPS:
+            if has_value:
+                raise ValueError(
+                    f"{context}: operator {op} in condition {i} takes no value; "
+                    f"remove the 'value' key."
+                )
+            clauses.append(f"{column} {op}")
+            continue
+
+        if not has_value:
+            raise ValueError(
+                f"{context}: operator {op} in condition {i} requires a 'value' key."
+            )
+        value = cond["value"]
+
+        if op in LIST_OPS:
+            if not isinstance(value, (list, tuple)):
+                raise ValueError(
+                    f"{context}: operator {op} in condition {i} requires a list "
+                    f'value, got {type(value).__name__}. Example: {{"column": '
+                    f'"status", "op": "IN", "value": ["a", "b"]}}.'
+                )
+            if not value:
+                raise ValueError(
+                    f"{context}: operator {op} in condition {i} got an empty "
+                    f"list, which matches no rows. Supply at least one value, "
+                    f"or omit this condition."
+                )
+            if len(value) > _MAX_IN_VALUES:
+                raise ValueError(
+                    f"{context}: operator {op} in condition {i} got "
+                    f"{len(value)} values, over the {_MAX_IN_VALUES} SQLite "
+                    f"can bind. Narrow the filter, or run the operation in "
+                    f"batches."
+                )
+            names = []
+            for j, item in enumerate(value):
+                _require_bindable(item, i, context)
+                name = f"{_WHERE_PARAM_PREFIX}{i}_{j}"
+                params[name] = item
+                names.append(f":{name}")
+            clauses.append(f"{column} {op} ({', '.join(names)})")
+            continue
+
+        if op in ("LIKE", "NOT LIKE") and not isinstance(value, str):
+            raise ValueError(
+                f"{context}: operator {op} in condition {i} requires a string "
+                f"value, got {type(value).__name__}."
+            )
+        _require_bindable(value, i, context)
+        name = f"{_WHERE_PARAM_PREFIX}{i}"
+        params[name] = value
+        clauses.append(f"{column} {op} :{name}")
+
+    return " AND ".join(clauses), params
+
+
+def _require_bindable(value: Any, index: int, context: str) -> None:
+    if not isinstance(value, _BINDABLE):
+        raise ValueError(
+            f"{context}: condition {index} value has type "
+            f"{type(value).__name__}, which SQLite cannot bind. Use a string, "
+            f"number, boolean, or null."
+        )
+
+
+@dataclass
+class _Window:
+    """An open read-only window. ``conn`` is held so its id() stays unique."""
+
+    depth: int
+    denied: List[str]
+    conn: sqlite3.Connection
+
+
+# Open read-only windows keyed by connection id, so a nested call joins the
+# outer window instead of disarming it on exit.
+_OPEN_WINDOWS: Dict[int, _Window] = {}
+_WINDOWS_LOCK = threading.Lock()
+
+
+@contextmanager
+def readonly(conn: sqlite3.Connection) -> Iterator[List[str]]:
+    """Block writes, DDL, ATTACH, and non-allowlisted pragmas on *conn*.
+
+    Yields the list of denied actions. It is empty unless the authorizer
+    refused something, which lets callers tell an authorization failure from an
+    ordinary SQL error without matching on SQLite's message text — the message
+    varies ("not authorized", "authorization denied") by statement.
+
+    Re-entrant: a nested call joins the open window and only the outermost
+    exit disarms it. Because the authorizer is connection-scoped, a concurrent
+    writer on the same connection is denied for as long as any window is open.
+    Any authorizer already installed on *conn* is not restored on exit.
+    """
+    key = id(conn)
+    with _WINDOWS_LOCK:
+        entry = _OPEN_WINDOWS.get(key)
+        if entry is None:
+            denied: List[str] = []
+
+            def _authorizer(action, arg1, _arg2, _db_name, _trigger):
+                if action in (
+                    sqlite3.SQLITE_SELECT,
+                    sqlite3.SQLITE_READ,
+                    sqlite3.SQLITE_FUNCTION,
+                    sqlite3.SQLITE_RECURSIVE,
+                ):
+                    return sqlite3.SQLITE_OK
+                if (
+                    action == sqlite3.SQLITE_PRAGMA
+                    and (arg1 or "").lower() in READONLY_PRAGMAS
+                ):
+                    return sqlite3.SQLITE_OK
+                denied.append(f"action={action} arg={arg1!r}")
+                return sqlite3.SQLITE_DENY
+
+            # Arm before publishing: a failed set_authorizer must not leave a
+            # registered window that later calls would join and skip arming.
+            conn.set_authorizer(_authorizer)
+            # Hold conn so its id() can't be recycled onto a stale entry.
+            entry = _Window(depth=0, denied=denied, conn=conn)
+            _OPEN_WINDOWS[key] = entry
+        entry.depth += 1
+
+    try:
+        yield entry.denied
+    finally:
+        with _WINDOWS_LOCK:
+            entry.depth -= 1
+            if entry.depth == 0:
+                del _OPEN_WINDOWS[key]
+                conn.set_authorizer(None)

--- a/tests/integration/test_database_agent.py
+++ b/tests/integration/test_database_agent.py
@@ -3,6 +3,8 @@
 
 """Integration tests for DatabaseAgent."""
 
+import pytest
+
 from gaia import DatabaseAgent
 from gaia.database import temp_db
 
@@ -129,7 +131,9 @@ def test_db_update_tool():
 
     db_update = _TOOL_REGISTRY["db_update"]["function"]
 
-    result = db_update("items", {"quantity": 20}, "name = :name", {"name": "Apple"})
+    result = db_update(
+        "items", {"quantity": 20}, [{"column": "name", "op": "=", "value": "Apple"}]
+    )
     assert result["updated"] == 1
 
     # Verify update
@@ -138,6 +142,22 @@ def test_db_update_tool():
     )
     assert item["quantity"] == 20
 
+    agent.close_db()
+
+
+def test_db_update_tool_accepts_json_string_where():
+    """The tool schema advertises 'where' as a string, so models send JSON."""
+    agent = SimpleDBAgent()
+    agent.insert("items", {"name": "Apple", "quantity": 10})
+
+    from gaia.agents.base.tools import _TOOL_REGISTRY
+
+    db_update = _TOOL_REGISTRY["db_update"]["function"]
+
+    result = db_update(
+        "items", {"quantity": 20}, '[{"column": "name", "op": "=", "value": "Apple"}]'
+    )
+    assert result["updated"] == 1
     agent.close_db()
 
 
@@ -152,7 +172,7 @@ def test_db_delete_tool():
 
     db_delete = _TOOL_REGISTRY["db_delete"]["function"]
 
-    result = db_delete("items", "name = :name", {"name": "Apple"})
+    result = db_delete("items", [{"column": "name", "op": "=", "value": "Apple"}])
     assert result["deleted"] == 1
 
     # Verify delete
@@ -160,6 +180,40 @@ def test_db_delete_tool():
     assert len(items) == 1
     assert items[0]["name"] == "Banana"
 
+    agent.close_db()
+
+
+def test_db_delete_tool_accepts_json_string_where():
+    """The tool schema advertises 'where' as a string, so models send JSON."""
+    agent = SimpleDBAgent()
+    agent.insert("items", {"name": "Apple", "quantity": 10})
+    agent.insert("items", {"name": "Banana", "quantity": 5})
+
+    from gaia.agents.base.tools import _TOOL_REGISTRY
+
+    db_delete = _TOOL_REGISTRY["db_delete"]["function"]
+
+    result = db_delete("items", '[{"column": "name", "op": "=", "value": "Apple"}]')
+    assert result["deleted"] == 1
+    assert [i["name"] for i in agent.query("SELECT * FROM items")] == ["Banana"]
+    agent.close_db()
+
+
+def test_db_delete_tool_supports_in_operator():
+    """IN takes a list value and binds each element."""
+    agent = SimpleDBAgent()
+    for n in ("Apple", "Banana", "Cherry"):
+        agent.insert("items", {"name": n, "quantity": 1})
+
+    from gaia.agents.base.tools import _TOOL_REGISTRY
+
+    db_delete = _TOOL_REGISTRY["db_delete"]["function"]
+
+    result = db_delete(
+        "items", [{"column": "name", "op": "IN", "value": ["Apple", "Cherry"]}]
+    )
+    assert result["deleted"] == 2
+    assert [i["name"] for i in agent.query("SELECT * FROM items")] == ["Banana"]
     agent.close_db()
 
 
@@ -224,3 +278,308 @@ def test_database_agent_file_persistence(tmp_path):
     assert len(items) == 1
     assert items[0]["name"] == "Persistent"
     agent2.close_db()
+
+
+# --- Injection regressions ---
+#
+# Each seeds 3 rows, fires a payload that previously mutated the table, and
+# asserts the row count is unchanged. The tool layer is the LLM trust boundary.
+
+
+def _seeded_agent():
+    agent = SimpleDBAgent()
+    for n, q in (("Apple", 10), ("Banana", 5), ("Cherry", 7)):
+        agent.insert("items", {"name": n, "quantity": q})
+    return agent
+
+
+def _tools():
+    from gaia.agents.base.tools import _TOOL_REGISTRY
+
+    return _TOOL_REGISTRY
+
+
+@pytest.mark.parametrize(
+    "where",
+    [
+        "name = :name OR 1=1",
+        "1=1",
+        "id = :id OR 1=1",
+    ],
+)
+def test_db_delete_rejects_free_text_where(where):
+    """A raw WHERE fragment is no longer an accepted shape."""
+    agent = _seeded_agent()
+    db_delete = _tools()["db_delete"]["function"]
+
+    with pytest.raises(ValueError):
+        db_delete("items", where)
+
+    assert len(agent.query("SELECT * FROM items")) == 3
+    agent.close_db()
+
+
+def test_db_delete_rejects_or_operator():
+    """OR is not in the operator allowlist, so `OR 1=1` has no structured form."""
+    agent = _seeded_agent()
+    db_delete = _tools()["db_delete"]["function"]
+
+    with pytest.raises(ValueError, match="unsupported operator"):
+        db_delete("items", '[{"column": "id", "op": "OR", "value": 1}]')
+
+    assert len(agent.query("SELECT * FROM items")) == 3
+    agent.close_db()
+
+
+def test_db_delete_rejects_injected_column_name():
+    """A predicate smuggled through the column slot fails identifier validation."""
+    agent = _seeded_agent()
+    db_delete = _tools()["db_delete"]["function"]
+
+    with pytest.raises(ValueError, match="invalid column name"):
+        db_delete(
+            "items",
+            [
+                {"column": "id", "op": "=", "value": 1},
+                {"column": "1", "op": "=", "value": 1},
+            ],
+        )
+
+    assert len(agent.query("SELECT * FROM items")) == 3
+    agent.close_db()
+
+
+def test_db_delete_rejects_table_name_injection():
+    """The table slot is interpolated, so it must be a bare identifier."""
+    agent = _seeded_agent()
+    db_delete = _tools()["db_delete"]["function"]
+
+    with pytest.raises(ValueError, match="invalid table name"):
+        db_delete("items WHERE 1=1 --", [{"column": "id", "op": "=", "value": 1}])
+
+    assert len(agent.query("SELECT * FROM items")) == 3
+    agent.close_db()
+
+
+def test_db_update_rejects_table_name_injection():
+    agent = _seeded_agent()
+    db_update = _tools()["db_update"]["function"]
+
+    with pytest.raises(ValueError, match="invalid table name"):
+        db_update(
+            "items WHERE 1=1 --",
+            {"quantity": 0},
+            [{"column": "id", "op": "=", "value": 1}],
+        )
+
+    assert (
+        agent.query("SELECT quantity FROM items WHERE id = 1", one=True)["quantity"]
+        == 10
+    )
+    agent.close_db()
+
+
+def test_db_insert_rejects_column_injection():
+    agent = _seeded_agent()
+    db_insert = _tools()["db_insert"]["function"]
+
+    with pytest.raises(ValueError, match="invalid column name"):
+        db_insert("items", {"name) VALUES ('x'); --": "x"})
+
+    assert len(agent.query("SELECT * FROM items")) == 3
+    agent.close_db()
+
+
+@pytest.mark.parametrize(
+    "sql",
+    [
+        "DELETE FROM items",
+        "UPDATE items SET quantity = 0",
+        "INSERT INTO items (name) VALUES ('Injected')",
+        "DROP TABLE items",
+        "CREATE TABLE other (id INTEGER)",
+        "ATTACH DATABASE ':memory:' AS side",
+        "PRAGMA writable_schema=ON",
+    ],
+)
+def test_db_query_is_read_only(sql):
+    """db_query executes statements; SQLite refuses anything but a read."""
+    agent = _seeded_agent()
+    db_query = _tools()["db_query"]["function"]
+
+    with pytest.raises(PermissionError, match="Read-only query blocked"):
+        db_query(sql)
+
+    assert len(agent.query("SELECT * FROM items")) == 3
+    agent.close_db()
+
+
+def test_db_query_still_works_after_blocked_write():
+    """A leaked authorizer would break every later write in the process."""
+    agent = _seeded_agent()
+    db_query = _tools()["db_query"]["function"]
+
+    with pytest.raises(PermissionError):
+        db_query("DELETE FROM items")
+
+    assert db_query("SELECT * FROM items")["count"] == 3
+    agent.insert("items", {"name": "Date", "quantity": 1})
+    assert len(agent.query("SELECT * FROM items")) == 4
+    agent.close_db()
+
+
+def test_db_delete_requires_all_rows_for_full_table():
+    """An empty condition list must not silently become a mass delete."""
+    agent = _seeded_agent()
+    db_delete = _tools()["db_delete"]["function"]
+
+    with pytest.raises(ValueError, match="all_rows"):
+        db_delete("items", [])
+    assert len(agent.query("SELECT * FROM items")) == 3
+
+    assert db_delete("items", [], all_rows=True)["deleted"] == 3
+    assert agent.query("SELECT * FROM items") == []
+    agent.close_db()
+
+
+def test_db_update_requires_all_rows_for_full_table():
+    agent = _seeded_agent()
+    db_update = _tools()["db_update"]["function"]
+
+    with pytest.raises(ValueError, match="all_rows"):
+        db_update("items", {"quantity": 0}, [])
+    assert (
+        agent.query("SELECT quantity FROM items WHERE id = 1", one=True)["quantity"]
+        == 10
+    )
+
+    assert db_update("items", {"quantity": 0}, [], all_rows=True)["updated"] == 3
+    agent.close_db()
+
+
+def test_db_delete_rejects_all_rows_with_conditions():
+    """Ambiguous intent is refused rather than resolved silently."""
+    agent = _seeded_agent()
+    db_delete = _tools()["db_delete"]["function"]
+
+    with pytest.raises(ValueError, match="not both"):
+        db_delete("items", [{"column": "id", "op": "=", "value": 1}], all_rows=True)
+
+    assert len(agent.query("SELECT * FROM items")) == 3
+    agent.close_db()
+
+
+def test_db_schema_raises_on_bad_table():
+    """db_schema raises instead of returning an error dict a model reads as data."""
+    agent = _seeded_agent()
+    db_schema = _tools()["db_schema"]["function"]
+
+    with pytest.raises(ValueError, match="invalid table name"):
+        db_schema("items; DROP TABLE items")
+
+    assert agent.table_exists("items")
+    agent.close_db()
+
+
+@pytest.mark.parametrize("all_rows", ["no", "yes", 2, [], {}])
+def test_db_delete_rejects_non_boolean_all_rows(all_rows):
+    """A truthy string like "false" must not authorize a full-table delete."""
+    agent = _seeded_agent()
+    db_delete = _tools()["db_delete"]["function"]
+
+    with pytest.raises(ValueError, match="must be true or false"):
+        db_delete("items", [], all_rows)
+
+    assert len(agent.query("SELECT * FROM items")) == 3
+    agent.close_db()
+
+
+def test_db_update_rejects_non_boolean_all_rows():
+    agent = _seeded_agent()
+    db_update = _tools()["db_update"]["function"]
+
+    with pytest.raises(ValueError, match="must be true or false"):
+        db_update("items", {"quantity": 0}, [], "nope")
+
+    assert (
+        agent.query("SELECT quantity FROM items WHERE id = 1", one=True)["quantity"]
+        == 10
+    )
+    agent.close_db()
+
+
+@pytest.mark.parametrize("data", ["abc", "[1,2]", "123", '"s"'])
+def test_db_insert_rejects_non_object_data(data):
+    agent = _seeded_agent()
+    db_insert = _tools()["db_insert"]["function"]
+
+    with pytest.raises(ValueError):
+        db_insert("items", data)
+
+    assert len(agent.query("SELECT * FROM items")) == 3
+    agent.close_db()
+
+
+def test_db_insert_accepts_json_string_data():
+    """The tool schema types object params as strings, so models send JSON."""
+    agent = _seeded_agent()
+    db_insert = _tools()["db_insert"]["function"]
+
+    assert db_insert("items", '{"name": "Date", "quantity": 2}')["success"] is True
+    assert len(agent.query("SELECT * FROM items")) == 4
+    agent.close_db()
+
+
+def test_db_update_accepts_json_string_data():
+    agent = _seeded_agent()
+    db_update = _tools()["db_update"]["function"]
+
+    result = db_update(
+        "items", '{"quantity": 42}', [{"column": "name", "op": "=", "value": "Apple"}]
+    )
+    assert result["updated"] == 1
+    agent.close_db()
+
+
+def test_db_query_rejects_vacuum():
+    agent = _seeded_agent()
+    db_query = _tools()["db_query"]["function"]
+
+    with pytest.raises(PermissionError):
+        db_query("VACUUM")
+
+    assert len(agent.query("SELECT * FROM items")) == 3
+    agent.close_db()
+
+
+def test_db_insert_error_names_the_tool_not_the_python_api():
+    """The model can call db_insert; it cannot call DatabaseMixin.insert."""
+    agent = _seeded_agent()
+    db_insert = _tools()["db_insert"]["function"]
+
+    with pytest.raises(ValueError, match="^db_insert:"):
+        db_insert("items WHERE 1=1 --", {"name": "x"})
+
+    agent.close_db()
+
+
+@pytest.mark.parametrize("falsey", ["false", "False", " FALSE "])
+def test_db_delete_string_false_does_not_authorize_mass_delete(falsey):
+    """The tool schema types all_rows as a string, so "false" must mean false."""
+    agent = _seeded_agent()
+    db_delete = _tools()["db_delete"]["function"]
+
+    with pytest.raises(ValueError, match="all_rows"):
+        db_delete("items", [], falsey)
+
+    assert len(agent.query("SELECT * FROM items")) == 3
+    agent.close_db()
+
+
+@pytest.mark.parametrize("truthy", ["true", "True", " TRUE "])
+def test_db_delete_string_true_authorizes_mass_delete(truthy):
+    agent = _seeded_agent()
+    db_delete = _tools()["db_delete"]["function"]
+
+    assert db_delete("items", [], truthy)["deleted"] == 3
+    agent.close_db()

--- a/tests/unit/test_database_mixin.py
+++ b/tests/unit/test_database_mixin.py
@@ -390,3 +390,217 @@ def test_execute_inside_transaction_raises():
             db.execute("CREATE TABLE other (id INTEGER)")  # Should raise
 
     db.close_db()
+
+
+# --- Identifier Validation ---
+
+
+def _seeded_db():
+    db = DB()
+    db.init_db()
+    db.execute("CREATE TABLE items (id INTEGER PRIMARY KEY, name TEXT, qty INTEGER)")
+    for i, n in enumerate(("a", "b", "c"), 1):
+        db.insert("items", {"name": n, "qty": i * 10})
+    return db
+
+
+@pytest.mark.parametrize(
+    "table",
+    ["items WHERE 1=1 --", "items; DROP TABLE items", "1items", "", '"items"'],
+)
+def test_insert_rejects_bad_table(table):
+    """Table names are interpolated, so they must be bare identifiers."""
+    db = _seeded_db()
+    with pytest.raises(ValueError, match="invalid table name"):
+        db.insert(table, {"name": "x"})
+    assert len(db.query("SELECT * FROM items")) == 3
+    db.close_db()
+
+
+def test_insert_rejects_bad_column():
+    """Dict keys become column names in the SQL, so they are validated too."""
+    db = _seeded_db()
+    with pytest.raises(ValueError, match="invalid column name"):
+        db.insert("items", {"name) VALUES (1); --": "x"})
+    assert len(db.query("SELECT * FROM items")) == 3
+    db.close_db()
+
+
+def test_insert_rejects_empty_data():
+    db = _seeded_db()
+    with pytest.raises(ValueError, match="'data' is empty"):
+        db.insert("items", {})
+    db.close_db()
+
+
+def test_update_rejects_bad_table():
+    db = _seeded_db()
+    with pytest.raises(ValueError, match="invalid table name"):
+        db.update("items WHERE 1=1 --", {"qty": 0}, "id = :id", {"id": 1})
+    assert db.query("SELECT qty FROM items WHERE id = 1", one=True)["qty"] == 10
+    db.close_db()
+
+
+def test_update_rejects_bad_column():
+    db = _seeded_db()
+    with pytest.raises(ValueError, match="invalid column name"):
+        db.update("items", {"qty = 0, name": "x"}, "id = :id", {"id": 1})
+    db.close_db()
+
+
+def test_update_rejects_empty_data():
+    db = _seeded_db()
+    with pytest.raises(ValueError, match="'data' is empty"):
+        db.update("items", {}, "id = :id", {"id": 1})
+    db.close_db()
+
+
+def test_delete_rejects_bad_table():
+    db = _seeded_db()
+    with pytest.raises(ValueError, match="invalid table name"):
+        db.delete("items WHERE 1=1 --", "id = :id", {"id": 1})
+    assert len(db.query("SELECT * FROM items")) == 3
+    db.close_db()
+
+
+@pytest.mark.parametrize("where", ["", "   "])
+def test_delete_rejects_blank_where(where):
+    db = _seeded_db()
+    with pytest.raises(ValueError, match="'where' is empty"):
+        db.delete("items", where, {})
+    assert len(db.query("SELECT * FROM items")) == 3
+    db.close_db()
+
+
+@pytest.mark.parametrize(
+    "where,params",
+    [
+        ("1 = 1", {}),
+        ("name IS NULL", {}),
+        ("qty < :threshold", {"threshold": 25}),
+        ("id = :id", {"id": 1}),
+        ("id = :id OR qty > :q", {"id": 1, "q": 25}),
+    ],
+)
+def test_delete_still_accepts_trusted_where_fragments(where, params):
+    """The mixin's `where` stays a trusted SQL fragment for Python callers.
+
+    These are the literal shapes used across the codebase; the LLM trust
+    boundary is DatabaseAgent's tools, not this method. Do not tighten this
+    without auditing every internal caller.
+    """
+    db = _seeded_db()
+    db.delete("items", where, params)
+    db.close_db()
+
+
+# --- Read-Only Query ---
+
+
+def test_query_readonly_allows_select():
+    db = _seeded_db()
+    assert len(db.query_readonly("SELECT * FROM items")) == 3
+    assert (
+        db.query_readonly("SELECT * FROM items WHERE id = :id", {"id": 1}, one=True)[
+            "name"
+        ]
+        == "a"
+    )
+    db.close_db()
+
+
+@pytest.mark.parametrize(
+    "sql",
+    [
+        "DELETE FROM items",
+        "UPDATE items SET qty = 0",
+        "INSERT INTO items (name) VALUES ('x')",
+        "DROP TABLE items",
+        "CREATE TABLE other (id INTEGER)",
+        "ATTACH DATABASE ':memory:' AS side",
+        "PRAGMA writable_schema=ON",
+    ],
+)
+def test_query_readonly_blocks_writes(sql):
+    db = _seeded_db()
+    with pytest.raises(PermissionError, match="Read-only query blocked"):
+        db.query_readonly(sql)
+    assert len(db.query("SELECT * FROM items")) == 3
+    db.close_db()
+
+
+def test_query_readonly_restores_authorizer():
+    """A leaked authorizer would break every later write in the process."""
+    db = _seeded_db()
+    with pytest.raises(PermissionError):
+        db.query_readonly("DELETE FROM items")
+    db.insert("items", {"name": "d", "qty": 40})
+    assert len(db.query("SELECT * FROM items")) == 4
+    db.close_db()
+
+
+def test_query_readonly_propagates_real_errors():
+    """A genuine SQL error must not be relabelled as a permission problem."""
+    import sqlite3
+
+    db = _seeded_db()
+    with pytest.raises(sqlite3.OperationalError, match="no such table"):
+        db.query_readonly("SELECT * FROM nope")
+    db.close_db()
+
+
+def test_query_readonly_allows_schema_pragma():
+    db = _seeded_db()
+    assert db.query_readonly("PRAGMA table_info(items)")
+    db.close_db()
+
+
+def test_query_readonly_denies_vacuum():
+    """VACUUM's denial message differs; classification must not depend on it."""
+    db = _seeded_db()
+    with pytest.raises(PermissionError):
+        db.query_readonly("VACUUM")
+    db.close_db()
+
+
+def test_query_readonly_does_not_mislabel_table_named_like_denial():
+    """A real SQL error must survive even when its text mentions authorization."""
+    import sqlite3
+
+    db = _seeded_db()
+    with pytest.raises(sqlite3.OperationalError, match="no such table"):
+        db.query_readonly('SELECT * FROM "not authorized"')
+    db.close_db()
+
+
+def test_query_readonly_works_inside_transaction():
+    db = _seeded_db()
+    with db.transaction():
+        db.insert("items", {"name": "d", "qty": 40})
+        assert len(db.query_readonly("SELECT * FROM items")) == 4
+    db.close_db()
+
+
+@pytest.mark.parametrize("data", ['{"name": "x"}', "abc", ["name"], None, 5])
+def test_insert_rejects_non_dict_data(data):
+    db = _seeded_db()
+    with pytest.raises(ValueError, match="must be a dict"):
+        db.insert("items", data)
+    db.close_db()
+
+
+@pytest.mark.parametrize("where", [None, 123, ["id = :id"], {"id": 1}])
+def test_delete_rejects_non_string_where(where):
+    db = _seeded_db()
+    with pytest.raises(ValueError, match="must be a SQL fragment string"):
+        db.delete("items", where, {})
+    db.close_db()
+
+
+def test_update_rejects_params_colliding_with_set_prefix():
+    """The __set_ prefix is only a guarantee if a caller can't overwrite it."""
+    db = _seeded_db()
+    with pytest.raises(ValueError, match="collide with the reserved"):
+        db.update("items", {"qty": 99}, "id = :id", {"id": 1, "__set_qty": 0})
+    assert db.query("SELECT qty FROM items WHERE id = 1", one=True)["qty"] == 10
+    db.close_db()

--- a/tests/unit/test_sql_safety.py
+++ b/tests/unit/test_sql_safety.py
@@ -1,0 +1,520 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+"""Unit tests for gaia.database.sql_safety."""
+
+import re
+import sqlite3
+import time
+
+import pytest
+
+from gaia.database.sql_safety import (
+    _OPEN_WINDOWS,
+    build_where,
+    coerce_bool,
+    coerce_conditions,
+    coerce_object,
+    readonly,
+    validate_identifier,
+)
+
+# --- validate_identifier ---
+
+
+@pytest.mark.parametrize("name", ["items", "_x", "a1_b", "T", "_"])
+def test_validate_identifier_accepts_bare_identifiers(name):
+    assert validate_identifier(name, "table name", "ctx") == name
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        "",
+        "1abc",
+        "a-b",
+        "a b",
+        "a;b",
+        "items WHERE 1=1 --",
+        '"quoted"',
+        "items) VALUES (1); --",
+        "naïve",
+    ],
+)
+def test_validate_identifier_rejects_unsafe(name):
+    with pytest.raises(ValueError, match="invalid table name"):
+        validate_identifier(name, "table name", "db_delete")
+
+
+@pytest.mark.parametrize("name", [None, 123, ["items"]])
+def test_validate_identifier_rejects_non_strings(name):
+    with pytest.raises(ValueError, match="must be a string"):
+        validate_identifier(name, "table name", "db_delete")
+
+
+def test_validate_identifier_error_names_value_and_grammar():
+    with pytest.raises(ValueError) as exc:
+        validate_identifier("items WHERE 1=1 --", "table name", "db_delete")
+    msg = str(exc.value)
+    assert "db_delete" in msg
+    assert "items WHERE 1=1 --" in msg
+    assert "[A-Za-z_][A-Za-z0-9_]*" in msg
+    assert "db_tables" in msg  # tells the caller how to recover
+
+
+# --- coerce_conditions ---
+
+
+def test_coerce_conditions_accepts_list():
+    conds = [{"column": "id", "op": "=", "value": 1}]
+    assert coerce_conditions(conds, "db_delete") == conds
+
+
+def test_coerce_conditions_accepts_json_string():
+    # The tool schema advertises 'where' as a string, so models send JSON.
+    raw = '[{"column": "id", "op": "=", "value": 1}]'
+    assert coerce_conditions(raw, "db_delete") == [
+        {"column": "id", "op": "=", "value": 1}
+    ]
+
+
+def test_coerce_conditions_none_is_empty():
+    assert coerce_conditions(None, "db_delete") == []
+
+
+def test_coerce_conditions_rejects_free_text():
+    with pytest.raises(ValueError, match="not valid JSON"):
+        coerce_conditions("id = :id OR 1=1", "db_delete")
+
+
+def test_coerce_conditions_rejects_wrong_type():
+    with pytest.raises(ValueError, match="must be a list of condition objects"):
+        coerce_conditions(42, "db_delete")
+
+
+def test_coerce_conditions_rejects_non_dict_entries():
+    with pytest.raises(ValueError, match="condition 0 must be an object"):
+        coerce_conditions([["id", "=", 1]], "db_delete")
+
+
+# --- build_where: happy paths ---
+
+
+def test_build_where_single_scalar():
+    assert build_where([{"column": "id", "op": "=", "value": 42}], context="c") == (
+        "id = :__w0",
+        {"__w0": 42},
+    )
+
+
+def test_build_where_op_defaults_to_equals():
+    sql, params = build_where([{"column": "id", "value": 42}], context="c")
+    assert sql == "id = :__w0"
+    assert params == {"__w0": 42}
+
+
+def test_build_where_repeated_column_uses_positional_params():
+    # Param names are indexed by position, not column, so a column can repeat.
+    sql, params = build_where(
+        [
+            {"column": "age", "op": ">=", "value": 18},
+            {"column": "age", "op": "<=", "value": 65},
+        ],
+        context="c",
+    )
+    assert sql == "age >= :__w0 AND age <= :__w1"
+    assert params == {"__w0": 18, "__w1": 65}
+
+
+def test_build_where_in_list():
+    sql, params = build_where(
+        [{"column": "status", "op": "IN", "value": ["a", "b", "c"]}], context="c"
+    )
+    assert sql == "status IN (:__w0_0, :__w0_1, :__w0_2)"
+    assert params == {"__w0_0": "a", "__w0_1": "b", "__w0_2": "c"}
+
+
+def test_build_where_not_in():
+    sql, _ = build_where(
+        [{"column": "status", "op": "NOT IN", "value": ["a"]}], context="c"
+    )
+    assert sql == "status NOT IN (:__w0_0)"
+
+
+@pytest.mark.parametrize("op", ["IS NULL", "IS NOT NULL"])
+def test_build_where_nullary_binds_nothing(op):
+    sql, params = build_where([{"column": "deleted_at", "op": op}], context="c")
+    assert sql == f"deleted_at {op}"
+    assert params == {}
+
+
+@pytest.mark.parametrize(
+    "raw,expected",
+    [
+        ("is not null", "IS NOT NULL"),
+        ("IS  NOT  NULL", "IS NOT NULL"),
+        ("in", "IN"),
+        ("like", "LIKE"),
+    ],
+)
+def test_build_where_normalizes_operator_case_and_spacing(raw, expected):
+    cond = {"column": "c", "op": raw}
+    if expected == "IN":
+        cond["value"] = ["x"]
+    elif expected == "LIKE":
+        cond["value"] = "x%"
+    sql, _ = build_where([cond], context="c")
+    assert expected in sql
+
+
+def test_build_where_null_value_binds_none():
+    _, params = build_where([{"column": "c", "op": "=", "value": None}], context="c")
+    assert params == {"__w0": None}
+
+
+# --- build_where: rejections ---
+
+
+def test_build_where_rejects_empty_conditions():
+    with pytest.raises(ValueError, match="no conditions supplied"):
+        build_where([], context="db_delete")
+
+
+def test_build_where_rejects_unknown_key():
+    with pytest.raises(ValueError, match="unknown key"):
+        build_where([{"column": "id", "value": 1, "table": "x"}], context="c")
+
+
+def test_build_where_rejects_missing_column():
+    with pytest.raises(ValueError, match="missing required key 'column'"):
+        build_where([{"op": "=", "value": 1}], context="c")
+
+
+def test_build_where_rejects_bad_column_name():
+    with pytest.raises(ValueError, match="invalid column name"):
+        build_where([{"column": "1", "op": "=", "value": 1}], context="c")
+
+
+def test_build_where_rejects_or_operator():
+    # "OR 1=1" is the canonical injection payload; OR is not in the allowlist.
+    with pytest.raises(ValueError) as exc:
+        build_where([{"column": "id", "op": "OR", "value": 1}], context="db_delete")
+    msg = str(exc.value)
+    assert "unsupported operator" in msg
+    assert "joined with AND" in msg
+    assert "IS NOT NULL" in msg  # enumerates what IS allowed so a model recovers
+
+
+@pytest.mark.parametrize("op", ["=; DROP TABLE t --", "GLOB", "MATCH", "REGEXP", ""])
+def test_build_where_rejects_operators_outside_allowlist(op):
+    with pytest.raises(ValueError, match="unsupported operator"):
+        build_where([{"column": "id", "op": op, "value": 1}], context="c")
+
+
+def test_build_where_rejects_non_string_operator():
+    with pytest.raises(ValueError, match="operator must be a string"):
+        build_where([{"column": "id", "op": 1, "value": 1}], context="c")
+
+
+def test_build_where_rejects_value_on_nullary_op():
+    with pytest.raises(ValueError, match="takes no value"):
+        build_where([{"column": "c", "op": "IS NULL", "value": None}], context="c")
+
+
+def test_build_where_rejects_scalar_op_without_value():
+    with pytest.raises(ValueError, match="requires a 'value' key"):
+        build_where([{"column": "c", "op": "="}], context="c")
+
+
+def test_build_where_rejects_in_with_scalar_value():
+    with pytest.raises(ValueError, match="requires a list value"):
+        build_where([{"column": "c", "op": "IN", "value": 1}], context="c")
+
+
+def test_build_where_rejects_in_with_empty_list():
+    with pytest.raises(ValueError, match="matches no rows"):
+        build_where([{"column": "c", "op": "IN", "value": []}], context="c")
+
+
+def test_build_where_rejects_like_with_non_string():
+    with pytest.raises(ValueError, match="requires a string value"):
+        build_where([{"column": "c", "op": "LIKE", "value": 5}], context="c")
+
+
+@pytest.mark.parametrize("value", [{"a": 1}, [1, 2], object()])
+def test_build_where_rejects_unbindable_value(value):
+    with pytest.raises(ValueError, match="cannot bind"):
+        build_where([{"column": "c", "op": "=", "value": value}], context="c")
+
+
+def test_build_where_rejects_unbindable_item_inside_in_list():
+    with pytest.raises(ValueError, match="cannot bind"):
+        build_where([{"column": "c", "op": "IN", "value": [{"a": 1}]}], context="c")
+
+
+# --- Param-name collision with UPDATE's __set_ prefix ---
+
+
+def test_where_params_never_collide_with_set_params():
+    _, params = build_where(
+        [
+            {"column": "set_x", "op": "=", "value": 1},
+            {"column": "w0", "op": "=", "value": 2},
+            {"column": "_", "op": "IN", "value": [3]},
+        ],
+        context="c",
+    )
+    assert params  # sanity
+    for key in params:
+        assert not key.startswith("__set_")
+        assert re.fullmatch(r"__w\d+(_\d+)?", key), key
+
+
+def test_build_where_output_binds_cleanly_in_sqlite():
+    conn = sqlite3.connect(":memory:")
+    conn.execute("CREATE TABLE t (id INTEGER, name TEXT)")
+    conn.executemany("INSERT INTO t VALUES (?,?)", [(1, "a"), (2, "b"), (3, "c")])
+    sql, params = build_where(
+        [{"column": "id", "op": "IN", "value": [1, 3]}], context="c"
+    )
+    rows = conn.execute(f"SELECT name FROM t WHERE {sql}", params).fetchall()
+    assert [r[0] for r in rows] == ["a", "c"]
+
+
+# --- readonly() authorizer ---
+
+
+@pytest.fixture
+def conn():
+    c = sqlite3.connect(":memory:")
+    c.execute("CREATE TABLE t (id INTEGER PRIMARY KEY, name TEXT)")
+    c.executemany("INSERT INTO t VALUES (?,?)", [(1, "a"), (2, "b"), (3, "c")])
+    c.commit()
+    yield c
+    c.close()
+
+
+@pytest.mark.parametrize(
+    "sql",
+    [
+        "SELECT * FROM t",
+        "SELECT COUNT(*) FROM t WHERE id > 1",
+        "WITH c AS (SELECT * FROM t) SELECT * FROM c",
+        "WITH RECURSIVE n(x) AS (SELECT 1 UNION ALL SELECT x+1 FROM n WHERE x<3)"
+        " SELECT * FROM n",
+        "SELECT upper(name) FROM t",
+        "PRAGMA table_info(t)",
+        "SELECT name FROM sqlite_master WHERE type='table'",
+    ],
+)
+def test_readonly_allows_reads(conn, sql):
+    with readonly(conn):
+        conn.execute(sql).fetchall()
+
+
+@pytest.mark.parametrize(
+    "sql",
+    [
+        "DELETE FROM t",
+        "UPDATE t SET name='x'",
+        "INSERT INTO t VALUES (4,'d')",
+        "DROP TABLE t",
+        "CREATE TABLE z (a INT)",
+        "ALTER TABLE t ADD COLUMN extra TEXT",
+        "ATTACH DATABASE ':memory:' AS x",
+        "PRAGMA writable_schema=ON",
+        "PRAGMA journal_mode=WAL",
+    ],
+)
+def test_readonly_denies_writes_and_ddl(conn, sql):
+    with pytest.raises(sqlite3.DatabaseError, match="not authorized"):
+        with readonly(conn):
+            conn.execute(sql).fetchall()
+    assert conn.execute("SELECT COUNT(*) FROM t").fetchone()[0] == 3
+
+
+def test_readonly_restores_authorizer_on_success(conn):
+    with readonly(conn):
+        conn.execute("SELECT * FROM t").fetchall()
+    conn.execute("DELETE FROM t WHERE id=1")
+    conn.commit()
+    assert conn.execute("SELECT COUNT(*) FROM t").fetchone()[0] == 2
+
+
+def test_readonly_restores_authorizer_after_denial(conn):
+    # A leaked authorizer would break every later write in the process.
+    with pytest.raises(sqlite3.DatabaseError):
+        with readonly(conn):
+            conn.execute("DELETE FROM t")
+    conn.execute("INSERT INTO t VALUES (4,'d')")
+    conn.commit()
+    assert conn.execute("SELECT COUNT(*) FROM t").fetchone()[0] == 4
+
+
+def test_readonly_restores_authorizer_after_unrelated_exception(conn):
+    with pytest.raises(RuntimeError):
+        with readonly(conn):
+            raise RuntimeError("boom")
+    conn.execute("INSERT INTO t VALUES (5,'e')")
+    conn.commit()
+    assert conn.execute("SELECT COUNT(*) FROM t").fetchone()[0] == 4
+
+
+def test_validate_identifier_rejects_trailing_newline():
+    """`$` would accept a trailing newline; the grammar we advertise doesn't."""
+    with pytest.raises(ValueError, match="invalid table name"):
+        validate_identifier("items\n", "table name", "db_delete")
+
+
+def test_build_where_rejects_oversized_in_list():
+    with pytest.raises(ValueError, match="SQLite can bind"):
+        build_where(
+            [{"column": "id", "op": "IN", "value": list(range(5000))}], context="c"
+        )
+
+
+def test_readonly_reports_denials_via_flag(conn):
+    """Denials are flagged by the authorizer, not sniffed from the message."""
+    with pytest.raises(sqlite3.DatabaseError):
+        with readonly(conn) as denied:
+            conn.execute("DELETE FROM t").fetchall()
+    assert denied
+
+
+def test_readonly_flag_stays_empty_for_ordinary_sql_errors(conn):
+    with pytest.raises(sqlite3.OperationalError):
+        with readonly(conn) as denied:
+            conn.execute("SELECT * FROM nope").fetchall()
+    assert denied == []
+
+
+def test_readonly_denies_vacuum(conn):
+    """VACUUM reports 'authorization denied', not 'not authorized'."""
+    with pytest.raises(sqlite3.DatabaseError):
+        with readonly(conn) as denied:
+            conn.execute("VACUUM")
+    assert denied
+
+
+def test_readonly_nesting_does_not_disarm_outer_window(conn):
+    with readonly(conn):
+        with readonly(conn):
+            pass
+        # Inner exit must not clear the outer authorizer.
+        with pytest.raises(sqlite3.DatabaseError):
+            conn.execute("DELETE FROM t")
+    conn.execute("DELETE FROM t WHERE id = 1")
+    conn.commit()
+    assert conn.execute("SELECT COUNT(*) FROM t").fetchone()[0] == 2
+
+
+# --- coerce_bool ---
+
+
+@pytest.mark.parametrize("value", [True, 1, "true", "True", " TRUE ", "1"])
+def test_coerce_bool_true_spellings(value):
+    assert coerce_bool(value, "all_rows", "c") is True
+
+
+@pytest.mark.parametrize("value", [False, 0, "false", "False", "0", None, ""])
+def test_coerce_bool_false_spellings(value):
+    assert coerce_bool(value, "all_rows", "c") is False
+
+
+@pytest.mark.parametrize("value", ["no", "yes", "off", 2, -1, [], {}, 1.5])
+def test_coerce_bool_rejects_ambiguous(value):
+    """bool() would read "no" as True; only enumerated spellings are accepted."""
+    with pytest.raises(ValueError, match="must be true or false"):
+        coerce_bool(value, "all_rows", "c")
+
+
+# --- coerce_object ---
+
+
+def test_coerce_object_accepts_dict_and_json():
+    assert coerce_object({"a": 1}, "data", "c") == {"a": 1}
+    assert coerce_object('{"a": 1}', "data", "c") == {"a": 1}
+
+
+@pytest.mark.parametrize("value", ["abc", "[1,2]", "123", 5, ["a"], None])
+def test_coerce_object_rejects_non_objects(value):
+    with pytest.raises(ValueError):
+        coerce_object(value, "data", "c")
+
+
+# --- readonly() window bookkeeping ---
+
+
+def test_readonly_registry_is_empty_after_use(conn):
+    with readonly(conn):
+        conn.execute("SELECT * FROM t").fetchall()
+    assert not _OPEN_WINDOWS
+
+
+def test_readonly_registry_is_empty_after_denial(conn):
+    with pytest.raises(sqlite3.DatabaseError):
+        with readonly(conn):
+            conn.execute("DELETE FROM t")
+    assert not _OPEN_WINDOWS
+
+
+def test_readonly_does_not_leak_window_when_arming_fails():
+    """A failed set_authorizer must not register a window later calls join."""
+    closed = sqlite3.connect(":memory:")
+    closed.close()
+    with pytest.raises(sqlite3.ProgrammingError):
+        with readonly(closed):
+            pass
+    assert not _OPEN_WINDOWS
+
+
+def test_readonly_nesting_refcounts(conn):
+    with readonly(conn):
+        with readonly(conn):
+            with readonly(conn):
+                pass
+            with pytest.raises(sqlite3.DatabaseError):
+                conn.execute("DELETE FROM t")
+        with pytest.raises(sqlite3.DatabaseError):
+            conn.execute("DELETE FROM t")
+    assert not _OPEN_WINDOWS
+    conn.execute("DELETE FROM t WHERE id = 1")
+    conn.commit()
+    assert conn.execute("SELECT COUNT(*) FROM t").fetchone()[0] == 2
+
+
+def test_readonly_concurrent_windows_stay_armed():
+    """One thread exiting must not disarm a window another thread still holds.
+
+    init_db() opens with check_same_thread=False, so this sharing is reachable.
+    """
+    import threading
+
+    shared = sqlite3.connect(":memory:", check_same_thread=False)
+    shared.execute("CREATE TABLE t (id INTEGER PRIMARY KEY)")
+    shared.executemany("INSERT INTO t VALUES (?)", [(1,), (2,), (3,)])
+    shared.commit()
+
+    start = threading.Barrier(2)
+    result = {}
+
+    def worker():
+        with readonly(shared):
+            start.wait(timeout=5)
+            time.sleep(0.2)  # outer window exits during this
+            try:
+                shared.execute("DELETE FROM t")
+                result["leaked"] = True
+            except sqlite3.DatabaseError:
+                result["leaked"] = False
+
+    t = threading.Thread(target=worker)
+    t.start()
+    with readonly(shared):
+        start.wait(timeout=5)
+    t.join(timeout=5)
+
+    assert result.get("leaked") is False
+    assert not _OPEN_WINDOWS
+    assert shared.execute("SELECT COUNT(*) FROM t").fetchone()[0] == 3
+    shared.close()


### PR DESCRIPTION
`DatabaseAgent` hands the LLM a set of database tools, and two of them — `db_update` and `db_delete` — took the WHERE clause as free text that got interpolated straight into the SQL. A model emitting `where="id = :id OR 1=1"`, whether through prompt injection or a plain mistake, deleted every row in the table instead of the one it meant. `db_query` compounded it: despite a docstring promising SELECTs, it ran whatever it was given, so `db_query("DELETE FROM users")` worked. Table and column names were interpolated unvalidated too, so `table="items WHERE 1=1 --"` rewrote the statement on its own. After this change the LLM cannot put raw SQL into any of these tools: filters are structured conditions that GAIA compiles and binds, identifiers are validated, reads are read-only at the SQLite engine level, and wiping a whole table takes an explicit `all_rows`.

The Python-facing `DatabaseMixin` API is deliberately unchanged — `where` stays a trusted SQL fragment for the ~30 internal callers that pass literals. The trust boundary is the tool layer, and a named regression test pins that split so it doesn't quietly erode.

### Threads

- **Structured conditions replace the WHERE string.** `[{"column","op","value"}]`, ANDed only, operators from a closed allowlist. An AND-chain of allowlisted predicates can only *narrow* the row set, so `OR 1=1` has no representable form — this is injection being impossible by construction rather than filtered by a pattern that has to anticipate every bypass.
- **`db_query` is genuinely read-only**, enforced by a SQLite authorizer rather than by sniffing the statement text. Denials are detected via a flag the authorizer sets, because SQLite's message varies (`not authorized` vs `authorization denied`) and a real SQL error must still surface as its own exception.
- **Identifier validation moved into the mixin**, so it protects every caller instead of only `db_schema`. `ScratchpadService` had been working around the gap locally.
- **JSON-string parameter forms are accepted.** The `@tool` schema advertises every non-`str` parameter as a JSON `string` (the Python→JSON type map keys on Python names while the registry already stores JSON names), so models really do send strings. `where`, `data`, and `all_rows` accept the encoded form — parsed strictly against enumerated spellings, never coerced. `all_rows="false"` must not read as true.
- **Mass mutation requires opt-in.** An empty condition list raises unless `all_rows` is set.

### Breaking changes

- `db_update` / `db_delete` tool signatures change. No in-tree agent subclasses `DatabaseAgent`, so internal blast radius is zero; external SDK users who exposed these tools will need the new shape.
- `db_schema` now raises on an invalid table name instead of returning `{"error": ..., "columns": []}` — a shape a model reads as "this table has no columns".
- `DatabaseMixin.insert/update/delete` reject table and column names that aren't bare identifiers. Quoted and non-ASCII names SQLite would accept are no longer allowed. Every in-tree call site passes literals (verified); this needs a release-note line for SDK users.

### Deliberately not fixed here

- **`db_insert` remains a full write primitive.** This change closes injection, not authorization — the tools still reach every table in the database. A per-table allowlist is a design change, not a bug fix. The class docstring now states this limit plainly instead of implying the tools are safe.
- **The `@tool` type-inference bug** collapses every non-`str` parameter to `"string"` across ~108 params repo-wide. That's why the JSON-string paths above exist. Worth its own issue.

### Test plan

- [ ] `python -m pytest tests/unit/test_sql_safety.py tests/unit/test_database_mixin.py tests/integration/test_database_agent.py -q`
- [ ] `python -m pytest tests/integration/test_database_mixin_integration.py -q` — must pass **unmodified**; it's the proof the mixin's trusted-fragment contract was preserved
- [ ] `python -m pytest tests/unit/test_scratchpad_service.py tests/unit/test_filesystem_index.py tests/unit/test_daemon_scheduler.py -q` — heaviest `DatabaseMixin` consumers, confirms identifier validation isn't over-strict
- [ ] `python util/lint.py --all`

Injection regressions assert the row count is unchanged after each payload: `OR 1=1` as free text and as `op: "OR"`, `table="items WHERE 1=1 --"`, injected column names, `db_query` parametrized over DELETE/UPDATE/DROP/INSERT/ATTACH/`PRAGMA writable_schema`/VACUUM, empty `where` without `all_rows`, and `all_rows="false"`. Separate tests cover authorizer reset after a denial (a leaked authorizer would break every later write in the process), nested and concurrent read-only windows, and that a genuine `OperationalError` isn't relabelled `PermissionError`.

No eval run: this touches tool docstrings and schemas, which is normally an eval-gated surface, but no eval scenario exercises `db_*` tools — no shipped agent subclasses `DatabaseAgent`.
