### PR TITLE
fix(connectors): record only granted agent scopes

### DIFF
--- a/docs/security/connections.mdx
+++ b/docs/security/connections.mdx
@@ -40,6 +40,10 @@ Without an activation, an MCP connector's tools never enter the agent's tool lis
 
 Grants are stored in `~/.gaia/connectors/grants.json` and activations in `~/.gaia/connectors/activations.json` — both flat files that are **not** secret stores. They contain agent IDs and scope/boolean values, never credentials.
 
+When a grant is requested during OAuth connect, GAIA records only the
+intersection of the agent's requested scopes and the scopes the token endpoint
+actually grants.
+
 ## Revocation
 
 You can revoke access at any level:

--- a/hub/agents/email/python/gaia_agent_email/connector_routes.py
+++ b/hub/agents/email/python/gaia_agent_email/connector_routes.py
@@ -87,12 +87,13 @@ def _can_send(provider: str) -> bool:
     from gaia_agent_email.outlook_scopes import SCOPE_MAIL_SEND
     from gaia_agent_email.scopes import SCOPE_GMAIL_SEND
 
-    from gaia.connectors.api import list_agent_grants
+    from gaia.connectors.api import get_connection, list_agent_grants
 
     send_scope = SCOPE_GMAIL_SEND if provider == "google" else SCOPE_MAIL_SEND
     try:
-        granted = list_agent_grants(provider).get(EMAIL_AGENT_ID, [])
-        return send_scope in granted
+        connection_scopes = set((get_connection(provider) or {}).get("scopes", []))
+        granted = set(list_agent_grants(provider).get(EMAIL_AGENT_ID, []))
+        return send_scope in connection_scopes & granted
     except Exception as e:
         # Badge fails closed, but a broken grant store must stay diagnosable.
         log.warning("can_send check failed for %s: %s", provider, e)

--- a/src/gaia/connectors/cli.py
+++ b/src/gaia/connectors/cli.py
@@ -423,7 +423,7 @@ def _handle_connect(args: argparse.Namespace) -> int:
         for scope in scopes:
             sys.stdout.write(f"  - {SCOPE_DESCRIPTIONS.get(scope, scope)}\n")
 
-    async def _run() -> str:
+    async def _run() -> dict:
         info = await start_authorization(
             args.connector_id, scopes=scopes, grant_agents=grant_agents
         )
@@ -437,12 +437,15 @@ def _handle_connect(args: argparse.Namespace) -> int:
         )
         sys.stdout.flush()
         result = await complete_authorization(info["flow_id"])
-        return result.get("account_email") or "<unknown>"
+        return result
 
-    email = asyncio.run(_run())
+    result = asyncio.run(_run())
+    email = result.get("account_email") or "<unknown>"
     msg = f"Connected as {email}"
     if grant_agent:
