### PR TITLE
fix(agent-gaia): stop the npm sidecar attaching to a foreign server

### DIFF
--- a/.github/workflows/test_agent_gaia_npm.yml
+++ b/.github/workflows/test_agent_gaia_npm.yml
@@ -1,0 +1,97 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+# Builds + tests the @amd-gaia/gaia npm package (the `npx @amd-gaia/gaia`
+# launcher: binary fetcher + sidecar lifecycle). Until now nothing ran it on a
+# PR -- only release_agent_gaia.yml touched the package, at release time -- so a
+# change that broke the launcher stayed green all the way to the release gate.
+# That is the same gap test_gaia_agent.yml closed for the Python side.
+#
+# The package ships NO binaries: they are fetched from R2 and SHA-256 verified
+# against binaries.lock.json at run time, so the last step asserts the tarball
+# stays thin.
+
+name: Agent GAIA npm Package Tests
+
+on:
+  workflow_call:
+  push:
+    branches: [ main ]
+    paths:
+      - 'hub/agents/gaia/npm/**'
+      - '.github/workflows/test_agent_gaia_npm.yml'
+  pull_request:
+    branches: [ main ]
+    types: [opened, synchronize, reopened, ready_for_review]
+    paths:
+      - 'hub/agents/gaia/npm/**'
+      - '.github/workflows/test_agent_gaia_npm.yml'
+  merge_group:
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  test-agent-gaia-npm:
+    name: Build & Test gaia npm package
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false || contains(github.event.pull_request.labels.*.name, 'ready_for_ci')
+    defaults:
+      run:
+        working-directory: hub/agents/gaia/npm
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v7
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: hub/agents/gaia/npm/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build (tsc)
+        run: npm run build
+
+      - name: Test (vitest)
+        run: npm test
+
+      # Thin-package invariant: the published tarball must NEVER contain a
+      # platform binary -- the sidecar and the TUI are fetched from R2 and
+      # verified against binaries.lock.json. Fail loudly if one is packed.
+      - name: Assert tarball ships no binaries
+        run: |
+          npm pack --dry-run --json > pack.json
+          node -e '
+            const fs = require("fs");
+            const pack = JSON.parse(fs.readFileSync("pack.json", "utf8"));
+            const files = (pack[0]?.files ?? []).map((f) => f.path);
+            const offenders = files.filter((p) => {
+              const base = p.split("/").pop();
+              return (
+                /\.(exe|bin)$/i.test(base) ||
+                base === "gaia-agent" ||
+                base === "gaia-tui" ||
+                /^gaia-(agent|tui)(-|\.)/i.test(base)
+              );
+            });
+            if (offenders.length > 0) {
+              console.error("❌ Tarball contains forbidden binary file(s):");
+              offenders.forEach((p) => console.error("   " + p));
+              console.error(
+                "The @amd-gaia/gaia package must stay thin — binaries are " +
+                "fetched from R2 at run time, never committed to the tarball."
+              );
+              process.exit(1);
+            }
+            console.log("✅ Thin-package invariant holds — " + files.length + " files, no binaries.");
+          '

--- a/hub/agents/gaia/npm/CHANGELOG.md
+++ b/hub/agents/gaia/npm/CHANGELOG.md
@@ -76,6 +76,67 @@ the terminal UI meant building it from source.
 - **Programmatic exports** — `fetchAll`, `startSidecar`, `shutdown`, `runTui`, the
   platform helpers, and the typed error classes, for embedding GAIA in another
   app.
+- **The `.installed` record is written after a verified sidecar install.**
+  Staging the binary was only half an install: the daemon and the terminal UI
+  both key "this agent is installed" on `~/.gaia/agents/gaia/.installed`, and
+  without it the UI ran the REST sidecar as its own stdio child and the chat
+  filled with uvicorn's startup log. It is written on a cache hit as well as a
+  fresh download, so an install left by an earlier version repairs itself.
+  See SPEC §4.1.
+- **`--allow-insecure-base-url`** — opt-in for a non-`https` `--base-url`, for a
+  trusted local mirror.
+
+### Fixed
+
+- **A second `gaia serve` no longer reports success against a server it does not
+  own.** With the port already taken, its own sidecar died but the incumbent
+  answered `/health`, so the start "succeeded" and the later shutdown logged
+  "already exited" while the real server kept running. It now fails naming the
+  port and the likely cause.
+- **Importing the package no longer changes a host app's error handling.** The
+  crash and signal handlers reaped every sidecar *before* checking whether the
+  host had its own handler, so an exception the host handled killed the sidecar
+  and the host's next request got an unexplained `ECONNREFUSED`.
+- **`gaia run` no longer breaks the terminal UI's `PATH`.** Hiding our own `gaia`
+  shim removed the whole bin directory, which on a Homebrew or pipx layout also
+  took `python3`, `lemonade-server`, and the real `gaia` with it — so the UI
+  reported a missing CLI that we had hidden. A shared directory now moves to the
+  end of `PATH` instead of being dropped.
+- **Flags a command does not read are refused, not ignored.** `run --port 9000`
+  parsed fine and came up on the default port; likewise `serve --component` and
+  `serve --cache-dir`.
+- **A failed install says what to do.** A download that could not be moved into
+  place — usually a running sidecar holding the file on Windows — printed a raw
+  stack trace.
+- **`taskkill` failures name their reason.** Its exit code and stderr were
+  discarded, so "Access is denied" surfaced ten seconds later as a generic
+  timeout.
+- **A sidecar that survives shutdown is still reaped at exit.** `shutdown`
+  de-registered it before killing it, so one that survived both kill windows
+  became a permanent orphan holding the port.
+- **`serve` removes its signal handlers once it stops**, so Ctrl+C keeps working
+  afterwards, and a repeat Ctrl+C during a slow teardown now says what it is
+  waiting for instead of looking frozen.
+- **A non-JSON reply from a sidecar probe raises a typed error** rather than a
+  bare `SyntaxError` — the case where a proxy answers `200` with an HTML page.
+- **`--port` no longer accepts what `Number()` would coerce**, so `--port 0x2710`
+  is rejected instead of quietly binding 10000.
+
+### Security
+
+- **`resolveSidecarPath` / `resolveTuiPath` verify the binary before returning a
+  path that gets spawned.** Both fed `spawn()` from a predictable cache path with
+  no integrity check, so anything able to write `~/.gaia/agents/gaia/` got code
+  run — despite the package documenting the SHA verify as its security boundary.
+  They now re-hash against `binaries.lock.json`; pass `{ verify: false }` for a
+  binary you built yourself. Note this makes them proportional to the binary's
+  size — resolve once at startup, not per request.
+- **`--base-url` requires `https`** unless `--allow-insecure-base-url` is passed.
+  The pinned SHA already made a plaintext mirror non-exploitable, but tampering
+  surfaced as a confusing `IntegrityError` instead of the transport failure it is.
+- **Downloads stream to disk instead of being buffered whole**, so a ~200MB
+  artifact no longer peaks at roughly double that in memory. The hash is computed
+  incrementally and still verified *before* the file is moved into place.
 
 ### Notes
 

--- a/hub/agents/gaia/npm/CHANGELOG.md
+++ b/hub/agents/gaia/npm/CHANGELOG.md
@@ -81,18 +81,20 @@ the terminal UI meant building it from source.
   both key "this agent is installed" on `~/.gaia/agents/gaia/.installed`, and
   without it the UI ran the REST sidecar as its own stdio child and the chat
   filled with uvicorn's startup log. It is written on a cache hit as well as a
-  fresh download, so an install left by an earlier version repairs itself.
-  See SPEC §4.1.
+  fresh download, so an install left by an earlier version repairs itself, and
+  only for this host's own platform — a `--platform` fetch stages a binary for a
+  different machine and records nothing. See SPEC §4.1.
 - **`--allow-insecure-base-url`** — opt-in for a non-`https` `--base-url`, for a
   trusted local mirror.
 
 ### Fixed
 
 - **A second `gaia serve` no longer reports success against a server it does not
-  own.** With the port already taken, its own sidecar died but the incumbent
-  answered `/health`, so the start "succeeded" and the later shutdown logged
-  "already exited" while the real server kept running. It now fails naming the
-  port and the likely cause.
+  own.** With the port already taken, the incumbent answered `/health` while our
+  own sidecar was still unpacking, so the start "succeeded", printed a ready URL
+  for someone else's server, and the child then died of `EADDRINUSE`. The port is
+  now checked before anything is spawned, and a taken one fails naming the port
+  and how to find the process holding it.
 - **Importing the package no longer changes a host app's error handling.** The
   crash and signal handlers reaped every sidecar *before* checking whether the
   host had its own handler, so an exception the host handled killed the sidecar
@@ -134,9 +136,11 @@ the terminal UI meant building it from source.
 - **`--base-url` requires `https`** unless `--allow-insecure-base-url` is passed.
   The pinned SHA already made a plaintext mirror non-exploitable, but tampering
   surfaced as a confusing `IntegrityError` instead of the transport failure it is.
-- **Downloads stream to disk instead of being buffered whole**, so a ~200MB
-  artifact no longer peaks at roughly double that in memory. The hash is computed
-  incrementally and still verified *before* the file is moved into place.
+- **A ~200MB artifact is never held in memory whole.** Downloads stream to disk,
+  and the cache-hit check that re-hashes an already-installed binary — which runs
+  on every `gaia run` — reads it in bounded chunks. Both hashes are computed
+  incrementally, and a download is still verified *before* the file is moved into
+  place.
 
 ### Notes
 

--- a/hub/agents/gaia/npm/README.md
+++ b/hub/agents/gaia/npm/README.md
@@ -75,14 +75,19 @@ npx @amd-gaia/gaia -- --debug
 
 Common options:
 
-| Flag                  | Meaning                                                       |
-| --------------------- | ------------------------------------------------------------- |
-| `--base-url <url>`    | Override the download base URL from `binaries.lock.json`       |
-| `--cache-dir <dir>`   | Where to cache the terminal UI binary                          |
-| `--sidecar-dir <dir>` | Where to install the agent sidecar (default `~/.gaia/agents/gaia`) |
-| `--platform <key>`    | Fetch for another platform (`fetch` only)                      |
-| `--force`             | Re-download even when a verified binary is already cached      |
-| `--port <n>`          | Sidecar bind port for `serve` (default `8141`)                 |
+| Flag                  | Meaning                                                       | Accepted by |
+| --------------------- | ------------------------------------------------------------- | ----------- |
+| `--base-url <url>`    | Override the download base URL from `binaries.lock.json`. Must be `https:` | `run`, `fetch`, `serve` |
+| `--allow-insecure-base-url` | Permit a non-`https` `--base-url` (a trusted local mirror) | `run`, `fetch`, `serve` |
+| `--sidecar-dir <dir>` | Where to install the agent sidecar (default `~/.gaia/agents/gaia`) | `run`, `fetch`, `serve` |
+| `--cache-dir <dir>`   | Where to cache the terminal UI binary                          | `run`, `fetch` |
+| `--force`             | Re-download even when a verified binary is already cached      | `run`, `fetch`, `serve` |
+| `--platform <key>`    | Fetch for another platform                                     | `fetch` |
+| `--component <name>`  | Fetch only `sidecar` or `tui`                                  | `fetch` |
+| `--port <n>`          | Sidecar bind port (default `8141`)                             | `serve` |
+
+A flag a command does not read is **refused**, not ignored — `gaia run --port
+9000` exits 2 rather than silently coming up on the default port.
 
 Set `DEBUG=gaia` for download, spawn, and sidecar output on stderr. Diagnostics
 never touch stdout, which the terminal UI owns.
@@ -92,12 +97,19 @@ never touch stdout, which the terminal UI owns.
 | What            | Path                                     |
 | --------------- | ---------------------------------------- |
 | Agent sidecar   | `~/.gaia/agents/gaia/gaia-agent[.exe]`   |
+| Install record  | `~/.gaia/agents/gaia/.installed`         |
 | Terminal UI     | `~/.gaia/npm-cache/gaia-<version>/gaia-tui[.exe]` |
 
 The sidecar goes into the GAIA daemon's own cache directory on purpose: the daemon
 is what spawns and supervises it, and it does its own SHA-256 check on the way. By
 putting an already-verified binary there we save a second download rather than
 racing one.
+
+The `.installed` record next to it is what the daemon and the terminal UI read to
+know the agent is installed — without it the UI would run the sidecar as its own
+stdio child instead of letting the daemon supervise it. It is rewritten even when
+the binary was already cached, so an install left by an earlier version repairs
+itself the next time you run.
 
 The terminal UI is installed as `gaia-tui`, **never** as `gaia` — a file named
 `gaia` in a cache directory would shadow the `gaia` shim npm puts on your `PATH`.

--- a/hub/agents/gaia/npm/README.md
+++ b/hub/agents/gaia/npm/README.md
@@ -109,7 +109,8 @@ The `.installed` record next to it is what the daemon and the terminal UI read t
 know the agent is installed — without it the UI would run the sidecar as its own
 stdio child instead of letting the daemon supervise it. It is rewritten even when
 the binary was already cached, so an install left by an earlier version repairs
-itself the next time you run.
+itself the next time you run. A `--platform` fetch stages a binary for a
+*different* machine, so it deliberately leaves no record.
 
 The terminal UI is installed as `gaia-tui`, **never** as `gaia` — a file named
 `gaia` in a cache directory would shadow the `gaia` shim npm puts on your `PATH`.

--- a/hub/agents/gaia/npm/SKILL.md
+++ b/hub/agents/gaia/npm/SKILL.md
@@ -51,7 +51,10 @@ built-in `fetch`. Use `import`, not `require`; from CommonJS use
    each against the lock**.
 4. Installs the sidecar into `~/.gaia/agents/gaia/` and the TUI into
    `~/.gaia/npm-cache/gaia-<version>/`.
-5. Execs the TUI, whose exit code becomes ours.
+5. Writes `~/.gaia/agents/gaia/.installed` — the record the daemon and the TUI
+   both read to decide the sidecar is installed. Written on a cache hit too, so
+   an install staged by an earlier release repairs itself.
+6. Execs the TUI, whose exit code becomes ours.
 
 `run` deliberately does **not** spawn a sidecar. The TUI reaches agents through
 the GAIA daemon's relay and never holds a sidecar token, and the daemon is what
@@ -382,8 +385,11 @@ interface.
 ## 12. Running in a server or long-lived app
 
 - **`fetchAll` / `fetchBinary` are a build step**, not per request — network plus
-  a full SHA-256 hash of a large artifact. Run once; `resolveSidecarPath` /
-  `resolveTuiPath` at runtime.
+  a full SHA-256 hash of a large artifact. Run once at install time.
+- **`resolveSidecarPath` / `resolveTuiPath` are startup, not per request.** They
+  re-hash the binary against `binaries.lock.json` before handing back a path that
+  gets spawned, so they cost a full read of a large file. Resolve once and keep
+  the path. `{ verify: false }` skips the check for a binary you built yourself.
 - **Spawn once at boot** and hold the `Sidecar` handle for the process lifetime.
   Never per request.
 - **Low concurrency.** One local Lemonade model slot, so parallel queries
@@ -421,9 +427,12 @@ There is no silent null.
 - **`run_id` must be a UUID**, and unknown fields in the request body are a
   **422** — the model forbids extras. Typos don't get ignored.
 - **`gaia run` needs the *Python* `gaia` CLI on `PATH`** — the TUI shells out to
-  it to start the daemon. The package deliberately strips its own npm bin
-  directory from the child's `PATH` so the TUI doesn't re-invoke the npm shim; if
-  the Python CLI isn't installed, the daemon never comes up.
+  it to start the daemon. So the TUI doesn't re-invoke our own npm shim, the
+  child's `PATH` is rewritten: a directory holding nothing but our shim (an npx
+  temp dir) is dropped, and a **shared** bin directory is moved to the end
+  instead of removed, so the `python3` / `lemonade-server` / real `gaia` beside
+  it stay reachable. If the Python CLI isn't installed anywhere, the daemon never
+  comes up.
 - **The TUI is installed as `gaia-tui`, never `gaia`** — the terminal-hub artifact
   *is* called `gaia-<platform>`, and a file named `gaia` in a cache directory would
   shadow the npm bin shim. The lock's `filename` and `executable` differ for that

