### PR TITLE
feat(email,skills): read-only inbox triage on the flagship agent

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -397,6 +397,7 @@
               "plans/connectors",
               "plans/email-calendar-integration",
               "plans/email-triage-agent",
+              "plans/email-triage-skill",
               "plans/messaging-integrations-plan",
               "plans/autonomy-engine"
             ]

--- a/docs/plans/email-triage-skill.mdx
+++ b/docs/plans/email-triage-skill.mdx
@@ -1,0 +1,363 @@
+---
+title: "Email Triage as a Flagship Skill"
+description: "Replace the standalone Email Triage Agent with an email tool mixin plus an inbox-triage skill on the flagship GAIA agent, so the custom agent can be decommissioned"
+icon: "inbox"
+---
+
+<Info>
+  **Issue draft.** Proposed for `amd/gaia`, labels `enhancement` + `agent` + `p1`.
+  Cross-links [#2672](https://github.com/amd/gaia/issues/2672),
+  [#2683](https://github.com/amd/gaia/issues/2683),
+  [#2863](https://github.com/amd/gaia/issues/2863),
+  [#2982](https://github.com/amd/gaia/issues/2982).
+</Info>
+
+## The problem
+
+Ask the flagship GAIA agent to triage your inbox and it cannot. It has no Gmail
+tool, no Outlook tool, and no Google or Microsoft connector grant — 67 registered
+tools and not one of them touches mail. Email lives in a separate installable
+agent with its own sidecar process, its own REST API, its own npm package, and its
+own 66-tool surface. A user who wants "read my mail and tell me what needs me"
+alongside "search my documents" has to run two agents and cannot ask one question
+that spans both.
+
+After this change, `triage my inbox` works in the Go TUI against the same flagship
+agent that already does documents, web, shell, and memory — and the standalone
+email agent becomes redundant rather than load-bearing.
+
+This is the architectural direction CLAUDE.md already states: per-task agents were
+deleted and their capability became the flagship's tool surface driven by a
+`SKILL.md` in `hub/skills/`. Email is the last major holdout.
+
+## Position against the prior art
+
+Four issues touch this area. This proposal is deliberately narrower than all of them.
+
+| Issue | What it wants | Relationship |
+|---|---|---|
+| [#2672](https://github.com/amd/gaia/issues/2672) | Email's ~59 tools become **portable skills installable into any agent** | Same mechanism, different goal. Explicitly keeps email agent behaviour unchanged — it does not decommission. Blocked on #2863. |
+| [#2683](https://github.com/amd/gaia/issues/2683) | Email agent as the **adaptive-skills (skills-v2) reference example** | Assumes the email agent keeps existing. Orthogonal; would retarget onto the flagship if this lands. |
+| [#2863](https://github.com/amd/gaia/issues/2863) | Phase 2 **local-capability sandbox** | Blocks #2672. **Does not block this proposal** — see below. |
+| [#2982](https://github.com/amd/gaia/issues/2982) | Collapse example agents into flagship + skills | Same direction, but names the email agent as an explicit **non-goal** ("reference sidecar product — stays"). **This proposal contradicts that.** Needs an owner decision. |
+
+**File this as a new issue narrowing #2672, not as an amendment.** #2672's goal is
+portability of email capability *into arbitrary agents*; its acceptance test is
+literally "a non-email agent installs an extracted skill and uses its tools", and
+it is blocked on a sandbox that does not exist. This proposal has one consumer (the
+flagship), needs no sandbox, and its success condition is the *deletion* of a
+package. Folding a decommission plan into a portability issue would bury it behind
+a blocker it does not have.
+
+## The constraint that picks the architecture — verified, and it is not what it looks like
+
+The premise that local-capability permissions are refused is **true but does not
+apply here**, for two independent reasons. Both were verified in code.
+
+**1. `shell` is no longer a local-capability domain.** It was, when #2672 was
+written. It is now binary-bridged:
+
+```python
+# src/gaia/skills/permissions.py:63-73
+CONNECTOR_BRIDGED_DOMAINS = frozenset({"network", "mcp"})
+BINARY_BRIDGED_DOMAINS = frozenset({"shell"})
+LOCAL_CAPABILITY_DOMAINS = (
+    frozenset(DOMAIN_LEVELS) - CONNECTOR_BRIDGED_DOMAINS - BINARY_BRIDGED_DOMAINS
+)
+```
+
+So the refused set today is `filesystem`, `database`, `desktop`, `env` — **not**
+`shell`. That is why `hub/skills/github-triage/SKILL.md` can declare
+`shell:execute:gh` and load: a scoped binary grant resolves against
+`BINARY_POLICIES` in `src/gaia/skills/binaries.py` (only `gh` and `pytest` have
+policies today). Unscoped `shell:execute` is still refused, because that asks for
+the whole shell. There is no allowlist exception and no bundled-vs-installed
+distinction — the gate is the same for every skill.
+
+**2. The gate only ever runs on skill permissions, never on agent code.** Every
+call site of `refuse_unbridged_permissions` passes `skill.parsed_permissions()`
+(`agent.py:1619`, `loader.py:62`, `install.py:353`, `publish.py:137`,
+`migrate.py:821`). A tool mixin composed into an agent class is ordinary Python in
+the agent — it is not a skill, declares no permissions, and is never gated.
+
+**Consequence:** a first-class email tool mixin is available **now**. The sandbox
+in #2863 is not on its critical path. What #2863 blocks is shipping email tools as
+a *skill-provided* `tools.py`, because the reversible-action ledger needs
+`database:write` — and that is precisely why #2672 is stuck.
+
+## Recommended architecture — A: tool mixin + skill
+
+**A new `gaia.agents.tools.email_tools.EmailToolsMixin`, registered in
+`KNOWN_TOOLS`, orchestrated by `hub/skills/inbox-triage/SKILL.md`.**
+
+The skill carries judgment (what "urgent" means, when to escalate, how to word a
+digest). The mixin carries capability (authenticated Gmail/Graph calls). This is
+exactly the split every shipped starter skill already uses — `document-brief`
+names `RAGToolsMixin`'s tools in `tools_required` without any code coupling.
+
+### Why not the alternatives
+
+**B — MCP connector.** Available today via `mcp:connect`, but there is no
+Gmail or Outlook server in `src/gaia/connectors/catalog/mcp_servers.py` (only
+`mcp-github`, `mcp-tavily`, `mcp-memory`, `mcp-git`). Adopting it means handing a
+third-party `npx` subprocess standing access to the user's entire mailbox, and
+moving OAuth credentials out of the OS keyring into subprocess env vars — wrong
+for a local-first product, and it discards `gmail_backend.py` / `outlook_backend.py`,
+which are tested and already authenticate through `gaia.connectors.api`. Keep MCP
+as a bring-your-own-provider escape hatch, not the primary path.
+
+**C — skill drives the email agent's REST API.** Hides the agent instead of
+retiring it, so it fails the stated goal. It is not even cheap: the flagship has no
+HTTP POST tool, and `shell:execute:curl` has no binary policy, so it needs new
+plumbing to deliver strictly less.
+
+**D — a `gaia-mail` CLI plus a binary policy, mirroring `gh`.** Structurally the
+closest analogue to `github-triage`, but it means building the same Gmail client and
+then wrapping it in argv parsing and a second permission layer. Strictly more work
+than A for the same result.
+
+### Why A is cheaper than it looks
+
+The connector plumbing is already shared. `gmail_backend.py` and
+`outlook_backend.py` obtain tokens via
+`gaia.connectors.api.get_access_token_sync(provider=..., scopes=..., agent_id=...)`
+— the same call a core mixin makes. Grants are enforced centrally by
+`check_agent_grant()`. Moving the backends into `src/gaia/agents/tools/` is largely
+a relocation, not a rewrite.
+
+### New and changed files
+
+| Path | Change |
+|---|---|
+| `src/gaia/agents/tools/email_tools.py` | New — `EmailToolsMixin`, ~19 tools |
+| `src/gaia/agents/tools/_email/gmail.py` | New — relocated from `gaia_agent_email/gmail_backend.py` |
+| `src/gaia/agents/tools/_email/graph.py` | New — relocated from `outlook_backend.py` (Phase 4) |
+| `src/gaia/agents/tools/_email/scopes.py` | New — relocated; keeps the `https://mail.google.com/` exclusion (#2533) |
+| `src/gaia/agents/registry.py` | Add `"email"` to `KNOWN_TOOLS` |
+| `hub/skills/inbox-triage/SKILL.md` | New — the judgment layer |
+| `hub/agents/gaia/python/gaia-agent.yaml` | Bump `tools_count` (drift-guarded by `test_gaia_agent.py`) |
+
+## Capability parity
+
+A decommission is only credible if parity is explicit. Two views: the 27 externally
+exposed operations from `hub/agents/email/python/CAPABILITY_MATRIX.md`, and the
+66 internal agent-loop tools.
+
+### The 27 exposed operations
+
+| Op | Surface | Verdict | Note |
+|---|---|---|---|
+| `triage` | REST | **Must survive** | The headline capability |
+| `triage/batch` | REST | **Must survive** | Batch classification |
+| `triage_email` | MCP | **Must survive** | Duplicate of `triage` |
+| `triage_email_batch` | MCP | **Must survive** | Duplicate of `triage/batch` |
+| `prescan` | REST | **Must survive** | Cheap scan; feeds triage without per-message classification |
+| `search` | REST | **Must survive** | Gmail query operators |
+| `archive` | REST | **Must survive** | Core reversible action |
+| `unarchive` | REST | **Must survive** | Undo — safety-critical, not optional |
+| `attention` | REST | **Must survive** | "What needs you"; real dedup machinery (`attention_cache.py`) |
+| `briefing` | REST | **Must survive** (Phase 3) | Needs the scheduler |
+| `draft` | REST | **Must survive** | Judged by the `drafting` eval |
+| `draft_reply` | MCP | **Must survive** | Duplicate of `draft` |
+| `send` | REST | **Must survive** | Highest-stakes op; hard confirmation gate |
+| `send_email` | MCP | **Must survive** | Duplicate of `send` |
+| `confirm` | REST | **Must survive, reshaped** | Exists because a sidecar cannot prompt. On the flagship it becomes `console.confirm_tool_execution`, not an endpoint |
+| `calendar/events (GET)` | REST | Defer | Calendar is a separate capability; own scopes |
+| `calendar/events (POST)` | REST | Defer | |
+| `calendar/events/preview` | REST | Defer | |
+| `calendar/events/respond` | REST | Defer | RSVP |
+| `quarantine` | REST | Defer | Phishing SLM; carries the `specific-ai-tools` dependency |
+| `unquarantine` | REST | Defer | Pairs with `quarantine` |
+| `query` | REST | Drop | This *is* the agent loop — on the flagship the user just talks to the agent |
+| `query/{run_id}/cancel` | REST | Drop | TUI already cancels runs |
+| `query/{run_id}/respond` | REST | Drop | TUI already handles `needs_input` |
+| `/v1/connections` | REST | Drop | Covered by the connectors framework |
+| `/v1/connections/{provider} (POST)` | REST | Drop | Covered by `gaia connectors` |
+| `/v1/connections/{provider} (DELETE)` | REST | Drop | Covered by `gaia connectors` |
+
+**Headline: 15 must survive, 6 defer, 6 drop.** The 15 collapse to **11 distinct
+capabilities** once the four MCP tools fold into their REST twins.
+
+### The 66 internal tools → ~19
+
+Do not port 66 tools. The flagship already registers 67; adding 66 more would give
+it 133 and wreck `ToolLoader`'s per-turn selection — which is the same problem
+[#2835](https://github.com/amd/gaia/issues/2835) and
+[#2836](https://github.com/amd/gaia/issues/2836) are already solving *inside* the
+email agent. Parity is at the operation level, not the tool level.
+
+| Group | Email agent | Flagship mixin | How |
+|---|---|---|---|
+| Read | 9 (`read_tools`) | 5 | `list_inbox`, `search_messages`, `get_message`, `get_thread`, `list_labels` |
+| Triage | 3 | 3 | `triage_inbox`, `pre_scan_inbox`, `list_waiting_on_you` |
+| Organize | 15 (`organize_tools`) | 2 | Collapse the 7 single + 7 batch variants into one `organize_messages(ids, action)`; add `undo_last_action` |
+| Write | 5 (`reply_tools`) + 4 (`delete_tools`) | 3 | `draft_reply`, `send_draft`, `trash_message` |
+| Briefing / tasks | 3 | 3 | `get_briefing`, `extract_action_items`, `list_tasks` |
+| Preferences | 8 | 2 | `set_sender_priority`, `get_preferences` |
+| Connection | 3 | 1 | `check_mailbox_access` |
+| Calendar | 6 | 0 | Deferred |
+| Phishing | 2 | 0 | Deferred |
+| Voice / profile / misc | 5 | 0 | Deferred |
+| **Total** | **66** | **~19** | |
+
+### The hard parts
+
+These are not prompt-shaped and a `SKILL.md` cannot replicate them. Each needs real
+code in the mixin:
+
+- **Classification pipeline** — two-tier heuristic → LLM escalation
+  (`triage_heuristics.py`, `llm_triage.py`, `triage_condense.py`), 5-category
+  taxonomy tied to Gmail label semantics. Must move as code.
+- **Batch safety gate** — `ORGANIZE_BATCH_OP_THRESHOLD = 5` /
+  `ORGANIZE_BATCH_SENDER_THRESHOLD = 3` (`agent.py:782-783`): more than 5 organize
+  mutations across more than 3 distinct senders in one turn forces confirmation.
+  Must move verbatim.
+- **Undo ledger** — `action_store.py` persists `email_actions` / `email_drafts` to
+  `~/.gaia/email/state.db` with a 120s default window, and enforces the ordering
+  invariant that the API call succeeds *before* the row is recorded (a phantom undo
+  row is state corruption). This is the `database:write` dependency that blocks
+  #2672; as agent code it is unblocked.
+- **Context budgeting** — `context_budget.py`, `thread_fold.py`,
+  `body_normalize.py`. Partly generic, but the flagship's prompt is larger, so the
+  budget needs recalculating, not copying.
+- **Attention dedup** — `attention_cache.py` dedupes signals across four sources.
+- **Briefing scheduling** — `scheduler.py` / `schedule_store.py` are daemon-managed.
+  This is why briefing is Phase 3, not Phase 0.
+
+## Permission and connector model
+
+### Reads: one consent, then silent
+
+The mixin declares `REQUIRED_CONNECTORS` on the flagship agent class, mirroring the
+email agent's existing declaration (`gaia_agent_email/agent.py:748-760`). The user
+consents once when connecting the account; reads then run without prompting —
+the same shape as `gh issue list` running silently under `shell:execute:gh`.
+
+Scopes stay exactly as the email agent requests them, including the deliberate
+exclusion of `https://mail.google.com/` (full-mailbox permanent delete,
+[#2533](https://github.com/amd/gaia/issues/2533)). **Do not widen scopes during the
+move.** `build_tui.yml` already path-triggers on `scopes.py` as a drift guard; that
+guard must follow the file to its new home.
+
+### Writes: confirmation, and a higher bar than `gh`
+
+`gh issue comment` is public and retractable. Sending mail is private and
+irreversible. The gate must be stricter, not equivalent.
+
+The mechanism already exists and is wired: `TOOLS_REQUIRING_CONFIRMATION`
+(`agent.py:198`) is unioned at runtime with the agent's own
+`CONFIRMATION_REQUIRED_TOOLS` ClassVar (`agent.py:3184-3193`), and a listed tool
+causes `_execute_tool` to call `console.confirm_tool_execution` and block
+(`agent.py:3436`).
+
+| Action | Gate |
+|---|---|
+| `send_draft`, `send_now`, `forward_message`, `schedule_send` | **Always confirm**, showing literal to / subject / body preview |
+| `trash_message` | **Always confirm** — reversible only while the message stays in Trash |
+| `organize_messages` (archive, label, mark-read, star) | Silent below the batch threshold; **confirm** above 5 ops across more than 3 senders |
+| `undo_last_action` | Silent — it only ever reduces effect |
+| All reads | Silent after connector consent |
+
+**Do not route this through `src/gaia/governance/`.** The layer exists and is
+well-designed, but it has zero consumers: `@govern` appears only inside its own
+docstring, and `GovernedAgentMixin` is mixed into no agent in the repo. Wiring
+email writes into an unexercised path would be the first real user of a layer with
+no production evidence. Use the confirmation mechanism that already ships. If
+governance is later adopted, email writes are the obvious first
+`@govern(risk="review")` case — as a follow-up, not a prerequisite.
+
+## Acceptance bar
+
+**Blocker first:** [#2983](https://github.com/amd/gaia/issues/2983) — the flagship
+has no scorecard and no release eval gate. Committed baselines exist only for
+`rag_quality`, `tool_selection`, and `context_retention`
+(`tests/fixtures/eval_baselines/gemma-4-e4b-d71cd914/`). An email category for the
+flagship has to exist before "no regression" means anything.
+
+To justify decommissioning, the flagship plus skill must:
+
+| Suite | Bar |
+|---|---|
+| `quality` | **Meet or beat** the email agent's committed baseline on the acceptance-enforced within-one-bucket categorization metric. This is the release gate today; it stays the gate. |
+| `drafting` | **Meet or beat** `approval_min` 0.70 |
+| `briefing` | Run and report. Enforcement is off in the fixture; do not silently tighten or loosen it |
+| `action_items` | Run and report |
+| `perf` | Fresh Strix Halo baseline required. The flagship's prompt is larger, so a TTFT regression is *expected* — it must be quantified and accepted explicitly, not waved through |
+| `followups` | Out of scope — CI-unwired, tracked by [#2040](https://github.com/amd/gaia/issues/2040) |
+
+**The sleeper risk, and the one nobody would think to test:** adding ~19 tools to a
+67-tool agent can degrade selection for *non-email* work. Every phase must re-run
+`gaia eval agent --category tool_selection` against the flagship's existing
+committed baseline. A win on email that costs document Q&A is not a win.
+
+Evals run **serially** — never two `gaia eval agent` processes at once. Confirm
+`ps aux | grep "gaia eval" | grep -v grep | wc -l` prints `0` before starting.
+
+## Phased plan
+
+**Phase 0 — read-only Gmail triage from the TUI.** One PR. `EmailToolsMixin` with
+5 read tools plus `triage_inbox`, registered in `KNOWN_TOOLS`; `inbox-triage`
+skill; Google connector requirement with read scopes only. No writes, no state DB,
+no Outlook, no calendar. Acceptance: `triage my inbox` works end-to-end in
+`gaia tui` against a real Gmail account, and `tool_selection` does not regress
+against the committed baseline.
+
+**Phase 1** — organize + undo. Brings the action ledger and the batch threshold.
+
+**Phase 2** — draft, send, trash, behind confirmation.
+
+**Phase 3** — briefing, tasks, scheduling. Needs daemon-managed jobs.
+
+**Phase 4** — Outlook / Microsoft Graph.
+
+**Phase 5** — deprecate. Not before Phases 0–4 have shipped and the eval bar is met.
+
+## Decommission blast radius
+
+**This is a multi-release effort, and the removal is larger than the build.**
+
+| Surface | Scale |
+|---|---|
+| Tests | **174 files** — 130 in-package, 44 repo-wide |
+| CI workflows | **11** referencing email; **7** email-only (`release_agent_email.yml`, `test_email_agent{,_unit,_eval}.yml`, `test_agent_email_npm.yml`, `email_scorecard_refresh.yml`, `build_cpp_email.yml`) |
+| Package docs | ~332 KB across README / SPEC / SKILL / CHANGELOG / CAPABILITY_MATRIX / CONTRACT / `openapi.email.json` / `specification.html` — all must move together per CLAUDE.md |
+| npm | `@amd-gaia/agent-email` **published at 0.6.0** — needs `npm deprecate`, not deletion |
+| PyPI | `gaia-agent-email` in `setup.py:30` `AGENT_WHEEL_PACKAGES` |
+| Daemon | **9 modules** in `src/gaia/daemon/sidecars/` with email-specific paths, ports, and scope literals |
+| UI proxy | `src/gaia/ui/email_sidecar/` — 6 files, entirely an email proxy |
+| Eval framework | **5 modules** import `gaia_agent_email` directly (`benchmark.py`, `draft_quality.py`, `briefing_quality.py`, `followup_quality.py`, `action_item_quality.py`) |
+| CLI | `gaia email` + `gaia email autonomy` (`cli.py:1424-1489`, handlers at `4542-4825`) |
+| Go TUI | Catalog seed entry with `Transport: TransportDaemon` + tests |
+| Docs site | `docs/docs.json` lines 102-103, 398-399, 410; `guides/email.mdx`, `guides/email-integration.mdx`, 3 plan docs |
+
+**The cost nobody has priced:** the email agent is the *only* proven sidecar. It is
+the reference implementation for the entire daemon-supervised sidecar
+architecture — frozen binaries on four platforms, SSE translation, caller auth,
+forwarded credentials. Deleting it deletes that reference. A defensible middle
+path is to move the *capability* to the flagship and keep the package as an
+architectural reference, unlisted on the hub. That would also resolve the conflict
+with #2982's non-goal without abandoning either position.
+
+## Non-goals
+
+- Not delivering the Phase 2 sandbox (#2863). This proposal routes around it.
+- Not skills-v2 adaptive learning (#2683).
+- Not the C++ runtime (#1543, #2799).
+- Not calendar, phishing SLM, or voice-profile capability in Phases 0–4.
+- Not deleting the sidecar architecture — only this consumer of it.
+- Not widening OAuth scopes. The `https://mail.google.com/` exclusion is permanent.
+
+## Open questions for the owner
+
+1. **#2982 conflict.** It names the email agent a permanent non-goal. Does this
+   proposal supersede that, or does the package survive as an unlisted reference?
+2. **Move or duplicate?** #2672 asks the same question and never settled it.
+   Duplicating creates two implementations to drift; moving is a breaking change
+   for anyone importing `gaia_agent_email`. Recommendation: **move**, with the
+   package retained at a frozen version until Phase 5.
+3. **Does #2672 get closed, narrowed, or left alone** once this lands? Its
+   portability goal survives independently, but its email framing would be stale.
+4. **Eval decoupling.** Five eval modules import the email package directly. Do
+   they retarget to the flagship in Phase 0, or keep dual baselines through Phase 4?
+5. **npm consumers.** Is `@amd-gaia/agent-email` known to have external users? That
+   decides deprecation-window length.

--- a/hub/agents/chat/python/gaia_agent_chat/tool_bundles.py
+++ b/hub/agents/chat/python/gaia_agent_chat/tool_bundles.py
@@ -395,6 +395,19 @@ FULL_BUNDLES = [
         members=frozenset({"set_loop_state", "request_user_input"}),
         description="Control the autonomous loop and ask the user questions.",
     ),
+    ToolBundle(
+        name="email",
+        members=frozenset(
+            {
+                "check_mailbox_access",
+                "list_inbox",
+                "search_email",
+                "read_email",
+                "list_mail_folders",
+            }
+        ),
+        description="Read a connected mailbox: list, search, and read messages.",
+    ),
 ]
 
 # Bundle members a healthy ``full`` registry may legitimately lack. Handed to
@@ -434,6 +447,11 @@ FULL_OPTIONAL_TOOLS = frozenset(
         "search_skill_hub",
         "install_skill",
         "remove_skill",
+        "check_mailbox_access",
+        "list_inbox",
+        "search_email",
+        "read_email",
+        "list_mail_folders",
     }
 )
 

--- a/hub/agents/gaia/python/gaia-agent.yaml
+++ b/hub/agents/gaia/python/gaia-agent.yaml
@@ -17,10 +17,11 @@ icon: sparkles
 # the agent and compares — a hand-edit that disagrees with the registry fails CI.
 # 55 from ChatAgent's "full" profile + 7 skill-library tools
 # (gaia_agent.skill_tools.SKILL_LIBRARY_TOOL_NAMES) + 4 code-index tools
+# + 5 read-only email tools (gaia.agents.tools.email_tools)
 # + the load_tools escape hatch, which registers because dynamic_tools is on.
 # This is the REGISTERED size — what the agent can do. Dynamic tool loading
 # means a single turn only shows the model a subset of it.
-tools_count: 67
+tools_count: 72
 
 language: python
 min_gaia_version: "0.23.0"

--- a/hub/agents/gaia/python/gaia_agent/__init__.py
+++ b/hub/agents/gaia/python/gaia_agent/__init__.py
@@ -74,7 +74,7 @@ def build_gaia():
         icon="sparkles",
         # Must equal the real registry size for the default construction, and
         # the manifest's own tools_count. Drift-guarded by tests/test_gaia_agent.py.
-        tools_count=67,
+        tools_count=72,
         # ChatAgent loads MCP servers dynamically, so the Settings "Active for"
         # panel must list this agent for MCP-server connectors.
         consumes_mcp_servers=True,

--- a/hub/agents/gaia/python/gaia_agent/agent.py
+++ b/hub/agents/gaia/python/gaia_agent/agent.py
@@ -60,7 +60,9 @@ from gaia.agents.base.skill_loader import (
     dynamic_skills_env_override,
 )
 from gaia.agents.tools.code_index_tools import CodeIndexToolsMixin
+from gaia.agents.tools.email_tools import MAIL_SCOPES, EmailToolsMixin
 from gaia.agents.tools.skill_library_tools import SkillLibraryToolsMixin
+from gaia.connectors.providers.base import ConnectorRequirement
 from gaia.logger import get_logger
 
 logger = get_logger(__name__)
@@ -208,11 +210,23 @@ class GaiaAgentConfig(ChatAgentConfig):
 # Base agent first, tool mixins after — the repo's MRO convention for every
 # hub agent. Neither mixin overrides anything today; this order keeps a future
 # mixin method from silently winning over ChatAgent's.
-class GaiaAgent(ChatAgent, SkillLibraryToolsMixin, CodeIndexToolsMixin):
+class GaiaAgent(
+    ChatAgent, SkillLibraryToolsMixin, CodeIndexToolsMixin, EmailToolsMixin
+):
     """The flagship GAIA agent — conversation, documents, data, web, and skills."""
 
     SKILL_DIRS: ClassVar[List[str]] = _bundled_skill_roots()
     SKILL_MANIFEST: ClassVar[Optional[str]] = _locate_agent_manifest()
+
+    # Declared, not acquired: the user consents once via `gaia connectors`, and
+    # nothing here reaches a mailbox until an email tool is actually called.
+    REQUIRED_CONNECTORS: ClassVar[List[ConnectorRequirement]] = [
+        ConnectorRequirement(
+            connector_id="microsoft",
+            scopes=list(MAIL_SCOPES),
+            reason="Read and search your Outlook mail so the agent can triage your inbox.",
+        ),
+    ]
 
     # Installing a skill writes third-party code under ~/.gaia/skills and
     # removing one deletes it, so both are gated the way file mutation is.
@@ -246,8 +260,8 @@ class GaiaAgent(ChatAgent, SkillLibraryToolsMixin, CodeIndexToolsMixin):
 
         Skill-library tools go first: ChatAgent's registration ends with
         ``_snapshot_tools()``, and anything registered after that snapshot is
-        absent from this instance's registry. Code-index tools join them for the
-        same reason.
+        absent from this instance's registry. Code-index and email tools join
+        them for the same reason.
 
         Semantic code search is what makes this agent usable ON a codebase
         rather than merely in one: grep finds a string, this finds the function
@@ -271,6 +285,7 @@ class GaiaAgent(ChatAgent, SkillLibraryToolsMixin, CodeIndexToolsMixin):
         allowed = getattr(self.config, "allowed_paths", None) or [str(Path.home())]
         self._init_code_index_state(repo_path=allowed[0])
         self.register_code_index_tools()
+        self.register_email_tools()
         super()._register_tools()
 
     # ── lazy skill-body loader (#2848 follow-up) ────────────────────────────

--- a/hub/skills/inbox-triage/SKILL.md
+++ b/hub/skills/inbox-triage/SKILL.md
@@ -71,6 +71,20 @@ Never claim to have taken an action you cannot take.
 6. **Say when there is nothing.** An empty urgent list is a real and useful
    answer. Say "nothing needs you right now" and stop.
 
+## Follow-ups
+
+The triage pass ends at step 6. The remaining two tools are for what the user
+asks next — do not reach for them during the pass itself.
+
+`search_email` answers "anything else from Dana?" or "where is that invoice?"
+It searches the whole mailbox, not just the inbox, so it finds messages that
+were already filed and never appeared in your triage.
+
+`list_mail_folders` explains a surprisingly empty inbox. If `list_inbox`
+returned little and the user expected more, folder unread counts show where the
+mail is actually landing. Report the counts and stop — do not start reading
+other folders unless the user asks.
+
 ## Judgement
 
 **Sender beats subject.** A message from a person the user actually works with

--- a/hub/skills/inbox-triage/SKILL.md
+++ b/hub/skills/inbox-triage/SKILL.md
@@ -1,0 +1,101 @@
+---
+name: inbox-triage
+description: Triage a mailbox — group what arrived, judge what actually needs the user, and say what to do about it. Use when asked to triage or check email, go through the inbox, summarise what came in, find what needs a reply, or work out which messages matter today.
+license: MIT
+version: 0.1.0
+metadata:
+  gaia:
+    security_tier: community
+    tools_required:
+      - check_mailbox_access
+      - list_inbox
+      - search_email
+      - read_email
+      - list_mail_folders
+    provenance:
+      source: starter-pack
+---
+
+# Inbox triage
+
+Turn a pile of mail into a short list of things that need the user, and a
+one-line reason for each. The judging is yours — the tools return facts, not
+verdicts.
+
+## Read-only
+
+Every tool here reads. Nothing archives, replies, deletes, or marks read. If the
+user asks you to act on a message, say plainly that triage is read-only right
+now and tell them what you would have done, so they can do it themselves.
+
+Never claim to have taken an action you cannot take.
+
+## Procedure
+
+1. **Check access only if you need to.** If a mail tool fails, call
+   `check_mailbox_access` and relay what it says. Do not open with it on a
+   normal request — it costs a round trip and tells the user nothing new.
+
+2. **List before reading.** `list_inbox` returns sender, subject, preview,
+   received time, unread and flagged state for many messages in one call.
+   `read_email` fetches one body. Start with the list; that is usually enough
+   to sort most messages.
+
+3. **Read only what you cannot judge from the preview.** A newsletter is
+   obvious from its subject. A short note from a colleague asking a question
+   may not be. Budget your reads: a handful, not the whole list.
+
+4. **Sort into these five categories.** Every message gets exactly one:
+
+   | Category | Means |
+   |---|---|
+   | `URGENT` | Time-critical and needs the user specifically. A deadline today, an outage, a blocked colleague. |
+   | `NEEDS_RESPONSE` | A real person is waiting on a reply, but it is not on fire. |
+   | `PERSONAL` | From a human, to this user, no action implied. |
+   | `FYI` | Automated but genuine — build results, receipts, calendar notices, alerts the user opted into. |
+   | `PROMOTIONAL` | Marketing, newsletters, cold outreach. Bulk mail nobody is waiting on. |
+
+   When torn between `URGENT` and `NEEDS_RESPONSE`, ask whether something bad
+   happens if it waits until tomorrow. If nothing does, it is
+   `NEEDS_RESPONSE`.
+
+   When torn between `FYI` and `PROMOTIONAL`, ask whether the user asked to
+   receive it. A CI failure is `FYI`. A conference invitation is
+   `PROMOTIONAL`.
+
+5. **Lead with what needs them.** Report `URGENT` and `NEEDS_RESPONSE` first,
+   as a short list, each with the sender and a one-line reason. Then give
+   `FYI` and `PROMOTIONAL` as counts, not lists — "11 promotional, 4 FYI" is
+   what the user wants, not eleven subject lines.
+
+6. **Say when there is nothing.** An empty urgent list is a real and useful
+   answer. Say "nothing needs you right now" and stop.
+
+## Judgement
+
+**Sender beats subject.** A message from a person the user actually works with
+outranks a subject line that shouts. Marketing mail is engineered to look
+urgent; a colleague writing "quick question" is often the thing that matters.
+
+**A question mark aimed at the user is the strongest signal** that something is
+`NEEDS_RESPONSE`. Check whether they are on the `to` line or merely `cc` — a cc
+usually means they are being kept informed, not asked.
+
+**Old unread mail is not automatically urgent.** If it has sat for two weeks and
+nothing broke, it is not urgent now. Say it is old instead.
+
+**Do not invent deadlines.** Only call something time-critical if a date or a
+stated deadline is actually in the message. If you are inferring urgency from
+tone, say so — "reads as urgent, but no date given".
+
+## Reporting
+
+Keep the whole answer short enough to read at a glance. A triage that takes as
+long to read as the inbox has failed.
+
+Give counts, not inventories, for anything that does not need the user. Group
+several messages from the same sender into one line. Do not include message ids
+unless the user asks — they are for your tool calls, not for them.
+
+If a tool returned an error, say what failed and what the user should do. Never
+present a partial inbox as if it were the whole one.

--- a/setup.py
+++ b/setup.py
@@ -73,6 +73,7 @@ setup(
         "gaia.agents",
         "gaia.agents.base",
         "gaia.agents.tools",
+        "gaia.agents.tools._email",
         "gaia.agents.builder",
         "gaia.agents.code_index",
         "gaia.agents.code_index.tools",

--- a/src/gaia/agents/registry.py
+++ b/src/gaia/agents/registry.py
@@ -47,6 +47,7 @@ KNOWN_TOOLS: Dict[str, tuple] = {
     "filesystem": ("gaia.agents.tools.filesystem_tools", "FileSystemToolsMixin"),
     "scratchpad": ("gaia.agents.tools.scratchpad_tools", "ScratchpadToolsMixin"),
     "browser": ("gaia.agents.tools.browser_tools", "BrowserToolsMixin"),
+    "email": ("gaia.agents.tools.email_tools", "EmailToolsMixin"),
     "sd": ("gaia.sd.mixin", "SDToolsMixin"),
     "vlm": ("gaia.vlm.mixin", "VLMToolsMixin"),
     "skills": ("gaia.agents.tools.skill_library_tools", "SkillLibraryToolsMixin"),

--- a/src/gaia/agents/tools/_email/__init__.py
+++ b/src/gaia/agents/tools/_email/__init__.py
@@ -1,0 +1,23 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""Mailbox backends for :mod:`gaia.agents.tools.email_tools`.
+
+Read-only for now. Write verbs (organize, draft, send) land with the action
+ledger in a later phase — see ``docs/plans/email-triage-skill.mdx``.
+"""
+
+from gaia.agents.tools._email.graph import (
+    GRAPH_API_BASE,
+    MailboxAuthError,
+    MailboxError,
+    OutlookReadBackend,
+    message_summary,
+)
+
+__all__ = [
+    "GRAPH_API_BASE",
+    "MailboxAuthError",
+    "MailboxError",
+    "OutlookReadBackend",
+    "message_summary",
+]

--- a/src/gaia/agents/tools/_email/graph.py
+++ b/src/gaia/agents/tools/_email/graph.py
@@ -1,0 +1,248 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""Read-only Microsoft Graph mailbox client for the flagship agent's email tools.
+
+Scope is deliberately narrow: list, search, read, and folder enumeration. There
+is no mutating verb here, so there is no action ledger to keep consistent and
+nothing to undo. Writes arrive in a later phase together with the ledger that
+makes them reversible.
+
+This is a lean reimplementation of the read half of
+``gaia_agent_email.outlook_backend``, not an import of it: the flagship must not
+depend on the standalone email package it is meant to replace. The wire
+contract (Graph ``message`` resource) is the shared truth, not the Python.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Callable, Dict, Iterable, List, Optional
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+GRAPH_API_BASE = "https://graph.microsoft.com/v1.0"
+
+# Every field the read tools and the triage signals need, and nothing heavier.
+# ``body`` is excluded — it is the one large field, and only ``read_email``
+# fetches it. ``bodyPreview`` is Graph's snippet equivalent and is enough for
+# scanning.
+_LIST_SELECT = (
+    "id,conversationId,subject,from,toRecipients,ccRecipients,"
+    "receivedDateTime,isRead,isDraft,flag,categories,bodyPreview"
+)
+_FULL_SELECT = _LIST_SELECT + ",body"
+
+# Graph caps $top at 999; asking for more is a 400, not a truncation.
+_MAX_TOP = 999
+
+
+class MailboxError(RuntimeError):
+    """A mailbox request failed in a way the caller should surface verbatim."""
+
+
+class MailboxAuthError(MailboxError):
+    """The mailbox rejected our credentials or refused the requested scope."""
+
+
+def _address(entity: Optional[Dict[str, Any]]) -> str:
+    """Render a Graph recipient as ``Name <addr>``, or the bare address."""
+    if not entity:
+        return ""
+    email = entity.get("emailAddress") or {}
+    name = (email.get("name") or "").strip()
+    addr = (email.get("address") or "").strip()
+    if name and addr and name.lower() != addr.lower():
+        return f"{name} <{addr}>"
+    return addr or name
+
+
+def _address_list(entities: Optional[Iterable[Dict[str, Any]]]) -> str:
+    return ", ".join(p for p in (_address(e) for e in (entities or [])) if p)
+
+
+def message_summary(
+    msg: Dict[str, Any], *, include_body: bool = False
+) -> Dict[str, Any]:
+    """Flatten a Graph ``message`` into the shape the agent's tools return.
+
+    Provider-neutral on purpose: a Gmail backend added later emits this same
+    shape, so the tools and the skill never learn which mailbox they are on.
+    """
+    flag = (msg.get("flag") or {}).get("flagStatus")
+    summary: Dict[str, Any] = {
+        "id": msg.get("id"),
+        "thread_id": msg.get("conversationId") or msg.get("id"),
+        "subject": msg.get("subject") or "(no subject)",
+        "from": _address(msg.get("from")),
+        "to": _address_list(msg.get("toRecipients")),
+        "cc": _address_list(msg.get("ccRecipients")),
+        "received": msg.get("receivedDateTime") or "",
+        "unread": not msg.get("isRead", True),
+        "flagged": flag in ("flagged", "complete"),
+        "categories": list(msg.get("categories") or []),
+        "preview": (msg.get("bodyPreview") or "").strip(),
+    }
+    if include_body:
+        body = msg.get("body") or {}
+        summary["body"] = body.get("content") or ""
+        summary["body_content_type"] = (body.get("contentType") or "text").lower()
+    return summary
+
+
+class OutlookReadBackend:
+    """Read-only Microsoft Graph client for one connected Outlook mailbox."""
+
+    def __init__(
+        self,
+        access_token_fn: Callable[[], str],
+        *,
+        http_client: Optional[httpx.Client] = None,
+        timeout_seconds: float = 15.0,
+    ) -> None:
+        self._access_token_fn = access_token_fn
+        # Tests inject an httpx.MockTransport-backed client so no test ever
+        # needs the network or a real token.
+        self._client = http_client or httpx.Client(timeout=timeout_seconds)
+
+    # -- HTTP ---------------------------------------------------------------
+
+    def _headers(self) -> Dict[str, str]:
+        # Re-minted per request. A cached token would let a mid-scan revoke
+        # look like success on the pages already fetched.
+        return {"Authorization": f"Bearer {self._access_token_fn()}"}
+
+    def _raise(self, response: httpx.Response, where: str) -> None:
+        # Built from status + truncated body only. Never from a wrapper
+        # exception, which can carry the Authorization header into a log.
+        detail = response.text[:300]
+        if response.status_code == 401:
+            raise MailboxAuthError(
+                "Microsoft Graph rejected the access token (401). The Outlook "
+                "connection has expired or been revoked. Reconnect it with "
+                "`gaia connectors` (or Settings → Connectors in the Agent UI), "
+                f"then retry. (request: {where})"
+            )
+        if response.status_code == 403:
+            raise MailboxAuthError(
+                "Microsoft Graph refused the request (403 — insufficient "
+                "permissions). The connected account has not granted "
+                "Mail.ReadWrite to this agent. Reconnect Microsoft with "
+                "`gaia connectors` and approve mail access. "
+                f"(request: {where}; detail: {detail})"
+            )
+        if response.status_code == 429:
+            retry_after = response.headers.get("Retry-After", "unknown")
+            raise MailboxError(
+                "Microsoft Graph is rate-limiting this mailbox (429). Retry "
+                f"after {retry_after}s. Reduce `limit` if this repeats. "
+                f"(request: {where})"
+            )
+        raise MailboxError(
+            f"Microsoft Graph request failed: {where} returned "
+            f"{response.status_code}. Detail: {detail}"
+        )
+
+    def _get(self, path: str, *, params: Optional[dict] = None) -> Any:
+        try:
+            resp = self._client.get(
+                f"{GRAPH_API_BASE}{path}", headers=self._headers(), params=params
+            )
+        except httpx.HTTPError as exc:
+            raise MailboxError(
+                f"Could not reach Microsoft Graph for {path}: {exc}. Check "
+                "network connectivity, then retry."
+            ) from exc
+        if resp.status_code != 200:
+            self._raise(resp, f"GET {path}")
+        return resp.json()
+
+    # -- Reads --------------------------------------------------------------
+
+    def get_user_email(self) -> str:
+        """The connected mailbox's address."""
+        data = self._get("/me", params={"$select": "mail,userPrincipalName"})
+        # Personal accounts frequently have a null `mail` and carry the address
+        # on userPrincipalName instead.
+        address = data.get("mail") or data.get("userPrincipalName") or ""
+        if not address:
+            raise MailboxError(
+                "Microsoft Graph returned no address for the connected account "
+                "(both `mail` and `userPrincipalName` were empty). The "
+                "connection is in an unusable state — reconnect Microsoft with "
+                "`gaia connectors`."
+            )
+        return address
+
+    def _clamp(self, limit: int) -> int:
+        if limit < 1:
+            raise ValueError(f"limit must be >= 1, got {limit}")
+        return min(limit, _MAX_TOP)
+
+    def list_inbox(
+        self, *, limit: int = 25, unread_only: bool = False
+    ) -> List[Dict[str, Any]]:
+        """Newest-first inbox messages, with metadata but no bodies."""
+        params: Dict[str, Any] = {
+            "$top": self._clamp(limit),
+            "$select": _LIST_SELECT,
+            "$orderby": "receivedDateTime desc",
+        }
+        if unread_only:
+            params["$filter"] = "isRead eq false"
+        data = self._get("/me/mailFolders/inbox/messages", params=params)
+        return [message_summary(m) for m in data.get("value", [])]
+
+    def search(self, query: str, *, limit: int = 25) -> List[Dict[str, Any]]:
+        """Full-mailbox keyword search.
+
+        Uses Graph's ``$search`` (KQL). Graph forbids combining ``$search``
+        with ``$orderby``, so results come back in relevance order, not date
+        order — the tool docstring says so, because a caller that assumes
+        newest-first would silently misreport.
+        """
+        if not query or not query.strip():
+            raise ValueError("query must be a non-empty search string")
+        params = {
+            "$top": self._clamp(limit),
+            "$select": _LIST_SELECT,
+            "$search": f'"{query}"',
+        }
+        data = self._get("/me/messages", params=params)
+        return [message_summary(m) for m in data.get("value", [])]
+
+    def get_message(self, message_id: str) -> Dict[str, Any]:
+        """One message, body included."""
+        if not message_id or not message_id.strip():
+            raise ValueError("message_id must be a non-empty message id")
+        data = self._get(f"/me/messages/{message_id}", params={"$select": _FULL_SELECT})
+        return message_summary(data, include_body=True)
+
+    def list_folders(self, *, limit: int = 50) -> List[Dict[str, Any]]:
+        """Mail folders with their unread and total counts."""
+        data = self._get(
+            "/me/mailFolders",
+            params={
+                "$top": self._clamp(limit),
+                "$select": "id,displayName,unreadItemCount,totalItemCount",
+            },
+        )
+        return [
+            {
+                "id": f.get("id"),
+                "name": f.get("displayName") or "",
+                "unread": f.get("unreadItemCount", 0),
+                "total": f.get("totalItemCount", 0),
+            }
+            for f in data.get("value", [])
+        ]
+
+
+__all__ = [
+    "GRAPH_API_BASE",
+    "MailboxAuthError",
+    "MailboxError",
+    "OutlookReadBackend",
+    "message_summary",
+]

--- a/src/gaia/agents/tools/email_tools.py
+++ b/src/gaia/agents/tools/email_tools.py
@@ -1,0 +1,231 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+# pylint: disable=protected-access
+
+"""
+Email Tools — read-only mailbox access for the flagship agent.
+
+Gives an agent the ability to list, search, and read mail from a connected
+mailbox so a skill (``hub/skills/inbox-triage``) can do the judging. The tools
+deliberately return facts, not verdicts: categorisation is the model's job,
+driven by the skill, which is the whole point of moving email onto the flagship
+rather than shipping a second agent with its own classifier.
+
+Read-only by design. Nothing here archives, sends, or deletes; write verbs
+arrive with the reversible-action ledger in a later phase. See
+``docs/plans/email-triage-skill.mdx``.
+
+Provider support: Outlook / Microsoft Graph. Gmail lands in a later phase behind
+the same tool names — the tools return a provider-neutral shape so neither the
+skill nor the model has to care which mailbox is connected.
+"""
+
+import json
+import logging
+from typing import Any, Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+
+# The agent identity the grant ledger records these tools under. Namespaced per
+# gaia.connectors.grants: the flagship ships as a wheel-installed hub agent.
+EMAIL_AGENT_ID = "installed:gaia"
+
+MICROSOFT_CONNECTOR_ID = "microsoft"
+
+# Phase 0 is read-only but requests Mail.ReadWrite rather than Mail.Read.
+#
+# check_agent_grant does exact string-subset matching with no scope-implication
+# logic, so a user who already granted Mail.ReadWrite would be forced to
+# re-consent for a strictly narrower scope. Requesting the broader scope reuses
+# the existing grant. The trade is that the agent holds write scope during a
+# phase that performs no writes; it narrows when the write tools land and the
+# scope set becomes meaningful. Tracked in the plan doc, not silently accepted.
+MAIL_SCOPES: tuple = ("https://graph.microsoft.com/Mail.ReadWrite",)
+
+_MAX_LIMIT = 100
+
+
+class EmailToolsMixin:
+    """Read-only mailbox tools (Outlook / Microsoft Graph).
+
+    Tool registration follows the GAIA pattern: ``register_email_tools()``.
+
+    The mixin builds its backend lazily on first use, so composing it costs an
+    agent nothing until a mail tool is actually called — an agent whose user
+    never mentions email never touches the connectors layer.
+    """
+
+    _email_backend = None  # OutlookReadBackend, built lazily
+
+    def _build_email_backend(self):
+        """Construct the mailbox backend, or fail with an actionable error."""
+        from gaia.agents.tools._email import MailboxError, OutlookReadBackend
+
+        try:
+            from gaia.connectors.api import get_access_token_sync
+        except ImportError as exc:  # pragma: no cover - packaging guard
+            raise MailboxError(
+                "The connectors framework is unavailable, so no mailbox can be "
+                "reached. Reinstall GAIA with `uv pip install -e .` and retry."
+            ) from exc
+
+        def _token() -> str:
+            return get_access_token_sync(
+                provider=MICROSOFT_CONNECTOR_ID,
+                scopes=list(MAIL_SCOPES),
+                agent_id=EMAIL_AGENT_ID,
+            )
+
+        return OutlookReadBackend(_token)
+
+    def _email(self):
+        """The mailbox backend for this agent, built on first use."""
+        if self._email_backend is None:
+            self._email_backend = self._build_email_backend()
+        return self._email_backend
+
+    def register_email_tools(self) -> None:
+        """Register read-only email tools."""
+        from gaia.agents.base.tools import tool
+
+        mixin = self
+
+        def _fail(exc: Exception, action: str) -> str:
+            """Render an exception as an actionable tool result.
+
+            Errors are surfaced, never swallowed: the model needs to tell the
+            user what to fix, and a tool that returns an empty list on failure
+            reads as "your inbox is empty".
+            """
+            logger.warning("email tool failed during %s: %s", action, exc)
+            return json.dumps(
+                {"error": str(exc), "action": action, "success": False}, indent=2
+            )
+
+        def _clamp(limit: int) -> int:
+            return max(1, min(int(limit), _MAX_LIMIT))
+
+        @tool(atomic=True)
+        def check_mailbox_access() -> str:
+            """Check whether a mailbox is connected and readable.
+
+            Call this first when the user asks about email and you are unsure a
+            mailbox is set up, or when another email tool has just failed. It
+            reports the connected address and the inbox unread count.
+
+            Returns the mailbox address and folder counts, or an error naming
+            what the user must do to connect one.
+            """
+            try:
+                backend = mixin._email()
+                address = backend.get_user_email()
+                folders = backend.list_folders(limit=50)
+                inbox = next(
+                    (f for f in folders if (f["name"] or "").lower() == "inbox"), None
+                )
+                return json.dumps(
+                    {
+                        "success": True,
+                        "provider": "outlook",
+                        "address": address,
+                        "inbox_unread": inbox["unread"] if inbox else None,
+                        "inbox_total": inbox["total"] if inbox else None,
+                        "folder_count": len(folders),
+                    },
+                    indent=2,
+                )
+            except Exception as exc:  # surfaced, not swallowed
+                return _fail(exc, "check_mailbox_access")
+
+        @tool(atomic=True)
+        def list_inbox(limit: int = 25, unread_only: bool = False) -> str:
+            """List recent email in the inbox, newest first.
+
+            The tool to start any mail question with: triaging the inbox,
+            finding which emails need a reply, seeing what arrived today, what
+            is unread, what is waiting on the user, or what is important.
+
+            Returns metadata and a short preview for each message — sender,
+            subject, received time, unread and flagged state — but not full
+            bodies. Use `read_email` when you need the body of one message.
+
+            Args:
+                limit: How many messages to return (1-100, default 25)
+                unread_only: Only return messages that are still unread
+            """
+            try:
+                messages = mixin._email().list_inbox(
+                    limit=_clamp(limit), unread_only=bool(unread_only)
+                )
+                return json.dumps(
+                    {"success": True, "count": len(messages), "messages": messages},
+                    indent=2,
+                )
+            except Exception as exc:
+                return _fail(exc, "list_inbox")
+
+        @tool(atomic=True)
+        def search_email(query: str, limit: int = 25) -> str:
+            """Find email matching a keyword, from anyone, in any mail folder.
+
+            Use to answer "did I get mail about X", to find a message from a
+            named sender, or to look for a receipt, invoice, or thread the user
+            half-remembers.
+
+            Searches every folder, not just the inbox. Results come back in
+            relevance order, NOT newest-first — do not describe them as "the
+            most recent" unless you check the received timestamps yourself.
+
+            Args:
+                query: Keywords to search for (e.g. 'invoice from Acme')
+                limit: How many messages to return (1-100, default 25)
+            """
+            try:
+                messages = mixin._email().search(query, limit=_clamp(limit))
+                return json.dumps(
+                    {
+                        "success": True,
+                        "count": len(messages),
+                        "order": "relevance",
+                        "messages": messages,
+                    },
+                    indent=2,
+                )
+            except Exception as exc:
+                return _fail(exc, "search_email")
+
+        @tool(atomic=True)
+        def read_email(message_id: str) -> str:
+            """Read one message in full, including its body.
+
+            Use after `list_inbox` or `search_email` has given you a message id.
+            Fetching bodies is the expensive call — read the messages you
+            actually need to judge, not every message in a listing.
+
+            Args:
+                message_id: The message id from a listing or search result
+            """
+            try:
+                message = mixin._email().get_message(message_id)
+                return json.dumps({"success": True, "message": message}, indent=2)
+            except Exception as exc:
+                return _fail(exc, "read_email")
+
+        @tool(atomic=True)
+        def list_mail_folders() -> str:
+            """List mail folders with their unread and total message counts.
+
+            Use to answer "how much mail is in X" or to find a folder's name
+            before searching it.
+            """
+            try:
+                folders = mixin._email().list_folders()
+                return json.dumps(
+                    {"success": True, "count": len(folders), "folders": folders},
+                    indent=2,
+                )
+            except Exception as exc:
+                return _fail(exc, "list_mail_folders")
+
+
+__all__ = ["EmailToolsMixin", "EMAIL_AGENT_ID", "MAIL_SCOPES", "MICROSOFT_CONNECTOR_ID"]

--- a/src/gaia/agents/tools/email_tools.py
+++ b/src/gaia/agents/tools/email_tools.py
@@ -22,7 +22,6 @@ skill nor the model has to care which mailbox is connected.
 
 import json
 import logging
-from typing import Any, Dict, List, Optional
 
 logger = logging.getLogger(__name__)
 

--- a/tests/unit/agents/tools/test_email_tools.py
+++ b/tests/unit/agents/tools/test_email_tools.py
@@ -429,8 +429,19 @@ def test_skill_declares_no_permissions():
 
 def test_email_tools_are_bundled_for_the_loader():
     """An unbundled tool can never be pulled in with its cohort."""
+    # The chat agent is a separate hub package; the core unit-test job does not
+    # install it. "Test Chat Agent" and "Test Gaia Agent" do, and run this there.
+    pytest.importorskip("gaia_agent_chat")
     from gaia_agent_chat.tool_bundles import PROFILE_TOOL_CONFIGS
 
     bundles = PROFILE_TOOL_CONFIGS["full"].bundles
-    email = next(b for b in bundles if b.name == "email")
+    email = next(
+        (b for b in bundles if b.name == "email"),
+        None,
+    )
+    assert email is not None, (
+        "the 'email' bundle is missing from the full profile: add it to "
+        "gaia_agent_chat.tool_bundles.FULL_BUNDLES or the loader can never "
+        "pull the email tools in as a cohort"
+    )
     assert email.members == set(_inbox_triage_skill().gaia.tools_required)

--- a/tests/unit/agents/tools/test_email_tools.py
+++ b/tests/unit/agents/tools/test_email_tools.py
@@ -14,7 +14,6 @@ import httpx
 import pytest
 
 from gaia.agents.tools._email.graph import (
-    GRAPH_API_BASE,
     MailboxAuthError,
     MailboxError,
     OutlookReadBackend,

--- a/tests/unit/agents/tools/test_email_tools.py
+++ b/tests/unit/agents/tools/test_email_tools.py
@@ -1,0 +1,437 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""Read-only email tools for the flagship agent (Phase 0 of the email skill).
+
+The backend tests drive a real ``httpx`` client over a ``MockTransport``, so
+they assert the *shape of the outgoing Graph request* — path, ``$select``,
+``$filter``, ``$top`` — not merely that a stub was called. A hand-rolled fake
+would happily accept a request Graph itself would 400.
+"""
+
+import json
+
+import httpx
+import pytest
+
+from gaia.agents.tools._email.graph import (
+    GRAPH_API_BASE,
+    MailboxAuthError,
+    MailboxError,
+    OutlookReadBackend,
+    message_summary,
+)
+from gaia.agents.tools.email_tools import (
+    EMAIL_AGENT_ID,
+    MAIL_SCOPES,
+    EmailToolsMixin,
+)
+
+# --------------------------------------------------------------------------
+# fixtures
+# --------------------------------------------------------------------------
+
+GRAPH_MESSAGE = {
+    "id": "AAMk-1",
+    "conversationId": "conv-1",
+    "subject": "Q3 numbers",
+    "from": {"emailAddress": {"name": "Dana Ruiz", "address": "dana@example.com"}},
+    "toRecipients": [{"emailAddress": {"name": "Me", "address": "me@example.com"}}],
+    "ccRecipients": [],
+    "receivedDateTime": "2026-09-02T08:15:00Z",
+    "isRead": False,
+    "flag": {"flagStatus": "flagged"},
+    "categories": ["Work"],
+    "bodyPreview": "  Can you confirm the Q3 figures?  ",
+    "body": {"contentType": "html", "content": "<p>Can you confirm?</p>"},
+}
+
+
+def make_backend(handler):
+    """An OutlookReadBackend whose HTTP goes to `handler`, with a fixed token."""
+    client = httpx.Client(transport=httpx.MockTransport(handler))
+    return OutlookReadBackend(lambda: "test-token", http_client=client)
+
+
+def json_response(payload, status=200):
+    return httpx.Response(status, json=payload)
+
+
+# --------------------------------------------------------------------------
+# message_summary — provider-neutral flattening
+# --------------------------------------------------------------------------
+
+
+def test_summary_flattens_graph_shape():
+    out = message_summary(GRAPH_MESSAGE)
+    assert out["id"] == "AAMk-1"
+    assert out["thread_id"] == "conv-1"
+    assert out["from"] == "Dana Ruiz <dana@example.com>"
+    assert out["unread"] is True
+    assert out["flagged"] is True
+    assert out["preview"] == "Can you confirm the Q3 figures?"
+
+
+def test_summary_omits_body_unless_asked():
+    assert "body" not in message_summary(GRAPH_MESSAGE)
+    assert message_summary(GRAPH_MESSAGE, include_body=True)["body"] == (
+        "<p>Can you confirm?</p>"
+    )
+
+
+def test_summary_falls_back_to_message_id_when_no_conversation():
+    out = message_summary({"id": "solo", "subject": "x"})
+    assert out["thread_id"] == "solo"
+
+
+def test_summary_bare_address_when_name_missing():
+    msg = {"id": "1", "from": {"emailAddress": {"address": "a@b.com"}}}
+    assert message_summary(msg)["from"] == "a@b.com"
+
+
+def test_summary_subject_placeholder():
+    assert message_summary({"id": "1"})["subject"] == "(no subject)"
+
+
+# --------------------------------------------------------------------------
+# request validity — the calls must be ones Graph would actually accept
+# --------------------------------------------------------------------------
+
+
+def test_list_inbox_requests_inbox_folder_newest_first():
+    seen = {}
+
+    def handler(request):
+        seen["url"] = request.url
+        return json_response({"value": [GRAPH_MESSAGE]})
+
+    messages = make_backend(handler).list_inbox(limit=10)
+
+    url = seen["url"]
+    assert url.path == "/v1.0/me/mailFolders/inbox/messages"
+    assert url.params["$top"] == "10"
+    assert url.params["$orderby"] == "receivedDateTime desc"
+    # Bodies are the expensive field; a listing must not fetch them.
+    assert "body" not in url.params["$select"].split(",")
+    assert "bodyPreview" in url.params["$select"]
+    assert len(messages) == 1
+
+
+def test_list_inbox_unread_only_sets_filter():
+    seen = {}
+
+    def handler(request):
+        seen["url"] = request.url
+        return json_response({"value": []})
+
+    make_backend(handler).list_inbox(unread_only=True)
+    assert seen["url"].params["$filter"] == "isRead eq false"
+
+
+def test_list_inbox_without_unread_sends_no_filter():
+    seen = {}
+
+    def handler(request):
+        seen["url"] = request.url
+        return json_response({"value": []})
+
+    make_backend(handler).list_inbox()
+    assert "$filter" not in seen["url"].params
+
+
+def test_search_quotes_the_term_and_omits_orderby():
+    seen = {}
+
+    def handler(request):
+        seen["url"] = request.url
+        return json_response({"value": []})
+
+    make_backend(handler).search("invoice")
+
+    url = seen["url"]
+    assert url.path == "/v1.0/me/messages"
+    assert url.params["$search"] == '"invoice"'
+    # Graph rejects $search combined with $orderby — sending both is a 400.
+    assert "$orderby" not in url.params
+
+
+def test_get_message_selects_body():
+    seen = {}
+
+    def handler(request):
+        seen["url"] = request.url
+        return json_response(GRAPH_MESSAGE)
+
+    out = make_backend(handler).get_message("AAMk-1")
+
+    assert seen["url"].path == "/v1.0/me/messages/AAMk-1"
+    assert "body" in seen["url"].params["$select"].split(",")
+    assert out["body"] == "<p>Can you confirm?</p>"
+
+
+def test_top_is_clamped_to_graph_maximum():
+    seen = {}
+
+    def handler(request):
+        seen["url"] = request.url
+        return json_response({"value": []})
+
+    make_backend(handler).list_inbox(limit=5000)
+    # Graph 400s on $top > 999 rather than truncating.
+    assert seen["url"].params["$top"] == "999"
+
+
+@pytest.mark.parametrize("bad", [0, -1])
+def test_non_positive_limit_is_rejected(bad):
+    backend = make_backend(lambda r: json_response({"value": []}))
+    with pytest.raises(ValueError, match="limit must be >= 1"):
+        backend.list_inbox(limit=bad)
+
+
+@pytest.mark.parametrize("bad", ["", "   "])
+def test_empty_search_query_is_rejected(bad):
+    backend = make_backend(lambda r: json_response({"value": []}))
+    with pytest.raises(ValueError, match="non-empty search string"):
+        backend.search(bad)
+
+
+def test_token_is_reminted_per_request():
+    """A cached token would let a mid-scan revoke look like success."""
+    calls = []
+
+    def token():
+        calls.append(1)
+        return f"token-{len(calls)}"
+
+    seen = []
+
+    def handler(request):
+        seen.append(request.headers["Authorization"])
+        return json_response({"value": []})
+
+    client = httpx.Client(transport=httpx.MockTransport(handler))
+    backend = OutlookReadBackend(token, http_client=client)
+    backend.list_inbox()
+    backend.list_inbox()
+
+    assert seen == ["Bearer token-1", "Bearer token-2"]
+
+
+# --------------------------------------------------------------------------
+# errors are actionable and never leak the token
+# --------------------------------------------------------------------------
+
+
+def test_401_names_the_fix():
+    backend = make_backend(lambda r: httpx.Response(401, text="expired"))
+    with pytest.raises(MailboxAuthError) as err:
+        backend.list_inbox()
+    assert "gaia connectors" in str(err.value)
+
+
+def test_403_names_the_missing_scope():
+    backend = make_backend(lambda r: httpx.Response(403, text="denied"))
+    with pytest.raises(MailboxAuthError) as err:
+        backend.list_inbox()
+    assert "Mail.ReadWrite" in str(err.value)
+
+
+def test_429_surfaces_retry_after():
+    backend = make_backend(
+        lambda r: httpx.Response(429, text="slow down", headers={"Retry-After": "30"})
+    )
+    with pytest.raises(MailboxError, match="30"):
+        backend.list_inbox()
+
+
+def test_error_message_never_contains_the_bearer_token():
+    backend = make_backend(lambda r: httpx.Response(500, text="boom"))
+    with pytest.raises(MailboxError) as err:
+        backend.list_inbox()
+    assert "test-token" not in str(err.value)
+    assert "Bearer" not in str(err.value)
+
+
+def test_network_failure_is_actionable():
+    def handler(request):
+        raise httpx.ConnectError("no route to host")
+
+    with pytest.raises(MailboxError, match="Check network connectivity"):
+        make_backend(handler).list_inbox()
+
+
+def test_empty_account_address_fails_loudly():
+    backend = make_backend(
+        lambda r: json_response({"mail": None, "userPrincipalName": ""})
+    )
+    with pytest.raises(MailboxError, match="unusable state"):
+        backend.get_user_email()
+
+
+def test_user_email_falls_back_to_principal_name():
+    backend = make_backend(
+        lambda r: json_response({"mail": None, "userPrincipalName": "me@example.com"})
+    )
+    assert backend.get_user_email() == "me@example.com"
+
+
+# --------------------------------------------------------------------------
+# the mixin surface
+# --------------------------------------------------------------------------
+
+
+class _Harness(EmailToolsMixin):
+    """Minimal host for the mixin — no Agent machinery needed."""
+
+    def __init__(self, backend):
+        self._email_backend = backend
+        self.tools = {}
+
+    def _tool(self, name):
+        from gaia.agents.base.tools import _TOOL_REGISTRY
+
+        return _TOOL_REGISTRY[name]["function"]
+
+
+@pytest.fixture
+def harness_factory():
+    def build(handler):
+        h = _Harness(make_backend(handler))
+        h.register_email_tools()
+        return h
+
+    return build
+
+
+def test_grant_identity_is_the_namespaced_flagship_id():
+    # Must match gaia.connectors.grants' namespacing for a wheel-installed agent.
+    assert EMAIL_AGENT_ID == "installed:gaia"
+    assert MAIL_SCOPES == ("https://graph.microsoft.com/Mail.ReadWrite",)
+
+
+def test_list_inbox_tool_returns_structured_success(harness_factory):
+    h = harness_factory(lambda r: json_response({"value": [GRAPH_MESSAGE]}))
+    out = json.loads(h._tool("list_inbox")(limit=5))
+    assert out["success"] is True
+    assert out["count"] == 1
+    assert out["messages"][0]["subject"] == "Q3 numbers"
+
+
+def test_search_tool_reports_relevance_ordering(harness_factory):
+    """The model must not describe relevance-ordered hits as 'most recent'."""
+    h = harness_factory(lambda r: json_response({"value": [GRAPH_MESSAGE]}))
+    out = json.loads(h._tool("search_email")(query="q3"))
+    assert out["order"] == "relevance"
+
+
+def test_tool_failure_is_reported_not_swallowed(harness_factory):
+    h = harness_factory(lambda r: httpx.Response(401, text="expired"))
+    out = json.loads(h._tool("list_inbox")())
+    assert out["success"] is False
+    assert "gaia connectors" in out["error"]
+    # An empty list here would read to the model as "your inbox is empty".
+    assert "messages" not in out
+
+
+def test_check_mailbox_access_reports_inbox_counts(harness_factory):
+    def handler(request):
+        if request.url.path.endswith("/me"):
+            return json_response({"mail": "me@example.com"})
+        return json_response(
+            {
+                "value": [
+                    {
+                        "id": "f1",
+                        "displayName": "Inbox",
+                        "unreadItemCount": 4,
+                        "totalItemCount": 120,
+                    }
+                ]
+            }
+        )
+
+    out = json.loads(harness_factory(handler)._tool("check_mailbox_access")())
+    assert out["success"] is True
+    assert out["address"] == "me@example.com"
+    assert out["inbox_unread"] == 4
+
+
+def test_limit_is_clamped_at_the_tool_boundary(harness_factory):
+    seen = {}
+
+    def handler(request):
+        seen["top"] = request.url.params["$top"]
+        return json_response({"value": []})
+
+    harness_factory(handler)._tool("list_inbox")(limit=99999)
+    assert seen["top"] == "100"
+
+
+def test_backend_is_not_built_until_a_tool_runs():
+    """Composing the mixin must not touch the connectors layer."""
+
+    class Eager(EmailToolsMixin):
+        def _build_email_backend(self):
+            raise AssertionError("backend built too early")
+
+    Eager().register_email_tools()  # must not raise
+
+
+# --------------------------------------------------------------------------
+# skill <-> mixin drift
+# --------------------------------------------------------------------------
+
+
+def _inbox_triage_skill():
+    from pathlib import Path
+
+    from gaia.skills.format import parse_skill
+
+    root = Path(__file__).resolve().parents[4]
+    path = root / "hub" / "skills" / "inbox-triage" / "SKILL.md"
+    return parse_skill(path.read_text(encoding="utf-8"), source=str(path))
+
+
+def test_skill_tools_required_match_the_registered_tools():
+    """A tool rename must not leave the skill silently pointing at nothing.
+
+    ``tools_required`` is what feeds ToolLoader's SKILL term, and semantic
+    selection alone does not reliably reach these tools (see the PR notes), so
+    a stale name here is the difference between the skill working and quietly
+    doing nothing.
+    """
+    harness = _Harness(backend=None)
+    harness.register_email_tools()
+
+    from gaia.agents.base.tools import _TOOL_REGISTRY
+
+    registered = {
+        "check_mailbox_access",
+        "list_inbox",
+        "search_email",
+        "read_email",
+        "list_mail_folders",
+    }
+    assert registered <= set(_TOOL_REGISTRY)
+    assert set(_inbox_triage_skill().gaia.tools_required) == registered
+
+
+def test_skill_declares_no_permissions():
+    """The capability is agent code, so the skill needs no permission grant.
+
+    This is what keeps the work off #2863's critical path: a skill declaring a
+    local-capability domain is refused at load, and this one declares none.
+    """
+    from gaia.skills.permissions import refuse_unbridged_permissions
+
+    skill = _inbox_triage_skill()
+    assert skill.gaia.permissions == []
+    refuse_unbridged_permissions(skill.parsed_permissions(), skill_name=skill.name)
+
+
+def test_email_tools_are_bundled_for_the_loader():
+    """An unbundled tool can never be pulled in with its cohort."""
+    from gaia_agent_chat.tool_bundles import PROFILE_TOOL_CONFIGS
+
+    bundles = PROFILE_TOOL_CONFIGS["full"].bundles
+    email = next(b for b in bundles if b.name == "email")
+    assert email.members == set(_inbox_triage_skill().gaia.tools_required)

--- a/tests/unit/test_starter_skills.py
+++ b/tests/unit/test_starter_skills.py
@@ -153,6 +153,7 @@ def registry_tool_names() -> frozenset[str]:
     from gaia.agents.base.tools import _TOOL_REGISTRY
     from gaia.agents.tools.browser_tools import BrowserToolsMixin
     from gaia.agents.tools.code_index_tools import CodeIndexToolsMixin
+    from gaia.agents.tools.email_tools import EmailToolsMixin
     from gaia.agents.tools.file_io_tools import FileIOToolsMixin
     from gaia.agents.tools.file_tools import FileSearchToolsMixin
     from gaia.agents.tools.filesystem_tools import FileSystemToolsMixin
@@ -183,6 +184,7 @@ def registry_tool_names() -> frozenset[str]:
         (ShellToolsMixin, "register_shell_tools"),
         (CodeIndexToolsMixin, "register_code_index_tools"),
         (MemoryMixin, "register_memory_tools"),
+        (EmailToolsMixin, "register_email_tools"),
     ]
 
     before = dict(_TOOL_REGISTRY)


### PR DESCRIPTION
Ask the flagship GAIA agent to triage your inbox today and nothing happens — it has 67 registered tools and not one touches mail. Email only works through a separate installable agent with its own sidecar process, REST API, and npm package, so you cannot ask a single question that spans your mail and your documents. After this, `triage my inbox` works on the same agent that already does documents, web, shell, and memory.

This is Phase 0 of #3329 — retiring the standalone email agent by moving the capability onto the flagship. Read-only, Outlook/Graph only: five mailbox tools plus an `inbox-triage` skill that does the judging. No writes, no calendar, no state DB.

## Why a tool mixin and not a skill-provided `tools.py`

This is the design decision worth reviewing. #2672 tried the skill-provided route and is blocked on the Phase 2 sandbox (#2863), because email's reversible-action ledger needs `database:write`.

Shipping the capability as agent code routes around that entirely: `refuse_unbridged_permissions` is only ever called on *skill* permissions (`agent.py:1619`, `loader.py:62`, `install.py:353`, `publish.py:137`, `migrate.py:821`), never on a mixin. The skill here declares **zero** permissions and loads clean — there is a test pinning that.

Worth noting separately: #2672's premise that `shell` is refused is now stale. `permissions.py:63-73` splits three ways, and `shell` is binary-bridged, not local-capability — which is how `github-triage` loads with `shell:execute:gh`.

## The open risk: tool selection

Semantic selection alone does **not** reliably reach these tools. Measured against the live embedder:

| Query | Email tools selected |
|---|---|
| `triage my inbox` | all 5 |
| `what is unread?` | all 5 |
| `anything important in my mail?` | all 5 |
| `what emails need a reply today?` | **none** |
| `who is waiting on me?` | **none** |
| `did I get an invoice from Acme?` | **none** |
| `index this codebase` | none (correct) |

I tried widening the tool docstrings and stopped: it did not fix the misses and it introduced a false positive (`what did I do last week?` started pulling email tools, which should be memory). Tuning prose to game an embedding threshold is fragile.

The mechanism that does work is the one the architecture already provides — the skill's `tools_required` feeds the loader's SKILL term, which is admitted ahead of semantic candidates. With that signal the tools are reachable for every query above. So the skill is not optional polish here; it is what makes the capability findable. `test_skill_tools_required_match_the_registered_tools` pins the names so a rename cannot silently break it.

## Test plan

- [ ] `pytest tests/unit/agents/tools/test_email_tools.py` — 33 pass. Graph calls go through `httpx.MockTransport` and assert the **shape** of the outgoing request (`$select` excludes `body` on listings, `$search` is never combined with `$orderby`, `$top` clamps at 999) — a stub returning success would not catch a request Graph itself would 400.
- [ ] `pytest hub/agents/gaia/python/tests/` — 305 pass. Both drift guards caught real gaps while writing this (`tools_count` 67→72, and the email tools being unbundled) and now pass.
- [ ] Confirm errors stay actionable and never leak the bearer token — `test_error_message_never_contains_the_bearer_token`.
- [ ] Confirm the skill loads on a real flagship build and reaches the system prompt.

**Not verified, and it matters:** no live mailbox round trip. This machine has a `microsoft` grant-ledger entry but no configured OAuth client and no activations, so the connection is inert — the grant record was a leftover, not a working mailbox. Verifying needs an Azure app registration plus an interactive sign-in. Until someone does that, the Graph wire contract is asserted against mocks only.

Reviewer note: I added a `microsoft` → `installed:gaia` grant while testing. Revert with `gaia connectors` or by restoring `~/.gaia/connectors/grants.json.bak-phase0`.

## Not in this PR

Writes, undo ledger, batch thresholds, briefing, calendar, Gmail, and the decommission itself. Phases 1-5 in `docs/plans/email-triage-skill.mdx`.

No eval was run: this adds tools but changes no existing prompt, and the flagship has no committed email baseline to compare against (#2983). Before Phase 1 the `tool_selection` baseline should be re-run — adding 5 tools to a 67-tool agent could degrade non-email selection, which is the regression nobody would think to look for.
