### PR TITLE
fix(tui): gate Claude launches on credentials

### DIFF
--- a/tui/internal/ui/preflight/local.go
+++ b/tui/internal/ui/preflight/local.go
@@ -1,12 +1,14 @@
 package preflight
 
 import (
+	"bufio"
 	"context"
 	"errors"
 	"fmt"
 	"net/http"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"time"
 
@@ -123,9 +125,76 @@ func (l localRunner) Check(ctx context.Context, cfg Config) Report {
 
 // --- 1.5. the Claude credential --------------------------------------------
 
+// claudeCredentialConfigured mirrors the agent's credential sources that are
+// available before the child starts: an inherited process variable or a .env
+// file discoverable from the TUI's working directory. The subprocess inherits
+// that same working directory, so accepting a .env here cannot turn a launch
+// into a false pass that the child would reject.
+func claudeCredentialConfigured() bool {
+	if strings.TrimSpace(os.Getenv(claudeAPIKeyEnv)) != "" {
+		return true
+	}
+
+	dir, err := os.Getwd()
+	if err != nil {
+		return false
+	}
+	for {
+		if dotenvHasNonEmptyValue(filepath.Join(dir, ".env"), claudeAPIKeyEnv) {
+			return true
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return false
+		}
+		dir = parent
+	}
+}
+
+// dotenvHasNonEmptyValue reads only the named key. It is intentionally a
+// small presence check rather than a general dotenv loader: preflight must not
+// mutate the TUI environment or expose a credential in a report.
+func dotenvHasNonEmptyValue(path, key string) bool {
+	file, err := os.Open(path)
+	if err != nil {
+		return false
+	}
+	defer file.Close()
+
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		line = strings.TrimSpace(strings.TrimPrefix(line, "export "))
+		name, value, ok := strings.Cut(line, "=")
+		if !ok || strings.TrimSpace(name) != key {
+			continue
+		}
+		if strings.TrimSpace(dotenvValue(value)) != "" {
+			return true
+		}
+	}
+	return false
+}
+
+func dotenvValue(value string) string {
+	value = strings.TrimSpace(value)
+	if len(value) >= 2 && value[0] == '"' && value[len(value)-1] == '"' {
+		if unquoted, err := strconv.Unquote(value); err == nil {
+			return unquoted
+		}
+	}
+	if len(value) >= 2 && value[0] == '\'' && value[len(value)-1] == '\'' {
+		return value[1 : len(value)-1]
+	}
+	return value
+}
+
 func (l localRunner) checkClaudeCredential(_ context.Context, _ Config) Row {
 	row := Row{Key: KeyClaudeCredential}
-	if strings.TrimSpace(os.Getenv(claudeAPIKeyEnv)) != "" {
+	if claudeCredentialConfigured() {
 		row.State = StateOK
 		row.Line = "set"
 		return row
@@ -136,7 +205,7 @@ func (l localRunner) checkClaudeCredential(_ context.Context, _ Config) Row {
 	row.Line = "not set"
 	row.Detail = "Claude needs an Anthropic credential before the first message."
 	row.Remedy = Remedy{
-		Action: "Set " + claudeAPIKeyEnv + " in your shell, then press r to re-check.",
+		Action: "Set " + claudeAPIKeyEnv + " (or put it in .env), then relaunch — this session cannot pick up a variable exported after it started.",
 		Where:  "https://docs.anthropic.com/en/api/getting-started",
 	}
 	// Keep the raw answer diagnostic but never include the value of the secret.

--- a/tui/internal/ui/preflight/local.go
+++ b/tui/internal/ui/preflight/local.go
@@ -23,9 +23,11 @@ import (
 // answer "not installed" for a launch that works. That is exactly why this
 // launch used to have NO gate at all.
 //
-// Three rows, each probed directly on this machine:
+// Three rows, each probed directly on this machine for a local session, plus
+// the Claude credential row when --use-claude is active:
 //
 //	GAIA agent  is the program on disk?      catalog.Find
+//	Claude      is the Anthropic credential set?  process environment
 //	Local AI    is the model server up?      one GET on loopback
 //	AI model    are the models downloaded?   gaia init --check
 //
@@ -49,6 +51,11 @@ var lemonadePorts = []string{"13305", "8000"}
 // machine. When it is set it is the ONLY thing probed: finding a local server
 // on 13305 would prove nothing about the one the agent will actually use.
 const lemonadeBaseURLEnv = "LEMONADE_BASE_URL"
+
+// claudeAPIKeyEnv is the credential the agent's Claude provider reads before
+// constructing its first client. The preflight only checks presence; it never
+// prints the value or makes a remote request that could validate a secret.
+const claudeAPIKeyEnv = "ANTHROPIC_API_KEY"
 
 var (
 	errFixFailed = errors.New("the fix did not succeed")
@@ -76,9 +83,14 @@ func (l localRunner) Label() string { return "local" }
 func (l localRunner) Rows(cfg Config) []Row {
 	rows := []Row{
 		{Key: KeyBinary, Label: cfg.AgentName + " agent"},
-		{Key: KeyLemonade, Label: lemonadeRowLabel},
-		{Key: KeyModel, Label: "AI model"},
 	}
+	if l.opts.ClaudeMode {
+		rows = append(rows, Row{Key: KeyClaudeCredential, Label: "Claude credential"})
+	}
+	rows = append(rows,
+		Row{Key: KeyLemonade, Label: lemonadeRowLabel},
+		Row{Key: KeyModel, Label: "AI model"},
+	)
 	for i := range rows {
 		rows[i].State = StatePending
 		rows[i].Line = "—"
@@ -86,18 +98,18 @@ func (l localRunner) Rows(cfg Config) []Row {
 	return rows
 }
 
-// Check walks the three rows in dependency order and STOPS at the first
+// Check walks the rows in dependency order and STOPS at the first
 // failure, the same way the daemon walk does: "the models are not downloaded"
 // is meaningless when the program that would use them is not on the machine.
 func (l localRunner) Check(ctx context.Context, cfg Config) Report {
 	cfg = cfg.withDefaults()
 	rep := Report{AgentID: cfg.AgentID, AgentName: cfg.AgentName, Rows: l.Rows(cfg)}
 
-	steps := []func(context.Context, Config) Row{
-		l.checkBinary,
-		l.checkLemonade,
-		l.checkModels,
+	steps := []func(context.Context, Config) Row{l.checkBinary}
+	if l.opts.ClaudeMode {
+		steps = append(steps, l.checkClaudeCredential)
 	}
+	steps = append(steps, l.checkLemonade, l.checkModels)
 	for _, step := range steps {
 		row := step(ctx, cfg)
 		setRow(&rep, row)
@@ -107,6 +119,29 @@ func (l localRunner) Check(ctx context.Context, cfg Config) Report {
 		}
 	}
 	return rep
+}
+
+// --- 1.5. the Claude credential --------------------------------------------
+
+func (l localRunner) checkClaudeCredential(_ context.Context, _ Config) Row {
+	row := Row{Key: KeyClaudeCredential}
+	if strings.TrimSpace(os.Getenv(claudeAPIKeyEnv)) != "" {
+		row.State = StateOK
+		row.Line = "set"
+		return row
+	}
+
+	row.State = StateFailed
+	row.Disposition = status.DispositionHalt
+	row.Line = "not set"
+	row.Detail = "Claude needs an Anthropic credential before the first message."
+	row.Remedy = Remedy{
+		Action: "Set " + claudeAPIKeyEnv + " in your shell, then press r to re-check.",
+		Where:  "https://docs.anthropic.com/en/api/getting-started",
+	}
+	// Keep the raw answer diagnostic but never include the value of the secret.
+	row.Raw = claudeAPIKeyEnv + " is not set"
+	return row
 }
 
 // --- 1. the agent's own program --------------------------------------------

--- a/tui/internal/ui/preflight/local_test.go
+++ b/tui/internal/ui/preflight/local_test.go
@@ -217,6 +217,97 @@ func TestClaudeModeDoesNotLetADownLemonadeRefuseTheLaunch(t *testing.T) {
 	}
 }
 
+func TestClaudeCredentialIsRequiredBeforeTheFirstMessage(t *testing.T) {
+	t.Setenv(claudeAPIKeyEnv, "")
+
+	row := localRunner{opts: LocalOptions{ClaudeMode: true}}.
+		checkClaudeCredential(context.Background(), localCfg())
+
+	if row.State != StateFailed {
+		t.Fatalf("missing Claude credential is %s, want failed", row.State.Word())
+	}
+	if row.Disposition != status.DispositionHalt {
+		t.Fatalf("disposition = %v, want halt", row.Disposition)
+	}
+	if row.Line != "not set" {
+		t.Errorf("line = %q, want not set", row.Line)
+	}
+	for _, text := range []string{claudeAPIKeyEnv, "first message", "press r"} {
+		if !strings.Contains(row.Detail+row.Remedy.Action+row.Raw, text) {
+			t.Errorf("missing %q from credential guidance: %+v", text, row)
+		}
+	}
+	if strings.Contains(row.Detail+row.Remedy.Action+row.Raw, "sk-ant-") {
+		t.Error("credential guidance must not suggest or expose a token value")
+	}
+}
+
+func TestClaudeCredentialPassesWithoutEchoingTheSecret(t *testing.T) {
+	const secret = "sk-ant-test-only"
+	t.Setenv(claudeAPIKeyEnv, secret)
+
+	row := localRunner{opts: LocalOptions{ClaudeMode: true}}.
+		checkClaudeCredential(context.Background(), localCfg())
+
+	if row.State != StateOK {
+		t.Fatalf("set Claude credential is %s, want ok", row.State.Word())
+	}
+	if strings.Contains(row.Line+row.Detail+row.Remedy.Action+row.Raw, secret) {
+		t.Error("credential row echoed the secret")
+	}
+}
+
+func TestClaudeCredentialRowOnlyAppearsInClaudeMode(t *testing.T) {
+	localRows := localRunner{}.Rows(localCfg())
+	for _, row := range localRows {
+		if row.Key == KeyClaudeCredential {
+			t.Fatal("local mode unexpectedly added a Claude credential row")
+		}
+	}
+
+	claudeRows := localRunner{opts: LocalOptions{ClaudeMode: true}}.Rows(localCfg())
+	if len(claudeRows) != len(localRows)+1 {
+		t.Fatalf("Claude mode has %d rows, local mode has %d; want one extra row", len(claudeRows), len(localRows))
+	}
+	if claudeRows[1].Key != KeyClaudeCredential {
+		t.Fatalf("Claude row order = %q, want credential immediately after the binary", claudeRows[1].Key)
+	}
+}
+
+func TestClaudeCheckStopsBeforeLocalProbesWhenCredentialIsMissing(t *testing.T) {
+	isolateHome(t)
+	t.Setenv(claudeAPIKeyEnv, "")
+	t.Setenv(lemonadeBaseURLEnv, "http://127.0.0.1:9/api/v1")
+	stubGaiaInit(t, func() (string, error) {
+		t.Error("the model row was probed even though the Claude credential is missing")
+		return "", errors.New("must not be called")
+	})
+
+	dir := t.TempDir()
+	name := "fixture-agent"
+	if runtime.GOOS == "windows" {
+		name += ".exe"
+	}
+	path := filepath.Join(dir, name)
+	if err := os.WriteFile(path, []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	rep := localRunner{opts: LocalOptions{Binary: path, ClaudeMode: true}}.
+		Check(context.Background(), localCfg())
+
+	blocker, ok := rep.Blocker()
+	if !ok || blocker.Key != KeyClaudeCredential {
+		t.Fatalf("blocker = %q, found=%v; want Claude credential", blocker.Key, ok)
+	}
+	if row, _ := rep.Find(KeyLemonade); row.State != StatePending {
+		t.Errorf("Lemonade row is %s, want pending behind credential failure", row.State.Word())
+	}
+	if row, _ := rep.Find(KeyModel); row.State != StatePending {
+		t.Errorf("model row is %s, want pending behind credential failure", row.State.Word())
+	}
+}
+
 // Exit 2 is what an installed gaia older than `--check` returns for
 // "unrecognized arguments". Reading it as "not ready" ran a full multi-minute
 // `gaia init` on EVERY launch.
@@ -314,12 +405,14 @@ func TestRowsMatchWhatCheckProduces(t *testing.T) {
 // silently proceeds instead of loudly halting — see Row.needsHalt.
 func TestEveryNonOKLocalRowDeclaresADisposition(t *testing.T) {
 	isolateHome(t)
+	t.Setenv(claudeAPIKeyEnv, "")
 	t.Setenv(lemonadeBaseURLEnv, "http://127.0.0.1:9/api/v1")
 	stubGaiaInit(t, func() (string, error) { return exitStub(t, 1), nil })
 
 	r := localRunner{opts: LocalOptions{Binary: "gaia-agent-absent-fixture"}}
 	rows := []Row{
 		r.checkBinary(context.Background(), localCfg()),
+		r.checkClaudeCredential(context.Background(), localCfg()),
 		r.checkLemonade(context.Background(), localCfg()),
 		r.checkModels(context.Background(), localCfg()),
 	}

--- a/tui/internal/ui/preflight/local_test.go
+++ b/tui/internal/ui/preflight/local_test.go
@@ -232,13 +232,32 @@ func TestClaudeCredentialIsRequiredBeforeTheFirstMessage(t *testing.T) {
 	if row.Line != "not set" {
 		t.Errorf("line = %q, want not set", row.Line)
 	}
-	for _, text := range []string{claudeAPIKeyEnv, "first message", "press r"} {
+	for _, text := range []string{claudeAPIKeyEnv, "first message", ".env", "relaunch"} {
 		if !strings.Contains(row.Detail+row.Remedy.Action+row.Raw, text) {
 			t.Errorf("missing %q from credential guidance: %+v", text, row)
 		}
 	}
 	if strings.Contains(row.Detail+row.Remedy.Action+row.Raw, "sk-ant-") {
 		t.Error("credential guidance must not suggest or expose a token value")
+	}
+}
+
+func TestClaudeCredentialAcceptsTheWorkingDirectoryDotenv(t *testing.T) {
+	t.Setenv(claudeAPIKeyEnv, "")
+	dir := t.TempDir()
+	t.Chdir(dir)
+	if err := os.WriteFile(filepath.Join(dir, ".env"), []byte("# local fixture\nexport ANTHROPIC_API_KEY=sk-ant-from-dotenv\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	row := localRunner{opts: LocalOptions{ClaudeMode: true}}.
+		checkClaudeCredential(context.Background(), localCfg())
+
+	if row.State != StateOK {
+		t.Fatalf("working-directory .env credential is %s, want ok: %+v", row.State.Word(), row)
+	}
+	if strings.Contains(row.Line+row.Detail+row.Remedy.Action+row.Raw, "sk-ant-from-dotenv") {
+		t.Error("dotenv credential was echoed")
 	}
 }
 

--- a/tui/internal/ui/preflight/local_test.go
+++ b/tui/internal/ui/preflight/local_test.go
@@ -219,6 +219,7 @@ func TestClaudeModeDoesNotLetADownLemonadeRefuseTheLaunch(t *testing.T) {
 
 func TestClaudeCredentialIsRequiredBeforeTheFirstMessage(t *testing.T) {
 	t.Setenv(claudeAPIKeyEnv, "")
+	t.Chdir(t.TempDir())
 
 	row := localRunner{opts: LocalOptions{ClaudeMode: true}}.
 		checkClaudeCredential(context.Background(), localCfg())
@@ -296,6 +297,7 @@ func TestClaudeCredentialRowOnlyAppearsInClaudeMode(t *testing.T) {
 func TestClaudeCheckStopsBeforeLocalProbesWhenCredentialIsMissing(t *testing.T) {
 	isolateHome(t)
 	t.Setenv(claudeAPIKeyEnv, "")
+	t.Chdir(t.TempDir())
 	t.Setenv(lemonadeBaseURLEnv, "http://127.0.0.1:9/api/v1")
 	stubGaiaInit(t, func() (string, error) {
 		t.Error("the model row was probed even though the Claude credential is missing")

--- a/tui/internal/ui/preflight/report.go
+++ b/tui/internal/ui/preflight/report.go
@@ -238,16 +238,18 @@ func (r Row) Outcome() status.Outcome {
 }
 
 // Stable row keys. KeyDaemon/KeySidecar are the daemon runner's; KeyBinary is
-// the local runner's. KeyLemonade and KeyModel are asked by both, over
+// the local runner's. KeyClaudeCredential is asked by the local runner only in
+// Claude mode. KeyLemonade and KeyModel are asked by both, over
 // different probes. KeyMailbox is email-specific and arrives through
 // Config.Extras.
 const (
-	KeyDaemon   = "daemon"
-	KeySidecar  = "sidecar"
-	KeyBinary   = "binary"
-	KeyLemonade = "lemonade"
-	KeyModel    = "model"
-	KeyMailbox  = "mailbox"
+	KeyDaemon           = "daemon"
+	KeySidecar          = "sidecar"
+	KeyBinary           = "binary"
+	KeyClaudeCredential = "claude-credential"
+	KeyLemonade         = "lemonade"
+	KeyModel            = "model"
+	KeyMailbox          = "mailbox"
 )
 
 // Report is the whole readiness answer: one row per precondition, in dependency

--- a/tui/test/launch_verification_test.go
+++ b/tui/test/launch_verification_test.go
@@ -207,6 +207,9 @@ func writeStub(t *testing.T, path, body string) {
 // not off it having passed.
 func TestAnIndeterminateSetupRowIsNotReAskedInTheChat(t *testing.T) {
 	isolateGaiaHome(t)
+	// This test exercises the later setup row; satisfy the earlier Claude
+	// credential precondition with a non-secret fixture value.
+	t.Setenv("ANTHROPIC_API_KEY", "test-credential")
 	// Exit 2 is what an installed gaia older than --check returns, and a
 	// missing gaia produces the same "unanswered" shape.
 	stubSetupCheck(t, 2)


### PR DESCRIPTION
## Summary

Add a Claude credential row to the local TUI readiness gate so --use-claude cannot reach the first chat message without ANTHROPIC_API_KEY.

## Why

The Claude provider fails when it constructs its first client if the credential is missing, but the local readiness gate previously checked only the agent binary, Lemonade, and model setup. This surfaced a predictable startup failure only after the user entered a message.

## Linked issue

Closes #3138

## Changes

- Add a Claude-only Claude credential readiness row keyed by claude-credential.
- Halt before local network/model probes when ANTHROPIC_API_KEY is missing or blank, with actionable setup guidance that never exposes the token.
- Preserve the existing three-row local-session layout and behavior when Claude mode is off.
- Add tests for missing/present credentials, secret non-echoing, row ordering, early blocking, and the affected Claude setup integration test.

## Test plan

- [x] go test ./internal/ui/preflight -count=1 -timeout=5m
- [x] go test ./test -run 'TestAnIndeterminateSetupRowIsNotReAskedInTheChat|TestASkippedSetupRowIsStillAskedInTheChat' -count=1 -timeout=5m
- [x] go test ./... -count=1 -timeout=15m
- [x] go vet ./...
- [x] golangci-lint run ./...
- [x] go build ./...
- [x] gofmt and git diff --check
- [ ] go test -race: unavailable on this Windows host because gcc is not installed.

## Evidence

- [x] **Agent exposed in the Agent UI** — N/A: this change targets the terminal TUI readiness screen, not the browser Agent UI; the TUI integration and preflight tests cover the user-facing path.
- [x] **MCP tools / servers** — N/A: no MCP surface changed.
- [x] **CLI** — N/A: no Python gaia subcommand behavior changed; the TUI's Claude-mode preflight is covered by tui/test.
- [x] **HTTP API / REST** — N/A: no HTTP/API surface changed; missing credentials are rejected before any remote request.

## Checklist

- [x] I have linked a GitHub issue above (Closes #N / Fixes #N / Refs #N).
- [x] I have described why this change is being made, not just what changed.
- [x] I have run linting and tests locally (golangci-lint, go test, go vet).
- [x] I have attached real-world evidence matched to the surface I changed (terminal TUI surface is covered by deterministic integration tests; browser/MCP/HTTP surfaces are N/A).
- [x] I have updated documentation if user-visible behavior changed — existing tui/README.md and CLI help already document the ANTHROPIC_API_KEY requirement; this change makes the documented requirement fail early.