### PR TITLE
fix(agent-gaia): stop one-shot /query runs leaking an agent each

### DIFF
--- a/hub/agents/gaia/npm/CHANGELOG.md
+++ b/hub/agents/gaia/npm/CHANGELOG.md
@@ -18,6 +18,13 @@ the terminal UI meant building it from source.
   slot is busy and none is idle enough to evict, starting a new session
   returns `503` with the reason in `detail` — retryable, distinct from a
   bug-shaped `500`. See SPEC §5.2.
+- **Three further client-visible refusals from `/query`.** Reusing a `run_id`
+  that is still in flight gets `409` — it used to replace the live run, leaving
+  it with no way to be cancelled. Supplying a `model` that differs from the one
+  the `session_id` was built with gets `409` rather than silently answering on
+  the old model. A request with an absent or empty `Host` header gets `400`
+  rather than being served, closing a DNS-rebinding check that failed open.
+  See SPEC §5 and §5.2.
 - **Per-turn skill-body selection.** A loaded skill stays loaded, but its body
   only renders in the prompt on turns whose query matches its description; the
   rest collapse to a one-line menu the model re-activates with `load_skill`.

--- a/hub/agents/gaia/npm/SKILL.md
+++ b/hub/agents/gaia/npm/SKILL.md
@@ -238,7 +238,7 @@ Request body (`extra: "forbid"` — an unknown field is a **422**, not ignored):
 | `context` | yes | Transcript slice, pushed in the body — may be `[]`, never absent. Each item `{ role, content }`; `role` ∈ `user` / `assistant` / `system` / `tool`. |
 | `session_id` | no | Contract ≥ 2.12. **Pass it.** The agent persists its indexed-document set per session — without it, it forgets a document between the turn that indexed it and the next question. |
 | `can_answer_questions` | no | Set `false` for one-shot / batch runs so the agent resolves ambiguity itself instead of parking on a question nobody can see. |
-| `model` | no | Overrides the model id for this run. |
+| `model` | no | Overrides the model id — only when the run builds a fresh agent. On a retained `session_id` the agent already exists, so a model that differs from the one it was built with is a **409**, not an override. |
 | `provider` | no | Local inference only — anything but `"lemonade"` is a **400**. |
 | `max_steps` | no | ≥ 1. |
 

--- a/hub/agents/gaia/npm/SPEC.md
+++ b/hub/agents/gaia/npm/SPEC.md
@@ -245,6 +245,11 @@ Both defaults are overridable (`--sidecar-dir`, `--cache-dir`).
 
 Served by `gaia_agent.server`. Bound to `127.0.0.1` only.
 
+Every request must carry a loopback `Host` header. A `Host` that is non-loopback,
+absent or empty is refused with `400` before routing — that check is what defeats
+DNS rebinding, so it fails closed rather than serving a request that simply omits
+the header.
+
 | Property           | Value                                   |
 | ------------------ | --------------------------------------- |
 | Default port       | `8141` (`DEFAULT_PORT` in `server.py`)  |
@@ -299,6 +304,14 @@ evicted id gets a fresh agent (the conversation is not blocked) but the
 response stream's first event is a `{"type":"status","status":"warning",...}`
 telling the caller that per-turn state — most visibly any loaded skill — did
 not survive and should be reloaded.
+
+A second `/query` reusing a `run_id` that is still in flight gets `409` —
+`run_id` is caller-minted, so mint a fresh UUID per request; reusing one would
+leave the earlier run with no way to be cancelled. A `/query` supplying a `model`
+that differs from the one its `session_id` was built with also gets `409`: only
+agent construction reads a model, so the request cannot be honoured on the
+retained agent. Omit `model` to continue on the session's current one, or start a
+new `session_id` to switch.
 
 ### 5.3 Version gate
 

--- a/hub/agents/gaia/npm/SPEC.md
+++ b/hub/agents/gaia/npm/SPEC.md
@@ -335,9 +335,11 @@ env-var names and exempt paths onto the shared mechanism in
    sits in the environment — or `GAIA_GAIA_SIDECAR_TOKEN`, the token itself, the
    legacy delivery. A request without it is **401**, with a `detail` naming both
    env vars.
-2. **Host allowlist.** The `Host` header must be loopback (`127.0.0.1`,
-   `localhost`, `::1`); anything else is **400**. This is what defeats DNS
-   rebinding, where the rebound request arrives with `Host: evil.com`.
+2. **Host allowlist.** The `Host` header must be present *and* loopback
+   (`127.0.0.1`, `localhost`, `::1`); anything else — including an absent or
+   empty header — is **400**. This is what defeats DNS rebinding, where the
+   rebound request arrives with `Host: evil.com`, so it fails closed rather
+   than letting a caller opt out by omitting the header.
 3. **Origin rejection.** A request carrying a non-loopback browser `Origin` is
    **403**. Non-browser clients send no `Origin` and are unaffected.
 

--- a/hub/agents/gaia/python/gaia_agent/agent.py
+++ b/hub/agents/gaia/python/gaia_agent/agent.py
@@ -42,7 +42,6 @@ unchanged.
 
 from __future__ import annotations
 
-import logging
 import os
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -57,8 +56,9 @@ from gaia.agents.base.skill_loader import (
 )
 from gaia.agents.tools.code_index_tools import CodeIndexToolsMixin
 from gaia.agents.tools.skill_library_tools import SkillLibraryToolsMixin
+from gaia.logger import get_logger
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 #: Bundled skills ship inside the package so they survive both the wheel and the
 #: frozen sidecar; as ``SKILL_DIRS`` they outrank a same-named user or Claude Code copy.
@@ -207,7 +207,25 @@ class GaiaAgent(ChatAgent, SkillLibraryToolsMixin, CodeIndexToolsMixin):
     )
 
     def __init__(self, config: Optional[GaiaAgentConfig] = None, **kwargs):
+        if config is not None and kwargs:
+            raise TypeError(
+                "GaiaAgent takes either a ready GaiaAgentConfig or the config "
+                f"fields as keyword arguments, not both. Got config= plus "
+                f"{sorted(kwargs)}; those keywords would be silently dropped. "
+                "Set them on the config object, or drop the config= argument."
+            )
         super().__init__(config=config or GaiaAgentConfig(**kwargs))
+
+    def close(self) -> None:
+        """Release this agent's watchers, HTTP session and SQLite handles now.
+
+        ``ChatAgent`` puts that teardown in ``__del__``, which for an instance
+        whose tool registry holds bound methods only runs when the cyclic
+        collector gets to it — far too late for a sidecar that builds an agent
+        per one-shot request. Every step is individually guarded and idempotent,
+        so the later ``__del__`` is harmless.
+        """
+        self.__del__()
 
     def _register_tools(self) -> None:
         """ChatAgent's profile tools, plus runtime access to the skill library.

--- a/hub/agents/gaia/python/gaia_agent/caller_auth.py
+++ b/hub/agents/gaia/python/gaia_agent/caller_auth.py
@@ -2,9 +2,10 @@
 # SPDX-License-Identifier: MIT
 """The flagship sidecar's binding of the shared caller-auth layer.
 
-The mechanism lives in :mod:`gaia.sidecar.caller_auth` and is shared with the
-email sidecar so the two cannot drift. This module supplies only what is
-specific to this agent: which env vars carry the token, and which paths skip it.
+The mechanism lives in :mod:`gaia.sidecar.caller_auth`. This module supplies only
+what is specific to this agent: which env vars carry the token, and which paths
+skip it. The email sidecar still has its own copy of the mechanism rather than
+importing that one, so the two are not yet a single implementation.
 
 This sidecar is the one that most needs the layer — it exposes shell and file
 tools and a bypass-permissions mode, so an unauthenticated loopback port lets
@@ -40,9 +41,16 @@ TOKEN_ENV_VAR = "GAIA_GAIA_SIDECAR_TOKEN"
 
 SURFACE = "GAIA agent sidecar"
 
-# Paths that never require a token: the liveness and version probes a host polls
-# during the attach handshake, before any query is in play. None of them expose
+# The token-free probes a host polls during the attach handshake, before any
+# query is in play: ``/health`` (liveness), ``/version`` (the daemon's contract
+# probe) and ``/v1/gaia/version`` (the TUI's negotiate.go probe). None expose
 # user data or accept work. Host/Origin controls still apply to them.
