### PR TITLE
ci(hub): one approval per component release, not two

### DIFF
--- a/.github/workflows/release_components.yml
+++ b/.github/workflows/release_components.yml
@@ -161,15 +161,21 @@ jobs:
   # other deploy path (agent_hub_worker_ci.yml only tests), so the Worker drifts
   # until someone runs `wrangler deploy` by hand.
   #
-  # Deploying here rather than on push-to-main is deliberate: this job inherits
-  # the agent-publish reviewer gate, so a production Worker deploy still needs a
-  # human, and it lands in the same approval as the upload it has to match.
+  # Deliberately NOT in the agent-publish environment, despite deploying to
+  # production. GitHub raises one approval per batch of jobs that pend together;
+  # this job must finish before the publishes, so gating it here would mean two
+  # prompts per release. The reviewer gate exists for the part that cannot be
+  # undone — an immutable R2 upload — and this deploy is neither irreversible
+  # (redeploy fixes it) nor unchecked (worker-check runs typecheck, the suite,
+  # and a bundle first). It also only runs on a real release the maintainer
+  # dispatched, never on a dry run.
+  #
+  # Consequence: CLOUDFLARE_* must be REPO-level secrets, not environment ones.
   deploy-worker:
     name: Deploy Agent Hub Worker
     needs: [version, worker-check]
     if: needs.version.outputs.dry_run == 'false'
     runs-on: ubuntu-latest
-    environment: agent-publish
     steps:
       - uses: actions/checkout@v7
 
@@ -193,7 +199,7 @@ jobs:
           [ -n "${CLOUDFLARE_API_TOKEN:-}" ]  || missing="${missing} CLOUDFLARE_API_TOKEN"
           [ -n "${CLOUDFLARE_ACCOUNT_ID:-}" ] || missing="${missing} CLOUDFLARE_ACCOUNT_ID"
           if [ -n "${missing}" ]; then
-            echo "::error::missing environment secret(s) on agent-publish:${missing}. The Agent Hub Worker validates the manifests this workflow uploads, so publishing without deploying it first is how a stale validator rejects a valid release. Create a Cloudflare API token from the 'Edit Cloudflare Workers' template (it must also cover R2 for the bucket binding) and add both secrets to the agent-publish environment. See workers/agent-hub/README.md."
+            echo "::error::missing repository secret(s):${missing}. The Agent Hub Worker validates the manifests this workflow uploads, so publishing without deploying it first is how a stale validator rejects a valid release. Create a Cloudflare API token from the 'Edit Cloudflare Workers' template (it must also cover R2 for the bucket binding) and add both as REPOSITORY secrets (not environment ones — this job runs outside agent-publish so the release needs only one approval). See workers/agent-hub/README.md."
             exit 1
           fi
           # Stamp the commit so the check below can prove WHICH build went live.

--- a/.github/workflows/release_components.yml
+++ b/.github/workflows/release_components.yml
@@ -161,21 +161,26 @@ jobs:
   # other deploy path (agent_hub_worker_ci.yml only tests), so the Worker drifts
   # until someone runs `wrangler deploy` by hand.
   #
-  # Deliberately NOT in the agent-publish environment, despite deploying to
-  # production. GitHub raises one approval per batch of jobs that pend together;
-  # this job must finish before the publishes, so gating it here would mean two
-  # prompts per release. The reviewer gate exists for the part that cannot be
-  # undone — an immutable R2 upload — and this deploy is neither irreversible
-  # (redeploy fixes it) nor unchecked (worker-check runs typecheck, the suite,
-  # and a bundle first). It also only runs on a real release the maintainer
-  # dispatched, never on a dry run.
+  # A SECOND environment, not agent-publish, and not no-environment at all.
   #
