### PR TITLE
Devlab/dispatch passing

### DIFF
--- a/.github/workflows/test_agent_sdk.yml
+++ b/.github/workflows/test_agent_sdk.yml
@@ -43,8 +43,8 @@ permissions:
 jobs:
   test-agent-sdk-windows:
     name: Test Agent SDK on Windows (Lemonade Integration)
-    # Default lane runs on the AMD Ryzen DevLab Dispatch ephemeral pool via devlab-dispatch; a PR labelled stx-test still goes to the static stx-test box.
-    runs-on: ${{ contains(github.event.pull_request.labels.*.name, 'stx-test') && fromJSON('["self-hosted","Windows","stx-test"]') || fromJSON('["self-hosted","Windows","devlab-dispatch","strix-halo"]') }}
+    # Runs on the AMD Ryzen DevLab Dispatch ephemeral pool via the devlab-dispatch label.
+    runs-on: [self-hosted, Windows, devlab-dispatch, strix-halo]
     if: github.event_name != 'pull_request' || github.event.pull_request.draft == false || contains(github.event.pull_request.labels.*.name, 'ready_for_ci')
     steps:
       - uses: actions/checkout@v7

--- a/.github/workflows/test_agent_sdk.yml
+++ b/.github/workflows/test_agent_sdk.yml
@@ -43,10 +43,12 @@ permissions:
 jobs:
   test-agent-sdk-windows:
     name: Test Agent SDK on Windows (Lemonade Integration)
-    runs-on:
-      - self-hosted
-      - Windows
-      - ${{ contains(github.event.pull_request.labels.*.name, 'stx-test') && 'stx-test' || 'stx' }}
+    # Runs on the AMD Ryzen Dev Lab pool: a runner is registered for this job
+    # alone and destroyed afterwards. 'devlab-dispatch' is what routes it there;
+    # 'strix-halo' narrows to the silicon. The pool does not answer to 'stx' or
+    # 'stx-test' -- those name specific static machines, and a shared pool
+    # claiming them would compete for their work rather than add capacity.
+    runs-on: [self-hosted, Windows, devlab-dispatch, strix-halo]
     if: github.event_name != 'pull_request' || github.event.pull_request.draft == false || contains(github.event.pull_request.labels.*.name, 'ready_for_ci')
     steps:
       - uses: actions/checkout@v7

--- a/.github/workflows/test_agent_sdk.yml
+++ b/.github/workflows/test_agent_sdk.yml
@@ -43,8 +43,8 @@ permissions:
 jobs:
   test-agent-sdk-windows:
     name: Test Agent SDK on Windows (Lemonade Integration)
-    # Runs on the AMD Ryzen DevLab Dispatch ephemeral pool via the devlab-dispatch label.
-    runs-on: [self-hosted, Windows, devlab-dispatch, strix-halo]
+    # Default lane runs on the AMD Ryzen DevLab Dispatch ephemeral pool via devlab-dispatch; a PR labelled stx-test still goes to the static stx-test box.
+    runs-on: ${{ contains(github.event.pull_request.labels.*.name, 'stx-test') && fromJSON('["self-hosted","Windows","stx-test"]') || fromJSON('["self-hosted","Windows","devlab-dispatch","strix-halo"]') }}
     if: github.event_name != 'pull_request' || github.event.pull_request.draft == false || contains(github.event.pull_request.labels.*.name, 'ready_for_ci')
     steps:
       - uses: actions/checkout@v7

--- a/.github/workflows/test_agent_sdk.yml
+++ b/.github/workflows/test_agent_sdk.yml
@@ -43,11 +43,7 @@ permissions:
 jobs:
   test-agent-sdk-windows:
     name: Test Agent SDK on Windows (Lemonade Integration)
-    # Runs on the AMD Ryzen Dev Lab pool: a runner is registered for this job
-    # alone and destroyed afterwards. 'devlab-dispatch' is what routes it there;
-    # 'strix-halo' narrows to the silicon. The pool does not answer to 'stx' or
-    # 'stx-test' -- those name specific static machines, and a shared pool
-    # claiming them would compete for their work rather than add capacity.
+    # Runs on the AMD Ryzen DevLab Dispatch ephemeral pool via the devlab-dispatch label.
     runs-on: [self-hosted, Windows, devlab-dispatch, strix-halo]
     if: github.event_name != 'pull_request' || github.event.pull_request.draft == false || contains(github.event.pull_request.labels.*.name, 'ready_for_ci')
     steps:

