### PR TITLE
fix(skills,tools): stop two tools deleting data while reporting success

### DIFF
--- a/docs/spec/file-io-tools-mixin.mdx
+++ b/docs/spec/file-io-tools-mixin.mdx
@@ -199,12 +199,17 @@ Edit any file by replacing content without validation.
 
 ### 8. replace_function
 
-Replace a specific function in a Python file.
+Replace one function definition in a Python file. The replaced span is the
+definition and its decorators, taken from the AST — nothing between it and the
+next definition is touched.
 
 **Parameters:**
 - `file_path` (str, required): Path to Python file
-- `function_name` (str, required): Name of function to replace
-- `new_implementation` (str, required): New function implementation
+- `function_name` (str, required): A module-level function name, or a qualified
+  `Class.method` / `outer.inner` name. A bare name that exists only as a method
+  is an error naming the qualified alternatives, not a guess.
+- `new_implementation` (str, required): The complete new definition, including
+  any decorator it should keep and the indentation of the definition it replaces
 - `backup` (bool, optional): Create backup (default: True)
 
 **Returns:**

--- a/docs/spec/file-io-tools-mixin.mdx
+++ b/docs/spec/file-io-tools-mixin.mdx
@@ -203,6 +203,10 @@ Replace one function definition in a Python file. The replaced span is the
 definition and its decorators, taken from the AST — nothing between it and the
 next definition is touched.
 
+The edit is refused unless the function still resolves at the same qualified name
+afterwards, so a de-indented replacement cannot silently relocate a method to
+module level, and the tool never renames or moves a definition.
+
 **Parameters:**
 - `file_path` (str, required): Path to Python file
 - `function_name` (str, required): A module-level function name, or a qualified

--- a/hub/agents/gaia/python/tests/test_skill_library_tools.py
+++ b/hub/agents/gaia/python/tests/test_skill_library_tools.py
@@ -458,8 +458,10 @@ def test_load_refuses_a_skill_that_asks_for_shell_execute(session):
 def test_disk_tools_refuse_a_name_that_is_a_path(session, tool_name, hostile):
     """A model-supplied name must never reach a filesystem join.
 
-    See ``test_the_substrate_deletes_outside_the_skills_root`` for why: the
-    delete underneath has no validation of its own.
+    The substrate validates these names too now (see the companion test below),
+    but this layer still owns the model-facing contract: ``load_skill`` resolves
+    through the manager and never reaches those joins, and a tool must answer
+    with a structured error rather than raise.
     """
     result = call(session, tool_name, name=hostile)
 
@@ -467,15 +469,16 @@ def test_disk_tools_refuse_a_name_that_is_a_path(session, tool_name, hostile):
     assert "not a skill name" in result["error"]
 
 
-def test_the_substrate_deletes_outside_the_skills_root(tmp_path):
-    """Documents the flaw the name check compensates for.
+def test_the_substrate_refuses_to_delete_outside_the_skills_root(tmp_path):
+    """The second line of defence, under the tool layer.
 
-    ``gaia.skills.install.remove_skill`` builds ``root / name`` and ``rmtree``s
-    it, so a traversing name deletes a directory outside the skills root and
-    reports success. Reachable from a chat turn the moment a tool passes the
-    model's string through — hence the guard above. If this test starts failing
-    because the substrate grew its own validation, drop ``_reject_bad_name``.
+    ``remove_skill`` used to build ``root / name`` and ``rmtree`` it unvalidated,
+    so a traversing name deleted a directory outside the skills root and reported
+    success. :mod:`gaia.skills.naming` now refuses the name at the join, which is
+    what makes the guard above defence in depth rather than the only thing
+    standing between a mistyped name and someone's files.
     """
+    from gaia.skills.errors import SkillValidationError
     from gaia.skills.install import remove_skill as _hub_remove
 
     root = tmp_path / "skills"
@@ -485,9 +488,10 @@ def test_the_substrate_deletes_outside_the_skills_root(tmp_path):
     (victim / "notes.txt").write_text("payroll", encoding="utf-8")
     manager = SkillManager(user_skills_root=root, include_claude_roots=False)
 
-    _hub_remove("../victim", manager=manager)
+    with pytest.raises(SkillValidationError):
+        _hub_remove("../victim", manager=manager)
 
-    assert not victim.exists()
+    assert (victim / "notes.txt").read_text(encoding="utf-8") == "payroll"
 
 
 def test_load_refuses_code_from_an_ungated_claude_import(session):

--- a/src/gaia/agents/tools/file_io_tools.py
+++ b/src/gaia/agents/tools/file_io_tools.py
@@ -1088,24 +1088,17 @@ class FileIOToolsMixin:
         ) -> Dict[str, Any]:
             """Replace one function definition in a Python file.
 
-            Replaces exactly the target definition and its decorators, leaving
-            everything around it untouched. Because decorators are part of what
-            is replaced, new_implementation must repeat any decorator the
-            function should keep, and must carry the indentation of the
-            definition it replaces — a de-indented method would otherwise land
-            at module level, out of its class. The edit is refused if the
-            function no longer resolves at the same qualified name afterwards,
-            so this tool never renames or moves a definition.
+            Replaces the definition and its decorators, leaving the code around
+            it untouched.
 
             Includes security guardrails: path validation, blocked directory enforcement,
             sensitive file protection, size limits, backup creation, and audit logging.
 
             Args:
                 file_path: Path to the Python file
-                function_name: A module-level function name, or a qualified
-                    'Class.method' / 'outer.inner' name for a nested one. A bare
-                    name that only exists as a method is an error, not a guess.
-                new_implementation: Complete new definition, decorators included
+                function_name: Module-level name, or 'Class.method' for a nested one
+                new_implementation: Complete new definition — include any decorator
+                    it keeps, and match the indentation of the one it replaces
                 backup: Whether to create backup
 
             Returns:

--- a/src/gaia/agents/tools/file_io_tools.py
+++ b/src/gaia/agents/tools/file_io_tools.py
@@ -63,8 +63,8 @@ def _resolve_function_node(tree: ast.Module, function_name: str):
         where = ", ".join(str(node.lineno) for node in matches)
         raise FunctionLookupError(
             f"'{name}' is defined more than once (lines {where}). Refusing to "
-            "guess which definition to replace — rename one, or edit the file "
-            "with edit_python_file instead."
+            "guess which definition to replace — for an @overload stack or a "
+            "conditional definition, edit the file with edit_python_file instead."
         )
 
     if "." not in name:
@@ -78,6 +78,40 @@ def _resolve_function_node(tree: ast.Module, function_name: str):
             )
 
     raise FunctionLookupError(f"Function '{function_name}' not found in file")
