### PR TITLE
ci(hub): require component manifests to match the release tag again

### DIFF
--- a/.github/workflows/release_components.yml
+++ b/.github/workflows/release_components.yml
@@ -62,13 +62,19 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      # Each component is versioned by its OWN manifest, independently of the
-      # core release and of each other. They used to be pinned to the release
-      # tag, which meant a terminal-hub rebuild could not ship without a whole
-      # core release, and bumping one component forced the other.
+      # Both components ship as part of the core release and carry its version,
+      # deliberately: one number for the whole release is simpler to reason
+      # about than three, and agent-ui's npm package already tracks
+      # src/gaia/version.py through installer/version/bump-ui-version.mjs.
       #
-      # `version` here is the CORE release, kept only for the min_gaia_version
-      # check below — it is NOT the path anything publishes under.
+      # A TAG therefore requires both manifests to already match it (asserted
+      # below). A DISPATCH does not: re-running a publish, or shipping a rebuilt
+      # binary between core releases, must not require cutting a core release —
+      # that coupling is what made every terminal-hub re-run fail.
+      #
+      # Each still publishes under the version in its own manifest, read by
+      # publish_to_r2.py. The assertion keeps them equal to the release; it is
+      # not what supplies the path.
       - id: v
         shell: bash
         run: |
@@ -98,6 +104,29 @@ jobs:
               exit 1
             fi
           done
+
+          # Both components ship as part of the core release and carry its
+          # version, so a TAG must find them already bumped: publishing under a
+          # stale version writes to an immutable path that cannot be corrected,
+          # and the catalog picks latest_version by highest SemVer, so a stale
+          # one is not even reachable as "latest".
+          #
+          # A DISPATCH is deliberately exempt. That is the whole point of the
+          # split: re-running a component publish, or shipping a rebuilt binary
+          # between core releases, must not require cutting a core release.
+          if [ "${{ github.event_name }}" != "workflow_dispatch" ]; then
+            fail=0
+            for pair in "${TERMINAL_HUB_MANIFEST}:${TUI_V}" "${AGENT_UI_MANIFEST}:${UI_V}"; do
+              m="${pair%:*}"; got="${pair##*:}"
+              if [ "${got}" != "${CORE}" ]; then
+                echo "::error file=${m}::version ${got} does not match the release ${CORE}. Bump it before tagging — R2 paths are immutable, so publishing under a stale version cannot be undone."
+                fail=1
+              else
+                echo "✓ ${m} = ${got}"
+              fi
+            done
+            [ "${fail}" -eq 0 ] || exit 1
+          fi
 
           echo "version=${CORE}"       >> "$GITHUB_OUTPUT"
           echo "tui_version=${TUI_V}"  >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
`terminal-hub` and `agent-ui` ship as part of the core release and carry its version — one number for the whole release rather than three, and agent-ui's npm package already tracks `src/gaia/version.py` through `installer/version/bump-ui-version.mjs`.

#3035 removed the assertion that kept them equal, because that same assertion also made it impossible to publish a component without cutting a whole core release — which is why every terminal-hub re-run failed. This restores the half worth keeping: **a tag must find both manifests already bumped, a dispatch stays exempt.**

Without it, a forgotten bump publishes to an immutable path that cannot be corrected. Worse, it would not even be reachable: the catalog picks `latest_version` by highest SemVer (`latestVersion()` in `workers/agent-hub/src/catalog.ts`), so a stale version is silently invisible to `install.sh`, `install.ps1`, and the website download button — all of which resolve through that field.

<details>
<summary>🔍 Technical details</summary>

The split matters because the two triggers want opposite things:

| Trigger | Behaviour | Why |
|---|---|---|
| `push: tags: v*` | both manifests must equal the tag | a core release ships them; a stale manifest is an unfixable publish |
| `workflow_dispatch` | uses each manifest's own version | re-running a publish, or shipping a rebuilt binary between releases, must not require a core release |

Each component still publishes under the version in its own manifest — `publish_to_r2.py` reads it from there. The assertion keeps that equal to the release; it is not what supplies the path.
</details>

## Test plan

- [x] YAML parses; all six jobs intact
- [x] `python util/verify_publish_pipeline.py` — 18/18 across both publishers (the harness #3035 added)
- [ ] Reviewer: confirm a `workflow_dispatch` run still resolves versions from the manifests — that exemption is what unblocked component re-runs
