### PR TITLE
test: verify embedded backend install contract

### DIFF
--- a/tests/integration/test_lemonade_embedded_lifecycle.py
+++ b/tests/integration/test_lemonade_embedded_lifecycle.py
@@ -24,7 +24,11 @@ import urllib.request
 
 import pytest
 
-from gaia.llm.lemonade_embedded import EmbeddedLemonade, UnsupportedPlatformError
+from gaia.llm.lemonade_embedded import (
+    EmbeddedLemonade,
+    EmbeddedLemonadeError,
+    UnsupportedPlatformError,
+)
 
 pytestmark = [
     pytest.mark.integration,
@@ -132,6 +136,14 @@ def test_stop_is_idempotent_and_clears_state(running_instance):
     assert not running_instance.state_path.exists()
     assert running_instance.stop() is False
     assert running_instance.status().running is False
+
+
+def test_backend_install_command_is_accepted(running_instance):
+    """The real bundled client can install a backend through the live server."""
+    try:
+        running_instance.install_backend("llamacpp:cpu", timeout=600.0)
+    except EmbeddedLemonadeError as exc:
+        pytest.fail(f"embedded Lemonade rejected the backend install: {exc}")
 
 
 def test_install_is_reentrant_without_force(tmp_path):

--- a/tests/unit/test_lemonade_embedded.py
+++ b/tests/unit/test_lemonade_embedded.py
@@ -10,6 +10,7 @@ import stat
 import tarfile
 import zipfile
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
@@ -462,3 +463,40 @@ class TestFailureMessages:
         with pytest.raises(EmbeddedLemonadeError) as exc:
             manager.install_backend("llamacpp:vulkan")
         assert "gaia lemonade embedded start" in str(exc.value)
+
+    def test_backend_install_passes_the_client_cli_contract(self, manager, monkeypatch):
+        """The bundled client receives the documented argv and API key."""
+        manager._write_state(
+            {
+                "pid": 4321,
+                "port": 13305,
+                "api_key": "secret",
+                "version": manager.version,
+            }
+        )
+        monkeypatch.setattr(manager, "_health", lambda *args, **kwargs: {"ok": True})
+        calls = []
+
+        def fake_run(command, **kwargs):
+            calls.append((command, kwargs))
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+        monkeypatch.setattr("gaia.llm.lemonade_embedded.subprocess.run", fake_run)
+
+        manager.install_backend("llamacpp:cpu", timeout=37.0)
+
+        assert len(calls) == 1
+        command, kwargs = calls[0]
+        assert command == [
+            str(manager.client_path),
+            "--port",
+            "13305",
+            "backends",
+            "install",
+            "llamacpp:cpu",
+        ]
+        assert kwargs["env"]["LEMONADE_API_KEY"] == "secret"
+        assert kwargs["timeout"] == 37.0
+        assert kwargs["capture_output"] is True
+        assert kwargs["text"] is True
+        assert kwargs["check"] is False


### PR DESCRIPTION
## Summary

Fixes #3241

The embedded Lemonade backend installer now has regression coverage for both the exact bundled-client command contract and a real backend installation through the live embedded server.

## Why

Previously, the success path was untested: an argv-order regression could reach users before the bundled client or server rejected it.

## Changes

- Assert the full lemonade --port PORT backends install SPEC argv, API-key environment, timeout, and subprocess options in the unit suite.
- Start the real embedded Lemonade artifact and install llamacpp:cpu through its bundled client in the lifecycle integration suite.
- Keep the integration test isolated by the existing temporary-home fixture, with guaranteed daemon cleanup.

## Test plan

- PYTHONPATH=src python -m pytest tests/unit/test_lemonade_embedded.py -q — 46 passed, 4 skipped.
- PYTHONPATH=src python -m pytest tests/integration/test_lemonade_embedded_lifecycle.py -q — 7 passed.
- lack --check, isort --check-only, targeted Pylint syntax/undefined-variable, targeted MyPy, compileall, and git diff --check — passed.
- python util/lint.py --all — formatting/import sorting/Flake8/Bandit/agent/dependabot/docs passed; existing POSIX-only Pylint errors and environment import-validation failure remain outside this diff.

## Evidence

- Agent UI: N/A (test-only change)
- MCP: N/A (test-only change)
- CLI: N/A (test-only change)
- HTTP/API: N/A (test-only change)