--- a/hub/agents/gaia/npm/SPEC.md
+++ b/hub/agents/gaia/npm/SPEC.md
@@ -190,6 +190,41 @@ supervises the sidecar and does its own SHA-256 check on the binary it finds
 there; installing an already-verified binary at that path turns the daemon's fetch
 into a cache hit instead of a second multi-hundred-megabyte download.
 
+### 4.1 The `.installed` sentinel
+
+Installing the sidecar also writes `~/.gaia/agents/gaia/.installed`, the record
+the daemon and the TUI both read to answer "is this agent installed?". It is
+written for the `sidecar` component only — the TUI is not a hub agent — and on a
+**cache hit as well as a fresh download**, so an install staged by an earlier
+release repairs itself on the next run.
+
+```json
+{
+  "id": "gaia",
+  "version": "<sidecar componentVersion>",
+  "language": "python",
+  "installed_at": "<ISO-8601 UTC>",
+  "artifact_sha256": "<the verified SHA-256>",
+  "path": "<install directory>",
+  "artifact_kind": "binary",
+  "executable": "gaia-agent[.exe]"
+}
+```
+
+The shape is a cross-repo contract with `InstalledAgent.to_dict()` in
+`gaia.hub.installer`. Three fields are load-bearing:
+`gaia.daemon.sidecars.fetch._hub_installed_binary` ignores the install unless
+`artifact_kind` is `binary` and `executable` and `artifact_sha256` are non-empty,
+and it **re-hashes the binary and raises `IntegrityError` if the file no longer
+matches `artifact_sha256`** — so the recorded hash is the one actually verified,
+never the lock's nominal value. `executable` must be a bare filename;
+`installer.read_sentinel` discards a sentinel whose executable contains a path
+separator, which reads as "never installed".
+
+Without the sentinel the daemon sees no install and the TUI falls back to running
+`gaia-agent` as its own stdio child — spawning the REST sidecar over stdio and
+filling the chat with uvicorn's startup log.
+
 The TUI directory is keyed by `agentVersion` — this package's version, not the
 component's — so a bump of either never reuses the previous release's executable.
 
@@ -293,7 +328,8 @@ from `~/.gaia/agents/gaia/`. A sidecar spawned here would be a second process th
 TUI never talks to, competing for port `8141`.
 
 So `run`'s contribution to the sidecar is putting a **verified** binary where the
-daemon looks. Daemon and sidecar lifecycle belong to the daemon.
+daemon looks, and recording the install in `.installed` (§4.1) so the daemon and
+the TUI both see it. Daemon and sidecar lifecycle belong to the daemon.
 
 ### 6.2 `gaia serve` — the direct path
 
@@ -325,8 +361,8 @@ failed start never leaks a process.
 | Code    | Meaning                                                                 |
 | ------- | ----------------------------------------------------------------------- |
 | `0`     | Success                                                                 |
-| `1`     | A typed failure: `IntegrityError`, `PlatformError`, `HealthTimeoutError`, `VersionMismatchError`, `BinaryNotFoundError`, or an unexpected error |
-| `2`     | Usage error: unknown command, unknown `--component`, invalid `--port`    |
+| `1`     | A typed failure: `IntegrityError`, `PlatformError`, `HealthTimeoutError`, `VersionMismatchError`, `BinaryNotFoundError`, `SidecarExitedError`, `MalformedResponseError`, or an unexpected error |
+| `2`     | Usage error: unknown command, invalid `--port`, or a flag the command does not read (`run --port`, `serve --component`, `serve --cache-dir`, `run`/`serve` `--platform`), an unknown `--component`, or a non-https `--base-url` without `--allow-insecure-base-url` |
 | *other* | From `run`: the TUI's own exit code, propagated verbatim                 |
 
 A TUI killed by a signal propagates as `128 + signum` (the shell convention), so a
@@ -340,12 +376,14 @@ All extend `GaiaError`, so `instanceof GaiaError` catches any of ours.
 
 | Class                  | Raised when                                                    |
 | ---------------------- | -------------------------------------------------------------- |
-| `IntegrityError`       | A download's SHA-256 does not match the lock                   |
+| `IntegrityError`       | A download's SHA-256 does not match the lock, or a resolved binary's does not |
 | `PlatformError`        | Unsupported platform, missing/incomplete entry, placeholder hash, malformed lock |
 | `HealthTimeoutError`   | The sidecar did not report healthy within the timeout          |
 | `VersionMismatchError` | `apiVersion` major differs from this package's                 |
 | `BinaryNotFoundError`  | A binary is absent from disk when spawning                     |
+| `SidecarExitedError`   | The spawned sidecar died while the port answered — something else owns it |
 | `HttpError`            | A non-2xx from a sidecar probe                                 |
+| `MalformedResponseError` | A 2xx from a sidecar probe whose body is not JSON            |
 
 Per the repo's no-silent-fallbacks rule, every message names what failed, what to
 do, and where to look next.
@@ -370,7 +408,8 @@ do, and where to look next.
 Exported from the package root — see `src/index.ts`.
 
 **Fetch:** `fetchAll`, `fetchBinary`, `verifySha256`, `fileSha256`,
-`binaryExists`, `defaultCacheDir`, `daemonSidecarCacheDir`.
+`binaryExists`, `defaultCacheDir`, `daemonSidecarCacheDir`,
+`INSTALLED_SENTINEL_NAME`, `SIDECAR_AGENT_ID`.
 
 **Lifecycle:** `spawnSidecar`, `startSidecar`, `waitForHealth`, `checkVersion`,
 `health`, `version`, `shutdown`, `runTui`, `resolveSidecarPath`, `resolveTuiPath`,
@@ -383,6 +422,13 @@ Exported from the package root — see `src/index.ts`.
 
 **Constants:** `AGENT_ID`, `API_VERSION`, `DEFAULT_HOST`, `DEFAULT_PORT`,
 `RESERVED_PORT`.
+
+`resolveSidecarPath` / `resolveTuiPath` re-verify the file's SHA-256 against
+`binaries.lock.json` before returning a path that is about to be spawned — the
+cache path is predictable, so anything able to write it would otherwise get code
+run. That makes them **O(size of the binary)**, not a cheap path join: resolve
+once at startup, not per request. Pass `{ verify: false }` for a binary you built
+yourself, which no lock describes, and `{ lock }` to reuse an already-loaded lock.
 
 ---
 

--- a/hub/agents/gaia/npm/SPEC.md
+++ b/hub/agents/gaia/npm/SPEC.md
@@ -194,9 +194,12 @@ into a cache hit instead of a second multi-hundred-megabyte download.
 
 Installing the sidecar also writes `~/.gaia/agents/gaia/.installed`, the record
 the daemon and the TUI both read to answer "is this agent installed?". It is
