### PR TITLE
fix(tui): preserve seeded transport for wheel agents

### DIFF
--- a/tui/internal/catalog/catalog.go
+++ b/tui/internal/catalog/catalog.go
@@ -70,15 +70,18 @@ func (c *Catalog) DiscoverBinaries() {
 		}
 	}
 
-	// Sentinels are read AFTER the binary lookup: a binary install becomes a
-	// daemon transport only after its executable has had a chance to resolve.
-	// Applying them first would make the loop above skip that lookup.
+	// Resolve paths before applying installed metadata so a completed binary
+	// install can still provide its executable path for diagnostics.
 	c.LoadInstalledAgents()
 }
 
 // SentinelName is the file gaia.hub.installer writes into an agent's install
 // directory when the install completes. Its presence IS the installed state.
 const SentinelName = ".installed"
+
+// ArtifactKindBinary is the sentinel's artifact_kind for a frozen executable.
+// It mirrors installer.ARTIFACT_KIND_BINARY and identifies daemon sidecars.
+const ArtifactKindBinary = "binary"
 
 // InstallRoot is the directory the daemon installs hub agents into. It mirrors
 // gaia.hub.installer.default_install_root() exactly — a client that looked
@@ -512,7 +515,7 @@ func (c *Catalog) applyInstalledRecord(id, version, artifactKind string) {
 	// subprocess agent such as the flagship; its seed transport is authoritative
 	// because the install record proves installation, not how the TUI must talk
 	// to that id. Unknown ids retain the daemon default set above.
-	if artifactKind == "binary" {
+	if artifactKind == ArtifactKindBinary {
 		a.Transport = TransportDaemon
 	}
 	a.InstalledVersion = version

--- a/tui/internal/catalog/catalog.go
+++ b/tui/internal/catalog/catalog.go
@@ -70,9 +70,9 @@ func (c *Catalog) DiscoverBinaries() {
 		}
 	}
 
-	// Sentinels are read AFTER the binary lookup: applying them first flips
-	// every installed id to daemon transport, and the loop above skips daemon
-	// agents — which made the install-root lookup unreachable.
+	// Sentinels are read AFTER the binary lookup: a binary install becomes a
+	// daemon transport only after its executable has had a chance to resolve.
+	// Applying them first would make the loop above skip that lookup.
 	c.LoadInstalledAgents()
 }
 