-        granted_scopes = grant_agents[grant_agent]
+        from gaia.connectors.grants import list_agent_grants
+
+        granted_scopes = list_agent_grants(args.connector_id).get(grant_agent, [])
         msg += (
             f"; granted {args.connector_id} → {grant_agent}: "
             f"{', '.join(granted_scopes)}"

--- a/src/gaia/connectors/flow.py
+++ b/src/gaia/connectors/flow.py
@@ -436,8 +436,8 @@ async def _handle_callback(request: web.Request, flow_id: str) -> web.Response:
     return web.Response(text=_SUCCESS_HTML, content_type="text/html")
 
 
-async def _commit_grants(flow: _PendingFlow) -> None:
-    """Write the per-agent grants requested at ``start_authorization`` time.
+async def _commit_grants(flow: _PendingFlow, granted_scopes: Iterable[str]) -> None:
+    """Write per-agent grants limited to the scopes the token exchange granted.
 
     Called only after the connection is persisted. Each grant is written
     through the same ledger the CLI/SDK/Settings panel use, so it is
@@ -456,9 +456,13 @@ async def _commit_grants(flow: _PendingFlow) -> None:
     # and keeps flow.py's module-load dependency graph unchanged.
     from gaia.connectors.grants import grant_agent
 
+    granted_scope_set = set(granted_scopes)
     for agent_id, agent_scopes in flow.grant_agents.items():
+        effective_scopes = [
+            scope for scope in agent_scopes if scope in granted_scope_set
+        ]
         try:
-            grant_agent(flow.provider_id, agent_id, list(agent_scopes))
+            grant_agent(flow.provider_id, agent_id, effective_scopes)
         except Exception as e:
             raise GrantAfterConnectError(
                 flow.provider_id,
@@ -467,7 +471,7 @@ async def _commit_grants(flow: _PendingFlow) -> None:
                     f"{e}. The connection was saved; grant the agent manually "
                     f"from Settings → Connectors, or via `gaia connectors "
                     f"grants grant {flow.provider_id} {agent_id} --scopes "
-                    f"{' '.join(agent_scopes)}`"
+                    f"{' '.join(effective_scopes)}`"
                 ),
             ) from e
         await emit(
@@ -475,14 +479,14 @@ async def _commit_grants(flow: _PendingFlow) -> None:
             {
                 "connector_id": flow.provider_id,
                 "agent_id": agent_id,
-                "scopes": list(agent_scopes),
+                "scopes": effective_scopes,
             },
         )
         logger.info(
             "flow: granted connector_id=%s agent_id=%s scopes=%d on connect",
             flow.provider_id,
             agent_id,
-            len(agent_scopes),
+            len(effective_scopes),
         )
 
 
@@ -574,7 +578,7 @@ async def _exchange_code_for_tokens(flow: _PendingFlow, code: str) -> Dict[str, 
     # email agent access without a follow-up CLI grant. Fail loudly — a
     # connection that persisted but whose grant could not be written is the
     # exact silent half-success the connect flow must not produce.
-    await _commit_grants(flow)
+    await _commit_grants(flow, granted_scopes)
 
     # Google's token endpoint does not return a ``connected_at`` field
     # (RFC 6749 has no such concept) — record the local wall-clock at

--- a/src/gaia/connectors/flow.py
+++ b/src/gaia/connectors/flow.py
@@ -484,6 +484,15 @@ async def _commit_grants_for_provider(
                     "screen."
                 ),
             )
+        if len(effective_scopes) != len(requested_scopes):
+            logger.warning(
+                "flow: narrowed grant connector_id=%s agent_id=%s requested=%d "
+                "granted=%d — the user declined some scopes at consent",
+                provider_id,
+                agent_id,
+                len(requested_scopes),
+                len(effective_scopes),
+            )
         try:
             grant_agent(provider_id, agent_id, effective_scopes)
         except Exception as e:
