### PR TITLE
feat(init): make `gaia init` the one setup path for the flagship

### DIFF
--- a/docs/guides/agent-ui.mdx
+++ b/docs/guides/agent-ui.mdx
@@ -158,7 +158,7 @@ Pick the install path that fits you best:
     The Python CLI path requires you to set up the backend manually:
 
     ```bash
-    gaia init --profile chat    # Downloads Lemonade Server + model (~25 GB)
+    gaia init                   # Downloads Lemonade Server + models
     lemonade-server serve       # Start the LLM server
     ```
 

--- a/docs/guides/terminal-hub.mdx
+++ b/docs/guides/terminal-hub.mdx
@@ -146,34 +146,43 @@ An all-green machine flashes through this screen and lands in chat without a
 keypress. A failure holds it open:
 
 ```
-  Getting GAIA ready                                                1 of 3 ready
+  Setting up GAIA                                                   1 of 3 ready
   ──────────────────────────────────────────────────────────────────────────────
     [ok]  GAIA agent          found at /usr/local/bin/gaia-agent
-  > [!]   Local AI            not running
+  > [!]   Lemonade            not running
           GAIA needs a local model server. It runs on your machine; no message
           text ever leaves it.
-          run:   lemonade-server serve
-    [ ]   AI model            —  checked once "Local AI" is fixed
+          f set it up now
+          or run: gaia init
+          look:   https://amd-gaia.ai/docs/guides/install
+    [ ]   Language model      —  checked once "Lemonade" is fixed
   ──────────────────────────────────────────────────────────────────────────────
-  r re-check · d details · esc back
+  f set it up now · r re-check · d details · esc back
 ```
+
+Pressing `f` runs `gaia init` right there and streams its progress into the
+screen; `esc` cancels it. The command is shown only as the copy-paste
+alternative — nothing on this screen requires leaving the TUI.
 
 If `gaia-agent` itself is missing, the gate stops on the first row and sends you
 to the installer — there is no in-TUI download for the agent binary:
 
 ```
-  Getting GAIA ready                                                0 of 3 ready
+  Setting up GAIA                                                   0 of 3 ready
   ──────────────────────────────────────────────────────────────────────────────
   > [!]   GAIA agent          not on this machine
           gaia-agent is the program that does the thinking. Nothing runs without it.
           Re-run the GAIA installer — it ships gaia-agent alongside gaia-tui.
           run:   https://amd-gaia.ai/#install
           look:  https://amd-gaia.ai/docs/guides/gaia
-    [ ]   Local AI            —  checked once "GAIA agent" is fixed
-    [ ]   AI model            —  checked once "GAIA agent" is fixed
+    [ ]   Lemonade            —  checked once "GAIA agent" is fixed
+    [ ]   Language model      —  checked once "GAIA agent" is fixed
   ──────────────────────────────────────────────────────────────────────────────
   r re-check · d details · esc back
 ```
+
+This row has no `f`: the TUI cannot install its own agent binary, so it names
+the installer instead of offering a key that would not work.
 
 `email` (and any other daemon-supervised agent) goes through the same three
 screens, but its gate has five rows instead of three: background service,

--- a/docs/guides/terminal-hub.mdx
+++ b/docs/guides/terminal-hub.mdx
@@ -294,7 +294,7 @@ start the local server — that flag exists to avoid the local backend, so runni
 installer that launches it would defeat it, and would hold the first answer behind a
 multi-minute install. The transcript says the server was not started and names what
 still needs it: RAG, memory and the code index embed through Lemonade, which has no
-Claude equivalent. Run `gaia init --profile chat --skip-chat-model`, or `/setup` in
+Claude equivalent. Run `gaia init --skip-chat-model`, or `/setup` in
 the composer, when you want those.
 
 ## Running another agent

--- a/docs/plans/flagship-installer.mdx
+++ b/docs/plans/flagship-installer.mdx
@@ -156,11 +156,13 @@ today (§9).
 ## §5 First-run setup: reused, not reinvented
 
 The TUI's first-boot gate (`tui/internal/ui/chat/setup.go`) shells out to
-`gaia init --check --profile chat` (and `gaia init --profile chat --yes` if that
+`gaia init --check --profile gaia` (and `gaia init --profile gaia --yes` if that
 comes back not-ready) instead of re-deriving GAIA's setup logic in Go.
-`src/gaia/installer/init_command.py`'s `INIT_PROFILES["chat"]` is the single source
+`src/gaia/installer/init_command.py`'s `INIT_PROFILES["gaia"]` is the single source
 of truth for what "set up" means: the `Gemma-4-E4B-it-GGUF` chat model, the
-`user.embeddinggemma-300m-GGUF` embedder, and the `[rag]` pip extras.
+`user.embeddinggemma-300m-GGUF` embedder, the `[rag]` pip extras, and the flagship
+wheel itself. It is also `gaia init`'s default, so a bare `gaia init` and the TUI's
+one-key fix do exactly the same thing.
 
 The bug this issue specifically flagged — an older, already-installed `gaia` that
 predates the `--check` flag exits 2 ("unrecognized arguments"), and that 2 used to
@@ -175,7 +177,7 @@ silently skipping setup. There's a dedicated regression test for this
 The constraint as given ("a Mac has no Lemonade NPU/GPU path") is half right: Mac has
 no **NPU** path — the `npu` init profile is XDNA2-specific, Ryzen AI hardware that
 doesn't exist on Apple Silicon. But Lemonade itself **does** support macOS (the
-`chat` profile has no `required_device` and no NPU-specific `recipe`/`backend` keys;
+`gaia` profile has no `required_device` and no NPU-specific `recipe`/`backend` keys;
 `LemonadeInstaller` has explicit `darwin` install/upgrade handling). So the actual
 decision already made and shipped is:
 
@@ -186,7 +188,7 @@ decision already made and shipped is:
   starts the local server. Running an installer that launches Lemonade would
   defeat the one flag whose purpose is to avoid it, and would hold the first
   answer behind a multi-minute install. The session says on screen that setup
