### PR TITLE
test(telegram): cover access and session isolation

### DIFF
--- a/src/gaia/messaging/telegram.py
+++ b/src/gaia/messaging/telegram.py
@@ -11,7 +11,6 @@ Notes:
 from __future__ import annotations
 
 import asyncio
-import logging
 import os
 import signal
 import tempfile
@@ -19,9 +18,10 @@ import threading
 from typing import Dict, Optional, Set
 
 from gaia.chat.sdk import AgentConfig, AgentSDK
+from gaia.logger import get_logger
 from gaia.messaging.ingest import ingest_document_to_rag, ingest_image_to_vlm
 
-log = logging.getLogger(__name__)
+log = get_logger(__name__)
 
 # Simple per-user session store: user_id -> AgentSDK
 _USER_SESSIONS: Dict[int, AgentSDK] = {}
@@ -62,6 +62,7 @@ class TelegramAdapter:
     async def _handle_message(self, update, context):
         user = update.effective_user
         if not self._allowed(user.id):
+            log.warning("Refused Telegram message from unauthorized user %s", user.id)
             await update.message.reply_text(
                 "Sorry — you're not authorized to use this bot."
             )
@@ -136,13 +137,16 @@ class TelegramAdapter:
 
         # Consume queue and edit message
         accumulated = ""
+        last_edited = None
         try:
             while True:
                 text_chunk, done = await queue.get()
                 accumulated = text_chunk
                 # Edit the reply with the latest accumulated text (Telegram rate limits apply)
                 try:
-                    await reply.edit_text(accumulated)
+                    if accumulated != last_edited:
+                        await reply.edit_text(accumulated)
+                        last_edited = accumulated
                 except Exception as e:
                     # Ignore transient edit failures (rate limits) where possible,
                     # but log for observability. Classify common telegram errors if available.
@@ -237,6 +241,10 @@ class TelegramAdapter:
                 os.makedirs(pid_dir, exist_ok=True)
                 pid_path = os.path.join(pid_dir, "telegram.pid")
 
+            if os.getenv("GAIA_TEST_MODE"):
+                log.info("GAIA_TEST_MODE set: skipping background services")
+                return
+
             # Simple health server
             def _health_server(stop_event: threading.Event):
                 from http.server import BaseHTTPRequestHandler, HTTPServer
@@ -266,11 +274,6 @@ class TelegramAdapter:
                 target=_health_server, args=(stop_event,), daemon=True
             )
             hs_thread.start()
-
-            # If GAIA_TEST_MODE is set, avoid running the real polling loop
-            if os.getenv("GAIA_TEST_MODE"):
-                log.info("GAIA_TEST_MODE set: skipping actual polling start")
-                return
 
             def _run_polling():
                 try:

--- a/tests/unit/test_telegram_adapter.py
+++ b/tests/unit/test_telegram_adapter.py
@@ -1,5 +1,12 @@
+import logging
 import os
 import sys
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, call
+
+import pytest
+
+from gaia.messaging.telegram import TelegramAdapter
 
 
 def test_run_telegram_scaffold_returns_adapter(mock_home, monkeypatch):
@@ -20,3 +27,70 @@ def test_run_telegram_scaffold_returns_adapter(mock_home, monkeypatch):
     assert 12345 in adapter.allowed_users
     # Application may be None if the telegram dependency is missing.
     assert hasattr(adapter, "application")
+
+
+@pytest.mark.asyncio
+async def test_unknown_user_is_refused_before_session_creation(monkeypatch, caplog):
+    adapter = TelegramAdapter(token="fake-token", allowed_users={12345})
+    reply_text = AsyncMock()
+    update = SimpleNamespace(
+        effective_user=SimpleNamespace(id=99999),
+        message=SimpleNamespace(reply_text=reply_text),
+    )
+
+    def fail_if_session_created(user_id):
+        raise AssertionError(f"session created for unauthorized user {user_id}")
+
+    monkeypatch.setattr(
+        "gaia.messaging.telegram.get_or_create_session", fail_if_session_created
+    )
+
+    with caplog.at_level(logging.WARNING, logger="gaia.messaging.telegram"):
+        await adapter._handle_message(update, None)
+
+    reply_text.assert_awaited_once_with(
+        "Sorry — you're not authorized to use this bot."
+    )
+    assert "Refused Telegram message from unauthorized user 99999" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_allowed_user_streams_accumulated_response(monkeypatch):
+    adapter = TelegramAdapter(token="fake-token", allowed_users={12345})
+    streamed_reply = AsyncMock()
+    reply_text = AsyncMock(return_value=streamed_reply)
+    update = SimpleNamespace(
+        effective_user=SimpleNamespace(id=12345),
+        message=SimpleNamespace(
+            text="hello",
+            photo=[],
+            document=None,
+            reply_text=reply_text,
+        ),
+    )
+    requested_users = []
+
+    class StubSession:
+        def send_stream(self, text):
+            assert text == "hello"
+            return iter(
+                [
+                    SimpleNamespace(text="Hello"),
+                    SimpleNamespace(text=" from Gaia"),
+                ]
+            )
+
+    def get_session(user_id):
+        requested_users.append(user_id)
+        return StubSession()
+
+    monkeypatch.setattr("gaia.messaging.telegram.get_or_create_session", get_session)
+
+    await adapter._handle_message(update, None)
+
+    assert requested_users == [12345]
+    reply_text.assert_awaited_once_with("Thinking...")
+    assert streamed_reply.edit_text.await_args_list == [
+        call("Hello"),
+        call("Hello from Gaia"),
+    ]

