### PR TITLE
fix(chat): surface unavailable memory at startup

### DIFF
--- a/hub/agents/chat/python/tests/test_chat_agent.py
+++ b/hub/agents/chat/python/tests/test_chat_agent.py
@@ -59,6 +59,42 @@ def test_config_defaults():
     assert cfg.prompt_profile == "full"
 
 
+def test_memory_failure_is_reported_to_chat_console():
+    from gaia.agents.base.memory import (
+        MEMORY_UNAVAILABLE_DISABLED_BY_ENV,
+        MEMORY_UNAVAILABLE_MODEL_NOT_PULLED,
+        MemoryMixin,
+    )
+
+    class Console:
+        def __init__(self):
+            self.messages = []
+
+        def print_warning(self, message):
+            self.messages.append(message)
+
+    class Agent:
+        def __init__(self, reason):
+            self._memory_unavailable_reason = reason
+            self.console = Console()
+            self._memory_unavailable_warning_reported = False
+
+        def memory_unavailable_message(self):
+            return "Embedding model is unavailable; pull it and restart."
+
+    reported = Agent(MEMORY_UNAVAILABLE_MODEL_NOT_PULLED)
+    assert MemoryMixin.report_memory_unavailable(reported) is True
+    assert MemoryMixin.report_memory_unavailable(reported) is False
+    assert reported.console.messages == [
+        "Embedding model is unavailable; pull it and restart."
+    ]
+
+    for reason in (MEMORY_UNAVAILABLE_DISABLED_BY_ENV, None):
+        quiet = Agent(reason)
+        assert MemoryMixin.report_memory_unavailable(quiet) is False
+        assert quiet.console.messages == []
+
+
 def test_discovered_when_installed():
     from gaia.agents.registry import AgentRegistry
 

