### PR TITLE
fix: report missing API server on stop

### DIFF
--- a/src/gaia/cli.py
+++ b/src/gaia/cli.py
@@ -4918,8 +4918,12 @@ def handle_api_command(args):
     elif args.subcommand == "stop":
         print(f"🛑 Stopping API server on port {args.port}...")
         try:
-            kill_process_by_port(args.port)
-            print("✅ API server stopped")
+            result = kill_process_by_port(args.port)
+            if result.get("success"):
+                print("✅ API server stopped")
+            else:
+                print(f"❌ {result.get('message', 'API server was not running')}")
+                sys.exit(1)
         except Exception as e:
             print(f"❌ Error stopping server: {e}")
             sys.exit(1)

--- a/tests/unit/cli/test_stub_surface_gates.py
+++ b/tests/unit/cli/test_stub_surface_gates.py
@@ -109,6 +109,33 @@ class TestApiStatus:
         handle_api_command(Namespace(subcommand="status", host="127.0.0.1", port=8123))
         checker.assert_called_once_with("127.0.0.1", 8123)
 
+    def test_stop_reports_success_when_a_process_was_killed(self, mocker, capsys):
+        killer = mocker.patch(
+            "gaia.cli.kill_process_by_port",
+            return_value={"success": True, "message": "killed"},
+        )
+
+        handle_api_command(Namespace(subcommand="stop", host="localhost", port=8080))
+
+        killer.assert_called_once_with(8080)
+        assert "✅ API server stopped" in capsys.readouterr().out
+
+    def test_stop_returns_nonzero_when_no_process_was_found(self, mocker, capsys):
+        mocker.patch(
+            "gaia.cli.kill_process_by_port",
+            return_value={"success": False, "message": "No process found"},
+        )
+
+        with pytest.raises(SystemExit) as exc:
+            handle_api_command(
+                Namespace(subcommand="stop", host="localhost", port=8080)
+            )
+
+        assert exc.value.code == 1
+        out = capsys.readouterr().out
+        assert "❌ No process found" in out
+        assert "✅ API server stopped" not in out
+
 
 # ---------------------------------------------------------------------------
 # #2009 — reserved eval flags removed from the parser


### PR DESCRIPTION
## Summary

Fixes #3220

`gaia api stop` delegated to `kill_process_by_port()` but ignored its structured result, so stopping an absent server printed success and exited 0. This made scripts unable to distinguish a real stop from a no-op.

## Changes

- Check the existing `success` result before reporting that the API server stopped.
- Print the existing failure message and exit non-zero when no process was found or the port could not be handled.
- Add deterministic CLI coverage for both a killed process and an absent server.

## Test plan

- `PYTHONPATH=src python -m pytest tests/unit/cli/test_stub_surface_gates.py -q` (16 passed)
- Black, isort, Pylint E/F, `compileall`, and `git diff --check` passed for the changed paths.
