### PR TITLE
fix(cli): exit non-zero from gaia agent status <id>, add --json

### DIFF
--- a/docs/reference/cli.mdx
+++ b/docs/reference/cli.mdx
@@ -536,7 +536,13 @@ gaia agent status            # every discovered agent
 ```
 
 ```bash Gate a script on a single agent
-gaia agent status chat --json | jq -e '.health == "healthy"'
+# Exit code alone is enough to gate on: 0 if installed, 1 if not.
+gaia agent status chat || echo "chat is not installed"
+
+# Or inspect the JSON. Passing the value with --arg keeps this working in
+# Windows PowerShell 5.1, which strips embedded double quotes from arguments
+# to native commands.
+gaia agent status chat --json | jq -e --arg v healthy '.health == $v'
 ```
 </CodeGroup>
 

--- a/docs/reference/cli.mdx
+++ b/docs/reference/cli.mdx
@@ -500,15 +500,19 @@ Manage an *installed* agent: set per-agent configuration, verify it loads, and i
 
 ```bash
 gaia agent configure <id> [--model NAME] [--set KEY=VALUE ...] [--replace] [--show]
-gaia agent health <id>
-gaia agent status [<id>]
+gaia agent health <id> [--json]
+gaia agent status [<id>] [--json]
 ```
 
 **`configure`** writes per-agent settings (e.g. a preferred model). `--set` values are JSON-decoded when possible (`--set temperature=0.2` stores a number, `--set verbose=true` a boolean), otherwise kept as strings. Settings merge into the existing config by default; pass `--replace` to overwrite it wholesale, or `--show` to print the current config without changing it.
 
-**`health`** verifies that an installed agent actually loads — its registration resolves and its entry point imports. It reports one of `healthy`, `degraded` (loads but something optional is off, e.g. a corrupt config), `error` (a required piece fails to load), or `not_installed`, and exits non-zero for `error` / `not_installed` so scripts can gate on it.
+**`health`** verifies that an installed agent actually loads — its registration resolves and its entry point imports. It reports one of `healthy`, `degraded` (loads but something optional is off, e.g. a corrupt config), `error` (a required piece fails to load), or `not_installed`.
 
 **`status`** aggregates installed version, health, config summary, and source for one agent — or every discovered agent when `<id>` is omitted.
+
+**Exit codes:** with an explicit `<id>`, both commands exit `1` when that agent's health is `error` or `not_installed`, `0` otherwise — so scripts can gate on a single agent without parsing table output. The all-agents form (`gaia agent status` with no `<id>`) always exits `0`; an absent agent shows up as a row, not a failure of the listing itself.
+
+**`--json`** emits machine-readable output instead of the table/text form, with log lines routed to stderr so stdout stays pure JSON for `| jq`. `health --json` prints one object (`HealthStatus.to_dict()`); `status --json` prints one object for a single `<id>`, or a JSON **list** of objects for the all-agents form.
 
 | Option | Applies to | Description |
 |--------|------------|-------------|
@@ -517,6 +521,7 @@ gaia agent status [<id>]
 | `--set KEY=VALUE` | `configure` | Set an arbitrary setting (repeatable) |
 | `--replace` | `configure` | Replace the whole config instead of merging |
 | `--show` | `configure` | Print the current config and exit |
+| `--json` | `health`, `status` | Emit machine-readable JSON instead of text |
 
 **Examples:**
 
@@ -528,6 +533,10 @@ gaia agent configure chat --model Qwen3.5-35B-A3B-GGUF
 ```bash Check health and status
 gaia agent health chat
 gaia agent status            # every discovered agent
