### PR TITLE
ci(claude): skip Claude PR review for Dependabot PRs

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -145,10 +145,16 @@ permissions:
 
 jobs:
   # Auto-review new PRs (including forks)
+  #
+  # Dependabot is excluded: claude-code-action hard-fails on a bot actor unless the bot is
+  # allowlisted ("Workflow initiated by non-human actor"), so every Dependabot PR went red on
+  # a job that never reviewed anything. Allowlisting instead of skipping would spend a review
+  # on a generated lockfile diff; Dependency Review and Audit Dependencies already cover those.
   pr-review:
     if: |
       github.repository == 'amd/gaia' &&
       github.event_name == 'pull_request_target' &&
+      github.event.pull_request.user.login != 'dependabot[bot]' &&
       (github.event.action == 'opened' || github.event.action == 'reopened' ||
        github.event.action == 'ready_for_review' ||
        (github.event.action == 'labeled' &&
@@ -442,9 +448,11 @@ jobs:
   # of the silent lightweight pass. --max-turns is raised to 80 for that path (a ceiling, so
   # it costs nothing extra on ordinary re-reviews).
   pr-rereview:
+    # Dependabot excluded for the same reason as pr-review above.
     if: |
       github.repository == 'amd/gaia' &&
       github.event_name == 'pull_request_target' &&
+      github.event.pull_request.user.login != 'dependabot[bot]' &&
       github.event.action == 'synchronize' &&
       (github.event.pull_request.draft == false ||
        contains(github.event.pull_request.labels.*.name, 'ready_for_ci'))

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -150,11 +150,14 @@ jobs:
   # allowlisted ("Workflow initiated by non-human actor"), so every Dependabot PR went red on
   # a job that never reviewed anything. Allowlisting instead of skipping would spend a review
   # on a generated lockfile diff; Dependency Review and Audit Dependencies already cover those.
+  #
+  # Gate on github.actor, not pull_request.user.login: the action rejects on who INITIATED the
+  # run, so a human pushing to a Dependabot branch still gets reviewed (verified on #3155-#3157).
   pr-review:
     if: |
       github.repository == 'amd/gaia' &&
       github.event_name == 'pull_request_target' &&
-      github.event.pull_request.user.login != 'dependabot[bot]' &&
+      github.actor != 'dependabot[bot]' &&
       (github.event.action == 'opened' || github.event.action == 'reopened' ||
        github.event.action == 'ready_for_review' ||
        (github.event.action == 'labeled' &&
@@ -452,7 +455,7 @@ jobs:
     if: |
       github.repository == 'amd/gaia' &&
       github.event_name == 'pull_request_target' &&
-      github.event.pull_request.user.login != 'dependabot[bot]' &&
+      github.actor != 'dependabot[bot]' &&
       github.event.action == 'synchronize' &&
       (github.event.pull_request.draft == false ||
        contains(github.event.pull_request.labels.*.name, 'ready_for_ci'))


### PR DESCRIPTION
Every Dependabot PR has been showing a red `pr-review / run` check while the job never actually reviewed anything — it exits ~490 ms in, before reading the diff. Four PRs are red on this alone right now (#3154–#3157), and two of them have no other failing check, so the red X was hiding whether the bump was safe rather than telling anyone anything. `claude-code-action` rejects a bot actor outright, so the review job can never succeed on a Dependabot PR as configured.

This gates `pr-review` and `pr-rereview` on the PR author instead of allowlisting the bot. Reviewing a generated lockfile diff spends a full pass for almost nothing, and `Dependency Review` + `Audit Dependencies` already cover dependency risk on exactly those PRs — both pass today.

Also created the three labels `.github/dependabot.yml` asks for but the repo did not have — `github-actions`, `example-app`, `python` — which is what Dependabot has been complaining about in comments on #3154 and #3157.

Closes #3258

## Test plan

- [ ] Merge, then re-run CI on #3156 (a Dependabot PR whose only red check is `pr-review / run`) and confirm the job is skipped, not failed, and the PR goes fully green.
- [ ] Confirm `pr-review` still runs normally on this very PR — it is human-authored, so the new condition must not skip it. Visible in this PR's own checks.
- [ ] `gh label list | grep -E "github-actions|example-app|python"` returns all three.

<details>
<summary>🔍 Technical details</summary>

Failing step, job 99364331234 (PR #3157), log line 1711:

```
##[error]Action failed with error: Workflow initiated by non-human actor: dependabot
(type: Bot). Add bot to allowed_bots list or use '*' to allow all bots.
```

`duration_ms=489`. Not an auth problem — `claude_code_oauth_token: ***` is present and masked at log line 673 of the same job.

The gate is added at the job level in `claude.yml` rather than as an `allowed_bots` input threaded through `claude-run.yml`, which also keeps it clear of #3157's edits to the same file (lines 1052 and 1527) so the two do not conflict.

Labels were created directly rather than in this diff — they are repo settings, not files.
</details>
