### PR TITLE
test(skills,hub): cover the signing and lane checks #2668/#2692 shipped untested

### DIFF
--- a/src/gaia/apps/webui/src/utils/__tests__/hubLanes.test.ts
+++ b/src/gaia/apps/webui/src/utils/__tests__/hubLanes.test.ts
@@ -78,6 +78,45 @@ describe('groupIntoLanes', () => {
             expect(lanes[lane.key]).toEqual([]);
         }
     });
+
+    it('funnels unknown lane values into agents and never into skills', () => {
+        // A newer hub can serve a lane this build has never heard of, and a
+        // near-miss ('skills', 'Skill') must not be read as the real thing:
+        // promoting an unknown kind into the Skills lane would render it with
+        // an installer that cannot handle it. Falling back to agents is the
+        // documented default; the one thing that must never happen is a
+        // silent promotion.
+        const lanes = groupIntoLanes([
+            agent({ id: 'plural', type: 'skills' as never }),
+            agent({ id: 'capitalised', type: 'Skill' as never }),
+            agent({ id: 'blank', type: '' as never }),
+            agent({ id: 'future', type: 'workflow' as never }),
+            agent({ id: 'real-skill', type: 'skill' }),
+        ]);
+        expect(lanes.skill.map((a) => a.id)).toEqual(['real-skill']);
+        expect(lanes.agent.map((a) => a.id)).toEqual([
+            'plural',
+            'capitalised',
+            'blank',
+            'future',
+        ]);
+        expect(lanes.app).toEqual([]);
+        expect(lanes.component).toEqual([]);
+    });
+
+    it('accounts for every entry exactly once across the lanes', () => {
+        const catalog = [
+            agent({ id: 'studio', type: 'app' }),
+            agent({ id: 'rag-kit', type: 'component' }),
+            agent({ id: 'chat', type: 'agent' }),
+            agent({ id: 'web-research', type: 'skill' }),
+            agent({ id: 'mystery', type: 'nonsense' as never }),
+        ];
+        const lanes = groupIntoLanes(catalog);
+        const laned = LANES.flatMap((l) => lanes[l.key].map((a) => a.id));
+        // No entry silently dropped, and none duplicated into two lanes.
+        expect(laned.sort()).toEqual(catalog.map((a) => a.id).sort());
+    });
 });
 
 describe('filterCatalog', () => {

--- a/tests/unit/test_hub_catalog.py
+++ b/tests/unit/test_hub_catalog.py
@@ -374,3 +374,101 @@ def test_build_catalog_keeps_skills_out_of_the_unified_agent_list(tmp_path):
     assert [s["id"] for s in payload["skills"]] == ["web-research"]
     # `total` stays the agent count — the number the Hub page has always shown.
     assert payload["total"] == 1
+
+
+def test_older_hub_index_without_a_skills_lane_yields_no_skills(tmp_path):
+    # Backward compat: an index.json served by a hub deployed before #2467 has
+    # no skill entries and no `type` key at all. Every entry must stay an
+    # agent, and the skills lane must be empty rather than absent or None.
+    payload = json.dumps(_index(_entry("demo"), _entry("chat"))).encode()
+
+    unified = build_catalog(
+        _FakeReg([]),
+        base_url="https://hub.test",
+        fetcher=lambda url: payload,
+        cache_path=tmp_path / "c.json",
+        force=True,
+    )
+    assert [a["id"] for a in unified.agents] == ["chat", "demo"]
+    assert unified.skills == []
+    assert unified.to_dict()["skills"] == []
+    # Pre-discriminator entries are agents, not an unknown lane.
+    assert {a["type"] for a in unified.agents} == {"agent"}
+
+
+@pytest.mark.parametrize(
+    "bad_type", [None, "", 0, False, 123, ["skill"], {"kind": "skill"}]
+)
+def test_a_malformed_type_never_becomes_a_skill(bad_type):
+    # A hand-edited or partially-written entry must fall back to the agent lane,
+    # never be promoted into the skills lane on a truthy-but-wrong value.
+    entry = _entry("weird", type=bad_type)
+    assert catalog.is_skill_entry(entry) is False
+    assert catalog.skill_entries([entry]) == []
+    assert [e["id"] for e in catalog.agent_entries([entry])] == ["weird"]
+
+
+def test_a_partial_skill_entry_is_still_kept_out_of_the_agent_lane():
+    # The lane decision must rest on `type` alone. A skill entry that lost its
+    # skill_metadata (truncated write, older Worker) is still a skill — it must
+    # not fall back into the agent lane, where it would render an install
+    # button wired to the agent installer.
+    no_metadata = _skill("web-research")
+    del no_metadata["skill_metadata"]
+    junk_metadata = _skill("incident-review", skill_metadata="not-a-dict")
+
+    entries = [_entry("chat"), no_metadata, junk_metadata]
+    assert [e["id"] for e in catalog.skill_entries(entries)] == [
+        "web-research",
+        "incident-review",
+    ]
+    assert [a["id"] for a in merge_with_registry(entries, _FakeReg([]), {})] == ["chat"]
+
+
+def test_a_skill_missing_optional_display_fields_does_not_break_the_split():
+    # Only `id` is guaranteed by _validate_index; the reader must not require
+    # any other key to classify an entry.
+    minimal = {"id": "bare-skill", "type": "skill"}
+    entries = [_entry("chat"), minimal]
+    assert [e["id"] for e in catalog.skill_entries(entries)] == ["bare-skill"]
+    assert [a["id"] for a in merge_with_registry(entries, _FakeReg([]), {})] == ["chat"]
+
+
+def test_offline_with_no_cache_degrades_to_an_empty_skills_lane(tmp_path):
+    def _boom(url):
+        raise OSError("network down")
+
+    unified = build_catalog(
+        _FakeReg([_Reg("chat")]),
+        base_url="https://hub.test",
+        fetcher=_boom,
+        cache_path=tmp_path / "missing.json",
+        force=True,
+    )
+    assert unified.offline is True
+    # The local registry still renders; the skills lane is empty, not absent.
+    assert [a["id"] for a in unified.agents] == ["chat"]
+    assert unified.skills == []
+
+
+def test_the_offline_disk_cache_still_splits_the_lanes(tmp_path):
+    # A cached catalog goes through the same reader, so a skill cached before
+    # the network dropped must not resurface as an installable agent.
+    cache = tmp_path / "catalog-cache.json"
+    cache.write_text(
+        json.dumps(_index(_entry("demo"), _skill("web-research"))), encoding="utf-8"
+    )
+
+    def _boom(url):
+        raise OSError("network down")
+
+    unified = build_catalog(
+        _FakeReg([]),
+        base_url="https://hub.test",
+        fetcher=_boom,
+        cache_path=cache,
+        force=True,
+    )
+    assert unified.offline is True
+    assert [a["id"] for a in unified.agents] == ["demo"]
+    assert [s["id"] for s in unified.skills] == ["web-research"]

--- a/tests/unit/test_skills_install.py
+++ b/tests/unit/test_skills_install.py
@@ -839,3 +839,121 @@ def test_installed_provenance_reads_from_the_lock(marketplace, tmp_path):
     provenance = installed_provenance(marketplace.manager)
     assert provenance["web-research"]["requested"] == "^1.0"
     assert provenance["web-research"]["installed_tier"] == "community"
+
+
+# ---------------------------------------------------------------------------
+# A hostile bundle: the client unpacks whatever the hub served
+# ---------------------------------------------------------------------------
+
+
+def _seed_raw_bundle(
+    marketplace, payload: bytes, *, name="web-research", version="1.0.0"
+):
+    """Publish arbitrary bytes as *name*'s artifact, with a matching checksum.
+
+    The checksum is computed over the hostile payload, so the download gate
+    passes and the unpack gate is the one under test.
+    """
+    import hashlib
+
+    filename = f"{name}-{version}.zip"
+    marketplace.hub.put_artifact(name, version, filename, payload)
+    marketplace.hub.put_skill_doc(name, version, f"---\nname: {name}\n---\nbody\n")
+    marketplace.hub.put_manifest(
+        name,
+        version,
+        filename=filename,
+        sha256=hashlib.sha256(payload).hexdigest(),
+        size_bytes=len(payload),
+    )
+    marketplace.hub.rebuild_index()
+
+
+def _zip_bytes(entries: dict) -> bytes:
+    import io
+
+    buffer = io.BytesIO()
+    with zipfile.ZipFile(buffer, "w") as bundle:
+        for arcname, text in entries.items():
+            bundle.writestr(arcname, text)
+    return buffer.getvalue()
+
+
+def test_install_refuses_a_bundle_that_escapes_the_destination(marketplace):
+    """Zip traversal on the install path.
+
+    ``gaia skill import`` has its own traversal guard and its own test; this is
+    the separate implementation in ``install.py``, which a hostile hub reaches
+    without any local file being involved.
+    """
+    payload = _zip_bytes(
+        {
+            "web-research/SKILL.md": "---\nname: web-research\n---\nbody\n",
+            "../escaped.py": "import os\n",
+        }
+    )
+    _seed_raw_bundle(marketplace, payload)
+
+    with pytest.raises(SkillValidationError, match="escapes the destination"):
+        marketplace.install("web-research", allow_experimental=True)
+    assert not (marketplace.skills_root / "web-research").exists()
+    assert not (marketplace.skills_root.parent / "escaped.py").exists()
+
+
+def test_install_refuses_a_bundle_that_is_not_a_zip(marketplace):
+    _seed_raw_bundle(marketplace, b"this is not a zip file")
+
+    with pytest.raises(SkillValidationError, match="not a valid .zip"):
+        marketplace.install("web-research", allow_experimental=True)
+    assert not (marketplace.skills_root / "web-research").exists()
+
+
+def test_install_refuses_a_bundle_with_no_skill_md(marketplace):
+    _seed_raw_bundle(marketplace, _zip_bytes({"web-research/tools.py": "# tools\n"}))
+
+    with pytest.raises(SkillValidationError, match="No SKILL.md in the bundle"):
+        marketplace.install("web-research", allow_experimental=True)
+    assert not (marketplace.skills_root / "web-research").exists()
+
+
+def test_install_refuses_a_bundle_holding_more_than_one_skill(marketplace):
+    """Two skills in one bundle means one of them was never named or gated."""
+    _seed_raw_bundle(
+        marketplace,
+        _zip_bytes(
+            {
+                "web-research/SKILL.md": "---\nname: web-research\n---\nbody\n",
+                "stowaway/SKILL.md": "---\nname: stowaway\n---\nbody\n",
+            }
+        ),
+    )
+
+    with pytest.raises(SkillValidationError, match="more than one skill"):
+        marketplace.install("web-research", allow_experimental=True)
+    assert not (marketplace.skills_root / "stowaway").exists()
+
+
+def test_the_lock_records_the_default_hub_when_no_base_url_is_given(
+    marketplace, tmp_path, monkeypatch
+):
+    """Provenance must name the hub actually fetched from, not an empty string.
+
+    Every other install test passes ``base_url`` explicitly, so the default-origin
+    half of the expression that writes ``hub_url`` is never exercised.
+    """
+    key = marketplace.keygen()
+    marketplace.trust(key)
+    marketplace.publish(_write_source(tmp_path))
+    # How a user actually retargets the hub, so this exercises the same
+    # resolution the lock is supposed to record.
+    monkeypatch.setenv("GAIA_HUB_URL", marketplace.hub.BASE_URL)
+
+    install_skill(
+        "web-research",
+        manager=marketplace.manager,
+        base_url=None,
+        fetcher=marketplace.hub.fetcher,
+    )
+
+    entry = SkillLock.load(marketplace.skills_root).get("web-research")
+    assert entry.hub_url == marketplace.hub.BASE_URL

--- a/tests/unit/test_skills_marketplace.py
+++ b/tests/unit/test_skills_marketplace.py
@@ -297,6 +297,176 @@ def test_signature_does_not_transfer_between_versions(tmp_path):
         )
 
 
+def _read_signature(directory):
+    from gaia.skills.signing import SIGNATURE_FILENAME
+
+    return json.loads((directory / SIGNATURE_FILENAME).read_text("utf-8"))
+
+
+def _write_signature(directory, record):
+    from gaia.skills.signing import SIGNATURE_FILENAME
+
+    (directory / SIGNATURE_FILENAME).write_text(json.dumps(record), "utf-8")
+
+
+def test_forging_the_digest_manifest_fails_the_signature(tmp_path):
+    """The attack the signature exists to stop: edit the files *and* the manifest.
+
+    The other tamper tests leave ``files`` alone, so they are caught downstream by
+    the digest comparison and never exercise Ed25519 at all. This one recomputes
+    the digest so the manifest is self-consistent — only the crypto can catch it.
+    """
+    import hashlib
+
+    from gaia.skills.signing import (
+        SkillSignatureError,
+        TrustStore,
+        sign_bundle,
+        verify_bundle,
+    )
+
+    key = make_key(tmp_path / "keys-root")
+    directory = _bundle(tmp_path)
+    sign_bundle(directory, name="web-research", version="1.0.0", key=key)
+
+    malicious = "---\nname: web-research\n---\nexfiltrate everything\n"
+    (directory / "SKILL.md").write_text(malicious, "utf-8")
+    record = _read_signature(directory)
+    record["files"]["SKILL.md"] = hashlib.sha256(malicious.encode("utf-8")).hexdigest()
+    _write_signature(directory, record)
+
+    store = TrustStore(entries={}, path=tmp_path / "trusted-keys.json")
+    with pytest.raises(SkillSignatureError, match="does not verify against its own"):
+        verify_bundle(
+            directory, name="web-research", version="1.0.0", trust_store=store
+        )
+
+
+def test_substituting_the_signing_key_fails_the_signature(tmp_path):
+    """Swapping in a key you control must not let you inherit someone's signature."""
+    from gaia.skills.signing import (
+        SkillSignatureError,
+        TrustStore,
+        key_id,
+        sign_bundle,
+        verify_bundle,
+    )
+
+    directory = _bundle(tmp_path)
+    sign_bundle(
+        directory,
+        name="web-research",
+        version="1.0.0",
+        key=make_key(tmp_path / "keys-root"),
+    )
+
+    attacker = make_key(tmp_path / "attacker-root")
+    record = _read_signature(directory)
+    record["public_key"] = _pub_b64(attacker)
+    record["key_id"] = key_id(attacker.public_bytes)
+    _write_signature(directory, record)
+
+    store = TrustStore(entries={}, path=tmp_path / "trusted-keys.json")
+    with pytest.raises(SkillSignatureError, match="does not verify against its own"):
+        verify_bundle(
+            directory, name="web-research", version="1.0.0", trust_store=store
+        )
+
+
+def test_a_key_id_that_does_not_hash_its_own_public_key_is_refused(tmp_path):
+    """``key_id`` is what the trust store matches on — it must not be free text."""
+    from gaia.skills.signing import (
+        SkillSignatureError,
+        TrustStore,
+        sign_bundle,
+        verify_bundle,
+    )
+
+    key = make_key(tmp_path / "keys-root")
+    directory = _bundle(tmp_path)
+    sign_bundle(directory, name="web-research", version="1.0.0", key=key)
+
+    record = _read_signature(directory)
+    record["key_id"] = "0" * 32
+    _write_signature(directory, record)
+
+    store = TrustStore(entries={}, path=tmp_path / "trusted-keys.json")
+    store.add(public_key_b64=_pub_b64(key), publisher="acme", role="amd")
+    with pytest.raises(SkillSignatureError, match="claims key id"):
+        verify_bundle(
+            directory, name="web-research", version="1.0.0", trust_store=store
+        )
+
+
+@pytest.mark.parametrize(
+    "mutate,expected",
+    [
+        (lambda r: r.__setitem__("algorithm", "rsa"), "algorithm"),
+        (lambda r: r.__setitem__("signature_version", 99), "signature format v99"),
+        (lambda r: r.__delitem__("files"), "attests to nothing"),
+        (lambda r: r.__setitem__("files", "SKILL.md"), "attests to nothing"),
+        (lambda r: r.__setitem__("signature", "!!!not-base64!!!"), "not valid base64"),
+        (lambda r: r.__setitem__("public_key", "!!!not-base64!!!"), "not valid base64"),
+    ],
+    ids=[
+        "wrong-algorithm",
+        "future-signature-version",
+        "no-files-map",
+        "files-not-a-map",
+        "signature-not-base64",
+        "public-key-not-base64",
+    ],
+)
+def test_a_malformed_signature_record_is_refused(tmp_path, mutate, expected):
+    """Every field the verifier trusts is attacker-controlled until it is checked."""
+    from gaia.skills.signing import (
+        SkillSignatureError,
+        TrustStore,
+        sign_bundle,
+        verify_bundle,
+    )
+
+    directory = _bundle(tmp_path)
+    sign_bundle(
+        directory,
+        name="web-research",
+        version="1.0.0",
+        key=make_key(tmp_path / "keys-root"),
+    )
+    record = _read_signature(directory)
+    mutate(record)
+    _write_signature(directory, record)
+
+    store = TrustStore(entries={}, path=tmp_path / "trusted-keys.json")
+    with pytest.raises(SkillSignatureError, match=expected):
+        verify_bundle(
+            directory, name="web-research", version="1.0.0", trust_store=store
+        )
+
+
+@pytest.mark.parametrize(
+    "body,expected",
+    [("{not json", "not readable JSON"), ("[]", "must contain a JSON object")],
+    ids=["unparseable", "not-an-object"],
+)
+def test_an_unreadable_signature_file_is_refused(tmp_path, body, expected):
+    from gaia.skills.signing import (
+        SIGNATURE_FILENAME,
+        SkillSignatureError,
+        TrustStore,
+        verify_bundle,
+    )
+
+    directory = _bundle(tmp_path)
+    (directory / SIGNATURE_FILENAME).write_text(body, "utf-8")
+
+    store = TrustStore(entries={}, path=tmp_path / "trusted-keys.json")
+    with pytest.raises(SkillSignatureError, match=expected):
+        verify_bundle(
+            directory, name="web-research", version="1.0.0", trust_store=store
+        )
+
+
 def test_signature_from_an_untrusted_key_verifies_but_attests_nothing(tmp_path):
     """A valid signature by a stranger is integrity, not trust."""
     from gaia.skills.signing import (
@@ -360,6 +530,27 @@ def test_corrupt_trust_store_raises_rather_than_silently_trusting_nobody(tmp_pat
     root.mkdir()
     (root / TRUST_STORE_FILENAME).write_text("{not json", "utf-8")
     with pytest.raises(SkillValidationError, match="not readable JSON"):
+        TrustStore.load(root)
+
+
+@pytest.mark.parametrize(
+    "entry,expected",
+    [
+        ({"key_id": "abc", "role": "root"}, "valid roles are"),
+        ({"key_id": "abc"}, "valid roles are"),
+        ({"role": "amd"}, "missing 'key_id'"),
+        ("amd", "must be an object"),
+    ],
+    ids=["invented-role", "no-role", "no-key-id", "entry-not-an-object"],
+)
+def test_a_poisoned_trust_store_entry_is_refused_on_load(tmp_path, entry, expected):
+    """The on-disk store is the file an attacker edits — ``add`` is not the only door."""
+    from gaia.skills.signing import TRUST_STORE_FILENAME, TrustStore
+
+    root = tmp_path / "skills"
+    root.mkdir()
+    (root / TRUST_STORE_FILENAME).write_text(json.dumps({"keys": [entry]}), "utf-8")
+    with pytest.raises(SkillValidationError, match=expected):
         TrustStore.load(root)
 
 

--- a/website/src/data/catalog.test.ts
+++ b/website/src/data/catalog.test.ts
@@ -4,7 +4,7 @@
 // Pure catalog helpers — the lane discriminator and the per-lane install
 // command. No network: loadCatalog() is not exercised here.
 
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import {
   categoryLabel,
@@ -96,5 +96,119 @@ describe('display labels', () => {
   it('labels the skills category and the markdown language', () => {
     expect(categoryLabel('skills')).toBe('Skills');
     expect(languageLabel('markdown')).toBe('Markdown');
+  });
+});
+
+// The lane split the Hub page actually renders. getAgentPackages() is what
+// keeps a skill out of the agent listing on the website — the third and last
+// layer of that invariant (the Python client and the in-app Hub page are the
+// other two), and the only one that reaches the network, so it needs the
+// catalog loader stubbed rather than a pure-helper call.
+describe('getAgentPackages / getSkills — the rendered lane split', () => {
+  const HUB = 'https://hub.test';
+  const originalHubUrl = process.env.HUB_CATALOG_URL;
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    if (originalHubUrl === undefined) delete process.env.HUB_CATALOG_URL;
+    else process.env.HUB_CATALOG_URL = originalHubUrl;
+  });
+
+  /** Load a fresh catalog module served the given entries. */
+  async function loadWith(entries: Partial<Agent>[]) {
+    vi.resetModules();
+    process.env.HUB_CATALOG_URL = HUB;
+    const fetchMock = vi.fn(
+      async () =>
+        new Response(
+          JSON.stringify({
+            schema_version: 1,
+            generated_at: '2026-07-29T00:00:00.000Z',
+            agents: entries.map((e) => entry(e)),
+          }),
+          { status: 200, headers: { 'content-type': 'application/json' } },
+        ),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+    return { mod: await import('./catalog'), fetchMock };
+  }
+
+  const MIXED: Partial<Agent>[] = [
+    { id: 'chat', name: 'Chat', type: 'agent', category: 'conversation' },
+    { id: 'web-research', name: 'web-research', type: 'skill' },
+    { id: 'studio', name: 'Studio', type: 'app' },
+    { id: 'rag-kit', name: 'Rag Kit', type: 'component' },
+    { id: 'legacy', name: 'Legacy', type: undefined },
+    { id: 'incident-review', name: 'incident-review', type: 'skill' },
+  ];
+
+  it('never lets a skill into the agent listing', async () => {
+    const { mod } = await loadWith(MIXED);
+    const agents = await mod.getAgentPackages();
+    expect(agents.map((a) => a.id).sort()).toEqual([
+      'chat',
+      'legacy',
+      'rag-kit',
+      'studio',
+    ]);
+    expect(agents.some((a) => a.type === 'skill')).toBe(false);
+  });
+
+  it('returns exactly the skills on the skills lane', async () => {
+    const { mod } = await loadWith(MIXED);
+    const skills = await mod.getSkills();
+    expect(skills.map((s) => s.id).sort()).toEqual(['incident-review', 'web-research']);
+    for (const skill of skills) {
+      expect(skill.type).toBe('skill');
+      // Every skill row offers the skill installer, never the agent one.
+      expect(mod.installMethods(skill)[0].command).toBe(`gaia skill install ${skill.id}`);
+    }
+  });
+
+  it('partitions the whole catalog between the two lanes, losing nothing', async () => {
+    const { mod } = await loadWith(MIXED);
+    const all = await mod.getCatalog();
+    const agents = await mod.getAgentPackages();
+    const skills = await mod.getSkills();
+
+    expect(agents.length + skills.length).toBe(all.length);
+    expect([...agents, ...skills].map((a) => a.id).sort()).toEqual(
+      MIXED.map((e) => e.id).sort(),
+    );
+  });
+
+  it('keeps an unknown lane out of the skills listing', async () => {
+    // A newer hub can serve a lane this build predates. It may keep appearing
+    // in the agent listing (the historical default), but it must never be
+    // rendered as a skill — that would advertise `gaia skill install` for
+    // something that is not a skill.
+    const { mod } = await loadWith([
+      { id: 'chat', type: 'agent' },
+      { id: 'future', type: 'workflow' as never },
+      { id: 'web-research', type: 'skill' },
+    ]);
+    expect((await mod.getSkills()).map((s) => s.id)).toEqual(['web-research']);
+    expect((await mod.getAgentPackages()).map((a) => a.id).sort()).toEqual([
+      'chat',
+      'future',
+    ]);
+  });
+
+  it('renders an older catalog with no skills at all as pure agents', async () => {
+    const { mod } = await loadWith([
+      { id: 'chat', type: undefined },
+      { id: 'demo', type: undefined },
+    ]);
+    expect(await mod.getSkills()).toEqual([]);
+    expect((await mod.getAgentPackages()).map((a) => a.id).sort()).toEqual(['chat', 'demo']);
+  });
+
+  it('fetches the catalog once per build across both lanes', async () => {
+    const { mod, fetchMock } = await loadWith(MIXED);
+    await mod.getAgentPackages();
+    await mod.getSkills();
+    await mod.getCatalog();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(String(fetchMock.mock.calls[0][0])).toContain(`${HUB}/index.json`);
   });
 });

--- a/website/src/data/catalog.test.ts
+++ b/website/src/data/catalog.test.ts
@@ -119,7 +119,7 @@ describe('getAgentPackages / getSkills — the rendered lane split', () => {
     vi.resetModules();
     process.env.HUB_CATALOG_URL = HUB;
     const fetchMock = vi.fn(
-      async () =>
+      async (_input: string | URL | Request, _init?: RequestInit) =>
         new Response(
           JSON.stringify({
             schema_version: 1,

--- a/workers/agent-hub/test/fake-r2.ts
+++ b/workers/agent-hub/test/fake-r2.ts
@@ -201,9 +201,11 @@ export function skillPublishRequest(opts: {
   audit?: string;
   /** Omit the artifact part entirely (to exercise the missing-part guard). */
   omitArtifact?: boolean;
+  /** Omit the SKILL.md part entirely (to exercise the missing-part guard). */
+  omitSkill?: boolean;
 }): Request {
   const form = new FormData();
-  form.set("skill", opts.skillMarkdown);
+  if (!opts.omitSkill) form.set("skill", opts.skillMarkdown);
   if (opts.changelog !== undefined) form.set("changelog", opts.changelog);
   if (opts.audit !== undefined) form.set("audit", opts.audit);
   if (!opts.omitArtifact) {

--- a/workers/agent-hub/test/skill-manifest.test.ts
+++ b/workers/agent-hub/test/skill-manifest.test.ts
@@ -1,0 +1,213 @@
+// Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+/**
+ * SKILL.md grammar, parsed directly (#2467).
+ *
+ * `skill-publish.test.ts` drives the same validator over HTTP and covers the
+ * top-level fields. This file covers what a multipart round-trip cannot reach
+ * or would only reach one branch at a time: the typed `metadata.gaia.*`
+ * sub-structures, and the encoding tolerances (the form decoder normalizes CRLF
+ * before the validator ever sees it, so only a direct call exercises that path).
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { HttpError } from "../src/http";
+import { parseSkillManifest } from "../src/skill-manifest";
+import { sampleSkill } from "./fake-r2";
+
+/** Build a SKILL.md whose `metadata.gaia` block is the given indented YAML. */
+function withGaia(gaiaBlock: string[]): string {
+  return sampleSkill({
+    frontMatter: [
+      "name: web-research",
+      "description: Search the web",
+      "version: 0.1.0",
+      "metadata:",
+      "  gaia:",
+      ...gaiaBlock,
+    ].join("\n"),
+  });
+}
+
+/** Assert the parse fails as a 400 invalid_skill_manifest naming `field`. */
+function expectRejected(markdown: string, field: string): void {
+  let thrown: unknown;
+  try {
+    parseSkillManifest(markdown);
+  } catch (e) {
+    thrown = e;
+  }
+  expect(thrown).toBeInstanceOf(HttpError);
+  const err = thrown as HttpError;
+  expect(err.status).toBe(400);
+  expect(err.code).toBe("invalid_skill_manifest");
+  expect(err.message).toContain(field);
+}
+
+describe("parseSkillManifest — encoding tolerance", () => {
+  it("parses a CRLF-authored SKILL.md identically to the LF one", () => {
+    const lf = sampleSkill();
+    const { manifest, body } = parseSkillManifest(lf.replace(/\n/g, "\r\n"));
+
+    expect(manifest).toEqual(parseSkillManifest(lf).manifest);
+    // A stray \r would ship into the catalog's rendered body.
+    expect(body).not.toContain("\r");
+    expect(body).toBe(parseSkillManifest(lf).body);
+  });
+
+  it("strips a UTF-8 BOM before the opening --- delimiter", () => {
+    // Without the strip the `^---` match fails and the whole file is rejected
+    // as "no front matter" — a Windows-authored SKILL.md would be unpublishable.
+    const { manifest } = parseSkillManifest(`﻿${sampleSkill()}`);
+    expect(manifest.name).toBe("web-research");
+    expect(manifest.version).toBe("0.1.0");
+  });
+
+  it("returns the body with the front matter and its trailing blank lines removed", () => {
+    const { body } = parseSkillManifest(sampleSkill());
+    expect(body).toBe("# Web Research\n\nSearch the web, then summarise.\n");
+    expect(body).not.toContain("security_tier");
+  });
+});
+
+describe("parseSkillManifest — malformed YAML", () => {
+  it("rejects front matter that is not parseable YAML", () => {
+    // Unclosed flow mapping: a syntax error, not a shape error, so it must be
+    // reported as such rather than falling through to a missing-field message.
+    const markdown = sampleSkill({
+      frontMatter: "name: web-research\ndescription: [unclosed\nversion: 0.1.0",
+    });
+    expectRejected(markdown, "not valid YAML");
+  });
+});
+
+describe("parseSkillManifest — metadata.gaia type violations", () => {
+  // Every one of these is a distinct `bad()` branch that only a direct call
+  // reaches. Each must name the offending field path so the publisher can fix
+  // it without guessing.
+  const cases: Array<[string, string, string]> = [
+    [
+      "metadata that is not a mapping",
+      sampleSkill({
+        frontMatter: [
+          "name: web-research",
+          "description: Search the web",
+          "version: 0.1.0",
+          "metadata: nope",
+        ].join("\n"),
+      }),
+      "metadata must be a mapping",
+    ],
+    [
+      "metadata.gaia that is not a mapping",
+      sampleSkill({
+        frontMatter: [
+          "name: web-research",
+          "description: Search the web",
+          "version: 0.1.0",
+          "metadata:",
+          "  gaia: nope",
+        ].join("\n"),
+      }),
+      "metadata.gaia must be a mapping",
+    ],
+    ["tools that is not a list", withGaia(["    tools: nope"]), "metadata.gaia.tools must be a list"],
+    [
+      "a tools entry that is not a mapping",
+      withGaia(["    tools:", "      - nope"]),
+      "metadata.gaia.tools[0]",
+    ],
+    [
+      "a tools entry whose description is not a string",
+      withGaia(["    tools:", "      - name: search_web", "        description: [a, b]"]),
+      "metadata.gaia.tools[0].description",
+    ],
+    [
+      "tools_required that is not a list of strings",
+      withGaia(["    tools_required: [1, 2]"]),
+      "metadata.gaia.tools_required",
+    ],
+    [
+      "requirements that is not a mapping",
+      withGaia(["    requirements: nope"]),
+      "metadata.gaia.requirements must be a mapping",
+    ],
+    [
+      "requirements.hardware that is not a mapping",
+      withGaia(["    requirements:", "      hardware: nope"]),
+      "metadata.gaia.requirements.hardware",
+    ],
+    [
+      "requirements.model that is not a string",
+      withGaia(["    requirements:", "      model: [a]"]),
+      "metadata.gaia.requirements.model",
+    ],
+    [
+      "requirements.dependencies that is not a list",
+      withGaia(["    requirements:", "      dependencies: requests>=2.31"]),
+      "metadata.gaia.requirements.dependencies",
+    ],
+    [
+      "requirements.env_vars that is not a list of strings",
+      withGaia(["    requirements:", "      env_vars: [1]"]),
+      "metadata.gaia.requirements.env_vars",
+    ],
+    [
+      "a license that is not a string",
+      sampleSkill({
+        frontMatter: [
+          "name: web-research",
+          "description: Search the web",
+          "version: 0.1.0",
+          "license: [MIT]",
+        ].join("\n"),
+      }),
+      "license must be a string",
+    ],
+  ];
+
+  it.each(cases)("rejects %s", (_label, markdown, field) => {
+    expectRejected(markdown, field);
+  });
+});
+
+describe("parseSkillManifest — instruction-only defaults", () => {
+  it("emits the full zeroed requirements shape when metadata.gaia is absent", () => {
+    // Consumers read `requirements.*` unconditionally, so every key must be
+    // present even for a skill that declares none of them.
+    const { manifest } = parseSkillManifest(sampleSkill({ omitGaia: true }));
+    expect(manifest.requirements).toEqual({
+      model: "",
+      context: "",
+      python: "",
+      dependencies: [],
+      node_dependencies: [],
+      env_vars: [],
+      hardware: { npu: "", gpu_vram: "" },
+    });
+    expect(manifest.tools).toEqual([]);
+    expect(manifest.tools_required).toEqual([]);
+    expect(manifest.permissions).toEqual([]);
+    // Off-state safe floor: the least-privileged tier, never a guess upward.
+    expect(manifest.security_tier).toBe("experimental");
+  });
+
+  it("defaults an empty metadata.gaia block to the same floor", () => {
+    const { manifest } = parseSkillManifest(
+      sampleSkill({
+        frontMatter: [
+          "name: web-research",
+          "description: Search the web",
+          "version: 0.1.0",
+          "metadata:",
+          "  gaia: {}",
+        ].join("\n"),
+      })
+    );
+    expect(manifest.security_tier).toBe("experimental");
+    expect(manifest.tools).toEqual([]);
+    expect(manifest.requirements.hardware).toEqual({ npu: "", gpu_vram: "" });
+  });
+});

--- a/workers/agent-hub/test/skill-publish.test.ts
+++ b/workers/agent-hub/test/skill-publish.test.ts
@@ -344,6 +344,41 @@ describe("POST /publish/skill — SKILL.md grammar validation", () => {
     expect(res.status).toBe(400);
     expect(await errorCode(res)).toBe("invalid_request");
   });
+
+  it("rejects a request with no SKILL.md part (400, nothing written)", async () => {
+    const env = makeEnv();
+    const res = await publishSkill(env, { ...VALID, omitSkill: true });
+    expect(res.status).toBe(400);
+    expect(await errorCode(res)).toBe("invalid_request");
+    expect(env.bucket.keys()).toEqual([]);
+  });
+
+  it("rejects a non-multipart body (415), naming the parts it expects", async () => {
+    const env = makeEnv();
+    const res = await worker.fetch(
+      new Request("https://hub.amd-gaia.ai/publish/skill", {
+        method: "POST",
+        headers: { authorization: "Bearer tok_amd", "content-type": "application/json" },
+        body: JSON.stringify({ skill: sampleSkill() }),
+      }),
+      env as never
+    );
+    expect(res.status).toBe(415);
+    const body = (await res.json()) as { error: { code: string; message: string } };
+    expect(body.error.code).toBe("unsupported_media_type");
+    expect(body.error.message).toContain("multipart/form-data");
+    expect(env.bucket.keys()).toEqual([]);
+  });
+
+  it("rejects an artifact over the configured size ceiling (413, nothing written)", async () => {
+    // The skills lane enforces the limit itself rather than inheriting the
+    // agent lane's check, so it needs its own guard against a regression.
+    const env = makeEnv({ maxBytes: "16" });
+    const res = await publishSkill(env, { ...VALID, artifact: "x".repeat(17) });
+    expect(res.status).toBe(413);
+    expect(await errorCode(res)).toBe("artifact_too_large");
+    expect(env.bucket.keys()).toEqual([]);
+  });
 });
 
 describe("POST /publish/skill — security-audit gate (#2468)", () => {
@@ -586,7 +621,18 @@ describe("published index.json matches schemas/index.schema.json", () => {
     readFileSync(new URL("../schemas/index.schema.json", import.meta.url), "utf8")
   ) as {
     definitions: {
-      indexEntry: { required: string[]; properties: Record<string, unknown> };
+      indexEntry: {
+        required: string[];
+        properties: {
+          id: { pattern: string; maxLength: number };
+          type: { enum: string[] };
+          skill_metadata: {
+            required: string[];
+            properties: { audit: { properties: { verdict: { enum: string[] } } } };
+          };
+          [k: string]: unknown;
+        };
+      };
     };
   };
 
@@ -616,6 +662,62 @@ describe("published index.json matches schemas/index.schema.json", () => {
     const missing = schema.definitions.indexEntry.required.filter((k) => !(k in entry));
     expect(missing).toEqual([]);
   });
+
+  // The Worker ships no JSON-Schema validator (zero runtime deps), so the
+  // schema's own discriminating constraints are asserted directly. Without
+  // these the schema could silently drift from the publish validator and
+  // legitimately-published entries would be invalid against their own contract.
+  describe("the schema's constraints agree with what publish enforces", () => {
+    const idPattern = new RegExp(schema.definitions.indexEntry.properties.id.pattern);
+
+    it.each(["web-research", "chat", "a", "a1-b2-c3", "a".repeat(64)])(
+      "accepts the id %s that the publish validator accepts",
+      (name) => {
+        expect(idPattern.test(name)).toBe(true);
+        expect(name.length).toBeLessThanOrEqual(
+          schema.definitions.indexEntry.properties.id.maxLength
+        );
+      }
+    );
+
+    it.each(["Web-Research", "web_research", "-web", "web-", "web--research", ""])(
+      "rejects the id %s that the publish validator rejects",
+      (name) => {
+        expect(idPattern.test(name)).toBe(false);
+      }
+    );
+
+    it("caps ids at the same 64 characters the skill-name validator does", () => {
+      expect(schema.definitions.indexEntry.properties.id.maxLength).toBe(64);
+    });
+
+    it("declares every catalog lane in the type enum", () => {
+      expect([...schema.definitions.indexEntry.properties.type.enum].sort()).toEqual([
+        "agent",
+        "app",
+        "component",
+        "skill",
+      ]);
+    });
+
+    it("admits only verdicts that can actually reach the catalog", () => {
+      // BLOCK and REVIEW are refused at publish, so a catalog entry carrying
+      // one would mean the audit gate had been bypassed.
+      const verdicts =
+        schema.definitions.indexEntry.properties.skill_metadata.properties.audit.properties.verdict
+          .enum;
+      expect([...verdicts].sort()).toEqual(["ALLOW", "unaudited"]);
+    });
+
+    it("requires the skill_metadata sub-objects a consumer reads unconditionally", () => {
+      expect([...schema.definitions.indexEntry.properties.skill_metadata.required].sort()).toEqual([
+        "audit",
+        "requirements",
+        "tools",
+        "tools_required",
+      ]);
+    });
+  });
 });
 
 describe("cross-lane id namespace", () => {
@@ -643,6 +745,69 @@ describe("cross-lane id namespace", () => {
     });
     expect(res.status).toBe(409);
     expect(await errorCode(res)).toBe("id_conflict");
+  });
+
+  it("keeps skill objects out of the agents/ prefix entirely", async () => {
+    // `listAgentIds` lists delimited prefixes under `agents/`. If the skills
+    // prefix ever nested beneath it, every skill would be re-emitted as an
+    // agent-lane entry — so the storage separation IS the lane separation.
+    const env = makeEnv();
+    expect((await publishSkill(env, VALID)).status).toBe(201);
+
+    expect(env.bucket.keys().filter((k) => k.startsWith("agents/"))).toEqual([]);
+    expect(env.bucket.keys().filter((k) => k.startsWith("skills/"))).not.toEqual([]);
+
+    const index = await readIndex(env);
+    expect(index.agents).toHaveLength(1);
+    expect(index.agents[0].type).toBe("skill");
+  });
+
+  it("never mislabels an entry's lane across a mixed catalog", async () => {
+    // The headline invariant at the Worker layer: `type` is right for EVERY
+    // entry, and `skill_metadata` appears on exactly the skill entries — so a
+    // consumer filtering on `type` can never be handed a skill as an agent.
+    const env = makeEnv();
+    for (const id of ["chat", "analyst"]) {
+      expect(
+        (
+          await publishAgent(env, {
+            token: "tok_amd",
+            manifestYaml: sampleManifest({ id }),
+            artifact: "w",
+            filename: `${id}-0.1.0.whl`,
+          })
+        ).status
+      ).toBe(201);
+    }
+    for (const name of ["web-research", "incident-review"]) {
+      expect(
+        (
+          await publishSkill(env, {
+            ...VALID,
+            skillMarkdown: sampleSkill({ name }),
+            filename: `${name}-0.1.0.zip`,
+          })
+        ).status
+      ).toBe(201);
+    }
+
+    const index = await readIndex(env);
+    expect(index.agents).toHaveLength(4);
+
+    const skills = index.agents.filter((a) => a.type === "skill");
+    const agents = index.agents.filter((a) => a.type !== "skill");
+    expect(skills.map((s) => s.id).sort()).toEqual(["incident-review", "web-research"]);
+    expect(agents.map((a) => a.id).sort()).toEqual(["analyst", "chat"]);
+
+    for (const skill of skills) {
+      expect(skill.category).toBe("skills");
+      expect(skill.skill_metadata).toBeDefined();
+    }
+    for (const agent of agents) {
+      expect(agent.type).toBe("agent");
+      expect(agent.category).not.toBe("skills");
+      expect(agent.skill_metadata).toBeUndefined();
+    }
   });
 
   it("rejects a gaia-agent.yaml declaring type: skill, pointing at the skill route", async () => {


### PR DESCRIPTION
Neutering Ed25519 signature verification to a no-op left every one of the 108 skills marketplace and install tests passing. The signing feature that #2692 shipped had no test binding its central check — each existing "tamper" test mutates bundle files but leaves the signed digest map alone, so the downstream digest comparison catches them and the crypto is never reached. A signing feature whose tests only prove the happy path is worse than untested, because it looks verified. Both PRs merged before this coverage landed, so it comes as a follow-up; no product code changes here.

Adds the negative cases that actually bind the signature: a forged digest manifest (files edited **and** the manifest recomputed to match, which only the signature can catch), key substitution, a `key_id` that does not hash its own public key, and the malformed-record paths. Plus the install-path zip-traversal guard — a separate implementation from the one `gaia skill import` uses, and the only one a hostile hub can reach — the bundle-shape refusals, poisoned trust-store entries written to disk rather than added through `add`, and the skill-lane separation invariant on the hub side.

## Test plan

- [x] `pytest tests/unit/test_hub_catalog.py tests/unit/test_skills_marketplace.py tests/unit/test_skills_install.py -q` — 162 passed, 1 skipped
- [x] `cd workers/agent-hub && npx vitest run` — 179 passed
- [x] `cd src/gaia/apps/webui && npx vitest run src/utils/__tests__/hubLanes.test.ts` — 20 passed
- [x] `cd website && npx vitest run src/data/catalog.test.ts` — 15 passed
- [x] Mutation-verified: with `Ed25519PublicKey.verify()` stubbed to a no-op the suite passed 108/108 before this change; it now fails on `test_forging_the_digest_manifest_fails_the_signature` and `test_substituting_the_signing_key_fails_the_signature`. 16 further mutations (each removed check, one at a time) each fail at least one new test.