### PR TITLE
fix(ci): install the publish extra in test_email_agent.yml

### DIFF
--- a/.github/workflows/test_email_agent.yml
+++ b/.github/workflows/test_email_agent.yml
@@ -78,7 +78,10 @@ jobs:
         run: |
           # [api] adds fastapi/uvicorn — the email REST-spec tests
           # (test_spec_html.py) import the contract's api_routes module.
-          uv pip install --system -e .[dev,api]
+          # [publish] adds the 'build' package (#2934): hub/agents/email/python/tests/
+          # includes the sdist packaging regression test, which builds a real
+          # sdist with --no-isolation and fails loudly without 'build' present.
+          uv pip install --system -e .[dev,api,publish]
           # EmailTriageAgent ships as the standalone gaia-agent-email wheel (#1102)
           uv pip install --system -e hub/agents/email/python
 


### PR DESCRIPTION
main is red: `test_email_agent.yml` fails on every push and PR because the sdist-packaging regression test it collects (`hub/agents/email/python/tests/test_sdist_packaging_2934.py`, added in #2938) needs the `build` package, which that workflow's install step never installs. #2938 added the `[publish]` extra to `test_email_agent_unit.yml`'s install line but missed `test_email_agent.yml`, which collects the same `hub/agents/email/python/tests/` directory — this is that follow-up.

## Test plan

- [x] Reproduced: throwaway venv installed with the current `.[dev,api]` line hits the exact CI failure (`the 'build' package is required to run this test but is not installed...`)
- [x] Fixed: same venv with `.[dev,api,publish]` — the sdist test passes
- [x] Ran the full command `test_email_agent.yml` executes (all 18 test paths) — 3218 passed, 1 pre-existing unrelated skip (`connectors-demo not loaded`), corpus-skip guard step also passes
- [x] `python util/lint.py --all` — 0 failures