### PR TITLE
ci(eval): pin the agent eval to Strix Halo, and record which box measured

### DIFF
--- a/.github/workflows/test_eval_agent_gemma_consolidation.yml
+++ b/.github/workflows/test_eval_agent_gemma_consolidation.yml
@@ -136,6 +136,11 @@ on:
         description: 'Driver + judge model for the eval harness (must match the baseline)'
         required: false
         default: 'claude-sonnet-4-6'
+      deep_diagnostics:
+        description: 'Run the full embedder-failure ladder (purges the model from disk, unloads all models). Off on PRs - it costs ~7 extra min and disturbs other jobs on the box.'
+        required: false
+        type: boolean
+        default: false
   # `pull_request`, NOT `push`. A `push` path filter matches the files in the
   # PUSH, so merging main into a branch replays all of main's churn through the
   # filter — which is how #2807 and #2809, both pure C++ PRs with no Python in
@@ -205,6 +210,11 @@ env:
   # Opus 5; this one value is exempt until the baselines are regenerated with
   # that driver. Override per-run via the dispatch input above.
   EVAL_MODEL: ${{ github.event.inputs.eval_model || 'claude-sonnet-4-6' }}
+  # Deep ladder is opt-in. Its rungs purge the embedder from disk and unload every
+  # resident model, which is fine while investigating and wrong to repeat on every
+  # PR: the cause is known (#3016) and the box is shared, so the next job landing
+  # on it pays for a cold reload it did not ask for.
+  DEEP_DIAG: ${{ github.event.inputs.deep_diagnostics || 'false' }}
   # Loopback services — bypass any runner proxy. This covers the PYTHON side
   # (httpx/requests in the eval, the agents and the backend); PowerShell's
   # Invoke-RestMethod ignores NO_PROXY and uses the system proxy instead.
@@ -669,6 +679,28 @@ jobs:
             }
           }
 
+          # STOP HERE ON A NORMAL RUN. Everything above is cheap and read-only:
+          # it establishes whether llama-server works at all on this box and
+          # whether a stale backend was the problem. Everything below purges the
+          # model from disk and unloads every resident model, which was the right
+          # thing to do while the cause was unknown and is the wrong thing to
+          # repeat on every PR now that it is known (#3016) - it adds ~7 min and
+          # leaves the next job on this shared box paying for a cold reload.
+          # Re-dispatch with deep_diagnostics: true to run the full ladder.
+          # ...and do NOT kill the job here. Only rag_quality and context_retention
+          # answer out of embedder-produced chunks; tool_selection's four scenarios
+          # (known_path_read, multi_step_plan, no_tools_needed, smart_discovery)
+          # carry no corpus at all, so a dead embedder costs two categories, not
+          # three. Exiting cost the third for free and left PRs with no regression
+          # signal whatsoever. Record the state, let the run measure what it can,
+          # and let the integrity gate render the honest verdict - the job still
+          # fails, because two of three were not measured.
+          if (-not $embedOk -and $env:DEEP_DIAG -ne 'true') {
+            Show-LemonadeTaskLog | Out-Null
+            "EMBEDDER_OK=false" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
+            Write-Host "::error::The RAG embedder $embeddingModel will not load on this runner - a known Strix Halo limitation tracked in #3016, NOT a fault in this PR. The chat model loaded and served over the same llama-server binary earlier in this step, and the same embedder loads fine on the Strix Point boxes, so llama-server works here and the gap is specific to the embeddings path on this SoC. Re-running this gate will not clear it. rag_quality and context_retention cannot be measured; tool_selection does not need the embedder and WILL still run, so this job continues and still gates that category. The deeper rungs (purge the model from disk, load without --ubatch-size 2048, load with everything else unloaded) are skipped on PR runs on purpose because they disturb other jobs on this shared box - re-dispatch with deep_diagnostics: true if you need the full elimination ladder."
+          }
+
           # RUNG 3 - purge the model's BYTES, not just its registration, then
           # retry the production load once. `--register-embedding` already deletes
           # and re-pulls before every attempt above, so a third identical retry
