### PR TITLE
feat(llm): add Atlas Cloud provider

### DIFF
--- a/docs/sdk/configuration.mdx
+++ b/docs/sdk/configuration.mdx
@@ -24,6 +24,7 @@ export GAIA_API_STREAMING="1"  # stream LLM responses over the API
 # API Keys (for cloud providers)
 export ANTHROPIC_API_KEY="sk-ant-..."
 export OPENAI_API_KEY="sk-..."
+export ATLASCLOUD_API_KEY="atlas-..."
 ```
 
 <Note>

--- a/docs/sdk/sdks/llm.mdx
+++ b/docs/sdk/sdks/llm.mdx
@@ -66,6 +66,12 @@ llm_claude = create_client(use_claude=True)
 # OpenAI API
 llm_openai = create_client(use_openai=True)
 
+# Atlas Cloud's OpenAI-compatible LLM API
+llm_atlascloud = create_client(
+    "atlascloud",
+    model="deepseek-ai/deepseek-v3.2",
+)
+
 # LiteLLM gateway — 100+ providers (Bedrock, Vertex AI, Groq, Azure, ...)
 # Requires: pip install 'gaia[litellm]'
 llm_litellm = create_client("litellm", model="anthropic/claude-sonnet-4-6")

--- a/docs/spec/llm-client.mdx
+++ b/docs/spec/llm-client.mdx
@@ -58,7 +58,7 @@ Methods marked with ✗ raise `NotSupportedError` when called on that provider.
 
 1. **Factory Pattern**
    - `create_client()` factory function for client creation
-   - Explicit provider selection via `provider` parameter ("lemonade", "openai", "claude")
+   - Explicit provider selection via `provider` parameter ("lemonade", "openai", "atlascloud", "claude", "litellm")
    - Backward-compatible `use_claude`/`use_openai` flags
    - Auto-detection of provider from flags when `provider` not specified
    - Default to Lemonade provider when no flags set
@@ -150,7 +150,7 @@ def create_client(
     Create an LLM client, auto-detecting provider from parameters.
 
     Args:
-        provider: Explicit provider name ("lemonade", "openai", or "claude").
+        provider: Explicit provider name ("lemonade", "openai", "atlascloud", "claude", or "litellm").
                   If not specified, auto-detected from use_claude/use_openai flags.
         use_claude: If True, use Claude provider (ignored if provider is specified)
         use_openai: If True, use OpenAI provider (ignored if provider is specified)
@@ -169,6 +169,7 @@ def create_client(
         # Explicit provider selection
         client = create_client(provider="lemonade", model="Qwen3-0.6B-GGUF")
         client = create_client(provider="openai", api_key="sk-...")
+        client = create_client(provider="atlascloud", model="deepseek-ai/deepseek-v3.2")
         client = create_client(provider="claude", api_key="sk-ant-...")
 
         # Backward-compatible flags

--- a/src/gaia/llm/factory.py
+++ b/src/gaia/llm/factory.py
@@ -9,6 +9,7 @@ from .base_client import LLMClient
 _PROVIDERS: dict[str, str] = {
     "lemonade": "gaia.llm.providers.lemonade.LemonadeProvider",
     "openai": "gaia.llm.providers.openai_provider.OpenAIProvider",
+    "atlascloud": "gaia.llm.providers.atlascloud.AtlasCloudProvider",
     "claude": "gaia.llm.providers.claude.ClaudeProvider",
     "litellm": "gaia.llm.providers.litellm.LiteLLMProvider",
 }
@@ -24,8 +25,9 @@ def create_client(
     Create an LLM client, auto-detecting provider from parameters.
 
     Args:
-        provider: Explicit provider name ("lemonade", "openai", "claude", or "litellm").
-                  If not specified, auto-detected from use_claude/use_openai flags.
+        provider: Explicit provider name ("lemonade", "openai", "atlascloud",
+                  "claude", or "litellm"). If not specified, auto-detected from
+                  use_claude/use_openai flags.
         use_claude: If True, use Claude provider (ignored if provider is specified)
         use_openai: If True, use OpenAI provider (ignored if provider is specified)
         **kwargs: Provider-specific arguments (base_url, model, api_key, etc.)

--- a/src/gaia/llm/providers/__init__.py
+++ b/src/gaia/llm/providers/__init__.py
@@ -2,9 +2,16 @@
 # SPDX-License-Identifier: MIT
 """LLM provider implementations."""
 
+from .atlascloud import AtlasCloudProvider
 from .claude import ClaudeProvider
 from .lemonade import LemonadeProvider
 from .litellm import LiteLLMProvider
 from .openai_provider import OpenAIProvider
 
-__all__ = ["ClaudeProvider", "LemonadeProvider", "LiteLLMProvider", "OpenAIProvider"]
+__all__ = [
+    "AtlasCloudProvider",
+    "ClaudeProvider",
+    "LemonadeProvider",
+    "LiteLLMProvider",
+    "OpenAIProvider",
+]

--- a/src/gaia/llm/providers/atlascloud.py
+++ b/src/gaia/llm/providers/atlascloud.py
@@ -1,0 +1,53 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""Atlas Cloud provider using its OpenAI-compatible LLM API."""
+
+import os
+from typing import Optional
+
+from ..exceptions import NotSupportedError
+from .openai_provider import OpenAIProvider
+
+DEFAULT_ATLASCLOUD_BASE_URL = "https://api.atlascloud.ai/v1"
+DEFAULT_ATLASCLOUD_MODEL = "deepseek-ai/deepseek-v3.2"
+
+
+class AtlasCloudProvider(OpenAIProvider):
+    """Atlas Cloud chat-completions provider."""
+
+    def __init__(
+        self,
+        api_key: Optional[str] = None,
+        model: str = DEFAULT_ATLASCLOUD_MODEL,
+        base_url: str = DEFAULT_ATLASCLOUD_BASE_URL,
+        system_prompt: Optional[str] = None,
+        **client_kwargs,
+    ):  # pylint: disable=super-init-not-called
+        resolved_api_key = api_key or os.getenv("ATLASCLOUD_API_KEY")
+        if not resolved_api_key:
+            raise ValueError(
+                "Atlas Cloud API key is required. Set ATLASCLOUD_API_KEY or pass "
+                "api_key."
+            )
+
+        import openai
+
+        self._client = openai.OpenAI(
+            api_key=resolved_api_key,
+            base_url=base_url.rstrip("/"),
+            **client_kwargs,
+        )
+        self._model = model
+        self._system_prompt = system_prompt
+
+    @property
+    def provider_name(self) -> str:
+        return "Atlas Cloud"
+
+    def embed(
+        self,
+        texts: list[str],
+        model: str = "text-embedding-3-small",
+        **kwargs,
+    ) -> list[list[float]]:
+        raise NotSupportedError(self.provider_name, "embed")

--- a/tests/unit/test_atlascloud_provider.py
+++ b/tests/unit/test_atlascloud_provider.py
@@ -1,0 +1,115 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""Unit tests for the Atlas Cloud LLM provider."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from gaia.llm.exceptions import NotSupportedError
+from gaia.llm.providers.atlascloud import (
+    DEFAULT_ATLASCLOUD_BASE_URL,
+    DEFAULT_ATLASCLOUD_MODEL,
+    AtlasCloudProvider,
+)
+
+
+@pytest.fixture()
+def mock_openai_module():
+    mock_mod = MagicMock()
+    mock_client = MagicMock()
+    mock_mod.OpenAI.return_value = mock_client
+    with patch.dict("sys.modules", {"openai": mock_mod}):
+        yield mock_mod, mock_client
+
+
+class TestAtlasCloudProviderInit:
+    def test_uses_explicit_configuration(self, mock_openai_module):
+        mock_mod, _ = mock_openai_module
+
+        provider = AtlasCloudProvider(
+            api_key="atlas-test",
+            model="openai/gpt-5",
+            base_url="https://atlas.example/v1/",
+            timeout=30,
+        )
+
+        mock_mod.OpenAI.assert_called_once_with(
+            api_key="atlas-test",
+            base_url="https://atlas.example/v1",
+            timeout=30,
+        )
+        assert provider._model == "openai/gpt-5"
+        assert provider.provider_name == "Atlas Cloud"
+
+    def test_uses_environment_api_key(self, mock_openai_module, monkeypatch):
+        mock_mod, _ = mock_openai_module
+        monkeypatch.setenv("ATLASCLOUD_API_KEY", "atlas-env")
+
+        AtlasCloudProvider()
+
+        mock_mod.OpenAI.assert_called_once_with(
+            api_key="atlas-env",
+            base_url=DEFAULT_ATLASCLOUD_BASE_URL,
+        )
+
+    def test_explicit_api_key_overrides_environment(
+        self, mock_openai_module, monkeypatch
+    ):
+        mock_mod, _ = mock_openai_module
+        monkeypatch.setenv("ATLASCLOUD_API_KEY", "atlas-env")
+
+        AtlasCloudProvider(api_key="atlas-explicit")
+
+        assert mock_mod.OpenAI.call_args.kwargs["api_key"] == "atlas-explicit"
+
+    def test_missing_api_key_fails_loudly(self, mock_openai_module, monkeypatch):
+        monkeypatch.delenv("ATLASCLOUD_API_KEY", raising=False)
+
+        with pytest.raises(ValueError, match="ATLASCLOUD_API_KEY"):
+            AtlasCloudProvider()
+
+    def test_default_model(self, mock_openai_module):
+        provider = AtlasCloudProvider(api_key="atlas-test")
+
+        assert provider._model == DEFAULT_ATLASCLOUD_MODEL
+
+
+class TestAtlasCloudFactory:
+    def test_create_client(self, mock_openai_module):
+        from gaia.llm import create_client
+
+        provider = create_client("atlascloud", api_key="atlas-test")
+
+        assert isinstance(provider, AtlasCloudProvider)
+
+    def test_create_client_is_case_insensitive(self, mock_openai_module):
+        from gaia.llm import create_client
+
+        provider = create_client("ATLASCLOUD", api_key="atlas-test")
+
+        assert provider.provider_name == "Atlas Cloud"
+
+
+class TestAtlasCloudChat:
+    def test_chat_uses_default_model(self, mock_openai_module):
+        _, client = mock_openai_module
+        response = MagicMock()
+        response.choices = [MagicMock()]
+        response.choices[0].message.content = "hello"
+        client.chat.completions.create.return_value = response
+        provider = AtlasCloudProvider(api_key="atlas-test")
+
+        result = provider.chat([{"role": "user", "content": "Hi"}])
+
+        assert result == "hello"
+        assert (
+            client.chat.completions.create.call_args.kwargs["model"]
+            == DEFAULT_ATLASCLOUD_MODEL
+        )
+
+    def test_embedding_fails_as_unsupported(self, mock_openai_module):
+        provider = AtlasCloudProvider(api_key="atlas-test")
+
+        with pytest.raises(NotSupportedError, match="Atlas Cloud.*embed"):
+            provider.embed(["hello"])


### PR DESCRIPTION
Closes #2875

GAIA users can now select Atlas Cloud through the normal LLM client factory instead of wiring a generic OpenAI client by hand. The provider reads `ATLASCLOUD_API_KEY`, uses Atlas Cloud's OpenAI-compatible endpoint, keeps the model and base URL configurable, and fails loudly when credentials are missing.

## Test plan
- [x] 55 focused provider and factory tests
- [x] 284 affected baseline tests (2 skipped)
- [x] Black, isort, Pylint, Flake8, MyPy, Bandit, and import checks
- [x] Python compileall
- [x] Wheel build and package-content verification