--- a/.github/workflows/test_api.yml
+++ b/.github/workflows/test_api.yml
@@ -49,8 +49,8 @@ permissions:
 jobs:
   test-api:
     name: API Tests
-    # Runs on the AMD Ryzen DevLab Dispatch ephemeral pool via the devlab-dispatch label.
-    runs-on: [self-hosted, Windows, devlab-dispatch, strix-halo]
+    # Default lane runs on the AMD Ryzen DevLab Dispatch ephemeral pool via devlab-dispatch; a PR labelled stx-test still goes to the static stx-test box.
+    runs-on: ${{ contains(github.event.pull_request.labels.*.name, 'stx-test') && fromJSON('["self-hosted","Windows","stx-test"]') || fromJSON('["self-hosted","Windows","devlab-dispatch","strix-halo"]') }}
     timeout-minutes: 30
     if: github.event_name != 'pull_request' || github.event.pull_request.draft == false || contains(github.event.pull_request.labels.*.name, 'ready_for_ci')
 

--- a/.github/workflows/test_api.yml
+++ b/.github/workflows/test_api.yml
@@ -49,10 +49,12 @@ permissions:
 jobs:
   test-api:
     name: API Tests
-    runs-on:
-      - self-hosted
-      - Windows
-      - ${{ contains(github.event.pull_request.labels.*.name, 'stx-test') && 'stx-test' || 'stx' }}
+    # Runs on the AMD Ryzen Dev Lab pool: a runner is registered for this job
+    # alone and destroyed afterwards. 'devlab-dispatch' is what routes it there;
+    # 'strix-halo' narrows to the silicon. The pool does not answer to 'stx' or
+    # 'stx-test' -- those name specific static machines, and a shared pool
+    # claiming them would compete for their work rather than add capacity.
+    runs-on: [self-hosted, Windows, devlab-dispatch, strix-halo]
     timeout-minutes: 30
     if: github.event_name != 'pull_request' || github.event.pull_request.draft == false || contains(github.event.pull_request.labels.*.name, 'ready_for_ci')
 

--- a/.github/workflows/test_api.yml
+++ b/.github/workflows/test_api.yml
@@ -49,8 +49,8 @@ permissions:
 jobs:
   test-api:
     name: API Tests
-    # Default lane runs on the AMD Ryzen DevLab Dispatch ephemeral pool via devlab-dispatch; a PR labelled stx-test still goes to the static stx-test box.
-    runs-on: ${{ contains(github.event.pull_request.labels.*.name, 'stx-test') && fromJSON('["self-hosted","Windows","stx-test"]') || fromJSON('["self-hosted","Windows","devlab-dispatch","strix-halo"]') }}
+    # Runs on the AMD Ryzen DevLab Dispatch ephemeral pool via the devlab-dispatch label.
+    runs-on: [self-hosted, Windows, devlab-dispatch, strix-halo]
     timeout-minutes: 30
     if: github.event_name != 'pull_request' || github.event.pull_request.draft == false || contains(github.event.pull_request.labels.*.name, 'ready_for_ci')
 

--- a/.github/workflows/test_api.yml
+++ b/.github/workflows/test_api.yml
@@ -49,11 +49,7 @@ permissions:
 jobs:
   test-api:
     name: API Tests
-    # Runs on the AMD Ryzen Dev Lab pool: a runner is registered for this job
-    # alone and destroyed afterwards. 'devlab-dispatch' is what routes it there;
-    # 'strix-halo' narrows to the silicon. The pool does not answer to 'stx' or
-    # 'stx-test' -- those name specific static machines, and a shared pool
-    # claiming them would compete for their work rather than add capacity.
+    # Runs on the AMD Ryzen DevLab Dispatch ephemeral pool via the devlab-dispatch label.
     runs-on: [self-hosted, Windows, devlab-dispatch, strix-halo]
     timeout-minutes: 30
     if: github.event_name != 'pull_request' || github.event.pull_request.draft == false || contains(github.event.pull_request.labels.*.name, 'ready_for_ci')