-written for the `sidecar` component only — the TUI is not a hub agent — and on a
-**cache hit as well as a fresh download**, so an install staged by an earlier
-release repairs itself on the next run.
+written on a **cache hit as well as a fresh download**, so an install staged by
+an earlier release repairs itself on the next run, and only when the fetch
+produced a runnable local install — that is, for the `sidecar` component (the
+TUI is not a hub agent) **and** for this host's own platform. A `--platform`
+fetch stages a binary for a different host; recording it would hand the daemon a
+wrong-architecture executable that re-hashes correctly and then fails to exec.
 
 ```json
 {
@@ -334,8 +337,17 @@ the TUI both see it. Daemon and sidecar lifecycle belong to the daemon.
 ### 6.2 `gaia serve` — the direct path
 
 `serve` fetches the sidecar and spawns it itself, for integrators who want the
-REST surface without a daemon or a UI. This path owns the process fully: spawn →
-`waitForHealth` → `checkVersion` → run until interrupted → tree-kill.
+REST surface without a daemon or a UI. This path owns the process fully:
+port pre-flight → spawn → `waitForHealth` → `checkVersion` → run until
+interrupted → tree-kill.
+
+The port is checked **before** the spawn, and a taken port raises
+`PortInUseError` without starting anything. That ordering is the guarantee: the
+frozen sidecar spends seconds unpacking before it attempts its bind, while an
+incumbent answers `/health` in milliseconds — so a post-spawn check alone would
+see a healthy port and a still-alive child, and hand back a handle for a server
+it does not own. `assertOurs` and the re-probe after a failed health wait remain
+as backstops for the narrower window where something binds after the pre-flight.
 
 ### 6.3 Tree-kill
 
@@ -361,7 +373,7 @@ failed start never leaks a process.
 | Code    | Meaning                                                                 |
 | ------- | ----------------------------------------------------------------------- |
 | `0`     | Success                                                                 |
-| `1`     | A typed failure: `IntegrityError`, `PlatformError`, `HealthTimeoutError`, `VersionMismatchError`, `BinaryNotFoundError`, `SidecarExitedError`, `MalformedResponseError`, or an unexpected error |
+| `1`     | A typed failure: `IntegrityError`, `PlatformError`, `HealthTimeoutError`, `VersionMismatchError`, `BinaryNotFoundError`, `PortInUseError`, `SidecarExitedError`, `MalformedResponseError`, or an unexpected error |
 | `2`     | Usage error: unknown command, invalid `--port`, or a flag the command does not read (`run --port`, `serve --component`, `serve --cache-dir`, `run`/`serve` `--platform`), an unknown `--component`, or a non-https `--base-url` without `--allow-insecure-base-url` |
 | *other* | From `run`: the TUI's own exit code, propagated verbatim                 |
 
@@ -381,6 +393,7 @@ All extend `GaiaError`, so `instanceof GaiaError` catches any of ours.
 | `HealthTimeoutError`   | The sidecar did not report healthy within the timeout          |
 | `VersionMismatchError` | `apiVersion` major differs from this package's                 |
 | `BinaryNotFoundError`  | A binary is absent from disk when spawning                     |
+| `PortInUseError`       | The bind port was already taken; nothing was spawned            |
 | `SidecarExitedError`   | The spawned sidecar died while the port answered — something else owns it |
 | `HttpError`            | A non-2xx from a sidecar probe                                 |
 | `MalformedResponseError` | A 2xx from a sidecar probe whose body is not JSON            |

--- a/hub/agents/gaia/npm/src/cli.ts
+++ b/hub/agents/gaia/npm/src/cli.ts
@@ -14,7 +14,7 @@
  * "continue anyway" path.
  */
 
-import { realpathSync } from "node:fs";
+import { readdirSync, realpathSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -115,7 +115,10 @@ Usage:
 
 run options:
   --base-url <url>     Override the per-component download base URL from
-                       binaries.lock.json (applies to every component fetched)
+                       binaries.lock.json (applies to every component fetched).
+                       Must be https unless --allow-insecure-base-url is given.
+  --allow-insecure-base-url
+                       Permit a non-https --base-url (a trusted local mirror)
   --cache-dir <dir>    Where to cache the TUI binary
   --sidecar-dir <dir>  Where to install the agent sidecar
                        (default ~/.gaia/agents/gaia — the daemon's own cache)
@@ -129,6 +132,8 @@ fetch options:
 
 serve options:
   --port <n>           Bind port (default ${DEFAULT_PORT}; ${RESERVED_PORT} is reserved and refused)
+  --base-url, --sidecar-dir, --force as above. \`serve\` never downloads the TUI,
+  so --cache-dir is refused rather than ignored.
 
 Notes:
   * No binaries are committed to the repo. Every download is SHA-256 verified
@@ -154,21 +159,76 @@ interface DownloadOptions {
 }
 
 /**
- * Shared download options. `--platform` is accepted only by `fetch`: `run` and
- * `serve` execute what they download, and honouring a foreign platform there
- * would write a wrong-architecture binary into the daemon's cache and then try
- * to spawn it.
+ * Which commands actually READ each value flag, and why the others refuse it.
+ * A flag a command ignores is worse than one it rejects: `run --port 9000`
+ * used to parse fine and silently come up on the default port.
  */
-function downloadOptions(args: ParsedArgs, allowPlatform = false): DownloadOptions {
-  const platformKey = flagStr(args, "platform");
-  if (platformKey !== undefined && !allowPlatform) {
+const VALUE_FLAG_SCOPE: Record<string, { commands: readonly string[]; why: string }> = {
+  "base-url": { commands: ["run", "fetch", "serve"], why: "it only affects downloads" },
+  "sidecar-dir": { commands: ["run", "fetch", "serve"], why: "it only affects downloads" },
+  platform: {
+    commands: ["fetch"],
+    why:
+      "`run` and `serve` execute the binary, so it must be built for this host " +
+      `(${currentPlatformKey()})`,
+  },
+  port: {
+    commands: ["serve"],
+    why: "only `serve` binds a port; `run` reaches the agent through the daemon, which picks its own",
+  },
+  component: {
+    commands: ["fetch"],
+    why: "`run` needs both binaries and `serve` needs the sidecar, so neither can fetch a subset",
+  },
+  "cache-dir": {
+    commands: ["run", "fetch"],
+    why: "it caches the TUI, which `serve` never downloads (use --sidecar-dir)",
+  },
+};
+
+/** Refuse a value flag the chosen command would otherwise silently ignore. */
+function assertFlagsInScope(args: ParsedArgs, cmd: string): void {
+  for (const [flag, scope] of Object.entries(VALUE_FLAG_SCOPE)) {
+    if (args.flags[flag] === undefined || scope.commands.includes(cmd)) continue;
     throw new UsageError(
-      "--platform is only valid for `gaia fetch`. `run` and `serve` execute the " +
-        `binary, so it must be built for this host (${currentPlatformKey()}).`,
+      `--${flag} is not valid for \`gaia ${cmd}\` — ${scope.why}. ` +
+        `It is accepted by: ${scope.commands.map((c) => `\`gaia ${c}\``).join(", ")}.`,
     );
   }
+}
+
+/**
+ * Require https for a download source. Integrity still holds over plaintext
+ * (the SHA is pinned), but a MITM then surfaces as a baffling IntegrityError
+ * instead of the transport failure it is.
+ */
+function checkedBaseUrl(args: ParsedArgs): string | undefined {
+  const raw = flagStr(args, "base-url");
+  if (raw === undefined) return undefined;
+  let parsed: URL;
+  try {
+    parsed = new URL(raw);
+  } catch {
+    throw new UsageError(
+      `--base-url '${raw}' is not a valid absolute URL (expected e.g. https://host/path).`,
+    );
+  }
+  if (parsed.protocol !== "https:" && !args.flags["allow-insecure-base-url"]) {
+    throw new UsageError(
+      `--base-url '${raw}' uses ${parsed.protocol}, not https. Downloads are ` +
+        "SHA-256 verified either way, but plaintext turns tampering into a " +
+        "confusing integrity failure instead of a transport error. Use an https " +
+        "URL, or pass --allow-insecure-base-url for a trusted local mirror.",
+    );
+  }
+  return raw;
+}
+
+/** Shared download options. Scope and scheme are validated before we get here. */
+function downloadOptions(args: ParsedArgs, allowPlatform = false): DownloadOptions {
+  const platformKey = flagStr(args, "platform");
   return {
-    baseUrl: flagStr(args, "base-url"),
+    baseUrl: checkedBaseUrl(args),
     ...(allowPlatform && platformKey !== undefined ? { platformKey } : {}),
     force: Boolean(args.flags["force"]),
     tuiDir: flagStr(args, "cache-dir"),
@@ -191,8 +251,10 @@ export function pathWithoutOwnShim(
   if (rawPath === undefined || !argv1) return rawPath;
   const sep = process.platform === "win32" ? ";" : ":";
   let ownBinDir: string;
+  let ownName: string;
   try {
     ownBinDir = path.resolve(path.dirname(argv1));
+    ownName = path.basename(argv1);
   } catch {
     return rawPath;
   }
@@ -202,15 +264,36 @@ export function pathWithoutOwnShim(
       ? resolved.toLowerCase() === ownBinDir.toLowerCase()
       : resolved === ownBinDir;
   };
-  return rawPath
-    .split(sep)
-    .filter((d) => d !== "" && !same(d))
-    .join(sep);
+  const entries = rawPath.split(sep).filter((d) => d !== "");
+  const kept = entries.filter((d) => !same(d));
+  if (kept.length === entries.length) return kept.join(sep);
+  // A dir holding nothing but our own shim (an npx temp dir, node_modules/.bin)
+  // costs nothing to drop. A SHARED bin dir must NOT be dropped — that is where
+  // python3 / lemonade-server / the real `gaia` live — so it moves to the end
+  // instead, letting any other `gaia` on PATH win while its siblings survive.
+  return (isExclusivelyOurs(ownBinDir, ownName) ? kept : [...kept, ownBinDir]).join(sep);
+}
+
+/** True when every file in `dir` is a shim for `name` (`gaia`, `gaia.cmd`, …). */
+function isExclusivelyOurs(dir: string, name: string): boolean {
+  const stem = name.replace(/\.(cmd|bat|ps1|exe)$/i, "");
+  let entries: string[];
+  try {
+    entries = readdirSync(dir);
+  } catch {
+    return false; // unreadable → treat as shared, the non-destructive branch
+  }
+  return (
+    entries.length > 0 &&
+    entries.every((e) => e.replace(/\.(cmd|bat|ps1|exe)$/i, "") === stem)
+  );
 }
 
 /** Validate `--port`. Rejects out-of-range values and the reserved port. */
 export function resolvePort(raw: string | boolean | undefined): { port: number } | { error: string } {
-  const port = typeof raw === "string" ? Number(raw) : DEFAULT_PORT;
+  // Strict digits, not Number(): that accepts "0x2710", " 80 ", and "1e3",
+  // so a typo would quietly bind a port the user never named.
+  const port = typeof raw === "string" ? (/^\d+$/.test(raw) ? Number(raw) : NaN) : DEFAULT_PORT;
   if (!Number.isInteger(port) || port <= 0 || port > 65535 || port === RESERVED_PORT) {
     return {
       error: `--port must be a port in 1..65535 and not ${RESERVED_PORT} (got ${String(raw)})`,
@@ -289,6 +372,8 @@ async function cmdFetch(args: ParsedArgs): Promise<number> {
   return 0;
 }
 
+const SERVE_SIGNALS = ["SIGINT", "SIGTERM", "SIGHUP"] as const;
+
 async function cmdServe(args: ParsedArgs): Promise<number> {
   const parsed = resolvePort(args.flags["port"]);
   if ("error" in parsed) {
@@ -316,10 +401,19 @@ async function cmdServe(args: ParsedArgs): Promise<number> {
     process.stdout.write(`\n  ▸ GAIA agent: ${sidecar.baseUrl}/v1/gaia/query\n`);
     process.stdout.write(`    Health:     ${sidecar.baseUrl}/health\n`);
     process.stdout.write("    Lemonade must be running for live queries. Ctrl+C to stop.\n\n");
-    await new Promise<void>((resolve) => {
+    let stop!: () => void;
+    const stopped = new Promise<void>((resolve) => {
       let stopping = false;
-      const stop = (): void => {
-        if (stopping) return; // a second signal must not re-enter shutdown
+      stop = (): void => {
+        if (stopping) {
+          // Absorbed, so say what is happening — otherwise a repeat Ctrl+C
+          // during a slow teardown just looks like a frozen terminal.
+          process.stderr.write(
+            `[gaia] already stopping the sidecar (pid ${String(sidecar.child.pid)}); ` +
+              "waiting for its process tree to exit ...\n",
+          );
+          return;
+        }
         stopping = true;
         process.stderr.write("\n[gaia] stopping the sidecar ...\n");
         void shutdown(sidecar).catch(() => undefined).finally(resolve);
@@ -328,8 +422,15 @@ async function cmdServe(args: ParsedArgs): Promise<number> {
       // otherwise hit Node's default disposition and kill us mid-teardown,
       // orphaning the detached sidecar tree on port 8141. The `stopping` guard
       // absorbs the repeats.
-      for (const sig of ["SIGINT", "SIGTERM", "SIGHUP"] as const) process.on(sig, stop);
+      for (const sig of SERVE_SIGNALS) process.on(sig, stop);
     });
+    try {
+      await stopped;
+    } finally {
+      // Left installed, they would swallow every later signal AND suppress
+      // Node's default disposition, so Ctrl+C would stop working entirely.
+      for (const sig of SERVE_SIGNALS) process.removeListener(sig, stop);
+    }
     return 0;
   } catch (e) {
     await shutdown(sidecar).catch(() => undefined);
@@ -386,6 +487,7 @@ export async function main(argv: string[]): Promise<number> {
         "Arguments for the terminal UI go after a bare `--`.",
     );
   }
+  assertFlagsInScope(args, cmd);
   switch (cmd) {
     case "run":
       return cmdRun(args);

--- a/hub/agents/gaia/npm/src/errors.ts
+++ b/hub/agents/gaia/npm/src/errors.ts
@@ -32,6 +32,9 @@ export class BinaryNotFoundError extends GaiaError {}
 /** The sidecar we spawned died; anything answering its port is not ours. */
 export class SidecarExitedError extends GaiaError {}
 
+/** The bind port was already taken before we spawned anything. */
+export class PortInUseError extends GaiaError {}
+
 /** A 2xx response whose body is not the JSON the contract promises. */
 export class MalformedResponseError extends GaiaError {}
 

--- a/hub/agents/gaia/npm/src/errors.ts
+++ b/hub/agents/gaia/npm/src/errors.ts
@@ -29,6 +29,12 @@ export class VersionMismatchError extends GaiaError {}
 /** A binary could not be located on disk for spawning. */
 export class BinaryNotFoundError extends GaiaError {}
 
+/** The sidecar we spawned died; anything answering its port is not ours. */
+export class SidecarExitedError extends GaiaError {}
+
+/** A 2xx response whose body is not the JSON the contract promises. */
+export class MalformedResponseError extends GaiaError {}
+
 /** An HTTP request to the sidecar returned a non-2xx status. */
 export class HttpError extends GaiaError {
   constructor(

--- a/hub/agents/gaia/npm/src/fetch.ts
+++ b/hub/agents/gaia/npm/src/fetch.ts
@@ -68,6 +68,17 @@ export function daemonSidecarCacheDir(agentId = SIDECAR_AGENT_ID): string {
 }
 
 /**
+ * Whether this fetch produced a runnable local install worth recording.
+ *
+ * `--platform` fetches a binary for a DIFFERENT host — a cross-compile staging
+ * step, not an install. Recording one would hand the daemon a wrong-arch
+ * executable that re-hashes correctly and then fails to exec.
+ */
+function installsForThisHost(component: ComponentName, platformKey: string): boolean {
+  return component === "sidecar" && platformKey === currentPlatformKey();
+}
+
+/**
  * Record a completed install the way `gaia.hub.installer` does.
  *
  * Staging a verified binary is only half the job the CLI claims to do. Without
@@ -160,6 +171,9 @@ function sha256Hex(buf: Buffer): string {
   return crypto.createHash("sha256").update(buf).digest("hex");
 }
 
+/** Read size for incremental hashing — bounded regardless of artifact size. */
+const HASH_CHUNK_BYTES = 1 << 20;
+
 /**
  * SHA-256 of a file on disk, or null when it is simply absent. Any other error
  * (a permission problem, a directory in the way) is re-raised: reading it as
@@ -167,16 +181,35 @@ function sha256Hex(buf: Buffer): string {
  * less useful message.
  */
 export async function fileSha256(filePath: string): Promise<string | null> {
-  try {
-    return sha256Hex(await fsp.readFile(filePath));
-  } catch (e) {
-    const code = (e as NodeJS.ErrnoException).code;
-    if (code === "ENOENT") return null;
-    throw new Error(
+  const unreadable = (e: unknown): Error =>
+    new Error(
       `cannot read the cached binary at ${filePath} to check its hash: ${(e as Error).message}. ` +
         "Fix the permissions on that path, or pass a different --cache-dir / --sidecar-dir.",
       { cause: e },
     );
+
+  let fh: fsp.FileHandle;
+  try {
+    fh = await fsp.open(filePath, "r");
+  } catch (e) {
+    if ((e as NodeJS.ErrnoException).code === "ENOENT") return null;
+    throw unreadable(e);
+  }
+  // Chunked, not readFile: this runs on every cache hit, and the sidecar is
+  // ~200MB — buffering it whole is the peak the streaming download removed.
+  try {
+    const hash = crypto.createHash("sha256");
+    const buf = Buffer.allocUnsafe(HASH_CHUNK_BYTES);
+    for (;;) {
+      const { bytesRead } = await fh.read(buf, 0, buf.length, null);
+      if (bytesRead === 0) break;
+      hash.update(buf.subarray(0, bytesRead));
+    }
+    return hash.digest("hex");
+  } catch (e) {
+    throw unreadable(e);
+  } finally {
+    await fh.close();
   }
 }
 
@@ -301,7 +334,7 @@ export async function fetchBinary(opts: FetchOptions): Promise<FetchResult> {
       if (process.platform !== "win32") await fsp.chmod(binaryPath, 0o755);
       // Also on a cache hit: an earlier release staged a verified binary with no
       // sentinel, and those installs would otherwise never repair themselves.
-      if (opts.component === "sidecar") {
+      if (installsForThisHost(opts.component, platformKey)) {
         await writeInstalledSentinel({
           outDir,
           version: componentLock(lock, "sidecar").componentVersion,
@@ -387,7 +420,7 @@ export async function fetchBinary(opts: FetchOptions): Promise<FetchResult> {
     );
   }
 
-  if (opts.component === "sidecar") {
+  if (installsForThisHost(opts.component, platformKey)) {
     await writeInstalledSentinel({
       outDir,
       version: componentLock(lock, "sidecar").componentVersion,

--- a/hub/agents/gaia/npm/src/fetch.ts
+++ b/hub/agents/gaia/npm/src/fetch.ts
@@ -33,6 +33,7 @@ import {
   type BinaryLockEntry,
   type ComponentName,
   componentBaseUrl,
+  componentLock,
   currentPlatformKey,
   defaultLockPath,
   isPlaceholderSha,
@@ -50,14 +51,70 @@ export function defaultCacheDir(agentVersion: string): string {
   return path.join(os.homedir(), ".gaia", "npm-cache", `gaia-${agentVersion}`);
 }
 
+/** The hub agent id this package installs the sidecar as. */
+export const SIDECAR_AGENT_ID = "gaia";
+
+/** Basename of the hub install record (`gaia.hub.installer.SENTINEL_NAME`). */
+export const INSTALLED_SENTINEL_NAME = ".installed";
+
 /**
  * The daemon's own sidecar cache — `~/.gaia/agents/gaia/`, mirroring
  * `gaia.daemon.sidecars.fetch.default_cache_dir("gaia")`. Staging the verified
  * sidecar here means the daemon's own fetch is a SHA-256 cache hit instead of a
  * second download. This path is a cross-repo contract with the daemon.
  */
-export function daemonSidecarCacheDir(agentId = "gaia"): string {
+export function daemonSidecarCacheDir(agentId = SIDECAR_AGENT_ID): string {
   return path.join(os.homedir(), ".gaia", "agents", agentId);
+}
+
+/**
+ * Record a completed install the way `gaia.hub.installer` does.
+ *
+ * Staging a verified binary is only half the job the CLI claims to do. Without
+ * this file the daemon's `_hub_installed_binary` sees no install, and the TUI
+ * treats `gaia-agent` as its own stdio child — spawning our REST sidecar over
+ * stdio and filling the chat with uvicorn's startup log. With it, the TUI uses
+ * daemon transport and the daemon supervises the process and mints its token.
+ *
+ * Field names and `artifact_kind`/`executable`/`artifact_sha256` are a
+ * cross-repo contract with `InstalledAgent.to_dict()`; the daemon re-hashes the
+ * binary and raises if it does not match `artifact_sha256`, so this must carry
+ * the hash we actually verified.
+ */
+async function writeInstalledSentinel(opts: {
+  outDir: string;
+  version: string;
+  sha256: string;
+  executable: string;
+}): Promise<void> {
+  const sentinel = path.join(opts.outDir, INSTALLED_SENTINEL_NAME);
+  const record = {
+    id: SIDECAR_AGENT_ID,
+    version: opts.version,
+    language: "python",
+    installed_at: new Date().toISOString(),
+    artifact_sha256: opts.sha256,
+    path: opts.outDir,
+    artifact_kind: "binary",
+    executable: opts.executable,
+  };
+  // Temp-then-rename: a truncated sentinel reads as a corrupt install, which
+  // looks identical to "never installed".
+  const tmp = `${sentinel}.tmp.${process.pid}`;
+  try {
+    await fsp.writeFile(tmp, `${JSON.stringify(record, null, 2)}\n`, "utf8");
+    await fsp.rename(tmp, sentinel);
+  } catch (e) {
+    await fsp.rm(tmp, { force: true }).catch(() => undefined);
+    throw new Error(
+      `verified the sidecar at ${opts.outDir} but could not write its ` +
+        `${INSTALLED_SENTINEL_NAME} record: ${(e as Error).message}. Without it the ` +
+        "daemon does not see a completed install and the TUI falls back to running " +
+        `the sidecar over stdio. Check write permissions on ${opts.outDir}.`,
+      { cause: e },
+    );
+  }
+  log.debug(`wrote ${sentinel} (v${opts.version})`);
 }
 
 export interface FetchOptions {
@@ -242,6 +299,16 @@ export async function fetchBinary(opts: FetchOptions): Promise<FetchResult> {
       // Re-apply the exec bit: an interrupted earlier run or a restrictive umask
       // can leave correct bytes that still cannot be spawned.
       if (process.platform !== "win32") await fsp.chmod(binaryPath, 0o755);
+      // Also on a cache hit: an earlier release staged a verified binary with no
+      // sentinel, and those installs would otherwise never repair themselves.
+      if (opts.component === "sidecar") {
+        await writeInstalledSentinel({
+          outDir,
+          version: componentLock(lock, "sidecar").componentVersion,
+          sha256: existing,
+          executable: entry.executable,
+        });
+      }
       return {
         component: opts.component,
         binaryPath,
@@ -318,6 +385,15 @@ export async function fetchBinary(opts: FetchOptions): Promise<FetchResult> {
         "pass a --sidecar-dir / --cache-dir you own.",
       { cause: e },
     );
+  }
+
+  if (opts.component === "sidecar") {
+    await writeInstalledSentinel({
+      outDir,
+      version: componentLock(lock, "sidecar").componentVersion,
+      sha256: sha,
+      executable: entry.executable,
+    });
   }
 
   log.info(`installed verified ${opts.component} -> ${binaryPath}`);

--- a/hub/agents/gaia/npm/src/fetch.ts
+++ b/hub/agents/gaia/npm/src/fetch.ts
@@ -124,15 +124,52 @@ export async function fileSha256(filePath: string): Promise<string | null> {
 }
 
 /**
- * Verify a buffer against an expected SHA-256. Throws `IntegrityError` loudly on
- * mismatch — this is the no-silent-fallback integrity gate.
+ * Stream a response body to `tmp`, hashing as it goes.
+ *
+ * Incremental on purpose: the sidecar is ~200MB and `arrayBuffer()` would peak
+ * at roughly double that. Awaiting each write applies backpressure.
  */
-export function verifySha256(
-  buf: Buffer,
-  expected: string,
-  sourceLabel: string,
-): string {
-  const actual = sha256Hex(buf);
+async function streamToFile(
+  res: Response,
+  tmp: string,
+  url: string,
+): Promise<{ sha256: string; bytes: number }> {
+  if (!res.body) {
+    throw new Error(
+      `download failed: ${url} returned HTTP ${res.status} with no response body. ` +
+        "Check the base URL and that the artifact is published for this platform.",
+    );
+  }
+  const hash = crypto.createHash("sha256");
+  let bytes = 0;
+  let fh: fsp.FileHandle;
+  try {
+    fh = await fsp.open(tmp, "w");
+  } catch (e) {
+    throw new Error(
+      `cannot open ${tmp} to stage the download: ${(e as Error).message}. ` +
+        "Check write permissions on that directory, or pass a different " +
+        "--sidecar-dir / --cache-dir.",
+      { cause: e },
+    );
+  }
+  try {
+    for await (const chunk of res.body as unknown as AsyncIterable<Uint8Array>) {
+      hash.update(chunk);
+      bytes += chunk.byteLength;
+      await fh.write(chunk);
+    }
+  } finally {
+    await fh.close();
+  }
+  return { sha256: hash.digest("hex"), bytes };
+}
+
+/**
+ * Compare an already-computed SHA-256 with the expected one. Throws
+ * `IntegrityError` loudly on mismatch — this is the no-silent-fallback gate.
+ */
+function assertSha256(actual: string, expected: string, sourceLabel: string): string {
   if (actual.toLowerCase() !== expected.toLowerCase()) {
     throw new IntegrityError(
       `SHA-256 mismatch for ${sourceLabel}:\n` +
@@ -145,6 +182,15 @@ export function verifySha256(
     );
   }
   return actual;
+}
+
+/** Verify an in-memory buffer against an expected SHA-256. */
+export function verifySha256(
+  buf: Buffer,
+  expected: string,
+  sourceLabel: string,
+): string {
+  return assertSha256(sha256Hex(buf), expected, sourceLabel);
 }
 
 /**
@@ -211,7 +257,12 @@ export async function fetchBinary(opts: FetchOptions): Promise<FetchResult> {
   const timeoutMs = opts.timeoutMs ?? 300_000;
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), timeoutMs);
-  let buf: Buffer;
+
+  // Streamed to a temp file while hashing incrementally: the sidecar is ~200MB
+  // and buffering it whole peaks at roughly double that in RSS.
+  const tmp = `${binaryPath}.download.${process.pid}`;
+  let actualSha: string;
+  let bytes: number;
   try {
     const res = await fetchImpl(url, {
       headers: { accept: "application/octet-stream" },
@@ -223,8 +274,9 @@ export async function fetchBinary(opts: FetchOptions): Promise<FetchResult> {
           "Check the base URL and that the artifact is published for this platform.",
       );
     }
-    buf = Buffer.from(await res.arrayBuffer());
+    ({ sha256: actualSha, bytes } = await streamToFile(res, tmp, url));
   } catch (e) {
+    await fsp.rm(tmp, { force: true }).catch(() => undefined);
     if ((e as Error).name === "AbortError") {
       throw new Error(`download timed out after ${timeoutMs}ms for ${url}`);
     }
@@ -232,23 +284,40 @@ export async function fetchBinary(opts: FetchOptions): Promise<FetchResult> {
   } finally {
     clearTimeout(timer);
   }
-  log.debug(`downloaded ${buf.length} bytes`);
+  log.debug(`downloaded ${bytes} bytes`);
 
-  const sha = verifySha256(buf, entry.sha256, `${opts.component} ${platformKey} (${url})`);
-
-  // Write to a temp then rename, so a crash mid-write never leaves a
-  // half-written file that a later run would treat as a real binary.
-  const tmp = `${binaryPath}.download.${process.pid}`;
+  // Verify BEFORE the rename: unverified bytes must never reach the final path.
+  let sha: string;
   try {
-    await fsp.writeFile(tmp, buf);
-    await fsp.rename(tmp, binaryPath);
+    sha = assertSha256(actualSha, entry.sha256, `${opts.component} ${platformKey} (${url})`);
   } catch (e) {
     await fsp.rm(tmp, { force: true }).catch(() => undefined);
     throw e;
   }
 
-  if (process.platform !== "win32") {
-    await fsp.chmod(binaryPath, 0o755);
+  try {
+    await fsp.rename(tmp, binaryPath);
+  } catch (e) {
+    await fsp.rm(tmp, { force: true }).catch(() => undefined);
+    throw new Error(
+      `downloaded and verified the ${opts.component}, but could not move it into place ` +
+        `at ${binaryPath}: ${(e as Error).message}. ` +
+        "The usual cause is that the file is in use — stop any running gaia sidecar " +
+        "or TUI (`gaia kill`) and re-run. Otherwise check write permissions on " +
+        `${outDir}, or pass a different --sidecar-dir / --cache-dir.`,
+      { cause: e },
+    );
+  }
+
+  try {
+    if (process.platform !== "win32") await fsp.chmod(binaryPath, 0o755);
+  } catch (e) {
+    throw new Error(
+      `installed the ${opts.component} at ${binaryPath} but could not make it ` +
+        `executable: ${(e as Error).message}. Run \`chmod +x ${binaryPath}\`, or ` +
+        "pass a --sidecar-dir / --cache-dir you own.",
+      { cause: e },
+    );
   }
 
   log.info(`installed verified ${opts.component} -> ${binaryPath}`);

--- a/hub/agents/gaia/npm/src/index.ts
+++ b/hub/agents/gaia/npm/src/index.ts
@@ -16,6 +16,8 @@
  */
 
 export {
+  INSTALLED_SENTINEL_NAME,
+  SIDECAR_AGENT_ID,
   fetchAll,
   fetchBinary,
   verifySha256,

--- a/hub/agents/gaia/npm/src/index.ts
+++ b/hub/agents/gaia/npm/src/index.ts
@@ -91,6 +91,8 @@ export {
   HealthTimeoutError,
   HttpError,
   IntegrityError,
+  MalformedResponseError,
   PlatformError,
+  SidecarExitedError,
   VersionMismatchError,
 } from "./errors.js";

--- a/hub/agents/gaia/npm/src/index.ts
+++ b/hub/agents/gaia/npm/src/index.ts
@@ -95,6 +95,7 @@ export {
   IntegrityError,
   MalformedResponseError,
   PlatformError,
+  PortInUseError,
   SidecarExitedError,
   VersionMismatchError,
 } from "./errors.js";

--- a/hub/agents/gaia/npm/src/lifecycle.ts
+++ b/hub/agents/gaia/npm/src/lifecycle.ts
@@ -20,6 +20,7 @@
  */
 
 import { type ChildProcess, spawn, spawnSync } from "node:child_process";
+import crypto from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
 
@@ -27,10 +28,20 @@ import {
   BinaryNotFoundError,
   HealthTimeoutError,
   HttpError,
+  IntegrityError,
+  MalformedResponseError,
+  SidecarExitedError,
   VersionMismatchError,
 } from "./errors.js";
 import { createLogger } from "./logger.js";
-import { currentPlatformKey } from "./platform.js";
+import {
+  type BinaryLock,
+  type ComponentName,
+  currentPlatformKey,
+  isPlaceholderSha,
+  loadLock,
+  resolveEntry,
+} from "./platform.js";
 
 const log = createLogger("lifecycle");
 
@@ -83,10 +94,73 @@ export interface ResolveOptions {
   resourcesDir: string;
   /** Override the executable basename (defaults per-platform). */
   executable?: string;
+  /**
+   * Re-verify the file's SHA-256 against `binaries.lock.json` before handing
+   * back a path that is about to be spawned. Default `true` — the cache dir is
+   * predictable, so anything that can write it could otherwise get code run.
+   * Set `false` only for a binary you built yourself, which no lock describes.
+   */
+  verify?: boolean;
+  /** Pre-loaded lock, to avoid re-reading it per call. */
+  lock?: BinaryLock;
+}
+
+/** SHA-256 of a file, read in chunks so a ~200MB binary is not buffered whole. */
+function fileSha256Sync(filePath: string): string {
+  const hash = crypto.createHash("sha256");
+  const buf = Buffer.allocUnsafe(1 << 20);
+  const fd = fs.openSync(filePath, "r");
+  try {
+    for (;;) {
+      const n = fs.readSync(fd, buf, 0, buf.length, null);
+      if (n === 0) break;
+      hash.update(buf.subarray(0, n));
+    }
+  } finally {
+    fs.closeSync(fd);
+  }
+  return hash.digest("hex");
+}
+
+/**
+ * Re-verify an on-disk binary against the lock. `fetch.ts` calls the SHA verify
+ * "the security boundary"; this keeps that true for the resolve→spawn path,
+ * which is exported and whose cache path is guessable.
+ */
+function verifyAgainstLock(
+  full: string,
+  component: ComponentName,
+  lock: BinaryLock | undefined,
+): void {
+  const platformKey = currentPlatformKey();
+  const entry = resolveEntry(lock ?? loadLock(), component, platformKey);
+  if (isPlaceholderSha(entry.sha256)) {
+    throw new IntegrityError(
+      `binaries.lock.json has a placeholder sha256 for ${component}/'${platformKey}', ` +
+        `so ${full} cannot be verified and must not be spawned. Install a released ` +
+        "@amd-gaia/gaia, or pass { verify: false } if you built this binary yourself.",
+    );
+  }
+  const actual = fileSha256Sync(full);
+  if (actual.toLowerCase() !== entry.sha256.toLowerCase()) {
+    throw new IntegrityError(
+      `SHA-256 mismatch for the ${component} binary at ${full}:\n` +
+        `  expected ${entry.sha256}\n` +
+        `  actual   ${actual}\n` +
+        "Refusing to spawn a binary that does not match binaries.lock.json. " +
+        "Re-run `npx @amd-gaia/gaia fetch --force` to reinstall it; if it persists, " +
+        "report it at https://github.com/amd/gaia/issues.",
+    );
+  }
 }
 
 /** Resolve a fetched binary's path, failing loudly if it is not there. */
-function resolveIn(opts: ResolveOptions, fallback: string, what: string): string {
+function resolveIn(
+  opts: ResolveOptions,
+  component: ComponentName,
+  fallback: string,
+  what: string,
+): string {
   if (!opts?.resourcesDir) {
     throw new TypeError("resolve requires { resourcesDir }");
   }
@@ -97,15 +171,16 @@ function resolveIn(opts: ResolveOptions, fallback: string, what: string): string
         "Run the fetch step first: `npx @amd-gaia/gaia fetch`.",
     );
   }
+  if (opts.verify ?? true) verifyAgainstLock(full, component, opts.lock);
   return full;
 }
 
 export function resolveSidecarPath(opts: ResolveOptions): string {
-  return resolveIn(opts, sidecarExecutableName(), "gaia-agent sidecar");
+  return resolveIn(opts, "sidecar", sidecarExecutableName(), "gaia-agent sidecar");
 }
 
 export function resolveTuiPath(opts: ResolveOptions): string {
-  return resolveIn(opts, tuiExecutableName(), "gaia-tui");
+  return resolveIn(opts, "tui", tuiExecutableName(), "gaia-tui");
 }
 
 export interface SpawnOptions {
@@ -145,18 +220,46 @@ const liveSidecars = new Set<Sidecar>();
 let cleanupInstalled = false;
 const CLEANUP_SIGNALS: NodeJS.Signals[] = ["SIGINT", "SIGTERM", "SIGHUP"];
 
+/** stderr from an exit handler: console.error can be async on a piped stderr. */
+function writeStderrSync(msg: string): void {
+  try {
+    fs.writeSync(2, msg.endsWith("\n") ? msg : `${msg}\n`);
+  } catch {
+    /* stderr unavailable */
+  }
+}
+
 function killTreeSync(sidecar: Sidecar): void {
   const { child } = sidecar;
   if (child.pid === undefined) return;
   if (child.exitCode !== null || child.signalCode !== null) return;
   try {
     if (process.platform === "win32") {
-      spawnSync("taskkill", ["/PID", String(child.pid), "/T", "/F"], { stdio: "ignore" });
+      const r = spawnSync("taskkill", ["/PID", String(child.pid), "/T", "/F"], {
+        stdio: ["ignore", "ignore", "pipe"],
+        encoding: "utf8",
+      });
+      // A refusal ("Access is denied") leaves the port held; say so now rather
+      // than let it surface as an unexplained bind failure on the next run.
+      if (r.error || r.status !== 0) {
+        writeStderrSync(
+          `[gaia:lifecycle] ERROR taskkill /PID ${child.pid} /T /F failed ` +
+            `(${r.error ? r.error.message : `exit ${String(r.status)}`}): ` +
+            `${(r.stderr ?? "").trim() || "(no output)"}. ` +
+            `Kill pid ${child.pid} manually or port ${sidecar.port} stays bound.`,
+        );
+      }
     } else {
       process.kill(-child.pid, "SIGKILL");
     }
-  } catch {
-    /* already gone */
+  } catch (e) {
+    const code = (e as NodeJS.ErrnoException).code;
+    if (code === "ESRCH") return; // already gone — the outcome we wanted
+    writeStderrSync(
+      `[gaia:lifecycle] ERROR could not kill the sidecar process group ` +
+        `${String(child.pid)}: ${(e as Error).message}. ` +
+        `Kill it manually or port ${sidecar.port} stays bound.`,
+    );
   }
 }
 
@@ -180,27 +283,37 @@ function crashHandler(err: unknown): void {
   process.exit(1);
 }
 
+/**
+ * True when ours is the only listener for `event`, i.e. nothing else in this
+ * process handles it and the process is therefore going down.
+ *
+ * Reaping is only ours to do in that case: a host with its own handler keeps
+ * running, and killing its sidecar would turn an exception it handled into an
+ * unexplained ECONNREFUSED on its next request.
+ */
+function weOwnTheExit(event: string): boolean {
+  return process.listenerCount(event) === 1;
+}
+
 function installCleanupHandlers(): void {
   if (cleanupInstalled) return;
   cleanupInstalled = true;
+  // The backstop: whatever route the process takes out, this runs.
   process.on("exit", reapAllSync);
+  // crashHandler reaps before it exits, so the guard is the whole handler.
   process.on("uncaughtException", (err) => {
-    reapAllSync();
-    if (process.listenerCount("uncaughtException") === 1) crashHandler(err);
+    if (weOwnTheExit("uncaughtException")) crashHandler(err);
   });
   process.on("unhandledRejection", (err) => {
-    reapAllSync();
-    if (process.listenerCount("unhandledRejection") === 1) crashHandler(err);
+    if (weOwnTheExit("unhandledRejection")) crashHandler(err);
   });
   for (const sig of CLEANUP_SIGNALS) {
     const handler = (): void => {
+      if (!weOwnTheExit(sig)) return;
       reapAllSync();
-      // Sole listener → restore the default disposition and re-raise so the
-      // process still terminates (Ctrl+C).
-      if (process.listenerCount(sig) === 1) {
-        process.removeListener(sig, handler);
-        process.kill(process.pid, sig);
-      }
+      // Restore the default disposition and re-raise so we still terminate.
+      process.removeListener(sig, handler);
+      process.kill(process.pid, sig);
     };
     process.on(sig, handler);
   }
@@ -253,9 +366,18 @@ export function spawnSidecar(opts: SpawnOptions): Sidecar {
   return sidecar;
 }
 
-async function getJson<T>(url: string, timeoutMs: number): Promise<T> {
+async function getJson<T>(
+  url: string,
+  timeoutMs: number,
+  signal?: AbortSignal,
+): Promise<T> {
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), timeoutMs);
+  // Link the caller's signal so an in-flight probe aborts the moment the
+  // process being probed dies, rather than at the next poll.
+  const onAbort = (): void => controller.abort();
+  if (signal?.aborted) controller.abort();
+  else signal?.addEventListener("abort", onAbort, { once: true });
   try {
     const res = await fetch(url, {
       headers: { accept: "application/json" },
@@ -263,15 +385,31 @@ async function getJson<T>(url: string, timeoutMs: number): Promise<T> {
     });
     const text = await res.text();
     if (!res.ok) throw new HttpError(res.status, url, text);
-    return JSON.parse(text) as T;
+    try {
+      return JSON.parse(text) as T;
+    } catch (e) {
+      // A proxy or captive portal answering 200 with HTML lands here; a bare
+      // SyntaxError would escape the CLI's GaiaError branch as a raw stack.
+      throw new MalformedResponseError(
+        `${url} returned HTTP ${res.status} but its body is not JSON ` +
+          `(${(e as Error).message}). First 200 bytes: ${JSON.stringify(text.slice(0, 200))}. ` +
+          "Something other than the gaia sidecar is answering that address — " +
+          "check for a proxy on the port, or point at the right host/port.",
+      );
+    }
   } finally {
     clearTimeout(timer);
+    signal?.removeEventListener("abort", onAbort);
   }
 }
 
 /** `GET /health` — liveness only; it does not mean a model is loaded. */
-export function health(baseUrl: string, timeoutMs = 1000): Promise<HealthResponse> {
-  return getJson<HealthResponse>(`${baseUrl}/health`, timeoutMs);
+export function health(
+  baseUrl: string,
+  timeoutMs = 1000,
+  signal?: AbortSignal,
+): Promise<HealthResponse> {
+  return getJson<HealthResponse>(`${baseUrl}/health`, timeoutMs, signal);
 }
 
 /** `GET /version` — the contract probe (`{ apiVersion, agentVersion }`). */
@@ -303,25 +441,32 @@ export async function waitForHealth(
   const deadline = Date.now() + timeoutMs;
   let lastErr = "";
   let attempts = 0;
+  // Re-checked after every await, not just at the top of the loop: a probe that
+  // races the process's death would otherwise report a foreign server's health.
+  const throwIfAborted = (): void => {
+    if (!opts.signal?.aborted) return;
+    throw new HealthTimeoutError(
+      `health wait for ${baseUrl} was aborted after ${attempts} probe(s) ` +
+        "(the process being probed exited).",
+    );
+  };
   while (Date.now() < deadline) {
-    if (opts.signal?.aborted) {
-      throw new HealthTimeoutError(
-        `health wait for ${baseUrl} was aborted after ${attempts} probe(s) ` +
-          "(the process being probed exited).",
-      );
-    }
+    throwIfAborted();
     attempts++;
     try {
-      const h = await health(baseUrl, intervalMs * 4);
+      const h = await health(baseUrl, intervalMs * 4, opts.signal);
+      throwIfAborted();
       if (h.status === "ok") {
         log.debug(`sidecar healthy after ${attempts} probe(s)`);
         return;
       }
       lastErr = `unexpected health status: ${JSON.stringify(h)}`;
     } catch (e) {
+      throwIfAborted();
       lastErr = (e as Error).message;
     }
     await sleep(intervalMs);
+    throwIfAborted();
   }
   throw new HealthTimeoutError(
     `the gaia sidecar at ${baseUrl} did not become healthy within ${timeoutMs}ms ` +
@@ -375,8 +520,8 @@ export async function checkVersion(
  */
 export async function shutdown(sidecar: Sidecar, timeoutMs = 5000): Promise<void> {
   const { child } = sidecar;
-  liveSidecars.delete(sidecar); // an explicit shutdown owns the lifecycle now
   if (child.exitCode !== null || child.signalCode !== null || child.pid === undefined) {
+    liveSidecars.delete(sidecar);
     log.debug("shutdown: sidecar already exited");
     return;
   }
@@ -387,11 +532,29 @@ export async function shutdown(sidecar: Sidecar, timeoutMs = 5000): Promise<void
     child.once("exit", () => resolve());
   });
 
+  // Why the kill was refused, kept for the throw below — "Access is denied" is
+  // the difference between "retry" and "run this elevated".
+  let killDiagnostic = "";
+
   if (process.platform === "win32") {
     const killer = spawn("taskkill", ["/PID", String(pid), "/T", "/F"], {
-      stdio: "ignore",
+      stdio: ["ignore", "ignore", "pipe"],
     });
-    killer.on("error", (e) => log.error(`taskkill failed: ${e.message}`));
+    let taskkillErr = "";
+    killer.stderr?.on("data", (d) => {
+      taskkillErr += String(d);
+    });
+    killer.on("error", (e) => {
+      killDiagnostic = `taskkill could not be launched: ${e.message}`;
+      log.error(killDiagnostic);
+    });
+    killer.on("exit", (code) => {
+      if (code === 0) return;
+      killDiagnostic =
+        `taskkill /PID ${pid} /T /F exited ${String(code)}: ` +
+        `${taskkillErr.trim() || "(no output)"}`;
+      log.error(killDiagnostic);
+    });
   } else {
     try {
       process.kill(-pid, "SIGTERM"); // negative pid → the whole process group
@@ -427,16 +590,20 @@ export async function shutdown(sidecar: Sidecar, timeoutMs = 5000): Promise<void
     // Bound the final wait too. On Windows there is no second escalation after
     // taskkill, so an unbounded await here would hang Ctrl+C forever.
     if ((await raceExit(timeoutMs)) === "timeout") {
+      // Deliberately still registered: the process-exit reaper is the last
+      // chance to reap a survivor, and de-registering here would orphan it.
       throw new Error(
-        `the gaia sidecar (pid ${pid}) did not exit after a forced kill. ` +
-          "Kill it manually — " +
+        `the gaia sidecar (pid ${pid}) did not exit after a forced kill` +
+          (killDiagnostic ? ` (${killDiagnostic})` : "") +
+          ". Kill it manually — " +
           (process.platform === "win32"
             ? `taskkill /PID ${pid} /T /F`
             : `kill -9 -${pid}`) +
-          ` — or the port it holds stays bound.`,
+          ` — or port ${sidecar.port} stays bound.`,
       );
     }
   }
+  liveSidecars.delete(sidecar);
   log.info("sidecar shut down");
 }
 
@@ -450,9 +617,30 @@ export interface StartOptions extends SpawnOptions {
 }
 
 /**
- * Spawn → wait for health → (optionally) version-check. On any failure the
- * sidecar is shut down before rethrowing, so a failed start never leaks a
- * process.
+ * Refuse a handle whose own child is dead. A healthy `/health` proves *something*
+ * owns the port — this proves it is ours. Without it a second `gaia serve` would
+ * print a ready URL for a server it cannot shut down.
+ */
+function assertOurs(sidecar: Sidecar): void {
+  const { child } = sidecar;
+  if (child.exitCode === null && child.signalCode === null) return;
+  throw new SidecarExitedError(
+    `the gaia sidecar we spawned exited (code=${String(child.exitCode)} ` +
+      `signal=${String(child.signalCode)}) while ${sidecar.baseUrl}/health still ` +
+      `answered — another process is already bound to port ${sidecar.port}, most ` +
+      "likely an instance you started earlier. Stop it (" +
+      (process.platform === "win32"
+        ? `netstat -ano | findstr :${sidecar.port}`
+        : `lsof -i :${sidecar.port}`) +
+      ") or start on a different port with --port. Re-run with DEBUG=gaia to see " +
+      "the sidecar's own output.",
+  );
+}
+
+/**
+ * Spawn → wait for health → assert the child is still ours → (optionally)
+ * version-check. On any failure the sidecar is shut down before rethrowing, so a
+ * failed start never leaks a process.
  */
 export async function startSidecar(opts: StartOptions): Promise<Sidecar> {
   const sidecar = spawnSidecar(opts);
@@ -465,10 +653,12 @@ export async function startSidecar(opts: StartOptions): Promise<Sidecar> {
       timeoutMs: opts.healthTimeoutMs,
       signal: died.signal,
     });
+    assertOurs(sidecar);
     if (opts.verifyVersion ?? true) {
       await checkVersion(sidecar.baseUrl, {
         expectedApiVersion: opts.expectedApiVersion,
       });
+      assertOurs(sidecar);
     }
     return sidecar;
   } catch (e) {

--- a/hub/agents/gaia/npm/src/lifecycle.ts
+++ b/hub/agents/gaia/npm/src/lifecycle.ts
@@ -47,7 +47,7 @@ const log = createLogger("lifecycle");
 
 export const DEFAULT_HOST = "127.0.0.1";
 
-/** Matches `gaia_agent_gaia.server.DEFAULT_PORT`. NEVER 4001 (repo-reserved). */
+/** Matches `gaia_agent.server.DEFAULT_PORT`. NEVER 4001 (repo-reserved). */
 export const DEFAULT_PORT = 8141;
 
 /** Repo-wide reserved port. Nothing here may ever bind it. */

--- a/hub/agents/gaia/npm/src/lifecycle.ts
+++ b/hub/agents/gaia/npm/src/lifecycle.ts
@@ -638,6 +638,26 @@ function assertOurs(sidecar: Sidecar): void {
 }
 
 /**
+ * Decide what a dead child actually means, by asking who owns the port now.
+ *
+ * The health wait aborts the instant our child exits, so on a fast machine that
+ * abort can beat a healthy reply from an incumbent — and then a port conflict
+ * reports as a plain timeout. Re-probing settles which failure this is instead
+ * of letting the race name it. Silent when our child is alive, or when nothing
+ * answers: that is a genuine timeout and the caller rethrows it.
+ */
+async function assertNotAForeignServer(sidecar: Sidecar): Promise<void> {
+  const { child } = sidecar;
+  if (child.exitCode === null && child.signalCode === null) return;
+  try {
+    if ((await health(sidecar.baseUrl, 1_000)).status !== "ok") return;
+  } catch {
+    return; // nothing is listening — our sidecar simply died
+  }
+  assertOurs(sidecar); // something else owns the port; throws SidecarExitedError
+}
+
+/**
  * Spawn → wait for health → assert the child is still ours → (optionally)
  * version-check. On any failure the sidecar is shut down before rethrowing, so a
  * failed start never leaks a process.
@@ -649,10 +669,15 @@ export async function startSidecar(opts: StartOptions): Promise<Sidecar> {
   const died = new AbortController();
   sidecar.child.once("exit", () => died.abort());
   try {
-    await waitForHealth(sidecar.baseUrl, {
-      timeoutMs: opts.healthTimeoutMs,
-      signal: died.signal,
-    });
+    try {
+      await waitForHealth(sidecar.baseUrl, {
+        timeoutMs: opts.healthTimeoutMs,
+        signal: died.signal,
+      });
+    } catch (e) {
+      await assertNotAForeignServer(sidecar);
+      throw e;
+    }
     assertOurs(sidecar);
     if (opts.verifyVersion ?? true) {
       await checkVersion(sidecar.baseUrl, {

--- a/hub/agents/gaia/npm/src/lifecycle.ts
+++ b/hub/agents/gaia/npm/src/lifecycle.ts
@@ -22,6 +22,7 @@
 import { type ChildProcess, spawn, spawnSync } from "node:child_process";
 import crypto from "node:crypto";
 import fs from "node:fs";
+import net from "node:net";
 import path from "node:path";
 
 import {
@@ -30,6 +31,7 @@ import {
   HttpError,
   IntegrityError,
   MalformedResponseError,
+  PortInUseError,
   SidecarExitedError,
   VersionMismatchError,
 } from "./errors.js";
@@ -658,11 +660,53 @@ async function assertNotAForeignServer(sidecar: Sidecar): Promise<void> {
 }
 
 /**
+ * True when something is already listening on host:port.
+ *
+ * A TCP connect, not a `/health` probe: ANY listener makes our bind fail, and
+ * the incumbent need not be a GAIA sidecar. Unreachable-in-time counts as free —
+ * this exists to turn a confusing failure into a clear one early, and the
+ * spawn + health wait remains the actual gate.
+ */
+function portInUse(host: string, port: number, timeoutMs = 500): Promise<boolean> {
+  return new Promise((resolve) => {
+    const socket = net.connect({ host, port });
+    const settle = (inUse: boolean): void => {
+      socket.destroy();
+      resolve(inUse);
+    };
+    socket.setTimeout(timeoutMs, () => settle(false));
+    socket.once("connect", () => settle(true));
+    socket.once("error", () => settle(false)); // ECONNREFUSED — nothing there
+  });
+}
+
+/**
  * Spawn → wait for health → assert the child is still ours → (optionally)
  * version-check. On any failure the sidecar is shut down before rethrowing, so a
  * failed start never leaks a process.
+ *
+ * The port is checked BEFORE the spawn. Without that, the frozen sidecar spends
+ * seconds unpacking before it even attempts its bind, while an incumbent answers
+ * `/health` in milliseconds — so the health wait succeeds, the still-unpacking
+ * child looks alive, and we would hand back a handle for a server we do not own.
+ * `assertOurs` / `assertNotAForeignServer` stay as backstops for the narrower
+ * race where something binds after this check.
  */
 export async function startSidecar(opts: StartOptions): Promise<Sidecar> {
+  const host = opts.host ?? DEFAULT_HOST;
+  const port = opts.port ?? DEFAULT_PORT;
+  if (await portInUse(host, port)) {
+    throw new PortInUseError(
+      `port ${port} on ${host} is already in use, so the gaia sidecar cannot bind ` +
+        "it. Most likely an instance you started earlier is still running. Find it " +
+        "with " +
+        (process.platform === "win32"
+          ? `\`netstat -ano | findstr :${port}\``
+          : `\`lsof -i :${port}\``) +
+        `, then stop it — or start on a different port with --port. Nothing was ` +
+        "spawned.",
+    );
+  }
   const sidecar = spawnSidecar(opts);
   // A sidecar that dies immediately (missing runtime lib, port already bound)
   // must not make the caller wait out the full health timeout.

--- a/hub/agents/gaia/npm/test/cli.test.ts
+++ b/hub/agents/gaia/npm/test/cli.test.ts
@@ -2,9 +2,14 @@
 // SPDX-License-Identifier: MIT
 /** Argument parsing, port validation, and the lifecycle layer's name contracts. */
 
-import { describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
+import fs from "node:fs";
+import fsp from "node:fs/promises";
+import os from "node:os";
 import path from "node:path";
+
+import { PlatformError } from "../src/errors.js";
 
 import { UsageError, main, parseArgs, pathWithoutOwnShim, resolvePort } from "../src/cli.js";
 import {
@@ -77,6 +82,13 @@ describe("resolvePort", () => {
       expect(resolvePort(bad)).toHaveProperty("error");
     }
   });
+
+  it("refuses anything Number() would coerce behind the user's back", () => {
+    // `Number("0x2710")` is 10000 — a typo would have bound a port never named.
+    for (const bad of ["0x2710", " 80 ", "1e3", "+80", "80\n", "0b1010", ""]) {
+      expect(resolvePort(bad)).toHaveProperty("error");
+    }
+  });
 });
 
 describe("executable names", () => {
@@ -102,18 +114,53 @@ describe("contract constants", () => {
 
 describe("pathWithoutOwnShim", () => {
   const sep = process.platform === "win32" ? ";" : ":";
+  let tmp: string;
+  const resolveAll = (p: string): string[] => p.split(sep).map((d) => path.resolve(d));
 
-  it("removes the directory holding our own `gaia` shim", () => {
+  beforeEach(async () => {
+    tmp = await fsp.mkdtemp(path.join(os.tmpdir(), "gaia-shim-"));
+  });
+  afterEach(async () => {
+    await fsp.rm(tmp, { recursive: true, force: true });
+  });
+
+  /** A bin dir containing exactly `names`, plus the path of its `gaia` entry. */
+  function binDir(name: string, names: string[]): { dir: string; argv1: string } {
+    const dir = path.join(tmp, name);
+    fs.mkdirSync(dir, { recursive: true });
+    for (const n of names) fs.writeFileSync(path.join(dir, n), "");
+    return { dir, argv1: path.join(dir, "gaia") };
+  }
+
+  it("drops a dir holding nothing but our own shim (an npx temp dir)", () => {
     // The TUI starts the daemon by resolving `gaia` on PATH, expecting the
     // PYTHON CLI. Our npm shim has the same name; left on PATH it would win and
     // the TUI would re-invoke us with `daemon start`.
-    const shimDir = path.resolve("/tmp/npm/bin");
-    const argv1 = path.join(shimDir, "gaia");
-    const raw = [shimDir, path.resolve("/usr/local/bin"), path.resolve("/usr/bin")].join(sep);
-    const out = pathWithoutOwnShim(raw, argv1)!.split(sep).map((d) => path.resolve(d));
-    expect(out).not.toContain(shimDir);
+    const { dir, argv1 } = binDir("npx-cache", ["gaia", "gaia.cmd", "gaia.ps1"]);
+    const raw = [dir, path.resolve("/usr/local/bin"), path.resolve("/usr/bin")].join(sep);
+    const out = resolveAll(pathWithoutOwnShim(raw, argv1)!);
+    expect(out).not.toContain(path.resolve(dir));
     expect(out).toContain(path.resolve("/usr/local/bin"));
     expect(out).toContain(path.resolve("/usr/bin"));
+  });
+
+  it("KEEPS a shared bin dir, so its other executables stay reachable", () => {
+    // Homebrew/pipx layout: our shim shares /opt/homebrew/bin (or ~/.local/bin)
+    // with python3, git, and lemonade-server. Dropping the directory took those
+    // off the child's PATH and the TUI then reported failures we had caused.
+    const { dir, argv1 } = binDir("shared-bin", ["gaia", "python3", "lemonade-server"]);
+    const raw = [dir, path.resolve("/usr/bin")].join(sep);
+    const out = resolveAll(pathWithoutOwnShim(raw, argv1)!);
+    expect(out).toContain(path.resolve(dir));
+    expect(out).toContain(path.resolve("/usr/bin"));
+  });
+
+  it("moves a shared bin dir LAST, so any other `gaia` on PATH wins", () => {
+    const { dir, argv1 } = binDir("shared-order", ["gaia", "python3"]);
+    const realCli = path.resolve("/opt/venv/bin");
+    const out = resolveAll(pathWithoutOwnShim([dir, realCli].join(sep), argv1)!);
+    expect(out.indexOf(realCli)).toBeLessThan(out.indexOf(path.resolve(dir)));
+    expect(out[out.length - 1]).toBe(path.resolve(dir));
   });
 
   it("leaves a PATH that does not contain our shim dir untouched", () => {
@@ -162,5 +209,79 @@ describe("main dispatch", () => {
     for (const argv of [["--help"], ["-h"], ["help"], ["fetch", "--help"]]) {
       await expect(main(argv)).resolves.toBe(0);
     }
+  });
+});
+
+describe("value flags a command would ignore", () => {
+  // Parsing a flag the command never reads is worse than refusing it: the user
+  // asked for something and got the default without being told.
+  const IGNORED: ReadonlyArray<[string, string[]]> = [
+    ["--port", ["run", "--port", "9000"]],
+    ["--port", ["fetch", "--port", "9000"]],
+    ["--component", ["run", "--component", "tui"]],
+    ["--component", ["serve", "--component", "tui"]],
+    ["--cache-dir", ["serve", "--cache-dir", "/tmp/x"]],
+    ["--base-url", ["version", "--base-url", "https://mirror.test/x"]],
+  ];
+
+  for (const [flag, argv] of IGNORED) {
+    it(`refuses ${flag} for \`gaia ${argv[0]}\` instead of dropping it`, async () => {
+      const p = main(argv);
+      await expect(p).rejects.toBeInstanceOf(UsageError);
+      await expect(p).rejects.toThrow(new RegExp(`${flag} is not valid`));
+      // The message must say where the flag DOES work, not just that it failed.
+      await expect(p).rejects.toThrow(/accepted by/);
+    });
+  }
+
+  it("still accepts each flag on the command that reads it", () => {
+    // Parse-level only; the commands themselves need the network.
+    expect(parseArgs(["serve", "--port", "9000"]).flags["port"]).toBe("9000");
+    expect(parseArgs(["fetch", "--component", "tui"]).flags["component"]).toBe("tui");
+  });
+});
+
+describe("--base-url scheme", () => {
+  it("REFUSES a plaintext base URL, naming the opt-out", async () => {
+    const p = main(["fetch", "--base-url", "http://mirror.internal/gaia"]);
+    await expect(p).rejects.toBeInstanceOf(UsageError);
+    await expect(p).rejects.toThrow(/https/);
+    await expect(p).rejects.toThrow(/--allow-insecure-base-url/);
+  });
+
+  it("refuses a value that is not a URL at all", async () => {
+    await expect(main(["fetch", "--base-url", "mirror.internal/gaia"])).rejects.toThrow(
+      /not a valid absolute URL/,
+    );
+  });
+
+  it("allows plaintext once the opt-out is explicit", async () => {
+    // Gets past the scheme gate and fails later, on the platform lookup — which
+    // is a PlatformError, not a UsageError, and needs no network.
+    const p = main([
+      "fetch",
+      "--base-url",
+      "http://mirror.internal/gaia",
+      "--allow-insecure-base-url",
+      "--component",
+      "sidecar",
+      "--platform",
+      "linux-arm64",
+    ]);
+    await expect(p).rejects.toBeInstanceOf(PlatformError);
+    await expect(p).rejects.toThrow(/linux-arm64/);
+  });
+
+  it("accepts https without the opt-out", async () => {
+    const p = main([
+      "fetch",
+      "--base-url",
+      "https://mirror.internal/gaia",
+      "--component",
+      "sidecar",
+      "--platform",
+      "linux-arm64",
+    ]);
+    await expect(p).rejects.toBeInstanceOf(PlatformError);
   });
 });

--- a/hub/agents/gaia/npm/test/fetch.test.ts
+++ b/hub/agents/gaia/npm/test/fetch.test.ts
@@ -18,8 +18,19 @@ import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import { IntegrityError, PlatformError } from "../src/errors.js";
-import { fetchAll, fetchBinary, verifySha256 } from "../src/fetch.js";
-import { SIDECAR_BASE, TUI_BASE, makeLock, writeLockFile } from "./helpers.js";
+import {
+  INSTALLED_SENTINEL_NAME,
+  fetchAll,
+  fetchBinary,
+  verifySha256,
+} from "../src/fetch.js";
+import {
+  SIDECAR_BASE,
+  SIDECAR_VERSION,
+  TUI_BASE,
+  makeLock,
+  writeLockFile,
+} from "./helpers.js";
 
 const SIDECAR_BYTES = Buffer.from("#!/fake-frozen-gaia-agent\n");
 const TUI_BYTES = Buffer.from("#!/fake-gaia-tui\n");
@@ -345,5 +356,116 @@ describe("fetchAll", () => {
       }),
     ).rejects.toBeInstanceOf(IntegrityError);
     expect(fs.existsSync(path.join(tuiDir, "gaia-tui"))).toBe(false);
+  });
+});
+
+describe("the .installed sentinel", () => {
+  /** Read the sentinel the daemon and the TUI both key "installed" on. */
+  function readSentinel(outDir: string): Record<string, unknown> {
+    const raw = fs.readFileSync(path.join(outDir, INSTALLED_SENTINEL_NAME), "utf8");
+    return JSON.parse(raw) as Record<string, unknown>;
+  }
+
+  async function installSidecar(outDir: string): Promise<string> {
+    const lockPath = await realShaLock();
+    const res = await fetchBinary({
+      component: "sidecar",
+      outDir,
+      platformKey: "linux-x64",
+      lockPath,
+      fetchImpl: recordingFetch(BODIES),
+    });
+    return res.sha256;
+  }
+
+  it("is written on a fresh install, in the shape the daemon requires", async () => {
+    // Staging a verified binary is only half an install: without this file the
+    // daemon sees nothing installed and the TUI runs the REST sidecar over
+    // stdio, filling the chat with uvicorn's startup log.
+    const outDir = path.join(tmp, "agents", "gaia");
+    await installSidecar(outDir);
+    const s = readSentinel(outDir);
+    // gaia/daemon/sidecars/fetch.py::_hub_installed_binary rejects the install
+    // unless all three of these hold.
+    expect(s["artifact_kind"]).toBe("binary");
+    expect(s["executable"]).toBe("gaia-agent");
+    expect(s["artifact_sha256"]).toBe(SIDECAR_SHA);
+    expect(s["id"]).toBe("gaia");
+    expect(s["language"]).toBe("python");
+    expect(s["version"]).toBe(SIDECAR_VERSION);
+    expect(s["path"]).toBe(outDir);
+    expect(Number.isNaN(Date.parse(String(s["installed_at"])))).toBe(false);
+  });
+
+  it("records the sha the daemon will re-hash the binary against", async () => {
+    // A wrong hash here is an IntegrityError at daemon start, not a no-op.
+    const outDir = path.join(tmp, "agents", "gaia");
+    await installSidecar(outDir);
+    const onDisk = crypto
+      .createHash("sha256")
+      .update(fs.readFileSync(path.join(outDir, "gaia-agent")))
+      .digest("hex");
+    expect(readSentinel(outDir)["artifact_sha256"]).toBe(onDisk);
+  });
+
+  it("keeps `executable` a bare filename", () => {
+    // installer.read_sentinel discards a sentinel whose executable contains a
+    // separator, which silently un-installs the agent.
+    const outDir = path.join(tmp, "agents", "gaia");
+    return installSidecar(outDir).then(() => {
+      const exe = String(readSentinel(outDir)["executable"]);
+      expect(exe).not.toContain("/");
+      expect(exe).not.toContain("\\");
+      expect(path.basename(exe)).toBe(exe);
+    });
+  });
+
+  it("is written on a CACHE HIT too, repairing an older sentinel-less install", async () => {
+    // Users who already ran an earlier npx have a verified binary and no
+    // sentinel; if we only wrote on download they would stay broken forever.
+    const outDir = path.join(tmp, "agents", "gaia");
+    await installSidecar(outDir);
+    fs.rmSync(path.join(outDir, INSTALLED_SENTINEL_NAME));
+
+    const lockPath = await realShaLock();
+    urls.length = 0;
+    const res = await fetchBinary({
+      component: "sidecar",
+      outDir,
+      platformKey: "linux-x64",
+      lockPath,
+      fetchImpl: recordingFetch(BODIES),
+    });
+    expect(res.cached).toBe(true);
+    expect(urls).toEqual([]); // proves it really was the cache path
+    expect(readSentinel(outDir)["artifact_sha256"]).toBe(SIDECAR_SHA);
+  });
+
+  it("is NOT written for the tui, which is not a hub agent", async () => {
+    const outDir = path.join(tmp, "cache");
+    const lockPath = await realShaLock();
+    await fetchBinary({
+      component: "tui",
+      outDir,
+      platformKey: "linux-x64",
+      lockPath,
+      fetchImpl: recordingFetch(BODIES),
+    });
+    expect(fs.existsSync(path.join(outDir, INSTALLED_SENTINEL_NAME))).toBe(false);
+  });
+
+  it("fetchAll leaves one for the sidecar and none for the tui", async () => {
+    const lockPath = await realShaLock();
+    const sidecarDir = path.join(tmp, "agents", "gaia");
+    const tuiDir = path.join(tmp, "cache");
+    await fetchAll({
+      lockPath,
+      platformKey: "linux-x64",
+      sidecarDir,
+      tuiDir,
+      fetchImpl: recordingFetch(BODIES),
+    });
+    expect(fs.existsSync(path.join(sidecarDir, INSTALLED_SENTINEL_NAME))).toBe(true);
+    expect(fs.existsSync(path.join(tuiDir, INSTALLED_SENTINEL_NAME))).toBe(false);
   });
 });

--- a/hub/agents/gaia/npm/test/fetch.test.ts
+++ b/hub/agents/gaia/npm/test/fetch.test.ts
@@ -15,13 +15,15 @@ import fsp from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { IntegrityError, PlatformError } from "../src/errors.js";
+import { TUI_ARTIFACT_NAMES } from "../src/platform.js";
 import {
   INSTALLED_SENTINEL_NAME,
   fetchAll,
   fetchBinary,
+  fileSha256,
   verifySha256,
 } from "../src/fetch.js";
 import {
@@ -360,6 +362,16 @@ describe("fetchAll", () => {
 });
 
 describe("the .installed sentinel", () => {
+  // A sentinel records a LOCAL install, so these must run against the host's own
+  // platform — the default when no platformKey is passed.
+  const HOST_KEY = `${process.platform}-${process.arch}`;
+  const WIN = process.platform === "win32";
+  const HOST_EXE = WIN ? "gaia-agent.exe" : "gaia-agent";
+  const HOST_BODIES: Record<string, Buffer> = {
+    [`gaia-agent-${HOST_KEY}${WIN ? ".exe" : ""}`]: SIDECAR_BYTES,
+    [TUI_ARTIFACT_NAMES[HOST_KEY]!]: TUI_BYTES,
+  };
+
   /** Read the sentinel the daemon and the TUI both key "installed" on. */
   function readSentinel(outDir: string): Record<string, unknown> {
     const raw = fs.readFileSync(path.join(outDir, INSTALLED_SENTINEL_NAME), "utf8");
@@ -371,9 +383,8 @@ describe("the .installed sentinel", () => {
     const res = await fetchBinary({
       component: "sidecar",
       outDir,
-      platformKey: "linux-x64",
       lockPath,
-      fetchImpl: recordingFetch(BODIES),
+      fetchImpl: recordingFetch(HOST_BODIES),
     });
     return res.sha256;
   }
@@ -388,7 +399,7 @@ describe("the .installed sentinel", () => {
     // gaia/daemon/sidecars/fetch.py::_hub_installed_binary rejects the install
     // unless all three of these hold.
     expect(s["artifact_kind"]).toBe("binary");
-    expect(s["executable"]).toBe("gaia-agent");
+    expect(s["executable"]).toBe(HOST_EXE);
     expect(s["artifact_sha256"]).toBe(SIDECAR_SHA);
     expect(s["id"]).toBe("gaia");
     expect(s["language"]).toBe("python");
@@ -403,7 +414,7 @@ describe("the .installed sentinel", () => {
     await installSidecar(outDir);
     const onDisk = crypto
       .createHash("sha256")
-      .update(fs.readFileSync(path.join(outDir, "gaia-agent")))
+      .update(fs.readFileSync(path.join(outDir, HOST_EXE)))
       .digest("hex");
     expect(readSentinel(outDir)["artifact_sha256"]).toBe(onDisk);
   });
@@ -426,15 +437,13 @@ describe("the .installed sentinel", () => {
     const outDir = path.join(tmp, "agents", "gaia");
     await installSidecar(outDir);
     fs.rmSync(path.join(outDir, INSTALLED_SENTINEL_NAME));
-
     const lockPath = await realShaLock();
     urls.length = 0;
     const res = await fetchBinary({
       component: "sidecar",
       outDir,
-      platformKey: "linux-x64",
       lockPath,
-      fetchImpl: recordingFetch(BODIES),
+      fetchImpl: recordingFetch(HOST_BODIES),
     });
     expect(res.cached).toBe(true);
     expect(urls).toEqual([]); // proves it really was the cache path
@@ -447,9 +456,8 @@ describe("the .installed sentinel", () => {
     await fetchBinary({
       component: "tui",
       outDir,
-      platformKey: "linux-x64",
       lockPath,
-      fetchImpl: recordingFetch(BODIES),
+      fetchImpl: recordingFetch(HOST_BODIES),
     });
     expect(fs.existsSync(path.join(outDir, INSTALLED_SENTINEL_NAME))).toBe(false);
   });
@@ -460,12 +468,105 @@ describe("the .installed sentinel", () => {
     const tuiDir = path.join(tmp, "cache");
     await fetchAll({
       lockPath,
-      platformKey: "linux-x64",
       sidecarDir,
       tuiDir,
-      fetchImpl: recordingFetch(BODIES),
+      fetchImpl: recordingFetch(HOST_BODIES),
     });
     expect(fs.existsSync(path.join(sidecarDir, INSTALLED_SENTINEL_NAME))).toBe(true);
     expect(fs.existsSync(path.join(tuiDir, INSTALLED_SENTINEL_NAME))).toBe(false);
+  });
+});
+
+describe("a cross-platform fetch is not a local install", () => {
+  // `--platform` stages a binary for a DIFFERENT host. Recording it as installed
+  // hands the daemon a wrong-arch executable that re-hashes correctly and then
+  // fails to exec; before the sentinel existed that fetch was inert.
+  const HOST_KEY = `${process.platform}-${process.arch}`;
+  const FOREIGN = HOST_KEY === "linux-x64" ? "win32-x64" : "linux-x64";
+  const FOREIGN_FILE = `gaia-agent-${FOREIGN}${FOREIGN.startsWith("win32") ? ".exe" : ""}`;
+  const FOREIGN_EXE = FOREIGN.startsWith("win32") ? "gaia-agent.exe" : "gaia-agent";
+
+  it("writes the binary but NO sentinel for another platform", async () => {
+    const lockPath = await realShaLock();
+    const outDir = path.join(tmp, "agents", "gaia");
+    const res = await fetchBinary({
+      component: "sidecar",
+      outDir,
+      platformKey: FOREIGN,
+      lockPath,
+      fetchImpl: recordingFetch({ [FOREIGN_FILE]: SIDECAR_BYTES }),
+    });
+    expect(res.platformKey).toBe(FOREIGN);
+    expect(fs.existsSync(path.join(outDir, FOREIGN_EXE))).toBe(true);
+    expect(fs.existsSync(path.join(outDir, INSTALLED_SENTINEL_NAME))).toBe(false);
+  });
+
+  it("does not write one on a cross-platform CACHE HIT either", async () => {
+    const lockPath = await realShaLock();
+    const outDir = path.join(tmp, "agents", "gaia");
+    const opts = {
+      component: "sidecar" as const,
+      outDir,
+      platformKey: FOREIGN,
+      lockPath,
+      fetchImpl: recordingFetch({ [FOREIGN_FILE]: SIDECAR_BYTES }),
+    };
+    await fetchBinary(opts);
+    const again = await fetchBinary(opts);
+    expect(again.cached).toBe(true);
+    expect(fs.existsSync(path.join(outDir, INSTALLED_SENTINEL_NAME))).toBe(false);
+  });
+});
+
+describe("fileSha256", () => {
+  it("returns null for an absent file, not an error", async () => {
+    expect(await fileSha256(path.join(tmp, "nope"))).toBeNull();
+  });
+
+  it("re-raises anything that is not ENOENT", async () => {
+    // A directory in the way must not read as "no cache" — that would trigger a
+    // re-download which then fails on write with a far less useful message.
+    const dir = path.join(tmp, "a-directory");
+    fs.mkdirSync(dir);
+    await expect(fileSha256(dir)).rejects.toThrow(/cannot read the cached binary/);
+  });
+
+  it("hashes a file larger than one read chunk correctly", async () => {
+    // The cache-hit path runs this on a ~200MB binary on every `gaia run`, so it
+    // reads in bounded chunks; a single-chunk implementation would hash only the
+    // first 1MB and silently accept a tampered tail.
+    const big = path.join(tmp, "big.bin");
+    const chunk = Buffer.alloc(1 << 20, 0xab);
+    const tail = Buffer.from("DISTINCT-TAIL");
+    fs.writeFileSync(big, Buffer.concat([chunk, chunk, chunk, tail]));
+    const expected = crypto
+      .createHash("sha256")
+      .update(fs.readFileSync(big))
+      .digest("hex");
+    expect(await fileSha256(big)).toBe(expected);
+  });
+
+  it("never buffers the whole file", async () => {
+    // The property, not just the result: `readFile` allocates the entire ~200MB
+    // binary on every cache hit, which is the peak the streaming download was
+    // supposed to have removed. Correctness alone cannot tell the two apart.
+    const file = path.join(tmp, "chunked.bin");
+    fs.writeFileSync(file, Buffer.alloc((1 << 20) * 3, 0x5a));
+    const readFile = vi.spyOn(fsp, "readFile");
+    try {
+      expect(await fileSha256(file)).toHaveLength(64);
+      expect(readFile).not.toHaveBeenCalled();
+    } finally {
+      readFile.mockRestore();
+    }
+  });
+
+  it("notices a change in the LAST chunk", async () => {
+    const a = path.join(tmp, "a.bin");
+    const b = path.join(tmp, "b.bin");
+    const head = Buffer.alloc((1 << 20) * 2, 7);
+    fs.writeFileSync(a, Buffer.concat([head, Buffer.from("one")]));
+    fs.writeFileSync(b, Buffer.concat([head, Buffer.from("two")]));
+    expect(await fileSha256(a)).not.toBe(await fileSha256(b));
   });
 });

--- a/hub/agents/gaia/npm/test/lifecycle.test.ts
+++ b/hub/agents/gaia/npm/test/lifecycle.test.ts
@@ -77,7 +77,7 @@ async function stubSidecar(
  * down deterministically. Returns the port so a spawn can be aimed at it.
  */
 async function stubSidecarOnPort(
-  opts: { versionDelayMs?: number; healthBody?: unknown } = {},
+  opts: { versionDelayMs?: number; healthDelayMs?: number; healthBody?: unknown } = {},
 ): Promise<{ baseUrl: string; port: number }> {
   const http = await import("node:http");
   const server = http.createServer((req, res) => {
@@ -88,7 +88,10 @@ async function stubSidecarOnPort(
       }, delayMs);
     };
     if (req.url === "/health")
-      return send(opts.healthBody ?? { status: "ok", service: "not-ours" });
+      return send(
+        opts.healthBody ?? { status: "ok", service: "not-ours" },
+        opts.healthDelayMs ?? 0,
+      );
     if (req.url === "/version")
       return send({ apiVersion: API_VERSION, agentVersion: "9.9.9" }, opts.versionDelayMs ?? 0);
     res.writeHead(404).end();
@@ -264,6 +267,22 @@ describe("startSidecar vs a FOREIGN server already on the port", () => {
     });
     await expect(p).rejects.toBeInstanceOf(SidecarExitedError);
     await expect(p).rejects.toThrow(new RegExp(`port ${port}`));
+    await expect(p).rejects.toThrow(/another process is already bound/);
+  }, 30_000);
+
+  // Whether the incumbent's reply or our child's death reaches startSidecar
+  // first is a race, and CI on Linux lost it where Windows won: the port
+  // conflict reported as a plain HealthTimeoutError. Delaying /health past the
+  // child's exit pins the losing order on every platform.
+  it("still names the port conflict when the child's death wins the race", async () => {
+    const { port } = await stubSidecarOnPort({ healthDelayMs: 400 });
+    const p = startSidecar({
+      binaryPath: diesInstantly(),
+      port,
+      autoCleanup: false,
+      healthTimeoutMs: 20_000,
+    });
+    await expect(p).rejects.toBeInstanceOf(SidecarExitedError);
     await expect(p).rejects.toThrow(/another process is already bound/);
   }, 30_000);
 

--- a/hub/agents/gaia/npm/test/lifecycle.test.ts
+++ b/hub/agents/gaia/npm/test/lifecycle.test.ts
@@ -6,6 +6,7 @@
  * tests exercise real process management rather than a mock.
  */
 
+import crypto from "node:crypto";
 import fs from "node:fs";
 import fsp from "node:fs/promises";
 import net from "node:net";
@@ -16,21 +17,28 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import {
   BinaryNotFoundError,
+  GaiaError,
   HealthTimeoutError,
+  IntegrityError,
+  MalformedResponseError,
+  SidecarExitedError,
   VersionMismatchError,
 } from "../src/errors.js";
 import {
   API_VERSION,
   RESERVED_PORT,
   checkVersion,
+  health,
   resolveSidecarPath,
   resolveTuiPath,
   runTui,
   shutdown,
   spawnSidecar,
   startSidecar,
+  tuiExecutableName,
   waitForHealth,
 } from "../src/lifecycle.js";
+import { makeLock } from "./helpers.js";
 
 let tmp: string;
 const servers: net.Server[] = [];
@@ -63,6 +71,55 @@ async function stubSidecar(
   const addr = server.address() as net.AddressInfo;
   return `http://127.0.0.1:${addr.port}`;
 }
+
+/**
+ * A stub sidecar on a known port, with per-route delays so a race can be pinned
+ * down deterministically. Returns the port so a spawn can be aimed at it.
+ */
+async function stubSidecarOnPort(
+  opts: { versionDelayMs?: number; healthBody?: unknown } = {},
+): Promise<{ baseUrl: string; port: number }> {
+  const http = await import("node:http");
+  const server = http.createServer((req, res) => {
+    const send = (v: unknown, delayMs = 0): void => {
+      setTimeout(() => {
+        res.writeHead(200, { "content-type": "application/json" });
+        res.end(JSON.stringify(v));
+      }, delayMs);
+    };
+    if (req.url === "/health")
+      return send(opts.healthBody ?? { status: "ok", service: "not-ours" });
+    if (req.url === "/version")
+      return send({ apiVersion: API_VERSION, agentVersion: "9.9.9" }, opts.versionDelayMs ?? 0);
+    res.writeHead(404).end();
+  });
+  servers.push(server);
+  await new Promise<void>((r) => server.listen(0, "127.0.0.1", r));
+  const { port } = server.address() as net.AddressInfo;
+  return { baseUrl: `http://127.0.0.1:${port}`, port };
+}
+
+/** An HTTP server that answers 200 with a body that is NOT JSON. */
+async function stubHtml(): Promise<string> {
+  const http = await import("node:http");
+  const server = http.createServer((_req, res) => {
+    res.writeHead(200, { "content-type": "text/html" });
+    res.end("<html><body>502 Bad Gateway (corporate proxy)</body></html>");
+  });
+  servers.push(server);
+  await new Promise<void>((r) => server.listen(0, "127.0.0.1", r));
+  return `http://127.0.0.1:${(server.address() as net.AddressInfo).port}`;
+}
+
+/**
+ * A binary that is guaranteed to die instantly on every platform: `node` rejects
+ * the `--host`/`--port` that spawnSidecar puts first ("bad option") and exits 9
+ * in ~25ms. Unlike `fakeBinary` this needs no shell wrapper, so it runs on
+ * Windows too.
+ */
+const diesInstantly = (): string => process.execPath;
+
+const sleepFor = (ms: number): Promise<void> => new Promise((r) => setTimeout(r, ms));
 
 /** Write a Node script and return its path (not itself spawnable). */
 async function script(name: string, js: string): Promise<string> {
@@ -192,6 +249,125 @@ posixOnly("shutdown", () => {
   }, 20_000);
 });
 
+describe("startSidecar vs a FOREIGN server already on the port", () => {
+  it("refuses a handle whose own child is dead, naming the port", async () => {
+    // The failure this reproduces: a second `gaia serve` finds 8141 already
+    // bound, its own sidecar dies, but the incumbent answers /health and
+    // /version — so startSidecar used to hand back a handle it did not own, and
+    // shutdown then logged "already exited" while the real server kept running.
+    const { port } = await stubSidecarOnPort({ versionDelayMs: 750 });
+    const p = startSidecar({
+      binaryPath: diesInstantly(),
+      port,
+      autoCleanup: false,
+      healthTimeoutMs: 20_000,
+    });
+    await expect(p).rejects.toBeInstanceOf(SidecarExitedError);
+    await expect(p).rejects.toThrow(new RegExp(`port ${port}`));
+    await expect(p).rejects.toThrow(/another process is already bound/);
+  }, 30_000);
+
+  it("reports a SidecarExitedError as a GaiaError, so the CLI formats it", async () => {
+    const { port } = await stubSidecarOnPort({ versionDelayMs: 750 });
+    await expect(
+      startSidecar({
+        binaryPath: diesInstantly(),
+        port,
+        autoCleanup: false,
+        healthTimeoutMs: 20_000,
+      }),
+    ).rejects.toBeInstanceOf(GaiaError);
+  }, 30_000);
+});
+
+describe("non-JSON responses", () => {
+  it("raises a GaiaError, not a bare SyntaxError, for a 200 that is HTML", async () => {
+    // A proxy answering 200 with an error page used to escape the CLI's
+    // `instanceof GaiaError` branch and print a raw stack.
+    const baseUrl = await stubHtml();
+    const p = health(baseUrl);
+    await expect(p).rejects.toBeInstanceOf(MalformedResponseError);
+    await expect(p).rejects.toBeInstanceOf(GaiaError);
+    await expect(p).rejects.toThrow(/not JSON/);
+  });
+
+  it("keeps polling rather than crashing when health is not JSON", async () => {
+    const baseUrl = await stubHtml();
+    await expect(
+      waitForHealth(baseUrl, { timeoutMs: 300, intervalMs: 50 }),
+    ).rejects.toBeInstanceOf(HealthTimeoutError);
+  });
+});
+
+describe("auto-cleanup registration", () => {
+  it("installs the process-level reapers by default", () => {
+    // autoCleanup defaults true, but every spawning test passed false, so none
+    // of installCleanupHandlers/registerForCleanup ever ran under test.
+    const sidecar = spawnSidecar({ binaryPath: diesInstantly(), port: 8195 });
+    try {
+      expect(process.listenerCount("exit")).toBeGreaterThan(0);
+      for (const sig of ["SIGINT", "SIGTERM", "SIGHUP"] as const) {
+        expect(process.listenerCount(sig)).toBeGreaterThan(0);
+      }
+    } finally {
+      sidecar.child.kill("SIGKILL");
+    }
+  });
+});
+
+posixOnly("auto-cleanup ownership", () => {
+  /**
+   * A live sidecar registered for auto-cleanup, torn down whatever happens.
+   * Needs a surrogate that ignores --host/--port and stays up, which on Windows
+   * would require a real .exe fixture.
+   */
+  async function withLiveSidecar(
+    port: number,
+    body: (s: ReturnType<typeof spawnSidecar>) => Promise<void>,
+  ): Promise<void> {
+    const bin = await fakeBinary(`live-${port}`, "setInterval(() => {}, 1000)");
+    const sidecar = spawnSidecar({ binaryPath: bin, port });
+    try {
+      await body(sidecar);
+    } finally {
+      await shutdown(sidecar, 10_000).catch(() => undefined);
+    }
+  }
+
+  it("does NOT reap the sidecar when the HOST app owns the signal", async () => {
+    // Importing this library must not change what a host's own SIGINT handler
+    // means. It used to: the reap ran before the ownership check, so a
+    // host-handled signal killed the sidecar and its next request got an
+    // unexplained ECONNREFUSED.
+    await withLiveSidecar(8194, async (sidecar) => {
+      const hostHandler = (): void => {};
+      process.on("SIGINT", hostHandler);
+      try {
+        process.emit("SIGINT");
+        await sleepFor(400);
+      } finally {
+        process.removeListener("SIGINT", hostHandler);
+      }
+      expect(sidecar.child.exitCode).toBeNull();
+      expect(sidecar.child.signalCode).toBeNull();
+    });
+  }, 30_000);
+
+  it("de-registers only once the child has actually exited", async () => {
+    // shutdown() used to de-register up front, so a sidecar that survived both
+    // kill windows became a permanent orphan: it threw correctly but was gone
+    // from the set the process-exit backstop reaps. The survivor branch itself
+    // cannot be tested — nothing can ignore SIGKILL — so this pins the other
+    // half: a COMPLETED shutdown does de-register, and the child really is gone.
+    await withLiveSidecar(8193, async (sidecar) => {
+      await shutdown(sidecar, 10_000);
+      expect(sidecar.child.exitCode !== null || sidecar.child.signalCode !== null).toBe(
+        true,
+      );
+    });
+  }, 30_000);
+});
+
 posixOnly("startSidecar", () => {
   it("gives up as soon as the process dies instead of waiting out the health timeout", async () => {
     const bin = await fakeBinary("dies", "process.exit(3)");
@@ -246,6 +422,15 @@ describe("runTui", () => {
 });
 
 describe("resolve*Path", () => {
+  const exe = (): string => tuiExecutableName();
+  /** Write a TUI binary and a lock that agrees (or not) with its bytes. */
+  function stage(content: string, lockContent = content): { full: string; lock: ReturnType<typeof makeLock> } {
+    const full = path.join(tmp, exe());
+    fs.writeFileSync(full, content);
+    const sha = crypto.createHash("sha256").update(lockContent).digest("hex");
+    return { full, lock: makeLock(sha) };
+  }
+
   it("throws an actionable BinaryNotFoundError when nothing is fetched yet", () => {
     for (const fn of [resolveSidecarPath, resolveTuiPath]) {
       try {
@@ -258,9 +443,34 @@ describe("resolve*Path", () => {
     }
   });
 
-  it("returns the path once the binary is present", async () => {
-    const exe = process.platform === "win32" ? "gaia-tui.exe" : "gaia-tui";
-    fs.writeFileSync(path.join(tmp, exe), "x");
-    expect(resolveTuiPath({ resourcesDir: tmp })).toBe(path.join(tmp, exe));
+  it("returns the path once the binary is present and matches the lock", () => {
+    const { full, lock } = stage("a verified gaia-tui");
+    expect(resolveTuiPath({ resourcesDir: tmp, lock })).toBe(full);
+  });
+
+  it("REFUSES a binary whose bytes do not match the lock", () => {
+    // fetch.ts calls the SHA verify "the security boundary". This path is
+    // exported and its cache dir is predictable, so anything able to write
+    // ~/.gaia/agents/gaia used to get code spawned unverified.
+    const { full, lock } = stage("tampered", "what the lock pins");
+    try {
+      resolveTuiPath({ resourcesDir: tmp, lock });
+      throw new Error("should have thrown");
+    } catch (e) {
+      expect(e).toBeInstanceOf(IntegrityError);
+      expect((e as Error).message).toContain(full);
+      expect((e as Error).message).toContain("Refusing to spawn");
+    }
+  });
+
+  it("skips the check only when the caller opts out explicitly", () => {
+    const { full, lock } = stage("a self-built binary", "something else");
+    expect(resolveTuiPath({ resourcesDir: tmp, lock, verify: false })).toBe(full);
+  });
+
+  it("refuses a placeholder-hash lock rather than treating it as verified", () => {
+    const { lock } = stage("anything");
+    for (const e of Object.values(lock.components["tui"]!.platforms)) e.sha256 = "0".repeat(64);
+    expect(() => resolveTuiPath({ resourcesDir: tmp, lock })).toThrow(IntegrityError);
   });
 });

--- a/hub/agents/gaia/npm/test/lifecycle.test.ts
+++ b/hub/agents/gaia/npm/test/lifecycle.test.ts
@@ -326,7 +326,12 @@ posixOnly("startSidecar backstops (something binds AFTER the pre-flight)", () =>
    * and an unrelated process takes it before our sidecar binds. Reproduced by a
    * fake sidecar that hands the port to a DETACHED holder and exits — the same
    * shape as the frozen build's uvicorn grandchild. The holder signals readiness
-   * through a file, so the ordering is pinned rather than timed.
+   * through a file so it is listening before the child goes away.
+   *
+   * Which backstop fires is still a race — a probe landing before the child's
+   * exit reaches `assertOurs` directly, one landing after goes through the
+   * re-probe — and both raise the same error, which is the point. Neutering
+   * either alone still passes; neutering both fails this test.
    */
   it("names the port conflict when our child dies and something else answers", async () => {
     const readyFile = path.join(tmp, "holder.ready");

--- a/hub/agents/gaia/npm/test/lifecycle.test.ts
+++ b/hub/agents/gaia/npm/test/lifecycle.test.ts
@@ -21,6 +21,7 @@ import {
   HealthTimeoutError,
   IntegrityError,
   MalformedResponseError,
+  PortInUseError,
   SidecarExitedError,
   VersionMismatchError,
 } from "../src/errors.js";
@@ -123,6 +124,15 @@ async function stubHtml(): Promise<string> {
 const diesInstantly = (): string => process.execPath;
 
 const sleepFor = (ms: number): Promise<void> => new Promise((r) => setTimeout(r, ms));
+
+/** A port that is free right now — bound, read, and released. */
+async function freePort(): Promise<number> {
+  const server = net.createServer();
+  await new Promise<void>((r) => server.listen(0, "127.0.0.1", r));
+  const { port } = server.address() as net.AddressInfo;
+  await new Promise((r) => server.close(r));
+  return port;
+}
 
 /** Write a Node script and return its path (not itself spawnable). */
 async function script(name: string, js: string): Promise<string> {
@@ -253,11 +263,12 @@ posixOnly("shutdown", () => {
 });
 
 describe("startSidecar vs a FOREIGN server already on the port", () => {
-  it("refuses a handle whose own child is dead, naming the port", async () => {
-    // The failure this reproduces: a second `gaia serve` finds 8141 already
-    // bound, its own sidecar dies, but the incumbent answers /health and
-    // /version — so startSidecar used to hand back a handle it did not own, and
-    // shutdown then logged "already exited" while the real server kept running.
+  // The real conflict: a second `gaia serve` finds 8141 already bound. The
+  // incumbent answers /health in milliseconds while our own child — a ~200MB
+  // one-file build — is still unpacking, so it is very much ALIVE at every
+  // post-spawn check. Only a pre-flight probe catches that ordering; the
+  // post-spawn backstops below cover the narrower window after it.
+  it("refuses the start, naming the port, before anything is spawned", async () => {
     const { port } = await stubSidecarOnPort({ versionDelayMs: 750 });
     const p = startSidecar({
       binaryPath: diesInstantly(),
@@ -265,28 +276,38 @@ describe("startSidecar vs a FOREIGN server already on the port", () => {
       autoCleanup: false,
       healthTimeoutMs: 20_000,
     });
-    await expect(p).rejects.toBeInstanceOf(SidecarExitedError);
+    await expect(p).rejects.toBeInstanceOf(PortInUseError);
     await expect(p).rejects.toThrow(new RegExp(`port ${port}`));
-    await expect(p).rejects.toThrow(/another process is already bound/);
+    await expect(p).rejects.toThrow(/already in use/);
   }, 30_000);
 
-  // Whether the incumbent's reply or our child's death reaches startSidecar
-  // first is a race, and CI on Linux lost it where Windows won: the port
-  // conflict reported as a plain HealthTimeoutError. Delaying /health past the
-  // child's exit pins the losing order on every platform.
-  it("still names the port conflict when the child's death wins the race", async () => {
-    const { port } = await stubSidecarOnPort({ healthDelayMs: 400 });
+  it("never spawns a child when the port is taken", async () => {
+    // A binary that does NOT exist: spawnSidecar throws BinaryNotFoundError the
+    // moment it is reached. Getting PortInUseError instead proves the port check
+    // ran first — no process was created, and none could have been.
+    const { port } = await stubSidecarOnPort();
     const p = startSidecar({
-      binaryPath: diesInstantly(),
+      binaryPath: path.join(tmp, "never-created"),
       port,
       autoCleanup: false,
-      healthTimeoutMs: 20_000,
     });
-    await expect(p).rejects.toBeInstanceOf(SidecarExitedError);
-    await expect(p).rejects.toThrow(/another process is already bound/);
+    await expect(p).rejects.toBeInstanceOf(PortInUseError);
+    await expect(p).rejects.not.toBeInstanceOf(BinaryNotFoundError);
   }, 30_000);
 
-  it("reports a SidecarExitedError as a GaiaError, so the CLI formats it", async () => {
+  it("keeps the health-timeout error when the port is genuinely free", async () => {
+    // The pre-flight must not swallow the ordinary "our sidecar never came up"
+    // case: nothing is listening, so this has to reach the health wait.
+    const p = startSidecar({
+      binaryPath: diesInstantly(),
+      port: 8189,
+      autoCleanup: false,
+      healthTimeoutMs: 3_000,
+    });
+    await expect(p).rejects.toBeInstanceOf(HealthTimeoutError);
+  }, 30_000);
+
+  it("reports the conflict as a GaiaError, so the CLI formats it", async () => {
     const { port } = await stubSidecarOnPort({ versionDelayMs: 750 });
     await expect(
       startSidecar({
@@ -297,6 +318,63 @@ describe("startSidecar vs a FOREIGN server already on the port", () => {
       }),
     ).rejects.toBeInstanceOf(GaiaError);
   }, 30_000);
+});
+
+posixOnly("startSidecar backstops (something binds AFTER the pre-flight)", () => {
+  /**
+   * The window the pre-flight cannot cover: the port is free when we probe it,
+   * and an unrelated process takes it before our sidecar binds. Reproduced by a
+   * fake sidecar that hands the port to a DETACHED holder and exits — the same
+   * shape as the frozen build's uvicorn grandchild. The holder signals readiness
+   * through a file, so the ordering is pinned rather than timed.
+   */
+  it("names the port conflict when our child dies and something else answers", async () => {
+    const readyFile = path.join(tmp, "holder.ready");
+    const holder = await script(
+      "holder",
+      `import http from "node:http";
+       import fs from "node:fs";
+       const port = Number(process.argv[2]);
+       const server = http.createServer((_q, s) => {
+         s.writeHead(200, { "content-type": "application/json" });
+         s.end(JSON.stringify({ status: "ok", service: "not-ours" }));
+       });
+       server.listen(port, "127.0.0.1", () => fs.writeFileSync(${JSON.stringify(readyFile)}, String(process.pid)));
+       setTimeout(() => process.exit(0), 20000).unref();`,
+    );
+    const bin = await fakeBinary(
+      "hands-off-port",
+      `import { spawn } from "node:child_process";
+       import fs from "node:fs";
+       const port = process.argv[process.argv.indexOf("--port") + 1];
+       const child = spawn(process.execPath, [${JSON.stringify(holder)}, port], { detached: true, stdio: "ignore" });
+       child.unref();
+       // Exit only once the holder really owns the port — no timing race.
+       const wait = () => fs.existsSync(${JSON.stringify(readyFile)}) ? process.exit(0) : setTimeout(wait, 20);
+       wait();`,
+    );
+
+    const free = await freePort();
+    try {
+      const p = startSidecar({
+        binaryPath: bin,
+        port: free,
+        autoCleanup: false,
+        healthTimeoutMs: 15_000,
+      });
+      await expect(p).rejects.toBeInstanceOf(SidecarExitedError);
+      await expect(p).rejects.toThrow(/another process is already bound/);
+    } finally {
+      if (fs.existsSync(readyFile)) {
+        const pid = Number(fs.readFileSync(readyFile, "utf8"));
+        try {
+          process.kill(pid, "SIGKILL");
+        } catch {
+          /* already gone */
+        }
+      }
+    }
+  }, 40_000);
 });
 
 describe("non-JSON responses", () => {

--- a/hub/agents/gaia/npm/test/url.test.ts
+++ b/hub/agents/gaia/npm/test/url.test.ts
@@ -1,0 +1,58 @@
+// Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: MIT
+/**
+ * URL joining. The slash trimmers were rewritten as linear char scans to kill a
+ * polynomial-ReDoS finding (CodeQL js/polynomial-redos) and had no test at all,
+ * so a regression back to `/\/+$/` would have gone unnoticed.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { joinUrl, stripLeadingSlashes, stripTrailingSlashes } from "../src/url.js";
+
+describe("stripTrailingSlashes", () => {
+  it("removes every trailing slash and nothing else", () => {
+    expect(stripTrailingSlashes("https://h/a/")).toBe("https://h/a");
+    expect(stripTrailingSlashes("https://h/a///")).toBe("https://h/a");
+    expect(stripTrailingSlashes("https://h/a")).toBe("https://h/a");
+  });
+
+  it("leaves interior slashes alone", () => {
+    expect(stripTrailingSlashes("https://h/a/b")).toBe("https://h/a/b");
+  });
+
+  it("collapses an all-slash string to empty", () => {
+    expect(stripTrailingSlashes("////")).toBe("");
+    expect(stripTrailingSlashes("")).toBe("");
+  });
+});
+
+describe("stripLeadingSlashes", () => {
+  it("removes every leading slash and nothing else", () => {
+    expect(stripLeadingSlashes("/a")).toBe("a");
+    expect(stripLeadingSlashes("///a")).toBe("a");
+    expect(stripLeadingSlashes("a")).toBe("a");
+  });
+
+  it("collapses an all-slash string to empty", () => {
+    expect(stripLeadingSlashes("////")).toBe("");
+  });
+});
+
+describe("joinUrl", () => {
+  it("joins with exactly one slash regardless of the input's slashes", () => {
+    for (const base of ["https://h/v1", "https://h/v1/", "https://h/v1///"]) {
+      for (const file of ["gaia-agent", "/gaia-agent", "///gaia-agent"]) {
+        expect(joinUrl(base, file)).toBe("https://h/v1/gaia-agent");
+      }
+    }
+  });
+
+  it("stays linear on a long run of slashes (the ReDoS case)", () => {
+    // The regex forms backtracked polynomially here; a char scan is O(n).
+    const nasty = `https://h/${"/".repeat(50_000)}`;
+    const started = Date.now();
+    expect(joinUrl(nasty, "x")).toBe("https://h/x");
+    expect(Date.now() - started).toBeLessThan(1000);
+  });
+});


### PR DESCRIPTION
Three ways `npx @amd-gaia/gaia` could mislead you, and one reason none of them was caught.

**It reported success for a server it didn't own.** Run `gaia serve` twice: the second sidecar fails to bind 8141 and exits, but the health probe gets an "ok" from the *first* instance and wins the race, so the CLI prints a ready URL for someone else's server. Ctrl+C then reports "already exited" and leaves the real one running.

**It killed your sidecar when your own app handled an error.** The crash and signal handlers reaped before checking whether we own the exit, so a host with its own `uncaughtException` listener — which keeps running by design — lost its sidecar anyway and got an unexplained ECONNREFUSED on the next request. Merely importing this package changed the semantics of the host's error handling.

**It removed your tools from the child's PATH.** Stripping our own `gaia` shim dropped the shim's whole *directory*, so on a Homebrew or `~/.local/bin` layout `python3`, `lemonade-server` and the real `gaia` disappeared — and the TUI then reported "the `gaia` CLI is not on PATH", an error we had caused. A directory holding only our shim is still dropped; a shared one now moves to the end of PATH instead.

**And `gaia run` never finished the job it documents.** It stages a verified binary where the daemon looks, but never wrote the `.installed` record that means "completed install" — so the TUI treated the frozen REST sidecar as its own stdio child and filled the chat with uvicorn's startup log. Writing it also means the daemon supervises the process and mints its caller-auth token, which is the intended path.

The reason all of this shipped: **the package had no PR-time CI at all.** Only the release workflow touched it. That's added here, mirroring the email package's.

Also: the ~200MB download is now streamed and hashed incrementally rather than buffered whole (~400MB RSS peak), with the integrity gate unchanged — unverified bytes still never reach the final path.

<details>
<summary>🔍 Technical details</summary>

- `startSidecar` asserts the child is alive after the health wait, and the caller's abort signal is linked into `getJson` so an in-flight probe aborts the moment the child dies rather than at the next poll.
- `weOwnTheExit()` gates the reap on `listenerCount === 1`; `process.on("exit", reapAllSync)` stays as the backstop.
- Sentinel fields are a cross-repo contract with `InstalledAgent.to_dict()`. It is written on a **cache hit too**, so installs staged by an earlier release repair themselves.
- Smaller fixes: `resolveSidecarPath`/`resolveTuiPath` now verify against `binaries.lock.json` before returning a path to spawn; per-command rejection of `--port`/`--component`/`--cache-dir` where they do nothing; `taskkill` exit code + stderr surfaced; `shutdown` de-registers only on confirmed exit; `cmdServe` removes its signal handlers; `--base-url` requires https (with `--allow-insecure-base-url`); guarded `JSON.parse`; strict-digit port parsing.
- Not fixed, deliberately: no auth token is minted in `spawnSidecar`. That is a behaviour change to a published package and a product decision — raised in #3076.
</details>

## Test plan

- [ ] `cd hub/agents/gaia/npm && npm ci && npm run build && npm test` — 136 pass (101 before)
- [ ] The new CI job runs exactly that on every PR touching `hub/agents/gaia/npm/**`
- [ ] Sentinel accepted by the real consumers, not just shaped like it: writing the exact JSON this emits, then calling `gaia.hub.installer.read_sentinel` and the daemon's `_hub_installed_binary`, returns a verified `FetchResult` (`using hub-installed verified binary … v0.1.1`)
- [ ] Untestable and stated as such rather than papered over: the `taskkill` branches (win32-only, no spawnable long-lived surrogate) and `shutdown`'s survivor path (nothing can ignore SIGKILL)