### PR TITLE
ci(webui): run the Agent UI Vitest job on Node 22 so the suite executes

### DIFF
--- a/.github/workflows/test_electron.yml
+++ b/.github/workflows/test_electron.yml
@@ -91,10 +91,17 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
+      # Deliberately above the Agent UI's `engines.node` build floor: this job
+      # runs the *test* toolchain, and jsdom 30 (#2750) pulls undici 8, which
+      # needs Node >= 22.19 for worker_threads `markAsUncloneable`. On Node 20
+      # every Vitest worker dies at import with "webidl.util.markAsUncloneable
+      # is not a function" and the suite silently reports zero tests. Don't
+      # lower this to match `engines.node` — that floor covers building the
+      # app, which has no jsdom.
       - name: Setup Node.js
         uses: actions/setup-node@v7
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'npm'
           cache-dependency-path: src/gaia/apps/webui/package-lock.json
 


### PR DESCRIPTION
The Agent UI test suite has been giving **zero signal** since Aug 6 — every PR touching the UI has merged unverified. The Vitest job reports `Test Files: no tests / Tests: no tests / Errors: 35 errors`: dependabot bumped jsdom 29 → 30 (#2750), jsdom 30 pulls undici 8, and undici 8 calls `worker_threads.markAsUncloneable`, which does not exist on the Node 20 the job pins. All 35 workers die at import with `webidl.util.markAsUncloneable is not a function` before a single test runs, so the job — and the Test Summary check that depends on it — is red repo-wide, including on PRs that never touch the UI. Pinning the job to Node 22 makes the suite actually execute: **35 files / 259 tests passing**, and `npm ci` drops all EBADENGINE warnings.

`engines.node` is deliberately untouched. That field declares the floor for *building* the app (no jsdom in that path), #2887 already carries its correction, and `gaia init`'s preflight will read it — raising it to the test toolchain's 22.22.2 would lock out Node 20 users who can build fine.

## Test plan

- [x] **Test Agent UI Components (Vitest)** — before: `no tests`, `35 errors` ([job](https://github.com/amd/gaia/actions/runs/31511554939/job/93846338187)); after: `Test Files 35 passed (35)`, `Tests 259 passed (259)` ([job](https://github.com/amd/gaia/actions/runs/31518597788/job/93869803202))
- [x] `npm ci` in `src/gaia/apps/webui` emits zero `EBADENGINE` warnings on Node 22 (12 on Node 20)
- [ ] **Test Summary** goes green

Unblocks #2668, #2702, and every other open PR failing on this job.
