### PR TITLE
docs(dev): require --extra-index-url for every uv pip install on Linux

### DIFF
--- a/docs/reference/dev.mdx
+++ b/docs/reference/dev.mdx
@@ -107,7 +107,7 @@ You should see `(.venv)` in your terminal prompt when activated.
 ### Step 5: Install Dependencies
 
 <Warning>
-  **Linux/WSL users:** GAIA's base dependencies (`transformers`, `accelerate`) require PyTorch. Always use `--extra-index-url` to install CPU-only PyTorch and avoid large CUDA packages (~2GB → ~200MB).
+  **Linux/WSL users:** GAIA's base dependencies (`transformers`, `accelerate`) require PyTorch. Always use `--extra-index-url` to install CPU-only PyTorch and avoid large CUDA packages (the PyTorch download alone drops from ~2 GB to ~200 MB).
 </Warning>
 
 ```bash

--- a/docs/reference/dev.mdx
+++ b/docs/reference/dev.mdx
@@ -135,8 +135,9 @@ On Linux the flag is required for **every** `uv pip install`, with or without
 extras — `accelerate` is an unconditional base dependency, so PyTorch is always
 resolved. The `[tool.uv.sources]` block in `pyproject.toml` does not help here:
 it applies only to uv's project interface (`uv sync`, `uv lock`, `uv add`), never
-to `uv pip install`. Omit the flag and you get `torch==2.13.0+cu130` plus ~15
-`nvidia-*` packages — a 4.7 GB venv instead of 1.5 GB.
+to `uv pip install`. Omit the flag and PyTorch resolves from PyPI as a CUDA
+build, pulling ~18 `nvidia-*` / `cuda-*` packages — a 4.7 GB venv instead of
+1.5 GB.
 </Note>
 
 **Available extras** (see `setup.py` for the full list):

--- a/docs/reference/dev.mdx
+++ b/docs/reference/dev.mdx
@@ -123,19 +123,20 @@ uv pip install -e ".[dev]"
 
 **With optional extras:**
 ```bash
-# Linux/WSL  (uv picks the CPU-PyTorch wheel automatically via
-# tool.uv.sources in pyproject.toml — no --extra-index-url needed)
-uv pip install -e ".[dev,talk,rag,ui]"
+# Linux/WSL - CPU-only PyTorch (required, extras or not)
+uv pip install -e ".[dev,talk,rag,ui]" --extra-index-url https://download.pytorch.org/whl/cpu
 
 # Windows
 uv pip install -e ".[dev,talk,rag,ui]"
 ```
 
 <Note>
-The `--extra-index-url https://download.pytorch.org/whl/cpu` workaround is
-only needed with plain `pip`. `uv` reads `tool.uv.sources.pytorch-cpu` from
-`pyproject.toml` and routes CPU-only torch wheels through the right index
-automatically.
+On Linux the flag is required for **every** `uv pip install`, with or without
+extras — `accelerate` is an unconditional base dependency, so PyTorch is always
+resolved. The `[tool.uv.sources]` block in `pyproject.toml` does not help here:
+it applies only to uv's project interface (`uv sync`, `uv lock`, `uv add`), never
+to `uv pip install`. Omit the flag and you get `torch==2.13.0+cu130` plus ~15
+`nvidia-*` packages — a 4.7 GB venv instead of 1.5 GB.
 </Note>
 
 **Available extras** (see `setup.py` for the full list):


### PR DESCRIPTION
`docs/reference/dev.mdx` Step 5 told Linux contributors two opposite things about `--extra-index-url`: a `<Warning>` saying always use it, then a code comment and a `<Note>` two paragraphs below saying uv routes CPU-only PyTorch automatically. Anyone following the "with optional extras" command — the one you need for `[ui]` or `[rag]` — resolved a CUDA-linked PyTorch and 18 `nvidia-*`/`cuda-*` packages: a 4.7 GB venv of CUDA on AMD-only hardware. The flag is now present in every Linux command, and the `<Note>` explains why it is always required: `accelerate` is an unconditional base dependency, and `[tool.uv.sources]` applies only to uv's project interface (`uv sync`/`uv lock`/`uv add`), never to `uv pip install`.

Closes #2877

## Test plan

- [x] Linux/x86_64, resolution-only into a clean throwaway venv: `uv pip install --dry-run -e .` (no flag) resolves `torch==2.13.0` plus **18** `nvidia-*`/`cuda-*` packages — full output in the comment below
- [x] Same box: adding `--extra-index-url https://download.pytorch.org/whl/cpu` resolves `torch==2.13.0+cpu` with **zero** CUDA packages
- [x] `git diff --stat` touches only `docs/reference/dev.mdx`
- [x] The Windows commands are unchanged (they correctly omit the flag)
- [x] The `<Warning>` and the `<Note>` in Step 5 now state the same rule

<details>
<summary>Why the old <code>&lt;Note&gt;</code> was wrong, and how it got there</summary>

`[tool.uv.sources]` is a **project-interface** feature — `uv sync`, `uv lock`, `uv add`. uv's documentation states that project-interface settings have "no effect on the uv pip interface", which is configured separately under `[tool.uv.pip]`. Every install command in GAIA's docs is `uv pip install`, so the routing never applied.

Two further errors in the old note:

- it named a key that does not exist — `tool.uv.sources.pytorch-cpu`, where `pytorch-cpu` is the *index* name in `[[tool.uv.index]]` (`pyproject.toml:61-64`); the actual `sources` keys are `torch`/`torchvision`/`torchaudio` (`:66-69`);
- `pyproject.toml` has no `[project]` table, so uv's project interface is not usable on this repo at all — the sources block cannot fire via any command the docs use.

Both the note and the flagless extras command were introduced by #794 ("docs: fix drift between docs and source").

Not changed, because they were already correct: `docs/quickstart.mdx:264,412`, `docs/guides/talk.mdx:38`, `installer/scripts/install.sh:210,244`, `src/gaia/apps/webui/services/backend-installer.cjs:1462`.

</details>
