### PR TITLE
fix(ci): make the Claude audits produce output, not just run green

### DIFF
--- a/.github/workflows/claude-security-audit.yml
+++ b/.github/workflows/claude-security-audit.yml
@@ -67,10 +67,11 @@ jobs:
   # Deterministic layer — maintained security rules, native SARIF.
   # ---------------------------------------------------------------------------
   # ---------------------------------------------------------------------------
-  # Cost guard for the nightly cadence. The Claude layer below is 3 lenses x 30
-  # turns + synthesis; running that unconditionally every night would burn the
-  # shared subscription pool re-reading an unchanged tree. Mirrors the
-  # skip-if-empty preflight in claude-weekly-audit.yml.
+  # Cost guard for the nightly cadence. The Claude layer below is 3 lenses x 45
+  # turns + synthesis (~$4-6 of subscription-equivalent usage per lens at the
+  # ceiling); running that unconditionally every night would burn the shared
+  # subscription pool re-reading an unchanged tree. Mirrors the skip-if-empty
+  # preflight in claude-weekly-audit.yml.
   #
   # semgrep is deliberately NOT gated on this — it is cheap, deterministic, and
   # its rulesets update independently of this repo, so it still has something to
@@ -84,10 +85,25 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       skip: ${{ steps.scope.outputs.skip }}
+      lenses: ${{ steps.lenses.outputs.lenses }}
+      lens_count: ${{ steps.lenses.outputs.lens_count }}
     steps:
       - uses: actions/checkout@v7
         with:
           fetch-depth: 0
+      # Single source of truth for the lens list: the audit matrix and the synthesis
+      # completeness check both read it, so adding a lens can't leave the check
+      # counting the old number and silently re-open the empty-SARIF hole.
+      - name: Resolve the lens list
+        id: lenses
+        run: |
+          set -euo pipefail
+          lenses='["sink-taint","authz","suppression-review"]'
+          {
+            echo "lenses=$lenses"
+            echo "lens_count=$(printf '%s' "$lenses" | python3 -c 'import json,sys; print(len(json.load(sys.stdin)))')"
+          } >> "$GITHUB_OUTPUT"
+          echo "Lenses: $lenses"
       - name: Skip the Claude layer on a night with no commits
         id: scope
         env:
@@ -148,7 +164,7 @@ jobs:
       fail-fast: false
       max-parallel: 1
       matrix:
-        lens: [sink-taint, authz, suppression-review]
+        lens: ${{ fromJSON(needs.preflight.outputs.lenses) }}
     steps:
       - uses: actions/checkout@v7
         with:
@@ -182,10 +198,11 @@ jobs:
           anthropic_api_key: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN == '' && secrets.ANTHROPIC_API_KEY || '' }}
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          # On `schedule`, github.actor is whoever last touched the default branch — always
-          # github-merge-queue[bot] here. Without this the human-actor gate rejects every
+          # On `schedule`, github.actor is whoever last touched the default branch — a bot
+          # in this repo: github-merge-queue[bot] normally, github-actions[bot] after a
+          # release workflow commits. Without this the human-actor gate rejects every
           # scheduled run before Claude starts. Safe: schedule/dispatch only, no fork input.
-          allowed_bots: "github-merge-queue"
+          allowed_bots: "github-merge-queue,github-actions"
           prompt: |
             You are one lens of GAIA's proactive SECURITY audit. YOUR LENS: ${{ matrix.lens }}.
             Find real, exploitable security weaknesses.
@@ -261,8 +278,14 @@ jobs:
             validated two lines down, guarded elsewhere). If you cannot quote concrete evidence you
             have not verified it — omit it.
 
