### PR TITLE
fix(mcp): port servers to MCP SDK 2

### DIFF
--- a/.github/actions/setup-venv/action.yml
+++ b/.github/actions/setup-venv/action.yml
@@ -204,7 +204,11 @@ runs:
 
         $EXTRA_INDEX = ""
         if ("${{ inputs.extra-index-url }}" -ne "") {
-          $EXTRA_INDEX = "--extra-index-url ${{ inputs.extra-index-url }}"
+          # Without this, uv's default first-index strategy resolves a package
+          # (e.g. idna) only from whichever index lists it first -- here the
+          # pytorch CPU index -- even if that version is too old for another
+          # dependency (e.g. mcp's httpx2>=2.5.0 needs idna>=3.18).
+          $EXTRA_INDEX = "--extra-index-url ${{ inputs.extra-index-url }} --index-strategy unsafe-best-match"
         }
 
         Write-Host "Installing package: ${{ inputs.install-package }} using uv..."
@@ -221,7 +225,11 @@ runs:
 
         EXTRA_INDEX=""
         if [ -n "${{ inputs.extra-index-url }}" ]; then
-          EXTRA_INDEX="--extra-index-url ${{ inputs.extra-index-url }}"
+          # Without this, uv's default first-index strategy resolves a package
+          # (e.g. idna) only from whichever index lists it first -- here the
+          # pytorch CPU index -- even if that version is too old for another
+          # dependency (e.g. mcp's httpx2>=2.5.0 needs idna>=3.18).
+          EXTRA_INDEX="--extra-index-url ${{ inputs.extra-index-url }} --index-strategy unsafe-best-match"
         fi
 
         echo "Installing package: ${{ inputs.install-package }} using uv..."

--- a/.github/workflows/test_agent_mcp_server.yml
+++ b/.github/workflows/test_agent_mcp_server.yml
@@ -84,8 +84,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          uv pip install --system -e .[dev]
-          uv pip install --system "fastmcp>=0.1.0"
+          uv pip install --system -e ".[dev,mcp]"
 
       # TODO: Start Lemonade server for integration tests
       # For now, integration tests requiring LLM will be skipped

--- a/docs/spec/mcp-server.mdx
+++ b/docs/spec/mcp-server.mdx
@@ -1,6 +1,6 @@
 ---
 title: "MCP Server"
-description: "Server implementation for Model Context Protocol with FastMCP and SSE streaming"
+description: "Server implementation for Model Context Protocol with MCPServer and SSE streaming"
 icon: "network-wired"
 ---
 
@@ -11,7 +11,7 @@ icon: "network-wired"
 <Note>
 **Component:** AgentMCPServer - Generic MCP Server for MCPAgent Subclasses
 **Module:** `gaia.mcp.agent_mcp_server`
-**Protocol:** Model Context Protocol (MCP) via FastMCP
+**Protocol:** Model Context Protocol (MCP) via MCPServer (mcp 2.x)
 **Transport:** Streamable HTTP (SSE)
 </Note>
 
@@ -19,7 +19,7 @@ icon: "network-wired"
 
 ## Overview
 
-AgentMCPServer is a generic wrapper that exposes any MCPAgent subclass as an MCP server using the MCP Python SDK (FastMCP). It dynamically registers tools from the agent and handles parameter mapping between MCP clients (like VSCode) and agent implementations.
+AgentMCPServer is a generic wrapper that exposes any MCPAgent subclass as an MCP server using the MCP Python SDK's `MCPServer` class. It dynamically registers tools from the agent and handles parameter mapping between MCP clients (like VSCode) and agent implementations.
 
 **Key Features:**
 - Generic wrapper for any MCPAgent
@@ -53,7 +53,7 @@ AgentMCPServer is a generic wrapper that exposes any MCPAgent subclass as an MCP
    - Log parameter transformations
 
 4. **Server Management**
-   - Start FastMCP server with streamable-http
+   - Start MCPServer with streamable-http
    - Configure host/port
    - Display startup banner
    - Handle graceful shutdown
@@ -115,7 +115,7 @@ class AgentMCPServer:
         pass
 
     def _register_agent_tools(self):
-        """Dynamically register agent tools with FastMCP."""
+        """Dynamically register agent tools with MCPServer."""
         pass
 
     def _print_startup_info(self):
