### PR TITLE
fix(daemon): honor extended agent query timeouts

### DIFF
--- a/docs/reference/cli.mdx
+++ b/docs/reference/cli.mdx
@@ -122,7 +122,7 @@ Each tool call is bounded so a hung tool (e.g. a stuck connector or network requ
 export GAIA_AGENT_TOOL_TIMEOUT=300
 ```
 
-Tools that legitimately run longer opt out in code via `@tool(timeout=...)` — for example image generation, which may need to download a model on first use. An invalid `GAIA_AGENT_TOOL_TIMEOUT` value (non-numeric or ≤ 0) fails fast with an actionable error rather than silently removing the guard.
+Tools that legitimately run longer opt out in code via `@tool(timeout=...)` — for example image generation, which may need to download a model on first use. For relayed agent queries, the same variable also extends the SSE idle-read budget in the daemon relay, API host, and thin client. That transport budget remains at least **300 seconds** and adds a 60-second grace period above a larger configured tool timeout so the sidecar can return its own timeout error. An invalid `GAIA_AGENT_TOOL_TIMEOUT` value (non-numeric or ≤ 0) fails fast with an actionable error rather than silently removing the guard.
 
 ### Confirming dangerous tools
 

--- a/src/gaia/api/agent_proxy.py
+++ b/src/gaia/api/agent_proxy.py
@@ -42,6 +42,7 @@ from fastapi.responses import Response, StreamingResponse
 from starlette.convertors import Convertor, register_url_convertor
 
 from gaia.daemon.errors import DaemonError
+from gaia.daemon.timeouts import DEFAULT_AGENT_READ_TIMEOUT, agent_read_timeout
 from gaia.logger import get_logger
 
 logger = get_logger(__name__)
@@ -55,7 +56,7 @@ AUTH_SCHEME = "Bearer"
 CONNECT_TIMEOUT = 10.0
 #: Read timeout between chunks — spans a whole agent-loop step relayed by the
 #: daemon, so it matches the daemon relay's own long per-request budget.
-READ_TIMEOUT = 300.0
+READ_TIMEOUT = DEFAULT_AGENT_READ_TIMEOUT
 
 #: HTTP methods the fixed-function relay accepts. OPTIONS/HEAD are intentionally
 #: left to the CORS middleware / FastAPI defaults.
@@ -314,8 +315,12 @@ def build_agent_proxy_router() -> APIRouter:
         upstream_headers["Accept-Encoding"] = "identity"
         url = f"{inst.base_url}/v1/{agent_id}/{path}"
 
+        try:
+            read_timeout = agent_read_timeout()
+        except ValueError as exc:
+            raise HTTPException(status_code=500, detail=str(exc)) from exc
         client = httpx.AsyncClient(
-            timeout=httpx.Timeout(READ_TIMEOUT, connect=CONNECT_TIMEOUT)
+            timeout=httpx.Timeout(read_timeout, connect=CONNECT_TIMEOUT)
         )
         try:
             upstream = await client.send(

--- a/src/gaia/daemon/agent_query.py
+++ b/src/gaia/daemon/agent_query.py
@@ -32,6 +32,7 @@ from typing import Any, Dict, List, Optional
 from gaia.daemon import client, paths
 from gaia.daemon.constants import AUTH_SCHEME
 from gaia.daemon.errors import DaemonError
+from gaia.daemon.timeouts import DEFAULT_AGENT_READ_TIMEOUT, agent_read_timeout
 from gaia.logger import get_logger
 
 logger = get_logger(__name__)
@@ -43,7 +44,7 @@ TERMINAL_TYPES = frozenset({"final", "error"})
 #: Connect fast (a dead daemon should fail quickly); read generously — a single
 #: upstream chunk spans a whole agent-loop step (matches the relay's READ_TIMEOUT).
 _CONNECT_TIMEOUT = 10.0
-_READ_TIMEOUT = 300.0
+_READ_TIMEOUT = DEFAULT_AGENT_READ_TIMEOUT
 #: Cancel POST must never wait out the read timeout.
 _CANCEL_TIMEOUT = 10.0
 
@@ -311,7 +312,7 @@ def run_query(
             headers=headers,
             json=payload,
             stream=True,
-            timeout=(_CONNECT_TIMEOUT, _READ_TIMEOUT),
+            timeout=(_CONNECT_TIMEOUT, agent_read_timeout()),
         ) as response:
             if response.status_code != 200:
                 raise DaemonError(

--- a/src/gaia/daemon/agent_query.py
+++ b/src/gaia/daemon/agent_query.py
@@ -44,6 +44,8 @@ TERMINAL_TYPES = frozenset({"final", "error"})
 #: Connect fast (a dead daemon should fail quickly); read generously — a single
 #: upstream chunk spans a whole agent-loop step (matches the relay's READ_TIMEOUT).
 _CONNECT_TIMEOUT = 10.0
+# Historical floor retained for callers that inspect this module; run_query()
+# resolves the effective value at request time with agent_read_timeout().
 _READ_TIMEOUT = DEFAULT_AGENT_READ_TIMEOUT
 #: Cancel POST must never wait out the read timeout.
 _CANCEL_TIMEOUT = 10.0

--- a/src/gaia/daemon/relay.py
+++ b/src/gaia/daemon/relay.py
@@ -60,6 +60,7 @@ from gaia.daemon.sidecars.errors import (
     SidecarUnresponsiveError,
     UnknownAgentError,
 )
+from gaia.daemon.timeouts import DEFAULT_AGENT_READ_TIMEOUT, agent_read_timeout
 from gaia.logger import get_logger
 
 logger = get_logger(__name__)
@@ -68,7 +69,7 @@ logger = get_logger(__name__)
 CONNECT_TIMEOUT = 10.0
 #: Read timeout between upstream chunks — spans a whole agent-loop step, so it
 #: matches the sidecar proxy's long per-request budget, not the connect one.
-READ_TIMEOUT = 300.0
+READ_TIMEOUT = DEFAULT_AGENT_READ_TIMEOUT
 #: Cancel POST timeout — best-effort cleanup must never wait out READ_TIMEOUT.
 CANCEL_TIMEOUT = 10.0
 
@@ -289,7 +290,7 @@ def build_relay_router(token: str, registry):
         url = f"{base_url}/v1/{agent_id}/{path}"
 
         client = httpx.AsyncClient(
-            timeout=httpx.Timeout(READ_TIMEOUT, connect=CONNECT_TIMEOUT)
+            timeout=httpx.Timeout(agent_read_timeout(), connect=CONNECT_TIMEOUT)
         )
         try:
             upstream = await client.send(

--- a/src/gaia/daemon/relay.py
+++ b/src/gaia/daemon/relay.py
@@ -69,6 +69,8 @@ logger = get_logger(__name__)
 CONNECT_TIMEOUT = 10.0
 #: Read timeout between upstream chunks — spans a whole agent-loop step, so it
 #: matches the sidecar proxy's long per-request budget, not the connect one.
+# Compatibility alias for the historical floor; the request path resolves the
+# effective value with agent_read_timeout() so long-lived daemons see env changes.
 READ_TIMEOUT = DEFAULT_AGENT_READ_TIMEOUT
 #: Cancel POST timeout — best-effort cleanup must never wait out READ_TIMEOUT.
 CANCEL_TIMEOUT = 10.0

--- a/src/gaia/daemon/relay.py
+++ b/src/gaia/daemon/relay.py
@@ -289,8 +289,12 @@ def build_relay_router(token: str, registry):
         upstream_headers["Accept-Encoding"] = "identity"
         url = f"{base_url}/v1/{agent_id}/{path}"
 
+        try:
+            read_timeout = agent_read_timeout()
+        except ValueError as exc:
+            raise HTTPException(status_code=500, detail=str(exc)) from exc
         client = httpx.AsyncClient(
-            timeout=httpx.Timeout(agent_read_timeout(), connect=CONNECT_TIMEOUT)
+            timeout=httpx.Timeout(read_timeout, connect=CONNECT_TIMEOUT)
         )
         try:
             upstream = await client.send(

--- a/src/gaia/daemon/timeouts.py
+++ b/src/gaia/daemon/timeouts.py
@@ -12,6 +12,7 @@ import os
 # explicitly raised the existing agent timeout setting.
 DEFAULT_AGENT_READ_TIMEOUT = 300.0
 _TIMEOUT_ENV_VAR = "GAIA_AGENT_TOOL_TIMEOUT"
+_TIMEOUT_GRACE = 60.0
 
 
 def agent_read_timeout() -> float:
@@ -21,7 +22,8 @@ def agent_read_timeout() -> float:
     CLI process observes an environment override without requiring a restart.
     The value can extend, but never shorten, the historical 300-second
     default: the setting is intended to accommodate long agent work, not to
-    make the transport less tolerant than before.
+    make the transport less tolerant than before. The transport also gets a
+    short grace period so the sidecar can emit its own tool-timeout error.
     """
     raw = os.environ.get(_TIMEOUT_ENV_VAR)
     if raw is None or raw == "":
@@ -31,13 +33,13 @@ def agent_read_timeout() -> float:
     except ValueError as exc:
         raise ValueError(
             f"{_TIMEOUT_ENV_VAR} must be a positive number of seconds, "
-            f"got {raw!r}. Unset it to use the default "
+            f"got {raw!r}. Unset it to use the default relay read budget "
             f"({DEFAULT_AGENT_READ_TIMEOUT})."
         ) from exc
     if configured <= 0:
         raise ValueError(
             f"{_TIMEOUT_ENV_VAR} must be a positive number of seconds, "
-            f"got {configured}. Unset it to use the default "
+            f"got {configured}. Unset it to use the default relay read budget "
             f"({DEFAULT_AGENT_READ_TIMEOUT})."
         )
-    return max(DEFAULT_AGENT_READ_TIMEOUT, configured)
+    return max(DEFAULT_AGENT_READ_TIMEOUT, configured + _TIMEOUT_GRACE)

--- a/src/gaia/daemon/timeouts.py
+++ b/src/gaia/daemon/timeouts.py
@@ -1,0 +1,43 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+"""Timeouts shared by the daemon relay and its thin clients."""
+
+from __future__ import annotations
+
+import os
+
+# A single agent-loop step can be quiet while the sidecar is classifying a
+# mailbox message. Keep the shipping idle-read budget unless the operator has
+# explicitly raised the existing agent timeout setting.
+DEFAULT_AGENT_READ_TIMEOUT = 300.0
+_TIMEOUT_ENV_VAR = "GAIA_AGENT_TOOL_TIMEOUT"
+
+
+def agent_read_timeout() -> float:
+    """Return the SSE idle-read timeout for a relayed agent query.
+
+    The relay and thin client both read this at request time so a long-running
+    CLI process observes an environment override without requiring a restart.
+    The value can extend, but never shorten, the historical 300-second
+    default: the setting is intended to accommodate long agent work, not to
+    make the transport less tolerant than before.
+    """
+    raw = os.environ.get(_TIMEOUT_ENV_VAR)
+    if raw is None or raw == "":
+        return DEFAULT_AGENT_READ_TIMEOUT
+    try:
+        configured = float(raw)
+    except ValueError as exc:
+        raise ValueError(
+            f"{_TIMEOUT_ENV_VAR} must be a positive number of seconds, "
+            f"got {raw!r}. Unset it to use the default "
+            f"({DEFAULT_AGENT_READ_TIMEOUT})."
+        ) from exc
+    if configured <= 0:
+        raise ValueError(
+            f"{_TIMEOUT_ENV_VAR} must be a positive number of seconds, "
+            f"got {configured}. Unset it to use the default "
+            f"({DEFAULT_AGENT_READ_TIMEOUT})."
+        )
+    return max(DEFAULT_AGENT_READ_TIMEOUT, configured)

--- a/tests/unit/test_daemon_agent_query.py
+++ b/tests/unit/test_daemon_agent_query.py
@@ -1,0 +1,46 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+"""Unit tests for the daemon thin-client query timeout contract."""
+
+from types import SimpleNamespace
+
+import requests
+
+from gaia.daemon import agent_query
+
+
+class _Response:
+    status_code = 200
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_exc):
+        return False
+
+
+def test_run_query_passes_configured_read_timeout(monkeypatch):
+    observed = {}
+
+    monkeypatch.setattr(
+        agent_query.client,
+        "ensure_agent",
+        lambda _agent_id: SimpleNamespace(
+            base_url="http://127.0.0.1:12345", token="daemon-token"
+        ),
+    )
+
+    def _post(*_args, **kwargs):
+        observed["timeout"] = kwargs["timeout"]
+        return _Response()
+
+    monkeypatch.setattr(requests, "post", _post)
+    monkeypatch.setattr(agent_query, "_consume", lambda *_args: "final")
+    monkeypatch.setenv("GAIA_AGENT_TOOL_TIMEOUT", "900")
+
+    renderer = SimpleNamespace(final_answer=None, error_detail=None)
+    outcome = agent_query.run_query("email", "triage", renderer=renderer)
+
+    assert outcome.exit_code == 0
+    assert observed["timeout"] == (10.0, 900.0)

--- a/tests/unit/test_daemon_agent_query.py
+++ b/tests/unit/test_daemon_agent_query.py
@@ -43,4 +43,4 @@ def test_run_query_passes_configured_read_timeout(monkeypatch):
     outcome = agent_query.run_query("email", "triage", renderer=renderer)
 
     assert outcome.exit_code == 0
-    assert observed["timeout"] == (10.0, 900.0)
+    assert observed["timeout"] == (10.0, 960.0)

--- a/tests/unit/test_daemon_relay.py
+++ b/tests/unit/test_daemon_relay.py
@@ -81,10 +81,58 @@ def test_agent_read_timeout_defaults_to_relay_budget(monkeypatch):
 
 def test_agent_read_timeout_honours_only_longer_override(monkeypatch):
     monkeypatch.setenv("GAIA_AGENT_TOOL_TIMEOUT", "900")
-    assert agent_read_timeout() == 900.0
+    assert agent_read_timeout() == 960.0
 
     monkeypatch.setenv("GAIA_AGENT_TOOL_TIMEOUT", "120")
     assert agent_read_timeout() == DEFAULT_AGENT_READ_TIMEOUT
+
+
+def test_relay_uses_configured_read_timeout(monkeypatch):
+    from gaia.daemon import relay as relay_mod
+
+    observed = {}
+
+    class _Response:
+        status_code = 200
+        headers = {"content-type": "application/json"}
+
+        async def aread(self):
+            return b"{}"
+
+        async def aclose(self):
+            pass
+
+    class _Client:
+        def __init__(self, *, timeout):
+            observed["timeout"] = timeout
+
+        def build_request(self, *_args, **_kwargs):
+            return object()
+
+        async def send(self, *_args, **_kwargs):
+            return _Response()
+
+        async def aclose(self):
+            pass
+
+    monkeypatch.setattr(relay_mod.httpx, "AsyncClient", _Client)
+    monkeypatch.setenv("GAIA_AGENT_TOOL_TIMEOUT", "900")
+
+    client = _daemon_test_client(_StubRegistry(base_url="http://sidecar"))
+    response = client.post("/v1/email/triage", json={"query": "q"}, headers=_auth())
+
+    assert response.status_code == 200
+    assert observed["timeout"].read == 960.0
+
+
+def test_relay_rejects_invalid_read_timeout(monkeypatch):
+    monkeypatch.setenv("GAIA_AGENT_TOOL_TIMEOUT", "not-a-number")
+    client = _daemon_test_client(_StubRegistry(base_url="http://sidecar"))
+
+    response = client.post("/v1/email/triage", json={"query": "q"}, headers=_auth())
+
+    assert response.status_code == 500
+    assert "GAIA_AGENT_TOOL_TIMEOUT" in response.json()["detail"]
 
 
 @pytest.mark.parametrize("raw", ["not-a-number", "0", "-1"])

--- a/tests/unit/test_daemon_relay.py
+++ b/tests/unit/test_daemon_relay.py
@@ -51,6 +51,7 @@ from gaia.daemon.relay import (
     stream_ended_unexpectedly_detail,
 )
 from gaia.daemon.sidecars.errors import SidecarNotRunningError, UnknownAgentError
+from gaia.daemon.timeouts import DEFAULT_AGENT_READ_TIMEOUT, agent_read_timeout
 
 _HAS_FASTAPI = importlib.util.find_spec("fastapi") is not None
 _HAS_UVICORN = importlib.util.find_spec("uvicorn") is not None
@@ -71,6 +72,26 @@ needs_live_servers = pytest.mark.skipif(
 
 _DAEMON_TOKEN = "daemon-client-tok"
 _SIDECAR_TOKEN = "sidecar-bearer-tok"
+
+
+def test_agent_read_timeout_defaults_to_relay_budget(monkeypatch):
+    monkeypatch.delenv("GAIA_AGENT_TOOL_TIMEOUT", raising=False)
+    assert agent_read_timeout() == DEFAULT_AGENT_READ_TIMEOUT
+
+
+def test_agent_read_timeout_honours_only_longer_override(monkeypatch):
+    monkeypatch.setenv("GAIA_AGENT_TOOL_TIMEOUT", "900")
+    assert agent_read_timeout() == 900.0
+
+    monkeypatch.setenv("GAIA_AGENT_TOOL_TIMEOUT", "120")
+    assert agent_read_timeout() == DEFAULT_AGENT_READ_TIMEOUT
+
+
+@pytest.mark.parametrize("raw", ["not-a-number", "0", "-1"])
+def test_agent_read_timeout_rejects_invalid_override(monkeypatch, raw):
+    monkeypatch.setenv("GAIA_AGENT_TOOL_TIMEOUT", raw)
+    with pytest.raises(ValueError, match="GAIA_AGENT_TOOL_TIMEOUT"):
+        agent_read_timeout()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #2893

## Summary
- centralize the relayed-agent SSE idle-read timeout with the historical 300-second default
- let `GAIA_AGENT_TOOL_TIMEOUT` extend that timeout at request time in both the daemon relay and thin client
- keep smaller values from shortening the transport budget and reject invalid values loudly

## Why
Long inbox triage can spend more than 300 seconds between SSE chunks while classifying messages. The existing environment setting already controls agent tool execution, but both transport layers ignored it, so increasing the setting could not prevent the relay from cutting the stream at five minutes.

## Test plan
- `PYTHONPATH=src python -m pytest tests/unit/test_daemon_relay.py tests/unit/test_daemon_agent_query.py -q -k 'not dead_upstream'` — 42 passed, 1 deselected
- covers unset/default, extended override, lower-than-default override, invalid values, and thin-client timeout propagation
- Black, isort, mypy, compileall, and `git diff --check` passed on changed files
- the full relay file was attempted; the existing `test_relay_dead_upstream_maps_to_502_with_reensure_remedy` is incompatible with this local httpx/Starlette response combination (502 body is empty), while the remaining relay tests pass