### PR TITLE
fix(installer): ship the agent the TUI spawns, not just the TUI

### DIFF
--- a/.github/workflows/release_agent_gaia.yml
+++ b/.github/workflows/release_agent_gaia.yml
@@ -5,7 +5,7 @@
 # (@amd-gaia/gaia on npm, gaia-agent-gaia on the Agent Hub). One namespaced tag
 # does the whole release.
 #
-# TWO shipped components, from TWO DIFFERENT HUB LANES:
+# THREE shipped components, from TWO DIFFERENT HUB LANES:
 #
 #   sidecar — the agent's REST sidecar, frozen with PyInstaller into a one-file
 #             native binary per platform. PyInstaller cannot cross-compile, so
@@ -13,6 +13,19 @@
 #             publishes it, into agents/gaia/<version>/:
 #               gaia-agent-win32-x64.exe / -darwin-arm64 / -darwin-x64 / -linux-x64
 #             Installed executable name: gaia-agent[.exe]
+#   stdio   — the SAME agent frozen against packaging/stdio_entry.py instead: a
+#             JSONL child speaking over stdin/stdout. This is what the terminal
+#             UI actually spawns (TransportSubprocess, seedAgents() in
+#             tui/internal/catalog/catalog.go); the REST sidecar ignores stdin
+#             and can never serve it, so before this lane existed the hub
+#             published no artifact the TUI could launch. Built by the SAME
+#             freeze legs, published into the same agents/gaia/<version>/:
+#               gaia-agent-stdio-win32-x64.exe / -darwin-arm64 / -darwin-x64 /
+#               -linux-x64
+#             Installed executable name: gaia-agent[.exe] — the name the TUI
+#             looks for. That is the SAME installed name the sidecar uses, and
+#             the npm client writes every component into ONE cache directory, so
+#             a consumer must fetch one transport or the other, never both.
 #   tui     — the Go terminal UI, CONSUMED (not built) from the published
 #             `terminal-hub` component at agents/terminal-hub/<tuiVersion>/:
 #               gaia-{win-x64,win-arm64,darwin-arm64,darwin-x64,
@@ -31,9 +44,9 @@
 # version fails the release loudly, naming the version required. There is no
 # fallback to building our own.
 #
-# binaries.lock.json is therefore TWO-LANE (schemaVersion "3.0") — each component
-# carries its own version and base URL, which one shared top-level baseUrl could
-# not express:
+# binaries.lock.json is therefore PER-COMPONENT (schemaVersion "3.0") — each
+# component carries its own version and base URL, which one shared top-level
+# baseUrl could not express (sidecar and stdio share a lane; tui does not):
 #   { schemaVersion, agentVersion,
 #     components: { <name>: { componentVersion, baseUrl, platforms: {...} } } }
 # gen_binaries_lock.py writes each lane from the per-artifact meta records the
@@ -44,9 +57,10 @@
 #                  fail fast if it disagrees with package.json or
 #                  gaia-agent.yaml, or if stamp_version.py --check finds drift.
 #                  Also reads the terminal-hub pin out of the committed lock.
-#                  Runs BEFORE ~40 runner-minutes of freezing.
-#   2. freeze    — per-platform PyInstaller freeze of the sidecar, smoke-tested
-#                  on the frozen binary itself, staged under its hub name with a
+#                  Runs BEFORE ~80 runner-minutes of freezing.
+#   2. freeze    — per-platform PyInstaller freeze of BOTH the sidecar and the
+#                  stdio binary, each smoke-tested on the frozen file itself in
+#                  its own transport's mode, staged under its hub name with a
 #                  SHA-256 + size meta.
 #   3. tui       — prove the pinned terminal-hub version is published, download
 #                  all 6 artifacts from that lane, and cross-check each against
@@ -54,10 +68,11 @@
 #   4. tests     — the gaia agent's Python test suite + the npm package's vitest
 #                  suite. A failure blocks the release.
 #   5. publish   — behind the `agent-publish` environment's manual approval:
-#                  POST the SIDECAR binaries + gaia-agent.yaml to the Agent Hub
-#                  Worker's /publish endpoint, regenerate binaries.lock.json with
-#                  the REAL hashes for both lanes, verify every entry is
-#                  fetchable AND hash-matches at the public origin, then
+#                  POST the SIDECAR + STDIO binaries + gaia-agent.yaml to the
+#                  Agent Hub Worker's /publish endpoint, regenerate
+#                  binaries.lock.json with the REAL hashes for all three
+#                  components, verify every entry is fetchable AND hash-matches
+#                  at the public origin, then
 #                  `npm publish` via npm trusted publishing (OIDC, provenance —
 #                  NO npm token).
 #
@@ -323,9 +338,9 @@ jobs:
             [ -f "$f" ] || echo "::warning::${f} not found — the release will publish without that hub doc tab."
           done
 
-  # ── Stage 2: native sidecar freeze on every platform ────────────────
+  # ── Stage 2: native freeze (sidecar + stdio) on every platform ──────
   freeze:
-    name: Freeze sidecar (${{ matrix.key }})
+    name: Freeze binaries (${{ matrix.key }})
     runs-on: ${{ matrix.os }}
     needs: [version]
     # darwin-x64 (Intel) is BEST-EFFORT, built on macos-26-intel (the latest
@@ -339,7 +354,12 @@ jobs:
     # REQUIRED platforms. A miss is announced LOUDLY (::warning:: + job summary)
     # and Intel users still fail loudly at install — never silent.
     continue-on-error: ${{ !matrix.required }}
-    timeout-minutes: ${{ matrix.required && 40 || 60 }}
+    # Two full PyInstaller freezes per leg, not one, and freeze.py passes
+    # --clean so the second gets no warm analysis cache — it costs about what
+    # the first did. The dependency install is the only part still paid once.
+    # 40 -> 75 keeps roughly the old headroom over an observed ~45 min; the
+    # best-effort Intel leg is the slowest runner, so 60 -> 100.
+    timeout-minutes: ${{ matrix.required && 75 || 100 }}
     strategy:
       # Never let one slow/stuck leg cancel the others — each platform freezes
       # independently and `publish` reconciles whatever arrived.
@@ -351,18 +371,24 @@ jobs:
             key: win32-x64
             artifact: gaia-agent-win32-x64.exe
             frozen: gaia-agent.exe
+            stdio_artifact: gaia-agent-stdio-win32-x64.exe
+            stdio_frozen: gaia-agent-stdio.exe
             required: true
           - os: macos-14
             platform: darwin-arm64
             key: darwin-arm64
             artifact: gaia-agent-darwin-arm64
             frozen: gaia-agent
+            stdio_artifact: gaia-agent-stdio-darwin-arm64
+            stdio_frozen: gaia-agent-stdio
             required: true
           - os: ubuntu-latest
             platform: linux-x64
             key: linux-x64
             artifact: gaia-agent-linux-x64
             frozen: gaia-agent
+            stdio_artifact: gaia-agent-stdio-linux-x64
+            stdio_frozen: gaia-agent-stdio
             required: true
           # darwin-x64 (Intel) BEST-EFFORT — see the job-level comment above.
           - os: macos-26-intel
@@ -370,6 +396,8 @@ jobs:
             key: darwin-x64
             artifact: gaia-agent-darwin-x64
             frozen: gaia-agent
+            stdio_artifact: gaia-agent-stdio-darwin-x64
+            stdio_frozen: gaia-agent-stdio
             required: false
     steps:
       - uses: actions/checkout@v7
@@ -404,7 +432,7 @@ jobs:
             -e hub/agents/gaia/python \
             pyinstaller
 
-      - name: Freeze one-file binary
+      - name: Freeze one-file binary (sidecar / REST)
         shell: bash
         run: |
           set -euo pipefail
@@ -415,43 +443,80 @@ jobs:
       # An import that only resolves in the dev venv (a hidden import PyInstaller
       # missed, a package-data file that didn't get collected) fails here rather
       # than on a user's machine after the tag is immutable.
-      - name: Smoke-test the frozen binary
+      - name: Smoke-test the frozen sidecar binary
         shell: bash
         run: |
           set -euo pipefail
           PY=.venv-freeze/$([ "$RUNNER_OS" = "Windows" ] && echo Scripts || echo bin)/python
-          "$PY" "${PACKAGING}/smoke_test.py" "${FREEZE_DIST}/${{ matrix.frozen }}"
+          "$PY" "${PACKAGING}/smoke_test.py" --mode sidecar "${FREEZE_DIST}/${{ matrix.frozen }}"
 
-      - name: Stage artifact + compute SHA-256 / size
+      # Both targets build into the same dist/ under DIFFERENT names, and
+      # freeze.py cleans only its own target's paths (_clean_target_outputs), so
+      # this copy is ordering-independent. Kept here so a failed stdio freeze
+      # cannot leave the sidecar unstaged.
+      - name: Stage the sidecar binary out of dist/
         shell: bash
         run: |
           set -euo pipefail
           mkdir -p staging
           cp "${FREEZE_DIST}/${{ matrix.frozen }}" "staging/${{ matrix.artifact }}"
-          python - "staging/${{ matrix.artifact }}" "${{ matrix.platform }}" "${{ matrix.artifact }}" "${{ matrix.frozen }}" <<'PY'
+
+      # The transport the terminal UI actually spawns. Same code, same venv,
+      # different entry point (packaging/stdio_entry.py) and a distinct
+      # PyInstaller --name so it cannot collide with the sidecar in dist/.
+      - name: Freeze one-file binary (stdio / JSONL)
+        shell: bash
+        run: |
+          set -euo pipefail
+          PY=.venv-freeze/$([ "$RUNNER_OS" = "Windows" ] && echo Scripts || echo bin)/python
+          "$PY" "${PACKAGING}/freeze.py" --onefile --target stdio
+
+      # Same gate as the sidecar's, in the transport this binary actually
+      # speaks — an HTTP /health probe can never pass against a stdio child, so
+      # `--mode stdio` is what makes this a real check rather than a formality.
+      - name: Smoke-test the frozen stdio binary
+        shell: bash
+        run: |
+          set -euo pipefail
+          PY=.venv-freeze/$([ "$RUNNER_OS" = "Windows" ] && echo Scripts || echo bin)/python
+          "$PY" "${PACKAGING}/smoke_test.py" --mode stdio "${FREEZE_DIST}/${{ matrix.stdio_frozen }}"
+
+      - name: Stage artifacts + compute SHA-256 / size
+        shell: bash
+        run: |
+          set -euo pipefail
+          cp "${FREEZE_DIST}/${{ matrix.stdio_frozen }}" "staging/${{ matrix.stdio_artifact }}"
+          python - "${{ matrix.platform }}" \
+            "sidecar=${{ matrix.artifact }}" \
+            "stdio=${{ matrix.stdio_artifact }}" <<'PY'
           import hashlib, json, sys
-          path, platform, filename, frozen = sys.argv[1:5]
-          data = open(path, "rb").read()
-          meta = {
-              "component": "sidecar",
-              "platform": platform,
-              "filename": filename,
-              "executable": "gaia-agent.exe" if frozen.endswith(".exe") else "gaia-agent",
-              "sha256": hashlib.sha256(data).hexdigest(),
-              "size": len(data),
-          }
-          with open(f"staging/sidecar-{platform}.meta.json", "w") as fh:
-              fh.write(json.dumps([meta], indent=2))
-          print(json.dumps(meta, indent=2))
+          platform, *specs = sys.argv[1:]
+          for spec in specs:
+              component, _, filename = spec.partition("=")
+              data = open(f"staging/{filename}", "rb").read()
+              meta = {
+                  "component": component,
+                  "platform": platform,
+                  "filename": filename,
+                  # Both transports install under the name the TUI spawns.
+                  "executable": "gaia-agent.exe" if filename.endswith(".exe") else "gaia-agent",
+                  "sha256": hashlib.sha256(data).hexdigest(),
+                  "size": len(data),
+              }
+              with open(f"staging/{component}-{platform}.meta.json", "w") as fh:
+                  fh.write(json.dumps([meta], indent=2))
+              print(json.dumps(meta, indent=2))
           PY
 
-      - name: Upload platform artifact
+      - name: Upload platform artifacts
         uses: actions/upload-artifact@v7
         with:
           name: gaia-agent-${{ matrix.key }}
           path: |
             staging/${{ matrix.artifact }}
+            staging/${{ matrix.stdio_artifact }}
             staging/sidecar-${{ matrix.platform }}.meta.json
+            staging/stdio-${{ matrix.platform }}.meta.json
           if-no-files-found: error
 
   # ── Stage 3: verify the pinned terminal-hub component ───────────────
@@ -791,15 +856,15 @@ jobs:
             exit 1
           fi
 
-      - name: Download sidecar artifacts
+      - name: Download freeze artifacts (sidecar + stdio)
         uses: actions/download-artifact@v8
         with:
           pattern: gaia-agent-*
-          path: artifacts/sidecar
+          path: artifacts/freeze
 
       # Metas only: the TUI binaries stay in the terminal-hub lane and are never
-      # copied into ours. `bins/` below therefore holds sidecar artifacts alone,
-      # which is exactly what gets POSTed to /publish.
+      # copied into ours. `bins/` below therefore holds only the two frozen
+      # transports, which is exactly what gets POSTed to /publish.
       - name: Download terminal-hub metas
         uses: actions/download-artifact@v8
         with:
@@ -816,28 +881,35 @@ jobs:
           find artifacts -type f -name '*.meta.json' -exec cp {} metas/ \;
           find artifacts -type f -name 'gaia-agent-*' ! -name '*.meta.json' \
             -exec cp {} bins/ \;
-          echo "=== collected binaries (sidecar only) ===" && ls -la bins/
+          echo "=== collected binaries (sidecar + stdio only) ===" && ls -la bins/
           echo "=== collected metas ===" && ls -la metas/
 
-          # Nothing but the sidecar may be published under agents/gaia/. Anything
-          # else staged here — a terminal UI binary above all — would mean the
-          # duplicate publish this release deliberately dropped crept back in.
+          # Only the two frozen transports may be published under agents/gaia/.
+          # Anything else staged here — a terminal UI binary above all — would
+          # mean the duplicate publish this release deliberately dropped crept
+          # back in.
           for f in bins/*; do
             [ -f "$f" ] || continue
             case "$(basename "$f")" in
+              gaia-agent-stdio-*) ;;
               gaia-agent-*) ;;
               *)
-                echo "::error::'$(basename "$f")' is staged for publish in bins/, but this release publishes ONLY the sidecar (gaia-agent-*) under agents/gaia/. The terminal UI is consumed from the published terminal-hub component and must never be republished here. Remove whatever job staged it."
+                echo "::error::'$(basename "$f")' is staged for publish in bins/, but this release publishes ONLY the frozen agent transports (gaia-agent-* and gaia-agent-stdio-*) under agents/gaia/. The terminal UI is consumed from the published terminal-hub component and must never be republished here. Remove whatever job staged it."
                 exit 1
                 ;;
             esac
           done
 
           missing=()
-          # Sidecar: the 3 non-Intel platforms are REQUIRED. A missing one is a
-          # real build failure, not best-effort — fail the release loudly.
+          # Both transports on the 3 non-Intel platforms are REQUIRED. A missing
+          # one is a real build failure, not best-effort — fail the release
+          # loudly. A release without the stdio binary publishes nothing the
+          # terminal UI can spawn, which is the gap this lane exists to close.
           for f in gaia-agent-win32-x64.exe gaia-agent-darwin-arm64 gaia-agent-linux-x64; do
             [ -f "bins/$f" ] || missing+=("sidecar:$f")
+          done
+          for f in gaia-agent-stdio-win32-x64.exe gaia-agent-stdio-darwin-arm64 gaia-agent-stdio-linux-x64; do
+            [ -f "bins/$f" ] || missing+=("stdio:$f")
           done
           if [ "${#missing[@]}" -gt 0 ]; then
             echo "::error::required release artifacts missing: ${missing[*]}. Their build leg failed — the release cannot proceed. Re-run those jobs, then re-approve."
@@ -848,32 +920,49 @@ jobs:
           # drops that platform. The 6 tui metas come from the terminal-hub
           # verify job, not from a build here.
           for m in sidecar-win32-x64 sidecar-darwin-arm64 sidecar-linux-x64 \
+                   stdio-win32-x64 stdio-darwin-arm64 stdio-linux-x64 \
                    tui-win32-x64 tui-win32-arm64 tui-darwin-arm64 \
                    tui-darwin-x64 tui-linux-x64 tui-linux-arm64; do
             if [ ! -f "metas/${m}.meta.json" ]; then
-              echo "::error::missing artifact meta metas/${m}.meta.json — binaries.lock.json would ship without an entry for it. Re-run the job that produces it (freeze for sidecar-*, the terminal-hub verify for tui-*)."
+              echo "::error::missing artifact meta metas/${m}.meta.json — binaries.lock.json would ship without an entry for it. Re-run the job that produces it (freeze for sidecar-*/stdio-*, the terminal-hub verify for tui-*)."
               exit 1
             fi
           done
 