-  # Consequence: CLOUDFLARE_* must be REPO-level secrets, not environment ones.
+  # GitHub raises one approval per batch of jobs that pend together. This job
+  # must finish before the publishes, so putting it in agent-publish costs a
+  # second prompt. Dropping `environment:` entirely would fix that but throw
+  # away more than the prompt: agent-publish also carries the deployment ref
+  # allowlist (main / v* / agent-pkg-*), and without it anyone with write access
+  # could dispatch this workflow from an arbitrary branch with dry_run unchecked
+  # and push that branch's Worker straight to production — the Worker being the
+  # manifest validator and the holder of the R2 binding.
+  #
+  # worker-deploy therefore has NO required reviewers (so no second prompt) but
+  # the SAME ref allowlist as agent-publish, and holds the Cloudflare secrets so
+  # they stay environment-scoped rather than readable by every workflow.
   deploy-worker:
     name: Deploy Agent Hub Worker
     needs: [version, worker-check]
     if: needs.version.outputs.dry_run == 'false'
     runs-on: ubuntu-latest
+    environment: worker-deploy
     steps:
       - uses: actions/checkout@v7
 
@@ -199,7 +204,7 @@ jobs:
           [ -n "${CLOUDFLARE_API_TOKEN:-}" ]  || missing="${missing} CLOUDFLARE_API_TOKEN"
           [ -n "${CLOUDFLARE_ACCOUNT_ID:-}" ] || missing="${missing} CLOUDFLARE_ACCOUNT_ID"
           if [ -n "${missing}" ]; then
-            echo "::error::missing repository secret(s):${missing}. The Agent Hub Worker validates the manifests this workflow uploads, so publishing without deploying it first is how a stale validator rejects a valid release. Create a Cloudflare API token from the 'Edit Cloudflare Workers' template (it must also cover R2 for the bucket binding) and add both as REPOSITORY secrets (not environment ones — this job runs outside agent-publish so the release needs only one approval). See workers/agent-hub/README.md."
+            echo "::error::missing environment secret(s) on worker-deploy:${missing}. The Agent Hub Worker validates the manifests this workflow uploads, so publishing without deploying it first is how a stale validator rejects a valid release. Create a Cloudflare API token from the 'Edit Cloudflare Workers' template (it must also cover R2 for the bucket binding) and add both to the worker-deploy environment (which has no reviewers, so the release still needs only one approval). See workers/agent-hub/README.md."
             exit 1
           fi
           # Stamp the commit so the check below can prove WHICH build went live.
@@ -216,7 +221,15 @@ jobs:
           GAIA_HUB_BASE_URL: ${{ vars.GAIA_HUB_BASE_URL }}
         run: |
           set -euo pipefail
-          base="${GAIA_HUB_PUBLISH_URL:-${GAIA_HUB_BASE_URL:-https://hub.amd-gaia.ai}}"
+          # No default. Falling back to the custom domain would verify a
+          # DIFFERENT origin than the publish jobs upload to (they go through
+          # workers.dev because the WAF fronts hub.amd-gaia.ai), so a silent
+          # default here reports freshness for something we are not publishing to.
+          base="${GAIA_HUB_PUBLISH_URL:-${GAIA_HUB_BASE_URL:-}}"
+          if [ -z "${base}" ]; then
+            echo "::error::neither GAIA_HUB_PUBLISH_URL nor GAIA_HUB_BASE_URL resolved for this job. Both must be REPOSITORY variables — an environment-scoped one resolves empty here, and this check would then target the custom domain rather than the origin the publish jobs POST to."
+            exit 1
+          fi
           for i in 1 2 3 4 5 6; do
             live="$(curl -fsS --max-time 15 "${base}/health" | python -c 'import json,sys; print(json.load(sys.stdin).get("build",""))' 2>/dev/null || true)"
             if [ "${live}" = "${GITHUB_SHA}" ]; then

--- a/workers/agent-hub/README.md
+++ b/workers/agent-hub/README.md
@@ -252,7 +252,8 @@ checked into the repo:
    redeployed, so every publish failed with `language "go" is not supported`
    while the source said otherwise.
 
