### PR TITLE
fix(tui): preserve partial-success batch outcomes

### DIFF
--- a/src/gaia/ui/sse_handler.py
+++ b/src/gaia/ui/sse_handler.py
@@ -29,6 +29,8 @@ from gaia.ui.event_narration import DEBUG_CHANNEL, format_count
 
 logger = logging.getLogger(__name__)
 
+_SUMMARY_CHAR_CAP = 300
+
 #: Seconds the agent thread waits for a tool-confirm response from the frontend.
 TOOL_CONFIRM_TIMEOUT_SECONDS = 60
 
@@ -402,7 +404,7 @@ class SSEOutputHandler(OutputHandler):
         # String-returning tools (notably email envelopes) are summarized by a
         # hard character cap. Tell downstream classifiers that an unparsable
         # summary may be incomplete instead of making them infer truncation.
-        if isinstance(data, str) and len(data) > 300:
+        if not isinstance(data, dict) and len(str(data)) > _SUMMARY_CHAR_CAP:
             event["summary_truncated"] = True
 
         # Attach latency for tool calls (measured from print_tool_usage)
@@ -1340,7 +1342,7 @@ def _count_summary(data: Dict[str, Any]) -> Optional[str]:
 def _summarize_tool_result(data: Dict[str, Any]) -> str:
     """Create a detailed human-readable summary of a tool result."""
     if not isinstance(data, dict):
-        return str(data)[:300]
+        return str(data)[:_SUMMARY_CHAR_CAP]
 
     # Command execution results
     if "command" in data and "stdout" in data:

--- a/src/gaia/ui/sse_handler.py
+++ b/src/gaia/ui/sse_handler.py
@@ -399,6 +399,11 @@ class SSEOutputHandler(OutputHandler):
                 data.get("status") != "error" if isinstance(data, dict) else True
             ),
         }
+        # String-returning tools (notably email envelopes) are summarized by a
+        # hard character cap. Tell downstream classifiers that an unparsable
+        # summary may be incomplete instead of making them infer truncation.
+        if isinstance(data, str) and len(data) > 300:
+            event["summary_truncated"] = True
 
         # Attach latency for tool calls (measured from print_tool_usage)
         if self._tool_start_time is not None:

--- a/src/gaia/ui/sse_translation.py
+++ b/src/gaia/ui/sse_translation.py
@@ -338,7 +338,13 @@ class CanonicalTranslator:
             # The handler's tool_result event is a summary view; carry the
             # available structured bits so the generic result card has content.
             data = {}
-            for key in ("summary", "success", "command_output", "latency_ms"):
+            for key in (
+                "summary",
+                "success",
+                "summary_truncated",
+                "command_output",
+                "latency_ms",
+            ):
                 if key in event:
                     data[key] = event[key]
         tool = self._last_tool or "unknown"

--- a/tests/unit/chat/ui/test_sse_handler.py
+++ b/tests/unit/chat/ui/test_sse_handler.py
@@ -504,6 +504,12 @@ class TestPrettyPrintJsonToolResults:
         assert event["summary_truncated"] is True
         assert len(event["summary"]) == 300
 
