### PR TITLE
release(agent-email): 0.6.0

### DIFF
--- a/hub/agents/email/npm/CHANGELOG.md
+++ b/hub/agents/email/npm/CHANGELOG.md
@@ -2,9 +2,9 @@
 
 What's new in `@amd-gaia/agent-email`, in plain language. For the technical detail
 behind any entry — API shapes, endpoints, and version semantics — see
-[`SPEC.md`](https://github.com/amd/gaia/blob/agent-pkg-email-v0.5.0/hub/agents/email/npm/SPEC.md).
+[`SPEC.md`](https://github.com/amd/gaia/blob/agent-pkg-email-v0.6.0/hub/agents/email/npm/SPEC.md).
 
-## Unreleased
+## [0.6.0] - 2026-08-12
 
 - **Work Microsoft 365 mailboxes are now supported alongside Gmail and personal
   Outlook.** A work/school Microsoft account (Entra ID) can now be connected and
@@ -47,14 +47,15 @@ behind any entry — API shapes, endpoints, and version semantics — see
   five lines below, listed a message needing review. The card is now one
   worklist (`needs_you`, schema 2.11) built from a single scan: up to five
   things that genuinely need you, each tagged with what to do (reply, decide,
-  check, or a carried-over action item) and how old it is. Everything
-  filtered out is counted alongside the test that filtered it (`bulk`), so a
-  claim like "47 filtered" is something you can judge rather than take on
-  faith. `NeedsYouItem` / `BulkSummary` are new on `EmailPreScanResult`;
-  nothing existing was removed or renamed (#2743). `NeedsYouItem.detail` is
-  also new — reserved for a couple of lines of real substance per row (the
-  question actually asked, the meeting time actually proposed, the deadline
-  actually quoted) — but ships **always empty** in this release: the
+  check, or a carried-over action item) and how old it is. `NeedsYouItem` /
+  `BulkSummary` are new on `EmailPreScanResult` — `BulkSummary` carries a
+  count plus the id(s) of the test(s) that filtered it, for an app that
+  wants to render why a message didn't make the list, rather than a bare
+  unauditable number; nothing existing was removed or renamed (#2743).
+  `NeedsYouItem.detail` is also new — reserved for a couple of lines of
+  real substance per row (the question actually asked, the meeting time
+  actually proposed, the deadline actually quoted) — but ships **always
+  empty** in this release: the
   per-item extraction pass that would fill it was implemented and then
   withdrawn before merge so it could ship on a firm timing budget rather
   than risk a slow scan; a follow-up will populate it.
@@ -186,9 +187,77 @@ behind any entry — API shapes, endpoints, and version semantics — see
   request/response shape is unchanged). This is **daemon-managed** — a standalone
   integrator using this package is unaffected and keeps resolving the mailbox from
   the local GAIA connector store exactly as before (#2154).
-
-## 0.6.0
-
+- **The agent's autonomy commands now work against the shipped binary.** `gaia
+  email autonomy status/set-level/pause/resume/run/undo/kill/trust` call REST
+  routes (`/v1/email/agent/autonomy*`) that did not exist in any previously
+  published binary — a sidecar installed from 0.5.0 or earlier 404'd on every
+  one of them, with nothing telling the caller why. All eight subcommands now
+  reach a real route and get back a 200, or a correct 409 when autonomy is
+  off (#2894).
+- **Muting a sender no longer buries their genuinely urgent mail as
+  promotional.** The category override for a muted (low-priority) sender was
+  unconditional — every message from that sender was force-classified
+  PROMOTIONAL regardless of content, which also made it an autonomy
+  auto-archive candidate with no confirmation. "I don't care about most of
+  this sender's mail" is not "this specific message is never urgent" —
+  category is now always decided by content; muting only affects ordering
+  (#2774).
+- **Scanning a real Gmail inbox no longer fails outright on a rate limit.** A
+  scan batching 100 messages in one request reliably tripped Gmail's
+  per-user concurrency limit, and a single 429 discarded the other 99
+  already-successful results with the whole scan failing on
+  `CONNECTOR_ERROR`. Batches are now chunked to a measured-safe size, a 429
+  is retried with backoff, and a message still rate-limited after retrying
+  is dropped individually and reported — not thrown away with everything
+  else (#2727).
+- **A counting question about a long-bodied sender no longer overflows the
+  model's context and comes back empty.** Searching messages defaulted to
+  fetching full bodies, and a "how many emails from X in the last two
+  weeks?" question against a verbose sender could blow the context window
+  before the model produced an answer. The search now defaults to metadata
+  only (subject/from/date/snippet, no body) — a counting or listing question
+  never needed the body — cutting the result size by roughly an order of
+  magnitude (#2782).
+- **A fresh conversation's first inbox listing or search could overflow the
+  NPU profile's context window before you got a reply.** `listInbox` /
+  `searchMessages` capped each message's body independently but never
+  checked the COMBINED size of the result — a realistic 25-message inbox
+  built a response over the NPU profile's 32K-token budget on the very
+  first call, and the overflow sometimes surfaced as a silently truncated
+  count (10 requested, 8 returned) rather than an error. Both now shrink
+  every message's body together to fit the active device's budget; a
+  request too large even at the smallest usable body size fails with an
+  actionable error naming the limit instead of quietly returning less than
+  asked for (#2514).
+- **Calendar answers can no longer invent attendee names or invite
+  confirmations that aren't in the mailbox.** Asked "did anyone send me a
+  meeting invite?", the agent could answer "yes" with no message,
+  mutation, or attachment behind it — a real `organizer` field was
+  sometimes narrated as "sent you an invite." Calendar listing and
+  conflict checks now surface each event's real `attendees` (an event with
+  none normalizes to `[]` instead of the field being omitted), and two new
+  checks catch an invite or attendee claim the tool result doesn't support
+  before it reaches you. Scoped to calendar attendee/invite claims only —
+  not a general claim about hallucination elsewhere (#2766).
+- **A reply, draft, or send could report failure even after it actually
+  succeeded, and retrying made it worse.** A transient local bookkeeping
+  write, unrelated to the real Gmail/Outlook call, could fail right after
+  the message was actually sent or the draft actually created — and that
+  bookkeeping failure was surfaced as if the whole action had failed.
+  Retrying then hit an already-consumed draft id. `draft()`/`send()`/forward
+  now report success whenever the real mail action succeeded regardless of
+  that local write, and retrying an already-sent draft gets a plain "already
+  sent" instead of a generic error (#2908).
+- **The triage card is now assembled from the scan's own data, not retyped
+  by the model.** The categorized breakdown the model used to compose
+  freehand — numbering, message counts, addresses — could drift from the
+  scan that produced it: a number pointing at the wrong message, an item
+  repeated or dropped, or a bare item count with no list at all. The card is
+  now rendered directly from the same `needs_you` data the scan already
+  computed — a template fill, not a generation — so a reference like
+  `archive 3` always names the message actually shown as 3; the model still
+  writes the opening sentence and nothing else. On a 55-item real inbox this
+  completed in under a minute end to end (#2858).
 - **The launch secret no longer sits in the sidecar's environment.** The
   per-session auth token used to be handed to the sidecar as a bare environment
   variable, visible to any local process that can inspect process environments.

--- a/hub/agents/email/npm/EVALUATION.md
+++ b/hub/agents/email/npm/EVALUATION.md
@@ -3,7 +3,7 @@
 Short version: we measure how reliably the agent sorts email into the right
 priority, using a fixed set of labeled emails and comparing its answer to the
 correct one. The current result is on the
-[**Scorecard**](https://github.com/amd/gaia/blob/agent-pkg-email-v0.5.0/hub/agents/email/npm/SCORECARD.md)
+[**Scorecard**](https://github.com/amd/gaia/blob/agent-pkg-email-v0.6.0/hub/agents/email/npm/SCORECARD.md)
 tab. This page explains what that number means and how it's measured — in plain
 terms first, with the technical recipe at the end.
 
@@ -57,7 +57,7 @@ changes.
 You need a source checkout of [amd/gaia](https://github.com/amd/gaia) and **AMD
 Ryzen AI hardware** (the npm package ships neither the test corpus nor the eval
 harness). The exact, version-stamped command lives in the
-[Scorecard's *Reproduction* section](https://github.com/amd/gaia/blob/agent-pkg-email-v0.5.0/hub/agents/email/npm/SCORECARD.md#reproduction)
+[Scorecard's *Reproduction* section](https://github.com/amd/gaia/blob/agent-pkg-email-v0.6.0/hub/agents/email/npm/SCORECARD.md#reproduction)
 — it's auto-generated so it always matches the published number. Run that block;
 it installs the eval tools, starts a local model server, rebuilds the test emails
 from the committed seed, and runs the benchmark (~17 minutes on a 4B model).

--- a/hub/agents/email/npm/README.md
+++ b/hub/agents/email/npm/README.md
@@ -11,7 +11,7 @@ by a local AI model (via AMD's Lemonade runtime); message content is never sent 
 a cloud service, and that's enforced when the agent starts up.
 
 > Using an AI coding assistant? This package ships a
-> [`SKILL.md`](https://github.com/amd/gaia/blob/agent-pkg-email-v0.5.0/hub/agents/email/npm/SKILL.md)
+> [`SKILL.md`](https://github.com/amd/gaia/blob/agent-pkg-email-v0.6.0/hub/agents/email/npm/SKILL.md)
 > — load it into Claude Code (or similar) for a copy-paste integration playbook.
 
 ## What it can do
@@ -150,7 +150,7 @@ Nothing for you to do or change: there is no set to pin, and passing
 `--skill-set` / `GAIA_EMAIL_SKILL_SET` fails at startup saying so rather than
 quietly doing nothing. Re-enabling is a change inside the agent, not in your
 integration. Full detail in
-[`SPEC.md`](https://github.com/amd/gaia/blob/agent-pkg-email-v0.5.0/hub/agents/email/npm/SPEC.md).
+[`SPEC.md`](https://github.com/amd/gaia/blob/agent-pkg-email-v0.6.0/hub/agents/email/npm/SPEC.md).
 
 ## How it works
 
@@ -163,20 +163,20 @@ Three pieces, all on your own machine — no cloud, no separate GAIA install:
   machine's local network only.
 
 Full architecture, the complete API, authentication, and every endpoint are in
-[`SPEC.md`](https://github.com/amd/gaia/blob/agent-pkg-email-v0.5.0/hub/agents/email/npm/SPEC.md).
+[`SPEC.md`](https://github.com/amd/gaia/blob/agent-pkg-email-v0.6.0/hub/agents/email/npm/SPEC.md).
 
 ## How good is the triage?
 
 Scores **84.53 / 100** on a labeled benchmark inbox — see the **Scorecard** tab (or
-[`SCORECARD.md`](https://github.com/amd/gaia/blob/agent-pkg-email-v0.5.0/hub/agents/email/npm/SCORECARD.md))
+[`SCORECARD.md`](https://github.com/amd/gaia/blob/agent-pkg-email-v0.6.0/hub/agents/email/npm/SCORECARD.md))
 for the full breakdown, and the **Evaluation** tab for how it's measured.
 
 ## Reference
 
-- [`SPEC.md`](https://github.com/amd/gaia/blob/agent-pkg-email-v0.5.0/hub/agents/email/npm/SPEC.md) — full API, authentication, lifecycle, connectors, and platforms.
-- [`SKILL.md`](https://github.com/amd/gaia/blob/agent-pkg-email-v0.5.0/hub/agents/email/npm/SKILL.md) — integration playbook for AI coding assistants.
-- [`SCORECARD.md`](https://github.com/amd/gaia/blob/agent-pkg-email-v0.5.0/hub/agents/email/npm/SCORECARD.md) / [`EVALUATION.md`](https://github.com/amd/gaia/blob/agent-pkg-email-v0.5.0/hub/agents/email/npm/EVALUATION.md) — eval results and how they're measured.
-- [`CHANGELOG.md`](https://github.com/amd/gaia/blob/agent-pkg-email-v0.5.0/hub/agents/email/npm/CHANGELOG.md) — what's new in each version.
+- [`SPEC.md`](https://github.com/amd/gaia/blob/agent-pkg-email-v0.6.0/hub/agents/email/npm/SPEC.md) — full API, authentication, lifecycle, connectors, and platforms.
+- [`SKILL.md`](https://github.com/amd/gaia/blob/agent-pkg-email-v0.6.0/hub/agents/email/npm/SKILL.md) — integration playbook for AI coding assistants.
+- [`SCORECARD.md`](https://github.com/amd/gaia/blob/agent-pkg-email-v0.6.0/hub/agents/email/npm/SCORECARD.md) / [`EVALUATION.md`](https://github.com/amd/gaia/blob/agent-pkg-email-v0.6.0/hub/agents/email/npm/EVALUATION.md) — eval results and how they're measured.
+- [`CHANGELOG.md`](https://github.com/amd/gaia/blob/agent-pkg-email-v0.6.0/hub/agents/email/npm/CHANGELOG.md) — what's new in each version.
 
 ## License
 

--- a/hub/agents/email/npm/assets/architecture.html
+++ b/hub/agents/email/npm/assets/architecture.html
@@ -83,7 +83,7 @@
   <div class="card" id="card">
     <div class="head">
       <span class="pkg">@amd-gaia/agent-email</span>
-      <span class="ver" id="ver">v0.5.0</span>
+      <span class="ver" id="ver">v0.6.0</span>
       <span class="tag">architecture</span>
     </div>
     <div class="install"><span class="p mono">$</span><code>npm i @amd-gaia/agent-email</code></div>

--- a/hub/agents/email/npm/binaries.lock.json
+++ b/hub/agents/email/npm/binaries.lock.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": "1.0",
-  "agentVersion": "0.5.0",
-  "baseUrl": "https://hub.amd-gaia.ai/agents/email/0.5.0",
+  "agentVersion": "0.6.0",
+  "baseUrl": "https://hub.amd-gaia.ai/agents/email/0.6.0",
   "binaries": {
     "win32-x64": {
       "filename": "email-agent-win32-x64.exe",

--- a/hub/agents/email/npm/package.json
+++ b/hub/agents/email/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amd-gaia/agent-email",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "type": "module",
   "description": "Thin JS/TS client + build-time binary fetcher + sidecar lifecycle helpers for the GAIA email agent (frozen, no-Python REST sidecar). Runs 100% locally on AMD Ryzen AI.",
   "author": "AMD AI Group",

--- a/hub/agents/email/npm/test/query-integration.test.ts
+++ b/hub/agents/email/npm/test/query-integration.test.ts
@@ -87,7 +87,7 @@ describe.skipIf(!python)("query() against the real sidecar (dev mode)", () => {
 
   it("reports apiVersion 2.4 (the handshake already accepted it at startup)", async () => {
     const v = await sidecar.client.version();
-    expect(v.apiVersion).toBe("2.4");
+    expect(v.apiVersion).toBe("2.14");
   });
 
   it("streams the canonical status -> tool_call -> tool_result -> final sequence", async () => {

--- a/hub/agents/email/python/CHANGELOG.md
+++ b/hub/agents/email/python/CHANGELOG.md
@@ -5,7 +5,7 @@ Format loosely follows [Keep a Changelog](https://keepachangelog.com/); the REST
 contract version is tracked separately as
 `gaia_agent_email.contract.SCHEMA_VERSION` (see `CONTRACT.md`).
 
-## [Unreleased]
+## [0.6.0] - 2026-08-12
 
 ### Added
 
@@ -201,9 +201,10 @@ contract version is tracked separately as
   buckets plus the waiting-on-you detector and persisted action items —
   never re-derived from raw scan results, so nothing those buckets already
   caught can go missing from it. `bulk.filter_tests` carries opaque ids (never
-  prose) a renderer maps to a sentence, so "47 filtered" always names the
-  test that filtered it. `NeedsYouItem.due_hint` (action items only) is
-  wrapped in the same untrusted-input delimiters that cover a raw message
+  prose) that a renderer can map to a sentence naming the test that filtered
+  a message, rather than a bare unauditable count. `NeedsYouItem.due_hint`
+  (action items only) is wrapped in the same untrusted-input delimiters
+  that cover a raw message
   body — it is regex-extracted verbatim from a message body and re-enters
   the calling agent's own tool-result context while that agent holds
   archive/send/delete authority. Nothing existing was removed, renamed, or
@@ -221,6 +222,22 @@ contract version is tracked separately as
   was never budgeted for. A follow-up will populate it, bounded to a
   deadline so a slow extraction degrades to partial detail rather than a
   stalled card.
+- **The triage card is now rendered from the scan's own data instead of
+  retyped by the model (#2858).** The chat model was previously asked to
+  transcribe a list the tools had already computed — categories, numbering,
+  addresses — and that transcription could drift from the underlying scan:
+  a number pointing at a different message than the one shown under it, an
+  item dropped or duplicated, or no list at all despite a populated scan.
+  Categorization is still model judgement (heuristic, then the
+  `specific-ai-triage` SLM, then an LLM fallback, all inside
+  `pre_scan_inbox`); the breakdown itself is now rendered directly from
+  `needs_you` via a `finalize_answer` hook on the base agent, so a
+  reference like `archive 3` always resolves to the message actually shown
+  as row 3, and the same deterministic corrections (calendar-conflict,
+  attention-card, invite-claim, fabricated-attendee) now reach the stream
+  and the console, not just an unread return value. On a 55-item real
+  inbox on the NPU profile this completed in under a minute, with no
+  timeout, on the CLI-to-daemon relay path.
 - **The inbox-scan default is now owned in one place (#2743, closing the loop
   #2643 started).** `config.DEFAULT_INBOX_SCAN_MESSAGES` (50) is now the
   single source every scan-default call site imports instead of restating a
@@ -327,6 +344,14 @@ contract version is tracked separately as
   every other `gaia email` command (no second auth scheme): `status`,
   `set-level`, `pause`, `resume`, `run`, `trust`, `kill`. Closes the gap where
   the code and the plan doc both described this command before it existed.
+- **The autonomy CLI now works against a real installed sidecar, not just
+  this checkout (#2894).** The `/v1/email/agent/autonomy*` routes above did
+  not exist in any binary published before this release, so `gaia email
+  autonomy status` (and every other subcommand) 404'd for anyone running an
+  installed sidecar rather than a source checkout, with nothing explaining
+  why. This release is the first where the shipped binary actually serves
+  those routes: every subcommand now reaches a real route and returns 200,
+  or a correct 409 when autonomy is off.
 
 ### Fixed
 
@@ -803,6 +828,20 @@ contract version is tracked separately as
   request too large even at the smallest usable body size fails with an
   actionable error naming the limit instead of silently returning less
   than was asked for.
+- **A counting question about a long-bodied sender no longer overflows the
+  model's context and comes back with an apology instead of an answer
+  (#2782).** Asking "how many emails from X in the last two weeks?" against
+  a verbose sender ran the search correctly, then blew the context window
+  re-reading the full body of every result and gave up — reproduced 8 of 8
+  times across two machines. `search_messages` now defaults to metadata
+  only (subject/from/date/snippet, no body): a counting or listing question
+  never needed the body, and metadata cuts the result size by roughly an
+  order of magnitude. A docstring instruction telling the model to pass
+  `include_bodies=False` for a counting question was tried first and
+  measured to fail live — the model didn't reliably do it — so the fix
+  flips the tool's *default* instead, which holds regardless of what the
+  model does. A turn that still can't fit now names the actual constraint
+  rather than a generic "had to trim the conversation" apology.
 - **Calendar listing and conflict checks no longer 400 on a date-only range,
   and never end a turn narrating a retry that didn't happen (#2517).**
   `list_calendar_events` and `detect_calendar_conflicts` forwarded a
@@ -964,7 +1003,7 @@ contract version is tracked separately as
     fully-trusted sender — a parity test locks the policy floor to the agent's
     real `CONFIRMATION_REQUIRED_TOOLS`. Only reversible actions auto-execute,
     each with undo via `action_store`.
-  - **It learns from your corrections.** `record_autonomy_outcome` is the single
+  - **A correction pulls trust back down.** `record_autonomy_outcome` is the single
     funnel every trust signal flows through; undoing an auto-archive (through the
     real `undo_archive_batch` tool) is captured automatically as a negative outcome
     and pulls trust back below the bar, updating both the sender and the category

--- a/hub/agents/email/python/gaia-agent.yaml
+++ b/hub/agents/email/python/gaia-agent.yaml
@@ -1,6 +1,6 @@
 id: email
 name: Email Triage
-version: 0.5.0
+version: 0.6.0
 description: "GAIA email triage agent — read, triage, organize, and reply to Gmail/Outlook locally"
 author: AMD
 license: MIT

--- a/hub/agents/email/python/gaia_agent_email/version.py
+++ b/hub/agents/email/python/gaia_agent_email/version.py
@@ -28,7 +28,7 @@ from gaia_agent_email.contract import SCHEMA_VERSION
 # Package build version. Keep in sync with ``pyproject.toml``'s ``version`` —
 # ``test_rest_contract.test_agent_version_matches_package_metadata`` asserts the
 # installed distribution metadata agrees with this literal so the two never drift.
-AGENT_VERSION = "0.5.0"
+AGENT_VERSION = "0.6.0"
 
 # REST/contract version exposed to hosts. Aliased to the frozen contract's
 # SCHEMA_VERSION so a contract bump is an API bump — no second number to forget.

--- a/hub/agents/email/python/pyproject.toml
+++ b/hub/agents/email/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "gaia-agent-email"
-version = "0.5.0"
+version = "0.6.0"
 description = "GAIA email triage agent — read, triage, organize, and reply to Gmail/Outlook locally"
 authors = [{ name = "AMD" }]
 license = { text = "MIT" }


### PR DESCRIPTION
Autonomy commands now work end to end where the shipped v0.5.0 binary 404'd on every one of them — `gaia email autonomy status/set-level/pause/resume/run/undo/kill/trust` reach real routes now. The triage card is deterministically rendered from the scan's own data instead of retyped by the model, mailbox reconnects can no longer silently narrow a working connection down to identity-only scopes, and a Gmail 429 no longer kills an entire scan. Also closes #2302 — the npm CHANGELOG had a stray, never-actually-published "## 0.6.0" heading left over from an earlier release attempt that stayed at 0.5.0; its content is folded into this real 0.6.0 instead of shipping as a duplicate header.

Closes #2302.

### Verified

- Frozen-binary autonomy routes are live: darwin frozen binary + Linux source build both confirmed `gaia email autonomy status` -> 200 (previously 404 on every subcommand against any published binary — v0.5.0 shipped zero autonomy routes).
- 1980/1980 python tests and 111/111 npm tests pass (npm run included the `query-integration.test.ts` suite against a real spawned sidecar, not skipped — confirms the fixed `SCHEMA_VERSION` assertion and the live handshake reporting `apiVersion=2.14`).
- Deterministic triage rendering: a real 55-item Outlook inbox triaged via `gaia email -q "Triage my inbox"` (source build, Linux/NPU, CLI-to-daemon relay) completed in 24.4s and 57.4s across two runs, exit 0, no timeout — template-filled from the scan's own `needs_you` data, not model-generated prose.
- Triage confirmed working across Windows/Linux/macOS (user-confirmed); 0.6.0's own contribution is the render-from-scan mechanism, honest truncation, and stable counts — not "triage now works," which it already did in 0.5.0.
- Safety floor intact: `send_now`/forward/RSVP/quarantine remain confirmation-gated at every autonomy level; `permanent_delete` was removed from the tool surface entirely (not just left unreachable) in #2533.

### Held back

- **Adaptive trust-building** — not claimed. #2392 retracted the earlier "the agent learns from you" framing: the trust ledger only ratchets *down* on a correction: positive-outcome accrual (trust rising as suggestions are accepted) is still not wired. Retitled the changelog entry accordingly.
- **A blanket "no more hallucination" claim** — not made. The two grounding fixes that shipped (#2908 send-status, #2766 calendar attendee/invite) are scoped to exactly what they fixed; two adjacent issues (#2914 fabricated draft success, #2916 audit-write masking deletes) are still open.
- **Skills on by default** — not the case. The six bundled skills ship in the package but no set is declared, so none of them load; this is opt-in only (#2848).
- **Vector search / long-term memory** — not claimed. `faiss-cpu` isn't in the frozen binary; the feature degrades gracefully but is absent from what actually ships.
- **The "count of what was filtered" UX claim** — softened. The drafted changelog said a filtered-out count is shown to the user as an auditable "N filtered" line; a live run showed the underlying `BulkSummary` field is real, but didn't confirm that sentence actually renders anywhere today. Changelog now describes the field as an integrator-facing capability, not a delivered UX claim.

### Release checklist

- [x] version 0.6.0 in all three files (`gaia-agent.yaml`, `pyproject.toml`, npm `package.json`) — plus `version.py`'s `AGENT_VERSION` literal, which the version-bump tool doesn't touch, and every derived reference (`binaries.lock.json`, README/EVALUATION doc links, the architecture.html badge) synced via `packaging/stamp_version.py --check` (zero drift).
- [x] CHANGELOG dated (`## [0.6.0] - 2026-08-12` in both packages)
- [x] npm build+test green (`npm ci && npm run build && npm test` — 111/111)
- [ ] tag `agent-pkg-email-v0.6.0` from `main` after merge
- [ ] maintainer approves the `agent-publish` gate

### Test plan

- [x] `gaia agent version minor --path hub/agents/email/python` + manual npm `package.json` sync — all three (four, counting `version.py`) agree at 0.6.0
- [x] `python hub/agents/email/python/packaging/stamp_version.py --check` — zero drift across every stamped target
- [x] `npm ci && npm run build && npm test` in `hub/agents/email/npm/` — 111/111 passing (11 files, 0 skipped)
- [x] `npm pack hub/agents/email/npm --dry-run` — confirms `README.md` + `CHANGELOG.md` ship, version 0.6.0
- [x] Full `hub/agents/email/python/tests/` suite — 1980/1980 passing
- [x] `python util/lint.py --all` — Black/isort/Pylint/Flake8/Import Validation/Agent Conventions all pass (the one Bandit failure is pre-existing, in vendored `apps/webui/node_modules/node-gyp`, unrelated to this change)