@@ -520,17 +529,24 @@ def _resolve_granted_scopes(
 
     Per RFC 6749 §5.1 the token endpoint returns ``scope`` only when the
     granted set differs from what was requested; its absence means "as
-    requested." Google's granular-consent screen lets a user untick Calendar
-    while approving Gmail, so trusting the request unconditionally (what this
-    code did before) records a connection that lies about carrying scopes the
-    user declined — every downstream coverage check then passes against a
-    fabricated record instead of catching the shortfall here, loudly, with an
-    actionable message.
+    requested." An explicitly empty ``scope`` therefore means that none of the
+    requested scopes were granted. Google's granular-consent screen lets a user
+    untick Calendar while approving Gmail, so trusting the request
+    unconditionally (what this code did before) records a connection that lies
+    about carrying scopes the user declined — every downstream coverage check
+    then passes against a fabricated record instead of catching the shortfall
+    here, loudly, with an actionable message.
     """
-    raw = payload.get("scope") or ""
-    returned = raw.split()
-    if not returned:
+    if "scope" not in payload:
         return list(requested)
+    raw = payload.get("scope")
+    if not isinstance(raw, str):
+        logger.warning(
+            "flow: token response contained a non-string scope; treating it "
+            "as no granted scopes"
+        )
+        return []
+    returned = raw.split()
     requested_set = set(requested)
     return [s for s in returned if s in requested_set]
 

--- a/src/gaia/connectors/flow.py
+++ b/src/gaia/connectors/flow.py
@@ -449,7 +449,18 @@ async def _commit_grants(flow: _PendingFlow, granted_scopes: Iterable[str]) -> N
     Connecting-without-granting is the bug this flow exists to prevent, so a
     grant failure must not be swallowed.
     """
-    if not flow.grant_agents:
+    await _commit_grants_for_provider(
+        flow.provider_id, flow.grant_agents, granted_scopes
+    )
+
+
+async def _commit_grants_for_provider(
+    provider_id: str,
+    grant_agents: Optional[Mapping[str, Iterable[str]]],
+    granted_scopes: Iterable[str],
+) -> None:
+    """Commit effective per-agent grants for either OAuth flow entry point."""
+    if not grant_agents:
         return
 
     # Local import mirrors the lazy-keyring contract in connectors/__init__.py
@@ -457,34 +468,46 @@ async def _commit_grants(flow: _PendingFlow, granted_scopes: Iterable[str]) -> N
     from gaia.connectors.grants import grant_agent
 
     granted_scope_set = set(granted_scopes)
-    for agent_id, agent_scopes in flow.grant_agents.items():
+    for agent_id, agent_scopes in grant_agents.items():
+        requested_scopes = list(agent_scopes)
         effective_scopes = [
-            scope for scope in agent_scopes if scope in granted_scope_set
+            scope for scope in requested_scopes if scope in granted_scope_set
         ]
+        if not effective_scopes:
+            raise GrantAfterConnectError(
+                provider_id,
+                agent_id,
+                reason=(
+                    "the provider granted none of the scopes this agent asked "
+                    f"for ({' '.join(requested_scopes)}). The connection was "
+                    "saved; re-run connect and approve them on the consent "
+                    "screen."
+                ),
+            )
         try:
-            grant_agent(flow.provider_id, agent_id, effective_scopes)
+            grant_agent(provider_id, agent_id, effective_scopes)
         except Exception as e:
             raise GrantAfterConnectError(
-                flow.provider_id,
+                provider_id,
                 agent_id,
                 reason=(
                     f"{e}. The connection was saved; grant the agent manually "
                     f"from Settings → Connectors, or via `gaia connectors "
-                    f"grants grant {flow.provider_id} {agent_id} --scopes "
+                    f"grants grant {provider_id} {agent_id} --scopes "
                     f"{' '.join(effective_scopes)}`"
                 ),
             ) from e
         await emit(
             "connector.grant.changed",
             {
-                "connector_id": flow.provider_id,
+                "connector_id": provider_id,
                 "agent_id": agent_id,
                 "scopes": effective_scopes,
             },
         )
         logger.info(
             "flow: granted connector_id=%s agent_id=%s scopes=%d on connect",
-            flow.provider_id,
+            provider_id,
             agent_id,
             len(effective_scopes),
         )
@@ -790,22 +813,7 @@ async def poll_device_flow(
         account_type=account_type,
     )
 
-    if grant_agents:
-        from gaia.connectors.grants import grant_agent
-
-        for agent_id, agent_scopes in grant_agents.items():
-            try:
-                grant_agent(provider_id, agent_id, list(agent_scopes))
-            except Exception as e:
-                raise GrantAfterConnectError(
-                    provider_id,
-                    agent_id,
-                    reason=(
-                        f"{e}. Grant it manually with `gaia connectors grants "
-                        f"grant {provider_id} {agent_id} --scopes "
-                        f"{' '.join(agent_scopes)}`"
-                    ),
-                ) from e
+    await _commit_grants_for_provider(provider_id, grant_agents, granted_scopes)
 
     await emit(
         "connector.oauth.completed",

--- a/tests/unit/agents/email/test_connector_scope_and_badge.py
+++ b/tests/unit/agents/email/test_connector_scope_and_badge.py
@@ -174,7 +174,10 @@ class TestListEmailConnectorsCanSend:
         monkeypatch.setattr(
             capi,
             "get_connection",
-            lambda p: {"scopes": [], "account_email": "me@g.com"},
+            lambda p: {
+                "scopes": ["https://www.googleapis.com/auth/gmail.send"],
+                "account_email": "me@g.com",
+            },
         )
         monkeypatch.setattr(
             capi,
@@ -188,10 +191,37 @@ class TestListEmailConnectorsCanSend:
             },
         )
 
-        client = self._make_client()
-        body = client.get("/v1/email/connectors").json()
-        by = {p["provider"]: p for p in body["providers"]}
-        assert by["google"]["can_send"] is True
+        from gaia_agent_email.connector_routes import _can_send
+
+        assert _can_send("google") is True
+
+    def test_can_send_false_when_grant_overclaims_connection_scope(self, monkeypatch):
+        """A stale ledger grant cannot make the badge claim a declined scope."""
+        import gaia.connectors.api as capi
+
+        monkeypatch.setattr(capi, "connected_mailbox_providers", lambda: ["google"])
+        monkeypatch.setattr(
+            capi,
+            "get_connection",
+            lambda p: {
+                "scopes": ["openid", "https://www.googleapis.com/auth/gmail.modify"],
+                "account_email": "me@g.com",
+            },
+        )
+        monkeypatch.setattr(
+            capi,
+            "list_agent_grants",
+            lambda p: {
+                "installed:email": [
+                    "openid",
+                    "https://www.googleapis.com/auth/gmail.send",
+                ]
+            },
+        )
+
+        from gaia_agent_email.connector_routes import _can_send
+
+        assert _can_send("google") is False
 
     def test_can_send_true_when_mail_send_in_outlook_grant(self, monkeypatch):
         """Outlook grant with Mail.Send → can_send=True."""
@@ -201,7 +231,10 @@ class TestListEmailConnectorsCanSend:
         monkeypatch.setattr(
             capi,
             "get_connection",
-            lambda p: {"scopes": [], "account_email": "me@live.com"},
+            lambda p: {
+                "scopes": ["https://graph.microsoft.com/Mail.Send"],
+                "account_email": "me@live.com",
+            },
         )
         monkeypatch.setattr(
             capi,
@@ -214,10 +247,9 @@ class TestListEmailConnectorsCanSend:
             },
         )
 
