### PR TITLE
fix(ci): stop the Claude audits re-filing the same finding every run

### DIFF
--- a/.claude/agents/code-reviewer.md
+++ b/.claude/agents/code-reviewer.md
@@ -21,7 +21,7 @@ Follow [`CLAUDE.md`](../../CLAUDE.md) → "How You Communicate".
 
 - Architectural / cross-layer reviews → `architecture-reviewer`
 - SDK API design reviews → `sdk-architect`
-- Security-sensitive findings → **flag privately to `@kovtcharov-amd`** per `CLAUDE.md` security protocol; do not post exploit details publicly. This is the *reactive* (per-PR) counterpart to the *proactive* weekly audit (`.github/workflows/claude-weekly-audit.yml`); both use the same rule — security detail goes to the run log / a private channel, never a public issue.
+- Security-sensitive findings → **flag privately to `@kovtcharov-amd`** per `CLAUDE.md` security protocol; do not post exploit details publicly. This is the *reactive* (per-PR) counterpart to the *proactive* weekly audit (`.github/workflows/claude-nightly-audit.yml`); both use the same rule — security detail goes to the run log / a private channel, never a public issue.
 - Test-suite completeness reviews → `test-engineer`
 
 ## Review workflow

--- a/.claude/agents/github-actions-specialist.md
+++ b/.claude/agents/github-actions-specialist.md
@@ -33,7 +33,7 @@ Follow [`CLAUDE.md`](../../CLAUDE.md) → "How You Communicate".
 | `test_gaia_cli.yml` | Top-level test orchestrator |
 | `lint.yml` | Formatting, imports, security scans |
 | `claude.yml` | Claude auto-review + issue/PR handler (reactive) |
-| `claude-weekly-audit.yml` | Proactive **nightly** audit (10:37 UTC ≈ 3am Pacific; deep sweep on Sundays) — scheduled fan-out (correctness/docs/tests/features; security has its own nightly workflow) → one `weekly-audit` triage issue; findings promote to PRs via the `bug`→`auto-fix` path. Reuses the `claude.yml` auth + `claude-auth-canary.yml` canary. See the `weekly-audit-patterns` skill before editing (dedup-key + private-security invariants). |
+| `claude-nightly-audit.yml` | Proactive **nightly** audit (10:37 UTC ≈ 3am Pacific; deep sweep on Sundays) — scheduled fan-out (correctness/docs/tests/features; security has its own nightly workflow) → **one issue per defect**, labelled `weekly-audit` (a provenance label, not a cadence one). No per-run triage issue: the run report goes to the job summary. Findings promote to PRs via the `bug`→`auto-fix` path. Reuses the `claude.yml` auth + `claude-auth-canary.yml` canary. See the `weekly-audit-patterns` skill before editing (two-key dedup + private-security invariants). |
 
 ### Platform & integration
 | File | Scope |

--- a/.claude/skills/weekly-audit-patterns/SKILL.md
+++ b/.claude/skills/weekly-audit-patterns/SKILL.md
@@ -1,21 +1,31 @@
 ---
 name: "weekly-audit-patterns"
-description: "The non-obvious invariants of the proactive nightly Claude audit workflow (.github/workflows/claude-weekly-audit.yml): the day-of-week mode selector, the stable dedup-key scheme that keeps it from re-filing findings every run, the four audit dimensions (security has its own nightly workflow, claude-security-audit.yml) and which one owns the Fail-Loudly check, and the `bug`-label → auto-fix promotion path. Read before editing that workflow, changing its cadence, changing how findings are filed/deduped, or adding an audit dimension."
+description: "The non-obvious invariants of the proactive nightly Claude audit workflow (.github/workflows/claude-nightly-audit.yml): the day-of-week mode selector, the two-key dedup scheme (cluster_key per defect, dedup_key per location) that keeps one defect from becoming N issues, the four audit dimensions (security has its own nightly workflow, claude-security-audit.yml) and which one owns the Fail-Loudly check, and the `bug`-label → auto-fix promotion path. Read before editing that workflow, changing its cadence, changing how findings are filed/deduped, or adding an audit dimension."
 ---
 
 # Nightly Audit Patterns
 
-`.github/workflows/claude-weekly-audit.yml` is the repo's one **proactive** Claude
+`.github/workflows/claude-nightly-audit.yml` is the repo's one **proactive** Claude
 lens — a scheduled deep review (not triggered by a PR) that fans out one read-only
-Claude job per dimension and files a ranked triage issue. Everything else in
+Claude job per dimension and files **one issue per defect**. Everything else in
 `claude.yml` is reactive. These are the invariants a future editor will otherwise break.
 
-> **Naming:** this ran weekly until it moved to a nightly cron (10:37 UTC ≈ 3am Pacific,
-> deep on Sundays). Three identifiers deliberately kept the `weekly` name so the change
-> did not orphan existing state or break references: the **filename**, the
-> **`weekly-audit` issue label** (it is the dedup key — renaming it would re-file every
-> open finding), and this **skill's `name`** (referenced from `CLAUDE.md`). Issue titles
-> and the workflow display name did change, to `Nightly audit — …`.
+> **Naming:** this ran weekly before it moved to a nightly cron (10:37 UTC ≈ 3am Pacific,
+> deep on Sundays). The filename, `name:`, cron, and concurrency group now all say
+> **nightly**. Two identifiers still say `weekly` and are correct as they are:
+>
+> - the **`weekly-audit` label** — a **provenance** label ("a proactive Claude audit filed
+>   this"), shared with the genuinely-weekly `claude-weekly-doc-walkthrough.yml`. No
+>   cadence word fits both workflows, so it keeps the neutral name it happens to have;
+>   its `--description` in both workflows says exactly that.
+> - this **skill's `name`**, referenced from `CLAUDE.md`.
+>
+> An earlier version of this note justified the label by claiming a rename "would re-file
+> every open finding." That is **false**, and worth correcting because it is the reasoning
+> a future editor inherits: GitHub renames a label in place and every issue keeps it, and
+> dedup never matched on the label text — it reads the `audit-key` / `audit-cluster`
+> markers in issue bodies. The label only scopes which issues get scanned for those
+> markers (`--label` in `scripts/audit/prepare_synthesis.py`, one default to update).
 
 ## The four dimensions are mutually exclusive
 
@@ -26,8 +36,8 @@ the private code-scanning tab). Don't re-add it here; that created two half-owne
 single general "security lens" is what missed the hub tar-slip.
 The lenses **overlap unless the prompt keeps them disjoint**, and the first run proved it:
 correctness findings (a rollback that never rolls back, a poller returning null, a mode
-that no-ops) leaked into `features`, and the priciest job's output vanished from the
-triage issue. The decisive question for a broken thing: **is the code wired but
+that no-ops) leaked into `features`, and the priciest job's output vanished from what got
+filed. The decisive question for a broken thing: **is the code wired but
 misbehaving (`correctness`), never written (`features`), or contradicted by its docs
 (`docs`)?**
 
@@ -36,9 +46,9 @@ misbehaving (`correctness`), never written (`features`), or contradicted by its 
 - **`features`** is only genuinely-missing/half-shipped capability — a TODO for code never
   written. Wired-but-broken is correctness, not features.
 - **`docs`** owns doc-vs-code drift, including a feature *documented as working but stubbed*.