+#
+# Today all three are registered on the APP, outside the token-guarded router,
+# so they are already tokenless and this set never decides a request. It is the
+# declaration of which paths are public — the mechanism only if one is ever
+# remounted under the router. ``test_caller_auth`` pins both halves of that, so
+# the set cannot quietly drift from the routes it names.
 EXEMPT_PATHS: FrozenSet[str] = frozenset(
     {
         "/health",

--- a/hub/agents/gaia/python/gaia_agent/server.py
+++ b/hub/agents/gaia/python/gaia_agent/server.py
@@ -12,12 +12,13 @@ The event translation itself is NOT reimplemented here — it lives in
 ``gaia.ui.sse_translation.CanonicalTranslator``, shared with the email sidecar,
 so the two agents cannot drift into private dialects of the same contract.
 
-Scope note: this deliberately implements ``/query`` and ``/query/{run_id}/cancel``
-only. ``needs_confirmation`` ends the run with a refusal (the stateless D1 stub,
-same as email) rather than pretending to support server-side resume, and there is
-no ``/respond`` yet — the flagship's tools are read-mostly, so neither gate is
-exercised. Both are additive when a tool needs them; claiming support we haven't
-built would be worse than the honest gap.
+Scope note: the surfaces here are ``/init`` (readiness preflight), ``/query``,
+``/query/{run_id}/cancel`` and ``/query/{run_id}/respond``. ``needs_input`` is
+answered over ``/respond`` on the run's existing stream. ``needs_confirmation``
+is the one gate still unimplemented: it ends the run with a refusal (the
+stateless D1 stub, same as email) rather than pretending to support server-side
+resume. That is additive when a tool needs it; claiming support we haven't built
+would be worse than the honest gap.
 """
 
 from __future__ import annotations
@@ -33,7 +34,7 @@ from typing import Any, Dict, List, Optional
 
 from fastapi import APIRouter, Depends, FastAPI, HTTPException, Request
 from gaia_agent import caller_auth
-from gaia_agent.session_registry import SessionCapacityError
+from gaia_agent.session_registry import SessionCapacityError, close_agent
 from gaia_agent.session_registry import registry as session_registry
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 from starlette.responses import StreamingResponse
@@ -154,20 +155,74 @@ class _QueryRun:
         self.result: Optional[Dict[str, Any]] = None
 
 
+class DuplicateRunError(RuntimeError):
+    """A ``run_id`` already in flight was submitted again.
+
+    ``run_id`` is client-minted, so this is reachable from a client bug. Taking
+    the newer run would make the older one uncancellable and let either stream's
+    teardown drop the other's run-table entry.
+    """
+
+
+#: Cap on remembered cancel-before-start ids. Each is one short string, consumed
+#: the moment its run registers; this only bounds cancels whose run never came.
+_MAX_PRECANCELLED = 256
+
+_MISSING = object()
+
+
 class _RunRegistry:
     """Process-local run table so ``/cancel`` can find a live run."""
 
     def __init__(self) -> None:
         self._runs: Dict[str, _QueryRun] = {}
+        #: run_ids cancelled before their ``/query`` registered. Insertion
+        #: ordered, so the oldest is the one evicted at the cap.
+        self._precancelled: Dict[str, None] = {}
         self._lock = threading.Lock()
 
-    def add(self, run: _QueryRun) -> None:
+    def add(self, run: _QueryRun) -> bool:
+        """Register an in-flight run; returns whether it arrives pre-cancelled.
+
+        Raises :class:`DuplicateRunError` rather than overwriting: the run
+        already under this id is live, and clobbering it strands it.
+        """
         with self._lock:
+            if run.run_id in self._runs:
+                raise DuplicateRunError(
+                    f"run_id {run.run_id} is already running on this sidecar. "
+                    "run_id is minted by the caller, so mint a fresh UUID per "
+                    "request — reusing one would leave the earlier run with no "
+                    "way to be cancelled."
+                )
             self._runs[run.run_id] = run
+            return self._precancelled.pop(run.run_id, _MISSING) is not _MISSING
 
     def get(self, run_id: str) -> Optional[_QueryRun]:
         with self._lock:
             return self._runs.get(run_id)
+
+    def cancel(self, run_id: str) -> bool:
+        """Stop a live run, or remember the cancel for one about to register.
+
+        Returns whether a LIVE run was stopped. An id with no live run stays
+        ``False`` — a cancel racing a run's own completion should not claim to
+        have stopped anything — but the id is tombstoned so that a run which
+        registers *after* this call starts already cancelled. The caller mints
+        ``run_id`` before it POSTs ``/query``, so that ordering is a real race,
+        not a hypothetical one. Consumed on use, so it fires at most once.
+        """
+        with self._lock:
+            run = self._runs.get(run_id)
+            if run is not None:
+                run.cancel_event.set()
+                run.handler.cancelled.set()
+                return True
+            self._precancelled.pop(run_id, None)  # re-insert as newest
+            self._precancelled[run_id] = None
+            while len(self._precancelled) > _MAX_PRECANCELLED:
+                self._precancelled.pop(next(iter(self._precancelled)))
+            return False
 
     def remove(self, run_id: str) -> None:
         with self._lock:
@@ -360,7 +415,7 @@ router = APIRouter(
 
 
 @router.get("/init")
-async def init(response: Any = None) -> Dict[str, Any]:
+async def init() -> Dict[str, Any]:
     """Readiness preflight — the row data the TUI's preflight screen renders.
 
     Unlike ``/health`` (liveness only, never touches the model server) this
@@ -433,6 +488,23 @@ async def query(request: QueryRequest):
 
     handler = SSEOutputHandler()
     session = None
+    #: Set only on the one-shot path. A session agent belongs to the registry
+    #: and must never be closed here.
+    one_shot_agent: Optional[Any] = None
+    #: Whether THIS request owns the run-table entry under its run_id. A request
+    #: that fails before registering must not remove that id: it may belong to
+    #: the live run it collided with.
+    registered = False
+
+    def _unwind_setup() -> None:
+        """Undo the setup done so far, on a path that never reaches the loop."""
+        if registered:
+            _registry.remove(request.run_id)
+        if session is not None:
+            session.run_lock.release()
+        if one_shot_agent is not None:
+            close_agent(one_shot_agent)
+
     try:
         kwargs: Dict[str, Any] = {}
         if request.model:
@@ -456,6 +528,21 @@ async def query(request: QueryRequest):
                         "Cancel that run or wait for it to finish, then retry."
                     ),
                 )
+            if request.model and request.model != session.model_id:
+                # Only construction reads a model, and this session's agent is
+                # already built — running the old one silently would answer a
+                # request the caller did not make.
+                current = session.model_id or "the agent's default model"
+                raise HTTPException(
+                    status_code=409,
+                    detail=(
+                        f"session {request.session_id} is already running "
+                        f"{current}, and a model cannot be switched on a live "
+                        f"session. Start a new session_id to use "
+                        f"{request.model!r}, or omit 'model' to continue on "
+                        "the current one."
+                    ),
+                )
             agent = session.agent
             if session.reclaimed_after_eviction:
                 # Consume once: reset before the warning reaches the caller so
@@ -468,22 +555,17 @@ async def query(request: QueryRequest):
                     AGENT_ID,
                     request.session_id,
                 )
-                handler._emit(
-                    {
-                        "type": "status",
-                        "status": "warning",
-                        "message": (
-                            "This session was reclaimed after being idle or "
-                            "crowded out by other sessions — loaded skills "
-                            "and other per-turn state were reset. Reload any "
-                            "skill you still need."
-                        ),
-                    }
+                handler.print_warning(
+                    "This session was reclaimed after being idle or crowded "
+                    "out by other sessions — loaded skills and other per-turn "
+                    "state were reset. Reload any skill you still need."
                 )
         else:
             # No session handle — a genuine one-shot. Nothing persists past this
-            # turn, and the agent is told so rather than over-promising.
+            # turn, and the agent is told so rather than over-promising. Nothing
+            # else will ever reference it either, so this run owns its teardown.
             agent = build_query_agent(**kwargs)
+            one_shot_agent = agent
         agent.console = handler
         if request.can_answer_questions is False:
             # Nobody is there to answer. Let the loop know so it resolves
@@ -497,26 +579,30 @@ async def query(request: QueryRequest):
             ]
 
         run = _QueryRun(request.run_id, agent, handler)
-        _registry.add(run)
+        precancelled = _registry.add(run)
+        registered = True
         agent._cancel_event = run.cancel_event
+        if precancelled:
+            # A /cancel for this run_id landed before it registered. The loop
+            # checks the flag at its first step boundary, so it stops without
+            # ever calling the model.
+            run.cancel_event.set()
+            handler.cancelled.set()
+    except DuplicateRunError as exc:
+        _unwind_setup()
+        raise HTTPException(status_code=409, detail=str(exc)) from exc
     except HTTPException:
         # Already an actionable status (e.g. the 409 above) — do not relabel it
         # as a generic 500.
-        _registry.remove(request.run_id)
-        if session is not None:
-            session.run_lock.release()
+        _unwind_setup()
         raise
     except SessionCapacityError as exc:
         # Actionable and temporary ("N sessions are already active and none
         # are idle enough to evict") — 503, not a bug-shaped 500.