-        client = self._make_client()
-        body = client.get("/v1/email/connectors").json()
-        by = {p["provider"]: p for p in body["providers"]}
-        assert by["microsoft"]["can_send"] is True
+        from gaia_agent_email.connector_routes import _can_send
+
+        assert _can_send("microsoft") is True
 
     def test_can_send_false_for_microsoft_without_mail_send(self, monkeypatch):
         """Outlook grant missing Mail.Send → can_send=False."""

--- a/tests/unit/agents/email/test_connector_scope_and_badge.py
+++ b/tests/unit/agents/email/test_connector_scope_and_badge.py
@@ -22,6 +22,8 @@ pytest.importorskip("gaia_agent_email")
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
+pytestmark = pytest.mark.allow_network
+
 
 @pytest.fixture
 def client() -> TestClient:
@@ -191,9 +193,10 @@ class TestListEmailConnectorsCanSend:
             },
         )
 
-        from gaia_agent_email.connector_routes import _can_send
-
-        assert _can_send("google") is True
+        client = self._make_client()
+        body = client.get("/v1/email/connectors").json()
+        by = {p["provider"]: p for p in body["providers"]}
+        assert by["google"]["can_send"] is True
 
     def test_can_send_false_when_grant_overclaims_connection_scope(self, monkeypatch):
         """A stale ledger grant cannot make the badge claim a declined scope."""

--- a/tests/unit/connectors/test_cli.py
+++ b/tests/unit/connectors/test_cli.py
@@ -17,6 +17,8 @@ import pytest
 from gaia.connectors import cli as connections_cli
 from gaia.connectors.providers import _registry
 
+pytestmark = pytest.mark.allow_network
+
 
 @pytest.fixture(autouse=True)
 def fake_home(tmp_path, monkeypatch):
