### PR TITLE
fix(agent-gaia): make the flagship agent releasable — RAG in the binary, 0.1.1 on npm

### DIFF
--- a/.github/workflows/release_agent_gaia.yml
+++ b/.github/workflows/release_agent_gaia.yml
@@ -381,8 +381,14 @@ jobs:
           # rather than resolved from PyPI — the frozen binary must contain the
           # ChatAgent this commit was developed against, not whatever is
           # published.
+          #
+          # `rag` is required, not optional, in THIS lane: the agent's own
+          # pyproject leaves it out because a wheel gets it from `gaia init`
+          # into the active interpreter (#2358), and a frozen binary has no
+          # interpreter to install into. Without it faiss/pypdf are absent, the
+          # RAG tools still register, and document Q&A fails on every call.
           uv pip install --python .venv-freeze \
-            -e ".[api]" \
+            -e ".[api,rag]" \
             -e hub/agents/chat/python \
             -e hub/agents/gaia/python \
             pyinstaller
@@ -625,7 +631,9 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          uv pip install --system -e ".[api]" -e hub/agents/chat/python -e hub/agents/gaia/python pytest
+          # Same extras as the freeze env: testing without `rag` would exercise
+          # a dependency set no released binary ever has.
+          uv pip install --system -e ".[api,rag]" -e hub/agents/chat/python -e hub/agents/gaia/python pytest
 
       - name: Python tests (hub/agents/gaia/python/tests)
         shell: bash

--- a/hub/agents/gaia/npm/CHANGELOG.md
+++ b/hub/agents/gaia/npm/CHANGELOG.md
@@ -4,13 +4,13 @@ All notable changes to `@amd-gaia/gaia` are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and this package adheres
 to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.1.0] — unreleased
+## [0.1.1] — unreleased
 
-First release. `npx @amd-gaia/gaia` is now the single command that gets a user
-running GAIA: it fetches and verifies everything GAIA needs and drops them into
-the terminal UI. Before this there was no packaged path at all — the flagship agent
-had to be run from a repo checkout with a Python environment, and reaching the
-terminal UI meant building it from source.
+First working release. `npx @amd-gaia/gaia` is now the single command that gets a
+user running GAIA: it fetches and verifies everything GAIA needs and drops them
+into the terminal UI. Before this there was no packaged path at all — the flagship
+agent had to be run from a repo checkout with a Python environment, and reaching
+the terminal UI meant building it from source.
 
 ### Added
 
@@ -87,7 +87,7 @@ terminal UI meant building it from source.
 - The sidecar has no arm64 Linux or arm64 Windows build. On those platforms the
   run stops with an error naming the platform and the supported set rather than
   launching a UI with no agent behind it.
-- `gaia_agent` 0.1.0 has no caller-auth token, so unlike
+- `gaia_agent` 0.1.1 has no caller-auth token, so unlike
   `@amd-gaia/agent-email` this package mints and sends none.
 - Tracks sidecar contract `apiVersion` **2.12**; a differing major raises
   `VersionMismatchError`.

--- a/hub/agents/gaia/npm/SKILL.md
+++ b/hub/agents/gaia/npm/SKILL.md
@@ -328,7 +328,7 @@ for a personal document agent, and it is still a real boundary — system
 directories, program files, and other users' homes are refused, with the check
 run against the *resolved* path so a symlink out of scope doesn't slip through.
 
-**In 0.1.0 narrowing it is a construction-time setting only.** The packaged
+**In 0.1.1 narrowing it is a construction-time setting only.** The packaged
 sidecar exposes no flag or env var for `allowed_paths` (its CLI accepts only
 `--host` and `--port`), so restricting the scope means embedding `GaiaAgent` in
 your own Python process:
