### PR TITLE
test(telegram): cover media ingest paths

### DIFF
--- a/tests/unit/test_telegram_adapter.py
+++ b/tests/unit/test_telegram_adapter.py
@@ -98,3 +98,98 @@ async def test_allowed_user_streams_accumulated_response(monkeypatch):
         call("Hello"),
         call("Hello from Gaia"),
     ]
+
+
+@pytest.mark.asyncio
+async def test_photo_ingest_is_included_in_session_input(monkeypatch, tmp_path):
+    adapter = TelegramAdapter(token="fake-token", allowed_users={12345})
+    streamed_reply = AsyncMock()
+    reply_text = AsyncMock(return_value=streamed_reply)
+    downloaded_path = tmp_path / "gaia_telegram_photo-1.jpg"
+    downloaded_file = SimpleNamespace(
+        file_id="photo-1",
+        download_to_drive=AsyncMock(),
+    )
+    photo = SimpleNamespace(get_file=AsyncMock(return_value=downloaded_file))
+    update = SimpleNamespace(
+        effective_user=SimpleNamespace(id=12345),
+        message=SimpleNamespace(
+            text="What is shown here?",
+            photo=[photo],
+            document=None,
+            reply_text=reply_text,
+        ),
+    )
+    sent_inputs = []
+
+    class StubSession:
+        def send_stream(self, text):
+            sent_inputs.append(text)
+            return iter([SimpleNamespace(text="Description")])
+
+    monkeypatch.setattr(
+        "gaia.messaging.telegram.tempfile.gettempdir", lambda: str(tmp_path)
+    )
+    monkeypatch.setattr(
+        "gaia.messaging.telegram.ingest_image_to_vlm",
+        lambda path: {"status": "success", "text": "A red bicycle"},
+    )
+    monkeypatch.setattr(
+        "gaia.messaging.telegram.get_or_create_session", lambda user_id: StubSession()
+    )
+
+    await adapter._handle_message(update, None)
+
+    downloaded_file.download_to_drive.assert_awaited_once_with(str(downloaded_path))
+    assert sent_inputs == [
+        "What is shown here? [photo uploaded and processed] - A red bicycle"
+    ]
+
+
+@pytest.mark.asyncio
+async def test_document_ingest_failure_is_visible_in_session_input(
+    monkeypatch, tmp_path
+):
+    adapter = TelegramAdapter(token="fake-token", allowed_users={12345})
+    streamed_reply = AsyncMock()
+    reply_text = AsyncMock(return_value=streamed_reply)
+    downloaded_file = SimpleNamespace(
+        file_id="document-1",
+        download_to_drive=AsyncMock(),
+    )
+    document = SimpleNamespace(
+        file_name="notes.pdf", get_file=AsyncMock(return_value=downloaded_file)
+    )
+    update = SimpleNamespace(
+        effective_user=SimpleNamespace(id=12345),
+        message=SimpleNamespace(
+            text="Summarize this",
+            photo=[],
+            document=document,
+            reply_text=reply_text,
+        ),
+    )
+    sent_inputs = []
+
+    class StubSession:
+        def send_stream(self, text):
+            sent_inputs.append(text)
+            return iter([SimpleNamespace(text="Unable to index")])
+
+    monkeypatch.setattr(
+        "gaia.messaging.telegram.tempfile.gettempdir", lambda: str(tmp_path)
+    )
+    monkeypatch.setattr(
+        "gaia.messaging.telegram.ingest_document_to_rag",
+        lambda path: {"success": False},
+    )
+    monkeypatch.setattr(
+        "gaia.messaging.telegram.get_or_create_session", lambda user_id: StubSession()
+    )
+
+    await adapter._handle_message(update, None)
+
+    downloaded_file.download_to_drive.assert_awaited_once_with(
+        str(tmp_path / "gaia_telegram_document-1")
+    )
+    assert sent_inputs == ["Summarize this [file uploaded: notes.pdf - index failed]"]

--- a/tests/unit/test_telegram_adapter.py
+++ b/tests/unit/test_telegram_adapter.py
@@ -193,3 +193,97 @@ async def test_document_ingest_failure_is_visible_in_session_input(
         str(tmp_path / "gaia_telegram_document-1")
     )
     assert sent_inputs == ["Summarize this [file uploaded: notes.pdf - index failed]"]
