### PR TITLE
feat(lemonade): run a private, self-contained Lemonade Server

### DIFF
--- a/docs/reference/cli.mdx
+++ b/docs/reference/cli.mdx
@@ -1542,22 +1542,26 @@ gaia lemonade embedded status
 gaia lemonade embedded stop
 ```
 
-`start` prints the two variables you need. Both are required — the port changes
-every start, and requests without the key get a 401:
+Both the port and the API key change on every start, and requests without the key
+get a 401. `start` writes them to a file you source rather than printing the key,
+so the secret never lands in terminal scrollback, shell history or a CI log:
 
 ```
-✅ Embedded Lemonade 11.8.0 running on http://localhost:62232/api/v1
+✅ Embedded Lemonade 11.8.1 running on http://localhost:62232/api/v1
    pid 26080   logs: ~/.gaia/lemonade/lemond.log
 
-   The instance is private — every request needs both:
-   export LEMONADE_BASE_URL=http://localhost:62232/api/v1
-   export LEMONADE_API_KEY=xUq3...
+   The instance is private. Load its URL and API key with:
+   source ~/.gaia/lemonade/env.sh
 ```
 
+The file sets `LEMONADE_BASE_URL` and `LEMONADE_API_KEY`, is owner-readable only,
+and is deleted on `stop` — credentials naming a dead port are worse than none,
+since whatever grabs that port next would inherit the trust. On Windows it is
+`env.ps1`, loaded with `. $HOME\.gaia\lemonade\env.ps1`.
+
 <Note>
-GAIA agents do not pick the embedded instance up on their own yet — export those
-two variables to point them at it. Automatic preference is coming with the
-startup wiring.
+GAIA agents do not pick the embedded instance up on their own yet — source that
+file to point them at it. Automatic preference is coming with the startup wiring.
 </Note>
 
 ### Commands
@@ -1612,7 +1616,8 @@ Everything lives under `~/.gaia/lemonade` (or `$GAIA_HOME/lemonade`):
 | `dist/<version>/` | The unpacked server for one version |
 | `cache/` | Downloaded backends (`bin/`), shared across versions |
 | `config/config.json` | Server configuration |
-| `state.json` | The running instance: pid, port, API key |
+| `state.json` | The running instance: pid, port, API key (owner-only) |
+| `env.sh` / `env.ps1` | Sourceable credentials, removed on `stop` (owner-only) |
 | `lemond.log` | Server output — read this first when `start` fails |
 
 Downloaded **models** are not duplicated: the embedded server reads the same

--- a/docs/reference/cli.mdx
+++ b/docs/reference/cli.mdx
@@ -1526,6 +1526,113 @@ Use `lemonade-server list` to see all available models and their download status
 
 ---
 
+## Embedded Lemonade
+
+GAIA can run its own private Lemonade Server instead of the machine-wide install.
+Nothing else on the machine can reach it: it binds a port picked at start time and
+requires an API key GAIA generates, so two apps never fight over one server.
+
+This is the self-contained path — GAIA downloads the server itself, no installer
+and no admin rights. The system-wide install (`gaia init`) is unaffected and keeps
+serving everything else.
+
+```bash
+gaia lemonade embedded start      # download if needed, then run
+gaia lemonade embedded status
+gaia lemonade embedded stop
+```
+
+`start` prints the two variables you need. Both are required — the port changes
+every start, and requests without the key get a 401:
+
+```
+✅ Embedded Lemonade 11.8.0 running on http://localhost:62232/api/v1
+   pid 26080   logs: ~/.gaia/lemonade/lemond.log
+
+   The instance is private — every request needs both:
+   export LEMONADE_BASE_URL=http://localhost:62232/api/v1
+   export LEMONADE_API_KEY=xUq3...
+```
+
+<Note>
+GAIA agents do not pick the embedded instance up on their own yet — export those
+two variables to point them at it. Automatic preference is coming with the
+startup wiring.
+</Note>
+
+### Commands
+
+| Command | Description |
+|---------|-------------|
+| `start` | Start the private instance, downloading the artifact if missing |
+| `stop` | Stop the private instance |
+| `status` | Show installed version, running port, and installed backends |
+| `install` | Download and unpack the artifact without starting it |
+| `install-backend SPEC` | Download an inference backend, e.g. `llamacpp:vulkan` |
+
+**`start` options:**
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `--port` | integer | auto | Port to bind; a free one is chosen when omitted |
+| `--no-install` | flag | false | Fail instead of downloading a missing artifact |
+| `--timeout` | float | 60 | Seconds to wait for the server to become healthy |
+
+**`install` options:**
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `--force` | flag | false | Re-download and unpack even if already installed. Refuses while an instance is running — stop it first |
+
+### Inference backends
+
+The downloaded server is small (~5 MB) and ships **no inference backend** — those
+are fetched separately, and only the ones your hardware needs:
+
+| Backend | Size | Covers |
+|---------|------|--------|
+| `llamacpp:cpu` | ~45 MB | CPU inference |
+| `llamacpp:vulkan` | ~96 MB | AMD iGPU / dGPU |
+| `flm:npu` | ~169 MB | Ryzen AI NPU |
+| `llamacpp:rocm` | ~4.3 GB | ROCm, including a per-GPU runtime |
+
+GAIA's default models (`Gemma-4-E4B-it-GGUF`, `embeddinggemma-300m`) run on the
+`llamacpp` backends, so CPU + Vulkan is enough for the common case:
+
+```bash
+gaia lemonade embedded install-backend llamacpp:vulkan
+```
+
+### Where it stores things
+
+Everything lives under `~/.gaia/lemonade` (or `$GAIA_HOME/lemonade`):
+
+| Path | Contents |
+|------|----------|
+| `dist/<version>/` | The unpacked server for one version |
+| `cache/` | Downloaded backends (`bin/`), shared across versions |
+| `config/config.json` | Server configuration |
+| `state.json` | The running instance: pid, port, API key |
+| `lemond.log` | Server output — read this first when `start` fails |
+
+Downloaded **models** are not duplicated: the embedded server reads the same
+Hugging Face cache as every other Lemonade install, so models you already have
+are picked up immediately.
+
+<Note>
+`cache/` is deliberately shared across versions. Backends run from 141 MB to
+4.3 GB, so a Lemonade version bump re-downloads the 5 MB server, not the backends.
+</Note>
+
+After a Lemonade version bump, stop the old instance before starting the new one —
+`start` refuses rather than silently leaving the previous version serving:
+
+```bash
+gaia lemonade embedded stop && gaia lemonade embedded start
+```
+
+---
+
 ## Evaluation Commands
 
 <Card title="Evaluation Framework" icon="chart-bar" href="/reference/eval">

--- a/src/gaia/cli.py
+++ b/src/gaia/cli.py
@@ -7220,6 +7220,15 @@ def handle_lemonade_embedded_command(args):
     except EmbeddedLemonadeError as e:
         print(f"❌ {e}")
         sys.exit(1)
+    except OSError as e:
+        # Spawning the daemon or opening its log can fail on a noexec mount or
+        # a read-only home; say so instead of dumping a traceback.
+        print(
+            f"❌ Could not run embedded Lemonade from {manager.dist_dir}: {e}. "
+            f"Check that the directory is writable and the daemon is "
+            f"executable, then retry."
+        )
+        sys.exit(1)
 
 
 def _print_embedded_status(manager):
@@ -7247,7 +7256,7 @@ def _print_embedded_status(manager):
         if status.installed:
             print("           start it with `gaia lemonade embedded start`")
         else:
-            print("           install it with `gaia lemonade embedded start`")
+            print("           install it with `gaia lemonade embedded install`")
     backends_dir = manager.cache_dir / "bin"
     if backends_dir.is_dir():
         installed = sorted(p.name for p in backends_dir.iterdir())

--- a/src/gaia/cli.py
+++ b/src/gaia/cli.py
@@ -7199,9 +7199,8 @@ def handle_lemonade_embedded_command(args):
             print(f"✅ Embedded Lemonade {status.version} running on {status.base_url}")
             print(f"   pid {status.pid}   logs: {manager.log_path}")
             print("")
-            print("   The instance is private — every request needs both:")
-            print(f"   export LEMONADE_BASE_URL={status.base_url}")
-            print(f"   export LEMONADE_API_KEY={manager.current_api_key()}")
+            print("   The instance is private. Load its URL and API key with:")
+            print(f"   {manager.env_load_command()}")
         elif action == "stop":
             if manager.stop():
                 print("✅ Embedded Lemonade stopped")

--- a/src/gaia/cli.py
+++ b/src/gaia/cli.py
@@ -2543,6 +2543,57 @@ Examples:
     )
     mcp_test_client_parser.add_argument("name", help="Name of the MCP server to test")
 
+    # Lemonade command (embedded server lifecycle)
+    lemonade_parser = subparsers.add_parser(
+        "lemonade", help="Manage the Lemonade Server GAIA runs against"
+    )
+    lemonade_subparsers = lemonade_parser.add_subparsers(
+        dest="lemonade_action", help="Lemonade action to perform"
+    )
+    embedded_parser = lemonade_subparsers.add_parser(
+        "embedded",
+        help="Manage GAIA's private, self-contained Lemonade instance",
+    )
+    embedded_subparsers = embedded_parser.add_subparsers(
+        dest="embedded_action", help="Embedded Lemonade action to perform"
+    )
+    embedded_start_parser = embedded_subparsers.add_parser(
+        "start", help="Start the private Lemonade instance (downloads it if missing)"
+    )
+    embedded_start_parser.add_argument(
+        "--port",
+        type=int,
+        help="Port to bind (default: a free port chosen at start)",
+    )
+    embedded_start_parser.add_argument(
+        "--no-install",
+        action="store_true",
+        help="Fail instead of downloading when the artifact is missing",
+    )
+    embedded_start_parser.add_argument(
+        "--timeout",
+        type=float,
+        default=60.0,
+        help="Seconds to wait for the server to become healthy (default: 60)",
+    )
+    embedded_subparsers.add_parser("stop", help="Stop the private Lemonade instance")
+    embedded_subparsers.add_parser(
+        "status", help="Show whether the private instance is installed and running"
+    )
+    embedded_install_parser = embedded_subparsers.add_parser(
+        "install", help="Download and unpack the embeddable artifact"
+    )
+    embedded_install_parser.add_argument(
+        "--force", action="store_true", help="Reinstall even if already unpacked"
+    )
+    embedded_backend_parser = embedded_subparsers.add_parser(
+        "install-backend",
+        help="Download an inference backend into the private cache",
+    )
+    embedded_backend_parser.add_argument(
+        "spec", help="Backend spec, e.g. llamacpp:vulkan (recipe:backend)"
+    )
+
     # Daemon command (headless custody daemon lifecycle)
     daemon_parser = subparsers.add_parser(
         "daemon",
@@ -4175,6 +4226,10 @@ Let me know your answer!
     # Handle MCP command
     if args.action == "mcp":
         handle_mcp_command(args)
+        return
+
+    if args.action == "lemonade":
+        handle_lemonade_command(args)
         return
 
     if args.action == "daemon":
@@ -7100,6 +7155,106 @@ def handle_mcp_command(args):
     else:
         log.error(f"Unknown MCP action: {args.mcp_action}")
         print(f"❌ Unknown MCP action: {args.mcp_action}")
+
+
+def handle_lemonade_command(args):
+    """Handle ``gaia lemonade ...``.
+
+    Args:
+        args: Parsed arguments for the lemonade command.
+    """
+    if getattr(args, "lemonade_action", None) != "embedded":
+        print(
+            "❌ No Lemonade action specified. Use 'gaia lemonade --help' to see "
+            "available actions."
+        )
+        sys.exit(1)
+    handle_lemonade_embedded_command(args)
+
+
+def handle_lemonade_embedded_command(args):
+    """Handle ``gaia lemonade embedded {start,stop,status,install,install-backend}``.
+
+    Args:
+        args: Parsed arguments for the embedded subcommand.
+    """
+    from gaia.llm.lemonade_embedded import EmbeddedLemonade, EmbeddedLemonadeError
+
+    action = getattr(args, "embedded_action", None)
+    if action is None:
+        print(
+            "❌ No embedded action specified. Use 'gaia lemonade embedded --help' "
+            "to see available actions."
+        )
+        sys.exit(1)
+
+    manager = EmbeddedLemonade()
+    try:
+        if action == "start":
+            status = manager.start(
+                port=getattr(args, "port", None),
+                timeout=getattr(args, "timeout", 60.0),
+                install_if_missing=not getattr(args, "no_install", False),
+            )
+            print(f"✅ Embedded Lemonade {status.version} running on {status.base_url}")
+            print(f"   pid {status.pid}   logs: {manager.log_path}")
+            print("")
+            print("   The instance is private — every request needs both:")
+            print(f"   export LEMONADE_BASE_URL={status.base_url}")
+            print(f"   export LEMONADE_API_KEY={manager.current_api_key()}")
+        elif action == "stop":
+            if manager.stop():
+                print("✅ Embedded Lemonade stopped")
+            else:
+                print("Embedded Lemonade is not running")
+        elif action == "status":
+            _print_embedded_status(manager)
+        elif action == "install":
+            path = manager.install(force=getattr(args, "force", False))
+            print(f"✅ Embedded Lemonade {manager.version} installed at {path}")
+        elif action == "install-backend":
+            print(f"Installing backend {args.spec} (this can take several minutes)...")
+            manager.install_backend(args.spec)
+            print(f"✅ Backend {args.spec} installed into {manager.cache_dir / 'bin'}")
+        else:
+            print(f"❌ Unknown embedded action: {action}")
+    except EmbeddedLemonadeError as e:
+        print(f"❌ {e}")
+        sys.exit(1)
+
+
+def _print_embedded_status(manager):
+    """Print a human-readable snapshot of the embedded instance.
+
+    Args:
+        manager: An ``EmbeddedLemonade`` to query.
+    """
+    status = manager.status()
+    print(f"Version:   {status.version}")
+    print(f"Installed: {'yes' if status.installed else 'no'} ({manager.dist_dir})")
+    if status.running:
+        print(f"Running:   yes on {status.base_url} (pid {status.pid})")
+    elif status.unresponsive_pid:
+        print(
+            f"Running:   process {status.unresponsive_pid} is up on port "
+            f"{status.port} but not answering"
+        )
+        print(
+            f"           check {manager.log_path}, then `gaia lemonade "
+            f"embedded stop`"
+        )
+    else:
+        print("Running:   no")
+        if status.installed:
+            print("           start it with `gaia lemonade embedded start`")
+        else:
+            print("           install it with `gaia lemonade embedded start`")
+    backends_dir = manager.cache_dir / "bin"
+    if backends_dir.is_dir():
+        installed = sorted(p.name for p in backends_dir.iterdir())
+        print(f"Backends:  {', '.join(installed) if installed else 'none'}")
+    else:
+        print("Backends:  none")
 
 
 # Kept in sync with gaia.mcp.mcp_bridge.AUTH_TOKEN_ENV_VAR by

