### PR TITLE
fix(email): declare the sidecar bearer gate in the OpenAPI contract

### DIFF
--- a/docs/guides/email-integration.mdx
+++ b/docs/guides/email-integration.mdx
@@ -253,6 +253,13 @@ identify who is calling.
   (DNS-rebinding); a non-loopback browser `Origin` → **HTTP 403** (drive-by web
   page). No permissive CORS is ever sent.
 
+The sidecar's OpenAPI document (`GET /openapi.json`, and the committed
+`openapi.email.json`) declares this posture: a `bearerAuth` HTTP scheme, and per
+gated operation `security: [{"bearerAuth": []}, {}]` — bearer OR none, matching
+the check above being skipped when no token is configured. Exempt routes
+(`/health`, `/version`, `/v1/email/health`, `/v1/email/version`) declare an
+explicit empty security requirement instead.
+
 How this maps to the entry points above:
 
 - **Frozen sidecar / npm** — `startSidecar` mints the token, injects it, and binds

--- a/hub/agents/email/npm/CHANGELOG.md
+++ b/hub/agents/email/npm/CHANGELOG.md
@@ -4,6 +4,14 @@ What's new in `@amd-gaia/agent-email`, in plain language. For the technical deta
 behind any entry — API shapes, endpoints, and version semantics — see
 [`SPEC.md`](https://github.com/amd/gaia/blob/agent-pkg-email-v0.6.0/hub/agents/email/npm/SPEC.md).
 
+## [Unreleased]
+
+- **The published API contract now shows that requests need a session token.**
+  The sidecar has always required a bearer token on most calls, but the
+  contract document didn't say so. It now declares the requirement (and marks
+  `/health`, `/version`, and the other exempt routes as public) — nothing about
+  which calls need a token, or when, has changed (#2993).
+
 ## [0.6.0] - 2026-08-12
 
 - **Work Microsoft 365 mailboxes are now supported alongside Gmail and personal

--- a/hub/agents/email/npm/SPEC.md
+++ b/hub/agents/email/npm/SPEC.md
@@ -67,6 +67,12 @@ Running the sidecar by hand without `GAIA_EMAIL_SIDECAR_TOKEN` disables the toke
 check (local development only, logged loudly); the Host/Origin controls still
 apply. The shipped product always spawns with a token.
 
+The OpenAPI document (both the live `/openapi.json` and the committed
+`openapi.email.json`) declares this: a `bearerAuth` HTTP scheme plus, per
+gated operation, `security: [{"bearerAuth": []}, {}]` — bearer OR none,
+matching the conditional check above. Exempt paths declare an explicit empty
+requirement instead.
+
 ## REST API
 
 The code-derived, CI-guarded inventory of every capability surface (internal

--- a/hub/agents/email/python/CHANGELOG.md
+++ b/hub/agents/email/python/CHANGELOG.md
@@ -5,6 +5,20 @@ Format loosely follows [Keep a Changelog](https://keepachangelog.com/); the REST
 contract version is tracked separately as
 `gaia_agent_email.contract.SCHEMA_VERSION` (see `CONTRACT.md`).
 
+## [Unreleased]
+
+### Fixed
+
+- **The OpenAPI document now declares the sidecar's bearer-token gate (#2993).**
+  `require_caller_token` enforces a per-session bearer token at runtime, but was
+  invisible to schema generation (it's a plain `Request` dependency, not a
+  `fastapi.security` class) — every documented operation showed 0 security
+  requirements. The live `/openapi.json` and the committed `openapi.email.json`
+  now declare a `bearerAuth` HTTP scheme and, per gated operation, `security:
+  [{"bearerAuth": []}, {}]` (bearer OR none — the check is conditional, skipped
+  when the sidecar has no token configured for local development). `EXEMPT_PATHS`
+  routes declare an explicit empty requirement. No runtime auth behavior changed.
+
 ## [0.6.0] - 2026-08-12
 
 ### Added

--- a/hub/agents/email/python/CONTRACT.md
+++ b/hub/agents/email/python/CONTRACT.md
@@ -77,12 +77,16 @@ test asserts byte-for-byte equality, so drift in either place fails CI.
 | `PROMOTIONAL` | Marketing / bulk mail. |
 | `PERSONAL` | Personal correspondence. |
 
-> **Transport authentication is separate from this schema.** The frozen sidecar
-> requires a **per-session bearer token** (`Authorization: Bearer <token>`) on
-> every `/v1/email/*` request and enforces a loopback Host/Origin allowlist
-> ([#1706](https://github.com/amd/gaia/issues/1706)) — `401`/`400`/`403` on
-> failure. That is a deployment/transport control, not part of the request/response
-> contract, so it is **not** encoded in the frozen OpenAPI document. See
+> **Transport authentication is separate from this schema, but IS declared in the
+> OpenAPI document.** The frozen sidecar requires a **per-session bearer token**
+> (`Authorization: Bearer <token>`) on every `/v1/email/*` request and enforces a
+> loopback Host/Origin allowlist ([#1706](https://github.com/amd/gaia/issues/1706))
+> — `401`/`400`/`403` on failure. That check is conditional — a sidecar started
+> with no token configured (local development) skips it — so the OpenAPI document
+> declares a `bearerAuth` HTTP scheme and, per operation, `security: [{"bearerAuth":
+> []}, {}]` (bearer OR none) rather than asserting an unconditional requirement.
+> `EXEMPT_PATHS` routes (`/health`, `/version`, `/v1/email/health`, `/v1/email/version`)
+> declare an explicit empty requirement instead. See
 > [Email Integration → Authentication](https://amd-gaia.ai/docs/guides/email-integration#authentication).
 
 ---

--- a/hub/agents/email/python/gaia_agent_email/caller_auth.py
+++ b/hub/agents/email/python/gaia_agent_email/caller_auth.py
@@ -214,6 +214,28 @@ def openapi_security_extension(spec: dict) -> dict:
     return spec
 
 
+def install_openapi_security(app) -> None:
+    """Wire :func:`openapi_security_extension` onto ``app.openapi()`` (#2993).
+
+    Shared by the sidecar (``server.py``) and the export app
+    (``export_openapi.py``) so the bearer-gate overlay is defined once and both
+    documents can never drift apart. Delegates to the app's own ``app.openapi``
+    (FastAPI's default schema builder) rather than calling
+    ``fastapi.openapi.utils.get_openapi`` directly — the default already forwards
+    everything ``FastAPI.__init__`` was given (``servers``, ``openapi_tags``,
+    etc.), so nothing set on the app can silently drop out of the published spec.
+    """
+    base_openapi = app.openapi
+
+    def _openapi() -> dict:
+        if app.openapi_schema:
+            return app.openapi_schema
+        app.openapi_schema = openapi_security_extension(base_openapi())
+        return app.openapi_schema
+
+    app.openapi = _openapi
+
+
 def _host_only(header_value: str) -> str:
     """Extract the bare host from a ``Host`` header value, dropping the port.
 
@@ -322,4 +344,5 @@ __all__ = [
     "is_exempt_path",
     "token_ok",
     "openapi_security_extension",
+    "install_openapi_security",
 ]

--- a/hub/agents/email/python/gaia_agent_email/caller_auth.py
+++ b/hub/agents/email/python/gaia_agent_email/caller_auth.py
@@ -84,6 +84,8 @@ EXEMPT_PATHS: FrozenSet[str] = frozenset(
         "/version",
         "/v1/email/health",
         "/v1/email/version",
+        # spec/playground are include_in_schema=False, so they never appear
+        # in the generated OpenAPI document below.
         "/v1/email/spec",
         "/v1/email/playground",
     }

--- a/hub/agents/email/python/gaia_agent_email/caller_auth.py
+++ b/hub/agents/email/python/gaia_agent_email/caller_auth.py
@@ -184,6 +184,36 @@ def is_exempt_path(path: str) -> bool:
     return path in EXEMPT_PATHS
 
 
+# HTTP methods FastAPI/OpenAPI ever attach an operation to under a path item.
+_OPENAPI_METHODS: FrozenSet[str] = frozenset(
+    {"get", "post", "put", "patch", "delete", "options", "head", "trace"}
+)
+
+
+def openapi_security_extension(spec: dict) -> dict:
+    """Overlay the bearer-token gate onto a generated OpenAPI document (#2993).
+
+    ``require_caller_token`` is a plain ``Request``-typed dependency (by
+    design — it must not risk behaviour drift in the live auth path), so
+    FastAPI's schema generator never sees it and emits no
+    ``securitySchemes``/``security`` at all. This overlay documents the REAL
+    posture instead: the gate is skipped entirely when the sidecar has no
+    token configured (local dev), so every gated operation declares
+    ``security: [{"bearerAuth": []}, {}]`` — bearer OR none — never a false
+    "always required" claim. :data:`EXEMPT_PATHS` routes get an explicit
+    empty requirement (``security: []``) so they read as deliberately public,
+    not merely undocumented. Mutates and returns ``spec``.
+    """
+    schemes = spec.setdefault("components", {}).setdefault("securitySchemes", {})
+    schemes["bearerAuth"] = {"type": "http", "scheme": "bearer"}
+    for path, operations in spec.get("paths", {}).items():
+        requirement = [] if is_exempt_path(path) else [{"bearerAuth": []}, {}]
+        for method, operation in operations.items():
+            if method in _OPENAPI_METHODS:
+                operation["security"] = requirement
+    return spec
+
+
 def _host_only(header_value: str) -> str:
     """Extract the bare host from a ``Host`` header value, dropping the port.
 
@@ -291,4 +321,5 @@ __all__ = [
     "config_from_env",
     "is_exempt_path",
     "token_ok",
+    "openapi_security_extension",
 ]

--- a/hub/agents/email/python/gaia_agent_email/export_openapi.py
+++ b/hub/agents/email/python/gaia_agent_email/export_openapi.py
@@ -53,6 +53,8 @@ def build_app():
     spec matches what a host actually serves.
     """
     from fastapi import FastAPI
+    from fastapi.openapi.utils import get_openapi
+    from gaia_agent_email import caller_auth
     from gaia_agent_email.api_routes import router as email_router
     from gaia_agent_email.connection_intake_routes import (
         router as connection_intake_router,
@@ -68,6 +70,22 @@ def build_app():
     # (schema 2.5), so it belongs in the published artifact, unlike the
     # playground-only connector routes (include_in_schema=False).
     app.include_router(connection_intake_router)
+
+    def _openapi():
+        if app.openapi_schema:
+            return app.openapi_schema
+        schema = get_openapi(
+            title=app.title, version=app.version, description=app.description,
+            routes=app.routes,
+        )
+        # Declare the sidecar's bearer gate (#2993) — this app mounts the
+        # SAME routers the sidecar gates in server.py, so its exported
+        # document must describe the same posture even though this minimal
+        # app never wires the dependency itself.
+        app.openapi_schema = caller_auth.openapi_security_extension(schema)
+        return app.openapi_schema
+
+    app.openapi = _openapi
     return app
 
 

--- a/hub/agents/email/python/gaia_agent_email/export_openapi.py
+++ b/hub/agents/email/python/gaia_agent_email/export_openapi.py
@@ -53,7 +53,6 @@ def build_app():
     spec matches what a host actually serves.
     """
     from fastapi import FastAPI
-    from fastapi.openapi.utils import get_openapi
     from gaia_agent_email import caller_auth
     from gaia_agent_email.api_routes import router as email_router
     from gaia_agent_email.connection_intake_routes import (
@@ -71,21 +70,11 @@ def build_app():
     # playground-only connector routes (include_in_schema=False).
     app.include_router(connection_intake_router)
 
-    def _openapi():
-        if app.openapi_schema:
-            return app.openapi_schema
-        schema = get_openapi(
-            title=app.title, version=app.version, description=app.description,
-            routes=app.routes,
-        )
-        # Declare the sidecar's bearer gate (#2993) — this app mounts the
-        # SAME routers the sidecar gates in server.py, so its exported
-        # document must describe the same posture even though this minimal
-        # app never wires the dependency itself.
-        app.openapi_schema = caller_auth.openapi_security_extension(schema)
-        return app.openapi_schema
-
-    app.openapi = _openapi
+    # Declare the sidecar's bearer gate (#2993) — this app mounts the SAME
+    # routers the sidecar gates in server.py, so its exported document must
+    # describe the same posture even though this minimal app never wires the
+    # dependency itself.
+    caller_auth.install_openapi_security(app)
     return app
 
 

--- a/hub/agents/email/python/gaia_agent_email/server.py
+++ b/hub/agents/email/python/gaia_agent_email/server.py
@@ -195,6 +195,23 @@ def build_app():
     # Router import is light; the heavy agent/memory imports are deferred to the
     # first session build.
     app.include_router(agent_router, dependencies=token_gate)
+
+    def _openapi():
+        if app.openapi_schema:
+            return app.openapi_schema
+        from fastapi.openapi.utils import get_openapi
+
+        schema = get_openapi(
+            title=app.title, version=app.version, description=app.description,
+            routes=app.routes,
+        )
+        # require_caller_token is a plain Request dependency (not a
+        # fastapi.security class), so FastAPI never emits securitySchemes for
+        # it (#2993) — overlay the real, conditional (bearer-or-none) posture.
+        app.openapi_schema = caller_auth.openapi_security_extension(schema)
+        return app.openapi_schema
+
+    app.openapi = _openapi
     return app
 
 

--- a/hub/agents/email/python/gaia_agent_email/server.py
+++ b/hub/agents/email/python/gaia_agent_email/server.py
@@ -196,22 +196,10 @@ def build_app():
     # first session build.
     app.include_router(agent_router, dependencies=token_gate)
 
-    def _openapi():
-        if app.openapi_schema:
-            return app.openapi_schema
-        from fastapi.openapi.utils import get_openapi
-
-        schema = get_openapi(
-            title=app.title, version=app.version, description=app.description,
-            routes=app.routes,
-        )
-        # require_caller_token is a plain Request dependency (not a
-        # fastapi.security class), so FastAPI never emits securitySchemes for
-        # it (#2993) — overlay the real, conditional (bearer-or-none) posture.
-        app.openapi_schema = caller_auth.openapi_security_extension(schema)
-        return app.openapi_schema
-
-    app.openapi = _openapi
+    # require_caller_token is a plain Request dependency (not a
+    # fastapi.security class), so FastAPI never emits securitySchemes for
+    # it (#2993) — overlay the real, conditional (bearer-or-none) posture.
+    caller_auth.install_openapi_security(app)
     return app
 
 

--- a/hub/agents/email/python/openapi.email.json
+++ b/hub/agents/email/python/openapi.email.json
@@ -3371,6 +3371,12 @@
         "title": "VersionResponse",
         "type": "object"
       }
+    },
+    "securitySchemes": {
+      "bearerAuth": {
+        "scheme": "bearer",
+        "type": "http"
+      }
     }
   },
   "info": {
@@ -3396,6 +3402,12 @@
             "description": "Successful Response"
           }
         },
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {}
+        ],
         "summary": "List Forwarded Connections",
         "tags": [
           "email-forward-out"
@@ -3439,6 +3451,12 @@
             "description": "Validation Error"
           }
         },
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {}
+        ],
         "summary": "Withdraw Forwarded Connection",
         "tags": [
           "email-forward-out"
@@ -3490,6 +3508,12 @@
             "description": "Validation Error"
           }
         },
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {}
+        ],
         "summary": "Import Forwarded Connection",
         "tags": [
           "email-forward-out"
@@ -3547,6 +3571,12 @@
             "description": "No account connected, or backend configuration is missing — connect Google or Microsoft in Settings → Connectors."
           }
         },
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {}
+        ],
         "summary": "Archive Email",
         "tags": [
           "email"
@@ -3600,6 +3630,12 @@
             "description": "No account connected, or backend configuration is missing — connect Google or Microsoft in Settings → Connectors."
           }
         },
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {}
+        ],
         "summary": "Get Attention View",
         "tags": [
           "email"
@@ -3628,6 +3664,12 @@
             "description": "The persisted briefing could not be read or does not match the email_pre_scan envelope."
           }
         },
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {}
+        ],
         "summary": "Get Briefing",
         "tags": [
           "email"
@@ -3722,6 +3764,12 @@
             "description": "No account connected, or backend configuration is missing — connect Google or Microsoft in Settings → Connectors."
           }
         },
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {}
+        ],
         "summary": "List Calendar Events",
         "tags": [
           "email"
@@ -3774,6 +3822,12 @@
             "description": "No account connected, or backend configuration is missing — connect Google or Microsoft in Settings → Connectors."
           }
         },
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {}
+        ],
         "summary": "Create Calendar Event",
         "tags": [
           "email"
@@ -3816,6 +3870,12 @@
             "description": "Validation Error"
           }
         },
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {}
+        ],
         "summary": "Preview Calendar Event",
         "tags": [
           "email"
@@ -3870,6 +3930,12 @@
             "description": "No account connected, or backend configuration is missing — connect Google or Microsoft in Settings → Connectors."
           }
         },
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {}
+        ],
         "summary": "Respond Calendar Event",
         "tags": [
           "email"
@@ -3912,6 +3978,12 @@
             "description": "Validation Error"
           }
         },
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {}
+        ],
         "summary": "Confirm Action",
         "tags": [
           "email"
@@ -3954,6 +4026,12 @@
             "description": "Validation Error"
           }
         },
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {}
+        ],
         "summary": "Draft Reply",
         "tags": [
           "email"
@@ -3976,6 +4054,7 @@
             "description": "Successful Response"
           }
         },
