### PR TITLE
ci(eval): capture llama-server's error so the embedder failure is diagnosable

### DIFF
--- a/.github/workflows/test_eval_agent_gemma_consolidation.yml
+++ b/.github/workflows/test_eval_agent_gemma_consolidation.yml
@@ -671,7 +671,27 @@ jobs:
               exit 1
             }
 
-            Write-Host "::error::The RAG embedder $embeddingModel cannot serve embeddings on this runner, and it fails WITH and WITHOUT ``--ubatch-size 2048``. Registration, the model's on-disk bytes and the llama.cpp backend cache have each been purged and retried, so none of those is the cause and the flag is not the trigger either - what is left is this RUNNER or the co-resident chat model. $logHint. Reproduce by hand with ``python tests/ci_lemonade_check.py --model $embeddingModel --checkpoint $embeddingCheckpoint --recipe $embeddingRecipe --register-embedding --embeddings --llamacpp-args '--ubatch-size 2048'``, and check whether an Application Control policy is blocking llama-server.exe (#2826). rag_quality and context_retention would otherwise score ~2/10 as non-answers against a ~9/10 baseline and read as a model regression. Do NOT re-run the eval until this passes - it costs 3.5h and measures nothing."
+            # RUNG 5 - the last hypothesis standing. The chat model loaded and
+            # served over the same llama-server binary earlier in this step, so
+            # the box can spawn it; the flag, the registration, the model's bytes
+            # and the backend cache are all eliminated above. What differs from
+            # the two green sibling jobs is that they load this embedder on a
+            # fresh `-NoModel` server while here a chat model is already resident
+            # (#1544 keeps it co-resident by design). Evict everything and load
+            # the embedder alone: if that works, co-residency is the cause, and
+            # on unified-memory hardware that is a GAIA problem, not a CI one.
+            Write-Host "=== Final discriminator: unloading ALL models, then loading the embedder ALONE ==="
+            $ErrorActionPreference = "Continue"
+            python -c "from gaia.llm.lemonade_client import LemonadeClient; LemonadeClient().unload_model(ignore_if_not_loaded=True); print('[ci] unloaded all models')"
+            $ErrorActionPreference = "Stop"
+            $aloneOk = Invoke-EmbedProbe -LlamacppArgs "--ubatch-size 2048"
+            Show-LemonadeTaskLog | Out-Null
+            if ($aloneOk) {
+              Write-Host "::error::The RAG embedder $embeddingModel loads ALONE but not while the chat model is resident. This runner cannot hold both at once, and gaia/rag/sdk.py::_load_embedder deliberately keeps the chat model resident (#1544) — so on this hardware every RAG-backed agent hits the same wall, and this gate has never been able to measure them. Fix the co-residency in the RAG SDK (evict-then-reload, or a smaller resident context); do NOT paper over it here, since an eval that unloads the chat model measures a configuration GAIA never runs."
+              exit 1
+            }
+
+            Write-Host "::error::The RAG embedder $embeddingModel cannot be served on this runner under any condition tried. Everything cheap is now eliminated, so do not re-run hoping it clears: the chat model LOADED and served over the same llama-server binary earlier in this step (so the binary spawns fine here and this is not #2826), the load fails identically with and without ``--ubatch-size 2048``, alone and co-resident with the chat model, and the registration, the model's on-disk bytes and the llama.cpp backend cache were each purged and retried. What is left is this specific embedding model on this specific box - most likely the ``--embeddings``/pooling path of the llama.cpp build Lemonade ships here, which is the same class of fault as #1831. Next step is a HUMAN one: on the runner, run Lemonade in a console (not the Scheduled Task, whose stdout/stderr it does not write to) and read llama-server's own failure while reproducing with ``python tests/ci_lemonade_check.py --model $embeddingModel --checkpoint $embeddingCheckpoint --recipe $embeddingRecipe --register-embedding --embeddings --llamacpp-args '--ubatch-size 2048'``. $logHint. Until then rag_quality and context_retention cannot be measured at all - they would score ~2/10 as non-answers against a ~9/10 baseline and read as a model regression."
             exit 1
           }
 

--- a/.github/workflows/test_eval_agent_gemma_consolidation.yml
+++ b/.github/workflows/test_eval_agent_gemma_consolidation.yml
@@ -260,6 +260,14 @@ jobs:
         # 5.1's rules — the Tee-Object/`2>&1` and $LASTEXITCODE notes are
         # 5.1-specific — and this file's first run died because nothing declared
         # a shell at all and the steps were bash.
+        #
+        # KEEP EVERY `run:` BODY PURE ASCII. Actions writes the block to a .ps1
+        # with no BOM, and PowerShell 5.1 reads a BOM-less file as ANSI, not
+        # UTF-8 — so one em dash inside a `run:` string is three cp1252 bytes
+        # mid-token and the whole step dies at parse time before a line executes.
+        # (Run 32274575191: a single `—` in an ::error:: message produced
+        # "Missing argument in parameter list" 30 lines away from itself.) YAML
+        # comments and step `name:` values are fine; they never reach the file.
         shell: powershell
     # BUDGET DERIVATION — measured on this runner, not guessed.
     #
@@ -687,7 +695,7 @@ jobs:
             $aloneOk = Invoke-EmbedProbe -LlamacppArgs "--ubatch-size 2048"
             Show-LemonadeTaskLog | Out-Null
             if ($aloneOk) {
-              Write-Host "::error::The RAG embedder $embeddingModel loads ALONE but not while the chat model is resident. This runner cannot hold both at once, and gaia/rag/sdk.py::_load_embedder deliberately keeps the chat model resident (#1544) — so on this hardware every RAG-backed agent hits the same wall, and this gate has never been able to measure them. Fix the co-residency in the RAG SDK (evict-then-reload, or a smaller resident context); do NOT paper over it here, since an eval that unloads the chat model measures a configuration GAIA never runs."
+              Write-Host "::error::The RAG embedder $embeddingModel loads ALONE but not while the chat model is resident. This runner cannot hold both at once, and gaia/rag/sdk.py::_load_embedder deliberately keeps the chat model resident (#1544), so on this hardware every RAG-backed agent hits the same wall, and this gate has never been able to measure them. Fix the co-residency in the RAG SDK (evict-then-reload, or a smaller resident context); do NOT paper over it here, since an eval that unloads the chat model measures a configuration GAIA never runs."
               exit 1
             }
 

