### PR TITLE
test(api): pin the flagship construction the API server depends on

### DIFF
--- a/.github/workflows/test_gaia_agent.yml
+++ b/.github/workflows/test_gaia_agent.yml
@@ -20,6 +20,9 @@ on:
       - 'src/gaia/agents/tools/**'
       - 'src/gaia/skills/**'
       - 'src/gaia/code_index/**'
+      # agent_registry.py's init_params are pinned against the flagship's
+      # constructor, so editing it alone must still run that gate.
+      - 'src/gaia/api/agent_registry.py'
       - 'setup.py'
       - '.github/workflows/test_gaia_agent.yml'
   pull_request:
@@ -32,6 +35,9 @@ on:
       - 'src/gaia/agents/tools/**'
       - 'src/gaia/skills/**'
       - 'src/gaia/code_index/**'
+      # agent_registry.py's init_params are pinned against the flagship's
+      # constructor, so editing it alone must still run that gate.
+      - 'src/gaia/api/agent_registry.py'
       - 'setup.py'
       - '.github/workflows/test_gaia_agent.yml'
   merge_group:

--- a/.github/workflows/test_gaia_agent.yml
+++ b/.github/workflows/test_gaia_agent.yml
@@ -21,8 +21,9 @@ on:
       - 'src/gaia/skills/**'
       - 'src/gaia/code_index/**'
       # agent_registry.py's init_params are pinned against the flagship's
-      # constructor, so editing it alone must still run that gate.
-      - 'src/gaia/api/agent_registry.py'
+      # constructor, and sse_handler.py against its console, so editing the
+      # API layer alone must still run that gate.
+      - 'src/gaia/api/**'
       - 'setup.py'
       - '.github/workflows/test_gaia_agent.yml'
   pull_request:
@@ -36,8 +37,9 @@ on:
       - 'src/gaia/skills/**'
       - 'src/gaia/code_index/**'
       # agent_registry.py's init_params are pinned against the flagship's
-      # constructor, so editing it alone must still run that gate.
-      - 'src/gaia/api/agent_registry.py'
+      # constructor, and sse_handler.py against its console, so editing the
+      # API layer alone must still run that gate.
+      - 'src/gaia/api/**'
       - 'setup.py'
       - '.github/workflows/test_gaia_agent.yml'
   merge_group:

--- a/hub/agents/gaia/python/tests/test_api_construction.py
+++ b/hub/agents/gaia/python/tests/test_api_construction.py
@@ -107,13 +107,27 @@ def test_debug_env_overrides_stay_within_the_config_fields():
             ):
                 mp.setenv(var, "1")
             _apply_env_overrides()
-        injected = set(init_params) - set(saved)
-        undeclared = sorted(set(init_params) - declared)
+        applied = dict(init_params)
+        undeclared = sorted(set(applied) - declared)
     finally:
         init_params.clear()
         init_params.update(saved)
 
