### PR TITLE
docs(readme): note the Email agent's CLI install path

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@
 
 See the [installation guide](https://github.com/amd/gaia/blob/main/docs/guides/install.mdx) for setup instructions.
 
+> **Note (Email agent):** the Email agent (0.6.0) supports **two** install paths — the npm client and `gaia hub install email`, which fetches the same build as a binary sidecar into your GAIA agents directory. There is no PyPI wheel; `gaia hub install email` is the preferred path since it integrates with the GAIA CLI and requires no Node.js toolchain.
+
 ---
 
 ## Why GAIA?

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@
 
 See the [installation guide](https://github.com/amd/gaia/blob/main/docs/guides/install.mdx) for setup instructions.
 
-> **Note (Email agent):** the Email agent (0.6.0) supports **two** install paths — the npm client and `gaia hub install email`, which fetches the same build as a binary sidecar into your GAIA agents directory. There is no PyPI wheel; `gaia hub install email` is the preferred path since it integrates with the GAIA CLI and requires no Node.js toolchain.
+> **Note (Email agent):** the Email agent installs with `gaia hub install email`, which fetches a binary sidecar into your GAIA agents directory — no PyPI wheel and no Node.js toolchain required. An npm client is also published for embedding the agent in a JS/TS app.
 
 ---
 

--- a/website/src/components/InstallCard.astro
+++ b/website/src/components/InstallCard.astro
@@ -36,7 +36,7 @@ const meta = [
 
   <p class="mt-3.5 text-[13px] leading-[1.6] text-g-faint">
     {isNpm && (
-      <span>Ships as an npm client plus a frozen binary sidecar — npm is its only supported install path (there is no PyPI wheel). </span>
+      <span>Installs with <span class="mono text-g-muted">gaia hub install {agent.id}</span>, which fetches the frozen binary sidecar into your GAIA agents directory. The npm package is an embed path for JS/TS apps rather than a way to install the agent itself. </span>
     )}
     A local model must be running first: <span class="mono text-g-muted">gaia init</span> then <span class="mono text-g-muted">lemonade-server serve</span>.
   </p>

--- a/website/src/components/InstallCard.astro
+++ b/website/src/components/InstallCard.astro
@@ -36,7 +36,7 @@ const meta = [
 
   <p class="mt-3.5 text-[13px] leading-[1.6] text-g-faint">
     {isNpm && (
-      <span>Installs with <span class="mono text-g-muted">gaia hub install {agent.id}</span>, which fetches the frozen binary sidecar into your GAIA agents directory. The npm package is an embed path for JS/TS apps rather than a way to install the agent itself. </span>
+      <span>Ships as an npm client plus a frozen binary sidecar — npm is its only supported install path (there is no PyPI wheel). </span>
     )}
     A local model must be running first: <span class="mono text-g-muted">gaia init</span> then <span class="mono text-g-muted">lemonade-server serve</span>.
   </p>


### PR DESCRIPTION
The README never said how to install the Email agent, so anyone looking for it landed on the hub page — which tells them npm is the only supported path. That's wrong: `gaia hub install email` fetches the same build as a binary sidecar, needs no Node.js, and is the path we actually want people on. This adds one line to the Download section saying so.

This does **not** close #2969. That issue is about the live hub page, which is generated from `website/` and isn't fed by this file — the real fix touches five places in the install-card logic and is tracked in #3147. Related: #3145 (stale `--trust` flag in the email install docs).

## Test plan

- [x] "No PyPI wheel" — `.github/workflows/release_agent_email.yml` (834 lines) has no `pypi` or `twine` step; it publishes to the Agent Hub and npm only.
- [x] "npm is for embedding" — `hub/agents/email/npm/package.json:5` describes the package as a "Thin JS/TS client + build-time binary fetcher + sidecar lifecycle helpers".
- [x] No version number to go stale — the pinned `0.6.0` is gone. It had no drift guard: the only README rules in `hub/agents/email/python/packaging/stamp_version.py` `build_rules()` target `hub/agents/email/npm/README.md`, never the repo root.
- [ ] `gaia hub install email` lands the sidecar and reports 0.6.0 — tested by the reporter in #2969 (both paths, both succeeded).