--- a/.github/workflows/test_eval_agent_gemma_consolidation.yml
+++ b/.github/workflows/test_eval_agent_gemma_consolidation.yml
@@ -361,6 +361,108 @@ jobs:
           $ErrorActionPreference = "Stop"
           $ProgressPreference = "SilentlyContinue"
 
+          # One probe, so each rung of the ladder below runs an identical check.
+          # $LlamacppArgs empty = load the embedder bare, which is ONLY ever used
+          # as the discriminator on the last rung -- never to take the job green,
+          # because production RAG always passes --ubatch-size 2048
+          # (gaia/rag/sdk.py::_load_embedder) and measuring a different load than
+          # production performs is exactly the "we did not measure" case the
+          # integrity gate exists to refuse.
+          function Invoke-EmbedProbe {
+            param([string]$LlamacppArgs)
+            $ErrorActionPreference = "Continue"
+            $global:LASTEXITCODE = 0
+            if ($LlamacppArgs) {
+              $out = & python tests/ci_lemonade_check.py `
+                --model $embeddingModel --checkpoint $embeddingCheckpoint `
+                --recipe $embeddingRecipe --register-embedding --embeddings `
+                --llamacpp-args $LlamacppArgs 2>&1
+            } else {
+              $out = & python tests/ci_lemonade_check.py `
+                --model $embeddingModel --checkpoint $embeddingCheckpoint `
+                --recipe $embeddingRecipe --register-embedding --embeddings 2>&1
+            }
+            $code = $LASTEXITCODE
+            $ErrorActionPreference = "Stop"
+            $out | ForEach-Object { Write-Host "$_" }
+            # Assert the EMBEDDINGS line, not the helper's terminal `[ci] OK` -
+            # that one prints whether or not --embeddings was passed. `dim=` only
+            # prints after a real vector came back. Exit 0 alone is not enough
+            # either: a command that fails to LAUNCH leaves $LASTEXITCODE at the
+            # reset 0 and would read as a pass.
+            return ($code -eq 0 -and [bool]($out -match '\[ci\] embeddings OK \(dim='))
+          }
+
+          # Lemonade runs as a SYSTEM Scheduled Task, whose action has no console
+          # and whose stdout/stderr the scheduler records nowhere -- so until
+          # ensure-lemonade-running.ps1 began redirecting them, llama-server's
+          # startup error was discarded by the OS, not merely hard to locate.
+          # Every #2920 failure reported "(none found)" from a SYSTEM-profile glob
+          # that never had anything to match. Read the redirect target instead.
+          function Show-LemonadeTaskLog {
+            $dir = "C:\ProgramData\GaiaLemonadeServer"
+            Write-Host "=== Lemonade task stdout/stderr (tail) ==="
+            $found = $false
+            foreach ($f in @("$dir\lemonade-task-stderr.log", "$dir\lemonade-task-stdout.log")) {
+              if (Test-Path $f) {
+                # Report the size: "file exists but is empty" and "file is absent"
+                # are different faults (buffering vs. no redirect) and printing
+                # nothing for both makes them indistinguishable.
+                $len = (Get-Item $f).Length
+                Write-Host "--- $f ($len bytes) ---"
+                if ($len -gt 0) {
+                  Get-Content $f -Tail 120 -ErrorAction SilentlyContinue | ForEach-Object { Write-Host "$_" }
+                  $found = $true
+                } else {
+                  Write-Host "(empty - server captured nothing on this stream)"
+                }
+              }
+            }
+            if (-not $found) {
+              Write-Host "(none found in $dir - this runner's Scheduled Task predates the redirect; the -ForceRestart below re-registers it with logging)"
+            }
+            return $found
+          }
+
+          # Lemonade's POST /delete is documented to remove a model's files, but
+          # GAIA ships `gaia uninstall --purge-hf-cache` precisely because the HF
+          # blob cache survives deletion. The probe has re-"downloaded" this model
+          # on every attempt with no change in behaviour, which is what a cache hit
+          # looks like. Delete the blobs directly and REPORT what was there, so the
+          # log settles which of the two is true instead of leaving it assumed.
+          function Clear-EmbedderFromDisk {
+            $sys = "$env:SystemRoot\System32\config\systemprofile"
+            $roots = @(
+              "$sys\AppData\Local\huggingface\hub", "$sys\.cache\huggingface\hub",
+              "$sys\AppData\Local\lemonade\models",  "$sys\.cache\lemonade\models",
+              "$env:LOCALAPPDATA\huggingface\hub",   "$env:USERPROFILE\.cache\huggingface\hub",
+              "$env:LOCALAPPDATA\lemonade\models",   "$env:USERPROFILE\.cache\lemonade\models"
+            )
+            if ($env:HF_HOME) { $roots += (Join-Path $env:HF_HOME "hub") }
+            $removed = 0
+            foreach ($root in ($roots | Where-Object { $_ } | Select-Object -Unique)) {
+              if (-not (Test-Path $root)) { continue }
+              Get-ChildItem $root -Filter "*embeddinggemma*" -Directory -ErrorAction SilentlyContinue |
+                ForEach-Object {
+                  $mb = 0
+                  try {
+                    $mb = [math]::Round(((Get-ChildItem $_.FullName -Recurse -File -ErrorAction SilentlyContinue |
+                          Measure-Object Length -Sum).Sum / 1MB), 1)
+                  } catch { }
+                  Write-Host "Removing on-disk embedder cache: $($_.FullName) ($mb MB)"
+                  Remove-Item $_.FullName -Recurse -Force -ErrorAction SilentlyContinue
+                  $removed++
+                }
+            }
+            if ($removed -eq 0) {
+              Write-Host "PURGE: nothing left on disk - Lemonade's delete DOES remove the bytes, so each prior re-pull was a real download."
+            } else {
+              Write-Host "PURGE: removed $removed dir(s) that SURVIVED Lemonade's delete - every prior 're-download' was a cache hit on the same files."
+            }
+            return $removed
+          }
+
+
           if (-not $env:ANTHROPIC_API_KEY) {
             Write-Host "::error::ANTHROPIC_API_KEY is not set. The eval judge (src/gaia/eval/claude.py) reads it from the environment; without it every scenario scores as an infra error and the scorecard is meaningless. Add the ANTHROPIC_API_KEY repository secret, or run the eval locally on AMD hardware."
             exit 1
@@ -420,6 +522,28 @@ jobs:
           }
           Write-Host "Model under test present: $modelUnderTest"
 
+          # ...but "present" only means the GGUF is on disk. Nothing in this job
+          # has ever LOADED it: ensure-lemonade-running.ps1 warms via /pull, which
+          # is a download, and the check above reads /models' `downloaded` flag. So
+          # a runner where llama-server cannot start AT ALL looks identical here to
+          # a healthy one, and the first thing to actually load a model is the
+          # embedder probe below -- which is why an embedder-specific fault and a
+          # dead llama-server have been indistinguishable for this gate's whole
+          # history (#2920). Load the CHAT model first: it shares the llama-server
+          # binary, so if it also fails, the embedder is not the variable.
+          $ErrorActionPreference = "Continue"
+          $global:LASTEXITCODE = 0
+          $chatOut = & python tests/ci_lemonade_check.py --model $modelUnderTest --chat 2>&1
+          $chatCode = $LASTEXITCODE
+          $ErrorActionPreference = "Stop"
+          $chatOut | ForEach-Object { Write-Host "$_" }
+          if ($chatCode -ne 0 -or -not ($chatOut -match '\[ci\] chat OK')) {
+            Write-Host "::error::llama-server cannot start for the CHAT model $modelUnderTest on this runner either, so this is not an embedder fault - no model can be served here and every category would fail. The GGUF is downloaded and Lemonade answers /health, so the server process is up and the binary underneath it is what will not spawn. Check whether an Application Control policy is blocking llama-server.exe on this box (#2826), and read the Lemonade task log below."
+            Show-LemonadeTaskLog | Out-Null
+            exit 1
+          }
+          Write-Host "Chat model loads and serves - llama-server works on this runner, so an embedder failure below is embedder-specific."
+
           # THE RAG CATEGORIES RUN ON A SECOND MODEL. rag_quality and
           # context_retention answer entirely out of chunks the EMBEDDER
           # produced, so an embedder that cannot start turns every doc-grounded
@@ -457,99 +581,6 @@ jobs:
           # Continue, not Stop: under Stop the helper's first stderr line becomes
           # a terminating NativeCommandError and the step dies before the
           # ::error:: below. Same reasoning as the eval step's own note.
-          # One probe, so each rung of the ladder below runs an identical check.
-          # $LlamacppArgs empty = load the embedder bare, which is ONLY ever used
-          # as the discriminator on the last rung -- never to take the job green,
-          # because production RAG always passes --ubatch-size 2048
-          # (gaia/rag/sdk.py::_load_embedder) and measuring a different load than
-          # production performs is exactly the "we did not measure" case the
-          # integrity gate exists to refuse.
-          function Invoke-EmbedProbe {
-            param([string]$LlamacppArgs)
-            $ErrorActionPreference = "Continue"
-            $global:LASTEXITCODE = 0
-            if ($LlamacppArgs) {
-              $out = & python tests/ci_lemonade_check.py `
-                --model $embeddingModel --checkpoint $embeddingCheckpoint `
-                --recipe $embeddingRecipe --register-embedding --embeddings `
-                --llamacpp-args $LlamacppArgs 2>&1
-            } else {
-              $out = & python tests/ci_lemonade_check.py `
-                --model $embeddingModel --checkpoint $embeddingCheckpoint `
-                --recipe $embeddingRecipe --register-embedding --embeddings 2>&1
-            }
-            $code = $LASTEXITCODE
-            $ErrorActionPreference = "Stop"
-            $out | ForEach-Object { Write-Host "$_" }
-            # Assert the EMBEDDINGS line, not the helper's terminal `[ci] OK` -
-            # that one prints whether or not --embeddings was passed. `dim=` only
-            # prints after a real vector came back. Exit 0 alone is not enough
-            # either: a command that fails to LAUNCH leaves $LASTEXITCODE at the
-            # reset 0 and would read as a pass.
-            return ($code -eq 0 -and [bool]($out -match '\[ci\] embeddings OK \(dim='))
-          }
-
-          # Lemonade runs as a SYSTEM Scheduled Task, whose action has no console
-          # and whose stdout/stderr the scheduler records nowhere -- so until
-          # ensure-lemonade-running.ps1 began redirecting them, llama-server's
-          # startup error was discarded by the OS, not merely hard to locate.
-          # Every #2920 failure reported "(none found)" from a SYSTEM-profile glob
-          # that never had anything to match. Read the redirect target instead.
-          function Show-LemonadeTaskLog {
-            $dir = "C:\ProgramData\GaiaLemonadeServer"
-            Write-Host "=== Lemonade task stdout/stderr (tail) ==="
-            $found = $false
-            foreach ($f in @("$dir\lemonade-task-stderr.log", "$dir\lemonade-task-stdout.log")) {
-              if (Test-Path $f) {
-                Write-Host "--- $f ---"
-                Get-Content $f -Tail 120 -ErrorAction SilentlyContinue | ForEach-Object { Write-Host "$_" }
-                $found = $true
-              }
-            }
-            if (-not $found) {
-              Write-Host "(none found in $dir - this runner's Scheduled Task predates the redirect; the -ForceRestart below re-registers it with logging)"
-            }
-            return $found
-          }
-
-          # Lemonade's POST /delete is documented to remove a model's files, but
-          # GAIA ships `gaia uninstall --purge-hf-cache` precisely because the HF
-          # blob cache survives deletion. The probe has re-"downloaded" this model
-          # on every attempt with no change in behaviour, which is what a cache hit
-          # looks like. Delete the blobs directly and REPORT what was there, so the
-          # log settles which of the two is true instead of leaving it assumed.
-          function Clear-EmbedderFromDisk {
-            $sys = "$env:SystemRoot\System32\config\systemprofile"
-            $roots = @(
-              "$sys\AppData\Local\huggingface\hub", "$sys\.cache\huggingface\hub",
-              "$sys\AppData\Local\lemonade\models",  "$sys\.cache\lemonade\models",
-              "$env:LOCALAPPDATA\huggingface\hub",   "$env:USERPROFILE\.cache\huggingface\hub",
-              "$env:LOCALAPPDATA\lemonade\models",   "$env:USERPROFILE\.cache\lemonade\models"
-            )
-            if ($env:HF_HOME) { $roots += (Join-Path $env:HF_HOME "hub") }
-            $removed = 0
-            foreach ($root in ($roots | Where-Object { $_ } | Select-Object -Unique)) {
-              if (-not (Test-Path $root)) { continue }
-              Get-ChildItem $root -Filter "*embeddinggemma*" -Directory -ErrorAction SilentlyContinue |
-                ForEach-Object {
-                  $mb = 0
-                  try {
-                    $mb = [math]::Round(((Get-ChildItem $_.FullName -Recurse -File -ErrorAction SilentlyContinue |
-                          Measure-Object Length -Sum).Sum / 1MB), 1)
-                  } catch { }
-                  Write-Host "Removing on-disk embedder cache: $($_.FullName) ($mb MB)"
-                  Remove-Item $_.FullName -Recurse -Force -ErrorAction SilentlyContinue
-                  $removed++
-                }
-            }
-            if ($removed -eq 0) {
-              Write-Host "PURGE: nothing left on disk - Lemonade's delete DOES remove the bytes, so each prior re-pull was a real download."
-            } else {
-              Write-Host "PURGE: removed $removed dir(s) that SURVIVED Lemonade's delete - every prior 're-download' was a cache hit on the same files."
-            }
-            return $removed
-          }
-
           # RUNG 1 - the load production performs.
           $embedOk = Invoke-EmbedProbe -LlamacppArgs "--ubatch-size 2048"
 

