### PR TITLE
fix(website): Mac visitors on Safari got no install button

### DIFF
--- a/website/src/components/TuiDownload.astro
+++ b/website/src/components/TuiDownload.astro
@@ -137,29 +137,46 @@ const DOWNLOAD_ICON = `<svg class="h-4 w-4 flex-none" fill="none" stroke="curren
             )}
       </div>
 
+      {/* Every sentence here is written for ONE architecture — it names a chip,
+          or links the one standalone binary this block owns. When two blocks
+          merge, the script drops `[data-dl-one-arch]` and reveals the
+          `[data-dl-multi-arch]` wording instead. */}
       <p class:list={['g-body mt-3 max-w-[440px] text-[13px]', centered && 'mx-auto']}>
         {row.installers.length > 0 ? (
           <Fragment>
             Installs the agent and puts <code class="text-g-text">gaia-tui</code> on your PATH.
             {row.binary && (
-              <Fragment>
+              <span data-dl-one-arch>
                 {' '}Or take the{' '}
                 <a href={row.binary.url} class="text-g-gold-text underline-offset-2 hover:underline">
                   standalone binary
                 </a>{' '}— one file, no PATH entry and no agent alongside it.
-              </Fragment>
+              </span>
             )}
           </Fragment>
         ) : anyInstaller ? (
           <Fragment>
-            No installer is published for {PLATFORM_LABELS[row.platform]} — the agent has no
-            build for that architecture. This is the standalone binary: put it on your PATH
-            yourself.
+            <span data-dl-one-arch>
+              No installer is published for {PLATFORM_LABELS[row.platform]} — the agent has no
+              build for that architecture. This is the standalone binary: put it on your PATH
+              yourself.
+            </span>
+            <span data-dl-multi-arch hidden>
+              No installer is published for either architecture — the agent has no build for
+              them. These are the standalone binaries: put the one you pick on your PATH
+              yourself.
+            </span>
           </Fragment>
         ) : (
           <Fragment>
-            The standalone binary — put it on your PATH and run{' '}
-            <code class="text-g-text">gaia-tui</code>.
+            <span data-dl-one-arch>
+              The standalone binary — put it on your PATH and run{' '}
+              <code class="text-g-text">gaia-tui</code>.
+            </span>
+            <span data-dl-multi-arch hidden>
+              Standalone binaries — put the one you pick on your PATH and run{' '}
+              <code class="text-g-text">gaia-tui</code>.
+            </span>
           </Fragment>
         )}
       </p>
@@ -227,7 +244,23 @@ const DOWNLOAD_ICON = `<svg class="h-4 w-4 flex-none" fill="none" stroke="curren
     const buttons = primary.querySelector('[data-dl-buttons]');
     for (const extra of rest) {
       const extraButtons = extra.querySelector('[data-dl-buttons]');
-      if (buttons && extraButtons) buttons.append(...extraButtons.children);
+      // Both wrappers are rendered above, so a miss means the markup changed
+      // out from under this — say so rather than drop an install button.
+      if (!buttons || !extraButtons) {
+        console.warn('[tui-download] no [data-dl-buttons]; dropped', extra.dataset.platform);
+        continue;
+      }
+      buttons.append(...extraButtons.children);
+    }
+
+    // The copy under the buttons names ONE architecture — its chip, its own
+    // standalone binary. With two merged in, that link hands half of these
+    // visitors a binary that cannot run; the disclosure lists both, labelled.
+    if (rest.length) {
+      primary.querySelectorAll('[data-dl-one-arch]').forEach((el) => el.remove());
+      primary
+        .querySelectorAll<HTMLElement>('[data-dl-multi-arch]')
+        .forEach((el) => (el.hidden = false));
     }
 
     // Every platform stays reachable, one disclosure away — including this

--- a/website/src/components/TuiDownload.astro
+++ b/website/src/components/TuiDownload.astro
@@ -12,9 +12,11 @@
 //
 // Every published platform is rendered server-side, so a no-JS visitor gets the
 // whole list and a working link. JS reveals the block for the platform this
