### PR TITLE
fix(skills): make skill tools work on the Claude provider

### DIFF
--- a/src/gaia/agents/base/agent.py
+++ b/src/gaia/agents/base/agent.py
@@ -3629,10 +3629,11 @@ Do NOT wrap conversational replies in JSON.
                 "error_displayed": True,
             }
 
-        # Normalize common model name-construction errors before registry lookup:
-        # strip trailing "()" some models append, and convert hyphens to underscores
-        # (tool names are always snake_case; hyphens are never valid).
-        tool_name = tool_name.removesuffix("()").replace("-", "_")
+        # Exact name first — skill tools register with a literal hyphen
+        # (``rss-digest/fetch_rss``); the normalization below is only a typo rescue.
+        tool_name = tool_name.removesuffix("()")
+        if tool_name not in self._tools_registry:
+            tool_name = tool_name.replace("-", "_")
 
         logger.debug(f"Executing tool {tool_name} with args: {tool_args}")
 

--- a/src/gaia/llm/providers/claude.py
+++ b/src/gaia/llm/providers/claude.py
@@ -10,6 +10,7 @@ so the agent loop's response parser works unchanged against either backend.
 import json
 import logging
 import os
+import re
 import time
 from typing import Any, Dict, Iterator, List, Optional, Union
 
@@ -206,26 +207,61 @@ class ClaudeProvider(LLMClient):
                 return candidate
         return DEFAULT_CLAUDE_MODEL
 
-    @staticmethod
-    def _to_anthropic_tools(tools: Optional[List[dict]]) -> Optional[List[dict]]:
+    #: Anthropic's tool-name contract. GAIA names can be wider — skill tools are
+    #: namespaced ``<skill>/<tool>`` and the ``/`` 400s the whole request — so
+    #: names are sanitized outbound and mapped back on returned tool_use blocks.
+    _TOOL_NAME_RE = re.compile(r"^[a-zA-Z0-9_-]{1,128}$")
+
+    def _api_tool_name(self, name: str) -> str:
+        if self._TOOL_NAME_RE.fullmatch(name):
+            return name
+        return re.sub(r"[^a-zA-Z0-9_-]", "_", name)[:128]
+
+    def _restore_tool_name(self, api_name: str) -> str:
+        mapping = getattr(self, "_tool_name_map", None)
+        if mapping is None or api_name not in mapping:
+            # Every outbound name is registered, so a miss means the map is
+            # stale — the agent would blame the model for "Unknown tool name".
+            logger.warning(
+                "Tool %r is not in the outbound name map; returning it "
+                "unmapped. Dispatch will fail if the name was sanitized.",
+                api_name,
+            )
+            return api_name
+        return mapping[api_name]
+
+    def _to_anthropic_tools(self, tools: Optional[List[dict]]) -> Optional[List[dict]]:
         """OpenAI ``{"type":"function","function":{...}}`` → Anthropic shape."""
+        self._tool_name_map: dict = {}
         if not tools:
             return None
         converted = []
         for tool in tools:
             fn = tool.get("function") if tool.get("type") == "function" else None