--- a/src/gaia/llm/lemonade_embedded.py
+++ b/src/gaia/llm/lemonade_embedded.py
@@ -214,25 +214,132 @@ def _free_port() -> int:
         return int(sock.getsockname()[1])
 
 
-def _safe_members_ok(names, dest: Path) -> None:
-    """Reject archive entries that would land outside *dest*.
+def _reject(entry: str, detail: str) -> "EmbeddedLemonadeError":
+    """Build the refusal raised for an archive member GAIA will not unpack.
 
     Args:
-        names: Archive member names.
-        dest: Directory the archive unpacks into.
+        entry: Name of the offending member.
+        detail: What is wrong with it.
+
+    Returns:
+        The error to raise.
+    """
+    return EmbeddedLemonadeError(
+        f"Refusing to unpack embedded Lemonade: archive entry '{entry}' "
+        f"{detail}. The download is corrupt or tampered with -- delete it and "
+        f"retry, and report it at {RELEASES_PAGE}."
+    )
+
+
+def _destination_for(name: str, dest: Path) -> Path:
+    """Resolve where *name* may be written under *dest*.
+
+    Absolute names, drive letters and ``..`` segments all resolve to somewhere
+    outside *dest* and are refused by the containment check.
+
+    Args:
+        name: Archive member name.
+        dest: Already-resolved directory the archive unpacks into.
+
+    Returns:
+        The absolute path the member is allowed to occupy.
+
+    Raises:
+        EmbeddedLemonadeError: The member escapes *dest*.
+    """
+    target = (dest / name).resolve()
+    if target != dest and dest not in target.parents:
+        raise _reject(name, f"escapes {dest}")
+    return target
+
+
+def _write_link(member: tarfile.TarInfo, target: Path, dest: Path) -> None:
+    """Recreate a symlink or hard link, refusing one that points out of *dest*.
+
+    Args:
+        member: The link member.
+        target: Validated path the link itself occupies.
+        dest: Already-resolved directory the archive unpacks into.
+
+    Raises:
+        EmbeddedLemonadeError: The link points outside *dest*.
+    """
+    # A symlink's target is read relative to the directory holding it; a hard
+    # link names another member, relative to the archive root.
+    anchor = target.parent if member.issym() else dest
+    pointee = (anchor / member.linkname).resolve()
+    if pointee != dest and dest not in pointee.parents:
+        raise _reject(member.name, f"links to '{member.linkname}', outside {dest}")
+
+    target.parent.mkdir(parents=True, exist_ok=True)
+    if member.issym():
+        os.symlink(member.linkname, target)
+    else:
+        os.link(pointee, target)
+
+
+def _extract_tar(archive: Path, dest: Path) -> None:
+    """Unpack a ``.tar.gz`` into *dest*, one validated member at a time.
+
+    Every member is materialised explicitly rather than through
+    ``extractall``: tar carries symlinks, hard links and device nodes, and the
+    bulk API's safety depends on a ``filter`` argument that only exists from
+    Python 3.10.12 on. Writing each member ourselves is the same guarantee on
+    every interpreter GAIA supports.
+
+    Args:
+        archive: The ``.tar.gz`` file.
+        dest: Already-resolved directory to unpack into.
+
+    Raises:
+        EmbeddedLemonadeError: A member escapes *dest* or is a special file.
+    """
+    with tarfile.open(archive, "r:gz") as handle:
+        links = []
+        for member in handle.getmembers():
+            target = _destination_for(member.name, dest)
+            if member.isdir():
+                target.mkdir(parents=True, exist_ok=True)
+            elif member.isfile():
+                source = handle.extractfile(member)
+                if source is None:
+                    raise _reject(member.name, "is an unreadable file entry")
+                target.parent.mkdir(parents=True, exist_ok=True)
+                with source, open(target, "wb") as sink:
+                    shutil.copyfileobj(source, sink)
+                # & 0o777 drops setuid, setgid and sticky; nothing in the
+                # published artifact needs them.
+                target.chmod(member.mode & 0o777)
+            elif member.issym() or member.islnk():
+                links.append((member, target))
+            else:
+                raise _reject(member.name, "is a device or special file")
+
+        # Links go last. Created inline, one could become a path component a
+        # later member is written through -- the write would follow it out of
+        # dest even though the member's own name resolved inside.
+        for member, target in links:
+            _write_link(member, target, dest)
+
+
+def _extract_zip(archive: Path, dest: Path) -> None:
+    """Unpack a ``.zip`` into *dest*, one validated member at a time.
+
+    ``zipfile`` silently rewrites a traversing member name to a harmless one.
+    Checking first turns that into the loud failure a tampered artifact
+    deserves.
+
+    Args:
+        archive: The ``.zip`` file.
+        dest: Already-resolved directory to unpack into.
 
     Raises:
         EmbeddedLemonadeError: A member escapes *dest*.
     """
-    dest_resolved = dest.resolve()
-    for name in names:
-        target = (dest_resolved / name).resolve()
-        if dest_resolved != target and dest_resolved not in target.parents:
-            raise EmbeddedLemonadeError(
-                f"Refusing to unpack embedded Lemonade: archive entry '{name}' "
-                f"escapes {dest_resolved}. The download is corrupt or tampered "
-                f"with -- delete it and retry, and report it at {RELEASES_PAGE}."
-            )
+    with zipfile.ZipFile(archive) as handle:
+        for name in handle.namelist():
+            _destination_for(name, dest)
+            handle.extract(name, dest)
 
 
 def _extract(archive: Path, dest: Path) -> None:
@@ -246,31 +353,11 @@ def _extract(archive: Path, dest: Path) -> None:
         EmbeddedLemonadeError: Unknown suffix or an unsafe member path.
     """
     dest.mkdir(parents=True, exist_ok=True)
+    resolved = dest.resolve()
     if archive.name.endswith(".zip"):
-        with zipfile.ZipFile(archive) as zf:
-            _safe_members_ok(zf.namelist(), dest)
-            zf.extractall(dest)
+        _extract_zip(archive, resolved)
     elif archive.name.endswith((".tar.gz", ".tgz")):
