### PR TITLE
fix(skills): normalize common plural stems

### DIFF
--- a/src/gaia/agents/base/skill_retriever.py
+++ b/src/gaia/agents/base/skill_retriever.py
@@ -167,8 +167,11 @@ please anything something nothing everything
 """.split())
 
 #: Deliberately tiny and suffix-only. A real stemmer would need a dependency and
-#: conflates words this corpus needs kept apart.
-_SUFFIXES = ("ing", "ed", "es", "s")
+#: conflates words this corpus needs kept apart. Plurals normally lose only the
+#: final ``s`` (``notes`` -> ``note``); the spellings below need ``es`` removed
+#: to keep their singular form (``boxes`` -> ``box``).
+_SUFFIXES = ("ing", "ed", "s")
+_ES_PLURAL_SUFFIXES = ("ches", "shes", "sses", "xes", "zes")
 
 #: Shortest a stem may be. Below this, suffix stripping starts merging unrelated
 #: words ("gas" -> "ga") and a three-letter stem matches far too much.
@@ -179,6 +182,8 @@ def _stem(word: str) -> str:
     """Strip a common English suffix, never taking a word below :data:`_MIN_STEM`."""
     if word.endswith("ies") and len(word) > 5:
         return word[:-3] + "y"
+    if word.endswith(_ES_PLURAL_SUFFIXES) and len(word) - 2 >= _MIN_STEM:
+        return word[:-2]
     for suffix in _SUFFIXES:
         if word.endswith(suffix) and len(word) - len(suffix) >= _MIN_STEM:
             return word[: -len(suffix)]

--- a/tests/unit/test_skill_retriever.py
+++ b/tests/unit/test_skill_retriever.py
@@ -64,7 +64,24 @@ def retriever() -> SkillRetriever:
 
 
 def test_stopwords_and_stemming():
-    assert tokenize("What are the issues you would use?") == ["issu"]
+    assert tokenize("What are the issues you would use?") == ["issue"]
+
+
+def test_plural_and_singular_forms_share_a_stem():
+    assert tokenize("issue issues note notes file files") == [
+        "issue",
+        "issue",
+        "note",
+        "note",
+        "file",
+        "file",
+    ]
+
+
+def test_plural_query_matches_singular_skill_name():
+    retriever = SkillRetriever()
+    retriever.index_texts({"note-taker": "Organize personal notes and reminders."})
+    assert retriever.decide("my notes").load == "note-taker"
 
 
 def test_stemmer_never_shortens_below_the_minimum():


### PR DESCRIPTION
## Summary

Fixes skill discovery misses caused by common singular/plural word forms.

## Why

The retriever stemmed `issues`, `notes`, and `files` by removing `es`, producing `issu`, `not`, and `fil`; their singular forms remained `issue`, `note`, and `file`. A user saying "my notes" could therefore miss a skill whose name is `note-taker`.

## Linked issue

Closes #3233

## Changes

- Normalize ordinary plurals by removing only the final `s`.
- Preserve `es` removal for spellings that require it, such as `boxes`, `classes`, and `matches`.
- Add tokenization and end-to-end retriever regressions for singular/plural matching.

## Test plan

- `PYTHONPATH=src python -m pytest tests/unit/test_skill_retriever.py tests/unit/test_skill_discovery.py tests/unit/test_skill_discovery_integration.py -q` (59 passed)
- `python -m black --check --target-version py311 ...` (the installed Black reports only a pre-existing multi-line-set formatting difference in the untouched file)
- `python -m isort --check-only src/gaia/agents/base/skill_retriever.py tests/unit/test_skill_retriever.py`
- `python -m mypy --follow-imports=skip --ignore-missing-imports src/gaia/agents/base/skill_retriever.py`
- `python -m pylint src/gaia/agents/base/skill_retriever.py --disable=all --enable=syntax-error,undefined-variable`
- `python -m compileall -q src/gaia/agents/base/skill_retriever.py tests/unit/test_skill_retriever.py`
- `git diff --check`

## Evidence

- Agent UI: N/A — this is a deterministic internal skill selection path; no live model or UI state is required.
- MCP tools / servers: N/A — not an MCP surface.
- CLI: N/A — no CLI surface is changed.
- HTTP API / REST: N/A — no network/API surface is changed.

## Checklist

- [x] I have linked a GitHub issue above (`Closes #N` / `Fixes #N` / `Refs #N`).
- [x] I have described why this change is being made, not just what changed.
- [x] I have run focused linting and tests locally.
- [x] I have marked real-world evidence as N/A because this is an internal deterministic change.
- [x] I have not updated documentation because this is an internal matching correction with no documentation contract change.