### PR TITLE
fix(cpp): unblock the C++ gate — split the third-party skill corpus from the conformance one

### DIFF
--- a/.github/workflows/build_cpp.yml
+++ b/.github/workflows/build_cpp.yml
@@ -17,6 +17,11 @@ on:
       - '.github/actions/install-lemonade/**'
       - '.github/scripts/**'
       - 'cpp/**'
+      # test_skill.cpp discovers these corpora from disk, so adding a fixture
+      # can break the C++ build. Without them here the breaking PR never runs
+      # this workflow and main goes red on the next unrelated push (#2693).
+      - 'tests/fixtures/skills/**'
+      - 'tests/fixtures/*_skills/**'
       - '.github/workflows/build_cpp.yml'
       - '.github/workflows/benchmark_cpp.yml'
   pull_request:
@@ -27,6 +32,8 @@ on:
       - '.github/actions/install-lemonade/**'
       - '.github/scripts/**'
       - 'cpp/**'
+      - 'tests/fixtures/skills/**'
+      - 'tests/fixtures/*_skills/**'
       - '.github/workflows/build_cpp.yml'
       - '.github/workflows/benchmark_cpp.yml'
   merge_group:

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -474,10 +474,9 @@ if(GAIA_BUILD_TESTS)
 
     target_compile_definitions(tests_mock PRIVATE
         GAIA_TEST_FIXTURES_DIR="${CMAKE_CURRENT_SOURCE_DIR}/tests/fixtures"
-        # The SKILL.md conformance corpus is shared with the Python runtime and
-        # lives at the repo root. test_skill.cpp discovers the skills from the
-        # directory, so new corpora (e.g. openclaw_skills/) are picked up
-        # automatically instead of needing a hardcoded list here.
+        # The SKILL.md corpora are shared with the Python runtime and live at
+        # the repo root. test_skill.cpp discovers them from disk: skills/ must
+        # conform, <vendor>_skills/ are third-party inputs that need not.
         GAIA_REPO_FIXTURES_DIR="${CMAKE_CURRENT_SOURCE_DIR}/../tests/fixtures"
     )
     target_include_directories(tests_mock PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/tests)

--- a/cpp/tests/test_skill.cpp
+++ b/cpp/tests/test_skill.cpp
@@ -124,47 +124,52 @@ private:
 };
 
 // ---------------------------------------------------------------------------
-// Conformance corpus
+// Skill corpora
 //
-// Discovered from disk rather than hardcoded, so a new GAIA-authored corpus is
-// picked up without editing a list.
+// Two corpora sit under tests/fixtures/ with opposite contracts. Both are
+// discovered from disk, so a new fixture joins a suite without editing a list.
 //
-// A corpus carrying PROVENANCE.md is EXCLUDED. Those are verbatim third-party
-// skills kept byte-for-byte as migrator input, and their own PROVENANCE.md
-// says so: "including invalid or nonstandard frontmatter - that irregularity
-// is the point of the fixture." Holding them to the GAIA conformance contract
-// asserts the opposite of what they exist to prove, and the only way to make
-// them pass is to edit files that file forbids editing.
+//   skills/           GAIA-format conformance. Every file must parse,
+//                     validate, and round-trip.
+//   <vendor>_skills/  Real third-party SKILL.md files copied byte-for-byte from
+//                     published repos — malformed and nonstandard ones
+//                     included, on purpose (see their PROVENANCE.md). These are
+//                     migration *input*, not GAIA skills, so "it parses" is not
+//                     a property they have. What must hold is that the parser
+//                     reaches a verdict on every one of them.
 // ---------------------------------------------------------------------------
 