-            ## Output — write `findings-${{ matrix.lens }}.json` at the repo root
-            `{"findings": []}` if nothing. Each finding:
+            ## Output — this file IS the deliverable
+            Write a JSON file at the repo root named exactly `findings-${{ matrix.lens }}.json`.
+            You have no Write tool, so create it with Bash (a `cat > … <<'JSON'` heredoc).
+            Write `{"findings": []}` if you find nothing — an empty file is a valid, useful
+            result. An investigation that ends without this file is a FAILED run: it is
+            indistinguishable from the lens never having started, and the synthesis step
+            rejects the whole audit. Write it even if you are mid-investigation and out of
+            budget. Each finding:
             ```json
             {"findings": [{
               "path": "src/gaia/....py",
@@ -279,10 +302,19 @@ jobs:
             }]}
             ```
             `dedup_key` is `security:<path>:<symbol>` — a stable symbol, NEVER a line number.
-            Also print each finding's full detail to STDOUT prefixed "SECURITY FINDING:" (the run
-            log is access-controlled; this is the private detail channel).
+            AFTER the file exists, also print each finding's full detail to STDOUT prefixed
+            "SECURITY FINDING:" (the run log is access-controlled; this is a secondary detail
+            channel). STDOUT is never a substitute for the file — only the file is collected.
+
+            ## Budget
+            You have --max-turns 45 and share one rate-limited subscription pool with the
+            sibling lenses (run back-to-back), the nightly code audit, and the interactive
+            PR-review jobs. The worklist is long and you are told not to sample, so pace
+            yourself: STOP investigating at ~5 turns remaining and spend them writing the
+            findings file. Reaching the turn ceiling mid-investigation discards everything
+            you found. Partial findings written to the file beat perfect findings lost.
           claude_args: |
-            --max-turns 30
+            --max-turns 45
             --model ${{ env.AUDIT_MODEL }}
             --allowedTools Read,Grep,Glob,Bash
 
@@ -323,7 +355,7 @@ jobs:
           path: audit-findings
       - name: Convert findings to SARIF
         env:
-          EXPECTED_LENSES: "3"  # keep in sync with the audit job's matrix.lens
+          EXPECTED_LENSES: ${{ needs.preflight.outputs.lens_count }}
         run: |
           set -euo pipefail
           # Flatten the per-lens artifact subdirs into one glob for the converter.

--- a/.github/workflows/claude-weekly-audit.yml
+++ b/.github/workflows/claude-weekly-audit.yml
@@ -59,7 +59,7 @@
 # (CLAUDE_CODE_OAUTH_TOKEN, covered by the monthly claude-auth-canary.yml). Runs on the
 # Claude Max subscription pool, so there is no per-run dollar cost — only shared quota.
 #
-# COST CEILING: 4 dimension jobs (--max-turns 30) + 1 synthesis job (--max-turns 32) =
+# COST CEILING: 4 dimension jobs (--max-turns 45) + 1 synthesis job (--max-turns 32) =
 # a known per-run ceiling, now paid up to 7x/week instead of once since the cadence went
 # nightly. window_days=1 and skip-if-empty are what keep that affordable. This shares one
 # Max subscription pool with claude-security-audit.yml (also nightly) and the interactive
@@ -128,11 +128,27 @@ jobs:
       skip: ${{ steps.scope.outputs.skip }}
       mode: ${{ steps.scope.outputs.mode }}
       window_days: ${{ steps.scope.outputs.window_days }}