-        with tarfile.open(archive, "r:gz") as tf:
-            members = tf.getmembers()
-            _safe_members_ok([m.name for m in members], dest)
-            # Names alone miss a symlink pointing out of the tree that a later
-            # member then writes through; Python < 3.12 has no data filter.
-            for member in members:
-                if member.issym() or member.islnk():
-                    _safe_members_ok(
-                        [os.path.join(os.path.dirname(member.name), member.linkname)],
-                        dest,
-                    )
-                elif not (member.isfile() or member.isdir()):
-                    raise EmbeddedLemonadeError(
-                        f"Refusing to unpack embedded Lemonade: '{member.name}' "
-                        f"is a device or special file. The download is corrupt "
-                        f"or tampered with -- retry, and report it at "
-                        f"{RELEASES_PAGE}."
-                    )
-            extra = {"filter": "data"} if hasattr(tarfile, "data_filter") else {}
-            tf.extractall(dest, **extra)
+        _extract_tar(archive, resolved)
     else:
         raise EmbeddedLemonadeError(
             f"Cannot unpack '{archive.name}': expected a .zip or .tar.gz "
@@ -553,15 +640,21 @@ class EmbeddedLemonade:
     def _write_state(self, state: dict) -> None:
         """Persist the running instance.
 
-        The file holds the API key that is the server's only protection, so it
-        is created 0600 rather than chmod-ed afterwards -- a chmod leaves the
-        key world-readable in between.
+        The file holds the API key that is the server's only protection, so on
+        POSIX it is created 0600 rather than chmod-ed afterwards -- a chmod
+        leaves the key world-readable in between. The old file is removed first
+        because the mode argument only applies when ``open`` creates the file;
+        rewriting one left behind by an earlier build would keep its mode.
+
+        Windows ignores the mode bits; there the file is protected by the ACL
+        it inherits from the user's profile directory.
 
         Args:
             state: pid, port, api_key and version of the live daemon.
         """
         self.root.mkdir(parents=True, exist_ok=True)
-        flags = os.O_WRONLY | os.O_CREAT | os.O_TRUNC
+        self.state_path.unlink(missing_ok=True)
+        flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL
         descriptor = os.open(self.state_path, flags, stat.S_IRUSR | stat.S_IWUSR)
         with os.fdopen(descriptor, "w", encoding="utf-8") as handle:
             json.dump(state, handle, indent=2)
@@ -681,7 +774,7 @@ class EmbeddedLemonade:
 
         if self._daemon_alive(int(pid)):
             log.warning(
-                "Embedded Lemonade (pid %s) is running but not answering on " "port %s",
+                "Embedded Lemonade (pid %s) is running but not answering on port %s",
                 pid,
                 port,
             )
@@ -714,6 +807,13 @@ class EmbeddedLemonade:
     def _write_env_file(self, port: int, api_key: str) -> Path:
         """Write the sourceable credentials file for the running instance.
 
+        Created owner-only, and removed first so the mode applies: ``open``
+        honours its mode argument only when it creates the file, so rewriting
+        one left behind by an earlier build would keep that file's permissions.
+
+        Windows ignores the mode bits; there the file is protected by the ACL
+        it inherits from the user's profile directory.
+
         Args:
             port: Port the instance listens on.
             api_key: Bearer token the instance requires.
@@ -734,7 +834,8 @@ class EmbeddedLemonade:
             )
 
         self.root.mkdir(parents=True, exist_ok=True)
-        flags = os.O_WRONLY | os.O_CREAT | os.O_TRUNC
+        self.env_path.unlink(missing_ok=True)
+        flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL
         descriptor = os.open(self.env_path, flags, stat.S_IRUSR | stat.S_IWUSR)
         with os.fdopen(descriptor, "w", encoding="utf-8") as handle:
             handle.write(body)

--- a/src/gaia/llm/lemonade_embedded.py
+++ b/src/gaia/llm/lemonade_embedded.py
@@ -74,10 +74,10 @@ _MACHINE_ALIASES = {
 # install() fail loudly; tests/integration/test_lemonade_embeddable_assets.py
 # checks them against the live release so CI catches the omission first.
 EMBEDDABLE_SHA256: Dict[str, str] = {
-    "lemonade-embeddable-11.8.0-windows-x64.zip": "c0dc9087840de5c7a1e9974279ba4690cb1ec545c7e165dbf52468ed845c71c7",
-    "lemonade-embeddable-11.8.0-ubuntu-x64.tar.gz": "3cb13e93b0496c583e4cb4dda6aef58c39fc71fbb058fb171d62ac18f4cd72fc",
-    "lemonade-embeddable-11.8.0-ubuntu-arm64.tar.gz": "04f0f6b72d9e70efa250b7e91a9a29e8a77e33fc66db6ca59e29afe5eac8262c",
-    "lemonade-embeddable-11.8.0-macos-arm64.tar.gz": "6cf8a519d883e2f3072a676fab69dd9be96f4d476a7ef440b3e4fb6e08ed4c36",
+    "lemonade-embeddable-11.8.1-windows-x64.zip": "9f76aeacec1ec9e3fce2460929229c02ae637bcdf73e70467b6a1aedc8739921",
+    "lemonade-embeddable-11.8.1-ubuntu-x64.tar.gz": "ed7809b66e325ee99c9fe3e241cfec7c6fc4b43ae794dcb70fc3627bfa3e4865",
+    "lemonade-embeddable-11.8.1-ubuntu-arm64.tar.gz": "0bbd7435a0a6a7d876de4a92f00118802775d2b5c268570acd55651c836a07f5",
+    "lemonade-embeddable-11.8.1-macos-arm64.tar.gz": "472aa96b290ddb3b4950b028151020aac1f838e59f32b347cfa0a15e2b573cb5",
 }
 
 # lemond reads these from <config_dir>/config.json.
@@ -335,6 +335,16 @@ class EmbeddedLemonade:
         return self.root / "config"
 
     @property
+    def env_path(self) -> Path:
+        """Shell-sourceable credentials for the running instance.
+
+        The API key is written here instead of printed, so it never reaches
+        terminal scrollback, shell history or a CI log.
+        """
+        name = "env.ps1" if platform.system() == "Windows" else "env.sh"
+        return self.root / name
+
+    @property
     def state_path(self) -> Path:
         """JSON file recording the running instance."""
         return self.root / "state.json"
@@ -557,8 +567,13 @@ class EmbeddedLemonade:
             json.dump(state, handle, indent=2)
 
     def _clear_state(self) -> None:
-        """Remove the state file if present."""
+        """Remove the state and credentials files if present.
+
+        Both go together: credentials naming a dead port are worse than none,
+        because the next process to grab that port inherits the trust.
+        """
         self.state_path.unlink(missing_ok=True)
+        self.env_path.unlink(missing_ok=True)
 
     # -- lifecycle --------------------------------------------------------
 
@@ -686,14 +701,54 @@ class EmbeddedLemonade:
     def current_api_key(self) -> Optional[str]:
         """Return the API key of the recorded instance, if there is one.
 
-        Every request to the private server needs this as a bearer token; the
-        CLI prints it so callers can export ``LEMONADE_API_KEY``.
+        Every request to the private server needs this as a bearer token.
+        Callers that only need to hand it to a shell should point the user at
+        :attr:`env_path` rather than printing it.
 
         Returns:
             The bearer token, or None when no instance is recorded.
         """
         state = self._read_state()
         return state.get("api_key") if state else None
+
+    def _write_env_file(self, port: int, api_key: str) -> Path:
+        """Write the sourceable credentials file for the running instance.
+
+        Args:
+            port: Port the instance listens on.
+            api_key: Bearer token the instance requires.
+
+        Returns:
+            Path to the written file.
+        """
+        base_url = self.base_url_for(port)
+        if platform.system() == "Windows":
+            body = (
+                f'$env:LEMONADE_BASE_URL = "{base_url}"\n'
+                f'$env:LEMONADE_API_KEY = "{api_key}"\n'
+            )
+        else:
+            body = (
+                f'export LEMONADE_BASE_URL="{base_url}"\n'
+                f'export LEMONADE_API_KEY="{api_key}"\n'
+            )
+
+        self.root.mkdir(parents=True, exist_ok=True)
+        flags = os.O_WRONLY | os.O_CREAT | os.O_TRUNC
+        descriptor = os.open(self.env_path, flags, stat.S_IRUSR | stat.S_IWUSR)
+        with os.fdopen(descriptor, "w", encoding="utf-8") as handle:
+            handle.write(body)
+        return self.env_path
+
+    def env_load_command(self) -> str:
+        """Return the shell command that loads the credentials file.
+
+        Returns:
+            A command the user can paste to set both environment variables.
+        """
+        if platform.system() == "Windows":
+            return f". {self.env_path}"
+        return f"source {self.env_path}"
 
     @staticmethod
     def base_url_for(port: int) -> str:
@@ -840,6 +895,7 @@ class EmbeddedLemonade:
                 "version": self.version,
             }
         )
+        self._write_env_file(port, api_key)
         log.info("Embedded Lemonade %s ready on port %s", self.version, port)
         return EmbeddedStatus(
             installed=True,

--- a/src/gaia/llm/lemonade_embedded.py
+++ b/src/gaia/llm/lemonade_embedded.py
@@ -1,0 +1,1013 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""Private, per-install Lemonade Server for GAIA.
+
+Upstream ships an "embeddable" Lemonade build: a ``lemond`` daemon plus a
+``lemonade`` HTTP client, with no installer, no tray app and no machine-wide
+state. This module downloads that artifact, unpacks it under ``~/.gaia``, and
+runs it on a private port behind a generated API key.
+
+The point is a GAIA that carries its own inference server. The system-wide
+Lemonade install keeps working and stays the fallback -- see
+``gaia.llm.lemonade_launcher`` for that path.
+
+Layout under ``$GAIA_HOME/lemonade`` (``~/.gaia/lemonade`` by default)::
+
+    dist/<version>/     unpacked artifact (lemond, lemonade, resources/)
+    cache/              lemond cache_dir -- downloaded backends live in bin/
+    config/config.json  lemond config_dir
+    state.json          the running instance: pid, port, API key, version
+    lemond.log          daemon stdout/stderr
+
+``cache/`` and ``config/`` are deliberately *not* versioned: backends run from
+141 MB (llama.cpp CPU + Vulkan) to 4.3 GB (ROCm, which also pulls a per-GPU
+TheRock runtime), and re-downloading them on every Lemonade bump is not
+acceptable. lemond invalidates stale binaries itself via the
+``clear_bin_if_lemonade_below`` pin in its ``backend_versions.json``.
+"""
+
+import hashlib
+import json
+import os
+import platform
+import secrets
+import shutil
+import signal
+import socket
+import stat
+import subprocess
+import tarfile
+import tempfile
+import time
+import urllib.error
+import urllib.request
+import zipfile
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Callable, Dict, Optional, Tuple
+
+from gaia.logger import get_logger
+from gaia.version import LEMONADE_VERSION
+
+log = get_logger(__name__)
+
+GITHUB_RELEASE_BASE = "https://github.com/lemonade-sdk/lemonade/releases/download"
+RELEASES_PAGE = "https://github.com/lemonade-sdk/lemonade/releases"
+
+# (platform.system(), normalized machine) -> asset name template.
+_ASSET_TEMPLATES: Dict[Tuple[str, str], str] = {
+    ("Windows", "x86_64"): "lemonade-embeddable-{version}-windows-x64.zip",
+    ("Linux", "x86_64"): "lemonade-embeddable-{version}-ubuntu-x64.tar.gz",
+    ("Linux", "aarch64"): "lemonade-embeddable-{version}-ubuntu-arm64.tar.gz",
+    ("Darwin", "aarch64"): "lemonade-embeddable-{version}-macos-arm64.tar.gz",
+}
+
+_MACHINE_ALIASES = {
+    "amd64": "x86_64",
+    "x86_64": "x86_64",
+    "arm64": "aarch64",
+    "aarch64": "aarch64",
+}
+
+# SHA-256 of every embeddable asset for LEMONADE_VERSION, as published by the
+# GitHub release API. Bumping LEMONADE_VERSION without refreshing these makes
+# install() fail loudly; tests/integration/test_lemonade_embeddable_assets.py
+# checks them against the live release so CI catches the omission first.
+EMBEDDABLE_SHA256: Dict[str, str] = {
+    "lemonade-embeddable-11.8.0-windows-x64.zip": "c0dc9087840de5c7a1e9974279ba4690cb1ec545c7e165dbf52468ed845c71c7",
+    "lemonade-embeddable-11.8.0-ubuntu-x64.tar.gz": "3cb13e93b0496c583e4cb4dda6aef58c39fc71fbb058fb171d62ac18f4cd72fc",
+    "lemonade-embeddable-11.8.0-ubuntu-arm64.tar.gz": "04f0f6b72d9e70efa250b7e91a9a29e8a77e33fc66db6ca59e29afe5eac8262c",
+    "lemonade-embeddable-11.8.0-macos-arm64.tar.gz": "6cf8a519d883e2f3072a676fab69dd9be96f4d476a7ef440b3e4fb6e08ed4c36",
+}
+
+# lemond reads these from <config_dir>/config.json.
+#
+# broadcast=false keeps the private instance off the UDP discovery beacon, so a
+# stray `lemonade` CLI on the machine does not attach to GAIA's server.
+#
+# Deliberately absent: no_fetch_executables. Setting it true collapses the
+# advertised catalogue from 204 models to the 4 runnable by built-in backends,
+# which would break `gaia download` for everything else.
+_LEMOND_CONFIG = {
+    "config_version": 2,
+    "host": "localhost",
+    "broadcast": False,
+}
+
+_HEALTH_PATH = "/api/v1/health"
+_START_TIMEOUT = 60.0
+_STOP_TIMEOUT = 20.0
+_DOWNLOAD_TIMEOUT = 300
+
+
+class EmbeddedLemonadeError(RuntimeError):
+    """An embedded Lemonade operation failed. Message names the remedy."""
+
+
+class UnsupportedPlatformError(EmbeddedLemonadeError):
+    """No embeddable artifact is published for this OS/architecture."""
+
+
+@dataclass(frozen=True)
+class EmbeddedStatus:
+    """Snapshot of the embedded instance.
+
+    Attributes:
+        installed: Whether the artifact is unpacked and the daemon present.
+        running: Whether the recorded instance answers its health endpoint.
+        version: Version of the running instance, else the targeted version.
+        port: TCP port of the running instance, if any.
+        pid: Process id of the running instance, if any.
+        base_url: OpenAI-compatible base URL, if running.
+        dist_dir: Where the artifact is unpacked.
+        unresponsive_pid: A daemon process that is alive but not answering.
+            Set only when ``running`` is False; the caller must stop it rather
+            than start a second one.
+    """
+
+    installed: bool
+    running: bool
+    version: str
+    port: Optional[int] = None
+    pid: Optional[int] = None
+    base_url: Optional[str] = None
+    dist_dir: Optional[Path] = None
+    unresponsive_pid: Optional[int] = None
+
+
+def gaia_home() -> Path:
+    """Return GAIA's state directory.
+
+    Returns:
+        ``$GAIA_HOME`` when set, otherwise ``~/.gaia``.
+    """
+    override = os.environ.get("GAIA_HOME")
+    if override:
+        return Path(os.path.expandvars(os.path.expanduser(override))).resolve()
+    return Path.home() / ".gaia"
+
+
+def _normalized_machine() -> str:
+    """Return this host's architecture in the naming the asset table uses.
+
+    Returns:
+        ``x86_64`` or ``aarch64``.
+
+    Raises:
+        UnsupportedPlatformError: The architecture is not one GAIA maps.
+    """
+    raw = platform.machine().lower()
+    normalized = _MACHINE_ALIASES.get(raw)
+    if normalized is None:
+        raise UnsupportedPlatformError(
+            f"Unsupported CPU architecture '{platform.machine()}' for embedded "
+            f"Lemonade. Install Lemonade Server system-wide instead ("
+            f"`gaia init`), or see {RELEASES_PAGE} for the published assets."
+        )
+    return normalized
+
+
+def asset_name(version: str = LEMONADE_VERSION) -> str:
+    """Return the embeddable asset filename for this platform.
+
+    Args:
+        version: Lemonade version to resolve.
+
+    Returns:
+        The release asset filename.
+
+    Raises:
+        UnsupportedPlatformError: No asset is published for this OS/arch.
+    """
+    key = (platform.system(), _normalized_machine())
+    template = _ASSET_TEMPLATES.get(key)
+    if template is None:
+        supported = ", ".join(f"{s}/{m}" for s, m in sorted(_ASSET_TEMPLATES))
+        raise UnsupportedPlatformError(
+            f"Embedded Lemonade is not published for {key[0]}/{key[1]}. "
+            f"Supported: {supported}. Install Lemonade Server system-wide "
+            f"instead (`gaia init`), or check {RELEASES_PAGE}."
+        )
+    return template.format(version=version)
+
+
+def asset_url(version: str = LEMONADE_VERSION) -> str:
+    """Return the download URL for this platform's embeddable asset.
+
+    Args:
+        version: Lemonade version to resolve.
+
+    Returns:
+        Absolute GitHub release download URL.
+    """
+    return f"{GITHUB_RELEASE_BASE}/v{version}/{asset_name(version)}"
+
+
+def _free_port() -> int:
+    """Return a TCP port the OS reports as free on loopback.
+
+    Returns:
+        A port number nothing is currently bound to.
+    """
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        return int(sock.getsockname()[1])
+
+
+def _safe_members_ok(names, dest: Path) -> None:
+    """Reject archive entries that would land outside *dest*.
+
+    Args:
+        names: Archive member names.
+        dest: Directory the archive unpacks into.
+
+    Raises:
+        EmbeddedLemonadeError: A member escapes *dest*.
+    """
+    dest_resolved = dest.resolve()
+    for name in names:
+        target = (dest_resolved / name).resolve()
+        if dest_resolved != target and dest_resolved not in target.parents:
+            raise EmbeddedLemonadeError(
+                f"Refusing to unpack embedded Lemonade: archive entry '{name}' "
+                f"escapes {dest_resolved}. The download is corrupt or tampered "
+                f"with -- delete it and retry, and report it at {RELEASES_PAGE}."
+            )
+
+
+def _extract(archive: Path, dest: Path) -> None:
+    """Unpack *archive* into *dest*, validating every member path.
+
+    Args:
+        archive: ``.zip`` or ``.tar.gz`` file.
+        dest: Empty directory to unpack into.
+
+    Raises:
+        EmbeddedLemonadeError: Unknown suffix or an unsafe member path.
+    """
+    dest.mkdir(parents=True, exist_ok=True)
+    if archive.name.endswith(".zip"):
+        with zipfile.ZipFile(archive) as zf:
+            _safe_members_ok(zf.namelist(), dest)
+            zf.extractall(dest)
+    elif archive.name.endswith((".tar.gz", ".tgz")):
+        with tarfile.open(archive, "r:gz") as tf:
+            members = tf.getmembers()
+            _safe_members_ok([m.name for m in members], dest)
+            # Names alone miss a symlink pointing out of the tree that a later
+            # member then writes through; Python < 3.12 has no data filter.
+            for member in members:
+                if member.issym() or member.islnk():
+                    _safe_members_ok(
+                        [os.path.join(os.path.dirname(member.name), member.linkname)],
+                        dest,
+                    )
+                elif not (member.isfile() or member.isdir()):
+                    raise EmbeddedLemonadeError(
+                        f"Refusing to unpack embedded Lemonade: '{member.name}' "
+                        f"is a device or special file. The download is corrupt "
+                        f"or tampered with -- retry, and report it at "
+                        f"{RELEASES_PAGE}."
+                    )
+            extra = {"filter": "data"} if hasattr(tarfile, "data_filter") else {}
+            tf.extractall(dest, **extra)
+    else:
+        raise EmbeddedLemonadeError(
+            f"Cannot unpack '{archive.name}': expected a .zip or .tar.gz "
+            f"embedded Lemonade asset. Delete {archive} and retry."
+        )
+
+
+def _flatten_single_root(unpacked: Path) -> Path:
+    """Return the directory actually holding the payload.
+
+    The published archives wrap their contents in a single
+    ``lemonade-embeddable-<version>-<platform>/`` directory. Strip it so the
+    on-disk layout does not depend on that packaging choice.
+
+    Args:
+        unpacked: Directory the archive was extracted into.
+
+    Returns:
+        *unpacked*, or its sole subdirectory when that is all it contains.
+    """
+    entries = list(unpacked.iterdir())
+    if len(entries) == 1 and entries[0].is_dir():
+        return entries[0]
+    return unpacked
+
+
+class EmbeddedLemonade:
+    """Manages GAIA's private Lemonade Server: install, start, stop, status.
+
+    Args:
+        version: Lemonade version to install and run.
+        home: GAIA state directory. Defaults to :func:`gaia_home`.
+        progress_callback: Called as ``(bytes_done, total_bytes)`` while
+            downloading. ``total_bytes`` is 0 when the server sends no length.
+    """
+
+    def __init__(
+        self,
+        version: str = LEMONADE_VERSION,
+        home: Optional[Path] = None,
+        progress_callback: Optional[Callable[[int, int], None]] = None,
+    ):
+        self.version = version
+        self.root = (home or gaia_home()) / "lemonade"
+        self.progress_callback = progress_callback
+
+    # -- paths ------------------------------------------------------------
+
+    @property
+    def dist_dir(self) -> Path:
+        """Directory holding the unpacked artifact for this version."""
+        return self.root / "dist" / self.version
+
+    @property
+    def cache_dir(self) -> Path:
+        """lemond ``cache_dir`` -- shared across versions, holds ``bin/``."""
+        return self.root / "cache"
+
+    @property
+    def config_dir(self) -> Path:
+        """lemond ``config_dir`` -- shared across versions."""
+        return self.root / "config"
+
+    @property
+    def state_path(self) -> Path:
+        """JSON file recording the running instance."""
+        return self.root / "state.json"
+
+    @property
+    def log_path(self) -> Path:
+        """File the daemon's stdout and stderr are appended to."""
+        return self.root / "lemond.log"
+
+    @property
+    def daemon_path(self) -> Path:
+        """Path to the ``lemond`` executable for this version."""
+        suffix = ".exe" if platform.system() == "Windows" else ""
+        return self.dist_dir / f"lemond{suffix}"
+
+    @property
+    def client_path(self) -> Path:
+        """Path to the bundled ``lemonade`` HTTP client for this version."""
+        suffix = ".exe" if platform.system() == "Windows" else ""
+        return self.dist_dir / f"lemonade{suffix}"
+
+    def is_installed(self) -> bool:
+        """Whether the artifact is unpacked and the daemon is present.
+
+        Returns:
+            True if :attr:`daemon_path` exists.
+        """
+        return self.daemon_path.is_file()
+
+    # -- install ----------------------------------------------------------
+
+    def install(self, force: bool = False) -> Path:
+        """Download, verify and unpack the embeddable artifact.
+
+        Args:
+            force: Reinstall even when the version is already unpacked.
+
+        Returns:
+            The directory the artifact was unpacked into.
+
+        Raises:
+            UnsupportedPlatformError: No asset for this OS/architecture.
+            EmbeddedLemonadeError: Download, checksum or unpack failed.
+        """
+        if self.is_installed() and not force:
+            log.debug("Embedded Lemonade %s already installed", self.version)
+            return self.dist_dir
+
+        if force and self.is_installed():
+            running = self.status()
+            if running.running or running.unresponsive_pid:
+                raise EmbeddedLemonadeError(
+                    f"Refusing to reinstall embedded Lemonade while it is "
+                    f"running (pid {running.pid or running.unresponsive_pid}). "
+                    f"Run `gaia lemonade embedded stop` first."
+                )
+
+        name = asset_name(self.version)
+        expected = EMBEDDABLE_SHA256.get(name)
+        if expected is None:
+            raise EmbeddedLemonadeError(
+                f"No pinned SHA-256 for '{name}'. GAIA verifies the embeddable "
+                f"download against a checksum pinned in "
+                f"gaia/llm/lemonade_embedded.py (EMBEDDABLE_SHA256); the pins "
+                f"cover Lemonade {LEMONADE_VERSION}. Add the digest from "
+                f"{RELEASES_PAGE}/tag/v{self.version} before installing "
+                f"version {self.version}."
+            )
+
+        self.root.mkdir(parents=True, exist_ok=True)
+        with tempfile.TemporaryDirectory(prefix="gaia-lemonade-") as tmp:
+            archive = Path(tmp) / name
+            self._download(asset_url(self.version), archive)
+            self._verify(archive, expected)
+
+            unpacked = Path(tmp) / "unpacked"
+            _extract(archive, unpacked)
+            payload = _flatten_single_root(unpacked)
+            self._install_payload(payload)
+
+        if not self.is_installed():
+            raise EmbeddedLemonadeError(
+                f"Unpacked embedded Lemonade {self.version} but "
+                f"{self.daemon_path.name} is missing from {self.dist_dir}. The "
+                f"release layout changed -- check "
+                f"{RELEASES_PAGE}/tag/v{self.version}."
+            )
+        log.info("Installed embedded Lemonade %s to %s", self.version, self.dist_dir)
+        return self.dist_dir
+
+    def _download(self, url: str, dest: Path) -> None:
+        """Stream *url* to *dest*, reporting progress.
+
+        Args:
+            url: Asset download URL.
+            dest: File to write.
+
+        Raises:
+            EmbeddedLemonadeError: The asset is missing or the transfer failed.
+        """
+        log.info("Downloading %s", url)
+        request = urllib.request.Request(url, headers={"User-Agent": "GAIA/1.0"})
+        try:
+            with urllib.request.urlopen(request, timeout=_DOWNLOAD_TIMEOUT) as response:
+                total = int(response.headers.get("content-length", 0))
+                done = 0
+                with open(dest, "wb") as handle:
+                    while True:
+                        chunk = response.read(64 * 1024)
+                        if not chunk:
+                            break
+                        handle.write(chunk)
+                        done += len(chunk)
+                        if self.progress_callback:
+                            self.progress_callback(done, total)
+        except urllib.error.HTTPError as e:
+            if e.code in (404, 410):
+                raise EmbeddedLemonadeError(
+                    f"Embedded Lemonade asset not found: {url} (HTTP {e.code}). "
+                    f"Either LEMONADE_VERSION points at a release without an "
+                    f"embeddable build, or the asset was renamed. Check "
+                    f"{RELEASES_PAGE}/tag/v{self.version}."
+                ) from e
+            raise EmbeddedLemonadeError(
+                f"Failed to download {url}: HTTP {e.code} {e.reason}. Retry, or "
+                f"download it by hand from {RELEASES_PAGE}/tag/v{self.version}."
+            ) from e
+        except urllib.error.URLError as e:
+            raise EmbeddedLemonadeError(
+                f"Failed to download {url}: {e.reason}. Check network access to "
+                f"github.com (proxy? offline?) and retry."
+            ) from e
+
+    def _verify(self, archive: Path, expected_sha256: str) -> None:
+        """Check *archive* against its pinned digest.
+
+        Args:
+            archive: Downloaded file.
+            expected_sha256: Hex digest the release publishes.
+
+        Raises:
+            EmbeddedLemonadeError: The digest does not match.
+        """
+        digest = hashlib.sha256()
+        with open(archive, "rb") as handle:
+            for block in iter(lambda: handle.read(1024 * 1024), b""):
+                digest.update(block)
+        actual = digest.hexdigest()
+        if actual != expected_sha256:
+            raise EmbeddedLemonadeError(
+                f"Checksum mismatch for {archive.name}: expected "
+                f"{expected_sha256}, got {actual}. The download is corrupt or "
+                f"the release asset was replaced. Retry; if it persists, "
+                f"compare against {RELEASES_PAGE}/tag/v{self.version}."
+            )
+        log.debug("Verified %s (sha256 %s)", archive.name, actual)
+
+    def _install_payload(self, payload: Path) -> None:
+        """Move an unpacked payload into :attr:`dist_dir`.
+
+        Replaces any previous unpack of the same version, so a half-written
+        directory from an interrupted install cannot survive.
+
+        Args:
+            payload: Directory holding ``lemond``, ``resources/`` and friends.
+        """
+        self.dist_dir.parent.mkdir(parents=True, exist_ok=True)
+        if self.dist_dir.exists():
+            shutil.rmtree(self.dist_dir)
+        shutil.move(str(payload), str(self.dist_dir))
+
+        if platform.system() != "Windows":
+            for name in ("lemond", "lemonade"):
+                binary = self.dist_dir / name
+                if binary.is_file():
+                    binary.chmod(binary.stat().st_mode | 0o111)
+
+    def write_config(self) -> Path:
+        """Write ``config.json`` into the lemond config directory.
+
+        Returns:
+            Path to the written file.
+        """
+        self.config_dir.mkdir(parents=True, exist_ok=True)
+        self.cache_dir.mkdir(parents=True, exist_ok=True)
+        path = self.config_dir / "config.json"
+        path.write_text(json.dumps(_LEMOND_CONFIG, indent=2), encoding="utf-8")
+        return path
+
+    # -- state ------------------------------------------------------------
+
+    def _read_state(self) -> Optional[dict]:
+        """Return the recorded instance, or None when there is none.
+
+        Returns:
+            The parsed state file, or None if absent or unreadable.
+        """
+        if not self.state_path.is_file():
+            return None
+        try:
+            return json.loads(self.state_path.read_text(encoding="utf-8"))
+        except (OSError, ValueError) as e:
+            log.warning("Discarding unreadable %s: %s", self.state_path, e)
+            return None
+
+    def _write_state(self, state: dict) -> None:
+        """Persist the running instance.
+
+        The file holds the API key that is the server's only protection, so it
+        is created 0600 rather than chmod-ed afterwards -- a chmod leaves the
+        key world-readable in between.
+
+        Args:
+            state: pid, port, api_key and version of the live daemon.
+        """
+        self.root.mkdir(parents=True, exist_ok=True)
+        flags = os.O_WRONLY | os.O_CREAT | os.O_TRUNC
+        descriptor = os.open(self.state_path, flags, stat.S_IRUSR | stat.S_IWUSR)
+        with os.fdopen(descriptor, "w", encoding="utf-8") as handle:
+            json.dump(state, handle, indent=2)
+
+    def _clear_state(self) -> None:
+        """Remove the state file if present."""
+        self.state_path.unlink(missing_ok=True)
+
+    # -- lifecycle --------------------------------------------------------
+
+    def _health(self, port: int, api_key: str, timeout: float = 3.0) -> Optional[dict]:
+        """Probe the health endpoint of a candidate instance.
+
+        The API key doubles as an identity check: only the daemon GAIA started
+        accepts the key GAIA generated, so a successful probe proves the port
+        is ours and not a recycled pid or an unrelated server.
+
+        Args:
+            port: Port to probe.
+            api_key: Bearer token the instance was started with.
+            timeout: Per-request timeout in seconds.
+
+        Returns:
+            The decoded health payload, or None if it did not answer.
+        """
+        request = urllib.request.Request(
+            f"http://127.0.0.1:{port}{_HEALTH_PATH}",
+            headers={"Authorization": f"Bearer {api_key}"},
+        )
+        try:
+            with urllib.request.urlopen(request, timeout=timeout) as response:
+                return json.loads(response.read().decode("utf-8"))
+        except (urllib.error.URLError, OSError, ValueError):
+            return None
+
+    @staticmethod
+    def _daemon_alive(pid: int) -> bool:
+        """Whether *pid* is a live ``lemond`` process.
+
+        Checked by image name, not just existence, so a recycled pid belonging
+        to some unrelated program is never mistaken for GAIA's daemon.
+
+        Args:
+            pid: Process id from the state file.
+
+        Returns:
+            True if a running process with that id is a lemond binary.
+        """
+        try:
+            if platform.system() == "Windows":
+                result = subprocess.run(
+                    ["tasklist", "/FI", f"PID eq {pid}", "/NH", "/FO", "CSV"],
+                    capture_output=True,
+                    text=True,
+                    timeout=15,
+                    check=False,
+                )
+                return "lemond" in result.stdout.lower()
+            result = subprocess.run(
+                ["ps", "-p", str(pid), "-o", "comm="],
+                capture_output=True,
+                text=True,
+                timeout=15,
+                check=False,
+            )
+            return "lemond" in result.stdout.lower()
+        except (OSError, subprocess.SubprocessError) as e:
+            log.warning("Could not check whether pid %s is alive: %s", pid, e)
+            return False
+
+    def status(self) -> EmbeddedStatus:
+        """Report whether the embedded instance is installed and running.
+
+        The state file is only discarded once the recorded process is gone.
+        A daemon that is up but slow to answer -- loading a multi-gigabyte
+        backend, say -- is reported through ``unresponsive_pid`` and keeps its
+        state, so ``stop`` can still reach it.
+
+        Returns:
+            The current :class:`EmbeddedStatus`.
+        """
+        installed = self.is_installed()
+        stopped = EmbeddedStatus(
+            installed=installed,
+            running=False,
+            version=self.version,
+            dist_dir=self.dist_dir if installed else None,
+        )
+
+        state = self._read_state()
+        if not state:
+            return stopped
+
+        port = state.get("port")
+        api_key = state.get("api_key")
+        pid = state.get("pid")
+        if not (port and api_key and pid):
+            log.warning("Discarding incomplete state in %s", self.state_path)
+            self._clear_state()
+            return stopped
+
+        if self._health(int(port), api_key) is not None:
+            return EmbeddedStatus(
+                installed=installed,
+                running=True,
+                version=state.get("version", self.version),
+                port=int(port),
+                pid=int(pid),
+                base_url=self.base_url_for(int(port)),
+                dist_dir=self.dist_dir if installed else None,
+            )
+
+        if self._daemon_alive(int(pid)):
+            log.warning(
+                "Embedded Lemonade (pid %s) is running but not answering on " "port %s",
+                pid,
+                port,
+            )
+            return EmbeddedStatus(
+                installed=installed,
+                running=False,
+                version=state.get("version", self.version),
+                port=int(port),
+                dist_dir=self.dist_dir if installed else None,
+                unresponsive_pid=int(pid),
+            )
+
+        log.debug("Recorded instance (pid %s) is gone; clearing state", pid)
+        self._clear_state()
+        return stopped
+
+    def current_api_key(self) -> Optional[str]:
+        """Return the API key of the recorded instance, if there is one.
+
+        Every request to the private server needs this as a bearer token; the
+        CLI prints it so callers can export ``LEMONADE_API_KEY``.
+
+        Returns:
+            The bearer token, or None when no instance is recorded.
+        """
+        state = self._read_state()
+        return state.get("api_key") if state else None
+
+    @staticmethod
+    def base_url_for(port: int) -> str:
+        """Return the OpenAI-compatible base URL for *port*.
+
+        Args:
+            port: Port the instance listens on.
+
+        Returns:
+            A URL suitable for ``LEMONADE_BASE_URL``.
+        """
+        return f"http://localhost:{port}/api/v1"
+
+    def start(
+        self,
+        port: Optional[int] = None,
+        timeout: float = _START_TIMEOUT,
+        install_if_missing: bool = True,
+    ) -> EmbeddedStatus:
+        """Start the private daemon and wait for it to answer.
+
+        Args:
+            port: Port to bind. A free one is chosen when omitted.
+            timeout: Seconds to wait for the health endpoint.
+            install_if_missing: Download the artifact when it is not unpacked.
+
+        Returns:
+            Status of the running instance.
+
+        Raises:
+            EmbeddedLemonadeError: Not installed, the daemon exited, or it
+                never became healthy.
+        """
+        existing = self.status()
+        if existing.running:
+            if existing.version != self.version:
+                raise EmbeddedLemonadeError(
+                    f"Embedded Lemonade {existing.version} is already running on "
+                    f"port {existing.port}, but GAIA now targets "
+                    f"{self.version}. Run `gaia lemonade embedded stop` first, "
+                    f"then start again to pick up the new version."
+                )
+            log.info("Embedded Lemonade already running on port %s", existing.port)
+            return existing
+
+        if existing.unresponsive_pid:
+            raise EmbeddedLemonadeError(
+                f"Embedded Lemonade (pid {existing.unresponsive_pid}) is running "
+                f"but not answering on port {existing.port}. Starting another "
+                f"would leave two servers behind. Run "
+                f"`gaia lemonade embedded stop`, check {self.log_path} for why "
+                f"it stalled, then start again."
+            )
+
+        if not self.is_installed():
+            if not install_if_missing:
+                raise EmbeddedLemonadeError(
+                    f"Embedded Lemonade {self.version} is not installed at "
+                    f"{self.dist_dir}. Run `gaia lemonade embedded start` "
+                    f"without --no-install to download it."
+                )
+            self.install()
+
+        self.write_config()
+        port = port or _free_port()
+        api_key = secrets.token_urlsafe(32)
+
+        env = dict(os.environ)
+        env["LEMONADE_API_KEY"] = api_key
+
+        argv = [
+            str(self.daemon_path),
+            str(self.cache_dir),
+            str(self.config_dir),
+            "--port",
+            str(port),
+        ]
+        log.info("Starting embedded Lemonade: %s", " ".join(argv))
+
+        # Detach so the daemon outlives the CLI process that spawned it.
+        kwargs = {}
+        if platform.system() == "Windows":
+            kwargs["creationflags"] = (
+                subprocess.CREATE_NEW_PROCESS_GROUP | subprocess.DETACHED_PROCESS
+            )
+        else:
+            kwargs["start_new_session"] = True
+
+        self.root.mkdir(parents=True, exist_ok=True)
+        with open(self.log_path, "ab") as logfile:
+            process = subprocess.Popen(
+                argv,
+                env=env,
+                stdout=logfile,
+                stderr=subprocess.STDOUT,
+                stdin=subprocess.DEVNULL,
+                cwd=str(self.dist_dir),
+                **kwargs,
+            )
+
+        # Record the instance before waiting: an interrupt during the wait must
+        # still leave `stop` able to find and kill what we just spawned.
+        self._write_state(
+            {
+                "pid": process.pid,
+                "port": port,
+                "api_key": api_key,
+                "version": self.version,
+            }
+        )
+
+        healthy = False
+        try:
+            deadline = time.monotonic() + timeout
+            while time.monotonic() < deadline:
+                if process.poll() is not None:
+                    raise EmbeddedLemonadeError(
+                        f"Embedded Lemonade exited immediately (code "
+                        f"{process.returncode}) on port {port}. Read "
+                        f"{self.log_path} for the daemon's own error, then retry "
+                        f"with `gaia lemonade embedded start --port <other>` if "
+                        f"the port was taken."
+                    )
+                if self._health(port, api_key) is not None:
+                    healthy = True
+                    break
+                time.sleep(0.25)
+            if not healthy:
+                raise EmbeddedLemonadeError(
+                    f"Embedded Lemonade did not answer {_HEALTH_PATH} on port "
+                    f"{port} within {timeout:.0f}s. Read {self.log_path} for what "
+                    f"it was doing, then retry."
+                )
+        except BaseException:
+            self._terminate(process)
+            self._clear_state()
+            raise
+
+        self._write_state(
+            {
+                "pid": process.pid,
+                "port": port,
+                "api_key": api_key,
+                "version": self.version,
+            }
+        )
+        log.info("Embedded Lemonade %s ready on port %s", self.version, port)
+        return EmbeddedStatus(
+            installed=True,
+            running=True,
+            version=self.version,
+            port=port,
+            pid=process.pid,
+            base_url=self.base_url_for(port),
+            dist_dir=self.dist_dir,
+        )
+
+    def stop(self, timeout: float = _STOP_TIMEOUT) -> bool:
+        """Stop the recorded instance and its inference backends.
+
+        Reaches a daemon that has stopped answering as well as a healthy one,
+        so a stalled server can still be cleaned up. The pid is only signalled
+        after it is confirmed to be a lemond process, so a recycled pid is
+        never killed by mistake.
+
+        Args:
+            timeout: Seconds to wait for the daemon to exit.
+
+        Returns:
+            True if an instance was stopped, False if none was running.
+
+        Raises:
+            EmbeddedLemonadeError: The process would not terminate.
+        """
+        current = self.status()
+        state = self._read_state()
+        if state is None or not (current.running or current.unresponsive_pid):
+            self._clear_state()
+            return False
+
+        pid = int(state["pid"])
+        port = int(state["port"])
+        api_key = state["api_key"]
+        log.info("Stopping embedded Lemonade (pid %s, port %s)", pid, port)
+
+        self._kill_tree(pid)
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            gone = self._health(port, api_key, timeout=1.0) is None
+            if gone and not self._daemon_alive(pid):
+                self._clear_state()
+                log.info("Embedded Lemonade stopped")
+                return True
+            time.sleep(0.25)
+
+        raise EmbeddedLemonadeError(
+            f"Embedded Lemonade (pid {pid}) is still alive {timeout:.0f}s after "
+            f"being asked to stop. Kill it with `gaia kill --port {port}`, then "
+            f"delete {self.state_path}."
+        )
+
+    @staticmethod
+    def _kill_tree(pid: int) -> None:
+        """Terminate a daemon and the backend processes it spawned.
+
+        llama-server children hold gigabytes of GPU memory, so killing only the
+        daemon would leak them.
+
+        Args:
+            pid: Process id of the daemon, confirmed to be lemond.
+
+        Raises:
+            EmbeddedLemonadeError: The signal could not be delivered.
+        """
+        try:
+            if platform.system() == "Windows":
+                subprocess.run(
+                    ["taskkill", "/PID", str(pid), "/T", "/F"],
+                    check=True,
+                    capture_output=True,
+                    timeout=30,
+                )
+            else:
+                # start() makes the daemon a session leader, so its backends
+                # share its process group. killpg/getpgid are POSIX-only, so
+                # the no-member warning is a false positive on Windows.
+                os.killpg(  # pylint: disable=no-member
+                    os.getpgid(pid), signal.SIGTERM  # pylint: disable=no-member
+                )
+        except ProcessLookupError:
+            log.debug("Process %s already gone", pid)
+        except (OSError, subprocess.SubprocessError) as e:
+            raise EmbeddedLemonadeError(
+                f"Could not terminate embedded Lemonade (pid {pid}): {e}. Kill "
+                f"it by hand and delete the state file, then retry."
+            ) from e
+
+    def _terminate(self, process: subprocess.Popen) -> None:
+        """Kill a daemon that never became healthy, and anything it spawned.
+
+        Args:
+            process: The spawned daemon.
+        """
+        try:
+            self._kill_tree(process.pid)
+        except EmbeddedLemonadeError as e:
+            log.warning("Could not clean up failed start: %s", e)
+            process.kill()
+        try:
+            process.wait(timeout=10)
+        except subprocess.TimeoutExpired:
+            log.warning("Embedded Lemonade pid %s ignored kill", process.pid)
+
+    # -- backends ---------------------------------------------------------
+
+    def install_backend(self, spec: str, timeout: float = 1800.0) -> None:
+        """Download an inference backend into the private cache.
+
+        Backends are not part of the embeddable artifact. ``llamacpp:cpu`` and
+        ``llamacpp:vulkan`` together are ~141 MB and cover GAIA's default
+        models; ``llamacpp:rocm`` pulls a ~4.3 GB per-GPU ROCm runtime.
+
+        Args:
+            spec: ``recipe:backend``, e.g. ``llamacpp:vulkan``.
+            timeout: Seconds to allow the download.
+
+        Raises:
+            EmbeddedLemonadeError: No instance is running, or the install
+                failed.
+        """
+        status = self.status()
+        if not status.running:
+            raise EmbeddedLemonadeError(
+                "Cannot install a backend: no embedded Lemonade is running. "
+                "Start it first with `gaia lemonade embedded start`."
+            )
+        api_key = self.current_api_key()
+        if not api_key:
+            raise EmbeddedLemonadeError(
+                f"The embedded instance answered but {self.state_path} has no "
+                f"API key. Run `gaia lemonade embedded stop` then `start` to "
+                f"re-record it."
+            )
+
+        env = dict(os.environ)
+        env["LEMONADE_API_KEY"] = api_key
+        try:
+            result = subprocess.run(
+                [
+                    str(self.client_path),
+                    "--port",
+                    str(status.port),
+                    "backends",
+                    "install",
+                    spec,
+                ],
+                env=env,
+                capture_output=True,
+                text=True,
+                timeout=timeout,
+                check=False,
+            )
+        except subprocess.TimeoutExpired as e:
+            raise EmbeddedLemonadeError(
+                f"Installing backend '{spec}' timed out after {timeout:.0f}s. "
+                f"Large backends (ROCm is ~4.3 GB) need a longer timeout or a "
+                f"faster link; retry, or check {self.log_path}."
+            ) from e
+
+        if result.returncode != 0:
+            raise EmbeddedLemonadeError(
+                f"Installing backend '{spec}' failed (exit "
+                f"{result.returncode}): {(result.stderr or result.stdout).strip()}. "
+                f"Run `{self.client_path} --port {status.port} backends` to see "
+                f"which specs this machine supports."
+            )
+        log.info("Installed backend %s", spec)

--- a/tests/integration/test_lemonade_embeddable_assets.py
+++ b/tests/integration/test_lemonade_embeddable_assets.py
@@ -1,0 +1,100 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+"""Check the pinned embeddable checksums against the live upstream release.
+
+GAIA verifies the embeddable Lemonade download against SHA-256 digests pinned
+in ``gaia.llm.lemonade_embedded.EMBEDDABLE_SHA256``. Pins are only worth
+anything if they match what GitHub actually serves, and a ``LEMONADE_VERSION``
+bump that forgets to refresh them would otherwise fail on a user's machine
+mid-install rather than in CI.
+
+The unit tests assert the pins are *present* and well-formed with no network.
+This one asks GitHub what the digests really are.
+
+Skips when GitHub is unreachable (offline dev box) or ``GAIA_SKIP_NETWORK_TESTS``
+is set. CI runners always have network, so it runs there.
+"""
+
+import json
+import os
+import urllib.error
+import urllib.request
+
+import pytest
+
+from gaia.llm.lemonade_embedded import _ASSET_TEMPLATES, EMBEDDABLE_SHA256
+from gaia.version import LEMONADE_VERSION
+
+RELEASE_API = (
+    "https://api.github.com/repos/lemonade-sdk/lemonade/releases/tags/v{version}"
+)
+
+
+def _github_reachable() -> bool:
+    """Whether api.github.com answers at all."""
+    request = urllib.request.Request(
+        "https://api.github.com",
+        method="HEAD",
+        headers={"User-Agent": "GAIA/1.0"},
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=10):
+            return True
+    except urllib.error.HTTPError:
+        return True  # Reached GitHub; the status code doesn't matter here.
+    except (urllib.error.URLError, TimeoutError):
+        return False
+
+
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.skipif(
+        bool(os.environ.get("GAIA_SKIP_NETWORK_TESTS")),
+        reason="GAIA_SKIP_NETWORK_TESTS is set",
+    ),
+]
+
+
+@pytest.fixture(scope="module")
+def published_digests():
+    """Map asset name -> sha256 hex digest, as published for LEMONADE_VERSION."""
+    if not _github_reachable():
+        pytest.skip("GitHub is unreachable")
+
+    url = RELEASE_API.format(version=LEMONADE_VERSION)
+    request = urllib.request.Request(url, headers={"User-Agent": "GAIA/1.0"})
+    try:
+        with urllib.request.urlopen(request, timeout=30) as response:
+            release = json.loads(response.read().decode("utf-8"))
+    except urllib.error.HTTPError as e:
+        if e.code == 403:
+            pytest.skip("GitHub API rate limit reached")
+        raise
+
+    digests = {}
+    for asset in release.get("assets", []):
+        digest = asset.get("digest") or ""
+        if digest.startswith("sha256:"):
+            digests[asset["name"]] = digest.split(":", 1)[1]
+    return digests
+
+
+@pytest.mark.parametrize("template", sorted(_ASSET_TEMPLATES.values()))
+def test_pinned_digest_matches_the_published_asset(published_digests, template):
+    """Every embeddable asset GAIA can download is pinned to the real digest."""
+    name = template.format(version=LEMONADE_VERSION)
+
+    assert name in published_digests, (
+        f"Release v{LEMONADE_VERSION} publishes no asset named '{name}' (or no "
+        f"digest for it). Published: {sorted(published_digests)}"
+    )
+    pinned = EMBEDDABLE_SHA256.get(name)
+    assert pinned is not None, (
+        f"No pinned SHA-256 for '{name}'. Add "
+        f"'{name}': '{published_digests[name]}' to EMBEDDABLE_SHA256."
+    )
+    assert pinned == published_digests[name], (
+        f"Pinned digest for '{name}' is stale. Update EMBEDDABLE_SHA256 to "
+        f"'{published_digests[name]}'."
+    )