+    def test_long_non_dict_result_marks_summary_truncated(self, handler):
+        handler.pretty_print_json(["result"] * 100, title="Result")
+        event = _drain(handler)[0]
+        assert event["summary_truncated"] is True
+        assert len(event["summary"]) == 300
+
     def test_command_output_included(self, handler):
         data = {
             "command": "ls -la",

--- a/tests/unit/chat/ui/test_sse_handler.py
+++ b/tests/unit/chat/ui/test_sse_handler.py
@@ -495,6 +495,14 @@ class TestPrettyPrintJsonToolResults:
         handler.pretty_print_json("some string", title="Result")
         events = _drain(handler)
         assert events[0]["success"] is True
+        assert "summary_truncated" not in events[0]
+
+    def test_long_string_result_marks_summary_truncated(self, handler):
+        data = '{"succeeded": ["message-1"], "failed": [{"error": "already archived"}]}'
+        handler.pretty_print_json(data + "x" * 300, title="Result")
+        event = _drain(handler)[0]
+        assert event["summary_truncated"] is True
+        assert len(event["summary"]) == 300
 
     def test_command_output_included(self, handler):
         data = {

--- a/tests/unit/test_sse_narration.py
+++ b/tests/unit/test_sse_narration.py
@@ -265,6 +265,20 @@ class TestTranslatorNarration:
         assert result["data"]["summary"] == "18 skills"
         assert result["preview"] == "18 skills · 21ms"
 
+    def test_tool_result_preserves_truncation_marker(self):
+        translator = _tr()
+        translator.translate({"type": "tool_start", "tool": "archive_message_batch"})
+        translator.translate({"type": "tool_args", "args": {}})
+        (result,) = translator.translate(
+            {
+                "type": "tool_result",
+                "summary": '{"succeeded":["message-1"],"failed":[{"error":"already archived"',
+                "success": True,
+                "summary_truncated": True,
+            }
+        )
+        assert result["data"]["summary_truncated"] is True
+
     def test_render_map_result_still_gets_a_preview(self):
         """``data`` is the card payload for a render tool; preview comes from the source."""
         translator = CanonicalTranslator(

--- a/tui/internal/event/tool_error.go
+++ b/tui/internal/event/tool_error.go
@@ -221,10 +221,18 @@ func toolErrorFromEncoded(encoded string, truncatedHint bool) (ToolError, bool) 
 		return te, failed
 	}
 	// Unparsable: look for the markers a failed GAIA tool result carries.
-	if truncatedHint && truncatedPayloadShowsPartialSuccess(trimmed) {
+	for _, marker := range []string{`"ok": false`, `"ok":false`} {
+		if strings.Contains(trimmed, marker) {
+			return ToolError{Message: trimmed + "\n" + TruncatedNote}, true
+		}
+	}
+	// Older producers do not send summary_truncated. The encoded summary is
+	// already known to be incomplete because it failed JSON parsing, so visible
+	// successes still settle a batch result without that optional hint.
+	if truncatedPayloadShowsPartialSuccess(trimmed) {
 		return ToolError{}, false
 	}
-	for _, marker := range []string{`"error"`, `"ok": false`, `"ok":false`} {
+	for _, marker := range []string{`"error"`} {
 		if strings.Contains(trimmed, marker) {
 			return ToolError{Message: trimmed + "\n" + TruncatedNote}, true
 		}

--- a/tui/internal/event/tool_error.go
+++ b/tui/internal/event/tool_error.go
@@ -128,6 +128,7 @@ func LegacyToolErrorOf(e ToolResultEvent) (ToolError, bool) {
 func toolErrorFrom(data json.RawMessage, failedHint bool) (ToolError, bool) {
 	failed := failedHint
 	var te ToolError
+	var summaryTruncated bool
 
 	var payload map[string]json.RawMessage
 	if len(data) > 0 {
@@ -135,6 +136,9 @@ func toolErrorFrom(data json.RawMessage, failedHint bool) (ToolError, bool) {
 			// A payload that is not an object carries no error fields to read.
 			return ToolError{}, failed
 		}
+	}
+	if raw, ok := payload["summary_truncated"]; ok {
+		_ = json.Unmarshal(raw, &summaryTruncated)
 	}
 
 	if s, ok := stringField(payload, "status"); ok && strings.EqualFold(s, "error") {
@@ -175,7 +179,7 @@ func toolErrorFrom(data json.RawMessage, failedHint bool) (ToolError, bool) {
 	// The email sidecar string-encodes the tool's whole return value into
 	// `summary`, so the failure is one level down.
 	if summary, ok := stringField(payload, "summary"); ok {
-		if nested, nestedFailed := toolErrorFromEncoded(summary); nestedFailed {
+		if nested, nestedFailed := toolErrorFromEncoded(summary, summaryTruncated); nestedFailed {
 			failed = true
 			if te.Message == "" {
 				te.Message = nested.Message
@@ -208,7 +212,7 @@ const TruncatedNote = "(the agent cut this message short before sending it — r
 // A payload that was truncated mid-encoding no longer parses, so the raw text is
 // surfaced instead: it is still the tool's own words, and dropping it would
 // leave only the model's paraphrase.
-func toolErrorFromEncoded(encoded string) (ToolError, bool) {
+func toolErrorFromEncoded(encoded string, truncatedHint bool) (ToolError, bool) {
 	trimmed := strings.TrimSpace(encoded)
 	if !strings.HasPrefix(trimmed, "{") {
 		return ToolError{}, false
@@ -217,12 +221,35 @@ func toolErrorFromEncoded(encoded string) (ToolError, bool) {
 		return te, failed
 	}
 	// Unparsable: look for the markers a failed GAIA tool result carries.
+	if truncatedHint && truncatedPayloadShowsPartialSuccess(trimmed) {
+		return ToolError{}, false
+	}
 	for _, marker := range []string{`"error"`, `"ok": false`, `"ok":false`} {
 		if strings.Contains(trimmed, marker) {
 			return ToolError{Message: trimmed + "\n" + TruncatedNote}, true
 		}
 	}
 	return ToolError{}, false
+}
+
+// truncatedPayloadShowsPartialSuccess recognizes the stable batch envelope
+// evidence without trying to parse an intentionally incomplete JSON string.
+func truncatedPayloadShowsPartialSuccess(encoded string) bool {
+	const key = `"succeeded"`
+	idx := strings.Index(encoded, key)
+	if idx < 0 {
+		return false
+	}
+	rest := strings.TrimSpace(encoded[idx+len(key):])
+	if !strings.HasPrefix(rest, ":") {
+		return false
+	}
+	rest = strings.TrimSpace(rest[1:])
+	if strings.HasPrefix(rest, "[") {
+		rest = strings.TrimSpace(rest[1:])
+		return rest != "" && !strings.HasPrefix(rest, "]")
+	}
+	return rest != "" && rest[0] >= '1' && rest[0] <= '9'
 }
 
 func stringField(payload map[string]json.RawMessage, key string) (string, bool) {

--- a/tui/internal/event/tool_error_test.go
+++ b/tui/internal/event/tool_error_test.go
@@ -197,3 +197,29 @@ func TestToolErrorStillFailsOnTruncatedFailure(t *testing.T) {
 		t.Fatal("a truncated failure without successes was not reported")
 	}
 }
+
+func TestToolErrorIgnoresPartialSuccessWithoutTruncatedHint(t *testing.T) {
+	data, err := json.Marshal(map[string]any{
+		"summary": `{"succeeded":["a"],"failed":[{"error":"already archived"`,
+		"success": true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, failed := ToolErrorOf(CanonicalToolResultEvent{Tool: "archive_message_batch", Data: data}); failed {
+		t.Fatal("a truncated partial-success batch without a producer hint was reported as failed")
+	}
+}
+
+func TestToolErrorHonorsExplicitFailureBeforePartialSuccess(t *testing.T) {
+	data, err := json.Marshal(map[string]any{
+		"summary": `{"succeeded":["a"],"ok":false,"failed":[{"error":"rejected"`,
+		"success": true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, failed := ToolErrorOf(CanonicalToolResultEvent{Tool: "archive_message_batch", Data: data}); !failed {
+		t.Fatal("an explicit nested ok:false was hidden by partial-success evidence")
+	}
+}

--- a/tui/internal/event/tool_error_test.go
+++ b/tui/internal/event/tool_error_test.go
@@ -1,6 +1,7 @@
 package event
 
 import (
+	"encoding/json"
 	"strings"
 	"testing"
 )
@@ -164,5 +165,35 @@ func TestToolErrorLeavesAHealthyEncodedSummaryAlone(t *testing.T) {
 	plain := `{"summary":"Listed 5 files and 1 directory","success":true}`
 	if _, failed := ToolErrorOf(CanonicalToolResultEvent{Tool: "ls", Data: []byte(plain)}); failed {
 		t.Error("a prose summary was read as a failure")
+	}
+}
+
+func TestToolErrorDoesNotFailOnTruncatedPartialSuccess(t *testing.T) {
+	// The Python producer marks this summary because it was cut at the cap;
+	// the visible succeeded evidence must beat a per-item error marker.
+	data, err := json.Marshal(map[string]any{
+		"summary_truncated": true,
+		"summary":           `{"succeeded":["a","b"],"failed":[{"error":"already archived"`,
+		"success":           true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, failed := ToolErrorOf(CanonicalToolResultEvent{Tool: "archive_message_batch", Data: data}); failed {
+		t.Fatal("a truncated partial-success batch was reported as failed")
+	}
+}
+
+func TestToolErrorStillFailsOnTruncatedFailure(t *testing.T) {
+	data, err := json.Marshal(map[string]any{
+		"summary_truncated": true,
+		"summary":           `{"succeeded":[],"failed":[{"error":"permission denied"`,
+		"success":           true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, failed := ToolErrorOf(CanonicalToolResultEvent{Tool: "archive_message_batch", Data: data}); !failed {
+		t.Fatal("a truncated failure without successes was not reported")
 	}
 }

--- a/tui/internal/ui/chat/tool_error_render_test.go
+++ b/tui/internal/ui/chat/tool_error_render_test.go
@@ -164,22 +164,22 @@ func TestSilentRenderPayloadStillTicksSucceeded(t *testing.T) {
 }
 
 // AC-7c: the pre-mortem's proven false positive. A truncated, string-encoded
-// batch summary containing a per-item "error" key classifies as Failed even
-// though the operation was an ordinary partial success — but because Render
-// is empty, this change must leave it untouched (S1). #2723 is the actual
-// fix for the classifier; this test only pins that nothing here acts on it.
+// batch summary containing a per-item "error" key is an ordinary partial
+// success, not a failed operation. #2723 fixes the classifier; this test pins
+// that the chat surface remains free of a RoleError and a non-render card.
 func TestBatchFalsePositiveStaysHarmless(t *testing.T) {
-	truncated := `{\"succeeded\": [\"m1\", \"m2\", \"m3\"], \"failed\": [{\"message_id\": \"m4\", \"error\": \"not fou`
-	data := json.RawMessage(`{"summary":"` + truncated + `","success":true}`)
+	truncated := `{"succeeded": ["m1", "m2", "m3"], "failed": [{"message_id": "m4", "error": "not fou`
+	dataBytes, err := json.Marshal(map[string]any{
+		"summary": truncated,
+		"success": true,
+	})
+	if err != nil {
+		t.Fatalf("fixture setup: %v", err)
+	}
+	data := json.RawMessage(dataBytes)
 
-	// Sanity, deliberately kept: this fixture must really trip the
-	// classifier, or the assertions below prove nothing about the gate. When
-	// #2723 fixes the truncation heuristic, this misfire stops happening and
-	// this Fatalf will fire — that is the point, not a flake: it forces
-	// whoever lands #2723 to come back and re-examine this gate rather than
-	// silently letting the fixture go stale. Do not delete this on a "cleanup".
-	if outcome, _ := event.ToolOutcomeOf(event.CanonicalToolResultEvent{Tool: "archive_message_batch", Data: data}); outcome != event.ToolOutcomeFailed {
-		t.Fatalf("fixture setup: expected the classifier to misfire as Failed, got %s", outcome)
+	if outcome, _ := event.ToolOutcomeOf(event.CanonicalToolResultEvent{Tool: "archive_message_batch", Data: data}); outcome == event.ToolOutcomeFailed {
+		t.Fatalf("partial-success fixture was classified as failed: %s", outcome)
 	}
 
 	m := feed(t, newTestChat(t),
@@ -189,15 +189,14 @@ func TestBatchFalsePositiveStaysHarmless(t *testing.T) {
 
 	for _, msg := range m.messages {
 		if msg.Role == RoleError {
-			t.Fatalf("a non-render tool must not gain a RoleError message even when the classifier misfires: %+v", msg)
+			t.Fatalf("a non-render tool must not gain a RoleError message: %+v", msg)
 		}
 		if msg.Role == RoleCard {
 			t.Fatalf("a non-render tool must never produce a card: %+v", msg)
 		}
 	}
-	// The fixture carries a top-level "success":true, which is what today's
-	// classifier (toolResultSucceeded) reads — pinned literally, not derived
-	// from the function under test.
+	// The fixture carries a top-level "success":true, which keeps the activity
+	// tick independent from the nested partial-success classification.
 	item := m.activity[0]
 	if item.Success == nil || !*item.Success {
 		t.Errorf("tick must stay whatever today's classifier already computes: got %v, want true", item.Success)

--- a/tui/internal/ui/oneshot_exitcode_test.go
+++ b/tui/internal/ui/oneshot_exitcode_test.go
@@ -1,6 +1,7 @@
 package ui
 
 import (
+	"encoding/json"
 	"strings"
 	"testing"
 
@@ -175,6 +176,29 @@ func TestTheSidecarsEncodedEnvelopeDecidesTheExitCode(t *testing.T) {
 
 	if res.ExitCode != 1 {
 		t.Fatalf("exit = %d, want 1: success:true on the event does not outrank ok:false in the envelope", res.ExitCode)
+	}
+}
+
+func TestTruncatedPartialSuccessExitsZero(t *testing.T) {
+	data, err := json.Marshal(map[string]any{
+		"summary": `{"succeeded":["a","b"],"failed":[{"error":"already archived"`,
+		"success": true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	res, _, _ := captureOneShot(t,
+		event.CanonicalToolResultEvent{
+			Type: "tool_result", Tool: "archive_message_batch",
+			Data: data,
+		},
+		event.CanonicalFinalEvent{Type: "final", Answer: "Two messages archived."},
+	)
+	if res.ExitCode != 0 {
+		t.Fatalf("exit = %d, want 0: visible successes prove the partial batch did work", res.ExitCode)
+	}
+	if len(res.FailedTools) != 0 {
+		t.Fatalf("FailedTools = %v, want none", res.FailedTools)
 	}
 }
 


### PR DESCRIPTION
## Summary
- preserve an explicit marker when a string tool result is capped at the SSE summary limit
- carry the marker through canonical tool-result events
- treat visible `succeeded` entries as authoritative for truncated partial-success envelopes, while keeping truncated failures non-zero

Fixes #2723.

## Validation
- `go test ./internal/event/... ./internal/ui/...`
- `uv run --frozen pytest tests/unit/test_sse_narration.py tests/unit/chat/ui/test_sse_handler.py -q` (292 passed)
- `black --check --target-version py312` with Black 26.5.1
- `isort --check-only` with isort 9.0.1
- `mypy src/gaia/ui/sse_handler.py src/gaia/ui/sse_translation.py`
- `git diff --check`