### PR TITLE
fix(tui): send caller checkout to daemon ensure

### DIFF
--- a/.claude/skills/driving-the-tui/SKILL.md
+++ b/.claude/skills/driving-the-tui/SKILL.md
@@ -96,20 +96,14 @@ something fixed on another branch. Build from a merged integration branch, or
 say explicitly which slice you tested.
 
 Similarly, `mode: user` runs the **published frozen sidecar**, which is routinely
-older than source (2.4 vs 2.6). Confirm with
-`gaia daemon start-agent <id> --mode dev` when testing source behaviour, and
-check `api_version` in `GET /daemon/v1/agents`.
+older than source (2.4 vs 2.6). When testing an agent from a checkout, set the
+same mode on the TUI launch so its ensure request agrees with the sidecar:
 
-## The card/context trap
+```bash
+GAIA_EMAIL_AGENT_MODE=dev /path/to/gaia-tui --control-port 8815
+```
 
-Cards are rendered by the TUI from `tool_result.render`, not by the sidecar. The
-transcript pushed back as `context` must therefore carry a compact record of what
-was displayed, or a follow-up referring to a visible row ("when is that one?")
-resolves against nothing. See `SSEClient.appendTurn` / `displayedCard`.
-
-## Reporting what you saw
-
-Write results per [CLAUDE.md → How You
-Communicate](../../../CLAUDE.md#how-you-communicate): open with whether the thing works, in
-one plain sentence, then the captures and `file:line` detail beneath it. Say plainly which
-screens you never reached — an unstated gap reads as a pass.
+Use `GAIA_GAIA_AGENT_MODE=dev` for the flagship `gaia` agent. The TUI resolves
+the caller checkout and sends the per-agent source directory to the daemon;
+starting a dev sidecar separately while the TUI still defaults to `user`
+creates a mode conflict. Check `api_version` in `GET /daemon/v1/agents`.

--- a/docs/guides/gaia.mdx
+++ b/docs/guides/gaia.mdx
@@ -58,10 +58,15 @@ The agent runs local inference only: the sidecar's `/query` endpoint rejects any
 
     ```bash
     uv pip install -e hub/agents/gaia/python    # once
-    gaia daemon start-agent gaia --mode dev
+    GAIA_GAIA_AGENT_MODE=dev gaia-tui
     ```
 
-    Dev mode always runs from **the daemon's own checkout**. If the daemon is already running from a different checkout, it refuses loudly and names both paths rather than quietly serving the wrong source. Check what's running with `gaia daemon agents`; stop it with `gaia daemon stop-agent gaia`.
+    Set `GAIA_GAIA_AGENT_MODE=dev` on the TUI launch as well as on any manual
+    `gaia daemon start-agent gaia --mode dev` launch. The TUI sends its caller
+    checkout to the daemon, so both sides agree on the source tree. Dev mode
+    refuses loudly if a sidecar is already running from a different checkout;
+    check what's running with `gaia daemon agents` and stop it with `gaia daemon
+    stop-agent gaia`.
 
     Installing the wheel also registers the agent under the id `gaia` in GAIA's agent registry, so anything that enumerates installed agents picks it up.
   </Tab>

--- a/tui/README.md
+++ b/tui/README.md
@@ -218,19 +218,20 @@ The footgun: a per-user daemon keeps serving the checkout that launched it no
 matter which directory you run the CLI from. If your edits do not seem to take,
 that is almost always why.
 
-**An agent from source** — `--mode user` (the default) runs the published frozen
-binary; `--mode dev` runs it from a checkout:
+**An agent from source** — `user` (the default) runs the published frozen
+binary; set the agent's mode environment variable to `dev` on the TUI launch so
+the TUI and daemon request the same checkout:
 
 ```bash
-gaia daemon start-agent email --mode dev [--dev-src-dir <path>]
+GAIA_EMAIL_AGENT_MODE=dev gaia-tui run email
 ```
 
-Dev mode resolves your shell's own checkout (`git rev-parse --show-toplevel`)
-and compares it — never executes it — against the checkout the daemon is
-anchored to; a mismatch is refused loudly, naming both checkouts and the fix.
-`--dev-src-dir` is the explicit escape hatch, and wants the agent's package
-directory (`<clone>/hub/agents/email/python`), not the repo root.
-
+Dev mode resolves the TUI caller's checkout (`git rev-parse --show-toplevel`)
+and sends the agent package directory (`<clone>/hub/agents/email/python`) to
+the daemon. It compares that path — never executes it — against the checkout
+the daemon is anchored to; a mismatch is refused loudly, naming both
+checkouts and the fix. If you start the sidecar manually instead, use the same
+mode with `gaia daemon start-agent email --mode dev`.
 ## An agent that only exists in your clone
 
 **It shows up in `status`.** The catalog reads `~/.gaia/agents/<id>/.installed`

--- a/tui/internal/daemon/client.go
+++ b/tui/internal/daemon/client.go
@@ -9,7 +9,10 @@ import (
 	"io"
 	"net"
 	"net/http"
+	"os"
 	"os/exec"
+	"path/filepath"
+	"runtime"
 	"strings"
 	"time"
 )
@@ -505,6 +508,13 @@ func (c *Client) EnsureAgent(ctx context.Context, agentID string) (*Instance, er
 	if agentID == "" {
 		return nil, &RequestError{Op: "ensure an agent sidecar", Detail: "no agent id was given"}
 	}
+	body, err := ensureRequestBody(agentID)
+	if err != nil {
+		return nil, &RequestError{
+			Op:     fmt.Sprintf("resolve the caller settings for the '%s' sidecar", agentID),
+			Detail: err.Error(),
+		}
+	}
 	inst, err := c.StartOrAttach(ctx)
 	if err != nil {
 		return nil, err
@@ -516,7 +526,7 @@ func (c *Client) EnsureAgent(ctx context.Context, agentID string) (*Instance, er
 	resp, inst, err := c.Do(ctx, inst, Request{
 		Method:     http.MethodPost,
 		Path:       APIPrefix + "/agents/" + agentID + "/ensure",
-		Body:       []byte("{}"),
+		Body:       body,
 		Header:     http.Header{"Content-Type": []string{"application/json"}},
 		HTTPClient: c.ensure,
 		Op:         fmt.Sprintf("ensure the '%s' sidecar via the daemon", agentID),
@@ -533,6 +543,70 @@ func (c *Client) EnsureAgent(ctx context.Context, agentID string) (*Instance, er
 		}
 	}
 	return inst, nil
+}
+
+// callerMode mirrors the built-in sidecar mode environment variables used by
+// the Python callers. Unknown IDs intentionally default to user mode: only
+// registered built-in agents have a caller-owned mode switch.
+func callerMode(agentID string) string {
+	envVar := ""
+	switch agentID {
+	case "email":
+		envVar = "GAIA_EMAIL_AGENT_MODE"
+	case "gaia":
+		envVar = "GAIA_GAIA_AGENT_MODE"
+	}
+	if envVar != "" {
+		if mode := os.Getenv(envVar); mode != "" {
+			return mode
+		}
+	}
+	return "user"
+}
+
+// callerDevSrcDir resolves the same per-agent source layout as the daemon,
+// anchored to the checkout containing the caller's current working directory.
+// The TUI binary's location is not a reliable checkout anchor, especially for
+// installed binaries and Windows development checkouts.
+func callerDevSrcDir(agentID string) (string, error) {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return "", fmt.Errorf("could not determine the current working directory: %w", err)
+	}
+	cmd := exec.Command("git", "rev-parse", "--show-toplevel")
+	cmd.Dir = cwd
+	raw, err := cmd.Output()
+	if err != nil {
+		return "", fmt.Errorf(
+			"could not determine the git checkout root from %s: %w; run from inside a git work tree",
+			cwd, err,
+		)
+	}
+	root := strings.TrimSpace(string(raw))
+	if root == "" {
+		return "", fmt.Errorf("git returned an empty checkout root; run from inside a git work tree")
+	}
+	if runtime.GOOS == "windows" && len(root) >= 3 && root[0] == '/' &&
+		((root[1] >= 'a' && root[1] <= 'z') || (root[1] >= 'A' && root[1] <= 'Z')) &&
+		root[2] == '/' {
+		// Git for Windows may emit /c/path when invoked from a Unix-like shell.
+		root = string(root[1]) + ":" + root[2:]
+	}
+	root = filepath.Clean(filepath.FromSlash(root))
+	return filepath.Join(root, "hub", "agents", agentID, "python"), nil
+}
+
+func ensureRequestBody(agentID string) ([]byte, error) {
+	mode := callerMode(agentID)
+	body := map[string]string{"mode": mode}
+	if mode == "dev" {
+		devSrcDir, err := callerDevSrcDir(agentID)
+		if err != nil {
+			return nil, err
+		}
+		body["dev_src_dir"] = devSrcDir
+	}
+	return json.Marshal(body)
 }
 
 // Logf emits a diagnostic through the client's configured logger. Exported so

--- a/tui/internal/daemon/daemon_test.go
+++ b/tui/internal/daemon/daemon_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -35,6 +36,7 @@ type fakeDaemon struct {
 	statusCode   int
 	ensureStatus int
 	ensureDetail string
+	ensureBody   []byte
 	authSeen     []string
 	paths        []string
 }
@@ -100,8 +102,13 @@ func (f *fakeDaemon) handle(w http.ResponseWriter, r *http.Request) {
 		writeJSON(w, map[string]any{"service": service, "pid": pid, "api_version": DAEMONAPIVersionForTest})
 
 	case strings.HasSuffix(r.URL.Path, "/ensure"):
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			f.t.Fatalf("read ensure request body: %v", err)
+		}
 		f.mu.Lock()
 		code, detail := f.ensureStatus, f.ensureDetail
+		f.ensureBody = append([]byte(nil), body...)
 		f.mu.Unlock()
 		if code != http.StatusOK {
 			w.WriteHeader(code)
@@ -173,6 +180,12 @@ func (f *fakeDaemon) sawPath(want string) bool {
 		}
 	}
 	return false
+}
+
+func (f *fakeDaemon) lastEnsureBody() []byte {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return append([]byte(nil), f.ensureBody...)
 }
 
 // testClient builds a Client with fast timeouts and no real launcher.
@@ -467,6 +480,7 @@ func TestDoFailsWhenTokenDidNotRotate(t *testing.T) {
 func TestEnsureAgentNeverReturnsTheSidecarToken(t *testing.T) {
 	f := newFakeDaemon(t)
 	f.writeInstance(nil)
+	t.Setenv("GAIA_EMAIL_AGENT_MODE", "")
 
 	inst, err := testClient(t, nil).EnsureAgent(context.Background(), "email")
 	if err != nil {
@@ -480,6 +494,45 @@ func TestEnsureAgentNeverReturnsTheSidecarToken(t *testing.T) {
 	}
 	if !f.sawPath("POST " + APIPrefix + "/agents/email/ensure") {
 		t.Error("ensure was never called")
+	}
+	var body map[string]string
+	if err := json.Unmarshal(f.lastEnsureBody(), &body); err != nil {
+		t.Fatalf("decode ensure request body: %v", err)
+	}
+	if body["mode"] != "user" {
+		t.Fatalf("ensure request mode = %q, want user", body["mode"])
+	}
+	if _, ok := body["dev_src_dir"]; ok {
+		t.Fatal("user-mode ensure request must not contain dev_src_dir")
+	}
+}
+
+func TestEnsureAgentSendsCallerDevCheckout(t *testing.T) {
+	t.Setenv("GAIA_EMAIL_AGENT_MODE", "dev")
+	f := newFakeDaemon(t)
+	f.writeInstance(nil)
+
+	if _, err := testClient(t, nil).EnsureAgent(context.Background(), "email"); err != nil {
+		t.Fatalf("EnsureAgent: %v", err)
+	}
+
+	var body map[string]string
+	if err := json.Unmarshal(f.lastEnsureBody(), &body); err != nil {
+		t.Fatalf("decode ensure request body: %v", err)
+	}
+	if body["mode"] != "dev" {
+		t.Fatalf("ensure request mode = %q, want dev", body["mode"])
+	}
+	root, err := exec.Command("git", "rev-parse", "--show-toplevel").Output()
+	if err != nil {
+		t.Fatalf("resolve test checkout root: %v", err)
+	}
+	want := filepath.Join(
+		filepath.Clean(filepath.FromSlash(strings.TrimSpace(string(root)))),
+		"hub", "agents", "email", "python",
+	)
+	if body["dev_src_dir"] != want {
+		t.Fatalf("ensure request dev_src_dir = %q, want %q", body["dev_src_dir"], want)
 	}
 }
 


### PR DESCRIPTION
## Summary

Fixes #2597.

- Send the caller's resolved `mode` when ensuring a daemon sidecar.
- In `dev` mode, resolve the caller checkout with `git rev-parse --show-toplevel` and include the per-agent `hub/agents/<id>/python` source directory.
- Surface checkout-resolution failures before starting or attaching to a daemon.
- Add daemon-client regression coverage for user mode and dev checkout payloads.

## Validation

- `go test ./... -count=1`
- `go vet ./...`
- `golangci-lint run ./...`
- `gofmt` and `git diff --check`
- `go test ./... -count=1 -race -timeout=15m` could not start because the environment has no `gcc` compiler for cgo.