### PR TITLE
fix(database): make the SQL read-only authorizer disarm on Python 3.10

### DIFF
--- a/src/gaia/database/sql_safety.py
+++ b/src/gaia/database/sql_safety.py
@@ -12,6 +12,7 @@ place that happens, so the guarantee can be audited in one file.
 import json
 import re
 import sqlite3
+import sys
 import threading
 from contextlib import contextmanager
 from dataclasses import dataclass
@@ -307,6 +308,21 @@ class _Window:
 _OPEN_WINDOWS: Dict[int, _Window] = {}
 _WINDOWS_LOCK = threading.Lock()
 
+# set_authorizer(None) only detaches the authorizer from 3.11 on (bpo-44491).
+# Before that it installs None as the callback, and the C trampoline turns the
+# resulting TypeError into SQLITE_DENY — bricking the connection for good.
+_SET_AUTHORIZER_NONE_DETACHES = sys.version_info >= (3, 11)
+
+
+def _allow_all(_action, _arg1, _arg2, _db_name, _trigger):
+    """Authorizer that permits everything — a stand-in for having none."""
+    return sqlite3.SQLITE_OK
+
+
+def _disarm(conn: sqlite3.Connection) -> None:
+    """Stop enforcing the read-only window on *conn*."""
+    conn.set_authorizer(None if _SET_AUTHORIZER_NONE_DETACHES else _allow_all)
+
 
 @contextmanager
 def readonly(conn: sqlite3.Connection) -> Iterator[List[str]]:
@@ -359,4 +375,4 @@ def readonly(conn: sqlite3.Connection) -> Iterator[List[str]]:
             entry.depth -= 1
             if entry.depth == 0:
                 del _OPEN_WINDOWS[key]
-                conn.set_authorizer(None)
+                _disarm(conn)

--- a/tests/unit/test_sql_safety.py
+++ b/tests/unit/test_sql_safety.py
@@ -9,6 +9,7 @@ import time
 
 import pytest
 
+from gaia.database import sql_safety
 from gaia.database.sql_safety import (
     _OPEN_WINDOWS,
     build_where,
@@ -358,6 +359,52 @@ def test_readonly_restores_authorizer_after_unrelated_exception(conn):
     conn.execute("INSERT INTO t VALUES (5,'e')")
     conn.commit()
     assert conn.execute("SELECT COUNT(*) FROM t").fetchone()[0] == 4
+
+
+def test_readonly_disarms_without_set_authorizer_none(conn, monkeypatch):
+    """The pre-3.11 disarm path must free the connection, on every version.
+
+    set_authorizer(None) is a no-op before 3.11 — it installs None as the
+    callback and every later statement is denied. Only the 3.10 lane exercises
+    that branch naturally, so force it here.
+    """
+    monkeypatch.setattr(sql_safety, "_SET_AUTHORIZER_NONE_DETACHES", False)
+
+    with pytest.raises(sqlite3.DatabaseError):
+        with readonly(conn):
+            conn.execute("DELETE FROM t")
+
+    conn.execute("INSERT INTO t VALUES (4,'d')")
+    conn.commit()
+    assert conn.execute("SELECT COUNT(*) FROM t").fetchone()[0] == 4
+
+    # Re-arming after the shim disarm must still deny.
+    with pytest.raises(sqlite3.DatabaseError):
+        with readonly(conn):
+            conn.execute("DELETE FROM t")
+
+
+def test_disarm_installs_a_permissive_callback_on_legacy_pythons(monkeypatch):
+    """Pin the contract: <3.11 must get a callable that permits writes.
+
+    Guards the refactor where the version flag stops being read at call time —
+    the window test above would then pass while exercising the 3.11 path.
+    """
+
+    class _RecordingConn:
+        installed = "unset"
+
+        def set_authorizer(self, callback):
+            self.installed = callback
+
+    monkeypatch.setattr(sql_safety, "_SET_AUTHORIZER_NONE_DETACHES", False)
+    conn = _RecordingConn()
+    sql_safety._disarm(conn)
+
+    assert callable(conn.installed)
+    assert conn.installed(sqlite3.SQLITE_DELETE, "t", None, "main", None) == (
+        sqlite3.SQLITE_OK
+    )
 
 
 def test_validate_identifier_rejects_trailing_newline():


### PR DESCRIPTION
The py3.10 unit-test lane has been red on `main` since Aug 10 and is reddening every open PR whose CI re-runs — 24 failures across `test_sql_safety.py` and `test_database_mixin.py`. It is a real bug, not a test artifact: on Python 3.10 the read-only SQL window left the database connection permanently unusable after it closed, so every subsequent statement — including `rollback()` — failed with "not authorized". Anyone running GAIA on 3.10 would hit this the first time an agent ran a read-only query. 3.11/3.12/macOS were unaffected, which is why it shipped.

The read-only window from #2860 cleared its authorizer with `set_authorizer(None)`. That only detaches the callback from Python 3.11 on ([bpo-44491](https://github.com/python/cpython/issues/88657)); on 3.10 it installs `None` *as* the callback and CPython's C trampoline turns the resulting `TypeError` into `SQLITE_DENY`, bricking the connection. On <3.11 we now disarm with an always-`SQLITE_OK` callback instead.

**The security control is unchanged.** The authorizer, its action allowlist, `READONLY_PRAGMAS`, and the arming path are untouched — the window still refuses exactly what it refused before, on every version. Only the *teardown* differs, and only below 3.11. No `skipif`, no weakened assertion.

## Test plan

- [ ] CI: the **Unit Tests (py3.10)** lane goes green (this is the point of the PR); 3.11/3.12/macOS stay green
- [ ] `pytest tests/unit/test_sql_safety.py tests/unit/test_database_mixin.py` → 184 passed (182 before, +2 new)
- [ ] `pytest tests/integration/test_database_agent.py` → 55 passed
- [ ] The 3.10 branch is unreachable on 3.11+, so two new tests force it via the version flag rather than leaving it to the CI lane. Confirm they fail if the shim is broken: flip `_allow_all` to return `SQLITE_DENY` and `test_readonly_disarms_without_set_authorizer_none` reproduces the exact `not authorized` symptom.