### PR TITLE
fix(email-agent): sdist missing _build_hooks.py and gaia-agent.yaml

### DIFF
--- a/.github/workflows/test_email_agent_unit.yml
+++ b/.github/workflows/test_email_agent_unit.yml
@@ -126,12 +126,16 @@ jobs:
           # [dev] covers the email + eval unit tests (pytest, pytest-mock,
           # respx, keyring, httpx). [api] adds fastapi/uvicorn, which the
           # tests/unit/connectors/ router tests import via the UI connectors
-          # router. The in-memory keyring backend in tests/conftest.py avoids
-          # the SecretService daemon prerequisite on Linux runners. The email
-          # hub package is installed so the REST-contract + OpenAPI-conformance
-          # tests can import gaia_agent_email (they build the app in-process and
-          # mock Lemonade — no server needed).
-          uv pip install --system -e ".[dev,api]" -e hub/agents/email/python
+          # router. [publish] adds the 'build' package (#2934): the sdist
+          # packaging regression test builds a real sdist with --no-isolation
+          # against this env's already-installed setuptools, so it needs
+          # 'build' present but never touches the network. The in-memory
+          # keyring backend in tests/conftest.py avoids the SecretService
+          # daemon prerequisite on Linux runners. The email hub package is
+          # installed so the REST-contract + OpenAPI-conformance tests can
+          # import gaia_agent_email (they build the app in-process and mock
+          # Lemonade — no server needed).
+          uv pip install --system -e ".[dev,api,publish]" -e hub/agents/email/python
 
       - name: Run email-agent unit tests
         # NOTE: do NOT set GAIA_MEMORY_DISABLED here. The hub/agents/email/python

--- a/hub/agents/email/python/MANIFEST.in
+++ b/hub/agents/email/python/MANIFEST.in
@@ -1,0 +1,3 @@
+# Both required at build time by _build_hooks.py's build_py (see pyproject.toml [tool.setuptools.cmdclass]).
+include _build_hooks.py
+include gaia-agent.yaml

--- a/hub/agents/email/python/tests/test_sdist_packaging_2934.py
+++ b/hub/agents/email/python/tests/test_sdist_packaging_2934.py
@@ -1,0 +1,118 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""sdist packaging guard for the email agent's build hook (#2934).
+
+The wheel build depends on two files that live at the package ROOT, sibling
+to ``pyproject.toml`` -- not inside ``gaia_agent_email/``: ``_build_hooks.py``
+(wired via ``[tool.setuptools.cmdclass]``) and ``gaia-agent.yaml`` (staged
+into the package by that hook -- see ``_build_hooks.py``). Neither is a
+Python module inside the package, and neither matches
+``[tool.setuptools.package-data]``'s glob (which cannot reach outside its own
+package), so nothing declared them for sdist inclusion until ``MANIFEST.in``.
+
+``test_skill_sets_2466.py`` already asserts the cmdclass wiring and loads
+``_build_hooks.py`` by path from the source tree -- both pass even when the
+sdist is broken, which is exactly why this bug shipped. This test instead
+builds a REAL sdist with the real setuptools backend and reads its member
+list, so a regression in what actually ships is caught, not a string match
+against pyproject.toml/MANIFEST.in.
+
+This is a narrow, single-package sdist-*contents* guard, not a reversal of
+``publish_agents.yml``'s decision to stop building all 14 agent wheels on
+every PR (that build was "pure noise" per that workflow's own comment,
+deferring broken-wheel detection to release time) -- it runs one lightweight
+``--sdist``-only build for the one package whose build depends on files
+outside its own package data.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import shutil
+import subprocess
+import sys
+import tarfile
+from pathlib import Path
+
+import pytest
+
+_PKG_ROOT = Path(__file__).resolve().parents[1]
+
+# setuptools' egg_info step writes SOURCES.txt into the SOURCE tree, not
+# --outdir. A leftover copy from an earlier local build can make sdist skip
+# regenerating the file list -- silently masking the exact MANIFEST.in
+# regression this test exists to catch.
+_STALE_BUILD_STATE = (
+    _PKG_ROOT / "gaia_agent_email.egg-info",
+    _PKG_ROOT / "build",
+)
+
+
+def _clear_stale_build_state() -> None:
+    for stale_dir in _STALE_BUILD_STATE:
+        shutil.rmtree(stale_dir, ignore_errors=True)
+
+
+def test_sdist_includes_build_hook_and_agent_manifest(tmp_path):
+    """A real ``--sdist`` build must ship both root-level files the build needs.
+
+    Fails loudly (not skipped) if the ``build`` package isn't installed --
+    it ships in the ``[publish]`` extra (``setup.py``), not ``[dev]``, so a
+    plain ``pip install -e ".[dev,api]"`` will not have it.
+    """
+    if importlib.util.find_spec("build") is None:
+        pytest.fail(
+            "the 'build' package is required to run this test but is not "
+            "installed. Install the [publish] extra: "
+            "pip install -e '.[publish]' (see setup.py's 'publish' extra).",
+            pytrace=False,
+        )
+
+    _clear_stale_build_state()
+    try:
+        result = subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "build",
+                "--sdist",
+                # Use the already-installed setuptools instead of creating an
+                # isolated build env that fetches it from PyPI -- this suite
+                # runs with no network.
+                "--no-isolation",
+                "--outdir",
+                str(tmp_path),
+                str(_PKG_ROOT),
+            ],
+            capture_output=True,
+            text=True,
+            timeout=120,
+        )
+    finally:
+        _clear_stale_build_state()
+
+    assert result.returncode == 0, (
+        f"sdist build failed (exit {result.returncode}):\n"
+        f"--- stdout ---\n{result.stdout}\n--- stderr ---\n{result.stderr}"
+    )
+
+    sdists = sorted(tmp_path.glob("*.tar.gz"))
+    assert sdists, f"no sdist produced in {tmp_path}:\n{result.stdout}\n{result.stderr}"
+
+    with tarfile.open(sdists[0]) as tf:
+        names = tf.getnames()
+
+    assert any(name.endswith("/_build_hooks.py") for name in names), (
+        "_build_hooks.py is missing from the sdist. The wheel step imports it "
+        "as a top-level module via [tool.setuptools.cmdclass], so rebuilding "
+        "a wheel from this sdist (as a PyPI consumer with no matching wheel, "
+        "or CI's build-agent-wheel action, would) fails with "
+        "ModuleNotFoundError: _build_hooks. Declare it in MANIFEST.in."
+    )
+    assert any(name.endswith("/gaia-agent.yaml") for name in names), (
+        "gaia-agent.yaml is missing from the sdist. It lives at the package "
+        "root and [tool.setuptools.package-data] cannot reach outside "
+        "gaia_agent_email/, so it needs its own MANIFEST.in entry -- without "
+        "it, _build_hooks.py's build_py hook cannot stage it and the wheel "
+        "build fails with 'gaia-agent.yaml not found next to pyproject.toml'."
+    )


