### PR TITLE
fix(mcp): expose TUI state wait matcher

### DIFF
--- a/src/gaia/mcp/servers/tui_mcp.py
+++ b/src/gaia/mcp/servers/tui_mcp.py
@@ -811,8 +811,10 @@ def create_tui_mcp() -> "MCPServer":
         Args:
             contains: Text that must appear on screen.
             absent: Text that must have disappeared from the screen.
-            state: State fields that must match, e.g. {"view": "chat"} or
-                {"blocker": "lemonade"}.
+            state: State fields that must match — supported keys are view, agent,
+                overlay, blocker (strings) and streaming (bool), e.g.
+                {"view": "chat"} or {"streaming": False}. Other keys are
+                rejected by the control server.
             timeout_ms: How long to wait before giving up (default 30000).
         """
         return _wait_for(

--- a/src/gaia/mcp/servers/tui_mcp.py
+++ b/src/gaia/mcp/servers/tui_mcp.py
@@ -671,12 +671,21 @@ def _wait(
 
 
 def _wait_for(
-    contains: str = "", absent: str = "", timeout_ms: int = 30000
+    contains: str = "",
+    absent: str = "",
+    state: Optional[Dict[str, Any]] = None,
+    timeout_ms: int = 30000,
 ) -> Dict[str, Any]:
     info, error = _discovered()
     if error:
         return error
-    return _wait(info, contains=contains, absent=absent, timeout_ms=timeout_ms)
+    return _wait(
+        info,
+        contains=contains,
+        absent=absent,
+        state=state,
+        timeout_ms=timeout_ms,
+    )
 
 
 def _resize(cols: int, rows: int) -> Dict[str, Any]:
@@ -786,20 +795,32 @@ def create_tui_mcp() -> "MCPServer":
 
     @mcp.tool()
     def tui_wait_for(
-        contains: str = "", absent: str = "", timeout_ms: int = 30000
+        contains: str = "",
+        absent: str = "",
+        state: Optional[Dict[str, Any]] = None,
+        timeout_ms: int = 30000,
     ) -> Dict[str, Any]:
         """Block until the GAIA TUI's screen matches, instead of polling it.
 
-        Pass at least one matcher; both are ANDed and matched against the plain
-        (ANSI-stripped) screen. On timeout this returns an error containing the
-        text the screen actually had, so you can see why the match never landed.
+        Pass at least one matcher. Text matchers are ANDed against the plain
+        (ANSI-stripped) screen; state matchers are ANDed against the TUI's
+        structured state. On timeout this returns an error containing the text
+        and state the TUI actually had, so you can see why the match never
+        landed.
 
         Args:
             contains: Text that must appear on screen.
             absent: Text that must have disappeared from the screen.