-        _registry.remove(request.run_id)
-        if session is not None:
-            session.run_lock.release()
+        _unwind_setup()
         raise HTTPException(status_code=503, detail=str(exc)) from exc
     except Exception as exc:
-        _registry.remove(request.run_id)
-        if session is not None:
-            session.run_lock.release()
+        _unwind_setup()
         raise HTTPException(
             status_code=500, detail=f"Failed to start the query run: {exc}"
         ) from exc
@@ -531,15 +617,21 @@ async def query(request: QueryRequest):
                 run.result = agent.process_query(request.query)
         except Exception as exc:  # surface loudly as a terminal error event
             logger.exception("%s /query run failed for run_id=%s", AGENT_ID, run.run_id)
-            handler._emit(
-                {"type": "agent_error", "content": _terminal_error_detail(exc)}
-            )
+            handler.print_error(_terminal_error_detail(exc))
         finally:
             handler.signal_done()
             # Release only after the agent is done touching the instance, so the
             # next turn on this session cannot start mid-run.
             if session is not None:
                 session.run_lock.release()
+            # This thread is the last thing to touch a one-shot agent — the
+            # stream reads only run.result and the handler — so its RAG index,
+            # scratchpad DB and HTTP session go now rather than accumulating one
+            # leaked agent per request for the life of the process. Covers the
+            # client-disconnect path too: the stream sets the cancel flag, which
+            # ends the loop, which lands here.
+            if one_shot_agent is not None:
+                close_agent(one_shot_agent)
 
     thread = threading.Thread(target=_run_agent, daemon=True)
     try:
@@ -548,9 +640,7 @@ async def query(request: QueryRequest):
         # _run_agent never got to run, so its own finally: never fires —
         # release the run_lock here or a thread-exhaustion failure leaves
         # this session_id permanently 409ing for the life of the process.
-        _registry.remove(request.run_id)
-        if session is not None:
-            session.run_lock.release()
+        _unwind_setup()
         raise HTTPException(
             status_code=500, detail=f"Failed to start the query run: {exc}"
         ) from exc
@@ -622,14 +712,15 @@ async def query(request: QueryRequest):
 
 @router.post("/query/{run_id}/cancel", response_model=QueryCancelResponse)
 async def cancel_query(run_id: str) -> QueryCancelResponse:
-    """Ask a live run to stop. Unknown ids report ``cancelled=False``, not 404 —
-    a race between the client's cancel and the run's own completion is normal."""
-    run = _registry.get(run_id)
-    if run is None:
-        return QueryCancelResponse(run_id=run_id, cancelled=False)
-    run.cancel_event.set()
-    run.handler.cancelled.set()
-    return QueryCancelResponse(run_id=run_id, cancelled=True)
+    """Ask a live run to stop.
+
+    Unknown ids report ``cancelled=False``, not 404 — a cancel racing the run's
+    own completion is normal, and reporting it stopped something would be a lie.
+    The id is still remembered, so a run that registers *after* this call starts
+    cancelled: the caller mints ``run_id`` before it POSTs ``/query``, which
+    makes cancel-arrives-first a real ordering, not a hypothetical one.
+    """
+    return QueryCancelResponse(run_id=run_id, cancelled=_registry.cancel(run_id))
 
 
 DEFAULT_HOST = "127.0.0.1"

--- a/hub/agents/gaia/python/gaia_agent/server.py
+++ b/hub/agents/gaia/python/gaia_agent/server.py
@@ -168,7 +168,19 @@ class DuplicateRunError(RuntimeError):
 #: the moment its run registers; this only bounds cancels whose run never came.
 _MAX_PRECANCELLED = 256
 
+#: Cap on remembered just-finished ids, which is what lets ``cancel`` tell a run
+#: that ended a moment ago from one that has not registered yet.
+_MAX_FINISHED = 256
+
 _MISSING = object()
+
+
+def _remember_bounded(store: Dict[str, None], key: str, cap: int) -> None:
+    """Record ``key`` as the newest entry, dropping the oldest past ``cap``."""
+    store.pop(key, None)  # re-insert at the end, so this is the newest
+    store[key] = None
+    while len(store) > cap:
+        store.pop(next(iter(store)))
 
 
 class _RunRegistry:
@@ -179,6 +191,9 @@ class _RunRegistry:
         #: run_ids cancelled before their ``/query`` registered. Insertion
         #: ordered, so the oldest is the one evicted at the cap.
         self._precancelled: Dict[str, None] = {}
+        #: run_ids whose run has already ended. Same shape, and the reason
+        #: ``cancel`` does not tombstone them.
+        self._finished: Dict[str, None] = {}
         self._lock = threading.Lock()
 
     def add(self, run: _QueryRun) -> bool:
@@ -205,12 +220,18 @@ class _RunRegistry:
     def cancel(self, run_id: str) -> bool:
         """Stop a live run, or remember the cancel for one about to register.
 
-        Returns whether a LIVE run was stopped. An id with no live run stays
-        ``False`` — a cancel racing a run's own completion should not claim to
-        have stopped anything — but the id is tombstoned so that a run which
-        registers *after* this call starts already cancelled. The caller mints
-        ``run_id`` before it POSTs ``/query``, so that ordering is a real race,
-        not a hypothetical one. Consumed on use, so it fires at most once.
+        Returns whether a LIVE run was stopped; an id with no live run stays
+        ``False``, because a cancel racing a run's own completion should not
+        claim to have stopped anything.
+
+        Two different situations miss ``_runs``, and only one of them may be
+        tombstoned. A run that ALREADY ENDED is the common, documented race, and
+        arming a tombstone for it would leave an entry nothing can consume — and
+        would pre-cancel the next run if the caller reused that id. A run that
+        has NOT REGISTERED YET is the real ordering this exists for: the caller
+        mints ``run_id`` before it POSTs ``/query``, so a cancel can genuinely
+        arrive first. Only the latter is remembered, and it is consumed on use,
+        so it fires at most once.
         """
         with self._lock:
             run = self._runs.get(run_id)
@@ -218,15 +239,16 @@ class _RunRegistry:
                 run.cancel_event.set()
                 run.handler.cancelled.set()
                 return True
-            self._precancelled.pop(run_id, None)  # re-insert as newest
-            self._precancelled[run_id] = None
-            while len(self._precancelled) > _MAX_PRECANCELLED:
-                self._precancelled.pop(next(iter(self._precancelled)))
+            if run_id not in self._finished:
+                _remember_bounded(self._precancelled, run_id, _MAX_PRECANCELLED)
             return False
 
     def remove(self, run_id: str) -> None:
+        """Retire a finished run, remembering the id so a late cancel knows it
+        ended rather than treating it as one that has yet to start."""
         with self._lock:
             self._runs.pop(run_id, None)
+            _remember_bounded(self._finished, run_id, _MAX_FINISHED)
 
 
 _registry = _RunRegistry()

--- a/hub/agents/gaia/python/gaia_agent/session_registry.py
+++ b/hub/agents/gaia/python/gaia_agent/session_registry.py
@@ -10,20 +10,23 @@ learned during the turn. A skill activated by ``load_skill`` lives on
 no skills loaded while the model, having just said "it's loaded", keeps
 promising otherwise.
 
-Mirrors ``gaia_agent_email.agent_routes._SessionRegistry`` deliberately: same
-idle-TTL + LRU bounds, same claim-the-lock eviction. The duplication is a known
-cost — extracting one shared registry into core touches the email agent's
-tested paths and belongs in its own change.
+Started as a deliberate mirror of ``gaia_agent_email.agent_routes._SessionRegistry``
+— same idle-TTL + LRU bounds, same claim-the-lock eviction — and has since
+diverged: this one reserves a slot while an agent builds so the cap is a real
+bound, and tears agents down through ``close()``, which the email agent does not
+have. The duplication is a known cost; extracting one shared registry into core
+touches the email agent's tested paths and belongs in its own change.
 """
 
 from __future__ import annotations
 
-import logging
 import threading
 import time
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Set
 
-logger = logging.getLogger(__name__)
+from gaia.logger import get_logger
+
+logger = get_logger(__name__)
 
 #: Human label used in the cap-exhausted error below.
 AGENT_LABEL = "GAIA"
@@ -59,9 +62,14 @@ class _AgentSession:
     second turn cannot corrupt the cached agent's conversation state.
     """
 
-    def __init__(self, session_id: str, agent: Any) -> None:
+    def __init__(self, session_id: str, agent: Any, model_id: Any = None) -> None:
         self.session_id = session_id
         self.agent = agent
