### PR TITLE
fix(ui): report Lemonade probe failures accurately

### DIFF
--- a/src/gaia/apps/webui/src/components/ConnectionBanner.tsx
+++ b/src/gaia/apps/webui/src/components/ConnectionBanner.tsx
@@ -216,13 +216,16 @@ export function ConnectionBanner({ onRetry }: { onRetry?: () => void }) {
 
     // Case 2: Backend is up but Lemonade Server is not running
     if (systemStatus && !systemStatus.lemonade_running) {
+        const queryFailed = Boolean(systemStatus.lemonade_error);
         return (
             <div className="connection-banner connection-banner--warning" role="status">
                 <div className="connection-banner__icon">
                     <AlertTriangle size={16} />
                 </div>
                 <div className="connection-banner__text">
-                    LLM server is not responding &mdash; it may be busy or not running.{' '}
+                    {queryFailed
+                        ? 'Could not query the LLM server status.'
+                        : 'LLM server is not responding — it may be busy or not running.'}{' '}
                     <span className="connection-banner__hint">
                         {systemStatus.start_command
                             ? <>If not started, run: <code>{systemStatus.start_command}</code></>

--- a/src/gaia/apps/webui/src/components/SettingsModal.tsx
+++ b/src/gaia/apps/webui/src/components/SettingsModal.tsx
@@ -236,10 +236,10 @@ export function SettingsModal() {
                                 <div className="status-grid">
                                     <StatusRow
                                         label="Lemonade Server"
-                                        value={status.lemonade_running ? `Running${status.lemonade_version ? ` v${status.lemonade_version}` : ''}` : 'Not Running'}
+                                        value={status.lemonade_running ? `Running${status.lemonade_version ? ` v${status.lemonade_version}` : ''}` : status.lemonade_error ? 'Status unavailable' : 'Not Running'}
                                         ok={status.lemonade_running}
                                         hint={!status.lemonade_running
-                                            ? (status.initialized ? (status.start_command ? `Run: ${status.start_command}` : (status.start_instruction ?? 'Start Lemonade Server')) : 'Run: gaia init --profile chat')
+                                            ? (status.lemonade_error ? 'Could not query Lemonade Server; check it and retry.' : status.initialized ? (status.start_command ? `Run: ${status.start_command}` : (status.start_instruction ?? 'Start Lemonade Server')) : 'Run: gaia init --profile chat')
                                             : undefined}
                                     />
                                     <StatusRow

--- a/src/gaia/apps/webui/src/components/SettingsPage.tsx
+++ b/src/gaia/apps/webui/src/components/SettingsPage.tsx
@@ -226,10 +226,10 @@ export function SettingsPage() {
                             <div className="status-grid">
                                 <StatusRow
                                     label="Lemonade Server"
-                                    value={status.lemonade_running ? `Running${status.lemonade_version ? ` v${status.lemonade_version}` : ''}` : 'Not Running'}
+                                    value={status.lemonade_running ? `Running${status.lemonade_version ? ` v${status.lemonade_version}` : ''}` : status.lemonade_error ? 'Status unavailable' : 'Not Running'}
                                     ok={status.lemonade_running}
                                     hint={!status.lemonade_running
-                                        ? (status.initialized ? (status.start_command ? `Run: ${status.start_command}` : (status.start_instruction ?? 'Start Lemonade Server')) : 'Run: gaia init --profile chat')
+                                        ? (status.lemonade_error ? 'Could not query Lemonade Server; check it and retry.' : status.initialized ? (status.start_command ? `Run: ${status.start_command}` : (status.start_instruction ?? 'Start Lemonade Server')) : 'Run: gaia init --profile chat')
                                         : undefined}
                                 />
                                 <StatusRow

--- a/src/gaia/apps/webui/src/components/onboarding/PreflightStep.tsx
+++ b/src/gaia/apps/webui/src/components/onboarding/PreflightStep.tsx
@@ -113,7 +113,9 @@ export function PreflightStep({ onGuardChange, onReport }: PreflightStepProps) {
                             ? 'Detected'
                             : report.npu_detected === false
                                 ? 'Not found'
-                                : 'Unknown'
+                                : report.lemonade_error
+                                    ? 'Unknown (query failed)'
+                                    : 'Unknown'
                     }
                 />
                 {report.gpu_name && (

--- a/src/gaia/apps/webui/src/types/index.ts
+++ b/src/gaia/apps/webui/src/types/index.ts
@@ -449,6 +449,8 @@ export interface DownloadProgress {
 
 export interface SystemStatus {
     lemonade_running: boolean;
+    /** Present when the Lemonade health/catalog query failed. */
+    lemonade_error?: string | null;
     /** How to start Lemonade on this host, resolved server-side. */
     start_instruction?: string | null;
     /** Shell command, or null on hosts started from a GUI (tray / app). */
@@ -508,6 +510,8 @@ export interface PreflightReport {
     gpu_name: string | null;
     gpu_vram_gb: number | null;
     lemonade_running: boolean;
+    /** Present when the Lemonade system-info query failed. */
+    lemonade_error?: string | null;
     tier: 'full' | 'standard' | 'light' | 'insufficient' | 'unknown' | string;
     recommended_profile: string;
     recommended_model: string;

--- a/src/gaia/hub/compatibility.py
+++ b/src/gaia/hub/compatibility.py
@@ -309,8 +309,8 @@ def check_compatibility(
                 )
         elif npu_probe_error:
             warnings.append(
-                f"{subject} could not query Lemonade for NPU availability; "
-                "the NPU result is unknown."
+                "GAIA could not query Lemonade for NPU availability; the NPU "
+                f"result for {subject.lower()} is unknown."
             )
         else:
             warnings.append(

--- a/src/gaia/hub/compatibility.py
+++ b/src/gaia/hub/compatibility.py
@@ -184,6 +184,7 @@ def check_compatibility(
     install_dir: Optional[Path] = None,
     detected_npu: Optional[bool] = None,
     detected_gpu_vram_gb: Optional[float] = None,
+    npu_probe_error: Optional[str] = None,
     subject: str = "This agent",
 ) -> CompatibilityReport:
     """Check whether the current machine satisfies *requirements*.
@@ -204,6 +205,9 @@ def check_compatibility(
         detected_gpu_vram_gb: GPU VRAM (GB) reported by the caller's scan, used
             the same way for a ``gpu_vram_gb`` requirement. ``None`` keeps the
             "cannot verify" warning.
+        npu_probe_error: A caller-provided reason why NPU detection failed.
+            When present, the warning describes the failed query instead of
+            suggesting a driver remediation that has not been established.
         subject: What the warnings call the thing being checked. Defaults to
             ``"This agent"`` for the hub-install path; the onboarding preflight
             passes its own phrase (e.g. ``"The recommended model"``) so first-run
@@ -303,6 +307,11 @@ def check_compatibility(
                     "machine. It will fall back to GPU/CPU inference, which is "
                     "slower. Ensure your Ryzen AI NPU driver is installed."
                 )
+        elif npu_probe_error:
+            warnings.append(
+                f"{subject} could not query Lemonade for NPU availability; "
+                "the NPU result is unknown."
+            )
         else:
             warnings.append(
                 f"{subject} requests an NPU. GAIA cannot verify NPU availability "

--- a/src/gaia/ui/models.py
+++ b/src/gaia/ui/models.py
@@ -44,6 +44,9 @@ class SystemStatus(BaseModel):
     """System readiness status."""
 
     lemonade_running: bool = False
+    # Present when the Lemonade health/catalog query failed. This distinguishes
+    # an unavailable server from a probe failure without inventing a verdict.
+    lemonade_error: Optional[str] = None
     model_loaded: Optional[str] = None
     embedding_model_loaded: bool = False
     disk_space_gb: float = 0.0

--- a/src/gaia/ui/routers/onboarding.py
+++ b/src/gaia/ui/routers/onboarding.py
@@ -52,6 +52,7 @@ _RECOMMENDED_MODEL = "Gemma-4-E4B-it-GGUF"
 _RECOMMENDED_DISK_GB = 6.0
 # RAM below which the recommended model is likely to swap/fail to load.
 _RECOMMENDED_MEMORY_GB = 8.0
+_LEMONADE_SYSTEM_INFO_ERROR = "Lemonade system-info query failed"
 
 _INIT_MARKER = Path.home() / ".gaia" / "chat" / "initialized"
 
@@ -92,7 +93,7 @@ async def _probe_lemonade_devices() -> Dict[str, Any]:
         async with httpx.AsyncClient(timeout=3.0) as client:
             resp = await client.get(f"{base_url}/system-info", headers=auth)
             if resp.status_code != 200:
-                result["lemonade_error"] = "Lemonade system-info query failed"
+                result["lemonade_error"] = _LEMONADE_SYSTEM_INFO_ERROR
                 return result
             result["lemonade_running"] = True
             devices = resp.json().get("devices", {})
@@ -109,9 +110,13 @@ async def _probe_lemonade_devices() -> Dict[str, Any]:
                         result["npu_detected"] = True
             if result["npu_detected"] is None and npu_seen:
                 result["npu_detected"] = False
+    except httpx.ConnectError as exc:
+        # A refused connection is a confirmed "not running" result, not an
+        # ambiguous probe failure. Keep the existing not-running/unknown copy.
+        logger.debug("onboarding: Lemonade is not running: %s", exc)
     except Exception as exc:  # pylint: disable=broad-except
         logger.debug("onboarding: lemonade device probe failed: %s", exc)
-        result["lemonade_error"] = "Lemonade system-info query failed"
+        result["lemonade_error"] = _LEMONADE_SYSTEM_INFO_ERROR
     return result
 
 

--- a/src/gaia/ui/routers/onboarding.py
+++ b/src/gaia/ui/routers/onboarding.py
@@ -64,7 +64,8 @@ async def _probe_lemonade_devices() -> Dict[str, Any]:
     """Best-effort NPU/GPU probe via Lemonade's ``/system-info``.
 
     Returns ``{"lemonade_running": bool, "npu_detected": Optional[bool],
-    "gpu_name": Optional[str], "gpu_vram_gb": Optional[float]}``. A ``None`` for
+    "gpu_name": Optional[str], "gpu_vram_gb": Optional[float],
+    "lemonade_error": Optional[str]}``. A ``None`` for
     a device means we could not determine it (Lemonade down, or it did not
     report that device) — the caller turns that into a "couldn't verify"
     warning rather than assuming the hardware is present. A ``None`` GPU name
@@ -81,6 +82,7 @@ async def _probe_lemonade_devices() -> Dict[str, Any]:
         "npu_detected": None,
         "gpu_name": None,
         "gpu_vram_gb": None,
+        "lemonade_error": None,
     }
     try:
         import httpx  # pylint: disable=import-outside-toplevel
@@ -90,6 +92,7 @@ async def _probe_lemonade_devices() -> Dict[str, Any]:
         async with httpx.AsyncClient(timeout=3.0) as client:
             resp = await client.get(f"{base_url}/system-info", headers=auth)
             if resp.status_code != 200:
+                result["lemonade_error"] = "Lemonade system-info query failed"
                 return result
             result["lemonade_running"] = True
             devices = resp.json().get("devices", {})
@@ -108,6 +111,7 @@ async def _probe_lemonade_devices() -> Dict[str, Any]:
                 result["npu_detected"] = False
     except Exception as exc:  # pylint: disable=broad-except
         logger.debug("onboarding: lemonade device probe failed: %s", exc)
+        result["lemonade_error"] = "Lemonade system-info query failed"
     return result
 
 
@@ -135,6 +139,7 @@ class PreflightReport(BaseModel):
     gpu_name: Optional[str] = None
     gpu_vram_gb: Optional[float] = None
     lemonade_running: bool = False
+    lemonade_error: Optional[str] = None
     tier: str = "unknown"
     recommended_profile: str = "chat"
     recommended_model: str = _RECOMMENDED_MODEL
@@ -191,6 +196,7 @@ async def onboarding_preflight() -> PreflightReport:
         install_dir=Path.home() / ".gaia",
         detected_npu=npu_detected,
         detected_gpu_vram_gb=gpu_vram,
+        npu_probe_error=devices.get("lemonade_error"),
         # No agent has been chosen yet during first-run setup — frame the warnings
         # around the recommended model, not "This agent" (#2396).
         subject="The recommended model",
@@ -207,6 +213,7 @@ async def onboarding_preflight() -> PreflightReport:
         gpu_name=devices["gpu_name"],
         gpu_vram_gb=gpu_vram,
         lemonade_running=devices["lemonade_running"],
+        lemonade_error=devices.get("lemonade_error"),
         tier=_classify_tier(ram_gb, npu_detected),
         recommended_profile="chat",
         recommended_model=_RECOMMENDED_MODEL,

--- a/src/gaia/ui/routers/system.py
+++ b/src/gaia/ui/routers/system.py
@@ -660,6 +660,11 @@ async def system_status(request: Request, db: ChatDatabase = Depends(get_db)):
                             break
                 else:
                     status.lemonade_error = "Lemonade health query failed"
+    except httpx.ConnectError as exc:
+        # Nothing listening is a confirmed outage; preserve the actionable
+        # "not responding" banner rather than calling it an ambiguous probe.
+        logger.debug("system status: Lemonade is not running: %s", exc)
+        status.lemonade_running = False
     except Exception:
         status.lemonade_running = False
         status.lemonade_error = "Lemonade health query failed"

--- a/src/gaia/ui/routers/system.py
+++ b/src/gaia/ui/routers/system.py
@@ -658,8 +658,11 @@ async def system_status(request: Request, db: ChatDatabase = Depends(get_db)):
                         if "embed" in m.get("id", "").lower():
                             status.embedding_model_loaded = True
                             break
+                else:
+                    status.lemonade_error = "Lemonade health query failed"
     except Exception:
         status.lemonade_running = False
+        status.lemonade_error = "Lemonade health query failed"
 
     # Active profile from persistent config (#1220)
     try:

--- a/tests/unit/test_hub_compatibility.py
+++ b/tests/unit/test_hub_compatibility.py
@@ -117,6 +117,16 @@ def test_unprobed_npu_keeps_cannot_verify_warning(monkeypatch):
     assert any("cannot verify NPU" in w for w in report.warnings)
 
 
+def test_failed_npu_probe_does_not_suggest_driver_remediation(monkeypatch):
+    monkeypatch.setattr(compatibility, "detect_free_disk_gb", lambda _p: 500.0)
+    report = check_compatibility(
+        {"platforms": [], "npu": True},
+        npu_probe_error="Lemonade system-info query failed",
+    )
+    assert any("could not query Lemonade" in w for w in report.warnings)
+    assert not any("driver is installed" in w for w in report.warnings)
+
+
 def test_detected_gpu_vram_below_requirement_warns(monkeypatch):
     monkeypatch.setattr(compatibility, "detect_free_disk_gb", lambda _p: 500.0)
     report = check_compatibility(

--- a/tests/unit/test_onboarding_router.py
+++ b/tests/unit/test_onboarding_router.py
@@ -9,8 +9,6 @@ from gaia.hub import compatibility
 from gaia.ui.routers import onboarding as onboarding_mod
 from gaia.ui.server import create_app
 
-pytestmark = pytest.mark.allow_network
-
 
 @pytest.fixture
 def marker(tmp_path, monkeypatch):
@@ -44,6 +42,7 @@ def _stub_devices(**overrides):
 # ── preflight ────────────────────────────────────────────────────────────
 
 
+@pytest.mark.allow_network
 def test_preflight_full_tier_compatible(client, monkeypatch):
     monkeypatch.setattr(onboarding_mod, "_probe_lemonade_devices", _stub_devices())
     monkeypatch.setattr(compatibility, "detect_total_memory_gb", lambda: 32.0)
@@ -61,6 +60,7 @@ def test_preflight_full_tier_compatible(client, monkeypatch):
     assert not any("NPU" in w for w in body["warnings"])
 
 
+@pytest.mark.allow_network
 def test_preflight_no_npu_with_gpu_is_informational(client, monkeypatch):
     # No-NPU box with a capable GPU (the #2396 Radeon dGPU case): the Hardware
     # check must read as informational — no "agent" framing, no "install your
@@ -82,6 +82,7 @@ def test_preflight_no_npu_with_gpu_is_informational(client, monkeypatch):
     assert "optional" in joined.lower()
 
 
+@pytest.mark.allow_network
 def test_preflight_no_npu_no_gpu_still_warns_to_remediate(client, monkeypatch):
     # A box with neither NPU nor a detectable GPU keeps the remediation warning.
     monkeypatch.setattr(
@@ -98,6 +99,7 @@ def test_preflight_no_npu_no_gpu_still_warns_to_remediate(client, monkeypatch):
     assert not any("agent" in w.lower() for w in body["warnings"])
 
 
+@pytest.mark.allow_network
 def test_preflight_low_disk_is_blocker(client, monkeypatch):
     monkeypatch.setattr(onboarding_mod, "_probe_lemonade_devices", _stub_devices())
     monkeypatch.setattr(compatibility, "detect_total_memory_gb", lambda: 32.0)
@@ -108,6 +110,7 @@ def test_preflight_low_disk_is_blocker(client, monkeypatch):
     assert any("disk" in b.lower() for b in body["blockers"])
 
 
+@pytest.mark.allow_network
 def test_preflight_insufficient_ram_warns(client, monkeypatch):
     monkeypatch.setattr(onboarding_mod, "_probe_lemonade_devices", _stub_devices())
     monkeypatch.setattr(compatibility, "detect_total_memory_gb", lambda: 4.0)
@@ -120,6 +123,7 @@ def test_preflight_insufficient_ram_warns(client, monkeypatch):
     assert body["compatible"] is True
 
 
+@pytest.mark.allow_network
 def test_preflight_lemonade_down_leaves_npu_unknown(client, monkeypatch):
     async def _probe():
         return {
@@ -127,7 +131,6 @@ def test_preflight_lemonade_down_leaves_npu_unknown(client, monkeypatch):
             "npu_detected": None,
             "gpu_name": None,
             "gpu_vram_gb": None,
-            "lemonade_error": "Lemonade system-info query failed",
         }
 
     monkeypatch.setattr(onboarding_mod, "_probe_lemonade_devices", _probe)
@@ -137,14 +140,14 @@ def test_preflight_lemonade_down_leaves_npu_unknown(client, monkeypatch):
     body = client.get("/api/onboarding/preflight").json()
     assert body["npu_detected"] is None
     assert body["lemonade_running"] is False
-    assert body["lemonade_error"] == "Lemonade system-info query failed"
-    assert any("could not query Lemonade" in w for w in body["warnings"])
-    assert not any("driver is installed" in w for w in body["warnings"])
+    assert body["lemonade_error"] is None
+    assert any("cannot verify NPU" in w for w in body["warnings"])
 
 
 # ── status / complete ──────────────────────────────────────────────────────
 
 
+@pytest.mark.allow_network
 def test_status_uninitialized(client, marker):
     assert not marker.exists()
     body = client.get("/api/onboarding/status").json()
@@ -152,6 +155,7 @@ def test_status_uninitialized(client, marker):
     assert body["skipped"] is False
 
 
+@pytest.mark.allow_network
 def test_complete_then_status(client, marker):
     resp = client.post(
         "/api/onboarding/complete",
@@ -166,6 +170,7 @@ def test_complete_then_status(client, marker):
     assert body["completed_at"] == "2026-07-17T00:00:00Z"
 
 
+@pytest.mark.allow_network
 def test_complete_skipped_records_skip(client, marker):
     client.post("/api/onboarding/complete", json={"skipped": True})
     body = client.get("/api/onboarding/status").json()
@@ -173,6 +178,7 @@ def test_complete_skipped_records_skip(client, marker):
     assert body["skipped"] is True
 
 
+@pytest.mark.allow_network
 def test_legacy_empty_marker_counts_as_initialized(client, marker):
     marker.parent.mkdir(parents=True, exist_ok=True)
     marker.write_text("", encoding="utf-8")

--- a/tests/unit/test_onboarding_router.py
+++ b/tests/unit/test_onboarding_router.py
@@ -9,6 +9,8 @@ from gaia.hub import compatibility
 from gaia.ui.routers import onboarding as onboarding_mod
 from gaia.ui.server import create_app
 
+pytestmark = pytest.mark.allow_network
+
 
 @pytest.fixture
 def marker(tmp_path, monkeypatch):
@@ -125,6 +127,7 @@ def test_preflight_lemonade_down_leaves_npu_unknown(client, monkeypatch):
             "npu_detected": None,
             "gpu_name": None,
             "gpu_vram_gb": None,
+            "lemonade_error": "Lemonade system-info query failed",
         }
 
     monkeypatch.setattr(onboarding_mod, "_probe_lemonade_devices", _probe)
@@ -134,8 +137,9 @@ def test_preflight_lemonade_down_leaves_npu_unknown(client, monkeypatch):
     body = client.get("/api/onboarding/preflight").json()
     assert body["npu_detected"] is None
     assert body["lemonade_running"] is False
-    # Unprobed NPU falls back to the conservative "cannot verify" message.
-    assert any("cannot verify NPU" in w for w in body["warnings"])
+    assert body["lemonade_error"] == "Lemonade system-info query failed"
+    assert any("could not query Lemonade" in w for w in body["warnings"])
+    assert not any("driver is installed" in w for w in body["warnings"])
 
 
 # ── status / complete ──────────────────────────────────────────────────────

--- a/tests/unit/test_ui_gpu_detection.py
+++ b/tests/unit/test_ui_gpu_detection.py
@@ -23,6 +23,8 @@ from gaia.llm.lemonade_manager import gpu_display_info, system_info_has_gpu
 from gaia.ui.routers import onboarding as onboarding_mod
 from gaia.ui.server import create_app
 
+pytestmark = pytest.mark.allow_network
+
 FIXTURES_DIR = os.path.join(os.path.dirname(__file__), "..", "fixtures", "hardware")
 
 
@@ -222,6 +224,16 @@ def test_system_status_no_npu_on_macos(stub_lemonade):
     assert "npu" not in body["detected_devices"]
 
 
+def test_system_status_reports_health_query_failure(stub_lemonade):
+    """A failed health/catalog probe must not masquerade as a confirmed outage."""
+    stub_lemonade({})
+
+    body = TestClient(create_app(db_path=":memory:")).get("/api/system/status").json()
+
+    assert body["lemonade_running"] is False
+    assert body["lemonade_error"] == "Lemonade health query failed"
+
+
 # ── onboarding preflight probe ───────────────────────────────────────────
 
 
@@ -270,3 +282,37 @@ async def test_onboarding_probe_npu_absent_is_false_not_unknown(stub_lemonade):
     result = await onboarding_mod._probe_lemonade_devices()
 
     assert result["npu_detected"] is False
+
+
+@pytest.mark.asyncio
+async def test_onboarding_probe_reports_query_failure(monkeypatch):
+    class _FailingClient:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *_exc):
+            return False
+
+        async def get(self, *_args, **_kwargs):
+            raise RuntimeError("connection refused")
+
+    import httpx
+
+    monkeypatch.setattr(httpx, "AsyncClient", lambda *a, **k: _FailingClient())
+
+    result = await onboarding_mod._probe_lemonade_devices()
+
+    assert result["lemonade_running"] is False
+    assert result["npu_detected"] is None
+    assert result["lemonade_error"] == "Lemonade system-info query failed"
+
+
+@pytest.mark.asyncio
+async def test_onboarding_probe_reports_non_200_query(stub_lemonade):
+    stub_lemonade({})
+
+    result = await onboarding_mod._probe_lemonade_devices()
+
+    assert result["lemonade_running"] is False
+    assert result["npu_detected"] is None
+    assert result["lemonade_error"] == "Lemonade system-info query failed"

--- a/tests/unit/test_ui_gpu_detection.py
+++ b/tests/unit/test_ui_gpu_detection.py
@@ -23,8 +23,6 @@ from gaia.llm.lemonade_manager import gpu_display_info, system_info_has_gpu
 from gaia.ui.routers import onboarding as onboarding_mod
 from gaia.ui.server import create_app
 
-pytestmark = pytest.mark.allow_network
-
 FIXTURES_DIR = os.path.join(os.path.dirname(__file__), "..", "fixtures", "hardware")
 
 
@@ -163,6 +161,7 @@ def test_gpu_display_info_non_numeric_vram_is_undetected_not_zero(caplog):
 
 
 @pytest.mark.parametrize("fixture,expected_name,expected_vram", REAL_PAYLOADS)
+@pytest.mark.allow_network
 def test_system_status_reports_gpu(
     fixture, expected_name, expected_vram, stub_lemonade
 ):
@@ -180,6 +179,7 @@ def test_system_status_reports_gpu(
     assert body["gpu_vram_gb"] == expected_vram
 
 
+@pytest.mark.allow_network
 def test_system_status_no_gpu_reports_null(stub_lemonade):
     stub_lemonade(
         {
@@ -195,6 +195,7 @@ def test_system_status_no_gpu_reports_null(stub_lemonade):
     assert body["gpu_vram_gb"] is None
 
 
+@pytest.mark.allow_network
 def test_system_status_detects_npu_from_real_payload(stub_lemonade):
     """NPU detection must survive the GPU refactor (linux fixture has an NPU)."""
     stub_lemonade(
@@ -210,6 +211,7 @@ def test_system_status_detects_npu_from_real_payload(stub_lemonade):
     assert "npu" in body["detected_devices"]
 
 
+@pytest.mark.allow_network
 def test_system_status_no_npu_on_macos(stub_lemonade):
     stub_lemonade(
         {
@@ -224,6 +226,7 @@ def test_system_status_no_npu_on_macos(stub_lemonade):
     assert "npu" not in body["detected_devices"]
 
 
+@pytest.mark.allow_network
 def test_system_status_reports_health_query_failure(stub_lemonade):
     """A failed health/catalog probe must not masquerade as a confirmed outage."""
     stub_lemonade({})
@@ -234,11 +237,37 @@ def test_system_status_reports_health_query_failure(stub_lemonade):
     assert body["lemonade_error"] == "Lemonade health query failed"
 
 
+@pytest.mark.allow_network
+def test_system_status_connection_refused_keeps_not_running_state(monkeypatch):
+    import httpx
+
+    class _FailingClient:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *_exc):
+            return False
+
+        async def get(self, *_args, **_kwargs):
+            raise httpx.ConnectError(
+                "connection refused",
+                request=httpx.Request("GET", "http://localhost:13305"),
+            )
+
+    monkeypatch.setattr(httpx, "AsyncClient", lambda *a, **k: _FailingClient())
+
+    body = TestClient(create_app(db_path=":memory:")).get("/api/system/status").json()
+
+    assert body["lemonade_running"] is False
+    assert body["lemonade_error"] is None
+
+
 # ── onboarding preflight probe ───────────────────────────────────────────
 
 
 @pytest.mark.parametrize("fixture,expected_name,expected_vram", REAL_PAYLOADS)
 @pytest.mark.asyncio
+@pytest.mark.allow_network
 async def test_onboarding_probe_reports_gpu(
     fixture, expected_name, expected_vram, stub_lemonade
 ):
@@ -252,6 +281,7 @@ async def test_onboarding_probe_reports_gpu(
 
 
 @pytest.mark.asyncio
+@pytest.mark.allow_network
 async def test_onboarding_probe_no_gpu_reports_none(stub_lemonade):
     stub_lemonade({"/system-info": {"devices": load_devices("cpu_only.json")}})
 
@@ -262,6 +292,7 @@ async def test_onboarding_probe_no_gpu_reports_none(stub_lemonade):
 
 
 @pytest.mark.asyncio
+@pytest.mark.allow_network
 async def test_onboarding_probe_npu_flags_from_real_payloads(stub_lemonade):
     stub_lemonade(
         {"/system-info": {"devices": load_devices("lemonade11_amd_igpu_linux.json")}}
@@ -273,6 +304,7 @@ async def test_onboarding_probe_npu_flags_from_real_payloads(stub_lemonade):
 
 
 @pytest.mark.asyncio
+@pytest.mark.allow_network
 async def test_onboarding_probe_npu_absent_is_false_not_unknown(stub_lemonade):
     """Lemonade answered, so a missing NPU is a definite False (not None)."""
     stub_lemonade(
@@ -285,6 +317,7 @@ async def test_onboarding_probe_npu_absent_is_false_not_unknown(stub_lemonade):
 
 
 @pytest.mark.asyncio
+@pytest.mark.allow_network
 async def test_onboarding_probe_reports_query_failure(monkeypatch):
     class _FailingClient:
         async def __aenter__(self):
@@ -308,6 +341,34 @@ async def test_onboarding_probe_reports_query_failure(monkeypatch):
 
 
 @pytest.mark.asyncio
+@pytest.mark.allow_network
+async def test_onboarding_probe_connection_refused_keeps_npu_unknown(monkeypatch):
+    import httpx
+
+    class _FailingClient:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *_exc):
+            return False
+
+        async def get(self, *_args, **_kwargs):
+            raise httpx.ConnectError(
+                "connection refused",
+                request=httpx.Request("GET", "http://localhost:13305"),
+            )
+
+    monkeypatch.setattr(httpx, "AsyncClient", lambda *a, **k: _FailingClient())
+
+    result = await onboarding_mod._probe_lemonade_devices()
+
+    assert result["lemonade_running"] is False
+    assert result["npu_detected"] is None
+    assert result["lemonade_error"] is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.allow_network
 async def test_onboarding_probe_reports_non_200_query(stub_lemonade):
     stub_lemonade({})
 


### PR DESCRIPTION
Closes #2966

## Summary
- expose stable Lemonade probe failure state in onboarding and system status responses
- avoid turning a failed NPU query into a driver-installation recommendation
- render query failures explicitly in the first-run hardware check and connection banner

## Why
On a healthy Linux system, a failed or non-200 Lemonade probe previously returned only default values. That made onboarding show `NPU — Unknown` with a driver hint and made the main UI claim the LLM server was not responding. The new error field preserves the unknown hardware state while identifying the failed query, and keeps the existing remediation for a confirmed absent NPU.

## Test plan
- `$env:PYTHONPATH='src'; python -m pytest tests/unit/test_onboarding_router.py tests/unit/test_hub_compatibility.py tests/unit/test_ui_gpu_detection.py -q` — 65 passed
- `npm run build` — passed
- `npm test -- --run` — 35 files / 279 tests passed
- Black, isort, compileall, and mypy on changed Python modules — passed; mypy's existing `no-any-return` findings were excluded from the focused check
- `tests/unit/chat/ui/test_server.py` was also attempted; its TestClient cases are blocked on this Windows environment by the repository socket guard (98 failed, 94 passed)