### PR TITLE
test(conftest): stop the unit suite opening the developer's real browser

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,6 +11,7 @@ This file (conftest.py) is a special pytest file that provides:
 See: https://docs.pytest.org/en/stable/reference/fixtures.html#conftest-py-sharing-fixtures-across-multiple-files
 
 Current fixtures:
+- _block_real_browser_launch: Session-autouse guard so no test can open a real browser
 - api_server: Function-scoped fixture that starts GAIA API server for integration tests
 - api_client: HTTP client (requests.Session) configured for API testing
 - lemonade_available: Session-scoped fixture checking if Lemonade server is running
@@ -29,9 +30,39 @@ be automatically available to all test files.
 
 import subprocess
 import time
+import webbrowser
 
 import pytest
 import requests
+
+_BROWSER_LAUNCHERS = ("open", "open_new", "open_new_tab")
+
+
+@pytest.fixture(scope="session", autouse=True)
+def _block_real_browser_launch():
+    """Make it impossible for the suite to open the developer's real browser.
+
+    A per-test ``monkeypatch.setattr("webbrowser.open", ...)`` is not enough:
+    ``connectors.flow.start_authorization`` launches the browser from a
+    fire-and-forget ``asyncio.ensure_future`` task that resolves
+    ``webbrowser.open`` when it runs, which can be after the patch was torn
+    down. Session scope means the restored value is always this stub, so the
+    race can only ever reach a no-op.
+    """
+    saved = {name: getattr(webbrowser, name) for name in _BROWSER_LAUNCHERS}
+
+    def _blocked(url, *_args, **_kwargs):
+        raise RuntimeError(
+            f"A test tried to open a real browser at {url!r}. Patch the "
+            "launcher in the test (monkeypatch.setattr('webbrowser.open', ...)) "
+            "or stub the code path that calls it."
+        )
+
+    for name in _BROWSER_LAUNCHERS:
+        setattr(webbrowser, name, _blocked)
+    yield
+    for name, original in saved.items():
+        setattr(webbrowser, name, original)
 
 
 @pytest.fixture(scope="session", autouse=True)

--- a/tests/unit/test_no_real_browser_launch.py
+++ b/tests/unit/test_no_real_browser_launch.py
@@ -1,0 +1,29 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""Pins the session guard that stops the suite opening a real browser.
+
+``connectors.flow.start_authorization`` fires the browser launch from a
+fire-and-forget task, so a test's own ``monkeypatch`` can be torn down before
+the launch runs and the real ``webbrowser.open`` gets called — popping a Google
+consent screen on the developer's desktop mid-test-run.
+"""
+
+import webbrowser
+
+import pytest
+
+
+@pytest.mark.parametrize("launcher", ["open", "open_new", "open_new_tab"])
+def test_browser_launchers_are_blocked(launcher):
+    with pytest.raises(RuntimeError, match="tried to open a real browser"):
+        getattr(webbrowser, launcher)("https://example.invalid")
+
+
+def test_a_local_patch_restores_to_the_guard_not_the_real_launcher():
+    """The teardown of a per-test patch must not re-arm the real launcher."""
+    with pytest.MonkeyPatch.context() as patch:
+        patch.setattr("webbrowser.open", lambda *_a, **_k: True)
+        assert webbrowser.open("https://example.invalid") is True
+
+    with pytest.raises(RuntimeError, match="tried to open a real browser"):
+        webbrowser.open("https://example.invalid")


### PR DESCRIPTION
Running the unit suite could pop a Google OAuth consent screen onto the developer's desktop, mid-run, stealing focus — and because the flow ran with a dummy client id, the window that appeared was an "Access blocked: 401 invalid_client" error page. It happens on any full `tests/unit/` run, intermittently, so it reads as a mystery browser popup rather than a test problem.

`connectors.flow.start_authorization` launches the browser from a fire-and-forget `asyncio.ensure_future` task that resolves `webbrowser.open` at the moment it runs — which can be after the test that patched it has finished and `monkeypatch` has restored the real function. The connector tests all do patch the launcher; the patch just isn't guaranteed to still be in place when the launch fires. A session-scoped guard closes the race from the other side: a per-test patch now restores to the stub, never to the real function.

## Test plan

- [ ] `python -m pytest tests/unit/test_no_real_browser_launch.py -v` — 4 passed
- [ ] `python -m pytest tests/unit/connectors/ -q` — no test trips the guard (it only fires on a genuine leak)
- [ ] Verified against the real path, not just a unit test: calling `flow.start_authorization("google", ...)` with a dummy client id and no local patch is intercepted, logged by `flow.py` as `flow: webbrowser.open failed (...); fall back to copy-paste of authorization_url`, and opens no window

<details>
<summary>🔍 Technical details</summary>

The guard replaces `webbrowser.open`, `open_new` and `open_new_tab` for the session. `flow.py`'s launch wrapper catches `Exception`, so a leaking test gets a log warning rather than a red test — enough to stop the popup, but it won't name the offending test in CI. Making it fail loudly would mean narrowing that handler in `flow.py`, which is out of scope here.

Unrelated pre-existing breakage seen while validating on Windows, not addressed by this PR: `tests/unit/connectors/` reports ~273 `ConnectionError: Unit tests must not make real network connections` because the existing network guard trips on `socket.socketpair()` inside `pytest-asyncio`'s event-loop setup.
</details>