@@ -154,7 +156,6 @@ class TestConnectGrantAgent:
         monkeypatch.setattr(
             "gaia.connectors.api.complete_authorization", _fake_complete
         )
-
         rc, _out, err = _run(
             "connectors", "connect", "google", "--grant-agent", "installed:email"
         )
@@ -190,6 +191,12 @@ class TestConnectGrantAgent:
         monkeypatch.setattr(
             "gaia.connectors.api.complete_authorization", _fake_complete
         )
+        monkeypatch.setattr(
+            "gaia.connectors.grants.list_agent_grants",
+            lambda _connector_id: {
+                "installed:email": ["https://www.googleapis.com/auth/gmail.modify"]
+            },
+        )
 
         # --scopes is explicit here, so resolve_declared_scopes must never run.
         def _must_not_run(*_a, **_k):
@@ -207,16 +214,22 @@ class TestConnectGrantAgent:
             "google",
             "--scopes",
             "https://www.googleapis.com/auth/gmail.modify",
+            "https://www.googleapis.com/auth/gmail.send",
             "--grant-agent",
             "installed:email",
         )
         assert rc == 0
         # The grant rides the SAME scopes as the connect — no drift possible.
         assert captured["grant_agents"] == {
-            "installed:email": ["https://www.googleapis.com/auth/gmail.modify"]
+            "installed:email": [
+                "https://www.googleapis.com/auth/gmail.modify",
+                "https://www.googleapis.com/auth/gmail.send",
+            ]
         }
         assert "Connected as alice@example.com" in out
         assert "granted google → installed:email" in out
+        assert "gmail.modify" in out
+        assert "gmail.send" not in out
 
     def test_plain_connect_passes_no_grant_agents(self, monkeypatch):
         captured = {}

--- a/tests/unit/connectors/test_device_flow.py
+++ b/tests/unit/connectors/test_device_flow.py
@@ -279,9 +279,8 @@ class TestPollDeviceFlow:
         assert grants.get("installed:email") == [MAIL_READ]
 
     def test_empty_effective_grant_fails_loudly(self, monkeypatch):
-        other_scope = "https://graph.microsoft.com/Calendars.ReadWrite"
         payload = self._success_payload()
-        payload["scope"] = other_scope
+        payload["scope"] = ""
         _install_responses(monkeypatch, [_FakeResp(200, payload)])
 
         with pytest.raises(GrantAfterConnectError, match="granted none"):

--- a/tests/unit/connectors/test_device_flow.py
+++ b/tests/unit/connectors/test_device_flow.py
@@ -28,7 +28,10 @@ from gaia.connectors.errors import (
     ConnectorsError,
     ConsentDeniedError,
     FlowTimeoutError,
+    GrantAfterConnectError,
 )
+
+pytestmark = pytest.mark.allow_network
 
 MAIL_READ = "https://graph.microsoft.com/Mail.Read"
 
@@ -258,19 +261,38 @@ class TestPollDeviceFlow:
         assert blob["scopes"] == [MAIL_READ]
 
     def test_grant_agents_committed_on_success(self, monkeypatch):
-        _install_responses(monkeypatch, [_FakeResp(200, self._success_payload())])
+        other_scope = "https://graph.microsoft.com/Calendars.ReadWrite"
+        payload = self._success_payload()
+        payload["scope"] = MAIL_READ
+        _install_responses(monkeypatch, [_FakeResp(200, payload)])
         asyncio.run(
             flow_mod.poll_device_flow(
                 "microsoft",
                 "DEV",
-                scopes=[MAIL_READ],
-                grant_agents={"installed:email": [MAIL_READ]},
+                scopes=[MAIL_READ, other_scope],
+                grant_agents={"installed:email": [MAIL_READ, other_scope]},
             )
         )
         from gaia.connectors.grants import list_agent_grants
 
         grants = list_agent_grants("microsoft")
         assert grants.get("installed:email") == [MAIL_READ]
