### PR TITLE
fix(ci): the eval gate skipped every category when the embedder failed

### DIFF
--- a/.github/workflows/test_eval_agent_gemma_consolidation.yml
+++ b/.github/workflows/test_eval_agent_gemma_consolidation.yml
@@ -695,10 +695,21 @@ jobs:
           # signal whatsoever. Record the state, let the run measure what it can,
           # and let the integrity gate render the honest verdict - the job still
           # fails, because two of three were not measured.
+          #
+          # `exit 0` is what makes both of those true, and it is load-bearing:
+          # without it this block only PRINTED the promise. Execution fell through
+          # into the rungs below and ended at their terminal `exit 1`, which failed
+          # the step, which skipped the eval step entirely - so tool_selection was
+          # never measured either and the gate blocked PRs while reporting nothing
+          # (run 33286140041: 12 min of preflight, three categories skipped). It is
+          # not a green light: EMBEDDER_OK=false above routes the integrity gate to
+          # mark rag_quality and context_retention NOT MEASURED and fail the job
+          # there, on its own terms, with tool_selection genuinely compared.
           if (-not $embedOk -and $env:DEEP_DIAG -ne 'true') {
             Show-LemonadeTaskLog | Out-Null
             "EMBEDDER_OK=false" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
             Write-Host "::error::The RAG embedder $embeddingModel will not load on this runner - a known Strix Halo limitation tracked in #3016, NOT a fault in this PR. The chat model loaded and served over the same llama-server binary earlier in this step, and the same embedder loads fine on the Strix Point boxes, so llama-server works here and the gap is specific to the embeddings path on this SoC. Re-running this gate will not clear it. rag_quality and context_retention cannot be measured; tool_selection does not need the embedder and WILL still run, so this job continues and still gates that category. The deeper rungs (purge the model from disk, load without --ubatch-size 2048, load with everything else unloaded) are skipped on PR runs on purpose because they disturb other jobs on this shared box - re-dispatch with deep_diagnostics: true if you need the full elimination ladder."
+            exit 0
           }
 
           # RUNG 3 - purge the model's BYTES, not just its registration, then


### PR DESCRIPTION
The Gemma eval gate has been blocking PRs while measuring nothing. When the RAG embedder will not load on the Strix Halo runner (the upstream fault tracked in #3016), the preflight is meant to record the degraded state and let `tool_selection` — which needs no embedder — still run and be compared. It recorded the state, printed an annotation promising "this job continues and still gates that category", and then kept going into the deep diagnostic rungs and died on their terminal failure — which skipped the eval step and every category in it. Now the run measures what it can. The job still goes red, but for one honest reason, with `tool_selection` genuinely measured and `rag_quality`/`context_retention` still reported as NOT MEASURED rather than quietly passing.

## Test plan

- [ ] YAML parses: `python -c "import yaml; yaml.safe_load(open('.github/workflows/test_eval_agent_gemma_consolidation.yml'))"`
- [ ] Every `run:` block parses under Windows PowerShell 5.1, the shell this job pins — `[System.Management.Automation.Language.Parser]::ParseFile` reports zero errors on all 7 blocks
- [ ] Step graph reads correctly in each state:
  - **embedder OK** — unchanged; all three categories measured and compared
  - **embedder down** — preflight exits 0 having set `EMBEDDER_OK=false`; the eval step runs `tool_selection` only; the integrity gate fails the job naming `rag_quality` and `context_retention` as NOT MEASURED; `tool_selection` is compared against its baseline
  - **judge key missing** — preflight still hard-fails before any of this, unchanged
  - **Lemonade unreachable** (also: missing baselines, no `claude` CLI, chat model will not load) — preflight still hard-fails, unchanged
- [ ] The downstream wiring is already proven, not new: in [run 33286140041](https://github.com/amd/gaia/actions/runs/33286140041) the integrity gate took the degraded branch correctly and marked both RAG categories NOT MEASURED — but reported `tool_selection: no scorecard produced`, because the eval step had been skipped. That skip is the only thing this changes.
- [ ] Deferred by design — dispatching the real eval costs ~3.5h on a single-slot pool, so this was not run. On the next dispatch, confirm `tool_selection` produces a scorecard and appears in the compare step.
