### PR TITLE
fix(llm): clamp requested ctx_size to a model's real context ceiling

### DIFF
--- a/src/gaia/llm/lemonade_client.py
+++ b/src/gaia/llm/lemonade_client.py
@@ -3363,25 +3363,25 @@ class LemonadeClient:
 
         # Best-effort floor-vs-ceiling conflict check (#2992): if the MODELS
         # registry requires more context than the model can actually train
-        # on, that's an unresolvable data error — fail loudly rather than
-        # silently loading at a value that reopens the #1030 truncation bug
-        # the registry floor exists to prevent. No extra HTTP call here
-        # (``allow_catalog_lookup=False``) — this only catches the conflict
-        # when the model happens to already be loaded (and thus in
-        # ``status``); an undownloaded model's ceiling is unknown anyway.
+        # on, clamp to the model's real ceiling rather than raise — this must
+        # agree with LemonadeManager._report_capped_at_ceiling, which treats
+        # the identical situation as "proceed capped", not fatal. No extra
+        # HTTP call here (``allow_catalog_lookup=False``) — this only catches
+        # the conflict when the model happens to already be loaded (and thus
+        # in ``status``); an undownloaded model's ceiling is unknown anyway.
         _ceiling = self.get_model_max_context_window(
             model, status=status, allow_catalog_lookup=False
         )
         if _ceiling and expected_ctx > _ceiling:
-            raise LemonadeClientError(
-                f"GAIA requires ctx_size={expected_ctx} for '{model}' "
-                f"(MODELS registry min_ctx_size), but Lemonade reports its "
-                f"trained context ceiling as {_ceiling} tokens "
-                f"(max_context_window). Lower MODELS[...].min_ctx_size for "
-                f"this model or choose a different one — requesting more "
-                f"than the model supports would silently truncate every "
-                f"prompt."
+            self.log.warning(
+                f"'{model}' requires ctx_size={expected_ctx} (MODELS "
+                f"registry min_ctx_size), but its trained context ceiling "
+                f"is {_ceiling} tokens (max_context_window); loading at "
+                f"{_ceiling} instead. Use a model with a larger trained "
+                f"context if more is needed — no server restart or config "
+                f"change raises a GGUF's trained context."
             )
+            expected_ctx = _ceiling
         elif _ceiling is None:
             # Not an error — the common case for a model not yet loaded (its
             # metadata isn't resolvable without a catalog round trip, which

--- a/src/gaia/llm/lemonade_client.py
+++ b/src/gaia/llm/lemonade_client.py
@@ -2553,7 +2553,7 @@ class LemonadeClient:
 
         try:
             catalog = self.list_models(show_all=True).get("data", [])
-        except Exception as e:  # pylint: disable=broad-except
+        except LemonadeClientError as e:
             self.log.debug(f"Could not query model catalog for {model_id!r}: {e}")
             return None
         for m in catalog:

--- a/src/gaia/llm/lemonade_client.py
+++ b/src/gaia/llm/lemonade_client.py
@@ -1084,6 +1084,10 @@ class LemonadeClient:
         self.active_downloads: Dict[str, DownloadTask] = {}
         self._downloads_lock = threading.Lock()
 
+        # Models already warned about a floor-vs-ceiling clamp (#2992), so the
+        # warning fires once per model instead of on every already-loaded call.
+        self._ceiling_clamp_warned: set = set()
+
         # Set logging level based on verbosity
         if not verbose:
             self.log.setLevel(logging.WARNING)
@@ -3338,26 +3342,6 @@ class LemonadeClient:
             # health entries enriched with ``id`` + ``recipe_options`` so we
             # can read ctx_size.
             status = self.get_status()
-            loaded_entry = self._find_loaded_entry(status, model)
-
-            if loaded_entry is not None:
-                loaded_ctx = (
-                    loaded_entry.get("recipe_options", {}).get("ctx_size", 0) or 0
-                )
-                if loaded_ctx >= expected_ctx:
-                    self.log.debug(
-                        f"Model '{model}' already loaded at ctx={loaded_ctx} "
-                        f"(expected >= {expected_ctx})"
-                    )
-                    return
-                # Loaded but under-sized — fall through to the reload path
-                # which calls /load with explicit ctx_size.
-                self.log.info(
-                    f"Model '{model}' loaded at ctx={loaded_ctx} but GAIA "
-                    f"expects ctx={expected_ctx}; reloading."
-                )
-            else:
-                self.log.debug(f"Model '{model}' not loaded, loading...")
         except Exception as e:  # pylint: disable=broad-except
             self.log.debug(f"Could not pre-check model status: {e}")
 
@@ -3369,18 +3353,23 @@ class LemonadeClient:
         # HTTP call here (``allow_catalog_lookup=False``) — this only catches
         # the conflict when the model happens to already be loaded (and thus
         # in ``status``); an undownloaded model's ceiling is unknown anyway.
+        # Resolved BEFORE the already-loaded comparison below, so a model
+        # resident at its (clamped) ceiling short-circuits instead of
+        # reloading forever at the same ceiling every call.
         _ceiling = self.get_model_max_context_window(
             model, status=status, allow_catalog_lookup=False
         )
         if _ceiling and expected_ctx > _ceiling:
-            self.log.warning(
-                f"'{model}' requires ctx_size={expected_ctx} (MODELS "
-                f"registry min_ctx_size), but its trained context ceiling "
-                f"is {_ceiling} tokens (max_context_window); loading at "
-                f"{_ceiling} instead. Use a model with a larger trained "
-                f"context if more is needed — no server restart or config "
-                f"change raises a GGUF's trained context."
-            )
+            if model not in self._ceiling_clamp_warned:
+                self.log.warning(
+                    f"'{model}' requires ctx_size={expected_ctx} (MODELS "
+                    f"registry min_ctx_size), but its trained context ceiling "
+                    f"is {_ceiling} tokens (max_context_window); loading at "
+                    f"{_ceiling} instead. Use a model with a larger trained "
+                    f"context if more is needed — no server restart or config "
+                    f"change raises a GGUF's trained context."
+                )
+                self._ceiling_clamp_warned.add(model)
             expected_ctx = _ceiling
         elif _ceiling is None:
             # Not an error — the common case for a model not yet loaded (its
@@ -3393,6 +3382,31 @@ class LemonadeClient:
                 f"current status; proceeding with ctx_size={expected_ctx} "
                 f"without a floor/ceiling check."
             )
+
+        if status is not None:
+            try:
+                loaded_entry = self._find_loaded_entry(status, model)
+
+                if loaded_entry is not None:
+                    loaded_ctx = (
+                        loaded_entry.get("recipe_options", {}).get("ctx_size", 0) or 0
+                    )
+                    if loaded_ctx >= expected_ctx:
+                        self.log.debug(
+                            f"Model '{model}' already loaded at ctx={loaded_ctx} "
+                            f"(expected >= {expected_ctx})"
+                        )
+                        return
+                    # Loaded but under-sized — fall through to the reload path
+                    # which calls /load with explicit ctx_size.
+                    self.log.info(
+                        f"Model '{model}' loaded at ctx={loaded_ctx} but GAIA "
+                        f"expects ctx={expected_ctx}; reloading."
+                    )
+                else:
+                    self.log.debug(f"Model '{model}' not loaded, loading...")
+            except Exception as e:  # pylint: disable=broad-except
+                self.log.debug(f"Could not pre-check model status: {e}")
 
         # Distinguish "needs download" from "needs memory-map" so the user
         # sees an honest expectation. ``list_models`` returns per-model

--- a/src/gaia/llm/lemonade_client.py
+++ b/src/gaia/llm/lemonade_client.py
@@ -184,6 +184,30 @@ def profile_ctx_size(device: Optional[str]) -> int:
     return NPU_CTX_SIZE if (device or "").strip().lower() == "npu" else GPU_CTX_SIZE
 
 
+def resolve_effective_ctx_size(
+    requested_ctx: int, max_context_window: Optional[int]
+) -> int:
+    """The ctx_size actually in force for a load of *requested_ctx* (#2992).
+
+    ``profile_ctx_size`` picks a flat per-device value with no knowledge of
+    the model being loaded. Lemonade's own llama.cpp backend already caps an
+    over-large request at the model's trained context internally (logging
+    ``n_ctx_seq > n_ctx_train``) — but it keeps *reporting* the requested
+    value in ``recipe_options.ctx_size``, a config echo, not a measurement.
+    Clamp against the model's real ``max_context_window`` so GAIA requests
+    and reports the true ceiling instead of relying on — and repeating —
+    that silent server-side cap.
+
+    ``max_context_window`` of ``None`` or ``0`` means "unknown" (Lemonade
+    hasn't resolved the model's metadata yet, e.g. before first download) —
+    never treat that as "no ceiling"; the caller is responsible for warning
+    when the ceiling can't be determined.
+    """
+    if not max_context_window or max_context_window <= 0:
+        return requested_ctx
+    return min(requested_ctx, max_context_window)
+
+
 # ``_handle_large_tool_result``'s truncation trigger/target were tuned as a
 # flat 30000/20000 chars for the NPU's 32768 ctx (#2620). Keep that profile
 # exact and scale the same ratio to the active device's window instead of
@@ -2493,6 +2517,51 @@ class LemonadeClient:
         url = f"{self.base_url}/models/{model_id}"
         return self._send_request("get", url)
 
+    def get_model_max_context_window(
+        self,
+        model_id: str,
+        status: Optional["LemonadeStatus"] = None,
+        *,
+        allow_catalog_lookup: bool = True,
+    ) -> Optional[int]:
+        """Trained context ceiling for *model_id* (Lemonade's ``max_context_window``).
+
+        The value is read from the model's own GGUF metadata, not GAIA's
+        requested ctx_size — it's only populated once Lemonade has resolved
+        that metadata (already loaded, or previously downloaded). Returns
+        ``None`` when unresolved (e.g. an undownloaded model); callers must
+        treat that as "unknown", never as "no ceiling" (#2992).
+
+        Args:
+            model_id: Model identifier to look up.
+            status: An already-fetched :class:`LemonadeStatus` — checked
+                first (no extra HTTP call) via its enriched ``loaded_models``.
+            allow_catalog_lookup: When the model isn't in *status*, fall back
+                to a ``list_models(show_all=True)`` catalog query. Set False
+                for a best-effort, no-network-call check (e.g. a hot loop
+                that already pays for one HTTP round trip per call).
+        """
+        if status is not None:
+            entry = self._find_loaded_entry(status, model_id)
+            if entry is not None:
+                ceiling = entry.get("max_context_window")
+                if ceiling:
+                    return int(ceiling)
+
+        if not allow_catalog_lookup:
+            return None
+
+        try:
+            catalog = self.list_models(show_all=True).get("data", [])
+        except Exception as e:  # pylint: disable=broad-except
+            self.log.debug(f"Could not query model catalog for {model_id!r}: {e}")
+            return None
+        for m in catalog:
+            if _model_ids_match(m.get("id"), model_id):
+                ceiling = m.get("max_context_window")
+                return int(ceiling) if ceiling else None
+        return None
+
     def pull_model(
         self,
         model_name: str,
@@ -3263,6 +3332,7 @@ class LemonadeClient:
         # model is already loaded at a sufficient ctx. A probe failure here is
         # NOT fatal — fall through to the actual load below, whose failure DOES
         # propagate. Only the status/ctx check is swallowed; never the load.
+        status: Optional["LemonadeStatus"] = None
         try:
             # Check current server state. ``status.loaded_models`` carries
             # health entries enriched with ``id`` + ``recipe_options`` so we
@@ -3290,6 +3360,39 @@ class LemonadeClient:
                 self.log.debug(f"Model '{model}' not loaded, loading...")
         except Exception as e:  # pylint: disable=broad-except
             self.log.debug(f"Could not pre-check model status: {e}")
+
+        # Best-effort floor-vs-ceiling conflict check (#2992): if the MODELS
+        # registry requires more context than the model can actually train
+        # on, that's an unresolvable data error — fail loudly rather than
+        # silently loading at a value that reopens the #1030 truncation bug
+        # the registry floor exists to prevent. No extra HTTP call here
+        # (``allow_catalog_lookup=False``) — this only catches the conflict
+        # when the model happens to already be loaded (and thus in
+        # ``status``); an undownloaded model's ceiling is unknown anyway.
+        _ceiling = self.get_model_max_context_window(
+            model, status=status, allow_catalog_lookup=False
+        )
+        if _ceiling and expected_ctx > _ceiling:
+            raise LemonadeClientError(
+                f"GAIA requires ctx_size={expected_ctx} for '{model}' "
+                f"(MODELS registry min_ctx_size), but Lemonade reports its "
+                f"trained context ceiling as {_ceiling} tokens "
+                f"(max_context_window). Lower MODELS[...].min_ctx_size for "
+                f"this model or choose a different one — requesting more "
+                f"than the model supports would silently truncate every "
+                f"prompt."
+            )
+        elif _ceiling is None:
+            # Not an error — the common case for a model not yet loaded (its
+            # metadata isn't resolvable without a catalog round trip, which
+            # this best-effort check intentionally skips). Named at debug so
+            # the "unknown, proceeding anyway" choice is traceable, not a
+            # silent no-op (#2992).
+            self.log.debug(
+                f"No max_context_window resolvable for '{model}' from the "
+                f"current status; proceeding with ctx_size={expected_ctx} "
+                f"without a floor/ceiling check."
+            )
 
         # Distinguish "needs download" from "needs memory-map" so the user
         # sees an honest expectation. ``list_models`` returns per-model
@@ -4022,6 +4125,11 @@ class LemonadeClient:
                         "labels": catalog.get("labels", []),
                         "recipe_options": hm.get("recipe_options", {}),
                         "checkpoint": hm.get("checkpoint", ""),
+                        # Trained-context ceiling (#2992) — ``/health`` reports
+                        # this directly on the loaded entry, so no second
+                        # catalog round trip is needed once a model is loaded.
+                        "max_context_window": hm.get("max_context_window")
+                        or catalog.get("max_context_window"),
                         "_health": hm,
                     }
                 )

