### PR TITLE
perf(email): batch Outlook message fetches

### DIFF
--- a/hub/agents/email/python/CHANGELOG.md
+++ b/hub/agents/email/python/CHANGELOG.md
@@ -9,6 +9,9 @@ contract version is tracked separately as
 
 ### Fixed
 
+- **Outlook triage now fetches message details through Microsoft Graph batches
+  (#3104).** Outlook scans split requests at Graph's 20-subrequest limit while
+  preserving per-message response validation.
 - **An unexpected failure on `/v1/email/*` now returns parseable JSON instead of
   a bare text 500 (#3000).** Only four connector exception types were mapped to
   a status code, so anything else — a `KeyError` on an unexpected Graph payload,

--- a/hub/agents/email/python/gaia_agent_email/gmail_backend.py
+++ b/hub/agents/email/python/gaia_agent_email/gmail_backend.py
@@ -218,9 +218,9 @@ class GmailBackend(Protocol):
         NOTE: ``get_messages_batch`` (#2643 lever 2 — fetch many messages in
         one round-trip) is intentionally NOT part of this Protocol. It is a
         duck-typed, opt-in capability some backends provide (``LiveGmailBackend``,
-        ``FakeGmailBackend``) — declaring it here would force EVERY backend
-        (including ``LiveOutlookBackend``, which doesn't implement it) to grow
-        it just to keep satisfying ``isinstance(x, GmailBackend)``, which
+        ``LiveOutlookBackend``, ``FakeGmailBackend``) — declaring it here would
+        force EVERY backend to grow it just to keep satisfying
+        ``isinstance(x, GmailBackend)``, which
         several tests rely on. Callers detect it via
         ``getattr(gmail, "get_messages_batch", None)`` and fall back to a
         per-id ``get_message`` loop when it's absent — see

--- a/hub/agents/email/python/gaia_agent_email/outlook_backend.py
+++ b/hub/agents/email/python/gaia_agent_email/outlook_backend.py
@@ -52,6 +52,7 @@ Token lifecycle, error hygiene, and the no-silent-fallback contract mirror
 from __future__ import annotations
 
 import base64
+import json
 from datetime import datetime, timezone
 from typing import (
     Any,
@@ -61,6 +62,7 @@ from typing import (
     List,
     Optional,
 )
+from urllib.parse import quote
 
 import httpx
 from gaia_agent_email.outlook_query import translate_query
@@ -88,7 +90,8 @@ _LABEL_STARRED = "STARRED"
 _LABEL_SENT = "SENT"
 _LABEL_IMPORTANT = "IMPORTANT"
 
-# ``$select`` for ``get_message`` — pull exactly the fields the Gmail-shape
+# ``$select`` for ``get_message`` and Graph ``$batch`` fetches — pull exactly
+# the fields the Gmail-shape
 # translation needs (Graph returns a large default projection otherwise).
 _MESSAGE_SELECT = (
     "id,conversationId,subject,from,toRecipients,ccRecipients,"
@@ -99,10 +102,10 @@ _MESSAGE_SELECT = (
 # Metadata-only ``$select`` (#2643 lever 1) — identical to ``_MESSAGE_SELECT``
 # minus ``body``, the one heavy field a heuristic-only scan never reads.
 # ``bodyPreview`` (Gmail's ``snippet`` equivalent) stays, since the category
-# heuristic and meeting-request detector both read that. Batched fetches
-# (Gmail lever 2) are NOT implemented for Outlook in this change — Graph's
-# ``$batch`` is a materially different JSON wire protocol, left as a
-# follow-up; this backend still benefits from skipping the body field alone.
+# heuristic and meeting-request detector both read that.
+#
+# Graph accepts at most 20 requests in one JSON ``$batch`` envelope.
+_BATCH_MAX_SUBREQUESTS = 20
 _MESSAGE_SELECT_METADATA = (
     "id,conversationId,subject,from,toRecipients,ccRecipients,"
     "receivedDateTime,sentDateTime,isRead,isDraft,flag,categories,"
@@ -496,6 +499,110 @@ class LiveOutlookBackend:
         select = _MESSAGE_SELECT_METADATA if format == "metadata" else _MESSAGE_SELECT
         data = self._get(f"/me/messages/{message_id}", params={"$select": select})
         return graph_message_to_gmail(data, include_body=(format != "metadata"))
+
+    def get_messages_batch(
+        self, message_ids: Iterable[str], *, format: str = "full"
+    ) -> Dict[str, Dict[str, Any]]:
+        """Fetch multiple messages through Microsoft Graph's JSON batch API.
+
+        The email read tools discover this capability by duck typing. Keeping
+        the one-message path on ``get_message`` avoids paying batch framing
+        overhead for a single fetch, while larger requests are split at
+        Graph's 20-subrequest limit. Responses are correlated by their
+        response ``id`` rather than wire order, and every requested id must
+        resolve before returning so a partial batch can never look complete.
+        """
+        ids = list(message_ids)
+        if not ids:
+            return {}
+        if len(ids) == 1:
+            return {ids[0]: self.get_message(ids[0], format=format)}
+
+        out: Dict[str, Dict[str, Any]] = {}
+        for start in range(0, len(ids), _BATCH_MAX_SUBREQUESTS):
+            chunk = ids[start : start + _BATCH_MAX_SUBREQUESTS]
+            out.update(self._get_messages_batch(chunk, format=format))
+        return out
+
+    def _get_messages_batch(
+        self, ids: List[str], *, format: str
+    ) -> Dict[str, Dict[str, Any]]:
+        select = _MESSAGE_SELECT_METADATA if format == "metadata" else _MESSAGE_SELECT
+        requests = [
+            {
+                "id": str(index),
+                "method": "GET",
+                "url": f"/me/messages/{quote(message_id, safe='')}?"
+                f"$select={select}",
+            }
+            for index, message_id in enumerate(ids)
+        ]
+        response = self._client.post(
+            f"{GRAPH_API_BASE}/$batch",
+            headers={**self._headers(), "Content-Type": "application/json"},
+            json={"requests": requests},
+        )
+        if response.status_code != 200:
+            self._raise_http(response, "POST /$batch")
+        try:
+            data = response.json()
+        except ValueError as exc:
+            raise ConnectorsError(
+                f"Microsoft Graph batch response for {len(ids)} message(s) "
+                "was not valid JSON"
+            ) from exc
+
+        responses = data.get("responses") if isinstance(data, dict) else None
+        if not isinstance(responses, list):
+            raise ConnectorsError(
+                f"Microsoft Graph batch response for {len(ids)} message(s) "
+                "did not contain a responses list"
+            )
+
+        by_id: Dict[str, Dict[str, Any]] = {}
+        expected = {str(index): message_id for index, message_id in enumerate(ids)}
+        for item in responses:
+            if not isinstance(item, dict):
+                raise ConnectorsError(
+                    "Microsoft Graph batch response contained a non-object item"
+                )
+            request_id = str(item.get("id", ""))
+            message_id = expected.get(request_id)
+            if message_id is None:
+                raise ConnectorsError(
+                    f"Microsoft Graph batch response contained unknown request id "
+                    f"{request_id!r}"
+                )
+            if request_id in by_id:
+                raise ConnectorsError(
+                    f"Microsoft Graph batch response repeated request id "
+                    f"{request_id!r}"
+                )
+            status = item.get("status")
+            if status != 200:
+                detail = json.dumps(item.get("body"), ensure_ascii=False)[:300]
+                raise ConnectorsError(
+                    f"Microsoft Graph batch GET for message {message_id!r} "
+                    f"returned {status}: {detail}"
+                )
+            body = item.get("body")
+            if not isinstance(body, dict):
+                raise ConnectorsError(
+                    f"Microsoft Graph batch response for message {message_id!r} "
+                    "did not contain a message object"
+                )
+            by_id[request_id] = graph_message_to_gmail(
+                body, include_body=(format != "metadata")
+            )
+
+        missing = [request_id for request_id in expected if request_id not in by_id]
+        if missing:
+            missing_messages = [expected[request_id] for request_id in missing[:5]]
+            raise ConnectorsError(
+                f"Microsoft Graph batch response returned {len(by_id)} of "
+                f"{len(ids)} requested message(s); missing: {missing_messages}"
+            )
+        return {expected[request_id]: by_id[request_id] for request_id in expected}
 
     def get_thread(self, thread_id: str) -> Dict[str, Any]:
         # Graph has no thread-get; fetch every message in the conversation.

--- a/hub/agents/email/python/gaia_agent_email/outlook_backend.py
+++ b/hub/agents/email/python/gaia_agent_email/outlook_backend.py
@@ -104,13 +104,14 @@ _MESSAGE_SELECT = (
 # ``bodyPreview`` (Gmail's ``snippet`` equivalent) stays, since the category
 # heuristic and meeting-request detector both read that.
 #
-# Graph accepts at most 20 requests in one JSON ``$batch`` envelope.
-_BATCH_MAX_SUBREQUESTS = 20
 _MESSAGE_SELECT_METADATA = (
     "id,conversationId,subject,from,toRecipients,ccRecipients,"
     "receivedDateTime,sentDateTime,isRead,isDraft,flag,categories,"
     "bodyPreview,parentFolderId"
 )
+
+# Graph accepts at most 20 requests in one JSON ``$batch`` envelope.
+_BATCH_MAX_SUBREQUESTS = 20
 
 
 # ---------------------------------------------------------------------------
@@ -497,7 +498,10 @@ class LiveOutlookBackend:
 
     def get_message(self, message_id: str, *, format: str = "full") -> Dict[str, Any]:
         select = _MESSAGE_SELECT_METADATA if format == "metadata" else _MESSAGE_SELECT
-        data = self._get(f"/me/messages/{message_id}", params={"$select": select})
+        data = self._get(
+            f"/me/messages/{quote(message_id, safe='')}",
+            params={"$select": select},
+        )
         return graph_message_to_gmail(data, include_body=(format != "metadata"))
 
     def get_messages_batch(

--- a/hub/agents/email/python/tests/test_outlook_batch_3104.py
+++ b/hub/agents/email/python/tests/test_outlook_batch_3104.py
@@ -69,17 +69,17 @@ def _item(request_id: str, message: dict, *, status: int = 200) -> dict:
 
 def test_empty_and_single_fetch_keep_existing_request_paths():
     backend, recorder = _backend(
-        lambda _: httpx.Response(200, json=_graph_message("m1"))
+        lambda _: httpx.Response(200, json=_graph_message("m/1"))
     )
 
     assert backend.get_messages_batch([]) == {}
     assert recorder.requests == []
 
-    result = backend.get_messages_batch(["m1"], format="metadata")
+    result = backend.get_messages_batch(["m/1"], format="metadata")
 
-    assert result["m1"]["id"] == "m1"
+    assert result["m/1"]["id"] == "m/1"
     assert len(recorder.requests) == 1
-    assert recorder.requests[0].url.path.endswith("/me/messages/m1")
+    assert recorder.requests[0].url.raw_path.startswith(b"/v1.0/me/messages/m%2F1?")
     assert recorder.requests[0].url.params["$select"] == _MESSAGE_SELECT_METADATA
 
 

--- a/hub/agents/email/python/tests/test_outlook_batch_3104.py
+++ b/hub/agents/email/python/tests/test_outlook_batch_3104.py
@@ -1,0 +1,189 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""Regression tests for Outlook's Graph ``$batch`` message fetch (#3104)."""
+
+from __future__ import annotations
+
+import json
+from typing import Callable, List
+
+import httpx
+import pytest
+
+pytest.importorskip("gaia_agent_email")
+
+from gaia_agent_email.outlook_backend import (  # noqa: E402
+    _BATCH_MAX_SUBREQUESTS,
+    _MESSAGE_SELECT,
+    _MESSAGE_SELECT_METADATA,
+    LiveOutlookBackend,
+)
+from gaia_agent_email.tools.read_tools import _fetch_messages  # noqa: E402
+
+from gaia.connectors.errors import ConnectorsError  # noqa: E402
+
+
+class _Recorder:
+    def __init__(self, handler: Callable[[httpx.Request], httpx.Response]):
+        self.requests: List[httpx.Request] = []
+        self._handler = handler
+
+    def __call__(self, request: httpx.Request) -> httpx.Response:
+        self.requests.append(request)
+        return self._handler(request)
+
+
+def _backend(
+    handler: Callable[[httpx.Request], httpx.Response],
+) -> tuple[LiveOutlookBackend, _Recorder]:
+    recorder = _Recorder(handler)
+    client = httpx.Client(transport=httpx.MockTransport(recorder))
+    return LiveOutlookBackend(lambda: "GRAPH-TOKEN-1", http_client=client), recorder
+
+
+def _graph_message(message_id: str) -> dict:
+    return {
+        "id": message_id,
+        "conversationId": f"conversation-{message_id}",
+        "subject": f"Subject {message_id}",
+        "from": {"emailAddress": {"name": "Sender", "address": "sender@example.com"}},
+        "toRecipients": [],
+        "receivedDateTime": "2026-06-01T09:30:00Z",
+        "isRead": True,
+        "isDraft": False,
+        "flag": {"flagStatus": "notFlagged"},
+        "bodyPreview": f"Preview {message_id}",
+        "categories": [],
+        "parentFolderId": "inbox",
+        "body": {"contentType": "text", "content": f"Body {message_id}"},
+    }
+
+
+def _batch_response(*items: dict) -> httpx.Response:
+    return httpx.Response(200, json={"responses": list(items)})
+
+
+def _item(request_id: str, message: dict, *, status: int = 200) -> dict:
+    return {"id": request_id, "status": status, "body": message}
+
+
+def test_empty_and_single_fetch_keep_existing_request_paths():
+    backend, recorder = _backend(
+        lambda _: httpx.Response(200, json=_graph_message("m1"))
+    )
+
+    assert backend.get_messages_batch([]) == {}
+    assert recorder.requests == []
+
+    result = backend.get_messages_batch(["m1"], format="metadata")
+
+    assert result["m1"]["id"] == "m1"
+    assert len(recorder.requests) == 1
+    assert recorder.requests[0].url.path.endswith("/me/messages/m1")
+    assert recorder.requests[0].url.params["$select"] == _MESSAGE_SELECT_METADATA
+
+
+def test_multiple_messages_use_one_graph_batch_and_correlate_by_response_id():
+    captured = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url.path.endswith("/$batch")
+        assert request.headers["authorization"] == "Bearer GRAPH-TOKEN-1"
+        assert request.headers["content-type"] == "application/json"
+        captured["payload"] = json.loads(request.content)
+        return _batch_response(
+            _item("1", _graph_message("m2")),
+            _item("0", _graph_message("m/1")),
+        )
+
+    backend, recorder = _backend(handler)
+    result = backend.get_messages_batch(["m/1", "m2"])
+
+    assert len(recorder.requests) == 1
+    requests = captured["payload"]["requests"]
+    assert [request["id"] for request in requests] == ["0", "1"]
+    assert [request["method"] for request in requests] == ["GET", "GET"]
+    assert "/me/messages/m%2F1?$select=" in requests[0]["url"]
+    assert requests[0]["url"].endswith(_MESSAGE_SELECT)
+    assert result["m/1"]["id"] == "m/1"
+    assert result["m2"]["id"] == "m2"
+
+
+def test_metadata_batch_omits_body_from_graph_select_and_translation():
+    captured = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["payload"] = json.loads(request.content)
+        return _batch_response(
+            _item("0", _graph_message("m1")),
+            _item("1", _graph_message("m2")),
+        )
+
+    backend, _recorder = _backend(handler)
+    result = backend.get_messages_batch(["m1", "m2"], format="metadata")
+
+    requests = captured["payload"]["requests"]
+    assert all(
+        request["url"].endswith(_MESSAGE_SELECT_METADATA) for request in requests
+    )
+    assert all("body," not in request["url"] for request in requests)
+    assert "data" not in result["m1"]["payload"]["body"]
+
+
+def test_read_tools_uses_outlook_batch_capability():
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests = json.loads(request.content)["requests"]
+        return _batch_response(
+            *(
+                _item(item["id"], _graph_message(f"message-{item['id']}"))
+                for item in requests
+            )
+        )
+
+    backend, recorder = _backend(handler)
+    fetched, dropped = _fetch_messages(backend, ["m1", "m2"], format="metadata")
+
+    assert dropped == []
+    assert set(fetched) == {"m1", "m2"}
+    assert len(recorder.requests) == 1
+    assert json.loads(recorder.requests[0].content)["requests"][0]["url"].endswith(
+        _MESSAGE_SELECT_METADATA
+    )
+
+
+def test_batch_requests_are_chunked_at_graph_limit():
+    ids = [f"m{index}" for index in range(_BATCH_MAX_SUBREQUESTS + 1)]
+    chunk_sizes: List[int] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests = json.loads(request.content)["requests"]
+        chunk_sizes.append(len(requests))
+        return _batch_response(
+            *(_item(item["id"], _graph_message("response")) for item in requests)
+        )
+
+    backend, recorder = _backend(handler)
+    result = backend.get_messages_batch(ids)
+
+    assert len(recorder.requests) == 2
+    assert chunk_sizes == [_BATCH_MAX_SUBREQUESTS, 1]
+    assert set(result) == set(ids)
+
+
+def test_partial_or_failed_batch_response_raises_loudly():
+    def missing_handler(request: httpx.Request) -> httpx.Response:
+        return _batch_response(_item("0", _graph_message("m1")))
+
+    backend, _recorder = _backend(missing_handler)
+    with pytest.raises(ConnectorsError, match="missing"):
+        backend.get_messages_batch(["m1", "m2"])
+
+    def failed_handler(request: httpx.Request) -> httpx.Response:
+        return _batch_response(
+            _item("0", _graph_message("m1")),
+            _item("1", {"error": {"message": "not found"}}, status=404),
+        )
+
+    backend, _recorder = _backend(failed_handler)
+    with pytest.raises(ConnectorsError, match="m2.*404"):
+        backend.get_messages_batch(["m1", "m2"])

--- a/hub/agents/email/python/tests/test_outlook_metadata_2643.py
+++ b/hub/agents/email/python/tests/test_outlook_metadata_2643.py
@@ -10,12 +10,10 @@ accidentally tries to decode a metadata-mode message's body gets nothing
 (matching what live Graph would actually return), never a stale/wrong
 "complete" body.
 
-Outlook does NOT get lever 2 (batched fetches) in this change — Microsoft
-Graph's ``$batch`` is a materially different (JSON, not MIME multipart) wire
-protocol and is left as a follow-up; ``get_messages_batch`` is a duck-typed
-capability (see ``gmail_backend.py``), so its absence here does not affect
-``isinstance(x, GmailBackend)`` or the read-tools scan loop, which falls back
-to a per-id ``get_message`` loop for any backend lacking it.
+Outlook's batched fetch path is covered separately in
+``test_outlook_batch_3104.py``. ``get_messages_batch`` remains a duck-typed
+capability (see ``gmail_backend.py``), so the read-tools scan loop continues
+to fall back to a per-id ``get_message`` loop for any backend lacking it.
 """
 
 from __future__ import annotations


### PR DESCRIPTION
## Summary

Add Microsoft Graph JSON `$batch` support to Outlook email message reads so triage fetches multiple messages in batched requests.

## Why

The shared email read path already duck-types `get_messages_batch`, but Outlook only implemented `get_message`, so triage performed one Graph request per message. This increases latency and request pressure for the common multi-message scan path.

## Linked issue

Closes #3104

## Changes

- Add `LiveOutlookBackend.get_messages_batch` using Graph JSON `$batch`.
- Split requests at Graph's 20-subrequest limit and preserve the existing single-message path.
- Support both full and metadata-only selects, URL-escape message IDs, correlate responses by batch response ID, and fail loudly on partial or failed responses.
- Keep the existing duck-typed read-tools fallback for backends without batching.

## Test plan

- [x] `uv run --frozen pytest hub/agents/email/python/tests/test_outlook_batch_3104.py hub/agents/email/python/tests/test_outlook_metadata_2643.py -q` (12 passed)
- [x] Related email regression selection (74 tests) passed before the integration regression was added; rerun after the addition remains covered by the focused 12-test run plus the existing related tests in the same command set.
- [x] `uv run --frozen black --check ...` and `uv run --frozen isort --check-only ...`
- [x] `uv run --frozen pylint --errors-only ...`
- [x] `uv run --frozen python -m compileall -q ...` and `git diff --check`
- [ ] Full related email suite: attempted 3,011 tests with `-x -vv`; it was still progressing through slow existing async tests after about 9% and was stopped without a result.

## Evidence

- [ ] Agent UI / MCP / CLI / HTTP live evidence — N/A: this is an internal HTTP client batching change; tests use deterministic `httpx.MockTransport`, and no external mailbox or credential is required.

## Checklist

- [x] I have linked a GitHub issue above (`Closes #3104`).
- [x] I have described why this change is being made.
- [x] I have run focused linting and tests locally.
- [x] Real-world evidence is marked N/A because no live external surface is changed.
- [x] Documentation/comments were updated where the previous Outlook batching follow-up note became stale.