+      dimensions: ${{ steps.dims.outputs.dimensions }}
+      dimension_count: ${{ steps.dims.outputs.dimension_count }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7
         with:
           fetch-depth: 0
+
+      # Single source of truth for the dimension list: the audit matrix and the
+      # synthesis completeness check both read it, so adding a dimension can't leave
+      # the check counting the old number.
+      - name: Resolve the dimension list
+        id: dims
+        run: |
+          set -euo pipefail
+          dimensions='["correctness","docs","tests","features"]'
+          {
+            echo "dimensions=$dimensions"
+            echo "dimension_count=$(printf '%s' "$dimensions" | python3 -c 'import json,sys; print(len(json.load(sys.stdin)))')"
+          } >> "$GITHUB_OUTPUT"
+          echo "Dimensions: $dimensions"
 
       - name: Resolve mode and skip-if-empty
         id: scope
@@ -184,7 +200,7 @@ jobs:
       # wall-clock (~5 sequential Claude jobs) for a smoother token profile.
       max-parallel: 1
       matrix:
-        dimension: [correctness, docs, tests, features]
+        dimension: ${{ fromJSON(needs.preflight.outputs.dimensions) }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7
@@ -373,19 +389,23 @@ jobs:
             conservatism back into a lens prompt.
 
             ## Budget
-            You have --max-turns 30 and share one rate-limited subscription pool with the
+            You have --max-turns 45 and share one rate-limited subscription pool with the
             sibling lenses (run back-to-back), the nightly security audit, and the
             interactive PR-review jobs. Delegate to a subagent only for a genuinely wide,
             parallelizable investigation — not for work you can finish in a handful of tool
             calls, and never to verify or double-check your own findings. Prefer one
             subagent over several. Spend turns reading code, not coordinating.
 
+            STOP investigating at ~5 turns remaining and spend them writing the findings
+            file. Hitting the ceiling mid-investigation discards everything you found and
+            fails the whole audit — partial findings written beat perfect findings lost.
+
             ## Security is out of scope — hand it off, do not file it here
             If you notice a security weakness, do NOT file it in this audit's findings or the
             public triage issue (that would disclose it). Security has a dedicated private-channel
             workflow (claude-security-audit.yml). Leave it to that sweep.
           claude_args: |
-            --max-turns 30
+            --max-turns 45
             --model ${{ env.AUDIT_MODEL }}
             --allowedTools Read,Grep,Glob,Bash
 
@@ -421,6 +441,21 @@ jobs:
         uses: actions/download-artifact@v8
         with:
           path: audit-findings
+
+      # "No dimension produced output" and "every dimension found nothing" both leave
+      # synthesis with nothing to file, and it reports success either way. Refuse the
+      # first case loudly instead of calling an audit that never ran a clean bill of health.
+      - name: Require every dimension to have reported in
+        env:
+          EXPECTED_DIMENSIONS: ${{ needs.preflight.outputs.dimension_count }}
+        run: |
+          set -euo pipefail
+          got=$(find audit-findings -name 'findings-*.json' | wc -l)
+          if [ "$got" -lt "$EXPECTED_DIMENSIONS" ]; then
+            echo "::error title=Nightly audit::Only $got/$EXPECTED_DIMENSIONS dimensions produced findings files — the audit did not run. Not filing a triage issue off a partial sweep."
+            exit 1
+          fi
+          echo "All $got/$EXPECTED_DIMENSIONS dimensions reported in."
 
       - name: Ensure labels exist
         env:

--- a/.github/workflows/claude-weekly-audit.yml
+++ b/.github/workflows/claude-weekly-audit.yml
@@ -224,10 +224,11 @@ jobs:
           anthropic_api_key: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN == '' && secrets.ANTHROPIC_API_KEY || '' }}
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          # On `schedule`, github.actor is whoever last touched the default branch — always
-          # github-merge-queue[bot] here. Without this the human-actor gate rejects every
+          # On `schedule`, github.actor is whoever last touched the default branch — a bot
+          # in this repo: github-merge-queue[bot] normally, github-actions[bot] after a
+          # release workflow commits. Without this the human-actor gate rejects every
           # scheduled run before Claude starts. Safe: schedule/dispatch only, no fork input.
-          allowed_bots: "github-merge-queue"
+          allowed_bots: "github-merge-queue,github-actions"
           prompt: |
             You are one lens of GAIA's proactive nightly code audit. YOUR LENS IS: ${{ matrix.dimension }}
             Do ONLY that lens — ignore issues that belong to the other four.
@@ -441,8 +442,8 @@ jobs:
           anthropic_api_key: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN == '' && secrets.ANTHROPIC_API_KEY || '' }}
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          # See the dimension job's note — scheduled runs are actored by github-merge-queue[bot].
-          allowed_bots: "github-merge-queue"
+          # See the dimension job's note — scheduled runs are actored by a bot.
+          allowed_bots: "github-merge-queue,github-actions"
           prompt: |
             You are the synthesis step of GAIA's nightly proactive audit. Four dimension jobs
             (correctness, docs, tests, features) each wrote a findings JSON file.