+
+
+def _misplaced_target(new_tree: ast.Module, qualname: str) -> Optional[str]:
+    """Why the rewritten module no longer defines ``qualname``; ``None`` if fine.
+
+    An exact span is not enough on its own: a de-indented method parses cleanly
+    at module level, so the syntax gate passes while the definition quietly
+    leaves its class. The qualified name encodes the scope, so resolving it again
+    in the rewritten tree checks placement, not just presence.
+    """
+    table = _qualified_functions(new_tree)
+    found = table.get(qualname, [])
+    if len(found) == 1:
+        return None
+
+    if len(found) > 1:
+        return (
+            f"The replacement defines '{qualname}' {len(found)} times; it must "
+            "define it exactly once."
+        )
+
+    basename = qualname.rsplit(".", 1)[-1]
+    moved = sorted(q for q in table if q.rsplit(".", 1)[-1] == basename)
+    if moved:
+        return (
+            f"The replacement moves '{qualname}' to "
+            f"{', '.join(repr(q) for q in moved)}. Indent new_implementation to "
+            f"match the definition it replaces — nothing was written."
+        )
+    return (
+        f"The replacement does not define '{qualname}'. It must define the same "
+        "function in the same scope; replace_function does not rename or move "
+        "one. Nothing was written."
+    )
 
 
 def _function_span(node, lines: list) -> tuple:
@@ -1058,7 +1092,10 @@ class FileIOToolsMixin:
             everything around it untouched. Because decorators are part of what
             is replaced, new_implementation must repeat any decorator the
             function should keep, and must carry the indentation of the
-            definition it replaces.
+            definition it replaces — a de-indented method would otherwise land
+            at module level, out of its class. The edit is refused if the
+            function no longer resolves at the same qualified name afterwards,
+            so this tool never renames or moves a definition.
 
             Includes security guardrails: path validation, blocked directory enforcement,
             sensitive file protection, size limits, backup creation, and audit logging.
@@ -1163,6 +1200,19 @@ class FileIOToolsMixin:
                         "error": "Replacement would result in invalid syntax",
                         "syntax_errors": validation.get("errors", []),
                     }
+
+                # Parsing clean is not the same as landing in the right scope.
+                try:
+                    new_tree = ast.parse(modified_content)
+                except SyntaxError as e:
+                    return {
+                        "status": "error",
+                        "error": "Replacement would result in invalid syntax",
+                        "syntax_errors": [str(e)],
+                    }
+                misplaced = _misplaced_target(new_tree, function_name.strip())
+                if misplaced:
+                    return {"status": "error", "error": misplaced}
 
                 # Write the modified content
                 with open(file_path, "w", encoding="utf-8") as f:

--- a/src/gaia/agents/tools/file_io_tools.py
+++ b/src/gaia/agents/tools/file_io_tools.py
@@ -16,6 +16,87 @@ from typing import Any, Dict, Optional
 from gaia.agents.base.tools import tool
 
 
