### PR TITLE
test(init): stop init tests overwriting the real ~/.gaia/config.json

### DIFF
--- a/tests/unit/test_webui_build.py
+++ b/tests/unit/test_webui_build.py
@@ -283,6 +283,8 @@ class TestInitCommandWebuiBuild(unittest.TestCase):
             patch.object(InitCommand, "_ensure_lemonade_installed", return_value=True),
             patch.object(InitCommand, "_ensure_server_running", return_value=True),
             patch.object(InitCommand, "_verify_setup", return_value=True),
+            # Never touch the real ~/.gaia/config.json during a test.
+            patch("gaia.config.GaiaConfig"),
         ):
             cmd = InitCommand.__new__(InitCommand)
             cmd.profile = "minimal"


### PR DESCRIPTION
Running the unit suite quietly rewrote your own `~/.gaia/config.json`. Two tests in `tests/unit/test_webui_build.py` drove `InitCommand.run()` to completion with the heavy steps mocked but the "persist profile choice" block left live, so every run reset the developer's real profile to `minimal` and device to `gpu` — and both tests passed either way, so nothing ever flagged it. This applies the isolation the other `InitCommand.run()` tests already use, so the suite stops mutating the machine it runs on.

Closes #2890

## Evidence

Planted a sentinel config, ran only the affected test class, and compared mtime + md5.

**Before the fix — config clobbered while tests report green:**

```
BEFORE  mtime=1786390160 md5=bdd42e26  {"profile":"npu","default_device":"npu","default_model":"SENTINEL-KEEP-ME"}
$ pytest tests/unit/test_webui_build.py::TestInitCommandWebuiBuild -q
2 passed in 0.42s
AFTER   mtime=1786390162 md5=bae13f36  {"profile":"minimal","default_device":"gpu","default_model":"SENTINEL-KEEP-ME"}
```

**After the fix — byte-identical:**

```
BEFORE  mtime=1786390981 md5=bdd42e26  {"profile":"npu","default_device":"npu","default_model":"SENTINEL-KEEP-ME"}
$ pytest tests/unit/test_webui_build.py::TestInitCommandWebuiBuild -q
2 passed in 0.37s
AFTER   mtime=1786390981 md5=bdd42e26  {"profile":"npu","default_device":"npu","default_model":"SENTINEL-KEEP-ME"}
RESULT: UNTOUCHED
```

The whole `tests/unit` suite (9175 passed) also leaves the file untouched now.

## Test plan

- [ ] `pytest tests/unit/test_webui_build.py tests/unit/test_init_command.py -q` → 112 passed
- [ ] `stat`/`md5` on `~/.gaia/config.json` before and after `pytest tests/unit/test_webui_build.py::TestInitCommandWebuiBuild` → unchanged
- [ ] `python util/lint.py --all` → all quality checks pass

<details>
<summary>Why this patch target, and what else was checked</summary>

- `src/gaia/installer/init_command.py:662` imports `GaiaConfig` **inside** `run()`, so the name resolves against `gaia.config` at call time. `patch("gaia.config.GaiaConfig")` is therefore the only correct target — `patch("gaia.installer.init_command.GaiaConfig")` raises `AttributeError` at `with`-entry, since that module has no top-level alias. Patching `GaiaConfig.save` alone would leave `load()` reading the host's real file.
- Identical to the existing convention at `tests/unit/test_init_command.py:1874` (`# Never touch the real user's ~/.gaia/config.json during a test.`), which covers all seven `cmd.run()` tests there. `_patch_common_steps` itself is deliberately not reused — it is private to a different harness in a different file.
- Neither test asserts on config state (both assert only on `ensure_webui_built`, which runs earlier in `run()`), so nothing is masked. `GaiaConfigError` is intentionally left real — mocking it would make `except <MagicMock>` a `TypeError`.
- After this change the two `InitCommand.run()` call sites in the suite are both isolated, closing the leak class rather than one instance.
- 10 unrelated failures in the full `tests/unit` run (hub-installer wheel installs, missing faiss, console scripts not on PATH, `test_claude_judge` missing-api-key) fail identically on pristine `main` — pre-existing, not caused by this change.
- Out of scope, tracked separately: `tests/unit/test_telegram_background.py:13-24` writes and then unconditionally deletes the real `~/.gaia/telegram.pid`.

</details>