@@ -135,9 +135,8 @@ class AgentMCPServer:
 
 **Configuration:**
 ```python
-# Set via mcp.settings
-self.mcp.settings.host = "localhost"
-self.mcp.settings.port = 8080
+# mcp 2.x takes host and port as run() arguments, not settings
+self.mcp.run(transport="streamable-http", host="localhost", port=8080)
 ```
 
 ---
@@ -148,7 +147,7 @@ self.mcp.settings.port = 8080
 
 ```python
 def _register_agent_tools(self):
-    """Dynamically register agent tools with FastMCP."""
+    """Dynamically register agent tools with MCPServer."""
 
     tools = self.agent.get_mcp_tool_definitions()
 
@@ -311,7 +310,7 @@ def test_tool_registration():
     )
 
     # Check tool was registered
-    # FastMCP stores tools in internal registry
+    # MCPServer stores tools in internal registry
     tools = server.agent.get_mcp_tool_definitions()
     assert len(tools) > 0
     assert tools[0]["name"] == "greet"
@@ -357,8 +356,8 @@ curl -X POST http://localhost:8081/mcp/tools/greet \
 ## Dependencies
 
 ```python
-# FastMCP (MCP Python SDK)
-from mcp.server.fastmcp import FastMCP
+# MCP Python SDK (mcp 2.x)
+from mcp.server import MCPServer
 
 # GAIA
 from gaia.agents.base.mcp_agent import MCPAgent

--- a/setup.py
+++ b/setup.py
@@ -207,13 +207,10 @@ setup(
             "torchaudio",
         ],
         "mcp": [
-            # Capped below 2.0: mcp 2.0.0 (released 2026-07-28) removed
-            # mcp.server.fastmcp (FastMCP -> MCPServer, moved to
-            # mcp.server.mcpserver), breaking every FastMCP-based server
-            # GAIA ships (agent_mcp_server.py, servers/agent_ui_mcp.py,
-            # servers/tui_mcp.py). Lift the cap only in a change that
-            # ports them.
-            "mcp>=1.1.0,<2.0",
+            # Supports mcp 2.x: its public MCPServer API replaced
+            # mcp.server.fastmcp (FastMCP). Keep the upper bound below the next
+            # incompatible major release.
+            "mcp>=2.0.0,<3.0",
             "starlette",
             "uvicorn",
         ],

--- a/src/gaia/cli.py
+++ b/src/gaia/cli.py
@@ -7734,8 +7734,8 @@ def handle_mcp_serve(args):
                     mcp._tool_manager._tools
                 )  # pylint: disable=protected-access
                 print(f"   Tools   : {tool_count} registered")
-            except Exception:
-                pass
+            except AttributeError:
+                log.debug("MCPServer tool registry layout changed; skipping tool count")
             print("\nPress Ctrl+C to stop")
             print("=" * 60)
             mcp.run(transport="streamable-http", host=args.host, port=args.port)
@@ -7781,7 +7781,7 @@ def handle_mcp_tui(args):
                 )  # pylint: disable=protected-access
                 print(f"   Tools   : {tool_count} registered")
             except AttributeError:
-                log.debug("FastMCP tool registry layout changed; skipping tool count")
+                log.debug("MCPServer tool registry layout changed; skipping tool count")
             print("\nPress Ctrl+C to stop")
             print("=" * 60)
             mcp.run(transport="streamable-http", host=args.host, port=args.port)

--- a/src/gaia/cli.py
+++ b/src/gaia/cli.py
@@ -7724,9 +7724,6 @@ def handle_mcp_serve(args):
             )
             mcp.run(transport="stdio")
         else:
-            mcp.settings.host = args.host
-            mcp.settings.port = args.port
-
             print("=" * 60)
             print("🤖 GAIA Agent UI MCP Server")
             print("=" * 60)
@@ -7741,7 +7738,7 @@ def handle_mcp_serve(args):
                 pass
             print("\nPress Ctrl+C to stop")
             print("=" * 60)
-            mcp.run(transport="streamable-http")
+            mcp.run(transport="streamable-http", host=args.host, port=args.port)
 
     except KeyboardInterrupt:
         print("\n✅ Agent UI MCP server stopped")
@@ -7773,9 +7770,6 @@ def handle_mcp_tui(args):
             )
             mcp.run(transport="stdio")
         else:
-            mcp.settings.host = args.host
-            mcp.settings.port = args.port
-
             print("=" * 60)
             print("🖥️  GAIA TUI Control MCP Server")
             print("=" * 60)
