### PR TITLE
docs(agent-gaia): correct the npm sidecar docs against the code

### DIFF
--- a/docs/guides/gaia.mdx
+++ b/docs/guides/gaia.mdx
@@ -22,7 +22,7 @@ GAIA is the agent a new user meets first. One agent handles the everyday work yo
 - **Web research** — search the web, fetch and read pages, download files.
 - **Files** — read, search by name or content, and walk directory trees inside your allowed scope. Writing and editing are available too, behind an explicit confirmation (see [Tools that need your approval](#tools-that-need-your-approval)).
 - **Images** — describe a local image or answer a question about it, using the local vision model.
-- **Skills** — short playbooks loaded into the agent's own prompt. Opt-in; see [Skills](#skills-opt-in) below for what ships in this release.
+- **Skills** — short playbooks loaded into the agent's own prompt. One ships always-on; the rest are opt-in. See [Skills](#skills) below for what this release ships.
 
 ## Requirements
 
@@ -82,9 +82,15 @@ curl -s http://127.0.0.1:8141/v1/gaia/init
 
 It answers **200** when ready and **503** when not, with a `hint` naming the fix — Lemonade unreachable, Lemonade too old, or model not downloaded. Liveness alone is `GET /health`, which never touches the model server.
 
+<Note>
+  A **401** here means the sidecar wants a caller token — `/v1/gaia/*` requires one, while
+  `/health` and `/version` don't. That's the normal state for the sidecar the daemon
+  spawns. See [Authenticating your requests](#authenticating-your-requests).
+</Note>
+
 ## Tool surface
 
-The default construction registers **55 tools**. Grouped by what they're for:
+The default construction registers **67 tools** — the 55 of the Chat agent's `full` profile, plus 7 skill-library tools, 4 code-search tools, and the `load_tools` escape hatch. Grouped by what they're for:
 
 | Area | Tools |
 |---|---|
@@ -95,7 +101,11 @@ The default construction registers **55 tools**. Grouped by what they're for:
 | Memory | `remember`, `recall`, `forget`, `update_memory`, `search_past_conversations` |
 | Images | `analyze_image`, `answer_question_about_image` |
 | Desktop & system | `take_screenshot`, `list_windows`, `get_system_info`, `notify_desktop`, `read_clipboard`, `write_clipboard`, `text_to_speech`, `run_shell_command` |
-| Run control | `request_user_input`, `set_loop_state` |
+| Skills | `list_skills`, `search_skill_hub`, `install_skill`, `remove_skill`, `load_skill`, `unload_skill`, `skill_status` |
+| Code search | `index_codebase`, `search_code_index`, `get_index_status`, `clear_code_index` |
+| Run control | `request_user_input`, `set_loop_state`, `load_tools` |
+
+That count is what the agent *can* do, not what it sees at once: per-turn tool selection sends the model a subset of the registry on any one call, and `load_tools` is the escape hatch it calls mid-turn to pull in a bundle the selector missed. No capability is lost either way.
 
 `run_shell_command` is restricted to a read-only command allowlist (`ls`, `cat`, `grep`, `find`, `stat`, `df`, `uname`, and similar) and rate-limited. Anything that writes, installs, or executes an arbitrary binary is refused.
 
@@ -103,11 +113,11 @@ The default construction registers **55 tools**. Grouped by what they're for:
 
 ### Tools that need your approval
 
-Three tools mutate your machine and are gated behind an explicit confirmation: **`write_file`**, **`edit_file`**, and **`run_shell_command`**. Everything else — reading, indexing, querying, web fetching, memory — runs without asking.
+Six tools mutate your machine and are gated behind an explicit confirmation: **`write_file`**, **`edit_file`**, **`run_shell_command`**, **`execute_python_file`**, and — because installing a skill writes third-party code under `~/.gaia/skills` and removing one deletes it — **`install_skill`** and **`remove_skill`**. Everything else — reading, indexing, querying, web fetching, memory — runs without asking.
 
 <Warning>
-  **Over the sidecar's `/query` stream, those three are refused rather than prompted.** That
-  surface has no way to collect an approval yet, so instead of pretending to, the run stops
+  **Over the sidecar's `/query` stream, all six are refused rather than prompted.** That
+  surface has no way to collect an approval, so instead of pretending to, the run stops
   with a message saying which action it declined. If your workflow depends on the agent
   writing files, drive it from a surface that can prompt you, or perform the write yourself.
 </Warning>
@@ -121,7 +131,7 @@ That's the honest scope for a personal document agent — "ask questions about m
 To narrow it, construct the agent with an explicit list:
 
 ```python
-from gaia_agent_gaia.agent import GaiaAgent, GaiaAgentConfig
+from gaia_agent.agent import GaiaAgent, GaiaAgentConfig
 
 agent = GaiaAgent(config=GaiaAgentConfig(
     allowed_paths=["/home/me/Documents", "/home/me/projects"],
@@ -129,7 +139,7 @@ agent = GaiaAgent(config=GaiaAgentConfig(
 ```
 
 <Note>
-  In v0.1.0 this is a **construction-time** setting only — the packaged sidecar exposes no
+  In v0.1.1 this is a **construction-time** setting only — the packaged sidecar exposes no
   flag or environment variable for it, so narrowing the scope means embedding the agent in
   your own Python process.
 </Note>
@@ -140,11 +150,13 @@ Memory is on by default and lives on-device. The agent writes facts you ask it t
 
 The mechanism, storage location, and how to disable it are covered in the [Memory guide](/guides/memory).
 
-## Skills (opt-in)
+## Skills
 
 [Agent Skills](/guides/composing-skills) are short playbooks an agent loads into its own prompt, grouped into named **skill sets** — exactly one set is active per launch. GAIA is built to host them: its own bundled skill directory is the highest-precedence discovery root, so a skill shipped with the agent wins over a same-named user copy.
 
-**No skill set loads by default, and v0.1.0 declares none.** Skill bodies cost prompt tokens and shrink the room left for an answer, and no eval has measured that trade for this agent yet. The manifest's skill-set declarations ship commented out; enabling them is uncommenting two blocks, with no code change.
+**One skill ships enabled: `gaia-voice`.** It is declared in the manifest's always-on `skills:` list, so it is in the prompt on every call — 676 tokens of it, and it registers no tools. It isn't a task recipe but the agent's honesty floor: don't claim work you didn't do, don't present empty output as a result, don't substitute a near-miss and report success. Those failures spoil an answer whatever the task is, which is why it can't sit in a bundle you have to opt into.
+
+**No skill *set* loads by default, and v0.1.1 declares none.** Loading several skill bodies into every prompt costs tokens and shrinks the room left for an answer, and no eval has measured that trade for this agent yet. The manifest's skill-set declarations ship commented out; enabling them is uncommenting two blocks, with no code change.
 
 Once a release declares sets, you select one at launch:
 
@@ -182,6 +194,18 @@ The agent runs as a **sidecar** — a self-contained HTTP service the GAIA daemo
 - **Idle streams emit `: keepalive` comments** every 10 seconds so a long tool call doesn't look like a dead connection.
 - **Confirmation-gated tools end the run with a refusal** — see [Tools that need your approval](#tools-that-need-your-approval).
 
+### Authenticating your requests
+
+Binding to loopback is not access control — this agent has shell and file tools, so an open port would let any page you visit drive it. Three checks guard the sidecar:
+
+- **A per-session bearer token.** Every `/v1/gaia/*` request must carry `Authorization: Bearer <token>`; without it you get **401**. The process that spawned the sidecar supplies the token, either as `GAIA_GAIA_SIDECAR_TOKEN_FILE` — a path to a `0600`, owner-only file, so the secret never sits in the environment — or directly as `GAIA_GAIA_SIDECAR_TOKEN`. When the GAIA daemon runs the agent, it mints the token and uses the file channel.
+- **A loopback `Host` allowlist.** A `Host` header that isn't `127.0.0.1`, `localhost`, or `::1` is **400** — this is what defeats DNS rebinding.
+- **Origin rejection.** A request carrying a non-loopback browser `Origin` is **403**. Non-browser clients send no `Origin` and are unaffected.
+
+`GET /health`, `GET /version`, and `GET /v1/gaia/version` skip the token — they're the probes a host polls before any token is in play, and none of them exposes your data. `Host` and `Origin` still apply to them.
+
+If neither token variable is set, the sidecar starts with the token check off and says so loudly in its log; `Host` and `Origin` stay enforced. That's a **local development** convenience — a sidecar you started by hand — not something to build on. Full details, including how to supply a token when you spawn the sidecar yourself, are in the package's [SPEC.md §5.4](https://github.com/amd/gaia/blob/main/hub/agents/gaia/npm/SPEC.md).
+
 ## Troubleshooting
 
 ### "Local Lemonade Server is not reachable"
@@ -208,10 +232,10 @@ It isn't on the Agent Hub yet, so there is nothing to install — the row is del
 
 The daemon redirects the sidecar's output to `~/.gaia/agents/gaia/logs/sidecar-<port>.log`. Check that file first; a failed start also surfaces the log tail in the error. `gaia daemon agents` shows id, mode, pid, port, and contract version for everything currently running.
 
-## Limitations (v0.1.0)
+## Limitations (v0.1.1)
 
 - **Not published on the Agent Hub yet** — install from source until the release tag lands.
-- **No skill sets declared** — the skill machinery is wired and tested, but nothing ships enabled; see [Skills](#skills-opt-in).
+- **No skill sets declared** — the skill machinery is wired and tested, and `gaia-voice` ships always-on, but no *set* does; see [Skills](#skills).
 - **Narrowing file scope requires embedding the agent** — no sidecar flag for `allowed_paths` yet.
-- **No server-side confirmation flow** — over `/query`, `write_file`, `edit_file`, and `run_shell_command` end the run with a refusal instead of prompting over the stream.
+- **No server-side confirmation flow** — over `/query`, all six [confirmation-gated tools](#tools-that-need-your-approval) end the run with a refusal instead of prompting over the stream.
 - **No image generation** — deliberately, so the chat model is never evicted mid-conversation.

--- a/hub/agents/gaia/npm/CHANGELOG.md
+++ b/hub/agents/gaia/npm/CHANGELOG.md
@@ -31,7 +31,15 @@ the terminal UI meant building it from source.
   hatch the model calls mid-turn to pull in a bundle the selector missed.
   `GAIA_DYNAMIC_TOOLS=0` turns the selection off, `GAIA_DYNAMIC_TOOLS_MAX`
   moves the cap and `GAIA_DYNAMIC_TOOLS_TAU` the match threshold.
-- **A materially smaller fixed prompt on every call.** The always-on
+- **One bundled skill ships enabled: `gaia-voice`.** It is a manifest `skills:`
+  entry, so it is always on and rendered in full on every LLM call — 676 tokens
+  of every prompt, and it declares no tools. It is the agent's honesty floor
+  (don't claim work you didn't do, don't present empty output as a result,
+  don't substitute a near-miss and report success), which is why it is not in an
+  opt-in bundle the way a task skill is. No *skill set* ships enabled: the
+  manifest's `skill_sets:` / `default_skill_set:` blocks stay commented out until
+  an eval measures what loading several bodies costs. See SKILL.md §10.
+- **A materially smaller fixed prompt on every call.** That always-on
   `gaia-voice` guidance was rewritten from 2,145 tokens to 692 with all of its
   behavioural rules intact. It had been a rationale document — every rule
   followed by the incident that motivated it — and the model needs the rule,
@@ -99,7 +107,10 @@ the terminal UI meant building it from source.
 - The sidecar has no arm64 Linux or arm64 Windows build. On those platforms the
   run stops with an error naming the platform and the supported set rather than
   launching a UI with no agent behind it.
-- `gaia_agent` 0.1.1 has no caller-auth token, so unlike
-  `@amd-gaia/agent-email` this package mints and sends none.
+- `gaia_agent` enforces a per-session caller-auth bearer on every `/v1/gaia/*`
+  request, plus a loopback `Host` allowlist and non-loopback `Origin` rejection.
+  This package mints no token, so a sidecar it spawns comes up in dev mode (token
+  check skipped, loudly warned, Host/Origin still enforced) — pass your own
+  through `spawnSidecar`'s `env` to turn it on. See SPEC §5.4.
 - Tracks sidecar contract `apiVersion` **2.12**; a differing major raises
   `VersionMismatchError`.

--- a/hub/agents/gaia/npm/CHANGELOG.md
+++ b/hub/agents/gaia/npm/CHANGELOG.md
@@ -40,7 +40,7 @@ the terminal UI meant building it from source.
   manifest's `skill_sets:` / `default_skill_set:` blocks stay commented out until
   an eval measures what loading several bodies costs. See SKILL.md §10.
 - **A materially smaller fixed prompt on every call.** That always-on
-  `gaia-voice` guidance was rewritten from 2,145 tokens to 692 with all of its
+  `gaia-voice` guidance was rewritten from 2,129 tokens to 676 with all of its
   behavioural rules intact. It had been a rationale document — every rule
   followed by the incident that motivated it — and the model needs the rule,
   not the incident report.

--- a/hub/agents/gaia/npm/README.md
+++ b/hub/agents/gaia/npm/README.md
@@ -9,7 +9,10 @@ npx @amd-gaia/gaia
 That fetches the two binaries GAIA needs — the agent sidecar and the terminal UI —
 verifies both against a checksum manifest that ships inside this package, and drops
 you into the terminal UI. No Python to install, no repo to clone, no build step.
-Everything runs locally on your machine; nothing you type or index leaves it.
+Everything runs locally on your machine; nothing you type or index leaves it. The
+terminal UI's `--use-claude` flag, which would send a conversation to the
+Anthropic API, is refused for the agent this package installs — see
+[`SPEC.md` §5.5](./SPEC.md#55-other-transports).
 
 The terminal UI you get here is the published **`terminal-hub`** component — the
 exact same binary a full GAIA install runs as `gaia tui`, not a separate build. So
@@ -125,6 +128,12 @@ curl http://127.0.0.1:8141/health
 
 It waits for `GET /health`, checks the contract version, and tears the whole
 process tree down on Ctrl+C. See [`SPEC.md`](./SPEC.md) for the endpoints.
+
+The sidecar normally requires a per-session bearer token on `/v1/gaia/*`, but
+neither `serve` nor `startSidecar` mints one, so both leave it in dev mode — the
+token check off, `Host`/`Origin` still enforced. This agent has shell and file
+tools, so before you expose it to anything, supply a token of your own: see
+[`SPEC.md` §5.4](./SPEC.md#54-caller-authentication).
 
 ## Programmatic use
 

--- a/hub/agents/gaia/npm/SKILL.md
+++ b/hub/agents/gaia/npm/SKILL.md
@@ -520,6 +520,20 @@ session slot is busy and none is idle enough to evict (SPEC §5.2). Do NOT
 loop on `/v1/gaia/init` — it will report ready. Wait for a running turn to
 finish (or close an idle session) and retry the same `/query`.
 
+**Three more refusals are yours to avoid**, each naming its fix in `detail`
+(SPEC §5.2 has the reasoning):
+
+- **409 — the `run_id` is still in flight.** You mint it, so mint a fresh UUID
+  per request; reusing one would leave the earlier run with no way to be
+  cancelled.
+- **409 — `model` differs from what this `session_id` was built with.** Only
+  construction reads a model, so it cannot be applied to the retained agent.
+  Omit `model` to stay on the session's current one, or start a new
+  `session_id` to switch.
+- **400 — the `Host` header is absent or empty.** The loopback check fails
+  closed, so omitting the header is refused rather than served. Send
+  `Host: 127.0.0.1:<port>`; every real HTTP client already does.
+
 For the full wire contract, lock schema, exit codes, and timeout table, see
 [`SPEC.md`](./SPEC.md). For the user-facing overview, see [`README.md`](./README.md)
 and <https://amd-gaia.ai/docs/guides/gaia>.

--- a/hub/agents/gaia/npm/SKILL.md
+++ b/hub/agents/gaia/npm/SKILL.md
@@ -23,7 +23,8 @@ Two ways in:
 > playbook: how *you* wire this package into an app. The agent separately loads
 > **Agent Skills** into its own prompt at runtime from
 > `gaia_agent/skills/<name>/SKILL.md`. Same filename, different artifact —
-> don't ship this one as an agent skill. See [Skills](#10-skills--opt-in-and-empty-in-010).
+> don't ship this one as an agent skill. See
+> [Skills](#10-skills--one-always-on-the-rest-opt-in).
 
 ## 1. Install
 
@@ -187,6 +188,30 @@ await shutdown(proc);   // tree-kill; auto-cleanup also reaps on exit
   on `exit`, `SIGINT`/`SIGTERM`/`SIGHUP`, `uncaughtException`, and
   `unhandledRejection`. A `SIGKILL` of *your* process is the one case nothing
   in-process can catch.
+- **Mint a caller token, or you are running the sidecar unauthenticated.** The
+  sidecar requires `Authorization: Bearer <token>` on every `/v1/gaia/*`
+  request, and skips the check only when neither token env var is set — dev
+  mode, which is what `startSidecar` gives you, because this package mints
+  nothing. Loopback binding is not the boundary: this agent has shell and file
+  tools. Mint your own and pass it through the `env` option (`StartOptions`
+  extends `SpawnOptions`, so it merges over `process.env`):
+
+  ```ts
+  import { randomBytes } from "node:crypto";
+  const token = randomBytes(32).toString("hex");
+  const proc = await startSidecar({
+    binaryPath: sidecar.binaryPath,
+    env: { GAIA_GAIA_SIDECAR_TOKEN: token },   // or ..._TOKEN_FILE, a 0600 path
+  });
+  ```
+
+  Then send `authorization: "Bearer " + token` on every `/v1/gaia/*` call.
+  `/health`, `/version`, and `/v1/gaia/version` are exempt, so `startSidecar`'s
+  own health-and-version handshake works either way. **If you did not spawn the
+  sidecar** — you are talking to one the GAIA daemon started — the token is the
+  daemon's, delivered to the sidecar as `GAIA_GAIA_SIDECAR_TOKEN_FILE` (a `0600`
+  file path); read it from there, don't invent one. A 401 whose `detail` names
+  both env vars means you sent the wrong token or none.
 
 Or skip the code entirely and let the CLI own it:
 
@@ -220,7 +245,11 @@ import { randomUUID } from "node:crypto";
 const runId = randomUUID();
 const res = await fetch(`${proc.baseUrl}/v1/gaia/query`, {
   method: "POST",
-  headers: { "content-type": "application/json", accept: "text/event-stream" },
+  headers: {
+    "content-type": "application/json",
+    accept: "text/event-stream",
+    authorization: `Bearer ${token}`,   // required unless the sidecar is in dev mode — §6
+  },
   body: JSON.stringify({
     query: "Summarize the PDFs in ~/Documents/reports",
     run_id: runId,
@@ -290,14 +319,18 @@ Rules a client must respect:
   **200**, not a 404, because a cancel racing a normal completion is expected.
   Dropping the HTTP connection also cancels the run.
 
-## 8. Confirmation-gated tools are **refused, not prompted**
+## 8. Over `/v1/gaia/query`, confirmation-gated tools are **refused, not prompted**
 
-Read this before you design a workflow around it.
+Read this before you design a workflow around it. This section is about the HTTP
+surface — the agent's other transport can collect an approval; see SPEC §5.5.
 
-Three of the agent's 55 tools write to disk or execute a command, and sit in the
-base `TOOLS_REQUIRING_CONFIRMATION` set: **`write_file`**, **`edit_file`**, and
-**`run_shell_command`**. Everything else — reading, indexing, querying, web
-fetching, memory — runs without asking.
+Six of the agent's 67 tools mutate the machine and need explicit approval before
+they run. Four sit in the base `TOOLS_REQUIRING_CONFIRMATION` set —
+**`write_file`**, **`edit_file`**, **`run_shell_command`**, and
+**`execute_python_file`** — and the flagship adds two of its own,
+**`install_skill`** and **`remove_skill`**, because installing a skill writes
+third-party code under `~/.gaia/skills` and removing one deletes it. Everything
+else — reading, indexing, querying, web fetching, memory — runs without asking.
 
 Over `/v1/gaia/query` there is **no way to collect an approval**, so the stream
 does not prompt. When the agent reaches one of those tools it emits a
@@ -314,11 +347,13 @@ data: {"type":"needs_confirmation","run_id":"…","action":"write_file","summary
 data: {"type":"final","answer":"I stopped before running 'write_file' because it needs your explicit approval, and this streaming surface cannot collect that yet. …"}
 ```
 
-So: **`/query` cannot write files, edit files, or run shell commands.** If your
-integration needs that, drive the agent from a surface that can prompt (the
-terminal UI or the Agent UI), or perform the mutation yourself from your own code
-and let the agent do the reading and reasoning. Treat `needs_confirmation` as an
-early warning that the run is about to end, not as a question you can answer.
+So: **`/query` cannot run any of those six tools.** If your integration needs
+that, drive the agent from a surface that can prompt — its stdio transport is the
+one that can, because its control channel carries an approval back to a turn
+already in flight (SPEC §5.5) — or perform the mutation yourself from your own
+code and let the agent do the reading and reasoning. Treat `needs_confirmation`
+as an early warning that the run is about to end, not as a question you can
+answer.
 
 ## 9. File-access scope
 
@@ -339,7 +374,7 @@ from gaia_agent.agent import GaiaAgent, GaiaAgentConfig
 agent = GaiaAgent(config=GaiaAgentConfig(allowed_paths=["/home/me/Documents"]))
 ```
 
-## 10. Skills — opt-in, and empty in 0.1.1
+## 10. Skills — one always-on, the rest opt-in
 
 The agent is built to host **Agent Skills** (short playbooks loaded into its own
 prompt, grouped into named sets, one set active per launch), and its bundled
@@ -355,17 +390,25 @@ threshold. Manifest `skills:` entries are always-on and never collapse. If the
 embedder is unavailable, selection disables itself for the session and every
 body renders — capability is never silently lost to a failed match.
 
-**Nothing ships enabled in 0.1.1.** The bundled skill library is empty, and
-`gaia-agent.yaml` ships its `skills:` / `skill_sets:` / `default_skill_set:`
-blocks **commented out** — following the email agent's precedent, because skill
-bodies cost prompt tokens and no eval has measured that trade for this agent yet.
-Re-enabling is uncommenting two blocks; no code change.
+**One skill ships enabled: `gaia-voice`.** It is a manifest `skills:` entry, so
+it is always on, always rendered in full, and paid on every LLM call of every
+turn — budget for it. It is not a task recipe but the agent's honesty floor: do
+not claim work you did not do, do not present empty output as a result, do not
+substitute a near-miss and report success. Those failures corrupt an answer
+whatever the task is, which is why it cannot live in an opt-in bundle. It
+declares no tools, and its body measures 676 tokens (tiktoken `cl100k`).
 
-So today: no skill set loads, and there is nothing for `GAIA_SKILL_SET` to
-select — leave it unset. Once a release declares sets, `GAIA_SKILL_SET` is the
-selection channel for the packaged sidecar (its CLI has no `--skill-set` flag),
-and an undeclared name raises naming the valid sets rather than falling back to a
-default. Do not document or design around skills being on by default.
+**No skill *set* loads.** `gaia-agent.yaml` ships its `skill_sets:` and
+`default_skill_set:` blocks **commented out** — following the email agent's
+precedent, because loading several skill bodies into every prompt costs tokens
+and no eval has measured that trade for this agent yet. Re-enabling is
+uncommenting two blocks; no code change.
+
+So today there is nothing for `GAIA_SKILL_SET` to select — leave it unset. Once
+a release declares sets, `GAIA_SKILL_SET` is the selection channel for the
+packaged sidecar (its CLI accepts only `--host` and `--port`), and an undeclared
+name raises naming the valid sets rather than falling back to a default. Beyond
+`gaia-voice`, do not design around a skill being on by default.
 
 ## 11. Ports
 
@@ -408,16 +451,20 @@ There is no silent null.
   reachable"** means Lemonade isn't running or isn't reachable — not a bug in
   this package. Start it, or set `LEMONADE_BASE_URL`.
 - **`needs_confirmation` is followed by a refusal and the run ends.** See §8.
-  `write_file` / `edit_file` / `run_shell_command` are unreachable over `/query`.
+  The six gated tools are unreachable **over `/query`** — the agent itself can
+  run them on a transport that can prompt (SPEC §5.5).
 - **A placeholder hash in `binaries.lock.json` blocks the fetch before any
   network call.** Between releases that is the *expected* state — it is not a
   broken install, and there is no override.
 - **No `linux-arm64` / `win32-arm64` sidecar.** The TUI has both. A `PlatformError`
   on those hosts is the design, not a missing artifact.
-- **There is no caller-auth token at 0.1.1.** Unlike `@amd-gaia/agent-email`, this
-  sidecar mints none and this package sends none — don't add an `Authorization`
-  header looking for one, and don't rely on its absence as a security boundary.
-  Loopback binding is what protects it.
+- **A `401` from `/v1/gaia/*` is the caller-auth token, not a bug.** The sidecar
+  requires `Authorization: Bearer <token>`; `/health`, `/version`, and
+  `/v1/gaia/version` are exempt, which is why a green health check sits happily
+  in front of a 401 on `/query`. It skips the check only in dev mode — neither
+  token env var set — which is what `spawnSidecar` and `gaia serve` produce,
+  because this package mints nothing. Do not treat loopback binding as the
+  boundary; mint a token and pass it (§6).
 - **`run_id` must be a UUID**, and unknown fields in the request body are a
   **422** — the model forbids extras. Typos don't get ignored.
 - **`gaia run` needs the *Python* `gaia` CLI on `PATH`** — the TUI shells out to
@@ -462,6 +509,11 @@ curl -N -X POST http://127.0.0.1:8141/v1/gaia/query \
 A healthy run streams `status` / `token` events and ends with one `final`. If
 `/v1/gaia/init` is 503, fix what its `hint` names and retry — the rest of your
 integration is fine.
+
+That `/query` call carries no `Authorization` header because `gaia serve` starts
+the sidecar in dev mode. Against one started with a token, add
+`-H "authorization: Bearer $TOKEN"` — a **401** here and a green `/health` is
+that and nothing else (§6).
 
 **A 503 from `/query` itself is a different condition**: every retained
 session slot is busy and none is idle enough to evict (SPEC §5.2). Do NOT

--- a/hub/agents/gaia/npm/SPEC.md
+++ b/hub/agents/gaia/npm/SPEC.md
@@ -253,7 +253,10 @@ none is idle enough to evict gets `503` with the reason in `detail` — a
 temporary, retryable condition, not a bug: wait for a turn to finish (or
 close an idle session) and retry. A
 `session_id` can also be evicted from the retention table under an idle
-timeout or an LRU cap on concurrent sessions; a `/query` that lands on an
+timeout (**4 hours** without a turn) or an LRU cap on concurrent sessions
+(**100**) — the two knobs that decide when the `503` above can happen at all
+(`session_registry.py`). Eviction is idle-only: a conversation still in use is
+never timed out mid-flight. A `/query` that lands on an
 evicted id gets a fresh agent (the conversation is not blocked) but the
 response stream's first event is a `{"type":"status","status":"warning",...}`
 telling the caller that per-turn state — most visibly any loaded skill — did
@@ -266,13 +269,65 @@ against this package's `API_VERSION`. A differing major is a breaking contract
 change and raises `VersionMismatchError`. A higher minor with the same major is a
 backward-compatible addition and is accepted.
 
-### 5.4 No caller-auth token
+### 5.4 Caller authentication
 
-The email sidecar authenticates callers with a per-session bearer minted into
-`GAIA_EMAIL_SIDECAR_TOKEN`. `gaia_agent` has **no equivalent** at 0.1.1, so
-this package mints and sends nothing. When the sidecar grows one, it lands here as
-a spawn-time env var and a request header — a change to this section, not a new
-subsystem.
+Loopback binding is not access control: this sidecar exposes shell and file
+tools, so an unauthenticated port lets any page the user visits drive it. Three
+controls guard it, all in `gaia_agent.caller_auth` over the mechanism shared
+with the email sidecar (`gaia.sidecar.caller_auth`):
+
+1. **Per-session bearer token.** Every `/v1/gaia/*` request must carry
+   `Authorization: Bearer <token>`. The spawning parent supplies it one of two
+   ways: `GAIA_GAIA_SIDECAR_TOKEN_FILE` — the path to a `0600`, owner-only file
+   holding the token, which is the preferred channel because the secret never
+   sits in the environment — or `GAIA_GAIA_SIDECAR_TOKEN`, the token itself, the
+   legacy delivery. A request without it is **401**, with a `detail` naming both
+   env vars.
+2. **Host allowlist.** The `Host` header must be loopback (`127.0.0.1`,
+   `localhost`, `::1`); anything else is **400**. This is what defeats DNS
+   rebinding, where the rebound request arrives with `Host: evil.com`.
+3. **Origin rejection.** A request carrying a non-loopback browser `Origin` is
+   **403**. Non-browser clients send no `Origin` and are unaffected.
+
+`/health`, `/version`, and `/v1/gaia/version` are **token-exempt** — they are
+the probes a host polls during the attach handshake, before any token is in
+play, and none of them exposes user data or accepts work. Host and Origin still
+apply to them, so `waitForHealth` and `checkVersion` work against a
+token-protected sidecar without knowing the token.
+
+**Dev mode.** If neither env var is set the token check is skipped and the
+sidecar logs a loud warning saying so; Host and Origin are still enforced. That
+is the state a sidecar this package spawns comes up in, because `spawnSidecar`
+mints nothing — pass your own token through `spawnSidecar`'s `env` option to
+turn the check on. The shipped product does not rely on dev mode: the daemon
+mints a per-session token and passes it as `GAIA_GAIA_SIDECAR_TOKEN_FILE`
+(`gaia.daemon.sidecars.spec` mirrors both names as plain strings so core never
+imports this wheel).
+
+### 5.5 Other transports
+
+The HTTP server above is the surface this package drives, and everything in
+this document describes it. It is not the agent's only transport:
+`gaia_agent.stdio` runs the same agent over newline-delimited JSON on
+stdin/stdout — no port, no token, no discovery file. The terminal UI reaches it
+that way when it spawns the agent as a subprocess; an agent **installed** from
+the hub, which is what this package delivers, is supervised by the daemon over
+the HTTP surface above instead (§6.1).
+
+It emits the identical canonical event vocabulary, but its input channel accepts
+a JSON line carrying a `gaia_control` key, which gives it something HTTP does
+not have: a back-channel that can answer a confirmation prompt *while* a turn is
+in flight. It also takes `--bypass-permissions` (start with gating off) and
+`--use-claude` / `--claude-model` (route chat to the Anthropic API instead of
+local Lemonade; embeddings stay on Lemonade either way). None of that is
+reachable over `/v1/gaia/query`.
+
+`--use-claude` is the one with a reach beyond the machine, and it cannot be
+turned on for what this package delivers: the terminal UI **refuses** it for a
+daemon-transport agent, with an error saying so, because the daemon relay has no
+way to switch inference backends. So the local-only claim in the README holds
+for every path this package installs — it is a property of the transport, not a
+default someone can flip.
 
 ---
 

--- a/hub/agents/gaia/npm/SPEC.md
+++ b/hub/agents/gaia/npm/SPEC.md
@@ -273,8 +273,9 @@ backward-compatible addition and is accepted.
 
 Loopback binding is not access control: this sidecar exposes shell and file
 tools, so an unauthenticated port lets any page the user visits drive it. Three
-controls guard it, all in `gaia_agent.caller_auth` over the mechanism shared
-with the email sidecar (`gaia.sidecar.caller_auth`):
+controls guard it, all in `gaia_agent.caller_auth`, which binds this sidecar's
+env-var names and exempt paths onto the shared mechanism in
+`gaia.sidecar.caller_auth`:
 
 1. **Per-session bearer token.** Every `/v1/gaia/*` request must carry
    `Authorization: Bearer <token>`. The spawning parent supplies it one of two


### PR DESCRIPTION
An integrator following these docs would have shipped an unauthenticated integration and mis-scoped what the agent can do. Three of the four docs stated the sidecar has **no** caller-auth token; it has an enforced one — a per-session bearer, a loopback `Host` allowlist, and `Origin` rejection — so anyone building against them sent no `Authorization` header, hit a 401 with no explanation, and treated loopback binding as a security boundary on an agent that has shell and file tools. The token landed in #2932; the email agent's docs were corrected in #3002 and the flagship's never were.

The same file also said the bundled skill library is empty while `gaia-voice` ships always-on and is paid on every LLM call, and undercounted both the registry (55 → 67) and the confirmation-gated tools (3 → 6).

🔒 For @kovtcharov-amd: §5.4 now documents, accurately, that a sidecar this package spawns comes up in dev mode because `spawnSidecar` mints no token. That is existing shipped behaviour, not a change here — but it is worth a decision on whether `gaia serve` should mint one by default. Happy to follow up either way.

## Test plan

- [ ] `grep -rn "no caller-auth\|mints none\|library is empty\|55 tools" hub/agents/gaia/npm/` returns nothing
- [ ] Tool counts match the registry: build the agent and intersect it with the confirmation set — 67 registered, and exactly six gated (`edit_file`, `execute_python_file`, `install_skill`, `remove_skill`, `run_shell_command`, `write_file`). `hub/agents/gaia/python/tests/test_gaia_agent.py` already guards the 67.
- [ ] `gaia-voice` body measures 676 cl100k tokens, matching `gaia-agent.yaml` (the CHANGELOG's 692 is a past release's record and is deliberately left alone)
- [ ] Relative links and anchors in the four files resolve