### PR TITLE
ci: run embedded Lemonade checksum guard

### DIFF
--- a/.github/workflows/test_unit.yml
+++ b/.github/workflows/test_unit.yml
@@ -148,6 +148,15 @@ jobs:
           echo ""
           pytest tests/integration/test_lemonade_release_assets.py -v --tb=short
 
+      - name: Run embedded Lemonade checksum pinning test
+        env:
+          GAIA_MEMORY_DISABLED: "1"
+        run: |
+          echo "=== Verifying embedded Lemonade SHA-256 pins against live upstream ==="
+          echo "Catches a stale executable digest before embedded install reaches users"
+          echo ""
+          pytest tests/integration/test_lemonade_embeddable_assets.py -v --tb=short
+
       - name: Run daemon integration tests
         env:
           GAIA_MEMORY_DISABLED: "1"


### PR DESCRIPTION
## Summary

Fixes #3240

Run the existing embedded Lemonade SHA-256 pin verification in CI so stale executable digests fail before release users discover them during installation.

## Why

EMBEDDABLE_SHA256 is security- and reliability-relevant, but the integration test that compares every pin with the published Lemonade release was not included in any workflow.

## Changes

- Add the existing 	ests/integration/test_lemonade_embeddable_assets.py check to the Ubuntu unit-test workflow.
- Keep the check in the existing Python matrix and use the repository's normal pytest invocation.

## Test plan

- PYTHONPATH=src python -m pytest tests/integration/test_lemonade_embeddable_assets.py -q — 4 passed.
- YAML parse with PyYAML — passed.
- git diff --check — passed.
- ctionlint was not installed in the local environment.

## Evidence

- Agent UI: N/A (CI configuration change)
- MCP: N/A (CI configuration change)
- CLI: N/A (CI configuration change)
- HTTP/API: N/A (CI configuration change)