### PR TITLE
fix(hub): give the website redeploy a repo to dispatch against

### DIFF
--- a/.github/workflows/release_components.yml
+++ b/.github/workflows/release_components.yml
@@ -518,5 +518,6 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
-          gh workflow run deploy_website.yml --ref main
+          # --repo: this job has no checkout, so gh cannot infer the repository.
+          gh workflow run deploy_website.yml --repo "${GITHUB_REPOSITORY}" --ref main
           echo "✓ requested website redeploy (deploy_website.yml on main)"


### PR DESCRIPTION
The first successful hub publish (run 32529121706 — `terminal-hub` and `agent-ui` both green) exposed a bug that has been latent since this job was written: the website never gets rebuilt.

```
gh workflow run deploy_website.yml --ref main
  -> failed to run git: fatal: not a git repository
```

The job deliberately does not check out, so `gh` has no git remote to infer the repository from. It only runs when **both** publishes succeed, and until today one always failed — so nothing ever reached it.

**Why it matters:** the website builds its Hub pages from the live `index.json` at deploy time, so a publish is invisible on amd-gaia.ai until a rebuild. `agent-ui@0.23.0` is in the catalog right now and the site does not know.

`${GITHUB_REPOSITORY}` rather than a literal, so a fork dispatches against itself.

## Test plan

- [x] YAML parses; all six jobs intact
- [ ] Reviewer: next component publish should trigger `deploy_website.yml` on main
- [ ] One-off: the site needs a manual redeploy to pick up `agent-ui@0.23.0`