+        "security": [],
         "summary": "Email Health",
         "tags": [
           "email"
@@ -4008,6 +4087,12 @@
             "description": "Service Unavailable"
           }
         },
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {}
+        ],
         "summary": "Email Init",
         "tags": [
           "email"
@@ -4059,6 +4144,12 @@
             "description": "No account connected, or backend configuration is missing — connect Google or Microsoft in Settings → Connectors."
           }
         },
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {}
+        ],
         "summary": "Prescan Inbox",
         "tags": [
           "email"
@@ -4113,6 +4204,12 @@
             "description": "No account connected, or backend configuration is missing — connect Google or Microsoft in Settings → Connectors."
           }
         },
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {}
+        ],
         "summary": "Quarantine Email",
         "tags": [
           "email"
@@ -4159,6 +4256,12 @@
             "description": "Validation Error"
           }
         },
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {}
+        ],
         "summary": "Query",
         "tags": [
           "email",
@@ -4203,6 +4306,12 @@
             "description": "Validation Error"
           }
         },
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {}
+        ],
         "summary": "Cancel Query",
         "tags": [
           "email",
@@ -4257,6 +4366,12 @@
             "description": "Validation Error"
           }
         },
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {}
+        ],
         "summary": "Respond Query",
         "tags": [
           "email",
@@ -4312,6 +4427,12 @@
             "description": "No account connected, or backend configuration is missing — connect Google or Microsoft in Settings → Connectors."
           }
         },
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {}
+        ],
         "summary": "Search Inbox",
         "tags": [
           "email"
@@ -4369,6 +4490,12 @@
             "description": "No account connected, or backend configuration is missing — connect Google or Microsoft in Settings → Connectors."
           }
         },
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {}
+        ],
         "summary": "Send Email",
         "tags": [
           "email"
@@ -4414,6 +4541,12 @@
             "description": "Local LLM triage failed — Lemonade Server unreachable or it returned an unusable result."
           }
         },
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {}
+        ],
         "summary": "Triage Email",
         "tags": [
           "email"
@@ -4459,6 +4592,12 @@
             "description": "Local LLM triage failed — Lemonade Server unreachable or it returned an unusable result."
           }
         },
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {}
+        ],
         "summary": "Triage Email Batch",
         "tags": [
           "email"
@@ -4516,6 +4655,12 @@
             "description": "No account connected, or backend configuration is missing — connect Google or Microsoft in Settings → Connectors."
           }
         },
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {}
+        ],
         "summary": "Unarchive Email",
         "tags": [
           "email"
@@ -4573,6 +4718,12 @@
             "description": "No account connected, or backend configuration is missing — connect Google or Microsoft in Settings → Connectors."
           }
         },
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {}
+        ],
         "summary": "Unquarantine Email",
         "tags": [
           "email"
@@ -4595,6 +4746,7 @@
             "description": "Successful Response"
           }
         },