-// machine can run and collapses the list behind a disclosure; a machine it
-// cannot place (Apple Silicon behind Safari, an unknown arch) keeps the full
-// list rather than guessing — see scripts/download-target.ts.
+// machine can run and collapses the list behind a disclosure. A Mac behind
+// Safari reports no architecture, so both Mac builds are offered side by side;
+// a machine we publish nothing for (an iPad sending the Mac UA, an unknown
+// arch) keeps the full list rather than guessing — see
+// scripts/download-target.ts.
 //
 // Nothing here builds a URL. Each link is the `url` the hub manifest published
 // for an artifact whose filename matched a key exactly, so a platform the hub
@@ -116,7 +118,10 @@ const DOWNLOAD_ICON = `<svg class="h-4 w-4 flex-none" fill="none" stroke="curren
       outranks Tailwind's preflight `[hidden]` rule and would show them all. */}
   {rows.map((row) => (
     <div data-dl-cta data-platform={row.platform} hidden>
-      <div class:list={['flex flex-wrap items-center gap-3', centered && 'justify-center']}>
+      <div
+        data-dl-buttons
+        class:list={['flex flex-wrap items-center gap-3', centered && 'justify-center']}
+      >
         {row.installers.length > 0
           ? row.installers.map((i) => (
               <a href={i.artifact.url} class="g-btn g-btn-primary px-6 py-3 text-[15px]">
@@ -197,19 +202,33 @@ const DOWNLOAD_ICON = `<svg class="h-4 w-4 flex-none" fill="none" stroke="curren
 </div>
 
 <script>
