### PR TITLE
ci(eval): queue eval runs instead of cancelling the pending one

### DIFF
--- a/.github/workflows/email_scorecard_refresh.yml
+++ b/.github/workflows/email_scorecard_refresh.yml
@@ -138,6 +138,9 @@ concurrency:
   # runs never race-evict each other's model (CLAUDE.md: evals run serially).
   group: lemonade-eval
   cancel-in-progress: false
+  # `queue: single` (the default) keeps only ONE pending run and cancels the
+  # previously-queued one — a phantom red X on the PR. `max` queues them FIFO.
+  queue: max
 
 permissions:
   contents: write   # auto-commit the refreshed scorecard to the branch

--- a/.github/workflows/test_email_agent_eval.yml
+++ b/.github/workflows/test_email_agent_eval.yml
@@ -86,18 +86,20 @@
 #      cancel-in-progress, so rapid pushes never stack up 90-minute jobs.
 #   3. LIMIT. PR runs triage 20 emails, not 50 — same slice the release gate uses.
 #
-# COST TO THE RELEASE PATH, STATED PLAINLY. The `lemonade-eval` group holds one
-# running plus one pending run; a newly-queued run CANCELS the previously pending
-# one. Adding ~1 PR run/day to that group therefore makes it possible for a
-# release-gate or weekly call to be evicted while pending. That is the price of
-# pre-merge coverage on a single-slot pool, and it is bounded, not hidden:
-# per-PR cancel-in-progress collapses repeated pushes to one run, and
-# weekly_eval.yml now treats a non-success (not merely a 'failure') callee as a
-# reportable outcome so an eviction cannot pass as a clean run. Making the same
-# eviction visible in publish.yml / release_agent_email.yml is tracked separately.
-# It cuts the other way too: a PR run can itself be evicted while pending, which
-# leaves that PR with no eval and no auto-requeue. Re-run the job from the Checks
-# tab if the coverage matters for the change under review.
+# COST TO THE RELEASE PATH, STATED PLAINLY. The `lemonade-eval` group runs one at
+# a time and queues the rest FIFO (`queue: max`), so adding ~1 PR run/day costs
+# release-gate and weekly calls WAIT time rather than eviction. FIFO has no
+# priority lane: a release call sits behind every PR eval already queued, plus any
+# in-flight scorecard refresh (up to 14h) or gemma consolidation (up to 7.5h).
+# Even so the cost is bounded and visible, not hidden: per-PR cancel-in-progress
+# collapses repeated pushes to one run, and weekly_eval.yml treats a non-success
+# (not merely a 'failure') callee as a reportable outcome. The residual bad
+# outcome is a run that waits out GitHub's 24h job-queue limit and is CANCELLED,
+# leaving it with no eval and no auto-requeue — rarer than the evict-the-pending-
+# run behavior this replaced, but not gone. Re-run the job from the Checks tab if
+# the coverage matters for the change under review. Surfacing that outcome in
+# publish.yml / release_agent_email.yml the way weekly_eval.yml already does is
+# tracked separately.
 #
 # A PR RUN IS ADVISORY, AND THAT IS NOT A TRIGGER-SCOPED CHOICE. Per the enforce
 # state above, no gate blocks anything on any trigger right now, so a PR run is
@@ -292,6 +294,9 @@ jobs:
     concurrency:
       group: lemonade-eval
       cancel-in-progress: false
+      # `queue: single` (the default) keeps only ONE pending run and cancels the
+      # previously-queued one — a phantom red X on the PR. `max` queues them FIFO.
+      queue: max
     # PR guard (no-op for schedule / workflow_dispatch / workflow_call):
     #   - fork PRs never reach the self-hosted pool, and could only produce an
     #     un-judged result anyway (no ANTHROPIC_API_KEY) — see the header;

--- a/.github/workflows/test_eval_agent_gemma_consolidation.yml
+++ b/.github/workflows/test_eval_agent_gemma_consolidation.yml
@@ -176,6 +176,9 @@ concurrency:
   # runs never race-evict each other's model (CLAUDE.md: evals run serially).
   group: lemonade-eval
   cancel-in-progress: false
+  # `queue: single` (the default) keeps only ONE pending run and cancels the
+  # previously-queued one — a phantom red X on the PR. `max` queues them FIFO.
+  queue: max
 
 permissions:
   contents: read

--- a/.github/workflows/test_eval_rag.yml
+++ b/.github/workflows/test_eval_rag.yml
@@ -30,6 +30,9 @@ permissions:
 concurrency:
   group: lemonade-eval
   cancel-in-progress: false
+  # `queue: single` (the default) keeps only ONE pending run and cancels the
+  # previously-queued one — a phantom red X on the PR. `max` queues them FIFO.
+  queue: max
 
 jobs:
   skip-warning:

--- a/.github/workflows/weekly_eval.yml
+++ b/.github/workflows/weekly_eval.yml
@@ -54,13 +54,14 @@ jobs:
     # always() so this runs even though the needed job failed; then gate on the
     # result being anything other than a clean pass.
     #