+```
+
+```bash Gate a script on a single agent
+gaia agent status chat --json | jq -e '.health == "healthy"'
 ```
 </CodeGroup>
 

--- a/src/gaia/cli_agent.py
+++ b/src/gaia/cli_agent.py
@@ -235,6 +235,9 @@ def register_subparsers(agent_subparsers) -> None:
         help="Health check: does an installed agent load + its entry point resolve?",
     )
     health_p.add_argument("id", help="Agent id to health-check, e.g. 'chat'")
+    health_p.add_argument(
+        "--json", action="store_true", dest="as_json", help="Emit machine-readable JSON"
+    )
 
     status_p = agent_subparsers.add_parser(
         "status",
@@ -245,6 +248,9 @@ def register_subparsers(agent_subparsers) -> None:
         nargs="?",
         default=None,
         help="Agent id (omit to show every discovered agent)",
+    )
+    status_p.add_argument(
+        "--json", action="store_true", dest="as_json", help="Emit machine-readable JSON"
     )
 
     login_p = agent_subparsers.add_parser(
@@ -986,23 +992,45 @@ def cmd_configure(args) -> None:
 
 def cmd_health(args) -> None:
     """Run a health check against an installed agent."""
+    import json
+
     from gaia.hub import lifecycle
+
+    as_json = getattr(args, "as_json", False)
+    if as_json:
+        _quiet_console_logging()
 
     registry = _build_registry()
     result = lifecycle.health_check(args.id, registry=registry)
-    print(f"{args.id}: {result.state}")
-    if result.detail:
-        print(f"  {result.detail}")
-    for warning in result.warnings:
-        print(f"  warning: {warning}")
+
+    if as_json:
+        print(json.dumps(result.to_dict(), indent=2, sort_keys=True))
+    else:
+        print(f"{args.id}: {result.state}")
+        if result.detail:
+            print(f"  {result.detail}")
+        for warning in result.warnings:
+            print(f"  warning: {warning}")
     # error/not_installed are non-zero exits so scripts can gate on it.
     if result.state in (lifecycle.HEALTH_ERROR, lifecycle.HEALTH_NOT_INSTALLED):
         sys.exit(1)
 
 
 def cmd_status(args) -> None:
-    """Show installed version + health + config for one or all agents."""
+    """Show installed version + health + config for one or all agents.
+
+    Exit code: with an explicit ``id``, a not-installed/error agent exits
+    non-zero so scripts can gate on it (same contract as ``cmd_health``). The
+    all-agents listing always exits 0 — an absent agent there is just a row,
+    not the thing being asked about.
+    """
+    import json
+
     from gaia.hub import lifecycle
+
+    as_json = getattr(args, "as_json", False)
+    if as_json:
+        _quiet_console_logging()
 
     registry = _build_registry()
     if args.id:
@@ -1011,17 +1039,42 @@ def cmd_status(args) -> None:
         statuses = lifecycle.status_all(registry=registry)
 
     if not statuses:
-        print("No agents discovered.")
+        # Only the all-agents form can land here — a single explicit id
+        # always yields a (possibly not_installed) AgentStatus, never empty.
+        if as_json:
+            print(json.dumps([]))
+        else:
+            print("No agents discovered.")
         return
 
-    width = max(len(aid) for aid in statuses)
-    print(f"{'AGENT'.ljust(width)}  VERSION    HEALTH         SOURCE")
-    for aid, st in statuses.items():
-        version = st.installed_version or "-"
+    if as_json:
+        payload = [st.to_dict() for st in statuses.values()]
         print(
-            f"{aid.ljust(width)}  {version.ljust(9)}  "
-            f"{st.health.ljust(13)}  {st.source or '-'}"
+            json.dumps(payload if not args.id else payload[0], indent=2, sort_keys=True)
         )
+    else:
+        width = max(len(aid) for aid in statuses)
+        print(f"{'AGENT'.ljust(width)}  VERSION    HEALTH         SOURCE")
+        for aid, st in statuses.items():
+            version = st.installed_version or "-"
+            print(
+                f"{aid.ljust(width)}  {version.ljust(9)}  "
+                f"{st.health.ljust(13)}  {st.source or '-'}"
+            )
+
+    # Only the specifically-addressed form gates on health; the listing form
+    # (args.id is None) always exits 0 even if some listed agent is absent.
+    if args.id:
+        health = statuses[args.id].health
+        if health in (lifecycle.HEALTH_ERROR, lifecycle.HEALTH_NOT_INSTALLED):
+            sys.exit(1)
+
+
+def _quiet_console_logging() -> None:
+    """Keep stdout pure JSON — route log lines to stderr for ``--json`` output."""
+    from gaia.logger import route_console_logging_to_stderr
+
+    route_console_logging_to_stderr()
 
 
 def _build_registry():

--- a/tests/unit/test_cli_agent.py
+++ b/tests/unit/test_cli_agent.py
@@ -499,3 +499,200 @@ def test_handle_dispatches_pack(tmp_path, monkeypatch):
         packager, "pack", lambda p, *, output_dir=None, **k: _FakePackResult(tmp_path)
     )
     assert cli_agent.handle(_pack_args(tmp_path)) is True
+
+
+# ---------------------------------------------------------------------------
+# status / health — exit codes and --json (issue #2994)
+# ---------------------------------------------------------------------------
+
+
+def _status_args(agent_id=None, as_json=False):
+    return Namespace(agent_action="status", id=agent_id, as_json=as_json)
+
+
+def _health_args(agent_id, as_json=False):
+    return Namespace(agent_action="health", id=agent_id, as_json=as_json)
+
+
+def _fake_status(agent_id, health, *, version="1.0.0", source="installed"):
+    from gaia.hub import lifecycle
+
+    return lifecycle.AgentStatus(
+        id=agent_id,
+        installed=health != lifecycle.HEALTH_NOT_INSTALLED,
+        installed_version=None if health == lifecycle.HEALTH_NOT_INSTALLED else version,
+        health=health,
+        config={},
+        source="" if health == lifecycle.HEALTH_NOT_INSTALLED else source,
+    )
+
+
+def test_cmd_status_absent_id_exits_nonzero(monkeypatch):
+    from gaia.hub import lifecycle
+
+    monkeypatch.setattr(cli_agent, "_build_registry", lambda: None)
+    monkeypatch.setattr(
+        lifecycle,
+        "status",
+        lambda agent_id, registry=None: _fake_status(
+            agent_id, lifecycle.HEALTH_NOT_INSTALLED
+        ),
+    )
+    with pytest.raises(SystemExit) as exc:
+        cli_agent.cmd_status(_status_args("ghost"))
+    assert exc.value.code != 0
+
+
+def test_cmd_status_present_id_exits_zero(monkeypatch, capsys):
+    from gaia.hub import lifecycle
+
+    monkeypatch.setattr(cli_agent, "_build_registry", lambda: None)
+    monkeypatch.setattr(
+        lifecycle,
+        "status",
+        lambda agent_id, registry=None: _fake_status(
+            agent_id, lifecycle.HEALTH_HEALTHY
+        ),
+    )
+    # Should not raise SystemExit at all.
+    cli_agent.cmd_status(_status_args("chat"))
+    assert "chat" in capsys.readouterr().out
+
+
+def test_cmd_status_all_agents_exits_zero_even_with_absent(monkeypatch, capsys):
+    from gaia.hub import lifecycle
+
+    monkeypatch.setattr(cli_agent, "_build_registry", lambda: None)
+    monkeypatch.setattr(
+        lifecycle,
+        "status_all",
+        lambda registry=None: {
+            "chat": _fake_status("chat", lifecycle.HEALTH_HEALTHY),
+            "ghost": _fake_status("ghost", lifecycle.HEALTH_NOT_INSTALLED),
+        },
+    )
+    # The listing form never gates on an absent agent — no SystemExit.
+    cli_agent.cmd_status(_status_args(None))
+    out = capsys.readouterr().out
+    assert "chat" in out
+    assert "ghost" in out
+
+
+def test_cmd_status_json_single_agent(monkeypatch, capsys):
+    import json
+
+    from gaia.hub import lifecycle
+
+    monkeypatch.setattr(cli_agent, "_build_registry", lambda: None)
+    monkeypatch.setattr(
+        lifecycle,
+        "status",
+        lambda agent_id, registry=None: _fake_status(
+            agent_id, lifecycle.HEALTH_HEALTHY
+        ),
+    )
+    cli_agent.cmd_status(_status_args("chat", as_json=True))
+    payload = json.loads(capsys.readouterr().out)
+    assert payload == {
+        "id": "chat",
+        "installed": True,
+        "installed_version": "1.0.0",
+        "health": lifecycle.HEALTH_HEALTHY,
+        "config": {},
+        "source": "installed",
+    }
+
+
+def test_cmd_status_json_all_agents_is_a_list(monkeypatch, capsys):
+    import json
+
+    from gaia.hub import lifecycle
+
+    monkeypatch.setattr(cli_agent, "_build_registry", lambda: None)
+    monkeypatch.setattr(
+        lifecycle,
+        "status_all",
+        lambda registry=None: {
+            "chat": _fake_status("chat", lifecycle.HEALTH_HEALTHY),
+            "ghost": _fake_status("ghost", lifecycle.HEALTH_NOT_INSTALLED),
+        },
+    )
+    cli_agent.cmd_status(_status_args(None, as_json=True))
+    payload = json.loads(capsys.readouterr().out)
+    assert isinstance(payload, list)
+    assert {entry["id"] for entry in payload} == {"chat", "ghost"}
+
+
+def test_cmd_status_json_absent_still_exits_nonzero(monkeypatch, capsys):
+    import json
+
+    from gaia.hub import lifecycle
+
+    monkeypatch.setattr(cli_agent, "_build_registry", lambda: None)
+    monkeypatch.setattr(
+        lifecycle,
+        "status",
+        lambda agent_id, registry=None: _fake_status(
+            agent_id, lifecycle.HEALTH_NOT_INSTALLED
+        ),
+    )
+    with pytest.raises(SystemExit) as exc:
+        cli_agent.cmd_status(_status_args("ghost", as_json=True))
+    assert exc.value.code != 0
+    # stdout must be pure, parseable JSON — no log lines mixed in.
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["health"] == lifecycle.HEALTH_NOT_INSTALLED
+
+
+def test_cmd_health_absent_id_exits_nonzero(monkeypatch):
+    from gaia.hub import lifecycle
+
+    monkeypatch.setattr(cli_agent, "_build_registry", lambda: None)
+    monkeypatch.setattr(
+        lifecycle,
+        "health_check",
+        lambda agent_id, registry=None: lifecycle.HealthStatus(
+            id=agent_id, state=lifecycle.HEALTH_NOT_INSTALLED, detail="not installed"
+        ),
+    )
+    with pytest.raises(SystemExit) as exc:
+        cli_agent.cmd_health(_health_args("ghost"))
+    assert exc.value.code != 0
+
+
+def test_cmd_health_present_id_exits_zero(monkeypatch, capsys):
+    from gaia.hub import lifecycle
+
+    monkeypatch.setattr(cli_agent, "_build_registry", lambda: None)
+    monkeypatch.setattr(
+        lifecycle,
+        "health_check",
+        lambda agent_id, registry=None: lifecycle.HealthStatus(
+            id=agent_id, state=lifecycle.HEALTH_HEALTHY, detail="ok"
+        ),
+    )
+    cli_agent.cmd_health(_health_args("chat"))
+    assert "chat" in capsys.readouterr().out
+
+
+def test_cmd_health_json_shape(monkeypatch, capsys):
+    import json
+
+    from gaia.hub import lifecycle
+
+    monkeypatch.setattr(cli_agent, "_build_registry", lambda: None)
+    monkeypatch.setattr(
+        lifecycle,
+        "health_check",
+        lambda agent_id, registry=None: lifecycle.HealthStatus(
+            id=agent_id, state=lifecycle.HEALTH_HEALTHY, detail="ok"
+        ),
+    )
+    cli_agent.cmd_health(_health_args("chat", as_json=True))
+    payload = json.loads(capsys.readouterr().out)
+    assert payload == {
+        "id": "chat",
+        "state": lifecycle.HEALTH_HEALTHY,
+        "detail": "ok",
+        "warnings": [],
+    }


### PR DESCRIPTION
Closes #2994

`gaia agent status <id>` printed a "not_installed" table row and exited 0 for an agent that isn't installed, so a script had to parse console text to tell "installed and healthy" apart from "absent." `gaia agent health` already got this right (#465) — `status` now matches: an explicit `<id>` exits 1 when that agent is `error`/`not_installed`, 0 otherwise. The all-agents listing form (no `<id>`) keeps exiting 0 no matter what it finds, since it's a report, not a check on one agent.

Both subcommands also gain `--json`, serialized from the existing `AgentStatus`/`HealthStatus.to_dict()`, with console log lines routed to stderr so stdout stays pure JSON for `| jq`.

## Test plan

- [x] `PYTHONPATH=src python -m pytest tests/unit/test_cli_agent.py -q` — 49 passed (new tests cover absent/present/all-agents exit codes and `--json` shape for both commands)
- [x] `python util/lint.py --all --fix` — all checks pass

Real CLI output (`builder` is the only builtin agent registered on this box; `ghost-agent` doesn't exist):

```
$ gaia agent status ghost-agent
AGENT        VERSION    HEALTH         SOURCE
ghost-agent  -          not_installed  -
$ echo $?
1

$ gaia agent status builder
AGENT    VERSION    HEALTH         SOURCE
builder  -          healthy        builtin
$ echo $?
0

$ gaia agent status            # all-agents form, exits 0 regardless
AGENT    VERSION    HEALTH         SOURCE
builder  -          healthy        builtin
$ echo $?
0

$ gaia agent status builder --json | jq .
{
  "config": {},
  "health": "healthy",
  "id": "builder",
  "installed": true,
  "installed_version": null,
  "source": "builtin"
}

$ gaia agent status --json | jq .
[
  {
    "config": {},
    "health": "healthy",
    "id": "builder",
    "installed": true,
    "installed_version": null,
    "source": "builtin"
  }
]

$ gaia agent health builder --json | jq .
{
  "detail": "'builder' is healthy.",
  "id": "builder",
  "state": "healthy",
  "warnings": []
}
```