### PR TITLE
fix(ci): scheduled Claude audits were green but never ran

### DIFF
--- a/.github/workflows/claude-security-audit.yml
+++ b/.github/workflows/claude-security-audit.yml
@@ -182,6 +182,10 @@ jobs:
           anthropic_api_key: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN == '' && secrets.ANTHROPIC_API_KEY || '' }}
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
+          # On `schedule`, github.actor is whoever last touched the default branch — always
+          # github-merge-queue[bot] here. Without this the human-actor gate rejects every
+          # scheduled run before Claude starts. Safe: schedule/dispatch only, no fork input.
+          allowed_bots: "github-merge-queue"
           prompt: |
             You are one lens of GAIA's proactive SECURITY audit. YOUR LENS: ${{ matrix.lens }}.
             Find real, exploitable security weaknesses.
@@ -288,7 +292,9 @@ jobs:
         with:
           name: findings-${{ matrix.lens }}
           path: findings-${{ matrix.lens }}.json
-          if-no-files-found: warn
+          # A lens that ran writes `{"findings": []}` even when clean, so a missing file
+          # means the lens never ran. Fail the job — a silent skip reads as "audited, clean".
+          if-no-files-found: error
 
   # ---------------------------------------------------------------------------
   # Score + publish. Converts Claude findings to SARIF (CVSS -> security-severity)
@@ -316,17 +322,23 @@ jobs:
         with:
           path: audit-findings
       - name: Convert findings to SARIF
+        env:
+          EXPECTED_LENSES: "3"  # keep in sync with the audit job's matrix.lens
         run: |
           set -euo pipefail
           # Flatten the per-lens artifact subdirs into one glob for the converter.
           find audit-findings -name 'findings-*.json' -exec cp {} . \; || true
-          if ls findings-*.json >/dev/null 2>&1; then
-            python util/findings_to_sarif.py findings-*.json -o claude-security.sarif
-          else
-            echo "No findings files produced; writing an empty SARIF run."
-            python util/findings_to_sarif.py /dev/null -o claude-security.sarif || \
-              echo '{"$schema":"https://json.schemastore.org/sarif-2.1.0.json","version":"2.1.0","runs":[{"tool":{"driver":{"name":"gaia-claude-security-audit","rules":[]}},"results":[]}]}' > claude-security.sarif
+          # "No lens produced output" and "every lens found nothing" produce the same empty
+          # SARIF, and uploading it would mark existing code-scanning alerts as FIXED. So a
+          # short count is a hard failure, not a quiet clean bill of health.
+          # `find`, not `ls findings-*.json` — under `set -euo pipefail` a no-match glob
+          # makes ls exit non-zero and kills the step before it can report why.
+          got=$(find . -maxdepth 1 -name 'findings-*.json' | wc -l)
+          if [ "$got" -lt "$EXPECTED_LENSES" ]; then
+            echo "::error title=Security audit::Only $got/$EXPECTED_LENSES lenses produced findings files — the audit did not run. Refusing to upload an empty SARIF (it would clear existing alerts)."
+            exit 1
           fi
+          python util/findings_to_sarif.py findings-*.json -o claude-security.sarif
       - name: Upload Claude SARIF to code scanning
         uses: github/codeql-action/upload-sarif@v4
         with:

--- a/.github/workflows/claude-weekly-audit.yml
+++ b/.github/workflows/claude-weekly-audit.yml
@@ -224,6 +224,10 @@ jobs:
           anthropic_api_key: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN == '' && secrets.ANTHROPIC_API_KEY || '' }}
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
+          # On `schedule`, github.actor is whoever last touched the default branch — always
+          # github-merge-queue[bot] here. Without this the human-actor gate rejects every
+          # scheduled run before Claude starts. Safe: schedule/dispatch only, no fork input.
+          allowed_bots: "github-merge-queue"
           prompt: |
             You are one lens of GAIA's proactive nightly code audit. YOUR LENS IS: ${{ matrix.dimension }}
             Do ONLY that lens — ignore issues that belong to the other four.
@@ -390,7 +394,9 @@ jobs:
         with:
           name: findings-${{ matrix.dimension }}
           path: findings-${{ matrix.dimension }}.json