@@ -7790,7 +7784,7 @@ def handle_mcp_tui(args):
                 log.debug("FastMCP tool registry layout changed; skipping tool count")
             print("\nPress Ctrl+C to stop")
             print("=" * 60)
-            mcp.run(transport="streamable-http")
+            mcp.run(transport="streamable-http", host=args.host, port=args.port)
 
     except KeyboardInterrupt:
         print("\n✅ TUI control MCP server stopped")

--- a/src/gaia/mcp/agent_mcp_server.py
+++ b/src/gaia/mcp/agent_mcp_server.py
@@ -12,7 +12,7 @@ import json
 import sys
 from typing import Any, Dict, Literal, Type
 
-from mcp.server.fastmcp import FastMCP
+from mcp.server import MCPServer
 
 from gaia.agents.base.mcp_agent import MCPAgent
 from gaia.logger import get_logger, route_console_logging_to_stderr
@@ -30,7 +30,7 @@ MCP_DEFAULT_HOST = "localhost"
 Transport = Literal["streamable-http", "stdio"]
 
 # JSON-Schema -> python annotation for typed tool registration. Anything not
-# listed maps to ``Any`` (FastMCP then emits an open schema for that param).
+# listed maps to ``Any`` (MCPServer then emits an open schema for that param).
 _JSON_TYPE_TO_PY = {
     "string": str,
     "integer": int,
@@ -92,19 +92,15 @@ class AgentMCPServer:
         self.transport: Transport = transport
         self.register_typed_tools = register_typed_tools
 
-        # Create FastMCP server
+        # Create mcp 2.x MCPServer
         server_info = self.agent.get_mcp_server_info()
-        self.mcp = FastMCP(name=server_info.get("name", self.name))
-
-        # Configure server settings (host, port)
-        self.mcp.settings.host = self.host
-        self.mcp.settings.port = self.port
+        self.mcp = MCPServer(name=server_info.get("name", self.name))
 
         # Register tools dynamically from agent
         self._register_agent_tools()
 
     def _register_agent_tools(self):
-        """Dynamically register agent tools with FastMCP"""
+        """Dynamically register agent tools with MCPServer"""
         tools = self.agent.get_mcp_tool_definitions()
 
         if self.register_typed_tools:
@@ -119,7 +115,7 @@ class AgentMCPServer:
 
             # Create a wrapper function for this tool
             # We need to capture tool_name in the closure properly
-            # NOTE: Using **kwargs means FastMCP won't validate parameters,
+            # NOTE: Using **kwargs means MCPServer won't validate parameters,
             # allowing us to handle both standard and VSCode's kwargs format
             def create_tool_wrapper(name: str, description: str, verbose: bool):
                 async def tool_wrapper(**kwargs) -> Dict[str, Any]:
@@ -229,7 +225,7 @@ class AgentMCPServer:
             # Create the tool function
             tool_func = create_tool_wrapper(tool_name, tool_description, self.verbose)
 
-            # Register using FastMCP's decorator API
+            # Register using MCPServer's decorator API
             # This ensures proper registration using the public API
             self.mcp.tool()(tool_func)
 
@@ -239,8 +235,8 @@ class AgentMCPServer:
     def _register_typed_tool(self, tool_def: Dict[str, Any]) -> None:
         """Register one tool with an explicit, typed signature.
 
-        FastMCP derives a tool's JSON schema from the wrapper function's
-        signature + annotations. A bare ``**kwargs`` wrapper makes FastMCP emit
+        MCPServer derives a tool's JSON schema from the wrapper function's
+        signature + annotations. A bare ``**kwargs`` wrapper makes MCPServer emit
         a single required ``kwargs`` property — which standard MCP clients
         cannot satisfy. So when ``register_typed_tools`` is set we synthesize a
         signature whose keyword-only parameters mirror the tool's
@@ -339,8 +335,8 @@ class AgentMCPServer:
             # Run with streamable-http transport (industry standard)
             # This automatically serves at /mcp endpoint
             # Supports both HTTP POST and SSE streaming
-            # Host and port are configured via mcp.settings
-            self.mcp.run(transport="streamable-http")
+            # mcp 2.x takes host and port as run arguments.
+            self.mcp.run(transport="streamable-http", host=self.host, port=self.port)
         except KeyboardInterrupt:
             print("\n✅ Server stopped")
 

--- a/src/gaia/mcp/servers/agent_ui_mcp.py
+++ b/src/gaia/mcp/servers/agent_ui_mcp.py
@@ -33,7 +33,7 @@ from gaia.ui.sse_handler import (
 )
 
 if TYPE_CHECKING:  # import only for type checking; runtime import is lazy (#1750)
-    from mcp.server.fastmcp import FastMCP
+    from mcp.server import MCPServer
 
 logger = logging.getLogger(__name__)
 
@@ -238,14 +238,14 @@ def _stream_chat(base_url: str, session_id: str, message: str) -> Dict[str, Any]
     return result
 
 
-def create_agent_ui_mcp(backend_url: str = DEFAULT_BACKEND) -> "FastMCP":
+def create_agent_ui_mcp(backend_url: str = DEFAULT_BACKEND) -> "MCPServer":
     """Create the MCP server with tools for interacting with GAIA Agent UI."""
     # Imported lazily so the pure helpers above (_normalize_error, _api,
     # _stream_chat) stay importable without the optional ``mcp`` dependency,
     # which the unit-test job does not install (issue #1750).
-    from mcp.server.fastmcp import FastMCP
+    from mcp.server import MCPServer
 
-    mcp = FastMCP(name="GAIA Agent UI")
+    mcp = MCPServer(name="GAIA Agent UI")
 
     # ── System ─────────────────────────────────────────────────────
 
@@ -840,14 +840,12 @@ def main():
         print("Starting GAIA Agent UI MCP Server (stdio mode)...", file=sys.stderr)
         mcp.run(transport="stdio")
     else:
-        mcp.settings.host = args.host
-        mcp.settings.port = args.port
         print("\n🚀 GAIA Agent UI MCP Server")
         print(f"   Backend: {args.backend}")
         print(f"   MCP: http://{args.host}:{args.port}/mcp")
         tool_count = len(mcp._tool_manager._tools)  # pylint: disable=protected-access
         print(f"   Tools: {tool_count} registered\n")
-        mcp.run(transport="streamable-http")
+        mcp.run(transport="streamable-http", host=args.host, port=args.port)
 
 
 if __name__ == "__main__":

--- a/src/gaia/mcp/servers/agent_ui_mcp.py
+++ b/src/gaia/mcp/servers/agent_ui_mcp.py
@@ -843,8 +843,13 @@ def main():
         print("\n🚀 GAIA Agent UI MCP Server")
         print(f"   Backend: {args.backend}")
         print(f"   MCP: http://{args.host}:{args.port}/mcp")
-        tool_count = len(mcp._tool_manager._tools)  # pylint: disable=protected-access
-        print(f"   Tools: {tool_count} registered\n")
+        try:
+            tool_count = len(
+                mcp._tool_manager._tools
+            )  # pylint: disable=protected-access
+            print(f"   Tools: {tool_count} registered\n")
+        except AttributeError:
+            logger.debug("MCPServer tool registry layout changed; skipping tool count")
         mcp.run(transport="streamable-http", host=args.host, port=args.port)
 
 

--- a/src/gaia/mcp/servers/tui_mcp.py
+++ b/src/gaia/mcp/servers/tui_mcp.py
@@ -36,7 +36,7 @@ import requests
 from gaia.logger import get_logger
 
 if TYPE_CHECKING:  # import only for type checking; runtime import is lazy (#1750)
-    from mcp.server.fastmcp import FastMCP
+    from mcp.server import MCPServer
 
 logger = get_logger(__name__)
 
@@ -708,13 +708,13 @@ def route_logging_to_stderr() -> None:
             handler.setStream(sys.stderr)
 
 
-def create_tui_mcp() -> "FastMCP":
+def create_tui_mcp() -> "MCPServer":
     """Create the MCP server exposing the GAIA TUI control tools."""
     # Imported lazily so the helpers above stay importable without the optional
     # ``mcp`` dependency, which the unit-test job does not install (issue #1750).
-    from mcp.server.fastmcp import FastMCP
+    from mcp.server import MCPServer
 
-    mcp = FastMCP(name="GAIA TUI")
+    mcp = MCPServer(name="GAIA TUI")
 
     @mcp.tool()
     def tui_status() -> Dict[str, Any]:
@@ -849,14 +849,12 @@ def main():
         print("Starting GAIA TUI MCP Server (stdio mode)...", file=sys.stderr)
         mcp.run(transport="stdio")
     else:
-        mcp.settings.host = args.host
-        mcp.settings.port = args.port
         print("\n🚀 GAIA TUI MCP Server")
         print(f"   Control file: {_display_path()}")
         print(f"   MCP: http://{args.host}:{args.port}/mcp")
         tool_count = len(mcp._tool_manager._tools)  # pylint: disable=protected-access
         print(f"   Tools: {tool_count} registered\n")
-        mcp.run(transport="streamable-http")
+        mcp.run(transport="streamable-http", host=args.host, port=args.port)
 
 
 if __name__ == "__main__":

--- a/src/gaia/mcp/servers/tui_mcp.py
+++ b/src/gaia/mcp/servers/tui_mcp.py
@@ -852,8 +852,13 @@ def main():
         print("\n🚀 GAIA TUI MCP Server")
         print(f"   Control file: {_display_path()}")
         print(f"   MCP: http://{args.host}:{args.port}/mcp")
-        tool_count = len(mcp._tool_manager._tools)  # pylint: disable=protected-access
-        print(f"   Tools: {tool_count} registered\n")
+        try:
+            tool_count = len(
+                mcp._tool_manager._tools
+            )  # pylint: disable=protected-access
+            print(f"   Tools: {tool_count} registered\n")
+        except AttributeError:
+            logger.debug("MCPServer tool registry layout changed; skipping tool count")
         mcp.run(transport="streamable-http", host=args.host, port=args.port)
 
 

--- a/tests/fixtures/mcp/dummy_server/server.py
+++ b/tests/fixtures/mcp/dummy_server/server.py
@@ -3,7 +3,7 @@
 
 """Dummy MCP server fixture.
 
-The server speaks stdio MCP via FastMCP and records each tool call to a JSONL
+The server speaks stdio MCP via MCPServer and records each tool call to a JSONL
 file when ``GAIA_DUMMY_MCP_LOG`` is set. It is intentionally dependency-light
 and deterministic so installer tests do not need npx, network, or credentials.
 
@@ -18,7 +18,7 @@ import os
 from pathlib import Path
 from typing import Any, Dict
 
-from mcp.server.fastmcp import FastMCP
+from mcp.server import MCPServer
 
 
 def _record_tool_call(tool: str, arguments: Dict[str, Any], result: Any) -> None:
@@ -38,9 +38,9 @@ def _record_tool_call(tool: str, arguments: Dict[str, Any], result: Any) -> None
         )
 
 