+
+    def test_empty_effective_grant_fails_loudly(self, monkeypatch):
+        other_scope = "https://graph.microsoft.com/Calendars.ReadWrite"
+        payload = self._success_payload()
+        payload["scope"] = other_scope
+        _install_responses(monkeypatch, [_FakeResp(200, payload)])
+
+        with pytest.raises(GrantAfterConnectError, match="granted none"):
+            asyncio.run(
+                flow_mod.poll_device_flow(
+                    "microsoft",
+                    "DEV",
+                    scopes=[MAIL_READ],
+                    grant_agents={"installed:email": [MAIL_READ]},
+                )
+            )
 
     def test_account_email_falls_back_to_userinfo(self, monkeypatch):
         # Device-code id_token often carries no decodable email — the flow then

--- a/tests/unit/connectors/test_flow.py
+++ b/tests/unit/connectors/test_flow.py
@@ -434,7 +434,7 @@ class TestGrantOnConnect:
         "https://www.googleapis.com/auth/gmail.send",
     ]
 
-    async def test_commit_grants_intersects_token_scopes(self, monkeypatch):
+    async def test_commit_grants_intersects_token_scopes(self, monkeypatch, caplog):
         from types import SimpleNamespace
         from unittest.mock import AsyncMock, Mock
 
@@ -451,12 +451,19 @@ class TestGrantOnConnect:
         )
         granted_scope = self._EMAIL_SCOPES[0]
 
-        await _commit_grants(flow, [granted_scope])
+        with caplog.at_level(logging.WARNING, logger="gaia.connectors.flow"):
+            await _commit_grants(flow, [granted_scope])
 
         grant_agent.assert_called_once_with(
             "google", "installed:email", [granted_scope]
         )
         assert emit.await_args.args[1]["scopes"] == [granted_scope]
+        assert "narrowed grant" in caplog.text
+
+    def test_explicit_empty_scope_field_means_no_scopes(self):
+        from gaia.connectors.flow import _resolve_granted_scopes
+
+        assert _resolve_granted_scopes({"scope": ""}, ["openid"]) == []
 
     @respx.mock
     async def test_grant_committed_on_success(self, google_provider):

--- a/tests/unit/connectors/test_flow.py
+++ b/tests/unit/connectors/test_flow.py
@@ -59,7 +59,7 @@ def _no_browser(monkeypatch):
     monkeypatch.setattr("webbrowser.open", lambda *_, **__: True)
 
 