-          if-no-files-found: warn
+          # A dimension that ran writes `{"findings": []}` even when clean, so a missing file
+          # means the lens never ran. Fail the job — a silent skip reads as "audited, clean".
+          if-no-files-found: error
 
   # Collect the four dimension outputs, dedupe against open weekly-audit issues, rank,
   # and file ONE parent triage issue + per-finding child issues. This is the only job
@@ -435,6 +441,8 @@ jobs:
           anthropic_api_key: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN == '' && secrets.ANTHROPIC_API_KEY || '' }}
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
+          # See the dimension job's note — scheduled runs are actored by github-merge-queue[bot].
+          allowed_bots: "github-merge-queue"
           prompt: |
             You are the synthesis step of GAIA's nightly proactive audit. Four dimension jobs
             (correctness, docs, tests, features) each wrote a findings JSON file.
@@ -584,5 +592,9 @@ jobs:
           if [ "$ok" = "true" ]; then
             echo "✅ Nightly audit synthesis completed (log: $EXEC_FILE)"
           else
-            echo "::warning title=Nightly audit did not complete::The synthesis step crashed or errored before finishing (often the upstream install-phase ENOENT flake). Re-run: $RUN_URL"
+            # Hard-fail, not a warning: a green run that audited nothing is indistinguishable
+            # from a green run that found nothing, which is how the actor-gate outage went
+            # unnoticed for a month. A flake here costs one re-run; silence costs coverage.
+            echo "::error title=Nightly audit did not complete::The synthesis step crashed or errored before finishing (often the upstream install-phase ENOENT flake). Re-run: $RUN_URL"
+            exit 1
           fi

--- a/.github/workflows/claude-weekly-doc-walkthrough.yml
+++ b/.github/workflows/claude-weekly-doc-walkthrough.yml
@@ -208,6 +208,26 @@ jobs:
           "" | Out-File -Append -Encoding utf8 $env:GITHUB_STEP_SUMMARY
           "- **Start:** $(Get-Date -Format o), clean run dir: ``$runDir``" | Out-File -Append -Encoding utf8 $env:GITHUB_STEP_SUMMARY
 
+      # FOUND ON A LIVE RUN (2026-08-10, run 31387768076): this runner has no
+      # `python` on PATH, so the venv step below died with CommandNotFound before
+      # any doc was walked. Every other STX workflow gets its interpreter through
+      # uv (see .github/actions/setup-venv), so do the same here rather than
+      # depending on a system Python that isn't there.
+      - name: Ensure uv is on PATH (provides the interpreter for the venv below)
+        shell: powershell
+        run: |
+          $uvBin = "$env:USERPROFILE\.local\bin"
+          if (-not (Test-Path "$uvBin\uv.exe")) {
+            Write-Host "uv not present -- installing."
+            irm https://astral.sh/uv/install.ps1 | iex
+          }
+          if (-not (Test-Path "$uvBin\uv.exe")) {
+            Write-Host "::error::uv install did not produce $uvBin\uv.exe -- cannot create the walkthrough venv."
+            exit 1
+          }
+          Add-Content -Path $env:GITHUB_PATH -Value $uvBin
+          Write-Host "uv on PATH at $uvBin"
+
       - name: Fresh venv, real-user install (no -e install, no hub packages)
         shell: powershell
         run: |
@@ -218,8 +238,10 @@ jobs:
           # hub/agents/*/python package alongside it. This is the property
           # that would have caught #2260 -- do not "fix" a resulting
           # ImportError by installing a hub package here; that IS the bug.
+          # uv only supplies the interpreter; --seed puts real pip in the venv so
+          # the install below is still a plain `pip install <wheel>`.
           Write-Host "Creating venv at $env:RUN_DIR\venv ..."
-          python -m venv "$env:RUN_DIR\venv"
+          uv venv --seed --python 3.12 "$env:RUN_DIR\venv"
           & "$env:RUN_DIR\venv\Scripts\python.exe" -m pip install --upgrade pip build
           Write-Host "Building wheel from the checkout ..."
           & "$env:RUN_DIR\venv\Scripts\python.exe" -m build --wheel --outdir "$env:RUN_DIR\dist" .
@@ -289,6 +311,10 @@ jobs:
           anthropic_api_key: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN == '' && secrets.ANTHROPIC_API_KEY || '' }}
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
+          # On `schedule`, github.actor is whoever last touched the default branch — always
+          # github-merge-queue[bot] here. Without this the human-actor gate rejects every
+          # scheduled run before Claude starts. Safe: schedule/dispatch only, no fork input.
+          allowed_bots: "github-merge-queue"
           prompt: |
             You are the EXECUTOR half of GAIA's weekly doc walkthrough. Your only job is
             to run commands and capture their raw output -- judging correctness is a
