### PR TITLE
fix(hub): stop boto3's default checksums breaking every R2 upload

### DIFF
--- a/hub/agents/email/python/packaging/publish_to_r2.py
+++ b/hub/agents/email/python/packaging/publish_to_r2.py
@@ -147,6 +147,7 @@ def _upload_to_r2(artifact_path: Path, key: str, sha_hex: str) -> None:
     """
     try:
         import boto3  # imported lazily: only the direct-upload path needs it
+        from botocore.config import Config as BotoConfig
     except ImportError as e:  # pragma: no cover - environment problem, not logic
         raise SystemExit(
             "error: boto3 is required to upload artifacts larger than "
@@ -167,12 +168,24 @@ def _upload_to_r2(artifact_path: Path, key: str, sha_hex: str) -> None:
     access_key, secret_key, account_id = creds
     bucket = os.environ.get("R2_BUCKET", "gaia-hub")
 
+    # boto3 >= 1.36 adds a CRC32 checksum to every PutObject by default and
+    # sends it as an aws-chunked trailer (Content-Encoding: aws-chunked,
+    # x-amz-content-sha256: STREAMING-UNSIGNED-PAYLOAD-TRAILER). R2 does not
+    # accept that trailer format and rejects the request outright — as
+    # `Unauthorized`, which reads like a credentials problem and is not one.
+    # `when_required` suppresses the automatic checksum while still sending the
+    # explicit ChecksumSHA256 below as a normal header, which is the whole point:
+    # the Worker refuses to publish an object R2 recorded no SHA-256 for.
     client = boto3.client(
         "s3",
         endpoint_url=f"https://{account_id}.r2.cloudflarestorage.com",
         aws_access_key_id=access_key,
         aws_secret_access_key=secret_key,
         region_name="auto",
+        config=BotoConfig(
+            request_checksum_calculation="when_required",
+            response_checksum_validation="when_required",
+        ),
     )
     print(
         f"[publish] uploading {artifact_path.name} -> r2://{bucket}/{key}", flush=True

--- a/hub/agents/email/python/tests/test_publish_to_r2_by_reference.py
+++ b/hub/agents/email/python/tests/test_publish_to_r2_by_reference.py
@@ -77,7 +77,13 @@ class _Resp:
 @pytest.fixture
 def captured(monkeypatch):
     """Capture the outgoing POST and any R2 upload, without performing either."""
-    seen: dict = {"post": None, "put": None, "head": None, "already_published": False}
+    seen: dict = {
+        "post": None,
+        "put": None,
+        "head": None,
+        "client_kwargs": None,
+        "already_published": False,
+    }
 
     def fake_post(url, headers=None, files=None, timeout=None):
         # requests encodes each value as (filename, body[, content_type]); read
@@ -98,6 +104,10 @@ def captured(monkeypatch):
         def put_object(self, **kw):
             seen["put"] = kw
 
+    def fake_client(*a, **kw):
+        seen["client_kwargs"] = kw
+        return _S3()
+
     def fake_head(url, timeout=None, allow_redirects=None):
         seen["head"] = url
         return type(
@@ -108,11 +118,22 @@ def captured(monkeypatch):
 
     monkeypatch.setattr(pub.requests, "post", fake_post)
     monkeypatch.setattr(pub, "_download_sha256", lambda *a, **k: None)
+
+    # Stub boto3 AND botocore.config: neither is installed in the unit env, and
+    # the client is constructed with a botocore Config object whose settings are
+    # the thing under test.
+    class _Config:
+        def __init__(self, **kw):
+            self.__dict__.update(kw)
+
+    sysmod = __import__("sys").modules
     monkeypatch.setitem(
-        __import__("sys").modules,
-        "boto3",
-        type("m", (), {"client": lambda *a, **k: _S3()}),
+        sysmod, "boto3", type("m", (), {"client": staticmethod(fake_client)})
     )
+    botocore = type("m", (), {})
+    botocore_config = type("m", (), {"Config": _Config})
+    monkeypatch.setitem(sysmod, "botocore", botocore)
+    monkeypatch.setitem(sysmod, "botocore.config", botocore_config)
     return seen
 
 
@@ -246,3 +267,40 @@ def test_the_check_runs_before_the_upload_not_after(
 
     assert captured["head"] is not None
     assert captured["put"] is not None
+
+
+def test_r2_client_disables_boto3_automatic_checksums(
+    manifest, tmp_path, captured, monkeypatch
+):
+    """boto3 >= 1.36 breaks R2 uploads unless the new defaults are turned off.
+
+    It adds a CRC32 checksum to every PutObject and sends it as an aws-chunked
+    trailer, which R2 rejects — reported as `Unauthorized`, which reads like a
+    credentials problem and sends you looking in the wrong place entirely. This
+    cost one real release, so pin the config rather than the symptom.
+    """
+    monkeypatch.setenv("R2_ACCESS_KEY_ID", "k")
+    monkeypatch.setenv("R2_SECRET_ACCESS_KEY", "s")
+    monkeypatch.setenv("CLOUDFLARE_ACCOUNT_ID", "acct")
+
+    _publish(manifest, _artifact(tmp_path, pub.DIRECT_UPLOAD_THRESHOLD + 1))
+
+    cfg = captured["client_kwargs"]["config"]
+    assert cfg.request_checksum_calculation == "when_required"
+    assert cfg.response_checksum_validation == "when_required"
+    # The explicit digest must survive — the Worker refuses an object R2 has no
+    # SHA-256 for, so suppressing checksums entirely would break verification.
+    assert "ChecksumSHA256" in captured["put"]
+
+
+def test_the_r2_endpoint_is_account_scoped(manifest, tmp_path, captured, monkeypatch):
+    monkeypatch.setenv("R2_ACCESS_KEY_ID", "k")
+    monkeypatch.setenv("R2_SECRET_ACCESS_KEY", "s")
+    monkeypatch.setenv("CLOUDFLARE_ACCOUNT_ID", "acct123")
+
+    _publish(manifest, _artifact(tmp_path, pub.DIRECT_UPLOAD_THRESHOLD + 1))
+
+    assert (
+        captured["client_kwargs"]["endpoint_url"]
+        == "https://acct123.r2.cloudflarestorage.com"
+    )


### PR DESCRIPTION
## Why this matters

The first real release through the direct-to-R2 lane died on `Unauthorized` from `PutObject` — which reads as a credentials problem, sends you to the Cloudflare token page, and is not the cause. The credentials were correct the whole time.

**boto3 ≥ 1.36 adds a CRC32 checksum to every `PutObject` by default** and sends it as an `aws-chunked` trailer. R2 doesn't accept that format and rejects the request. CI installs boto3 unpinned and got 1.43.76, so this would break every oversized publish, every time.

## Test plan

- [ ] `pytest hub/agents/email/python/tests/test_publish_to_r2_by_reference.py` — 11 pass
- [ ] Re-run `release_components.yml` with `dry_run=false`; `agent-ui` uploads and publishes where it previously got `Unauthorized`
- [ ] Confirm the published installer's catalog SHA-256 matches the file: `curl -s https://hub.amd-gaia.ai/index.json`

<details>
<summary>🔍 Why not just disable checksums</summary>

`request_checksum_calculation="when_required"` suppresses boto3's *automatic* CRC32 while leaving the explicit `ChecksumSHA256` as an ordinary header. That distinction is load-bearing: the Worker refuses to publish any object R2 recorded no whole-object SHA-256 for (`artifact_unverifiable`), so turning checksums off wholesale would swap one failure for another and lose the integrity guarantee the by-reference lane depends on.

A test asserts both config values *and* that `ChecksumSHA256` still reaches `put_object`, so a future "simplification" can't quietly drop the digest. Verified it fails with the config removed.

Pinning `boto3<1.36` would also work but freezes a security-relevant dependency to dodge a default; `when_required` is what both AWS and Cloudflare document for S3-compatible services.

Refs: [boto3#4392](https://github.com/boto/boto3/issues/4392), [boto3#4400](https://github.com/boto/boto3/issues/4400), [Cloudflare R2 boto3 docs](https://developers.cloudflare.com/r2/examples/aws/boto3/)
</details>
