### PR TITLE
feat(llm): add OrcaRouter named provider

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,6 +7,7 @@ HUGGINGFACE_ACCESS_TOKEN=
 HF_TOKEN=
 ANTHROPIC_API_KEY=
 PERPLEXITY_API_KEY=
+ORCAROUTER_API_KEY=
 
 # MCP Server Configuration
 # Base URL for Lemonade LLM server (used by all agents: code, jira, blender)

--- a/docs/sdk/configuration.mdx
+++ b/docs/sdk/configuration.mdx
@@ -30,6 +30,9 @@ export GAIA_AUTO_APPROVE_TOOLS="1"
 # API Keys (for cloud providers)
 export ANTHROPIC_API_KEY="sk-ant-..."
 export OPENAI_API_KEY="sk-..."
+# OrcaRouter gateway (OpenAI-compatible) — `create_client("orcarouter", ...)`.
+# Optional; defaults to https://api.orcarouter.ai/v1 and the "orcarouter/auto" model.
+export ORCAROUTER_API_KEY="sk-orca-..."
 ```
 
 <Note>

--- a/docs/sdk/sdks/llm.mdx
+++ b/docs/sdk/sdks/llm.mdx
@@ -70,6 +70,11 @@ llm_openai = create_client(use_openai=True)
 # Requires: pip install 'gaia[litellm]'
 llm_litellm = create_client("litellm", model="anthropic/claude-sonnet-4-6")
 
+# OrcaRouter gateway — OpenAI-compatible model routing (zero-trust security
+# for AI agents). Reads ORCAROUTER_API_KEY / ORCAROUTER_BASE_URL /
+# ORCAROUTER_MODEL, defaults to https://api.orcarouter.ai/v1 + "orcarouter/auto".
+llm_orcarouter = create_client("orcarouter")
+
 # Use same interface
 response = llm_claude.generate("Explain Python decorators")
 ```

--- a/docs/spec/llm-client.mdx
+++ b/docs/spec/llm-client.mdx
@@ -36,15 +36,15 @@ The LLM client package provides a unified interface for generating text from mul
 
 **Provider Capabilities:**
 
-| Method | Lemonade | OpenAI | Claude |
-|--------|:--------:|:------:|:------:|
-| `generate()` | ✓ | ✓ | ✓ |
-| `chat()` | ✓ | ✓ | ✓ |
-| `embed()` | ✓ | ✓ | ✗ |
-| `vision()` | ✓ | ✗ | ✓ |
-| `get_performance_stats()` | ✓ | ✗ | ✗ |
-| `load_model()` | ✓ | ✗ | ✗ |
-| `unload_model()` | ✓ | ✗ | ✗ |
+| Method | Lemonade | OpenAI | Claude | LiteLLM | OrcaRouter |
+|--------|:--------:|:------:|:------:|:-------:|:----------:|
+| `generate()` | ✓ | ✓ | ✓ | ✓ | ✓ |
+| `chat()` | ✓ | ✓ | ✓ | ✓ | ✓ |
+| `embed()` | ✓ | ✓ | ✗ | ✓ | ✗ |
+| `vision()` | ✓ | ✗ | ✓ | ✗ | ✗ |
+| `get_performance_stats()` | ✓ | ✗ | ✗ | ✗ | ✗ |
+| `load_model()` | ✓ | ✗ | ✗ | ✗ | ✗ |
+| `unload_model()` | ✓ | ✗ | ✗ | ✗ | ✗ |
 
 <Note>
 Methods marked with ✗ raise `NotSupportedError` when called on that provider.
@@ -58,7 +58,7 @@ Methods marked with ✗ raise `NotSupportedError` when called on that provider.
 
 1. **Factory Pattern**
    - `create_client()` factory function for client creation
-   - Explicit provider selection via `provider` parameter ("lemonade", "openai", "claude")
+   - Explicit provider selection via `provider` parameter ("lemonade", "openai", "claude", "orcarouter")
    - Backward-compatible `use_claude`/`use_openai` flags
    - Auto-detection of provider from flags when `provider` not specified
    - Default to Lemonade provider when no flags set
@@ -80,6 +80,7 @@ Methods marked with ✗ raise `NotSupportedError` when called on that provider.
    - **LemonadeProvider**: Full support for all methods, connects to local Lemonade server
    - **OpenAIProvider**: `generate`, `chat`, `embed` only
    - **ClaudeProvider**: `generate`, `chat`, `vision` only