-            if fn is None:
-                # Already Anthropic-shaped (has name + input_schema) — pass through.
-                converted.append(tool)
-                continue
-            converted.append(
-                {
+            entry = (
+                dict(tool)  # already Anthropic-shaped (name + input_schema)
+                if fn is None
+                else {
                     "name": fn["name"],
                     "description": fn.get("description", ""),
                     "input_schema": fn.get("parameters")
                     or {"type": "object", "properties": {}},
                 }
             )
+            original = entry.get("name", "")
+            api_name = self._api_tool_name(original)
+            # Register identity names too: `write/file` sanitizes onto the
+            # builtin `write_file`, and only a full map can see that clash.
+            if api_name in self._tool_name_map:
+                clash = self._tool_name_map[api_name]
+                raise ValueError(
+                    f"Tool names {clash!r} and {original!r} both map to "
+                    f"{api_name!r} for the Anthropic API — the model's call "
+                    "could not be routed back unambiguously. Rename one."
+                )
+            self._tool_name_map[api_name] = original
+            entry["name"] = api_name
+            converted.append(entry)
         return converted
 
     def _split_system(self, messages: List[dict]) -> tuple:
@@ -361,7 +397,7 @@ class ClaudeProvider(LLMClient):
                         "id": block.id,
                         "type": "function",
                         "function": {
-                            "name": block.name,
+                            "name": self._restore_tool_name(block.name),
                             "arguments": json.dumps(block.input or {}),
                         },
                     }
@@ -412,7 +448,10 @@ class ClaudeProvider(LLMClient):
                         tool_slots[event.index] = {
                             "id": block.id,
                             "type": "function",
-                            "function": {"name": block.name, "arguments": ""},
+                            "function": {
+                                "name": self._restore_tool_name(block.name),
+                                "arguments": "",
+                            },
                         }
                 elif etype == "content_block_delta":
                     delta = event.delta

--- a/src/gaia/llm/providers/claude.py
+++ b/src/gaia/llm/providers/claude.py
@@ -192,6 +192,8 @@ class ClaudeProvider(LLMClient):
             )
         self._system_prompt = system_prompt
         self._last_usage: Optional[dict] = None
+        # Sanitized-name → GAIA-name; rebuilt per request by _to_anthropic_tools.
+        self._tool_name_map: Dict[str, str] = {}
 
     @property
     def provider_name(self) -> str:
@@ -218,8 +220,7 @@ class ClaudeProvider(LLMClient):
         return re.sub(r"[^a-zA-Z0-9_-]", "_", name)[:128]
 
     def _restore_tool_name(self, api_name: str) -> str:
-        mapping = getattr(self, "_tool_name_map", None)
-        if mapping is None or api_name not in mapping:
+        if api_name not in self._tool_name_map:
             # Every outbound name is registered, so a miss means the map is
             # stale — the agent would blame the model for "Unknown tool name".
             logger.warning(
@@ -228,11 +229,11 @@ class ClaudeProvider(LLMClient):
                 api_name,
             )
             return api_name
-        return mapping[api_name]
+        return self._tool_name_map[api_name]
 
     def _to_anthropic_tools(self, tools: Optional[List[dict]]) -> Optional[List[dict]]:
         """OpenAI ``{"type":"function","function":{...}}`` → Anthropic shape."""
-        self._tool_name_map: dict = {}
+        self._tool_name_map = {}
         if not tools:
             return None
         converted = []

--- a/src/gaia/llm/providers/claude.py
+++ b/src/gaia/llm/providers/claude.py
@@ -221,14 +221,23 @@ class ClaudeProvider(LLMClient):
 
     def _restore_tool_name(self, api_name: str) -> str:
         if api_name not in self._tool_name_map:
-            # Every outbound name is registered, so a miss means the map is
-            # stale — the agent would blame the model for "Unknown tool name".
-            logger.warning(
-                "Tool %r is not in the outbound name map; returning it "
-                "unmapped. Dispatch will fail if the name was sanitized.",
+            # Every outbound name is registered, so a miss means request and
+            # response were shaped against different tool sets. The message
+            # reaches the user verbatim, so the diagnostic detail goes to the
+            # log rather than into the exception.
+            logger.error(
+                "Tool %r is not in the outbound name map. The map is rebuilt "
+                "per request in _to_anthropic_tools, so a miss means this "
+                "response was parsed against a different tool set than the one "
+                "sent — e.g. an overlapping chat() call on this provider "
+                "instance. Registered: %s",
                 api_name,
+                sorted(self._tool_name_map),
             )
-            return api_name
+            raise RuntimeError(
+                f"Claude returned tool {api_name!r}, which was not in the tool "
+                "set sent with this request."
+            )
         return self._tool_name_map[api_name]
 
     def _to_anthropic_tools(self, tools: Optional[List[dict]]) -> Optional[List[dict]]:
@@ -243,13 +252,22 @@ class ClaudeProvider(LLMClient):
                 dict(tool)  # already Anthropic-shaped (name + input_schema)
                 if fn is None
                 else {
-                    "name": fn["name"],
+                    # .get so a nameless entry hits the guard below rather
+                    # than dying on a bare KeyError.
+                    "name": fn.get("name"),
                     "description": fn.get("description", ""),
                     "input_schema": fn.get("parameters")
                     or {"type": "object", "properties": {}},
                 }
             )