+        #: The ``model_id`` this session's agent was BUILT with (``None`` = the
+        #: agent's own default). Only construction reads a model, so a later turn
+        #: asking for a different one cannot be honoured — the server compares
+        #: against this and refuses rather than running the old model silently.
+        self.model_id = model_id
         self.run_lock = threading.Lock()
         #: True exactly once, on the session built to replace one this
         #: registry involuntarily evicted (LRU cap or idle timeout) — never
@@ -87,14 +95,30 @@ _DEFAULT_IDLE_TTL_SECONDS = 4 * 60 * 60  # 4 hours
 _DEFAULT_MAX_SESSIONS = 100
 
 
-def _close_agent(agent: Any) -> None:
-    """Best-effort teardown of a retained agent's handles on eviction."""
-    close = getattr(agent, "close_db", None)
-    if callable(close):
-        try:
-            close()
-        except Exception as exc:  # pragma: no cover - teardown must not raise
-            logger.warning("agent session close_db failed: %s", exc)
+def close_agent(agent: Any) -> None:
+    """Release one agent's handles — RAG/index, scratchpad DB, HTTP session.
+
+    ``close()`` is the flagship's teardown; ``close_db()`` is the email agent's,
+    accepted so a caller can hand either here. An agent exposing neither is a
+    LOUD error, not a quiet skip: this helper reached that state once already by
+    probing only ``close_db``, which ``GaiaAgent`` does not define, and every
+    eviction leaked the whole agent while looking like it had cleaned up.
+    """
+    close = getattr(agent, "close", None)
+    if not callable(close):
+        close = getattr(agent, "close_db", None)
+    if not callable(close):
+        logger.error(
+            "%s exposes neither close() nor close_db(), so its RAG index, "
+            "scratchpad DB and HTTP session leak until the process exits. "
+            "Give the agent class a close() method.",
+            type(agent).__name__,
+        )
+        return
+    try:
+        close()
+    except Exception as exc:  # pragma: no cover - teardown must not raise
+        logger.warning("%s teardown failed: %s", type(agent).__name__, exc)
 
 
 class _SessionRegistry:
@@ -126,6 +150,12 @@ class _SessionRegistry:
         #: retire the previous tombstone to make room, erasing it before it
         #: was ever consumed.
         self._evicted_ids: Dict[str, None] = {}
+        #: session_ids whose agent is being BUILT right now. Construction runs
+        #: outside the lock, so without reserving the slot here two creators for
+        #: two new ids both pass the capacity check at len == max-1 and both
+        #: install, putting the registry at max+1. Counted against the cap and
+        #: dropped by whichever creator added it, on every exit path.
+        self._pending: Set[str] = set()
         self._max_evicted_ids = max(4 * max_sessions, 32)
         self._lock = threading.Lock()
         self._idle_ttl_seconds = idle_ttl_seconds
@@ -150,7 +180,9 @@ class _SessionRegistry:
             if existing is not None:
                 self._last_used[session_id] = time.monotonic()
                 return existing
-            if len(self._sessions) >= self._max_sessions:
+            # Racers for the SAME id share one reservation (a set), so the pair
+            # costs one slot — which is what they will end up occupying.
+            if len(self._sessions) + len(self._pending) >= self._max_sessions:
                 evicted = self._claim_lru_locked()
                 if evicted is None:
                     raise SessionCapacityError(
@@ -160,16 +192,23 @@ class _SessionRegistry:
                         "terminal/window, or wait for one to finish its current "
                         "turn, and retry."
                     )
+            self._pending.add(session_id)
         if evicted is not None:
-            _close_agent(evicted.agent)
+            close_agent(evicted.agent)
         # Build outside the lock — construction is slow and must not block other
         # sessions. A racing creator for the SAME id is resolved below by
         # discarding the loser's agent.
-        agent = build_session_agent(**config_kwargs)
+        try:
+            agent = build_session_agent(**config_kwargs)
+        except BaseException:
+            with self._lock:
+                self._pending.discard(session_id)
+            raise
         with self._lock:
+            self._pending.discard(session_id)
             existing = self._sessions.get(session_id)
             if existing is not None:
-                _close_agent(agent)
+                close_agent(agent)
                 self._last_used[session_id] = time.monotonic()
                 return existing
             # Consume the eviction tombstone HERE, on the branch that installs
@@ -177,7 +216,9 @@ class _SessionRegistry:
             # id could win the install with the flag already consumed, and the
             # "your loaded skills were reset" warning would reach no one.
             reclaimed = self._evicted_ids.pop(session_id, _SENTINEL) is not _SENTINEL
-            session = _AgentSession(session_id, agent)
+            session = _AgentSession(
+                session_id, agent, model_id=config_kwargs.get("model_id")
+            )
             session.reclaimed_after_eviction = reclaimed
             self._sessions[session_id] = session
             self._last_used[session_id] = time.monotonic()
@@ -229,7 +270,7 @@ class _SessionRegistry:
                 self._note_evicted_locked(sid)
                 evicted.append(session)
         for session in evicted:
-            _close_agent(session.agent)
+            close_agent(session.agent)
         return [s.session_id for s in evicted]
 
     def delete(self, session_id: str) -> bool:
@@ -238,7 +279,7 @@ class _SessionRegistry:
             self._last_used.pop(session_id, None)
         if session is None:
             return False
-        _close_agent(session.agent)
+        close_agent(session.agent)
         return True
 
     def clear(self) -> None:
@@ -248,7 +289,7 @@ class _SessionRegistry:
             self._sessions.clear()
             self._last_used.clear()
         for session in sessions:
-            _close_agent(session.agent)
+            close_agent(session.agent)
 
 
 #: One process == the whole registry. The sidecar never runs uvicorn with
