### PR TITLE
fix(installer): install the stdio agent the TUI spawns, not the REST sidecar

### DIFF
--- a/.github/workflows/release_agent_gaia.yml
+++ b/.github/workflows/release_agent_gaia.yml
@@ -5,7 +5,7 @@
 # (@amd-gaia/gaia on npm, gaia-agent-gaia on the Agent Hub). One namespaced tag
 # does the whole release.
 #
-# TWO shipped components, from TWO DIFFERENT HUB LANES:
+# THREE shipped components, from TWO DIFFERENT HUB LANES:
 #
 #   sidecar — the agent's REST sidecar, frozen with PyInstaller into a one-file
 #             native binary per platform. PyInstaller cannot cross-compile, so
@@ -13,6 +13,19 @@
 #             publishes it, into agents/gaia/<version>/:
 #               gaia-agent-win32-x64.exe / -darwin-arm64 / -darwin-x64 / -linux-x64
 #             Installed executable name: gaia-agent[.exe]
+#   stdio   — the SAME agent frozen against packaging/stdio_entry.py instead: a
+#             JSONL child speaking over stdin/stdout. This is what the terminal
+#             UI actually spawns (TransportSubprocess, seedAgents() in
+#             tui/internal/catalog/catalog.go); the REST sidecar ignores stdin
+#             and can never serve it, so before this lane existed the hub
+#             published no artifact the TUI could launch. Built by the SAME
+#             freeze legs, published into the same agents/gaia/<version>/:
+#               gaia-agent-stdio-win32-x64.exe / -darwin-arm64 / -darwin-x64 /
+#               -linux-x64
+#             Installed executable name: gaia-agent[.exe] — the name the TUI
+#             looks for. That is the SAME installed name the sidecar uses, and
+#             the npm client writes every component into ONE cache directory, so
+#             a consumer must fetch one transport or the other, never both.
 #   tui     — the Go terminal UI, CONSUMED (not built) from the published
 #             `terminal-hub` component at agents/terminal-hub/<tuiVersion>/:
 #               gaia-{win-x64,win-arm64,darwin-arm64,darwin-x64,
@@ -31,9 +44,9 @@
 # version fails the release loudly, naming the version required. There is no
 # fallback to building our own.
 #
-# binaries.lock.json is therefore TWO-LANE (schemaVersion "3.0") — each component
-# carries its own version and base URL, which one shared top-level baseUrl could
-# not express:
+# binaries.lock.json is therefore PER-COMPONENT (schemaVersion "3.0") — each
+# component carries its own version and base URL, which one shared top-level
+# baseUrl could not express (sidecar and stdio share a lane; tui does not):
 #   { schemaVersion, agentVersion,
 #     components: { <name>: { componentVersion, baseUrl, platforms: {...} } } }
 # gen_binaries_lock.py writes each lane from the per-artifact meta records the
@@ -44,9 +57,10 @@
 #                  fail fast if it disagrees with package.json or
 #                  gaia-agent.yaml, or if stamp_version.py --check finds drift.
 #                  Also reads the terminal-hub pin out of the committed lock.
-#                  Runs BEFORE ~40 runner-minutes of freezing.
-#   2. freeze    — per-platform PyInstaller freeze of the sidecar, smoke-tested
-#                  on the frozen binary itself, staged under its hub name with a
+#                  Runs BEFORE ~80 runner-minutes of freezing.
+#   2. freeze    — per-platform PyInstaller freeze of BOTH the sidecar and the
+#                  stdio binary, each smoke-tested on the frozen file itself in
+#                  its own transport's mode, staged under its hub name with a
 #                  SHA-256 + size meta.
 #   3. tui       — prove the pinned terminal-hub version is published, download
 #                  all 6 artifacts from that lane, and cross-check each against
@@ -54,10 +68,11 @@
 #   4. tests     — the gaia agent's Python test suite + the npm package's vitest
 #                  suite. A failure blocks the release.
 #   5. publish   — behind the `agent-publish` environment's manual approval:
-#                  POST the SIDECAR binaries + gaia-agent.yaml to the Agent Hub
-#                  Worker's /publish endpoint, regenerate binaries.lock.json with
-#                  the REAL hashes for both lanes, verify every entry is
-#                  fetchable AND hash-matches at the public origin, then
+#                  POST the SIDECAR + STDIO binaries + gaia-agent.yaml to the
+#                  Agent Hub Worker's /publish endpoint, regenerate
+#                  binaries.lock.json with the REAL hashes for all three
+#                  components, verify every entry is fetchable AND hash-matches
+#                  at the public origin, then
 #                  `npm publish` via npm trusted publishing (OIDC, provenance —
 #                  NO npm token).
 #
@@ -323,9 +338,9 @@ jobs:
             [ -f "$f" ] || echo "::warning::${f} not found — the release will publish without that hub doc tab."
           done
 
-  # ── Stage 2: native sidecar freeze on every platform ────────────────
+  # ── Stage 2: native freeze (sidecar + stdio) on every platform ──────
   freeze:
-    name: Freeze sidecar (${{ matrix.key }})
+    name: Freeze binaries (${{ matrix.key }})
     runs-on: ${{ matrix.os }}
     needs: [version]
     # darwin-x64 (Intel) is BEST-EFFORT, built on macos-26-intel (the latest
@@ -339,7 +354,12 @@ jobs:
     # REQUIRED platforms. A miss is announced LOUDLY (::warning:: + job summary)
     # and Intel users still fail loudly at install — never silent.
     continue-on-error: ${{ !matrix.required }}
-    timeout-minutes: ${{ matrix.required && 40 || 60 }}
+    # Two full PyInstaller freezes per leg, not one, and freeze.py passes
+    # --clean so the second gets no warm analysis cache — it costs about what
+    # the first did. The dependency install is the only part still paid once.
+    # 40 -> 75 keeps roughly the old headroom over an observed ~45 min; the
+    # best-effort Intel leg is the slowest runner, so 60 -> 100.
+    timeout-minutes: ${{ matrix.required && 75 || 100 }}
     strategy:
       # Never let one slow/stuck leg cancel the others — each platform freezes
       # independently and `publish` reconciles whatever arrived.
@@ -351,18 +371,24 @@ jobs:
             key: win32-x64
             artifact: gaia-agent-win32-x64.exe
             frozen: gaia-agent.exe
+            stdio_artifact: gaia-agent-stdio-win32-x64.exe
+            stdio_frozen: gaia-agent-stdio.exe
             required: true
           - os: macos-14
             platform: darwin-arm64
             key: darwin-arm64
             artifact: gaia-agent-darwin-arm64
             frozen: gaia-agent
+            stdio_artifact: gaia-agent-stdio-darwin-arm64
+            stdio_frozen: gaia-agent-stdio
             required: true
           - os: ubuntu-latest
             platform: linux-x64
             key: linux-x64
             artifact: gaia-agent-linux-x64
             frozen: gaia-agent
+            stdio_artifact: gaia-agent-stdio-linux-x64
+            stdio_frozen: gaia-agent-stdio
             required: true
           # darwin-x64 (Intel) BEST-EFFORT — see the job-level comment above.
           - os: macos-26-intel
@@ -370,6 +396,8 @@ jobs:
             key: darwin-x64
             artifact: gaia-agent-darwin-x64
             frozen: gaia-agent
+            stdio_artifact: gaia-agent-stdio-darwin-x64
+            stdio_frozen: gaia-agent-stdio
             required: false
     steps:
       - uses: actions/checkout@v7
@@ -404,7 +432,7 @@ jobs:
             -e hub/agents/gaia/python \
             pyinstaller
 
-      - name: Freeze one-file binary
+      - name: Freeze one-file binary (sidecar / REST)
         shell: bash
         run: |
           set -euo pipefail
@@ -415,43 +443,80 @@ jobs:
       # An import that only resolves in the dev venv (a hidden import PyInstaller
       # missed, a package-data file that didn't get collected) fails here rather
       # than on a user's machine after the tag is immutable.
-      - name: Smoke-test the frozen binary
+      - name: Smoke-test the frozen sidecar binary
         shell: bash
         run: |
           set -euo pipefail
           PY=.venv-freeze/$([ "$RUNNER_OS" = "Windows" ] && echo Scripts || echo bin)/python
-          "$PY" "${PACKAGING}/smoke_test.py" "${FREEZE_DIST}/${{ matrix.frozen }}"
+          "$PY" "${PACKAGING}/smoke_test.py" --mode sidecar "${FREEZE_DIST}/${{ matrix.frozen }}"
 
-      - name: Stage artifact + compute SHA-256 / size
+      # Both targets build into the same dist/ under DIFFERENT names, and
+      # freeze.py cleans only its own target's paths (_clean_target_outputs), so
+      # this copy is ordering-independent. Kept here so a failed stdio freeze
+      # cannot leave the sidecar unstaged.
+      - name: Stage the sidecar binary out of dist/
         shell: bash
         run: |
           set -euo pipefail
           mkdir -p staging
           cp "${FREEZE_DIST}/${{ matrix.frozen }}" "staging/${{ matrix.artifact }}"
-          python - "staging/${{ matrix.artifact }}" "${{ matrix.platform }}" "${{ matrix.artifact }}" "${{ matrix.frozen }}" <<'PY'
+
+      # The transport the terminal UI actually spawns. Same code, same venv,
+      # different entry point (packaging/stdio_entry.py) and a distinct
+      # PyInstaller --name so it cannot collide with the sidecar in dist/.
+      - name: Freeze one-file binary (stdio / JSONL)
+        shell: bash
+        run: |
+          set -euo pipefail
+          PY=.venv-freeze/$([ "$RUNNER_OS" = "Windows" ] && echo Scripts || echo bin)/python
+          "$PY" "${PACKAGING}/freeze.py" --onefile --target stdio
+
+      # Same gate as the sidecar's, in the transport this binary actually
+      # speaks — an HTTP /health probe can never pass against a stdio child, so
+      # `--mode stdio` is what makes this a real check rather than a formality.
+      - name: Smoke-test the frozen stdio binary
+        shell: bash
+        run: |
+          set -euo pipefail
+          PY=.venv-freeze/$([ "$RUNNER_OS" = "Windows" ] && echo Scripts || echo bin)/python
+          "$PY" "${PACKAGING}/smoke_test.py" --mode stdio "${FREEZE_DIST}/${{ matrix.stdio_frozen }}"
+
+      - name: Stage artifacts + compute SHA-256 / size
+        shell: bash
+        run: |
+          set -euo pipefail
+          cp "${FREEZE_DIST}/${{ matrix.stdio_frozen }}" "staging/${{ matrix.stdio_artifact }}"
+          python - "${{ matrix.platform }}" \
+            "sidecar=${{ matrix.artifact }}" \
+            "stdio=${{ matrix.stdio_artifact }}" <<'PY'
           import hashlib, json, sys
-          path, platform, filename, frozen = sys.argv[1:5]
-          data = open(path, "rb").read()
-          meta = {
-              "component": "sidecar",
-              "platform": platform,
-              "filename": filename,
-              "executable": "gaia-agent.exe" if frozen.endswith(".exe") else "gaia-agent",
-              "sha256": hashlib.sha256(data).hexdigest(),
-              "size": len(data),
-          }
-          with open(f"staging/sidecar-{platform}.meta.json", "w") as fh:
-              fh.write(json.dumps([meta], indent=2))
-          print(json.dumps(meta, indent=2))
+          platform, *specs = sys.argv[1:]
+          for spec in specs:
+              component, _, filename = spec.partition("=")
+              data = open(f"staging/{filename}", "rb").read()
+              meta = {
+                  "component": component,
+                  "platform": platform,
+                  "filename": filename,
+                  # Both transports install under the name the TUI spawns.
+                  "executable": "gaia-agent.exe" if filename.endswith(".exe") else "gaia-agent",
+                  "sha256": hashlib.sha256(data).hexdigest(),
+                  "size": len(data),
+              }
+              with open(f"staging/{component}-{platform}.meta.json", "w") as fh:
+                  fh.write(json.dumps([meta], indent=2))
+              print(json.dumps(meta, indent=2))
           PY
 
-      - name: Upload platform artifact
+      - name: Upload platform artifacts
         uses: actions/upload-artifact@v7
         with:
           name: gaia-agent-${{ matrix.key }}
           path: |
             staging/${{ matrix.artifact }}
+            staging/${{ matrix.stdio_artifact }}
             staging/sidecar-${{ matrix.platform }}.meta.json