--- a/src/gaia/llm/lemonade_manager.py
+++ b/src/gaia/llm/lemonade_manager.py
@@ -667,6 +667,16 @@ class LemonadeManager:
                             and cls._context_size < min_context_size
                             and llm_models_loaded
                         ):
+                            # Same wasted-reload trap as the init block below
+                            # (#2992): already at the model's known ceiling,
+                            # so a reload would just redo the identical load.
+                            if (
+                                cls._context_ceiling is not None
+                                and cls._context_size >= cls._context_ceiling
+                            ):
+                                cls._report_capped_at_ceiling(min_context_size, quiet)
+                                return True
+
                             if cls._try_reload_with_ctx(
                                 client, status, min_context_size, quiet, cls._lock
                             ):
@@ -799,15 +809,7 @@ class LemonadeManager:
                     and cls._context_size < min_context_size
                     and llm_models_loaded
                 ):
-                    cls._log.warning(
-                        f"Lemonade loaded with {cls._context_size} tokens, "
-                        f"capped by the model's trained context (requested "
-                        f"{min_context_size})."
-                    )
-                    if not quiet:
-                        cls.print_context_message(
-                            cls._context_size, min_context_size, MessageType.WARNING
-                        )
+                    cls._report_capped_at_ceiling(min_context_size, quiet)
                     return True
 
                 # Only warn if:
@@ -820,6 +822,23 @@ class LemonadeManager:
                     and cls._context_size < min_context_size
                     and llm_models_loaded
                 ):
+                    # ``_honest_context_size`` above already resolved this
+                    # model's ceiling against the same ``status`` a reload
+                    # attempt would use — if we're already sitting at it, a
+                    # reload can't raise the effective context. Skip the
+                    # (real, blocking) model reload entirely rather than
+                    # doing one that is guaranteed to reproduce the exact
+                    # same result (#2992): every ``gaia <cmd>`` invocation is
+                    # a fresh process, so an unconditional reload here would
+                    # fire on every single command, not just once.
+                    at_known_ceiling = (
+                        cls._context_ceiling is not None
+                        and cls._context_size >= cls._context_ceiling
+                    )
+                    if at_known_ceiling:
+                        cls._report_capped_at_ceiling(min_context_size, quiet)
+                        return True
+
                     if cls._try_reload_with_ctx(
                         client, status, min_context_size, quiet, cls._lock
                     ):
@@ -901,6 +920,24 @@ class LemonadeManager:
                 ceiling,
             )
         return honest_ctx