-def create_dummy_mcp_server() -> FastMCP:
+def create_dummy_mcp_server() -> MCPServer:
     """Create the deterministic dummy MCP server."""
-    mcp = FastMCP(name="GAIA Dummy MCP")
+    mcp = MCPServer(name="GAIA Dummy MCP")
 
     @mcp.tool()
     def echo(message: str) -> str:

--- a/tests/fixtures/mcp/dummy_server/test_dummy_server.py
+++ b/tests/fixtures/mcp/dummy_server/test_dummy_server.py
@@ -8,6 +8,13 @@ from __future__ import annotations
 import json
 import sys
 
+import pytest
+
+try:
+    from mcp.server import MCPServer  # noqa: F401
+except ImportError:
+    pytest.skip("mcp 2.x SDK not installed", allow_module_level=True)
+
 from gaia.mcp.client.mcp_client import MCPClient
 
 

--- a/tests/mcp/test_agent_mcp_server.py
+++ b/tests/mcp/test_agent_mcp_server.py
@@ -20,8 +20,13 @@ from typing import Any, Dict, List
 
 import pytest
 
-from gaia.agents.base.mcp_agent import MCPAgent
-from gaia.mcp.agent_mcp_server import AgentMCPServer
+try:
+    from mcp.server import MCPServer  # noqa: F401
+except ImportError:
+    pytest.skip("mcp 2.x SDK not installed", allow_module_level=True)
+
+from gaia.agents.base.mcp_agent import MCPAgent  # noqa: E402
+from gaia.mcp.agent_mcp_server import AgentMCPServer  # noqa: E402
 
 # ============================================================================
 # TEST: MCPAgent Abstract Interface

