### PR TITLE
ci(cloud): provision the dev install in Claude Code cloud sessions

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -6,7 +6,7 @@
   "hooks": {
     "SessionStart": [
       {
-        "matcher": "startup|resume",
+        "matcher": "startup|resume|clear|compact",
         "hooks": [
           {
             "type": "command",

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -2,5 +2,18 @@
   "enabledPlugins": {
     "frontend-design@claude-plugins-official": true,
     "superpowers@claude-plugins-official": true
+  },
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "startup|resume",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"$CLAUDE_PROJECT_DIR\"/scripts/cloud_bootstrap.sh"
+          }
+        ]
+      }
+    ]
   }
 }

--- a/docs/reference/dev.mdx
+++ b/docs/reference/dev.mdx
@@ -159,6 +159,16 @@ build, pulling ~18 `nvidia-*` / `cuda-*` packages — a 4.7 GB venv instead of
 
 ### Step 6: Claude Code Plugins (Optional)
 
+<Note>
+The same `.claude/settings.json` registers a `SessionStart` hook that runs
+[`scripts/cloud_bootstrap.sh`](https://github.com/amd/gaia/blob/main/scripts/cloud_bootstrap.sh).
+It builds the editable dev install for [Claude Code cloud sessions](https://code.claude.com/docs/en/claude-code-on-the-web),
+where the environment's own setup script runs before the repo is cloned and so
+cannot do it. On a local machine and in CI it exits immediately without output —
+it is gated on `CLAUDE_CODE_REMOTE` and `CI`.
+</Note>
+
+
 GAIA ships a `.claude/settings.json` that declares two recommended Claude Code plugins from the official Anthropic marketplace:
 
 - **`frontend-design`** — higher-quality, less generic UI generation

--- a/scripts/cloud_bootstrap.sh
+++ b/scripts/cloud_bootstrap.sh
@@ -23,13 +23,18 @@ if [ -n "$CI" ]; then
     exit 0
 fi
 
+# Defensive only: the hook interpolates $CLAUDE_PROJECT_DIR to locate this
+# script, so an unset value fails before this runs. Reachable when invoked directly.
 if [ -z "$CLAUDE_PROJECT_DIR" ]; then
     echo "cloud_bootstrap: CLAUDE_PROJECT_DIR is unset, cannot locate the repo root." >&2
-    echo "  Expected Claude Code to set it. Check the SessionStart hook in .claude/settings.json." >&2
+    echo "  Set it to the repo root, or run via the SessionStart hook in .claude/settings.json." >&2
     exit 1
 fi
 
-cd "$CLAUDE_PROJECT_DIR" || exit 1
+if ! cd "$CLAUDE_PROJECT_DIR"; then
+    echo "cloud_bootstrap: cannot enter CLAUDE_PROJECT_DIR ($CLAUDE_PROJECT_DIR)." >&2
+    exit 1
+fi
 
 # Claude Code clones the repo before SessionStart hooks run, so a missing
 # checkout means something is wrong upstream. Say so rather than acting on it.
@@ -38,11 +43,21 @@ if [ ! -f pyproject.toml ]; then
     exit 1
 fi
 
+if ! command -v uv >/dev/null 2>&1; then
+    echo "cloud_bootstrap: uv is not installed, cannot build the dev environment." >&2
+    echo "  Add 'curl -LsSf https://astral.sh/uv/install.sh | sh' to the cloud environment's setup script." >&2
+    exit 1
+fi
+
 set -e
 
-# A cached environment snapshot may already carry a provisioned venv.
-if [ ! -x .venv/bin/python ]; then
-    uv venv .venv --python 3.12
+# Probe the package, not the interpreter: an install interrupted partway leaves
+# a working .venv/bin/python behind but no gaia, and every later session would
+# skip the rebuild while still being told the install is ready.
+if ! .venv/bin/python -c "import gaia" >/dev/null 2>&1; then
+    # --clear because uv refuses to build over an existing venv, which is
+    # exactly the state the probe above catches.
+    uv venv .venv --clear --python 3.12
 
     # --extra-index-url is load-bearing: without the CPU wheel index this
     # resolves to the CUDA torch build and drags in ~4.7 GB of packages.

--- a/scripts/cloud_bootstrap.sh
+++ b/scripts/cloud_bootstrap.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+# GAIA - Claude Code cloud session bootstrap
+#
+# Creates the editable dev install for a Claude Code cloud session. A cloud
+# environment's setup script runs before the repo is cloned, so anything that
+# needs the checkout has to run here instead, as a SessionStart hook wired up
+# in .claude/settings.json.
+#
+# No-op on local machines.
+
+# CLAUDE_CODE_REMOTE is "true" only inside a cloud session VM.
+if [ "$CLAUDE_CODE_REMOTE" != "true" ]; then
+    exit 0
+fi
+
+# Belt and braces: several workflows run Claude Code in GitHub Actions, which
+# provisions its own environment. Never provision one there.
+if [ -n "$CI" ]; then
+    exit 0
+fi
+
+if [ -z "$CLAUDE_PROJECT_DIR" ]; then
+    echo "cloud_bootstrap: CLAUDE_PROJECT_DIR is unset, cannot locate the repo root." >&2
+    echo "  Expected Claude Code to set it. Check the SessionStart hook in .claude/settings.json." >&2
+    exit 1
+fi
+
+cd "$CLAUDE_PROJECT_DIR" || exit 1
+
+# Claude Code clones the repo before SessionStart hooks run, so a missing
+# checkout means something is wrong upstream. Say so rather than acting on it.
+if [ ! -f pyproject.toml ]; then
+    echo "cloud_bootstrap: no pyproject.toml at $CLAUDE_PROJECT_DIR, skipping the dev install." >&2
+    exit 1
+fi
+
+set -e
+
+# A cached environment snapshot may already carry a provisioned venv.
+if [ ! -x .venv/bin/python ]; then
+    uv venv .venv --python 3.12
+
+    # --extra-index-url is load-bearing: without the CPU wheel index this
+    # resolves to the CUDA torch build and drags in ~4.7 GB of packages.
+    uv pip install --python .venv/bin/python -e ".[dev]" \
+        --extra-index-url https://download.pytorch.org/whl/cpu
+fi
+
+# SessionStart stdout becomes session context. Without this the session reaches
+# for the system python, where gaia isn't importable.
+echo "GAIA dev install is in .venv — use .venv/bin/python, .venv/bin/pytest, .venv/bin/gaia."


### PR DESCRIPTION
Claude Code cloud sessions currently start with no GAIA install, so anything that imports `gaia` or runs `pytest` fails at import — which makes a cloud session useless for verifying pull requests. This adds a SessionStart hook that provisions the editable dev install once the repo is cloned. The environment's setup script can't do this job: it runs *before* the clone exists, and its filesystem is snapshotted and reused for days, so a checkout made there would be frozen at one commit on one branch.

The hook is inert everywhere except a cloud session VM. It exits before producing any output when `CLAUDE_CODE_REMOTE` isn't `true`, and again when `CI` is set, so local development and the eight workflows that run Claude Code in GitHub Actions are unaffected. SessionStart hooks cannot block a session, so the worst case anywhere is a stderr line.

## Test plan

- [x] Local dev path is a silent no-op — exit 0, no stdout, no stderr, **9.75 ms** per session start (measured over 20 runs)
- [x] `CI=true` exits 0, including when `CLAUDE_CODE_REMOTE` is also set
- [x] Missing checkout / unset `CLAUDE_PROJECT_DIR` fails loudly with an actionable message rather than guessing
- [x] Existing `.venv` short-circuits the reinstall
- [x] Install line resolves for the cloud VM's platform: `uv pip install --dry-run --python-platform x86_64-unknown-linux-gnu -e ".[dev]" --extra-index-url https://download.pytorch.org/whl/cpu` → **131 packages, `torch==2.13.0+cpu`, zero CUDA packages**
- [ ] End-to-end in a real cloud session — requires the hook on `main` first, since cloud sessions clone from there

<details>
<summary>🔍 Technical details</summary>

**Why a SessionStart hook rather than the environment setup script.** Per the [cloud environments docs](https://code.claude.com/docs/en/cloud-environments), the setup script "runs first, before Claude Code launches, and only when no cached environment exists," and its result is a filesystem snapshot reused for roughly seven days. The repo clone is per-session and happens after, so the setup script has no checkout to install from and no way to know which branch the session wants.

**Guard order** in `scripts/cloud_bootstrap.sh`: `CLAUDE_CODE_REMOTE != "true"` → exit 0; `CI` set → exit 0; `CLAUDE_PROJECT_DIR` unset → exit 1 with a message naming `.claude/settings.json`; no `pyproject.toml` → exit 1. Only then `set -e` and the install.

**`--extra-index-url` is load-bearing.** Without the CPU wheel index the resolve picks the CUDA torch build and pulls roughly 4.7 GB.

**Hook stdout is session context.** SessionStart is one of the events where Claude Code adds plain-text stdout as context, so the hook names `.venv` explicitly — otherwise the session reaches for the system python and `import gaia` fails confusingly. This line is only emitted on the cloud path.

**Not included:** the environment's setup script itself, which lives in the cloud environment dialog rather than the repo. It needs `apt-get update` and `apt-get install -y gh` on separate lines — joined by `&&` under `set -e`, a failing left side is exempt from `set -e`, so `gh` silently never installs. `apt-get update` currently exits non-zero because the security proxy 403s `ppa.launchpadcontent.net` (only `ppa.launchpad.net` is on the Trusted allowlist), which is harmless since every Ubuntu archive fetches fine.

</details>
