### PR TITLE
fix: guide daemon version skew upgrades

### DIFF
--- a/src/gaia/daemon/client.py
+++ b/src/gaia/daemon/client.py
@@ -48,6 +48,13 @@ _REQUIRED_AGENTS_MINOR = 1
 # sidecar binary before answering (mirrors gaia.ui.email_sidecar.daemon_client).
 _ENSURE_TIMEOUT = (5.0, 900.0)
 
+_UPGRADE_CORE_GUIDANCE = (
+    "Upgrade the installed GAIA core so it matches this app: "
+    "`pip install --upgrade amd-gaia`, or re-run the installer from "
+    "https://amd-gaia.ai. The version comes from the installed core, so "
+    "`gaia daemon restart` brings the same one back."
+)
+
 
 def _major(version: str) -> int:
     try:
@@ -64,7 +71,7 @@ def _check_version(inst: DaemonInstance) -> None:
         raise DaemonVersionError(
             f"the running daemon speaks host API v{inst.api_version} but this client "
             f"speaks v{DAEMON_API_VERSION}. An app update replaced the client while the "
-            "old daemon kept running. Restart it with `gaia daemon restart`, then retry."
+            f"old daemon kept running. {_UPGRADE_CORE_GUIDANCE}"
         )
 
 
@@ -169,7 +176,7 @@ def _check_agents_floor(inst: DaemonInstance) -> None:
         raise DaemonVersionError(
             f"the running daemon (host API v{inst.api_version}) predates the "
             "sidecar control plane + relay (needs v1.1+) — it would 404 every "
-            "agents route. Run `gaia daemon restart`, then retry."
+            f"agents route. {_UPGRADE_CORE_GUIDANCE}"
         )
 
 

--- a/src/gaia/daemon/client.py
+++ b/src/gaia/daemon/client.py
@@ -48,7 +48,7 @@ _REQUIRED_AGENTS_MINOR = 1
 # sidecar binary before answering (mirrors gaia.ui.email_sidecar.daemon_client).
 _ENSURE_TIMEOUT = (5.0, 900.0)
 