+   - **OrcaRouterProvider**: `generate`, `chat` only (OpenAI-compatible gateway, no embeddings)
    - All providers support streaming and non-streaming modes
 
 4. **Error Handling**
@@ -123,7 +124,9 @@ src/gaia/llm/
 └── providers/
     ├── lemonade.py          # LemonadeProvider
     ├── openai_provider.py   # OpenAIProvider
-    └── claude.py            # ClaudeProvider
+    ├── claude.py            # ClaudeProvider
+    ├── litellm.py           # LiteLLMProvider
+    └── orcarouter.py        # OrcaRouterProvider
 ```
 
 ### Package Exports (`__init__.py`)
@@ -150,7 +153,7 @@ def create_client(
     Create an LLM client, auto-detecting provider from parameters.
 
     Args:
-        provider: Explicit provider name ("lemonade", "openai", or "claude").
+        provider: Explicit provider name ("lemonade", "openai", "claude", or "orcarouter").
                   If not specified, auto-detected from use_claude/use_openai flags.
         use_claude: If True, use Claude provider (ignored if provider is specified)
         use_openai: If True, use OpenAI provider (ignored if provider is specified)
@@ -170,6 +173,7 @@ def create_client(
         client = create_client(provider="lemonade", model="Qwen3-0.6B-GGUF")
         client = create_client(provider="openai", api_key="sk-...")
         client = create_client(provider="claude", api_key="sk-ant-...")
+        client = create_client(provider="orcarouter", api_key="sk-orca-...")
 
         # Backward-compatible flags
         client = create_client(use_claude=True, api_key="sk-ant-...")

--- a/src/gaia/llm/factory.py
+++ b/src/gaia/llm/factory.py
@@ -11,6 +11,7 @@ _PROVIDERS: dict[str, str] = {
     "openai": "gaia.llm.providers.openai_provider.OpenAIProvider",
     "claude": "gaia.llm.providers.claude.ClaudeProvider",
     "litellm": "gaia.llm.providers.litellm.LiteLLMProvider",
+    "orcarouter": "gaia.llm.providers.orcarouter.OrcaRouterProvider",
 }
 
 
@@ -24,7 +25,8 @@ def create_client(
     Create an LLM client, auto-detecting provider from parameters.
 
     Args:
-        provider: Explicit provider name ("lemonade", "openai", "claude", or "litellm").
+        provider: Explicit provider name ("lemonade", "openai", "claude",
+                  "litellm", or "orcarouter").
                   If not specified, auto-detected from use_claude/use_openai flags.
         use_claude: If True, use Claude provider (ignored if provider is specified)
         use_openai: If True, use OpenAI provider (ignored if provider is specified)

--- a/src/gaia/llm/providers/__init__.py
+++ b/src/gaia/llm/providers/__init__.py
@@ -6,5 +6,12 @@ from .claude import ClaudeProvider
 from .lemonade import LemonadeProvider
 from .litellm import LiteLLMProvider
 from .openai_provider import OpenAIProvider
+from .orcarouter import OrcaRouterProvider
 
-__all__ = ["ClaudeProvider", "LemonadeProvider", "LiteLLMProvider", "OpenAIProvider"]
+__all__ = [
+    "ClaudeProvider",
+    "LemonadeProvider",
+    "LiteLLMProvider",
+    "OpenAIProvider",
+    "OrcaRouterProvider",
+]

--- a/src/gaia/llm/providers/orcarouter.py
+++ b/src/gaia/llm/providers/orcarouter.py
@@ -1,0 +1,60 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""OrcaRouter provider - OpenAI-compatible gateway for routing LLM calls.
+
+OrcaRouter is a gateway endpoint (``https://api.orcarouter.ai/v1``) that
+accepts OpenAI-compatible chat completions and routes each request to a
+model. Like the LiteLLM provider, it is a named gateway-style backend
+registered in the LLM client factory.
+"""
+
+import os
+from typing import Optional
+
+from ..exceptions import NotSupportedError
+from .openai_provider import OpenAIProvider
+
+#: OrcaRouter gateway base URL (mirrors the official OpenAI-compatible path).
+ORCAROUTER_DEFAULT_BASE_URL = "https://api.orcarouter.ai/v1"
+
+#: Default model id routed through the gateway.
+ORCAROUTER_DEFAULT_MODEL = "orcarouter/auto"
+
+
+class OrcaRouterProvider(OpenAIProvider):
+    """OrcaRouter gateway provider (OpenAI-compatible chat completions).
+
+    Configurable via ``ORCAROUTER_API_KEY`` / ``ORCAROUTER_BASE_URL`` /
+    ``ORCAROUTER_MODEL`` environment variables or explicit constructor
+    arguments. Chat/generate/stream behavior is inherited from
+    ``OpenAIProvider``; embeddings are not supported by the gateway.
+    """
+
+    def __init__(
+        self,
+        api_key: Optional[str] = None,
+        model: Optional[str] = None,
+        base_url: Optional[str] = None,
+        system_prompt: Optional[str] = None,
+        **_kwargs,
+    ):  # pylint: disable=super-init-not-called
+        # Deliberately replaces OpenAIProvider.__init__: the base class has no
+        # base_url parameter, which OrcaRouter requires for the gateway endpoint.
+        import openai
+
+        self._client = openai.OpenAI(
+            api_key=api_key or os.getenv("ORCAROUTER_API_KEY"),
+            base_url=base_url
+            or os.getenv("ORCAROUTER_BASE_URL", ORCAROUTER_DEFAULT_BASE_URL),
+        )
+        self._model = model or os.getenv("ORCAROUTER_MODEL", ORCAROUTER_DEFAULT_MODEL)
+        self._system_prompt = system_prompt
+
+    @property
+    def provider_name(self) -> str:
+        return "OrcaRouter"
+
+    def embed(self, texts: list[str], **kwargs) -> list[list[float]]:
+        # OrcaRouter is a chat-completions gateway; it does not expose an
+        # embeddings endpoint.
+        raise NotSupportedError(self.provider_name, "embed")

--- a/tests/unit/test_orcarouter_provider.py
+++ b/tests/unit/test_orcarouter_provider.py
@@ -1,0 +1,248 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""Unit tests for OrcaRouterProvider — chat, generate, stream, env config."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from gaia.llm.exceptions import NotSupportedError
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def mock_openai_module():
+    """Patch the openai module so OrcaRouterProvider never hits the network."""
+    mock_mod = MagicMock()
+    mock_client_instance = MagicMock()
+    mock_mod.OpenAI.return_value = mock_client_instance
+    with patch.dict("sys.modules", {"openai": mock_mod}):
+        yield mock_mod, mock_client_instance
+
+
+@pytest.fixture()
+def provider(mock_openai_module):
+    """Return an OrcaRouterProvider backed by the mocked openai module."""
+    from gaia.llm.providers.orcarouter import OrcaRouterProvider
+
+    return OrcaRouterProvider(api_key="sk-orca-test", model="orcarouter/auto")
+
+
+@pytest.fixture()
+def client(mock_openai_module):
+    """Shortcut to the mocked openai.OpenAI() instance."""
+    return mock_openai_module[1]
+
+
+# ---------------------------------------------------------------------------
+# Initialization
+# ---------------------------------------------------------------------------
+
+
+class TestOrcaRouterProviderInit:
+    """Constructor and basic properties."""
+
+    def test_provider_name(self, provider):
+        assert provider.provider_name == "OrcaRouter"
+
+    def test_default_base_url(self, mock_openai_module):
+        from gaia.llm.providers.orcarouter import (
+            ORCAROUTER_DEFAULT_BASE_URL,
+            OrcaRouterProvider,
+        )
+
+        mock_mod, mock_client = mock_openai_module
+        OrcaRouterProvider(api_key="sk-orca-test")
+        mock_mod.OpenAI.assert_called_once_with(
+            api_key="sk-orca-test",
+            base_url=ORCAROUTER_DEFAULT_BASE_URL,
+        )
+
+    def test_custom_base_url(self, mock_openai_module):
+        from gaia.llm.providers.orcarouter import OrcaRouterProvider
+
+        mock_mod, _ = mock_openai_module
+        OrcaRouterProvider(
+            api_key="sk-orca-test", base_url="https://custom.orca.example/v1"
+        )
+        mock_mod.OpenAI.assert_called_once_with(
+            api_key="sk-orca-test",
+            base_url="https://custom.orca.example/v1",
+        )
+
+    def test_default_model(self, mock_openai_module):
+        from gaia.llm.providers.orcarouter import (
+            ORCAROUTER_DEFAULT_MODEL,
+            OrcaRouterProvider,
+        )
+
+        p = OrcaRouterProvider(api_key="sk-orca-test")
+        assert p._model == ORCAROUTER_DEFAULT_MODEL
+
+    def test_env_fallbacks(self, mock_openai_module, monkeypatch):
+        from gaia.llm.providers.orcarouter import OrcaRouterProvider
+
+        monkeypatch.setenv("ORCAROUTER_API_KEY", "sk-orca-env")
+        monkeypatch.setenv("ORCAROUTER_BASE_URL", "https://env.orca.example/v1")
+        monkeypatch.setenv("ORCAROUTER_MODEL", "deepseek/deepseek-v4-pro")
+
+        mock_mod, mock_client = mock_openai_module
+        p = OrcaRouterProvider()
+        assert p._model == "deepseek/deepseek-v4-pro"
+        mock_mod.OpenAI.assert_called_once_with(
+            api_key="sk-orca-env",
+            base_url="https://env.orca.example/v1",
+        )
+
+
+# ---------------------------------------------------------------------------
+# chat() — non-streaming
+# ---------------------------------------------------------------------------
+
+
+class TestChat:
+    """chat() delegates to OpenAI SDK and returns content."""
+
+    def test_returns_message_content(self, provider, client):
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.content = "Hello!"
+        client.chat.completions.create.return_value = mock_response
+
+        result = provider.chat([{"role": "user", "content": "Hi"}], stream=False)
+        assert result == "Hello!"
+
+    def test_uses_default_model(self, provider, client):
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.content = "ok"
+        client.chat.completions.create.return_value = mock_response
+
+        provider.chat([{"role": "user", "content": "Hi"}])
+        call_kwargs = client.chat.completions.create.call_args
+        assert call_kwargs.kwargs["model"] == "orcarouter/auto"
+
+    def test_model_override(self, provider, client):
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.content = "ok"
+        client.chat.completions.create.return_value = mock_response
+
+        provider.chat(
+            [{"role": "user", "content": "Hi"}], model="deepseek/deepseek-v4-pro"
+        )
+        call_kwargs = client.chat.completions.create.call_args
+        assert call_kwargs.kwargs["model"] == "deepseek/deepseek-v4-pro"
+
+    def test_extra_kwargs_passed_through(self, provider, client):
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.content = "ok"
+        client.chat.completions.create.return_value = mock_response
+
+        provider.chat(
+            [{"role": "user", "content": "Hi"}],
+            temperature=0.5,
+            max_tokens=100,
+        )
+        call_kwargs = client.chat.completions.create.call_args
+        assert call_kwargs.kwargs["temperature"] == 0.5
+        assert call_kwargs.kwargs["max_tokens"] == 100
+
+
+# ---------------------------------------------------------------------------
+# chat() — streaming
+# ---------------------------------------------------------------------------
+
+
+class TestChatStreaming:
+    """chat(stream=True) returns an iterator of text chunks."""
+
+    def _make_chunk(self, content):
+        chunk = MagicMock()
+        chunk.choices = [MagicMock()]
+        chunk.choices[0].delta.content = content
+        return chunk
+
+    def test_stream_yields_content(self, provider, client):
+        chunks = [self._make_chunk("Hello"), self._make_chunk(" world")]
+        client.chat.completions.create.return_value = iter(chunks)
+
+        result = provider.chat([{"role": "user", "content": "Hi"}], stream=True)
+        pieces = list(result)
+        assert pieces == ["Hello", " world"]
+
+
+# ---------------------------------------------------------------------------
+# generate()
+# ---------------------------------------------------------------------------
+
+
+class TestGenerate:
+    """generate() wraps prompt into a user message and delegates to chat()."""
+
+    def test_generate_non_streaming(self, provider, client):
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.content = "42"
+        client.chat.completions.create.return_value = mock_response
+
+        result = provider.generate("What is 6*7?")
+        assert result == "42"
+
+        call_kwargs = client.chat.completions.create.call_args
+        messages = call_kwargs.kwargs["messages"]
+        assert len(messages) == 1
+        assert messages[0]["role"] == "user"
+        assert messages[0]["content"] == "What is 6*7?"
+
+
+# ---------------------------------------------------------------------------
+# Unsupported methods
+# ---------------------------------------------------------------------------
+
+
+class TestUnsupportedMethods:
+    """Methods not supported by OrcaRouterProvider raise NotSupportedError."""
+
+    def test_embed_not_supported(self, provider):
+        with pytest.raises(NotSupportedError, match="OrcaRouter.*embed"):
+            provider.embed(["text"])
+
+    def test_vision_not_supported(self, provider):
+        with pytest.raises(NotSupportedError, match="OrcaRouter.*vision"):
+            provider.vision([b"img"], "describe")
+
+    def test_get_performance_stats_not_supported(self, provider):
+        with pytest.raises(
+            NotSupportedError, match="OrcaRouter.*get_performance_stats"
+        ):
+            provider.get_performance_stats()
+
+    def test_load_model_not_supported(self, provider):
+        with pytest.raises(NotSupportedError, match="OrcaRouter.*load_model"):
+            provider.load_model("orcarouter/auto")
+
+
+# ---------------------------------------------------------------------------
+# Factory registration
+# ---------------------------------------------------------------------------
+
+
+class TestFactory:
+    """create_client resolves the orcarouter provider name."""
+
+    def test_create_client_orcarouter(self, mock_openai_module):
+        from gaia.llm import create_client
+
+        client = create_client("orcarouter", api_key="sk-orca-test")
+        assert client.provider_name == "OrcaRouter"
+
+    def test_create_client_orcarouter_case_insensitive(self, mock_openai_module):
+        from gaia.llm import create_client
+
+        client = create_client("ORCAROUTER", api_key="sk-orca-test")
+        assert client.provider_name == "OrcaRouter"


### PR DESCRIPTION
## Summary

Adds a named `orcarouter` provider to the GAIA LLM client factory, so `create_client("orcarouter")` talks to the [OrcaRouter](https://www.orcarouter.ai) gateway instead of requiring a user to hand-wire an OpenAI-compatible base URL.

## Why

GAIA already ships named providers for local Lemonade, OpenAI, Anthropic, and LiteLLM. OrcaRouter is an OpenAI-compatible gateway (`https://api.orcarouter.ai/v1`) that routes chat completions to a model of your choice. Without a named provider, OrcaRouter users must construct a custom `OpenAIProvider` with a manual base URL — a named entry makes the gateway first-class and discoverable. It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.