--- a/tests/unit/test_telegram_adapter.py
+++ b/tests/unit/test_telegram_adapter.py
@@ -6,6 +6,8 @@ from unittest.mock import AsyncMock, call
 
 import pytest
 
+sys.path.insert(0, os.path.abspath("src"))
+
 from gaia.messaging.telegram import TelegramAdapter
 
 
@@ -69,10 +71,11 @@ async def test_allowed_user_streams_accumulated_response(monkeypatch):
         ),
     )
     requested_users = []
+    sent_inputs = []
 
     class StubSession:
         def send_stream(self, text):
-            assert text == "hello"
+            sent_inputs.append(text)
             return iter(
                 [
                     SimpleNamespace(text="Hello"),
@@ -89,6 +92,7 @@ async def test_allowed_user_streams_accumulated_response(monkeypatch):
     await adapter._handle_message(update, None)
 
     assert requested_users == [12345]
+    assert sent_inputs == ["hello"]
     reply_text.assert_awaited_once_with("Thinking...")
     assert streamed_reply.edit_text.await_args_list == [
         call("Hello"),

--- a/tests/unit/test_telegram_background.py
+++ b/tests/unit/test_telegram_background.py
@@ -1,5 +1,8 @@
 import os
 import sys
+import threading
+from types import SimpleNamespace
+from unittest.mock import MagicMock
 
 sys.path.insert(0, os.path.abspath("src"))
 
@@ -24,11 +27,22 @@ def test_background_writes_pid(mock_home, monkeypatch):
 def test_background_test_mode_does_not_start_threads(mock_home, monkeypatch):
     monkeypatch.setenv("GAIA_TEST_MODE", "1")
 
+    # python-telegram-bot is optional and is absent from the unit CI job.
+    # Stub its builder so the test reaches the GAIA_TEST_MODE guard.
+    monkeypatch.setitem(sys.modules, "telegram", MagicMock())
+    monkeypatch.setitem(sys.modules, "telegram.ext", MagicMock())
+
     def fail_if_thread_started(*args, **kwargs):
         raise AssertionError("GAIA_TEST_MODE started a background thread")
 
-    monkeypatch.setattr(telegram.threading, "Thread", fail_if_thread_started)
+    monkeypatch.setattr(
+        telegram,
+        "threading",
+        SimpleNamespace(Thread=fail_if_thread_started, Event=threading.Event),
+    )
 
-    telegram.run_telegram(
+    adapter = telegram.run_telegram(
         token="fake-token-no-threads", allowed_users=None, background=True
     )
+
+    assert adapter.application is not None

--- a/tests/unit/test_telegram_background.py
+++ b/tests/unit/test_telegram_background.py
@@ -3,7 +3,7 @@ import sys
 
 sys.path.insert(0, os.path.abspath("src"))
 
-from gaia.messaging.telegram import run_telegram
+from gaia.messaging import telegram
 
 
 def test_background_writes_pid(mock_home, monkeypatch):
@@ -12,10 +12,23 @@ def test_background_writes_pid(mock_home, monkeypatch):
 
     # mock_home redirects "~" at a tmp dir, so the adapter's
     # expanduser("~/.gaia") pid file never overwrites a live adapter's real one.
-    run_telegram(token="fake-token-bg", allowed_users=None, background=True)
+    telegram.run_telegram(token="fake-token-bg", allowed_users=None, background=True)
 
     # Assert on the sandbox path, not expanduser("~") — if the isolation is
     # removed this fails instead of passing while clobbering the real pid file.
     pid_path = mock_home / ".gaia" / "telegram.pid"
     assert pid_path.exists()
     assert pid_path.read_text(encoding="utf-8").strip().isdigit()
+
+
+def test_background_test_mode_does_not_start_threads(mock_home, monkeypatch):
+    monkeypatch.setenv("GAIA_TEST_MODE", "1")
+
+    def fail_if_thread_started(*args, **kwargs):
+        raise AssertionError("GAIA_TEST_MODE started a background thread")
+
+    monkeypatch.setattr(telegram.threading, "Thread", fail_if_thread_started)
+
+    telegram.run_telegram(
+        token="fake-token-no-threads", allowed_users=None, background=True
+    )

--- a/tests/unit/test_telegram_sessions.py
+++ b/tests/unit/test_telegram_sessions.py
@@ -1,12 +1,44 @@
 import os
 import sys
 
+import pytest
+
 sys.path.insert(0, os.path.abspath("src"))
 
-from gaia.messaging.telegram import get_or_create_session
+from gaia.messaging import telegram
 
 
-def test_sessions_reuse():
-    s1 = get_or_create_session(1001)
-    s2 = get_or_create_session(1001)
+@pytest.fixture(autouse=True)
+def clear_session_store():
+    with telegram._SESSIONS_LOCK:
+        telegram._USER_SESSIONS.clear()
+    yield
+    with telegram._SESSIONS_LOCK:
+        telegram._USER_SESSIONS.clear()
+
+
+@pytest.fixture
+def stub_agent_sdk(monkeypatch):
+    class StubAgentSDK:
+        def __init__(self, config):
+            self.config = config
+            self.history = []
+
+    monkeypatch.setattr(telegram, "AgentSDK", StubAgentSDK)
+    return StubAgentSDK
+
+
+def test_sessions_reuse(stub_agent_sdk):
+    s1 = telegram.get_or_create_session(1001)
+    s2 = telegram.get_or_create_session(1001)
     assert s1 is s2
+
+
+def test_sessions_are_isolated_by_user(stub_agent_sdk):
+    first = telegram.get_or_create_session(1001)
+    second = telegram.get_or_create_session(2002)
+
+    first.history.append("first-user-message")
+
+    assert first is not second
+    assert second.history == []


### PR DESCRIPTION
## Summary

Telegram access-control and per-user session behavior now have deterministic unit coverage. The adapter also records denied users, avoids duplicate terminal edits, and keeps test-mode startup from leaving background threads.

## Why

The allowlist is Telegram's access-control boundary, but regressions could previously create a session for an unauthorized user without a failing test. The same gap covered session-state bleed, duplicate final edits, and background services leaking into tests.

## Linked issue

Refs #2986

## Changes

- cover allowlist refusal before session creation and the configured audit log
- cover per-user session reuse/isolation and cumulative streaming edit behavior
- prevent `GAIA_TEST_MODE` from starting health and polling threads

## Test plan

- [x] `.venv/bin/python -m pytest -p no:rerunfailures tests/unit/test_telegram_adapter.py tests/unit/test_telegram_background.py tests/unit/test_telegram_sessions.py tests/unit/test_ingest_helpers.py -q` — 9 passed
- [x] `PATH="$PWD/.venv/bin:$PATH" .venv/bin/python util/lint.py --black --isort` — passed
- [x] `.venv/bin/python -m pytest tests/unit/ -q` — 10,013 passed, 203 skipped; 7 unrelated baseline/environment failures reproduced on the clean branch (editable-install shims, pip-less wheel installation, and FAISS availability)
- [x] `git diff --check` — passed

## Evidence

- [ ] **Agent exposed in the Agent UI** (Chat, Email, …) — N/A: this PR changes only the internal Telegram adapter and its unit tests.
- [ ] **MCP tools / servers** — N/A: no MCP surface changed.
- [ ] **CLI** — N/A: no CLI surface changed.
- [ ] **HTTP API / REST** — N/A: no HTTP route changed.

## Checklist

- [x] I have linked a GitHub issue above (`Closes #N` / `Fixes #N` / `Refs #N`).
- [x] I have described why this change is being made, not just what changed.
- [x] I have run linting and tests locally (`python util/lint.py --all`, `pytest tests/unit/`).
- [x] I have attached real-world evidence matched to the surface I changed (see Evidence above), or marked each surface N/A.
- [x] I have updated documentation if user-visible behavior changed (not user-visible; internal adapter coverage and test-mode lifecycle only).
