### PR TITLE
fix(skills): reject version pins GAIA cannot read instead of matching them

### DIFF
--- a/docs/guides/composing-skills.mdx
+++ b/docs/guides/composing-skills.mdx
@@ -117,8 +117,8 @@ skill_sets:
   library:
     - api-compatibility                # required (the default)
     - name: changelog-discipline
-      version: ">=0.1.0"               # recorded, not yet resolved
-      required: false                  # missing ⇒ logged and skipped
+      version: ">=0.1.0"               # checked against the installed version
+      required: false                  # missing/incompatible ⇒ logged, skipped
 ```
 
 ## 3. Point the agent at both

--- a/docs/plans/skill-format.mdx
+++ b/docs/plans/skill-format.mdx
@@ -195,8 +195,8 @@ Each entry in `skills` or a set's list is either a **skill name** or a mapping:
 | Key | Type | Required | Description |
 |---|---|---|---|
 | `name` | string | yes | A skill name per [naming](#naming). |
-| `version` | string | no | SemVer or range. **Recorded, not resolved** in this phase — see below. |
-| `required` | bool | no | Default `true`. A missing `required: false` skill is logged and skipped; a missing required one fails the launch. |
+| `version` | string | no | SemVer or range, **enforced at load** against the installed skill's version — see below. |
+| `required` | bool | no | Default `true`. A `required: false` skill that is missing *or version-incompatible* is logged and skipped; either failure on a required one fails the launch. |
 
 **Set names** use the same slug shape as skill names, capped at 32 chars — a
 lowercase alphanumeric start and end with internal hyphens:

--- a/docs/plans/skill-format.mdx
+++ b/docs/plans/skill-format.mdx
@@ -218,12 +218,18 @@ undeclared set, an unrecognized key in a reference mapping, a non-boolean
 set of skills or does not load.
 
 <Note>
-**`version:` is a declaration surface only in this phase.** It is parsed,
-validated as a non-empty string, and surfaced — but no constraint solving
-happens until [#2467](https://github.com/amd/gaia/issues/2467) can install
-versioned skills from the marketplace. Until then, a bundled skill's version is
-whatever the agent package ships. This mirrors how `network:` permissions are
-recorded but not enforced in Phase 1.
+**`version:` is enforced at load.** The range is matched against the installed
+skill's frontmatter `version`, and a mismatch is fail-loud: a `required` entry
+raises and the agent does not launch, an optional one is skipped with the reason
+logged. A skill with no `version` in its frontmatter cannot satisfy a pin —
+otherwise a local edit would silently shadow a pinned hub install. A range that
+names no version (`>=v2`, `1.2.x`) is rejected at manifest-parse time with the
+shapes above, rather than treated as "any" — so the verdict never depends on
+which skills happen to be installed on the machine doing the parsing.
+
+What [#2467](https://github.com/amd/gaia/issues/2467) still owns is resolution
+*across installable versions* — choosing which version to fetch from the
+marketplace. Checking the one version actually installed happens today.
 </Note>
 
 Selection semantics — the order a set is chosen in, the selector hook, and the

--- a/src/gaia/skills/hub.py
+++ b/src/gaia/skills/hub.py
@@ -46,6 +46,7 @@ from gaia.hub.catalog import (
 from gaia.logger import get_logger
 from gaia.skills.errors import SkillError, SkillNotFoundError, SkillValidationError
 from gaia.skills.versions import resolve as resolve_version_spec
+from gaia.skills.versions import validate_spec as validate_version_spec
 
 log = get_logger(__name__)
 
@@ -223,10 +224,14 @@ class RemoteSkill:
         """Highest published version satisfying *spec*.
 
         Raises:
+            SkillValidationError: *spec* is not a range GAIA can read. Checked
+                before the candidate list, so an unreadable pin is reported as
+                such even for a skill with nothing published yet.
             SkillNotFoundError: when no published version satisfies it. The error
                 lists what *is* published, which is what the user needs to
                 correct the pin.
         """
+        validate_version_spec(spec)
         available = sorted(self.versions)
         chosen = resolve_version_spec(available, spec)
         if chosen is None:

--- a/src/gaia/skills/sets.py
+++ b/src/gaia/skills/sets.py
@@ -64,11 +64,17 @@ SOURCE_NONE = "none"
 class SkillRef:
     """One entry in a ``skills:`` list or a ``skill_sets:`` bundle.
 
-    ``version`` is a **declaration surface only** in this phase: it is parsed,
-    validated as a string, and surfaced, but no constraint solving happens until
-    the marketplace phase (#2467) can install versioned skills. ``required:
-    false`` marks an optional enhancement — a missing optional skill is logged
-    and skipped, a missing required one fails the launch.
+    ``version`` is a SemVer range (``">=1.0.0"``, ``"^1.2"``) and it is
+    **enforced at load**, not merely recorded: this module parses it, and
+    :func:`gaia.skills.consume.resolve_requirements` matches it against the
+    installed skill's frontmatter ``version``. A skill that is unversioned, or
+    versioned outside the range, does not satisfy the pin. ``required: false``
+    marks an optional enhancement — an optional skill that is missing or
+    version-incompatible is logged and skipped, a required one fails the launch.
+
+    Full resolution *across installable versions* (picking which version to
+    fetch) still belongs to the marketplace phase (#2467); what happens here is
+    checking the one version that is actually installed.
     """
 
     name: str
@@ -350,6 +356,8 @@ def _parse_ref(entry: Any, field_name: str, where: str) -> SkillRef:
             f"version or range, e.g. '>=1.0.0'), got {version!r}. "
             f"See {_SETS_DOCS_URL}."
         )
+    if isinstance(version, str):
+        _validated_range(version.strip(), field_name, where)
 
     required = entry.get("required", True)
     if not isinstance(required, bool):
@@ -363,6 +371,25 @@ def _parse_ref(entry: Any, field_name: str, where: str) -> SkillRef:
         version=version.strip() if isinstance(version, str) else None,
         required=required,
     )
+
+
+def _validated_range(spec: str, field_name: str, where: str) -> None:
+    """Reject a ``version:`` range the resolver would not be able to evaluate.
+
+    Checked here, with every other malformed shape, so the verdict does not
+    depend on whether the pinned skill happens to be installed on this machine.
+    """
+    # Deferred like NAME_PATTERN below: keeps the manifest validator's import
+    # graph off the hub catalog for the agents that declare no skills.
+    from gaia.skills.versions import validate_spec
+
+    try:
+        validate_spec(spec)
+    except SkillValidationError as e:
+        raise SkillValidationError(
+            f"'{field_name}.version'{where} is not a version range GAIA can "
+            f"evaluate. {e}"
+        ) from e
 
 
 def _validated_name(value: Any, field_name: str, where: str) -> str:

--- a/src/gaia/skills/versions.py
+++ b/src/gaia/skills/versions.py
@@ -52,6 +52,24 @@ def _core(version: str) -> tuple[int, int, int]:
     return int(major), int(minor or 0), int(patch or 0)
 
 
+def _reject_unreadable_target(clause: str, target: str) -> None:
+    """Refuse a comparator target that is not a version number.
+
+    ``compare_versions`` is the catalog's *sort* comparator: it coerces
+    unreadable text to a sortable key instead of raising. Handing it a garbage
+    target therefore answers True for ``>=``/``>``/``!=`` — silently widening
+    the pin to "any", the one thing this module promises never to do.
+    """
+    if _PARTIAL_RE.match(target):
+        return
+    raise SkillValidationError(
+        f"Version range {clause.strip()!r} does not name a version number GAIA "
+        f"can read ({target!r}). Use MAJOR[.MINOR[.PATCH]] after the operator, "
+        f"e.g. '>=1.2.0', '^1.2', or '1' — with no 'v' prefix and no fourth "
+        f"component. See {_DOCS}"
+    )
+
+
 def _matches_clause(version: str, clause: str) -> bool:
     """Whether *version* satisfies a single comparator clause."""
     if "||" in clause:
@@ -72,6 +90,7 @@ def _matches_clause(version: str, clause: str) -> bool:
             f"Could not parse version range {clause!r}. See {_DOCS}"
         )
     operator, target = match.group(1), match.group(2)
+    _reject_unreadable_target(clause, target)
 
     if operator is None or operator == "==":
         # A bare partial version is a prefix match: '1.2' accepts any 1.2.x,
@@ -127,6 +146,19 @@ def matches(version: str, spec: Optional[str]) -> bool:
         for clause in normalized.split(",")
         if clause.strip()
     )
+
+
+def validate_spec(spec: Optional[str]) -> None:
+    """Raise if *spec* is not a range this module can evaluate.
+
+    Lets a manifest reject an unreadable pin when it is *parsed*, rather than at
+    the first launch that happens to have the skill installed — otherwise the
+    same manifest fails on one machine and passes on another.
+
+    Raises:
+        SkillValidationError: naming the clause that could not be read.
+    """
+    matches("0.0.0", spec)
 
 
 def highest(versions: Iterable[str]) -> Optional[str]:

--- a/src/gaia/skills/versions.py
+++ b/src/gaia/skills/versions.py
@@ -158,7 +158,15 @@ def validate_spec(spec: Optional[str]) -> None:
     Raises:
         SkillValidationError: naming the clause that could not be read.
     """
-    matches("0.0.0", spec)
+    # Every clause, deliberately not via ``matches``: its ``all()`` short-circuits
+    # on the first clause a probe version fails, which would leave a later
+    # unreadable clause of a conjunction unchecked.
+    normalized = (spec or "").strip()
+    if normalized.lower() in ANY_SPECS:
+        return
+    for clause in normalized.split(","):
+        if clause.strip():
+            _matches_clause("0.0.0", clause)
 
 
 def highest(versions: Iterable[str]) -> Optional[str]:

--- a/tests/unit/test_skill_sets.py
+++ b/tests/unit/test_skill_sets.py
@@ -12,6 +12,7 @@ previous run left it lying around is not a passing test.
 
 from __future__ import annotations
 
+import logging
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -604,15 +605,25 @@ def test_agent_required_pin_violation_fails_the_launch(tmp_path, pinned):
     assert agent.active_skill_set is None
 
 
-def test_agent_optional_pin_violation_is_skipped_with_a_reason(tmp_path, pinned):
+def test_agent_optional_pin_violation_is_skipped_with_a_reason(
+    tmp_path, pinned, caplog
+):
     agent = _pinned_agent(
         tmp_path,
         pinned,
         {"name": "inbox-triage", "version": ">=2.0.0", "required": False},
     )
 
-    assert agent.load_skill_set() == {}
+    with caplog.at_level(logging.INFO):
+        assert agent.load_skill_set() == {}
     assert agent.active_skill_set == "work"
+
+    # "Skipped" has to be visible, not invisible: the reason names the pin and
+    # the version on disk, or the agent quietly runs without the capability.
+    skipped = "\n".join(
+        r.getMessage() for r in caplog.records if "inbox-triage" in r.getMessage()
+    )
+    assert ">=2.0.0" in skipped and "1.4.0" in skipped
 
 
 def test_agent_pin_against_an_unversioned_skill_is_refused(tmp_path, pinned):

--- a/tests/unit/test_skill_sets.py
+++ b/tests/unit/test_skill_sets.py
@@ -196,6 +196,20 @@ def test_skills_for_prepends_the_always_on_list():
             },
             "missing a skill name",
         ),
+        # A range that parses as a string but names no version (#2864). Caught
+        # here, not at load, so the verdict does not depend on whether the
+        # pinned skill happens to be installed on this machine.
+        (
+            {
+                "skill_sets": {"work": [{"name": "x", "version": ">=v2"}]},
+                "default_skill_set": "work",
+            },
+            "not a version range GAIA can evaluate",
+        ),
+        (
+            {"skills": [{"name": "x", "version": "1.2.x"}]},
+            "not a version range GAIA can evaluate",
+        ),
         (
             {"skill_sets": {"work": ["Inbox_Triage"]}, "default_skill_set": "work"},
             "not a valid",
@@ -516,6 +530,109 @@ def test_agent_missing_optional_skill_is_skipped(tmp_path, bundled):
 
     assert list(loaded) == ["meeting-scheduling"]
     assert agent.active_skill_set == "work"
+
+
+# ----------------------------------------------------------------------
+# Version pins — a declared range is checked, never silently accepted (#2864)
+#
+# The resolver itself is unit-tested in ``test_skills_consume.py``. These drive
+# the surface an agent author actually touches: a ``version:`` in the manifest,
+# resolved through ``load_skill_set``. A pin that parses and is then dropped on
+# the floor is the silent-fallback mode CLAUDE.md prohibits.
+# ----------------------------------------------------------------------
+
+
+def _versioned_skill_text(name: str, version: str) -> str:
+    return (
+        f"---\nname: {name}\nversion: {version}\n"
+        f"description: Test skill {name}. Use when exercising version pins.\n"
+        f"---\n\n# {name.title()}\n\nBody of {name}.\n"
+    )
+
+
+@pytest.fixture
+def pinned(tmp_path: Path) -> Path:
+    """A bundled root with one versioned skill and one that declares no version."""
+    root = tmp_path / "pkg" / "skills"
+    write_skill_dir(
+        root, "inbox-triage", _versioned_skill_text("inbox-triage", "1.4.0")
+    )
+    write_skill_dir(root, "no-version", _skill_text("no-version"))
+    return root
+
+
+def _pinned_agent(tmp_path, pinned, entry) -> _StubAgent:
+    return _agent(
+        tmp_path, pinned, skill_sets={"work": [entry]}, default_skill_set="work"
+    )
+
+
+def test_agent_loads_a_skill_whose_version_satisfies_the_pin(tmp_path, pinned):
+    agent = _pinned_agent(
+        tmp_path, pinned, {"name": "inbox-triage", "version": ">=1.0.0"}
+    )
+
+    loaded = agent.load_skill_set()
+
+    assert list(loaded) == ["inbox-triage"]
+    assert loaded["inbox-triage"].version == "1.4.0"
+
+
+def test_agent_with_no_pin_declared_accepts_whatever_is_installed(tmp_path, pinned):
+    """The common case must stay byte-identical: no pin, no version gate."""
+    for entry in ("inbox-triage", {"name": "inbox-triage"}):
+        agent = _pinned_agent(tmp_path, pinned, entry)
+        assert list(agent.load_skill_set()) == ["inbox-triage"]
+
+
+def test_agent_required_pin_violation_fails_the_launch(tmp_path, pinned):
+    agent = _pinned_agent(
+        tmp_path, pinned, {"name": "inbox-triage", "version": ">=2.0.0"}
+    )
+
+    with pytest.raises(SkillValidationError) as excinfo:
+        agent.load_skill_set()
+    message = str(excinfo.value)
+
+    # What failed: the pin and the version actually on disk, both named.
+    assert ">=2.0.0" in message and "1.4.0" in message
+    # What to do, and where to look next.
+    assert "gaia skill install inbox-triage@>=2.0.0" in message
+    assert "loosen the pin" in message
+    # The agent is untouched — a refused launch never half-loads.
+    assert agent.loaded_skills == {}
+    assert agent.active_skill_set is None
+
+
+def test_agent_optional_pin_violation_is_skipped_with_a_reason(tmp_path, pinned):
+    agent = _pinned_agent(
+        tmp_path,
+        pinned,
+        {"name": "inbox-triage", "version": ">=2.0.0", "required": False},
+    )
+
+    assert agent.load_skill_set() == {}
+    assert agent.active_skill_set == "work"
+
+
+def test_agent_pin_against_an_unversioned_skill_is_refused(tmp_path, pinned):
+    """Unsatisfiable by unknowability: absence of a version is not a match."""
+    agent = _pinned_agent(
+        tmp_path, pinned, {"name": "no-version", "version": ">=1.0.0"}
+    )
+
+    with pytest.raises(SkillValidationError, match="unversioned"):
+        agent.load_skill_set()
+    assert agent.loaded_skills == {}
+
+
+def test_agent_unreadable_pin_is_rejected_rather_than_widened(tmp_path, pinned):
+    """'>=v2' parses as a manifest string but names no version — never treat as any."""
+    agent = _pinned_agent(tmp_path, pinned, {"name": "inbox-triage", "version": ">=v2"})
+
+    with pytest.raises(SkillValidationError, match="does not name a version number"):
+        agent.load_skill_set()
+    assert agent.loaded_skills == {}
 
 
 def test_agent_without_a_manifest_loads_nothing(tmp_path, bundled):

--- a/tests/unit/test_skills_marketplace.py
+++ b/tests/unit/test_skills_marketplace.py
@@ -93,6 +93,60 @@ def test_unsupported_range_syntax_raises_rather_than_matching_everything(spec):
         matches("1.5.0", spec)
 
 
+@pytest.mark.parametrize(
+    "spec",
+    [
+        ">=v2",  # a 'v' prefix — the most likely real-world typo
+        ">=1.0.0.0",  # a fourth component after an operator
+        "1.2.3.4",  # ...and bare: this one used to answer True
+        "1.2.x",  # npm x-range syntax GAIA does not implement
+        ">=junk",
+        ">junk",
+        "!=junk",
+        "<=junk",
+        "==junk",
+        "abc.def.ghi",
+    ],
+)
+def test_a_comparator_target_that_is_not_a_version_raises(spec):
+    """``compare_versions`` is a lenient *sort* comparator (#2864).
+
+    It coerces unreadable text to a sortable key rather than raising, so
+    delegating a garbage target straight to it answered a value instead of
+    raising — True for '>=', '>' and '!=' (silently widening the pin to "any"),
+    False for the rest (silently narrowing it). Both are wrong: a range GAIA
+    cannot read must be rejected, not guessed at.
+    """
+    from gaia.skills.versions import matches
+
+    with pytest.raises(SkillValidationError, match="does not name a version number"):
+        matches("1.5.0", spec)
+
+
+def test_validate_spec_accepts_every_supported_range_shape():
+    """The parse-time gate must not reject a range the matcher can evaluate."""
+    from gaia.skills.versions import validate_spec
+
+    for spec in (
+        None,
+        "",
+        "*",
+        "latest",
+        "1",
+        "1.2",
+        "1.2.3",
+        ">=1.2.3-beta.1",  # prerelease — legal per format.SEMVER_PATTERN
+        "<2.0.0+build.5",  # build metadata
+        ">= 1.0.0",  # whitespace after the operator
+        "^1.2",
+        "~1",
+        "~=1.2",
+        "!=1.0.0",
+        ">=1.2.0, <2.0.0",
+    ):
+        validate_spec(spec)
+
+
 # ---------------------------------------------------------------------------
 # Tiers
 # ---------------------------------------------------------------------------
@@ -682,6 +736,24 @@ def test_remote_skill_resolve_lists_published_versions_when_no_match():
         remote.resolve(">=2.0.0")
     # The user needs to see what IS published to fix their pin.
     assert "1.0.0, 1.2.0" in str(excinfo.value)
+
+
+def test_remote_skill_resolve_reports_an_unreadable_pin_as_such():
+    """Not as 'nothing satisfies it' — including when nothing is published.
+
+    ``resolve`` matches lazily, so with an empty candidate list the bad spec was
+    never evaluated and the user got the wrong diagnosis (#2864).
+    """
+    from gaia.skills.hub import RemoteSkill
+
+    for versions in ({"1.0.0": {}}, {}):
+        remote = RemoteSkill(
+            name="web-research", latest_version="1.0.0", versions=versions
+        )
+        with pytest.raises(
+            SkillValidationError, match="does not name a version number"
+        ):
+            remote.resolve(">=v2")
 
 
 def test_manifest_without_a_verifiable_artifact_is_refused():

--- a/tests/unit/test_skills_marketplace.py
+++ b/tests/unit/test_skills_marketplace.py
@@ -143,7 +143,33 @@ def test_validate_spec_accepts_every_supported_range_shape():
         "~=1.2",
         "!=1.0.0",
         ">=1.2.0, <2.0.0",
+        ">=1.2.3-beta.1, <2.0.0",
+        ">= 1.0.0 , < 2.0.0",  # whitespace around the conjunction
     ):
+        validate_spec(spec)
+
+
+@pytest.mark.parametrize(
+    "spec",
+    [
+        ">=1.2.0, 1.2.x",
+        ">=1.2.0, >=v2",
+        ">=1.2.0, <2.0.0.0",
+        "<2.0.0, junk",
+    ],
+)
+def test_validate_spec_checks_every_clause_of_a_conjunction(spec):
+    """The gate must not stop at the first clause a probe version fails.
+
+    ``matches`` is ``all()`` over a generator, so it short-circuits: probing
+    with a sentinel meant `>=1.2.0` returned False and the unreadable clause
+    after it was never parsed. The manifest was then accepted, and the failure
+    resurfaced at load only on machines with that skill installed at a version
+    passing clause one — the machine-dependent verdict this gate exists to kill.
+    """
+    from gaia.skills.versions import validate_spec
+
+    with pytest.raises(SkillValidationError, match="does not name a version number"):
         validate_spec(spec)
 
 


### PR DESCRIPTION
Closes #2864.

Pin a skill version with a typo — `version: ">=v2"`, a stray fourth component, or npm's `1.2.x` — and GAIA loaded whatever was on disk and said nothing. The range parsed as a string, then the matcher handed it to the hub catalog's *sort* comparator, which coerces unreadable text into a sortable key instead of raising, so the pin silently resolved to "any". Now an unreadable range is rejected when the manifest is parsed, naming the field, the bad range, and the correct form. Pins that GAIA *can* read were already enforced against the installed skill's frontmatter version; this closes the case where it could not read one and matched anyway.

Validating at parse time rather than at load also removes a machine-dependent hole: an unreadable pin on a `required: false` entry escaped entirely on any machine where that skill happened not to be installed, so the same manifest passed locally and failed in CI.

## Test plan

- [ ] `pytest tests/unit/test_skill_sets.py tests/unit/test_skills_marketplace.py tests/unit/test_skills_consume.py -q` — pin-satisfied, pin-violated (required + optional), no-pin-declared, unversioned-skill-vs-pin, and unreadable-pin, driven through `Agent.load_skill_set`.
- [ ] `pytest tests/unit -k skill -q` — 1093 pass; the 9 failures are pre-existing on `main` (Windows subprocess/path artifacts), verified by running the same selection against a clean `b38f5e60` worktree.
- [ ] Every `gaia-agent.yaml` in the repo (26 of them, `hub/`, `cpp/`, `hub/components/`) still parses — the new gate rejects no manifest that works today.
- [ ] `python util/lint.py --black --isort` clean; pylint errors-only clean on the three changed modules.