@@ -846,7 +878,9 @@ jobs:
             # No --agent-type: the committed baselines were produced against the
             # backend default (their `config` records only backend_url/model/budget),
             # so passing one here would compare against a different agent.
-            foreach ($category in @("rag_quality", "context_retention", "tool_selection")) {
+            $categories = if ($env:EMBEDDER_OK -eq 'false') { @("tool_selection") } else { @("rag_quality", "context_retention", "tool_selection") }
+            if ($env:EMBEDDER_OK -eq 'false') { Write-Host "::warning::Embedder unavailable (#3016) - measuring tool_selection only. rag_quality and context_retention answer out of embedder-produced chunks and cannot be measured; the integrity gate below still fails the job for them." }
+            foreach ($category in $categories) {
               Write-Host "=================================================================="
               Write-Host "  gaia eval agent --category $category"
               Write-Host "=================================================================="
@@ -902,7 +936,8 @@ jobs:
           $ErrorActionPreference = "Stop"
           $missing = $false
 
-          foreach ($category in @("rag_quality", "context_retention", "tool_selection")) {
+          $categories = if ($env:EMBEDDER_OK -eq 'false') { @("tool_selection") } else { @("rag_quality", "context_retention", "tool_selection") }
+          foreach ($category in $categories) {
             $log = "eval-out\$category.log"
             if (-not (Test-Path $log)) {
               Write-Host "::error::No log for $category - the chain stopped before it ran."
@@ -964,7 +999,9 @@ jobs:
           $noMeasurement = @("infra_error", "errored", "timeout", "blocked", "budget_exceeded", "skipped")
           $problems = @()
 
-          foreach ($category in @("rag_quality", "context_retention", "tool_selection")) {
+          $categories = if ($env:EMBEDDER_OK -eq 'false') { @("tool_selection") } else { @("rag_quality", "context_retention", "tool_selection") }
+          $skipped = if ($env:EMBEDDER_OK -eq 'false') { @("rag_quality", "context_retention") } else { @() }
+          foreach ($category in $categories) {
             $current = "eval-out\$category\scorecard.json"
             if (-not (Test-Path $current)) {
               $problems += "${category}: no scorecard produced"
@@ -994,9 +1031,22 @@ jobs:
             Write-Host "${category}: $($got.Count) scenario(s) run, $($want.Count) in baseline, unmeasured=$shown"
           }
 
+          # A category the embedder made impossible is still an unmeasured
+          # category. It is named with its cause rather than silently dropped,
+          # and it still fails the job: this gate's whole job is refusing to
+          # render a verdict over measurements that do not exist, and "we knew
+          # why" is not the same as "we measured it".
+          foreach ($sk in $skipped) {
+            $problems += "${sk}: NOT MEASURED - the RAG embedder will not load on this runner (#3016), and this category answers out of embedder-produced chunks"
+          }
+
           if ($problems.Count -gt 0) {
             foreach ($p in $problems) { Write-Host "::error::Integrity: $p" }
             Write-Host ""
+            if ($skipped.Count -gt 0) {
+              Write-Host "NOTE: $($categories -join ', ') still ran and IS compared below - read that verdict, it is a real regression signal. What this job cannot tell you today is anything about $($skipped -join ' or '), and it will keep failing until #3016 is fixed."
+              Write-Host ""
+            }
             Write-Host "The eval did not produce a complete set of measurements, so the baseline comparison below is not trustworthy. This fails regardless of ``enforce`` - report mode softens a WORSE score, never a MISSING one. Check the backend/Lemonade logs in the artifact, then re-run."
             exit 1
           }
@@ -1009,7 +1059,8 @@ jobs:
           $regressed = @()
           $failedCompare = $false
 
-          foreach ($category in @("rag_quality", "context_retention", "tool_selection")) {
+          $categories = if ($env:EMBEDDER_OK -eq 'false') { @("tool_selection") } else { @("rag_quality", "context_retention", "tool_selection") }
+          foreach ($category in $categories) {
             $current = "eval-out\$category\scorecard.json"
             $baseline = Join-Path $env:BASELINE_DIR "scorecard_$category.json"
             Write-Host ""

--- a/.github/workflows/test_eval_agent_gemma_consolidation.yml
+++ b/.github/workflows/test_eval_agent_gemma_consolidation.yml
@@ -247,12 +247,22 @@ jobs:
     # LemonadeServer.exe. Landing on Linux dies with 'powershell: command not
     # found'. Same guard as test_email_agent_eval.yml.
     #
-    # `lemonade-eval` — as opposed to the `stx` label the sibling evals use — is
-    # currently carried by exactly one runner (sjlab-stx-halo-18, itself an stx
-    # box). Serialisation comes from the concurrency group above, NOT from this
-    # label; the label only narrows WHICH box. Widen to `stx` if this job should
-    # be schedulable across the whole pool.
-    runs-on: [self-hosted, Windows, lemonade-eval]
+    # `strix-halo` pins the SoC, and that is a correctness requirement, not a
+    # preference: the `stx` pool spans Strix Point boxes as well (sjlab-stx-1,
+    # sjlab-stx-3), which do not have the 128 GB of unified memory this eval's
+    # model needs, and scores from two different SoCs are not comparable to each
+    # other or to the committed baselines. Do NOT widen this to `stx` — an
+    # earlier revision of this comment suggested exactly that, which would have
+    # let a scorecard be produced on whichever machine happened to be free.
+    #
+    # `lemonade-eval` is kept alongside it to say WHICH Halo box owns the long
+    # eval slot. It is redundant while exactly one runner carries both, and that
+    # is the point: if the label is ever moved to a non-Halo box this job finds
+    # no runner and queues visibly, rather than quietly measuring the wrong
+    # hardware. Serialisation still comes from the concurrency group, not either
+    # label. Same `Windows` guard as the sibling evals: the pool also matches a
+    # Linux box (xsj-aimlab-stxp-04) and every step here is PowerShell.
+    runs-on: [self-hosted, Windows, strix-halo, lemonade-eval]
     defaults:
       run:
         # Pinned to Windows PowerShell 5.1, not left to the runner default (pwsh
@@ -516,6 +526,22 @@ jobs:
             exit 1
           }
           Write-Host "Lemonade reachable at $lemonadeUrl"
+
+          # Record WHICH machine produced this scorecard. The runs-on labels state
+          # the intent; this is the only thing that proves it held at runtime, and
+          # a score is not interpretable without it - the pool spans two SoCs and
+          # only Strix Halo has the memory this eval assumes. /v1/system-info also
+          # carries per-recipe backend state (unsupported / installable /
+          # update_required / installed) and compatible devices, which is the
+          # diff that explains why this embedder loads on a Strix Point box and
+          # not here (#3016). Best-effort and never fatal: it is evidence, not a
+          # gate, and must not be able to fail a run on its own.
+          $ErrorActionPreference = "Continue"
+          Write-Host "=== Lemonade system-info (device + llamacpp backend state) ==="
+          python -c "import json; from gaia.llm.lemonade_client import LemonadeClient; si = LemonadeClient().get_system_info(); print(json.dumps({k: v for k, v in si.items() if k != 'recipes'}, indent=2, default=str)[:2000]); print('--- recipes.llamacpp ---'); print(json.dumps(si.get('recipes', {}).get('llamacpp'), indent=2, default=str)[:2000])"
+          if ($LASTEXITCODE -ne 0) { Write-Host "(system-info unavailable on this Lemonade build - continuing, this is diagnostic only)" }
+          $global:LASTEXITCODE = 0
+          $ErrorActionPreference = "Stop"
 
           # ensure-lemonade-running.ps1 SWALLOWS a failed warm pull ("WARN: warm
           # pull failed") and still exits 0, so a healthy server proves nothing


### PR DESCRIPTION
Part of #3016

Two problems with how this eval gate behaves, both of which make its result untrustworthy or absent.

**It was targeting a pool, not a machine.** The `stx` pool spans two SoCs — Strix Point and Strix Halo — and this eval reached it through a label that only happens to sit on the Halo box today. Strix Point does not have the 128 GB of unified memory this eval's model assumes, and a scorecard from one SoC is not comparable to one from the other or to the committed baselines. Only the intended machine carries `strix-halo`, so requiring it makes the SoC a scheduling constraint instead of a convention that happens to hold.

**A dead embedder was costing three categories when it costs two.** `rag_quality` and `context_retention` answer out of embedder-produced chunks, but `tool_selection`'s four scenarios carry no corpus at all. The preflight was exiting on embedder failure and throwing away the one category still measurable — so PRs got no regression signal whatsoever. It now measures what it can. The job still fails, and the integrity gate is still what fails it, but `tool_selection` is compared against its baseline and that verdict is readable.

This does not turn the gate green — the embedder still cannot load on Strix Halo (#3016). It makes the gate say something true and useful while that is unfixed, and measure on the right hardware once it is.

<details>
<summary>🔍 Design notes</summary>

**`runs-on: [self-hosted, Windows, strix-halo, lemonade-eval]`** — `strix-halo` pins the SoC; `lemonade-eval` says which Halo box owns the long eval slot. Redundant while one runner carries both, deliberately: if that label is ever moved to a non-Halo machine the job finds no runner and queues visibly rather than quietly measuring the wrong hardware. Serialisation still comes from the concurrency group. `test_agent_behavior_e2e.yml` already uses `[self-hosted, strix-halo]`; this follows that precedent. The comment that previously invited widening to `stx` now says the opposite, with the reason.

**Partial measurement is not a softened verdict.** A category nobody could measure is named with its cause and still counted as unmeasured — "we knew why" is not "we measured it". That keeps the integrity gate's existing rule intact: it never renders a verdict over measurements that do not exist.

**The deep rungs are now opt-in** (`deep_diagnostics` dispatch input). Purging the model from disk and unloading every resident model was right while the cause was unknown; repeating it on every PR is not, now that #3016 records the answer — it costs ~7 min and leaves the next job on this shared box paying for a cold reload. The cheap rungs that localise the fault, the chat-model load probe and the stale-backend self-heal, still run every time.

**On cost, since recent behaviour is misleading:** this job dying at preflight in ~16 minutes was never the design, it was the symptom. Measuring one category is cheaper than the three the gate is meant to run — and far more useful than a gate that measures nothing. It does mean triggering PRs now occupy the Halo box for the length of a `tool_selection` run rather than failing fast.

**Left alone deliberately** — two sibling evals have the same SoC exposure, but pinning them trades shared CI capacity and I do not know which SoC their baselines were captured on; pinning them the wrong way would invalidate the comparison:

| Workflow | `runs-on` | Risk |
|---|---|---|
| `test_email_agent_eval.yml` | `["self-hosted","Windows","stx"]` | scorecard from whichever SoC it lands on |
| `email_scorecard_refresh.yml` | `["self-hosted","Windows","stx"]` | **refreshes committed baselines** from whichever SoC it lands on |
</details>

## Test plan

- [x] YAML parses; 12 steps; `runs-on` resolves to `['self-hosted', 'Windows', 'strix-halo', 'lemonade-eval']`
- [x] Every `run:` body parses under **Windows PowerShell 5.1** from a **BOM-less file** via `ParseFile` — the invocation Actions actually uses — and all bodies asserted pure ASCII (a stdin-piped check decodes as UTF-8 and cannot catch an encoding fault; one em dash previously killed a step at parse time)
- [x] Category selection exercised in all three states: `EMBEDDER_OK=false` -> `tool_selection` only, skipped `rag_quality,context_retention`; `true` and **unset** -> all three, so the healthy path is unchanged
- [x] `Collect` / `Integrity` / `Compare` all carry `if: !cancelled()`, so `tool_selection` really is compared after the integrity gate fails
- [x] The `/v1/system-info` one-liner compile-checked before shipping, so a syntax error cannot burn a runner slot
- [x] `strix-halo` verified against the live runner list — carried by exactly one runner, and no Strix Point box has it
- [ ] First run on this PR: schedules on the Halo box, system-info prints device + `recipes.llamacpp` state, and `tool_selection` produces a comparable verdict while the two RAG categories are reported unmeasured