+
+
+@pytest.mark.asyncio
+async def test_photo_ingest_failure_is_visible_in_session_input(monkeypatch, tmp_path):
+    adapter = TelegramAdapter(token="fake-token", allowed_users={12345})
+    streamed_reply = AsyncMock()
+    reply_text = AsyncMock(return_value=streamed_reply)
+    downloaded_file = SimpleNamespace(
+        file_id="photo-2",
+        download_to_drive=AsyncMock(),
+    )
+    photo = SimpleNamespace(get_file=AsyncMock(return_value=downloaded_file))
+    update = SimpleNamespace(
+        effective_user=SimpleNamespace(id=12345),
+        message=SimpleNamespace(
+            text="Describe this",
+            photo=[photo],
+            document=None,
+            reply_text=reply_text,
+        ),
+    )
+    sent_inputs = []
+
+    class StubSession:
+        def send_stream(self, text):
+            sent_inputs.append(text)
+            return iter([SimpleNamespace(text="Unable to describe")])
+
+    monkeypatch.setattr(
+        "gaia.messaging.telegram.tempfile.gettempdir", lambda: str(tmp_path)
+    )
+    monkeypatch.setattr(
+        "gaia.messaging.telegram.ingest_image_to_vlm",
+        lambda path: {"status": "error", "error": "vlm unavailable"},
+    )
+    monkeypatch.setattr(
+        "gaia.messaging.telegram.get_or_create_session", lambda user_id: StubSession()
+    )
+
+    await adapter._handle_message(update, None)
+
+    downloaded_file.download_to_drive.assert_awaited_once_with(
+        str(tmp_path / "gaia_telegram_photo-2.jpg")
+    )
+    assert sent_inputs == ["Describe this [photo uploaded - VLM failed]"]
+
+
+@pytest.mark.asyncio
+async def test_document_ingest_success_is_included_in_session_input(
+    monkeypatch, tmp_path
+):
+    adapter = TelegramAdapter(token="fake-token", allowed_users={12345})
+    streamed_reply = AsyncMock()
+    reply_text = AsyncMock(return_value=streamed_reply)
+    downloaded_file = SimpleNamespace(
+        file_id="document-2",
+        download_to_drive=AsyncMock(),
+    )
+    document = SimpleNamespace(
+        file_name="report.pdf", get_file=AsyncMock(return_value=downloaded_file)
+    )
+    update = SimpleNamespace(
+        effective_user=SimpleNamespace(id=12345),
+        message=SimpleNamespace(
+            text="Review this",
+            photo=[],
+            document=document,
+            reply_text=reply_text,
+        ),
+    )
+    sent_inputs = []
+
+    class StubSession:
+        def send_stream(self, text):
+            sent_inputs.append(text)
+            return iter([SimpleNamespace(text="Indexed")])
+
+    monkeypatch.setattr(
+        "gaia.messaging.telegram.tempfile.gettempdir", lambda: str(tmp_path)
+    )
+    monkeypatch.setattr(
+        "gaia.messaging.telegram.ingest_document_to_rag",
+        lambda path: {"success": True},
+    )
+    monkeypatch.setattr(
+        "gaia.messaging.telegram.get_or_create_session", lambda user_id: StubSession()
+    )
+
+    await adapter._handle_message(update, None)
+
+    downloaded_file.download_to_drive.assert_awaited_once_with(
+        str(tmp_path / "gaia_telegram_document-2")
+    )
+    assert sent_inputs == ["Review this [file indexed: report.pdf]"]


### PR DESCRIPTION
Telegram media uploads had no adapter-level regression coverage, so changes to VLM success handling or RAG failure reporting could pass without a test signal. These focused async tests assert the downloaded file paths and the exact session context sent to the agent for both successful photo processing and failed document indexing.

## Why

Issue #2986 calls for coverage of the Telegram media-ingest paths. The tests keep the user-visible context intact: processed photos include their extracted text, while indexing failures remain explicit instead of silently dropping the upload.

## Linked issue

Refs #2986

## Changes

- cover photo download and successful VLM context propagation
- cover document download and visible RAG indexing failure context

## Test plan

- [x] `/tmp/gaia/.venv/bin/pytest tests/unit/test_telegram_adapter.py -q` — 5 passed
- [x] `black --check tests/unit/test_telegram_adapter.py`
- [x] `isort --check-only tests/unit/test_telegram_adapter.py`

## Evidence

- [x] **Agent exposed in the Agent UI** — N/A: test-only change; no UI surface changed.
- [x] **MCP tools / servers** — N/A: test-only change; no MCP surface changed.
- [x] **CLI** — N/A: test-only change; no CLI surface changed.
- [x] **HTTP API / REST** — N/A: test-only change; no HTTP surface changed.

## Checklist

- [x] I have linked a GitHub issue above (`Refs #2986`).
- [x] I have described why this change is being made, not just what changed.
- [x] I have run focused linting and tests locally.
- [x] I have marked unrelated real-world evidence surfaces N/A because this is test-only.
- [x] I have not changed user-visible behavior or documentation.