@@ -258,6 +299,7 @@ registry = _SessionRegistry()
 
 __all__ = [
     "build_session_agent",
+    "close_agent",
     "registry",
     "_AgentSession",
     "_SessionRegistry",

--- a/hub/agents/gaia/python/tests/test_caller_auth.py
+++ b/hub/agents/gaia/python/tests/test_caller_auth.py
@@ -21,6 +21,8 @@ unauthenticated request is actually refused by the app the binary serves.
 
 from __future__ import annotations
 
+import asyncio
+
 import pytest
 
 pytest.importorskip("gaia_agent")
@@ -229,6 +231,57 @@ def test_the_missing_host_check_also_covers_the_probes(monkeypatch):
     """Same rule for the token-free paths — they skip the token, not transport."""
     client = _client(monkeypatch, token=_TOKEN)
     assert client.get("/health", headers={"Host": ""}).status_code == 400
+
+
+def _reject_body_for(headers: list) -> bytes:
+    """Drive the middleware over a raw ASGI scope and return the refusal body.
+
+    ``TestClient`` normalises the header, so a malformed value is unreachable
+    through it.
+    """
+    caller_auth.configure(caller_auth.CallerAuthConfig(token=_TOKEN))
+    sent: list = []
+
+    async def app(scope, receive, send):  # pragma: no cover - must never run
+        raise AssertionError("a request with a bad Host reached the app")
+
+    async def _send(message):
+        sent.append(message)
+
+    async def _receive():
+        return {"type": "http.request", "body": b"", "more_body": False}
+
+    scope = {
+        "type": "http",
+        "method": "GET",
+        "path": "/health",
+        "query_string": b"",
+        "headers": headers,
+    }
+    asyncio.run(caller_auth.HostOriginMiddleware(app)(scope, _receive, _send))
+
+    start = next(m for m in sent if m["type"] == "http.response.start")
+    assert start["status"] == 400
+    return b"".join(
+        m.get("body", b"") for m in sent if m["type"] == "http.response.body"
+    )
+
+
+@pytest.mark.parametrize("raw", [b":8141", b"::1"])
+def test_malformed_host_is_rejected_and_quoted_back(raw):
+    """A Host that parses to nothing is still a Host the caller sent.
+
+    ``_host_only`` returns ``""`` for these, so keying the message on the parsed
+    value would tell someone debugging their client it sent no Host at all.
+    """
+    body = _reject_body_for([(b"host", raw)])
+    assert b"no Host header" not in body
+    assert raw in body
+
+
+def test_whitespace_only_host_reads_as_absent():
+    """Nothing useful to quote back, so it is reported the way it presents."""
+    assert b"no Host header" in _reject_body_for([(b"host", b"   ")])
 
 
 # -- EXEMPT_PATHS is a real declaration, not decoration -----------------------

--- a/hub/agents/gaia/python/tests/test_caller_auth.py
+++ b/hub/agents/gaia/python/tests/test_caller_auth.py
@@ -202,3 +202,71 @@ def test_probe_paths_do_not_require_a_token(monkeypatch, path):
     """The attach handshake polls these before it can know the token."""
     client = _client(monkeypatch, token=_TOKEN)
     assert client.get(path).status_code == 200, path
+
+
+def test_a_request_with_no_host_header_is_rejected(monkeypatch):
+    """The control failed OPEN on an absent Host: the check was skipped entirely.
+
+    A browser always sends Host, so the sharp drive-by vector stayed covered —
+    but a raw-socket or HTTP/1.0 client could opt out of rebinding protection
+    just by omitting the header, which is not a thing a security control may let
+    a caller choose.
+    """
+    client = _client(monkeypatch, token=_TOKEN)
+    r = client.post(
+        "/v1/gaia/query",
+        json=_QUERY_BODY,
+        headers={"Host": "", "Authorization": f"Bearer {_TOKEN}"},
+    )
+    assert r.status_code == 400, r.text
+    detail = r.json()["detail"]
+    assert "no Host header" in detail
+    # Actionable: it must say what to send instead.
+    assert "127.0.0.1" in detail
+
+
+def test_the_missing_host_check_also_covers_the_probes(monkeypatch):
+    """Same rule for the token-free paths — they skip the token, not transport."""
+    client = _client(monkeypatch, token=_TOKEN)
+    assert client.get("/health", headers={"Host": ""}).status_code == 400
+
+
+# -- EXEMPT_PATHS is a real declaration, not decoration -----------------------
+
+
+def test_exempt_paths_names_exactly_the_token_free_routes(monkeypatch):
+    """EXEMPT_PATHS listed three paths that the token guard could never see:
+    all three are registered on the APP, outside the token-guarded router, so
+    ``is_exempt_path`` never decided any of them.
+
+    Leaving that unstated is a config implying protection semantics it does not
+    have, so pin the real shape — every named path answers without a token, and
+    no OTHER router path does.
+    """
+    client = _client(monkeypatch, token=_TOKEN)
+
+    for path in caller_auth.EXEMPT_PATHS:
+        assert client.get(path).status_code == 200, f"{path} unexpectedly gated"
+
+    # And the guarded router really is guarded, so the exemption is not what is
+    # keeping those three open.
+    assert client.post("/v1/gaia/query", json=_QUERY_BODY).status_code == 401
+    assert client.get("/v1/gaia/init").status_code == 401
+
+
+def test_exempt_paths_never_matches_a_guarded_route(monkeypatch):
+    """The honest statement of today's wiring: the guarded router is mounted
+    under /v1/gaia and no exempt path except the version probe lives there — and
+    that one is registered on the app, not the router."""
+    _client(monkeypatch, token=_TOKEN)  # installs the active config
+    guarded_prefix = "/v1/gaia/"
+    guarded = {
+        p
+        for p in caller_auth.EXEMPT_PATHS
+        if p.startswith(guarded_prefix) and p != "/v1/gaia/version"
+    }
+    assert guarded == set(), (
+        f"{sorted(guarded)} sit under the token-guarded router prefix; either "
+        "they are genuinely public (and the router must skip them) or the "
+        "exemption is dead config."
+    )

--- a/hub/agents/gaia/python/tests/test_gaia_agent.py
+++ b/hub/agents/gaia/python/tests/test_gaia_agent.py
@@ -224,3 +224,29 @@ def test_manifest_ships_default_skill_set_disabled(manifest):
         "default_skill_set is live — skills would load for every user before an "
         "eval has measured their prompt-token cost (see #2848)."
     )
+
+
+# ---------------------------------------------------------------------------
+# Construction contract
+# ---------------------------------------------------------------------------
+
+
+def test_passing_both_a_config_and_kwargs_is_refused():
+    """``config or GaiaAgentConfig(**kwargs)`` dropped the kwargs on the floor,
+    so a caller that set a field this way got an agent silently ignoring it."""
+    with pytest.raises(TypeError) as exc:
+        GaiaAgent(config=GaiaAgentConfig(), model_id="some-model")
+
+    message = str(exc.value)
+    assert "model_id" in message  # names what would have been dropped
+    assert "not both" in message
+
+
+def test_the_readiness_probe_takes_no_request_parameters():
+    """``init(response: Any = None)`` was unused, and FastAPI published it as a
+    real query parameter — an argument callers could pass that does nothing."""
+    from gaia_agent.server import build_app
+
+    schema = build_app().openapi()
+    operation = schema["paths"]["/v1/gaia/init"]["get"]
+    assert operation.get("parameters", []) == []

--- a/hub/agents/gaia/python/tests/test_server_query.py
+++ b/hub/agents/gaia/python/tests/test_server_query.py
@@ -245,7 +245,7 @@ def test_the_refused_duplicate_does_not_leak_its_agent(built):
     assert agents[0].closed == 1
 
 
-def test_run_registry_rejects_a_duplicate_directly(built):
+def test_run_registry_rejects_a_duplicate_directly():
     run_id = str(uuid.uuid4())
     reg = server_mod._RunRegistry()
     reg.add(server_mod._QueryRun(run_id, object(), object()))
@@ -339,6 +339,51 @@ def test_a_cancel_that_beats_the_run_still_stops_it(built):
     # ...but the run that arrives afterwards starts already cancelled.
     assert agents[0].saw_cancelled is True
     assert len(_terminals(r)) == 1
+
+
+def test_cancelling_a_run_that_just_finished_does_not_arm_a_tombstone(built):
+    """A cancel racing the run's own completion is the documented normal case,
+    so it must not leave an entry behind that nothing can ever consume — and
+    must not pre-cancel a reuse of that id, which the run table allows once the
+    first run is done."""
+    client, agents = built
+    run_id = str(uuid.uuid4())
+
+    first = client.post("/v1/gaia/query", json=_body(run_id=run_id))
+    assert first.status_code == 200
+    assert _wait_until(lambda: server_mod._registry.get(run_id) is None)
+
+    late = client.post(f"/v1/gaia/query/{run_id}/cancel")
+    assert late.json()["cancelled"] is False
+    assert run_id not in server_mod._registry._precancelled
+
+    second = client.post("/v1/gaia/query", json=_body(run_id=run_id))
+    assert second.status_code == 200, second.text
+    assert agents[1].saw_cancelled is False, (
+        "a reused run_id was pre-cancelled by a cancel aimed at the run that "
+        "already finished under it"
+    )
+
+
+def test_a_late_cancel_still_reports_it_stopped_nothing(built):
+    """The response contract for the completion race is unchanged."""
+    client, _ = built
+    run_id = str(uuid.uuid4())
+    client.post("/v1/gaia/query", json=_body(run_id=run_id))
+    assert _wait_until(lambda: server_mod._registry.get(run_id) is None)
+
+    assert client.post(f"/v1/gaia/query/{run_id}/cancel").json()["cancelled"] is False
+
+
+def test_a_cancel_for_a_never_seen_id_is_still_remembered(built):
+    """The distinction the fix turns on: unknown-and-unstarted still arms, so
+    the cancel-beats-the-POST race stays closed."""
+    client, _ = built
+    run_id = str(uuid.uuid4())
+
+    client.post(f"/v1/gaia/query/{run_id}/cancel")
+
+    assert run_id in server_mod._registry._precancelled
 
 
 def test_an_early_cancel_applies_once_and_only_to_its_own_run_id(built):

