### PR TITLE
fix(npu): install the FLM backend before pulling FLM models

### DIFF
--- a/.github/workflows/build_cpp.yml
+++ b/.github/workflows/build_cpp.yml
@@ -338,6 +338,9 @@ jobs:
           try {
               # Start Lemonade with Qwen3-4B-GGUF
               .\installer\scripts\start-lemonade.ps1 -ModelName "Qwen3-4B-Instruct-2507-GGUF" -Port 13305 -CtxSize 16384 -InitWaitTime 15
+              # Stop here on setup failure: the script exits non-zero without
+              # loading the model, so the suite would run at Lemonade's own ctx.
+              if ($LASTEXITCODE -ne 0) { throw "Lemonade setup failed (exit $LASTEXITCODE)" }
 
               # Verify health
               $health = Invoke-RestMethod -Uri "http://localhost:13305/api/v1/health" -Method GET -TimeoutSec 10

--- a/.github/workflows/test_agent_behavior_e2e.yml
+++ b/.github/workflows/test_agent_behavior_e2e.yml
@@ -63,6 +63,9 @@ jobs:
                   -Port 13305 `
                   -CtxSize 32768 `
                   -InitWaitTime 15
+              # Stop here on setup failure: the script exits non-zero without
+              # loading the model, so the suite would run at Lemonade's own ctx.
+              if ($LASTEXITCODE -ne 0) { throw "Lemonade setup failed (exit $LASTEXITCODE)" }
 
               python -m pytest tests/integration/eval/test_behavior_e2e.py `
                   -m real_model -v -rs --tb=short `

--- a/.github/workflows/test_embeddings.yml
+++ b/.github/workflows/test_embeddings.yml
@@ -100,6 +100,13 @@ jobs:
                 throw "Embedding model setup/verify via LemonadeClient failed"
             }
 
+            # Request-shape checks against the live server. A mocked unit test
+            # cannot catch a payload the server rejects -- that is how
+            # install_backend shipped sending {"spec": ...} and 400ing.
+            Write-Host "`n=== Verifying Lemonade request contracts ==="
+            pytest tests/integration/test_lemonade_backend_contract.py -v -rs --tb=short
+            if ($LASTEXITCODE -ne 0) { throw "Lemonade contract tests failed" }
+
             Write-Host "`n=== Running Embedding Tests ==="
             # Use --tb=long for full traceback, -rA for all test output summary
             pytest tests/test_lemonade_embeddings.py -v -s --tb=long -rA --log-cli-level=DEBUG

--- a/.github/workflows/test_examples.yml
+++ b/.github/workflows/test_examples.yml
@@ -140,6 +140,9 @@ jobs:
                   -Port 8000 `
                   -CtxSize 8192 `
                   -InitWaitTime 15