-  import { resolvePlatform } from '../scripts/download-target';
+  import { resolveTargets } from '../scripts/download-target';
 
   document.querySelectorAll<HTMLElement>('[data-tui-download]').forEach(async (root) => {
     const blocks = Array.from(root.querySelectorAll<HTMLElement>('[data-dl-cta]'));
     if (!blocks.length) return;
 
-    const platform = await resolvePlatform(navigator).catch(() => null);
-    if (!platform) return;   // Unplaceable machine: the full list stays as-is.
+    const targets = await resolveTargets(navigator).catch(() => []);
+    // Unplaceable machine, or none of its platforms are published: the full
+    // list stays as-is.
+    const matched = targets.flatMap((t) => {
+      const block = blocks.find((b) => b.dataset.platform === t);
+      return block ? [block] : [];
+    });
+    if (!matched.length) return;
 
-    const match = blocks.find((b) => b.dataset.platform === platform);
-    if (!match) return;      // A platform the hub does not publish for.
+    const [primary, ...rest] = matched;
+    primary.hidden = false;
 
-    match.hidden = false;
+    // More than one target means a Mac whose architecture Safari will not
+    // report. Fold the others' buttons into the first block's row so they read
+    // as one choice — the same side-by-side shape Linux already uses for .deb
+    // and .rpm — instead of two near-identical blocks with duplicate copy.
+    const buttons = primary.querySelector('[data-dl-buttons]');
+    for (const extra of rest) {
+      const extraButtons = extra.querySelector('[data-dl-buttons]');
+      if (buttons && extraButtons) buttons.append(...extraButtons.children);
+    }
 
     // Every platform stays reachable, one disclosure away — including this
     // machine's other options, so the standalone binary is never hidden from

--- a/website/src/scripts/download-target.test.ts
+++ b/website/src/scripts/download-target.test.ts
@@ -10,8 +10,9 @@ import {
   PLATFORM_LABELS,
   artifactFileName,
   detectOs,
+  placeOs,
   resolveArch,
-  resolvePlatform,
+  resolveTargets,
   type DownloadKey,
   type NavigatorLike,
   type PlatformKey,
@@ -111,28 +112,52 @@ describe('resolveArch', () => {
     expect(await resolveArch(nav(UA.linux), 'linux')).toBe('x64');
   });
 
-  // Safari reports "Intel Mac OS X" on Apple Silicon and offers no hints, so
-  // the UA alone cannot decide; touch points are the one honest signal.
-  it('uses touch points to place an Apple Silicon Mac behind Safari', async () => {
-    expect(await resolveArch(nav(UA.macSafari, { maxTouchPoints: 5 }), 'darwin')).toBe('arm64');
-  });
-
   it('refuses to guess a Mac architecture with no evidence', async () => {
     expect(await resolveArch(nav(UA.macSafari), 'darwin')).toBeNull();
     expect(await resolveArch(nav(UA.mac, { hintsThrow: true }), 'darwin')).toBeNull();
   });
+
+  // Touch points say nothing about the chip: every Mac reports 0, Intel and
+  // Apple Silicon alike. Reading them as an Apple Silicon signal placed every
+  // Safari Mac nowhere and handed every iPad a Mac build.
+  it('does not read touch points as an architecture signal', async () => {
+    expect(await resolveArch(nav(UA.macSafari, { maxTouchPoints: 5 }), 'darwin')).toBeNull();
+  });
 });
 
-describe('resolvePlatform', () => {
-  it('returns the hub platform key', async () => {
-    expect(await resolvePlatform(nav(UA.win))).toBe('win-x64');
-    expect(await resolvePlatform(nav(UA.linuxArm))).toBe('linux-arm64');
-    expect(await resolvePlatform(nav(UA.mac, { architecture: 'arm' }))).toBe('darwin-arm64');
+describe('placeOs', () => {
+  it('places the desktops we publish for', () => {
+    expect(placeOs(nav(UA.win))).toBe('win');
+    expect(placeOs(nav(UA.macSafari))).toBe('darwin');
+    expect(placeOs(nav(UA.linux))).toBe('linux');
   });
 
-  it('returns null for anything unplaceable, so the caller shows every option', async () => {
-    expect(await resolvePlatform(nav(UA.iphone))).toBeNull();
-    expect(await resolvePlatform(nav(UA.macSafari))).toBeNull();
+  // iPadOS Safari sends the Mac UA verbatim; touch points are the only tell.
+  it('rejects an iPad sending the Mac desktop UA', () => {
+    expect(placeOs(nav(UA.macSafari, { maxTouchPoints: 5 }))).toBeNull();
+  });
+
+  it('keeps a real Mac, which reports no touch points', () => {
+    expect(placeOs(nav(UA.macSafari, { maxTouchPoints: 0 }))).toBe('darwin');
+  });
+});
+
+describe('resolveTargets', () => {
+  it('offers exactly one platform when the machine is placeable', async () => {
+    expect(await resolveTargets(nav(UA.win))).toEqual(['win-x64']);
+    expect(await resolveTargets(nav(UA.linuxArm))).toEqual(['linux-arm64']);
+    expect(await resolveTargets(nav(UA.mac, { architecture: 'arm' }))).toEqual(['darwin-arm64']);
+  });
+
+  // The case that regressed: a Mac on Safari must still get an install button.
+  it('offers both Mac builds when the architecture cannot be read', async () => {
+    expect(await resolveTargets(nav(UA.macSafari))).toEqual(['darwin-arm64', 'darwin-x64']);
+  });
+
+  it('offers nothing to a machine we do not publish for', async () => {
+    expect(await resolveTargets(nav(UA.iphone))).toEqual([]);
+    expect(await resolveTargets(nav(UA.android))).toEqual([]);
+    expect(await resolveTargets(nav(UA.macSafari, { maxTouchPoints: 5 }))).toEqual([]);
   });
 });
 

--- a/website/src/scripts/download-target.ts
+++ b/website/src/scripts/download-target.ts
@@ -82,11 +82,14 @@ export const INSTALLERS_FOR: Record<PlatformKey, InstallerKey[]> = {
 /**
  * Primary-button text per installer. Linux names the distro family in the
  * button itself: the two packages sit side by side and the visitor picks, so
- * the button has to say which one is theirs.
+ * the button has to say which one is theirs. macOS names the chip for the same
+ * reason — Safari cannot report it, so both Mac buttons are shown together and
+ * a bare "Install GAIA for macOS" beside "(Intel)" would read as the universal
+ * one.
  */
 export const INSTALLER_CTA_LABELS: Record<InstallerKey, string> = {
   'win-x64-setup': 'Install GAIA for Windows',
-  'darwin-arm64-pkg': 'Install GAIA for macOS',
+  'darwin-arm64-pkg': 'Install GAIA for macOS (Apple Silicon)',
   'darwin-x64-pkg': 'Install GAIA for macOS (Intel)',
   'linux-x64-deb': 'Debian / Ubuntu (.deb)',
   'linux-x64-rpm': 'Fedora / RHEL / SUSE (.rpm)',
@@ -115,12 +118,21 @@ export function detectOs(userAgent: string): Os | null {
 }
 
 /**
- * Apple Silicon without client hints (Safari): the UA says "Intel" on every
- * Mac, so the UA cannot decide it. A Mac reporting touch points is an M-series
- * machine — Intel Macs report 0 — which is the one signal Safari does expose.
+ * iPadOS Safari asks for desktop sites by default, sending the *Mac* UA
+ * (`Macintosh; Intel Mac OS X 10_15_7`) with no iPad token — so the UA alone
+ * calls it a Mac. Touch points are the only separator: no Mac has a
+ * touchscreen and every one reports 0 (Touch Bar models included), while an
+ * iPad reports 5. `> 1` rather than `> 0` because a handful of browsers report
+ * 1 on non-touch hardware.
  */
-function appleSiliconBySideChannel(nav: NavigatorLike): boolean {
-  return (nav.maxTouchPoints ?? 0) > 0;
+function isIpadClaimingToBeAMac(nav: NavigatorLike): boolean {
+  return /Macintosh/i.test(nav.userAgent) && (nav.maxTouchPoints ?? 0) > 1;
+}
+
+/** The OS we publish for, or null for one we do not — including an iPad. */
+export function placeOs(nav: NavigatorLike): Os | null {
+  if (isIpadClaimingToBeAMac(nav)) return null;
+  return detectOs(nav.userAgent);
 }
 
 export async function resolveArch(nav: NavigatorLike, os: Os): Promise<Arch | null> {
@@ -139,19 +151,35 @@ export async function resolveArch(nav: NavigatorLike, os: Os): Promise<Arch | nu
 
   // Explicit arm64 in the UA — Linux and Windows do sometimes say so.
   if (/aarch64|arm64/i.test(nav.userAgent)) return 'arm64';
-  if (os === 'darwin') return appleSiliconBySideChannel(nav) ? 'arm64' : null;
+  // Undecidable on macOS: Safari exposes no client hints, and every Mac —
+  // Intel and Apple Silicon alike — says "Intel Mac OS X". Nothing is left to
+  // read, so callers offer both builds rather than guess.
+  if (os === 'darwin') return null;
   // Windows and Linux on arm64 without hints are rare enough that x64 is the
   // safe read; on macOS it is not, which is why that case returns null above.
   if (/x86_64|win64|wow64|x64|amd64|intel/i.test(nav.userAgent)) return 'x64';
   return null;
 }
 
-export async function resolvePlatform(nav: NavigatorLike): Promise<PlatformKey | null> {
-  const os = detectOs(nav.userAgent);
-  if (!os) return null;
+/**
+ * Every platform to offer this visitor, best first.
+ *
+ * Usually one, and empty for a machine we do not publish for. Two only on a
+ * Mac whose architecture cannot be read — Apple Silicon leads because it is
+ * what Apple has shipped since 2020. Offering both beats the alternatives: a
+ * guess hands half of Safari's Mac visitors a package that will not run, and
+ * offering nothing is what left them with no install button at all.
+ *
+ * This replaced a `resolvePlatform` that returned one platform or null. The
+ * null was indistinguishable from "unsupported machine", so the caller showed
+ * no install button at all — which is how a Mac on Safari ended up with none.
+ */
+export async function resolveTargets(nav: NavigatorLike): Promise<PlatformKey[]> {
+  const os = placeOs(nav);
+  if (!os) return [];
   const arch = await resolveArch(nav, os);
-  if (!arch) return null;
-  return `${os}-${arch}`;
+  if (arch) return [`${os}-${arch}`];
+  return os === 'darwin' ? ['darwin-arm64', 'darwin-x64'] : [];
 }
 
 // The installer filenames, as the packaging scripts name them — each carries

--- a/website/src/scripts/download-target.ts
+++ b/website/src/scripts/download-target.ts
@@ -7,10 +7,11 @@
 // The hub publishes six: {win,darwin,linux} x {x64,arm64}, so unlike a
 // single-architecture installer this has to resolve the ARCHITECTURE too, and
 // only the client hints report it truthfully — every OS masks arm64 in the UA
-// string to keep old sites working. A machine we cannot place resolves to null
-// and the caller keeps its full platform list on screen, which is the honest
-// outcome: an arm64 user handed an x64 binary gets a failure at exec time, not
-// a download error they can act on.
+// string to keep old sites working. Nothing here guesses: a machine we cannot
+// place resolves to no platform at all and the caller keeps its full list on
+// screen, and a Mac — whose architecture Safari never reports — resolves to
+// both builds, for the caller to offer side by side. An arm64 user handed an
+// x64 binary gets a failure at exec time, not a download error they can act on.
 
 export type Os = 'win' | 'darwin' | 'linux';
 export type Arch = 'x64' | 'arm64';


### PR DESCRIPTION
Roughly half of Mac traffic reaches the download section and sees no install button at all, while iPads are offered a macOS package they cannot open. Both come from one inverted signal: the Mac architecture check read `navigator.maxTouchPoints > 0` as "this is Apple Silicon", but no Mac reports touch points — Intel and Apple Silicon both report 0, Touch Bar models included. Every Mac fell through to "architecture unknown", which the caller treats as unsupported, so nothing was revealed. The only machine reporting touch points behind a Mac user agent is an iPad in its default desktop mode — the one case the check fired on was the one it should have excluded.

Touch points now separate an iPad from a Mac, which is what they can actually tell us. A Mac's architecture is genuinely undecidable behind Safari, so both Mac builds are offered side by side — the shape Linux already uses for `.deb` and `.rpm`.

## Test plan

- [ ] `cd website && npx astro check && npm test && HUB_CATALOG_URL=https://hub.amd-gaia.ai npx astro build` — the four steps `website-ci.yml` runs (71 tests)
- [ ] Drive the built page with a spoofed `Macintosh` UA and `navigator.maxTouchPoints` overridden:
  - `maxTouchPoints: 0` (every real Mac) → two buttons, "Install GAIA for macOS (Apple Silicon)" and "(Intel)"
  - `maxTouchPoints: 5` (iPad) → no install button; the full download list stays
- [ ] Confirm no regression where the architecture *is* knowable: Windows, Linux, and Mac Chrome with client hints each still resolve to exactly one button
- [ ] Manual, on a real Mac: open the page in Safari and confirm both Mac buttons appear; in Chrome, confirm only the matching one does

## Verified

Every bullet above except the last was run against the built site in a real browser, overriding the UA and `maxTouchPoints` per context. Results:

| Visitor | Before | After |
|---|---|---|
| Mac, Safari | *(no button)* | Apple Silicon + Intel |
| iPad, Safari | offered a Mac `.pkg` | *(no button, full list)* |
| Mac Chrome, arm hint | Apple Silicon | Apple Silicon |
| Mac Chrome, x86 hint | Intel | Intel |
| Windows / Linux / iPhone | unchanged | unchanged |

The real-Mac-in-Safari case is the one thing not proven on real hardware — it is spoofed here, and the last checkbox covers it.