## Linked issue

Closes #3013

## Changes

- `src/gaia/llm/providers/orcarouter.py` — `OrcaRouterProvider` (subclasses `OpenAIProvider`; `ORCAROUTER_API_KEY` / `ORCAROUTER_BASE_URL` / `ORCAROUTER_MODEL` env config, defaulting to `https://api.orcarouter.ai/v1` + `orcarouter/auto`).
- `src/gaia/llm/factory.py` + `src/gaia/llm/providers/__init__.py` — register and export the provider.
- Docs: `docs/sdk/sdks/llm.mdx`, `docs/sdk/configuration.mdx`, `docs/spec/llm-client.mdx` capability table; `.env.example`.
- Tests: `tests/unit/test_orcarouter_provider.py` mirroring the OpenAI provider suite.

## Test plan

- [ ] `pytest tests/unit/test_orcarouter_provider.py` — 17 passed
- [ ] `pytest tests/unit/test_llm_client_factory.py tests/unit/test_litellm_provider.py tests/unit/test_openai_provider.py tests/unit/test_claude_provider.py` — 96 passed, 1 skipped
- [ ] `python util/lint.py --black --isort --pylint --flake8` — all pass
- [ ] Live check: `create_client("orcarouter")` → `POST https://api.orcarouter.ai/v1/chat/completions` returns `200` with `orcarouter/auto`

## Evidence

- [x] **CLI / SDK** — real live call through `gaia.llm.create_client("orcarouter")` with a real key hit `https://api.orcarouter.ai/v1/chat/completions` and returned `ORCA-LIVE-OK` (HTTP 200). (Provider is SDK-level; no Agent UI / MCP / HTTP API surface changed.)
- [ ] **Agent UI** — N/A (no UI surface changed)
- [ ] **MCP** — N/A (no MCP surface changed)
- [ ] **HTTP API / REST** — N/A (provider factory only, no REST endpoint changed)

## Checklist

- [x] I have linked a GitHub issue above (`Closes #3013`).
- [x] I have described **why** this change is being made.
- [x] I have run linting and tests locally (`python util/lint.py --all`, `pytest tests/unit/`).
- [x] I have attached **real-world evidence** matched to the surface I changed.
- [x] I have updated documentation for the user-visible behavior change.

---

Disclosure: I'm an engineer on the OrcaRouter team.