--- a/.github/workflows/test_eval_agent_gemma_consolidation.yml
+++ b/.github/workflows/test_eval_agent_gemma_consolidation.yml
@@ -432,12 +432,13 @@ jobs:
             return $found
           }
 
-          # Lemonade's POST /delete is documented to remove a model's files, but
-          # GAIA ships `gaia uninstall --purge-hf-cache` precisely because the HF
-          # blob cache survives deletion. The probe has re-"downloaded" this model
-          # on every attempt with no change in behaviour, which is what a cache hit
-          # looks like. Delete the blobs directly and REPORT what was there, so the
-          # log settles which of the two is true instead of leaving it assumed.
+          # Lemonade's POST /delete deregisters a model but never removes its
+          # files, so the probe's delete + re-pull cannot re-fetch anything: it
+          # short-circuits on the blob cache and reloads the same bytes every
+          # time. Freeing them needs an OS-level delete, which is this function.
+          # Roots follow _huggingface_cache_dir / _lemonade_models_dir in
+          # src/gaia/installer/uninstall_command.py; report what was removed, since
+          # the sizes are the evidence that a re-pull was ever real.
           function Clear-EmbedderFromDisk {
             $sys = "$env:SystemRoot\System32\config\systemprofile"
             $roots = @(
@@ -463,9 +464,13 @@ jobs:
                 }
             }
             if ($removed -eq 0) {
-              Write-Host "PURGE: nothing left on disk - Lemonade's delete DOES remove the bytes, so each prior re-pull was a real download."
+              # Do NOT read this as "the delete worked" - it never removes files.
+              # Nothing found almost certainly means the cache lives somewhere the
+              # roots above do not cover, so the retry below is still loading the
+              # same bytes and this probe proved nothing.
+              Write-Host "PURGE: found nothing to remove. Lemonade's delete does not remove files, so this most likely means the model cache is NOT under any of these roots, not that the disk was clean: $($roots -join '; ')"
             } else {
-              Write-Host "PURGE: removed $removed dir(s) that SURVIVED Lemonade's delete - every prior 're-download' was a cache hit on the same files."
+              Write-Host "PURGE: removed $removed dir(s). Lemonade's delete only deregisters, so this is the first time the bytes are actually gone and the next pull genuinely re-fetches."
             }
             return $removed
           }