-    assert injected, "_apply_env_overrides injected nothing — the flags are dead."
+    # Asserted by VALUE, not by key presence. ``streaming`` and ``silent_mode``
+    # are already keys of AGENT_MODELS' init_params, so every key-based check —
+    # a diff against the pre-call state or a subset test — stays green when
+    # GAIA_API_STREAMING stops being read. Only the value moves.
+    expected = {
+        "debug": True,
+        "show_prompts": True,
+        "streaming": True,
+        "silent_mode": False,
+    }
+    dead = sorted(k for k, v in expected.items() if applied.get(k) != v)
+    assert not dead, (
+        f"_apply_env_overrides did not apply every flag: {dead}. Expected "
+        f"{expected}, got { {k: applied.get(k) for k in expected} }."
+    )
     assert not undeclared, (
         f"init_params keys absent from GaiaAgentConfig: {undeclared}. get_agent "
         "passes each one as a keyword, so this is a TypeError per request."

--- a/hub/agents/gaia/python/tests/test_api_construction.py
+++ b/hub/agents/gaia/python/tests/test_api_construction.py
@@ -1,0 +1,120 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""Contract gate between ``gaia.api.agent_registry`` and this agent's constructor.
+
+``AgentRegistry.get_agent`` is the only way an OpenAI-compatible client reaches
+the flagship, and it builds it blind: every key of ``AGENT_MODELS["gaia"]
+["init_params"]``, plus an ``output_handler`` it adds itself, goes straight in as
+a keyword argument. ``GaiaAgent`` funnels those into the ``GaiaAgentConfig``
+dataclass, so a keyword the dataclass does not declare is a ``TypeError`` raised
+per request — ``/v1/chat/completions`` 500s for every caller while the rest of
+the suite stays green. ``output_handler`` exists on ``ChatAgentConfig`` for no
+reason other than this call site.
+
+``get_agent`` is therefore called here rather than re-implemented: a local copy
+of its body would pin ``AGENT_MODELS`` against the constructor but not the
+caller, and the next keyword added to ``init_params`` would slip through the
+same gap this file exists to close.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import importlib
+from dataclasses import fields
+
+import pytest
+from gaia_agent.agent import GaiaAgent, GaiaAgentConfig
+
+from gaia.agents.base.tools import _TOOL_REGISTRY
+from gaia.api.agent_registry import AGENT_MODELS, AgentRegistry, _apply_env_overrides
+from gaia.api.sse_handler import SSEOutputHandler
+
+MODEL_ID = "gaia"
+
+
+@contextlib.contextmanager
+def _isolated_registry():
+    """@tool writes into a process-global dict shared with every other agent."""
+    saved = dict(_TOOL_REGISTRY)
+    _TOOL_REGISTRY.clear()
+    try:
+        yield
+    finally:
+        _TOOL_REGISTRY.clear()
+        _TOOL_REGISTRY.update(saved)
+
+
+def test_get_agent_builds_the_flagship_and_installs_the_sse_handler():
+    """Drive the real registry, then assert the handler actually took effect.
+
+    Construction not raising is only half of it: ``silent_mode=True`` also ships
+    in ``init_params``, and if it won over ``output_handler`` the agent would
+    stream to a plain console while the API looked perfectly healthy.
+    """
+    # Memory init is forced off for the same reason as the sibling tests: no
+    # embedder in CI, and MemoryMixin's self-disable makes the surface differ
+    # between a dev box and a runner.
+    with _isolated_registry(), pytest.MonkeyPatch.context() as mp:
+        mp.setenv("GAIA_MEMORY_DISABLED", "1")
+        agent = AgentRegistry().get_agent(MODEL_ID)
+
+    assert isinstance(agent, GaiaAgent)
+    assert isinstance(agent.console, SSEOutputHandler), (
+        "get_agent's output_handler did not reach the agent's console — "
+        "GaiaAgentConfig/ChatAgentConfig must declare an output_handler field "
+        "and ChatAgent must forward it to Agent.__init__."
+    )
+
+
+def test_registry_class_path_resolves_to_this_agent():
+    """The other half of the contract: the dotted path the registry imports.
+
+    ``get_agent`` folds a stale path's ``ImportError`` into a generic "agent not
+    available" ``ValueError``, so a package or class rename surfaces as a
+    runtime 500 rather than anything CI notices.
+    """
+    class_path = AGENT_MODELS[MODEL_ID]["class_name"]
+    module_path, class_name = class_path.rsplit(".", 1)
+    resolved = getattr(importlib.import_module(module_path), class_name, None)
+
+    assert resolved is GaiaAgent, (
+        f"AGENT_MODELS['{MODEL_ID}']['class_name'] is {class_path!r}, which no "
+        "longer resolves to gaia_agent.agent.GaiaAgent."
+    )
+
+
+def test_debug_env_overrides_stay_within_the_config_fields():
+    """``gaia api start --debug`` injects extra keywords; they must be fields too.
+
+    ``_apply_env_overrides`` adds ``debug``/``silent_mode``/``show_prompts``/
+    ``streaming`` to ``init_params`` when the API server is started with those
+    flags. They reach the constructor exactly like ``output_handler`` does, so
+    that path deserves the same gate — it only runs at import, which is why it
+    is re-invoked here instead of monkeypatching the environment alone.
+    """
+    declared = {f.name for f in fields(GaiaAgentConfig)}
+    assert "output_handler" in declared
+
+    init_params = AGENT_MODELS[MODEL_ID]["init_params"]
+    saved = dict(init_params)
+    try:
+        with pytest.MonkeyPatch.context() as mp:
+            for var in (
+                "GAIA_API_DEBUG",
+                "GAIA_API_SHOW_PROMPTS",
+                "GAIA_API_STREAMING",
+            ):
+                mp.setenv(var, "1")
+            _apply_env_overrides()
+        injected = set(init_params) - set(saved)
+        undeclared = sorted(set(init_params) - declared)
+    finally:
+        init_params.clear()
+        init_params.update(saved)
+
+    assert injected, "_apply_env_overrides injected nothing — the flags are dead."
+    assert not undeclared, (
+        f"init_params keys absent from GaiaAgentConfig: {undeclared}. get_agent "
+        "passes each one as a keyword, so this is a TypeError per request."
+    )

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -318,9 +318,8 @@ class TestApiUnitValidation:
         """Test that empty messages array returns 400 (no user message)."""
         from gaia.api.openai_server import registry as server_registry
 
-        # Model-existence check runs before the empty-messages check, and
-        # Stub the registry so this test
-        # exercises the message-validation branch it's named for.
+        # The model 404 check runs first; stubbing it keeps a future rename of
+        # the model from failing this test somewhere other than its own branch.
         mocker.patch.object(server_registry, "model_exists", return_value=True)
 
         response = self.client.post(

--- a/tests/unit/api/test_sse_confirmation_gate.py
+++ b/tests/unit/api/test_sse_confirmation_gate.py
@@ -246,9 +246,8 @@ class TestRegistryWiring:
         installs is the one the agent actually consults — ``silent_mode=True``
         in ``AGENT_MODELS`` must not win over ``output_handler``.
 
-        AGENT_MODELS holds the flagship, not the agent this probe stubs, so
-        it used to expose are gone — so a fake entry is patched in here to
-        exercise the get_agent() wiring this test actually targets.
+        AGENT_MODELS holds only the flagship, so a fake entry is patched in to
+        exercise the get_agent() wiring without building the real agent.
         """
         from unittest.mock import patch
 

--- a/util/lint.ps1
+++ b/util/lint.ps1
@@ -348,6 +348,7 @@ function Invoke-ImportTests {
 
         # Specialized Agents — optional so a framework-only env (no
         # gaia-agent-<id> installed) skips rather than fails.
+        @{Import="from gaia_agent.agent import GaiaAgent"; Desc="Flagship agent"; Optional=$true},
         @{Import="from gaia_agent_chat import ChatAgent"; Desc="Chat agent"; Optional=$true},
 
         # Database

--- a/util/lint.py
+++ b/util/lint.py
@@ -416,6 +416,7 @@ def check_imports() -> CheckResult:
         ("from", "gaia.agents.base", "tool", "Tool decorator", False),
         # Specialized Agents — optional so a framework-only env (no
         # gaia-agent-<id> installed) skips rather than fails.
+        ("from", "gaia_agent.agent", "GaiaAgent", "Flagship agent", True),
         ("from", "gaia_agent_chat", "ChatAgent", "Chat agent", True),
         # Database
         ("from", "gaia.database", "DatabaseAgent", "Database agent", False),


### PR DESCRIPTION
Renaming one field on `ChatAgentConfig` breaks `/v1/chat/completions` for every caller — and the entire API test suite stays green. The server builds the one agent it serves by splatting the registry's `init_params` plus an SSE `output_handler` straight into the config dataclass, so any keyword the dataclass stops declaring is a `TypeError` raised per request; that construction had no test anywhere. It does now, and it drives the real `get_agent()` rather than a copy of its body, so drift on either side of the contract fails CI instead of shipping.

## Test plan

- [ ] `python -m pytest hub/agents/gaia/python/tests/test_api_construction.py -xvs` — 3 pass
- [ ] `python -m pytest hub/agents/gaia/python/tests/ tests/unit/api/ tests/test_api.py -q` — no collateral damage (220 + 112 pass locally)
- [ ] Confirm the gate is real: rename `output_handler` on `ChatAgentConfig` (`hub/agents/chat/python/gaia_agent_chat/agent.py`) and re-run — must fail with `TypeError: GaiaAgentConfig.__init__() got an unexpected keyword argument 'output_handler'`. Before this PR the same break left all 115 API tests passing.
- [ ] Second injected break: add a keyword to `init_params` inside `get_agent()` only — must fail. This is why the test calls `get_agent()` instead of reproducing it.
- [ ] `python util/lint.py --imports` with and without the hub wheels installed — the new flagship entry reports `[OK]` when present and `[SKIP]` when not, never a failure.

<details>
<summary>🔍 Technical details</summary>

Three cases in `hub/agents/gaia/python/tests/test_api_construction.py`:
- `get_agent("gaia")` builds a real `GaiaAgent` and the SSE handler lands on `agent.console` — `silent_mode=True` also ships in `init_params`, so construction not raising is only half the assertion.
- `AGENT_MODELS["gaia"]["class_name"]` still resolves to `GaiaAgent`; `get_agent` folds a stale path's `ImportError` into a generic `ValueError`, so a rename would otherwise surface only as a runtime 500.
- `_apply_env_overrides()` injects `debug`/`silent_mode`/`show_prompts`/`streaming` for `gaia api start --debug`; those keys are derived from the function rather than hardcoded, and asserted to be declared fields.

Hermetic and ~14s: memory init is forced off via `GAIA_MEMORY_DISABLED` and the tool registry is isolated, matching the sibling tests in that directory. No model server needed.

Two smaller items ride along. `test_gaia_agent.yml` gains `src/gaia/api/agent_registry.py` in its path filter — without it, editing the registry alone would not run the suite that now guards it. `tests/test_api.py` and `tests/unit/api/test_sse_confirmation_gate.py` had comments left garbled by #2995; note the `test_api.py` stub is defensive rather than load-bearing (`model_exists("gaia")` is already `True`), and the rewritten comment says so.
</details>