--- a/.github/workflows/test_embeddings.yml
+++ b/.github/workflows/test_embeddings.yml
@@ -40,10 +40,12 @@ permissions:
 jobs:
   test-embeddings:
     name: Test Lemonade Embeddings API
-    runs-on:
-      - self-hosted
-      - Windows
-      - ${{ contains(github.event.pull_request.labels.*.name, 'stx-test') && 'stx-test' || 'stx' }}
+    # Runs on the AMD Ryzen Dev Lab pool: a runner is registered for this job
+    # alone and destroyed afterwards. 'devlab-dispatch' is what routes it there;
+    # 'strix-halo' narrows to the silicon. The pool does not answer to 'stx' or
+    # 'stx-test' -- those name specific static machines, and a shared pool
+    # claiming them would compete for their work rather than add capacity.
+    runs-on: [self-hosted, Windows, devlab-dispatch, strix-halo]
     # Bound a wedged model pull/load — the LemonadeClient pull timeout alone
     # is 200 min; don't let one hold the self-hosted runner for the 6h default.
     timeout-minutes: 30

--- a/.github/workflows/test_embeddings.yml
+++ b/.github/workflows/test_embeddings.yml
@@ -40,8 +40,8 @@ permissions:
 jobs:
   test-embeddings:
     name: Test Lemonade Embeddings API
-    # Default lane runs on the AMD Ryzen DevLab Dispatch ephemeral pool via devlab-dispatch; a PR labelled stx-test still goes to the static stx-test box.
-    runs-on: ${{ contains(github.event.pull_request.labels.*.name, 'stx-test') && fromJSON('["self-hosted","Windows","stx-test"]') || fromJSON('["self-hosted","Windows","devlab-dispatch","strix-halo"]') }}
+    # Runs on the AMD Ryzen DevLab Dispatch ephemeral pool via the devlab-dispatch label.
+    runs-on: [self-hosted, Windows, devlab-dispatch, strix-halo]
     # Bound a wedged model pull/load — the LemonadeClient pull timeout alone
     # is 200 min; don't let one hold the self-hosted runner for the 6h default.
     timeout-minutes: 30

--- a/.github/workflows/test_embeddings.yml
+++ b/.github/workflows/test_embeddings.yml
@@ -40,11 +40,7 @@ permissions:
 jobs:
   test-embeddings:
     name: Test Lemonade Embeddings API
-    # Runs on the AMD Ryzen Dev Lab pool: a runner is registered for this job
-    # alone and destroyed afterwards. 'devlab-dispatch' is what routes it there;
-    # 'strix-halo' narrows to the silicon. The pool does not answer to 'stx' or
-    # 'stx-test' -- those name specific static machines, and a shared pool
-    # claiming them would compete for their work rather than add capacity.
+    # Runs on the AMD Ryzen DevLab Dispatch ephemeral pool via the devlab-dispatch label.
     runs-on: [self-hosted, Windows, devlab-dispatch, strix-halo]
     # Bound a wedged model pull/load — the LemonadeClient pull timeout alone
     # is 200 min; don't let one hold the self-hosted runner for the 6h default.

--- a/.github/workflows/test_embeddings.yml
+++ b/.github/workflows/test_embeddings.yml
@@ -40,8 +40,8 @@ permissions:
 jobs:
   test-embeddings:
     name: Test Lemonade Embeddings API
-    # Runs on the AMD Ryzen DevLab Dispatch ephemeral pool via the devlab-dispatch label.
-    runs-on: [self-hosted, Windows, devlab-dispatch, strix-halo]
+    # Default lane runs on the AMD Ryzen DevLab Dispatch ephemeral pool via devlab-dispatch; a PR labelled stx-test still goes to the static stx-test box.
+    runs-on: ${{ contains(github.event.pull_request.labels.*.name, 'stx-test') && fromJSON('["self-hosted","Windows","stx-test"]') || fromJSON('["self-hosted","Windows","devlab-dispatch","strix-halo"]') }}
     # Bound a wedged model pull/load — the LemonadeClient pull timeout alone
     # is 200 min; don't let one hold the self-hosted runner for the 6h default.
     timeout-minutes: 30

--- a/.github/workflows/test_examples.yml
+++ b/.github/workflows/test_examples.yml
@@ -93,8 +93,8 @@ jobs:
   test-examples-integration:
     name: Example Agents Integration Tests (stx)
     needs: test-examples-unit