@@ -396,10 +396,11 @@ func (c *Catalog) SetStatus(id string, status AgentStatus) {
 // InstalledRecord is one ~/.gaia/agents/<id>/.installed sentinel, the local
 // source of truth for "this agent is installed" (gaia.hub.installer).
 type InstalledRecord struct {
-	ID         string `json:"id"`
-	Version    string `json:"version"`
-	Language   string `json:"language"`
-	Executable string `json:"executable"`
+	ID           string `json:"id"`
+	Version      string `json:"version"`
+	Language     string `json:"language"`
+	ArtifactKind string `json:"artifact_kind"`
+	Executable   string `json:"executable"`
 }
 
 // Warnings returns problems found while reading local state — an unreadable
@@ -477,7 +478,7 @@ func (c *Catalog) LoadInstalledAgents() {
 	records, warnings := LocalInstalls()
 	c.warnings = append(c.warnings, warnings...)
 	for _, record := range records {
-		c.applyInstalledRecord(record.ID, record.Version)
+		c.applyInstalledRecord(record.ID, record.Version, record.ArtifactKind)
 	}
 }
 
@@ -486,7 +487,7 @@ func (c *Catalog) LoadInstalledAgents() {
 // index carries. upsertHubEntry would overwrite a cached name, publisher, tier,
 // and size with blanks, degrading "Email · AMD · 31.1 MB" to a bare id in
 // exactly the offline case this function exists to serve.
-func (c *Catalog) applyInstalledRecord(id, version string) {
+func (c *Catalog) applyInstalledRecord(id, version, artifactKind string) {
 	idx := -1
 	for i := range c.agents {
 		if c.agents[i].ID == id {
@@ -506,12 +507,14 @@ func (c *Catalog) applyInstalledRecord(id, version string) {
 	}
 	a := &c.agents[idx]
 	a.FromHub = true
-	// A sentinel under the install root means the daemon installed it as an
-	// HTTP sidecar it supervises, so there is no binary for the TUI to spawn --
-	// same invariant upsertHubEntry applies. Seeded entries reach here with
-	// whatever transport the seed guessed, and a seeded subprocess agent that
-	// kept it would be spawned over stdio and fed a frozen REST binary.
-	a.Transport = TransportDaemon
+	// Binary artifacts are daemon-supervised sidecars, so keep the #3062
+	// correction for them. A wheel/cpp sentinel can also belong to a seeded
+	// subprocess agent such as the flagship; its seed transport is authoritative
+	// because the install record proves installation, not how the TUI must talk
+	// to that id. Unknown ids retain the daemon default set above.
+	if artifactKind == "binary" {
+		a.Transport = TransportDaemon
+	}
 	a.InstalledVersion = version
 	if version != "" {
 		a.Version = version

--- a/tui/internal/catalog/hub_test.go
+++ b/tui/internal/catalog/hub_test.go
@@ -244,6 +244,40 @@ func TestInstalledSeededSubprocessAgentBecomesDaemonTransport(t *testing.T) {
 	}
 }
 
+// A wheel install can share the flagship id without being a daemon sidecar.
+// The sentinel proves that the package is installed, but it must not override
+// the seeded subprocess transport the flagship uses.
+func TestInstalledSeededSubprocessAgentKeepsItsTransportForWheel(t *testing.T) {
+	sentinel := `{"id":"gaia","version":"0.1.1","language":"python","artifact_kind":"wheel"}`
+	home := t.TempDir()
+	agentDir := filepath.Join(home, ".gaia", "agents", "gaia")
+	if err := os.MkdirAll(agentDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(agentDir, SentinelName), []byte(sentinel), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("HOME", home)
+	if runtime.GOOS == "windows" {
+		t.Setenv("USERPROFILE", home)
+	}
+
+	c := NewCatalog()
+	if seeded := c.Get("gaia"); seeded == nil || seeded.Transport != TransportSubprocess {
+		t.Skip("gaia is no longer seeded as a subprocess agent; this regression cannot recur")
+	}
+
+	c.LoadInstalledAgents()
+
+	gaia := c.Get("gaia")
+	if gaia == nil {
+		t.Fatal("gaia disappeared from the catalog after loading its sentinel")
+	}
+	if gaia.Transport != TransportSubprocess {
+		t.Errorf("transport = %v, want TransportSubprocess: a wheel install must not turn the flagship into a daemon sidecar", gaia.Transport)
+	}
+}
+
 func TestLoadInstalledAgentsReadsSentinels(t *testing.T) {
 	// InstallRoot mirrors the Python installer exactly (<home>/.gaia/agents),
 	// so the fixture is a fake home rather than an env override.

--- a/tui/internal/catalog/hub_test.go
+++ b/tui/internal/catalog/hub_test.go
@@ -278,6 +278,36 @@ func TestInstalledSeededSubprocessAgentKeepsItsTransportForWheel(t *testing.T) {
 	}
 }
 
+func TestInstalledSeededSubprocessAgentKeepsItsTransportWithoutArtifactKind(t *testing.T) {
+	sentinel := `{"id":"gaia","version":"0.1.1","language":"python"}`
+	home := t.TempDir()
+	agentDir := filepath.Join(home, ".gaia", "agents", "gaia")
+	if err := os.MkdirAll(agentDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(agentDir, SentinelName), []byte(sentinel), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("HOME", home)
+	if runtime.GOOS == "windows" {
+		t.Setenv("USERPROFILE", home)
+	}
+
+	c := NewCatalog()
+	if seeded := c.Get("gaia"); seeded == nil || seeded.Transport != TransportSubprocess {
+		t.Skip("gaia is no longer seeded as a subprocess agent; this regression cannot recur")
+	}
+
+	c.LoadInstalledAgents()
+	gaia := c.Get("gaia")
+	if gaia == nil {
+		t.Fatal("gaia disappeared from the catalog after loading its sentinel")
+	}
+	if gaia.Transport != TransportSubprocess {
+		t.Errorf("transport = %v, want TransportSubprocess: missing artifact_kind defaults to a wheel install", gaia.Transport)
+	}
+}
+
 func TestLoadInstalledAgentsReadsSentinels(t *testing.T) {
 	// InstallRoot mirrors the Python installer exactly (<home>/.gaia/agents),
 	// so the fixture is a fake home rather than an env override.


### PR DESCRIPTION
Closes #3135

Installing a non-binary hub package under the flagship id incorrectly changed the TUI from its seeded subprocess transport to the daemon relay. Preserve the existing transport for wheel and cpp installs while keeping binary artifacts on the daemon path required by #3062.

Test plan:
- [x] go test ./...
- [x] go vet ./...
- [x] gofmt and git diff --check
- [x] go test ./internal/catalog (including binary and wheel transport regressions)