+              # Stop here on setup failure: the script exits non-zero without
+              # loading the model, so the suite would run at Lemonade's own ctx.
+              if ($LASTEXITCODE -ne 0) { throw "Lemonade setup failed (exit $LASTEXITCODE)" }
 
               Write-Host "=== Running example agent integration tests ==="
               python -m pytest tests/integration/test_example_agents.py `

--- a/.github/workflows/test_lemonade_server.yml
+++ b/.github/workflows/test_lemonade_server.yml
@@ -77,6 +77,9 @@ jobs:
           try {
               # Start server and load model (all in one session)
               .\installer\scripts\start-lemonade.ps1 -ModelName "Qwen3-4B-Instruct-2507-GGUF" -Port 13305 -CtxSize 32768 -InitWaitTime 10
+              # Stop here on setup failure: the script exits non-zero without
+              # loading the model, so the suite would run at Lemonade's own ctx.
+              if ($LASTEXITCODE -ne 0) { throw "Lemonade setup failed (exit $LASTEXITCODE)" }
 
               # Verify health endpoint
               Write-Host "=== Verifying Health Endpoint ==="

--- a/.github/workflows/test_npu_embedder.yml
+++ b/.github/workflows/test_npu_embedder.yml
@@ -94,11 +94,14 @@ jobs:
               -Port 13305 `
               -CtxSize 32768 `
               -InitWaitTime 15
-          # The script exits non-zero on setup failure; without this check the
-          # step ran on regardless and passed on skipped tests.
-          if ($LASTEXITCODE -ne 0) { throw "Lemonade/FLM setup failed (exit $LASTEXITCODE)" }
+          $setupExit = $LASTEXITCODE
 
           try {
+              # The script exits non-zero on setup failure; without this check
+              # the step ran on regardless and passed on skipped tests. Inside
+              # the try so the finally still reaps a half-started server.
+              if ($setupExit -ne 0) { throw "Lemonade/FLM setup failed (exit $setupExit)" }
+
               # -rs prints skip reasons; under GAIA_REQUIRE_FLM=1 a missing FLM
               # model fails instead of skipping.
               python -m pytest tests/test_npu_flm_embedder_hw.py -v -rs --tb=short

--- a/.github/workflows/test_npu_embedder.yml
+++ b/.github/workflows/test_npu_embedder.yml
@@ -2,9 +2,14 @@
 # SPDX-License-Identifier: MIT
 
 # Validates the NPU-native FLM embedder (embed-gemma-300m-FLM, #1744) on real
-# Ryzen AI hardware. The test (tests/test_npu_flm_embedder_hw.py) SKIPS unless
-# the live Lemonade Server advertises the FLM model, so on a runner without the
-# FLM/NPU backend this job is a clean no-op rather than a false failure.
+# Ryzen AI hardware.
+#
+# FLM models are NOT in Lemonade's built-in catalog (server_models.json): the
+# server enumerates them by shelling out to the `flm` CLI, so until the flm:npu
+# backend is installed no *-FLM name resolves and every pull 400s. Installing
+# that backend is therefore a step, not an assumption -- and GAIA_REQUIRE_FLM=1
+# makes the tests fail rather than skip once it is installed, so this job can no
+# longer report green while validating nothing.
 #
 # Runs on the AMD Ryzen Dev Lab pool, which registers a runner per job and
 # destroys it afterwards. `devlab-dispatch` is what routes it there; that pool
@@ -70,6 +75,10 @@ jobs:
         shell: powershell
         env:
           NO_PROXY: "localhost,127.0.0.1"
+          # Turn "FLM model missing from the catalog" into a failure. This
+          # runner is selected for its NPU, so an absent FLM backend is a broken
+          # runner, not a reason to pass.
+          GAIA_REQUIRE_FLM: "1"
         run: |
           [Console]::OutputEncoding = [System.Text.Encoding]::UTF8
           $env:PYTHONIOENCODING = "utf-8"
@@ -77,17 +86,21 @@ jobs:
           chcp 65001 | Out-Null
 
           # Free the port, then start Lemonade in a single session so the FLM
-          # backend child survives for the test run.
+          # backend child survives for the test run. -Backend installs flm:npu
+          # first; without it the FLM half of the catalog is empty.
           .\installer\scripts\start-lemonade.ps1 `
               -ModelName "gemma4-it-e2b-FLM" `
+              -Backend "flm:npu" `
               -Port 13305 `
               -CtxSize 32768 `
               -InitWaitTime 15
+          # The script exits non-zero on setup failure; without this check the
+          # step ran on regardless and passed on skipped tests.
+          if ($LASTEXITCODE -ne 0) { throw "Lemonade/FLM setup failed (exit $LASTEXITCODE)" }
 
           try {
-              # The test loads embed-gemma-300m-FLM itself and skips cleanly if
-              # the runner's Lemonade has no FLM/NPU backend. -rs prints skip
-              # reasons so a silent skip is visible in the log.
+              # -rs prints skip reasons; under GAIA_REQUIRE_FLM=1 a missing FLM
+              # model fails instead of skipping.
               python -m pytest tests/test_npu_flm_embedder_hw.py -v -rs --tb=short
               if ($LASTEXITCODE -ne 0) { throw "NPU FLM embedder tests failed" }
           }

--- a/docs/guides/npu.mdx
+++ b/docs/guides/npu.mdx
@@ -128,7 +128,21 @@ lemonade backends install flm:npu
 
 ### Model not available
 
-If `gemma4-it-e2b-FLM` is not found, pull it manually:
-```bash
-lemonade pull gemma4-it-e2b-FLM --recipe flm
 ```
