### PR TITLE
docs(claude): correct stale commands, the GaiaAgent status, and the CLI list

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -253,7 +253,7 @@ self-contradicting lifecycle docs.
 
 **Before creating new functionality:**
 1. Check if similar functionality exists in `src/gaia/agents/base/`
-2. Check existing mixins in agent packages (e.g., `hub/agents/chat/python/gaia_agent_chat/tools/`)
+2. Check the reusable tool mixins in `src/gaia/agents/tools/` (indexed by `KNOWN_TOOLS` in [`src/gaia/agents/registry.py`](src/gaia/agents/registry.py))
 3. Extract shared logic into base classes or mixins when patterns repeat
 
 ### Code Comments — Short or Skip
@@ -377,7 +377,7 @@ python -m gaia.mcp.mcp_bridge
 
 **Changes that REQUIRE an eval run before merge:**
 
-- ChatAgent / DocumentQAAgent / FileIOAgent / ChatAgentLite system prompts (`_get_system_prompt()`) or any mixin prompt fragment
+- GaiaAgent / ChatAgent / ChatAgentLite system prompts (`_get_system_prompt()`) or any mixin prompt fragment
 - The base agent's `_compose_system_prompt`, prompt-assembly order, or `_format_tools_for_prompt`
 - Tool registration, tool docstrings, or the JSON tool schema sent to Lemonade
 - Error classification (`LemonadeError` subclasses, `_classify_chat_exception`, `_extract_lemonade_user_message`) or the agent-loop catchall
@@ -462,11 +462,22 @@ python -m pytest tests/ --hybrid   # Cloud + local testing
 
 ### Running GAIA
 ```bash
-lemonade-server serve              # Start LLM backend
+gaia init                          # Install Lemonade Server + models, and start it (first run)
 gaia llm "Hello"                   # Test LLM
 gaia chat                          # Interactive chat
 gaia chat --ui                     # Agent UI (browser-based)
 ```
+
+**Never tell anyone to run `lemonade-server serve`** — Lemonade 10.7/10.8 removed that
+CLI, so the binary does not exist on a current install. There is no portable command to
+substitute: how the server starts depends on the install (Windows tray, macOS app, Linux
+`systemctl --user start lemond`, legacy CLI). `gaia init` is the only thing in the tree
+that auto-starts the server; the normal runtime path (`LemonadeManager.ensure_ready`)
+merely *checks*, and errors out on a stopped server rather than launching one. When you
+need to print a start instruction, call `describe_start_hint()`
+([`src/gaia/llm/lemonade_launcher.py`](src/gaia/llm/lemonade_launcher.py)) instead of
+hard-coding a command — it resolves the installed tooling and never names a binary the
+host lacks.
 
 ### Agent UI Development
 ```bash
@@ -502,20 +513,26 @@ gaia/
 │   ├── chat/           # Agent SDK (AgentSDK class, prompts, app entry)
 │   ├── code_index/     # Code indexing/search backend
 │   ├── connectors/     # Connector framework (Google/GitHub OAuth, MCP-server connectors, grants)
+│   ├── daemon/         # Headless daemon (gaia daemon): custody, broker, scheduler, sidecars
 │   ├── database/       # DatabaseMixin and DatabaseAgent
 │   ├── electron/       # Electron app integration
 │   ├── eval/           # Evaluation framework
+│   ├── factory/        # Claude Code session-corpus harvest/analysis (LLM-free, local cache)
 │   ├── filesystem/     # Filesystem service/utilities
 │   ├── governance/     # Governance / guardrails layer
+│   ├── hub/            # Agent Hub backend (catalog, install, package, publish)
 │   ├── img/            # Shared image assets
 │   ├── installer/      # Install/init commands (gaia init, lemonade installer)
 │   ├── llm/            # LLM backend clients (Lemonade, Claude, OpenAI) + providers/
 │   ├── mcp/            # Model Context Protocol servers/clients
 │   ├── messaging/      # Messaging adapters (Telegram, …)
 │   ├── rag/            # Document retrieval (RAG)
+│   ├── schedule/       # Cron scheduling backend (gaia schedule)
 │   ├── sd/             # Stable Diffusion tool mixin (SDToolsMixin)
 │   ├── scratchpad/     # Scratchpad tables backend
 │   ├── shell/          # Shell integration
+│   ├── sidecar/        # Shared building blocks for local agent sidecars
+│   ├── skills/         # Skill backend (gaia skill): loader, install, audit, signing
 │   ├── talk/           # Voice interaction SDK
 │   ├── testing/        # Test utilities and fixtures
 │   ├── ui/             # Agent UI backend (FastAPI server, routers, SSE, database)
@@ -527,11 +544,15 @@ gaia/
 │   ├── unit/           # Unit tests
 │   ├── mcp/            # MCP integration tests
 │   ├── integration/    # Cross-system integration tests
+│   ├── installer/      # Installer / gaia init tests
 │   ├── stress/         # Stress/load tests
 │   ├── electron/       # Electron app tests (Jest)
 │   ├── fixtures/       # Shared test fixtures/data
 │   └── test_*.py       # Top-level feature tests (sdk, api, chat, code, rag, eval…)
+├── hub/                # Agent Hub packages — agents/<id>/{npm,python}/, skills/, components/
+├── tui/                # Go terminal UI (module github.com/amd/gaia/tui)
 ├── scripts/            # Build, install, and launch scripts
+├── util/               # Repo tooling (lint.py, check_doc_links.py, …)
 ├── docs/               # Documentation (MDX format)
 └── .github/workflows/  # CI/CD pipelines
 ```