+class FunctionLookupError(Exception):
+    """``replace_function`` could not resolve the name to exactly one definition."""
+
+
+def _qualified_functions(tree: ast.Module) -> Dict[str, list]:
+    """Map every ``def`` in a module to its dotted qualified name.
+
+    ``foo`` for a module-level function, ``Runner.run`` for a method,
+    ``outer.helper`` for a nested one. Statements that do not open a scope
+    (``if``/``try``/``with``/``for``) are transparent, so a function guarded by
+    ``if TYPE_CHECKING:`` is still module-level.
+    """
+    found: Dict[str, list] = {}
+
+    def walk(node: ast.AST, prefix: str) -> None:
+        for child in ast.iter_child_nodes(node):
+            if isinstance(child, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                qualname = f"{prefix}{child.name}"
+                found.setdefault(qualname, []).append(child)
+                walk(child, f"{qualname}.")
+            elif isinstance(child, ast.ClassDef):
+                walk(child, f"{prefix}{child.name}.")
+            else:
+                walk(child, prefix)
+
+    walk(tree, "")
+    return found
+
+
+def _resolve_function_node(tree: ast.Module, function_name: str):
+    """Find the one definition ``function_name`` names, or raise.
+
+    A bare name resolves against module-level functions only; a nested or
+    method-level definition must be named ``Class.method`` / ``outer.inner``.
+    Guessing is what let ``replace_function("run")`` rewrite the first ``run``
+    anywhere in the file.
+    """
+    name = (function_name or "").strip()
+    table = _qualified_functions(tree)
+    matches = table.get(name, [])
+
+    if len(matches) == 1:
+        return matches[0]
+    if len(matches) > 1:
+        where = ", ".join(str(node.lineno) for node in matches)
+        raise FunctionLookupError(
+            f"'{name}' is defined more than once (lines {where}). Refusing to "
+            "guess which definition to replace — rename one, or edit the file "
+            "with edit_python_file instead."
+        )
+
+    if "." not in name:
+        nested = sorted(q for q in table if q.rsplit(".", 1)[-1] == name)
+        if nested:
+            options = ", ".join(repr(q) for q in nested)
+            raise FunctionLookupError(
+                f"No module-level function named '{name}'. It is defined as "
+                f"{options}. Pass the qualified name so the right definition is "
+                "replaced."
+            )
+
+    raise FunctionLookupError(f"Function '{function_name}' not found in file")
+
+
+def _function_span(node, lines: list) -> tuple:
+    """0-based half-open ``(start, end)`` line span covering decorators + body.
+
+    Uses the AST's own end position. Scanning forward for the next same-indent
+    ``def``/``class`` swept up everything in between — module constants and the
+    next function's decorators — and deleted it.
+    """
+    start = node.lineno - 1
+    if node.decorator_list:
+        start = min(start, node.decorator_list[0].lineno - 1)
+        # PEP 614 parenthesized decorators put the '@' on its own line, above
+        # where the decorator expression starts.
+        while start > 0 and lines[start - 1].lstrip().startswith("@"):
+            start -= 1
+    return start, node.end_lineno
+
+
 class FileIOToolsMixin:
     """Mixin class providing file I/O tools for code agents.
 
@@ -971,15 +1052,23 @@ class FileIOToolsMixin:
             new_implementation: str,
             backup: bool = True,
         ) -> Dict[str, Any]:
-            """Replace a specific function in a Python file.
+            """Replace one function definition in a Python file.
+
+            Replaces exactly the target definition and its decorators, leaving
+            everything around it untouched. Because decorators are part of what
+            is replaced, new_implementation must repeat any decorator the
+            function should keep, and must carry the indentation of the
+            definition it replaces.
 
             Includes security guardrails: path validation, blocked directory enforcement,
             sensitive file protection, size limits, backup creation, and audit logging.
 
             Args:
                 file_path: Path to the Python file
-                function_name: Name of the function to replace
-                new_implementation: New function implementation
+                function_name: A module-level function name, or a qualified
+                    'Class.method' / 'outer.inner' name for a nested one. A bare
+                    name that only exists as a method is an error, not a guess.
+                new_implementation: Complete new definition, decorators included
                 backup: Whether to create backup
 
             Returns:
@@ -1033,38 +1122,13 @@ class FileIOToolsMixin:
                 except SyntaxError as e:
                     return {"status": "error", "error": f"File has syntax errors: {e}"}
 
-                # Find the function node
-                function_node = None
-                for node in ast.walk(tree):
-                    if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
-                        if node.name == function_name:
-                            function_node = node
-                            break
+                try:
+                    function_node = _resolve_function_node(tree, function_name)
+                except FunctionLookupError as e:
+                    return {"status": "error", "error": str(e)}
 
-                if not function_node:
-                    return {
-                        "status": "error",
-                        "error": f"Function '{function_name}' not found in file",
-                    }
-
-                # Get line range of the function
                 lines = content.splitlines(keepends=True)
-                start_line = function_node.lineno - 1
-
-                # Find end of function (simplified - finds next def or class at same indent)
-                end_line = len(lines)
-                indent_level = len(lines[start_line]) - len(lines[start_line].lstrip())
-
-                for i in range(start_line + 1, len(lines)):
-                    line = lines[i]
-                    if line.strip() and not line.lstrip().startswith("#"):
-                        current_indent = len(line) - len(line.lstrip())
-                        if current_indent <= indent_level and line.strip():
-                            if line.lstrip().startswith(
-                                ("def ", "class ", "async def ")
-                            ):
-                                end_line = i
-                                break
+                start_line, end_line = _function_span(function_node, lines)
 
                 # Create backup via path_validator if available, else manual
                 backup_path = None
@@ -1078,7 +1142,9 @@ class FileIOToolsMixin:
 
                 # Replace the function
                 new_lines = (
-                    lines[:start_line] + [new_implementation + "\n"] + lines[end_line:]
+                    lines[:start_line]
+                    + [new_implementation.rstrip("\n") + "\n"]
+                    + lines[end_line:]
                 )
                 modified_content = "".join(new_lines)
 

--- a/src/gaia/agents/tools/skill_library_tools.py
+++ b/src/gaia/agents/tools/skill_library_tools.py
@@ -36,10 +36,10 @@ a model that would happily approve itself:
   gate of its own (verified, not assumed) — so it would import that Python on a
   model-issued call. Instruction-only imports still load.
 * Every disk-touching tool refuses a **name that is not a bare skill name**.
-  ``gaia.skills.install.remove_skill`` joins the caller's string onto the skills
-  root and ``rmtree``\\ s it unvalidated, so ``../notes`` escapes the root. That
-  is a substrate flaw reported upstream; until it is fixed there, these tools
-  will not hand it a path.
+  :mod:`gaia.skills.naming` guards the substrate's own joins now, but this layer
+  keeps its check: ``load_skill`` resolves through the manager and never reaches
+  those joins, and the model needs a structured tool error naming the fix rather
+  than a raised ``SkillValidationError``.
 
 Each surfaces as an error naming what would proceed instead.
 

--- a/src/gaia/agents/tools/skill_library_tools.py
+++ b/src/gaia/agents/tools/skill_library_tools.py
@@ -108,10 +108,10 @@ def _failure(action: str, exc: Exception) -> Dict[str, Any]:
 def _reject_bad_name(action: str, name: str) -> Dict[str, Any] | None:
     """Refuse anything that is not a bare skill name; ``None`` when it is fine.
 
-    ``remove_skill`` in the substrate does ``rmtree(root / name)`` with no
-    validation, so a model-supplied ``../documents`` deletes outside the skills
-    root. Validated against the canonical ``NAME_PATTERN`` rather than a
-    hand-rolled check, so the two can't drift.
+    The substrate validates the same names now (:mod:`gaia.skills.naming`); this
+    stays so the model gets a structured tool error naming the fix rather than a
+    raised exception. Validated against the canonical ``NAME_PATTERN`` rather
+    than a hand-rolled check, so the two can't drift.
     """
     from gaia.skills.format import NAME_PATTERN
 

--- a/src/gaia/skills/cli.py
+++ b/src/gaia/skills/cli.py
@@ -52,6 +52,7 @@ from gaia.skills.migrate import (
     install_migrated,
     migrate_skill_dir,
 )
+from gaia.skills.naming import skill_directory, validated_skill_name
 from gaia.skills.signing import ROLE_AMD, ROLE_PUBLISHER
 from gaia.skills.tiers import LOWEST_TIER
 
@@ -531,7 +532,7 @@ def _handle_info(args: argparse.Namespace) -> int:
 
 def _handle_create(args: argparse.Namespace) -> int:
     parent = Path(args.directory) if args.directory else _manager().user_root
-    target = parent / args.name
+    target = skill_directory(parent, args.name, source="create")
 
     if target.exists() and not args.force:
         sys.stderr.write(
@@ -584,8 +585,11 @@ def _handle_import(args: argparse.Namespace) -> int:
     with tempfile.TemporaryDirectory(prefix="gaia-skill-import-") as tmp:
         source_dir = _materialize_source(args.source, Path(tmp))
         skill = parse_skill_file(source_dir, check_directory_name=False)
-        name = args.name or skill.name
-        target = destination_root / name
+        # Without --name the name comes from the imported bundle's own SKILL.md,
+        # which nothing validated on the way in.
+        origin = "--name" if args.name else f"{source_dir / SKILL_FILENAME}"
+        name = validated_skill_name(args.name or skill.name, source=origin)
+        target = skill_directory(destination_root, name, source=origin)
 
         if target.exists():
             if not args.force:

--- a/src/gaia/skills/cli.py
+++ b/src/gaia/skills/cli.py
@@ -532,7 +532,8 @@ def _handle_info(args: argparse.Namespace) -> int:
 
 def _handle_create(args: argparse.Namespace) -> int:
     parent = Path(args.directory) if args.directory else _manager().user_root
-    target = skill_directory(parent, args.name, source="create")
+    name = validated_skill_name(args.name, source="create")
+    target = skill_directory(parent, name, source="create")
 
     if target.exists() and not args.force:
         sys.stderr.write(
@@ -553,18 +554,18 @@ def _handle_create(args: argparse.Namespace) -> int:
         ]
 
     skill = Skill(
-        name=args.name,
+        name=name,
         description=args.description or _DEFAULT_DESCRIPTION,
         version="0.1.0",
         license="MIT",
         gaia=gaia_meta,
-        body=_scaffold_body(args.name, with_tools=args.with_tools),
+        body=_scaffold_body(name, with_tools=args.with_tools),
     )
     # Validate the scaffold through the real parser before writing it, so
     # 'gaia skill create' can never emit a SKILL.md that 'gaia skill info' rejects.
     from gaia.skills.format import parse_skill
 
-    parse_skill(skill.to_markdown(), source=f"<scaffold {args.name}>")
+    parse_skill(skill.to_markdown(), source=f"<scaffold {name}>")
 
     if target.exists() and args.force:
         shutil.rmtree(target)
@@ -573,8 +574,8 @@ def _handle_create(args: argparse.Namespace) -> int:
     if args.with_tools:
         (target / SKILL_TOOLS_FILENAME).write_text(_SCAFFOLD_TOOLS, encoding="utf-8")
 
-    print(f"✅ Created skill '{args.name}' at {target}")
-    print(f"   Edit {target / SKILL_FILENAME}, then: gaia skill info {args.name}")
+    print(f"✅ Created skill '{name}' at {target}")
+    print(f"   Edit {target / SKILL_FILENAME}, then: gaia skill info {name}")
     return EXIT_OK
 
 

--- a/src/gaia/skills/install.py
+++ b/src/gaia/skills/install.py
@@ -60,6 +60,7 @@ from gaia.skills.hub import (
 )
 from gaia.skills.lock import SOURCE_HUB, LockEntry, SkillLock
 from gaia.skills.manager import SkillManager
+from gaia.skills.naming import skill_directory
 from gaia.skills.permissions import refuse_unbridged_permissions
 from gaia.skills.signing import (
     SIGNATURE_FILENAME,
@@ -184,7 +185,7 @@ def install_skill(
     name, spec = parse_skill_ref(reference)
     resolver = manager if manager is not None else SkillManager()
     destination_root = resolver.user_root
-    target = destination_root / name
+    target = skill_directory(destination_root, name, source=f"install {reference!r}")
 
     lock = SkillLock.load(destination_root)
     previous = lock.get(name)
@@ -494,10 +495,12 @@ def remove_skill(name: str, *, manager: Optional[SkillManager] = None) -> Remove
     Raises:
         SkillNotFoundError: nothing of that name is installed in the user root.
         SkillInstallError: the skill exists but lives in a read-only root.
+        SkillValidationError: ``name`` is not a bare skill name — ``.``, ``..``
+            and absolute paths all resolve to a real directory outside the root.
     """
     resolver = manager if manager is not None else SkillManager()
     root = resolver.user_root
-    target = root / name
+    target = skill_directory(root, name, source=f"remove {name!r}")
 
     if not target.is_dir():
         discovered = resolver.discover().get(name)

--- a/src/gaia/skills/migrate.py
+++ b/src/gaia/skills/migrate.py
@@ -59,6 +59,7 @@ from gaia.skills.format import (
     reset_security_tier,
     split_frontmatter,
 )
+from gaia.skills.naming import skill_directory
 from gaia.skills.permissions import refuse_unbridged_permissions
 
 log = get_logger(__name__)
@@ -920,7 +921,11 @@ def install_migrated(
         )
 
     skill = outcome.skill
-    target = Path(destination_root) / skill.name
+    # skill.name came out of a foreign vendor's manifest; --force rmtrees this
+    # path, so it is validated as a bare name inside the root before it is used.
+    target = skill_directory(
+        destination_root, skill.name, source=f"migrate {outcome.source}"
+    )
     source_dir = outcome.source.parent if outcome.source.is_file() else None
     if target.exists():
         if (

--- a/src/gaia/skills/naming.py
+++ b/src/gaia/skills/naming.py
@@ -1,0 +1,85 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""One safe way to turn a skill name into a directory under a skills root.
+
+Every skill entry point — install, remove, import, create, migrate — resolves a
+directory as ``root / name``, and most of them then ``rmtree`` it. ``pathlib``
+collapses ``root / "."`` back to ``root``, leaves ``root / ".."`` at the root's
+parent, and lets an absolute name replace the root outright — and ``is_dir()``
+is true for all three. So an unvalidated join turned ``gaia skill remove .``
+into "delete the skills root, signing keys and trust store included".
+
+:func:`skill_directory` is the only join callers should use. It validates the
+name against the canonical :data:`gaia.skills.format.NAME_PATTERN` *and* asserts
+the resolved target is a direct child of the resolved root — the second half is
+the load-bearing one, because it catches the symlink and ``\\\\?\\`` shapes the
+pattern never sees.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from gaia.skills.errors import FORMAT_DOCS_URL, SkillValidationError
+from gaia.skills.format import MAX_NAME_LENGTH, NAME_PATTERN
+
+__all__ = ["validated_skill_name", "skill_directory"]
+
+
+def validated_skill_name(name: str, *, source: str = "skill name") -> str:
+    """Return the stripped name, or raise if it is not a bare skill name.
+
+    Args:
+        name: The candidate name — a CLI argument, or the ``name`` a downloaded
+            bundle's own ``SKILL.md`` declares.
+        source: What produced the name, quoted back in the error.
+
+    Raises:
+        SkillValidationError: the name is empty, over-long, or is anything other
+            than lowercase letters, digits and single internal hyphens.
+    """
+    text = (name or "").strip()
+    if not text:
+        raise SkillValidationError(
+            f"{source}: no skill name given. Pass the name exactly as "
+            "'gaia skill list' reports it, e.g. 'web-research'."
+        )
+    if len(text) > MAX_NAME_LENGTH:
+        raise SkillValidationError(
+            f"{source}: name {text!r} is {len(text)} characters; the limit is "
+            f"{MAX_NAME_LENGTH}. See {FORMAT_DOCS_URL}#naming"
+        )
+    if not NAME_PATTERN.match(text):
+        # Same wording as validate_skill's, so a user meets one message whether
+        # the name was refused at the join or at manifest validation.
+        raise SkillValidationError(
+            f"{source}: name {text!r} is not a valid skill name. Use lowercase "
+            "letters and digits separated by single hyphens (e.g. 'web-research') "
+            "— no slashes, no '.', no '..', no absolute path. Pass the name "
+            f"exactly as 'gaia skill list' reports it. See {FORMAT_DOCS_URL}#naming"
+        )
+    return text
+
+
+def skill_directory(root: Path | str, name: str, *, source: str = "skill name") -> Path:
+    """``root/<name>`` for a validated ``name``, asserted to sit directly in ``root``.
+
+    Call this instead of ``root / name`` anywhere the result may be created,
+    overwritten, or deleted.
+
+    Raises:
+        SkillValidationError: the name is not a bare skill name, or the join
+            resolves outside ``root``.
+    """
+    validated = validated_skill_name(name, source=source)
+    root_path = Path(root)
+    target = root_path / validated
+
+    if target.resolve().parent != root_path.resolve():
+        raise SkillValidationError(
+            f"{source}: {target} does not resolve to a direct child of the skills "
+            f"root {root_path} (it resolves to {target.resolve()}). Refusing to "
+            "touch it. If the skill directory is a symlink, delete the link "
+            "yourself — this command only manages real directories inside the root."
+        )
+    return target

--- a/tests/unit/test_replace_function_spans.py
+++ b/tests/unit/test_replace_function_spans.py
@@ -165,6 +165,66 @@ def test_a_module_level_function_guarded_by_if_is_still_module_level(replace, tm
     assert "def after():\n    return 2" in after
 
 
+CLASS_WITH_ATTR = """\
+class Alpha:
+    x = 1
+
+    def run(self):
+        return "alpha"
+"""
+
+
+def test_a_de_indented_method_replacement_is_refused(replace, tmp_path):
+    """Parsing clean is not the same as landing in the right scope.
+
+    Without the indentation the replacement is a valid module-level ``def``, so
+    the syntax gate passes while ``Alpha.run`` quietly leaves its class.
+    """
+    target = tmp_path / "alpha.py"
+    target.write_text(CLASS_WITH_ATTR, encoding="utf-8")
+
+    result = replace(
+        str(target),
+        "Alpha.run",
+        'def run(self):\n    return "PATCHED"',
+        backup=False,
+    )
+
+    assert result["status"] == "error"
+    assert "Alpha.run" in result["error"] and "indent" in result["error"].lower()
+    assert target.read_text(encoding="utf-8") == CLASS_WITH_ATTR
+
+
+def test_the_correctly_indented_replacement_of_the_same_method_succeeds(
+    replace, tmp_path
+):
+    """The guard must not cost the legitimate edit."""
+    target = tmp_path / "alpha.py"
+    target.write_text(CLASS_WITH_ATTR, encoding="utf-8")
+
+    result = replace(
+        str(target),
+        "Alpha.run",
+        '    def run(self):\n        return "PATCHED"',
+        backup=False,
+    )
+    after = target.read_text(encoding="utf-8")
+
+    assert result["status"] == "success"
+    assert 'return "PATCHED"' in after
+    assert "    x = 1" in after
+    assert after.startswith("class Alpha:")
+
+
+def test_a_replacement_that_renames_the_function_is_refused(replace, module):
+    """`replace_function` replaces one definition; it does not rename one."""
+    result = replace(str(module), "foo", "def renamed():\n    return 99", backup=False)
+
+    assert result["status"] == "error"
+    assert "does not define 'foo'" in result["error"]
+    assert module.read_text(encoding="utf-8") == MODULE
+
+
 def test_a_missing_function_is_still_reported_as_not_found(replace, module):
     result = replace(str(module), "nope", "def nope(): pass", backup=False)
 

--- a/tests/unit/test_replace_function_spans.py
+++ b/tests/unit/test_replace_function_spans.py
@@ -1,0 +1,192 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""``replace_function`` must replace one definition and nothing else.
+
+It used to find the end of the target by scanning forward for the next line at
+the same indent starting with ``def``/``class``. Everything in between — module
+constants, the *next* function's decorators — sat inside the replaced span and
+was deleted, while the tool returned ``success``. Two more defects rode along:
+the target's own decorators sat *above* ``start_line``, so they survived and were
+silently re-applied to the replacement; and ``ast.walk`` took the first
+same-named function anywhere in the module.
+
+These tests assert on the resulting file, not on the return value — the old code
+reported success for every one of them.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from gaia.agents.base.tools import _TOOL_REGISTRY
+from gaia.agents.tools.file_io_tools import FileIOToolsMixin
+
+MODULE = """\
+import functools
+
+
+@functools.cache
+def foo():
+    return 1
+
+
+CONSTANT = 42
+
+
+@functools.cache
+def bar():
+    return CONSTANT
+
+
+class Runner:
+    def run(self):
+        return "method run"
+
+
+def run():
+    return "module run"
+"""
+
+
+@pytest.fixture
+def replace():
+    """The registered ``replace_function`` tool, with no PathValidator attached."""
+    mixin = FileIOToolsMixin()
+    mixin.console = None
+    saved = dict(_TOOL_REGISTRY)
+    _TOOL_REGISTRY.clear()
+    try:
+        mixin.register_file_io_tools()
+        fn = _TOOL_REGISTRY["replace_function"]["function"]
+        yield fn
+    finally:
+        _TOOL_REGISTRY.clear()
+        _TOOL_REGISTRY.update(saved)
+
+
+@pytest.fixture
+def module(tmp_path):
+    target = tmp_path / "mod.py"
+    target.write_text(MODULE, encoding="utf-8")
+    return target
+
+
+def test_a_module_constant_between_two_functions_survives(replace, module):
+    result = replace(str(module), "foo", "def foo():\n    return 99", backup=False)
+    after = module.read_text(encoding="utf-8")
+
+    assert result["status"] == "success"
+    assert "CONSTANT = 42" in after
+    assert "return 99" in after
+
+
+def test_the_next_functions_decorator_survives(replace, module):
+    replace(str(module), "foo", "def foo():\n    return 99", backup=False)
+    after = module.read_text(encoding="utf-8")
+
+    assert "@functools.cache\ndef bar():" in after
+
+
+def test_the_targets_own_decorator_is_replaced_not_re_applied(replace, module):
+    """The replacement fully defines the function; a dropped decorator is a
+    deliberate change the caller asked for, not a silent carry-over."""
+    replace(str(module), "foo", "def foo():\n    return 99", backup=False)
+    after = module.read_text(encoding="utf-8")
+
+    assert "@functools.cache\ndef foo():" not in after
+    assert after.count("@functools.cache") == 1  # bar's, and only bar's
+
+
+def test_a_bare_name_resolves_to_the_module_level_function(replace, module):
+    replace(str(module), "run", 'def run():\n    return "REPLACED"', backup=False)
+    after = module.read_text(encoding="utf-8")
+
+    assert 'return "method run"' in after  # Runner.run untouched
+    assert 'return "REPLACED"' in after
+
+
+def test_a_method_level_name_is_not_clobbered_by_a_bare_name(replace, tmp_path):
+    """Two same-named methods and no module-level one: refuse, don't guess."""
+    source = (
+        'class Alpha:\n    def run(self):\n        return "alpha"\n\n\n'
+        'class Beta:\n    def run(self):\n        return "beta"\n'
+    )
+    target = tmp_path / "classes.py"
+    target.write_text(source, encoding="utf-8")
+
+    result = replace(str(target), "run", "whatever", backup=False)
+
+    assert result["status"] == "error"
+    assert "Alpha.run" in result["error"] and "Beta.run" in result["error"]
+    assert target.read_text(encoding="utf-8") == source
+
+
+def test_a_qualified_name_replaces_exactly_that_method(replace, tmp_path):
+    source = (
+        'class Alpha:\n    def run(self):\n        return "alpha"\n\n\n'
+        'class Beta:\n    def run(self):\n        return "beta"\n'
+    )
+    target = tmp_path / "classes.py"
+    target.write_text(source, encoding="utf-8")
+
+    result = replace(
+        str(target),
+        "Alpha.run",
+        '    def run(self):\n        return "PATCHED"',
+        backup=False,
+    )
+    after = target.read_text(encoding="utf-8")
+
+    assert result["status"] == "success"
+    assert 'return "PATCHED"' in after
+    assert 'return "beta"' in after
+
+
+def test_a_module_level_function_guarded_by_if_is_still_module_level(replace, tmp_path):
+    """``if TYPE_CHECKING:`` does not open a scope, so the name stays bare."""
+    source = (
+        "import typing\n\nif typing.TYPE_CHECKING:\n"
+        "    async def guarded():\n        return 1\n\n\n"
+        "def after():\n    return 2\n"
+    )
+    target = tmp_path / "guarded.py"
+    target.write_text(source, encoding="utf-8")
+
+    result = replace(
+        str(target),
+        "guarded",
+        "    async def guarded():\n        return 99",
+        backup=False,
+    )
+    after = target.read_text(encoding="utf-8")
+
+    assert result["status"] == "success"
+    assert "return 99" in after
+    assert "def after():\n    return 2" in after
+
+
+def test_a_missing_function_is_still_reported_as_not_found(replace, module):
+    result = replace(str(module), "nope", "def nope(): pass", backup=False)
+
+    assert result["status"] == "error"
+    assert "not found" in result["error"]
+    assert module.read_text(encoding="utf-8") == MODULE
+
+
+def test_the_backup_holds_the_original_without_a_path_validator(replace, module):
+    """The manual ``.bak`` path is the one every un-validated agent takes."""
+    result = replace(str(module), "foo", "def foo():\n    return 99", backup=True)
+
+    backup = module.parent / f"{module.name}.bak"
+    assert result["backup_path"] == str(backup)
+    assert backup.read_text(encoding="utf-8") == MODULE
+
+
+def test_replacing_the_last_function_keeps_everything_above_it(replace, module):
+    replace(str(module), "run", 'def run():\n    return "last"', backup=False)
+    after = module.read_text(encoding="utf-8")
+
+    assert "CONSTANT = 42" in after
+    assert "def bar():" in after
+    assert "class Runner:" in after
+    assert after.endswith('return "last"\n')

--- a/tests/unit/test_skills_name_containment.py
+++ b/tests/unit/test_skills_name_containment.py
@@ -1,0 +1,299 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""No skill entry point may resolve a name to a directory outside the skills root.
+
+Every one of these verbs does ``root / name`` and several then ``rmtree`` it, so
+a name that is not a bare skill name is a delete outside the root: ``pathlib``
+collapses ``root / "."`` to the root itself (taking ``keys/`` and the trust store
+with it), leaves ``root / ".."`` at the root's parent, and lets an absolute name
+replace the root outright.
+
+The bundle-supplied name matters as much as the typed one: ``gaia skill import``
+falls back to the name the *imported* ``SKILL.md`` declares, and nothing on that
+path validated it.
+
+Each test asserts the refusal **and** that the victim files are still on disk —
+an exception that fired after the ``rmtree`` would pass the first half alone.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import subprocess
+
+import pytest
+
+from gaia.skills.errors import SkillValidationError
+from gaia.skills.install import install_skill, remove_skill
+from gaia.skills.migrate import install_migrated, migrate_text
+from gaia.skills.naming import skill_directory, validated_skill_name
+from tests.unit.skills_helpers import isolated_manager
+
+#: The shapes that survive ``root / name`` as a real directory outside the root.
+#: ``../x`` is included because it only failed before by not existing.
+ESCAPING_NAMES = [".", "..", "../x", "..\\x", "sub/nested"]
+
+
+@pytest.fixture
+def home(tmp_path):
+    """A cold GAIA home: skills root with signing keys, trust store, and a skill."""
+    gaia_home = tmp_path / "gaia-home"
+    skills = gaia_home / "skills"
+    (skills / "keys").mkdir(parents=True)
+    (skills / "keys" / "signing.key").write_text("SECRET", encoding="utf-8")
+    (skills / "trust.json").write_text("{}", encoding="utf-8")
+    (skills / "web-research").mkdir()
+    (skills / "web-research" / "SKILL.md").write_text(
+        "---\nname: web-research\ndescription: Search the web.\n---\n\nBody.\n",
+        encoding="utf-8",
+    )
+    gaia_home.joinpath("config.json").write_text('{"real": 1}', encoding="utf-8")
+    return gaia_home
+
+
+def assert_intact(home):
+    """Nothing outside the named skill directory was touched."""
+    skills = home / "skills"
+    assert skills.is_dir()
+    assert (skills / "keys" / "signing.key").read_text(encoding="utf-8") == "SECRET"
+    assert (skills / "trust.json").is_file()
+    assert (skills / "web-research" / "SKILL.md").is_file()
+    assert (home / "config.json").is_file()
+
+
+# ----------------------------------------------------------------------
+# The helper itself
+# ----------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("name", ESCAPING_NAMES + ["", "   ", "UPPER", "under_score"])
+def test_validated_skill_name_refuses_anything_that_is_not_a_bare_name(name):
+    with pytest.raises(SkillValidationError):
+        validated_skill_name(name)
+
+
+def test_skill_directory_returns_a_direct_child_for_a_good_name(tmp_path):
+    assert skill_directory(tmp_path, " web-research ") == tmp_path / "web-research"
+
+
+def test_skill_directory_refuses_an_absolute_name(tmp_path, home):
+    with pytest.raises(SkillValidationError):
+        skill_directory(tmp_path, str(home))
+
+
+def test_skill_directory_refuses_a_linked_skill_directory(tmp_path, home):
+    """The containment assert, not the pattern, is what catches this shape.
+
+    ``linked`` passes NAME_PATTERN and ``is_dir()``; only resolving it shows the
+    rmtree would land outside the root.
+    """
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    (outside / "keep.txt").write_text("keep me", encoding="utf-8")
+    link = home / "skills" / "linked"
+    try:
+        link.symlink_to(outside, target_is_directory=True)
+    except (OSError, NotImplementedError):
+        # Windows needs admin or Developer Mode for symlinks; a junction is the
+        # same shape to Path.resolve() and needs neither.
+        if os.name != "nt":
+            raise
+        if subprocess.run(
+            ["cmd", "/c", "mklink", "/J", str(link), str(outside)],
+            capture_output=True,
+        ).returncode:
+            pytest.skip("cannot create a symlink or junction on this platform")
+
+    with pytest.raises(SkillValidationError, match="direct child"):
+        skill_directory(home / "skills", "linked")
+    assert (outside / "keep.txt").is_file()
+
+
+# ----------------------------------------------------------------------
+# gaia skill remove
+# ----------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("name", ESCAPING_NAMES)
+def test_remove_skill_refuses_an_escaping_name(home, tmp_path, name):
+    manager = isolated_manager(tmp_path, user_skills_root=home / "skills")
+    with pytest.raises(SkillValidationError):
+        remove_skill(name, manager=manager)
+    assert_intact(home)
+
+
+def test_remove_skill_refuses_an_absolute_name(home, tmp_path):
+    victim = tmp_path / "victim"
+    victim.mkdir()
+    (victim / "important.txt").write_text("keep me", encoding="utf-8")
+    manager = isolated_manager(tmp_path, user_skills_root=home / "skills")
+
+    with pytest.raises(SkillValidationError):
+        remove_skill(str(victim), manager=manager)
+
+    assert (victim / "important.txt").is_file()
+    assert_intact(home)
+
+
+def test_remove_skill_still_removes_a_real_skill(home, tmp_path):
+    manager = isolated_manager(tmp_path, user_skills_root=home / "skills")
+    result = remove_skill("web-research", manager=manager)
+
+    assert result.name == "web-research"
+    assert not (home / "skills" / "web-research").exists()
+    assert (home / "skills" / "keys" / "signing.key").is_file()
+
+
+# ----------------------------------------------------------------------
+# gaia skill install
+# ----------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("name", ESCAPING_NAMES)
+def test_install_skill_refuses_an_escaping_name_before_touching_the_network(
+    home, tmp_path, name
+):
+    """The name is validated before the hub is contacted, so no fetcher is needed."""
+    manager = isolated_manager(tmp_path, user_skills_root=home / "skills")
+
+    def explode(*_args, **_kwargs):
+        raise AssertionError("install must refuse the name before fetching")
+
+    with pytest.raises(SkillValidationError):
+        install_skill(name, manager=manager, fetcher=explode, force=True)
+    assert_intact(home)
+
+
+# ----------------------------------------------------------------------
+# gaia skill import / create  (CLI handlers, called directly)
+# ----------------------------------------------------------------------
+
+
+def _import_args(source, *, name=None, force=True):
+    return argparse.Namespace(source=str(source), name=name, force=force)
+
+
+def _bundle(tmp_path, declared_name):
+    """A skill directory whose SKILL.md declares ``declared_name``."""
+    source = tmp_path / "bundle"
+    source.mkdir()
+    (source / "SKILL.md").write_text(
+        f"---\nname: {declared_name}\ndescription: Imported bundle.\n---\n\nBody.\n",
+        encoding="utf-8",
+    )
+    return source
+
+
+@pytest.mark.parametrize("name", ESCAPING_NAMES)
+def test_import_refuses_an_escaping_bundle_supplied_name(
+    home, tmp_path, name, monkeypatch
+):
+    """Without --name the name comes from the bundle's own SKILL.md."""
+    from gaia.skills import cli as skills_cli
+
+    manager = isolated_manager(tmp_path, user_skills_root=home / "skills")
+    monkeypatch.setattr(skills_cli, "_manager", lambda: manager)
+
+    with pytest.raises(SkillValidationError):
+        skills_cli._handle_import(_import_args(_bundle(tmp_path, name)))
+    assert_intact(home)
+
+
+@pytest.mark.parametrize("name", ESCAPING_NAMES)
+def test_import_refuses_an_escaping_name_flag(home, tmp_path, name, monkeypatch):
+    from gaia.skills import cli as skills_cli
+
+    manager = isolated_manager(tmp_path, user_skills_root=home / "skills")
+    monkeypatch.setattr(skills_cli, "_manager", lambda: manager)
+    source = _bundle(tmp_path, "web-research")
+
+    with pytest.raises(SkillValidationError):
+        skills_cli._handle_import(_import_args(source, name=name))
+    assert_intact(home)
+
+
+def test_import_still_installs_a_well_named_bundle(home, tmp_path, monkeypatch):
+    from gaia.skills import cli as skills_cli
+
+    manager = isolated_manager(tmp_path, user_skills_root=home / "skills")
+    monkeypatch.setattr(skills_cli, "_manager", lambda: manager)
+
+    code = skills_cli._handle_import(_import_args(_bundle(tmp_path, "doc-search")))
+
+    assert code == 0
+    assert (home / "skills" / "doc-search" / "SKILL.md").is_file()
+
+
+@pytest.mark.parametrize("name", ESCAPING_NAMES)
+def test_create_refuses_an_escaping_name(home, tmp_path, name):
+    from gaia.skills import cli as skills_cli
+
+    args = argparse.Namespace(
+        name=name,
+        directory=str(home / "skills"),
+        description=None,
+        with_tools=False,
+        force=True,
+    )
+    with pytest.raises(SkillValidationError):
+        skills_cli._handle_create(args)
+    assert_intact(home)
+
+
+# ----------------------------------------------------------------------
+# gaia skill migrate
+# ----------------------------------------------------------------------
+
+
+def _vendor_outcome(tmp_path, declared_name):
+    """Migrate an OpenClaw skill whose manifest declares ``declared_name``."""
+    source = tmp_path / "vendor" / "skill"
+    source.mkdir(parents=True)
+    source.joinpath("SKILL.md").write_text(
+        f"---\nname: {declared_name}\n"
+        "description: Summarize the working tree status.\n"
+        "version: 0.3.0\n"
+        "metadata:\n  openclaw:\n    emoji: 🌱\n"
+        "---\n\n# Body\nSummarize it.\n",
+        encoding="utf-8",
+    )
+    return migrate_text(
+        source.joinpath("SKILL.md").read_text(encoding="utf-8"),
+        source=source / "SKILL.md",
+    )
+
+
+@pytest.mark.parametrize("name", ESCAPING_NAMES)
+def test_migrate_never_writes_outside_the_skills_root(home, tmp_path, name):
+    """Refused, or normalized to a safe name — never a write above the root.
+
+    ``migrate`` slugifies where it can (``sub/nested`` becomes a real skill
+    name), so the guarantee under test is containment, not refusal.
+    """
+    root = home / "skills"
+    outcome = _vendor_outcome(tmp_path, name)
+
+    if not outcome.migrated:
+        assert outcome.blockers
+    else:
+        try:
+            target = install_migrated(outcome, root, force=True)
+        except SkillValidationError:
+            pass
+        else:
+            assert target.resolve().parent == root.resolve()
+
+    assert_intact(home)
+
+
+@pytest.mark.parametrize("name", ESCAPING_NAMES)
+def test_install_migrated_refuses_a_name_that_reached_it(home, tmp_path, name):
+    """The join is guarded even when the name was set after normalization."""
+    outcome = _vendor_outcome(tmp_path, "git-status")
+    assert outcome.migrated, outcome.blockers
+    outcome.skill.name = name
+
+    with pytest.raises(SkillValidationError):
+        install_migrated(outcome, home / "skills", force=True)
+    assert_intact(home)


### PR DESCRIPTION
## Summary

Two tools that destroy user data and report success now refuse, or replace only
what they were asked to.

## Why

`gaia skill remove .` deleted the entire skills root — signing keys, trust store
and lock included — printed "✅ Removed skill" and exited 0; `..` took `~/.gaia`
and its `config.json` with it. Every skill entry point resolved `root / name`
without validating the name, and `pathlib` collapses `.` back to the root, leaves
`..` at its parent, and lets an absolute name replace the root outright. The
import path matters most: without `--name` the name comes from the *imported
bundle's own* `SKILL.md`, so it is supplied by whatever the user downloaded.

`replace_function` found the end of its target by scanning forward for the next
same-indent `def`/`class`, so module constants and the next function's decorators
sat inside the replaced span and were deleted while the tool returned `success`.
It also left the target's own decorators behind and re-applied them to the
replacement, and resolved the name via the first `ast.walk` hit anywhere in the
module — so on a file with two classes that each define `run`, it rewrote the
wrong one.

Neither is reachable by an attacker; both are mistakes a user or the model makes
on the way to something else. Both are silent, and both are unrecoverable.

## Linked issue

Closes #3356

## Changes

- New `gaia.skills.naming` guards every join that can be created, overwritten or
  deleted (remove / install / create / import / migrate). It validates against
  the canonical `NAME_PATTERN` and then asserts the target resolves to a direct
  child of the root — the assert is the load-bearing half, since it catches the
  symlink and `\?\` shapes a name pattern never sees.
- `replace_function` takes its span from the AST (`end_lineno`,
  `decorator_list[0].lineno`) and resolves the target by module-level name or an
  explicit `Class.method`. A bare name that exists only as a method is now an
  error listing the qualified alternatives, not a guess.
- **Behaviour change worth a look:** the replaced span now includes the target's
  decorators, so `new_implementation` must repeat any decorator the function
  keeps. The tool docstring and `docs/spec/file-io-tools-mixin.mdx` both say so.
  `skill_library_tools._reject_bad_name`'s docstring claimed the substrate did no
  validation — corrected, and the guard kept so the model still gets a structured
  tool error rather than a raised exception.

## Test plan

- [x] `python -m pytest tests/unit/test_skills_name_containment.py tests/unit/test_replace_function_spans.py -q` → **60 passed**. Reverting only the source changes turns **26 of those 60 red**, including all five `replace_function` defect tests.
- [x] `python -m pytest tests/unit/test_skills_install.py tests/unit/test_skills_cli.py tests/unit/test_skills_migrate.py tests/unit/test_skills_marketplace.py tests/unit/test_skills_format.py tests/unit/test_skills_manager.py tests/unit/test_file_write_guardrails.py tests/unit/test_skills_name_containment.py tests/unit/test_replace_function_spans.py -q` → **571 passed, 3 failed, 4 skipped**. The 3 failures are `test_skills_cli.py::test_real_cli_*`, which shell out to `gaia` and hit `RuntimeError: Could not determine home directory` on Windows; they fail identically on the unmodified base commit.
- [x] `python util/lint.py --all --fix` then `python util/lint.py --all` → black, isort, flake8, bandit, import validation and the convention checks all pass. It exits 1 on 9 pre-existing pylint `E1101`s for `os.killpg` / `os.getpgid` / `os.geteuid` in `daemon/sidecars/{ledger,manager}.py` and `installer/lemonade_installer.py` — POSIX-only members flagged because pylint ran on Windows. Same 9, same three files, none in this diff.
- [x] **Agent eval run — `tool_selection`, the category covering a tool-schema change.** `ANTHROPIC_API_KEY= gaia eval agent --category tool_selection`, judged by `claude-opus-5`, against Lemonade 11.5.0 with `Gemma-4-E4B-it-GGUF`. Run `eval-20260904-224526`: **3/5 passed, avg 7.5**. Four scenarios pass; `smart_discovery` fails, and it fails identically on unmodified `upstream/main` — see Evidence.

  The empty `ANTHROPIC_API_KEY=` is load-bearing: `load_dotenv()` reaches up into the parent checkout's `.env` and picks up an exhausted key, which flips `eval/runner.py` into `--bare` and cuts OAuth off. An earlier "Credit balance is too low" on this PR was that, not an account limit.

## Evidence

**CLI — `gaia skill remove` (the surface this PR changes).** Scratch `GAIA_CONFIG_DIR`, one `demo-skill` installed, signing key in `skills/keys/`.

*Before (base `abe87edc`):*

```
$ ls /tmp/before /tmp/before/skills
config.json  skills
demo-skill  keys

$ gaia skill remove .
✅ Removed skill '.' from ...\before\skills
   (it was not hub-installed, so no lock entry was tracked)
$ echo $?
0
$ ls /tmp/before/skills
ls: cannot access '/tmp/before/skills': No such file or directory
```

*After:*

```
$ gaia skill remove .
❌ remove '.': name '.' is not a valid skill name. Use lowercase letters and digits
   separated by single hyphens (e.g. 'web-research') — no slashes, no '.', no '..',
   no absolute path. Pass the name exactly as 'gaia skill list' reports it.
   See https://amd-gaia.ai/docs/plans/skill-format#naming
$ echo $?
4
$ ls /tmp/fakehome /tmp/fakehome/skills
config.json  skills
demo-skill  keys

$ gaia skill remove demo-skill
✅ Removed skill 'demo-skill' from ...\fakehome\skills\demo-skill
$ echo $?
0
```

`..` and `../x` refuse identically; a real name still removes.

**`replace_function` — before/after file dump**, same input file and same call
(`replace_function(path, "foo", "def foo():\n    return 99")`), both reporting
`success`:

```
----- mod.py BEFORE -----          ----- AFTER (base abe87edc) -----   ----- AFTER (this PR) -----
import functools                   import functools                    import functools


@functools.cache                   @functools.cache                    def foo():
def foo():                         def foo():                              return 99
    return 1                           return 99


                                   def bar():                          CONSTANT = 42
CONSTANT = 42                          return CONSTANT


                                                                       @functools.cache
@functools.cache                                                       def bar():
def bar():                                                                 return CONSTANT
    return CONSTANT
```

`CONSTANT = 42` and `bar`'s decorator are gone on the left; `foo`'s own decorator
survived and now decorates the new body. On the right only `foo` changed.

**Agent eval — `smart_discovery` is red, and it is not this change.**

The load-bearing evidence is a control run: revert every source file in this PR to `upstream/main` and the scenario fails the same way.

```
source                              index state          smart_discovery
upstream/main (abe87edc), reverted  180's paths          FAIL 2.35
upstream/main (abe87edc), reverted  empty                FAIL 3.77
this branch                         180's paths          FAIL 2.72 / 2.40 / 3.40
this branch                         cleared → my paths    FAIL 2.30
```

Six runs, two branches, three index states, never a pass. The judge attributes it to the environment: *"the eval corpus directory is not in the agent's allowed_paths, so `PathValidator.is_path_allowed` (`src/gaia/security.py:375`) denies both `index_document` and `read_file`… while `list_files` on the same directory succeeds"* — filed as #3370. There is also a mechanical reason this PR cannot be the cause: `smart_discovery` runs the `doc` profile, whose `tool_groups=('doc_rag',)` never registers `file_io`, and `file`/`full` pop `replace_function` out (`agent.py:1962`) — so the docstring this PR edits is in no chat profile's tool schema.

Same category, same machine, same day, same judge, different branches:

```
scenario                        #3364        #3359        this PR
data_vs_recall_disambiguation   FAIL 6.40    PASS 9.05    FAIL 6.50   (flaky — also red on #3364)
known_path_read                 PASS 9.55    PASS 9.75    PASS 9.70
multi_step_plan                 PASS 9.82    PASS 8.98    PASS 9.50
no_tools_needed                 PASS 9.97    PASS 9.98    PASS 10.0
smart_discovery                 PASS 8.07    PASS 9.88    FAIL 2.30
```

The two green `smart_discovery` results ran against a **warm** document library whose indexed paths matched their worktree. The scenario only passes from warm state; its cold discover-index-answer path does not work on this machine (#3370).

The committed baseline is deliberately not quoted: `gemma-4-e4b-d71cd914` was judged by `claude-sonnet-4-6` over 4 scenarios, while these runs use `claude-opus-5` over 5, so a delta against it measures judge and corpus drift (#3371).

*Footnote on the middle row:* the "cleared → my paths" run required manually deleting three rows from `~/.gaia/chat/gaia_chat.db` that pointed at another worktree. That is a manual environment fix, not routine — it removed the `Access denied` failure and exposed a second one underneath (`find_files` restricted to `pdf,docx,txt`, excluding the `.md` handbook), so the scenario still failed.

*The `replace_function` docstring was trimmed 1110 → 631 chars while investigating this. It did not move the number — see above for why it could not — and is kept only because a tool docstring ships in the schema every turn.*

- **Agent exposed in the Agent UI** — N/A. Neither surface is rendered in the Agent UI; `replace_function` is a tool the agent calls, and `gaia skill remove` is CLI-only.
- **MCP tools / servers** — N/A. Nothing here is exposed over MCP.
- **HTTP API / REST** — N/A. No router or endpoint touched.