-          # darwin-x64 sidecar (Intel) is BEST-EFFORT.
-          if [ -f "bins/gaia-agent-darwin-x64" ] && [ -f "metas/sidecar-darwin-x64.meta.json" ]; then
-            echo "DARWIN_X64_SIDECAR=true" >> "$GITHUB_ENV"
-            echo "darwin-x64 (Intel) sidecar present — full 4-platform sidecar release."
-          else
-            echo "DARWIN_X64_SIDECAR=false" >> "$GITHUB_ENV"
+          # darwin-x64 (Intel) is BEST-EFFORT for BOTH transports. They come from
+          # the same freeze leg, which uploads both or neither, so a half-set
+          # means that leg produced something unexpected — fail rather than ship
+          # one transport for a platform.
+          intel_have=() intel_lack=()
+          for pair in "sidecar:gaia-agent-darwin-x64" "stdio:gaia-agent-stdio-darwin-x64"; do
+            lane="${pair%%:*}"; file="${pair#*:}"
+            if [ -f "bins/${file}" ] && [ -f "metas/${lane}-darwin-x64.meta.json" ]; then
+              intel_have+=("${lane}")
+            else
+              intel_lack+=("${lane}")
+            fi
+          done
+          if [ "${#intel_lack[@]}" -eq 0 ]; then
+            echo "DARWIN_X64_INTEL=true" >> "$GITHUB_ENV"
+            echo "darwin-x64 (Intel) present for both transports — full 4-platform release."
+          elif [ "${#intel_have[@]}" -eq 0 ]; then
+            echo "DARWIN_X64_INTEL=false" >> "$GITHUB_ENV"
             # Never publish a binary we have no verified hash for.
-            rm -f bins/gaia-agent-darwin-x64 metas/sidecar-darwin-x64.meta.json
-            echo "::warning::darwin-x64 (Intel macOS) SIDECAR not published — its best-effort freeze leg did not produce a binary + meta. Releasing the other 3 sidecar platforms; Intel-mac users get a loud 'no sidecar binary for darwin-x64' error at install until one is published for this version. (The terminal UI is unaffected — it is consumed from the published terminal-hub component, not built here.)"
+            rm -f bins/gaia-agent-darwin-x64 metas/sidecar-darwin-x64.meta.json \
+                  bins/gaia-agent-stdio-darwin-x64 metas/stdio-darwin-x64.meta.json
+            echo "::warning::darwin-x64 (Intel macOS) NOT published — its best-effort freeze leg did not produce binaries + metas for either transport. Releasing the other 3 platforms; Intel-mac users get a loud 'no binary for darwin-x64' error at install until one is published for this version. (The terminal UI is unaffected — it is consumed from the published terminal-hub component, not built here.)"
             {
-              echo "### ⚠️ Intel macOS (darwin-x64) sidecar NOT published"
+              echo "### ⚠️ Intel macOS (darwin-x64) NOT published"
               echo ""
-              echo "The best-effort \`darwin-x64\` PyInstaller freeze did not produce a usable binary, so this release ships **3 of 4** sidecar platforms. The terminal UI is unaffected — it comes from the published \`terminal-hub\` component."
+              echo "The best-effort \`darwin-x64\` PyInstaller freeze did not produce usable binaries, so this release ships **3 of 4** platforms for both the sidecar and the stdio agent. The terminal UI is unaffected — it comes from the published \`terminal-hub\` component."
               echo ""
-              echo "Intel-mac users will hit a loud install error until an Intel sidecar is published for this version."
+              echo "Intel-mac users will hit a loud install error until an Intel build is published for this version."
               echo ""
-              echo "**Follow-up:** re-run once the Intel leg succeeds; \`POST /publish\` is immutable-per-filename, so adding the Intel binary to the *same* version is safe and idempotent."
+              echo "**Follow-up:** re-run once the Intel leg succeeds; \`POST /publish\` is immutable-per-filename, so adding the Intel binaries to the *same* version is safe and idempotent."
             } >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "::error::darwin-x64 (Intel) produced ${intel_have[*]} but not ${intel_lack[*]}. Both transports are built by the same freeze leg, so it uploads both or neither — a half-set means that leg was tampered with or its upload was partial. Refusing to publish an inconsistent Intel release; re-run the darwin-x64 freeze leg, then re-approve."
+            exit 1
           fi
 
       - name: Publish binaries to the Agent Hub (POST /publish)
@@ -921,7 +1010,7 @@ jobs:
             fi
           done
 