--- a/tests/mcp/test_agent_mcp_server_stdio.py
+++ b/tests/mcp/test_agent_mcp_server_stdio.py
@@ -19,7 +19,10 @@ from typing import Any, Dict, List
 
 import pytest
 
-pytest.importorskip("mcp", reason="mcp SDK not installed ([mcp] extra)")
+try:
+    from mcp.server import MCPServer  # noqa: F401
+except ImportError:
+    pytest.skip("mcp 2.x SDK not installed", allow_module_level=True)
 
 from gaia.agents.base.console import SilentConsole  # noqa: E402
 from gaia.agents.base.mcp_agent import MCPAgent  # noqa: E402

--- a/tests/unit/test_mcp2_server.py
+++ b/tests/unit/test_mcp2_server.py
@@ -1,0 +1,150 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+"""Regression tests for the mcp 2.x MCPServer API (#2940)."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any, Dict, List
+from unittest.mock import patch
+
+import pytest
+
+try:
+    from mcp.server import MCPServer
+except ImportError:
+    pytest.skip("mcp 2.x is required for these tests", allow_module_level=True)
+
+from gaia import cli
+from gaia.agents.base.console import SilentConsole
+from gaia.agents.base.mcp_agent import MCPAgent
+from gaia.mcp.agent_mcp_server import AgentMCPServer
+from gaia.mcp.servers import agent_ui_mcp, tui_mcp
+from gaia.mcp.servers.agent_ui_mcp import create_agent_ui_mcp
+from gaia.mcp.servers.tui_mcp import create_tui_mcp
+
+
+class _EchoAgent(MCPAgent):
+    """Minimal agent that does not need a model or external service."""
+
+    def __init__(self, **kwargs: Any):
+        kwargs.setdefault("skip_lemonade", True)
+        kwargs.setdefault("silent_mode", True)
+        super().__init__(**kwargs)
+
+    def _get_system_prompt(self) -> str:
+        return "echo agent"
+
+    def _create_console(self):
+        return SilentConsole()
+
+    def _register_tools(self) -> None:
+        pass
+
+    def get_mcp_tool_definitions(self) -> List[Dict[str, Any]]:
+        return [
+            {
+                "name": "echo",
+                "description": "Echo text.",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {"text": {"type": "string"}},
+                    "required": ["text"],
+                },
+            }
+        ]
+
+    def execute_mcp_tool(
+        self, tool_name: str, arguments: Dict[str, Any]
+    ) -> Dict[str, Any]:
+        return {"tool": tool_name, "arguments": arguments}
+
+
+def test_mcp2_server_import_and_construction():
+    """All GAIA MCP constructors use the mcp 2.x public MCPServer class."""
+    server = AgentMCPServer(agent_class=_EchoAgent)
+    assert isinstance(server.mcp, MCPServer)
+
+    with patch("requests.get") as get:
+        get.return_value.raise_for_status.return_value = None
+        get.return_value.json.return_value = {"mcp_memory_enabled": False}
+        assert isinstance(create_agent_ui_mcp(), MCPServer)
+
+    assert isinstance(create_tui_mcp(), MCPServer)
+
+
+def test_agent_server_http_passes_host_and_port_to_run():
+    """mcp 2.x receives HTTP bind settings as run kwargs, not server settings."""
+    server = AgentMCPServer(agent_class=_EchoAgent, host="0.0.0.0", port=9876)
+    with (
+        patch.object(server, "_print_startup_info"),
+        patch.object(server.mcp, "run") as run,
+    ):
+        server.start()
+
+    run.assert_called_once_with(transport="streamable-http", host="0.0.0.0", port=9876)
+
+
+def test_agent_ui_main_http_passes_host_and_port_to_run():
+    server = MCPServer(name="test")
+    with (
+        patch.object(agent_ui_mcp, "create_agent_ui_mcp", return_value=server),
+        patch.object(server, "run") as run,
+        patch.object(
+            agent_ui_mcp.sys,
+            "argv",
+            ["agent_ui_mcp", "--host", "0.0.0.0", "--port", "9877"],
+        ),
+    ):
+        agent_ui_mcp.main()
+
+    run.assert_called_once_with(transport="streamable-http", host="0.0.0.0", port=9877)
+
+
+def test_tui_main_http_passes_host_and_port_to_run():
+    server = MCPServer(name="test")
+    with (
+        patch.object(tui_mcp, "create_tui_mcp", return_value=server),
+        patch.object(server, "run") as run,
+        patch.object(
+            tui_mcp.sys,
+            "argv",
+            ["tui_mcp", "--host", "0.0.0.0", "--port", "9878"],
+        ),
+    ):
+        tui_mcp.main()
+
+    run.assert_called_once_with(transport="streamable-http", host="0.0.0.0", port=9878)
+
+
+def test_cli_agent_ui_http_passes_host_and_port_to_run():
+    server = MCPServer(name="test")
+    args = SimpleNamespace(
+        backend="http://backend", stdio=False, host="0.0.0.0", port=9879
+    )
+    with (
+        patch(
+            "gaia.mcp.servers.agent_ui_mcp.create_agent_ui_mcp",
+            return_value=server,
+        ),
+        patch.object(server, "run") as run,
+    ):
+        cli.handle_mcp_serve(args)
+
+    run.assert_called_once_with(transport="streamable-http", host="0.0.0.0", port=9879)
+
+
+def test_cli_tui_http_passes_host_and_port_to_run():
+    server = MCPServer(name="test")
+    args = SimpleNamespace(stdio=False, host="0.0.0.0", port=9880)
+    with (
+        patch(
+            "gaia.mcp.servers.tui_mcp.create_tui_mcp",
+            return_value=server,
+        ),
+        patch.object(server, "run") as run,
+    ):
+        cli.handle_mcp_tui(args)
+
+    run.assert_called_once_with(transport="streamable-http", host="0.0.0.0", port=9880)

--- a/tests/unit/test_mcp_extras.py
+++ b/tests/unit/test_mcp_extras.py
@@ -1,24 +1,18 @@
 # Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
 # SPDX-License-Identifier: MIT
 
-"""Packaging guard for the [mcp] extra's version pin (issue #2885).
+"""Packaging guard for the [mcp] extra's version range (issue #2940).
 
-setup.py's ``extras_require["mcp"]`` block carries a comment saying the mcp
-dependency is "Capped below 2.0" because mcp 2.0.0 (released 2026-07-28)
-removed ``mcp.server.fastmcp`` (``FastMCP`` was renamed to ``MCPServer`` and
-moved to ``mcp.server.mcpserver``), breaking every FastMCP-based server GAIA
-ships. But the pin itself reads ``mcp>=1.1.0,<3.0``, which does NOT enforce
-the cap the comment describes: the comment and the enforced version range
-contradict each other, so ``pip install`` can still resolve an mcp 2.x that
-breaks those servers.
+setup.py's ``extras_require["mcp"]`` block supports the mcp 2.x API. mcp 2.0.0
+(released 2026-07-28) removed ``mcp.server.fastmcp`` (``FastMCP`` was renamed
+to ``MCPServer`` and moved to ``mcp.server.mcpserver``), so the range must
+exclude future incompatible major versions while admitting mcp 2.x.
 
 This file asserts two things, independently:
 
-* the pin is exactly ``mcp>=1.1.0,<2.0`` (the enforced range, not the
-  comment's claim about it);
-* the comment directly above the pin and the pin itself never contradict
-  each other — if the comment still says the dependency is "Capped below
-  2.0", the enforced range must actually be ``<2.0``.
+* the pin is exactly ``mcp>=2.0.0,<3.0``;
+* the comment directly above the pin documents support for mcp 2.x and the
+  upper bound that protects against a future incompatible major release.
 
 This is a static packaging assertion — it reads setup.py's source text and
 never imports or installs anything, so it works in the CI unit-tests venv
@@ -33,18 +27,15 @@ from pathlib import Path
 
 SETUP_PY = Path(__file__).resolve().parents[2] / "setup.py"
 
-# Single source of truth for the expected pin. If a future change legitimately
-# widens the cap (e.g. after porting the client to the mcp 2.x API), update
-# this one constant — and setup.py's pin and comment to match — rather than
-# editing the assertions below.
-EXPECTED_MCP_PIN = "mcp>=1.1.0,<2.0"
-EXPECTED_CAP_COMMENT_SUBSTRING = "capped below 2.0"
+# Single source of truth for the expected range. Update this constant and
+# setup.py's requirement/comment together when supporting another major.
+EXPECTED_MCP_PIN = "mcp>=2.0.0,<3.0"
+EXPECTED_CAP_COMMENT_SUBSTRING = "supports mcp 2.x"
 
 _PORT_INSTRUCTION = (
-    "mcp 2.0.0 removed mcp.server.fastmcp (FastMCP -> MCPServer) — before "
-    "widening the cap past <2.0, port GAIA's FastMCP-based MCP servers "
-    "(src/gaia/mcp/agent_mcp_server.py, src/gaia/mcp/servers/agent_ui_mcp.py, "
-    "src/gaia/mcp/servers/tui_mcp.py) to the mcp 2.x API."
+    "mcp 2.x support requires the MCPServer API in "
+    "src/gaia/mcp/agent_mcp_server.py, src/gaia/mcp/servers/agent_ui_mcp.py, "
+    "and src/gaia/mcp/servers/tui_mcp.py."
 )
 
 
@@ -119,8 +110,8 @@ def _pin_and_preceding_comment(name: str, pin_prefix: str) -> tuple[str, str]:
     return pin_value, " ".join(comment_lines)
 
 
-def test_mcp_extra_pin_is_capped_below_2_0() -> None:
-    """setup.py's mcp extra must pin EXPECTED_MCP_PIN exactly — see #2885.
+def test_mcp_extra_supports_2_x() -> None:
+    """setup.py's mcp extra must use the supported mcp 2.x range — see #2940.
 
     This checks the enforced version range directly (not the comment that
     claims to describe it), so a contradiction between the two can't hide
@@ -128,32 +119,26 @@ def test_mcp_extra_pin_is_capped_below_2_0() -> None:
     """
     mcp_reqs = _parse_extra("mcp")
     assert EXPECTED_MCP_PIN in mcp_reqs, (
-        f'#2885: setup.py\'s "mcp" extras_require block does not pin '
+        f'#2940: setup.py\'s "mcp" extras_require block does not pin '
         f'"{EXPECTED_MCP_PIN}". ' + _PORT_INSTRUCTION + "\n"
         f'Current "mcp" extra: {mcp_reqs}'
     )
 
 