-    # Default lane runs on the AMD Ryzen DevLab Dispatch ephemeral pool via devlab-dispatch; a PR labelled stx-test still goes to the static stx-test box.
-    runs-on: ${{ contains(github.event.pull_request.labels.*.name, 'stx-test') && fromJSON('["self-hosted","Windows","stx-test"]') || fromJSON('["self-hosted","Windows","devlab-dispatch","strix-halo"]') }}
+    # Runs on the AMD Ryzen DevLab Dispatch ephemeral pool via the devlab-dispatch label.
+    runs-on: [self-hosted, Windows, devlab-dispatch, strix-halo]
     if: github.event_name != 'pull_request' || github.event.pull_request.draft == false || contains(github.event.pull_request.labels.*.name, 'ready_for_ci')
     timeout-minutes: 30
 

--- a/.github/workflows/test_examples.yml
+++ b/.github/workflows/test_examples.yml
@@ -93,8 +93,8 @@ jobs:
   test-examples-integration:
     name: Example Agents Integration Tests (stx)
     needs: test-examples-unit
-    # Runs on the AMD Ryzen DevLab Dispatch ephemeral pool via the devlab-dispatch label.
-    runs-on: [self-hosted, Windows, devlab-dispatch, strix-halo]
+    # Default lane runs on the AMD Ryzen DevLab Dispatch ephemeral pool via devlab-dispatch; a PR labelled stx-test still goes to the static stx-test box.
+    runs-on: ${{ contains(github.event.pull_request.labels.*.name, 'stx-test') && fromJSON('["self-hosted","Windows","stx-test"]') || fromJSON('["self-hosted","Windows","devlab-dispatch","strix-halo"]') }}
     if: github.event_name != 'pull_request' || github.event.pull_request.draft == false || contains(github.event.pull_request.labels.*.name, 'ready_for_ci')
     timeout-minutes: 30
 

--- a/.github/workflows/test_examples.yml
+++ b/.github/workflows/test_examples.yml
@@ -93,10 +93,12 @@ jobs:
   test-examples-integration:
     name: Example Agents Integration Tests (stx)
     needs: test-examples-unit
-    runs-on:
-      - self-hosted
-      - Windows
-      - ${{ contains(github.event.pull_request.labels.*.name, 'stx-test') && 'stx-test' || 'stx' }}
+    # Runs on the AMD Ryzen Dev Lab pool: a runner is registered for this job
+    # alone and destroyed afterwards. 'devlab-dispatch' is what routes it there;
+    # 'strix-halo' narrows to the silicon. The pool does not answer to 'stx' or
+    # 'stx-test' -- those name specific static machines, and a shared pool
+    # claiming them would compete for their work rather than add capacity.
+    runs-on: [self-hosted, Windows, devlab-dispatch, strix-halo]
     if: github.event_name != 'pull_request' || github.event.pull_request.draft == false || contains(github.event.pull_request.labels.*.name, 'ready_for_ci')
     timeout-minutes: 30
 

--- a/.github/workflows/test_examples.yml
+++ b/.github/workflows/test_examples.yml
@@ -93,11 +93,7 @@ jobs:
   test-examples-integration:
     name: Example Agents Integration Tests (stx)
     needs: test-examples-unit
-    # Runs on the AMD Ryzen Dev Lab pool: a runner is registered for this job
-    # alone and destroyed afterwards. 'devlab-dispatch' is what routes it there;
-    # 'strix-halo' narrows to the silicon. The pool does not answer to 'stx' or
-    # 'stx-test' -- those name specific static machines, and a shared pool
-    # claiming them would compete for their work rather than add capacity.
+    # Runs on the AMD Ryzen DevLab Dispatch ephemeral pool via the devlab-dispatch label.
     runs-on: [self-hosted, Windows, devlab-dispatch, strix-halo]
     if: github.event_name != 'pull_request' || github.event.pull_request.draft == false || contains(github.event.pull_request.labels.*.name, 'ready_for_ci')
     timeout-minutes: 30

--- a/.github/workflows/test_gaia_cli_windows.yml
+++ b/.github/workflows/test_gaia_cli_windows.yml
@@ -46,8 +46,8 @@ permissions:
 jobs:
   test-gaia-cli-windows:
     name: Test GAIA CLI on Windows (Full Integration)