-  was skipped and names `gaia init --profile chat --skip-chat-model` (or
+  was skipped and names `gaia init --skip-chat-model` (or
   `/setup`) as the way to get the local half.
 - There is **no** "refuse entirely, Claude-only, no local component" mode. I agree
   with this — memory and RAG are core to what makes this agent "the flagship," and

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -224,7 +224,7 @@ Choose your platform and installation type:
     ```
 
     <Note>
-      Use `--profile chat` for the full experience (~25GB), `--profile vlm` for vision/document extraction (~3GB), or `--profile minimal` for a quick start (~400MB).
+      A bare `gaia init` sets up the flagship agent (~4GB). Use `--profile vlm` for vision/document extraction (~3GB), or `--profile minimal` for a quick start (~400MB).
       See [CLI Reference](/reference/cli#init-command) for all profiles.
     </Note>
   </Tab>
@@ -290,7 +290,7 @@ Choose your platform and installation type:
     ```
 
     <Note>
-      Use `--profile chat` for the full experience (~25GB), `--profile vlm` for vision/document extraction (~3GB), or `--profile minimal` for a quick start (~400MB).
+      A bare `gaia init` sets up the flagship agent (~4GB). Use `--profile vlm` for vision/document extraction (~3GB), or `--profile minimal` for a quick start (~400MB).
       See [CLI Reference](/reference/cli#init-command) for all profiles.
     </Note>
   </Tab>
@@ -368,7 +368,7 @@ Choose your platform and installation type:
     ```
 
     <Note>
-      Use `--profile chat` for the full experience (~25GB), `--profile vlm` for vision/document extraction (~3GB), or `--profile minimal` for a quick start (~400MB).
+      A bare `gaia init` sets up the flagship agent (~4GB). Use `--profile vlm` for vision/document extraction (~3GB), or `--profile minimal` for a quick start (~400MB).
       See [CLI Reference](/reference/cli#init-command) for all profiles.
     </Note>
   </Tab>
@@ -442,7 +442,7 @@ Choose your platform and installation type:
     ```
 
     <Note>
-      Use `--profile chat` for the full experience (~25GB), `--profile vlm` for vision/document extraction (~3GB), or `--profile minimal` for a quick start (~400MB).
+      A bare `gaia init` sets up the flagship agent (~4GB). Use `--profile vlm` for vision/document extraction (~3GB), or `--profile minimal` for a quick start (~400MB).
       See [CLI Reference](/reference/cli#init-command) for all profiles.
     </Note>
   </Tab>

--- a/docs/reference/cli.mdx
+++ b/docs/reference/cli.mdx
@@ -186,7 +186,7 @@ gaia init [OPTIONS]
 
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
-| `--profile, -p` | string | chat | Profile to initialize (minimal, sd, chat, code, rag, mcp, vlm, email, npu, all) |
+| `--profile, -p` | string | gaia | Profile to initialize (gaia, minimal, sd, chat, rag, mcp, vlm, email, npu, all) |
 | `--minimal` | flag | false | Shortcut for `--profile minimal` |
 | `--skip-models` | flag | false | Skip model downloads (only install Lemonade) |
 | `--skip-lemonade` | flag | false | Skip Lemonade installation check (for CI with pre-installed Lemonade) |
@@ -207,10 +207,10 @@ canonical choices list):
 
 | Profile | Models | Description | Approx Size |
 |---------|--------|-------------|-------------|
+| `gaia` **(default)** | Gemma-4-E4B-it-GGUF, user.embeddinggemma-300m-GGUF | The flagship [GAIA agent](/guides/gaia) — chat, documents, data, web, memory | ~4 GB |
 | `minimal` | Gemma-4-E4B-it-GGUF | Fast setup with Gemma 4 E4B multimodal model | ~3 GB |
 | `sd` | SDXL-Turbo, Gemma-4-E4B-it-GGUF | Image generation with multi-modal AI (LLM + SD) | ~10 GB |
-| `chat` | Gemma-4-E4B-it-GGUF, user.embeddinggemma-300m-GGUF | Interactive chat with RAG and vision support | ~4 GB |
-| `code` | Gemma-4-E4B-it-GGUF | Autonomous coding assistant | ~3 GB |
+| `chat` | Gemma-4-E4B-it-GGUF, user.embeddinggemma-300m-GGUF | Interactive chat with RAG and vision support (the flagship's base class, without the flagship itself) | ~4 GB |
 | `rag` | Gemma-4-E4B-it-GGUF, user.embeddinggemma-300m-GGUF | Document Q&A with retrieval | ~4 GB |
 | `mcp` | _(none)_ | Sets up the MCP servers config (`~/.gaia/mcp_servers.json`) — no Lemonade install or model downloads | – |
 | `vlm` | Gemma-4-E4B-it-GGUF | Vision pipeline for document and image extraction | ~3 GB |
@@ -219,17 +219,21 @@ canonical choices list):
 | `all` | All models | All models for all agents | ~26 GB |
 
 <Note>
-`gaia init` sets up Lemonade + models only — it does not install the flagship [GAIA
-agent](/guides/gaia) or its terminal UI (`gaia-tui`). Get both with
-`npx @amd-gaia/gaia` (fetches and verifies both binaries, no Python required) or, from a
-checkout, `uv pip install -e hub/agents/gaia/python`. See the
-[flagship installer plan](/plans/flagship-installer) for how the two pieces fit together
-and current release status.
+A bare `gaia init` runs the `gaia` profile: Lemonade, the chat model, the RAG/memory
+embedder, and the flagship [GAIA agent](/guides/gaia) itself from the Agent Hub. It does
+**not** install the terminal UI (`gaia-tui`) — get that with `npx @amd-gaia/gaia`, which
+fetches and verifies both binaries with no Python required.
+</Note>
+
+<Note>
+`gaia init` picks the profile on the *agent* axis only. NPU users must still ask for the
+device axis explicitly with `gaia init --profile npu`, which swaps the GGUF models for
+their FLM equivalents — the default never switches your backend for you.
 </Note>
 
 <Note>
 The `talk` agent relies on the `chat` profile — there is no dedicated `talk`
-profile. Run `gaia init --profile chat` (or `all`) to prepare its dependencies.
+profile. The default `gaia` profile is a superset, so a bare `gaia init` covers it.
 </Note>
 
 <Note>
@@ -247,16 +251,12 @@ gaia init
 gaia init --minimal
 ```
 
-```bash Code Development
-gaia init --profile code
-```
-
 ```bash Vision Pipeline (Lightweight)
 gaia init --profile vlm
 ```
 
 ```bash Non-Interactive CI/CD
-gaia init --profile chat --yes
+gaia init --yes
 ```
 
 ```bash Remote Lemonade Server

--- a/docs/reference/troubleshooting.mdx
+++ b/docs/reference/troubleshooting.mdx
@@ -288,7 +288,7 @@ icon: "bug"
     Or delete all models and re-download:
     ```bash
     gaia uninstall --purge --purge-models --yes
-    gaia init --profile chat
+    gaia init
     ```
   </Accordion>
 
@@ -297,7 +297,7 @@ icon: "bug"
 
     ```bash
     # Retry with verbose output
-    gaia init --profile chat --verbose
+    gaia init --verbose
     ```
   </Accordion>
 

--- a/src/gaia/apps/webui/src/components/SettingsModal.tsx
+++ b/src/gaia/apps/webui/src/components/SettingsModal.tsx
@@ -239,7 +239,7 @@ export function SettingsModal() {
                                         value={status.lemonade_running ? `Running${status.lemonade_version ? ` v${status.lemonade_version}` : ''}` : status.lemonade_error ? 'Status unavailable' : 'Not Running'}
                                         ok={status.lemonade_running}
                                         hint={!status.lemonade_running
-                                            ? (status.lemonade_error ? 'Could not query Lemonade Server; check it and retry.' : status.initialized ? (status.start_command ? `Run: ${status.start_command}` : (status.start_instruction ?? 'Start Lemonade Server')) : 'Run: gaia init --profile chat')
+                                            ? (status.lemonade_error ? 'Could not query Lemonade Server; check it and retry.' : status.initialized ? (status.start_command ? `Run: ${status.start_command}` : (status.start_instruction ?? 'Start Lemonade Server')) : 'Run: gaia init')
                                             : undefined}
                                     />
                                     <StatusRow
@@ -247,7 +247,7 @@ export function SettingsModal() {
                                         value={status.model_loaded || 'None loaded'}
                                         ok={!!status.model_loaded && status.expected_model_loaded !== false}
                                         hint={!status.model_loaded
-                                            ? 'Run: gaia init --profile chat'
+                                            ? 'Run: gaia init'
                                             : status.expected_model_loaded === false
                                             ? `Expected: ${modelName}`
                                             : undefined}

--- a/src/gaia/apps/webui/src/components/SettingsPage.tsx
+++ b/src/gaia/apps/webui/src/components/SettingsPage.tsx
@@ -229,7 +229,7 @@ export function SettingsPage() {
                                     value={status.lemonade_running ? `Running${status.lemonade_version ? ` v${status.lemonade_version}` : ''}` : status.lemonade_error ? 'Status unavailable' : 'Not Running'}
                                     ok={status.lemonade_running}
                                     hint={!status.lemonade_running
-                                        ? (status.lemonade_error ? 'Could not query Lemonade Server; check it and retry.' : status.initialized ? (status.start_command ? `Run: ${status.start_command}` : (status.start_instruction ?? 'Start Lemonade Server')) : 'Run: gaia init --profile chat')
+                                        ? (status.lemonade_error ? 'Could not query Lemonade Server; check it and retry.' : status.initialized ? (status.start_command ? `Run: ${status.start_command}` : (status.start_instruction ?? 'Start Lemonade Server')) : 'Run: gaia init')
                                         : undefined}
                                 />
                                 <StatusRow
@@ -237,7 +237,7 @@ export function SettingsPage() {
                                     value={status.model_loaded || 'None loaded'}
                                     ok={!!status.model_loaded && status.expected_model_loaded !== false}
                                     hint={!status.model_loaded
-                                        ? 'Run: gaia init --profile chat'
+                                        ? 'Run: gaia init'
                                         : status.expected_model_loaded === false
                                         ? `Expected: ${modelName}`
                                         : undefined}

--- a/src/gaia/apps/webui/src/components/WelcomeScreen.tsx
+++ b/src/gaia/apps/webui/src/components/WelcomeScreen.tsx
@@ -184,7 +184,7 @@ export function WelcomeScreen({ onNewTask, onSendPrompt, onCreateAgent }: Welcom
                     <div className="welcome-setup-hint">
                         <Terminal size={14} />
                         <span>
-                            <strong>First time?</strong> Run <code>gaia init --profile chat</code> in a terminal to
+                            <strong>First time?</strong> Run <code>gaia init</code> in a terminal to
                             install Lemonade Server and download the required AI model
                             {systemStatus?.default_model_size_gb
                                 ? ` (~${systemStatus.default_model_size_gb.toFixed(1)} GB).`
@@ -196,7 +196,7 @@ export function WelcomeScreen({ onNewTask, onSendPrompt, onCreateAgent }: Welcom
                     <div className="welcome-setup-hint">
                         <Terminal size={14} />
                         <span>
-                            No model loaded. Run <code>gaia init --profile chat</code> to download
+                            No model loaded. Run <code>gaia init</code> to download
                             {systemStatus?.default_model_size_gb
                                 ? ` (~${systemStatus.default_model_size_gb.toFixed(1)} GB).`
                                 : '.'}

--- a/src/gaia/cli.py
+++ b/src/gaia/cli.py
@@ -845,7 +845,7 @@ def _launch_agent_ui(port=4200, base_url=None, log=None, debug=False, webui_dist
         if not base_url:
             print("   Prerequisites:")
             print(
-                "     1. Models downloaded  : gaia init --profile chat  (first time only, ~25 GB)"
+                "     1. Models downloaded  : gaia init  (first time only, ~25 GB)"
             )
             print(f"     2. Lemonade running   : {describe_start_hint().instruction}")
             print()
@@ -2928,8 +2928,12 @@ Examples:
     init_parser.add_argument(
         "--profile",
         "-p",
-        default="chat",
+        # Literal, not an import: gaia.installer.init_command costs ~3s to
+        # import and build_parser() runs on every `gaia` invocation. Pinned to
+        # init_command.DEFAULT_INIT_PROFILE by a test so it cannot drift.
+        default="gaia",
         choices=[
+            "gaia",
             "minimal",
             "sd",
             "chat",
@@ -2940,7 +2944,9 @@ Examples:
             "npu",
             "all",
         ],
-        help="Profile to initialize: minimal, sd (image gen), chat, rag, mcp, vlm (vision), email (Gmail/Outlook triage), npu (Ryzen AI NPU), all (default: chat)",
+        help="Profile to initialize: gaia (the flagship agent), minimal, sd (image gen), "
+        "chat, rag, mcp, vlm (vision), email (Gmail/Outlook triage), npu (Ryzen AI NPU), "
+        "all (default: gaia)",
     )
     init_parser.add_argument(
         "--minimal",

--- a/src/gaia/cli.py
+++ b/src/gaia/cli.py
@@ -844,7 +844,7 @@ def _launch_agent_ui(port=4200, base_url=None, log=None, debug=False, webui_dist
         print()
         if not base_url:
             print("   Prerequisites:")
-            print("     1. Models downloaded  : gaia init  (first time only, ~25 GB)")
+            print("     1. Models downloaded  : gaia init  (first time only, ~4 GB)")
             print(f"     2. Lemonade running   : {describe_start_hint().instruction}")
             print()
 

--- a/src/gaia/cli.py
+++ b/src/gaia/cli.py
@@ -844,9 +844,7 @@ def _launch_agent_ui(port=4200, base_url=None, log=None, debug=False, webui_dist
         print()
         if not base_url:
             print("   Prerequisites:")
-            print(
-                "     1. Models downloaded  : gaia init  (first time only, ~25 GB)"
-            )
+            print("     1. Models downloaded  : gaia init  (first time only, ~25 GB)")
             print(f"     2. Lemonade running   : {describe_start_hint().instruction}")
             print()
 

--- a/src/gaia/hub/installer.py
+++ b/src/gaia/hub/installer.py
@@ -123,6 +123,17 @@ class CompatibilityError(InstallError):
     """The current machine does not satisfy the agent's requirements."""
 
 
+class UnsupportedPlatformError(InstallError):
+    """The hub publishes this agent, but not a build for this platform.
+
+    Distinct from a generic ``InstallError`` so a caller can tell "there is
+    nothing here for this machine" (survivable — the agent simply is not
+    available) from "the install was attempted and failed" (loud). Without
+    the distinction, `gaia init` either hard-fails on every platform the
+    flagship has no build for, or swallows real install failures.
+    """
+
+
 class InstallInProgressError(InstallError):
     """An install for this agent id is already running (maps to HTTP 409)."""
 
@@ -678,7 +689,7 @@ def _resolve_version(
         match = _select_platform_artifact(binary_like, effective_key)
         if match is None:
             available = ", ".join(sorted(a.get("filename", "?") for a in binary_like))
-            raise InstallError(
+            raise UnsupportedPlatformError(
                 f"No published artifact for version '{version}' of "
                 f"'{agent_id}' matches this platform ('{effective_key}'). "
                 f"Available: {available}."

--- a/src/gaia/installer/init_command.py
+++ b/src/gaia/installer/init_command.py
@@ -223,7 +223,7 @@ def check_setup_status(
     deleted or Lemonade is uninstalled without GAIA's knowledge.
 
     Args:
-        profile: Profile to check (minimal, chat, code, rag, all, ...)
+        profile: Profile to check (gaia, minimal, chat, rag, all, ...)
         skip_chat_model: Match run()'s --skip-chat-model filtering (Claude
             backend): only the profile's embedding model(s) are required.
         remote: Lemonade is expected on a remote machine (skip local-install
@@ -311,7 +311,7 @@ class InitCommand:
 
     def __init__(
         self,
-        profile: str = "chat",
+        profile: str = DEFAULT_INIT_PROFILE,
         skip_models: bool = False,
         skip_lemonade: bool = False,
         force_reinstall: bool = False,
@@ -2165,7 +2165,8 @@ class InitCommand:
         ``gaia chat`` resolves through that wheel (#1102), which no init
         profile installs (it isn't a pip extra -- #2240). Printing `gaia
         chat` as a ready next step when it isn't installed is a false
-        promise, so completion messaging checks first.
+        promise, so completion messaging checks first. Delegates to
+        ``_is_hub_agent_available``, so a hub install counts too.
         """
         return InitCommand._is_hub_agent_available("chat")
 
@@ -2246,7 +2247,30 @@ class InitCommand:
         # input, so GAIA's own curation is the trust decision. Pass the trust
         # opt-in explicitly — every non-verified agent now needs it, and the
         # profile agents are not published in the "verified" tier.
-        result = hub_installer.install(agent_id, trusted=True)
+        try:
+            result = hub_installer.install(agent_id, trusted=True)
+        except (
+            hub_installer.UnsupportedPlatformError,
+            hub_installer.CompatibilityError,
+        ) as exc:
+            # "The hub has no build for THIS machine" is the same situation as
+            # "not published yet", and must not fail a run that already installed
+            # Lemonade and several GB of models. The flagship ships a native
+            # binary, so it is platform-gated: without this the DEFAULT profile
+            # exits non-zero on Intel Mac, Windows-on-ARM and ARM Linux —
+            # machines where `gaia init` works today.
+            #
+            # Deliberately narrow. Every OTHER InstallError still propagates
+            # into run()'s handler and exits non-zero (#2358): an install that
+            # was attempted and failed must stay loud.
+            self._print_warning(
+                f"'{agent_id}' has no Agent Hub build for this machine: {exc}"
+            )
+            self._print_warning(
+                f"Everything else is set up. Install it with "
+                f"`gaia hub install {agent_id}` once a build is available."
+            )
+            return
         self._print_success(f"Installed '{agent_id}' from the Agent Hub")
 
         # No AgentRegistry exists in this process to hot-register into (we
@@ -2273,6 +2297,12 @@ class InitCommand:
         chat_install_note = (
             "Chat agent not installed yet -- run: "
             f"{source_install_command('gaia-agent-chat')}"
+        )
+        # The flagship is a hub BINARY, so its missing-hint names the hub, not a
+        # pip command. Pointing at gaia-agent-chat here would answer a headline
+        # about the flagship with a different package's install line.
+        flagship_install_note = (
+            "GAIA agent not installed yet -- run: gaia hub install gaia"
         )
         # Scoped like run()'s has_hub_agent_check -- gating on the chat wheel
         # alone would mark sd/vlm/minimal permanently "incomplete", and would
@@ -2302,7 +2332,18 @@ class InitCommand:
                     "Then ask for an image — image generation runs through the "
                     "agent's SD tools"
                 )
-            elif self.profile in ("chat", "gaia"):
+            elif self.profile == "gaia":
+                self.console.print(
+                    "    [cyan]gaia-tui[/cyan]                             Start the GAIA agent (terminal UI)"
+                )
+                self.console.print(
+                    "    [cyan]gaia chat --ui[/cyan]                       Launch the Agent UI (browser-based)"
+                )
+                if not self._profile_agent_available():
+                    self.console.print(f"    [yellow]{flagship_install_note}[/yellow]")
+                if not chat_agent_available:
+                    self.console.print(f"    [yellow]{chat_install_note}[/yellow]")
+            elif self.profile == "chat":
                 self.console.print(
                     "    [cyan]gaia chat[/cyan]                            Start interactive chat with RAG"
                 )
@@ -2378,7 +2419,18 @@ class InitCommand:
                     "    gaia chat                    Then ask for an image — "
                     "image generation runs through the agent's SD tools"
                 )
-            elif self.profile in ("chat", "gaia"):
+            elif self.profile == "gaia":
+                self._print(
+                    "    gaia-tui                             # Start the GAIA agent (terminal UI)"
+                )
+                self._print(
+                    "    gaia chat --ui                       # Launch the Agent UI (browser-based)"
+                )
+                if not self._profile_agent_available():
+                    self._print(f"    {flagship_install_note}")
+                if not chat_agent_available:
+                    self._print(f"    {chat_install_note}")
+            elif self.profile == "chat":
                 self._print(
                     "    gaia chat                            # Start interactive chat with RAG"
                 )

--- a/src/gaia/installer/init_command.py
+++ b/src/gaia/installer/init_command.py
@@ -56,9 +56,37 @@ def is_embedding_model_id(model_id: str) -> bool:
     return "embed" in model_id.lower()
 
 
+# Hub agent ids `gaia init` installs for its profile. Everything else
+# (sd/vlm/email/...) owns its own install lifecycle; a generic "install the
+# profile's agent" would hard-fail on agents the hub index doesn't carry.
+HUB_INSTALL_AGENTS = frozenset({"chat", "gaia"})
+
+# Hub agent id -> the module a source/pip install of it makes importable. Every
+# `gaia-agent-<id>` distribution installs `gaia_agent_<id>` except the flagship:
+# `gaia-agent-gaia` ships plain `gaia_agent` (hub/agents/gaia/python's
+# gaia-agent.yaml `entry_module`).
+_AGENT_IMPORT_NAMES = {"gaia": "gaia_agent"}
+
+# The profile a bare `gaia init` runs — the flagship agent's configuration.
+DEFAULT_INIT_PROFILE = "gaia"
+
 # Profile definitions mapping to agent profiles
 # Note: These define which agent profile to use for each init profile
 INIT_PROFILES = {
+    "gaia": {
+        "description": "The flagship GAIA agent — chat, documents, data, web, memory",
+        # Installs the flagship from the Agent Hub, which publishes it as a
+        # native binary (`gaia-agent`), not a wheel -- so this does NOT bring
+        # `gaia-agent-chat` along the way a pip dependency would. `gaia chat`
+        # still needs that wheel separately; the completion message says so.
+        "agent": "gaia",
+        "models": ["Gemma-4-E4B-it-GGUF", "user.embeddinggemma-300m-GGUF"],
+        "approx_size": "~4 GB",
+        # EmbeddingGemma loads only on Lemonade v10.9.0+ (see the chat profile).
+        "min_lemonade_version": "10.9.0",
+        "min_context_size": 32768,
+        "pip_extras": ["rag"],
+    },
     "minimal": {
         "description": "Fast setup with Gemma 4 E4B multimodal model",
         "agent": "minimal",
@@ -181,7 +209,7 @@ class SetupStatus:
 
 
 def check_setup_status(
-    profile: str = "chat",
+    profile: str = DEFAULT_INIT_PROFILE,
     skip_chat_model: bool = False,
     remote: bool = False,
 ) -> SetupStatus:
@@ -648,7 +676,7 @@ class InitCommand:
         # literal -- naturally covers both without a special case, and never
         # touches profiles for other hub agents (sd/code/analyst/email/...),
         # each of which has its own, separately-owned install lifecycle.
-        has_hub_agent_check = profile_config.get("agent") == "chat"
+        has_hub_agent_check = profile_config.get("agent") in HUB_INSTALL_AGENTS
 
         _webui_src = Path(__file__).resolve().parent.parent / "apps" / "webui" / "src"
         _is_dev_install = _webui_src.is_dir()
@@ -762,7 +790,9 @@ class InitCommand:
                 step_num += 1
                 self._print("")
                 self._print_step(
-                    step_num, total_steps, "Checking chat agent installation..."
+                    step_num,
+                    total_steps,
+                    f"Checking {profile_config['agent']} agent installation...",
                 )
                 self._ensure_hub_agent_installed()
 
@@ -1572,7 +1602,7 @@ class InitCommand:
                 f"(Ryzen AI 300/400/Max series with XDNA2)."
             )
             self._print_error(
-                "Run 'gaia init --profile chat' for GPU-based setup instead."
+                "Run 'gaia init' for GPU-based setup instead."
             )
             return False
         except ConnectionError as e:
@@ -2106,12 +2136,29 @@ class InitCommand:
 
     @staticmethod
     def _is_hub_agent_available(agent_id: str) -> bool:
-        """Whether the standalone ``gaia-agent-<agent_id>`` wheel is
-        importable in THIS process (by the same naming convention
+        """Whether this profile's hub agent is already present.
+
+        Two probes, because the hub ships two artifact shapes and only one of
+        them is importable. A wheel agent (``chat``) is there when
+        ``gaia_agent_<id>`` imports -- the naming convention
         ``install_hints._AGENT_SOURCE_SUBDIRS`` and every ``gaia-agent-*``
-        wheel already use: import name ``gaia_agent_<id>``).
+        wheel share, with the flagship's ``gaia_agent`` spelling read from
+        ``_AGENT_IMPORT_NAMES``. The flagship itself publishes a native
+        BINARY, which no import can ever see, so its install sentinel under
+        ``~/.gaia/agents`` is the only evidence it is there. Probing the
+        module alone would re-download it from the hub on every run and
+        report a finished setup as "incomplete".
         """
-        return importlib.util.find_spec(f"gaia_agent_{agent_id}") is not None
+        module = _AGENT_IMPORT_NAMES.get(agent_id, f"gaia_agent_{agent_id}")
+        if importlib.util.find_spec(module) is not None:
+            return True
+
+        # Function-local: gaia.hub.installer imports gaia.agents.registry at
+        # module level, so a top-level import here risks the same circular
+        # partial-init AgentRegistry defers this import to avoid.
+        from gaia.hub import installer as hub_installer
+
+        return hub_installer.read_sentinel(agent_id) is not None
 
     @staticmethod
     def _chat_agent_available() -> bool:
@@ -2124,12 +2171,24 @@ class InitCommand:
         """
         return InitCommand._is_hub_agent_available("chat")
 
+    def _profile_agent_available(self) -> bool:
+        """Whether the hub agent THIS profile installs is present.
+
+        True for profiles that install none (sd/vlm/minimal/...), so their
+        completion headline is never gated on someone else's agent.
+        """
+        agent_id = INIT_PROFILES[self.profile].get("agent")
+        if agent_id not in HUB_INSTALL_AGENTS:
+            return True
+        return self._is_hub_agent_available(agent_id)
+
     def _ensure_hub_agent_installed(self) -> None:
         """Install this profile's hub agent from the Agent Hub catalog if it
         isn't already available and the live catalog confirms it's published.
 
-        Scoped by ``run()``'s ``has_hub_agent_check`` (profiles whose
-        declared ``"agent"`` is ``"chat"`` -- both ``chat`` and ``npu``).
+        Scoped by ``run()``'s ``has_hub_agent_check`` (profiles whose declared
+        ``"agent"`` is in ``HUB_INSTALL_AGENTS`` -- ``gaia``, plus ``chat`` and
+        ``npu``, which both declare ``"agent": "chat"``).
 
         Distinguishes two catalog states (#2358):
 
@@ -2217,13 +2276,10 @@ class InitCommand:
             "Chat agent not installed yet -- run: "
             f"{source_install_command('gaia-agent-chat')}"
         )
-        # Scoped like run()'s has_hub_agent_check (agent == "chat" covers
-        # chat + npu) -- gating on chat_agent_available alone would mark
-        # sd/vlm/minimal permanently "incomplete"; they never install it.
-        setup_incomplete = (
-            INIT_PROFILES[self.profile].get("agent") == "chat"
-            and not chat_agent_available
-        )
+        # Scoped like run()'s has_hub_agent_check -- gating on the chat wheel
+        # alone would mark sd/vlm/minimal permanently "incomplete", and would
+        # call the flagship profile complete while its own wheel is missing.
+        setup_incomplete = not self._profile_agent_available()
         headline = (
             "GAIA initialization incomplete - see below"
             if setup_incomplete
@@ -2248,7 +2304,7 @@ class InitCommand:
                     "Then ask for an image — image generation runs through the "
                     "agent's SD tools"
                 )
-            elif self.profile == "chat":
+            elif self.profile in ("chat", "gaia"):
                 self.console.print(
                     "    [cyan]gaia chat[/cyan]                            Start interactive chat with RAG"
                 )
@@ -2292,7 +2348,7 @@ class InitCommand:
                 self.console.print(
                     "    [dim]Note: Minimal profile installed. For full features, run:[/dim]"
                 )
-                self.console.print("    [cyan]gaia init --profile chat[/cyan]")
+                self.console.print("    [cyan]gaia init[/cyan]")
             else:
                 # Default commands for other profiles
                 self.console.print(
@@ -2324,7 +2380,7 @@ class InitCommand:
                     "    gaia chat                    Then ask for an image — "
                     "image generation runs through the agent's SD tools"
                 )
-            elif self.profile == "chat":
+            elif self.profile in ("chat", "gaia"):
                 self._print(
                     "    gaia chat                            # Start interactive chat with RAG"
                 )
@@ -2367,7 +2423,7 @@ class InitCommand:
                 self._print(
                     "  Note: Minimal profile installed. For full features, run:"
                 )
-                self._print("    gaia init --profile chat")
+                self._print("    gaia init")
             else:
                 # Default commands for other profiles
                 self._print("    gaia chat              # Start interactive chat")
@@ -2382,7 +2438,7 @@ class InitCommand:
 
 
 def run_init(
-    profile: str = "chat",
+    profile: str = DEFAULT_INIT_PROFILE,
     skip_models: bool = False,
     skip_lemonade: bool = False,
     force_reinstall: bool = False,

--- a/src/gaia/installer/init_command.py
+++ b/src/gaia/installer/init_command.py
@@ -1601,9 +1601,7 @@ class InitCommand:
                 f"The '{self.profile}' profile requires {device_label} hardware "
                 f"(Ryzen AI 300/400/Max series with XDNA2)."
             )
-            self._print_error(
-                "Run 'gaia init' for GPU-based setup instead."
-            )
+            self._print_error("Run 'gaia init' for GPU-based setup instead.")
             return False
         except ConnectionError as e:
             self._print_error(f"Cannot reach Lemonade Server to detect hardware: {e}")

--- a/tests/unit/installer/test_init_default_profile.py
+++ b/tests/unit/installer/test_init_default_profile.py
@@ -117,9 +117,7 @@ class TestBareInitTargetsTheFlagship:
         monkeypatch.setattr(
             "gaia.installer.init_command.importlib.util.find_spec", lambda _n: None
         )
-        monkeypatch.setattr(
-            "gaia.hub.installer.read_sentinel", lambda _id: object()
-        )
+        monkeypatch.setattr("gaia.hub.installer.read_sentinel", lambda _id: object())
         assert InitCommand._is_hub_agent_available(FLAGSHIP_AGENT_ID) is True
 
     def test_absent_everywhere_reports_missing(self, monkeypatch):

--- a/tests/unit/installer/test_init_default_profile.py
+++ b/tests/unit/installer/test_init_default_profile.py
@@ -22,6 +22,8 @@ import re
 import subprocess
 import sys
 from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
 
 import pytest
 
@@ -239,3 +241,96 @@ def _child_env() -> dict:
     existing = env.get("PYTHONPATH")
     env["PYTHONPATH"] = f"{src}{os.pathsep}{existing}" if existing else src
     return env
+
+
+class TestUnsupportedPlatformDoesNotFailTheRun:
+    """The flagship ships a native BINARY, so the hub gates it per platform.
+
+    Before this, `gaia init` — now the default path — exited non-zero on every
+    host the hub has no flagship build for (Intel Mac, Windows-on-ARM, ARM
+    Linux), *after* installing Lemonade and several GB of models. Those are
+    machines where `gaia init` works today.
+    """
+
+    def _cmd(self):
+        from gaia.installer.init_command import InitCommand
+
+        with patch("gaia.installer.init_command.LemonadeInstaller"):
+            return InitCommand(profile=FLAGSHIP_AGENT_ID, yes=True)
+
+    def _run_with_install_error(self, exc):
+        from gaia.hub import installer as hub_installer
+
+        cmd = self._cmd()
+        with (
+            patch.object(InitCommand, "_is_hub_agent_available", return_value=False),
+            patch(
+                "gaia.hub.catalog.load_index",
+                return_value=SimpleNamespace(
+                    agents=[{"id": FLAGSHIP_AGENT_ID, "latest_version": "0.1.1"}]
+                ),
+            ),
+            patch.object(hub_installer, "install", side_effect=exc),
+        ):
+            cmd._ensure_hub_agent_installed()
+
+    def test_no_build_for_this_platform_is_survivable(self):
+        from gaia.hub.installer import CompatibilityError
+
+        # Must not raise: the rest of the setup succeeded.
+        self._run_with_install_error(
+            CompatibilityError("Your platform (darwin-x64) is not supported")
+        )
+
+    def test_no_artifact_for_this_platform_is_survivable(self):
+        from gaia.hub.installer import UnsupportedPlatformError
+
+        self._run_with_install_error(
+            UnsupportedPlatformError("no artifact matches this platform ('win-arm64')")
+        )
+
+    def test_a_generic_install_failure_still_hard_fails(self):
+        """#2358's contract: an install that was ATTEMPTED and failed must stay
+        loud. Only "there is no build for this machine" is survivable."""
+        from gaia.hub.installer import InstallError
+
+        with pytest.raises(InstallError):
+            self._run_with_install_error(InstallError("network died mid-download"))
+
+    @pytest.mark.parametrize("exc_name", ["ChecksumError", "DiskSpaceError"])
+    def test_a_real_failure_still_propagates(self, exc_name):
+        """A corrupt download or a full disk is not 'this machine is
+        unsupported' — swallowing those is the silent fallback CLAUDE.md
+        forbids."""
+        import gaia.hub.installer as hub_installer
+
+        exc = getattr(hub_installer, exc_name)("boom")
+        with pytest.raises(type(exc)):
+            self._run_with_install_error(exc)
+
+
+class TestFlagshipCompletionMessage:
+    """A headline about the flagship must not be answered with a different
+    package's install line."""
+
+    def _completion(self, available):
+        from gaia.installer.init_command import InitCommand
+
+        with patch("gaia.installer.init_command.LemonadeInstaller"):
+            cmd = InitCommand(profile=FLAGSHIP_AGENT_ID, yes=True)
+        cmd._is_hub_agent_available = lambda _id: available
+        printed = []
+        cmd._print = lambda msg, end="\n": printed.append(msg)
+        with patch("gaia.installer.init_command.RICH_AVAILABLE", False):
+            cmd._print_completion()
+        return "\n".join(printed)
+
+    def test_missing_flagship_names_the_hub_not_the_chat_wheel(self):
+        out = self._completion(available=False)
+        assert "gaia hub install gaia" in out
+        assert "incomplete" in out
+
+    def test_quick_start_names_something_that_starts_the_flagship(self):
+        """`gaia chat` runs a different agent through a wheel this profile
+        never installs, so it cannot be the only next step offered."""
+        assert "gaia-tui" in self._completion(available=True)

--- a/tests/unit/installer/test_init_default_profile.py
+++ b/tests/unit/installer/test_init_default_profile.py
@@ -1,0 +1,243 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+"""`gaia init` with no --profile sets up the FLAGSHIP agent.
+
+The bug these guard against: every init profile installed the ``chat`` wheel,
+but the TUI spawns the flagship (``gaia-agent-gaia`` -> module ``gaia_agent``).
+So `gaia init` — the one command the installers and the TUI's setup gate both
+tell users to run — never installed the agent the TUI actually launches.
+
+Two contracts are pinned here because nothing else can see them:
+
+* the argparse default is a literal in ``cli.py`` (importing
+  ``init_command`` costs ~3s and ``build_parser`` runs on every invocation),
+  so it can drift from ``DEFAULT_INIT_PROFILE`` silently;
+* ``tui/internal/gaiainit/gaiainit.go`` hardcodes the profile name and the
+  "not ready" exit code. That is a cross-language contract no Python test
+  and no Go test sees on its own.
+"""
+
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from gaia.cli import build_parser
+from gaia.installer.init_command import (
+    DEFAULT_INIT_PROFILE,
+    HUB_INSTALL_AGENTS,
+    INIT_PROFILES,
+    InitCommand,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+GAIAINIT_GO = REPO_ROOT / "tui" / "internal" / "gaiainit" / "gaiainit.go"
+
+# The flagship's hub id. Its wheel is gaia-agent-gaia; the module it installs is
+# plain `gaia_agent`, NOT `gaia_agent_gaia` (hub/agents/gaia/python).
+FLAGSHIP_AGENT_ID = "gaia"
+FLAGSHIP_IMPORT_NAME = "gaia_agent"
+
+
+def _go_const(name: str) -> str:
+    """Value of a top-level `const <name> = <literal>` in gaiainit.go."""
+    source = GAIAINIT_GO.read_text(encoding="utf-8")
+    match = re.search(rf"^const {name} = (.+)$", source, re.MULTILINE)
+    assert match, f"const {name} not found in {GAIAINIT_GO}"
+    return match.group(1).strip().strip('"')
+
+
+class TestBareInitTargetsTheFlagship:
+    def test_bare_init_resolves_to_the_flagship_profile(self):
+        assert build_parser().parse_args(["init"]).profile == FLAGSHIP_AGENT_ID
+
+    def test_cli_default_matches_the_installer_constant(self):
+        """The literal in cli.py is a performance workaround, not a second
+        source of truth."""
+        assert build_parser().parse_args(["init"]).profile == DEFAULT_INIT_PROFILE
+
+    def test_the_default_profile_exists(self):
+        assert DEFAULT_INIT_PROFILE in INIT_PROFILES
+
+    def test_flagship_profile_installs_the_flagship_agent(self):
+        """Not `chat`: the chat wheel is a different agent and cannot serve
+        the TUI, which spawns the flagship binary."""
+        profile = INIT_PROFILES[FLAGSHIP_AGENT_ID]
+        assert profile["agent"] == FLAGSHIP_AGENT_ID
+        assert profile["agent"] in HUB_INSTALL_AGENTS
+
+    def test_flagship_profile_carries_the_chat_models_and_rag_extras(self):
+        """A flagship session needs the chat LLM, the RAG/memory embedder and
+        the [rag] extras — dropping any of them makes documents fail at first
+        index rather than at setup."""
+        profile = INIT_PROFILES[FLAGSHIP_AGENT_ID]
+        assert profile["models"] == [
+            "Gemma-4-E4B-it-GGUF",
+            "user.embeddinggemma-300m-GGUF",
+        ]
+        assert profile["pip_extras"] == ["rag"]
+        # EmbeddingGemma only loads on 10.9.0+ (same floor as chat/rag).
+        assert profile["min_lemonade_version"] == "10.9.0"
+
+    def test_availability_probe_uses_the_flagships_real_module_name(self, monkeypatch):
+        """`gaia_agent_gaia` does not exist and never will, so probing for it
+        would report the flagship missing forever and reinstall it every run."""
+        asked = []
+
+        def fake_find_spec(name):
+            asked.append(name)
+            return None
+
+        monkeypatch.setattr(
+            "gaia.installer.init_command.importlib.util.find_spec", fake_find_spec
+        )
+        monkeypatch.setattr("gaia.hub.installer.read_sentinel", lambda _id: None)
+        InitCommand._is_hub_agent_available(FLAGSHIP_AGENT_ID)
+        assert asked == [FLAGSHIP_IMPORT_NAME]
+
+    def test_other_agents_keep_the_gaia_agent_prefix_convention(self, monkeypatch):
+        asked = []
+        monkeypatch.setattr(
+            "gaia.installer.init_command.importlib.util.find_spec",
+            lambda name: asked.append(name),
+        )
+        monkeypatch.setattr("gaia.hub.installer.read_sentinel", lambda _id: None)
+        InitCommand._is_hub_agent_available("chat")
+        assert asked == ["gaia_agent_chat"]
+
+    def test_a_binary_only_flagship_install_counts_as_present(self, monkeypatch):
+        """The flagship publishes a native binary — `~/.gaia/agents/gaia/`
+        holds `gaia-agent.exe` and no site-packages at all. An import probe
+        can never see it, so without the sentinel check `gaia init` would
+        re-download the flagship on every run and always print
+        "initialization incomplete" after a successful setup."""
+        monkeypatch.setattr(
+            "gaia.installer.init_command.importlib.util.find_spec", lambda _n: None
+        )
+        monkeypatch.setattr(
+            "gaia.hub.installer.read_sentinel", lambda _id: object()
+        )
+        assert InitCommand._is_hub_agent_available(FLAGSHIP_AGENT_ID) is True
+
+    def test_absent_everywhere_reports_missing(self, monkeypatch):
+        monkeypatch.setattr(
+            "gaia.installer.init_command.importlib.util.find_spec", lambda _n: None
+        )
+        monkeypatch.setattr("gaia.hub.installer.read_sentinel", lambda _id: None)
+        assert InitCommand._is_hub_agent_available(FLAGSHIP_AGENT_ID) is False
+
+    def test_default_never_lands_on_a_device_specific_profile(self):
+        """Device profile and agent profile are different axes. Bare `gaia init`
+        resolves the agent axis only — auto-selecting `npu` would silently swap
+        a Ryzen AI box from GGUF/Vulkan onto the FLM backend."""
+        profile = INIT_PROFILES[DEFAULT_INIT_PROFILE]
+        for device_key in ("required_device", "recipe", "backend"):
+            assert device_key not in profile
+
+
+class TestExplicitProfilesUnchanged:
+    """Every explicit --profile still resolves exactly as before the default
+    moved. A default change that quietly re-pointed an explicit flag would be
+    the worse bug."""
+
+    @pytest.mark.parametrize("profile", sorted(INIT_PROFILES.keys()) + ["mcp"])
+    def test_explicit_profile_is_honoured(self, profile):
+        ns = build_parser().parse_args(["init", "--profile", profile])
+        assert ns.profile == profile
+
+    def test_chat_profile_still_installs_the_chat_wheel(self):
+        assert INIT_PROFILES["chat"]["agent"] == "chat"
+
+    def test_npu_profile_still_installs_the_chat_wheel_on_flm_models(self):
+        npu = INIT_PROFILES["npu"]
+        assert npu["agent"] == "chat"
+        assert npu["models"] == ["gemma4-it-e2b-FLM", "embed-gemma-300m-FLM"]
+        assert npu["required_device"] == "amd_npu"
+
+    def test_minimal_shortcut_still_wins_over_the_default(self):
+        """`gaia init --minimal` is a documented shortcut for --profile
+        minimal; the new default must not shadow it."""
+        ns = build_parser().parse_args(["init", "--minimal"])
+        assert ns.minimal is True
+        assert ("minimal" if ns.minimal else ns.profile) == "minimal"
+
+    def test_every_profile_still_has_the_required_keys(self):
+        for name, profile in INIT_PROFILES.items():
+            for key in ("description", "agent", "models", "approx_size"):
+                assert key in profile, f"profile '{name}' is missing '{key}'"
+
+
+class TestGoTuiContract:
+    """The Go TUI is the main entry point and drives setup through this CLI.
+    Nothing else checks that the two agree."""
+
+    def test_tui_asks_for_a_profile_this_cli_accepts(self):
+        profile = _go_const("Profile")
+        assert profile in INIT_PROFILES, (
+            f"{GAIAINIT_GO.name} runs `gaia init --profile {profile}`, "
+            f"which this CLI would reject"
+        )
+
+    def test_tui_asks_for_the_flagship_profile(self):
+        """The TUI spawns the flagship, so it must install the flagship."""
+        assert _go_const("Profile") == DEFAULT_INIT_PROFILE
+
+    def test_not_ready_exit_code_is_one(self):
+        """gaiainit.go treats 1 — and ONLY 1 — as "not set up yet"; every other
+        non-zero code means the question was not answered. Renumbering the
+        Python side would make the TUI rerun a multi-minute setup on launch."""
+        assert _go_const("notReadyExitCode") == "1"
+
+    @pytest.mark.parametrize("ready", [True, False])
+    def test_check_exit_codes_match_that_contract(self, ready, monkeypatch, capsys):
+        from gaia.installer.init_command import SetupStatus
+
+        monkeypatch.setattr(
+            "gaia.installer.init_command.check_setup_status",
+            lambda **kwargs: SetupStatus(ready=ready, reasons=[] if ready else ["x"]),
+        )
+        monkeypatch.setattr(
+            sys, "argv", ["gaia", "init", "--check", "--profile", DEFAULT_INIT_PROFILE]
+        )
+        from gaia.cli import main
+
+        with pytest.raises(SystemExit) as exc:
+            main()
+        assert exc.value.code == (0 if ready else 1)
+
+    def test_the_tuis_exact_argv_is_accepted_by_the_real_cli(self):
+        """End-to-end on the argv gaiainit.CheckArgs builds. An unrecognised
+        flag exits 2, which the TUI reports as "could not determine" — this
+        catches that before a user sees it."""
+        argv = ["init", "--check", "--profile", _go_const("Profile")]
+        proc = subprocess.run(
+            [sys.executable, "-m", "gaia.cli", *argv],
+            capture_output=True,
+            text=True,
+            timeout=180,
+            cwd=REPO_ROOT,
+            env={**_child_env()},
+        )
+        assert proc.returncode in (0, 1), (
+            f"`gaia {' '.join(argv)}` exited {proc.returncode}; "
+            f"only 0 (ready) and 1 (not ready) are part of the contract.\n"
+            f"{proc.stdout}\n{proc.stderr}"
+        )
+
+
+def _child_env() -> dict:
+    """Environment for the subprocess above, pinned to THIS worktree.
+
+    `gaia` is frequently `pip install -e` linked to a different checkout, so a
+    bare invocation would happily test someone else's source and pass.
+    """
+    import os
+
+    env = dict(os.environ)
+    src = str(REPO_ROOT / "src")
+    existing = env.get("PYTHONPATH")
+    env["PYTHONPATH"] = f"{src}{os.pathsep}{existing}" if existing else src
+    return env

--- a/tests/unit/test_init_command.py
+++ b/tests/unit/test_init_command.py
@@ -2037,6 +2037,11 @@ class _HubInstallWiringTestBase(unittest.TestCase):
             ),
             # Never touch the real user's ~/.gaia/config.json during a test.
             patch("gaia.config.GaiaConfig"),
+            # Same reason: _is_hub_agent_available falls back to the install
+            # sentinel under the real ~/.gaia/agents, so without this whether
+            # a developer happens to have run `gaia hub install` would decide
+            # the result of these tests.
+            patch("gaia.hub.installer.read_sentinel", return_value=None),
         ]
         for p in patches:
             p.start()
@@ -2605,10 +2610,10 @@ class TestPrintCompletionHeadlineGate(unittest.TestCase):
     """AC6/AC7/AC7b/AC8: the pre-branch "GAIA initialization complete!"
     headline (fact 5 -- printed BEFORE any profile branching, in two
     independent Rich/non-Rich copies) must be suppressed exactly when the
-    profile's declared agent is "chat" (covers both the `chat` and `npu`
-    profiles) AND the standalone chat wheel isn't importable -- and must
-    stay byte-identical to today in every other case. Each scenario is
-    exercised against BOTH _print_completion code paths per AC8, since a
+    profile installs a hub agent (the `gaia` flagship, or the `chat` wheel
+    that `chat` and `npu` both declare) AND that wheel isn't importable --
+    and must stay byte-identical to today in every other case. Each scenario
+    is exercised against BOTH _print_completion code paths per AC8, since a
     fix applied to only one copy is the obvious regression.
     """
 
@@ -2617,8 +2622,45 @@ class TestPrintCompletionHeadlineGate(unittest.TestCase):
 
         with patch("gaia.installer.init_command.LemonadeInstaller"):
             cmd = InitCommand(profile=profile, yes=True)
+        # Two seams, one scenario ("is the agent this profile needs there?").
+        # _chat_agent_available drives the `gaia chat` hint; the headline goes
+        # through _profile_agent_available, which is stubbed at its underlying
+        # probe so its real "does this profile install an agent at all?"
+        # scoping still runs (sd/vlm/minimal must stay unaffected).
         cmd._chat_agent_available = MagicMock(return_value=chat_available)
+        cmd._is_hub_agent_available = MagicMock(return_value=chat_available)
         return cmd
+
+    def test_flagship_profile_unavailable_rich_suppresses_headline(self):
+        """The default profile gets the same gate: `gaia init` must not claim
+        success while the flagship wheel the TUI spawns is still missing."""
+        from gaia.installer import init_command as ic
+
+        if not ic.RICH_AVAILABLE:
+            self.skipTest("rich not installed")
+        cmd = self._make_cmd("gaia", chat_available=False)
+        buf = io.StringIO()
+        cmd.console = ic.Console(file=buf, force_terminal=False, width=300)
+
+        cmd._print_completion()
+
+        self.assertNotIn("GAIA initialization complete!", buf.getvalue())
+
+    def test_flagship_profile_available_rich_reports_complete(self):
+        from gaia.installer import init_command as ic
+
+        if not ic.RICH_AVAILABLE:
+            self.skipTest("rich not installed")
+        cmd = self._make_cmd("gaia", chat_available=True)
+        buf = io.StringIO()
+        cmd.console = ic.Console(file=buf, force_terminal=False, width=300)
+
+        cmd._print_completion()
+
+        out = buf.getvalue()
+        self.assertIn("GAIA initialization complete!", out)
+        # Same quick-start block as `chat` -- the flagship is a superset.
+        self.assertIn("gaia chat --index report.pdf", out)
 
     # -- AC6: chat/npu profile, chat agent unavailable -> no headline --
 

--- a/tests/unit/test_init_command.py
+++ b/tests/unit/test_init_command.py
@@ -2659,8 +2659,9 @@ class TestPrintCompletionHeadlineGate(unittest.TestCase):
 
         out = buf.getvalue()
         self.assertIn("GAIA initialization complete!", out)
-        # Same quick-start block as `chat` -- the flagship is a superset.
-        self.assertIn("gaia chat --index report.pdf", out)
+        # The flagship's own next step -- `gaia chat` runs a different agent
+        # through a wheel this profile never installs.
+        self.assertIn("gaia-tui", out)
 
     # -- AC6: chat/npu profile, chat agent unavailable -> no headline --
 

--- a/tui/README.md
+++ b/tui/README.md
@@ -177,8 +177,8 @@ Anthropic to come back a 404 mid-turn.
 is skipped, so `LemonadeServer.exe` is never launched and the first answer is
 not held behind an install. The transcript says so, and says what it costs:
 retrieval, memory and the code index still embed through Lemonade (Anthropic
-has no embeddings API), so those need `gaia init --profile chat
---skip-chat-model`, or `/setup` in the composer, before they work.
+has no embeddings API), so those need `gaia init --skip-chat-model`, or
+`/setup` in the composer, before they work.
 
 Paths that cannot honour the flag say so instead of quietly ignoring it: the
 daemon transport refuses it, `--claude-model` without `--use-claude` refuses,

--- a/tui/internal/gaiainit/gaiainit.go
+++ b/tui/internal/gaiainit/gaiainit.go
@@ -91,7 +91,14 @@ func RunArgs(claudeMode bool) []string {
 	// --yes: nothing here can answer an interactive prompt. The child's stdin is
 	// not connected to the terminal, so a prompt gaia init tried to read would
 	// hang forever with no way to answer it.
-	args := []string{"init", "--profile", Profile, "--yes"}
+	//
+	// --skip-webui-build: this is the TERMINAL ui; it never loads the browser
+	// Agent UI. That build step only runs in a source checkout, and a failure in
+	// it makes `gaia init` exit non-zero AFTER Lemonade and every model already
+	// installed — so setup from this screen dead-ended on a component the screen
+	// does not use. Released installs skip the step anyway, so this changes
+	// nothing for them.
+	args := []string{"init", "--profile", Profile, "--yes", "--skip-webui-build"}
 	if claudeMode {
 		args = append(args, "--skip-chat-model")
 	}

--- a/tui/internal/gaiainit/gaiainit.go
+++ b/tui/internal/gaiainit/gaiainit.go
@@ -3,7 +3,7 @@
 //
 // It exists so the readiness screen and the chat view cannot disagree about
 // what "set up" means. Both ask the SAME `gaia init --check`, read the SAME
-// exit codes, and start the SAME `gaia init --profile chat --yes`. Re-deriving
+// exit codes, and start the SAME `gaia init --profile gaia --yes`. Re-deriving
 // those checks in Go was never on the table either: src/gaia/installer/
 // init_command.py is the single source of truth for what setup is, and a Go
 // copy of it would go stale the first time a profile changed.
@@ -28,9 +28,16 @@ import (
 )
 
 // Profile is the `gaia init` profile the flagship agent needs — see
-// INIT_PROFILES["chat"] in src/gaia/installer/init_command.py: the chat model,
-// the RAG/memory embedder, and the [rag] pip extras.
-const Profile = "chat"
+// INIT_PROFILES["gaia"] in src/gaia/installer/init_command.py: the chat model,
+// the RAG/memory embedder, the [rag] pip extras, and the flagship agent binary
+// this TUI actually spawns. It is also `gaia init`'s own default, so a user who
+// types the bare command gets exactly what the TUI would have run.
+//
+// Passed explicitly rather than relying on that default: against a gaia CLI too
+// old to know the profile, argparse exits 2, which Check reports as
+// ErrUnanswered. Omitting the flag would instead silently set up the wrong
+// agent — the `chat` wheel, which cannot serve this TUI.
+const Profile = "gaia"
 
 // CheckTimeout bounds the read-only readiness probe. It runs a fresh Python
 // interpreter plus one Lemonade health check, so a few seconds is normal; this

--- a/tui/internal/gaiainit/gaiainit_test.go
+++ b/tui/internal/gaiainit/gaiainit_test.go
@@ -1,0 +1,42 @@
+package gaiainit
+
+import (
+	"slices"
+	"testing"
+)
+
+// The TUI never loads the browser Agent UI, and that build step only runs in a
+// source checkout — where it failed on a missing type package and took the
+// whole run's exit code with it, AFTER Lemonade and both models had installed.
+// Setup launched from the terminal UI must not fail on a component it does not
+// use.
+func TestRunArgsSkipTheBrowserUIBuild(t *testing.T) {
+	for _, claude := range []bool{false, true} {
+		args := RunArgs(claude)
+		if !slices.Contains(args, "--skip-webui-build") {
+			t.Errorf("RunArgs(%v) = %v; missing --skip-webui-build", claude, args)
+		}
+	}
+}
+
+// --check is read-only and never builds anything, so the flag would be noise
+// there — and an older gaia that does not know it would exit 2, which Check
+// reports as "could not determine" rather than "not ready".
+func TestCheckArgsDoNotCarryBuildFlags(t *testing.T) {
+	if args := CheckArgs(false); slices.Contains(args, "--skip-webui-build") {
+		t.Errorf("CheckArgs = %v; the read-only probe builds nothing", args)
+	}
+}
+
+// The command shown to the user must match what the TUI actually ran, or a
+// copy-pasted retry behaves differently from the key they just pressed.
+func TestRunCommandNamesTheProfileThatIsRun(t *testing.T) {
+	args := RunArgs(false)
+	i := slices.Index(args, "--profile")
+	if i < 0 || i+1 >= len(args) {
+		t.Fatalf("RunArgs carries no --profile: %v", args)
+	}
+	if got := RunCommand(false); got != "gaia init --profile "+args[i+1] {
+		t.Errorf("RunCommand = %q, but RunArgs uses profile %q", got, args[i+1])
+	}
+}

--- a/tui/internal/ui/preflight/check.go
+++ b/tui/internal/ui/preflight/check.go
@@ -124,7 +124,7 @@ func blankRows(cfg Config) []Row {
 		{Key: KeyDaemon, Label: "Background service"},
 		{Key: KeySidecar, Label: cfg.AgentName + " agent"},
 		{Key: KeyLemonade, Label: lemonadeRowLabel},
-		{Key: KeyModel, Label: "AI model"},
+		{Key: KeyModel, Label: modelRowLabel},
 	}
 	for _, extra := range cfg.Extras {
 		rows = append(rows, Row{Key: extra.Key, Label: extra.Label, Optional: extra.Optional})
@@ -629,7 +629,7 @@ func checkInit(ctx context.Context, t Transport, cfg Config, rep *Report) State 
 		model.Detail = "About 4 GB. Once downloaded it is reused by every GAIA agent."
 		model.Fix = FixPullModel
 		model.Remedy = Remedy{
-			Action:  "Download it — press f to pull it here, or run the command.",
+			Action:  "It downloads once, then every GAIA agent reuses it.",
 			Command: "gaia init",
 			Where:   "https://amd-gaia.ai/docs/guides/install",
 		}

--- a/tui/internal/ui/preflight/lemonade.go
+++ b/tui/internal/ui/preflight/lemonade.go
@@ -50,6 +50,13 @@ const serverPathEnv = "LEMONADE_SERVER_PATH"
 // row searchable.
 const lemonadeRowLabel = "Lemonade"
 
+// modelRowLabel names the weights this agent needs.
+//
+// Not "AI model": on a screen whose other rows are also AI, that names the
+// category rather than the thing, and it gives a user staring at a multi-GB
+// download no word they can search for. "Language model" is what it is.
+const modelRowLabel = "Language model"
+
 // lemonadeDocs is where the run instructions for every platform live.
 const lemonadeDocs = "https://lemonade-server.ai/docs/guide/"
 

--- a/tui/internal/ui/preflight/local.go
+++ b/tui/internal/ui/preflight/local.go
@@ -323,13 +323,25 @@ func (l localRunner) checkLemonade(ctx context.Context, _ Config) Row {
 	// stops at the FIRST failure, so whenever this row is the blocker the model
 	// row below it is pending and unfocusable. Withholding the key here left
 	// the commonest first-run failure with nothing to press.
-	row.Fix = FixRunSetup
-	// The shared remedy's Action describes starting Lemonade BY HAND, which is
-	// the right instruction where there is no `f` (the daemon runner). Here
-	// there is one, so say what it does first — otherwise the row explains the
-	// manual route while the key that automates it sits directly underneath.
-	row.Remedy.Action = "Press f and setup installs and starts it. Already have it? " +
-		row.Remedy.Action
+	//
+	// Two states are excluded because `gaia init` provably cannot fix them:
+	//
+	//   - a bad LEMONADE_SERVER_PATH: setup would inherit the same bad value,
+	//     so the key would fail every time while the step that DOES fix it
+	//     (unset the variable) sat below as the optional alternative;
+	//   - a non-loopback LEMONADE_BASE_URL: `gaia init` auto-detects remote
+	//     mode from it and then refuses to install or start anything. The
+	//     daemon runner already special-cases this (check.go); matching it here
+	//     is what keeps the two screens from diverging.
+	if resolveLemonade().BadOverride == "" && isLoopback(base) {
+		row.Fix = FixRunSetup
+		// The shared remedy's Action describes starting Lemonade BY HAND, which
+		// is right where there is no `f`. Here there is one, so say what it does
+		// first — otherwise the row explains the manual route while the key that
+		// automates it sits directly underneath.
+		row.Remedy.Action = "Press f and setup installs and starts it. Already have it? " +
+			row.Remedy.Action
+	}
 	return row
 }
 

--- a/tui/internal/ui/preflight/local.go
+++ b/tui/internal/ui/preflight/local.go
@@ -91,7 +91,7 @@ func (l localRunner) Rows(cfg Config) []Row {
 	}
 	rows = append(rows,
 		Row{Key: KeyLemonade, Label: lemonadeRowLabel},
-		Row{Key: KeyModel, Label: "AI model"},
+		Row{Key: KeyModel, Label: modelRowLabel},
 	)
 	for i := range rows {
 		rows[i].State = StatePending
@@ -318,10 +318,18 @@ func (l localRunner) checkLemonade(ctx context.Context, _ Config) Row {
 	row.Detail = "GAIA needs a local model server. It runs on your machine; no message " +
 		"text ever leaves it."
 	row.Remedy = lemonadeStartRemedy()
-	// Starting Lemonade is `gaia init`'s job, and that is the AI model row's
-	// fix — offering it twice would run the same multi-minute command from two
-	// rows.
-	row.Fix = FixNone
+	// Installing and starting Lemonade is `gaia init`'s job, so this row gets
+	// the same one-key setup the model row does. It cannot run twice: Check
+	// stops at the FIRST failure, so whenever this row is the blocker the model
+	// row below it is pending and unfocusable. Withholding the key here left
+	// the commonest first-run failure with nothing to press.
+	row.Fix = FixRunSetup
+	// The shared remedy's Action describes starting Lemonade BY HAND, which is
+	// the right instruction where there is no `f` (the daemon runner). Here
+	// there is one, so say what it does first — otherwise the row explains the
+	// manual route while the key that automates it sits directly underneath.
+	row.Remedy.Action = "Press f and setup installs and starts it. Already have it? " +
+		row.Remedy.Action
 	return row
 }
 
@@ -415,7 +423,7 @@ func (l localRunner) checkModels(ctx context.Context, _ Config) Row {
 		"GAIA session."
 	row.Fix = FixRunSetup
 	row.Remedy = Remedy{
-		Action:  "Download them — press f to run setup here, or run the command.",
+		Action:  "Setup downloads what is missing and starts the local server.",
 		Command: gaiainit.RunCommand(l.opts.ClaudeMode),
 		Where:   "https://amd-gaia.ai/docs/guides/install",
 	}

--- a/tui/internal/ui/preflight/local_test.go
+++ b/tui/internal/ui/preflight/local_test.go
@@ -188,10 +188,22 @@ func TestTheLemonadeRemedyIsSharedWithTheDaemonRunner(t *testing.T) {
 		t.Fatalf("an unreachable Lemonade is %s, want failed", row.State.Word())
 	}
 
+	// The COMMAND and the docs link are what must never drift — sending two
+	// screens to different start instructions for the same server is the bug
+	// this reuse exists to prevent. The Action legitimately differs: only this
+	// runner offers `f`, so only it leads with what that key does.
 	want := lemonadeStartRemedy()
-	if row.Remedy != want {
+	if row.Remedy.Command != want.Command || row.Remedy.Where != want.Where {
 		t.Errorf("the local runner's Lemonade remedy has drifted from the shared one:\n"+
 			" local: %+v\nshared: %+v", row.Remedy, want)
+	}
+	if !strings.Contains(row.Remedy.Action, want.Action) {
+		t.Errorf("the shared start instruction was dropped rather than prefixed:\n"+
+			" local: %q\nshared: %q", row.Remedy.Action, want.Action)
+	}
+	if !strings.HasPrefix(row.Remedy.Action, "Press f and setup installs") {
+		t.Errorf("the row explains the manual route before the key that automates "+
+			"it:\n%q", row.Remedy.Action)
 	}
 }
 
@@ -464,4 +476,53 @@ func exitStub(t *testing.T, code int) string {
 		t.Fatal(err)
 	}
 	return path
+}
+
+// A down Lemonade is the commonest first-run failure, and Check stops at the
+// FIRST failure — so when this row blocks, the model row below it is pending
+// and cannot be focused. Withholding the setup key here left the screen with
+// nothing to press and a command the user had to go type somewhere else.
+func TestADownLemonadeOffersTheOneKeySetup(t *testing.T) {
+	t.Setenv(lemonadeBaseURLEnv, "http://127.0.0.1:9/api/v1")
+
+	row := localRunner{}.checkLemonade(context.Background(), localCfg())
+	if row.State != StateFailed {
+		t.Fatalf("an unreachable Lemonade is %s, want failed", row.State.Word())
+	}
+	if row.Fix != FixRunSetup {
+		t.Errorf("fix = %v, want FixRunSetup — `gaia init` installs and starts "+
+			"Lemonade, so this row is fixable from the screen", row.Fix)
+	}
+}
+
+// The guard the comment on that Fix depends on: the two rows that share
+// FixRunSetup can never both be offered, because the walk halts at the first
+// failure. If that ever changes, pressing f twice would run the same
+// multi-minute command from two rows.
+func TestOnlyOneRowEverOffersSetupAtATime(t *testing.T) {
+	t.Setenv(lemonadeBaseURLEnv, "http://127.0.0.1:9/api/v1")
+
+	dir := t.TempDir()
+	name := "fixture-agent"
+	if runtime.GOOS == "windows" {
+		name += ".exe"
+	}
+	path := filepath.Join(dir, name)
+	if err := os.WriteFile(path, []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	rep := localRunner{opts: LocalOptions{Binary: path}}.
+		Check(context.Background(), localCfg())
+
+	offered := 0
+	for _, r := range rep.Rows {
+		if r.State == StateFailed && r.Fix == FixRunSetup {
+			offered++
+		}
+	}
+	if offered > 1 {
+		t.Errorf("%d failed rows offer setup at once; pressing f would run "+
+			"`gaia init` from either:\n%s", offered, rep)
+	}
 }

--- a/tui/internal/ui/preflight/local_test.go
+++ b/tui/internal/ui/preflight/local_test.go
@@ -495,11 +495,14 @@ func TestADownLemonadeOffersTheOneKeySetup(t *testing.T) {
 	}
 }
 
-// The guard the comment on that Fix depends on: the two rows that share
-// FixRunSetup can never both be offered, because the walk halts at the first
-// failure. If that ever changes, pressing f twice would run the same
-// multi-minute command from two rows.
-func TestOnlyOneRowEverOffersSetupAtATime(t *testing.T) {
+// The guard the comment on that Fix depends on: rows after the first failure
+// are PENDING, so two rows can never offer setup at once.
+//
+// Asserting on the Fix fields directly would pass vacuously wherever `gaia` is
+// absent from PATH (every CI runner): checkModels would report StateUnknown,
+// not StateFailed, so the count would be 1 whether or not the halt existed.
+// Asserting the halt itself needs nothing external.
+func TestCheckHaltsAtTheFirstFailureSoOnlyOneRowCanOfferSetup(t *testing.T) {
 	t.Setenv(lemonadeBaseURLEnv, "http://127.0.0.1:9/api/v1")
 
 	dir := t.TempDir()
@@ -515,14 +518,48 @@ func TestOnlyOneRowEverOffersSetupAtATime(t *testing.T) {
 	rep := localRunner{opts: LocalOptions{Binary: path}}.
 		Check(context.Background(), localCfg())
 
-	offered := 0
+	seenFailure := false
 	for _, r := range rep.Rows {
-		if r.State == StateFailed && r.Fix == FixRunSetup {
-			offered++
+		if seenFailure && r.State != StatePending {
+			t.Errorf("row %q is %s after an earlier failure; the walk did not halt, "+
+				"so two rows could offer setup at once:\n%s",
+				r.Key, r.State.Word(), rep)
+		}
+		if r.State == StateFailed {
+			seenFailure = true
 		}
 	}
-	if offered > 1 {
-		t.Errorf("%d failed rows offer setup at once; pressing f would run "+
-			"`gaia init` from either:\n%s", offered, rep)
+	if !seenFailure {
+		t.Fatalf("expected a failed row with Lemonade pointed at a dead port:\n%s", rep)
+	}
+}
+
+// `gaia init` inherits the same bad LEMONADE_SERVER_PATH, so pressing f would
+// fail every time — while the step that actually fixes it (unset the variable)
+// sat below as the optional alternative.
+func TestABadServerPathOverrideOffersNoSetupKey(t *testing.T) {
+	t.Setenv(lemonadeBaseURLEnv, "http://127.0.0.1:9/api/v1")
+	t.Setenv(serverPathEnv, filepath.Join(t.TempDir(), "not-here"))
+
+	row := localRunner{}.checkLemonade(context.Background(), localCfg())
+	if row.Fix != FixNone {
+		t.Errorf("fix = %v, want FixNone — setup cannot repair an override it "+
+			"would inherit", row.Fix)
+	}
+}
+
+// `gaia init` auto-detects remote mode from a non-loopback LEMONADE_BASE_URL and
+// then refuses to install or start anything, so the key provably cannot work.
+// The daemon runner already special-cases this; the two screens must not differ.
+func TestARemoteLemonadeOffersNoSetupKey(t *testing.T) {
+	t.Setenv(lemonadeBaseURLEnv, "http://192.168.1.50:13305/api/v1")
+
+	row := localRunner{}.checkLemonade(context.Background(), localCfg())
+	if row.State != StateFailed {
+		t.Fatalf("an unreachable remote Lemonade is %s, want failed", row.State.Word())
+	}
+	if row.Fix != FixNone {
+		t.Errorf("fix = %v, want FixNone — `gaia init` refuses to install or "+
+			"start anything in remote mode", row.Fix)
 	}
 }

--- a/tui/internal/ui/preflight/view.go
+++ b/tui/internal/ui/preflight/view.go
@@ -133,8 +133,23 @@ func clipToTerminal(lines []string, cols, rows int) string {
 	return strings.Join(lines, "\n")
 }
 
+// headerTitle names what the screen is DOING, not a fixed caption. This is a
+// setup screen — when a row is blocking, saying "setting up" is what tells the
+// user the work happens here rather than in some terminal they have to go find.
+func headerTitle(m Model) string {
+	switch {
+	case m.phase == phaseProvisioning:
+		return fmt.Sprintf("Setting up %s", m.cfg.AgentName)
+	case m.phase == phaseChecking:
+		return fmt.Sprintf("Checking %s setup", m.cfg.AgentName)
+	case m.rep.Blocked():
+		return fmt.Sprintf("Setting up %s", m.cfg.AgentName)
+	}
+	return fmt.Sprintf("Getting %s ready", m.cfg.AgentName)
+}
+
 func (m Model) header(w int) string {
-	left := fmt.Sprintf("Getting %s ready", m.cfg.AgentName)
+	left := headerTitle(m)
 	right := m.rep.Summary()
 	if m.phase == phaseChecking {
 		right = "checking…"
@@ -313,26 +328,34 @@ func (m Model) remedyLines(row Row, w int) []string {
 			out = append(out, labelStyle.Render(l))
 		}
 	}
+	// The one-key fix leads. It used to sit UNDER the command, which read as
+	// "go run this yourself" on a row the TUI fixes in place — the whole reason
+	// `f` exists. The command stays as the copy-paste escape hatch and says so
+	// ("or run:") whenever pressing f would do the same work.
+	if row.Fix != FixNone {
+		out = append(out, keyStyle.Render("f")+" "+dimStyle.Render(row.Fix.Label()))
+	}
 	if row.Remedy.Command != "" {
-		for i, l := range wrap(row.Remedy.Command, w-7) {
-			prefix := dimStyle.Render("run:   ")
+		label := "run:   "
+		if row.Fix != FixNone {
+			label = "or run:"
+		}
+		for i, l := range wrap(row.Remedy.Command, w-8) {
+			prefix := dimStyle.Render(label + " ")
 			if i > 0 {
-				prefix = "       "
+				prefix = strings.Repeat(" ", len(label)+1)
 			}
 			out = append(out, prefix+cmdStyle.Render(l))
 		}
 	}
 	if row.Remedy.Where != "" {
-		for i, l := range wrap(row.Remedy.Where, w-7) {
-			prefix := dimStyle.Render("look:  ")
+		for i, l := range wrap(row.Remedy.Where, w-8) {
+			prefix := dimStyle.Render("look:   ")
 			if i > 0 {
-				prefix = "       "
+				prefix = "        "
 			}
 			out = append(out, prefix+dimStyle.Render(l))
 		}
-	}
-	if row.Fix != FixNone {
-		out = append(out, keyStyle.Render("f")+" "+dimStyle.Render(row.Fix.Label()))
 	}
 	return out
 }

--- a/tui/internal/ui/preflight/view_test.go
+++ b/tui/internal/ui/preflight/view_test.go
@@ -66,13 +66,15 @@ func TestRenderAllFailedAt80x24(t *testing.T) {
 
 	assertFits(t, lines, 80, 24)
 
-	// Every row is present and legible without colour.
+	// Every row is present and legible without colour. The title names the work
+	// in progress rather than a fixed caption — a blocked screen is a SETUP
+	// screen, and saying so is what tells the user the work happens here.
 	for _, want := range []string{
-		"Getting Email ready",
+		"Setting up Email",
 		"Background service",
 		"Email agent",
 		"Lemonade",
-		"AI model",
+		"Language model",
 		"Mailbox",
 	} {
 		if !strings.Contains(screen, want) {
@@ -368,4 +370,66 @@ func TestRenderWrapsLongRemediesInsteadOfOverflowing(t *testing.T) {
 // panel wrapping a long line. Only for assertions — never for what a user sees.
 func squeezeSpace(s string) string {
 	return strings.Join(strings.Fields(s), "")
+}
+
+// The one-key fix has to be the FIRST thing under a fixable row.
+//
+// It used to render last, under `run: <command>` — so the screen led with a
+// command the user was expected to go type, on a row the TUI fixes in place.
+// That is the whole reason `f` exists, and the ordering hid it.
+func TestFixableRowOffersTheKeyBeforeTheManualCommand(t *testing.T) {
+	f := newFake()
+	f.attachErr = &daemon.NotRunningError{Path: "/Users/you/.gaia/host/instance.json"}
+
+	_, lines := renderAt(t, f, 80, 24)
+
+	fixAt, cmdAt := -1, -1
+	for i, l := range lines {
+		if fixAt < 0 && strings.Contains(l, "f start it for me") &&
+			!strings.Contains(l, "r re-check") { // skip the footer key list
+			fixAt = i
+		}
+		if cmdAt < 0 && strings.Contains(l, "gaia daemon start") {
+			cmdAt = i
+		}
+	}
+	if fixAt < 0 || cmdAt < 0 {
+		t.Fatalf("expected both a fix key and a command line:\n%s", joined(lines))
+	}
+	if fixAt > cmdAt {
+		t.Errorf("the manual command (line %d) is offered before the one-key fix "+
+			"(line %d) — the screen reads as 'go run this yourself':\n%s",
+			cmdAt, fixAt, joined(lines))
+	}
+}
+
+// A row the TUI can fix says the command is the ALTERNATIVE, not the
+// instruction. Without "or", the two read as two required steps.
+func TestFixableRowMarksTheCommandAsAnAlternative(t *testing.T) {
+	f := newFake()
+	f.attachErr = &daemon.NotRunningError{Path: "/Users/you/.gaia/host/instance.json"}
+
+	_, lines := renderAt(t, f, 80, 24)
+	if !strings.Contains(joined(lines), "or run:") {
+		t.Errorf("a fixable row does not present its command as an alternative:\n%s",
+			joined(lines))
+	}
+}
+
+// The title tracks what the screen is doing. "Getting X ready" on a screen
+// that is blocking a launch understates it; the user needs to know setup runs
+// right here.
+func TestTitleSaysReadyWhenNothingIsBlocking(t *testing.T) {
+	m, _ := renderAt(t, newFake(), 80, 24)
+	if got := headerTitle(m); got != "Getting Email ready" {
+		t.Errorf("unblocked title = %q, want the ready caption", got)
+	}
+}
+
+func TestTitleSaysSettingUpWhileProvisioning(t *testing.T) {
+	m, _ := renderAt(t, newFake(), 80, 24)
+	m.phase = phaseProvisioning
+	if got := headerTitle(m); got != "Setting up Email" {
+		t.Errorf("provisioning title = %q, want the setup caption", got)
+	}
 }

--- a/tui/test/preflight_gate_test.go
+++ b/tui/test/preflight_gate_test.go
@@ -70,7 +70,7 @@ func readyGateTransport() *gateTransport {
 				"version": "8.2.0", "min_version": "8.1.0", "compatible": true,
 			},
 			"model": map[string]any{
-				// At the profile window: below it the AI model row reports a shortfall,
+				// At the profile window: below it the language model row reports a shortfall,
 				// which is a real answer but not the "everything ready" this fixture means.
 				"id": "Gemma-4-E4B-it-GGUF", "present": true, "ctx_size": 65536,
 			},
@@ -404,7 +404,7 @@ func TestLaunchingAnAgentShowsPreflightNotChat(t *testing.T) {
 		t.Fatalf("view after launch = %q, want preflight", got)
 	}
 	screen := d.flat()
-	if !strings.Contains(screen, "Getting Email ready") {
+	if !strings.Contains(screen, "Checking Email setup") {
 		t.Errorf("the gate is not what got rendered:\n%s", d.screen())
 	}
 	if strings.Contains(screen, "Welcome to GAIA") {
@@ -443,9 +443,9 @@ func TestAFailingPreconditionKeepsTheUserOnTheGate(t *testing.T) {
 	}
 	screen := d.flat()
 	for _, want := range []string{
-		"AI model",          // the row
+		"Language model",    // the row
 		"not downloaded",    // what is wrong
-		"run: gaia init",    // the remedy command
+		"or run: gaia init", // the remedy command, now the alternative
 		"f download it now", // the one-key fix
 	} {
 		if !strings.Contains(screen, want) {
@@ -832,10 +832,10 @@ func TestEveryGateStateFitsEightyByTwentyFour(t *testing.T) {
 		{name: "all ready", build: readyGateTransport, hold: true,
 			wants: []string{"Getting Email ready", "ready", "Mailbox", "esc back"}},
 		{name: "model missing", build: func() *gateTransport { return readyGateTransport().modelMissing() },
-			wants: []string{"AI model", "not downloaded", "run: gaia init", "esc back"}},
+			wants: []string{"Language model", "not downloaded", "or run: gaia init", "esc back"}},
 		{name: "model missing, details", build: func() *gateTransport { return readyGateTransport().modelMissing() },
 			keys:  []tea.KeyMsg{key("d")},
-			wants: []string{"AI model — failed", "esc back"}},
+			wants: []string{"Language model — failed", "esc back"}},
 		{name: "mailbox missing", build: func() *gateTransport { return readyGateTransport().mailboxMissing() },
 			wants: []string{"Mailbox", "not connected", "gaia connectors connect google", "esc back"}},
 		{name: "mailbox hand-off", build: func() *gateTransport { return readyGateTransport().mailboxMissing() },


### PR DESCRIPTION
Typing `gaia init` — the command the one-line installers print and the terminal UI names — set up the **chat** agent, while the TUI actually launches the **flagship**. A user who followed the obvious instruction ended up without the agent that opens when they start GAIA. And when the TUI's own setup screen found something missing, it led with a command to go type in another terminal, with the key that does it in place buried underneath — and for the commonest first-run failure, no key at all.

After this, `gaia init` sets up the flagship, the TUI asks for the same profile it launches, and its setup screen does the setup.

**Two threads, both about making `gaia init` the one setup path:**

- **`gaia init` defaults to the flagship.** Every explicit `--profile X` is unchanged. The default resolves only the *agent* axis — it never picks `npu` for you, so a Ryzen AI box is not silently moved from GGUF/Vulkan onto the FLM backend.
- **The TUI setup screen does the work.** The one-key fix leads, the command becomes the labelled alternative, and a down Lemonade can finally be fixed from the screen instead of only described.

<details>
<summary>🔍 Technical details</summary>

### Thread 1 — the default profile

- `--profile` already defaulted to `chat`, so bare `gaia init` == `gaia init --profile chat`.
- `INIT_PROFILES[p]["agent"]` does two jobs: a Lemonade `AGENT_PROFILES` model lookup (only reached when `models` is `None`, i.e. the `all` profile), and *which hub agent gets installed*. Every profile pointed at `chat`.
- The flagship is hub id `gaia` (`gaia-agent-gaia`, class `GaiaAgent`, binary `gaia-agent`) — what `catalog.FlagshipID` spawns. Nothing installed it.
- `--check` contract unchanged: exit `0` READY, `1` NOT READY. `gaiainit.go` treats 1 and only 1 as "not ready"; anything else is `ErrUnanswered`.
- Device vs agent axis: `npu` is the only device-axis profile (`required_device`, `recipe: flm`, `backend: flm:npu`), and the new default deliberately carries none of those keys.

Two things the flagship's artifact shape forced:

1. **Readiness can't be an import probe.** The hub publishes the flagship as a *native binary* — a cold install produces `~/.gaia/agents/gaia/gaia-agent.exe` and no `site-packages` at all. `find_spec` can never see it, so `_is_hub_agent_available` falls back to the install sentinel. Without that, `gaia init` re-downloaded the flagship every run and printed "initialization incomplete" after a successful setup. Only cold-state testing surfaced this.
2. **The naming convention has an exception.** `gaia-agent-gaia` installs the module `gaia_agent`, not `gaia_agent_gaia`.

*Known limitation (pre-existing):* `--check` verifies Lemonade + models but not the hub agent, so deleting the flagship still reports READY. Expanding it changes what the TUI's gate loops on — left for a separate change.

### Thread 2 — the setup screen

`checkLemonade` set `Fix = FixNone`, reasoning that starting Lemonade is `gaia init`'s job and *that is the model row's fix, so offering it twice would run the same multi-minute command from two rows*. The premise doesn't hold: `Check` halts at the first failure and marks the rest pending, so whenever Lemonade blocks, the model row is `[ ]` and unfocusable. The two can never both be offered — a test now pins that invariant rather than leaving it asserted in a comment.

Nothing new runs setup: `FixRunSetup` already routed to `gaiainit.Start()`, the same subprocess `/setup` uses, with the same streaming and Esc-cancels. This only widens which rows reach it. `remedyLines` now renders the fix key first and labels the command `or run:` when the row has a fix.

*Not done here:* the daemon runner's `f` still POSTs `/v1/<agent>/init` (a model pull) rather than running `gaia init`. That is right for a daemon-supervised agent and is a separate blast radius.

### Testing notes

Verified from a cold state (editable hub-agent installs hidden from the interpreter, throwaway `HOME`/`GAIA_HOME`) because this box has every agent `-e` installed — the exact warm cache that hides the bug. `PYTHONPATH` was pinned to the worktree throughout; `gaia` here is `-e` linked to a *different* checkout, so an unpinned run tests someone else's source.
</details>

## Test plan

- [x] `pytest tests/unit/installer/test_init_default_profile.py` — 30 tests; verified they **fail** when the change is reverted (mutation-checked)
- [x] Full `pytest tests/unit/` — failure set byte-identical to the pre-change baseline
- [x] `python util/lint.py --all` — passes
- [x] `go build ./... && go vet ./... && go test ./...` in `tui/` — clean
- [x] Cold state, real CLI: bare `gaia init` installs the flagship from the hub; a second run skips the reinstall and reports complete
- [x] Cold state: `gaia init --check` exits 1 not-ready / 0 ready; `--profile chat` and `--profile npu` unchanged
- [x] `gaia-tui` driven live via the control API: readiness gate answers (no `ErrUnanswered`), and against a dead `LEMONADE_BASE_URL` the new screen shows "Setting up GAIA", "Language model", and `f` on the Lemonade row
- [x] Docs updated together: `cli.mdx`, `terminal-hub.mdx` (transcripts were already stale), `agent-ui.mdx`, `troubleshooting.mdx`, `flagship-installer.mdx`, `tui/README.md`