### PR DESCRIPTION
Tagging a release build for the email agent fails outright: the published source archive is missing two files the build depends on, not just the one the failure message names, so applying only the fix the failure suggests clears that error and immediately hits a second, previously hidden one. This change declares both files for inclusion, so the `Publish Agent Wheels (PyPI)` build job and the on-demand `Share Agent Package (GitHub Release)` workflow can produce the email agent's wheel again. PyPI publishing itself stays paused repo-wide for every agent wheel (a separate, pre-existing gate) — this restores the ability to build the package, not to publish it.

**The fix suggested in the issue is insufficient.** Declaring only `_build_hooks.py` (the file named in the failure) clears the reported `ModuleNotFoundError` but fails on the very next step, on a second file (`gaia-agent.yaml`) the build also needs but that never appeared in any error message — see the step-2 reproduction below. Both files need their own inclusion rule, so the fix here is a two-line `MANIFEST.in`, not a `pyproject.toml` change.

No other package under `hub/agents/*/python/` shares this root cause: none of the other 14 wheel-publish packages (`setup.py`'s `AGENT_WHEEL_PACKAGES`) declare a custom `cmdclass`, and none reference `gaia-agent.yaml` from their `pyproject.toml` — the email agent is the only one whose own runtime code reads that manifest. This is also the first `MANIFEST.in` under `hub/agents/`.

Closes #2934

## Test plan

- [x] `python -m build --outdir hub/agents/email/python/dist hub/agents/email/python` exits 0 and writes both a `.tar.gz` and a `.whl`
- [x] `tar -tzf dist/gaia_agent_email-*.tar.gz` lists both `_build_hooks.py` and `gaia-agent.yaml`
- [x] `unzip -l dist/*.whl` shows `gaia_agent_email/gaia-agent.yaml` and no top-level `_build_hooks.py`
- [x] `twine check dist/*` reports PASSED for both artifacts
- [x] `python -m pytest hub/agents/email/python/tests/ -q` — 1981 passed, including the new regression test, which fails on the pre-fix tree (both the fully unfixed tree and the issue's own suggested fix)
- [x] `python util/lint.py --all` — all checks pass

<details>
<summary>Reproduction: three-step build trace</summary>

**1. Unfixed tree — matches the issue's reported failure:**

```
$ python -m build --outdir hub/agents/email/python/dist hub/agents/email/python
...
  File ".../setuptools/config/expand.py", line 199, in _find_spec
    raise ModuleNotFoundError(module_name)
ModuleNotFoundError: _build_hooks
ERROR Backend subprocess exited when trying to invoke get_requires_for_build_wheel

$ tar -tzf hub/agents/email/python/dist/*.tar.gz | grep -E '_build_hooks|gaia-agent\.yaml'
(no output — both files are absent from the sdist)
```

**2. Half-fixed tree — the issue's own suggested fix (`_build_hooks.py` declared, `gaia-agent.yaml` still not):**

```
$ python -m build --outdir hub/agents/email/python/dist hub/agents/email/python
...
error: gaia-agent.yaml not found next to pyproject.toml (.../gaia_agent_email-0.5.0/gaia-agent.yaml). It is
required: the built package stages it inside gaia_agent_email/ so the agent can resolve its declared skill
sets at runtime.
ERROR Backend subprocess exited when trying to invoke build_wheel
```

Past the reported error, straight into the next one — the issue's fix moves the failure, it doesn't remove it.

**3. Fixed tree — both files declared in `MANIFEST.in`:**

```
$ python -m build --outdir hub/agents/email/python/dist hub/agents/email/python
...
Successfully built gaia_agent_email-0.5.0.tar.gz and gaia_agent_email-0.5.0-py3-none-any.whl

$ tar -tzf hub/agents/email/python/dist/*.tar.gz | grep -E '_build_hooks|gaia-agent\.yaml'
gaia_agent_email-0.5.0/_build_hooks.py
gaia_agent_email-0.5.0/gaia-agent.yaml

$ unzip -l hub/agents/email/python/dist/*.whl | grep -E 'gaia-agent.yaml|build_hooks'
     3596  ...   gaia_agent_email/gaia-agent.yaml

$ twine check hub/agents/email/python/dist/*
Checking .../gaia_agent_email-0.5.0-py3-none-any.whl: PASSED with warnings
Checking .../gaia_agent_email-0.5.0.tar.gz: PASSED with warnings
```

</details>
