### PR TITLE
ci(release): document the agent-publish tag allowlist gap

### DIFF
--- a/.github/workflows/release_components.yml
+++ b/.github/workflows/release_components.yml
@@ -120,6 +120,10 @@ jobs:
     name: Publish terminal-hub
     needs: version
     runs-on: ubuntu-latest
+    # agent-publish gates on a deployment tag allowlist that lives in repo settings,
+    # not here: it must include v* or every release tag is rejected before any step
+    # runs (#2935). It also requires a reviewer, so admitted v* runs pause for approval,
+    # same as the agent-pkg-* tags the sibling release workflows already use.
     environment: agent-publish
     steps:
       - uses: actions/checkout@v7
@@ -223,6 +227,7 @@ jobs:
     name: Publish agent-ui
     needs: version
     runs-on: ubuntu-latest
+    # Same tag-allowlist requirement as terminal-hub above (#2935).
     environment: agent-publish
     steps:
       - uses: actions/checkout@v7


### PR DESCRIPTION
Publishing the Hub components (the `gaia tui` binary and the Agent UI installers) to R2 is rejected on every release tag. The `agent-publish` environment's deployment tag allowlist only admits `agent-pkg-*` tags, not the `v*` tags this workflow actually triggers on — and nothing in the workflow file itself hints that a setting elsewhere is the gate.

**This PR does not fix #2935.** The real fix is widening that environment's tag allowlist, which is a repository-admin action outside a workflow diff. What lands here is a short comment next to both `environment: agent-publish` lines recording the constraint, so the next person reusing this pattern for a differently-named tag isn't blocked by an invisible rule. Refs #2935 (not Closes).

## Evidence

<details>
<summary>Workflow diff</summary>

```diff
diff --git a/.github/workflows/release_components.yml b/.github/workflows/release_components.yml
index d70e1b05..a339f212 100644
--- a/.github/workflows/release_components.yml
+++ b/.github/workflows/release_components.yml
@@ -120,6 +120,10 @@ jobs:
     name: Publish terminal-hub
     needs: version
     runs-on: ubuntu-latest
+    # agent-publish gates on a deployment tag allowlist that lives in repo settings,
+    # not here: it must include v* or every release tag is rejected before any step
+    # runs (#2935). It also requires a reviewer, so admitted v* runs pause for approval,
+    # same as the agent-pkg-* tags the sibling release workflows already use.
     environment: agent-publish
     steps:
       - uses: actions/checkout@v7
@@ -223,6 +227,7 @@ jobs:
     name: Publish agent-ui
     needs: version
     runs-on: ubuntu-latest
+    # Same tag-allowlist requirement as terminal-hub above (#2935).
     environment: agent-publish
     steps:
       - uses: actions/checkout@v7
```

</details>

<details>
<summary>Before-state: agent-publish's deployment tag allowlist has no v* rule</summary>

```
$ gh api /repos/amd/gaia/environments/agent-publish/deployment-branch-policies
{"total_count":2,"branch_policies":[{"id":52248873,"name":"main","type":"branch"},{"id":52248904,"name":"agent-pkg-*","type":"tag"}]}
```

</details>

<details>
<summary>The failing v0.23.0 run this issue reports</summary>

```
$ gh run view 31703403949 --json jobs --jq '.jobs[] | {name, conclusion}'
{"conclusion":"success","name":"Resolve & gate version"}
{"conclusion":"failure","name":"Publish terminal-hub"}
{"conclusion":"failure","name":"Publish agent-ui"}
{"conclusion":"skipped","name":"Redeploy website"}
```

</details>

## Test plan

- [x] `python -c "import yaml,sys; yaml.safe_load(open('.github/workflows/release_components.yml')); print('YAML OK')"` → `YAML OK`
- [x] `git diff main...HEAD --name-only` → exactly one file, `.github/workflows/release_components.yml`
- [ ] Out of scope for this PR: a run actually reaching the `agent-publish` gate under a `v*` tag — that requires the environment's tag allowlist to be widened first (the repository-admin step this PR intentionally does not make)