--- a/.github/workflows/claude-weekly-doc-walkthrough.yml
+++ b/.github/workflows/claude-weekly-doc-walkthrough.yml
@@ -223,7 +223,10 @@ jobs:
           }
           Write-Host "Claude Code CLI at $claude"
           & $claude --version
-          "path=$claude" | Out-File -Append -Encoding utf8 $env:GITHUB_OUTPUT
+          # Add-Content, not `Out-File -Encoding utf8`: on Windows PowerShell 5.1 that
+          # writes a BOM mid-file, and the runner then rejects the NEXT step's append
+          # with "Unable to process file command 'output'".
+          Add-Content -Path $env:GITHUB_OUTPUT -Value "path=$claude"
 
       - name: Verify clean start state
         shell: powershell

--- a/.github/workflows/claude-weekly-doc-walkthrough.yml
+++ b/.github/workflows/claude-weekly-doc-walkthrough.yml
@@ -198,6 +198,14 @@ jobs:
       # continue-on-error reported the job green. Install from npm instead (which does
       # support Windows) and hand the action the binary via
       # `path_to_claude_code_executable`, its documented skip-the-install escape hatch.
+      # npm is not on PATH on this runner either (same story as bash and python).
+      # test_eval_agent_gemma_consolidation.yml sets Node up the same way on the
+      # same runner pool before its own `npm install -g @anthropic-ai/claude-code`.
+      - name: Set up Node (provides npm for the Claude Code install below)
+        uses: actions/setup-node@v7
+        with:
+          node-version: '22'
+
       - name: Install Claude Code (npm — the action's own installer refuses Windows)
         id: claude_cli
         shell: powershell

--- a/.github/workflows/claude-weekly-doc-walkthrough.yml
+++ b/.github/workflows/claude-weekly-doc-walkthrough.yml
@@ -55,9 +55,22 @@
 #   self-hosted Windows runner doesn't provide by default even though Git for
 #   Windows (and its bash.exe) is installed -- fixed with an explicit
 #   "Ensure bash is on PATH" step before any claude-code-action use.
-# - Re-run pending as of this comment -- if you're reading this in a PR that
-#   updates it, check whether both fixes actually resolved the run before
-#   trusting the weekly schedule.
+# - Run 32755389532 (2026-08-24): both fixes above held; the run died one step
+#   later. claude-code-action installs the CLI with `curl claude.ai/install.sh
+#   | bash`, which refuses Windows, so the executor and judge both failed after
+#   3 attempts before any doc was walked -- and continue-on-error reported the
+#   job green. Fixed by installing from npm and passing the binary through
+#   `path_to_claude_code_executable`.
+# - Run 32764106980: npm wasn't on PATH either (same story as bash and python);
+#   fixed with actions/setup-node, matching what
+#   test_eval_agent_gemma_consolidation.yml already does on this runner pool.
+# - Run 32767640853: executor finished cleanly (is_error=false, 52 turns) and the
+#   judge wrote findings, yet the status step called it a crash -- it parsed
+#   execution_file line-by-line, but that file is a pretty-printed JSON array.
+#   Fixed by scanning the whole text for the last is_error.
+# - Run 32770642262: PASSED end to end -- every step green, findings artifact
+#   uploaded, issue #3071 filed. First fully working run of this workflow.
+#   A `.cmd` shim via path_to_claude_code_executable does work on this runner.
 
 name: Claude Weekly Doc Walkthrough
 
@@ -210,6 +223,12 @@ jobs:
         id: claude_cli
         shell: powershell
         run: |
+          if (-not (Get-Command npm -ErrorAction SilentlyContinue)) {
+            Write-Host "::error::No npm on PATH -- the Set up Node step above should have provided it. claude-code-action's own installer refuses Windows, so npm is the only install path here."
+            exit 1
+          }
+          # Deliberately unpinned. The action bundles its own expected CLI version and
+          # bumps it with the SHA; pinning here independently would drift against it.
           npm install -g @anthropic-ai/claude-code@latest
           if ($LASTEXITCODE -ne 0) {
             Write-Host "::error::npm install of @anthropic-ai/claude-code failed -- the executor and judge cannot run."
@@ -417,7 +436,15 @@ jobs:
             and any retry) to `<RUN_DIR>\transcript.md` (substitute the real value of the
             `RUN_DIR` env var), structured with one section per step in doc order. This
             transcript is the ONLY thing the judge step reads -- anything not captured
-            there does not exist for judging purposes.
+            there does not exist for judging purposes. You have no Write tool: create it
+            with Bash (a `cat > … <<'MD'` heredoc). A run that ends without this file is a
+            FAILED run -- the job hard-fails on it, because a missing transcript is
+            indistinguishable from the walk never having started.
+
+            ## Budget
+            You have --max-turns 60. Stop walking the guide at ~5 turns remaining and
+            spend them writing the transcript. Reaching the ceiling mid-walk discards
+            everything you captured; a partial transcript beats a perfect one never written.
           claude_args: |
             --max-turns 60
             --model ${{ env.WALKTHROUGH_EXECUTOR_MODEL }}
@@ -534,6 +561,15 @@ jobs:
                false but the underlying command doesn't crash; 🟡 a cosmetic/minor gap
                (a missing caveat, a stale example). `auto_fixable` = true only if the fix
                is small and locatable (~1-3 files, no design call).
+
+               This file IS the deliverable. You have no Write tool: create it with Bash
+               (a `cat > … <<'JSON'` heredoc). An empty `{"findings": []}` is a valid,
+               useful result; ending without the file at all is a FAILED run and the job
+               hard-fails on it.
+
+            ## Budget
+            You have --max-turns 25. Stop judging at ~3 turns remaining and spend them
+            writing the findings file -- partial findings written beat complete findings lost.
           claude_args: |
             --max-turns 25
             --model ${{ env.WALKTHROUGH_JUDGE_MODEL }}

--- a/.github/workflows/claude-weekly-doc-walkthrough.yml
+++ b/.github/workflows/claude-weekly-doc-walkthrough.yml
@@ -191,6 +191,32 @@ jobs:
             exit 1
           }
 