--- a/hub/agents/email/python/gaia_agent_email/agent.py
+++ b/hub/agents/email/python/gaia_agent_email/agent.py
@@ -1211,6 +1211,12 @@ class EmailTriageAgent(
         return super().get_memory_dynamic_context()
 
     def process_query(self, user_input: str, *args, **kwargs):
+        # EmailTriageAgent.__mro__ puts Agent before MemoryMixin, so
+        # Agent.process_query never delegates into MemoryMixin.process_query
+        # (unlike ChatAgent) — report here or the construction-time report is
+        # this session's only chance to warn about a UI console swapped in later.
+        self.report_memory_unavailable()
+
         # Zero the batch-organize counter per turn so a long-lived instance
         # can't carry a prior turn's count into the batch-confirm threshold.
         # Only the batch counter resets here; session preferences persist.

--- a/hub/agents/email/python/gaia_agent_email/agent.py
+++ b/hub/agents/email/python/gaia_agent_email/agent.py
@@ -92,11 +92,7 @@ if TYPE_CHECKING:  # import-cheap: only for annotations, never at runtime
 
 from gaia.agents.base.agent import Agent
 from gaia.agents.base.console import AgentConsole
-from gaia.agents.base.memory import (
-    MEMORY_UNAVAILABLE_MODEL_NOT_PULLED,
-    MEMORY_UNAVAILABLE_SERVICE_UNREACHABLE,
-    MemoryMixin,
-)
+from gaia.agents.base.memory import MemoryMixin
 from gaia.agents.base.tools import _TOOL_REGISTRY
 from gaia.agents.registry import get_embedding_model_for_device
 from gaia.connectors.errors import ConnectorsError
@@ -983,11 +979,7 @@ class EmailTriageAgent(
         # rather than being told memory failed to come up and how to fix it.
         # Skip the deliberate GAIA_MEMORY_DISABLED=1 opt-out here — that's an
         # explicit choice (used by tests/CI), not a silent degradation.
-        if getattr(self, "_memory_unavailable_reason", None) in (
-            MEMORY_UNAVAILABLE_MODEL_NOT_PULLED,
-            MEMORY_UNAVAILABLE_SERVICE_UNREACHABLE,
-        ):
-            self.console.print_warning(self.memory_unavailable_message())
+        self.report_memory_unavailable()
 
         # Exact ctx pin (#1892): set the instance-scoped override on the
         # concrete LemonadeClient this agent chats through. Post-super(),

--- a/hub/agents/email/python/tests/test_email_memory.py
+++ b/hub/agents/email/python/tests/test_email_memory.py
@@ -693,3 +693,77 @@ class TestMemoryDegradedStateNotice:
             assert agent.memory_status()["available"] is True
         finally:
             agent.close_db()
+
+    def test_process_query_reports_after_a_later_console_swap(
+        self, tmp_path, monkeypatch
+    ):
+        """UI/sidecar callers build the agent with a SilentConsole, then swap in
+        the real console once the first turn arrives (``agent.console = ...`` in
+        ``_chat_helpers.py``). EmailTriageAgent's MRO puts ``Agent`` ahead of
+        ``MemoryMixin``, so ``Agent.process_query`` never delegates into
+        ``MemoryMixin.process_query`` the way ``ChatAgent`` does — the notice
+        must instead be reported directly from
+        ``EmailTriageAgent.process_query`` or it never reaches this later,
+        real console.
+        """
+        from gaia.agents.base.agent import Agent
+        from gaia.agents.base.console import SilentConsole
+
+        model_not_found = RuntimeError(
+            "Embedding failed: Error generating embeddings: Request failed "
+            'with status 404: {"error":{"code":"model_not_found",'
+            '"message":"Model \'user.embeddinggemma-300m-GGUF\' was not '
+            'found."}}'
+        )
+        with patch.object(
+            EmailTriageAgent, "_create_console", return_value=SilentConsole()
+        ):
+            agent = _build_agent_with_failing_embedder(tmp_path, model_not_found)
+        try:
+            # Construction reported into the SilentConsole, which renders
+            # nothing — the one-shot flag must still be unspent (fix #2).
+            assert agent._memory_unavailable_warning_reported is False
+
+            real_console = MagicMock()
+            agent.console = real_console
+            monkeypatch.setattr(
+                Agent,
+                "process_query",
+                lambda self, *a, **k: {"status": "success", "result": "loop ran"},
+            )
+
+            agent.process_query("what's in my inbox")
+
+            real_console.print_warning.assert_called_once()
+            assert "not been pulled" in real_console.print_warning.call_args[0][0]
+            assert agent._memory_unavailable_warning_reported is True
+        finally:
+            agent.close_db()
+
+    def test_silent_console_does_not_spend_the_one_shot_report(self, tmp_path):
+        """Reporting into a ``SilentConsole`` must not mark the notice as
+        delivered — a later real console must still get it (fix #2)."""
+        from gaia.agents.base.console import SilentConsole
+
+        model_not_found = RuntimeError(
+            "Embedding failed: Error generating embeddings: Request failed "
+            'with status 404: {"error":{"code":"model_not_found",'
+            '"message":"Model \'user.embeddinggemma-300m-GGUF\' was not '
+            'found."}}'
+        )
+        with patch.object(
+            EmailTriageAgent, "_create_console", return_value=SilentConsole()
+        ):
+            agent = _build_agent_with_failing_embedder(tmp_path, model_not_found)
+        try:
+            assert isinstance(agent.console, SilentConsole)
+            # The SilentConsole report at construction must not have consumed
+            # the one-shot flag.
+            assert agent._memory_unavailable_warning_reported is False
+
+            real_console = MagicMock()
+            agent.console = real_console
+            assert agent.report_memory_unavailable() is True
+            real_console.print_warning.assert_called_once()
+        finally:
+            agent.close_db()

--- a/src/gaia/agents/base/memory.py
+++ b/src/gaia/agents/base/memory.py
@@ -428,6 +428,7 @@ class MemoryMixin(ProceduralMemoryMixin):
         # "unreachable" after the fact.
         self._memory_unavailable_reason: Optional[str] = None
         self._memory_unavailable_detail: Optional[str] = None
+        self._memory_unavailable_warning_reported = False
 
         if os.environ.get("GAIA_MEMORY_DISABLED") == "1":
             logger.info(
@@ -835,6 +836,25 @@ class MemoryMixin(ProceduralMemoryMixin):
             f"unreachable at startup{detail_suffix}. Start Lemonade Server, "
             f"then restart the agent. {restart_note}"
         )
+
+    def report_memory_unavailable(self, console=None) -> bool:
+        """Report a real startup failure once through the current UI console."""
+        if getattr(self, "_memory_unavailable_warning_reported", False):
+            return False
+        if getattr(self, "_memory_unavailable_reason", None) not in (
+            MEMORY_UNAVAILABLE_MODEL_NOT_PULLED,
+            MEMORY_UNAVAILABLE_SERVICE_UNREACHABLE,
+        ):
+            return False
+        target = console if console is not None else getattr(self, "console", None)
+        if target is None:
+            return False
+        message = self.memory_unavailable_message()
+        if not message:
+            return False
+        target.print_warning(message)
+        self._memory_unavailable_warning_reported = True
+        return True
 
     # ------------------------------------------------------------------
     # Properties
@@ -2188,6 +2208,10 @@ class MemoryMixin(ProceduralMemoryMixin):
         upcoming/overdue items) is injected per-turn by prepending it to the
         user message.
         """
+        # UI callers may replace the construction-time silent console before
+        # the first turn; report failures through the current handler.
+        self.report_memory_unavailable()
+
         # Run deferred LLM startup tasks on first real query (after self.chat exists)
         if getattr(self, "_memory_post_init_pending", False):
             self._memory_post_init_pending = False

--- a/src/gaia/agents/base/memory.py
+++ b/src/gaia/agents/base/memory.py
@@ -47,6 +47,7 @@ from uuid import uuid4
 
 import numpy as np
 
+from gaia.agents.base.console import SilentConsole
 from gaia.agents.base.memory_store import (
     EXTRACTABLE_CATEGORIES,
     MAX_CONTENT_LENGTH,
@@ -837,8 +838,14 @@ class MemoryMixin(ProceduralMemoryMixin):
             f"then restart the agent. {restart_note}"
         )
 
-    def report_memory_unavailable(self, console=None) -> bool:
-        """Report a real startup failure once through the current UI console."""
+    def report_memory_unavailable(self) -> bool:
+        """Report a real startup failure once through the current UI console.
+
+        A ``SilentConsole`` renders ``print_warning`` as a no-op, so reporting
+        through one must not spend the one-shot flag — the UI's non-streaming
+        path builds agents with a ``SilentConsole`` (``_chat_helpers.py``), and
+        the same cached agent later serves streaming turns with a real one.
+        """
         if getattr(self, "_memory_unavailable_warning_reported", False):
             return False
         if getattr(self, "_memory_unavailable_reason", None) not in (
@@ -846,8 +853,8 @@ class MemoryMixin(ProceduralMemoryMixin):
             MEMORY_UNAVAILABLE_SERVICE_UNREACHABLE,
         ):
             return False
-        target = console if console is not None else getattr(self, "console", None)
-        if target is None:
+        target = getattr(self, "console", None)
+        if target is None or isinstance(target, SilentConsole):
             return False
         message = self.memory_unavailable_message()
         if not message:


### PR DESCRIPTION
ChatAgent currently logs embedding initialization failures but does not show them in the chat UI, so every MemoryMixin-based chat session can silently lose memory. This change reports model-not-pulled and service-unreachable states through the existing console warning channel after the console is initialized, while preserving the explicit GAIA_MEMORY_DISABLED opt-out. Added a deterministic unit test for the warning boundary.

Tested: PYTHONPATH=src;hub/agents/chat/python python -m pytest hub/agents/chat/python/tests/test_chat_agent.py -q (8 passed); python -m black --check on changed files; git diff --check.

Refs #2831