-def _mock_token_endpoint():
+def _mock_token_endpoint(scope="openid"):
     """Mock the Google token endpoint and pass-through 127.0.0.1.
 
     Without the pass_through() call respx would intercept the loopback
@@ -73,7 +73,7 @@ def _mock_token_endpoint():
                 "access_token": "fresh-access",
                 "refresh_token": "fresh-refresh",
                 "expires_in": 3600,
-                "scope": "openid",
+                "scope": scope,
                 "id_token": (
                     # JWT payload {"email": "alice@example.com"}; signature
                     # is a placeholder — flow.py decodes only the email
@@ -157,7 +157,7 @@ class TestGrantedScopesTruthfulness:
         params = parse_qs(urlparse(info["authorization_url"]).query)
         redirect_uri = params["redirect_uri"][0]
         state = params["state"][0]
-        async with httpx.AsyncClient() as c:
+        async with httpx.AsyncClient(trust_env=False) as c:
             await c.get(f"{redirect_uri}?code=ok&state={state}")
         result = await asyncio.wait_for(
             complete_authorization(info["flow_id"]), timeout=2.0
@@ -434,11 +434,36 @@ class TestGrantOnConnect:
         "https://www.googleapis.com/auth/gmail.send",
     ]
 
+    async def test_commit_grants_intersects_token_scopes(self, monkeypatch):
+        from types import SimpleNamespace
+        from unittest.mock import AsyncMock, Mock
+
+        from gaia.connectors.flow import _commit_grants
+
+        grant_agent = Mock()
+        emit = AsyncMock()
+        monkeypatch.setattr("gaia.connectors.grants.grant_agent", grant_agent)
+        monkeypatch.setattr("gaia.connectors.flow.emit", emit)
+
+        flow = SimpleNamespace(
+            provider_id="google",
+            grant_agents={"installed:email": self._EMAIL_SCOPES},
+        )
+        granted_scope = self._EMAIL_SCOPES[0]
+
+        await _commit_grants(flow, [granted_scope])
+
+        grant_agent.assert_called_once_with(
+            "google", "installed:email", [granted_scope]
+        )
+        assert emit.await_args.args[1]["scopes"] == [granted_scope]
+
     @respx.mock
     async def test_grant_committed_on_success(self, google_provider):
         from gaia.connectors.grants import list_agent_grants
 
-        _mock_token_endpoint()
+        granted_scope = self._EMAIL_SCOPES[0]
+        _mock_token_endpoint(scope=granted_scope)
         info = await start_authorization(
             "google",
             scopes=self._EMAIL_SCOPES,
@@ -448,13 +473,13 @@ class TestGrantOnConnect:
         redirect_uri = params["redirect_uri"][0]
         state = params["state"][0]
 
-        async with httpx.AsyncClient() as c:
+        async with httpx.AsyncClient(trust_env=False) as c:
             resp = await c.get(f"{redirect_uri}?code=ok&state={state}")
         assert resp.status_code == 200
         await asyncio.wait_for(complete_authorization(info["flow_id"]), timeout=2.0)
 
         grants = list_agent_grants("google")
-        assert grants.get("installed:email") == self._EMAIL_SCOPES
+        assert grants.get("installed:email") == [granted_scope]
 
     @respx.mock
     async def test_no_grant_agents_leaves_ledger_empty(self, google_provider):


### PR DESCRIPTION
## Summary

Record only the scopes actually returned by the provider when creating per-agent connector grants. Keep the CLI and email capability badge aligned with the persisted grant ledger, and fail clearly when an agent receives no requested scope.

## Why

OAuth providers may return a narrower `scope` value when a user declines part of a consent request. The loopback and device-code flows must not persist the original request as if every scope had been granted.

## Changes

- Share effective-scope grant committing between loopback and device-code flows.
- Treat an omitted token `scope` as the requested set for RFC 6749 compatibility, but treat an explicit empty or malformed value as no granted scopes.
- Warn when consent narrows an agent grant and raise `GrantAfterConnectError` before reporting success when the effective intersection is empty.
- Make CLI grant output read the persisted ledger and retain an HTTP-level positive `can_send` regression.

## Linked issue

Closes #2737

## Test plan

- `python -m pytest tests/unit/connectors/test_flow.py tests/unit/connectors/test_device_flow.py tests/unit/connectors/test_cli.py tests/unit/agents/email/test_connector_scope_and_badge.py -q --tb=short --timeout=120` — 93 passed.
- `python -m mypy src/gaia/connectors/flow.py --ignore-missing-imports --follow-imports=skip` — passed.
- `python -m py_compile src/gaia/connectors/flow.py tests/unit/connectors/test_flow.py tests/unit/connectors/test_device_flow.py` — passed.
- Black, isort, Flake8, and `git diff --check` — passed.

## Evidence

The deterministic tests exercise mocked provider responses for both the loopback callback and Microsoft device-code flow, including a narrowed grant, an explicit empty grant, grant-write failure, CLI ledger output, and the HTTP `can_send=true` endpoint response. Live provider consent was not run because this environment has no OAuth client credentials.

## Compatibility / Known limitations

The implementation preserves the RFC behavior for responses that omit `scope`; explicit empty or non-string values fail closed. The repository-wide unit run was started on Windows but not completed: after collecting 11,510 items, unrelated existing email route, readiness, and REST-search tests failed under the local dependency/environment setup. The targeted changed-path suite and static checks above completed successfully.

## Checklist

- [x] Regression tests cover the changed success, narrowing, empty-grant, failure, and capability paths.
- [x] No generated files, secrets, or dependency lockfiles were changed.