+      # FOUND ON A LIVE RUN (2026-08-24, run 32755389532): claude-code-action installs
+      # the CLI with `curl https://claude.ai/install.sh | bash`, and that script refuses
+      # Windows ("Windows is not supported by this script"). Both the executor and the
+      # judge died there after 3 attempts, before any doc was walked -- and
+      # continue-on-error reported the job green. Install from npm instead (which does
+      # support Windows) and hand the action the binary via
+      # `path_to_claude_code_executable`, its documented skip-the-install escape hatch.
+      - name: Install Claude Code (npm — the action's own installer refuses Windows)
+        id: claude_cli
+        shell: powershell
+        run: |
+          npm install -g @anthropic-ai/claude-code@latest
+          if ($LASTEXITCODE -ne 0) {
+            Write-Host "::error::npm install of @anthropic-ai/claude-code failed -- the executor and judge cannot run."
+            exit 1
+          }
+          $npmPrefix = (npm prefix -g).Trim()
+          $claude = Join-Path $npmPrefix "claude.cmd"
+          if (-not (Test-Path $claude)) {
+            Write-Host "::error::Claude Code installed but no claude.cmd under $npmPrefix -- cannot point the action at it."
+            exit 1
+          }
+          Write-Host "Claude Code CLI at $claude"
+          & $claude --version
+          "path=$claude" | Out-File -Append -Encoding utf8 $env:GITHUB_OUTPUT
+
       - name: Verify clean start state
         shell: powershell
         run: |
@@ -311,10 +337,13 @@ jobs:
           anthropic_api_key: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN == '' && secrets.ANTHROPIC_API_KEY || '' }}
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          # On `schedule`, github.actor is whoever last touched the default branch — always
-          # github-merge-queue[bot] here. Without this the human-actor gate rejects every
+          # On `schedule`, github.actor is whoever last touched the default branch — a bot
+          # in this repo: github-merge-queue[bot] normally, github-actions[bot] after a
+          # release workflow commits. Without this the human-actor gate rejects every
           # scheduled run before Claude starts. Safe: schedule/dispatch only, no fork input.