-    # Runs on the AMD Ryzen DevLab Dispatch ephemeral pool via the devlab-dispatch label.
-    runs-on: [self-hosted, Windows, devlab-dispatch, strix-halo]
+    # Default lane runs on the AMD Ryzen DevLab Dispatch ephemeral pool via devlab-dispatch; a PR labelled stx-test still goes to the static stx-test box.
+    runs-on: ${{ contains(github.event.pull_request.labels.*.name, 'stx-test') && fromJSON('["self-hosted","Windows","stx-test"]') || fromJSON('["self-hosted","Windows","devlab-dispatch","strix-halo"]') }}
     if: github.event_name != 'pull_request' || github.event.pull_request.draft == false || contains(github.event.pull_request.labels.*.name, 'ready_for_ci')
     steps:
       - uses: actions/checkout@v7

--- a/.github/workflows/test_gaia_cli_windows.yml
+++ b/.github/workflows/test_gaia_cli_windows.yml
@@ -46,10 +46,12 @@ permissions:
 jobs:
   test-gaia-cli-windows:
     name: Test GAIA CLI on Windows (Full Integration)
-    runs-on:
-      - self-hosted
-      - Windows
-      - ${{ contains(github.event.pull_request.labels.*.name, 'stx-test') && 'stx-test' || 'stx' }}
+    # Runs on the AMD Ryzen Dev Lab pool: a runner is registered for this job
+    # alone and destroyed afterwards. 'devlab-dispatch' is what routes it there;
+    # 'strix-halo' narrows to the silicon. The pool does not answer to 'stx' or
+    # 'stx-test' -- those name specific static machines, and a shared pool
+    # claiming them would compete for their work rather than add capacity.
+    runs-on: [self-hosted, Windows, devlab-dispatch, strix-halo]
     if: github.event_name != 'pull_request' || github.event.pull_request.draft == false || contains(github.event.pull_request.labels.*.name, 'ready_for_ci')
     steps:
       - uses: actions/checkout@v7

--- a/.github/workflows/test_gaia_cli_windows.yml
+++ b/.github/workflows/test_gaia_cli_windows.yml
@@ -46,11 +46,7 @@ permissions:
 jobs:
   test-gaia-cli-windows:
     name: Test GAIA CLI on Windows (Full Integration)
-    # Runs on the AMD Ryzen Dev Lab pool: a runner is registered for this job
-    # alone and destroyed afterwards. 'devlab-dispatch' is what routes it there;
-    # 'strix-halo' narrows to the silicon. The pool does not answer to 'stx' or
-    # 'stx-test' -- those name specific static machines, and a shared pool
-    # claiming them would compete for their work rather than add capacity.
+    # Runs on the AMD Ryzen DevLab Dispatch ephemeral pool via the devlab-dispatch label.
     runs-on: [self-hosted, Windows, devlab-dispatch, strix-halo]
     if: github.event_name != 'pull_request' || github.event.pull_request.draft == false || contains(github.event.pull_request.labels.*.name, 'ready_for_ci')
     steps:

--- a/.github/workflows/test_gaia_cli_windows.yml
+++ b/.github/workflows/test_gaia_cli_windows.yml
@@ -46,8 +46,8 @@ permissions:
 jobs:
   test-gaia-cli-windows:
     name: Test GAIA CLI on Windows (Full Integration)
-    # Default lane runs on the AMD Ryzen DevLab Dispatch ephemeral pool via devlab-dispatch; a PR labelled stx-test still goes to the static stx-test box.
-    runs-on: ${{ contains(github.event.pull_request.labels.*.name, 'stx-test') && fromJSON('["self-hosted","Windows","stx-test"]') || fromJSON('["self-hosted","Windows","devlab-dispatch","strix-halo"]') }}
+    # Runs on the AMD Ryzen DevLab Dispatch ephemeral pool via the devlab-dispatch label.
+    runs-on: [self-hosted, Windows, devlab-dispatch, strix-halo]
     if: github.event_name != 'pull_request' || github.event.pull_request.draft == false || contains(github.event.pull_request.labels.*.name, 'ready_for_ci')
     steps:
       - uses: actions/checkout@v7