--- a/tests/integration/test_lemonade_embedded_lifecycle.py
+++ b/tests/integration/test_lemonade_embedded_lifecycle.py
@@ -1,0 +1,151 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+"""Download and run the real embeddable Lemonade, end to end.
+
+The unit tests mock nothing at the process boundary because mocking it would
+prove only that GAIA called ``lemond`` -- never that the arguments it passes are
+ones ``lemond`` accepts. That contract is the whole risk here: the published
+docs describe a single ``DIR`` positional, while 11.8 takes two
+(``lemond <cache_dir> <config_dir>``). A stub returning success would have
+sailed straight past that.
+
+So this test downloads the artifact (~5 MB), starts it on a private port, proves
+the generated API key is enforced, and stops it. It never downloads a model or
+an inference backend, so it stays cheap.
+
+Skips when GitHub is unreachable or ``GAIA_SKIP_NETWORK_TESTS`` is set.
+"""
+
+import json
+import os
+import urllib.error
+import urllib.request
+
+import pytest
+
+from gaia.llm.lemonade_embedded import EmbeddedLemonade, UnsupportedPlatformError
+
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.skipif(
+        bool(os.environ.get("GAIA_SKIP_NETWORK_TESTS")),
+        reason="GAIA_SKIP_NETWORK_TESTS is set",
+    ),
+]
+
+
+def _github_reachable() -> bool:
+    """Whether github.com answers at all."""
+    request = urllib.request.Request(
+        "https://github.com", method="HEAD", headers={"User-Agent": "GAIA/1.0"}
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=10):
+            return True
+    except urllib.error.HTTPError:
+        return True
+    except (urllib.error.URLError, TimeoutError):
+        return False
+
+
+@pytest.fixture
+def running_instance(tmp_path):
+    """A real embedded Lemonade, started in a temp home and always stopped."""
+    if not _github_reachable():
+        pytest.skip("GitHub is unreachable")
+
+    manager = EmbeddedLemonade(home=tmp_path)
+    try:
+        manager.start(timeout=120.0)
+    except UnsupportedPlatformError:
+        pytest.skip("No embeddable artifact for this platform")
+    try:
+        yield manager
+    finally:
+        # Never leave a daemon (or its backends) behind on a dev box.
+        try:
+            manager.stop()
+        except Exception as e:  # noqa: BLE001 - cleanup must not mask failures
+            pytest.fail(f"Could not stop the embedded instance: {e}")
+
+
+def _get(url, api_key=None, timeout=15):
+    """GET *url*, returning (status_code, decoded_body_or_None)."""
+    headers = {"Authorization": f"Bearer {api_key}"} if api_key else {}
+    request = urllib.request.Request(url, headers=headers)
+    try:
+        with urllib.request.urlopen(request, timeout=timeout) as response:
+            return response.status, json.loads(response.read().decode("utf-8"))
+    except urllib.error.HTTPError as e:
+        return e.code, None
+
+
+def test_the_launch_contract_lemond_actually_accepts(running_instance):
+    """``lemond <cache_dir> <config_dir> --port N`` starts a healthy server."""
+    status = running_instance.status()
+    assert status.running, "started, but status says it isn't running"
+    assert status.port and status.base_url
+
+    code, body = _get(
+        f"{status.base_url}/health", api_key=running_instance.current_api_key()
+    )
+    assert code == 200, f"health endpoint returned {code}"
+    assert body is not None
+
+
+def test_the_generated_api_key_locks_other_apps_out(running_instance):
+    """The private instance rejects callers without GAIA's key."""
+    status = running_instance.status()
+    models_url = f"{status.base_url}/models"
+
+    assert _get(models_url)[0] == 401, "unauthenticated request was allowed in"
+    assert _get(models_url, api_key="not-the-key")[0] == 401, "wrong key was accepted"
+    assert _get(models_url, api_key=running_instance.current_api_key())[0] == 200
+
+
+def test_the_model_catalogue_is_not_truncated(running_instance):
+    """The server advertises a real catalogue, not a handful of models.
+
+    Setting ``no_fetch_executables`` collapses this to the 4 models runnable by
+    built-in backends, which would break ``gaia download`` for everything else.
+    """
+    code, body = _get(
+        f"{running_instance.status().base_url}/models",
+        api_key=running_instance.current_api_key(),
+    )
+    assert code == 200
+    assert isinstance(body.get("data"), list)
+
+
+def test_start_is_idempotent(running_instance):
+    """Starting again returns the same instance instead of spawning a second."""
+    first = running_instance.status()
+    again = running_instance.start()
+    assert again.port == first.port
+    assert again.pid == first.pid
+
+
+def test_stop_is_idempotent_and_clears_state(running_instance):
+    """Stopping twice reports honestly and leaves no stale state file."""
+    assert running_instance.stop() is True
+    assert not running_instance.state_path.exists()
+    assert running_instance.stop() is False
+    assert running_instance.status().running is False
+
+
+def test_install_is_reentrant_without_force(tmp_path):
+    """A second install of the same version is a no-op, not a re-download."""
+    if not _github_reachable():
+        pytest.skip("GitHub is unreachable")
+
+    manager = EmbeddedLemonade(home=tmp_path)
+    try:
+        first = manager.install()
+    except UnsupportedPlatformError:
+        pytest.skip("No embeddable artifact for this platform")
+
+    assert manager.is_installed()
+    stamp = manager.daemon_path.stat().st_mtime_ns
+    assert manager.install() == first
+    assert manager.daemon_path.stat().st_mtime_ns == stamp, "re-downloaded needlessly"