+            staging/stdio-${{ matrix.platform }}.meta.json
           if-no-files-found: error
 
   # ── Stage 3: verify the pinned terminal-hub component ───────────────
@@ -791,15 +856,15 @@ jobs:
             exit 1
           fi
 
-      - name: Download sidecar artifacts
+      - name: Download freeze artifacts (sidecar + stdio)
         uses: actions/download-artifact@v8
         with:
           pattern: gaia-agent-*
-          path: artifacts/sidecar
+          path: artifacts/freeze
 
       # Metas only: the TUI binaries stay in the terminal-hub lane and are never
-      # copied into ours. `bins/` below therefore holds sidecar artifacts alone,
-      # which is exactly what gets POSTed to /publish.
+      # copied into ours. `bins/` below therefore holds only the two frozen
+      # transports, which is exactly what gets POSTed to /publish.
       - name: Download terminal-hub metas
         uses: actions/download-artifact@v8
         with:
@@ -816,28 +881,35 @@ jobs:
           find artifacts -type f -name '*.meta.json' -exec cp {} metas/ \;
           find artifacts -type f -name 'gaia-agent-*' ! -name '*.meta.json' \
             -exec cp {} bins/ \;
-          echo "=== collected binaries (sidecar only) ===" && ls -la bins/
+          echo "=== collected binaries (sidecar + stdio only) ===" && ls -la bins/
           echo "=== collected metas ===" && ls -la metas/
 
-          # Nothing but the sidecar may be published under agents/gaia/. Anything
-          # else staged here — a terminal UI binary above all — would mean the
-          # duplicate publish this release deliberately dropped crept back in.
+          # Only the two frozen transports may be published under agents/gaia/.
+          # Anything else staged here — a terminal UI binary above all — would
+          # mean the duplicate publish this release deliberately dropped crept
+          # back in.
           for f in bins/*; do
             [ -f "$f" ] || continue
             case "$(basename "$f")" in
+              gaia-agent-stdio-*) ;;
               gaia-agent-*) ;;
               *)
-                echo "::error::'$(basename "$f")' is staged for publish in bins/, but this release publishes ONLY the sidecar (gaia-agent-*) under agents/gaia/. The terminal UI is consumed from the published terminal-hub component and must never be republished here. Remove whatever job staged it."
+                echo "::error::'$(basename "$f")' is staged for publish in bins/, but this release publishes ONLY the frozen agent transports (gaia-agent-* and gaia-agent-stdio-*) under agents/gaia/. The terminal UI is consumed from the published terminal-hub component and must never be republished here. Remove whatever job staged it."
                 exit 1
                 ;;
             esac
           done
 
           missing=()
-          # Sidecar: the 3 non-Intel platforms are REQUIRED. A missing one is a
-          # real build failure, not best-effort — fail the release loudly.
+          # Both transports on the 3 non-Intel platforms are REQUIRED. A missing
+          # one is a real build failure, not best-effort — fail the release
+          # loudly. A release without the stdio binary publishes nothing the
+          # terminal UI can spawn, which is the gap this lane exists to close.
           for f in gaia-agent-win32-x64.exe gaia-agent-darwin-arm64 gaia-agent-linux-x64; do
             [ -f "bins/$f" ] || missing+=("sidecar:$f")
+          done
+          for f in gaia-agent-stdio-win32-x64.exe gaia-agent-stdio-darwin-arm64 gaia-agent-stdio-linux-x64; do
+            [ -f "bins/$f" ] || missing+=("stdio:$f")
           done
           if [ "${#missing[@]}" -gt 0 ]; then
             echo "::error::required release artifacts missing: ${missing[*]}. Their build leg failed — the release cannot proceed. Re-run those jobs, then re-approve."
@@ -848,32 +920,49 @@ jobs:
           # drops that platform. The 6 tui metas come from the terminal-hub
           # verify job, not from a build here.
           for m in sidecar-win32-x64 sidecar-darwin-arm64 sidecar-linux-x64 \
+                   stdio-win32-x64 stdio-darwin-arm64 stdio-linux-x64 \
                    tui-win32-x64 tui-win32-arm64 tui-darwin-arm64 \
                    tui-darwin-x64 tui-linux-x64 tui-linux-arm64; do
             if [ ! -f "metas/${m}.meta.json" ]; then
-              echo "::error::missing artifact meta metas/${m}.meta.json — binaries.lock.json would ship without an entry for it. Re-run the job that produces it (freeze for sidecar-*, the terminal-hub verify for tui-*)."
+              echo "::error::missing artifact meta metas/${m}.meta.json — binaries.lock.json would ship without an entry for it. Re-run the job that produces it (freeze for sidecar-*/stdio-*, the terminal-hub verify for tui-*)."
               exit 1
             fi
           done
 
-          # darwin-x64 sidecar (Intel) is BEST-EFFORT.
-          if [ -f "bins/gaia-agent-darwin-x64" ] && [ -f "metas/sidecar-darwin-x64.meta.json" ]; then
-            echo "DARWIN_X64_SIDECAR=true" >> "$GITHUB_ENV"
-            echo "darwin-x64 (Intel) sidecar present — full 4-platform sidecar release."
-          else
-            echo "DARWIN_X64_SIDECAR=false" >> "$GITHUB_ENV"
+          # darwin-x64 (Intel) is BEST-EFFORT for BOTH transports. They come from
+          # the same freeze leg, which uploads both or neither, so a half-set
+          # means that leg produced something unexpected — fail rather than ship
+          # one transport for a platform.
+          intel_have=() intel_lack=()
+          for pair in "sidecar:gaia-agent-darwin-x64" "stdio:gaia-agent-stdio-darwin-x64"; do
+            lane="${pair%%:*}"; file="${pair#*:}"
+            if [ -f "bins/${file}" ] && [ -f "metas/${lane}-darwin-x64.meta.json" ]; then
+              intel_have+=("${lane}")
+            else
+              intel_lack+=("${lane}")
+            fi
+          done
+          if [ "${#intel_lack[@]}" -eq 0 ]; then
+            echo "DARWIN_X64_INTEL=true" >> "$GITHUB_ENV"
+            echo "darwin-x64 (Intel) present for both transports — full 4-platform release."
+          elif [ "${#intel_have[@]}" -eq 0 ]; then
+            echo "DARWIN_X64_INTEL=false" >> "$GITHUB_ENV"
             # Never publish a binary we have no verified hash for.
-            rm -f bins/gaia-agent-darwin-x64 metas/sidecar-darwin-x64.meta.json
-            echo "::warning::darwin-x64 (Intel macOS) SIDECAR not published — its best-effort freeze leg did not produce a binary + meta. Releasing the other 3 sidecar platforms; Intel-mac users get a loud 'no sidecar binary for darwin-x64' error at install until one is published for this version. (The terminal UI is unaffected — it is consumed from the published terminal-hub component, not built here.)"
+            rm -f bins/gaia-agent-darwin-x64 metas/sidecar-darwin-x64.meta.json \
+                  bins/gaia-agent-stdio-darwin-x64 metas/stdio-darwin-x64.meta.json
+            echo "::warning::darwin-x64 (Intel macOS) NOT published — its best-effort freeze leg did not produce binaries + metas for either transport. Releasing the other 3 platforms; Intel-mac users get a loud 'no binary for darwin-x64' error at install until one is published for this version. (The terminal UI is unaffected — it is consumed from the published terminal-hub component, not built here.)"
             {
-              echo "### ⚠️ Intel macOS (darwin-x64) sidecar NOT published"
+              echo "### ⚠️ Intel macOS (darwin-x64) NOT published"
               echo ""
-              echo "The best-effort \`darwin-x64\` PyInstaller freeze did not produce a usable binary, so this release ships **3 of 4** sidecar platforms. The terminal UI is unaffected — it comes from the published \`terminal-hub\` component."
+              echo "The best-effort \`darwin-x64\` PyInstaller freeze did not produce usable binaries, so this release ships **3 of 4** platforms for both the sidecar and the stdio agent. The terminal UI is unaffected — it comes from the published \`terminal-hub\` component."
               echo ""
-              echo "Intel-mac users will hit a loud install error until an Intel sidecar is published for this version."
+              echo "Intel-mac users will hit a loud install error until an Intel build is published for this version."
               echo ""
-              echo "**Follow-up:** re-run once the Intel leg succeeds; \`POST /publish\` is immutable-per-filename, so adding the Intel binary to the *same* version is safe and idempotent."
+              echo "**Follow-up:** re-run once the Intel leg succeeds; \`POST /publish\` is immutable-per-filename, so adding the Intel binaries to the *same* version is safe and idempotent."
             } >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "::error::darwin-x64 (Intel) produced ${intel_have[*]} but not ${intel_lack[*]}. Both transports are built by the same freeze leg, so it uploads both or neither — a half-set means that leg was tampered with or its upload was partial. Refusing to publish an inconsistent Intel release; re-run the darwin-x64 freeze leg, then re-approve."
+            exit 1
           fi
 
       - name: Publish binaries to the Agent Hub (POST /publish)
@@ -921,7 +1010,7 @@ jobs:
             fi
           done
 
