### PR TITLE
fix(cpp): normalize CRLF so Windows-authored skills parse identically

### DIFF
--- a/cpp/src/skill.cpp
+++ b/cpp/src/skill.cpp
@@ -601,6 +601,23 @@ std::string stripBom(const std::string& text) {
     return offset ? text.substr(offset) : text;
 }
 
+/// Collapse CRLF and lone CR to LF. Python opens SKILL.md in text mode, so its
+/// parser never sees a carriage return; without this the two runtimes disagree
+/// on every Windows-authored file.
+std::string normalizeNewlines(const std::string& text) {
+    if (text.find('\r') == std::string::npos) return text;
+    std::string out;
+    out.reserve(text.size());
+    for (size_t i = 0; i < text.size(); ++i) {
+        if (text[i] != '\r') {
+            out += text[i];
+        } else if (i + 1 >= text.size() || text[i + 1] != '\n') {
+            out += '\n';
+        }
+    }
+    return out;
+}
+
 bool splitFrontmatter(const std::string& text, std::string& yamlOut,
                       std::string& bodyOut) {
     const size_t n = text.size();
@@ -972,7 +989,7 @@ std::string toMarkdown(const Skill& skill) {
 Skill parseSkill(const std::string& text, const std::string& source) {
     std::string rawYaml;
     std::string body;
-    if (!splitFrontmatter(stripBom(text), rawYaml, body)) {
+    if (!splitFrontmatter(normalizeNewlines(stripBom(text)), rawYaml, body)) {
         throw SkillValidationError(
             source +
             ": no YAML frontmatter found. A SKILL.md must open with a '---' line, the "

--- a/cpp/tests/test_skill.cpp
+++ b/cpp/tests/test_skill.cpp
@@ -882,9 +882,26 @@ TEST(SkillEncoding, CrlfFrontmatterParses) {
         if (*p == '\n') crlf += '\r';
         crlf += *p;
     }
-    const Skill skill = gaia::parseSkill(crlf);
-    EXPECT_EQ(skill.name, "bare-standard");
-    EXPECT_THAT(skill.body, HasSubstr("# Incident Review"));
+    // Python reads SKILL.md in text mode, so CRLF never reaches its parser. A
+    // Windows-authored skill has to give both runtimes the same body, not just
+    // one that happens to contain the same substring.
+    EXPECT_EQ(gaia::parseSkill(crlf), gaia::parseSkill(kBare));
+    EXPECT_EQ(gaia::parseSkill(crlf).body,
+              "# Incident Review\n\n1. Establish the timeline.");
+}
+
+TEST(SkillEncoding, CrlfDoesNotLeakIntoMultiLineScalars) {
+    // The body is not the only place a carriage return can survive — a literal
+    // block in the frontmatter carries it into the field value itself.
+    const std::string lf =
+        "---\nname: ok\ndescription: |\n  Line one.\n  Line two.\n---\n\nbody\n";
+    std::string crlf;
+    for (char c : lf) {
+        if (c == '\n') crlf += '\r';
+        crlf += c;
+    }
+    EXPECT_EQ(gaia::parseSkill(crlf), gaia::parseSkill(lf));
+    EXPECT_EQ(gaia::parseSkill(crlf).description.find('\r'), std::string::npos);
 }
 
 TEST(SkillEncoding, LeadingBomIsTolerated) {


### PR DESCRIPTION
A `SKILL.md` saved on Windows currently gives the C++ and Python runtimes different text. Python opens the file in text mode, so CRLF is normalized away before its parser ever runs; the C++ port reads it binary and only strips `\n`, so the parsed body keeps a blank line at the front, a dangling carriage return at the end, and stray `\r` inside multi-line frontmatter scalars. That body is what reaches the model and what gets written back on save, so the same skill behaves differently depending on which runtime read it — on the C++ side's headline platform.

Follow-up to #2824: the finding landed on that PR about two minutes after it merged, so the fix could not go in with it.

## Test plan

- [x] `SkillEncoding.CrlfFrontmatterParses` now asserts the CRLF and LF forms parse **equal** (it previously checked only the name and a substring, so it passed with the bug present — verified failing before the fix, passing after)
- [x] New `SkillEncoding.CrlfDoesNotLeakIntoMultiLineScalars` covers a literal block in the frontmatter
- [x] Full C++ suite green locally (MSVC, Release): 836 passed, 4 skipped (pre-existing environment skips)
- [x] `pytest tests/unit/test_skills_format.py` green (57 passed) — Python behaviour is the reference and is unchanged