-   The job needs two secrets on the **`agent-publish`** environment:
+   The job needs two **repository** secrets (not environment ones — it runs
+   outside `agent-publish` so a release needs only one approval):
 
    | Secret | How to get it |
    |---|---|

--- a/workers/agent-hub/README.md
+++ b/workers/agent-hub/README.md
@@ -252,8 +252,9 @@ checked into the repo:
    redeployed, so every publish failed with `language "go" is not supported`
    while the source said otherwise.
 
-   The job needs two **repository** secrets (not environment ones — it runs
-   outside `agent-publish` so a release needs only one approval):
+   The job needs two secrets on the **`worker-deploy`** environment — a second
+   environment with no required reviewers (so a release still prompts once)
+   but the same deployment ref allowlist as `agent-publish`:
 
    | Secret | How to get it |
    |---|---|

--- a/workers/agent-hub/README.md
+++ b/workers/agent-hub/README.md
@@ -263,6 +263,15 @@ checked into the repo:
 
    Without them the job fails loudly rather than publishing to a stale Worker.
 
+   **Creating the environment** (Settings → Environments → New environment,
+   named `worker-deploy`). Both settings below are load-bearing, and the second
+   one is easy to miss:
+
+   | Setting | Value | Why |
+   |---|---|---|
+   | Required reviewers | *leave empty* | The publish jobs are already gated on `agent-publish`. A reviewer here would add a second approval prompt to every release, which is the thing this environment exists to avoid. |
+   | Deployment branches and tags | `main`, `v*`, `agent-pkg-*` — the same allowlist as `agent-publish` | This is the *only* remaining restriction on the job. Without it, anyone with write access can dispatch the workflow from an arbitrary branch with `dry_run` unchecked and push that branch's Worker to production — and the Worker is the manifest validator that holds the R2 binding. |
+
    The deploy stamps the commit into `WORKER_BUILD`, which `GET /health`
    returns, so the workflow can assert *which* build went live instead of
    assuming. Check it by hand any time:


### PR DESCRIPTION
## Why this matters

Releasing hub components asks for approval twice. GitHub raises one prompt per *batch* of jobs that become pending together — `terminal-hub` and `agent-ui` pend simultaneously and share one, but `deploy-worker` has to finish before them, so it always forms an earlier batch of its own. Any environment-gated job placed before the publishes does this; it was a side effect of #2991 rather than a deliberate choice.

Dropping the environment from `deploy-worker` leaves exactly one gate, on the step that actually needs a human.

## Test plan

- [ ] Move `CLOUDFLARE_API_TOKEN` and `CLOUDFLARE_ACCOUNT_ID` to **repository** secrets (they are currently on the `agent-publish` environment, where this job can no longer read them)
- [ ] Dispatch with `dry_run=false` — exactly **one** approval prompt, raised after `deploy-worker` has already run
- [ ] Confirm `deploy-worker` still gates the publishes: they must not start if it fails
- [ ] Dispatch with `dry_run=true` — no deploy, no approval, `worker-check` still runs

<details>
<summary>🔍 The trade-off</summary>

The reviewer gate exists for the part that cannot be undone: an immutable R2 upload. The Worker deploy is neither irreversible (redeploying fixes it) nor unchecked — `worker-check` runs typecheck, the vitest suite, and a full bundle first, and the deploy only happens on a real release someone dispatched.

The genuine cost is secret scope: repository secrets are readable by every workflow in the repo, where environment secrets were readable by one. That is a real widening and the reason to keep the token minimally scoped — Workers + R2 on the single account, plus the `amd-gaia.ai` zone for the custom-domain route.

The alternative that keeps them environment-scoped is a second environment with the same reviewers, which trades the extra prompt for an extra environment to keep in sync. Happy to go that way instead if the wider secret scope is the bigger concern.
</details>