-          allowed_bots: "github-merge-queue"
+          allowed_bots: "github-merge-queue,github-actions"
+          # Skip the action's Linux-only installer — see the npm install step above.
+          path_to_claude_code_executable: ${{ steps.claude_cli.outputs.path }}
           prompt: |
             You are the EXECUTOR half of GAIA's weekly doc walkthrough. Your only job is
             to run commands and capture their raw output -- judging correctness is a
@@ -419,11 +448,15 @@ jobs:
             Write-Host "✅ Executor completed and wrote a transcript."
             "- **Executor:** ✅ completed, transcript written" | Out-File -Append -Encoding utf8 $env:GITHUB_STEP_SUMMARY
           } elseif ($ok -and -not $transcriptExists) {
-            Write-Host "::warning::Executor step reported success but no transcript.md was written -- the judge will file a crash finding for this."
-            "- **Executor:** ⚠️ reported success but wrote no transcript" | Out-File -Append -Encoding utf8 $env:GITHUB_STEP_SUMMARY
+            # No transcript means the judge would review nothing and write nothing, and the
+            # job would still go green. Stop here so the cause is the reported failure.
+            Write-Host "::error title=Executor wrote no transcript (${{ matrix.doc.path }})::The executor reported success but never wrote transcript.md, so there is nothing to judge. log: $env:EXEC_FILE"
+            "- **Executor:** ❌ reported success but wrote no transcript" | Out-File -Append -Encoding utf8 $env:GITHUB_STEP_SUMMARY
+            exit 1
           } else {
-            Write-Host "::warning title=Executor did not complete cleanly (${{ matrix.doc.path }})::log: $env:EXEC_FILE"
+            Write-Host "::error title=Executor did not complete cleanly (${{ matrix.doc.path }})::log: $env:EXEC_FILE"
             "- **Executor:** ❌ did not complete cleanly" | Out-File -Append -Encoding utf8 $env:GITHUB_STEP_SUMMARY
+            exit 1
           }
 
       - name: "Judge (Opus): verify ${{ matrix.doc.path }} against its transcript"
@@ -435,8 +468,10 @@ jobs:
           anthropic_api_key: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN == '' && secrets.ANTHROPIC_API_KEY || '' }}
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          # See the executor step's note — scheduled runs are actored by github-merge-queue[bot].
-          allowed_bots: "github-merge-queue"
+          # See the executor step's note — scheduled runs are actored by a bot.
+          allowed_bots: "github-merge-queue,github-actions"
+          # Skip the action's Linux-only installer — see the npm install step above.
+          path_to_claude_code_executable: ${{ steps.claude_cli.outputs.path }}
           prompt: |
             You are the JUDGE half of GAIA's weekly doc walkthrough. Do not trust the
             executor's framing -- read its raw transcript and the doc yourself, and reach
@@ -566,7 +601,9 @@ jobs:
         with:
           name: findings-walkthrough-${{ matrix.doc.slug }}
           path: findings-walkthrough-${{ matrix.doc.slug }}.json
-          if-no-files-found: warn
+          # The judge writes `{"findings": []}` even when a doc is clean, so a missing file
+          # means the judge never ran. Fail — a silent skip reads as "walked, all good".
+          if-no-files-found: error
 
   # Collect every matrix job's findings, dedupe against open weekly-audit
   # issues, and file ONE parent triage issue + per-finding child issues.
@@ -640,8 +677,8 @@ jobs:
           anthropic_api_key: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN == '' && secrets.ANTHROPIC_API_KEY || '' }}
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          # See the executor step's note — scheduled runs are actored by github-merge-queue[bot].
-          allowed_bots: "github-merge-queue"
+          # See the executor step's note — scheduled runs are actored by a bot.
+          allowed_bots: "github-merge-queue,github-actions"
           prompt: |
             You are the synthesis step of GAIA's weekly DOC WALKTHROUGH (the
             execution-based sibling of the static weekly-audit -- see

