### PR TITLE
fix: fail Telegram startup when dependency is missing

### DIFF
--- a/src/gaia/cli.py
+++ b/src/gaia/cli.py
@@ -3254,11 +3254,15 @@ def main():
                     )
                     sys.exit(2)
 
-            run_telegram(
-                token=args.token,
-                allowed_users=allowed,
-                background=getattr(args, "background", False),
-            )
+            try:
+                run_telegram(
+                    token=args.token,
+                    allowed_users=allowed,
+                    background=getattr(args, "background", False),
+                )
+            except RuntimeError as e:
+                print(f"❌ {e}", file=sys.stderr)
+                sys.exit(1)
             return
 
         if action == "stop":

--- a/src/gaia/messaging/telegram.py
+++ b/src/gaia/messaging/telegram.py
@@ -229,22 +229,23 @@ class TelegramAdapter:
                 MessageHandler,
                 filters,
             )
-        except ImportError as e:  # pragma: no cover - dependency missing
+        except ImportError as e:
             if background:
                 # The PID file is created before importing the optional
                 # dependency so supervisors can discover a real background
                 # process. Do not leave a false-positive PID behind when the
                 # process cannot start.
-                if pid_path:
-                    try:
-                        os.remove(pid_path)
-                    except OSError as cleanup_error:
-                        log.warning(
-                            "Failed to remove Telegram PID file after startup failure: %s",
-                            cleanup_error,
-                        )
+                try:
+                    os.remove(pid_path)
+                except OSError as cleanup_error:
+                    log.warning(
+                        "Failed to remove Telegram PID file after startup failure: %s",
+                        cleanup_error,
+                    )
             raise RuntimeError(
-                "python-telegram-bot is required for Telegram support"
+                "python-telegram-bot is required for Telegram support. "
+                'Install it with: pip install "gaia[telegram]" '
+                "(see https://amd-gaia.ai/docs/guides/telegram-adapter)"
             ) from e
 
         app = ApplicationBuilder().token(token).build()

--- a/src/gaia/messaging/telegram.py
+++ b/src/gaia/messaging/telegram.py
@@ -230,13 +230,19 @@ class TelegramAdapter:
                 filters,
             )
         except ImportError as e:  # pragma: no cover - dependency missing
-            # If running in background mode (tests or dry-run), allow import to be missing
             if background:
-                log.warning(
-                    "python-telegram-bot not installed; running in dry/background mode"
-                )
-                self.application = None
-                return
+                # The PID file is created before importing the optional
+                # dependency so supervisors can discover a real background
+                # process. Do not leave a false-positive PID behind when the
+                # process cannot start.
+                if pid_path:
+                    try:
+                        os.remove(pid_path)
+                    except OSError as cleanup_error:
+                        log.warning(
+                            "Failed to remove Telegram PID file after startup failure: %s",
+                            cleanup_error,
+                        )
             raise RuntimeError(
                 "python-telegram-bot is required for Telegram support"
             ) from e

--- a/tests/unit/test_telegram_adapter.py
+++ b/tests/unit/test_telegram_adapter.py
@@ -2,7 +2,7 @@ import logging
 import os
 import sys
 from types import SimpleNamespace
-from unittest.mock import AsyncMock, call
+from unittest.mock import AsyncMock, MagicMock, call
 
 import pytest
 
@@ -22,13 +22,14 @@ def test_run_telegram_scaffold_returns_adapter(mock_home, monkeypatch):
 
     # Run in background mode so the function does not block; in CI the
     # python-telegram-bot runtime may not be available, so guard accordingly.
+    monkeypatch.setitem(sys.modules, "telegram", MagicMock())
+    monkeypatch.setitem(sys.modules, "telegram.ext", MagicMock())
     adapter = run_telegram(
         token="fake-token-123", allowed_users={12345}, background=True
     )
     assert adapter.token == "fake-token-123"
     assert 12345 in adapter.allowed_users
-    # Application may be None if the telegram dependency is missing.
-    assert hasattr(adapter, "application")
+    assert adapter.application is not None
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_telegram_background.py
+++ b/tests/unit/test_telegram_background.py
@@ -1,8 +1,11 @@
+import builtins
 import os
 import sys
 import threading
 from types import SimpleNamespace
 from unittest.mock import MagicMock
+
+import pytest
 
 sys.path.insert(0, os.path.abspath("src"))
 
@@ -12,6 +15,8 @@ from gaia.messaging import telegram
 def test_background_writes_pid(mock_home, monkeypatch):
     # GAIA_TEST_MODE stops the adapter from starting a real polling loop.
     monkeypatch.setenv("GAIA_TEST_MODE", "1")
+    monkeypatch.setitem(sys.modules, "telegram", MagicMock())
+    monkeypatch.setitem(sys.modules, "telegram.ext", MagicMock())
 
     # mock_home redirects "~" at a tmp dir, so the adapter's
     # expanduser("~/.gaia") pid file never overwrites a live adapter's real one.