+            state: State fields that must match, e.g. {"view": "chat"} or
+                {"blocker": "lemonade"}.
             timeout_ms: How long to wait before giving up (default 30000).
         """
-        return _wait_for(contains=contains, absent=absent, timeout_ms=timeout_ms)
+        return _wait_for(
+            contains=contains,
+            absent=absent,
+            state=state,
+            timeout_ms=timeout_ms,
+        )
 
     @mcp.tool()
     def tui_resize(cols: int, rows: int) -> Dict[str, Any]:

--- a/tests/integration/test_tui_control_e2e.py
+++ b/tests/integration/test_tui_control_e2e.py
@@ -171,6 +171,9 @@ def _ready(cols=120, rows=40):
     assert resized.get("status") != "error", resized
     waited = tui_mcp._wait_for(contains="GAIA", timeout_ms=20000)
     assert waited.get("matched") is True, waited
+    view = tui_mcp._status()["state"]["view"]
+    state_wait = tui_mcp._wait_for(state={"view": view}, timeout_ms=20000)
+    assert state_wait.get("matched") is True, state_wait
 
 
 def _settled_view():

--- a/tests/unit/test_tui_mcp.py
+++ b/tests/unit/test_tui_mcp.py
@@ -269,15 +269,9 @@ class FakeTui:
     STATE_MATCHER_KEYS = {
         "view": str,
         "agent": str,
-        "blocker": str,
-        "can_return_to_hub": bool,
-        "hub_tab": str,
-        "selected_agent_id": str,
         "overlay": str,
+        "blocker": str,
         "streaming": bool,
-        "filtering": bool,
-        "hub_tab_index": (int, float),
-        "visible_contains": str,
     }
 
     def _reject_invalid(self, method, path, body):
@@ -699,6 +693,48 @@ def test_wait_for_forwards_state_matcher(live_tui):
 
     right_state = tui_mcp._wait_for(state={"view": "preflight", "blocker": "lemonade"})
     assert right_state["matched"] is True
+
+
+def test_registered_wait_tool_forwards_state(monkeypatch):
+    """The public MCP wrapper must keep the state matcher it receives."""
+    import inspect
+    import sys
+    from types import SimpleNamespace
+
+    class FakeMCPServer:
+        def __init__(self, **_kwargs):
+            self.tools = {}
+
+        def tool(self):
+            def register(fn):
+                self.tools[fn.__name__] = fn
+                return fn
+
+            return register
+
+    monkeypatch.setitem(
+        sys.modules,
+        "mcp.server",
+        SimpleNamespace(MCPServer=FakeMCPServer),
+    )
+    server = tui_mcp.create_tui_mcp()
+    wrapper = server.tools["tui_wait_for"]
+    assert "state" in inspect.signature(wrapper).parameters
+
+    captured = {}
+
+    def fake_wait_for(**kwargs):
+        captured.update(kwargs)
+        return {"matched": True}
+
+    monkeypatch.setattr(tui_mcp, "_wait_for", fake_wait_for)
+    assert wrapper(state={"view": "chat"}, timeout_ms=123) == {"matched": True}
+    assert captured == {
+        "contains": "",
+        "absent": "",
+        "state": {"view": "chat"},
+        "timeout_ms": 123,
+    }
 
 
 def test_wait_for_timeout_returns_the_actual_screen(live_tui):

--- a/tests/unit/test_tui_mcp.py
+++ b/tests/unit/test_tui_mcp.py
@@ -269,6 +269,7 @@ class FakeTui:
     STATE_MATCHER_KEYS = {
         "view": str,
         "agent": str,
+        "blocker": str,
         "can_return_to_hub": bool,
         "hub_tab": str,
         "selected_agent_id": str,
@@ -686,6 +687,18 @@ def test_wait_for_match(live_tui):
     live_tui()
     out = tui_mcp._wait_for(contains="chat with")
     assert out["matched"] is True
+
+
+def test_wait_for_forwards_state_matcher(live_tui):
+    """State waits must reach the control server, not become an empty wait."""
+    live_tui(view="preflight", blocker="lemonade")
+
+    wrong_view = tui_mcp._wait_for(state={"view": "chat"}, timeout_ms=100)
+    assert wrong_view["status"] == "error"
+    assert wrong_view["timed_out"] is True
+
+    right_state = tui_mcp._wait_for(state={"view": "preflight", "blocker": "lemonade"})
+    assert right_state["matched"] is True
 
 
 def test_wait_for_timeout_returns_the_actual_screen(live_tui):


### PR DESCRIPTION
Closes #3137

Automation could not call the documented tui_wait_for(state={...}) form because the public Python wrapper dropped state before sending the request. Expose the existing matcher in the tool signature and forward it through the existing wait path, with regression coverage for both mismatch timeout and successful matching.

Test plan:
- [x] PYTHONPATH=src; uv run --frozen pytest tests/unit/test_tui_mcp.py -q
- [x] go test ./...
- [x] Black, isort, targeted Pylint/MyPy, py_compile, and git diff --check
- [x] uv run --frozen python util/lint.py --all (fails only on 9 existing Windows POSIX API Pylint false positives; no changed-file findings)