### PR TITLE
test(telegram): isolate HOME so the pid test can't clobber a live adapter

### DIFF
--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -14,8 +14,35 @@ from any ``test_memory_*.py`` file so the per-test mocks take effect.
 
 import os
 import socket
+from pathlib import Path
 
 import pytest
+
+
+@pytest.fixture
+def mock_home(tmp_path, monkeypatch):
+    """Redirect the process home directory at a per-test ``tmp_path``.
+
+    Patches ``HOME``, ``USERPROFILE``, ``Path.home()``, and
+    ``os.path.expanduser`` so code resolving the home dir through env vars,
+    pathlib, or ``os.path`` lands in the sandbox — a real ``~/.gaia`` is never
+    read or written. Returns the fake home so tests can build expected paths
+    under it.
+    """
+    real_expanduser = os.path.expanduser
+
+    def fake_expanduser(path):
+        if path == "~":
+            return str(tmp_path)
+        if path.startswith(("~/", "~\\")):
+            return str(tmp_path) + path[1:]
+        return real_expanduser(path)
+
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("USERPROFILE", str(tmp_path))
+    monkeypatch.setattr(Path, "home", staticmethod(lambda: tmp_path))
+    monkeypatch.setattr(os.path, "expanduser", fake_expanduser)
+    return tmp_path
 
 
 def pytest_configure(config):

--- a/tests/unit/test_telegram_adapter.py
+++ b/tests/unit/test_telegram_adapter.py
@@ -2,18 +2,21 @@ import os
 import sys
 
 
-def test_run_telegram_scaffold_returns_adapter():
+def test_run_telegram_scaffold_returns_adapter(mock_home, monkeypatch):
     # Ensure local "src" directory is on sys.path for imports during tests
     sys.path.insert(0, os.path.abspath("src"))
     from gaia.messaging.telegram import run_telegram
+
+    # GAIA_TEST_MODE stops real polling; mock_home keeps the background pid/log
+    # files out of the developer's real ~/.gaia (see test_telegram_background).
+    monkeypatch.setenv("GAIA_TEST_MODE", "1")
 
     # Run in background mode so the function does not block; in CI the
     # python-telegram-bot runtime may not be available, so guard accordingly.
     adapter = run_telegram(
         token="fake-token-123", allowed_users={12345}, background=True
     )
-    assert adapter is not None
-    assert getattr(adapter, "token", None) == "fake-token-123"
-    assert 12345 in getattr(adapter, "allowed_users")
-    # Application may be None if dependency missing; check attribute exists
+    assert adapter.token == "fake-token-123"
+    assert 12345 in adapter.allowed_users
+    # Application may be None if the telegram dependency is missing.
     assert hasattr(adapter, "application")

--- a/tests/unit/test_telegram_background.py
+++ b/tests/unit/test_telegram_background.py
@@ -9,16 +9,27 @@ from gaia.messaging.telegram import run_telegram
 def test_background_writes_pid(tmp_path, monkeypatch):
     # Ensure GAIA_TEST_MODE set so we don't actually start polling
     monkeypatch.setenv("GAIA_TEST_MODE", "1")
+
+    # Isolate HOME so the test never touches the developer's real
+    # ~/.gaia/telegram.pid — deleting that file would break a running
+    # `gaia telegram start` adapter. The adapter resolves the pid path via
+    # os.path.expanduser("~/.gaia"), so redirect "~" at tmp_path.
+    real_expanduser = os.path.expanduser
+
+    def fake_expanduser(path):
+        if path.startswith("~"):
+            return os.path.join(str(tmp_path), path[1:].lstrip("/\\"))
+        return real_expanduser(path)
+
+    monkeypatch.setattr(os.path, "expanduser", fake_expanduser)
+
     # Use a fake token; background mode should write ~/.gaia/telegram.pid
     adapter = run_telegram(token="fake-token-bg", allowed_users=None, background=True)
+    assert adapter is not None
     pid_path = os.path.expanduser("~/.gaia/telegram.pid")
-    try:
-        assert os.path.exists(pid_path)
-        with open(pid_path, "r", encoding="utf-8") as f:
-            content = f.read().strip()
-            assert content.isdigit()
-    finally:
-        try:
-            os.remove(pid_path)
-        except OSError:
-            pass
+    assert os.path.exists(pid_path)
+    with open(pid_path, "r", encoding="utf-8") as f:
+        content = f.read().strip()
+        assert content.isdigit()
+    # No manual cleanup: pid_path lives under the tmp_path fixture, which
+    # pytest removes automatically — so a real ~/.gaia/telegram.pid is untouched.

--- a/tests/unit/test_telegram_background.py
+++ b/tests/unit/test_telegram_background.py
@@ -6,27 +6,16 @@ sys.path.insert(0, os.path.abspath("src"))
 from gaia.messaging.telegram import run_telegram
 
 
-def test_background_writes_pid(tmp_path, monkeypatch):
-    # Ensure GAIA_TEST_MODE set so we don't actually start polling
+def test_background_writes_pid(mock_home, monkeypatch):
+    # GAIA_TEST_MODE stops the adapter from starting a real polling loop.
     monkeypatch.setenv("GAIA_TEST_MODE", "1")
 
-    # Isolate HOME: the adapter resolves its pid path via expanduser("~/.gaia"),
-    # and a real ~/.gaia/telegram.pid belongs to a live `gaia telegram` adapter.
-    real_expanduser = os.path.expanduser
+    # mock_home redirects "~" at a tmp dir, so the adapter's
+    # expanduser("~/.gaia") pid file never overwrites a live adapter's real one.
+    run_telegram(token="fake-token-bg", allowed_users=None, background=True)
 