-    # `!= 'success'` rather than `== 'failure'`: the callee's job now shares the
-    # `lemonade-eval` group with PR-triggered runs (test_email_agent_eval.yml
-    # gained a `pull_request` trigger), and that group holds one running plus one
-    # pending run — a newly-queued run cancels the pending one. An evicted weekly
-    # eval reports 'cancelled', not 'failure', so the old condition filed nothing
-    # and the week's eval vanished with zero signal. A week with no eval is a week
-    # with no evidence; say so out loud.
+    # `!= 'success'` rather than `== 'failure'`: a callee that never ran reports
+    # 'cancelled' or 'skipped', not 'failure', so `== 'failure'` would file nothing
+    # and the week's eval would vanish with zero signal. The callee shares the
+    # `lemonade-eval` slot with PR-triggered runs (test_email_agent_eval.yml gained
+    # a `pull_request` trigger); that slot now queues FIFO (`queue: max`) instead
+    # of evicting the pending run, but a manual cancel or GitHub's 24h job-queue
+    # limit still produces 'cancelled'. A week with no eval is a week with no
+    # evidence; say so out loud.
     if: ${{ always() && needs.email-eval.result != 'success' }}
     runs-on: ubuntu-latest
     permissions:
@@ -97,9 +98,10 @@ jobs:
           (\`enforce: true\`) gate breach. Open the run log above to see which stage failed (triage / drafting /
           action-item) and why.
 
-          If the result is \`cancelled\`: the run was most likely evicted from the shared \`lemonade-eval\` concurrency
-          slot — it holds one running plus one pending run, and a newly-queued run cancels the pending one (PR-triggered
-          email evals now queue there too). No eval ran this week; re-dispatch \`weekly_eval.yml\` when the slot is free.
+          If the result is \`cancelled\`: check for a manual cancel, or a run that waited out GitHub's 24h job-queue
+          limit behind a long occupant of the shared \`lemonade-eval\` slot. That slot now queues pending runs FIFO
+          (\`queue: max\`) instead of evicting them, so slot eviction is no longer the routine cause it once was.
+          No eval ran this week; re-dispatch \`weekly_eval.yml\`.
           EOF
           )"
           # One rolling issue: comment on the open one if it exists, else open it.


### PR DESCRIPTION
Queued eval runs were being silently cancelled and showing up as red X's on PRs, so the eval gate produced phantom failures nobody could reproduce — more than one person has chased a "regression" that was really just a cancelled run. All four workflows on the shared `lemonade-eval` slot already set `cancel-in-progress: false`, but that only protects the *running* job; GitHub's default `queue: single` keeps just one *pending* run per group and cancels it the moment another run queues behind it. With a multi-hour eval holding the slot, that fires constantly. Adding `queue: max` lets waiting runs queue FIFO (up to 100) instead of killing each other, so a run that's waiting now looks like it's waiting.

Serialization itself is unchanged and deliberately kept — two concurrent evals race-evict each other's model from the single Lemonade backend ([CLAUDE.md: run agent evals serially](https://github.com/amd/gaia/blob/main/CLAUDE.md)). This changes only what happens to runs that are *already* waiting.

Also fixes three comments and the weekly-eval failure notification, which told operators a cancelled run "was most likely evicted from the concurrency slot" — no longer the routine cause, and it would have sent them looking in the wrong place.

## Test plan

- [ ] GitHub accepts the workflow files — no "Invalid workflow file" annotation on this PR (validates the `queue` key, including at **job** level in `test_email_agent_eval.yml`, which is a reusable workflow called by `publish.yml` and `release_agent_email.yml`).
- [ ] `python -c "import yaml,sys; [yaml.safe_load(open(f,encoding='utf-8')) for f in sys.argv[1:]]" .github/workflows/*.yml` parses all 72 workflows.
- [ ] No `lemonade-eval` declaration pairs `queue: max` with `cancel-in-progress: true` (a hard validation error): `grep -rn "group: lemonade-eval" -A 3 .github/workflows/` shows `false` in all four.
- [ ] Behavioral check — dispatch `test_eval_agent_gemma_consolidation.yml` twice while one is running; the second stays **pending** rather than cancelling, and the third queues behind it instead of evicting the second.

## Notes for the reviewer

- `queue` is GA since [May 2026](https://github.blog/changelog/2026-05-07-github-actions-concurrency-groups-now-allow-larger-queues/); [docs](https://docs.github.com/en/actions/how-tos/write-workflows/choose-when-workflows-run/control-workflow-concurrency).
- **FIFO has no priority lane.** A release-gate call now waits behind every PR eval already queued plus any in-flight 14h scorecard refresh — previously it could jump the queue by evicting the pending run. That trade is called out in the `test_email_agent_eval.yml` header. The residual bad outcome is GitHub's 24h job-queue limit, which *cancels*; rarer than before, not gone.
- Worth a follow-up, deliberately not in this PR: the four workflows don't all contend for the same backend (`stx`-labelled runs can land on any of three boxes, each with its own Lemonade on 13305), while the six sibling `stx` workflows that force-kill port 13305 aren't in the group at all. Slot *duration* is the deeper problem, and the group is both over- and under-inclusive for it.