-          # Sidecar binaries only — the TUI is already published in the
+          # The two frozen transports only — the TUI is already published in the
           # terminal-hub lane and is deliberately not republished here.
           args=()
           for f in bins/*; do
@@ -952,8 +1041,8 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          # Every meta from every leg, both lanes. gen_binaries_lock writes each
-          # lane's componentVersion + baseUrl + platforms, refuses a
+          # Every meta from every leg, all three components. gen_binaries_lock
+          # writes each one's componentVersion + baseUrl + platforms, refuses a
           # placeholder/non-sha256 hash, and rejects a tui filename that is not
           # what terminal-hub publishes — so a bad record fails here rather than
           # shipping an unverifiable lock. The fetch-verify below proves these
@@ -976,22 +1065,22 @@ jobs:
             "${meta_args[@]}"
 
           # gen_binaries_lock.py keeps the PRIOR entry for any platform absent
-          # from the metas. If the best-effort Intel sidecar was skipped, that
-          # prior entry is the committed PENDING-replace-with-real-sha256
-          # placeholder — drop it so the shipped lock carries NO sidecar
-          # darwin-x64 entry. The installer then emits a clear "no sidecar
+          # from the metas. If the best-effort Intel leg was skipped, that prior
+          # entry is the committed PENDING-replace-with-real-sha256 placeholder
+          # — drop it from BOTH gaia-lane components so the shipped lock carries
+          # no darwin-x64 entry at all. The installer then emits a clear "no
           # binary for darwin-x64 (available: …)" error instead of chasing an
           # object that was never published. Explicit absence beats a
           # placeholder hash.
-          if [ "${DARWIN_X64_SIDECAR}" = "false" ]; then
+          if [ "${DARWIN_X64_INTEL}" = "false" ]; then
             python - "${PKG_DIR}/binaries.lock.json" <<'PY'
           import json, sys
           p = sys.argv[1]
           lock = json.load(open(p))
-          platforms = lock.get("components", {}).get("sidecar", {}).get("platforms", {})
-          removed = platforms.pop("darwin-x64", None)
-          if removed is not None:
-              print("[lock] dropped unpublished sidecar/darwin-x64 entry (Intel best-effort skip)")
+          for component in ("sidecar", "stdio"):
+              platforms = lock.get("components", {}).get(component, {}).get("platforms", {})
+              if platforms.pop("darwin-x64", None) is not None:
+                  print(f"[lock] dropped unpublished {component}/darwin-x64 entry (Intel best-effort skip)")
           open(p, "w").write(json.dumps(lock, indent=2) + "\n")
           PY
           fi
@@ -1063,11 +1152,11 @@ jobs:
 
           lock = json.load(open(sys.argv[1]))
           components = lock.get("components") or {}
-          if sorted(components) != ["sidecar", "tui"]:
+          if sorted(components) != ["sidecar", "stdio", "tui"]:
               print(
                   "::error::regenerated binaries.lock.json does not carry exactly the "
-                  f"sidecar + tui components (got: {', '.join(sorted(components)) or 'none'}). "
-                  "Expected the two-lane schemaVersion 3.0 shape. gen_binaries_lock.py "
+                  f"sidecar + stdio + tui components (got: {', '.join(sorted(components)) or 'none'}). "
+                  "Expected the schemaVersion 3.0 shape. gen_binaries_lock.py "
                   "did not write what this release expects; refusing to publish an "
                   "unverifiable lock.",
                   flush=True,
@@ -1178,5 +1267,5 @@ jobs:
             echo ""
             echo "- Hub: \`${BASE_URL}\`"
             echo "- npm: \`${NPM_PKG}@${VERSION}\`"
-            echo "- Intel sidecar published: \`${DARWIN_X64_SIDECAR:-unknown}\`"
+            echo "- Intel (darwin-x64) published: \`${DARWIN_X64_INTEL:-unknown}\`"
           } >> "$GITHUB_STEP_SUMMARY"

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -116,13 +116,18 @@ Install GAIA globally with a single command:
     - ✅ Download Python 3.12 (if needed)
     - ✅ Create `%USERPROFILE%\.gaia\venv` virtual environment
     - ✅ Install GAIA CLI (accessible globally via PATH)
+    - ✅ Download `gaia-tui` and `gaia-agent`, each verified against the
+      SHA-256 the Agent Hub publishes
     - ✅ Add GAIA to your PATH
 
     <Tip>
-      After installation, close and reopen your terminal, then run:
+      After installation, close and reopen your terminal, then start GAIA:
       ```powershell
-      gaia init --profile minimal
+      gaia-tui
       ```
+      The first run checks what is still missing and can download the models
+      for you. To do that up front instead, run `gaia init --profile minimal`
+      first.
     </Tip>
   </Tab>
 
@@ -138,14 +143,19 @@ Install GAIA globally with a single command:
     - ✅ Download Python 3.12 (if needed)
     - ✅ Create `~/.gaia/venv` virtual environment
     - ✅ Install GAIA CLI (accessible globally via PATH)
+    - ✅ Download `gaia-tui` and `gaia-agent`, each verified against the
+      SHA-256 the Agent Hub publishes
     - ✅ Add GAIA to your PATH
 
     <Tip>
-      After installation, reload your shell config, then run:
+      After installation, reload your shell config, then start GAIA:
       ```bash
       source ~/.bashrc  # or ~/.zshrc
-      gaia init --profile minimal
+      gaia-tui
       ```
+      The first run checks what is still missing and can download the models
+      for you. To do that up front instead, run `gaia init --profile minimal`
+      first.
     </Tip>
   </Tab>
 </Tabs>

--- a/hub/agents/gaia/npm/binaries.lock.json
+++ b/hub/agents/gaia/npm/binaries.lock.json
@@ -32,6 +32,36 @@
         }
       }
     },
+    "stdio": {
+      "componentVersion": "0.1.1",
+      "baseUrl": "https://hub.amd-gaia.ai/agents/gaia/0.1.1",
+      "platforms": {
+        "win32-x64": {
+          "filename": "gaia-agent-stdio-win32-x64.exe",
+          "executable": "gaia-agent.exe",
+          "sha256": "PENDING-replace-with-real-sha256",
+          "size": 0
+        },
+        "darwin-arm64": {
+          "filename": "gaia-agent-stdio-darwin-arm64",
+          "executable": "gaia-agent",
+          "sha256": "PENDING-replace-with-real-sha256",
+          "size": 0
+        },
+        "darwin-x64": {
+          "filename": "gaia-agent-stdio-darwin-x64",
+          "executable": "gaia-agent",
+          "sha256": "PENDING-replace-with-real-sha256",
+          "size": 0
+        },
+        "linux-x64": {
+          "filename": "gaia-agent-stdio-linux-x64",
+          "executable": "gaia-agent",
+          "sha256": "PENDING-replace-with-real-sha256",
+          "size": 0
+        }
+      }
+    },
     "tui": {
       "componentVersion": "0.23.0",
       "baseUrl": "https://hub.amd-gaia.ai/agents/terminal-hub/0.23.0",

--- a/hub/agents/gaia/npm/test/lock.test.ts
+++ b/hub/agents/gaia/npm/test/lock.test.ts
@@ -44,9 +44,31 @@ const EXPECTED_EXECUTABLE: Record<string, string> = {
 };
 
 describe("shipped binaries.lock.json", () => {
-  it("parses with the two-lane schema", () => {
+  it("carries every lane this package consumes", () => {
     expect(lock.schemaVersion).toMatch(/^3\./);
-    expect(Object.keys(lock.components).sort()).toEqual([...COMPONENTS].sort());
+    // A superset, not an exact match: the lock is the release's record of every
+    // artifact published from the gaia lane, and the native installers read a
+    // lane this package deliberately does not (see the `stdio` test below).
+    for (const component of COMPONENTS) {
+      expect(Object.keys(lock.components)).toContain(component);
+    }
+  });
+
+  // `gaia-agent-stdio-*` is the stdin/stdout JSONL child the TUI spawns; the
+  // `sidecar` lane is the REST server this package starts. Both install under
+  // the name `gaia-agent`, so adding `stdio` to COMPONENTS would make `fetch`
+  // download both into one cache directory and leave which transport `npx`
+  // installed up to whichever landed last.
+  it("records the stdio lane without consuming it", () => {
+    const stdio = lock.components["stdio"];
+    expect(stdio, "the release must record the TUI's stdio child").toBeDefined();
+    expect([...COMPONENTS]).not.toContain("stdio");
+
+    for (const [platform, entry] of Object.entries(stdio!.platforms)) {
+      expect(entry.filename, `stdio/${platform} must not be the REST sidecar`).toMatch(
+        /^gaia-agent-stdio-/,
+      );
+    }
   });
 
   // Pinning the literal version here would only force an edit every release;

--- a/hub/agents/gaia/python/packaging/freeze.py
+++ b/hub/agents/gaia/python/packaging/freeze.py
@@ -1,19 +1,33 @@
 # Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
 # SPDX-License-Identifier: MIT
 """
-Reproducible PyInstaller freeze for the GAIA flagship agent REST sidecar.
+Reproducible PyInstaller freeze for the GAIA flagship agent.
 
-Freezes ``packaging/server.py`` into a self-contained executable that boots the
-``/v1/gaia/*`` REST surface with NO Python interpreter on the target machine.
+Two DIFFERENT programs ship from this one package, and each needs its own
+binary. ``--target`` picks which:
+
+- ``--target sidecar`` (the default) freezes ``packaging/server.py`` as
+  ``gaia-agent``: the ``/v1/gaia/*`` REST surface the daemon supervises.
+- ``--target stdio`` freezes ``packaging/stdio_entry.py`` as
+  ``gaia-agent-stdio``: the stdin/stdout JSONL child the TUI spawns.
+
+The names differ so the two ``dist/`` outputs cannot collide — and because they
+are not interchangeable: the TUI spawns its child bare and scans stdout for JSON
+lines, so handed the sidecar it reads uvicorn's startup log instead (#3062).
 
 Usage (from a venv with the deps + pyinstaller installed)::
 
-    python hub/agents/gaia/python/packaging/freeze.py            # one-dir (default)
-    python hub/agents/gaia/python/packaging/freeze.py --onefile  # one-file
+    python .../freeze.py                            # sidecar, one-dir
+    python .../freeze.py --onefile                  # sidecar, one-file
+    python .../freeze.py --target stdio --onefile   # stdio, one-file
 
-Output:
-    one-dir:  hub/agents/gaia/python/packaging/dist/gaia-agent/gaia-agent[.exe]
-    one-file: hub/agents/gaia/python/packaging/dist/gaia-agent[.exe]
+Output (``<name>`` is the target's binary name above):
+    one-dir:  hub/agents/gaia/python/packaging/dist/<name>/<name>[.exe]
+    one-file: hub/agents/gaia/python/packaging/dist/<name>[.exe]
+
+Both targets are collected IDENTICALLY. They import the same agent, so the
+import graph is the same; a marginally larger binary is far cheaper than a
+string-import that only goes missing on one of them.
 
 Design notes / gotchas baked in (mirrors the email sidecar's freeze):
 - ``uvicorn`` loads its loops/protocols/lifespan impls by string import, so its
@@ -29,7 +43,7 @@ Design notes / gotchas baked in (mirrors the email sidecar's freeze):
   runtime (see ``gaia_agent/agent.py``).
 - We deliberately do NOT ``--collect-submodules gaia``: the whole core package
   pulls every agent + RAG + torch and explodes the binary. Static analysis from
-  the sidecar entry pulls only the reachable core modules.
+  the entry module pulls only the reachable core modules.
 - The agent's import graph reaches ``gaia.chat.sdk``, whose static graph reaches
   the ML stack (torch, transformers, ...). All inference is Lemonade over HTTP
   and never runs in-process, so the ML stack is EXCLUDED to keep the binary lean.
@@ -43,11 +57,36 @@ import os
 import shutil
 import sys
 import time
+from dataclasses import dataclass
 from pathlib import Path
 
 HERE = Path(__file__).resolve().parent
-ENTRY = HERE / "server.py"
-NAME = "gaia-agent"
+
+
+@dataclass(frozen=True)
+class Target:
+    """One freezable program: which file is the entry, what the binary is called."""
+
+    entry: Path
+    name: str
+    summary: str
+
+
+TARGETS = {
+    "sidecar": Target(
+        entry=HERE / "server.py",
+        name="gaia-agent",
+        summary="REST sidecar; serves /v1/gaia/* for the daemon",
+    ),
+    "stdio": Target(
+        entry=HERE / "stdio_entry.py",
+        name="gaia-agent-stdio",
+        summary="stdio JSONL child; one query per stdin line, for the TUI",
+    ),
+}
+#: Freezing the sidecar is what every existing caller means by "freeze".
+DEFAULT_TARGET = "sidecar"
+
 # Repo root: packaging/ -> python/ -> gaia/ -> agents/ -> hub/ -> <root>
 REPO_ROOT = HERE.parents[4]
 PKG_ROOT = REPO_ROOT / "hub" / "agents" / "gaia" / "python"
@@ -183,8 +222,35 @@ def _resolve_add_data() -> list[tuple[Path, str]]:
     return add_data
 
 
-def build(onefile: bool = False, clean: bool = True) -> Path:
+def _exe_suffix() -> str:
+    return ".exe" if sys.platform == "win32" else ""
+
+
+def _clean_target_outputs(work: Path, dist: Path, name: str) -> None:
+    """Remove only THIS target's build/dist paths, never the whole tree.
+
+    The release job freezes both targets into the same ``dist/``, so wiping it
+    wholesale would delete the sibling binary that was just built.
+    """
+    shutil.rmtree(work / name, ignore_errors=True)
+    # onedir puts a directory here; onefile puts a file of the same stem.
+    shutil.rmtree(dist / name, ignore_errors=True)
+    onefile_exe = dist / (name + _exe_suffix())
+    if onefile_exe.is_file():
+        onefile_exe.unlink()
+
+
+def build(
+    onefile: bool = False, clean: bool = True, target: str = DEFAULT_TARGET
+) -> Path:
     import PyInstaller.__main__
+
+    spec = TARGETS[target]
+    if not spec.entry.is_file():
+        raise SystemExit(
+            f"freeze: the '{target}' entry is missing: {spec.entry}\n"
+            "PyInstaller has nothing to freeze. Restore the file and re-run."
+        )
 
     _verify_collect_targets()
     add_data = _resolve_add_data()
@@ -192,14 +258,14 @@ def build(onefile: bool = False, clean: bool = True) -> Path:
     work = HERE / "build"
     dist = HERE / "dist"
     if clean:
-        for d in (work, dist):
-            if d.exists():
-                shutil.rmtree(d, ignore_errors=True)
+        _clean_target_outputs(work, dist, spec.name)
+
+    print(f"freeze: target '{target}' -> {spec.name} ({spec.summary})", flush=True)
 
     args = [
-        str(ENTRY),
+        str(spec.entry),
         "--name",
-        NAME,
+        spec.name,
         "--console",
         "--noconfirm",
         "--clean",
@@ -228,8 +294,9 @@ def build(onefile: bool = False, clean: bool = True) -> Path:
     PyInstaller.__main__.run(args)
     elapsed = time.time() - t0
 
-    suffix = ".exe" if sys.platform == "win32" else ""
-    exe = dist / (NAME + suffix) if onefile else dist / NAME / (NAME + suffix)
+    name = spec.name
+    suffix = _exe_suffix()
+    exe = dist / (name + suffix) if onefile else dist / name / (name + suffix)
     print(f"\nBuild finished in {elapsed:.1f}s")
     print(f"Executable: {exe}")
     if exe.exists():
@@ -237,7 +304,7 @@ def build(onefile: bool = False, clean: bool = True) -> Path:
             size = exe.stat().st_size
         else:
             size = sum(
-                p.stat().st_size for p in (dist / NAME).rglob("*") if p.is_file()
+                p.stat().st_size for p in (dist / name).rglob("*") if p.is_file()
             )
         print(
             f"Size: {size / 1e6:.1f} MB ({'one-file exe' if onefile else 'one-dir total'})"
@@ -248,12 +315,22 @@ def build(onefile: bool = False, clean: bool = True) -> Path:
 
 
 def main(argv=None) -> int:
-    parser = argparse.ArgumentParser(description="Freeze the GAIA agent REST sidecar.")
+    parser = argparse.ArgumentParser(
+        description="Freeze a GAIA flagship agent binary.",
+        epilog="targets: "
+        + "; ".join(f"{key} = {spec.summary}" for key, spec in TARGETS.items()),
+    )
     parser.add_argument(
         "--onefile", action="store_true", help="Build a single-file executable."
     )
+    parser.add_argument(
+        "--target",
+        choices=sorted(TARGETS),
+        default=DEFAULT_TARGET,
+        help=f"Which program to freeze (default: {DEFAULT_TARGET}).",
+    )
     args = parser.parse_args(argv)
-    exe = build(onefile=args.onefile)
+    exe = build(onefile=args.onefile, target=args.target)
     return 0 if exe.exists() else 1
 
 

--- a/hub/agents/gaia/python/packaging/gen_binaries_lock.py
+++ b/hub/agents/gaia/python/packaging/gen_binaries_lock.py
@@ -7,11 +7,16 @@ by the GAIA hub R2 catalog.
 The npm ``fetch`` CLI downloads each binary and verifies its SHA-256 against this
 lock -- the lock's hashes are the integrity gate the CLI enforces on download.
 
-Schema 3.0 (two lanes): this package ships TWO executables per platform, and
-they come from DIFFERENT hub lanes at DIFFERENT versions:
+Schema 3.0: this package ships THREE components, published across TWO hub lanes
+at DIFFERENT versions:
 
-* ``sidecar`` -- the frozen Python agent, published by this package's own
-  release into ``agents/gaia/<agentVersion>/``.
+* ``sidecar`` -- the frozen Python agent speaking REST, published by this
+  package's own release into ``agents/gaia/<agentVersion>/``.
+* ``stdio`` -- the SAME agent frozen against a stdio/JSONL entry point. This is
+  the transport the terminal UI spawns as a child process; the REST sidecar
+  ignores stdin and cannot serve it. Published into the SAME
+  ``agents/gaia/<agentVersion>/`` directory, so it shares the sidecar's version
+  and base URL and differs only in filename.
 * ``tui`` -- the Go terminal UI, which is the published ``terminal-hub``
   COMPONENT (``agents/terminal-hub/<tuiVersion>/``), built and published by the
   core release. This package consumes it; it does not build or republish it, so
@@ -25,6 +30,11 @@ Schema 2.0's single top-level ``baseUrl`` could not express two lanes::
       "agentVersion": "0.1.0",
       "components": {
         "sidecar": {
+          "componentVersion": "0.1.0",
+          "baseUrl": "https://hub.amd-gaia.ai/agents/gaia/0.1.0",
+          "platforms": {"win32-x64": {filename, executable, sha256, size}, ...}
+        },
+        "stdio": {
           "componentVersion": "0.1.0",
           "baseUrl": "https://hub.amd-gaia.ai/agents/gaia/0.1.0",
           "platforms": {"win32-x64": {filename, executable, sha256, size}, ...}
@@ -50,15 +60,20 @@ single-platform local run does not wipe the others; the CI release passes every
 platform's meta and regenerates the whole lock.
 
 Platform keys are the npm side's ``${process.platform}-${process.arch}``
-(``win32-x64``), for both components. The terminal-hub lane spells its Windows
+(``win32-x64``), for every component. The terminal-hub lane spells its Windows
 artifacts ``win-x64`` / ``win-arm64``; that difference is carried by the entry's
 ``filename``, and ``TUI_ARTIFACT_NAMES`` below is the authority both sides are
 checked against -- a meta whose tui filename does not match is rejected, because
 nothing else in this pipeline would catch it before a user hits a 404.
 
+The gaia-lane names are checked the same way for a different reason: ``sidecar``
+and ``stdio`` are published into ONE directory, so swapping their filenames
+would still hash-verify at publish time and quietly hand the installer the wrong
+transport.
+
 NO silent fallback: an unknown component, an unsupported platform for that
-component, an unexpected tui artifact name, a missing/placeholder sha256, a base
-URL that is not http(s), or a base URL whose trailing segment disagrees with its
+component, an unexpected artifact name, a missing/placeholder sha256, a base URL
+that is not http(s), or a base URL whose trailing segment disagrees with its
 component's version raises loudly.
 """
 
@@ -69,11 +84,16 @@ import json
 import re
 from pathlib import Path
 
-# The sidecar is frozen by PyInstaller on the four platforms GAIA ships wheels
-# for; the Go TUI cross-compiles to two more.
+# Both frozen transports come off the same PyInstaller legs, on the four
+# platforms GAIA ships wheels for; the Go TUI cross-compiles to two more.
 SIDECAR_PLATFORMS = {"win32-x64", "darwin-arm64", "darwin-x64", "linux-x64"}
+STDIO_PLATFORMS = SIDECAR_PLATFORMS
 TUI_PLATFORMS = SIDECAR_PLATFORMS | {"linux-arm64", "win32-arm64"}
-COMPONENTS = {"sidecar": SIDECAR_PLATFORMS, "tui": TUI_PLATFORMS}
+COMPONENTS = {
+    "sidecar": SIDECAR_PLATFORMS,
+    "stdio": STDIO_PLATFORMS,
+    "tui": TUI_PLATFORMS,
+}
 
 # npm platform key -> the artifact terminal-hub publishes under
 # agents/terminal-hub/<version>/. Mirrors TUI_ARTIFACT_NAMES in
@@ -86,6 +106,27 @@ TUI_ARTIFACT_NAMES = {
     "darwin-x64": "gaia-darwin-x64",
     "linux-x64": "gaia-linux-x64",
     "linux-arm64": "gaia-linux-arm64",
+}
+
+# npm platform key -> the artifact THIS package's release publishes under
+# agents/gaia/<agentVersion>/. Mirrors the freeze matrix in
+# .github/workflows/release_agent_gaia.yml.
+SIDECAR_ARTIFACT_NAMES = {
+    "win32-x64": "gaia-agent-win32-x64.exe",
+    "darwin-arm64": "gaia-agent-darwin-arm64",
+    "darwin-x64": "gaia-agent-darwin-x64",
+    "linux-x64": "gaia-agent-linux-x64",
+}
+STDIO_ARTIFACT_NAMES = {
+    "win32-x64": "gaia-agent-stdio-win32-x64.exe",
+    "darwin-arm64": "gaia-agent-stdio-darwin-arm64",
+    "darwin-x64": "gaia-agent-stdio-darwin-x64",
+    "linux-x64": "gaia-agent-stdio-linux-x64",
+}
+ARTIFACT_NAMES = {
+    "sidecar": SIDECAR_ARTIFACT_NAMES,
+    "stdio": STDIO_ARTIFACT_NAMES,
+    "tui": TUI_ARTIFACT_NAMES,
 }
 
 SCHEMA_VERSION = "3.0"
@@ -139,6 +180,23 @@ def _load_metas(paths: list[Path]) -> dict[str, dict[str, dict]]:
                     "TUI_ARTIFACT_NAMES here AND in "
                     "hub/agents/gaia/npm/src/platform.ts."
                 )
+            # sidecar and stdio share one hub directory, so a crossed filename
+            # publishes and hash-verifies cleanly and only shows up as the TUI
+            # failing to speak to a REST binary (or vice versa) on a user's box.
+            if (
+                component in ("sidecar", "stdio")
+                and rec.get("filename") != ARTIFACT_NAMES[component][plat]
+            ):
+                raise SystemExit(
+                    f"error: {p} {component}/{plat} names artifact "
+                    f"{rec.get('filename')!r}, but this package publishes "
+                    f"{ARTIFACT_NAMES[component][plat]!r} for that platform. The "
+                    "sidecar and stdio transports live in the same "
+                    "agents/gaia/<version>/ directory, so a swapped name would "
+                    "hash-verify at publish time and hand the installer the wrong "
+                    "binary. Fix the meta, or update ARTIFACT_NAMES here AND the "
+                    "freeze matrix in .github/workflows/release_agent_gaia.yml."
+                )
             try:
                 merged.setdefault(component, {})[plat] = {
                     "filename": rec["filename"],
@@ -173,16 +231,18 @@ def _checked_base_url(raw: str, version: str, flag: str) -> str:
 
 def main(argv=None) -> int:
     parser = argparse.ArgumentParser(
-        description="Regenerate the two-lane binaries.lock.json (schema 3.0)."
+        description="Regenerate the per-component binaries.lock.json (schema 3.0)."
     )
     parser.add_argument(
-        "--version", required=True, help="Agent (sidecar) version, e.g. 0.1.0."
+        "--version",
+        required=True,
+        help="Agent version — the sidecar's and the stdio binary's, e.g. 0.1.0.",
     )
     parser.add_argument(
         "--sidecar-base-url",
         required=True,
-        help="Public directory the sidecar's filenames are joined onto, e.g. "
-        "https://hub.amd-gaia.ai/agents/gaia/0.1.0",
+        help="Public directory the gaia-lane filenames (sidecar AND stdio) are "
+        "joined onto, e.g. https://hub.amd-gaia.ai/agents/gaia/0.1.0",
     )
     parser.add_argument(
         "--tui-version",
@@ -209,13 +269,15 @@ def main(argv=None) -> int:
     )
     args = parser.parse_args(argv)
 
+    gaia_lane_base = _checked_base_url(
+        args.sidecar_base_url, args.version, "--sidecar-base-url"
+    )
     lanes = {
-        "sidecar": (
-            args.version,
-            _checked_base_url(
-                args.sidecar_base_url, args.version, "--sidecar-base-url"
-            ),
-        ),
+        # sidecar and stdio are two freezes of the same agent published into one
+        # agents/gaia/<version>/ directory, so they share a version and base URL
+        # by construction rather than by two flags that could drift apart.
+        "sidecar": (args.version, gaia_lane_base),
+        "stdio": (args.version, gaia_lane_base),
         "tui": (
             args.tui_version,
             _checked_base_url(args.tui_base_url, args.tui_version, "--tui-base-url"),
@@ -278,6 +340,18 @@ def main(argv=None) -> int:
                     f"{rec.get('filename')!r}, but the terminal-hub lane publishes "
                     f"{TUI_ARTIFACT_NAMES[plat]!r}. This entry had no meta this run, "
                     "so it is a stale committed value -- fix it in the lock."
+                )
+            if (
+                component in ("sidecar", "stdio")
+                and rec.get("filename") != ARTIFACT_NAMES[component][plat]
+            ):
+                raise SystemExit(
+                    f"error: {args.lock} {component}/{plat} names artifact "
+                    f"{rec.get('filename')!r}, but this package publishes "
+                    f"{ARTIFACT_NAMES[component][plat]!r}. This entry had no meta "
+                    "this run, so it is a stale committed value -- fix it in the "
+                    "lock. The two transports share a hub directory, so nothing "
+                    "downstream would catch the swap."
                 )
 
     args.lock.write_text(json.dumps(lock, indent=2) + "\n", encoding="utf-8")

--- a/hub/agents/gaia/python/packaging/smoke_test.py
+++ b/hub/agents/gaia/python/packaging/smoke_test.py
@@ -1,10 +1,12 @@
 # Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
 # SPDX-License-Identifier: MIT
 """
-No-Python smoke test for the frozen GAIA flagship agent sidecar.
+No-Python smoke test for the frozen GAIA flagship agent binaries.
 
-Proves the FROZEN BINARY (not ``python -m ...``) boots and serves the sidecar
-contract:
+Two DIFFERENT programs freeze out of this package and each has its own wire, so
+each has its own mode. ``--mode`` picks which; the default is ``sidecar``.
+
+``--mode sidecar`` -- the REST surface the daemon supervises:
 
   1. Launch the binary as a subprocess -- binary only, no interpreter available
      to it.
@@ -15,7 +17,39 @@ contract:
      attach, so an empty one is a contract break, not cosmetic.
   5. ``GET /openapi.json`` -> contains ``/v1/gaia/query`` and ``/v1/gaia/init``.
 
-This harness runs under Python (it is a test driver), but the SERVER under test
+``--mode stdio`` -- the child the TUI spawns. This mode exists because the two
+binaries are indistinguishable from the outside: an HTTP sidecar frozen under
+the stdio name boots happily, passes any "did it start?" check, and then feeds
+uvicorn's startup log to a JSON line scanner (#3062). So the assertions are all
+about the WIRE:
+
+  1. Launch the binary BARE -- no argv at all, exactly as the TUI spawns the
+     flagship (``seedAgents`` in ``tui/internal/catalog/catalog.go`` declares no
+     ``BinaryArgs``). A binary that needs ``--host``/``--port`` to do anything is
+     the sidecar.
+  2. The first stdout line must be the startup model-state ping: a canonical
+     ``status`` event naming the model the agent resolved
+     (``gaia_agent/stdio.py`` ``_model_state_event``, written by ``main`` before
+     stdin is read). Reaching it proves the frozen binary constructed the whole
+     ``GaiaAgent`` -- every hidden import, every bundled data file.
+  3. Write ``{"gaia_query": "/model"}`` and expect exactly one terminal ``final``
+     event back. ``/model`` is intercepted before the LLM ever sees it
+     (``run_model_command``), so this is a real round trip that needs NO model
+     and NO Lemonade -- verified against a dead Lemonade URL, which the ping
+     reports as ``lemonade_reachable: false`` and otherwise ignores.
+  4. Nothing but JSON objects on stdout -- stdout IS the wire, and anything else
+     there renders in the TUI as an unreadable event.
+  5. Nothing listening on the sidecar's port, re-checked every second while
+     waiting for (2). This is the check that actually catches a mis-frozen
+     binary: uvicorn logs to STDERR, so the sidecar under the stdio name is not
+     noisy on stdout -- it is SILENT there, and silence alone would only fail at
+     the end of the startup window.
+
+It does NOT prove the agent can answer a question: no inference runs, so a model
+that loads but produces garbage passes this. That is deliberate -- requiring a
+model server would make the release gate depend on a runner that has one.
+
+This harness runs under Python (it is a test driver), but the program under test
 is the frozen binary. Uses only the stdlib so it has no install requirements.
 
 Exit code 0 = PASS, non-zero = FAIL. Verbose ``[smoke]`` logging throughout.
@@ -25,9 +59,11 @@ from __future__ import annotations
 
 import argparse
 import json
+import queue
 import socket
 import subprocess
 import sys
+import threading
 import time
 import urllib.error
 import urllib.request
@@ -38,6 +74,36 @@ PORT = 8142  # 8141 is the gaia sidecar's runtime port; 8131 is email. NEVER 400
 BASE = f"http://{HOST}:{PORT}"
 
 REQUIRED_PATHS = {"/v1/gaia/query", "/v1/gaia/init"}
+
+# The sidecar's default bind port. The stdio binary must never listen anywhere,
+# and this is the one port a mis-frozen stdio binary would land on.
+SIDECAR_DEFAULT_PORT = 8141
+
+# Must match gaia_agent.stdio.QUERY_KEY -- the agent only unwraps an object
+# carrying exactly this key, and a bare line would still be read as a query, so
+# using the wrapper is what actually exercises the host's half of the contract.
+QUERY_KEY = "gaia_query"
+
+# `/model` with no argument lists models and returns; it never reaches
+# process_query. See gaia_agent.stdio.is_model_command / run_model_command.
+MODEL_COMMAND = "/model"
+
+# Agent construction is eager (embeddings, two FAISS rebuilds, scratchpad DB,
+# filesystem index) -- ~21s from source on a warm dev box, and a onefile binary
+# must unpack itself before any of that starts on a cold CI runner.
+STDIO_STARTUP_DEADLINE_S = 300.0
+# The round trip itself is local bookkeeping: ~2s observed from source.
+STDIO_TURN_DEADLINE_S = 90.0
+
+
+# The agent's events carry non-ASCII (arrows, box drawing). The Windows runner's
+# console is cp1252, so printing one raises UnicodeEncodeError and the smoke test
+# dies mid-run looking like a binary failure. Reconfigure rather than escape the
+# text, so every log line is safe and not just the ones we remembered.
+if hasattr(sys.stdout, "reconfigure"):
+    sys.stdout.reconfigure(encoding="utf-8", errors="replace")
+if hasattr(sys.stderr, "reconfigure"):
+    sys.stderr.reconfigure(encoding="utf-8", errors="replace")
 
 
 def log(msg: str) -> None:
@@ -147,27 +213,295 @@ def check_openapi() -> bool:
     return True
 
 
-def main(argv=None) -> int:
-    parser = argparse.ArgumentParser(
-        description="Smoke-test the frozen GAIA agent sidecar."
-    )
-    parser.add_argument(
-        "binary", help="Path to the frozen gaia-agent executable to test."
-    )
-    args = parser.parse_args(argv)
+class StdioContractBreak(Exception):
+    """The frozen binary did not speak the TUI's stdin/stdout contract."""
 
-    binary = Path(args.binary).resolve()
-    if not binary.exists():
-        log(f"FAIL: binary not found: {binary}")
-        return 2
 
-    # Preflight: refuse if the port is already bound -- otherwise we would
-    # health-check a stale server and report a false PASS.
+def _port_is_open(port: int) -> bool:
     with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
         s.settimeout(2.0)
-        if s.connect_ex((HOST, PORT)) == 0:
-            log(f"FAIL: port {PORT} already in use -- kill the stale server first.")
-            return 2
+        return s.connect_ex((HOST, port)) == 0
+
+
+def _pump(stream, on_line, label: str) -> None:
+    """Read *stream* line by line on a daemon thread, ending with a None sentinel.
+
+    A thread per pipe rather than a timed read: there is no portable way to put
+    a deadline on a pipe read (``select`` does not take Windows pipes), and a
+    full stderr buffer would deadlock the child.
+    """
+
+    def run() -> None:
+        try:
+            while True:
+                line = stream.readline()
+                if not line:
+                    break
+                on_line(line.rstrip("\r\n"))
+        except (OSError, ValueError) as exc:
+            # Expected when teardown closes the pipe under us; still logged,
+            # because a truncated read otherwise looks like a clean end of output.
+            log(f"{label} reader stopped: {exc}")
+        finally:
+            on_line(None)
+
+    threading.Thread(target=run, daemon=True, name=label).start()
+
+
+class _Deadline:
+    """One time budget shared across several reads, so a multi-event wait cannot
+    restart its clock on every event it skips."""
+
+    def __init__(self, budget_s: float) -> None:
+        self.budget_s = budget_s
+        self.end = time.time() + budget_s
+
+    def remaining(self) -> float:
+        return self.end - time.time()
+
+
+def _next_event(
+    events: "queue.Queue",
+    proc: subprocess.Popen,
+    deadline: _Deadline,
+    what: str,
+    guard=None,
+) -> dict:
+    """Next JSON object off stdout, or raise ``StdioContractBreak``.
+
+    *guard* is re-checked on every idle second so a binary that fails by going
+    silent (an HTTP server, which never answers stdin at all) is caught in
+    seconds instead of at the end of the startup window.
+    """
+    while True:
+        remaining = deadline.remaining()
+        if remaining <= 0:
+            raise StdioContractBreak(
+                f"no {what} within {deadline.budget_s:.0f}s. The binary wrote no "
+                "usable JSON to stdout -- which is what an HTTP server frozen "
+                "under the stdio name does: it binds a port and never reads stdin."
+            )
+        try:
+            line = events.get(timeout=min(remaining, 1.0))
+        except queue.Empty:
+            if guard is not None:
+                guard()
+            continue
+        if line is None:
+            raise StdioContractBreak(
+                f"stdout closed before {what} arrived (process exit code: "
+                f"{proc.poll()})"
+            )
+        if not line.strip():
+            continue
+        try:
+            event = json.loads(line)
+        except ValueError as exc:
+            raise StdioContractBreak(
+                f"stdout carried a line that is not JSON ({exc}): {line[:200]!r}. "
+                "stdout IS the wire -- the TUI parses every line as an event, so "
+                "anything else there renders as an unreadable-event warning."
+            ) from exc
+        if not isinstance(event, dict):
+            raise StdioContractBreak(
+                f"stdout carried JSON that is not an object: {line[:200]!r}"
+            )
+        log(f"<- {json.dumps(event, ensure_ascii=False)[:300]}")
+        return event
+
+
+def check_startup_ping(event: dict) -> None:
+    """The first line must be the model-state ping ``main`` writes at startup.
+
+    Reaching it means the frozen binary built the whole ``GaiaAgent``, so this
+    is also the check that catches a hidden import PyInstaller missed -- that
+    failure arrives here as a terminal ``error`` event instead.
+    """
+    kind = event.get("type")
+    if kind == "error":
+        raise StdioContractBreak(
+            "the binary's first event is a terminal error, so agent construction "
+            f"failed inside the frozen binary: {event.get('detail') or event}"
+        )
+    if kind != "status":
+        raise StdioContractBreak(
+            f"first event is {kind!r}, expected the 'status' model-state ping "
+            "(gaia_agent/stdio.py::_model_state_event)"
+        )
+    model_id = event.get("model_id")
+    if not isinstance(model_id, str) or not model_id:
+        raise StdioContractBreak(
+            "the startup ping carries no model_id, so the TUI header has nothing "
+            f"to name: {event}"
+        )
+    backend = event.get("model_backend")
+    if backend not in ("lemonade", "claude"):
+        raise StdioContractBreak(
+            f"the startup ping's model_backend is {backend!r}, expected "
+            "'lemonade' or 'claude'"
+        )
+    # Reported, not asserted: this test deliberately does not require a model
+    # server, and the ping is designed to say so rather than fail.
+    log(
+        f"startup ping PASS -- model {model_id} on {backend} "
+        f"(lemonade_reachable={event.get('lemonade_reachable')})"
+    )
+
+
+def check_model_round_trip(proc: subprocess.Popen, events: "queue.Queue") -> None:
+    """Send ``/model`` and require exactly one terminal ``final`` back.
+
+    ``/model`` is the only turn that needs no inference: ``dispatch_query``
+    routes it to ``run_model_command`` before ``process_query`` is reached, so a
+    PASS here does not imply a working model -- only a working wire.
+    """
+    line = json.dumps({QUERY_KEY: MODEL_COMMAND})
+    log(f"-> {line}")
+    try:
+        proc.stdin.write(line + "\n")
+        proc.stdin.flush()
+    except OSError as exc:
+        raise StdioContractBreak(
+            f"could not write a query to the binary's stdin: {exc}"
+        ) from exc
+
+    deadline = _Deadline(STDIO_TURN_DEADLINE_S)
+    while True:
+        event = _next_event(
+            events, proc, deadline, f"a terminal event for {MODEL_COMMAND}"
+        )
+        kind = event.get("type")
+        if kind == "error":
+            raise StdioContractBreak(
+                f"{MODEL_COMMAND} answered with an error event: "
+                f"{event.get('detail') or event}"
+            )
+        if kind != "final":
+            # status/token/tool_* before the terminal event are legal; the turn
+            # is only over when exactly one terminal event lands.
+            continue
+        answer = event.get("answer")
+        if not isinstance(answer, str) or not answer.strip():
+            raise StdioContractBreak(
+                f"{MODEL_COMMAND} returned an empty final event: {event}"
+            )
+        log(f"round-trip PASS -- final answer, {len(answer)} chars")
+        return
+
+
+def assert_no_http_listener() -> None:
+    """The stdio binary must not be listening anywhere.
+
+    The whole point of the separate target: the sidecar frozen under the stdio
+    name boots fine and binds this port, and every "did it start?" check passes
+    while the TUI reads uvicorn's log as JSON (#3062).
+    """
+    if _port_is_open(SIDECAR_DEFAULT_PORT):
+        raise StdioContractBreak(
+            f"something is listening on {HOST}:{SIDECAR_DEFAULT_PORT} -- this "
+            "binary started an HTTP server, so it is the REST sidecar, not the "
+            "stdio child the TUI spawns."
+        )
+
+
+def run_stdio(binary: Path) -> int:
+    # Preflight on the sidecar's port: a server already sitting there would make
+    # the no-listener check meaningless, and we cannot tell it from our own.
+    if _port_is_open(SIDECAR_DEFAULT_PORT):
+        log(
+            f"FAIL: port {SIDECAR_DEFAULT_PORT} is already in use -- kill the "
+            "stale sidecar first, or the 'binary started no HTTP server' check "
+            "cannot mean anything."
+        )
+        return 2
+
+    # Bare argv: exactly how the TUI spawns the flagship (catalog.go seedAgents
+    # declares no BinaryArgs). stderr stays SEPARATE -- merging it would put
+    # tracebacks on the wire and mask the very thing this mode checks.
+    cmd = [str(binary)]
+    log(f"launching frozen binary: {binary}")
+    log(f"command: {' '.join(cmd)} (bare, as the TUI spawns it)")
+    t0 = time.time()
+    proc = subprocess.Popen(
+        cmd,
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        # JSON is UTF-8 by definition. Without this the reader decodes with the
+        # locale codec, and on the Windows leg cp1252 dies on the first non-ASCII
+        # byte the agent prints -- reported as "stdout closed", not as a decode
+        # error, so it reads like a broken binary.
+        encoding="utf-8",
+        errors="replace",
+        bufsize=1,
+    )
+
+    events: "queue.Queue" = queue.Queue()
+    errors: list = []
+
+    def keep_stderr(line) -> None:
+        if line is not None:  # the pump's EOF sentinel
+            errors.append(line)
+
+    _pump(proc.stdout, events.put, "stdout")
+    _pump(proc.stderr, keep_stderr, "stderr")
+
+    results: dict[str, bool] = {}
+    try:
+        try:
+            log(
+                f"waiting up to {STDIO_STARTUP_DEADLINE_S:.0f}s for the startup "
+                f"ping (watching {HOST}:{SIDECAR_DEFAULT_PORT} meanwhile)"
+            )
+            ping = _next_event(
+                events,
+                proc,
+                _Deadline(STDIO_STARTUP_DEADLINE_S),
+                "a startup event",
+                guard=assert_no_http_listener,
+            )
+            log(f"time to first event: {time.time() - t0:.1f}s")
+            check_startup_ping(ping)
+            results["startup_ping"] = True
+
+            assert_no_http_listener()
+            log(f"no-listener PASS -- nothing bound on {HOST}:{SIDECAR_DEFAULT_PORT}")
+            results["no_http_listener"] = True
+
+            check_model_round_trip(proc, events)
+            results["model_round_trip"] = True
+        except StdioContractBreak as exc:
+            log(f"FAIL: {exc}")
+    finally:
+        log("closing stdin (how a well-behaved agent is asked to exit)")
+        try:
+            proc.stdin.close()
+        except OSError as exc:
+            log(f"stdin was already gone: {exc}")
+        try:
+            proc.wait(timeout=30)
+            log(f"exited on stdin close with code {proc.returncode}")
+        except subprocess.TimeoutExpired:
+            # Not a failure: the TUI force-kills after its own grace window
+            # (SubprocessClient.Close), so a slow exit is tolerated by design.
+            log("did not exit within 30s of stdin close -- killing the tree")
+        _kill_tree(proc)
+        if errors:
+            log("stderr tail:\n" + "\n".join(errors[-40:]))
+
+    log(f"results: {results}")
+    ok = len(results) == 3 and all(results.values())
+    log("VERDICT: PASS" if ok else "VERDICT: FAIL")
+    return 0 if ok else 1
+
+
+def run_sidecar(binary: Path) -> int:
+    # Preflight: refuse if the port is already bound -- otherwise we would
+    # health-check a stale server and report a false PASS.
+    if _port_is_open(PORT):
+        log(f"FAIL: port {PORT} already in use -- kill the stale server first.")
+        return 2
 
     cmd = [str(binary), "--host", HOST, "--port", str(PORT)]
     log(f"launching frozen binary: {binary}")
@@ -178,6 +512,10 @@ def main(argv=None) -> int:
         stdout=subprocess.PIPE,
         stderr=subprocess.STDOUT,
         text=True,
+        # Same reason as the stdio mode: the locale codec cannot read the
+        # agent's UTF-8 log output on the Windows leg.
+        encoding="utf-8",
+        errors="replace",
         bufsize=1,
     )
 
@@ -199,6 +537,33 @@ def main(argv=None) -> int:
     ok = len(results) == 3 and all(results.values())
     log("VERDICT: PASS" if ok else "VERDICT: FAIL")
     return 0 if ok else 1
+
+
+MODES = {"sidecar": run_sidecar, "stdio": run_stdio}
+
+
+def main(argv=None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Smoke-test a frozen GAIA flagship agent binary."
+    )
+    parser.add_argument("binary", help="Path to the frozen executable to test.")
+    parser.add_argument(
+        "--mode",
+        choices=sorted(MODES),
+        default="sidecar",
+        help="Which wire to test: 'sidecar' probes /health, /version and "
+        "/openapi.json over HTTP; 'stdio' spawns the binary bare and speaks the "
+        "TUI's stdin/stdout JSONL contract (default: sidecar).",
+    )
+    args = parser.parse_args(argv)
+
+    binary = Path(args.binary).resolve()
+    if not binary.exists():
+        log(f"FAIL: binary not found: {binary}")
+        return 2
+
+    log(f"mode: {args.mode}")
+    return MODES[args.mode](binary)
 
 
 if __name__ == "__main__":

--- a/hub/agents/gaia/python/packaging/stdio_entry.py
+++ b/hub/agents/gaia/python/packaging/stdio_entry.py
@@ -1,0 +1,28 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""Frozen-binary entrypoint for the GAIA flagship agent's stdio transport.
+
+A thin wrapper around :mod:`gaia_agent.stdio`, which is the single source of
+truth for the wire. It exists for the same reason ``packaging/server.py`` does:
+PyInstaller freezes a *file*, and the stdio transport is published as a console
+script (``gaia-agent = "gaia_agent.stdio:main"`` in ``pyproject.toml``), which
+has no file to point at. This module is that file.
+
+Named ``stdio_entry`` rather than ``stdio``: PyInstaller puts the entry script's
+directory on ``sys.path``, so a top-level ``stdio`` module would sit ahead of
+``gaia_agent.stdio`` for anything importing the bare name.
+
+The binary this produces is what the TUI spawns as a child process — bare argv,
+one query per stdin line, canonical events back as JSON lines on stdout (see
+``client.SubprocessClient`` on the Go side). It is NOT the REST sidecar; freezing
+the wrong one feeds uvicorn's startup log to a JSON line scanner (#3062).
+"""
+
+from __future__ import annotations
+
+import sys
+
+from gaia_agent.stdio import main  # noqa: F401  (re-exported for the freeze)
+
+if __name__ == "__main__":  # pragma: no cover
+    sys.exit(main())

--- a/installer/scripts/install.ps1
+++ b/installer/scripts/install.ps1
@@ -15,6 +15,22 @@ $GAIA_HUB_BASE_URL = if ($env:GAIA_HUB_BASE_URL) { $env:GAIA_HUB_BASE_URL } else
 $GAIA_HUB_BASE_URL = $GAIA_HUB_BASE_URL.TrimEnd('/')
 $TERMINAL_HUB_ID = "terminal-hub"
 
+# The terminal hub spawns `gaia-agent` as a child process, so installing the hub
+# alone ships a front end with nothing behind it - and the TUI's readiness gate
+# halts on the missing binary telling the user to re-run this installer.
+$FLAGSHIP_AGENT_ID = "gaia"
+
+# The STDIO build, not the REST sidecar. Both are published under agents/gaia/
+# and both would install as `gaia-agent.exe`, but only this one speaks the
+# newline-delimited JSON the TUI writes to the child's stdin - the sidecar just
+# binds a port and ignores it (#3062).
+$FLAGSHIP_ARTIFACT_PREFIX = "gaia-agent-stdio"
+
+# Terminal-hub platform key -> the flagship's npm-style key. Mirrors
+# PLATFORM_KEYS in installer/tui/fetch_sidecar.py. win-arm64 is absent on
+# purpose: the terminal hub builds there and the flagship does not.
+$FLAGSHIP_PLATFORM_KEYS = @{ "win-x64" = "win32-x64" }
+
 # Network limit: a black-holed connection must fail, not hang silently.
 $HTTP_TIMEOUT_SEC = 900
 
@@ -146,6 +162,37 @@ function Install-Gaia {
     Write-Success "GAIA package installed successfully"
 }
 
+# Refuse a platform the flagship has no build for. Loud, never skipped: the
+# terminal hub builds for win-arm64 and the flagship does not, so continuing
+# would install the exact dead end this installer exists to prevent.
+function Show-UnsupportedPlatformError {
+    param([Parameter(Mandatory = $true)][string]$Platform)
+
+    Write-Error "The GAIA agent publishes no build for $Platform."
+    Write-Host "  The terminal hub runs here but has no agent to run, so GAIA would" -ForegroundColor $COLOR_YELLOW
+    Write-Host "  install a front end that cannot start. Nothing has been installed." -ForegroundColor $COLOR_YELLOW
+    Write-Host "  Published targets: $($FLAGSHIP_PLATFORM_KEYS.Keys -join ', ')" -ForegroundColor $COLOR_YELLOW
+    Write-Host "  Fix:  build the agent yourself - it needs a Python 3.12 venv with" -ForegroundColor $COLOR_YELLOW
+    Write-Host "        pyinstaller, and the binary has to land on your PATH as" -ForegroundColor $COLOR_YELLOW
+    Write-Host "        gaia-agent.exe:" -ForegroundColor $COLOR_YELLOW
+    Write-Host "          git clone https://github.com/amd/gaia; cd gaia" -ForegroundColor $COLOR_YELLOW
+    Write-Host "          python hub\agents\$FLAGSHIP_AGENT_ID\python\packaging\freeze.py --onefile --target stdio" -ForegroundColor $COLOR_YELLOW
+    Write-Host "          copy hub\agents\$FLAGSHIP_AGENT_ID\python\packaging\dist\gaia-agent-stdio.exe $GAIA_BIN\gaia-agent.exe" -ForegroundColor $COLOR_YELLOW
+    Write-Host "  Look: $GAIA_HUB_BASE_URL/agents/$FLAGSHIP_AGENT_ID/manifest.json" -ForegroundColor $COLOR_YELLOW
+    Write-Host "  Track: https://github.com/amd/gaia/issues" -ForegroundColor $COLOR_YELLOW
+    exit 1
+}
+
+# Before uv, Python and the venv: on a platform with no agent build this install
+# can only end in failure, and finding that out after a multi-minute download
+# leaves a half-install behind every single time.
+function Assert-FlagshipPlatform {
+    $platform = Get-TerminalHubPlatform
+    if ($platform -and -not $FLAGSHIP_PLATFORM_KEYS[$platform]) {
+        Show-UnsupportedPlatformError $platform
+    }
+}
+
 function Get-TerminalHubPlatform {
     # The Agent Hub platform keys are what release_components.yml publishes
     # under, so they are the authority - not GOARCH ("amd64").
@@ -157,32 +204,34 @@ function Get-TerminalHubPlatform {
     }
 }
 
-# A missing terminal hub fails the install - it is the advertised entry point.
-function Install-Tui {
-    Write-Step "Installing the GAIA terminal hub"
-
-    $platform = Get-TerminalHubPlatform
-    if (-not $platform) {
-        $arch = if ($env:PROCESSOR_ARCHITEW6432) { $env:PROCESSOR_ARCHITEW6432 } else { $env:PROCESSOR_ARCHITECTURE }
-        Write-Error "No terminal hub build for processor architecture '$arch'."
-        Write-Host "  Published targets: win-x64, win-arm64, linux-x64, linux-arm64," -ForegroundColor $COLOR_YELLOW
-        Write-Host "  darwin-x64, darwin-arm64. See $GAIA_HUB_BASE_URL/index.json" -ForegroundColor $COLOR_YELLOW
-        exit 1
-    }
-    $filename = "gaia-$platform.exe"
+# Download one Agent Hub artifact, verify it against the SHA-256 the manifest
+# publishes, and install it into $GAIA_BIN.
+#
+# Both binaries go through here so their verification can never drift apart.
+# Every failure path exits: there is no branch that returns having installed
+# nothing.
+function Install-HubBinary {
+    param(
+        [Parameter(Mandatory = $true)][string]$AgentId,
+        [Parameter(Mandatory = $true)][string]$Platform,
+        [Parameter(Mandatory = $true)][string]$Filename,
+        [Parameter(Mandatory = $true)][string]$InstallAs,
+        [Parameter(Mandatory = $true)][string]$Label,
+        [Parameter(Mandatory = $true)][string]$Hint
+    )
 
     # The manifest is the only source for the version, the per-platform
     # filename, and the Worker-computed SHA-256.
-    $manifestUrl = "$GAIA_HUB_BASE_URL/agents/$TERMINAL_HUB_ID/manifest.json"
+    $manifestUrl = "$GAIA_HUB_BASE_URL/agents/$AgentId/manifest.json"
     try {
         $manifest = Invoke-RestMethod -Uri $manifestUrl -UseBasicParsing -TimeoutSec $HTTP_TIMEOUT_SEC
     }
     catch {
-        Write-Error "Could not fetch the terminal hub manifest: $_"
+        Write-Error "Could not fetch the $Label manifest: $_"
         Write-Host "  URL:  $manifestUrl" -ForegroundColor $COLOR_YELLOW
         Write-Host "  Fix:  check your network, then retry. If the component is not yet" -ForegroundColor $COLOR_YELLOW
         Write-Host "        published for this release, build from source:" -ForegroundColor $COLOR_YELLOW
-        Write-Host "          git clone https://github.com/amd/gaia; cd gaia\tui; make build" -ForegroundColor $COLOR_YELLOW
+        Write-Host "          $Hint" -ForegroundColor $COLOR_YELLOW
         Write-Host "  Look: $GAIA_HUB_BASE_URL/index.json lists what the hub serves." -ForegroundColor $COLOR_YELLOW
         exit 1
     }
@@ -205,31 +254,31 @@ function Install-Tui {
         $artifacts = if ($entry.artifact) { @($entry.artifact) } else { @() }
     }
 
-    $match = $artifacts | Where-Object { $_.filename -eq $filename } | Select-Object -First 1
+    $match = $artifacts | Where-Object { $_.filename -eq $Filename } | Select-Object -First 1
     if (-not $match) {
         $listed = ($artifacts | ForEach-Object { $_.filename } | Sort-Object) -join ", "
         if (-not $listed) { $listed = "none" }
-        Write-Error "Terminal hub $version publishes no $filename (it publishes: $listed)."
+        Write-Error "$Label $version publishes no $Filename (it publishes: $listed)."
         Write-Host "  Fix:  if your platform is genuinely unpublished, build from source:" -ForegroundColor $COLOR_YELLOW
-        Write-Host "          git clone https://github.com/amd/gaia; cd gaia\tui; make build" -ForegroundColor $COLOR_YELLOW
+        Write-Host "          $Hint" -ForegroundColor $COLOR_YELLOW
         Write-Host "  Look: $manifestUrl" -ForegroundColor $COLOR_YELLOW
         exit 1
     }
 
     $want = $match.sha256
     if (-not $want) {
-        Write-Error "Terminal hub $version publishes $filename with no SHA-256 - refusing to install unverified."
+        Write-Error "$Label $version publishes $Filename with no SHA-256 - refusing to install unverified."
         Write-Host "  Look: $manifestUrl" -ForegroundColor $COLOR_YELLOW
         exit 1
     }
 
-    $binaryUrl = "$GAIA_HUB_BASE_URL/agents/$TERMINAL_HUB_ID/$version/$filename"
-    $tmpDir = Join-Path $env:TEMP ("gaia-tui-" + [guid]::NewGuid().ToString("N"))
+    $binaryUrl = "$GAIA_HUB_BASE_URL/agents/$AgentId/$version/$Filename"
+    $tmpDir = Join-Path $env:TEMP ("gaia-install-" + [guid]::NewGuid().ToString("N"))
     New-Item -ItemType Directory -Path $tmpDir -Force | Out-Null
-    $tmpFile = Join-Path $tmpDir $filename
+    $tmpFile = Join-Path $tmpDir $Filename
 
     try {
-        Write-Step "Downloading terminal hub $version for $platform"
+        Write-Step "Downloading $Label $version for $Platform"
         try {
             $prevProgress = $ProgressPreference
             $ProgressPreference = "SilentlyContinue"
@@ -241,7 +290,7 @@ function Install-Tui {
             }
         }
         catch {
-            Write-Error "Could not download the terminal hub binary: $_"
+            Write-Error "Could not download the $Label binary: $_"
             Write-Host "  URL:  $binaryUrl" -ForegroundColor $COLOR_YELLOW
             Write-Host "  Fix:  check your network and retry." -ForegroundColor $COLOR_YELLOW
             Write-Host "  Look: $manifestUrl lists what is published for $version." -ForegroundColor $COLOR_YELLOW
@@ -251,7 +300,7 @@ function Install-Tui {
         # No checksum, no install.
         $got = (Get-FileHash -Path $tmpFile -Algorithm SHA256).Hash
         if ($got -ne $want.ToUpper()) {
-            Write-Error "Checksum mismatch for $filename - refusing to install."
+            Write-Error "Checksum mismatch for $Filename - refusing to install."
             Write-Host "  expected $($want.ToUpper())" -ForegroundColor $COLOR_YELLOW
             Write-Host "  got      $got" -ForegroundColor $COLOR_YELLOW
             Write-Host "  Fix:  retry; if it persists report it at https://github.com/amd/gaia/issues" -ForegroundColor $COLOR_YELLOW
@@ -265,20 +314,70 @@ function Install-Tui {
         if (-not (Test-Path $GAIA_BIN)) {
             New-Item -ItemType Directory -Path $GAIA_BIN -Force | Out-Null
         }
+        $dest = Join-Path $GAIA_BIN $InstallAs
         try {
-            Move-Item -Path $tmpFile -Destination "$GAIA_BIN\gaia-tui.exe" -Force
+            Move-Item -Path $tmpFile -Destination $dest -Force
         }
         catch {
-            Write-Error "Downloaded and verified, but could not write $GAIA_BIN\gaia-tui.exe`: $_"
-            Write-Host "  Fix:  close any running gaia-tui (and any tool scanning that" -ForegroundColor $COLOR_YELLOW
-            Write-Host "        folder), then re-run this installer." -ForegroundColor $COLOR_YELLOW
+            Write-Error "Downloaded and verified, but could not write $dest`: $_"
+            Write-Host "  Fix:  close any running gaia-tui or gaia-agent (and any tool" -ForegroundColor $COLOR_YELLOW
+            Write-Host "        scanning that folder), then re-run this installer." -ForegroundColor $COLOR_YELLOW
             exit 1
         }
-        Write-Success "Terminal hub $version installed to $GAIA_BIN\gaia-tui.exe"
+        Write-Success "$Label $version installed to $dest"
     }
     finally {
         if (Test-Path $tmpDir) { Remove-Item -Path $tmpDir -Recurse -Force }
     }
+}
+
+# A missing terminal hub fails the install - it is the advertised entry point.
+function Install-Tui {
+    Write-Step "Installing the GAIA terminal hub"
+
+    $platform = Get-TerminalHubPlatform
+    if (-not $platform) {
+        $arch = if ($env:PROCESSOR_ARCHITEW6432) { $env:PROCESSOR_ARCHITEW6432 } else { $env:PROCESSOR_ARCHITECTURE }
+        Write-Error "No terminal hub build for processor architecture '$arch'."
+        Write-Host "  Published targets: win-x64, win-arm64, linux-x64, linux-arm64," -ForegroundColor $COLOR_YELLOW
+        Write-Host "  darwin-x64, darwin-arm64. See $GAIA_HUB_BASE_URL/index.json" -ForegroundColor $COLOR_YELLOW
+        exit 1
+    }
+
+    Install-HubBinary -AgentId $TERMINAL_HUB_ID -Platform $platform `
+        -Filename "gaia-$platform.exe" -InstallAs "gaia-tui.exe" `
+        -Label "terminal hub" `
+        -Hint "git clone https://github.com/amd/gaia; cd gaia\tui; make build"
+}
+
+# A missing flagship agent fails the install too. The terminal hub spawns
+# `gaia-agent`, so shipping the hub without it installs a front end whose
+# readiness gate halts on the first launch - and whose remedy is "re-run the
+# GAIA installer", which is this script.
+function Install-Agent {
+    Write-Step "Installing the GAIA agent"
+
+    $platform = Get-TerminalHubPlatform
+    if (-not $platform) {
+        $arch = if ($env:PROCESSOR_ARCHITEW6432) { $env:PROCESSOR_ARCHITEW6432 } else { $env:PROCESSOR_ARCHITECTURE }
+        Write-Error "No GAIA agent build for processor architecture '$arch'."
+        Write-Host "  Look: $GAIA_HUB_BASE_URL/agents/$FLAGSHIP_AGENT_ID/manifest.json" -ForegroundColor $COLOR_YELLOW
+        exit 1
+    }
+
+    # Unreachable in a normal run - Assert-FlagshipPlatform refuses this before
+    # anything is installed. Kept as the authoritative guard so the function is
+    # safe to call on its own.
+    $npmKey = $FLAGSHIP_PLATFORM_KEYS[$platform]
+    if (-not $npmKey) {
+        Show-UnsupportedPlatformError $platform
+    }
+
+    # `gaia-agent.exe`, never `gaia.exe`: same collision as the terminal hub.
+    Install-HubBinary -AgentId $FLAGSHIP_AGENT_ID -Platform $platform `
+        -Filename "$FLAGSHIP_ARTIFACT_PREFIX-$npmKey.exe" -InstallAs "gaia-agent.exe" `
+        -Label "GAIA agent" `
+        -Hint "git clone https://github.com/amd/gaia; cd gaia; python hub\agents\$FLAGSHIP_AGENT_ID\python\packaging\freeze.py --onefile --target stdio"
 }
 
 function Add-ToPath {
@@ -323,14 +422,16 @@ function Show-NextSteps {
     Write-Host "================================" -ForegroundColor $COLOR_GREEN
     Write-Host "`n"
 
-    Write-Host "Next steps:" -ForegroundColor $COLOR_CYAN
+    Write-Host "Start GAIA:" -ForegroundColor $COLOR_CYAN
     Write-Host "  1. Close and reopen your terminal (or run: refreshenv)" -ForegroundColor White
-    Write-Host "  2. Run: " -ForegroundColor White -NoNewline
-    Write-Host "gaia init" -ForegroundColor $COLOR_GREEN -NoNewline
-    Write-Host " to set up Lemonade Server and download models" -ForegroundColor White
-    Write-Host "     (the Lemonade installer asks for administrator approval)" -ForegroundColor White
-    Write-Host "  3. Open the terminal hub: " -ForegroundColor White -NoNewline
+    Write-Host "  2. " -ForegroundColor White -NoNewline
     Write-Host "gaia-tui" -ForegroundColor $COLOR_GREEN
+    Write-Host "`n"
+    Write-Host "On first run it checks what is still missing and can download the" -ForegroundColor White
+    Write-Host "models for you. To do that up front instead, run " -ForegroundColor White -NoNewline
+    Write-Host "gaia init" -ForegroundColor $COLOR_GREEN -NoNewline
+    Write-Host " first" -ForegroundColor White
+    Write-Host "- it installs Lemonade Server and asks for administrator approval." -ForegroundColor White
     Write-Host "`n"
 
     Write-Host "Documentation: https://amd-gaia.ai" -ForegroundColor $COLOR_CYAN
@@ -354,6 +455,8 @@ function Main {
         exit 1
     }
 
+    Assert-FlagshipPlatform
+
     Show-ElevationNotice
 
     # Install uv if needed
@@ -366,8 +469,11 @@ function Main {
     # CLI reachable.
     Add-ToPath
 
-    # Install the terminal hub binary
+    # The two halves of one program: the hub is the front end, the agent is what
+    # it spawns. Installing either without the other is a dead end, so they land
+    # in the same phase.
     Install-Tui
+    Install-Agent
 
     # Show next steps
     Show-NextSteps

--- a/installer/scripts/install.sh
+++ b/installer/scripts/install.sh
@@ -19,6 +19,24 @@ GAIA_HUB_BASE_URL="${GAIA_HUB_BASE_URL:-https://hub.amd-gaia.ai}"
 GAIA_HUB_BASE_URL="${GAIA_HUB_BASE_URL%/}"
 TERMINAL_HUB_ID="terminal-hub"
 
+# The terminal hub spawns `gaia-agent` as a child process, so installing the hub
+# alone ships a front end with nothing behind it — and the TUI's readiness gate
+# halts on the missing binary telling the user to re-run this installer.
+FLAGSHIP_AGENT_ID="gaia"
+
+# The STDIO build, not the REST sidecar. Both are published under agents/gaia/
+# and both would install as `gaia-agent`, but only this one speaks the
+# newline-delimited JSON the TUI writes to the child's stdin — the sidecar just
+# binds a port and ignores it (#3062).
+FLAGSHIP_ARTIFACT_PREFIX="gaia-agent-stdio"
+
+# Platform keys the flagship publishes a stdio build for. Mirrors PLATFORM_KEYS
+# in installer/tui/fetch_sidecar.py: linux-arm64 is absent on purpose — the
+# terminal hub builds there and the flagship does not, and an install that
+# quietly skipped the agent would produce exactly the dead end this installs it
+# to prevent.
+FLAGSHIP_PLATFORMS="darwin-arm64 darwin-x64 linux-x64"
+
 # Network limits: a black-holed connection must fail, not hang silently.
 CONNECT_TIMEOUT=15
 MAX_TIME=900
@@ -107,6 +125,16 @@ detect_environment() {
             exit 1
             ;;
     esac
+
+    # Before uv, Python and the venv: on a platform with no agent build this
+    # install can only end in failure, and finding that out after a multi-minute
+    # download leaves a half-install behind every single time.
+    platform=""
+    if platform="$(terminal_hub_platform)"; then
+        if ! flagship_filename "$platform" > /dev/null; then
+            unsupported_platform_error "$platform"
+        fi
+    fi
 
     print_success "Environment: $OS_LABEL ($ARCH)"
 }
@@ -275,7 +303,7 @@ terminal_hub_platform() {
 
 # Resolve the Python interpreter used to read the hub manifest. install_gaia has
 # already created the venv by the time this runs.
-terminal_hub_python() {
+hub_python() {
     if [ -x "$GAIA_VENV/bin/python" ]; then
         printf '%s\n' "$GAIA_VENV/bin/python"
     elif command -v python3 > /dev/null 2>&1; then
@@ -285,36 +313,75 @@ terminal_hub_python() {
     fi
 }
 
-# A missing terminal hub fails the install — it is the advertised entry point.
-install_tui() {
-    print_step "Installing the GAIA terminal hub"
+# Refuse a platform the flagship has no build for. Loud, never skipped: the
+# terminal hub builds for linux-arm64 and the flagship does not, so continuing
+# would install the exact dead end this installer exists to prevent.
+unsupported_platform_error() {
+    print_error "The GAIA agent publishes no build for $1."
+    echo "  The terminal hub runs here but has no agent to run, so GAIA would"
+    echo "  install a front end that cannot start. Nothing has been installed."
+    echo "  Published targets: $FLAGSHIP_PLATFORMS"
+    echo "  Fix:  build the agent yourself — it needs a Python 3.12 venv with"
+    echo "        pyinstaller, and the binary has to land on your PATH as"
+    echo "        gaia-agent:"
+    echo "          git clone https://github.com/amd/gaia && cd gaia"
+    echo "          python hub/agents/$FLAGSHIP_AGENT_ID/python/packaging/freeze.py --onefile --target stdio"
+    echo "          mkdir -p $GAIA_BIN && install -m 0755 \\"
+    echo "            hub/agents/$FLAGSHIP_AGENT_ID/python/packaging/dist/gaia-agent-stdio \\"
+    echo "            $GAIA_BIN/gaia-agent"
+    echo "  Look: $GAIA_HUB_BASE_URL/agents/$FLAGSHIP_AGENT_ID/manifest.json"
+    echo "  Track: https://github.com/amd/gaia/issues"
+    exit 1
+}
 
-    platform=""
-    if ! platform="$(terminal_hub_platform)"; then
-        print_error "No terminal hub build for $(uname -s)/$(uname -m)."
-        echo "Published targets: linux-x64, linux-arm64, darwin-x64, darwin-arm64,"
-        echo "win-x64, win-arm64. See $GAIA_HUB_BASE_URL/index.json"
-        exit 1
-    fi
-    filename="gaia-${platform}"
+# Print the flagship's artifact filename for a terminal-hub platform key, or
+# fail when the flagship publishes no build there.
+flagship_filename() {
+    for _supported in $FLAGSHIP_PLATFORMS; do
+        if [ "$_supported" = "$1" ]; then
+            printf '%s-%s\n' "$FLAGSHIP_ARTIFACT_PREFIX" "$1"
+            return 0
+        fi
+    done
+    return 1
+}
+
+# Download one Agent Hub artifact, verify it against the SHA-256 the manifest
+# publishes, and install it into $GAIA_BIN.
+#
+#   $1 hub agent id        $2 platform key, for messages
+#   $3 artifact filename to ask for
+#   $4 name to install as  $5 what to call it in messages
+#   $6 the build-from-source hint for a genuinely unpublished platform
+#
+# Both binaries go through here so their verification can never drift apart.
+# Every failure path exits: there is no branch that returns having installed
+# nothing.
+hub_install_binary() {
+    _hub_id="$1"
+    _hub_platform="$2"
+    _hub_filename="$3"
+    _hub_install_as="$4"
+    _hub_label="$5"
+    _hub_hint="$6"
 
     py=""
-    if ! py="$(terminal_hub_python)"; then
+    if ! py="$(hub_python)"; then
         print_error "No Python interpreter available to read the Agent Hub manifest."
         echo "Expected $GAIA_VENV/bin/python (created earlier in this install)."
         exit 1
     fi
 
-    scratch_dir tui
+    scratch_dir "$_hub_install_as"
     tmp="$SCRATCH"
 
-    manifest_url="$GAIA_HUB_BASE_URL/agents/$TERMINAL_HUB_ID/manifest.json"
+    manifest_url="$GAIA_HUB_BASE_URL/agents/$_hub_id/manifest.json"
     if ! fetch_file "$manifest_url" "$tmp/manifest.json"; then
-        print_error "Could not fetch the terminal hub manifest."
+        print_error "Could not fetch the $_hub_label manifest."
         echo "  URL:  $manifest_url"
         echo "  Fix:  check your network, then retry. If the component is not yet"
         echo "        published for this release, build from source:"
-        echo "          git clone https://github.com/amd/gaia && cd gaia/tui && make build"
+        echo "          $_hub_hint"
         echo "  Look: $GAIA_HUB_BASE_URL/index.json lists what the hub serves."
         exit 1
     fi
@@ -322,7 +389,7 @@ install_tui() {
     # The manifest is the only source for the version, the per-platform
     # filename, and the Worker-computed SHA-256.
     resolved=""
-    if ! resolved="$("$py" - "$tmp/manifest.json" "$filename" <<'PYEOF'
+    if ! resolved="$("$py" - "$tmp/manifest.json" "$_hub_filename" <<'PYEOF'
 import json
 import sys
 
@@ -358,10 +425,10 @@ if not digest:
 print("%s %s" % (version, digest))
 PYEOF
 )"; then
-        print_error "Could not resolve the terminal hub build for $platform."
+        print_error "Could not resolve the $_hub_label build for $_hub_platform."
         echo "  Reported above by the manifest reader."
         echo "  Fix:  if your platform is genuinely unpublished, build from source:"
-        echo "          git clone https://github.com/amd/gaia && cd gaia/tui && make build"
+        echo "          $_hub_hint"
         echo "  Look: $manifest_url"
         exit 1
     fi
@@ -369,10 +436,10 @@ PYEOF
     version="${resolved%% *}"
     want="${resolved##* }"
 
-    binary_url="$GAIA_HUB_BASE_URL/agents/$TERMINAL_HUB_ID/$version/$filename"
-    print_step "Downloading terminal hub $version for $platform"
-    if ! fetch_file "$binary_url" "$tmp/$filename"; then
-        print_error "Could not download the terminal hub binary."
+    binary_url="$GAIA_HUB_BASE_URL/agents/$_hub_id/$version/$_hub_filename"
+    print_step "Downloading $_hub_label $version for $_hub_platform"
+    if ! fetch_file "$binary_url" "$tmp/$_hub_filename"; then
+        print_error "Could not download the $_hub_label binary."
         echo "  URL:  $binary_url"
         echo "  Fix:  check your network and retry."
         echo "  Look: $manifest_url lists what is published for $version."
@@ -381,9 +448,9 @@ PYEOF
 
     # No checksum, no install.
     if command -v sha256sum > /dev/null 2>&1; then
-        got="$(sha256sum "$tmp/$filename" | awk '{print $1}')"
+        got="$(sha256sum "$tmp/$_hub_filename" | awk '{print $1}')"
     elif command -v shasum > /dev/null 2>&1; then
-        got="$(shasum -a 256 "$tmp/$filename" | awk '{print $1}')"
+        got="$(shasum -a 256 "$tmp/$_hub_filename" | awk '{print $1}')"
     else
         print_error "No sha256sum or shasum available to verify the download."
         echo "  Fix:  install coreutils (Linux) or perl (macOS ships shasum), then retry."
@@ -391,7 +458,7 @@ PYEOF
     fi
 
     if [ "$want" != "$got" ]; then
-        print_error "Checksum mismatch for $filename — refusing to install."
+        print_error "Checksum mismatch for $_hub_filename — refusing to install."
         echo "  expected $want"
         echo "  got      $got"
         echo "  Fix:  retry; if it persists report it at https://github.com/amd/gaia/issues"
@@ -402,8 +469,55 @@ PYEOF
     # Never `gaia`: tui/internal/daemon/client.go resolves `gaia` on PATH to
     # start the Python-owned daemon, so a Go binary by that name finds itself.
     mkdir -p "$GAIA_BIN"
-    install -m 0755 "$tmp/$filename" "$GAIA_BIN/gaia-tui"
-    print_success "Terminal hub $version installed to $GAIA_BIN/gaia-tui"
+    install -m 0755 "$tmp/$_hub_filename" "$GAIA_BIN/$_hub_install_as"
+    print_success "$_hub_label $version installed to $GAIA_BIN/$_hub_install_as"
+}
+
+# A missing terminal hub fails the install — it is the advertised entry point.
+install_tui() {
+    print_step "Installing the GAIA terminal hub"
+
+    platform=""
+    if ! platform="$(terminal_hub_platform)"; then
+        print_error "No terminal hub build for $(uname -s)/$(uname -m)."
+        echo "Published targets: linux-x64, linux-arm64, darwin-x64, darwin-arm64,"
+        echo "win-x64, win-arm64. See $GAIA_HUB_BASE_URL/index.json"
+        exit 1
+    fi
+
+    hub_install_binary "$TERMINAL_HUB_ID" "$platform" "gaia-${platform}" "gaia-tui" \
+        "terminal hub" \
+        "git clone https://github.com/amd/gaia && cd gaia/tui && make build"
+}
+
+# A missing flagship agent fails the install too. The terminal hub spawns
+# `gaia-agent`, so shipping the hub without it installs a front end whose
+# readiness gate halts on the first launch — and whose remedy is "re-run the
+# GAIA installer", which is this script.
+install_agent() {
+    print_step "Installing the GAIA agent"
+
+    platform=""
+    if ! platform="$(terminal_hub_platform)"; then
+        print_error "No GAIA agent build for $(uname -s)/$(uname -m)."
+        echo "Published targets: $FLAGSHIP_PLATFORMS."
+        echo "See $GAIA_HUB_BASE_URL/agents/$FLAGSHIP_AGENT_ID/manifest.json"
+        exit 1
+    fi
+
+    filename=""
+    if ! filename="$(flagship_filename "$platform")"; then
+        # Unreachable in a normal run — detect_environment refuses this platform
+        # before anything is installed. Kept as the authoritative guard so the
+        # function is safe to call on its own.
+        unsupported_platform_error "$platform"
+    fi
+
+    # `gaia-agent`, never `gaia`: same collision as the terminal hub — the TUI
+    # resolves `gaia` on PATH to the Python CLI that starts the daemon.
+    hub_install_binary "$FLAGSHIP_AGENT_ID" "$platform" "$filename" "gaia-agent" \
+        "GAIA agent" \
+        "git clone https://github.com/amd/gaia && cd gaia && python hub/agents/$FLAGSHIP_AGENT_ID/python/packaging/freeze.py --onefile --target stdio"
 }
 
 # Add GAIA to PATH
@@ -490,16 +604,18 @@ show_next_steps() {
     printf '%s================================%s\n' "$COLOR_GREEN" "$COLOR_RESET"
     echo ""
 
-    printf '%sNext steps:%s\n' "$COLOR_CYAN" "$COLOR_RESET"
+    printf '%sStart GAIA:%s\n' "$COLOR_CYAN" "$COLOR_RESET"
     if [ -n "${RELOAD_FILE:-}" ]; then
         echo "  1. Reload your shell config:"
         printf '     %ssource %s%s\n' "$COLOR_GREEN" "$RELOAD_FILE" "$COLOR_RESET"
     else
         echo "  1. Open a new terminal (PATH was not written to a startup file)"
     fi
-    printf '  2. Set up the local model runtime: %sgaia init%s\n' "$COLOR_GREEN" "$COLOR_RESET"
-    echo "     (installs Lemonade Server — asks for your password)"
-    printf '  3. Open the terminal hub: %sgaia-tui%s\n' "$COLOR_GREEN" "$COLOR_RESET"
+    printf '  2. %sgaia-tui%s\n' "$COLOR_GREEN" "$COLOR_RESET"
+    echo ""
+    echo "On first run it checks what is still missing and can download the"
+    printf 'models for you. To do that up front instead, run %sgaia init%s\n' "$COLOR_GREEN" "$COLOR_RESET"
+    echo "first — it installs Lemonade Server and asks for your password."
     echo ""
 
     printf '%sDocumentation:%s https://amd-gaia.ai\n' "$COLOR_CYAN" "$COLOR_RESET"
@@ -531,8 +647,11 @@ main() {
     # CLI reachable.
     add_to_path
 
-    # Install the terminal hub binary
+    # The two halves of one program: the hub is the front end, the agent is what
+    # it spawns. Installing either without the other is a dead end, so they land
+    # in the same phase.
     install_tui
+    install_agent
 
     # Show next steps
     show_next_steps

--- a/installer/tui/fetch_sidecar.py
+++ b/installer/tui/fetch_sidecar.py
@@ -1,10 +1,17 @@
 #!/usr/bin/env python3
 # Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
 # SPDX-License-Identifier: MIT
-"""Download the flagship `gaia-agent` sidecar and verify it against the committed lock.
+"""Download the flagship `gaia-agent` child and verify it against the committed lock.
 
 The terminal hub spawns `gaia-agent` as a child process, so an installer that
 ships only the TUI installs a front end with nothing behind it.
+
+Which of the flagship's two binaries this stages matters: `agents/gaia/` publishes
+BOTH the REST sidecar the daemon supervises and the stdin/stdout JSONL child the
+TUI spawns, and the native installers put what lands here on PATH as `gaia-agent`
+— exactly the name the TUI resolves. So it reads the lock's `stdio` lane. Staging
+the sidecar instead installs a program that binds a port and never answers stdin,
+feeding uvicorn's startup log to a JSON line scanner (#3062).
 
 Both the expected SHA-256 and the sidecar version come from the COMMITTED
 ``hub/agents/gaia/npm/binaries.lock.json``, never from the origin that served the
@@ -66,6 +73,10 @@ USER_AGENT = "gaia-installer-build/1.0"
 # The committed sidecar pin, relative to the repo root.
 BINARIES_LOCK = Path("hub/agents/gaia/npm/binaries.lock.json")
 
+# The lock lane to stage from. `stdio`, never `sidecar`: see the module docstring
+# — the installers put this on PATH under the name the TUI spawns.
+LOCK_COMPONENT = "stdio"
+
 # Allowlist a real digest rather than blocklist known placeholders, so a lock
 # left half-filled by a future generator cannot slip past as "not PENDING".
 SHA256_RE = re.compile(r"^[0-9a-fA-F]{64}$")
@@ -81,18 +92,18 @@ def _repo_root() -> Path:
 
 
 def _sidecar_lock() -> tuple[dict, Path]:
-    """The committed sidecar pin: version plus the per-platform digests."""
+    """The committed pin for the stdio child: version plus per-platform digests."""
     lock_path = _repo_root() / BINARIES_LOCK
     try:
         lock = json.loads(lock_path.read_text(encoding="utf-8"))
-        sidecar = lock["components"]["sidecar"]
+        sidecar = lock["components"][LOCK_COMPONENT]
         if not isinstance(sidecar, dict):
-            raise TypeError("components.sidecar is not an object")
+            raise TypeError(f"components.{LOCK_COMPONENT} is not an object")
         return sidecar, lock_path
     except (OSError, json.JSONDecodeError, KeyError, TypeError) as e:
         raise SystemExit(
-            f"could not read the sidecar pin from {lock_path}: {e}\n"
-            f"It must contain components.sidecar with componentVersion and "
+            f"could not read the {LOCK_COMPONENT} pin from {lock_path}: {e}\n"
+            f"It must contain components.{LOCK_COMPONENT} with componentVersion and "
             f"platforms.<key>.sha256. Regenerate it with {LOCK_GENERATOR}."
         ) from e
 
@@ -112,7 +123,7 @@ def _expected_sha256(sidecar: dict, npm_key: str, lock_path: Path) -> str:
         # best-effort sidecar build was skipped, so the npm installer can say
         # "not published for this platform". Say the same thing here.
         raise NoSidecarForPlatform(
-            f"{lock_path} has no components.sidecar.platforms.{npm_key} entry, so the "
+            f"{lock_path} has no components.{LOCK_COMPONENT}.platforms.{npm_key} entry, so the "
             f"flagship agent publishes no sidecar for this platform."
         )
     sha = str(entry.get("sha256", ""))
@@ -256,7 +267,7 @@ def main() -> int:
     version = args.version or pinned
     if not version:
         raise SystemExit(
-            f"{lock_path} has no components.sidecar.componentVersion, so there is no "
+            f"{lock_path} has no components.{LOCK_COMPONENT}.componentVersion, so there is no "
             f"pinned sidecar version to fetch. Regenerate it with {LOCK_GENERATOR}."
         )
     if version != pinned:
@@ -285,7 +296,7 @@ def main() -> int:
     filename = str(entry.get("filename") or "")
     if not filename:
         raise SystemExit(
-            f"{lock_path} has no components.sidecar.platforms.{npm_key}.filename, so "
+            f"{lock_path} has no components.{LOCK_COMPONENT}.platforms.{npm_key}.filename, so "
             f"there is no artifact name to request from the hub. Regenerate the lock "
             f"with {LOCK_GENERATOR}."
         )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,6 +11,7 @@ This file (conftest.py) is a special pytest file that provides:
 See: https://docs.pytest.org/en/stable/reference/fixtures.html#conftest-py-sharing-fixtures-across-multiple-files
 
 Current fixtures:
+- _block_real_browser_launch: Session-autouse guard so no test can open a real browser
 - api_server: Function-scoped fixture that starts GAIA API server for integration tests
 - api_client: HTTP client (requests.Session) configured for API testing
 - lemonade_available: Session-scoped fixture checking if Lemonade server is running
@@ -29,9 +30,39 @@ be automatically available to all test files.
 
 import subprocess
 import time
+import webbrowser
 
 import pytest
 import requests
+
+_BROWSER_LAUNCHERS = ("open", "open_new", "open_new_tab")
+
+
+@pytest.fixture(scope="session", autouse=True)
+def _block_real_browser_launch():
+    """Make it impossible for the suite to open the developer's real browser.
+
+    A per-test ``monkeypatch.setattr("webbrowser.open", ...)`` is not enough:
+    ``connectors.flow.start_authorization`` launches the browser from a
+    fire-and-forget ``asyncio.ensure_future`` task that resolves
+    ``webbrowser.open`` when it runs, which can be after the patch was torn
+    down. Session scope means the restored value is always this stub, so the
+    race can only ever reach a no-op.
+    """
+    saved = {name: getattr(webbrowser, name) for name in _BROWSER_LAUNCHERS}
+
+    def _blocked(url, *_args, **_kwargs):
+        raise RuntimeError(
+            f"A test tried to open a real browser at {url!r}. Patch the "
+            "launcher in the test (monkeypatch.setattr('webbrowser.open', ...)) "
+            "or stub the code path that calls it."
+        )
+
+    for name in _BROWSER_LAUNCHERS:
+        setattr(webbrowser, name, _blocked)
+    yield
+    for name, original in saved.items():
+        setattr(webbrowser, name, original)
 
 
 @pytest.fixture(scope="session", autouse=True)

--- a/tests/unit/installer/test_install_scripts.py
+++ b/tests/unit/installer/test_install_scripts.py
@@ -1,16 +1,22 @@
 # Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
 # SPDX-License-Identifier: MIT
 
-"""Coverage for terminal-hub installation in installer/scripts/install.{sh,ps1}.
+"""Coverage for installer/scripts/install.{sh,ps1}.
+
+The one-liner must install BOTH halves of the product: the terminal hub
+(``gaia-tui``) and the flagship agent it spawns (``gaia-agent``). Shipping the
+hub alone strands the user at a readiness gate whose remedy is "re-run the
+installer" — the very script that skipped the agent.
 
 Two layers, because a static check alone is what let the previous version ship
 pointing at a channel nothing published to:
 
-* static — the Agent Hub URL shape, the platform keys, the binary name, and the
-  absence of bash-only syntax (the documented one-liner pipes into ``sh``);
-* functional — ``install_tui`` run for real against a throwaway HTTP server that
-  serves a manifest in the Worker's shape, asserting it installs on a match and
-  installs *nothing* on a checksum mismatch.
+* static — the Agent Hub URL shape, the platform keys, the installed names, the
+  artifact each binary asks for, and the absence of bash-only syntax (the
+  documented one-liner pipes into ``sh``);
+* functional — the install functions run for real against a throwaway HTTP
+  server that serves a manifest in the Worker's shape, asserting they install on
+  a match and install *nothing* on a checksum mismatch.
 """
 
 from __future__ import annotations
@@ -64,16 +70,18 @@ def test_sh_reads_the_agent_hub_not_release_assets(sh_text):
     assert "gaia-tui-SHA256SUMS.txt" not in sh_text
     assert "hub.amd-gaia.ai" in sh_text
     assert 'TERMINAL_HUB_ID="terminal-hub"' in sh_text
-    assert "/agents/$TERMINAL_HUB_ID/manifest.json" in sh_text
-    assert "/agents/$TERMINAL_HUB_ID/$version/$filename" in sh_text
+    assert 'FLAGSHIP_AGENT_ID="gaia"' in sh_text
+    assert "/agents/$_hub_id/manifest.json" in sh_text
+    assert "/agents/$_hub_id/$version/$_hub_filename" in sh_text
 
 
 def test_ps1_reads_the_agent_hub(ps1_text):
     assert "releases/latest/download" not in ps1_text
     assert "hub.amd-gaia.ai" in ps1_text
     assert '$TERMINAL_HUB_ID = "terminal-hub"' in ps1_text
-    assert "/agents/$TERMINAL_HUB_ID/manifest.json" in ps1_text
-    assert "/agents/$TERMINAL_HUB_ID/$version/$filename" in ps1_text
+    assert '$FLAGSHIP_AGENT_ID = "gaia"' in ps1_text
+    assert "/agents/$AgentId/manifest.json" in ps1_text
+    assert "/agents/$AgentId/$version/$Filename" in ps1_text
 
 
 def test_component_id_matches_the_published_manifest():
@@ -116,13 +124,79 @@ def test_ps1_maps_processor_architecture_to_hub_keys(ps1_text):
 # ── the binary keeps the name `gaia-tui` ───────────────────────────────────
 
 
-def test_binary_is_installed_as_gaia_tui(sh_text, ps1_text):
+def test_binaries_are_installed_under_their_own_names(sh_text, ps1_text):
     """tui/internal/daemon/client.go resolves `gaia` on PATH to start the
-    Python-owned daemon; a Go binary named `gaia` would find itself."""
-    assert '"$GAIA_BIN/gaia-tui"' in sh_text
-    assert "$GAIA_BIN\\gaia-tui.exe" in ps1_text
+    Python-owned daemon; a binary named `gaia` would find itself."""
+    assert '"gaia-tui" \\' in sh_text
+    assert '"gaia-agent" \\' in sh_text
+    assert '-InstallAs "gaia-tui.exe"' in ps1_text
+    assert '-InstallAs "gaia-agent.exe"' in ps1_text
     assert '"$GAIA_BIN/gaia"' not in sh_text
     assert "$GAIA_BIN\\gaia.exe" not in ps1_text
+
+
+# ── both halves get installed, or the TUI is a dead end ────────────────────
+
+
+@pytest.mark.parametrize("script", ["sh", "ps1"])
+def test_the_installer_installs_the_agent_not_just_the_hub(sh_text, ps1_text, script):
+    """The regression this file exists for.
+
+    The terminal hub spawns `gaia-agent`; installing only `gaia-tui` leaves the
+    readiness gate halting on a missing binary whose remedy — "re-run the GAIA
+    installer" — is this script. Both must be fetched, and `main` must call
+    both.
+    """
+    text = sh_text if script == "sh" else ps1_text
+    installer = "install_agent" if script == "sh" else "Install-Agent"
+    hub = "install_tui" if script == "sh" else "Install-Tui"
+
+    assert installer in text, f"install.{script} never installs the flagship agent"
+    # Defined AND called: a function nothing invokes installs nothing.
+    assert text.count(installer) >= 2
+    assert text.index(hub) < text.index(installer)
+
+
+@pytest.mark.parametrize("script", ["sh", "ps1"])
+def test_the_agent_artifact_is_the_stdio_build_not_the_rest_sidecar(
+    sh_text, ps1_text, script
+):
+    """`agents/gaia/` publishes two different programs under names one character
+    apart, and only one of them can be spawned by the TUI.
+
+    `gaia-agent-<platform>` is the REST sidecar: it binds a port and ignores
+    stdin, so the TUI's JSON line scanner reads uvicorn's startup log (#3062).
+    `gaia-agent-stdio-<platform>` is the child the TUI actually talks to. Asking
+    for the wrong one turns the readiness gate green and then breaks the launch,
+    which is worse than today's honest halt.
+    """
+    text = sh_text if script == "sh" else ps1_text
+    assert "gaia-agent-stdio" in text
+
+    # The bare sidecar prefix must never be what gets requested. It may appear
+    # in prose explaining why; only the artifact-name construction is checked.
+    code = "\n".join(
+        line
+        for line in text.splitlines()
+        if not line.lstrip().startswith("#") and line.strip()
+    )
+    for wrong in ('"gaia-agent-%s"', "gaia-agent-$platform", "gaia-agent-$npmKey"):
+        assert wrong not in code, f"install.{script} asks for the REST sidecar: {wrong}"
+
+
+@pytest.mark.parametrize("script", ["sh", "ps1"])
+def test_a_platform_with_no_agent_build_fails_loudly(sh_text, ps1_text, script):
+    """The terminal hub builds for linux-arm64 / win-arm64 and the flagship does
+    not. Silently skipping the agent there ships the dead end on purpose."""
+    text = sh_text if script == "sh" else ps1_text
+    if script == "sh":
+        # An allowlist, so a NEW terminal-hub platform fails closed.
+        assert 'FLAGSHIP_PLATFORMS="darwin-arm64 darwin-x64 linux-x64"' in text
+        assert "linux-arm64" not in text.split("FLAGSHIP_PLATFORMS")[1][:200]
+    else:
+        assert '$FLAGSHIP_PLATFORM_KEYS = @{ "win-x64" = "win32-x64" }' in text
+        assert "win-arm64" not in text.split("FLAGSHIP_PLATFORM_KEYS")[1][:200]
+    assert "publishes no build for" in text
 
 
 def test_path_registration_covers_the_terminal_hub_bin_dir(sh_text, ps1_text):
@@ -184,20 +258,48 @@ def _shell_function_body(sh_text: str, name: str) -> str:
     return match.group(1)
 
 
-def test_install_tui_never_soft_skips(sh_text):
-    body = _shell_function_body(sh_text, "install_tui")
+@pytest.mark.parametrize(
+    "func,min_exits",
+    [
+        # The wrappers only guard the platform and delegate the rest; the shared
+        # helper carries the network, manifest, checksum and write failures.
+        ("install_tui", 1),
+        ("install_agent", 1),
+        ("unsupported_platform_error", 1),
+        ("hub_install_binary", 6),
+    ],
+)
+def test_install_functions_never_soft_skip(sh_text, func, min_exits):
+    body = _shell_function_body(sh_text, func)
     assert "return 0" not in body
     assert "skipping" not in body
     # Every failure branch aborts.
-    assert body.count("exit 1") >= 6
+    assert body.count("exit 1") >= min_exits
 
 
-def test_install_tui_refuses_an_unverified_binary(sh_text, ps1_text):
-    body = _shell_function_body(sh_text, "install_tui")
+def test_both_binaries_are_verified_by_one_shared_path(sh_text, ps1_text):
+    """One download-and-verify implementation, used by both installs.
+
+    Two copies drift: the second binary is exactly where a checksum step gets
+    dropped, and nothing about the install would look different if it were.
+    """
+    body = _shell_function_body(sh_text, "hub_install_binary")
     assert "publishes %s with no SHA-256" in body
     assert "Checksum mismatch" in body
+    assert "sha256sum" in body and "shasum" in body
+    # Both wrappers delegate here rather than rolling their own.
+    for wrapper in ("install_tui", "install_agent"):
+        assert "hub_install_binary" in _shell_function_body(sh_text, wrapper)
+
     assert "no SHA-256" in ps1_text
     assert "Checksum mismatch" in ps1_text
+    assert ps1_text.count("Get-FileHash") == 1, (
+        "install.ps1 should verify through one shared Install-HubBinary; a "
+        "second Get-FileHash means a second, driftable copy"
+    )
+    for wrapper in ("Install-Tui", "Install-Agent"):
+        assert wrapper in ps1_text
+    assert ps1_text.count("Install-HubBinary") >= 3  # definition + two callers
 
 
 def test_elevation_is_announced_before_it_is_needed(sh_text, ps1_text):
@@ -273,32 +375,51 @@ class _QuietHandler(http.server.SimpleHTTPRequestHandler):
         pass
 
 
+# The two hub lanes the installer reads, and what each publishes per platform.
+# `gaia` deliberately carries BOTH the REST sidecar and the stdio build, because
+# picking the wrong one is the failure this fixture has to be able to catch.
+TUI_KEYS = ("linux-x64", "linux-arm64", "darwin-x64", "darwin-arm64")
+AGENT_KEYS = ("linux-x64", "darwin-x64", "darwin-arm64")
+
+
 @pytest.fixture
 def fake_hub(tmp_path):
-    """Serve an Agent-Hub-shaped manifest plus one binary over loopback."""
+    """Serve Agent-Hub-shaped manifests for both lanes over loopback."""
     root = tmp_path / "hub"
-    version_dir = root / "agents" / "terminal-hub" / "0.99.0"
-    version_dir.mkdir(parents=True)
+    digests: dict[tuple[str, str], str] = {}
+    lanes = {
+        "terminal-hub": [f"gaia-{k}" for k in TUI_KEYS],
+        "gaia": [f"gaia-agent-stdio-{k}" for k in AGENT_KEYS]
+        # The sidecar shares the lane. Asking for it must not install.
+        + [f"gaia-agent-{k}" for k in AGENT_KEYS],
+    }
 
-    payload = b"#!/bin/sh\necho gaia-tui 0.99.0\n"
-    digests = {}
-    for key in ("linux-x64", "linux-arm64", "darwin-x64", "darwin-arm64"):
-        (version_dir / f"gaia-{key}").write_bytes(payload + key.encode())
-        digests[key] = hashlib.sha256(payload + key.encode()).hexdigest()
+    for agent_id, filenames in lanes.items():
+        version_dir = root / "agents" / agent_id / "0.99.0"
+        version_dir.mkdir(parents=True)
+        for filename in filenames:
+            payload = f"#!/bin/sh\necho {filename} 0.99.0\n".encode()
+            (version_dir / filename).write_bytes(payload)
+            digests[(agent_id, filename)] = hashlib.sha256(payload).hexdigest()
 
-    def write_manifest(overrides=None):
+    def write_manifest(agent_id="terminal-hub", overrides=None):
+        """Rewrite one lane's manifest, optionally corrupting its digests."""
         artifacts = [
             {
-                "filename": f"gaia-{key}",
-                "path": f"agents/terminal-hub/0.99.0/gaia-{key}",
-                "size_bytes": len(payload) + len(key),
-                "sha256": (overrides or {}).get(key, digest),
+                "filename": filename,
+                "path": f"agents/{agent_id}/0.99.0/{filename}",
+                "size_bytes": (root / "agents" / agent_id / "0.99.0" / filename)
+                .stat()
+                .st_size,
+                "sha256": (overrides or {}).get(
+                    filename, digests[(agent_id, filename)]
+                ),
                 "content_type": "application/octet-stream",
             }
-            for key, digest in digests.items()
+            for filename in lanes[agent_id]
         ]
         manifest = {
-            "id": "terminal-hub",
+            "id": agent_id,
             "latest_version": "0.99.0",
             "versions": {
                 "0.99.0": {
@@ -308,11 +429,12 @@ def fake_hub(tmp_path):
                 }
             },
         }
-        (root / "agents" / "terminal-hub" / "manifest.json").write_text(
+        (root / "agents" / agent_id / "manifest.json").write_text(
             json.dumps(manifest), encoding="utf-8"
         )
 
-    write_manifest()
+    for agent_id in lanes:
+        write_manifest(agent_id)
 
     handler = type(
         "Handler",
@@ -356,23 +478,29 @@ def _run_sh_function(tmp_path, snippet, env_overrides=None, shell="sh"):
     return result, home
 
 
-def _run_install_tui(tmp_path, base_url, downloader="curl", shell="sh"):
+# Which shell function installs which binary, so every functional case below
+# runs against BOTH halves instead of proving the hub works and assuming.
+INSTALLS = {"install_tui": "gaia-tui", "install_agent": "gaia-agent"}
+
+
+def _run_install(tmp_path, base_url, func, downloader="curl", shell="sh"):
     result, home = _run_sh_function(
         tmp_path,
-        f"DOWNLOAD_CMD={downloader}; install_tui",
+        f"DOWNLOAD_CMD={downloader}; {func}",
         {"GAIA_HUB_BASE_URL": base_url},
         shell=shell,
     )
-    return result, home / ".gaia" / "bin" / "gaia-tui"
+    return result, home / ".gaia" / "bin" / INSTALLS[func]
 
 
 @pytest.mark.skipif(sys.platform == "win32", reason="needs a POSIX shell")
+@pytest.mark.parametrize("func", sorted(INSTALLS))
 @pytest.mark.parametrize("downloader", ["curl", "wget"])
-def test_install_tui_installs_a_verified_binary(tmp_path, fake_hub, downloader):
+def test_install_puts_a_verified_binary_on_disk(tmp_path, fake_hub, downloader, func):
     if shutil.which(downloader) is None:
         pytest.skip(f"{downloader} not installed")
     base_url, _ = fake_hub
-    result, installed = _run_install_tui(tmp_path, base_url, downloader=downloader)
+    result, installed = _run_install(tmp_path, base_url, func, downloader=downloader)
 
     assert result.returncode == 0, result.stdout + result.stderr
     assert installed.is_file()
@@ -381,12 +509,27 @@ def test_install_tui_installs_a_verified_binary(tmp_path, fake_hub, downloader):
 
 
 @pytest.mark.skipif(sys.platform == "win32", reason="needs a POSIX shell")
+@pytest.mark.skipif(shutil.which("curl") is None, reason="needs curl")
+def test_the_agent_install_fetches_the_stdio_build(tmp_path, fake_hub):
+    """Both programs live in `agents/gaia/`. Installing the REST sidecar would
+    satisfy the readiness gate and then break the launch (#3062), so assert on
+    the bytes that landed — not merely that something did."""
+    base_url, _ = fake_hub
+    result, installed = _run_install(tmp_path, base_url, "install_agent")
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    body = installed.read_text(encoding="utf-8")
+    assert "gaia-agent-stdio-" in body, f"installed the wrong artifact: {body!r}"
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="needs a POSIX shell")
 @pytest.mark.skipif(shutil.which("dash") is None, reason="dash not installed")
-def test_install_tui_works_under_dash(tmp_path, fake_hub):
+@pytest.mark.parametrize("func", sorted(INSTALLS))
+def test_install_works_under_dash(tmp_path, fake_hub, func):
     """`curl … | sh` is dash on Debian/Ubuntu; macOS `sh` is bash, so a
     curl-only, sh-only run would never exercise the real Linux shell."""
     base_url, _ = fake_hub
-    result, installed = _run_install_tui(tmp_path, base_url, shell="dash")
+    result, installed = _run_install(tmp_path, base_url, func, shell="dash")
 
     assert result.returncode == 0, result.stdout + result.stderr
     assert installed.is_file()
@@ -394,16 +537,18 @@ def test_install_tui_works_under_dash(tmp_path, fake_hub):
 
 @pytest.mark.skipif(sys.platform == "win32", reason="needs a POSIX shell")
 @pytest.mark.skipif(shutil.which("curl") is None, reason="needs curl")
-def test_install_tui_installs_nothing_on_a_checksum_mismatch(tmp_path, fake_hub):
+@pytest.mark.parametrize("func", sorted(INSTALLS))
+def test_install_puts_nothing_on_disk_on_a_checksum_mismatch(tmp_path, fake_hub, func):
     base_url, write_manifest = fake_hub
-    write_manifest(
-        overrides={
-            key: "d" * 64
-            for key in ("linux-x64", "linux-arm64", "darwin-x64", "darwin-arm64")
-        }
+    agent_id = "terminal-hub" if func == "install_tui" else "gaia"
+    names = (
+        [f"gaia-{k}" for k in TUI_KEYS]
+        if func == "install_tui"
+        else [f"gaia-agent-stdio-{k}" for k in AGENT_KEYS]
     )
+    write_manifest(agent_id, overrides={name: "d" * 64 for name in names})
 
-    result, installed = _run_install_tui(tmp_path, base_url)
+    result, installed = _run_install(tmp_path, base_url, func)
 
     assert result.returncode != 0
     assert "Checksum mismatch" in result.stdout + result.stderr
@@ -412,11 +557,47 @@ def test_install_tui_installs_nothing_on_a_checksum_mismatch(tmp_path, fake_hub)
 
 @pytest.mark.skipif(sys.platform == "win32", reason="needs a POSIX shell")
 @pytest.mark.skipif(shutil.which("curl") is None, reason="needs curl")
-def test_install_tui_fails_when_the_hub_is_unreachable(tmp_path):
-    result, installed = _run_install_tui(tmp_path, "http://127.0.0.1:1")
+@pytest.mark.parametrize("func", sorted(INSTALLS))
+def test_install_fails_when_the_hub_is_unreachable(tmp_path, func):
+    result, installed = _run_install(tmp_path, "http://127.0.0.1:1", func)
 
     assert result.returncode != 0
-    assert "Could not fetch the terminal hub manifest" in result.stdout + result.stderr
+    assert "Could not fetch" in result.stdout + result.stderr
+    assert not installed.exists()
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="needs a POSIX shell")
+@pytest.mark.skipif(shutil.which("curl") is None, reason="needs curl")
+def test_the_agent_install_fails_when_the_stdio_build_is_unpublished(
+    tmp_path, fake_hub
+):
+    """The lane exists and serves the sidecar, but the stdio build is absent.
+
+    Falling back to the sidecar here is exactly the silent degradation that
+    would reinstate the bug, so the install must stop and name what is missing.
+    """
+    base_url, write_manifest = fake_hub
+    root_manifest = json.loads(
+        (Path(tmp_path) / "hub" / "agents" / "gaia" / "manifest.json").read_text(
+            encoding="utf-8"
+        )
+    )
+    entry = root_manifest["versions"]["0.99.0"]
+    entry["artifacts"] = [
+        a
+        for a in entry["artifacts"]
+        if not a["filename"].startswith("gaia-agent-stdio")
+    ]
+    entry["artifact"] = entry["artifacts"][0]
+    (Path(tmp_path) / "hub" / "agents" / "gaia" / "manifest.json").write_text(
+        json.dumps(root_manifest), encoding="utf-8"
+    )
+
+    result, installed = _run_install(tmp_path, base_url, "install_agent")
+
+    assert result.returncode != 0
+    combined = result.stdout + result.stderr
+    assert "gaia-agent-stdio" in combined
     assert not installed.exists()
 
 
@@ -488,3 +669,42 @@ def test_add_to_path_does_not_write_a_file_an_unknown_shell_ignores(tmp_path):
     assert result.returncode == 0, result.stdout + result.stderr
     assert _rc_files(home) == []
     assert "Add these two directories to your PATH by hand" in result.stdout
+
+
+# ── a platform with no agent build stops the install, and stops it early ────
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="needs a POSIX shell")
+def test_install_agent_refuses_a_platform_with_no_flagship_build(tmp_path):
+    """linux-arm64 has a terminal hub build and no agent build.
+
+    Installing the hub alone there is the dead end this whole file guards, so
+    the only correct outcome is a hard stop.
+    """
+    result, home = _run_sh_function(
+        tmp_path,
+        "terminal_hub_platform() { echo linux-arm64; }; install_agent",
+    )
+    combined = result.stdout + result.stderr
+
+    assert result.returncode != 0
+    assert "publishes no build for linux-arm64" in combined
+    assert not (home / ".gaia" / "bin" / "gaia-agent").exists()
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="needs a POSIX shell")
+def test_an_unsupported_platform_is_refused_before_anything_is_installed(tmp_path):
+    """The check belongs in detect_environment, not at the download.
+
+    Discovering it after uv, a Python 3.12 download and the venv leaves a
+    half-install behind on every attempt.
+    """
+    result, home = _run_sh_function(
+        tmp_path,
+        "terminal_hub_platform() { echo linux-arm64; }; detect_environment",
+    )
+
+    assert result.returncode != 0
+    assert "publishes no build for linux-arm64" in result.stdout + result.stderr
+    # Nothing was created: the refusal happens before install_uv/install_gaia.
+    assert not (home / ".gaia").exists()

--- a/tests/unit/test_fetch_sidecar.py
+++ b/tests/unit/test_fetch_sidecar.py
@@ -27,7 +27,7 @@ _spec.loader.exec_module(fetch_sidecar)  # type: ignore[union-attr]
 PLACEHOLDER = "PENDING-replace-with-real-sha256"
 VERSION = "0.1.1"
 WIN_KEY = "win32-x64"
-WIN_FILE = "gaia-agent-win32-x64.exe"
+WIN_FILE = "gaia-agent-stdio-win32-x64.exe"
 
 BODY = b"\x4d\x5a" + b"pretend this is a signed sidecar" * 8
 BODY_SHA = hashlib.sha256(BODY).hexdigest()
@@ -55,8 +55,15 @@ def _platform_entry(**overrides) -> dict:
 
 
 def _lock(platforms: dict, *, version: str = VERSION) -> dict:
+    # The `stdio` lane, not `sidecar`: what gets staged here is installed on PATH
+    # as `gaia-agent`, and only the stdio build answers the TUI's stdin (#3062).
     return {
-        "components": {"sidecar": {"componentVersion": version, "platforms": platforms}}
+        "components": {
+            fetch_sidecar.LOCK_COMPONENT: {
+                "componentVersion": version,
+                "platforms": platforms,
+            }
+        }
     }
 
 
@@ -382,3 +389,36 @@ def test_platform_has_sidecar_reflects_the_lock(write_lock):
     write_lock(_lock({WIN_KEY: _platform_entry()}))
     assert fetch_sidecar.platform_has_sidecar("win-x64") is True
     assert fetch_sidecar.platform_has_sidecar("linux-x64") is False
+
+
+# ---------------------------------------------------------------------------
+# The lane: the stdio child, never the REST sidecar
+# ---------------------------------------------------------------------------
+#
+# Every test above builds its lock from ``LOCK_COMPONENT``, so it would stay
+# green if the constant were flipped back to "sidecar" -- and the native
+# installers would silently go back to putting a program that binds a port and
+# ignores stdin on PATH under the name the TUI spawns (#3062). These two pin it
+# against the real, committed lock.
+
+
+def test_the_staged_lane_is_the_stdio_child():
+    assert fetch_sidecar.LOCK_COMPONENT == "stdio"
+
+
+def test_the_committed_lock_publishes_stdio_artifacts_for_every_platform():
+    lock_path = Path(__file__).resolve().parents[2] / fetch_sidecar.BINARIES_LOCK
+    lock = json.loads(lock_path.read_text(encoding="utf-8"))
+    lane = lock["components"][fetch_sidecar.LOCK_COMPONENT]
+
+    # Every platform the fetcher can be asked for must be published.
+    assert set(lane["platforms"]) == set(fetch_sidecar.PLATFORM_KEYS.values())
+
+    for key, entry in lane["platforms"].items():
+        assert entry["filename"].startswith("gaia-agent-stdio-"), (
+            f"{key} stages {entry['filename']!r}: that is the REST sidecar, which "
+            "never answers the stdin the TUI writes to it"
+        )
+        # What it is INSTALLED as stays `gaia-agent` -- that is the name the
+        # TUI resolves on PATH.
+        assert entry["executable"] in ("gaia-agent", "gaia-agent.exe")

--- a/tests/unit/test_no_real_browser_launch.py
+++ b/tests/unit/test_no_real_browser_launch.py
@@ -1,0 +1,29 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""Pins the session guard that stops the suite opening a real browser.
+
+``connectors.flow.start_authorization`` fires the browser launch from a
+fire-and-forget task, so a test's own ``monkeypatch`` can be torn down before
+the launch runs and the real ``webbrowser.open`` gets called — popping a Google
+consent screen on the developer's desktop mid-test-run.
+"""
+
+import webbrowser
+
+import pytest
+
+
+@pytest.mark.parametrize("launcher", ["open", "open_new", "open_new_tab"])
+def test_browser_launchers_are_blocked(launcher):
+    with pytest.raises(RuntimeError, match="tried to open a real browser"):
+        getattr(webbrowser, launcher)("https://example.invalid")
+
+
+def test_a_local_patch_restores_to_the_guard_not_the_real_launcher():
+    """The teardown of a per-test patch must not re-arm the real launcher."""
+    with pytest.MonkeyPatch.context() as patch:
+        patch.setattr("webbrowser.open", lambda *_a, **_k: True)
+        assert webbrowser.open("https://example.invalid") is True
+
+    with pytest.raises(RuntimeError, match="tried to open a real browser"):
+        webbrowser.open("https://example.invalid")


### PR DESCRIPTION
A one-line install left the terminal hub permanently unusable. `gaia-tui` spawns
`gaia-agent` as a child process, but neither installer ever fetched it, so the
first launch stopped at a readiness gate reporting `gaia-agent` **"not on this
machine"** — and the fix it printed, *"Re-run the GAIA installer — it ships
gaia-agent alongside gaia-tui"*, pointed straight back at the script that had
just skipped it. Now both binaries are installed and SHA-256 verified, and the
gate walks through to the model check.

**The Agent Hub had no binary that could fix this, which is why this PR is
bigger than the installers.** `gaia-agent-<platform>` is the *REST sidecar* the
daemon supervises — run bare with JSON lines on stdin it binds a port and never
answers. Installing it would have turned the gate green and then broken the
launch, which is the collision #3062 exists to prevent and strictly worse than
today's honest halt. The flagship's own `pyproject.toml` already declares the
right entry point (`gaia-agent = "gaia_agent.stdio:main"`); it was simply never
frozen or published.

Three threads a reviewer should weigh separately:

- **A second freeze target** (`freeze.py --target stdio`) publishing
  `gaia-agent-stdio-<platform>`, smoke-tested on every platform leg with a new
  `--mode stdio` that fails if the binary opens a port instead of answering
  stdin. `--target sidecar` stays the default, so existing behaviour is
  unchanged.
- **Both installers fetch both binaries** through one shared download-and-verify
  path, so the second binary cannot be the one where a checksum step quietly goes
  missing. A platform the flagship has no build for (linux-arm64, win-arm64) is
  refused in `detect_environment` — before uv and the venv — rather than
  half-installing and failing at the download.
- **The native NSIS/deb/pkg payload** reads the same new lock lane, since it also
  puts `gaia-agent` on PATH. Left alone it would keep staging the sidecar.

No `.installed` sentinel is written. One under `~/.gaia/agents/gaia/` flips the
flagship to daemon transport via `applyInstalledRecord`, which would break the
launch this fixes; PATH resolution is what the gate actually uses.

> [!IMPORTANT]
> **Merge after a flagship release, not before.** The installers ask for
> `gaia-agent-stdio-*`, which nothing has published yet, so on today's hub they
> fail loudly at that step. Land this, cut a `gaia` agent release so the freeze
> job publishes the artifacts and fills the lock's `PENDING` digests, and the
> one-liner works. Merging it ahead of that release trades a blocked TUI for a
> failed install.

## Test plan

Frozen binary, real hub, real gate — not mocks.

- [x] **The frozen stdio binary boots and speaks the wire.** `freeze.py --onefile
  --target stdio` on Windows → 112.6 MB exe; `smoke_test.py --mode stdio` PASSes
  all three checks (startup ping, no HTTP listener on 8141, `/model` round trip).
  Three consecutive runs; first-ever execution of a fresh exe failed once to
  Defender scanning it, then was stable at ~30s startup.
- [x] **Passes with Lemonade down** — the CI runner's state.
  `LEMONADE_BASE_URL=http://127.0.0.1:59999` → `lemonade_reachable: false`, still
  PASS.
- [x] **The smoke test can actually fail.** Against the published *sidecar* it
  reports the uvicorn listener and fails — that is the regression guard.
- [x] **Cold install on Linux (WSL, throwaway `HOME`, real hub).** `install_tui`
  + `install_agent` → both land in `~/.gaia/bin`, executable, digests verified
  against the manifest.
- [x] **The TUI gate goes green.** Drove `gaia-tui` via the control API against a
  throwaway profile: without `gaia-agent`, `blocker: "binary"` and the circular
  remedy; with it on PATH and **no sentinel**, `[ok] GAIA agent` / `[ok]
  Lemonade`, blocker moves to `model`.
- [x] **PowerShell path exercised** (Windows PowerShell 5.1, fake hub):
  `Install-Agent` installs `gaia-agent.exe` and the bytes prove it took the
  *stdio* artifact, not the sidecar sitting in the same lane. Corrupt digest →
  refuses, installs nothing. `win-arm64` → refuses, names the platform.
- [x] `pytest tests/unit/installer/test_install_scripts.py tests/unit/test_fetch_sidecar.py`
  — 76 passed on Linux (`/bin/sh` is dash, so the shell tests run under it).
- [x] `npm test` in `hub/agents/gaia/npm` — 146 passed. The lock gained a third
  lane; the shipped-lock test asserted exactly two.

Not verified here: the download path end-to-end, since the artifact is
unpublished until the release above — hence the merge-order note. macOS and the
`darwin-*` / `linux-x64` freeze legs run first in CI.
