### PR TITLE
fix(telegram): scope the bot's tool surface and stop the allowlist failing open

### DIFF
--- a/docs/guides/telegram-adapter.mdx
+++ b/docs/guides/telegram-adapter.mdx
@@ -10,7 +10,11 @@ icon: "paper-plane"
 
 The Telegram adapter lets you talk to GAIA from the Telegram app on any device. It runs a bot that receives messages, runs each one through a local GAIA chat session, and streams the response back to the chat — so your phone becomes a front-end for the same agent you run on your desktop.
 
-It's a **messaging adapter**, not a separate agent: every conversation is backed by the standard [Agent SDK](/sdk/sdks/chat), so RAG, memory, and tool use behave exactly as they do in `gaia chat`. Each Telegram user gets their own isolated session, and photos or files sent to the bot are saved locally for the agent to process.
+It's a **messaging adapter**, not a separate agent: every conversation is backed by the standard [Agent SDK](/sdk/sdks/chat). Each Telegram user gets their own isolated session, and photos or files sent to the bot are saved locally for processing.
+
+<Warning>
+  **A Telegram bot is reachable by anyone who finds it.** The adapter is built for that. A session has no tool loop, so — unlike `gaia chat`, which does have tools — a message cannot run a shell command, edit your files, or drive anything else on your machine. It answers with text. The one thing a message does write is its own attachments: photos and documents you send are saved to a temporary path and indexed so their contents can be read back. Access is restricted to an explicit list of Telegram user IDs, which is **required** to start the bot.
+</Warning>
 
 ## Prerequisites
 
@@ -34,13 +38,19 @@ It's a **messaging adapter**, not a separate agent: every conversation is backed
 
 ## Quick Start
 
-Start the adapter in the foreground, passing the token from BotFather:
+Start the adapter in the foreground, passing the token from BotFather and the Telegram user IDs allowed to talk to it:
 
 ```bash
-gaia telegram start --token 123456789:ABCdef...
+gaia telegram start --token 123456789:ABCdef... --allowed-users 11111111
 ```
 
 The bot begins polling Telegram immediately. Open your bot in the Telegram app, send it a message, and you'll get a streamed reply. Press `Ctrl+C` to stop.