@@ -46,3 +51,26 @@ def test_background_test_mode_does_not_start_threads(mock_home, monkeypatch):
     )
 
     assert adapter.application is not None
+
+
+def test_background_missing_dependency_fails_and_removes_pid(mock_home, monkeypatch):
+    """A missing optional dependency must not look like a running adapter."""
+    real_import = builtins.__import__
+
+    def fail_telegram_ext(name, *args, **kwargs):
+        if name == "telegram.ext":
+            raise ImportError("No module named telegram")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", fail_telegram_ext)
+
+    with pytest.raises(
+        RuntimeError, match="python-telegram-bot is required for Telegram support"
+    ):
+        telegram.run_telegram(
+            token="fake-token-missing-dependency",
+            allowed_users=None,
+            background=True,
+        )
+
+    assert not (mock_home / ".gaia" / "telegram.pid").exists()

--- a/tests/unit/test_telegram_background.py
+++ b/tests/unit/test_telegram_background.py
@@ -56,6 +56,13 @@ def test_background_test_mode_does_not_start_threads(mock_home, monkeypatch):
 def test_background_missing_dependency_fails_and_removes_pid(mock_home, monkeypatch):
     """A missing optional dependency must not look like a running adapter."""
     real_import = builtins.__import__
+    pid_path = mock_home / ".gaia" / "telegram.pid"
+    removed_paths = []
+    real_remove = telegram.os.remove
+
+    def record_remove(path):
+        removed_paths.append(path)
+        return real_remove(path)
 
     def fail_telegram_ext(name, *args, **kwargs):
         if name == "telegram.ext":
@@ -63,9 +70,11 @@ def test_background_missing_dependency_fails_and_removes_pid(mock_home, monkeypa
         return real_import(name, *args, **kwargs)
 
     monkeypatch.setattr(builtins, "__import__", fail_telegram_ext)
+    monkeypatch.setattr(telegram.os, "remove", record_remove)
 
     with pytest.raises(
-        RuntimeError, match="python-telegram-bot is required for Telegram support"
+        RuntimeError,
+        match=r'python-telegram-bot is required for Telegram support.*gaia\[telegram\]',
     ):
         telegram.run_telegram(
             token="fake-token-missing-dependency",
@@ -73,4 +82,30 @@ def test_background_missing_dependency_fails_and_removes_pid(mock_home, monkeypa
             background=True,
         )
 
-    assert not (mock_home / ".gaia" / "telegram.pid").exists()
+    assert len(removed_paths) == 1
+    assert os.path.normpath(removed_paths[0]) == os.path.normpath(str(pid_path))
+    assert not pid_path.exists()
+
+
+def test_cli_reports_missing_dependency_without_traceback(monkeypatch, capsys):
+    """The CLI turns the adapter's actionable error into a clean exit."""
+    from gaia import cli
+
+    def fail_start(**_kwargs):
+        raise RuntimeError(
+            'python-telegram-bot is required for Telegram support. '
+            'Install it with: pip install "gaia[telegram]"'
+        )
+
+    monkeypatch.setattr(telegram, "run_telegram", fail_start)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["gaia", "telegram", "start", "--token", "fake-token", "--background"],
+    )
+
+    with pytest.raises(SystemExit) as exc_info:
+        cli.main()
+
+    assert exc_info.value.code == 1
+    assert "pip install" in capsys.readouterr().err

--- a/tests/unit/test_telegram_background.py
+++ b/tests/unit/test_telegram_background.py
@@ -74,7 +74,7 @@ def test_background_missing_dependency_fails_and_removes_pid(mock_home, monkeypa
 
     with pytest.raises(
         RuntimeError,
-        match=r'python-telegram-bot is required for Telegram support.*gaia\[telegram\]',
+        match=r"python-telegram-bot is required for Telegram support.*gaia\[telegram\]",
     ):
         telegram.run_telegram(
             token="fake-token-missing-dependency",
@@ -93,7 +93,7 @@ def test_cli_reports_missing_dependency_without_traceback(monkeypatch, capsys):
 
     def fail_start(**_kwargs):
         raise RuntimeError(
-            'python-telegram-bot is required for Telegram support. '
+            "python-telegram-bot is required for Telegram support. "
             'Install it with: pip install "gaia[telegram]"'
         )
 


### PR DESCRIPTION
## Summary
- make background Telegram startup fail loudly when `python-telegram-bot` is unavailable
- remove the PID file created before dependency loading so supervisors cannot treat a failed process as running
- update success-path tests to inject the optional dependency and add deterministic missing-dependency coverage

## Issue
Closes #3134

## Validation
- `uv run --frozen pytest tests/unit/test_telegram_background.py tests/unit/test_telegram_adapter.py -k "background or scaffold" -q` (4 passed)
- `uvx black --check --diff` (2 files unchanged)
- `uvx isort --check-only --diff` (2 files unchanged)
- source Pylint errors-only, compileall, and `git diff --check` passed

The broader Telegram async adapter tests remain subject to the repository existing Windows Proactor/socketpair network-guard setup failure.