### PR TITLE
feat(installer): the one-line install now brings the agent with it

### DIFF
--- a/installer/scripts/install.ps1
+++ b/installer/scripts/install.ps1
@@ -322,9 +322,9 @@ function Install-Tui {
 # child process, so without this binary the flagship cannot run -- which is what
 # this one-liner left behind before: a UI with no agent under it.
 #
-# Installed BESIDE gaia-tui.exe on purpose. The hub resolves its agent from its
-# own directory before consulting PATH (catalog.resolveAgentBinary), so a stale
-# gaia-agent elsewhere cannot shadow the one this script just verified.
+# Installed into $GAIA_BIN because that is the directory this installer owns and
+# has already put on PATH, so the hub's exec.LookPath finds gaia-agent there.
+#
 # Returns $true only when the agent binary is on disk. The caller uses that to
 # decide what to promise: the hub spawns gaia-agent as a child process, so
 # without it `gaia-tui` opens an agent list rather than a chat. ARM64 Windows
@@ -339,9 +339,8 @@ function Install-FlagshipAgent {
     }
     # The sidecar is published under win32-x64; the terminal hub uses win-x64.
     $lockPlatform = $platform -replace '^win-', 'win32-'
-    $suffix = if ($lockPlatform -like 'win32-*') { ".exe" } else { "" }
 
-    $ok = Install-HubBinary -AgentId $FLAGSHIP_AGENT_ID -Filename "gaia-agent-$lockPlatform$suffix" -DestName "gaia-agent.exe" -Label "GAIA agent" -Optional
+    $ok = Install-HubBinary -AgentId $FLAGSHIP_AGENT_ID -Filename "gaia-agent-$lockPlatform.exe" -DestName "gaia-agent.exe" -Label "GAIA agent" -Optional
     return [bool]$ok
 }
 

--- a/installer/scripts/install.ps1
+++ b/installer/scripts/install.ps1
@@ -14,6 +14,7 @@ $PYTHON_VERSION = "3.12"
 $GAIA_HUB_BASE_URL = if ($env:GAIA_HUB_BASE_URL) { $env:GAIA_HUB_BASE_URL } else { "https://hub.amd-gaia.ai" }
 $GAIA_HUB_BASE_URL = $GAIA_HUB_BASE_URL.TrimEnd('/')
 $TERMINAL_HUB_ID = "terminal-hub"
+$FLAGSHIP_AGENT_ID = "gaia"
 
 # Network limit: a black-holed connection must fail, not hang silently.
 $HTTP_TIMEOUT_SEC = 900
