### PR TITLE
fix(talk): honor restart voice command

### DIFF
--- a/src/gaia/talk/sdk.py
+++ b/src/gaia/talk/sdk.py
@@ -242,6 +242,14 @@ class TalkSDK:
 
             # Create voice processor that uses AgentSDK for responses
             async def voice_processor(text: str):
+                # Keep the documented voice command out of the conversation.
+                # The history belongs to TalkSDK's AgentSDK, not AudioClient's
+                # provider client, so handle it at this boundary.
+                if text.lower().strip().rstrip(".!?") == "restart":
+                    self.clear_history()
+                    print("Conversation history cleared.")
+                    return
+
                 # Call user callback if provided
                 if on_voice_input:
                     on_voice_input(text)

--- a/tests/unit/test_talk_voice_commands.py
+++ b/tests/unit/test_talk_voice_commands.py
@@ -1,0 +1,66 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+"""Tests for voice-session command handling."""
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from gaia.talk.sdk import TalkConfig, TalkSDK
+
+# asyncio uses a local socketpair for its Windows event-loop wakeup.
+pytestmark = pytest.mark.allow_network
+
+
+def _talk_sdk_with_captured_voice_processor():
+    """Build a TalkSDK seam without creating real audio or model clients."""
+    talk = TalkSDK.__new__(TalkSDK)
+    talk.config = TalkConfig(enable_tts=False)
+    talk.log = MagicMock()
+    talk.show_stats = False
+    talk.chat_sdk = MagicMock()
+    talk.audio_client = MagicMock()
+    talk.audio_client.start_voice_chat = AsyncMock()
+    return talk
+
+
+def _run(coro):
+    """Run async SDK code without the Windows proactor socketpair."""
+    selector_policy = getattr(asyncio, "WindowsSelectorEventLoopPolicy", None)
+    previous_policy = asyncio.get_event_loop_policy()
+    if selector_policy:
+        asyncio.set_event_loop_policy(selector_policy())
+    try:
+        return asyncio.run(coro)
+    finally:
+        asyncio.set_event_loop_policy(previous_policy)
+
+
+def test_restart_voice_command_clears_history_without_model_call(capsys):
+    """The documented restart command clears history and is not sent to the LLM."""
+    talk = _talk_sdk_with_captured_voice_processor()
+
+    _run(talk.start_voice_session())
+    voice_processor = talk.audio_client.start_voice_chat.call_args.args[0]
+
+    _run(voice_processor("  Restart! "))
+
+    talk.chat_sdk.clear_history.assert_called_once_with()
+    talk.chat_sdk.send.assert_not_called()
+    assert "Conversation history cleared." in capsys.readouterr().out
+
+
+def test_regular_voice_input_still_reaches_model():
+    """Only the exact restart command is intercepted."""
+    talk = _talk_sdk_with_captured_voice_processor()
+    talk.chat_sdk.send.return_value = MagicMock(text="response", stats=None)
+
+    _run(talk.start_voice_session())
+    voice_processor = talk.audio_client.start_voice_chat.call_args.args[0]
+
+    _run(voice_processor("restart the server"))
+
+    talk.chat_sdk.clear_history.assert_not_called()
+    talk.chat_sdk.send.assert_called_once_with("restart the server")


### PR DESCRIPTION
## Summary

Honor the documented `restart` voice command by clearing the active TalkSDK conversation history.

## Why

The voice-session banner tells users that saying `restart` clears chat history, but the transcribed word currently goes to the model as a normal prompt.

## Linked issue

Closes #3214

## Changes

- Intercept the normalized `restart` command in the TalkSDK voice processor.
- Clear the same AgentSDK history used by voice responses and skip the model call.
- Add regression coverage for punctuation/casing and for preserving ordinary voice input behavior.

## Test plan

- `PYTHONPATH=src python -m pytest tests/unit/test_talk_voice_commands.py tests/unit/test_audio_client_mic_check.py tests/unit/test_talk_config.py tests/test_sdk.py::TestTalkSDK -q` — 17 passed.
- `git diff --check` — passed.
- Black, isort, Pylint errors-only, and compileall on changed files — passed.
- `python util/lint.py --all` — formatting, Flake8, Bandit, security suppressions, agent conventions, Dependabot, and doc-version checks passed; existing Windows Pylint false positives, existing MyPy warnings, and uninstalled-package import validation are recorded below.
- `PYTHONPATH=src python -m pytest tests/unit/ -x --tb=short -q` — 640 passed, 91 skipped, then stopped at existing Windows event-loop/socket guard setup failure in `tests/unit/chat/ui/test_agent_loop.py::TestRunStepModeGate::test_manual_pauses`.

## Evidence

- [x] **Agent exposed in the Agent UI** — N/A; this change is limited to the TalkSDK voice-session callback and does not change the Agent UI.
- [x] **MCP tools / servers** — N/A; no MCP surface changed.
- [x] **CLI** — N/A for automated evidence; the CLI delegates to the same TalkSDK callback, while this environment has no deterministic microphone/model session. The callback path is covered by API-key-free unit tests.
- [x] **HTTP API / REST** — N/A; no HTTP surface changed.

## Checklist

- [x] I have linked a GitHub issue above (`Closes #3214`).
- [x] I have described why this change is being made, not just what changed.
- [x] I have run linting and tests locally.
- [x] I have attached real-world evidence matched to the surface changed, or marked each surface N/A with a reason.
- [x] Existing documentation already describes the `restart` behavior; no documentation update is needed.