--- a/.github/workflows/test_lemonade_server.yml
+++ b/.github/workflows/test_lemonade_server.yml
@@ -52,10 +52,12 @@ concurrency:
 jobs:
   test-lemonade-server:
     name: Lemonade Server Smoke Test (${{ inputs.runson || (contains(github.event.pull_request.labels.*.name, 'stx-test') && 'stx-test') || 'stx' }})
-    runs-on:
-      - self-hosted
-      - Windows
-      - ${{ inputs.runson || (contains(github.event.pull_request.labels.*.name, 'stx-test') && 'stx-test') || 'stx' }}
+    # Runs on the AMD Ryzen Dev Lab pool: a runner is registered for this job
+    # alone and destroyed afterwards. 'devlab-dispatch' is what routes it there;
+    # 'strix-halo' narrows to the silicon. The pool does not answer to 'stx' or
+    # 'stx-test' -- those name specific static machines, and a shared pool
+    # claiming them would compete for their work rather than add capacity.
+    runs-on: [self-hosted, Windows, devlab-dispatch, strix-halo]
     if: github.event_name != 'pull_request' || github.event.pull_request.draft == false || contains(github.event.pull_request.labels.*.name, 'ready_for_ci')
 
     steps:

--- a/.github/workflows/test_lemonade_server.yml
+++ b/.github/workflows/test_lemonade_server.yml
@@ -52,8 +52,8 @@ concurrency:
 jobs:
   test-lemonade-server:
     name: Lemonade Server Smoke Test (${{ inputs.runson || (contains(github.event.pull_request.labels.*.name, 'stx-test') && 'stx-test') || 'stx' }})
-    # Default lane runs on the AMD Ryzen DevLab Dispatch ephemeral pool via devlab-dispatch; a PR labelled stx-test still goes to the static stx-test box.
-    runs-on: ${{ contains(github.event.pull_request.labels.*.name, 'stx-test') && fromJSON('["self-hosted","Windows","stx-test"]') || fromJSON('["self-hosted","Windows","devlab-dispatch","strix-halo"]') }}
+    # Runs on the AMD Ryzen DevLab Dispatch ephemeral pool via the devlab-dispatch label.
+    runs-on: [self-hosted, Windows, devlab-dispatch, strix-halo]
     if: github.event_name != 'pull_request' || github.event.pull_request.draft == false || contains(github.event.pull_request.labels.*.name, 'ready_for_ci')
 
     steps:

--- a/.github/workflows/test_lemonade_server.yml
+++ b/.github/workflows/test_lemonade_server.yml
@@ -52,11 +52,7 @@ concurrency:
 jobs:
   test-lemonade-server:
     name: Lemonade Server Smoke Test (${{ inputs.runson || (contains(github.event.pull_request.labels.*.name, 'stx-test') && 'stx-test') || 'stx' }})
-    # Runs on the AMD Ryzen Dev Lab pool: a runner is registered for this job
-    # alone and destroyed afterwards. 'devlab-dispatch' is what routes it there;
-    # 'strix-halo' narrows to the silicon. The pool does not answer to 'stx' or
-    # 'stx-test' -- those name specific static machines, and a shared pool
-    # claiming them would compete for their work rather than add capacity.
+    # Runs on the AMD Ryzen DevLab Dispatch ephemeral pool via the devlab-dispatch label.
     runs-on: [self-hosted, Windows, devlab-dispatch, strix-halo]
     if: github.event_name != 'pull_request' || github.event.pull_request.draft == false || contains(github.event.pull_request.labels.*.name, 'ready_for_ci')
 

--- a/.github/workflows/test_lemonade_server.yml
+++ b/.github/workflows/test_lemonade_server.yml
@@ -52,8 +52,8 @@ concurrency:
 jobs:
   test-lemonade-server:
     name: Lemonade Server Smoke Test (${{ inputs.runson || (contains(github.event.pull_request.labels.*.name, 'stx-test') && 'stx-test') || 'stx' }})