-            original = entry.get("name", "")
+            original = entry.get("name")
+            if not original:
+                raise ValueError(
+                    "Tool definition has no name: "
+                    f"{tool!r}. Anthropic requires a name on every tool entry "
+                    "(custom, server, and client-side alike), and GAIA needs "
+                    "one to route the model's call back to a registered tool."
+                )
             api_name = self._api_tool_name(original)
             # Register identity names too: `write/file` sanitizes onto the
             # builtin `write_file`, and only a full map can see that clash.

--- a/tests/unit/test_claude_provider.py
+++ b/tests/unit/test_claude_provider.py
@@ -677,3 +677,104 @@ def test_openai_tools_gate_counts_claude_as_tool_calling():
 
     agent._use_claude = False
     assert agent._openai_tools is None
+
+
+class TestToolNameSanitization:
+    """Skill tools are namespaced ``<skill>/<tool>`` — the ``/`` 400s the
+    Anthropic API (pattern ``^[a-zA-Z0-9_-]{1,128}$``), so names must be
+    sanitized outbound and restored on returned tool_use blocks."""
+
+    def _tools(self, *names):
+        return [
+            {
+                "type": "function",
+                "function": {"name": n, "description": "", "parameters": {}},
+            }
+            for n in names
+        ]
+
+    def test_slash_name_is_sanitized_and_mapped(self, fake_anthropic):
+        p = _provider(fake_anthropic)
+        converted = p._to_anthropic_tools(self._tools("rss-digest/fetch_rss"))
+        assert converted[0]["name"] == "rss-digest_fetch_rss"
+        assert p._restore_tool_name("rss-digest_fetch_rss") == "rss-digest/fetch_rss"
+
+    def test_valid_names_pass_through_untouched(self, fake_anthropic):
+        p = _provider(fake_anthropic)
+        converted = p._to_anthropic_tools(self._tools("read_file", "query-docs"))
+        assert [t["name"] for t in converted] == ["read_file", "query-docs"]
+        assert p._restore_tool_name("read_file") == "read_file"
+
+    def test_sanitization_collision_fails_loudly(self, fake_anthropic):
+        p = _provider(fake_anthropic)
+        with pytest.raises(ValueError, match="both map to"):
+            p._to_anthropic_tools(self._tools("a/b", "a.b"))
+
+    def test_sanitized_name_shadowing_a_builtin_is_refused(self, fake_anthropic):
+        p = _provider(fake_anthropic)
+        # `write/file` -> `write_file`, which is already a real builtin.
+        with pytest.raises(ValueError, match="both map to"):
+            p._to_anthropic_tools(self._tools("write_file", "write/file"))
+
+    def test_order_does_not_hide_the_collision(self, fake_anthropic):
+        p = _provider(fake_anthropic)
+        with pytest.raises(ValueError, match="both map to"):
+            p._to_anthropic_tools(self._tools("write/file", "write_file"))
+
+    def test_chat_round_trips_the_skill_name_end_to_end(self, fake_anthropic):
+        """The map is written while shaping the request and read while parsing
+        the response — the coupling a refactor would silently break."""
+        p = _provider(fake_anthropic)
+        p._client.messages.create.return_value = _response(
+            [_tool_use_block("toolu_5", "rss-digest_fetch_rss", {"url": "http://x"})],
+            stop_reason="tool_use",
+        )
+        envelope = json.loads(
+            p.chat(
+                [{"role": "user", "content": "digest it"}],
+                tools=self._tools("rss-digest/fetch_rss"),
+            )
+        )
+        # Anthropic saw the sanitized name; the agent gets the registered one.
+        sent = p._client.messages.create.call_args.kwargs["tools"]
+        assert [t["name"] for t in sent] == ["rss-digest_fetch_rss"]
+        (call,) = envelope[_NATIVE_TC_KEY]
+        assert call["function"]["name"] == "rss-digest/fetch_rss"
+
+    def test_stream_round_trips_the_skill_name_end_to_end(self, fake_anthropic):
+        p = _provider(fake_anthropic)
+        p._client.messages.create.return_value = iter(
+            [
+                SimpleNamespace(
+                    type="content_block_start",
+                    index=0,
+                    content_block=SimpleNamespace(
+                        type="tool_use",
+                        id="toolu_6",
+                        name="rss-digest_fetch_rss",
+                        input={},
+                    ),
+                ),
+                SimpleNamespace(
+                    type="content_block_delta",
+                    index=0,
+                    delta=SimpleNamespace(
+                        type="input_json_delta", partial_json='{"url": "http://x"}'
+                    ),
+                ),
+                SimpleNamespace(
+                    type="message_delta",
+                    delta=SimpleNamespace(stop_reason="tool_use"),
+                    usage=SimpleNamespace(output_tokens=3),
+                ),
+            ]
+        )
+        chunks = list(
+            p.chat(
+                [{"role": "user", "content": "digest it"}],
+                stream=True,
+                tools=self._tools("rss-digest/fetch_rss"),
+            )
+        )
+        (call,) = json.loads(chunks[-1])[_NATIVE_TC_KEY]
+        assert call["function"]["name"] == "rss-digest/fetch_rss"