+        "security": [],
         "summary": "Email Version",
         "tags": [
           "email"

--- a/hub/agents/email/python/tests/test_rest_contract.py
+++ b/hub/agents/email/python/tests/test_rest_contract.py
@@ -1961,6 +1961,8 @@ def test_exempt_paths_are_explicitly_public(spec):
     for path in ("/v1/email/health", "/v1/email/version"):
         assert path in spec["paths"], f"{path} missing from spec"
         for method, op in spec["paths"][path].items():
+            if method not in _caller_auth._OPENAPI_METHODS:
+                continue
             assert op.get("security") == [], (
                 f"{method.upper()} {path} is an EXEMPT_PATHS route and must "
                 "declare an explicit empty security requirement"

--- a/hub/agents/email/python/tests/test_rest_contract.py
+++ b/hub/agents/email/python/tests/test_rest_contract.py
@@ -31,6 +31,7 @@ pytest.importorskip("gaia_agent_email")
 
 from fastapi.testclient import TestClient  # noqa: E402
 from gaia_agent_email import __version__ as package_version  # noqa: E402
+from gaia_agent_email import caller_auth as _caller_auth  # noqa: E402
 from gaia_agent_email import export_openapi  # noqa: E402
 from gaia_agent_email.contract import (  # noqa: E402
     SCHEMA_VERSION,
@@ -1934,9 +1935,6 @@ def test_calendar_create_bad_event_after_gate_is_400(client, monkeypatch):
 #     sidecar has no token configured (local dev).
 # ---------------------------------------------------------------------------
 
-from gaia_agent_email import caller_auth as _caller_auth  # noqa: E402
-
-
 def test_spec_declares_bearer_security_scheme(spec):
     schemes = spec["components"]["securitySchemes"]
     assert schemes["bearerAuth"]["type"] == "http"
@@ -1951,6 +1949,8 @@ def test_gated_operations_require_bearer_or_none(spec):
         if _caller_auth.is_exempt_path(path):
             continue
         for method, op in operations.items():
+            if method not in _caller_auth._OPENAPI_METHODS:
+                continue
             assert op.get("security") == [{"bearerAuth": []}, {}], (
                 f"{method.upper()} {path} does not declare the conditional "
                 "bearer-or-none security requirement"
@@ -1965,6 +1965,24 @@ def test_exempt_paths_are_explicitly_public(spec):
                 f"{method.upper()} {path} is an EXEMPT_PATHS route and must "
                 "declare an explicit empty security requirement"
             )
+
+
+def test_sidecar_app_document_declares_the_gate():
+    # The `spec`/`client` fixtures above build the export app, which mounts
+    # the same routers as the sidecar but never wires require_caller_token
+    # itself — asserting only on that app would leave the actual shipped
+    # sidecar document (`server.build_app()`) unverified. `/health` and
+    # `/version` are mounted on the sidecar app directly rather than via a
+    # router, so they appear ONLY in this document, not the export app's.
+    from gaia_agent_email import server
+
+    spec = server.build_app().openapi()
+    assert spec["components"]["securitySchemes"]["bearerAuth"]["scheme"] == "bearer"
+    assert spec["paths"]["/v1/email/send"]["post"]["security"] == [
+        {"bearerAuth": []},
+        {},
+    ]
+    assert spec["paths"]["/health"]["get"]["security"] == []
 
 
 def test_spec_page_serves_html(client):

--- a/hub/agents/email/python/tests/test_rest_contract.py
+++ b/hub/agents/email/python/tests/test_rest_contract.py
@@ -1925,6 +1925,48 @@ def test_calendar_create_bad_event_after_gate_is_400(client, monkeypatch):
     assert "start" in resp.json()["detail"].lower()
 
 
+# ---------------------------------------------------------------------------
+# 13. OpenAPI security declaration (#2993) — the per-session bearer gate
+#     (``require_caller_token``) is invisible to FastAPI's schema generator
+#     because it is a plain ``Request`` dependency, not a ``SecurityBase``
+#     one. The document must still declare the scheme and the real,
+#     conditional posture: bearer OR none, since the gate no-ops when the
+#     sidecar has no token configured (local dev).
+# ---------------------------------------------------------------------------
+
+from gaia_agent_email import caller_auth as _caller_auth  # noqa: E402
+
+
+def test_spec_declares_bearer_security_scheme(spec):
+    schemes = spec["components"]["securitySchemes"]
+    assert schemes["bearerAuth"]["type"] == "http"
+    assert schemes["bearerAuth"]["scheme"] == "bearer"
+
+
+def test_gated_operations_require_bearer_or_none(spec):
+    # Every documented operation not in EXEMPT_PATHS must declare the
+    # conditional posture: bearer OR no credential — never a blanket
+    # "bearer always required" (the gate is off when no token is configured).
+    for path, operations in spec["paths"].items():
+        if _caller_auth.is_exempt_path(path):
+            continue
+        for method, op in operations.items():
+            assert op.get("security") == [{"bearerAuth": []}, {}], (
+                f"{method.upper()} {path} does not declare the conditional "
+                "bearer-or-none security requirement"
+            )
+
+
+def test_exempt_paths_are_explicitly_public(spec):
+    for path in ("/v1/email/health", "/v1/email/version"):
+        assert path in spec["paths"], f"{path} missing from spec"
+        for method, op in spec["paths"][path].items():
+            assert op.get("security") == [], (
+                f"{method.upper()} {path} is an EXEMPT_PATHS route and must "
+                "declare an explicit empty security requirement"
+            )
+
+
 def test_spec_page_serves_html(client):
     """GET /spec (include_in_schema=False, human page) serves the HTML spec."""
     resp = client.get("/v1/email/spec")


### PR DESCRIPTION
Closes #2993

The email sidecar enforces a per-session bearer token at runtime, but its OpenAPI document didn't say so — every consumer (the npm client, native builds, anyone reading `/openapi.json`) saw 0 of 40 operations carrying a security requirement, even though `/v1/email/init`, `/draft`, `/send`, etc. reject an unauthenticated request with 401.

The document now declares a `bearerAuth` HTTP scheme and, per gated operation, the real conditional posture — `security: [{"bearerAuth": []}, {}]` (bearer OR none, since the check is skipped when the sidecar has no token configured for local dev) — with `EXEMPT_PATHS` routes (`/health`, `/version`, etc.) marked explicitly public. No runtime auth behavior changed.

## Test plan

- [x] New tests in `tests/test_rest_contract.py` assert the `securitySchemes` block, the conditional security requirement on every gated operation, and an explicit empty requirement on every `EXEMPT_PATHS` route.
- [x] `pytest tests/test_rest_contract.py tests/test_caller_auth.py` — 138 passed (includes the byte-for-byte `openapi.email.json` up-to-date check, regenerated in this PR).
- [x] Full email package suite (`pytest tests/`) — 1981 passed, 3 pre-existing failures unrelated to this change (local Lemonade model unavailable; missing `build` package for a packaging test).
- [x] `python util/lint.py --all --fix` — clean (pre-existing mypy findings are in untouched files).
- [x] Manually started the sidecar with `GAIA_EMAIL_SIDECAR_TOKEN` set and confirmed live, on the real process:

```
$ init (no token):                          401
$ init (Authorization: Bearer <token>):     200
$ health (exempt path, no token):           200

$ GET /openapi.json → components.securitySchemes
{"bearerAuth": {"type": "http", "scheme": "bearer"}}
$ GET /openapi.json → paths["/v1/email/triage"]["post"]["security"]
[{"bearerAuth": []}, {}]
$ GET /openapi.json → paths["/v1/email/health"]["get"]["security"]
[]
```

  The regenerated `openapi.email.json` (committed in this PR) matches the live process byte-for-byte on these fields.

---

@kovtcharov-amd — this changes the rationale in `CONTRACT.md` you authored (previously: auth is deliberately not encoded in the OpenAPI document). Would appreciate a sign-off that declaring the conditional bearer-or-none posture is the right call here.