@@ -614,10 +635,11 @@ New agents are Python classes inheriting from `Agent` (see [`src/gaia/agents/bas
 When adding a new tool mixin, register it in `KNOWN_TOOLS` so other agents can compose it by name.
 
 ### Default Models
-- `gaia llm` default: `Gemma-4-E4B-it-GGUF` (`DEFAULT_MODEL_NAME` in [`src/gaia/llm/lemonade_client.py`](src/gaia/llm/lemonade_client.py)). ChatAgent and EmailTriageAgent explicitly use it too.
-- Agents that leave `model_id` unset fall back to `Gemma-4-E4B-it-GGUF` — the base `Agent.__init__` default (`model_id or DEFAULT_MODEL_NAME`). That covers GaiaAgent, ChatAgent, BuilderAgent, and the example templates. Every agent shares one model id so switching agents never evicts and cold-reloads the resident model.
-- Context window is pinned per device profile, not per agent: `GPU_CTX_SIZE` (65536, GPU/CPU) and `NPU_CTX_SIZE` (32768, the FLM ceiling) in [`src/gaia/llm/lemonade_client.py`](src/gaia/llm/lemonade_client.py). A machine runs one profile, so exactly one `(model, ctx_size)` pair is ever resident.
-- Vision: `Gemma-4-E4B-it-GGUF` is the default VLM (VLM mixin + EMR agent); `Qwen3-VL-4B-Instruct-GGUF` also supported
+- `gaia llm` default: `Gemma-4-E4B-it-GGUF` (`DEFAULT_MODEL_NAME` in [`src/gaia/llm/lemonade_client.py`](src/gaia/llm/lemonade_client.py)). ChatAgent explicitly uses it too.
+- Agents that leave `model_id` unset fall back to `Gemma-4-E4B-it-GGUF` — the base `Agent.__init__` default (`model_id or DEFAULT_MODEL_NAME`). That covers GaiaAgent, ChatAgent, BuilderAgent, and the example templates. Sharing one model id is what keeps switching agents from evicting and cold-reloading the resident model.
+- **EmailTriageAgent is the one exception.** With no explicit `model_id` it calls `resolve_default_email_model()` (`hub/agents/email/python/gaia_agent_email/model_select.py`), which returns `gemma4-it-e2b-FLM` when an NPU is present *and* that model is already servable, and `DEFAULT_MODEL_NAME` in every other case.
+- Context window is pinned per device profile, not per agent: `GPU_CTX_SIZE` (65536, GPU/CPU) and `NPU_CTX_SIZE` (32768, the FLM ceiling) in [`src/gaia/llm/lemonade_client.py`](src/gaia/llm/lemonade_client.py). A machine runs one profile, so the ctx size is fixed machine-wide; the NPU email model above is the only case where a second model id enters the picture.
+- Vision: `Gemma-4-E4B-it-GGUF` is the default VLM (`vlm/mixin.py`, `llm/vlm_client.py`, `vlm/structured_extraction.py`); `Qwen3-VL-4B-Instruct-GGUF` also supported, and is the RAG SDK's `vlm_model` default (`src/gaia/rag/sdk.py`)
 - Image generation (SD): `SDXL-Turbo`
 
 ## CLI Commands
@@ -637,7 +659,7 @@ All commands are registered in [`src/gaia/cli.py`](src/gaia/cli.py). Run `gaia -
 **Servers & infrastructure:**
 - `gaia daemon` - The headless daemon (one machine-wide custody process; supervises sidecar agents)
 - `gaia api` - OpenAI-compatible API server
-- `gaia mcp {start|stop|status|test|agent|serve|list|tools|test-client}` - MCP bridge (add/remove moved to the connectors framework, #977)
+- `gaia mcp {start|stop|status|test|agent|serve|tui|list|tools|test-client}` - MCP bridge (add/remove moved to the connectors framework, #977)
 - `gaia schedule {add|list|show|remove|pause|resume|run|daemon}` - Run a skill or prompt on a cron schedule
 - `gaia telegram {start|stop|status}` - Telegram messaging adapter
 - `gaia connectors` - Manage connectors (Google/GitHub OAuth, MCP servers) and per-agent grants
@@ -645,9 +667,10 @@ All commands are registered in [`src/gaia/cli.py`](src/gaia/cli.py). Run `gaia -
 
 **Setup & utilities:**
 - `gaia init` - Setup Lemonade Server and download models
+- `gaia lemonade embedded {start|stop|status|install|install-backend}` - GAIA's private, self-contained Lemonade instance (#3121)
 - `gaia install` - Install helper (e.g. Lemonade on first run)
 - `gaia uninstall` - Tiered cleanup of `~/.gaia` and caches
-- `gaia config {get|set}` - Persistent config in `~/.gaia/config.json`
+- `gaia config {show|get|set}` - Persistent config in `~/.gaia/config.json`
 - `gaia hub` - Browse, install, and uninstall agents from the Agent Hub
 - `gaia skill` - Author and manage agent skills (`SKILL.md` capabilities)
 - `gaia download` - Download a model
@@ -657,7 +680,7 @@ All commands are registered in [`src/gaia/cli.py`](src/gaia/cli.py). Run `gaia -
 - `gaia stats` - Show statistics from the most recent run
 - `gaia memory` - Manage agent memory (onboarding bootstrap, status)
 - `gaia diagnostics` - Bundle logs + system info into a tarball for bug reports
-- `gaia agent {export|import}` - Manage custom agent bundles
+- `gaia agent {init|version|test|pack|publish|configure|health|status|login|export|import|install|list}` - Author and manage agents
 
 **Evaluation & analysis** (see [`docs/reference/eval.mdx`](docs/reference/eval.mdx)):
 - `gaia eval agent` - Run the agent eval benchmark (`--fix` auto-fixes failures)
@@ -686,7 +709,7 @@ agent-hub, skill-format, OEM bundling, desktop-installer, MCP, CUA, Docker, and 
 Browse the directory rather than a partial list here.
 
 **Key architectural decisions (April 2026):**
-- **GaiaAgent** rename planned (#696) — not yet landed; the chat agent class is still `ChatAgent` (`hub/agents/chat/python/gaia_agent_chat/agent.py`)
+- **GaiaAgent** rename (#696) landed, but resolved differently than planned: rather than renaming `ChatAgent`, `GaiaAgent` became the flagship (`hub/agents/gaia/python/gaia_agent/agent.py`) and `ChatAgent` (`hub/agents/chat/python/gaia_agent_chat/agent.py`) was kept as its base class — see [Agent Implementations](#agent-implementations)
 - Voice-first is P0 enabling technology (#702)
 - No context compaction — memory + RAG handles long conversations
 - Configuration dashboard + Observability dashboard as separate Agent UI panels


### PR DESCRIPTION
CLAUDE.md is the file that teaches every agent and contributor how this repo works, and it was teaching a command that no longer exists. The "Running GAIA" block told you to start the backend with `lemonade-server serve` — Lemonade 10.7/10.8 removed that CLI, so on a current install the binary simply isn't there. Five open issues report it (#3160, #3178, #3189, #3204, #3208). The same document also said the GaiaAgent rename had "not yet landed" while its own Agent Implementations table 100 lines above described the finished result, and it omitted `gaia lemonade embedded` entirely despite that shipping in #3121. After this change the start instructions match what the code actually does, the GaiaAgent entry states the resolved outcome, and the CLI list covers what `gaia -h` really offers.

Every claim was re-derived from the tree rather than from the old text, which turned up more than the three known defects — most notably that "EmailTriageAgent explicitly uses `DEFAULT_MODEL_NAME`" is false (it picks the NPU FLM model when one is available), and that the bullet directly below it asserted exactly one model is ever resident. Those two contradicted each other and are now reconciled.

There is no single command to substitute for `lemonade-server serve`, which is the interesting part: how the server starts depends on the install. `gaia init` is the only thing in the tree that auto-starts it — the normal runtime path only checks and errors out. So the doc now points writers at `describe_start_hint()` instead of inviting the next person to hard-code a fresh wrong command.

**This is scoped to CLAUDE.md only.** The `lemonade-server serve` string still appears 154 times across 97 other tracked files, including `docs/reference/dev.mdx:230`. That sweep is deliberately not done here and the issues above still track it.

<details>
<summary>🔍 Technical details</summary>

Evidence for the replacement start instruction, per the request to cite it:

```
$ gaia lemonade --help
usage: cli.py lemonade [-h] {embedded} ...
    embedded  Manage GAIA's private, self-contained Lemonade instance

$ gaia lemonade embedded --help
usage: cli.py lemonade embedded [-h] {start,stop,status,install,install-backend} ...
```

- `src/gaia/llm/lemonade_launcher.py:6` — "Modern Lemonade Server (10.7/10.8) removed the `lemonade-server` CLI"; `_classify_kind_from_name` returns `"legacy"` for it and `build_start_command` only emits `serve` for a resolved legacy install.
- `describe_start_hint()` (`:324`) is the platform-correct renderer; it returns `command=None` rather than naming a binary the host lacks.
- Auto-start is `gaia init` only: `src/gaia/installer/init_command.py:1439`/`:1443` → `_auto_start_server`. The runtime path `LemonadeManager.ensure_ready` returns `False` at `src/gaia/llm/lemonade_manager.py:692` when the server is down. (`lemonade_manager.py:329` prints "GAIA will automatically start Lemonade Server if installed" — that string is also inaccurate, but it's a code fix, out of scope here.)
- `class GaiaAgent(ChatAgent, ...)` at `hub/agents/gaia/python/gaia_agent/agent.py:211`; #696 is closed.
- EmailTriageAgent: `agent.py:913` → `resolve_default_email_model()` (`model_select.py:132`), returning `gemma4-it-e2b-FLM` only when an NPU is present *and* the model is servable.
- Brace-lists corrected by argparse introspection, not by reading source: `gaia mcp` gained `tui`, `gaia config` gained `show`, `gaia agent` was listed as `{export|import}` but has 13 subcommands.
- Structure tree: added six tracked `src/gaia/` packages (`daemon`, `factory`, `hub`, `schedule`, `sidecar`, `skills`) plus `hub/`, `tui/`, `util/`, all confirmed via `git ls-files` — `ls` is misleading here because `src/gaia/agents/` still holds `__pycache__` for agents deleted by #2995.
- Dropped references to `DocumentQAAgent` / `FileIOAgent` (zero hits in the tree) and to `hub/agents/chat/python/gaia_agent_chat/tools/` (the package is flat).

Findings deliberately **not** changed:
- `gaia eval` has `{agent,benchmark,sessions,code}` but the doc lists only `gaia eval agent`. It presents no brace-list, so it is incomplete rather than wrong; expanding it is curation, not correction.
- `src/gaia/llm/vlm_client.py:66`'s docstring claims a Qwen3-VL default while the code at `:73` uses Gemma-4-E4B. A code bug, not a CLAUDE.md one.
- `init_command.py:1451` hard-codes the Windows tray prose instead of calling `describe_start_hint()`, so the "single source of truth" framing was softened rather than asserted.
- Root dirs `cpp/`, `eval/`, `website/`, `workers/`, `installer/`, `examples/`, `data/`, `tools/`, `skills/` are also absent from the structure tree; adding all of them is a restructure, which this pass avoids.
</details>

## Test plan

- [ ] `python util/check_doc_links.py` passes (2340 links, 0 broken; the 2 warnings are pre-existing external-URL timeouts unrelated to this change).
- [ ] Every relative link, `#anchor`, and backticked `src|hub|tests|docs|util/...` path in CLAUDE.md resolves against `git ls-files` — verified, zero misses.
- [ ] `gaia lemonade --help` and `gaia lemonade embedded --help` match the documented brace-list (output above).
- [ ] `python -m pytest tests/unit/test_no_stale_agent_paths.py tests/unit/test_remedy_commands_are_runnable.py tests/unit/test_amd_gaia_urls.py` passes.
- [ ] Confirm no hunk touches "How You Communicate", "Version Control Guidelines", or the PR-description rules — hunks land only in Development Standards, Testing Philosophy, Common Development Commands, Project Structure, Architecture, CLI Commands, and Roadmap & Plans.
