### PR TITLE
fix(tests): exclude docs/releases/ from the tenant-var drift guard

### DIFF
--- a/tests/unit/connectors/test_microsoft_tenant_env_var_removed.py
+++ b/tests/unit/connectors/test_microsoft_tenant_env_var_removed.py
@@ -17,15 +17,22 @@ Modeled on ``test_catalog_docs_url.py`` / ``test_google_console_scope_docs_drift
 ``hub/agents/email/npm/CHANGELOG.md`` is deliberately out of scope: it is a
 historical record of what a past release did, not current configuration, and
 lives outside both roots this test scans.
+
+``docs/releases/`` gets the same carve-out, for the same reason: release notes
+announcing a removal have to name the variable, and unlike the changelog above
+they live inside ``_DOCS_ROOT``, so ``_scanned_files()`` excludes the
+directory explicitly.
 """
 
 from __future__ import annotations
 
+import sys
 from pathlib import Path
 
 _REPO_ROOT = Path(__file__).resolve().parents[3]
 _SRC_ROOT = _REPO_ROOT / "src" / "gaia"
 _DOCS_ROOT = _REPO_ROOT / "docs"
+_DOCS_RELEASES_ROOT = _DOCS_ROOT / "releases"
 
 _NEEDLE = "GAIA_MICROSOFT_TENANT"
 
@@ -36,7 +43,11 @@ def _scanned_files() -> list[Path]:
     files: list[Path] = []
     for root in (_SRC_ROOT, _DOCS_ROOT):
         files.extend(
-            p for p in root.rglob("*") if p.is_file() and p.suffix in _SCANNED_SUFFIXES
+            p
+            for p in root.rglob("*")
+            if p.is_file()
+            and p.suffix in _SCANNED_SUFFIXES
+            and not p.is_relative_to(_DOCS_RELEASES_ROOT)
         )
     return files
 
@@ -64,4 +75,42 @@ def test_env_var_never_reappears_in_src_or_docs():
         "— tenant resolution never read it, and the migration guard that used "
         "to validate it is gone. Do not reintroduce the variable, the guard, "
         "or docs advice referencing it."
+    )
+
+
+def test_docs_releases_exclusion_is_scoped(tmp_path, monkeypatch):
+    """The ``docs/releases/`` carve-out must not blind the guard to other docs.
+
+    Builds a throwaway tree so a reintroduction anywhere else under ``docs/``
+    still trips the guard, while a release note announcing a removal stays
+    exempt.
+    """
+    src_root = tmp_path / "src" / "gaia"
+    docs_root = tmp_path / "docs"
+    releases_root = docs_root / "releases"
+    guides_root = docs_root / "guides"
+    for directory in (src_root, releases_root, guides_root):
+        directory.mkdir(parents=True)
+
+    (releases_root / "v9.9.9.mdx").write_text(
+        f"### `{_NEEDLE}` is gone\n", encoding="utf-8"
+    )
+    (guides_root / "misplaced.mdx").write_text(
+        f"Set `{_NEEDLE}` to configure your tenant.\n", encoding="utf-8"
+    )
+
+    module = sys.modules[__name__]
+    monkeypatch.setattr(module, "_SRC_ROOT", src_root)
+    monkeypatch.setattr(module, "_DOCS_ROOT", docs_root)
+    monkeypatch.setattr(module, "_DOCS_RELEASES_ROOT", releases_root)
+
+    offenders = {
+        p.relative_to(tmp_path).as_posix(): p.read_text(encoding="utf-8").count(_NEEDLE)
+        for p in _scanned_files()
+        if p.read_text(encoding="utf-8").count(_NEEDLE)
+    }
+
+    assert offenders == {"docs/guides/misplaced.mdx": 1}, (
+        "docs/releases/ should be excluded and docs/guides/ should still be "
+        f"caught, got: {offenders}"
     )


### PR DESCRIPTION
`main` has shown all four `Unit Tests` jobs (py3.10/3.11/3.12, macOS smoke) plus `Email Agent Unit Tests` red since the v0.23.0 release merged, and every PR that touches a matching path inherits the same unrelated failure. A drift guard asserting `GAIA_MICROSOFT_TENANT` never reappears in `src/gaia/` or `docs/` doesn't distinguish between reintroducing the variable and the release notes correctly announcing its removal, so it fails against its own documentation.

Excludes `docs/releases/` from the guard's scanned tree — the guard already makes this exact carve-out for the email-agent changelog on the grounds that it's "a historical record of what a past release did, not current configuration"; release notes are the same category, they just happen to live inside a root the guard already scans.

The exclusion is scoped, not a blanket weakening: a new test builds a throwaway tree (via `tmp_path`/`monkeypatch`) proving a reintroduction anywhere else under `docs/` still trips the guard, and a real reintroduction was planted and reverted locally to confirm the same by hand.

Closes #2942

## Test plan

- [x] `python -m pytest tests/unit/connectors/test_microsoft_tenant_env_var_removed.py -v` — RED on unmodified `main` (`GAIA_MICROSOFT_TENANT reappeared: {'docs/releases/v0.23.0.mdx': 3}`), GREEN after the fix, all 3 tests pass
- [x] New `test_docs_releases_exclusion_is_scoped` passes: a planted string under `docs/releases/` is excluded, a planted string under `docs/guides/` still trips the guard
- [x] A temporary reintroduction was planted directly in a non-release doc, confirmed the guard still fails, then reverted
- [x] `python -m pytest tests/unit/connectors/` — 759 passed, 8 skipped, 0 failed (no regressions)
- [x] `python util/lint.py --all` — all quality checks pass