### PR TITLE
fix: report RAG indexing failures accurately

### DIFF
--- a/src/gaia/chat/sdk.py
+++ b/src/gaia/chat/sdk.py
@@ -874,13 +874,17 @@ class AgentSDK:
         """Get the number of conversation pairs (user + assistant)."""
         return len(self.chat_history) // 2
 
-    def enable_rag(self, documents: Optional[List[str]] = None, **rag_kwargs):
+    def enable_rag(self, documents: Optional[List[str]] = None, **rag_kwargs) -> bool:
         """
         Enable RAG (Retrieval-Augmented Generation) for document-based chat.
 
         Args:
             documents: List of PDF file paths to index
             **rag_kwargs: Additional RAG configuration options
+
+        Returns:
+            True when RAG is enabled and every requested document was indexed;
+            False when one or more documents could not be indexed.
         """
         try:
             from gaia.rag.sdk import RAGSDK, RAGConfig
@@ -901,19 +905,27 @@ class AgentSDK:
         self.rag_enabled = True
 
         # Index documents if provided
+        document_count = len(documents) if documents else 0
+        indexed_count = 0
         if documents:
             for doc_path in documents:
                 self.log.info(f"Indexing document: {doc_path}")
                 result = self.rag.index_document(doc_path)
 
-                if result:
+                if isinstance(result, dict) and result.get("success") is True:
+                    indexed_count += 1
                     self.log.info(f"Successfully indexed: {doc_path}")
                 else:
                     self.log.warning(f"Failed to index document: {doc_path}")
 
-        self.log.info(
-            f"RAG enabled with {len(documents) if documents else 0} documents"
-        )
+        if indexed_count == document_count:
+            self.log.info(f"RAG enabled with {document_count} documents")
+        else:
+            self.log.warning(
+                f"RAG enabled but indexed {indexed_count} of "
+                f"{document_count} documents"
+            )
+        return indexed_count == document_count
 
     def disable_rag(self):
         """Disable RAG functionality."""

--- a/src/gaia/talk/sdk.py
+++ b/src/gaia/talk/sdk.py
@@ -355,11 +355,16 @@ class TalkSDK:
             True if RAG was successfully enabled
         """
         try:
-            self.chat_sdk.enable_rag(documents=documents, **rag_kwargs)
-            self.log.info(
-                f"RAG enabled with {len(documents) if documents else 0} documents"
-            )
-            return True
+            enabled = bool(self.chat_sdk.enable_rag(documents=documents, **rag_kwargs))
+            if enabled:
+                self.log.info(
+                    f"RAG enabled with {len(documents) if documents else 0} documents"
+                )
+            else:
+                self.log.warning(
+                    "RAG enabled but one or more documents failed to index"
+                )
+            return enabled
         except ImportError:
             self.log.warning(
                 'RAG dependencies not available. Install with: uv pip install -e ".[rag]"'

--- a/tests/unit/test_rag_index_status.py
+++ b/tests/unit/test_rag_index_status.py
@@ -1,0 +1,81 @@
+# SPDX-License-Identifier: MIT
+
+"""Regression tests for RAG startup/indexing status propagation."""
+
+from unittest.mock import Mock, patch
+
+from gaia.chat.sdk import AgentConfig, AgentSDK
+from gaia.talk.sdk import TalkSDK
+
+
+def _uninitialized_chat() -> AgentSDK:
+    """Build an AgentSDK without starting an LLM provider."""
+    chat = AgentSDK.__new__(AgentSDK)
+    chat.config = AgentConfig()
+    chat.log = Mock()
+    chat.rag = None
+    chat.rag_enabled = False
+    return chat
+
+
+def test_chat_enable_rag_requires_a_successful_index_result():
+    """A non-empty failure dict must not produce a success log or result."""
+    chat = _uninitialized_chat()
+
+    with patch("gaia.rag.sdk.RAGSDK") as rag_class:
+        rag_class.return_value.index_document.return_value = {
+            "success": False,
+            "error": "embedding model unavailable",
+        }
+
+        result = chat.enable_rag(documents=["manual.pdf"])
+
+    assert result is False
+    assert chat.rag_enabled is True
+    assert any(
+        "Failed to index document" in call.args[0]
+        for call in chat.log.warning.call_args_list
+    )
+    assert not any(
+        "Successfully indexed" in call.args[0] for call in chat.log.info.call_args_list
+    )
+    assert any(
+        "indexed 0 of 1 documents" in call.args[0]
+        for call in chat.log.warning.call_args_list
+    )
+
+
+def test_talk_enable_rag_propagates_chat_index_failure():
+    """Talk must not report RAG success when Chat reports a failed index."""
+    talk = TalkSDK.__new__(TalkSDK)
+    talk.chat_sdk = Mock()
+    talk.chat_sdk.enable_rag.return_value = False
+    talk.log = Mock()
+
+    result = talk.enable_rag(documents=["manual.pdf"])
+
+    assert result is False
+    talk.chat_sdk.enable_rag.assert_called_once_with(documents=["manual.pdf"])
+    assert not any(
+        "RAG enabled with" in call.args[0] for call in talk.log.info.call_args_list
+    )
+    talk.log.warning.assert_called_once_with(
+        "RAG enabled but one or more documents failed to index"
+    )
+
+
+def test_talk_enable_rag_preserves_success_status():
+    """Talk keeps its success log when Chat indexes every document."""
+    talk = TalkSDK.__new__(TalkSDK)
+    talk.chat_sdk = Mock()
+    talk.chat_sdk.enable_rag.return_value = True
+    talk.log = Mock()
+
+    result = talk.enable_rag(documents=["manual.pdf"])
+
+    assert result is True
+    assert any(
+        "RAG enabled with 1 documents" in call.args[0]
+        for call in talk.log.info.call_args_list
+    )
+    talk.log.warning.assert_not_called()


### PR DESCRIPTION
## Summary

Fixes #3216

RAG indexing returns a structured result with `success: false` when extraction or embedding fails. The Chat SDK previously treated any non-empty result as success, and the Talk SDK ignored Chat's outcome, so startup logs claimed documents were indexed when the vector index was empty.

## Changes

- Check the documented `success` field instead of dict truthiness.
- Track successful versus requested documents and return the aggregate status from `AgentSDK.enable_rag`.
- Propagate that status through `TalkSDK.enable_rag` and emit a warning instead of a success log for failed indexing.
- Add deterministic mock coverage for failed and successful Chat/Talk startup paths.

## Test plan

- `PYTHONPATH=src python -m pytest tests/unit/test_rag_index_status.py tests/test_rag.py -q` (46 passed)
- `black`, `isort`, Pylint E/F, `compileall`, and `git diff --check` passed for the changed paths.

Repository-wide lint retains its existing 9 POSIX API Pylint errors, non-blocking MyPy warnings, and editable-install validation failure in this environment.
