### PR TITLE
fix(release): emit release notes as short bullets, not prose

### DIFF
--- a/.claude/skills/gaia-release/SKILL.md
+++ b/.claude/skills/gaia-release/SKILL.md
@@ -54,7 +54,7 @@ These map to [CLAUDE.md](../../../CLAUDE.md). Re-read them whenever this skill r
 - **Plain language first, in every artifact** — the release notes, PR body, Discord post, and your own between-phase status updates all follow [CLAUDE.md → How You Communicate](../../../CLAUDE.md#how-you-communicate): lead with what a user can now do, layer version numbers, SHAs, and pipeline mechanics underneath. Say each point once — don't restate a highlight in the changelog and again in the announcement.
 - **No Claude attribution anywhere** — not in PR titles, PR bodies, commit messages (no `Co-Authored-By: Claude ...` trailer), release notes, code comments, or the Discord announcement.
 - **No silent fallbacks** — if a validator fails, a step times out, or a workflow run isn't found, stop with an actionable error. Do not retry blindly. Do not "proceed anyway."
-- **Match house style for release notes** — see *Generation parameters* in Phase 1. In short: value-prop first, **local agents are the headline** (not the SDK), one agent/command per highlight, plain language, engaging but factual, and **no emoji, no fluff** (full banned-phrase list under *Generation parameters*). Read the **last 2–3 release notes** before drafting. Patch releases do **not** include a `pip install` block. Use the `Why upgrade:` framing with a short bullet list, then `## What's New`, then `## Bug Fixes`, then `## Full Changelog`.
+- **Release notes are bulleted, plain, and short** — see *Notes format* in Phase 1. Every entry is one bullet, never a prose block; no narrative overview paragraph; no emoji; a hard word budget that is checked, not eyeballed. Sections in order: `## Breaking Changes` (only if any), `## What's New`, `## Bug Fixes`, `## Known Issues` (only if any), `## Contributors`, `## Full Changelog`. Patch releases do **not** include a `pip install` block.
 - **Match the previous release PR body shape exactly** — read the most recent merged `Release vX.Y.Z` PR (e.g. `gh pr list --repo amd/gaia --state merged --search "Release v in:title" --limit 3`). Open with `# GAIA vX.Y.Z Release Notes` (no MDX frontmatter in the PR body), end with a `Release checklist` section. Style drift here costs review cycles.
 - **Bulletproof commits only** — every change made by this skill must satisfy the four criteria in CLAUDE.md (validated, critiqued, scope-clean, no half-finished work) before being committed.
 - **Pushing tags is irreversible.** Always confirm the SHA the tag will point to and the green status of the pre-tag verification run before `git push origin v<version>`.
@@ -91,48 +91,43 @@ These map to [CLAUDE.md](../../../CLAUDE.md). Re-read them whenever this skill r
 
    If the requested version doesn't match the rubric, **stop and surface the mismatch**: *"You asked for `v<requested>` (patch). I see N feat commits since `<prev>` including `<one or two examples>` — this looks minor-shaped. Continue as patch, or bump to `v<suggested>`?"* Do not silently proceed.
 
-2. **Read the last 2–3 release notes** to match structure and length (not tone — see *Generation parameters*).
-   - [docs/releases/v0.17.4.mdx](../../../docs/releases/v0.17.4.mdx)
-   - [docs/releases/v0.17.3.mdx](../../../docs/releases/v0.17.3.mdx)
-   - [docs/releases/v0.17.2.mdx](../../../docs/releases/v0.17.2.mdx)
+2. **Read recent release notes for structure only** — frontmatter shape, section headings, PR-link format. Take **length and tone from *Notes format* below, not from the files**: [v0.21.1](../../../docs/releases/v0.21.1.mdx) is the model at 267 narrative words, while v0.22.0 (1705) and v0.23.0 (1119) were flagged in review as too much text in too-blocky a form — they are the regression this section exists to prevent.
 
-   Cross-check: same frontmatter shape, same section headings, same *structure* and length per entry — but **not** the prior tone. The last few releases predate the *Generation parameters* below; match their shape, not their dryness. Patch releases are short; minor/major releases include `pip install` and may have a "Highlights" block.
+   Patch releases are short. Minor/major releases carry more bullets and a `pip install` block — the per-bullet shape is identical, only the count grows.
 
 3. **Create [docs/releases/v<version>.mdx](../../../docs/releases/)** with this skeleton (adapt to whether it's patch / minor / major):
 
    ```mdx
    ---
    title: "v<version>"
-   description: "<one-line elevator pitch — what shipped, who benefits>"
+   description: "<one plain line: what shipped. Not a pitch.>"
    ---
 
    # GAIA v<version> Release Notes
 
-   <One-paragraph overview: what kind of release this is and what it covers.>
+   <Optional single sentence naming what this release is about. Drop it entirely if
+   the bullets already say it — that is the common case. Never a paragraph.>
 
-   **Why upgrade:**
-   - **<short title>** — <one-line value-and-mechanism>.
-   - **<short title>** — <one-line value-and-mechanism>.
+   ## Breaking Changes
 
-   ---
+   - **<what changed>** — <what to do instead>. (PR [#NNN](https://github.com/amd/gaia/pull/NNN))
 
    ## What's New
 
-   ### <What the user can now do> — `<gaia command>`
-
-   <Lead with the outcome and why it matters, in plain language that makes the reader
-   want to try it. Then one line on how to run it, PR linked inline. One agent or
-   command per entry — add another `### ` block for the next one. Not every highlight
-   is a command — for UI / SDK / perf items, use a plain title with no trailing
-   command.>
-
-   ---
+   - **<what the user can now do>** — `<gaia command>`. <At most one more sentence, only
+     if the title genuinely needs it.> (PRs [#NNN](https://github.com/amd/gaia/pull/NNN), [#NNN](https://github.com/amd/gaia/pull/NNN))
 
    ## Bug Fixes
 
-   - **<title>** (PR [#NNN](https://github.com/amd/gaia/pull/NNN)) — <one-line description of fix and impact>.
+   - **<what was broken>** — <what now happens>. (PR [#NNN](https://github.com/amd/gaia/pull/NNN))
 
-   ---
+   ## Known Issues
+
+   - **<what still does not work>** — <workaround, or "tracked in [#NNN](https://github.com/amd/gaia/issues/NNN)">.
+
+   ## Contributors
+
+   - [@handle](https://github.com/handle) — <what they contributed>. (PR [#NNN](https://github.com/amd/gaia/pull/NNN))
 
    ## Full Changelog
 
@@ -143,6 +138,9 @@ These map to [CLAUDE.md](../../../CLAUDE.md). Re-read them whenever this skill r
 
    Full Changelog: [v<previous>...v<version>](https://github.com/amd/gaia/compare/v<previous>...v<version>)
    ```
+
+   Omit `## Breaking Changes` and `## Known Issues` when empty — no "None" placeholder. Drop
+   the `---` rules between sections; the headings already separate them.
 
    **Generate the changelog by introspecting git, and escape it for MDX.** Do not
    hand-transcribe subjects, and do not pipe `git log` output in raw — a subject
@@ -168,39 +166,41 @@ These map to [CLAUDE.md](../../../CLAUDE.md). Re-read them whenever this skill r
    claimed 197 when the real count was 198). The claimed count, the listed lines, and
    `git log` must all agree.
 
-   **Generation parameters (apply to every entry — this is the point of the skill).**
-   GAIA's notes have historically read dry and engineering-first: they say *what
-   changed* but not *why a user should care or want to try it*. Generate against these
-   every time:
+   **Notes format (apply to every entry — this is the point of the skill).** Tone is
+   already governed by [CLAUDE.md → How You Communicate](../../../CLAUDE.md#how-you-communicate)
+   — plain language, outcome first, each point made exactly once. Do not restate or soften
+   it here. What *is* release-notes-specific is the shape:
 
-   - **Value-prop first.** Open each entry with what the user can now do and why it
-     matters — the outcome, not the implementation. "Triage your inbox in one command"
-     before "added EmailAgent with Gmail polling".
-   - **Local agents are the headline.** Lead with the agents that solve real problems
-     (`gaia browse`, `gaia analyze`, email triage, …); SDK / infra / refactors are
-     supporting detail. People come for the agents, not the SDK.
-   - **One agent or command per highlight.** `gaia browse` and `gaia analyze` each get
-     their own `### ` entry with its own one-line utility — never lumped together.
-   - **Plain, human language.** Write like you're telling a colleague what they can do
-     now. Short sentences; plain words over jargon.
-   - **Engaging, still factual.** Make the reader want to try it without overselling —
-     no invented benchmarks, no "fastest ever". The pull comes from a clear, real
-     capability, not adjectives.
-   - **No fluff, no emoji.** Banned: emoji in headings or body, "we're excited to
-     announce", "finally", "blazing(-fast)", "Here's the good stuff", "no more
-     crashes", "silently", "game-changer".
+   - **Bullets, not paragraphs.** Every entry is one bullet: a bold clause naming what the
+     user can now do, then at most one sentence, then the PR links. No `###` prose blocks
+     inside `What's New`.
+   - **Say it once.** A highlight appears in the bullet list or in the opening sentence,
+     never both. The frontmatter `description` is not a third copy.
+   - **Factual, not promotional.** State the capability and stop. Banned: emoji, "we're
+     excited to announce", "finally", "blazing(-fast)", "game-changer", "seamless",
+     "powerful", "unlock", "Here's the good stuff", "makes X effortless", "no more
+     crashes", invented benchmarks.
+   - **Order by what users run.** Agents and commands first (`gaia hub`, `gaia email`, …);
+     SDK, CI, and refactor work last, or omitted when it has no user-visible effect.
+   - **Word budget — a cap, not a target.** **≤ 350 words** for a patch, **≤ 600** for a
+     minor/major, measured from the top down to the first of `## Bug Fixes` / `## Known
+     Issues` / `## Contributors` / `## Full Changelog`. Those four are reference lists —
+     their length is set by how many fixes actually shipped, and squeezing them hides work.
+     The cap is on the narrative part, which is what bloats. Over budget means cut entries,
+     not reflow them. Step 8 checks it. (Calibration, same measure: v0.21.1 shipped at 267,
+     v0.22.0 at 1705, v0.23.0 at 1119.)
 
-   **Example — one highlight, done right:**
+   **Example — one highlight:**
 
-   > **Bad** (dry, implementation-first, no reason to care):
-   > ### EmailAgent
-   > Adds an EmailAgent with Gmail polling and a rules engine for classification.
-
-   > **Good** (value-first, plain, makes you want to try it):
+   > **Bad** (prose block, promotional, three sentences where one works):
    > ### Triage your inbox from the terminal — `gaia email`
    > Point GAIA at your inbox and it sorts the noise from what needs you: drafts
    > replies to routine mail, flags what's urgent, leaves the rest. Runs locally, so
    > your mail never leaves your machine. Try it: `gaia email`.
+
+   > **Good** (one bullet, plain, factual):
+   > - **Triage your inbox from the terminal** — `gaia email` sorts mail, drafts replies to
+   >   routine messages, and flags what needs you. Runs locally. (PR [#1234](https://github.com/amd/gaia/pull/1234))
 
 4. **Update [docs/docs.json](../../../docs/docs.json):**
    - Add `releases/v<version>` to the Releases tab.
@@ -249,6 +249,11 @@ These map to [CLAUDE.md](../../../CLAUDE.md). Re-read them whenever this skill r
    ```bash
    python util/validate_release_notes.py docs/releases/v<version>.mdx --tag v<version>
    (cd docs && npx -y mintlify@latest validate)   # the docs.yml `validate` job — MUST also pass
+
+   # Word budget from *Notes format* — the narrative part only, not the reference lists.
+   # Cap: 350 words for a patch, 600 for a minor/major. Over budget means cut entries.
+   awk '/^## (Bug Fixes|Known Issues|Contributors|Full Changelog)/{exit} {print}' \
+     docs/releases/v<version>.mdx | wc -w
    ```
    Both must exit 0. Fix any errors before continuing. If either fails for reasons unrelated to your changes (missing dep, broken import), stop and surface that — do not silently bypass. `validate_release_notes.py` prints the first failing check (missing/renamed section, absent `compare/` link, tag mismatch) — read that line to localise the fix; it has no `--verbose` flag.
 
@@ -460,7 +465,7 @@ Show the user the run URL, the **release PR number** (`#$RELEASE_PR`), and the *
    ```
    Required artifacts: `.whl`, `.tar.gz`, `.deb`, `.AppImage`, `.dmg`, `.exe`, and the `latest*.yml` files for the Electron auto-updater. If any are missing, the corresponding build job didn't run or didn't upload — investigate.
 
-3. **Draft the Discord announcement.** Read the just-shipped release notes (`docs/releases/v<version>.mdx`) to populate the highlight list — one bullet per "What's New" entry plus any Bug Fix worth surfacing, written in the same voice as the notes — apply the same *Generation parameters* (value-prop first, plain, engaging, no fluff/emoji).
+3. **Draft the Discord announcement.** Read the just-shipped release notes (`docs/releases/v<version>.mdx`) to populate the highlight list — reuse the `What's New` bullets near-verbatim plus any Bug Fix worth surfacing. Same *Notes format* rules apply: bullets, plain, factual, no emoji.
 
    **The template and format rules live in**
    [`reference/discord-announcement.md`](reference/discord-announcement.md) — read it and

--- a/.claude/skills/gaia-release/reference/discord-announcement.md
+++ b/.claude/skills/gaia-release/reference/discord-announcement.md
@@ -4,8 +4,9 @@ The house format for the `#announcements` Discord post, cut at the end of Phase 
 [`gaia-release`](../SKILL.md) skill. This is the v0.22.0 shape — the format the maintainer
 actually posts.
 
-Populate the highlights from the just-shipped `docs/releases/v<version>.mdx`, in the same
-voice as the notes: value-prop first, plain, engaging, no fluff, no emoji.
+Populate the highlights from the just-shipped `docs/releases/v<version>.mdx` — reuse its
+`What's New` bullets near-verbatim. Same rules as the notes (*Notes format* in the skill):
+one bullet per highlight, plain, factual, no emoji, no pitch.
 
 ## Template (copy verbatim, fill the bracketed fields)
 

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1491,7 +1491,8 @@ jobs:
           # Note: claude-code-action does not support workflow_run events natively.
           # Using automation mode (via `prompt`) to bypass event type validation.
           prompt: |
-            Generate comprehensive release notes for GAIA version ${{ steps.tag.outputs.TAG_NAME }}.
+            Generate release notes for GAIA version ${{ steps.tag.outputs.TAG_NAME }}.
+            Short, plain, and bulleted — see the format and word budget below.
 
             ## FIRST ACTIONS
             1. Read release-context.txt - Contains commit log, contributors, PRs, and list of diff files
@@ -1530,41 +1531,43 @@ jobs:
             ```
             ---
             title: "${{ steps.tag.outputs.TAG_NAME }}"
-            description: "[One-line summary of this release]"
+            description: "[One plain line: what shipped. Not a pitch.]"
             ---
             ```
 
-            Then use this content structure for both files:
+            Then use this content structure for both files. Sections and shape must match
+            `.claude/skills/gaia-release/SKILL.md` (*Notes format*, Phase 1) exactly — both
+            generators write `docs/releases/<tag>.mdx`, so a divergence here makes the file's
+            shape depend on which one happened to run.
+
+            Bullets, not paragraphs. Every entry is one bullet, never a prose block.
 
             # GAIA ${{ steps.tag.outputs.TAG_NAME }} Release Notes
 
-            ## Overview
-
-            [2-3 sentence summary of the most important changes. Highlight major new features, significant improvements, or breaking changes.]
-
-            ## What's New
-
-            ### 🚀 [Major Feature Name]
-            [Description with code example if applicable]
-
-            [Continue for each major new feature...]
-
-            ## Improvements
-
-            ### [Category - e.g., Agent UX, Performance, etc.]
-            - **[Improvement name]**: [Brief description]
-
-            ## Bug Fixes
-
-            - **#[issue]**: [Description of fix]
-
-            ## Infrastructure
-
-            - [Change description]
+            [Optional single sentence naming what this release is about. Drop it if the
+            bullets already say it — that is the common case. Never a paragraph, and never
+            an "## Overview" section.]
 
             ## Breaking Changes
 
-            [List any breaking changes, or "None. All changes are additive."]
+            - **[what changed]** - [what to do instead]. (PR #[number])
+
+            ## What's New
+
+            - **[what the user can now do]** - `[gaia command]`. [At most one more sentence,
+              only if the title genuinely needs it.] (PRs #[number], #[number])
+
+            ## Bug Fixes
+
+            - **[what was broken]** - [what now happens]. (PR #[number])
+
+            ## Known Issues
+
+            - **[what still does not work]** - [workaround, or "tracked in #[number]"].
+
+            ## Contributors
+
+            - @[handle] - [what they contributed]. (PR #[number])
 
             ## Full Changelog
 
@@ -1575,14 +1578,33 @@ jobs:
 
             Full Changelog: [${{ env.PREVIOUS_TAG }}...${{ steps.tag.outputs.TAG_NAME }}](https://github.com/amd/gaia/compare/${{ env.PREVIOUS_TAG }}...${{ steps.tag.outputs.TAG_NAME }})
 
+            Omit `## Breaking Changes` and `## Known Issues` when there are none — do not emit
+            an empty section or a "None. All changes are additive." placeholder.
+
             ## Guidelines
 
-            1. **Be specific** - Reference actual file changes, not generic descriptions
-            2. **Include code examples** - For new features, show how to use them
-            3. **Categorize properly**: 🚀 new features, 🎯 improvements, 🐛 bug fixes, 🔧 infrastructure, 📚 docs, 🔒 security
-            4. **Link PRs and issues** - Use #number format
-            5. **Credit contributors** - Mention contributors for significant changes
-            6. **Highlight AMD-specific features** - NPU optimizations, Ryzen AI features
+            1. **Plain language, outcome first** - say what a user can now do, in the words
+               they would use. CLAUDE.md "How You Communicate" governs this output too.
+            2. **Bulleted and short** - one bullet per entry, at most two sentences in it.
+               No `###` prose blocks, no code examples, no walkthroughs.
+            3. **Word budget (a cap, not a target)** - from the top down to the first of
+               `## Bug Fixes` / `## Known Issues` / `## Contributors` / `## Full Changelog`,
+               total <= 350 words for a patch release, <= 600 for a minor/major. Those four are
+               reference lists sized by how many fixes shipped; squeezing them hides work. The
+               cap is on the narrative part. Over budget means cut entries, not reflow them.
+               Count before finishing:
+               `awk '/^## (Bug Fixes|Known Issues|Contributors|Full Changelog)/{exit} {print}' <file> | wc -w`
+            4. **Factual, not promotional** - state the capability and stop. No emoji anywhere,
+               in headings or body. Banned: "we're excited to announce", "finally",
+               "blazing(-fast)", "game-changer", "seamless", "powerful", "unlock",
+               "makes X effortless", invented benchmarks.
+            5. **Specific, not generic** - name the actual command, flag, or behavior that
+               changed, not "various improvements".
+            6. **Order by what users run** - agents and commands first, including AMD-specific
+               capabilities (NPU, Ryzen AI) when they ship; SDK, CI, and refactor work last, or
+               omitted when it has no user-visible effect.
+            7. **Link PRs and issues** - use the #number format.
+            8. **Credit contributors** - one comma-separated line under `## Contributors`.
 
             ## What NOT to Include
 


### PR DESCRIPTION
Release notes had grown into long blocks of prose with a marketing-toned paragraph on top. They now generate as short bullets grouped by section, with a word cap on the narrative part. Nothing informational is lost — every PR link, contributor credit, and changelog entry is preserved; the prose around them is cut.

Two generators write `docs/releases/<tag>.mdx` and they had drifted apart. The `gaia-release` skill told the model GAIA's notes "read dry" and to make them "engaging"; the `release-notes` job in `claude.yml` asked for "comprehensive" notes with an `## Overview` paragraph and emoji headings. Fixing one alone would have been overwritten by the other on the next tag, so both now share one spec.

Closes #2961

## What it looks like now

Regenerated from the last two releases — same facts, same PR numbers, new template. Narrative words (the capped part, excluding bug-fix/contributor/changelog lists):

| Release | Published | Regenerated | Cap |
|---|---|---|---|
| v0.22.0 (minor) | 1705 | **538** | 600 |
| v0.23.0 (minor) | 1119 | **280** | 600 |

<details>
<summary>Example 1 — v0.23.0 regenerated</summary>

```markdown
---
title: "v0.23.0"
description: "Install and run agents from the terminal, add capabilities as skills, and connect a Microsoft account without a secret."
---

# GAIA v0.23.0 Release Notes

Agents are now installable from the terminal, and the confirmation gate that pauses an agent before a consequential action works everywhere, not just in the Agent UI.

## Breaking Changes

- **`GAIA_MICROSOFT_TENANT` is gone** — the Microsoft connector split into Personal and Work/School, each with its own tenant. Drop the variable and pick the matching connector. (PR [#2729](https://github.com/amd/gaia/pull/2729))

## What's New

- **Install and run agents from the terminal** — `gaia hub list`, `gaia hub install <agent> --trust`, `gaia hub uninstall <agent>`. `--trust` is required for an unverified agent. (PRs [#2484](https://github.com/amd/gaia/pull/2484), [#2530](https://github.com/amd/gaia/pull/2530), [#2708](https://github.com/amd/gaia/pull/2708))
- **Every agent asks before it acts** — the confirmation gate for sending mail, writing files, and running commands now fires from the terminal, the local API, and MCP tool calls, not only the Agent UI. Set `GAIA_AUTO_APPROVE_TOOLS=1` to opt out. (PRs [#2475](https://github.com/amd/gaia/pull/2475), [#2544](https://github.com/amd/gaia/pull/2544), [#2846](https://github.com/amd/gaia/pull/2846), [#2854](https://github.com/amd/gaia/pull/2854))
- **Safer by default** — the MCP bridge binds to localhost and enforces `--auth-token`; the local API refuses credentialed cross-origin requests from non-allow-listed sites; MCP servers launch without a shell; agents cannot write to `~/.gaia` or pass crafted SQL to the database agent. (PRs [#2246](https://github.com/amd/gaia/pull/2246), [#2238](https://github.com/amd/gaia/pull/2238), [#2344](https://github.com/amd/gaia/pull/2344), [#2844](https://github.com/amd/gaia/pull/2844), [#2847](https://github.com/amd/gaia/pull/2847), [#2860](https://github.com/amd/gaia/pull/2860))
- **Add capabilities as skills** — `gaia skill create|import|list|info` gives an agent a new capability from a folder and a manifest. Skills are signed with trust tiers, audited before publish, and opt-in. (PRs [#2669](https://github.com/amd/gaia/pull/2669), [#2692](https://github.com/amd/gaia/pull/2692), [#2702](https://github.com/amd/gaia/pull/2702), [#2693](https://github.com/amd/gaia/pull/2693))
- **Connect a Microsoft account without a secret** — Personal and Work/School are separate connectors with device-code sign-in. (PRs [#2718](https://github.com/amd/gaia/pull/2718), [#2364](https://github.com/amd/gaia/pull/2364))
- **Lemonade Server 11.5.0.**

## Bug Fixes

- **Triage paginates large inboxes and reports truncation** (PR [#2646](https://github.com/amd/gaia/pull/2646)) — mail past a hidden limit is no longer dropped without saying so.
- **Thread messages come back sorted and numbered** (PR [#2570](https://github.com/amd/gaia/pull/2570)) — "reply to 3" hits the message shown at position 3.
- **The inbox pre-scan reports uncertainty as uncertainty** (PR [#2587](https://github.com/amd/gaia/pull/2587)).
- **An email conversation survives its turns** (PR [#2837](https://github.com/amd/gaia/pull/2837)) — a follow-up keeps session context.
- **A bare reconnect keeps existing grants** (PR [#2733](https://github.com/amd/gaia/pull/2733)).
- **Restore from Trash anytime** (PR [#2542](https://github.com/amd/gaia/pull/2542)) — no time window on undo.
- **Sender priority no longer overrides content classification** (PR [#2774](https://github.com/amd/gaia/pull/2774)).
- **The agent survives an OpenMP double-init** (PR [#2508](https://github.com/amd/gaia/pull/2508)).
- **Large tool results truncate to valid JSON** (PR [#2645](https://github.com/amd/gaia/pull/2645)).
- **A missing model surfaces as a real 404** (PR [#2245](https://github.com/amd/gaia/pull/2245)).
- **GPU is detected on all platforms and `default_device` is honoured** (PR [#2244](https://github.com/amd/gaia/pull/2244)).
- **A sidecar that is alive but not serving is detected** (PR [#2707](https://github.com/amd/gaia/pull/2707)).
- **The model-slot lease is held across inference** (PR [#2394](https://github.com/amd/gaia/pull/2394)) — a second agent can't evict the model mid-generation.
- **A browser that never launched is surfaced** (PR [#2507](https://github.com/amd/gaia/pull/2507)).
- **Stop aborts in-flight streaming** (PR [#2166](https://github.com/amd/gaia/pull/2166)).

## Known Issues

- **The email agent is beta and CLI-first** — treat its output as a draft to review.
- **A full inbox triage can time out on larger mailboxes.**
- **Email autonomy is experimental** and not wired up in the packaged sidecar.

## Contributors

- [@handle](https://github.com/handle) — <contribution> (PR [#NNN](https://github.com/amd/gaia/pull/NNN))
  <!-- generated from the commit log; v0.23.0's list is unchanged from the published notes -->


## Full Changelog

**N commits** since v0.22.0:

- `<sha>` — <subject>

Full Changelog: [v0.22.0...v0.23.0](https://github.com/amd/gaia/compare/v0.22.0...v0.23.0)
```
</details>

<details>
<summary>Example 2 — v0.22.0 regenerated (the largest recent release)</summary>

```markdown
---
title: "v0.22.0"
description: "The email agent tracks follow-ups and action items, drafts in your voice, and runs as its own process. Plus a cron scheduler and Word document support in RAG."
---

# GAIA v0.22.0 Release Notes

A large release built around the email agent, which now tracks what you're waiting on instead of forgetting it after triage.

## Breaking Changes

- **Triage returns a reply scaffold, not an empty draft** — `POST /v1/email/triage` and `/triage/batch` now return a `DraftScaffold` without `body`. Code reading `result.draft.body` gets a missing key instead of `""`; use `POST /v1/email/draft` for composed prose. (PR [#1984](https://github.com/amd/gaia/pull/1984))
- **RoutingAgent and DocumentQAAgent moved to standalone packages** — install `gaia-agent-routing` and `gaia-agent-docqa`. The old imports fail; there is no deprecation shim. (PR [#1455](https://github.com/amd/gaia/pull/1455))

## What's New

- **An inbox agent that keeps track** — `gaia email` scans Sent folders across every connected mailbox and flags threads still waiting on a reply past a window you set (default 3 days). Detection only; it never nudges anyone for you. (PRs [#1922](https://github.com/amd/gaia/pull/1922), [#1917](https://github.com/amd/gaia/pull/1917), [#1919](https://github.com/amd/gaia/pull/1919), [#1918](https://github.com/amd/gaia/pull/1918))
- **Drafts in your own voice** — the agent derives greeting, sign-off, length, and formality from your Sent history and composes against that. Only the derived characteristics are stored, never old mail content. (PR [#1925](https://github.com/amd/gaia/pull/1925))
- **Attachments work end to end** — triage surfaces each attachment's name, type, and size, and drafting and sending accept real attachments as Gmail multipart MIME or Outlook Graph attachments. (PRs [#1921](https://github.com/amd/gaia/pull/1921), [#1883](https://github.com/amd/gaia/pull/1883))
- **Email runs as its own process in the Agent UI (beta)** — install it from the Agent Hub panel and the UI talks to it over HTTP, instead of loading the email stack into the UI process. (PRs [#1884](https://github.com/amd/gaia/pull/1884), [#1910](https://github.com/amd/gaia/pull/1910), [#2100](https://github.com/amd/gaia/pull/2100), [#2101](https://github.com/amd/gaia/pull/2101), [#2105](https://github.com/amd/gaia/pull/2105))
- **Run prompts on a cron from the terminal** — `gaia schedule add --name digest --cron "0 9 * * *" --prompt "summarize my inbox" --sink stdout`, then `gaia schedule daemon`. Schedules live in a hand-editable `~/.gaia/schedules.toml`; sinks are `stdout`, `file:<path>`, `notification`, or `telegram`. (PR [#1371](https://github.com/amd/gaia/pull/1371))
- **Agents learn from work they repeat** — after enough successes on the same shape of goal, an agent distills the tool sequence into a reusable procedure and recalls it next time. Runs inside the existing memory pass; nothing to install. (PR [#1794](https://github.com/amd/gaia/pull/1794))
- **Pick your model once** — `gaia config set default_model <id>` persists across `gaia chat`, `gaia llm`, and `gaia prompt`. An explicit `--model` still wins for a one-off. (PR [#1863](https://github.com/amd/gaia/pull/1863))
- **RAG reads Word documents** — `.docx` files index like PDF and PPTX, including table cells, nested tables, content controls, hyperlinks, and textboxes, so filled-in form values get indexed. (PR [#1866](https://github.com/amd/gaia/pull/1866))
- **A new default embedder** — the previous default cannot be loaded by current llama.cpp builds, which broke indexing, code search, and memory embedding on an up-to-date Lemonade. The default is now EmbeddingGemma 300M at the same 768 dimensions. (PRs [#1952](https://github.com/amd/gaia/pull/1952), [#1761](https://github.com/amd/gaia/pull/1761), [#1748](https://github.com/amd/gaia/pull/1748))
- **The Agent Hub shows what an agent is worth** — an agent's page now carries its eval scorecard with a score badge and a code-derived capability matrix. (PRs [#1985](https://github.com/amd/gaia/pull/1985), [#2020](https://github.com/amd/gaia/pull/2020), [#2066](https://github.com/amd/gaia/pull/2066))
- **Lemonade Server 10.10.0** — adds an audio-generation endpoint, lets Windows reuse system ROCm, and inhibits suspend during inference. Two upstream breaking changes are Linux-specific. (PR [#1969](https://github.com/amd/gaia/pull/1969))

## Bug Fixes

- **`gaia init` said a working Lemonade wasn't installed** (PR [#1940](https://github.com/amd/gaia/pull/1940)) — modern Lemonade (10.7+) dropped the `lemonade-server` CLI that GAIA probed for.
- **Installing the email agent from the Hub failed on every platform** (PR [#2086](https://github.com/amd/gaia/pull/2086)).
- **Bulk triage broke on any real inbox** (PR [#2088](https://github.com/amd/gaia/pull/2088)) — 60 emails overflowed the 16K context window; the result envelope is now condensed.
- **RAG silently indexed nothing** (PR [#1979](https://github.com/amd/gaia/pull/1979)) — a failed `sentence-transformers` import made every indexing call a no-op.
- **Email bodies were truncated at 4,000 characters with no override** (PR [#2036](https://github.com/amd/gaia/pull/2036)) — MFA codes and precise replies lost content past the cutoff.
- **Long threads overflowed the model's context** (PR [#2076](https://github.com/amd/gaia/pull/2076)).
- **A disabled device was treated as usable** (PR [#2081](https://github.com/amd/gaia/pull/2081)) — a device reporting `available: false`, such as an unpowered NPU, was misread as ready.
- **A newly connected mailbox was skipped** (PR [#1808](https://github.com/amd/gaia/pull/1808)) — mailboxes connected mid-session were not picked up.
- **JSON with a `}` inside a string was dropped** (PR [#1824](https://github.com/amd/gaia/pull/1824)).
- **Outlook users were told to reconnect Google** (PR [#1757](https://github.com/amd/gaia/pull/1757)) — `AGENT_NOT_GRANTED` named the wrong provider.
- **The Agent UI hard-crashed on a recoverable GPU crash** (PR [#1799](https://github.com/amd/gaia/pull/1799)) — it now falls back to software rendering.
- **A user-edited memory could be silently downgraded and then wiped** (PR [#1958](https://github.com/amd/gaia/pull/1958)).
- **The builder agent ignored an agent name you had already given** (PR [#1981](https://github.com/amd/gaia/pull/1981)).
- **The landing and hub pages scrolled sideways on phones** (PR [#1959](https://github.com/amd/gaia/pull/1959)).

## Known Issues

- **Inbox pre-scan needs a single mailbox for now** — with both Gmail and Outlook connected, an Agent UI pre-scan errors. Disconnect one in Settings → Connectors; triage itself still spans every mailbox. ([#2127](https://github.com/amd/gaia/issues/2127))
- **Spam detection under-flags over the REST API** — `/v1/email/triage` uses a narrow sender check rather than the model's reading. The agent's own inbox scanning is unaffected. ([#2124](https://github.com/amd/gaia/issues/2124))
- **The email agent is beta** — treat its output as a draft to review. It never sends without your confirmation.

## Contributors

- [@alexey-tyurin](https://github.com/alexey-tyurin) — skill auto-synthesis / procedural memory (PR [#1794](https://github.com/amd/gaia/pull/1794))
- [@TravisHaa](https://github.com/TravisHaa) — the `gaia schedule` CLI and cron-based dispatch (PR [#1371](https://github.com/amd/gaia/pull/1371))
- [@Rohithmatham12](https://github.com/Rohithmatham12) — refresh resolved email backends before multi-mailbox triage (PR [#1808](https://github.com/amd/gaia/pull/1808))
- [@Osamaali313](https://github.com/Osamaali313) — fix `extract_json_from_text` dropping JSON containing `}` (PR [#1824](https://github.com/amd/gaia/pull/1824))
- [@eeee2345](https://github.com/eeee2345) — offline model-endpoint guard-proxy integration guide (PR [#1809](https://github.com/amd/gaia/pull/1809))
- [@somo9909](https://github.com/somo9909) — prerequisites section for the memory guide (PR [#1665](https://github.com/amd/gaia/pull/1665))

## Full Changelog

**N commits** since v0.21.2:

- `<sha>` — <subject>

Full Changelog: [v0.21.2...v0.22.0](https://github.com/amd/gaia/compare/v0.21.2...v0.22.0)
```
</details>

<details>
<summary>What changed in the templates</summary>

- The narrative overview paragraph and the `**Why upgrade:**` block are gone — the latter restated `What's New` verbatim.
- `What's New` entries are bullets, not `###` prose blocks.
- Tone guidance is no longer restated in the skill; it points at CLAUDE.md § How You Communicate.
- The skill's embedded example now shows the old prose block as **bad** and the bullet form as **good**.
- Emoji removed from the CI prompt (it asked for 🚀 / 🎯 / 🐛 headings against the skill's own no-emoji rule).
- Both generators now emit the same sections in the same order, so the file's shape no longer depends on which one ran.
- The cap excludes `Bug Fixes` / `Known Issues` / `Contributors` / `Full Changelog`. Those are reference lists sized by how many fixes shipped — capping them would hide work. This was caught by regenerating v0.22.0, which overflowed a whole-file cap purely on its 14 bug-fix bullets.

**Follow-up, not in this PR:** the cap lives in prompt text, so it is advisory. Making it a hard check in `util/validate_release_notes.py` would enforce it in CI.
</details>

## Test plan

- [ ] `python util/validate_release_notes.py <regenerated sample> --tag v0.23.0` exits 0 — passes unmodified, no validator changes in this PR
- [ ] `awk '/^## (Bug Fixes|Known Issues|Contributors|Full Changelog)/{exit} {print}' <file> | wc -w` is under 350 (patch) / 600 (minor-major)
- [ ] `.github/workflows/claude.yml` parses as valid YAML and its release-notes prompt contains no emoji
- [ ] `.claude/skills/gaia-release/SKILL.md` is under 500 lines (498)
- [ ] Both generators list the same sections in the same order
