### PR TITLE
fix(init): stop reporting success gaia init did not deliver

### DIFF
--- a/src/gaia/installer/_stdin.py
+++ b/src/gaia/installer/_stdin.py
@@ -1,0 +1,23 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+"""Shared stdin-TTY detection for installer commands.
+
+A leaf module (no imports from sibling command modules) so both
+``init_command.py`` and ``uninstall_command.py`` can detect whether stdin is
+an interactive terminal without one command module importing another.
+"""
+
+import sys
+
+
+def stdin_is_tty() -> bool:
+    """Return True if stdin looks like an interactive terminal.
+
+    False on any of the ways a non-interactive run can make ``isatty()``
+    itself raise (e.g. closed stdin), not just when it returns False.
+    """
+    try:
+        return bool(sys.stdin.isatty())
+    except (AttributeError, ValueError, OSError):
+        return False

--- a/src/gaia/installer/init_command.py
+++ b/src/gaia/installer/init_command.py
@@ -33,6 +33,7 @@ except ImportError:
 
 from gaia.agents.base.console import AgentConsole
 from gaia.agents.install_hints import source_install_command
+from gaia.installer._stdin import stdin_is_tty
 from gaia.installer.lemonade_installer import LemonadeInfo, LemonadeInstaller
 from gaia.llm.lemonade_launcher import (
     build_start_command,
@@ -507,6 +508,23 @@ class InitCommand:
         Returns:
             Exit code (0 for success, non-zero for failure)
         """
+        # Refuse rather than silently declining every prompt: with nobody to
+        # answer them, EOFError-driven defaults used to report success on a
+        # setup that never downloaded a model (issue #2882).
+        if not self.yes and not stdin_is_tty():
+            print(
+                f"Error: refusing to run 'gaia init --profile {self.profile}' "
+                "non-interactively without --yes.\n"
+                "Pass --yes to auto-confirm setup prompts (add --skip-models "
+                "to also skip downloading models).\n"
+                "Note: --yes also authorizes an unattended Lemonade upgrade, "
+                "which uninstalls the current Lemonade install before "
+                "reinstalling, if the detected version is below this "
+                "profile's minimum.",
+                file=sys.stderr,
+            )
+            return 1
+
         self._print_header()
 
         profile_config = INIT_PROFILES[self.profile]

--- a/src/gaia/installer/init_command.py
+++ b/src/gaia/installer/init_command.py
@@ -508,9 +508,8 @@ class InitCommand:
         Returns:
             Exit code (0 for success, non-zero for failure)
         """
-        # Refuse rather than silently declining every prompt: with nobody to
-        # answer them, EOFError-driven defaults used to report success on a
-        # setup that never downloaded a model (issue #2882).
+        # No one to answer prompts non-interactively -- refuse instead of
+        # silently declining every one and claiming a setup that never ran.
         if not self.yes and not stdin_is_tty():
             print(
                 f"Error: refusing to run 'gaia init --profile {self.profile}' "
@@ -1891,7 +1890,7 @@ class InitCommand:
                 self.console.print()
                 self._print_warning("Verification interrupted")
                 # Ctrl-C means stop, not "skip the rest and declare success" --
-                # propagate to run()'s own KeyboardInterrupt handler (#2882).
+                # propagate to run()'s own KeyboardInterrupt handler.
                 raise
 
             # Summary
@@ -2073,9 +2072,8 @@ class InitCommand:
             f"{source_install_command('gaia-agent-chat')}"
         )
         # Scoped like run()'s has_hub_agent_check (agent == "chat" covers
-        # both chat and npu): gating on chat_agent_available alone would mark
-        # sd/vlm/minimal permanently "incomplete", since the chat wheel isn't
-        # something those profiles ever install (#2882).
+        # chat + npu) -- gating on chat_agent_available alone would mark
+        # sd/vlm/minimal permanently "incomplete"; they never install it.
         setup_incomplete = (
             INIT_PROFILES[self.profile].get("agent") == "chat"
             and not chat_agent_available

--- a/src/gaia/installer/init_command.py
+++ b/src/gaia/installer/init_command.py
@@ -2072,11 +2072,24 @@ class InitCommand:
             "Chat agent not installed yet -- run: "
             f"{source_install_command('gaia-agent-chat')}"
         )
+        # Scoped like run()'s has_hub_agent_check (agent == "chat" covers
+        # both chat and npu): gating on chat_agent_available alone would mark
+        # sd/vlm/minimal permanently "incomplete", since the chat wheel isn't
+        # something those profiles ever install (#2882).
+        setup_incomplete = (
+            INIT_PROFILES[self.profile].get("agent") == "chat"
+            and not chat_agent_available
+        )
+        headline = (
+            "GAIA initialization incomplete - see below"
+            if setup_incomplete
+            else "GAIA initialization complete!"
+        )
         if RICH_AVAILABLE and self.console:
             self.console.print()
             self.console.print(
                 Panel(
-                    "[bold green]GAIA initialization complete![/bold green]",
+                    f"[bold green]{headline}[/bold green]",
                     border_style="green",
                     padding=(0, 2),
                 )
@@ -2158,7 +2171,7 @@ class InitCommand:
         else:
             self._print("")
             self._print("=" * 60)
-            self._print("  GAIA initialization complete!")
+            self._print(f"  {headline}")
             self._print("=" * 60)
             self._print("")
             self._print("  Quick start commands:")

--- a/src/gaia/installer/init_command.py
+++ b/src/gaia/installer/init_command.py
@@ -347,7 +347,7 @@ class InitCommand:
             if not response:
                 return default
             return response in ("y", "yes")
-        except (EOFError, KeyboardInterrupt):
+        except EOFError:
             self._print("")
             return False
 
@@ -1341,7 +1341,7 @@ class InitCommand:
                     "   [bold]Press Enter when server is started...[/bold]", end=""
                 )
                 input()
-            except (EOFError, KeyboardInterrupt):
+            except EOFError:
                 self.console.print()
                 self._print_error("Initialization cancelled")
                 return False
@@ -1839,7 +1839,6 @@ class InitCommand:
 
             models_passed = 0
             models_failed = []
-            interrupted = False
 
             try:
                 for model_id in model_ids:
@@ -1891,16 +1890,14 @@ class InitCommand:
             except KeyboardInterrupt:
                 self.console.print()
                 self._print_warning("Verification interrupted")
-                interrupted = True
+                # Ctrl-C means stop, not "skip the rest and declare success" --
+                # propagate to run()'s own KeyboardInterrupt handler (#2882).
+                raise
 
             # Summary
             total = len(model_ids)
             self.console.print()
-            if interrupted:
-                self._print_success(
-                    f"Verified {models_passed} model(s) before interruption"
-                )
-            elif models_failed:
+            if models_failed:
                 self._print_warning(f"Models verified: {models_passed}/{total} passed")
                 self.console.print()
                 self.console.print(

--- a/src/gaia/installer/uninstall_command.py
+++ b/src/gaia/installer/uninstall_command.py
@@ -60,6 +60,8 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Callable, List, Optional
 
+from gaia.installer._stdin import stdin_is_tty
+
 log = logging.getLogger(__name__)
 
 
@@ -342,11 +344,12 @@ def _should_skip_prompt(yes: bool) -> bool:
 
 
 def _stdin_is_tty() -> bool:
-    """Return True if stdin looks like an interactive terminal."""
-    try:
-        return bool(sys.stdin.isatty())
-    except (AttributeError, ValueError, OSError):
-        return False
+    """Return True if stdin looks like an interactive terminal.
+
+    Delegates to the shared predicate in ``gaia.installer._stdin`` so
+    uninstall and init share exactly one implementation.
+    """
+    return stdin_is_tty()
 
 
 def _confirm(

--- a/tests/unit/test_init_command.py
+++ b/tests/unit/test_init_command.py
@@ -7,6 +7,7 @@ Unit tests for the gaia init command.
 These tests use mocking to avoid actual network calls and installations.
 """
 
+import io
 import sys
 import unittest
 from unittest.mock import MagicMock, patch
@@ -2081,6 +2082,385 @@ class TestHubInstallWiringNpuProfile(_HubInstallWiringTestBase):
 
         self.assertEqual(rc, 0)
         mock_install.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# #2882: `gaia init` must not report success it did not deliver. Covers the
+# non-interactive pre-flight refusal (AC1/AC2/AC3/AC5b), the Ctrl-C exit-130
+# contract (AC4/AC4b/AC4c/AC5), and the profile-scoped completion-banner gate
+# (AC6/AC7/AC7b/AC8). See the issue for the full acceptance-criteria list.
+# ---------------------------------------------------------------------------
+
+
+def _assert_refusal_message_shape(testcase, message, profile):
+    """Shared AC1/AC5b assertions for the D2a-mandated refusal message: it
+    must name the profile, both flags that unblock it, and (per D2a) that
+    --yes also authorizes an unattended Lemonade upgrade that uninstalls
+    the current install."""
+    testcase.assertIn(profile, message)
+    testcase.assertIn("--yes", message)
+    testcase.assertIn("--skip-models", message)
+    testcase.assertIn("uninstall", message.lower())
+
+
+class TestInitPreflightRefusal(unittest.TestCase):
+    """AC1/AC2/AC3/AC5b: `gaia init` must refuse to run non-interactively
+    without --yes -- on stderr, before Step 1 -- and must do so cleanly
+    even when sys.stdin.isatty() itself raises (closed stdin).
+
+    Every test that drives run() here defensively neutralizes the two real
+    side effects run() unconditionally reaches once it falls through to
+    completion (a live Hub-catalog network call and a real `tsc && vite
+    build` that writes ~/.gaia/config.json): required regardless of
+    whether THIS test expects the refusal to fire, because prior to the
+    fix `run()` has no gate at all and genuinely falls through to doing
+    that work.
+    """
+
+    def _make_cmd(self, yes: bool, profile: str = "minimal"):
+        from gaia.installer.init_command import InitCommand
+
+        with patch("gaia.installer.init_command.LemonadeInstaller"):
+            cmd = InitCommand(profile=profile, yes=yes)
+        return cmd
+
+    def test_ac1_non_tty_no_yes_refuses_before_step1(self):
+        """Non-TTY + no --yes -> refuse before Step 1; the three real-work
+        methods are never called; exit 1; message lands on stderr."""
+        cmd = self._make_cmd(yes=False)
+
+        with (
+            patch.object(sys.stdin, "isatty", return_value=False),
+            patch.object(cmd, "_ensure_lemonade_installed") as mock_lemonade,
+            patch.object(cmd, "_ensure_server_running") as mock_server,
+            patch.object(cmd, "_download_models") as mock_download,
+            patch.object(cmd, "_verify_setup", return_value=True),
+            patch("gaia.ui.build.ensure_webui_built", return_value=False),
+            patch("gaia.config.GaiaConfig"),
+            patch("sys.stderr", new_callable=io.StringIO) as mock_stderr,
+            patch("sys.stdout", new_callable=io.StringIO) as mock_stdout,
+        ):
+            rc = cmd.run()
+
+        mock_lemonade.assert_not_called()
+        mock_server.assert_not_called()
+        mock_download.assert_not_called()
+        self.assertEqual(rc, 1)
+        self.assertEqual(mock_stdout.getvalue(), "", "refusal must not print to stdout")
+        _assert_refusal_message_shape(self, mock_stderr.getvalue(), cmd.profile)
+
+    def test_ac2_non_tty_with_yes_gate_noops(self):
+        """Non-TTY + --yes -> the gate no-ops; Step 1 is genuinely reached.
+
+        Isolated: does NOT replay a full successful run() end to end --
+        tests/installer/test_installer_scenarios.py:167 already covers that.
+        """
+        cmd = self._make_cmd(yes=True)
+        cmd.console = MagicMock()
+
+        with (
+            patch.object(sys.stdin, "isatty", return_value=False),
+            patch.object(cmd, "_print_header") as mock_header,
+            patch.object(
+                cmd, "_ensure_lemonade_installed", return_value=False
+            ) as mock_lemonade,
+        ):
+            rc = cmd.run()
+
+        mock_header.assert_called_once()
+        mock_lemonade.assert_called_once()
+        self.assertEqual(rc, 1)
+
+    def test_ac3_tty_no_yes_no_refusal(self):
+        """TTY + no --yes -> no refusal; Step 1 is genuinely reached
+        (prompts render as today)."""
+        cmd = self._make_cmd(yes=False)
+        cmd.console = MagicMock()
+
+        with (
+            patch.object(sys.stdin, "isatty", return_value=True),
+            patch.object(cmd, "_print_header") as mock_header,
+            patch.object(
+                cmd, "_ensure_lemonade_installed", return_value=False
+            ) as mock_lemonade,
+        ):
+            rc = cmd.run()
+
+        mock_header.assert_called_once()
+        mock_lemonade.assert_called_once()
+        self.assertEqual(rc, 1)
+
+    def test_ac5b_closed_stdin_isatty_raises_still_refuses_cleanly(self):
+        """sys.stdin.isatty() raising ValueError (closed stdin -- the
+        literal scenario in the issue title) must not escape as a
+        traceback; run() still returns 1 with the AC1-shaped message."""
+        cmd = self._make_cmd(yes=False)
+
+        with (
+            patch.object(
+                sys.stdin,
+                "isatty",
+                side_effect=ValueError("I/O operation on closed file"),
+            ),
+            patch.object(cmd, "_ensure_lemonade_installed") as mock_lemonade,
+            patch.object(cmd, "_ensure_server_running") as mock_server,
+            patch.object(cmd, "_download_models") as mock_download,
+            patch.object(cmd, "_verify_setup", return_value=True),
+            patch("gaia.ui.build.ensure_webui_built", return_value=False),
+            patch("gaia.config.GaiaConfig"),
+            patch("sys.stderr", new_callable=io.StringIO) as mock_stderr,
+            patch("sys.stdout", new_callable=io.StringIO) as mock_stdout,
+        ):
+            rc = cmd.run()
+
+        mock_lemonade.assert_not_called()
+        mock_server.assert_not_called()
+        mock_download.assert_not_called()
+        self.assertEqual(rc, 1)
+        self.assertEqual(mock_stdout.getvalue(), "", "refusal must not print to stdout")
+        _assert_refusal_message_shape(self, mock_stderr.getvalue(), cmd.profile)
+
+
+class TestPromptYesNoKeyboardInterrupt(unittest.TestCase):
+    """AC4b/AC5: `_prompt_yes_no` in isolation, with no run() plumbing --
+    KeyboardInterrupt must propagate uncaught (D4's core edit) while
+    EOFError must still return False (unchanged; pins that D4 touched
+    only the KeyboardInterrupt half of the old combined handler)."""
+
+    def _make_cmd(self):
+        from gaia.installer.init_command import InitCommand
+
+        with patch("gaia.installer.init_command.LemonadeInstaller"):
+            cmd = InitCommand(profile="minimal", yes=False)
+        cmd.console = MagicMock()
+        return cmd
+
+    def test_ac4b_keyboard_interrupt_propagates(self):
+        cmd = self._make_cmd()
+        with patch("builtins.input", side_effect=KeyboardInterrupt):
+            with self.assertRaises(KeyboardInterrupt):
+                cmd._prompt_yes_no("Continue?", default=True)
+
+    def test_ac5_eof_error_still_returns_false(self):
+        cmd = self._make_cmd()
+        with patch("builtins.input", side_effect=EOFError):
+            result = cmd._prompt_yes_no("Continue?", default=True)
+        self.assertFalse(result)
+
+
+class TestRunKeyboardInterruptExitCode(unittest.TestCase):
+    """AC4/AC4c: a KeyboardInterrupt raised while run() is mid-flight must
+    reach run()'s own top-level `except KeyboardInterrupt` handler and
+    produce the SAME end-to-end contract everywhere it can fire: exit 130
+    and "Initialization cancelled by user." on stdout -- and, critically
+    for AC4c, NOT the "GAIA initialization complete!" banner (today's
+    second instance of the issue's headline bug, fact 4).
+
+    Both tests defensively neutralize the Agent UI build and config-persist
+    side effects (see TestInitPreflightRefusal's docstring) since today's
+    unfixed code falls all the way through to them.
+    """
+
+    def _make_cmd(self, yes: bool = False, **kwargs):
+        from gaia.installer.init_command import InitCommand
+
+        with patch("gaia.installer.init_command.LemonadeInstaller"):
+            cmd = InitCommand(profile="minimal", yes=yes, skip_lemonade=True, **kwargs)
+        return cmd
+
+    def test_ac4_ctrl_c_at_download_prompt_returns_130(self):
+        """Ctrl-C at Step 5's 'Continue?' download-confirmation prompt.
+
+        Uses yes=False + isatty->True (mechanics item 2): yes=True would
+        make _prompt_yes_no return before input() is ever called, and the
+        new AC1 refusal would fire first -- either way silently proving
+        nothing.
+        """
+        cmd = self._make_cmd(yes=False)
+
+        with (
+            patch.object(sys.stdin, "isatty", return_value=True),
+            patch.object(cmd, "_ensure_server_running", return_value=True),
+            patch.object(cmd, "_verify_setup", return_value=True),
+            patch("gaia.ui.build.ensure_webui_built", return_value=False),
+            patch("gaia.config.GaiaConfig"),
+            patch("gaia.llm.lemonade_client.LemonadeClient"),
+            patch("builtins.input", side_effect=KeyboardInterrupt),
+            patch("sys.stdout", new_callable=io.StringIO) as mock_stdout,
+        ):
+            rc = cmd.run()
+
+        self.assertEqual(rc, 130)
+        self.assertIn("Initialization cancelled by user.", mock_stdout.getvalue())
+
+    def test_ac4c_ctrl_c_during_verification_loop_returns_130_no_banner(self):
+        """Ctrl-C during Step 8's per-model verification loop.
+
+        Today (fact 4) this is swallowed by _verify_setup's own
+        KeyboardInterrupt handler, which falls through to `return True` --
+        the fix must not let either that or the completion banner happen.
+        Uses yes=True to sail past _verify_setup's OWN "Run model
+        verification?" prompt without a real input() call; the interrupt
+        under test fires inside the loop itself, not at a prompt, so
+        mechanics item 2 does not apply to this particular call site.
+        """
+        cmd = self._make_cmd(yes=True)
+
+        mock_client = MagicMock()
+        mock_client.health_check.return_value = {"status": "ok"}
+        mock_client.check_model_available.return_value = True
+
+        with (
+            patch.object(cmd, "_ensure_server_running", return_value=True),
+            patch.object(cmd, "_download_models", return_value=True),
+            patch.object(cmd, "_test_model_inference", side_effect=KeyboardInterrupt),
+            patch("gaia.ui.build.ensure_webui_built", return_value=False),
+            patch("gaia.config.GaiaConfig"),
+            patch(
+                "gaia.llm.lemonade_client.LemonadeClient",
+                return_value=mock_client,
+            ),
+            patch(
+                "gaia.llm.lemonade_manager.LemonadeManager.ensure_ready",
+                return_value=True,
+            ),
+            patch("sys.stdout", new_callable=io.StringIO) as mock_stdout,
+        ):
+            rc = cmd.run()
+
+        out = mock_stdout.getvalue()
+        self.assertEqual(rc, 130)
+        self.assertIn("Initialization cancelled by user.", out)
+        self.assertNotIn("GAIA initialization complete!", out)
+
+
+class TestPrintCompletionHeadlineGate(unittest.TestCase):
+    """AC6/AC7/AC7b/AC8: the pre-branch "GAIA initialization complete!"
+    headline (fact 5 -- printed BEFORE any profile branching, in two
+    independent Rich/non-Rich copies) must be suppressed exactly when the
+    profile's declared agent is "chat" (covers both the `chat` and `npu`
+    profiles) AND the standalone chat wheel isn't importable -- and must
+    stay byte-identical to today in every other case. Each scenario is
+    exercised against BOTH _print_completion code paths per AC8, since a
+    fix applied to only one copy is the obvious regression.
+    """
+
+    def _make_cmd(self, profile, chat_available):
+        from gaia.installer.init_command import InitCommand
+
+        with patch("gaia.installer.init_command.LemonadeInstaller"):
+            cmd = InitCommand(profile=profile, yes=True)
+        cmd._chat_agent_available = MagicMock(return_value=chat_available)
+        return cmd
+
+    # -- AC6: chat/npu profile, chat agent unavailable -> no headline --
+
+    def test_ac6_chat_profile_unavailable_rich_suppresses_headline(self):
+        from gaia.installer import init_command as ic
+
+        if not ic.RICH_AVAILABLE:
+            self.skipTest("rich not installed")
+        cmd = self._make_cmd("chat", chat_available=False)
+        buf = io.StringIO()
+        cmd.console = ic.Console(file=buf, force_terminal=False, width=300)
+
+        cmd._print_completion()
+
+        out = buf.getvalue()
+        self.assertNotIn("GAIA initialization complete!", out)
+        self.assertIn("Chat agent not installed yet -- run:", out)
+
+    def test_ac6_npu_profile_unavailable_rich_suppresses_headline(self):
+        from gaia.installer import init_command as ic
+
+        if not ic.RICH_AVAILABLE:
+            self.skipTest("rich not installed")
+        cmd = self._make_cmd("npu", chat_available=False)
+        buf = io.StringIO()
+        cmd.console = ic.Console(file=buf, force_terminal=False, width=300)
+
+        cmd._print_completion()
+
+        out = buf.getvalue()
+        self.assertNotIn("GAIA initialization complete!", out)
+        self.assertIn("Chat agent not installed yet -- run:", out)
+
+    def test_ac6_chat_profile_unavailable_non_rich_suppresses_headline(self):
+        cmd = self._make_cmd("chat", chat_available=False)
+
+        with (
+            patch("gaia.installer.init_command.RICH_AVAILABLE", False),
+            patch("sys.stdout", new_callable=io.StringIO) as mock_stdout,
+        ):
+            cmd._print_completion()
+
+        out = mock_stdout.getvalue()
+        self.assertNotIn("GAIA initialization complete!", out)
+        self.assertIn("Chat agent not installed yet -- run:", out)
+
+    # -- AC7: chat/npu profile, chat agent available -> unchanged --
+
+    def test_ac7_chat_profile_available_rich_unchanged(self):
+        from gaia.installer import init_command as ic
+
+        if not ic.RICH_AVAILABLE:
+            self.skipTest("rich not installed")
+        cmd = self._make_cmd("chat", chat_available=True)
+        buf = io.StringIO()
+        cmd.console = ic.Console(file=buf, force_terminal=False, width=300)
+
+        cmd._print_completion()
+
+        out = buf.getvalue()
+        self.assertIn("GAIA initialization complete!", out)
+        self.assertNotIn("Chat agent not installed yet -- run:", out)
+
+    def test_ac7_chat_profile_available_non_rich_unchanged(self):
+        cmd = self._make_cmd("chat", chat_available=True)
+
+        with (
+            patch("gaia.installer.init_command.RICH_AVAILABLE", False),
+            patch("sys.stdout", new_callable=io.StringIO) as mock_stdout,
+        ):
+            cmd._print_completion()
+
+        out = mock_stdout.getvalue()
+        self.assertIn("GAIA initialization complete!", out)
+        self.assertNotIn("Chat agent not installed yet -- run:", out)
+
+    # -- AC7b: non-chat profile (sd) -> headline always present --
+
+    def test_ac7b_sd_profile_rich_headline_present_regardless_of_availability(
+        self,
+    ):
+        from gaia.installer import init_command as ic
+
+        if not ic.RICH_AVAILABLE:
+            self.skipTest("rich not installed")
+        for chat_available in (False, True):
+            with self.subTest(chat_available=chat_available):
+                cmd = self._make_cmd("sd", chat_available=chat_available)
+                buf = io.StringIO()
+                cmd.console = ic.Console(file=buf, force_terminal=False, width=300)
+
+                cmd._print_completion()
+
+                self.assertIn("GAIA initialization complete!", buf.getvalue())
+
+    def test_ac7b_sd_profile_non_rich_headline_present_regardless_of_availability(
+        self,
+    ):
+        for chat_available in (False, True):
+            with self.subTest(chat_available=chat_available):
+                cmd = self._make_cmd("sd", chat_available=chat_available)
+
+                with (
+                    patch("gaia.installer.init_command.RICH_AVAILABLE", False),
+                    patch("sys.stdout", new_callable=io.StringIO) as mock_stdout,
+                ):
+                    cmd._print_completion()
+
+                self.assertIn("GAIA initialization complete!", mock_stdout.getvalue())
 
 
 if __name__ == "__main__":

--- a/tests/unit/test_webui_build.py
+++ b/tests/unit/test_webui_build.py
@@ -294,6 +294,7 @@ class TestInitCommandWebuiBuild(unittest.TestCase):
             cmd._lemonade_base_url = None
             cmd.installer = mock_installer
             cmd.console = MagicMock()
+            cmd.yes = True
             cmd.run()
 
         return mock_ensure_built


### PR DESCRIPTION
Closes #2882

## Why this matters

`gaia init` used to report success for work it never did. Run without a person at the keyboard and without `--yes` — a CI job, a setup script, an agent — it hit its `[Y/n]` prompts on a closed stdin, silently read every one as "no", downloaded **zero models**, and still printed `GAIA initialization complete!` at exit `0`. A caller checking `$?` read that as a working install; the user got a GAIA that couldn't answer a single prompt. Pressing Ctrl-C behaved the same way at two separate prompts: init shrugged, carried on, and still claimed it finished.

After this change: a non-interactive run without `--yes` **refuses up front** (stderr, exit `1`) and names the flag to add; Ctrl-C **stops** init (exit `130`) everywhere it previously didn't; and the completion banner no longer says "complete!" when the profile's own agent was never installed — it says what's still outstanding instead.

> [!IMPORTANT]
> **Deliberate behaviour change for non-interactive callers.** `gaia init` now requires `--yes` when stdin is not a TTY. In-repo blast radius is zero — every scripted caller (`test_sd.yml`, `test_installer_scenarios.py`, the Electron backend installer) already passes `--yes` — but external integrators (OEM factory scripts, customer Dockerfiles) can't be grepped, so this is called out for release notes.

## Test plan

- [x] `python -m pytest tests/unit/test_init_command.py tests/unit/test_webui_build.py tests/unit/installer/ -q` → **231 passed, 2 skipped** (baseline 216; +15 new AC-driving tests, zero regressions)
- [x] `tests/unit/installer/test_uninstall_command.py` standalone (the delegation target is load-bearing for desktop uninstallers) → **44 passed**
- [x] `python util/lint.py --all` → exit 0, all blocking checks pass
- [ ] Real-world CLI evidence on three platforms (linux/x86_64 ×2, darwin/arm64) — attached in a follow-up comment

<details>
<summary>What changed, and the design calls behind it</summary>

Four edits across `src/gaia/installer/`, all under CLAUDE.md's "No Silent Fallbacks — Fail Loudly":

- **New `_stdin.py`** — one guarded `stdin_is_tty()` (tolerates `isatty()` *raising* on a closed stdin, not just returning False). `uninstall_command._stdin_is_tty` now delegates to it, so the predicate has exactly one implementation instead of the several ad-hoc copies scattered across the tree.
- **Pre-flight refusal** at the top of `run()` — before any work — on stderr, exit 1. The message discloses that `--yes` also authorizes an unattended Lemonade upgrade that *uninstalls* the current install when the version is below the profile minimum, not just model downloads.
- **Ctrl-C** — split the shared `except (EOFError, KeyboardInterrupt)` in three handlers so `KeyboardInterrupt` propagates to `run()`'s exit-130 path; `EOFError` still declines (Ctrl-D at an interactive prompt legitimately means "no"). This closed a second false-success path an adversarial review found: verification-loop Ctrl-C used to fall through to `return True`.
- **Completion banner** — the "complete!" headline is now gated on `INIT_PROFILES[profile].agent == "chat" and not chat_agent_available`. Profile-scoped deliberately: gating on availability alone would mark `sd`/`vlm`/`minimal` "incomplete" forever, since the chat wheel is unpublished for everyone today.

Exit code for the agent-absent case stays `0` — a non-zero exit there would fail every `gaia init --profile chat --yes` in CI, since the wheel is unpublished by design (#2275). Only the refusal introduces a new non-zero exit.

**Deliberately out of scope:** auto-installing the chat wheel (owned by #2275); the Agent-UI-build honesty path (#2880, which builds on this banner mechanism); a pre-existing `test_webui_build.py` issue that writes the real `~/.gaia/config.json` (flagged as a separate follow-up).
</details>