--- a/hub/agents/gaia/python/tests/test_server_query.py
+++ b/hub/agents/gaia/python/tests/test_server_query.py
@@ -1,0 +1,390 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""Run lifecycle on ``POST /v1/gaia/query``.
+
+Every test here drives the real ``build_app()`` over HTTP with a scripted agent
+injected at the two construction seams. A mocked route would prove the handler
+was called; only the real app proves a one-shot agent is actually torn down, a
+duplicate ``run_id`` is actually refused, and the SSE contract still ends each
+run with exactly one terminal event.
+
+What these pin, and the bug each one caught:
+
+* **One-shot teardown** — ``/query`` without a ``session_id`` built an agent that
+  nothing ever closed, so a host issuing one-shot queries accumulated a RAG/FAISS
+  index, a scratchpad DB handle and an HTTP session per request until the process
+  died.
+* **Duplicate run_id** — the run table took the newer run over the older one, so
+  the older became uncancellable and either stream's teardown dropped the other's
+  entry. ``run_id`` is client-minted, so a client bug reaches this.
+* **Per-turn model** — a retained session ignored a changed ``model``, answering
+  on the old one with no error at all.
+* **Cancel before start** — ``run_id`` is minted before the POST, so a cancel can
+  legitimately arrive first; it used to be dropped and the run proceeded.
+"""
+
+from __future__ import annotations
+
+import json
+import threading
+import time
+import uuid
+
+import pytest
+
+pytest.importorskip("gaia_agent")
+
+from fastapi.testclient import TestClient  # noqa: E402
+from gaia_agent import caller_auth  # noqa: E402
+from gaia_agent import server as server_mod  # noqa: E402
+from gaia_agent import session_registry as sr  # noqa: E402
+
+_BASE_URL = "http://127.0.0.1:8141"
+
+
+class _ScriptedAgent:
+    """Stands in for GaiaAgent: identity, teardown, and a scriptable loop."""
+
+    def __init__(self, **kwargs):
+        self.kwargs = kwargs
+        self.closed = 0
+        self.console = None
+        self.conversation_history = []
+        self._cancel_event = None
+        self.saw_cancelled = None
+        self.raise_on_query = False
+        self.block = None  # optional threading.Event to park the loop on
+
+    def process_query(self, query, max_steps=None):
+        if self.block is not None:
+            self.block.wait(timeout=10)
+        # Mirrors the base loop, which checks the flag at its first step
+        # boundary — before any model call.
+        self.saw_cancelled = bool(
+            self._cancel_event is not None and self._cancel_event.is_set()
+        )
+        if self.raise_on_query:
+            raise RuntimeError("scripted failure")
+        if self.saw_cancelled:
+            return {"answer": "stopped before doing any work"}
+        return {"answer": f"answered: {query}"}
+
+    def close(self):
+        self.closed += 1
+
+
+@pytest.fixture
+def built(monkeypatch):
+    """The real app, with both agent-construction seams scripted.
+
+    Yields a ``(client, agents)`` pair; ``agents`` collects every agent built,
+    in construction order, so a test can assert on teardown.
+    """
+    caller_auth.reset()
+    monkeypatch.delenv(caller_auth.TOKEN_FILE_ENV_VAR, raising=False)
+    monkeypatch.delenv(caller_auth.TOKEN_ENV_VAR, raising=False)
+
+    agents: list[_ScriptedAgent] = []
+
+    def build(**kw):
+        agent = _ScriptedAgent(**kw)
+        agents.append(agent)
+        return agent
+
+    monkeypatch.setattr(server_mod, "build_query_agent", build)
+    monkeypatch.setattr(sr, "build_session_agent", build)
+
+    sr.registry.clear()
+    server_mod._registry = server_mod._RunRegistry()
+
+    client = TestClient(server_mod.build_app(), base_url=_BASE_URL)
+    try:
+        yield client, agents
+    finally:
+        sr.registry.clear()
+        server_mod._registry = server_mod._RunRegistry()
+        caller_auth.reset()
+
+
+def _body(**overrides):
+    payload = {
+        "query": "hello",
+        "run_id": str(uuid.uuid4()),
+        "context": [],
+    }
+    payload.update(overrides)
+    return payload
+
+
+def _events(response):
+    """Parse the canonical events out of an SSE response body."""
+    out = []
+    for line in response.text.splitlines():
+        if line.startswith("data: "):
+            out.append(json.loads(line[len("data: ") :]))
+    return out
+
+
+def _terminals(response):
+    from gaia.ui.sse_translation import TERMINAL_TYPES
+
+    return [e for e in _events(response) if e.get("type") in TERMINAL_TYPES]
+
+
+def _wait_until(predicate, timeout=5.0):
+    """Poll for a condition the run thread satisfies after the response ends.
+
+    The stream returns as soon as the done-sentinel lands; teardown happens a
+    moment later in the worker thread's ``finally``.
+    """
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if predicate():
+            return True
+        time.sleep(0.01)
+    return False
+
+
+# ---------------------------------------------------------------------------
+# One-shot teardown
+# ---------------------------------------------------------------------------
+
+
+def test_a_one_shot_run_closes_its_agent(built):
+    """Without this, every session-less /query leaks a whole agent."""
+    client, agents = built
+    r = client.post("/v1/gaia/query", json=_body())
+
+    assert r.status_code == 200, r.text
+    assert len(agents) == 1
+    assert _wait_until(lambda: agents[0].closed == 1), "one-shot agent was never closed"
+
+
+def test_a_one_shot_agent_is_closed_even_when_the_run_raises(built, monkeypatch):
+    """The leak must not come back on the failure path."""
+    client, agents = built
+
+    def build(**kw):
+        agent = _ScriptedAgent(**kw)
+        agent.raise_on_query = True
+        agents.append(agent)
+        return agent
+
+    monkeypatch.setattr(server_mod, "build_query_agent", build)
+    r = client.post("/v1/gaia/query", json=_body())
+
+    assert r.status_code == 200, r.text
+    assert _wait_until(lambda: agents[0].closed == 1)
+    assert len(_terminals(r)) == 1, _events(r)
+
+
+def test_a_retained_session_agent_is_never_closed_by_the_run(built):
+    """The registry owns a session agent; closing it here would hand the next
+    turn a dead agent with shut SQLite handles."""
+    client, agents = built
+    r = client.post("/v1/gaia/query", json=_body(session_id="s-1"))
+
+    assert r.status_code == 200, r.text
+    assert len(agents) == 1
+    # Give the worker thread the same window the one-shot test allows.
+    assert not _wait_until(lambda: agents[0].closed > 0, timeout=0.5)
+    assert sr.registry.get("s-1") is not None
+
+
+def test_one_terminal_event_per_run(built):
+    """The frozen contract: exactly one final-or-error, always."""
+    client, _ = built
+    r = client.post("/v1/gaia/query", json=_body())
+    assert len(_terminals(r)) == 1, _events(r)
+
+
+# ---------------------------------------------------------------------------
+# Duplicate run_id
+# ---------------------------------------------------------------------------
+
+
+def test_a_duplicate_in_flight_run_id_is_refused(built):
+    """A reused run_id used to overwrite the live run, stranding it."""
+    client, _ = built
+    run_id = str(uuid.uuid4())
+
+    live = server_mod._QueryRun(run_id, object(), object())
+    server_mod._registry.add(live)
+
+    r = client.post("/v1/gaia/query", json=_body(run_id=run_id))
+
+    assert r.status_code == 409, r.text
+    detail = r.json()["detail"]
+    assert run_id in detail
+    assert "fresh UUID" in detail
+
+
+def test_the_refused_duplicate_leaves_the_live_run_registered(built):
+    """The sharp half of the bug: the loser's cleanup dropped the winner's entry,
+    which is what made the live run uncancellable."""
+    client, _ = built
+    run_id = str(uuid.uuid4())
+    live = server_mod._QueryRun(run_id, object(), object())
+    server_mod._registry.add(live)
+
+    client.post("/v1/gaia/query", json=_body(run_id=run_id))
+
+    assert server_mod._registry.get(run_id) is live
+
+
+def test_the_refused_duplicate_does_not_leak_its_agent(built):
+    """The rejected request still built a one-shot agent; it must be torn down."""
+    client, agents = built
+    run_id = str(uuid.uuid4())
+    server_mod._registry.add(server_mod._QueryRun(run_id, object(), object()))
+
+    r = client.post("/v1/gaia/query", json=_body(run_id=run_id))
+
+    assert r.status_code == 409
+    assert len(agents) == 1
+    assert agents[0].closed == 1
+
+
+def test_run_registry_rejects_a_duplicate_directly(built):
+    run_id = str(uuid.uuid4())
+    reg = server_mod._RunRegistry()
+    reg.add(server_mod._QueryRun(run_id, object(), object()))
+
+    with pytest.raises(server_mod.DuplicateRunError):
+        reg.add(server_mod._QueryRun(run_id, object(), object()))
+
+
+def test_a_reused_run_id_is_fine_once_the_first_run_finished(built):
+    """Only an IN-FLIGHT collision is refused — the table is keyed on live runs."""
+    client, _ = built
+    run_id = str(uuid.uuid4())
+
+    first = client.post("/v1/gaia/query", json=_body(run_id=run_id))
+    assert first.status_code == 200
+    assert _wait_until(lambda: server_mod._registry.get(run_id) is None)
+
+    second = client.post("/v1/gaia/query", json=_body(run_id=run_id))
+    assert second.status_code == 200, second.text
+
+
+# ---------------------------------------------------------------------------
+# Per-turn model on a retained session
+# ---------------------------------------------------------------------------
+
+
+def test_switching_model_on_a_live_session_is_refused(built):
+    """It used to run the OLD model with no error and no warning."""
+    client, agents = built
+
+    first = client.post("/v1/gaia/query", json=_body(session_id="s-1", model="model-a"))
+    assert first.status_code == 200, first.text
+
+    second = client.post(
+        "/v1/gaia/query", json=_body(session_id="s-1", model="model-b")
+    )
+
+    assert second.status_code == 409, second.text
+    detail = second.json()["detail"]
+    assert "model-a" in detail and "model-b" in detail
+    assert "new session_id" in detail
+    # The refusal must not have built a second agent, nor stranded the session.
+    assert len(agents) == 1
+
+
+def test_the_refused_switch_leaves_the_session_usable(built):
+    """A 409 must release the run lock, or the session 409s forever after."""
+    client, _ = built
+    client.post("/v1/gaia/query", json=_body(session_id="s-1", model="model-a"))
+    client.post("/v1/gaia/query", json=_body(session_id="s-1", model="model-b"))
+
+    again = client.post("/v1/gaia/query", json=_body(session_id="s-1", model="model-a"))
+    assert again.status_code == 200, again.text
+
+
+def test_the_same_model_across_turns_is_allowed(built):
+    client, agents = built
+    body = dict(session_id="s-1", model="model-a")
+    assert client.post("/v1/gaia/query", json=_body(**body)).status_code == 200
+    assert client.post("/v1/gaia/query", json=_body(**body)).status_code == 200
+    assert len(agents) == 1  # same retained agent both turns
+
+
+def test_omitting_model_continues_on_the_session_model(built):
+    """A caller expressing no preference is not a switch request."""
+    client, _ = built
+    client.post("/v1/gaia/query", json=_body(session_id="s-1", model="model-a"))
+    r = client.post("/v1/gaia/query", json=_body(session_id="s-1"))
+    assert r.status_code == 200, r.text
+
+
+# ---------------------------------------------------------------------------
+# Cancel arriving before the run registers
+# ---------------------------------------------------------------------------
+
+
+def test_a_cancel_that_beats_the_run_still_stops_it(built):
+    """run_id is minted before the POST, so cancel-arrives-first is a real
+    ordering. It used to be dropped and the run went on to call the model."""
+    client, agents = built
+    run_id = str(uuid.uuid4())
+
+    cancel = client.post(f"/v1/gaia/query/{run_id}/cancel")
+    assert cancel.status_code == 200
+    # No live run was stopped, and saying otherwise would be a lie...
+    assert cancel.json()["cancelled"] is False
+
+    r = client.post("/v1/gaia/query", json=_body(run_id=run_id))
+
+    assert r.status_code == 200, r.text
+    # ...but the run that arrives afterwards starts already cancelled.
+    assert agents[0].saw_cancelled is True
+    assert len(_terminals(r)) == 1
+
+
+def test_an_early_cancel_applies_once_and_only_to_its_own_run_id(built):
+    """The tombstone is consumed on use, so a later run under the same id — or
+    any other id — is unaffected."""
+    client, agents = built
+    run_id = str(uuid.uuid4())
+    client.post(f"/v1/gaia/query/{run_id}/cancel")
+
+    client.post("/v1/gaia/query", json=_body(run_id=run_id))
+    assert _wait_until(lambda: server_mod._registry.get(run_id) is None)
+
+    client.post("/v1/gaia/query", json=_body(run_id=run_id))
+    assert agents[1].saw_cancelled is False
+
+    client.post("/v1/gaia/query", json=_body())
+    assert agents[2].saw_cancelled is False
+
+
+def test_cancelling_a_live_run_reports_it_stopped(built, monkeypatch):
+    """The existing contract for the normal case must not have moved."""
+    client, agents = built
+    run_id = str(uuid.uuid4())
+    gate = threading.Event()
+
+    def build(**kw):
+        agent = _ScriptedAgent(**kw)
+        agent.block = gate
+        agents.append(agent)
+        return agent
+
+    monkeypatch.setattr(server_mod, "build_query_agent", build)
+
+    result = {}
+
+    def run():
+        result["response"] = client.post("/v1/gaia/query", json=_body(run_id=run_id))
+
+    worker = threading.Thread(target=run, daemon=True)
+    worker.start()
+    try:
+        assert _wait_until(lambda: server_mod._registry.get(run_id) is not None)
+        cancel = client.post(f"/v1/gaia/query/{run_id}/cancel")
+        assert cancel.json()["cancelled"] is True
+    finally:
+        gate.set()
+        worker.join(timeout=10)
+
+    assert result["response"].status_code == 200

--- a/hub/agents/gaia/python/tests/test_session_registry.py
+++ b/hub/agents/gaia/python/tests/test_session_registry.py
@@ -222,3 +222,166 @@ def test_reclaimed_flag_is_not_repeated_on_the_next_lookup(monkeypatch):
     assert same is reclaimed
     assert same.reclaimed_after_eviction is False
     reg.clear()
+
+
+# ---------------------------------------------------------------------------
+# Teardown: the helper must actually reach a real agent's handles. It probed
+# only ``close_db`` — which GaiaAgent does not define — so every eviction was a
+# silent no-op that leaked the whole agent while looking like it had cleaned up.
+# ---------------------------------------------------------------------------
+
+
+class _ClosableAgent:
+    """The flagship's shape: teardown behind ``close()``, not ``close_db()``."""
+
+    def __init__(self, **kwargs):
+        self.kwargs = kwargs
+        self.closed = False
+
+    def close(self):
+        self.closed = True
+
+
+class _UncloseableAgent:
+    """An agent with no teardown at all."""
+
+
+def test_close_agent_uses_close_when_that_is_what_the_agent_has():
+    agent = _ClosableAgent()
+    sr.close_agent(agent)
+    assert agent.closed is True
+
+
+def test_close_agent_still_accepts_the_email_agents_close_db():
+    agent = _FakeAgent()
+    sr.close_agent(agent)
+    assert agent.closed is True
+
+
+def test_close_agent_is_loud_when_an_agent_exposes_no_teardown(caplog):
+    """A silent no-op here is the whole bug: the caller believes it cleaned up."""
+    with caplog.at_level("ERROR"):
+        sr.close_agent(_UncloseableAgent())
+    assert any(
+        "neither close() nor close_db()" in r.getMessage() for r in caplog.records
+    ), caplog.text
+
+
+def test_the_real_gaia_agent_exposes_the_teardown_the_registry_calls():
+    """The regression itself, asserted against the shipped class rather than a
+    fake — a fake that defines ``close_db`` proved nothing about GaiaAgent."""
+    from gaia_agent.agent import GaiaAgent
+
+    assert callable(getattr(GaiaAgent, "close", None)) or callable(
+        getattr(GaiaAgent, "close_db", None)
+    ), "GaiaAgent has no teardown, so every evicted session leaks its handles"
+
+
+def test_evicting_a_session_actually_closes_a_close_only_agent(monkeypatch):
+    """End-to-end of the same bug, through the registry's own eviction path."""
+    monkeypatch.setattr(sr, "build_session_agent", lambda **kw: _ClosableAgent(**kw))
+    reg = sr._SessionRegistry(max_sessions=1)
+    first = reg.get_or_create("a")
+    reg.get_or_create("b")  # evicts "a"
+    assert first.agent.closed is True
+    reg.clear()
+
+
+# ---------------------------------------------------------------------------
+# The session cap must be a real bound. The check and the install sat in two
+# different lock sections with a slow agent build between them, so two creators
+# for two NEW ids could both pass at len == max-1 and both install.
+# ---------------------------------------------------------------------------
+
+
+def test_racing_creators_for_new_ids_cannot_exceed_the_cap(monkeypatch):
+    """Both racers reach the capacity check before either installs."""
+    max_sessions = 4
+    entered = threading.Semaphore(0)
+    released = threading.Event()
+
+    def slow_build(**kw):
+        # Park INSIDE construction — exactly the window the old code left open
+        # between passing the check and installing the session.
+        entered.release()
+        released.wait(timeout=10)
+        return _FakeAgent(**kw)
+
+    monkeypatch.setattr(sr, "build_session_agent", lambda **kw: _FakeAgent(**kw))
+    reg = sr._SessionRegistry(max_sessions=max_sessions)
+    # Fill to max-1, all idle so they are evictable rather than capacity errors.
+    for i in range(max_sessions - 1):
+        reg.get_or_create(f"filler-{i}")
+
+    monkeypatch.setattr(sr, "build_session_agent", slow_build)
+    outcomes = []
+
+    def create(session_id):
+        try:
+            outcomes.append(reg.get_or_create(session_id))
+        except sr.SessionCapacityError as exc:
+            outcomes.append(exc)
+
+    threads = [
+        threading.Thread(target=create, args=(sid,)) for sid in ("racer-x", "racer-y")
+    ]
+    for t in threads:
+        t.start()
+    try:
+        # Hold both racers inside slow_build, i.e. both past the capacity check,
+        # before letting either install.
+        assert entered.acquire(timeout=10)
+        assert entered.acquire(timeout=10)
+    finally:
+        released.set()
+        for t in threads:
+            t.join(timeout=10)
+
+    assert len(outcomes) == 2
+    assert (
+        len(reg._sessions) <= max_sessions
+    ), f"cap of {max_sessions} exceeded: {sorted(reg._sessions)}"
+    reg.clear()
+
+
+def test_a_pending_build_counts_against_the_cap(monkeypatch):
+    """The reservation, stated directly: a slot being built is a slot taken."""
+    monkeypatch.setattr(sr, "build_session_agent", lambda **kw: _FakeAgent(**kw))
+    reg = sr._SessionRegistry(max_sessions=2)
+    reg.get_or_create("a")
+    assert len(reg._sessions) + len(reg._pending) == 1
+    reg.get_or_create("b")
+    assert len(reg._sessions) + len(reg._pending) == 2
+    reg.clear()
+
+
+def test_a_failed_build_releases_its_reservation(monkeypatch):
+    """A construction error must not permanently consume a session slot."""
+
+    def boom(**kw):
+        raise RuntimeError("no model server")
+
+    monkeypatch.setattr(sr, "build_session_agent", boom)
+    reg = sr._SessionRegistry(max_sessions=1)
+    with pytest.raises(RuntimeError):
+        reg.get_or_create("a")
+    assert reg._pending == set()
+
+    monkeypatch.setattr(sr, "build_session_agent", lambda **kw: _FakeAgent(**kw))
+    assert reg.get_or_create("a") is not None
+    reg.clear()
+
+
+# ---------------------------------------------------------------------------
+# The model a session was built with, which the server compares a later turn
+# against instead of silently running the old one.
+# ---------------------------------------------------------------------------
+
+
+def test_a_session_records_the_model_it_was_built_with(registry):
+    session = registry.get_or_create("s", model_id="model-a")
+    assert session.model_id == "model-a"
+
+
+def test_a_session_built_without_a_model_records_none(registry):
+    assert registry.get_or_create("s").model_id is None

