### PR TITLE
fix(tui): don't run an unverified binary from the hub install root

### DIFF
--- a/tui/internal/catalog/catalog.go
+++ b/tui/internal/catalog/catalog.go
@@ -121,7 +121,30 @@ func findInstalledBinary(agentID, name string) string {
 	return findInstalledBinaryIn(InstallRoot(), agentID, name)
 }
 
+// findInstalledBinaryIn returns the agent's binary under the install root, but
+// only when an .installed sentinel proves the directory is a completed install.
+//
+// Without that gate the file's NAME is the only evidence of what it is, and the
+// name is not unique: `gaia-agent` is both the stdio child this looks for and
+// the frozen REST sidecar other installers stage into this same directory.
+// Spawning the wrong one feeds uvicorn's startup log to a JSON line scanner
+// (#3062). A directory with no sentinel is a leftover or an in-progress
+// install, which is how LocalInstalls already treats it.
 func findInstalledBinaryIn(root, agentID, name string) string {
+	if root == "" || agentID == "" {
+		return ""
+	}
+	if record, err := readSentinel(filepath.Join(root, agentID, SentinelName)); err != nil || record == nil {
+		return ""
+	}
+	return installDirBinaryIn(root, agentID, name)
+}
+
+// installDirBinaryIn finds the binary by name alone, with no sentinel check.
+// Only two callers may use it: findInstalledBinaryIn once the sentinel has
+// verified the install, and ResolveExecutable's diagnostic, which needs to tell
+// "nothing is there" apart from "something is there but unverified".
+func installDirBinaryIn(root, agentID, name string) string {
 	if root == "" || agentID == "" {
 		return ""
 	}
@@ -215,6 +238,15 @@ func ResolveExecutable(nameOrPath, agentID string) (string, error) {
 		where = "~/.gaia/agents"
 	} else {
 		where = filepath.Join(where, agentID)
+	}
+	// A file IS sitting there, it just has no sentinel to say what it is. Saying
+	// "not found" here sends the user hunting for a missing download when the
+	// real answer is "finish the install"; naming the file is the difference.
+	if p := installDirBinaryIn(InstallRoot(), agentID, nameOrPath); p != "" {
+		return "", fmt.Errorf(
+			"%w: reinstall %s with `gaia hub install %s` — %s exists but the install "+
+				"is unverified (no %s), so it is not safe to run",
+			ErrNoExecutable, agentID, agentID, p, SentinelName)
 	}
 	// Action first: this text is also shown in the hub's one-row status bar,
 	// where an 80-column terminal truncates whatever comes after ~70 characters.

--- a/tui/internal/catalog/hub_test.go
+++ b/tui/internal/catalog/hub_test.go
@@ -7,6 +7,20 @@ import (
 	"testing"
 )
 
+// writeSentinel marks <root>/<agentID> a completed install, which is what
+// findInstalledBinaryIn requires before it will hand back a binary from there.
+func writeSentinel(t *testing.T, root, agentID, executable string) {
+	t.Helper()
+	dir := filepath.Join(root, agentID)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	body := `{"id":"` + agentID + `","version":"0.1.0","language":"python","executable":"` + executable + `"}`
+	if err := os.WriteFile(filepath.Join(dir, SentinelName), []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
 func hubResponse(installed bool, supervised bool) *HubCatalog {
 	entry := HubEntry{
 		ID:                "email",
@@ -179,6 +193,7 @@ func TestFindInstalledBinaryFindsANonWindowsExecutable(t *testing.T) {
 	if err := os.WriteFile(path, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
 		t.Fatal(err)
 	}
+	writeSentinel(t, root, "email", name)
 
 	got := findInstalledBinaryIn(root, "email", "gaia-agent-email")
 	if got == "" {
@@ -198,8 +213,59 @@ func TestFindInstalledBinarySearchesTheBinSubdir(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(dir, "gaia-agent-email"), []byte("x"), 0o755); err != nil {
 		t.Fatal(err)
 	}
+	writeSentinel(t, root, "email", "gaia-agent-email")
 	if got := findInstalledBinaryIn(root, "email", "gaia-agent-email"); got == "" {
 		t.Fatal("did not search <id>/bin/")
+	}
+}
+
+// The flagship's stdio child and the frozen REST sidecar are both named
+// `gaia-agent`, and other installers stage the REST one into this same
+// directory without a sentinel. Spawning it fed uvicorn's startup log to a JSON
+// line scanner, which the user saw as "unreadable event skipped" (#3062).
+func TestFindInstalledBinaryIgnoresABinaryWithNoSentinel(t *testing.T) {
+	root := t.TempDir()
+	dir := filepath.Join(root, "gaia")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	name := "gaia-agent"
+	if runtime.GOOS == "windows" {
+		name += ".exe"
+	}
+	if err := os.WriteFile(filepath.Join(dir, name), []byte("x"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	if got := findInstalledBinaryIn(root, "gaia", "gaia-agent"); got != "" {
+		t.Errorf("ran an unverified binary from the install root: %s", got)
+	}
+	// The file is still there, so the diagnostic must say "finish the install"
+	// rather than sending the user to look for a download that already happened.
+	if got := installDirBinaryIn(root, "gaia", "gaia-agent"); got == "" {
+		t.Error("installDirBinaryIn must still see the file, for the diagnostic")
+	}
+}
+
+// A corrupt sentinel is not proof of a completed install either.
+func TestFindInstalledBinaryIgnoresACorruptSentinel(t *testing.T) {
+	root := t.TempDir()
+	dir := filepath.Join(root, "gaia")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	name := "gaia-agent"
+	if runtime.GOOS == "windows" {
+		name += ".exe"
+	}
+	if err := os.WriteFile(filepath.Join(dir, name), []byte("x"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, SentinelName), []byte("{not json"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if got := findInstalledBinaryIn(root, "gaia", "gaia-agent"); got != "" {
+		t.Errorf("trusted a corrupt sentinel: %s", got)
 	}
 }
 
@@ -215,6 +281,10 @@ func TestFindInstalledBinaryIgnoresANonExecutableFile(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(dir, "gaia-agent-email"), []byte("x"), 0o644); err != nil {
 		t.Fatal(err)
 	}
+	// Sentinel present on purpose: without it the install-completeness gate
+	// would reject this, and the test would pass without ever reaching the mode
+	// bits it exists to check.
+	writeSentinel(t, root, "email", "gaia-agent-email")
 	if got := findInstalledBinaryIn(root, "email", "gaia-agent-email"); got != "" {
 		t.Errorf("returned a non-executable file: %s", got)
 	}

--- a/tui/internal/catalog/seed_test.go
+++ b/tui/internal/catalog/seed_test.go
@@ -129,6 +129,40 @@ func TestSetMockBinaryMakesTheSubprocessAgentLaunchable(t *testing.T) {
 	}
 }
 
+// The diagnostic a user actually reads when a binary IS there but unverified.
+// "not found" would send them chasing a download that already happened, so the
+// wording is the fix, not an implementation detail — pin it.
+func TestResolveExecutableNamesAnUnverifiedInstall(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)        // os.UserHomeDir on POSIX
+	t.Setenv("USERPROFILE", home) // ... and on Windows
+	dir := filepath.Join(home, ".gaia", "agents", "gaia")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// A name no real machine has on PATH, so exec.LookPath cannot pre-empt the
+	// install-root lookup this is about.
+	const name = "gaia-agent-unverified-fixture"
+	file := name
+	if runtime.GOOS == "windows" {
+		file += ".exe"
+	}
+	if err := os.WriteFile(filepath.Join(dir, file), []byte("x"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := ResolveExecutable(name, "gaia")
+	if err == nil {
+		t.Fatal("an unverified binary in the install root resolved successfully")
+	}
+	// Naming the file is what separates "finish the install" from "go download it".
+	for _, want := range []string{"gaia hub install", SentinelName, file} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("the error does not mention %q:\n%s", want, err)
+		}
+	}
+}
+
 // ResolveExecutable is what turns "the catalog names a binary" into "this
 // process can exec it". A name that resolves nowhere must fail here — before a
 // caller can report a connection.


### PR DESCRIPTION
Install the flagship agent with npm, then start the TUI, and the chat can fill with uvicorn's startup log instead of answers — the same `[unreadable event skipped]` failure #3062 fixed, reached by a different route. The install root is the Agent Hub's namespace, but the lookup keyed on filename alone, and `gaia-agent` names two different programs: the stdio child the TUI spawns, and the frozen REST sidecar other installers stage into that same directory. #3062 routed agents carrying an `.installed` sentinel through the daemon; a directory with **no** sentinel kept the old behaviour and was spawned anyway.

A sentinel-less directory is a leftover or an in-progress install — which is how `LocalInstalls` already treats it — so the lookup now requires one. When a file is present but unverified, the error names it and says to reinstall, instead of reporting a download that already happened as missing.

## Test plan

- [ ] `cd tui && go test ./...` — 15 packages pass
- [ ] `cd tui && go vet ./... && golangci-lint run ./internal/catalog/...` — clean
- [ ] Both new tests fail with the gate reverted (verified by reverting it): `TestFindInstalledBinaryIgnoresABinaryWithNoSentinel` and `TestFindInstalledBinaryIgnoresACorruptSentinel`
- [ ] The three pre-existing `findInstalledBinaryIn` tests now write a sentinel, so they still exercise what they claim rather than passing on the new gate