### PR TITLE
fix(eval): drop the judge temperature pin the model now rejects

### DIFF
--- a/src/gaia/eval/action_item_quality.py
+++ b/src/gaia/eval/action_item_quality.py
@@ -713,8 +713,8 @@ def make_claude_judge(model: str | None = None) -> Callable[[str, str], bool]:
     """
     from gaia.eval.claude import ClaudeClient
 
-    # Judge determinism: generation is temp-0, the judge must be too (#2094).
-    client = ClaudeClient(model=model, temperature=0.0)
+    # No temperature pin — the judge model rejects sampling params (400).
+    client = ClaudeClient(model=model)
 
     def judge(predicted_desc: str, expected_desc: str) -> bool:
         prompt = build_equivalence_prompt(predicted_desc, expected_desc)

--- a/src/gaia/eval/briefing_quality.py
+++ b/src/gaia/eval/briefing_quality.py
@@ -313,8 +313,8 @@ def make_claude_judge(model: str | None = None) -> Callable[[str], str]:
     """
     from gaia.eval.claude import ClaudeClient
 
-    # Judge determinism: generation is temp-0, the judge must be too (#2094).
-    client = ClaudeClient(model=model, temperature=0.0)
+    # No temperature pin — the judge model rejects sampling params (400).
+    client = ClaudeClient(model=model)
 
     def judge(prompt: str) -> str:
         content = client.get_completion(prompt)

--- a/src/gaia/eval/claude.py
+++ b/src/gaia/eval/claude.py
@@ -38,7 +38,8 @@ class ClaudeClient:
             temperature: Sampling temperature forwarded to every completion call.
                 Left as None (the default), no temperature is sent and the API
                 default applies — generation callers depend on that diversity.
-                Judges pass 0.0 explicitly (#2094).
+                Leave it unset for current models: they reject sampling params
+                with a 400, so pinning a value fails the call outright.
         """
         # Check for required dependencies
         if anthropic is None:

--- a/src/gaia/eval/draft_quality.py
+++ b/src/gaia/eval/draft_quality.py
@@ -275,8 +275,8 @@ def make_claude_judge(model: str | None = None) -> Callable[[str], str]:
     """
     from gaia.eval.claude import ClaudeClient
 
-    # Judge determinism: generation is temp-0, the judge must be too (#2094).
-    client = ClaudeClient(model=model, temperature=0.0)
+    # No temperature pin — the judge model rejects sampling params (400).
+    client = ClaudeClient(model=model)
 
     def judge(prompt: str) -> str:
         content = client.get_completion(prompt)

--- a/tests/unit/eval/test_claude_judge.py
+++ b/tests/unit/eval/test_claude_judge.py
@@ -414,12 +414,17 @@ class TestAnalyzeFileWithUsageBinaryTemperature:
 
 
 # ---------------------------------------------------------------------------
-# Judge factories pin temperature=0.0 (#2094 AC-5)
+# Judge factories send no sampling params
+#
+# The judge model rejects `temperature` with a 400, which fails every judged
+# eval at its first API call. The factories pinned temperature=0.0 until that
+# parameter was removed from the model; these tests keep the pin from coming
+# back. Determinism is now a property of the judge prompt, not the request.
 # ---------------------------------------------------------------------------
 
 
 class TestJudgeFactoryTemperature:
-    def test_action_item_quality_pins_temperature_zero(self, monkeypatch):
+    def test_action_item_quality_sends_no_temperature(self, monkeypatch):
         spy = MagicMock()
         monkeypatch.setattr("gaia.eval.claude.ClaudeClient", spy)
 
@@ -427,9 +432,9 @@ class TestJudgeFactoryTemperature:
 
         make_claude_judge(model="claude-sonnet-4-6")
 
-        spy.assert_called_once_with(model="claude-sonnet-4-6", temperature=0.0)
+        spy.assert_called_once_with(model="claude-sonnet-4-6")
 
-    def test_briefing_quality_pins_temperature_zero(self, monkeypatch):
+    def test_briefing_quality_sends_no_temperature(self, monkeypatch):
         spy = MagicMock()
         monkeypatch.setattr("gaia.eval.claude.ClaudeClient", spy)
 
@@ -437,9 +442,9 @@ class TestJudgeFactoryTemperature:
 
         make_claude_judge(model="claude-sonnet-4-6")
 
-        spy.assert_called_once_with(model="claude-sonnet-4-6", temperature=0.0)
+        spy.assert_called_once_with(model="claude-sonnet-4-6")
 
-    def test_draft_quality_pins_temperature_zero(self, monkeypatch):
+    def test_draft_quality_sends_no_temperature(self, monkeypatch):
         spy = MagicMock()
         monkeypatch.setattr("gaia.eval.claude.ClaudeClient", spy)
 
@@ -447,4 +452,4 @@ class TestJudgeFactoryTemperature:
 
         make_claude_judge(model="claude-sonnet-4-6")
 
-        spy.assert_called_once_with(model="claude-sonnet-4-6", temperature=0.0)
+        spy.assert_called_once_with(model="claude-sonnet-4-6")


### PR DESCRIPTION
Every judge-scored eval is currently failing at its first API call. The judge model stopped accepting `temperature`, and the drafting, action-item and briefing judges each pinned it to `0.0`, so the request comes back `400 invalid_request_error: temperature is deprecated for this model`. That takes down the email agent's drafting/action-item/briefing gates — and with them the **Email Triage Eval** check on every PR that touches the email agent, the skills runtime, or the eval machinery (currently red on #2693 and #2702 for exactly this reason). After this change the judges run again; determinism comes from the judge prompt instead of the request parameter.

`ClaudeClient` already omits the parameter when it is left unset, so the fix is to stop passing it. The client keeps the `temperature` knob for callers on models that still accept one — only the three judge factories stop using it. The call-site tests asserted the pin, so they now assert its absence; re-adding it would break every judged eval again.

## Test plan

- [x] `pytest tests/unit/eval/test_claude_judge.py` — 29 passed
- [x] `black --check` / `isort --check-only` on the changed files
- [ ] Re-run **Email Triage Eval** on #2693 or #2702 and confirm the "Voice-drafting quality eval (judge-scored)" step gets past its first judge call (it currently dies there in ~16 min)

Note for the reviewer: `tests/unit/eval/test_scorecard_gate.py` has 29 pre-existing failures on `main`, unrelated to this change.