### PR TITLE
feat(tui): lay out to the real terminal width

### DIFF
--- a/docs/guides/terminal-hub.mdx
+++ b/docs/guides/terminal-hub.mdx
@@ -287,10 +287,15 @@ The flagship agent (the one spawned as a local subprocess, not through the
 background daemon) runs this same setup automatically on its first launch on a
 clean machine — installing Lemonade and downloading the models it needs instead
 of failing at whichever piece is missing. `/setup` reruns it on demand, e.g.
-after deleting a model or reinstalling Lemonade. A session launched with
-`--use-claude` skips downloading the local chat model (inference runs on
-Anthropic's API instead) but still installs the RAG/memory embedding model,
-which has no Claude equivalent.
+after deleting a model or reinstalling Lemonade.
+
+A session launched with `--use-claude` skips this setup entirely and does not
+start the local server — that flag exists to avoid the local backend, so
+running an installer that launches it would defeat it, and would hold the first
+answer behind a multi-minute install. The transcript says the server was not
+started and names what still needs it: RAG, memory and the code index embed
+through Lemonade, which has no Claude equivalent. Run `gaia init --profile chat
+--skip-chat-model`, or `/setup` in the composer, when you want those.
 
 ## Next steps
 

--- a/docs/plans/flagship-installer.mdx
+++ b/docs/plans/flagship-installer.mdx
@@ -181,17 +181,22 @@ decision already made and shipped is:
 
 - **Lemonade is required on every platform**, including Mac — for the RAG/memory
   embedder at minimum, because Anthropic has no embeddings API.
-- **The chat model itself is optional**, via `--use-claude`. That flag maps onto
-  `gaia init --skip-chat-model`: the multi-GB `Gemma-4-E4B-it-GGUF` download is
-  skipped, but the small embedding model still downloads, and Lemonade still has to
-  be installed and running.
+- **The chat model itself is optional**, via `--use-claude`, and so is running
+  setup at all: a Claude launch skips the first-boot gate entirely and never
+  starts the local server. Running an installer that launches Lemonade would
+  defeat the one flag whose purpose is to avoid it, and would hold the first
+  answer behind a multi-minute install. The session says on screen that setup
+  was skipped and names `gaia init --profile chat --skip-chat-model` (or
+  `/setup`) as the way to get the local half.
 - There is **no** "refuse entirely, Claude-only, no local component" mode. I agree
   with this — memory and RAG are core to what makes this agent "the flagship," and
-  neither has a non-local equivalent today.
+  neither has a non-local equivalent today. A Claude session simply defers the
+  local half rather than doing without it forever.
 
-This is fully implemented, not a gap: `setupCheckArgs`/`setupRunArgs` in `setup.go`
-already branch on `claudeMode`, and the npm README documents Lemonade + the `gaia`
-CLI on PATH as hard requirements regardless of backend.
+Implemented in `applyFirstBootGate` (`tui/internal/ui/chat/setup.go`), which
+returns early in Claude mode; `setupCheckArgs`/`setupRunArgs` still branch on
+`claudeMode` for the explicit `/setup` path. The npm README documents Lemonade +
+the `gaia` CLI on PATH as requirements for the local-embedding features.
 
 ---
 

--- a/tui/README.md
+++ b/tui/README.md
@@ -123,17 +123,26 @@ model's.
 
 ```bash
 gaia-tui run gaia --query "..." --use-claude
-gaia-tui run gaia --query "..." --use-claude --claude-model claude-opus-5
+gaia-tui run gaia --use-claude --claude-model claude-haiku-4-5
 ```
 
 **This sends your conversation off the machine**, which is the one thing GAIA
-otherwise never does — so the chat header names the exact model in use (e.g.
-`Sonnet 5`) for as long as the mode is on, colored to mark it remote, and the
-launch says so in the transcript. It needs `ANTHROPIC_API_KEY` set, and it is a
-debugging tool, not a way to use GAIA.
+otherwise never does — so the chat header names the exact model in use
+(`claude · haiku-4.5`) for as long as the mode is on, colored to mark it
+remote, and the launch says so in the transcript. It needs `ANTHROPIC_API_KEY`
+set (a repo-root `.env` works too).
 
-Only the chat model moves. Retrieval over your documents still embeds locally
-through Lemonade, so document questions need Lemonade running either way.
+`--claude-model` takes one of `claude-opus-5`, `claude-sonnet-5`,
+`claude-haiku-4-5`, `claude-fable-5` — there is no date suffix. Anything else
+is refused at the command line, with the accepted ids, rather than forwarded to
+Anthropic to come back a 404 mid-turn.
+
+**A Claude session does not start the local backend at all.** First-boot setup
+is skipped, so `LemonadeServer.exe` is never launched and the first answer is
+not held behind an install. The transcript says so, and says what it costs:
+retrieval, memory and the code index still embed through Lemonade (Anthropic
+has no embeddings API), so those need `gaia init --profile chat
+--skip-chat-model`, or `/setup` in the composer, before they work.
 
 Paths that cannot honour the flag say so instead of quietly ignoring it: the
 daemon transport refuses it, `--claude-model` without `--use-claude` refuses,
@@ -143,9 +152,15 @@ and `chat --subprocess` tells you to put the flag in the command line you own.
 chat composer — `/model` alone lists every switchable id (the curated Claude
 5 family, plus whatever Lemonade currently has downloaded), and `/model <id>`
 swaps the live client without losing conversation history or loaded skills.
+Typing the space in `/model ` turns the slash palette into a model picker, so
+the Claude ids are pickable rather than remembered; local ids stay behind bare
+`/model`, since only the agent knows what this machine has downloaded.
+
 An unknown id, a missing credential, or an unreachable Lemonade Server all
 refuse the switch with an actionable message and leave the session on
-whichever model was already working.
+whichever model was already working. Backends never swap themselves: a local
+switch with Lemonade down is refused with both ways forward (start the server,
+or name a Claude id), never silently answered somewhere else.
 
 ## Running against a local clone
 

--- a/tui/internal/cli/claudeflag_test.go
+++ b/tui/internal/cli/claudeflag_test.go
@@ -118,3 +118,54 @@ func TestClaudeModelWithoutUseClaudeIsRefusedAtLaunch(t *testing.T) {
 		t.Errorf("the pair together must be accepted: %v", err)
 	}
 }
+
+// A model id nothing recognises must be refused at the command line, with the
+// ids that would work. Nothing downstream catches it: the provider forwards
+// any "claude-*" string to Anthropic verbatim (src/gaia/llm/providers/
+// claude.py), so an unrefused typo surfaces as a 404 several seconds into the
+// first turn, far from the flag that caused it.
+func TestUnknownClaudeModelIsRefusedAtLaunch(t *testing.T) {
+	flags := rootCmd.PersistentFlags()
+	f := flags.Lookup("claude-model")
+	if f == nil {
+		t.Fatal("--claude-model is not registered")
+	}
+	t.Cleanup(func() {
+		useClaude = false
+		claudeModel = defaultClaudeModel
+		f.Changed = false
+	})
+
+	useClaude = true
+	if err := flags.Set("claude-model", "claude-haiku-45"); err != nil {
+		t.Fatalf("--claude-model: %v", err)
+	}
+	err := rootCmd.PersistentPreRunE(rootCmd, nil)
+	if err == nil {
+		t.Fatal("a typo'd model id was accepted and would have reached Anthropic")
+	}
+	for _, must := range []string{"--claude-model", "claude-haiku-4-5"} {
+		if !strings.Contains(err.Error(), must) {
+			t.Errorf("the refusal must mention %q: %v", must, err)
+		}
+	}
+
+	// The id the whole fleet actually runs on must pass.
+	if err := flags.Set("claude-model", "claude-haiku-4-5"); err != nil {
+		t.Fatalf("--claude-model: %v", err)
+	}
+	if err := rootCmd.PersistentPreRunE(rootCmd, nil); err != nil {
+		t.Errorf("claude-haiku-4-5 must be accepted: %v", err)
+	}
+}
+
+// The default stays claude-sonnet-5. Which model a given deployment prefers is
+// an operational choice made per launch, not something the binary should bake
+// in — flipping this would silently change the model for everyone who passes
+// no --claude-model at all.
+func TestTheDefaultClaudeModelIsStillSonnet(t *testing.T) {
+	if defaultClaudeModel != "claude-sonnet-5" {
+		t.Errorf("defaultClaudeModel = %q; changing it changes what every "+
+			"flagless --use-claude launch runs on", defaultClaudeModel)
+	}
+}

--- a/tui/internal/cli/root.go
+++ b/tui/internal/cli/root.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/amd/gaia/tui/internal/client"
 	"github.com/amd/gaia/tui/internal/ui"
 )
 
@@ -110,17 +111,27 @@ func init() {
 	rootCmd.PersistentFlags().BoolVar(&useClaude, "use-claude", false,
 		"run the agent against Anthropic's Claude API instead of the local Lemonade "+
 			"backend — your conversation is sent to Anthropic, not processed on this "+
-			"machine. Requires ANTHROPIC_API_KEY. The chat header shows a \"claude\" "+
-			"chip while this is on")
+			"machine. Requires ANTHROPIC_API_KEY. The local server is NOT started and "+
+			"first-run setup is skipped; the chat header names the model in use "+
+			"(e.g. \"claude · haiku-4.5\") while this is on")
 	rootCmd.PersistentFlags().StringVar(&claudeModel, "claude-model", defaultClaudeModel,
-		"Claude model id to use with --use-claude (pass \"\" to let the agent pick)")
-	// --claude-model without --use-claude would be accepted and then change
-	// nothing; refuse it before any UI opens.
+		"Claude model id to use with --use-claude: "+
+			strings.Join(client.ClaudeModelIDs(), ", ")+
+			" (pass \"\" to let the agent pick)")
+	// Both --claude-model refusals happen here, before any UI opens: a flag
+	// that will not do what it says must fail as a command-line error, not as
+	// something the user has to notice inside a running TUI.
 	rootCmd.PersistentPreRunE = func(cmd *cobra.Command, args []string) error {
 		if rootCmd.PersistentFlags().Changed("claude-model") && !useClaude {
 			return fmt.Errorf(
 				"--claude-model only applies with --use-claude: the local Lemonade " +
 					"backend does not run Claude models. Add --use-claude, or drop --claude-model")
+		}
+		// An id nothing accepts reaches Anthropic verbatim and comes back a
+		// 404 mid-turn — see client.ValidateClaudeModel for why nothing
+		// downstream catches it.
+		if err := client.ValidateClaudeModel(claudeModel); err != nil {
+			return fmt.Errorf("--claude-model: %w", err)
 		}
 		return nil
 	}

--- a/tui/internal/client/claudemodels.go
+++ b/tui/internal/client/claudemodels.go
@@ -1,0 +1,140 @@
+// Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+package client
+
+import (
+	"fmt"
+	"strings"
+)
+
+// The Claude ids this TUI will hand to an agent, and nothing else.
+//
+// It lives beside ClaudeModelFlag because it is part of the same argv
+// contract: whatever goes after --claude-model reaches the child verbatim,
+// and the child's provider accepts ANY string starting with "claude-" (see
+// src/gaia/llm/providers/claude.py). So a typo like "claude-haiku-45" is not
+// caught anywhere downstream — it becomes a 404 from Anthropic several
+// seconds into the first turn, long after the user could connect it to what
+// they typed. Refusing it here, before a UI even opens, is the only place the
+// message can still name the flag the user got wrong.
+//
+// This list MUST stay identical to CLAUDE_MODELS in
+// hub/agents/gaia/python/gaia_agent/stdio.py — the agent validates `/model`
+// against its own copy, and two lists that disagree means an id the launch
+// flag accepts and `/model` refuses (or worse, the reverse). TestGoAndPython
+// ClaudeModelListsAgree (claudemodels_test.go) reads that file and fails the
+// build if they drift.
+//
+// Ordered, not a map, because it is rendered: the palette and every refusal
+// message list these in a fixed order, and Go map iteration would reshuffle
+// them on every run.
+var ClaudeModels = []ClaudeModel{
+	{ID: "claude-opus-5", Label: "Opus 5"},
+	{ID: "claude-sonnet-5", Label: "Sonnet 5"},
+	{ID: "claude-haiku-4-5", Label: "Haiku 4.5"},
+	{ID: "claude-fable-5", Label: "Fable 5"},
+}
+
+// ExampleClaudeModelID is the id every piece of help text and every refusal
+// names when it needs to show one. A constant rather than a literal repeated
+// at each site: a message that advertises an id ValidateClaudeModel rejects is
+// worse than one that shows none. TestTheExampleModelIsOneWeAccept holds it to
+// that.
+const ExampleClaudeModelID = "claude-haiku-4-5"
+
+// ClaudeModel is one selectable remote model: the wire id and the name a
+// human reads.
+type ClaudeModel struct {
+	ID    string
+	Label string
+}
+
+// ClaudeModelPrefix is what makes an id a REMOTE one. The split matters
+// because the two backends validate differently: the Claude side is a closed
+// set known at compile time, while the local side is whatever Lemonade has
+// downloaded — only the agent can answer that, so local ids are never
+// refused here.
+const ClaudeModelPrefix = "claude-"
+
+// IsClaudeModelID reports whether an id addresses the Claude backend at all.
+func IsClaudeModelID(id string) bool {
+	return strings.HasPrefix(id, ClaudeModelPrefix)
+}
+
+// KnownClaudeModel returns the entry for id, and whether it is one this build
+// accepts.
+func KnownClaudeModel(id string) (ClaudeModel, bool) {
+	for _, m := range ClaudeModels {
+		if m.ID == id {
+			return m, true
+		}
+	}
+	return ClaudeModel{}, false
+}
+
+// ClaudeModelIDs lists every accepted id, in display order.
+func ClaudeModelIDs() []string {
+	ids := make([]string, 0, len(ClaudeModels))
+	for _, m := range ClaudeModels {
+		ids = append(ids, m.ID)
+	}
+	return ids
+}
+
+// ValidateClaudeModel refuses an id this build does not know.
+//
+// The empty string is accepted and means "let the agent pick its own
+// default" — that is what --claude-model "" is documented to do, and it is a
+// real choice, not a missing value.
+func ValidateClaudeModel(id string) error {
+	if id == "" {
+		return nil
+	}
+	if _, ok := KnownClaudeModel(id); ok {
+		return nil
+	}
+	return fmt.Errorf(
+		"unknown Claude model %q. Accepted ids: %s. Note there is no date "+
+			"suffix — it is `%s`, not `%s-20250101`",
+		id, strings.Join(ClaudeModelIDs(), ", "),
+		ExampleClaudeModelID, ExampleClaudeModelID)
+}
+
+// ClaudeModelShortName turns a wire id into the name the header chip shows:
+// "claude-haiku-4-5" -> "haiku-4.5".
+//
+// Derived from the id rather than read off ClaudeModels' Label, so it still
+// produces something honest for an id this build has never heard of — which
+// is exactly the case a header has to render (the agent may be newer than the
+// TUI, and its model-state ping is authoritative over this list).
+func ClaudeModelShortName(id string) string {
+	short := strings.TrimPrefix(id, ClaudeModelPrefix)
+	if short == "" {
+		return id
+	}
+	// Anthropic spells the minor version with a dash on the wire
+	// ("haiku-4-5") and a dot everywhere a human reads it ("Haiku 4.5").
+	// Only the version tail is rewritten: the family name keeps its dashes.
+	parts := strings.Split(short, "-")
+	for i := len(parts) - 1; i > 0; i-- {
+		if !isDigits(parts[i]) || !isDigits(parts[i-1]) {
+			break
+		}
+		parts[i-1] = parts[i-1] + "." + parts[i]
+		parts = parts[:i]
+	}
+	return strings.Join(parts, "-")
+}
+
+func isDigits(s string) bool {
+	if s == "" {
+		return false
+	}
+	for _, r := range s {
+		if r < '0' || r > '9' {
+			return false
+		}
+	}
+	return true
+}

--- a/tui/internal/client/claudemodels_test.go
+++ b/tui/internal/client/claudemodels_test.go
@@ -1,0 +1,110 @@
+// Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+package client
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// Haiku 4.5 is the id the fleet actually runs on, and the one people get
+// wrong — so it is asserted by name rather than left to a table.
+func TestHaiku45IsAcceptedByItsExactID(t *testing.T) {
+	if err := ValidateClaudeModel("claude-haiku-4-5"); err != nil {
+		t.Fatalf("claude-haiku-4-5 must be accepted: %v", err)
+	}
+	if err := ValidateClaudeModel("claude-haiku-4-5-20250101"); err == nil {
+		t.Error("a date-suffixed id must be refused — no such model id exists")
+	}
+}
+
+func TestUnknownClaudeModelIsRefusedWithTheAcceptedList(t *testing.T) {
+	err := ValidateClaudeModel("claude-haiku-45")
+	if err == nil {
+		t.Fatal("a typo'd model id must be refused, not passed through to Anthropic")
+	}
+	// The refusal is the ONLY place the user finds out what to type instead;
+	// without the list it is no more useful than the 404 it prevents.
+	for _, id := range ClaudeModelIDs() {
+		if !strings.Contains(err.Error(), id) {
+			t.Errorf("refusal does not offer %q: %v", id, err)
+		}
+	}
+}
+
+// "" is a documented choice — let the agent pick — not a missing value.
+func TestEmptyClaudeModelIsAllowed(t *testing.T) {
+	if err := ValidateClaudeModel(""); err != nil {
+		t.Errorf(`--claude-model "" must be allowed: %v`, err)
+	}
+}
+
+func TestClaudeModelShortName(t *testing.T) {
+	for _, tc := range []struct{ id, want string }{
+		{"claude-haiku-4-5", "haiku-4.5"},
+		{"claude-sonnet-5", "sonnet-5"},
+		{"claude-opus-5", "opus-5"},
+		{"claude-fable-5", "fable-5"},
+		// Unknown to this build: still rendered, never dropped — the agent
+		// can be newer than the TUI and its ping is authoritative.
+		{"claude-newmodel-9-1", "newmodel-9.1"},
+		// Not a Claude id at all: passed through unchanged rather than
+		// mangled into something that looks like one.
+		{"Gemma-4-E4B-it-GGUF", "Gemma-4-E4B-it-GGUF"},
+	} {
+		if got := ClaudeModelShortName(tc.id); got != tc.want {
+			t.Errorf("ClaudeModelShortName(%q) = %q, want %q", tc.id, got, tc.want)
+		}
+	}
+}
+
+// The Go list and the agent's own CLAUDE_MODELS must not drift: an id the
+// launch flag accepts but `/model` refuses (or the reverse) is a bug the user
+// experiences as "it worked yesterday". Parsed out of the Python source the
+// same way palette_test parses submit — the source file IS the contract.
+func TestGoAndPythonClaudeModelListsAgree(t *testing.T) {
+	src, err := os.ReadFile(pythonStdioPath(t))
+	if err != nil {
+		t.Skipf("agent source not available in this checkout: %v", err)
+	}
+	block := regexp.MustCompile(`(?s)CLAUDE_MODELS: Dict\[str, str\] = \{(.*?)\}`).
+		FindSubmatch(src)
+	if block == nil {
+		t.Fatal("CLAUDE_MODELS not found in gaia_agent/stdio.py — has it been renamed?")
+	}
+	var pyIDs []string
+	for _, m := range regexp.MustCompile(`"(claude-[^"]+)"\s*:`).FindAllSubmatch(block[1], -1) {
+		pyIDs = append(pyIDs, string(m[1]))
+	}
+	if strings.Join(pyIDs, ",") != strings.Join(ClaudeModelIDs(), ",") {
+		t.Errorf("Claude model lists disagree:\n  Go:     %v\n  Python: %v",
+			ClaudeModelIDs(), pyIDs)
+	}
+}
+
+// pythonStdioPath locates the agent module relative to THIS source file, so
+// the test does not depend on the working directory the suite is run from.
+func pythonStdioPath(t *testing.T) string {
+	t.Helper()
+	_, self, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("cannot locate this test's own source file")
+	}
+	repo := filepath.Join(filepath.Dir(self), "..", "..", "..")
+	return filepath.Join(repo, "hub", "agents", "gaia", "python", "gaia_agent", "stdio.py")
+}
+
+// Every refusal and every help string names ExampleClaudeModelID. If it ever
+// stops being one of the ids we accept, those messages start advertising an id
+// ValidateClaudeModel rejects — the exact confusion they exist to prevent.
+func TestTheExampleModelIsOneWeAccept(t *testing.T) {
+	if err := ValidateClaudeModel(ExampleClaudeModelID); err != nil {
+		t.Errorf("ExampleClaudeModelID (%q) is advertised but refused: %v",
+			ExampleClaudeModelID, err)
+	}
+}

