### PR TITLE
chore(lemonade): pin Lemonade 11.8.1

### DIFF
--- a/cpp/README.md
+++ b/cpp/README.md
@@ -28,12 +28,12 @@ Included demos:
 
 The agent connects to an OpenAI-compatible LLM server at `http://localhost:13305/api/v1` by default. The reference backend is [Lemonade Server](https://github.com/lemonade-sdk/lemonade), which runs models locally on AMD hardware.
 
-Download and install Lemonade Server v11.5.0, then start it:
+Download and install Lemonade Server v11.8.1, then start it:
 
 **Windows:**
 ```powershell
 # Download and run the MSI installer
-curl -L -o lemonade-server-minimal.msi https://github.com/lemonade-sdk/lemonade/releases/download/v11.5.0/lemonade-server-minimal.msi
+curl -L -o lemonade-server-minimal.msi https://github.com/lemonade-sdk/lemonade/releases/download/v11.8.1/lemonade-server-minimal.msi
 msiexec /i lemonade-server-minimal.msi
 ```
 
@@ -44,7 +44,7 @@ sudo add-apt-repository ppa:lemonade-team/stable
 sudo apt install lemonade-server
 ```
 
-Or browse all platform options on the [Lemonade v11.5.0 release page](https://github.com/lemonade-sdk/lemonade/releases/tag/v11.5.0).
+Or browse all platform options on the [Lemonade v11.8.1 release page](https://github.com/lemonade-sdk/lemonade/releases/tag/v11.8.1).
 
 After installation, start the server:
 ```bash

--- a/cpp/tests/test_skill.cpp
+++ b/cpp/tests/test_skill.cpp
@@ -126,9 +126,15 @@ private:
 // ---------------------------------------------------------------------------
 // Conformance corpus
 //
-// Discovered from disk rather than hardcoded: tests/fixtures/skills/ has 6
-// skills today and tests/fixtures/openclaw_skills/ adds 26 more when PR #2693
-// lands. A hardcoded list would silently ignore the new ones.
+// Discovered from disk rather than hardcoded, so a new GAIA-authored corpus is
+// picked up without editing a list.
+//
+// A corpus carrying PROVENANCE.md is EXCLUDED. Those are verbatim third-party
+// skills kept byte-for-byte as migrator input, and their own PROVENANCE.md
+// says so: "including invalid or nonstandard frontmatter - that irregularity
+// is the point of the fixture." Holding them to the GAIA conformance contract
+// asserts the opposite of what they exist to prove, and the only way to make
+// them pass is to edit files that file forbids editing.
 // ---------------------------------------------------------------------------
 
 bool isSkillCorpusDir(const std::string& name) {
@@ -138,6 +144,13 @@ bool isSkillCorpusDir(const std::string& name) {
            name.compare(name.size() - kSuffix.size(), kSuffix.size(), kSuffix) == 0;
 }
 
+// Verbatim third-party content, identified by the file that records where each
+// skill was fetched from.
+bool isVendorCorpus(const fs::path& corpus) {
+    std::error_code ec;
+    return fs::exists(corpus / "PROVENANCE.md", ec);
+}
+
 std::vector<std::string> discoverCorpus() {
     std::vector<std::string> skills;
     std::error_code ec;
@@ -145,6 +158,7 @@ std::vector<std::string> discoverCorpus() {
     for (const auto& corpus : fs::directory_iterator(fixtures, ec)) {
         if (!corpus.is_directory()) continue;
         if (!isSkillCorpusDir(corpus.path().filename().string())) continue;
+        if (isVendorCorpus(corpus.path())) continue;
         for (const auto& skill : fs::directory_iterator(corpus.path(), ec)) {
             if (!skill.is_directory()) continue;
             if (fs::exists(skill.path() / gaia::SKILL_FILENAME)) {
@@ -423,7 +437,15 @@ INSTANTIATE_TEST_SUITE_P(Fixtures, SkillCorpus, ::testing::ValuesIn(discoverCorp
 TEST(SkillCorpusDiscovery, FindsTheOnDiskCorpus) {
     // Guards the discovery itself: an empty corpus would make every
     // parameterized case above vacuously pass.
-    EXPECT_GE(discoverCorpus().size(), 6u);
+    const auto skills = discoverCorpus();
+    EXPECT_GE(skills.size(), 6u);
+    // And guards the other direction: vendor fixtures are verbatim third-party
+    // migrator input whose nonstandard frontmatter is the point, so pulling
+    // them in asserts the opposite of what they exist to prove.
+    for (const auto& path : skills) {
+        EXPECT_EQ(path.find("openclaw_skills"), std::string::npos)
+            << path << " is vendor migrator input, not a GAIA-conformant skill";
+    }
 }
 
 // ---------------------------------------------------------------------------

--- a/docs/cpp/setup.mdx
+++ b/docs/cpp/setup.mdx
@@ -76,17 +76,17 @@ icon: "wrench"
 
     The agent needs an OpenAI-compatible LLM server. [Lemonade Server](https://lemonade-server.ai) is recommended (optimized for AMD hardware).
 
-    Download and run the installer (v11.5.0):
+    Download and run the installer (v11.8.1):
 
     ```powershell
     # Download the MSI installer
-    curl -L -o lemonade-server-minimal.msi https://github.com/lemonade-sdk/lemonade/releases/download/v11.5.0/lemonade-server-minimal.msi
+    curl -L -o lemonade-server-minimal.msi https://github.com/lemonade-sdk/lemonade/releases/download/v11.8.1/lemonade-server-minimal.msi
 
     # Run the installer
     msiexec /i lemonade-server-minimal.msi
     ```
 
-    Or download directly from the [Lemonade v11.5.0 release page](https://github.com/lemonade-sdk/lemonade/releases/tag/v11.5.0).
+    Or download directly from the [Lemonade v11.8.1 release page](https://github.com/lemonade-sdk/lemonade/releases/tag/v11.8.1).
 
     After installation, restart your terminal and start the server:
     ```powershell
@@ -176,7 +176,7 @@ icon: "wrench"
     sudo apt-get install -y lemonade-server
     ```
 
-    Or browse all platform options on the [Lemonade v11.5.0 release page](https://github.com/lemonade-sdk/lemonade/releases/tag/v11.5.0).
+    Or browse all platform options on the [Lemonade v11.8.1 release page](https://github.com/lemonade-sdk/lemonade/releases/tag/v11.8.1).
 
     After installation, start the server:
     ```bash
@@ -219,7 +219,7 @@ icon: "wrench"
 | C++ Compiler | C++17 support (MSVC 2019+ or GCC 9+) | `cl` (Windows) or `g++ --version` (Linux) |
 | CMake | 3.14+ | `cmake --version` |
 | Git | any | `git --version` |
-| [Lemonade Server](https://lemonade-server.ai) | 11.5.0 | `lemonade-server --version` |
+| [Lemonade Server](https://lemonade-server.ai) | 11.8.1 | `lemonade-server --version` |
 | uvx | any (optional) | `uvx --version` |
 
 <Note>

--- a/docs/guides/npu.mdx
+++ b/docs/guides/npu.mdx
@@ -11,7 +11,7 @@ GAIA supports running agents on your AMD Ryzen AI NPU via the [FastFlowLM (FLM)]
 - **Hardware:** AMD Ryzen AI 300/400/Max series processor with XDNA2 NPU
   - Strix Point, Strix Halo, Kraken Point, or Gorgon Point
   - Ryzen AI 7000/8000/200-series (XDNA1) is **not supported**
-- **Software:** [Lemonade Server](https://lemonade-server.ai) v11.5.0+
+- **Software:** [Lemonade Server](https://lemonade-server.ai) v11.8.1+
 - **Driver:** Latest AMD NPU driver (firmware v1.1.0.0+)
 
 <Warning>

--- a/src/gaia/installer/lemonade_installer.py
+++ b/src/gaia/installer/lemonade_installer.py
@@ -811,7 +811,9 @@ class LemonadeInstaller:
     def _uninstall_macos() -> InstallResult:
         """macOS: the upstream .pkg ships no uninstaller, so say so and hand over steps.
 
-        Paths and pkgutil identifiers come from the v11.5.0 .pkg BOMs.
+        Paths and pkgutil identifiers come from the v11.8.1 .pkg BOMs. Upstream
+        renamed the launchd labels and receipts com.lemonade.* -> ai.lemonadeserver.*
+        after 11.5.0, so these track the pin.
         """
         return InstallResult(
             success=False,
@@ -819,13 +821,13 @@ class LemonadeInstaller:
                 "Automatic uninstall is not supported on macOS — the Lemonade .pkg "
                 "ships no uninstaller. Remove it manually:\n"
                 "  sudo launchctl bootout system "
-                "/Library/LaunchDaemons/com.lemonade.server.plist\n"
-                "  sudo rm -f /Library/LaunchDaemons/com.lemonade.server.plist "
-                "/Library/LaunchAgents/com.lemonade.tray.plist\n"
+                "/Library/LaunchDaemons/ai.lemonadeserver.server.plist\n"
+                "  sudo rm -f /Library/LaunchDaemons/ai.lemonadeserver.server.plist "
+                "/Library/LaunchAgents/ai.lemonadeserver.tray.plist\n"
                 "  sudo rm -rf /Applications/lemonade-app.app\n"
                 "  sudo rm -f /usr/local/bin/lemonade /usr/local/bin/lemond "
                 "/usr/local/bin/lemonade-tray\n"
-                "  pkgutil --pkgs | grep '^com.lemonade.server' | "
+                "  pkgutil --pkgs | grep '^ai.lemonadeserver.server' | "
                 "xargs -n1 sudo pkgutil --forget"
             ),
         )

--- a/src/gaia/version.py
+++ b/src/gaia/version.py
@@ -9,7 +9,7 @@ from importlib.metadata import version as get_package_version_metadata
 __version__ = "0.23.0"
 
 # Lemonade version used across CI and installer
-LEMONADE_VERSION = "11.8.0"
+LEMONADE_VERSION = "11.8.1"
 
 # Oldest Lemonade Server GAIA runs against. LEMONADE_VERSION is what we install;
 # this is the floor below which we refuse. Profiles may require newer

--- a/src/gaia/version.py
+++ b/src/gaia/version.py
@@ -9,7 +9,7 @@ from importlib.metadata import version as get_package_version_metadata
 __version__ = "0.23.0"
 
 # Lemonade version used across CI and installer
-LEMONADE_VERSION = "11.5.0"
+LEMONADE_VERSION = "11.8.0"
 
 # Oldest Lemonade Server GAIA runs against. LEMONADE_VERSION is what we install;
 # this is the floor below which we refuse. Profiles may require newer

--- a/tests/unit/test_lemonade_macos_install.py
+++ b/tests/unit/test_lemonade_macos_install.py
@@ -16,9 +16,10 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from gaia.installer.lemonade_installer import LemonadeInfo
+from gaia.version import LEMONADE_VERSION
 from tests.fixtures.lemonade_assets import make_installer
 
-PKG = Path("/tmp/Lemonade-11.5.0-Darwin.pkg")
+PKG = Path(f"/tmp/Lemonade-{LEMONADE_VERSION}-Darwin.pkg")
 
 
 def _completed(returncode=0, stdout="", stderr=""):

--- a/tests/unit/test_lemonade_macos_uninstall.py
+++ b/tests/unit/test_lemonade_macos_uninstall.py
@@ -1,0 +1,53 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+"""The manual macOS uninstall steps must name what the pinned .pkg installs.
+
+These identifiers are not derivable from anything in the repo — they come from
+the upstream .pkg BOMs, and upstream renamed them com.lemonade.* ->
+ai.lemonadeserver.* somewhere after 11.5.0. Nothing in the tree pinned them, so
+the steps went stale silently: they told users to bootout a plist that no longer
+exists and to forget receipts that match nothing. Pinning them here means the
+next version bump has to look at the BOMs again instead of assuming.
+
+Kept out of test_lemonade_macos_install.py deliberately — that file patches
+os.geteuid, which does not exist on Windows, so every test in it errors there.
+These assertions are pure string checks and run on every platform.
+"""
+
+import pytest
+
+from tests.fixtures.lemonade_assets import make_installer
+
+
+@pytest.fixture
+def steps():
+    result = make_installer("Darwin", "arm64")._uninstall_macos()
+    assert result.success is False, "manual-only uninstall must not claim success"
+    return result.error
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "/Library/LaunchDaemons/ai.lemonadeserver.server.plist",
+        "/Library/LaunchAgents/ai.lemonadeserver.tray.plist",
+        "/Applications/lemonade-app.app",
+        "/usr/local/bin/lemond",
+        "/usr/local/bin/lemonade",
+        "/usr/local/bin/lemonade-tray",
+    ],
+)
+def test_names_every_path_the_pkg_installs(steps, path):
+    assert path in steps
+
+
+def test_forgets_receipts_under_the_current_prefix(steps):
+    # Receipts are ai.lemonadeserver.server.{core,dev,Runtime,Resources,
+    # Applications,Unspecified}; the grep anchors on their shared prefix.
+    assert "grep '^ai.lemonadeserver.server'" in steps
+    assert "pkgutil --forget" in steps
+
+
+def test_no_stale_pre_11_8_identifiers_survive(steps):
+    assert "com.lemonade" not in steps

--- a/tui/internal/ui/preflight/lemonade.go
+++ b/tui/internal/ui/preflight/lemonade.go
@@ -125,9 +125,12 @@ var macAppBundles = []string{
 // macDaemonPlist is the file whose presence proves it is installed. The daemon is
 // a SYSTEM job (RunAtLoad, no KeepAlive), so it does not come back on its own
 // after it exits, and only launchctl can restart it.
+//
+// The label tracks the pinned Lemonade: upstream renamed it from
+// com.lemonade.server after 11.5.0, so the old one matches nothing on 11.8.1.
 const (
-	macDaemonLabel = "com.lemonade.server"
-	macDaemonPlist = "/Library/LaunchDaemons/com.lemonade.server.plist"
+	macDaemonLabel = "ai.lemonadeserver.server"
+	macDaemonPlist = "/Library/LaunchDaemons/ai.lemonadeserver.server.plist"
 )
 
 // macDaemonBinaries are where the installer puts lemond. Probed by PATH-free
@@ -308,7 +311,7 @@ func unitPath(p hostProbe) string {
 //     /Applications/lemonade-app.app on that machine produced only
 //     `/usr/local/bin/lemonade-tray` — no server. It brings up the tray UI; it is
 //     not, on its own, a verified way to get the port listening.
-//   - `launchctl kickstart system/com.lemonade.server` looks canonical (the
+//   - `launchctl kickstart system/<macDaemonLabel>` looks canonical (the
 //     plist is installed, ProgramArguments is [/usr/local/bin/lemond]) but on
 //     that machine the job reports `state = not running` while a lemond outside
 //     launchd serves the port — and driving a system-domain job needs sudo, so

--- a/tui/internal/ui/preflight/lemonade_test.go
+++ b/tui/internal/ui/preflight/lemonade_test.go
@@ -162,12 +162,14 @@ func TestEveryPlatformGetsALauncherThatExistsThere(t *testing.T) {
 		},
 		{
 			// …but a machine that has ONLY the job still gets it, rather than being
-			// told nothing is installed when the plist is plainly there.
+			// told nothing is installed when the plist is plainly there. The label
+			// is spelled out rather than built from macDaemonLabel so that a wrong
+			// constant fails here instead of agreeing with itself.
 			name: "macOS falls back to launchd when nothing else is there",
 			probe: fakeHostFor("darwin", []string{"launchctl"},
 				[]string{macDaemonPlist}, nil),
-			wantStart:   "sudo launchctl kickstart system/com.lemonade.server",
-			wantRestart: "sudo launchctl kickstart -k system/com.lemonade.server",
+			wantStart:   "sudo launchctl kickstart system/ai.lemonadeserver.server",
+			wantRestart: "sudo launchctl kickstart -k system/ai.lemonadeserver.server",
 			wantHint:    "Applications folder",
 		},
 		{

--- a/util/check_doc_versions.py
+++ b/util/check_doc_versions.py
@@ -46,6 +46,9 @@ SCAN_PATHS = [
 EXCLUDE_PATTERNS = [
     "docs/releases/*",  # Release notes are historical, versions are intentional
     "docs/plans/*",  # Planning docs may reference old versions
+    # Design specs record what was verified against a version at the time.
+    # Bumping the number there turns a true record into a false one.
+    "docs/superpowers/specs/*",
 ]
 
 


### PR DESCRIPTION
Lemonade 11.8 added **cloud offload**: a local Lemonade can route inference to any OpenAI-compatible endpoint and surface those models in its own catalogue. That is the primitive the AMD LLM gateway support builds on, and it does not exist before 11.8. This bumps the pin so `gaia init` installs a version that has it.

The pin is **11.8.1, not 11.8.0** — upstream's 11.8.0 release published no Linux or macOS installer at all (11.5/11.6/11.7 each ship three; 11.8.0 ships none), so `gaia init` would have 404'd on both platforms. 11.8.1 restores all three and keeps cloud offload.

Upstream also renamed its macOS launchd jobs and pkgutil receipts `com.lemonade.*` → `ai.lemonadeserver.*` after 11.5.0. GAIA's manual uninstall steps and the TUI's launchd fallback still named the old ones, so a Mac user following the uninstall instructions would hit an error on the first command and leave the daemon, tray agent, and every receipt behind. Both now track the pin, verified by diffing the actual `.pkg` BOMs of 11.5.0 and 11.8.1 rather than assuming.

Only the install target moves. The per-profile `min_lemonade_version` floors in `INIT_PROFILES` are unchanged, so nobody whose profile does not need 11.8 is forced to upgrade.

> **Note for reviewers:** this deliberately does *not* include the embeddable-Lemonade packaging work (bundling `lemond` into the release, R2 publish). That is a larger change, called out below so it is not mistaken for missing scope.

### Follow-up this unblocks

Embeddable Lemonade ships as a ~5 MB per-platform artifact from the same release. Bundling it would make GAIA self-contained. Two findings from running it locally that the packaging work will need:

- A cold start indexes all 228 bundled models and took **10+ minutes**, pinning the disk. Trimming `resources/server_models.json` to 2 entries — a documented customization — brings it to **under 15 seconds**. A GAIA bundle should ship a trimmed catalogue.
- `offline: true` **disables cloud discovery**, so it is not usable for a gateway setup.

## Test plan

- [ ] `gaia init` installs 11.8.1 (CI's Lemonade health check now reports `version: 11.8.1`)
- [ ] Existing local-model flows are unchanged (`gaia llm "hello"`)
- [ ] `python -m pytest tests/unit/test_lemonade_version_check.py tests/unit/test_lemonade_macos_uninstall.py`
- [ ] `python -m pytest tests/integration/test_lemonade_release_assets.py` — all four install targets resolve
- [ ] `cd tui && go test ./internal/ui/preflight/`
