### PR TITLE
fix(webui): raise declared Node floor from >=18 to 20.19.0

### DIFF
--- a/docs/guides/agent-ui.mdx
+++ b/docs/guides/agent-ui.mdx
@@ -98,7 +98,7 @@ Pick the install path that fits you best:
   <Tab title="npm">
     The npm package handles everything — on first run it auto-installs Python, the GAIA backend, Lemonade Server, and a minimal model.
 
-    **Requires:** [Node.js 20+](https://nodejs.org) (`winget install OpenJS.NodeJS.LTS` on Windows, `brew install node@20` on macOS)
+    **Requires:** [Node.js 20.19+](https://nodejs.org) (`winget install OpenJS.NodeJS.LTS` on Windows, `brew install node@20` on macOS)
 
     ```bash
     npm install -g @amd-gaia/agent-ui

--- a/docs/playbooks/custom-installer/index.mdx
+++ b/docs/playbooks/custom-installer/index.mdx
@@ -41,7 +41,7 @@ Who this path is for: **OEM partners** pre-loading GAIA on Ryzen AI hardware, **
 What you need installed:
 
 - Git
-- Node.js 18+ and npm
+- Node.js 20.19+ and npm
 - Python 3.10+ (for running the agent locally to verify it before packaging)
 
 Clone and install:

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -54,7 +54,7 @@ gaia-ui
 On first run, GAIA automatically installs the Python backend and all dependencies.
 
 <Note>
-  Requires [Node.js 20+](https://nodejs.org). If you don't have it:
+  Requires [Node.js 20.19+](https://nodejs.org). If you don't have it:
 
   - **Windows:** `winget install OpenJS.NodeJS.LTS`
   - **macOS:** `brew install node@20`

--- a/scripts/install-ui.ps1
+++ b/scripts/install-ui.ps1
@@ -24,13 +24,13 @@ try {
     Write-Host "  Node.js: $nodeVersion" -ForegroundColor Green
 } catch {
     Write-Host "  ERROR: Node.js is not installed." -ForegroundColor Red
-    Write-Host "  Install Node.js 18+ from https://nodejs.org"
+    Write-Host "  Install Node.js 20.19+ from https://nodejs.org"
     exit 1
 }
 
 $nodeMajor = [int]($nodeVersion -replace 'v','').Split('.')[0]
-if ($nodeMajor -lt 18) {
-    Write-Host "  ERROR: Node.js 18+ is required. Current version: $nodeVersion" -ForegroundColor Red
+if ($nodeMajor -lt 20) {
+    Write-Host "  ERROR: Node.js 20.19+ is required. Current version: $nodeVersion" -ForegroundColor Red
     exit 1
 }
 

--- a/scripts/install-ui.sh
+++ b/scripts/install-ui.sh
@@ -23,15 +23,15 @@ echo "Checking prerequisites..."
 # Check Node.js
 if ! command -v node &> /dev/null; then
     echo "  ERROR: Node.js is not installed."
-    echo "  Install Node.js 18+ from https://nodejs.org"
+    echo "  Install Node.js 20.19+ from https://nodejs.org"
     exit 1
 fi
 
 NODE_VERSION=$(node -v | sed 's/v//' | cut -d. -f1)
 echo "  Node.js: $(node -v)"
 
-if [ "$NODE_VERSION" -lt 18 ]; then
-    echo "  ERROR: Node.js 18+ is required. Current version: $(node -v)"
+if [ "$NODE_VERSION" -lt 20 ]; then
+    echo "  ERROR: Node.js 20.19+ is required. Current version: $(node -v)"
     exit 1
 fi
 

--- a/src/gaia/apps/webui/package.json
+++ b/src/gaia/apps/webui/package.json
@@ -44,7 +44,7 @@
     "LICENSE"
   ],
   "engines": {
-    "node": ">=18"
+    "node": ">=20.19.0"
   },
   "scripts": {
     "dev": "vite",

--- a/src/gaia/apps/webui/services/agent-seeder.cjs
+++ b/src/gaia/apps/webui/services/agent-seeder.cjs
@@ -120,7 +120,7 @@ function copyDirRecursive(src, dest) {
     fs.cpSync(src, dest, { recursive: true, errorOnExist: false, force: true, dereference: true });
     return;
   }
-  // Fallback path (shouldn't normally hit on Electron 40 / Node 20).
+  // Fallback path (shouldn't normally hit on Electron 43 / Node 24).
   fs.mkdirSync(dest, { recursive: true });
   for (const entry of fs.readdirSync(src, { withFileTypes: true })) {
     const s = path.join(src, entry.name);

--- a/tests/unit/test_webui_node_engines.py
+++ b/tests/unit/test_webui_node_engines.py
@@ -1,0 +1,152 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""Regression: every place that states a Node.js floor for building
+``src/gaia/apps/webui`` must agree with the package's own ``engines.node``
+(issue #2879).
+
+The locked ``vite``/``rolldown`` toolchain declares ``^20.19.0 || >=22.12.0``;
+below that, the build fails at parse time (``node:util`` has no ``styleText``
+export before Node 20.12) or the bundler itself refuses with ``EBADENGINE``.
+``engines.node`` is the single source of truth for the floor -- every CI job
+that actually builds the webui, and both installer scripts' hardcoded Node
+gate, must be at or above it, or a contributor/packager on a too-old Node
+gets a cryptic bundler crash instead of an actionable error.
+
+Modeled on tests/unit/test_amd_gaia_urls.py -- structural scan + invariant,
+fails CI on drift, never hardcodes either side of the comparison.
+"""
+
+import json
+import re
+from pathlib import Path
+
+import yaml
+
+_ROOT = Path(__file__).resolve().parents[2]
+_WEBUI_PKG = _ROOT / "src" / "gaia" / "apps" / "webui" / "package.json"
+_WORKFLOWS_DIR = _ROOT / ".github" / "workflows"
+_INSTALL_SH = _ROOT / "scripts" / "install-ui.sh"
+_INSTALL_PS1 = _ROOT / "scripts" / "install-ui.ps1"
+
+# The literal path a workflow step must reference for its job to be treated
+# as "builds the webui" -- deliberately a plain substring check (not a glob)
+# so a future job that touches this path is picked up automatically instead
+# of requiring this file to be updated too.
+_WEBUI_PATH_LITERAL = "src/gaia/apps/webui"
+
+_FLOOR_RE = re.compile(r"^>=\s*(\d+)\.(\d+)\.(\d+)$")
+_BARE_MAJOR_RE = re.compile(r"^(\d+)$")
+
+
+def _read_floor() -> tuple:
+    """Parse engines.node from the webui package.json into a (major, minor,
+    patch) tuple. Raises rather than guessing if the declared range isn't a
+    simple '>=X.Y.Z' floor -- a range shape this guard can't confidently
+    reason about must fail loud, not pass silently."""
+    data = json.loads(_WEBUI_PKG.read_text(encoding="utf-8"))
+    node_range = data.get("engines", {}).get("node")
+    assert node_range, f"{_WEBUI_PKG} declares no engines.node"
+    match = _FLOOR_RE.match(node_range.strip())
+    assert match, (
+        f"{_WEBUI_PKG} engines.node={node_range!r} is not a simple '>=X.Y.Z' "
+        "floor this guard knows how to parse"
+    )
+    return tuple(int(g) for g in match.groups())
+
+
+def _bare_major_satisfies_floor(pin: str, floor: tuple) -> bool:
+    """A bare major CI pin (e.g. '20', '24') is assumed to resolve to the
+    latest patch of that major -- setup-node's documented behavior, verified
+    once against a live green run (see PR body), not re-checked per run.
+    Any other pin shape (an exact version, a range) is not evaluated here;
+    the caller raises rather than silently passing it."""
+    match = _BARE_MAJOR_RE.match(pin.strip())
+    assert match, (
+        f"CI node-version pin {pin!r} is not a bare major this guard knows "
+        "how to evaluate against the engines.node floor"
+    )
+    return int(match.group(1)) >= floor[0]
+
+
+def _find_webui_building_jobs() -> list:
+    """Walk every workflow file (not a hardcoded list -- the file list is
+    itself drift) and return (workflow_path, job_name, node_version_pin) for
+    each job that both pins actions/setup-node's node-version AND references
+    the literal webui path somewhere in the job (run/working-directory/
+    cache-dependency-path)."""
+    found = []
+    for wf_path in sorted(_WORKFLOWS_DIR.glob("*.yml")):
+        doc = yaml.safe_load(wf_path.read_text(encoding="utf-8"))
+        if not isinstance(doc, dict):
+            continue
+        jobs = doc.get("jobs")
+        if not isinstance(jobs, dict):
+            continue
+        for job_name, job in jobs.items():
+            if not isinstance(job, dict):
+                continue
+            if _WEBUI_PATH_LITERAL not in yaml.dump(job):
+                continue
+            node_version = None
+            for step in job.get("steps") or []:
+                if not isinstance(step, dict):
+                    continue
+                uses = step.get("uses", "")
+                if isinstance(uses, str) and "actions/setup-node" in uses:
+                    node_version = (step.get("with") or {}).get("node-version")
+            if node_version is not None:
+                found.append((wf_path, job_name, str(node_version)))
+    return found
+
+
+def _installer_gate_major(path: Path, pattern: str) -> int:
+    match = re.search(pattern, path.read_text(encoding="utf-8"))
+    assert match, f"{path} does not contain the expected Node major-version gate"
+    return int(match.group(1))
+
+
+def test_webui_engines_node_floor_is_declared():
+    floor = _read_floor()
+    assert floor >= (1, 0, 0)
+
+
+def test_ci_jobs_building_webui_satisfy_the_engines_floor():
+    floor = _read_floor()
+    webui_jobs = _find_webui_building_jobs()
+    assert webui_jobs, (
+        "selector found no job building src/gaia/apps/webui across "
+        f"{_WORKFLOWS_DIR}/*.yml -- it broke, or the webui path moved"
+    )
+
+    offenders = []
+    for wf_path, job_name, pin in webui_jobs:
+        try:
+            satisfied = _bare_major_satisfies_floor(pin, floor)
+        except AssertionError as exc:
+            offenders.append(f"{wf_path.name}:{job_name}: {exc}")
+            continue
+        if not satisfied:
+            offenders.append(
+                f"{wf_path.name}:{job_name}: node-version {pin!r} is below the "
+                f"engines.node floor {'.'.join(map(str, floor))}"
+            )
+
+    assert not offenders, (
+        "CI job(s) building the webui pin a Node version below engines.node "
+        "(issue #2879):\n  " + "\n  ".join(offenders)
+    )
+
+
+def test_installer_scripts_gate_satisfies_the_engines_floor():
+    floor = _read_floor()
+    sh_major = _installer_gate_major(_INSTALL_SH, r'"\$NODE_VERSION"\s*-lt\s*(\d+)')
+    ps1_major = _installer_gate_major(_INSTALL_PS1, r"\$nodeMajor\s*-lt\s*(\d+)")
+
+    assert sh_major >= floor[0], (
+        f"{_INSTALL_SH} gates on Node major {sh_major}, below the engines.node "
+        f"floor major {floor[0]}"
+    )
+    assert ps1_major >= floor[0], (
+        f"{_INSTALL_PS1} gates on Node major {ps1_major}, below the "
+        f"engines.node floor major {floor[0]}"
+    )


### PR DESCRIPTION
Closes #2879

## Why this matters

`src/gaia/apps/webui/package.json` declared `engines.node: ">=18"`, but the Agent UI cannot build on Node 18 — it dies at parse time (`node:util.styleText`, added in Node 20.12), and the locked bundler (`vite@8.2.0` / `rolldown@1.2.1`) declares it needs **Node 20.19+**. The same stale "Node 18" claim was repeated across the curl-to-bash installer scripts and setup docs, and nothing checked that these places agreed. Anyone following the declared floor — a new contributor, a packager, an automated setup — got a broken Agent UI and a cryptic error that didn't point at the cause. This raises the declared floor to the honest **20.19.0** everywhere it's stated, and adds a drift guard so the declarations can't silently diverge again.

The floor was measured on real Node versions, not guessed — see the evidence below. The narrower "bump CI to a newer Node just to silence a cosmetic transitive-dependency warning" work is intentionally **not** in this PR (asymmetric risk mid-release-candidate); it's a separate follow-up.

## Test plan

- [x] `tests/unit/test_webui_node_engines.py` — new drift guard, written first and run red against the pre-fix tree (`engines.node='>=18' is not a simple '>=X.Y.Z' floor`), green after the fix. It walks every workflow YAML (no hardcoded job list), asserts a **non-empty** set of webui-building jobs, and checks each pinned Node — plus both installer scripts — satisfies the declared floor.
- [x] `python util/lint.py --all` clean (Black/isort/flake8/pylint/bandit PASS).
- [x] Full `tests/unit/` suite: 8135 passed, 3/3 new tests green. (7 failures are throwaway-venv provisioning artifacts — unactivated PATH, `uv venv` shipping without `pip`, a nested-worktree `.env`, and a `[dev]+[ui]` extras combo — none touch a changed file; all pass in CI's clean environment.)

<details>
<summary>Node floor measurement (Radeon dGPU box, Ubuntu, npm ci)</summary>

| Node | Result |
|---|---|
| 18.19.1 | FAIL — `styleText` parse error (cited from issue; reproduced on two checkouts) |
| 20.11.1 | FAIL — no `styleText` |
| 20.12.2 | **HARD build failure** — npm skips `@rolldown/binding-linux-x64-gnu` (the optional dep's own `engines` gate excludes 20.12.2), so the bundler can't find its native binding. (Correction to the original hypothesis, which predicted "builds but warns".) |
| **20.19.0** | **BUILD, clean of vite/rolldown EBADENGINE** — the chosen floor |
| 20.20.2 | builds, warns (cited from issue) |
| 22.22.2 | builds, zero EBADENGINE — rejected as the floor (see below) |

**Why 20.19.0 and not 22.x:** the residual EBADENGINE above 20.19 comes from `node-abi@4.33.0` (`>=22.12.0`) and the test-only `jsdom@30.0.1` / `mute-stream@4.0.0` (`^22.22.2 || ^24.15.0 || >=26.0.0`) — none of which the Agent UI *build* needs (the app has no native production deps to rebuild). Their warning is cosmetic; chasing it would over-declare the floor and needlessly restrict consumers. (Note: `whatwg-url@17.1.0` carries a *different* constraint, `^22.14.0 || >=24.0.0`, and does not belong to that group.)

**CI needs no edits.** Six jobs pin `node-version` and build `src/gaia/apps/webui`: `test_electron.yml:test-webui-vitest`, `pypi.yml:build`, `build-installers.yml:build`, `publish.yml:validate`, `publish.yml:build-npm` (all `'20'`), and `publish.yml:publish-npm` (`'24'`, deliberately higher for npm-provenance OIDC). A real green run ([`gh run 30467337052`](https://github.com/amd/gaia/actions/runs/30467337052)) shows bare `'20'` resolving to **20.20.2** — above the 20.19.0 floor — so every pin already satisfies it. The drift guard's self-updating selector independently picked up the same six jobs.

**Consumer scope:** one coherent floor is declared everywhere (package.json, `.nvmrc` already `v20.20.0`, installer scripts, docs) rather than a split build-vs-runtime pair — two numbers is exactly the drift this fixes, and issue #2880's build preflight reads `engines.node` and needs it to carry the build floor. Sub-floor consumers get only a non-fatal warning (no `engine-strict` anywhere in the repo). The MCP-npx "Node 18+" note in the connector docs is left as-is — that's an unrelated launcher requirement, not the webui build toolchain.
</details>