-          # Sidecar binaries only — the TUI is already published in the
+          # The two frozen transports only — the TUI is already published in the
           # terminal-hub lane and is deliberately not republished here.
           args=()
           for f in bins/*; do
@@ -952,8 +1041,8 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          # Every meta from every leg, both lanes. gen_binaries_lock writes each
-          # lane's componentVersion + baseUrl + platforms, refuses a
+          # Every meta from every leg, all three components. gen_binaries_lock
+          # writes each one's componentVersion + baseUrl + platforms, refuses a
           # placeholder/non-sha256 hash, and rejects a tui filename that is not
           # what terminal-hub publishes — so a bad record fails here rather than
           # shipping an unverifiable lock. The fetch-verify below proves these
@@ -976,22 +1065,22 @@ jobs:
             "${meta_args[@]}"
 
           # gen_binaries_lock.py keeps the PRIOR entry for any platform absent
-          # from the metas. If the best-effort Intel sidecar was skipped, that
-          # prior entry is the committed PENDING-replace-with-real-sha256
-          # placeholder — drop it so the shipped lock carries NO sidecar
-          # darwin-x64 entry. The installer then emits a clear "no sidecar
+          # from the metas. If the best-effort Intel leg was skipped, that prior
+          # entry is the committed PENDING-replace-with-real-sha256 placeholder
+          # — drop it from BOTH gaia-lane components so the shipped lock carries
+          # no darwin-x64 entry at all. The installer then emits a clear "no
           # binary for darwin-x64 (available: …)" error instead of chasing an
           # object that was never published. Explicit absence beats a
           # placeholder hash.
-          if [ "${DARWIN_X64_SIDECAR}" = "false" ]; then
+          if [ "${DARWIN_X64_INTEL}" = "false" ]; then
             python - "${PKG_DIR}/binaries.lock.json" <<'PY'
           import json, sys
           p = sys.argv[1]
           lock = json.load(open(p))
-          platforms = lock.get("components", {}).get("sidecar", {}).get("platforms", {})
-          removed = platforms.pop("darwin-x64", None)
-          if removed is not None:
-              print("[lock] dropped unpublished sidecar/darwin-x64 entry (Intel best-effort skip)")
+          for component in ("sidecar", "stdio"):
+              platforms = lock.get("components", {}).get(component, {}).get("platforms", {})
+              if platforms.pop("darwin-x64", None) is not None:
+                  print(f"[lock] dropped unpublished {component}/darwin-x64 entry (Intel best-effort skip)")
           open(p, "w").write(json.dumps(lock, indent=2) + "\n")
           PY
           fi
@@ -1063,11 +1152,11 @@ jobs:
 
           lock = json.load(open(sys.argv[1]))
           components = lock.get("components") or {}
-          if sorted(components) != ["sidecar", "tui"]:
+          if sorted(components) != ["sidecar", "stdio", "tui"]:
               print(
                   "::error::regenerated binaries.lock.json does not carry exactly the "
-                  f"sidecar + tui components (got: {', '.join(sorted(components)) or 'none'}). "
-                  "Expected the two-lane schemaVersion 3.0 shape. gen_binaries_lock.py "
+                  f"sidecar + stdio + tui components (got: {', '.join(sorted(components)) or 'none'}). "
+                  "Expected the schemaVersion 3.0 shape. gen_binaries_lock.py "
                   "did not write what this release expects; refusing to publish an "
                   "unverifiable lock.",
                   flush=True,
@@ -1178,5 +1267,5 @@ jobs:
             echo ""
             echo "- Hub: \`${BASE_URL}\`"
             echo "- npm: \`${NPM_PKG}@${VERSION}\`"
-            echo "- Intel sidecar published: \`${DARWIN_X64_SIDECAR:-unknown}\`"
+            echo "- Intel (darwin-x64) published: \`${DARWIN_X64_INTEL:-unknown}\`"
           } >> "$GITHUB_STEP_SUMMARY"

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -116,6 +116,8 @@ Install GAIA globally with a single command:
     - ✅ Download Python 3.12 (if needed)
     - ✅ Create `%USERPROFILE%\.gaia\venv` virtual environment
     - ✅ Install GAIA CLI (accessible globally via PATH)
+    - ✅ Download `gaia-tui` and the `gaia-agent` it runs, each verified
+      against the SHA-256 the Agent Hub publishes
     - ✅ Add GAIA to your PATH
 
     <Tip>
@@ -138,6 +140,8 @@ Install GAIA globally with a single command:
     - ✅ Download Python 3.12 (if needed)
     - ✅ Create `~/.gaia/venv` virtual environment
     - ✅ Install GAIA CLI (accessible globally via PATH)
+    - ✅ Download `gaia-tui` and the `gaia-agent` it runs, each verified
+      against the SHA-256 the Agent Hub publishes
     - ✅ Add GAIA to your PATH
 
     <Tip>

--- a/hub/agents/gaia/npm/binaries.lock.json
+++ b/hub/agents/gaia/npm/binaries.lock.json
@@ -32,6 +32,36 @@
         }
       }
     },
+    "stdio": {
+      "componentVersion": "0.1.1",
+      "baseUrl": "https://hub.amd-gaia.ai/agents/gaia/0.1.1",
+      "platforms": {
+        "win32-x64": {
+          "filename": "gaia-agent-stdio-win32-x64.exe",
+          "executable": "gaia-agent.exe",
+          "sha256": "PENDING-replace-with-real-sha256",
+          "size": 0
+        },
+        "darwin-arm64": {
+          "filename": "gaia-agent-stdio-darwin-arm64",
+          "executable": "gaia-agent",
+          "sha256": "PENDING-replace-with-real-sha256",
+          "size": 0
+        },
+        "darwin-x64": {
+          "filename": "gaia-agent-stdio-darwin-x64",
+          "executable": "gaia-agent",
+          "sha256": "PENDING-replace-with-real-sha256",
+          "size": 0
+        },
+        "linux-x64": {
+          "filename": "gaia-agent-stdio-linux-x64",
+          "executable": "gaia-agent",
+          "sha256": "PENDING-replace-with-real-sha256",
+          "size": 0
+        }
+      }
+    },
     "tui": {
       "componentVersion": "0.23.0",
       "baseUrl": "https://hub.amd-gaia.ai/agents/terminal-hub/0.23.0",

--- a/hub/agents/gaia/npm/test/lock.test.ts
+++ b/hub/agents/gaia/npm/test/lock.test.ts
@@ -44,9 +44,31 @@ const EXPECTED_EXECUTABLE: Record<string, string> = {
 };
 
 describe("shipped binaries.lock.json", () => {
-  it("parses with the two-lane schema", () => {
+  it("carries every lane this package consumes", () => {
     expect(lock.schemaVersion).toMatch(/^3\./);
-    expect(Object.keys(lock.components).sort()).toEqual([...COMPONENTS].sort());
+    // A superset, not an exact match: the lock is the release's record of every
+    // artifact published from the gaia lane, and the native installers read a
+    // lane this package deliberately does not (see the `stdio` test below).
+    for (const component of COMPONENTS) {
+      expect(Object.keys(lock.components)).toContain(component);
+    }
+  });
+
+  // `gaia-agent-stdio-*` is the stdin/stdout JSONL child the TUI spawns; the
+  // `sidecar` lane is the REST server this package starts. Both install under
+  // the name `gaia-agent`, so adding `stdio` to COMPONENTS would make `fetch`
+  // download both into one cache directory and leave which transport `npx`
+  // installed up to whichever landed last.
+  it("records the stdio lane without consuming it", () => {
+    const stdio = lock.components["stdio"];
+    expect(stdio, "the release must record the TUI's stdio child").toBeDefined();
+    expect([...COMPONENTS]).not.toContain("stdio");
+
+    for (const [platform, entry] of Object.entries(stdio!.platforms)) {
+      expect(entry.filename, `stdio/${platform} must not be the REST sidecar`).toMatch(
+        /^gaia-agent-stdio-/,
+      );
+    }
   });
 
   // Pinning the literal version here would only force an edit every release;

--- a/hub/agents/gaia/python/packaging/freeze.py
+++ b/hub/agents/gaia/python/packaging/freeze.py
@@ -1,19 +1,33 @@
 # Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
 # SPDX-License-Identifier: MIT
 """
-Reproducible PyInstaller freeze for the GAIA flagship agent REST sidecar.
+Reproducible PyInstaller freeze for the GAIA flagship agent.
 
-Freezes ``packaging/server.py`` into a self-contained executable that boots the
-``/v1/gaia/*`` REST surface with NO Python interpreter on the target machine.
+Two DIFFERENT programs ship from this one package, and each needs its own
+binary. ``--target`` picks which:
+
+- ``--target sidecar`` (the default) freezes ``packaging/server.py`` as
+  ``gaia-agent``: the ``/v1/gaia/*`` REST surface the daemon supervises.
+- ``--target stdio`` freezes ``packaging/stdio_entry.py`` as
+  ``gaia-agent-stdio``: the stdin/stdout JSONL child the TUI spawns.
+
+The names differ so the two ``dist/`` outputs cannot collide — and because they
+are not interchangeable: the TUI spawns its child bare and scans stdout for JSON
+lines, so handed the sidecar it reads uvicorn's startup log instead (#3062).
 
 Usage (from a venv with the deps + pyinstaller installed)::
 
-    python hub/agents/gaia/python/packaging/freeze.py            # one-dir (default)
-    python hub/agents/gaia/python/packaging/freeze.py --onefile  # one-file
+    python .../freeze.py                            # sidecar, one-dir
+    python .../freeze.py --onefile                  # sidecar, one-file
+    python .../freeze.py --target stdio --onefile   # stdio, one-file
 
-Output:
-    one-dir:  hub/agents/gaia/python/packaging/dist/gaia-agent/gaia-agent[.exe]
-    one-file: hub/agents/gaia/python/packaging/dist/gaia-agent[.exe]
+Output (``<name>`` is the target's binary name above):
+    one-dir:  hub/agents/gaia/python/packaging/dist/<name>/<name>[.exe]
+    one-file: hub/agents/gaia/python/packaging/dist/<name>[.exe]
+
+Both targets are collected IDENTICALLY. They import the same agent, so the
+import graph is the same; a marginally larger binary is far cheaper than a
+string-import that only goes missing on one of them.
 
 Design notes / gotchas baked in (mirrors the email sidecar's freeze):
 - ``uvicorn`` loads its loops/protocols/lifespan impls by string import, so its
@@ -29,7 +43,7 @@ Design notes / gotchas baked in (mirrors the email sidecar's freeze):
   runtime (see ``gaia_agent/agent.py``).
 - We deliberately do NOT ``--collect-submodules gaia``: the whole core package
   pulls every agent + RAG + torch and explodes the binary. Static analysis from
-  the sidecar entry pulls only the reachable core modules.
+  the entry module pulls only the reachable core modules.
 - The agent's import graph reaches ``gaia.chat.sdk``, whose static graph reaches
   the ML stack (torch, transformers, ...). All inference is Lemonade over HTTP
   and never runs in-process, so the ML stack is EXCLUDED to keep the binary lean.
@@ -43,11 +57,36 @@ import os
 import shutil
 import sys
 import time
+from dataclasses import dataclass
 from pathlib import Path
 
 HERE = Path(__file__).resolve().parent
-ENTRY = HERE / "server.py"
-NAME = "gaia-agent"
+
+
+@dataclass(frozen=True)
+class Target:
+    """One freezable program: which file is the entry, what the binary is called."""
+
+    entry: Path
+    name: str
+    summary: str
+
+
+TARGETS = {
+    "sidecar": Target(
+        entry=HERE / "server.py",
+        name="gaia-agent",
+        summary="REST sidecar; serves /v1/gaia/* for the daemon",
+    ),
+    "stdio": Target(
+        entry=HERE / "stdio_entry.py",
+        name="gaia-agent-stdio",
+        summary="stdio JSONL child; one query per stdin line, for the TUI",
+    ),
+}
+#: Freezing the sidecar is what every existing caller means by "freeze".
+DEFAULT_TARGET = "sidecar"
+
 # Repo root: packaging/ -> python/ -> gaia/ -> agents/ -> hub/ -> <root>
 REPO_ROOT = HERE.parents[4]
 PKG_ROOT = REPO_ROOT / "hub" / "agents" / "gaia" / "python"
@@ -183,8 +222,35 @@ def _resolve_add_data() -> list[tuple[Path, str]]:
     return add_data
 
 
-def build(onefile: bool = False, clean: bool = True) -> Path:
+def _exe_suffix() -> str:
+    return ".exe" if sys.platform == "win32" else ""
+
+
+def _clean_target_outputs(work: Path, dist: Path, name: str) -> None:
+    """Remove only THIS target's build/dist paths, never the whole tree.
+
+    The release job freezes both targets into the same ``dist/``, so wiping it
+    wholesale would delete the sibling binary that was just built.
+    """
+    shutil.rmtree(work / name, ignore_errors=True)
+    # onedir puts a directory here; onefile puts a file of the same stem.
+    shutil.rmtree(dist / name, ignore_errors=True)
+    onefile_exe = dist / (name + _exe_suffix())
+    if onefile_exe.is_file():
+        onefile_exe.unlink()
+
+
+def build(
+    onefile: bool = False, clean: bool = True, target: str = DEFAULT_TARGET
+) -> Path:
     import PyInstaller.__main__
+
+    spec = TARGETS[target]
+    if not spec.entry.is_file():
+        raise SystemExit(
+            f"freeze: the '{target}' entry is missing: {spec.entry}\n"
+            "PyInstaller has nothing to freeze. Restore the file and re-run."
+        )
 
     _verify_collect_targets()
     add_data = _resolve_add_data()
@@ -192,14 +258,14 @@ def build(onefile: bool = False, clean: bool = True) -> Path:
     work = HERE / "build"
     dist = HERE / "dist"
     if clean:
-        for d in (work, dist):
-            if d.exists():
-                shutil.rmtree(d, ignore_errors=True)
+        _clean_target_outputs(work, dist, spec.name)
+
+    print(f"freeze: target '{target}' -> {spec.name} ({spec.summary})", flush=True)
 
     args = [
-        str(ENTRY),
+        str(spec.entry),
         "--name",
-        NAME,
+        spec.name,
         "--console",
         "--noconfirm",
         "--clean",
@@ -228,8 +294,9 @@ def build(onefile: bool = False, clean: bool = True) -> Path:
     PyInstaller.__main__.run(args)
     elapsed = time.time() - t0
 
-    suffix = ".exe" if sys.platform == "win32" else ""
-    exe = dist / (NAME + suffix) if onefile else dist / NAME / (NAME + suffix)
+    name = spec.name
+    suffix = _exe_suffix()
+    exe = dist / (name + suffix) if onefile else dist / name / (name + suffix)
     print(f"\nBuild finished in {elapsed:.1f}s")
     print(f"Executable: {exe}")
     if exe.exists():
@@ -237,7 +304,7 @@ def build(onefile: bool = False, clean: bool = True) -> Path:
             size = exe.stat().st_size
         else:
             size = sum(
-                p.stat().st_size for p in (dist / NAME).rglob("*") if p.is_file()
+                p.stat().st_size for p in (dist / name).rglob("*") if p.is_file()
             )
         print(
             f"Size: {size / 1e6:.1f} MB ({'one-file exe' if onefile else 'one-dir total'})"
@@ -248,12 +315,22 @@ def build(onefile: bool = False, clean: bool = True) -> Path:
 
 
 def main(argv=None) -> int:
-    parser = argparse.ArgumentParser(description="Freeze the GAIA agent REST sidecar.")
+    parser = argparse.ArgumentParser(
+        description="Freeze a GAIA flagship agent binary.",
+        epilog="targets: "
+        + "; ".join(f"{key} = {spec.summary}" for key, spec in TARGETS.items()),
+    )
     parser.add_argument(
         "--onefile", action="store_true", help="Build a single-file executable."
     )
+    parser.add_argument(
+        "--target",
+        choices=sorted(TARGETS),
+        default=DEFAULT_TARGET,
+        help=f"Which program to freeze (default: {DEFAULT_TARGET}).",
+    )
     args = parser.parse_args(argv)
-    exe = build(onefile=args.onefile)
+    exe = build(onefile=args.onefile, target=args.target)
     return 0 if exe.exists() else 1
 
 

--- a/hub/agents/gaia/python/packaging/gen_binaries_lock.py
+++ b/hub/agents/gaia/python/packaging/gen_binaries_lock.py
@@ -7,11 +7,16 @@ by the GAIA hub R2 catalog.
 The npm ``fetch`` CLI downloads each binary and verifies its SHA-256 against this
 lock -- the lock's hashes are the integrity gate the CLI enforces on download.
 
-Schema 3.0 (two lanes): this package ships TWO executables per platform, and
-they come from DIFFERENT hub lanes at DIFFERENT versions:
+Schema 3.0: this package ships THREE components, published across TWO hub lanes
+at DIFFERENT versions:
 
-* ``sidecar`` -- the frozen Python agent, published by this package's own
-  release into ``agents/gaia/<agentVersion>/``.
+* ``sidecar`` -- the frozen Python agent speaking REST, published by this
+  package's own release into ``agents/gaia/<agentVersion>/``.
+* ``stdio`` -- the SAME agent frozen against a stdio/JSONL entry point. This is
+  the transport the terminal UI spawns as a child process; the REST sidecar
+  ignores stdin and cannot serve it. Published into the SAME
+  ``agents/gaia/<agentVersion>/`` directory, so it shares the sidecar's version
+  and base URL and differs only in filename.
 * ``tui`` -- the Go terminal UI, which is the published ``terminal-hub``
   COMPONENT (``agents/terminal-hub/<tuiVersion>/``), built and published by the
   core release. This package consumes it; it does not build or republish it, so
@@ -25,6 +30,11 @@ Schema 2.0's single top-level ``baseUrl`` could not express two lanes::
       "agentVersion": "0.1.0",
       "components": {
         "sidecar": {
+          "componentVersion": "0.1.0",
+          "baseUrl": "https://hub.amd-gaia.ai/agents/gaia/0.1.0",
+          "platforms": {"win32-x64": {filename, executable, sha256, size}, ...}
+        },
+        "stdio": {
           "componentVersion": "0.1.0",
           "baseUrl": "https://hub.amd-gaia.ai/agents/gaia/0.1.0",
           "platforms": {"win32-x64": {filename, executable, sha256, size}, ...}
@@ -50,15 +60,20 @@ single-platform local run does not wipe the others; the CI release passes every
 platform's meta and regenerates the whole lock.
 
 Platform keys are the npm side's ``${process.platform}-${process.arch}``
-(``win32-x64``), for both components. The terminal-hub lane spells its Windows
+(``win32-x64``), for every component. The terminal-hub lane spells its Windows
 artifacts ``win-x64`` / ``win-arm64``; that difference is carried by the entry's
 ``filename``, and ``TUI_ARTIFACT_NAMES`` below is the authority both sides are
 checked against -- a meta whose tui filename does not match is rejected, because
 nothing else in this pipeline would catch it before a user hits a 404.
 
+The gaia-lane names are checked the same way for a different reason: ``sidecar``
+and ``stdio`` are published into ONE directory, so swapping their filenames
+would still hash-verify at publish time and quietly hand the installer the wrong
+transport.
+
 NO silent fallback: an unknown component, an unsupported platform for that
-component, an unexpected tui artifact name, a missing/placeholder sha256, a base
-URL that is not http(s), or a base URL whose trailing segment disagrees with its
+component, an unexpected artifact name, a missing/placeholder sha256, a base URL
+that is not http(s), or a base URL whose trailing segment disagrees with its
 component's version raises loudly.
 """
 
@@ -69,11 +84,16 @@ import json
 import re
 from pathlib import Path
 
-# The sidecar is frozen by PyInstaller on the four platforms GAIA ships wheels
-# for; the Go TUI cross-compiles to two more.
+# Both frozen transports come off the same PyInstaller legs, on the four
+# platforms GAIA ships wheels for; the Go TUI cross-compiles to two more.
 SIDECAR_PLATFORMS = {"win32-x64", "darwin-arm64", "darwin-x64", "linux-x64"}
+STDIO_PLATFORMS = SIDECAR_PLATFORMS
 TUI_PLATFORMS = SIDECAR_PLATFORMS | {"linux-arm64", "win32-arm64"}
-COMPONENTS = {"sidecar": SIDECAR_PLATFORMS, "tui": TUI_PLATFORMS}
+COMPONENTS = {
+    "sidecar": SIDECAR_PLATFORMS,
+    "stdio": STDIO_PLATFORMS,
+    "tui": TUI_PLATFORMS,
+}
 
 # npm platform key -> the artifact terminal-hub publishes under
 # agents/terminal-hub/<version>/. Mirrors TUI_ARTIFACT_NAMES in
@@ -86,6 +106,27 @@ TUI_ARTIFACT_NAMES = {
     "darwin-x64": "gaia-darwin-x64",
     "linux-x64": "gaia-linux-x64",
     "linux-arm64": "gaia-linux-arm64",
+}
+
+# npm platform key -> the artifact THIS package's release publishes under
+# agents/gaia/<agentVersion>/. Mirrors the freeze matrix in
+# .github/workflows/release_agent_gaia.yml.
+SIDECAR_ARTIFACT_NAMES = {
+    "win32-x64": "gaia-agent-win32-x64.exe",
+    "darwin-arm64": "gaia-agent-darwin-arm64",
+    "darwin-x64": "gaia-agent-darwin-x64",
+    "linux-x64": "gaia-agent-linux-x64",
+}
+STDIO_ARTIFACT_NAMES = {
+    "win32-x64": "gaia-agent-stdio-win32-x64.exe",
+    "darwin-arm64": "gaia-agent-stdio-darwin-arm64",
+    "darwin-x64": "gaia-agent-stdio-darwin-x64",
+    "linux-x64": "gaia-agent-stdio-linux-x64",
+}
+ARTIFACT_NAMES = {
+    "sidecar": SIDECAR_ARTIFACT_NAMES,
+    "stdio": STDIO_ARTIFACT_NAMES,
+    "tui": TUI_ARTIFACT_NAMES,
 }
 
 SCHEMA_VERSION = "3.0"
@@ -139,6 +180,23 @@ def _load_metas(paths: list[Path]) -> dict[str, dict[str, dict]]:
                     "TUI_ARTIFACT_NAMES here AND in "
                     "hub/agents/gaia/npm/src/platform.ts."
                 )
+            # sidecar and stdio share one hub directory, so a crossed filename
+            # publishes and hash-verifies cleanly and only shows up as the TUI
+            # failing to speak to a REST binary (or vice versa) on a user's box.
+            if (
+                component in ("sidecar", "stdio")
+                and rec.get("filename") != ARTIFACT_NAMES[component][plat]
+            ):
+                raise SystemExit(
+                    f"error: {p} {component}/{plat} names artifact "
+                    f"{rec.get('filename')!r}, but this package publishes "
+                    f"{ARTIFACT_NAMES[component][plat]!r} for that platform. The "
+                    "sidecar and stdio transports live in the same "
+                    "agents/gaia/<version>/ directory, so a swapped name would "
+                    "hash-verify at publish time and hand the installer the wrong "
+                    "binary. Fix the meta, or update ARTIFACT_NAMES here AND the "
+                    "freeze matrix in .github/workflows/release_agent_gaia.yml."
+                )
             try:
                 merged.setdefault(component, {})[plat] = {
                     "filename": rec["filename"],
@@ -173,16 +231,18 @@ def _checked_base_url(raw: str, version: str, flag: str) -> str:
 
 def main(argv=None) -> int:
     parser = argparse.ArgumentParser(
-        description="Regenerate the two-lane binaries.lock.json (schema 3.0)."
+        description="Regenerate the per-component binaries.lock.json (schema 3.0)."
     )
     parser.add_argument(
-        "--version", required=True, help="Agent (sidecar) version, e.g. 0.1.0."
+        "--version",
+        required=True,
+        help="Agent version — the sidecar's and the stdio binary's, e.g. 0.1.0.",
     )
     parser.add_argument(
         "--sidecar-base-url",
         required=True,
-        help="Public directory the sidecar's filenames are joined onto, e.g. "
-        "https://hub.amd-gaia.ai/agents/gaia/0.1.0",
+        help="Public directory the gaia-lane filenames (sidecar AND stdio) are "
+        "joined onto, e.g. https://hub.amd-gaia.ai/agents/gaia/0.1.0",
     )
     parser.add_argument(
         "--tui-version",
@@ -209,13 +269,15 @@ def main(argv=None) -> int:
     )
     args = parser.parse_args(argv)
 
+    gaia_lane_base = _checked_base_url(
+        args.sidecar_base_url, args.version, "--sidecar-base-url"
+    )
     lanes = {
-        "sidecar": (
-            args.version,
-            _checked_base_url(
-                args.sidecar_base_url, args.version, "--sidecar-base-url"
-            ),
-        ),
+        # sidecar and stdio are two freezes of the same agent published into one
+        # agents/gaia/<version>/ directory, so they share a version and base URL
+        # by construction rather than by two flags that could drift apart.
+        "sidecar": (args.version, gaia_lane_base),
+        "stdio": (args.version, gaia_lane_base),
         "tui": (
             args.tui_version,
             _checked_base_url(args.tui_base_url, args.tui_version, "--tui-base-url"),
@@ -278,6 +340,18 @@ def main(argv=None) -> int:
                     f"{rec.get('filename')!r}, but the terminal-hub lane publishes "
                     f"{TUI_ARTIFACT_NAMES[plat]!r}. This entry had no meta this run, "
                     "so it is a stale committed value -- fix it in the lock."
+                )
+            if (
+                component in ("sidecar", "stdio")
+                and rec.get("filename") != ARTIFACT_NAMES[component][plat]
+            ):
+                raise SystemExit(
+                    f"error: {args.lock} {component}/{plat} names artifact "
+                    f"{rec.get('filename')!r}, but this package publishes "
+                    f"{ARTIFACT_NAMES[component][plat]!r}. This entry had no meta "
+                    "this run, so it is a stale committed value -- fix it in the "
+                    "lock. The two transports share a hub directory, so nothing "
+                    "downstream would catch the swap."
                 )
 
     args.lock.write_text(json.dumps(lock, indent=2) + "\n", encoding="utf-8")

--- a/hub/agents/gaia/python/packaging/smoke_test.py
+++ b/hub/agents/gaia/python/packaging/smoke_test.py
@@ -1,10 +1,12 @@
 # Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
 # SPDX-License-Identifier: MIT
 """
-No-Python smoke test for the frozen GAIA flagship agent sidecar.
+No-Python smoke test for the frozen GAIA flagship agent binaries.
 
-Proves the FROZEN BINARY (not ``python -m ...``) boots and serves the sidecar
-contract:
+Two DIFFERENT programs freeze out of this package and each has its own wire, so
+each has its own mode. ``--mode`` picks which; the default is ``sidecar``.
+
+``--mode sidecar`` -- the REST surface the daemon supervises:
 
   1. Launch the binary as a subprocess -- binary only, no interpreter available
      to it.
@@ -15,7 +17,39 @@ contract:
      attach, so an empty one is a contract break, not cosmetic.
   5. ``GET /openapi.json`` -> contains ``/v1/gaia/query`` and ``/v1/gaia/init``.
 
-This harness runs under Python (it is a test driver), but the SERVER under test
+``--mode stdio`` -- the child the TUI spawns. This mode exists because the two
+binaries are indistinguishable from the outside: an HTTP sidecar frozen under
+the stdio name boots happily, passes any "did it start?" check, and then feeds
+uvicorn's startup log to a JSON line scanner (#3062). So the assertions are all
+about the WIRE:
+
+  1. Launch the binary BARE -- no argv at all, exactly as the TUI spawns the
+     flagship (``seedAgents`` in ``tui/internal/catalog/catalog.go`` declares no
+     ``BinaryArgs``). A binary that needs ``--host``/``--port`` to do anything is
+     the sidecar.
+  2. The first stdout line must be the startup model-state ping: a canonical
+     ``status`` event naming the model the agent resolved
+     (``gaia_agent/stdio.py`` ``_model_state_event``, written by ``main`` before
+     stdin is read). Reaching it proves the frozen binary constructed the whole
+     ``GaiaAgent`` -- every hidden import, every bundled data file.
+  3. Write ``{"gaia_query": "/model"}`` and expect exactly one terminal ``final``
+     event back. ``/model`` is intercepted before the LLM ever sees it
+     (``run_model_command``), so this is a real round trip that needs NO model
+     and NO Lemonade -- verified against a dead Lemonade URL, which the ping
+     reports as ``lemonade_reachable: false`` and otherwise ignores.
+  4. Nothing but JSON objects on stdout -- stdout IS the wire, and anything else
+     there renders in the TUI as an unreadable event.
+  5. Nothing listening on the sidecar's port, re-checked every second while
+     waiting for (2). This is the check that actually catches a mis-frozen
+     binary: uvicorn logs to STDERR, so the sidecar under the stdio name is not
+     noisy on stdout -- it is SILENT there, and silence alone would only fail at
+     the end of the startup window.
+
+It does NOT prove the agent can answer a question: no inference runs, so a model
+that loads but produces garbage passes this. That is deliberate -- requiring a
+model server would make the release gate depend on a runner that has one.
+
+This harness runs under Python (it is a test driver), but the program under test
 is the frozen binary. Uses only the stdlib so it has no install requirements.
 
 Exit code 0 = PASS, non-zero = FAIL. Verbose ``[smoke]`` logging throughout.
@@ -25,9 +59,11 @@ from __future__ import annotations
 
 import argparse
 import json
+import queue
 import socket
 import subprocess
 import sys
+import threading
 import time
 import urllib.error
 import urllib.request
@@ -38,6 +74,36 @@ PORT = 8142  # 8141 is the gaia sidecar's runtime port; 8131 is email. NEVER 400
 BASE = f"http://{HOST}:{PORT}"
 
 REQUIRED_PATHS = {"/v1/gaia/query", "/v1/gaia/init"}
+
+# The sidecar's default bind port. The stdio binary must never listen anywhere,
+# and this is the one port a mis-frozen stdio binary would land on.
+SIDECAR_DEFAULT_PORT = 8141
+
+# Must match gaia_agent.stdio.QUERY_KEY -- the agent only unwraps an object
+# carrying exactly this key, and a bare line would still be read as a query, so
+# using the wrapper is what actually exercises the host's half of the contract.
+QUERY_KEY = "gaia_query"
+
+# `/model` with no argument lists models and returns; it never reaches
+# process_query. See gaia_agent.stdio.is_model_command / run_model_command.
+MODEL_COMMAND = "/model"
+
+# Agent construction is eager (embeddings, two FAISS rebuilds, scratchpad DB,
+# filesystem index) -- ~21s from source on a warm dev box, and a onefile binary
+# must unpack itself before any of that starts on a cold CI runner.
+STDIO_STARTUP_DEADLINE_S = 300.0
+# The round trip itself is local bookkeeping: ~2s observed from source.
+STDIO_TURN_DEADLINE_S = 90.0
+
+
+# The agent's events carry non-ASCII (arrows, box drawing). The Windows runner's
+# console is cp1252, so printing one raises UnicodeEncodeError and the smoke test
+# dies mid-run looking like a binary failure. Reconfigure rather than escape the
+# text, so every log line is safe and not just the ones we remembered.
+if hasattr(sys.stdout, "reconfigure"):
+    sys.stdout.reconfigure(encoding="utf-8", errors="replace")
+if hasattr(sys.stderr, "reconfigure"):
+    sys.stderr.reconfigure(encoding="utf-8", errors="replace")
 
 
 def log(msg: str) -> None:
@@ -147,27 +213,295 @@ def check_openapi() -> bool:
     return True
 
 
-def main(argv=None) -> int:
-    parser = argparse.ArgumentParser(
-        description="Smoke-test the frozen GAIA agent sidecar."
-    )
-    parser.add_argument(
-        "binary", help="Path to the frozen gaia-agent executable to test."
-    )
-    args = parser.parse_args(argv)
+class StdioContractBreak(Exception):
+    """The frozen binary did not speak the TUI's stdin/stdout contract."""
 
-    binary = Path(args.binary).resolve()
-    if not binary.exists():
-        log(f"FAIL: binary not found: {binary}")
-        return 2
 
-    # Preflight: refuse if the port is already bound -- otherwise we would
-    # health-check a stale server and report a false PASS.
+def _port_is_open(port: int) -> bool:
     with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
         s.settimeout(2.0)
-        if s.connect_ex((HOST, PORT)) == 0:
-            log(f"FAIL: port {PORT} already in use -- kill the stale server first.")
-            return 2
+        return s.connect_ex((HOST, port)) == 0
+
+
+def _pump(stream, on_line, label: str) -> None:
+    """Read *stream* line by line on a daemon thread, ending with a None sentinel.
+
+    A thread per pipe rather than a timed read: there is no portable way to put
+    a deadline on a pipe read (``select`` does not take Windows pipes), and a
+    full stderr buffer would deadlock the child.
+    """
+
+    def run() -> None:
+        try:
+            while True:
+                line = stream.readline()
+                if not line:
+                    break
+                on_line(line.rstrip("\r\n"))
+        except (OSError, ValueError) as exc:
+            # Expected when teardown closes the pipe under us; still logged,
+            # because a truncated read otherwise looks like a clean end of output.
+            log(f"{label} reader stopped: {exc}")
+        finally:
+            on_line(None)
+
+    threading.Thread(target=run, daemon=True, name=label).start()
+
+
+class _Deadline:
+    """One time budget shared across several reads, so a multi-event wait cannot
+    restart its clock on every event it skips."""
+
+    def __init__(self, budget_s: float) -> None:
+        self.budget_s = budget_s
+        self.end = time.time() + budget_s
+
+    def remaining(self) -> float:
+        return self.end - time.time()
+
+
+def _next_event(
+    events: "queue.Queue",
+    proc: subprocess.Popen,
+    deadline: _Deadline,
+    what: str,
+    guard=None,
+) -> dict:
+    """Next JSON object off stdout, or raise ``StdioContractBreak``.
+
+    *guard* is re-checked on every idle second so a binary that fails by going
+    silent (an HTTP server, which never answers stdin at all) is caught in
+    seconds instead of at the end of the startup window.
+    """
+    while True:
+        remaining = deadline.remaining()
+        if remaining <= 0:
+            raise StdioContractBreak(
+                f"no {what} within {deadline.budget_s:.0f}s. The binary wrote no "
+                "usable JSON to stdout -- which is what an HTTP server frozen "
+                "under the stdio name does: it binds a port and never reads stdin."
+            )
+        try:
+            line = events.get(timeout=min(remaining, 1.0))
+        except queue.Empty:
+            if guard is not None:
+                guard()
+            continue
+        if line is None:
+            raise StdioContractBreak(
+                f"stdout closed before {what} arrived (process exit code: "
+                f"{proc.poll()})"
+            )
+        if not line.strip():
+            continue
+        try:
+            event = json.loads(line)
+        except ValueError as exc:
+            raise StdioContractBreak(
+                f"stdout carried a line that is not JSON ({exc}): {line[:200]!r}. "
+                "stdout IS the wire -- the TUI parses every line as an event, so "
+                "anything else there renders as an unreadable-event warning."
+            ) from exc
+        if not isinstance(event, dict):
+            raise StdioContractBreak(
+                f"stdout carried JSON that is not an object: {line[:200]!r}"
+            )
+        log(f"<- {json.dumps(event, ensure_ascii=False)[:300]}")
+        return event
+
+
+def check_startup_ping(event: dict) -> None:
+    """The first line must be the model-state ping ``main`` writes at startup.
+
+    Reaching it means the frozen binary built the whole ``GaiaAgent``, so this
+    is also the check that catches a hidden import PyInstaller missed -- that
+    failure arrives here as a terminal ``error`` event instead.
+    """
+    kind = event.get("type")
+    if kind == "error":
+        raise StdioContractBreak(
+            "the binary's first event is a terminal error, so agent construction "
+            f"failed inside the frozen binary: {event.get('detail') or event}"
+        )
+    if kind != "status":
+        raise StdioContractBreak(
+            f"first event is {kind!r}, expected the 'status' model-state ping "
+            "(gaia_agent/stdio.py::_model_state_event)"
+        )
+    model_id = event.get("model_id")
+    if not isinstance(model_id, str) or not model_id:
+        raise StdioContractBreak(
+            "the startup ping carries no model_id, so the TUI header has nothing "
+            f"to name: {event}"
+        )
+    backend = event.get("model_backend")
+    if backend not in ("lemonade", "claude"):
+        raise StdioContractBreak(
+            f"the startup ping's model_backend is {backend!r}, expected "
+            "'lemonade' or 'claude'"
+        )
+    # Reported, not asserted: this test deliberately does not require a model
+    # server, and the ping is designed to say so rather than fail.
+    log(
+        f"startup ping PASS -- model {model_id} on {backend} "
+        f"(lemonade_reachable={event.get('lemonade_reachable')})"
+    )
+
+
+def check_model_round_trip(proc: subprocess.Popen, events: "queue.Queue") -> None:
+    """Send ``/model`` and require exactly one terminal ``final`` back.
+
+    ``/model`` is the only turn that needs no inference: ``dispatch_query``
+    routes it to ``run_model_command`` before ``process_query`` is reached, so a
+    PASS here does not imply a working model -- only a working wire.
+    """
+    line = json.dumps({QUERY_KEY: MODEL_COMMAND})
+    log(f"-> {line}")
+    try:
+        proc.stdin.write(line + "\n")
+        proc.stdin.flush()
+    except OSError as exc:
+        raise StdioContractBreak(
+            f"could not write a query to the binary's stdin: {exc}"
+        ) from exc
+
+    deadline = _Deadline(STDIO_TURN_DEADLINE_S)
+    while True:
+        event = _next_event(
+            events, proc, deadline, f"a terminal event for {MODEL_COMMAND}"
+        )
+        kind = event.get("type")
+        if kind == "error":
+            raise StdioContractBreak(
+                f"{MODEL_COMMAND} answered with an error event: "
+                f"{event.get('detail') or event}"
+            )
+        if kind != "final":
+            # status/token/tool_* before the terminal event are legal; the turn
+            # is only over when exactly one terminal event lands.
+            continue
+        answer = event.get("answer")
+        if not isinstance(answer, str) or not answer.strip():
+            raise StdioContractBreak(
+                f"{MODEL_COMMAND} returned an empty final event: {event}"
+            )
+        log(f"round-trip PASS -- final answer, {len(answer)} chars")
+        return
+
+
+def assert_no_http_listener() -> None:
+    """The stdio binary must not be listening anywhere.
+
+    The whole point of the separate target: the sidecar frozen under the stdio
+    name boots fine and binds this port, and every "did it start?" check passes
+    while the TUI reads uvicorn's log as JSON (#3062).
+    """
+    if _port_is_open(SIDECAR_DEFAULT_PORT):
+        raise StdioContractBreak(
+            f"something is listening on {HOST}:{SIDECAR_DEFAULT_PORT} -- this "
+            "binary started an HTTP server, so it is the REST sidecar, not the "
+            "stdio child the TUI spawns."
+        )
+
+
+def run_stdio(binary: Path) -> int:
+    # Preflight on the sidecar's port: a server already sitting there would make
+    # the no-listener check meaningless, and we cannot tell it from our own.
+    if _port_is_open(SIDECAR_DEFAULT_PORT):
+        log(
+            f"FAIL: port {SIDECAR_DEFAULT_PORT} is already in use -- kill the "
+            "stale sidecar first, or the 'binary started no HTTP server' check "
+            "cannot mean anything."
+        )
+        return 2
+
+    # Bare argv: exactly how the TUI spawns the flagship (catalog.go seedAgents
+    # declares no BinaryArgs). stderr stays SEPARATE -- merging it would put
+    # tracebacks on the wire and mask the very thing this mode checks.
+    cmd = [str(binary)]
+    log(f"launching frozen binary: {binary}")
+    log(f"command: {' '.join(cmd)} (bare, as the TUI spawns it)")
+    t0 = time.time()
+    proc = subprocess.Popen(
+        cmd,
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        # JSON is UTF-8 by definition. Without this the reader decodes with the
+        # locale codec, and on the Windows leg cp1252 dies on the first non-ASCII
+        # byte the agent prints -- reported as "stdout closed", not as a decode
+        # error, so it reads like a broken binary.
+        encoding="utf-8",
+        errors="replace",
+        bufsize=1,
+    )
+
+    events: "queue.Queue" = queue.Queue()
+    errors: list = []
+
+    def keep_stderr(line) -> None:
+        if line is not None:  # the pump's EOF sentinel
+            errors.append(line)
+
+    _pump(proc.stdout, events.put, "stdout")
+    _pump(proc.stderr, keep_stderr, "stderr")
+
+    results: dict[str, bool] = {}
+    try:
+        try:
+            log(
+                f"waiting up to {STDIO_STARTUP_DEADLINE_S:.0f}s for the startup "
+                f"ping (watching {HOST}:{SIDECAR_DEFAULT_PORT} meanwhile)"
+            )
+            ping = _next_event(
+                events,
+                proc,
+                _Deadline(STDIO_STARTUP_DEADLINE_S),
+                "a startup event",
+                guard=assert_no_http_listener,
+            )
+            log(f"time to first event: {time.time() - t0:.1f}s")
+            check_startup_ping(ping)
+            results["startup_ping"] = True
+
+            assert_no_http_listener()
+            log(f"no-listener PASS -- nothing bound on {HOST}:{SIDECAR_DEFAULT_PORT}")
+            results["no_http_listener"] = True
+
+            check_model_round_trip(proc, events)
+            results["model_round_trip"] = True
+        except StdioContractBreak as exc:
+            log(f"FAIL: {exc}")
+    finally:
+        log("closing stdin (how a well-behaved agent is asked to exit)")
+        try:
+            proc.stdin.close()
+        except OSError as exc:
+            log(f"stdin was already gone: {exc}")
+        try:
+            proc.wait(timeout=30)
+            log(f"exited on stdin close with code {proc.returncode}")
+        except subprocess.TimeoutExpired:
+            # Not a failure: the TUI force-kills after its own grace window
+            # (SubprocessClient.Close), so a slow exit is tolerated by design.
+            log("did not exit within 30s of stdin close -- killing the tree")
+        _kill_tree(proc)
+        if errors:
+            log("stderr tail:\n" + "\n".join(errors[-40:]))
+
+    log(f"results: {results}")
+    ok = len(results) == 3 and all(results.values())
+    log("VERDICT: PASS" if ok else "VERDICT: FAIL")
+    return 0 if ok else 1
+
+
+def run_sidecar(binary: Path) -> int:
+    # Preflight: refuse if the port is already bound -- otherwise we would
+    # health-check a stale server and report a false PASS.
+    if _port_is_open(PORT):
+        log(f"FAIL: port {PORT} already in use -- kill the stale server first.")
+        return 2
 
     cmd = [str(binary), "--host", HOST, "--port", str(PORT)]
     log(f"launching frozen binary: {binary}")
@@ -178,6 +512,10 @@ def main(argv=None) -> int:
         stdout=subprocess.PIPE,
         stderr=subprocess.STDOUT,
         text=True,
+        # Same reason as the stdio mode: the locale codec cannot read the
+        # agent's UTF-8 log output on the Windows leg.
+        encoding="utf-8",
+        errors="replace",
         bufsize=1,
     )
 
@@ -199,6 +537,33 @@ def main(argv=None) -> int:
     ok = len(results) == 3 and all(results.values())
     log("VERDICT: PASS" if ok else "VERDICT: FAIL")
     return 0 if ok else 1
+
+
+MODES = {"sidecar": run_sidecar, "stdio": run_stdio}
+
+
+def main(argv=None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Smoke-test a frozen GAIA flagship agent binary."
+    )
+    parser.add_argument("binary", help="Path to the frozen executable to test.")
+    parser.add_argument(
+        "--mode",
+        choices=sorted(MODES),
+        default="sidecar",
+        help="Which wire to test: 'sidecar' probes /health, /version and "
+        "/openapi.json over HTTP; 'stdio' spawns the binary bare and speaks the "
+        "TUI's stdin/stdout JSONL contract (default: sidecar).",
+    )
+    args = parser.parse_args(argv)
+
+    binary = Path(args.binary).resolve()
+    if not binary.exists():
+        log(f"FAIL: binary not found: {binary}")
+        return 2
+
+    log(f"mode: {args.mode}")
+    return MODES[args.mode](binary)
 
 
 if __name__ == "__main__":

--- a/hub/agents/gaia/python/packaging/stdio_entry.py
+++ b/hub/agents/gaia/python/packaging/stdio_entry.py
@@ -1,0 +1,28 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""Frozen-binary entrypoint for the GAIA flagship agent's stdio transport.
+
+A thin wrapper around :mod:`gaia_agent.stdio`, which is the single source of
+truth for the wire. It exists for the same reason ``packaging/server.py`` does:
+PyInstaller freezes a *file*, and the stdio transport is published as a console
+script (``gaia-agent = "gaia_agent.stdio:main"`` in ``pyproject.toml``), which
+has no file to point at. This module is that file.
+
+Named ``stdio_entry`` rather than ``stdio``: PyInstaller puts the entry script's
+directory on ``sys.path``, so a top-level ``stdio`` module would sit ahead of
+``gaia_agent.stdio`` for anything importing the bare name.
+
+The binary this produces is what the TUI spawns as a child process — bare argv,
+one query per stdin line, canonical events back as JSON lines on stdout (see
+``client.SubprocessClient`` on the Go side). It is NOT the REST sidecar; freezing
+the wrong one feeds uvicorn's startup log to a JSON line scanner (#3062).
+"""
+
+from __future__ import annotations
+
+import sys
+
+from gaia_agent.stdio import main  # noqa: F401  (re-exported for the freeze)
+
+if __name__ == "__main__":  # pragma: no cover
+    sys.exit(main())

--- a/hub/agents/gaia/python/tests/test_gen_binaries_lock.py
+++ b/hub/agents/gaia/python/tests/test_gen_binaries_lock.py
@@ -1,13 +1,20 @@
 # Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
 # SPDX-License-Identifier: MIT
 """
-Contract tests for ``packaging/gen_binaries_lock.py`` (schema 3.0, two lanes).
+Contract tests for ``packaging/gen_binaries_lock.py`` (schema 3.0: three
+components across two lanes).
 
 The lock this writes is the integrity gate the npm client enforces on every
-download, and half of it now points at the ``terminal-hub`` lane — which this
+download, and part of it points at the ``terminal-hub`` lane — which this
 package does not publish. A wrong filename or a wrong lane version there is not
 a build failure anywhere; it is a 404 on a user's first run. These tests cover
 the generator's loud failures as much as its happy path.
+
+``sidecar`` and ``stdio`` are two freezes of the same agent sharing ONE hub
+directory, so a swapped filename between them hash-verifies at publish time and
+only surfaces as the TUI talking to a REST binary on a user's box. That is why
+the happy path here feeds metas for all three components: a release that skips
+one leaves its lane on the committed placeholders.
 """
 
 from __future__ import annotations
@@ -42,6 +49,16 @@ SIDECAR_ARTIFACTS = {
     "darwin-x64": "gaia-agent-darwin-x64",
     "linux-x64": "gaia-agent-linux-x64",
 }
+STDIO_ARTIFACTS = {
+    "win32-x64": "gaia-agent-stdio-win32-x64.exe",
+    "darwin-arm64": "gaia-agent-stdio-darwin-arm64",
+    "darwin-x64": "gaia-agent-stdio-darwin-x64",
+    "linux-x64": "gaia-agent-stdio-linux-x64",
+}
+
+# Both frozen transports install under the name the TUI spawns; only the TUI
+# itself is renamed. Mirrors the meta-emitting step in release_agent_gaia.yml.
+_BASE_EXECUTABLE = {"sidecar": "gaia-agent", "stdio": "gaia-agent", "tui": "gaia-tui"}
 
 
 def _sha(text: str) -> str:
@@ -54,7 +71,7 @@ def _record(component: str, platform: str, filename: str) -> dict:
         "component": component,
         "platform": platform,
         "filename": filename,
-        "executable": ("gaia-agent" if component == "sidecar" else "gaia-tui")
+        "executable": _BASE_EXECUTABLE[component]
         + (".exe" if filename.endswith(".exe") else ""),
         "sha256": _sha(body),
         "size": len(body),
@@ -93,15 +110,28 @@ def _run(lock: Path, metas: list[Path], **overrides) -> int:
 
 
 def _all_metas(tmp_path: Path) -> list[Path]:
+    """Every meta a full release emits — all three components, all platforms."""
     metas = [
         _write_meta(tmp_path, _record("sidecar", p, f))
         for p, f in SIDECAR_ARTIFACTS.items()
+    ]
+    metas += [
+        _write_meta(tmp_path, _record("stdio", p, f))
+        for p, f in STDIO_ARTIFACTS.items()
     ]
     metas += [
         _write_meta(tmp_path, _record("tui", p, f))
         for p, f in gen.TUI_ARTIFACT_NAMES.items()
     ]
     return metas
+
+
+def test_the_test_fixtures_track_the_generators_artifact_tables():
+    # These local tables exist so a rename in the generator has to be made
+    # deliberately in both places rather than silently agreeing with itself.
+    assert SIDECAR_ARTIFACTS == gen.SIDECAR_ARTIFACT_NAMES
+    assert STDIO_ARTIFACTS == gen.STDIO_ARTIFACT_NAMES
+    assert set(_BASE_EXECUTABLE) == set(gen.COMPONENTS)
 
 
 def test_committed_lock_is_the_schema_this_generator_writes():
@@ -128,6 +158,7 @@ def test_full_release_writes_both_lanes(tmp_path, capsys):
     assert "baseUrl" not in written
 
     sidecar = written["components"]["sidecar"]
+    stdio = written["components"]["stdio"]
     tui = written["components"]["tui"]
     assert sidecar["componentVersion"] == AGENT_VERSION
     assert sidecar["baseUrl"] == SIDECAR_BASE
@@ -135,9 +166,24 @@ def test_full_release_writes_both_lanes(tmp_path, capsys):
     assert tui["baseUrl"] == TUI_BASE
     # The two lanes are genuinely different — the whole point of schema 3.0.
     assert tui["baseUrl"] != sidecar["baseUrl"]
+    # stdio is the same freeze published beside the sidecar, so it rides the
+    # gaia lane rather than carrying a third version that could drift.
+    assert stdio["componentVersion"] == AGENT_VERSION
+    assert stdio["baseUrl"] == SIDECAR_BASE
 
     assert set(sidecar["platforms"]) == set(SIDECAR_ARTIFACTS)
+    assert set(stdio["platforms"]) == set(STDIO_ARTIFACTS)
     assert set(tui["platforms"]) == set(gen.TUI_ARTIFACT_NAMES)
+    for platform, entry in stdio["platforms"].items():
+        assert entry["filename"] == STDIO_ARTIFACTS[platform]
+        assert entry["sha256"] == _sha(f"stdio-{platform}")
+        # One directory, two transports: the sidecar's name must never appear
+        # on a stdio entry, or the installer hands the TUI a REST server.
+        assert entry["filename"] != sidecar["platforms"][platform]["filename"]
+    # Both transports install as `gaia-agent` — that collision is why the npm
+    # client consumes only one of them (see npm/test/lock.test.ts).
+    assert stdio["platforms"]["win32-x64"]["executable"] == "gaia-agent.exe"
+    assert stdio["platforms"]["linux-x64"]["executable"] == "gaia-agent"
     for platform, entry in tui["platforms"].items():
         assert entry["filename"] == gen.TUI_ARTIFACT_NAMES[platform]
         assert entry["sha256"] == _sha(f"tui-{platform}")
@@ -168,10 +214,11 @@ def test_partial_metas_keep_the_other_platforms(tmp_path):
     )
     assert _run(lock, [only]) == 0
     after = json.loads(lock.read_text(encoding="utf-8"))
-    assert (
-        after["components"]["tui"]["platforms"]
-        == before["components"]["tui"]["platforms"]
-    )
+    for untouched in ("tui", "stdio"):
+        assert (
+            after["components"][untouched]["platforms"]
+            == before["components"][untouched]["platforms"]
+        )
     assert set(after["components"]["sidecar"]["platforms"]) == set(SIDECAR_ARTIFACTS)
 
 
@@ -185,6 +232,40 @@ def test_rejects_a_tui_filename_terminal_hub_does_not_publish(tmp_path):
         _run(lock, [bad])
     assert "gaia-win-x64.exe" in str(e.value)
     assert "terminal-hub" in str(e.value)
+
+
+@pytest.mark.parametrize(
+    "component, other",
+    [("sidecar", "stdio"), ("stdio", "sidecar")],
+)
+def test_rejects_the_two_gaia_lane_transports_swapping_filenames(
+    tmp_path, component, other
+):
+    # sidecar and stdio publish into ONE agents/gaia/<version>/ directory, so a
+    # crossed filename uploads and hash-verifies cleanly. Nothing downstream
+    # catches it — the user just gets the wrong transport.
+    lock = _seed_lock(tmp_path)
+    names = {"sidecar": SIDECAR_ARTIFACTS, "stdio": STDIO_ARTIFACTS}
+    bad = _record(component, "linux-x64", names[other]["linux-x64"])
+    with pytest.raises(SystemExit) as e:
+        _run(lock, [_write_meta(tmp_path, bad)])
+    assert names[component]["linux-x64"] in str(e.value)
+
+
+def test_rejects_a_stale_stdio_filename_in_the_committed_lock(tmp_path):
+    # The whole-lock revalidation must cover stdio, not just sidecar and tui —
+    # an entry with no meta this run keeps its committed value.
+    lock = _seed_lock(tmp_path)
+    data = json.loads(lock.read_text(encoding="utf-8"))
+    data["components"]["stdio"]["platforms"]["linux-x64"][
+        "filename"
+    ] = "gaia-agent-linux-x64"
+    lock.write_text(json.dumps(data), encoding="utf-8")
+    only_tui = _write_meta(tmp_path, _record("tui", "linux-x64", "gaia-linux-x64"))
+    with pytest.raises(SystemExit) as e:
+        _run(lock, [only_tui])
+    assert "stale committed value" in str(e.value)
+    assert "gaia-agent-stdio-linux-x64" in str(e.value)
 
 
 def test_rejects_a_stale_committed_entry_no_meta_overwrites(tmp_path):

--- a/installer/scripts/install.ps1
+++ b/installer/scripts/install.ps1
@@ -318,12 +318,18 @@ function Install-Tui {
     [void](Install-HubBinary -AgentId $TERMINAL_HUB_ID -Filename "gaia-$platform.exe" -DestName "gaia-tui.exe" -Label "terminal hub")
 }
 
-# The flagship agent's frozen sidecar. The terminal hub spawns `gaia-agent` as a
-# child process, so without this binary the flagship cannot run -- which is what
-# this one-liner left behind before: a UI with no agent under it.
+# The flagship agent's frozen STDIO build. The terminal hub spawns `gaia-agent`
+# as a child process, so without this binary the flagship cannot run -- which is
+# what this one-liner left behind before: a UI with no agent under it.
 #
 # Installed into $GAIA_BIN because that is the directory this installer owns and
 # has already put on PATH, so the hub's exec.LookPath finds gaia-agent there.
+#
+# STDIO, not the sidecar: `agents/gaia/` publishes two programs whose artifact
+# names differ by one word, and only one can be spawned. `gaia-agent-<platform>`
+# is the REST sidecar the daemon supervises -- it binds a port and never reads
+# stdin, so under this name it satisfies the hub's readiness check and then
+# feeds uvicorn's startup log to a JSON line scanner (#3062).
 #
 # Returns $true only when the agent binary is on disk. The caller uses that to
 # decide what to promise: the hub spawns gaia-agent as a child process, so
@@ -337,10 +343,10 @@ function Install-FlagshipAgent {
         Write-Warning "No flagship agent build for this architecture - skipping."
         return $false
     }
-    # The sidecar is published under win32-x64; the terminal hub uses win-x64.
+    # The agent lane is published under win32-x64; the terminal hub uses win-x64.
     $lockPlatform = $platform -replace '^win-', 'win32-'
 
-    $ok = Install-HubBinary -AgentId $FLAGSHIP_AGENT_ID -Filename "gaia-agent-$lockPlatform.exe" -DestName "gaia-agent.exe" -Label "GAIA agent" -Optional
+    $ok = Install-HubBinary -AgentId $FLAGSHIP_AGENT_ID -Filename "gaia-agent-stdio-$lockPlatform.exe" -DestName "gaia-agent.exe" -Label "GAIA agent" -Optional
     return [bool]$ok
 }
 

--- a/installer/scripts/install.sh
+++ b/installer/scripts/install.sh
@@ -447,12 +447,18 @@ install_tui() {
     print_success "Terminal hub $version installed to $GAIA_BIN/gaia-tui"
 }
 
-# The flagship agent's frozen sidecar. The terminal hub spawns `gaia-agent` as a
-# child process, so without this binary the flagship is listed but cannot run —
-# which is what `curl | sh` left behind before: a UI with no agent under it.
+# The flagship agent's frozen STDIO build. The terminal hub spawns `gaia-agent`
+# as a child process, so without this binary the flagship is listed but cannot
+# run — which is what `curl | sh` left behind before: a UI with no agent under it.
 #
 # Installed into $GAIA_BIN because that is the directory this installer owns and
 # has already put on PATH, so the hub's exec.LookPath finds gaia-agent there.
+#
+# STDIO, not the sidecar: `agents/gaia/` publishes two programs whose artifact
+# names differ by one word, and only one can be spawned. `gaia-agent-<platform>`
+# is the REST sidecar the daemon supervises — it binds a port and never reads
+# stdin, so under this name it satisfies the hub's readiness check and then
+# feeds uvicorn's startup log to a JSON line scanner (#3062).
 #
 # Only a checksum mismatch is fatal. A missing build or a failed download leaves
 # a working hub and a working Python CLI, so those warn and continue rather than
@@ -467,7 +473,7 @@ install_flagship_agent() {
         echo "  The terminal hub still works; the GAIA agent will show as unavailable."
         return 0
     fi
-    filename="gaia-agent-${platform}"
+    filename="gaia-agent-stdio-${platform}"
 
     py=""
     if ! py="$(terminal_hub_python)"; then

--- a/installer/tui/fetch_sidecar.py
+++ b/installer/tui/fetch_sidecar.py
@@ -1,10 +1,17 @@
 #!/usr/bin/env python3
 # Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
 # SPDX-License-Identifier: MIT
-"""Download the flagship `gaia-agent` sidecar and verify it against the committed lock.
+"""Download the flagship `gaia-agent` child and verify it against the committed lock.
 
 The terminal hub spawns `gaia-agent` as a child process, so an installer that
 ships only the TUI installs a front end with nothing behind it.
+
+Which of the flagship's two binaries this stages matters: `agents/gaia/` publishes
+BOTH the REST sidecar the daemon supervises and the stdin/stdout JSONL child the
+TUI spawns, and the native installers put what lands here on PATH as `gaia-agent`
+— exactly the name the TUI resolves. So it reads the lock's `stdio` lane. Staging
+the sidecar instead installs a program that binds a port and never answers stdin,
+feeding uvicorn's startup log to a JSON line scanner (#3062).
 
 Both the expected SHA-256 and the sidecar version come from the COMMITTED
 ``hub/agents/gaia/npm/binaries.lock.json``, never from the origin that served the
@@ -66,6 +73,10 @@ USER_AGENT = "gaia-installer-build/1.0"
 # The committed sidecar pin, relative to the repo root.
 BINARIES_LOCK = Path("hub/agents/gaia/npm/binaries.lock.json")
 
+# The lock lane to stage from. `stdio`, never `sidecar`: see the module docstring
+# — the installers put this on PATH under the name the TUI spawns.
+LOCK_COMPONENT = "stdio"
+
 # Allowlist a real digest rather than blocklist known placeholders, so a lock
 # left half-filled by a future generator cannot slip past as "not PENDING".
 SHA256_RE = re.compile(r"^[0-9a-fA-F]{64}$")
@@ -81,18 +92,18 @@ def _repo_root() -> Path:
 
 
 def _sidecar_lock() -> tuple[dict, Path]:
-    """The committed sidecar pin: version plus the per-platform digests."""
+    """The committed pin for the stdio child: version plus per-platform digests."""
     lock_path = _repo_root() / BINARIES_LOCK
     try:
         lock = json.loads(lock_path.read_text(encoding="utf-8"))
-        sidecar = lock["components"]["sidecar"]
+        sidecar = lock["components"][LOCK_COMPONENT]
         if not isinstance(sidecar, dict):
-            raise TypeError("components.sidecar is not an object")
+            raise TypeError(f"components.{LOCK_COMPONENT} is not an object")
         return sidecar, lock_path
     except (OSError, json.JSONDecodeError, KeyError, TypeError) as e:
         raise SystemExit(
-            f"could not read the sidecar pin from {lock_path}: {e}\n"
-            f"It must contain components.sidecar with componentVersion and "
+            f"could not read the {LOCK_COMPONENT} pin from {lock_path}: {e}\n"
+            f"It must contain components.{LOCK_COMPONENT} with componentVersion and "
             f"platforms.<key>.sha256. Regenerate it with {LOCK_GENERATOR}."
         ) from e
 
@@ -112,7 +123,7 @@ def _expected_sha256(sidecar: dict, npm_key: str, lock_path: Path) -> str:
         # best-effort sidecar build was skipped, so the npm installer can say
         # "not published for this platform". Say the same thing here.
         raise NoSidecarForPlatform(
-            f"{lock_path} has no components.sidecar.platforms.{npm_key} entry, so the "
+            f"{lock_path} has no components.{LOCK_COMPONENT}.platforms.{npm_key} entry, so the "
             f"flagship agent publishes no sidecar for this platform."
         )
     sha = str(entry.get("sha256", ""))
@@ -256,7 +267,7 @@ def main() -> int:
     version = args.version or pinned
     if not version:
         raise SystemExit(
-            f"{lock_path} has no components.sidecar.componentVersion, so there is no "
+            f"{lock_path} has no components.{LOCK_COMPONENT}.componentVersion, so there is no "
             f"pinned sidecar version to fetch. Regenerate it with {LOCK_GENERATOR}."
         )
     if version != pinned:
@@ -285,7 +296,7 @@ def main() -> int:
     filename = str(entry.get("filename") or "")
     if not filename:
         raise SystemExit(
-            f"{lock_path} has no components.sidecar.platforms.{npm_key}.filename, so "
+            f"{lock_path} has no components.{LOCK_COMPONENT}.platforms.{npm_key}.filename, so "
             f"there is no artifact name to request from the hub. Regenerate the lock "
             f"with {LOCK_GENERATOR}."
         )

--- a/tests/unit/installer/test_install_scripts_terminal_hub.py
+++ b/tests/unit/installer/test_install_scripts_terminal_hub.py
@@ -337,30 +337,36 @@ def fake_hub(tmp_path):
         platforms=HUB_PLATFORMS,
         digest_overrides=None,
         omit_binaries=False,
+        also_prefixes=(),
     ):
+        # `also_prefixes` puts a SECOND program in the same lane. The real
+        # agents/gaia/ lane carries both the stdio child and the REST sidecar,
+        # so a fixture with only one cannot tell "installed the agent" from
+        # "installed the wrong agent" -- the failure this file has to catch.
         version_dir = root / "agents" / agent_id / HUB_VERSION
         version_dir.mkdir(parents=True, exist_ok=True)
         artifacts = []
-        for key in platforms:
-            blob = f"#!/bin/sh\necho {prefix} {HUB_VERSION} {key}\n".encode()
-            filename = f"{prefix}-{key}"
-            if omit_binaries:
-                # Published in the manifest, absent from the bucket: the
-                # transient-download-failure case, which must not be fatal.
-                (version_dir / filename).unlink(missing_ok=True)
-            else:
-                (version_dir / filename).write_bytes(blob)
-            artifacts.append(
-                {
-                    "filename": filename,
-                    "path": f"agents/{agent_id}/{HUB_VERSION}/{filename}",
-                    "size_bytes": len(blob),
-                    "sha256": (digest_overrides or {}).get(
-                        key, hashlib.sha256(blob).hexdigest()
-                    ),
-                    "content_type": "application/octet-stream",
-                }
-            )
+        for pfx in (prefix, *also_prefixes):
+            for key in platforms:
+                blob = f"#!/bin/sh\necho {pfx} {HUB_VERSION} {key}\n".encode()
+                filename = f"{pfx}-{key}"
+                if omit_binaries:
+                    # Published in the manifest, absent from the bucket: the
+                    # transient-download-failure case, which must not be fatal.
+                    (version_dir / filename).unlink(missing_ok=True)
+                else:
+                    (version_dir / filename).write_bytes(blob)
+                artifacts.append(
+                    {
+                        "filename": filename,
+                        "path": f"agents/{agent_id}/{HUB_VERSION}/{filename}",
+                        "size_bytes": len(blob),
+                        "sha256": (digest_overrides or {}).get(
+                            key, hashlib.sha256(blob).hexdigest()
+                        ),
+                        "content_type": "application/octet-stream",
+                    }
+                )
         manifest = {
             "id": agent_id,
             "latest_version": HUB_VERSION,
@@ -377,7 +383,7 @@ def fake_hub(tmp_path):
         )
 
     publish("terminal-hub", "gaia")
-    publish("gaia", "gaia-agent")
+    publish("gaia", "gaia-agent-stdio", also_prefixes=("gaia-agent",))
 
     handler = type(
         "Handler",
@@ -518,7 +524,7 @@ def test_a_verified_agent_installs_and_arms_the_banner(tmp_path, fake_hub):
 def test_an_unpublished_agent_platform_leaves_the_hub_installed(tmp_path, fake_hub):
     """No build for this machine is a warning, not a failed install."""
     base_url, publish = fake_hub
-    publish("gaia", "gaia-agent", platforms=("aix-ppc64",))
+    publish("gaia", "gaia-agent-stdio", platforms=("aix-ppc64",))
 
     result, tui, agent = _run_bootstrap(tmp_path, base_url)
 
@@ -535,7 +541,7 @@ def test_a_failed_agent_download_leaves_the_hub_installed(tmp_path, fake_hub):
     """A network blip after uv, the package, the hub and PATH are all in place
     must not throw that away — the sidecar is the only thing missing."""
     base_url, publish = fake_hub
-    publish("gaia", "gaia-agent", omit_binaries=True)
+    publish("gaia", "gaia-agent-stdio", omit_binaries=True)
 
     result, tui, agent = _run_bootstrap(tmp_path, base_url)
 
@@ -551,7 +557,11 @@ def test_a_failed_agent_download_leaves_the_hub_installed(tmp_path, fake_hub):
 def test_a_tampered_agent_aborts_and_writes_nothing(tmp_path, fake_hub):
     """Integrity is the one agent failure that is never downgraded."""
     base_url, publish = fake_hub
-    publish("gaia", "gaia-agent", digest_overrides={k: "d" * 64 for k in HUB_PLATFORMS})
+    publish(
+        "gaia",
+        "gaia-agent-stdio",
+        digest_overrides={k: "d" * 64 for k in HUB_PLATFORMS},
+    )
 
     result, tui, agent = _run_bootstrap(tmp_path, base_url)
 
@@ -631,3 +641,48 @@ def test_add_to_path_does_not_write_a_file_an_unknown_shell_ignores(tmp_path):
     assert result.returncode == 0, result.stdout + result.stderr
     assert _rc_files(home) == []
     assert "Add these two directories to your PATH by hand" in result.stdout
+
+
+# ── the agent must be the STDIO build, not the REST sidecar ────────────────
+#
+# `agents/gaia/` publishes two programs whose artifact names differ by one word.
+# `gaia-agent-<platform>` is the REST sidecar the daemon supervises: it binds a
+# port and never reads stdin. Installed as `gaia-agent` it satisfies the hub's
+# readiness check and then feeds uvicorn's startup log to a JSON line scanner
+# (#3062) — a green gate followed by a broken chat, which is worse than an
+# honest "not installed".
+
+
+@pytest.mark.parametrize("script", ["sh", "ps1"])
+def test_the_agent_artifact_is_the_stdio_build(sh_text, ps1_text, script):
+    text = sh_text if script == "sh" else ps1_text
+    assert "gaia-agent-stdio" in text
+
+    # The bare sidecar name must never be what gets constructed. Prose may
+    # mention it to explain why; only executable lines are checked.
+    code = "\n".join(
+        line
+        for line in text.splitlines()
+        if not line.lstrip().startswith("#") and line.strip()
+    )
+    for wrong in ('"gaia-agent-${platform}"', '"gaia-agent-$lockPlatform.exe"'):
+        assert wrong not in code, f"install.{script} asks for the REST sidecar"
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="needs a POSIX shell")
+@pytest.mark.skipif(shutil.which("curl") is None, reason="needs curl")
+def test_the_installed_agent_is_the_stdio_artifact(tmp_path, fake_hub):
+    """Both programs are published in the lane, so assert on the bytes.
+
+    Checking only that `gaia-agent` exists passes just as happily when the
+    sidecar was the thing downloaded.
+    """
+    base_url, _ = fake_hub
+    result, _tui, agent = _run_bootstrap(tmp_path, base_url)
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    # Each fake artifact echoes its own prefix, so the first token names which
+    # of the two programs in the lane was downloaded. Substring-matching the
+    # stdio name alone would not do: the sidecar's name is a prefix of it.
+    body = agent.read_text(encoding="utf-8")
+    assert "echo gaia-agent-stdio " in body, f"installed the wrong artifact: {body!r}"

--- a/tests/unit/test_fetch_sidecar.py
+++ b/tests/unit/test_fetch_sidecar.py
@@ -27,7 +27,7 @@ _spec.loader.exec_module(fetch_sidecar)  # type: ignore[union-attr]
 PLACEHOLDER = "PENDING-replace-with-real-sha256"
 VERSION = "0.1.1"
 WIN_KEY = "win32-x64"
-WIN_FILE = "gaia-agent-win32-x64.exe"
+WIN_FILE = "gaia-agent-stdio-win32-x64.exe"
 
 BODY = b"\x4d\x5a" + b"pretend this is a signed sidecar" * 8
 BODY_SHA = hashlib.sha256(BODY).hexdigest()
@@ -55,8 +55,15 @@ def _platform_entry(**overrides) -> dict:
 
 
 def _lock(platforms: dict, *, version: str = VERSION) -> dict:
+    # The `stdio` lane, not `sidecar`: what gets staged here is installed on PATH
+    # as `gaia-agent`, and only the stdio build answers the TUI's stdin (#3062).
     return {
-        "components": {"sidecar": {"componentVersion": version, "platforms": platforms}}
+        "components": {
+            fetch_sidecar.LOCK_COMPONENT: {
+                "componentVersion": version,
+                "platforms": platforms,
+            }
+        }
     }
 
 
@@ -382,3 +389,36 @@ def test_platform_has_sidecar_reflects_the_lock(write_lock):
     write_lock(_lock({WIN_KEY: _platform_entry()}))
     assert fetch_sidecar.platform_has_sidecar("win-x64") is True
     assert fetch_sidecar.platform_has_sidecar("linux-x64") is False
+
+
+# ---------------------------------------------------------------------------
+# The lane: the stdio child, never the REST sidecar
+# ---------------------------------------------------------------------------
+#
+# Every test above builds its lock from ``LOCK_COMPONENT``, so it would stay
+# green if the constant were flipped back to "sidecar" -- and the native
+# installers would silently go back to putting a program that binds a port and
+# ignores stdin on PATH under the name the TUI spawns (#3062). These two pin it
+# against the real, committed lock.
+
+
+def test_the_staged_lane_is_the_stdio_child():
+    assert fetch_sidecar.LOCK_COMPONENT == "stdio"
+
+
+def test_the_committed_lock_publishes_stdio_artifacts_for_every_platform():
+    lock_path = Path(__file__).resolve().parents[2] / fetch_sidecar.BINARIES_LOCK
+    lock = json.loads(lock_path.read_text(encoding="utf-8"))
+    lane = lock["components"][fetch_sidecar.LOCK_COMPONENT]
+
+    # Every platform the fetcher can be asked for must be published.
+    assert set(lane["platforms"]) == set(fetch_sidecar.PLATFORM_KEYS.values())
+
+    for key, entry in lane["platforms"].items():
+        assert entry["filename"].startswith("gaia-agent-stdio-"), (
+            f"{key} stages {entry['filename']!r}: that is the REST sidecar, which "
+            "never answers the stdin the TUI writes to it"
+        )
+        # What it is INSTALLED as stays `gaia-agent` -- that is the name the
+        # TUI resolves on PATH.
+        assert entry["executable"] in ("gaia-agent", "gaia-agent.exe")


### PR DESCRIPTION
`curl … | sh` now installs a `gaia-agent` the terminal hub cannot run. #3300 fixed
the missing binary, but the artifact it fetches — `gaia-agent-<platform>` — is the
**REST sidecar the daemon supervises**, not the stdin/stdout child `gaia-tui`
spawns. Run bare with JSON lines on stdin it binds a port and never answers, so
the hub finds it on PATH, reports the flagship ready, spawns it, and reads
uvicorn's startup log with a JSON line scanner. That is the collision #3062
describes, and it is worse than the halt it replaced: the gate now goes green
before the chat breaks.

**Nothing published could have worked.** `freeze.py` only ever froze
`packaging/server.py`, so the entry point the flagship's own `pyproject.toml`
declares — `gaia-agent = "gaia_agent.stdio:main"` — had no binary anywhere on the
hub, and `gaia-agent-gaia` is not on PyPI. Fixing the installers alone was not
possible, which is why this touches the release pipeline.

Three threads worth reviewing separately:

- **A second freeze target.** `freeze.py --target stdio` builds that entry point
  as `gaia-agent-stdio-<platform>`; `--target sidecar` stays the default, so the
  REST binary is byte-for-byte unchanged. The release publishes both from the
  same platform legs and records the new `stdio` lane in the lock.
- **A smoke test that can catch this class of bug.** `smoke_test.py --mode stdio`
  spawns the binary exactly as the hub does and asserts a canonical startup
  event, a `/model` round trip, **and that nothing is listening on the sidecar's
  port**. Point it at today's published artifact and it fails.
- **All three installers ask for the stdio build** — both one-liners and the
  native NSIS/deb/pkg payload (`fetch_sidecar.py`), which stages onto PATH under
  the same name and had the same defect.

The installer diff is small (16 and 14 lines) because #3300's shared
download-and-verify helper is reused as-is; its optional-agent policy and closing
banner are untouched.

> [!IMPORTANT]
> **Merge after a flagship release, not before.** `gaia-agent-stdio-*` is not
> published yet, so until a `gaia` agent release runs the freeze job and fills the
> lock's `PENDING` digests, the agent step warns and skips — a hub with no agent,
> which is #3300's starting point rather than a new regression. Ordering the
> release first makes the one-liner correct on the first try.

## Test plan

The frozen binary, the real hub, and the real gate — not mocks.

- [x] **A real freeze, then the real gate.** `freeze.py --onefile --target stdio`
  → 112.6 MB exe; `smoke_test.py --mode stdio` PASSes all three checks. Stable
  across three runs (~30s startup); the binary's first-ever execution failed once
  to Defender scanning a fresh 112 MB file, then never again.
- [x] **Passes with Lemonade down**, which is the CI runner's state —
  `lemonade_reachable: false`, still PASS. This was the main worry about gating
  three required release legs on a new smoke mode.
- [x] **The published sidecar fails that smoke test.** Downloaded
  `gaia-agent-linux-x64` from the live hub and ran it as the hub does: it starts
  uvicorn on `127.0.0.1:8141` and ignores stdin. That is the bug, reproduced.
- [x] **The TUI gate.** Drove `gaia-tui` over the control API against a throwaway
  profile: with no agent, `blocker: "binary"`; with a stdio `gaia-agent` on PATH
  and **no `.installed` sentinel**, `[ok] GAIA agent` / `[ok] Lemonade`. (A
  sentinel would flip the flagship to daemon transport via
  `applyInstalledRecord` and break the launch — so none is written.)
- [x] **Cold install on Linux** (WSL, throwaway `HOME`, live hub): both binaries
  land in `~/.gaia/bin`, executable, digests verified.
- [x] **PowerShell path** (Windows PowerShell 5.1, fake hub serving *both*
  programs in the lane): installs `gaia-agent.exe` and the bytes prove it took the
  stdio artifact. Tampered digest → refuses, writes nothing. `win-arm64` → skips
  and says so.
- [x] `pytest tests/unit/installer tests/unit/test_fetch_sidecar.py` — 68 passed
  on Linux (`/bin/sh` is dash there, so the shell tests run under it).
- [x] **The new guards fail when they should.** Reverting the artifact name to
  `gaia-agent-<platform>` breaks 4 tests; flipping `fetch_sidecar.LOCK_COMPONENT`
  back to `"sidecar"` breaks 2.
- [x] `npm test` in `hub/agents/gaia/npm` — 146 passed; the shipped-lock test
  asserted exactly two lanes and now allows the third without consuming it.

Not verified here: the hub download of the new artifact, which is unpublished
until the release above. macOS is untested locally — `darwin-arm64` and
`darwin-x64` first build in CI.