-- **`tests`** in deep mode rolls plain "module X has no coverage" into ONE aggregate finding
-  (`dedup_key: tests:aggregate:untested-modules`); separate findings only for risk-bearing
-  untested logic (auth/gate/precedence/error-mapping/#1655).
+- **`tests`** in deep mode gives every plain "module X has no coverage" the shared
+  `cluster_key` `tests:aggregate-untested-modules` so they merge into one issue; separate
+  findings only for risk-bearing untested logic (auth/gate/precedence/error-mapping/#1655).
 
 Adding a dimension means: add it to the matrix, describe its disjoint lens in the shared
 prompt, and the synthesis picks up its `findings-<dim>.json` automatically.
@@ -64,12 +74,12 @@ missing tests on non-risk logic, cosmetic gaps. The synthesis emits a section pe
 dimension (fixed order: Correctness, Features, Docs, Tests), grouping each
 finding under the dimension it **declares** — it never re-buckets.
 
-## Child issues are 🔴/🟠 only, and tagged auto-fixable
+## Only 🔴/🟠 get an issue — 🟡 lives in the job summary
 
-Only high/medium findings get a child issue (and thus one-click `bug`→auto-fix promotion).
-🟡 (low) findings are listed in the parent triage issue and nowhere else — this caps
-tracker churn (the first deep run filed 19 children, ~13 of them low-value coverage nits).
-Each finding carries an `auto_fixable` boolean; the child body says whether applying `bug`
+Only high/medium defects are filed (and thus get one-click `bug`→auto-fix promotion). 🟡
+(low) findings appear in the run's job-summary report and nowhere else — this caps tracker
+churn; the first deep run filed 19 issues, ~13 of them low-value coverage nits. Each
+finding carries an `auto_fixable` boolean, and the issue body says whether applying `bug`
 will let auto-fix land it (locatable/small) or whether it needs a human (a test suite, a
 refactor) — so maintainers don't promote something auto-fix can't handle.
 
@@ -91,10 +101,9 @@ What each side owns:
   `severity` (file it 🟡 and say so in `why`), never by dropping the item.
 - **Synthesis**: the real gate. Drops any finding at any severity whose evidence doesn't
   substantiate its title, re-reads the cited `path`/`symbol` for every 🔴/🟠 before
-  filing, demotes over-stated findings rather than deleting them, collapses an
-  implausible flood on one area into a single finding, and does an **intra-run
-  cross-dimension dedup** (a stubbed command flagged by both `docs` and `correctness` is
-  ONE issue, not two — keep the most severe, note the other lens).
+  filing, and demotes over-stated findings rather than deleting them. The *mechanical*
+  half of its old job — merging one defect's locations, including across dimensions —
+  now happens before it, in the deterministic dedup pass below.
 
 If the tracker gets noisy, tighten synthesis. Do not re-muzzle the lenses.
 
@@ -106,48 +115,87 @@ broke and who it hurts, in plain words; the `path:line` evidence goes underneath
 sub-bullet or a `<details>` block. A finding that opens with a symbol name is one a
 triager skips.
 
-## Dedup + suppression — the single biggest usability risk
+## ONE ISSUE PER DEFECT — the invariant everything else serves
 
-Each finding carries `dedup_key = <dimension>:<repo-relative-path>:<symbol-or-section>`.
-**The symbol is a function/class name or doc heading — NEVER a line number** (line numbers
-move, so a line-based key re-files the same finding every run and the issue is unusable by
-week 3). The key is embedded in each child body as `<!-- audit-key: KEY -->`. Synthesis
-skips a finding whose key is in EITHER set:
-- **already-filed** — keys on any *open* `weekly-audit` issue (avoid duplicates).
-- **suppressed-forever** — keys on any `weekly-audit` issue also labeled **`audit-wontfix`**
-  (open or closed). This is how you permanently silence accepted debt: close a child with
-  `audit-wontfix` and it never comes back. Without this, wontfix findings resurface every
-  deep run forever.
+A defect is what a maintainer **fixes**, not where they see it. One root cause spanning 39
+files is one fix, so it gets ONE issue listing 39 locations. Both halves of this have
+already broken, in a single night each: file-scoped keys turned one dead
+`lemonade-server serve` command into five issues, and dedup that searched only the
+`weekly-audit` label could not see the four-month-old #1077, so the audit re-discovered it
+14 times.
 
-## Parent triage issues accumulate — the workflow NEVER closes one
+Every finding carries **two** keys, and they are not interchangeable:
 
-Each run files a NEW parent (`Nightly audit — <mode> — <run_id>`; synthesis also matches the legacy `Weekly audit — ` prefix so the chain survives the rename) and **cross-links the
-most recently created open parent** with a comment ("Follow-up audit run filed as #N —
-stays OPEN until its findings are addressed") — it does **not** close it. An earlier
-version auto-closed the previous parent as "superseded," which silently hid an epic's
-still-open child findings the moment the next run fired (#2010: 18 unaddressed children
-went dark). Only a **human maintainer** may close a parent, and only after its findings
-are addressed. Child issues stay open regardless (they're the actionable units) — that
-was already true and is unchanged.
+- **`cluster_key` = `<dimension>:<root-cause-slug>`** identifies the DEFECT and contains
+  **no path**. Every location of one defect carries the *identical* key and merges into
+  one issue. The test the lens prompt gives: *how many separate PRs would fix all of
+  this?* — that is how many cluster keys there should be.
+- **`dedup_key` = `<dimension>:<path>:<symbol-or-section>`** identifies the LOCATION. The
+  symbol is a function/class name or doc heading, **NEVER a line number** (line numbers
+  move, so a line-based key re-files the same finding every run).
 
-Since parents are never auto-closed, there can be several open `Nightly audit —` (and legacy `Weekly audit —`) issues at
-once; synthesis always cross-links the highest-numbered (most recent) one, never assumes
-there's "at most one." The tradeoff is deliberate: parents pile up until a maintainer
-closes them, trading tracker tidiness for guaranteeing unaddressed findings stay visible.
-The parent opens with a one-line tally (new/low/suppressed counts) for trend. On a
-zero-new-findings run, synthesis posts nothing and does not touch any prior parent.
+Filed issues embed both as `<!-- audit-cluster: KEY -->` and `<!-- audit-key: KEY -->`, and
+the dedup pass reads *either* marker — that back-compatibility is what stopped the
+two-key change from re-filing the ~130 findings already open.
+
+**`scripts/audit/prepare_synthesis.py` is the dedup pass**, run by the `synthesize` job of
+both this workflow and the doc walkthrough, *before* the Claude filing step. It merges
+findings by `cluster_key`, searches the **whole open backlog** (not one label) for an issue
+already tracking each defect, flags likely sibling clusters within a run, and writes
+`synthesis-dossier.md` as the model's worklist. It is deterministic on purpose: asking a
+model to eyeball dedup across ~900 open issues produced a 2.35x duplication ratio. Do not
+move this back into the prompt, and do not narrow the search back to one label.
+
+Synthesis then picks exactly one of three outcomes per defect: **drop** it (the evidence
+gate), **comment** on the existing backlog issue the dossier surfaced, or **file one** new
+issue. Commenting is the #1077 fix — err toward it, because a comment on the wrong issue
+is trivially undone and a duplicate issue is what created this backlog.
+
+**Suppression is load-bearing, and it is now SCOPED to the key that carries it.** Closing
+an issue with **`audit-wontfix`** (open or closed) is still the only way to permanently
+silence accepted debt, but which key that issue carries decides how much it silences:
+
+- an **`audit-cluster`** key silences the whole defect — it never comes back;
+- an **`audit-key`** silences only that one location; the defect's other locations still
+  get filed, minus the suppressed one.
+
+Two matching rules follow the same split, and both exist because the naive version loses
+real findings: one old per-file wontfix must not mute a defect later found in 38 more
+places, and a single months-old issue must not make 38 newly-found locations vanish. So a
+location-key match against an *open* issue leaves the defect `new` and hands the issue
+number to synthesis as a **comment** target — which is also how the ~130 pre-clustering
+one-issue-per-file findings get consolidated instead of orphaned.
+
+## No run receipts — the per-run report is a job summary
+
+Neither this workflow nor the doc walkthrough files a `Nightly audit — <run-id>` /
+`Doc walkthrough — <run-id>` issue. Synthesis writes `triage-report.md` and a following
+step appends it to `$GITHUB_STEP_SUMMARY`. There is no parent issue, no chain, no
+cross-linking a prior run, and no "never close a parent" rule — that whole mechanism is
+gone. It filed one bookkeeping issue per run and accumulated 19 of them, none actionable.
+
+The report is a one-line tally (filed / commented / low / dropped) then a section per
+dimension in fixed order — Correctness, Features, Docs, Tests — with each defect under the
+dimension it **declares**, never re-bucketed, and 🔴 → 🟠 → 🟡 within a section. 🟡 lines
+live here and nowhere else. The publishing step is plain bash under `if: always()`, so the
+report survives a synthesis step that errored after writing it.
+
+**Still enforced: the workflow never closes an issue.** Only a human does. An earlier
+version auto-closed the previous parent as "superseded" and silently hid 18 unaddressed
+findings the moment the next run fired (#2010). The parents are gone; the no-auto-close
+rule outlives them and applies to every issue the audits file or comment on.
 
 ## Security is out of scope here — it has its own workflow
 
 Security moved to `.github/workflows/claude-security-audit.yml` (see its own patterns
-skill). This audit files to a **public** triage issue, which is the wrong channel for a
+skill). This audit files **public** issues, which is the wrong channel for a
 vulnerability — so the prompt now tells every lens to hand off any security issue it
 notices rather than file it, and the synthesis emits **no** security section. Do not
-re-add a security dimension here or route a security finding into the public issue.
+re-add a security dimension here or route a security finding into a public issue.
 
 ## Promotion: `bug` label → existing auto-fix job
 
-Child issues are opened **without** any auto-fix trigger label. A maintainer promotes
+Filed issues are opened **without** any auto-fix trigger label. A maintainer promotes
 one to a PR by applying the **`bug`** label; the existing `auto-fix` job in
 `claude.yml` (gated on `label.name == 'bug'` **and** `contains(labels,'bug')`) then
 creates the branch + PR. There is **no PR-creation code in this workflow** — humans
@@ -183,7 +231,27 @@ route promotions through `bug` unless you deliberately widen the auto-fix `if`.
   "simplify" it back to a day-of-month check.
 - **Read-only**: dimension + synthesis jobs run `--allowedTools Read,Grep,Glob,Bash` —
   no Edit/Write, never install or run repo code (same rule as `claude.yml` review jobs).
-- **Concurrency group** `claude-weekly-audit` (not cancel-in-progress) so two scheduled
+- **A partial sweep never synthesizes.** Every lens writes `{"findings": []}` even when
+  clean, so a missing file means the lens never ran: the upload fails on it, and synthesis
+  hard-fails if fewer files arrive than `preflight` declared dimensions. The doc
+  walkthrough gained the same gate per discovered guide (#3058) — without it a night where
+  every judge crashed reached synthesis, found nothing to file, and reported a clean run.
+- **Concurrency group** `claude-nightly-audit` (not cancel-in-progress) so two scheduled
   runs never overlap and double-file.
-- Auth is the same OAuth-preferred / API-key-fallback wiring as every `claude.yml` job,
-  covered by `claude-auth-canary.yml`.
+- **`dry_run` dispatch input** (both this workflow and the doc walkthrough): files and
+  comments nothing, and reports what it *would* have done in the job summary. This is the
+  only way to validate a dedup change against the live backlog without polluting it — a
+  bad dedup pass files dozens of duplicates, which is expensive to undo and untestable any
+  other way. Don't remove it.
+- Auth is the same OAuth-preferred / API-key-fallback wiring as every `claude.yml` job.
+  `claude-auth-canary.yml` covers the *credentials* — it does **not** cover the actor gate
+  below, because the canary runs on dispatch with a human actor.
+- **`allowed_bots` must name every bot that can actor a schedule event.** On `schedule`
+  the actor is whoever last touched the default branch: `github-merge-queue[bot]` normally,
+  `github-actions[bot]` after a release workflow commits. A bot missing from the list means
+  claude-code-action rejects the run *before Claude starts* — and the run still reports
+  green. That failure went unnoticed for five weeks, and then recurred when the fix was
+  applied to the canary but not the six other steps (#3059). Every
+  `anthropics/claude-code-action` step in a scheduled workflow now needs
+  `allowed_bots: "github-merge-queue,github-actions"`;
+  `tests/unit/test_claude_audit_workflow_contract.py` fails if one drops it.

--- a/.github/workflows/claude-nightly-audit.yml
+++ b/.github/workflows/claude-nightly-audit.yml
@@ -7,11 +7,30 @@
 # page, a code path with no test, a silent `except Exception: pass`, a cli.mdx that
 # drifted from the real flags) sits unnoticed until a user hits it. This workflow is
 # the missing proactive lens: a scheduled deep review that fans out one Claude job
-# per dimension, then files ONE ranked triage issue + per-finding child issues.
+# per dimension, then files ONE issue per DEFECT.
+#
+# NAMING: the filename, `name:`, and cron all say NIGHTLY, because it is nightly. The
+# `weekly-audit` LABEL keeps its name deliberately — it is a PROVENANCE label ("a
+# proactive Claude audit filed this"), shared with the genuinely-weekly
+# claude-weekly-doc-walkthrough.yml, so no cadence word fits it. Nothing depends on the
+# label's spelling any more: dedup reads the audit-key/audit-cluster markers and searches
+# the whole open backlog, not one label.
 #
 # HUMAN-GATED — NOT an auto-merge bot. The workflow produces *findings*, never
-# commits. To turn a child issue into a PR, a maintainer applies the `bug` label and
+# commits. To turn an issue into a PR, a maintainer applies the `bug` label and
 # the existing auto-fix job (claude.yml) takes over. No new PR-creation code here.
+#
+# ONE ISSUE PER DEFECT, NOT PER LOCATION. A defect spanning 39 files is ONE fix, so it
+# gets ONE issue listing 39 locations. Lenses key findings by ROOT CAUSE (`cluster_key`);
+# scripts/audit/prepare_synthesis.py merges every location of a cluster, then searches
+# the WHOLE open backlog — not just this workflow's own label — for an issue already
+# tracking it. Both halves are load-bearing: file-scoped keys turned one dead command
+# into 5 issues in a night, and label-scoped dedup made the 4-month-old #1077 invisible,
+# so the audit re-discovered it 14 times in a single run.
+#
+# NO RUN RECEIPTS. The per-run summary goes to $GITHUB_STEP_SUMMARY, never a new issue.
+# Filing a bookkeeping issue per run accumulated 19 of them in the tracker with nothing
+# actionable in any of them.
 #
 # MODES:
 #   normal (6 nights/wk) — reviews the last N days of merged work (window_days, default
@@ -37,8 +56,9 @@
 #                 invocation, not call validity (CLAUDE.md "#1655" boundary rule).
 #   features    — half-finished follow-ups, TODO-as-placeholder, gaps a recent feature implies.
 #
-# A synthesis job collects the four structured outputs, dedupes against already-open
-# `weekly-audit` issues via a stable per-finding key, ranks by severity, and files output.
+# A synthesis job collects the four structured outputs, runs them through the
+# deterministic dedup pass (scripts/audit/prepare_synthesis.py), and files one issue per
+# surviving defect.
 #
 # MODEL: claude-opus-5 (Claude Opus 5) — excellent for static review at half the token
 # burn of Fable ($5/$25 vs $10/$50 per MTok), and priced identically to the Opus 4.8 it
@@ -102,6 +122,14 @@ on:
         # 1, not 7: the schedule is nightly, so each run should audit the day that just
         # passed. Leaving this at 7 would re-audit the same week seven times over.
         default: "1"
+      dry_run:
+        # Files and comments NOTHING; writes what it WOULD have filed to the job summary.
+        # This is how you validate a dedup change against the real backlog without adding
+        # to it — the failure mode being guarded here is a bad dedup pass filing dozens of
+        # duplicates, which is expensive to undo and impossible to test any other way.
+        description: "Report what would be filed, without touching the tracker"
+        type: boolean
+        default: false
 
 # Least-privilege default. Only the synthesis job files issues, via its own
 # per-job `issues: write`. The dimension jobs are read-only.
@@ -111,7 +139,7 @@ permissions:
 # Never let two scheduled runs overlap — they would race-evict each other's model
 # slot and double-file issues. Not cancel-in-progress: let an in-flight run finish.
 concurrency:
-  group: claude-weekly-audit
+  group: claude-nightly-audit
   cancel-in-progress: false
 
 env:
@@ -289,11 +317,10 @@ jobs:
               mode, do NOT file a separate finding for every large module that merely lacks tests
               — that floods the tracker.** File separate findings only for untested RISK-BEARING
               logic: auth/token handling, a release or trust gate, flag/precedence dispatch,
-              error-to-exit mapping, or the #1655 mock-only pattern. Roll all the plain
-              "module X has no coverage" cases into ONE aggregate finding titled
-              "Untested modules (deep sweep)", listing them in `why`, with
-              `dedup_key` = `tests:aggregate:untested-modules`. In NORMAL mode, focus on
-              new/changed code paths from the scope file.
+              error-to-exit mapping, or the #1655 mock-only pattern. Give every plain
+              "module X has no coverage" case the shared `cluster_key`
+              `tests:aggregate-untested-modules` so they merge into one issue. In NORMAL
+              mode, focus on new/changed code paths from the scope file.
 
             ## Published hub agents — HOLD TO THE HIGHEST BAR
             Published agents are the project's shop window — an integrator installs them and
@@ -345,16 +372,42 @@ jobs:
                 "why": "one sentence: the concrete impact / what breaks",
                 "evidence": "a direct quote or `path:line` you READ that proves the claim — enough for a reviewer to verify without re-deriving. e.g. \"auditStore.ts:88 sets `rolledBack = true` with a `// TODO: call IPC` and no IPC call\"",
                 "auto_fixable": true | false,
+                "cluster_key": "${{ matrix.dimension }}:<root-cause-slug>",
                 "dedup_key": "${{ matrix.dimension }}:<repo-relative-path>:<symbol-or-section>"
               }
             ]}
             ```
 
-            The `dedup_key` MUST be `${{ matrix.dimension }}:<path>:<symbol>` — a stable
-            function/class name or doc heading, NEVER a line number (line numbers move and
-            would re-file the same finding every week). Line numbers may appear in `title`/`why`,
-            never in the key. **`title`, `path`/`symbol`, and `dedup_key` must all point at the
-            SAME file and symbol** — don't let the title name one file and the key another.
+            ### `cluster_key` — ONE KEY PER DEFECT. This is the most important field.
+            A defect is what a maintainer FIXES, not where they see it. If the same root
+            cause shows up in 39 files, that is **one** defect with 39 locations, and every
+            one of those 39 findings carries the **identical** `cluster_key`. Everything
+            sharing a key is merged into a single issue automatically, so you do not have
+            to hold back: emit one finding per LOCATION with the shared key, and let the
+            merge do the collapsing.
+
+            The key is a short slug naming the CAUSE, with no path in it:
+            - `docs:lemonade-server-serve-command-removed` — one dead command, cited in
+              163 places across 106 files. ONE key. (This really happened and became five
+              separate issues in one night because keys were file-scoped.)
+            - `docs:guide-prerequisites-missing-extras` — 14 guides, one omission. ONE key.
+              (This really happened too: 14 issues in one night, for a defect already
+              tracked as #1077 since May.)
+            - `correctness:silent-except-pass-in-ui-layer` — one banned pattern, many files.
+            Two findings get DIFFERENT keys only when they need different fixes. Same
+            symptom in one file and a genuinely unrelated cause elsewhere = two keys.
+
+            **Before you write the file, re-read your own findings and ask: how many
+            separate PRs would fix all of this?** That number is how many distinct
+            `cluster_key`s you should have. If you have 20 findings and one PR fixes 14 of
+            them, those 14 share a key — go back and make them share it.
+
+            ### `dedup_key` — the per-location key (unchanged)
+            `${{ matrix.dimension }}:<path>:<symbol>` — a stable function/class name or doc
+            heading, NEVER a line number (line numbers move and would re-file the same
+            finding every week). Line numbers may appear in `title`/`why`, never in a key.
+            It identifies the LOCATION; `cluster_key` identifies the DEFECT.
+
             `auto_fixable` = true only if the fix is locatable and small (~1-3 files, targeted,
             no design decision) so the `bug`→auto-fix path can land it; false if it needs a human
             (writing a test suite, a refactor, a design call).
@@ -401,9 +454,9 @@ jobs:
             fails the whole audit — partial findings written beat perfect findings lost.
 
             ## Security is out of scope — hand it off, do not file it here
-            If you notice a security weakness, do NOT file it in this audit's findings or the
-            public triage issue (that would disclose it). Security has a dedicated private-channel
-            workflow (claude-security-audit.yml). Leave it to that sweep.
+            If you notice a security weakness, do NOT put it in this audit's findings — they
+            become public issues, which would disclose it. Security has a dedicated
+            private-channel workflow (claude-security-audit.yml). Leave it to that sweep.
           claude_args: |
             --max-turns 45
             --model ${{ env.AUDIT_MODEL }}
@@ -419,9 +472,8 @@ jobs:
           # means the lens never ran. Fail the job — a silent skip reads as "audited, clean".
           if-no-files-found: error
 
-  # Collect the four dimension outputs, dedupe against open weekly-audit issues, rank,
-  # and file ONE parent triage issue + per-finding child issues. This is the only job
-  # with issues: write.
+  # Collect the four dimension outputs, run the DETERMINISTIC dedup pass over them, and
+  # file one issue per surviving defect. This is the only job with issues: write.
   synthesize:
     needs: [preflight, audit]
     # Re-assert the repo gate (custom `if` drops the needs-succeeded guard). !cancelled()
@@ -452,7 +504,7 @@ jobs:
           set -euo pipefail
           got=$(find audit-findings -name 'findings-*.json' | wc -l)
           if [ "$got" -lt "$EXPECTED_DIMENSIONS" ]; then
-            echo "::error title=Nightly audit::Only $got/$EXPECTED_DIMENSIONS dimensions produced findings files — the audit did not run. Not filing a triage issue off a partial sweep."
+            echo "::error title=Nightly audit::Only $got/$EXPECTED_DIMENSIONS dimensions produced findings files — the audit did not run. Not filing anything off a partial sweep."
             exit 1
           fi
           echo "All $got/$EXPECTED_DIMENSIONS dimensions reported in."
@@ -461,15 +513,51 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          # `weekly-audit` is a PROVENANCE label, not a cadence one — it marks "a proactive
+          # Claude audit filed this" and is shared with the genuinely-weekly doc walkthrough.
           gh label create weekly-audit --color 5319e7 \
-            --description "Proactive weekly Claude audit finding" \
+            --description "Filed by a proactive Claude audit (nightly code audit or weekly doc walkthrough)" \
             2>/dev/null && echo "created weekly-audit label" || echo "weekly-audit label already exists"
           # audit-wontfix permanently suppresses a finding — synthesis skips its key forever.
           gh label create audit-wontfix --color cccccc \
-            --description "Accepted debt — weekly audit will never re-file this finding" \
+            --description "Accepted debt — the audits will never re-file this finding" \
             2>/dev/null && echo "created audit-wontfix label" || echo "audit-wontfix label already exists"
 
-      - name: Synthesize and file the triage issue
+      # THE dedup pass. Deterministic on purpose: asking a model to eyeball dedup across
+      # ~900 open issues is what produced a 2.35x duplication ratio. This step merges every
+      # location of a `cluster_key` into one defect and searches the WHOLE open backlog for
+      # an issue already tracking it, then hands the model a short worklist whose only open
+      # question is the semantic one ("is #1077 really this defect?").
+      - name: Dedupe findings into a synthesis worklist
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          python3 scripts/audit/prepare_synthesis.py \
+            --findings-dir audit-findings \
+            --repo "${{ github.repository }}" \
+            --out synthesis-input.json \
+            --dossier synthesis-dossier.md
+          {
+            echo "## 🔁 Dedup pass"
+            echo ""
+            python3 -c "import json; c=json.load(open('synthesis-input.json'))['counts']; print(f\"{c['raw_findings']} raw findings → **{c['clusters']} distinct defects** ({c['new']} new, {c['already_filed']} already filed, {c['suppressed']} suppressed), searched {c['open_issues_searched']} open issues.\")"
+            echo ""
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      # A dry run is only prompt-enforced, and a mode that silently isn't dry is worse
+      # than no mode at all. Record the watermark now and check it afterwards.
+      - name: Record the issue watermark (dry run)
+        if: github.event.inputs.dry_run == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          gh issue list --repo "${{ github.repository }}" --state all --limit 1 \
+            --json number --jq '.[0].number // 0' > .issue-watermark
+          echo "Highest issue before synthesis: $(cat .issue-watermark)"
+
+      - name: Synthesize and file one issue per defect
         id: claude
         continue-on-error: true
         uses: anthropics/claude-code-action@a874e9ecd7bb36efdad65429c6b35815f5a08f10  # v1.0.210
@@ -480,137 +568,163 @@ jobs:
           # See the dimension job's note — scheduled runs are actored by a bot.
           allowed_bots: "github-merge-queue,github-actions"
           prompt: |
-            You are the synthesis step of GAIA's nightly proactive audit. Four dimension jobs
-            (correctness, docs, tests, features) each wrote a findings JSON file.
-            Dedupe them against already-open findings, rank them, and file the output.
+            You are the synthesis step of GAIA's nightly proactive audit. A deterministic
+            pass has ALREADY collapsed the four dimension jobs' raw findings into distinct
+            defects and searched the whole open backlog for each one. Your job is the part
+            a script cannot do: verify the evidence, decide whether a defect is genuinely
+            new or already tracked, and write for a human.
 
             REPO: ${{ github.repository }}
             AUDIT MODE: ${{ needs.preflight.outputs.mode }}
+            DRY RUN: ${{ github.event.inputs.dry_run || 'false' }}
             RUN LOG: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
 
             ## First actions
-            1. Read every `findings-*.json` under `audit-findings/` (each artifact is in its own
-               subdir, e.g. `audit-findings/findings-docs/findings-docs.json`). Missing or empty
-               files are fine — a dimension may have found nothing or crashed.
-            2. Read `CLAUDE.md` → "Issue Response Guidelines" for the tone/format to write in.
-            3. Build the **already-filed** key set (findings not to re-file):
-               `gh issue list --repo ${{ github.repository }} --label weekly-audit --state open --json number,title,body --limit 200`
-               Each body carries a hidden `<!-- audit-key: KEY -->` marker — collect those KEYs.
-            4. Build the **suppressed-forever** key set (accepted debt):
-               `gh issue list --repo ${{ github.repository }} --label weekly-audit --label audit-wontfix --state all --json body --limit 200`
-               Collect their `audit-key` KEYs too. These are permanently dismissed.
-            5. Find the **previous parent** to cross-link: parents are never auto-closed, so
-               there may now be SEVERAL currently-open issues whose title starts
-               `Nightly audit —` **or** the older `Weekly audit —` (this audit moved from a
-               weekly to a nightly cadence; match BOTH prefixes so the chain is not broken at
-               the changeover). Pick the MOST RECENTLY CREATED one (highest issue number)
-               across both. Note its number. Do NOT close it.
+            1. Read `synthesis-dossier.md` — your worklist. It has one section per NEW
+               defect, each with its locations and a ranked list of possibly-matching open
+               issues. Defects already filed or suppressed are listed at the bottom and are
+               **already handled — do not act on them at all**.
+            2. Read `CLAUDE.md` → "Issue Response Guidelines" for the tone to write in.
+            3. `synthesis-input.json` has the same data structured, if you need a field the
+               dossier elides — including the full location list when one is truncated.
+            If the dossier reports malformed findings or that the lenses barely clustered,
+            say so in the run report: that is a lens-prompt bug a human needs to see.
+            You do NOT need to re-list issues or rebuild key sets — that is done. Spend your
+            turns reading cited code instead.
 
-            ## Dedup + verify (the single biggest quality risk)
-            Reduce the raw findings to the NEW, real set, in this order:
-            1. **Suppress + skip** any finding whose `dedup_key` is in the already-filed OR the
-               suppressed-forever set. Match the exact key string — never line numbers or prose.
-            2. **Cross-dimension dedup within THIS run:** if two findings from different dimensions
-               describe the same root cause (same file + symbol/area), keep the single most-severe
-               one, mention the other lens in its body, and file just ONE child. (A stubbed command
-               is often flagged by both `docs` and `correctness` — that's one issue, not two.)
-            3. **Evidence gate — YOU ARE THE ONLY FILTER.** The lenses are instructed to
-               report everything they ground in something they read, including items they
-               are unsure about, precisely so nothing is silently withheld upstream. That
-               makes this step load-bearing: expect more raw findings than the tracker
-               should receive, and cut hard.
-               - Drop any finding at ANY severity whose `evidence` is missing, or does not
-                 actually substantiate its `title`.
-               - For every 🔴/🟠 survivor, open the cited `path`/`symbol` and confirm the
-                 problem is really there before filing. A false 🔴 costs more trust than
-                 ten dropped 🟡s.
-               - Demote rather than delete when a finding is real but overstated: a 🟠
-                 whose impact you cannot substantiate becomes 🟡 (parent-only, no child).
-               - If a lens returns an implausible flood on one file/area, treat it as one
-                 finding about that area rather than filing each line.
-            If, after all of the above, there are ZERO new findings, post NOTHING and exit
-            cleanly — do not file a parent issue, and never close or comment on a prior parent.
+            ## For each NEW defect, choose exactly one of three outcomes
 
-            ## File per-finding CHILD issues — 🔴 high / 🟠 medium ONLY (non-security)
-            Open a child issue only for NEW, verified, non-security findings whose severity is
-            🔴 or 🟠. **🟡 (low) findings get NO child issue** — they are listed in the parent
-            only (they are nits and don't warrant tracker churn or one-click promotion). Open the
-            child WITHOUT any auto-fix trigger label (do NOT add `bug`). Write the body to a temp
-            file first, then
-            `gh issue create --repo ${{ github.repository }} --label weekly-audit --title "<title>" --body-file <file>`.
-            Body format — follow CLAUDE.md → "How You Communicate": a human triages this, so
-            the title and opening line say what broke and who it hurts in plain words, and the
-            location / evidence / severity rows go in a collapsed `<details>` underneath.
-            Say each point once. The blank line after `</summary>` is REQUIRED or GitHub renders
-            the block as literal text. The audit-key marker is REQUIRED and drives the next
-            run's dedup:
+            ### (a) DROP it — the evidence gate
+            You are the only filter; the lenses deliberately over-report. Drop a defect when
+            its `evidence` is missing or does not actually substantiate its title. For every
+            🔴/🟠 survivor, open the cited path/symbol and confirm the problem is really
+            there before filing — a false 🔴 costs more trust than ten dropped 🟡s. Demote
+            rather than delete when a finding is real but overstated. **🟡 (low) defects are
+            never filed as issues** — they go in the job summary only.
+
+            ### (b) COMMENT on an existing issue — 🔴/🟠 only, check this BEFORE filing
+            The dossier lists candidate open issues per defect, drawn from the WHOLE backlog
+            — not just this audit's own label. **Open the top candidates and read them.** If
+            one already tracks this defect, comment on it instead of filing:
+            `gh issue comment <n> --repo ${{ github.repository }} --body-file <file>`
+            The comment adds only what is NEW — the extra locations this run found, or fresh
+            evidence — and never restates the issue. Include the marker line so future runs
+            match it by key: `<!-- audit-cluster: <cluster_key> -->`.
+            A candidate counts as a match when the same FIX would close both. The 4-month-old
+            #1077 ("Guide prerequisites missing across ~14 guides") is the canonical case:
+            the audit re-filed it 14 times in one night because it only searched its own
+            label. Err toward commenting — a comment on the wrong issue is trivially undone;
+            a duplicate issue is what created this backlog.
+
+            ### (c) FILE ONE issue — 🔴/🟠 only, non-security
+            Write the body to a temp file, then
+            `gh issue create --repo ${{ github.repository }} --label weekly-audit --title "<title>" --body-file <file>`
+            WITHOUT the `bug` label (humans gate every code change).
+
+            **One issue per DEFECT, listing every location.** A defect the dossier shows at
+            39 locations is ONE issue with 39 lines in it, never 39 issues. Its title names
+            the defect, never one file: "The documented Lemonade start command no longer
+            exists (163 places)", not "quickstart.mdx uses lemonade-server serve".
+
+            Body — follow CLAUDE.md → "How You Communicate": a human triages this, so the
+            opening line says what broke and who it hurts in plain words, and the mechanical
+            rows go in a collapsed `<details>`. The blank line after `</summary>` is REQUIRED
+            or GitHub renders the block as literal text. Both marker lines are REQUIRED —
+            they are what the next run dedupes against:
             ```
-            <one-paragraph why-this-matters: what's wrong + the concrete impact, in plain words>
+            <one paragraph: what's wrong + the concrete impact, in plain words>
 
             <details>
-            <summary>🔍 Evidence and location</summary>
+            <summary>🔍 Evidence and locations</summary>
 
-            **Where:** `path` · `symbol`   (the finding carries no line number — do not invent one)
-            **Evidence:** <the finding's `evidence` — the concrete proof a reviewer can check>
-            **Dimension:** <the finding's own dimension>   **Severity:** 🔴 high / 🟠 medium
+            **Severity:** 🔴 high / 🟠 medium   **Lens:** <dimension(s)>
             **Auto-fixable:** yes — apply `bug` to let auto-fix open the PR  |  no — needs a human
+
+            | Where | Evidence |
+            |---|---|
+            | `path` · `symbol` | <that location's evidence> |
             </details>
 
             Not acting on this? Close it with the `audit-wontfix` label and the audit will never
             re-file it. Applying `bug` instead hands it to the existing auto-fix job.
 
-            <!-- audit-key: <the finding's dedup_key> -->
+            <!-- audit-cluster: <cluster_key> -->
+            <!-- audit-key: <the first location's dedup_key> -->
             ```
-            Set the Auto-fixable line from the finding's `auto_fixable` field. Capture each child
-            issue number to reference from the parent.
+            List up to 20 locations in the table; if there are more, add a final row saying
+            how many were elided and where to grep. Set Auto-fixable from `auto_fixable`.
 
-            ## File ONE parent TRIAGE issue
-            Title: `Nightly audit — ${{ needs.preflight.outputs.mode }} — ${{ github.run_id }}`.
-            Label it `weekly-audit`. **Emit a section for EVERY dimension that has at least one
-            finding, in this fixed order: Correctness, Features, Docs, Tests.** Group
-            each finding under the dimension IT declares in its JSON — NEVER re-bucket a
-            correctness finding under features (the `dimension` field is authoritative). Within a
-            section, order 🔴 → 🟠 → 🟡 and prefix each line with its severity emoji. 🔴/🟠 lines
-            link their child issue (`· #<n>`); 🟡 lines have no child (they live only here). Example:
+            ## Write the run report to `triage-report.md` — NOT to an issue
+            A following step appends this file to the run's job summary. **Do not file a
+            "Nightly audit — <run-id>" issue; that convention is gone** — 19 such bookkeeping
+            issues accumulated in the tracker with nothing actionable in any of them. The
+            old parent-chain bookkeeping is gone with it: do not cross-link a previous run's
+            issue, and never close one. (Commenting on a backlog issue that tracks a real
+            defect — outcome (b) above — is a different thing, and is encouraged.)
+
+            Write `triage-report.md` with a one-line tally then a section per dimension in
+            this fixed order — Correctness, Features, Docs, Tests — filing each defect under
+            the lens the dossier lists for it (its `lens/doc` line). A merged defect found by
+            two lenses goes under the more severe one's section, named once, never twice.
+            Order 🔴 → 🟠 → 🟡 within a section. 🟡 lines live here and nowhere else.
             ```
-            Proactive nightly audit (${{ needs.preflight.outputs.mode }} mode). Promote a finding
-            to a PR by applying the `bug` label to its child issue. Severity: 🔴 high · 🟠 medium · 🟡 low.
+            ### Nightly audit — ${{ needs.preflight.outputs.mode }} mode
+            Filed: 3 new (🔴 1 · 🟠 2) · commented on existing: 2 · low (report-only): 4 · dropped on evidence: 6
 
-            ## Correctness (2)
-            - [ ] 🔴 `rollbackAction` flips rolledBack=true but never calls the IPC — a fake success · #<n>
-            - [ ] 🟠 `except Exception: pass` swallows the Lemonade timeout in `foo.py` · #<n>
-            ## Docs (1)
-            - [ ] 🟠 `gaia api status` documented in cli.mdx but the impl is a stub · #<n>
-            ## Tests (1)
-            - [ ] 🟡 `perf_analysis.py` has no coverage
+            #### Correctness
+            - 🔴 `rollbackAction` flips rolledBack=true but never calls the IPC — #<n>
+            - 🟡 `perf_analysis.py` swallows a KeyError (report-only, no issue)
+            #### Docs
+            - 🟠 Lemonade start command is dead in 163 places — commented on existing #<n>
             ```
-            Start the parent body with a one-line tally so trend is visible at a glance, e.g.
-            `New this run: 4 (🔴 1 · 🟠 3) · low (in-parent only): 2 · suppressed as dup/wontfix: 9`.
-            Security is not a dimension here (see claude-security-audit.yml) — do not emit a
-            security section, and if any dimension's findings JSON contains a security issue,
-            omit it rather than disclosing it in this public issue.
 
-            ## Cross-link the previous parent (NEVER close it)
-            After filing the new parent, comment on the previous parent you found in
-            First-actions step 5 so readers can follow the chain — but leave it OPEN:
-            `gh issue comment <prev-parent-#> --repo ${{ github.repository }} --body "Follow-up audit run filed as #<new-parent-#>. This issue stays OPEN until its findings are addressed — only a maintainer should close it."`
-            Child issues stay OPEN too — they are the actionable units. Parents now
-            accumulate across runs by design, so unaddressed findings stay visible: only a
-            human maintainer closes a parent, and only after its findings are addressed.
-            Never call `gh issue close` on a parent from this workflow.
+            ## If DRY RUN is true
+            Run NO `gh issue create` and NO `gh issue comment` — file and comment nothing.
+            Do everything else, and in `triage-report.md` write what you WOULD have done
+            (`would file:` / `would comment on #<n>:`) so the dedup pass can be validated
+            against the real backlog without adding to it.
 
             ## Rules
             - No Claude attribution anywhere (no "Generated with", no Co-Authored-By).
-            - Do not open any PR and do not apply the `bug` label — humans gate every code change.
-            - Never close a parent triage issue — only a human maintainer closes one, after its
-              findings are addressed.
-            - Lead with the finding; keep each line to one sentence (CLAUDE.md issue style).
-            - Never collapse a security concern or a @kovtcharov-amd tag inside `<details>` —
-              those stay visible in the summary.
+            - Do not open any PR and do not apply the `bug` label.
+            - Never close any issue.
+            - Security is not a dimension here (see claude-security-audit.yml). If a findings
+              JSON contains a security issue, omit it rather than disclosing it publicly.
+            - Never collapse a security concern or a @kovtcharov-amd tag inside `<details>`.
           claude_args: |
             --max-turns 32
             --model ${{ env.AUDIT_MODEL }}
             --allowedTools Read,Grep,Glob,Bash
+
+      - name: Prove the dry run filed nothing
+        if: always() && github.event.inputs.dry_run == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          before=$(cat .issue-watermark)
+          created=$(gh issue list --repo "${{ github.repository }}" --state all \
+            --limit 100 --json number --jq "[.[] | select(.number > $before) | .number] | join(\", \")")
+          if [ -n "$created" ]; then
+            echo "::error title=Dry run was not dry::The synthesis step created issue(s) $created despite dry_run=true. Close them, then fix the dry-run instruction in the prompt."
+            exit 1
+          fi
+          echo "✅ Dry run confirmed: no issue created above #$before."
+
+      # The run receipt. This replaces the per-run "Nightly audit — <run-id>" ISSUE that
+      # used to be filed: a CI run's bookkeeping belongs in the run, not the tracker.
+      # Deterministic, so the report survives a synthesis step that errored after writing it.
+      - name: Publish the triage report to the job summary
+        if: always()
+        run: |
+          set -euo pipefail
+          if [ -f triage-report.md ]; then
+            cat triage-report.md >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "## ⚠️ No triage report" >> "$GITHUB_STEP_SUMMARY"
+            echo "" >> "$GITHUB_STEP_SUMMARY"
+            echo "The synthesis step wrote no \`triage-report.md\`. See the step status below." >> "$GITHUB_STEP_SUMMARY"
+          fi
 
       - name: Verify the audit filed output
         if: always()

--- a/.github/workflows/claude-security-audit.yml
+++ b/.github/workflows/claude-security-audit.yml
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: MIT
 #
 # Proactive Claude SECURITY audit. A dedicated, security-only companion to
-# claude-weekly-audit.yml (which now owns correctness/docs/tests/features). It
+# claude-nightly-audit.yml (which now owns correctness/docs/tests/features). It
 # exists because the weekly audit's single general "security lens" missed the hub
 # tar-slip (CWE-22): it sampled a huge repo in one pass and trusted a
 # `# noqa: S202 - hub artifacts are trusted` comment as a settled decision.
@@ -41,7 +41,7 @@ on:
     # so one fixed hour cannot be the same local time year-round; the 1h winter drift is
     # accepted. The off-the-hour minute avoids the ":00" fleet-wide queue.
     #
-    # Deliberately ~1.4h BEFORE claude-weekly-audit.yml's nightly 10:37 UTC slot — the two
+    # Deliberately ~1.4h BEFORE claude-nightly-audit.yml's nightly 10:37 UTC slot — the two
     # proactive Claude runs must not stack on the shared subscription rate limit, and this
     # one goes first because it is the shorter job (deterministic semgrep + a single
     # Claude sweep, vs. four serialized lenses + synthesis).
@@ -71,7 +71,7 @@ jobs:
   # turns + synthesis (~$4-6 of subscription-equivalent usage per lens at the
   # ceiling); running that unconditionally every night would burn the shared
   # subscription pool re-reading an unchanged tree. Mirrors the skip-if-empty
-  # preflight in claude-weekly-audit.yml.
+  # preflight in claude-nightly-audit.yml.
   #
   # semgrep is deliberately NOT gated on this — it is cheap, deterministic, and
   # its rulesets update independently of this repo, so it still has something to

--- a/.github/workflows/claude-weekly-doc-walkthrough.yml
+++ b/.github/workflows/claude-weekly-doc-walkthrough.yml
@@ -1,7 +1,7 @@
 # Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
 # SPDX-License-Identifier: MIT
 #
-# Execution-based sibling to claude-weekly-audit.yml (see docs/plans/
+# Execution-based sibling to claude-nightly-audit.yml (see docs/plans/
 # weekly-doc-walkthrough-audit.md and docs/plans/weekly-claude-audit.md's
 # "Non-goals"). That workflow is deliberately static (read-only, never installs
 # or runs repo code) -- this one exists because that non-goal has a real blind
@@ -14,13 +14,23 @@
 # Lemonade instance -- never the runner's shared, CI-warmed install (see
 # "Execution environment" in the design doc for why that distinction matters).
 #
-# STANDALONE from claude-weekly-audit.yml on purpose: different runner
+# STANDALONE from claude-nightly-audit.yml on purpose: different runner
 # (self-hosted Windows vs. ubuntu-latest), different cost/runtime profile
 # (hours, not minutes -- deliberate; see design doc "Cadence"), different
 # failure modes (a live command can hang). Isolating them means a stuck
-# walkthrough never delays the fast static audit's triage issue. Shares
-# vocabulary with it (severity scale, dedup-key pattern, weekly-audit label,
-# bug-label auto-fix promotion) but files its OWN parent issue.
+# walkthrough never delays the fast static audit. Shares vocabulary with it
+# (severity scale, cluster/dedup keys, weekly-audit label, bug-label auto-fix
+# promotion) and the same deterministic dedup pass,
+# scripts/audit/prepare_synthesis.py.
+#
+# CROSS-GUIDE DEDUP IS LOAD-BEARING HERE. The per-guide judges below are blind to
+# each other, so one broken thing arrives as N differently-worded findings. Only
+# the synthesize job can see all of them, and it is where they merge into ONE
+# issue -- five guides quoting a single dead Lemonade command previously became
+# five issues in one night. Do not move filing back into the matrix jobs.
+#
+# NO RUN RECEIPTS. The per-run summary goes to $GITHUB_STEP_SUMMARY, never a new
+# issue.
 #
 # EXECUTOR / JUDGE SPLIT: the executor walks each guide (high tool-call volume,
 # grinding sequential work); a SEPARATE judge pass scores the transcript (low
@@ -100,6 +110,13 @@ on:
       doc_filter:
         description: "Glob to scope this run to one or a few docs (e.g. docs/quickstart.mdx). Empty = all discovered docs."
         default: ""
+      dry_run:
+        # Files and comments NOTHING; writes what it WOULD have filed to the job summary.
+        # This is how you validate a dedup change against the real backlog without adding
+        # to it — see the same input on claude-nightly-audit.yml.
+        description: "Report what would be filed, without touching the tracker"
+        type: boolean
+        default: false
 
 permissions:
   contents: read
@@ -471,7 +488,7 @@ jobs:
       # run -- which is correct -- but it also means the job can look green
       # in the Actions UI while the executor actually failed. Surface that
       # explicitly: check the action's own execution_file (same technique
-      # claude-weekly-audit.yml's synthesis job uses), and independently
+      # claude-nightly-audit.yml's synthesis job uses), and independently
       # confirm the transcript the judge depends on actually exists.
       - name: Report executor status
         if: always()
@@ -487,7 +504,7 @@ jobs:
           # line by line makes every line invalid and silently reports a healthy run
           # as crashed. Scan the whole text and keep the LAST is_error, matching the
           # bash `jq -s '[.. | objects | select(has("is_error")) | .is_error] | .[-1]'`
-          # claude-weekly-audit.yml uses on ubuntu.
+          # claude-nightly-audit.yml uses on ubuntu.
           $ok = $false
           if ($env:EXEC_FILE -and (Test-Path $env:EXEC_FILE)) {
             $raw = Get-Content -Raw $env:EXEC_FILE
@@ -539,8 +556,13 @@ jobs:
             set by an earlier step in this job (check your Bash tool's shell to read it --
             `$env:RUN_DIR` in PowerShell, `$RUN_DIR` in a POSIX shell; not confirmed which
             this runner's tool uses at authoring time). If the file is missing, the
-            executor crashed before writing it -- file ONE 🟠 finding for that, dedup_key
-            `walkthrough:${{ matrix.doc.path }}:executor-crash`, and stop.
+            executor crashed before writing it -- file ONE 🟠 finding for that and stop.
+            It needs EVERY field the schema at step 5 lists (a finding missing one is
+            rejected): `severity` 🟠, `title`, `why`, `evidence` (say the file is absent),
+            `path`, `symbol`, `auto_fixable` false, `dedup_key`
+            `walkthrough:${{ matrix.doc.path }}:executor-crash`, and `cluster_key`
+            `walkthrough:executor-crash` — that shared cluster key merges every guide whose
+            executor died into one issue instead of one issue per guide.
 
             ## What to do
             1. Read `${{ matrix.doc.path }}` and the transcript file above, in full.
@@ -558,7 +580,7 @@ jobs:
                skip it. A step that failed and did NOT reproduce cleanly on retry (i.e.
                failed twice) IS eligible.
             5. Write findings to `findings-walkthrough-${{ matrix.doc.slug }}.json`
-               (repo root), same shape `claude-weekly-audit.yml` uses:
+               (repo root), same shape `claude-nightly-audit.yml` uses:
                ```json
                {"findings": [
                  {
@@ -569,6 +591,7 @@ jobs:
                    "why": "one sentence: the concrete impact / what breaks",
                    "evidence": "the exact transcript excerpt (command + captured output) proving the claim",
                    "auto_fixable": true | false,
+                   "cluster_key": "docs:<root-cause-slug>",
                    "dedup_key": "walkthrough:${{ matrix.doc.path }}:<step-heading>"
                  }
                ]}
@@ -578,6 +601,27 @@ jobs:
                false but the underlying command doesn't crash; 🟡 a cosmetic/minor gap
                (a missing caveat, a stale example). `auto_fixable` = true only if the fix
                is small and locatable (~1-3 files, no design call).
+
+               ### `cluster_key` — name the CAUSE, so guides you cannot see can merge with you
+               You are one of many parallel judges, each walking a different guide and
+               blind to the others. The same underlying defect usually breaks several
+               guides at once, and it is ONE fix — so a synthesis step merges findings that
+               share a `cluster_key`, and the maintainer gets one issue instead of five.
+               (Five guides quoting one dead command really did become five issues in a
+               single night.)
+
+               So write `cluster_key` as a short kebab-case slug describing **what is
+               broken in the product or in every guide**, with **no doc path, no guide
+               name, and no step heading in it** — those go in `dedup_key`. Ask: "if
+               another judge hit this exact problem in a different guide, would they write
+               this same slug?" If the slug mentions your guide, they would not.
+               - ✅ `docs:lemonade-server-serve-command-removed`
+               - ✅ `docs:missing-extras-in-prerequisites`
+               - ✅ `docs:gaia-chat-needs-chat-agent-package`
+               - ❌ `docs:quickstart-step-2-fails` (names your guide and step, merges with nothing)
+               Prefer the most obvious plain-English name for the cause; two judges
+               converge on `lemonade-server-serve-command-removed` far more often than on
+               a clever one.
 
                This file IS the deliverable. You have no Write tool: create it with Bash
                (a `cat > … <<'JSON'` heredoc). An empty `{"findings": []}` is a valid,
@@ -668,11 +712,10 @@ jobs:
           # means the judge never ran. Fail — a silent skip reads as "walked, all good".
           if-no-files-found: error
 
-  # Collect every matrix job's findings, dedupe against open weekly-audit
-  # issues, and file ONE parent triage issue + per-finding child issues.
-  # Same conventions as claude-weekly-audit.yml's synthesis job (label
-  # scheme, dedup-key marker, evidence gate, cross-link-never-close
-  # lifecycle) -- see the weekly-audit-patterns skill.
+  # Collect every matrix job's findings, run the deterministic dedup pass over
+  # them, and file ONE issue per surviving defect. Same conventions as
+  # claude-nightly-audit.yml's synthesis job (label scheme, cluster/dedup keys,
+  # evidence gate, job-summary report) -- see the weekly-audit-patterns skill.
   synthesize:
     needs: [discover, walkthrough]
     if: github.repository == 'amd/gaia' && !cancelled() && needs.discover.outputs.docs != '[]'
@@ -721,18 +764,71 @@ jobs:
           echo "**$total_files findings file(s) reported in, $total_findings raw finding(s) before dedup/verification.**" >> "$GITHUB_STEP_SUMMARY"
           echo "Reported in: $total_files files, $total_findings raw findings before dedup"
 
+      # The static audit has always refused to synthesize off a partial sweep; the
+      # walkthrough only tallied and carried on, so a night where every guide's judge died
+      # reached synthesis with zero findings and reported "nothing to file" — a crash
+      # reading as a pass (#3058). Every discovered doc writes a findings file even when
+      # clean, so a short count means guides went unwalked. Fail instead of filing.
+      - name: Require every discovered doc to have reported in
+        env:
+          EXPECTED_DOCS: ${{ needs.discover.outputs.docs }}
+        run: |
+          set -euo pipefail
+          expected=$(printf '%s' "$EXPECTED_DOCS" | python3 -c 'import json,sys; print(len(json.load(sys.stdin)))')
+          got=$(find walkthrough-findings -name 'findings-walkthrough-*.json' | wc -l)
+          if [ "$got" -lt "$expected" ]; then
+            echo "::error title=Doc walkthrough::Only $got/$expected guides produced findings — $((expected - got)) went unverified. Not synthesizing off a partial sweep."
+            exit 1
+          fi
+          echo "All $got/$expected guides reported in."
+
       - name: Ensure labels exist
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          # `weekly-audit` is a PROVENANCE label shared with claude-nightly-audit.yml, not a
+          # cadence one. See that workflow's header for why it keeps the name.
           gh label create weekly-audit --color 5319e7 \
-            --description "Proactive weekly Claude audit finding" \
+            --description "Filed by a proactive Claude audit (nightly code audit or weekly doc walkthrough)" \
             2>/dev/null && echo "created weekly-audit label" || echo "weekly-audit label already exists"
           gh label create audit-wontfix --color cccccc \
-            --description "Accepted debt -- weekly audit will never re-file this finding" \
+            --description "Accepted debt -- the audits will never re-file this finding" \
             2>/dev/null && echo "created audit-wontfix label" || echo "audit-wontfix label already exists"
 
-      - name: Synthesize and file the triage issue
+      # Same deterministic dedup pass the nightly audit runs — and the ONLY place this
+      # workflow gets cross-guide memory. Its per-guide judges are blind to each other, so
+      # without this five guides quoting one dead command file five issues in a night.
+      # It merges shared cluster keys, flags likely siblings whose keys disagreed, and
+      # searches the WHOLE open backlog rather than just this workflow's own label.
+      - name: Dedupe findings into a synthesis worklist
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          python3 scripts/audit/prepare_synthesis.py \
+            --findings-dir walkthrough-findings \
+            --repo "${{ github.repository }}" \
+            --out synthesis-input.json \
+            --dossier synthesis-dossier.md
+          {
+            echo "## 🔁 Dedup pass"
+            echo ""
+            python3 -c "import json; c=json.load(open('synthesis-input.json'))['counts']; print(f\"{c['raw_findings']} raw findings → **{c['clusters']} distinct defects** ({c['new']} new, {c['already_filed']} already filed, {c['suppressed']} suppressed), searched {c['open_issues_searched']} open issues.\")"
+            echo ""
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      # A dry run is only prompt-enforced, and a mode that silently isn't dry is worse
+      # than no mode at all. Record the watermark now and check it afterwards.
+      - name: Record the issue watermark (dry run)
+        if: github.event.inputs.dry_run == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          gh issue list --repo "${{ github.repository }}" --state all --limit 1 \n            --json number --jq '.[0].number // 0' > .issue-watermark
+          echo "Highest issue before synthesis: $(cat .issue-watermark)"
+
+      - name: Synthesize and file one issue per defect
         id: claude
         continue-on-error: true
         uses: anthropics/claude-code-action@a874e9ecd7bb36efdad65429c6b35815f5a08f10  # v1.0.210
@@ -744,90 +840,154 @@ jobs:
           allowed_bots: "github-merge-queue,github-actions"
           prompt: |
             You are the synthesis step of GAIA's weekly DOC WALKTHROUGH (the
-            execution-based sibling of the static weekly-audit -- see
-            docs/plans/weekly-doc-walkthrough-audit.md). Each matrix job wrote a
-            findings-walkthrough-<slug>.json. Dedupe, rank, and file the output.
+            execution-based sibling of the static nightly audit -- see
+            docs/plans/weekly-doc-walkthrough-audit.md). A deterministic pass has ALREADY
+            merged the per-guide judges' findings into distinct defects and searched the
+            whole open backlog for each. Your job is the part a script cannot do: verify
+            the evidence, decide new-vs-already-tracked, and write for a human.
 
             REPO: ${{ github.repository }}
+            DRY RUN: ${{ github.event.inputs.dry_run || 'false' }}
             RUN LOG: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
 
             ## First actions
-            1. Read every `findings-walkthrough-*.json` under `walkthrough-findings/`
-               (each artifact is in its own subdir). Missing/empty files are fine -- a
-               guide may have found nothing, or its job may have crashed.
+            1. Read `synthesis-dossier.md` -- your worklist. One section per NEW defect,
+               each with its locations, a ranked list of possibly-matching open issues,
+               and (where the per-guide judges disagreed on a key) its likely siblings in
+               this same run. Defects listed as already-filed or suppressed at the bottom
+               are **already handled -- do not act on them at all**.
             2. Read `CLAUDE.md` -> "Issue Response Guidelines" for tone/format.
-            3. Already-filed keys:
-               `gh issue list --repo ${{ github.repository }} --label weekly-audit --state open --json number,title,body --limit 200`,
-               collect the `<!-- audit-key: KEY -->` marker from each body.
-            4. Suppressed-forever keys:
-               `gh issue list --repo ${{ github.repository }} --label weekly-audit --label audit-wontfix --state all --json body --limit 200`.
-            5. Previous parent to cross-link: the most recently created OPEN issue whose
-               title starts `Doc walkthrough —` (NOT `Weekly audit —` -- that belongs to
-               the static audit, a different lineage; do not cross-link across workflows).
+            3. `synthesis-input.json` has the same data structured, if you need a field
+               the dossier elides -- including the full location list when truncated.
+            If the dossier reports malformed findings or that the judges barely clustered,
+            say so in the run report: that is a judge-prompt bug a human needs to see.
+            You do NOT need to list issues or rebuild key sets -- that is done.
 
-            ## Dedup + verify
-            1. Drop any finding whose `dedup_key` is in either key set from step 3/4 above.
-               Match the exact key string -- never line numbers or prose similarity.
-            2. Evidence gate: drop any 🔴/🟠 finding whose `evidence` doesn't actually
-               substantiate its `title` -- spot-check by reading the cited transcript
-               excerpt/doc section yourself before filing.
-            3. If zero new findings remain after the above, post NOTHING and exit
-               cleanly -- do not file a parent issue, and never touch a prior parent.
+            ## Merge across guides BEFORE you file -- this workflow's signature failure
+            Each guide was judged by its own Claude job, blind to every other guide. One
+            broken thing therefore arrives as several defects worded differently. The
+            dossier's ⚠ sibling lines are exactly those: **if one fix would close a group
+            of them, they are ONE issue.** File it once, list every guide it breaks, and
+            skip the other sections. Five guides quoting one dead Lemonade command became
+            five separate issues in a single night -- that is the bug you are preventing.
 
-            ## File child issues -- 🔴/🟠 ONLY, non-security (this workflow finds no
-            security issues -- that lens belongs to claude-weekly-audit.yml)
-            🟡 (low) findings get NO child issue -- list them in the parent only. For each
-            NEW, verified 🔴/🟠 finding, write the body to a temp file, then
+            ## For each NEW defect, choose exactly one of three outcomes
+
+            ### (a) DROP it -- the evidence gate
+            Drop any finding whose `evidence` doesn't substantiate its `title`; spot-check
+            by reading the cited transcript excerpt or doc section yourself before filing.
+            **🟡 (low) defects are never filed** -- they go in the run report only.
+
+            ### (b) COMMENT on an existing issue -- 🔴/🟠 only, check this BEFORE filing
+            The dossier's candidates come from the WHOLE open backlog, not just this
+            workflow's label, so a human-filed or long-milestoned issue tracking the same
+            defect is visible. Open the top candidates and read them. If one already tracks
+            it, comment instead of filing:
+            `gh issue comment <n> --repo ${{ github.repository }} --body-file <file>`
+            The comment adds only what is NEW (the extra guides this run found, fresh
+            transcript evidence) and never restates the issue. End it with
+            `<!-- audit-cluster: <cluster_key> -->` so future runs match it by key.
+            A candidate matches when the same FIX closes both. Err toward commenting.
+
+            ### (c) FILE ONE issue -- 🔴/🟠 only
+            (This workflow finds no security issues -- that lens belongs to
+            claude-security-audit.yml.) Write the body to a temp file, then
             `gh issue create --repo ${{ github.repository }} --label weekly-audit --title "<title>" --body-file <file>`
-            WITHOUT the `bug` label. Body format — follow CLAUDE.md → "How You Communicate":
-            a human triages this, so the title and opening line say what broke and who it
-            hurts in plain words, and the location/evidence rows go in a collapsed
-            `<details>` underneath. Say each point once. The blank line after `</summary>`
-            is REQUIRED or GitHub renders the block as literal text.
+            WITHOUT the `bug` label.
+
+            **One issue per DEFECT, listing every guide it breaks.** The title names the
+            defect, never one guide: "The documented Lemonade start command no longer
+            exists (5 guides)", not "quickstart.mdx step 2 fails".
+
+            Body -- follow CLAUDE.md → "How You Communicate": the opening line says what
+            broke and who it hurts in plain words; mechanical rows go in a collapsed
+            `<details>`. The blank line after `</summary>` is REQUIRED or GitHub renders
+            the block as literal text. Both markers are REQUIRED -- they drive the next
+            run's dedup:
             ```
-            <one-paragraph why-this-matters: what's wrong + the concrete impact, in plain words>
+            <one paragraph: what's wrong + the concrete impact, in plain words>
 
             <details>
-            <summary>🔍 Evidence and location</summary>
+            <summary>🔍 Evidence and locations</summary>
 
-            **Where:** `path` · `symbol`   (the finding carries no line number — do not invent one)
-            **Evidence:** <the finding's `evidence` -- the concrete transcript/doc excerpt>
             **Severity:** 🔴 high / 🟠 medium
             **Auto-fixable:** yes — apply `bug` to let auto-fix open the PR  |  no — needs a human
+
+            | Guide · step | Evidence (transcript excerpt) |
+            |---|---|
+            | `path` · `symbol` | <that location's evidence> |
             </details>
 
             Not acting on this? Close it with the `audit-wontfix` label and the audit will
             never re-file it. Applying `bug` instead hands it to the existing auto-fix job.
 
-            <!-- audit-key: <the finding's dedup_key> -->
+            <!-- audit-cluster: <cluster_key> -->
+            <!-- audit-key: <the first location's dedup_key> -->
             ```
-            Capture each child issue number to reference from the parent.
 
-            ## File ONE parent issue
-            Title: `Doc walkthrough — ${{ github.run_id }}`. Label it `weekly-audit`.
-            Group findings by DOC PATH (this workflow has one detection mechanism, not
-            five dimensions like the static audit) -- most-severe-first across the whole
-            run, 🔴 before 🟠 before 🟡, each line prefixed with its severity emoji.
-            🔴/🟠 lines link their child issue (`· #<n>`); 🟡 lines have no child. Start
-            the body with a one-line tally: `New this run: N (🔴 a · 🟠 b) · low
-            (in-parent only): c · suppressed as dup/wontfix: d`.
+            ## Write the run report to `triage-report.md` -- NOT to an issue
+            A following step appends this file to the run's job summary. **Do not file a
+            "Doc walkthrough — <run-id>" issue; that convention is gone** -- those receipts
+            piled up in the tracker with nothing actionable in them. The old parent-chain
+            bookkeeping is gone with it: do not cross-link a previous run's issue, and never
+            close one. (Commenting on a backlog issue that tracks a real defect — outcome (b)
+            above — is a different thing, and is encouraged.)
 
-            ## Cross-link the previous parent -- NEVER close it
-            After filing the new parent, comment on the previous `Doc walkthrough —`
-            parent found in First-actions step 5 (if one exists) so readers can follow the
-            chain, but leave it OPEN:
-            `gh issue comment <prev-parent-#> --repo ${{ github.repository }} --body "Follow-up walkthrough run filed as #<new-parent-#>. This issue stays OPEN until its findings are addressed — only a maintainer should close it."`
-            Never call `gh issue close` on a parent from this workflow.
+            Write `triage-report.md`: a one-line tally, then the defects grouped by guide,
+            most-severe-first (🔴 → 🟠 → 🟡), each line prefixed with its severity emoji.
+            🟡 lines live here and nowhere else.
+            ```
+            ### Doc walkthrough
+            Filed: 2 new (🔴 1 · 🟠 1) · commented on existing: 1 · low (report-only): 3 · dropped on evidence: 4
+
+            - 🔴 The documented Lemonade start command no longer exists — breaks 5 guides — #<n>
+            - 🟠 `gaia chat` needs the chat agent package the Prerequisites never install — commented on existing #1077
+            - 🟡 `docs/guides/talk.mdx` example output is stale (report-only, no issue)
+            ```
+
+            ## If DRY RUN is true
+            Run NO `gh issue create` and NO `gh issue comment` -- file and comment nothing.
+            Do everything else, and in `triage-report.md` write what you WOULD have done
+            (`would file:` / `would comment on #<n>:`).
 
             ## Rules
             - No Claude attribution anywhere (no "Generated with", no Co-Authored-By).
             - Do not open any PR and do not apply the `bug` label -- humans gate every
               code change.
+            - Never close any issue.
             - Lead with the finding; keep each line to one sentence (CLAUDE.md issue style).
           claude_args: |
             --max-turns 32
             --model ${{ env.WALKTHROUGH_JUDGE_MODEL }}
             --allowedTools Read,Grep,Glob,Bash
+
+      - name: Prove the dry run filed nothing
+        if: always() && github.event.inputs.dry_run == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          before=$(cat .issue-watermark)
+          created=$(gh issue list --repo "${{ github.repository }}" --state all \n            --limit 100 --json number --jq "[.[] | select(.number > $before) | .number] | join(\", \")")
+          if [ -n "$created" ]; then
+            echo "::error title=Dry run was not dry::The synthesis step created issue(s) $created despite dry_run=true. Close them, then fix the dry-run instruction in the prompt."
+            exit 1
+          fi
+          echo "✅ Dry run confirmed: no issue created above #$before."
+
+      # The run receipt. Replaces the per-run "Doc walkthrough — <run-id>" ISSUE: a CI
+      # run's bookkeeping belongs in the run, not the tracker.
+      - name: Publish the triage report to the job summary
+        if: always()
+        run: |
+          set -euo pipefail
+          if [ -f triage-report.md ]; then
+            cat triage-report.md >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "## ⚠️ No triage report" >> "$GITHUB_STEP_SUMMARY"
+            echo "" >> "$GITHUB_STEP_SUMMARY"
+            echo "The synthesis step wrote no \`triage-report.md\`. See the step status below." >> "$GITHUB_STEP_SUMMARY"
+          fi
 
       - name: Verify the walkthrough filed output
         if: always()
@@ -837,7 +997,7 @@ jobs:
         run: |
           # Don't trust step outcome (continue-on-error masks it; an install
           # crash exits before it's set). Check the real artifact the action
-          # writes on completion -- same verification claude-weekly-audit.yml
+          # writes on completion -- same verification claude-nightly-audit.yml
           # uses for its own synthesis step.
           ok=false
           if [ -n "$EXEC_FILE" ] && [ -f "$EXEC_FILE" ]; then
@@ -847,7 +1007,7 @@ jobs:
           if [ "$ok" = "true" ]; then
             echo "✅ Weekly doc walkthrough synthesis completed (log: $EXEC_FILE)"
           else
-            # Hard-fail for the same reason as claude-weekly-audit.yml: a green run that
+            # Hard-fail for the same reason as claude-nightly-audit.yml: a green run that
             # synthesised nothing is indistinguishable from one that found nothing.
             echo "::error title=Weekly doc walkthrough did not complete::The synthesis step crashed or errored before finishing. Re-run: $RUN_URL"
             exit 1

--- a/docs/plans/weekly-claude-audit.md
+++ b/docs/plans/weekly-claude-audit.md
@@ -1,6 +1,6 @@
-# Weekly Claude deep-audit → triage issue + human-gated PRs
+# Nightly Claude deep-audit → one issue per defect + human-gated PRs
 
-Design record for `.github/workflows/claude-weekly-audit.yml`.
+Design record for `.github/workflows/claude-nightly-audit.yml`.
 
 ## Why this matters
 
@@ -9,7 +9,7 @@ Every Claude job in this repo is **reactive** — it fires on a PR, a comment, o
 ships inside a green PR — a feature with no doc page, a code path with no test, a silent
 `except Exception: pass`, a `cli.mdx` that drifted from the real flags — sits unnoticed
 until a user hits it. This workflow adds the missing proactive lens: a scheduled deep
-review that files **one ranked triage issue** a maintainer skims and promotes.
+review that files **one issue per defect** for a maintainer to triage and promote.
 
 **Human-gated, not an auto-merge bot.** The workflow produces *findings*, never commits.
 
@@ -27,19 +27,19 @@ review that files **one ranked triage issue** a maintainer skims and promotes.
 > seven consecutive deep sweeps. See the `weekly-audit-patterns` skill for current
 > invariants.
 
-## Dimensions (one read-only Claude job each, in parallel)
+## Dimensions (one read-only Claude job each, serialized)
 
 > **Security is not a dimension here.** It moved to a dedicated workflow,
 > `.github/workflows/claude-security-audit.yml` (deterministic semgrep + a Claude
 > taint/authz/suppression sweep, CVSS-scored, findings to the private code-scanning tab).
-> Filing security into this audit's **public** triage issue was the wrong channel, and a
+> Filing security into this audit's **public** issues was the wrong channel, and a
 > single general "security lens" is what missed the hub tar-slip.
 
 | Dimension | Looks for |
 |-----------|-----------|
 | `correctness` | code that is **wired but misbehaves** — a handler that flips a success flag without doing the work (a rollback that never rolls back), a poller that always returns null, a mode that no-ops, a flag whose handler raises `NotImplementedError` — plus real logic bugs and every CLAUDE.md "Fail Loudly" violation. **Owns wired-but-broken behavior and the silent-fallback check.** |
 | `docs` | new feature with no `docs/` page or `docs.json` entry; `cli.mdx` drift; `amd-gaia.ai` links missing `/docs/`; hub-agent README/SPEC/SKILL/CHANGELOG drift. A feature **documented as working but stubbed** is a docs finding (doc-vs-code drift), not features. |
-| `tests` | code paths with no test, or assertions that prove invocation not call validity (#1655). In **deep** mode, plain "module X has no coverage" rolls up into ONE aggregate finding; separate findings only for risk-bearing untested logic (auth/gate/precedence/error-mapping/#1655). |
+| `tests` | code paths with no test, or assertions that prove invocation not call validity (#1655). In **deep** mode, every plain "module X has no coverage" gets the shared `cluster_key` `tests:aggregate-untested-modules` so they merge into one issue; separate findings only for risk-bearing untested logic (auth/gate/precedence/error-mapping/#1655). |
 | `features` | a genuinely **missing or half-shipped** capability where nothing is wired yet (a TODO standing in for unwritten code). If the code is wired but broken, that is `correctness`, not features. |
 
 The four lenses are **mutually exclusive** — the decisive question for a broken thing is
@@ -75,36 +75,66 @@ detected by a `release_agent_<id>.yml` workflow, a shipped `SCORECARD.md`, or a 
 > (Security was later split out into `claude-security-audit.yml`, leaving the four
 > dimensions above.)
 
-## Synthesis → one triage issue + child issues
+## Synthesis → one issue per defect
 
-A synthesis job collects the four structured outputs, reduces them to the verified new set,
-ranks by severity (**🔴 high · 🟠 medium · 🟡 low** — no green; green reads as "pass"), and files:
+> **Superseded (2026-09).** Two decisions in the original design were reversed after a
+> month of live runs:
+> - **Parent triage issue per run — gone.** It filed one bookkeeping issue per run and 19
+>   accumulated, none actionable. (An intermediate version also auto-closed the previous
+>   parent as "superseded," which silently hid 18 unaddressed child findings — #2010 — so
+>   closing was dropped before the parent itself was.) The per-run report is now a job
+>   summary.
+> - **Per-finding child issues, deduped by label — gone.** One defect spanning N locations
+>   became N issues, and dedup that only scanned `weekly-audit`-labelled issues could not
+>   see the four-month-old #1077, so the audit re-filed it 14 times in one night.
+>
+> The rest of this section describes the current design.
 
-- **Parent triage issue** (`weekly-audit`): opens with a one-line tally (new/low/suppressed
-  counts) for trend, then a section for **every** dimension with a finding, in fixed order
-  (Correctness, Features, Docs, Tests), each finding grouped under the dimension it
-  *declares* (never re-bucketed). Each run **supersedes and closes the previous parent** so
-  they don't pile up.
-- **Per-finding child issues** for **🔴/🟠 only** — 🟡 (low) findings are listed in the
-  parent, not filed separately, to cap churn. Each child carries its `evidence` and an
-  **auto-fixable** flag; a maintainer promotes one with **`bug`** (→ existing `auto-fix`
-  job), or permanently silences it with **`audit-wontfix`**. No new PR-creation code.
+A synthesis job collects the four structured outputs, runs them through a deterministic
+dedup pass (`scripts/audit/prepare_synthesis.py`) that merges findings by root cause and
+searches the **whole** open backlog for an issue already tracking each one, and ranks by
+severity (**🔴 high · 🟠 medium · 🟡 low** — no green; green reads as "pass"). For each
+surviving defect it does exactly one of three things:
+
+- **Drop it** — the evidence gate: `evidence` missing, or not substantiating the title.
+  🟡 (low) defects are never filed; they appear in the run report only.
+- **Comment on an existing issue** — when a backlog candidate would be closed by the same
+  fix. This is the #1077 fix, and synthesis is told to err toward it.
+- **File ONE issue** (🔴/🟠, labelled `weekly-audit`) listing **every** location of that
+  defect. It carries each location's `evidence` and an **auto-fixable** flag; a maintainer
+  promotes it with **`bug`** (→ existing `auto-fix` job) or permanently silences it with
+  **`audit-wontfix`**. No new PR-creation code.
+
+The per-run report — a one-line tally, then a section per dimension in fixed order
+(Correctness, Features, Docs, Tests), each defect under the dimension it *declares*, never
+re-bucketed — is written to `triage-report.md` and appended to `$GITHUB_STEP_SUMMARY`. It
+is not an issue, and the workflow never closes an issue.
 
 **Precision & lifecycle** (what makes it trustworthy over time):
-- **Verify before file**: dimensions must carry `evidence` (a read quote) and confirm the
-  problem isn't already handled; synthesis drops 🔴/🟠 findings whose evidence is thin.
-- **Cross-dimension dedup within a run**: one root cause = one issue, even if two lenses flag it.
+- **Verify before file**: lenses must carry `evidence` (a read quote) and confirm the
+  problem isn't already handled; synthesis re-reads the cited path/symbol for every 🔴/🟠.
+- **One defect, one issue**: locations merge by `cluster_key`, across files and across
+  dimensions, before the model sees them.
 - **Permanent suppression**: a finding whose key sits on an `audit-wontfix` issue never re-files.
 
 ## Invariants (see the `weekly-audit-patterns` skill)
 
-- **Dedup key** = `<dimension>:<path>:<symbol-or-section>` — a function/class name or doc
-  heading, **never a line number** (line numbers move and re-file the finding every week).
-  Embedded as `<!-- audit-key: KEY -->` in each child body; synthesis skips any key already
-  on an *open* `weekly-audit` issue OR on any `audit-wontfix` issue (accepted debt).
+- **Two keys per finding.** `cluster_key` = `<dimension>:<root-cause-slug>` identifies the
+  DEFECT and holds no path — every location shares it and merges into one issue.
+  `dedup_key` = `<dimension>:<path>:<symbol-or-section>` identifies the LOCATION, using a
+  function/class name or doc heading, **never a line number** (line numbers move and
+  re-file the finding every run). A filed issue embeds both as `<!-- audit-cluster: … -->`
+  and `<!-- audit-key: … -->`; the dedup pass reads either and skips any key already on an
+  *open* `weekly-audit` issue OR on any `audit-wontfix` issue (accepted debt).
+- **`weekly-audit` is a provenance label**, not a cadence one — it marks "a proactive
+  Claude audit filed this" and is shared with the genuinely-weekly doc walkthrough.
 - **Security is a separate workflow**: `claude-security-audit.yml` owns it; this audit files
-  to a public issue, so it hands security off rather than disclosing it here.
-- **Skip-if-empty**: normal mode exits before any Claude call on a no-change week.
+  public issues, so it hands security off rather than disclosing it here.
+- **Skip-if-empty**: normal mode exits before any Claude call on a night with no commits.
+- **A partial sweep never files**: synthesis hard-fails when fewer dimensions reported in
+  than `preflight` declared — a crash that files nothing otherwise reads as a clean audit.
+- **`dry_run` dispatch input**: files and comments nothing, reports what it would have
+  done. The only way to validate a dedup change against the live backlog.
 - **Read-only**: `--allowedTools Read,Grep,Glob,Bash`; never install or run repo code.
 - **Model** `claude-opus-5` via the top-level `AUDIT_MODEL` env (one place to change);
   `claude-fable-5` for max depth at ~2x cost. Dimensions run `max-parallel: 1` (serialized)

--- a/docs/plans/weekly-doc-walkthrough-audit.md
+++ b/docs/plans/weekly-doc-walkthrough-audit.md
@@ -4,8 +4,8 @@ Design record for `.github/workflows/claude-weekly-doc-walkthrough.yml`.
 
 ## Why this matters
 
-`claude-weekly-audit.yml` (see `docs/plans/weekly-claude-audit.md`) is deliberately
-**static** — five read-only Claude lenses that read and grep, never install or run repo
+`claude-nightly-audit.yml` (see `docs/plans/weekly-claude-audit.md`) is deliberately
+**static** — read-only Claude lenses that read and grep, never install or run repo
 code. That non-goal was intentional, but it has a real blind spot: two bugs shipped that
 are only observable by actually running GAIA from a real user's initial state, never by
 reading source.
@@ -31,7 +31,7 @@ this sibling workflow is where execution-based verification now lives.
 
 ## Relationship to the static audit
 
-A **standalone sibling workflow**, not a 6th dimension of `claude-weekly-audit.yml`:
+A **standalone sibling workflow**, not a fifth dimension of `claude-nightly-audit.yml`:
 
 - Different runner (`[self-hosted, Windows, stx]` vs. the static audit's `ubuntu-latest`).
 - Different cost/runtime profile (hours, not minutes — deliberately; see Cadence).
@@ -39,21 +39,28 @@ A **standalone sibling workflow**, not a 6th dimension of `claude-weekly-audit.y
   can hang or time out).
 
 Isolating them means a slow or stuck walkthrough never delays or destabilizes the fast
-static lenses' weekly triage issue. The two workflows share vocabulary — severity scale
-(🔴 high · 🟠 medium · 🟡 low, no green), the `weekly-audit` label, the dedup-key pattern,
-`bug` → auto-fix promotion, `audit-wontfix` permanent suppression — but each files its
-**own** parent triage issue (`Doc walkthrough — <run_id>` vs. `Weekly audit — <mode> —
-<run_id>`), because they are different detection mechanisms surfacing potentially
-different root causes.
+static lenses. The two workflows share vocabulary — severity scale (🔴 high · 🟠 medium ·
+🟡 low, no green), the `weekly-audit` provenance label, the `cluster_key`/`dedup_key`
+scheme, `bug` → auto-fix promotion, `audit-wontfix` permanent suppression — and, since
+2026-09, the same deterministic dedup pass, `scripts/audit/prepare_synthesis.py`.
+
+> **Superseded (2026-09):** each workflow originally filed its **own** parent triage issue
+> (`Doc walkthrough — <run_id>` vs. `Weekly audit — <mode> — <run_id>`). Neither files one
+> now — see Synthesis below. The two are still separate detection mechanisms; they just
+> land their findings in the same shared backlog, deduped against it.
 
 ## Cadence & runtime
 
-Weekly, same day as the static audit but offset (static audit: Monday 06:00 UTC; this
-workflow: Monday 12:00 UTC) so the two don't compete for review attention or runner time
-in the same window. **Deliberately allowed to run for hours** — this is the one weekly
-deep pass, not a per-PR check, and thoroughness is the explicit goal over speed.
-`workflow_dispatch` accepts an optional `doc_filter` glob input so a single guide can be
-re-run in isolation (for validating the workflow itself, or re-checking one finding).
+Weekly, Monday 12:00 UTC. The static siblings went nightly; this one stays weekly on
+purpose because it drives a real Lemonade instance on the self-hosted Windows/STX box for
+hours, so it is hardware-bound rather than token-bound and a nightly cadence would
+monopolise that runner. On a Monday the three run in sequence — security audit 09:13 UTC →
+static audit 10:37 UTC → this at 12:00 UTC — so they never compete for runner time or
+review attention. **Deliberately allowed to run for hours** — this is the one weekly deep
+pass, not a per-PR check, and thoroughness is the explicit goal over speed.
+`workflow_dispatch` accepts an optional `doc_filter` glob so a single guide can be re-run
+in isolation, and a `dry_run` boolean that files and comments nothing while reporting what
+it would have done — the only way to validate a dedup change against the live backlog.
 
 ## Scope
 
@@ -155,6 +162,13 @@ Each matrix entry:
    is a claim, never trusted on its face"), applied here because a single self-judging
    session is exactly the kind of false-negative risk that would quietly erode trust in
    this workflow the way a false positive would.
+
+   > **Superseded:** both passes now run `claude-opus-5` — the repo standardised every
+   > Claude workflow on it, so this is no longer a cost split. What still matters is the
+   > **structural** split: the judge is a fresh context that never sees the executor's
+   > self-assessment. If a cheaper executor is reintroduced, change only
+   > `WALKTHROUGH_EXECUTOR_MODEL` and leave the judge on the stronger model.
+
 4. **Deterministic layer for `cli.mdx` specifically.** In addition to the judge's
    narrative read, the judge is instructed to explicitly enumerate every flag from
    `gaia -h` / each subcommand's `-h` output and from the doc's flag tables and diff them
@@ -167,24 +181,40 @@ Each matrix entry:
    static audit's "verify before you report" precision rule.
 6. **Output** — `findings-walkthrough-<doc-slug>.json`, same shape as the static audit's
    findings (`severity`/`path`/`symbol`/`title`/`why`/`evidence`/`auto_fixable`/
-   `dedup_key`), with `dedup_key` namespaced `walkthrough:<doc-path>:<step-heading>` —
-   a different namespace from the static lenses' `<dimension>:<path>:<symbol>`, so the two
-   mechanisms won't automatically cross-dedupe a shared root cause. Accepted as a known
-   gap for v1: a maintainer fixing either finding closes the underlying bug, which makes
-   the duplicate moot going forward.
+   `cluster_key`/`dedup_key`). `dedup_key` is namespaced `walkthrough:<doc-path>:<step-heading>`,
+   a different namespace from the static lenses' `<dimension>:<path>:<symbol>` — v1 accepted
+   that as a known gap, since it meant the two mechanisms could not cross-dedupe a shared
+   root cause. **Closed (2026-09)** by the second key: judges emit `cluster_key`
+   `docs:<root-cause-slug>`, the same root-cause namespace the static `docs` lens uses, so
+   one defect found by both mechanisms now merges into one issue.
 
 ## Synthesis
 
+> **Superseded (2026-09):** v1 filed a `Doc walkthrough — <run_id>` parent issue plus a
+> child issue per 🔴/🟠 finding, deduped against open `weekly-audit`-labelled issues only,
+> and cross-linked (never closed) the previous parent. Parents and children are both gone,
+> for the reasons recorded in `docs/plans/weekly-claude-audit.md` → Synthesis. The
+> no-auto-close rule they came from (#2010) survives as a blanket "the workflow never
+> closes an issue."
+
 A separate synthesis job (same repo, `issues: write` only there, matching the static
-audit's least-privilege pattern) collects every `findings-walkthrough-*.json`, dedupes
-against already-open `weekly-audit`-labeled issues via the same `<!-- audit-key: KEY -->`
-marker convention, rolls 🟡 (low) findings into the parent issue only (no child issue —
-reuses the static audit's already-learned churn-control rule: its first deep run filed 19
-children, ~13 low-value), files 🔴/🟠 findings as child issues, and posts one parent
-`Doc walkthrough — <run_id>` issue labeled `weekly-audit`. Cross-links (never closes) the
-previous walkthrough parent — the static audit's own postmortem (#2010: an earlier
-auto-close silently hid 18 unaddressed children) is the reason this rule exists; it
-applies identically here.
+audit's least-privilege pattern) collects every `findings-walkthrough-*.json` and runs the
+shared deterministic dedup pass, `scripts/audit/prepare_synthesis.py`. **That pass is this
+workflow's only cross-guide memory** — its per-guide judges are blind to each other, so one
+broken thing arrives as N differently-worded findings; the pass merges them by
+`cluster_key`, flags likely siblings whose keys disagreed, and searches the whole open
+backlog for an issue already tracking each defect. Five guides quoting a single dead
+Lemonade command became five issues in one night before it existed.
+
+Synthesis then drops, comments, or files exactly as the static audit does: 🟡 (low) defects
+are never filed, 🔴/🟠 defects become **one issue listing every guide they break**, and a
+defect the backlog already tracks gets a comment instead. The run report goes to
+`$GITHUB_STEP_SUMMARY`, not an issue.
+
+**A partial sweep never synthesizes.** Every discovered doc writes a findings file even
+when clean, so a short count means guides went unwalked — the job fails instead of filing.
+Without that gate a night where every judge crashed reached synthesis with zero findings
+and reported "nothing to file": a crash reading as a pass (#3058).
 
 ## Non-goals (v1)
 

--- a/scripts/audit/discover_walkthrough_docs.py
+++ b/scripts/audit/discover_walkthrough_docs.py
@@ -6,7 +6,7 @@
 Emits a JSON array of {"path": ..., "slug": ...} for every doc the
 walkthrough should walk. Glob-based (not a hardcoded list) so a new guide is
 picked up automatically -- same extensibility principle as
-claude-weekly-audit.yml's dimension matrix. stdlib only: this runs before any
+claude-nightly-audit.yml's dimension matrix. stdlib only: this runs before any
 venv exists.
 """
 

--- a/scripts/audit/prepare_synthesis.py
+++ b/scripts/audit/prepare_synthesis.py
@@ -1,0 +1,868 @@
+#!/usr/bin/env python3
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""Turn raw audit findings into a deduplicated worklist for the synthesis step.
+
+The proactive Claude audits used to hand their raw findings straight to a
+synthesis prompt and ask it to dedupe by eye. It could not:
+
+* One defect spanning N files arrived as N findings with N different
+  ``dedup_key``s, so it filed N issues for one fix (``lemonade-server serve``
+  became five issues in a single night).
+* Dedup only looked at issues already carrying the audit's own label, so a
+  four-month-old milestoned issue was invisible and got re-discovered 14 times
+  in one night (#1077).
+
+This script does the mechanical half deterministically -- cluster by root cause,
+then search the WHOLE open backlog for each cluster -- and leaves the synthesis
+model only the semantic call it is actually good at: "is candidate #1077 really
+the same defect as this cluster?"
+
+stdlib only; runs on a bare GitHub-hosted runner before any venv exists.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import re
+import subprocess
+import sys
+from collections import defaultdict
+from pathlib import Path
+from typing import Any
+
+#: Severity ranking, most severe first. Used to pick a cluster's severity and
+#: to order the dossier.
+SEVERITY_ORDER = ["🔴", "🟠", "🟡"]
+
+#: Fields every finding must carry. A finding missing one is REJECTED, never
+#: defaulted: filing a finding under a guessed cluster key is exactly the failure
+#: this script exists to end. Rejects are reported loudly (a CI error annotation
+#: plus a dossier section) rather than sinking the whole run -- see load_findings.
+REQUIRED_FINDING_FIELDS = ("severity", "title", "why", "evidence", "cluster_key")
+
+#: Titles the audits file about themselves (run receipts) are never a match for
+#: a code finding. Kept as a guard for the receipts already in the backlog --
+#: the workflows no longer create them.
+RECEIPT_TITLE_RE = re.compile(
+    r"^(nightly audit|weekly audit|doc walkthrough|security audit)\s*[-—–]",
+    re.IGNORECASE,
+)
+
+#: A backlog issue must clear this cosine-ish similarity to be shown to the
+#: synthesis model as a possible duplicate. Low on purpose: the model makes the
+#: final call and a missed candidate is what caused #1077's 14 re-files, while a
+#: wrong candidate costs one line of dossier.
+MATCH_THRESHOLD = 0.18
+
+#: How many backlog candidates to show per cluster.
+MAX_CANDIDATES = 5
+
+#: How many of a defect's locations the dossier lists. Matches the cap the
+#: synthesis prompts give for the issue's location table, so the model is never
+#: asked to list more rows than it was shown.
+MAX_LOCATIONS_SHOWN = 20
+
+
+#: Words that carry no signal for matching an issue title to a finding.
+STOPWORDS = frozenset("""
+    a an and are as at be because been but by can cannot could did do does doesn
+    doing done for from had has have how in into is it its just like made make
+    more never no not of on only or our out over own same should so some still
+    such than that the their them then there these they this those to too under
+    up use used uses using was way we were what when where which while who why
+    will with without would you your
+    add added adds also always any bug currently every fix fixed issue must need
+    needs new now real really run runs same set still support supports thing
+    things via
+    """.split())
+
+
+# ----------------------------------------------------------------------
+# Loading findings
+# ----------------------------------------------------------------------
+
+
+def _dimension_from_filename(name: str) -> str:
+    """`findings-docs.json` -> `docs`; `findings-walkthrough-cli.json` -> `walkthrough-cli`."""
+    stem = re.sub(r"\.json$", "", name)
+    return re.sub(r"^findings-", "", stem) or "unknown"
+
+
+def load_findings(findings_dir: Path) -> tuple[list[dict[str, Any]], list[str]]:
+    """Read every ``findings-*.json`` under *findings_dir* (recursively).
+
+    Returns ``(findings, rejects)``. Each artifact lands in its own subdirectory,
+    hence the recursive glob.
+
+    A malformed finding is QUARANTINED, not swallowed and not fatal. The lenses
+    now emit one finding per location, so a big run is a hundred independent
+    chances to drop a field, and failing the batch would throw away every lens's
+    work over one bad record. Rejects are returned so the caller can raise them
+    as CI errors and print them in the dossier — loud, but not all-or-nothing.
+    Zero valid findings alongside rejects IS fatal; the caller enforces that.
+    """
+    files = sorted(findings_dir.rglob("findings-*.json"))
+    if not files:
+        raise SystemExit(
+            f"No findings-*.json under {findings_dir}. Every lens writes one even when "
+            f"clean, so zero files means no lens ran. Refusing to synthesize an empty "
+            f"audit -- check the lens jobs' artifacts."
+        )
+
+    findings: list[dict[str, Any]] = []
+    problems: list[str] = []
+    for path in files:
+        try:
+            payload = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, ValueError) as exc:
+            raise SystemExit(f"Cannot read findings file {path}: {exc}") from exc
+        raw = payload.get("findings")
+        if raw is None or not isinstance(raw, list):
+            problems.append(f"{path}: no top-level 'findings' list")
+            continue
+        dimension = _dimension_from_filename(path.name)
+        for index, finding in enumerate(raw):
+            if not isinstance(finding, dict):
+                problems.append(f"{path}[{index}]: not an object")
+                continue
+            missing = [f for f in REQUIRED_FINDING_FIELDS if not finding.get(f)]
+            if missing:
+                problems.append(f"{path}[{index}]: missing {', '.join(missing)}")
+                continue
+            enriched = dict(finding)
+            enriched.setdefault("dimension", dimension)
+            enriched.setdefault("path", "")
+            enriched.setdefault("symbol", "")
+            enriched.setdefault("dedup_key", enriched["cluster_key"])
+            enriched.setdefault("auto_fixable", False)
+            findings.append(enriched)
+
+    if problems and not findings:
+        raise SystemExit(
+            "Every finding was malformed — the lens prompt and this schema have "
+            "drifted:\n  "
+            + "\n  ".join(problems)
+            + "\nEvery finding needs "
+            + ", ".join(REQUIRED_FINDING_FIELDS)
+            + ". Fix the lens prompt in the workflow rather than relaxing this check."
+        )
+    return findings, problems
+
+
+# ----------------------------------------------------------------------
+# Clustering by root cause
+# ----------------------------------------------------------------------
+
+
+def normalize_key(key: str) -> str:
+    return re.sub(r"\s+", " ", str(key)).strip().lower()
+
+
+def _severity_rank(severity: str) -> int:
+    try:
+        return SEVERITY_ORDER.index(severity)
+    except ValueError:
+        # An unknown severity sorts last but is never dropped -- see it in the
+        # dossier and fix the lens, don't lose the finding.
+        return len(SEVERITY_ORDER)
+
+
+def cluster_findings(findings: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Collapse findings that share a ``cluster_key`` into one defect.
+
+    This is the fix for "one defect, N files, N issues": the lenses key a
+    finding by ROOT CAUSE, so every location of the same defect merges here --
+    across files, across dimensions, and across the walkthrough's per-guide jobs
+    that cannot see each other.
+    """
+    buckets: dict[str, list[dict[str, Any]]] = defaultdict(list)
+    for finding in findings:
+        buckets[normalize_key(finding["cluster_key"])].append(finding)
+
+    clusters = []
+    for key, members in buckets.items():
+        members.sort(key=lambda f: _severity_rank(f["severity"]))
+        lead = members[0]
+        locations = []
+        seen_locations = set()
+        for member in members:
+            signature = (member["path"], member["symbol"])
+            if signature in seen_locations:
+                continue
+            seen_locations.add(signature)
+            locations.append(
+                {
+                    "path": member["path"],
+                    "symbol": member["symbol"],
+                    "evidence": member["evidence"],
+                    "dedup_key": member["dedup_key"],
+                    "dimension": member["dimension"],
+                }
+            )
+        clusters.append(
+            {
+                "cluster_key": key,
+                "severity": lead["severity"],
+                "title": lead["title"],
+                "why": lead["why"],
+                "dimensions": sorted({m["dimension"] for m in members}),
+                "auto_fixable": any(bool(m["auto_fixable"]) for m in members),
+                "locations": locations,
+                "member_count": len(members),
+            }
+        )
+
+    clusters.sort(key=lambda c: (_severity_rank(c["severity"]), c["cluster_key"]))
+    return clusters
+
+
+# ----------------------------------------------------------------------
+# The open backlog
+# ----------------------------------------------------------------------
+
+
+def _gh_json(args: list[str]) -> Any:
+    """Run a `gh` command that emits JSON, failing loudly on any error."""
+    try:
+        completed = subprocess.run(
+            args, capture_output=True, text=True, encoding="utf-8", check=False
+        )
+    except FileNotFoundError as exc:
+        raise SystemExit(
+            "`gh` is not on PATH. This script needs the GitHub CLI to read the open "
+            "backlog; on a GitHub-hosted runner it is preinstalled and only needs "
+            "GH_TOKEN in the environment."
+        ) from exc
+    if completed.returncode != 0:
+        raise SystemExit(
+            f"`{' '.join(args[:4])} ...` failed with exit {completed.returncode}:\n"
+            f"{completed.stderr.strip()}\n"
+            "Refusing to dedupe against a backlog we could not read — that is how the "
+            "same finding gets filed twice."
+        )
+    return json.loads(completed.stdout)
+
+
+def fetch_backlog(repo: str, label: str, limit: int) -> dict[str, Any]:
+    """Read the whole open backlog plus the audit's own filed/suppressed keys."""
+    open_issues = _gh_json(
+        [
+            "gh",
+            "issue",
+            "list",
+            "--repo",
+            repo,
+            "--state",
+            "open",
+            "--limit",
+            str(limit),
+            "--json",
+            "number,title,labels",
+        ]
+    )
+    labelled = _gh_json(
+        [
+            "gh",
+            "issue",
+            "list",
+            "--repo",
+            repo,
+            "--label",
+            label,
+            "--state",
+            "open",
+            "--limit",
+            str(limit),
+            "--json",
+            "number,body",
+        ]
+    )
+    suppressed = _gh_json(
+        [
+            "gh",
+            "issue",
+            "list",
+            "--repo",
+            repo,
+            "--label",
+            label,
+            "--label",
+            "audit-wontfix",
+            "--state",
+            "all",
+            "--limit",
+            str(limit),
+            "--json",
+            "number,body",
+        ]
+    )
+    return {
+        "open_issues": open_issues,
+        "filed": labelled,
+        "suppressed": suppressed,
+    }
+
+
+#: Both markers are read. `audit-key` is what every already-filed issue carries;
+#: `audit-cluster` is the root-cause key this script introduced. Reading both is
+#: what stops the schema change from re-filing the ~130 findings already open.
+KEY_MARKER_RE = re.compile(r"<!--\s*audit-(?:key|cluster):\s*(.+?)\s*-->")
+
+
+def extract_keys(issues: list[dict[str, Any]]) -> dict[str, list[int]]:
+    """Map every audit key embedded in an issue body to the issues carrying it.
+
+    A list, not a single number: two open issues can carry the same key (the
+    backlog already holds several open issues per defect from before clustering
+    existed), and keeping only the first makes the rest unreachable — they stay
+    open forever with nothing ever pointing at them again.
+    """
+    keys: dict[str, list[int]] = defaultdict(list)
+    for issue in issues:
+        for match in KEY_MARKER_RE.finditer(issue.get("body") or ""):
+            number = issue["number"]
+            bucket = keys[normalize_key(match.group(1))]
+            if number not in bucket:
+                bucket.append(number)
+    return dict(keys)
+
+
+# ----------------------------------------------------------------------
+# Matching a cluster to the open backlog
+# ----------------------------------------------------------------------
+
+_TOKEN_RE = re.compile(r"[A-Za-z0-9_]+")
+
+
+def tokenize(text: str) -> set[str]:
+    """Split text into lowercase content tokens, also splitting snake/camel case.
+
+    `lemonade-server serve` and `LemonadeServer.serve()` must share tokens, or
+    the backlog search misses the very duplicates it exists to catch.
+    """
+    tokens: set[str] = set()
+    for raw in _TOKEN_RE.findall(text or ""):
+        parts = [raw] + re.findall(r"[A-Z]?[a-z0-9]+|[A-Z]+(?![a-z])", raw)
+        for part in parts:
+            lowered = part.lower()
+            if len(lowered) >= 3 and lowered not in STOPWORDS:
+                tokens.add(lowered)
+    return tokens
+
+
+def _idf(corpus: list[set[str]]) -> tuple[dict[str, float], float]:
+    """Inverse document frequency, plus the weight to use for an unseen token.
+
+    An unseen token is maximally rare, so it gets the weight a once-seen token
+    would. Defaulting it to 1.0 instead made the score depend on how big the
+    backlog happened to be: rare corpus tokens weigh ~7 against 1000 open
+    issues, so under-weighting novel query tokens shrank the query norm and
+    inflated every score.
+    """
+    document_count = max(len(corpus), 1)
+    frequency: dict[str, int] = defaultdict(int)
+    for document in corpus:
+        for token in document:
+            frequency[token] += 1
+    idf = {
+        token: math.log(document_count / (1 + count)) + 1.0
+        for token, count in frequency.items()
+    }
+    return idf, math.log(document_count) + 1.0
+
+
+def cluster_query_text(cluster: dict[str, Any]) -> str:
+    """Everything about a cluster that is worth matching a backlog title against."""
+    parts = [cluster["title"], cluster["why"], cluster["cluster_key"]]
+    for location in cluster["locations"][:8]:
+        parts.append(Path(location["path"]).name if location["path"] else "")
+        parts.append(location["symbol"])
+    return " ".join(p for p in parts if p)
+
+
+def find_backlog_candidates(
+    clusters: list[dict[str, Any]],
+    open_issues: list[dict[str, Any]],
+    *,
+    threshold: float = MATCH_THRESHOLD,
+    max_candidates: int = MAX_CANDIDATES,
+) -> tuple[dict[str, float], float]:
+    """Attach the most similar open issues to each cluster, in place.
+
+    This is the #1077 fix: the search covers EVERY open issue, not just the ones
+    carrying the audit's label, so a human-filed issue tracking the same defect
+    is visible to the synthesis step and gets a comment instead of a 15th
+    duplicate.
+
+    Returns the term weights built from the backlog so sibling detection can
+    score against the same large, stable corpus.
+    """
+    searchable = [
+        issue
+        for issue in open_issues
+        if not RECEIPT_TITLE_RE.match(issue.get("title") or "")
+    ]
+    issue_tokens = [tokenize(issue.get("title") or "") for issue in searchable]
+    idf, unseen = _idf(issue_tokens)
+
+    for cluster in clusters:
+        query = tokenize(cluster_query_text(cluster))
+        query_norm = math.sqrt(sum(idf.get(t, unseen) ** 2 for t in query)) or 1.0
+        scored = []
+        for issue, tokens in zip(searchable, issue_tokens):
+            overlap = query & tokens
+            if not overlap:
+                continue
+            issue_norm = math.sqrt(sum(idf.get(t, unseen) ** 2 for t in tokens)) or 1.0
+            score = sum(idf.get(t, unseen) ** 2 for t in overlap) / (
+                query_norm * issue_norm
+            )
+            if score >= threshold:
+                scored.append((score, issue))
+        scored.sort(key=lambda pair: (-pair[0], pair[1]["number"]))
+        cluster["backlog_candidates"] = [
+            {
+                "number": issue["number"],
+                "title": issue["title"],
+                "labels": [lab["name"] for lab in issue.get("labels") or []],
+                "score": round(score, 3),
+            }
+            for score, issue in scored[:max_candidates]
+        ]
+    return idf, unseen
+
+
+#: Two clusters in the SAME run must look this alike before we ask the synthesis
+#: model whether they are one defect. Higher than MATCH_THRESHOLD: these are
+#: findings that already failed to agree on a cluster key, so only a strong
+#: signal is worth a second look.
+#:
+#: Calibrated against a real 106-finding walkthrough run: the median score for
+#: an overlapping pair there is 0.04, genuine duplicates score 0.30-0.45, and
+#: 0.30 selects 26 pairs out of 5460 — every one of the top pairs a real
+#: duplicate. Do NOT raise this without re-measuring; at 0.45 that same run
+#: surfaced ZERO siblings, including nine findings that were all one crash.
+SIBLING_THRESHOLD = 0.30
+
+
+def find_sibling_clusters(
+    clusters: list[dict[str, Any]],
+    idf: dict[str, float],
+    unseen: float,
+    *,
+    threshold: float = SIBLING_THRESHOLD,
+) -> None:
+    """Flag new clusters in THIS run that look like the same defect, in place.
+
+    The doc walkthrough fans out one judge per guide and those judges cannot see
+    each other, so five guides quoting the same dead command produced five
+    findings with five different keys — and five issues in one night. Cluster
+    keys catch that only when the independent judges happen to agree on a slug;
+    this catches it when they don't.
+
+    Scored with the BACKLOG's term weights, not weights derived from this run's
+    own findings. Deriving them per-run made the threshold mean different things
+    on different nights — a duplicate pair scored 0.65 in a 5-finding run and
+    0.35 in a 106-finding one, because a term's rarity was measured against
+    however many findings happened to come in.
+
+    The relation is symmetric and never truncated. Two earlier shapes were both
+    wrong, and both in ways that would re-file duplicates:
+
+    * A per-cluster list capped at the top N is asymmetric — in a group of nine,
+      A shows five, so a reader merges those six and moves on while the other
+      three keep live sections and get filed separately.
+    * Transitively closing the pairs into components over-merges badly. Single
+      linkage chains A-B-C until loosely-related things join up: on a real
+      106-finding run it produced ONE component of 46 defects, which tells a
+      reader nothing they can act on.
+
+    So: direct pairs only, both directions recorded, nothing dropped.
+    """
+    # c["status"], not .get(): if classify() has not run, that is a bug that
+    # must raise, not a run that quietly finds zero siblings.
+    new_clusters = [c for c in clusters if c["status"] == "new"]
+    token_sets = [tokenize(cluster_query_text(c)) for c in new_clusters]
+    norms = [
+        math.sqrt(sum(idf.get(t, unseen) ** 2 for t in tokens)) or 1.0
+        for tokens in token_sets
+    ]
+
+    for cluster in new_clusters:
+        cluster["sibling_clusters"] = []
+
+    for i in range(len(new_clusters)):
+        for j in range(i + 1, len(new_clusters)):
+            overlap = token_sets[i] & token_sets[j]
+            if not overlap:
+                continue
+            score = sum(idf.get(t, unseen) ** 2 for t in overlap) / (
+                norms[i] * norms[j]
+            )
+            if score < threshold:
+                continue
+            rounded = round(score, 3)
+            new_clusters[i]["sibling_clusters"].append(
+                {
+                    "cluster_key": new_clusters[j]["cluster_key"],
+                    "title": new_clusters[j]["title"],
+                    "score": rounded,
+                }
+            )
+            new_clusters[j]["sibling_clusters"].append(
+                {
+                    "cluster_key": new_clusters[i]["cluster_key"],
+                    "title": new_clusters[i]["title"],
+                    "score": rounded,
+                }
+            )
+
+    for cluster in new_clusters:
+        cluster["sibling_clusters"].sort(key=lambda s: (-s["score"], s["cluster_key"]))
+
+
+# ----------------------------------------------------------------------
+# Assembling the worklist
+# ----------------------------------------------------------------------
+
+
+def classify(
+    clusters: list[dict[str, Any]],
+    filed_keys: dict[str, list[int]],
+    suppressed_keys: dict[str, list[int]],
+) -> None:
+    """Mark each cluster `suppressed`, `already-filed`, or `new`, in place.
+
+    A key match is scoped to what it actually covers. Both key kinds coexist and
+    they mean different things, so treating any hit as a whole-defect verdict
+    loses real findings:
+
+    * A **cluster-key** hit covers the DEFECT. Suppressed → never mention it
+      again; filed → it is already tracked, don't re-file.
+    * A **location-key** hit covers ONE LOCATION. Those are what the ~130
+      pre-clustering issues carry, one per file. Suppressing that one location
+      must not silence the 38 others, and an old single-location issue must not
+      swallow a defect the run just found in 38 more places. So a
+      location-key hit drops that location (suppressed) or promotes the issue to
+      a comment candidate (filed) — it never discards the cluster.
+
+    Records EVERY matching issue, not just the first: one defect was routinely
+    filed under N keys, and naming only one leaves the rest open as permanent
+    duplicates that nothing ever points at again.
+    """
+    for cluster in clusters:
+        cluster_key = cluster["cluster_key"]
+
+        # Location-scoped suppression: drop the silenced locations only.
+        kept, silenced = [], []
+        for location in cluster["locations"]:
+            hits = suppressed_keys.get(normalize_key(location["dedup_key"]), ())
+            (silenced if hits else kept).append(location)
+        cluster["suppressed_locations"] = len(silenced)
+
+        defect_suppressed = sorted(set(suppressed_keys.get(cluster_key, ())))
+        if defect_suppressed or (silenced and not kept):
+            cluster["status"] = "suppressed"
+            cluster["existing_issues"] = defect_suppressed or sorted(
+                {
+                    n
+                    for loc in silenced
+                    for n in suppressed_keys[normalize_key(loc["dedup_key"])]
+                }
+            )
+        else:
+            cluster["locations"] = kept
+            defect_filed = sorted(set(filed_keys.get(cluster_key, ())))
+            location_filed = sorted(
+                {
+                    n
+                    for loc in kept
+                    for n in filed_keys.get(normalize_key(loc["dedup_key"]), ())
+                }
+            )
+            if defect_filed:
+                cluster["status"] = "already-filed"
+                cluster["existing_issues"] = defect_filed
+            else:
+                # Location-key hits mean part of this defect is already on the
+                # tracker under the old one-issue-per-file scheme. That is a
+                # comment, not a skip — and it is how those issues get
+                # consolidated instead of orphaned.
+                cluster["status"] = "new"
+                cluster["existing_issues"] = location_filed
+        cluster["existing_issue"] = (
+            cluster["existing_issues"][0] if cluster["existing_issues"] else None
+        )
+
+
+#: Evidence is a raw quote or transcript excerpt and can run to hundreds of
+#: characters. The dossier is a worklist, not the archive — the JSON written
+#: alongside it keeps the full text for anything the model wants to read in full.
+MAX_EVIDENCE_CHARS = 240
+
+
+def _abbreviate(text: str) -> str:
+    flat = re.sub(r"\s+", " ", str(text)).strip()
+    if len(flat) <= MAX_EVIDENCE_CHARS:
+        return flat
+    return flat[:MAX_EVIDENCE_CHARS] + " …[truncated; full text in the synthesis JSON]"
+
+
+def _plural(count: int, noun: str) -> str:
+    return noun if count == 1 else noun + "s"
+
+
+def _shorten(text: str, limit: int = 110) -> str:
+    """Trim a title used only to identify an issue the reader will go and open."""
+    flat = re.sub(r"\s+", " ", str(text)).strip()
+    return flat if len(flat) <= limit else flat[:limit] + "…"
+
+
+def render_dossier(
+    clusters: list[dict[str, Any]],
+    counts: dict[str, int],
+    rejects: list[str] | None = None,
+) -> str:
+    """The markdown the synthesis model reads instead of raw findings JSON."""
+    lines = [
+        "# Synthesis worklist",
+        "",
+        f"{counts['raw_findings']} raw findings collapsed to {counts['clusters']} "
+        f"distinct {_plural(counts['clusters'], 'defect')}: **{counts['new']} new**, "
+        f"{counts['already_filed']} already filed, {counts['suppressed']} suppressed "
+        f"as wontfix.",
+        "",
+    ]
+
+    # Barely any collapse means the lenses keyed per location instead of per root
+    # cause — the exact failure that turned one dead command into five issues. Say
+    # so loudly: the sibling lists are then the only dedup signal left.
+    if (
+        counts["raw_findings"] >= 10
+        and counts["clusters"] > 0.9 * counts["raw_findings"]
+    ):
+        lines += [
+            f"> ⚠ **The lenses barely clustered anything** — {counts['raw_findings']} "
+            f"findings produced {counts['clusters']} keys, so they keyed by LOCATION, "
+            f"not by root cause. Do not file one issue per section below. Lean hard on "
+            f"the ⚠ sibling lists and the backlog candidates, and mention the "
+            f"mis-keying in the run report so the lens prompt can be fixed.",
+            "",
+        ]
+
+    if rejects:
+        lines += [
+            f"> ⚠ **{len(rejects)} finding(s) were dropped as malformed** and are NOT "
+            "below — a lens omitted a required field. Say so in the run report so the "
+            "lens prompt gets fixed:",
+            "",
+        ]
+        lines += [f"> - {reject}" for reject in rejects[:10]]
+        if len(rejects) > 10:
+            lines.append(f"> - …and {len(rejects) - 10} more")
+        lines.append("")
+
+    new_clusters = [c for c in clusters if c["status"] == "new"]
+    if not new_clusters:
+        lines += ["No new defects this run. File nothing.", ""]
+    else:
+        # Stated once here rather than repeated under all N defects.
+        lines += [
+            "One section per NEW defect below. For each, in order:",
+            "",
+            "1. **already-open issues** — issues from the WHOLE open backlog whose "
+            "titles resemble this defect, best match first. Open the top ones. If a "
+            "fix for this defect would close one of them, COMMENT on it instead of "
+            "filing a duplicate.",
+            "2. **⚠ may be the same defect as these, from this run** — a text match, "
+            "not a verdict, and NOT transitive. Read each; where ONE fix closes a "
+            "set of them, file ONE issue covering it and skip their sections.",
+            "3. **locations** — every place this one defect appears. They belong in "
+            "ONE issue, never one issue each.",
+            "",
+            "Scores are cosine similarity over issue-title terms; they rank, they do "
+            "not decide. Evidence is truncated here; the synthesis JSON written "
+            "alongside this file has it in full.",
+            "",
+        ]
+
+    for cluster in new_clusters:
+        multi = len(cluster["locations"]) > 1
+        lines.append(f"## {cluster['severity']} {cluster['title']}")
+        lines.append("")
+        if multi:
+            # The heading is one member's wording and usually names that member's
+            # file, which pulls directly against "title the defect, not a file".
+            # Say so rather than letting the model copy it.
+            lines.append(
+                "- ⚠ **the heading above is ONE member's wording and probably names "
+                "just its own file — write a title for the whole defect instead.**"
+            )
+        lines.append(
+            f"- **cluster key:** `{cluster['cluster_key']}` (use as `audit-cluster`)"
+        )
+        lines.append(f"- **why:** {_abbreviate(cluster['why'])}")
+        if cluster.get("existing_issues"):
+            refs = ", ".join(f"#{n}" for n in cluster["existing_issues"])
+            lines.append(
+                f"- ‼ **{refs} already track part of this defect** (matched by location "
+                "key, from the old one-issue-per-file scheme). COMMENT on the "
+                "lowest-numbered one with the locations below and note the others as "
+                "its duplicates — do not open another."
+            )
+        if cluster.get("suppressed_locations"):
+            lines.append(
+                f"- {cluster['suppressed_locations']} location(s) omitted as "
+                "`audit-wontfix`; the rest still stand."
+            )
+        lines.append(f"- **lens/doc:** {', '.join(cluster['dimensions'])}")
+        lines.append(
+            f"- **auto-fixable:** {'yes' if cluster['auto_fixable'] else 'no'}"
+        )
+        if multi:
+            lines.append(
+                f"- ⚠ **this ONE defect spans {len(cluster['locations'])} locations** — "
+                "file a single issue listing every location in its body."
+            )
+        if cluster["locations"]:
+            # The prompts require an `audit-key` marker built from the first
+            # location's dedup_key, so the dossier has to actually carry it.
+            lines.append(
+                f"- **first location key:** `{cluster['locations'][0]['dedup_key']}` "
+                "(use as `audit-key`)"
+            )
+        lines.append(f"- **locations ({len(cluster['locations'])}):**")
+        for location in cluster["locations"][:MAX_LOCATIONS_SHOWN]:
+            where = " · ".join(p for p in (location["path"], location["symbol"]) if p)
+            lines.append(f"  - `{where}` — {_abbreviate(location['evidence'])}")
+        if len(cluster["locations"]) > MAX_LOCATIONS_SHOWN:
+            elided = len(cluster["locations"]) - MAX_LOCATIONS_SHOWN
+            lines.append(
+                f"  - …and {elided} more locations — the full list is in the synthesis "
+                "JSON; say in the issue how many were elided."
+            )
+        if cluster.get("backlog_candidates"):
+            lines.append("- **already-open issues that may be this defect:**")
+            for candidate in cluster["backlog_candidates"]:
+                labels = (
+                    f" [{', '.join(candidate['labels'])}]"
+                    if candidate["labels"]
+                    else ""
+                )
+                lines.append(
+                    f"  - #{candidate['number']} ({candidate['score']}){labels} "
+                    f"— {_shorten(candidate['title'])}"
+                )
+        else:
+            lines.append("- **already-open issues:** none above threshold")
+        siblings = cluster.get("sibling_clusters") or []
+        if siblings:
+            lines.append(
+                f"- ⚠ **may be the same defect as these {len(siblings)} from this run:**"
+            )
+            for sibling in siblings:
+                lines.append(
+                    f"  - `{sibling['cluster_key']}` ({sibling['score']}) "
+                    f"— {_shorten(sibling['title'])}"
+                )
+        lines.append("")
+
+    skipped = [c for c in clusters if c["status"] != "new"]
+    if skipped:
+        lines.append("## Skipped (do not re-file, do not comment)")
+        lines.append("")
+        for cluster in skipped:
+            issues = cluster.get("existing_issues") or []
+            refs = ", ".join(f"#{n}" for n in issues) or "unknown"
+            extra = (
+                "  ← several open issues track this one defect; note it in the report"
+                if len(issues) > 1
+                else ""
+            )
+            lines.append(
+                f"- {cluster['status']}: `{cluster['cluster_key']}` → {refs}{extra}"
+            )
+        lines.append("")
+    return "\n".join(lines)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--findings-dir", type=Path, required=True)
+    parser.add_argument("--repo", required=True, help="owner/name")
+    parser.add_argument("--label", default="weekly-audit")
+    parser.add_argument("--limit", type=int, default=1000)
+    parser.add_argument("--out", type=Path, required=True)
+    parser.add_argument("--dossier", type=Path, required=True)
+    parser.add_argument(
+        "--backlog-file",
+        type=Path,
+        help=(
+            "Read the backlog from this JSON file instead of calling `gh`. Used by the "
+            "unit tests and by a local dry run against a saved snapshot."
+        ),
+    )
+    args = parser.parse_args(argv)
+
+    findings, rejects = load_findings(args.findings_dir)
+    for reject in rejects:
+        # A GitHub annotation, so a dropped field is visible in the run without
+        # reading the log — and one bad record does not cost the whole night.
+        print(f"::error title=Malformed finding::{reject}", file=sys.stderr)
+    clusters = cluster_findings(findings)
+
+    if args.backlog_file:
+        backlog = json.loads(args.backlog_file.read_text(encoding="utf-8"))
+    else:
+        backlog = fetch_backlog(args.repo, args.label, args.limit)
+
+    if len(backlog["open_issues"]) >= args.limit:
+        raise SystemExit(
+            f"The backlog query returned {len(backlog['open_issues'])} issues, hitting "
+            f"the --limit of {args.limit}. Dedup would silently be searching only part "
+            f"of the backlog — which is the exact failure this pass exists to end. "
+            f"Raise --limit above the open-issue count."
+        )
+
+    classify(
+        clusters,
+        extract_keys(backlog["filed"]),
+        extract_keys(backlog["suppressed"]),
+    )
+    idf, unseen = find_backlog_candidates(clusters, backlog["open_issues"])
+    find_sibling_clusters(clusters, idf, unseen)
+
+    counts = {
+        "raw_findings": len(findings),
+        "clusters": len(clusters),
+        "new": sum(1 for c in clusters if c["status"] == "new"),
+        "already_filed": sum(1 for c in clusters if c["status"] == "already-filed"),
+        "suppressed": sum(1 for c in clusters if c["status"] == "suppressed"),
+        "open_issues_searched": len(backlog["open_issues"]),
+        "rejected_findings": len(rejects),
+    }
+
+    for destination in (args.out, args.dossier):
+        destination.parent.mkdir(parents=True, exist_ok=True)
+    args.out.write_text(
+        json.dumps({"counts": counts, "clusters": clusters}, indent=2),
+        encoding="utf-8",
+    )
+    args.dossier.write_text(render_dossier(clusters, counts, rejects), encoding="utf-8")
+
+    print(
+        f"{counts['raw_findings']} raw findings -> {counts['clusters']} "
+        f"{_plural(counts['clusters'], 'defect')} ({counts['new']} new, "
+        f"{counts['already_filed']} already filed, {counts['suppressed']} suppressed); "
+        f"searched {counts['open_issues_searched']} open issues"
+        + (f"; {counts['rejected_findings']} malformed" if rejects else "")
+        + "."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/unit/test_audit_synthesis_prep.py
+++ b/tests/unit/test_audit_synthesis_prep.py
@@ -1,0 +1,1788 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""
+`prepare_synthesis.py` is the reason the nightly audit stopped filing the same
+defect fifteen times — these tests pin the behaviours that make that true.
+
+Three regressions motivated the script, and each has tests below:
+
+* One defect spanning N files arrived as N findings with N ``dedup_key``s, so
+  the synthesis model filed N issues for one fix. Clustering by ``cluster_key``
+  is the fix, so a cluster that loses its members is a silent relapse.
+* Dedup only searched issues already carrying the audit's own label, so a
+  four-month-old human-filed issue was invisible and the same finding got
+  re-discovered 14 times in one night (#1077). The backlog search now covers
+  every open issue — including ones with unrelated labels.
+* The doc walkthrough runs one judge per guide and those judges cannot see each
+  other, so five guides quoting the same dead command invented five different
+  cluster keys and produced five issues. ``find_sibling_clusters`` catches what
+  the keys miss.
+
+Three supporting properties matter as much as the three above, because all of
+them fail silently:
+
+* A cluster must report EVERY already-open issue it matches. The real backlog
+  has one defect spread over five issues; naming one orphans four.
+* Both scorers must weigh terms against the same stable backlog corpus. Scoring
+  siblings against the run's own findings measured rarity against however many
+  findings happened to arrive, so the 106-finding walkthrough of 2026-08-31
+  found ZERO siblings — nine of those findings were one executor crash.
+* When almost nothing collapses, the dossier has to SAY the lenses mis-keyed.
+  A silent 20-findings-20-keys run reads exactly like a genuine 20-defect night.
+
+The failure mode for all of this is silent: the script still exits 0 and still
+writes a dossier, it just quietly files duplicates again. Hence assertions on
+behaviour (clusters collapse, keys are read in both spellings, receipts never
+match) rather than on function signatures.
+
+The script is stdlib-only and not an installed package, so it is loaded by path.
+Everything here is offline: ``--backlog-file`` exists precisely so no test ever
+shells out to `gh`.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = REPO_ROOT / "scripts" / "audit" / "prepare_synthesis.py"
+
+#: Severity markers, written as escapes so the file stays pure-ASCII and the
+#: tests pass on a Windows console with a legacy code page.
+HIGH = "\U0001f534"
+MEDIUM = "\U0001f7e0"
+LOW = "\U0001f7e1"
+
+#: U+2014, the dash the audit workflows actually put in run-receipt titles.
+EM_DASH = "—"
+
+
+@pytest.fixture(scope="module")
+def prep():
+    """The script under test, loaded from its path (it is not importable)."""
+    assert SCRIPT.is_file(), f"{SCRIPT} is missing"
+    spec = importlib.util.spec_from_file_location("audit_prepare_synthesis", SCRIPT)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def make_finding(**overrides: Any) -> dict[str, Any]:
+    """A minimal valid finding; override whatever the test is about."""
+    finding = {
+        "severity": MEDIUM,
+        "title": "Guides skip prerequisites",
+        "why": "A reader following the guide hits a missing dependency.",
+        "evidence": "No prerequisites section.",
+        "cluster_key": "docs-guide-prerequisites-missing",
+        "path": "docs/guides/chat.mdx",
+        "symbol": "",
+    }
+    finding.update(overrides)
+    return finding
+
+
+def write_findings(directory: Path, name: str, findings: list[dict[str, Any]]) -> Path:
+    """Write one lens artifact the way the workflow's lens jobs do."""
+    directory.mkdir(parents=True, exist_ok=True)
+    path = directory / name
+    path.write_text(json.dumps({"findings": findings}), encoding="utf-8")
+    return path
+
+
+# ----------------------------------------------------------------------
+# Clustering: one defect is one entry, however many files it touches
+# ----------------------------------------------------------------------
+
+
+def test_one_defect_across_fourteen_files_collapses_to_one_cluster(prep, tmp_path):
+    """The #1077 case: 14 findings, one root cause, one issue to file."""
+    findings = [
+        make_finding(path=f"docs/guides/guide-{i:02d}.mdx", evidence=f"guide {i}")
+        for i in range(14)
+    ]
+    write_findings(tmp_path, "findings-docs.json", findings)
+
+    loaded, rejects = prep.load_findings(tmp_path)
+    clusters = prep.cluster_findings(loaded)
+
+    assert rejects == []
+    assert len(clusters) == 1
+    assert len(clusters[0]["locations"]) == 14
+    assert clusters[0]["member_count"] == 14
+
+
+def test_the_same_defect_seen_by_two_lenses_merges_into_one_cluster(prep, tmp_path):
+    """Lens jobs run in parallel and cannot see each other's findings."""
+    write_findings(tmp_path / "docs", "findings-docs.json", [make_finding()])
+    write_findings(
+        tmp_path / "correctness",
+        "findings-correctness.json",
+        [make_finding(path="src/gaia/cli.py", evidence="argparse help omits it")],
+    )
+
+    clusters = prep.cluster_findings(prep.load_findings(tmp_path)[0])
+
+    assert len(clusters) == 1
+    assert clusters[0]["dimensions"] == ["correctness", "docs"]
+    assert len(clusters[0]["locations"]) == 2
+
+
+def test_a_cluster_takes_the_severity_of_its_most_severe_member(prep, tmp_path):
+    """A high-severity location must not be buried under a low-severity lead."""
+    write_findings(
+        tmp_path,
+        "findings-docs.json",
+        [
+            make_finding(severity=LOW, path="docs/a.mdx", title="low one"),
+            make_finding(severity=HIGH, path="docs/b.mdx", title="high one"),
+        ],
+    )
+
+    clusters = prep.cluster_findings(prep.load_findings(tmp_path)[0])
+
+    assert len(clusters) == 1
+    assert clusters[0]["severity"] == HIGH
+    assert clusters[0]["title"] == "high one"
+
+
+def test_two_findings_at_the_same_location_produce_one_location(prep, tmp_path):
+    write_findings(
+        tmp_path,
+        "findings-docs.json",
+        [
+            make_finding(path="docs/guides/chat.mdx", symbol="Prerequisites"),
+            make_finding(path="docs/guides/chat.mdx", symbol="Prerequisites"),
+        ],
+    )
+
+    clusters = prep.cluster_findings(prep.load_findings(tmp_path)[0])
+
+    assert clusters[0]["member_count"] == 2
+    assert len(clusters[0]["locations"]) == 1
+
+
+# ----------------------------------------------------------------------
+# Loading: a malformed finding is quarantined, not fatal
+# ----------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "field", ["severity", "title", "why", "evidence", "cluster_key"]
+)
+def test_a_finding_missing_a_required_field_is_quarantined_not_defaulted(
+    prep, tmp_path, field
+):
+    """A dropped field must be loud — a guessed cluster key re-files duplicates.
+
+    Loud, but not fatal: the lenses emit one finding per LOCATION, so a big run
+    is a hundred independent chances to drop a field. Aborting the batch over one
+    bad record throws away every other lens's night of work.
+    """
+    assert field in prep.REQUIRED_FINDING_FIELDS
+    broken = make_finding()
+    del broken[field]
+    write_findings(tmp_path, "findings-docs.json", [make_finding(), broken])
+
+    findings, rejects = prep.load_findings(tmp_path)
+
+    assert len(findings) == 1
+    assert findings[0]["cluster_key"] == "docs-guide-prerequisites-missing"
+    assert len(rejects) == 1
+    # The reject has to name the field, or nobody can fix the lens prompt.
+    assert field in rejects[0]
+    assert "findings-docs.json" in rejects[0]
+
+
+def test_a_lens_file_without_a_findings_list_is_quarantined_not_fatal(prep, tmp_path):
+    """A lens that emitted the wrong SHAPE loses only its own file."""
+    good = tmp_path / "docs"
+    good.mkdir()
+    write_findings(good, "findings-docs.json", [make_finding()])
+    bad = tmp_path / "correctness"
+    bad.mkdir()
+    (bad / "findings-correctness.json").write_text(
+        json.dumps({"findings": "not a list"}), encoding="utf-8"
+    )
+
+    findings, rejects = prep.load_findings(tmp_path)
+
+    assert len(findings) == 1
+    assert len(rejects) == 1
+    assert "no top-level 'findings' list" in rejects[0]
+
+
+def test_every_finding_being_malformed_aborts_the_run(prep, tmp_path):
+    """Zero survivors means the schema and the lens prompt have actually drifted.
+
+    That is not one flaky record — it is a run with nothing left to synthesize,
+    and continuing would report an all-clear audit.
+    """
+    broken = make_finding()
+    del broken["cluster_key"]
+    write_findings(tmp_path, "findings-docs.json", [broken, broken])
+
+    with pytest.raises(SystemExit) as excinfo:
+        prep.load_findings(tmp_path)
+
+    assert "cluster_key" in str(excinfo.value)
+
+
+def test_an_empty_findings_directory_aborts_the_run(prep, tmp_path):
+    """Every lens writes `{"findings": []}` even when clean, so zero files means
+    no lens ran at all — synthesizing that would report an all-clear audit."""
+    with pytest.raises(SystemExit) as excinfo:
+        prep.load_findings(tmp_path)
+
+    assert "no lens ran" in str(excinfo.value).lower()
+
+
+def test_an_unreadable_findings_file_aborts_the_run(prep, tmp_path):
+    """Truncated JSON is a lost artifact, not a bad record — nothing to quarantine.
+
+    Quarantine needs to know WHAT it dropped; an unparseable file could hold one
+    finding or a hundred, so continuing would silently under-report the run.
+    """
+    (tmp_path / "findings-docs.json").write_text('{"findings": [', encoding="utf-8")
+
+    with pytest.raises(SystemExit) as excinfo:
+        prep.load_findings(tmp_path)
+
+    assert "Cannot read findings file" in str(excinfo.value)
+
+
+def test_a_lens_with_nothing_to_report_is_not_an_error(prep, tmp_path):
+    write_findings(tmp_path, "findings-docs.json", [])
+
+    assert prep.load_findings(tmp_path) == ([], [])
+
+
+# ----------------------------------------------------------------------
+# Key markers: both spellings, or the schema change re-files everything
+# ----------------------------------------------------------------------
+
+
+def test_both_key_marker_spellings_are_read(prep):
+    """~130 open issues carry `audit-key`; new ones carry `audit-cluster`.
+
+    Reading only the new spelling would make every already-filed finding look
+    new on the first run after the schema change.
+    """
+    issues = [
+        {"number": 1077, "body": "text\n<!-- audit-key: docs-prereqs -->\n"},
+        {"number": 2001, "body": "text\n<!-- audit-cluster: cli-serve-flag -->\n"},
+    ]
+
+    keys = prep.extract_keys(issues)
+
+    assert keys["docs-prereqs"] == [1077]
+    assert keys["cli-serve-flag"] == [2001]
+
+
+def test_key_markers_are_matched_case_and_space_insensitively(prep):
+    issues = [{"number": 42, "body": "<!--audit-cluster:   Docs  Prereqs   -->"}]
+
+    assert prep.extract_keys(issues) == {"docs prereqs": [42]}
+
+
+def test_two_issues_sharing_one_key_are_both_reachable(prep):
+    """Keeping only the first made the second unreachable forever.
+
+    The backlog holds several open issues per defect from before clustering
+    existed, and they frequently carry the SAME key. Mapping a key to one issue
+    number silently orphaned the rest — nothing would ever point at them again.
+    """
+    issues = [
+        {"number": 900, "body": "<!-- audit-key: lemonade-serve-dead -->"},
+        {"number": 950, "body": "<!-- audit-key: lemonade-serve-dead -->"},
+    ]
+
+    assert prep.extract_keys(issues) == {"lemonade-serve-dead": [900, 950]}
+
+
+def test_one_issue_repeating_a_key_is_recorded_once(prep):
+    issues = [
+        {
+            "number": 900,
+            "body": "<!-- audit-key: k --> text <!-- audit-cluster: k -->",
+        }
+    ]
+
+    assert prep.extract_keys(issues) == {"k": [900]}
+
+
+# ----------------------------------------------------------------------
+# Classification against the audit's own filed / suppressed keys
+# ----------------------------------------------------------------------
+
+
+def _cluster(prep, findings: list[dict[str, Any]], tmp_path: Path):
+    write_findings(tmp_path, "findings-docs.json", findings)
+    return prep.cluster_findings(prep.load_findings(tmp_path)[0])
+
+
+def test_a_suppressed_cluster_key_silences_the_whole_defect(prep, tmp_path):
+    """A cluster-key `audit-wontfix` is a verdict on the DEFECT, not one file.
+
+    That key only ever gets written by the post-clustering scheme, so a human
+    who applied it was looking at every location at once and said no.
+    """
+    clusters = _cluster(
+        prep,
+        [
+            make_finding(path="docs/a.mdx", dedup_key="docs-a-prereqs"),
+            make_finding(path="docs/b.mdx", dedup_key="docs-b-prereqs"),
+        ],
+        tmp_path,
+    )
+    key = clusters[0]["cluster_key"]
+
+    prep.classify(clusters, {}, {key: [700]})
+
+    assert clusters[0]["status"] == "suppressed"
+    assert clusters[0]["existing_issues"] == [700]
+    # Nothing survives: the verdict covered every location, so none are dropped
+    # individually and none are left for the reader to file.
+    assert clusters[0]["suppressed_locations"] == 0
+
+
+def test_a_filed_cluster_key_marks_the_whole_defect_already_filed(prep, tmp_path):
+    """A cluster-key hit means this exact defect is already on the tracker."""
+    clusters = _cluster(
+        prep,
+        [
+            make_finding(path="docs/a.mdx", dedup_key="docs-a-prereqs"),
+            make_finding(path="docs/b.mdx", dedup_key="docs-b-prereqs"),
+        ],
+        tmp_path,
+    )
+    key = clusters[0]["cluster_key"]
+
+    prep.classify(clusters, {key: [1077]}, {})
+
+    assert clusters[0]["status"] == "already-filed"
+    assert clusters[0]["existing_issues"] == [1077]
+    assert clusters[0]["existing_issue"] == 1077
+
+
+def test_one_suppressed_location_does_not_silence_the_other_locations(prep, tmp_path):
+    """A location-key `audit-wontfix` covers ONE FILE, and only that file.
+
+    The ~130 pre-clustering issues carry one location key each, so treating any
+    of them as a whole-defect verdict let a single months-old per-file wontfix
+    delete a 39-location defect from the worklist entirely.
+    """
+    clusters = _cluster(
+        prep,
+        [
+            make_finding(path="docs/a.mdx", dedup_key="docs-a-prereqs"),
+            make_finding(path="docs/b.mdx", dedup_key="docs-b-prereqs"),
+            make_finding(path="docs/c.mdx", dedup_key="docs-c-prereqs"),
+        ],
+        tmp_path,
+    )
+
+    prep.classify(clusters, {}, {"docs-b-prereqs": [700]})
+
+    assert clusters[0]["status"] == "new"
+    assert clusters[0]["suppressed_locations"] == 1
+    assert [loc["path"] for loc in clusters[0]["locations"]] == [
+        "docs/a.mdx",
+        "docs/c.mdx",
+    ]
+
+
+def test_a_cluster_whose_every_location_is_suppressed_becomes_suppressed(
+    prep, tmp_path
+):
+    """Nothing left to file is the one case where per-file wontfixes add up."""
+    clusters = _cluster(
+        prep,
+        [
+            make_finding(path="docs/a.mdx", dedup_key="docs-a-prereqs"),
+            make_finding(path="docs/b.mdx", dedup_key="docs-b-prereqs"),
+        ],
+        tmp_path,
+    )
+
+    prep.classify(clusters, {}, {"docs-a-prereqs": [700], "docs-b-prereqs": [701, 702]})
+
+    assert clusters[0]["status"] == "suppressed"
+    assert clusters[0]["suppressed_locations"] == 2
+    # Every issue that voted to suppress, not just the first one found.
+    assert clusters[0]["existing_issues"] == [700, 701, 702]
+
+
+def test_a_filed_location_key_leaves_the_cluster_new_as_a_consolidation_target(
+    prep, tmp_path
+):
+    """One old per-file issue must not swallow 38 locations found tonight.
+
+    A location-key hit means part of this defect is tracked under the old
+    one-issue-per-file scheme. That is a COMMENT on the existing issue plus the
+    remaining locations — never a reason to drop the defect, which is how 38
+    newly-found locations used to vanish behind one months-old issue.
+    """
+    clusters = _cluster(
+        prep,
+        [
+            make_finding(path="docs/a.mdx", dedup_key="docs-a-prereqs"),
+            make_finding(path="docs/b.mdx", dedup_key="docs-b-prereqs"),
+        ],
+        tmp_path,
+    )
+    filed = {"docs-b-prereqs": [1077]}
+
+    prep.classify(clusters, filed, {})
+
+    assert clusters[0]["cluster_key"] not in filed
+    assert clusters[0]["status"] == "new"
+    assert clusters[0]["existing_issues"] == [1077]
+    assert clusters[0]["existing_issue"] == 1077
+    # The defect keeps BOTH locations — the filed one is the consolidation
+    # target, not a location to forget.
+    assert len(clusters[0]["locations"]) == 2
+
+
+def test_every_matching_issue_is_recorded_not_just_the_first(prep, tmp_path):
+    """One defect was filed under N keys before clustering existed.
+
+    So a cluster routinely matches several already-open issues. Reporting only
+    the first leaves the rest open as permanent orphans that nothing will ever
+    point at again — the real backlog has one defect spread over five issues.
+    """
+    clusters = _cluster(
+        prep,
+        [
+            make_finding(path="docs/chat.mdx", dedup_key="docs-chat-prereqs"),
+            make_finding(path="docs/talk.mdx", dedup_key="docs-talk-prereqs"),
+        ],
+        tmp_path,
+    )
+
+    prep.classify(
+        clusters, {"docs-chat-prereqs": [900], "docs-talk-prereqs": [950]}, {}
+    )
+
+    assert clusters[0]["status"] == "new"
+    assert clusters[0]["existing_issues"] == [900, 950]
+    assert clusters[0]["existing_issue"] == 900
+
+
+def test_two_issues_under_one_key_both_reach_the_cluster(prep, tmp_path):
+    """The other half of the `extract_keys` fix, end to end through `classify`.
+
+    One key, two open issues — both must land in `existing_issues`, or the
+    second stays open with nothing pointing at it.
+    """
+    clusters = _cluster(prep, [make_finding()], tmp_path)
+    key = clusters[0]["cluster_key"]
+
+    prep.classify(clusters, {key: [900, 950]}, {})
+
+    assert clusters[0]["status"] == "already-filed"
+    assert clusters[0]["existing_issues"] == [900, 950]
+    assert clusters[0]["existing_issue"] == 900
+
+
+def test_suppression_wins_over_already_filed(prep, tmp_path):
+    """audit-wontfix is permanent; a stale open issue must not resurrect it."""
+    clusters = _cluster(prep, [make_finding()], tmp_path)
+    key = clusters[0]["cluster_key"]
+
+    prep.classify(clusters, {key: [1077]}, {key: [900]})
+
+    assert clusters[0]["status"] == "suppressed"
+    assert clusters[0]["existing_issue"] == 900
+    assert clusters[0]["existing_issues"] == [900]
+
+
+def test_an_unseen_cluster_is_new(prep, tmp_path):
+    clusters = _cluster(prep, [make_finding()], tmp_path)
+
+    prep.classify(clusters, {}, {})
+
+    assert clusters[0]["status"] == "new"
+    assert clusters[0]["existing_issue"] is None
+    assert clusters[0]["existing_issues"] == []
+
+
+# ----------------------------------------------------------------------
+# Backlog search: the whole backlog, not just our own label
+# ----------------------------------------------------------------------
+
+
+@pytest.fixture
+def backlog_issues() -> list[dict[str, Any]]:
+    """A small open backlog: one real duplicate, a receipt, and distractors.
+
+    The duplicate deliberately carries only `documentation` — under the old
+    label-scoped dedup it was invisible, which is how #1077 got re-discovered
+    14 times in a single night.
+    """
+    return [
+        {
+            "number": 1077,
+            "title": "Guide prerequisites missing across ~14 guides",
+            "labels": [{"name": "documentation"}],
+        },
+        {
+            "number": 3300,
+            "title": f"Nightly audit {EM_DASH} normal {EM_DASH} 33620854963",
+            "labels": [{"name": "weekly-audit"}],
+        },
+        {"number": 10, "title": "NPU inference stalls on Strix Halo", "labels": []},
+        {
+            "number": 11,
+            "title": "Electron installer fails on Windows ARM",
+            "labels": [],
+        },
+        {
+            "number": 12,
+            "title": "Telegram adapter drops media attachments",
+            "labels": [],
+        },
+        {
+            "number": 13,
+            "title": "Voice pipeline latency regression in Kokoro",
+            "labels": [],
+        },
+        {"number": 14, "title": "Scratchpad tables leak SQLite handles", "labels": []},
+        {
+            "number": 15,
+            "title": "Blender agent removed from the registry",
+            "labels": [],
+        },
+        {"number": 16, "title": "Bump pytest to 8.x in dev extras", "labels": []},
+        {
+            "number": 17,
+            "title": "OAuth token refresh loops for GitHub connector",
+            "labels": [],
+        },
+        {
+            "number": 18,
+            "title": "Stable Diffusion turbo model download is slow",
+            "labels": [],
+        },
+    ]
+
+
+def test_a_matching_issue_without_the_audit_label_is_surfaced(
+    prep, tmp_path, backlog_issues
+):
+    """THE #1077 fix: the search covers every open issue, not just our label."""
+    clusters = _cluster(
+        prep,
+        [
+            make_finding(
+                title="Guide prerequisites missing",
+                why="Guides do not list prerequisites before the first command.",
+                cluster_key="guide-prerequisites-missing",
+                path="docs/guides/chat.mdx",
+            )
+        ],
+        tmp_path,
+    )
+
+    prep.find_backlog_candidates(clusters, backlog_issues)
+
+    numbers = [c["number"] for c in clusters[0]["backlog_candidates"]]
+    assert 1077 in numbers, clusters[0]["backlog_candidates"]
+    match = next(c for c in clusters[0]["backlog_candidates"] if c["number"] == 1077)
+    assert match["labels"] == ["documentation"]
+
+
+def test_run_receipts_are_never_offered_as_duplicates(prep, tmp_path, backlog_issues):
+    """The audits file issues about themselves; those match nothing."""
+    clusters = _cluster(
+        prep,
+        [
+            make_finding(
+                title="Nightly audit workflow uploads no artifact",
+                why="The nightly audit job finishes without uploading findings.",
+                cluster_key="nightly-audit-artifact-missing",
+                path=".github/workflows/audit.yml",
+            )
+        ],
+        tmp_path,
+    )
+
+    prep.find_backlog_candidates(clusters, backlog_issues)
+
+    assert 3300 not in [c["number"] for c in clusters[0]["backlog_candidates"]]
+
+
+@pytest.mark.parametrize(
+    "title",
+    [
+        f"Nightly audit {EM_DASH} normal {EM_DASH} 33620854963",
+        f"Weekly audit {EM_DASH} deep {EM_DASH} 33620854963",
+        f"Doc walkthrough {EM_DASH} 33620854963",
+    ],
+)
+def test_receipt_titles_are_recognised(prep, title):
+    assert prep.RECEIPT_TITLE_RE.match(title), title
+
+
+def test_a_real_finding_title_is_not_mistaken_for_a_receipt(prep):
+    assert not prep.RECEIPT_TITLE_RE.match("Nightly audit workflow uploads no artifact")
+
+
+# ----------------------------------------------------------------------
+# Tokenization
+# ----------------------------------------------------------------------
+
+
+def test_camel_case_and_kebab_case_spellings_share_tokens(prep):
+    """`LemonadeServer.serve()` and `lemonade-server serve` are the same defect."""
+    assert {"lemonade", "server"} <= prep.tokenize("LemonadeServer")
+    assert {"lemonade", "server"} <= prep.tokenize("lemonade-server serve")
+
+
+def test_snake_case_is_split_too(prep):
+    assert {"lemonade", "server"} <= prep.tokenize("lemonade_server")
+
+
+def test_stopwords_carry_no_signal(prep):
+    tokens = prep.tokenize("the server should not have been used")
+    assert "server" in tokens
+    assert tokens & {"the", "should", "not", "have", "been", "used"} == set()
+
+
+# ----------------------------------------------------------------------
+# Scoring weights: the threshold must mean the same thing at any backlog size
+# ----------------------------------------------------------------------
+
+
+def test_a_token_absent_from_the_backlog_is_weighted_as_maximally_rare(prep):
+    """An unseen token is rarer than any seen one, so it cannot weigh less.
+
+    Defaulting it to 1.0 made the score depend on backlog size: against 1000
+    open issues a rare corpus token weighs ~7, so under-weighting novel query
+    tokens shrank the query norm and inflated every score. The threshold then
+    meant something different in CI than in a unit test.
+    """
+    corpus = [prep.tokenize(f"issue number {i} about widgets") for i in range(40)]
+
+    idf, unseen = prep._idf(corpus)
+
+    assert unseen >= max(idf.values())
+
+
+def test_the_unseen_weight_grows_with_the_backlog(prep):
+    """Sanity check on the direction — a bigger corpus makes rarity worth more."""
+    _, small = prep._idf([prep.tokenize("alpha beta") for _ in range(5)])
+    _, large = prep._idf([prep.tokenize("alpha beta") for _ in range(500)])
+
+    assert large > small
+
+
+def test_scores_do_not_drift_when_the_backlog_grows(prep, tmp_path):
+    """The same cluster and the same duplicate must score alike at any scale.
+
+    This is what the unseen-token weight buys. Distractors are unrelated, so
+    they should move the score barely at all; before the fix they moved it a lot.
+    """
+    clusters = _cluster(
+        prep,
+        [
+            make_finding(
+                title="Guide prerequisites missing",
+                why="Guides do not list prerequisites before the first command.",
+                cluster_key="guide-prerequisites-missing",
+                path="docs/guides/chat.mdx",
+            )
+        ],
+        tmp_path,
+    )
+    duplicate = {
+        "number": 1077,
+        "title": "Guide prerequisites missing across ~14 guides",
+        "labels": [],
+    }
+    distractors = [
+        {
+            "number": 500 + i,
+            "title": f"Unrelated defect {i} in module {i}",
+            "labels": [],
+        }
+        for i in range(200)
+    ]
+
+    def score_against(issues: list[dict[str, Any]]) -> float:
+        import copy
+
+        local = copy.deepcopy(clusters)
+        prep.find_backlog_candidates(local, issues)
+        return next(
+            c["score"] for c in local[0]["backlog_candidates"] if c["number"] == 1077
+        )
+
+    small = score_against([duplicate] + distractors[:5])
+    large = score_against([duplicate] + distractors)
+
+    assert abs(small - large) < 0.1, (small, large)
+
+
+# ----------------------------------------------------------------------
+# Sibling clusters: one defect that five blind judges keyed five ways
+# ----------------------------------------------------------------------
+
+
+def make_cluster(
+    key: str, title: str, path: str, why: str, status: str = "new"
+) -> dict:
+    """A cluster shaped the way `cluster_findings` emits them."""
+    return {
+        "cluster_key": key,
+        "title": title,
+        "why": why,
+        "severity": MEDIUM,
+        "dimensions": ["walkthrough"],
+        "auto_fixable": False,
+        "member_count": 1,
+        "status": status,
+        "locations": [
+            {
+                "path": path,
+                "symbol": "",
+                "evidence": "The guide's first command exits 127.",
+                "dedup_key": key,
+                "dimension": "walkthrough",
+            }
+        ],
+    }
+
+
+#: What the per-guide judges actually wrote for ONE dead command. Five guides,
+#: five judges that cannot see each other, five different cluster keys — and
+#: five issues in a single night. Cluster keys only catch this when independent
+#: judges happen to agree on a slug; here they did not.
+DEAD_COMMAND_WHY = (
+    "The guide tells the reader to run lemonade-server serve, which exits 127 "
+    "on a current Lemonade install."
+)
+DEAD_COMMAND_CLUSTERS = [
+    (
+        "lemonade-serve-command-missing",
+        "lemonade-server serve does not exist on a current Lemonade install",
+        "docs/guides/chat.mdx",
+    ),
+    (
+        "docs-stale-lemonade-start-command",
+        "The documented command to start Lemonade Server does not exist on a "
+        "modern Lemonade install",
+        "docs/guides/talk.mdx",
+    ),
+    (
+        "walkthrough-lemonade-serve-127",
+        "lemonade-server serve is not a command on a current Lemonade install "
+        "- it exits 127",
+        "docs/guides/npu.mdx",
+    ),
+    (
+        "quickstart-lemonade-server-serve-dead",
+        "Quickstart tells the reader to run lemonade-server serve, which no "
+        "current Lemonade install provides",
+        "docs/guides/install.mdx",
+    ),
+    (
+        "rag-guide-lemonade-serve-invalid",
+        "The Lemonade Server start command in the RAG guide does not exist on "
+        "a current install",
+        "docs/sdk/sdks/rag.mdx",
+    ),
+]
+
+
+def dead_command_clusters_of(count: int) -> list[dict[str, Any]]:
+    return [
+        make_cluster(key, title, path, DEAD_COMMAND_WHY)
+        for key, title, path in DEAD_COMMAND_CLUSTERS[:count]
+    ]
+
+
+@pytest.fixture
+def dead_command_clusters() -> list[dict[str, Any]]:
+    return dead_command_clusters_of(len(DEAD_COMMAND_CLUSTERS))
+
+
+@pytest.fixture
+def unrelated_clusters() -> list[dict[str, Any]]:
+    return [
+        make_cluster(
+            "telegram-media-dropped",
+            "Telegram adapter silently drops media attachments",
+            "src/gaia/messaging/telegram.py",
+            "Inbound photos never reach the agent at all.",
+        ),
+        make_cluster(
+            "sd-model-download-progress",
+            "Stable Diffusion turbo model download shows no progress",
+            "src/gaia/sd/mixin.py",
+            "The user sees a blank screen for several minutes.",
+        ),
+    ]
+
+
+def _sibling_keys(cluster: dict[str, Any]) -> set[str]:
+    return {s["cluster_key"] for s in cluster["sibling_clusters"]}
+
+
+def _reachable(clusters: list[dict[str, Any]], start: str) -> set[str]:
+    """Every cluster key connected to *start* through sibling links."""
+    by_key = {c["cluster_key"]: c for c in clusters}
+    seen, stack = {start}, [start]
+    while stack:
+        for key in _sibling_keys(by_key[stack.pop()]):
+            if key not in seen:
+                seen.add(key)
+                stack.append(key)
+    return seen
+
+
+#: Sibling scores are measured against the BACKLOG's term weights, never
+#: weights derived from the run's own findings. Twenty titles stand in for the
+#: open backlog: enough that `lemonade` and `server` read as ordinary terms
+#: rather than maximally rare ones.
+BACKLOG_TITLES = [
+    "Guide prerequisites missing across ~14 guides",
+    "lemonade-server serve fails to start on Windows",
+    "Lemonade Server install docs are out of date",
+    "NPU inference stalls on Strix Halo",
+    "Electron installer fails on Windows ARM",
+    "Telegram adapter drops media attachments",
+    "Voice pipeline latency regression in Kokoro",
+    "Scratchpad tables leak SQLite handles",
+    "Blender agent removed from the registry",
+    "Bump pytest to 8.x in dev extras",
+    "OAuth token refresh loops for GitHub connector",
+    "Stable Diffusion turbo model download is slow",
+    "RAG chunking drops the final page of a PDF",
+    "Agent UI session list does not refresh",
+    "MCP bridge tools time out after 30 seconds",
+    "Whisper ASR mis-detects silence as speech",
+    "Docker build fails on arm64 runners",
+    "Email triage agent ignores the Google connector grant",
+    "Hub agent install leaves a stale sidecar",
+    "CLI help text omits the schedule subcommand",
+]
+
+
+@pytest.fixture
+def weights(prep) -> tuple[dict[str, float], float]:
+    """`(idf, unseen)` from a stable backlog corpus, as `main` passes them."""
+    return prep._idf([prep.tokenize(title) for title in BACKLOG_TITLES])
+
+
+def test_the_backlog_search_hands_its_term_weights_to_sibling_detection(
+    prep, tmp_path, backlog_issues
+):
+    """`find_backlog_candidates` returns the weights so both passes share a scale.
+
+    It still fills in `backlog_candidates` in place; the return value is the new
+    part, and `main` feeds it straight into `find_sibling_clusters`.
+    """
+    clusters = _cluster(prep, [make_finding()], tmp_path)
+
+    idf, unseen = prep.find_backlog_candidates(clusters, backlog_issues)
+
+    assert isinstance(idf, dict) and idf
+    assert unseen >= max(idf.values())
+    assert "backlog_candidates" in clusters[0]
+
+
+def test_five_differently_keyed_findings_for_one_defect_become_siblings(
+    prep, dead_command_clusters, unrelated_clusters, weights
+):
+    """The doc-walkthrough fix: five keys, one dead command, one issue to file."""
+    clusters = dead_command_clusters + unrelated_clusters
+
+    prep.find_sibling_clusters(clusters, *weights)
+
+    dead_keys = {key for key, _, _ in DEAD_COMMAND_CLUSTERS}
+    for cluster in dead_command_clusters:
+        # Every one of the five sees the other four — not merely a chain.
+        assert _sibling_keys(cluster) == dead_keys - {cluster["cluster_key"]}
+    for key in dead_keys:
+        assert _reachable(clusters, key) == dead_keys
+
+
+def test_sibling_scores_do_not_depend_on_how_many_findings_arrived(
+    prep, dead_command_clusters, weights
+):
+    """The regression that forced weights out of the run and onto the backlog.
+
+    Deriving term weights from the run's own findings measured a term's rarity
+    against however many findings happened to arrive, so the same duplicate pair
+    scored 0.65 in a 5-finding run and 0.35 in a 106-finding one. The real
+    2026-08-31 walkthrough (106 findings) found ZERO siblings that way, nine of
+    them one executor crash.
+    """
+    pair = dead_command_clusters[:2]
+    filler = [
+        make_cluster(
+            f"unrelated-defect-{i:02d}",
+            f"Subsystem {i} mishandles its own teardown path",
+            f"src/gaia/module_{i:02d}/core.py",
+            f"Component {i} leaves state behind when it exits.",
+        )
+        for i in range(38)
+    ]
+
+    def score_in_a_run_of(clusters: list[dict[str, Any]]) -> float:
+        prep.find_sibling_clusters(clusters, *weights)
+        return next(
+            s["score"]
+            for s in clusters[0]["sibling_clusters"]
+            if s["cluster_key"] == clusters[1]["cluster_key"]
+        )
+
+    small = score_in_a_run_of(
+        [make_cluster(*c, DEAD_COMMAND_WHY) for c in DEAD_COMMAND_CLUSTERS[:3]]
+    )
+    large = score_in_a_run_of(
+        [make_cluster(*c, DEAD_COMMAND_WHY) for c in DEAD_COMMAND_CLUSTERS[:2]] + filler
+    )
+
+    assert small == pytest.approx(large), (small, large)
+    assert small >= prep.SIBLING_THRESHOLD
+
+
+def test_the_sibling_relation_is_symmetric(prep, dead_command_clusters, weights):
+    """A appears in B's list if and only if B appears in A's. No exceptions.
+
+    The dossier is read section by section, and a section says "where ONE fix
+    closes a group, file ONE issue and skip their sections". A one-way link
+    means the reader merges a group from A's section while B still has a live
+    section of its own — and files the same defect twice.
+    """
+    clusters = dead_command_clusters + [
+        make_cluster(
+            "whisper-download-fails",
+            "The Whisper ASR model download fails midway",
+            "src/gaia/audio/whisper.py",
+            "The Whisper ASR model download fails midway through.",
+        )
+    ]
+
+    prep.find_sibling_clusters(clusters, *weights)
+
+    by_key = {c["cluster_key"]: c for c in clusters}
+    for left in by_key:
+        for right in by_key:
+            if left == right:
+                continue
+            assert (right in _sibling_keys(by_key[left])) == (
+                left in _sibling_keys(by_key[right])
+            ), (left, right)
+
+
+def test_unrelated_defects_do_not_become_siblings(prep, unrelated_clusters, weights):
+    """A false sibling tells the model to merge two real, separate defects."""
+    prep.find_sibling_clusters(unrelated_clusters, *weights)
+
+    for cluster in unrelated_clusters:
+        assert cluster["sibling_clusters"] == []
+
+
+def test_only_new_clusters_are_offered_as_siblings(
+    prep, dead_command_clusters, unrelated_clusters, weights
+):
+    """A suppressed or already-filed cluster must never pull a new one along."""
+    settled = dead_command_clusters[0]
+    settled["status"] = "suppressed"
+    already = dead_command_clusters[1]
+    already["status"] = "already-filed"
+    clusters = dead_command_clusters + unrelated_clusters
+
+    prep.find_sibling_clusters(clusters, *weights)
+
+    assert "sibling_clusters" not in settled
+    assert "sibling_clusters" not in already
+    still_new = {c["cluster_key"] for c in dead_command_clusters[2:]}
+    for cluster in dead_command_clusters[2:]:
+        # Non-empty, or the subset assertion below would hold vacuously.
+        assert _sibling_keys(cluster)
+        assert _sibling_keys(cluster) <= still_new
+
+
+def test_a_large_duplicate_group_is_never_truncated(prep, weights):
+    """Every member of a nine-way duplicate group sees the other eight.
+
+    Capping each list at the top N silently broke symmetry, and it broke it
+    worst exactly where it mattered most: in a group of nine, A listed five, so
+    a reader merged those six and moved on while the other three kept live
+    sections and got filed separately.
+    """
+    clusters = [
+        make_cluster(
+            f"lemonade-serve-dead-{i:02d}",
+            f"lemonade-server serve does not exist on a current Lemonade install "
+            f"(guide {i})",
+            f"docs/guides/guide-{i:02d}.mdx",
+            DEAD_COMMAND_WHY,
+        )
+        for i in range(9)
+    ]
+    all_keys = {c["cluster_key"] for c in clusters}
+
+    prep.find_sibling_clusters(clusters, *weights)
+
+    for cluster in clusters:
+        assert _sibling_keys(cluster) == all_keys - {cluster["cluster_key"]}
+    assert not hasattr(prep, "MAX_SIBLINGS"), "the cap was removed on purpose"
+
+
+def test_siblings_are_ordered_by_descending_score(prep, weights):
+    """Best match first — the reader works top-down and may stop early."""
+    clusters = dead_command_clusters_of(3) + [
+        make_cluster(
+            "whisper-download-fails",
+            "lemonade-server serve is gone and the Whisper ASR model download fails",
+            "src/gaia/audio/whisper.py",
+            "The Whisper ASR model download fails midway through.",
+        )
+    ]
+
+    prep.find_sibling_clusters(clusters, *weights)
+
+    for cluster in clusters:
+        keyed = [(-s["score"], s["cluster_key"]) for s in cluster["sibling_clusters"]]
+        assert keyed == sorted(keyed), cluster["cluster_key"]
+
+
+def test_a_sibling_of_my_sibling_is_not_made_a_sibling_of_mine(prep, weights):
+    """Direct pairs only — deliberately NOT a transitive closure.
+
+    Union-ing the pairs into connected components was tried and measured: single
+    linkage chained loosely-related pairs until a real 106-finding run collapsed
+    into ONE component of 46 defects, which tells a reader nothing actionable.
+    A links to B and B links to C, but A and C are not alike, so A must not list
+    C.
+    """
+    bridge = [
+        make_cluster(
+            "a-lemonade-serve",
+            "lemonade-server serve does not exist on a current Lemonade install",
+            "docs/guides/chat.mdx",
+            "The quickstart tells the reader to run lemonade-server serve on a "
+            "current Lemonade install.",
+        ),
+        make_cluster(
+            "b-bridge",
+            "lemonade-server serve does not exist, and the Whisper ASR model "
+            "download fails",
+            "docs/guides/talk.mdx",
+            "On a current Lemonade install the lemonade-server serve command is "
+            "gone; the Whisper ASR model download fails too.",
+        ),
+        make_cluster(
+            "c-whisper",
+            "The Whisper ASR model download fails midway",
+            "src/gaia/audio/whisper.py",
+            "The Whisper ASR model download fails midway through.",
+        ),
+    ]
+
+    prep.find_sibling_clusters(bridge, *weights)
+
+    a, b, c = bridge
+    assert _sibling_keys(b) == {"a-lemonade-serve", "c-whisper"}
+    assert _sibling_keys(a) == {"b-bridge"}
+    assert _sibling_keys(c) == {"b-bridge"}
+
+
+def test_sibling_detection_before_classify_raises_rather_than_finding_nothing(
+    prep, tmp_path
+):
+    """`classify` must run first, and the ordering contract enforces itself.
+
+    Sibling detection only considers clusters whose status is `new`. Reading the
+    status with `.get()` made an un-classified run find zero siblings and exit 0
+    — a reordering would silently disable the whole doc-walkthrough fix.
+    """
+    clusters = _cluster(prep, [make_finding()], tmp_path)
+    assert "status" not in clusters[0]
+    idf, unseen = prep._idf([prep.tokenize(title) for title in BACKLOG_TITLES])
+
+    with pytest.raises(KeyError):
+        prep.find_sibling_clusters(clusters, idf, unseen)
+
+
+# ----------------------------------------------------------------------
+# The dossier's warnings
+# ----------------------------------------------------------------------
+
+#: The two warnings a multi-location cluster must carry. The first stops the
+#: model copying a heading that names one file; the second stops it filing one
+#: issue per location.
+HEADING_WARNING = "the heading above is ONE member"
+SPAN_WARNING = "this ONE defect spans"
+
+
+def _render(
+    prep, clusters: list[dict[str, Any]], rejects: list[str] | None = None
+) -> str:
+    counts = {
+        "raw_findings": sum(c["member_count"] for c in clusters),
+        "clusters": len(clusters),
+        "new": sum(1 for c in clusters if c["status"] == "new"),
+        "already_filed": sum(1 for c in clusters if c["status"] == "already-filed"),
+        "suppressed": sum(1 for c in clusters if c["status"] == "suppressed"),
+        "rejected_findings": len(rejects or []),
+    }
+    return prep.render_dossier(clusters, counts, rejects)
+
+
+def test_a_multi_location_cluster_carries_both_warnings(prep, tmp_path):
+    clusters = _cluster(
+        prep,
+        [
+            make_finding(path="docs/guides/chat.mdx", title="chat.mdx has no prereqs"),
+            make_finding(path="docs/guides/talk.mdx"),
+        ],
+        tmp_path,
+    )
+    prep.classify(clusters, {}, {})
+
+    text = _render(prep, clusters)
+
+    assert HEADING_WARNING in text
+    assert f"{SPAN_WARNING} 2 locations" in text
+
+
+def test_a_single_location_cluster_carries_neither_warning(prep, tmp_path):
+    """Both warnings are noise for a one-file defect, and noise gets ignored."""
+    clusters = _cluster(prep, [make_finding()], tmp_path)
+    prep.classify(clusters, {}, {})
+
+    text = _render(prep, clusters)
+
+    assert HEADING_WARNING not in text
+    assert SPAN_WARNING not in text
+
+
+def test_the_dossier_renders_a_cluster_without_a_backlog_search(prep, tmp_path):
+    """`render_dossier` must not require `find_backlog_candidates` to have run.
+
+    They are independent passes; a reorder used to raise KeyError at the very
+    end of an otherwise complete run.
+    """
+    clusters = _cluster(prep, [make_finding()], tmp_path)
+    prep.classify(clusters, {}, {})
+
+    text = _render(prep, clusters)
+
+    assert "**already-open issues:** none above threshold" in text
+
+
+def test_the_dossier_shows_the_sibling_block(prep, dead_command_clusters, weights):
+    prep.find_sibling_clusters(dead_command_clusters, *weights)
+
+    text = _render(prep, dead_command_clusters)
+
+    # Four siblings each, and the header states the count.
+    assert "may be the same defect as these 4 from this run:" in text
+    assert "lemonade-serve-command-missing" in text
+
+
+def test_the_dossier_labels_the_backlog_candidates(prep, tmp_path, backlog_issues):
+    clusters = _cluster(
+        prep,
+        [
+            make_finding(
+                title="Guide prerequisites missing",
+                why="Guides do not list prerequisites before the first command.",
+                cluster_key="guide-prerequisites-missing",
+            )
+        ],
+        tmp_path,
+    )
+    prep.classify(clusters, {}, {})
+    prep.find_backlog_candidates(clusters, backlog_issues)
+
+    text = _render(prep, clusters)
+
+    assert "**already-open issues that may be this defect:**" in text
+    assert "#1077" in text
+
+
+def test_the_three_sections_are_explained_once_not_per_defect(prep, tmp_path):
+    """The preamble was per-cluster boilerplate — 71KB of a 200KB worst case."""
+    clusters = _cluster(
+        prep,
+        [
+            make_finding(path=f"docs/guides/guide-{i:02d}.mdx", cluster_key=f"key-{i}")
+            for i in range(5)
+        ],
+        tmp_path,
+    )
+    prep.classify(clusters, {}, {})
+
+    text = _render(prep, clusters)
+
+    assert text.count("One section per NEW defect below") == 1
+    assert text.count("they rank, they do not decide") == 1
+
+
+# ----------------------------------------------------------------------
+# Truncation: the dossier is a worklist, the JSON is the archive
+# ----------------------------------------------------------------------
+
+
+def test_long_evidence_is_trimmed_in_the_dossier_but_kept_whole_in_the_json(
+    prep, tmp_path
+):
+    """That split IS the contract — trimming the archive would lose the quote."""
+    evidence = "E" * 500
+    findings_dir = tmp_path / "findings"
+    write_findings(
+        findings_dir, "findings-docs.json", [make_finding(evidence=evidence)]
+    )
+    backlog_file = tmp_path / "backlog.json"
+    backlog_file.write_text(
+        json.dumps({"open_issues": [], "filed": [], "suppressed": []}), encoding="utf-8"
+    )
+    out = tmp_path / "worklist.json"
+    dossier = tmp_path / "dossier.md"
+
+    assert (
+        prep.main(
+            [
+                "--findings-dir",
+                str(findings_dir),
+                "--repo",
+                "amd/gaia",
+                "--out",
+                str(out),
+                "--dossier",
+                str(dossier),
+                "--backlog-file",
+                str(backlog_file),
+            ]
+        )
+        == 0
+    )
+
+    payload = json.loads(out.read_text(encoding="utf-8"))
+    assert payload["clusters"][0]["locations"][0]["evidence"] == evidence
+
+    text = dossier.read_text(encoding="utf-8")
+    assert evidence not in text
+    # No filename baked in — the archive is whatever `--out` was called.
+    assert "…[truncated; full text in the synthesis JSON]" in text
+    assert "synthesis-input.json" not in text
+    assert "E" * prep.MAX_EVIDENCE_CHARS in text
+
+
+def test_a_short_quote_is_left_exactly_as_written(prep):
+    assert prep._abbreviate("lemonade-server serve exits 127") == (
+        "lemonade-server serve exits 127"
+    )
+
+
+def test_a_long_issue_title_is_shortened_for_the_reference_line(prep):
+    """Candidate titles only identify an issue the reader will go and open."""
+    assert prep._shorten("T" * 200).endswith("…")
+    assert len(prep._shorten("T" * 200)) == 111
+    assert prep._shorten("short title") == "short title"
+
+
+# ----------------------------------------------------------------------
+# The mis-keying alarm
+# ----------------------------------------------------------------------
+
+MISKEY_WARNING = "The lenses barely clustered anything"
+
+
+def _distinct_key_clusters(prep, tmp_path, findings_per_key: int, keys: int):
+    return _cluster(
+        prep,
+        [
+            make_finding(
+                cluster_key=f"key-{k:02d}",
+                path=f"docs/guides/guide-{k:02d}-{n}.mdx",
+            )
+            for k in range(keys)
+            for n in range(findings_per_key)
+        ],
+        tmp_path,
+    )
+
+
+def test_a_lens_that_keyed_per_location_sets_off_the_alarm(prep, tmp_path):
+    """20 findings, 20 keys — the lens keyed by LOCATION, not by root cause.
+
+    That is the original bug: one dead command became five issues. When nothing
+    collapses, the sibling groups are the only dedup signal left, so the dossier
+    has to say so rather than let the model file 20 issues.
+    """
+    clusters = _distinct_key_clusters(prep, tmp_path, findings_per_key=1, keys=20)
+    prep.classify(clusters, {}, {})
+
+    assert len(clusters) == 20
+    assert MISKEY_WARNING in _render(prep, clusters)
+
+
+def test_a_run_that_clustered_properly_does_not_set_off_the_alarm(prep, tmp_path):
+    """20 findings collapsing to 3 defects is the system working."""
+    clusters = _distinct_key_clusters(prep, tmp_path, findings_per_key=7, keys=3)
+    prep.classify(clusters, {}, {})
+
+    assert len(clusters) == 3
+    assert MISKEY_WARNING not in _render(prep, clusters)
+
+
+def test_a_tiny_run_does_not_set_off_the_alarm(prep, tmp_path):
+    """Three unrelated findings are three defects, not evidence of mis-keying.
+
+    Below the 10-finding floor the ratio is noise — every clean small night
+    would cry wolf and the warning would stop being read.
+    """
+    clusters = _distinct_key_clusters(prep, tmp_path, findings_per_key=1, keys=3)
+    prep.classify(clusters, {}, {})
+
+    assert len(clusters) == 3
+    assert MISKEY_WARNING not in _render(prep, clusters)
+
+
+def test_the_dossier_names_every_duplicate_issue_for_a_skipped_cluster(prep, tmp_path):
+    """Five open issues for one defect must all be named, or four stay orphaned."""
+    clusters = _cluster(prep, [make_finding()], tmp_path)
+    key = clusters[0]["cluster_key"]
+    prep.classify(clusters, {key: [900, 950]}, {})
+
+    text = _render(prep, clusters)
+
+    assert "#900, #950" in text
+    assert "several open issues track this one defect" in text
+
+
+# ----------------------------------------------------------------------
+# The dossier's markers: the synthesis prompt copies these verbatim
+# ----------------------------------------------------------------------
+
+
+def test_the_dossier_carries_both_keys_labelled_by_the_marker_they_become(
+    prep, tmp_path
+):
+    """The prompt writes two markers, so the dossier must carry two keys.
+
+    `audit-cluster` is the root-cause key and `audit-key` is the first location's
+    — the second is what the ~130 already-open issues are matched on. Showing
+    only the cluster key made the model invent an `audit-key`, and an invented
+    key matches nothing on the next run.
+    """
+    clusters = _cluster(
+        prep,
+        [make_finding(path="docs/a.mdx", dedup_key="docs-a-prereqs")],
+        tmp_path,
+    )
+    prep.classify(clusters, {}, {})
+
+    text = _render(prep, clusters)
+
+    assert (
+        "- **cluster key:** `docs-guide-prerequisites-missing` (use as `audit-cluster`)"
+        in text
+    )
+    assert "- **first location key:** `docs-a-prereqs` (use as `audit-key`)" in text
+
+
+def test_the_dossier_tells_the_reader_to_comment_on_a_partly_tracked_defect(
+    prep, tmp_path
+):
+    """A location-key hit is a consolidation instruction, not a skip.
+
+    The cluster stays NEW — so it keeps a section — and that section has to say
+    "comment on #1077", or the model files a duplicate of the very issue the
+    location key matched.
+    """
+    clusters = _cluster(
+        prep,
+        [
+            make_finding(path="docs/a.mdx", dedup_key="docs-a-prereqs"),
+            make_finding(path="docs/b.mdx", dedup_key="docs-b-prereqs"),
+        ],
+        tmp_path,
+    )
+    prep.classify(clusters, {"docs-a-prereqs": [1077]}, {})
+
+    text = _render(prep, clusters)
+
+    assert "#1077 already track part of this defect" in text
+    assert "do not open another" in text
+    # It is still a NEW defect with a section of its own, not a skipped line.
+    assert "Skipped (do not re-file" not in text
+
+
+def test_the_dossier_says_how_many_locations_were_dropped_as_wontfix(prep, tmp_path):
+    """The count is the reader's only clue that the location list is partial."""
+    clusters = _cluster(
+        prep,
+        [
+            make_finding(path="docs/a.mdx", dedup_key="docs-a-prereqs"),
+            make_finding(path="docs/b.mdx", dedup_key="docs-b-prereqs"),
+            make_finding(path="docs/c.mdx", dedup_key="docs-c-prereqs"),
+        ],
+        tmp_path,
+    )
+    prep.classify(clusters, {}, {"docs-b-prereqs": [700]})
+
+    text = _render(prep, clusters)
+
+    assert "1 location(s) omitted as `audit-wontfix`" in text
+    assert "docs/b.mdx" not in text
+    assert "docs/a.mdx" in text and "docs/c.mdx" in text
+
+
+def test_a_clean_run_says_nothing_about_omitted_locations(prep, tmp_path):
+    """Zero suppressed locations must print no line at all — noise gets skimmed."""
+    clusters = _cluster(prep, [make_finding()], tmp_path)
+    prep.classify(clusters, {}, {})
+
+    assert "omitted as `audit-wontfix`" not in _render(prep, clusters)
+
+
+def test_one_defect_is_called_a_defect_not_defects(prep, tmp_path):
+    """The header is the first line the model reads; "1 defects" reads as a bug."""
+    clusters = _cluster(prep, [make_finding()], tmp_path)
+    prep.classify(clusters, {}, {})
+
+    text = _render(prep, clusters)
+
+    assert "collapsed to 1 distinct defect:" in text
+    assert "1 defects" not in text
+
+
+def test_a_long_location_list_is_truncated_with_the_elided_count(prep, tmp_path):
+    """The dossier is a worklist; the JSON keeps every location.
+
+    The cap matches what the synthesis prompt allows in the issue's location
+    table, so the model is never shown more rows than it may write — but it must
+    be told how many it did not see, or the issue claims a smaller blast radius
+    than the defect has.
+    """
+    assert prep.MAX_LOCATIONS_SHOWN == 20
+    clusters = _cluster(
+        prep,
+        [
+            make_finding(path=f"docs/guides/guide-{i:02d}.mdx", evidence=f"guide {i}")
+            for i in range(25)
+        ],
+        tmp_path,
+    )
+    prep.classify(clusters, {}, {})
+
+    text = _render(prep, clusters)
+
+    assert "- **locations (25):**" in text
+    assert text.count("docs/guides/guide-") == 20
+    assert "…and 5 more locations" in text
+    assert "say in the issue how many were elided" in text
+
+
+# ----------------------------------------------------------------------
+# Quarantined findings are reported, never silently dropped
+# ----------------------------------------------------------------------
+
+
+def test_the_dossier_names_the_findings_it_dropped(prep, tmp_path):
+    """A quarantined finding that nobody hears about is a silently lost defect.
+
+    Quarantine is only acceptable because it is loud: the lens prompt gets fixed
+    from this block and the CI error annotation, not from a diff in the count.
+    """
+    clusters = _cluster(prep, [make_finding()], tmp_path)
+    prep.classify(clusters, {}, {})
+
+    text = _render(prep, clusters, ["findings-docs.json[3]: missing cluster_key"])
+
+    assert "1 finding(s) were dropped as malformed" in text
+    assert "findings-docs.json[3]: missing cluster_key" in text
+
+
+def test_the_dropped_findings_block_is_capped_but_states_the_true_total(prep, tmp_path):
+    """Listing 200 rejects buries the worklist; hiding the count hides the drift."""
+    clusters = _cluster(prep, [make_finding()], tmp_path)
+    prep.classify(clusters, {}, {})
+    rejects = [f"findings-docs.json[{i}]: missing why" for i in range(14)]
+
+    text = _render(prep, clusters, rejects)
+
+    assert "14 finding(s) were dropped as malformed" in text
+    assert "…and 4 more" in text
+    assert "findings-docs.json[9]: missing why" in text
+    assert "findings-docs.json[10]: missing why" not in text
+
+
+def test_a_run_with_no_rejects_carries_no_dropped_findings_block(prep, tmp_path):
+    clusters = _cluster(prep, [make_finding()], tmp_path)
+    prep.classify(clusters, {}, {})
+
+    assert "dropped as malformed" not in _render(prep, clusters)
+
+
+# ----------------------------------------------------------------------
+# End to end, offline
+# ----------------------------------------------------------------------
+
+
+def test_main_writes_a_worklist_and_a_dossier_without_touching_gh(
+    prep, tmp_path, backlog_issues, capsys
+):
+    findings_dir = tmp_path / "findings"
+    write_findings(
+        findings_dir / "docs",
+        "findings-docs.json",
+        [
+            make_finding(
+                title="Guide prerequisites missing",
+                why="Guides do not list prerequisites before the first command.",
+                cluster_key="guide-prerequisites-missing",
+                path="docs/guides/chat.mdx",
+            ),
+            make_finding(
+                title="Guide prerequisites missing",
+                why="Guides do not list prerequisites before the first command.",
+                cluster_key="guide-prerequisites-missing",
+                path="docs/guides/talk.mdx",
+            ),
+        ],
+    )
+    backlog_file = tmp_path / "backlog.json"
+    backlog_file.write_text(
+        json.dumps({"open_issues": backlog_issues, "filed": [], "suppressed": []}),
+        encoding="utf-8",
+    )
+    out = tmp_path / "worklist.json"
+    dossier = tmp_path / "dossier.md"
+
+    exit_code = prep.main(
+        [
+            "--findings-dir",
+            str(findings_dir),
+            "--repo",
+            "amd/gaia",
+            "--out",
+            str(out),
+            "--dossier",
+            str(dossier),
+            "--backlog-file",
+            str(backlog_file),
+        ]
+    )
+
+    assert exit_code == 0
+    payload = json.loads(out.read_text(encoding="utf-8"))
+    assert payload["counts"] == {
+        "raw_findings": 2,
+        "clusters": 1,
+        "new": 1,
+        "already_filed": 0,
+        "suppressed": 0,
+        "open_issues_searched": len(backlog_issues),
+        "rejected_findings": 0,
+    }
+    assert len(payload["clusters"][0]["locations"]) == 2
+
+    text = dossier.read_text(encoding="utf-8")
+    # The synthesis model must be told to file ONE issue, not one per location.
+    assert "this ONE defect spans 2 locations" in text
+    assert "#1077" in text
+    assert "2 raw findings -> 1 defect (" in capsys.readouterr().out
+
+
+def test_main_reports_no_new_defects_rather_than_an_empty_dossier(
+    prep, tmp_path, backlog_issues
+):
+    """A clean run must say so explicitly — a blank dossier reads as a crash."""
+    findings_dir = tmp_path / "findings"
+    write_findings(findings_dir, "findings-docs.json", [make_finding()])
+    backlog_file = tmp_path / "backlog.json"
+    backlog_file.write_text(
+        json.dumps(
+            {
+                "open_issues": backlog_issues,
+                "filed": [
+                    {
+                        "number": 1077,
+                        "body": "<!-- audit-key: docs-guide-prerequisites-missing -->",
+                    }
+                ],
+                "suppressed": [],
+            }
+        ),
+        encoding="utf-8",
+    )
+    out = tmp_path / "worklist.json"
+    dossier = tmp_path / "dossier.md"
+
+    assert (
+        prep.main(
+            [
+                "--findings-dir",
+                str(findings_dir),
+                "--repo",
+                "amd/gaia",
+                "--out",
+                str(out),
+                "--dossier",
+                str(dossier),
+                "--backlog-file",
+                str(backlog_file),
+            ]
+        )
+        == 0
+    )
+
+    text = dossier.read_text(encoding="utf-8")
+    assert "No new defects this run. File nothing." in text
+    assert "already-filed: `docs-guide-prerequisites-missing`" in text
+
+
+def test_main_creates_the_output_directory(prep, tmp_path):
+    """The workflow writes into a subdirectory that does not exist yet.
+
+    Failing here throws away a complete run at the last line, after every lens
+    and the whole backlog search have already been paid for.
+    """
+    findings_dir = tmp_path / "findings"
+    write_findings(findings_dir, "findings-docs.json", [make_finding()])
+    backlog_file = tmp_path / "backlog.json"
+    backlog_file.write_text(
+        json.dumps({"open_issues": [], "filed": [], "suppressed": []}),
+        encoding="utf-8",
+    )
+    out = tmp_path / "sub" / "dir" / "worklist.json"
+    dossier = tmp_path / "other" / "dossier.md"
+    assert not out.parent.exists()
+
+    exit_code = prep.main(
+        [
+            "--findings-dir",
+            str(findings_dir),
+            "--repo",
+            "amd/gaia",
+            "--out",
+            str(out),
+            "--dossier",
+            str(dossier),
+            "--backlog-file",
+            str(backlog_file),
+        ]
+    )
+
+    assert exit_code == 0
+    assert json.loads(out.read_text(encoding="utf-8"))["counts"]["clusters"] == 1
+    assert dossier.read_text(encoding="utf-8").startswith("# Synthesis worklist")
+
+
+def test_main_quarantines_a_bad_finding_and_reports_it_three_ways(
+    prep, tmp_path, capsys
+):
+    """One bad record costs one record — but it is counted, annotated, and printed.
+
+    The lenses emit one finding per location, so a 106-finding night is 106
+    chances to drop a field. Failing the batch threw away every other lens's
+    work; failing silently would let the lens prompt drift for months.
+    """
+    findings_dir = tmp_path / "findings"
+    broken = make_finding(path="docs/b.mdx")
+    del broken["evidence"]
+    write_findings(
+        findings_dir, "findings-docs.json", [make_finding(path="docs/a.mdx"), broken]
+    )
+    backlog_file = tmp_path / "backlog.json"
+    backlog_file.write_text(
+        json.dumps({"open_issues": [], "filed": [], "suppressed": []}),
+        encoding="utf-8",
+    )
+    out = tmp_path / "worklist.json"
+    dossier = tmp_path / "dossier.md"
+
+    exit_code = prep.main(
+        [
+            "--findings-dir",
+            str(findings_dir),
+            "--repo",
+            "amd/gaia",
+            "--out",
+            str(out),
+            "--dossier",
+            str(dossier),
+            "--backlog-file",
+            str(backlog_file),
+        ]
+    )
+
+    assert exit_code == 0
+    counts = json.loads(out.read_text(encoding="utf-8"))["counts"]
+    assert counts == {
+        "raw_findings": 1,
+        "clusters": 1,
+        "new": 1,
+        "already_filed": 0,
+        "suppressed": 0,
+        "open_issues_searched": 0,
+        "rejected_findings": 1,
+    }
+    assert "1 finding(s) were dropped as malformed" in dossier.read_text(
+        encoding="utf-8"
+    )
+    # A GitHub error annotation, so it shows on the run without opening the log.
+    assert "::error title=Malformed finding::" in capsys.readouterr().err
+
+
+def test_main_aborts_when_the_backlog_query_hit_its_own_limit(prep, tmp_path):
+    """A truncated backlog is a partial dedup search wearing a green checkmark.
+
+    Searching "the whole open backlog" is the #1077 fix; if `--limit` capped the
+    query then the issues past the cap were never compared, and the run files
+    duplicates of exactly the issues it could not see.
+    """
+    findings_dir = tmp_path / "findings"
+    write_findings(findings_dir, "findings-docs.json", [make_finding()])
+    backlog_file = tmp_path / "backlog.json"
+    backlog_file.write_text(
+        json.dumps(
+            {
+                "open_issues": [
+                    {"number": n, "title": f"Some open issue {n}", "labels": []}
+                    for n in (10, 11, 12)
+                ],
+                "filed": [],
+                "suppressed": [],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(SystemExit) as excinfo:
+        prep.main(
+            [
+                "--findings-dir",
+                str(findings_dir),
+                "--repo",
+                "amd/gaia",
+                "--limit",
+                "3",
+                "--out",
+                str(tmp_path / "worklist.json"),
+                "--dossier",
+                str(tmp_path / "dossier.md"),
+                "--backlog-file",
+                str(backlog_file),
+            ]
+        )
+
+    assert "hitting the --limit of 3" in str(excinfo.value)
+    assert "Raise --limit" in str(excinfo.value)

--- a/tests/unit/test_claude_audit_workflow_contract.py
+++ b/tests/unit/test_claude_audit_workflow_contract.py
@@ -1,0 +1,355 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""The proactive Claude audits fail SILENTLY — assert the settings that stop that.
+
+Every failure these tests pin has already happened at least once, and none of
+them turned a run red at the time:
+
+* The scheduled-actor gate rejected every run for five weeks and the runs stayed
+  green, because ``allowed_bots`` omitted the bot that actors a post-release
+  schedule event (#3059). The audit itself filed that bug, twice, and nothing
+  pinned it either time.
+* A completeness constant hand-synced to a job matrix by comment silently
+  under-counted, letting a short SARIF clear real unfixed alerts (#3060).
+* The doc walkthrough reported green when its judge wrote no findings at all, so
+  a crash read as a pass (#3058).
+* Dedup only searched the audit's own label, so one defect became many issues and
+  a four-month-old issue was rediscovered 14 times in one night.
+
+These are configuration assertions, not behaviour tests. They exist because the
+workflow still runs and still goes green — it just stops auditing anything.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+WORKFLOW_DIR = REPO_ROOT / ".github" / "workflows"
+
+NIGHTLY_AUDIT = WORKFLOW_DIR / "claude-nightly-audit.yml"
+DOC_WALKTHROUGH = WORKFLOW_DIR / "claude-weekly-doc-walkthrough.yml"
+SECURITY_AUDIT = WORKFLOW_DIR / "claude-security-audit.yml"
+
+#: Every scheduled Claude workflow that files or publishes findings.
+PROACTIVE_WORKFLOWS = (NIGHTLY_AUDIT, DOC_WALKTHROUGH, SECURITY_AUDIT)
+
+#: The action whose actor gate rejects a bot-actored scheduled run.
+CLAUDE_ACTION = "anthropics/claude-code-action"
+
+#: On a `schedule` event the actor is whoever last touched the default branch,
+#: which in this repo is one of these two bots. Both must be allowed or the run
+#: is rejected before Claude starts.
+REQUIRED_BOTS = ("github-merge-queue", "github-actions")
+
+
+def _load(path: Path) -> dict:
+    assert path.is_file(), f"{path} is missing"
+    # `on:` is parsed by PyYAML 1.1 rules as the boolean True, hence the lookup
+    # helper below.
+    return yaml.safe_load(path.read_text(encoding="utf-8"))
+
+
+def _triggers(workflow: dict) -> dict:
+    return workflow.get("on") or workflow.get(True)
+
+
+def _steps(workflow: dict):
+    for job in workflow["jobs"].values():
+        for step in job.get("steps") or []:
+            yield step
+
+
+def _claude_steps(workflow: dict):
+    return [s for s in _steps(workflow) if CLAUDE_ACTION in str(s.get("uses", ""))]
+
+
+@pytest.fixture(scope="module")
+def nightly() -> dict:
+    return _load(NIGHTLY_AUDIT)
+
+
+@pytest.fixture(scope="module")
+def walkthrough() -> dict:
+    return _load(DOC_WALKTHROUGH)
+
+
+@pytest.fixture(scope="module")
+def security() -> dict:
+    return _load(SECURITY_AUDIT)
+
+
+# ----------------------------------------------------------------------
+# The scheduled-actor gate (#3059)
+# ----------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("path", PROACTIVE_WORKFLOWS, ids=lambda p: p.name)
+def test_every_scheduled_claude_step_allows_the_bots_that_actor_it(path: Path):
+    """Without this the run is rejected before Claude starts — and reports green.
+
+    #3059 is this bug, filed by the audit about itself: the allowlist named only
+    `github-merge-queue`, so the first run after any release — where `claude.yml`
+    pushes release notes to main as `github-actions[bot]` — was rejected.
+    """
+    workflow = _load(path)
+    assert "schedule" in _triggers(workflow), f"{path.name} is not scheduled"
+    steps = _claude_steps(workflow)
+    assert steps, f"{path.name} declares no {CLAUDE_ACTION} step"
+    for step in steps:
+        allowed = str(step["with"].get("allowed_bots", ""))
+        missing = [bot for bot in REQUIRED_BOTS if bot not in allowed]
+        assert not missing, (
+            f"{path.name} step {step.get('name', step.get('id'))!r} omits "
+            f"{missing} from allowed_bots ({allowed!r}). A scheduled run actored "
+            f"by that bot is rejected before Claude starts, and reports green."
+        )
+
+
+# ----------------------------------------------------------------------
+# A partial sweep must never read as a clean bill of health (#3058, #3060)
+# ----------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("path", PROACTIVE_WORKFLOWS, ids=lambda p: p.name)
+def test_a_lens_that_wrote_no_findings_fails_its_job(path: Path):
+    """Every lens writes `{"findings": []}` when clean, so a missing file means
+    the lens never ran. Uploading nothing must fail, not warn."""
+    workflow = _load(path)
+    uploads = [
+        s
+        for s in _steps(workflow)
+        if "upload-artifact" in str(s.get("uses", ""))
+        and "findings" in str(s.get("with", {}).get("path", ""))
+    ]
+    assert uploads, f"{path.name} uploads no findings artifact"
+    for step in uploads:
+        assert step["with"].get("if-no-files-found") == "error", (
+            f"{path.name}: a missing findings file must fail the job — a silent "
+            f"skip reads as 'audited, clean' (#3058)."
+        )
+
+
+def test_the_walkthrough_refuses_to_synthesize_a_partial_sweep(walkthrough: dict):
+    """#3058's remaining half: the per-doc upload failing is not enough.
+
+    The synthesize job runs on `!cancelled()`, so without a run-level gate a night
+    where guides went unwalked still reached synthesis, found nothing to file, and
+    called that a clean run.
+    """
+    steps = walkthrough["jobs"]["synthesize"]["steps"]
+    gate = [s for s in steps if "reported in" in str(s.get("name", ""))]
+    assert gate, (
+        "the walkthrough's synthesize job needs a step requiring every discovered "
+        "doc to have produced findings, matching the nightly audit's dimension gate"
+    )
+    run = gate[0]["run"]
+    assert "exit 1" in run, "a short sweep must fail, not warn"
+
+
+def test_the_nightly_audit_refuses_to_synthesize_a_partial_sweep(nightly: dict):
+    steps = nightly["jobs"]["synthesize"]["steps"]
+    gate = [s for s in steps if "reported in" in str(s.get("name", ""))]
+    assert gate and "exit 1" in gate[0]["run"]
+
+
+@pytest.mark.parametrize(
+    ("path", "job", "matrix_key", "count_output"),
+    [
+        (NIGHTLY_AUDIT, "audit", "dimension", "dimension_count"),
+        (SECURITY_AUDIT, "audit", "lens", "lens_count"),
+    ],
+    ids=["nightly-dimensions", "security-lenses"],
+)
+def test_the_completeness_count_is_derived_from_the_matrix_not_hand_typed(
+    path: Path, job: str, matrix_key: str, count_output: str
+):
+    """#3060: the expected-count constant used to be hand-synced by comment.
+
+    Adding a lens without bumping it made the guard under-count and pass, which
+    for the security audit means uploading a short SARIF that marks real unfixed
+    alerts as FIXED.
+    """
+    workflow = _load(path)
+    matrix = workflow["jobs"][job]["strategy"]["matrix"][matrix_key]
+    assert "fromJSON" in str(matrix) and "preflight.outputs" in str(matrix), (
+        f"{path.name}: the {matrix_key} matrix must come from the preflight output "
+        f"that also feeds the completeness check, so the two cannot drift"
+    )
+    body = path.read_text(encoding="utf-8")
+    assert re.search(rf"needs\.preflight\.outputs\.{count_output}", body), (
+        f"{path.name}: the completeness check must read {count_output} from "
+        f"preflight rather than a hand-typed constant (#3060)"
+    )
+
+
+# ----------------------------------------------------------------------
+# Dedup: one issue per defect, searched against the whole backlog
+# ----------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("path", (NIGHTLY_AUDIT, DOC_WALKTHROUGH), ids=lambda p: p.name)
+def test_the_deterministic_dedup_pass_runs_before_anything_is_filed(path: Path):
+    """Model-eyeballed dedup across ~900 open issues produced a 2.35x duplication
+    ratio. The clustering + whole-backlog search has to be a real script."""
+    workflow = _load(path)
+    steps = workflow["jobs"]["synthesize"]["steps"]
+    prep_index = next(
+        (
+            i
+            for i, s in enumerate(steps)
+            if "prepare_synthesis.py" in str(s.get("run", ""))
+        ),
+        None,
+    )
+    assert (
+        prep_index is not None
+    ), f"{path.name} must run scripts/audit/prepare_synthesis.py before filing"
+    claude_index = next(
+        i for i, s in enumerate(steps) if CLAUDE_ACTION in str(s.get("uses", ""))
+    )
+    assert prep_index < claude_index, "dedup must run BEFORE the filing step"
+
+
+def test_the_dedup_script_exists():
+    assert (REPO_ROOT / "scripts" / "audit" / "prepare_synthesis.py").is_file()
+
+
+@pytest.mark.parametrize("path", (NIGHTLY_AUDIT, DOC_WALKTHROUGH), ids=lambda p: p.name)
+def test_lenses_emit_a_root_cause_cluster_key(path: Path):
+    """A file-scoped key files N issues for one N-file defect.
+
+    `lemonade-server serve` became five issues in one night that way — one per
+    doc walked, for a single fix spanning 163 occurrences.
+    """
+    body = path.read_text(encoding="utf-8")
+    assert "cluster_key" in body, (
+        f"{path.name}: findings must carry a root-cause `cluster_key` distinct "
+        f"from the per-location `dedup_key`"
+    )
+
+
+@pytest.mark.parametrize("path", (NIGHTLY_AUDIT, DOC_WALKTHROUGH), ids=lambda p: p.name)
+def test_synthesis_can_comment_on_an_existing_issue_instead_of_filing(path: Path):
+    """The #1077 fix. Dedup that only searched its own label could not see a
+    four-month-old milestoned issue, so it re-filed it 14 times in one night."""
+    body = path.read_text(encoding="utf-8")
+    assert "gh issue comment" in body, (
+        f"{path.name}: synthesis must be able to comment on an existing backlog "
+        f"issue rather than always filing a new one"
+    )
+
+
+# ----------------------------------------------------------------------
+# Run receipts belong in the run, not the tracker
+# ----------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("path", (NIGHTLY_AUDIT, DOC_WALKTHROUGH), ids=lambda p: p.name)
+def test_the_run_summary_goes_to_the_job_summary_not_a_new_issue(path: Path):
+    """19 bookkeeping issues accumulated at one per run, none actionable."""
+    workflow = _load(path)
+    steps = workflow["jobs"]["synthesize"]["steps"]
+    publishes = [s for s in steps if "triage-report.md" in str(s.get("run", ""))]
+    assert publishes, f"{path.name} must publish its run report to a step summary"
+    assert any(
+        "GITHUB_STEP_SUMMARY" in str(s.get("run", "")) for s in publishes
+    ), f"{path.name}: the run report goes to $GITHUB_STEP_SUMMARY"
+
+    body = path.read_text(encoding="utf-8")
+    # The receipt title is only a problem when it is an ISSUE title. The same
+    # words as a job-summary heading are exactly what should replace it, so match
+    # the `gh issue create --title` shape rather than the words alone.
+    receipt_issue = re.search(
+        r"--title\s+\"(Nightly audit|Weekly audit|Doc walkthrough|Security audit)",
+        body,
+    )
+    assert receipt_issue is None, (
+        f"{path.name} still files a per-run receipt issue "
+        f"({receipt_issue.group(0) if receipt_issue else ''!r}). A CI run's "
+        f"bookkeeping belongs in the run, not the tracker — 19 such issues "
+        f"accumulated with nothing actionable in any of them."
+    )
+    assert "NOT to an issue" in body, (
+        f"{path.name}: the synthesis prompt must say explicitly that the run "
+        f"report is a file for the job summary, not an issue"
+    )
+
+
+@pytest.mark.parametrize("path", (NIGHTLY_AUDIT, DOC_WALKTHROUGH), ids=lambda p: p.name)
+def test_a_dry_run_mode_exists_so_dedup_can_be_validated_without_filing(path: Path):
+    """Workflow changes are otherwise untestable without polluting the tracker."""
+    workflow = _load(path)
+    inputs = _triggers(workflow)["workflow_dispatch"]["inputs"]
+    assert "dry_run" in inputs, f"{path.name} needs a dry_run dispatch input"
+    body = path.read_text(encoding="utf-8")
+    assert (
+        "DRY RUN" in body
+    ), f"{path.name}: the synthesis prompt must be told when the run is a dry run"
+
+
+# ----------------------------------------------------------------------
+# Cadence honesty and preserved invariants
+# ----------------------------------------------------------------------
+
+
+def test_the_nightly_audit_says_nightly_everywhere_it_says_anything(nightly: dict):
+    """Filename, display name, and cron told three different stories."""
+    assert NIGHTLY_AUDIT.name == "claude-nightly-audit.yml"
+    assert "Nightly" in nightly["name"]
+    crons = [entry["cron"] for entry in _triggers(nightly)["schedule"]]
+    assert crons and all(
+        cron.split()[2:] == ["*", "*", "*"] for cron in crons
+    ), f"a workflow named nightly must run every day, got {crons}"
+    assert nightly["concurrency"]["group"] == "claude-nightly-audit"
+
+
+def test_the_doc_walkthrough_really_is_weekly(walkthrough: dict):
+    crons = [entry["cron"] for entry in _triggers(walkthrough)["schedule"]]
+    assert crons and all(
+        cron.split()[4] != "*" for cron in crons
+    ), f"a workflow named weekly must pin a day-of-week, got {crons}"
+
+
+@pytest.mark.parametrize("path", (NIGHTLY_AUDIT, DOC_WALKTHROUGH), ids=lambda p: p.name)
+def test_the_wontfix_suppression_mechanism_survives(path: Path):
+    """Closing a finding with `audit-wontfix` must silence it forever. It is the
+    only way a maintainer can permanently dismiss accepted debt."""
+    body = path.read_text(encoding="utf-8")
+    assert "audit-wontfix" in body
+    prep = (REPO_ROOT / "scripts" / "audit" / "prepare_synthesis.py").read_text(
+        encoding="utf-8"
+    )
+    assert (
+        "audit-wontfix" in prep
+    ), "the dedup pass must read the suppressed-forever key set"
+
+
+@pytest.mark.parametrize("path", PROACTIVE_WORKFLOWS, ids=lambda p: p.name)
+def test_the_claude_jobs_stay_read_only(path: Path):
+    """Same rule as the claude.yml review jobs: report, never edit or run repo code."""
+    for step in _claude_steps(_load(path)):
+        args = str(step["with"].get("claude_args", ""))
+        granted = re.search(r"--allowedTools\s+(\S+)", args)
+        assert granted, f"{path.name}: a Claude step declares no --allowedTools"
+        # Compared as a SET, not a substring: `Read,Grep,Glob,Bash,Edit` contains
+        # `Read,Grep,Glob,Bash`, so a substring check waves Edit straight through.
+        assert set(granted.group(1).split(",")) == {"Read", "Grep", "Glob", "Bash"}, (
+            f"{path.name} step {step.get('name', step.get('id'))!r} grants "
+            f"{granted.group(1)} — an audit reports, it never edits or runs repo code"
+        )
+
+
+def test_the_security_audit_never_files_a_public_issue(security: dict):
+    """Findings go to the private code-scanning tab. A public issue would be
+    disclosure."""
+    body = SECURITY_AUDIT.read_text(encoding="utf-8")
+    assert "gh issue create" not in body
+    for job in security["jobs"].values():
+        assert "issues" not in (
+            job.get("permissions") or {}
+        ), "no security-audit job may hold issues: write"


### PR DESCRIPTION
One doc typo used to become five GitHub issues in a night, and a four-month-old milestoned issue (#1077) was rediscovered fourteen times in a single run. Between them the nightly audit and the weekly doc walkthrough were adding ~130 issues a month at a 2.35x duplication ratio — 129 substantive findings covering only 55 distinct defects, plus 19 run receipts nobody could act on. Now one defect is one issue listing all its locations, a defect the backlog already tracks gets a comment instead of a duplicate, and the run report goes to the job summary instead of the tracker.

Three separate causes, each fixed:

- **Keys were file-scoped, so one defect meant N issues.** Findings now carry a second key naming the *root cause* with no path in it. Every location of one defect shares it and merges. (`lemonade-server serve` is one fix across 163 occurrences — it became 5 issues, one per doc walked.)
- **Dedup only searched the audit's own label**, which is exactly why a `documentation`-labelled issue open since May was invisible. A new deterministic pass searches the whole open backlog and hands synthesis a short worklist; synthesis can now comment on what it finds. That pass also groups look-alike findings within one run, which is the doc walkthrough's missing cross-guide memory — its per-guide judges can't see each other.
- **Receipts were issues by design.** They're now `$GITHUB_STEP_SUMMARY`.

The filename `claude-weekly-audit.yml` was the last thing claiming that workflow is weekly — its cron and display name have said nightly for a while — so it's renamed to `claude-nightly-audit.yml`. The `weekly-audit` **label** deliberately keeps its name: it marks provenance rather than cadence, it's shared with the genuinely-weekly walkthrough so no cadence word fits it, and nothing depends on its spelling now that dedup reads the issue-body markers. (The skill doc's old justification — that renaming it "would re-file every open finding" — was simply false, and is corrected rather than repeated.)

Closes #3058, #3059 and #3060 — the audits' own reports about their unreliability. The behaviour in all three was already fixed in the tree; nothing *pinned* it, and #3059 had already regressed that way once when a fix was applied to the canary but not the six sibling steps. `tests/unit/test_claude_audit_workflow_contract.py` now fails if any of the three comes back.

## Test plan

- [ ] `python -m pytest tests/unit/test_audit_synthesis_prep.py tests/unit/test_claude_audit_workflow_contract.py -q` — 105 tests.
- [ ] `actionlint .github/workflows/claude-*.yml` and `python util/lint.py --black --isort`.
- [ ] **Verify the dedup pass against the live backlog without touching it:** `gh workflow run claude-nightly-audit.yml -f dry_run=true`. It files and comments nothing; the job summary shows the raw→deduplicated counts and what it *would* have filed. A watermark check fails the run if any issue was created anyway.
- [ ] Same for the walkthrough: `gh workflow run claude-weekly-doc-walkthrough.yml -f doc_filter=docs/quickstart.mdx -f dry_run=true` (self-hosted STX runner, ~20 min for one guide).
- [ ] Confirm the first real scheduled run files one issue for a multi-file defect, not one per file.

<details>
<summary>🔍 How the dedup pass was validated before merge</summary>

Replayed against the real artifacts of run `33391970579` — the 2026-08-31 walkthrough that produced this cohort — with the backlog reconstructed as it stood *before* that run (843 open issues, 80 previously audit-filed).

Those 106 findings predate the new key, so the replay ran the **worst case**: every finding keyed per location, as if a lens ignored the root-cause instruction entirely. Even then, 66 of 105 clusters were grouped with a same-run sibling and 51 matched an existing open issue, leaving 28 that would file fresh. #1077 surfaced as a candidate for 6 clusters, top-ranked for the prerequisites one. With keys emitted correctly, a 20-finding fixture over the two real duplicate clusters collapses to 3 defects.

Two calibration bugs were found and fixed this way and would not have shown up on a small fixture: term weights derived per-run made the sibling threshold mean different things on different nights (the same duplicate pair scored 0.65 in a 5-finding run and 0.35 in a 106-finding one, so a real 9-finding group scored *zero* siblings), and transitively closing sibling pairs chained into one useless component of 46.

Not verified: the synthesis prompts themselves, which only a real Claude run exercises — hence the dry-run mode.
</details>

<details>
<summary>🔍 Cleanup a maintainer may want after merge</summary>

Nothing in this PR touches existing issues. The 19 open run receipts are now orphaned by design and can be closed in bulk; the ~130 open findings keep working, because the dedup pass reads both the legacy `audit-key` marker and the new `audit-cluster` one. Where several open issues track one defect, the pass surfaces all of them so the next run's comment can name the duplicates.
</details>
