### PR TITLE
fix(tui): run an installed hub agent over the daemon, not stdio

### DIFF
--- a/tui/internal/catalog/catalog.go
+++ b/tui/internal/catalog/catalog.go
@@ -421,6 +421,12 @@ func (c *Catalog) applyInstalledRecord(id, version string) {
 	}
 	a := &c.agents[idx]
 	a.FromHub = true
+	// A sentinel under the install root means the daemon installed it as an
+	// HTTP sidecar it supervises, so there is no binary for the TUI to spawn --
+	// same invariant upsertHubEntry applies. Seeded entries reach here with
+	// whatever transport the seed guessed, and a seeded subprocess agent that
+	// kept it would be spawned over stdio and fed a frozen REST binary.
+	a.Transport = TransportDaemon
 	a.InstalledVersion = version
 	if version != "" {
 		a.Version = version

--- a/tui/internal/catalog/hub_test.go
+++ b/tui/internal/catalog/hub_test.go
@@ -239,6 +239,43 @@ func TestFindBinaryInRepoFindsANonExeBuildOutput(t *testing.T) {
 	}
 }
 
+// The flagship agent is the only seeded entry declared TransportSubprocess, so
+// it is the only one whose transport the sentinel path had to correct -- which
+// is why installing it shipped a TUI that spawned the frozen REST sidecar and
+// tried to read newline-delimited JSON out of a uvicorn log.
+func TestInstalledSeededSubprocessAgentBecomesDaemonTransport(t *testing.T) {
+	sentinel := `{"id":"gaia","version":"0.1.1","language":"python","artifact_kind":"binary"}`
+	home := t.TempDir()
+	agentDir := filepath.Join(home, ".gaia", "agents", "gaia")
+	if err := os.MkdirAll(agentDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(agentDir, SentinelName), []byte(sentinel), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("HOME", home)
+	if runtime.GOOS == "windows" {
+		t.Setenv("USERPROFILE", home)
+	}
+
+	c := NewCatalog()
+	if seeded := c.Get("gaia"); seeded == nil || seeded.Transport != TransportSubprocess {
+		t.Skip("gaia is no longer seeded as a subprocess agent; this regression cannot recur")
+	}
+
+	c.LoadInstalledAgents()
+
+	gaia := c.Get("gaia")
+	if gaia == nil {
+		t.Fatal("gaia disappeared from the catalog after loading its sentinel")
+	}
+	if gaia.Transport != TransportDaemon {
+		t.Errorf("transport = %v, want TransportDaemon: an installed hub agent is an "+
+			"HTTP sidecar the daemon supervises, not a binary to spawn over stdio",
+			gaia.Transport)
+	}
+}
+
 func TestLoadInstalledAgentsReadsSentinels(t *testing.T) {
 	// InstallRoot mirrors the Python installer exactly (<home>/.gaia/agents),
 	// so the fixture is a fake home rather than an env override.


### PR DESCRIPTION
Install the flagship agent from the hub, run it, and the first thing you see is uvicorn's startup log being parsed as chat events:

```
[unreadable event skipped: not valid JSON: invalid character '-' after array element]
❌ The agent process exited unexpectedly (code 143).
```

The TUI spawned the frozen REST sidecar as a subprocess and tried to read newline-delimited JSON out of an HTTP server. `applyInstalledRecord` sets the transport only when it appends an id the catalog has never seen; an id already in the seed keeps whatever the seed guessed, and `gaia` is seeded `TransportSubprocess`. Every other hub agent is seeded `TransportDaemon`, which is why the flagship is the only one that could hit this and why it survived until now.

The invariant is the one `upsertHubEntry` already states: a sentinel under the install root means the daemon supervises it as an HTTP sidecar, so there is no binary to spawn. `DiscoverBinaries`' own ordering comment assumes the flip happens — it reads sentinels *after* the binary lookup precisely because flipping first would make installed agents skip that loop — so this was a missing assignment, not a deliberate omission.

Depends on nothing, but only becomes reachable once #3054 ships a core that can install the agent at all.

## Test plan

- [ ] `go test ./...` in `tui/` — 15 packages pass
- [ ] The new test fails without the one-line fix (verified by reverting it) and skips if `gaia` is ever reseeded as a daemon agent, so it can't silently stop testing anything
- [ ] With the agent installed, `gaia tui run gaia` reaches the daemon: preflight reports `GAIA agent 0.1.1 · running` instead of spawning a subprocess

Verified on Windows against the real published 0.1.1 binary. The end-to-end answer itself was not exercised here — this machine cannot safely load a model — but the transport selection, which is what this changes, is.
