### PR TITLE
fix(installer): install the extras the daemon needs to start

### DIFF
--- a/docs/reference/cli.mdx
+++ b/docs/reference/cli.mdx
@@ -2444,7 +2444,8 @@ daemon client token from `~/.gaia/host/instance.json`; the per-sidecar bearer
 is injected by the daemon and never leaves it for relayed traffic.
 
 Requires the daemon extras (`fastapi`/`uvicorn`/`psutil`) — install with
-`pip install "amd-gaia[ui]"` (or `[api]`/`[dev]`). Running it on a base install
+`pip install "amd-gaia[api]"` (or `[ui]`, which adds the Agent UI's RAG stack on
+top). The one-line installer already does this. Running it on a base install
 fails loudly with that instruction.
 
 #### Model-slot serialization
@@ -2554,7 +2555,7 @@ gaia hub uninstall email           # stops the sidecar first, then removes the d
   `security_tier` counts as `experimental` and is gated the same way. Nothing
   infers the opt-in for you, and there is no bypass — a client (TUI, UI) renders
   this as a "Trust & Install" confirmation and retries with `trusted: true`.
-- Requires the daemon extras (`pip install "amd-gaia[ui]"`), same as `gaia daemon`.
+- Requires the daemon extras (`pip install "amd-gaia[api]"`), same as `gaia daemon`.
 
 <Note>
 `gaia agent install <id>` does the same install **in-process**; `gaia hub

--- a/installer/scripts/install.ps1
+++ b/installer/scripts/install.ps1
@@ -99,7 +99,7 @@ function Install-Gaia {
         # so the pip form fails on every re-run.
         # --upgrade exits 0 when there is nothing to do, so non-zero is a real
         # failure, not "already current".
-        & uv pip install --python "$GAIA_VENV\Scripts\python.exe" --upgrade amd-gaia --quiet
+        & uv pip install --python "$GAIA_VENV\Scripts\python.exe" --upgrade "amd-gaia[api]" --quiet
         if ($LASTEXITCODE -ne 0) {
             Write-Error "Failed to update the GAIA package in $GAIA_VENV (exit $LASTEXITCODE)."
             Write-Host "  Fix:  re-run this installer, or delete $GAIA_HOME to start clean." -ForegroundColor $COLOR_YELLOW
@@ -136,7 +136,7 @@ function Install-Gaia {
     # Target the venv python rather than running Activate.ps1: that is a script
     # on disk, so a Restricted execution policy blocks it even though the
     # piped-in installer itself is exempt.
-    & uv pip install --python "$GAIA_VENV\Scripts\python.exe" amd-gaia
+    & uv pip install --python "$GAIA_VENV\Scripts\python.exe" "amd-gaia[api]"
     if ($LASTEXITCODE -ne 0) {
         Write-Error "Failed to install the GAIA package (uv exit $LASTEXITCODE)."
         Write-Host "  Fix:  re-run this installer; if it persists report it at" -ForegroundColor $COLOR_YELLOW

--- a/installer/scripts/install.sh
+++ b/installer/scripts/install.sh
@@ -207,7 +207,7 @@ install_gaia() {
 
         # --upgrade exits 0 when there is nothing to do, so non-zero is a real
         # failure, not "already current".
-        if ! uv pip install --python "$GAIA_VENV/bin/python" --upgrade amd-gaia --extra-index-url https://download.pytorch.org/whl/cpu --quiet; then
+        if ! uv pip install --python "$GAIA_VENV/bin/python" --upgrade "amd-gaia[api]" --extra-index-url https://download.pytorch.org/whl/cpu --quiet; then
             print_error "Failed to update the GAIA package in $GAIA_VENV."
             echo "  Fix:  re-run this installer, or delete $GAIA_HOME to start clean."
             exit 1
@@ -241,7 +241,7 @@ install_gaia() {
     # Target the venv python rather than sourcing bin/activate: that script is
     # not `set -u` clean (it reads $OSTYPE, unset in dash) and noisily half-fails
     # under the documented `curl … | sh`.
-    if ! uv pip install --python "$GAIA_VENV/bin/python" amd-gaia --extra-index-url https://download.pytorch.org/whl/cpu; then
+    if ! uv pip install --python "$GAIA_VENV/bin/python" "amd-gaia[api]" --extra-index-url https://download.pytorch.org/whl/cpu; then
         print_error "Failed to install GAIA package"
         exit 1
     fi

--- a/setup.py
+++ b/setup.py
@@ -162,6 +162,10 @@ setup(
             # in-process (#2176), so [api] carries no per-agent deps (keyring is
             # already a core install_requires dep for `gaia connectors`, #1621).
             "httpx>=0.27.0",
+            # The daemon's sidecar registry imports psutil at module scope and
+            # _check_daemon_deps refuses to start without it — declare it rather
+            # than rely on accelerate pulling it in transitively.
+            "psutil>=5.9.0",
         ],
         "ui": [
             "fastapi>=0.115.0",

--- a/src/gaia/cli.py
+++ b/src/gaia/cli.py
@@ -6431,8 +6431,8 @@ def _check_daemon_deps():
     """Fail loud if the daemon's runtime deps (extras-only) are missing.
 
     ``gaia daemon`` is a base console command but the daemon process needs
-    ``fastapi``/``uvicorn``/``psutil``, which live in the ``[ui]``/``[api]``/
-    ``[dev]`` extras. On a base install the spawned daemon would die on
+    ``fastapi``/``uvicorn``/``psutil``, which live in the ``[api]`` and ``[ui]``
+    extras. On a base install the spawned daemon would die on
     ``ModuleNotFoundError`` and surface a cryptic "process exited early"; name
     the real cause and the fix instead.
     """
@@ -6451,8 +6451,8 @@ def _check_daemon_deps():
         print(
             "❌ `gaia daemon` needs packages not in the base install: "
             + ", ".join(missing)
-            + '.\n   Install the daemon extras:  pip install "amd-gaia[ui]"'
-            "  (or [api]/[dev])."
+            + '.\n   Install the daemon extras:  pip install "amd-gaia[api]"'
+            "  (or [ui], which adds the Agent UI's RAG stack on top)."
         )
         sys.exit(1)
 

--- a/tests/unit/installer/test_install_scripts_terminal_hub.py
+++ b/tests/unit/installer/test_install_scripts_terminal_hub.py
@@ -131,6 +131,35 @@ def test_path_registration_covers_the_terminal_hub_bin_dir(sh_text, ps1_text):
     assert '@("$GAIA_VENV\\Scripts", $GAIA_BIN)' in ps1_text
 
 
+# ── the core install carries the daemon extras ─────────────────────────────
+
+
+@pytest.mark.parametrize("script", ["sh", "ps1"])
+def test_every_core_install_requests_the_daemon_extras(sh_text, ps1_text, script):
+    """gaia-tui is useless without `gaia daemon`, which bare amd-gaia can't run.
+
+    Both the fresh-install and the `--upgrade` call site must ask for [api];
+    dropping it from either leaves that path installing a core that refuses to
+    start the daemon (fastapi/uvicorn/psutil missing).
+    """
+    text = sh_text if script == "sh" else ps1_text
+    call_sites = [
+        line.strip()
+        for line in text.splitlines()
+        if "uv pip install" in line and "amd-gaia" in line
+    ]
+    assert len(call_sites) == 2, (
+        f"expected the fresh-install and --upgrade pip call sites in "
+        f"install.{script}; found {len(call_sites)}: {call_sites}"
+    )
+    bare = [line for line in call_sites if '"amd-gaia[api]"' not in line]
+    assert not bare, (
+        f"install.{script} installs amd-gaia without the [api] extra — the "
+        "daemon needs fastapi/uvicorn/psutil and no `gaia init` profile "
+        f"supplies them. Offending line(s): {bare}"
+    )
+
+
 # ── macOS is no longer gated out ───────────────────────────────────────────
 
 

--- a/tests/unit/test_api_extras.py
+++ b/tests/unit/test_api_extras.py
@@ -18,6 +18,12 @@ So this file now asserts the thin-host arrangement instead:
 * gaia-agent-email still depends on ``amd-gaia[api]`` so its sidecar gets the
   REST-server deps (fastapi/uvicorn) automatically.
 
+It also guards the daemon's dependency contract (#3056): the one-line installer
+installs exactly ``amd-gaia[api]``, and ``gaia daemon`` — which the terminal hub
+cannot run without — hard-exits when fastapi/uvicorn/psutil are absent. Both the
+extra's contents and the error message's suggested remedy are checked against the
+module list in ``cli.py::_check_daemon_deps`` so neither can drift from it.
+
 These are static packaging/source assertions (no runtime import), so they work
 in the CI unit-tests venv that does not actually install [api]. Same framing as
 test_ui_extras.py's #845 docstring.
@@ -25,6 +31,7 @@ test_ui_extras.py's #845 docstring.
 
 from __future__ import annotations
 
+import ast
 import re
 from pathlib import Path
 
@@ -32,6 +39,7 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 SETUP_PY = REPO_ROOT / "setup.py"
 OPENAI_SERVER = REPO_ROOT / "src" / "gaia" / "api" / "openai_server.py"
 EMAIL_PYPROJECT = REPO_ROOT / "hub" / "agents" / "email" / "python" / "pyproject.toml"
+CLI_PY = REPO_ROOT / "src" / "gaia" / "cli.py"
 
 
 def _parse_extra(name: str) -> list[str]:
@@ -78,6 +86,23 @@ def _parse_install_requires() -> list[str]:
     return re.findall(r'"([^"]+)"', "\n".join(body))
 
 
+def _daemon_required_packages() -> list[str]:
+    """The distributions ``_check_daemon_deps`` refuses to start the daemon without.
+
+    Read out of cli.py rather than hardcoded, so adding a module to the check
+    without declaring it in [api] fails here instead of at a user's first
+    ``gaia daemon start``.
+    """
+    tree = ast.parse(CLI_PY.read_text(encoding="utf-8"))
+    for node in ast.walk(tree):
+        if isinstance(node, ast.FunctionDef) and node.name == "_check_daemon_deps":
+            for inner in ast.walk(node):
+                if isinstance(inner, ast.ListComp):
+                    pairs = ast.literal_eval(inner.generators[0].iter)
+                    return [pkg for _mod, pkg in pairs]
+    raise AssertionError("Could not find the dep list in cli.py::_check_daemon_deps")
+
+
 def test_api_server_does_not_mount_email_in_process() -> None:
     """The API server must not import/mount the email agent in-process (#2176).
 
@@ -113,6 +138,49 @@ def test_keyring_guaranteed_for_api_installs_via_core() -> None:
         "install_requires dep (#1621) and the in-process email mount that "
         f"needed it in [api] was removed (#2176). Current [api] extra: {api_reqs}"
     )
+
+
+def test_api_extra_covers_every_daemon_dep() -> None:
+    """``pip install 'amd-gaia[api]'`` must be enough to start ``gaia daemon``.
+
+    The installer installs exactly this extra, and the terminal hub is dead
+    without the daemon. psutil was only ever present transitively (accelerate
+    pulls it), so a resolver change could have re-broken the bug this guards.
+    """
+    api_reqs = [
+        r.split(">")[0].split("=")[0].split("<")[0].lower() for r in _parse_extra("api")
+    ]
+    missing = [
+        pkg for pkg in _daemon_required_packages() if pkg.lower() not in api_reqs
+    ]
+    assert not missing, (
+        f"setup.py[api] must declare {missing} — cli.py::_check_daemon_deps "
+        "hard-exits without them, and installer/scripts/install.{sh,ps1} "
+        "install 'amd-gaia[api]' as the only route to a working `gaia daemon`."
+    )
+
+
+def test_daemon_deps_error_names_an_extra_that_satisfies_it() -> None:
+    """The remedy must point at an extra that actually declares the deps.
+
+    The message used to name ``[dev]``, which declares none of fastapi,
+    uvicorn or psutil — following it left the daemon just as dead.
+    """
+    src = CLI_PY.read_text(encoding="utf-8")
+    body = src[
+        src.index("def _check_daemon_deps") : src.index("def handle_daemon_command")
+    ]
+    named = set(re.findall(r"\[([a-z]+)\]", body.split('"""', 2)[-1]))
+    required = {p.lower() for p in _daemon_required_packages()}
+    for extra in named:
+        declared = {
+            r.split(">")[0].split("=")[0].split("<")[0].lower()
+            for r in _parse_extra(extra)
+        }
+        assert required <= declared, (
+            f"cli.py::_check_daemon_deps tells the user to install [{extra}], "
+            f"but that extra does not declare {sorted(required - declared)}."
+        )
 
 
 def test_email_wheel_requires_amd_gaia_api_extra() -> None:


### PR DESCRIPTION
Following the website exactly — run the one-line installer, `gaia init`, then `gaia-tui` — leaves you unable to start the terminal hub. The installer sets up the `gaia` CLI the hub depends on, but installs bare `amd-gaia`, which has no fastapi or uvicorn, and the hub is useless without the background service:

```
gaia daemon needs packages not in the base install: fastapi, uvicorn.
   Install the daemon extras:  pip install "amd-gaia[ui]"  (or [api]/[dev]).