--- a/.github/workflows/test_eval_agent_gemma_consolidation.yml
+++ b/.github/workflows/test_eval_agent_gemma_consolidation.yml
@@ -457,49 +457,106 @@ jobs:
           # Continue, not Stop: under Stop the helper's first stderr line becomes
           # a terminating NativeCommandError and the step dies before the
           # ::error:: below. Same reasoning as the eval step's own note.
-          $ErrorActionPreference = "Continue"
-          $global:LASTEXITCODE = 0
-          $embedOut = & python tests/ci_lemonade_check.py `
-            --model $embeddingModel `
-            --checkpoint $embeddingCheckpoint `
-            --recipe $embeddingRecipe `
-            --register-embedding `
-            --embeddings `
-            --llamacpp-args "--ubatch-size 2048" 2>&1
-          $embedCode = $LASTEXITCODE
-          $ErrorActionPreference = "Stop"
-          $embedOut | ForEach-Object { Write-Host "$_" }
-          # Assert the EMBEDDINGS line, not the helper's terminal `[ci] OK` - that
-          # one prints whether or not --embeddings was passed, so a dropped flag
-          # would take this preflight green having verified nothing. `dim=` only
-          # prints after a real vector came back. Exit 0 alone is not enough
-          # either: a command that fails to LAUNCH leaves $LASTEXITCODE at the
-          # reset 0 and would read as a pass.
-          if ($embedCode -ne 0 -or -not ($embedOut -match '\[ci\] embeddings OK \(dim=')) {
-            # Why llama-server refused to start is in Lemonade's own log, which
-            # the probe cannot see. Print it so the fix does not need an RDP
-            # session onto the box. The server runs as the SYSTEM scheduled task
-            # (ensure-lemonade-running.ps1), so the log is in the SYSTEM
-            # profile's ~/.cache/lemonade - server.log per lemonade_client.py,
-            # but glob both that dir and a logs/ subdir since the layout has
-            # moved before.
-            Write-Host "=== Lemonade server log (tail) ==="
-            $logGlobs = @(
-              "$env:SystemRoot\System32\config\systemprofile\.cache\lemonade\*.log",
-              "$env:SystemRoot\System32\config\systemprofile\.cache\lemonade\logs\*.log",
-              "$env:USERPROFILE\.cache\lemonade\*.log",
-              "$env:USERPROFILE\.cache\lemonade\logs\*.log"
-            )
-            $logged = $false
-            Get-ChildItem $logGlobs -ErrorAction SilentlyContinue |
-              Sort-Object LastWriteTime -Descending | Select-Object -First 1 |
-              ForEach-Object {
-                Write-Host "--- $($_.FullName) ---"
-                Get-Content $_.FullName -Tail 120 -ErrorAction SilentlyContinue
-                $logged = $true
+          # One probe, so each rung of the ladder below runs an identical check.
+          # $LlamacppArgs empty = load the embedder bare, which is ONLY ever used
+          # as the discriminator on the last rung -- never to take the job green,
+          # because production RAG always passes --ubatch-size 2048
+          # (gaia/rag/sdk.py::_load_embedder) and measuring a different load than
+          # production performs is exactly the "we did not measure" case the
+          # integrity gate exists to refuse.
+          function Invoke-EmbedProbe {
+            param([string]$LlamacppArgs)
+            $ErrorActionPreference = "Continue"
+            $global:LASTEXITCODE = 0
+            if ($LlamacppArgs) {
+              $out = & python tests/ci_lemonade_check.py `
+                --model $embeddingModel --checkpoint $embeddingCheckpoint `
+                --recipe $embeddingRecipe --register-embedding --embeddings `
+                --llamacpp-args $LlamacppArgs 2>&1
+            } else {
+              $out = & python tests/ci_lemonade_check.py `
+                --model $embeddingModel --checkpoint $embeddingCheckpoint `
+                --recipe $embeddingRecipe --register-embedding --embeddings 2>&1
+            }
+            $code = $LASTEXITCODE
+            $ErrorActionPreference = "Stop"
+            $out | ForEach-Object { Write-Host "$_" }
+            # Assert the EMBEDDINGS line, not the helper's terminal `[ci] OK` -
+            # that one prints whether or not --embeddings was passed. `dim=` only
+            # prints after a real vector came back. Exit 0 alone is not enough
+            # either: a command that fails to LAUNCH leaves $LASTEXITCODE at the
+            # reset 0 and would read as a pass.
+            return ($code -eq 0 -and [bool]($out -match '\[ci\] embeddings OK \(dim='))
+          }
+
+          # Lemonade runs as a SYSTEM Scheduled Task, whose action has no console
+          # and whose stdout/stderr the scheduler records nowhere -- so until
+          # ensure-lemonade-running.ps1 began redirecting them, llama-server's
+          # startup error was discarded by the OS, not merely hard to locate.
+          # Every #2920 failure reported "(none found)" from a SYSTEM-profile glob
+          # that never had anything to match. Read the redirect target instead.
+          function Show-LemonadeTaskLog {
+            $dir = "C:\ProgramData\GaiaLemonadeServer"
+            Write-Host "=== Lemonade task stdout/stderr (tail) ==="
+            $found = $false
+            foreach ($f in @("$dir\lemonade-task-stderr.log", "$dir\lemonade-task-stdout.log")) {
+              if (Test-Path $f) {
+                Write-Host "--- $f ---"
+                Get-Content $f -Tail 120 -ErrorAction SilentlyContinue | ForEach-Object { Write-Host "$_" }
+                $found = $true
               }
-            $logHint = if ($logged) { "the llama-server error is in the Lemonade log tail above" } else { "no Lemonade log was found on this runner (looked in: $($logGlobs -join ', ')) - read llama-server's failure from the Lemonade console instead" }
-            if (-not $logged) { Write-Host "(none found)" }
+            }
+            if (-not $found) {
+              Write-Host "(none found in $dir - this runner's Scheduled Task predates the redirect; the -ForceRestart below re-registers it with logging)"
+            }
+            return $found
+          }
+
+          # Lemonade's POST /delete is documented to remove a model's files, but
+          # GAIA ships `gaia uninstall --purge-hf-cache` precisely because the HF
+          # blob cache survives deletion. The probe has re-"downloaded" this model
+          # on every attempt with no change in behaviour, which is what a cache hit
+          # looks like. Delete the blobs directly and REPORT what was there, so the
+          # log settles which of the two is true instead of leaving it assumed.
+          function Clear-EmbedderFromDisk {
+            $sys = "$env:SystemRoot\System32\config\systemprofile"
+            $roots = @(
+              "$sys\AppData\Local\huggingface\hub", "$sys\.cache\huggingface\hub",
+              "$sys\AppData\Local\lemonade\models",  "$sys\.cache\lemonade\models",
+              "$env:LOCALAPPDATA\huggingface\hub",   "$env:USERPROFILE\.cache\huggingface\hub",
+              "$env:LOCALAPPDATA\lemonade\models",   "$env:USERPROFILE\.cache\lemonade\models"
+            )
+            if ($env:HF_HOME) { $roots += (Join-Path $env:HF_HOME "hub") }
+            $removed = 0
+            foreach ($root in ($roots | Where-Object { $_ } | Select-Object -Unique)) {
+              if (-not (Test-Path $root)) { continue }
+              Get-ChildItem $root -Filter "*embeddinggemma*" -Directory -ErrorAction SilentlyContinue |
+                ForEach-Object {
+                  $mb = 0
+                  try {
+                    $mb = [math]::Round(((Get-ChildItem $_.FullName -Recurse -File -ErrorAction SilentlyContinue |
+                          Measure-Object Length -Sum).Sum / 1MB), 1)
+                  } catch { }
+                  Write-Host "Removing on-disk embedder cache: $($_.FullName) ($mb MB)"
+                  Remove-Item $_.FullName -Recurse -Force -ErrorAction SilentlyContinue
+                  $removed++
+                }
+            }
+            if ($removed -eq 0) {
+              Write-Host "PURGE: nothing left on disk - Lemonade's delete DOES remove the bytes, so each prior re-pull was a real download."
+            } else {
+              Write-Host "PURGE: removed $removed dir(s) that SURVIVED Lemonade's delete - every prior 're-download' was a cache hit on the same files."
+            }
+            return $removed
+          }
+
+          # RUNG 1 - the load production performs.
+          $embedOk = Invoke-EmbedProbe -LlamacppArgs "--ubatch-size 2048"
+
+          # RUNG 2 - a stale llama.cpp backend cannot spawn and reports exactly
+          # this "llama-server failed to start".
+          if (-not $embedOk) {
+            Show-LemonadeTaskLog | Out-Null
 
             # A stale llama.cpp backend in Lemonade's bin cache cannot spawn, and
             # reports exactly this "llama-server failed to start". install-lemonade
@@ -536,23 +593,55 @@ jobs:
             powershell -ExecutionPolicy Bypass -File installer\scripts\ensure-lemonade-running.ps1 -ForceRestart
             $global:LASTEXITCODE = 0
 
-            $ErrorActionPreference = "Continue"
-            $embedOut = & python tests/ci_lemonade_check.py `
-              --model $embeddingModel `
-              --checkpoint $embeddingCheckpoint `
-              --recipe $embeddingRecipe `
-              --register-embedding `
-              --embeddings `
-              --llamacpp-args "--ubatch-size 2048" 2>&1
-            $embedCode = $LASTEXITCODE
-            $ErrorActionPreference = "Stop"
-            $embedOut | ForEach-Object { Write-Host "$_" }
+            $embedOk = Invoke-EmbedProbe -LlamacppArgs "--ubatch-size 2048"
+            if ($embedOk) {
+              Write-Host "Embedder recovered after the backend-cache wipe - the cached llama.cpp backend was stale."
+            }
+          }
 
-            if ($embedCode -ne 0 -or -not ($embedOut -match '\[ci\] embeddings OK \(dim=')) {
-              Write-Host "::error::The RAG embedder $embeddingModel cannot serve embeddings on this runner, and clearing the llama.cpp backend cache did not fix it (retry exit $embedCode; its output is above). rag_quality and context_retention would score ~2/10 as non-answers against a ~9/10 baseline and look like a model regression. Registration, download and the backend cache have all been ruled out, so this is the RUNNER: $logHint. On sjlab-stx-halo-18 read llama-server's failure from the Lemonade console and re-run this probe by hand (``python tests/ci_lemonade_check.py --model $embeddingModel --checkpoint $embeddingCheckpoint --recipe $embeddingRecipe --register-embedding --embeddings --llamacpp-args '--ubatch-size 2048'``). Check whether an Application Control policy is blocking llama-server.exe (#2826). Do NOT re-run the eval until it passes - it costs 3.5h and measures nothing."
+          # RUNG 3 - purge the model's BYTES, not just its registration, then
+          # retry the production load once. `--register-embedding` already deletes
+          # and re-pulls before every attempt above, so a third identical retry
+          # would prove nothing; what has never been tried is removing the files
+          # underneath, because Lemonade's delete may only drop the registry entry
+          # and leave the HF blob cache intact (`gaia uninstall --purge-hf-cache`
+          # exists for exactly that). If a corrupt or truncated GGUF is the cause,
+          # this is the only rung that can clear it - and it takes the job green,
+          # which the diagnostic rung below deliberately never does.
+          if (-not $embedOk) {
+            Write-Host "=== Backend-cache wipe did not help; purging the embedder from disk and retrying once ==="
+            Clear-EmbedderFromDisk | Out-Null
+            Write-Host "Restarting Lemonade before the clean-disk retry..."
+            powershell -ExecutionPolicy Bypass -File installer\scripts\ensure-lemonade-running.ps1 -ForceRestart
+            $global:LASTEXITCODE = 0
+            $embedOk = Invoke-EmbedProbe -LlamacppArgs "--ubatch-size 2048"
+            if ($embedOk) {
+              Write-Host "Embedder recovered after a full on-disk purge - the cached GGUF was bad. Continuing."
+            }
+          }
+
+          # RUNG 4 - DIAGNOSTIC ONLY, never a pass. Everything shared with the two
+          # healthy sibling jobs (test_embeddings.yml, test_rag.yml - same model,
+          # same helper, green on their runner) has now been ruled out, and the
+          # remaining differences are this job's --ubatch-size 2048 and its
+          # co-resident chat model. Loading bare separates those in one run
+          # instead of another week of blind re-runs. It cannot take the job
+          # green: production RAG always passes the flag (gaia/rag/sdk.py), so a
+          # bare load measures something GAIA never does.
+          if (-not $embedOk) {
+            Show-LemonadeTaskLog | Out-Null
+            Write-Host "=== Discriminating probe: loading the embedder WITHOUT --ubatch-size 2048 (diagnostic only) ==="
+            $bareOk = Invoke-EmbedProbe
+            $logged = Show-LemonadeTaskLog
+            $logHint = if ($logged) { "llama-server's own error is in the task-log tail above" } else { "no task log was captured even after a -ForceRestart re-register - check that this runner's ensure-lemonade-running.ps1 carries the stdout/stderr redirect" }
+
+            if ($bareOk) {
+              Write-Host "::error::The RAG embedder $embeddingModel loads FINE without ``--ubatch-size 2048`` and fails WITH it, on this runner. That flag is not CI-only - gaia/rag/sdk.py::_load_embedder passes it on every embedder load, so document Q&A and every RAG-backed agent are broken on this hardware the same way, and this eval gate has simply never been able to measure them (0 passes in its history, #2920). Fix the load in gaia/rag/sdk.py - do NOT drop the flag from this probe to go green, which would measure a load GAIA never performs. $logHint"
               exit 1
             }
-            Write-Host "Embedder recovered after the backend-cache wipe - the cached llama.cpp backend was stale."
+
+            Write-Host "::error::The RAG embedder $embeddingModel cannot serve embeddings on this runner, and it fails WITH and WITHOUT ``--ubatch-size 2048``. Registration, the model's on-disk bytes and the llama.cpp backend cache have each been purged and retried, so none of those is the cause and the flag is not the trigger either - what is left is this RUNNER or the co-resident chat model. $logHint. Reproduce by hand with ``python tests/ci_lemonade_check.py --model $embeddingModel --checkpoint $embeddingCheckpoint --recipe $embeddingRecipe --register-embedding --embeddings --llamacpp-args '--ubatch-size 2048'``, and check whether an Application Control policy is blocking llama-server.exe (#2826). rag_quality and context_retention would otherwise score ~2/10 as non-answers against a ~9/10 baseline and read as a model regression. Do NOT re-run the eval until this passes - it costs 3.5h and measures nothing."
+            exit 1
           }
 
       - name: Run the three eval categories serially

--- a/installer/scripts/ensure-lemonade-running.ps1
+++ b/installer/scripts/ensure-lemonade-running.ps1
@@ -85,9 +85,11 @@ $LogDir = "C:\ProgramData\GaiaLemonadeServer"
 New-Item -ItemType Directory -Force -Path $LogDir | Out-Null
 $StdoutLog = Join-Path $LogDir "lemonade-task-stdout.log"
 $StderrLog = Join-Path $LogDir "lemonade-task-stderr.log"
-# PYTHONUNBUFFERED: the server is Python, and Python block-buffers stdout when
-# it is a pipe rather than a console. Without this the redirect below produces
-# two empty files for the whole life of a server that never exits.
+# PYTHONUNBUFFERED: Python block-buffers stdout when it is a pipe rather than a
+# console, so without this a server that never exits never flushes and its stdout
+# log stays empty. Measured: stdout 0 bytes without it, 39 with; stderr arrives
+# either way (Python line-buffers stderr). So an empty STDERR log is not a
+# buffering symptom -- it means the server wrote nothing there.
 $InnerCmd  = "`$env:PYTHONUNBUFFERED='1'; " +
              "Start-Process -FilePath '$ServerExe' -ArgumentList '--port $Port' " +
              "-RedirectStandardOutput '$StdoutLog' -RedirectStandardError '$StderrLog' " +

--- a/installer/scripts/ensure-lemonade-running.ps1
+++ b/installer/scripts/ensure-lemonade-running.ps1
@@ -75,15 +75,21 @@ foreach ($cfg in @(
 #
 # Wrapped in powershell.exe + Start-Process only to capture output: a Task
 # Scheduler action has no console and the scheduler records its stdout/stderr
-# nowhere, so a bare -Execute discards the server's output entirely -- and with
-# it llama-server's startup error, which the child writes to inherited handles.
+# nowhere, so a bare -Execute discards the server's output entirely. This
+# captures the SERVER's streams; whether llama-server's own stderr rides on them
+# or goes to a pipe Lemonade owns is unconfirmed, so do not rely on this alone
+# to explain a child that will not spawn.
 # Fixed ProgramData path (SYSTEM-writable): the task outlives the job that
 # registered it, so its log has to outlive that job too.
 $LogDir = "C:\ProgramData\GaiaLemonadeServer"
 New-Item -ItemType Directory -Force -Path $LogDir | Out-Null
 $StdoutLog = Join-Path $LogDir "lemonade-task-stdout.log"
 $StderrLog = Join-Path $LogDir "lemonade-task-stderr.log"
-$InnerCmd  = "Start-Process -FilePath '$ServerExe' -ArgumentList '--port $Port' " +
+# PYTHONUNBUFFERED: the server is Python, and Python block-buffers stdout when
+# it is a pipe rather than a console. Without this the redirect below produces
+# two empty files for the whole life of a server that never exits.
+$InnerCmd  = "`$env:PYTHONUNBUFFERED='1'; " +
+             "Start-Process -FilePath '$ServerExe' -ArgumentList '--port $Port' " +
              "-RedirectStandardOutput '$StdoutLog' -RedirectStandardError '$StderrLog' " +
              "-NoNewWindow -Wait"
 try {

--- a/installer/scripts/ensure-lemonade-running.ps1
+++ b/installer/scripts/ensure-lemonade-running.ps1
@@ -72,15 +72,30 @@ foreach ($cfg in @(
 
 # (Re)register a Scheduled Task that runs the server as SYSTEM, auto-starting at
 # boot and restarting on failure. Force overwrites any prior definition.
+#
+# Wrapped in powershell.exe + Start-Process only to capture output: a Task
+# Scheduler action has no console and the scheduler records its stdout/stderr
+# nowhere, so a bare -Execute discards the server's output entirely -- and with
+# it llama-server's startup error, which the child writes to inherited handles.
+# Fixed ProgramData path (SYSTEM-writable): the task outlives the job that
+# registered it, so its log has to outlive that job too.
+$LogDir = "C:\ProgramData\GaiaLemonadeServer"
+New-Item -ItemType Directory -Force -Path $LogDir | Out-Null
+$StdoutLog = Join-Path $LogDir "lemonade-task-stdout.log"
+$StderrLog = Join-Path $LogDir "lemonade-task-stderr.log"
+$InnerCmd  = "Start-Process -FilePath '$ServerExe' -ArgumentList '--port $Port' " +
+             "-RedirectStandardOutput '$StdoutLog' -RedirectStandardError '$StderrLog' " +
+             "-NoNewWindow -Wait"
 try {
-    $action    = New-ScheduledTaskAction -Execute $ServerExe -Argument "--port $Port"
+    $action    = New-ScheduledTaskAction -Execute "powershell.exe" `
+                    -Argument "-NoProfile -ExecutionPolicy Bypass -Command `"$InnerCmd`""
     $trigger   = New-ScheduledTaskTrigger -AtStartup
     $principal = New-ScheduledTaskPrincipal -UserId "SYSTEM" -LogonType ServiceAccount -RunLevel Highest
     $settings  = New-ScheduledTaskSettingsSet -AllowStartIfOnBatteries -DontStopIfGoingOnBatteries `
                     -ExecutionTimeLimit ([TimeSpan]::Zero) -RestartCount 3 -RestartInterval (New-TimeSpan -Minutes 1)
     Register-ScheduledTask -TaskName $TaskName -Action $action -Trigger $trigger `
         -Principal $principal -Settings $settings -Force -ErrorAction Stop | Out-Null
-    Write-Host "Registered scheduled task '$TaskName'."
+    Write-Host "Registered scheduled task '$TaskName' (stdout: $StdoutLog, stderr: $StderrLog)."
 } catch {
     Write-Host "ERROR: could not register scheduled task (need admin?): $($_.Exception.Message)"
     exit 1


### PR DESCRIPTION
Closes #2920

The Gemma-4-E4B agent eval gate has **never passed — 55 failures, 0 successes** — and nobody could say why, because every failure printed `(none found)` where the reason should be. Its red X has been landing on unrelated PRs for weeks, so people re-run it, and a real eval regression would look identical to the noise.

This does not make the gate pass. It makes it **say what is wrong**. The preflight now proves llama-server works on the box before blaming the embedder, escalates through the recoveries that had never actually been tried, and ends with a verdict naming what has been ruled out instead of pointing at whichever PR triggered it.

**What that produced, on the real runner:** the embedder cannot be served there under any condition — while the chat model loads and completes over the *same* llama-server binary. So the fault is the machine's llama.cpp backend, not this repo, and not the PR under test. Two sibling jobs load the identical model via the identical helper on a different runner and stay green.

Along the way it also established that **Lemonade's `delete` never removes model files** — 318 MB of GGUF survived it — so the delete + re-pull that every retry relied on could never re-fetch anything. Only an OS-level delete frees the bytes.

<details>
<summary>🔍 The elimination ladder, and one thing that does not work</summary>

```
[ci] chat OK (choices=1, content='OK')        <- chat model loads AND serves
rung 1  embedder + --ubatch-size 2048          -> fail
rung 2  llama.cpp backend cache wiped, restart -> fail
rung 3  318 MB purged from disk, restart       -> fail
rung 4  bare load, no llama.cpp args           -> fail
rung 5  ALL models unloaded, embedder ALONE    -> fail
```

| Candidate | Verdict |
|---|---|
| The PR under test | ruled out — fails on every branch, 0 passes in gate history |
| Registration / embeddings label | ruled out — re-registered before every attempt |
| Corrupt GGUF on disk | ruled out — 318 MB purged, re-pulled, same failure |
| Stale llama.cpp backend cache | ruled out — wiped + restart (#2932) |
| `--ubatch-size 2048` | ruled out — bare load fails identically; production RAG's flag is fine |
| llama-server blocked (#2826) | ruled out — chat model loads + serves on the same binary |
| Co-residency with the chat model (#1544) | ruled out — fails with everything unloaded |

**Be honest about the log capture: it does not work.** The Scheduled Task now redirects the server's streams, but both come back 0 bytes across four runs, after `PYTHONUNBUFFERED` and a `-ForceRestart` re-register. Measured on PowerShell 5.1: the flag does fix stdout (0 -> 39 bytes), but stderr was never buffered, so an empty stderr means the server writes nothing to handles a parent can inherit — llama-server's text is not reachable this way. Kept because it costs nothing and a future Lemonade may log there, but **the diagnosis came from the chat probe, not from it.**

Getting llama-server's own error needs console access on the box:

```
python tests/ci_lemonade_check.py --model user.embeddinggemma-300m-GGUF \
  --checkpoint ggml-org/embeddinggemma-300M-GGUF:Q8_0 --recipe llamacpp \
  --register-embedding --embeddings --llamacpp-args "--ubatch-size 2048"
```

**Follow-ups, deliberately not in this PR:** this gate cannot pass on its current runner, so it should either be scheduled on one that demonstrably serves this embedder (the sibling jobs prove one exists) or have the backend fixed — that decides which shared pool a 3.5 h job occupies, so it is not mine to make. And the on-disk purge probably belongs in `tests/ci_lemonade_check.py` alongside the other three workflows rather than inline here.
</details>

## Test plan

- [x] Workflow YAML parses; all 12 steps intact
- [x] Every `run:` body parses under **Windows PowerShell 5.1** from a **BOM-less file** via `ParseFile` — the way Actions invokes it. A stdin-piped check is not equivalent: it decodes as UTF-8 and cannot catch an encoding fault (one em dash killed run `32274575191` at parse time before any line ran). All `run:` bodies are now asserted pure ASCII, with the constraint documented at the `shell: powershell` pin.
- [x] Scheduled-task redirect proven end-to-end — argument built from the real file text, launched as Task Scheduler does, captured `llama-server failed to start` into the stderr log (with a space in the exe path)
- [x] `PYTHONUNBUFFERED` A/B measured on a long-running Python child: stdout 0 -> 39 bytes; stderr 38 either way
- [x] Purge function against a faked HF layout with a decoy — removed the embedder only, left the chat model untouched
- [x] Chat probe exercised across all three branches: pass, load-failure, and the exit-0-without-an-OK-line trap
- [x] Full ladder executed on the real runner (run `32277801464`), reaching a named verdict