-bool isSkillCorpusDir(const std::string& name) {
+std::vector<std::string> skillsIn(const fs::path& corpus) {
+    std::vector<std::string> skills;
+    std::error_code ec;
+    for (const auto& skill : fs::directory_iterator(corpus, ec)) {
+        if (!skill.is_directory()) continue;
+        if (fs::exists(skill.path() / gaia::SKILL_FILENAME)) {
+            skills.push_back(skill.path().string());
+        }
+    }
+    std::sort(skills.begin(), skills.end());
+    return skills;
+}
+
+std::vector<std::string> discoverCorpus() {
+    return skillsIn(fs::path(GAIA_REPO_FIXTURES_DIR) / "skills");
+}
+
+bool isForeignCorpusDir(const std::string& name) {
     static const std::string kSuffix = "_skills";
-    if (name == "skills") return true;
     return name.size() > kSuffix.size() &&
            name.compare(name.size() - kSuffix.size(), kSuffix.size(), kSuffix) == 0;
 }
 
-// Verbatim third-party content, identified by the file that records where each
-// skill was fetched from.
-bool isVendorCorpus(const fs::path& corpus) {
-    std::error_code ec;
-    return fs::exists(corpus / "PROVENANCE.md", ec);
-}
-
-std::vector<std::string> discoverCorpus() {
+std::vector<std::string> discoverForeignCorpus() {
     std::vector<std::string> skills;
     std::error_code ec;
     const fs::path fixtures(GAIA_REPO_FIXTURES_DIR);
     for (const auto& corpus : fs::directory_iterator(fixtures, ec)) {
         if (!corpus.is_directory()) continue;
-        if (!isSkillCorpusDir(corpus.path().filename().string())) continue;
-        if (isVendorCorpus(corpus.path())) continue;
-        for (const auto& skill : fs::directory_iterator(corpus.path(), ec)) {
-            if (!skill.is_directory()) continue;
-            if (fs::exists(skill.path() / gaia::SKILL_FILENAME)) {
-                skills.push_back(skill.path().string());
-            }
-        }
+        if (!isForeignCorpusDir(corpus.path().filename().string())) continue;
+        for (auto& skill : skillsIn(corpus.path())) skills.push_back(std::move(skill));
     }
     std::sort(skills.begin(), skills.end());
     return skills;
@@ -410,7 +415,7 @@ TEST(SkillFailure, NullKeyIsRefusedRatherThanBecomingTheEmptyKey) {
 }
 
 // ---------------------------------------------------------------------------
-// Conformance corpus — every skill on disk parses and round-trips
+// Conformance corpus — every GAIA skill on disk parses and round-trips
 // ---------------------------------------------------------------------------
 
 class SkillCorpus : public ::testing::TestWithParam<std::string> {};
@@ -437,14 +442,76 @@ INSTANTIATE_TEST_SUITE_P(Fixtures, SkillCorpus, ::testing::ValuesIn(discoverCorp
 TEST(SkillCorpusDiscovery, FindsTheOnDiskCorpus) {
     // Guards the discovery itself: an empty corpus would make every
     // parameterized case above vacuously pass.
-    const auto skills = discoverCorpus();
-    EXPECT_GE(skills.size(), 6u);
-    // And guards the other direction: vendor fixtures are verbatim third-party
-    // migrator input whose nonstandard frontmatter is the point, so pulling
-    // them in asserts the opposite of what they exist to prove.
-    for (const auto& path : skills) {
-        EXPECT_EQ(path.find("openclaw_skills"), std::string::npos)
-            << path << " is vendor migrator input, not a GAIA-conformant skill";
+    EXPECT_GE(discoverCorpus().size(), 6u);
+}
+
+// ---------------------------------------------------------------------------
+// Third-party corpus — the parser reaches a verdict on real published skills
+//
+// Mirrors test_skills_migrate.py::test_real_openclaw_skill_migrates_or_reports_why:
+// a foreign SKILL.md either loads cleanly or is refused for a stated reason.
+// Anything else — a crash, or a half-parsed skill that silently drops what the
+// author declared — is the failure this suite exists to catch.
+// ---------------------------------------------------------------------------
+
+class ForeignSkillCorpus : public ::testing::TestWithParam<std::string> {};
+
+TEST_P(ForeignSkillCorpus, ParsesCleanlyOrRefusesActionably) {
+    // Directory-name enforcement is off: these fixtures are re-homed under
+    // disambiguating names (two upstreams each publish a `1password`), so the
+    // directory is ours and the frontmatter is theirs. They are allowed to
+    // differ here, and only here — SkillFailure.NameDirectoryMismatch covers
+    // the rule itself.
+    Skill skill;
+    try {
+        skill = gaia::parseSkillFile(GetParam(), "", false, /*checkDirectoryName=*/false);
+    } catch (const SkillValidationError& exc) {
+        const std::string message = exc.what();
+        EXPECT_THAT(message, HasSubstr(GetParam()));         // what failed, and where
+        EXPECT_THAT(message, HasSubstr(gaia::FORMAT_DOCS_URL));  // where to look next
+        return;
+    }
+    EXPECT_FALSE(skill.name.empty());
+    EXPECT_FALSE(skill.description.empty());
+    EXPECT_EQ(gaia::parseSkill(gaia::toMarkdown(skill)), skill);
+}
+
+INSTANTIATE_TEST_SUITE_P(Fixtures, ForeignSkillCorpus,
+                         ::testing::ValuesIn(discoverForeignCorpus()), corpusTestName);
+
+TEST(SkillCorpusDiscovery, FindsTheThirdPartyCorpus) {
+    // tests/fixtures/openclaw_skills/ ships 26; a checkout that lost them would
+    // make every case above vacuously pass.
+    EXPECT_GE(discoverForeignCorpus().size(), 10u);
+}
+
+TEST(SkillCorpusDiscovery, TheThirdPartyCorpusExercisesBothVerdicts) {
+    // "Reaches a verdict" is satisfied by refusing all 26, so pin the split:
+    // most real published skills must still load, and at least one must still
+    // be refused or the suite has stopped testing the refusal path. Mirrors
+    // test_skills_migrate.py, which likewise refuses to let the corpus drift
+    // into all-pass or all-fail.
+    size_t parsed = 0, refused = 0;
+    for (const std::string& path : discoverForeignCorpus()) {
+        try {
+            gaia::parseSkillFile(path, "", false, /*checkDirectoryName=*/false);
+            ++parsed;
+        } catch (const SkillValidationError&) {
+            ++refused;
+        }
+    }
+    EXPECT_GE(refused, 1u) << "corpus no longer exercises refusal — re-pin a fixture";
+    EXPECT_GT(parsed, 2 * refused) << "the parser regressed on real-world skills";
+}
+
+TEST(SkillCorpusDiscovery, TheTwoCorporaDoNotOverlap) {
+    // The conformance suite must never silently absorb third-party fixtures —
+    // that is what turned the gate red when the openclaw corpus landed.
+    const std::vector<std::string> gaiaSkills = discoverCorpus();
+    for (const std::string& foreign : discoverForeignCorpus()) {
+        EXPECT_EQ(std::find(gaiaSkills.begin(), gaiaSkills.end(), foreign),
+                  gaiaSkills.end())
+            << foreign << " is in both corpora";
     }
 }
 

--- a/docs/plans/cpp-framework-parity.md
+++ b/docs/plans/cpp-framework-parity.md
@@ -313,7 +313,7 @@ missing piece of research.
 |---|---|---|---|
 | `src/gaia/skills/sets.py` — `SkillRef`, `SkillSets`, `SkillSetResolution`, `SkillSetError` | **PR #2695** (`feat(email,skills): bundled skills + account-keyed skill-set selection`) | **P3.4** skill sets | P3.4 blocks. It is a port of that module, and porting a moving target produces two divergent implementations. Do not start P3.4 until #2695 merges. |
 | `workers/agent-hub/src/skill-manifest.ts` — a TypeScript reimplementation of the frontmatter validator | **PR #2668** (`feat(hub,skills): publish and serve skills as a first-class hub catalog lane`) | **P3.1** parser (as a template, not a dependency) | P3.1 proceeds regardless — it ports from `src/gaia/skills/format.py`, which *is* on `main`. #2668 is a convenience: a second-language port of the same validator, including its error wording and BOM/CRLF handling, is the closest prior art for a third. Use it if available. |
-| `tests/fixtures/openclaw_skills/` — 26 real ClawHub skills, commit-pinned with `PROVENANCE.md` | **PR #2693** (`feat(skills): gaia skill migrate`) | **P3.1** tests, **P5.2** CI gate | Both proceed against the 6-skill `tests/fixtures/skills/` corpus that is on `main`. When #2693 merges, extend the conformance gate to the full 32. P5.2 must not make a nonexistent path a required check. |
+| `tests/fixtures/openclaw_skills/` — 26 real ClawHub skills, commit-pinned with `PROVENANCE.md` | **PR #2693** (`feat(skills): gaia skill migrate`) | **P3.1** tests, **P5.2** CI gate | Both proceed against the 6-skill `tests/fixtures/skills/` corpus that is on `main`. Do **not** fold these 26 into the conformance gate when #2693 merges — they are migration input, invalid frontmatter included, so they belong in their own verdict-per-skill suite. P5.2 must not make a nonexistent path a required check. |
 
 **Consequence for wave scheduling:** P3.4 is gated on an external PR, not just on P3.1–P3.3.
 Everything else in Phase 3 is independent of these and can proceed immediately.
@@ -408,7 +408,10 @@ level-1 disclosure), `validateSkill`, `toMarkdown`. Constants ported **verbatim*
 ≤1024, SemVer 2.0.0, `0.0.0` reserved, tier enum defaulting to `experimental`, name must equal
 directory name, `compatibility`/`allowed-tools`/`disallowed-tools` parsed and deliberately
 ignored. BOM and CRLF tolerant. Tested against the 6-skill `tests/fixtures/skills/` corpus on
-`main`; extend to `tests/fixtures/openclaw_skills/` (26 more) once PR #2693 merges.
+`main`. `tests/fixtures/openclaw_skills/` (26 more, from PR #2693) is **not** conformance
+material: those files are third-party migration *input* and several are invalid by design.
+They get their own suite asserting the parser reaches a verdict on each — parses cleanly, or
+refuses with a message naming the file — never that all 32 parse.
 
 **P3.2 — Skill permissions**
 New `cpp/include/gaia/skill_permissions.h`. `<domain>:<level>[:scope]` parser (split on `:`, max


### PR DESCRIPTION
The C++ build has been red on `main` since 13 August, and it blocks every PR that touches `cpp/`, `src/gaia/version.py`, or the Lemonade install action — currently #3117, #3054 and #2931, none of which have anything to do with C++. All three fail with the identical 26 test failures. After this, the gate is green and they are unblocked.

Nothing was actually broken. #2824 added a corpus test that discovers skill fixtures from disk and asserts every one of them parses; #2693 then added 26 real third-party `SKILL.md` files that are invalid *on purpose* — three have no frontmatter at all, and their own `PROVENANCE.md` calls that irregularity the point of the fixture. #2693 does not touch `cpp/`, so it never ran this workflow, and the two PRs were only ever tested apart.

The two corpora have opposite contracts, so they now get separate suites. `tests/fixtures/skills/` stays a strict conformance gate. `tests/fixtures/openclaw_skills/` is migration *input*, so it asserts what the Python side already asserts in `test_skills_migrate.py`: every skill reaches a verdict — it loads cleanly and round-trips, or it is refused with a message naming the file and pointing at the format docs. That is a stronger claim than "it parses", not a weaker one, and no fixture was dropped or edited.

This closes the hole rather than quieting the symptom: `tests/fixtures/{skills,*_skills}/` now trigger the C++ workflow, so the PR that adds a fixture is the PR that finds out. The plan doc that said to "extend the conformance gate to the full 32" — the instruction that produced this bug — now says the opposite, and why.

## Test plan

- [ ] `C++ (ubuntu-latest)`, `C++ (windows-latest)` and `C++ Build Summary` green on this PR
- [ ] Full mock suite locally (MSVC 17.14, Release): 918 passed, 0 failed, 4 skipped — the same 4 the Windows runner skips
- [ ] `tests_mock --gtest_filter=*SkillCorpus*` → 44 passed, covering all 26 third-party fixtures and both verdicts
- [ ] Cross-checked against the Python parser: it refuses the identical 13 fixtures for the identical two reasons, so the C++/Python parity claim still holds
- [ ] Rebase #3117 on this and confirm its C++ checks go green