```

Nothing downstream covers it — no `gaia init` profile asks for `api` or `ui` (`pip_extras` is `[]` or `["rag"]` across all nine), so the packages never arrive by any route the onboarding walks.

`[api]` is fastapi, uvicorn, python-multipart and httpx — what the daemon actually needs. `[ui]` would also satisfy it but drags in torch and faiss for a process that needs neither, and the flagship agent ships as a frozen sidecar carrying its own dependencies, so the core doesn't need RAG extras on its behalf.

Two follow-ons landed here because installing `[api]` alone still wasn't sufficient. That extra never declared `psutil`, which the daemon's own pre-flight check requires — it was arriving only as a transitive of `accelerate`, one resolver change from re-breaking this. And the error message above pointed at `[dev]`, which declares none of the three, so a user who followed it stayed broken.

This is the last blocker in the TUI onboarding path; #3054 (releasing the core that can run the flagship agent) and #3055 (its version floor) are the other two.

## Test plan

- [ ] Clean venv + bare `amd-gaia` → `gaia daemon start` fails naming fastapi/uvicorn/psutil, and points at `[api]`
- [ ] Clean venv + `amd-gaia[api]` → daemon starts, and `gaia daemon status` lists `gaia` as a supervised sidecar
- [ ] In that venv, `pip show psutil` succeeds — declared by the extra, not inherited from `accelerate`
- [ ] End to end from that venv: `gaia install gaia` → `gaia daemon start-agent gaia` → sidecar `/health` returns `{"status":"ok"}`
- [ ] `pytest tests/unit/test_api_extras.py tests/unit/installer/` — the new guards pass (the `dash` failure is a pre-existing Windows CRLF checkout artifact; `install.sh` parses clean under both `dash -n` and `bash -n` with LF endings)