@@ -339,7 +339,7 @@ from gaia_agent.agent import GaiaAgent, GaiaAgentConfig
 agent = GaiaAgent(config=GaiaAgentConfig(allowed_paths=["/home/me/Documents"]))
 ```
 
-## 10. Skills — opt-in, and empty in 0.1.0
+## 10. Skills — opt-in, and empty in 0.1.1
 
 The agent is built to host **Agent Skills** (short playbooks loaded into its own
 prompt, grouped into named sets, one set active per launch), and its bundled
@@ -355,7 +355,7 @@ threshold. Manifest `skills:` entries are always-on and never collapse. If the
 embedder is unavailable, selection disables itself for the session and every
 body renders — capability is never silently lost to a failed match.
 
-**Nothing ships enabled in 0.1.0.** The bundled skill library is empty, and
+**Nothing ships enabled in 0.1.1.** The bundled skill library is empty, and
 `gaia-agent.yaml` ships its `skills:` / `skill_sets:` / `default_skill_set:`
 blocks **commented out** — following the email agent's precedent, because skill
 bodies cost prompt tokens and no eval has measured that trade for this agent yet.
@@ -414,7 +414,7 @@ There is no silent null.
   broken install, and there is no override.
 - **No `linux-arm64` / `win32-arm64` sidecar.** The TUI has both. A `PlatformError`
   on those hosts is the design, not a missing artifact.
-- **There is no caller-auth token at 0.1.0.** Unlike `@amd-gaia/agent-email`, this
+- **There is no caller-auth token at 0.1.1.** Unlike `@amd-gaia/agent-email`, this
   sidecar mints none and this package sends none — don't add an `Authorization`
   header looking for one, and don't rely on its absence as a security boundary.
   Loopback binding is what protects it.
@@ -452,7 +452,7 @@ Then, in another terminal:
 
 ```bash
 curl -s http://127.0.0.1:8141/health          # {"status":"ok","service":"gaia-agent-gaia"}
-curl -s http://127.0.0.1:8141/version         # {"apiVersion":"2.12","agentVersion":"0.1.0"}
+curl -s http://127.0.0.1:8141/version         # {"apiVersion":"2.12","agentVersion":"0.1.1"}
 curl -s http://127.0.0.1:8141/v1/gaia/init    # 200 + "ready":true, or 503 + a "hint"
 curl -N -X POST http://127.0.0.1:8141/v1/gaia/query \
   -H 'content-type: application/json' \

--- a/hub/agents/gaia/npm/SPEC.md
+++ b/hub/agents/gaia/npm/SPEC.md
@@ -1,6 +1,6 @@
 # `@amd-gaia/gaia` — technical reference
 
-Version **0.1.0**. Companion to [`README.md`](./README.md), which is the
+Version **0.1.1**. Companion to [`README.md`](./README.md), which is the
 user-facing doc. This file specifies the wire and file formats the package
 depends on and the guarantees it makes.
 