-    # Runs on the AMD Ryzen DevLab Dispatch ephemeral pool via the devlab-dispatch label.
-    runs-on: [self-hosted, Windows, devlab-dispatch, strix-halo]
+    # Default lane runs on the AMD Ryzen DevLab Dispatch ephemeral pool via devlab-dispatch; a PR labelled stx-test still goes to the static stx-test box.
+    runs-on: ${{ contains(github.event.pull_request.labels.*.name, 'stx-test') && fromJSON('["self-hosted","Windows","stx-test"]') || fromJSON('["self-hosted","Windows","devlab-dispatch","strix-halo"]') }}
     if: github.event_name != 'pull_request' || github.event.pull_request.draft == false || contains(github.event.pull_request.labels.*.name, 'ready_for_ci')
 
     steps:

--- a/.github/workflows/test_sd.yml
+++ b/.github/workflows/test_sd.yml
@@ -41,11 +41,7 @@ permissions:
 jobs:
   test-sd-windows:
     name: Test SD Image Generation (Lemonade Integration)
-    # Runs on the AMD Ryzen Dev Lab pool: a runner is registered for this job
-    # alone and destroyed afterwards. 'devlab-dispatch' is what routes it there;
-    # 'strix-halo' narrows to the silicon. The pool does not answer to 'stx' or
-    # 'stx-test' -- those name specific static machines, and a shared pool
-    # claiming them would compete for their work rather than add capacity.
+    # Runs on the AMD Ryzen DevLab Dispatch ephemeral pool via the devlab-dispatch label.
     runs-on: [self-hosted, Windows, devlab-dispatch, strix-halo]
     if: github.event_name != 'pull_request' || github.event.pull_request.draft == false || contains(github.event.pull_request.labels.*.name, 'ready_for_ci')
     timeout-minutes: 25

--- a/.github/workflows/test_sd.yml
+++ b/.github/workflows/test_sd.yml
@@ -41,10 +41,12 @@ permissions:
 jobs:
   test-sd-windows:
     name: Test SD Image Generation (Lemonade Integration)
-    runs-on:
-      - self-hosted
-      - Windows
-      - ${{ contains(github.event.pull_request.labels.*.name, 'stx-test') && 'stx-test' || 'stx' }}
+    # Runs on the AMD Ryzen Dev Lab pool: a runner is registered for this job
+    # alone and destroyed afterwards. 'devlab-dispatch' is what routes it there;
+    # 'strix-halo' narrows to the silicon. The pool does not answer to 'stx' or
+    # 'stx-test' -- those name specific static machines, and a shared pool
+    # claiming them would compete for their work rather than add capacity.
+    runs-on: [self-hosted, Windows, devlab-dispatch, strix-halo]
     if: github.event_name != 'pull_request' || github.event.pull_request.draft == false || contains(github.event.pull_request.labels.*.name, 'ready_for_ci')
     timeout-minutes: 25
     steps:

--- a/.github/workflows/test_sd.yml
+++ b/.github/workflows/test_sd.yml
@@ -41,8 +41,8 @@ permissions:
 jobs:
   test-sd-windows:
     name: Test SD Image Generation (Lemonade Integration)
-    # Default lane runs on the AMD Ryzen DevLab Dispatch ephemeral pool via devlab-dispatch; a PR labelled stx-test still goes to the static stx-test box.
-    runs-on: ${{ contains(github.event.pull_request.labels.*.name, 'stx-test') && fromJSON('["self-hosted","Windows","stx-test"]') || fromJSON('["self-hosted","Windows","devlab-dispatch","strix-halo"]') }}
+    # Runs on the AMD Ryzen DevLab Dispatch ephemeral pool via the devlab-dispatch label.
+    runs-on: [self-hosted, Windows, devlab-dispatch, strix-halo]
     if: github.event_name != 'pull_request' || github.event.pull_request.draft == false || contains(github.event.pull_request.labels.*.name, 'ready_for_ci')
     timeout-minutes: 25
     steps:

--- a/.github/workflows/test_sd.yml
+++ b/.github/workflows/test_sd.yml
@@ -41,8 +41,8 @@ permissions:
 jobs:
   test-sd-windows:
     name: Test SD Image Generation (Lemonade Integration)