--- a/src/gaia/sidecar/caller_auth.py
+++ b/src/gaia/sidecar/caller_auth.py
@@ -215,10 +215,16 @@ class HostOriginMiddleware:
             # Fail closed on an absent/empty Host: HTTP/1.1 requires one and
             # every real client sends it, so "no Host" is a raw-socket caller
             # skipping the rebinding control, not a case to wave through.
-            host = _host_only(headers.get("host", ""))
+            raw_host = headers.get("host", "")
+            host = _host_only(raw_host)
             if host not in config.allowed_hosts:
+                # Keyed on the RAW header: _host_only also returns "" for a
+                # malformed value (`:8141`, an unbracketed `::1`), and calling
+                # that "no Host header" misdirects whoever is debugging it.
                 named = (
-                    f"Host header '{host}'" if host else "A request with no Host header"
+                    f"Host header '{raw_host}'"
+                    if raw_host.strip()
+                    else "A request with no Host header"
                 )
                 await self._reject(
                     scope,

--- a/src/gaia/sidecar/caller_auth.py
+++ b/src/gaia/sidecar/caller_auth.py
@@ -17,8 +17,10 @@ Three controls, keyed on a :class:`CallerAuthConfig` installed at app build:
    process can read it via ``/proc/<pid>/environ`` or ``ps eww``) or directly
    in the *token* env var (legacy). Non-exempt requests must present
    ``Authorization: Bearer <token>``.