-def test_mcp_extra_capped_comment_matches_pin() -> None:
-    """The "Capped below 2.0" comment above the mcp pin must match the pin — see #2885.
+def test_mcp_extra_support_comment_matches_pin() -> None:
+    """The support comment above the mcp pin must match the pin — see #2940.
 
-    setup.py documents the cap with a comment ("Capped below 2.0: mcp 2.0.0
-    ... removed mcp.server.fastmcp"), but the pin itself can drift out of
-    sync with what the comment claims (it currently reads
-    ``mcp>=1.1.0,<3.0``). This must fail whenever the comment still claims
-    the dependency is capped below 2.0 but the pin's upper bound is anything
-    other than EXPECTED_MCP_PIN — the contradiction must not silently pass.
+    setup.py documents the supported API and upper bound in a comment. This
+    must fail if that comment or the enforced range drifts.
     """
     pin, comment = _pin_and_preceding_comment("mcp", "mcp>=")
     assert EXPECTED_CAP_COMMENT_SUBSTRING in comment.lower(), (
-        "#2885: expected the comment directly above the mcp pin in setup.py "
-        'to still say "Capped below 2.0" (it documents why mcp is capped, '
-        f"following the mcp 2.0.0 mcp.server.fastmcp removal); got: {comment!r}. "
+        "#2940: expected the comment directly above the mcp pin in setup.py "
+        f'to say "supports mcp 2.x"; got: {comment!r}. '
         "If the comment was intentionally reworded, update this test to match "
         "it; otherwise restore the comment."
     )
     assert pin == EXPECTED_MCP_PIN, (
-        f'#2885: setup.py\'s mcp extra comment says "Capped below 2.0" but the '
-        f'enforced pin is "{pin}", not "{EXPECTED_MCP_PIN}" — the comment and '
-        "the enforced version range contradict each other. " + _PORT_INSTRUCTION
+        f"#2940: setup.py's mcp extra comment documents mcp 2.x support but "
+        f'the enforced pin is "{pin}", not "{EXPECTED_MCP_PIN}". ' + _PORT_INSTRUCTION
     )


### PR DESCRIPTION
Closes #2940

GAIA installs mcp 2.x but its MCP servers still imported the removed FastMCP API, so MCP server startup and HTTP binding failed after dependency resolution. This ports the generic, Agent UI, TUI, CLI, and custom-agent fixture paths to the public MCPServer API and passes HTTP host/port through the mcp 2.x run interface while preserving stdio framing.

Test plan:
- [x] mcp 2.x focused MCP, CLI, packaging, and fixture tests: 94 passed, 30 skipped
- [x] Full MCP-related test selection: 94 passed, 30 skipped
- [x] RED reproduction against the baseline: mcp 2.x raised ModuleNotFoundError for mcp.server.fastmcp
- [x] black, isort, compileall, and git diff --check
- [ ] Run the full repository test suite in CI