### PR TITLE
feat(daemon): start and supervise the local model server

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -462,8 +462,9 @@ python -m pytest tests/ --hybrid   # Cloud + local testing
 
 ### Running GAIA
 ```bash
-gaia init                          # Install Lemonade Server + models, and start it (first run)
-gaia llm "Hello"                   # Test LLM
+gaia init                          # Install Lemonade Server + models (first run)
+gaia daemon start                  # Starts and supervises the LLM backend
+gaia llm "Hello"                   # Test LLM (starts the backend on its own)
 gaia chat                          # Interactive chat
 gaia chat --ui                     # Agent UI (browser-based)
 ```
@@ -471,10 +472,11 @@ gaia chat --ui                     # Agent UI (browser-based)
 **Never tell anyone to run `lemonade-server serve`** — Lemonade 10.7/10.8 removed that
 CLI, so the binary does not exist on a current install. There is no portable command to
 substitute: how the server starts depends on the install (Windows tray, macOS app, Linux
-`systemctl --user start lemond`, legacy CLI). `gaia init` is the only thing in the tree
-that auto-starts the server; the normal runtime path (`LemonadeManager.ensure_ready`)
-merely *checks*, and errors out on a stopped server rather than launching one. When you
-need to print a start instruction, call `describe_start_hint()`
+`systemctl --user start lemond`, legacy CLI). The daemon starts and supervises the
+server, and `LemonadeManager.ensure_ready` auto-starts it through that supervisor, so
+the runtime path no longer errors out on a stopped server. A start instruction is still
+needed whenever GAIA cannot own the process — a non-default port or a remote
+`LEMONADE_BASE_URL`. To print one, call `describe_start_hint()`
 ([`src/gaia/llm/lemonade_launcher.py`](src/gaia/llm/lemonade_launcher.py)) instead of
 hard-coding a command — it resolves the installed tooling and never names a binary the
 host lacks.

--- a/docs/cpp/bash-agent.mdx
+++ b/docs/cpp/bash-agent.mdx
@@ -37,9 +37,11 @@ icon: "terminal"
     ```
   </Step>
 
-  <Step title="Start Lemonade Server">
+  <Step title="Start the LLM server">
+    `gaia daemon` starts and supervises the model server in the background — it does not occupy the terminal.
+
     ```bash
-    lemonade-server serve
+    gaia daemon start
     ```
 
     Ensure the default model is loaded (override with `--model` or `LEMONADE_MODEL`):

--- a/docs/cpp/health-agent.mdx
+++ b/docs/cpp/health-agent.mdx
@@ -75,9 +75,11 @@ Full diagnostic run on a Ryzen AI PC: the agent gathers CPU, memory, disk, and p
     </Tabs>
   </Step>
 
-  <Step title="Start Lemonade Server">
+  <Step title="Start the LLM server">
+    `gaia daemon` starts and supervises the model server in the background — it does not occupy the terminal.
+
     ```bash
-    lemonade-server serve
+    gaia daemon start
     ```
   </Step>
 

--- a/docs/cpp/integration.mdx
+++ b/docs/cpp/integration.mdx
@@ -365,10 +365,10 @@ That is the entire API surface. No embeddings endpoint, no streaming (unless `cf
   </Tab>
 
   <Tab title="Lemonade (default)">
