### PR TITLE
fix(telegram): report unsupported media types

### DIFF
--- a/src/gaia/messaging/telegram.py
+++ b/src/gaia/messaging/telegram.py
@@ -121,6 +121,20 @@ class TelegramAdapter:
                 media_note = f"[file indexed: {update.message.document.file_name}]"
             else:
                 media_note = f"[file uploaded: {update.message.document.file_name} - index failed]"
+        elif any(
+            getattr(update.message, media_type, None)
+            for media_type in (
+                "video",
+                "voice",
+                "audio",
+                "sticker",
+                "animation",
+                "video_note",
+            )
+        ):
+            media_note = (
+                "[unsupported media type — supported types are photos and documents]"
+            )
 
         user_input = f"{text} {media_note}".strip()
 

--- a/src/gaia/messaging/telegram.py
+++ b/src/gaia/messaging/telegram.py
@@ -132,9 +132,10 @@ class TelegramAdapter:
                 "video_note",
             )
         ):
-            media_note = (
-                "[unsupported media type — supported types are photos and documents]"
+            await update.message.reply_text(
+                "Unsupported media type — I can handle photos and documents."
             )
+            return
 
         user_input = f"{text} {media_note}".strip()
 

--- a/tests/unit/test_telegram_adapter.py
+++ b/tests/unit/test_telegram_adapter.py
@@ -329,3 +329,41 @@ async def test_document_ingest_success_is_included_in_session_input(
         str(tmp_path / "gaia_telegram_document-2")
     )
     assert sent_inputs == ["Review this [file indexed: report.pdf]"]
+
+
+@pytest.mark.asyncio
+async def test_unsupported_media_type_is_actionable_in_session_input(monkeypatch):
+    adapter = TelegramAdapter(token="fake-token", allowed_users={12345})
+    streamed_reply = AsyncMock()
+    reply_text = AsyncMock(return_value=streamed_reply)
+    update = SimpleNamespace(
+        effective_user=SimpleNamespace(id=12345),
+        message=SimpleNamespace(
+            text="",
+            photo=[],
+            document=None,
+            video=SimpleNamespace(file_id="video-1"),
+            voice=None,
+            audio=None,
+            sticker=None,
+            animation=None,
+            video_note=None,
+            reply_text=reply_text,
+        ),
+    )
+    sent_inputs = []
+
+    class StubSession:
+        def send_stream(self, text):
+            sent_inputs.append(text)
+            return iter([SimpleNamespace(text="Unsupported media")])
+
+    monkeypatch.setattr(
+        "gaia.messaging.telegram.get_or_create_session", lambda user_id: StubSession()
+    )
+
+    await adapter._handle_message(update, None)
+
+    assert sent_inputs == [
+        "[unsupported media type — supported types are photos and documents]"
+    ]

--- a/tests/unit/test_telegram_adapter.py
+++ b/tests/unit/test_telegram_adapter.py
@@ -332,38 +332,41 @@ async def test_document_ingest_success_is_included_in_session_input(
 
 
 @pytest.mark.asyncio
-async def test_unsupported_media_type_is_actionable_in_session_input(monkeypatch):
+@pytest.mark.parametrize(
+    "media_type", ["video", "voice", "audio", "sticker", "animation", "video_note"]
+)
+async def test_unsupported_media_type_replies_directly(monkeypatch, media_type):
     adapter = TelegramAdapter(token="fake-token", allowed_users={12345})
-    streamed_reply = AsyncMock()
-    reply_text = AsyncMock(return_value=streamed_reply)
+    reply_text = AsyncMock()
+    media = {
+        "video": None,
+        "voice": None,
+        "audio": None,
+        "sticker": None,
+        "animation": None,
+        "video_note": None,
+    }
+    media[media_type] = SimpleNamespace(file_id=f"{media_type}-1")
     update = SimpleNamespace(
         effective_user=SimpleNamespace(id=12345),
         message=SimpleNamespace(
             text="",
             photo=[],
             document=None,
-            video=SimpleNamespace(file_id="video-1"),
-            voice=None,
-            audio=None,
-            sticker=None,
-            animation=None,
-            video_note=None,
             reply_text=reply_text,
+            **media,
         ),
     )
-    sent_inputs = []
-
-    class StubSession:
-        def send_stream(self, text):
-            sent_inputs.append(text)
-            return iter([SimpleNamespace(text="Unsupported media")])
 
     monkeypatch.setattr(
-        "gaia.messaging.telegram.get_or_create_session", lambda user_id: StubSession()
+        "gaia.messaging.telegram.get_or_create_session",
+        lambda user_id: (_ for _ in ()).throw(
+            AssertionError("unsupported media should not create a session")
+        ),
     )
 
     await adapter._handle_message(update, None)
 
-    assert sent_inputs == [
-        "[unsupported media type — supported types are photos and documents]"
-    ]
+    reply_text.assert_awaited_once_with(
+        "Unsupported media type — I can handle photos and documents."
+    )


### PR DESCRIPTION
Refs #2986

Video, voice, audio, sticker, animation, and video-note messages previously fell through as empty input, so the bot gave no indication that the upload was ignored. This adds an explicit supported-types note to the session input and a regression test for the video path.

Test plan:
- [x] `pytest tests/unit/test_telegram_adapter.py -q` (11 passed)
- [x] `black --check src/gaia/messaging/telegram.py tests/unit/test_telegram_adapter.py`
- [x] `isort --check-only src/gaia/messaging/telegram.py tests/unit/test_telegram_adapter.py`