-    def fake_expanduser(path):
-        if path == "~" or path.startswith(("~/", "~\\")):
-            return os.path.join(str(tmp_path), path[2:])
-        return real_expanduser(path)
-
-    monkeypatch.setattr(os.path, "expanduser", fake_expanduser)
-
-    # Use a fake token; background mode should write <home>/.gaia/telegram.pid
-    adapter = run_telegram(token="fake-token-bg", allowed_users=None, background=True)
-    assert adapter is not None
-
-    # Assert on the sandbox path, not expanduser("~") — if the isolation above is
+    # Assert on the sandbox path, not expanduser("~") — if the isolation is
     # removed this fails instead of passing while clobbering the real pid file.
-    pid_path = tmp_path / ".gaia" / "telegram.pid"
+    pid_path = mock_home / ".gaia" / "telegram.pid"
     assert pid_path.exists()
     assert pid_path.read_text(encoding="utf-8").strip().isdigit()

--- a/tests/unit/test_telegram_background.py
+++ b/tests/unit/test_telegram_background.py
@@ -10,26 +10,23 @@ def test_background_writes_pid(tmp_path, monkeypatch):
     # Ensure GAIA_TEST_MODE set so we don't actually start polling
     monkeypatch.setenv("GAIA_TEST_MODE", "1")
 
-    # Isolate HOME so the test never touches the developer's real
-    # ~/.gaia/telegram.pid — deleting that file would break a running
-    # `gaia telegram start` adapter. The adapter resolves the pid path via
-    # os.path.expanduser("~/.gaia"), so redirect "~" at tmp_path.
+    # Isolate HOME: the adapter resolves its pid path via expanduser("~/.gaia"),
+    # and a real ~/.gaia/telegram.pid belongs to a live `gaia telegram` adapter.
     real_expanduser = os.path.expanduser
 
     def fake_expanduser(path):
-        if path.startswith("~"):
-            return os.path.join(str(tmp_path), path[1:].lstrip("/\\"))
+        if path == "~" or path.startswith(("~/", "~\\")):
+            return os.path.join(str(tmp_path), path[2:])
         return real_expanduser(path)
 
     monkeypatch.setattr(os.path, "expanduser", fake_expanduser)
 
-    # Use a fake token; background mode should write ~/.gaia/telegram.pid
+    # Use a fake token; background mode should write <home>/.gaia/telegram.pid
     adapter = run_telegram(token="fake-token-bg", allowed_users=None, background=True)
     assert adapter is not None
-    pid_path = os.path.expanduser("~/.gaia/telegram.pid")
-    assert os.path.exists(pid_path)
-    with open(pid_path, "r", encoding="utf-8") as f:
-        content = f.read().strip()
-        assert content.isdigit()
-    # No manual cleanup: pid_path lives under the tmp_path fixture, which
-    # pytest removes automatically — so a real ~/.gaia/telegram.pid is untouched.
+
+    # Assert on the sandbox path, not expanduser("~") — if the isolation above is
+    # removed this fails instead of passing while clobbering the real pid file.
+    pid_path = tmp_path / ".gaia" / "telegram.pid"
+    assert pid_path.exists()
+    assert pid_path.read_text(encoding="utf-8").strip().isdigit()


### PR DESCRIPTION
Running the unit suite used to silently destroy `~/.gaia/telegram.pid` on the developer's own machine. `test_background_writes_pid` called the real adapter, let it write the real pid file, then `os.remove()`d it unconditionally in a `finally` block — so if a `gaia telegram start` adapter happened to be running, `gaia telegram stop`/`status` quietly stopped working and the only symptom was a *green* test run. The test now writes into a `tmp_path` sandbox, and a live adapter's pid file survives the suite untouched.

The assertion deliberately targets `tmp_path/.gaia/telegram.pid` rather than `expanduser("~")`: if the isolation is ever removed, the test fails loudly instead of passing while writing to the real home.

Closes #2892

Sibling of #2891 (same leak class, in the `gaia init` tests) — separate file, no dependency, so this is not stacked on it.

**Evidence** — the same test in three variants, each run with a sentinel value planted in a real `~/.gaia/telegram.pid`:

| variant | pytest | real `~/.gaia/telegram.pid` |
|---|---|---|
| before (`main`) | PASS | **destroyed** |
| after (this PR) | PASS | survives, untouched |
| after, isolation removed | **FAIL** | guard fires |

The middle row is the fix; the bottom row is why the fix can't silently rot.

### Test plan

- [ ] `pytest tests/unit/test_telegram_background.py` passes
- [ ] With `echo SENTINEL > ~/.gaia/telegram.pid` planted first, the file still reads `SENTINEL` after that run
- [ ] `pytest tests/unit/` — 9186 passed; the 11 failures are pre-existing (identical set on `main` with this change stashed: CLI-binary-on-path, hub installer, wheel-packaging, and the known missing-API-key case)
- [ ] `python util/lint.py --all` — no findings against this file; `black`/`isort` clean

<details>
<summary>Commands used for the evidence table</summary>

```bash
# per variant: plant sentinel, run, check survival
echo "SENTINEL" > ~/.gaia/telegram.pid
python -m pytest tests/unit/test_telegram_background.py -q
cat ~/.gaia/telegram.pid   # SENTINEL = survived, absent = destroyed
```

The "isolation removed" variant deletes the `monkeypatch.setattr(os.path, "expanduser", ...)` line and expects a FAILING test.
</details>