--- a/tests/unit/cli/test_cli_lemonade_embedded.py
+++ b/tests/unit/cli/test_cli_lemonade_embedded.py
@@ -1,0 +1,164 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+"""CLI surface for ``gaia lemonade embedded``.
+
+``tests/unit/test_lemonade_embedded.py`` covers the manager class and stops at
+its boundary. These tests cover the layer above it: that every subcommand is
+reachable through the real parser, that refusals exit non-zero, and -- the
+failure mode this file exists for -- that every ``gaia ...`` remedy the module
+tells users to run is a command the parser actually accepts.
+"""
+
+import re
+import shlex
+from pathlib import Path
+
+import pytest
+
+from gaia.llm import lemonade_embedded
+
+
+def _parser():
+    from gaia.cli import build_parser
+
+    return build_parser()
+
+
+class TestParsing:
+    """Every documented invocation reaches the parser."""
+
+    @pytest.mark.parametrize(
+        "argv",
+        [
+            ["lemonade", "embedded", "start"],
+            ["lemonade", "embedded", "start", "--port", "13399"],
+            ["lemonade", "embedded", "start", "--no-install"],
+            ["lemonade", "embedded", "start", "--timeout", "90"],
+            ["lemonade", "embedded", "stop"],
+            ["lemonade", "embedded", "status"],
+            ["lemonade", "embedded", "install"],
+            ["lemonade", "embedded", "install", "--force"],
+            ["lemonade", "embedded", "install-backend", "llamacpp:vulkan"],
+        ],
+    )
+    def test_accepted(self, argv):
+        parsed = _parser().parse_args(argv)
+        assert parsed.action == "lemonade"
+        assert parsed.lemonade_action == "embedded"
+
+    @pytest.mark.parametrize(
+        "argv",
+        [
+            # install-backend needs a spec; a typo'd verb must not be silently
+            # swallowed as one.
+            ["lemonade", "embedded", "install-backend"],
+            ["lemonade", "embedded", "staart"],
+        ],
+    )
+    def test_rejected(self, argv):
+        with pytest.raises(SystemExit):
+            _parser().parse_args(argv)
+
+    def test_port_is_parsed_as_an_integer(self):
+        assert (
+            _parser()
+            .parse_args(["lemonade", "embedded", "start", "--port", "13399"])
+            .port
+            == 13399
+        )
+
+
+class TestRemediesAreRunnable:
+    """Remedy strings must be commands the CLI accepts, not just plausible text.
+
+    A message telling a stuck user to run something the parser rejects leaves
+    them stuck. Extract every ``gaia ...`` command the module emits and parse it.
+    """
+
+    def test_every_gaia_command_in_the_module_parses(self):
+        source = Path(lemonade_embedded.__file__).read_text(encoding="utf-8")
+        # Commands are written inside backticks in the error messages.
+        commands = set(re.findall(r"`(gaia [^`]+)`", source))
+        assert commands, "no remedy commands found -- has the format changed?"
+
+        for command in sorted(commands):
+            # Stand in for `<other>`-style prose placeholders and `{port}`
+            # f-string fields, which read literally from source.
+            command = re.sub(r"<[^>]+>|\{[^}]+\}", "13399", command)
+            argv = shlex.split(command)
+            try:
+                _parser().parse_args(argv[1:])
+            except SystemExit as exc:
+                pytest.fail(f"parser rejected remedy {command!r} (exit={exc.code})")
+
+
+class TestDispatch:
+    """Refusals must exit non-zero so scripts can chain on them."""
+
+    @pytest.mark.parametrize(
+        "argv",
+        [
+            ["lemonade"],
+            ["lemonade", "embedded"],
+        ],
+    )
+    def test_missing_subaction_exits_non_zero(self, argv, capsys):
+        from gaia.cli import handle_lemonade_command
+
+        with pytest.raises(SystemExit) as exc:
+            handle_lemonade_command(_parser().parse_args(argv))
+        assert exc.value.code == 1
+        assert "❌" in capsys.readouterr().out
+
+    def test_manager_errors_exit_non_zero_with_the_message(
+        self, monkeypatch, capsys, tmp_path
+    ):
+        from gaia.cli import handle_lemonade_embedded_command
+
+        def boom(*_args, **_kwargs):
+            raise lemonade_embedded.EmbeddedLemonadeError("the actionable reason")
+
+        monkeypatch.setattr(lemonade_embedded.EmbeddedLemonade, "start", boom)
+        monkeypatch.setenv("GAIA_HOME", str(tmp_path))
+
+        with pytest.raises(SystemExit) as exc:
+            handle_lemonade_embedded_command(
+                _parser().parse_args(["lemonade", "embedded", "start"])
+            )
+        assert exc.value.code == 1
+        assert "the actionable reason" in capsys.readouterr().out
+
+    def test_os_errors_are_explained_not_dumped(self, monkeypatch, capsys, tmp_path):
+        # A noexec mount or read-only home raises OSError out of Popen; the user
+        # should get a sentence, not a traceback.
+        from gaia.cli import handle_lemonade_embedded_command
+
+        def boom(*_args, **_kwargs):
+            raise PermissionError(13, "Permission denied")
+
+        monkeypatch.setattr(lemonade_embedded.EmbeddedLemonade, "start", boom)
+        monkeypatch.setenv("GAIA_HOME", str(tmp_path))
+
+        with pytest.raises(SystemExit) as exc:
+            handle_lemonade_embedded_command(
+                _parser().parse_args(["lemonade", "embedded", "start"])
+            )
+        assert exc.value.code == 1
+        assert "Could not run embedded Lemonade" in capsys.readouterr().out
+
+
+class TestStatusOutput:
+    """`status` must be readable from a cold state."""
+
+    def test_cold_status_reports_not_installed(self, monkeypatch, capsys, tmp_path):
+        from gaia.cli import handle_lemonade_embedded_command
+
+        monkeypatch.setenv("GAIA_HOME", str(tmp_path))
+        handle_lemonade_embedded_command(
+            _parser().parse_args(["lemonade", "embedded", "status"])
+        )
+        out = capsys.readouterr().out
+        assert "Installed: no" in out
+        assert "Running:   no" in out
+        assert "Backends:  none" in out

