### PR TITLE
fix: keep source-less agents compatible with skill discovery

### DIFF
--- a/.github/workflows/test_unit.yml
+++ b/.github/workflows/test_unit.yml
@@ -119,7 +119,7 @@ jobs:
           echo "=== Running CLI Tool-Confirmation Integration Tests ==="
           echo "The subprocess probe exercises the real confirmation gate, including dynamic agents."
           echo ""
-          pytest tests/integration/test_cli_tool_confirmation.py -v --tb=short
+          pytest tests/integration/test_cli_tool_confirmation.py -v --tb=short --timeout=300
 
       - name: Upload coverage to Codecov
         if: always()

--- a/.github/workflows/test_unit.yml
+++ b/.github/workflows/test_unit.yml
@@ -112,6 +112,15 @@ jobs:
           pytest tests/unit/ -v --tb=short \
             --cov=src/gaia --cov-report=term-missing --cov-report=xml:coverage.xml
 
+      - name: Run CLI tool-confirmation integration tests
+        env:
+          GAIA_MEMORY_DISABLED: "1"
+        run: |
+          echo "=== Running CLI Tool-Confirmation Integration Tests ==="
+          echo "The subprocess probe exercises the real confirmation gate, including dynamic agents."
+          echo ""
+          pytest tests/integration/test_cli_tool_confirmation.py -v --tb=short
+
       - name: Upload coverage to Codecov
         if: always()
         uses: codecov/codecov-action@v7

--- a/src/gaia/agents/base/agent.py
+++ b/src/gaia/agents/base/agent.py
@@ -1745,7 +1745,15 @@ Do NOT wrap conversational replies in JSON.
         if self.SKILL_MANIFEST:
             path = Path(self.SKILL_MANIFEST)
             if not path.is_absolute():
-                module_file = inspect.getfile(type(self))
+                try:
+                    module_file = inspect.getfile(type(self))
+                except (OSError, TypeError) as exc:
+                    raise _skill_validation_error(
+                        f"Agent {type(self).__name__} sets relative "
+                        f"SKILL_MANIFEST={self.SKILL_MANIFEST!r}, but its source "
+                        "file is unavailable. Use an absolute path or define "
+                        "the agent in a source-backed module."
+                    ) from exc
                 path = (Path(module_file).resolve().parent / path).resolve()
             if not path.is_file():
                 raise _skill_validation_error(

--- a/src/gaia/agents/base/agent.py
+++ b/src/gaia/agents/base/agent.py
@@ -1516,7 +1516,7 @@ Do NOT wrap conversational replies in JSON.
         candidates: List[Path] = []
         try:
             module_dir = Path(inspect.getfile(type(self))).resolve().parent
-        except TypeError:
+        except (OSError, TypeError):
             # A class defined in a REPL/exec has no source file to search from.
             module_dir = None
         if module_dir is not None:
@@ -1758,7 +1758,7 @@ Do NOT wrap conversational replies in JSON.
 
         try:
             module_file = inspect.getfile(type(self))
-        except TypeError:
+        except (OSError, TypeError):
             # A class defined in a REPL/exec has no source file to search from.
             return None
         module_dir = Path(module_file).resolve().parent

--- a/tests/unit/test_skills_manager.py
+++ b/tests/unit/test_skills_manager.py
@@ -10,6 +10,8 @@ Every test runs from a cold state: roots live under ``tmp_path`` and the real
 
 from __future__ import annotations
 
+from unittest.mock import patch
+
 import pytest
 
 from gaia.agents.base.tools import _TOOL_REGISTRY
@@ -558,6 +560,29 @@ class _StubAgent:
 
     def rebuild_system_prompt(self):
         self.rebuilt += 1
+
+
+def test_source_less_agent_skips_bundled_skill_discovery():
+    agent = _StubAgent()
+
+    with patch(
+        "gaia.agents.base.agent.inspect.getfile",
+        side_effect=OSError("source code not available"),
+    ):
+        assert agent._bundled_skill_dirs() == []
+        assert agent._resolve_skill_manifest() is None
+
+
+def test_source_less_agent_with_relative_manifest_fails_actionably():
+    class RelativeManifestAgent(_StubAgent):
+        SKILL_MANIFEST = "gaia-agent.yaml"
+
+    with patch(
+        "gaia.agents.base.agent.inspect.getfile",
+        side_effect=OSError("source code not available"),
+    ):
+        with pytest.raises(SkillValidationError, match="Use an absolute path"):
+            RelativeManifestAgent()._resolve_skill_manifest()
 
 
 def test_agent_load_skill_registers_namespaced_tools_and_injects_body(roots):


### PR DESCRIPTION
## Summary

Source-less agents now complete skill discovery without crashing, and the real CLI confirmation integration suite runs in CI.

## Why

A dynamically defined agent (for example, a `python -c` subprocess used by the confirmation gate) makes `inspect.getfile()` raise `OSError`. The skill-discovery path only handled `TypeError`, so the security integration test failed before it could exercise the confirmation behavior and was not running in CI.

## Linked issue

Closes #2946

## Changes

- Handle both `OSError` and `TypeError` in the two source-file discovery paths.
- Add `tests/integration/test_cli_tool_confirmation.py` to the Ubuntu unit workflow.

## Test plan

- [x] `python -X utf8 -m pytest tests/integration/test_cli_tool_confirmation.py -q -vv --tb=short` — 3 passed, 6 skipped on Windows (POSIX pty cases are expected to skip).
- [x] Related skill tests — 110 passed.
- [x] Combined focused regression tests — 125 passed, 6 skipped.
- [x] Targeted Black, isort, Flake8, and Pylint checks pass.
- [ ] Full `tests/unit/` — 640 passed, 91 skipped before the existing `test_manual_pauses` socket-guard error; the failure is outside this change and is reproducible on the untouched test path.

## Evidence

The subprocess probe now reaches the confirmation gate and verifies denial, explicit unattended opt-in, and tool execution behavior instead of terminating during agent initialization.

## Checklist

- [x] Tests added or updated where applicable
- [x] Lint and type checks run
- [x] Scope is limited to this issue
- [x] No credentials or external services are required by the regression test