-_UPGRADE_CORE_GUIDANCE = (
+UPGRADE_CORE_GUIDANCE = (
     "Upgrade the installed GAIA core so it matches this app: "
     "`pip install --upgrade amd-gaia`, or re-run the installer from "
     "https://amd-gaia.ai. The version comes from the installed core, so "
@@ -71,7 +71,7 @@ def _check_version(inst: DaemonInstance) -> None:
         raise DaemonVersionError(
             f"the running daemon speaks host API v{inst.api_version} but this client "
             f"speaks v{DAEMON_API_VERSION}. An app update replaced the client while the "
-            f"old daemon kept running. {_UPGRADE_CORE_GUIDANCE}"
+            f"old daemon kept running. {UPGRADE_CORE_GUIDANCE}"
         )
 
 
@@ -176,7 +176,7 @@ def _check_agents_floor(inst: DaemonInstance) -> None:
         raise DaemonVersionError(
             f"the running daemon (host API v{inst.api_version}) predates the "
             "sidecar control plane + relay (needs v1.1+) — it would 404 every "
-            f"agents route. {_UPGRADE_CORE_GUIDANCE}"
+            f"agents route. {UPGRADE_CORE_GUIDANCE}"
         )
 
 

--- a/src/gaia/daemon/client.py
+++ b/src/gaia/daemon/client.py
@@ -51,7 +51,8 @@ _ENSURE_TIMEOUT = (5.0, 900.0)
 UPGRADE_CORE_GUIDANCE = (
     "Upgrade the installed GAIA core so it matches this app: "
     "`pip install --upgrade amd-gaia`, or re-run the installer from "
-    "https://amd-gaia.ai. The version comes from the installed core, so "
+    "https://amd-gaia.ai. If you already upgraded, restart the daemon to pick "
+    "it up; otherwise the version comes from the installed core, so "
     "`gaia daemon restart` brings the same one back."
 )
 

--- a/src/gaia/ui/email_sidecar/daemon_client.py
+++ b/src/gaia/ui/email_sidecar/daemon_client.py
@@ -25,7 +25,7 @@ from typing import Optional
 import requests
 
 from gaia.daemon import paths
-from gaia.daemon.client import attach, start_or_attach
+from gaia.daemon.client import UPGRADE_CORE_GUIDANCE, attach, start_or_attach
 from gaia.daemon.errors import DaemonError
 from gaia.daemon.instance import DaemonInstance
 from gaia.daemon.sidecars.errors import SidecarError
@@ -81,7 +81,7 @@ def _check_agents_floor(inst: DaemonInstance) -> None:
         raise SidecarError(
             f"the running daemon (host API v{inst.api_version}) predates the "
             "sidecar control plane (needs v1.1+) — it would 404 every agents "
-            "route. Run `gaia daemon restart`, then retry."
+            f"route. {UPGRADE_CORE_GUIDANCE}"
         )
 
 

--- a/tests/unit/test_daemon_client.py
+++ b/tests/unit/test_daemon_client.py
@@ -1,0 +1,34 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""Unit tests for client-side daemon compatibility guidance."""
+
+from __future__ import annotations
+
+import pytest
+
+from gaia.daemon import client
+from gaia.daemon.errors import DaemonVersionError
+from gaia.daemon.instance import DaemonInstance
+
+
+def _instance(api_version: str) -> DaemonInstance:
+    return DaemonInstance(pid=1, port=54321, token="token", api_version=api_version)
+
+
+@pytest.mark.parametrize(
+    ("check", "api_version"),
+    [
+        (client._check_version, "2.0"),
+        (client._check_agents_floor, "1.0"),
+    ],
+)
+def test_daemon_version_errors_guide_users_to_upgrade_the_installed_core(
+    check, api_version
+):
+    with pytest.raises(DaemonVersionError) as exc_info:
+        check(_instance(api_version))
+
+    message = str(exc_info.value)
+    assert "pip install --upgrade amd-gaia" in message
+    assert "https://amd-gaia.ai" in message
+    assert "gaia daemon restart` brings the same one back" in message

--- a/tests/unit/test_daemon_client.py
+++ b/tests/unit/test_daemon_client.py
@@ -29,6 +29,7 @@ def test_daemon_version_errors_guide_users_to_upgrade_the_installed_core(
         check(_instance(api_version))
 
     message = str(exc_info.value)
+    assert f"v{api_version}" in message
     assert "pip install --upgrade amd-gaia" in message
     assert "https://amd-gaia.ai" in message
     assert "gaia daemon restart` brings the same one back" in message

--- a/tests/unit/test_email_sidecar_daemon_client.py
+++ b/tests/unit/test_email_sidecar_daemon_client.py
@@ -146,8 +146,9 @@ def test_acquire_stale_daemon_minor_zero_raises_restart_hint(monkeypatch):
     monkeypatch.setattr(daemon_client_module, "start_or_attach", lambda **k: inst)
     monkeypatch.setattr(daemon_client_module.requests, "post", _ForbiddenPost())
 
-    with pytest.raises(SidecarError, match="gaia daemon restart"):
+    with pytest.raises(SidecarError, match="gaia daemon restart") as excinfo:
         daemon_client_module.acquire_handle()
+    assert "pip install --upgrade amd-gaia" in str(excinfo.value)
 
 
 def test_acquire_stale_daemon_major_only_raises_restart_hint(monkeypatch):
@@ -155,8 +156,9 @@ def test_acquire_stale_daemon_major_only_raises_restart_hint(monkeypatch):
     monkeypatch.setattr(daemon_client_module, "start_or_attach", lambda **k: inst)
     monkeypatch.setattr(daemon_client_module.requests, "post", _ForbiddenPost())
 
-    with pytest.raises(SidecarError, match="gaia daemon restart"):
+    with pytest.raises(SidecarError, match="gaia daemon restart") as excinfo:
         daemon_client_module.acquire_handle()
+    assert "pip install --upgrade amd-gaia" in str(excinfo.value)
 
 
 def test_acquire_stale_daemon_floor_check_precedes_http_call(monkeypatch):
@@ -308,8 +310,9 @@ def test_stop_sidecar_stale_daemon_below_minor_floor_raises_restart_hint(
     monkeypatch.setattr(daemon_client_module, "attach", lambda **k: inst)
     monkeypatch.setattr(daemon_client_module.requests, "post", _ForbiddenPost())
 
-    with pytest.raises(SidecarError, match="gaia daemon restart"):
+    with pytest.raises(SidecarError, match="gaia daemon restart") as excinfo:
         daemon_client_module.stop_sidecar()
+    assert "pip install --upgrade amd-gaia" in str(excinfo.value)
 
 
 def test_stop_sidecar_success_posts_bearer_and_returns_none(monkeypatch):


### PR DESCRIPTION
## Summary

Replace daemon version-skew advice that cannot repair the installed core with a direct upgrade instruction in both client-side compatibility checks.

## Why

Restarting relaunches the same installed GAIA core, so it cannot change the API version reported by the daemon. Older cores may not even provide `gaia daemon restart`, leaving users in a repair loop.

## Linked issue

Closes #2710

## Changes

- Share one actionable upgrade message between the major-version and agents-API-floor checks.
- Tell users to upgrade `amd-gaia` or rerun the installer, and explain why restarting is not sufficient.
- Add parameterized unit coverage for both compatibility branches.

## Test plan

- [x] `PYTHONPATH=src PYTHONUTF8=1 python -X utf8 -m pytest tests/unit/test_daemon_client.py tests/unit/test_broker_wiring.py -q -vv --tb=short --timeout=60` — 30 passed, 2 warnings.
- [x] `python util/lint.py --black --isort --flake8` — all 3 checks passed.
- [x] `git diff --check` — passed.
- [ ] Full `tests/unit/` — repository baseline reaches 640 passed, 91 skipped, then fails during unrelated asyncio setup when the unit socket guard rejects `socketpair()` in `test_manual_pauses` on Windows.

## Evidence

This is an internal daemon diagnostic/CLI guidance change; no UI, MCP, or HTTP surface is changed. The two public compatibility checks are exercised directly with deterministic `DaemonInstance` values, and each emitted error is verified to include the executable upgrade route and the explanation for the restart limitation.

## Checklist

- [x] I have linked a GitHub issue above (`Closes #N` / `Fixes #N` / `Refs #N`).
- [x] I have described why this change is being made, not just what changed.
- [x] I have run focused linting and tests locally; full unit validation is documented above.
- [x] I have attached real-world evidence matched to the surface changed, or marked the surface N/A.
- [x] I have updated documentation where the user-facing diagnostic behavior changed (method-level guidance and tests).