-2. **Host allowlist** — the ``Host`` header must be loopback, which is what
-   defeats DNS rebinding (the rebound request carries ``Host: evil.com``).
+2. **Host allowlist** — the ``Host`` header must be present AND loopback, which
+   is what defeats DNS rebinding (the rebound request carries ``Host: evil.com``).
+   An absent or empty ``Host`` is refused too, so a raw-socket client cannot skip
+   the control by omitting the header.
 3. **Origin rejection** — a request carrying a non-loopback browser ``Origin``
    is refused. Non-browser clients send no ``Origin`` and are unaffected.
 
@@ -27,8 +29,10 @@ no token configured the token check is skipped and a loud warning is logged, but
 Host/Origin still apply — so a hand-run developer sidecar keeps the control that
 stops a web page driving it.
 
-Each sidecar binds its own env-var names and exempt paths; everything else is
-shared so the two cannot drift apart.
+A sidecar binds its own env-var names and exempt paths and inherits everything
+else from here. Only the flagship (``gaia_agent.caller_auth``) does so today —
+the email sidecar still carries its own copy of this logic, so a change here
+does NOT reach it.
 """
 
 from __future__ import annotations
@@ -208,16 +212,23 @@ class HostOriginMiddleware:
         if config is not None:
             headers = Headers(scope=scope)
 
+            # Fail closed on an absent/empty Host: HTTP/1.1 requires one and
+            # every real client sends it, so "no Host" is a raw-socket caller
+            # skipping the rebinding control, not a case to wave through.
             host = _host_only(headers.get("host", ""))
-            if host and host not in config.allowed_hosts:
+            if host not in config.allowed_hosts:
+                named = (
+                    f"Host header '{host}'" if host else "A request with no Host header"
+                )
                 await self._reject(
                     scope,
                     receive,
                     send,
                     400,
-                    f"Rejected: Host header '{host}' is not an allowed loopback "
-                    f"host. The {config.surface} serves only 127.0.0.1/localhost; "
-                    "a non-loopback Host is a DNS-rebinding attempt.",
+                    f"Rejected: {named} is not an allowed loopback host. The "
+                    f"{config.surface} serves only 127.0.0.1/localhost; send "
+                    "'Host: 127.0.0.1:<port>'. A non-loopback or absent Host is "
+                    "a DNS-rebinding attempt.",
                 )
                 return
 


### PR DESCRIPTION
A host that drives the flagship sidecar over `/v1/gaia/query` without a `session_id` leaked a whole agent per request — a FAISS index, two SQLite handles, a filesystem watcher and an HTTP session — until the process died.

Worse, the cleanup that *was* there had never run. `_close_agent` looked for a `close_db()` method to call on eviction, and no class in the hierarchy defines one — not `GaiaAgent`, not `ChatAgent`, not the base `Agent`. So `getattr` returned `None`, the helper quietly did nothing, and **every** evicted session leaked too while the code read as if it had cleaned up. That is the silent-fallback failure mode `CLAUDE.md` bans: an agent that exposes no teardown is now a loud error naming the class, not a skipped branch.

Three smaller contract holes went with it, each of which used to resolve by quietly doing the wrong thing:

- A **second turn asking for a different `model`** was accepted and then ignored, because only construction reads a model and a retained session returns the agent it already built. It is now refused with the session's current model named.
- A **reused `run_id`** overwrote the run table, leaving the first run uncancellable and letting either stream's teardown remove the other's entry. Now a 409.
- The **session cap could be exceeded**: capacity was checked in one lock section and the session installed in a later one, so two racing creators both passed at `max-1`. A slot is now reserved while the agent builds, which keeps construction outside the lock.

Also: an absent `Host` header skipped the DNS-rebinding check entirely (`if host and host not in ...`). Browsers always send one, so the drive-by vector stayed covered — this is defence-in-depth, not a practical bypass — but it now fails closed. The email sidecar has the identical line in its own copy; that is #3077.

<details>
<summary>🔍 Technical details</summary>

- `close_agent()` accepts `close()` (flagship) or `close_db()` (email), and logs an error naming the class when neither exists. `GaiaAgent.close()` runs `ChatAgent.__del__`'s teardown eagerly — that body is already individually guarded and idempotent, so the later `__del__` is harmless. The cleaner shape is a real `close()` on `ChatAgent` with `__del__` delegating to it; that touches a second published package and is left as a follow-up.
- `_unwind_setup()` replaces three copies of the pre-loop unwind, so the one-shot agent is released on every path that never reaches the stream. The in-loop release sits in `_run_agent`'s `finally`, which also covers client disconnect (the stream sets the cancel flag, the loop ends, the `finally` runs).
- `EXEMPT_PATHS` was dead config — all three paths are registered on the app, outside the token-guarded router — and is now pinned by a test rather than implying protection it never applied.
- The `/query` module docstring claimed `/respond` did not exist; it is implemented 600 lines below. Fixed, along with the missing `/init`.
- Nits: `GaiaAgent(config=..., **kwargs)` raised nothing while dropping the kwargs, now a `TypeError`; `handler._emit` replaced with the public `print_error`; `/init`'s unused `response` parameter removed from the OpenAPI schema; stdlib `logging` swapped for `gaia.logger.get_logger`.
</details>

## Test plan

- [ ] `pytest hub/agents/gaia/python/tests/` — 249 pass (217 before)
- [ ] `pytest tests/unit/test_sidecar_caller_auth.py hub/agents/email/python/tests/test_caller_auth.py` — 53 pass, so the shared-module change doesn't disturb the email sidecar
- [ ] `python util/lint.py --all` — identical finding count with and without this change (verified by stashing); none in the files touched here
- [ ] The teardown test fails against the old `close_db` probe, which is what proves the helper was a no-op rather than merely untested