### PR TITLE
Route the Strix Halo jobs to the Ryzen Dev Lab pool

### DIFF
--- a/.github/workflows/test_agent_behavior_e2e.yml
+++ b/.github/workflows/test_agent_behavior_e2e.yml
@@ -1,6 +1,15 @@
-# NOTE: This workflow activates once #1297 (Strix Halo self-hosted runner) lands.
-# Until then it is validated out-of-band on Strix Halo class hardware.
-# The strix-halo runner is Windows. Python/uv setup goes through the
+# NOTE: Runs on the AMD Ryzen Dev Lab pool, which registers a runner per job and
+# destroys it afterwards. `devlab-dispatch` is what routes it there. That pool
+# does not answer to `strix-halo` alone: the word describes the silicon, and it
+# is equally true of the dedicated runner #1297 is about, so naming it is a
+# description of hardware rather than a request for a particular fleet.
+#
+# `Windows` is load-bearing rather than tidy. The pool is mixed and most of its
+# Halos are Linux, while the inline `run:` step below is PowerShell -- without
+# the OS label this job can be placed on a Linux host and fail there. It never
+# needed an OS before because the only runner carrying `strix-halo` was Windows.
+#
+# Python/uv setup goes through the
 # ./.github/actions/setup-venv composite action (the lab-runner convention,
 # see build_cpp.yml) which installs uv, creates .venv and puts it on PATH.
 # Inline `run:` steps use PowerShell — bash syntax (&&, \ continuation) is not
@@ -22,7 +31,7 @@ permissions:
 
 jobs:
   behavior-e2e:
-    runs-on: [self-hosted, strix-halo]
+    runs-on: [self-hosted, Windows, devlab-dispatch, strix-halo]
     steps:
       - uses: actions/checkout@v7
 

--- a/.github/workflows/test_npu_embedder.yml
+++ b/.github/workflows/test_npu_embedder.yml
@@ -5,6 +5,16 @@
 # Ryzen AI hardware. The test (tests/test_npu_flm_embedder_hw.py) SKIPS unless
 # the live Lemonade Server advertises the FLM model, so on a runner without the
 # FLM/NPU backend this job is a clean no-op rather than a false failure.
+#
+# Runs on the AMD Ryzen Dev Lab pool, which registers a runner per job and
+# destroys it afterwards. `devlab-dispatch` is what routes it there; that pool
+# does not answer to `strix-halo` alone, because the word describes the silicon
+# rather than naming a fleet, and more than one fleet is Strix Halo.
+#
+# `Windows` is required, not tidy: the pool is mixed and most of its Halos are
+# Linux, while the step below is PowerShell. Every Windows host in the pool also
+# carries the NPU driver and XRT, so this reaches the same hardware the test
+# expects -- and where it does not, the test skips by design rather than failing.
 name: Test NPU FLM Embedder
 
 on:
@@ -40,7 +50,7 @@ permissions:
 jobs:
   test-npu-embedder:
     name: Test NPU FLM Embedder
-    runs-on: [self-hosted, strix-halo]
+    runs-on: [self-hosted, Windows, devlab-dispatch, strix-halo]
     if: github.event_name != 'pull_request' || github.event.pull_request.draft == false || contains(github.event.pull_request.labels.*.name, 'ready_for_ci')
 
     steps:


### PR DESCRIPTION
Adding `devlab-dispatch` routes these jobs to the **DevLab** pool of ephemeral runners, where every job gets a fresh runner that is destroyed afterwards (**DevLab-Dispatch**). The label is required because `strix-halo` only describes the silicon and is equally true of other AMD fleets, so the pool no longer treats it as a request on its own.

`Windows` is added because the pool is mixed and most of its hosts are Linux, while both jobs have `PowerShell` steps.

No steps change, and `test_eval_agent_gemma_consolidation.yml` is deliberately untouched because it targets the `lemonade-eval` runners.