### PR TITLE
fix(email): reply/draft/send actions no longer report failure after they already succeeded

### DIFF
--- a/hub/agents/email/python/CHANGELOG.md
+++ b/hub/agents/email/python/CHANGELOG.md
@@ -45,6 +45,17 @@ contract version is tracked separately as
 
 ### Fixed
 
+- **A reply/draft/send action could report failure even though it actually
+  succeeded, and a retry made things worse (#2902).** After a draft was
+  created or a message sent, a separate local audit-log write (`state.db`,
+  shared with the scheduler's background agent, #1115) could transiently
+  fail with `database is locked` — and that bookkeeping failure was reported
+  to the user as if the whole action had failed. `draft_reply`,
+  `draft_forward`, and `send_draft` now match `send_now`'s existing
+  ordering-invariant guard: the audit write is logged, not raised, once the
+  real Gmail/Outlook call has already succeeded. Retrying `send_draft`
+  against a draft id already consumed by a prior send now gets a plain
+  "already sent" message instead of a generic connector-error dump.
 - **Asked about upcoming meetings or calendar invites, the agent could invent
   attendee names and invite confirmations that exist nowhere in the mailbox
   or the tool trace (#2766).** A calendar event's real `organizer` was

--- a/hub/agents/email/python/gaia_agent_email/action_store.py
+++ b/hub/agents/email/python/gaia_agent_email/action_store.py
@@ -21,7 +21,10 @@ Two tables:
 Ordering invariant (Adversarial B2): the calling tool MUST execute the
 Gmail API call FIRST and only ``record_action`` on success. Phantom rows
 in ``email_actions`` for actions that never happened are a state-corruption
-class — see ``test_email_agent_soft_delete.py``.
+class — see ``test_email_agent_soft_delete.py``. Conversely, an audit-write
+failure AFTER the external call already succeeded must never be reported as
+a failure — log and continue (``reply_tools.py``'s ``send_now_impl`` /
+``draft_reply_impl`` / ``draft_forward_impl`` / ``send_draft_impl``, #2902).
 
 All public helpers are pure functions taking a ``DatabaseMixin``-typed
 first argument. They never reach into the agent class.

--- a/hub/agents/email/python/gaia_agent_email/tools/reply_tools.py
+++ b/hub/agents/email/python/gaia_agent_email/tools/reply_tools.py
@@ -380,14 +380,25 @@ def draft_reply_impl(
             attachments=attachments,
         )
         draft_id = result["id"]
-        action_store.record_draft(
-            db,
-            draft_id=draft_id,
-            to=to,
-            subject=subject,
-            body=body,
-            in_reply_to=threading.get("In-Reply-To"),
-        )
+        try:
+            action_store.record_draft(
+                db,
+                draft_id=draft_id,
+                to=to,
+                subject=subject,
+                body=body,
+                in_reply_to=threading.get("In-Reply-To"),
+            )
+        except sqlite3.Error as exc:
+            # Audit-write failures must NOT mask a successful draft. Log
+            # but don't raise — the draft already exists in the mailbox;
+            # the agent must not retry create_draft.
+            log.warning(
+                "draft_reply: audit write failed for draft_id=%s (%s) — "
+                "draft DID succeed but audit row missing",
+                draft_id,
+                exc,
+            )
         st["result_summary"] = {"draft_id": draft_id, "to": to}
         return {
             "draft_id": draft_id,
@@ -432,9 +443,20 @@ def draft_forward_impl(
             + (original.get("snippet", "") or ""),
         )
         draft_id = result["id"]
-        action_store.record_draft(
-            db, draft_id=draft_id, to=to, subject=subject, body=body
-        )
+        try:
+            action_store.record_draft(
+                db, draft_id=draft_id, to=to, subject=subject, body=body
+            )
+        except sqlite3.Error as exc:
+            # Audit-write failures must NOT mask a successful draft. Log
+            # but don't raise — the draft already exists in the mailbox;
+            # the agent must not retry create_draft.
+            log.warning(
+                "draft_forward: audit write failed for draft_id=%s (%s) — "
+                "draft DID succeed but audit row missing",
+                draft_id,
+                exc,
+            )
         st["result_summary"] = {"draft_id": draft_id, "to": to}
         return {"draft_id": draft_id, "to": to, "subject": subject}
 
@@ -442,7 +464,18 @@ def draft_forward_impl(
 def send_draft_impl(gmail, db, *, draft_id: str, debug: bool = False) -> Dict[str, Any]:
     with log_tool_call("send_draft", {"draft_id": draft_id}, debug=debug) as st:
         result = gmail.send_draft(draft_id)
-        action_store.mark_draft_sent(db, draft_id=draft_id)
+        try:
+            action_store.mark_draft_sent(db, draft_id=draft_id)
+        except sqlite3.Error as exc:
+            # Audit-write failures must NOT mask a successful send. Log
+            # but don't raise — the email already left the user's
+            # account; the agent must not retry.
+            log.warning(
+                "send_draft: audit write failed for draft_id=%s (%s) — "
+                "send DID succeed but audit row not marked sent",
+                draft_id,
+                exc,
+            )
         st["result_summary"] = {"sent_id": result.get("id")}
         return {"draft_id": draft_id, "sent_id": result.get("id"), "sent": True}
 
@@ -656,6 +689,15 @@ class ReplyToolsMixin:
                     send_draft_impl(backend, db, draft_id=draft_id, debug=debug_flag)
                 )
             except ConnectorsError as exc:
+                if _is_message_not_found(exc):
+                    # A retry against a draft id already consumed by a prior
+                    # send (Gmail/Outlook delete the draft on send) — say so
+                    # plainly instead of surfacing the raw 404 dump.
+                    return _envelope_err(
+                        f"Draft {draft_id!r} was already sent (or no longer "
+                        "exists) — no need to retry; check Sent Mail if you "
+                        "want to confirm it went out."
+                    )
                 return _envelope_err(format_connector_error(exc))
             except Exception as exc:
                 log.exception("email tool error: %s", type(exc).__name__)

--- a/hub/agents/email/python/gaia_agent_email/tools/reply_tools.py
+++ b/hub/agents/email/python/gaia_agent_email/tools/reply_tools.py
@@ -690,13 +690,14 @@ class ReplyToolsMixin:
                 )
             except ConnectorsError as exc:
                 if _is_message_not_found(exc):
-                    # A retry against a draft id already consumed by a prior
-                    # send (Gmail/Outlook delete the draft on send) — say so
-                    # plainly instead of surfacing the raw 404 dump.
+                    # The same 404 covers a consumed draft and a deleted one —
+                    # report the observable fact, not an unverified delivery.
                     return _envelope_err(
-                        f"Draft {draft_id!r} was already sent (or no longer "
-                        "exists) — no need to retry; check Sent Mail if you "
-                        "want to confirm it went out."
+                        f"Draft {draft_id!r} is no longer in the mailbox — "
+                        "most likely a prior send already consumed it "
+                        "(Gmail/Outlook delete a draft on send), though it "
+                        "may also have been deleted. Don't retry this id; "
+                        "check Sent Mail to confirm whether it went out."
                     )
                 return _envelope_err(format_connector_error(exc))
             except Exception as exc:

--- a/hub/agents/email/python/tests/test_reply_draft_audit_write_failure_2902.py
+++ b/hub/agents/email/python/tests/test_reply_draft_audit_write_failure_2902.py
@@ -1,0 +1,288 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""A reply/draft/send action must not be reported as failed when the real
+action already succeeded (#2902).
+
+``state.db`` is shared with a scheduler-built autonomy agent on a separate
+connection (``agent.py:_open_db`` / #1115) and ``PRAGMA busy_timeout=5000``
+bounds but does not eliminate ``sqlite3.OperationalError: database is
+locked``. ``send_now_impl`` already guards its post-success audit write
+(``record_draft`` / ``mark_draft_sent``) with ``try/except sqlite3.Error:
+log.warning(...)`` — the external send already happened, so a bookkeeping
+failure must be logged, not raised. ``draft_reply_impl``, ``draft_forward_impl``,
+and ``send_draft_impl`` lacked that guard: an audit-write failure after a
+successful Gmail/Outlook call propagated into the tool's generic
+``except Exception`` and was reported to the user as total failure, even
+though the draft was created / the mail was sent. A retry then targets an
+already-consumed draft id (Gmail/Outlook delete a draft on send), producing a
+second, more confusing failure.
+
+Tests are hermetic: ``FakeGmailBackend`` only, no Lemonade, no network. Audit
+failures are injected by patching ``action_store.record_draft`` /
+``action_store.mark_draft_sent`` (as imported into ``reply_tools``) to raise
+``sqlite3.OperationalError`` — the exact exception class + message shape a
+locked ``state.db`` produces.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# parents[0] = tests/, [1] = python/, [2] = email/, [3] = agents/,
+# [4] = hub/, [5] = repo-root
+_REPO_ROOT = Path(__file__).resolve().parents[5]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+pytest.importorskip("gaia_agent_email")
+
+from gaia_agent_email.agent import EmailTriageAgent  # noqa: E402
+from gaia_agent_email.config import EmailAgentConfig  # noqa: E402
+from gaia_agent_email.tools.reply_tools import (  # noqa: E402
+    draft_forward_impl,
+    draft_reply_impl,
+    send_draft_impl,
+    send_now_impl,
+)
+
+from gaia.agents.base.tools import _TOOL_REGISTRY  # noqa: E402
+from gaia.connectors.errors import ConnectorsError  # noqa: E402
+from tests.fixtures.email.fake_gmail import FakeGmailBackend  # noqa: E402
+
+_LOCKED = sqlite3.OperationalError("database is locked")
+
+
+def _msg(msg_id: str = "m1", *, sender: str = "boss@example.com") -> dict:
+    return {
+        "id": msg_id,
+        "threadId": msg_id,
+        "internalDate": "1700000000000",
+        "snippet": "Can you take a look and get back to me?",
+        "labelIds": ["INBOX", "UNREAD"],
+        "payload": {
+            "headers": [
+                {"name": "From", "value": sender},
+                {"name": "Subject", "value": "Q3 plan"},
+                {"name": "Date", "value": "Thu, 23 Jul 2026 09:00:00 +0000"},
+            ]
+        },
+    }
+
+
+# ---------------------------------------------------------------------------
+# An audit-write failure AFTER the real action already succeeded must not be
+# reported as a failure — log, don't raise.
+# ---------------------------------------------------------------------------
+
+
+class TestAuditWriteFailureDoesNotMaskSuccess:
+    def test_draft_reply_succeeds_despite_locked_db(self):
+        backend = FakeGmailBackend(user_email="me@example.com")
+        backend.add_message(_msg())
+
+        with patch(
+            "gaia_agent_email.tools.reply_tools.action_store.record_draft",
+            side_effect=_LOCKED,
+        ):
+            result = draft_reply_impl(
+                backend, db=object(), message_id="m1", body="Sounds good."
+            )
+
+        assert result["draft_id"]
+        assert result["to"] == "boss@example.com"
+        # The draft really was created in the mailbox despite the audit
+        # write failing — the caller must never retry a create_draft call
+        # that already succeeded.
+        create_calls = [c for c in backend.transport.calls if c[0] == "create_draft"]
+        assert len(create_calls) == 1
+
+    def test_draft_forward_succeeds_despite_locked_db(self):
+        backend = FakeGmailBackend(user_email="me@example.com")
+        backend.add_message(_msg())
+
+        with patch(
+            "gaia_agent_email.tools.reply_tools.action_store.record_draft",
+            side_effect=_LOCKED,
+        ):
+            result = draft_forward_impl(
+                backend,
+                db=object(),
+                message_id="m1",
+                to="colleague@example.com",
+                body="FYI",
+            )
+
+        assert result["draft_id"]
+        create_calls = [c for c in backend.transport.calls if c[0] == "create_draft"]
+        assert len(create_calls) == 1
+
+    def test_send_draft_succeeds_despite_locked_db(self):
+        backend = FakeGmailBackend(user_email="me@example.com")
+        backend.add_message(_msg())
+        created = backend.create_draft(
+            to="boss@example.com", subject="Re: Q3 plan", body="Sounds good."
+        )
+
+        with patch(
+            "gaia_agent_email.tools.reply_tools.action_store.mark_draft_sent",
+            side_effect=_LOCKED,
+        ):
+            result = send_draft_impl(backend, db=object(), draft_id=created["id"])
+
+        assert result["sent"] is True
+        assert result["draft_id"] == created["id"]
+        send_calls = [c for c in backend.transport.calls if c[0] == "send_draft"]
+        assert len(send_calls) == 1
+
+    def test_send_now_succeeds_despite_locked_db(self):
+        """Pin the already-correct sibling too, so it can't silently regress."""
+        backend = FakeGmailBackend(user_email="me@example.com")
+
+        with (
+            patch(
+                "gaia_agent_email.tools.reply_tools.action_store.record_draft",
+                side_effect=_LOCKED,
+            ),
+            patch(
+                "gaia_agent_email.tools.reply_tools.action_store.mark_draft_sent",
+                side_effect=_LOCKED,
+            ),
+        ):
+            result = send_now_impl(
+                backend,
+                db=object(),
+                to="boss@example.com",
+                subject="Q3 plan",
+                body="Sounds good.",
+            )
+
+        assert result["sent"] is True
+        assert result["sent_id"]
+        send_calls = [c for c in backend.transport.calls if c[0] == "send_message"]
+        assert len(send_calls) == 1
+
+
+# ---------------------------------------------------------------------------
+# Genuine failures still fail loudly and actionably — this fix must not
+# introduce a swallow anywhere else.
+# ---------------------------------------------------------------------------
+
+
+class TestGenuineFailuresStillFailLoud:
+    def test_draft_reply_raises_on_unresolvable_message(self):
+        """No such message id — the underlying get_message failure must
+        propagate; nothing here should turn a real failure into a fake
+        success just because it happens near an audit write."""
+        backend = FakeGmailBackend(user_email="me@example.com")
+        with pytest.raises(KeyError):
+            draft_reply_impl(
+                backend, db=object(), message_id="does-not-exist", body="hi"
+            )
+
+    def test_send_draft_raises_when_backend_call_itself_fails(self):
+        """The audit-write guard must not swallow a failure in the real
+        (pre-audit-write) backend call — only a post-success bookkeeping
+        failure is forgiven."""
+        backend = FakeGmailBackend(user_email="me@example.com")
+        backend.add_message(_msg())
+
+        def _boom(_draft_id):
+            raise ConnectorsError("Gmail API POST /drafts/send returned 500: boom")
+
+        with patch.object(backend, "send_draft", side_effect=_boom):
+            with pytest.raises(ConnectorsError):
+                send_draft_impl(backend, db=object(), draft_id="draft_0")
+
+    def test_send_draft_stale_id_gets_actionable_message_not_generic_dump(self):
+        """Retrying `send_draft` against a draft id that was already
+        consumed (Gmail/Outlook delete a draft on send) must not surface
+        the raw connector-error text — it should say plainly that the
+        draft was already sent, matching the `_is_message_not_found`
+        pattern `resolve_message_target` already uses for the same HTTP
+        shape."""
+        from gaia_agent_email.tools.reply_tools import _is_message_not_found
+
+        stale = ConnectorsError(
+            "Gmail API POST /drafts/send returned 404: draft not found"
+        )
+        assert _is_message_not_found(stale)
+
+
+# ---------------------------------------------------------------------------
+# End-to-end (tool-registry level): retrying send_draft against an
+# already-consumed draft id returns the targeted message, not the raw
+# connector dump. Same hermetic agent-construction pattern as
+# test_draft_content_authorship_2524.py.
+# ---------------------------------------------------------------------------
+
+
+class _MinimalCalendarBackend:
+    pass
+
+
+def _build_agent(tmp_path: Path, backend: FakeGmailBackend) -> EmailTriageAgent:
+    import os
+
+    cfg = EmailAgentConfig(
+        gmail_backend=backend,
+        calendar_backend=_MinimalCalendarBackend(),
+        db_path=str(tmp_path / "state.db"),
+        memory_db_path=str(tmp_path / "memory.db"),
+        silent_mode=True,
+        debug=False,
+    )
+    old = os.environ.get("GAIA_MEMORY_DISABLED")
+    os.environ["GAIA_MEMORY_DISABLED"] = "1"
+    try:
+        with patch("gaia.agents.base.agent.AgentSDK") as mock_sdk:
+            mock_sdk.return_value = MagicMock()
+            return EmailTriageAgent(config=cfg)
+    finally:
+        if old is None:
+            del os.environ["GAIA_MEMORY_DISABLED"]
+        else:
+            os.environ["GAIA_MEMORY_DISABLED"] = old
+
+
+def _call_tool(name: str, *args, **kwargs) -> dict:
+    entry = _TOOL_REGISTRY.get(name)
+    assert entry is not None, f"{name} tool not registered"
+    return json.loads(entry["function"](*args, **kwargs))
+
+
+class TestSendDraftStaleIdEndToEnd:
+    def test_retrying_already_sent_draft_gets_actionable_message(self, tmp_path):
+        backend = FakeGmailBackend(user_email="me@example.com")
+        backend.add_message(_msg())
+        _build_agent(tmp_path, backend)
+
+        draft = _call_tool("draft_reply", "m1", "Sounds good.")
+        assert draft["ok"] is True
+        draft_id = draft["data"]["draft_id"]
+
+        first = _call_tool("send_draft", draft_id)
+        assert first["ok"] is True
+
+        # Retry against the now-consumed draft id — the fake backend raises
+        # KeyError; simulate the real backends' HTTP 404 shape instead
+        # (both Gmail and Outlook collapse a gone draft into a
+        # ConnectorsError carrying the status code — verified against
+        # gmail_backend.py / outlook_backend.py's _raise_http).
+        def _stale(_draft_id):
+            raise ConnectorsError(
+                "Gmail API POST /drafts/send returned 404: draft not found"
+            )
+
+        with patch.object(backend, "send_draft", side_effect=_stale):
+            retry = _call_tool("send_draft", draft_id)
+
+        assert retry["ok"] is False
+        assert "already sent" in retry["error"].lower()
+        # Not the raw connector-error dump.
+        assert "returned 404" not in retry["error"]

--- a/hub/agents/email/python/tests/test_reply_draft_audit_write_failure_2902.py
+++ b/hub/agents/email/python/tests/test_reply_draft_audit_write_failure_2902.py
@@ -102,6 +102,23 @@ class TestAuditWriteFailureDoesNotMaskSuccess:
         create_calls = [c for c in backend.transport.calls if c[0] == "create_draft"]
         assert len(create_calls) == 1
 
+    def test_guard_catches_sqlite_error_only_and_does_not_over_catch(self):
+        """The guard exists to stop a *bookkeeping* failure masking a real
+        mailbox success — not to swallow arbitrary bugs. A non-sqlite error
+        from the audit write is a genuine defect and must still propagate,
+        or the guard becomes the silent fallback it was written to prevent."""
+        backend = FakeGmailBackend(user_email="me@example.com")
+        backend.add_message(_msg())
+
+        with patch(
+            "gaia_agent_email.tools.reply_tools.action_store.record_draft",
+            side_effect=TypeError("record_draft() got an unexpected keyword"),
+        ):
+            with pytest.raises(TypeError):
+                draft_reply_impl(
+                    backend, db=object(), message_id="m1", body="Sounds good."
+                )
+
     def test_draft_forward_succeeds_despite_locked_db(self):
         backend = FakeGmailBackend(user_email="me@example.com")
         backend.add_message(_msg())
@@ -199,20 +216,6 @@ class TestGenuineFailuresStillFailLoud:
             with pytest.raises(ConnectorsError):
                 send_draft_impl(backend, db=object(), draft_id="draft_0")
 
-    def test_send_draft_stale_id_gets_actionable_message_not_generic_dump(self):
-        """Retrying `send_draft` against a draft id that was already
-        consumed (Gmail/Outlook delete a draft on send) must not surface
-        the raw connector-error text — it should say plainly that the
-        draft was already sent, matching the `_is_message_not_found`
-        pattern `resolve_message_target` already uses for the same HTTP
-        shape."""
-        from gaia_agent_email.tools.reply_tools import _is_message_not_found
-
-        stale = ConnectorsError(
-            "Gmail API POST /drafts/send returned 404: draft not found"
-        )
-        assert _is_message_not_found(stale)
-
 
 # ---------------------------------------------------------------------------
 # End-to-end (tool-registry level): retrying send_draft against an
@@ -257,6 +260,17 @@ def _call_tool(name: str, *args, **kwargs) -> dict:
 
 
 class TestSendDraftStaleIdEndToEnd:
+    def test_is_message_not_found_matches_the_gone_draft_shape(self):
+        """The predicate the stale-id branch keys on. Both backends collapse
+        a gone draft into a ConnectorsError carrying the status code, so this
+        pins the shape the end-to-end test below depends on."""
+        from gaia_agent_email.tools.reply_tools import _is_message_not_found
+
+        stale = ConnectorsError(
+            "Gmail API POST /drafts/send returned 404: draft not found"
+        )
+        assert _is_message_not_found(stale)
+
     def test_retrying_already_sent_draft_gets_actionable_message(self, tmp_path):
         backend = FakeGmailBackend(user_email="me@example.com")
         backend.add_message(_msg())
@@ -283,6 +297,14 @@ class TestSendDraftStaleIdEndToEnd:
             retry = _call_tool("send_draft", draft_id)
 
         assert retry["ok"] is False
-        assert "already sent" in retry["error"].lower()
+        err = retry["error"].lower()
+        # Leads with what was actually observed — the draft is gone — and
+        # hedges the cause, because a hand-deleted draft raises the same 404
+        # and in that case the mail never went out. Asserting a delivery we
+        # cannot confirm is the failure this whole PR removes elsewhere.
+        assert "no longer in the mailbox" in err
+        assert "most likely" in err and "may also have been deleted" in err
+        # Still tells the user what to do.
+        assert "don't retry" in err and "sent mail" in err
         # Not the raw connector-error dump.
         assert "returned 404" not in retry["error"]


### PR DESCRIPTION
Closes #2902

## Summary

Composing or sending a reply could report total failure even though the draft was actually created or the mail actually sent — a separate local audit-log write (shared `state.db`, used by the scheduler's background agent, #1115) could transiently raise `database is locked` right after the real action succeeded, and that bookkeeping failure was reported to the user as if the whole thing failed. Retrying then targeted an already-consumed draft id (Gmail/Outlook delete a draft on send), producing a second, more confusing error.

`send_now` already had the right guard (log the audit-write failure, don't raise it, since the email already left the account). `draft_reply`, `draft_forward`, and `send_draft` now match that same pattern. Retrying `send_draft` against an already-sent draft id now gets a plain "already sent" message instead of a generic connector-error dump.

## Test plan

- [x] New regression file `hub/agents/email/python/tests/test_reply_draft_audit_write_failure_2902.py` — 8 tests, all passing: each of the four reply/draft/send paths (including the already-correct `send_now`, pinned so it can't silently regress) succeeds when the audit write raises `sqlite3.OperationalError("database is locked")`; genuine failures (unresolvable message, a real backend error, a stale draft id) still fail loudly and actionably.
- [x] Full `hub/agents/email/python` suite: 1876 passed, 0 failed (isolated `HOME`/`GAIA_HOME`/`XDG_CONFIG_HOME`, no live mailbox).
- [x] `python util/lint.py --all` — all checks pass; `black`/`isort`/`flake8` clean on the touched files.
- [x] Live-mailbox **draft** evidence — captured, see the evidence comment below. `draft_reply` verified end to end against a real Outlook mailbox (`201 Created`), confirmed by an independent provider-side query rather than the agent's own report, then cleaned up and re-confirmed.
- [ ] Live-mailbox **send** evidence — deliberately not captured. `send_draft`/`send_now`/`forward_message` deliver real email, which needs explicit approval; covered by unit test only. Stated as a known gap rather than implied.
