### PR TITLE
fix(telegram): apply the allowlist to every handler, not just messages

### DIFF
--- a/src/gaia/messaging/telegram.py
+++ b/src/gaia/messaging/telegram.py
@@ -11,6 +11,7 @@ Notes:
 from __future__ import annotations
 
 import asyncio
+import functools
 import os
 import signal
 import tempfile
@@ -43,6 +44,29 @@ def get_or_create_session(user_id: int) -> AgentSDK:
         return sdk
 
 
+UNAUTHORIZED_REPLY = "Sorry — you're not authorized to use this bot."
+
+
+def require_allowed(handler):
+    """Enforce the allowlist on a Telegram update handler.
+
+    Every handler needs its own check: command updates are routed to their
+    ``CommandHandler`` and never reach the ``~filters.COMMAND`` message handler.
+    """
+
+    @functools.wraps(handler)
+    async def guarded(self, update, context):
+        user = update.effective_user
+        if not self._allowed(user.id):
+            log.warning("Refused Telegram message from unauthorized user %s", user.id)
+            await update.message.reply_text(UNAUTHORIZED_REPLY)
+            return None
+        return await handler(self, update, context)
+
+    guarded.__gaia_allowlist_guarded__ = True
+    return guarded
+
+
 class TelegramAdapter:
     def __init__(self, token: str, allowed_users: Optional[Set[int]] = None):
         self.token = token
@@ -54,20 +78,15 @@ class TelegramAdapter:
             return True
         return user_id in self.allowed_users
 
+    @require_allowed
     async def _handle_start(self, update, context):
         await update.message.reply_text(
             "Hello! I'm Gaia. Send a message and I'll respond (streaming)."
         )
 
+    @require_allowed
     async def _handle_message(self, update, context):
         user = update.effective_user
-        if not self._allowed(user.id):
-            log.warning("Refused Telegram message from unauthorized user %s", user.id)
-            await update.message.reply_text(
-                "Sorry — you're not authorized to use this bot."
-            )
-            return
-
         text = update.message.text or ""
 
         # If the user sent media, note it and download to tmp for later ingestion

--- a/tests/unit/test_telegram_adapter.py
+++ b/tests/unit/test_telegram_adapter.py
@@ -8,7 +8,7 @@ import pytest
 
 sys.path.insert(0, os.path.abspath("src"))
 
-from gaia.messaging.telegram import TelegramAdapter
+from gaia.messaging.telegram import UNAUTHORIZED_REPLY, TelegramAdapter
 
 
 def test_run_telegram_scaffold_returns_adapter(mock_home, monkeypatch):
@@ -50,10 +50,52 @@ async def test_unknown_user_is_refused_before_session_creation(monkeypatch, capl
     with caplog.at_level(logging.WARNING, logger="gaia.messaging.telegram"):
         await adapter._handle_message(update, None)
 
-    reply_text.assert_awaited_once_with(
-        "Sorry — you're not authorized to use this bot."
-    )
+    reply_text.assert_awaited_once_with(UNAUTHORIZED_REPLY)
     assert "Refused Telegram message from unauthorized user 99999" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_unknown_user_is_refused_by_start_command(caplog):
+    adapter = TelegramAdapter(token="fake-token", allowed_users={12345})
+    reply_text = AsyncMock()
+    update = SimpleNamespace(
+        effective_user=SimpleNamespace(id=99999),
+        message=SimpleNamespace(reply_text=reply_text),
+    )
+
+    with caplog.at_level(logging.WARNING, logger="gaia.messaging.telegram"):
+        await adapter._handle_start(update, None)
+
+    reply_text.assert_awaited_once_with(UNAUTHORIZED_REPLY)
+    assert "Refused Telegram message from unauthorized user 99999" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_allowed_user_gets_start_greeting():
+    adapter = TelegramAdapter(token="fake-token", allowed_users={12345})
+    reply_text = AsyncMock()
+    update = SimpleNamespace(
+        effective_user=SimpleNamespace(id=12345),
+        message=SimpleNamespace(reply_text=reply_text),
+    )
+
+    await adapter._handle_start(update, None)
+
+    assert reply_text.await_args.args[0].startswith("Hello! I'm Gaia.")
+
+
+def test_every_update_handler_enforces_the_allowlist():
+    """A handler added without ``@require_allowed`` is reachable unauthenticated."""
+    handlers = [name for name in dir(TelegramAdapter) if name.startswith("_handle_")]
+    assert handlers, "no update handlers found — did they get renamed?"
+    unguarded = [
+        name
+        for name in handlers
+        if not getattr(
+            getattr(TelegramAdapter, name), "__gaia_allowlist_guarded__", False
+        )
+    ]
+    assert not unguarded, f"handlers missing @require_allowed: {unguarded}"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
The Telegram bot's `/start` greeting answered anyone who sent it — the allowlist was only checked on the message path, and command updates are routed past that path. So a user who was never added to `--allowed-users` still got a reply from the bot. Now the greeting command enforces the same allowlist as every other message, with the same refusal text and the same warning log.

🔒 cc @kovtcharov-amd for awareness — this is live on `main` today.

The check moved into a `require_allowed` decorator applied to every handler rather than being patched into `_handle_start` alone. `/start` is the only command registered today, but the routing split means *any* command handler added later would inherit the same gap; a structural test now asserts every `_handle_*` method carries the decorator, so the next one fails CI instead of shipping open.

Credit to #3051 by @Devansh-awat for finding it. That PR also carries useful test coverage that isn't duplicated here — this PR is deliberately narrow (the fix plus its regression test) so the gap closes without waiting on a rebase.

## Test plan

- [ ] `python -m pytest tests/unit/test_telegram_adapter.py tests/unit/test_telegram_background.py tests/unit/test_telegram_sessions.py -q` → 10 passed
- [ ] Revert the `@require_allowed` line on `_handle_start` and re-run: `test_unknown_user_is_refused_by_start_command` and `test_every_update_handler_enforces_the_allowlist` both fail
- [ ] `python -m black --check src/gaia/messaging/telegram.py tests/unit/test_telegram_adapter.py`