@@ -32,11 +32,11 @@ of truth for what is downloaded and what it must hash to.
 ```jsonc
 {
   "schemaVersion": "3.0",
-  "agentVersion": "0.1.0",
+  "agentVersion": "0.1.1",
   "components": {
     "sidecar": {
-      "componentVersion": "0.1.0",
-      "baseUrl": "https://hub.amd-gaia.ai/agents/gaia/0.1.0",
+      "componentVersion": "0.1.1",
+      "baseUrl": "https://hub.amd-gaia.ai/agents/gaia/0.1.1",
       "platforms": { "<platformKey>": { /* entry */ } }
     },
     "tui": {
@@ -269,7 +269,7 @@ backward-compatible addition and is accepted.
 ### 5.4 No caller-auth token
 
 The email sidecar authenticates callers with a per-session bearer minted into
-`GAIA_EMAIL_SIDECAR_TOKEN`. `gaia_agent` has **no equivalent** at 0.1.0, so
+`GAIA_EMAIL_SIDECAR_TOKEN`. `gaia_agent` has **no equivalent** at 0.1.1, so
 this package mints and sends nothing. When the sidecar grows one, it lands here as
 a spawn-time env var and a request header — a change to this section, not a new
 subsystem.

--- a/hub/agents/gaia/npm/binaries.lock.json
+++ b/hub/agents/gaia/npm/binaries.lock.json
@@ -1,10 +1,10 @@
 {
   "schemaVersion": "3.0",
-  "agentVersion": "0.1.0",
+  "agentVersion": "0.1.1",
   "components": {
     "sidecar": {
-      "componentVersion": "0.1.0",
-      "baseUrl": "https://hub.amd-gaia.ai/agents/gaia/0.1.0",
+      "componentVersion": "0.1.1",
+      "baseUrl": "https://hub.amd-gaia.ai/agents/gaia/0.1.1",
       "platforms": {
         "win32-x64": {
           "filename": "gaia-agent-win32-x64.exe",

--- a/hub/agents/gaia/npm/package.json
+++ b/hub/agents/gaia/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amd-gaia/gaia",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "type": "module",
   "description": "One command to run GAIA: fetches and SHA-256 verifies the flagship agent sidecar and the terminal UI, then launches them. Runs 100% locally on AMD Ryzen AI.",
   "author": "AMD AI Group",

--- a/hub/agents/gaia/npm/test/lock.test.ts
+++ b/hub/agents/gaia/npm/test/lock.test.ts
@@ -49,9 +49,12 @@ describe("shipped binaries.lock.json", () => {
     expect(Object.keys(lock.components).sort()).toEqual([...COMPONENTS].sort());
   });
 
+  // Pinning the literal version here would only force an edit every release;
+  // what actually protects a publish is the lock and package.json agreeing,
+  // and the version being a real semver rather than a leftover placeholder.
   it("agrees with package.json on the version", () => {
     expect(lock.agentVersion).toBe(pkg.version);
-    expect(pkg.version).toBe("0.1.0");
+    expect(pkg.version).toMatch(/^\d+\.\d+\.\d+$/);
   });
 
   it("publishes the sidecar from the gaia lane at the agent's own version", () => {

--- a/hub/agents/gaia/python/gaia-agent.yaml
+++ b/hub/agents/gaia/python/gaia-agent.yaml
@@ -1,6 +1,6 @@
 id: gaia
 name: GAIA
-version: 0.1.0
+version: 0.1.1
 description: "The flagship GAIA agent — conversation, document Q&A, data analysis, and web research, with persistent memory and add-on skills"
 author: AMD
 license: MIT

--- a/hub/agents/gaia/python/gaia_agent/__init__.py
+++ b/hub/agents/gaia/python/gaia_agent/__init__.py
@@ -9,7 +9,7 @@ this module must not drag in RAG, the browser stack, or a model client.
 
 __all__ = ["build_gaia"]
 
-__version__ = "0.1.0"
+__version__ = "0.1.1"
 
 _LAZY = {
     "GaiaAgent": "agent",

--- a/hub/agents/gaia/python/packaging/freeze.py
+++ b/hub/agents/gaia/python/packaging/freeze.py
@@ -62,6 +62,28 @@ PATHEX = [
 MANIFEST_SRC = PKG_ROOT / "gaia-agent.yaml"
 SKILLS_SRC = PKG_ROOT / "gaia_agent" / "skills"
 
+# Modules PyInstaller must pull in wholesale, and the distributions whose
+# metadata must travel with them. Declared once so the preflight guard below
+# and the CLI args can never disagree about what has to be in the binary.
+COLLECT_SUBMODULES = [
+    # uvicorn: string-imported loops/protocols/lifespan.
+    "uvicorn",
+    # keyring: OS backend resolution via entry points.
+    "keyring",
+    # Both agent packages register tools lazily inside functions.
+    "gaia_agent",
+    "gaia_agent_chat",
+    # connector provider discovery is dynamic.
+    "gaia.connectors",
+    # pydantic v2 ships a compiled core; collect data to be safe.
+    "pydantic",
+]
+# FAISS backs the memory / RAG working-context index. faiss-cpu ships compiled
+# libs + swig submodules the static analyzer misses.
+COLLECT_ALL = ["faiss"]
+# importlib.metadata version probes + entry-point agent discovery.
+COPY_METADATA = ["keyring", "amd-gaia", "gaia-agent-gaia", "gaia-agent-chat"]
+
 # Heavy ML stack reached only through the lazily-imported chat/SDK graph. All
 # inference goes to Lemonade over HTTP, so excluding these keeps the binary at
 # ~100 MB instead of ~2 GB. numpy stays (memory.py imports it at module level).
@@ -84,6 +106,35 @@ EXCLUDES = [
     "sympy",
     "pandas",
 ]
+
+
+def _verify_collect_targets() -> None:
+    """Fail the build if a collect target is not importable in this env.
+
+    PyInstaller downgrades an uncollectable ``--collect-all`` target to a
+    WARNING and keeps going, so a missing dependency does not fail the freeze --
+    it ships a binary silently missing that capability. ``faiss`` is the live
+    example: the release workflow installs only ``.[api]``, which carries no RAG
+    deps, so the binary booted and passed the smoke test with vector search and
+    document Q&A absent. A frozen binary has no interpreter for the
+    "pip install" remedy those code paths advise, so the gap is unrecoverable on
+    the user's machine -- it has to fail here instead.
+    """
+    import importlib.util
+
+    missing = [
+        mod
+        for mod in COLLECT_SUBMODULES + COLLECT_ALL
+        if importlib.util.find_spec(mod) is None
+    ]
+    if missing:
+        raise SystemExit(
+            "freeze: refusing to build -- these modules are declared for "
+            f"collection but are not installed: {', '.join(missing)}.\n"
+            "PyInstaller would only warn and produce a binary missing that "
+            "capability. Install them into the freeze environment and re-run, "
+            'e.g. `uv pip install --python .venv-freeze -e ".[api,rag]"`.'
+        )
 
 
 def _resolve_add_data() -> list[tuple[Path, str]]:
@@ -135,6 +186,7 @@ def _resolve_add_data() -> list[tuple[Path, str]]:
 def build(onefile: bool = False, clean: bool = True) -> Path:
     import PyInstaller.__main__
 
+    _verify_collect_targets()
     add_data = _resolve_add_data()
 
     work = HERE / "build"
@@ -160,38 +212,12 @@ def build(onefile: bool = False, clean: bool = True) -> Path:
     ]
     for path in PATHEX:
         args += ["--paths", str(path)]
-    args += [
-        # uvicorn: string-imported loops/protocols/lifespan.
-        "--collect-submodules",
-        "uvicorn",
-        # keyring: OS backend resolution via entry points.
-        "--collect-submodules",
-        "keyring",
-        "--copy-metadata",
-        "keyring",
-        # Both agent packages register tools lazily inside functions.
-        "--collect-submodules",
-        "gaia_agent",
-        "--collect-submodules",
-        "gaia_agent_chat",
-        # connector provider discovery is dynamic.
-        "--collect-submodules",
-        "gaia.connectors",
-        # FAISS backs the memory / RAG working-context index. faiss-cpu ships
-        # compiled libs + swig submodules the static analyzer misses.
-        "--collect-all",
-        "faiss",
-        # pydantic v2 ships a compiled core; collect data to be safe.
-        "--collect-submodules",
-        "pydantic",
-        # importlib.metadata version probes + entry-point agent discovery.
-        "--copy-metadata",
-        "amd-gaia",
-        "--copy-metadata",
-        "gaia-agent-gaia",
-        "--copy-metadata",
-        "gaia-agent-chat",
-    ]
+    for mod in COLLECT_SUBMODULES:
+        args += ["--collect-submodules", mod]
+    for mod in COLLECT_ALL:
+        args += ["--collect-all", mod]
+    for distribution in COPY_METADATA:
+        args += ["--copy-metadata", distribution]
     for source, dest in add_data:
         args += ["--add-data", f"{source}{os.pathsep}{dest}"]
     for mod in EXCLUDES:

--- a/hub/agents/gaia/python/packaging/stamp_version.py
+++ b/hub/agents/gaia/python/packaging/stamp_version.py
@@ -128,6 +128,15 @@ def build_rules() -> list[Rule]:
             "baseUrl",
             required=True,
         ),
+        # The SIDECAR lane's componentVersion — anchored on "sidecar" so the tui
+        # lane, which tracks terminal-hub and not this package, is never touched.
+        Rule(
+            "binaries.lock.json (sidecar componentVersion)",
+            NPM_ROOT / "binaries.lock.json",
+            re.compile(r'("sidecar"\s*:\s*\{\s*"componentVersion":\s*")([^"]+)(")'),
+            "componentVersion",
+            required=True,
+        ),
         # Optional: shields.io static version badges in the shipped READMEs.
         *(
             Rule(

--- a/hub/agents/gaia/python/pyproject.toml
+++ b/hub/agents/gaia/python/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "gaia-agent-gaia"
-version = "0.1.0"
+version = "0.1.1"
 description = "The flagship GAIA agent — conversation, document Q&A, data analysis, and web research, with persistent memory and add-on skills"
 authors = [{ name = "AMD" }]
 license = "MIT"


### PR DESCRIPTION
Two things would have gone wrong the moment someone tagged the flagship agent's first release. This PR fixes both. It does not release anything — tagging `agent-pkg-gaia-v0.1.1` is still a maintainer's call.

**The binary would have shipped without document Q&A.** CI froze the sidecar from `.[api]`, which carries no RAG dependencies, so `--collect-all faiss` matched nothing — and PyInstaller downgrades an uncollectable target to a warning, not an error. The build went green, the binary booted, and the smoke test passed with faiss and the PDF readers entirely absent. The failure only surfaces once a user asks about a document: the RAG tools still register and are advertised to the model, then every call returns *"RAG not available. Install with: uv pip install -e .[rag]"* — advice that a user running a frozen binary has no interpreter to follow. The agent's manifest leads with document Q&A; it would have failed on every attempt.

**npm would have been skipped silently.** `@amd-gaia/gaia` already holds `0.1.0` and `0.0.0` from before the code existed — two files each, no client — and npm versions are immutable. The release skips `npm publish` when the version exists, so tagging 0.1.0 would have published the hub artifacts and left `npx @amd-gaia/gaia` on a package that does nothing. Hence **0.1.1**.

Verified on Windows by running the freeze exactly as CI does: **91.1 MB** with RAG (49.1 MB without), ~80–105s — the sidecar size the [flagship-installer plan](https://github.com/amd/gaia/blob/main/docs/plans/flagship-installer.mdx) calls unmeasured. The frozen binary constructs the agent on a real query, loading faiss, the filesystem index, the scratchpad DB, and 28 skills, and stops only at the Lemonade connection — the documented LLM-less pass.

## Before tagging

- [ ] **Register the npm trusted publisher for `@amd-gaia/gaia`** (repo `amd/gaia`, workflow `release_agent_gaia.yml`). The publish step uses OIDC with no token and this package has never published that way — `0.1.0` was hand-published by `kovtcharov-amd` with no attestations, while `@amd-gaia/agent-email@0.6.0` shows `GitHub Actions` + attestations. Without it the release fails at its last step, after the hub publish has landed.
- [ ] Confirm `GAIA_HUB_TOKEN` is an **environment** secret on `agent-publish` (the environment itself exists).

<details>
<summary>🔍 Technical details</summary>

**Why the RAG gap existed.** `hub/agents/gaia/python/pyproject.toml` deliberately declares bare `amd-gaia` with no `[rag]` extra, because for a wheel those dependencies genuinely arrive via `gaia init` into the active interpreter (#2358). That reasoning is right for a wheel and wrong for a frozen binary, where there is no interpreter to install into. The freeze lane is the exception, so the extras are added there — the agent's own pyproject is unchanged.

**Why the smoke test could not catch it.** `build_query_agent` imports the agent lazily and `/init` only probes Lemonade, so `/health`, `/version` and `/openapi.json` never construct it. The workflow comment claiming "an import that only resolves in the dev venv … fails here" is not true as written; agent construction happens on `POST /v1/gaia/query`, well after the smoke checks pass. `freeze.py` now refuses to build when a declared collect target is not importable, which is where this class of gap can actually be caught.

**The version gate had a hole too.** `stamp_version.py` stamped the lock's `agentVersion` and `baseUrl` but not the sidecar lane's `componentVersion`, so `--check` passed on a lock whose two version fields disagreed. The new rule is anchored to the sidecar lane, leaving the tui lane (which tracks `terminal-hub`, not this package) alone. The lock test's hardcoded version pin is replaced with a semver-shape assertion — it forced an edit every release without covering anything the drift check above it does not.

**Already green:** `terminal-hub` is published at 0.23.0, the version the lock pins for the tui lane (the release is gated on it). All three version sources agree at 0.1.1. `GAIA_HUB_BASE_URL` being unset in CI is harmless — the workflow defaults it.
</details>

## Test plan

- [x] Windows PyInstaller freeze run exactly as CI does — succeeds; frozen binary boots, constructs the agent on a real POST, loads faiss + 28 skills
- [x] Verified the pre-fix config reproduces the bug: `.[api]` builds a 49.1 MB binary with zero faiss/pypdf entries in the archive
- [x] `stamp_version.py --check` clean at 0.1.1, and confirmed it now **fails** on hand-drifted sidecar `componentVersion` (it previously passed)
- [x] gaia agent Python suite — 188 passed
- [x] npm suite — 101 passed, 3 skipped; `npm pack --dry-run` 39 files / 188.6 kB
- [ ] Reviewer: freeze is verified on Windows only. macOS arm64/x64 and Linux x64 build for the first time during the release itself.