### PR TITLE
Show GAIA install alongside npm on hub agent pages

### DIFF
--- a/website/src/components/FeaturedCard.astro
+++ b/website/src/components/FeaturedCard.astro
@@ -16,9 +16,9 @@ interface Props {
 }
 
 const { agent, eyebrow = 'Featured' } = Astro.props;
-// The canonical primary install command (npm for npm agents, GAIA otherwise) —
-// same source as the detail page, so the card never shows a command the agent
-// cannot actually be installed with.
+// The canonical primary install command (the GAIA install for agents and
+// skills) — same source as the detail page, so the card never shows a command
+// the agent cannot actually be installed with.
 const installCmd = installMethods(agent)[0].command;
 
 // Metadata grid. Every value comes from the catalog; a field the catalog does

--- a/website/src/components/InstallCard.astro
+++ b/website/src/components/InstallCard.astro
@@ -7,7 +7,7 @@
 // from the catalog — nothing about a specific agent is written into the markup.
 
 import InstallMethods from './InstallMethods.astro';
-import { formatBytes, languageLabel, type Agent } from '../data/catalog';
+import { formatBytes, isAgent, languageLabel, type Agent } from '../data/catalog';
 
 interface Props {
   agent: Agent;
@@ -35,8 +35,8 @@ const meta = [
   <InstallMethods agent={agent} />
 
   <p class="mt-3.5 text-[13px] leading-[1.6] text-g-faint">
-    {isNpm && (
-      <span>Ships as an npm client plus a frozen binary sidecar — npm is its only supported install path (there is no PyPI wheel). </span>
+    {isAgent(agent) && isNpm && (
+      <span>Ships as an npm client plus a frozen binary sidecar — GAIA is the recommended install path (there is no PyPI wheel). The npm package is for embedding the agent in a JS/TS app. </span>
     )}
     A local model must be running first: <span class="mono text-g-muted">gaia init</span> then <span class="mono text-g-muted">lemonade-server serve</span>.
   </p>

--- a/website/src/components/InstallCard.astro
+++ b/website/src/components/InstallCard.astro
@@ -43,7 +43,10 @@ const meta = [
 
   <div class="mt-[18px] flex flex-wrap gap-3">
     {isNpm ? (
-      <a href={npmUrl} target="_blank" rel="noopener" class="g-btn g-btn-primary">View on npm</a>
+      <>
+        <a href={deepLink} class="g-btn g-btn-primary">Open in GAIA</a>
+        <a href={npmUrl} target="_blank" rel="noopener" class="g-btn g-btn-secondary">View on npm</a>
+      </>
     ) : (
       <a href={deepLink} class="g-btn g-btn-primary">Open in GAIA</a>
     )}

--- a/website/src/components/InstallMethods.astro
+++ b/website/src/components/InstallMethods.astro
@@ -23,8 +23,8 @@ const hasTabs = methods.length > 1;
 ---
 
 <div data-install-methods>
-  {/* The switcher only makes sense with 2+ methods. A single-method agent (e.g.
-      an npm-only sidecar) just shows its command — no lone, inert tab button. */}
+  {/* The switcher only makes sense with 2+ methods. A single-method entry (e.g.
+      a skill) just shows its command — no lone, inert tab button. */}
   {hasTabs && (
     <div
       role="tablist"

--- a/website/src/data/catalog.test.ts
+++ b/website/src/data/catalog.test.ts
@@ -90,6 +90,16 @@ describe('installMethods', () => {
     const methods = installMethods(entry({ id: 'chat', type: 'agent', language: 'python' }));
     expect(methods[0].command).toBe('gaia agent install chat');
   });
+
+  it('offers GAIA first for an npm agent, then npm', () => {
+    const methods = installMethods(
+      entry({ id: 'email', type: 'agent', language: 'typescript', npm_package: '@amd-gaia/agent-email' }),
+    );
+    expect(methods[0].key).toBe('gaia');
+    expect(methods[0].command).toBe('gaia agent install email');
+    expect(methods[1].key).toBe('npm');
+    expect(methods[1].command).toBe('npm i @amd-gaia/agent-email');
+  });
 });
 
 describe('display labels', () => {

--- a/website/src/data/catalog.ts
+++ b/website/src/data/catalog.ts
@@ -440,17 +440,6 @@ export interface InstallMethod {
   note: string;
 }
 
-/**
- * Install methods for an agent, derived from the MANIFEST — never from README
- * markup. We only ever show channels that actually work:
- *
- *  - An agent with `npm_package` (the email sidecar) is distributed as an npm
- *    client + frozen binary, NOT a PyPI wheel. We show GAIA first (recommended)
- *    and npm as the embed option — no broken `pip install` (there's no wheel)
- *    and no unverified source build.
- *  - Otherwise: the GAIA app install, a pip package for Python agents, and a
- *    source build (language-driven, the long-standing default).
- */
 /** An entry's package type, defaulting to 'agent' as the manifest schema does. */
 export function packageType(agent: Agent): PackageType {
   return agent.type ?? "agent";
@@ -466,6 +455,17 @@ export function isSkill(agent: Agent): boolean {
   return packageType(agent) === "skill";
 }
 
+/**
+ * Install methods for an agent, derived from the MANIFEST — never from README
+ * markup. We only ever show channels that actually work:
+ *
+ *  - An agent with `npm_package` (the email sidecar) is distributed as an npm
+ *    client + frozen binary, NOT a PyPI wheel. We show GAIA first (recommended)
+ *    and npm as the embed option — no broken `pip install` (there's no wheel)
+ *    and no unverified source build.
+ *  - Otherwise: the GAIA app install, a pip package for Python agents, and a
+ *    source build (language-driven, the long-standing default).
+ */
 export function installMethods(agent: Agent): InstallMethod[] {
   // A skill is not an agent package: it installs into ~/.gaia/skills/ and is
   // composed by any agent, so `gaia agent install` would not work for it.
@@ -519,7 +519,7 @@ export function installMethods(agent: Agent): InstallMethod[] {
         key: "npm",
         label: "npm",
         command: `npm i ${agent.npm_package}`,
-        note: "For embedding the agent in a JS/TS app — fetches the same binary at build time.",
+        note: "For embedding the agent in a JS/TS app — fetches the same binary at build time or first run.",
       },
     ];
   }

--- a/website/src/data/catalog.ts
+++ b/website/src/data/catalog.ts
@@ -86,8 +86,8 @@ export interface Agent {
   // when none was published or parseable. Drives the sidebar score badge.
   eval_score?: number;
   // npm package name (e.g. "@amd-gaia/agent-email") when the agent is
-  // distributed as an npm client + frozen sidecar. Present → npm is the install
-  // path. Absent → the agent installs via pip/GAIA (language-driven).
+  // distributed as an npm client + frozen sidecar. Present → GAIA install is
+  // shown first, with npm as the embed path. Absent → pip/GAIA (language-driven).
   npm_package?: string;
   // Localhost URL of the agent's interactive playground, served by its sidecar
   // (e.g. "http://127.0.0.1:8131/v1/email/playground"). Only resolves once the
@@ -445,9 +445,9 @@ export interface InstallMethod {
  * markup. We only ever show channels that actually work:
  *
  *  - An agent with `npm_package` (the email sidecar) is distributed as an npm
- *    client + frozen binary, NOT a PyPI wheel. npm is its single supported path,
- *    so we show only that — no broken `pip install` (there's no wheel) and no
- *    unverified source build.
+ *    client + frozen binary, NOT a PyPI wheel. We show GAIA first (recommended)
+ *    and npm as the embed option — no broken `pip install` (there's no wheel)
+ *    and no unverified source build.
  *  - Otherwise: the GAIA app install, a pip package for Python agents, and a
  *    source build (language-driven, the long-standing default).
  */
@@ -510,10 +510,16 @@ export function installMethods(agent: Agent): InstallMethod[] {
   if (agent.npm_package) {
     return [
       {
+        key: "gaia",
+        label: "GAIA",
+        command: `gaia agent install ${agent.id}`,
+        note: "Recommended — installs the binary sidecar into your GAIA app and registers the agent automatically.",
+      },
+      {
         key: "npm",
         label: "npm",
         command: `npm i ${agent.npm_package}`,
-        note: "",
+        note: "For embedding the agent in a JS/TS app — fetches the same binary at build time.",
       },
     ];
   }


### PR DESCRIPTION
## Summary
Hub agent pages currently show only the npm install command when an agent has an npm package. GAIA install should be first, with npm as the embed option.

This change returns both methods from installMethods, updates InstallCard copy for agents, and asserts the first method is gaia.

Closes #3147

## Test plan
Ran website catalog tests.