-    # Runs on the AMD Ryzen DevLab Dispatch ephemeral pool via the devlab-dispatch label.
-    runs-on: [self-hosted, Windows, devlab-dispatch, strix-halo]
+    # Default lane runs on the AMD Ryzen DevLab Dispatch ephemeral pool via devlab-dispatch; a PR labelled stx-test still goes to the static stx-test box.
+    runs-on: ${{ contains(github.event.pull_request.labels.*.name, 'stx-test') && fromJSON('["self-hosted","Windows","stx-test"]') || fromJSON('["self-hosted","Windows","devlab-dispatch","strix-halo"]') }}
     if: github.event_name != 'pull_request' || github.event.pull_request.draft == false || contains(github.event.pull_request.labels.*.name, 'ready_for_ci')
     timeout-minutes: 25
     steps:


### PR DESCRIPTION
## Summary

Moves seven Windows test workflows off the static `stx` runners and onto the AMD
Ryzen DevLab Dispatch ephemeral pool, where a runner is registered for each job
and destroyed afterwards.

## Why

The static `stx` machines are shared, long-lived, and accumulate state between
jobs — a leaked model or half-installed toolchain lands on whatever runs next.
They are also a fixed, small pool that jobs queue behind.

The DevLab pool gives each job a clean runner that is destroyed when the job
ends, so no run inherits another's state, and it is 98% idle so there is
capacity to absorb this.

Only workflows that were **measured** to pass are moved. All fourteen
self-hosted workflows were pointed at the pool on a scratch branch and run; these
seven passed with no change to the workflow and no change to the pool's
machines. The other seven stay exactly where they are.

## Linked issue

Closes #3343 

## Changes

- `runs-on` changed to `[self-hosted, Windows, devlab-dispatch, strix-halo]` in:
  `test_api.yml`, `test_agent_sdk.yml`, `test_examples.yml`,
  `test_gaia_cli_windows.yml`, `test_lemonade_server.yml`, `test_sd.yml`,
  `test_embeddings.yml`
- One comment line added above each, naming the pool
- Nothing else changes — no steps, triggers, or job logic

**Two things a reviewer should know:**

- **The `stx-test` lane is removed from these seven.** They previously routed a
  PR labelled `stx-test` to the `stx-test` machines and everything else to
  `stx`. They now go to the pool unconditionally. Say so if that escape hatch is
  still wanted — the conditional can be kept with only the default lane moved.
- **The silicon changes.** `stx` matched five Windows machines, of which only
  `sjlab-stx-halo-18` carries `strix-halo`, so these jobs mostly ran on Strix
  Point and will now run on Strix Halo. They passed on Halo, but if any test
  exists to characterise Strix Point specifically, it should stay put.

**Not moved:** `build_cpp`, `test_rag`, `test_email_agent_eval`,
`email_scorecard_refresh`, `test_eval_agent_gemma_consolidation` (failed on the
pool). `runner_heartbeat` and `stx_driver_update` are excluded by design — they
monitor and patch the static machines, so pointing them at an ephemeral pool
would stop them doing their job.

## Test plan

- [ ] Open this PR and confirm the seven workflows run and pass on the pool
- [ ] Check each job's runner name is `ephemeral-devlab-…`, confirming a
      per-job runner rather than a static one
- [ ] Confirm the seven not-moved workflows still run on their existing runners

## Evidence

All fourteen self-hosted workflows were run on the pool from a scratch branch.
These seven passed unmodified:

| Workflow | Result |
|---|---|
| API Server Tests | pass |
| Agent SDK Tests (Windows) | pass |
| Example Agents Integration Tests | pass |
| GAIA CLI Tests (Windows) | pass |
| Lemonade Server Smoke Test | pass |
| SD Integration Tests (Windows) | pass |
| Test Lemonade Embeddings | pass |

- [x] **CI workflows** — the seven runs above, on `ephemeral-devlab-*` runners
- [ ] **Agent exposed in the Agent UI** — N/A, no application code changes
- [ ] **MCP tools / servers** — N/A, no application code changes
- [ ] **CLI** — N/A, no application code changes
- [ ] **HTTP API / REST** — N/A, no application code changes

## Checklist

- [ ] I have linked a GitHub issue above (`Closes #N` / `Fixes #N` / `Refs #N`).
- [x] I have described **why** this change is being made, not just what changed.
- [ ] I have run linting and tests locally — N/A, this changes only `runs-on`
      lines in workflow YAML; the evidence is the seven passing CI runs.
- [x] I have attached **real-world evidence matched to the surface I changed**.
- [ ] I have updated documentation if user-visible behavior changed — N/A, no
      user-visible behavior changes.