### PR TITLE
test(telegram): pin the _allowed truth table including the fail-open

### DIFF
--- a/tests/unit/test_telegram_allowlist.py
+++ b/tests/unit/test_telegram_allowlist.py
@@ -1,0 +1,34 @@
+"""Direct coverage of the Telegram allowlist predicate.
+
+`_handle_start` and `_handle_message` gating are covered in
+test_telegram_adapter.py; this file pins `_allowed` itself, including the
+deliberate fail-open when the allowlist is empty or None.
+"""
+
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath("src"))
+
+from gaia.messaging.telegram import TelegramAdapter
+
+
+def test_allowed_user_passes():
+    adapter = TelegramAdapter(token="t", allowed_users={1, 2})
+    assert adapter._allowed(1) is True
+    assert adapter._allowed(2) is True
+
+
+def test_unknown_user_denied():
+    adapter = TelegramAdapter(token="t", allowed_users={1, 2})
+    assert adapter._allowed(999) is False
+
+
+def test_empty_allowlist_intentionally_allows_all():
+    adapter = TelegramAdapter(token="t")
+    assert adapter._allowed(12345) is True
+
+
+def test_none_allowlist_intentionally_allows_all():
+    adapter = TelegramAdapter(token="t", allowed_users=None)
+    assert adapter._allowed(12345) is True


### PR DESCRIPTION
Refs #2986 (the allowlist bullet)

`TelegramAdapter._allowed` had no direct unit coverage. In particular, an empty or `None` allowlist deliberately means "anyone who finds this bot may use it" — a security-relevant default that nothing in the suite pinned, so a refactor could flip it in either direction without a test noticing. `None` is the real production spelling: `run_telegram` defaults to it and passes it straight through.

This adds a four-case truth table for `_allowed` and nothing else. Handler-level gating for `/start` and `_handle_message` is already covered in `test_telegram_adapter.py`.

## Test plan

- [x] `pytest tests/unit/test_telegram_allowlist.py tests/unit/test_telegram_adapter.py tests/unit/test_telegram_background.py tests/unit/test_telegram_sessions.py -q` → 14 passed
- [x] `python util/lint.py --black --isort` → pass
- [x] No production change — `git diff origin/main -- src/` is empty
