### PR TITLE
fix(cli): honor prompt device selection

### DIFF
--- a/docs/reference/cli.mdx
+++ b/docs/reference/cli.mdx
@@ -1407,9 +1407,9 @@ For `gaia chat`, `gaia llm`, and `gaia prompt`, the model is resolved highest-wi
 3. The command's built-in default (`DEFAULT_MODEL_NAME`)
 
 So `gaia config set default_model <id>` lets you skip `--model` entirely, while
-`--model` still overrides it for a single run. For `gaia chat`, passing an
-explicit `--device` selects a device-specific model and takes precedence over
-the config default.
+`--model` still overrides it for a single run. For `gaia chat` and `gaia prompt`,
+passing an explicit `--device` selects a device-specific model and takes
+precedence over the config default.
 
 <Note>
 A **missing** config file is fine — GAIA falls back to built-in defaults. A

--- a/src/gaia/cli.py
+++ b/src/gaia/cli.py
@@ -101,6 +101,7 @@ def initialize_lemonade_for_agent(
     host: str | None = None,
     port: int | None = None,
     base_url: str | None = None,
+    device: str | None = None,
 ):
     """
     Initialize Lemonade Server for a specific GAIA agent.
@@ -118,6 +119,8 @@ def initialize_lemonade_for_agent(
         port: Port number of the Lemonade server (defaults to LEMONADE_BASE_URL env var)
         base_url: Full base URL for the Lemonade server (e.g., https://abc.ngrok-free.app).
                   When provided, takes priority over host/port.
+        device: Device target for context sizing and hardware validation. When omitted,
+                the persisted default device is used.
 
     Returns:
         Tuple of (success: bool, base_url: str | None)
@@ -155,7 +158,8 @@ def initialize_lemonade_for_agent(
     # Keyed on device, not agent, because the NPU's FLM build caps below the
     # GPU window and would fail to load at it.
     # Users on tight RAM can override with the ``GAIA_CTX_SIZE`` env var.
-    required_ctx = profile_ctx_size(_configured_device())
+    target_device = device or _configured_device()
+    required_ctx = profile_ctx_size(target_device)
 
     # Env-var override: lets users on lower-memory hardware dial back
     # (or, in advanced cases, push higher up to the model's 128K max).
@@ -187,6 +191,7 @@ def initialize_lemonade_for_agent(
                 min_context_size=required_ctx,
                 quiet=quiet,
                 base_url=base_url,
+                device=target_device,
             )
         else:
             success = LemonadeManager.ensure_ready(
@@ -194,6 +199,7 @@ def initialize_lemonade_for_agent(
                 quiet=quiet,
                 host=host,
                 port=port,
+                device=target_device,
             )
     except LemonadeClientError as e:
         print(f"❌ Error: {e}", file=sys.stderr)
@@ -362,6 +368,10 @@ class GaiaCliClient:
                 ),
                 None,
             )
+            if model is None:
+                raise ValueError(
+                    f"Unknown device {device!r}: no model is registered for it."
+                )
 
         self.model = model or DEFAULT_MODEL_NAME
         self.max_tokens = max_tokens
@@ -545,6 +555,7 @@ async def async_main(action, **kwargs):
             use_claude=use_claude,
             use_chatgpt=use_chatgpt,
             base_url=lemonade_base_url,
+            device=kwargs.get("device"),
         )
         if not success:
             sys.exit(1)
@@ -557,6 +568,9 @@ async def async_main(action, **kwargs):
     # Create client for actions that use GaiaCliClient (not chat - it uses ChatAgent)
     client = None
     if action in ["prompt", "stats"]:
+        if action == "prompt" and kwargs.get("device") is None:
+            # Keep direct prompts consistent with chat and `gaia init --profile`.
+            kwargs["device"] = _configured_device()
         # Pass only what GaiaCliClient accepts; unrelated CLI flags (e.g. --ui)
         # would otherwise reach the constructor and crash it with a TypeError.
         client = GaiaCliClient(**_gaia_cli_client_params(kwargs))

--- a/src/gaia/cli.py
+++ b/src/gaia/cli.py
@@ -338,22 +338,38 @@ class GaiaCliClient:
 
     def __init__(
         self,
-        model=DEFAULT_MODEL_NAME,
+        model=None,
         max_tokens=512,
         show_stats=False,
         logging_level="INFO",
+        device=None,
     ):
         self.log = self.__class__.log  # Use the class-level logger for instances
         # Set the logging level for this instance's logger
         self.log.setLevel(getattr(logging, logging_level))
 
-        self.model = model
+        # A device selector chooses the model that is built for that target.
+        # Keep an explicitly supplied model first in the precedence order so
+        # existing `--model` usage remains authoritative.
+        if model is None and device is not None:
+            from gaia.agents.registry import DEFAULT_DEVICE_CONFIGS
+
+            model = next(
+                (
+                    config.model
+                    for config in DEFAULT_DEVICE_CONFIGS
+                    if config.device == device
+                ),
+                None,
+            )
+
+        self.model = model or DEFAULT_MODEL_NAME
         self.max_tokens = max_tokens
         self.cli_mode = True  # Set this to True for CLI mode
         self.show_stats = show_stats
 
         # Initialize LLM client for local inference
-        self.llm_client = create_client("lemonade", model=model)
+        self.llm_client = create_client("lemonade", model=self.model)
 
         self.log.debug("Gaia CLI client initialized.")
         self.log.debug(f"model: {self.model}\n max_tokens: {self.max_tokens}")
@@ -3193,8 +3209,8 @@ def main():
 
     # Apply the persistent default_model (issue #98) for model-bearing commands.
     # Precedence: explicit --model flag > config default_model > built-in default.
-    # An explicit `chat --device` requests a device-specific model, so it keeps
-    # precedence over the config default there.
+    # An explicit `chat --device` or `prompt --device` requests a
+    # device-specific model, so it keeps precedence over the config default.
     if (
         args.action in ("prompt", "chat", "llm")
         and getattr(args, "model", None) is None
@@ -3208,7 +3224,7 @@ def main():
             sys.exit(1)
         # builtin_default=None: leave args.model unset when no config default so
         # each command keeps applying its own built-in default downstream.
-        if not (args.action == "chat" and getattr(args, "device", None)):
+        if not (args.action in ("chat", "prompt") and getattr(args, "device", None)):
             resolved = _cfg.resolve_model(args.model, None)
             if resolved:
                 args.model = resolved

--- a/tests/unit/test_cli_config.py
+++ b/tests/unit/test_cli_config.py
@@ -301,6 +301,23 @@ class TestModelInjection:
         main()
         assert "model" not in captured["kwargs"]
 
+    def test_prompt_explicit_device_skips_config_default(self, monkeypatch, tmp_path):
+        # An explicit `prompt --device` selects a device-specific model and must
+        # take precedence over the config default (model stays unset here).
+        from gaia import config as config_mod
+        from gaia.config import GaiaConfig
+
+        monkeypatch.setattr(config_mod, "GAIA_CONFIG_FILE", tmp_path / "config.json")
+        monkeypatch.setattr(config_mod, "GAIA_CONFIG_DIR", tmp_path)
+        GaiaConfig(default_model="Configured-GGUF").save()
+
+        captured = self._capture_run_cli(monkeypatch)
+        monkeypatch.setattr(sys, "argv", ["gaia", "prompt", "hi", "--device", "npu"])
+        from gaia.cli import main
+
+        main()
+        assert "model" not in captured["kwargs"]
+
     def test_corrupt_config_fails_loudly_on_model_command(
         self, monkeypatch, tmp_path, capsys
     ):

--- a/tests/unit/test_cli_prompt_device.py
+++ b/tests/unit/test_cli_prompt_device.py
@@ -1,0 +1,49 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+"""Tests for device-aware direct prompt model selection."""
+
+from unittest.mock import MagicMock, patch
+
+
+def test_prompt_client_params_forward_device_selector():
+    """The prompt dispatch preserves --device for GaiaCliClient."""
+    from gaia.cli import _gaia_cli_client_params
+
+    params = _gaia_cli_client_params({"message": "hi", "device": "npu"})
+
+    assert params["device"] == "npu"
+
+
+def test_prompt_client_uses_npu_model_for_device():
+    """The NPU prompt path selects the FLM model from the registry."""
+    from gaia.cli import GaiaCliClient
+
+    with patch("gaia.cli.create_client", return_value=MagicMock()) as create_client:
+        client = GaiaCliClient(device="npu")
+
+    assert client.model == "gemma4-it-e2b-FLM"
+    create_client.assert_called_once_with("lemonade", model="gemma4-it-e2b-FLM")
+
+
+def test_prompt_client_explicit_model_wins_over_device():
+    """An explicit model remains authoritative when both flags are supplied."""
+    from gaia.cli import GaiaCliClient
+
+    with patch("gaia.cli.create_client", return_value=MagicMock()) as create_client:
+        client = GaiaCliClient(model="custom-model", device="npu")
+
+    assert client.model == "custom-model"
+    create_client.assert_called_once_with("lemonade", model="custom-model")
+
+
+def test_prompt_client_without_device_keeps_default_model():
+    """Existing direct prompt callers retain the default GPU model."""
+    from gaia.cli import GaiaCliClient
+    from gaia.llm.lemonade_client import DEFAULT_MODEL_NAME
+
+    with patch("gaia.cli.create_client", return_value=MagicMock()) as create_client:
+        client = GaiaCliClient()
+
+    assert client.model == DEFAULT_MODEL_NAME
+    create_client.assert_called_once_with("lemonade", model=DEFAULT_MODEL_NAME)

--- a/tests/unit/test_cli_prompt_device.py
+++ b/tests/unit/test_cli_prompt_device.py
@@ -5,6 +5,8 @@
 
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 
 def test_prompt_client_params_forward_device_selector():
     """The prompt dispatch preserves --device for GaiaCliClient."""
@@ -47,3 +49,57 @@ def test_prompt_client_without_device_keeps_default_model():
 
     assert client.model == DEFAULT_MODEL_NAME
     create_client.assert_called_once_with("lemonade", model=DEFAULT_MODEL_NAME)
+
+
+def test_prompt_initialization_uses_explicit_device():
+    """Prompt bring-up uses the same device as its selected model."""
+    from gaia.cli import initialize_lemonade_for_agent
+
+    with (
+        patch(
+            "gaia.cli._get_lemonade_config",
+            return_value=("localhost", 13305, None),
+        ),
+        patch(
+            "gaia.llm.lemonade_manager.LemonadeManager.ensure_ready",
+            return_value=True,
+        ) as ensure_ready,
+        patch(
+            "gaia.llm.lemonade_manager.LemonadeManager.get_base_url",
+            return_value="http://localhost:13305/api/v1",
+        ),
+    ):
+        assert initialize_lemonade_for_agent("minimal", device="npu")[0] is True
+
+    assert ensure_ready.call_args.kwargs["device"] == "npu"
+
+
+@pytest.mark.allow_network  # asyncio's Windows proactor uses a local socketpair.
+def test_prompt_uses_configured_device_when_flag_is_absent(monkeypatch):
+    """A prompt without --device follows the persisted device profile."""
+    from gaia import cli
+
+    captured = {}
+
+    class FakeClient:
+        def __init__(self, device=None, **kwargs):
+            captured["device"] = device
+            captured.update(kwargs)
+
+        async def prompt(self, _message):
+            yield "ok"
+
+    monkeypatch.setattr(cli, "GaiaCliClient", FakeClient)
+    monkeypatch.setattr(cli, "_configured_device", lambda: "npu")
+    monkeypatch.setattr(
+        cli,
+        "initialize_lemonade_for_agent",
+        lambda **_kwargs: (True, "http://localhost:13305/api/v1"),
+    )
+
+    import asyncio
+
+    result = asyncio.run(cli.async_main("prompt", message="hi"))
+
+    assert result == {"response": "ok"}
+    assert captured["device"] == "npu"


### PR DESCRIPTION
## Summary

Honor `gaia prompt --device` by selecting the model registered for the requested device.

## Why

The prompt parser advertised `--device`, but `async_main` filtered it out before constructing `GaiaCliClient`, which then always used `Gemma-4-E4B-it-GGUF`. For `--device npu`, this silently ran the GPU model instead of the NPU FLM model.

## Linked issue

Closes #3212

## Changes

- Preserve `device` when dispatching prompt arguments to `GaiaCliClient`.
- Resolve a device-specific model through the existing `DEFAULT_DEVICE_CONFIGS` registry.
- Keep an explicit `--model` ahead of `--device`, and retain the existing default model when neither is supplied.
- Keep an explicit prompt device ahead of the persistent `default_model` config value.

## Test plan

- `PYTHONPATH=src python -m pytest tests/unit/test_cli_prompt_device.py tests/unit/test_cli_config.py tests/unit/test_cli_device_resolution.py tests/unit/cli -q` — 230 passed, 2 skipped; the two failures are the existing console-script discovery checks because this interpreter does not have GAIA editable-installed.
- `git diff --check` — passed.
- Black, isort, Pylint errors-only, and compileall on changed files — passed; Pylint emits the existing Windows GBK parsing warning for `cli.py` but no errors.
- `python util/lint.py --all` — Black, isort, Flake8, Bandit, security suppressions, agent conventions, Dependabot, and doc-version checks passed. Existing baseline limitations: 9 Windows Pylint `os.killpg/getpgid/geteuid` errors, 1116 non-blocking MyPy warnings, and import validation blocked by the uninstalled package.

## Evidence

- [x] **Agent exposed in the Agent UI** — N/A; no Agent UI surface changed.
- [x] **MCP tools / servers** — N/A; no MCP surface changed.
- [x] **CLI** — Live Lemonade/model execution is not deterministic or available in this environment. The exact prompt dispatch, NPU model selection, explicit-model precedence, and default behavior are covered with API-key-free unit tests.
- [x] **HTTP API / REST** — N/A; no HTTP surface changed.

## Checklist

- [x] I have linked a GitHub issue above (`Closes #3212`).
- [x] I have described why this change is being made, not just what changed.
- [x] I have run linting and tests locally.
- [x] I have attached real-world evidence matched to the surface changed, or marked each surface N/A with a reason.
- [x] Existing documentation already advertises `--device`; the implementation now matches it, so no documentation update is needed.