### PR TITLE
fix(tests): auto-approve the gated MCP tool in the custom-agent harness

### DIFF
--- a/tests/installer/test_custom_agent_mcp_harness.py
+++ b/tests/installer/test_custom_agent_mcp_harness.py
@@ -22,6 +22,7 @@ from typing import Iterable
 
 import pytest
 
+from gaia.agents.base.console import SilentConsole
 from gaia.agents.registry import AgentRegistry
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
@@ -136,7 +137,15 @@ def test_custom_agent_dummy_mcp_path_uses_installed_bundle(
     assert "Imported: installer-mcp" in result.stdout
 
     registry = _discover_agent("installer-mcp")
-    agent = registry.create_agent("installer-mcp", mcp_config_file=str(mcp_config))
+    # mcp_dummy_add_two_numbers is confirmation-gated (#2475) and this harness
+    # has no terminal to ask on; opt this trusted run in explicitly rather than
+    # via GAIA_AUTO_APPROVE_TOOLS, which gaia.pre_dotenv_env snapshots at the
+    # process's first `import gaia` — long before a test body could set it.
+    agent = registry.create_agent(
+        "installer-mcp",
+        mcp_config_file=str(mcp_config),
+        output_handler=SilentConsole(auto_approve_gated_tools=True),
+    )
 
     try:
         response = agent.process_query("add 7 and 35")


### PR DESCRIPTION
The installer's MCP smoke test failed on every run, which failed `Build complete`, which skipped every publish step of a release — this is why the last tag published nothing despite every installer and package building successfully. The failure wasn't the MCP path itself; it was a security confirmation gate (added in #2475) correctly refusing to run a tool with no human to ask, because the test never told it this is a trusted automated run.

Marks the one test that calls a gated tool as a trusted run, using the console-level opt-in rather than the `GAIA_AUTO_APPROVE_TOOLS` env var: `gaia.pre_dotenv_env` snapshots the process environment at the first `import gaia`, which happens at test-collection time — before a test body's `monkeypatch.setenv` could ever take effect. The env var remains the documented escape for hosts that can set it before the process starts; this harness just can't reach it in time, so it uses the equivalent constructor opt-in instead.

Does not touch the gate itself — the other three tests in this harness, and the gate's own directional tests, are unmodified.

## Test plan

- [x] Reproduced the failure locally: `assert 'denied' == 'success'`, same as CI
- [x] `pytest tests/fixtures/mcp/dummy_server/test_dummy_server.py tests/installer/test_custom_agent_mcp_harness.py -v` — all 4 pass (the exact command CI runs)
- [x] `python util/lint.py --all` — all quality checks pass
- [ ] CI green on this PR (ubuntu-latest + windows-latest)

Closes #2944
