### PR TITLE
fix(tui): anchor TTFT on first inference token, use real token counts

### DIFF
--- a/docs/sdk/sdks/agent-ui.mdx
+++ b/docs/sdk/sdks/agent-ui.mdx
@@ -662,7 +662,7 @@ class AttachDocumentRequest(BaseModel):
     | Event type | Fields | Description |
     |------------|--------|-------------|
     | `chunk` | `content` (string) | Incremental text fragment of the response, streamed as the LLM generates tokens. Raw tool-call JSON is automatically filtered out. |
-    | `answer` | `content` (string), `elapsed` (number), `steps` (int), `tools_used` (int) | Final complete answer from the agent. `elapsed` is wall-clock seconds. `steps` and `tools_used` are execution totals. Double-escaped newlines/tabs from LLM output are automatically corrected. |
+    | `answer` | `content` (string), `elapsed` (number), `steps` (int), `tools_used` (int), `tokens` (int, optional), `ttft` (number, optional) | Final complete answer from the agent. `elapsed` is wall-clock seconds. `steps` and `tools_used` are execution totals. `tokens` is the real output-token count and `ttft` the real time-to-first-token for the run, in seconds -- both omitted entirely (never a fake `0`) when no real value was recorded. Double-escaped newlines/tabs from LLM output are automatically corrected. |
     | `agent_error` | `content` (string) | Error message from the agent. |
 
     **Stream Termination**
@@ -682,7 +682,7 @@ class AttachDocumentRequest(BaseModel):
     data: {"type": "chunk", "content": "This function"}
     data: {"type": "chunk", "content": " initializes"}
     data: {"type": "chunk", "content": " the database..."}