@@ -409,6 +435,8 @@ jobs:
           anthropic_api_key: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN == '' && secrets.ANTHROPIC_API_KEY || '' }}
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
+          # See the executor step's note — scheduled runs are actored by github-merge-queue[bot].
+          allowed_bots: "github-merge-queue"
           prompt: |
             You are the JUDGE half of GAIA's weekly doc walkthrough. Do not trust the
             executor's framing -- read its raw transcript and the doc yourself, and reach
@@ -612,6 +640,8 @@ jobs:
           anthropic_api_key: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN == '' && secrets.ANTHROPIC_API_KEY || '' }}
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
+          # See the executor step's note — scheduled runs are actored by github-merge-queue[bot].
+          allowed_bots: "github-merge-queue"
           prompt: |
             You are the synthesis step of GAIA's weekly DOC WALKTHROUGH (the
             execution-based sibling of the static weekly-audit -- see
@@ -717,5 +747,8 @@ jobs:
           if [ "$ok" = "true" ]; then
             echo "✅ Weekly doc walkthrough synthesis completed (log: $EXEC_FILE)"
           else
-            echo "::warning title=Weekly doc walkthrough did not complete::The synthesis step crashed or errored before finishing. Re-run: $RUN_URL"
+            # Hard-fail for the same reason as claude-weekly-audit.yml: a green run that
+            # synthesised nothing is indistinguishable from one that found nothing.
+            echo "::error title=Weekly doc walkthrough did not complete::The synthesis step crashed or errored before finishing. Re-run: $RUN_URL"
+            exit 1
           fi


### PR DESCRIPTION
Our three proactive Claude audits — the nightly code audit, the nightly security audit, and the weekly doc walkthrough — have produced nothing since 19 July, while reporting green the whole time. `claude-code-action`'s human-actor gate rejects them before Claude starts, because on a `schedule` event `github.actor` is whoever last touched the default branch, which in a merge-queue repo is always `github-merge-queue[bot]`. `continue-on-error` then turned the hard failure into a passing job, so five weeks of missing coverage looked identical to five weeks of clean bills of health. This adds `allowed_bots` to all six action steps and closes the three separate places where "nothing ran" was reported as "nothing found."

Manual `workflow_dispatch` runs are actored by a human, so every hand-test of these workflows passed — which is exactly why nobody caught it. #2859 diagnosed the same gate for the auth canary and added `allowed_bots` there, but the fix was never carried to the other six steps.

Also fixed alongside it:

- **The doc walkthrough never got past setup.** Its runner has no `python` on PATH, so the venv step died with `CommandNotFound` before a single doc was walked. It now gets its interpreter through `uv --seed`, matching every other STX workflow; the install it exercises is still a plain `pip install <wheel>`.
- **Three places treated "no lens produced output" as "every lens found nothing."** For the security audit that meant uploading an *empty* SARIF, which tells code scanning that every existing alert is fixed. All three now fail loudly instead.

## Test plan

- [ ] YAML parses and every `claude-code-action` step carries `allowed_bots` — 1 in `claude-security-audit.yml`, 2 in `claude-weekly-audit.yml`, 3 in `claude-weekly-doc-walkthrough.yml`
- [ ] `gh workflow run claude-weekly-audit.yml -f mode=normal` still passes (proves nothing regressed for the human-actor path; it cannot exercise the bot path)
- [ ] `gh workflow run claude-weekly-doc-walkthrough.yml -f doc_filter=docs/quickstart.mdx` reaches the walkthrough step instead of dying in venv creation
- [ ] **After merge, confirm on the real schedule** — the next nightly run must reach the Claude step, and `gh issue list --label weekly-audit` must gain an entry newer than #2305. The bot-actor path is only reachable from a `schedule` event, so this is the only check that actually proves the fix.

Verified against the live failures rather than by reading the YAML: run [32634614194](https://github.com/amd/gaia/actions/runs/32634614194) (nightly audit synthesize), [32564858924](https://github.com/amd/gaia/actions/runs/32564858924) (security audit, all 3 lenses + the empty-SARIF upload), [32028649421](https://github.com/amd/gaia/actions/runs/32028649421) (doc walkthrough).
