### PR TITLE
test(daemon): stop the hub stray-process test orphaning a sleep child

### DIFF
--- a/tests/unit/test_daemon_hub_routes.py
+++ b/tests/unit/test_daemon_hub_routes.py
@@ -520,6 +520,7 @@ def test_mutation_refuses_while_a_forgotten_process_runs_from_the_dir(
     check is exercised against the OS rather than a mocked process table.
     """
     import os
+    import signal
     import subprocess
 
     if os.name == "nt":
@@ -532,7 +533,9 @@ def test_mutation_refuses_while_a_forgotten_process_runs_from_the_dir(
     stray = install_root / "email" / "email-agent"
     stray.write_text("#!/bin/sh\nsleep 120\n", encoding="utf-8")
     stray.chmod(0o755)
-    proc = subprocess.Popen([str(stray)])
+    # Own session, so the whole tree can be killed: /bin/sh forks `sleep`
+    # rather than exec'ing it, and killing only the shell orphans the child.
+    proc = subprocess.Popen([str(stray)], start_new_session=True)
     try:
         fetcher = _RecordingFetcher(_hub_files())
         _patch_hub(monkeypatch, fetcher)
@@ -548,11 +551,17 @@ def test_mutation_refuses_while_a_forgotten_process_runs_from_the_dir(
         assert r.status_code == 500
         assert not any(ARTIFACT_NAME in c for c in fetcher.calls)
     finally:
-        proc.kill()
+        try:
+            os.killpg(proc.pid, signal.SIGKILL)
+        except ProcessLookupError:
+            pass
         proc.wait(timeout=10)
 
-    # With the stray gone, the same uninstall succeeds.
-    assert client.delete("/daemon/v1/agents/email", headers=_auth()).status_code == 200
+    # With the stray gone, the same uninstall succeeds. Carry the refusal
+    # detail into the message: a bare `500 == 200` names neither the pid that
+    # blocked it nor which guard fired.
+    final = client.delete("/daemon/v1/agents/email", headers=_auth())
+    assert final.status_code == 200, final.json().get("detail")
 
 
 def test_install_sha_mismatch_is_a_hard_failure_leaving_nothing_installed(


### PR DESCRIPTION
A daemon-hub test was leaking a live process on every run and, when it failed on CI, said only `assert 500 == 200` — no pid, no reason, so the only move was a rerun. This stops the leak and makes the next failure readable.

The stand-in for a forgotten sidecar is a `#!/bin/sh` script running `sleep 120`, cleaned up with `proc.kill()`. dash forks `sleep` instead of exec'ing it, so that killed the shell and left the child running for the full two minutes — four leaked processes per CI unit-test run, one per matrix job. It now runs in its own session and the whole group is killed.

Worth being straight about the limit: this does **not** explain the py3.11 failure on #3150. A leaked `sleep` has cmdline `["sleep", "120"]`, which the directory guard does not match, and ~70 local attempts never reproduced it. That is why the final assertion now carries the refusal detail — so the next occurrence names the pid and the guard instead of a bare status-code mismatch. #3228 tracks the rest, including a `pid_exists`-counts-zombies inconsistency on the same route that is left for its own PR.

Closes #3228 partially — see the issue for what stays open.

## Test plan

- [x] `pytest tests/unit/test_daemon_hub_routes.py` — 59 passed, run 6x consecutively
- [x] Orphan leak measured before and after: unpatched, 3 runs of the single test took the system's orphaned-`sleep` count from 2 → 5; patched, 6 full-file runs leaked 0
- [x] Fork behaviour confirmed directly: parent `cmdline: ['/bin/sh', '<dir>/email-agent']`, `children: [(pid, ['sleep', '120'])]`, 15/15 iterations
- [x] `black --check` and `isort --check-only` clean

<details>
<summary>🔍 Technical details</summary>

Evidence run, showing the fork the old cleanup missed:

```
$ python /tmp/repro3.py
parent cmdline: ['/bin/sh', '/tmp/tmpxl70z4xv/email-agent'] exe: /usr/bin/dash
children: [(320551, ['sleep', '120'])]
forked (has children): 15/15
```

Leak measurement:

```
UNPATCHED after 3 runs=5 (was 2)     # +1 orphan per run
PATCHED   after 6 runs=1 (was 1)     # 0 leaked
```

`os.killpg(proc.pid, SIGKILL)` is safe to address by pid because `start_new_session=True` makes the child its own process-group leader, so pid == pgid. `ProcessLookupError` is swallowed for the case where the process is already gone; `proc.wait(timeout=10)` still reaps.

The guard this test exercises is `src/gaia/daemon/sidecars/install.py:411`, and it is the only 500 reachable here — `_FakeRegistry` is built with `stop_error=None`.

Failing job that prompted this: https://github.com/amd/gaia/actions/runs/33312831740/job/99260843595
</details>
