### PR TITLE
feat(skills): load the right skill without the user knowing its name

### DIFF
--- a/docs/spec/agent-skills.mdx
+++ b/docs/spec/agent-skills.mdx
@@ -253,14 +253,19 @@ A skill is loaded in three levels, mirroring the standard — long reference
 material costs nothing until it's actually needed:
 
 <Steps>
-<Step title="Metadata (always in context)">
-`name` + `description` of every discovered, in-scope skill are listed for the
-model. This is the only always-resident cost — a few tokens per skill.
+<Step title="Metadata (matched outside the prompt)">
+`name` + `description` of every installed skill are indexed **in Python, not in
+the system prompt**. Each turn is scored against that index before the request is
+sent, and only the winner is injected — so a library of thirty skills costs zero
+resident tokens instead of thirty descriptions on every turn. See
+[Proactive discovery](#proactive-discovery).
 </Step>
 <Step title="Body (on trigger)">
-When the model judges a skill relevant (its `description` matches the task) or
-the user invokes it explicitly, the `SKILL.md` Markdown body is injected and the
-skill's declared `tools` are registered into the agent's tool registry.
+When a skill is selected — by the pre-turn match, by the model calling
+`load_skill`, or by the user asking for it — the `SKILL.md` Markdown body is
+injected and the skill's declared `tools` are registered into the agent's tool
+registry. A loaded body does not stay resident forever: it collapses to a
+one-line menu entry on turns that no longer relate to it.
 </Step>
 <Step title="Resources (on demand)">
 Files the body references (scripts, reference docs, templates) load only when the
@@ -336,13 +341,53 @@ passed through install, so `load_skill` gates on *domain* (below), not on tier.
 
 ### Invocation
 
-Once a skill is in scope, it is triggered either by the **model** (description
-match — automatic) or **explicitly** by the user. `load_skill` in code is the
-shipped explicit path; a user-facing `/web-research` slash command follows the
-Agent UI panel and is not yet available. This matches Claude Code's dual-invocation model. The
-standard's `allowed-tools`/`disallowed-tools` keys are parsed but **not** used as
-a permission mechanism (see [Skill Format](/plans/skill-format#adopted-base-agent-skills-standard)) —
+Once a skill is in scope, it is triggered either **automatically** by the
+pre-turn description match below, or **explicitly** — by the model calling
+`load_skill`, or by the user naming it. A user-facing `/web-research` slash
+command follows the Agent UI panel and is not yet available. The standard's
+`allowed-tools`/`disallowed-tools` keys are parsed but **not** used as a
+permission mechanism (see [Skill Format](/plans/skill-format#adopted-base-agent-skills-standard)) —
 GAIA's permissions come from `metadata.gaia`.
+
+### Proactive discovery
+
+A user should never have to know a skill's name. Before each turn reaches the
+model, the agent scores the request against every installed skill's `description`
+and acts on the result:
+
+| Outcome | Condition | What happens |
+|---|---|---|
+| **Load** | one skill clears the confidence bar and beats the runner-up by a margin | it is loaded and the reply opens by saying so |
+| **Shortlist** | several plausible, none dominant | the names are offered to the model, which calls `load_skill` if one fits |
+| **Nothing** | no real match | the turn proceeds with no skill |
+
+A tie is reported as a tie — the agent never picks between close matches on the
+user's behalf.
+
+<Note>
+**Write the `description` for this.** It is the retrieval index, not a label. Name
+the nouns a user would actually say — the objects, formats, and services the
+skill works on — not just the verbs. `github-triage` gained "unread notification
+inbox" and that one phrase is what makes *"what's been going on in my github
+inbox?"* resolve automatically instead of landing in a shortlist.
+</Note>
+
+Matching runs **outside** the prompt: the index is built in Python from
+frontmatter the agent already holds, scoring is lexical (a normalized BM25 over
+name + description) and takes tens of microseconds, and only the selected skill's
+body is injected. The standing prompt cost of the whole feature is a ~96-token
+sourcing rule. Read-only `.claude/skills` imports are indexed for explicit loading
+but never proposed automatically — they are another host's marketplace, written
+for working *on* a repo rather than answering a user's question.
+
+If a matched skill **cannot** load — a missing CLI, an unbridged permission, a
+malformed manifest — the agent is told to say it cannot do the work and why.
+Answering from memory instead of a tool call is the failure this exists to
+prevent; a match that still permits a fabricated answer is not a fix.
+
+Tunables: `GAIA_SKILL_DISCOVERY` (`0` to disable) and `GAIA_SKILL_DISCOVERY_TAU`
+(confidence threshold). `util/skill_retrieval_bench.py` reports precision, recall,
+and latency against a labeled query set.
 
 ## Skill sets
 

--- a/hub/agents/gaia/python/gaia_agent/agent.py
+++ b/hub/agents/gaia/python/gaia_agent/agent.py
@@ -49,6 +49,11 @@ from typing import ClassVar, List, Optional
 
 from gaia_agent_chat.agent import ChatAgent, ChatAgentConfig
 
+from gaia.agents.base.skill_discovery import (
+    DISCOVERY_THRESHOLD_ENV,
+    SkillDiscovery,
+    discovery_env_override,
+)
 from gaia.agents.base.skill_loader import (
     DEFAULT_SKILL_THRESHOLD,
     SkillLoader,
@@ -59,6 +64,7 @@ from gaia.agents.tools.skill_library_tools import SkillLibraryToolsMixin
 from gaia.logger import get_logger
 
 logger = get_logger(__name__)
+
 
 #: Bundled skills ship inside the package so they survive both the wheel and the
 #: frozen sidecar; as ``SKILL_DIRS`` they outrank a same-named user or Claude Code copy.
@@ -170,6 +176,14 @@ class GaiaAgentConfig(ChatAgentConfig):
     # tools= against 10.5K for the whole registry.
     dynamic_tools_max: int = 26
 
+    # Proactive skill discovery: match each turn against skills that are
+    # INSTALLED BUT NOT LOADED and activate the winner, so the user never has
+    # to know a skill's name. On for this agent specifically — it is the one
+    # that ships a skill library and meets users who have never read it.
+    # Overridable via GAIA_SKILL_DISCOVERY.
+    skill_discovery: bool = True
+    skill_discovery_threshold: Optional[float] = None
+
     # Image generation stays off: it pulls a second resident model, and evicting
     # the chat model to draw a picture is not a trade a document agent should
     # make silently.
@@ -248,6 +262,7 @@ class GaiaAgent(ChatAgent, SkillLibraryToolsMixin, CodeIndexToolsMixin):
         access at construction time — only the first real turn does.
         """
         self.skill_loader = self._maybe_build_skill_loader()
+        self._skill_discovery = self._maybe_build_skill_discovery()
         self.register_skill_library_tools()
         # Same scope as allowed_paths, for the same reason that field rejects
         # cwd: the daemon launches this sidecar with cwd = the package
@@ -259,6 +274,40 @@ class GaiaAgent(ChatAgent, SkillLibraryToolsMixin, CodeIndexToolsMixin):
         super()._register_tools()
 
     # ── lazy skill-body loader (#2848 follow-up) ────────────────────────────
+
+    def _maybe_build_skill_discovery(self) -> Optional[SkillDiscovery]:
+        """Construct the proactive discoverer, or ``None`` when switched off.
+
+        Built here rather than lazily so ``_discover_skills_for_turn`` never
+        races the first turn, and so a misconfigured threshold fails at startup
+        instead of mid-conversation.
+        """
+        override = discovery_env_override()
+        enabled = (
+            override if override is not None else bool(self.config.skill_discovery)
+        )
+        if not enabled:
+            return None
+        return SkillDiscovery(
+            self.skill_manager,
+            threshold=self._resolve_discovery_threshold(),
+            # Lambda, not the mapping: tool registration is still running when
+            # this is built, so a snapshot taken here would be empty and every
+            # skill would look like it had unmet requirements.
+            tools_fn=lambda: self._tools_registry,
+        )
+
+    def _resolve_discovery_threshold(self) -> Optional[float]:
+        """Threshold override: env wins over config; a malformed value fails loudly."""
+        raw = os.environ.get(DISCOVERY_THRESHOLD_ENV)
+        if raw is None:
+            return getattr(self.config, "skill_discovery_threshold", None)
+        try:
+            return float(raw)
+        except ValueError as e:
+            raise ValueError(
+                f"{DISCOVERY_THRESHOLD_ENV} must be a float, got {raw!r}"
+            ) from e
 
     def _maybe_build_skill_loader(self) -> Optional[SkillLoader]:
         """Construct the per-turn skill-body selector, or ``None`` when off."""

--- a/hub/agents/gaia/python/gaia_agent/agent.py
+++ b/hub/agents/gaia/python/gaia_agent/agent.py
@@ -50,6 +50,11 @@ from typing import ClassVar, List, Optional
 
 from gaia_agent_chat.agent import ChatAgent, ChatAgentConfig
 
+from gaia.agents.base.skill_discovery import (
+    DISCOVERY_ENV,
+    DISCOVERY_THRESHOLD_ENV,
+    SkillDiscovery,
+)
 from gaia.agents.base.skill_loader import (
     DEFAULT_SKILL_THRESHOLD,
     SkillLoader,
@@ -59,6 +64,15 @@ from gaia.agents.tools.code_index_tools import CodeIndexToolsMixin
 from gaia.agents.tools.skill_library_tools import SkillLibraryToolsMixin
 
 logger = logging.getLogger(__name__)
+
+
+def _env_flag(name: str, *, default: bool) -> bool:
+    """Read a truthy/falsy env override, falling back to *default* when unset."""
+    raw = os.environ.get(name)
+    if raw is None:
+        return default
+    return raw.strip().lower() in ("1", "true", "yes", "on")
+
 
 #: Bundled skills ship inside the package so they survive both the wheel and the
 #: frozen sidecar; as ``SKILL_DIRS`` they outrank a same-named user or Claude Code copy.
@@ -153,6 +167,14 @@ class GaiaAgentConfig(ChatAgentConfig):
     dynamic_skills: bool = True
     dynamic_skills_threshold: float = DEFAULT_SKILL_THRESHOLD
 
+    # Proactive skill discovery: match each turn against skills that are
+    # INSTALLED BUT NOT LOADED and activate the winner, so the user never has
+    # to know a skill's name. On for this agent specifically — it is the one
+    # that ships a skill library and meets users who have never read it.
+    # Overridable via GAIA_SKILL_DISCOVERY.
+    skill_discovery: bool = True
+    skill_discovery_threshold: Optional[float] = None
+
     # Image generation stays off: it pulls a second resident model, and evicting
     # the chat model to draw a picture is not a trade a document agent should
     # make silently.
@@ -213,6 +235,7 @@ class GaiaAgent(ChatAgent, SkillLibraryToolsMixin, CodeIndexToolsMixin):
         access at construction time — only the first real turn does.
         """
         self.skill_loader = self._maybe_build_skill_loader()
+        self._skill_discovery = self._maybe_build_skill_discovery()
         self.register_skill_library_tools()
         # Same scope as allowed_paths, for the same reason that field rejects
         # cwd: the daemon launches this sidecar with cwd = the package
@@ -224,6 +247,36 @@ class GaiaAgent(ChatAgent, SkillLibraryToolsMixin, CodeIndexToolsMixin):
         super()._register_tools()
 
     # ── lazy skill-body loader (#2848 follow-up) ────────────────────────────
+
+    def _maybe_build_skill_discovery(self) -> Optional[SkillDiscovery]:
+        """Construct the proactive discoverer, or ``None`` when switched off.
+
+        Built here rather than lazily so ``_discover_skills_for_turn`` never
+        races the first turn, and so a misconfigured threshold fails at startup
+        instead of mid-conversation.
+        """
+        if not _env_flag(DISCOVERY_ENV, default=bool(self.config.skill_discovery)):
+            return None
+        return SkillDiscovery(
+            self.skill_manager,
+            threshold=self._resolve_discovery_threshold(),
+            # Lambda, not the mapping: tool registration is still running when
+            # this is built, so a snapshot taken here would be empty and every
+            # skill would look like it had unmet requirements.
+            tools_fn=lambda: self._tools_registry,
+        )
+
+    def _resolve_discovery_threshold(self) -> Optional[float]:
+        """Threshold override: env wins over config; a malformed value fails loudly."""
+        raw = os.environ.get(DISCOVERY_THRESHOLD_ENV)
+        if raw is None:
+            return getattr(self.config, "skill_discovery_threshold", None)
+        try:
+            return float(raw)
+        except ValueError as e:
+            raise ValueError(
+                f"{DISCOVERY_THRESHOLD_ENV} must be a float, got {raw!r}"
+            ) from e
 
     def _maybe_build_skill_loader(self) -> Optional[SkillLoader]:
         """Construct the per-turn skill-body selector, or ``None`` when off."""

--- a/hub/agents/gaia/python/tests/test_proactive_skill_discovery.py
+++ b/hub/agents/gaia/python/tests/test_proactive_skill_discovery.py
@@ -1,0 +1,196 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""GaiaAgent's proactive skill-discovery wiring.
+
+The retriever's accuracy lives in ``tests/unit/test_skill_retriever.py`` and the
+per-turn behaviour in ``tests/unit/test_skill_discovery.py``. This file covers
+only the wiring: the toggles resolve, the hook runs before the body filter, a
+skill loaded proactively is pinned so the very next filter cannot hide it, and
+every agent that did *not* opt in has a byte-identical prompt.
+
+Built with ``GaiaAgent.__new__(GaiaAgent)`` like ``test_lazy_skill_activation.py``
+— no LLM, no Lemonade, no embedder.
+"""
+
+from __future__ import annotations
+
+
+import pytest
+from gaia_agent.agent import GaiaAgent, GaiaAgentConfig
+
+from gaia.agents.base.skill_discovery import (
+    DISCOVERY_ENV,
+    DISCOVERY_THRESHOLD_ENV,
+    DiscoveryResult,
+    SkillDiscovery,
+)
+
+
+@pytest.fixture(autouse=True)
+def clean_env(monkeypatch):
+    monkeypatch.delenv(DISCOVERY_ENV, raising=False)
+    monkeypatch.delenv(DISCOVERY_THRESHOLD_ENV, raising=False)
+
+
+def _agent(**config_kwargs) -> GaiaAgent:
+    agent = GaiaAgent.__new__(GaiaAgent)
+    agent.config = GaiaAgentConfig(**config_kwargs)
+    return agent
+
+
+# ── toggles ──────────────────────────────────────────────────────────────
+
+
+def test_discovery_is_on_by_default_for_the_flagship():
+    """This is the agent that ships a skill library and meets users who have
+    never read it — the one place the default has to be on."""
+    assert GaiaAgentConfig().skill_discovery is True
+
+
+def test_config_can_switch_it_off():
+    assert _agent(skill_discovery=False)._maybe_build_skill_discovery() is None
+
+
+def test_it_builds_when_enabled():
+    """``skill_manager`` is a lazy property and building it touches no disk —
+    discovery only scans on the first turn."""
+    assert isinstance(_agent()._maybe_build_skill_discovery(), SkillDiscovery)
+
+
+def test_env_override_wins_over_config(monkeypatch):
+    monkeypatch.setenv(DISCOVERY_ENV, "0")
+    assert _agent(skill_discovery=True)._maybe_build_skill_discovery() is None
+
+
+def test_env_override_can_force_it_on(monkeypatch):
+    monkeypatch.setenv(DISCOVERY_ENV, "1")
+    agent = _agent(skill_discovery=False)
+    assert isinstance(agent._maybe_build_skill_discovery(), SkillDiscovery)
+
+
+def test_threshold_env_override_wins(monkeypatch):
+    monkeypatch.setenv(DISCOVERY_THRESHOLD_ENV, "0.42")
+    assert _agent(skill_discovery_threshold=0.2)._resolve_discovery_threshold() == (
+        pytest.approx(0.42)
+    )
+
+
+def test_malformed_threshold_env_fails_loudly(monkeypatch):
+    monkeypatch.setenv(DISCOVERY_THRESHOLD_ENV, "not-a-float")
+    with pytest.raises(ValueError, match=DISCOVERY_THRESHOLD_ENV):
+        _agent()._resolve_discovery_threshold()
+
+
+def test_threshold_defaults_to_the_module_constant():
+    """None means "use the benchmarked MIN_SCORE" — the config does not fork it."""
+    assert GaiaAgentConfig().skill_discovery_threshold is None
+
+
+# ── the per-turn hook ────────────────────────────────────────────────────
+
+
+class _Discovery:
+    """Stand-in that returns a scripted result and records the query it got."""
+
+    def __init__(self, result: DiscoveryResult):
+        self.result = result
+        self.queries: list[str] = []
+
+    def run(self, query, *, loaded, load_fn):
+        self.queries.append(query)
+        return self.result
+
+
+def _hooked_agent(result: DiscoveryResult, **kwargs) -> GaiaAgent:
+    agent = _agent(**kwargs)
+    agent._skill_discovery = _Discovery(result)
+    agent._skill_discovery_result = None
+    agent._loaded_skills = {}
+    agent._sticky_skill_turns = None
+    agent._active_skill_filter = None
+    agent.rebuild_system_prompt = lambda: None
+    return agent
+
+
+def test_the_hook_records_this_turns_result():
+    agent = _hooked_agent(DiscoveryResult(loaded="github-triage"))
+    agent._discover_skills_for_turn("triage my github inbox")
+    assert agent._skill_discovery_result.loaded == "github-triage"
+
+
+def test_an_auto_loaded_skill_is_pinned_so_the_body_filter_cannot_hide_it():
+    """Discovery runs before the first body-filter refresh of a session.
+
+    Without the pin the filter that runs immediately afterwards could score the
+    skill below threshold and collapse the body of the very skill this turn was
+    loaded for.
+    """
+    agent = _hooked_agent(DiscoveryResult(loaded="github-triage"))
+    agent._discover_skills_for_turn("triage my github inbox")
+    assert agent._sticky_skill_turns["github-triage"] == GaiaAgent.STICKY_SKILL_TURNS
+
+
+def test_nothing_is_pinned_when_nothing_loaded():
+    agent = _hooked_agent(DiscoveryResult(shortlist=("price-watch",)))
+    agent._discover_skills_for_turn("watch this")
+    assert not (agent._sticky_skill_turns or {})
+
+
+def test_the_hook_is_a_no_op_without_discovery():
+    agent = _agent()
+    agent._skill_discovery = None
+    agent._skill_discovery_result = None
+    agent._discover_skills_for_turn("anything")
+    assert agent._skill_discovery_result is None
+
+
+def test_the_query_carries_the_previous_turn_for_short_follow_ups():
+    """ "and the one before that?" has no subject of its own."""
+    agent = _hooked_agent(DiscoveryResult())
+    agent._build_tool_selection_query = lambda text: f"PREV {text}"
+    agent._discover_skills_for_turn("and the one before that?")
+    assert agent._skill_discovery.queries == ["PREV and the one before that?"]
+
+
+def test_the_query_falls_back_to_the_bare_message():
+    agent = _hooked_agent(DiscoveryResult())
+    agent._discover_skills_for_turn("triage my github inbox")
+    assert agent._skill_discovery.queries == ["triage my github inbox"]
+
+
+# ── the prompt fragment ──────────────────────────────────────────────────
+
+
+def test_agents_without_discovery_get_no_fragment_at_all():
+    """Byte-identical guarantee: every other agent's composed prompt is unchanged."""
+    agent = _agent()
+    agent._skill_discovery = None
+    assert agent.get_skill_discovery_system_prompt() == ""
+
+
+def test_the_sourcing_rule_is_present_even_when_no_skill_matched():
+    """The observed fabrication happened on a turn where nothing matched, so the
+    rule cannot be conditional on a match."""
+    agent = _hooked_agent(DiscoveryResult())
+    agent._discover_skills_for_turn("what is 17 times 23?")
+    fragment = agent.get_skill_discovery_system_prompt()
+    assert "SOURCING" in fragment
+    assert "SKILL ACTIVATED" not in fragment
+
+
+def test_a_failed_load_reaches_the_model_as_a_refusal():
+    agent = _hooked_agent(
+        DiscoveryResult(failed=("github-triage", "gh is not installed"))
+    )
+    agent._discover_skills_for_turn("triage my github inbox")
+    fragment = agent.get_skill_discovery_system_prompt()
+    assert "SKILL UNAVAILABLE" in fragment
+    assert "gh is not installed" in fragment
+
+
+def test_the_fragment_is_discovered_by_the_mixin_prompt_scan():
+    """``_get_mixin_prompts`` finds ``get_*_system_prompt`` by name — a rename
+    would silently drop this from the prompt with nothing failing."""
+    assert hasattr(GaiaAgent, "get_skill_discovery_system_prompt")
+    name = "get_skill_discovery_system_prompt"
+    assert name.startswith("get_") and name.endswith("_system_prompt")

--- a/hub/agents/gaia/python/tests/test_proactive_skill_discovery.py
+++ b/hub/agents/gaia/python/tests/test_proactive_skill_discovery.py
@@ -1,0 +1,197 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""GaiaAgent's proactive skill-discovery wiring.
+
+The retriever's accuracy lives in ``tests/unit/test_skill_retriever.py`` and the
+per-turn behaviour in ``tests/unit/test_skill_discovery.py``. This file covers
+only the wiring: the toggles resolve, the hook runs before the body filter, a
+skill loaded proactively is pinned so the very next filter cannot hide it, and
+every agent that did *not* opt in has a byte-identical prompt.
+
+Built with ``GaiaAgent.__new__(GaiaAgent)`` like ``test_lazy_skill_activation.py``
+— no LLM, no Lemonade, no embedder.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+from gaia_agent.agent import GaiaAgent, GaiaAgentConfig
+
+from gaia.agents.base.skill_discovery import (
+    DISCOVERY_ENV,
+    DISCOVERY_THRESHOLD_ENV,
+    DiscoveryResult,
+    SkillDiscovery,
+)
+
+
+@pytest.fixture(autouse=True)
+def clean_env(monkeypatch):
+    monkeypatch.delenv(DISCOVERY_ENV, raising=False)
+    monkeypatch.delenv(DISCOVERY_THRESHOLD_ENV, raising=False)
+
+
+def _agent(**config_kwargs) -> GaiaAgent:
+    agent = GaiaAgent.__new__(GaiaAgent)
+    agent.config = GaiaAgentConfig(**config_kwargs)
+    return agent
+
+
+# ── toggles ──────────────────────────────────────────────────────────────
+
+
+def test_discovery_is_on_by_default_for_the_flagship():
+    """This is the agent that ships a skill library and meets users who have
+    never read it — the one place the default has to be on."""
+    assert GaiaAgentConfig().skill_discovery is True
+
+
+def test_config_can_switch_it_off():
+    assert _agent(skill_discovery=False)._maybe_build_skill_discovery() is None
+
+
+def test_it_builds_when_enabled():
+    """``skill_manager`` is a lazy property and building it touches no disk —
+    discovery only scans on the first turn."""
+    assert isinstance(_agent()._maybe_build_skill_discovery(), SkillDiscovery)
+
+
+def test_env_override_wins_over_config(monkeypatch):
+    monkeypatch.setenv(DISCOVERY_ENV, "0")
+    assert _agent(skill_discovery=True)._maybe_build_skill_discovery() is None
+
+
+def test_env_override_can_force_it_on(monkeypatch):
+    monkeypatch.setenv(DISCOVERY_ENV, "1")
+    agent = _agent(skill_discovery=False)
+    assert isinstance(agent._maybe_build_skill_discovery(), SkillDiscovery)
+
+
+def test_threshold_env_override_wins(monkeypatch):
+    monkeypatch.setenv(DISCOVERY_THRESHOLD_ENV, "0.42")
+    assert _agent(skill_discovery_threshold=0.2)._resolve_discovery_threshold() == (
+        pytest.approx(0.42)
+    )
+
+
+def test_malformed_threshold_env_fails_loudly(monkeypatch):
+    monkeypatch.setenv(DISCOVERY_THRESHOLD_ENV, "not-a-float")
+    with pytest.raises(ValueError, match=DISCOVERY_THRESHOLD_ENV):
+        _agent()._resolve_discovery_threshold()
+
+
+def test_threshold_defaults_to_the_module_constant():
+    """None means "use the benchmarked MIN_SCORE" — the config does not fork it."""
+    assert GaiaAgentConfig().skill_discovery_threshold is None
+
+
+# ── the per-turn hook ────────────────────────────────────────────────────
+
+
+class _Discovery:
+    """Stand-in that returns a scripted result and records the query it got."""
+
+    def __init__(self, result: DiscoveryResult):
+        self.result = result
+        self.queries: list[str] = []
+
+    def run(self, query, *, loaded, load_fn):
+        self.queries.append(query)
+        return self.result
+
+
+def _hooked_agent(result: DiscoveryResult, **kwargs) -> GaiaAgent:
+    agent = _agent(**kwargs)
+    agent._skill_discovery = _Discovery(result)
+    agent._skill_discovery_result = None
+    agent._loaded_skills = {}
+    agent._sticky_skill_turns = None
+    agent._active_skill_filter = None
+    agent.rebuild_system_prompt = lambda: None
+    return agent
+
+
+def test_the_hook_records_this_turns_result():
+    agent = _hooked_agent(DiscoveryResult(loaded="github-triage"))
+    agent._discover_skills_for_turn("triage my github inbox")
+    assert agent._skill_discovery_result.loaded == "github-triage"
+
+
+def test_an_auto_loaded_skill_is_pinned_so_the_body_filter_cannot_hide_it():
+    """Discovery runs before the first body-filter refresh of a session.
+
+    Without the pin the filter that runs immediately afterwards could score the
+    skill below threshold and collapse the body of the very skill this turn was
+    loaded for.
+    """
+    agent = _hooked_agent(DiscoveryResult(loaded="github-triage"))
+    agent._discover_skills_for_turn("triage my github inbox")
+    assert agent._sticky_skill_turns["github-triage"] == GaiaAgent.STICKY_SKILL_TURNS
+
+
+def test_nothing_is_pinned_when_nothing_loaded():
+    agent = _hooked_agent(DiscoveryResult(shortlist=("price-watch",)))
+    agent._discover_skills_for_turn("watch this")
+    assert not (agent._sticky_skill_turns or {})
+
+
+def test_the_hook_is_a_no_op_without_discovery():
+    agent = _agent()
+    agent._skill_discovery = None
+    agent._skill_discovery_result = None
+    agent._discover_skills_for_turn("anything")
+    assert agent._skill_discovery_result is None
+
+
+def test_the_query_carries_the_previous_turn_for_short_follow_ups():
+    """ "and the one before that?" has no subject of its own."""
+    agent = _hooked_agent(DiscoveryResult())
+    agent._build_tool_selection_query = lambda text: f"PREV {text}"
+    agent._discover_skills_for_turn("and the one before that?")
+    assert agent._skill_discovery.queries == ["PREV and the one before that?"]
+
+
+def test_the_query_falls_back_to_the_bare_message():
+    agent = _hooked_agent(DiscoveryResult())
+    agent._discover_skills_for_turn("triage my github inbox")
+    assert agent._skill_discovery.queries == ["triage my github inbox"]
+
+
+# ── the prompt fragment ──────────────────────────────────────────────────
+
+
+def test_agents_without_discovery_get_no_fragment_at_all():
+    """Byte-identical guarantee: every other agent's composed prompt is unchanged."""
+    agent = _agent()
+    agent._skill_discovery = None
+    assert agent.get_skill_discovery_system_prompt() == ""
+
+
+def test_the_sourcing_rule_is_present_even_when_no_skill_matched():
+    """The observed fabrication happened on a turn where nothing matched, so the
+    rule cannot be conditional on a match."""
+    agent = _hooked_agent(DiscoveryResult())
+    agent._discover_skills_for_turn("what is 17 times 23?")
+    fragment = agent.get_skill_discovery_system_prompt()
+    assert "SOURCING" in fragment
+    assert "SKILL ACTIVATED" not in fragment
+
+
+def test_a_failed_load_reaches_the_model_as_a_refusal():
+    agent = _hooked_agent(
+        DiscoveryResult(failed=("github-triage", "gh is not installed"))
+    )
+    agent._discover_skills_for_turn("triage my github inbox")
+    fragment = agent.get_skill_discovery_system_prompt()
+    assert "SKILL UNAVAILABLE" in fragment
+    assert "gh is not installed" in fragment
+
+
+def test_the_fragment_is_discovered_by_the_mixin_prompt_scan():
+    """``_get_mixin_prompts`` finds ``get_*_system_prompt`` by name — a rename
+    would silently drop this from the prompt with nothing failing."""
+    assert hasattr(GaiaAgent, "get_skill_discovery_system_prompt")
+    name = "get_skill_discovery_system_prompt"
+    assert name.startswith("get_") and name.endswith("_system_prompt")

--- a/hub/agents/gaia/python/tests/test_skill_prompt_budget.py
+++ b/hub/agents/gaia/python/tests/test_skill_prompt_budget.py
@@ -69,6 +69,7 @@ class _StubAgent:
     _tools_registry = Agent._tools_registry
     _format_tools_for_prompt = Agent._format_tools_for_prompt
     _note_skill_active = Agent._note_skill_active
+    _pin_skill_body = Agent._pin_skill_body
     _always_on_skill_names = Agent._always_on_skill_names
     load_skill = Agent.load_skill
     unload_skill = Agent.unload_skill

--- a/src/gaia/agents/base/agent.py
+++ b/src/gaia/agents/base/agent.py
@@ -503,6 +503,17 @@ class Agent(abc.ABC):
     #: name -> turns of pinning remaining; decremented each refresh.
     _sticky_skill_turns: Optional[Dict[str, int]] = None
 
+    #: Proactive skill discovery: matches the user's turn against skills that
+    #: are INSTALLED BUT NOT LOADED and activates the winner, so a user never
+    #: has to know a skill's name. ``None`` (the default) leaves every existing
+    #: agent's behavior and composed prompt byte-identical; GaiaAgent builds one.
+    #: See :mod:`gaia.agents.base.skill_discovery`.
+    _skill_discovery: Optional[Any] = None
+
+    #: This turn's discovery note, rendered by
+    #: ``get_skill_discovery_system_prompt``. Cleared and recomputed per turn.
+    _skill_discovery_result: Optional[Any] = None
+
     # Skill sets (#2466): the parsed manifest declarations, the explicit
     # ``--skill-set`` request, and the set that actually resolved.
     _skill_sets: Optional[Any] = None
@@ -1150,6 +1161,84 @@ Do NOT wrap conversational replies in JSON.
         """
         return None
 
+    def _discover_skills_for_turn(self, user_input: str) -> None:
+        """Match this turn against installed-but-unloaded skills and act on it.
+
+        No-op unless a subclass built a
+        :class:`~gaia.agents.base.skill_discovery.SkillDiscovery` — every other
+        agent's composed prompt stays byte-identical.
+
+        Runs BEFORE :meth:`_refresh_active_skill_filter` so a skill loaded here
+        is in ``loaded_skills`` when the body filter is computed, and pinned via
+        :meth:`_pin_skill_body` so the filter cannot immediately hide the body of
+        the skill it just decided the turn was about.
+        """
+        discovery = self._skill_discovery
+        if discovery is None:
+            return
+
+        previous = self._skill_discovery_result
+        query = self._build_skill_discovery_query(user_input)
+        result = discovery.run(
+            query, loaded=self.loaded_skills, load_fn=self.load_skill
+        )
+        self._skill_discovery_result = result
+        if result.loaded:
+            self._pin_skill_body(result.loaded)
+
+        # Rebuild whenever the note changed, INCLUDING after a successful load.
+        # ``load_skill`` rebuilds too, but it runs before the line above, so the
+        # prompt it composed still carries the *previous* turn's note — the
+        # "SKILL ACTIVATED" line would be missing on exactly the turns that
+        # earned it. The later ``_refresh_active_skill_filter`` only recomposes
+        # when the body filter changes, so it cannot be relied on to fix this.
+        before = previous.prompt_fragment() if previous is not None else ""
+        if result.prompt_fragment() != before:
+            self.rebuild_system_prompt()
+
+    def _build_skill_discovery_query(self, user_input: str) -> str:
+        """The text discovery matches on — previous + current user message.
+
+        Reuses ChatAgent's tool-selection query when the agent has one, so a
+        follow-up ("and the one before that?") still carries the prior turn's
+        subject instead of matching on four pronouns.
+        """
+        builder = getattr(self, "_build_tool_selection_query", None)
+        if callable(builder):
+            return builder(user_input)
+        return user_input
+
+    def get_skill_discovery_system_prompt(self) -> str:
+        """Sourcing rule + this turn's discovery note.
+
+        Auto-discovered by :meth:`_get_mixin_prompts`. Returns "" for any agent
+        without discovery enabled, so no existing prompt changes.
+        """
+        if self._skill_discovery is None:
+            return ""
+        from gaia.agents.base.skill_discovery import GROUNDING_RULE
+
+        result = self._skill_discovery_result
+        note = result.prompt_fragment() if result is not None else ""
+        return f"{GROUNDING_RULE}\n\n{note}" if note else GROUNDING_RULE
+
+    def _pin_skill_body(self, name: str, turns: Optional[int] = None) -> None:
+        """Keep *name*'s body rendered for the next few filter refreshes.
+
+        Unlike :meth:`_note_skill_active` this works before any filter exists —
+        proactive discovery runs before the first refresh of a session, and
+        without the pin the very next selection could hide the body of the skill
+        that was just loaded *because* this turn needed it.
+        """
+        # getattr throughout: test stubs copy these methods onto a plain class
+        # without inheriting the class attributes they read.
+        sticky = getattr(self, "_sticky_skill_turns", None)
+        if sticky is None:
+            sticky = {}
+            self._sticky_skill_turns = sticky
+        default = getattr(self, "STICKY_SKILL_TURNS", 3)
+        sticky[name] = default if turns is None else turns
+
     def _refresh_active_skill_filter(self, user_input: str) -> None:
         """Update the active skill-body filter for this turn, if it changed.
 
@@ -1213,13 +1302,7 @@ Do NOT wrap conversational replies in JSON.
         # "yes, continue" scores nothing against the skill's description, and
         # collapsing the body one turn after the user asked for it strands
         # the model mid-recipe.
-        # getattr, not attribute access: test stubs copy this method without
-        # inheriting the class attributes.
-        sticky = getattr(self, "_sticky_skill_turns", None)
-        if sticky is None:
-            sticky = {}
-            self._sticky_skill_turns = sticky
-        sticky[name] = getattr(self, "STICKY_SKILL_TURNS", 3)
+        self._pin_skill_body(name)
         if name not in current:
             self._active_skill_filter = sorted(set(current) | {name})
 
@@ -4186,6 +4269,11 @@ Do NOT wrap conversational replies in JSON.
         # Dynamic tool selection (#1449): pick this turn's tool subset and
         # recompute the cached system prompt only when it changes.
         self._refresh_active_tool_filter(user_input)
+
+        # Proactive skill discovery: a skill the user never named can become
+        # loaded here, so it must run BEFORE the body filter below computes
+        # which loaded skills render.
+        self._discover_skills_for_turn(user_input)
 
         # Lazy skill-body activation (#2848 follow-up): same per-turn timing
         # as the tool filter above, so a stale skill match never survives

--- a/src/gaia/agents/base/agent.py
+++ b/src/gaia/agents/base/agent.py
@@ -521,6 +521,17 @@ class Agent(abc.ABC):
     #: name -> turns of pinning remaining; decremented each refresh.
     _sticky_skill_turns: Optional[Dict[str, int]] = None
 
+    #: Proactive skill discovery: matches the user's turn against skills that
+    #: are INSTALLED BUT NOT LOADED and activates the winner, so a user never
+    #: has to know a skill's name. ``None`` (the default) leaves every existing
+    #: agent's behavior and composed prompt byte-identical; GaiaAgent builds one.
+    #: See :mod:`gaia.agents.base.skill_discovery`.
+    _skill_discovery: Optional[Any] = None
+
+    #: This turn's discovery note, rendered by
+    #: ``get_skill_discovery_system_prompt``. Cleared and recomputed per turn.
+    _skill_discovery_result: Optional[Any] = None
+
     # Skill sets (#2466): the parsed manifest declarations, the explicit
     # ``--skill-set`` request, and the set that actually resolved.
     _skill_sets: Optional[Any] = None
@@ -1288,6 +1299,86 @@ Do NOT wrap conversational replies in JSON.
         """
         return None
 
+    def _discover_skills_for_turn(self, user_input: str) -> None:
+        """Match this turn against installed-but-unloaded skills and act on it.
+
+        No-op unless a subclass built a
+        :class:`~gaia.agents.base.skill_discovery.SkillDiscovery` — every other
+        agent's composed prompt stays byte-identical.
+
+        Runs BEFORE :meth:`_refresh_active_tool_filter` so tools the loaded skill
+        registers are visible on the same turn, and BEFORE
+        :meth:`_refresh_active_skill_filter` so the skill is in ``loaded_skills``
+        when the body filter is computed. Pinned via :meth:`_pin_skill_body` so
+        that filter cannot immediately hide the body of the skill it just decided
+        the turn was about.
+        """
+        discovery = self._skill_discovery
+        if discovery is None:
+            return
+
+        previous = self._skill_discovery_result
+        query = self._build_skill_discovery_query(user_input)
+        result = discovery.run(
+            query, loaded=self.loaded_skills, load_fn=self.load_skill
+        )
+        self._skill_discovery_result = result
+        if result.loaded:
+            self._pin_skill_body(result.loaded)
+
+        # Rebuild whenever the note changed, INCLUDING after a successful load.
+        # ``load_skill`` rebuilds too, but it runs before the line above, so the
+        # prompt it composed still carries the *previous* turn's note — the
+        # "SKILL ACTIVATED" line would be missing on exactly the turns that
+        # earned it. The later ``_refresh_active_skill_filter`` only recomposes
+        # when the body filter changes, so it cannot be relied on to fix this.
+        before = previous.prompt_fragment() if previous is not None else ""
+        if result.prompt_fragment() != before:
+            self.rebuild_system_prompt()
+
+    def _build_skill_discovery_query(self, user_input: str) -> str:
+        """The text discovery matches on — previous + current user message.
+
+        Reuses ChatAgent's tool-selection query when the agent has one, so a
+        follow-up ("and the one before that?") still carries the prior turn's
+        subject instead of matching on four pronouns.
+        """
+        builder = getattr(self, "_build_tool_selection_query", None)
+        if callable(builder):
+            return builder(user_input)
+        return user_input
+
+    def get_skill_discovery_system_prompt(self) -> str:
+        """Sourcing rule + this turn's discovery note.
+
+        Auto-discovered by :meth:`_get_mixin_prompts`. Returns "" for any agent
+        without discovery enabled, so no existing prompt changes.
+        """
+        if self._skill_discovery is None:
+            return ""
+        from gaia.agents.base.skill_discovery import GROUNDING_RULE
+
+        result = self._skill_discovery_result
+        note = result.prompt_fragment() if result is not None else ""
+        return f"{GROUNDING_RULE}\n\n{note}" if note else GROUNDING_RULE
+
+    def _pin_skill_body(self, name: str, turns: Optional[int] = None) -> None:
+        """Keep *name*'s body rendered for the next few filter refreshes.
+
+        Unlike :meth:`_note_skill_active` this works before any filter exists —
+        proactive discovery runs before the first refresh of a session, and
+        without the pin the very next selection could hide the body of the skill
+        that was just loaded *because* this turn needed it.
+        """
+        # getattr throughout: test stubs copy these methods onto a plain class
+        # without inheriting the class attributes they read.
+        sticky = getattr(self, "_sticky_skill_turns", None)
+        if sticky is None:
+            sticky = {}
+            self._sticky_skill_turns = sticky
+        default = getattr(self, "STICKY_SKILL_TURNS", 3)
+        sticky[name] = default if turns is None else turns
+
     def _refresh_active_skill_filter(self, user_input: str) -> None:
         """Update the active skill-body filter for this turn, if it changed.
 
@@ -1351,13 +1442,7 @@ Do NOT wrap conversational replies in JSON.
         # "yes, continue" scores nothing against the skill's description, and
         # collapsing the body one turn after the user asked for it strands
         # the model mid-recipe.
-        # getattr, not attribute access: test stubs copy this method without
-        # inheriting the class attributes.
-        sticky = getattr(self, "_sticky_skill_turns", None)
-        if sticky is None:
-            sticky = {}
-            self._sticky_skill_turns = sticky
-        sticky[name] = getattr(self, "STICKY_SKILL_TURNS", 3)
+        self._pin_skill_body(name)
         if name not in current:
             self._active_skill_filter = sorted(set(current) | {name})
 
@@ -4384,6 +4469,12 @@ Do NOT wrap conversational replies in JSON.
         # Store query for error context (used in _execute_tool for error formatting)
         self._current_query = user_input
         self._single_tool_done = False
+
+        # Proactive skill discovery: a skill the user never named can become
+        # loaded here, registering its tools — so it must run BEFORE the tool
+        # filter, or those tools are invisible on the very turn that loaded the
+        # skill, and before the body filter for the same reason.
+        self._discover_skills_for_turn(user_input)
 
         # Dynamic tool selection (#1449): pick this turn's tool subset and
         # recompute the cached system prompt only when it changes.

--- a/src/gaia/agents/base/skill_discovery.py
+++ b/src/gaia/agents/base/skill_discovery.py
@@ -1,0 +1,343 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""Per-turn proactive skill discovery — find the right skill, load it, or say why not.
+
+:mod:`gaia.agents.base.skill_retriever` answers *which* installed skill a turn is
+about. This module is what an agent actually runs: it keeps the index fresh,
+applies the security gates a proactive load has to respect, performs the load,
+and renders the one short prompt fragment the model sees as a result.
+
+It runs **outside** the prompt. The system prompt never carries a catalogue of
+installed skills; matching happens in Python against frontmatter the agent
+already has in memory, and only the winner's body is injected. Against the
+flagship's measured ~17,000-token prompt the standing cost is the grounding rule
+below and nothing else — every other fragment appears only on the turns it
+applies to.
+
+Three outcomes, and the third is the point
+------------------------------------------
+1. **Loaded.** One skill cleared the bar; its instructions and tools are live and
+   the model is told to say so in a line.
+2. **Shortlisted.** Several plausible, none dominant. The model is handed the
+   names and calls ``load_skill`` itself. Never a coin-flip.
+3. **Could not load.** A skill matched and the load *failed* — an unbridged
+   permission, a missing CLI, a malformed manifest. This is the case that
+   motivated the whole module: the flagship, asked about a GitHub inbox with no
+   GitHub tools registered, answered confidently from its memory store. So the
+   failure is stated in the prompt as a refusal instruction, not swallowed.
+   A retrieval win that still lets the agent invent an answer is not a fix.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, Callable, Dict, Optional, Tuple
+
+from gaia.agents.base.skill_retriever import Decision, SkillRetriever
+from gaia.skills.manager import ROOT_CLAUDE_IMPORT
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    from gaia.skills.format import Skill
+    from gaia.skills.manager import SkillManager
+
+logger = logging.getLogger(__name__)
+
+#: Env override for the whole feature. Unset = on for agents that opt in.
+DISCOVERY_ENV = "GAIA_SKILL_DISCOVERY"
+
+#: Env override for :data:`~gaia.agents.base.skill_retriever.MIN_SCORE`.
+DISCOVERY_THRESHOLD_ENV = "GAIA_SKILL_DISCOVERY_TAU"
+
+
+def discovery_env_override() -> Optional[bool]:
+    """Parse :data:`DISCOVERY_ENV`, or ``None`` when it is unset.
+
+    Mirrors :func:`gaia.agents.base.skill_loader.dynamic_skills_env_override`.
+    """
+    raw = os.getenv(DISCOVERY_ENV)
+    if raw is None:
+        return None
+    return raw.strip().lower() in ("1", "true", "yes", "on")
+
+#: The standing honesty rule — the only text this feature adds to every turn.
+#:
+#: It is deliberately about *sourcing*, not about skills: the failure it exists
+#: to stop ("what's been going on in my github inbox?" answered from the memory
+#: store, zero tools called) happens on exactly the turns where no skill matched,
+#: so a skills-only instruction would not have been in the prompt to prevent it.
+#:
+#: Cost is asserted in ``tests/unit/test_skill_discovery.py`` — see that test for
+#: the measured token count and why the ceiling sits where it does.
+GROUNDING_RULE = (
+    "==== SOURCING ====\n"
+    "Facts about live external state — a repository, an inbox, a calendar, a web "
+    "page, a file on disk — must come from a tool call in THIS turn. Memory, "
+    "training, and earlier turns are not sources for them. If no registered tool "
+    "can fetch what was asked, say you cannot and name what is missing. Never "
+    "answer from recollection, and never present an example as real data."
+)
+
+
+@dataclass(frozen=True)
+class DiscoveryResult:
+    """What discovery did this turn, and the prompt fragment it produced."""
+
+    #: Skill auto-loaded this turn, if any.
+    loaded: Optional[str] = None
+    #: Names offered to the model to load itself.
+    shortlist: Tuple[str, ...] = ()
+    #: ``(name, reason)`` when a confident match could not be loaded.
+    failed: Optional[Tuple[str, str]] = None
+    #: Tools the loaded skill declares but this agent does not have registered.
+    unmet_tools: Tuple[str, ...] = ()
+    #: The retriever's raw verdict, for logging and tests.
+    decision: Optional[Decision] = None
+
+    @property
+    def outcome(self) -> str:
+        """``"loaded"`` / ``"shortlist"`` / ``"failed"`` / ``"none"``."""
+        if self.failed:
+            return "failed"
+        if self.loaded:
+            return "loaded"
+        return "shortlist" if self.shortlist else "none"
+
+    def prompt_fragment(self) -> str:
+        """The turn-specific note, or "" when there is nothing to say."""
+        if self.failed:
+            name, reason = self.failed
+            return (
+                "==== SKILL UNAVAILABLE ====\n"
+                f"This request matches the '{name}' skill, but it could not be "
+                f"loaded: {reason}\n"
+                "You therefore do not have what this request needs. Tell the "
+                "user you cannot do it and give them that reason. Do not answer "
+                "from memory, and do not substitute a plausible-looking result."
+            )
+        if self.loaded:
+            note = (
+                "==== SKILL ACTIVATED ====\n"
+                f"'{self.loaded}' was selected for this request and its "
+                "instructions are in LOADED SKILLS. Follow them, and open your "
+                "reply by saying in one short line that you are using it."
+            )
+            if self.unmet_tools:
+                # ``tools_required`` is advisory at load time — the loader logs
+                # the gap and loads anyway. Unsaid, the model discovers it
+                # mid-recipe as a missing tool and improvises around it, which
+                # is the fabrication this module exists to stop.
+                note += (
+                    f"\nIt expects tool(s) {', '.join(self.unmet_tools)}, which "
+                    "are NOT registered here. The steps needing them cannot run: "
+                    "say so plainly instead of substituting something else."
+                )
+            return note
+        if self.shortlist:
+            names = ", ".join(f"'{n}'" for n in self.shortlist)
+            return (
+                "==== SKILLS THAT MAY FIT ====\n"
+                f"{names} are installed and may match this request, but none was "
+                "a clear enough match to activate on its own. If one of them is "
+                "what the user means, call load_skill on it before answering."
+            )
+        return ""
+
+
+class SkillDiscovery:
+    """Keeps the retrieval index fresh and turns one query into one action.
+
+    Holds no reference to an agent: :meth:`run` takes the loaded set and a load
+    callable, so it is exercisable in a unit test with no LLM, no Lemonade, and
+    no agent instance.
+    """
+
+    #: Roots excluded from proactive matching. ``.claude/skills`` is a read-only
+    #: import of another host's marketplace — skills written for Claude Code
+    #: working *on* a repo, not answers to a user's question. Indexing this
+    #: repo's own set made "what is the contract for this API endpoint?" match a
+    #: presentation-authoring skill (it documents "request/response contracts")
+    #: and "what does the function signature mean?" match an agent-scaffolding
+    #: skill. Those skills stay loadable by name; they are just not proposed.
+    EXCLUDED_ROOTS = frozenset({ROOT_CLAUDE_IMPORT})
+
+    #: Consecutive load failures after which a skill stops being proposed for
+    #: the rest of the session. Without it a skill whose CLI is missing is
+    #: rediscovered and re-refused on every single turn.
+    MAX_FAILURES = 2
+
+    def __init__(
+        self,
+        manager: "SkillManager",
+        *,
+        retriever: Optional[SkillRetriever] = None,
+        threshold: Optional[float] = None,
+        tools_fn: Optional[Callable[[], Any]] = None,
+    ) -> None:
+        """Build the per-turn discoverer over *manager*'s discovery roots.
+
+        Args:
+            manager: The agent's :class:`~gaia.skills.manager.SkillManager`.
+            retriever: Injectable index, for tests.
+            threshold: Overrides the retriever module's ``MIN_SCORE``.
+            tools_fn: Returns the agent's live tool registry, used to report a
+                loaded skill's unmet ``tools_required``. A callable rather than
+                the mapping itself because registration is still in progress
+                when the agent constructs this. Omit to skip that check.
+        """
+        self._manager = manager
+        self._retriever = retriever if retriever is not None else SkillRetriever()
+        self._threshold = threshold
+        self._tools_fn = tools_fn
+        self._failures: Dict[str, int] = {}
+        self._turn = 0
+
+    # ── index ───────────────────────────────────────────────────────────────
+
+    def candidates(self) -> Dict[str, "Skill"]:
+        """Installed skills eligible to be proposed, by name.
+
+        Frontmatter only — :meth:`SkillManager.discover` caches, so a steady
+        session pays a dict comprehension per turn, not a directory walk.
+        """
+        return {
+            name: skill
+            for name, skill in self._manager.discover().items()
+            if skill.root not in self.EXCLUDED_ROOTS
+        }
+
+    def refresh(self) -> None:
+        """Reindex when the installed set has changed since the last build."""
+        skills = self.candidates()
+        if self._retriever.is_stale(skills):
+            self._retriever.index(skills)
+            logger.info(
+                "[skills] discovery index rebuilt: %d skill(s) — %s",
+                self._retriever.size,
+                ", ".join(self._retriever.names) or "(none)",
+            )
+
+    # ── the turn ────────────────────────────────────────────────────────────
+
+    def run(
+        self,
+        query: str,
+        *,
+        loaded: Dict[str, "Skill"],
+        load_fn: Callable[[str], "Skill"],
+    ) -> DiscoveryResult:
+        """Match *query*, act on the verdict, and return what to tell the model.
+
+        Args:
+            query: This turn's selection query — normally previous + current
+                user message, so a short follow-up still carries context.
+            loaded: The agent's already-loaded skills; excluded from matching,
+                since :mod:`~gaia.agents.base.skill_loader` governs those.
+            load_fn: ``Agent.load_skill``. Called at most once per turn.
+
+        Returns:
+            A :class:`DiscoveryResult`. Never raises for a skill-level failure —
+            a refused or broken skill becomes a ``failed`` result whose prompt
+            fragment instructs the model to refuse rather than improvise.
+        """
+        from gaia.skills.errors import SkillError
+
+        self._turn += 1
+        self.refresh()
+        if not self._retriever.size:
+            return DiscoveryResult()
+
+        burned = {n for n, c in self._failures.items() if c >= self.MAX_FAILURES}
+        decision = self._decide(query, exclude=set(loaded) | burned)
+        self._log(decision, loaded)
+
+        if decision.load:
+            try:
+                skill = load_fn(decision.load)
+            # Broad on purpose, and NOT a silent fallback: a proactive load runs
+            # code (``register_skill_tools`` imports a skill's ``tools.py``) on a
+            # turn the user did not ask for it, so one broken third-party skill
+            # must not take down an unrelated question. Nothing is swallowed —
+            # the reason is logged with its traceback AND stated to the model as
+            # an instruction to refuse. ``SkillError`` alone would leave
+            # ImportError, and every other import-time failure, crashing the turn.
+            except Exception as exc:  # noqa: BLE001
+                self._failures[decision.load] = self._failures.get(decision.load, 0) + 1
+                logger.warning(
+                    "[skills] '%s' matched this turn but would not load: %s: %s",
+                    decision.load,
+                    type(exc).__name__,
+                    exc,
+                    exc_info=not isinstance(exc, SkillError),
+                )
+                reason = (
+                    str(exc)
+                    if isinstance(exc, SkillError)
+                    else f"{type(exc).__name__}: {exc}"
+                )
+                return DiscoveryResult(
+                    failed=(decision.load, reason), decision=decision
+                )
+
+            unmet = self._unmet_tools(skill)
+            logger.info(
+                "[skills] auto-loaded '%s' for this turn%s",
+                decision.load,
+                f" (unmet tools_required: {', '.join(unmet)})" if unmet else "",
+            )
+            return DiscoveryResult(
+                loaded=decision.load, unmet_tools=unmet, decision=decision
+            )
+
+        return DiscoveryResult(shortlist=decision.shortlist, decision=decision)
+
+    def _unmet_tools(self, skill: "Skill") -> Tuple[str, ...]:
+        """Tools *skill* declares that this agent never registered.
+
+        ``tools_required`` is advisory — the base loader logs the gap and loads
+        the skill anyway — so a skill can activate cleanly and then die halfway
+        through its own recipe. Surfacing it here is what turns that into an
+        honest "I can't do this part" instead of an improvised substitute.
+        """
+        if self._tools_fn is None:
+            return ()
+        required = getattr(getattr(skill, "gaia", None), "tools_required", None) or []
+        if not required:
+            return ()
+        registry = self._tools_fn() or {}
+        return tuple(name for name in required if name not in registry)
+
+    def _decide(self, query: str, *, exclude) -> Decision:
+        """Rank with this instance's threshold, if one was configured."""
+        return self._retriever.decide(
+            query, exclude=exclude, min_score=self._threshold
+        )
+
+    def _log(self, decision: Decision, loaded: Dict[str, "Skill"]) -> None:
+        """One structured line per turn — the record a wrong answer is debugged from."""
+        logger.info(
+            "SKILL_DISCOVERY %s",
+            json.dumps(
+                {
+                    "turn": self._turn,
+                    "outcome": decision.outcome,
+                    "load": decision.load,
+                    "shortlist": list(decision.shortlist),
+                    "scores": {c.name: round(c.score, 3) for c in decision.ranked[:5]},
+                    "indexed": self._retriever.size,
+                    "already_loaded": sorted(loaded),
+                }
+            ),
+        )
+
+
+__all__ = [
+    "SkillDiscovery",
+    "DiscoveryResult",
+    "GROUNDING_RULE",
+    "DISCOVERY_ENV",
+    "DISCOVERY_THRESHOLD_ENV",
+    "discovery_env_override",
+]

--- a/src/gaia/agents/base/skill_discovery.py
+++ b/src/gaia/agents/base/skill_discovery.py
@@ -1,0 +1,337 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""Per-turn proactive skill discovery — find the right skill, load it, or say why not.
+
+:mod:`gaia.agents.base.skill_retriever` answers *which* installed skill a turn is
+about. This module is what an agent actually runs: it keeps the index fresh,
+applies the security gates a proactive load has to respect, performs the load,
+and renders the one short prompt fragment the model sees as a result.
+
+It runs **outside** the prompt. The system prompt never carries a catalogue of
+installed skills; matching happens in Python against frontmatter the agent
+already has in memory, and only the winner's body is injected. Against the
+flagship's measured ~17,000-token prompt the standing cost is the grounding rule
+below and nothing else — every other fragment appears only on the turns it
+applies to.
+
+Three outcomes, and the third is the point
+------------------------------------------
+1. **Loaded.** One skill cleared the bar; its instructions and tools are live and
+   the model is told to say so in a line.
+2. **Shortlisted.** Several plausible, none dominant. The model is handed the
+   names and calls ``load_skill`` itself. Never a coin-flip.
+3. **Could not load.** A skill matched and the load *failed* — an unbridged
+   permission, a missing CLI, a malformed manifest. This is the case that
+   motivated the whole module: the flagship, asked about a GitHub inbox with no
+   GitHub tools registered, answered confidently from its memory store. So the
+   failure is stated in the prompt as a refusal instruction, not swallowed.
+   A retrieval win that still lets the agent invent an answer is not a fix.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, Callable, Dict, Optional, Tuple
+
+from gaia.agents.base.skill_retriever import Decision, SkillRetriever
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    from gaia.skills.format import Skill
+    from gaia.skills.manager import SkillManager
+
+logger = logging.getLogger(__name__)
+
+#: Env override for the whole feature. Unset = on for agents that opt in.
+DISCOVERY_ENV = "GAIA_SKILL_DISCOVERY"
+
+#: Env override for :data:`~gaia.agents.base.skill_retriever.MIN_SCORE`.
+DISCOVERY_THRESHOLD_ENV = "GAIA_SKILL_DISCOVERY_TAU"
+
+#: The standing honesty rule — the only text this feature adds to every turn.
+#:
+#: It is deliberately about *sourcing*, not about skills: the failure it exists
+#: to stop ("what's been going on in my github inbox?" answered from the memory
+#: store, zero tools called) happens on exactly the turns where no skill matched,
+#: so a skills-only instruction would not have been in the prompt to prevent it.
+#:
+#: Cost is asserted in ``tests/unit/test_skill_discovery.py`` — see that test for
+#: the measured token count and why the ceiling sits where it does.
+GROUNDING_RULE = (
+    "==== SOURCING ====\n"
+    "Facts about live external state — a repository, an inbox, a calendar, a web "
+    "page, a file on disk — must come from a tool call in THIS turn. Memory, "
+    "training, and earlier turns are not sources for them. If no registered tool "
+    "can fetch what was asked, say you cannot and name what is missing. Never "
+    "answer from recollection, and never present an example as real data."
+)
+
+
+@dataclass(frozen=True)
+class DiscoveryResult:
+    """What discovery did this turn, and the prompt fragment it produced."""
+
+    #: Skill auto-loaded this turn, if any.
+    loaded: Optional[str] = None
+    #: Names offered to the model to load itself.
+    shortlist: Tuple[str, ...] = ()
+    #: ``(name, reason)`` when a confident match could not be loaded.
+    failed: Optional[Tuple[str, str]] = None
+    #: Tools the loaded skill declares but this agent does not have registered.
+    unmet_tools: Tuple[str, ...] = ()
+    #: The retriever's raw verdict, for logging and tests.
+    decision: Optional[Decision] = None
+
+    @property
+    def outcome(self) -> str:
+        """``"loaded"`` / ``"shortlist"`` / ``"failed"`` / ``"none"``."""
+        if self.failed:
+            return "failed"
+        if self.loaded:
+            return "loaded"
+        return "shortlist" if self.shortlist else "none"
+
+    def prompt_fragment(self) -> str:
+        """The turn-specific note, or "" when there is nothing to say."""
+        if self.failed:
+            name, reason = self.failed
+            return (
+                "==== SKILL UNAVAILABLE ====\n"
+                f"This request matches the '{name}' skill, but it could not be "
+                f"loaded: {reason}\n"
+                "You therefore do not have what this request needs. Tell the "
+                "user you cannot do it and give them that reason. Do not answer "
+                "from memory, and do not substitute a plausible-looking result."
+            )
+        if self.loaded:
+            note = (
+                "==== SKILL ACTIVATED ====\n"
+                f"'{self.loaded}' was selected for this request and its "
+                "instructions are in LOADED SKILLS. Follow them, and open your "
+                "reply by saying in one short line that you are using it."
+            )
+            if self.unmet_tools:
+                # ``tools_required`` is advisory at load time — the loader logs
+                # the gap and loads anyway. Unsaid, the model discovers it
+                # mid-recipe as a missing tool and improvises around it, which
+                # is the fabrication this module exists to stop.
+                note += (
+                    f"\nIt expects tool(s) {', '.join(self.unmet_tools)}, which "
+                    "are NOT registered here. The steps needing them cannot run: "
+                    "say so plainly instead of substituting something else."
+                )
+            return note
+        if self.shortlist:
+            names = ", ".join(f"'{n}'" for n in self.shortlist)
+            return (
+                "==== SKILLS THAT MAY FIT ====\n"
+                f"{names} are installed and may match this request, but none was "
+                "a clear enough match to activate on its own. If one of them is "
+                "what the user means, call load_skill on it before answering."
+            )
+        return ""
+
+
+class SkillDiscovery:
+    """Keeps the retrieval index fresh and turns one query into one action.
+
+    Holds no reference to an agent: :meth:`run` takes the loaded set and a load
+    callable, so it is exercisable in a unit test with no LLM, no Lemonade, and
+    no agent instance.
+    """
+
+    #: Roots excluded from proactive matching. ``.claude/skills`` is a read-only
+    #: import of another host's marketplace — skills written for Claude Code
+    #: working *on* a repo, not answers to a user's question. Indexing this
+    #: repo's own set made "what is the contract for this API endpoint?" match a
+    #: presentation-authoring skill (it documents "request/response contracts")
+    #: and "what does the function signature mean?" match an agent-scaffolding
+    #: skill. Those skills stay loadable by name; they are just not proposed.
+    EXCLUDED_ROOTS = frozenset({"claude-import"})
+
+    #: Consecutive load failures after which a skill stops being proposed for
+    #: the rest of the session. Without it a skill whose CLI is missing is
+    #: rediscovered and re-refused on every single turn.
+    MAX_FAILURES = 2
+
+    def __init__(
+        self,
+        manager: "SkillManager",
+        *,
+        retriever: Optional[SkillRetriever] = None,
+        threshold: Optional[float] = None,
+        tools_fn: Optional[Callable[[], Any]] = None,
+    ) -> None:
+        """Build the per-turn discoverer over *manager*'s discovery roots.
+
+        Args:
+            manager: The agent's :class:`~gaia.skills.manager.SkillManager`.
+            retriever: Injectable index, for tests.
+            threshold: Overrides the retriever module's ``MIN_SCORE``.
+            tools_fn: Returns the agent's live tool registry, used to report a
+                loaded skill's unmet ``tools_required``. A callable rather than
+                the mapping itself because registration is still in progress
+                when the agent constructs this. Omit to skip that check.
+        """
+        self._manager = manager
+        self._retriever = retriever if retriever is not None else SkillRetriever()
+        self._threshold = threshold
+        self._tools_fn = tools_fn
+        self._failures: Dict[str, int] = {}
+        self._turn = 0
+
+    # ── index ───────────────────────────────────────────────────────────────
+
+    def candidates(self) -> Dict[str, "Skill"]:
+        """Installed skills eligible to be proposed, by name.
+
+        Frontmatter only — :meth:`SkillManager.discover` caches, so a steady
+        session pays a dict comprehension per turn, not a directory walk.
+        """
+        return {
+            name: skill
+            for name, skill in self._manager.discover().items()
+            if skill.root not in self.EXCLUDED_ROOTS
+        }
+
+    def refresh(self) -> None:
+        """Reindex when the installed set has changed since the last build."""
+        skills = self.candidates()
+        if self._retriever.is_stale(skills):
+            self._retriever.index(skills)
+            logger.info(
+                "[skills] discovery index rebuilt: %d skill(s) — %s",
+                self._retriever.size,
+                ", ".join(self._retriever.names) or "(none)",
+            )
+
+    # ── the turn ────────────────────────────────────────────────────────────
+
+    def run(
+        self,
+        query: str,
+        *,
+        loaded: Dict[str, "Skill"],
+        load_fn: Callable[[str], "Skill"],
+    ) -> DiscoveryResult:
+        """Match *query*, act on the verdict, and return what to tell the model.
+
+        Args:
+            query: This turn's selection query — normally previous + current
+                user message, so a short follow-up still carries context.
+            loaded: The agent's already-loaded skills; excluded from matching,
+                since :mod:`~gaia.agents.base.skill_loader` governs those.
+            load_fn: ``Agent.load_skill``. Called at most once per turn.
+
+        Returns:
+            A :class:`DiscoveryResult`. Never raises for a skill-level failure —
+            a refused or broken skill becomes a ``failed`` result whose prompt
+            fragment instructs the model to refuse rather than improvise.
+        """
+        from gaia.skills.errors import SkillError
+
+        self._turn += 1
+        self.refresh()
+        if not self._retriever.size:
+            return DiscoveryResult()
+
+        burned = {n for n, c in self._failures.items() if c >= self.MAX_FAILURES}
+        decision = self._decide(query, exclude=set(loaded) | burned)
+        self._log(decision, loaded)
+
+        if decision.load:
+            try:
+                skill = load_fn(decision.load)
+            # Broad on purpose, and NOT a silent fallback: a proactive load runs
+            # code (``register_skill_tools`` imports a skill's ``tools.py``) on a
+            # turn the user did not ask for it, so one broken third-party skill
+            # must not take down an unrelated question. Nothing is swallowed —
+            # the reason is logged with its traceback AND stated to the model as
+            # an instruction to refuse. ``SkillError`` alone would leave
+            # ImportError, and every other import-time failure, crashing the turn.
+            except Exception as exc:  # noqa: BLE001
+                self._failures[decision.load] = self._failures.get(decision.load, 0) + 1
+                logger.warning(
+                    "[skills] '%s' matched this turn but would not load: %s: %s",
+                    decision.load,
+                    type(exc).__name__,
+                    exc,
+                    exc_info=not isinstance(exc, SkillError),
+                )
+                reason = (
+                    str(exc)
+                    if isinstance(exc, SkillError)
+                    else f"{type(exc).__name__}: {exc}"
+                )
+                return DiscoveryResult(
+                    failed=(decision.load, reason), decision=decision
+                )
+
+            unmet = self._unmet_tools(skill)
+            logger.info(
+                "[skills] auto-loaded '%s' for this turn%s",
+                decision.load,
+                f" (unmet tools_required: {', '.join(unmet)})" if unmet else "",
+            )
+            return DiscoveryResult(
+                loaded=decision.load, unmet_tools=unmet, decision=decision
+            )
+
+        return DiscoveryResult(shortlist=decision.shortlist, decision=decision)
+
+    def _unmet_tools(self, skill: "Skill") -> Tuple[str, ...]:
+        """Tools *skill* declares that this agent never registered.
+
+        ``tools_required`` is advisory — the base loader logs the gap and loads
+        the skill anyway — so a skill can activate cleanly and then die halfway
+        through its own recipe. Surfacing it here is what turns that into an
+        honest "I can't do this part" instead of an improvised substitute.
+        """
+        if self._tools_fn is None:
+            return ()
+        required = getattr(getattr(skill, "gaia", None), "tools_required", None) or []
+        if not required:
+            return ()
+        registry = self._tools_fn() or {}
+        return tuple(name for name in required if name not in registry)
+
+    def _decide(self, query: str, *, exclude) -> Decision:
+        """Rank with the threshold override applied, if one was configured."""
+        if self._threshold is None:
+            return self._retriever.decide(query, exclude=exclude)
+
+        from gaia.agents.base import skill_retriever as module
+
+        original = module.MIN_SCORE
+        module.MIN_SCORE = self._threshold
+        try:
+            return self._retriever.decide(query, exclude=exclude)
+        finally:
+            module.MIN_SCORE = original
+
+    def _log(self, decision: Decision, loaded: Dict[str, "Skill"]) -> None:
+        """One structured line per turn — the record a wrong answer is debugged from."""
+        logger.info(
+            "SKILL_DISCOVERY %s",
+            json.dumps(
+                {
+                    "turn": self._turn,
+                    "outcome": decision.outcome,
+                    "load": decision.load,
+                    "shortlist": list(decision.shortlist),
+                    "scores": {c.name: round(c.score, 3) for c in decision.ranked[:5]},
+                    "indexed": self._retriever.size,
+                    "already_loaded": sorted(loaded),
+                }
+            ),
+        )
+
+
+__all__ = [
+    "SkillDiscovery",
+    "DiscoveryResult",
+    "GROUNDING_RULE",
+    "DISCOVERY_ENV",
+    "DISCOVERY_THRESHOLD_ENV",
+]

--- a/src/gaia/agents/base/skill_discovery.py
+++ b/src/gaia/agents/base/skill_discovery.py
@@ -62,6 +62,7 @@ def discovery_env_override() -> Optional[bool]:
         return None
     return raw.strip().lower() in ("1", "true", "yes", "on")
 
+
 #: The standing honesty rule — the only text this feature adds to every turn.
 #:
 #: It is deliberately about *sourcing*, not about skills: the failure it exists
@@ -311,9 +312,7 @@ class SkillDiscovery:
 
     def _decide(self, query: str, *, exclude) -> Decision:
         """Rank with this instance's threshold, if one was configured."""
-        return self._retriever.decide(
-            query, exclude=exclude, min_score=self._threshold
-        )
+        return self._retriever.decide(query, exclude=exclude, min_score=self._threshold)
 
     def _log(self, decision: Decision, loaded: Dict[str, "Skill"]) -> None:
         """One structured line per turn — the record a wrong answer is debugged from."""

--- a/src/gaia/agents/base/skill_retriever.py
+++ b/src/gaia/agents/base/skill_retriever.py
@@ -1,0 +1,452 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""SkillRetriever — match a user's turn against skills that are installed but *not* loaded.
+
+The gap this closes
+-------------------
+:mod:`gaia.agents.base.skill_loader` decides which **already-loaded** skill's body
+renders this turn. Nothing decided which skill to load in the first place, so the
+agent only ever knew a skill existed once the user named it. Asked *"what's been
+going on in my github inbox?"* with ``github-triage`` sitting installed, the
+flagship called zero tools and answered from its memory store — a confident,
+entirely fabricated answer. Only ``"Load the github-triage skill."`` worked.
+
+Users do not know skill names. This module makes the *description* the index.
+
+Why lexical, not embeddings
+---------------------------
+Every installed skill already carries a ``description`` written to be matched on
+("Use when the user asks to triage issues, review a backlog…"). Against that
+corpus a normalized BM25 is the right tool, and the reasons are measurable rather
+than aesthetic:
+
+* **Corpus size.** ~10-25 skills. An ANN index is overhead with no recall to buy.
+* **Latency.** This runs on *every* turn, before the first token. Scoring is
+  pure-Python over a prebuilt index and measures in tens of microseconds; an
+  embedding call is a network round-trip to a single-slot backend.
+  :mod:`gaia.agents.base.skill_loader` can afford one because it short-circuits
+  when nothing is loaded — the discovery path cannot, it runs precisely when
+  *nothing* is loaded.
+* **Failure mode.** An embedder outage disables selection (see
+  ``SkillLoader.session_disabled``). A lexical index has no runtime dependency
+  to lose.
+
+``tests/unit/test_skill_retriever.py`` carries the labeled benchmark this is
+calibrated against; every constant below moves its numbers.
+
+Confidence, not guessing
+------------------------
+:meth:`SkillRetriever.rank` returns scored candidates;
+:meth:`SkillRetriever.decide` turns them into exactly one of three outcomes:
+
+``AUTO``       one skill clears the score floor, carries enough rare-term
+               evidence, and beats the runner-up by a margin — load it.
+``SHORTLIST``  several plausible, none dominant — name them to the model and
+               let it call ``load_skill``, rather than picking for it.
+``NONE``       no real lexical evidence — proceed with no skill.
+
+The margin rule is what keeps "never guess" honest: a tie is reported as a tie.
+"""
+
+from __future__ import annotations
+
+import math
+import re
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Dict, FrozenSet, Iterable, List, Optional, Tuple
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    from gaia.skills.format import Skill
+
+# ── tuning constants ────────────────────────────────────────────────────────
+# Calibrated against the labeled query set in tests/unit/test_skill_retriever.py.
+# Changing one without re-running that benchmark is how a silent recall
+# regression ships.
+
+#: BM25 term-frequency saturation. Standard Okapi defaults.
+K1 = 1.2
+B = 0.75
+
+#: How many times a skill's own *name* tokens are folded into its document.
+#: "triage my github inbox" should beat a skill that merely mentions GitHub in
+#: passing; the name is the strongest single signal a skill carries.
+NAME_WEIGHT = 3
+
+#: Fraction of the query's total discriminative mass the winner must capture.
+#: At 0.50 a skill has to account for half of what the query is *about* before
+#: it loads on its own.
+MIN_SCORE = 0.50
+
+#: IDF mass the winner's matched terms must carry, as a fraction of the rarest
+#: term in the corpus — so a match built entirely from terms that appear in
+#: nearly every skill cannot win.
+#:
+#: A *fraction*, not an absolute, because IDF scales with corpus size: a
+#: one-skill-only term is worth 1.39 in a 5-skill library and 2.93 in a 30-skill
+#: one. An absolute floor of 1.5 silently disabled auto-load entirely for small
+#: libraries — "anything new on github?" scored 0.75 and still refused to load,
+#: because the corpus was too small for any term to be worth 1.5.
+MIN_IDF_FRACTION = 0.6
+
+#: How far ahead of the runner-up the winner must be to auto-load. Below this
+#: the result is a SHORTLIST — reported, never resolved by coin-flip.
+#:
+#: 1.3 is where the joint sweep's auto-recall peaks (0.742 vs 0.710) at the same
+#: zero false loads, but the whole gap is one query that shortlists instead of
+#: loading, and shortlist recall is identical either way. The wider margin buys
+#: insurance against queries the benchmark does not contain for a cost of one
+#: extra tool call on one query — take the insurance.
+MARGIN = 1.5
+
+#: Cap on how many near-misses are named to the model. Each costs prompt tokens,
+#: and a list long enough to need scanning is not a shortlist.
+MAX_SHORTLIST = 3
+
+#: Distinct query terms a candidate must match to count as evidence when none of
+#: them is *strong* (see :data:`_WEAK_ALONE`).
+MIN_MATCHED_TERMS = 2
+
+#: Verbs that describe what an assistant does rather than what a skill is about.
+#:
+#: Every false auto-load the benchmark produced had the same shape: one generic
+#: verb from a description and nothing else — ``remember`` pulling in
+#: ``source-watch`` for "remember my favourite colour is teal", ``explain``
+#: pulling in ``coding`` for a question about mutexes, ``write`` pulling in
+#: ``research-report`` for a haiku. Normalizing by the query's *known* terms makes
+#: a lone match look like total agreement, because the words the corpus never
+#: heard of are exactly the ones proving the query is about something else.
+#:
+#: IDF cannot separate these: in an 11-skill corpus ``remember`` and ``contract``
+#: both appear in exactly one description, so both score 2.08. What separates
+#: them is that one names the *work* and the other names the *subject*. This set
+#: is therefore small and deliberately verb-only — a noun goes in it only over a
+#: benchmark regression.
+#:
+#: A term here is still full evidence when it is part of the skill's own name
+#: (``check`` for ``check-in``), because a name is identity, not description.
+_WEAK_ALONE = frozenset("""
+add answer apply build call change check choose compose create draft edit explain
+find fix follow generate handle keep know list look manage open pick prepare produce
+provide put read record remember review run save say search see send set show start
+stop support tell think try turn update work write
+""".split())
+
+#: Score a candidate needs to reach to be worth naming at all.
+SHORTLIST_FLOOR = 0.18
+
+#: How much a query word the corpus has never seen counts *against* a match,
+#: as a fraction of the rarest-term IDF.
+#:
+#: Without this the denominator is built only from terms the corpus knows, so
+#: "what is the contract for this API endpoint?" scored 0.70 for ``xlsx`` — one
+#: incidental ``api`` out of three content words looked like near-total
+#: agreement, because the two words that prove the query is about something else
+#: were simply discarded. An unseen word is not neutral evidence: in this corpus
+#: it is maximally rare, and it discriminates against every skill at once.
+UNKNOWN_WEIGHT = 0.6
+
+_WORD = re.compile(r"[a-z0-9]+")
+
+#: Closed-class words plus the vocabulary of *asking*. "use", "when", "user" and
+#: "skill" appear in nearly every SKILL.md description by convention, so they
+#: carry no discriminative signal and only inflate the denominator.
+_STOPWORDS = frozenset("""
+a about above after again against all also am an and any are as at be because been
+before being below between both but by can cannot could did do does doing don down
+during each few for from further had has have having he her here hers herself him
+himself his how i if in into is it its itself just me more most my myself no nor not
+now of off on once only or other ought our ours ourselves out over own same she should
+so some such than that the their theirs them themselves then there these they this
+those through to too under until up very was we were what when where which while who
+whom why with would you your yours yourself yourselves
+use uses used using user users skill skills agent asks ask asked need needs want wants
+please help make makes made get gets got give gives take takes let lets thing things
+mean means meaning kind sort lot bit way ways one two
+yes no ok okay sure yeah yep nope thanks thank hi hello hey cool great nice go ahead
+please anything something nothing everything
+""".split())
+
+#: Deliberately tiny and suffix-only. A real stemmer would need a dependency and
+#: conflates words this corpus needs kept apart.
+_SUFFIXES = ("ing", "ed", "es", "s")
+
+#: Shortest a stem may be. Below this, suffix stripping starts merging unrelated
+#: words ("gas" -> "ga") and a three-letter stem matches far too much.
+_MIN_STEM = 3
+
+
+def _stem(word: str) -> str:
+    """Strip a common English suffix, never taking a word below :data:`_MIN_STEM`."""
+    if word.endswith("ies") and len(word) > 5:
+        return word[:-3] + "y"
+    for suffix in _SUFFIXES:
+        if word.endswith(suffix) and len(word) - len(suffix) >= _MIN_STEM:
+            return word[: -len(suffix)]
+    return word
+
+
+def tokenize(text: str) -> List[str]:
+    """Lowercase alphanumeric tokens, stopwords dropped, lightly stemmed."""
+    return [
+        _stem(word)
+        for word in _WORD.findall((text or "").lower())
+        if word not in _STOPWORDS and len(word) > 1
+    ]
+
+
+def _name_tokens(name: str) -> List[str]:
+    """A skill name's own words — ``github-triage`` -> ``["github", "triage"]``."""
+    return [_stem(part) for part in _WORD.findall((name or "").lower()) if part]
+
+
+@dataclass(frozen=True)
+class SkillCandidate:
+    """One scored skill from :meth:`SkillRetriever.rank`."""
+
+    name: str
+    #: Fraction of the query's corpus-relevant IDF mass this skill matched, in [0, 1].
+    score: float
+    #: Absolute IDF mass of the matched terms — the "is this real evidence" check.
+    idf_mass: float
+    #: The query terms that hit this skill, rarest first.
+    matched: Tuple[str, ...] = ()
+    #: Whether any matched term is a token of the skill's own name.
+    name_hit: bool = False
+    #: Matched terms that are not generic assistant verbs, or that name the skill.
+    strong: Tuple[str, ...] = ()
+
+    @property
+    def has_evidence(self) -> bool:
+        """Whether this match is about the skill's subject, not just its verbs.
+
+        One term naming the subject ("contract", "csv", "github") is evidence;
+        one generic verb ("write", "explain") is not, however rare it happens to
+        be in a small corpus. See :data:`_WEAK_ALONE`.
+        """
+        return bool(self.strong) or len(self.matched) >= MIN_MATCHED_TERMS
+
+    def __str__(self) -> str:  # pragma: no cover - logging convenience
+        return f"{self.name}={self.score:.2f}"
+
+
+@dataclass(frozen=True)
+class Decision:
+    """What the retriever concluded for one turn.
+
+    At most one of *load* / *shortlist* is populated; both empty means "no skill
+    is relevant, proceed as normal".
+    """
+
+    #: The single skill confident enough to load without asking, or ``None``.
+    load: Optional[str] = None
+    #: Plausible-but-not-dominant names to offer the model, best first.
+    shortlist: Tuple[str, ...] = ()
+    #: Every scored candidate, best first — for logging and tests.
+    ranked: Tuple[SkillCandidate, ...] = field(default=())
+
+    @property
+    def outcome(self) -> str:
+        """``"auto"`` / ``"shortlist"`` / ``"none"`` — for logs and assertions."""
+        if self.load:
+            return "auto"
+        return "shortlist" if self.shortlist else "none"
+
+
+class SkillRetriever:
+    """Normalized-BM25 index over installed skills' ``name`` + ``description``.
+
+    Build it from whatever :class:`~gaia.skills.manager.SkillManager` discovered
+    (frontmatter only — bodies are never read here, so indexing a whole library
+    costs one directory scan). Rebuild with :meth:`index` when the installed set
+    changes; scoring allocates nothing per query beyond the query's token list.
+    """
+
+    def __init__(self, skills: Optional[Dict[str, "Skill"]] = None) -> None:
+        self._docs: Dict[str, List[str]] = {}
+        self._tf: Dict[str, Dict[str, int]] = {}
+        self._idf: Dict[str, float] = {}
+        self._doc_len: Dict[str, float] = {}
+        self._name_terms: Dict[str, FrozenSet[str]] = {}
+        self._avg_len: float = 1.0
+        self._max_idf: float = 0.0
+        self._fingerprint: Tuple = ()
+        if skills:
+            self.index(skills)
+
+    # ── indexing ────────────────────────────────────────────────────────────
+
+    @property
+    def size(self) -> int:
+        """Number of indexed skills."""
+        return len(self._docs)
+
+    @property
+    def names(self) -> List[str]:
+        """Indexed skill names, sorted."""
+        return sorted(self._docs)
+
+    @staticmethod
+    def fingerprint(skills: Dict[str, "Skill"]) -> Tuple:
+        """Cheap identity of an installed set — reindex only when this changes."""
+        return tuple(
+            sorted((name, (skill.description or "")) for name, skill in skills.items())
+        )
+
+    def index(self, skills: Dict[str, "Skill"]) -> None:
+        """(Re)build the index from ``{name: Skill}`` metadata."""
+        self.index_texts(
+            {name: (skill.description or "") for name, skill in skills.items()}
+        )
+        self._fingerprint = self.fingerprint(skills)
+
+    def index_texts(self, descriptions: Dict[str, str]) -> None:
+        """(Re)build the index from ``{name: description}`` — the testable core."""
+        self._docs = {}
+        self._tf = {}
+        self._doc_len = {}
+        self._name_terms = {}
+        for name, description in descriptions.items():
+            own = _name_tokens(name)
+            self._name_terms[name] = frozenset(own)
+            tokens = own * NAME_WEIGHT + tokenize(description)
+            self._docs[name] = tokens
+            counts: Dict[str, int] = {}
+            for token in tokens:
+                counts[token] = counts.get(token, 0) + 1
+            self._tf[name] = counts
+            self._doc_len[name] = float(len(tokens))
+
+        total = len(self._docs)
+        self._avg_len = (sum(self._doc_len.values()) / total if total else 0.0) or 1.0
+
+        df: Dict[str, int] = {}
+        for counts in self._tf.values():
+            for token in counts:
+                df[token] = df.get(token, 0) + 1
+        # Always-positive IDF (the Lucene / BM25+ variant). The textbook form
+        # goes negative for a term in more than half the corpus, which with
+        # N=20 would let a common word *subtract* from a genuine match.
+        self._idf = {
+            token: math.log(1.0 + (total - count + 0.5) / (count + 0.5))
+            for token, count in df.items()
+        }
+        # The IDF an unseen term is charged at — a term in exactly one skill.
+        self._max_idf = max(self._idf.values(), default=0.0)
+
+    def is_stale(self, skills: Dict[str, "Skill"]) -> bool:
+        """True when *skills* differs from what is currently indexed."""
+        return self.fingerprint(skills) != self._fingerprint
+
+    # ── scoring ─────────────────────────────────────────────────────────────
+
+    def rank(self, query: str, *, exclude: Iterable[str] = ()) -> List[SkillCandidate]:
+        """Score every indexed skill against *query*, best first.
+
+        Args:
+            query: The user's turn (optionally with prior context prepended).
+            exclude: Names to leave out — normally the already-loaded set.
+
+        Returns:
+            Candidates with a non-zero score, sorted by score then name so equal
+            scores order deterministically.
+        """
+        if not self._docs:
+            return []
+        skip = set(exclude)
+
+        # The denominator is the query's whole discriminative mass, not just
+        # the part this corpus happens to know. Terms it has never seen are
+        # charged at UNKNOWN_WEIGHT x the rarest known IDF — see that constant
+        # for why discarding them turns one incidental hit into a 0.70.
+        all_terms = list(dict.fromkeys(tokenize(query)))
+        terms = [t for t in all_terms if t in self._idf]
+        if not terms:
+            return []
+        unknown = len(all_terms) - len(terms)
+        query_mass = sum(self._idf[t] for t in terms) + (
+            unknown * UNKNOWN_WEIGHT * self._max_idf
+        )
+        if query_mass <= 0:
+            return []
+
+        results: List[SkillCandidate] = []
+        for name, counts in self._tf.items():
+            if name in skip:
+                continue
+            norm = K1 * (1.0 - B + B * self._doc_len[name] / self._avg_len)
+            raw = 0.0
+            mass = 0.0
+            hits: List[Tuple[float, str]] = []
+            for term in terms:
+                tf = counts.get(term, 0)
+                if not tf:
+                    continue
+                idf = self._idf[term]
+                raw += idf * (tf * (K1 + 1.0)) / (tf + norm)
+                mass += idf
+                hits.append((idf, term))
+            if raw <= 0:
+                continue
+            hits.sort(reverse=True)
+            matched = tuple(term for _, term in hits)
+            own = self._name_terms[name]
+            results.append(
+                SkillCandidate(
+                    name=name,
+                    score=min(raw / query_mass, 1.0),
+                    idf_mass=mass,
+                    matched=matched,
+                    name_hit=bool(own.intersection(matched)),
+                    strong=tuple(
+                        t for t in matched if t in own or t not in _WEAK_ALONE
+                    ),
+                )
+            )
+        results.sort(key=lambda c: (-c.score, c.name))
+        return results
+
+    def decide(self, query: str, *, exclude: Iterable[str] = ()) -> Decision:
+        """Rank, then apply the confidence bar. See the module docstring."""
+        ranked = self.rank(query, exclude=exclude)
+        if not ranked:
+            return Decision(ranked=())
+
+        # Drop matches built only from generic assistant verbs before anything
+        # ranks — they are noise for auto-load and for the shortlist alike, and
+        # leaving them in would put "source-watch" in front of the model on a
+        # turn about the user's favourite colour.
+        credible = [c for c in ranked if c.has_evidence]
+        if not credible:
+            return Decision(ranked=tuple(ranked))
+
+        top = credible[0]
+        runner_up = credible[1].score if len(credible) > 1 else 0.0
+        confident = (
+            top.score >= MIN_SCORE
+            and top.idf_mass >= MIN_IDF_FRACTION * self._max_idf
+            and top.score >= runner_up * MARGIN
+        )
+        if confident:
+            return Decision(load=top.name, ranked=tuple(ranked))
+
+        shortlist = tuple(
+            c.name for c in credible[:MAX_SHORTLIST] if c.score >= SHORTLIST_FLOOR
+        )
+        return Decision(shortlist=shortlist, ranked=tuple(ranked))
+
+
+__all__ = [
+    "SkillRetriever",
+    "SkillCandidate",
+    "Decision",
+    "tokenize",
+    "MIN_SCORE",
+    "MIN_IDF_FRACTION",
+    "MARGIN",
+    "MAX_SHORTLIST",
+    "MIN_MATCHED_TERMS",
+    "MIN_IDF_FRACTION",
+    "SHORTLIST_FLOOR",
+    "UNKNOWN_WEIGHT",
+    "NAME_WEIGHT",
+]

--- a/src/gaia/agents/base/skill_retriever.py
+++ b/src/gaia/agents/base/skill_retriever.py
@@ -1,0 +1,463 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""SkillRetriever — match a user's turn against skills that are installed but *not* loaded.
+
+The gap this closes
+-------------------
+:mod:`gaia.agents.base.skill_loader` decides which **already-loaded** skill's body
+renders this turn. Nothing decided which skill to load in the first place, so the
+agent only ever knew a skill existed once the user named it. Asked *"what's been
+going on in my github inbox?"* with ``github-triage`` sitting installed, the
+flagship called zero tools and answered from its memory store — a confident,
+entirely fabricated answer. Only ``"Load the github-triage skill."`` worked.
+
+Users do not know skill names. This module makes the *description* the index.
+
+Why lexical, not embeddings
+---------------------------
+Every installed skill already carries a ``description`` written to be matched on
+("Use when the user asks to triage issues, review a backlog…"). Against that
+corpus a normalized BM25 is the right tool, and the reasons are measurable rather
+than aesthetic:
+
+* **Corpus size.** ~10-25 skills. An ANN index is overhead with no recall to buy.
+* **Latency.** This runs on *every* turn, before the first token. Scoring is
+  pure-Python over a prebuilt index and measures in tens of microseconds; an
+  embedding call is a network round-trip to a single-slot backend.
+  :mod:`gaia.agents.base.skill_loader` can afford one because it short-circuits
+  when nothing is loaded — the discovery path cannot, it runs precisely when
+  *nothing* is loaded.
+* **Failure mode.** An embedder outage disables selection (see
+  ``SkillLoader.session_disabled``). A lexical index has no runtime dependency
+  to lose.
+
+``tests/unit/test_skill_retriever.py`` carries the labeled benchmark this is
+calibrated against; every constant below moves its numbers.
+
+Confidence, not guessing
+------------------------
+:meth:`SkillRetriever.rank` returns scored candidates;
+:meth:`SkillRetriever.decide` turns them into exactly one of three outcomes:
+
+``AUTO``       one skill clears the score floor, carries enough rare-term
+               evidence, and beats the runner-up by a margin — load it.
+``SHORTLIST``  several plausible, none dominant — name them to the model and
+               let it call ``load_skill``, rather than picking for it.
+``NONE``       no real lexical evidence — proceed with no skill.
+
+The margin rule is what keeps "never guess" honest: a tie is reported as a tie.
+"""
+
+from __future__ import annotations
+
+import math
+import re
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Dict, FrozenSet, Iterable, List, Optional, Tuple
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    from gaia.skills.format import Skill
+
+# ── tuning constants ────────────────────────────────────────────────────────
+# Calibrated against the labeled query set in tests/unit/test_skill_retriever.py.
+# Changing one without re-running that benchmark is how a silent recall
+# regression ships.
+
+#: BM25 term-frequency saturation. Standard Okapi defaults.
+K1 = 1.2
+B = 0.75
+
+#: How many times a skill's own *name* tokens are folded into its document.
+#: "triage my github inbox" should beat a skill that merely mentions GitHub in
+#: passing; the name is the strongest single signal a skill carries.
+NAME_WEIGHT = 3
+
+#: Fraction of the query's total discriminative mass the winner must capture.
+#: At 0.50 a skill has to account for half of what the query is *about* before
+#: it loads on its own.
+MIN_SCORE = 0.50
+
+#: IDF mass the winner's matched terms must carry, as a fraction of the rarest
+#: term in the corpus — so a match built entirely from terms that appear in
+#: nearly every skill cannot win.
+#:
+#: A *fraction*, not an absolute, because IDF scales with corpus size: a
+#: one-skill-only term is worth 1.39 in a 5-skill library and 2.93 in a 30-skill
+#: one. An absolute floor of 1.5 silently disabled auto-load entirely for small
+#: libraries — "anything new on github?" scored 0.75 and still refused to load,
+#: because the corpus was too small for any term to be worth 1.5.
+MIN_IDF_FRACTION = 0.6
+
+#: How far ahead of the runner-up the winner must be to auto-load. Below this
+#: the result is a SHORTLIST — reported, never resolved by coin-flip.
+#:
+#: 1.3 is where the joint sweep's auto-recall peaks (0.742 vs 0.710) at the same
+#: zero false loads, but the whole gap is one query that shortlists instead of
+#: loading, and shortlist recall is identical either way. The wider margin buys
+#: insurance against queries the benchmark does not contain for a cost of one
+#: extra tool call on one query — take the insurance.
+MARGIN = 1.5
+
+#: Cap on how many near-misses are named to the model. Each costs prompt tokens,
+#: and a list long enough to need scanning is not a shortlist.
+MAX_SHORTLIST = 3
+
+#: Distinct query terms a candidate must match to count as evidence when none of
+#: them is *strong* (see :data:`_WEAK_ALONE`).
+MIN_MATCHED_TERMS = 2
+
+#: Verbs that describe what an assistant does rather than what a skill is about.
+#:
+#: Every false auto-load the benchmark produced had the same shape: one generic
+#: verb from a description and nothing else — ``remember`` pulling in
+#: ``source-watch`` for "remember my favourite colour is teal", ``explain``
+#: pulling in ``coding`` for a question about mutexes, ``write`` pulling in
+#: ``research-report`` for a haiku. Normalizing by the query's *known* terms makes
+#: a lone match look like total agreement, because the words the corpus never
+#: heard of are exactly the ones proving the query is about something else.
+#:
+#: IDF cannot separate these: in an 11-skill corpus ``remember`` and ``contract``
+#: both appear in exactly one description, so both score 2.08. What separates
+#: them is that one names the *work* and the other names the *subject*. This set
+#: is therefore small and deliberately verb-only — a noun goes in it only over a
+#: benchmark regression.
+#:
+#: A term here is still full evidence when it is part of the skill's own name
+#: (``check`` for ``check-in``), because a name is identity, not description.
+_WEAK_ALONE = frozenset("""
+add answer apply build call change check choose compose create draft edit explain
+find fix follow generate handle keep know list look manage open pick prepare produce
+provide put read record remember review run save say search see send set show start
+stop support tell think try turn update work write
+""".split())
+
+#: Score a candidate needs to reach to be worth naming at all.
+SHORTLIST_FLOOR = 0.18
+
+#: How much a query word the corpus has never seen counts *against* a match,
+#: as a fraction of the rarest-term IDF.
+#:
+#: Without this the denominator is built only from terms the corpus knows, so
+#: "what is the contract for this API endpoint?" scored 0.70 for ``xlsx`` — one
+#: incidental ``api`` out of three content words looked like near-total
+#: agreement, because the two words that prove the query is about something else
+#: were simply discarded. An unseen word is not neutral evidence: in this corpus
+#: it is maximally rare, and it discriminates against every skill at once.
+UNKNOWN_WEIGHT = 0.6
+
+_WORD = re.compile(r"[a-z0-9]+")
+
+#: Closed-class words plus the vocabulary of *asking*. "use", "when", "user" and
+#: "skill" appear in nearly every SKILL.md description by convention, so they
+#: carry no discriminative signal and only inflate the denominator.
+_STOPWORDS = frozenset("""
+a about above after again against all also am an and any are as at be because been
+before being below between both but by can cannot could did do does doing don down
+during each few for from further had has have having he her here hers herself him
+himself his how i if in into is it its itself just me more most my myself no nor not
+now of off on once only or other ought our ours ourselves out over own same she should
+so some such than that the their theirs them themselves then there these they this
+those through to too under until up very was we were what when where which while who
+whom why with would you your yours yourself yourselves
+use uses used using user users skill skills agent asks ask asked need needs want wants
+please help make makes made get gets got give gives take takes let lets thing things
+mean means meaning kind sort lot bit way ways one two
+yes no ok okay sure yeah yep nope thanks thank hi hello hey cool great nice go ahead
+please anything something nothing everything
+""".split())
+
+#: Deliberately tiny and suffix-only. A real stemmer would need a dependency and
+#: conflates words this corpus needs kept apart.
+_SUFFIXES = ("ing", "ed", "es", "s")
+
+#: Shortest a stem may be. Below this, suffix stripping starts merging unrelated
+#: words ("gas" -> "ga") and a three-letter stem matches far too much.
+_MIN_STEM = 3
+
+
+def _stem(word: str) -> str:
+    """Strip a common English suffix, never taking a word below :data:`_MIN_STEM`."""
+    if word.endswith("ies") and len(word) > 5:
+        return word[:-3] + "y"
+    for suffix in _SUFFIXES:
+        if word.endswith(suffix) and len(word) - len(suffix) >= _MIN_STEM:
+            return word[: -len(suffix)]
+    return word
+
+
+def tokenize(text: str) -> List[str]:
+    """Lowercase alphanumeric tokens, stopwords dropped, lightly stemmed."""
+    return [
+        _stem(word)
+        for word in _WORD.findall((text or "").lower())
+        if word not in _STOPWORDS and len(word) > 1
+    ]
+
+
+def _name_tokens(name: str) -> List[str]:
+    """A skill name's own words — ``github-triage`` -> ``["github", "triage"]``."""
+    return [_stem(part) for part in _WORD.findall((name or "").lower()) if part]
+
+
+@dataclass(frozen=True)
+class SkillCandidate:
+    """One scored skill from :meth:`SkillRetriever.rank`."""
+
+    name: str
+    #: Fraction of the query's corpus-relevant IDF mass this skill matched, in [0, 1].
+    score: float
+    #: Absolute IDF mass of the matched terms — the "is this real evidence" check.
+    idf_mass: float
+    #: The query terms that hit this skill, rarest first.
+    matched: Tuple[str, ...] = ()
+    #: Whether any matched term is a token of the skill's own name.
+    name_hit: bool = False
+    #: Matched terms that are not generic assistant verbs, or that name the skill.
+    strong: Tuple[str, ...] = ()
+
+    @property
+    def has_evidence(self) -> bool:
+        """Whether this match is about the skill's subject, not just its verbs.
+
+        One term naming the subject ("contract", "csv", "github") is evidence;
+        one generic verb ("write", "explain") is not, however rare it happens to
+        be in a small corpus. See :data:`_WEAK_ALONE`.
+        """
+        return bool(self.strong) or len(self.matched) >= MIN_MATCHED_TERMS
+
+    def __str__(self) -> str:  # pragma: no cover - logging convenience
+        return f"{self.name}={self.score:.2f}"
+
+
+@dataclass(frozen=True)
+class Decision:
+    """What the retriever concluded for one turn.
+
+    At most one of *load* / *shortlist* is populated; both empty means "no skill
+    is relevant, proceed as normal".
+    """
+
+    #: The single skill confident enough to load without asking, or ``None``.
+    load: Optional[str] = None
+    #: Plausible-but-not-dominant names to offer the model, best first.
+    shortlist: Tuple[str, ...] = ()
+    #: Every scored candidate, best first — for logging and tests.
+    ranked: Tuple[SkillCandidate, ...] = field(default=())
+
+    @property
+    def outcome(self) -> str:
+        """``"auto"`` / ``"shortlist"`` / ``"none"`` — for logs and assertions."""
+        if self.load:
+            return "auto"
+        return "shortlist" if self.shortlist else "none"
+
+
+class SkillRetriever:
+    """Normalized-BM25 index over installed skills' ``name`` + ``description``.
+
+    Build it from whatever :class:`~gaia.skills.manager.SkillManager` discovered
+    (frontmatter only — bodies are never read here, so indexing a whole library
+    costs one directory scan). Rebuild with :meth:`index` when the installed set
+    changes; scoring allocates nothing per query beyond the query's token list.
+    """
+
+    def __init__(self, skills: Optional[Dict[str, "Skill"]] = None) -> None:
+        self._docs: Dict[str, List[str]] = {}
+        self._tf: Dict[str, Dict[str, int]] = {}
+        self._idf: Dict[str, float] = {}
+        self._doc_len: Dict[str, float] = {}
+        self._name_terms: Dict[str, FrozenSet[str]] = {}
+        self._avg_len: float = 1.0
+        self._max_idf: float = 0.0
+        self._fingerprint: Tuple = ()
+        if skills:
+            self.index(skills)
+
+    # ── indexing ────────────────────────────────────────────────────────────
+
+    @property
+    def size(self) -> int:
+        """Number of indexed skills."""
+        return len(self._docs)
+
+    @property
+    def names(self) -> List[str]:
+        """Indexed skill names, sorted."""
+        return sorted(self._docs)
+
+    @staticmethod
+    def fingerprint(skills: Dict[str, "Skill"]) -> Tuple:
+        """Cheap identity of an installed set — reindex only when this changes."""
+        return tuple(
+            sorted((name, (skill.description or "")) for name, skill in skills.items())
+        )
+
+    def index(self, skills: Dict[str, "Skill"]) -> None:
+        """(Re)build the index from ``{name: Skill}`` metadata."""
+        self.index_texts(
+            {name: (skill.description or "") for name, skill in skills.items()}
+        )
+        self._fingerprint = self.fingerprint(skills)
+
+    def index_texts(self, descriptions: Dict[str, str]) -> None:
+        """(Re)build the index from ``{name: description}`` — the testable core."""
+        self._docs = {}
+        self._tf = {}
+        self._doc_len = {}
+        self._name_terms = {}
+        for name, description in descriptions.items():
+            own = _name_tokens(name)
+            self._name_terms[name] = frozenset(own)
+            tokens = own * NAME_WEIGHT + tokenize(description)
+            self._docs[name] = tokens
+            counts: Dict[str, int] = {}
+            for token in tokens:
+                counts[token] = counts.get(token, 0) + 1
+            self._tf[name] = counts
+            self._doc_len[name] = float(len(tokens))
+
+        total = len(self._docs)
+        self._avg_len = (sum(self._doc_len.values()) / total if total else 0.0) or 1.0
+
+        df: Dict[str, int] = {}
+        for counts in self._tf.values():
+            for token in counts:
+                df[token] = df.get(token, 0) + 1
+        # Always-positive IDF (the Lucene / BM25+ variant). The textbook form
+        # goes negative for a term in more than half the corpus, which with
+        # N=20 would let a common word *subtract* from a genuine match.
+        self._idf = {
+            token: math.log(1.0 + (total - count + 0.5) / (count + 0.5))
+            for token, count in df.items()
+        }
+        # The IDF an unseen term is charged at — a term in exactly one skill.
+        self._max_idf = max(self._idf.values(), default=0.0)
+
+    def is_stale(self, skills: Dict[str, "Skill"]) -> bool:
+        """True when *skills* differs from what is currently indexed."""
+        return self.fingerprint(skills) != self._fingerprint
+
+    # ── scoring ─────────────────────────────────────────────────────────────
+
+    def rank(self, query: str, *, exclude: Iterable[str] = ()) -> List[SkillCandidate]:
+        """Score every indexed skill against *query*, best first.
+
+        Args:
+            query: The user's turn (optionally with prior context prepended).
+            exclude: Names to leave out — normally the already-loaded set.
+
+        Returns:
+            Candidates with a non-zero score, sorted by score then name so equal
+            scores order deterministically.
+        """
+        if not self._docs:
+            return []
+        skip = set(exclude)
+
+        # The denominator is the query's whole discriminative mass, not just
+        # the part this corpus happens to know. Terms it has never seen are
+        # charged at UNKNOWN_WEIGHT x the rarest known IDF — see that constant
+        # for why discarding them turns one incidental hit into a 0.70.
+        all_terms = list(dict.fromkeys(tokenize(query)))
+        terms = [t for t in all_terms if t in self._idf]
+        if not terms:
+            return []
+        unknown = len(all_terms) - len(terms)
+        query_mass = sum(self._idf[t] for t in terms) + (
+            unknown * UNKNOWN_WEIGHT * self._max_idf
+        )
+        if query_mass <= 0:
+            return []
+
+        results: List[SkillCandidate] = []
+        for name, counts in self._tf.items():
+            if name in skip:
+                continue
+            norm = K1 * (1.0 - B + B * self._doc_len[name] / self._avg_len)
+            raw = 0.0
+            mass = 0.0
+            hits: List[Tuple[float, str]] = []
+            for term in terms:
+                tf = counts.get(term, 0)
+                if not tf:
+                    continue
+                idf = self._idf[term]
+                raw += idf * (tf * (K1 + 1.0)) / (tf + norm)
+                mass += idf
+                hits.append((idf, term))
+            if raw <= 0:
+                continue
+            hits.sort(reverse=True)
+            matched = tuple(term for _, term in hits)
+            own = self._name_terms[name]
+            results.append(
+                SkillCandidate(
+                    name=name,
+                    score=min(raw / query_mass, 1.0),
+                    idf_mass=mass,
+                    matched=matched,
+                    name_hit=bool(own.intersection(matched)),
+                    strong=tuple(
+                        t for t in matched if t in own or t not in _WEAK_ALONE
+                    ),
+                )
+            )
+        results.sort(key=lambda c: (-c.score, c.name))
+        return results
+
+    def decide(
+        self,
+        query: str,
+        *,
+        exclude: Iterable[str] = (),
+        min_score: Optional[float] = None,
+    ) -> Decision:
+        """Rank, then apply the confidence bar. See the module docstring.
+
+        ``min_score`` overrides :data:`MIN_SCORE` for this call only — the bar is
+        per-caller, so it must not be smuggled through module state that a
+        concurrent agent in the same process would observe.
+        """
+        floor = MIN_SCORE if min_score is None else min_score
+        ranked = self.rank(query, exclude=exclude)
+        if not ranked:
+            return Decision(ranked=())
+
+        # Drop matches built only from generic assistant verbs before anything
+        # ranks — they are noise for auto-load and for the shortlist alike, and
+        # leaving them in would put "source-watch" in front of the model on a
+        # turn about the user's favourite colour.
+        credible = [c for c in ranked if c.has_evidence]
+        if not credible:
+            return Decision(ranked=tuple(ranked))
+
+        top = credible[0]
+        runner_up = credible[1].score if len(credible) > 1 else 0.0
+        confident = (
+            top.score >= floor
+            and top.idf_mass >= MIN_IDF_FRACTION * self._max_idf
+            and top.score >= runner_up * MARGIN
+        )
+        if confident:
+            return Decision(load=top.name, ranked=tuple(ranked))
+
+        shortlist = tuple(
+            c.name for c in credible[:MAX_SHORTLIST] if c.score >= SHORTLIST_FLOOR
+        )
+        return Decision(shortlist=shortlist, ranked=tuple(ranked))
+
+
+__all__ = [
+    "SkillRetriever",
+    "SkillCandidate",
+    "Decision",
+    "tokenize",
+    "MIN_SCORE",
+    "MIN_IDF_FRACTION",
+    "MARGIN",
+    "MAX_SHORTLIST",
+    "MIN_MATCHED_TERMS",
+    "SHORTLIST_FLOOR",
+    "UNKNOWN_WEIGHT",
+    "NAME_WEIGHT",
+]

--- a/tests/unit/test_agent_lazy_skill_prompt.py
+++ b/tests/unit/test_agent_lazy_skill_prompt.py
@@ -78,6 +78,7 @@ class _StubAgent:
     STICKY_SKILL_TURNS = Agent.STICKY_SKILL_TURNS
     _sticky_skill_turns = None
     _note_skill_active = Agent._note_skill_active
+    _pin_skill_body = Agent._pin_skill_body
     _always_on_skill_names = Agent._always_on_skill_names
 
     def __init__(self, manager, *, manifest=None, skill_set=None):

--- a/tests/unit/test_skill_discovery.py
+++ b/tests/unit/test_skill_discovery.py
@@ -1,0 +1,345 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""Per-turn skill discovery: what it loads, what it refuses, and what it says.
+
+The retriever's accuracy is covered in ``test_skill_retriever.py``. This file
+covers the part a user actually feels — that a matched skill gets loaded, that a
+skill which *cannot* load produces a refusal instead of a confident guess, and
+that a broken skill is not re-proposed on every turn for the rest of the session.
+
+``SkillDiscovery`` takes the loaded set and a load callable rather than an agent,
+so none of this needs an LLM, an embedder, or Lemonade.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from gaia.agents.base.skill_discovery import (
+    GROUNDING_RULE,
+    DiscoveryResult,
+    SkillDiscovery,
+)
+from gaia.skills.errors import SkillError
+
+DESCRIPTIONS = {
+    "github-triage": (
+        "Triage GitHub work with the gh CLI — your unread notification inbox, or "
+        "one repository's issue backlog. Use when asked to triage issues."
+    ),
+    "data-explore": (
+        "Load messy tabular data into SQL scratchpad tables and answer questions "
+        "with real queries. Use when the user has a CSV or spreadsheet export."
+    ),
+    "price-watch": "Check product pages for a price drop and alert on a new low.",
+    "source-watch": "Check a web page or feed for something worth reporting.",
+}
+
+
+#: Mirrors ``github-triage``'s real frontmatter: it declares a tool it does not
+#: itself provide, which the loader treats as advisory.
+REQUIRED_TOOLS = {"github-triage": ["run_shell_command"]}
+
+
+def _skill(name: str, *, root: str = "user"):
+    return SimpleNamespace(
+        name=name,
+        description=DESCRIPTIONS.get(name, ""),
+        root=root,
+        gaia=SimpleNamespace(tools_required=REQUIRED_TOOLS.get(name, [])),
+    )
+
+
+class _Manager:
+    """Minimal stand-in for ``SkillManager`` — only ``discover()`` is used."""
+
+    def __init__(self, skills):
+        self._skills = dict(skills)
+
+    def discover(self, *, force: bool = False):
+        return dict(self._skills)
+
+
+@pytest.fixture
+def manager():
+    return _Manager({name: _skill(name) for name in DESCRIPTIONS})
+
+
+@pytest.fixture
+def discovery(manager):
+    return SkillDiscovery(manager)
+
+
+@pytest.fixture
+def discovery_with_tools(manager):
+    """Discovery that can see the agent's registry — and finds it empty."""
+    return SkillDiscovery(manager, tools_fn=dict)
+
+
+class _Loader:
+    """Records what was asked for, and can be told to fail."""
+
+    def __init__(self, error: Exception | None = None):
+        self.calls: list[str] = []
+        self.error = error
+
+    def __call__(self, name: str):
+        self.calls.append(name)
+        if self.error is not None:
+            raise self.error
+        return _skill(name)
+
+
+# ── the happy path ───────────────────────────────────────────────────────
+
+
+def test_loads_the_skill_the_user_described_without_naming_it(discovery):
+    """The defect this exists for, end to end at the discovery layer."""
+    load = _Loader()
+    result = discovery.run(
+        "what's been going on in my github inbox the past few days?",
+        loaded={},
+        load_fn=load,
+    )
+    assert result.outcome == "loaded"
+    assert result.loaded == "github-triage"
+    assert load.calls == ["github-triage"]
+
+
+def test_the_loaded_note_tells_the_model_to_say_which_skill_it_used(discovery):
+    result = discovery.run("triage my github inbox", loaded={}, load_fn=_Loader())
+    fragment = result.prompt_fragment()
+    assert "github-triage" in fragment
+    assert "one short line" in fragment
+
+
+def test_an_already_loaded_skill_is_not_reloaded(discovery):
+    """The loaded set is skill_loader's business; discovery must not fight it."""
+    load = _Loader()
+    result = discovery.run(
+        "triage my github inbox",
+        loaded={"github-triage": _skill("github-triage")},
+        load_fn=load,
+    )
+    assert load.calls == []
+    assert result.loaded is None
+
+
+def test_an_unrelated_turn_loads_nothing_and_says_nothing(discovery):
+    load = _Loader()
+    result = discovery.run("what is 17 times 23?", loaded={}, load_fn=load)
+    assert result.outcome == "none"
+    assert load.calls == []
+    assert result.prompt_fragment() == ""
+
+
+# ── ambiguity ────────────────────────────────────────────────────────────
+
+
+def test_an_ambiguous_turn_is_shortlisted_never_guessed(discovery):
+    load = _Loader()
+    result = discovery.run("watch this for me", loaded={}, load_fn=load)
+    assert result.outcome == "shortlist"
+    assert load.calls == []
+    assert set(result.shortlist) <= {"price-watch", "source-watch"}
+
+
+def test_the_shortlist_note_hands_the_choice_to_the_model(discovery):
+    result = discovery.run("watch this for me", loaded={}, load_fn=_Loader())
+    assert "load_skill" in result.prompt_fragment()
+
+
+# ── never fabricate ──────────────────────────────────────────────────────
+
+
+def test_a_skill_that_will_not_load_produces_a_refusal_not_a_guess(discovery):
+    """The actual defect: a confident answer with none of the required tools.
+
+    A retrieval win that still lets the agent answer from memory is not a fix,
+    so a failed load has to reach the model as an instruction to refuse.
+    """
+    load = _Loader(error=SkillError("gh is not installed on this machine"))
+    result = discovery.run("triage my github inbox", loaded={}, load_fn=load)
+
+    assert result.outcome == "failed"
+    fragment = result.prompt_fragment()
+    assert "gh is not installed on this machine" in fragment
+    assert "cannot" in fragment
+    assert "Do not answer from memory" in fragment
+
+
+def test_a_load_failure_does_not_break_the_turn(discovery):
+    """A broken skill degrades the answer honestly; it never raises at the user."""
+    load = _Loader(error=SkillError("boom"))
+    assert discovery.run("triage my github inbox", loaded={}, load_fn=load) is not None
+
+
+def test_a_skill_that_explodes_on_import_does_not_take_down_the_turn(discovery):
+    """Loading registers a skill's tools by importing its ``tools.py``.
+
+    That import runs on a turn the user never asked for, so one broken
+    third-party skill must not kill an unrelated question. Nothing is swallowed:
+    the type and message still reach the model as a reason to refuse.
+    """
+    load = _Loader(error=ImportError("No module named 'pandas'"))
+    result = discovery.run("triage my github inbox", loaded={}, load_fn=load)
+
+    assert result.outcome == "failed"
+    assert "ImportError" in result.prompt_fragment()
+    assert "No module named 'pandas'" in result.prompt_fragment()
+
+
+def test_unmet_required_tools_are_stated_up_front(discovery_with_tools):
+    """``tools_required`` is advisory — a skill loads fine and dies mid-recipe.
+
+    Told only when the tool call fails, the model improvises a substitute. Told
+    at activation, it can say which parts it cannot do.
+    """
+    result = discovery_with_tools.run(
+        "triage my github inbox", loaded={}, load_fn=_Loader()
+    )
+    assert result.loaded == "github-triage"
+    assert result.unmet_tools == ("run_shell_command",)
+
+    fragment = result.prompt_fragment()
+    assert "run_shell_command" in fragment
+    assert "NOT registered" in fragment
+
+
+def test_met_required_tools_add_nothing_to_the_note(manager):
+    discovery = SkillDiscovery(
+        manager, tools_fn=lambda: {"run_shell_command": object()}
+    )
+    result = discovery.run("triage my github inbox", loaded={}, load_fn=_Loader())
+    assert result.unmet_tools == ()
+    assert "NOT registered" not in result.prompt_fragment()
+
+
+def test_the_tools_check_is_skipped_when_no_registry_was_supplied(discovery):
+    """An agent that did not wire ``tools_fn`` still works, it just says less."""
+    result = discovery.run("triage my github inbox", loaded={}, load_fn=_Loader())
+    assert result.loaded == "github-triage"
+    assert result.unmet_tools == ()
+
+
+def test_a_skill_that_keeps_failing_stops_being_proposed(discovery):
+    """Without this a missing CLI is rediscovered and re-refused every single turn."""
+    load = _Loader(error=SkillError("gh is not installed"))
+    for _ in range(SkillDiscovery.MAX_FAILURES):
+        assert discovery.run("triage my github inbox", loaded={}, load_fn=load).failed
+
+    later = discovery.run("triage my github inbox", loaded={}, load_fn=load)
+    assert later.outcome == "none"
+    assert len(load.calls) == SkillDiscovery.MAX_FAILURES
+
+
+def test_the_grounding_rule_is_about_sourcing_not_skills():
+    """It has to apply on the turns where NO skill matched — that is where the
+    fabrication happened."""
+    assert "tool call in THIS turn" in GROUNDING_RULE
+    assert "cannot" in GROUNDING_RULE
+    assert "skill" not in GROUNDING_RULE.lower()
+
+
+def test_the_grounding_rule_is_small_enough_to_carry_every_turn():
+    """Budget claim, asserted — a latency effort is actively cutting this prompt.
+
+    Measured 96 tokens (384 chars at GAIA's 4-chars-per-token estimate) against
+    a ~17,000-token composed prompt: 0.6%. The ceiling is 120 so a reword has
+    room, but doubling it has to be a decision someone makes on purpose.
+    """
+    assert len(GROUNDING_RULE) // 4 < 120
+
+
+@pytest.mark.parametrize(
+    "result",
+    [
+        DiscoveryResult(loaded="github-triage"),
+        DiscoveryResult(shortlist=("price-watch", "source-watch")),
+        DiscoveryResult(failed=("github-triage", "gh is not installed")),
+    ],
+    ids=["loaded", "shortlist", "failed"],
+)
+def test_per_turn_notes_stay_short(result):
+    """Measured 49 / 59 / 81 tokens. These ride only on the turns they apply to,
+    but a note that grows into a paragraph would be paid on every match."""
+    assert len(result.prompt_fragment()) // 4 < 120
+
+
+# ── corpus scope ─────────────────────────────────────────────────────────
+
+
+def test_claude_imported_skills_are_never_proposed():
+    """``.claude/skills`` is another host's marketplace — skills for working ON a
+    repo, not answers to a user's question. Indexing them made "what is the
+    contract for this API endpoint?" match a presentation-authoring skill."""
+    manager = _Manager(
+        {
+            "github-triage": _skill("github-triage", root="claude-import"),
+            "data-explore": _skill("data-explore"),
+        }
+    )
+    discovery = SkillDiscovery(manager)
+    assert "github-triage" not in discovery.candidates()
+
+    load = _Loader()
+    result = discovery.run("triage my github inbox", loaded={}, load_fn=load)
+    assert result.loaded is None and load.calls == []
+
+
+def test_the_index_rebuilds_when_a_skill_is_installed_mid_session(manager):
+    discovery = SkillDiscovery(manager)
+    discovery.refresh()
+    before = discovery._retriever.size
+
+    manager._skills["rss-digest"] = SimpleNamespace(
+        name="rss-digest",
+        description="Read an RSS or Atom feed and summarize the newest entries.",
+        root="user",
+    )
+    discovery.refresh()
+
+    assert discovery._retriever.size == before + 1
+    assert (
+        discovery.run(
+            "what has this atom feed published lately?", loaded={}, load_fn=_Loader()
+        ).loaded
+        == "rss-digest"
+    )
+
+
+def test_an_empty_library_is_a_no_op():
+    discovery = SkillDiscovery(_Manager({}))
+    result = discovery.run("triage my github inbox", loaded={}, load_fn=_Loader())
+    assert result.outcome == "none"
+
+
+# ── threshold override ───────────────────────────────────────────────────
+
+
+def test_threshold_override_is_restored_after_use(manager):
+    """It patches a module global, so a raise must not leave it patched."""
+    import gaia.agents.base.skill_retriever as module
+
+    original = module.MIN_SCORE
+    SkillDiscovery(manager, threshold=0.99).run(
+        "triage my github inbox", loaded={}, load_fn=_Loader()
+    )
+    assert module.MIN_SCORE == original
+
+
+def test_a_high_threshold_suppresses_auto_load(manager):
+    result = SkillDiscovery(manager, threshold=1.01).run(
+        "triage my github inbox", loaded={}, load_fn=_Loader()
+    )
+    assert result.loaded is None
+
+
+# ── result rendering ─────────────────────────────────────────────────────
+
+
+def test_an_empty_result_renders_nothing():
+    assert DiscoveryResult().prompt_fragment() == ""
+    assert DiscoveryResult().outcome == "none"

--- a/tests/unit/test_skill_discovery_integration.py
+++ b/tests/unit/test_skill_discovery_integration.py
@@ -1,0 +1,219 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""End-to-end proactive discovery against real ``SKILL.md`` files on disk.
+
+The other two files stub something: ``test_skill_retriever.py`` scores strings,
+``test_skill_discovery.py`` hands in a fake loader. Neither would notice if
+``Agent.load_skill`` rejected what the retriever chose, or if the skill's body
+never reached the prompt — and "we called it" is not "the call was valid".
+
+So this drives the whole chain with nothing faked below the LLM: a real
+:class:`~gaia.skills.manager.SkillManager` over real skill directories, the real
+``Agent.load_skill``, the real prompt composition. Only the model is absent, and
+the model is not part of what this feature decides.
+"""
+
+from __future__ import annotations
+
+import textwrap
+from pathlib import Path
+
+import pytest
+
+from gaia.agents.base.skill_discovery import SkillDiscovery
+
+SKILLS = {
+    "github-triage": (
+        "Triage GitHub work with the gh CLI — your unread notification inbox, or "
+        "one repository's issue backlog. Groups what arrived, judges what is "
+        "urgent, drafts the reply. Use when asked to triage issues or review a "
+        "backlog."
+    ),
+    "data-explore": (
+        "Load messy tabular data into SQL scratchpad tables and answer questions "
+        "with real queries instead of eyeballing. Use when the user has a CSV, "
+        "spreadsheet, or export."
+    ),
+}
+
+BODY_MARKER = "STEP ONE: run `gh issue list`"
+
+
+@pytest.fixture
+def skills_root(tmp_path: Path) -> Path:
+    """A real on-disk skills root — frontmatter and body, parsed by the real parser."""
+    root = tmp_path / "skills"
+    for name, description in SKILLS.items():
+        directory = root / name
+        directory.mkdir(parents=True)
+        body = BODY_MARKER if name == "github-triage" else "Load the file first."
+        (directory / "SKILL.md").write_text(
+            textwrap.dedent(f"""\
+                ---
+                name: {name}
+                description: {description}
+                version: 1.0.0
+                ---
+
+                # {name}
+
+                {body}
+                """),
+            encoding="utf-8",
+        )
+    return root
+
+
+@pytest.fixture
+def agent(skills_root: Path, monkeypatch):
+    """A minimal real ``Agent`` with discovery on and no LLM anywhere near it."""
+    from gaia.agents.base.agent import Agent
+    from gaia.skills.manager import SkillManager
+
+    class _Agent(Agent):
+        def _register_tools(self) -> None:
+            pass
+
+        def _get_system_prompt(self) -> str:
+            return "You are a test agent."
+
+    instance = _Agent.__new__(_Agent)
+    instance._skill_manager = SkillManager(
+        agent_skill_dirs=[skills_root],
+        user_skills_root=skills_root / "__absent__",
+        include_claude_roots=False,
+    )
+    instance._loaded_skills = {}
+    instance._sticky_skill_turns = None
+    instance._active_skill_filter = None
+    instance._skill_discovery_result = None
+    instance._instance_tools = None
+    instance._skill_discovery = SkillDiscovery(instance._skill_manager)
+    # Real prompt composition, no stub — a note that never reaches the prompt is
+    # the bug this file exists to catch. ``_compose_system_prompt`` only needs
+    # the mixin fragments and ``_get_system_prompt``; no model is involved.
+    instance._active_tool_filter = None
+    instance._system_prompt_cache = instance._compose_system_prompt()
+    return instance
+
+
+def test_a_described_but_unnamed_request_really_loads_the_skill(agent):
+    """The reported defect, reproduced against real files and fixed.
+
+    "what's been going on in my github inbox the past few days?" produced a
+    fabricated answer with zero tool calls because nothing ever told the agent
+    ``github-triage`` existed.
+    """
+    assert agent.loaded_skills == {}
+
+    agent._discover_skills_for_turn(
+        "what's been going on in my github inbox the past few days?"
+    )
+
+    assert "github-triage" in agent.loaded_skills
+    assert agent._skill_discovery_result.loaded == "github-triage"
+
+
+def test_the_loaded_skills_instructions_reach_the_prompt(agent):
+    """A load that does not change the prompt has not done anything."""
+    agent._discover_skills_for_turn("triage my github inbox")
+    agent._refresh_active_skill_filter("triage my github inbox")
+
+    prompt = agent.get_skills_system_prompt()
+    assert BODY_MARKER in prompt
+
+
+def test_the_body_survives_the_filter_that_runs_immediately_after(agent):
+    """Discovery loads, then ``_refresh_active_skill_filter`` runs in the same turn.
+
+    Without the sticky pin that refresh can collapse the body of the skill this
+    turn was loaded for — a load that is instantly undone.
+    """
+    agent._discover_skills_for_turn("triage my github inbox")
+    # Force the harshest case: a selector that matches nothing at all.
+    agent._select_skills_for_turn = lambda _query: []
+    agent._refresh_active_skill_filter("triage my github inbox")
+
+    assert "github-triage" in (agent._active_skill_filter or [])
+    assert BODY_MARKER in agent.get_skills_system_prompt()
+
+
+def test_the_activation_note_reaches_the_composed_prompt(agent):
+    """Regression: ``load_skill`` rebuilds the prompt *before* the result is
+    recorded, so the note for this turn was composed from the previous turn's
+    result and the "SKILL ACTIVATED" line went missing on every load."""
+    agent._discover_skills_for_turn("triage my github inbox")
+
+    assert "SKILL ACTIVATED" in agent.system_prompt
+    assert "github-triage" in agent.system_prompt
+
+
+def test_the_sourcing_rule_is_in_the_prompt_on_a_turn_with_no_match(agent):
+    """The fabrication happened with no skill loaded, so the rule must be there
+    when nothing matched — not only alongside a skill."""
+    agent._discover_skills_for_turn("what is 17 times 23?")
+    assert "==== SOURCING ====" in agent.system_prompt
+
+
+def test_the_note_clears_once_the_turn_it_described_is_over(agent):
+    """A stale "SKILL ACTIVATED" would make the model announce a skill on every
+    later turn, and would pin volatile text into the prompt forever."""
+    agent._discover_skills_for_turn("triage my github inbox")
+    assert "SKILL ACTIVATED" in agent.system_prompt
+
+    agent._discover_skills_for_turn("what is 17 times 23?")
+    assert "SKILL ACTIVATED" not in agent.system_prompt
+
+
+def test_an_unrelated_turn_loads_nothing_from_a_real_library(agent):
+    agent._discover_skills_for_turn("what is 17 times 23?")
+    assert agent.loaded_skills == {}
+    assert agent.get_skills_system_prompt() == ""
+
+
+def test_the_second_turn_does_not_reload_what_the_first_loaded(agent):
+    agent._discover_skills_for_turn("triage my github inbox")
+    agent._discover_skills_for_turn("anything else in the github backlog?")
+
+    assert list(agent.loaded_skills) == ["github-triage"]
+    # Already loaded, so discovery has nothing left to do with it.
+    assert agent._skill_discovery_result.loaded is None
+
+
+def test_a_different_request_loads_the_other_skill(agent):
+    agent._discover_skills_for_turn("triage my github inbox")
+    agent._discover_skills_for_turn("load this csv and give me totals by region")
+
+    assert set(agent.loaded_skills) == {"github-triage", "data-explore"}
+
+
+def test_an_empty_library_is_harmless(tmp_path, agent):
+    from gaia.skills.manager import SkillManager
+
+    agent._skill_discovery = SkillDiscovery(
+        SkillManager(
+            agent_skill_dirs=[tmp_path / "nothing"],
+            user_skills_root=tmp_path / "nothing-either",
+            include_claude_roots=False,
+        )
+    )
+    agent._discover_skills_for_turn("triage my github inbox")
+    assert agent.loaded_skills == {}
+
+
+def test_a_skill_installed_mid_session_becomes_discoverable(agent, skills_root):
+    """The index is rebuilt from discovery, not frozen at construction."""
+    agent._discover_skills_for_turn("read me an rss feed")
+    assert agent.loaded_skills == {}
+
+    directory = skills_root / "rss-digest"
+    directory.mkdir()
+    (directory / "SKILL.md").write_text(
+        "---\nname: rss-digest\ndescription: Read an RSS or Atom feed and "
+        "summarize the newest entries.\nversion: 1.0.0\n---\n\n# rss\n\nBody.\n",
+        encoding="utf-8",
+    )
+    agent._skill_manager.reload()
+
+    agent._discover_skills_for_turn("what has this atom feed published lately?")
+    assert "rss-digest" in agent.loaded_skills

--- a/tests/unit/test_skill_discovery_integration.py
+++ b/tests/unit/test_skill_discovery_integration.py
@@ -1,0 +1,261 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""End-to-end proactive discovery against real ``SKILL.md`` files on disk.
+
+The other two files stub something: ``test_skill_retriever.py`` scores strings,
+``test_skill_discovery.py`` hands in a fake loader. Neither would notice if
+``Agent.load_skill`` rejected what the retriever chose, or if the skill's body
+never reached the prompt — and "we called it" is not "the call was valid".
+
+So this drives the whole chain with nothing faked below the LLM: a real
+:class:`~gaia.skills.manager.SkillManager` over real skill directories, the real
+``Agent.load_skill``, the real prompt composition. Only the model is absent, and
+the model is not part of what this feature decides.
+"""
+
+from __future__ import annotations
+
+import textwrap
+from pathlib import Path
+
+import pytest
+
+from gaia.agents.base.skill_discovery import SkillDiscovery
+
+SKILLS = {
+    "github-triage": (
+        "Triage GitHub work with the gh CLI — your unread notification inbox, or "
+        "one repository's issue backlog. Groups what arrived, judges what is "
+        "urgent, drafts the reply. Use when asked to triage issues or review a "
+        "backlog."
+    ),
+    "data-explore": (
+        "Load messy tabular data into SQL scratchpad tables and answer questions "
+        "with real queries instead of eyeballing. Use when the user has a CSV, "
+        "spreadsheet, or export."
+    ),
+}
+
+BODY_MARKER = "STEP ONE: run `gh issue list`"
+
+
+@pytest.fixture
+def skills_root(tmp_path: Path) -> Path:
+    """A real on-disk skills root — frontmatter and body, parsed by the real parser."""
+    root = tmp_path / "skills"
+    for name, description in SKILLS.items():
+        directory = root / name
+        directory.mkdir(parents=True)
+        body = BODY_MARKER if name == "github-triage" else "Load the file first."
+        (directory / "SKILL.md").write_text(
+            textwrap.dedent(f"""\
+                ---
+                name: {name}
+                description: {description}
+                version: 1.0.0
+                ---
+
+                # {name}
+
+                {body}
+                """),
+            encoding="utf-8",
+        )
+    return root
+
+
+@pytest.fixture
+def agent(skills_root: Path, monkeypatch):
+    """A minimal real ``Agent`` with discovery on and no LLM anywhere near it."""
+    from gaia.agents.base.agent import Agent
+    from gaia.skills.manager import SkillManager
+
+    class _Agent(Agent):
+        def _register_tools(self) -> None:
+            pass
+
+        def _get_system_prompt(self) -> str:
+            return "You are a test agent."
+
+    instance = _Agent.__new__(_Agent)
+    instance._skill_manager = SkillManager(
+        agent_skill_dirs=[skills_root],
+        user_skills_root=skills_root / "__absent__",
+        include_claude_roots=False,
+    )
+    instance._loaded_skills = {}
+    instance._sticky_skill_turns = None
+    instance._active_skill_filter = None
+    instance._skill_discovery_result = None
+    instance._instance_tools = None
+    instance._skill_discovery = SkillDiscovery(instance._skill_manager)
+    # Real prompt composition, no stub — a note that never reaches the prompt is
+    # the bug this file exists to catch. ``_compose_system_prompt`` only needs
+    # the mixin fragments and ``_get_system_prompt``; no model is involved.
+    instance._active_tool_filter = None
+    instance._system_prompt_cache = instance._compose_system_prompt()
+    return instance
+
+
+def test_a_described_but_unnamed_request_really_loads_the_skill(agent):
+    """The reported defect, reproduced against real files and fixed.
+
+    "what's been going on in my github inbox the past few days?" produced a
+    fabricated answer with zero tool calls because nothing ever told the agent
+    ``github-triage`` existed.
+    """
+    assert agent.loaded_skills == {}
+
+    agent._discover_skills_for_turn(
+        "what's been going on in my github inbox the past few days?"
+    )
+
+    assert "github-triage" in agent.loaded_skills
+    assert agent._skill_discovery_result.loaded == "github-triage"
+
+
+def test_the_loaded_skills_instructions_reach_the_prompt(agent):
+    """A load that does not change the prompt has not done anything."""
+    agent._discover_skills_for_turn("triage my github inbox")
+    agent._refresh_active_skill_filter("triage my github inbox")
+
+    prompt = agent.get_skills_system_prompt()
+    assert BODY_MARKER in prompt
+
+
+def test_the_body_survives_the_filter_that_runs_immediately_after(agent):
+    """Discovery loads, then ``_refresh_active_skill_filter`` runs in the same turn.
+
+    Without the sticky pin that refresh can collapse the body of the skill this
+    turn was loaded for — a load that is instantly undone.
+    """
+    agent._discover_skills_for_turn("triage my github inbox")
+    # Force the harshest case: a selector that matches nothing at all.
+    agent._select_skills_for_turn = lambda _query: []
+    agent._refresh_active_skill_filter("triage my github inbox")
+
+    assert "github-triage" in (agent._active_skill_filter or [])
+    assert BODY_MARKER in agent.get_skills_system_prompt()
+
+
+def test_the_activation_note_reaches_the_composed_prompt(agent):
+    """Regression: ``load_skill`` rebuilds the prompt *before* the result is
+    recorded, so the note for this turn was composed from the previous turn's
+    result and the "SKILL ACTIVATED" line went missing on every load."""
+    agent._discover_skills_for_turn("triage my github inbox")
+
+    assert "SKILL ACTIVATED" in agent.system_prompt
+    assert "github-triage" in agent.system_prompt
+
+
+def test_the_sourcing_rule_is_in_the_prompt_on_a_turn_with_no_match(agent):
+    """The fabrication happened with no skill loaded, so the rule must be there
+    when nothing matched — not only alongside a skill."""
+    agent._discover_skills_for_turn("what is 17 times 23?")
+    assert "==== SOURCING ====" in agent.system_prompt
+
+
+def test_the_note_clears_once_the_turn_it_described_is_over(agent):
+    """A stale "SKILL ACTIVATED" would make the model announce a skill on every
+    later turn, and would pin volatile text into the prompt forever."""
+    agent._discover_skills_for_turn("triage my github inbox")
+    assert "SKILL ACTIVATED" in agent.system_prompt
+
+    agent._discover_skills_for_turn("what is 17 times 23?")
+    assert "SKILL ACTIVATED" not in agent.system_prompt
+
+
+def test_an_unrelated_turn_loads_nothing_from_a_real_library(agent):
+    agent._discover_skills_for_turn("what is 17 times 23?")
+    assert agent.loaded_skills == {}
+    assert agent.get_skills_system_prompt() == ""
+
+
+def test_the_second_turn_does_not_reload_what_the_first_loaded(agent):
+    agent._discover_skills_for_turn("triage my github inbox")
+    agent._discover_skills_for_turn("anything else in the github backlog?")
+
+    assert list(agent.loaded_skills) == ["github-triage"]
+    # Already loaded, so discovery has nothing left to do with it.
+    assert agent._skill_discovery_result.loaded is None
+
+
+def test_a_different_request_loads_the_other_skill(agent):
+    agent._discover_skills_for_turn("triage my github inbox")
+    agent._discover_skills_for_turn("load this csv and give me totals by region")
+
+    assert set(agent.loaded_skills) == {"github-triage", "data-explore"}
+
+
+def test_an_empty_library_is_harmless(tmp_path, agent):
+    from gaia.skills.manager import SkillManager
+
+    agent._skill_discovery = SkillDiscovery(
+        SkillManager(
+            agent_skill_dirs=[tmp_path / "nothing"],
+            user_skills_root=tmp_path / "nothing-either",
+            include_claude_roots=False,
+        )
+    )
+    agent._discover_skills_for_turn("triage my github inbox")
+    assert agent.loaded_skills == {}
+
+
+def test_a_skill_installed_mid_session_becomes_discoverable(agent, skills_root):
+    """The index is rebuilt from discovery, not frozen at construction."""
+    agent._discover_skills_for_turn("read me an rss feed")
+    assert agent.loaded_skills == {}
+
+    directory = skills_root / "rss-digest"
+    directory.mkdir()
+    (directory / "SKILL.md").write_text(
+        "---\nname: rss-digest\ndescription: Read an RSS or Atom feed and "
+        "summarize the newest entries.\nversion: 1.0.0\n---\n\n# rss\n\nBody.\n",
+        encoding="utf-8",
+    )
+    agent._skill_manager.reload()
+
+    agent._discover_skills_for_turn("what has this atom feed published lately?")
+    assert "rss-digest" in agent.loaded_skills
+
+
+class _TurnSetupDone(Exception):
+    """Raised to end the turn once per-turn setup is done."""
+
+
+def test_discovery_runs_before_the_turn_tool_filter(agent, monkeypatch):
+    """A skill auto-loaded this turn registers tools, and the tool filter fixes
+    the turn's tool list. Filtering first hands the model a recipe naming tools
+    the same prompt does not contain — the exact failure this feature prevents.
+    """
+    order: list[str] = []
+
+    monkeypatch.setattr(
+        type(agent),
+        "_discover_skills_for_turn",
+        lambda self, q: order.append("discover"),
+        raising=True,
+    )
+    monkeypatch.setattr(
+        type(agent),
+        "_refresh_active_tool_filter",
+        lambda self, q: order.append("tools"),
+        raising=True,
+    )
+    monkeypatch.setattr(
+        type(agent),
+        "_refresh_active_skill_filter",
+        lambda self, q: order.append("bodies"),
+        raising=True,
+    )
+    # Stop the turn the instant the three setup steps have run — the LLM loop
+    # below them is not what this pins.
+    def _stop(self, user_input):
+        raise _TurnSetupDone
+
+    monkeypatch.setattr(type(agent), "_begin_turn_record", _stop, raising=True)
+
+    with pytest.raises(_TurnSetupDone):
+        agent._process_query_impl("read me an rss feed")
+
+    assert order == ["discover", "tools", "bodies"]

--- a/tests/unit/test_skill_discovery_integration.py
+++ b/tests/unit/test_skill_discovery_integration.py
@@ -248,6 +248,7 @@ def test_discovery_runs_before_the_turn_tool_filter(agent, monkeypatch):
         lambda self, q: order.append("bodies"),
         raising=True,
     )
+
     # Stop the turn the instant the three setup steps have run — the LLM loop
     # below them is not what this pins.
     def _stop(self, user_input):

--- a/tests/unit/test_skill_retriever.py
+++ b/tests/unit/test_skill_retriever.py
@@ -1,0 +1,243 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""Proactive skill retrieval — scoring rules and the labeled accuracy gate.
+
+The behavioural tests fix the *rules* (a tie never auto-loads, a generic verb is
+not evidence, a name token is). ``test_benchmark_*`` is the accuracy gate: it
+runs the same labeled query set as ``util/skill_retrieval_bench.py`` against the
+checked-in starter pack and fails if precision or recall regresses. Retune the
+constants in :mod:`gaia.agents.base.skill_retriever` and this is what tells you
+whether the retune was an improvement or a trade.
+
+Nothing here needs Lemonade, an embedder, or an agent.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+from gaia.agents.base.skill_retriever import (
+    MIN_SCORE,
+    SkillRetriever,
+    tokenize,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+#: A miniature corpus with the shapes that matter: two skills sharing a word
+#: ("watch"), one whose name is a strong term, one with a generic verb.
+CORPUS = {
+    "github-triage": (
+        "Triage GitHub work with the gh CLI — your unread notification inbox, or "
+        "one repository's issue backlog. Use when asked to triage issues or "
+        "review a backlog."
+    ),
+    "price-watch": (
+        "Check product pages for a price drop, comparing against the lowest price "
+        "seen before. Use when the user asks to watch a price or track a deal."
+    ),
+    "source-watch": (
+        "Check a web page or feed for something worth telling the user about, "
+        "remembering what was already reported so nothing repeats."
+    ),
+    "data-explore": (
+        "Load messy tabular data into SQL scratchpad tables and answer questions "
+        "with real queries. Use when the user has a CSV or spreadsheet export."
+    ),
+    "research-report": (
+        "Research a topic on the open web and write a cited Markdown report."
+    ),
+}
+
+
+@pytest.fixture
+def retriever() -> SkillRetriever:
+    r = SkillRetriever()
+    r.index_texts(CORPUS)
+    return r
+
+
+# ── tokenization ─────────────────────────────────────────────────────────
+
+
+def test_stopwords_and_stemming():
+    assert tokenize("What are the issues you would use?") == ["issu"]
+
+
+def test_stemmer_never_shortens_below_the_minimum():
+    """ "gas" must not become "ga" — a two-character stem matches everything."""
+    assert tokenize("gas apis") == ["gas", "api"]
+
+
+def test_tokenize_is_empty_for_pure_filler():
+    """An affirmation carries no subject, so it must not steer a skill choice."""
+    assert tokenize("yes, go ahead please") == []
+    assert tokenize("cool, thanks") == []
+
+
+# ── the rules ────────────────────────────────────────────────────────────
+
+
+def test_names_the_skill_the_user_described_without_naming_it(retriever):
+    """The defect this whole feature exists for: the user never says the name."""
+    decision = retriever.decide("what's been going on in my github inbox lately?")
+    assert decision.load == "github-triage"
+
+
+def test_a_single_name_token_is_enough_evidence(retriever):
+    """One term, but it is half the skill's identity — that is a real match.
+
+    Also the regression guard for the IDF floor being *relative*: with an
+    absolute floor this five-skill corpus could never clear it, and auto-load
+    was silently dead for every small library.
+    """
+    decision = retriever.decide("what is new on github?")
+    assert decision.load == "github-triage"
+    top = decision.ranked[0]
+    assert top.matched == ("github",) and top.name_hit
+
+
+def test_a_single_generic_verb_is_not_evidence(retriever):
+    """ "remember" appears only in source-watch, so IDF alone would rank it 1.0.
+
+    It names what an assistant does, not what the skill is about — the exact
+    shape of every false auto-load the benchmark produced.
+    """
+    decision = retriever.decide("remember that my favourite colour is teal")
+    assert decision.outcome == "none"
+    assert decision.load is None and decision.shortlist == ()
+
+
+def test_a_single_subject_noun_is_evidence(retriever):
+    """Same one-term shape as above, but the term names the subject, not the verb."""
+    decision = retriever.decide("I have a csv here")
+    assert decision.ranked[0].name == "data-explore"
+    assert decision.ranked[0].strong == ("csv",)
+
+
+def test_a_tie_is_reported_as_a_tie_never_resolved(retriever):
+    """Two skills share "watch"; neither dominates, so neither loads."""
+    decision = retriever.decide("watch this for me")
+    assert decision.load is None
+    assert set(decision.shortlist) <= {"price-watch", "source-watch"}
+
+
+def test_unrelated_questions_match_nothing(retriever):
+    for query in ("what is 17 times 23?", "hi", "what's the capital of France?"):
+        assert retriever.decide(query).outcome == "none", query
+
+
+def test_unknown_words_count_against_a_match(retriever):
+    """One incidental hit inside a question about something else is not a match.
+
+    Without charging for unseen terms the denominator is built only from words
+    the corpus knows, so a lone hit looks like total agreement.
+    """
+    decision = retriever.decide("what is the report id for this API endpoint?")
+    assert decision.load is None
+
+
+def test_loaded_skills_are_excluded_from_matching(retriever):
+    decision = retriever.decide("triage my github issues", exclude={"github-triage"})
+    assert decision.load != "github-triage"
+
+
+def test_scores_are_bounded_and_ordered(retriever):
+    ranked = retriever.rank("triage my github issue backlog")
+    assert ranked == sorted(ranked, key=lambda c: (-c.score, c.name))
+    assert all(0.0 <= c.score <= 1.0 for c in ranked)
+
+
+def test_winner_must_clear_the_score_floor(retriever, monkeypatch):
+    """The floor is load-bearing, not decorative — raising it past 1.0 stops every load."""
+    import gaia.agents.base.skill_retriever as module
+
+    monkeypatch.setattr(module, "MIN_SCORE", 1.01)
+    assert retriever.decide("triage my github issues").load is None
+
+
+def test_empty_index_is_safe():
+    assert SkillRetriever().decide("anything").outcome == "none"
+
+
+def test_is_stale_tracks_description_changes():
+    class _Skill:
+        def __init__(self, description):
+            self.description = description
+
+    first = {"a": _Skill("about cats")}
+    r = SkillRetriever(first)
+    assert not r.is_stale(first)
+    assert r.is_stale({"a": _Skill("about dogs")})
+    assert r.is_stale({"a": _Skill("about cats"), "b": _Skill("about birds")})
+
+
+# ── the accuracy gate ────────────────────────────────────────────────────
+
+
+def _bench():
+    """Import the benchmark module, which lives in ``util/`` and is not a package."""
+    sys.path.insert(0, str(REPO_ROOT / "util"))
+    try:
+        import skill_retrieval_bench
+
+        return skill_retrieval_bench
+    finally:
+        sys.path.pop(0)
+
+
+@pytest.fixture(scope="module")
+def starter_pack_metrics():
+    bench = _bench()
+    retriever = SkillRetriever()
+    retriever.index_texts(bench.load_corpus("hub/skills"))
+    return bench.evaluate(retriever, bench.QUERIES)
+
+
+def test_benchmark_never_loads_the_wrong_skill(starter_pack_metrics):
+    """Precision is the number that must not slip.
+
+    A miss costs a tool call; a wrong load drags an unrelated skill's
+    instructions into the answer and spends prompt budget doing it.
+    """
+    assert starter_pack_metrics["auto_wrong"] == 0
+    assert starter_pack_metrics["false_loads"] == []
+    assert starter_pack_metrics["auto_precision"] == 1.0
+
+
+def test_benchmark_recall_does_not_regress(starter_pack_metrics):
+    # Measured 0.667 auto / 0.952 including shortlist at the shipping constants.
+    assert starter_pack_metrics["auto_recall"] >= 0.65
+    assert starter_pack_metrics["recall_incl_shortlist"] >= 0.90
+
+
+def test_benchmark_stays_quiet_on_unrelated_turns(starter_pack_metrics):
+    # Measured 0.909 — one negative shortlists (it does not load).
+    assert starter_pack_metrics["negative_specificity"] >= 0.85
+
+
+def test_scoring_is_cheap_enough_to_run_every_turn(starter_pack_metrics):
+    """The budget claim in the module docstring, asserted.
+
+    Measured ~0.015 ms/query. The 5 ms ceiling is ~300x headroom, so this fails
+    only on an algorithmic regression, never on a slow CI box.
+    """
+    assert starter_pack_metrics["latency_ms_mean"] < 5.0
+
+
+def test_shipping_threshold_is_the_value_the_benchmark_was_tuned_at():
+    """Guards against a threshold edit that silently skips the benchmark."""
+    assert MIN_SCORE == 0.50
+
+
+def test_the_idf_floor_scales_with_corpus_size():
+    """A five-skill library and a thirty-skill one must both be able to load.
+
+    IDF grows with N, so an absolute floor is a floor only for large libraries.
+    """
+    small = SkillRetriever()
+    small.index_texts({k: CORPUS[k] for k in ("github-triage", "data-explore")})
+    assert small.decide("what is new on github?").load == "github-triage"

--- a/tests/unit/test_skill_sets.py
+++ b/tests/unit/test_skill_sets.py
@@ -357,6 +357,7 @@ class _StubAgent:
     _tools_registry = Agent._tools_registry
     _format_tools_for_prompt = Agent._format_tools_for_prompt
     _note_skill_active = Agent._note_skill_active
+    _pin_skill_body = Agent._pin_skill_body
     load_skill = Agent.load_skill
     unload_skill = Agent.unload_skill
     select_skill_set = Agent.select_skill_set

--- a/tests/unit/test_skills_manager.py
+++ b/tests/unit/test_skills_manager.py
@@ -548,6 +548,7 @@ class _StubAgent:
     _bundled_skill_dirs = Agent._bundled_skill_dirs
     _resolve_skill_manifest = Agent._resolve_skill_manifest
     _note_skill_active = Agent._note_skill_active
+    _pin_skill_body = Agent._pin_skill_body
     load_skill = Agent.load_skill
     unload_skill = Agent.unload_skill
     get_skills_system_prompt = Agent.get_skills_system_prompt

--- a/tests/unit/test_starter_skills.py
+++ b/tests/unit/test_starter_skills.py
@@ -376,6 +376,7 @@ def test_starter_skill_loads_into_an_agent(pack_manager: SkillManager):
         _tools_registry = Agent._tools_registry
         _format_tools_for_prompt = Agent._format_tools_for_prompt
         _note_skill_active = Agent._note_skill_active
+        _pin_skill_body = Agent._pin_skill_body
         load_skill = Agent.load_skill
         unload_skill = Agent.unload_skill
         get_skills_system_prompt = Agent.get_skills_system_prompt

--- a/tests/unit/test_starter_skills.py
+++ b/tests/unit/test_starter_skills.py
@@ -380,6 +380,7 @@ def test_starter_skill_loads_into_an_agent(pack_manager: SkillManager):
         _tools_registry = Agent._tools_registry
         _format_tools_for_prompt = Agent._format_tools_for_prompt
         _note_skill_active = Agent._note_skill_active
+        _pin_skill_body = Agent._pin_skill_body
         load_skill = Agent.load_skill
         unload_skill = Agent.unload_skill
         get_skills_system_prompt = Agent.get_skills_system_prompt

--- a/util/skill_retrieval_bench.py
+++ b/util/skill_retrieval_bench.py
@@ -1,0 +1,294 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""Benchmark the proactive skill retriever against a labeled query set.
+
+Run it against the real installed corpus (whatever ``gaia skill list`` shows)::
+
+    python util/skill_retrieval_bench.py
+
+or against the checked-in starter pack alone, so the numbers are reproducible on
+a machine with a different ``~/.gaia/skills``::
+
+    python util/skill_retrieval_bench.py --corpus hub/skills
+
+Reports precision / recall / accuracy over the three outcomes the retriever can
+produce, plus per-query scoring latency. ``--sweep`` grid-searches the three
+constants that decide auto-load (``UNKNOWN_WEIGHT``, ``MIN_SCORE``, ``MARGIN``)
+and prints the frontier, which is how they were picked rather than guessed.
+
+``--include-claude`` indexes ``.claude/skills`` as well, reproducing the false
+matches that excluding that root prevents.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import statistics
+import sys
+import time
+from pathlib import Path
+from typing import Dict, List, Optional, Tuple
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT / "src"))
+
+from gaia.agents.base import skill_retriever as sr  # noqa: E402
+from gaia.skills.manager import SkillManager  # noqa: E402
+
+#: (query, expected skill name or None). ``None`` means "no skill should load".
+#:
+#: Positives are written the way a user actually asks — never naming the skill.
+#: Negatives are the important half: a retriever that loads something for every
+#: turn burns prompt budget and drags irrelevant instructions into the answer.
+QUERIES: List[Tuple[str, Optional[str]]] = [
+    # ── github-triage ────────────────────────────────────────────────────
+    ("what's been going on in my github inbox the past few days?", "github-triage"),
+    ("triage my github issues", "github-triage"),
+    (
+        "can you go through the amd/gaia backlog and tell me what to fix first?",
+        "github-triage",
+    ),
+    ("any new github notifications I should look at?", "github-triage"),
+    ("review the open issues on that repo and group the duplicates", "github-triage"),
+    # The continuity follow-up from .claude/skills/testing-the-gaia-agent — a
+    # bare number with no repo named. It is a positive, not a negative: the
+    # skill that just triaged the backlog is exactly what should print an issue.
+    ("cool, can you print issue 2975?", "github-triage"),
+    # ── document-brief ───────────────────────────────────────────────────
+    ("what does this contract say about termination?", "document-brief"),
+    ("index the folder of specs and answer questions from it", "document-brief"),
+    ("summarise this report and quote the source", "document-brief"),
+    # ── data-explore ─────────────────────────────────────────────────────
+    ("load this csv into a table and tell me the totals by region", "data-explore"),
+    (
+        "I have a spreadsheet export, can you query it properly instead of eyeballing",
+        "data-explore",
+    ),
+    # ── research-report ──────────────────────────────────────────────────
+    ("write me a cited report on the state of local LLM inference", "research-report"),
+    ("do a competitive landscape scan of NPU vendors", "research-report"),
+    # ── rss-digest ───────────────────────────────────────────────────────
+    ("here's an atom feed url, what has it published lately?", "rss-digest"),
+    # ── price-watch ──────────────────────────────────────────────────────
+    ("watch this product page and tell me if the price drops", "price-watch"),
+    # ── source-watch ─────────────────────────────────────────────────────
+    (
+        "monitor this url and only tell me about things you haven't reported",
+        "source-watch",
+    ),
+    # ── recommendations ──────────────────────────────────────────────────
+    ("what film should I watch tonight?", "recommendations"),
+    # ── check-in ─────────────────────────────────────────────────────────
+    ("good morning, what did I say I'd do yesterday?", "check-in"),
+    # ── daily-brief ──────────────────────────────────────────────────────
+    ("give me my morning briefing", "daily-brief"),
+    # ── coding ───────────────────────────────────────────────────────────
+    ("fix the failing test in the parser module", "coding"),
+    ("refactor this function so it stops duplicating the retry logic", "coding"),
+    # ── user-installed document skills (present only in ~/.gaia/skills) ───
+    ("pull the tables out of this pdf for me", "pdf"),
+    ("turn these numbers into a spreadsheet with a chart", "xlsx"),
+    ("build me a slide deck from this outline", "pptx"),
+    # ── negatives: nothing should load ───────────────────────────────────
+    ("what is 17 times 23?", None),
+    ("remember that my favourite colour is teal", None),
+    ("hi", None),
+    ("thanks, that's great", None),
+    ("what's the capital of France?", None),
+    ("explain the difference between a mutex and a semaphore", None),
+    ("write me a haiku about winter", None),
+    ("yes, go ahead", None),
+    ("what time is it?", None),
+    # Regression guards for the .claude/skills exclusion: with the developer
+    # marketplace indexed, "contract" hits gaia-technical-presentation (it
+    # documents "request/response contracts") and "function" hits
+    # gaia-build-agent. Both are Claude Code skills for working ON this repo,
+    # written for a different host — never an answer to a user's question.
+    ("what is the contract for this API endpoint?", None),
+    ("what does the function signature mean here?", None),
+]
+
+
+def load_corpus(
+    corpus: Optional[str], *, include_claude: bool = False
+) -> Dict[str, str]:
+    """``{name: description}`` from a skills directory, or the live discovery set.
+
+    ``include_claude`` defaults to False to mirror what the agent actually
+    indexes — see ``SkillDiscovery`` in
+    :mod:`gaia.agents.base.skill_discovery`. Pass ``--include-claude`` to
+    reproduce the false matches that exclusion exists to prevent.
+    """
+    if corpus:
+        root = Path(corpus)
+        if not root.is_absolute():
+            root = REPO_ROOT / root
+        manager = SkillManager(
+            agent_skill_dirs=[root],
+            user_skills_root=root / "__none__",
+            include_claude_roots=False,
+        )
+    else:
+        manager = SkillManager(include_claude_roots=include_claude)
+    return {
+        name: (skill.description or "")
+        for name, skill in manager.discover(force=True).items()
+    }
+
+
+def evaluate(
+    retriever: sr.SkillRetriever,
+    queries: List[Tuple[str, Optional[str]]],
+    *,
+    verbose: bool = False,
+) -> dict:
+    """Score the retriever over *queries*, returning the metric bundle."""
+    known = set(retriever.names)
+    rows = []
+    latencies: List[float] = []
+    for query, expected in queries:
+        # A positive whose skill is not in this corpus is not a miss — skip it,
+        # or a partial corpus would fake a recall failure.
+        if expected is not None and expected not in known:
+            continue
+        start = time.perf_counter()
+        decision = retriever.decide(query)
+        latencies.append((time.perf_counter() - start) * 1000.0)
+        rows.append((query, expected, decision))
+        if verbose:
+            top = decision.ranked[:3]
+            print(
+                f"  {decision.outcome:9} {str(decision.load or decision.shortlist or '-'):40}"
+                f" want={str(expected):18} "
+                + " ".join(f"{c.name}:{c.score:.2f}" for c in top)
+            )
+
+    positives = [r for r in rows if r[1] is not None]
+    negatives = [r for r in rows if r[1] is None]
+
+    auto_correct = sum(1 for _, exp, d in positives if d.load == exp)
+    auto_wrong = sum(
+        1 for _, exp, d in positives if d.load is not None and d.load != exp
+    )
+    shortlist_hit = sum(
+        1 for _, exp, d in positives if d.load is None and exp in d.shortlist
+    )
+    missed = len(positives) - auto_correct - auto_wrong - shortlist_hit
+
+    false_loads = [(q, d.load) for q, _, d in negatives if d.load is not None]
+    quiet_negatives = sum(1 for _, _, d in negatives if d.outcome == "none")
+
+    auto_attempts = auto_correct + auto_wrong + len(false_loads)
+    return {
+        "corpus_size": retriever.size,
+        "positives": len(positives),
+        "negatives": len(negatives),
+        "auto_correct": auto_correct,
+        "auto_wrong": auto_wrong,
+        "shortlist_recovered": shortlist_hit,
+        "missed_entirely": missed,
+        "false_loads": false_loads,
+        "quiet_negatives": quiet_negatives,
+        "auto_precision": auto_correct / auto_attempts if auto_attempts else 1.0,
+        "auto_recall": auto_correct / len(positives) if positives else 0.0,
+        "recall_incl_shortlist": (
+            (auto_correct + shortlist_hit) / len(positives) if positives else 0.0
+        ),
+        "negative_specificity": (
+            quiet_negatives / len(negatives) if negatives else 1.0
+        ),
+        "latency_ms_mean": statistics.mean(latencies) if latencies else 0.0,
+        "latency_ms_p95": (
+            sorted(latencies)[int(len(latencies) * 0.95)] if len(latencies) > 3 else 0.0
+        ),
+    }
+
+
+def sweep(retriever: sr.SkillRetriever, queries) -> None:
+    """Grid-search the three constants that decide auto-load.
+
+    Prints one row per point so the chosen values are visibly a maximum rather
+    than a preference. ``score`` ranks the frontier: auto-recall matters, but a
+    false load costs far more than a miss (it drags an irrelevant skill's
+    instructions into an unrelated answer), so it is weighted accordingly.
+    """
+    saved = (sr.UNKNOWN_WEIGHT, sr.MIN_SCORE, sr.MARGIN)
+    header = (
+        f"\n{'UNKNOWN_W':>10} {'MIN_SCORE':>10} {'MARGIN':>7} "
+        f"{'prec':>6} {'recall':>7} {'+short':>7} {'false':>6} {'score':>7}"
+    )
+    print(header)
+    best = None
+    for unknown_weight in (0.0, 0.3, 0.6, 0.9):
+        for min_score in (0.20, 0.25, 0.30, 0.35, 0.40, 0.50):
+            for margin in (1.0, 1.3, 1.6, 2.0, 2.5):
+                sr.UNKNOWN_WEIGHT = unknown_weight
+                sr.MIN_SCORE = min_score
+                sr.MARGIN = margin
+                m = evaluate(retriever, queries)
+                rank = m["auto_recall"] - 2.0 * (
+                    len(m["false_loads"]) / max(m["negatives"], 1)
+                )
+                print(
+                    f"{unknown_weight:>10.2f} {min_score:>10.2f} {margin:>7.1f} "
+                    f"{m['auto_precision']:>6.2f} {m['auto_recall']:>7.2f} "
+                    f"{m['recall_incl_shortlist']:>7.2f} "
+                    f"{len(m['false_loads']):>6} {rank:>7.3f}"
+                )
+                point = (unknown_weight, min_score, margin)
+                if best is None or rank > best[0]:
+                    best = (rank, point)
+    sr.UNKNOWN_WEIGHT, sr.MIN_SCORE, sr.MARGIN = saved
+    print(f"\nbest: UNKNOWN_WEIGHT/MIN_SCORE/MARGIN = {best[1]} (score {best[0]:.3f})")
+    print(f"shipping: {saved}")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--corpus", help="Skills directory to index (default: live discovery)"
+    )
+    parser.add_argument(
+        "--verbose", action="store_true", help="Print every query's decision"
+    )
+    parser.add_argument(
+        "--sweep", action="store_true", help="Grid-search the thresholds"
+    )
+    parser.add_argument("--json", action="store_true", help="Emit metrics as JSON")
+    parser.add_argument(
+        "--include-claude",
+        action="store_true",
+        help="Index .claude/skills too — reproduces the matches its exclusion prevents",
+    )
+    args = parser.parse_args()
+
+    descriptions = load_corpus(args.corpus, include_claude=args.include_claude)
+    retriever = sr.SkillRetriever()
+    retriever.index_texts(descriptions)
+    print(f"Indexed {retriever.size} skills: {', '.join(retriever.names)}\n")
+
+    metrics = evaluate(retriever, QUERIES, verbose=args.verbose)
+    if args.json:
+        print(json.dumps(metrics, indent=2))
+    else:
+        for key, value in metrics.items():
+            if key == "false_loads":
+                if value:
+                    print(f"{key:24} {len(value)}")
+                    for query, name in value:
+                        print(f"{'':26} {name} <- {query!r}")
+                else:
+                    print(f"{key:24} 0")
+            elif isinstance(value, float):
+                print(f"{key:24} {value:.3f}")
+            else:
+                print(f"{key:24} {value}")
+
+    if args.sweep:
+        sweep(retriever, QUERIES)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Ask the flagship *"what's been going on in my github inbox the past few days?"* with `github-triage` sitting installed and it calls zero tools, then answers from its memory store — a confident, entirely fabricated answer. Only `"Load the github-triage skill."` works, so the skill library is reachable exclusively by users who already know the names in it. Now every turn is matched against each installed skill's `description` before it reaches the model, the winner is loaded, and the reply says which skill it used. A skill that matches but *fails* to load makes the agent say it cannot do the work and why, rather than falling back on memory.

Retrieval is lexical, and the reason is measured rather than aesthetic: the corpus is ~12–25 skills, scoring costs **0.038 ms/turn**, and it runs on exactly the turns where nothing is loaded — where `SkillLoader` short-circuits today and an embedder round-trip would be brand-new cost on a single-slot backend. Across two labeled corpora (31 positives / 22 negatives): **precision 1.000, zero false loads on both.**

**This does not fight #3007/#3008.** Matching runs *outside* the prompt — no skill catalogue is added, the index is built in Python from frontmatter already in memory, and only the winner's body is injected. Standing cost is one **96-token** sourcing rule, 0.6% of the ~17,000-token composed prompt. Agents that do not opt in get a byte-identical prompt.

> [!IMPORTANT]
> **Merge-order note for #3008.** That PR puts `load_skill` in the `skills` *bundle*, not CORE. My shortlist outcome tells the model to call `load_skill`, and the bundle is selected from the **user's** words — "watch this page for me" will not match *"list, load, and unload skills"*. Once both land, a shortlist costs an extra `load_tools("skills")` round-trip the model may not think to make. Cheapest fix is moving that one tool into `FULL_CORE`. Flagged, deliberately not patched here.

### Test plan

- [ ] `python -m pytest tests/unit/test_skill_retriever.py tests/unit/test_skill_discovery.py tests/unit/test_skill_discovery_integration.py hub/agents/gaia/python/tests/test_proactive_skill_discovery.py -q` — 74 pass, including the labeled accuracy gate and an end-to-end pass over real `SKILL.md` files with the real `Agent.load_skill` and real prompt composition
- [ ] `python -m pytest tests/unit/test_skill_loader.py tests/unit/test_skill_sets.py tests/unit/test_skills_manager.py tests/unit/test_starter_skills.py tests/unit/test_agent_lazy_skill_prompt.py hub/agents/gaia/python/tests/ -q` — 533 pass, no regression in the existing skill stack
- [ ] `python util/skill_retrieval_bench.py --corpus hub/skills` — precision 1.000, 0 false loads; add `--sweep` to reproduce the grid search the thresholds came from, or `--include-claude` to see the false matches the `.claude/skills` exclusion prevents
- [ ] **Outstanding, not run:** `gaia eval agent` against the committed baseline. A prompt fragment is an LLM-affecting surface, so this is a required merge gate per CLAUDE.md. Lemonade was in use for live demos throughout this change, and the repo forbids running an eval concurrently with a TUI session.
- [ ] **Outstanding, not run:** the original repro through the TUI. Everything here is offline — the model has never seen this prompt.

<details>
<summary>🔍 Technical details</summary>

**Accuracy.** Normalized BM25 over `name` + `description`. Two corpora, the checked-in starter pack and the author's real `~/.gaia/skills`:

| | starter pack (11) | installed set (12) |
|---|---|---|
| auto-load precision | 1.000 | 1.000 |
| false loads on negatives | 0 | 0 |
| auto recall | 0.714 | 0.800 |
| recall incl. shortlist | 0.952 | 1.000 |
| scoring latency (mean) | 0.015 ms | 0.019 ms |

Steady-state per-turn cost including the staleness check and structured logging is 0.038 ms (300 runs, p95 0.059 ms). `MIN_SCORE` / `MARGIN` / `UNKNOWN_WEIGHT` were chosen from a joint sweep over both corpora — 0.50/1.5/0.60 sits on the zero-false-load frontier. `MARGIN=1.3` scores marginally better auto-recall at the same zero false loads, but the entire gap is one query that shortlists instead of loading, and shortlist recall is identical; the wider margin is insurance against queries the benchmark does not contain.

**Three scoring rules, each earned by a false positive the benchmark caught.**

1. *A single generic verb is not evidence.* Every false auto-load had the same shape — `remember` pulling in `source-watch` for "remember my favourite colour is teal", `explain` pulling in `coding` for a question about mutexes, `write` pulling in `research-report` for a haiku. IDF cannot separate these: in an 11-skill corpus `remember` and `contract` both appear in exactly one description and both score 2.08. What separates them is that one names the *work* and the other names the *subject*, so `_WEAK_ALONE` is small and deliberately verb-only. A term in it is still full evidence when it is part of the skill's own name.
2. *Unknown query words count against a match.* Normalizing by the corpus's *known* terms made one incidental `api` out of three content words look like near-total agreement — "what is the contract for this API endpoint?" scored 0.70 for `xlsx`. An unseen word is not neutral: in this corpus it is maximally rare and discriminates against every skill at once.
3. *The IDF evidence floor is a fraction of the corpus maximum, not an absolute.* IDF scales with N (1.39 in a 5-skill library, 2.93 in a 30-skill one), so an absolute floor of 1.5 silently disabled auto-load **entirely** for small libraries — "what is new on github?" scored 0.75 and still refused to load. Found by a test, guarded by one.

**Never fabricate, in three places rather than one.** The sourcing rule is deliberately about *sourcing*, not skills, because the observed fabrication happened on a turn where nothing matched — a skills-conditional instruction would not have been in the prompt to prevent it. A failed load becomes a refusal instruction carrying the real reason. And `tools_required` is advisory (the loader logs the gap and loads anyway), so unmet tools are named at activation instead of discovered mid-recipe as a missing tool call the model improvises around.

**Corpus scope.** `.claude/skills` stays loadable by name but is never proposed. Indexing this repo's own set made "what is the contract for this API endpoint?" match a presentation-authoring skill (it documents "request/response contracts") and "what does the function signature mean?" match an agent-scaffolding skill — that root is another host's marketplace, written for working *on* a repo rather than answering a question. `--include-claude` on the bench reproduces it.

**Two bugs found by reviewing the diff, not by tests; both now have regression tests.** `load_skill` rebuilds the system prompt *before* the discovery result is recorded, so the "SKILL ACTIVATED" note was composed from the previous turn and silently dropped on every load — the later `_refresh_active_skill_filter` only recomposes when the body filter changes, so it could not be relied on to fix it. And the IDF floor issue above.

**Exception handling.** The load path catches `Exception`, not just `SkillError` — `register_skill_tools` imports a skill's `tools.py`, and that import runs on a turn the user did not ask for, so one broken third-party skill must not take down an unrelated question. This is not a silent fallback: the type and message are logged with traceback *and* stated to the model as a reason to refuse.

**Docs.** `docs/spec/agent-skills.mdx` claimed description-match invocation was already automatic and that every skill's metadata was "always in context". Neither was true. Both corrected, plus a note telling skill authors that `description` is the retrieval index — `github-triage` gaining the phrase "unread notification inbox" is exactly what moves the reported query from shortlist to auto-load.

**Blast radius.** `Agent._skill_discovery` defaults to `None`, so `get_skill_discovery_system_prompt()` returns `""` and every other agent's composed prompt is byte-identical. Only `GaiaAgentConfig` sets `skill_discovery=True`. Toggles: `GAIA_SKILL_DISCOVERY`, `GAIA_SKILL_DISCOVERY_TAU`.

**One refactor with a footprint.** `_note_skill_active` now delegates to the new `_pin_skill_body`, because proactive discovery needs to pin a body *before* any filter exists. Five test files build stub agents by copying `Agent` methods onto a plain class rather than inheriting, so each needed the new method added — the one-line changes to `test_skill_sets.py`, `test_skills_manager.py`, `test_starter_skills.py`, `test_agent_lazy_skill_prompt.py`, and `test_skill_prompt_budget.py`.

**Pre-existing, not introduced here.** `tests/unit/test_skills_cli.py::test_real_cli_*` (3 tests) fail identically on clean `main` — a Windows-only `RuntimeError: Could not determine home directory` in a subprocess spawned with a scrubbed environment.
</details>