+Error pulling model: No built-in model with the name 'gemma4-it-e2b-FLM' is registered.
+```
+
+The FLM backend is missing, not the model. Lemonade discovers `*-FLM` models
+through the FLM runtime itself, so until `flm:npu` is installed none of them
+exist to pull. Install the backend first, then pull by name:
+
+```bash
+lemonade backends install flm:npu
+lemonade pull gemma4-it-e2b-FLM
+```
+
+<Warning>
+Do not add `--recipe flm`. The recipe is baked into the built-in model and
+applied at load time; passing it turns the call into a custom-model
+registration, which fails asking for `--checkpoint`.
+</Warning>

--- a/installer/scripts/start-lemonade.ps1
+++ b/installer/scripts/start-lemonade.ps1
@@ -213,6 +213,9 @@ try {
     if ($Backend) {
         Write-Host "=== Installing Backend: $Backend ==="
         $recipe, $backendKey = $Backend.Split(":", 2)
+        if (-not $recipe -or -not $backendKey) {
+            throw "Invalid -Backend '$Backend': expected 'recipe:backend' (e.g. 'flm:npu')"
+        }
         $sysinfo = Invoke-RestMethod -Uri "http://localhost:${Port}/api/v1/system-info" -TimeoutSec 30
         $backendInfo = $sysinfo.recipes.$recipe.backends.$backendKey
         if (-not $backendInfo) {
@@ -233,8 +236,15 @@ try {
             # /install takes recipe + backend as separate fields; a combined
             # "spec" is rejected with 400 "Both 'recipe' and 'backend' are required".
             $installBody = @{ recipe = $recipe; backend = $backendKey } | ConvertTo-Json
-            $installResponse = Invoke-RestMethod -Uri "http://localhost:${Port}/api/v1/install" `
-                -Method POST -ContentType "application/json" -Body $installBody -TimeoutSec 900
+            try {
+                $installResponse = Invoke-RestMethod -Uri "http://localhost:${Port}/api/v1/install" `
+                    -Method POST -ContentType "application/json" -Body $installBody -TimeoutSec 900
+            } catch {
+                # The JSON body carries the actionable reason; the exception
+                # message is only "(400) Bad Request".
+                $detail = if ($_.ErrorDetails) { $_.ErrorDetails.Message } else { $_.Exception.Message }
+                throw "Installing backend '$Backend' failed: $detail"
+            }
             Write-Host "[OK] Backend installed: $($installResponse | ConvertTo-Json -Compress)"
         }
 

--- a/installer/scripts/start-lemonade.ps1
+++ b/installer/scripts/start-lemonade.ps1
@@ -31,8 +31,19 @@
     Start the server only (skip pull/load). Use when the caller registers/loads
     its own models afterwards (e.g. a custom user-model via LemonadeClient).
 
+.PARAMETER Backend
+    Lemonade backend to install before pulling, in recipe:backend form (e.g.
+    "flm:npu"). Required for backends whose models are contributed at runtime
+    rather than shipped in the built-in catalog: FLM models are enumerated by
+    shelling out to the `flm` CLI, so with no FLM backend installed the catalog
+    holds no *-FLM name and every pull 400s with "no built-in model ...".
+
 .EXAMPLE
     .\installer\scripts\start-lemonade.ps1 -ModelName "Qwen3-0.6B-GGUF"
+
+.EXAMPLE
+    # NPU/FLM: without -Backend the FLM half of the catalog is empty.
+    .\installer\scripts\start-lemonade.ps1 -ModelName "gemma4-it-e2b-FLM" -Backend "flm:npu"
 
 .EXAMPLE
     # Start the server robustly, then let the caller register a custom embedder:
@@ -62,7 +73,10 @@ param(
     [switch]$ClearCache,
 
     [Parameter(Mandatory=$false)]
-    [switch]$NoModel
+    [switch]$NoModel,
+
+    [Parameter(Mandatory=$false)]
+    [string]$Backend = ""
 )
 
 $ErrorActionPreference = "Stop"
@@ -193,6 +207,49 @@ try {
     }
     Write-Host ""
 
+    # Install the requested backend before any pull. Mirrors what
+    # ``gaia init --profile npu`` does (InitCommand._install_backend): check
+    # recipe status via /system-info, install via /install only when needed.
+    if ($Backend) {
+        Write-Host "=== Installing Backend: $Backend ==="
+        $recipe, $backendKey = $Backend.Split(":", 2)
+        $sysinfo = Invoke-RestMethod -Uri "http://localhost:${Port}/api/v1/system-info" -TimeoutSec 30
+        $backendInfo = $sysinfo.recipes.$recipe.backends.$backendKey
+        if (-not $backendInfo) {
+            throw "Lemonade does not know backend '$Backend' (recipes: $($sysinfo.recipes.PSObject.Properties.Name -join ', '))"
+        }
+        $state = $backendInfo.state
+        Write-Host "Reported state for ${recipe}:${backendKey}: $state"
+
+        if ($state -eq "unsupported") {
+            # Hardware genuinely can't run it -- say so here rather than letting
+            # the pull fail later with an opaque "model not registered".
+            throw "Backend '$Backend' is unsupported on this machine: $($backendInfo.message)"
+        }
+
+        if ($state -eq "installed") {
+            Write-Host "Already installed; skipping install"
+        } else {
+            # /install takes recipe + backend as separate fields; a combined
+            # "spec" is rejected with 400 "Both 'recipe' and 'backend' are required".
+            $installBody = @{ recipe = $recipe; backend = $backendKey } | ConvertTo-Json
+            $installResponse = Invoke-RestMethod -Uri "http://localhost:${Port}/api/v1/install" `
+                -Method POST -ContentType "application/json" -Body $installBody -TimeoutSec 900
+            Write-Host "[OK] Backend installed: $($installResponse | ConvertTo-Json -Compress)"
+        }
+
+        # The backend contributes its models to the catalog only once it is
+        # live; re-read /system-info so a silent no-op install fails here rather
+        # than as a confusing pull error.
+        $sysinfo = Invoke-RestMethod -Uri "http://localhost:${Port}/api/v1/system-info" -TimeoutSec 30
+        $state = $sysinfo.recipes.$recipe.backends.$backendKey.state
+        if ($state -ne "installed") {
+            throw "Backend '$Backend' still reports state '$state' after install (expected 'installed'); try '$($sysinfo.recipes.$recipe.backends.$backendKey.action)'"
+        }
+        Write-Host "[OK] Backend '$Backend' is installed"
+        Write-Host ""
+    }
+
     # Start-only mode: the caller registers/loads its own models (e.g. a custom
     # user-model via LemonadeClient), so skip the built-in pull/load path.
     if ($NoModel) {
@@ -215,9 +272,13 @@ try {
     # installs.
     Write-Host "=== Pulling Primary Model: $ModelName ==="
     $pullOutput = & $lemonadeCli pull $ModelName 2>&1
-    Write-Host "Pull exit code: $LASTEXITCODE"
+    $pullExit = $LASTEXITCODE
+    Write-Host "Pull exit code: $pullExit"
     if ($pullOutput) {
         $pullOutput | ForEach-Object { Write-Host "  $_" }
+    }
+    if ($pullExit -ne 0) {
+        throw "Pull of primary model '$ModelName' failed (exit $pullExit)"
     }
     Write-Host ""
 

--- a/src/gaia/installer/init_command.py
+++ b/src/gaia/installer/init_command.py
@@ -1601,17 +1601,18 @@ class InitCommand:
             return True
 
         try:
-            from gaia.llm.lemonade_client import LemonadeClient
+            from gaia.llm.lemonade_client import LemonadeClient, split_backend_spec
 
             client = LemonadeClient(verbose=self.verbose)
 
+            spec_recipe, backend_key = split_backend_spec(backend_spec)
+
             # Check if already installed via recipe status
-            recipe_name = profile_config.get("recipe", backend_spec.split(":")[0])
+            recipe_name = profile_config.get("recipe", spec_recipe)
             recipe_status = client.get_recipe_status(recipe_name)
 
             if recipe_status:
                 backends = recipe_status.get("backends", {})
-                backend_key = backend_spec.split(":")[-1] if ":" in backend_spec else ""
                 backend_info = backends.get(backend_key, {})
 
                 if backend_info.get("state") == "installed":

--- a/src/gaia/llm/lemonade_client.py
+++ b/src/gaia/llm/lemonade_client.py
@@ -223,6 +223,21 @@ def truncation_budget(device: Optional[str]) -> Tuple[int, int]:
     return budget_for_ctx(ctx)
 
 
+def _split_backend_spec(spec: str) -> Tuple[str, str]:
+    """Split a ``recipe:backend`` spec into its two parts.
+
+    ``/install`` and ``/uninstall`` take the halves as separate fields and
+    reject a combined one with 400 "Both 'recipe' and 'backend' are required".
+    """
+    recipe, _, backend = (spec or "").partition(":")
+    if not recipe or not backend:
+        raise ValueError(
+            f"Invalid backend spec {spec!r}: expected 'recipe:backend' "
+            "(e.g. 'flm:npu', 'llamacpp:vulkan')"
+        )
+    return recipe, backend
+
+
 # =========================================================================
 # Request Configuration Defaults
 # =========================================================================
@@ -2534,6 +2549,7 @@ class LemonadeClient:
             Dict containing installation status
 
         Raises:
+            ValueError: If *spec* is not in ``recipe:backend`` form
             LemonadeClientError: If the installation fails
 
         Examples:
@@ -2542,7 +2558,8 @@ class LemonadeClient:
             client.install_backend("llamacpp:rocm", force=True)
         """
         self.log.info(f"Installing backend: {spec}")
-        request_data: Dict[str, Any] = {"spec": spec}
+        recipe, backend = _split_backend_spec(spec)
+        request_data: Dict[str, Any] = {"recipe": recipe, "backend": backend}
         if force:
             request_data["force"] = True
         url = f"{self.base_url}/install"
@@ -2564,10 +2581,12 @@ class LemonadeClient:
             Dict containing uninstall status
 
         Raises:
+            ValueError: If *spec* is not in ``recipe:backend`` form
             LemonadeClientError: If the uninstall fails
         """
         self.log.info(f"Uninstalling backend: {spec}")
-        request_data: Dict[str, Any] = {"spec": spec}
+        recipe, backend = _split_backend_spec(spec)
+        request_data: Dict[str, Any] = {"recipe": recipe, "backend": backend}
         url = f"{self.base_url}/uninstall"
         try:
             response = self._send_request("post", url, request_data, timeout=timeout)

--- a/src/gaia/llm/lemonade_client.py
+++ b/src/gaia/llm/lemonade_client.py
@@ -223,7 +223,7 @@ def truncation_budget(device: Optional[str]) -> Tuple[int, int]:
     return budget_for_ctx(ctx)
 
 
-def _split_backend_spec(spec: str) -> Tuple[str, str]:
+def split_backend_spec(spec: str) -> Tuple[str, str]:
     """Split a ``recipe:backend`` spec into its two parts.
 
     ``/install`` and ``/uninstall`` take the halves as separate fields and
@@ -2558,7 +2558,7 @@ class LemonadeClient:
             client.install_backend("llamacpp:rocm", force=True)
         """
         self.log.info(f"Installing backend: {spec}")
-        recipe, backend = _split_backend_spec(spec)
+        recipe, backend = split_backend_spec(spec)
         request_data: Dict[str, Any] = {"recipe": recipe, "backend": backend}
         if force:
             request_data["force"] = True
@@ -2585,7 +2585,7 @@ class LemonadeClient:
             LemonadeClientError: If the uninstall fails
         """
         self.log.info(f"Uninstalling backend: {spec}")
-        recipe, backend = _split_backend_spec(spec)
+        recipe, backend = split_backend_spec(spec)
         request_data: Dict[str, Any] = {"recipe": recipe, "backend": backend}
         url = f"{self.base_url}/uninstall"
         try:

--- a/tests/integration/test_lemonade_backend_contract.py
+++ b/tests/integration/test_lemonade_backend_contract.py
@@ -34,14 +34,18 @@ def _installed_backend(client: LemonadeClient):
 
 
 def test_combined_spec_field_is_rejected(client, require_lemonade):
-    """Pins *why* the client splits the spec: a combined field is a 400."""
+    """Pins *why* the client splits the spec: a combined field is a 400.
+
+    Uses a nonexistent backend so that a server which *did* start honouring
+    ``spec`` would fail this test rather than kick off a real install.
+    """
     response = requests.post(
-        f"{client.base_url}/install", json={"spec": "flm:npu"}, timeout=30
+        f"{client.base_url}/install", json={"spec": "nonexistent:backend"}, timeout=30
     )
 
     assert response.status_code == 400, (
         "A combined 'spec' field was accepted -- if the server now supports it, "
-        "LemonadeClient._split_backend_spec can be simplified"
+        "split_backend_spec in lemonade_client can be simplified"
     )
     assert "recipe" in response.text and "backend" in response.text
 

--- a/tests/integration/test_lemonade_backend_contract.py
+++ b/tests/integration/test_lemonade_backend_contract.py
@@ -1,0 +1,64 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""The /install and /uninstall request contract, checked against a live server.
+
+``tests/unit/test_npu_device_support.py`` mocks ``_send_request``, so it can only
+prove the client *called* the endpoint -- it happily passed while the client sent
+``{"spec": "flm:npu"}``, which every Lemonade build rejects with a 400. That
+silently broke ``gaia init --profile npu`` and the NPU CI job.
+
+These tests talk to a real server, so they fail if the contract moves.
+"""
+
+import pytest
+import requests
+
+from gaia.llm.lemonade_client import LemonadeClient
+
+pytestmark = pytest.mark.integration
+
+
+@pytest.fixture(scope="module")
+def client():
+    return LemonadeClient()
+
+
+def _installed_backend(client: LemonadeClient):
+    """An (recipe, backend) pair the live server reports as already installed."""
+    recipes = client.get_system_info().get("recipes", {}) or {}
+    for recipe, info in sorted(recipes.items()):
+        for backend, state in (info.get("backends") or {}).items():
+            if state.get("state") == "installed":
+                return recipe, backend
+    return None
+
+
+def test_combined_spec_field_is_rejected(client, require_lemonade):
+    """Pins *why* the client splits the spec: a combined field is a 400."""
+    response = requests.post(
+        f"{client.base_url}/install", json={"spec": "flm:npu"}, timeout=30
+    )
+
+    assert response.status_code == 400, (
+        "A combined 'spec' field was accepted -- if the server now supports it, "
+        "LemonadeClient._split_backend_spec can be simplified"
+    )
+    assert "recipe" in response.text and "backend" in response.text
+
+
+def test_install_backend_request_is_accepted(client, require_lemonade):
+    """The client's real request shape round-trips against a live server.
+
+    Re-installing an already-installed backend is the idempotent no-op the
+    server offers, so this asserts validity without changing machine state.
+    """
+    pair = _installed_backend(client)
+    if pair is None:
+        pytest.skip("no already-installed backend to exercise idempotently")
+    recipe, backend = pair
+
+    result = client.install_backend(f"{recipe}:{backend}")
+
+    assert result.get("status") == "success", result
+    assert result.get("recipe") == recipe
+    assert result.get("backend") == backend

--- a/tests/test_npu_flm_embedder_hw.py
+++ b/tests/test_npu_flm_embedder_hw.py
@@ -27,7 +27,7 @@ import os
 import pytest
 
 from gaia.agents.registry import get_embedding_model_for_device
-from gaia.llm.lemonade_client import LemonadeClient, LemonadeClientError
+from gaia.llm.lemonade_client import LemonadeClient
 
 pytestmark = [pytest.mark.integration, pytest.mark.real_model]
 
@@ -42,11 +42,13 @@ EXPECTED_DIM = 768
 
 
 def _catalog_ids(client: LemonadeClient) -> set:
-    """Model ids the live server advertises (empty set if unreachable)."""
-    try:
-        catalog = client.list_models(show_all=True)
-    except LemonadeClientError:
-        return set()
+    """Model ids the live server advertises.
+
+    Deliberately does not swallow the error: an unreachable server must not be
+    reported as "the FLM backend is missing", which is what an empty set would
+    make the caller say.
+    """
+    catalog = client.list_models(show_all=True)
     data = catalog.get("data", catalog) if isinstance(catalog, dict) else catalog
     ids = set()
     for entry in data or []:
@@ -63,7 +65,9 @@ def _require_in_catalog(client: LemonadeClient, model: str) -> None:
         f"{model} not in the live Lemonade catalog -- FLM models are contributed "
         "by the flm:npu backend, which is not installed on this server"
     )
-    if os.getenv("GAIA_REQUIRE_FLM") == "1":
+    # Fail closed on any truthy spelling: a gate meant to stop silent passes
+    # must not revert to skipping because someone wrote "true" instead of "1".
+    if os.getenv("GAIA_REQUIRE_FLM", "").strip().lower() in {"1", "true", "yes", "on"}:
         pytest.fail(reason)
     pytest.skip(f"{reason}; requires an FLM/NPU-enabled server on Ryzen AI hardware")
 

--- a/tests/test_npu_flm_embedder_hw.py
+++ b/tests/test_npu_flm_embedder_hw.py
@@ -13,11 +13,16 @@ the mainline llamacpp/Vulkan catalog. Every test here therefore SKIPS unless the
 live server actually advertises the model, so the suite is safe on CPU/GPU boxes
 and in Vulkan CI while still executing for real on an NPU runner.
 
+Set ``GAIA_REQUIRE_FLM=1`` to turn that skip into a failure. CI does, because a
+runner that is meant to have the FLM backend and silently skips reports green
+while validating nothing.
+
 Run on NPU hardware with:
     python -m pytest tests/test_npu_flm_embedder_hw.py -v -rs
 """
 
 import math
+import os
 
 import pytest
 
@@ -50,6 +55,19 @@ def _catalog_ids(client: LemonadeClient) -> set:
     return ids
 
 
+def _require_in_catalog(client: LemonadeClient, model: str) -> None:
+    """Skip when the server has no FLM backend -- or fail, if CI asked us to."""
+    if model in _catalog_ids(client):
+        return
+    reason = (
+        f"{model} not in the live Lemonade catalog -- FLM models are contributed "
+        "by the flm:npu backend, which is not installed on this server"
+    )
+    if os.getenv("GAIA_REQUIRE_FLM") == "1":
+        pytest.fail(reason)
+    pytest.skip(f"{reason}; requires an FLM/NPU-enabled server on Ryzen AI hardware")
+
+
 @pytest.fixture(scope="module")
 def client():
     return LemonadeClient()
@@ -62,11 +80,7 @@ def npu_embedder(client, require_lemonade):
     ``require_lemonade`` skips when no server is up; this then skips when the
     server is up but not FLM/NPU-enabled (the Vulkan-catalog case).
     """
-    if FLM_EMBEDDER not in _catalog_ids(client):
-        pytest.skip(
-            f"{FLM_EMBEDDER} not in the live Lemonade catalog -- requires an "
-            "FLM/NPU-enabled server on Ryzen AI hardware"
-        )
+    _require_in_catalog(client, FLM_EMBEDDER)
     # Built-in FLM model: pull/load by name, no recipe (#1655-safe).
     client.load_model(FLM_EMBEDDER, auto_download=True, prompt=False)
     return FLM_EMBEDDER
@@ -127,10 +141,7 @@ class TestFlmCoresidency:
     versa) the way the Vulkan GGUF embedder did on a shared-memory APU."""
 
     def test_chat_and_embedder_coresident(self, client, npu_embedder):
-        if FLM_CHAT_MODEL not in _catalog_ids(client):
-            pytest.skip(
-                f"{FLM_CHAT_MODEL} not in the live catalog -- cannot test co-residency"
-            )
+        _require_in_catalog(client, FLM_CHAT_MODEL)
 
         client.load_model(
             FLM_CHAT_MODEL, auto_download=True, prompt=False, ctx_size=32768

--- a/tests/unit/test_npu_device_support.py
+++ b/tests/unit/test_npu_device_support.py
@@ -178,10 +178,11 @@ class TestLemonadeClientBackendMethods:
 
         result = client.install_backend("flm:npu")
         assert result == {"status": "success"}
+        # recipe and backend are separate fields; a combined "spec" is a 400.
         client._send_request.assert_called_once_with(
             "post",
             "http://localhost:13305/api/v1/install",
-            {"spec": "flm:npu"},
+            {"recipe": "flm", "backend": "npu"},
             timeout=300,
         )
 
@@ -195,7 +196,11 @@ class TestLemonadeClientBackendMethods:
 
         client.install_backend("llamacpp:rocm", force=True)
         call_args = client._send_request.call_args
-        assert call_args[0][2] == {"spec": "llamacpp:rocm", "force": True}
+        assert call_args[0][2] == {
+            "recipe": "llamacpp",
+            "backend": "rocm",
+            "force": True,
+        }
 
     def test_install_backend_error(self):
         from gaia.llm.lemonade_client import LemonadeClient, LemonadeClientError
@@ -221,9 +226,23 @@ class TestLemonadeClientBackendMethods:
         client._send_request.assert_called_once_with(
             "post",
             "http://localhost:13305/api/v1/uninstall",
-            {"spec": "flm:npu"},
+            {"recipe": "flm", "backend": "npu"},
             timeout=120,
         )
+
+    @pytest.mark.parametrize("spec", ["flm", "", ":npu", "flm:"])
+    def test_backend_spec_must_be_recipe_colon_backend(self, spec):
+        """A malformed spec fails here, not as an opaque 400 from the server."""
+        from gaia.llm.lemonade_client import LemonadeClient
+
+        client = LemonadeClient.__new__(LemonadeClient)
+        client.base_url = "http://localhost:13305/api/v1"
+        client.log = MagicMock()
+        client._send_request = MagicMock()
+
+        with pytest.raises(ValueError, match="recipe:backend"):
+            client.install_backend(spec)
+        client._send_request.assert_not_called()
 
     def test_get_recipe_status_found(self):
         from gaia.llm.lemonade_client import LemonadeClient


### PR DESCRIPTION
Setting up the NPU profile could not download its models. `gaia init --profile npu` failed with `No built-in model with the name 'gemma4-it-e2b-FLM' is registered`, and the NPU CI job reported green while running zero assertions — every ✅ in that workflow's history was a no-op.

The FLM backend was the missing piece, not the model. Lemonade doesn't ship `*-FLM` models in its built-in catalog; it discovers them through the FLM runtime, so until `flm:npu` is installed no FLM name resolves and every pull 400s. Installing it takes the catalog from 0 to 37 FLM models, after which the embedder tests run for real on the NPU for the first time.

Three further bugs surfaced while fixing it:

- **`install_backend` sent a payload Lemonade rejects.** It posted `{"spec": "recipe:backend"}`; the endpoint wants the halves as separate fields and 400s otherwise. This is what actually broke `gaia init --profile npu`. The unit test mocked the transport and asserted the `spec` payload, so it locked the wrong contract in rather than catching it — the same failure class as #1655.
- **The npu guide documented a command that fails.** `lemonade pull gemma4-it-e2b-FLM --recipe flm` turns the call into a custom-model registration and errors asking for `--checkpoint`.
- **The job passed on skipped tests.** `start-lemonade.ps1` exits non-zero on setup failure, but the step never checked `$LASTEXITCODE`, so it continued and pytest exited 0 with everything skipped. The step now checks it, and `GAIA_REQUIRE_FLM=1` makes an absent FLM catalog fail instead of skip: a runner selected for its NPU that has no FLM backend is broken, not a pass.

Verified against a real Lemonade 11.8.1 rather than a mock — including a new integration test that a mock cannot fake.

## Test plan

- [ ] The `Test NPU FLM Embedder` job on this PR installs `flm:npu`, pulls `gemma4-it-e2b-FLM`, and runs 5 tests — **not** 5 skips. This is the check that matters; the job has never done it before.
- [ ] `pytest tests/integration/test_lemonade_backend_contract.py -v` against a live Lemonade — 2 passed, 0 skipped. Confirms `/install` rejects the old `spec` field and accepts the new shape.
- [ ] `pytest tests/unit/test_npu_device_support.py -v` — 35 passed.
- [ ] On Ryzen AI hardware: `gaia init --profile npu` installs the backend and downloads both models.
- [ ] Sanity-check the non-FLM callers are unaffected: any workflow using `start-lemonade.ps1` without `-Backend` behaves exactly as before.

<details>
<summary>🔍 Verification evidence</summary>

Root cause, on a real server — before installing the backend the FLM catalog is empty, after it is populated:

```
$ curl -X POST /api/v1/install -d '{"spec":"flm:npu"}'
{"error":"Both 'recipe' and 'backend' are required"}   HTTP 400

$ curl -X POST /api/v1/install -d '{"recipe":"flm","backend":"npu"}'
{"backend":"npu","recipe":"flm","status":"success"}    HTTP 200

# catalog, show_all=true:  FLM models 0 -> 37
# includes gemma4-it-e2b-FLM and embed-gemma-300m-FLM
```

Hardware run after the fix (Ryzen AI, FLM on NPU): 5 passed.

The co-residency test failed once on a first local run with `loaded=['Gemma-4-E4B-it-GGUF']` — a concurrent process on the same box held the single LLM slot and evicted the FLM model mid-test. Uncontended re-run passes. Not a regression; noted because Lemonade is single-instance per machine and this test is sensitive to a shared server.

The 8 pre-existing `test_init_command.py` failures on Windows (POSIX-only `os.geteuid` mocks) are unrelated and present on `main`.
</details>