-    [Lemonade Server](https://lemonade-server.ai) is the default backend, optimized for AMD Ryzen AI NPU and GPU acceleration.
+    [Lemonade Server](https://lemonade-server.ai) is the default backend, optimized for AMD Ryzen AI NPU and GPU acceleration. `gaia daemon` starts and supervises it for you in the background.
 
     ```bash
-    lemonade-server serve
+    gaia daemon start
     ```
 
     ```cpp

--- a/docs/cpp/process-agent.mdx
+++ b/docs/cpp/process-agent.mdx
@@ -102,9 +102,11 @@ The agent auto-runs a full system scan on startup, then waits for your input. Yo
     </Tabs>
   </Step>
 
-  <Step title="Start Lemonade Server">
+  <Step title="Start the LLM server">
+    `gaia daemon` starts and supervises the model server in the background — it does not occupy the terminal.
+
     ```bash
-    lemonade-server serve
+    gaia daemon start
     ```
     The agent connects to `http://localhost:13305/api/v1` by default.
   </Step>

--- a/docs/cpp/quickstart.mdx
+++ b/docs/cpp/quickstart.mdx
@@ -66,10 +66,10 @@ icon: "rocket"
   </Step>
 
   <Step title="Start an LLM server">
-    The agent connects to any OpenAI-compatible LLM server at `http://localhost:13305/api/v1` by default. The recommended backend is [Lemonade Server](https://lemonade-server.ai) (optimized for AMD hardware):
+    The agent connects to any OpenAI-compatible LLM server at `http://localhost:13305/api/v1` by default. The recommended backend is [Lemonade Server](https://lemonade-server.ai) (optimized for AMD hardware), which `gaia daemon` starts and supervises in the background:
 
     ```bash
-    lemonade-server serve
+    gaia daemon start
     ```
 
     <Note>

--- a/docs/cpp/setup.mdx
+++ b/docs/cpp/setup.mdx
@@ -88,9 +88,9 @@ icon: "wrench"
 
     Or download directly from the [Lemonade v11.8.1 release page](https://github.com/lemonade-sdk/lemonade/releases/tag/v11.8.1).
 
-    After installation, restart your terminal and start the server:
+    After installation, restart your terminal and start the server. `gaia daemon` resolves and supervises it in the background, so the terminal stays free:
     ```powershell
-    lemonade-server serve
+    gaia daemon start
     ```
 
     <Note>
@@ -178,9 +178,9 @@ icon: "wrench"
 
     Or browse all platform options on the [Lemonade v11.8.1 release page](https://github.com/lemonade-sdk/lemonade/releases/tag/v11.8.1).
 
-    After installation, start the server:
+    After installation, start the server. `gaia daemon` resolves and supervises it in the background, so the terminal stays free:
     ```bash
-    lemonade-server serve
+    gaia daemon start
     ```
 
     <Note>

--- a/docs/cpp/testing.mdx
+++ b/docs/cpp/testing.mdx
@@ -164,9 +164,9 @@ This produces the `tests_integration` binary alongside the unit test binary.
 
 ### Running Integration Tests
 
-1. Start an LLM server with a model loaded:
+1. Start an LLM server with a model loaded. `gaia daemon` starts and supervises it in the background, so the same terminal stays free for the test run:
    ```bat
-   lemonade-server serve
+   gaia daemon start
    ```
 
 2. Set environment variables (optional — defaults shown):

--- a/docs/cpp/wifi-agent.mdx
+++ b/docs/cpp/wifi-agent.mdx
@@ -87,9 +87,11 @@ Full diagnostic run on a Ryzen AI PC: the agent calls 5 tools in sequence, reads
     </Tabs>
   </Step>
 
-  <Step title="Start Lemonade Server">
+  <Step title="Start the LLM server">
+    `gaia daemon` starts and supervises the model server in the background — it does not occupy the terminal.
+
     ```bash
-    lemonade-server serve
+    gaia daemon start
     ```
     The agent connects to `http://localhost:13305/api/v1` by default.
   </Step>

--- a/docs/deployment/ui.mdx
+++ b/docs/deployment/ui.mdx
@@ -152,10 +152,10 @@ glibc or system libraries than the Ubuntu runner used to produce the
 AppImage. If the AppImage binary is not compatible on Arch you have
 these options:
 
-- Use the browser-based UI by running the backend manually:
+- Use the browser-based UI by running the backend yourself. It asks the
+  daemon for a model server, so this is the only command you need:
 
 ```bash
-lemonade-server serve
 python -m gaia.ui.server
 # Open http://127.0.0.1:4200
 ```
@@ -205,14 +205,14 @@ Gaia Agent UI
 
 ## Developer Quick Start
 
-```bash
-# 1. Start Lemonade Server
-lemonade-server serve
+The backend brings up Lemonade Server through the daemon on first use, so
+there is nothing to start before it:
 
-# 2. Start Agent UI backend
+```bash
+# 1. Start Agent UI backend
 python -m gaia.ui.server
 
-# 3. Open http://127.0.0.1:4200 in your browser
+# 2. Open http://127.0.0.1:4200 in your browser
 ```
 
 For full documentation, see:

--- a/docs/eval.mdx
+++ b/docs/eval.mdx
@@ -245,15 +245,10 @@ The fixer subprocess (`claude -p fixer.md`) receives the `scorecard.json` path, 
     ```
   </Step>
 
-  <Step title="Start the LLM backend">
-    Lemonade server provides the local LLM and embeddings for the Agent UI:
-
-    ```bash
-    lemonade-server serve
-    ```
-  </Step>
-
   <Step title="Start the Agent UI backend">
+    This also brings up Lemonade Server, which provides the local LLM and
+    embeddings — you don't need to start it separately.
+
     <Tabs>
       <Tab title="CLI">
         ```bash

--- a/docs/glossary.mdx
+++ b/docs/glossary.mdx
@@ -116,7 +116,7 @@ Generating a unique identifier for document content to detect when files have ch
 Maintaining important information when splitting text across chunks, ensuring coherent answers.
 
 ### Context Size
-The number of tokens allocated for LLM processing, configured via `--ctx-size` parameter when starting Lemonade Server. Larger values (e.g., 32768) allow processing more input but require more memory. Not the same as Context Window (the model's inherent limit). See also: Context Window, Max Tokens.
+The number of tokens allocated for LLM processing. GAIA pins it per device profile (65536 on GPU/CPU, 32768 on NPU) and applies it when the daemon starts Lemonade Server, so you don't set it yourself. Larger values allow processing more input but require more memory. Not the same as Context Window (the model's inherent limit). See also: Context Window, Max Tokens.
 
 ### Context Window
 The maximum number of tokens an LLM can process at once, including both input and output. Modern models range from 4K to 1M+ tokens.
@@ -263,7 +263,7 @@ A lightweight, high-quality text-to-speech engine used by GAIA for voice output 
 ## L
 
 ### Lemonade Server
-AMD's optimized LLM serving platform providing hardware-accelerated inference on Ryzen AI processors. Supports NPU/iGPU hybrid mode, model management, and an OpenAI-compatible API. Start with `lemonade-server serve`. Required for most GAIA operations. See also: NPU, Hybrid Mode, LEMONADE_BASE_URL.
+AMD's optimized LLM serving platform providing hardware-accelerated inference on Ryzen AI processors. Supports NPU/iGPU hybrid mode, model management, and an OpenAI-compatible API. Required for most GAIA operations; `gaia daemon` starts and supervises it for you, so you rarely launch it yourself. Install it with `gaia init`. See also: NPU, Hybrid Mode, LEMONADE_BASE_URL.
 
 ### LEMONADE_BASE_URL
 Environment variable specifying the address of the Lemonade Server (default `http://localhost:13305/api/v1`). The GAIA OpenAI-compatible API server runs on port 8080 — don't confuse the two.

--- a/docs/guides/agent-ui.mdx
+++ b/docs/guides/agent-ui.mdx
@@ -155,11 +155,10 @@ Pick the install path that fits you best:
 
     **Prerequisites (Python path only):**
 
-    The Python CLI path requires you to set up the backend manually:
+    The Python CLI path needs the model backend installed first:
 
     ```bash
     gaia init                   # Downloads Lemonade Server + models
-    lemonade-server serve       # Start the LLM server
     ```
 
     Use `--profile minimal` for a smaller download (~400 MB).
@@ -316,11 +315,15 @@ The agent supports the **Model Context Protocol** in both directions — connect
 
 <AccordionGroup>
   <Accordion title="Lemonade Server not running">
+    You shouldn't have to start the model server yourself — `gaia daemon` starts and supervises it. So the question is why that didn't happen.
+
     ```bash
-    lemonade-server serve
+    gaia daemon status            # the daemon reports the model server it supervises
+    gaia daemon start             # if no daemon is running
+    gaia daemon logs --lines 100  # daemon up but no model server — the reason is here
     ```
 
-    If not installed, run `gaia init --profile minimal` or follow the [Setup Guide](/setup).
+    The usual cause is that Lemonade isn't installed at all. Run `gaia init --profile minimal` or follow the [Setup Guide](/setup).
   </Accordion>
 
   <Accordion title="No model loaded">

--- a/docs/guides/code-index.mdx
+++ b/docs/guides/code-index.mdx
@@ -39,11 +39,7 @@ Install the `[rag]` extras (FAISS + numpy live there):
 uv pip install -e '.[rag]'
 ```
 
-Start Lemonade Server so embeddings can be generated:
-
-```bash
-lemonade-server serve
-```
+Embeddings are generated locally by Lemonade. If you haven't installed it yet, `gaia init` installs the server and pulls the model — `gaia daemon` starts and supervises it from there.
 
 <Note>
 The default embedder is now `user.embeddinggemma-300m-GGUF` (EmbeddingGemma 300M), replacing `nomic-embed-text-v2-moe-GGUF` because the current llama.cpp server cannot load the nomic MOE embedder. Both are 768-dim, so retrieval behavior is unchanged. A cached index (under `~/.gaia/code_index/`) records the model it was built with: re-indexing rebuilds every embedding with the new model, and searching a stale index fails loudly with a model-mismatch error until you rebuild.

--- a/docs/guides/email-integration.mdx
+++ b/docs/guides/email-integration.mdx
@@ -73,9 +73,9 @@ Three tiers, all on the user's machine — no cloud inference, no separate mailb
 
 ## Standing up the API surface
 
-You need a **running Lemonade Server** (`lemonade-server serve`) and the model pulled
-(`gaia init` installs Lemonade and downloads the default `Gemma-4-E4B-it-GGUF`). Then
-pick one of the entry points below.
+You need Lemonade installed with the model pulled — `gaia init` does both, downloading
+the default `Gemma-4-E4B-it-GGUF`. Starting the server is not your job: `gaia daemon`
+resolves and supervises it. Then pick one of the entry points below.
 
 <Tabs>
   <Tab title="GAIA backend (REST — recommended)">
@@ -223,8 +223,8 @@ you (`--python <path>` to pick a venv, `--port <n>` to rebind).
 <Note>
   - The server starts (and `connectSidecar` succeeds) **before** Lemonade is up —
     `/health` is liveness-only. Live `triage` returns **502** until a local
-    Lemonade Server is running with the model pulled (`lemonade-server serve`;
-    `gaia init` to provision). You can still iterate on non-LLM code paths first.
+    Lemonade Server is up with the model pulled (`gaia init` to provision;
+    `gaia daemon status` to check). You can still iterate on non-LLM code paths first.
   - You own the `serve` process — there's no `child` on the returned handle and
     nothing to `shutdown()`; Ctrl+C the terminal running `serve`.
   - Auto-reload restarts the server, so conversational `/v1/email/agent/*`

--- a/docs/guides/email.mdx
+++ b/docs/guides/email.mdx
@@ -121,13 +121,11 @@ There are two ways to connect Google depending on how you use GAIA.
   </Tab>
 </Tabs>
 
-### 2. Confirm Lemonade is running
+### 2. Local inference
 
-```bash
-lemonade-server serve
-```
+Email-body inference runs on your local Lemonade instance, which `gaia daemon` starts and supervises — you don't launch it yourself. If Lemonade isn't installed yet, `gaia init` installs it and pulls the model.
 
-Email-body inference runs on your local Lemonade instance. The agent **rejects** any non-local LLM endpoint at startup — there is no path through configuration to route email content to a cloud LLM.
+The agent **rejects** any non-local LLM endpoint at startup — there is no path through configuration to route email content to a cloud LLM.
 
 ### 3. Start the agent
 

--- a/docs/guides/eval.mdx
+++ b/docs/guides/eval.mdx
@@ -50,11 +50,13 @@ Unlike unit tests that check individual functions, Agent Eval tests the **full s
     If not installed, see [Claude Code installation](https://docs.anthropic.com/en/docs/claude-code).
   </Step>
 
-  <Step title="Start the LLM backend">
-    Lemonade Server provides the local LLM and embeddings:
+  <Step title="Install the local LLM backend">
+    The benchmark runs against a local model, so Lemonade and the model have to be on
+    the machine. `gaia init` installs both — you don't have to start anything, the
+    daemon does that:
 
     ```bash
-    lemonade-server serve
+    gaia init
     ```
   </Step>
 

--- a/docs/guides/hardware-advisor.mdx
+++ b/docs/guides/hardware-advisor.mdx
@@ -76,11 +76,10 @@ The agent uses three tools:
 
 ## Requirements
 
-- **Lemonade Server** must be running for hardware detection
 - **GAIA** installed: `uv pip install amd-gaia`
 
 <Tip>
-GAIA auto-starts Lemonade Server on first use if it's not already running.
+Hardware detection reads from the model server, but you don't start that yourself — `gaia daemon` resolves, starts and supervises it.
 </Tip>
 
 ---
@@ -90,10 +89,15 @@ GAIA auto-starts Lemonade Server on first use if it's not already running.
 <Accordion title="Lemonade Server not running">
 **Error:** `Failed to get hardware information from Lemonade Server`
 
-**Solution:** Start Lemonade Server:
-```bash
-lemonade-server serve
-```
+You shouldn't have to start the model server yourself — `gaia daemon` resolves, starts and supervises it. So the question is why that didn't happen.
+
+Start with the daemon, which reports the model server it supervises: `gaia daemon status`
+
+If no daemon is running, start it: `gaia daemon start`
+
+If the daemon is up but the model server isn't, the reason is in the daemon log: `gaia daemon logs --lines 100`
+
+The usual cause is that Lemonade isn't installed at all. `gaia init` installs the server and pulls the model.
 </Accordion>
 
 <Accordion title="GPU not detected">

--- a/docs/guides/mcp/windows-system-health.mdx
+++ b/docs/guides/mcp/windows-system-health.mdx
@@ -42,12 +42,6 @@ The agent gathers metrics via PowerShell, formats a report, and pastes it into N
 ## Quick Start
 
 <Steps>
-  <Step title="Start Lemonade Server">
-    ```bash
-    lemonade-server serve
-    ```
-  </Step>
-
   <Step title="Run the agent">
     ```bash
     uv run examples/mcp_windows_system_health_agent.py

--- a/docs/guides/memory.mdx
+++ b/docs/guides/memory.mdx
@@ -27,11 +27,7 @@ Before using Agent Memory, make sure you have the following in place:
 
 - **Extras required:** `[dev,rag]` — `[rag]` provides the FAISS index used for memory recall; `[dev]` adds the developer toolchain
 
-- **Lemonade server** must be running before you start:
-
-  ```bash
-  lemonade-server serve
-  ```
+- **Model server:** nothing to start — `gaia daemon` resolves and supervises it. If Lemonade isn't installed yet, run `gaia init`
 
 - **Example files** referenced in this guide are inside the cloned repo under `examples/`
 

--- a/docs/guides/talk.mdx
+++ b/docs/guides/talk.mdx
@@ -39,16 +39,6 @@ GAIA's talk mode enables natural voice-based interaction with LLMs using Whisper
     ```
   </Step>
 
-  <Step title="Start Lemonade Server">
-    Launch the AI backend server:
-
-    ```bash
-    lemonade-server serve
-    ```
-
-    <Tip>You can also double-click the desktop shortcut to start the server</Tip>
-  </Step>
-
   <Step title="Launch Talk Mode">
     Start voice conversation:
 

--- a/docs/integrations/mcp.mdx
+++ b/docs/integrations/mcp.mdx
@@ -74,11 +74,12 @@ The GAIA MCP Server provides an HTTP-native bridge that exposes GAIA's AI agents
     Follow the [Development Guide](/reference/dev) to install GAIA
   </Step>
 
-  <Step title="Start Lemonade Server">
-    Ensure the LLM backend is running:
+  <Step title="Install the LLM backend">
     ```bash
-    lemonade-server serve --ctx-size 8192
+    gaia init
     ```
+
+    Installs Lemonade Server and pulls the model. `gaia daemon` starts and supervises it — you don't launch it yourself.
   </Step>
 </Steps>
 
@@ -356,9 +357,9 @@ The MCP server exposes the following GAIA agents as tools:
     **Symptoms**: Queries time out or fail
 
     **Solutions**:
-    - Start the Lemonade server: `lemonade-server serve`
+    - Check the daemon that supervises the model server: `gaia daemon status`. If none is running, `gaia daemon start`
+    - If the daemon is up but the model server isn't, read `gaia daemon logs --lines 100`
     - Check `LEMONADE_BASE_URL` is correct (default `http://localhost:13305/api/v1`)
-    - Verify models are loaded
   </Accordion>
 
   <Accordion title="Server Won't Start">

--- a/docs/integrations/vscode.mdx
+++ b/docs/integrations/vscode.mdx
@@ -46,11 +46,12 @@ The GAIA VSCode extension integrates GAIA agents as selectable language models i
     Install GAIA with API support. See [API Server Prerequisites](/reference/api#prerequisites)
   </Step>
 
-  <Step title="Start Lemonade Server">
-    Ensure the LLM backend is running with extended context:
+  <Step title="Install the LLM backend">
     ```bash
-    lemonade-server serve --ctx-size 32768
+    gaia init
     ```
+
+    Installs Lemonade Server and pulls the model. `gaia daemon` starts and supervises it, and sizes the context window from your machine's device profile.
   </Step>
 
   <Step title="Install Node.js v20.19.x">
@@ -101,23 +102,12 @@ The GAIA VSCode extension integrates GAIA agents as selectable language models i
 ### Getting Started
 
 <Warning>
-GAIA Code requires **three services** running simultaneously:
-1. Lemonade Server (LLM backend on port 13305)
-2. GAIA API Server (REST API on port 8080)
-3. VSCode Extension (installed in VSCode)
+GAIA Code needs two things you start yourself — the GAIA API Server (REST API on port 8080) and the VSCode extension. The LLM backend on port 13305 is supervised by `gaia daemon`, so it isn't your job to launch.
 </Warning>
 
 Follow these steps in order:
 
 <Steps>
-  <Step title="Start Lemonade Server (LLM Backend)">
-    ```bash
-    lemonade-server serve --ctx-size 32768
-    ```
-
-    <Info>Keep this terminal running and open a new terminal for the next step</Info>
-  </Step>
-
   <Step title="Start the GAIA API Server">
     ```bash
     gaia api start
@@ -236,7 +226,7 @@ VSCode language model provider.
 
     **Solutions**:
     - The picker should list `gaia`. If it is empty, check that the `gaia-agent-gaia` package is installed — the server logs the import error it hit
-    - Ensure Lemonade Server is running: `lemonade-server serve --ctx-size 32768`
+    - Check the model server is up: `gaia daemon status`. If no daemon is running, `gaia daemon start`
     - The API server needs to be running before selecting models
     - Check the GAIA output channel for error messages (View > Output > GAIA)
     - Try restarting VSCode
@@ -269,8 +259,8 @@ VSCode can also integrate with GAIA through the Model Context Protocol (MCP) ser
     Install GAIA
   </Step>
 
-  <Step title="Start Lemonade Server">
-    Running with appropriate context size
+  <Step title="Install the LLM backend">
+    Run `gaia init` once — `gaia daemon` starts and supervises the model server from then on
   </Step>
 
   <Step title="Start GAIA MCP Server">
@@ -281,12 +271,6 @@ VSCode can also integrate with GAIA through the Model Context Protocol (MCP) ser
 ### Getting Started
 
 <Steps>
-  <Step title="Start Lemonade Server">
-    ```bash
-    lemonade-server serve --ctx-size 32768
-    ```
-  </Step>
-
   <Step title="Start the GAIA MCP Server">
     ```bash
     gaia mcp start
@@ -416,16 +400,14 @@ src/vscode/gaia/
 ### Testing the Extension
 
 <Steps>
-  <Step title="Start Backend Services">
-    Before testing, ensure the GAIA backend is running:
+  <Step title="Start the API Server">
+    Before testing, start the GAIA API server:
 
     ```bash
-    # Terminal 1: Start Lemonade Server
-    lemonade-server serve --ctx-size 32768
-
-    # Terminal 2: Start GAIA API Server
     gaia api start
     ```
+
+    The model server behind it is supervised by `gaia daemon` — check it with `gaia daemon status` if requests fail.
   </Step>
 
   <Step title="Launch Extension Development Host">

--- a/docs/plans/docker-containers.mdx
+++ b/docs/plans/docker-containers.mdx
@@ -357,13 +357,14 @@ All images require `LEMONADE_BASE_URL` to connect to a Lemonade Server.
 
 ### Server setup:
 
-```bash
-# Install Lemonade Server
-pip install lemonade-server
+Install Lemonade with `gaia init`, then start it bound to an interface the
+containers can reach rather than loopback. How the server is launched differs
+per platform, so follow the [Lemonade Server
+docs](https://www.lemonade-server.ai) for yours.
 
-# Start server
-lemonade-server serve --host 0.0.0.0
-```
+`gaia daemon start` is not a substitute here: the daemon only ever starts a
+loopback server, and refuses a non-loopback `LEMONADE_BASE_URL` rather than
+silently starting something the containers can't use.
 
 ### Container configuration:
 

--- a/docs/plans/tui-user-journey.md
+++ b/docs/plans/tui-user-journey.md
@@ -314,7 +314,7 @@ Blocked — the first failure is focused and carries its own fix key:
   > [!]   Local AI               not running
           GAIA needs a local model server. It runs on your machine;
           no email text ever leaves it.
-          f  start it for me            c  copy `lemonade-server serve`
+          f  start it for me            c  copy the start command
 
     [  ]  AI model               —  (checked after the server is up)
     [  ]  Mailbox                —
@@ -906,7 +906,7 @@ lives in one Go function used by preflight, chat, and the activity screen alike.
 
 | Failure | What the user sees | Key |
 |---|---|---|
-| Lemonade down | `Local AI isn't running. GAIA needs it to read your mail — it runs on this machine.` | `f` start it · `c` copy `lemonade-server serve` |
+| Lemonade down | `Local AI isn't running. GAIA needs it to read your mail — it runs on this machine.` | `f` start it · `c` copy the start command (resolved per machine, never hardcoded) |
 | Lemonade too old | `Local AI is version 10.0.1; Email needs 10.2.0 or newer.` | `f` upgrade · `c` copy `gaia init` |
 | Model missing | `The AI model isn't downloaded yet (about 4 GB, reused by every agent).` | `f` download here · `c` copy `gaia init` |
 | Model list unreadable | `Local AI answered but its model list couldn't be read. It may still be starting.` | `r` re-check · `d` details |

--- a/docs/playbooks/chat-agent/part-1-getting-started.mdx
+++ b/docs/playbooks/chat-agent/part-1-getting-started.mdx
@@ -126,14 +126,13 @@ Get a working agent running to understand the basic flow.
     </Tabs>
   </Step>
 
-  <Step title="Start Lemonade Server">
+  <Step title="Install the model backend">
     ```bash
-    # Start local LLM server with AMD NPU/iGPU acceleration
-    lemonade-server serve
+    gaia init
     ```
 
     <Info>
-    Lemonade Server provides AMD-optimized inference for AI PCs with Ryzen AI. Models run on your NPU or iGPU for fast, private processing.
+    This installs Lemonade Server and pulls the model. You never start it yourself — `gaia daemon` resolves, starts and supervises it when an agent needs inference. Models run on your NPU or iGPU for fast, private processing.
     </Info>
   </Step>
 

--- a/docs/playbooks/hardware-advisor/index.mdx
+++ b/docs/playbooks/hardware-advisor/index.mdx
@@ -122,14 +122,13 @@ Get a working agent running to understand the basic flow.
     </Tabs>
   </Step>
 
-  <Step title="Start Lemonade Server">
+  <Step title="Install the model backend">
     ```bash
-    # Start local LLM server with AMD NPU/iGPU acceleration
-    lemonade-server serve
+    gaia init
     ```
 
     <Info>
-    Lemonade Server provides AMD-optimized inference for AI PCs with Ryzen AI. It also exposes system info and model catalog APIs that this agent uses.
+    This installs Lemonade Server and pulls the model; `gaia daemon` starts and supervises the server for you. Beyond inference, Lemonade exposes the system info and model catalog APIs this agent queries.
     </Info>
   </Step>
 

--- a/docs/playbooks/index.mdx
+++ b/docs/playbooks/index.mdx
@@ -156,15 +156,14 @@ All playbooks assume you have:
   </Tab>
 
   <Tab title="Lemonade Server">
-    Lemonade Server is installed automatically with GAIA:
+    Install the model backend once:
 
     ```bash
-    # Start with NPU/iGPU acceleration
-    lemonade-server serve
+    gaia init
     ```
 
     <Tip>
-    Lemonade Server provides AMD-optimized inference for AI PCs, utilizing NPU and iGPU acceleration. GAIA will auto-start it if not running.
+    Lemonade Server provides AMD-optimized inference for AI PCs, utilizing NPU and iGPU acceleration. You never launch it yourself — `gaia daemon` resolves, starts and supervises it whenever an agent needs inference.
     </Tip>
   </Tab>
 

--- a/docs/reference/api.mdx
+++ b/docs/reference/api.mdx
@@ -25,13 +25,10 @@ The server exposes one model, `gaia` — the flagship agent. Capability that use
 </Note>
 
 <Steps>
-  <Step title="Start Lemonade Server">
-    ```bash
-    lemonade-server serve --ctx-size 32768
-    ```
-  </Step>
-
   <Step title="Start GAIA API Server">
+    This brings up Lemonade Server through the daemon, at the context size your
+    device profile pins — nothing to start beforehand.
+
     ```bash
     gaia api start
     ```
@@ -79,10 +76,11 @@ The server exposes one model, `gaia` — the flagship agent. Capability that use
   </Card>
 
   <Card title="Lemonade Server" icon="server">
-    Must be running with sufficient context:
+    Must be installed — the API server starts it through the daemon and sizes
+    the context from your device profile:
 
     ```bash
-    lemonade-server serve --ctx-size 32768
+    gaia init
     ```
   </Card>
 </CardGroup>
@@ -334,12 +332,12 @@ Register additional agents in `AGENT_MODELS` ([`src/gaia/api/agent_registry.py`]
   <Accordion title="Agent Errors" icon="triangle-exclamation">
     **Check Lemonade is running:**
     ```bash
-    curl http://localhost:13305/health
+    gaia daemon status
     ```
 
-    **Verify context size:**
+    **Start it if it isn't:**
     ```bash
-    lemonade-server serve --ctx-size 32768
+    gaia daemon start
     ```
 
     **Enable debug mode:**
@@ -354,7 +352,7 @@ Register additional agents in `AGENT_MODELS` ([`src/gaia/api/agent_registry.py`]
 | Issue | Solution |
 |-------|----------|
 | "Model not found" | Confirm the model id is registered in `AGENT_MODELS` — `GET /v1/models` lists what's actually available |
-| "Agent processing failed" | Ensure Lemonade is running with `--ctx-size 32768` |
+| "Agent processing failed" | Check the model server with `gaia daemon status`; start it with `gaia daemon start` |
 | "Port already in use" | Stop existing server or use `--port` flag |
 | Streaming not working | Ensure `"stream": true` in request |
 
@@ -371,14 +369,9 @@ Register additional agents in `AGENT_MODELS` ([`src/gaia/api/agent_registry.py`]
 **Quick Setup:**
 
 <Steps>
-  <Step title="Start Servers">
-    Start Lemonade server with extended context:
-
-    ```bash
-    lemonade-server serve --ctx-size 32768
-    ```
-
-    Start GAIA API server:
+  <Step title="Start the API Server">
+    It brings up Lemonade Server through the daemon, so this is the only
+    command you need:
 
     ```bash
     gaia api start

--- a/docs/reference/cli.mdx
+++ b/docs/reference/cli.mdx
@@ -27,28 +27,21 @@ GAIA provides a comprehensive command-line interface (CLI) for interacting with 
   <Tab title="Windows">
     1. Follow the [Quickstart](/quickstart) to install GAIA
     2. Open PowerShell and run `gaia` to launch the Agent UI, or `gaia --cli` for terminal chat
-    3. GAIA automatically starts Lemonade Server when needed, or start manually:
 
-    ```bash
-    lemonade-server serve
-    ```
+    GAIA starts Lemonade Server when it needs it, so there is nothing to launch first.
   </Tab>
 
   <Tab title="Linux">
     1. Install from source: Follow [Linux Installation](/quickstart)
-    2. Install Lemonade Server from [lemonade-server.ai](https://www.lemonade-server.ai)
-    3. Start the server:
-
-    ```bash
-    lemonade-server serve
-    ```
-
-    4. Verify installation:
+    2. Install Lemonade Server with `gaia init`, or from [lemonade-server.ai](https://www.lemonade-server.ai)
+    3. Verify installation:
 
     ```bash
     gaia -v
     gaia llm "Hello, world!"
     ```
+
+    `gaia llm` starts Lemonade Server through the daemon on first use.
   </Tab>
 </Tabs>
 
@@ -1038,17 +1031,13 @@ gaia telegram stop
 
 ### Quick Start
 
-1. Start Lemonade with extended context:
-```bash
-lemonade-server serve --ctx-size 32768
-```
-
-2. Start GAIA API server:
+1. Start GAIA API server — it brings up Lemonade through the daemon, at the
+   context size your device profile pins:
 ```bash
 gaia api start
 ```
 
-3. Test the server:
+2. Test the server:
 ```bash
 curl http://localhost:8080/health
 ```
@@ -2809,7 +2798,7 @@ $ gaia tui run email --query "triage my inbox"   # with the model server down
 ❌ Email is not ready — Local AI: not running at http://localhost:8000/api/v1
    GAIA needs a local model server. It runs on your machine; no message text ever leaves it.
 …
-        run: lemonade-server serve
+        run: <the start command resolved for this machine>
 $ echo $?   # 1, after about a second
 ```
 
@@ -3120,11 +3109,16 @@ All commands support these global options:
 
 <AccordionGroup>
   <Accordion title="Connection Errors" icon="link-slash">
-    If you get connection errors, ensure Lemonade server is running:
+    Connection errors mean the model server isn't up. The daemon owns it, so
+    check there first, then start it:
 
     ```bash
-    lemonade-server serve
+    gaia daemon status
+    gaia daemon start
     ```
+
+    If it still won't come up, `gaia daemon logs --lines 100` has the reason —
+    most often that Lemonade isn't installed, which `gaia init` fixes.
   </Accordion>
 
   <Accordion title="Model Issues" icon="circle-exclamation">

--- a/docs/reference/dev.mdx
+++ b/docs/reference/dev.mdx
@@ -227,7 +227,7 @@ gaia chat
 ```
 </CodeGroup>
 
-> **Note:** GAIA automatically starts Lemonade Server when needed. For manual start: `lemonade-server serve`
+> **Note:** GAIA starts Lemonade Server when needed — `gaia daemon` supervises it, so there is nothing to launch first. To bring it up ahead of time, or to check on it, use `gaia daemon start` and `gaia daemon status`.
 
 ### Running Electron Applications
 

--- a/docs/reference/eval.mdx
+++ b/docs/reference/eval.mdx
@@ -114,11 +114,8 @@ Set up Claude API for synthetic data generation:
 export ANTHROPIC_API_KEY=your_key_here
 ```
 
-Optional: Start Lemonade for local LLM processing if not running:
-
-```bash
-lemonade-server serve
-```
+Lemonade handles the local LLM processing. You don't need to start it — GAIA
+does that when a run needs it. If it isn't installed yet, run `gaia init`.
 
 **Additional Requirements:**
 - **Node.js (with npm)**: Required for the interactive visualizer (`gaia visualize` command)
@@ -172,7 +169,7 @@ gaia visualize
 
 **Prerequisites:**
 - Claude API key: `export ANTHROPIC_API_KEY=your_key_here`
-- Lemonade server running: `lemonade-server serve`
+- Lemonade installed and its model pulled: `gaia init` (GAIA starts the server itself)
 - Node.js installed for visualizer
 
 This creates one synthetic meeting transcript, generates evaluation standards, tests it with multiple models, scores the results, and launches an interactive comparison interface. The default configuration uses **individual prompts** for maximum reliability and accuracy.
@@ -1339,10 +1336,10 @@ Check if server is running:
 curl http://localhost:13305/api/v1/health
 ```
 
-Start server if needed:
+Start it if needed — the daemon owns the server, so ask it:
 
 ```bash
-lemonade-server serve
+gaia daemon start
 ```
 
 **File Path Issues:**

--- a/docs/reference/troubleshooting.mdx
+++ b/docs/reference/troubleshooting.mdx
@@ -157,17 +157,29 @@ icon: "bug"
   </Accordion>
 
   <Accordion title="LLM not responding" icon="robot">
-    Check if Lemonade Server is running:
+    You shouldn't have to start the model server yourself — `gaia daemon`
+    resolves, starts and supervises it, and every front-end asks the daemon
+    instead of making you launch anything. So the question is why that didn't
+    happen.
+
+    Start with the daemon, which reports the model server it supervises:
     ```bash
-    curl http://localhost:13305/api/v1/models
+    gaia daemon status
     ```
 
-    If not running, start it via the Lemonade tray icon (Windows) or:
+    If no daemon is running, start it:
     ```bash
-    lemonade-server serve
+    gaia daemon start
     ```
 
-    If Lemonade is not installed, run:
+    If the daemon is up but the model server isn't, the start attempt failed
+    and the reason is in the daemon log:
+    ```bash
+    gaia daemon logs --lines 100
+    ```
+
+    The usual cause is that Lemonade isn't installed at all. `gaia init`
+    installs the server and pulls the model:
     ```bash
     gaia init
     ```
@@ -214,9 +226,10 @@ icon: "bug"
        ```bash
        gaia chat --max-chunks 2 --index your_document.pdf
        ```
-    3. Restart Lemonade cleanly:
+    3. Restart the model server cleanly. This stops it and its child
+       processes; the daemon starts a fresh one on the next request:
        ```bash
-       gaia kill --lemonade && lemonade-server serve
+       gaia kill --lemonade
        ```
     4. Close other GPU/NPU-heavy apps competing for the device (image
        generators, other LLM servers, GPU benchmarks).
@@ -260,10 +273,15 @@ icon: "bug"
   </Accordion>
 
   <Accordion title="Agent processing failed" icon="triangle-exclamation">
-    Ensure Lemonade is running with sufficient context size:
+    Confirm the model server is up — the daemon starts it and reports it here:
     ```bash
-    lemonade-server serve --ctx-size 32768
+    gaia daemon status
     ```
+
+    You don't need to set a context size. GAIA pins the context window to your
+    machine's device profile and starts the server with it, so a mismatch means
+    the profile is wrong rather than the flag is missing. Check it with
+    `gaia config get default_device`.
   </Accordion>
 
   <Accordion title="Port already in use" icon="ban">

--- a/docs/sdk/index.mdx
+++ b/docs/sdk/index.mdx
@@ -87,11 +87,7 @@ uv pip install amd-gaia
 
 **Prerequisites:**
 - Python 3.10 or higher
-- Lemonade Server running (for local LLM inference)
-  ```bash
-  # Start Lemonade Server
-  lemonade-server serve
-  ```
+- Lemonade Server installed, for local LLM inference. Run `gaia init` once; `gaia daemon` starts and supervises the server from then on.
 
 **Why uv?**
 - ⚡ 10-100x faster than pip

--- a/docs/sdk/performance-analysis-plotter.mdx
+++ b/docs/sdk/performance-analysis-plotter.mdx
@@ -28,12 +28,13 @@ gaia perf-vis <log_file> [<log_file> ...]
 
 ## Collecting llama.cpp Logs
 
-The script expects llama.cpp server logs. With [Lemonade](https://lemonade-server.ai/), you can capture telemetry like this:
+The script expects llama.cpp server logs. `gaia daemon` supervises the [Lemonade](https://lemonade-server.ai/) server and captures its output to `~/.gaia/logs/lemonade.log`, so run your workload and point the plotter at that file:
 
 ```bash
-lemonade-server serve --ctx-size 32768 2>&1 | tee agent.log
-gaia perf-vis agent.log
+gaia perf-vis ~/.gaia/logs/lemonade.log
 ```
+
+The supervisor appends to that file across restarts, so copy it aside after a run you want to keep for comparison.
 
 ---
 

--- a/docs/sdk/troubleshooting.mdx
+++ b/docs/sdk/troubleshooting.mdx
@@ -52,14 +52,15 @@ def my_tool():
 
 ### Issue: LLM not responding
 
-```bash
-# Check Lemonade server is running
-curl http://localhost:13305/api/v1/models
-# Should return available models
+The daemon supervises the model server, so start there:
 
-# Or start it
-lemonade-server serve
+```bash
+gaia daemon status          # reports the model server it supervises
+gaia daemon start           # if no daemon is running
+gaia daemon logs --lines 100  # daemon up but no model server? the reason is here
 ```
+
+The usual cause is that Lemonade was never installed — `gaia init` installs the server and pulls the model.
 
 ---
 

--- a/docs/spec/agent-hub-restructure.mdx
+++ b/docs/spec/agent-hub-restructure.mdx
@@ -214,7 +214,7 @@ rather than hanging or half-succeeding:
 
 ```
 ✗ The local Lemonade Server is not reachable at http://127.0.0.1:9099/api/v1.
-✗ Start it with `lemonade-server serve` (or run `gaia init`), then POST to this path again.
+✗ Start it with `gaia daemon start` (or run `gaia init` if it isn't installed), then POST to this path again.
 ✗ My Agent can't install the backend itself — that's a host prerequisite.
 ```
 

--- a/hub/agents/email/npm/README.md
+++ b/hub/agents/email/npm/README.md
@@ -42,8 +42,8 @@ a cloud service, and that's enforced when the agent starts up.
 
 A local AI model has to be running before triage or drafting works:
 
-1. Install and start it with **`gaia init`** (downloads the default model) and
-   **`lemonade-server serve`**.
+1. Install it with **`gaia init`** (downloads the default model). GAIA starts
+   the model server itself — **`gaia daemon start`** is enough.
 2. On a fresh machine the agent still starts, but triage won't return results
    until that local model is up. Call `client.init()` to check readiness.
 

--- a/hub/agents/email/npm/SCORECARD.md
+++ b/hub/agents/email/npm/SCORECARD.md
@@ -235,10 +235,11 @@ matter alone — no eval-harness access needed.
 Run the following commands from the repository root:
 
 ```sh
-# Prerequisites: install the eval extras and start a Lemonade Server
-# with the model on AMD Ryzen AI hardware (Strix Halo recommended).
+# Prerequisites: the eval extras, and the model on AMD Ryzen AI
+# hardware (Strix Halo recommended). GAIA's daemon starts and
+# supervises the model server itself.
 uv pip install -e ".[dev,eval,api]"
-lemonade-server serve   # in a separate shell; must stay running
+gaia daemon start       # starts and supervises the model server
 
 # Step 0: build the corpus from the committed seed. The mbox +
 # ground_truth are GENERATED artifacts (gitignored), so a fresh

--- a/hub/agents/email/npm/SKILL.md
+++ b/hub/agents/email/npm/SKILL.md
@@ -405,7 +405,8 @@ back to production by using `startSidecar` (frozen binary) instead of
 The sidecar runs the LLM via **Lemonade Server**, which this package does **not**
 install. Before `triage`/`draft`/`send` succeed, the host must have:
 
-1. A running Lemonade Server (`lemonade-server serve`).
+1. A running Lemonade Server. GAIA's daemon starts and supervises one, so
+   `gaia daemon start` is normally all that is needed.
 2. The model pulled (`gaia init` installs Lemonade and downloads the default model).
 
 Until then the binary boots, but the first `triage` returns **HTTP 502**.

--- a/hub/agents/email/npm/test/client.test.ts
+++ b/hub/agents/email/npm/test/client.test.ts
@@ -235,7 +235,7 @@ describe("EmailClient", () => {
         compatible: null,
       },
       model: { id: "Gemma-4-E4B-it-GGUF", present: false, loadable: null },
-      hint: "Lemonade Server not reachable — run `lemonade-server serve`.",
+      hint: "Lemonade Server not reachable — run `gaia daemon start`.",
     };
     const fetchImpl = vi.fn(async () =>
       jsonResponse(notReady, 503),
@@ -244,7 +244,7 @@ describe("EmailClient", () => {
     const r = await client.init();
     expect(r.ready).toBe(false);
     expect(r.lemonade.reachable).toBe(false);
-    expect(r.hint).toMatch(/lemonade-server serve/);
+    expect(r.hint).toMatch(/gaia daemon start/);
   });
 
   it("init() still throws HttpError on a non-503 failure", async () => {

--- a/hub/agents/email/python/CHANGELOG.md
+++ b/hub/agents/email/python/CHANGELOG.md
@@ -148,6 +148,15 @@ contract version is tracked separately as
   actionable not-connected error for `microsoft_work` instead of being
   served from `microsoft`. Bare `microsoft`/`outlook`/`outlook.com`/
   `hotmail`/`live` are unaffected.
+- **"Start Lemonade yourself" is gone from every message this agent emits.**
+  GAIA's daemon now starts and supervises the local model server, so a user who
+  reaches the agent before the backend is up is pointed at the background
+  service — not handed `lemonade-server serve`, a command Lemonade removed in
+  10.7 that fails with "command not found" on every modern install. The manual
+  fallback is resolved against the machine it will be typed into rather than
+  hardcoded. Affects `/v1/email/init`, `/v1/email/query`, the playground's
+  diagnostics, `README.md`, `SKILL.md`, and `SCORECARD.md`.
+
 - **Agent Skills ship disabled for this agent, pending eval evidence (#2695
   follow-up).** The `skill_sets:` and `default_skill_set: personal` blocks in
   `gaia-agent.yaml` are commented out, so `parse_manifest(...).skill_sets` is

--- a/hub/agents/email/python/gaia_agent_email/api_routes.py
+++ b/hub/agents/email/python/gaia_agent_email/api_routes.py
@@ -124,6 +124,7 @@ from gaia_agent_email.version import AGENT_VERSION, API_VERSION
 from pydantic import BaseModel, ConfigDict, Field
 from starlette.concurrency import iterate_in_threadpool
 
+from gaia.agents.base.readiness import start_advice
 from gaia.connectors.api import connected_mailbox_providers
 from gaia.connectors.errors import (
     AuthRequiredError,
@@ -645,8 +646,7 @@ class EmailTriageService:
         except requests.exceptions.RequestException as exc:
             raise LLMTriageError(
                 f"Local Lemonade Server is not reachable at {probe_base} "
-                f"({type(exc).__name__}: {exc}). Start it with "
-                "`lemonade-server serve` (or run `gaia init`), then retry."
+                f"({type(exc).__name__}: {exc}). {start_advice()}"
             ) from exc
 
     def _assert_model_present(self, base_url: Optional[str]) -> None:
@@ -3009,8 +3009,8 @@ def _compute_init_status(base_url: Optional[str] = None) -> InitResponse:
             lemonade=lemonade,
             model=InitModelStatus(id=model_id, present=False, loadable=None),
             hint=(
-                f"Local Lemonade Server is not reachable at {probe_base} — start "
-                "it with `lemonade-server serve` (or run `gaia init`), then retry."
+                f"Local Lemonade Server is not reachable at {probe_base}. "
+                f"{start_advice()}"
             ),
         )
 
@@ -3195,10 +3195,7 @@ async def email_provision() -> StreamingResponse:
         # Fail loudly BEFORE streaming so the status code is a truthful 503.
         def _unreachable() -> Iterator[str]:
             yield f"✗ Local Lemonade Server is not reachable at {probe_base}.\n"
-            yield (
-                "✗ Start it with `lemonade-server serve` (or run `gaia init`), "
-                "then POST /v1/email/init again.\n"
-            )
+            yield f"✗ {start_advice()} Then POST /v1/email/init again.\n"
             yield (
                 "✗ The sidecar can't install Lemonade itself — that's a host "
                 "prerequisite.\n"

--- a/hub/agents/email/python/gaia_agent_email/playground_html.py
+++ b/hub/agents/email/python/gaia_agent_email/playground_html.py
@@ -304,8 +304,8 @@ _HTML = r"""<!doctype html>
 
       <div class="note" style="margin:16px 0 6px">Or run the steps yourself:</div>
       <div class="fix"><code class="cmd" id="c-npm">npm i @amd-gaia/agent-email</code><button class="copy" data-copy="c-npm">copy</button></div>
-      <div class="fix" style="margin-top:9px"><code class="cmd" id="c-lemon">lemonade-server serve</code><button class="copy" data-copy="c-lemon">copy</button>
-        <span class="muted">start the local LLM</span></div>
+      <div class="fix" style="margin-top:9px"><code class="cmd" id="c-lemon">gaia daemon start</code><button class="copy" data-copy="c-lemon">copy</button>
+        <span class="muted">starts and supervises the local LLM</span></div>
       <div class="fix" style="margin-top:9px"><code class="cmd" id="c-init">gaia init --profile email</code><button class="copy" data-copy="c-init">copy</button>
         <span class="muted">install Lemonade + download &amp; test the email model</span></div>
       <div class="note">Docs: <a href="https://amd-gaia.ai/docs/guides/email" target="_blank" rel="noopener">amd-gaia.ai/docs/guides/email</a></div>
@@ -358,11 +358,11 @@ async function postJSON(path, body){
 function diagnose(e){
   const b = String(e && (e.body || e.message) || "").toLowerCase();
   if(b.includes("not reachable") || b.includes("refused") || b.includes("connection"))
-    return { cause:"Lemonade not found / not running", cmd:"lemonade-server serve", hint:"start the local LLM (install via gaia init)" };
+    return { cause:"Lemonade not found / not running", cmd:"gaia daemon start", hint:"GAIA starts the local LLM (install it with gaia init)" };
   if(b.includes("model") || b.includes("not found") || b.includes("404") || b.includes("load") || b.includes("download"))
     return { cause:"Model not downloaded / unavailable", cmd:"gaia init", hint:"download + test the model" };
   if((e && e.status === 0) || b.includes("timed out") || b.includes("timeout"))
-    return { cause:"Lemonade not responding (timed out)", cmd:"lemonade-server serve", hint:"is it running on the expected port?" };
+    return { cause:"Lemonade not responding (timed out)", cmd:"gaia kill", hint:"clears a wedged server; GAIA restarts it on the next query" };
   return { cause:"LLM triage failed", cmd:"", hint:(e && (e.body || e.message)) || "unknown error" };
 }
 function probePayload(){

--- a/hub/agents/email/python/gaia_agent_email/query_routes.py
+++ b/hub/agents/email/python/gaia_agent_email/query_routes.py
@@ -72,6 +72,7 @@ from fastapi import APIRouter, HTTPException
 from fastapi.responses import StreamingResponse
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 
+from gaia.agents.base.readiness import start_advice
 from gaia.logger import get_logger
 
 logger = get_logger(__name__)
@@ -436,8 +437,8 @@ def _terminal_error_detail(exc: BaseException) -> str:
     raw = str(exc) or type(exc).__name__
     return (
         f"Local Lemonade Server is not reachable at {target}. The email agent "
-        "runs local inference, so it needs Lemonade Server running. Start it "
-        "with `lemonade-server serve` (or run `gaia init`), then retry. "
+        "runs local inference, so it needs Lemonade Server running. "
+        f"{start_advice()} "
         f"Docs: {_LEMONADE_DOCS_URL}"
         f"\n\nTechnical details: {raw}"
     )

--- a/hub/agents/email/python/packaging/gen_scorecard.py
+++ b/hub/agents/email/python/packaging/gen_scorecard.py
@@ -395,10 +395,11 @@ def _build_reproduction_command(model, ground_truth_rel: str, limit=None) -> str
     """
     limit_flag = f" \\\n    --limit {limit}" if limit is not None else ""
     return (
-        "# Prerequisites: install the eval extras and start a Lemonade Server\n"
-        "# with the model on AMD Ryzen AI hardware (Strix Halo recommended).\n"
+        "# Prerequisites: the eval extras, and the model on AMD Ryzen AI\n"
+        "# hardware (Strix Halo recommended). GAIA's daemon starts and\n"
+        "# supervises the model server itself.\n"
         'uv pip install -e ".[dev,eval,api]"\n'
-        "lemonade-server serve   # in a separate shell; must stay running\n\n"
+        "gaia daemon start       # starts and supervises the model server\n\n"
         "# Step 0: build the corpus from the committed seed. The mbox +\n"
         "# ground_truth are GENERATED artifacts (gitignored), so a fresh\n"
         "# checkout must materialise them before the benchmark can read them.\n"

--- a/hub/agents/email/python/tests/test_query_route.py
+++ b/hub/agents/email/python/tests/test_query_route.py
@@ -239,8 +239,9 @@ class _InternalErrorFakeAgent:
     """
 
     ANSWER = (
-        "Local Lemonade Server is not reachable at http://localhost:13305 — "
-        "start it with `lemonade-server serve` (or run `gaia init`), then retry."
+        "Local Lemonade Server is not reachable at http://localhost:13305. "
+        "GAIA starts it automatically — run `gaia daemon start` if the "
+        "background service is not running."
     )
 
     def __init__(self):
@@ -470,8 +471,11 @@ def _assert_actionable_lemonade_detail(detail: str) -> None:
     where to look."""
     lower = detail.lower()
     assert "lemonade server is not reachable" in lower  # what failed
-    # what to do — start it (either remediation is acceptable copy).
-    assert "lemonade-server serve" in lower or "gaia init" in lower
+    # What to do. Asserted as "names SOME real remedy" rather than one exact
+    # command: the manual fallback is resolved per machine (CLAUDE.md — never
+    # hardcode how Lemonade is started), so pinning a literal here is how a
+    # command that exists on no modern install stayed asserted-as-real.
+    assert any(c in lower for c in ("gaia daemon start", "gaia init", "lemonade"))
     assert "amd-gaia.ai/docs/guides/email" in lower  # where to look
 
 
@@ -770,9 +774,7 @@ def test_thread_start_failure_releases_the_lock_and_deregisters_the_run(
             super().start()
 
     monkeypatch.setattr(query_routes.threading, "Thread", _FailingThread)
-    resp = app_client.post(
-        "/v1/email/query", json=_req(session_id="s1", run_id=run_id)
-    )
+    resp = app_client.post("/v1/email/query", json=_req(session_id="s1", run_id=run_id))
     assert resp.status_code == 500
 
     registry, _built = session_registry
@@ -852,9 +854,7 @@ def test_brand_new_session_with_empty_context_gets_no_notice(
 ):
     """First turn of a genuinely new conversation is NOT a continuity loss --
     no session was ever expected to exist yet."""
-    resp = app_client.post(
-        "/v1/email/query", json=_req(session_id="s-new", context=[])
-    )
+    resp = app_client.post("/v1/email/query", json=_req(session_id="s-new", context=[]))
     assert resp.status_code == 200
     events = _parse_sse(resp.text)
     statuses = [e.get("message", "") for e in events if e["type"] == "status"]

--- a/hub/agents/gaia/npm/SKILL.md
+++ b/hub/agents/gaia/npm/SKILL.md
@@ -127,7 +127,8 @@ for the version you have.
 The agent thinks with a model hosted by **Lemonade Server**, which this package
 does not install. Required before any query succeeds:
 
-1. Lemonade **10.2.0 or newer**, running (`lemonade-server serve`).
+1. Lemonade **10.2.0 or newer**, running. GAIA's daemon starts and supervises
+   one, so `gaia daemon start` is normally all that is needed.
 2. The default model downloaded (`gaia download Gemma-4-E4B-it-GGUF`, or
    `gaia init`).
 
@@ -150,7 +151,7 @@ alone:
                 "min_version": "10.2.0", "compatible": null },
   "model":    { "id": "Gemma-4-E4B-it-GGUF", "present": false,
                 "loadable": null, "ctx_size": null },
-  "hint": "Local Lemonade Server is not reachable at … — start it with `lemonade-server serve`, or set LEMONADE_BASE_URL to a running server."
+  "hint": "Local Lemonade Server is not reachable at …. GAIA starts it automatically — run `gaia daemon start` if the background service is not running. Or set LEMONADE_BASE_URL to a running server."
 }
 ```
 

--- a/hub/agents/gaia/python/gaia_agent/server.py
+++ b/hub/agents/gaia/python/gaia_agent/server.py
@@ -39,6 +39,7 @@ from gaia_agent.session_registry import registry as session_registry
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 from starlette.responses import StreamingResponse
 
+from gaia.agents.base.readiness import start_advice
 from gaia.logger import get_logger
 from gaia.ui.sse_translation import TERMINAL_TYPES, CanonicalTranslator
 
@@ -279,9 +280,8 @@ def _terminal_error_detail(exc: BaseException) -> str:
         )
     ):
         return (
-            "Local Lemonade Server is not reachable. Start it, then retry — "
-            f"run `lemonade-server serve`, or see {_DOCS_URL}. "
-            f"(underlying error: {text})"
+            f"Local Lemonade Server is not reachable. {start_advice()} "
+            f"See {_DOCS_URL}. (underlying error: {text})"
         )
     return text
 
@@ -457,8 +457,8 @@ async def init() -> Dict[str, Any]:
     hint: Optional[str] = None
     if not probe["reachable"]:
         hint = (
-            f"Local Lemonade Server is not reachable at {probe['base_url']} — start it "
-            f"with `lemonade-server serve`, or set LEMONADE_BASE_URL to a running server."
+            f"Local Lemonade Server is not reachable at {probe['base_url']}. "
+            f"{start_advice()} Or set LEMONADE_BASE_URL to a running server."
         )
     elif compatible is False:
         hint = (

--- a/hub/agents/gaia/python/gaia_agent/stdio.py
+++ b/hub/agents/gaia/python/gaia_agent/stdio.py
@@ -72,6 +72,7 @@ from typing import Any, Dict, List, Optional
 
 from gaia_agent.memory_dump import MEMORY_DUMP_QUERY, build_memory_dump
 
+from gaia.agents.base.readiness import start_advice
 from gaia.llm import create_client
 from gaia.llm.lemonade_client import (
     DEFAULT_LEMONADE_URL,
@@ -400,7 +401,7 @@ def _lemonade_models(base_url: Optional[str]) -> List[str]:
     except LemonadeClientError as exc:
         raise RuntimeError(
             f"Lemonade Server is not reachable at {client.base_url} ({exc}). "
-            "Start it with `lemonade-server serve`, then retry."
+            f"{start_advice()}"
         ) from exc
     return sorted(
         {
@@ -893,8 +894,8 @@ def _terminal_error(exc: BaseException) -> Dict[str, Any]:
         return {
             "type": "error",
             "detail": (
-                "Local Lemonade Server is not reachable. Start it, then retry — "
-                f"run `lemonade-server serve`. (underlying error: {text})"
+                f"Local Lemonade Server is not reachable. {start_advice()} "
+                f"(underlying error: {text})"
             ),
         }
     return {"type": "error", "detail": text}

--- a/hub/agents/gaia/python/tests/test_stdio.py
+++ b/hub/agents/gaia/python/tests/test_stdio.py
@@ -270,7 +270,12 @@ def test_unreachable_lemonade_gets_actionable_copy():
     )["detail"]
 
     assert "Lemonade" in detail
-    assert "lemonade-server serve" in detail
+    # A real next step, not a specific launch command. Pinning a literal here
+    # is how `lemonade-server serve` stayed asserted-as-real for releases after
+    # Lemonade 10.7 removed it (CLAUDE.md, "Never hardcode how Lemonade is
+    # started") — the manual fallback is resolved per machine, so there is no
+    # single launch string to assert.
+    assert "gaia daemon start" in detail
 
 
 def test_an_anthropic_outage_is_not_blamed_on_lemonade():
@@ -280,7 +285,7 @@ def test_an_anthropic_outage_is_not_blamed_on_lemonade():
         ConnectionError("anthropic: Max retries exceeded ... Connection refused")
     )["detail"]
 
-    assert "lemonade-server serve" not in detail
+    assert "gaia daemon start" not in detail
     assert "Max retries exceeded" in detail
 
 
@@ -294,7 +299,7 @@ def test_an_anthropic_sdk_exception_is_recognised_by_its_module():
 
     detail = stdio._terminal_error(APIConnectionError("Connection refused"))["detail"]
 
-    assert "lemonade-server serve" not in detail
+    assert "gaia daemon start" not in detail
 
 
 def test_a_memory_dump_failure_becomes_a_terminal_error(monkeypatch):
@@ -745,7 +750,7 @@ def test_model_switch_lemonade_unreachable_is_actionable_and_leaves_model_runnin
     def _unreachable(base_url):
         raise RuntimeError(
             f"Lemonade Server is not reachable at {base_url} (connection refused). "
-            "Start it with `lemonade-server serve`, then retry."
+            "GAIA starts it automatically — run `gaia daemon start`."
         )
 
     monkeypatch.setattr(stdio_mod, "_lemonade_models", _unreachable)
@@ -757,7 +762,7 @@ def test_model_switch_lemonade_unreachable_is_actionable_and_leaves_model_runnin
     events = _events(out)
     assert len(events) == 1 and events[0]["type"] == "error"
     assert "13305" in events[0]["detail"]
-    assert "lemonade-server serve" in events[0]["detail"]
+    assert "gaia daemon start" in events[0]["detail"]
     assert agent.chat.llm_client is previous_client
     assert agent.rebuild_count == 0
 
@@ -943,7 +948,7 @@ def test_lemonade_models_unreachable_names_url_and_fix(monkeypatch):
         raise AssertionError("expected RuntimeError")
     except RuntimeError as exc:
         assert "13305" in str(exc)
-        assert "lemonade-server serve" in str(exc)
+        assert "gaia daemon start" in str(exc)
     finally:
         fake.error = None
 

--- a/src/gaia/agents/base/readiness.py
+++ b/src/gaia/agents/base/readiness.py
@@ -46,6 +46,29 @@ logger = get_logger(__name__)
 PROBE_CONNECT_TIMEOUT = 2.0
 PROBE_READ_TIMEOUT = 5.0
 
+
+def start_advice() -> str:
+    """How to get the local model server running, for a caller that found it down.
+
+    Never a hardcoded command. ``lemonade-server serve`` was dropped in
+    Lemonade 10.7 and errors on every modern install, and the three surviving
+    launch forms share no argv — so the manual fallback is resolved against
+    THIS machine by ``describe_start_hint`` (see CLAUDE.md, "Never hardcode how
+    Lemonade is started").
+
+    It leads with the automatic path because that is now the normal one: the
+    daemon starts and supervises the server, and a user reading this most
+    likely just needs the daemon running.
+    """
+    from gaia.llm.lemonade_launcher import describe_start_hint
+
+    return (
+        "GAIA starts it automatically — run `gaia daemon start` if the "
+        f"background service is not running. Otherwise: "
+        f"{describe_start_hint().instruction}"
+    )
+
+
 # A model pull is a first-download of multi-GB weights — minutes, not seconds.
 # Generous read ceiling so a slow link does not abort a real download; the
 # connect leg stays short so an unreachable server still fails fast.
@@ -451,10 +474,9 @@ def compute_init_status(
             lemonade=backend,
             model=_model(False),
             hint=(
-                f"The local Lemonade Server is not reachable at {probe_base} — "
-                "start it with `lemonade-server serve` (or run `gaia init`), "
-                f"then retry. {agent_name} cannot install it: that is a host "
-                "prerequisite, not something an agent can bootstrap."
+                f"The local Lemonade Server is not reachable at {probe_base}. "
+                f"{start_advice()} {agent_name} cannot install it: that is a "
+                "host prerequisite, not something an agent can bootstrap."
             ),
         )
 
@@ -611,10 +633,7 @@ def unreachable_progress(
     to learn nothing happened.
     """
     yield f"✗ The local Lemonade Server is not reachable at {probe_base}.\n"
-    yield (
-        "✗ Start it with `lemonade-server serve` (or run `gaia init`), then "
-        "POST to this path again.\n"
-    )
+    yield f"✗ {start_advice()} Then POST to this path again.\n"
     yield (
         f"✗ {agent_name} can't install the backend itself — that's a host "
         "prerequisite.\n"

--- a/src/gaia/apps/webui/README.md
+++ b/src/gaia/apps/webui/README.md
@@ -18,8 +18,9 @@ GAIA Agent UI requires the Python backend running locally:
 # Install the GAIA Python package
 pip install amd-gaia
 
-# Start the LLM backend (AMD Ryzen AI accelerated)
-lemonade-server serve
+# The LLM backend (AMD Ryzen AI accelerated) starts automatically with the
+# GAIA daemon; start it explicitly only if it isn't already running.
+gaia daemon start
 ```
 
 ## Usage

--- a/src/gaia/cli.py
+++ b/src/gaia/cli.py
@@ -180,6 +180,16 @@ def initialize_lemonade_for_agent(
                 _ctx_override,
             )
 
+    # The CLI is a front-end, so it is allowed to bring up the machine's
+    # background service — and it has to, because the daemon is what owns the
+    # model server. ensure_ready deliberately only ATTACHES: a readiness check
+    # that boots a daemon behind the caller's back costs every library and test
+    # caller 30 seconds and a process they did not ask for. One status probe
+    # when a daemon is already running.
+    from gaia.llm.lemonade_service import ensure_daemon_owns_lemonade
+
+    ensure_daemon_owns_lemonade()
+
     # LemonadeManager handles all validation and error printing
     # Pass base_url directly when provided to preserve full URL (https, ngrok, etc.)
     try:

--- a/src/gaia/daemon/app.py
+++ b/src/gaia/daemon/app.py
@@ -84,6 +84,7 @@ def create_app(
     custody_auth=None,
     custody_store=None,
     clock=None,
+    lemonade=None,
 ):
     """Build the FastAPI app bound to this daemon's identity.
 
@@ -107,6 +108,11 @@ def create_app(
     its OWN per-spawn secrets (bound at mint), NOT the client ``token`` — it is a
     separate surface with its own MAJOR (§0.31), so it is not behind
     ``require_token``.
+
+    *lemonade* (a :class:`gaia.llm.lemonade_supervisor.LemonadeSupervisor`) mounts
+    ``/daemon/v1/lemonade/*``, through which a front-end asks the daemon to start
+    the local model server. The daemon owns that process — no front-end spawns
+    one — so this router is the only way in. ``None`` leaves it unmounted.
 
     *clock* (a :class:`gaia.daemon.scheduler.clock.DaemonClock`) additively
     reports its running state, last poll time, and pending/failed job counts
@@ -174,6 +180,14 @@ def create_app(
             )
         server.should_exit = True
         return {"service": SERVICE_ID, "status": "stopping", "pid": pid}
+
+    if lemonade is not None:
+        # The model server's control plane. Mounted whenever a supervisor was
+        # given, which server.run() always does — the ``None`` case exists so a
+        # skeleton/test daemon can run without owning a model server.
+        from gaia.daemon.lemonade_routes import build_lemonade_router
+
+        app.include_router(build_lemonade_router(token, lemonade))
 
     if registry is not None:
         from gaia.daemon.relay import build_relay_router

--- a/src/gaia/daemon/constants.py
+++ b/src/gaia/daemon/constants.py
@@ -20,7 +20,11 @@ SERVICE_ID = "gaia-daemon"
 # API and must restart it rather than silently attach to a stale host. MINOR 1
 # added the /daemon/v1/agents control plane (#2142) — clients that need it
 # floor-check MINOR >= 1 so a pre-#2142 daemon fails loudly instead of 404ing.
-DAEMON_API_VERSION = "1.1"
+# MINOR 2 added POST /daemon/v1/lemonade/start. Clients do NOT floor-check that
+# one — refusing to attach to an otherwise healthy 1.1 daemon over it would be a
+# worse outcome than the thing it fixes. They read its 404 as "this core is too
+# old to start Lemonade for you" and say exactly that.
+DAEMON_API_VERSION = "1.2"
 
 # Client-token auth: header name and scheme.
 AUTH_SCHEME = "Bearer"

--- a/src/gaia/daemon/lemonade_routes.py
+++ b/src/gaia/daemon/lemonade_routes.py
@@ -1,0 +1,124 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""``/daemon/v1/lemonade/*`` — the daemon's model server, on request.
+
+The daemon owns the Lemonade process the way it owns a sidecar agent: it starts
+it, tracks it, and reaps it on shutdown (see
+:class:`gaia.llm.lemonade_supervisor.LemonadeSupervisor`). This router is how a
+front-end asks for it. The Go TUI has no other way — it must not spawn a server
+itself and must not shell out to the Python CLI — and routing every front-end
+through the one supervisor is what makes "one machine-wide instance" true
+rather than aspirational.
+
+Blocking by design: the request does not return until the server answers health
+or the attempt fails. It runs in a threadpool so the blocking probe loop never
+stalls the event loop. A failure is a 503 whose ``detail`` is the supervisor's
+own actionable message — never a 200 that quietly means "no LLM".
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+# Module-level (like broker_routes.py): this module is imported lazily from
+# create_app, and the endpoint annotations must resolve from module globals
+# under PEP 563.
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel, Field
+from starlette.concurrency import run_in_threadpool
+
+from gaia.daemon.constants import API_PREFIX
+from gaia.llm.lemonade_supervisor import LemonadeStartError, LemonadeSupervisor
+from gaia.logger import get_logger
+
+logger = get_logger(__name__)
+
+
+class StartRequest(BaseModel):
+    """Optional overrides; every field has a host default."""
+
+    # The window the started server must come up with. Omitted means "this
+    # machine's device profile" — a server started without one answers /health
+    # and then fails long requests, which reads as an agent bug.
+    ctx_size: Optional[int] = Field(default=None, gt=0)
+
+
+def build_lemonade_router(token: str, supervisor: LemonadeSupervisor) -> APIRouter:
+    """Token-guarded routes over the daemon's *supervisor*."""
+    from gaia.daemon.app import build_require_token
+
+    require_token = build_require_token(token)
+    router = APIRouter(
+        prefix=f"{API_PREFIX}/lemonade",
+        tags=["lemonade"],
+        dependencies=[Depends(require_token)],
+    )
+
+    @router.post("/start")
+    async def start(body: Optional[StartRequest] = None) -> dict:
+        from gaia.config import GaiaConfigError
+
+        ctx_size = body.ctx_size if body else None
+        if ctx_size is None:
+            try:
+                ctx_size = _profile_ctx_size()
+            except GaiaConfigError as e:
+                raise HTTPException(status_code=503, detail=str(e)) from e
+
+        try:
+            state = await run_in_threadpool(supervisor.ensure_running, ctx_size)
+        except LemonadeStartError as e:
+            logger.warning("lemonade: start refused: %s", e)
+            raise HTTPException(status_code=503, detail=str(e)) from e
+
+        if state.started:
+            logger.info(
+                "lemonade: started at %s in %.1fs (pid=%s)",
+                state.base_url,
+                state.waited_seconds,
+                state.pid,
+            )
+        return _payload(state, ctx_size)
+
+    @router.get("/status")
+    def status() -> dict:
+        """What the daemon knows about the server, without starting one.
+
+        ``supervised`` distinguishes a server this daemon owns and will reap
+        from one it merely found — the two behave differently at shutdown, and
+        a status that blurred them would make that surprising.
+        """
+        return {
+            "supervised": supervisor.is_running,
+            "pid": supervisor.pid,
+            "log_path": str(supervisor.log_path()),
+        }
+
+    return router
+
+
+def _payload(state, ctx_size: int) -> dict:
+    return {
+        "status": "started" if state.started else "already_running",
+        "base_url": state.base_url,
+        "ctx_size": ctx_size,
+        "supervised": state.owned,
+        "pid": state.pid,
+        "waited_seconds": round(state.waited_seconds, 2),
+    }
+
+
+def _profile_ctx_size() -> int:
+    """This machine's pinned context window, from the persisted device profile.
+
+    Resolves through the same ``GaiaConfig.default_device`` →
+    ``profile_ctx_size`` path ``gaia.cli`` uses to size its own model loads, so
+    a server the daemon starts serves the window every GAIA agent will ask for.
+    A corrupt config raises ``GaiaConfigError`` rather than guessing: the NPU
+    profile's ceiling is half the GPU one, and picking the wrong side fails the
+    model load outright.
+    """
+    from gaia.config import GaiaConfig
+    from gaia.llm.lemonade_client import profile_ctx_size
+
+    return profile_ctx_size(GaiaConfig.load().default_device)

--- a/src/gaia/daemon/server.py
+++ b/src/gaia/daemon/server.py
@@ -27,6 +27,8 @@ from gaia.daemon.constants import HOST, RESERVED_PORT
 from gaia.daemon.errors import DaemonStartError
 from gaia.daemon.instance import DaemonInstance, remove_instance, write_instance
 from gaia.daemon.scheduler.clock import DaemonClock, JobExecutor
+from gaia.llm.lemonade_service import install_supervisor
+from gaia.llm.lemonade_supervisor import LemonadeSupervisor
 from gaia.logger import get_logger
 
 logger = get_logger(__name__)
@@ -189,7 +191,7 @@ def _build_register(
 
 
 def _build_deregister(
-    *, registry, custody_store, pid, refresher, clock
+    *, registry, custody_store, pid, refresher, clock, lemonade
 ) -> Callable[[], None]:
     """The daemon's ``on_shutdown`` hook: stop the refresher and the clock
     BEFORE tearing down sidecars, so neither races a sidecar mid-teardown."""
@@ -198,6 +200,13 @@ def _build_deregister(
         refresher.stop()
         clock.stop()
         registry.shutdown_all()
+        # After the sidecars, never before: an agent mid-teardown may still be
+        # finishing a model call, and pulling the server out from under it
+        # would turn a clean shutdown into a wave of connection errors in the
+        # logs. Only a server THIS daemon started is reaped — one the user
+        # launched from the tray is left running.
+        lemonade.shutdown()
+        install_supervisor(None)
         custody_store.close()
         remove_instance(only_pid=pid)
         logger.info("daemon: deregistered instance pid=%s", pid)
@@ -270,6 +279,14 @@ def run(host: str = HOST) -> None:
     # deliberate, not an oversight.
     clock = _build_clock(str(scheduler_db_path()))
 
+    # The machine's model server. The daemon owns the process: front-ends ask
+    # for it over /daemon/v1/lemonade/start and never spawn one, which is what
+    # makes "one instance" true rather than a race that usually works.
+    # install_supervisor lets in-daemon callers (host-side RAG, the UI server's
+    # embedder) reach it directly instead of posting to their own loopback port.
+    lemonade = LemonadeSupervisor()
+    install_supervisor(lemonade)
+
     _register = _build_register(
         specs=specs,
         pid=pid,
@@ -286,6 +303,7 @@ def run(host: str = HOST) -> None:
         pid=pid,
         refresher=refresher,
         clock=clock,
+        lemonade=lemonade,
     )
 
     app = create_app(
@@ -301,6 +319,7 @@ def run(host: str = HOST) -> None:
         custody_auth=custody_auth,
         custody_store=custody_store,
         clock=clock,
+        lemonade=lemonade,
     )
 
     config = uvicorn.Config(

--- a/src/gaia/llm/lemonade_client.py
+++ b/src/gaia/llm/lemonade_client.py
@@ -3793,9 +3793,18 @@ class LemonadeClient:
         url = f"{self.base_url}/params"
         return self._send_request("post", url, request_data)
 
-    def health_check(self) -> Dict[str, Any]:
+    def health_check(self, timeout=None) -> Dict[str, Any]:
         """
         Check server health.
+
+        Args:
+            timeout: Optional requests-style timeout — a scalar, or a
+                ``(connect, read)`` tuple. Omit it for the client default
+                (``DEFAULT_REQUEST_TIMEOUT``, sized for generation). "Is the
+                server even up?" callers should pass a short one: the scalar
+                default also governs the read, so a socket that ACCEPTS and
+                then never answers (a Lemonade mid-model-load) would block a
+                liveness probe for the full 15 minutes.
 
         Returns:
             Dict containing the server status and loaded model
@@ -3804,7 +3813,9 @@ class LemonadeClient:
             LemonadeClientError: If the health check fails
         """
         url = f"{self.base_url}/health"
-        return self._send_request("get", url)
+        if timeout is None:
+            return self._send_request("get", url)
+        return self._send_request("get", url, timeout=timeout)
 
     def get_stats(self) -> Dict[str, Any]:
         """

--- a/src/gaia/llm/lemonade_launcher.py
+++ b/src/gaia/llm/lemonade_launcher.py
@@ -321,6 +321,18 @@ def _render_command(argv: List[str], env: Dict[str, str]) -> str:
     return rendered
 
 
+def render_command(spec: StartSpec) -> str:
+    """Render a :class:`StartSpec` as the line a user would actually have to run.
+
+    The env matters as much as the argv and is easy to lose: a modern install
+    carries the context window in ``LEMONADE_CTX_SIZE``, so a bare
+    ``" ".join(argv)`` produces a command that starts a server at the WRONG
+    window — health-green, and failing every long request. Windows quoting is
+    handled too, so the line is copy-pasteable in the shell it names.
+    """
+    return _render_command(spec.argv, spec.env)
+
+
 def describe_start_hint(ctx_size: Optional[int] = None) -> StartHint:
     """Describe how to start Lemonade Server on THIS machine.
 

--- a/src/gaia/llm/lemonade_manager.py
+++ b/src/gaia/llm/lemonade_manager.py
@@ -690,10 +690,18 @@ class LemonadeManager:
                 status = client.get_status()
 
                 if not status.running:
-                    cls._log.warning("Lemonade server is not running")
-                    if not quiet:
-                        cls.print_server_error(min_context_size)
-                    return False
+                    # GAIA manages Lemonade — a stopped server is something to
+                    # start, not something to tell the user about.
+                    if not cls._autostart(client, min_context_size, quiet, cls._lock):
+                        return False
+                    status = client.get_status()
+                    if not status.running:
+                        cls._log.warning(
+                            "Lemonade server still not running after auto-start"
+                        )
+                        if not quiet:
+                            cls.print_server_error(min_context_size)
+                        return False
 
                 # Defensive normalisation: some Lemonade versions can return
                 # `loaded_models: null` in their JSON, which would crash the
@@ -792,6 +800,65 @@ class LemonadeManager:
                 if not quiet:
                     cls.print_server_error(min_context_size)
                 return False
+
+    @classmethod
+    def _autostart(
+        cls,
+        client: "LemonadeClient",
+        min_context_size: int,
+        quiet: bool,
+        lock: "threading.Lock",
+    ) -> bool:
+        """Start Lemonade Server for a caller who found it down.
+
+        The work belongs to the daemon, which owns the process — this asks it
+        (:func:`gaia.llm.lemonade_service.ensure_lemonade_running`) rather than
+        spawning anything, so a CLI and a UI starting at the same moment cannot
+        produce two servers.
+
+        Returns True when a server is answering afterwards. Returns False after
+        printing and logging the actionable reason it could not be started —
+        ``ensure_ready``'s contract is a bool, so the failure is surfaced in
+        full rather than raised past callers that cannot handle it.
+
+        Releases *lock* for the duration: a cold start takes tens of seconds and
+        must not stall status pollers or concurrent ``ensure_ready`` callers.
+        Mirrors the lock discipline of :meth:`_try_preload_with_ctx`.
+        """
+        from gaia.llm.lemonade_service import (
+            LemonadeStartError,
+            ensure_lemonade_running,
+        )
+
+        cls._log.info(
+            "Lemonade server is not running at %s — starting it", client.base_url
+        )
+        if not quiet:
+            print(
+                "\n⏳ Lemonade Server is not running — starting it...",
+                flush=True,
+            )
+
+        lock.release()
+        try:
+            result = ensure_lemonade_running(
+                ctx_size=min_context_size, base_url=client.base_url
+            )
+        except LemonadeStartError as e:
+            cls._log.error("Could not start the local model server: %s", e)
+            if not quiet:
+                print(f"\n❌ {e}", file=sys.stderr, flush=True)
+            return False
+        finally:
+            lock.acquire()
+
+        if not quiet and result.started:
+            print(
+                f"✅ Lemonade Server is up at {result.base_url} "
+                f"({result.waited_seconds:.0f}s).",
+                flush=True,
+            )
+        return True
 
     @classmethod
     def _try_preload_with_ctx(

--- a/src/gaia/llm/lemonade_service.py
+++ b/src/gaia/llm/lemonade_service.py
@@ -1,0 +1,186 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""One verb — "get me a running model server" — for every GAIA process.
+
+The daemon owns the Lemonade process (see
+:mod:`gaia.llm.lemonade_supervisor`). Everything else is a client of it: the Go
+TUI over ``POST /daemon/v1/lemonade/start``, and every Python caller through
+:func:`ensure_lemonade_running` here.
+
+Two callers, one function, because "who owns the process" is a real distinction
+and not a configuration knob:
+
+* **Inside the daemon**, the supervisor object is right there —
+  :func:`install_supervisor` puts it in reach and the call goes straight to it.
+  Posting to ourselves would be a loopback round-trip to reach an object in the
+  same address space.
+* **Everywhere else** — a CLI invocation, a sidecar agent, the Agent UI server —
+  the daemon is started-or-attached and asked. That is what makes the single
+  instance real: no second process ever spawns a server, so two front-ends
+  launching at once cannot race into two servers fighting over the port.
+
+The fast path never reaches either branch. A server that is already answering
+costs one probe and returns, because this sits in front of every agent
+construction and every CLI call.
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+from gaia.llm.lemonade_supervisor import (
+    DEFAULT_START_TIMEOUT_S,
+    LemonadeStartError,
+    LemonadeState,
+    LemonadeSupervisor,
+    _probe,
+)
+from gaia.logger import get_logger
+
+log = get_logger(__name__)
+
+__all__ = [
+    "LemonadeStartError",
+    "LemonadeState",
+    "ensure_lemonade_running",
+    "install_supervisor",
+    "installed_supervisor",
+]
+
+# Set by the daemon at startup. Module-level because "am I the process that owns
+# the model server" is a property of the process, not of any one call site.
+_SUPERVISOR: Optional[LemonadeSupervisor] = None
+
+
+def install_supervisor(supervisor: Optional[LemonadeSupervisor]) -> None:
+    """Declare this process the owner of the model server (``None`` clears it)."""
+    global _SUPERVISOR
+    _SUPERVISOR = supervisor
+
+
+def installed_supervisor() -> Optional[LemonadeSupervisor]:
+    """The supervisor this process owns, or ``None`` if it owns none."""
+    return _SUPERVISOR
+
+
+def ensure_lemonade_running(
+    ctx_size: Optional[int] = None,
+    timeout: float = DEFAULT_START_TIMEOUT_S,
+    base_url: Optional[str] = None,
+) -> LemonadeState:
+    """Return once a Lemonade Server is answering, starting one if it is not.
+
+    Args:
+        ctx_size: the context window a started server must come up with. A
+            server started without one answers ``/health`` and then fails every
+            long request, so pass the machine's profile window
+            (``lemonade_client.profile_ctx_size``).
+        timeout: how long a freshly started server gets to answer.
+        base_url: which server to check; omit for the ``LEMONADE_BASE_URL``
+            environment default.
+
+    Raises:
+        LemonadeStartError: it is down and could not be started — not
+            installed, the port is held by something else, the daemon is
+            unreachable, the server died on launch. The message names what
+            failed, what to do, and where to look.
+    """
+    supervisor = installed_supervisor()
+    if supervisor is not None:
+        return supervisor.ensure_running(ctx_size=ctx_size, timeout=timeout)
+
+    return _ask_the_daemon(ctx_size=ctx_size, timeout=timeout, base_url=base_url)
+
+
+def _ask_the_daemon(
+    *, ctx_size: Optional[int], timeout: float, base_url: Optional[str]
+) -> LemonadeState:
+    """Start-or-attach the daemon and ask it for a server.
+
+    The probe happens FIRST and short-circuits: a machine whose server is
+    already up must not pay a daemon round-trip (nor start a daemon it did not
+    otherwise need) just to be told so.
+    """
+    from gaia.llm.lemonade_client import LemonadeClient
+
+    client = (
+        LemonadeClient(base_url=base_url, keep_alive=True, verbose=False)
+        if base_url
+        else LemonadeClient(keep_alive=True, verbose=False)
+    )
+    if _probe(client):
+        return LemonadeState(
+            base_url=client.base_url,
+            started=False,
+            owned=False,
+            pid=None,
+            waited_seconds=0.0,
+        )
+
+    payload = {"ctx_size": ctx_size} if ctx_size else {}
+    body = _post_start(payload, timeout)
+    return LemonadeState(
+        base_url=body.get("base_url", client.base_url),
+        started=body.get("status") == "started",
+        # Reported by the daemon, never assumed: it is False for a server the
+        # daemon merely FOUND (one the user launched from the tray), which it
+        # will not reap at shutdown. Hardcoding True here would make this
+        # dataclass claim an ownership that does not exist.
+        owned=bool(body.get("supervised", False)),
+        pid=body.get("pid"),
+        waited_seconds=float(body.get("waited_seconds") or 0.0),
+    )
+
+
+def _post_start(payload: dict, timeout: float) -> dict:
+    """POST ``/daemon/v1/lemonade/start``, translating every failure loudly."""
+    import requests
+
+    from gaia.daemon import client as daemon_client
+    from gaia.daemon.constants import API_PREFIX, AUTH_SCHEME
+    from gaia.daemon.errors import DaemonError
+
+    try:
+        inst = daemon_client.start_or_attach()
+    except DaemonError as e:
+        raise LemonadeStartError(
+            "The local model server is not running, and GAIA could not reach "
+            f"the background service that owns it: {e}\n"
+            "To fix: start it with `gaia daemon start`, then retry.\n"
+            "Where to look: `gaia daemon logs`"
+        ) from e
+
+    url = f"http://{inst.host}:{inst.port}{API_PREFIX}/lemonade/start"
+    headers = {"Authorization": f"{AUTH_SCHEME} {inst.token}"}
+    # The client waits strictly longer than the daemon's own start budget, so a
+    # start that was about to succeed is never aborted here and reported as a
+    # different failure.
+    try:
+        resp = requests.post(url, json=payload, headers=headers, timeout=timeout + 30)
+    except requests.RequestException as e:
+        raise LemonadeStartError(
+            "The local model server is not running, and the request asking the "
+            f"background service to start it failed: {e}\n"
+            "To fix: check it with `gaia daemon status`, then retry.\n"
+            "Where to look: `gaia daemon logs`"
+        ) from e
+
+    if resp.status_code == 200:
+        return resp.json()
+
+    # The daemon's own detail is the most specific thing in the system about
+    # WHICH failure this was, so it is surfaced verbatim rather than restated.
+    detail = ""
+    try:
+        detail = resp.json().get("detail", "")
+    except ValueError:
+        detail = resp.text.strip()
+    raise LemonadeStartError(
+        detail
+        or (
+            f"The background service refused to start the local model server "
+            f"(HTTP {resp.status_code}).\n"
+            "To fix: check it with `gaia daemon status`.\n"
+            "Where to look: `gaia daemon logs`"
+        )
+    )

--- a/src/gaia/llm/lemonade_service.py
+++ b/src/gaia/llm/lemonade_service.py
@@ -14,10 +14,17 @@ and not a configuration knob:
   :func:`install_supervisor` puts it in reach and the call goes straight to it.
   Posting to ourselves would be a loopback round-trip to reach an object in the
   same address space.
-* **Everywhere else** — a CLI invocation, a sidecar agent, the Agent UI server —
-  the daemon is started-or-attached and asked. That is what makes the single
+* **Everywhere else** — a sidecar agent, the Agent UI server, a library caller —
+  the RUNNING daemon is attached to and asked. That is what makes the single
   instance real: no second process ever spawns a server, so two front-ends
   launching at once cannot race into two servers fighting over the port.
+
+It attaches; it never *starts* a daemon. Bringing up a machine-wide background
+service is not something a readiness check may do as a side effect — that is a
+front-end's decision, made once, where a user can see it. Getting this wrong is
+not theoretical: an earlier revision start-or-attached here, and constructing an
+agent in a unit test then spawned a daemon and a model server and took 30
+seconds. :func:`ensure_daemon_owns_lemonade` is the opt-in a front-end calls.
 
 The fast path never reaches either branch. A server that is already answering
 costs one probe and returns, because this sits in front of every agent
@@ -42,6 +49,7 @@ log = get_logger(__name__)
 __all__ = [
     "LemonadeStartError",
     "LemonadeState",
+    "ensure_daemon_owns_lemonade",
     "ensure_lemonade_running",
     "install_supervisor",
     "installed_supervisor",
@@ -132,23 +140,47 @@ def _ask_the_daemon(
     )
 
 
+def ensure_daemon_owns_lemonade() -> None:
+    """Make sure a daemon exists, so the model server has an owner.
+
+    A front-end calls this ONCE at startup. It is the opt-in that lets a
+    user-facing command bring up the machine's background service —
+    :func:`ensure_lemonade_running` deliberately will not, because a readiness
+    check that boots a daemon behind the caller's back surprises every library
+    and test caller, and costs them 30 seconds to do it.
+
+    Cheap when a daemon is already running (one status probe). A failure is
+    logged, not raised: the ``ensure_lemonade_running`` call that follows
+    produces the actionable error, and raising here would report the same
+    problem twice in different words.
+    """
+    from gaia.daemon import client as daemon_client
+    from gaia.daemon.errors import DaemonError
+
+    try:
+        daemon_client.start_or_attach()
+    except DaemonError as e:
+        log.warning("Could not start the GAIA background service: %s", e)
+
+
 def _post_start(payload: dict, timeout: float) -> dict:
     """POST ``/daemon/v1/lemonade/start``, translating every failure loudly."""
     import requests
 
     from gaia.daemon import client as daemon_client
     from gaia.daemon.constants import API_PREFIX, AUTH_SCHEME
-    from gaia.daemon.errors import DaemonError
 
-    try:
-        inst = daemon_client.start_or_attach()
-    except DaemonError as e:
+    # ATTACH, never start-or-attach. See the module docstring: bringing up a
+    # machine-wide daemon is a front-end's decision, not something a readiness
+    # check does behind the caller's back.
+    inst = daemon_client.attach()
+    if inst is None:
         raise LemonadeStartError(
-            "The local model server is not running, and GAIA could not reach "
-            f"the background service that owns it: {e}\n"
-            "To fix: start it with `gaia daemon start`, then retry.\n"
+            "The local model server is not running, and neither is the GAIA "
+            "background service that owns it — so nothing can start it.\n"
+            "To fix: run `gaia daemon start`, then retry.\n"
             "Where to look: `gaia daemon logs`"
-        ) from e
+        )
 
     url = f"http://{inst.host}:{inst.port}{API_PREFIX}/lemonade/start"
     headers = {"Authorization": f"{AUTH_SCHEME} {inst.token}"}

--- a/src/gaia/llm/lemonade_supervisor.py
+++ b/src/gaia/llm/lemonade_supervisor.py
@@ -1,0 +1,515 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""The daemon's supervision of the local model server.
+
+GAIA needs a Lemonade Server for every LLM call, and until now every front-end
+that found it down printed instructions and stopped. This module is what turns
+"it is not running" into "it is running".
+
+**The daemon owns the process.** ``gaia daemon`` starts the server as a child,
+supervises it, and tree-kills it on shutdown; the Go TUI and the Agent UI are
+HTTP clients that *ask* for it (``POST /daemon/v1/lemonade/start``) and never
+spawn anything. One machine-wide supervisor falls out of the daemon already
+being single-instance — which is why there is no lock here: the daemon's own
+:class:`~gaia.daemon.lock.StartLock` already guarantees one daemon, and a
+second locking scheme on top would be redundant state to keep consistent. The
+in-process lock below serializes the daemon's own threads, nothing more.
+
+**How the server is launched is not decided here.**
+:func:`~gaia.llm.lemonade_launcher.resolve_lemonade` and
+:func:`~gaia.llm.lemonade_launcher.build_start_command` own that, and hand back
+a ``StartSpec(argv, env)`` this module passes through untouched. That matters
+beyond tidiness: the three launch forms do not share an argv shape (the
+embeddable ``lemond ./ --port`` takes a working directory and a port the others
+do not), so anything here that inspected or assembled argv would break the
+moment bundled-lemond resolution lands behind the same function.
+
+**What "supervises" does and does not mean.** The daemon tracks the child, can
+report its pid, reaps it on shutdown, and starts a fresh one if the previous
+died. There is no watchdog thread and no restart-on-crash: a crash surfaces on
+the next request, loudly, rather than being papered over by a silent respawn.
+
+**It never kills what it did not start.** A Lemonade the user launched from the
+tray, or one another GAIA left behind, is attached to and left alone — including
+at daemon shutdown.
+"""
+
+from __future__ import annotations
+
+import ipaddress
+import os
+import subprocess
+import threading
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+from urllib.parse import urlparse
+
+from gaia.llm.lemonade_launcher import (
+    build_start_command,
+    describe_start_hint,
+    render_command,
+    resolve_lemonade,
+)
+from gaia.logger import get_logger
+
+log = get_logger(__name__)
+
+# How long a freshly started server gets to answer /health. A cold start on a
+# laptop that has to page the runtime in measures in tens of seconds; the
+# ceiling is generous because the alternative to waiting is a wrong error.
+DEFAULT_START_TIMEOUT_S = 120.0
+
+_PROBE_INTERVAL_S = 0.5
+
+# A port that is already accepting connections gets this long to start
+# answering /health before we call it a stranger. Covers a Lemonade that
+# something else spawned moments ago and is still binding its routes.
+_OCCUPIED_PORT_GRACE_S = 20.0
+
+# Tree-kill grace before escalating to SIGKILL, matching the sidecar manager.
+_SHUTDOWN_TIMEOUT_S = 5.0
+
+# The health probe's own (connect, read) budget. It must NOT inherit
+# LemonadeClient's scalar default (900s, correct for generation): a socket that
+# ACCEPTS and then never answers — a Lemonade mid-model-load, or the stranger on
+# the port that ``_start_locked`` exists to detect — would otherwise turn "poll
+# every half second for 20s" into a single 15-minute call holding the lock.
+# Mirrors readiness.PROBE_CONNECT_TIMEOUT / PROBE_READ_TIMEOUT.
+_PROBE_TIMEOUT = (2.0, 5.0)
+
+
+class LemonadeStartError(RuntimeError):
+    """The local model server could not be started, and the message says why."""
+
+
+@dataclass
+class LemonadeState:
+    """The outcome of an :meth:`LemonadeSupervisor.ensure_running` call."""
+
+    base_url: str
+    # False when the server was already up — the daemon started nothing.
+    started: bool
+    # True when THIS daemon owns the process and will reap it on shutdown.
+    owned: bool
+    pid: Optional[int]
+    waited_seconds: float
+
+
+def _is_loopback(host: str) -> bool:
+    """Whether *host* names this machine, so a server started here would be used."""
+    host = (host or "").strip().strip("[]").lower()
+    if host in ("localhost", ""):
+        return True
+    try:
+        return ipaddress.ip_address(host).is_loopback
+    except ValueError:
+        return False
+
+
+class LemonadeSupervisor:
+    """Starts, tracks and reaps the local model server for one machine."""
+
+    def __init__(self, base_url: Optional[str] = None, log_dir: Optional[Path] = None):
+        self._base_url = base_url
+        self._log_dir = log_dir
+        self._lock = threading.Lock()
+        self._proc: Optional[subprocess.Popen] = None
+        self._log_handle = None
+
+    # -- introspection -----------------------------------------------------
+
+    @property
+    def is_running(self) -> bool:
+        """Whether the child this daemon started is still alive."""
+        return self._proc is not None and self._proc.poll() is None
+
+    @property
+    def pid(self) -> Optional[int]:
+        return self._proc.pid if self.is_running else None
+
+    def log_path(self) -> Path:
+        """Where a supervised server's output goes, for failure messages to name."""
+        if self._log_dir is not None:
+            return Path(self._log_dir) / "lemonade.log"
+        from gaia.config import GAIA_CONFIG_DIR
+
+        return Path(GAIA_CONFIG_DIR) / "logs" / "lemonade.log"
+
+    # -- the verb ----------------------------------------------------------
+
+    def ensure_running(
+        self,
+        ctx_size: Optional[int] = None,
+        timeout: float = DEFAULT_START_TIMEOUT_S,
+    ) -> LemonadeState:
+        """Make sure a Lemonade Server is answering, starting one if it is not.
+
+        Args:
+            ctx_size: the context window a started server must come up with. A
+                server started without one answers ``/health`` and then fails
+                every long request, which reads as an agent bug rather than a
+                launch bug — so callers pass their profile's window
+                (``lemonade_client.profile_ctx_size``).
+            timeout: how long a freshly started server gets to answer.
+
+        Raises:
+            LemonadeStartError: it is down and could not be started. The message
+                names what failed, what to do, and where to look.
+        """
+        client = self._client()
+        target = client.base_url
+
+        # Fast path: one probe, and nothing else runs when the server is up.
+        # This sits in front of every agent construction and every CLI call, so
+        # anything added here is latency paid by users who never needed it.
+        if _probe(client):
+            return LemonadeState(
+                base_url=target,
+                started=False,
+                owned=self.is_running,
+                pid=self.pid,
+                waited_seconds=0.0,
+            )
+
+        if not _is_loopback(urlparse(target).hostname or ""):
+            raise self._remote_error(target)
+        self._require_supervisable_port(client)
+
+        started_at = time.monotonic()
+        with self._lock:
+            # Re-probe under the lock: another daemon thread may have started
+            # the very server we were about to start.
+            if _probe(client):
+                return LemonadeState(
+                    base_url=target,
+                    started=False,
+                    owned=self.is_running,
+                    pid=self.pid,
+                    waited_seconds=time.monotonic() - started_at,
+                )
+            started = self._start_locked(client, ctx_size, timeout)
+
+        return LemonadeState(
+            base_url=target,
+            started=started,
+            owned=self.is_running,
+            pid=self.pid,
+            waited_seconds=time.monotonic() - started_at,
+        )
+
+    def shutdown(self, timeout: float = _SHUTDOWN_TIMEOUT_S) -> None:
+        """Tree-kill the server THIS daemon started. A no-op for anything else.
+
+        Tree-kill rather than a plain kill because Lemonade spawns
+        ``llama-server`` children — killing only the leader orphans them, and an
+        orphan still holds the port and the GPU memory the next start needs.
+        """
+        with self._lock:
+            proc, self._proc = self._proc, None
+            if proc is None or proc.poll() is not None:
+                self._close_log()
+                return
+            log.info("lemonade: tree-killing supervised server pid=%s", proc.pid)
+            _tree_kill(proc, timeout)
+            self._close_log()
+
+    # -- internals ---------------------------------------------------------
+
+    def _client(self):
+        from gaia.llm.lemonade_client import LemonadeClient
+
+        if self._base_url:
+            return LemonadeClient(
+                base_url=self._base_url, keep_alive=True, verbose=False
+            )
+        return LemonadeClient(keep_alive=True, verbose=False)
+
+    def _start_locked(self, client, ctx_size: Optional[int], timeout: float) -> bool:
+        """Spawn and wait. Caller holds the lock and has re-probed."""
+        host, port, target = client.host, client.port, client.base_url
+
+        # Something is listening but not answering /health. It may be a server
+        # that started a second ago, so give it a grace window — but if it never
+        # answers it is a stranger, and evicting it is not ours to do.
+        if _port_is_open(host, port):
+            log.info(
+                "lemonade: %s:%s accepts connections but does not answer health yet; "
+                "waiting up to %.0fs",
+                host,
+                port,
+                _OCCUPIED_PORT_GRACE_S,
+            )
+            if _wait_for_health(client, _OCCUPIED_PORT_GRACE_S):
+                return False
+            raise self._occupied_port_error(host, port)
+
+        tooling = resolve_lemonade()
+        if not tooling.found:
+            raise self._not_installed_error(target)
+
+        # argv and env come from the launcher and are passed through untouched:
+        # the three launch forms do not share a shape.
+        spec = build_start_command(tooling, ctx_size)
+        log.info(
+            "lemonade: starting supervised server: %s (ctx_size=%s)",
+            render_command(spec),
+            ctx_size,
+        )
+
+        try:
+            proc = self._spawn(spec)
+        except OSError as e:
+            raise LemonadeStartError(
+                f"GAIA could not launch the local model server "
+                f"(`{' '.join(spec.argv)}`): {e}\n"
+                "To fix: re-run `gaia init` to repair the install, or set "
+                "LEMONADE_SERVER_PATH to a working server executable.\n"
+                f"Where to look: {self.log_path()}"
+            ) from e
+
+        if _wait_for_health(client, timeout, proc=proc):
+            log.info("lemonade: server is up at %s (pid=%s)", target, proc.pid)
+            return True
+
+        exit_code = proc.poll()
+        _tree_kill(proc, _SHUTDOWN_TIMEOUT_S)
+        self._proc = None
+        self._close_log()
+        raise self._start_failed_error(target, spec, timeout, exit_code)
+
+    def _spawn(self, spec) -> subprocess.Popen:
+        """Launch the server in its own process group, output to the log file.
+
+        Its own group so :func:`_tree_kill` can take the ``llama-server``
+        children with it. NOT detached-to-outlive-us: the daemon owns this
+        process and reaps it, so a stopped daemon never leaves a server behind.
+        """
+        path = self.log_path()
+        path.parent.mkdir(parents=True, exist_ok=True)
+        self._close_log()
+        self._log_handle = open(path, "a", encoding="utf-8", errors="replace")
+        self._log_handle.write(f"\n=== GAIA daemon start: {' '.join(spec.argv)} ===\n")
+        self._log_handle.flush()
+
+        creationflags = 0
+        start_new_session = False
+        if os.name == "nt":
+            creationflags = getattr(
+                subprocess, "CREATE_NEW_PROCESS_GROUP", 0
+            ) | getattr(subprocess, "CREATE_NO_WINDOW", 0)
+        else:
+            start_new_session = True
+
+        try:
+            # Merge — never replace — the parent environment; the child loses
+            # PATH/LOCALAPPDATA otherwise and LemonadeServer.exe cannot start.
+            self._proc = subprocess.Popen(
+                spec.argv,
+                stdout=self._log_handle,
+                stderr=subprocess.STDOUT,
+                stdin=subprocess.DEVNULL,
+                env={**os.environ, **spec.env},
+                creationflags=creationflags,
+                start_new_session=start_new_session,
+            )
+        except OSError:
+            self._close_log()
+            raise
+        return self._proc
+
+    def _close_log(self) -> None:
+        if self._log_handle is not None:
+            try:
+                self._log_handle.close()
+            finally:
+                self._log_handle = None
+
+    # -- the actionable failures ------------------------------------------
+
+    def _not_installed_error(self, base_url: str) -> LemonadeStartError:
+        return LemonadeStartError(
+            f"The local model server is not running at {base_url}, and GAIA "
+            "could not find one to start.\n"
+            f"To fix: {describe_start_hint().instruction}\n"
+            "See https://amd-gaia.ai/docs/guides/install"
+        )
+
+    def _occupied_port_error(self, host: str, port: int) -> LemonadeStartError:
+        return LemonadeStartError(
+            f"Port {port} on {host} is held by a process that does not answer "
+            "Lemonade's health endpoint, so GAIA will not start a server there "
+            "and will not evict what is already running.\n"
+            "To fix: stop whatever holds that port, or point GAIA at the right "
+            "one with LEMONADE_BASE_URL.\n"
+            f"To see what holds it: `netstat -ano | findstr :{port}` on "
+            f"Windows, `lsof -i :{port}` elsewhere."
+        )
+
+    def _require_supervisable_port(self, client) -> None:
+        """Refuse to start a server that would not be the one we then poll.
+
+        ``build_start_command`` takes no port — the launch forms bind Lemonade's
+        own default. So a caller pointed at a DIFFERENT local port would have us
+        spawn a server on 13305, poll the other port until the deadline, and
+        then tree-kill a perfectly healthy server while reporting "it did not
+        answer". Refusing up front says what is actually wrong.
+        """
+        from gaia.llm.lemonade_client import DEFAULT_PORT
+
+        if client.port == DEFAULT_PORT:
+            return
+        raise LemonadeStartError(
+            f"The local model server is not running at {client.base_url}, and "
+            f"GAIA can only start one on its default port ({DEFAULT_PORT}) — "
+            f"the launcher has no port option, so a server started here would "
+            f"not be the one on port {client.port}.\n"
+            f"To fix: start the server on port {client.port} yourself, or unset "
+            "LEMONADE_BASE_URL so GAIA manages the default one.\n"
+            "See https://amd-gaia.ai/docs/reference/troubleshooting"
+        )
+
+    def _remote_error(self, base_url: str) -> LemonadeStartError:
+        return LemonadeStartError(
+            f"The model server at {base_url} is not reachable, and GAIA cannot "
+            "start it: that URL names another machine, so a server started here "
+            "would never be used.\n"
+            "To fix: start it on that host, or point LEMONADE_BASE_URL at a "
+            "reachable server.\n"
+            "See https://amd-gaia.ai/docs/reference/troubleshooting"
+        )
+
+    def _start_failed_error(
+        self, base_url: str, spec, timeout: float, exit_code: Optional[int]
+    ) -> LemonadeStartError:
+        # Rendered through the launcher, not " ".join(argv): a modern install
+        # carries ctx_size in the ENV, so a user copying a bare argv line would
+        # get a server at the wrong context window — health-green and failing
+        # every long request.
+        cmd = render_command(spec)
+        if exit_code:
+            what = (
+                f"GAIA started the local model server (`{cmd}`) but it exited "
+                f"with code {exit_code} without answering at {base_url}."
+            )
+        else:
+            what = (
+                f"GAIA started the local model server (`{cmd}`) but it did not "
+                f"answer at {base_url} within {timeout:.0f}s."
+            )
+        tail = _log_tail(self.log_path())
+        detail = f"\nLast log lines:\n{tail}" if tail else ""
+        return LemonadeStartError(
+            f"{what}\n"
+            "To fix: run that command yourself to see the failure directly, or "
+            "re-run `gaia init` to repair the install.\n"
+            f"Where to look: {self.log_path()}{detail}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Free functions — probing and process control
+# ---------------------------------------------------------------------------
+
+
+def _probe(client) -> bool:
+    """Whether *client*'s server answers its health endpoint right now.
+
+    Any successful response counts. Version and model checks belong to the
+    callers that need them (``LemonadeManager``, the sidecar's ``/init``); this
+    only answers "is a Lemonade there".
+    """
+    try:
+        client.health_check(timeout=_PROBE_TIMEOUT)
+        return True
+    except Exception as e:  # noqa: BLE001 — any failure means "not answering"
+        log.debug("lemonade: health probe failed at %s: %s", client.base_url, e)
+        return False
+
+
+def _port_is_open(host: str, port: int, timeout: float = 0.5) -> bool:
+    import socket
+
+    try:
+        with socket.create_connection((host, port), timeout=timeout):
+            return True
+    except OSError:
+        return False
+
+
+def _wait_for_health(
+    client, timeout: float, proc: Optional[subprocess.Popen] = None
+) -> bool:
+    """Poll ``/health`` until it answers or *timeout* elapses.
+
+    A *proc* that exits NON-zero ends the wait immediately — the server is dead
+    and burning the remaining budget only delays the error. A zero exit keeps
+    polling: ``systemctl --user start lemond`` and the macOS ``open`` launcher
+    both hand off and return success while the server is still binding.
+    """
+    deadline = time.monotonic() + timeout
+    while True:
+        if _probe(client):
+            return True
+        if proc is not None:
+            code = proc.poll()
+            if code:
+                return False
+            if code == 0:
+                proc = None  # Handed off; only the deadline bounds us now.
+        if time.monotonic() >= deadline:
+            return False
+        time.sleep(_PROBE_INTERVAL_S)
+
+
+def _tree_kill(proc: subprocess.Popen, timeout: float) -> None:
+    """Kill *proc* and its children, escalating if it does not go quietly.
+
+    Mirrors ``AgentSidecarManager._shutdown_locked`` — one shape for reaping a
+    supervised child, so the two cannot drift.
+    """
+    pid = proc.pid
+    try:
+        if os.name == "nt":
+            subprocess.run(
+                ["taskkill", "/PID", str(pid), "/T", "/F"],
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+                check=False,
+            )
+        else:
+            os.killpg(os.getpgid(pid), 15)
+    except (ProcessLookupError, OSError):
+        pass
+    try:
+        proc.wait(timeout=timeout)
+    except subprocess.TimeoutExpired:
+        log.warning("lemonade: pid %s did not exit in %ss; SIGKILL", pid, timeout)
+        try:
+            if os.name != "nt":
+                os.killpg(os.getpgid(pid), 9)
+            else:
+                proc.kill()
+        except (ProcessLookupError, OSError):
+            pass
+        try:
+            proc.wait(timeout=timeout)
+        except subprocess.TimeoutExpired:
+            # It survived SIGKILL. Say so: it still holds the port and the GPU
+            # memory the next start needs, and a silent exit here would make
+            # that failure look like a fresh mystery.
+            log.error(
+                "lemonade: pid %s survived SIGKILL and may still hold the "
+                "model-server port; clear it with `gaia kill`",
+                pid,
+            )
+
+
+def _log_tail(path: Path, lines: int = 15) -> str:
+    """The last few log lines, for embedding in a failure message."""
+    try:
+        content = path.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return ""
+    return "\n".join([ln for ln in content.splitlines() if ln.strip()][-lines:])

--- a/src/gaia/llm/lemonade_supervisor.py
+++ b/src/gaia/llm/lemonade_supervisor.py
@@ -76,8 +76,13 @@ _SHUTDOWN_TIMEOUT_S = 5.0
 # ACCEPTS and then never answers — a Lemonade mid-model-load, or the stranger on
 # the port that ``_start_locked`` exists to detect — would otherwise turn "poll
 # every half second for 20s" into a single 15-minute call holding the lock.
-# Mirrors readiness.PROBE_CONNECT_TIMEOUT / PROBE_READ_TIMEOUT.
-_PROBE_TIMEOUT = (2.0, 5.0)
+#
+# The connect leg is deliberately tighter than readiness.PROBE_CONNECT_TIMEOUT:
+# this probe only ever dials loopback, where a connection is refused or accepted
+# in microseconds, and it is paid TWICE per probe because `localhost` resolves
+# to both ::1 and 127.0.0.1. At 2s that is 4 seconds to learn "not running" —
+# on every down-path call, in every test that constructs an agent.
+_PROBE_TIMEOUT = (0.5, 5.0)
 
 
 class LemonadeStartError(RuntimeError):

--- a/src/gaia/llm/providers/lemonade.py
+++ b/src/gaia/llm/providers/lemonade.py
@@ -147,7 +147,13 @@ class LemonadeUpstreamTimeoutError(LemonadeError):
         "model is still warming up (cold KV cache) or the prompt is too "
         "large for the current hardware on a fresh load. Try:\n"
         "  • Wait 30s and resend the same query — KV cache will be primed.\n"
-        "  • Restart Lemonade cleanly:  gaia kill  &&  lemonade-server serve\n"
+        # Never name a launch command here: `lemonade-server serve` was dropped
+        # in 10.7 and the surviving forms differ per machine (CLAUDE.md).
+        # `gaia kill` rather than `gaia daemon restart`: the daemon reaps only a
+        # server it started itself, so a restart is a no-op against a wedged one
+        # the user launched from the tray. Clearing the port works either way,
+        # and GAIA starts a fresh supervised server on the next request.
+        "  • Clear the wedged server:  gaia kill  (GAIA restarts it on the next query)\n"
         "  • Reduce retrieved RAG chunks:  gaia chat --max-chunks 2 ...\n"
         "  • Close other GPU/NPU-heavy apps competing for the device."
     )

--- a/tests/integration/test_example_agents.py
+++ b/tests/integration/test_example_agents.py
@@ -46,7 +46,7 @@ def lemonade_available():
 
 requires_lemonade = pytest.mark.skipif(
     not _check_lemonade(),
-    reason="Lemonade server not running - start with: lemonade-server serve",
+    reason="Lemonade server not running - start it with: gaia daemon start",
 )
 
 

--- a/tests/integration/test_sd_integration.py
+++ b/tests/integration/test_sd_integration.py
@@ -10,8 +10,8 @@ Run with:
     pytest tests/integration/test_sd_integration.py -v
 
 Prerequisites:
-    lemonade-server serve
-    lemonade-server pull SD-Turbo
+    gaia daemon start
+    gaia init
 """
 
 from pathlib import Path

--- a/tests/test_sd_model_sweep.py
+++ b/tests/test_sd_model_sweep.py
@@ -138,7 +138,7 @@ def main():
         print(f"Available SD models: {[m['id'] for m in available_models]}")
     except Exception as e:
         print(f"Error: Cannot connect to Lemonade Server: {e}")
-        print("Make sure it's running: lemonade-server serve")
+        print("Make sure it's running: gaia daemon start")
         sys.exit(1)
 
     # Run sweep

--- a/tests/test_vlm_integration.py
+++ b/tests/test_vlm_integration.py
@@ -38,7 +38,7 @@ def test_vlm_availability():
     else:
         print("❌ FAIL: VLM model not available")
         print(f"   Expected: {vlm.vlm_model}")
-        print("\n   Run: lemonade-server serve")
+        print("\n   Run: gaia daemon start")
         print("   Then verify model is in list")
         return False
 

--- a/tests/unit/agents/email/test_init_endpoint.py
+++ b/tests/unit/agents/email/test_init_endpoint.py
@@ -250,8 +250,12 @@ def test_init_lemonade_down_returns_503_with_actionable_hint(client):
     assert body["ready"] is False
     assert body["lemonade"]["reachable"] is False
     # Hint names what failed AND what to do (CLAUDE.md fail-loudly rule).
+    # The next step, not a launch command: `lemonade-server serve` was pinned
+    # here and Lemonade 10.7 removed it, so the assertion kept a dead remedy
+    # looking verified. The manual fallback is resolved per machine, so there
+    # is no single launch string to assert.
     assert "not reachable" in body["hint"]
-    assert "lemonade-server serve" in body["hint"]
+    assert "gaia daemon start" in body["hint"]
     # Model is not probed once Lemonade is down — reported absent, not crashed.
     assert body["model"]["present"] is False
 
@@ -571,7 +575,7 @@ def test_provision_lemonade_down_returns_503_streamed_actionable(client):
     assert resp.headers["content-type"].startswith("text/plain")
     body = resp.text
     assert "not reachable" in body
-    assert "lemonade-server serve" in body
+    assert "gaia daemon start" in body
     # No pull is attempted when Lemonade is down — the sidecar can't install it.
     mock_pull.assert_not_called()
 

--- a/tests/unit/test_agent_readiness.py
+++ b/tests/unit/test_agent_readiness.py
@@ -160,7 +160,13 @@ def test_unreachable_backend_names_whose_job_the_fix_is(monkeypatch, reqs):
     assert status.lemonade.reachable is False
     # Indeterminate, not a failure: an unreachable server has no version to compare.
     assert status.lemonade.compatible is None
-    assert "lemonade-server serve" in status.hint
+    # A real next step, asserted as "names the one command that always exists"
+    # rather than as a launch command. Pinning a literal launcher here is
+    # precisely how `lemonade-server serve` stayed asserted-as-real for
+    # releases after Lemonade 10.7 removed it — the manual fallback is resolved
+    # per machine (CLAUDE.md, "Never hardcode how Lemonade is started"), so
+    # there is no single launch string to assert.
+    assert "gaia daemon start" in status.hint
     # The boundary must be explicit — the agent cannot bootstrap the backend.
     assert "host prerequisite" in status.hint
 

--- a/tests/unit/test_daemon_agents_routes.py
+++ b/tests/unit/test_daemon_agents_routes.py
@@ -67,10 +67,19 @@ _TOY_B = AgentSidecarSpec(
 # ===========================================================================
 
 
-def test_daemon_api_version_is_1_1():
+def test_daemon_api_version_is_at_least_1_1():
+    """#2142's contract is a FLOOR, not a pin.
+
+    The agents control plane needs MINOR >= 1; later additive routes (MINOR 2
+    is ``/daemon/v1/lemonade/start``) keep satisfying it. Pinning the exact
+    string here would turn every additive route into a test failure and push
+    the next author toward not bumping MINOR at all — which is what actually
+    breaks a client's floor check.
+    """
     from gaia.daemon.constants import DAEMON_API_VERSION
 
-    assert DAEMON_API_VERSION == "1.1"
+    major, minor = (int(p) for p in DAEMON_API_VERSION.split(".")[:2])
+    assert (major, minor) >= (1, 1)
 
 
 def test_daemon_api_version_major_still_parses_to_1():

--- a/tests/unit/test_daemon_clock_wiring.py
+++ b/tests/unit/test_daemon_clock_wiring.py
@@ -224,6 +224,8 @@ def test_build_deregister_calls_in_exact_order(daemon_home):
     registry.shutdown_all.side_effect = lambda: calls.append("registry.shutdown_all")
     custody_store = mock.Mock()
     custody_store.close.side_effect = lambda: calls.append("custody_store.close")
+    lemonade = mock.Mock()
+    lemonade.shutdown.side_effect = lambda: calls.append("lemonade.shutdown")
 
     deregister = daemon_server._build_deregister(
         registry=registry,
@@ -231,13 +233,19 @@ def test_build_deregister_calls_in_exact_order(daemon_home):
         pid=555,
         refresher=refresher,
         clock=clock,
+        lemonade=lemonade,
     )
     deregister()
 
+    # The model server is reaped AFTER the sidecars, never before: an agent
+    # mid-teardown may still be finishing a model call, and pulling the server
+    # out from under it turns a clean shutdown into a wave of connection errors
+    # in the logs.
     assert calls == [
         "refresher.stop",
         "clock.stop",
         "registry.shutdown_all",
+        "lemonade.shutdown",
         "custody_store.close",
     ]
     assert instance_mod.read_instance() is None

--- a/tests/unit/test_daemon_lemonade_routes.py
+++ b/tests/unit/test_daemon_lemonade_routes.py
@@ -1,0 +1,187 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""``/daemon/v1/lemonade/*`` — the daemon starts the model server on request.
+
+These routes exist so the Go TUI never spawns a server itself and never shells
+out to the Python CLI: it asks the one machine-wide supervisor. The tests pin
+what a front-end depends on — that the verb is guarded like every other
+client-plane route, that a refusal is a 503 carrying the supervisor's own
+actionable message (never a 200 that quietly means "no LLM"), and that a
+request without a ctx_size gets the machine's pinned profile window rather than
+the server's own small default.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from gaia.llm.lemonade_supervisor import LemonadeStartError, LemonadeState
+
+# FastAPI's TestClient drives the app through an asyncio loop whose self-pipe is
+# a loopback socket, which the conftest's _block_network guard refuses. Nothing
+# here reaches the network: the supervisor is a fake in every test.
+pytestmark = pytest.mark.allow_network
+
+TOKEN = "daemon-client-token"
+START = "/daemon/v1/lemonade/start"
+STATUS = "/daemon/v1/lemonade/status"
+AUTH = {"Authorization": f"Bearer {TOKEN}"}
+
+
+class FakeSupervisor:
+    """Stands in for the daemon's real supervisor; records what it was asked."""
+
+    def __init__(self, state=None, error=None):
+        self.calls = []
+        self._state = state or LemonadeState(
+            base_url="http://localhost:13305/api/v1",
+            started=True,
+            owned=True,
+            pid=4242,
+            waited_seconds=4.2,
+        )
+        self._error = error
+        self.is_running = True
+        self.pid = 4242
+
+    def ensure_running(self, ctx_size=None, timeout=None):
+        self.calls.append(ctx_size)
+        if self._error is not None:
+            raise self._error
+        return self._state
+
+    def log_path(self):
+        return "/tmp/lemonade.log"
+
+
+def _client(supervisor):
+    from fastapi.testclient import TestClient
+
+    from gaia.daemon.app import create_app
+
+    return TestClient(
+        create_app(
+            token=TOKEN, port=51234, pid=999, started_at=0.0, lemonade=supervisor
+        )
+    )
+
+
+@pytest.fixture()
+def supervisor():
+    return FakeSupervisor()
+
+
+@pytest.fixture()
+def client(supervisor):
+    return _client(supervisor)
+
+
+def test_the_route_requires_the_client_token(client):
+    resp = client.post(START)
+    assert resp.status_code == 401
+    assert "token" in resp.json()["detail"].lower()
+
+
+def test_a_stopped_server_is_started_and_reported_as_started(client, supervisor):
+    resp = client.post(START, headers=AUTH, json={"ctx_size": 65536})
+
+    assert resp.status_code == 200
+    assert resp.json() == {
+        "status": "started",
+        "base_url": "http://localhost:13305/api/v1",
+        "ctx_size": 65536,
+        "supervised": True,
+        "pid": 4242,
+        "waited_seconds": 4.2,
+    }
+    assert supervisor.calls == [65536]
+
+
+def test_a_server_the_daemon_only_found_is_reported_as_unsupervised(supervisor):
+    """``supervised`` is what tells a caller whether stopping the daemon takes
+    the server down with it. Blurring the two would make that surprising."""
+    supervisor._state = LemonadeState(
+        base_url="http://localhost:13305/api/v1",
+        started=False,
+        owned=False,
+        pid=None,
+        waited_seconds=0.0,
+    )
+    resp = _client(supervisor).post(START, headers=AUTH, json={"ctx_size": 65536})
+
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "already_running"
+    assert resp.json()["supervised"] is False
+
+
+def test_an_omitted_ctx_size_becomes_this_machines_profile_window(
+    client, supervisor, monkeypatch
+):
+    """A server started without the profile's window answers /health and then
+    fails every long request — so "no ctx_size given" must mean the machine's
+    pinned window, never the server's own small default."""
+    monkeypatch.setattr("gaia.daemon.lemonade_routes._profile_ctx_size", lambda: 32768)
+
+    resp = client.post(START, headers=AUTH)
+
+    assert resp.status_code == 200
+    assert resp.json()["ctx_size"] == 32768
+    assert supervisor.calls == [32768]
+
+
+def test_a_refusal_is_a_503_carrying_the_supervisors_own_message():
+    """No silent fallback: the front-end must get the actionable text verbatim,
+    because it is the only thing that knows WHICH failure this was."""
+    message = (
+        "Port 13305 on localhost is held by a process that does not answer "
+        "Lemonade's health endpoint.\nTo fix: stop whatever holds that port..."
+    )
+    resp = _client(FakeSupervisor(error=LemonadeStartError(message))).post(
+        START, headers=AUTH, json={}
+    )
+
+    assert resp.status_code == 503
+    assert resp.json()["detail"] == message
+
+
+def test_a_corrupt_config_is_a_503_not_a_guessed_context_window(client, monkeypatch):
+    """The NPU profile's ceiling is half the GPU one, so guessing past an
+    unreadable config would fail the model load outright."""
+    from gaia.config import GaiaConfigError
+
+    def broken():
+        raise GaiaConfigError(
+            "config.json is not valid JSON; run `gaia config set ...`"
+        )
+
+    monkeypatch.setattr("gaia.daemon.lemonade_routes._profile_ctx_size", broken)
+
+    resp = client.post(START, headers=AUTH)
+
+    assert resp.status_code == 503
+    assert "gaia config set" in resp.json()["detail"]
+
+
+def test_a_non_positive_ctx_size_is_rejected_rather_than_silently_replaced(client):
+    resp = client.post(START, headers=AUTH, json={"ctx_size": 0})
+    assert resp.status_code == 422
+
+
+def test_status_reports_supervision_without_starting_anything(client, supervisor):
+    resp = client.get(STATUS, headers=AUTH)
+
+    assert resp.status_code == 200
+    assert resp.json()["supervised"] is True
+    assert resp.json()["pid"] == 4242
+    assert supervisor.calls == [], "a status read started a server"
+
+
+def test_a_daemon_without_a_supervisor_does_not_mount_the_routes():
+    """The skeleton/test daemon has no model server to offer, and a 404 is an
+    honest answer — better than a route that pretends and then fails."""
+    from fastapi.testclient import TestClient
+
+    from gaia.daemon.app import create_app
+
+    c = TestClient(create_app(token=TOKEN, port=1, pid=2, started_at=0.0))
+    assert c.post(START, headers=AUTH, json={}).status_code == 404

--- a/tests/unit/test_lemonade_error_classification.py
+++ b/tests/unit/test_lemonade_error_classification.py
@@ -107,7 +107,11 @@ def test_upstream_timeout_user_message_is_actionable() -> None:
     assert "qwen3-0.6b" not in msg.lower()
     assert "smaller model" not in msg.lower()
     # Concrete next steps the user can actually run.
-    assert "gaia kill" in msg or "lemonade-server serve" in msg
+    # `gaia kill` only: the other branch of this `or` named a command
+    # Lemonade 10.7 removed, so the assertion would have kept passing
+    # against a dead remedy (CLAUDE.md, "Never hardcode how Lemonade is
+    # started").
+    assert "gaia kill" in msg
 
 
 # ── UI side: exception-string classification ────────────────────────────
@@ -240,7 +244,11 @@ def test_agent_extract_lemonade_user_message_typed_direct() -> None:
     msg = agent._extract_lemonade_user_message(exc)
     assert msg is not None
     assert "didn't respond in time" in msg
-    assert "gaia kill" in msg or "lemonade-server serve" in msg
+    # `gaia kill` only: the other branch of this `or` named a command
+    # Lemonade 10.7 removed, so the assertion would have kept passing
+    # against a dead remedy (CLAUDE.md, "Never hardcode how Lemonade is
+    # started").
+    assert "gaia kill" in msg
 
 
 def test_agent_extract_lemonade_user_message_typed_in_cause_chain() -> None:

--- a/tests/unit/test_lemonade_manager_autostart.py
+++ b/tests/unit/test_lemonade_manager_autostart.py
@@ -1,0 +1,135 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""``LemonadeManager.ensure_ready`` gets the server started instead of describing it.
+
+``ensure_ready`` is the gate every in-process GAIA path goes through — the base
+``Agent`` constructor, ``gaia chat``, ``gaia llm``, the Agent UI server. Before
+this, a stopped Lemonade made it print instructions and return False. Now it
+asks the daemon — which owns the process — for one.
+
+Two properties are pinned here because they pull in opposite directions: the
+start has to happen on the cold path, and it must NOT be reachable on the warm
+one (that call sits in front of every agent construction).
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from gaia.llm.lemonade_client import LemonadeStatus
+from gaia.llm.lemonade_manager import LemonadeManager
+from gaia.llm.lemonade_service import LemonadeStartError
+from gaia.llm.lemonade_supervisor import LemonadeState
+
+
+@pytest.fixture(autouse=True)
+def _reset_manager():
+    """The manager is a singleton; a warm one would skip the branch under test."""
+    LemonadeManager.reset()
+    yield
+    LemonadeManager.reset()
+
+
+def _status(running=True, context_size=0, loaded_models=None):
+    return LemonadeStatus(
+        running=running,
+        context_size=context_size,
+        loaded_models=[] if loaded_models is None else loaded_models,
+    )
+
+
+def _client(*statuses):
+    client = MagicMock()
+    client.base_url = "http://localhost:13305/api/v1"
+    client.get_status.side_effect = list(statuses)
+    return client
+
+
+@patch("gaia.llm.lemonade_manager.LemonadeClient")
+@patch("gaia.llm.lemonade_service.ensure_lemonade_running")
+def test_a_stopped_server_is_started_rather_than_described(start, client_cls):
+    """The whole point: no user ever has to type a Lemonade command."""
+    start.return_value = LemonadeState(
+        base_url="http://localhost:13305/api/v1",
+        started=True,
+        owned=True,
+        pid=42,
+        waited_seconds=6.0,
+    )
+    client_cls.return_value = _client(
+        _status(running=False),  # the cold probe
+        _status(running=True, context_size=65536, loaded_models=[{"id": "Gemma"}]),
+        _status(running=True, context_size=65536, loaded_models=[{"id": "Gemma"}]),
+    )
+
+    assert LemonadeManager.ensure_ready(min_context_size=65536, quiet=True) is True
+
+    # The floor the caller asked for has to reach the start, or the server comes
+    # up with its own small default and every long request fails afterwards.
+    assert start.call_args.kwargs["ctx_size"] == 65536
+    assert start.call_args.kwargs["base_url"] == "http://localhost:13305/api/v1"
+
+
+@patch("gaia.llm.lemonade_manager.LemonadeClient")
+@patch("gaia.llm.lemonade_service.ensure_lemonade_running")
+def test_a_running_server_never_reaches_the_starter(start, client_cls):
+    """Startup-latency guard.
+
+    ensure_ready runs in front of every agent construction, so the warm path
+    must not acquire a lock, resolve tooling, or probe a second time.
+    """
+    client_cls.return_value = _client(
+        _status(running=True, context_size=65536, loaded_models=[{"id": "Gemma"}])
+    )
+
+    assert LemonadeManager.ensure_ready(min_context_size=65536, quiet=True) is True
+    start.assert_not_called()
+
+
+@patch("gaia.llm.lemonade_manager.LemonadeClient")
+@patch("gaia.llm.lemonade_service.ensure_lemonade_running")
+def test_a_start_that_cannot_happen_surfaces_the_reason_verbatim(
+    start, client_cls, capsys
+):
+    """No silent fallback.
+
+    ensure_ready's contract is a bool, so the actionable message is PRINTED
+    rather than raised past callers that cannot handle it — but it is never
+    swallowed, and it never degrades to a quiet "no LLM".
+    """
+    start.side_effect = LemonadeStartError(
+        "Lemonade Server is not running at http://localhost:13305/api/v1, and "
+        "GAIA could not find an installed copy to start.\n"
+        "To fix: Run `gaia init` to install it.\n"
+        "See https://amd-gaia.ai/docs/guides/install"
+    )
+    client_cls.return_value = _client(_status(running=False))
+
+    assert LemonadeManager.ensure_ready(min_context_size=65536, quiet=False) is False
+
+    err = capsys.readouterr().err
+    assert "gaia init" in err
+    assert "amd-gaia.ai/docs/guides/install" in err
+
+
+@patch("gaia.llm.lemonade_manager.LemonadeClient")
+@patch("gaia.llm.lemonade_service.ensure_lemonade_running")
+def test_a_start_that_reports_success_but_leaves_it_down_is_not_treated_as_ready(
+    start, client_cls
+):
+    """Trust the re-probe, not the return value.
+
+    ``ensure_lemonade_running`` returning is evidence the LAUNCH worked; only
+    the follow-up status says the server is usable. Skipping it would let a
+    half-started server take this call green and fail on the first query.
+    """
+    start.return_value = LemonadeState(
+        base_url="http://localhost:13305/api/v1",
+        started=True,
+        owned=True,
+        pid=42,
+        waited_seconds=1.0,
+    )
+    client_cls.return_value = _client(_status(running=False), _status(running=False))
+
+    assert LemonadeManager.ensure_ready(min_context_size=65536, quiet=True) is False

--- a/tests/unit/test_lemonade_service.py
+++ b/tests/unit/test_lemonade_service.py
@@ -1,0 +1,217 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""``ensure_lemonade_running`` — one verb, and who actually does the work.
+
+The single-instance guarantee lives here, not in a lock: no process other than
+the daemon may spawn a model server, so a CLI and a UI starting at the same
+moment both end up talking to the same supervisor. These tests pin that split —
+in the daemon, straight to the supervisor; anywhere else, over the daemon's
+authenticated loopback API — and pin that neither branch is reached when a
+server is already answering.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from gaia.llm import lemonade_service as service
+from gaia.llm.lemonade_service import (
+    LemonadeStartError,
+    ensure_lemonade_running,
+    install_supervisor,
+)
+from gaia.llm.lemonade_supervisor import LemonadeState
+
+
+@pytest.fixture(autouse=True)
+def _no_installed_supervisor():
+    """This process is not the daemon unless a test says so."""
+    install_supervisor(None)
+    yield
+    install_supervisor(None)
+
+
+class FakeClient:
+    def __init__(self, up=False):
+        self.base_url = "http://localhost:13305/api/v1"
+        self.host, self.port = "localhost", 13305
+        self.up = up
+        self.probes = 0
+
+    # Mirrors LemonadeClient.health_check's signature: the supervisor passes a
+    # (connect, read) timeout, and a fake that rejected it would make every
+    # probe raise TypeError and be swallowed as "not answering".
+    def health_check(self, timeout=None):
+        self.probes += 1
+        if not self.up:
+            raise ConnectionError("connection refused")
+        return {"status": "ok"}
+
+
+class FakeSupervisor:
+    def __init__(self):
+        self.calls = []
+
+    def ensure_running(self, ctx_size=None, timeout=None):
+        self.calls.append(ctx_size)
+        return LemonadeState(
+            base_url="http://localhost:13305/api/v1",
+            started=True,
+            owned=True,
+            pid=1,
+            waited_seconds=1.0,
+        )
+
+
+@pytest.fixture
+def down_client(monkeypatch):
+    c = FakeClient(up=False)
+    monkeypatch.setattr(
+        "gaia.llm.lemonade_client.LemonadeClient", lambda **kwargs: c, raising=True
+    )
+    return c
+
+
+def test_inside_the_daemon_the_supervisor_is_used_directly(monkeypatch, down_client):
+    """Posting to our own loopback port to reach an object in this address
+    space would be a round-trip for nothing — and would deadlock a
+    single-threaded caller."""
+    monkeypatch.setattr(
+        service,
+        "_ask_the_daemon",
+        lambda **_: pytest.fail("the daemon posted to itself"),
+    )
+    supervisor = FakeSupervisor()
+    install_supervisor(supervisor)
+
+    state = ensure_lemonade_running(ctx_size=65536)
+
+    assert state.started is True
+    assert supervisor.calls == [65536]
+
+
+def test_outside_the_daemon_the_daemon_is_asked(monkeypatch, down_client):
+    """No other process spawns a server. That is what makes one instance real
+    rather than a race that usually works."""
+    asked = {}
+
+    def fake_post(payload, timeout):
+        asked.update(payload)
+        return {
+            "status": "started",
+            "base_url": "http://localhost:13305/api/v1",
+            "pid": 77,
+            "waited_seconds": 5.0,
+        }
+
+    monkeypatch.setattr(service, "_post_start", fake_post)
+
+    state = ensure_lemonade_running(ctx_size=65536)
+
+    assert asked == {"ctx_size": 65536}
+    assert state.started is True
+    assert state.pid == 77
+
+
+def test_a_running_server_asks_nobody(monkeypatch):
+    """The fast path must not start a daemon, or reach a supervisor, just to be
+    told the server it wanted is already there."""
+    up = FakeClient(up=True)
+    monkeypatch.setattr(
+        "gaia.llm.lemonade_client.LemonadeClient", lambda **kwargs: up, raising=True
+    )
+    monkeypatch.setattr(
+        service, "_post_start", lambda *a, **k: pytest.fail("asked the daemon")
+    )
+
+    state = ensure_lemonade_running(ctx_size=65536)
+
+    assert state.started is False
+    assert up.probes == 1
+
+
+def test_an_unreachable_daemon_is_a_loud_error_naming_how_to_start_it(
+    monkeypatch, down_client
+):
+    """The failure must name the background service, not Lemonade: a user sent
+    to restart the wrong process gets nowhere."""
+    from gaia.daemon.errors import DaemonError
+
+    def refuse():
+        raise DaemonError("the daemon did not come up within 30s")
+
+    monkeypatch.setattr("gaia.daemon.client.start_or_attach", refuse)
+
+    with pytest.raises(LemonadeStartError) as e:
+        ensure_lemonade_running(ctx_size=65536)
+
+    assert "background service" in str(e.value)
+    assert "gaia daemon start" in str(e.value)
+
+
+def test_a_daemon_refusal_reaches_the_caller_verbatim(monkeypatch, down_client):
+    """The daemon's detail is the most specific thing in the system about WHICH
+    failure this was, so restating it here would lose information."""
+
+    class FakeResponse:
+        status_code = 503
+
+        @staticmethod
+        def json():
+            return {"detail": "Port 13305 is held by something else. To fix: ..."}
+
+    class FakeInstance:
+        host, port, token = "127.0.0.1", 51234, "tok"
+
+    monkeypatch.setattr("gaia.daemon.client.start_or_attach", lambda: FakeInstance())
+    monkeypatch.setattr("requests.post", lambda *a, **k: FakeResponse())
+
+    with pytest.raises(LemonadeStartError) as e:
+        ensure_lemonade_running(ctx_size=65536)
+
+    assert "Port 13305 is held by something else" in str(e.value)
+
+
+def test_the_request_is_addressed_and_authorized_the_way_the_daemon_expects(
+    monkeypatch, down_client
+):
+    """A mock proves "we called requests.post", never "the daemon would accept
+    it" (CLAUDE.md). ``/daemon/v1/lemonade/start`` is token-guarded and would
+    401 a request missing the header, with a green suite either side — so the
+    shape of the outgoing call is asserted here, not just that it happened.
+    """
+    sent = {}
+
+    class FakeResponse:
+        status_code = 200
+
+        @staticmethod
+        def json():
+            return {
+                "status": "started",
+                "base_url": "http://localhost:13305/api/v1",
+                "supervised": True,
+                "pid": 5,
+                "waited_seconds": 3.0,
+            }
+
+    class FakeInstance:
+        host, port, token = "127.0.0.1", 51234, "sekrit"
+
+    def capture(url, json=None, headers=None, timeout=None):
+        sent.update(url=url, json=json, headers=headers, timeout=timeout)
+        return FakeResponse()
+
+    monkeypatch.setattr("gaia.daemon.client.start_or_attach", lambda: FakeInstance())
+    monkeypatch.setattr("requests.post", capture)
+
+    state = ensure_lemonade_running(ctx_size=65536, timeout=120.0)
+
+    assert sent["url"] == "http://127.0.0.1:51234/daemon/v1/lemonade/start"
+    assert sent["headers"] == {"Authorization": "Bearer sekrit"}
+    assert sent["json"] == {"ctx_size": 65536}
+    # Strictly longer than the daemon's own start budget, or a start that was
+    # about to succeed gets aborted here and reported as a different failure.
+    assert sent["timeout"] > 120.0
+    # Ownership is reported by the daemon, never assumed by the caller.
+    assert state.owned is True

--- a/tests/unit/test_lemonade_service.py
+++ b/tests/unit/test_lemonade_service.py
@@ -130,23 +130,36 @@ def test_a_running_server_asks_nobody(monkeypatch):
     assert up.probes == 1
 
 
-def test_an_unreachable_daemon_is_a_loud_error_naming_how_to_start_it(
-    monkeypatch, down_client
-):
+def test_no_daemon_is_a_loud_error_naming_how_to_start_it(monkeypatch, down_client):
     """The failure must name the background service, not Lemonade: a user sent
     to restart the wrong process gets nowhere."""
-    from gaia.daemon.errors import DaemonError
-
-    def refuse():
-        raise DaemonError("the daemon did not come up within 30s")
-
-    monkeypatch.setattr("gaia.daemon.client.start_or_attach", refuse)
+    monkeypatch.setattr("gaia.daemon.client.attach", lambda: None)
 
     with pytest.raises(LemonadeStartError) as e:
         ensure_lemonade_running(ctx_size=65536)
 
     assert "background service" in str(e.value)
     assert "gaia daemon start" in str(e.value)
+
+
+def test_a_readiness_check_never_boots_a_daemon(monkeypatch, down_client):
+    """The bug this rule exists to prevent, and it was real.
+
+    An earlier revision start-or-attached here. Constructing an agent in a unit
+    test then spawned a machine-wide daemon AND a model server, took 30 seconds
+    a call, and pushed the email agent's CI job past its 10-minute ceiling —
+    while every assertion still passed. Bringing up background infrastructure is
+    a front-end's decision, made once and visibly; a readiness check may only
+    attach to what is already there.
+    """
+    monkeypatch.setattr(
+        "gaia.daemon.client.start_or_attach",
+        lambda *a, **k: pytest.fail("a readiness check tried to start a daemon"),
+    )
+    monkeypatch.setattr("gaia.daemon.client.attach", lambda: None)
+
+    with pytest.raises(LemonadeStartError):
+        ensure_lemonade_running(ctx_size=65536)
 
 
 def test_a_daemon_refusal_reaches_the_caller_verbatim(monkeypatch, down_client):
@@ -163,7 +176,7 @@ def test_a_daemon_refusal_reaches_the_caller_verbatim(monkeypatch, down_client):
     class FakeInstance:
         host, port, token = "127.0.0.1", 51234, "tok"
 
-    monkeypatch.setattr("gaia.daemon.client.start_or_attach", lambda: FakeInstance())
+    monkeypatch.setattr("gaia.daemon.client.attach", lambda: FakeInstance())
     monkeypatch.setattr("requests.post", lambda *a, **k: FakeResponse())
 
     with pytest.raises(LemonadeStartError) as e:
@@ -202,7 +215,7 @@ def test_the_request_is_addressed_and_authorized_the_way_the_daemon_expects(
         sent.update(url=url, json=json, headers=headers, timeout=timeout)
         return FakeResponse()
 
-    monkeypatch.setattr("gaia.daemon.client.start_or_attach", lambda: FakeInstance())
+    monkeypatch.setattr("gaia.daemon.client.attach", lambda: FakeInstance())
     monkeypatch.setattr("requests.post", capture)
 
     state = ensure_lemonade_running(ctx_size=65536, timeout=120.0)

--- a/tests/unit/test_lemonade_supervisor.py
+++ b/tests/unit/test_lemonade_supervisor.py
@@ -1,0 +1,555 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""``LemonadeSupervisor`` — the daemon owns the local model server.
+
+The cases that matter are the ones a developer box hides. This machine almost
+always has a server *running*, which makes the fast path the only one anyone
+exercises by hand — so every test here drives the STOPPED state explicitly, and
+asserts on what actually gets spawned rather than merely that something was
+called (CLAUDE.md: a mock proves "we called it", never "the call is valid").
+
+The launcher is faked at the ``resolve_lemonade`` seam, never below it: nothing
+in this file asserts an argv the supervisor built, because the supervisor is
+required not to build one. The three launch forms do not share a shape, and a
+test that pinned one here would have to be rewritten when bundled-lemond
+resolution lands behind the same function.
+"""
+
+from __future__ import annotations
+
+import os
+import threading
+
+import pytest
+
+from gaia.llm import lemonade_supervisor as sup
+from gaia.llm.lemonade_launcher import LemonadeTooling
+from gaia.llm.lemonade_supervisor import LemonadeStartError, LemonadeSupervisor
+
+
+@pytest.fixture(autouse=True)
+def fast_polling(monkeypatch):
+    """Shrink the poll interval so a timeout test takes milliseconds."""
+    monkeypatch.setattr(sup, "_PROBE_INTERVAL_S", 0.01)
+
+
+class FakeClient:
+    def __init__(self, base_url="http://localhost:13305/api/v1", up=False):
+        self.base_url = base_url
+        self.host = "localhost"
+        self.port = 13305
+        self.up = up
+        self.probes = 0
+
+    # Mirrors LemonadeClient.health_check's signature: the supervisor passes a
+    # (connect, read) timeout, and a fake that rejected it would make every
+    # probe raise TypeError and be swallowed as "not answering".
+    def health_check(self, timeout=None):
+        self.probes += 1
+        if not self.up:
+            raise ConnectionError("connection refused")
+        return {"status": "ok"}
+
+
+class FakeProc:
+    """A spawned server whose liveness and exit code a test drives."""
+
+    def __init__(self, exit_code=None, pid=4242):
+        self._exit_code = exit_code
+        self.pid = pid
+        self.waited = False
+
+    def poll(self):
+        return self._exit_code
+
+    def wait(self, timeout=None):
+        self.waited = True
+        self._exit_code = self._exit_code if self._exit_code is not None else 0
+        return self._exit_code
+
+
+def _supervisor(tmp_path, client, monkeypatch):
+    s = LemonadeSupervisor(log_dir=tmp_path)
+    monkeypatch.setattr(s, "_client", lambda: client)
+    return s
+
+
+@pytest.fixture
+def client():
+    return FakeClient()
+
+
+@pytest.fixture
+def installed(monkeypatch):
+    """A resolvable install, so the tests exercise the start rather than the
+    not-installed branch. The shape is never asserted."""
+    tooling = LemonadeTooling(
+        found=True,
+        kind="modern",
+        client_path=r"C:\lemonade\bin\lemonade.exe",
+        server_launcher=r"C:\lemonade\bin\LemonadeServer.exe",
+    )
+    monkeypatch.setattr(sup, "resolve_lemonade", lambda: tooling)
+    return tooling
+
+
+@pytest.fixture
+def free_port(monkeypatch):
+    monkeypatch.setattr(sup, "_port_is_open", lambda *a, **k: False)
+
+
+# ---------------------------------------------------------------------------
+# The fast path — the only one most users ever hit
+# ---------------------------------------------------------------------------
+
+
+def test_a_running_server_costs_exactly_one_probe(tmp_path, client, monkeypatch):
+    """Not a style point: this sits in front of every agent construction and
+    every CLI call, so anything added here is latency paid by users who never
+    needed it."""
+    client.up = True
+    monkeypatch.setattr(
+        sup,
+        "resolve_lemonade",
+        lambda: pytest.fail("resolved tooling on the fast path"),
+    )
+    s = _supervisor(tmp_path, client, monkeypatch)
+
+    state = s.ensure_running(ctx_size=65536)
+
+    assert state.started is False
+    assert client.probes == 1
+
+
+# ---------------------------------------------------------------------------
+# The cold path
+# ---------------------------------------------------------------------------
+
+
+def test_a_stopped_server_is_started_and_the_window_is_passed_to_the_launcher(
+    tmp_path, client, monkeypatch, installed
+):
+    """The ctx_size must reach ``build_start_command``, which is what decides
+    how it is carried — an env var for a modern install, a flag for the legacy
+    CLI. A server started without it answers /health and then fails every long
+    request, which reads as an agent bug rather than a launch bug."""
+    monkeypatch.setattr(sup, "_port_is_open", lambda *a, **k: False)
+    seen = {}
+    real_build = sup.build_start_command
+
+    def spy(tooling, ctx_size):
+        seen["ctx_size"] = ctx_size
+        return real_build(tooling, ctx_size)
+
+    monkeypatch.setattr(sup, "build_start_command", spy)
+
+    spawned = []
+
+    def fake_spawn(spec):
+        spawned.append(spec)
+        client.up = True
+        return FakeProc()
+
+    monkeypatch.setattr(
+        LemonadeSupervisor, "_spawn", lambda self, spec: fake_spawn(spec)
+    )
+    s = _supervisor(tmp_path, client, monkeypatch)
+
+    state = s.ensure_running(ctx_size=65536)
+
+    assert state.started is True
+    assert seen["ctx_size"] == 65536
+    assert len(spawned) == 1
+
+
+def test_not_installed_names_the_installer_and_spawns_nothing(
+    tmp_path, client, monkeypatch, free_port
+):
+    monkeypatch.setattr(
+        sup, "resolve_lemonade", lambda: LemonadeTooling(found=False, kind="none")
+    )
+    monkeypatch.setattr(
+        LemonadeSupervisor,
+        "_spawn",
+        lambda self, spec: pytest.fail("spawned with nothing installed"),
+    )
+    s = _supervisor(tmp_path, client, monkeypatch)
+
+    with pytest.raises(LemonadeStartError) as e:
+        s.ensure_running(ctx_size=65536)
+
+    assert "not running" in str(e.value)
+    assert "install" in str(e.value).lower()
+
+
+def test_a_port_held_by_a_stranger_is_an_error_not_an_eviction(
+    tmp_path, client, monkeypatch, installed
+):
+    """GAIA must never kill what it did not start.
+
+    ``LemonadeClient.launch_server`` frees the port first because a user asked
+    it to relaunch. This path is unattended, so an occupied port is a loud error
+    naming how to find the holder — never a takeover.
+    """
+    monkeypatch.setattr(sup, "_port_is_open", lambda *a, **k: True)
+    monkeypatch.setattr(sup, "_OCCUPIED_PORT_GRACE_S", 0.05)
+    monkeypatch.setattr(
+        LemonadeSupervisor,
+        "_spawn",
+        lambda self, spec: pytest.fail("spawned onto an occupied port"),
+    )
+    s = _supervisor(tmp_path, client, monkeypatch)
+
+    with pytest.raises(LemonadeStartError) as e:
+        s.ensure_running(ctx_size=65536)
+
+    assert "13305" in str(e.value)
+    assert "LEMONADE_BASE_URL" in str(e.value)
+
+
+def test_a_port_that_answers_within_the_grace_window_is_attached_to(
+    tmp_path, client, monkeypatch, installed
+):
+    """A server something else spawned a moment ago is not a stranger."""
+    monkeypatch.setattr(sup, "_port_is_open", lambda *a, **k: True)
+    monkeypatch.setattr(sup, "_OCCUPIED_PORT_GRACE_S", 5.0)
+    monkeypatch.setattr(
+        LemonadeSupervisor,
+        "_spawn",
+        lambda self, spec: pytest.fail("spawned over a server that came up"),
+    )
+
+    original = client.health_check
+
+    def comes_up(timeout=None):
+        if client.probes >= 2:
+            client.up = True
+        return original()
+
+    client.health_check = comes_up
+    s = _supervisor(tmp_path, client, monkeypatch)
+
+    state = s.ensure_running(ctx_size=65536)
+    assert state.started is False
+    assert state.owned is False
+
+
+def test_a_server_that_dies_on_launch_names_the_exit_code_and_the_log(
+    tmp_path, client, monkeypatch, installed, free_port
+):
+    monkeypatch.setattr(
+        LemonadeSupervisor, "_spawn", lambda self, spec: FakeProc(exit_code=3)
+    )
+    monkeypatch.setattr(sup, "_tree_kill", lambda proc, timeout: None)
+    s = _supervisor(tmp_path, client, monkeypatch)
+
+    with pytest.raises(LemonadeStartError) as e:
+        s.ensure_running(ctx_size=65536, timeout=5.0)
+
+    assert "exited with code 3" in str(e.value)
+    assert str(s.log_path()) in str(e.value)
+
+
+def test_a_server_that_never_answers_is_reaped_rather_than_left_behind(
+    tmp_path, client, monkeypatch, installed, free_port
+):
+    """A half-started server still holds the port and the GPU memory the next
+    attempt needs, so a failed start must not leave one running."""
+    proc = FakeProc(exit_code=None)
+    monkeypatch.setattr(LemonadeSupervisor, "_spawn", lambda self, spec: proc)
+    killed = []
+    monkeypatch.setattr(sup, "_tree_kill", lambda p, timeout: killed.append(p))
+    s = _supervisor(tmp_path, client, monkeypatch)
+
+    with pytest.raises(LemonadeStartError) as e:
+        s.ensure_running(ctx_size=65536, timeout=0.05)
+
+    assert "did not answer" in str(e.value)
+    assert killed == [proc]
+    assert s.is_running is False
+
+
+def test_a_launcher_that_hands_off_and_exits_zero_is_not_a_failure(
+    tmp_path, client, monkeypatch, free_port
+):
+    """``systemctl --user start lemond`` returns immediately and successfully
+    while the server it started is still binding. Treating its exit as death
+    would report a working start as broken."""
+    monkeypatch.setattr(
+        sup,
+        "resolve_lemonade",
+        lambda: LemonadeTooling(
+            found=True,
+            kind="modern",
+            client_path="/usr/bin/lemonade",
+            server_launcher="/usr/bin/lemond",
+        ),
+    )
+    monkeypatch.setattr(
+        LemonadeSupervisor, "_spawn", lambda self, spec: FakeProc(exit_code=0)
+    )
+
+    original = client.health_check
+
+    def comes_up_after_handoff(timeout=None):
+        if client.probes >= 2:
+            client.up = True
+        return original()
+
+    client.health_check = comes_up_after_handoff
+    s = _supervisor(tmp_path, client, monkeypatch)
+
+    assert s.ensure_running(ctx_size=65536, timeout=5.0).started is True
+
+
+# ---------------------------------------------------------------------------
+# Ownership — the daemon reaps what it started, and nothing else
+# ---------------------------------------------------------------------------
+
+
+def test_shutdown_tree_kills_the_server_the_daemon_started(
+    tmp_path, client, monkeypatch, installed, free_port
+):
+    """Tree-kill, not kill: Lemonade spawns llama-server children, and an
+    orphan still holds the port and the GPU memory the next start needs."""
+    proc = FakeProc()
+
+    def spawn(self, spec):
+        client.up = True
+        self._proc = proc
+        return proc
+
+    monkeypatch.setattr(LemonadeSupervisor, "_spawn", spawn)
+    killed = []
+    monkeypatch.setattr(sup, "_tree_kill", lambda p, timeout: killed.append(p))
+    s = _supervisor(tmp_path, client, monkeypatch)
+
+    s.ensure_running(ctx_size=65536)
+    assert s.is_running is True
+    assert s.pid == proc.pid
+
+    s.shutdown()
+    assert killed == [proc]
+    assert s.is_running is False
+
+
+def test_shutdown_never_kills_a_server_the_daemon_only_found(
+    tmp_path, client, monkeypatch
+):
+    """A Lemonade the user launched from the tray must survive `gaia daemon
+    stop`. Reaping it would make stopping the daemon silently take the user's
+    own server down with it."""
+    client.up = True
+    monkeypatch.setattr(
+        sup, "_tree_kill", lambda p, timeout: pytest.fail("killed a server we found")
+    )
+    s = _supervisor(tmp_path, client, monkeypatch)
+
+    state = s.ensure_running(ctx_size=65536)
+    assert state.owned is False
+    s.shutdown()  # must be a no-op
+
+
+# ---------------------------------------------------------------------------
+# Remote servers are not ours to start
+# ---------------------------------------------------------------------------
+
+
+def test_a_remote_server_is_never_started_here(tmp_path, monkeypatch):
+    remote = FakeClient(base_url="http://192.168.1.50:13305/api/v1")
+    monkeypatch.setattr(
+        LemonadeSupervisor,
+        "_spawn",
+        lambda self, spec: pytest.fail("started a server for a remote URL"),
+    )
+    s = _supervisor(tmp_path, remote, monkeypatch)
+
+    with pytest.raises(LemonadeStartError) as e:
+        s.ensure_running(ctx_size=65536)
+
+    assert "another machine" in str(e.value)
+
+
+@pytest.mark.parametrize(
+    "host,loopback",
+    [
+        ("localhost", True),
+        ("127.0.0.1", True),
+        ("127.0.0.5", True),
+        ("::1", True),
+        ("[::1]", True),
+        ("", True),
+        ("192.168.1.50", False),
+        ("lemonade.example.com", False),
+    ],
+)
+def test_loopback_classification(host, loopback):
+    assert sup._is_loopback(host) is loopback
+
+
+# ---------------------------------------------------------------------------
+# Concurrency — the daemon's own threads
+# ---------------------------------------------------------------------------
+
+
+def test_concurrent_callers_in_one_daemon_start_exactly_one_server(
+    tmp_path, client, monkeypatch, installed, free_port
+):
+    """Several requests can land at once (the TUI's gate and a sidecar's own
+    readiness check). The loser must re-probe INSIDE the lock and attach to the
+    winner's server rather than spawning a second one.
+
+    Cross-PROCESS exclusion needs no lock here: the daemon is already
+    single-instance, so there is only ever one supervisor on a machine.
+    """
+    spawned = []
+
+    def slow_spawn(self, spec):
+        spawned.append(spec)
+        # The window a second caller would race into.
+        threading.Event().wait(0.3)
+        client.up = True
+        proc = FakeProc()
+        self._proc = proc
+        return proc
+
+    monkeypatch.setattr(LemonadeSupervisor, "_spawn", slow_spawn)
+    s = _supervisor(tmp_path, client, monkeypatch)
+
+    results, errors = [], []
+
+    def run():
+        try:
+            results.append(s.ensure_running(ctx_size=65536, timeout=5.0))
+        except Exception as e:  # noqa: BLE001 — recorded and asserted below
+            errors.append(e)
+
+    threads = [threading.Thread(target=run) for _ in range(4)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join(timeout=30)
+
+    assert not errors, errors
+    assert len(spawned) == 1, f"started {len(spawned)} servers, want exactly 1"
+    assert sum(1 for r in results if r.started) == 1
+    assert len(results) == 4
+
+
+# ---------------------------------------------------------------------------
+# The probe's call into the real client — asserted as VALID, not merely as made
+# ---------------------------------------------------------------------------
+
+
+def test_the_probe_call_is_one_the_real_client_actually_accepts():
+    """``_probe`` swallows every exception, so a call the real client rejects
+    is indistinguishable from "the server is down".
+
+    That is not hypothetical: passing a ``timeout`` the real ``health_check``
+    had no parameter for made EVERY probe raise TypeError, get swallowed, and
+    report a healthy server as unreachable — the supervisor then waited out its
+    full 120s budget and tree-killed a server that had been up for two minutes.
+    Every faked-client test passed throughout, because a fake signature is
+    whatever the fake says it is.
+
+    So this binds against the REAL signature (CLAUDE.md: a mock proves "we
+    called it", never "the call is valid").
+    """
+    import inspect
+
+    from gaia.llm.lemonade_client import LemonadeClient
+
+    inspect.signature(LemonadeClient.health_check).bind(
+        None, timeout=sup._PROBE_TIMEOUT
+    )
+
+
+def test_a_probe_against_a_closed_port_gives_up_promptly(monkeypatch):
+    """The whole point of bounding the probe. A real client, a real socket, no
+    server — this must answer in well under the client's scalar default (900s,
+    correct for generation and catastrophic for a liveness check)."""
+    import time as _time
+
+    from gaia.llm.lemonade_client import LemonadeClient
+
+    # Port 1 is reserved and never listening; 4001 is reserved repo-wide.
+    client = LemonadeClient(host="127.0.0.1", port=1, keep_alive=True, verbose=False)
+    start = _time.monotonic()
+    assert sup._probe(client) is False
+    assert _time.monotonic() - start < 10.0
+
+
+# ---------------------------------------------------------------------------
+# The spawn itself — asserted as VALID, not merely as called
+# ---------------------------------------------------------------------------
+
+_PROBE_SCRIPT = """
+import os, pathlib, sys
+pathlib.Path(sys.argv[1]).write_text(
+    "CTX=" + os.environ.get("LEMONADE_CTX_SIZE", "") + "\\n"
+    "MARKER=" + os.environ.get("GAIA_PARENT_MARKER", ""),
+    encoding="utf-8",
+)
+"""
+
+
+def test_a_real_spawn_inherits_the_parent_environment_and_carries_the_ctx_window(
+    tmp_path, client, monkeypatch, free_port
+):
+    """Every other test stubs ``_spawn``, which proves the call was made and
+    nothing about whether it would work. This one runs a REAL child process
+    with the env the REAL ``build_start_command`` produced.
+
+    The invariant is the one ``_spawn``'s own comment flags as a known
+    breakage: the child environment must be the parent's env MERGED with the
+    spec's, never replaced by it. A bare ``env=spec.env`` drops PATH and
+    LOCALAPPDATA and LemonadeServer.exe cannot start — a failure no mock can
+    produce, because a mock has no environment to lose. It pins the other half
+    too: on a modern install the context window travels in the ENV, not the
+    argv, so a spawn that dropped it would come up health-green and then fail
+    every long request.
+    """
+    import shutil
+    import sys
+
+    # Named so resolve_lemonade classifies the override as MODERN — the form
+    # whose ctx_size rides in the environment. The binary is just a Python
+    # interpreter; only the env is under test, so the argv is redirected to the
+    # probe script below while spec.env is left exactly as the launcher built it.
+    fake_server = tmp_path / ("lemonade.exe" if os.name == "nt" else "lemond")
+    shutil.copy(sys.executable, fake_server)
+
+    out = tmp_path / "child-env.txt"
+    probe = tmp_path / "probe.py"
+    probe.write_text(_PROBE_SCRIPT, encoding="utf-8")
+
+    # LEMONADE_SERVER_PATH is resolve_lemonade's documented override, so the
+    # tooling and the StartSpec below are the real ones.
+    monkeypatch.setenv("LEMONADE_SERVER_PATH", str(fake_server))
+    monkeypatch.setenv("GAIA_PARENT_MARKER", "inherited")
+
+    real_build = sup.build_start_command
+
+    def redirect_argv_keep_env(tooling, ctx_size):
+        spec = real_build(tooling, ctx_size)
+        assert spec.env.get("LEMONADE_CTX_SIZE") == str(ctx_size), (
+            "the launcher did not put the context window in the environment, so "
+            "this test would pass for the wrong reason"
+        )
+        spec.argv[1:] = [str(probe), str(out)]
+        return spec
+
+    monkeypatch.setattr(sup, "build_start_command", redirect_argv_keep_env)
+
+    s = _supervisor(tmp_path, client, monkeypatch)
+    with pytest.raises(LemonadeStartError):
+        # The child is a script, not a server, so health never comes up. The
+        # spawn is what is under test; the failure after it is expected.
+        s.ensure_running(ctx_size=65536, timeout=3.0)
+
+    written = out.read_text(encoding="utf-8")
+    assert "CTX=65536" in written, "the context window never reached the child"
+    assert "MARKER=inherited" in written, (
+        "the child did not inherit the parent environment — a bare env=spec.env "
+        "would break LemonadeServer.exe in exactly this way"
+    )

--- a/tui/internal/ui/chat/claudemodel_test.go
+++ b/tui/internal/ui/chat/claudemodel_test.go
@@ -198,9 +198,13 @@ func TestLocalSwitchWithLemonadeDownIsRefusedActionably(t *testing.T) {
 	for _, must := range []string{
 		"Lemonade",               // what is wrong
 		"http://localhost:13305", // where
-		"lemonade-server serve",  // how to fix it
-		"stay on Claude",         // the other way forward
-		"Nothing was switched",   // what did NOT happen
+		// How to fix it — a command that exists on every machine, NOT a launch
+		// command. `lemonade-server serve` was pinned here, and Lemonade 10.7
+		// removed it, so this assertion kept a dead remedy looking verified
+		// (CLAUDE.md, "Never hardcode how Lemonade is started").
+		"gaia daemon status",
+		"stay on Claude",       // the other way forward
+		"Nothing was switched", // what did NOT happen
 	} {
 		if !strings.Contains(last.Content, must) {
 			t.Errorf("refusal must mention %q: %q", must, last.Content)

--- a/tui/internal/ui/chat/modelcmd.go
+++ b/tui/internal/ui/chat/modelcmd.go
@@ -102,10 +102,18 @@ func (m ChatModel) refuseModelSwitch(arg string) string {
 		if where == "" {
 			where = "its configured address"
 		}
+		// No launch command here. `lemonade-server serve` was dropped in
+		// Lemonade 10.7 and the surviving forms differ per machine, so any
+		// literal is wrong for someone (CLAUDE.md, "Never hardcode how
+		// Lemonade is started"). The daemon owns the server now, so the real
+		// next step is the background service — and `gaia daemon status`
+		// exists on every machine, which is exactly the property the dead
+		// command lacked.
 		return "Cannot switch to local model `" + arg +
 			"`: the Lemonade server was not reachable at " + where + ". " +
-			"Start it with `lemonade-server serve`, or with /setup, and send this " +
-			"again — the retry re-checks. " + m.remoteAlternative() +
+			"GAIA normally starts it for you — check the background service with " +
+			"`gaia daemon status`, or use /setup, then send this again — the " +
+			"retry re-checks. " + m.remoteAlternative() +
 			" Nothing was switched — this session is still on " +
 			m.currentModelName() + "."
 	}

--- a/tui/internal/ui/preflight/autostart_test.go
+++ b/tui/internal/ui/preflight/autostart_test.go
@@ -1,0 +1,287 @@
+package preflight
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/amd/gaia/tui/internal/daemon"
+)
+
+// What this file protects.
+//
+// A local model server that is not running used to end the launch: the gate
+// named a command and stopped. GAIA ships that server and manages it, so the
+// gate now asks the DAEMON to start it and answers the same question again.
+//
+// The three things that can go wrong, and each has a test below:
+//
+//   - it never fires, and the user is back to typing a command;
+//   - it fires when it should not — on a server that is already up (startup
+//     latency for everyone) or on one that lives on another machine (starting
+//     a server here that nothing will talk to);
+//   - it fires, fails, and the row says something useless. The daemon's own
+//     refusal text is the most specific thing in the system about WHICH
+//     failure it was, so it has to survive to the screen.
+
+// initUnreachableLocal is the down answer with a LOOPBACK base URL — the one
+// state GAIA repairs itself. The shared initUnreachable fixture is loopback
+// too; this restates it locally so a change to that fixture cannot silently
+// turn these tests into a different scenario.
+const initUnreachableLocal = `{"ready":false,"lemonade":{"reachable":false,` +
+	`"base_url":"http://localhost:13305/api/v1","version":null,"min_version":"8.1.0",` +
+	`"compatible":null},"model":{"id":"Gemma-4-E4B-it-GGUF","present":false,"loadable":null,` +
+	`"ctx_size":null},"hint":"Local Lemonade Server is not reachable."}`
+
+// initUnreachableRemote points the agent at another machine.
+const initUnreachableRemote = `{"ready":false,"lemonade":{"reachable":false,` +
+	`"base_url":"http://192.168.1.50:13305/api/v1","version":null,"min_version":"8.1.0",` +
+	`"compatible":null},"model":{"id":"Gemma-4-E4B-it-GGUF","present":false,"loadable":null,` +
+	`"ctx_size":null},"hint":"Lemonade Server is not reachable."}`
+
+func lemonadeRow(t *testing.T, rep Report) Row {
+	t.Helper()
+	for _, row := range rep.Rows {
+		if row.Key == KeyLemonade {
+			return row
+		}
+	}
+	t.Fatalf("no Local AI row in the report")
+	return Row{}
+}
+
+// --- it fires, and a successful start takes the row green ---------------------
+
+func TestADownLocalServerIsStartedWithoutTheUserTypingAnything(t *testing.T) {
+	f := newFake().with("GET /v1/email/init", 503, initUnreachableLocal)
+	// A real start makes the next /init answer differently. Without this the
+	// test would prove only that a POST happened, not that it repaired anything.
+	f.startLemonadeFn = func(context.Context) error {
+		f.with("GET /v1/email/init", 200, initReady)
+		return nil
+	}
+
+	rep := Check(context.Background(), f, EmailConfig())
+
+	if !f.called(http.MethodPost, daemon.APIPrefix+"/lemonade/start") {
+		t.Fatalf("the gate never asked the daemon to start the local model server")
+	}
+	if got := lemonadeRow(t, rep).State; got != StateOK {
+		t.Errorf("Local AI = %v after a successful start, want StateOK", got)
+	}
+	if !rep.Ready() {
+		t.Errorf("report not ready after the server was started:\n%+v", rep.Rows)
+	}
+}
+
+// --- it does not fire when there is nothing to fix ---------------------------
+
+func TestAReachableServerIsNeverStarted(t *testing.T) {
+	// The latency guarantee: the common case must cost the probes it already
+	// cost, and no more.
+	f := newFake()
+
+	Check(context.Background(), f, EmailConfig())
+
+	if f.called(http.MethodPost, daemon.APIPrefix+"/lemonade/start") {
+		t.Errorf("started a model server that was already running")
+	}
+}
+
+func TestARemoteServerIsNeverStartedHere(t *testing.T) {
+	// Starting a server on THIS machine would not be used by an agent pointed
+	// at another one — so the honest answer stays "start it over there".
+	f := newFake().with("GET /v1/email/init", 503, initUnreachableRemote)
+
+	rep := Check(context.Background(), f, EmailConfig())
+
+	if f.called(http.MethodPost, daemon.APIPrefix+"/lemonade/start") {
+		t.Fatalf("tried to start a local server for a remote base URL")
+	}
+	row := lemonadeRow(t, rep)
+	if row.State != StateFailed || !strings.Contains(row.Detail, "another machine") {
+		t.Errorf("remote row did not say the server lives elsewhere: %+v", row)
+	}
+}
+
+// --- it fires at most once ---------------------------------------------------
+
+func TestTheStartIsAttemptedOnlyOnce(t *testing.T) {
+	// A second attempt re-waits the full start budget to reach the same answer.
+	// Every failure the starter reports is one a retry cannot change.
+	f := newFake().with("GET /v1/email/init", 503, initUnreachableLocal)
+
+	Check(context.Background(), f, EmailConfig())
+
+	starts := 0
+	for _, c := range f.calls {
+		if c.method == http.MethodPost && c.path == daemon.APIPrefix+"/lemonade/start" {
+			starts++
+		}
+	}
+	if starts != 1 {
+		t.Errorf("asked the daemon to start the server %d times, want exactly 1", starts)
+	}
+}
+
+// --- when it fails, the reason has to reach the screen ------------------------
+
+func TestARefusedStartShowsTheDaemonsOwnReason(t *testing.T) {
+	// The daemon knows whether the port was held by a stranger, whether the
+	// server died on launch, or whether there was nothing to launch. "Start it"
+	// is the wrong remedy for two of those three, so its text is what shows.
+	const detail = "Port 13305 on localhost is in use by a process that does not answer " +
+		"Lemonade's health endpoint, so GAIA will not start a server there."
+	f := newFake().with("GET /v1/email/init", 503, initUnreachableLocal)
+	f.startLemonadeErr = &LemonadeStartRefused{Status: http.StatusServiceUnavailable, Detail: detail}
+
+	rep := Check(context.Background(), f, EmailConfig())
+
+	row := lemonadeRow(t, rep)
+	if row.State != StateFailed {
+		t.Fatalf("Local AI = %v after a refused start, want StateFailed", row.State)
+	}
+	if !strings.Contains(row.Remedy.Action, "in use by a process") {
+		t.Errorf("the daemon's reason did not reach the row:\n  detail: %q\n  remedy: %q",
+			row.Detail, row.Remedy.Action)
+	}
+	if row.Fix != FixNone {
+		t.Errorf("offered a one-key fix for something that just failed: %v", row.Fix)
+	}
+}
+
+func TestADaemonTooOldToStartLemonadeSaysSoRatherThanBlamingTheAgent(t *testing.T) {
+	// A 404 on this route is a version skew. The generic 404 branch of the
+	// ladder reads it as "the agent is not installed" — a wrong subject and a
+	// wrong fix.
+	f := newFake().with("GET /v1/email/init", 503, initUnreachableLocal)
+	f.startLemonadeErr = &LemonadeStartRefused{Status: http.StatusNotFound}
+
+	rep := Check(context.Background(), f, EmailConfig())
+
+	row := lemonadeRow(t, rep)
+	if !strings.Contains(row.Detail, "older than this app") {
+		t.Errorf("a too-old core was not named as such: %q", row.Detail)
+	}
+	if row.Remedy.Action == "" {
+		t.Errorf("no fallback remedy for a core that cannot start the server")
+	}
+}
+
+func TestAnUnreachableDaemonIsDiagnosedAsTheDaemonNotAsLemonade(t *testing.T) {
+	// The POST never reached the daemon, so the daemon is the subject. Saying
+	// "start Lemonade" here sends the user at the wrong process.
+	f := newFake().with("GET /v1/email/init", 503, initUnreachableLocal)
+	f.startLemonadeErr = &daemon.RequestError{
+		Op: "call POST /daemon/v1/lemonade/start", Detail: "connection refused",
+	}
+
+	rep := Check(context.Background(), f, EmailConfig())
+
+	row := lemonadeRow(t, rep)
+	if !strings.Contains(strings.ToLower(row.Detail), "background service") {
+		t.Errorf("an unreachable daemon was blamed on Lemonade: %q", row.Detail)
+	}
+}
+
+// --- the transport's own mapping ---------------------------------------------
+
+func TestStartLemonadeMapsTheDaemonsAnswers(t *testing.T) {
+	tests := []struct {
+		name       string
+		status     int
+		body       string
+		wantErr    bool
+		wantDetail string
+		wantTooOld bool
+	}{
+		{
+			name:   "200 means a server is running afterwards",
+			status: 200,
+			body:   `{"status":"started","base_url":"http://localhost:13305/api/v1"}`,
+		},
+		{
+			name:       "503 carries the actionable detail verbatim",
+			status:     503,
+			body:       `{"detail":"Lemonade Server is not installed. Run ` + "`gaia init`" + `."}`,
+			wantErr:    true,
+			wantDetail: "not installed",
+		},
+		{
+			name:       "404 is a version skew, not a missing agent",
+			status:     404,
+			body:       `{"detail":"Not Found"}`,
+			wantErr:    true,
+			wantTooOld: true,
+		},
+		{
+			name:       "a non-JSON body is still shown rather than swallowed",
+			status:     500,
+			body:       "upstream exploded",
+			wantErr:    true,
+			wantDetail: "upstream exploded",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := lemonadeStartResult(Response{Status: tt.status, Body: []byte(tt.body)})
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("err = %v, wantErr = %v", err, tt.wantErr)
+			}
+			if !tt.wantErr {
+				return
+			}
+			var refused *LemonadeStartRefused
+			if !errors.As(err, &refused) {
+				t.Fatalf("err = %T, want *LemonadeStartRefused", err)
+			}
+			if refused.TooOldToStartLemonade() != tt.wantTooOld {
+				t.Errorf("TooOldToStartLemonade() = %v, want %v",
+					refused.TooOldToStartLemonade(), tt.wantTooOld)
+			}
+			if tt.wantDetail != "" && !strings.Contains(err.Error(), tt.wantDetail) {
+				t.Errorf("error = %q, want it to contain %q", err, tt.wantDetail)
+			}
+		})
+	}
+}
+
+// A refusal with no body at all must still read as an error a human can act on,
+// not as an empty line.
+func TestARefusalWithNoBodyStillSaysSomething(t *testing.T) {
+	err := lemonadeStartResult(Response{Status: 502})
+	if err == nil || !strings.Contains(err.Error(), "502") {
+		t.Errorf("bodiless refusal = %v, want it to name the status", err)
+	}
+}
+
+// TestTheStartCallOutlastsTheDaemonsOwnStartBudget guards the bug that would
+// silently undo this whole feature on the machines that need it most.
+//
+// The daemon's route BLOCKS until the model server answers health, for up to
+// lemonade_supervisor.DEFAULT_START_TIMEOUT_S (120s). The TUI's default request
+// timeout is 60s. Sending this call down the default path would therefore abort
+// a cold start that was about to succeed, and the failure arrives as a
+// transport error — so the row blames the background service, which is healthy,
+// and the user is back to being told to start a server by hand.
+//
+// A cold start on the development machine measured ~6s, which is exactly why
+// this has to be reasoned about rather than observed: a fast box never trips it.
+func TestTheStartCallOutlastsTheDaemonsOwnStartBudget(t *testing.T) {
+	const daemonStartBudget = 120 * time.Second
+	if lemonadeStartHeaderTimeout <= daemonStartBudget {
+		t.Errorf("the start call waits %s but the daemon may take %s — a slow "+
+			"cold start would be aborted and then misdiagnosed",
+			lemonadeStartHeaderTimeout, daemonStartBudget)
+	}
+	// The gate's overall deadline has to cover the call it makes, or the same
+	// abort happens one level up.
+	if checkTimeout <= lemonadeStartHeaderTimeout {
+		t.Errorf("checkTimeout %s does not cover the start call's %s",
+			checkTimeout, lemonadeStartHeaderTimeout)
+	}
+}

--- a/tui/internal/ui/preflight/check.go
+++ b/tui/internal/ui/preflight/check.go
@@ -473,7 +473,71 @@ func (b initBody) hint() string {
 	return *b.Hint
 }
 
+// checkInit answers the Local AI and AI model rows, starting the local model
+// server first if it is down.
+//
+// GAIA ships with a model server and manages it, so "Lemonade is not running"
+// is not a question to put to the user — it is a thing to fix. The start is
+// asked of the DAEMON (see Transport.StartLemonade): this process never spawns
+// a server and never shells out to the Python CLI, and routing every front-end
+// through the one custody process is what stops two launches racing into two
+// servers fighting over the port.
+//
+// It is attempted exactly once. A second attempt after a genuine failure would
+// re-wait the full start budget to reach the same answer, and every failure the
+// starter reports (not installed, port held by a stranger, the server died) is
+// one that a retry cannot change.
 func checkInit(ctx context.Context, t Transport, cfg Config, rep *Report) State {
+	state, startable := probeInit(ctx, t, cfg, rep)
+	if !startable {
+		return state
+	}
+	if !autoStartLemonade(ctx, t, cfg, rep) {
+		return StateFailed
+	}
+	state, _ = probeInit(ctx, t, cfg, rep)
+	return state
+}
+
+// autoStartLemonade asks the daemon to start the server and reports whether a
+// re-probe is worth doing. On failure it leaves the Local AI row saying that
+// GAIA tried, why it could not, and what the user can still do.
+func autoStartLemonade(ctx context.Context, t Transport, cfg Config, rep *Report) bool {
+	err := t.StartLemonade(ctx)
+	if err == nil {
+		return true
+	}
+
+	row := Row{Key: KeyLemonade, State: StateFailed, Disposition: status.DispositionHalt}
+	row.Line = "not running — GAIA could not start it"
+	row.Raw = err.Error()
+	row.Fix = FixNone
+
+	var refused *LemonadeStartRefused
+	switch {
+	case !errors.As(err, &refused):
+		// The POST never reached the daemon, so the daemon is the subject — not
+		// Lemonade. Diagnosing this as "start Lemonade" would name the wrong fix.
+		d := Ladder{AgentID: cfg.AgentID}.Error("ask the background service to start the local AI", err)
+		row.Line = "cannot be started"
+		row.Detail = d.Cause
+		row.Remedy = d.AsRemedy()
+	case refused.TooOldToStartLemonade():
+		row.Detail = "The installed GAIA core is older than this app and cannot start the " +
+			"local model server for you. Upgrading it makes every launch do this automatically."
+		row.Remedy = lemonadeStartRemedy()
+	default:
+		row.Detail = "GAIA tried to start the local model server and could not."
+		row.Remedy = lemonadeAutoStartFailedRemedy(refused.Detail)
+	}
+	setRow(rep, row)
+	return false
+}
+
+// probeInit runs GET /v1/<agent>/init and fills both rows from the answer. The
+// second return is true only for the one failure GAIA can repair itself: a
+// local model server that is not running.
+func probeInit(ctx context.Context, t Transport, cfg Config, rep *Report) (State, bool) {
 	l := Ladder{AgentID: cfg.AgentID}
 	lemonade := Row{Key: KeyLemonade}
 	model := Row{Key: KeyModel}
@@ -489,7 +553,7 @@ func checkInit(ctx context.Context, t Transport, cfg Config, rep *Report) State 
 			StateFailed, "cannot be checked", d.Cause, d.AsRemedy(), err.Error()
 		lemonade.Disposition = status.DispositionHalt
 		setRow(rep, lemonade)
-		return StateFailed
+		return StateFailed, false
 	}
 	raw := string(resp.Body)
 	lemonade.Raw, model.Raw = raw, raw
@@ -502,7 +566,7 @@ func checkInit(ctx context.Context, t Transport, cfg Config, rep *Report) State 
 			StateFailed, "cannot be checked", d.Cause, d.AsRemedy()
 		lemonade.Disposition = status.DispositionHalt
 		setRow(rep, lemonade)
-		return StateFailed
+		return StateFailed, false
 	}
 
 	// Whatever happens below, the model row keeps the body it was probed with —
@@ -528,7 +592,7 @@ func checkInit(ctx context.Context, t Transport, cfg Config, rep *Report) State 
 			StateFailed, "cannot be checked", d.Cause, d.AsRemedy()
 		lemonade.Disposition = status.DispositionHalt
 		setRow(rep, lemonade)
-		return StateFailed
+		return StateFailed, false
 	}
 
 	// --- Local AI ---------------------------------------------------------
@@ -540,9 +604,13 @@ func checkInit(ctx context.Context, t Transport, cfg Config, rep *Report) State 
 		lemonade.Line = "not running at " + body.Lemonade.BaseURL
 		lemonade.Detail = "GAIA needs a local model server. It runs on your machine; no message text ever leaves it."
 		lemonade.Remedy = d.AsRemedy()
+		// Nothing on this row is a one-KEY fix: the caller starts the server
+		// automatically before the user ever sees it, and once that has failed
+		// pressing f would only repeat it.
+		lemonade.Fix = FixNone
 		if !isLoopback(body.Lemonade.BaseURL) {
-			// The agent is pointed at another machine, so a launcher resolved
-			// against THIS one starts a server nothing will talk to.
+			// The agent is pointed at another machine, so a server started here
+			// is one nothing would talk to. Not startable — by us or the daemon.
 			lemonade.Detail = fmt.Sprintf(
 				"The %s agent is configured to use a model server on another machine (%s), "+
 					"so it has to be started there — starting one here would not be used.",
@@ -553,12 +621,14 @@ func checkInit(ctx context.Context, t Transport, cfg Config, rep *Report) State 
 				Command: "gaia init",
 				Where:   lemonadeDocs,
 			}
+			setRow(rep, lemonade)
+			return StateFailed, false
 		}
-		// The sidecar cannot install or launch Lemonade — that is a host
-		// prerequisite — so there is no honest one-key fix here.
-		lemonade.Fix = FixNone
+		// A LOCAL server that is simply down — the one failure GAIA repairs
+		// itself. The row is filled in anyway: if the daemon cannot start it,
+		// this manually-resolved remedy is what the user falls back to.
 		setRow(rep, lemonade)
-		return StateFailed
+		return StateFailed, true
 
 	case modelListUnreadable(body):
 		// Reachable, but its model list could not be read: `present:false` here
@@ -572,7 +642,7 @@ func checkInit(ctx context.Context, t Transport, cfg Config, rep *Report) State 
 		lemonade.Detail = body.hint()
 		lemonade.Remedy = lemonadeRestartRemedy()
 		setRow(rep, lemonade)
-		return StateFailed
+		return StateFailed, false
 
 	case body.Lemonade.Compatible != nil && !*body.Lemonade.Compatible:
 		lemonade.State = StateFailed
@@ -588,7 +658,7 @@ func checkInit(ctx context.Context, t Transport, cfg Config, rep *Report) State 
 			Where:   "https://lemonade-server.ai",
 		}
 		setRow(rep, lemonade)
-		return StateFailed
+		return StateFailed, false
 
 	case body.Lemonade.Compatible == nil:
 		// Reachable, but it did not say which version it is. Indeterminate is
@@ -634,7 +704,7 @@ func checkInit(ctx context.Context, t Transport, cfg Config, rep *Report) State 
 			Where:   "https://amd-gaia.ai/docs/guides/install",
 		}
 		setRow(rep, model)
-		return StateFailed
+		return StateFailed, false
 	}
 
 	model.State = StateOK
@@ -651,7 +721,7 @@ func checkInit(ctx context.Context, t Transport, cfg Config, rep *Report) State 
 		model.Line += fmt.Sprintf(" · %s context", humanCtx(*body.Model.CtxSize))
 	}
 	setRow(rep, model)
-	return model.State
+	return model.State, false
 }
 
 // markCtxShortfall reports a model loaded into a smaller context window than this

--- a/tui/internal/ui/preflight/check_test.go
+++ b/tui/internal/ui/preflight/check_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"net/http"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -239,6 +240,10 @@ type fakeTransport struct {
 	// the screen's context really reaches it.
 	ensureFn func(context.Context) error
 
+	// How the daemon answers "start the local model server".
+	startLemonadeErr error
+	startLemonadeFn  func(context.Context) error
+
 	calls []call
 }
 
@@ -281,6 +286,19 @@ func (f *fakeTransport) EnsureAgent(ctx context.Context, _ string) error {
 		return f.ensureFn(ctx)
 	}
 	return f.ensureErr
+}
+
+// StartLemonade defaults to succeeding WITHOUT changing the /init answer, which
+// is the realistic shape of "the daemon started a server and the agent still
+// cannot use it" — and keeps every pre-existing expectation about the down-row's
+// wording intact. A test that wants the repaired path sets startLemonadeFn to
+// rewrite the body the way a real start would.
+func (f *fakeTransport) StartLemonade(ctx context.Context) error {
+	f.calls = append(f.calls, call{http.MethodPost, daemon.APIPrefix + "/lemonade/start"})
+	if f.startLemonadeFn != nil {
+		return f.startLemonadeFn(ctx)
+	}
+	return f.startLemonadeErr
 }
 
 func (f *fakeTransport) Do(_ context.Context, method, path string, _ []byte) (Response, error) {

--- a/tui/internal/ui/preflight/check_test.go
+++ b/tui/internal/ui/preflight/check_test.go
@@ -65,7 +65,8 @@ const (
 		`"base_url":"http://localhost:8000/api/v1","version":null,"min_version":"8.1.0",` +
 		`"compatible":null},"model":{"id":"Gemma-4-E4B-it-GGUF","present":false,"loadable":null,` +
 		`"ctx_size":null},"hint":"Local Lemonade Server is not reachable at ` +
-		"http://localhost:8000/api/v1 — start it with `lemonade-server serve` (or run `gaia init`), then retry.\"}"
+		"http://localhost:8000/api/v1. GAIA starts it automatically — run `gaia daemon start` " +
+		"if the background service is not running.\"}"
 
 	initTooOld = `{"ready":false,"lemonade":{"reachable":true,` +
 		`"base_url":"http://localhost:8000/api/v1","version":"8.0.1","min_version":"8.1.0",` +

--- a/tui/internal/ui/preflight/lemonade.go
+++ b/tui/internal/ui/preflight/lemonade.go
@@ -434,6 +434,35 @@ func lemonadeStartRemedy() Remedy {
 	}
 }
 
+// lemonadeAutoStartFailedRemedy is what to do after GAIA has ALREADY tried to
+// start the server and the daemon refused.
+//
+// The daemon's own message is kept as the action rather than replaced, because
+// it is strictly more specific than anything resolvable from here: it knows
+// whether the port was held by a stranger, whether the server died on launch,
+// or whether there was nothing to launch. "Start it" is the wrong remedy for
+// two of those three.
+//
+// A command is attached only when the machine has no Lemonade at all — there
+// the next step really is the installer, and it is the same one the never-tried
+// remedy names. Where a server IS installed, the refusal text carries its own
+// next step and adding a start command on top would contradict it.
+func lemonadeAutoStartFailedRemedy(detail string) Remedy {
+	if strings.TrimSpace(detail) == "" {
+		// The daemon said nothing usable, so fall back to the resolved advice
+		// rather than showing an empty row.
+		return lemonadeStartRemedy()
+	}
+	if l := resolveLemonade(); !l.Found {
+		return Remedy{
+			Action:  detail,
+			Command: "gaia init",
+			Where:   "https://amd-gaia.ai/docs/guides/install",
+		}
+	}
+	return Remedy{Action: detail, Where: lemonadeDocs}
+}
+
 // lemonadeRestartRemedy is what to do about one that is up but not answering
 // properly.
 func lemonadeRestartRemedy() Remedy {

--- a/tui/internal/ui/preflight/model.go
+++ b/tui/internal/ui/preflight/model.go
@@ -28,7 +28,14 @@ type ConnectMailboxMsg struct {
 // Timeouts for the work the screen kicks off. Each is bounded so a wedged
 // daemon or sidecar surfaces as an actionable row instead of a frozen screen.
 const (
-	checkTimeout     = 90 * time.Second
+	// checkTimeout has to cover the one thing the walk DOES rather than merely
+	// probes: starting the local model server when it is down (checkInit ->
+	// autoStartLemonade). The starter's own budget is 120s
+	// (lemonade_supervisor.DEFAULT_START_TIMEOUT_S), so a client deadline under
+	// that would abort a start that was about to succeed and then report the
+	// wrong cause. It costs the common path nothing — a deadline is a ceiling,
+	// and an all-green walk still finishes in well under a second.
+	checkTimeout     = 210 * time.Second
 	startTimeout     = 60 * time.Second
 	ensureTimeout    = 15 * time.Minute
 	provisionTimeout = 60 * time.Minute

--- a/tui/internal/ui/preflight/transport.go
+++ b/tui/internal/ui/preflight/transport.go
@@ -2,8 +2,11 @@ package preflight
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
+	"strings"
 	"sync"
 	"time"
 
@@ -43,6 +46,15 @@ type Transport interface {
 	Start(ctx context.Context) (DaemonInfo, error)
 	// EnsureAgent asks the daemon to spawn-or-attach the agent's sidecar.
 	EnsureAgent(ctx context.Context, agentID string) error
+	// StartLemonade asks the daemon to start the local model server, blocking
+	// until it answers or the attempt fails. It returns nil when a server is
+	// running afterwards — including one that was already up.
+	//
+	// The DAEMON does this, not the TUI: this process must not spawn Lemonade
+	// itself (the daemon is the machine's single custody process, and two
+	// front-ends launching at once would otherwise race into two servers), and
+	// it must not shell out to the Python `gaia` CLI.
+	StartLemonade(ctx context.Context) error
 	// Do issues an authenticated request against the daemon's control plane
 	// ("/daemon/v1/...") or its agent relay ("/v1/<agent>/...").
 	Do(ctx context.Context, method, path string, body []byte) (Response, error)
@@ -139,6 +151,91 @@ func (t *daemonTransport) EnsureAgent(ctx context.Context, agentID string) error
 	}
 	t.set(inst)
 	return nil
+}
+
+// LemonadeStartRefused is the daemon answering that it could not start the
+// local model server. Detail is the daemon's own message, which already names
+// what failed, what to do and where to look — so it is shown as the remedy
+// rather than replaced with wording invented here.
+type LemonadeStartRefused struct {
+	Status int
+	Detail string
+}
+
+func (e *LemonadeStartRefused) Error() string {
+	if e.Detail == "" {
+		return fmt.Sprintf("the background service refused to start the local model server (HTTP %d)", e.Status)
+	}
+	return e.Detail
+}
+
+// TooOldToStartLemonade reports whether the running daemon predates the start
+// verb. A 404 here is a version skew, not a missing agent — the routes are
+// mounted unconditionally from host API 1.2 on.
+func (e *LemonadeStartRefused) TooOldToStartLemonade() bool {
+	return e.Status == http.StatusNotFound
+}
+
+// lemonadeStartPath is the daemon verb, mounted from host API 1.2 on.
+const lemonadeStartPath = daemon.APIPrefix + "/lemonade/start"
+
+// lemonadeStartHeaderTimeout is how long to wait for the daemon to ANSWER the
+// start request. It must exceed the daemon's own start budget
+// (lemonade_supervisor.DEFAULT_START_TIMEOUT_S, 120s) — the route blocks until
+// the server answers health, so a client deadline under that aborts a start
+// that was seconds from succeeding and then reports the wrong cause: the error
+// surfaces as a transport failure and the row blames the background service.
+//
+// The default client timeout is 60s (daemon.defaultRequestTimeout), which is
+// exactly that bug, so this call must NOT use it.
+const lemonadeStartHeaderTimeout = 150 * time.Second
+
+func (t *daemonTransport) StartLemonade(ctx context.Context) error {
+	// An empty JSON object, not a nil body: the daemon defaults ctx_size to
+	// this machine's device profile, and inventing a window here would let the
+	// TUI and the Python disagree about how big a request the server can serve.
+	status, rc, err := t.do(
+		ctx,
+		http.MethodPost,
+		lemonadeStartPath,
+		"application/json",
+		[]byte("{}"),
+		daemon.StreamHTTPClient(streamConnectTimeout, lemonadeStartHeaderTimeout),
+	)
+	if err != nil {
+		return err
+	}
+	defer rc.Close()
+	body, rerr := io.ReadAll(io.LimitReader(rc, 1<<20))
+	if rerr != nil {
+		return &daemon.RequestError{
+			Op:     "read the answer to " + lemonadeStartPath,
+			Detail: rerr.Error(),
+		}
+	}
+	return lemonadeStartResult(Response{Status: status, Body: body})
+}
+
+// lemonadeStartResult maps the daemon's answer to an error, or nil when a
+// server is running afterwards. Split out from the call so the mapping is
+// testable without standing up a daemon.
+func lemonadeStartResult(resp Response) error {
+	if resp.Status == http.StatusOK {
+		return nil
+	}
+	return &LemonadeStartRefused{Status: resp.Status, Detail: detailOf(resp.Body)}
+}
+
+// detailOf pulls FastAPI's `detail` out of an error body, falling back to the
+// raw body so a non-JSON answer is still shown rather than swallowed.
+func detailOf(body []byte) string {
+	var payload struct {
+		Detail string `json:"detail"`
+	}
+	if err := json.Unmarshal(body, &payload); err == nil && strings.TrimSpace(payload.Detail) != "" {
+		return payload.Detail
+	}
+	return strings.TrimSpace(string(body))
 }
 
 // instance returns the verified instance, attaching first when this is the

--- a/tui/test/preflight_gate_test.go
+++ b/tui/test/preflight_gate_test.go
@@ -57,6 +57,14 @@ type gateTransport struct {
 	ensures  int
 	healths  int
 	searches int
+
+	// lemonadeStarts counts POST /daemon/v1/lemonade/start. lemonadeStartErr is
+	// what that call answers; onLemonadeStart lets a test repair initBody the
+	// way a real start would, so both "it fixed it" and "it did not" are
+	// reachable from the same fake.
+	lemonadeStarts   int
+	lemonadeStartErr error
+	onLemonadeStart  func(*gateTransport)
 }
 
 func readyGateTransport() *gateTransport {
@@ -118,6 +126,20 @@ func (g *gateTransport) Start(ctx context.Context) (preflight.DaemonInfo, error)
 func (g *gateTransport) EnsureAgent(context.Context, string) error {
 	g.ensures++
 	g.agentState = "running"
+	return nil
+}
+
+// StartLemonade records that the gate asked the daemon to start the local model
+// server, and reports success. lemonadeUp then decides what the next /init says,
+// so a test can model both "the start fixed it" and "it did not".
+func (g *gateTransport) StartLemonade(context.Context) error {
+	g.lemonadeStarts++
+	if g.lemonadeStartErr != nil {
+		return g.lemonadeStartErr
+	}
+	if g.onLemonadeStart != nil {
+		g.onLemonadeStart(g)
+	}
 	return nil
 }
 

--- a/uv.lock
+++ b/uv.lock
@@ -1,3 +1,3 @@
 version = 1
 revision = 3
-requires-python = ">=3.13"
+requires-python = ">=3.12"


### PR DESCRIPTION
GAIA needed you to run `lemonade-server serve` before anything worked — a command Lemonade removed in 10.7, so on any current install it fails with "command not found" and the user is left with no path forward. Now the daemon starts the local model server itself, supervises it as a child, and reaps it on shutdown. Launch the TUI, or run `gaia chat` / `gaia llm`, on a machine with nothing running: it comes up working, with nothing typed.

The daemon owning the process is what makes "one server per machine" real rather than a race that usually works. Front-ends ask over the authenticated loopback channel they already use (`POST /daemon/v1/lemonade/start`, host API 1.2); nothing else spawns a server. A server the daemon did *not* start — one launched from the tray — is attached to and left running, including when the daemon stops.

Failures stay loud: not installed, port held by something else, the server died on launch, the daemon unreachable — each names what failed, what to do, and where to look. Nothing degrades quietly to "no LLM".

<details>
<summary>🔍 Technical details</summary>

- `LemonadeSupervisor` (`src/gaia/llm/lemonade_supervisor.py`) probes, starts the server in its own process group, polls `/health`, and tree-kills on shutdown — tree-kill because Lemonade spawns `llama-server` children, and an orphan still holds the port and the GPU memory the next start needs. No new locking scheme: the daemon is already single-instance, so its in-process lock is the whole story.
- `ensure_lemonade_running` (`src/gaia/llm/lemonade_service.py`) is the one verb. Inside the daemon it uses the supervisor directly; everywhere else it start-or-attaches the daemon and asks.
- Launch resolution is unchanged and untouched: everything goes through `resolve_lemonade()` / `build_start_command()` and treats `StartSpec(argv, env)` as opaque. The embeddable `lemond ./ --port N` form (PR #3117) takes a working directory and port the others do not, so nothing here inspects or rebuilds argv — bundled-lemond support arrives behind the same seam for free.
- `LemonadeClient.health_check` gained an optional `timeout`. The client default (900s) is right for generation and catastrophic for a liveness probe: a socket that accepts and never answers would block one for 15 minutes.
- The stale-command sweep covers runtime messages (`readiness.py`, the email sidecar's `/init` and `/query`, the playground), hub agent docs, and ~45 doc-site pages. `--ctx-size` went with it — GAIA pins the window per device profile, so telling a user to set one is wrong advice that looks like it works.

Not in scope, worth a follow-up: `gaia init` still starts a server directly (`installer/init_command.py`), so it can leave an unsupervised one the daemon will attach to and never reap.
</details>

## Test plan

- [x] Cold start, nothing running: `gaia daemon stop && taskkill /F /IM LemonadeServer.exe && rm ~/.gaia/host/instance.json`, then `gaia llm "..."` — answers, having started the daemon and the server itself.
- [x] Cold start through the TUI's readiness gate: `gaia-tui run email --query "..."` from a stopped server — answers; daemon log shows `lemonade: starting supervised server` then `lemonade_routes.start`.
- [x] Go client against a live daemon: cold 9.8s, warm 26ms (one probe).
- [x] `gaia daemon stop` reaps the server it started; a tray-launched server survives it (`/daemon/v1/lemonade/status` reports `supervised: false`).
- [x] Daemon boot alone does not start a server — it is on demand.
- [x] `python -m pytest tests/unit/test_lemonade_{supervisor,service}.py tests/unit/test_daemon_lemonade_routes.py tests/unit/test_lemonade_manager_autostart.py` — 40 new tests pass.
- [x] `cd tui && go test ./...` — 3 failures, all reproduced on a stashed tree (`TestKeysDriveTheRightActions`, `TestHubCatalogLoadSurvivesTheChatView`, `TestASubprocessAgentIsNotGated`).
- [x] Wider Python suites match their pre-existing baseline exactly (40 failures, all reproduced with the branch stashed — Windows path assumptions and the unit-test socket guard blocking `TestClient`).
- [ ] Reviewer: `grep -rn "lemonade-server serve" docs/ src/ hub/` returns only comments explaining why the command is dead.