@@ -36,12 +37,12 @@ function Write-Step {
 
 function Write-Success {
     param([string]$Message)
-    Write-Host "[✓] $Message" -ForegroundColor $COLOR_GREEN
+    Write-Host "[OK] $Message" -ForegroundColor $COLOR_GREEN
 }
 
 function Write-Error {
     param([string]$Message)
-    Write-Host "[✗] $Message" -ForegroundColor $COLOR_RED
+    Write-Host "[X] $Message" -ForegroundColor $COLOR_RED
 }
 
 function Write-Warning {
@@ -158,6 +159,148 @@ function Get-TerminalHubPlatform {
 }
 
 # A missing terminal hub fails the install - it is the advertised entry point.
+# Resolve one artifact's version and SHA-256 from a hub manifest. The manifest
+# is the only source for both, so each installer reads it the same way.
+# Returns @{Version; Sha256; Url}, or $null when the platform is unpublished.
+function Resolve-HubArtifact {
+    param(
+        [Parameter(Mandatory)][string]$AgentId,
+        [Parameter(Mandatory)][string]$Filename,
+        [Parameter(Mandatory)][string]$Label
+    )
+
+    $manifestUrl = "$GAIA_HUB_BASE_URL/agents/$AgentId/manifest.json"
+    try {
+        $manifest = Invoke-RestMethod -Uri $manifestUrl -UseBasicParsing -TimeoutSec $HTTP_TIMEOUT_SEC
+    }
+    catch {
+        Write-Error "Could not fetch the $Label manifest: $_"
+        Write-Host "  URL:  $manifestUrl" -ForegroundColor $COLOR_YELLOW
+        Write-Host "  Fix:  check your network, then retry." -ForegroundColor $COLOR_YELLOW
+        return $null
+    }
+
+    $version = $manifest.latest_version
+    if (-not $version) {
+        Write-Error "The hub manifest at $manifestUrl declares no latest_version."
+        return $null
+    }
+
+    $entry = $manifest.versions.$version
+    if (-not $entry) {
+        Write-Error "The hub manifest names latest_version $version but publishes no such version."
+        Write-Host "  Look: $manifestUrl" -ForegroundColor $COLOR_YELLOW
+        return $null
+    }
+
+    $artifacts = @($entry.artifacts)
+    if (-not $artifacts -or $artifacts.Count -eq 0) {
+        $artifacts = if ($entry.artifact) { @($entry.artifact) } else { @() }
+    }
+
+    $match = $artifacts | Where-Object { $_.filename -eq $Filename } | Select-Object -First 1
+    if (-not $match) {
+        $listed = ($artifacts | ForEach-Object { $_.filename } | Sort-Object) -join ", "
+        if (-not $listed) { $listed = "none" }
+        Write-Error "$Label $version publishes no $Filename (it publishes: $listed)."
+        Write-Host "  Look: $manifestUrl" -ForegroundColor $COLOR_YELLOW
+        return $null
+    }
+
+    if (-not $match.sha256) {
+        Write-Error "$Label $version publishes $Filename with no SHA-256 - refusing to install unverified."
+        Write-Host "  Look: $manifestUrl" -ForegroundColor $COLOR_YELLOW
+        return $null
+    }
+
+    return @{
+        Version = $version
+        Sha256  = $match.sha256
+        Url     = "$GAIA_HUB_BASE_URL/agents/$AgentId/$version/$Filename"
+    }
+}
+
+# Download one hub artifact into $GAIA_BIN, refusing anything whose SHA-256 does
+# not match what the manifest published. Shared by the terminal hub and the
+# flagship agent so there is exactly one place the verification rule lives.
+#
+# -Optional turns a missing platform build or an unreachable manifest into a
+# warning instead of exiting: the hub is still usable without a given agent.
+# A CHECKSUM MISMATCH is never softened that way -- it always exits.
+function Install-HubBinary {
+    param(
+        [Parameter(Mandatory)][string]$AgentId,
+        [Parameter(Mandatory)][string]$Filename,
+        [Parameter(Mandatory)][string]$DestName,
+        [Parameter(Mandatory)][string]$Label,
+        [switch]$Optional
+    )
+
+    $resolved = Resolve-HubArtifact -AgentId $AgentId -Filename $Filename -Label $Label
+    if (-not $resolved) {
+        if ($Optional) {
+            Write-Warning "Skipping $Label - see above. The terminal hub still works."
+            return $false
+        }
+        exit 1
+    }
+
+    $tmpDir = Join-Path $env:TEMP ("gaia-dl-" + [guid]::NewGuid().ToString("N"))
+    New-Item -ItemType Directory -Path $tmpDir -Force | Out-Null
+    $tmpFile = Join-Path $tmpDir $Filename
+
+    try {
+        Write-Step "Downloading $Label $($resolved.Version)"
+        try {
+            $prevProgress = $ProgressPreference
+            $ProgressPreference = "SilentlyContinue"
+            try {
+                Invoke-WebRequest -Uri $resolved.Url -OutFile $tmpFile -UseBasicParsing -TimeoutSec $HTTP_TIMEOUT_SEC
+            }
+            finally {
+                $ProgressPreference = $prevProgress
+            }
+        }
+        catch {
+            Write-Error "Could not download the $Label binary: $_"
+            Write-Host "  URL:  $($resolved.Url)" -ForegroundColor $COLOR_YELLOW
+            Write-Host "  Fix:  check your network and retry." -ForegroundColor $COLOR_YELLOW
+            if ($Optional) { return $false }
+            exit 1
+        }
+
+        # No checksum, no install.
+        $got = (Get-FileHash -Path $tmpFile -Algorithm SHA256).Hash
+        if ($got -ne $resolved.Sha256.ToUpper()) {
+            Write-Error "Checksum mismatch for $Filename - refusing to install."
+            Write-Host "  expected $($resolved.Sha256.ToUpper())" -ForegroundColor $COLOR_YELLOW
+            Write-Host "  got      $got" -ForegroundColor $COLOR_YELLOW
+            Write-Host "  Fix:  retry; if it persists report it at https://github.com/amd/gaia/issues" -ForegroundColor $COLOR_YELLOW
+            exit 1
+        }
+
+        if (-not (Test-Path $GAIA_BIN)) {
+            New-Item -ItemType Directory -Path $GAIA_BIN -Force | Out-Null
+        }
+        try {
+            Move-Item -Path $tmpFile -Destination "$GAIA_BIN\$DestName" -Force
+        }
+        catch {
+            Write-Error "Downloaded and verified, but could not write $GAIA_BIN\$DestName`: $_"
+            Write-Host "  Fix:  close any running GAIA (and any tool scanning that" -ForegroundColor $COLOR_YELLOW
+            Write-Host "        folder), then re-run this installer." -ForegroundColor $COLOR_YELLOW
+            if ($Optional) { return $false }
+            exit 1
+        }
+        Write-Success "$Label $($resolved.Version) installed to $GAIA_BIN\$DestName"
+        return $true
+    }
+    finally {
+        if (Test-Path $tmpDir) { Remove-Item -Path $tmpDir -Recurse -Force }
+    }
+}
+
+# A missing terminal hub fails the install - it is the advertised entry point.
 function Install-Tui {
     Write-Step "Installing the GAIA terminal hub"
 
@@ -169,116 +312,37 @@ function Install-Tui {
         Write-Host "  darwin-x64, darwin-arm64. See $GAIA_HUB_BASE_URL/index.json" -ForegroundColor $COLOR_YELLOW
         exit 1
     }
-    $filename = "gaia-$platform.exe"
 
-    # The manifest is the only source for the version, the per-platform
-    # filename, and the Worker-computed SHA-256.
-    $manifestUrl = "$GAIA_HUB_BASE_URL/agents/$TERMINAL_HUB_ID/manifest.json"
-    try {
-        $manifest = Invoke-RestMethod -Uri $manifestUrl -UseBasicParsing -TimeoutSec $HTTP_TIMEOUT_SEC
+    # Never `gaia.exe`: tui/internal/daemon/client.go resolves `gaia` on PATH to
+    # start the Python-owned daemon, so a Go binary by that name finds itself.
+    [void](Install-HubBinary -AgentId $TERMINAL_HUB_ID -Filename "gaia-$platform.exe" -DestName "gaia-tui.exe" -Label "terminal hub")
+}
+
+# The flagship agent's frozen sidecar. The terminal hub spawns `gaia-agent` as a
+# child process, so without this binary the flagship cannot run -- which is what
+# this one-liner left behind before: a UI with no agent under it.
+#
+# Installed BESIDE gaia-tui.exe on purpose. The hub resolves its agent from its
+# own directory before consulting PATH (catalog.resolveAgentBinary), so a stale
+# gaia-agent elsewhere cannot shadow the one this script just verified.
+# Returns $true only when the agent binary is on disk. The caller uses that to
+# decide what to promise: the hub spawns gaia-agent as a child process, so
+# without it `gaia-tui` opens an agent list rather than a chat. ARM64 Windows
+# hits this every time — the sidecar publishes no build for it.
+function Install-FlagshipAgent {
+    Write-Step "Installing the GAIA flagship agent"
+
+    $platform = Get-TerminalHubPlatform
+    if (-not $platform) {
+        Write-Warning "No flagship agent build for this architecture - skipping."
+        return $false
     }
-    catch {
-        Write-Error "Could not fetch the terminal hub manifest: $_"
-        Write-Host "  URL:  $manifestUrl" -ForegroundColor $COLOR_YELLOW
-        Write-Host "  Fix:  check your network, then retry. If the component is not yet" -ForegroundColor $COLOR_YELLOW
-        Write-Host "        published for this release, build from source:" -ForegroundColor $COLOR_YELLOW
-        Write-Host "          git clone https://github.com/amd/gaia; cd gaia\tui; make build" -ForegroundColor $COLOR_YELLOW
-        Write-Host "  Look: $GAIA_HUB_BASE_URL/index.json lists what the hub serves." -ForegroundColor $COLOR_YELLOW
-        exit 1
-    }
+    # The sidecar is published under win32-x64; the terminal hub uses win-x64.
+    $lockPlatform = $platform -replace '^win-', 'win32-'
+    $suffix = if ($lockPlatform -like 'win32-*') { ".exe" } else { "" }
 
-    $version = $manifest.latest_version
-    if (-not $version) {
-        Write-Error "The hub manifest at $manifestUrl declares no latest_version."
-        exit 1
-    }
-
-    $entry = $manifest.versions.$version
-    if (-not $entry) {
-        Write-Error "The hub manifest names latest_version $version but publishes no such version."
-        Write-Host "  Look: $manifestUrl" -ForegroundColor $COLOR_YELLOW
-        exit 1
-    }
-
-    $artifacts = @($entry.artifacts)
-    if (-not $artifacts -or $artifacts.Count -eq 0) {
-        $artifacts = if ($entry.artifact) { @($entry.artifact) } else { @() }
-    }
-
-    $match = $artifacts | Where-Object { $_.filename -eq $filename } | Select-Object -First 1
-    if (-not $match) {
-        $listed = ($artifacts | ForEach-Object { $_.filename } | Sort-Object) -join ", "
-        if (-not $listed) { $listed = "none" }
-        Write-Error "Terminal hub $version publishes no $filename (it publishes: $listed)."
-        Write-Host "  Fix:  if your platform is genuinely unpublished, build from source:" -ForegroundColor $COLOR_YELLOW
-        Write-Host "          git clone https://github.com/amd/gaia; cd gaia\tui; make build" -ForegroundColor $COLOR_YELLOW
-        Write-Host "  Look: $manifestUrl" -ForegroundColor $COLOR_YELLOW
-        exit 1
-    }
-
-    $want = $match.sha256
-    if (-not $want) {
-        Write-Error "Terminal hub $version publishes $filename with no SHA-256 - refusing to install unverified."
-        Write-Host "  Look: $manifestUrl" -ForegroundColor $COLOR_YELLOW
-        exit 1
-    }
-
-    $binaryUrl = "$GAIA_HUB_BASE_URL/agents/$TERMINAL_HUB_ID/$version/$filename"
-    $tmpDir = Join-Path $env:TEMP ("gaia-tui-" + [guid]::NewGuid().ToString("N"))
-    New-Item -ItemType Directory -Path $tmpDir -Force | Out-Null
-    $tmpFile = Join-Path $tmpDir $filename
-
-    try {
-        Write-Step "Downloading terminal hub $version for $platform"
-        try {
-            $prevProgress = $ProgressPreference
-            $ProgressPreference = "SilentlyContinue"
-            try {
-                Invoke-WebRequest -Uri $binaryUrl -OutFile $tmpFile -UseBasicParsing -TimeoutSec $HTTP_TIMEOUT_SEC
-            }
-            finally {
-                $ProgressPreference = $prevProgress
-            }
-        }
-        catch {
-            Write-Error "Could not download the terminal hub binary: $_"
-            Write-Host "  URL:  $binaryUrl" -ForegroundColor $COLOR_YELLOW
-            Write-Host "  Fix:  check your network and retry." -ForegroundColor $COLOR_YELLOW
-            Write-Host "  Look: $manifestUrl lists what is published for $version." -ForegroundColor $COLOR_YELLOW
-            exit 1
-        }
-
-        # No checksum, no install.
-        $got = (Get-FileHash -Path $tmpFile -Algorithm SHA256).Hash
-        if ($got -ne $want.ToUpper()) {
-            Write-Error "Checksum mismatch for $filename - refusing to install."
-            Write-Host "  expected $($want.ToUpper())" -ForegroundColor $COLOR_YELLOW
-            Write-Host "  got      $got" -ForegroundColor $COLOR_YELLOW
-            Write-Host "  Fix:  retry; if it persists report it at https://github.com/amd/gaia/issues" -ForegroundColor $COLOR_YELLOW
-            Write-Host "  Look: $manifestUrl" -ForegroundColor $COLOR_YELLOW
-            exit 1
-        }
-
-        # Never `gaia.exe`: tui/internal/daemon/client.go resolves `gaia` on PATH
-        # to start the Python-owned daemon, so a Go binary by that name finds
-        # itself.
-        if (-not (Test-Path $GAIA_BIN)) {
-            New-Item -ItemType Directory -Path $GAIA_BIN -Force | Out-Null
-        }
-        try {
-            Move-Item -Path $tmpFile -Destination "$GAIA_BIN\gaia-tui.exe" -Force
-        }
-        catch {
-            Write-Error "Downloaded and verified, but could not write $GAIA_BIN\gaia-tui.exe`: $_"
-            Write-Host "  Fix:  close any running gaia-tui (and any tool scanning that" -ForegroundColor $COLOR_YELLOW
-            Write-Host "        folder), then re-run this installer." -ForegroundColor $COLOR_YELLOW
-            exit 1
-        }
-        Write-Success "Terminal hub $version installed to $GAIA_BIN\gaia-tui.exe"
-    }
-    finally {
-        if (Test-Path $tmpDir) { Remove-Item -Path $tmpDir -Recurse -Force }
-    }
+    $ok = Install-HubBinary -AgentId $FLAGSHIP_AGENT_ID -Filename "gaia-agent-$lockPlatform$suffix" -DestName "gaia-agent.exe" -Label "GAIA agent" -Optional
+    return [bool]$ok
 }
 
 function Add-ToPath {
@@ -317,6 +381,12 @@ function Add-ToPath {
 }
 
 function Show-NextSteps {
+    param(
+        # False when the flagship sidecar was skipped — no published build for
+        # this platform (ARM64 Windows), or its download failed. The banner must
+        # not promise an agent that is not on disk.
+        [bool]$FlagshipInstalled = $true
+    )
     Write-Host "`n" -NoNewline
     Write-Host "================================" -ForegroundColor $COLOR_GREEN
     Write-Host "  GAIA Installed Successfully!" -ForegroundColor $COLOR_GREEN
@@ -329,8 +399,18 @@ function Show-NextSteps {
     Write-Host "gaia init" -ForegroundColor $COLOR_GREEN -NoNewline
     Write-Host " to set up Lemonade Server and download models" -ForegroundColor White
     Write-Host "     (the Lemonade installer asks for administrator approval)" -ForegroundColor White
-    Write-Host "  3. Open the terminal hub: " -ForegroundColor White -NoNewline
-    Write-Host "gaia-tui" -ForegroundColor $COLOR_GREEN
+    if ($FlagshipInstalled) {
+        Write-Host "  3. Talk to the agent: " -ForegroundColor White -NoNewline
+        Write-Host "gaia-tui" -ForegroundColor $COLOR_GREEN
+        Write-Host "     (it opens the GAIA agent; type " -ForegroundColor White -NoNewline
+        Write-Host "/hub" -ForegroundColor $COLOR_GREEN -NoNewline
+        Write-Host " for the agent hub)" -ForegroundColor White
+    } else {
+        Write-Host "  3. Open the terminal hub: " -ForegroundColor White -NoNewline
+        Write-Host "gaia-tui" -ForegroundColor $COLOR_GREEN
+        Write-Host "     The GAIA agent was skipped - see the warning above - so this" -ForegroundColor $COLOR_YELLOW
+        Write-Host "     opens the agent list, not a chat. Re-run this installer to retry." -ForegroundColor $COLOR_YELLOW
+    }
     Write-Host "`n"
 
     Write-Host "Documentation: https://amd-gaia.ai" -ForegroundColor $COLOR_CYAN
@@ -369,8 +449,12 @@ function Main {
     # Install the terminal hub binary
     Install-Tui
 
+    # After Install-Tui so it lands in the same directory, which is where
+    # the hub looks for its agent first.
+    $flagshipInstalled = Install-FlagshipAgent
+
     # Show next steps
-    Show-NextSteps
+    Show-NextSteps -FlagshipInstalled:$flagshipInstalled
 }
 
 # Run installer

--- a/installer/scripts/install.sh
+++ b/installer/scripts/install.sh
@@ -334,6 +334,8 @@ MANIFEST_PY
 # so there is exactly one place the verification rule lives.
 #
 # Args: url, temp path, expected digest, destination path, label.
+# Returns: 0 installed, 2 checksum mismatch, 1 anything else. Callers that treat
+# the artifact as optional must still abort on 2 — only integrity is fatal there.
 download_and_verify() {
     _url="$1"; _tmp="$2"; _want="$3"; _dest="$4"; _label="$5"
 
@@ -360,7 +362,7 @@ download_and_verify() {
         echo "  expected $_want"
         echo "  got      $_got"
         echo "  Fix:  retry; if it persists report it at https://github.com/amd/gaia/issues"
-        return 1
+        return 2
     fi
 
     # Checked, because this is where a verified download still fails: an
@@ -449,14 +451,13 @@ install_tui() {
 # child process, so without this binary the flagship is listed but cannot run —
 # which is what `curl | sh` left behind before: a UI with no agent under it.
 #
-# Installed BESIDE gaia-tui on purpose. The hub resolves its agent from its own
-# directory first (catalog.resolveAgentBinary), so a stale gaia-agent elsewhere
-# on PATH cannot shadow the one this script just verified.
+# Installed into $GAIA_BIN because that is the directory this installer owns and
+# has already put on PATH, so the hub's exec.LookPath finds gaia-agent there.
 #
-# Not fatal when a platform has no published sidecar: the hub itself still works
-# and other agents still run, so this warns and continues rather than failing an
-# otherwise good install. It is never silent — an unrunnable flagship is exactly
-# the thing a user must be told about.
+# Only a checksum mismatch is fatal. A missing build or a failed download leaves
+# a working hub and a working Python CLI, so those warn and continue rather than
+# failing an otherwise complete install. Never silent — an unrunnable flagship is
+# exactly the thing a user must be told about.
 install_flagship_agent() {
     print_step "Installing the GAIA flagship agent"
 
@@ -487,7 +488,7 @@ install_flagship_agent() {
 
     resolved=""
     if ! resolved="$(read_hub_manifest "$py" "$tmp/manifest.json" "$filename")"; then
-        print_warning "The hub publishes no flagship agent for $platform — skipping."
+        print_warning "Could not resolve the flagship agent for $platform — skipping."
         echo "  Reported above by the manifest reader."
         echo "  Look: $manifest_url"
         return 0
@@ -498,11 +499,19 @@ install_flagship_agent() {
 
     binary_url="$GAIA_HUB_BASE_URL/agents/$FLAGSHIP_AGENT_ID/$version/$filename"
     print_step "Downloading GAIA agent $version for $platform"
-    if ! download_and_verify "$binary_url" "$tmp/$filename" "$want" \
-            "$GAIA_BIN/gaia-agent" "GAIA agent"; then
+    # `|| _rc=$?` rather than `if !`: `set -e` must stay armed, and the two
+    # failure modes are not the same failure.
+    _rc=0
+    download_and_verify "$binary_url" "$tmp/$filename" "$want" \
+            "$GAIA_BIN/gaia-agent" "GAIA agent" || _rc=$?
+    if [ "$_rc" -eq 2 ]; then
         # A checksum mismatch is never downgraded to a warning.
         echo "  Look: $manifest_url"
         exit 1
+    elif [ "$_rc" -ne 0 ]; then
+        print_warning "The GAIA agent did not install — skipping."
+        echo "  The terminal hub still works; re-run this installer to retry."
+        return 0
     fi
     # Read by show_next_steps: every path above this line leaves the machine
     # without an agent, and the closing banner must not promise one.

--- a/installer/scripts/install.sh
+++ b/installer/scripts/install.sh
@@ -18,6 +18,7 @@ PYTHON_VERSION="3.12"
 GAIA_HUB_BASE_URL="${GAIA_HUB_BASE_URL:-https://hub.amd-gaia.ai}"
 GAIA_HUB_BASE_URL="${GAIA_HUB_BASE_URL%/}"
 TERMINAL_HUB_ID="terminal-hub"
+FLAGSHIP_AGENT_ID="gaia"
 
 # Network limits: a black-holed connection must fail, not hang silently.
 CONNECT_TIMEOUT=15
@@ -285,6 +286,104 @@ terminal_hub_python() {
     fi
 }
 
+# Read one artifact's version and SHA-256 out of a hub manifest. The manifest is
+# the only source for the version, the per-platform filename, and the
+# Worker-computed digest, so both installers read it the same way.
+#
+# Args: python, manifest path, filename. Echoes "<version> <sha256>".
+read_hub_manifest() {
+    "$1" - "$2" "$3" <<'MANIFEST_PY'
+import json
+import sys
+
+manifest_path, filename = sys.argv[1], sys.argv[2]
+try:
+    with open(manifest_path, encoding="utf-8") as fh:
+        manifest = json.load(fh)
+except (OSError, ValueError) as exc:
+    sys.exit("the hub manifest is not readable JSON: %s" % exc)
+
+version = manifest.get("latest_version")
+if not version:
+    sys.exit("the hub manifest declares no latest_version")
+
+entry = (manifest.get("versions") or {}).get(version)
+if not isinstance(entry, dict):
+    sys.exit("the hub manifest names latest_version %s but publishes no such version" % version)
+
+artifacts = entry.get("artifacts")
+if not artifacts:
+    primary = entry.get("artifact")
+    artifacts = [primary] if primary else []
+
+match = next((a for a in artifacts if a.get("filename") == filename), None)
+if match is None:
+    listed = ", ".join(sorted(a.get("filename", "?") for a in artifacts)) or "none"
+    sys.exit("version %s publishes no %s (it publishes: %s)" % (version, filename, listed))
+
+digest = match.get("sha256")
+if not digest:
+    sys.exit("version %s publishes %s with no SHA-256" % (version, filename))
+
+print("%s %s" % (version, digest))
+MANIFEST_PY
+}
+
+# Download one hub artifact and refuse to install it unless its SHA-256 matches
+# what the manifest published. Shared by the terminal hub and the flagship agent
+# so there is exactly one place the verification rule lives.
+#
+# Args: url, temp path, expected digest, destination path, label.
+download_and_verify() {
+    _url="$1"; _tmp="$2"; _want="$3"; _dest="$4"; _label="$5"
+
+    if ! fetch_file "$_url" "$_tmp"; then
+        print_error "Could not download the $_label binary."
+        echo "  URL:  $_url"
+        echo "  Fix:  check your network and retry."
+        return 1
+    fi
+
+    # No checksum, no install.
+    if command -v sha256sum > /dev/null 2>&1; then
+        _got="$(sha256sum "$_tmp" | awk '{print $1}')"
+    elif command -v shasum > /dev/null 2>&1; then
+        _got="$(shasum -a 256 "$_tmp" | awk '{print $1}')"
+    else
+        print_error "No sha256sum or shasum available to verify the download."
+        echo "  Fix:  install coreutils (Linux) or perl (macOS ships shasum), then retry."
+        return 1
+    fi
+
+    if [ "$_want" != "$_got" ]; then
+        print_error "Checksum mismatch for $_label — refusing to install."
+        echo "  expected $_want"
+        echo "  got      $_got"
+        echo "  Fix:  retry; if it persists report it at https://github.com/amd/gaia/issues"
+        return 1
+    fi
+
+    # Checked, because this is where a verified download still fails: an
+    # unwritable directory, a full disk, a read-only $HOME. Both callers invoke
+    # this as `if ! download_and_verify ...`, which switches `set -e` off inside
+    # the body, so an unchecked failure here reached the caller as success and
+    # printed "installed" over a binary that was never written.
+    # (A running gaia-tui is not one of the cases: `install` unlinks the target
+    # first, so the replace succeeds and the live process keeps the old inode.)
+    if ! mkdir -p "$(dirname "$_dest")"; then
+        print_error "Could not create $(dirname "$_dest") for $_label."
+        echo "  Fix:  check you own that directory and that the disk is not full."
+        return 1
+    fi
+    if ! install -m 0755 "$_tmp" "$_dest"; then
+        print_error "Downloaded and verified $_label, but could not write $_dest."
+        echo "  Fix:  check you own $(dirname "$_dest") and that it is writable, then retry."
+        echo "  Look: free disk space, and whether $_dest is held by another tool."
+        return 1
+    fi
+    return 0
+}
+
 # A missing terminal hub fails the install — it is the advertised entry point.
 install_tui() {
     print_step "Installing the GAIA terminal hub"
@@ -322,42 +421,7 @@ install_tui() {
     # The manifest is the only source for the version, the per-platform
     # filename, and the Worker-computed SHA-256.
     resolved=""
-    if ! resolved="$("$py" - "$tmp/manifest.json" "$filename" <<'PYEOF'
-import json
-import sys
-
-manifest_path, filename = sys.argv[1], sys.argv[2]
-try:
-    with open(manifest_path, encoding="utf-8") as fh:
-        manifest = json.load(fh)
-except (OSError, ValueError) as exc:
-    sys.exit("the hub manifest is not readable JSON: %s" % exc)
-
-version = manifest.get("latest_version")
-if not version:
-    sys.exit("the hub manifest declares no latest_version")
-
-entry = (manifest.get("versions") or {}).get(version)
-if not isinstance(entry, dict):
-    sys.exit("the hub manifest names latest_version %s but publishes no such version" % version)
-
-artifacts = entry.get("artifacts")
-if not artifacts:
-    primary = entry.get("artifact")
-    artifacts = [primary] if primary else []
-
-match = next((a for a in artifacts if a.get("filename") == filename), None)
-if match is None:
-    listed = ", ".join(sorted(a.get("filename", "?") for a in artifacts)) or "none"
-    sys.exit("version %s publishes no %s (it publishes: %s)" % (version, filename, listed))
-
-digest = match.get("sha256")
-if not digest:
-    sys.exit("version %s publishes %s with no SHA-256" % (version, filename))
-
-print("%s %s" % (version, digest))
-PYEOF
-)"; then
+    if ! resolved="$(read_hub_manifest "$py" "$tmp/manifest.json" "$filename")"; then
         print_error "Could not resolve the terminal hub build for $platform."
         echo "  Reported above by the manifest reader."
         echo "  Fix:  if your platform is genuinely unpublished, build from source:"
@@ -371,39 +435,79 @@ PYEOF
 
     binary_url="$GAIA_HUB_BASE_URL/agents/$TERMINAL_HUB_ID/$version/$filename"
     print_step "Downloading terminal hub $version for $platform"
-    if ! fetch_file "$binary_url" "$tmp/$filename"; then
-        print_error "Could not download the terminal hub binary."
-        echo "  URL:  $binary_url"
-        echo "  Fix:  check your network and retry."
+    # Never `gaia`: tui/internal/daemon/client.go resolves `gaia` on PATH to
+    # start the Python-owned daemon, so a Go binary by that name finds itself.
+    if ! download_and_verify "$binary_url" "$tmp/$filename" "$want" \
+            "$GAIA_BIN/gaia-tui" "terminal hub"; then
         echo "  Look: $manifest_url lists what is published for $version."
         exit 1
     fi
+    print_success "Terminal hub $version installed to $GAIA_BIN/gaia-tui"
+}
 
-    # No checksum, no install.
-    if command -v sha256sum > /dev/null 2>&1; then
-        got="$(sha256sum "$tmp/$filename" | awk '{print $1}')"
-    elif command -v shasum > /dev/null 2>&1; then
-        got="$(shasum -a 256 "$tmp/$filename" | awk '{print $1}')"
-    else
-        print_error "No sha256sum or shasum available to verify the download."
-        echo "  Fix:  install coreutils (Linux) or perl (macOS ships shasum), then retry."
-        exit 1
+# The flagship agent's frozen sidecar. The terminal hub spawns `gaia-agent` as a
+# child process, so without this binary the flagship is listed but cannot run —
+# which is what `curl | sh` left behind before: a UI with no agent under it.
+#
+# Installed BESIDE gaia-tui on purpose. The hub resolves its agent from its own
+# directory first (catalog.resolveAgentBinary), so a stale gaia-agent elsewhere
+# on PATH cannot shadow the one this script just verified.
+#
+# Not fatal when a platform has no published sidecar: the hub itself still works
+# and other agents still run, so this warns and continues rather than failing an
+# otherwise good install. It is never silent — an unrunnable flagship is exactly
+# the thing a user must be told about.
+install_flagship_agent() {
+    print_step "Installing the GAIA flagship agent"
+
+    platform=""
+    if ! platform="$(terminal_hub_platform)"; then
+        print_warning "No flagship agent build for $(uname -s)/$(uname -m) — skipping."
+        echo "  The terminal hub still works; the GAIA agent will show as unavailable."
+        return 0
+    fi
+    filename="gaia-agent-${platform}"
+
+    py=""
+    if ! py="$(terminal_hub_python)"; then
+        print_warning "No Python interpreter available to read the agent manifest — skipping."
+        return 0
     fi
 
-    if [ "$want" != "$got" ]; then
-        print_error "Checksum mismatch for $filename — refusing to install."
-        echo "  expected $want"
-        echo "  got      $got"
-        echo "  Fix:  retry; if it persists report it at https://github.com/amd/gaia/issues"
+    scratch_dir agent
+    tmp="$SCRATCH"
+
+    manifest_url="$GAIA_HUB_BASE_URL/agents/$FLAGSHIP_AGENT_ID/manifest.json"
+    if ! fetch_file "$manifest_url" "$tmp/manifest.json"; then
+        print_warning "Could not fetch the flagship agent manifest — skipping."
+        echo "  URL:  $manifest_url"
+        echo "  The GAIA agent will show as unavailable until you re-run this installer."
+        return 0
+    fi
+
+    resolved=""
+    if ! resolved="$(read_hub_manifest "$py" "$tmp/manifest.json" "$filename")"; then
+        print_warning "The hub publishes no flagship agent for $platform — skipping."
+        echo "  Reported above by the manifest reader."
+        echo "  Look: $manifest_url"
+        return 0
+    fi
+
+    version="${resolved%% *}"
+    want="${resolved##* }"
+
+    binary_url="$GAIA_HUB_BASE_URL/agents/$FLAGSHIP_AGENT_ID/$version/$filename"
+    print_step "Downloading GAIA agent $version for $platform"
+    if ! download_and_verify "$binary_url" "$tmp/$filename" "$want" \
+            "$GAIA_BIN/gaia-agent" "GAIA agent"; then
+        # A checksum mismatch is never downgraded to a warning.
         echo "  Look: $manifest_url"
         exit 1
     fi
-
-    # Never `gaia`: tui/internal/daemon/client.go resolves `gaia` on PATH to
-    # start the Python-owned daemon, so a Go binary by that name finds itself.
-    mkdir -p "$GAIA_BIN"
-    install -m 0755 "$tmp/$filename" "$GAIA_BIN/gaia-tui"
-    print_success "Terminal hub $version installed to $GAIA_BIN/gaia-tui"
+    # Read by show_next_steps: every path above this line leaves the machine
+    # without an agent, and the closing banner must not promise one.
+    FLAGSHIP_INSTALLED=1
+    print_success "GAIA agent $version installed to $GAIA_BIN/gaia-agent"
 }
 
 # Add GAIA to PATH
@@ -499,7 +603,14 @@ show_next_steps() {
     fi
     printf '  2. Set up the local model runtime: %sgaia init%s\n' "$COLOR_GREEN" "$COLOR_RESET"
     echo "     (installs Lemonade Server — asks for your password)"
-    printf '  3. Open the terminal hub: %sgaia-tui%s\n' "$COLOR_GREEN" "$COLOR_RESET"
+    if [ "${FLAGSHIP_INSTALLED:-0}" = "1" ]; then
+        printf '  3. Talk to the agent: %sgaia-tui%s\n' "$COLOR_GREEN" "$COLOR_RESET"
+        printf '     (it opens the GAIA agent; type %s/hub%s for the agent hub)\n' "$COLOR_GREEN" "$COLOR_RESET"
+    else
+        printf '  3. Open the terminal hub: %sgaia-tui%s\n' "$COLOR_GREEN" "$COLOR_RESET"
+        printf '     %sThe GAIA agent was skipped — see the warning above — so this\n' "$COLOR_YELLOW"
+        printf '     opens the agent list, not a chat. Re-run this installer to retry.%s\n' "$COLOR_RESET"
+    fi
     echo ""
 
     printf '%sDocumentation:%s https://amd-gaia.ai\n' "$COLOR_CYAN" "$COLOR_RESET"
@@ -533,6 +644,10 @@ main() {
 
     # Install the terminal hub binary
     install_tui
+
+    # The agent the hub spawns. After install_tui so it lands in the same
+    # directory, which is where the hub looks for it first.
+    install_flagship_agent
 
     # Show next steps
     show_next_steps

--- a/tests/unit/installer/test_install_scripts_terminal_hub.py
+++ b/tests/unit/installer/test_install_scripts_terminal_hub.py
@@ -72,8 +72,11 @@ def test_ps1_reads_the_agent_hub(ps1_text):
     assert "releases/latest/download" not in ps1_text
     assert "hub.amd-gaia.ai" in ps1_text
     assert '$TERMINAL_HUB_ID = "terminal-hub"' in ps1_text
-    assert "/agents/$TERMINAL_HUB_ID/manifest.json" in ps1_text
-    assert "/agents/$TERMINAL_HUB_ID/$version/$filename" in ps1_text
+    # The hub id is a parameter now — one resolver serves the terminal hub and
+    # the agent — so the URL is built from $AgentId rather than a literal.
+    assert "/agents/$AgentId/manifest.json" in ps1_text
+    assert "/agents/$AgentId/$version/$Filename" in ps1_text
+    assert "-AgentId $TERMINAL_HUB_ID" in ps1_text
 
 
 def test_component_id_matches_the_published_manifest():
@@ -120,9 +123,12 @@ def test_binary_is_installed_as_gaia_tui(sh_text, ps1_text):
     """tui/internal/daemon/client.go resolves `gaia` on PATH to start the
     Python-owned daemon; a Go binary named `gaia` would find itself."""
     assert '"$GAIA_BIN/gaia-tui"' in sh_text
-    assert "$GAIA_BIN\\gaia-tui.exe" in ps1_text
+    # PowerShell installs through a shared helper, so the leaf name is passed
+    # as -DestName and joined to $GAIA_BIN inside it.
+    assert '-DestName "gaia-tui.exe"' in ps1_text
+    assert "$GAIA_BIN\\$DestName" in ps1_text
     assert '"$GAIA_BIN/gaia"' not in sh_text
-    assert "$GAIA_BIN\\gaia.exe" not in ps1_text
+    assert '-DestName "gaia.exe"' not in ps1_text
 
 
 def test_path_registration_covers_the_terminal_hub_bin_dir(sh_text, ps1_text):
@@ -188,16 +194,66 @@ def test_install_tui_never_soft_skips(sh_text):
     body = _shell_function_body(sh_text, "install_tui")
     assert "return 0" not in body
     assert "skipping" not in body
-    # Every failure branch aborts.
-    assert body.count("exit 1") >= 6
+    # Every failure branch aborts. Download and checksum handling moved into
+    # download_and_verify, so install_tui turns its non-zero return into an
+    # exit rather than owning that branch itself.
+    assert "download_and_verify" in body
+    assert body.count("exit 1") >= 5
+    assert re.search(r"if ! download_and_verify.*?\n.*?exit 1", body, re.DOTALL)
 
 
 def test_install_tui_refuses_an_unverified_binary(sh_text, ps1_text):
-    body = _shell_function_body(sh_text, "install_tui")
-    assert "publishes %s with no SHA-256" in body
-    assert "Checksum mismatch" in body
+    # Both live in the shared helpers now — one copy of the rule for the
+    # terminal hub and the agent, rather than a copy per caller.
+    assert "publishes %s with no SHA-256" in _shell_function_body(
+        sh_text, "read_hub_manifest"
+    )
+    assert "Checksum mismatch" in _shell_function_body(sh_text, "download_and_verify")
     assert "no SHA-256" in ps1_text
     assert "Checksum mismatch" in ps1_text
+
+
+# ── the flagship agent sidecar ─────────────────────────────────────────────
+#
+# `gaia-tui` spawns `gaia-agent` as a child, so a bootstrap that installs only
+# the hub leaves a UI with no agent under it.
+
+
+def test_both_scripts_install_the_flagship_agent(sh_text, ps1_text):
+    assert 'FLAGSHIP_AGENT_ID="gaia"' in sh_text
+    assert '$FLAGSHIP_AGENT_ID = "gaia"' in ps1_text
+    assert '"$GAIA_BIN/gaia-agent"' in sh_text
+    assert '-DestName "gaia-agent.exe"' in ps1_text
+
+
+def test_agent_is_fetched_under_the_hub_key_it_is_published_as(ps1_text):
+    """The sidecar publishes as win32-x64; the terminal hub uses win-x64.
+
+    Constructing `gaia-agent-win-x64.exe` 404s against a hub that only ever
+    published `gaia-agent-win32-x64.exe`, and only on a cold fetch.
+    """
+    assert "-replace '^win-', 'win32-'" in ps1_text
+
+
+def test_a_missing_agent_build_is_survivable_but_a_bad_one_is_not(sh_text):
+    """Absence and corruption are different failures and must not be merged.
+
+    No published build for this platform is a warning — the hub still works.
+    Bytes that do not match the digest are an integrity failure and stop the
+    install outright.
+    """
+    body = _shell_function_body(sh_text, "install_flagship_agent")
+    assert "skipping" in body
+    assert body.count("return 0") >= 3
+    # …but the verified-download branch aborts rather than skipping.
+    assert re.search(r"if ! download_and_verify.*?\n.*?exit 1", body, re.DOTALL)
+
+
+def test_the_closing_banner_only_promises_an_agent_that_installed(sh_text, ps1_text):
+    """Every early return above leaves no agent; the banner must not claim one."""
+    assert "FLAGSHIP_INSTALLED=1" in sh_text
+    assert 'if [ "${FLAGSHIP_INSTALLED:-0}" = "1" ]' in sh_text
+    assert "-FlagshipInstalled" in ps1_text
 
 
 def test_elevation_is_announced_before_it_is_needed(sh_text, ps1_text):

--- a/tests/unit/installer/test_install_scripts_terminal_hub.py
+++ b/tests/unit/installer/test_install_scripts_terminal_hub.py
@@ -8,9 +8,10 @@ pointing at a channel nothing published to:
 
 * static — the Agent Hub URL shape, the platform keys, the binary name, and the
   absence of bash-only syntax (the documented one-liner pipes into ``sh``);
-* functional — ``install_tui`` run for real against a throwaway HTTP server that
-  serves a manifest in the Worker's shape, asserting it installs on a match and
-  installs *nothing* on a checksum mismatch.
+* functional — ``install_tui`` and ``install_flagship_agent`` run for real
+  against a throwaway HTTP server serving manifests in the Worker's shape. The
+  hub is mandatory and the agent is optional, and only running them can tell a
+  survivable failure (no build, download blip) from a fatal one (bad digest).
 """
 
 from __future__ import annotations
@@ -235,20 +236,6 @@ def test_agent_is_fetched_under_the_hub_key_it_is_published_as(ps1_text):
     assert "-replace '^win-', 'win32-'" in ps1_text
 
 
-def test_a_missing_agent_build_is_survivable_but_a_bad_one_is_not(sh_text):
-    """Absence and corruption are different failures and must not be merged.
-
-    No published build for this platform is a warning — the hub still works.
-    Bytes that do not match the digest are an integrity failure and stop the
-    install outright.
-    """
-    body = _shell_function_body(sh_text, "install_flagship_agent")
-    assert "skipping" in body
-    assert body.count("return 0") >= 3
-    # …but the verified-download branch aborts rather than skipping.
-    assert re.search(r"if ! download_and_verify.*?\n.*?exit 1", body, re.DOTALL)
-
-
 def test_the_closing_banner_only_promises_an_agent_that_installed(sh_text, ps1_text):
     """Every early return above leaves no agent; the banner must not claim one."""
     assert "FLAGSHIP_INSTALLED=1" in sh_text
@@ -329,46 +316,68 @@ class _QuietHandler(http.server.SimpleHTTPRequestHandler):
         pass
 
 
+HUB_PLATFORMS = ("linux-x64", "linux-arm64", "darwin-x64", "darwin-arm64")
+HUB_VERSION = "0.99.0"
+
+
 @pytest.fixture
 def fake_hub(tmp_path):
-    """Serve an Agent-Hub-shaped manifest plus one binary over loopback."""
+    """Serve Agent-Hub-shaped manifests plus their binaries over loopback.
+
+    Yields ``(base_url, publish)``. ``publish`` (re)writes one agent's manifest
+    and artifacts, so a test can stage exactly the failure it is about:
+    a tampered digest, a manifest that resolves but whose binary 404s, or a
+    manifest that publishes nothing for this machine's platform.
+    """
     root = tmp_path / "hub"
-    version_dir = root / "agents" / "terminal-hub" / "0.99.0"
-    version_dir.mkdir(parents=True)
 
-    payload = b"#!/bin/sh\necho gaia-tui 0.99.0\n"
-    digests = {}
-    for key in ("linux-x64", "linux-arm64", "darwin-x64", "darwin-arm64"):
-        (version_dir / f"gaia-{key}").write_bytes(payload + key.encode())
-        digests[key] = hashlib.sha256(payload + key.encode()).hexdigest()
-
-    def write_manifest(overrides=None):
-        artifacts = [
-            {
-                "filename": f"gaia-{key}",
-                "path": f"agents/terminal-hub/0.99.0/gaia-{key}",
-                "size_bytes": len(payload) + len(key),
-                "sha256": (overrides or {}).get(key, digest),
-                "content_type": "application/octet-stream",
-            }
-            for key, digest in digests.items()
-        ]
+    def publish(
+        agent_id,
+        prefix,
+        platforms=HUB_PLATFORMS,
+        digest_overrides=None,
+        omit_binaries=False,
+    ):
+        version_dir = root / "agents" / agent_id / HUB_VERSION
+        version_dir.mkdir(parents=True, exist_ok=True)
+        artifacts = []
+        for key in platforms:
+            blob = f"#!/bin/sh\necho {prefix} {HUB_VERSION} {key}\n".encode()
+            filename = f"{prefix}-{key}"
+            if omit_binaries:
+                # Published in the manifest, absent from the bucket: the
+                # transient-download-failure case, which must not be fatal.
+                (version_dir / filename).unlink(missing_ok=True)
+            else:
+                (version_dir / filename).write_bytes(blob)
+            artifacts.append(
+                {
+                    "filename": filename,
+                    "path": f"agents/{agent_id}/{HUB_VERSION}/{filename}",
+                    "size_bytes": len(blob),
+                    "sha256": (digest_overrides or {}).get(
+                        key, hashlib.sha256(blob).hexdigest()
+                    ),
+                    "content_type": "application/octet-stream",
+                }
+            )
         manifest = {
-            "id": "terminal-hub",
-            "latest_version": "0.99.0",
+            "id": agent_id,
+            "latest_version": HUB_VERSION,
             "versions": {
-                "0.99.0": {
-                    "version": "0.99.0",
+                HUB_VERSION: {
+                    "version": HUB_VERSION,
                     "artifact": artifacts[0],
                     "artifacts": artifacts,
                 }
             },
         }
-        (root / "agents" / "terminal-hub" / "manifest.json").write_text(
+        (root / "agents" / agent_id / "manifest.json").write_text(
             json.dumps(manifest), encoding="utf-8"
         )
 
-    write_manifest()
+    publish("terminal-hub", "gaia")
+    publish("gaia", "gaia-agent")
 
     handler = type(
         "Handler",
@@ -383,7 +392,7 @@ def fake_hub(tmp_path):
     thread = threading.Thread(target=server.serve_forever, daemon=True)
     thread.start()
     try:
-        yield f"http://127.0.0.1:{server.server_port}", write_manifest
+        yield f"http://127.0.0.1:{server.server_port}", publish
     finally:
         server.shutdown()
         server.server_close()
@@ -451,12 +460,9 @@ def test_install_tui_works_under_dash(tmp_path, fake_hub):
 @pytest.mark.skipif(sys.platform == "win32", reason="needs a POSIX shell")
 @pytest.mark.skipif(shutil.which("curl") is None, reason="needs curl")
 def test_install_tui_installs_nothing_on_a_checksum_mismatch(tmp_path, fake_hub):
-    base_url, write_manifest = fake_hub
-    write_manifest(
-        overrides={
-            key: "d" * 64
-            for key in ("linux-x64", "linux-arm64", "darwin-x64", "darwin-arm64")
-        }
+    base_url, publish = fake_hub
+    publish(
+        "terminal-hub", "gaia", digest_overrides={k: "d" * 64 for k in HUB_PLATFORMS}
     )
 
     result, installed = _run_install_tui(tmp_path, base_url)
@@ -474,6 +480,87 @@ def test_install_tui_fails_when_the_hub_is_unreachable(tmp_path):
     assert result.returncode != 0
     assert "Could not fetch the terminal hub manifest" in result.stdout + result.stderr
     assert not installed.exists()
+
+
+# ── functional: the flagship sidecar is optional, but never unverified ──────
+#
+# The whole point of the sidecar step is that it can fail without taking a
+# complete install down with it — except on a digest mismatch. Asserting that
+# over the script's source text cannot tell the two apart, so these run it.
+
+
+def _run_bootstrap(tmp_path, base_url):
+    """Run install_tui then install_flagship_agent, as main() does."""
+    result, home = _run_sh_function(
+        tmp_path,
+        "DOWNLOAD_CMD=curl; install_tui; install_flagship_agent; "
+        'echo "FLAGSHIP_INSTALLED=${FLAGSHIP_INSTALLED:-0}"',
+        {"GAIA_HUB_BASE_URL": base_url},
+    )
+    bin_dir = home / ".gaia" / "bin"
+    return result, bin_dir / "gaia-tui", bin_dir / "gaia-agent"
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="needs a POSIX shell")
+@pytest.mark.skipif(shutil.which("curl") is None, reason="needs curl")
+def test_a_verified_agent_installs_and_arms_the_banner(tmp_path, fake_hub):
+    base_url, _ = fake_hub
+    result, tui, agent = _run_bootstrap(tmp_path, base_url)
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert tui.is_file() and agent.is_file()
+    assert os.access(agent, os.X_OK)
+    assert "FLAGSHIP_INSTALLED=1" in result.stdout
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="needs a POSIX shell")
+@pytest.mark.skipif(shutil.which("curl") is None, reason="needs curl")
+def test_an_unpublished_agent_platform_leaves_the_hub_installed(tmp_path, fake_hub):
+    """No build for this machine is a warning, not a failed install."""
+    base_url, publish = fake_hub
+    publish("gaia", "gaia-agent", platforms=("aix-ppc64",))
+
+    result, tui, agent = _run_bootstrap(tmp_path, base_url)
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert tui.is_file()
+    assert not agent.exists()
+    assert "Could not resolve the flagship agent" in result.stdout
+    assert "FLAGSHIP_INSTALLED=0" in result.stdout
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="needs a POSIX shell")
+@pytest.mark.skipif(shutil.which("curl") is None, reason="needs curl")
+def test_a_failed_agent_download_leaves_the_hub_installed(tmp_path, fake_hub):
+    """A network blip after uv, the package, the hub and PATH are all in place
+    must not throw that away — the sidecar is the only thing missing."""
+    base_url, publish = fake_hub
+    publish("gaia", "gaia-agent", omit_binaries=True)
+
+    result, tui, agent = _run_bootstrap(tmp_path, base_url)
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert tui.is_file()
+    assert not agent.exists()
+    assert "The GAIA agent did not install" in result.stdout
+    assert "FLAGSHIP_INSTALLED=0" in result.stdout
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="needs a POSIX shell")
+@pytest.mark.skipif(shutil.which("curl") is None, reason="needs curl")
+def test_a_tampered_agent_aborts_and_writes_nothing(tmp_path, fake_hub):
+    """Integrity is the one agent failure that is never downgraded."""
+    base_url, publish = fake_hub
+    publish("gaia", "gaia-agent", digest_overrides={k: "d" * 64 for k in HUB_PLATFORMS})
+
+    result, tui, agent = _run_bootstrap(tmp_path, base_url)
+
+    assert result.returncode != 0
+    assert "Checksum mismatch" in result.stdout + result.stderr
+    assert not agent.exists()
+    # The hub landed before the agent step ran; only the agent is refused.
+    assert tui.is_file()
+    assert "FLAGSHIP_INSTALLED=1" not in result.stdout
 
 
 # ── functional: add_to_path ────────────────────────────────────────────────


### PR DESCRIPTION
`curl … | sh` and `irm … | iex` installed the terminal hub and nothing else, so `gaia-tui` opened onto an agent list with no GAIA agent behind it — the hub spawns `gaia-agent` as a child process and there was no such binary on disk. Both scripts now fetch the frozen sidecar from the same hub manifest, verified against the same SHA-256, and install it beside `gaia-tui`.

Recoverable and corrupt stay different outcomes: no published sidecar for the platform, or a download that fails, warns and continues — the hub and the Python CLI are already installed and still work. Only bytes that do not match the digest stop the install outright, with nothing left on disk.

Salvaged from #3128, which bundled this with a second, parallel installer system that duplicates the one #3125 already landed. This is the part that stands alone.

## Test plan

- [ ] `PYTHONPATH=$(pwd)/src python -m pytest tests/unit/installer/test_install_scripts_terminal_hub.py`
- [ ] Cold container: `docker run --rm ubuntu:24.04`, run the hub + agent install, confirm both binaries land, `gaia-tui version` runs, and the installed agent's SHA-256 equals the hub manifest's
- [ ] Point `GAIA_HUB_BASE_URL` at a mirror serving a manifest with a wrong digest — the install must exit non-zero and leave no `gaia-agent`
- [ ] Serve a manifest with no build for the platform — must warn, exit 0, and the closing banner must not promise an agent
- [ ] Windows: run `Install-FlagshipAgent` with `$env:USERPROFILE` pointed at a scratch dir; confirm `gaia-agent.exe` lands and its digest matches

## Verified

Everything above was run, not just reasoned about.

| Check | Result |
|---|---|
| Cold Ubuntu 24.04 container, nothing pre-installed | `gaia-tui` 0.23.0 + `gaia-agent` 0.1.1 installed; `gaia-tui version` runs |
| Installed agent digest vs hub manifest (Linux) | match — `b704f83a…60c7a` |
| Installed agent digest vs hub manifest (Windows) | match — `416ed0e2…6856a` |
| Manifest serving a tampered digest | exit 1, expected-vs-got printed, **nothing written** |
| Manifest with the platform's build removed | warning, exit 0, banner does not promise an agent |
| `tests/unit/installer/` | 42 passed under Linux; on Windows only the two known pre-existing failures |

<details>
<summary>🔍 Three notes for the reviewer</summary>

**`test_sh_parses_under_dash` fails on a Windows checkout.** It is the CRLF the working tree carries, not the script: taking main's own committed blob and adding CRLF reproduces the identical `line 83: Syntax error` . The committed blob is LF (`CR=0`) in both main and here, and the LF file parses under dash cleanly, so CI is unaffected.

**The `[✓]`/`[✗]` → `[OK]`/`[X]` swap in `install.ps1` is not cosmetic drive-by.** The script is BOM-less UTF-8, which Windows PowerShell 5.1 reads as ANSI, so those glyphs render as mojibake on the exact platform the script targets. ASCII also matches `install.sh`.

**`test_uninstall_command.py` fails on `main` already** — 6 failures and 3 errors on a clean `origin/main` worktree, untouched by this change.
</details>
