### PR TITLE
fix(email): parse grouped Outlook duration queries

### DIFF
--- a/hub/agents/email/python/gaia_agent_email/outlook_query.py
+++ b/hub/agents/email/python/gaia_agent_email/outlook_query.py
@@ -45,7 +45,10 @@ from gaia_agent_email.gmail_query import parse_gmail_duration_value
 _IS_RE = re.compile(r"\bis:(unread|read)\b", re.IGNORECASE)
 
 _DURATION_RE = re.compile(
-    r"\b(?P<op>newer_than|older_than):(?P<val>\S+)", re.IGNORECASE
+    # Stop at grouping punctuation so `(newer_than:7d)` validates `7d`, not
+    # `7d)`, just like the Gmail query normalizer.
+    r'\b(?P<op>newer_than|older_than):(?P<val>"[^"]*"|[^\s)}\]]+)',
+    re.IGNORECASE,
 )
 
 # Graph has no calendar-aware relative-date filter, so a month is 30 days
@@ -122,6 +125,11 @@ def translate_query(query: str, *, now: Optional[datetime] = None) -> GraphQuery
 
     remainder = _IS_RE.sub(_is_sub, query)
     remainder = _DURATION_RE.sub(_duration_sub, remainder)
+    if filters:
+        # Parentheses/brackets that wrapped a filter-only operator are syntax,
+        # not a second search term. Keep rejecting actual text after removing
+        # those wrappers, because Graph cannot combine $filter and $search.
+        remainder = re.sub(r"[()\[\]{}]", " ", remainder)
     remainder = " ".join(remainder.split())
 
     if filters and remainder:

--- a/tests/unit/agents/email/test_outlook_query.py
+++ b/tests/unit/agents/email/test_outlook_query.py
@@ -59,6 +59,12 @@ def test_newer_than_days_becomes_ge_cutoff():
     assert result.filter == "receivedDateTime ge 2026-08-15T12:00:00Z"
 
 
+def test_grouped_newer_than_days_does_not_capture_closing_parenthesis():
+    result = translate_query("(newer_than:7d)", now=_NOW)
+    assert result.filter == "receivedDateTime ge 2026-08-15T12:00:00Z"
+    assert result.search is None
+
+
 def test_older_than_days_becomes_le_cutoff():
     result = translate_query("older_than:14d", now=_NOW)
     assert result.filter == "receivedDateTime le 2026-08-08T12:00:00Z"
@@ -96,6 +102,11 @@ def test_filter_and_search_operators_together_raises():
 def test_filter_and_bare_text_together_raises():
     with pytest.raises(ValueError, match="cannot be combined"):
         translate_query("newer_than:7d budget report", now=_NOW)
+
+
+def test_filter_and_grouped_bare_text_still_raises():
+    with pytest.raises(ValueError, match="cannot be combined"):
+        translate_query("(newer_than:7d) budget report", now=_NOW)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Fixes Outlook recency searches that are wrapped in Gmail-style grouping parentheses.

## Why

`(newer_than:7d)` is valid input used by the email agent, but the Outlook translator captured the closing parenthesis as part of the duration and rejected `7d)`. Outlook users therefore received an error where the Gmail path worked.

## Linked issue

Closes #3234

## Changes

- Match quoted and bare duration values using the same punctuation-aware grammar as Gmail.
- Treat grouping punctuation around extracted filter operators as syntax, while continuing to reject real mixed search text.
- Add regression coverage for grouped durations and mixed grouped-filter queries.

## Test plan

- `PYTHONPATH=hub/agents/email/python;src python -m pytest tests/unit/agents/email/test_outlook_query.py tests/unit/agents/email/test_outlook_backend.py tests/unit/agents/email/test_rest_search.py -q` (88 passed; local `TestClient` tests run with the repository's `allow_network` test override because Windows blocks socketpair in the default unit fixture)
- `python -m black --check --target-version py311 hub/agents/email/python/gaia_agent_email/outlook_query.py tests/unit/agents/email/test_outlook_query.py`
- `python -m isort --check-only hub/agents/email/python/gaia_agent_email/outlook_query.py tests/unit/agents/email/test_outlook_query.py`
- `python -m pylint hub/agents/email/python/gaia_agent_email/outlook_query.py --disable=all --enable=syntax-error,undefined-variable`
- `git diff --check`

## Evidence

- Agent UI: N/A — this is an internal Outlook query translation path and requires a real mailbox.
- MCP tools / servers: N/A — not an MCP surface.
- CLI: N/A — no CLI surface is changed.
- HTTP API / REST: N/A — the changed translator is covered with deterministic request-shape/unit tests; no external Outlook credentials are used.

## Checklist

- [x] I have linked a GitHub issue above (`Closes #N` / `Fixes #N` / `Refs #N`).
- [x] I have described why this change is being made, not just what changed.
- [x] I have run focused linting and tests locally.
- [x] I have attached or marked real-world evidence matched to the surface changed.
- [x] I have not updated documentation because this is a behavior fix with no documentation contract change.