-    data: {"type": "answer", "content": "This function initializes the database...", "elapsed": 3.45, "steps": 1, "tools_used": 1}
+    data: {"type": "answer", "content": "This function initializes the database...", "elapsed": 3.45, "steps": 1, "tools_used": 1, "tokens": 42, "ttft": 0.81}
     data: {"type": "status", "status": "complete", "message": "Completed in 1 steps", "steps": 1, "elapsed": 3.45}
     data: {"type": "done", "message_id": 42, "content": "This function initializes the database..."}
     ```

--- a/docs/spec/agent-ui-query-sse-contract.md
+++ b/docs/spec/agent-ui-query-sse-contract.md
@@ -260,7 +260,7 @@ indistinguishable from a dead one.
   "properties": {
     "type":   { "const": "final" },
     "answer": { "type": "string" },
-    "usage":  { "type": "object" }   // optional {steps?, tools_used?, elapsed?, tokens?}
+    "usage":  { "type": "object" }   // optional {steps?, tools_used?, elapsed?, tokens?, ttft?}
   } }
 
 // error
@@ -414,7 +414,7 @@ truth:** [`src/gaia/ui/sse_handler.py`](../../src/gaia/ui/sse_handler.py) on
 |---|---|---|
 | `tool_start` | `tool_call` | Rename; carry `tool`. `args` filled from the paired `tool_args` (§6.3). `detail`/`mcp_server` dropped (host derives its own label). |
 | `chunk` | `token` | `content` → `delta`. |
-| `answer` | `final` | `content` → `answer`; `elapsed`/`steps`/`tools_used` → `usage`. |
+| `answer` | `final` | `content` → `answer`; `elapsed`/`steps`/`tools_used`/`tokens`/`ttft` → `usage`. |
 | `permission_request` | `needs_confirmation` | `tool` → `action`; render `args` as `summary`; carry `run_id`; `confirm_url` per §5. |
 
 ### 6.2 Every remaining top-level source event

--- a/docs/spec/console.mdx
+++ b/docs/spec/console.mdx
@@ -159,8 +159,19 @@ class OutputHandler(ABC):
     # === Completion Methods (Required) ===
 
     @abstractmethod
-    def print_final_answer(self, answer: str):
-        """Print final answer/result."""
+    def print_final_answer(
+        self,
+        answer: str,
+        total_tokens: Optional[int] = None,
+        ttft_seconds: Optional[float] = None,
+    ):
+        """Print final answer/result.
+
+        total_tokens: real output-token count generated across the run, if
+        known. ttft_seconds: real time-to-first-token for the LLM call that
+        produced this answer, if known. Both None when no real value is
+        available — never a substituted estimate.
+        """
         ...
 
     @abstractmethod
@@ -364,7 +375,13 @@ class SilentConsole(TerminalConfirmationMixin, OutputHandler):
         self.silence_final_answer = silence_final_answer
         self.auto_approve_gated_tools = auto_approve_gated_tools
 
-    def print_final_answer(self, answer: str, streaming: bool = True) -> None:
+    def print_final_answer(
+        self,
+        answer: str,
+        streaming: bool = True,
+        total_tokens: Optional[int] = None,
+        ttft_seconds: Optional[float] = None,
+    ) -> None:
         """
         Print the final answer.
         Only suppressed if silence_final_answer is True.

--- a/hub/agents/email/npm/src/types.ts
+++ b/hub/agents/email/npm/src/types.ts
@@ -1046,6 +1046,8 @@ export interface QueryUsage {
   elapsed?: number;
   /** Token counts, when the backend reports them. */
   tokens?: number;
+  /** Time to first inference token, in seconds, when the backend reports it. */
+  ttft?: number;
   [key: string]: unknown;
 }
 

--- a/hub/agents/email/python/gaia_agent_email/sse_translation.py
+++ b/hub/agents/email/python/gaia_agent_email/sse_translation.py
@@ -239,6 +239,7 @@ class CanonicalTranslator:
             ("tools_used", "tools_used"),
             ("elapsed", "elapsed"),
             ("tokens", "tokens"),
+            ("ttft", "ttft"),
         ):
             if event.get(src) is not None:
                 usage[dst] = event[src]

--- a/hub/agents/email/python/gaia_agent_email/sse_translation.py
+++ b/hub/agents/email/python/gaia_agent_email/sse_translation.py
@@ -238,6 +238,7 @@ class CanonicalTranslator:
             ("steps", "steps"),
             ("tools_used", "tools_used"),
             ("elapsed", "elapsed"),
+            ("tokens", "tokens"),
         ):
             if event.get(src) is not None:
                 usage[dst] = event[src]

--- a/hub/agents/email/python/tests/test_sse_translation.py
+++ b/hub/agents/email/python/tests/test_sse_translation.py
@@ -49,6 +49,29 @@ def test_answer_maps_to_final_with_usage():
     assert out[0]["usage"] == {"steps": 3, "tools_used": 2, "elapsed": 1.2}
 
 
+def test_answer_maps_tokens_into_usage():
+    # #2899: the real generated-token count, when the source event carries
+    # one, must reach usage.tokens — the TUI reads it in place of its old
+    # char-count guess.
+    out = _tr().translate(
+        {
+            "type": "answer",
+            "content": "Done.",
+            "elapsed": 1.2,
+            "steps": 3,
+            "tools_used": 2,
+            "tokens": 42,
+        }
+    )
+    assert out[0]["usage"]["tokens"] == 42
+
+
+def test_answer_omits_tokens_when_source_has_none():
+    # No real count available -> omitted entirely, never a fake 0 (#2899).
+    out = _tr().translate({"type": "answer", "content": "Done.", "steps": 1})
+    assert "tokens" not in out[0]["usage"]
+
+
 def test_answer_is_terminal():
     out = _tr().translate({"type": "answer", "content": "Done."})
     assert out[0]["type"] in TERMINAL_TYPES

--- a/hub/agents/email/python/tests/test_sse_translation.py
+++ b/hub/agents/email/python/tests/test_sse_translation.py
@@ -5,7 +5,9 @@
 These assert the translation map is TOTAL — every top-level event type
 ``sse_handler.py`` emits has an explicit canonical mapping — and that the
 ``tool_start`` + ``tool_args`` → one ``tool_call`` buffering (spec §6.3) is exact.
-Dependency-light: no Lemonade, Gmail, or ``gaia.ui`` needed.
+Dependency-light by default: no Lemonade or Gmail needed. A handful of tests
+that guard the producer/translator boundary (see ``_real_answer_event``)
+import ``gaia.ui.sse_handler`` — a deliberate, narrow exception; see #2911.
 """
 
 from __future__ import annotations
@@ -22,6 +24,27 @@ def _tr() -> CanonicalTranslator:
 
 def _types(events):
     return [e["type"] for e in events]
+
+
+def _real_answer_event(**print_final_answer_kwargs) -> dict:
+    """Drive the REAL producer — ``SSEOutputHandler.print_final_answer`` —
+    and return the ``answer`` event it actually emits, instead of a
+    hand-typed guess of its shape.
+
+    #2911 review: a synthetic ``{"type": "answer", ...}`` dict that simply
+    omits a key (e.g. "tokens") passes against the translator's mapping
+    logic even when the real producer emits that key with a fake `0`
+    instead of leaving it off — the translator was never wrong, so the
+    hand-built input can't catch a producer-side regression. Importing
+    ``gaia.ui`` here is a deliberate, narrow exception to this file's
+    dependency-light default, scoped to the tests that specifically guard
+    the producer/translator boundary.
+    """
+    from gaia.ui.sse_handler import SSEOutputHandler
+
+    handler = SSEOutputHandler()
+    handler.print_final_answer("Done.", **print_final_answer_kwargs)
+    return handler.event_queue.get_nowait()
 
 
 # ---------------------------------------------------------------------------
@@ -52,23 +75,20 @@ def test_answer_maps_to_final_with_usage():
 def test_answer_maps_tokens_into_usage():
     # #2899: the real generated-token count, when the source event carries
     # one, must reach usage.tokens — the TUI reads it in place of its old
-    # char-count guess.
-    out = _tr().translate(
-        {
-            "type": "answer",
-            "content": "Done.",
-            "elapsed": 1.2,
-            "steps": 3,
-            "tools_used": 2,
-            "tokens": 42,
-        }
-    )
+    # char-count guess. Driven off the real producer (see
+    # ``_real_answer_event``) so this fails if the wire key ever changes.
+    out = _tr().translate(_real_answer_event(total_tokens=42))
     assert out[0]["usage"]["tokens"] == 42
 
 
 def test_answer_omits_tokens_when_source_has_none():
     # No real count available -> omitted entirely, never a fake 0 (#2899).
-    out = _tr().translate({"type": "answer", "content": "Done.", "steps": 1})
+    # Regression guard for #2911: the producer used to always pass an int
+    # (0 when no per-step stats existed), so this event legitimately carried
+    # `tokens: 0` on the wire until the producer-side guard was fixed to
+    # match ttft's. A hand-built dict without the "tokens" key can't catch
+    # that — it has to come from the real producer.
+    out = _tr().translate(_real_answer_event(total_tokens=0))
     assert "tokens" not in out[0]["usage"]
 
 
@@ -76,22 +96,13 @@ def test_answer_maps_ttft_into_usage():
     # #2899 follow-up: real ttft was never reaching the TUI at all on the
     # non-streaming daemon path (every native tool-calling model's normal
     # path) -- when the source event carries one, it must reach usage.ttft.
-    out = _tr().translate(
-        {
-            "type": "answer",
-            "content": "Done.",
-            "steps": 2,
-            "tools_used": 1,
-            "tokens": 72,
-            "ttft": 9.4,
-        }
-    )
+    out = _tr().translate(_real_answer_event(total_tokens=72, ttft_seconds=9.4))
     assert out[0]["usage"]["ttft"] == 9.4
 
 
 def test_answer_omits_ttft_when_source_has_none():
     # No real value available -> omitted entirely, never a fake 0.
-    out = _tr().translate({"type": "answer", "content": "Done.", "steps": 1})
+    out = _tr().translate(_real_answer_event(total_tokens=0))
     assert "ttft" not in out[0]["usage"]
 
 

--- a/hub/agents/email/python/tests/test_sse_translation.py
+++ b/hub/agents/email/python/tests/test_sse_translation.py
@@ -72,6 +72,29 @@ def test_answer_omits_tokens_when_source_has_none():
     assert "tokens" not in out[0]["usage"]
 
 
+def test_answer_maps_ttft_into_usage():
+    # #2899 follow-up: real ttft was never reaching the TUI at all on the
+    # non-streaming daemon path (every native tool-calling model's normal
+    # path) -- when the source event carries one, it must reach usage.ttft.
+    out = _tr().translate(
+        {
+            "type": "answer",
+            "content": "Done.",
+            "steps": 2,
+            "tools_used": 1,
+            "tokens": 72,
+            "ttft": 9.4,
+        }
+    )
+    assert out[0]["usage"]["ttft"] == 9.4
+
+
+def test_answer_omits_ttft_when_source_has_none():
+    # No real value available -> omitted entirely, never a fake 0.
+    out = _tr().translate({"type": "answer", "content": "Done.", "steps": 1})
+    assert "ttft" not in out[0]["usage"]
+
+
 def test_answer_is_terminal():
     out = _tr().translate({"type": "answer", "content": "Done."})
     assert out[0]["type"] in TERMINAL_TYPES

--- a/src/gaia/agents/base/agent.py
+++ b/src/gaia/agents/base/agent.py
@@ -340,58 +340,16 @@ def _sum_conversation_tokens(
 
 
 def _query_ttft_seconds(conversation: List[Dict[str, Any]]) -> Optional[float]:
-    """Real time-to-first-token for the turn, read off the EARLIEST per-step
-    'stats' entry already appended to ``conversation`` (same source
-    ``_sum_conversation_tokens`` reads for output tokens) — i.e. the first
-    LLM call of the turn, not the one that happened to produce the visible
-    answer.
-
-    Native tool-calling models attach the full tool schema on every step, and
-    Lemonade forces a request non-streaming whenever ``tools`` is attached
-    (see ``LemonadeProvider.chat``'s ``effective_stream`` gate) — so no
-    ``CanonicalTokenEvent`` is ever emitted to anchor the TUI's client-side
-    ttft on the daemon path (#2899 follow-up). Lemonade's own ``/stats``
-    endpoint's ``time_to_first_token`` is per-request measured latency, not a
-    wall-clock approximation — polled by the agent loop after every step
-    regardless of streaming, so it is available for step 1 same as any other.
-
-    Step 1 is deliberately the one read, not the last step: nothing of
-    substance happens between ``process_query``'s start_time and the first
-    LLM call (message-list assembly only, no I/O), so step 1's own
-    time_to_first_token is the closest available proxy for "query submit to
-    first inference token" — the AC's actual quantity. The LAST step's ttft
-    was tried first and rejected: it times only the final LLM call, silently
-    dropping every earlier step's tool-decision latency (the #2899 baseline's
-    own warm-query numbers: an ~8s tool-call decision, then more steps, on a
-    ~69s turn — a last-step reading would land near ~1-2s, reproducing
-    exactly the "implausibly small ttft on a minute-long query" defect this
-    issue exists to fix, just with a different number).
-
-    There is no further pre-step latency (queue time, model-load time) to add
-    on top: Lemonade's ``/stats`` payload has exactly five fields
-    (time_to_first_token, tokens_per_second, input_tokens, output_tokens,
-    decode_token_times — see ``tests/test_lemonade_client.py::test_get_stats``)
-    and none of them separates that out, so step 1's own value already is the
-    real number, not a component of a larger one still to be assembled.
-
-    Returns ``None`` when step 1 reported no positive value — never a
-    fabricated 0.0, and never a later step's value standing in for it. That
-    last case is real, not hypothetical: a failed ``/stats`` poll returns
-    ``{}`` (falsy, so the caller's ``if perf_stats:`` skips the append for
-    that step) and a parse-recovery retry can ``continue`` past the append
-    too, so the EARLIEST 'stats' entry present in ``conversation`` is not
-    always step 1's. Each entry carries its own step number, so that is
-    checked explicitly rather than trusting entry order (fail-loud: no
-    silent fake data, matching the token-count precedent above)."""
+    """Turn's ttft = the FIRST step's own time_to_first_token; a later step's
+    value would drop all earlier tool-decision latency. None when step 1 has
+    no positive value — never a fabricated 0.0."""
     for entry in conversation:
         if entry.get("role") == "system" and isinstance(entry.get("content"), dict):
             content = entry["content"]
             if content.get("type") == "stats" and "performance_stats" in content:
                 if content.get("step") != 1:
-                    # The earliest stats entry present belongs to a later
-                    # step (step 1's own poll failed or was skipped) —
-                    # omit rather than misattribute a later step's latency
-                    # as the turn's ttft.
+                    # Step 1's own poll failed/was skipped — never misattribute
+                    # a later step's latency as the turn's ttft.
                     return None
                 stats = content["performance_stats"]
                 ttft = (
@@ -2815,28 +2773,12 @@ Do NOT wrap conversational replies in JSON.
         ``_extract_tool_usage``; this method only appends.
 
         A tool whose internal LLM calls already route through ``self.chat``
-        would double-count here (its tokens would land in BOTH the per-step
-        ``performance_stats`` conversation entries AND this fold). No known
-        tool does this today — this is a constraint on future tools, not a
-        live bug. Warn loudly if it ever happens rather than silently
-        inflating the total.
+        would double-count here — a constraint on future tools, not a live one.
         """
         usage = _extract_tool_usage(tool_result)
         if usage is None:
             return
-        try:
-            stats_look_fresh = bool(self.chat.get_stats())
-        except Exception:  # pylint: disable=broad-except
-            # get_stats() is best-effort diagnostics, not part of this
-            # method's contract — never let it block a real usage fold.
-            stats_look_fresh = False
-        if stats_look_fresh:
-            logger.warning(
-                "Tool '%s' reported its own LLM usage AND self.chat has fresh "
-                "stats — likely double-counting; folding it in anyway but "
-                "this combination should not exist. See _fold_tool_usage.",
-                tool_name,
-            )
+        logger.debug("Tool '%s' reported its own LLM usage: %s", tool_name, usage)
         self._tool_reported_usage.append(usage)
 
     def _execute_tool(self, tool_name: str, tool_args: Dict[str, Any]) -> Any:

--- a/src/gaia/agents/base/agent.py
+++ b/src/gaia/agents/base/agent.py
@@ -300,6 +300,81 @@ def _find_matching_close_paren(text: str, open_pos: int) -> Optional[int]:
     return None
 
 
+def _safe_number(value: Any) -> int:
+    """Coerce a usage-stat value to a non-negative int; anything else
+    (string, None, nested structure, bool) is untrusted input and yields 0
+    rather than raising — a malformed stat must never break the run that
+    carries it."""
+    if isinstance(value, bool):
+        return 0
+    if isinstance(value, (int, float)) and value >= 0:
+        return int(value)
+    return 0
+
+
+def _sum_conversation_tokens(
+    conversation: List[Dict[str, Any]],
+    tool_usage_entries: Optional[List[Dict[str, Any]]] = None,
+) -> Tuple[int, int]:
+    """Sum input/output tokens from per-step 'stats' entries already appended
+    to conversation, plus any tool-reported usage folded in separately (see
+    ``_extract_tool_usage``). Returns (total_input, total_output)."""
+    total_input = 0
+    total_output = 0
+    for entry in conversation:
+        if entry.get("role") == "system" and isinstance(entry.get("content"), dict):
+            content = entry["content"]
+            if content.get("type") == "stats" and "performance_stats" in content:
+                stats = content["performance_stats"]
+                total_input += _safe_number(stats.get("input_tokens"))
+                total_output += _safe_number(stats.get("output_tokens"))
+    for usage in tool_usage_entries or []:
+        total_input += _safe_number(usage.get("prompt_tokens") or usage.get("input_tokens"))
+        total_output += _safe_number(
+            usage.get("completion_tokens") or usage.get("output_tokens")
+        )
+    return total_input, total_output
+
+
+# Only these field names are ever accepted from a tool's self-reported
+# ``usage`` dict — deliberately narrower than "any dict under a `usage` key",
+# so a tool with an unrelated `usage` value (rate-limit/quota/disk usage, not
+# LLM tokens) is never misread as token accounting (#2899).
+_TOOL_USAGE_TOKEN_FIELDS = (
+    "prompt_tokens",
+    "completion_tokens",
+    "input_tokens",
+    "output_tokens",
+)
+
+
+def _extract_tool_usage(tool_result: Any) -> Optional[Dict[str, Any]]:
+    """Pull a tool-reported usage dict off a tool's own return payload, if
+    present and shaped like real token accounting. Some tools make their own
+    internal LLM calls outside the normal per-step chat-completion accounting
+    (e.g. a triage tool that classifies many items with its own client calls)
+    and report the aggregate on their own return value instead of through the
+    per-step stats path. Never raises — a malformed payload (bad JSON, wrong
+    shape, non-numeric fields) yields ``None``, the same as "no usage to
+    report"."""
+    try:
+        payload = tool_result
+        if isinstance(payload, str):
+            payload = json.loads(payload)
+        if not isinstance(payload, dict):
+            return None
+        usage = payload.get("usage")
+        if not isinstance(usage, dict):
+            return None
+        has_real_token_field = any(
+            isinstance(usage.get(f), (int, float)) and not isinstance(usage.get(f), bool)
+            for f in _TOOL_USAGE_TOKEN_FIELDS
+        )
+        return usage if has_real_token_field else None
+    except (ValueError, TypeError):
+        return None
+
+
 # Suffix appended to the last tool-result message when ``single_tool_per_turn``
 # agents have completed their one tool call. The model sees this and emits a
 # short final reply instead of calling another tool. Greppable for fixtures
@@ -533,6 +608,10 @@ Do NOT wrap conversational replies in JSON.
         # post-registration skill-set load both see the explicit request.
         self._requested_skill_set = skill_set
         self.error_history = []  # Store error history for learning
+        # Safe default so _execute_tool -> _fold_tool_usage never AttributeErrors
+        # if called outside the normal process_query loop (e.g. directly in a
+        # test); _process_query_impl resets this per-turn (#2899).
+        self._tool_reported_usage: List[Dict[str, Any]] = []
         self.conversation_history = (
             []
         )  # Store conversation history for session persistence
@@ -2653,6 +2732,38 @@ Do NOT wrap conversational replies in JSON.
             return bool(flag)
         return tool_name.startswith("mcp_")
 
+    def _fold_tool_usage(self, tool_name: str, tool_result: Any) -> None:
+        """Record a tool's self-reported LLM usage (see ``_extract_tool_usage``)
+        against this turn's running total. Called from the single success path
+        inside ``_execute_tool`` so every caller is covered uniformly. Never
+        raises — extraction failures are already swallowed by
+        ``_extract_tool_usage``; this method only appends.
+
+        A tool whose internal LLM calls already route through ``self.chat``
+        would double-count here (its tokens would land in BOTH the per-step
+        ``performance_stats`` conversation entries AND this fold). No known
+        tool does this today — this is a constraint on future tools, not a
+        live bug. Warn loudly if it ever happens rather than silently
+        inflating the total.
+        """
+        usage = _extract_tool_usage(tool_result)
+        if usage is None:
+            return
+        try:
+            stats_look_fresh = bool(self.chat.get_stats())
+        except Exception:  # pylint: disable=broad-except
+            # get_stats() is best-effort diagnostics, not part of this
+            # method's contract — never let it block a real usage fold.
+            stats_look_fresh = False
+        if stats_look_fresh:
+            logger.warning(
+                "Tool '%s' reported its own LLM usage AND self.chat has fresh "
+                "stats — likely double-counting; folding it in anyway but "
+                "this combination should not exist. See _fold_tool_usage.",
+                tool_name,
+            )
+        self._tool_reported_usage.append(usage)
+
     def _execute_tool(self, tool_name: str, tool_args: Dict[str, Any]) -> Any:
         """
         Execute a tool by name with the provided arguments.
@@ -2796,6 +2907,7 @@ Do NOT wrap conversational replies in JSON.
         try:
             result = self._call_tool_bounded(tool, tool_args, tool_name)
             logger.debug(f"Tool execution result: {result}")
+            self._fold_tool_usage(tool_name, result)
             return result
         except ToolExecutionTimeout as e:
             # Bounded-execution guard fired: the tool body blocked past its
@@ -3666,6 +3778,10 @@ Do NOT wrap conversational replies in JSON.
         self.current_step = 0
         self.total_plan_steps = 0
         self.plan_iterations = 0  # Reset plan iteration counter
+        # Tool-reported LLM usage this turn (see _fold_tool_usage / #2899) —
+        # reset per-turn since an Agent instance persists across queries in
+        # an interactive session.
+        self._tool_reported_usage: List[Dict[str, Any]] = []
 
         # Add user query to the conversation history
         conversation.append({"role": "user", "content": user_input})
@@ -5538,7 +5654,17 @@ Do NOT wrap conversational replies in JSON.
 
                 final_answer = self.finalize_answer(answer_candidate, conversation)
                 self.execution_state = self.STATE_COMPLETION
-                self.console.print_final_answer(final_answer, streaming=self.streaming)
+                # Compute the real token total BEFORE printing the answer so it
+                # can ride the same event, instead of the post-loop aggregation
+                # below which runs after print_final_answer already fired
+                # (#2899). Output tokens only — "tokens actually generated",
+                # matching the tok/s calc downstream which is also output-only.
+                _pre_input_tokens, pre_output_tokens = _sum_conversation_tokens(
+                    conversation, self._tool_reported_usage
+                )
+                self.console.print_final_answer(
+                    final_answer, streaming=self.streaming, total_tokens=pre_output_tokens
+                )
                 break
 
             # Check if we're at the limit and ask user if they want to continue
@@ -5603,18 +5729,14 @@ Do NOT wrap conversational replies in JSON.
         # Calculate total duration
         total_duration = time.time() - start_time
 
-        # Aggregate token counts from conversation stats
-        total_input_tokens = 0
-        total_output_tokens = 0
-        for entry in conversation:
-            if entry.get("role") == "system" and isinstance(entry.get("content"), dict):
-                content = entry["content"]
-                if content.get("type") == "stats" and "performance_stats" in content:
-                    stats = content["performance_stats"]
-                    if stats.get("input_tokens") is not None:
-                        total_input_tokens += stats["input_tokens"]
-                    if stats.get("output_tokens") is not None:
-                        total_output_tokens += stats["output_tokens"]
+        # Aggregate token counts from conversation stats, plus any usage a
+        # tool self-reported (e.g. a triage tool's internal per-message LLM
+        # calls, #2899) — same helper the pre-answer computation above uses,
+        # reading identical inputs since nothing mutates conversation or
+        # self._tool_reported_usage between the two calls.
+        total_input_tokens, total_output_tokens = _sum_conversation_tokens(
+            conversation, self._tool_reported_usage
+        )
 
         # Return the result
         has_errors = len(self.error_history) > 0

--- a/src/gaia/agents/base/agent.py
+++ b/src/gaia/agents/base/agent.py
@@ -13,6 +13,7 @@ import datetime
 import inspect
 import json
 import logging
+import math
 import os
 import re
 import subprocess
@@ -336,6 +337,77 @@ def _sum_conversation_tokens(
             usage.get("completion_tokens") or usage.get("output_tokens")
         )
     return total_input, total_output
+
+
+def _query_ttft_seconds(conversation: List[Dict[str, Any]]) -> Optional[float]:
+    """Real time-to-first-token for the turn, read off the EARLIEST per-step
+    'stats' entry already appended to ``conversation`` (same source
+    ``_sum_conversation_tokens`` reads for output tokens) — i.e. the first
+    LLM call of the turn, not the one that happened to produce the visible
+    answer.
+
+    Native tool-calling models attach the full tool schema on every step, and
+    Lemonade forces a request non-streaming whenever ``tools`` is attached
+    (see ``LemonadeProvider.chat``'s ``effective_stream`` gate) — so no
+    ``CanonicalTokenEvent`` is ever emitted to anchor the TUI's client-side
+    ttft on the daemon path (#2899 follow-up). Lemonade's own ``/stats``
+    endpoint's ``time_to_first_token`` is per-request measured latency, not a
+    wall-clock approximation — polled by the agent loop after every step
+    regardless of streaming, so it is available for step 1 same as any other.
+
+    Step 1 is deliberately the one read, not the last step: nothing of
+    substance happens between ``process_query``'s start_time and the first
+    LLM call (message-list assembly only, no I/O), so step 1's own
+    time_to_first_token is the closest available proxy for "query submit to
+    first inference token" — the AC's actual quantity. The LAST step's ttft
+    was tried first and rejected: it times only the final LLM call, silently
+    dropping every earlier step's tool-decision latency (the #2899 baseline's
+    own warm-query numbers: an ~8s tool-call decision, then more steps, on a
+    ~69s turn — a last-step reading would land near ~1-2s, reproducing
+    exactly the "implausibly small ttft on a minute-long query" defect this
+    issue exists to fix, just with a different number).
+
+    There is no further pre-step latency (queue time, model-load time) to add
+    on top: Lemonade's ``/stats`` payload has exactly five fields
+    (time_to_first_token, tokens_per_second, input_tokens, output_tokens,
+    decode_token_times — see ``tests/test_lemonade_client.py::test_get_stats``)
+    and none of them separates that out, so step 1's own value already is the
+    real number, not a component of a larger one still to be assembled.
+
+    Returns ``None`` when step 1 reported no positive value — never a
+    fabricated 0.0, and never a later step's value standing in for it. That
+    last case is real, not hypothetical: a failed ``/stats`` poll returns
+    ``{}`` (falsy, so the caller's ``if perf_stats:`` skips the append for
+    that step) and a parse-recovery retry can ``continue`` past the append
+    too, so the EARLIEST 'stats' entry present in ``conversation`` is not
+    always step 1's. Each entry carries its own step number, so that is
+    checked explicitly rather than trusting entry order (fail-loud: no
+    silent fake data, matching the token-count precedent above)."""
+    for entry in conversation:
+        if entry.get("role") == "system" and isinstance(entry.get("content"), dict):
+            content = entry["content"]
+            if content.get("type") == "stats" and "performance_stats" in content:
+                if content.get("step") != 1:
+                    # The earliest stats entry present belongs to a later
+                    # step (step 1's own poll failed or was skipped) —
+                    # omit rather than misattribute a later step's latency
+                    # as the turn's ttft.
+                    return None
+                stats = content["performance_stats"]
+                ttft = (
+                    stats.get("time_to_first_token")
+                    if isinstance(stats, dict)
+                    else None
+                )
+                if (
+                    isinstance(ttft, (int, float))
+                    and not isinstance(ttft, bool)
+                    and math.isfinite(ttft)
+                    and ttft > 0
+                ):
+                    return float(ttft)
+                return None
+    return None
 
 
 # Only these field names are ever accepted from a tool's self-reported
@@ -5669,6 +5741,7 @@ Do NOT wrap conversational replies in JSON.
                     final_answer,
                     streaming=self.streaming,
                     total_tokens=pre_output_tokens,
+                    ttft_seconds=_query_ttft_seconds(conversation),
                 )
                 break
 

--- a/src/gaia/agents/base/agent.py
+++ b/src/gaia/agents/base/agent.py
@@ -329,7 +329,9 @@ def _sum_conversation_tokens(
                 total_input += _safe_number(stats.get("input_tokens"))
                 total_output += _safe_number(stats.get("output_tokens"))
     for usage in tool_usage_entries or []:
-        total_input += _safe_number(usage.get("prompt_tokens") or usage.get("input_tokens"))
+        total_input += _safe_number(
+            usage.get("prompt_tokens") or usage.get("input_tokens")
+        )
         total_output += _safe_number(
             usage.get("completion_tokens") or usage.get("output_tokens")
         )
@@ -367,7 +369,8 @@ def _extract_tool_usage(tool_result: Any) -> Optional[Dict[str, Any]]:
         if not isinstance(usage, dict):
             return None
         has_real_token_field = any(
-            isinstance(usage.get(f), (int, float)) and not isinstance(usage.get(f), bool)
+            isinstance(usage.get(f), (int, float))
+            and not isinstance(usage.get(f), bool)
             for f in _TOOL_USAGE_TOKEN_FIELDS
         )
         return usage if has_real_token_field else None
@@ -5663,7 +5666,9 @@ Do NOT wrap conversational replies in JSON.
                     conversation, self._tool_reported_usage
                 )
                 self.console.print_final_answer(
-                    final_answer, streaming=self.streaming, total_tokens=pre_output_tokens
+                    final_answer,
+                    streaming=self.streaming,
+                    total_tokens=pre_output_tokens,
                 )
                 break
 

--- a/src/gaia/agents/base/console.py
+++ b/src/gaia/agents/base/console.py
@@ -308,12 +308,20 @@ class OutputHandler(ABC):
     # === Completion Methods (Required) ===
 
     @abstractmethod
-    def print_final_answer(self, answer: str, total_tokens: Optional[int] = None):
+    def print_final_answer(
+        self,
+        answer: str,
+        total_tokens: Optional[int] = None,
+        ttft_seconds: Optional[float] = None,
+    ):
         """Print final answer/result.
 
         total_tokens: real output-token count generated across the run, if
         known (#2899). None means no real count is available — never
         substitute an estimate; the caller omits the stat instead.
+        ttft_seconds: real time-to-first-token for the LLM call that produced
+        this answer, if known (#2899 follow-up). None means no real value is
+        available — never substitute an estimate.
         """
         ...
 
@@ -1529,6 +1537,7 @@ class AgentConsole(TerminalConfirmationMixin, OutputHandler):
         answer: str,
         streaming: bool = True,  # pylint: disable=unused-argument
         total_tokens: Optional[int] = None,  # pylint: disable=unused-argument
+        ttft_seconds: Optional[float] = None,  # pylint: disable=unused-argument
     ) -> None:
         """
         Print the final answer with appropriate styling.
@@ -1537,6 +1546,7 @@ class AgentConsole(TerminalConfirmationMixin, OutputHandler):
             answer: The final answer to display
             streaming: Not used (kept for compatibility)
             total_tokens: Not used here (CLI stats table is out of scope for #2899)
+            ttft_seconds: Not used here (CLI stats table is out of scope for #2899)
         """
         if self.rich_available:
             self.console.print()  # Add newline before
@@ -2487,6 +2497,7 @@ class SilentConsole(TerminalConfirmationMixin, OutputHandler):
         answer: str,
         streaming: bool = True,  # pylint: disable=unused-argument
         total_tokens: Optional[int] = None,  # pylint: disable=unused-argument
+        ttft_seconds: Optional[float] = None,  # pylint: disable=unused-argument
     ) -> None:
         """
         Print the final answer.
@@ -2496,6 +2507,7 @@ class SilentConsole(TerminalConfirmationMixin, OutputHandler):
             answer: The final answer to display
             streaming: Not used (kept for compatibility)
             total_tokens: Not used here (JSON-only mode has its own stats path)
+            ttft_seconds: Not used here (JSON-only mode has its own stats path)
         """
         if self.silence_final_answer:
             return  # Completely silent

--- a/src/gaia/agents/base/console.py
+++ b/src/gaia/agents/base/console.py
@@ -308,8 +308,13 @@ class OutputHandler(ABC):
     # === Completion Methods (Required) ===
 
     @abstractmethod
-    def print_final_answer(self, answer: str):
-        """Print final answer/result."""
+    def print_final_answer(self, answer: str, total_tokens: Optional[int] = None):
+        """Print final answer/result.
+
+        total_tokens: real output-token count generated across the run, if
+        known (#2899). None means no real count is available — never
+        substitute an estimate; the caller omits the stat instead.
+        """
         ...
 
     @abstractmethod
@@ -1520,7 +1525,10 @@ class AgentConsole(TerminalConfirmationMixin, OutputHandler):
             print(f"\n⚠️ WARNING: {message}\n")
 
     def print_final_answer(
-        self, answer: str, streaming: bool = True  # pylint: disable=unused-argument
+        self,
+        answer: str,
+        streaming: bool = True,  # pylint: disable=unused-argument
+        total_tokens: Optional[int] = None,  # pylint: disable=unused-argument
     ) -> None:
         """
         Print the final answer with appropriate styling.
@@ -1528,6 +1536,7 @@ class AgentConsole(TerminalConfirmationMixin, OutputHandler):
         Args:
             answer: The final answer to display
             streaming: Not used (kept for compatibility)
+            total_tokens: Not used here (CLI stats table is out of scope for #2899)
         """
         if self.rich_available:
             self.console.print()  # Add newline before
@@ -2474,7 +2483,10 @@ class SilentConsole(TerminalConfirmationMixin, OutputHandler):
 
     # Implementation of OutputHandler abstract methods - all no-ops
     def print_final_answer(
-        self, answer: str, streaming: bool = True  # pylint: disable=unused-argument
+        self,
+        answer: str,
+        streaming: bool = True,  # pylint: disable=unused-argument
+        total_tokens: Optional[int] = None,  # pylint: disable=unused-argument
     ) -> None:
         """
         Print the final answer.
@@ -2483,6 +2495,7 @@ class SilentConsole(TerminalConfirmationMixin, OutputHandler):
         Args:
             answer: The final answer to display
             streaming: Not used (kept for compatibility)
+            total_tokens: Not used here (JSON-only mode has its own stats path)
         """
         if self.silence_final_answer:
             return  # Completely silent

--- a/src/gaia/api/sse_handler.py
+++ b/src/gaia/api/sse_handler.py
@@ -216,13 +216,14 @@ class SSEOutputHandler(OutputHandler):
         answer: str,
         streaming: bool = True,
         total_tokens: Optional[int] = None,
+        ttft_seconds: Optional[float] = None,
     ):  # pylint: disable=unused-argument
         """Print final answer/result.
 
-        total_tokens is accepted for interface parity with the base
-        OutputHandler contract (#2899) but not emitted here — this is the API
-        server's SSE handler, a different consumer from the Agent-UI/TUI
-        wire contract this issue's token plumbing targets.
+        total_tokens / ttft_seconds are accepted for interface parity with
+        the base OutputHandler contract (#2899, #2899 follow-up) but not
+        emitted here — this is the API server's SSE handler, a different
+        consumer from the Agent-UI/TUI wire contract this plumbing targets.
         """
         self._add_event("final_answer", {"answer": answer})
 

--- a/src/gaia/api/sse_handler.py
+++ b/src/gaia/api/sse_handler.py
@@ -10,7 +10,7 @@ import json
 import logging
 import time
 from collections import deque
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
 
 from gaia.agents.base.console import (
     AUTO_APPROVE_ENV_VAR,
@@ -212,9 +212,18 @@ class SSEOutputHandler(OutputHandler):
     # === Completion Methods (Required) ===
 
     def print_final_answer(
-        self, answer: str, streaming: bool = True
+        self,
+        answer: str,
+        streaming: bool = True,
+        total_tokens: Optional[int] = None,
     ):  # pylint: disable=unused-argument
-        """Print final answer/result."""
+        """Print final answer/result.
+
+        total_tokens is accepted for interface parity with the base
+        OutputHandler contract (#2899) but not emitted here — this is the API
+        server's SSE handler, a different consumer from the Agent-UI/TUI
+        wire contract this issue's token plumbing targets.
+        """
         self._add_event("final_answer", {"answer": answer})
 
     def print_repeated_tool_warning(self):

--- a/src/gaia/ui/sse_handler.py
+++ b/src/gaia/ui/sse_handler.py
@@ -544,8 +544,11 @@ class SSEOutputHandler(OutputHandler):
     # === Completion Methods ===
 
     def print_final_answer(
-        self, answer: str, streaming: bool = True
-    ):  # pylint: disable=unused-argument
+        self,
+        answer: str,
+        streaming: bool = True,  # pylint: disable=unused-argument
+        total_tokens: Optional[int] = None,
+    ):
         if answer:
             answer = _THINK_TAG_SUB_RE.sub("", answer)
             # Extract answer text from {"thought":..., "answer":...} JSON before
@@ -559,15 +562,18 @@ class SSEOutputHandler(OutputHandler):
             answer = _TOOL_CALL_JSON_SUB_RE.sub("", answer)
             answer = _THOUGHT_JSON_SUB_RE.sub("", answer)
             answer = answer.strip()
-        self._emit(
-            {
-                "type": "answer",
-                "content": _fix_double_escaped(answer) if answer else answer,
-                "elapsed": self._elapsed(),
-                "steps": self._step_count,
-                "tools_used": self._tool_count,
-            }
-        )
+        event: Dict[str, Any] = {
+            "type": "answer",
+            "content": _fix_double_escaped(answer) if answer else answer,
+            "elapsed": self._elapsed(),
+            "steps": self._step_count,
+            "tools_used": self._tool_count,
+        }
+        # Omit entirely when no real count exists — never emit "tokens": 0 as
+        # if it were a measured zero (#2899, fail-loud: no silent fake data).
+        if total_tokens is not None:
+            event["tokens"] = total_tokens
+        self._emit(event)
 
     def print_repeated_tool_warning(self):
         self._emit(

--- a/src/gaia/ui/sse_handler.py
+++ b/src/gaia/ui/sse_handler.py
@@ -571,15 +571,11 @@ class SSEOutputHandler(OutputHandler):
             "steps": self._step_count,
             "tools_used": self._tool_count,
         }
-        # Omit entirely when no real count exists — never emit "tokens": 0 as
-        # if it were a measured zero (#2899, fail-loud: no silent fake data).
+        # Omit entirely when no real count exists — never emit a fake zero.
         if total_tokens is not None:
             event["tokens"] = total_tokens
-        # Same omit-don't-fake rule for ttft (#2899 follow-up): a non-streaming
-        # turn (every native tool-calling model, every step) never fires a
-        # `chunk` event to anchor a client-side ttft, so this is the only value
-        # that reaches the wire at all — real, from Lemonade's own generation
-        # timing (see agent.py's _query_ttft_seconds), never a guess.
+        # Same omit-don't-fake rule for ttft: real value from Lemonade's own
+        # generation timing, or nothing.
         if (
             ttft_seconds is not None
             and math.isfinite(ttft_seconds)

--- a/src/gaia/ui/sse_handler.py
+++ b/src/gaia/ui/sse_handler.py
@@ -572,7 +572,12 @@ class SSEOutputHandler(OutputHandler):
             "tools_used": self._tool_count,
         }
         # Omit entirely when no real count exists — never emit a fake zero.
-        if total_tokens is not None:
+        # `_sum_conversation_tokens` returns 0 both when a real turn generated
+        # zero output tokens (never happens for a completed answer) and when
+        # no per-step stats were collected at all (the common "no real count"
+        # case) — it can't tell the two apart, so treat <= 0 as unavailable,
+        # same as the ttft guard below.
+        if total_tokens is not None and total_tokens > 0:
             event["tokens"] = total_tokens
         # Same omit-don't-fake rule for ttft: real value from Lemonade's own
         # generation timing, or nothing.

--- a/src/gaia/ui/sse_handler.py
+++ b/src/gaia/ui/sse_handler.py
@@ -10,6 +10,7 @@ to JSON events that the streaming endpoint sends to the frontend.
 
 import json
 import logging
+import math
 import queue
 import re
 import socket
@@ -548,6 +549,7 @@ class SSEOutputHandler(OutputHandler):
         answer: str,
         streaming: bool = True,  # pylint: disable=unused-argument
         total_tokens: Optional[int] = None,
+        ttft_seconds: Optional[float] = None,
     ):
         if answer:
             answer = _THINK_TAG_SUB_RE.sub("", answer)
@@ -573,6 +575,17 @@ class SSEOutputHandler(OutputHandler):
         # if it were a measured zero (#2899, fail-loud: no silent fake data).
         if total_tokens is not None:
             event["tokens"] = total_tokens
+        # Same omit-don't-fake rule for ttft (#2899 follow-up): a non-streaming
+        # turn (every native tool-calling model, every step) never fires a
+        # `chunk` event to anchor a client-side ttft, so this is the only value
+        # that reaches the wire at all — real, from Lemonade's own generation
+        # timing (see agent.py's _query_ttft_seconds), never a guess.
+        if (
+            ttft_seconds is not None
+            and math.isfinite(ttft_seconds)
+            and ttft_seconds > 0
+        ):
+            event["ttft"] = round(ttft_seconds, 3)
         self._emit(event)
 
     def print_repeated_tool_warning(self):

--- a/tests/unit/chat/ui/test_sse_handler.py
+++ b/tests/unit/chat/ui/test_sse_handler.py
@@ -786,6 +786,37 @@ class TestPrintFinalAnswer:
         events = _drain(handler)
         assert events[0]["elapsed"] == 0.0
 
+    # ── ttft_seconds (#2899 follow-up) ──────────────────────────────────
+    #
+    # Same omit-don't-fake contract already established for total_tokens: a
+    # real positive value rides the wire as "ttft"; anything else (None, 0,
+    # a negative) is left off entirely rather than shown as a fake 0.0s.
+
+    def test_positive_ttft_is_emitted(self, handler):
+        handler.print_final_answer("answer", ttft_seconds=9.4321)
+        events = _drain(handler)
+        assert events[0]["ttft"] == 9.432  # rounded to 3 decimals
+
+    def test_ttft_omitted_when_none(self, handler):
+        handler.print_final_answer("answer", ttft_seconds=None)
+        events = _drain(handler)
+        assert "ttft" not in events[0]
+
+    def test_ttft_omitted_when_zero(self, handler):
+        handler.print_final_answer("answer", ttft_seconds=0.0)
+        events = _drain(handler)
+        assert "ttft" not in events[0]
+
+    def test_ttft_omitted_when_negative(self, handler):
+        handler.print_final_answer("answer", ttft_seconds=-1.0)
+        events = _drain(handler)
+        assert "ttft" not in events[0]
+
+    def test_ttft_omitted_by_default(self, handler):
+        handler.print_final_answer("answer")
+        events = _drain(handler)
+        assert "ttft" not in events[0]
+
 
 # ===========================================================================
 # SSEOutputHandler.print_repeated_tool_warning

--- a/tests/unit/chat/ui/test_sse_handler.py
+++ b/tests/unit/chat/ui/test_sse_handler.py
@@ -786,9 +786,42 @@ class TestPrintFinalAnswer:
         events = _drain(handler)
         assert events[0]["elapsed"] == 0.0
 
+    # ── total_tokens (#2899, #2911 review) ──────────────────────────────
+    #
+    # `_sum_conversation_tokens` (agent.py) always returns an int, 0 when no
+    # per-step stats were collected — it can't tell "really generated zero
+    # tokens" from "no real accounting happened". A real positive count rides
+    # the wire as "tokens"; anything <= 0 is left off entirely rather than
+    # shown as a fake 0.
+
+    def test_positive_tokens_is_emitted(self, handler):
+        handler.print_final_answer("answer", total_tokens=42)
+        events = _drain(handler)
+        assert events[0]["tokens"] == 42
+
+    def test_tokens_omitted_when_zero(self, handler):
+        handler.print_final_answer("answer", total_tokens=0)
+        events = _drain(handler)
+        assert "tokens" not in events[0]
+
+    def test_tokens_omitted_when_none(self, handler):
+        handler.print_final_answer("answer", total_tokens=None)
+        events = _drain(handler)
+        assert "tokens" not in events[0]
+
+    def test_tokens_omitted_when_negative(self, handler):
+        handler.print_final_answer("answer", total_tokens=-1)
+        events = _drain(handler)
+        assert "tokens" not in events[0]
+
+    def test_tokens_omitted_by_default(self, handler):
+        handler.print_final_answer("answer")
+        events = _drain(handler)
+        assert "tokens" not in events[0]
+
     # ── ttft_seconds (#2899 follow-up) ──────────────────────────────────
     #
-    # Same omit-don't-fake contract already established for total_tokens: a
+    # Same omit-don't-fake contract established above for total_tokens: a
     # real positive value rides the wire as "ttft"; anything else (None, 0,
     # a negative) is left off entirely rather than shown as a fake 0.0s.
 

--- a/tests/unit/test_agent_token_usage.py
+++ b/tests/unit/test_agent_token_usage.py
@@ -1,0 +1,263 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+"""
+Tests for real per-turn token accounting (#2899).
+
+The TUI's stats line used to show a client-side `len(content)/4` guess of the
+final answer's length, not the tokens the model actually generated. The real
+fix crosses three layers; this file covers the Python side:
+
+1. `_sum_conversation_tokens` / `_safe_number` — pure aggregation, defensive
+   against malformed per-step stats.
+2. `_extract_tool_usage` — a generic, agent-agnostic convention letting a tool
+   that makes its own internal LLM calls (bypassing the normal per-step
+   accounting) report usage back on its own return payload. Deliberately
+   narrow (requires a recognized numeric token field) so an unrelated tool's
+   own "usage" key (rate-limit/quota/disk usage) is never misread as tokens.
+3. `_fold_tool_usage` / `Agent._execute_tool` wiring — the single choke point
+   every tool call goes through, verified end-to-end with a real Agent
+   instance and a real (non-mocked) `_execute_tool` call.
+"""
+
+from unittest.mock import patch
+
+import pytest
+
+from gaia.agents.base.agent import (
+    Agent,
+    _extract_tool_usage,
+    _safe_number,
+    _sum_conversation_tokens,
+)
+from gaia.agents.base.tools import _TOOL_REGISTRY, tool
+
+
+@pytest.fixture(autouse=True)
+def _clean_registry():
+    """Save/restore the global tool registry around each test."""
+    saved = dict(_TOOL_REGISTRY)
+    yield
+    _TOOL_REGISTRY.clear()
+    _TOOL_REGISTRY.update(saved)
+
+
+class _TokenUsageAgent(Agent):
+    """Minimal concrete Agent that pulls tools from the global registry."""
+
+    def _register_tools(self):  # tools are registered per-test via @tool
+        pass
+
+
+def _make_agent(**kwargs) -> _TokenUsageAgent:
+    """Construct a real Agent without touching Lemonade or the network."""
+    with patch("gaia.agents.base.agent.AgentSDK"):
+        agent = _TokenUsageAgent(skip_lemonade=True, silent_mode=True, **kwargs)
+    # A bare MagicMock is truthy, which would make _fold_tool_usage's
+    # "does self.chat look like it just made a call" heuristic fire on every
+    # test. Tests that care about that heuristic override this explicitly.
+    agent.chat.get_stats.return_value = None
+    return agent
+
+
+# ─────────────────────────── _safe_number ────────────────────────────────
+
+
+class TestSafeNumber:
+    @pytest.mark.parametrize(
+        "value,expected",
+        [
+            (42, 42),
+            (0, 0),
+            (3.7, 3),
+            (None, 0),
+            ("42", 0),  # untrusted string input never raises, never counts
+            ({"nested": 1}, 0),
+            ([1, 2], 0),
+            (-5, 0),  # negative is untrusted, not a valid token count
+            (True, 0),  # bool is an int subclass in Python — must not count as 1
+        ],
+    )
+    def test_coerces_or_zeroes(self, value, expected):
+        assert _safe_number(value) == expected
+
+
+# ─────────────────────────── _sum_conversation_tokens ─────────────────────
+
+
+class TestSumConversationTokens:
+    def test_sums_per_step_stats(self):
+        conversation = [
+            {"role": "user", "content": "hi"},
+            {
+                "role": "system",
+                "content": {
+                    "type": "stats",
+                    "step": 1,
+                    "performance_stats": {"input_tokens": 10, "output_tokens": 5},
+                },
+            },
+            {
+                "role": "system",
+                "content": {
+                    "type": "stats",
+                    "step": 2,
+                    "performance_stats": {"input_tokens": 12, "output_tokens": 8},
+                },
+            },
+        ]
+        total_in, total_out = _sum_conversation_tokens(conversation)
+        assert (total_in, total_out) == (22, 13)
+
+    def test_ignores_non_stats_system_entries(self):
+        conversation = [
+            {"role": "system", "content": "some other system message"},
+            {"role": "system", "content": {"type": "not_stats"}},
+        ]
+        assert _sum_conversation_tokens(conversation) == (0, 0)
+
+    def test_malformed_stats_do_not_raise(self):
+        conversation = [
+            {
+                "role": "system",
+                "content": {
+                    "type": "stats",
+                    "performance_stats": {"input_tokens": "bad", "output_tokens": None},
+                },
+            },
+        ]
+        assert _sum_conversation_tokens(conversation) == (0, 0)
+
+    def test_folds_tool_usage_entries(self):
+        tool_usage = [
+            {"prompt_tokens": 5, "completion_tokens": 20},
+            {"input_tokens": 3, "output_tokens": 7},
+        ]
+        total_in, total_out = _sum_conversation_tokens([], tool_usage)
+        assert (total_in, total_out) == (8, 27)
+
+    def test_conversation_and_tool_usage_both_fold_in(self):
+        conversation = [
+            {
+                "role": "system",
+                "content": {
+                    "type": "stats",
+                    "performance_stats": {"input_tokens": 10, "output_tokens": 5},
+                },
+            },
+        ]
+        tool_usage = [{"prompt_tokens": 5, "completion_tokens": 20}]
+        total_in, total_out = _sum_conversation_tokens(conversation, tool_usage)
+        assert (total_in, total_out) == (15, 25)
+
+
+# ─────────────────────────── _extract_tool_usage ──────────────────────────
+
+
+class TestExtractToolUsage:
+    def test_extracts_from_dict_payload(self):
+        result = {"results": [], "usage": {"prompt_tokens": 5, "completion_tokens": 20}}
+        assert _extract_tool_usage(result) == {
+            "prompt_tokens": 5,
+            "completion_tokens": 20,
+        }
+
+    def test_extracts_from_json_string_payload(self):
+        import json
+
+        result = json.dumps({"ok": True, "usage": {"completion_tokens": 20}})
+        assert _extract_tool_usage(result) == {"completion_tokens": 20}
+
+    def test_no_usage_key_yields_none(self):
+        assert _extract_tool_usage({"results": []}) is None
+
+    def test_non_dict_payload_yields_none(self):
+        assert _extract_tool_usage(["not", "a", "dict"]) is None
+        assert _extract_tool_usage(None) is None
+        assert _extract_tool_usage(42) is None
+
+    def test_malformed_json_string_yields_none_not_raise(self):
+        assert _extract_tool_usage("{not valid json") is None
+
+    def test_usage_key_without_recognized_token_field_is_rejected(self):
+        # An unrelated tool's own "usage" key (rate-limit/quota/disk usage,
+        # not LLM tokens) must never be misread as token accounting.
+        result = {"usage": {"remaining_quota": 100, "disk_usage_mb": 42}}
+        assert _extract_tool_usage(result) is None
+
+    def test_non_numeric_token_field_is_rejected(self):
+        result = {"usage": {"completion_tokens": "not-a-number"}}
+        assert _extract_tool_usage(result) is None
+
+    def test_bool_token_field_is_rejected(self):
+        # bool is an int subclass in Python; a stray True/False under a
+        # recognized field name must not be treated as a real count.
+        result = {"usage": {"completion_tokens": True}}
+        assert _extract_tool_usage(result) is None
+
+
+# ─────────────────────────── _execute_tool -> _fold_tool_usage wiring ─────
+
+
+class TestToolUsageRollup:
+    def test_tool_reported_usage_is_folded_via_execute_tool(self):
+        """AC2(c): a tool that makes its own internal LLM calls (bypassing the
+        normal per-step accounting, e.g. email triage's per-message
+        classification fan-out) and reports usage on its own return payload
+        gets that usage folded into the turn's running total."""
+
+        @tool
+        def triage_tool() -> dict:
+            """Simulates a triage-style tool with its own internal LLM usage."""
+            return {
+                "results": [],
+                "usage": {"prompt_tokens": 5, "completion_tokens": 20},
+            }
+
+        agent = _make_agent()
+        agent._tool_reported_usage = []  # simulate the per-turn reset
+
+        result = agent._execute_tool("triage_tool", {})
+
+        assert result["usage"] == {"prompt_tokens": 5, "completion_tokens": 20}
+        assert agent._tool_reported_usage == [
+            {"prompt_tokens": 5, "completion_tokens": 20}
+        ]
+        # And it reaches the real total through the same helper the loop uses.
+        _, total_output = _sum_conversation_tokens([], agent._tool_reported_usage)
+        assert total_output == 20
+
+    def test_tool_without_usage_does_not_pollute_the_total(self):
+        @tool
+        def plain_tool(value: str) -> dict:
+            """A normal tool with no LLM usage to report."""
+            return {"echo": value}
+
+        agent = _make_agent()
+        agent._tool_reported_usage = []
+
+        agent._execute_tool("plain_tool", {"value": "hi"})
+
+        assert agent._tool_reported_usage == []
+
+    def test_usage_accumulates_across_multiple_tool_calls_in_one_turn(self):
+        @tool
+        def classify_batch(n: int) -> dict:
+            """Each call reports its own slice of usage, like a fan-out loop."""
+            return {"usage": {"completion_tokens": n * 10}}
+
+        agent = _make_agent()
+        agent._tool_reported_usage = []
+
+        agent._execute_tool("classify_batch", {"n": 1})
+        agent._execute_tool("classify_batch", {"n": 2})
+        agent._execute_tool("classify_batch", {"n": 3})
+
+        _, total_output = _sum_conversation_tokens([], agent._tool_reported_usage)
+        assert total_output == 60  # (1 + 2 + 3) * 10
+
+    def test_new_agent_instance_starts_with_no_stale_usage(self):
+        """The __init__-level default (#2899) must not leak across instances
+        or survive without the per-turn reset that _process_query_impl does."""
+        agent = _make_agent()
+        assert agent._tool_reported_usage == []

--- a/tests/unit/test_agent_token_usage.py
+++ b/tests/unit/test_agent_token_usage.py
@@ -27,6 +27,7 @@ import pytest
 from gaia.agents.base.agent import (
     Agent,
     _extract_tool_usage,
+    _query_ttft_seconds,
     _safe_number,
     _sum_conversation_tokens,
 )
@@ -149,6 +150,160 @@ class TestSumConversationTokens:
         tool_usage = [{"prompt_tokens": 5, "completion_tokens": 20}]
         total_in, total_out = _sum_conversation_tokens(conversation, tool_usage)
         assert (total_in, total_out) == (15, 25)
+
+
+# ─────────────────────── _query_ttft_seconds (#2899 follow-up) ────────────
+#
+# A live run against a real mailbox showed the token half of #2899 working
+# but ttft never rendering at all on any of 4 real queries — not a wrong
+# value, an absent one. Root cause: EmailAgentConfig.streaming defaults False
+# and nothing overrides it on the daemon/TUI path, so the agent never calls
+# send_messages_stream() and no `chunk` event ever fires to anchor a
+# client-side ttft. Even flipping that default would not reliably fix it:
+# native tool-calling models attach their full tool schema on every step, and
+# Lemonade forces a request non-streaming whenever `tools` is attached
+# (lemonade.py's `effective_stream = stream and not (tool_capable and
+# tools)`) — so the non-streaming path is not an edge case for this agent,
+# it is the only path. This reads the one real per-request timing value
+# Lemonade already reports (via /stats, already polled every step for the
+# token count) off the same per-step 'stats' conversation entries.
+#
+# The FIRST step's value is read, not the last: a last-step reading times
+# only the final LLM call, dropping every earlier step's tool-decision
+# latency — on the #2899 baseline's own warm-query shape (~8s tool-call
+# decision, more steps, ~69s total) that reproduces the exact "implausibly
+# small ttft on a minute-long query" defect #2899 opened to fix, just with a
+# different number (see review discussion on this PR). Step 1's own
+# time_to_first_token is the closest available proxy for "query submit to
+# first inference token" because nothing but cheap in-process work (message
+# assembly, no I/O) happens between process_query's start_time and the first
+# LLM call.
+class TestQueryTTFTSeconds:
+    def test_reads_ttft_off_the_first_stats_entry(self):
+        conversation = [
+            {
+                "role": "system",
+                "content": {
+                    "type": "stats",
+                    "step": 1,
+                    "performance_stats": {"time_to_first_token": 8.2},
+                },
+            },
+            {
+                "role": "system",
+                "content": {
+                    "type": "stats",
+                    "step": 2,
+                    "performance_stats": {"time_to_first_token": 1.5},
+                },
+            },
+        ]
+        # Step 1 — the first LLM call of the turn — not the final step that
+        # happened to produce the visible answer, and not an average/sum.
+        assert _query_ttft_seconds(conversation) == 8.2
+
+    def test_no_stats_entries_returns_none(self):
+        assert _query_ttft_seconds([]) is None
+        assert _query_ttft_seconds([{"role": "user", "content": "hi"}]) is None
+
+    def test_missing_field_on_first_step_returns_none_not_a_later_steps_value(self):
+        # Step 1 reported stats but no ttft; step 2 has one. Falling through
+        # to step 2 would mislabel a later (typically much smaller, warmer)
+        # request's latency as "time to first token from submit" — the same
+        # misrepresentation this function exists to avoid, just shifted by
+        # one step. Must omit, not substitute.
+        conversation = [
+            {
+                "role": "system",
+                "content": {
+                    "type": "stats",
+                    "step": 1,
+                    "performance_stats": {"input_tokens": 10, "output_tokens": 5},
+                },
+            },
+            {
+                "role": "system",
+                "content": {
+                    "type": "stats",
+                    "step": 2,
+                    "performance_stats": {"time_to_first_token": 1.5},
+                },
+            },
+        ]
+        assert _query_ttft_seconds(conversation) is None
+
+    def test_step_1_entry_entirely_missing_returns_none_not_step_2s_value(self):
+        # The real (not hypothetical) failure mode caught in review: a failed
+        # /stats poll returns {} (falsy), so the caller's `if perf_stats:`
+        # skips appending a stats entry for step 1 at all — the EARLIEST
+        # entry actually present in conversation is step 2's. Trusting
+        # "first entry found" instead of the entry's own step number would
+        # silently misattribute step 2's (typically much smaller, warmer)
+        # latency as the turn's ttft — reproducing the exact bug this
+        # function exists to prevent, one step later.
+        conversation = [
+            {
+                "role": "system",
+                "content": {
+                    "type": "stats",
+                    "step": 2,
+                    "performance_stats": {"time_to_first_token": 1.5},
+                },
+            },
+        ]
+        assert _query_ttft_seconds(conversation) is None
+
+    def test_zero_or_negative_reported_value_is_treated_as_unavailable(self):
+        conversation = [
+            {
+                "role": "system",
+                "content": {
+                    "type": "stats",
+                    "step": 1,
+                    "performance_stats": {"time_to_first_token": 0},
+                },
+            },
+        ]
+        assert _query_ttft_seconds(conversation) is None
+
+    def test_non_finite_value_is_treated_as_unavailable(self):
+        conversation = [
+            {
+                "role": "system",
+                "content": {
+                    "type": "stats",
+                    "step": 1,
+                    "performance_stats": {"time_to_first_token": float("inf")},
+                },
+            },
+        ]
+        assert _query_ttft_seconds(conversation) is None
+
+    def test_non_dict_performance_stats_does_not_raise(self):
+        conversation = [
+            {
+                "role": "system",
+                "content": {
+                    "type": "stats",
+                    "step": 1,
+                    "performance_stats": "not a dict",
+                },
+            },
+        ]
+        assert _query_ttft_seconds(conversation) is None
+
+    def test_malformed_value_does_not_raise(self):
+        conversation = [
+            {
+                "role": "system",
+                "content": {
+                    "type": "stats",
+                    "step": 1,
+                    "performance_stats": {"time_to_first_token": "bad"},
+                },
+            },
+        ]
+        assert _query_ttft_seconds(conversation) is None
 
 
 # ─────────────────────────── _extract_tool_usage ──────────────────────────

--- a/tests/unit/test_agent_token_usage.py
+++ b/tests/unit/test_agent_token_usage.py
@@ -54,10 +54,6 @@ def _make_agent(**kwargs) -> _TokenUsageAgent:
     """Construct a real Agent without touching Lemonade or the network."""
     with patch("gaia.agents.base.agent.AgentSDK"):
         agent = _TokenUsageAgent(skip_lemonade=True, silent_mode=True, **kwargs)
-    # A bare MagicMock is truthy, which would make _fold_tool_usage's
-    # "does self.chat look like it just made a call" heuristic fire on every
-    # test. Tests that care about that heuristic override this explicitly.
-    agent.chat.get_stats.return_value = None
     return agent
 
 
@@ -154,30 +150,9 @@ class TestSumConversationTokens:
 
 # ─────────────────────── _query_ttft_seconds (#2899 follow-up) ────────────
 #
-# A live run against a real mailbox showed the token half of #2899 working
-# but ttft never rendering at all on any of 4 real queries — not a wrong
-# value, an absent one. Root cause: EmailAgentConfig.streaming defaults False
-# and nothing overrides it on the daemon/TUI path, so the agent never calls
-# send_messages_stream() and no `chunk` event ever fires to anchor a
-# client-side ttft. Even flipping that default would not reliably fix it:
-# native tool-calling models attach their full tool schema on every step, and
-# Lemonade forces a request non-streaming whenever `tools` is attached
-# (lemonade.py's `effective_stream = stream and not (tool_capable and
-# tools)`) — so the non-streaming path is not an edge case for this agent,
-# it is the only path. This reads the one real per-request timing value
-# Lemonade already reports (via /stats, already polled every step for the
-# token count) off the same per-step 'stats' conversation entries.
-#
-# The FIRST step's value is read, not the last: a last-step reading times
-# only the final LLM call, dropping every earlier step's tool-decision
-# latency — on the #2899 baseline's own warm-query shape (~8s tool-call
-# decision, more steps, ~69s total) that reproduces the exact "implausibly
-# small ttft on a minute-long query" defect #2899 opened to fix, just with a
-# different number (see review discussion on this PR). Step 1's own
-# time_to_first_token is the closest available proxy for "query submit to
-# first inference token" because nothing but cheap in-process work (message
-# assembly, no I/O) happens between process_query's start_time and the first
-# LLM call.
+# Reads the real per-request ttft Lemonade's /stats already reports off the
+# turn's FIRST step, not the last — a last-step reading drops every earlier
+# step's tool-decision latency.
 class TestQueryTTFTSeconds:
     def test_reads_ttft_off_the_first_stats_entry(self):
         conversation = [
@@ -207,11 +182,7 @@ class TestQueryTTFTSeconds:
         assert _query_ttft_seconds([{"role": "user", "content": "hi"}]) is None
 
     def test_missing_field_on_first_step_returns_none_not_a_later_steps_value(self):
-        # Step 1 reported stats but no ttft; step 2 has one. Falling through
-        # to step 2 would mislabel a later (typically much smaller, warmer)
-        # request's latency as "time to first token from submit" — the same
-        # misrepresentation this function exists to avoid, just shifted by
-        # one step. Must omit, not substitute.
+        # Step 1 has no ttft; step 2 does. Must omit, not fall through to step 2.
         conversation = [
             {
                 "role": "system",
@@ -233,14 +204,9 @@ class TestQueryTTFTSeconds:
         assert _query_ttft_seconds(conversation) is None
 
     def test_step_1_entry_entirely_missing_returns_none_not_step_2s_value(self):
-        # The real (not hypothetical) failure mode caught in review: a failed
-        # /stats poll returns {} (falsy), so the caller's `if perf_stats:`
-        # skips appending a stats entry for step 1 at all — the EARLIEST
-        # entry actually present in conversation is step 2's. Trusting
-        # "first entry found" instead of the entry's own step number would
-        # silently misattribute step 2's (typically much smaller, warmer)
-        # latency as the turn's ttft — reproducing the exact bug this
-        # function exists to prevent, one step later.
+        # A failed /stats poll can skip step 1's entry entirely, leaving
+        # step 2's as the earliest present — must check the step number,
+        # not just take the first entry found.
         conversation = [
             {
                 "role": "system",

--- a/tui/internal/event/canonical.go
+++ b/tui/internal/event/canonical.go
@@ -106,10 +106,13 @@ type CanonicalFinalEvent struct {
 
 // CanonicalUsage is the shape the TUI reads out of CanonicalFinalEvent.Usage.
 // Fields absent from the payload stay zero and are simply not displayed.
+// Tokens is the real generated-token count (#2899) — the TUI no longer
+// guesses from the answer string's character length.
 type CanonicalUsage struct {
 	Steps     int     `json:"steps"`
 	ToolsUsed int     `json:"tools_used"`
 	Elapsed   float64 `json:"elapsed"`
+	Tokens    int     `json:"tokens"`
 }
 
 // CanonicalErrorEvent — terminal failure. Detail is actionable and surfaced

--- a/tui/internal/event/canonical.go
+++ b/tui/internal/event/canonical.go
@@ -97,7 +97,7 @@ type CanonicalInputOption struct {
 }
 
 // CanonicalFinalEvent — terminal success. Usage is an optional
-// {steps?, tools_used?, elapsed?, tokens?} object.
+// {steps?, tools_used?, elapsed?, tokens?, ttft?} object.
 type CanonicalFinalEvent struct {
 	Type   string          `json:"type"`
 	Answer string          `json:"answer"`
@@ -108,11 +108,24 @@ type CanonicalFinalEvent struct {
 // Fields absent from the payload stay zero and are simply not displayed.
 // Tokens is the real generated-token count (#2899) — the TUI no longer
 // guesses from the answer string's character length.
+// TTFT is the turn's FIRST LLM call's own measured time-to-first-token, in
+// seconds (#2899 follow-up) — the fallback the client uses when no
+// CanonicalTokenEvent ever streamed this turn (every native tool-calling
+// model forces every step non-streaming, so that is the common case, not an
+// edge case). Deliberately the first step, not the last that happened to
+// produce the visible answer: nothing but cheap in-process work happens
+// between query submit and the first LLM call, so it is the closest
+// available proxy for "submit to first inference token" — a last-step
+// reading would silently drop every earlier step's tool-decision latency.
+// Real, server-measured latency, not a client-side approximation; see
+// ChatModel.handleCanonicalEvent's CanonicalFinalEvent case for how it
+// combines with a client-observed ttft.
 type CanonicalUsage struct {
 	Steps     int     `json:"steps"`
 	ToolsUsed int     `json:"tools_used"`
 	Elapsed   float64 `json:"elapsed"`
 	Tokens    int     `json:"tokens"`
+	TTFT      float64 `json:"ttft"`
 }
 
 // CanonicalErrorEvent — terminal failure. Detail is actionable and surfaced

--- a/tui/internal/event/canonical.go
+++ b/tui/internal/event/canonical.go
@@ -106,20 +106,9 @@ type CanonicalFinalEvent struct {
 
 // CanonicalUsage is the shape the TUI reads out of CanonicalFinalEvent.Usage.
 // Fields absent from the payload stay zero and are simply not displayed.
-// Tokens is the real generated-token count (#2899) — the TUI no longer
-// guesses from the answer string's character length.
-// TTFT is the turn's FIRST LLM call's own measured time-to-first-token, in
-// seconds (#2899 follow-up) — the fallback the client uses when no
-// CanonicalTokenEvent ever streamed this turn (every native tool-calling
-// model forces every step non-streaming, so that is the common case, not an
-// edge case). Deliberately the first step, not the last that happened to
-// produce the visible answer: nothing but cheap in-process work happens
-// between query submit and the first LLM call, so it is the closest
-// available proxy for "submit to first inference token" — a last-step
-// reading would silently drop every earlier step's tool-decision latency.
-// Real, server-measured latency, not a client-side approximation; see
-// ChatModel.handleCanonicalEvent's CanonicalFinalEvent case for how it
-// combines with a client-observed ttft.
+// Tokens is the real generated-token count. TTFT is the turn's first LLM
+// call's own measured time-to-first-token — the server-measured fallback
+// used when no token ever streamed this turn.
 type CanonicalUsage struct {
 	Steps     int     `json:"steps"`
 	ToolsUsed int     `json:"tools_used"`

--- a/tui/internal/event/canonical_parser_test.go
+++ b/tui/internal/event/canonical_parser_test.go
@@ -88,7 +88,7 @@ func TestParseCanonicalNeedsConfirmation(t *testing.T) {
 }
 
 func TestParseCanonicalFinalWithUsage(t *testing.T) {
-	e := ParseCanonicalEvent([]byte(`{"type":"final","answer":"3 urgent emails","usage":{"steps":4,"tools_used":2,"elapsed":8.5}}`))
+	e := ParseCanonicalEvent([]byte(`{"type":"final","answer":"3 urgent emails","usage":{"steps":4,"tools_used":2,"elapsed":8.5,"ttft":1.2}}`))
 	f, ok := e.(CanonicalFinalEvent)
 	if !ok {
 		t.Fatalf("expected CanonicalFinalEvent, got %T", e)
@@ -97,7 +97,7 @@ func TestParseCanonicalFinalWithUsage(t *testing.T) {
 		t.Errorf("answer = %q", f.Answer)
 	}
 	usage := CanonicalUsageOf(f)
-	if usage.Steps != 4 || usage.ToolsUsed != 2 || usage.Elapsed != 8.5 {
+	if usage.Steps != 4 || usage.ToolsUsed != 2 || usage.Elapsed != 8.5 || usage.TTFT != 1.2 {
 		t.Errorf("unexpected usage: %+v", usage)
 	}
 	if CanonicalTerminalType(f) != CanonicalTypeFinal {

--- a/tui/internal/ui/chat/canonical.go
+++ b/tui/internal/ui/chat/canonical.go
@@ -147,6 +147,7 @@ func (m ChatModel) handleCanonicalEvent(evt interface{}) (ChatModel, tea.Cmd, bo
 			TTFT:      m.ttft,
 			Steps:     usage.Steps,
 			ToolsUsed: usage.ToolsUsed,
+			Tokens:    usage.Tokens,
 		})
 		// Drain here, not on doneMsg: streaming flips false in THIS handler, and doneMsg fires later, after a second query could already be in flight.
 		m.drainPendingPreScan()

--- a/tui/internal/ui/chat/canonical.go
+++ b/tui/internal/ui/chat/canonical.go
@@ -129,6 +129,21 @@ func (m ChatModel) handleCanonicalEvent(evt interface{}) (ChatModel, tea.Cmd, bo
 
 	case event.CanonicalFinalEvent:
 		usage := event.CanonicalUsageOf(e)
+		// Server-reported ttft fallback (#2899 follow-up): native tool-calling
+		// models attach their full tool schema on every step, and Lemonade
+		// forces a request non-streaming whenever `tools` is attached — so no
+		// CanonicalTokenEvent ever arrives to anchor m.ttft client-side on
+		// that (common) path. usage.TTFT is the turn's FIRST LLM call's own
+		// measured latency (agent.py's _query_ttft_seconds), not a last-step
+		// reading — nothing but cheap in-process work happens between query
+		// submit and that first call, so this is a real, not approximated,
+		// answer to "time to first inference token". A genuine
+		// client-observed ttft still wins when one was actually captured: it
+		// is an end-to-end wall-clock measurement (covers the wire too),
+		// where the server value is only Lemonade's own internal timer.
+		if !m.firstToken && usage.TTFT > 0 {
+			m.ttft = time.Duration(usage.TTFT * float64(time.Second))
+		}
 		// `answer` is the contract's authoritative field (§4), so it wins over the
 		// streamed tokens rather than the other way round — otherwise the view and
 		// the transcript pushed back as `context` could disagree. The buffered

--- a/tui/internal/ui/chat/canonical.go
+++ b/tui/internal/ui/chat/canonical.go
@@ -46,6 +46,10 @@ func (m ChatModel) handleCanonicalEvent(evt interface{}) (ChatModel, tea.Cmd, bo
 		}
 
 	case event.CanonicalTokenEvent:
+		if !m.firstToken {
+			m.firstToken = true
+			m.ttft = time.Since(m.queryStart)
+		}
 		m.buffer += e.Delta
 
 	case event.CanonicalToolCallEvent:

--- a/tui/internal/ui/chat/canonical.go
+++ b/tui/internal/ui/chat/canonical.go
@@ -129,18 +129,8 @@ func (m ChatModel) handleCanonicalEvent(evt interface{}) (ChatModel, tea.Cmd, bo
 
 	case event.CanonicalFinalEvent:
 		usage := event.CanonicalUsageOf(e)
-		// Server-reported ttft fallback (#2899 follow-up): native tool-calling
-		// models attach their full tool schema on every step, and Lemonade
-		// forces a request non-streaming whenever `tools` is attached — so no
-		// CanonicalTokenEvent ever arrives to anchor m.ttft client-side on
-		// that (common) path. usage.TTFT is the turn's FIRST LLM call's own
-		// measured latency (agent.py's _query_ttft_seconds), not a last-step
-		// reading — nothing but cheap in-process work happens between query
-		// submit and that first call, so this is a real, not approximated,
-		// answer to "time to first inference token". A genuine
-		// client-observed ttft still wins when one was actually captured: it
-		// is an end-to-end wall-clock measurement (covers the wire too),
-		// where the server value is only Lemonade's own internal timer.
+		// Server-reported ttft fallback for turns where no token ever
+		// streamed client-side (e.g. non-streaming tool-calling requests).
 		if !m.firstToken && usage.TTFT > 0 {
 			m.ttft = time.Duration(usage.TTFT * float64(time.Second))
 		}

--- a/tui/internal/ui/chat/canonical_test.go
+++ b/tui/internal/ui/chat/canonical_test.go
@@ -88,6 +88,64 @@ func TestCanonicalFinalWithoutTokens(t *testing.T) {
 	if last.Role != RoleAssistant || last.Content != "no streaming here" {
 		t.Fatalf("unexpected message: %+v", last)
 	}
+	if last.Tokens != 0 {
+		t.Errorf("no usage.tokens on the wire -> Message.Tokens must stay 0, got %d", last.Tokens)
+	}
+}
+
+// TestCanonicalFinalCarriesRealTokenCount is AC2(a): a real usage.tokens
+// value on the wire reaches Message.Tokens, and renders as "N tokens" — no
+// "~" prefix, since this is a real count, not the old char-length guess.
+func TestCanonicalFinalCarriesRealTokenCount(t *testing.T) {
+	m, _ := newTestModel(t)
+	m.streaming = true
+	m.queryStart = time.Now().Add(-5 * time.Second)
+	m.ttft = 1 * time.Second
+
+	m = feed(t, m, event.CanonicalFinalEvent{
+		Type:   "final",
+		Answer: "short",
+		Usage:  []byte(`{"steps":2,"tools_used":1,"tokens":42}`),
+	})
+
+	last := m.messages[len(m.messages)-1]
+	if last.Tokens != 42 {
+		t.Fatalf("Tokens = %d, want 42", last.Tokens)
+	}
+
+	rendered := m.renderMessage(&last, nil)
+	if !strings.Contains(rendered, "42 tokens") {
+		t.Errorf("rendered stats line missing \"42 tokens\":\n%s", rendered)
+	}
+	if strings.Contains(rendered, "~42") {
+		t.Errorf("rendered stats line still shows the old approximation marker:\n%s", rendered)
+	}
+}
+
+// TestCanonicalRenderOmitsTokensWhenZero is AC4: the stats line stays
+// present (duration/ttft/steps/tools) even when no real token count exists —
+// this is a fix, not a removal, and there is no fallback to the old guess.
+func TestCanonicalRenderOmitsTokensWhenZero(t *testing.T) {
+	m, _ := newTestModel(t)
+	msg := &Message{
+		Role:      RoleAssistant,
+		Duration:  3200 * time.Millisecond,
+		TTFT:      800 * time.Millisecond,
+		Steps:     2,
+		ToolsUsed: 1,
+		Tokens:    0,
+		Content:   "a reasonably long answer that would have guessed a nonzero token count under the old code",
+	}
+
+	rendered := m.renderMessage(msg, nil)
+	if strings.Contains(rendered, "tokens") || strings.Contains(rendered, "tok/s") {
+		t.Errorf("expected no tokens/tok-per-sec sub-line when Tokens == 0:\n%s", rendered)
+	}
+	for _, want := range []string{"3.2s", "ttft 0.8s", "2 steps", "1 tools"} {
+		if !strings.Contains(rendered, want) {
+			t.Errorf("expected stats line to still contain %q:\n%s", want, rendered)
+		}
+	}
 }
 
 // TestCanonicalTTFTAnchorsOnFirstToken reproduces the WARM-query shape

--- a/tui/internal/ui/chat/canonical_test.go
+++ b/tui/internal/ui/chat/canonical_test.go
@@ -148,13 +148,9 @@ func TestCanonicalRenderOmitsTokensWhenZero(t *testing.T) {
 	}
 }
 
-// TestCanonicalTTFTAnchorsOnFirstToken reproduces the WARM-query shape
-// measured against a live sidecar (#2899): the status frame arrives
-// essentially immediately, but real generation doesn't start for several
-// more seconds. Before the fix, ttft was set on the status frame and read
-// ~0s in this exact shape — a cold-load-only test (large gap before even the
-// status frame) would not catch that regression, since the old code happened
-// to look right by coincidence when the delay came before the first frame.
+// TestCanonicalTTFTAnchorsOnFirstToken covers the warm-query shape: the
+// status frame arrives immediately, but ttft must anchor on the first real
+// token, not the status frame.
 func TestCanonicalTTFTAnchorsOnFirstToken(t *testing.T) {
 	m, _ := newTestModel(t)
 	m.streaming = true
@@ -183,13 +179,8 @@ func TestCanonicalTTFTAnchorsOnFirstToken(t *testing.T) {
 	}
 }
 
-// TestCanonicalLegacyTransportNeverSetsTTFT locks in a deliberate decision:
-// the legacy subprocess transport's ChunkEvent is documented as "disabled in
-// v1 json-events mode" (types.go), so a legacy AnswerEvent with no preceding
-// ChunkEvent leaves ttft at 0 and the stats line omits it entirely — a
-// strict improvement over the old "any first frame" anchor, which showed a
-// wrong non-zero value there. This is not a bug to fix; this test exists so
-// a future reader doesn't mistake the omission for one.
+// TestCanonicalLegacyTransportNeverSetsTTFT: the legacy transport never
+// fires ChunkEvent, so ttft stays 0 and is omitted — intentional, not a bug.
 func TestCanonicalLegacyTransportNeverSetsTTFT(t *testing.T) {
 	m, _ := newTestModel(t)
 	m.streaming = true
@@ -203,21 +194,9 @@ func TestCanonicalLegacyTransportNeverSetsTTFT(t *testing.T) {
 	}
 }
 
-// TestCanonicalTTFTFallsBackToServerReportedValue reproduces the gap a live
-// run against a real mailbox exposed as a follow-up to #2899: every one of
-// the four real queries got real token counts (the #2899 fix) but ttft never
-// rendered at all — not a wrong value, an absent one. Root cause: native
-// tool-calling models attach the full tool schema on every step, and
-// Lemonade forces every such request non-streaming (lemonade.py's
-// `effective_stream = stream and not (tool_capable and tools)`), so no
-// CanonicalTokenEvent is ever emitted to anchor ttft client-side — this is
-// the daemon/TUI path's NORMAL case, not an edge one. The agent-side fix
-// computes the turn's FIRST LLM call's own real time_to_first_token
-// (Lemonade's /stats, already polled every step for the token count — a
-// last-step reading was tried first and rejected, since it silently drops
-// every earlier step's tool-decision latency) and rides it on usage.ttft;
-// this test locks in the client using it when no token ever streamed this
-// turn.
+// TestCanonicalTTFTFallsBackToServerReportedValue: when no token ever
+// streamed this turn (the normal non-streaming tool-calling path), the
+// client must use the server-reported usage.ttft instead of leaving it at 0.
 func TestCanonicalTTFTFallsBackToServerReportedValue(t *testing.T) {
 	m, _ := newTestModel(t)
 	m.streaming = true

--- a/tui/internal/ui/chat/canonical_test.go
+++ b/tui/internal/ui/chat/canonical_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/amd/gaia/tui/internal/event"
 )
@@ -86,6 +87,61 @@ func TestCanonicalFinalWithoutTokens(t *testing.T) {
 	last := m.messages[len(m.messages)-1]
 	if last.Role != RoleAssistant || last.Content != "no streaming here" {
 		t.Fatalf("unexpected message: %+v", last)
+	}
+}
+
+// TestCanonicalTTFTAnchorsOnFirstToken reproduces the WARM-query shape
+// measured against a live sidecar (#2899): the status frame arrives
+// essentially immediately, but real generation doesn't start for several
+// more seconds. Before the fix, ttft was set on the status frame and read
+// ~0s in this exact shape — a cold-load-only test (large gap before even the
+// status frame) would not catch that regression, since the old code happened
+// to look right by coincidence when the delay came before the first frame.
+func TestCanonicalTTFTAnchorsOnFirstToken(t *testing.T) {
+	m, _ := newTestModel(t)
+	m.streaming = true
+	m.queryStart = time.Now()
+
+	m = feed(t, m, event.CanonicalStatusEvent{Type: "status", Message: "Scanning inbox"})
+	if m.ttft != 0 {
+		t.Fatalf("status frame must not set ttft, got %v", m.ttft)
+	}
+
+	// Simulate 8s of real elapsed time between the status frame and the
+	// first token, matching the live-baseline warm-query gap.
+	m.queryStart = m.queryStart.Add(-8 * time.Second)
+
+	m = feed(t, m, event.CanonicalTokenEvent{Type: "token", Delta: "Hi"})
+	if m.ttft < 7500*time.Millisecond || m.ttft > 8500*time.Millisecond {
+		t.Errorf("ttft = %v, want ~8s (anchored on the token, not the earlier status frame)", m.ttft)
+	}
+
+	// A second token must not move ttft again.
+	firstTTFT := m.ttft
+	m.queryStart = m.queryStart.Add(-100 * time.Second) // would blow up ttft if re-anchored
+	m = feed(t, m, event.CanonicalTokenEvent{Type: "token", Delta: " there"})
+	if m.ttft != firstTTFT {
+		t.Errorf("ttft changed on a second token: got %v, want unchanged %v", m.ttft, firstTTFT)
+	}
+}
+
+// TestCanonicalLegacyTransportNeverSetsTTFT locks in a deliberate decision:
+// the legacy subprocess transport's ChunkEvent is documented as "disabled in
+// v1 json-events mode" (types.go), so a legacy AnswerEvent with no preceding
+// ChunkEvent leaves ttft at 0 and the stats line omits it entirely — a
+// strict improvement over the old "any first frame" anchor, which showed a
+// wrong non-zero value there. This is not a bug to fix; this test exists so
+// a future reader doesn't mistake the omission for one.
+func TestCanonicalLegacyTransportNeverSetsTTFT(t *testing.T) {
+	m, _ := newTestModel(t)
+	m.streaming = true
+	m.queryStart = time.Now().Add(-5 * time.Second)
+
+	m = feed(t, m, event.AnswerEvent{Type: "answer", Content: "no chunk events here", Steps: 1, ToolsUsed: 0})
+
+	last := m.messages[len(m.messages)-1]
+	if last.TTFT != 0 {
+		t.Errorf("legacy transport with no ChunkEvent must leave TTFT at 0, got %v", last.TTFT)
 	}
 }
 

--- a/tui/internal/ui/chat/canonical_test.go
+++ b/tui/internal/ui/chat/canonical_test.go
@@ -203,6 +203,79 @@ func TestCanonicalLegacyTransportNeverSetsTTFT(t *testing.T) {
 	}
 }
 
+// TestCanonicalTTFTFallsBackToServerReportedValue reproduces the gap a live
+// run against a real mailbox exposed as a follow-up to #2899: every one of
+// the four real queries got real token counts (the #2899 fix) but ttft never
+// rendered at all — not a wrong value, an absent one. Root cause: native
+// tool-calling models attach the full tool schema on every step, and
+// Lemonade forces every such request non-streaming (lemonade.py's
+// `effective_stream = stream and not (tool_capable and tools)`), so no
+// CanonicalTokenEvent is ever emitted to anchor ttft client-side — this is
+// the daemon/TUI path's NORMAL case, not an edge one. The agent-side fix
+// computes the turn's FIRST LLM call's own real time_to_first_token
+// (Lemonade's /stats, already polled every step for the token count — a
+// last-step reading was tried first and rejected, since it silently drops
+// every earlier step's tool-decision latency) and rides it on usage.ttft;
+// this test locks in the client using it when no token ever streamed this
+// turn.
+func TestCanonicalTTFTFallsBackToServerReportedValue(t *testing.T) {
+	m, _ := newTestModel(t)
+	m.streaming = true
+	m.queryStart = time.Now().Add(-82 * time.Second)
+
+	// No CanonicalTokenEvent anywhere in this turn — the non-streaming
+	// daemon path a native tool-calling model always takes.
+	m = feed(t, m, event.CanonicalFinalEvent{
+		Type:   "final",
+		Answer: "triage summary",
+		Usage:  []byte(`{"steps":2,"tools_used":1,"tokens":72,"ttft":9.4}`),
+	})
+
+	last := m.messages[len(m.messages)-1]
+	wantTTFT := time.Duration(9.4 * float64(time.Second))
+	if last.TTFT != wantTTFT {
+		t.Fatalf("TTFT = %v, want %v from the server-reported usage.ttft fallback", last.TTFT, wantTTFT)
+	}
+
+	rendered := m.renderMessage(&last, nil)
+	if !strings.Contains(rendered, "ttft 9.4s") {
+		t.Errorf("rendered stats line missing \"ttft 9.4s\" — ttft still never reaches the user:\n%s", rendered)
+	}
+}
+
+// TestCanonicalTTFTClientObservedWinsOverServerReported ensures a genuinely
+// streamed token still anchors ttft on the real client-observed timestamp
+// rather than the server-reported fallback: the client's wall-clock
+// measurement is an end-to-end observation (covers the wire too), while the
+// server-reported value is only Lemonade's own internal timer for the first
+// LLM call. The two are not interchangeable, so the more complete
+// measurement must win whenever it was actually captured.
+func TestCanonicalTTFTClientObservedWinsOverServerReported(t *testing.T) {
+	m, _ := newTestModel(t)
+	m.streaming = true
+	m.queryStart = time.Now().Add(-8 * time.Second)
+
+	m = feed(t, m, event.CanonicalTokenEvent{Type: "token", Delta: "Hi"})
+	clientTTFT := m.ttft
+	if clientTTFT <= 0 {
+		t.Fatalf("test setup: client-observed ttft should be positive, got %v", clientTTFT)
+	}
+
+	// The final event's server-reported ttft is deliberately a very different
+	// value (0.05s) — if the fallback ever overrides a real client
+	// observation, this assertion catches it.
+	m = feed(t, m, event.CanonicalFinalEvent{
+		Type:   "final",
+		Answer: "Hi there",
+		Usage:  []byte(`{"ttft":0.05}`),
+	})
+
+	last := m.messages[len(m.messages)-1]
+	if last.TTFT != clientTTFT {
+		t.Errorf("TTFT = %v, want the client-observed %v (server-reported fallback must not override it)", last.TTFT, clientTTFT)
+	}
+}
+
 func TestCanonicalToolCallAndResult(t *testing.T) {
 	m, _ := newTestModel(t)
 	m.streaming = true

--- a/tui/internal/ui/chat/message.go
+++ b/tui/internal/ui/chat/message.go
@@ -27,10 +27,10 @@ type Message struct {
 	ToolName  string
 	Success   *bool
 	Duration  time.Duration // time from query to answer
-	TTFT      time.Duration // time to first inference token — client-observed from query submit when a token actually streamed, else the turn's first LLM call's own server-reported latency (#2899 follow-up); never model-load or a tool/status event
+	TTFT      time.Duration // time to first inference token; never model-load or a tool/status event
 	Steps     int           // agent steps taken
 	ToolsUsed int           // tools invoked
-	Tokens    int           // real generated-token count from usage.tokens; 0 => not reported, omit from display
+	Tokens    int           // real generated-token count; 0 => not reported, omit from display
 
 	// Render / Data carry a RoleCard message's payload straight off the wire;
 	// the cards package decides how (and whether) it can be drawn.

--- a/tui/internal/ui/chat/message.go
+++ b/tui/internal/ui/chat/message.go
@@ -27,7 +27,7 @@ type Message struct {
 	ToolName  string
 	Success   *bool
 	Duration  time.Duration // time from query to answer
-	TTFT      time.Duration // time from query submit to first inference token — not model-load or a tool/status event
+	TTFT      time.Duration // time to first inference token — client-observed from query submit when a token actually streamed, else the turn's first LLM call's own server-reported latency (#2899 follow-up); never model-load or a tool/status event
 	Steps     int           // agent steps taken
 	ToolsUsed int           // tools invoked
 	Tokens    int           // real generated-token count from usage.tokens; 0 => not reported, omit from display

--- a/tui/internal/ui/chat/message.go
+++ b/tui/internal/ui/chat/message.go
@@ -27,7 +27,7 @@ type Message struct {
 	ToolName  string
 	Success   *bool
 	Duration  time.Duration // time from query to answer
-	TTFT      time.Duration // time to first event (model load + first inference)
+	TTFT      time.Duration // time from query submit to first inference token — not model-load or a tool/status event
 	Steps     int           // agent steps taken
 	ToolsUsed int           // tools invoked
 

--- a/tui/internal/ui/chat/message.go
+++ b/tui/internal/ui/chat/message.go
@@ -30,6 +30,7 @@ type Message struct {
 	TTFT      time.Duration // time from query submit to first inference token — not model-load or a tool/status event
 	Steps     int           // agent steps taken
 	ToolsUsed int           // tools invoked
+	Tokens    int           // real generated-token count from usage.tokens; 0 => not reported, omit from display
 
 	// Render / Data carry a RoleCard message's payload straight off the wire;
 	// the cards package decides how (and whether) it can be drawn.

--- a/tui/internal/ui/chat/model.go
+++ b/tui/internal/ui/chat/model.go
@@ -149,7 +149,7 @@ type ChatModel struct {
 	initialQuery string
 	err          error
 	queryStart   time.Time // tracks when the current query started
-	firstEvent   bool      // whether we've received the first event this turn
+	firstToken   bool      // whether the first real inference token has arrived this turn (not just any SSE frame)
 	ttft         time.Duration
 
 	// pendingPreScan buffers a fetch resolved mid-turn until that turn ends, so it never lands between a question and its reply.
@@ -642,7 +642,7 @@ func (m ChatModel) sendQuery(query string) (tea.Model, tea.Cmd) {
 	m.activity = nil
 	m.buffer = ""
 	m.queryStart = time.Now()
-	m.firstEvent = false
+	m.firstToken = false
 	m.ttft = 0
 	// A new turn starts having drawn no card yet -- see drainPendingPreScan.
 	m.preScanRenderedThisTurn = false
@@ -698,10 +698,10 @@ func (m *ChatModel) CancelActiveTurn() {
 }
 
 func (m ChatModel) handleEvent(evt interface{}) (tea.Model, tea.Cmd) {
-	if !m.firstEvent {
-		m.firstEvent = true
-		m.ttft = time.Since(m.queryStart)
-	}
+	// TTFT is anchored on the first real inference token (CanonicalTokenEvent
+	// / legacy ChunkEvent below), not on the first SSE frame of any kind — a
+	// turn-start status frame arrives in single-digit ms and would otherwise
+	// make ttft measure "server said hello", not "model produced text" (#2899).
 
 	// The daemon transport speaks the canonical seven-event contract; the
 	// subprocess transport speaks the legacy in-process vocabulary below.
@@ -810,6 +810,10 @@ func (m ChatModel) handleEvent(evt interface{}) (tea.Model, tea.Cmd) {
 		return m, nil
 
 	case event.ChunkEvent:
+		if !m.firstToken {
+			m.firstToken = true
+			m.ttft = time.Since(m.queryStart)
+		}
 		m.buffer += e.Content
 
 	case event.AgentErrorEvent:

--- a/tui/internal/ui/chat/model.go
+++ b/tui/internal/ui/chat/model.go
@@ -1009,14 +1009,17 @@ func (m ChatModel) renderMessage(msg *Message, seen map[string]bool) string {
 			if msg.TTFT > 0 {
 				stats = append(stats, fmt.Sprintf("ttft %.1fs", msg.TTFT.Seconds()))
 			}
-			// Approximate output tokens (~4 chars per token for English)
-			outputTokens := len(msg.Content) / 4
-			if outputTokens > 0 {
-				stats = append(stats, fmt.Sprintf("~%d tokens", outputTokens))
+			// Real generated-token count (#2899) — no longer a char-count
+			// guess. Zero means the sidecar didn't report usage.tokens (e.g.
+			// the legacy transport, or an older agent); omit rather than
+			// fall back to the old estimate, which would silently
+			// reintroduce the exact bug this replaced.
+			if msg.Tokens > 0 {
+				stats = append(stats, fmt.Sprintf("%d tokens", msg.Tokens))
 				// Tokens per second (output only)
 				inferTime := msg.Duration - msg.TTFT
 				if inferTime > 0 {
-					tps := float64(outputTokens) / inferTime.Seconds()
+					tps := float64(msg.Tokens) / inferTime.Seconds()
 					stats = append(stats, fmt.Sprintf("%.1f tok/s", tps))
 				}
 			}


### PR DESCRIPTION
Closes #2899

## Why this matters

The TUI's per-query stats line was untrustworthy: a triage query that took a minute showed `ttft 0.1s` (impossible) and a token count guessed from the answer string's character length, not what the model actually generated. Both fixes are needed together — a client-side character-count guess was never going to be right regardless of what the answer text contained.

- **TTFT (warm path) is fixed; cold-load latency is still not captured.** Warm queries previously reported `ttft 0.0s` against 8–9s of real pre-generation latency and now report ~7.7s, matching independent measurement. **On a cold model load it under-reports**: a 44.5s cold query showed `ttft 7.6s` while the backend process did not spawn until +29s, because Lemonade's `time_to_first_token` covers generation prefill only. Before this change that case was *accidentally* accurate (it measured time-to-first-*frame*, delayed by the load), so the cold axis regresses from right-by-coincidence to wrong-by-omission — tracked in **#2924**. Characterise this as *warm-path ttft fixed*, not *ttft fixed*.
  - ⚠️ **The first attempt at this shipped a TTFT that never rendered at all.** Re-anchoring on the token event was correct, but that event never fires for this agent: `EmailAgentConfig.streaming` defaults `False`, and even flipping it changes nothing because `LemonadeProvider.chat()` forces `effective_stream = stream and not (tool_capable and tools)` — and the agent attaches its tool schema every step. Live capture showed `ttft` **absent** from all four queries, so the follow-up commit sources it from Lemonade's own per-step `time_to_first_token` (already polled for token accounting, previously discarded) and carries it on the same `usage` channel as tokens.
  - It reads the **earliest** token-generating step, not the last. A last-step reading times only the final LLM call and would land near ~1-2s on a ~69s turn — reproducing the exact defect this issue was opened for. Returns nothing rather than a fabricated `0` when unavailable.
- **Token count** is now the real total generated across the run, plumbed from the agent loop through the SSE wire contract into the TUI — replacing the `len(answer)/4` guess. A tool that makes its own internal LLM calls (email triage's per-message classification fan-out) now has its usage folded into the same total instead of being stranded on the tool's own return value.
- Step and tool counts are unchanged — they were already accurate.

⚠️ **Breaking change for custom `OutputHandler` subclasses.** `print_final_answer` now always receives `total_tokens=` and `ttft_seconds=` keyword arguments from the agent loop. An out-of-tree subclass with the old two-argument signature (`answer`, `streaming`) will raise `TypeError` on its first answer. All in-repo subclasses (`AgentConsole`, `SilentConsole`, `SSEOutputHandler`) are updated; `docs/spec/console.mdx` now documents the new signature too. This break is intentional rather than shimmed with a compatibility fallback — the alternative (inspecting the target's signature at the call site, or swallowing the `TypeError` and retrying without the new kwargs) is exactly the kind of silent-fallback behavior this repo's conventions rule out.

<!-- BEFORE/AFTER STATS: placeholder, filled by the orchestrator's evidence agent -->

**Known, separately-tracked gaps (not this PR):**
- Duration also under-reports true wall-clock (4-28% measured on a live baseline) — tracked in #2909. Requires moving where the terminal SSE event fires relative to post-answer server work; out of scope here.
- BuilderAgent has its own loop override and doesn't wire the new `total_tokens` param — its stats line will show no token count after this change. Not the flow this issue reports on (email triage), and out of this PR's file boundary.

## Test plan

- [x] `cd tui && go build ./... && go vet ./... && go test ./...` — all packages pass, including new tests for the warm-query TTFT regression and the real-token render path.
- [x] `python -m pytest tests/unit/ -q` — 10278 passed, 159 skipped. 10 pre-existing failures (CLI-binary-on-PATH, a Claude-judge missing-API-key artifact, hub-installer wheel installs, VLM PDF extraction) are all in files untouched by this diff — confirmed via `git diff origin/main --stat`.
- [x] `python -m pytest hub/agents/email/python/tests/ -q` — 1870 passed. Two pre-existing failures in `test_email_sidecar_relay.py` (expect a `render` card on `pre_scan_inbox` that current code deliberately no longer draws — unrelated to this change, confirmed identical to origin/main).
- [x] `python util/lint.py --all` — all quality checks passed.
- [ ] Real triage-run verification (AC5) — owned by a separate evidence-capture agent, not this PR's author; before/after stats will be added once captured.

Whichever of this PR and #2901 (stacked on this branch, touches the same `sendQuery`/`canonical.go` regions) merges second should re-run the Go suite against the post-merge tree — a hand-resolved conflict here could silently drop a one-line change without failing either branch's own CI.