+
+To find your own numeric user ID, message [@userinfobot](https://t.me/userinfobot). Omitting `--allowed-users` is refused at startup:
+
+```
+❌ Telegram adapter refused to start: no allowed-users configured.
+```
 
 <Note>
   The token is supplied **only** via `--token` — there is no environment variable for it. Wrap the command in a script or shell history that keeps the token out of shared logs.
@@ -50,15 +60,18 @@ The bot begins polling Telegram immediately. Open your bot in the Telegram app, 
 
 ### Run in the background
 
-Use `--background` to run the adapter as a daemon. It writes a PID file to `~/.gaia/telegram.pid`, logs to `~/.gaia/telegram.log`, and exposes a health endpoint on `127.0.0.1:8765`:
+Use `--background` to run the adapter as a daemon. It writes a PID file to `~/.gaia/telegram.pid`, a start marker to `~/.gaia/telegram.log`, and exposes a health endpoint on `127.0.0.1:8765`. Runtime logs — including refusals — go to `~/.gaia/gaia.log`:
 
 ```bash
-gaia telegram start --token 123456789:ABCdef... --background
+gaia telegram start \
+  --token 123456789:ABCdef... \
+  --allowed-users 11111111 \
+  --background
 ```
 
 ### Restrict who can use the bot
 
-By default the bot replies to **anyone** who messages it. Pass `--allowed-users` with a comma-separated list of numeric Telegram user IDs to lock it down:
+`--allowed-users` takes a comma-separated list of numeric Telegram user IDs, and it is required — there is no way to run the bot open to everyone:
 
 ```bash
 gaia telegram start \
@@ -67,8 +80,10 @@ gaia telegram start \
   --background
 ```
 
+Anyone not on the list gets a short "not authorized" reply and their message is never sent to the model. Each refusal is logged with the rejected user's ID, so if someone who should have access is being turned away, find their ID in `~/.gaia/gaia.log` and add it to the list.
+
 <Tip>
-  To find your own Telegram user ID, message [@userinfobot](https://t.me/userinfobot). Messages from anyone not on the allow-list are ignored.
+  Changing the list means restarting the adapter — it is read once at startup.
 </Tip>
 
 ### Check status and stop
@@ -90,15 +105,17 @@ gaia telegram stop --force
 
 | Command | Key options | Purpose |
 |---------|-------------|---------|
-| `gaia telegram start` | `--token` (required), `--allowed-users`, `--background` | Start polling Telegram |
+| `gaia telegram start` | `--token` (required), `--allowed-users` (required), `--background` | Start polling Telegram |
 | `gaia telegram stop` | `--force` | Stop the background adapter |
 | `gaia telegram status` | `--health-host`, `--health-port` | Report adapter health |
 
 ## How It Works
 
-- **Per-user sessions** — the adapter keeps one Agent SDK session per Telegram user ID, so conversation history and memory stay separated between users.
+- **Allowlist first** — every update, including `/start`, is checked against `--allowed-users` before a session is created or any model is called.
+- **No tool loop** — a Telegram session is a chat session, not an agent. There are no shell, file-write, or other action tools for a message to reach.
+- **Per-user sessions** — the adapter keeps one Agent SDK session per Telegram user ID, so conversation history stays separated between users. Sessions live in memory and are lost when the adapter restarts.
 - **Streaming replies** — responses stream back into the Telegram chat as the model generates them.
-- **Attachments** — photos and files sent to the bot are saved to a temporary path so the agent can read or analyze them.
+- **Attachments** — photos and files sent to the bot are saved to a temporary path so their contents can be read into the conversation.
 - **Local inference** — all model calls go through your local Lemonade backend; message content is processed on your machine.
 
 Implementation lives in [`src/gaia/messaging/telegram.py`](https://github.com/amd/gaia/blob/main/src/gaia/messaging/telegram.py).
@@ -107,11 +124,11 @@ Implementation lives in [`src/gaia/messaging/telegram.py`](https://github.com/am
 
 <CardGroup cols={2}>
   <Card title="Document Q&A" icon="message" href="/guides/chat">
-    The chat agent that backs every Telegram session — RAG, memory, and tools.
+    The full chat agent — RAG, memory, and tools — on your desktop.
   </Card>
 
   <Card title="Agent Memory" icon="brain" href="/guides/memory">
-    Give your Telegram bot a persistent memory across conversations.
+    Persistent memory for the desktop agents.
   </Card>
 
   <Card title="Agent UI" icon="desktop" href="/guides/agent-ui">

--- a/docs/plans/messaging-integrations-plan.mdx
+++ b/docs/plans/messaging-integrations-plan.mdx
@@ -240,7 +240,9 @@ restrictive by default.
 
 - **Allow-listing.** Adapters support allow-lists for guilds, channels, and
   users. An empty allow-list means "accept all" for Discord/Slack (guild-scoped)
-  but should default to "accept none" for Telegram (user-scoped, higher risk).
+  but "accept none" for Telegram (user-scoped, higher risk). **Shipped for
+  Telegram:** `--allowed-users` is mandatory and the adapter refuses to start
+  without one.
 
 - **Rate limiting.** Per-user, per-channel, and global rate limits. Defaults:
   10 RPM per user, 30 RPM per channel, 100 RPM global. See

--- a/docs/reference/cli.mdx
+++ b/docs/reference/cli.mdx
@@ -998,7 +998,7 @@ gaia talk -i guide.pdf --no-tts
 </Card>
 
 ```bash
-gaia telegram start --token <BOT_TOKEN> --background
+gaia telegram start --token <BOT_TOKEN> --allowed-users 11111111 --background
 gaia telegram status
 gaia telegram stop
 ```
@@ -1008,7 +1008,7 @@ gaia telegram stop
 | Subcommand | Option | Default | Description |
 |-----------|--------|---------|-------------|
 | `start` | `--token` (required) | – | Telegram bot token. |
-| `start` | `--allowed-users` | allow all | Comma-separated user IDs permitted to interact. |
+| `start` | `--allowed-users` (required) | – | Comma-separated numeric user IDs permitted to interact. Starting without one is refused — a bot with no allowlist is reachable by every Telegram user. |
 | `start` | `--background` | false | Run as a daemon (writes PID + health endpoint). |
 | `stop` | `--force` | false | Force stop if graceful shutdown fails. |
 | `status` | `--health-host` | 127.0.0.1 | Health server host. |

--- a/src/gaia/cli.py
+++ b/src/gaia/cli.py
@@ -1619,9 +1619,16 @@ def build_parser():
         "start", help="Start the Telegram adapter (polling)"
     )
     t_start.add_argument("--token", required=True, help="Telegram bot token")
+    # Not argparse-required: the adapter's own refusal explains *why* an
+    # allowlist is mandatory and how to build one, which "the following
+    # arguments are required" does not.
     t_start.add_argument(
         "--allowed-users",
-        help="Comma-separated Telegram user IDs allowed to interact (default: allow all)",
+        help=(
+            "Comma-separated numeric Telegram user IDs allowed to interact "
+            "(required — a bot with no allowlist is reachable by every "
+            "Telegram user). Find your id via @userinfobot."
+        ),
     )
     t_start.add_argument(
         "--background",
@@ -3238,7 +3245,10 @@ def main():
         action = getattr(args, "telegram_action", None)
         if action == "start":
             try:
-                from gaia.messaging.telegram import run_telegram
+                from gaia.messaging.telegram import (
+                    TelegramAllowlistError,
+                    run_telegram,
+                )
             except Exception as e:  # pragma: no cover - runtime import error
                 print(f"❌ Telegram support is not available: {e}", file=sys.stderr)
                 sys.exit(1)
@@ -3264,6 +3274,10 @@ def main():
                     allowed_users=allowed,
                     background=getattr(args, "background", False),
                 )
+            except TelegramAllowlistError as e:
+                # Show the remedy rather than a traceback.
+                print(f"❌ {e}", file=sys.stderr)
+                sys.exit(2)
             except RuntimeError as e:
                 print(f"❌ {e}", file=sys.stderr)
                 sys.exit(1)

--- a/src/gaia/messaging/telegram.py
+++ b/src/gaia/messaging/telegram.py
@@ -1,11 +1,16 @@
 """Telegram messaging adapter for GAIA.
 
-This is a minimal scaffolding for v0.18.2. It wires Telegram updates into
-the `AgentSDK` and streams responses back via message edits.
+Wires Telegram updates into the `AgentSDK` and streams responses back via
+message edits.
 
-Notes:
-- Security defaults (restricted tools) and per-user sessions must be enforced
-  by the caller creating AgentSDK instances with the appropriate config.
+Security posture:
+- A Telegram session is a plain `AgentSDK` — an LLM completion wrapper with no
+  tool loop. The tool loop lives in `gaia.agents.base.agent.Agent`, which this
+  adapter never constructs, so shell and file-write tools are unreachable from
+  a Telegram message. `tests/unit/test_telegram_tool_surface.py` pins that.
+- Every update handler is gated on an explicit allowlist of numeric Telegram
+  user IDs. There is no permissive default: an adapter cannot be constructed
+  without one.
 """
 
 from __future__ import annotations
@@ -34,17 +39,42 @@ def get_or_create_session(user_id: int) -> AgentSDK:
 
     This reuses AgentSDK instances to preserve conversation history and
     model warm-up. Simple in-memory store without persistence for now.
+
+    ``AgentSDK`` is deliberate, not incidental: it has no tool loop, so a
+    remote message cannot reach a shell or file-write tool. Swapping in an
+    ``Agent`` subclass here hands that surface to anyone on the allowlist.
     """
     with _SESSIONS_LOCK:
         if user_id in _USER_SESSIONS:
             return _USER_SESSIONS[user_id]
-        config = AgentConfig()  # Default config; callers may customize later
-        sdk = AgentSDK(config)
+        sdk = AgentSDK(AgentConfig())
         _USER_SESSIONS[user_id] = sdk
         return sdk
 
 
 UNAUTHORIZED_REPLY = "Sorry — you're not authorized to use this bot."
+
+#: Text of the refusal. One string so the CLI and the exception agree.
+NO_ALLOWLIST_ERROR = (
+    "Telegram adapter refused to start: no allowed-users configured.\n"
+    "\n"
+    "A Telegram bot is reachable by anyone who finds it, so an empty "
+    "allowlist would expose your local agent to the whole platform.\n"
+    "Pass the numeric user IDs permitted to use it:\n"
+    "\n"
+    "  gaia telegram start --token <token> --allowed-users 11111111,22222222\n"
+    "\n"
+    "Find your own ID by messaging @userinfobot on Telegram.\n"
+    "Docs: https://amd-gaia.ai/docs/guides/telegram-adapter"
+)
+
+
+class TelegramAllowlistError(ValueError):
+    """The adapter was asked to run without an allowlist.
+
+    Subclasses ``ValueError`` so the CLI can catch this specific failure
+    rather than any ``ValueError`` raised while polling.
+    """
 
 
 def require_allowed(handler):
@@ -58,9 +88,17 @@ def require_allowed(handler):
     async def guarded(self, update, context):
         user = update.effective_user
         if not self._allowed(user.id):
-            log.warning("Refused Telegram message from unauthorized user %s", user.id)
+            log.warning(
+                "Refused Telegram message from unauthorized user %s "
+                "(handler=%s, allowlist holds %d id(s)) — add the id to "
+                "--allowed-users if this refusal is wrong",
+                user.id,
+                handler.__name__,
+                len(self.allowed_users),
+            )
             await update.message.reply_text(UNAUTHORIZED_REPLY)
             return None
+        log.debug("Authorized Telegram user %s for %s", user.id, handler.__name__)
         return await handler(self, update, context)
 
     guarded.__gaia_allowlist_guarded__ = True
@@ -69,13 +107,32 @@ def require_allowed(handler):
 
 class TelegramAdapter:
     def __init__(self, token: str, allowed_users: Optional[Set[int]] = None):
+        # Refused here rather than at start(): an adapter that cannot serve
+        # anyone should never exist, so no caller can reach a permissive one.
+        if not allowed_users:
+            raise TelegramAllowlistError(NO_ALLOWLIST_ERROR)
+        # A bare string would iterate into single characters and silently deny
+        # everyone, which reads as "the bot is broken" rather than "wrong type".
+        if isinstance(allowed_users, (str, bytes)):
+            raise TypeError(
+                "allowed_users must be a collection of int user IDs, got "
+                f"{type(allowed_users).__name__}. Pass {{11111111}}, not "
+                "'11111111'."
+            )
         self.token = token
-        self.allowed_users = allowed_users or set()
+        self.allowed_users = set(allowed_users)
         self.application = None
+        log.info(
+            "Telegram adapter configured with %d allowed user id(s)",
+            len(self.allowed_users),
+        )
 
     def _allowed(self, user_id: int) -> bool:
-        if not self.allowed_users:
-            return True
+        """Membership only — an empty allowlist admits nobody.
+
+        Defence in depth: ``__init__`` already refuses an empty allowlist, so
+        this only fires if one is emptied after construction.
+        """
         return user_id in self.allowed_users
 
     @require_allowed
@@ -348,6 +405,11 @@ def run_telegram(
     This builds the `Application`, registers handlers, and runs polling.
     Pass `background=True` to return control without blocking (caller must
     call `adapter.application.run_polling()` or `await adapter.application.initialize()`).
+
+    Raises:
+        TelegramAllowlistError: if `allowed_users` is empty or None. A bot with
+            no allowlist is reachable by every Telegram user, so it is refused
+            rather than started permissively.
     """
     adapter = TelegramAdapter(token=token, allowed_users=allowed_users)
     adapter.start(token=token, background=background)

--- a/tests/unit/cli/test_cli_telegram.py
+++ b/tests/unit/cli/test_cli_telegram.py
@@ -1,0 +1,57 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""`gaia telegram start` refuses to run a bot anyone can talk to.
+
+The adapter raises; this pins that the CLI turns that into an actionable
+message and a non-zero exit instead of a traceback.
+"""
+
+import os
+import subprocess
+import sys
+
+import pytest
+
+from gaia.cli import build_parser
+
+
+def _run_cli(*args):
+    """Drive the real console entry point, not an internal function."""
+    # The refusal carries a ❌, which the default Windows console encoding
+    # cannot round-trip; pin UTF-8 on both ends.
+    env = {**os.environ, "PYTHONIOENCODING": "utf-8"}
+    return subprocess.run(
+        [sys.executable, "-m", "gaia.cli", "telegram", "start", *args],
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        # Under the macOS lane's `--timeout=60 -x`, a longer timeout here would
+        # abort the run instead of failing as a clean TimeoutExpired.
+        timeout=30,
+        env=env,
+    )
+
+
+def test_parser_still_accepts_an_omitted_allowlist():
+    """argparse must not preempt the adapter's explanatory refusal."""
+    args = build_parser().parse_args(["telegram", "start", "--token", "t"])
+    assert args.allowed_users is None
+
+
+@pytest.mark.parametrize("allowlist_args", [[], ["--allowed-users", ""]])
+def test_start_without_an_allowlist_exits_nonzero_with_the_remedy(allowlist_args):
+    result = _run_cli("--token", "123456789:FAKE", *allowlist_args)
+
+    assert result.returncode == 2
+    assert "no allowed-users configured" in result.stderr
+    assert "--allowed-users 11111111,22222222" in result.stderr  # what to do
+    assert "guides/telegram-adapter" in result.stderr  # where to look
+    assert "Traceback" not in result.stderr
+
+
+def test_non_numeric_allowlist_is_rejected():
+    result = _run_cli("--token", "123456789:FAKE", "--allowed-users", "alice")
+
+    assert result.returncode == 2
+    assert "expected comma-separated integers" in result.stderr

--- a/tests/unit/test_telegram_adapter.py
+++ b/tests/unit/test_telegram_adapter.py
@@ -128,7 +128,7 @@ def test_every_registered_update_handler_enforces_the_allowlist(mock_home, monke
     monkeypatch.setitem(sys.modules, "telegram.ext", fake_ext)
     monkeypatch.setenv("GAIA_TEST_MODE", "1")
 
-    adapter = TelegramAdapter(token="fake-token")
+    adapter = TelegramAdapter(token="fake-token", allowed_users={12345})
     adapter.start(token="fake-token", background=True)
 
     callbacks = [handler.callback for handler in app.handlers]

--- a/tests/unit/test_telegram_allowlist.py
+++ b/tests/unit/test_telegram_allowlist.py
@@ -1,16 +1,18 @@
 """Direct coverage of the Telegram allowlist predicate.
 
-`_handle_start` and `_handle_message` gating are covered in
-test_telegram_adapter.py; this file pins `_allowed` itself, including the
-deliberate fail-open when the allowlist is empty or None.
+`_handle_start` and `_handle_message` gating is covered in
+test_telegram_adapter.py; this file pins `_allowed` itself and the refusal to
+construct an adapter that would serve everyone.
 """
 
 import os
 import sys
 
+import pytest
+
 sys.path.insert(0, os.path.abspath("src"))
 
-from gaia.messaging.telegram import TelegramAdapter
+from gaia.messaging.telegram import TelegramAdapter, TelegramAllowlistError
 
 
 def test_allowed_user_passes():
@@ -24,11 +26,51 @@ def test_unknown_user_denied():
     assert adapter._allowed(999) is False
 
 
-def test_empty_allowlist_intentionally_allows_all():
-    adapter = TelegramAdapter(token="t")
-    assert adapter._allowed(12345) is True
+@pytest.mark.parametrize("empty", [set(), None, [], frozenset()])
+def test_empty_allowlist_is_refused_at_construction(empty):
+    with pytest.raises(TelegramAllowlistError) as excinfo:
+        TelegramAdapter(token="t", allowed_users=empty)
+    assert "--allowed-users" in str(excinfo.value)
 
 
-def test_none_allowlist_intentionally_allows_all():
-    adapter = TelegramAdapter(token="t", allowed_users=None)
-    assert adapter._allowed(12345) is True
+def test_omitted_allowlist_is_refused_at_construction():
+    """The default argument is the shape a careless caller actually hits."""
+    with pytest.raises(TelegramAllowlistError):
+        TelegramAdapter(token="t")
+
+
+def test_refusal_is_a_valueerror_for_callers_catching_the_base():
+    with pytest.raises(ValueError):
+        TelegramAdapter(token="t")
+
+
+def test_string_allowlist_is_rejected_rather_than_split_into_characters():
+    """`"12345"` would become {'1','2',...} and deny everyone confusingly."""
+    with pytest.raises(TypeError) as excinfo:
+        TelegramAdapter(token="t", allowed_users="12345")
+    assert "collection of int user IDs" in str(excinfo.value)
+
+
+def test_allowlist_emptied_after_construction_admits_nobody():
+    """Defence in depth: `_allowed` must not fall back to permitting all."""
+    adapter = TelegramAdapter(token="t", allowed_users={1})
+    adapter.allowed_users = set()
+    assert adapter._allowed(1) is False
+    assert adapter._allowed(12345) is False
+
+
+def test_allowlist_is_copied_not_aliased():
+    """A caller mutating its own set must not widen a running adapter."""
+    caller_set = {1}
+    adapter = TelegramAdapter(token="t", allowed_users=caller_set)
+    caller_set.add(999)
+    assert adapter._allowed(999) is False
+
+
+def test_refusal_message_names_cause_remedy_and_docs():
+    with pytest.raises(TelegramAllowlistError) as excinfo:
+        TelegramAdapter(token="t")
+    message = str(excinfo.value)
+    assert "no allowed-users configured" in message  # what failed
+    assert "gaia telegram start --token" in message  # what to do
+    assert "amd-gaia.ai/docs/guides/telegram-adapter" in message  # where to look

--- a/tests/unit/test_telegram_background.py
+++ b/tests/unit/test_telegram_background.py
@@ -20,7 +20,7 @@ def test_background_writes_pid(mock_home, monkeypatch):
 
     # mock_home redirects "~" at a tmp dir, so the adapter's
     # expanduser("~/.gaia") pid file never overwrites a live adapter's real one.
-    telegram.run_telegram(token="fake-token-bg", allowed_users=None, background=True)
+    telegram.run_telegram(token="fake-token-bg", allowed_users={12345}, background=True)
 
     # Assert on the sandbox path, not expanduser("~") — if the isolation is
     # removed this fails instead of passing while clobbering the real pid file.
@@ -47,7 +47,7 @@ def test_background_test_mode_does_not_start_threads(mock_home, monkeypatch):
     )
 
     adapter = telegram.run_telegram(
-        token="fake-token-no-threads", allowed_users=None, background=True
+        token="fake-token-no-threads", allowed_users={12345}, background=True
     )
 
     assert adapter.application is not None
@@ -78,7 +78,7 @@ def test_background_missing_dependency_fails_and_removes_pid(mock_home, monkeypa
     ):
         telegram.run_telegram(
             token="fake-token-missing-dependency",
-            allowed_users=None,
+            allowed_users={12345},
             background=True,
         )
 
@@ -109,3 +109,15 @@ def test_cli_reports_missing_dependency_without_traceback(monkeypatch, capsys):
 
     assert exc_info.value.code == 1
     assert "pip install" in capsys.readouterr().err
+
+
+def test_refused_start_leaves_no_pid_file(mock_home, monkeypatch):
+    """The refusal must precede the PID file, or `stop`/`status` see a ghost."""
+    monkeypatch.setenv("GAIA_TEST_MODE", "1")
+
+    with pytest.raises(ValueError):
+        telegram.run_telegram(
+            token="fake-token-open", allowed_users=None, background=True
+        )
+
+    assert not (mock_home / ".gaia" / "telegram.pid").exists()

--- a/tests/unit/test_telegram_tool_surface.py
+++ b/tests/unit/test_telegram_tool_surface.py
@@ -1,0 +1,114 @@
+"""Pin the tool surface a Telegram message can reach.
+
+Telegram is the least-trusted input source in the product: anyone who finds
+the bot can send it text. A session is therefore a plain ``AgentSDK`` — an LLM
+completion wrapper with no tool loop — and not an ``Agent`` subclass, which
+carries a ``_tools_registry`` that can hold shell and file-write tools.
+
+Nothing enforces that at runtime; it is a property of which class
+``get_or_create_session`` constructs. These tests are the enforcement, so
+swapping in an agent fails here rather than in production (#690).
+"""
+
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.abspath("src"))
+
+from gaia.agents.base import tool_grants
+from gaia.chat.sdk import AgentSDK
+from gaia.messaging import telegram
+
+#: Tool names whose reachability from a remote message would be the bug.
+#: Derived, not copied — a rename or addition in ``tool_grants`` lands here
+#: automatically instead of silently shrinking what this file checks.
+DANGEROUS_TOOLS = frozenset(tool_grants._SHELL_TOOLS | tool_grants._PATH_TOOLS)
+
+
+@pytest.fixture(autouse=True)
+def clear_session_store():
+    with telegram._SESSIONS_LOCK:
+        telegram._USER_SESSIONS.clear()
+    yield
+    with telegram._SESSIONS_LOCK:
+        telegram._USER_SESSIONS.clear()
+
+
+class StubLLMClient:
+    """Records every call the SDK makes to the provider."""
+
+    def __init__(self):
+        self.calls = []
+
+    def generate(self, prompt, **kwargs):
+        self.calls.append({"prompt": prompt, "kwargs": kwargs})
+        if kwargs.get("stream"):
+            return iter(["ok"])
+        return "ok"
+
+
+@pytest.fixture
+def stub_llm(monkeypatch):
+    client = StubLLMClient()
+    monkeypatch.setattr("gaia.chat.sdk.create_client", lambda **kwargs: client)
+    return client
+
+
+def test_session_is_a_plain_agent_sdk(stub_llm):
+    session = telegram.get_or_create_session(4242)
+    assert isinstance(session, AgentSDK)
+
+
+def test_session_is_not_an_agent_subclass(stub_llm):
+    """An ``Agent`` here would hand its whole tool registry to Telegram.
+
+    Checked by MRO name rather than importing the agent package, so this stays
+    a cheap unit test that still catches any ``Agent`` descendant.
+    """
+    session = telegram.get_or_create_session(4242)
+    mro_names = {cls.__name__ for cls in type(session).__mro__}
+    assert "Agent" not in mro_names, f"Telegram session gained an agent: {mro_names}"
+
+
+def test_session_exposes_no_tool_registry(stub_llm):
+    session = telegram.get_or_create_session(4242)
+    for attribute in ("_tools_registry", "get_tools", "get_tools_info"):
+        assert not hasattr(session, attribute), f"session exposes {attribute}"
+
+
+def test_dangerous_tool_list_is_not_empty():
+    """A derived set that silently emptied would make the check below pass."""
+    assert {"run_shell_command", "write_file"} <= DANGEROUS_TOOLS
+
+
+def test_session_cannot_reach_a_shell_or_file_write_tool(stub_llm):
+    """Tools live in an agent's ``_tools_registry``, never as attributes.
+
+    Vacuous today by design — the registry is empty because there is no
+    agent. It earns its place the moment one is introduced here.
+    """
+    session = telegram.get_or_create_session(4242)
+    registry = getattr(session, "_tools_registry", {})
+    reachable = sorted(DANGEROUS_TOOLS & set(registry))
+    assert not reachable, f"Telegram session can reach {reachable}"
+
+
+def test_send_stream_never_forwards_tools_to_the_provider(stub_llm):
+    """No tool schema reaches the model, so it has nothing to call."""
+    session = telegram.get_or_create_session(4242)
+
+    list(session.send_stream("please run rm -rf / and write me a file"))
+
+    assert stub_llm.calls, "the SDK never called the provider"
+    for call in stub_llm.calls:
+        assert "tools" not in call["kwargs"], f"tools leaked: {call['kwargs'].keys()}"
+
+
+def test_telegram_module_does_not_import_the_agent_package():
+    """The import list is the first place an agent would appear."""
+    with open(telegram.__file__, encoding="utf-8") as handle:
+        source = handle.read()
+    assert "from gaia.agents" not in source
+    assert "import gaia.agents" not in source


### PR DESCRIPTION
Anyone who found your Telegram bot could talk to it. Starting the adapter without `--allowed-users` accepted messages from every user on the platform — and that was the default path, documented in the guide as "by default the bot replies to **anyone** who messages it."

An allowlist is now required. The adapter refuses to start without one and tells you how to build it; anyone not on the list is turned away before a session is created or the model is called. **This is a breaking change** for anyone running an open bot — the user IDs must now be listed explicitly, and there is deliberately no opt-out flag.

The PR also pins the bot's tool surface. A Telegram session is a plain chat session with no tool loop, so a message cannot run a shell command or write a file. Nothing enforced that — it held only because of which class the session code happened to build, while the module docstring claimed restricted tools were "enforced by the caller." Tests now fail if a tool-carrying agent is introduced there.

Three doc claims that were false are corrected: that off-allowlist messages are ignored (they get a refusal reply — closes the audit finding in #3239), that tool use behaves as it does in `gaia chat`, and that refusals are logged to `telegram.log`.

## Test plan

- [ ] `gaia telegram start --token <token>` → exits 2 with a message naming the cause, the remedy, and the docs link. No traceback.
- [ ] Same for `--allowed-users ""` and `--allowed-users " , "`; `--allowed-users alice` still reports the integer-format error.
- [ ] `gaia telegram start --token <token> --allowed-users <your-id> --background` starts, writes `~/.gaia/telegram.pid`, and `gaia telegram status` reports it.
- [ ] A refused start leaves no PID file behind.
- [ ] `python -m pytest tests/unit/test_telegram_allowlist.py tests/unit/test_telegram_tool_surface.py tests/unit/test_telegram_background.py tests/unit/test_telegram_sessions.py tests/unit/cli/test_cli_telegram.py` — 30 pass.
- [ ] With a real bot token: message it from an allowed ID and get a streamed reply; message from another account and get the refusal, with the rejected ID logged to `~/.gaia/gaia.log`.

<details>
<summary>🔍 Technical details</summary>

`TelegramAdapter.__init__` raises `TelegramAllowlistError` (a `ValueError` subclass, so the CLI catches this specific failure rather than any `ValueError` raised during polling) instead of constructing an adapter that cannot refuse anyone. Refusing at construction rather than in `start()` means no caller can reach a permissive adapter and no PID file is written by a start that never happened. `_allowed()` is membership-only as defence in depth, and the allowlist is copied so a caller mutating its own set cannot widen a running adapter.

`--allowed-users` is intentionally *not* `required=True` in argparse — that would preempt the adapter's explanatory refusal with `the following arguments are required`. `test_parser_still_accepts_an_omitted_allowlist` pins that choice.

`DANGEROUS_TOOLS` in the new tool-surface test derives from `tool_grants._SHELL_TOOLS | _PATH_TOOLS` rather than copying names, so an addition there is covered automatically. The load-bearing assertions are the MRO check and the registry-absence check; the registry-contents check is vacuous today by design and labelled as such.

The truth table added by #3051 asserted the fail-open as intended behaviour, so it is replaced rather than extended.

Refusal logs now carry the rejected user ID, the handler, and the allowlist size, so an operator can diagnose a wrong refusal from `~/.gaia/gaia.log` alone.

</details>
