### PR TITLE
fix(agent-email): fail closed when a request omits its Host header

### DIFF
--- a/hub/agents/email/npm/CHANGELOG.md
+++ b/hub/agents/email/npm/CHANGELOG.md
@@ -6,6 +6,12 @@ behind any entry — API shapes, endpoints, and version semantics — see
 
 ## [Unreleased]
 
+- **A request with no `Host` header is now rejected instead of served.** The
+  sidecar's DNS-rebinding check used to skip itself when the header was absent.
+  No normal client is affected — this package, the Python client, and curl all
+  send `Host` — but a request that left it out used to get a `200` and now gets
+  a `400`.
+
 - **The published API contract now shows that requests need a session token.**
   The sidecar has always required a bearer token on most calls, but the
   contract document didn't say so. It now declares the requirement (and marks

--- a/hub/agents/email/npm/SKILL.md
+++ b/hub/agents/email/npm/SKILL.md
@@ -414,7 +414,8 @@ Until then the binary boots, but the first `triage` returns **HTTP 502**.
 
 - **Every `/v1/email/*` call needs the session token** (#1706). `sidecar.client`
   carries it automatically; a client you construct yourself must pass `authToken`
-  (from `sidecar.authToken`) or every call is **401**. Non-loopback `Host` → 400,
+  (from `sidecar.authToken`) or every call is **401**. Absent or non-loopback
+  `Host` → 400,
   non-loopback browser `Origin` → 403. `/health` · `/version` · `/v1/email/spec` ·
   `/v1/email/playground` are exempt.
 - **`health()` is liveness-only.** A green `/health` means the REST surface is up,

--- a/hub/agents/email/npm/SPEC.md
+++ b/hub/agents/email/npm/SPEC.md
@@ -59,7 +59,7 @@ binds a send to one exact message but does not identify the caller.
   logged, deprecated compatibility leg for older binaries; a set path var whose
   file is missing or empty fails sidecar startup loudly. The npm lifecycle
   currently uses the env channel.
-- **Host allowlist** — non-loopback `Host` → **400** (DNS-rebinding).
+- **Host allowlist** — an absent or non-loopback `Host` → **400** (DNS-rebinding).
 - **Origin rejection** — non-loopback browser `Origin` → **403** (drive-by page).
   Non-browser clients send no `Origin` and are unaffected. No CORS is ever sent.
 

--- a/hub/agents/email/python/CHANGELOG.md
+++ b/hub/agents/email/python/CHANGELOG.md
@@ -9,6 +9,14 @@ contract version is tracked separately as
 
 ### Fixed
 
+- **A request that omits its `Host` header is now refused (400).** The
+  DNS-rebinding check only compared the header when one was present, so a caller
+  could skip the control by leaving it out. Browsers always send `Host`, so the
+  drive-by vector this guards was never open and the token check applied
+  regardless — this closes a defence-in-depth fail-open, not a live bypass. The
+  refusal message quotes the header back when one was sent, so a malformed value
+  (`:8131`, an unbracketed `::1`) no longer reports as "no Host header".
+
 - **The OpenAPI document now declares the sidecar's bearer-token gate (#2993).**
   `require_caller_token` enforces a per-session bearer token at runtime, but was
   invisible to schema generation (it's a plain `Request` dependency, not a

--- a/hub/agents/email/python/gaia_agent_email/caller_auth.py
+++ b/hub/agents/email/python/gaia_agent_email/caller_auth.py
@@ -300,10 +300,16 @@ class HostOriginMiddleware:
             # Fail closed on an absent/empty Host: HTTP/1.1 requires one and
             # every real client sends it, so "no Host" is a caller skipping the
             # rebinding control, not a case to wave through.
-            host = _host_only(headers.get("host", ""))
+            raw_host = headers.get("host", "")
+            host = _host_only(raw_host)
             if host not in config.allowed_hosts:
+                # Keyed on the RAW header: _host_only returns "" for a malformed
+                # value too (`:8131`, an unbracketed `::1`), and calling that
+                # "no Host header" misdirects whoever is debugging the client.
                 named = (
-                    f"Host header '{host}'" if host else "A request with no Host header"
+                    f"Host header '{raw_host}'"
+                    if raw_host.strip()
+                    else "A request with no Host header"
                 )
                 await self._reject(
                     scope,

--- a/hub/agents/email/python/gaia_agent_email/caller_auth.py
+++ b/hub/agents/email/python/gaia_agent_email/caller_auth.py
@@ -23,10 +23,11 @@ Three controls, all keyed on a single :class:`CallerAuthConfig` set at app build
    in the environment) or directly in ``GAIA_EMAIL_SIDECAR_TOKEN`` (legacy).
    Every non-exempt request must present ``Authorization: Bearer <token>`` or it
    is rejected with 401. This authenticates the *caller*.
-2. **Host allowlist** — the ``Host`` header must be a loopback host
+2. **Host allowlist** — the ``Host`` header must be present AND a loopback host
    (127.0.0.1 / localhost / ::1). This closes DNS-rebinding, where a victim's
    browser is tricked into resolving ``evil.com`` → 127.0.0.1 and posting to the
-   sidecar (the browser then sends ``Host: evil.com``).
+   sidecar (the browser then sends ``Host: evil.com``). An absent or empty
+   ``Host`` is refused too, so the control cannot be skipped by omitting it.
 3. **Origin rejection** — a request carrying a browser ``Origin`` that is not a
    loopback origin is rejected with 403. This closes a drive-by web page that
    fetches ``http://127.0.0.1:<port>`` directly. Non-browser clients (the npm /
@@ -296,16 +297,23 @@ class HostOriginMiddleware:
         if config is not None:
             headers = Headers(scope=scope)
 
+            # Fail closed on an absent/empty Host: HTTP/1.1 requires one and
+            # every real client sends it, so "no Host" is a caller skipping the
+            # rebinding control, not a case to wave through.
             host = _host_only(headers.get("host", ""))
-            if host and host not in config.allowed_hosts:
+            if host not in config.allowed_hosts:
+                named = (
+                    f"Host header '{host}'" if host else "A request with no Host header"
+                )
                 await self._reject(
                     scope,
                     receive,
                     send,
                     400,
-                    f"Rejected: Host header '{host}' is not an allowed loopback "
-                    "host. The email sidecar serves only 127.0.0.1/localhost; a "
-                    "non-loopback Host is a DNS-rebinding attempt.",
+                    f"Rejected: {named} is not an allowed loopback host. The "
+                    "email sidecar serves only 127.0.0.1/localhost; send "
+                    "'Host: 127.0.0.1:<port>'. A non-loopback or absent Host is "
+                    "a DNS-rebinding attempt.",
                 )
                 return
 

--- a/hub/agents/email/python/gaia_agent_email/spec_html.py
+++ b/hub/agents/email/python/gaia_agent_email/spec_html.py
@@ -995,8 +995,8 @@ def render_endpoint_spec_html() -> str:
     <code>Authorization: Bearer &lt;token&gt;</code> or it is rejected with
     <strong>HTTP 401</strong>. Liveness/version probes
     (<code>/health</code>, <code>/version</code>) and these HTML pages are exempt.</li>
-  <li><strong>Host allowlist.</strong> A non-loopback <code>Host</code> header is
-    rejected with <strong>HTTP 400</strong>, closing DNS-rebinding.</li>
+  <li><strong>Host allowlist.</strong> An absent or non-loopback <code>Host</code>
+    header is rejected with <strong>HTTP 400</strong>, closing DNS-rebinding.</li>
   <li><strong>Origin rejection.</strong> A request carrying a non-loopback browser
     <code>Origin</code> is rejected with <strong>HTTP 403</strong>, closing
     drive-by web-page access. Non-browser clients send no Origin and are

--- a/hub/agents/email/python/packaging/README.md
+++ b/hub/agents/email/python/packaging/README.md
@@ -74,7 +74,7 @@ spawning parent hands over a per-session token through one of two channels:
   the file wins.
 
 Every `/v1/email/*` request must send `Authorization: Bearer <token>` or it is
-rejected with **401**. A non-loopback `Host` → **400** (DNS-rebinding) and a
+rejected with **401**. An absent or non-loopback `Host` → **400** (DNS-rebinding) and a
 non-loopback browser `Origin` → **403** (drive-by page); `/health`, `/version`,
 `/v1/email/spec`, and `/v1/email/playground` are exempt from the token. Launching
 by hand with neither variable disables the token check (local dev only, logged

--- a/hub/agents/email/python/specification.html
+++ b/hub/agents/email/python/specification.html
@@ -190,8 +190,8 @@ td:nth-child(3) {
     <code>Authorization: Bearer &lt;token&gt;</code> or it is rejected with
     <strong>HTTP 401</strong>. Liveness/version probes
     (<code>/health</code>, <code>/version</code>) and these HTML pages are exempt.</li>
-  <li><strong>Host allowlist.</strong> A non-loopback <code>Host</code> header is
-    rejected with <strong>HTTP 400</strong>, closing DNS-rebinding.</li>
+  <li><strong>Host allowlist.</strong> An absent or non-loopback <code>Host</code>
+    header is rejected with <strong>HTTP 400</strong>, closing DNS-rebinding.</li>
   <li><strong>Origin rejection.</strong> A request carrying a non-loopback browser
     <code>Origin</code> is rejected with <strong>HTTP 403</strong>, closing
     drive-by web-page access. Non-browser clients send no Origin and are

--- a/hub/agents/email/python/tests/test_caller_auth.py
+++ b/hub/agents/email/python/tests/test_caller_auth.py
@@ -7,7 +7,8 @@ mailbox. These tests lock in the three controls that make it safe to expose:
 
 1. **Per-session bearer token** — a non-exempt request without a valid token is
    401; with the correct token it is served; with a wrong token it is 401.
-2. **Host allowlist** — a non-loopback ``Host`` header is 400 (DNS-rebinding).
+2. **Host allowlist** — a non-loopback ``Host`` header is 400 (DNS-rebinding),
+   and so is a request that omits ``Host`` entirely.
 3. **Origin rejection** — a non-loopback browser ``Origin`` is 403 (drive-by).
 
 ``POST /v1/email/draft`` is the probe endpoint: it mints a confirmation token
@@ -16,6 +17,7 @@ with no mailbox/LLM dependency, so it exercises the auth layer in isolation.
 
 from __future__ import annotations
 
+import asyncio
 import importlib.util
 from pathlib import Path
 
@@ -163,6 +165,41 @@ def test_non_loopback_host_is_rejected_400():
     )
     assert resp.status_code == 400
     assert "host" in resp.json()["detail"].lower()
+
+
+def test_absent_host_is_rejected_400():
+    """Omitting ``Host`` must not skip the rebinding control.
+
+    Driven through the middleware directly: ``TestClient`` always sets a Host,
+    so a request without one is unreachable from it.
+    """
+    caller_auth.configure(caller_auth.CallerAuthConfig(token=_TOKEN))
+    sent: list = []
+
+    async def app(scope, receive, send):  # pragma: no cover - must never run
+        raise AssertionError("a Host-less request reached the app")
+
+    async def _send(message):
+        sent.append(message)
+
+    async def _receive():
+        return {"type": "http.request", "body": b"", "more_body": False}
+
+    scope = {
+        "type": "http",
+        "method": "GET",
+        "path": "/v1/email/health",
+        "query_string": b"",
+        "headers": [],  # no Host at all
+    }
+    asyncio.run(caller_auth.HostOriginMiddleware(app)(scope, _receive, _send))
+
+    start = next(m for m in sent if m["type"] == "http.response.start")
+    assert start["status"] == 400
+    body = b"".join(
+        m.get("body", b"") for m in sent if m["type"] == "http.response.body"
+    )
+    assert b"no Host header" in body
 
 
 def test_cross_origin_browser_request_is_rejected_403():

--- a/hub/agents/email/python/tests/test_caller_auth.py
+++ b/hub/agents/email/python/tests/test_caller_auth.py
@@ -167,17 +167,17 @@ def test_non_loopback_host_is_rejected_400():
     assert "host" in resp.json()["detail"].lower()
 
 
-def test_absent_host_is_rejected_400():
-    """Omitting ``Host`` must not skip the rebinding control.
+def _reject_body_for(headers: list) -> bytes:
+    """Drive the middleware over a raw ASGI scope and return the refusal body.
 
-    Driven through the middleware directly: ``TestClient`` always sets a Host,
-    so a request without one is unreachable from it.
+    ``TestClient`` always sets a Host, so neither an absent nor a malformed one
+    is reachable through it.
     """
     caller_auth.configure(caller_auth.CallerAuthConfig(token=_TOKEN))
     sent: list = []
 
     async def app(scope, receive, send):  # pragma: no cover - must never run
-        raise AssertionError("a Host-less request reached the app")
+        raise AssertionError("a request with a bad Host reached the app")
 
     async def _send(message):
         sent.append(message)
@@ -190,16 +190,37 @@ def test_absent_host_is_rejected_400():
         "method": "GET",
         "path": "/v1/email/health",
         "query_string": b"",
-        "headers": [],  # no Host at all
+        "headers": headers,
     }
     asyncio.run(caller_auth.HostOriginMiddleware(app)(scope, _receive, _send))
 
     start = next(m for m in sent if m["type"] == "http.response.start")
     assert start["status"] == 400
-    body = b"".join(
+    return b"".join(
         m.get("body", b"") for m in sent if m["type"] == "http.response.body"
     )
-    assert b"no Host header" in body
+
+
+def test_absent_host_is_rejected_400():
+    """Omitting ``Host`` must not skip the rebinding control."""
+    assert b"no Host header" in _reject_body_for([])
+
+
+@pytest.mark.parametrize("raw", [b":8131", b"::1"])
+def test_malformed_host_is_rejected_and_quoted_back(raw):
+    """A Host that parses to nothing is still a Host the caller sent.
+
+    ``_host_only`` returns ``""`` for these, so keying the message on the parsed
+    value would tell someone debugging their client it sent no Host at all.
+    """
+    body = _reject_body_for([(b"host", raw)])
+    assert b"no Host header" not in body
+    assert raw in body
+
+
+def test_whitespace_only_host_reads_as_absent():
+    """Nothing useful to quote back, so it is reported the way it presents."""
+    assert b"no Host header" in _reject_body_for([(b"host", b"   ")])
 
 
 def test_cross_origin_browser_request_is_rejected_403():


### PR DESCRIPTION
The email sidecar's anti-DNS-rebinding check waved through any request that sent no `Host` header at all — it only compared the header when one was present. A browser always sends `Host`, so the drive-by vector this control exists for stayed covered; this is a defence-in-depth fail-open, not a practical bypass. The check now does what its own docstring says it does.

Worth a maintainer's eye for a second reason, @kovtcharov-amd: `gaia.sidecar.caller_auth`'s docstring claims it is *"shared with the email sidecar so the two cannot drift apart."* They already had. This package carries its own 350-line copy and never imports the shared module, so a fix in one reaches neither the other nor anyone reading that docstring. Consolidating them is a bigger change than this one and I've left it alone, but the drift is real.

## Test plan

- [ ] `pytest hub/agents/email/python/tests/test_caller_auth.py` — 23 pass (22 before)
- [ ] The new `test_absent_host_is_rejected_400` fails without the fix (verified by reverting it)
- [ ] It drives the middleware through a raw ASGI scope on purpose — `TestClient` always sets a `Host`, so a request without one is unreachable from it
- [ ] `python util/lint.py --all` introduces no new findings (identical error count with and without this change)