### PR TITLE
test: cover registered Telegram handlers

### DIFF
--- a/tests/unit/test_telegram_adapter.py
+++ b/tests/unit/test_telegram_adapter.py
@@ -1,6 +1,7 @@
 import logging
 import os
 import sys
+import types
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, call
 
@@ -84,18 +85,59 @@ async def test_allowed_user_gets_start_greeting():
     assert reply_text.await_args.args[0].startswith("Hello! I'm Gaia.")
 
 
-def test_every_update_handler_enforces_the_allowlist():
-    """A handler added without ``@require_allowed`` is reachable unauthenticated."""
-    handlers = [name for name in dir(TelegramAdapter) if name.startswith("_handle_")]
-    assert handlers, "no update handlers found — did they get renamed?"
+def test_every_registered_update_handler_enforces_the_allowlist(mock_home, monkeypatch):
+    """Every callback actually registered with Telegram must be guarded."""
+
+    class FakeHandler:
+        def __init__(self, *args):
+            self.callback = args[-1]
+
+    class FakeApplication:
+        def __init__(self):
+            self.handlers = []
+
+        def add_handler(self, handler):
+            self.handlers.append(handler)
+
+    app = FakeApplication()
+
+    class FakeBuilder:
+        def token(self, token):
+            assert token == "fake-token"
+            return self
+
+        def build(self):
+            return app
+
+    class FakeFilter:
+        def __and__(self, other):
+            return self
+
+        def __invert__(self):
+            return self
+
+    fake_telegram = types.ModuleType("telegram")
+    fake_ext = types.ModuleType("telegram.ext")
+    fake_ext.ApplicationBuilder = FakeBuilder
+    fake_ext.CommandHandler = FakeHandler
+    fake_ext.MessageHandler = FakeHandler
+    fake_ext.filters = SimpleNamespace(ALL=FakeFilter(), COMMAND=FakeFilter())
+    fake_telegram.ext = fake_ext
+    monkeypatch.setitem(sys.modules, "telegram", fake_telegram)
+    monkeypatch.setitem(sys.modules, "telegram.ext", fake_ext)
+    monkeypatch.setenv("GAIA_TEST_MODE", "1")
+
+    adapter = TelegramAdapter(token="fake-token")
+    adapter.start(token="fake-token", background=True)
+
+    callbacks = [handler.callback for handler in app.handlers]
+    assert callbacks, "no Telegram handlers were registered"
     unguarded = [
-        name
-        for name in handlers
-        if not getattr(
-            getattr(TelegramAdapter, name), "__gaia_allowlist_guarded__", False
-        )
+        callback.__name__
+        for callback in callbacks
+        if not getattr(callback, "__gaia_allowlist_guarded__", False)
     ]
-    assert not unguarded, f"handlers missing @require_allowed: {unguarded}"
+    assert not unguarded, f"registered handlers missing @require_allowed: {unguarded}"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Fixes #3242

The allowlist regression test now inspects the callbacks actually registered with TelegramAdapter.start instead of inferring coverage from method names.

## Changes

- Capture handlers registered through a fake Telegram application.
- Assert every registered callback carries the require_allowed guard marker.
- Keep the test local-only and avoid real Telegram credentials or network calls.

## Test plan

- PYTHONPATH=src python -c ... pytest tests/unit/test_telegram_adapter.py tests/unit/test_telegram_background.py tests/unit/test_telegram_allowlist.py tests/unit/test_telegram_sessions.py -q (18 passed)
- mypy --follow-imports=skip --ignore-missing-imports tests/unit/test_telegram_adapter.py
- black --check --target-version py311 tests/unit/test_telegram_adapter.py
- isort --check-only tests/unit/test_telegram_adapter.py
- pylint syntax/undefined-variable checks
- compileall and git diff --check

## Evidence

- Agent UI: N/A (test-only change)
- MCP: N/A (test-only change)
- CLI: N/A (test-only change)
- HTTP/API: N/A (test-only change)