### PR TITLE
fix: keep skill discovery loader available

### DIFF
--- a/hub/agents/chat/python/gaia_agent_chat/tool_bundles.py
+++ b/hub/agents/chat/python/gaia_agent_chat/tool_bundles.py
@@ -169,15 +169,16 @@ DOC_BUNDLES = [
 # tools instead of 37, so the un-trimmed native ``tools=`` payload costs ~10.2K
 # tiktoken tokens on every LLM call of a 2-5 call ReAct turn.
 #
-# Always-on set (10 tools). Deliberately a smaller share of the registry than
+# Always-on set (12 tools). Deliberately a smaller share of the registry than
 # the doc CORE, because a general-purpose agent has no single reason to exist:
 # memory (recall is relevant to every turn), loop control (protocol-level turn
-# signalling), the ``load_tools`` escape hatch, and exactly two universal entry
-# points -- ``read_file`` and ``query_documents`` -- that answer "what is in
-# this file / what do my documents say" without a round trip. Everything else,
-# shell and the web included, is a bundle: it arrives when the turn asks for
-# it. Both entry points are bundle members too, so a file-shaped or
-# document-shaped turn pulls their whole cohort in with them.
+# signalling), the ``load_tools`` escape hatch, ``load_skill`` for proactive
+# skill discovery, and exactly two universal entry points -- ``read_file`` and
+# ``query_documents`` -- that answer "what is in this file / what do my
+# documents say" without a round trip. Everything else, shell and the web
+# included, is a bundle: it arrives when the turn asks for it. Both entry
+# points are bundle members too, so a file-shaped or document-shaped turn pulls
+# their whole cohort in with them.
 FULL_CORE_TOOLS = frozenset(
     {
         # memory v2 -- persistent recall is always relevant
@@ -194,6 +195,9 @@ FULL_CORE_TOOLS = frozenset(
         "request_user_input",
         # escape hatch (#1450)
         "load_tools",
+        # proactive skill discovery (#3235) — the shortlist prompt tells the
+        # model to call this even when the skills bundle was not selected.
+        "load_skill",
     }
 )
 

--- a/hub/agents/gaia/python/gaia_agent/agent.py
+++ b/hub/agents/gaia/python/gaia_agent/agent.py
@@ -167,7 +167,7 @@ class GaiaAgentConfig(ChatAgentConfig):
     # pays a 66-tool registry. Overridable via GAIA_DYNAMIC_TOOLS.
     dynamic_tools: bool = True
 
-    # 10 CORE (FULL_CORE_TOOLS) + 16 dynamic slots. The inherited 14 was sized
+    # 12 CORE (FULL_CORE_TOOLS) + 14 dynamic slots. The inherited 14 was sized
     # for the doc profile's 11 CORE, leaving 3 slots — less than one 6-member
     # bundle, so the flagship would truncate a cohesion group mid-pull instead
     # of loading it. Swept offline against nine representative queries: 22 cut

--- a/hub/agents/gaia/python/tests/test_full_tool_bundles.py
+++ b/hub/agents/gaia/python/tests/test_full_tool_bundles.py
@@ -35,7 +35,7 @@ from gaia_agent_chat.tool_bundles import (
 from gaia.agents.base.tools import _TOOL_REGISTRY
 
 #: Ceiling on bundle size. A pull-in must never be able to exhaust the dynamic
-#: slots on its own (GaiaAgentConfig.dynamic_tools_max=26 minus 10 CORE leaves 16).
+#: slots on its own (GaiaAgentConfig.dynamic_tools_max=26 minus 12 CORE leaves 14).
 MAX_BUNDLE_MEMBERS = 6
 
 
@@ -103,6 +103,12 @@ def test_escape_hatch_is_registered_and_core(flagship_registry):
     """Without load_tools in the registry a semantic miss is unrecoverable."""
     assert "load_tools" in FULL_CORE_TOOLS
     assert "load_tools" in flagship_registry
+
+
+def test_skill_discovery_loader_is_registered_and_core(flagship_registry):
+    """A shortlist must be able to call the tool its prompt advertises."""
+    assert "load_skill" in FULL_CORE_TOOLS
+    assert "load_skill" in flagship_registry
 
 
 def test_bundle_menu_renders_for_the_flagship():


### PR DESCRIPTION
## Summary

Fixes #3235

Keep load_skill available in the full-profile dynamic tool set whenever proactive skill discovery can tell the model to call it.

## Why

The shortlist prompt is produced before a skill is activated and explicitly instructs the model to call load_skill. Because load_skill lived only in the skills bundle, semantic tool selection could omit it on the exact turn where the shortlist was shown.

## Changes

- Add the already-registered load_skill tool to FULL_CORE_TOOLS so it is always surfaced for the flagship.
- Add a registry/core regression test proving the prompt-advertised tool exists and is core.
- Update the related core-capacity comments to reflect the new 12-tool core.

## Test plan

- PYTHONPATH=src;hub/agents/chat/python;hub/agents/gaia/python python -m pytest tests/unit/test_chat_tool_bundles.py tests/unit/test_chat_dynamic_tools.py hub/agents/gaia/python/tests/test_full_tool_bundles.py hub/agents/gaia/python/tests/test_proactive_skill_discovery.py hub/agents/gaia/python/tests/test_lazy_skill_activation.py -q — 92 passed.
- Black, isort, targeted Pylint syntax/undefined-variable, compileall, and git diff --check — passed.
- Targeted MyPy reports 4 pre-existing errors in hub/agents/gaia/python/gaia_agent/agent.py at lines 326, 381, and 392; no new error is from this change.

## Evidence

- Agent UI: N/A (tool-selection configuration and tests)
- MCP: N/A (tool-selection configuration and tests)
- CLI: N/A (tool-selection configuration and tests)
- HTTP/API: N/A (tool-selection configuration and tests)