### PR TITLE
docs: escape MDX-breaking literals so Mintlify validation passes

### DIFF
--- a/docs/plans/agent-ui-agent-capabilities-plan.md
+++ b/docs/plans/agent-ui-agent-capabilities-plan.md
@@ -1001,7 +1001,7 @@ every response is scoped to that agent (or its granted shared scope).
 | `GET /host/v1/sessions/{id}` | → `{transcript_slice}` | daemon verifies the session belongs to the caller (§0.30 `session id` = authz key) |
 | `POST /host/v1/audit` | `{action_id, action, summary, ts}` → `{seq}` | serialized append onto the hash-chain (§0.29); write-only to agents (§0.24) |
 | `POST /host/v1/models/lease` | `{model}` → `{lease}` / 429 | the §0.12 broker slot lease; blocks/queues by priority |
-| `POST /host/v1/agents/{id}/invoke` | `{query|capability, args}` → SSE/JSON | **orchestrator-scoped** agent-to-agent call (§0.32); not open to ordinary sidecars |
+| `POST /host/v1/agents/{id}/invoke` | `{query\|capability, args}` → SSE/JSON | **orchestrator-scoped** agent-to-agent call (§0.32); not open to ordinary sidecars |
 
 **Versioning:** this API carries its own MAJOR, negotiated on the sidecar↔daemon leg and
 subject to the §0.15 evolution rules (new-daemon/old-sidecar skew). **Errors:** every

--- a/docs/plans/agent-ui-v2-implementation-breakdown.md
+++ b/docs/plans/agent-ui-v2-implementation-breakdown.md
@@ -175,7 +175,7 @@ second toy agent (fixture) registers and spawns without touching manager code.
 *Deps:* V2-5.
 *Status:* landed via #2142 — spec-driven `AgentSidecarManager` + registry + crash-reap ledger in `gaia.daemon.sidecars`, `/daemon/v1/agents` control plane, UI backend cut over to `daemon_client`, per-agent CLI (`agents`/`start-agent`/`stop-agent`); idle reaper deliberately deferred to V2-15.
 