--- a/tests/unit/test_claude_provider.py
+++ b/tests/unit/test_claude_provider.py
@@ -443,7 +443,11 @@ def _stream_events():
                 type="content_block_start",
                 index=2,
                 content_block=SimpleNamespace(
-                    type="tool_use", id="toolu_s1", name="list_directory"
+                    # Must be a tool this request actually declared
+                    # (OPENAI_TOOLS) — the API only returns declared names.
+                    type="tool_use",
+                    id="toolu_s1",
+                    name="read_file",
                 ),
             ),
             SimpleNamespace(
@@ -481,7 +485,7 @@ def test_stream_assembles_input_json_deltas_into_sentinel(fake_anthropic):
     assert sentinel.startswith(NATIVE_TOOL_CALLS_PREFIX)
     envelope = json.loads(sentinel)
     (call,) = envelope[_NATIVE_TC_KEY]
-    assert call["function"]["name"] == "list_directory"
+    assert call["function"]["name"] == "read_file"
     assert json.loads(call["function"]["arguments"]) == {"path": "C:/"}
     assert envelope["finish_reason"] == "tool_calls"
     assert envelope["content"] == "Checking."
@@ -704,6 +708,34 @@ class TestToolNameSanitization:
         converted = p._to_anthropic_tools(self._tools("read_file", "query-docs"))
         assert [t["name"] for t in converted] == ["read_file", "query-docs"]
         assert p._restore_tool_name("read_file") == "read_file"
+
+    def test_unmapped_returned_name_fails_loudly(self, fake_anthropic, caplog):
+        """A miss means request and response were shaped against different
+        tool sets. Returning the name unmapped surfaces later as "unknown
+        tool", blaming the model for a bug that is here."""
+        p = _provider(fake_anthropic)
+        p._to_anthropic_tools(self._tools("read_file"))
+        with pytest.raises(RuntimeError, match="not in the tool set sent"):
+            p._restore_tool_name("some_other_tool")
+        # The user-facing message stays short; the diagnostic goes to the log.
+        assert "read_file" in caplog.text
+
+    @pytest.mark.parametrize(
+        "entry",
+        [
+            {"type": "function", "function": {"parameters": {}}},  # OpenAI shape
+            {"input_schema": {}},  # already-Anthropic shape
+        ],
+        ids=["openai_shape", "anthropic_shape"],
+    )
+    def test_nameless_tool_entry_fails_loudly(self, fake_anthropic, entry):
+        """Anthropic requires a name on every tool entry, so a nameless one is
+        malformed input — not something to pass through. Without the guard two
+        of them both sanitize to '' and trip the collision error, which names
+        the wrong problem."""
+        p = _provider(fake_anthropic)
+        with pytest.raises(ValueError, match="has no name"):
+            p._to_anthropic_tools([entry])
 
     def test_sanitization_collision_fails_loudly(self, fake_anthropic):
         p = _provider(fake_anthropic)

--- a/tests/unit/test_hyphenated_skill_tool_dispatch.py
+++ b/tests/unit/test_hyphenated_skill_tool_dispatch.py
@@ -1,0 +1,51 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""Skill-namespaced tools register with a literal hyphen (``rss-digest/fetch_rss``).
+
+_execute_tool used to blanket-replace ``-`` -> ``_`` before the registry lookup on
+the theory that tool names are always snake_case — which made every hyphenated
+skill's tools undispatchable ("Unknown tool name"). This pins the fix: the exact
+registered name resolves, while the hyphen->underscore normalization still rescues
+a genuine snake_case model typo.
+"""
+
+from gaia.agents.base.agent import Agent
+
+
+class _DispatchStub(Agent):
+    def __init__(self, registry):
+        self._instance_tools = registry
+
+    def _register_tools(self):
+        pass
+
+    def _resolve_tool_name(self, name):
+        return None
+
+
+def _tool(result):
+    def fn(**kwargs):
+        return {"status": "success", "result": result}
+
+    return {"function": fn, "description": "", "parameters": {}}
+
+
+def test_hyphenated_skill_tool_dispatches_to_exact_name():
+    agent = _DispatchStub({"rss-digest/fetch_rss": _tool("FEED")})
+    out = agent._execute_tool("rss-digest/fetch_rss", {"url": "http://x"})
+    assert out["status"] == "success"
+    assert out["result"] == "FEED"
+
+
+def test_hyphen_normalization_still_rescues_a_snake_case_typo():
+    # No exact match; the model emitted a hyphen for an underscore tool.
+    agent = _DispatchStub({"read_file": _tool("OK")})
+    out = agent._execute_tool("read-file", {})
+    assert out["status"] == "success"
+    assert out["result"] == "OK"
+
+
+def test_unknown_tool_still_errors():
+    agent = _DispatchStub({"read_file": _tool("OK")})
+    out = agent._execute_tool("nope/does_not_exist", {})
+    assert out["status"] == "error"

--- a/tests/unit/test_hyphenated_skill_tool_dispatch.py
+++ b/tests/unit/test_hyphenated_skill_tool_dispatch.py
@@ -9,29 +9,53 @@ registered name resolves, while the hyphen->underscore normalization still rescu
 a genuine snake_case model typo.
 """
 
+from unittest.mock import patch
+
 from gaia.agents.base.agent import Agent
 
 
-class _DispatchStub(Agent):
-    def __init__(self, registry):
-        self._instance_tools = registry
+class _DispatchAgent(Agent):
+    def _get_system_prompt(self) -> str:
+        return "test"
 
-    def _register_tools(self):
+    def _register_tools(self) -> None:
         pass
 
-    def _resolve_tool_name(self, name):
-        return None
+    def _create_console(self):
+        from gaia.agents.base.console import AgentConsole
+
+        return AgentConsole()
+
+
+def _agent_with_tools(registry):
+    """Build a real agent and swap its registry — the pattern used by the other
+    ``_execute_tool`` tests. Bypassing ``Agent.__init__`` would leave per-turn
+    state like ``_tool_reported_usage`` unset."""
+    with patch("gaia.agents.base.agent.AgentSDK"):
+        agent = _DispatchAgent(silent_mode=True, skip_lemonade=True)
+    agent._instance_tools = {
+        name: {
+            "name": name,
+            "description": "stub",
+            "parameters": {},
+            "function": fn,
+            # These tests exercise name resolution, not the confirmation gate.
+            "requires_confirmation": False,
+        }
+        for name, fn in registry.items()
+    }
+    return agent
 
 
 def _tool(result):
     def fn(**kwargs):
         return {"status": "success", "result": result}
 
-    return {"function": fn, "description": "", "parameters": {}}
+    return fn
 
 
 def test_hyphenated_skill_tool_dispatches_to_exact_name():
-    agent = _DispatchStub({"rss-digest/fetch_rss": _tool("FEED")})
+    agent = _agent_with_tools({"rss-digest/fetch_rss": _tool("FEED")})
     out = agent._execute_tool("rss-digest/fetch_rss", {"url": "http://x"})
     assert out["status"] == "success"
     assert out["result"] == "FEED"
@@ -39,13 +63,13 @@ def test_hyphenated_skill_tool_dispatches_to_exact_name():
 
 def test_hyphen_normalization_still_rescues_a_snake_case_typo():
     # No exact match; the model emitted a hyphen for an underscore tool.
-    agent = _DispatchStub({"read_file": _tool("OK")})
+    agent = _agent_with_tools({"read_file": _tool("OK")})
     out = agent._execute_tool("read-file", {})
     assert out["status"] == "success"
     assert out["result"] == "OK"
 
 
 def test_unknown_tool_still_errors():
-    agent = _DispatchStub({"read_file": _tool("OK")})
+    agent = _agent_with_tools({"read_file": _tool("OK")})
     out = agent._execute_tool("nope/does_not_exist", {})
     assert out["status"] == "error"


### PR DESCRIPTION
Loading any tool-bearing skill made the agent unusable on Claude. Skills register their tools namespaced as `<skill>/<tool>`, and the Anthropic API rejects `/` in a tool name — so every turn after a skill loaded failed with a 400. Even once that was past, the agent couldn't dispatch a hyphenated skill's tools at all: it normalized the hyphen away before the registry lookup and answered "Unknown tool name". Both are fixed, so shipped skills like `rss-digest` now actually run their tools on Claude. Lemonade was unaffected — it tolerated the slash, which is why this went unnoticed.

Extracted from #3074, which is too large to review as one unit; the eval corpus, scorecard/CI gates, and skill-capture work stay there.

## Test plan

- [x] `python -m pytest tests/unit/test_claude_provider.py tests/unit/test_hyphenated_skill_tool_dispatch.py` — 44 pass
- [x] Check out `main`, copy the two test files over, and re-run: 8 of them fail (`DID NOT RAISE ValueError`, `'rss-digest/fetch_rss' == 'rss-digest_fetch_rss'`, `Unknown tool name`)
- [x] `python -m pytest tests/unit/test_skill*.py tests/unit/test_skills*.py` — 1290 pass, 1 skipped. 3 `test_skills_cli.py::test_real_cli_*` failures are a local sandbox artifact (`RuntimeError: Could not determine home directory` from a spawned `python -m gaia.cli`), reproduced identically on a clean tree; CI's own Unit Tests pass.
- [x] `python util/lint.py --all` — black, isort, flake8, bandit, import validation, agent conventions all pass. The 9 pylint `no-member` errors (`os.killpg`, `os.getpgid`, `os.geteuid` in `daemon/sidecars/` and `installer/`) are POSIX-only calls flagged on a Windows checkout, in files this PR does not touch.
- [ ] With `ANTHROPIC_API_KEY` set, run the agent on Claude, load a hyphenated tool-bearing skill (`hub/skills/rss-digest`), and ask it to fetch a feed — the tool call round-trips instead of 400ing
- [ ] `gaia eval agent` — owed, since the dispatcher change touches tool-name resolution on every backend. Not run here; the eval box is serialized on one Lemonade instance.

<details>
<summary>🔍 Technical details</summary>

`Tool.name` must match `^[a-zA-Z0-9_-]{1,128}$` (Anthropic's OpenAPI spec; the prose docs page still says 64). Names are sanitized outbound and restored on returned `tool_use` blocks, on both the streaming and non-streaming paths.

The restore map registers *every* outbound name, identity included. Registering only the rewritten ones can't detect the collision that actually misroutes a call: a skill's `write/file` sanitizes onto the builtin `write_file`, and the map would then send the model's builtin call to the skill's tool. A clash now raises, naming both sides — a skill shadowing a registry name is an expected case per `skills/loader.py`, so this is reachable rather than theoretical.

`_execute_tool`'s hyphen→underscore normalization is kept as a typo rescue but now runs only when the exact name isn't in the registry.

Both restore-map miss and nameless-tool-entry paths raise rather than degrade, per CLAUDE.md's fail-loudly rule. Only `block.type == "tool_use"` reaches the restore path, so server tools (`server_tool_use`) and MCP tools (`mcp_tool_use`) are unaffected.
</details>