--- a/.github/workflows/claude-weekly-doc-walkthrough.yml
+++ b/.github/workflows/claude-weekly-doc-walkthrough.yml
@@ -227,9 +227,11 @@ jobs:
             Write-Host "::error::No npm on PATH -- the Set up Node step above should have provided it. claude-code-action's own installer refuses Windows, so npm is the only install path here."
             exit 1
           }
-          # Deliberately unpinned. The action bundles its own expected CLI version and
-          # bumps it with the SHA; pinning here independently would drift against it.
-          npm install -g @anthropic-ai/claude-code@latest
+          # Major-pinned, not exact. The action bundles its own expected CLI version and
+          # bumps it with the SHA, so pinning exactly here would drift against it; ^2
+          # still tracks that while stopping a 3.x breaking release from landing
+          # mid-scheduled-run. Revisit when the action's SHA moves to a 3.x CLI.
+          npm install -g "@anthropic-ai/claude-code@^2"
           if ($LASTEXITCODE -ne 0) {
             Write-Host "::error::npm install of @anthropic-ai/claude-code failed -- the executor and judge cannot run."
             exit 1

--- a/.github/workflows/claude-weekly-doc-walkthrough.yml
+++ b/.github/workflows/claude-weekly-doc-walkthrough.yml
@@ -439,20 +439,20 @@ jobs:
           # presence on this self-hosted Windows runner is not a confirmed
           # dependency (the ubuntu-hosted synthesis job below uses jq safely,
           # since GH-hosted runners guarantee it; this job cannot assume that).
-          # execution_file is JSONL (one object per line); walk every line and
-          # keep the LAST one that has an is_error key, matching the bash
-          # `jq -s '[.. | objects | select(has("is_error")) | .is_error] | .[-1]'`
+          # execution_file is a PRETTY-PRINTED JSON array, not JSONL, so parsing it
+          # line by line makes every line invalid and silently reports a healthy run
+          # as crashed. Scan the whole text and keep the LAST is_error, matching the
+          # bash `jq -s '[.. | objects | select(has("is_error")) | .is_error] | .[-1]'`
           # claude-weekly-audit.yml uses on ubuntu.
           $ok = $false
-          $isErr = $null
           if ($env:EXEC_FILE -and (Test-Path $env:EXEC_FILE)) {
-            foreach ($line in Get-Content $env:EXEC_FILE) {
-              try {
-                $obj = $line | ConvertFrom-Json -ErrorAction Stop
-                if ($obj.PSObject.Properties.Name -contains "is_error") { $isErr = $obj.is_error }
-              } catch {}
+            $raw = Get-Content -Raw $env:EXEC_FILE
+            $hits = [regex]::Matches($raw, '"is_error"\s*:\s*(true|false)')
+            if ($hits.Count -gt 0) {
+              $ok = $hits[$hits.Count - 1].Groups[1].Value -eq 'false'
+            } else {
+              Write-Host "::warning::No is_error in $env:EXEC_FILE -- treating as a crash."
             }
-            if ($isErr -eq $false) { $ok = $true }
           }
           $transcriptExists = Test-Path "$env:RUN_DIR\transcript.md"
           if ($ok -and $transcriptExists) {
@@ -549,18 +549,17 @@ jobs:
         env:
           EXEC_FILE: ${{ steps.judge.outputs.execution_file }}
         run: |
-          # PowerShell-native JSON parsing (ConvertFrom-Json), not jq -- see
-          # the "Report executor status" step above for why.
+          # Same whole-text scan as "Report executor status" above -- see the note there
+          # for why line-by-line parsing misreads this file.
           $ok = $false
-          $isErr = $null
           if ($env:EXEC_FILE -and (Test-Path $env:EXEC_FILE)) {
-            foreach ($line in Get-Content $env:EXEC_FILE) {
-              try {
-                $obj = $line | ConvertFrom-Json -ErrorAction Stop
-                if ($obj.PSObject.Properties.Name -contains "is_error") { $isErr = $obj.is_error }
-              } catch {}
+            $raw = Get-Content -Raw $env:EXEC_FILE
+            $hits = [regex]::Matches($raw, '"is_error"\s*:\s*(true|false)')
+            if ($hits.Count -gt 0) {
+              $ok = $hits[$hits.Count - 1].Groups[1].Value -eq 'false'
+            } else {
+              Write-Host "::warning::No is_error in $env:EXEC_FILE -- treating as a crash."
             }
-            if ($isErr -eq $false) { $ok = $true }
           }
           $findingsFile = "findings-walkthrough-${{ matrix.doc.slug }}.json"
           if ($ok) {


### PR DESCRIPTION
#3053 got the scheduled audits past the actor gate and the nightly code audit started working — it filed its first findings since 19 July. The other two ran and produced nothing. This makes them produce output, and closes the reporting gaps that let "produced nothing" look identical to "found nothing."

Every fix here was verified by dispatching the workflow on this branch and checking it uploaded **artifacts**, not by reading a green tick.

| | before | after |
|---|---|---|
| Security lenses writing findings | 0 of 3 | 3 of 3 → 17 SARIF results → 17 code-scanning alerts |
| Doc walkthrough | green, zero output | walks the doc, files issue #3071 |

**Security audit** — two causes, not one. `sink-taint` and `authz` hit `error_max_turns` at 31 turns, but `suppression-review` finished cleanly at 29 turns and *still* wrote nothing. Raising the ceiling alone would have left it broken: the write instruction was a section heading competing with a "print to STDOUT" channel. It's now imperative, STDOUT is explicitly secondary, and a Budget section tells the lens to stop investigating with turns left for the file.

**Doc walkthrough** — this had never worked on the STX runners, so nothing downstream of the install had ever run. Four bugs stacked behind each other, each only visible once the one before it was fixed:

- The action installs the CLI with `curl claude.ai/install.sh | bash`, which refuses Windows outright. Now installed from npm and passed in via `path_to_claude_code_executable`.
- `npm` isn't on PATH on those runners either — same story as `bash` and `python`. `actions/setup-node` matches what `test_eval_agent_gemma_consolidation.yml` already does on the same pool.
- `Out-File -Encoding utf8` writes a BOM on Windows PowerShell 5.1, which corrupted `$GITHUB_OUTPUT` and made the action's own `execution_file` output unparseable.
- Both status steps read `execution_file` a line at a time, but it's a pretty-printed JSON array — so a run where the executor finished with `is_error=false` over 52 turns was reported as a crash. They now scan for the last `is_error`, which is what the `jq` expression they mirror always did.

The green-when-empty reporting that hid all of this is fixed alongside: a failed executor is an error rather than a warning, and the findings upload uses `if-no-files-found: error` like the other two workflows already did.

Also: `allowed_bots` now covers `github-actions[bot]`, since a release-bot commit on `main` would re-break the actor gate the same way (#3059), and `EXPECTED_LENSES` is derived from the lens matrix instead of a hand-synced comment (#3060).

## Test plan

- [x] `actionlint` clean on all three workflows
- [x] Security audit on this branch → 3 artifacts, `Wrote 17 result(s) to claude-security.sarif`, 17 alerts on the branch ref ([run](https://github.com/amd/gaia/actions/runs/32762856116))
- [x] Doc walkthrough on this branch → every step green, artifact uploaded, issue #3071 filed ([run](https://github.com/amd/gaia/actions/runs/32770642262))
- [ ] After merge: the next *scheduled* run reaches Claude and files output — `workflow_dispatch` is human-actored and cannot exercise the bot path, so this is the only check that proves the actor-gate half

🔒 The security audit's first working run surfaced findings in the private code-scanning tab, including high-severity ones. Details deliberately not repeated here — @kovtcharov-amd.