-**V2-7 · `feat(daemon): streaming SSE reverse-proxy (`ANY /v1/<agent>/*`) with cancel + crash semantics`** — **M**
+**V2-7 · `feat(daemon): streaming SSE reverse-proxy (ANY /v1/<agent>/*) with cancel + crash semantics`** — **M**
 *Why:* §0.23 names this net-new: today's `EmailSidecarProxy` is synchronous
 `requests` ending in `resp.json()` — it buffers, so `/query` streaming is
 impossible through it.

--- a/docs/plans/cpp-framework-parity.md
+++ b/docs/plans/cpp-framework-parity.md
@@ -488,9 +488,9 @@ The milestone deliverable, per decision 8. New `cpp/agents/generic/` following t
 - Ships bundled skill sets (`coding`, `research`) as the real consumer P3.4 needs, and packages
   via `cpp/packaging/package_agents.py`.
 
-**Naming note:** `gaia-agent` parallels `gaia-bash`. It is a distinct binary from the `gaia agent
-{export|import}` CLI subcommand; if that proves confusing in review, `gaia-native` is the
-fallback. Settle it in the issue, not at package time.
+**Naming note:** `gaia-agent` parallels `gaia-bash`. It is a distinct binary from the
+`gaia agent {export|import}` CLI subcommand; if that proves confusing in review,
+`gaia-native` is the fallback. Settle it in the issue, not at package time.
 
 **Supersedes** the previously planned hardcoded `gaia-code` binary. A coding agent is now the
 `coding` skill set on this binary — one artifact to build, sign, package, and eval.

--- a/docs/plans/email-sidecar-agent-ui-implementation.md
+++ b/docs/plans/email-sidecar-agent-ui-implementation.md
@@ -1454,5 +1454,3 @@ found and fixed runtime issues the happy-path tests missed:
 - Node-free: only `requests`/`subprocess`/`hashlib`/`socket` — no npm, no `npx`.
 - Security boundary: `verify_sha256` tamper test + tampered-download-leaves-no-file
   test in Task 3.
-</content>
-</invoke>

--- a/docs/plans/tui-user-journey.md
+++ b/docs/plans/tui-user-journey.md
@@ -1045,7 +1045,7 @@ that keymap. `ctrl+g`, `ctrl+l`, `ctrl+r`, `ctrl+z` are the safe ones used here;
 `ctrl+s` / `ctrl+q`, which terminals swallow as flow control.
 
 Slash commands: `/help` `/hub` `/clear` exist. **`/init` must be removed or wired** — today
-it prints "Initializing <agent>..." and does nothing (`chat/model.go:299-305`). Point it at
+it prints "Initializing `<agent>`..." and does nothing (`chat/model.go:299-305`). Point it at
 the preflight screen. Add `/settings` and `/accounts`.
 
 ### Focus mode (inside a card)
@@ -1262,7 +1262,7 @@ base64-raster-only and cannot render in a terminal; `diff` has no producer. Buil
 `key_value`, `list` and the two fallback behaviours; the fallback covers the rest for free.
 
 **D-h. `/init` in chat is currently a lie and should be in Phase 1's cleanup list.** It
-prints "Initializing <agent>..." and returns. It is in the same category as the plan's §5
+prints "Initializing `<agent>`..." and returns. It is in the same category as the plan's §5
 bug list and costs one line to either delete or point at preflight.
 
 **D-i. Add two home-screen fixes to the §5 bug list.** The hub opens on an empty
@@ -1328,7 +1328,7 @@ auto-approve fix, which stands alone as a security fix regardless of the TUI. Do
 agent-initiated send cannot happen without a keystroke, and a 60-second silence denies.
 
 **Step 5 — It knows you were away.**
-Briefing on launch, the "since <day>" summary, the activity screen backed by
+Briefing on launch, the "since `<day>`" summary, the activity screen backed by
 `GET /v1/email/jobs` **[backend]**. Done when: opening on day 5 shows what happened and what
 is pending before anything is typed.
 

--- a/docs/superpowers/plans/2026-06-25-gaia-presentation-builder.md
+++ b/docs/superpowers/plans/2026-06-25-gaia-presentation-builder.md
@@ -735,7 +735,7 @@ grep -iq 'methodology' "$E" && { echo "FAIL: methodology in executive"; exit 1; 
 test "$(grep -c 'https\?://' "$E")" -eq 0 || { echo "FAIL: external ref"; exit 1; }
 echo PASS
 ```
-Expected: `technical=N executive=M` with M<N, then `PASS`.
+Expected: `technical=N executive=M` with `M<N`, then `PASS`.
 
 - [ ] **Step 3: Export PDF and confirm one slide per page**
 

--- a/docs/superpowers/plans/2026-07-18-weekly-doc-walkthrough.md
+++ b/docs/superpowers/plans/2026-07-18-weekly-doc-walkthrough.md
@@ -446,7 +446,7 @@ git commit -m "feat(ci): scaffold the weekly doc walkthrough workflow"
 
 - [ ] **Step 2: Add the judge step**
 
-```yaml
+````yaml
       - name: "Judge (Opus): verify ${{ matrix.doc.path }} against its transcript"
         id: judge
         if: always()
@@ -508,7 +508,7 @@ git commit -m "feat(ci): scaffold the weekly doc walkthrough workflow"
             --max-turns 25
             --model ${{ env.WALKTHROUGH_JUDGE_MODEL }}
             --allowedTools Read,Grep,Glob,Bash
-```
+````
 
 - [ ] **Step 3: Add cleanup + upload steps**
 

--- a/docs/testing/email-agent-linux-test.md
+++ b/docs/testing/email-agent-linux-test.md
@@ -64,7 +64,7 @@ none).
 
 **5a. Create a Google OAuth client** (Google Cloud Console):
 
-1. Create or pick a project at <https://console.cloud.google.com>
+1. Create or pick a project at [console.cloud.google.com](https://console.cloud.google.com)
 2. **Enable the Gmail API** for that project
 3. Configure the **OAuth consent screen** (External; add yourself as a test user)
 4. Create an **OAuth client ID** of type **Desktop app** — this gives you a


### PR DESCRIPTION
Docs Validation is red on `main` and is turning every open PR red one at a time as their CI re-runs — six are already failing (#2897, #2874, #2809, #2773, #2714, #2702) and the rest are only green because their last run predates the break. Nobody changed a doc: the workflow installs the Mintlify CLI unpinned, and 4.2.792 (published 2026-08-11) tightened MDX parsing, so eight long-standing plan/spec docs that always parsed now don't. Mintlify treats parse warnings as fatal, so the job dies with `Build validation failed with 8 warning(s)`. This escapes the offending literals at the source — no wording changed, no validation weakened.

Bare angle-bracket placeholders (`<agent>`, `<day>`), a bare `M<N`, an unescaped `|` inside a table code span, a `{` in column 1, a `<https://…>` autolink, and a three-backtick fence nested in a ```` ```yaml ```` block are all read as JSX or JS expressions. Each is now backticked, escaped, re-wrapped, or re-fenced. One file also had leaked `</content></invoke>` tool-call residue at EOF, which is deleted.

Worth a follow-up decision, not done here: `npm install -g mintlify` floats, so this class of breakage can recur without a docs change. Pinning would stop CI drifting — but Mintlify's hosted build always runs latest, so a pin buys green CI while the real site build breaks. Trading one for the other deserves its own discussion.

## Test plan

- [ ] `cd docs && npx mintlify@4.2.794 validate` → `success build validation passed` (fails with 8 warnings on `main`)
- [ ] `python util/check_doc_versions.py` still passes (second step of the same job)
- [ ] Docs Validation is green on this PR
- [ ] Spot-check rendering of the changed lines — the `\|` table cell still reads `{query|capability, args}`, and the widened ```` ````yaml ```` fence still shows the nested `json` block