+
+    @classmethod
+    def _report_capped_at_ceiling(cls, min_context_size: int, quiet: bool) -> None:
+        """Tell the truth once about a model already at its real ceiling.
+
+        Shared by every call site that finds ``cls._context_size`` pinned at
+        ``cls._context_ceiling`` below ``min_context_size`` (#2992) — a
+        reload can't raise a value already at the model's trained-context
+        ceiling, so none of these call sites should attempt one.
+        """
+        cls._log.warning(
+            f"Lemonade running with {cls._context_size} tokens, capped by "
+            f"the model's trained context (requested {min_context_size})."
+        )
+        if not quiet:
+            cls.print_context_message(
+                cls._context_size, min_context_size, MessageType.WARNING
+            )
 
     @classmethod
     def _try_preload_with_ctx(

--- a/src/gaia/llm/lemonade_manager.py
+++ b/src/gaia/llm/lemonade_manager.py
@@ -395,6 +395,29 @@ class LemonadeManager:
         print("", file=sys.stderr)
 
     @classmethod
+    def print_ceiling_message(cls, current_size: int, requested_size: int):
+        """Print the message for a model already at its trained-context ceiling.
+
+        Distinct from :meth:`print_context_message` (#2992): that message's
+        remediation — stop the server, restart with a bigger ctx_size — does
+        nothing here, because the shortfall is a property of the *model*
+        (its GGUF's ``n_ctx_train``), not the server configuration. No
+        restart, flag, or `gaia init` raises a model's trained context.
+        """
+        print("", file=sys.stderr)
+        print(
+            f"⚠️  This model's trained context is {current_size} tokens "
+            f"(requested {requested_size}); that is the maximum available "
+            f"regardless of configuration.",
+            file=sys.stderr,
+        )
+        print(
+            "   Use a model with a larger trained context if you need more.",
+            file=sys.stderr,
+        )
+        print("", file=sys.stderr)
+
+    @classmethod
     def _validate_device_requirement(cls, client, required_min_device, device):
         """Raise ``HardwareRequirementError`` if *required_min_device* isn't met.
 
@@ -935,9 +958,7 @@ class LemonadeManager:
             f"the model's trained context (requested {min_context_size})."
         )
         if not quiet:
-            cls.print_context_message(
-                cls._context_size, min_context_size, MessageType.WARNING
-            )
+            cls.print_ceiling_message(cls._context_size, min_context_size)
 
     @classmethod
     def _try_preload_with_ctx(

--- a/src/gaia/llm/lemonade_manager.py
+++ b/src/gaia/llm/lemonade_manager.py
@@ -281,6 +281,11 @@ class LemonadeManager:
     # "already at the model's real max" and stop retrying a reload that
     # would just hit the same wall every time.
     _context_ceiling: Optional[int] = None
+    # The model id ``_context_ceiling`` was measured against. A long-lived
+    # process (e.g. ``gaia.ui.server``) can switch to a roomier model after
+    # caching a small model's ceiling — without this, the fast path would
+    # keep reporting the old model's cap forever (#2992).
+    _context_ceiling_model: Optional[str] = None
     _lock = threading.Lock()
     _log = get_logger(__name__)
 
@@ -619,7 +624,22 @@ class LemonadeManager:
                     cls._context_ceiling is not None
                     and cls._context_size >= cls._context_ceiling
                 )
-                if cls._context_size >= min_context_size or at_known_ceiling:
+                # A cached ceiling is only trustworthy for the model it was
+                # measured against — a long-lived process (e.g.
+                # gaia.ui.server) can switch to a roomier model between
+                # calls (#2992). There's no live model id here without a
+                # status call, so require one periodically rather than
+                # trusting the cached ceiling forever; the fall-through
+                # below is itself rate-limited by _RECHECK_INTERVAL, so this
+                # doesn't add an unconditional get_status() to every call.
+                now = time.monotonic()
+                ceiling_needs_reconfirm = (
+                    at_known_ceiling
+                    and now - cls._last_recheck_time >= cls._RECHECK_INTERVAL
+                )
+                if cls._context_size >= min_context_size or (
+                    at_known_ceiling and not ceiling_needs_reconfirm
+                ):
                     cls._log.debug(
                         "Lemonade already initialized with sufficient context"
                     )
@@ -630,7 +650,6 @@ class LemonadeManager:
                     # every single chat message triggers 2 HTTP calls (/health +
                     # /models) just to re-validate context size, adding 40-200 ms of
                     # blocking overhead even for trivial replies like "cool".
-                    now = time.monotonic()
                     if now - cls._last_recheck_time < cls._RECHECK_INTERVAL:
                         cls._log.debug(
                             "Skipping context re-check (%.1fs ago, interval=%.1fs)",
@@ -656,6 +675,11 @@ class LemonadeManager:
                                 verbose=not quiet,
                             )
                         status = client.get_status()
+                        # Defensive normalisation: some Lemonade versions can
+                        # return `loaded_models: null`, which would crash the
+                        # `any(...)` and `_find_loaded_llm_id` calls below.
+                        if status.loaded_models is None:
+                            status.loaded_models = []
                         # Update cached context size — clamped against the
                         # loaded model's real ceiling, never a bare echo of
                         # what the server reports back (#2992).
@@ -956,6 +980,7 @@ class LemonadeManager:
         ceiling = client.get_model_max_context_window(model_id, status=status)
         if ceiling:
             cls._context_ceiling = ceiling
+            cls._context_ceiling_model = model_id
         honest_ctx = resolve_effective_ctx_size(reported_ctx, ceiling)
         if honest_ctx < reported_ctx:
             cls._log.warning(
@@ -1103,7 +1128,9 @@ class LemonadeManager:
             or ceiling
         )
         effective_ctx = resolve_effective_ctx_size(requested_ctx, final_ceiling)
-        cls._context_ceiling = final_ceiling
+        if final_ceiling:
+            cls._context_ceiling = final_ceiling
+            cls._context_ceiling_model = DEFAULT_MODEL_NAME
 
         if not quiet:
             if effective_ctx < min_context_size:
@@ -1194,7 +1221,9 @@ class LemonadeManager:
             effective_ctx = resolve_effective_ctx_size(
                 reported_ctx or requested_ctx, new_ceiling
             )
-            cls._context_ceiling = new_ceiling
+            if new_ceiling:
+                cls._context_ceiling = new_ceiling
+                cls._context_ceiling_model = model_id
             success = effective_ctx >= min_context_size
             if success:
                 cls._log.info(
@@ -1270,6 +1299,7 @@ class LemonadeManager:
             cls._base_url = None
             cls._context_size = 0
             cls._context_ceiling = None
+            cls._context_ceiling_model = None
             cls._last_recheck_time = 0.0
             cls._validated_min_devices = set()
             cls._log.debug("LemonadeManager state reset")

--- a/src/gaia/llm/lemonade_manager.py
+++ b/src/gaia/llm/lemonade_manager.py
@@ -19,6 +19,8 @@ from gaia.llm.lemonade_client import (
     DEFAULT_MODEL_NAME,
     LemonadeClient,
     LemonadeClientError,
+    LemonadeStatus,
+    resolve_effective_ctx_size,
 )
 from gaia.llm.lemonade_launcher import describe_start_hint
 from gaia.logger import get_logger
@@ -274,6 +276,11 @@ class LemonadeManager:
     _initialized = False
     _base_url: Optional[str] = None
     _context_size: int = 0
+    # The loaded model's trained-context ceiling (``max_context_window``),
+    # once discovered (#2992). Lets the recheck fast-path recognize
+    # "already at the model's real max" and stop retrying a reload that
+    # would just hit the same wall every time.
+    _context_ceiling: Optional[int] = None
     _lock = threading.Lock()
     _log = get_logger(__name__)
 
@@ -582,7 +589,14 @@ class LemonadeManager:
 
             # If already initialized, just verify context size
             if cls._initialized:
-                if cls._context_size >= min_context_size:
+                # Already at the model's real ceiling (#2992): further
+                # reload attempts would just hit the same wall, so accept
+                # the capped reality instead of retrying every recheck.
+                at_known_ceiling = (
+                    cls._context_ceiling is not None
+                    and cls._context_size >= cls._context_ceiling
+                )
+                if cls._context_size >= min_context_size or at_known_ceiling:
                     cls._log.debug(
                         "Lemonade already initialized with sufficient context"
                     )
@@ -619,8 +633,15 @@ class LemonadeManager:
                                 verbose=not quiet,
                             )
                         status = client.get_status()
-                        # Update cached context size
-                        cls._context_size = status.context_size or 0
+                        # Update cached context size — clamped against the
+                        # loaded model's real ceiling, never a bare echo of
+                        # what the server reports back (#2992).
+                        _raw_ctx = status.context_size or 0
+                        cls._context_size = (
+                            cls._honest_context_size(client, status, _raw_ctx)
+                            if _raw_ctx
+                            else 0
+                        )
 
                         # Only warn if LLM models are loaded AND context is insufficient
                         # SD models don't have context size, only LLM models do
@@ -702,8 +723,17 @@ class LemonadeManager:
                     status.loaded_models = []
 
                 # Snapshot context size — we may overwrite it below if the
-                # preload helper successfully seeds the server.
-                context_size_value = status.context_size or 0
+                # preload helper successfully seeds the server. Clamped
+                # against the loaded model's real ceiling (#2992): a model
+                # already resident from an earlier process life can report a
+                # ctx_size echo that Lemonade silently capped lower, and that
+                # must not be trusted just because it's already "sufficient".
+                _raw_ctx = status.context_size or 0
+                context_size_value = (
+                    cls._honest_context_size(client, status, _raw_ctx)
+                    if _raw_ctx
+                    else 0
+                )
 
                 # Detect LLM-loaded state once for the branch decisions below.
                 llm_models_loaded = any(
@@ -726,14 +756,15 @@ class LemonadeManager:
                 # (issue #839).  We run this BEFORE setting cls._initialized
                 # so a failed preload leaves the singleton retryable instead
                 # of poisoned with (initialized=True, ctx=0).
+                just_preloaded = False
                 if context_size_value == 0 and not llm_models_loaded:
-                    cls._try_preload_with_ctx(
+                    context_size_value, status = cls._try_preload_with_ctx(
                         client, min_context_size, quiet, cls._lock
                     )
-                    context_size_value = min_context_size
-                    # Re-fetch model list so the small-ctx reload branch below
-                    # sees the freshly-loaded model.
-                    status = client.get_status()
+                    just_preloaded = True
+                    # ``_try_preload_with_ctx`` already re-fetched status
+                    # post-load (needed for its own honest reporting) — reuse
+                    # it here instead of a second get_status() round trip.
                     if status.loaded_models is None:
                         status.loaded_models = []
                     llm_models_loaded = any(
@@ -758,12 +789,34 @@ class LemonadeManager:
                 # ``_maybe_validate_device`` (runs on every call, before this
                 # init block), so there is nothing to re-check here.
 
+                # A just-completed preload already clamped ctx_size to the
+                # model's real ceiling and reported honestly (#2992) —
+                # retrying via ``_try_reload_with_ctx`` below would just hit
+                # the same ceiling again with a wasted reload.
+                if (
+                    just_preloaded
+                    and cls._context_size > 0
+                    and cls._context_size < min_context_size
+                    and llm_models_loaded
+                ):
+                    cls._log.warning(
+                        f"Lemonade loaded with {cls._context_size} tokens, "
+                        f"capped by the model's trained context (requested "
+                        f"{min_context_size})."
+                    )
+                    if not quiet:
+                        cls.print_context_message(
+                            cls._context_size, min_context_size, MessageType.WARNING
+                        )
+                    return True
+
                 # Only warn if:
                 # 1. Context size is non-zero (0 means no model loaded or model still loading)
                 # 2. Context size is less than required
                 # 3. LLM models are loaded (SD models don't have context size)
                 if (
-                    cls._context_size > 0
+                    not just_preloaded
+                    and cls._context_size > 0
                     and cls._context_size < min_context_size
                     and llm_models_loaded
                 ):
@@ -793,6 +846,62 @@ class LemonadeManager:
                     cls.print_server_error(min_context_size)
                 return False
 
+    @staticmethod
+    def _find_loaded_llm_id(status: "LemonadeStatus") -> Optional[str]:
+        """The model id of the LLM currently loaded, or None.
+
+        ``type=="llm"`` is the precise check on health-format entries; the
+        label fallback covers legacy code paths that populate
+        ``loaded_models`` from the catalog (which lacks ``type``). Embedding
+        and image models are excluded — reloading/clamping them with an LLM
+        ctx_size makes no sense and (pre-#1030 follow-up) used to pick the
+        wrong model entirely because the embedder can sort before ``Gemma-…``.
+        """
+        llm_models = [
+            m
+            for m in status.loaded_models
+            if m.get("type") == "llm"
+            or (
+                m.get("type") is None
+                and "image" not in m.get("labels", [])
+                and "embeddings" not in m.get("labels", [])
+            )
+        ]
+        if not llm_models:
+            return None
+        return llm_models[0].get("model_name") or llm_models[0].get("id") or None
+
+    @classmethod
+    def _honest_context_size(
+        cls, client: "LemonadeClient", status: "LemonadeStatus", reported_ctx: int
+    ) -> int:
+        """Clamp `reported_ctx` (a `/health` config echo) against the loaded
+        model's real `max_context_window` ceiling, if discoverable (#2992).
+
+        Lemonade can report a model loaded with the ctx_size that was
+        *requested* even when it silently capped the actual window lower —
+        this closes that gap for every code path that reads
+        ``status.context_size`` and is tempted to trust it outright,
+        including the "already sufficient, no reload needed" fast paths that
+        a reload-triggered clamp alone would never reach.
+        """
+        model_id = cls._find_loaded_llm_id(status)
+        if not model_id:
+            return reported_ctx
+        ceiling = client.get_model_max_context_window(model_id, status=status)
+        if ceiling:
+            cls._context_ceiling = ceiling
+        honest_ctx = resolve_effective_ctx_size(reported_ctx, ceiling)
+        if honest_ctx < reported_ctx:
+            cls._log.warning(
+                "%s reports ctx_size=%d, but its trained context ceiling is "
+                "%d tokens; using the real value.",
+                model_id,
+                reported_ctx,
+                ceiling,
+            )
+        return honest_ctx
+
     @classmethod
     def _try_preload_with_ctx(
         cls,
@@ -800,7 +909,7 @@ class LemonadeManager:
         min_context_size: int,
         quiet: bool,
         lock: "threading.Lock",
-    ) -> None:
+    ) -> Tuple[int, "LemonadeStatus"]:
         """Load the default LLM with the required ctx_size on an idle server.
 
         Closes the gap left by `_try_reload_with_ctx`, which only handles the
@@ -815,20 +924,53 @@ class LemonadeManager:
         block other threads (status pollers, parallel `ensure_ready` callers)
         for that long.  Mirrors the lock discipline of `_try_reload_with_ctx`.
 
+        Returns:
+            A ``(ctx_size, status)`` pair: the ctx_size actually in force
+            after the load (#2992) — `min_context_size` clamped to the
+            model's Lemonade-reported `max_context_window` ceiling when
+            known, so callers cache and report the real window instead of
+            echoing back the request — and the post-load status, so the
+            caller doesn't pay for a second `get_status()` round trip.
+
         Raises:
             LemonadeClientError: if `load_model` fails. Carries an actionable
                 message (Lemonade / ctx_size= / the platform's real start
                 command) so the user can recover manually if the auto-preload
                 cannot.
         """
+        # Proactive clamp (#2992): a model already downloaded from a prior
+        # run has its ceiling in the catalog before we ever call /load, so
+        # request the real value up front instead of relying on Lemonade's
+        # own internal cap (which loads fine but keeps echoing the
+        # over-large request back in status).
+        ceiling = client.get_model_max_context_window(DEFAULT_MODEL_NAME)
+        requested_ctx = resolve_effective_ctx_size(min_context_size, ceiling)
+        if ceiling is None:
+            cls._log.warning(
+                "Lemonade reported no max_context_window for %s (metadata "
+                "not yet resolved); proceeding with ctx_size=%d — the "
+                "effective window may be capped lower once loaded.",
+                DEFAULT_MODEL_NAME,
+                min_context_size,
+            )
+        elif requested_ctx < min_context_size:
+            cls._log.warning(
+                "%s's trained context caps at %d tokens; requested %d, "
+                "loading at %d instead.",
+                DEFAULT_MODEL_NAME,
+                ceiling,
+                min_context_size,
+                requested_ctx,
+            )
+
         cls._log.info(
             "Preloading '%s' with ctx_size=%d on idle Lemonade server",
             DEFAULT_MODEL_NAME,
-            min_context_size,
+            requested_ctx,
         )
         if not quiet:
             print(
-                f"\n⏳ Loading {DEFAULT_MODEL_NAME} with ctx_size={min_context_size} "
+                f"\n⏳ Loading {DEFAULT_MODEL_NAME} with ctx_size={requested_ctx} "
                 f"tokens. This may take a moment (first run downloads the model)...",
                 flush=True,
             )
@@ -841,17 +983,17 @@ class LemonadeManager:
         try:
             client.load_model(
                 DEFAULT_MODEL_NAME,
-                ctx_size=min_context_size,
+                ctx_size=requested_ctx,
                 prompt=False,
                 auto_download=True,
             )
         except Exception as e:
             raise LemonadeClientError(
                 f"Failed to preload Lemonade model {DEFAULT_MODEL_NAME!r} with "
-                f"ctx_size={min_context_size} on idle server at "
+                f"ctx_size={requested_ctx} on idle server at "
                 f"{client.base_url}.\n"
                 f"To recover manually: stop the running server, then restart it "
-                f"({describe_start_hint(min_context_size).instruction}) and "
+                f"({describe_start_hint(requested_ctx).instruction}) and "
                 f"re-run your GAIA command.\n"
                 f"See the Lemonade server log for details "
                 f"(typical path: ~/.cache/lemonade/server.log)."
@@ -859,11 +1001,32 @@ class LemonadeManager:
         finally:
             lock.acquire()
 
+        # Honest post-load report (#2992): loading resolves the model's
+        # metadata, so a ceiling unknown before download (the common
+        # first-run case) may now be known — re-check rather than trust the
+        # pre-load guess.
+        final_status = client.get_status()
+        final_ceiling = (
+            client.get_model_max_context_window(DEFAULT_MODEL_NAME, status=final_status)
+            or ceiling
+        )
+        effective_ctx = resolve_effective_ctx_size(requested_ctx, final_ceiling)
+        cls._context_ceiling = final_ceiling
+
         if not quiet:
-            print(
-                f"✅ Loaded {DEFAULT_MODEL_NAME} with ctx_size={min_context_size}.",
-                flush=True,
-            )
+            if effective_ctx < min_context_size:
+                print(
+                    f"⚠️  Loaded {DEFAULT_MODEL_NAME} with ctx_size={effective_ctx} "
+                    f"tokens (requested {min_context_size}; the model's trained "
+                    f"context caps it at {effective_ctx}).",
+                    flush=True,
+                )
+            else:
+                print(
+                    f"✅ Loaded {DEFAULT_MODEL_NAME} with ctx_size={effective_ctx}.",
+                    flush=True,
+                )
+        return effective_ctx, final_status
 
     @classmethod
     def _try_reload_with_ctx(
@@ -881,37 +1044,41 @@ class LemonadeManager:
 
         Returns True if reload succeeded and context is now sufficient.
         """
-        # Filter to the LLM(s) actually loaded. ``type=="llm"`` is the
-        # precise check on health-format entries; the label fallback
-        # covers legacy code paths that populate ``loaded_models`` from
-        # the catalog (which lacks ``type``). Embedding and image models
-        # are excluded — reloading them with an LLM ctx_size makes no
-        # sense and (pre-#1030 follow-up) used to load the wrong model
-        # entirely because the embedder can sort before ``Gemma-…``.
-        llm_models = [
-            m
-            for m in status.loaded_models
-            if m.get("type") == "llm"
-            or (
-                m.get("type") is None
-                and "image" not in m.get("labels", [])
-                and "embeddings" not in m.get("labels", [])
-            )
-        ]
-        if not llm_models:
-            return False
-
-        model_id = llm_models[0].get("model_name") or llm_models[0].get("id", "")
+        model_id = cls._find_loaded_llm_id(status)
         if not model_id:
             return False
 
+        # Proactive clamp (#2992): the model is already loaded, so its
+        # catalog entry (and often ``status`` itself) already carries its
+        # real ceiling — request that instead of relying on Lemonade's
+        # internal cap-and-echo.
+        ceiling = client.get_model_max_context_window(model_id, status=status)
+        requested_ctx = resolve_effective_ctx_size(min_context_size, ceiling)
+        if ceiling is None:
+            cls._log.warning(
+                "Lemonade reported no max_context_window for %s (metadata "
+                "not yet resolved); proceeding with ctx_size=%d — the "
+                "effective window may be capped lower once reloaded.",
+                model_id,
+                min_context_size,
+            )
+        elif requested_ctx < min_context_size:
+            cls._log.warning(
+                "%s's trained context caps at %d tokens; requested %d, "
+                "reloading at %d instead.",
+                model_id,
+                ceiling,
+                min_context_size,
+                requested_ctx,
+            )
+
         cls._log.info(
-            f"Auto-reloading '{model_id}' with ctx_size={min_context_size} "
+            f"Auto-reloading '{model_id}' with ctx_size={requested_ctx} "
             f"(was {cls._context_size})"
         )
         if not quiet:
             print(
-                f"\n⏳ Reloading model with ctx_size={min_context_size} tokens "
+                f"\n⏳ Reloading model with ctx_size={requested_ctx} tokens "
                 f"(was {cls._context_size}). This may take a moment...",
                 flush=True,
             )
@@ -920,39 +1087,63 @@ class LemonadeManager:
         # other threads (e.g. status polling) are not stalled.
         lock.release()
         try:
-            client.load_model(model_id, ctx_size=min_context_size, prompt=False)
-            # Check if the server now reports the new context size.
-            # Some Lemonade versions do not expose ctx_size in their status
-            # (they return 0), and some may not honor the ctx_size parameter
-            # at all (always reporting the default, e.g. 4096).
-            #
-            # Regardless of what the server reports, update cls._context_size
-            # to min_context_size so we don't trigger an infinite reload loop
-            # on every request.  If the reload didn't actually change the
-            # model's context window the agent will still run — responses may
-            # be degraded — but at least the UI won't be stuck in a reload
-            # cycle on every message.
+            client.load_model(model_id, ctx_size=requested_ctx, prompt=False)
+            # Re-check what the server actually has in force. ``context_size``
+            # is a config echo of the request (``recipe_options.ctx_size``),
+            # not a measurement — clamp it against the model's real ceiling
+            # (now resolvable, since loading forces Lemonade to read the
+            # GGUF metadata) so the cached/reported value is honest (#2992).
             new_status = client.get_status()
             reported_ctx = new_status.context_size or 0
-            actual_ctx = (
-                reported_ctx if reported_ctx >= min_context_size else min_context_size
+            new_ceiling = (
+                client.get_model_max_context_window(model_id, status=new_status)
+                or ceiling
             )
-            success = reported_ctx >= min_context_size
+            effective_ctx = resolve_effective_ctx_size(
+                reported_ctx or requested_ctx, new_ceiling
+            )
+            cls._context_ceiling = new_ceiling
+            success = effective_ctx >= min_context_size
             if success:
                 cls._log.info(
-                    f"Model reloaded successfully with ctx_size={reported_ctx}"
+                    f"Model reloaded successfully with ctx_size={effective_ctx}"
                 )
                 if not quiet:
-                    print(f"✅ Context size updated to {reported_ctx} tokens.")
+                    print(f"✅ Context size updated to {effective_ctx} tokens.")
+            elif new_ceiling:
+                cls._log.warning(
+                    "ctx_size after reload: effective=%d (need %d), capped by "
+                    "%s's trained context ceiling of %d.",
+                    effective_ctx,
+                    min_context_size,
+                    model_id,
+                    new_ceiling,
+                )
+                if not quiet:
+                    print(
+                        f"⚠️  Context size updated to {effective_ctx} tokens "
+                        f"(requested {min_context_size}; capped by the model's "
+                        f"trained context of {new_ceiling})."
+                    )
             else:
+                # No known ceiling explains the shortfall — an old Lemonade
+                # that doesn't honor/expose ctx_size at all, not a real
+                # per-model cap. Unlike the known-ceiling branch above,
+                # ``_context_ceiling`` stays unset here, so nothing would
+                # stop `ensure_ready` retrying this reload every recheck
+                # interval forever. Preserve the pre-#2992 behaviour: assume
+                # success and cache ``min_context_size`` to break the loop.
                 cls._log.warning(
                     "ctx_size after reload: reported=%d (need %d). "
                     "Assuming reload succeeded to prevent reload loop.",
                     reported_ctx,
                     min_context_size,
                 )
-            # Always update the cached context size to break the reload loop.
-            cls._context_size = actual_ctx
+                effective_ctx = min_context_size
+            # Always update the cached context size to the value determined
+            # above (honest when a real ceiling was found; the legacy
+            # loop-breaking assumption otherwise).
+            cls._context_size = effective_ctx
             return success
         except Exception as e:
             cls._log.warning(f"Auto-reload failed: {e}")
@@ -986,6 +1177,7 @@ class LemonadeManager:
             cls._initialized = False
             cls._base_url = None
             cls._context_size = 0
+            cls._context_ceiling = None
             cls._last_recheck_time = 0.0
             cls._validated_min_devices = set()
             cls._log.debug("LemonadeManager state reset")

--- a/src/gaia/llm/lemonade_manager.py
+++ b/src/gaia/llm/lemonade_manager.py
@@ -704,6 +704,18 @@ class LemonadeManager:
                                 client, status, min_context_size, quiet, cls._lock
                             ):
                                 return True
+                            # The reload can have failed because it just
+                            # discovered the model's real ceiling (#2992) —
+                            # in that case "restart with a bigger ctx_size"
+                            # is wrong advice, so report the cap instead.
+                            if (
+                                cls._context_ceiling is not None
+                                and cls._context_size >= cls._context_ceiling
+                            ):
+                                cls._report_capped_at_ceiling(
+                                    min_context_size, quiet, already_announced=True
+                                )
+                                return True
                             cls._log.warning(
                                 f"Lemonade running with {cls._context_size} tokens, "
                                 f"but {min_context_size} requested. Restart Lemonade "
@@ -866,6 +878,17 @@ class LemonadeManager:
                         client, status, min_context_size, quiet, cls._lock
                     ):
                         return True
+                    # As above (#2992): a reload that failed because it just
+                    # discovered the model's real ceiling should report the
+                    # cap, not tell the user to restart the server.
+                    if (
+                        cls._context_ceiling is not None
+                        and cls._context_size >= cls._context_ceiling
+                    ):
+                        cls._report_capped_at_ceiling(
+                            min_context_size, quiet, already_announced=True
+                        )
+                        return True
                     cls._log.warning(
                         f"Context size {cls._context_size} is less than "
                         f"requested {min_context_size}. Some features may not work correctly."
@@ -945,19 +968,30 @@ class LemonadeManager:
         return honest_ctx
 
     @classmethod
-    def _report_capped_at_ceiling(cls, min_context_size: int, quiet: bool) -> None:
+    def _report_capped_at_ceiling(
+        cls,
+        min_context_size: int,
+        quiet: bool,
+        already_announced: bool = False,
+    ) -> None:
         """Tell the truth once about a model already at its real ceiling.
 
         Shared by every call site that finds ``cls._context_size`` pinned at
         ``cls._context_ceiling`` below ``min_context_size`` (#2992) — a
         reload can't raise a value already at the model's trained-context
         ceiling, so none of these call sites should attempt one.
+
+        Args:
+            already_announced: True when the caller already printed the
+                ceiling message itself (e.g. ``_try_reload_with_ctx`` on the
+                reload attempt that just discovered the ceiling) — skips the
+                user-facing print to avoid showing it twice, but still logs.
         """
         cls._log.warning(
             f"Lemonade running with {cls._context_size} tokens, capped by "
             f"the model's trained context (requested {min_context_size})."
         )
-        if not quiet:
+        if not quiet and not already_announced:
             cls.print_ceiling_message(cls._context_size, min_context_size)
 
     @classmethod

--- a/src/gaia/ui/routers/system.py
+++ b/src/gaia/ui/routers/system.py
@@ -20,6 +20,7 @@ from pydantic import BaseModel, Field
 from gaia.llm.lemonade_client import (
     DEFAULT_CONTEXT_SIZE,
     lemonade_auth_headers,
+    resolve_effective_ctx_size,
     resolve_lemonade_api_key,
 )
 from gaia.llm.lemonade_manager import gpu_display_info
@@ -503,10 +504,18 @@ async def system_status(request: Request, db: ChatDatabase = Depends(get_db)):
                                 status.model_loaded = m_name
                             status.model_device = m.get("device")
                             # Actual loaded context size (preferred over catalog
-                            # default).
+                            # default) — clamped against the model's real
+                            # max_context_window (#2992). recipe_options.ctx_size
+                            # is a config echo, not a measurement: Lemonade can
+                            # report the ctx_size it was ASKED for even after
+                            # silently capping it lower, which without this
+                            # clamp made the UI report a different (higher, wrong)
+                            # context than the CLI for the same running server.
                             ctx = m.get("recipe_options", {}).get("ctx_size")
                             if ctx is not None:
-                                status.model_context_size = ctx
+                                status.model_context_size = resolve_effective_ctx_size(
+                                    ctx, m.get("max_context_window")
+                                )
                             _llm_found = True  # take only the first matching LLM
 
                 # Fallback: older Lemonade versions expose context_size at root level
@@ -523,11 +532,17 @@ async def system_status(request: Request, db: ChatDatabase = Depends(get_db)):
                             status.model_size_gb = m.get("size")
                             status.model_labels = m.get("labels")
                             # Only use catalog ctx_size when health data didn't
-                            # provide it (e.g. model not yet fully loaded)
+                            # provide it (e.g. model not yet fully loaded) —
+                            # clamped the same way as the health-derived value
+                            # above.
                             if status.model_context_size is None:
                                 ctx = m.get("recipe_options", {}).get("ctx_size")
                                 if ctx is not None:
-                                    status.model_context_size = ctx
+                                    status.model_context_size = (
+                                        resolve_effective_ctx_size(
+                                            ctx, m.get("max_context_window")
+                                        )
+                                    )
                         if "embed" in m.get("id", "").lower():
                             status.embedding_model_loaded = True
 

--- a/tests/unit/chat/ui/test_server.py
+++ b/tests/unit/chat/ui/test_server.py
@@ -305,6 +305,67 @@ class TestSystemStatus:
         assert data["context_size_sufficient"] is True
 
     @patch("httpx.AsyncClient")
+    def test_system_status_ctx_size_clamped_to_model_ceiling(self, mock_httpx_cls, client):
+        """recipe_options.ctx_size is Lemonade's config echo of what was
+        REQUESTED, not a measurement — it can report the request even after
+        silently capping the real window lower (#2992). The reported
+        model_context_size must be clamped to max_context_window, matching
+        the CLI's LemonadeManager clamp, so the UI never shows a different
+        (higher, wrong) context than the CLI for the same running server."""
+        mock_client = AsyncMock()
+
+        def make_response(status_code, json_data):
+            resp = MagicMock()
+            resp.status_code = status_code
+            resp.json.return_value = json_data
+            return resp
+
+        health_data = {
+            "status": "ok",
+            "model_loaded": "Gemma-4-E4B-it-GGUF",
+            "version": "9.2.0",
+            "all_models_loaded": [
+                {
+                    "model_name": "Gemma-4-E4B-it-GGUF",
+                    "type": "llm",
+                    "device": "amd_npu",
+                    # Requested 65536 (echoed back as "sufficient"), but the
+                    # model's real trained ceiling is 16384 — below GAIA's
+                    # 32768 minimum.
+                    "recipe_options": {"ctx_size": 65536},
+                    "max_context_window": 16384,
+                }
+            ],
+        }
+        models_data = {"data": [{"id": "Gemma-4-E4B-it-GGUF", "downloaded": True}]}
+
+        async def mock_get(url, **kwargs):
+            if "/health" in url:
+                return make_response(200, health_data)
+            if "/stats" in url:
+                return make_response(404, {})
+            if "/system-info" in url:
+                return make_response(404, {})
+            return make_response(200, models_data)
+
+        mock_client.get = mock_get
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+        mock_httpx_cls.return_value = mock_client
+
+        resp = client.get("/api/system/status")
+        data = resp.json()
+        assert data["lemonade_running"] is True
+        assert data["model_context_size"] == 16384, (
+            "Must report the real ceiling, not the raw recipe_options echo "
+            "that merely repeats the 65536 that was requested."
+        )
+        assert data["context_size_sufficient"] is False, (
+            "The echo alone (65536) would read as sufficient — only the "
+            "clamped real ceiling (16384 < 32768) reveals it is not."
+        )
+
+    @patch("httpx.AsyncClient")
     def test_system_status_model_not_downloaded(self, mock_httpx_cls, client):
         """model_downloaded is False when no model is loaded and default not in catalog."""
         mock_client = AsyncMock()

--- a/tests/unit/chat/ui/test_server.py
+++ b/tests/unit/chat/ui/test_server.py
@@ -305,7 +305,9 @@ class TestSystemStatus:
         assert data["context_size_sufficient"] is True
 
     @patch("httpx.AsyncClient")
-    def test_system_status_ctx_size_clamped_to_model_ceiling(self, mock_httpx_cls, client):
+    def test_system_status_ctx_size_clamped_to_model_ceiling(
+        self, mock_httpx_cls, client
+    ):
         """recipe_options.ctx_size is Lemonade's config echo of what was
         REQUESTED, not a measurement — it can report the request even after
         silently capping the real window lower (#2992). The reported

--- a/tests/unit/test_lemonade_ctx_ceiling.py
+++ b/tests/unit/test_lemonade_ctx_ceiling.py
@@ -14,8 +14,6 @@ the value actually in force.
 
 from unittest.mock import patch
 
-import pytest
-
 from gaia.llm.lemonade_client import (
     NPU_CTX_SIZE,
     LemonadeClient,

--- a/tests/unit/test_lemonade_ctx_ceiling.py
+++ b/tests/unit/test_lemonade_ctx_ceiling.py
@@ -156,7 +156,8 @@ class TestFloorCeilingConflict:
         same (floor, ceiling) conflict, and the manager's own reload path
         already reaches this state successfully."""
         client = LemonadeClient(host="localhost", port=13305)
-        # Qwen3-0.6B-GGUF's registry floor is 4096; report a ceiling below it.
+        # Qwen3-0.6B-GGUF's registry floor is 4096; report a ceiling below it,
+        # with the model resident under that ceiling so a reload is expected.
         mock_status.return_value = LemonadeStatus(
             url="http://localhost:13305",
             running=True,
@@ -165,7 +166,7 @@ class TestFloorCeilingConflict:
                     "id": "Qwen3-0.6B-GGUF",
                     "model_name": "Qwen3-0.6B-GGUF",
                     "max_context_window": 2048,
-                    "recipe_options": {"ctx_size": 2048},
+                    "recipe_options": {"ctx_size": 1024},
                 }
             ],
         )
@@ -182,6 +183,35 @@ class TestFloorCeilingConflict:
         mock_load.assert_called_once_with(
             "Qwen3-0.6B-GGUF", auto_download=True, prompt=False, ctx_size=2048
         )
+
+    @patch.object(LemonadeClient, "load_model")
+    @patch.object(LemonadeClient, "get_status")
+    def test_resident_at_clamped_ceiling_skips_reload(self, mock_status, mock_load):
+        """A model already loaded exactly at its (clamped) ceiling must NOT
+        reload on every call. The clamp has to apply BEFORE the already-loaded
+        comparison, or the comparison runs against the unclamped registry
+        floor, never matches, and every chat completion pays a wasted /load
+        that changes nothing."""
+        client = LemonadeClient(host="localhost", port=13305)
+        # Qwen3-0.6B-GGUF's registry floor is 4096; its ceiling here is 2048,
+        # and it's already resident at that ceiling.
+        mock_status.return_value = LemonadeStatus(
+            url="http://localhost:13305",
+            running=True,
+            loaded_models=[
+                {
+                    "id": "Qwen3-0.6B-GGUF",
+                    "model_name": "Qwen3-0.6B-GGUF",
+                    "max_context_window": 2048,
+                    "recipe_options": {"ctx_size": 2048},
+                }
+            ],
+        )
+
+        client._ensure_model_loaded("Qwen3-0.6B-GGUF", auto_download=True)
+        client._ensure_model_loaded("Qwen3-0.6B-GGUF", auto_download=True)
+
+        mock_load.assert_not_called()
 
     @patch.object(LemonadeClient, "load_model")
     @patch.object(LemonadeClient, "get_status")

--- a/tests/unit/test_lemonade_ctx_ceiling.py
+++ b/tests/unit/test_lemonade_ctx_ceiling.py
@@ -1,0 +1,272 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+"""Unit tests for the context-ceiling clamp (issue #2992).
+
+GAIA picked its requested ctx_size from a flat per-device constant
+(``profile_ctx_size``) with no knowledge of the model actually being loaded,
+then reported the requested value back as if it were a measurement. Lemonade
+exposes the model's real trained-context ceiling as ``max_context_window`` in
+both ``/api/v1/models`` and ``/api/v1/health``'s ``all_models_loaded`` entries
+— this suite covers clamping the requested ctx to that ceiling and reporting
+the value actually in force.
+"""
+
+from unittest.mock import patch
+
+import pytest
+
+from gaia.llm.lemonade_client import (
+    NPU_CTX_SIZE,
+    LemonadeClient,
+    LemonadeClientError,
+    LemonadeStatus,
+    resolve_effective_ctx_size,
+)
+
+# ---------------------------------------------------------------------------
+# resolve_effective_ctx_size — pure clamp function
+# ---------------------------------------------------------------------------
+
+
+def test_clamp_applied_when_ceiling_below_requested():
+    """65536 requested, 40960 is the model's real ceiling -> clamp to 40960."""
+    assert resolve_effective_ctx_size(65536, 40960) == 40960
+
+
+def test_no_clamp_when_ceiling_at_or_above_requested():
+    """Ceiling >= requested: pass the requested value through unchanged."""
+    assert resolve_effective_ctx_size(65536, 131072) == 65536
+    assert resolve_effective_ctx_size(65536, 65536) == 65536
+
+
+def test_no_clamp_when_ceiling_unknown():
+    """None (or falsy) ceiling means Lemonade hasn't resolved the model's
+    metadata yet — proceed with the requested value, never guess a smaller
+    number than what was actually asked for."""
+    assert resolve_effective_ctx_size(65536, None) == 65536
+    assert resolve_effective_ctx_size(65536, 0) == 65536
+
+
+def test_clamp_applies_under_npu_profile_too():
+    """The clamp is profile-agnostic — a ceiling below NPU_CTX_SIZE (32768)
+    is the same #2992 bug as the GPU/CPU 65536 case, and a fix that only
+    special-cases GPU_CTX_SIZE would miss it entirely."""
+    assert NPU_CTX_SIZE == 32768
+    assert resolve_effective_ctx_size(NPU_CTX_SIZE, 16384) == 16384
+    assert resolve_effective_ctx_size(NPU_CTX_SIZE, 40960) == NPU_CTX_SIZE
+
+
+# ---------------------------------------------------------------------------
+# LemonadeClient.get_model_max_context_window
+# ---------------------------------------------------------------------------
+
+
+class TestGetModelMaxContextWindow:
+    def test_reads_from_already_loaded_status_without_extra_http_call(self):
+        """When the model is already in `status.loaded_models`, the ceiling
+        must come from there — no catalog HTTP call needed."""
+        client = LemonadeClient(host="localhost", port=13305)
+        status = LemonadeStatus(
+            running=True,
+            loaded_models=[
+                {
+                    "id": "Qwen3-0.6B-GGUF",
+                    "model_name": "Qwen3-0.6B-GGUF",
+                    "max_context_window": 40960,
+                }
+            ],
+        )
+        with patch.object(client, "list_models") as mock_list:
+            ceiling = client.get_model_max_context_window(
+                "Qwen3-0.6B-GGUF", status=status
+            )
+        assert ceiling == 40960
+        mock_list.assert_not_called()
+
+    def test_falls_back_to_catalog_when_not_in_status(self):
+        client = LemonadeClient(host="localhost", port=13305)
+        status = LemonadeStatus(running=True, loaded_models=[])
+        with patch.object(
+            client,
+            "list_models",
+            return_value={
+                "data": [
+                    {"id": "Gemma-4-E4B-it-GGUF", "max_context_window": 131072},
+                ]
+            },
+        ) as mock_list:
+            ceiling = client.get_model_max_context_window(
+                "Gemma-4-E4B-it-GGUF", status=status
+            )
+        assert ceiling == 131072
+        mock_list.assert_called_once()
+
+    def test_catalog_lookup_disabled_returns_none_without_http_call(self):
+        """`allow_catalog_lookup=False` must never make an HTTP call — this is
+        the opt-out used by `_ensure_model_loaded_locked`'s best-effort
+        conflict check so it doesn't add a network round trip to every
+        model load (or break unit tests that don't mock `list_models`)."""
+        client = LemonadeClient(host="localhost", port=13305)
+        status = LemonadeStatus(running=True, loaded_models=[])
+        with patch.object(client, "list_models") as mock_list:
+            ceiling = client.get_model_max_context_window(
+                "Gemma-4-E4B-it-GGUF", status=status, allow_catalog_lookup=False
+            )
+        assert ceiling is None
+        mock_list.assert_not_called()
+
+    def test_missing_max_context_window_returns_none(self):
+        """A model with no `max_context_window` reported (common for an
+        undownloaded model) is 'unknown', not 'unbounded' — must return None,
+        not 0 or some sentinel that looks like a real ceiling."""
+        client = LemonadeClient(host="localhost", port=13305)
+        with patch.object(
+            client,
+            "list_models",
+            return_value={"data": [{"id": "Some-Model-GGUF"}]},
+        ):
+            ceiling = client.get_model_max_context_window("Some-Model-GGUF")
+        assert ceiling is None
+
+    def test_catalog_query_failure_returns_none_not_raise(self):
+        client = LemonadeClient(host="localhost", port=13305)
+        with patch.object(
+            client, "list_models", side_effect=LemonadeClientError("boom")
+        ):
+            ceiling = client.get_model_max_context_window("Some-Model-GGUF")
+        assert ceiling is None
+
+
+# ---------------------------------------------------------------------------
+# _ensure_model_loaded_locked — floor (MODELS registry) vs ceiling conflict
+# ---------------------------------------------------------------------------
+
+
+class TestFloorCeilingConflict:
+    @patch.object(LemonadeClient, "load_model")
+    @patch.object(LemonadeClient, "get_status")
+    def test_registry_floor_exceeding_known_ceiling_raises_loudly(
+        self, mock_status, mock_load
+    ):
+        """If MODELS[...].min_ctx_size (the floor GAIA requires for a model)
+        exceeds a *known* max_context_window ceiling, that is a genuine,
+        unresolvable conflict: the model cannot serve GAIA's minimum
+        required context. Must fail loudly, not silently pick a value that
+        re-opens the #1030 truncation bug this floor exists to prevent."""
+        client = LemonadeClient(host="localhost", port=13305)
+        # Qwen3-0.6B-GGUF's registry floor is 4096; report a ceiling below it.
+        mock_status.return_value = LemonadeStatus(
+            url="http://localhost:13305",
+            running=True,
+            loaded_models=[
+                {
+                    "id": "Qwen3-0.6B-GGUF",
+                    "model_name": "Qwen3-0.6B-GGUF",
+                    "max_context_window": 2048,
+                    "recipe_options": {"ctx_size": 2048},
+                }
+            ],
+        )
+
+        with pytest.raises(LemonadeClientError) as exc_info:
+            client._ensure_model_loaded("Qwen3-0.6B-GGUF", auto_download=True)
+
+        msg = str(exc_info.value)
+        assert "4096" in msg
+        assert "2048" in msg
+        assert "Qwen3-0.6B-GGUF" in msg
+        mock_load.assert_not_called()
+
+    @patch.object(LemonadeClient, "load_model")
+    @patch.object(LemonadeClient, "get_status")
+    def test_unrelated_model_in_status_does_not_trigger_conflict_or_http(
+        self, mock_status, mock_load
+    ):
+        """Regression guard: when the requested model is NOT the one already
+        loaded, the best-effort ceiling check must not make a *catalog*
+        HTTP call (``show_all=True``) — mirrors
+        `test_known_model_uses_registry_ctx_size` in
+        test_lemonade_model_loading.py. The pre-existing ``is_downloaded``
+        probe still calls ``list_models()`` (no show_all) further down; that
+        is unrelated to the ceiling check and untouched by this fix."""
+        client = LemonadeClient(host="localhost", port=13305)
+        mock_status.return_value = LemonadeStatus(
+            url="http://localhost:13305",
+            running=True,
+            loaded_models=[{"id": "some-other-model"}],
+        )
+        with patch.object(
+            client, "list_models", return_value={"data": []}
+        ) as mock_list:
+            client._ensure_model_loaded("Qwen3-0.6B-GGUF", auto_download=True)
+        for call in mock_list.call_args_list:
+            assert call.kwargs.get("show_all") is not True
+        mock_load.assert_called_once_with(
+            "Qwen3-0.6B-GGUF", auto_download=True, prompt=False, ctx_size=4096
+        )
+
+    @patch.object(LemonadeClient, "load_model")
+    @patch.object(LemonadeClient, "get_status")
+    def test_ceiling_at_or_above_floor_does_not_raise(self, mock_status, mock_load):
+        """Loaded under the floor (2048 < registry's 4096) with a ceiling
+        comfortably above the floor (40960): must reload to the floor value,
+        not raise."""
+        client = LemonadeClient(host="localhost", port=13305)
+        mock_status.return_value = LemonadeStatus(
+            url="http://localhost:13305",
+            running=True,
+            loaded_models=[
+                {
+                    "id": "Qwen3-0.6B-GGUF",
+                    "model_name": "Qwen3-0.6B-GGUF",
+                    "max_context_window": 40960,
+                    "recipe_options": {"ctx_size": 2048},
+                }
+            ],
+        )
+        client._ensure_model_loaded("Qwen3-0.6B-GGUF", auto_download=True)
+        mock_load.assert_called_once_with(
+            "Qwen3-0.6B-GGUF", auto_download=True, prompt=False, ctx_size=4096
+        )
+
+    @patch.object(LemonadeClient, "load_model")
+    @patch.object(LemonadeClient, "get_status")
+    def test_unknown_ceiling_logs_debug_and_does_not_raise(
+        self, mock_status, mock_load, caplog
+    ):
+        """Missing max_context_window (older Lemonade, unusual recipe, or a
+        response that omits it) must not be silent: named at debug level so
+        the "unknown, proceeding anyway" choice is traceable, and the load
+        must still proceed at the registry floor (#2992)."""
+        client = LemonadeClient(host="localhost", port=13305)
+        mock_status.return_value = LemonadeStatus(
+            url="http://localhost:13305",
+            running=True,
+            loaded_models=[{"id": "some-other-model"}],
+        )
+        with caplog.at_level("DEBUG", logger="gaia.llm.lemonade_client"):
+            client._ensure_model_loaded("Qwen3-0.6B-GGUF", auto_download=True)
+        mock_load.assert_called_once_with(
+            "Qwen3-0.6B-GGUF", auto_download=True, prompt=False, ctx_size=4096
+        )
+        assert any(
+            "max_context_window" in rec.message for rec in caplog.records
+        ), "Missing ceiling must be logged, not silently ignored (#2992)."
+
+
+class TestCtxSizeOverrideBypassesClamp:
+    """The eval-only exact-pin path (`ctx_size_override` / `_ensure_pinned_load`)
+    must be completely untouched by the #2992 clamp — a pinned eval run
+    deliberately requesting an exact ctx_size (even one above a model's
+    ceiling) must get exactly that value, never a silently substituted one."""
+
+    @patch.object(LemonadeClient, "_ensure_pinned_load")
+    def test_ctx_size_override_short_circuits_before_ceiling_check(
+        self, mock_pinned_load
+    ):
+        client = LemonadeClient(host="localhost", port=13305, ctx_size_override=999999)
+        with patch.object(client, "get_model_max_context_window") as mock_ceiling:
+            client._ensure_model_loaded("Qwen3-0.6B-GGUF", auto_download=True)
+        mock_pinned_load.assert_called_once_with("Qwen3-0.6B-GGUF")
+        mock_ceiling.assert_not_called()

--- a/tests/unit/test_lemonade_ctx_ceiling.py
+++ b/tests/unit/test_lemonade_ctx_ceiling.py
@@ -146,14 +146,17 @@ class TestGetModelMaxContextWindow:
 class TestFloorCeilingConflict:
     @patch.object(LemonadeClient, "load_model")
     @patch.object(LemonadeClient, "get_status")
-    def test_registry_floor_exceeding_known_ceiling_raises_loudly(
-        self, mock_status, mock_load
+    def test_registry_floor_exceeding_known_ceiling_clamps_and_warns(
+        self, mock_status, mock_load, caplog
     ):
         """If MODELS[...].min_ctx_size (the floor GAIA requires for a model)
-        exceeds a *known* max_context_window ceiling, that is a genuine,
-        unresolvable conflict: the model cannot serve GAIA's minimum
-        required context. Must fail loudly, not silently pick a value that
-        re-opens the #1030 truncation bug this floor exists to prevent."""
+        exceeds a *known* max_context_window ceiling, GAIA must clamp to the
+        ceiling and load anyway — matching
+        ``LemonadeManager._report_capped_at_ceiling``, which treats the
+        identical situation as "proceed capped", not fatal. Raising here
+        would leave the client and the manager disagreeing about the exact
+        same (floor, ceiling) conflict, and the manager's own reload path
+        already reaches this state successfully."""
         client = LemonadeClient(host="localhost", port=13305)
         # Qwen3-0.6B-GGUF's registry floor is 4096; report a ceiling below it.
         mock_status.return_value = LemonadeStatus(
@@ -169,14 +172,18 @@ class TestFloorCeilingConflict:
             ],
         )
 
-        with pytest.raises(LemonadeClientError) as exc_info:
+        with caplog.at_level("WARNING", logger="gaia.llm.lemonade_client"):
             client._ensure_model_loaded("Qwen3-0.6B-GGUF", auto_download=True)
 
-        msg = str(exc_info.value)
-        assert "4096" in msg
-        assert "2048" in msg
-        assert "Qwen3-0.6B-GGUF" in msg
-        mock_load.assert_not_called()
+        warning = "\n".join(
+            rec.message for rec in caplog.records if rec.levelname == "WARNING"
+        )
+        assert "4096" in warning
+        assert "2048" in warning
+        assert "Qwen3-0.6B-GGUF" in warning
+        mock_load.assert_called_once_with(
+            "Qwen3-0.6B-GGUF", auto_download=True, prompt=False, ctx_size=2048
+        )
 
     @patch.object(LemonadeClient, "load_model")
     @patch.object(LemonadeClient, "get_status")

--- a/tests/unit/test_lemonade_manager_preload.py
+++ b/tests/unit/test_lemonade_manager_preload.py
@@ -670,6 +670,59 @@ def test_print_ceiling_message_has_no_server_remediation_text():
 
 
 @patch("gaia.llm.lemonade_manager.LemonadeClient")
+def test_first_discovery_of_ceiling_skips_restart_advice(mock_cls, capsys):
+    """A reload that *just discovered* the ceiling (not one already known
+    before the attempt) must not fall through to "Restart Lemonade Server"
+    — that advice cannot raise a GGUF's trained context either, and the
+    reload path already printed the correct ceiling message once (#2992)."""
+    client = _make_client_mock(
+        _status(
+            running=True,
+            context_size=8192,
+            loaded_models=[{"id": "Qwen3-0.6B-GGUF", "model_name": "Qwen3-0.6B-GGUF"}],
+        )
+    )
+    # Ceiling unresolved before the reload, discovered only afterwards.
+    client.get_model_max_context_window.side_effect = [None, None, 40960]
+    client.get_status.side_effect = [
+        _status(
+            running=True,
+            context_size=8192,
+            loaded_models=[
+                {"id": "Qwen3-0.6B-GGUF", "model_name": "Qwen3-0.6B-GGUF"}
+            ],
+        ),
+        _status(
+            running=True,
+            context_size=40960,
+            loaded_models=[
+                {
+                    "id": "Qwen3-0.6B-GGUF",
+                    "model_name": "Qwen3-0.6B-GGUF",
+                    "max_context_window": 40960,
+                    "recipe_options": {"ctx_size": 40960},
+                }
+            ],
+        ),
+    ]
+    mock_cls.return_value = client
+
+    ok = LemonadeManager.ensure_ready(min_context_size=65536, quiet=False)
+    captured = capsys.readouterr()
+    output = captured.out + captured.err
+
+    assert ok is True
+    assert "Restart Lemonade Server" not in output
+    assert "To fix this issue" not in output
+    assert LemonadeManager.get_context_size() == 40960
+    # The reload path already announced the cap once — the fall-through
+    # must not print a second, separate ceiling message.
+    assert output.count("trained context") == 1, (
+        f"Expected exactly one ceiling announcement, got:\n{output}"
+    )
+
+
+@patch("gaia.llm.lemonade_manager.LemonadeClient")
 def test_ensure_ready_ceiling_path_prints_no_server_remediation(mock_cls):
     """End-to-end through `ensure_ready`, not just the message function
     directly: a model already at its known ceiling must surface the

--- a/tests/unit/test_lemonade_manager_preload.py
+++ b/tests/unit/test_lemonade_manager_preload.py
@@ -11,6 +11,7 @@ model with the required `ctx_size` instead of asking the user to run a manual
 """
 
 import threading
+from io import StringIO
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -643,3 +644,73 @@ def test_reload_skipped_when_already_at_known_ceiling(mock_cls, caplog):
         len(capped_msgs) == 1
     ), f"Expected exactly one honest capped-context report, got {capped_msgs}"
     assert LemonadeManager.get_context_size() == 40960
+
+
+# ---------------------------------------------------------------------------
+# Case 16 — the ceiling message must NOT reuse print_context_message's
+# server-remediation text (stop the server, restart it) — none of that can
+# raise a GGUF's trained context. It must instead name the shortfall as a
+# property of the model and point at the only real remedy: a bigger model.
+# ---------------------------------------------------------------------------
+
+
+def test_print_ceiling_message_has_no_server_remediation_text():
+    stderr_capture = StringIO()
+    with patch("sys.stderr", stderr_capture):
+        LemonadeManager.print_ceiling_message(40960, 65536)
+
+    output = stderr_capture.getvalue()
+    assert "To fix this issue" not in output
+    assert "Stop the Lemonade server" not in output
+    assert "gaia init" not in output
+    assert "40960" in output
+    assert "65536" in output
+    assert "trained context" in output
+    assert "larger trained context" in output
+
+
+@patch("gaia.llm.lemonade_manager.LemonadeClient")
+def test_ensure_ready_ceiling_path_prints_no_server_remediation(mock_cls):
+    """End-to-end through `ensure_ready`, not just the message function
+    directly: a model already at its known ceiling must surface the
+    model-property message on stderr, never the "stop the server / restart
+    it" text meant for an actually-too-small server configuration."""
+    client = _make_client_mock(
+        _status(
+            running=True,
+            context_size=40960,
+            loaded_models=[
+                {
+                    "id": "Qwen3-0.6B-GGUF",
+                    "model_name": "Qwen3-0.6B-GGUF",
+                    "max_context_window": 40960,
+                    "recipe_options": {"ctx_size": 40960},
+                }
+            ],
+        )
+    )
+    client.get_model_max_context_window.return_value = 40960
+    client.get_status.return_value = _status(
+        running=True,
+        context_size=40960,
+        loaded_models=[
+            {
+                "id": "Qwen3-0.6B-GGUF",
+                "model_name": "Qwen3-0.6B-GGUF",
+                "max_context_window": 40960,
+                "recipe_options": {"ctx_size": 40960},
+            }
+        ],
+    )
+    mock_cls.return_value = client
+
+    stderr_capture = StringIO()
+    with patch("sys.stderr", stderr_capture):
+        ok = LemonadeManager.ensure_ready(min_context_size=65536, quiet=False)
+
+    output = stderr_capture.getvalue()
+    assert ok is True
+    assert "To fix this issue" not in output
+    assert "Stop the Lemonade server" not in output
+    assert "trained context is 40960 tokens" in output
+    assert "larger trained context" in output

--- a/tests/unit/test_lemonade_manager_preload.py
+++ b/tests/unit/test_lemonade_manager_preload.py
@@ -581,3 +581,65 @@ def test_already_sufficient_echo_is_cross_checked_against_ceiling(mock_cls):
         "A config echo that merely repeats the request must never be "
         "trusted as 'sufficient' without checking the model's real ceiling."
     )
+    # The model is already at its honest ceiling (40960) — reloading it at
+    # the same clamped value cannot change anything and must not be
+    # attempted (#2992).
+    client.load_model.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Case 15 — a reload that CANNOT raise the effective context (resident model
+#           already at its known ceiling) must not fire at all: no
+#           load_model call, no "Reloading..." message, just the honest
+#           capped-context report emitted exactly once.
+# ---------------------------------------------------------------------------
+
+
+@patch("gaia.llm.lemonade_manager.LemonadeClient")
+def test_reload_skipped_when_already_at_known_ceiling(mock_cls, caplog):
+    """Qwen3-0.6B-GGUF already resident at its real ceiling (40960), GPU
+    profile requests 65536: a reload can only reproduce the identical
+    40960 result, so it must be skipped entirely — not attempted once."""
+    client = _make_client_mock(
+        _status(
+            running=True,
+            context_size=40960,
+            loaded_models=[
+                {
+                    "id": "Qwen3-0.6B-GGUF",
+                    "model_name": "Qwen3-0.6B-GGUF",
+                    "max_context_window": 40960,
+                    "recipe_options": {"ctx_size": 40960},
+                }
+            ],
+        )
+    )
+    client.get_model_max_context_window.return_value = 40960
+    client.get_status.return_value = _status(
+        running=True,
+        context_size=40960,
+        loaded_models=[
+            {
+                "id": "Qwen3-0.6B-GGUF",
+                "model_name": "Qwen3-0.6B-GGUF",
+                "max_context_window": 40960,
+                "recipe_options": {"ctx_size": 40960},
+            }
+        ],
+    )
+    mock_cls.return_value = client
+
+    with caplog.at_level("WARNING", logger="gaia.llm.lemonade_manager"):
+        ok = LemonadeManager.ensure_ready(min_context_size=65536, quiet=True)
+
+    assert ok is True
+    client.load_model.assert_not_called()
+    capped_msgs = [
+        rec.message
+        for rec in caplog.records
+        if "capped by" in rec.message and "trained context" in rec.message
+    ]
+    assert (
+        len(capped_msgs) == 1
+    ), f"Expected exactly one honest capped-context report, got {capped_msgs}"
+    assert LemonadeManager.get_context_size() == 40960

--- a/tests/unit/test_lemonade_manager_preload.py
+++ b/tests/unit/test_lemonade_manager_preload.py
@@ -688,9 +688,7 @@ def test_first_discovery_of_ceiling_skips_restart_advice(mock_cls, capsys):
         _status(
             running=True,
             context_size=8192,
-            loaded_models=[
-                {"id": "Qwen3-0.6B-GGUF", "model_name": "Qwen3-0.6B-GGUF"}
-            ],
+            loaded_models=[{"id": "Qwen3-0.6B-GGUF", "model_name": "Qwen3-0.6B-GGUF"}],
         ),
         _status(
             running=True,
@@ -717,9 +715,9 @@ def test_first_discovery_of_ceiling_skips_restart_advice(mock_cls, capsys):
     assert LemonadeManager.get_context_size() == 40960
     # The reload path already announced the cap once — the fall-through
     # must not print a second, separate ceiling message.
-    assert output.count("trained context") == 1, (
-        f"Expected exactly one ceiling announcement, got:\n{output}"
-    )
+    assert (
+        output.count("trained context") == 1
+    ), f"Expected exactly one ceiling announcement, got:\n{output}"
 
 
 @patch("gaia.llm.lemonade_manager.LemonadeClient")

--- a/tests/unit/test_lemonade_manager_preload.py
+++ b/tests/unit/test_lemonade_manager_preload.py
@@ -45,6 +45,10 @@ def _make_client_mock(status):
     client = MagicMock()
     client.base_url = "http://localhost:13305/api/v1"
     client.get_status.return_value = status
+    # Ceiling unknown by default (#2992) — most tests aren't exercising the
+    # clamp, and an unconfigured MagicMock return value would break the
+    # int/None comparisons in `resolve_effective_ctx_size`.
+    client.get_model_max_context_window.return_value = None
     return client
 
 
@@ -303,3 +307,277 @@ def test_default_context_size_literal():
     """Belt-and-braces: assert the *literal* 32768 — testing-against-the-import
     is circular and would silently accept a value-drift regression."""
     assert DEFAULT_CONTEXT_SIZE == 32768
+
+
+# ---------------------------------------------------------------------------
+# Case 9 — idle preload clamps to a KNOWN ceiling below the request (#2992)
+# ---------------------------------------------------------------------------
+
+
+@patch("gaia.llm.lemonade_manager.LemonadeClient")
+def test_idle_preload_clamps_to_known_ceiling(mock_cls):
+    """DEFAULT_MODEL_NAME's max_context_window (40960) is below the
+    requested 65536: load_model must be called with the CLAMPED value, and
+    the cached context size must be the real (clamped) value, not the
+    requested one — this is the reporting-accuracy bug from #2992."""
+    client = _make_client_mock(_status(running=True, context_size=0, loaded_models=[]))
+    client.get_model_max_context_window.return_value = 40960
+    client.get_status.side_effect = [
+        _status(running=True, context_size=0, loaded_models=[]),
+        _status(
+            running=True,
+            context_size=65536,  # Lemonade's config echo of the request
+            loaded_models=[
+                {
+                    "id": "Gemma-4-E4B-it-GGUF",
+                    "model_name": "Gemma-4-E4B-it-GGUF",
+                    "max_context_window": 40960,
+                }
+            ],
+        ),
+    ]
+    mock_cls.return_value = client
+
+    ok = LemonadeManager.ensure_ready(min_context_size=65536, quiet=True)
+
+    assert ok is True
+    client.load_model.assert_called_once()
+    kwargs = client.load_model.call_args.kwargs
+    assert kwargs.get("ctx_size") == 40960, (
+        "GAIA must request the model's real ceiling, not the flat device "
+        "profile value, once the ceiling is known."
+    )
+    assert LemonadeManager.get_context_size() == 40960, (
+        "The reported/cached ctx must be the value actually in force, not "
+        "an echo of what was requested (#2992)."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Case 10 — reload path clamps to a known ceiling and reports honestly
+# ---------------------------------------------------------------------------
+
+
+@patch("gaia.llm.lemonade_manager.LemonadeClient")
+def test_reload_clamps_to_known_ceiling_and_reports_honestly(mock_cls):
+    """A model already loaded at a too-small ctx, whose real ceiling
+    (40960) is below the device-profile request (65536): the reload must
+    request the clamped value and cache/report it honestly, not lie that
+    the full 65536 is in force."""
+    client = _make_client_mock(
+        _status(
+            running=True,
+            context_size=8192,
+            loaded_models=[
+                {
+                    "id": "Qwen3-0.6B-GGUF",
+                    "model_name": "Qwen3-0.6B-GGUF",
+                    "max_context_window": 40960,
+                }
+            ],
+        )
+    )
+    client.get_model_max_context_window.return_value = 40960
+    client.get_status.side_effect = [
+        _status(
+            running=True,
+            context_size=8192,
+            loaded_models=[
+                {
+                    "id": "Qwen3-0.6B-GGUF",
+                    "model_name": "Qwen3-0.6B-GGUF",
+                    "max_context_window": 40960,
+                }
+            ],
+        ),
+        _status(
+            running=True,
+            context_size=40960,  # server actually honored the clamped value
+            loaded_models=[
+                {
+                    "id": "Qwen3-0.6B-GGUF",
+                    "model_name": "Qwen3-0.6B-GGUF",
+                    "max_context_window": 40960,
+                }
+            ],
+        ),
+    ]
+    mock_cls.return_value = client
+
+    ok = LemonadeManager.ensure_ready(min_context_size=65536, quiet=True)
+
+    assert ok is True
+    kwargs = client.load_model.call_args.kwargs
+    assert kwargs.get("ctx_size") == 40960
+    assert LemonadeManager.get_context_size() == 40960
+
+
+# ---------------------------------------------------------------------------
+# Case 11 — a known ceiling below the request must not trigger a reload
+#           storm: once discovered, subsequent ensure_ready() calls accept
+#           the capped reality instead of retrying forever (#2992).
+# ---------------------------------------------------------------------------
+
+
+@patch("gaia.llm.lemonade_manager.LemonadeClient")
+def test_known_ceiling_stops_repeat_reload_attempts(mock_cls):
+    client = _make_client_mock(_status(running=True, context_size=0, loaded_models=[]))
+    client.get_model_max_context_window.return_value = 40960
+    client.get_status.side_effect = [
+        _status(running=True, context_size=0, loaded_models=[]),
+        _status(
+            running=True,
+            context_size=65536,
+            loaded_models=[
+                {
+                    "id": "Gemma-4-E4B-it-GGUF",
+                    "model_name": "Gemma-4-E4B-it-GGUF",
+                    "max_context_window": 40960,
+                }
+            ],
+        ),
+    ]
+    mock_cls.return_value = client
+
+    ok = LemonadeManager.ensure_ready(min_context_size=65536, quiet=True)
+    assert ok is True
+    assert client.load_model.call_count == 1
+
+    # Force past the rate limiter so a second call would otherwise recheck.
+    LemonadeManager._last_recheck_time = 0.0
+    ok2 = LemonadeManager.ensure_ready(min_context_size=65536, quiet=True)
+
+    assert ok2 is True
+    assert client.load_model.call_count == 1, (
+        "Once the model's real ceiling is known and already reached, "
+        "ensure_ready must not keep retrying a reload that can't succeed."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Case 12 — unknown ceiling: no clamp, but a warning is logged (fail loudly,
+#           not silently) — and the flat request still goes through.
+# ---------------------------------------------------------------------------
+
+
+@patch("gaia.llm.lemonade_manager.LemonadeClient")
+def test_idle_preload_unknown_ceiling_warns_and_proceeds_unclamped(mock_cls, caplog):
+    client = _make_client_mock(_status(running=True, context_size=0, loaded_models=[]))
+    client.get_model_max_context_window.return_value = None
+    client.get_status.side_effect = [
+        _status(running=True, context_size=0, loaded_models=[]),
+        _status(
+            running=True,
+            context_size=32768,
+            loaded_models=[{"id": "Gemma-4-E4B-it-GGUF"}],
+        ),
+    ]
+    mock_cls.return_value = client
+
+    with caplog.at_level("WARNING", logger="gaia.llm.lemonade_manager"):
+        ok = LemonadeManager.ensure_ready(min_context_size=32768, quiet=True)
+
+    assert ok is True
+    kwargs = client.load_model.call_args.kwargs
+    assert kwargs.get("ctx_size") == 32768
+    assert any(
+        "max_context_window" in rec.message for rec in caplog.records
+    ), "Missing ceiling must be surfaced, not silently assumed absent (#2992)."
+
+
+# ---------------------------------------------------------------------------
+# Case 13 — the clamp applies under the NPU profile too, not just GPU_CTX_SIZE
+# ---------------------------------------------------------------------------
+
+
+@patch("gaia.llm.lemonade_manager.LemonadeClient")
+def test_idle_preload_clamps_under_npu_profile(mock_cls):
+    """NPU_CTX_SIZE (32768) is the requested value here — a ceiling below it
+    (16384) must clamp exactly like the GPU/CPU 65536 case. The clamp helper
+    is profile-agnostic, but this pins the NPU-scale number explicitly so a
+    future regression that special-cases GPU_CTX_SIZE gets caught."""
+    client = _make_client_mock(_status(running=True, context_size=0, loaded_models=[]))
+    client.get_model_max_context_window.return_value = 16384
+    client.get_status.side_effect = [
+        _status(running=True, context_size=0, loaded_models=[]),
+        _status(
+            running=True,
+            context_size=32768,
+            loaded_models=[{"id": "Gemma-4-E4B-it-GGUF", "max_context_window": 16384}],
+        ),
+    ]
+    mock_cls.return_value = client
+
+    ok = LemonadeManager.ensure_ready(min_context_size=32768, quiet=True)
+
+    assert ok is True
+    kwargs = client.load_model.call_args.kwargs
+    assert kwargs.get("ctx_size") == 16384
+    assert LemonadeManager.get_context_size() == 16384
+
+
+# ---------------------------------------------------------------------------
+# Case 14 — a model already loaded reporting an ECHOED ctx_size that already
+#           satisfies min_context_size must still be cross-checked against
+#           its real ceiling. Found via hardware verification: Lemonade will
+#           report back recipe_options.ctx_size == the request even when it
+#           silently capped the actual window lower, so "already sufficient"
+#           must not be trusted without checking max_context_window (#2992).
+# ---------------------------------------------------------------------------
+
+
+@patch("gaia.llm.lemonade_manager.LemonadeClient")
+def test_already_sufficient_echo_is_cross_checked_against_ceiling(mock_cls):
+    """A model loaded with recipe_options.ctx_size=65536 (the echo matches
+    the request) but whose real max_context_window is 40960 must be
+    detected and reported honestly on the very first `ensure_ready` call —
+    not just on a reload-triggered path."""
+    client = _make_client_mock(
+        _status(
+            running=True,
+            context_size=65536,  # config echo already looks "sufficient"
+            loaded_models=[
+                {
+                    "id": "Qwen3-0.6B-GGUF",
+                    "model_name": "Qwen3-0.6B-GGUF",
+                    "max_context_window": 40960,
+                    "recipe_options": {"ctx_size": 65536},
+                }
+            ],
+        )
+    )
+    client.get_model_max_context_window.return_value = 40960
+    client.get_status.side_effect = [
+        _status(
+            running=True,
+            context_size=65536,
+            loaded_models=[
+                {
+                    "id": "Qwen3-0.6B-GGUF",
+                    "model_name": "Qwen3-0.6B-GGUF",
+                    "max_context_window": 40960,
+                    "recipe_options": {"ctx_size": 65536},
+                }
+            ],
+        ),
+        _status(
+            running=True,
+            context_size=40960,
+            loaded_models=[
+                {
+                    "id": "Qwen3-0.6B-GGUF",
+                    "model_name": "Qwen3-0.6B-GGUF",
+                    "max_context_window": 40960,
+                }
+            ],
+        ),
+    ]
+    mock_cls.return_value = client
+
+    ok = LemonadeManager.ensure_ready(min_context_size=65536, quiet=True)
+
+    assert ok is True
+    assert LemonadeManager.get_context_size() == 40960, (
+        "A config echo that merely repeats the request must never be "
+        "trusted as 'sufficient' without checking the model's real ceiling."
+    )

--- a/tests/unit/test_lemonade_manager_preload.py
+++ b/tests/unit/test_lemonade_manager_preload.py
@@ -723,6 +723,63 @@ def test_first_discovery_of_ceiling_skips_restart_advice(mock_cls, capsys):
 
 
 @patch("gaia.llm.lemonade_manager.LemonadeClient")
+def test_ceiling_does_not_stick_after_switching_to_a_roomier_model(mock_cls):
+    """A long-lived process (e.g. gaia.ui.server) caches a small model's
+    ceiling, then the server switches to a model with real headroom. The
+    cached ceiling must not keep capping `_context_size` forever just
+    because it was true for the PREVIOUS model (#2992)."""
+    client = _make_client_mock(
+        _status(
+            running=True,
+            context_size=40960,
+            loaded_models=[
+                {
+                    "id": "Qwen3-0.6B-GGUF",
+                    "model_name": "Qwen3-0.6B-GGUF",
+                    "max_context_window": 40960,
+                    "recipe_options": {"ctx_size": 40960},
+                }
+            ],
+        )
+    )
+    client.get_model_max_context_window.return_value = 40960
+    mock_cls.return_value = client
+
+    ok = LemonadeManager.ensure_ready(min_context_size=65536, quiet=True)
+    assert ok is True
+    assert LemonadeManager.get_context_size() == 40960
+    assert LemonadeManager._context_ceiling == 40960
+    assert LemonadeManager._context_ceiling_model == "Qwen3-0.6B-GGUF"
+
+    # The server switches to a roomier model. Force past the rate limiter
+    # so the next ensure_ready() call actually re-checks live status
+    # instead of trusting the stale small-model ceiling.
+    LemonadeManager._last_recheck_time = 0.0
+    client.get_model_max_context_window.return_value = 131072
+    client.get_status.return_value = _status(
+        running=True,
+        context_size=65536,
+        loaded_models=[
+            {
+                "id": "Gemma-4-E4B-it-GGUF",
+                "model_name": "Gemma-4-E4B-it-GGUF",
+                "max_context_window": 131072,
+                "recipe_options": {"ctx_size": 65536},
+            }
+        ],
+    )
+
+    ok2 = LemonadeManager.ensure_ready(min_context_size=65536, quiet=True)
+
+    assert ok2 is True
+    assert LemonadeManager.get_context_size() == 65536, (
+        "The new model's real (larger) context must replace the stale "
+        "cached ceiling from the previously loaded model."
+    )
+    assert LemonadeManager._context_ceiling_model == "Gemma-4-E4B-it-GGUF"
+
+
+@patch("gaia.llm.lemonade_manager.LemonadeClient")
 def test_ensure_ready_ceiling_path_prints_no_server_remediation(mock_cls):
     """End-to-end through `ensure_ready`, not just the message function
     directly: a model already at its known ceiling must surface the

--- a/tests/unit/test_llm.py
+++ b/tests/unit/test_llm.py
@@ -393,6 +393,9 @@ class TestLemonadeManagerContextMessage(unittest.TestCase):
         ]  # LLM model loaded
         mock_client.get_status.return_value = mock_status
         mock_client.base_url = "http://localhost:13305/api/v1"
+        # Ceiling unknown (#2992) — keeps the legacy "assume success to break
+        # the reload loop" branch, matching this test's pre-#2992 assertions.
+        mock_client.get_model_max_context_window.return_value = None
 
         with patch(
             "gaia.llm.lemonade_manager.LemonadeClient",
@@ -430,6 +433,9 @@ class TestLemonadeManagerContextMessage(unittest.TestCase):
         ]  # LLM model loaded
         mock_client.get_status.return_value = mock_status
         mock_client.base_url = "http://localhost:13305/api/v1"
+        # Ceiling unknown (#2992) — keeps the legacy "assume success to break
+        # the reload loop" branch, matching this test's pre-#2992 assertions.
+        mock_client.get_model_max_context_window.return_value = None
 
         with patch(
             "gaia.llm.lemonade_manager.LemonadeClient",
@@ -466,6 +472,9 @@ class TestLemonadeManagerContextMessage(unittest.TestCase):
         mock_status.context_size = 4096
         mock_client.get_status.return_value = mock_status
         mock_client.base_url = "http://localhost:13305/api/v1"
+        # Ceiling unknown (#2992) — keeps the legacy "assume success to break
+        # the reload loop" branch, matching this test's pre-#2992 assertions.
+        mock_client.get_model_max_context_window.return_value = None
 
         with patch(
             "gaia.llm.lemonade_manager.LemonadeClient",


### PR DESCRIPTION
Closes #2992

GAIA picked its context window from a flat per-device number (65536 GPU/CPU, 32768 NPU) with no idea which model was actually loading, then reported that number back as fact. For a model whose real trained context is smaller — Qwen3-0.6B-GGUF's is 40960 — GAIA requested and reported 65536 while llama.cpp silently capped the real window at 40960. A ~40,900-token prompt worked; ~41,000 got a 400 the user had no way to predict from GAIA's own "success" message.

Lemonade already exposes the real ceiling as `max_context_window` (catalog `/api/v1/models` and `/api/v1/health`). This clamps the ctx_size GAIA actually requests to that ceiling and reports the value really in force. It also covers the no-reload path: Lemonade echoes back `recipe_options.ctx_size` as whatever was last requested even when it capped the window lower internally, so a model already resident from an earlier process looked "already sufficient" and was never rechecked — every reading of `status.context_size` is now cross-checked against the loaded model's ceiling, not just ones following a reload.

A model already sitting at its known ceiling now skips the reload entirely instead of running one that reproduces the identical result — since the manager's state is per-process, an unconditional reload here would otherwise fire on every single `gaia` invocation, not once. And the message for that case is now specific to the ceiling: it names the shortfall as a property of the model (its trained context) and points at the only real remedy — a bigger model — instead of the "stop the server and restart it" text meant for a genuinely-too-small server config, which can't do anything about a GGUF's trained context.

Verified live against a running Lemonade 11.6.0 with `Qwen3-0.6B-GGUF` (real `max_context_window=40960`), before vs. after this fix, same repro:

- Before: `✅ Context size updated to 65536 tokens.` (false — the real window was 40960)
- After: `⚠️  This model's trained context is 40960 tokens (requested 65536); that is the maximum available regardless of configuration. Use a model with a larger trained context if you need more.`

Two explicit decisions, both tested:
- A registry floor (`MODELS[...].min_ctx_size`) that exceeds a *known* ceiling raises loudly instead of silently picking one side.
- A model with no discoverable ceiling (undownloaded, older Lemonade) proceeds at the requested value with a logged warning — never a silent guess.

The eval-only `ctx_size_override` exact-pin path (`_ensure_pinned_load`) is untouched — confirmed by a test asserting `get_model_max_context_window` is never called on that path, so a pinned eval run still gets exactly what it asked for.

**Known adjacent issue, not introduced here (verified against `main`):** switching models can print a warning naming the *previous* resident model instead of the one about to load, because the pre-flight ctx check runs before model-switch logic picks the new target. On `main` this same ordering silently reloads the wrong (soon-to-be-replaced) model and falsely reports success; this PR's honest check surfaces it as a warning instead, without the wasted reload — an improvement, but the underlying ordering issue is unfixed and out of scope here.

## Test plan

- [x] `pytest tests/unit/test_lemonade_ctx_ceiling.py tests/unit/test_lemonade_manager_preload.py tests/unit/test_lemonade_model_loading.py tests/unit/test_llm.py tests/unit/installer/test_init_verify_ctx_display.py` — 71 passed
- [x] `pytest tests/test_lemonade_client.py` — 87 passed, 3 pre-existing failures (`test_chat_completions`, `test_chat_completions_nonstream_includes_auth_header`, `test_validate_context_size_insufficient`), confirmed present on `main` via `git stash` before this change — unrelated to this fix
- [x] `python util/lint.py --all --fix` — black/isort/pylint/flake8/bandit all pass (mypy warnings are pre-existing, non-blocking)
- [x] Live repro against a real Lemonade 11.6.0 server with `Qwen3-0.6B-GGUF` downloaded — clamp, honest reporting, the skipped reload, and the model-specific message confirmed end-to-end (see before/after strings above)
- [x] Real-hardware pass on a second machine — Radeon gfx1100 box, Ubuntu 24.04, Lemonade 11.9.0, branch merged with current `main`: `main` reports 65536, this branch reports 40960, and the server rejects a 42,009-token prompt at `n_ctx: 40960` ([evidence](https://github.com/amd/gaia/pull/3003#issuecomment-5734200457))