--- a/tui/internal/client/subprocess.go
+++ b/tui/internal/client/subprocess.go
@@ -479,6 +479,24 @@ func (s *SubprocessClient) ClaudeAtLaunch() bool {
 	return false
 }
 
+// ClaudeModelAtLaunch reports which Claude model the child was spawned with,
+// or "" when none was named (--use-claude alone, or a local launch).
+//
+// Read back off argv for the same reason ClaudeAtLaunch is: the header must
+// name what actually reached the child, never a second copy of the flag that
+// could disagree. It is what lets the chip say "claude · haiku-4.5" from the
+// first frame instead of a bare "claude" -- the agent's own model-state ping
+// is authoritative, but it is not read until the first turn (see
+// gaia_agent.stdio.main), which on a session that opens and waits is never.
+func (s *SubprocessClient) ClaudeModelAtLaunch() string {
+	for i, a := range s.args {
+		if a == ClaudeModelFlag && i+1 < len(s.args) {
+			return s.args[i+1]
+		}
+	}
+	return ""
+}
+
 // resetDeadChild kills, reaps, and discards a child the client can no longer
 // talk to. One helper, because the sequence is easy to get subtly wrong: a
 // missed discard leaves a corpse marked "started" and every later Send fails

--- a/tui/internal/ui/chat/canonical.go
+++ b/tui/internal/ui/chat/canonical.go
@@ -62,6 +62,8 @@ func (m ChatModel) handleCanonicalEvent(evt interface{}) (ChatModel, tea.Cmd, bo
 			if e.LemonadeReachable != nil {
 				m.lemonadeKnown = true
 				m.lemonadeUp = *e.LemonadeReachable
+				// Fresh evidence, so the one-shot pre-refusal is armed again.
+				m.lemonadeDownRefused = false
 				m.lemonadeVersion = e.LemonadeVersion
 				m.lemonadeBaseURL = e.LemonadeBaseURL
 			}

--- a/tui/internal/ui/chat/canonical.go
+++ b/tui/internal/ui/chat/canonical.go
@@ -83,13 +83,17 @@ func (m ChatModel) handleCanonicalEvent(evt interface{}) (ChatModel, tea.Cmd, bo
 		if n, ok := stepNumberOf(e.Message); ok {
 			m.totalSteps = n
 		}
+		// Bounded on the way in, like every other agent-supplied line the log
+		// keeps (see narrate.go). What PRINTS is still laid out to this terminal
+		// at render time; this only stops a megabyte of "status" living in the
+		// model for the rest of the session.
 		if msg := userFacingStatus(e.Message); msg != "" {
-			m.setLiveStatus(msg)
+			m.setLiveStatus(truncateRunes(msg, narrationMax))
 		} else if m.dev {
 			// --dev is where harness internals belong: suppressing them for
 			// everyone would make a wire-level bug invisible to whoever has to
 			// fix it.
-			m.setLiveStatus("[harness] " + clean(e.Message))
+			m.setLiveStatus(truncateRunes("[harness] "+clean(e.Message), narrationMax))
 		}
 
 	case event.CanonicalTokenEvent:

--- a/tui/internal/ui/chat/canonical.go
+++ b/tui/internal/ui/chat/canonical.go
@@ -504,11 +504,13 @@ func failureDetail(e event.CanonicalToolResultEvent, te event.ToolError) string 
 	if te.Code != "" {
 		head += " — " + te.Code
 	}
-	if msg := firstLine(te.Message); msg != "" {
-		return truncateRunes(head+": "+msg, detailWidth)
+	// clean, not firstLine: the log wraps now, and a tool's error message puts
+	// the remedy on its second line as often as not.
+	if msg := clean(te.Message); msg != "" {
+		return truncateRunes(head+": "+msg, detailMax)
 	}
 	if detail := toolResultDetail(e); detail != "" && !isBareStatusWord(detail) {
-		return truncateRunes(head+": "+detail, detailWidth)
+		return truncateRunes(head+": "+detail, detailMax)
 	}
 	return head
 }

--- a/tui/internal/ui/chat/claude.go
+++ b/tui/internal/ui/chat/claude.go
@@ -6,6 +6,7 @@ package chat
 import (
 	"github.com/charmbracelet/lipgloss"
 
+	"github.com/amd/gaia/tui/internal/client"
 	"github.com/amd/gaia/tui/internal/ui/theme"
 )
 
@@ -20,32 +21,64 @@ var claudeChipStyle = lipgloss.NewStyle().
 
 // applyLaunchClaude reflects a --use-claude launch into the model.
 //
-// The flag reaches the AGENT through its own argv; this reads it back off the
-// transport so the chip is driven by what was actually passed to the child,
-// never by a second bool that could disagree with it.
+// The flags reach the AGENT through its own argv; this reads them back off
+// the transport so the chip is driven by what was actually passed to the
+// child, never by a second copy that could disagree with it.
 func (m ChatModel) applyLaunchClaude() ChatModel {
 	type launchClaude interface{ ClaudeAtLaunch() bool }
-	if c, ok := m.client.(launchClaude); ok && c.ClaudeAtLaunch() {
-		m.claudeMode = true
-		m.messages = append(m.messages, Message{
-			Role: RoleStatus,
-			Content: "Launched with --use-claude: " + m.agentName +
-				" runs on Anthropic's Claude API, not the local backend — this " +
-				"conversation is sent to Anthropic.",
-		})
+	c, ok := m.client.(launchClaude)
+	if !ok || !c.ClaudeAtLaunch() {
+		return m
 	}
+	m.claudeMode = true
+	if withModel, ok := m.client.(interface{ ClaudeModelAtLaunch() string }); ok {
+		m.launchClaudeModel = withModel.ClaudeModelAtLaunch()
+	}
+	m.messages = append(m.messages, Message{
+		Role: RoleStatus,
+		Content: "Launched with --use-claude: " + m.agentName + " runs on " +
+			claudeLaunchName(m.launchClaudeModel) +
+			", not the local backend — this conversation is sent to Anthropic.",
+	})
 	return m
 }
 
-// renderClaudeChip is the header segment saying inference is remote, or ""
-// when the session runs locally. This is the PRE-PING fallback only — see
-// renderModelChip — because it can only ever say "claude" (the launch flag
-// carries no specific model id), never which one.
+// claudeLaunchName names the model in prose: "Claude Haiku 4.5" when the id
+// is one this build knows, the raw id when it is not, and "Anthropic's Claude
+// API" when the launch named none at all.
+func claudeLaunchName(modelID string) string {
+	if modelID == "" {
+		return "Anthropic's Claude API"
+	}
+	if known, ok := client.KnownClaudeModel(modelID); ok {
+		return "Claude " + known.Label
+	}
+	return modelID
+}
+
+// claudeChipLabel is the remote header segment's text — "claude · haiku-4.5",
+// never a bare "claude" once any model id is known.
+//
+// Telling Haiku from Sonnet from Opus at a glance is the whole point: they
+// differ in cost and capability by an order of magnitude, and a session that
+// silently reverted (see handleCanonicalEvent's restart detection) looks
+// identical to one that did not if the chip only ever says "claude".
+func claudeChipLabel(modelID string) string {
+	if modelID == "" {
+		return "claude"
+	}
+	return "claude · " + client.ClaudeModelShortName(modelID)
+}
+
+// renderClaudeChip is the header segment for a remote session before the
+// agent's first model-state ping has arrived — see renderModelChip. It names
+// the launch flag's model, which is a REQUEST rather than what resolved, so
+// the ping still overrides it the moment one lands.
 func (m ChatModel) renderClaudeChip() string {
 	if !m.claudeMode {
 		return ""
 	}
-	return claudeChipStyle.Render(" │ claude")
+	return claudeChipStyle.Render(" │ " + claudeChipLabel(m.launchClaudeModel))
 }
 
 // modelChipStyle is the local-model header segment: the same slot
@@ -60,15 +93,16 @@ var modelChipStyle = lipgloss.NewStyle().Foreground(theme.Text)
 //
 // Before the agent's first model-state ping arrives (see
 // handleCanonicalEvent) modelDisplay is still empty, so this falls back to
-// renderClaudeChip: the launch flag is the only fact known that early, and it
-// can only say a launch REQUESTED Claude, not which model resolved.
+// renderClaudeChip. That fallback is not rare: the ping is the first line the
+// child writes, but the transport does not scan its stdout until the first
+// turn, so a session the user opens and reads before typing has no ping at
+// all — which is exactly when the header was showing a bare "claude".
 func (m ChatModel) renderModelChip() string {
 	if m.modelDisplay == "" {
 		return m.renderClaudeChip()
 	}
-	style := modelChipStyle
 	if m.modelRemote {
-		style = claudeChipStyle
+		return claudeChipStyle.Render(" │ " + claudeChipLabel(m.modelID))
 	}
-	return style.Render(" │ " + m.modelDisplay)
+	return modelChipStyle.Render(" │ " + m.modelDisplay)
 }

--- a/tui/internal/ui/chat/claudemodel_test.go
+++ b/tui/internal/ui/chat/claudemodel_test.go
@@ -1,0 +1,357 @@
+// Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+package chat
+
+import (
+	"strings"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/x/ansi"
+
+	"github.com/amd/gaia/tui/internal/client"
+	"github.com/amd/gaia/tui/internal/event"
+)
+
+// claudeModelTransport is a transport spawned with both --use-claude and
+// --claude-model, matching what SubprocessClient reports back off a real
+// child's argv.
+type claudeModelTransport struct {
+	nullClient
+	model string
+}
+
+func (c *claudeModelTransport) ClaudeAtLaunch() bool        { return true }
+func (c *claudeModelTransport) ClaudeModelAtLaunch() string { return c.model }
+
+func claudeLaunchModel(t *testing.T, id string) ChatModel {
+	t.Helper()
+	m := NewChatModelForCatalogAgent(&claudeModelTransport{model: id}, setupAgentID, "GAIA", false)
+	m.width, m.height = 100, 30
+	return m
+}
+
+// canonicalModelPing is the agent's model-state ping — the header metadata it
+// emits at startup and after every switch.
+func canonicalModelPing(id, display string, remote bool) event.CanonicalStatusEvent {
+	return canonicalModelPingWithLemonade(id, display, remote, true, "http://localhost:13305")
+}
+
+func canonicalModelPingWithLemonade(id, display string, remote, lemonadeUp bool, baseURL string) event.CanonicalStatusEvent {
+	backend := "lemonade"
+	if remote {
+		backend = "claude"
+	}
+	up := lemonadeUp
+	return event.CanonicalStatusEvent{
+		Type:              "status",
+		ModelID:           id,
+		ModelDisplay:      display,
+		ModelBackend:      backend,
+		ModelRemote:       remote,
+		LemonadeReachable: &up,
+		LemonadeBaseURL:   baseURL,
+	}
+}
+
+// --- the header names WHICH Claude model ------------------------------------
+
+// The gap this closes: a bare "claude" chip cannot tell Haiku from Sonnet
+// from Opus, which differ by an order of magnitude in cost and capability.
+func TestHeaderNamesTheLaunchedClaudeModelBeforeAnyTurn(t *testing.T) {
+	for _, tc := range []struct{ id, want string }{
+		{"claude-haiku-4-5", "claude · haiku-4.5"},
+		{"claude-sonnet-5", "claude · sonnet-5"},
+		{"claude-opus-5", "claude · opus-5"},
+	} {
+		header := ansi.Strip(claudeLaunchModel(t, tc.id).renderHeader())
+		if !strings.Contains(header, tc.want) {
+			t.Errorf("launched on %s: header = %q, want it to contain %q",
+				tc.id, header, tc.want)
+		}
+	}
+}
+
+// --use-claude with no model named still says the session is remote — it just
+// has nothing more specific to say yet.
+func TestHeaderFallsBackToABareClaudeChipWithNoModelFlag(t *testing.T) {
+	header := ansi.Strip(claudeLaunchModel(t, "").renderHeader())
+	if !strings.Contains(header, "│ claude") {
+		t.Errorf("a --use-claude launch must still be marked remote: %q", header)
+	}
+	if strings.Contains(header, "·") {
+		t.Errorf("no model was named, so none may be shown: %q", header)
+	}
+}
+
+// The launch flag is a REQUEST; the agent's ping is what resolved. When they
+// disagree the ping wins, because it is the only one that reflects reality.
+func TestTheAgentsPingOverridesTheLaunchFlagInTheHeader(t *testing.T) {
+	m := claudeLaunchModel(t, "claude-haiku-4-5")
+	m = feed(t, m, canonicalModelPing("claude-opus-5", "Opus 5", true))
+
+	header := ansi.Strip(m.renderHeader())
+	if !strings.Contains(header, "claude · opus-5") {
+		t.Errorf("the agent's resolved model must win, got %q", header)
+	}
+	if strings.Contains(header, "haiku") {
+		t.Errorf("the header still shows the launch flag's model: %q", header)
+	}
+}
+
+// A launch-flagged Claude session that switches to a local model must stop
+// looking remote — the chip's text carries that meaning as well as its colour.
+func TestSwitchingToALocalModelClearsTheRemoteChip(t *testing.T) {
+	m := claudeLaunchModel(t, "claude-haiku-4-5")
+	m = feed(t, m, canonicalModelPing("Gemma-4-E4B-it-GGUF", "Gemma-4-E4B-it-GGUF", false))
+
+	header := ansi.Strip(m.renderHeader())
+	if strings.Contains(header, "claude ·") {
+		t.Errorf("a local session must not carry a claude model chip: %q", header)
+	}
+	if !strings.Contains(header, "Gemma-4-E4B-it-GGUF") {
+		t.Errorf("header must name the local model it switched to: %q", header)
+	}
+}
+
+// --- /model id validation ---------------------------------------------------
+
+// A typo'd Claude id is refused locally, with the accepted ids, instead of
+// being spent on a turn that ends in an opaque 404 from Anthropic.
+func TestBadClaudeIDIsRefusedWithoutSendingATurn(t *testing.T) {
+	m := gaiaTestModel(t)
+
+	updated, cmd := m.submit("/model claude-haiku-45")
+	m = updated.(ChatModel)
+
+	if cmd != nil {
+		t.Error("a refused switch must not start a turn")
+	}
+	if m.awaitingModelSwitch {
+		t.Error("a refused switch must not arm the switch state machine")
+	}
+	last := m.messages[len(m.messages)-1]
+	if last.Role != RoleError {
+		t.Fatalf("expected an error message, got %+v", last)
+	}
+	for _, id := range client.ClaudeModelIDs() {
+		if !strings.Contains(last.Content, id) {
+			t.Errorf("refusal does not offer %q: %q", id, last.Content)
+		}
+	}
+}
+
+// Every accepted id goes through — the point of the check is to refuse typos,
+// not to become a second gate on real models.
+func TestEveryKnownClaudeIDIsAcceptedForSwitching(t *testing.T) {
+	m := gaiaTestModel(t)
+	for _, id := range client.ClaudeModelIDs() {
+		if reason := m.refuseModelSwitch(id); reason != "" {
+			t.Errorf("%s must be switchable, refused with: %s", id, reason)
+		}
+	}
+}
+
+// A bare `/model` is a LIST request, not a switch — never validated away.
+func TestBareModelCommandIsNeverRefused(t *testing.T) {
+	m := gaiaTestModel(t)
+	if reason := m.refuseModelSwitch(modelCommandArg("/model")); reason != "" {
+		t.Errorf("`/model` must always be able to list: %s", reason)
+	}
+}
+
+func TestModelCommandArg(t *testing.T) {
+	for _, tc := range []struct{ in, want string }{
+		{"/model", ""},
+		{"  /model  ", ""},
+		{"/model claude-haiku-4-5", "claude-haiku-4-5"},
+		{"/model   claude-opus-5  ", "claude-opus-5"},
+	} {
+		if got := modelCommandArg(tc.in); got != tc.want {
+			t.Errorf("modelCommandArg(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+// --- Lemonade down: refuse with both ways forward, never fall back ----------
+
+// Switching to a local model with the local server known-down is a dead end
+// the TUI can see coming. It must say what is wrong, both ways out, and that
+// nothing changed — and must NOT quietly leave the session somewhere else
+// while reporting success.
+func TestLocalSwitchWithLemonadeDownIsRefusedActionably(t *testing.T) {
+	m := claudeLaunchModel(t, "claude-haiku-4-5")
+	m = feed(t, m, canonicalModelPingWithLemonade(
+		"claude-haiku-4-5", "Haiku 4.5", true, false, "http://localhost:13305"))
+
+	updated, cmd := m.submit("/model Gemma-4-E4B-it-GGUF")
+	m = updated.(ChatModel)
+
+	if cmd != nil {
+		t.Error("a switch that cannot succeed must not start a turn")
+	}
+	last := m.messages[len(m.messages)-1]
+	if last.Role != RoleError {
+		t.Fatalf("expected an error message, got %+v", last)
+	}
+	for _, must := range []string{
+		"Lemonade",               // what is wrong
+		"http://localhost:13305", // where
+		"lemonade-server serve",  // how to fix it
+		"stay on Claude",         // the other way forward
+		"Nothing was switched",   // what did NOT happen
+	} {
+		if !strings.Contains(last.Content, must) {
+			t.Errorf("refusal must mention %q: %q", must, last.Content)
+		}
+	}
+	// No silent fallback: the session is still exactly where it was.
+	if !m.modelRemote || m.modelID != "claude-haiku-4-5" {
+		t.Errorf("a refused switch must leave the session untouched, got %q remote=%v",
+			m.modelID, m.modelRemote)
+	}
+}
+
+// The same refusal on a LOCAL session must not tell the user to "stay remote"
+// — it is not remote — and must name what moving to Claude actually costs.
+func TestTheRemoteAlternativeIsPhrasedForALocalSession(t *testing.T) {
+	m := gaiaTestModel(t)
+	m = feed(t, m, canonicalModelPingWithLemonade(
+		"Gemma-4-E4B-it-GGUF", "Gemma-4-E4B-it-GGUF", false, false, "http://localhost:13305"))
+
+	updated, _ := m.submit("/model some-other-local-model")
+	m = updated.(ChatModel)
+
+	last := m.messages[len(m.messages)-1].Content
+	if strings.Contains(last, "stay on Claude") {
+		t.Errorf("a local session is not on Claude: %q", last)
+	}
+	for _, must := range []string{client.ExampleClaudeModelID, "ANTHROPIC_API_KEY"} {
+		if !strings.Contains(last, must) {
+			t.Errorf("the alternative must mention %q: %q", must, last)
+		}
+	}
+}
+
+// The refusal reads a CACHED snapshot — nothing refreshes it between agent
+// pings — so it must fire once and then get out of the way. A user who starts
+// Lemonade (in another terminal, or with /setup) and sends the same line again
+// has to reach the agent, which probes live. A sticky refusal would be a dead
+// end no retry could ever clear.
+func TestTheLemonadeDownRefusalDoesNotStickForever(t *testing.T) {
+	m := gaiaTestModel(t)
+	m = feed(t, m, canonicalModelPingWithLemonade(
+		"Gemma-4-E4B-it-GGUF", "Gemma-4-E4B-it-GGUF", false, false, "http://localhost:13305"))
+
+	updated, cmd := m.submit("/model some-other-local-model")
+	m = updated.(ChatModel)
+	if cmd != nil {
+		t.Fatal("precondition: the first attempt should have been refused locally")
+	}
+
+	updated, cmd = m.submit("/model some-other-local-model")
+	m = updated.(ChatModel)
+	if cmd == nil {
+		t.Error("the retry must reach the agent — it is the only live probe")
+	}
+	if !m.awaitingModelSwitch {
+		t.Error("the retry must arm the switch state machine")
+	}
+}
+
+// A fresh ping is fresh evidence, so the one-shot refusal is armed again.
+func TestANewPingRearmsTheLemonadeDownRefusal(t *testing.T) {
+	m := gaiaTestModel(t)
+	down := canonicalModelPingWithLemonade(
+		"Gemma-4-E4B-it-GGUF", "Gemma-4-E4B-it-GGUF", false, false, "http://localhost:13305")
+
+	m = feed(t, m, down)
+	updated, _ := m.submit("/model some-other-local-model")
+	m = updated.(ChatModel)
+	if !m.lemonadeDownRefused {
+		t.Fatal("precondition: the first refusal should have spent the latch")
+	}
+
+	m = feed(t, m, down)
+	if m.lemonadeDownRefused {
+		t.Error("a new report is new evidence — the refusal must be armed again")
+	}
+}
+
+// Lemonade's state UNKNOWN is not the same as Lemonade being down: the switch
+// goes through to the agent, which is the only thing that can actually answer.
+func TestLocalSwitchIsAllowedWhenLemonadeStateIsUnknown(t *testing.T) {
+	m := gaiaTestModel(t)
+	if m.lemonadeKnown {
+		t.Fatal("precondition: a fresh model has not heard about Lemonade yet")
+	}
+	if reason := m.refuseModelSwitch("Gemma-4-E4B-it-GGUF"); reason != "" {
+		t.Errorf("an unknown local state must not pre-refuse: %s", reason)
+	}
+}
+
+// --- the palette surfaces the models ---------------------------------------
+
+// `/model` takes a free-form id, so the models cannot be flat palette rows.
+// The space after the command name opens a second level instead.
+func TestTypingTheSpaceAfterModelOpensTheModelPicker(t *testing.T) {
+	m := gaiaTestModel(t)
+	m = typeInto(t, m, "/model ")
+
+	if !m.palette.open {
+		t.Fatal("`/model ` must open the model picker")
+	}
+	names := paletteNames(m.paletteFiltered())
+	for _, id := range client.ClaudeModelIDs() {
+		if !containsAll(names, "/model "+id) {
+			t.Errorf("the picker does not offer %q, got %v", id, names)
+		}
+	}
+	// Bare /model stays reachable: it is the only way to see LOCAL models,
+	// which only the agent can enumerate.
+	if !containsAll(names, "/model") {
+		t.Errorf("the picker must keep a row that lists every model, got %v", names)
+	}
+}
+
+// Nobody types "claude-" to find Haiku.
+func TestModelPickerMatchesOnTheFamilyName(t *testing.T) {
+	m := gaiaTestModel(t)
+	m = typeInto(t, m, "/model haiku")
+
+	names := paletteNames(m.paletteFiltered())
+	if len(names) != 1 || names[0] != "/model claude-haiku-4-5" {
+		t.Errorf(`"/model haiku" should narrow to Haiku alone, got %v`, names)
+	}
+}
+
+// The top-level palette is unchanged: the models live one level down, so the
+// real commands are not buried under a model list nobody asked for.
+func TestTheModelPickerDoesNotLeakIntoTheTopLevelPalette(t *testing.T) {
+	m := gaiaTestModel(t)
+	m = typeInto(t, m, "/mo")
+
+	names := paletteNames(m.paletteFiltered())
+	if len(names) != 1 || names[0] != "/model" {
+		t.Errorf(`"/mo" must still narrow to just /model, got %v`, names)
+	}
+}
+
+// Picking a model row runs it as the command it is — not as a chat message.
+func TestPickingAModelRowSubmitsTheSwitch(t *testing.T) {
+	m := claudeLaunchModel(t, "claude-sonnet-5")
+	m = typeInto(t, m, "/model haiku")
+
+	updated, _, _ := m.handlePaletteKey(tea.KeyMsg{Type: tea.KeyEnter})
+	m = updated
+
+	if !m.awaitingModelSwitch {
+		t.Error("picking a model row must dispatch the switch")
+	}
+	for _, msg := range m.messages {
+		if msg.Role == RoleUser {
+			t.Errorf("a picked model must never post as a chat message: %+v", msg)
+		}
+	}
+}

--- a/tui/internal/ui/chat/claudenolemonade_test.go
+++ b/tui/internal/ui/chat/claudenolemonade_test.go
@@ -1,0 +1,146 @@
+// Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+package chat
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+// The regression these guard: `gaia run gaia --use-claude --claude-model
+// claude-haiku-4-5` started LemonadeServer.exe anyway.
+//
+// The first-boot gate ran `gaia init` on every flagship launch, and `gaia
+// init` auto-starts the local server unconditionally (_auto_start_server,
+// src/gaia/installer/init_command.py). Claude mode only added
+// --skip-chat-model, which skips the model DOWNLOAD and nothing else — so the
+// one flag whose entire purpose is "do not use the local backend" was the
+// flag that reliably brought it up, and blocked the first Claude answer
+// behind a multi-minute install while it did.
+
+// runInitCmds executes whatever Init() scheduled, so a gate that fires shows
+// up as a real call rather than as unread intent.
+func runInitCmds(t *testing.T, m ChatModel) {
+	t.Helper()
+	cmd := m.Init()
+	if cmd == nil {
+		return
+	}
+	drainCmd(t, cmd)
+}
+
+// drainCmd runs a Cmd and everything tea.Batch folded into it — Init returns
+// a batch, and the setup probe is one member of it.
+func drainCmd(t *testing.T, cmd tea.Cmd) {
+	t.Helper()
+	switch msg := cmd().(type) {
+	case tea.BatchMsg:
+		for _, c := range msg {
+			if c != nil {
+				drainCmd(t, c)
+			}
+		}
+	case []tea.Cmd:
+		for _, c := range msg {
+			if c != nil {
+				drainCmd(t, c)
+			}
+		}
+	}
+}
+
+// A Claude session must not reach for the `gaia` CLI at all: every route to
+// LemonadeServer.exe from this package runs through it.
+func TestClaudeLaunchNeverInvokesTheGaiaCLI(t *testing.T) {
+	called := false
+	orig := gaiaBinary
+	gaiaBinary = func() (string, error) {
+		called = true
+		t.Error("a --use-claude launch resolved the gaia CLI — that path starts " +
+			"LemonadeServer.exe via `gaia init`")
+		return "", nil
+	}
+	t.Cleanup(func() { gaiaBinary = orig })
+
+	m := claudeLaunchModel(t, "claude-haiku-4-5")
+	runInitCmds(t, m)
+
+	if called {
+		t.Fatal("the local backend must not be started for a Claude session")
+	}
+}
+
+// The gate is skipped, not merely unarmed: setupChecking is what holds the
+// composer and the initial --query, so leaving it set would hang a session
+// whose probe now never runs.
+func TestClaudeLaunchDoesNotArmTheSetupGate(t *testing.T) {
+	m := claudeLaunchModel(t, "claude-haiku-4-5")
+
+	if m.setupChecking {
+		t.Error("a Claude session must not arm the first-boot gate — nothing " +
+			"will ever answer it, so the composer would stay held")
+	}
+	if m.setupRunning {
+		t.Error("a Claude session must not start a setup run")
+	}
+}
+
+// Skipping is not the same as hiding. The session says on screen that the
+// local server was not started and what that costs, because the embedder RAG
+// and memory need has no Anthropic equivalent.
+func TestClaudeLaunchSaysTheLocalBackendWasNotStarted(t *testing.T) {
+	m := claudeLaunchModel(t, "claude-haiku-4-5")
+
+	var transcript strings.Builder
+	for _, msg := range m.messages {
+		transcript.WriteString(msg.Content)
+		transcript.WriteString("\n")
+	}
+	text := transcript.String()
+
+	for _, must := range []string{
+		"not started",      // what did not happen
+		"Claude Haiku 4.5", // which model it runs on instead
+		"gaia init",        // the command that sets the local half up
+		"/setup",           // the in-TUI way to do the same
+	} {
+		if !strings.Contains(text, must) {
+			t.Errorf("the launch notice must mention %q, got:\n%s", must, text)
+		}
+	}
+}
+
+// A LOCAL flagship launch is untouched — it still needs the gate, and this
+// change must not have quietly disabled first-boot setup for everyone.
+//
+// It also proves the check above can actually fail: the same harness, on the
+// same constructor, DOES reach the gaia CLI when Claude mode is off. Without
+// this, "gaiaBinary was never called" would pass just as happily against a
+// model that never calls anything.
+func TestALocalFlagshipLaunchStillRunsTheSetupGate(t *testing.T) {
+	called := false
+	orig := gaiaBinary
+	gaiaBinary = func() (string, error) { called = true; return orig2Path(), nil }
+	t.Cleanup(func() { gaiaBinary = orig })
+
+	m := gaiaTestModel(t)
+	if !m.setupChecking {
+		t.Fatal("a local flagship launch must still run first-boot setup")
+	}
+	runInitCmds(t, m)
+	if !called {
+		t.Error("the local path must still reach the gaia CLI — otherwise the " +
+			"Claude-path assertion proves nothing")
+	}
+}
+
+// orig2Path is a path that certainly does not exist, so the probe fails fast
+// instead of running whatever `gaia` is installed on the test machine.
+func orig2Path() string {
+	return filepath.Join(os.TempDir(), "gaia-does-not-exist-for-tests")
+}

--- a/tui/internal/ui/chat/devlog.go
+++ b/tui/internal/ui/chat/devlog.go
@@ -78,13 +78,14 @@ func stepNumberOf(status string) (int, bool) {
 	return n, true
 }
 
-// devPayloadWidth caps an args/output line at capture time.
+// devPayloadWidth is how much of an args/output line is KEPT at capture time.
 //
 // A payload is data rather than prose, so it gets a wide capture — the renderer
 // re-clips it to whatever the terminal leaves (renderActivityItem), and unlike a
 // narration or an outcome it does not wrap: one row, always, so a --dev payload
-// can never push the live region around.
-const devPayloadWidth = 100
+// can never push the live region around. Sized past the widest row that one
+// terminal can show, or a wide window would re-clip what capture already cut.
+const devPayloadWidth = widestLogMeasure
 
 // devPayload renders a tool's arguments or its result for the developer log:
 // one line, no newlines, no control bytes, truncated to width.

--- a/tui/internal/ui/chat/devlog.go
+++ b/tui/internal/ui/chat/devlog.go
@@ -80,10 +80,10 @@ func stepNumberOf(status string) (int, bool) {
 
 // devPayloadWidth caps an args/output line at capture time.
 //
-// Wider than detailWidth (66) because a payload is data rather than prose and
-// the interesting part is often a path or an id near the end, but still short
-// of the narrowest terminal worth supporting so the line cannot wrap and push
-// the live region around.
+// A payload is data rather than prose, so it gets a wide capture — the renderer
+// re-clips it to whatever the terminal leaves (renderActivityItem), and unlike a
+// narration or an outcome it does not wrap: one row, always, so a --dev payload
+// can never push the live region around.
 const devPayloadWidth = 100
 
 // devPayload renders a tool's arguments or its result for the developer log:

--- a/tui/internal/ui/chat/devlog_test.go
+++ b/tui/internal/ui/chat/devlog_test.go
@@ -130,7 +130,7 @@ func TestDevPayloadsRenderOnlyUnderDev(t *testing.T) {
 
 	dev := NewChatModel(&nullClient{}, "GAIA", "", true)
 	dev.width = 120
-	devLines := strings.Join(dev.renderActivityItem(item, false, 0), "\n")
+	devLines := strings.Join(dev.renderActivityItem(item, false, 0, 0), "\n")
 	for _, want := range []string{"Reading /etc/hosts", "417 bytes", "/etc/hosts", "args", "out"} {
 		if !strings.Contains(devLines, want) {
 			t.Errorf("--dev render lost %q:\n%s", want, devLines)
@@ -143,7 +143,7 @@ func TestDevPayloadsRenderOnlyUnderDev(t *testing.T) {
 	user.width = 120
 	bare := item
 	bare.Args, bare.Output = "", ""
-	userLines := strings.Join(user.renderActivityItem(bare, false, 0), "\n")
+	userLines := strings.Join(user.renderActivityItem(bare, false, 0, 0), "\n")
 	if strings.Contains(userLines, "args") || strings.Contains(userLines, `{"`) {
 		t.Errorf("user mode drew a developer payload:\n%s", userLines)
 	}

--- a/tui/internal/ui/chat/model.go
+++ b/tui/internal/ui/chat/model.go
@@ -1863,7 +1863,9 @@ func (m ChatModel) cardWidth() int {
 // answerMeasure caps how wide a line of prose gets. A 200-column terminal will
 // happily lay an answer out as 200-character lines, and the eye loses the start
 // of the next one on the way back — the reason newspapers set narrow columns.
-// Tables and cards are not prose and are not capped by this.
+// Tables and cards are not prose and are not capped by this, and neither is the
+// work log: one-line content follows the terminal (see logWidth), because for a
+// single row more columns mean more of the line, not a longer read.
 const answerMeasure = 88
 
 // answerWidth is the width an answer lays out to — the same for the streaming
@@ -2037,18 +2039,31 @@ func (m ChatModel) logRows() int {
 	return budget
 }
 
-// logWidth is the measure one work-log ROW is wrapped to on THIS terminal. The
-// fixed cap is a readability ceiling, not a layout assumption: a line is wrapped
-// to it, never clipped by it, so the terminal's own width still decides where
-// the text breaks below ~80 columns.
+// logWidth is the measure one work-log ROW is laid out to on THIS terminal.
+//
+// Single-line content follows the window. A tool line, a live status and its
+// outcome each start as one row, so extra columns buy the reader more of the
+// SAME row rather than more rows — which matters most for the lines whose tail
+// carries the reason or the remedy. Wrapping (wrapLog) is what saves a tail
+// that still does not fit; a wider window is what stops it needing to.
+//
+// That is the opposite call from prose, which stays at answerMeasure however
+// wide the window gets; see that constant for why the two differ.
 func (m ChatModel) logWidth() int {
 	// 4 for the marker gutter, 2 for the viewport's own edge.
 	w := m.width - 6
-	if w > narrationWidth {
-		w = narrationWidth
-	}
 	if w < 16 {
 		w = 16
+	}
+	// The floor is there so a cramped window still shows SOMETHING, not so it
+	// prints past the last column: the viewport does not soft-wrap, so a row
+	// one column too wide shears the row beneath it. The gutter comes off the
+	// terminal either way.
+	if fits := m.width - 4; m.width > 0 && w > fits {
+		w = fits
+	}
+	if w < 1 {
+		w = 1
 	}
 	return w
 }
@@ -2148,7 +2163,11 @@ func (m ChatModel) renderLiveRegion() string {
 	// reappears the moment the last finished action scrolls out of view.
 	hint := ""
 	if !anyCompleted(m.activity) && elapsed >= stillWorkingAfter {
-		hint = "     " + activityStyle.Render(glyphDetail+" still working — local model, usually 60-90s")
+		// Measured like every other row in this region. Its 50 columns fit an
+		// 80-column terminal, but on a narrower one it wrapped to two rows and
+		// broke the single-row assumption the budget below is making.
+		hint = "     " + activityStyle.Render(truncateRunes(
+			glyphDetail+" still working — local model, usually 60-90s", m.logWidth()-1))
 	}
 
 	// The hint is part of the height budget, not an extra row bolted on after

--- a/tui/internal/ui/chat/model.go
+++ b/tui/internal/ui/chat/model.go
@@ -289,6 +289,11 @@ type ChatModel struct {
 	firstToken   bool      // whether the first real inference token has arrived this turn (not just any SSE frame)
 	ttft         time.Duration
 
+	// logPeakRows is the tallest the work log has been THIS turn. The region's
+	// height is held there (see liveRegionView) so it never shrinks mid-turn and
+	// drops the transcript above back down while it is being read.
+	logPeakRows int
+
 	// followTail is true while the view should stay pinned to the newest
 	// content. Scrolling up clears it, so a streaming answer stops yanking the
 	// reader back to the bottom mid-sentence; returning to the bottom (or
@@ -1134,6 +1139,9 @@ func (m ChatModel) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 func (m ChatModel) requestCancel() (tea.Model, tea.Cmd) {
 	m.cancelPending = true
 	m.activity = nil
+	// The log just emptied; holding the height it reached would leave a block of
+	// blank rows under "Stopping at the next step".
+	m.logPeakRows = 0
 	m.question = nil
 	m.confirmation = nil
 	// A follow-up queued behind this turn was written on the assumption the
@@ -1334,6 +1342,7 @@ func (m ChatModel) sendQuery(query string) (tea.Model, tea.Cmd) {
 func (m ChatModel) startTurn(query string) (tea.Model, tea.Cmd) {
 	m.streaming = true
 	m.activity = nil
+	m.logPeakRows = 0
 	m.buffer = ""
 	// Asking a new question means you want to see its answer, wherever the
 	// scroll happened to be left.
@@ -1505,7 +1514,11 @@ func (m ChatModel) handleEvent(evt interface{}) (tea.Model, tea.Cmd) {
 		// arrives with tabs, CRs and occasionally ANSI colour, and the old
 		// byte slice at [:60] cut mid-rune on any non-ASCII output — a path
 		// with an accent or a box-drawing character rendered as mojibake.
-		summary = truncateRunes(clean(summary), 60)
+		//
+		// Bounded here, but no longer CUT to a row: the renderer wraps this
+		// (renderActivityItem) and is the one place that decides where a line
+		// ends. A 60-column cut here lost the tail before it ever got there.
+		summary = truncateRunes(clean(summary), narrationMax)
 		if len(m.activity) > 0 {
 			last := &m.activity[len(m.activity)-1]
 			if last.Kind == "tool" {
@@ -1742,7 +1755,7 @@ func (m *ChatModel) updateViewport() {
 	// lands — the silent gap before an agent's first event is exactly when a
 	// blank screen reads as a hang.
 	if m.streaming {
-		sb.WriteString(m.renderLiveRegion())
+		sb.WriteString(m.liveRegionView())
 		sb.WriteString("\n")
 	}
 
@@ -1972,6 +1985,18 @@ const workLogLines = 6
 // 13 rows and shove the answer the user is reading off the top.
 const workLogMaxRows = 9
 
+// logHeadRows caps how many rows ONE action's description may wrap to. Wrapping
+// is what buys the tail back; the per-action cap is what stops a single 300-
+// character shell command from spending the whole region on itself and hiding
+// every other action. The region's own ceiling (logRows) is unchanged by
+// wrapping — a wrapped line costs HISTORY, never height.
+const logHeadRows = 3
+
+// logDetailRows caps an action's `└` outcome. Same room as the call above it,
+// not less: the outcomes that run long are the FAILURES, and a failure's tail
+// is the remedy — the one line in the log a user has to act on.
+const logDetailRows = 3
+
 // logRows is the height budget for THIS terminal: never more than half the
 // visible pane, so the log cannot crowd out the transcript on a short window
 // (a 12-row terminal leaves the viewport 5 rows — the fixed cap alone would
@@ -1987,9 +2012,10 @@ func (m ChatModel) logRows() int {
 	return budget
 }
 
-// logWidth is the column budget for one work-log line on THIS terminal. The
-// fixed caps are a readability ceiling, not a layout assumption: below ~80
-// columns every line would soft-wrap and double the region's real height.
+// logWidth is the measure one work-log ROW is wrapped to on THIS terminal. The
+// fixed cap is a readability ceiling, not a layout assumption: a line is wrapped
+// to it, never clipped by it, so the terminal's own width still decides where
+// the text breaks below ~80 columns.
 func (m ChatModel) logWidth() int {
 	// 4 for the marker gutter, 2 for the viewport's own edge.
 	w := m.width - 6
@@ -2020,6 +2046,37 @@ const (
 	glyphStatus = "✻"
 	glyphDetail = "└"
 )
+
+// liveRegionView is the work log at a height that does not go backwards.
+//
+// The region's height moves with what the agent is doing: an outcome lands and
+// an action grows a row; a wrapped action pushes an older one out and the block
+// gets SHORTER. Growth is fine — it is new work, at the bottom where the eye
+// already is. Shrinking is the one that hurts: everything above drops back down
+// mid-sentence while it is being read, and wrapping makes the swings bigger. So
+// the height is held at this turn's peak, never above the terminal's budget,
+// and the difference is padded with blank rows.
+func (m *ChatModel) liveRegionView() string {
+	out := m.renderLiveRegion()
+	rows := strings.Count(out, "\n") + 1
+	if rows > m.logPeakRows {
+		m.logPeakRows = rows
+	}
+	// A resize can lower the ceiling under a peak reached on a taller window.
+	if budget := m.logRows(); m.logPeakRows > budget {
+		m.logPeakRows = budget
+	}
+	// Before the first WindowSizeMsg there is no viewport to budget against, so
+	// logRows' 9 is a guess — padding to it would open the turn with a block of
+	// blank rows on a window that may only have five.
+	if m.viewport.Height <= 0 {
+		return out
+	}
+	if pad := m.logPeakRows - rows; pad > 0 {
+		out += strings.Repeat("\n", pad)
+	}
+	return out
+}
 
 // renderLiveRegion draws the rolling activity log for the running turn: one line
 // per meaningful action, newest last, each closed action followed by a single
@@ -2072,14 +2129,24 @@ func (m ChatModel) renderLiveRegion() string {
 		budget--
 	}
 	// Oldest first: the newest action is the one being watched, and the live
-	// line is always last.
-	rows := 0
+	// line is always last. Trimming from the top is what pays for wrapping —
+	// a wrapped action costs older HISTORY, not extra height.
+	kept, rows := 0, 0
 	for i := len(groups) - 1; i >= 0; i-- {
-		rows += len(groups[i])
-		if rows > budget {
-			groups = groups[i+1:]
+		if rows+len(groups[i]) > budget {
 			break
 		}
+		rows += len(groups[i])
+		kept++
+	}
+	if kept > 0 {
+		groups = groups[len(groups)-kept:]
+	} else if len(groups) > 0 {
+		// One action taller than the entire budget — a wrapped shell command on
+		// a 12-row terminal, where the budget is two rows. Clip it to fit rather
+		// than drop it: an empty live region is a blank screen, which is the one
+		// thing this whole region exists to prevent.
+		groups = [][]string{clipRows(groups[len(groups)-1], budget)}
 	}
 
 	var lines []string
@@ -2091,6 +2158,20 @@ func (m ChatModel) renderLiveRegion() string {
 	}
 
 	return strings.Join(lines, "\n")
+}
+
+// clipRows cuts one action's rendered rows to a height budget, marking the cut
+// so the reader can tell the action says more than the window can show.
+func clipRows(rows []string, max int) []string {
+	if max < 1 {
+		max = 1
+	}
+	if len(rows) <= max {
+		return rows
+	}
+	out := append([]string(nil), rows[:max]...)
+	out[max-1] += activityStyle.Render(" …")
+	return out
 }
 
 // anyCompleted reports whether anything in the log has actually finished — the
@@ -2200,45 +2281,71 @@ func formatElapsed(d time.Duration) string {
 // the state survives a terminal with no colour.
 func (m ChatModel) renderActivityItem(item ActivityItem, live bool, elapsed time.Duration) []string {
 	width := m.logWidth()
-	// The counter is reserved BEFORE truncating, not appended after. Appending
-	// after meant any narration already at the cap — which shell commands and
-	// long paths routinely are, and which are exactly the calls that repeat —
-	// had its "x14" cut straight back off.
-	content := item.Content
+
+	// The counter rides along through the wrap rather than being appended after
+	// it. Appended after, any narration already at the measure — which shell
+	// commands and long paths routinely are, and which are exactly the calls
+	// that repeat — had its "x14" cut straight back off.
+	suffix := ""
 	if item.Repeat > 0 {
-		suffix := fmt.Sprintf(" x%d", item.Repeat+1)
-		content = truncateRunes(content, width-len(suffix)) + suffix
-	} else {
-		content = truncateRunes(content, width)
+		suffix = fmt.Sprintf(" x%d", item.Repeat+1)
 	}
 
-	var head string
+	// The live row's measure is narrower by what the spinner's clock occupies:
+	// the clock is appended AFTER the text, so text wrapped to the full measure
+	// would push it past the pane's edge and the viewport would clip the one
+	// number proving the turn is still moving.
+	headWidth := width
+	if live {
+		headWidth -= elapsedReserve
+	}
+	rows := wrapLog(clean(item.Content), suffix, headWidth, logHeadRows)
+
+	// Glyph and colour differ per kind; the wrap and the continuation indent do
+	// not. Continuations line up under the TEXT, not the glyph, so the marker
+	// column stays a gutter and the eye reads one action as one block.
+	glyph := ""
+	style := activityStyle
 	switch {
 	case live:
-		head = m.renderLiveLine(content, elapsed)
+		style = thinkingStyle
 	case item.Kind == "tool" || item.Kind == "confirm":
-		style := toolNameStyle
+		glyph, style = glyphTool, toolNameStyle
 		if item.Success != nil && !*item.Success {
 			style = failStyle
 		}
-		head = "  " + activityStyle.Render(glyphTool) + " " + style.Render(content)
 	case item.Kind == "status" || item.Kind == "thinking":
-		head = "  " + activityStyle.Render(glyphStatus) + " " +
-			lipgloss.NewStyle().Foreground(theme.Warning).Render(content)
-	default:
-		head = "    " + activityStyle.Render(content)
+		glyph, style = glyphStatus, lipgloss.NewStyle().Foreground(theme.Warning)
 	}
 
-	lines := []string{head}
-	if detail := truncateRunes(clean(item.Detail), width-2); detail != "" {
-		style := activityStyle
+	var lines []string
+	switch {
+	case live:
+		lines = append(lines, m.renderLiveLine(rows[0], elapsed))
+	case glyph != "":
+		lines = append(lines, "  "+activityStyle.Render(glyph)+" "+style.Render(rows[0]))
+	default:
+		lines = append(lines, "    "+style.Render(rows[0]))
+	}
+	for _, row := range rows[1:] {
+		lines = append(lines, "    "+style.Render(row))
+	}
+
+	if detail := clean(item.Detail); detail != "" {
+		dstyle := activityStyle
 		if item.Success != nil && !*item.Success {
-			style = failStyle
+			dstyle = failStyle
 		}
-		lines = append(lines, "    "+style.Render(glyphDetail+" "+detail))
+		drows := wrapLog(detail, "", width-2, logDetailRows)
+		lines = append(lines, "    "+dstyle.Render(glyphDetail+" "+drows[0]))
+		for _, row := range drows[1:] {
+			lines = append(lines, "      "+dstyle.Render(row))
+		}
 	}
 	// Developer mode only. Args and Output are populated nowhere else, so the
 	// user-mode log is genuinely unchanged rather than merely filtered here.
+	// These stay ONE clipped row each: they are raw JSON, not prose, and the
+	// transcript's render card is where a full payload belongs.
 	for _, extra := range []struct{ label, text string }{
 		{"args", item.Args},
 		{"out", item.Output},
@@ -2252,6 +2359,86 @@ func (m ChatModel) renderActivityItem(item ActivityItem, live bool, elapsed time
 		}
 	}
 	return lines
+}
+
+// elapsedReserve is the room renderLiveLine's trailing clock needs: two spaces
+// and up to "10:05".
+const elapsedReserve = 8
+
+// wrapLog lays one work-log string out over at most maxRows rows of width
+// columns, reusing the same wrap the transcript uses (components.WrapText) so
+// there is one wrapping path in this package, not three.
+//
+// Wrapped, not clipped, for the reason the status path already gives: the
+// viewport does not soft-wrap, so a line longer than the measure loses its tail
+// — and for the lines that carry a reason or a remedy, the tail IS the point.
+// What the row cap cuts is still marked with an ellipsis, because a silent cut
+// is the bug this replaces. suffix (the repeat counter, or "") stays visible
+// even then: it is the part saying this call happened fourteen times.
+func wrapLog(s, suffix string, width, maxRows int) []string {
+	if width < 8 {
+		width = 8
+	}
+	if maxRows < 1 {
+		maxRows = 1
+	}
+	rows := hardBreak(strings.Split(components.WrapText(s+suffix, width), "\n"), width)
+	if len(rows) <= maxRows {
+		return rows
+	}
+	rows = rows[:maxRows]
+	rows[maxRows-1] = clipTail(strings.TrimRight(rows[maxRows-1], " "), width-displayWidth(suffix)) + suffix
+	return rows
+}
+
+// hardBreak splits any row still wider than the measure. WrapText breaks on
+// SPACES, and the lines that run long are routinely one unbroken token — a URL,
+// a Windows path, a quoted shell argument — which it emits whole. Left alone
+// those rows overrun the pane and the viewport clips them, which is the bug this
+// whole change is about.
+func hardBreak(rows []string, width int) []string {
+	out := make([]string, 0, len(rows))
+	for _, row := range rows {
+		for displayWidth(row) > width {
+			head, rest := splitAtWidth(row, width)
+			out = append(out, head)
+			row = rest
+		}
+		out = append(out, row)
+	}
+	return out
+}
+
+// splitAtWidth cuts s at a COLUMN count, never mid-rune.
+func splitAtWidth(s string, width int) (string, string) {
+	used := 0
+	for i, r := range s {
+		w := displayWidth(string(r))
+		if used+w > width {
+			return s[:i], s[i:]
+		}
+		used += w
+	}
+	return s, ""
+}
+
+// clipTail cuts s to limit columns and ALWAYS ends it with an ellipsis.
+// truncateRunes alone leaves a string that already fits untouched — and rows
+// arrive here filled TO the measure, so that is the common case, not a boundary
+// one. It would mean a cut with nothing on screen to say so.
+func clipTail(s string, limit int) string {
+	if limit <= 1 {
+		return "…"
+	}
+	if displayWidth(s) < limit {
+		return s + "…"
+	}
+	// limit-1, not limit: a row that lands EXACTLY on the measure — which is the
+	// common case, since the wrap fills rows to it — is "within budget" as far
+	// as truncateRunes is concerned, and it would hand the string straight back
+	// unmarked. Asking for one column less forces the cut, and truncateRunes
+	// adds the ellipsis itself.
+	return truncateRunes(s, limit-1)
 }
 
 // queuedEchoFloor is the narrowest the echoed line may get before the key hint
@@ -2390,8 +2577,12 @@ func (m ChatModel) View() string {
 // tool_args payload. Every truncation goes through truncateRunes: the previous
 // byte slice at [:60] split multi-byte runes, so a command touching a path with
 // any non-ASCII character rendered a replacement glyph mid-word.
+//
+// Bounded to the same measure the canonical path gives an argument, for the same
+// reason: the work log wraps, so a capture-time cut at one row's width threw the
+// tail away before anything could show it.
 func extractCommandFromArgs(raw json.RawMessage) string {
-	const argWidth = 60
+	const argWidth = narrationMax
 
 	var args map[string]interface{}
 	if err := json.Unmarshal(raw, &args); err != nil {

--- a/tui/internal/ui/chat/model.go
+++ b/tui/internal/ui/chat/model.go
@@ -2072,8 +2072,12 @@ func (m *ChatModel) liveRegionView() string {
 	if m.viewport.Height <= 0 {
 		return out
 	}
+	// Padded ABOVE. Below, the blank rows open a gap between the log and the
+	// answer streaming under it; above, they land in the space that already
+	// separates the log from the transcript, and hold the block's total height
+	// just the same.
 	if pad := m.logPeakRows - rows; pad > 0 {
-		out += strings.Repeat("\n", pad)
+		out = strings.Repeat("\n", pad) + out
 	}
 	return out
 }
@@ -2107,7 +2111,7 @@ func (m ChatModel) renderLiveRegion() string {
 	// hanging under nothing.
 	groups := make([][]string, 0, len(log)+1)
 	for i, item := range log {
-		groups = append(groups, m.renderActivityItem(item, i == live, elapsed))
+		groups = append(groups, m.renderActivityItem(item, i == live, elapsed, 0))
 	}
 	if live < 0 {
 		groups = append(groups, []string{m.renderLiveLine(m.idlePhrase(len(log)), elapsed)})
@@ -2141,12 +2145,15 @@ func (m ChatModel) renderLiveRegion() string {
 	}
 	if kept > 0 {
 		groups = groups[len(groups)-kept:]
-	} else if len(groups) > 0 {
+	} else if n := len(log) - 1; n >= 0 {
 		// One action taller than the entire budget — a wrapped shell command on
-		// a 12-row terminal, where the budget is two rows. Clip it to fit rather
-		// than drop it: an empty live region is a blank screen, which is the one
-		// thing this whole region exists to prevent.
-		groups = [][]string{clipRows(groups[len(groups)-1], budget)}
+		// a 12-row terminal, where the budget is two rows. Re-render it to fit
+		// rather than drop it: an empty live region is a blank screen, which is
+		// the one thing this whole region exists to prevent. Re-rendered, not
+		// row-sliced, so the ellipsis lands inside the text rather than after
+		// the clock. (The synthetic idle line is one row and always fits, so the
+		// group that overflowed is always the last log entry.)
+		groups = [][]string{m.renderActivityItem(log[n], n == live, elapsed, budget)}
 	}
 
 	var lines []string
@@ -2158,20 +2165,6 @@ func (m ChatModel) renderLiveRegion() string {
 	}
 
 	return strings.Join(lines, "\n")
-}
-
-// clipRows cuts one action's rendered rows to a height budget, marking the cut
-// so the reader can tell the action says more than the window can show.
-func clipRows(rows []string, max int) []string {
-	if max < 1 {
-		max = 1
-	}
-	if len(rows) <= max {
-		return rows
-	}
-	out := append([]string(nil), rows[:max]...)
-	out[max-1] += activityStyle.Render(" …")
-	return out
 }
 
 // anyCompleted reports whether anything in the log has actually finished — the
@@ -2279,7 +2272,12 @@ func formatElapsed(d time.Duration) string {
 // Failure is never signalled by colour or a glyph alone: a failed call's outcome
 // line begins with the word "failed" (see toolResultDetail / failureDetail), so
 // the state survives a terminal with no colour.
-func (m ChatModel) renderActivityItem(item ActivityItem, live bool, elapsed time.Duration) []string {
+// maxRows is the height this ONE action may occupy, or 0 for the standard caps.
+// The live region passes a real number only when a single action is taller than
+// the whole region's budget: the cut has to be made HERE, inside the text, or
+// the marker ends up appended to a rendered row — after the elapsed clock on the
+// live line, where it reads as part of the timer rather than as a truncation.
+func (m ChatModel) renderActivityItem(item ActivityItem, live bool, elapsed time.Duration, maxRows int) []string {
 	width := m.logWidth()
 
 	// The counter rides along through the wrap rather than being appended after
@@ -2291,15 +2289,17 @@ func (m ChatModel) renderActivityItem(item ActivityItem, live bool, elapsed time
 		suffix = fmt.Sprintf(" x%d", item.Repeat+1)
 	}
 
-	// The live row's measure is narrower by what the spinner's clock occupies:
-	// the clock is appended AFTER the text, so text wrapped to the full measure
-	// would push it past the pane's edge and the viewport would clip the one
-	// number proving the turn is still moving.
-	headWidth := width
-	if live {
-		headWidth -= elapsedReserve
+	headRows := logHeadRows
+	if maxRows > 0 && maxRows < headRows {
+		headRows = maxRows
 	}
-	rows := wrapLog(clean(item.Content), suffix, headWidth, logHeadRows)
+	// Only the FIRST row carries the clock, so only the first row pays for it.
+	// Charging every wrapped row 8 columns for a number none of them shows threw
+	// away two words per row of the longest lines in the log.
+	rows := wrapLog(clean(item.Content), suffix, width, headRows)
+	if live {
+		rows = wrapLogLead(clean(item.Content), suffix, width-elapsedReserve, width, headRows)
+	}
 
 	// Glyph and colour differ per kind; the wrap and the continuation indent do
 	// not. Continuations line up under the TEXT, not the glyph, so the marker
@@ -2331,12 +2331,16 @@ func (m ChatModel) renderActivityItem(item ActivityItem, live bool, elapsed time
 		lines = append(lines, "    "+style.Render(row))
 	}
 
-	if detail := clean(item.Detail); detail != "" {
+	detailRows := logDetailRows
+	if maxRows > 0 {
+		detailRows = maxRows - len(lines) // the call outranks its outcome
+	}
+	if detail := clean(item.Detail); detail != "" && detailRows > 0 {
 		dstyle := activityStyle
 		if item.Success != nil && !*item.Success {
 			dstyle = failStyle
 		}
-		drows := wrapLog(detail, "", width-2, logDetailRows)
+		drows := wrapLog(detail, "", width-2, detailRows)
 		lines = append(lines, "    "+dstyle.Render(glyphDetail+" "+drows[0]))
 		for _, row := range drows[1:] {
 			lines = append(lines, "      "+dstyle.Render(row))
@@ -2389,6 +2393,27 @@ func wrapLog(s, suffix string, width, maxRows int) []string {
 	rows = rows[:maxRows]
 	rows[maxRows-1] = clipTail(strings.TrimRight(rows[maxRows-1], " "), width-displayWidth(suffix)) + suffix
 	return rows
+}
+
+// wrapLogLead wraps like wrapLog, except the FIRST row gets a narrower measure
+// than the rest. The live row's elapsed clock is appended after its text and
+// takes those columns from THAT row only — continuations carry no clock and
+// should not pay for one.
+func wrapLogLead(s, suffix string, lead, width, maxRows int) []string {
+	if lead < 8 {
+		lead = 8
+	}
+	if displayWidth(s+suffix) <= lead {
+		return []string{s + suffix}
+	}
+	first := hardBreak(strings.Split(components.WrapText(s, lead), "\n"), lead)[0]
+	// A prefix of s, not a re-rendering of it: clean() has already collapsed
+	// runs of spaces, so WrapText's rows rejoin to exactly what went in.
+	rest := strings.TrimSpace(strings.TrimPrefix(s, first))
+	if rest == "" || maxRows <= 1 {
+		return wrapLog(s, suffix, lead, maxRows)
+	}
+	return append([]string{first}, wrapLog(rest, suffix, width, maxRows-1)...)
 }
 
 // hardBreak splits any row still wider than the measure. WrapText breaks on

--- a/tui/internal/ui/chat/model.go
+++ b/tui/internal/ui/chat/model.go
@@ -215,6 +215,14 @@ type ChatModel struct {
 	// kept in sync by every model-state ping thereafter (handleCanonicalEvent).
 	claudeMode bool
 
+	// launchClaudeModel is the id --claude-model put on the child's argv, ""
+	// when the launch named none. Kept separate from modelID on purpose:
+	// modelID means "what the agent RESOLVED" and the restart detector keys
+	// off it, so seeding it from a flag would let a launch flag masquerade as
+	// agent truth. This one is only ever read by the header's pre-ping
+	// fallback (renderClaudeChip).
+	launchClaudeModel string
+
 	// mouseCaptured is true while the APP holds the mouse, for either of the
 	// two independent reasons documented on overlayOpen (mousecapture.go):
 	// the user turned on wheel scrolling, or an overlay is open and needs
@@ -256,6 +264,11 @@ type ChatModel struct {
 	lemonadeUp      bool
 	lemonadeVersion string
 	lemonadeBaseURL string
+	// lemonadeDownRefused makes the "local server is down" pre-refusal fire
+	// once per down report instead of forever. Nothing refreshes lemonadeUp
+	// between pings, so a sticky refusal would outlive the problem — see
+	// refuseModelSwitch. Cleared by the next ping, whatever it says.
+	lemonadeDownRefused bool
 
 	// modelID/modelDisplay/modelBackend/modelRemote come from the agent's own
 	// model-state ping (a CanonicalStatusEvent with ModelID set — see
@@ -1242,6 +1255,18 @@ func (m ChatModel) submit(query string) (tea.Model, tea.Cmd) {
 				Content: m.agentName + " does not support live model switching " +
 					"(/model) — only the gaia flagship agent does.",
 			})
+			m.updateViewport()
+			return m, nil
+		}
+		// Refused here when the round-trip could only end in the same
+		// refusal — a bad Claude id, or a local id with the local server
+		// known-down. See refuseModelSwitch: the agent still validates, this
+		// only spares a turn that had no chance.
+		if reason := m.refuseModelSwitch(modelCommandArg(query)); reason != "" {
+			// Spent: the next identical request goes to the agent, which is
+			// the only thing that can re-probe the local server.
+			m.lemonadeDownRefused = true
+			m.messages = append(m.messages, Message{Role: RoleError, Content: reason})
 			m.updateViewport()
 			return m, nil
 		}

--- a/tui/internal/ui/chat/model.go
+++ b/tui/internal/ui/chat/model.go
@@ -306,6 +306,10 @@ type ChatModel struct {
 	// height is held there (see liveRegionView) so it never shrinks mid-turn and
 	// drops the transcript above back down while it is being read.
 	logPeakRows int
+	// logPeakWidth is the measure logPeakRows was reached at. A width change
+	// reflows the log, so a peak measured at another width describes a layout
+	// that no longer exists.
+	logPeakWidth int
 
 	// followTail is true while the view should stay pinned to the newest
 	// content. Scrolling up clears it, so a streaming answer stops yanking the
@@ -1718,6 +1722,15 @@ func (m *ChatModel) resize() {
 		vpWidth = 10
 	}
 
+	// A width change reflows the work log, so the height it peaked at was
+	// measured against a layout that no longer exists — holding it strands
+	// blank rows under the log for the rest of the turn. The mid-stream hold
+	// (liveRegionView) is untouched: that one absorbs the log shrinking while
+	// the reader is mid-sentence, which is not what a deliberate resize is.
+	if m.logPeakWidth != m.width {
+		m.logPeakWidth = m.width
+		m.logPeakRows = 0
+	}
 	m.viewport.Width = vpWidth
 	m.viewport.Height = vpHeight
 	m.input.SetWidth(vpWidth - 2)
@@ -2039,6 +2052,11 @@ func (m ChatModel) logRows() int {
 	return budget
 }
 
+// logGutter is the widest left margin a work-log row carries: two spaces, the
+// spinner (which draws two columns, not one) and a space. Static rows spend a
+// column less; one budget serves them all, so it is set by the widest.
+const logGutter = 5
+
 // logWidth is the measure one work-log ROW is laid out to on THIS terminal.
 //
 // Single-line content follows the window. A tool line, a live status and its
@@ -2057,9 +2075,10 @@ func (m ChatModel) logWidth() int {
 	}
 	// The floor is there so a cramped window still shows SOMETHING, not so it
 	// prints past the last column: the viewport does not soft-wrap, so a row
-	// one column too wide shears the row beneath it. The gutter comes off the
-	// terminal either way.
-	if fits := m.width - 4; m.width > 0 && w > fits {
+	// one column too wide shears the row beneath it. Measured against the
+	// WIDEST gutter, since one budget serves every row and the live one is a
+	// column deeper than the rest.
+	if fits := m.width - logGutter; m.width > 0 && w > fits {
 		w = fits
 	}
 	if w < 1 {
@@ -2154,7 +2173,11 @@ func (m ChatModel) renderLiveRegion() string {
 		groups = append(groups, m.renderActivityItem(item, i == live, elapsed, 0))
 	}
 	if live < 0 {
-		groups = append(groups, []string{m.renderLiveLine(m.idlePhrase(len(log)), elapsed)})
+		// Measured like every other row. This is the OPENING frame of every
+		// turn — before any tool event exists — so an unmeasured phrase here
+		// shears the frame on the very first thing a narrow window draws.
+		phrase := wrapLog(m.idlePhrase(len(log)), "", m.logWidth()-elapsedReserve, 1)[0]
+		groups = append(groups, []string{m.renderLiveLine(phrase, elapsed)})
 	}
 	// Shown until something has actually COMPLETED. A stage line alone does not
 	// count: a turn that sits on "Working out how to answer" for 1:47 with no
@@ -2167,7 +2190,7 @@ func (m ChatModel) renderLiveRegion() string {
 		// 80-column terminal, but on a narrower one it wrapped to two rows and
 		// broke the single-row assumption the budget below is making.
 		hint = "     " + activityStyle.Render(truncateRunes(
-			glyphDetail+" still working — local model, usually 60-90s", m.logWidth()-1))
+			glyphDetail+" still working — usually 60-90s", m.logWidth()-1))
 	}
 
 	// The hint is part of the height budget, not an extra row bolted on after
@@ -2410,7 +2433,8 @@ func (m ChatModel) renderActivityItem(item ActivityItem, live bool, elapsed time
 }
 
 // elapsedReserve is the room renderLiveLine's trailing clock needs: two spaces
-// and up to "10:05".
+// and up to "10:05", plus the column the spinner takes beyond a static row's
+// marker — the live row's gutter is one deeper than every other row's.
 const elapsedReserve = 8
 
 // wrapLog lays one work-log string out over at most maxRows rows of width
@@ -2424,8 +2448,13 @@ const elapsedReserve = 8
 // is the bug this replaces. suffix (the repeat counter, or "") stays visible
 // even then: it is the part saying this call happened fourteen times.
 func wrapLog(s, suffix string, width, maxRows int) []string {
-	if width < 8 {
-		width = 8
+	// Floored at 1, never raised to a comfortable minimum: this measure is what
+	// the CALLER can afford, and handing back a wider row than the window has
+	// columns is the shear every other budget here exists to avoid. One column
+	// of text is unreadable; a sheared frame is unreadable and takes the row
+	// below with it.
+	if width < 1 {
+		width = 1
 	}
 	if maxRows < 1 {
 		maxRows = 1

--- a/tui/internal/ui/chat/modelcmd.go
+++ b/tui/internal/ui/chat/modelcmd.go
@@ -3,7 +3,11 @@
 
 package chat
 
-import "strings"
+import (
+	"strings"
+
+	"github.com/amd/gaia/tui/internal/client"
+)
 
 // `/model` and `/model <id>` — live model switching. Unlike /bypass this
 // command genuinely needs the AGENT: only it can discover which local
@@ -40,5 +44,99 @@ func (m ChatModel) supportsModelCommand() bool {
 // refusal rather than falling through to a literal question either way.
 func isModelCommand(query string) bool {
 	trimmed := strings.TrimSpace(query)
-	return trimmed == "/model" || strings.HasPrefix(trimmed, "/model ")
+	return trimmed == modelCommandPrefix ||
+		strings.HasPrefix(trimmed, modelCommandPrefix+" ")
+}
+
+// modelCommandPrefix must match gaia_agent.stdio.MODEL_COMMAND_PREFIX — the
+// agent dispatches on the same literal.
+const modelCommandPrefix = "/model"
+
+// modelCommandArg is the id in `/model <id>`, or "" for a bare `/model`
+// (which asks the agent to LIST models rather than switch to one).
+func modelCommandArg(query string) string {
+	return strings.TrimSpace(
+		strings.TrimPrefix(strings.TrimSpace(query), modelCommandPrefix))
+}
+
+// refuseModelSwitch returns the reason `/model <id>` must not be sent to the
+// agent at all, or "" when it should be.
+//
+// This is a PRE-flight check, not a replacement for the agent's own: the
+// agent validates again (_switch_model in stdio.py) and is authoritative,
+// because only it can enumerate the local models Lemonade actually has
+// downloaded. What this catches is the two cases where a round-trip could
+// only ever end in the same refusal, and where the round-trip itself is the
+// problem — a switch turn against a wedged or Claude-only session can sit
+// there for its full timeout before saying "no".
+//
+// It never rewrites the request into one that would work. Choosing a backend
+// is the user's call; the refusal names both ways forward and stops.
+func (m ChatModel) refuseModelSwitch(arg string) string {
+	if arg == "" {
+		return "" // a bare `/model` lists; there is nothing to validate
+	}
+
+	if client.IsClaudeModelID(arg) {
+		if _, ok := client.KnownClaudeModel(arg); ok {
+			return ""
+		}
+		return "Unknown Claude model `" + arg + "`. Accepted ids: `" +
+			strings.Join(client.ClaudeModelIDs(), "`, `") + "`. " +
+			"There is no date suffix — it is `" + client.ExampleClaudeModelID + "`."
+	}
+
+	// A local id, and the last thing the agent said was that the local server
+	// is not answering. Worth saying immediately — but ONCE.
+	//
+	// lemonadeUp is a cached snapshot: it is only ever written by a model-state
+	// ping (canonical.go), which arrives at startup and after a successful
+	// switch, so nothing refreshes it when the user starts Lemonade — via
+	// /setup or in another terminal — and retries. A refusal that kept firing
+	// off that stale snapshot would be a dead end no retry could ever clear,
+	// which is the failure this whole change exists to remove. So the second
+	// attempt goes through to the agent, which probes live (_lemonade_models)
+	// and is the only authority on the answer.
+	if m.lemonadeKnown && !m.lemonadeUp && !m.lemonadeDownRefused {
+		where := m.lemonadeBaseURL
+		if where == "" {
+			where = "its configured address"
+		}
+		return "Cannot switch to local model `" + arg +
+			"`: the Lemonade server was not reachable at " + where + ". " +
+			"Start it with `lemonade-server serve`, or with /setup, and send this " +
+			"again — the retry re-checks. " + m.remoteAlternative() +
+			" Nothing was switched — this session is still on " +
+			m.currentModelName() + "."
+	}
+	return ""
+}
+
+// remoteAlternative names the other way forward, phrased for where the
+// session actually is. "Stay remote" is only true if it already is remote —
+// suggesting it to a local session both misreads the state and pushes
+// off-machine inference at someone who may have no ANTHROPIC_API_KEY.
+func (m ChatModel) remoteAlternative() string {
+	if m.claudeMode {
+		return "Or stay on Claude — this session already is."
+	}
+	return "Or move to Claude with `/model " + client.ExampleClaudeModelID +
+		"`, which sends the conversation to Anthropic and needs ANTHROPIC_API_KEY."
+}
+
+// currentModelName names the model this session is on right now, for a
+// message that has to say what did NOT change. Falls back to the launch
+// flag's model before the agent's first ping (see renderModelChip for why
+// that gap exists), and to a plain description when neither is known.
+func (m ChatModel) currentModelName() string {
+	if m.modelDisplay != "" {
+		return m.modelDisplay
+	}
+	if m.launchClaudeModel != "" {
+		return claudeLaunchName(m.launchClaudeModel)
+	}
+	if m.claudeMode {
+		return "Claude"
+	}
+	return "its current model"
 }

--- a/tui/internal/ui/chat/modelcmd_test.go
+++ b/tui/internal/ui/chat/modelcmd_test.go
@@ -94,6 +94,13 @@ func TestModelCommandDoesNotShowAsAChatBubble(t *testing.T) {
 
 // The header must name the SPECIFIC model the agent resolved — never a bare
 // backend word — and mark a remote one distinctly from a local one.
+//
+// A remote model is spelled "claude · sonnet-5", derived from the model id,
+// rather than the agent's own "Sonnet 5" label. Both name the model; the id
+// form is used because it is the ONLY form available before the agent's first
+// ping (the launch flag carries an id, not a label — see renderModelChip),
+// and a header that respelled itself the moment the first turn ran would read
+// as the model having changed when nothing did.
 func TestHeaderNamesTheSpecificModelFromTheAgent(t *testing.T) {
 	m, _ := newTestModel(t)
 
@@ -106,7 +113,7 @@ func TestHeaderNamesTheSpecificModelFromTheAgent(t *testing.T) {
 	})
 
 	header := ansi.Strip(m.renderHeader())
-	if !strings.Contains(header, "Sonnet 5") {
+	if !strings.Contains(header, "claude · sonnet-5") {
 		t.Errorf("header must name the specific model, got %q", header)
 	}
 	if strings.HasSuffix(strings.TrimSpace(header), "claude") {
@@ -150,7 +157,7 @@ func TestHeaderUpdatesAfterALiveModelSwitch(t *testing.T) {
 	})
 
 	header := ansi.Strip(m.renderHeader())
-	if !strings.Contains(header, "Opus 5") {
+	if !strings.Contains(header, "claude · opus-5") {
 		t.Errorf("header did not pick up the live switch, got %q", header)
 	}
 	if strings.Contains(header, "Gemma") {

--- a/tui/internal/ui/chat/narrate.go
+++ b/tui/internal/ui/chat/narrate.go
@@ -24,20 +24,21 @@ import (
 //   - A tool result becomes ONE indented line: outcome, size, latency. Never raw
 //     JSON — the render card in the transcript is where a full result belongs.
 const (
-	// narrationWidth is the MEASURE one work-log row is laid out to — the column
-	// the render layer wraps at, not the most text a line may carry. The log
-	// wraps rather than clips (renderActivityItem), so a line longer than this
-	// keeps its tail on a second row instead of losing it.
-	narrationWidth = 74
+	// widestLogMeasure is the widest a work-log row is ever laid out to. It
+	// is NOT the measure a row uses — that is logWidth, and it follows the
+	// real terminal. This exists because capture happens before any width is
+	// known and the user can widen the window mid-turn, so the bounds below
+	// have to assume the roomiest window they might later be rendered into.
+	widestLogMeasure = 240
 	// narrationMax bounds the whole narration string. It is a sanity bound on a
 	// runaway payload — a shell command with a page-long --jq expression — set to
 	// the rows the log will actually show, so nothing is carried that can never
 	// be rendered.
-	narrationMax = logHeadRows * narrationWidth
+	narrationMax = logHeadRows * widestLogMeasure
 	// detailMax bounds an outcome string the same way, over the rows its `└`
 	// line may wrap to. An outcome that failed carries the remedy, so it gets
 	// the same room as the call above it rather than one clipped row.
-	detailMax = logDetailRows * narrationWidth
+	detailMax = logDetailRows * widestLogMeasure
 )
 
 // shellTools name their argument better than any phrase could: for these the

--- a/tui/internal/ui/chat/narrate.go
+++ b/tui/internal/ui/chat/narrate.go
@@ -24,16 +24,22 @@ import (
 //   - A tool result becomes ONE indented line: outcome, size, latency. Never raw
 //     JSON — the render card in the transcript is where a full result belongs.
 const (
-	// widestLogMeasure is the widest a work-log row is ever laid out to. It
-	// is NOT the measure a row uses — that is logWidth, and it follows the
-	// real terminal. This exists because capture happens before any width is
-	// known and the user can widen the window mid-turn, so the bounds below
-	// have to assume the roomiest window they might later be rendered into.
-	widestLogMeasure = 240
+	// widestLogMeasure is an upper BOUND on what a work-log row could ever be
+	// laid out to — never the measure a row actually uses, which is logWidth
+	// and has no ceiling at all. It exists only because capture happens before
+	// any width is known, and the user can widen the window mid-turn, so the
+	// bounds below have to assume the roomiest window they might later be
+	// rendered into.
+	//
+	// 500 is the widest the TUI accepts anywhere (control/server.go's resize
+	// range), so deriving from it means no window this program will lay out
+	// can outrun what was captured for it.
+	widestLogMeasure = 500
 	// narrationMax bounds the whole narration string. It is a sanity bound on a
 	// runaway payload — a shell command with a page-long --jq expression — set to
-	// the rows the log will actually show, so nothing is carried that can never
-	// be rendered.
+	// the rows the log can show on the WIDEST window, so nothing is carried that
+	// no window could ever render. A narrower one shows less; it is the same
+	// string, laid out to fewer columns.
 	narrationMax = logHeadRows * widestLogMeasure
 	// detailMax bounds an outcome string the same way, over the rows its `└`
 	// line may wrap to. An outcome that failed carries the remedy, so it gets

--- a/tui/internal/ui/chat/narrate.go
+++ b/tui/internal/ui/chat/narrate.go
@@ -24,10 +24,20 @@ import (
 //   - A tool result becomes ONE indented line: outcome, size, latency. Never raw
 //     JSON — the render card in the transcript is where a full result belongs.
 const (
-	// narrationWidth caps a tool line so it never wraps out of the live region.
+	// narrationWidth is the MEASURE one work-log row is laid out to — the column
+	// the render layer wraps at, not the most text a line may carry. The log
+	// wraps rather than clips (renderActivityItem), so a line longer than this
+	// keeps its tail on a second row instead of losing it.
 	narrationWidth = 74
-	// detailWidth caps the `└` outcome line, which is subordinate to its call.
-	detailWidth = 66
+	// narrationMax bounds the whole narration string. It is a sanity bound on a
+	// runaway payload — a shell command with a page-long --jq expression — set to
+	// the rows the log will actually show, so nothing is carried that can never
+	// be rendered.
+	narrationMax = logHeadRows * narrationWidth
+	// detailMax bounds an outcome string the same way, over the rows its `└`
+	// line may wrap to. An outcome that failed carries the remedy, so it gets
+	// the same room as the call above it rather than one clipped row.
+	detailMax = logDetailRows * narrationWidth
 )
 
 // shellTools name their argument better than any phrase could: for these the
@@ -131,13 +141,13 @@ var salientArgKeys = []string{
 // inventing a description for a tool this client has never heard of.
 func toolNarration(tool string, args json.RawMessage, narration string) string {
 	if n := clean(narration); n != "" {
-		return truncateRunes(n, narrationWidth)
+		return truncateRunes(n, narrationMax)
 	}
 
 	// The command is the narration — anything wrapped round it is noise.
 	if shellTools[tool] {
 		if cmd := argValue(args, "command", "cmd"); cmd != "" {
-			return truncateRunes(cmd, narrationWidth)
+			return truncateRunes(cmd, narrationMax)
 		}
 	}
 
@@ -156,14 +166,14 @@ func toolNarration(tool string, args json.RawMessage, narration string) string {
 
 	line := phrase.Without
 	if arg != "" && phrase.With != "" {
-		line = fmt.Sprintf(phrase.With, truncateRunes(arg, 48))
+		line = fmt.Sprintf(phrase.With, truncateRunes(arg, narrationMax))
 	} else if arg != "" {
-		line = phrase.Without + ": " + truncateRunes(arg, 48)
+		line = phrase.Without + ": " + truncateRunes(arg, narrationMax)
 	}
 	if line == "" {
 		line = "Running " + tool
 	}
-	return truncateRunes(line, narrationWidth)
+	return truncateRunes(line, narrationMax)
 }
 
 // derivePhrase builds a phrase from the tool name when the table has no entry.
@@ -254,7 +264,7 @@ func markFailed(line string, failed bool) string {
 	if failed && !strings.HasPrefix(strings.ToLower(line), "failed") {
 		line = "failed — " + line
 	}
-	return truncateRunes(line, detailWidth)
+	return truncateRunes(line, detailMax)
 }
 
 // countPhrase names what came back and how much of it — "18 skills", "3 files".

--- a/tui/internal/ui/chat/narrate.go
+++ b/tui/internal/ui/chat/narrate.go
@@ -166,9 +166,14 @@ func toolNarration(tool string, args json.RawMessage, narration string) string {
 
 	line := phrase.Without
 	if arg != "" && phrase.With != "" {
-		line = fmt.Sprintf(phrase.With, truncateRunes(arg, narrationMax))
+		// Budgeted against the TEMPLATE, not against the whole line. Several
+		// phrases put words after the %s — "Looking for %s in your documents" —
+		// and an argument allowed to fill the line pushed them off the end,
+		// leaving the reader the query with no clue what was done with it.
+		room := narrationMax - displayWidth(fmt.Sprintf(phrase.With, ""))
+		line = fmt.Sprintf(phrase.With, truncateRunes(arg, room))
 	} else if arg != "" {
-		line = phrase.Without + ": " + truncateRunes(arg, narrationMax)
+		line = phrase.Without + ": " + truncateRunes(arg, narrationMax-displayWidth(phrase.Without)-2)
 	}
 	if line == "" {
 		line = "Running " + tool
@@ -230,7 +235,11 @@ func toolResultDetail(e event.CanonicalToolResultEvent) string {
 		parts = append(parts, summary)
 	}
 	if len(parts) == 0 {
-		if msg := firstLine(firstStringOf(data, "message", "error", "detail", "display_message")); msg != "" {
+		// clean, not firstLine, matching failureDetail: this is the ERROR text
+		// path, and a tool puts the remedy on its second line as often as not.
+		// `summary` above stays first-line-only — a summary that runs to several
+		// lines is a payload dump, not a sentence with a tail worth keeping.
+		if msg := firstStringOf(data, "message", "error", "detail", "display_message"); msg != "" {
 			parts = append(parts, msg)
 		}
 	}

--- a/tui/internal/ui/chat/palette.go
+++ b/tui/internal/ui/chat/palette.go
@@ -11,6 +11,7 @@ import (
 	"github.com/charmbracelet/lipgloss"
 	"github.com/charmbracelet/x/ansi"
 
+	"github.com/amd/gaia/tui/internal/client"
 	"github.com/amd/gaia/tui/internal/ui/theme"
 )
 
@@ -38,12 +39,71 @@ var paletteCommands = []paletteCommand{
 	{"/model", "Switch the model this session runs on (gaia flagship agent only)"},
 }
 
+// modelPalettePrefix is what turns the palette into the model picker: the
+// command name plus the space that starts its argument.
+//
+// `/model` takes a free-form model id, so it cannot be a flat palette row the
+// way `/bypass on` could — one row per id at the top level would bury the
+// real commands under a model list nobody was looking for. So the palette
+// gets a second level instead: `/model` stays one row, and typing the space
+// after it swaps the list for the ids. The set is closed and known at compile
+// time (client.ClaudeModels), which is exactly what makes it listable.
+//
+// Local ids are deliberately absent: only the agent knows which Lemonade
+// models are actually downloaded, and a palette that offered one the machine
+// does not have would be worse than not offering any. Bare `/model` — the
+// first row here — asks the agent for that list.
+const modelPalettePrefix = modelCommandPrefix + " "
+
+// modelPaletteCommands is the model picker's rows, built fresh per call so
+// the list can never drift from client.ClaudeModels.
+func modelPaletteCommands() []paletteCommand {
+	out := []paletteCommand{
+		{modelCommandPrefix, "List every model, including the local ones this machine has"},
+	}
+	for _, cm := range client.ClaudeModels {
+		out = append(out, paletteCommand{
+			Name: modelPalettePrefix + cm.ID,
+			// Short on purpose: the panel is capped at 60 columns and these
+			// names are the longest in it, so a longer line is a truncated
+			// line. Naming the destination is what has to survive the
+			// budget — the launch banner and the header chip already carry
+			// the longer "this conversation is sent to Anthropic".
+			Desc: cm.Label + " · Anthropic API",
+		})
+	}
+	return out
+}
+
+// filterModelCommands narrows the model picker to rows matching what has been
+// typed after `/model `. Matched by substring, not prefix: nobody types
+// "claude-" to find Haiku, they type "haiku".
+func filterModelCommands(arg string) []paletteCommand {
+	if arg == "" {
+		return modelPaletteCommands()
+	}
+	var out []paletteCommand
+	for _, c := range modelPaletteCommands() {
+		if strings.Contains(strings.ToLower(c.Name), arg) {
+			out = append(out, c)
+		}
+	}
+	return out
+}
+
 // filterPaletteCommands narrows paletteCommands to the ones whose name
 // starts with the composer's current text, case-insensitively. Recomputed
 // fresh on every keystroke rather than cached — the list is 7 entries long,
 // and caching it correctly would mean invalidating on every input change
 // anyway.
 func filterPaletteCommands(value string) []paletteCommand {
+	// The space after `/model` is the switch into the model picker, so this
+	// one case is matched BEFORE trimming — trimming would erase the very
+	// character that distinguishes "/model" (still naming a command) from
+	// "/model " (now naming its argument).
+	if arg, ok := strings.CutPrefix(strings.ToLower(value), modelPalettePrefix); ok {
+		return filterModelCommands(strings.TrimSpace(arg))
+	}
 	q := strings.ToLower(strings.TrimSpace(value))
 	var out []paletteCommand
 	for _, c := range paletteCommands {
@@ -279,8 +339,18 @@ const paletteBoxMaxWidth = 60
 
 // paletteNameColumn is how many columns a command's name gets before its
 // description starts — wide enough for the longest name ("/memory", 7
-// columns) plus a two-column gutter.
+// columns) plus paletteNameGutter.
+//
+// It is a floor, not a cap: the model picker's rows ("/model
+// claude-haiku-4-5") are more than twice this wide, and they keep the gutter
+// rather than being squeezed into the column.
 const paletteNameColumn = 9
+
+// paletteNameGutter is the blank space every row keeps between its name and
+// its description. Without it a name wider than paletteNameColumn ran
+// straight into its own description — "/model claude-opus-5Claude Opus 5 …"
+// on screen, which reads as one mangled string rather than two fields.
+const paletteNameGutter = 2
 
 // paletteBoxStyle is Padding(0, 2): the borderless box adds NO rows of its
 // own, so the fits-check budgets zero chrome. The old bordered-design values
@@ -389,7 +459,7 @@ func paletteBodyLines(query string, items []paletteCommand, selected, inner int)
 		"",
 	}
 	for i, c := range items {
-		name := c.Name
+		name := c.Name + strings.Repeat(" ", paletteNameGutter)
 		for lipgloss.Width(name) < paletteNameColumn {
 			name += " "
 		}

--- a/tui/internal/ui/chat/setup.go
+++ b/tui/internal/ui/chat/setup.go
@@ -265,12 +265,43 @@ func waitForSetupEvent(ch <-chan setupEvent) tea.Cmd {
 // does not run anything -- Init() fires the actual probe once Bubble Tea's
 // event loop is running; this only makes the composer hold Enter (and Init
 // hold the initial --query, if any) until that probe answers.
+//
+// A Claude session is never gated: `gaia init` starts LemonadeServer.exe
+// unconditionally (_auto_start_server in src/gaia/installer/init_command.py),
+// which is the one thing --use-claude exists to avoid. --skip-chat-model
+// skips the model DOWNLOAD only; nothing skipped the server.
+//
+// Skipped, not hidden -- setupSkippedForClaudeNotice says so and what it
+// costs. `/setup` still runs the real thing, because typing it IS the user
+// choosing to start the local backend.
 func (m ChatModel) applyFirstBootGate() ChatModel {
-	if m.agentID == setupAgentID {
-		m.setupChecking = true
+	if m.agentID != setupAgentID {
+		return m
 	}
+	if m.claudeMode {
+		m.messages = append(m.messages, Message{
+			Role:    RoleStatus,
+			Content: setupSkippedForClaudeNotice,
+		})
+		return m
+	}
+	m.setupChecking = true
 	return m
 }
+
+// setupSkippedForClaudeNotice says what was skipped and names the fix.
+//
+// Conditional on purpose. This is appended at construction, before anything
+// knows the local server's state, and most machines running this already have
+// Lemonade installed and up — asserting that document search is broken would
+// be wrong for them. So it states what did not run and leaves whether that
+// matters to what the user observes. Embeddings have no Anthropic equivalent,
+// so those features do need Lemonade either way (see
+// hub/agents/gaia/python/gaia_agent/stdio.py).
+const setupSkippedForClaudeNotice = "Local setup skipped — `gaia init` was not run " +
+	"and the Lemonade server was not started for this session. If document search, " +
+	"memory or the code index turn out not to work, that is why: run `gaia init " +
+	"--profile " + setupProfile + " --skip-chat-model` in a terminal, or type /setup here."
 
 // supersededSetup reports whether an event belongs to a setup run that is no
 // longer the current one.
@@ -365,6 +396,11 @@ func (m ChatModel) handleSetupEvent(evt setupEvent) (tea.Model, tea.Cmd) {
 	m.setupRunning = false
 	m.setupCancel = nil
 	m.setupCh = nil
+	// `gaia init` installs and STARTS the local server, so whatever the last
+	// ping said about it is now stale — drop it rather than let a `/model`
+	// switch be refused against a server this run just brought up.
+	m.lemonadeKnown = false
+	m.lemonadeDownRefused = false
 
 	switch {
 	case m.setupCancelRequested:

--- a/tui/internal/ui/chat/widthlayout_test.go
+++ b/tui/internal/ui/chat/widthlayout_test.go
@@ -72,18 +72,63 @@ func TestLogWidthFollowsTheTerminal(t *testing.T) {
 	}
 }
 
-// A terminal too small to lay anything out still gets a positive budget - but
-// never one that prints past its own last column. The floor exists so a
-// cramped window shows SOMETHING, not so it overflows.
-func TestLogWidthNeverOverrunsATinyTerminal(t *testing.T) {
-	for w := 8; w <= 32; w++ {
+// minSupportedCols is the narrowest window the TUI claims to work at: the
+// control API refuses a resize under it ("cols must be 20-500",
+// control/server.go). It is a real floor, not a convenience — a live row spends
+// 11 columns on decoration alone (gutter, spinner, the two-space gap and the
+// clock), so below about 13 no arrangement of text fits and the question stops
+// being about budgets.
+const minSupportedCols = 20
+
+// A cramped window must not shear. This RENDERS every row type at every width
+// in the band rather than checking logWidth's arithmetic: an earlier version of
+// this test asserted only that logWidth()+4 fits, which certified a property the
+// rendered rows did not actually have — wrapLog was raising the measure back up
+// to its own floor of 8, and the row printed past the last column anyway.
+func TestNoRowShearsOnACrampedTerminal(t *testing.T) {
+	for w := minSupportedCols; w <= 48; w++ {
+		// The opening frame of a turn: the idle live line, before any event.
+		idle := sizedChat(t, w, 10)
+		checkRowsFit(t, w, "opening frame", idle.liveRegionView())
+
+		// A turn under way: a live row with a clock, a wrapped action, an
+		// outcome, and the "still working" hint, all at once.
 		m := sizedChat(t, w, 10)
-		got := m.logWidth()
-		if got < 1 {
-			t.Errorf("logWidth() = %d on a %d-column terminal; a line would vanish", got, w)
+		m.dev = true
+		m.queryStart = time.Now().Add(-2 * stillWorkingAfter)
+		m = feed(t, m,
+			event.CanonicalToolCallEvent{
+				Type: "tool_call", Tool: "run_shell_command",
+				Args: json.RawMessage(`{"command":"` + strings.Repeat("z", 200) + `"}`),
+			},
+		)
+		checkRowsFit(t, w, "live row + hint", m.liveRegionView())
+
+		// And with the action closed, so the outcome and --dev payload rows draw.
+		m = feed(t, m, event.CanonicalToolResultEvent{
+			Type: "tool_result", Tool: "run_shell_command",
+			Preview: strings.Repeat("d", 200),
+		})
+		checkRowsFit(t, w, "closed action", m.liveRegionView())
+
+		// A repeated call stacks the "xN" counter onto whichever row is live.
+		rep := ActivityItem{Kind: "tool", Tool: "get_message", Content: strings.Repeat("m", 200), Repeat: 13}
+		for _, live := range []bool{true, false} {
+			checkRowsFit(t, w, "repeated action", strings.Join(
+				sizedChat(t, w, 10).renderActivityItem(rep, live, 3720*time.Second, 0), "\n"))
 		}
-		if got+4 > w {
-			t.Errorf("logWidth() = %d plus the 4-column gutter overruns a %d-column terminal", got, w)
+	}
+}
+
+// checkRowsFit fails if any rendered row is wider than the terminal drawing it.
+// Nothing in this viewport soft-wraps, so an over-wide row takes the row below
+// it with it.
+func checkRowsFit(t *testing.T, width int, what, rendered string) {
+	t.Helper()
+	for _, line := range strings.Split(ansi.Strip(rendered), "\n") {
+		if got := ansi.StringWidth(line); got > width {
+			t.Errorf("%s: a row is %d columns wide on a %d-column terminal: %q",
+				what, got, width, line)
 		}
 	}
 }
@@ -159,7 +204,7 @@ func TestTheLiveLineLeavesRoomForItsClock(t *testing.T) {
 			m := sizedChat(t, tc.width, tc.height)
 			item := ActivityItem{Kind: "tool", Tool: "run_shell_command", Content: strings.Repeat("z", 500)}
 			for _, elapsed := range []time.Duration{9 * time.Second, 125 * time.Second, 3720 * time.Second} {
-				for _, line := range m.renderActivityItem(item, true, elapsed) {
+				for _, line := range m.renderActivityItem(item, true, elapsed, 0) {
 					if w := ansi.StringWidth(ansi.Strip(line)); w > tc.width {
 						t.Errorf("the live line is %d columns wide at %s on a %d-column terminal",
 							w, formatElapsed(elapsed), tc.width)
@@ -177,7 +222,7 @@ func TestAWiderTerminalShowsMoreOnOneRow(t *testing.T) {
 	item := ActivityItem{Kind: "tool", Tool: "run_shell_command", Content: longNarration}
 	rendered := func(w int) []string {
 		m := sizedChat(t, w, 40)
-		return m.renderActivityItem(item, false, 0)
+		return m.renderActivityItem(item, false, 0, 0)
 	}
 
 	narrow, wide := rendered(80), rendered(240)
@@ -283,12 +328,119 @@ func TestAReservedCounterAndClockStack(t *testing.T) {
 				Content: strings.Repeat("m", 400),
 				Repeat:  13,
 			}
-			for _, line := range m.renderActivityItem(item, true, 3720*time.Second) {
+			for _, line := range m.renderActivityItem(item, true, 3720*time.Second, 0) {
 				if w := ansi.StringWidth(ansi.Strip(line)); w > tc.width {
 					t.Errorf("a repeated live row is %d columns wide on a %d-column terminal: %q",
 						w, tc.width, ansi.Strip(line))
 				}
 			}
 		})
+	}
+}
+
+// A resize reflows the work log, which before this change it could not: the
+// measure was pinned at 74, so widening from 100 to 240 columns moved nothing.
+// Now it moves 94 to 234 — straight into the peak-height hold, which is there to
+// absorb the log shrinking under a reader mid-sentence. A deliberate resize is
+// not that, and holding the old peak stranded blank rows under the log for the
+// rest of the turn.
+func TestResizingMidTurnStrandsNoBlankRows(t *testing.T) {
+	m := sizedChat(t, 100, 44)
+	m.queryStart = time.Now().Add(-95 * time.Second)
+	args, _ := json.Marshal(map[string]string{"command": longNarration})
+	m = feed(t, m,
+		event.CanonicalToolCallEvent{Type: "tool_call", Tool: "run_shell_command", Args: args},
+		event.CanonicalToolResultEvent{
+			Type: "tool_result", Tool: "run_shell_command",
+			Preview: "failed - permission denied; run gaia from a shell with write access to that folder",
+		},
+		event.CanonicalToolCallEvent{
+			Type: "tool_call", Tool: "query_documents",
+			Args: json.RawMessage(`{"query":"what did the Q3 board deck say about NPU attach rate targets"}`),
+		},
+	)
+
+	// Widen, narrow, widen again — a window drag, not a tidy single step.
+	for _, w := range []int{100, 240, 60, 240, 100} {
+		m.width = w
+		m.resize()
+		rows := strings.Split(ansi.Strip(m.liveRegionView()), "\n")
+		for i, r := range rows {
+			if strings.TrimSpace(r) == "" {
+				t.Errorf("at %d columns row %d of the live region is blank padding held over from another width:\n%s",
+					w, i, strings.Join(rows, "\n"))
+				break
+			}
+			if got := ansi.StringWidth(r); got > w {
+				t.Errorf("at %d columns a row is %d columns wide: %q", w, got, r)
+			}
+		}
+	}
+}
+
+// The hold itself must survive: it exists for the log growing and shrinking as
+// EVENTS land, which is the case that yanks the transcript under a reader. Only
+// the width case is released.
+func TestTheHeightHoldStillAbsorbsEventChurn(t *testing.T) {
+	m := sizedChat(t, 100, 44)
+	m = feed(t, m,
+		event.CanonicalToolCallEvent{Type: "tool_call", Tool: "read_file",
+			Args: json.RawMessage(`{"file_path":"` + strings.Repeat("some/long/path/", 12) + `x.go"}`)},
+		event.CanonicalToolResultEvent{Type: "tool_result", Tool: "read_file", Preview: "ok"},
+	)
+	tall := strings.Count(m.liveRegionView(), "\n") + 1
+
+	// A cancel is the one thing allowed to drop the height, so use ordinary new
+	// work: the region must not get SHORTER than it has already been.
+	m = feed(t, m, event.CanonicalStatusEvent{Type: "status", Message: "Thinking"})
+	if got := strings.Count(m.liveRegionView(), "\n") + 1; got < tall {
+		t.Errorf("the live region shrank from %d rows to %d while the turn was still running", tall, got)
+	}
+}
+
+// resize() also runs when the COMPOSER grows a row, with the width unchanged.
+// Releasing the height hold on every resize() rather than on a width change
+// would let typing a multi-line follow-up collapse the log under the answer
+// being read - the exact yank the hold exists to prevent.
+func TestGrowingTheComposerDoesNotReleaseTheHold(t *testing.T) {
+	m := sizedChat(t, 100, 44)
+	m = feed(t, m,
+		event.CanonicalToolCallEvent{Type: "tool_call", Tool: "read_file",
+			Args: json.RawMessage(`{"file_path":"` + strings.Repeat("some/long/path/", 12) + `x.go"}`)},
+		event.CanonicalToolResultEvent{Type: "tool_result", Tool: "read_file", Preview: "ok"},
+	)
+	m.liveRegionView()
+	peak := m.logPeakRows
+	if peak == 0 {
+		t.Fatal("no peak was recorded, so this proves nothing")
+	}
+
+	m.resize() // same width: a composer-height change, not a window resize
+	if m.logPeakRows != peak {
+		t.Errorf("a same-width resize dropped the held height from %d to %d", peak, m.logPeakRows)
+	}
+}
+
+// The capture bound has to outrun the widest window this program will ever lay
+// out, or a wide terminal re-clips text that capture already cut - which is the
+// original bug, one layer up. 500 columns is the ceiling the control API's
+// resize accepts, so that is the window to prove against.
+func TestCaptureCoversTheWidestWindowTheTUIAccepts(t *testing.T) {
+	const maxAcceptedCols = 500 // control/server.go: "cols must be 20-500"
+
+	if got := sizedChat(t, maxAcceptedCols, 60).logWidth(); got > widestLogMeasure {
+		t.Errorf("the widest accepted terminal lays rows out to %d columns, past the %d capture assumes",
+			got, widestLogMeasure)
+	}
+	// And an action's whole wrapped body fits inside what capture kept.
+	if rowsWorth := logHeadRows * widestLogMeasure; narrationMax < rowsWorth {
+		t.Errorf("narrationMax %d cannot fill the %d rows the log will render", narrationMax, logHeadRows)
+	}
+	if rowsWorth := logDetailRows * widestLogMeasure; detailMax < rowsWorth {
+		t.Errorf("detailMax %d cannot fill the %d rows an outcome will render", detailMax, logDetailRows)
+	}
+	if devPayloadWidth < widestLogMeasure {
+		t.Errorf("a --dev payload is captured at %d columns but one row can show %d",
+			devPayloadWidth, widestLogMeasure)
 	}
 }

--- a/tui/internal/ui/chat/widthlayout_test.go
+++ b/tui/internal/ui/chat/widthlayout_test.go
@@ -1,0 +1,294 @@
+// Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+package chat
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/charmbracelet/x/ansi"
+
+	"github.com/amd/gaia/tui/internal/event"
+)
+
+// terminalSizes spans the range a user actually runs the TUI at: a laptop
+// half-screen, the classic 80, a maximised window, and an ultrawide.
+var terminalSizes = []struct {
+	name          string
+	width, height int
+}{
+	{"cramped", 24, 10},
+	{"tiny", 40, 12},
+	{"narrow", 60, 20},
+	{"classic", 80, 24},
+	{"wide", 120, 40},
+	{"wider", 160, 45},
+	{"ultrawide", 240, 55},
+}
+
+func sizedChat(t *testing.T, w, h int) ChatModel {
+	t.Helper()
+	m := NewChatModel(&nullClient{}, "gaia", "", false)
+	m.width, m.height = w, h
+	m.resize()
+	m.streaming = true
+	m.queryStart = time.Now()
+	return m
+}
+
+// The report this came from: on a wide terminal the work log still cut lines at
+// the same column an 80-column terminal did, so the window's extra space bought
+// the reader nothing.
+func TestLogWidthFollowsTheTerminal(t *testing.T) {
+	for _, tc := range terminalSizes {
+		t.Run(tc.name, func(t *testing.T) {
+			m := sizedChat(t, tc.width, tc.height)
+			got := m.logWidth()
+			want := tc.width - 6
+			if want < 16 {
+				want = 16
+			}
+			// The floor never wins past what the row can actually hold: the
+			// 4-column marker gutter comes off the terminal either way.
+			if fits := tc.width - 4; want > fits {
+				want = fits
+			}
+			if got != want {
+				t.Errorf("logWidth() = %d on a %d-column terminal, want %d", got, tc.width, want)
+			}
+		})
+	}
+
+	// The point of the change, stated as a comparison: more columns must mean
+	// more room, not the same fixed cap twice.
+	narrow := sizedChat(t, 80, 24).logWidth()
+	wide := sizedChat(t, 240, 55).logWidth()
+	if wide <= narrow {
+		t.Errorf("a 240-column terminal budgets %d columns per log line, no more than an 80-column one at %d",
+			wide, narrow)
+	}
+}
+
+// A terminal too small to lay anything out still gets a positive budget - but
+// never one that prints past its own last column. The floor exists so a
+// cramped window shows SOMETHING, not so it overflows.
+func TestLogWidthNeverOverrunsATinyTerminal(t *testing.T) {
+	for w := 8; w <= 32; w++ {
+		m := sizedChat(t, w, 10)
+		got := m.logWidth()
+		if got < 1 {
+			t.Errorf("logWidth() = %d on a %d-column terminal; a line would vanish", got, w)
+		}
+		if got+4 > w {
+			t.Errorf("logWidth() = %d plus the 4-column gutter overruns a %d-column terminal", got, w)
+		}
+	}
+}
+
+// Prose deliberately does NOT follow the window: a 240-column terminal running
+// body text to 236 columns loses the eye on the carriage return, and a question
+// wrapped to the pane above an answer capped at 88 reads as two unrelated
+// blocks.
+func TestProseKeepsItsReadableMeasureAtEverySize(t *testing.T) {
+	for _, tc := range terminalSizes {
+		t.Run(tc.name, func(t *testing.T) {
+			m := sizedChat(t, tc.width, tc.height)
+			if w := m.answerWidth(); w > answerMeasure {
+				t.Errorf("answers lay out at %d columns on a %d-column terminal; the cap is %d",
+					w, tc.width, answerMeasure)
+			}
+			if w := m.answerWidth(); w > tc.width {
+				t.Errorf("answer width %d overruns the %d-column terminal", w, tc.width)
+			}
+		})
+	}
+}
+
+// longNarration is one tool line whose tail carries the part that matters — the
+// shape of every line this change exists for.
+const longNarration = "gh issue list --repo amd/gaia --state open --label bug " +
+	"--json number,title,labels,updatedAt --jq select(updatedAt < 2026-01-01)"
+
+// Every rendered work-log row must fit the window it is drawn in. Nothing here
+// soft-wraps, so a row one column too wide shears the row beneath it.
+func TestWorkLogRowsFitTheTerminal(t *testing.T) {
+	for _, tc := range terminalSizes {
+		t.Run(tc.name, func(t *testing.T) {
+			m := sizedChat(t, tc.width, tc.height)
+			m.dev = true
+			m = feed(t, m,
+				event.CanonicalToolCallEvent{
+					Type:      "tool_call",
+					Tool:      "run_shell_command",
+					Args:      json.RawMessage(`{"command":"` + strings.Repeat("x", 400) + `"}`),
+					Narration: longNarration,
+				},
+				event.CanonicalToolResultEvent{
+					Type:    "tool_result",
+					Tool:    "run_shell_command",
+					Preview: strings.Repeat("outcome text that keeps going ", 20),
+				},
+				event.CanonicalToolCallEvent{
+					Type: "tool_call",
+					Tool: "query_documents",
+					Args: json.RawMessage(`{"query":"` + strings.Repeat("q", 300) + `"}`),
+				},
+			)
+
+			out := ansi.Strip(m.renderLiveRegion())
+			for _, line := range strings.Split(out, "\n") {
+				if w := ansi.StringWidth(line); w > tc.width {
+					t.Errorf("a work-log row is %d columns wide on a %d-column terminal: %q",
+						w, tc.width, line)
+				}
+			}
+		})
+	}
+}
+
+// The live line hangs a clock off its right edge. That clock is appended after
+// the text is truncated, so it has to come out of the same budget — otherwise
+// it is the one row that always overruns, on exactly the wide terminals this
+// change opens up.
+func TestTheLiveLineLeavesRoomForItsClock(t *testing.T) {
+	for _, tc := range terminalSizes {
+		t.Run(tc.name, func(t *testing.T) {
+			m := sizedChat(t, tc.width, tc.height)
+			item := ActivityItem{Kind: "tool", Tool: "run_shell_command", Content: strings.Repeat("z", 500)}
+			for _, elapsed := range []time.Duration{9 * time.Second, 125 * time.Second, 3720 * time.Second} {
+				for _, line := range m.renderActivityItem(item, true, elapsed) {
+					if w := ansi.StringWidth(ansi.Strip(line)); w > tc.width {
+						t.Errorf("the live line is %d columns wide at %s on a %d-column terminal",
+							w, formatElapsed(elapsed), tc.width)
+					}
+				}
+			}
+		})
+	}
+}
+
+// A wider terminal has to actually SHOW more. Wrapping already saved the tail
+// from being lost; a wider window is what stops it needing a second row at all,
+// which is the difference between reading one line and reading a paragraph.
+func TestAWiderTerminalShowsMoreOnOneRow(t *testing.T) {
+	item := ActivityItem{Kind: "tool", Tool: "run_shell_command", Content: longNarration}
+	rendered := func(w int) []string {
+		m := sizedChat(t, w, 40)
+		return m.renderActivityItem(item, false, 0)
+	}
+
+	narrow, wide := rendered(80), rendered(240)
+	if ansi.StringWidth(ansi.Strip(wide[0])) <= ansi.StringWidth(ansi.Strip(narrow[0])) {
+		t.Fatalf("a 240-column terminal drew the same %d columns on its first row an 80-column one did",
+			ansi.StringWidth(ansi.Strip(wide[0])))
+	}
+	// With room for the whole command, it is one row and the tail is on it.
+	if len(wide) != 1 {
+		t.Errorf("a 240-column terminal spent %d rows on a line that fits in one", len(wide))
+	}
+	if !strings.Contains(ansi.Strip(wide[0]), "2026-01-01") {
+		t.Errorf("the tail of the command is missing on a 240-column terminal: %q", ansi.Strip(wide[0]))
+	}
+	// The same line does not fit an 80-column window, so it costs a second row
+	// there — which is exactly the cost a wide window buys back.
+	if len(narrow) < 2 {
+		t.Errorf("an 80-column terminal fitted a %d-column line on one row", displayWidth(longNarration))
+	}
+}
+
+// Capture must not pre-empt layout. Cutting the narration when the event
+// arrived froze every line at 74 columns no matter how wide the window later
+// turned out to be — the bug underneath all of the above.
+func TestCaptureKeepsMoreThanOneScreensWorth(t *testing.T) {
+	long := strings.Repeat("a", 300)
+	if got := toolNarration("run_shell_command", json.RawMessage(`{"command":"`+long+`"}`), ""); displayWidth(got) <= 74 {
+		t.Errorf("a shell command was captured at %d columns; layout can never widen it", displayWidth(got))
+	}
+	if got := toolNarration("some_tool", nil, long); displayWidth(got) <= 74 {
+		t.Errorf("agent narration was captured at %d columns", displayWidth(got))
+	}
+	// Bounded, though: the model must not hold an unbounded blob off the wire.
+	huge := strings.Repeat("b", 100000)
+	if got := toolNarration("some_tool", nil, huge); displayWidth(got) > narrationMax {
+		t.Errorf("narration captured at %d columns, past the %d bound", displayWidth(got), narrationMax)
+	}
+	detail := toolResultDetail(event.CanonicalToolResultEvent{
+		Type: "tool_result", Tool: "t", Preview: huge,
+	})
+	if displayWidth(detail) > detailMax {
+		t.Errorf("an outcome line captured at %d columns, past the %d bound", displayWidth(detail), detailMax)
+	}
+}
+
+// A resize storm — dragging a window edge emits one WindowSizeMsg per frame —
+// must not churn the markdown renderer, which SetWordWrap rebuilds on every
+// width CHANGE. It cannot: the answer measure is capped, so every width past
+// the cap asks for the same wrap and SetWordWrap short-circuits.
+func TestResizingWideDoesNotChurnTheMarkdownWrap(t *testing.T) {
+	m := sizedChat(t, 120, 40)
+	first := m.answerWidth()
+	for w := 121; w <= 240; w++ {
+		m.width = w
+		m.resize()
+		if got := m.answerWidth(); got != first {
+			t.Fatalf("answer width changed from %d to %d at %d columns; the wrap is capped and should be stable",
+				first, got, w)
+		}
+	}
+}
+
+// The "still working" hint is part of the live region's height budget, which
+// spends exactly one row on it. At 50 fixed columns it wrapped to two on a
+// narrow terminal, so the region overran the budget that had already been
+// decremented for it.
+func TestTheStillWorkingHintFitsAndStaysOneRow(t *testing.T) {
+	for _, tc := range terminalSizes {
+		t.Run(tc.name, func(t *testing.T) {
+			m := sizedChat(t, tc.width, tc.height)
+			// No completed work and past the threshold: exactly the state the
+			// hint exists for.
+			m.queryStart = time.Now().Add(-2 * stillWorkingAfter)
+			m = feed(t, m, event.CanonicalStatusEvent{Type: "status", Message: "Working out how to answer"})
+
+			out := ansi.Strip(m.renderLiveRegion())
+			if !strings.Contains(out, "still working") {
+				t.Fatalf("the hint did not render at all:\n%s", out)
+			}
+			for _, line := range strings.Split(out, "\n") {
+				if w := ansi.StringWidth(line); w > tc.width {
+					t.Errorf("a live-region row is %d columns wide on a %d-column terminal: %q",
+						w, tc.width, line)
+				}
+			}
+			if rows := len(strings.Split(out, "\n")); rows > m.logRows() {
+				t.Errorf("the live region is %d rows on a %d-row terminal; the budget is %d",
+					rows, tc.height, m.logRows())
+			}
+		})
+	}
+}
+
+// Two reservations on one row: a repeated call's "x14" counter AND the live
+// clock. Each is subtracted before truncating; together they still have to
+// leave the row inside the window.
+func TestAReservedCounterAndClockStack(t *testing.T) {
+	for _, tc := range terminalSizes {
+		t.Run(tc.name, func(t *testing.T) {
+			m := sizedChat(t, tc.width, tc.height)
+			item := ActivityItem{
+				Kind: "tool", Tool: "get_message",
+				Content: strings.Repeat("m", 400),
+				Repeat:  13,
+			}
+			for _, line := range m.renderActivityItem(item, true, 3720*time.Second) {
+				if w := ansi.StringWidth(ansi.Strip(line)); w > tc.width {
+					t.Errorf("a repeated live row is %d columns wide on a %d-column terminal: %q",
+						w, tc.width, ansi.Strip(line))
+				}
+			}
+		})
+	}
+}

--- a/tui/internal/ui/chat/worklogwrap_test.go
+++ b/tui/internal/ui/chat/worklogwrap_test.go
@@ -1,0 +1,396 @@
+// Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+package chat
+
+import (
+	"encoding/json"
+	"regexp"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/charmbracelet/x/ansi"
+
+	"github.com/amd/gaia/tui/internal/event"
+)
+
+// A turn runs 25-160s and the work log is most of what a user looks at while it
+// does. Every line in it was CLIPPED to the pane measure, so the tail of a long
+// tool line — the flag that says what the command actually did, the sentence
+// that says how to fix a failure — was simply gone. These tests hold the fix:
+// the log wraps, and it does so without growing taller than the terminal it is
+// drawn on.
+
+// term is one terminal geometry a user actually runs the TUI at.
+type term struct {
+	name          string
+	width, height int
+}
+
+var terms = []term{
+	{"tiny", 60, 12},
+	{"standard", 80, 24},
+	{"tall", 100, 40},
+	{"wide", 200, 50},
+}
+
+// chatAt builds a streaming chat model at one geometry.
+func chatAt(t *testing.T, tm term) ChatModel {
+	t.Helper()
+	m := NewChatModel(&nullClient{}, "gaia", "", false)
+	m.width, m.height = tm.width, tm.height
+	m.resize()
+	m.streaming = true
+	m.queryStart = time.Now()
+	return m
+}
+
+// longShell is the case that motivated this: one command whose jq expression
+// runs past any terminal's width.
+const longShell = "gh issue list --repo amd/gaia --state open --limit 50 --json number,title,labels --jq 'map(select(.labels)) | length'"
+
+// longURL is the same problem with no spaces to break on at all.
+const longURL = "https://github.com/amd/gaia/blob/main/tui/internal/ui/chat/model.go#L2033-renderLiveRegion-and-the-work-log-height-budget"
+
+func shellCall(cmd string) event.CanonicalToolCallEvent {
+	args, _ := json.Marshal(map[string]string{"command": cmd})
+	return event.CanonicalToolCallEvent{Type: "tool_call", Tool: "run_shell_command", Args: args}
+}
+
+// rowsOf strips styling and returns the region as rows, the way a terminal
+// shows it.
+func rowsOf(s string) []string { return strings.Split(ansi.Strip(s), "\n") }
+
+// liveClock matches the elapsed timer the live row carries. Stripped before a
+// content assertion: it rides at the END of the first row, so a naive join drops
+// "0:04" into the middle of the sentence under test.
+var liveClock = regexp.MustCompile(` +\d+:\d{2}$`)
+
+// despace compares text by its characters alone, so a row break inside an
+// unbroken token does not read as a missing character.
+func despace(s string) string { return strings.ReplaceAll(s, " ", "") }
+
+// flat joins the rows back into the one sentence they read as, so a test can
+// ask whether text SURVIVED without caring where it broke.
+func flat(rows []string) string {
+	var parts []string
+	for _, r := range rows {
+		parts = append(parts, strings.TrimSpace(liveClock.ReplaceAllString(r, "")))
+	}
+	return strings.TrimSpace(strings.Join(parts, " "))
+}
+
+// The tail is the point. A clipped shell command loses the flags that say what
+// it did; a clipped failure loses the remedy.
+func TestWorkLogWrapsRatherThanClipping(t *testing.T) {
+	cases := []struct {
+		name string
+		feed []interface{}
+		want string
+	}{
+		{
+			name: "shell command keeps its flags",
+			feed: []interface{}{shellCall(longShell)},
+			want: longShell,
+		},
+		{
+			name: "a failure keeps its remedy",
+			feed: []interface{}{
+				event.CanonicalToolCallEvent{Type: "tool_call", Tool: "write_file"},
+				event.CanonicalToolResultEvent{
+					Type: "tool_result", Tool: "write_file",
+					Preview: "failed - permission denied; run gaia from a shell with write access to that folder",
+				},
+			},
+			want: "run gaia from a shell with write access to that folder",
+		},
+		{
+			// The shape components.WrapText cannot break: one token with no
+			// spaces in it. A URL and a Windows path are the lines most likely
+			// to run long, and they wrap nowhere on their own.
+			name: "an unbroken token is broken by force",
+			feed: []interface{}{
+				event.CanonicalToolCallEvent{
+					Type: "tool_call", Tool: "fetch_page",
+					Args: []byte(`{"url":"` + longURL + `"}`),
+				},
+			},
+			want: longURL,
+		},
+		{
+			// The typed-error path (failureDetail), which composes its own line
+			// rather than taking the sidecar's preview. It was clipped at 66
+			// columns — the narrowest cut in the whole log, on the one line a
+			// user has to act on.
+			name: "a typed tool error keeps its remedy",
+			feed: []interface{}{
+				event.CanonicalToolCallEvent{Type: "tool_call", Tool: "list_inbox"},
+				event.CanonicalToolResultEvent{
+					// Render is what puts this on the typed-error path
+					// (canonical.go gates the classifier on a declared card).
+					Type: "tool_result", Tool: "list_inbox", Render: "email_pre_scan",
+					Data: []byte(`{"success":false,"error":{"code":"CONNECTOR_ERROR","message":"the Google connector is not authorised for this mailbox; run gaia connectors login google and try again"}}`),
+				},
+			},
+			want: "run gaia connectors login google and try again",
+		},
+		{
+			// The legacy dialect composes its own line ("tool: arg") at capture
+			// time and used to cut the argument at 60 columns, before the
+			// renderer ever saw it. Both transports feed the same log, so both
+			// have to survive the same wrap.
+			name: "the legacy transport keeps its argument",
+			feed: []interface{}{
+				event.ToolStartEvent{Tool: "run_shell_command"},
+				event.ToolArgsEvent{Args: []byte(`{"command":"` + longShell + `"}`)},
+			},
+			want: longShell,
+		},
+	}
+
+	// From "standard" up. A 60x12 terminal has two rows for the whole region and
+	// genuinely cannot show a wrapped command; that case is its own test
+	// (TestWorkLogNeverRendersEmpty — it must MARK the cut, not hide it).
+	for _, tc := range cases {
+		for _, tm := range terms[1:] {
+			t.Run(tc.name+"/"+tm.name, func(t *testing.T) {
+				m := feed(t, chatAt(t, tm), tc.feed...)
+				rows := rowsOf(m.renderLiveRegion())
+				t.Logf("\n%s", strings.Join(rows, "\n"))
+
+				// Compared without spaces: a token with no break in it is
+				// hard-broken across rows, so the characters survive in order
+				// but a space lands where the row ended. That is the wrap
+				// working, not text being lost.
+				got := flat(rows)
+				if !strings.Contains(despace(got), despace(tc.want)) {
+					t.Errorf("the log lost the tail that carries the point.\nwant: %s\ngot:  %s", tc.want, got)
+				}
+			})
+		}
+	}
+}
+
+// Wrapping multiplies rows per action, so the height budget matters MORE, not
+// less: a log that grows without bound shoves the answer being read off the top.
+func TestWorkLogStaysWithinItsHeightBudget(t *testing.T) {
+	for _, tm := range terms {
+		t.Run(tm.name, func(t *testing.T) {
+			m := chatAt(t, tm)
+			// Every action long enough to wrap, so the budget is under real
+			// pressure rather than nominal.
+			for i := 0; i < 8; i++ {
+				m = feed(t, m,
+					// Alternating: prose that WrapText can break, and a token
+					// it cannot. The width assertion below only bites on the
+					// second kind.
+					shellCall(longShell+" "+longURL),
+					event.CanonicalToolResultEvent{
+						Type: "tool_result", Tool: "run_shell_command",
+						Preview: "failed - the remote closed the connection after 30s; check the network and retry",
+					},
+				)
+			}
+			rows := rowsOf(m.renderLiveRegion())
+			t.Logf("\n%s", strings.Join(rows, "\n"))
+
+			if n, budget := len(rows), m.logRows(); n > budget {
+				t.Errorf("live region is %d rows on a %dx%d terminal; budget is %d", n, tm.width, tm.height, budget)
+			}
+			if n, half := len(rows), m.viewport.Height/2; half > 0 && n > half {
+				t.Errorf("live region takes %d of the viewport's %d rows — it is crowding out the transcript", n, m.viewport.Height)
+			}
+			for _, r := range rows {
+				if w := ansi.StringWidth(r); w > tm.width {
+					t.Errorf("row is %d columns on a %d-column terminal (the viewport clips it): %q", w, tm.width, r)
+				}
+			}
+		})
+	}
+}
+
+// On a 12-row terminal the budget is two rows and one wrapped command is three.
+// Trimming the newest action away leaves an EMPTY region — a blank screen, the
+// one thing this region exists to prevent.
+func TestWorkLogNeverRendersEmpty(t *testing.T) {
+	m := feed(t, chatAt(t, term{"tiny", 60, 12}), shellCall(strings.Repeat("gaia --flag ", 40)))
+	rows := rowsOf(m.renderLiveRegion())
+	t.Logf("\n%s", strings.Join(rows, "\n"))
+
+	if flat(rows) == "" {
+		t.Fatal("the live region rendered nothing at all")
+	}
+	if !strings.Contains(flat(rows), "gaia --flag") {
+		t.Errorf("the running action is not on screen:\n%s", strings.Join(rows, "\n"))
+	}
+	if !strings.Contains(flat(rows), "…") {
+		t.Errorf("the action was cut to fit with nothing saying so:\n%s", strings.Join(rows, "\n"))
+	}
+}
+
+// One action must not spend the whole region on itself: the log's job is to
+// show a SEQUENCE of work, and a 900-character command that fills the window
+// hides everything else the agent did.
+func TestOneLongActionCannotFillTheRegion(t *testing.T) {
+	m := chatAt(t, term{"standard", 80, 24})
+	m = feed(t, m,
+		event.CanonicalToolCallEvent{Type: "tool_call", Tool: "list_skills"},
+		event.CanonicalToolResultEvent{Type: "tool_result", Tool: "list_skills", Preview: "18 skills"},
+		shellCall(strings.Repeat("gaia --flag ", 80)),
+	)
+	rows := rowsOf(m.renderLiveRegion())
+	t.Logf("\n%s", strings.Join(rows, "\n"))
+
+	// The long action wrapped rather than being clipped to one row — the
+	// property under test, and the half of it that fails against the old
+	// truncating renderer.
+	wrapped := 0
+	for _, r := range rows {
+		if strings.Contains(r, "gaia --flag") {
+			wrapped++
+		}
+	}
+	if wrapped != logHeadRows {
+		t.Errorf("the long command occupies %d rows; it should wrap to exactly the %d-row cap", wrapped, logHeadRows)
+	}
+	if n := len(rows); n > m.logRows() {
+		t.Errorf("one action pushed the region to %d rows, past its %d-row budget", n, m.logRows())
+	}
+	if !strings.Contains(flat(rows), "Checking your installed skills") {
+		t.Errorf("the long command pushed the earlier action out of a region that had room:\n%s", strings.Join(rows, "\n"))
+	}
+}
+
+// The repeat counter is what turns twenty flickering lines into "this is
+// happening over and over" — and the calls that repeat are the long ones.
+func TestRepeatCounterSurvivesWrapping(t *testing.T) {
+	m := chatAt(t, term{"standard", 80, 24})
+	for i := 0; i < 13; i++ {
+		m = feed(t, m, shellCall(longShell))
+	}
+	got := flat(rowsOf(m.renderLiveRegion()))
+	if !strings.Contains(got, "x13") {
+		t.Errorf("the repeat count was lost in the wrap: %s", got)
+	}
+	// Both, or the counter is being bought with the command it counts —
+	// which is what the old renderer did, reserving the suffix by cutting
+	// the text.
+	if !strings.Contains(despace(got), despace(longShell)) {
+		t.Errorf("the counter survived but the command it counts did not: %s", got)
+	}
+}
+
+// Wrapping mid-stream must not yank the pane. The region growing is fine — it
+// happens at the bottom, where the eye already is. Shrinking is not: it drops
+// the transcript above back down mid-sentence.
+func TestWorkLogHeightNeverShrinksMidTurn(t *testing.T) {
+	m := chatAt(t, term{"standard", 80, 24})
+	peak := 0
+	for i := 0; i < 10; i++ {
+		m = feed(t, m,
+			shellCall(longShell+strings.Repeat(" --x", i)),
+			event.CanonicalToolResultEvent{
+				Type: "tool_result", Tool: "run_shell_command",
+				Preview: "failed - the remote closed the connection after 30s; check the network and retry",
+			},
+		)
+		n := len(rowsOf(m.liveRegionView()))
+		if n < peak {
+			t.Fatalf("the work log shrank from %d rows to %d mid-turn — the transcript above it just jumped", peak, n)
+		}
+		if budget := m.logRows(); n > budget {
+			t.Fatalf("holding the height pushed the region to %d rows, past its %d-row budget", n, budget)
+		}
+		peak = n
+	}
+
+	// A new turn starts from nothing: carrying the last turn's height over
+	// would open with a block of blank rows.
+	next, _ := m.startTurn("what changed?")
+	fresh := next.(ChatModel)
+	if got := len(rowsOf(fresh.liveRegionView())); got > 2 {
+		t.Errorf("a new turn opened %d rows tall; the previous turn's height leaked into it", got)
+	}
+}
+
+// The wrap itself, at the sizes and shapes its callers hand it.
+func TestWrapLog(t *testing.T) {
+	cases := []struct {
+		name          string
+		text, suffix  string
+		width, maxRow int
+		wantRows      int
+		wantContains  []string
+		wantCut       bool
+	}{
+		{
+			name: "short text is one row, untouched",
+			text: "Checking your installed skills", width: 74, maxRow: 3,
+			wantRows: 1, wantContains: []string{"Checking your installed skills"},
+		},
+		{
+			name: "long text wraps instead of losing its tail",
+			text: longShell, width: 74, maxRow: 3,
+			wantRows: 2, wantContains: []string{"gh issue list", "length'"},
+		},
+		{
+			name: "past the row cap it is cut, and says so",
+			text: strings.Repeat("word ", 200), width: 40, maxRow: 2,
+			wantRows: 2, wantCut: true,
+		},
+		{
+			name: "the repeat counter survives the cut",
+			text: strings.Repeat("word ", 200), suffix: " x14", width: 40, maxRow: 2,
+			wantRows: 2, wantContains: []string{"x14"}, wantCut: true,
+		},
+		{
+			// The cut row lands EXACTLY on the measure, which is the common
+			// case (WrapText fills rows to the limit), not a boundary one.
+			name: "an exactly-full cut row still says it was cut",
+			text: strings.Repeat("word ", 200), width: 39, maxRow: 2,
+			wantRows: 2, wantCut: true,
+		},
+		{
+			// WrapText breaks on spaces and this has none, so without a hard
+			// break the row runs past the pane and the viewport eats the tail.
+			name: "one unbroken token is broken by force",
+			text: longURL, width: 40, maxRow: 4,
+			wantRows: 4, wantContains: []string{"https://github.com"},
+		},
+		{
+			name: "a nonsense width still yields a row",
+			text: "something happened", width: 0, maxRow: 0,
+			wantRows: 1,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			rows := wrapLog(tc.text, tc.suffix, tc.width, tc.maxRow)
+			if len(rows) != tc.wantRows {
+				t.Errorf("got %d rows, want %d: %q", len(rows), tc.wantRows, rows)
+			}
+			joined := strings.Join(rows, " ")
+			for _, want := range tc.wantContains {
+				if !strings.Contains(joined, want) {
+					t.Errorf("wrapped text lost %q: %q", want, joined)
+				}
+			}
+			if tc.wantCut {
+				last := strings.TrimSpace(rows[len(rows)-1])
+				if !strings.HasSuffix(last, strings.TrimSpace(tc.suffix)) {
+					t.Errorf("the repeat counter is not at the end of the cut row: %q", last)
+				}
+				if !strings.Contains(joined, "…") {
+					t.Errorf("a cut with nothing on screen to say it was cut: %q", joined)
+				}
+			}
+			for _, r := range rows {
+				if w := ansi.StringWidth(r); tc.width > 0 && w > tc.width {
+					t.Errorf("row is %d columns, measure is %d: %q", w, tc.width, r)
+				}
+			}
+		})
+	}
+}

--- a/tui/internal/ui/chat/worklogwrap_test.go
+++ b/tui/internal/ui/chat/worklogwrap_test.go
@@ -394,3 +394,89 @@ func TestWrapLog(t *testing.T) {
 		})
 	}
 }
+
+// The cut marker has to land in the TEXT. Appended to the rendered row instead,
+// it follows the live line's elapsed clock — where it reads as part of the timer
+// rather than as "there is more of this command than fits".
+func TestTheCutMarkerLandsInTheTextNotAfterTheClock(t *testing.T) {
+	m := chatAt(t, term{"tiny", 60, 12})
+	// 12 rows leaves the region two, and the still-working hint (nothing has
+	// completed after 20s) takes one of them — so the live row is the ONLY row,
+	// and it is the row carrying the clock.
+	m.queryStart = time.Now().Add(-30 * time.Second)
+	m = feed(t, m, shellCall(strings.Repeat("gaia --flag ", 40)))
+	rows := rowsOf(m.renderLiveRegion())
+	t.Logf("\n%s", strings.Join(rows, "\n"))
+
+	if !strings.Contains(flat(rows), "…") {
+		t.Fatalf("the cut was not marked at all:\n%s", strings.Join(rows, "\n"))
+	}
+	for _, r := range rows {
+		if liveClock.MatchString(strings.TrimRight(r, "… ")) && strings.HasSuffix(strings.TrimRight(r, " "), "…") {
+			t.Errorf("the cut marker was appended after the elapsed clock: %q", r)
+		}
+	}
+}
+
+// Only the first row of a live action carries the clock, so only the first row
+// pays for it. Charging every wrapped row for a number none of them shows threw
+// away two words a row on the longest lines in the log.
+func TestOnlyTheClockRowPaysForTheClock(t *testing.T) {
+	m := chatAt(t, term{"standard", 80, 24})
+	m = feed(t, m, shellCall(longShell+" "+longShell))
+	rows := rowsOf(m.renderLiveRegion())
+	t.Logf("\n%s", strings.Join(rows, "\n"))
+
+	widest := 0
+	for _, r := range rows[1:] {
+		if w := ansi.StringWidth(strings.TrimSpace(r)); w > widest {
+			widest = w
+		}
+	}
+	if narrowed := m.logWidth() - elapsedReserve; widest <= narrowed {
+		t.Errorf("continuation rows reach only %d columns; the measure without the clock is %d", widest, m.logWidth())
+	}
+	for _, r := range rows {
+		if w := ansi.StringWidth(r); w > 80 {
+			t.Errorf("row is %d columns on an 80-column terminal: %q", w, r)
+		}
+	}
+}
+
+// Several phrases put words AFTER the argument. An argument allowed to fill the
+// whole line pushes them off the end, leaving the reader a query with no clue
+// what was done with it.
+func TestALongArgumentCannotEatItsOwnPhrase(t *testing.T) {
+	args, _ := json.Marshal(map[string]string{"query": strings.Repeat("retrieval augmented generation ", 12)})
+	got := toolNarration("search_indexed_chunks", args, "")
+	t.Logf("%q", got)
+
+	if !strings.HasPrefix(got, "Looking for ") {
+		t.Errorf("the phrase lost its opening: %q", got)
+	}
+	if !strings.Contains(got, "in your documents") {
+		t.Errorf("the argument ate the clause that says what was done with it: %q", got)
+	}
+}
+
+// The held height pads ABOVE the log. Below, the blank rows open a gap between
+// the log and the answer streaming under it.
+func TestHeldHeightPadsAboveTheLog(t *testing.T) {
+	m := chatAt(t, term{"standard", 80, 24})
+	for i := 0; i < 6; i++ {
+		m = feed(t, m,
+			shellCall(longShell+strings.Repeat(" --x", i)),
+			event.CanonicalToolResultEvent{
+				Type: "tool_result", Tool: "run_shell_command",
+				Preview: "failed - the remote closed the connection after 30s; check the network and retry",
+			},
+		)
+	}
+	m.activity = nil // the log empties, the held height stays
+	rows := rowsOf(m.liveRegionView())
+	t.Logf("%d rows:\n%s", len(rows), strings.Join(rows, "\n"))
+
+	if last := strings.TrimSpace(rows[len(rows)-1]); last == "" {
+		t.Errorf("the region ends in blank rows — the pad is under the log, not above it:\n%q", rows)
+	}
+}


### PR DESCRIPTION
On a wide terminal the work log stopped drawing at the same column an 80-column terminal did, so every extra column of window was wasted on the one thing a user stares at for a 25-160s turn. A 240-column window now draws a 238-column tool line instead of 78. Prose is deliberately excluded: an answer still lays out at 88 columns, because for a paragraph the extra width just loses the eye on the carriage return, while for a single row it is simply more of that row — and for the rows whose tail carries the reason or the remedy, the tail is the point.

Stacked on #3005 and #3004, in that order. Until both merge, the diff here shows their commits too; mine are the two on top.

<details>
<summary>🔍 Technical details</summary>

**Functions changed**

- `logWidth()` — dropped the `narrationWidth` (74) ceiling, so the measure is `m.width - 6`, clamped to `m.width - logGutter` so the floor of 16 cannot overrun a cramped window.
- `narrate.go` constants — `narrationWidth = 74` became `widestLogMeasure`, derived from the widest window the TUI accepts anywhere (`control/server.go`'s `"cols must be 20-500"`). #3004 already derives `narrationMax`/`detailMax` from the row measure; that reasoning is kept, but the basis has to be the widest window the text might *later* be rendered into, since capture happens before any width is known and the user can widen mid-turn.
- `devPayloadWidth` — same basis, for the same reason.
- `wrapLog()` — its floor raised any measure under 8 back to 8, overriding the caller's budget, so a 20-column terminal drew a 21-column row. A measure is what the caller can afford; floored at 1 now, never raised.
- `renderLiveRegion()` — two rows went through no measure at all: the "still working" hint (a fixed 50 columns) and the idle live line. The latter is the *opening frame of every turn*, and `"Thinking about the next step"` drew 39 columns, shearing anything narrower.
- `resize()` — releases #3004's peak-height hold on a **width** change. A resize reflows the log, which it could not before this branch; holding a peak measured at another width stranded blank rows for the rest of the turn. Guarded on width so the composer growing a row does not release it.
- `handleCanonicalEvent` — `setLiveStatus` was the one agent-supplied string with no capture bound at all.

`answerWidth()`, `wrapForPane()`, `wrapProse()`, `cardWidth()` and `answerMeasure` are unchanged. `answerMeasure` and `logWidth` now cross-reference each other so the split reads as chosen rather than overlooked.

**Assumptions about the other two branches**

- #3004 owns the wrapping. Its `wrapLog`, `logHeadRows`/`logDetailRows`, `elapsedReserve` and `liveRegionView` are taken as-is. The two compose: #3004 wraps a tail that does not fit, this makes it less likely to need to. Rebased onto its current head (`54a80d3d`), including its own review follow-up.
- #3005 touches disjoint parts of `model.go`.
- Verified rather than assumed: merging `#3005 → #3004 → this` onto `9c89cb47` in a scratch worktree merges with no conflicts, builds, vets, and passes.

**The root cause, for the record**

`logWidth` was the visible suspect but not the cause. `toolNarration`/`toolResultDetail` cut text to 74/66 columns *when the event arrived*, before any width was known, so widening the layout alone would have shown nothing new. Capture bounds now exist only to stop a runaway agent payload living in the model; layout decides what prints.
</details>

## Test plan

- [ ] `cd tui && go build ./... && go vet ./... && go test ./internal/...`
- [ ] `widthlayout_test.go` is table-driven over **24, 40, 60, 80, 120, 160 and 240** columns, plus a per-width sweep from the declared minimum of 20 up. It asserts at every size that no rendered row exceeds the terminal, that `logWidth` grows with the window, and that `answerWidth` never exceeds 88.
- [ ] The cramped-terminal test **renders** every row type — idle, live, wrapped, outcome, `--dev` payload, repeat counter — rather than checking `logWidth`'s arithmetic. An earlier version did the arithmetic only, and certified a property the rendered rows did not have.
- [ ] Every fix was confirmed by reverting it and watching the suite fail: reverting the `wrapLog` floor gives `21 columns wide on a 20-column terminal`; reverting the idle-line measure gives `39 columns wide on a 20-column terminal`.
- [ ] #3004's `worklogwrap_test.go` passes unchanged against the dynamic measure — the check that the wrapping and the width work compose rather than fight.
- [ ] `internal/control` passes, so the `resize_exceeds_terminal` guard from #2932 is intact; that file is untouched.
- [ ] Eyeball on a wide window: run a turn with a long shell command and confirm the log line runs to the window edge while the answer below it stays at 88.

Not run: `tui/test` (daemon integration). It needs a live GAIA daemon and the machine was running demos.