--- a/tests/unit/test_lemonade_embedded.py
+++ b/tests/unit/test_lemonade_embedded.py
@@ -159,7 +159,10 @@ class TestArchiveSafety:
             hop.linkname = "."
             tf.addfile(hop)
 
-            tf.addfile(tarfile.TarInfo("d/hop/../../pwned.txt"), io.BytesIO(b"owned"))
+            payload = b"owned"
+            through = tarfile.TarInfo("d/hop/../../pwned.txt")
+            through.size = len(payload)
+            tf.addfile(through, io.BytesIO(payload))
 
         dest = tmp_path / "dest"
         _extract(archive, dest)

--- a/tests/unit/test_lemonade_embedded.py
+++ b/tests/unit/test_lemonade_embedded.py
@@ -3,6 +3,7 @@
 """Unit tests for GAIA's private (embeddable) Lemonade Server."""
 
 import hashlib
+import io
 import json
 import platform
 import stat
@@ -18,8 +19,8 @@ from gaia.llm.lemonade_embedded import (
     EmbeddedLemonade,
     EmbeddedLemonadeError,
     UnsupportedPlatformError,
+    _extract,
     _flatten_single_root,
-    _safe_members_ok,
     asset_name,
     asset_url,
     gaia_home,
@@ -124,16 +125,76 @@ class TestChecksumPinning:
 class TestArchiveSafety:
     """Downloaded archives must not be able to write outside the target."""
 
-    @pytest.mark.parametrize("evil", ["../escape.txt", "a/../../escape.txt"])
+    @pytest.mark.parametrize(
+        "evil", ["../escape.txt", "a/../../escape.txt", "/tmp/escape.txt"]
+    )
     def test_rejects_members_escaping_the_destination(self, tmp_path, evil):
+        archive = tmp_path / "evil.tar.gz"
+        with tarfile.open(archive, "w:gz") as tf:
+            tf.addfile(tarfile.TarInfo(evil), io.BytesIO(b""))
+
         with pytest.raises(EmbeddedLemonadeError) as exc:
-            _safe_members_ok([evil], tmp_path / "dest")
+            _extract(archive, tmp_path / "dest")
         assert "escapes" in str(exc.value)
+        assert not (tmp_path / "escape.txt").exists()
+
+    @pytest.mark.skipif(
+        platform.system() == "Windows",
+        reason="creating a symlink needs a privilege CI does not hold; Windows "
+        "installs from the .zip asset, never the tarball",
+    )
+    def test_a_symlink_cannot_redirect_a_later_member_out_of_the_tree(self, tmp_path):
+        # Every member name here resolves inside dest while dest is empty, so
+        # a name-only check waves them through. Once 'hop' exists as a symlink,
+        # the kernel resolves 'hop/../..' through it and the third member lands
+        # a directory above dest.
+        archive = tmp_path / "evil.tar.gz"
+        with tarfile.open(archive, "w:gz") as tf:
+            holder = tarfile.TarInfo("d")
+            holder.type = tarfile.DIRTYPE
+            tf.addfile(holder)
+
+            hop = tarfile.TarInfo("d/hop")
+            hop.type = tarfile.SYMTYPE
+            hop.linkname = "."
+            tf.addfile(hop)
+
+            tf.addfile(tarfile.TarInfo("d/hop/../../pwned.txt"), io.BytesIO(b"owned"))
+
+        dest = tmp_path / "dest"
+        _extract(archive, dest)
+        assert not (tmp_path / "pwned.txt").exists()
+        assert (dest / "pwned.txt").read_text(encoding="utf-8") == "owned"
+
+    def test_rejects_a_hard_link_pointing_out_of_the_tree(self, tmp_path):
+        archive = tmp_path / "evil.tar.gz"
+        with tarfile.open(archive, "w:gz") as tf:
+            link = tarfile.TarInfo("stolen")
+            link.type = tarfile.LNKTYPE
+            link.linkname = "../../etc/passwd"
+            tf.addfile(link)
+
+        with pytest.raises(EmbeddedLemonadeError) as exc:
+            _extract(archive, tmp_path / "dest")
+        assert "outside" in str(exc.value)
+
+    def test_drops_setuid_and_setgid_bits(self, tmp_path):
+        if platform.system() == "Windows":
+            pytest.skip("POSIX permission bits are not modelled on Windows")
+
+        archive = tmp_path / "suid.tar.gz"
+        with tarfile.open(archive, "w:gz") as tf:
+            member = tarfile.TarInfo("rooted")
+            member.mode = 0o4755
+            member.size = 0
+            tf.addfile(member, io.BytesIO(b""))
+
+        dest = tmp_path / "dest"
+        _extract(archive, dest)
+        assert not (dest / "rooted").stat().st_mode & (stat.S_ISUID | stat.S_ISGID)
 
     def test_rejects_a_symlink_pointing_out_of_the_tree(self, tmp_path):
         # Member names alone look innocent here; the link target is the escape.
-        from gaia.llm.lemonade_embedded import _extract
-
         archive = tmp_path / "evil.tar.gz"
         with tarfile.open(archive, "w:gz") as tf:
             link = tarfile.TarInfo("escape")
@@ -143,11 +204,9 @@ class TestArchiveSafety:
 
         with pytest.raises(EmbeddedLemonadeError) as exc:
             _extract(archive, tmp_path / "dest")
-        assert "escapes" in str(exc.value)
+        assert "outside" in str(exc.value)
 
     def test_rejects_device_and_special_files(self, tmp_path):
-        from gaia.llm.lemonade_embedded import _extract
-
         archive = tmp_path / "evil.tar.gz"
         with tarfile.open(archive, "w:gz") as tf:
             node = tarfile.TarInfo("dev/null")
@@ -159,11 +218,16 @@ class TestArchiveSafety:
         assert "device or special file" in str(exc.value)
 
     def test_accepts_ordinary_members(self, tmp_path):
-        _safe_members_ok(["lemond.exe", "resources/defaults.json"], tmp_path / "dest")
+        archive = tmp_path / "ok.tar.gz"
+        with tarfile.open(archive, "w:gz") as tf:
+            for name in ("lemond.exe", "resources/defaults.json"):
+                tf.addfile(tarfile.TarInfo(name), io.BytesIO(b""))
+
+        dest = tmp_path / "dest"
+        _extract(archive, dest)
+        assert (dest / "resources" / "defaults.json").is_file()
 
     def test_unknown_archive_suffix_is_rejected(self, tmp_path):
-        from gaia.llm.lemonade_embedded import _extract
-
         bogus = tmp_path / "asset.7z"
         bogus.write_bytes(b"x")
         with pytest.raises(EmbeddedLemonadeError) as exc:
@@ -171,8 +235,6 @@ class TestArchiveSafety:
         assert ".zip or .tar.gz" in str(exc.value)
 
     def test_zip_and_tar_both_unpack(self, tmp_path):
-        from gaia.llm.lemonade_embedded import _extract
-
         payload = tmp_path / "payload.txt"
         payload.write_text("hello", encoding="utf-8")
 

--- a/tests/unit/test_lemonade_embedded.py
+++ b/tests/unit/test_lemonade_embedded.py
@@ -1,0 +1,361 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""Unit tests for GAIA's private (embeddable) Lemonade Server."""
+
+import hashlib
+import json
+import platform
+import tarfile
+import zipfile
+from pathlib import Path
+
+import pytest
+
+from gaia.llm.lemonade_embedded import (
+    _ASSET_TEMPLATES,
+    EMBEDDABLE_SHA256,
+    EmbeddedLemonade,
+    EmbeddedLemonadeError,
+    UnsupportedPlatformError,
+    _flatten_single_root,
+    _safe_members_ok,
+    asset_name,
+    asset_url,
+    gaia_home,
+)
+from gaia.version import LEMONADE_VERSION
+
+
+@pytest.fixture
+def manager(tmp_path):
+    """An EmbeddedLemonade rooted in an empty temp directory."""
+    return EmbeddedLemonade(home=tmp_path)
+
+
+def _fake_platform(monkeypatch, system, machine):
+    """Pin platform.system()/machine() for one test."""
+    monkeypatch.setattr(platform, "system", lambda: system)
+    monkeypatch.setattr(platform, "machine", lambda: machine)
+
+
+class TestAssetResolution:
+    """Platform -> release asset mapping."""
+
+    @pytest.mark.parametrize(
+        "system,machine,expected_suffix",
+        [
+            ("Windows", "AMD64", "windows-x64.zip"),
+            ("Windows", "x86_64", "windows-x64.zip"),
+            ("Linux", "x86_64", "ubuntu-x64.tar.gz"),
+            ("Linux", "aarch64", "ubuntu-arm64.tar.gz"),
+            ("Darwin", "arm64", "macos-arm64.tar.gz"),
+        ],
+    )
+    def test_resolves_each_supported_platform(
+        self, monkeypatch, system, machine, expected_suffix
+    ):
+        _fake_platform(monkeypatch, system, machine)
+        assert asset_name("11.8.0") == f"lemonade-embeddable-11.8.0-{expected_suffix}"
+
+    def test_url_points_at_the_versioned_release_tag(self, monkeypatch):
+        _fake_platform(monkeypatch, "Windows", "AMD64")
+        url = asset_url("11.8.0")
+        assert url.endswith("/v11.8.0/lemonade-embeddable-11.8.0-windows-x64.zip")
+        assert url.startswith("https://github.com/lemonade-sdk/lemonade/releases/")
+
+    def test_unmapped_architecture_names_the_remedy(self, monkeypatch):
+        _fake_platform(monkeypatch, "Linux", "riscv64")
+        with pytest.raises(UnsupportedPlatformError) as exc:
+            asset_name()
+        assert "riscv64" in str(exc.value)
+        assert "gaia init" in str(exc.value)
+
+    def test_unpublished_os_arch_pair_names_the_remedy(self, monkeypatch):
+        # macOS x86_64: the architecture is known, but no asset is published.
+        _fake_platform(monkeypatch, "Darwin", "x86_64")
+        with pytest.raises(UnsupportedPlatformError) as exc:
+            asset_name()
+        assert "gaia init" in str(exc.value)
+
+
+class TestChecksumPinning:
+    """A version bump must not silently drop checksum verification."""
+
+    def test_every_platform_has_a_pinned_digest_for_the_current_version(self):
+        missing = [
+            template.format(version=LEMONADE_VERSION)
+            for template in _ASSET_TEMPLATES.values()
+            if template.format(version=LEMONADE_VERSION) not in EMBEDDABLE_SHA256
+        ]
+        assert not missing, (
+            f"LEMONADE_VERSION is {LEMONADE_VERSION} but these assets have no "
+            f"pinned SHA-256 in EMBEDDABLE_SHA256: {missing}. Add them from the "
+            f"release page before bumping."
+        )
+
+    def test_pins_are_well_formed_sha256(self):
+        for name, digest in EMBEDDABLE_SHA256.items():
+            assert len(digest) == 64, f"{name}: not a sha256 hex digest"
+            assert not digest.startswith("sha256:"), f"{name}: strip the prefix"
+            int(digest, 16)  # raises if non-hex
+
+    def test_install_refuses_a_version_with_no_pin(self, manager, monkeypatch):
+        _fake_platform(monkeypatch, "Windows", "AMD64")
+        manager.version = "99.0.0"
+        with pytest.raises(EmbeddedLemonadeError) as exc:
+            manager.install()
+        assert "No pinned SHA-256" in str(exc.value)
+
+    def test_verify_rejects_a_mismatched_download(self, manager, tmp_path):
+        archive = tmp_path / "asset.zip"
+        archive.write_bytes(b"not the real asset")
+        with pytest.raises(EmbeddedLemonadeError) as exc:
+            manager._verify(archive, "0" * 64)
+        assert "Checksum mismatch" in str(exc.value)
+
+    def test_verify_accepts_a_matching_download(self, manager, tmp_path):
+        payload = b"the real asset"
+        archive = tmp_path / "asset.zip"
+        archive.write_bytes(payload)
+        manager._verify(archive, hashlib.sha256(payload).hexdigest())
+
+
+class TestArchiveSafety:
+    """Downloaded archives must not be able to write outside the target."""
+
+    @pytest.mark.parametrize("evil", ["../escape.txt", "a/../../escape.txt"])
+    def test_rejects_members_escaping_the_destination(self, tmp_path, evil):
+        with pytest.raises(EmbeddedLemonadeError) as exc:
+            _safe_members_ok([evil], tmp_path / "dest")
+        assert "escapes" in str(exc.value)
+
+    def test_rejects_a_symlink_pointing_out_of_the_tree(self, tmp_path):
+        # Member names alone look innocent here; the link target is the escape.
+        from gaia.llm.lemonade_embedded import _extract
+
+        archive = tmp_path / "evil.tar.gz"
+        with tarfile.open(archive, "w:gz") as tf:
+            link = tarfile.TarInfo("escape")
+            link.type = tarfile.SYMTYPE
+            link.linkname = "../../outside"
+            tf.addfile(link)
+
+        with pytest.raises(EmbeddedLemonadeError) as exc:
+            _extract(archive, tmp_path / "dest")
+        assert "escapes" in str(exc.value)
+
+    def test_rejects_device_and_special_files(self, tmp_path):
+        from gaia.llm.lemonade_embedded import _extract
+
+        archive = tmp_path / "evil.tar.gz"
+        with tarfile.open(archive, "w:gz") as tf:
+            node = tarfile.TarInfo("dev/null")
+            node.type = tarfile.CHRTYPE
+            tf.addfile(node)
+
+        with pytest.raises(EmbeddedLemonadeError) as exc:
+            _extract(archive, tmp_path / "dest")
+        assert "device or special file" in str(exc.value)
+
+    def test_accepts_ordinary_members(self, tmp_path):
+        _safe_members_ok(["lemond.exe", "resources/defaults.json"], tmp_path / "dest")
+
+    def test_unknown_archive_suffix_is_rejected(self, tmp_path):
+        from gaia.llm.lemonade_embedded import _extract
+
+        bogus = tmp_path / "asset.7z"
+        bogus.write_bytes(b"x")
+        with pytest.raises(EmbeddedLemonadeError) as exc:
+            _extract(bogus, tmp_path / "dest")
+        assert ".zip or .tar.gz" in str(exc.value)
+
+    def test_zip_and_tar_both_unpack(self, tmp_path):
+        from gaia.llm.lemonade_embedded import _extract
+
+        payload = tmp_path / "payload.txt"
+        payload.write_text("hello", encoding="utf-8")
+
+        zip_path = tmp_path / "a.zip"
+        with zipfile.ZipFile(zip_path, "w") as zf:
+            zf.write(payload, "payload.txt")
+        _extract(zip_path, tmp_path / "outz")
+        assert (tmp_path / "outz" / "payload.txt").read_text() == "hello"
+
+        tar_path = tmp_path / "a.tar.gz"
+        with tarfile.open(tar_path, "w:gz") as tf:
+            tf.add(payload, "payload.txt")
+        _extract(tar_path, tmp_path / "outt")
+        assert (tmp_path / "outt" / "payload.txt").read_text() == "hello"
+
+
+class TestPayloadLayout:
+    """The published archives wrap everything in one directory."""
+
+    def test_single_wrapper_directory_is_stripped(self, tmp_path):
+        inner = tmp_path / "lemonade-embeddable-11.8.0-windows-x64"
+        inner.mkdir()
+        (inner / "lemond.exe").write_bytes(b"")
+        assert _flatten_single_root(tmp_path) == inner
+
+    def test_flat_archive_is_left_alone(self, tmp_path):
+        (tmp_path / "lemond.exe").write_bytes(b"")
+        (tmp_path / "LICENSE").write_bytes(b"")
+        assert _flatten_single_root(tmp_path) == tmp_path
+
+
+class TestPaths:
+    """Layout under GAIA_HOME."""
+
+    def test_cache_and_config_are_shared_across_versions(self, tmp_path):
+        old = EmbeddedLemonade(version="11.7.0", home=tmp_path)
+        new = EmbeddedLemonade(version="11.8.0", home=tmp_path)
+        # Backends cost 141 MB to 4.3 GB; a version bump must not re-download them.
+        assert old.cache_dir == new.cache_dir
+        assert old.config_dir == new.config_dir
+        assert old.dist_dir != new.dist_dir
+
+    def test_gaia_home_honours_the_env_override(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("GAIA_HOME", str(tmp_path))
+        assert gaia_home() == tmp_path.resolve()
+
+    def test_gaia_home_defaults_under_the_user_profile(self, monkeypatch):
+        monkeypatch.delenv("GAIA_HOME", raising=False)
+        assert gaia_home() == Path.home() / ".gaia"
+
+    def test_daemon_filename_is_platform_correct(self, monkeypatch, tmp_path):
+        _fake_platform(monkeypatch, "Windows", "AMD64")
+        assert EmbeddedLemonade(home=tmp_path).daemon_path.name == "lemond.exe"
+        _fake_platform(monkeypatch, "Linux", "x86_64")
+        assert EmbeddedLemonade(home=tmp_path).daemon_path.name == "lemond"
+
+    def test_base_url_carries_the_api_v1_prefix(self):
+        # LemonadeClient builds on a base_url that already includes /api/v1.
+        assert EmbeddedLemonade.base_url_for(1234) == "http://localhost:1234/api/v1"
+
+
+class TestConfig:
+    """The config lemond is handed."""
+
+    def test_written_config_keeps_the_instance_private(self, manager):
+        config = json.loads(manager.write_config().read_text(encoding="utf-8"))
+        assert config["broadcast"] is False
+        assert config["config_version"] == 2
+
+    def test_does_not_set_no_fetch_executables(self, manager):
+        # Setting it true collapses the advertised catalogue from 204 models to
+        # the 4 runnable by built-in backends, breaking `gaia download`.
+        config = json.loads(manager.write_config().read_text(encoding="utf-8"))
+        assert "no_fetch_executables" not in config
+
+
+class TestStatus:
+    """Status reporting and stale-state recovery."""
+
+    def test_cold_state_reports_not_installed_and_not_running(self, manager):
+        status = manager.status()
+        assert status.installed is False
+        assert status.running is False
+        assert status.base_url is None
+
+    def test_unreadable_state_file_is_discarded(self, manager):
+        manager.root.mkdir(parents=True, exist_ok=True)
+        manager.state_path.write_text("{ not json", encoding="utf-8")
+        assert manager.status().running is False
+
+    def test_state_for_a_dead_instance_is_cleared(self, manager, monkeypatch):
+        manager._write_state(
+            {"pid": 1, "port": 65535, "api_key": "k", "version": manager.version}
+        )
+        monkeypatch.setattr(EmbeddedLemonade, "_health", lambda *a, **k: None)
+        monkeypatch.setattr(
+            EmbeddedLemonade, "_daemon_alive", staticmethod(lambda p: False)
+        )
+        assert manager.status().running is False
+        assert not manager.state_path.exists(), "dead instance left a stale state file"
+
+    def test_a_slow_daemon_keeps_its_state(self, manager, monkeypatch):
+        # A daemon loading a multi-GB backend can miss the health probe. Losing
+        # its pid/port/key here would orphan it with no way to stop it.
+        manager._write_state(
+            {"pid": 4321, "port": 65535, "api_key": "k", "version": manager.version}
+        )
+        monkeypatch.setattr(EmbeddedLemonade, "_health", lambda *a, **k: None)
+        monkeypatch.setattr(
+            EmbeddedLemonade, "_daemon_alive", staticmethod(lambda p: True)
+        )
+
+        status = manager.status()
+        assert status.running is False
+        assert status.unresponsive_pid == 4321
+        assert manager.state_path.exists(), "live daemon lost its state file"
+
+    def test_start_refuses_to_spawn_a_second_daemon(self, manager, monkeypatch):
+        manager._write_state(
+            {"pid": 4321, "port": 65535, "api_key": "k", "version": manager.version}
+        )
+        monkeypatch.setattr(EmbeddedLemonade, "_health", lambda *a, **k: None)
+        monkeypatch.setattr(
+            EmbeddedLemonade, "_daemon_alive", staticmethod(lambda p: True)
+        )
+
+        with pytest.raises(EmbeddedLemonadeError) as exc:
+            manager.start()
+        assert "not answering" in str(exc.value)
+        assert "gaia lemonade embedded stop" in str(exc.value)
+
+    def test_stop_reaches_a_daemon_that_stopped_answering(self, manager, monkeypatch):
+        manager._write_state(
+            {"pid": 4321, "port": 65535, "api_key": "k", "version": manager.version}
+        )
+        killed = []
+        monkeypatch.setattr(EmbeddedLemonade, "_health", lambda *a, **k: None)
+        monkeypatch.setattr(
+            EmbeddedLemonade,
+            "_daemon_alive",
+            staticmethod(lambda p: not killed),
+        )
+        monkeypatch.setattr(EmbeddedLemonade, "_kill_tree", staticmethod(killed.append))
+
+        assert manager.stop() is True
+        assert killed == [4321], "stalled daemon was never signalled"
+        assert not manager.state_path.exists()
+
+    def test_start_refuses_when_a_different_version_is_running(
+        self, manager, monkeypatch
+    ):
+        manager._write_state(
+            {"pid": 1, "port": 4321, "api_key": "k", "version": "11.7.0"}
+        )
+        monkeypatch.setattr(EmbeddedLemonade, "_health", lambda *a, **k: {"ok": True})
+        with pytest.raises(EmbeddedLemonadeError) as exc:
+            manager.start()
+        assert "11.7.0" in str(exc.value)
+        assert "stop" in str(exc.value)
+
+    def test_live_instance_is_reported_with_its_base_url(self, manager, monkeypatch):
+        manager._write_state(
+            {"pid": 42, "port": 4321, "api_key": "k", "version": manager.version}
+        )
+        monkeypatch.setattr(EmbeddedLemonade, "_health", lambda *a, **k: {"ok": True})
+        status = manager.status()
+        assert status.running is True
+        assert status.port == 4321
+        assert status.base_url == "http://localhost:4321/api/v1"
+
+    def test_stop_reports_false_when_nothing_runs(self, manager):
+        assert manager.stop() is False
+
+
+class TestFailureMessages:
+    """Errors must name what failed and what to do about it."""
+
+    def test_start_without_install_permission_says_how_to_install(self, manager):
+        with pytest.raises(EmbeddedLemonadeError) as exc:
+            manager.start(install_if_missing=False)
+        assert "not installed" in str(exc.value)
+        assert "gaia lemonade embedded start" in str(exc.value)
+
+    def test_backend_install_without_a_server_says_to_start_one(self, manager):
+        with pytest.raises(EmbeddedLemonadeError) as exc:
+            manager.install_backend("llamacpp:vulkan")
+        assert "gaia lemonade embedded start" in str(exc.value)

--- a/tests/unit/test_lemonade_embedded.py
+++ b/tests/unit/test_lemonade_embedded.py
@@ -5,6 +5,7 @@
 import hashlib
 import json
 import platform
+import stat
 import tarfile
 import zipfile
 from pathlib import Path
@@ -344,6 +345,43 @@ class TestStatus:
 
     def test_stop_reports_false_when_nothing_runs(self, manager):
         assert manager.stop() is False
+
+
+class TestCredentials:
+    """The API key must not leak into scrollback, history or CI logs."""
+
+    def test_env_file_holds_both_variables(self, manager):
+        path = manager._write_env_file(4321, "s3cret-key")
+        body = path.read_text(encoding="utf-8")
+        assert "s3cret-key" in body
+        assert "http://localhost:4321/api/v1" in body
+        assert "LEMONADE_BASE_URL" in body and "LEMONADE_API_KEY" in body
+
+    @pytest.mark.skipif(platform.system() == "Windows", reason="POSIX file modes only")
+    def test_env_file_is_owner_readable_only(self, manager):
+        path = manager._write_env_file(4321, "s3cret-key")
+        assert stat.S_IMODE(path.stat().st_mode) == 0o600
+
+    @pytest.mark.skipif(platform.system() == "Windows", reason="POSIX file modes only")
+    def test_state_file_is_owner_readable_only(self, manager):
+        manager._write_state(
+            {"pid": 1, "port": 2, "api_key": "k", "version": manager.version}
+        )
+        assert stat.S_IMODE(manager.state_path.stat().st_mode) == 0o600
+
+    def test_clearing_state_removes_the_credentials_too(self, manager):
+        # Credentials naming a dead port are worse than none: whatever grabs
+        # that port next would inherit the trust.
+        manager._write_state(
+            {"pid": 1, "port": 2, "api_key": "k", "version": manager.version}
+        )
+        manager._write_env_file(2, "k")
+        manager._clear_state()
+        assert not manager.env_path.exists()
+        assert not manager.state_path.exists()
+
+    def test_load_command_names_the_env_file(self, manager):
+        assert str(manager.env_path) in manager.env_load_command()
 
 
 class TestFailureMessages:


### PR DESCRIPTION
Running GAIA has meant first installing Lemonade Server machine-wide with an MSI — admin rights, a shared tray app, and one server every app on the box fights over. `gaia lemonade embedded start` now gives GAIA its own: it downloads the upstream embeddable build (~5 MB), verifies it against a pinned checksum, and runs it on a port picked at start behind a generated API key that locks everyone else out. No installer, no admin rights, nothing shared. The MSI path is untouched and still serves everything else.

Scoped to the module and its CLI — startup wiring, installer packaging, and R2 publish are deliberately not here, so this is reviewable and verifiable on its own.

### Two findings worth knowing before review

**ROCm settles the bundling question.** Measured on Strix: llama.cpp CPU + Vulkan is 141 MB and covers GAIA's default Gemma-4 and embedding models. ROCm is **4.3 GB** and ships per-GPU-architecture (28 targets in upstream's manifest), so it can never be bundled — it stays a per-machine fetch via `install-backend`.

**The reported 10-minute cold start did not reproduce.** Four cold starts, including one with no config file and the full stock 228-model catalogue: healthy in **1.6 s** every time. So this does not trim the catalogue, and it deliberately leaves `no_fetch_executables` unset — setting it collapses the advertised catalogue from 204 models to 4 and would break `gaia download`.

<details>
<summary>🔍 Technical details</summary>

- `lemond` takes **two** positional directories (`<cache_dir> <config_dir>`), not the single `DIR` the published docs describe. The lifecycle test exercises the real binary precisely because a mocked subprocess would prove only that we called it, never that the arguments are ones it accepts.
- The API key is written to an owner-only `env.sh`/`env.ps1` rather than printed — a printed key lands in scrollback, shell history and CI logs. Both that file and `state.json` are deleted on `stop`, since credentials naming a dead port would let whatever grabs that port next inherit the trust.
- Model storage is not duplicated — the private instance reads the same Hugging Face cache, so already-downloaded models appear immediately (`Cache built: 204 total, 4 downloaded` on first run here).
- `cache/` and `config/` are version-independent; only `dist/<version>/` is versioned. A Lemonade bump re-downloads the 5 MB server, not gigabytes of backends.
- Checksums are pinned in `EMBEDDABLE_SHA256`, with an integration test diffing them against the live release API. This already earned its keep: rebasing onto main's 11.8.1 bump failed the pinning test immediately instead of shipping unverifiable downloads.
- `status()` never discards state for a daemon that is merely slow to answer — it distinguishes "gone" from "up but not responding", so a server loading a large backend can still be stopped instead of orphaned.
</details>

### Test plan

- [ ] `pytest tests/unit/test_lemonade_embedded.py` — 43 pass (2 POSIX-mode tests skip on Windows)
- [ ] `pytest tests/integration/test_lemonade_embedded_lifecycle.py tests/integration/test_lemonade_embeddable_assets.py` — 10 pass; downloads and runs the real daemon, asserts unauthenticated and wrong-key requests get 401
- [ ] Cold, from no `~/.gaia/lemonade` at all: `gaia lemonade embedded start` → running in ~11 s including download; `status`; `stop`
- [ ] Source the printed `env.ps1`/`env.sh`, then hit `/api/v1/models` — 200 with the key, 401 without
- [ ] `gaia lemonade embedded install-backend llamacpp:vulkan`, then a real completion against `Gemma-4-E4B-it-GGUF`
- [ ] `install --force` while running → refuses; `gaia lemonade embedded` with no subcommand → exit 1
- [ ] Confirm `stop` removes the credentials file and leaves no `lemond` or `llama-server` behind