### PR TITLE
fix(connectors): make the per-agent grant check real and bounded

### DIFF
--- a/docs/sdk/infrastructure/connectors.mdx
+++ b/docs/sdk/infrastructure/connectors.mdx
@@ -61,7 +61,15 @@ async def main():
         scopes=["https://www.googleapis.com/auth/gmail.readonly"],
     )
 
+    # A grant cannot exceed what the connector's catalog entry advertises: a
+    # scope outside `available_scopes` raises ScopeNotAllowedError, and an
+    # unknown connector id raises UnknownConnectorError (both subclass
+    # ConnectorsError). Revoking is never gated this way — taking access away
+    # always works, even for a connector that has left the catalog.
+
     # 3. Fetch a short-lived access token (refresh is automatic).
+    #    Always name the scopes you need: a call that names none is refused
+    #    rather than silently skipping the grant check.
     token = await conn.get_access_token(
         provider="google",
         scopes=["https://www.googleapis.com/auth/gmail.readonly"],
@@ -206,6 +214,11 @@ gaia connectors grants grant google builtin:chat \
     --scopes https://www.googleapis.com/auth/gmail.readonly
 gaia connectors grants list google
 gaia connectors grants revoke google builtin:chat
+
+# `grant` exits 1 if the scope is outside the connector's available_scopes or
+# the connector id is not in the catalog — `gaia connectors list` shows the
+# ids, `gaia connectors list <id>` its scopes. `revoke` is never gated that
+# way: taking access away always works.
 
 # NOTE: the Agent UI grants on connect (#2117): POST
 # /api/connectors/{id}/authorize accepts grant_agents (namespaced agent

--- a/docs/sdk/infrastructure/connectors.mdx
+++ b/docs/sdk/infrastructure/connectors.mdx
@@ -90,6 +90,15 @@ asyncio.run(main())
 | `CONNECTION_MISSING_SCOPES` | Grant exists but covers fewer scopes. |
 | `REAUTH_REQUIRED` | OAuth client ID was rotated. |
 
+`AGENT_NOT_GRANTED` with `agent_id=None` is a distinct case: the call came from
+inside an agent turn that carries no identity, so no grant could be checked and
+none is assumed. Fix the identity, not the grants — see the warning below.
+
+It also raises `ConfigurationError` when an `agent_id` resolves but `scopes` is
+empty. An empty list satisfies the grant check vacuously, so it would hand back
+a full-capability token with the ledger never consulted; naming nothing is
+refused rather than treated as needing nothing.
+
 ## Forwarded connections (no re-auth)
 
 When a host app has **already** authenticated the user (its own OAuth flow),

--- a/docs/sdk/infrastructure/connectors.mdx
+++ b/docs/sdk/infrastructure/connectors.mdx
@@ -275,6 +275,39 @@ The Agent UI consent dialog renders `reason` in plain language. After
 the user grants the scopes, subsequent `get_access_token_sync` calls
 return fresh tokens transparently.
 
+<Warning>
+**Credential access fails closed inside an agent turn.** The tool above passes
+no `agent_id`, and that is correct: the agent runtime binds your agent's
+identity to the current context and the credential call reads it from there.
+What changed is what happens when it *cannot* be read while a turn is running —
+the call is now refused with `AuthRequiredError` instead of falling through
+ungated.
+
+That matters when your tool hands work to something that does **not** inherit
+the context — a thread or process you start yourself, a background task queued
+for later, a callback fired from another runtime. Capture the id on the way in
+and pass it explicitly:
+
+```python
+from gaia.connectors import current_agent_id, get_access_token_sync
+
+@tool(description="Fetch in a worker thread")
+def _fetch(self) -> str:
+    agent_id = current_agent_id()          # captured in the tool body
+    def _work():
+        return get_access_token_sync(
+            provider="google",
+            scopes=["https://www.googleapis.com/auth/gmail.readonly"],
+            agent_id=agent_id,             # carried across the boundary
+        )
+    ...
+```
+
+Outside an agent turn — the CLI, a script, your own SDK embedding — there is no
+identity to resolve and no grant to check, which is the documented escape
+hatch. Pass `agent_id=` explicitly there if you want the grant enforced anyway.
+</Warning>
+
 If instead your agent loads MCP servers dynamically at runtime (from
 `~/.gaia/mcp_servers.json`) rather than declaring specific connectors, set
 `CONSUMES_MCP_SERVERS = True` so the Settings → Connectors "Active for"

--- a/docs/security/connections.mdx
+++ b/docs/security/connections.mdx
@@ -61,6 +61,8 @@ You can revoke access at any level:
 |---|---|
 | Malicious process reads `mcp_servers.json` | File contains only `$keyring:...` references, never raw tokens |
 | Malicious agent requests a credential it wasn't granted | `get_credential_sync` checks the grants ledger before returning; unapproved calls raise `AuthRequiredError` |
+| Agent code runs a tool in its own thread and loses its identity | The runtime copies the calling context into every tool thread; a credential request inside an agent turn with no identity is refused, never treated as an un-scoped CLI call |
+| Grant ledger written with scopes the connector never advertised | `grant_agent` rejects any scope outside the connector's catalog entry and any unknown connector id, so the Agent UI, the CLI, and the SDK share one ceiling |
 | Connector re-added after disconnect silently inherits prior tool visibility | `disconnect` wipes both grants AND activations for that `connector_id`; re-adding requires explicit re-grant + re-activate |
 | Token leak via logging | Connector code never logs token values; credentials are redacted before any log statement |
 | Token exfiltration via a rogue custom agent | Custom agents run in the same process as GAIA — they are trusted code you install yourself, analogous to a browser extension |

--- a/src/gaia/agents/base/agent.py
+++ b/src/gaia/agents/base/agent.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 # Standard library imports
 import abc
 import ast
+import contextvars
 import datetime
 import inspect
 import json
@@ -3176,7 +3177,15 @@ Do NOT wrap conversational replies in JSON.
             except BaseException as exc:  # noqa: BLE001 — re-raised in caller
                 holder["exc"] = exc
 
-        worker = threading.Thread(target=_target, name=f"tool:{tool_name}", daemon=True)
+        # A new thread starts with an EMPTY context, so the agent-identity
+        # contextvar bound by process_query would be None inside every tool
+        # body — silently disabling the per-agent connector grant check
+        # (#915). Snapshot here, in the caller; copying inside _target would
+        # copy the worker's own empty context and change nothing.
+        ctx = contextvars.copy_context()
+        worker = threading.Thread(
+            target=lambda: ctx.run(_target), name=f"tool:{tool_name}", daemon=True
+        )
         worker.start()
         worker.join(timeout)
         if worker.is_alive():
@@ -4390,13 +4399,18 @@ Do NOT wrap conversational replies in JSON.
 
         Shared identity binding so that both process_query and
         on_heartbeat can resolve per-agent grants via contextvars.
+
+        Entered even when ``ns_id`` is None (an agent with no namespaced
+        identity): the block still marks an agent turn, so a credential
+        request from inside it fails closed rather than taking the ungated
+        CLI path.
         """
         # `_agent_context` is intentionally PRIVATE (issue #915): imported via
         # the private path so a malicious tool body can't forge an agent
         # identity through the public gaia.connectors API.
         from gaia.connectors.context import _agent_context
 
-        return _agent_context(ns_id) if ns_id else None
+        return _agent_context(ns_id)
 
     def _active_mcp_servers(self, manager) -> List[str]:
         """Return MCP server names whose tools should be visible to this agent.
@@ -4460,11 +4474,8 @@ Do NOT wrap conversational replies in JSON.
             Dict containing the final result and operation details
         """
         ns_id = self._namespaced_agent_id()
-        identity_ctx = self._agent_identity_context(ns_id)
         try:
-            if identity_ctx is None:
-                return self._process_query_impl(user_input, max_steps, trace, filename)
-            with identity_ctx:
+            with self._agent_identity_context(ns_id):
                 return self._process_query_impl(user_input, max_steps, trace, filename)
         finally:
             # The impl re-raises on purpose (the wrong-ctx reload its caller

--- a/src/gaia/connectors/__init__.py
+++ b/src/gaia/connectors/__init__.py
@@ -26,10 +26,10 @@ without notice. Only the names re-exported here are stable.
 
 from __future__ import annotations
 
-# Read-only contextvar accessor — public by design; agents and tools may
+# Read-only contextvar accessors — public by design; agents and tools may
 # read the current agent identity but cannot set it. The setter
 # (``_agent_context``) is intentionally NOT re-exported.
-from gaia.connectors.context import current_agent_id
+from gaia.connectors.context import agent_runtime_active, current_agent_id
 
 # Error types — caught by router/CLI/SDK consumers.
 from gaia.connectors.errors import (
@@ -125,6 +125,7 @@ __all__ = [
     # because they are provided lazily via __getattr__ and Pylint's static
     # analysis would flag them as undefined-all-variable (E0603).
     "current_agent_id",
+    "agent_runtime_active",
     # Event-emitter Protocol (router wires its impl)
     "EventEmitter",
     "set_emitter",

--- a/src/gaia/connectors/api.py
+++ b/src/gaia/connectors/api.py
@@ -196,6 +196,20 @@ def _authorize_access(
             missing_scopes=list(scopes),
         )
 
+    if resolved_agent is not None and not scopes:
+        # ``check_agent_grant(provider, agent, [])`` is True vacuously, and the
+        # connection-coverage check below is vacuous too — so a scope-less
+        # request would return a FULL-capability token with the ledger never
+        # consulted. That is the whole bypass this control exists to close,
+        # reached by simply not saying what you want. Same guard
+        # ``handler.get_credential`` applies; this is the OAuth twin of it.
+        raise ConfigurationError(
+            f"get_access_token({provider!r}) named no scopes, so the per-agent "
+            f"grant for {resolved_agent!r} cannot be verified and no token will "
+            "be issued. Pass the scopes the caller actually needs, e.g. "
+            "scopes=['https://www.googleapis.com/auth/gmail.readonly']."
+        )
+
     # Eager check for per-agent grant — surface the error BEFORE any
     # network round-trip so the caller can prompt the user immediately.
     if resolved_agent is not None:
@@ -253,7 +267,12 @@ async def get_access_token(
     Agent-id resolution order (per AC8 explicit opt-out clause):
       1. Explicit ``agent_id`` kwarg, if non-None.
       2. Active contextvar (``current_agent_id()``), set by the agent runtime.
-      3. ``None``, which BYPASSES the per-agent grant check.
+      3. ``None``, which BYPASSES the per-agent grant check — but ONLY outside
+         an agent turn. Inside one, a missing identity is a dropped context,
+         not an opt-out, so the request is refused (#915).
+
+    An empty ``scopes`` list is refused whenever an agent id resolves: it would
+    satisfy the grant check vacuously and hand back a full-capability token.
 
     The contextvar path is the production path: ``Agent.process_query``
     enters ``_agent_context(self.namespaced_agent_id)`` before invoking

--- a/src/gaia/connectors/api.py
+++ b/src/gaia/connectors/api.py
@@ -33,7 +33,7 @@ from gaia.connectors.activations import (
     list_agent_activations,
     load_activations,
 )
-from gaia.connectors.context import current_agent_id
+from gaia.connectors.context import agent_runtime_active, current_agent_id
 from gaia.connectors.errors import (
     AuthRequiredError,
     ConfigurationError,
@@ -182,9 +182,19 @@ def _authorize_access(
     Agent-id resolution order (per AC8 explicit opt-out clause):
       1. Explicit ``agent_id`` kwarg, if non-None.
       2. Active contextvar (``current_agent_id()``), set by the agent runtime.
-      3. ``None``, which BYPASSES the per-agent grant check.
+      3. ``None``, which BYPASSES the per-agent grant check — but ONLY outside
+         an agent turn. Inside one, a missing identity is a dropped context,
+         not an opt-out, so the request is refused (#915).
     """
     resolved_agent = agent_id if agent_id is not None else current_agent_id()
+
+    if resolved_agent is None and agent_runtime_active():
+        raise AuthRequiredError(
+            AuthRequiredError.Reason.AGENT_NOT_GRANTED,
+            provider=provider,
+            agent_id=None,
+            missing_scopes=list(scopes),
+        )
 
     # Eager check for per-agent grant — surface the error BEFORE any
     # network round-trip so the caller can prompt the user immediately.
@@ -486,6 +496,8 @@ def import_forwarded_connection(
       - insecure keyring backend → ``ConnectorsError`` (via
         ``verify_keyring_backend``);
       - empty ``client_id`` / ``refresh_token`` → ``ConnectorsError``;
+      - a forwarded scope outside the connector's catalog ceiling, when
+        ``grant_agents`` is set → ``ScopeNotAllowedError``;
       - forwarded scopes don't cover ``required_scopes`` → ``ScopeMismatchError``.
         ``required_scopes is None`` falls back to the per-provider default
         (``_DEFAULT_REQUIRED_SCOPES_BY_PROVIDER``, empty for unknown providers);
@@ -536,6 +548,17 @@ def import_forwarded_connection(
         raise ScopeMismatchError(
             required=required, granted=list(scopes), provider=provider
         )
+
+    # 3b. Grant ceiling (#915). Step 8 hands these scopes to ``grant_agent``,
+    #     which refuses any the connector never advertised — check it here so a
+    #     rejected forward still leaves the keyring untouched, per the
+    #     up-front-validation contract above.
+    if grant_agents:
+        from gaia.connectors.grants import resolve_spec
+
+        outside = sorted(set(scopes) - set(resolve_spec(provider).scope_ceiling()))
+        if outside:
+            raise ScopeNotAllowedError(None, provider, outside)
 
     account = account_email or DEFAULT_ACCOUNT
 

--- a/src/gaia/connectors/cli.py
+++ b/src/gaia/connectors/cli.py
@@ -659,7 +659,10 @@ def _handle_disconnect(args: argparse.Namespace) -> int:
 
 
 def _handle_grants(args: argparse.Namespace) -> int:
-    from gaia.connectors.errors import ScopeNotAllowedError
+    from gaia.connectors.errors import (
+        ScopeNotAllowedError,
+        UnknownConnectorError,
+    )
     from gaia.connectors.grants import (
         grant_agent,
         list_agent_grants,
@@ -680,14 +683,7 @@ def _handle_grants(args: argparse.Namespace) -> int:
         # route enforce one ceiling (#915).
         try:
             grant_agent(args.connector_id, args.agent_id, args.scopes)
-        except KeyError:
-            sys.stderr.write(
-                f"gaia connectors grants grant: unknown connector "
-                f"{args.connector_id!r}. Run 'gaia connectors list' to see "
-                "the available ids.\n"
-            )
-            return 1
-        except ScopeNotAllowedError as e:
+        except (ScopeNotAllowedError, UnknownConnectorError) as e:
             sys.stderr.write(f"gaia connectors grants grant: {e}\n")
             return 1
         sys.stdout.write(

--- a/src/gaia/connectors/cli.py
+++ b/src/gaia/connectors/cli.py
@@ -659,6 +659,7 @@ def _handle_disconnect(args: argparse.Namespace) -> int:
 
 
 def _handle_grants(args: argparse.Namespace) -> int:
+    from gaia.connectors.errors import ScopeNotAllowedError
     from gaia.connectors.grants import (
         grant_agent,
         list_agent_grants,
@@ -675,7 +676,20 @@ def _handle_grants(args: argparse.Namespace) -> int:
             sys.stdout.write(f"{args.connector_id} {agent_id}: {', '.join(scopes)}\n")
         return 0
     if sub == "grant":
-        grant_agent(args.connector_id, args.agent_id, args.scopes)
+        # Both gates live in grant_agent so this command and the Agent UI
+        # route enforce one ceiling (#915).
+        try:
+            grant_agent(args.connector_id, args.agent_id, args.scopes)
+        except KeyError:
+            sys.stderr.write(
+                f"gaia connectors grants grant: unknown connector "
+                f"{args.connector_id!r}. Run 'gaia connectors list' to see "
+                "the available ids.\n"
+            )
+            return 1
+        except ScopeNotAllowedError as e:
+            sys.stderr.write(f"gaia connectors grants grant: {e}\n")
+            return 1
         sys.stdout.write(
             f"Granted {args.connector_id} → {args.agent_id}: "
             f"{', '.join(args.scopes)}\n"

--- a/src/gaia/connectors/context.py
+++ b/src/gaia/connectors/context.py
@@ -3,7 +3,7 @@
 """
 Agent-identity context propagation for ``gaia.connectors``.
 
-Two callables, asymmetric visibility:
+Three callables, asymmetric visibility:
 
 - ``_agent_context(agent_id)`` — **PRIVATE**. Only the agent runtime calls
   this (via the private import path). A tool body cannot reach this from
@@ -13,29 +13,46 @@ Two callables, asymmetric visibility:
 - ``current_agent_id()`` — **PUBLIC**. Tools and the connections core may
   read the active agent id but cannot set it.
 
+- ``agent_runtime_active()`` — **PUBLIC**. True while an agent turn owns the
+  current context. Credential access with no resolvable identity fails closed
+  when this is True; outside an agent turn (CLI, SDK, debug) it stays the
+  documented ungated escape hatch.
+
 ContextVars are thread-local in CPython, but inherited across asyncio task
 boundaries via ``contextvars.copy_context()``. This is exactly the model
 the sync→async bridge relies on: ``Agent.process_query`` runs in a
 ``ThreadPoolExecutor`` worker, the context manager is entered there, and
 ``asyncio.run(get_access_token(...))`` from inside the worker inherits the
 worker thread's context — see the bridge test in ``test_agent_bridge.py``.
+The same rule is why any thread the runtime spawns to run a tool body must
+be started with a copied context (``Agent._call_tool_bounded``); a bare
+``threading.Thread`` starts empty and would drop the identity.
 """
 
 from __future__ import annotations
 
 from contextlib import contextmanager
 from contextvars import ContextVar
-from typing import Iterator
+from typing import Iterator, Optional
 
 _agent_id_var: ContextVar[str | None] = ContextVar(
     "gaia_connections_agent_id", default=None
 )
 
+_agent_runtime_var: ContextVar[bool] = ContextVar(
+    "gaia_connections_agent_runtime", default=False
+)
+
 
 @contextmanager
-def _agent_context(agent_id: str) -> Iterator[None]:
+def _agent_context(agent_id: Optional[str]) -> Iterator[None]:
     """
-    Set the active agent id for the lifetime of the ``with`` block.
+    Mark an agent turn — and bind its identity — for the ``with`` block.
+
+    ``agent_id`` may be ``None`` for an agent with no namespaced identity
+    (a directly-constructed test agent, an unregistered custom class). The
+    runtime flag is set either way, so a credential request from inside that
+    turn fails closed instead of silently taking the ungated path.
 
     PRIVATE — the agent runtime imports this via the explicit private path
     ``from gaia.connectors.context import _agent_context``. The connections
@@ -43,13 +60,25 @@ def _agent_context(agent_id: str) -> Iterator[None]:
     so a malicious tool body cannot forge an agent identity to bypass the
     per-agent grant check.
     """
-    token = _agent_id_var.set(agent_id)
+    id_token = _agent_id_var.set(agent_id)
+    runtime_token = _agent_runtime_var.set(True)
     try:
         yield
     finally:
-        _agent_id_var.reset(token)
+        _agent_runtime_var.reset(runtime_token)
+        _agent_id_var.reset(id_token)
 
 
 def current_agent_id() -> str | None:
     """Return the active agent id, or ``None`` if no context is set."""
     return _agent_id_var.get()
+
+
+def agent_runtime_active() -> bool:
+    """Return True while an agent turn owns the current context.
+
+    Read by ``handler.get_credential`` and ``api._authorize_access`` to decide
+    whether a missing agent identity is a CLI caller (allowed) or a dropped
+    context inside an agent turn (refused).
+    """
+    return _agent_runtime_var.get()

--- a/src/gaia/connectors/errors.py
+++ b/src/gaia/connectors/errors.py
@@ -374,6 +374,25 @@ class NoDeclaredScopesError(ConnectorsError):
         )
 
 
+class UnknownConnectorError(ConnectorsError):
+    """A connector id that the catalog does not publish.
+
+    ``REGISTRY.get`` raises a bare ``KeyError``, which reaches an HTTP boundary
+    as an unhandled 500 and a CLI as a traceback. Grant writes translate it to
+    this so every surface gets one actionable, typed error instead.
+    """
+
+    def __init__(self, connector_id: str, known_ids: list[str] | None = None):
+        self.connector_id = connector_id
+        self.known_ids = sorted(known_ids or [])
+        known = f" Known ids: {', '.join(self.known_ids)}." if self.known_ids else ""
+        super().__init__(
+            f"Unknown connector {connector_id!r}.{known} Run "
+            "'gaia connectors list' to see the catalog, or check the id for a "
+            "typo."
+        )
+
+
 class ScopeNotAllowedError(ConnectorsError):
     """A declared scope is outside the connector's ``available_scopes`` ceiling.
 

--- a/src/gaia/connectors/formatting.py
+++ b/src/gaia/connectors/formatting.py
@@ -67,6 +67,20 @@ def format_connector_error(e: BaseException) -> str:
     """
     if isinstance(e, AuthRequiredError):
         if e.reason is AuthRequiredError.Reason.AGENT_NOT_GRANTED:
+            if e.agent_id is None:
+                # The fail-closed branch (#915): a credential request inside an
+                # agent turn that carries no identity. "Grant it in Settings"
+                # is unfollowable here — there is no agent to grant anything
+                # TO. Name the actual cause instead.
+                return (
+                    f"AGENT_IDENTITY_MISSING: a credential for {e.provider} was "
+                    "requested from inside an agent turn that carries no agent "
+                    "identity, so no per-agent grant can be checked and none is "
+                    "assumed. Either the agent has no AGENT_ID, or the calling "
+                    "code left the agent's context (a thread or task it started "
+                    "itself) — capture current_agent_id() and pass agent_id= "
+                    "explicitly across that boundary."
+                )
             override = _AGENT_GRANT_MIGRATION_MESSAGES.get(
                 (e.agent_id or "", e.provider or "")
             )

--- a/src/gaia/connectors/grants.py
+++ b/src/gaia/connectors/grants.py
@@ -42,7 +42,11 @@ import threading
 from pathlib import Path
 from typing import Dict, List
 
-from gaia.connectors.errors import ConnectorsError, ScopeNotAllowedError
+from gaia.connectors.errors import (
+    ConnectorsError,
+    ScopeNotAllowedError,
+    UnknownConnectorError,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -158,16 +162,26 @@ def _save_grants_locked(data: Dict[str, Dict[str, List[str]]]) -> None:
 def resolve_spec(connector_id: str):
     """Return the catalog ``ConnectorSpec`` for ``connector_id``.
 
-    Raises ``KeyError`` for an id the catalog does not publish. Importing the
-    catalog here (deferred — it imports the handlers, which import this module)
-    means every caller gets a populated REGISTRY without each entry point
-    having to remember, exactly as ``api._require_mcp_server_for_activation``
-    does for activations.
+    Raises ``UnknownConnectorError`` — not the registry's bare ``KeyError``,
+    which would reach an HTTP boundary as an unhandled 500 and a CLI as a
+    traceback.
+
+    Importing the catalog here (deferred — it imports the handlers, which
+    import this module) means every caller gets a populated REGISTRY without
+    each entry point having to remember, exactly as
+    ``api._require_mcp_server_for_activation`` does for activations.
+
+    Only WIDENING operations call this. Revoking must never depend on the
+    catalog — see the note on ``revoke_agent_grant``.
     """
     import gaia.connectors.catalog  # noqa: F401  # pylint: disable=unused-import
     from gaia.connectors.registry import REGISTRY
 
-    return REGISTRY.get(connector_id)
+    try:
+        return REGISTRY.get(connector_id)
+    except KeyError as e:
+        known = [spec.id for spec in REGISTRY.all()]
+        raise UnknownConnectorError(connector_id, known) from e
 
 
 def grant_agent(connector_id: str, agent_id: str, scopes: List[str]) -> None:
@@ -181,8 +195,9 @@ def grant_agent(connector_id: str, agent_id: str, scopes: List[str]) -> None:
     Both authorization gates live HERE rather than at each call site, so the
     Agent UI route, the CLI, and the SDK cannot drift apart (#915, #3247):
 
-    - an id the catalog does not publish raises ``KeyError`` — otherwise a
-      typo'd connector persists a phantom ledger key nothing will ever read;
+    - an id the catalog does not publish raises ``UnknownConnectorError`` —
+      otherwise a typo'd connector persists a phantom ledger key nothing will
+      ever read;
     - a scope outside ``spec.scope_ceiling()`` raises ``ScopeNotAllowedError``
       — otherwise the ledger can be set to scopes the connector never
       advertised, and ``check_agent_grant`` would then approve token requests
@@ -210,6 +225,11 @@ def revoke_agent_grant(connector_id: str, agent_id: str) -> None:
     """
     Remove an agent's grant for ``connector_id``. Idempotent — silently no-ops
     if the agent has no grant.
+
+    Deliberately NOT catalog-gated, unlike ``grant_agent``. Taking authority
+    away must always be possible: a connector dropped from the catalog would
+    otherwise strand grants that can never be cleared — a security regression
+    in the opposite direction. Only widening is gated.
     """
     with _write_lock:
         data = load_grants()
@@ -226,6 +246,10 @@ def revoke_agent_grant(connector_id: str, agent_id: str) -> None:
 def revoke_all_grants_for(connector_id: str) -> List[str]:
     """
     Remove every agent grant for ``connector_id``.
+
+    Not catalog-gated, for the same reason as ``revoke_agent_grant``: this
+    runs on disconnect, including for a connector that is on its way out of
+    the catalog, and must clear the ledger regardless.
 
     Called on connector ``disconnect()`` to prevent silent grant inheritance
     when a connector with the same id is later re-added (which would otherwise

--- a/src/gaia/connectors/grants.py
+++ b/src/gaia/connectors/grants.py
@@ -42,7 +42,7 @@ import threading
 from pathlib import Path
 from typing import Dict, List
 
-from gaia.connectors.errors import ConnectorsError
+from gaia.connectors.errors import ConnectorsError, ScopeNotAllowedError
 
 logger = logging.getLogger(__name__)
 
@@ -155,6 +155,21 @@ def _save_grants_locked(data: Dict[str, Dict[str, List[str]]]) -> None:
         raise
 
 
+def resolve_spec(connector_id: str):
+    """Return the catalog ``ConnectorSpec`` for ``connector_id``.
+
+    Raises ``KeyError`` for an id the catalog does not publish. Importing the
+    catalog here (deferred — it imports the handlers, which import this module)
+    means every caller gets a populated REGISTRY without each entry point
+    having to remember, exactly as ``api._require_mcp_server_for_activation``
+    does for activations.
+    """
+    import gaia.connectors.catalog  # noqa: F401  # pylint: disable=unused-import
+    from gaia.connectors.registry import REGISTRY
+
+    return REGISTRY.get(connector_id)
+
+
 def grant_agent(connector_id: str, agent_id: str, scopes: List[str]) -> None:
     """
     Grant ``agent_id`` (already namespaced) the given scopes for ``connector_id``.
@@ -162,7 +177,23 @@ def grant_agent(connector_id: str, agent_id: str, scopes: List[str]) -> None:
     Overwrites any existing scopes for the same ``(connector_id, agent_id)`` pair.
     The full load-modify-save sequence is performed under the per-process
     write lock so concurrent grants from multiple threads don't lose updates.
+
+    Both authorization gates live HERE rather than at each call site, so the
+    Agent UI route, the CLI, and the SDK cannot drift apart (#915, #3247):
+
+    - an id the catalog does not publish raises ``KeyError`` — otherwise a
+      typo'd connector persists a phantom ledger key nothing will ever read;
+    - a scope outside ``spec.scope_ceiling()`` raises ``ScopeNotAllowedError``
+      — otherwise the ledger can be set to scopes the connector never
+      advertised, and ``check_agent_grant`` would then approve token requests
+      for them. This is the same ceiling ``flow._reject_scopes_outside_catalog``
+      applies to the OAuth authorize path.
     """
+    spec = resolve_spec(connector_id)
+    disallowed = sorted(set(scopes) - set(spec.scope_ceiling()))
+    if disallowed:
+        raise ScopeNotAllowedError(agent_id, connector_id, disallowed)
+
     with _write_lock:
         data = load_grants()
         data.setdefault(connector_id, {})[agent_id] = list(scopes)

--- a/src/gaia/connectors/handler.py
+++ b/src/gaia/connectors/handler.py
@@ -16,7 +16,9 @@ dispatcher is type-agnostic; adding a new type only requires:
 
 The per-agent grant check lives here (not in handlers) because it is
 type-agnostic: every connector type gates ``get_credential`` on whether
-the calling agent has been granted the required scopes.
+the calling agent has been granted the required scopes. It fails closed —
+a request made inside an agent turn with no resolvable identity is refused
+rather than falling through to the ungated CLI path (#915).
 """
 
 from __future__ import annotations
@@ -25,8 +27,12 @@ import asyncio
 import logging
 from typing import Any, Dict, List, Optional, Protocol, runtime_checkable
 
-from gaia.connectors.context import current_agent_id
-from gaia.connectors.errors import AuthRequiredError, ConnectorsError
+from gaia.connectors.context import agent_runtime_active, current_agent_id
+from gaia.connectors.errors import (
+    AuthRequiredError,
+    ConfigurationError,
+    ConnectorsError,
+)
 from gaia.connectors.grants import check_agent_grant, list_agent_grants
 from gaia.connectors.registry import REGISTRY
 from gaia.connectors.spec import ConnectorSpec, ConnectorType
@@ -143,18 +149,40 @@ async def get_credential(
     Agent-id resolution order:
       1. Explicit ``agent_id`` kwarg, if non-None.
       2. Active contextvar (``current_agent_id()``), set by the agent runtime.
-      3. ``None`` → grant check is SKIPPED (CLI/debug callers).
+      3. ``None`` → grant check is SKIPPED, but ONLY outside an agent turn
+         (the CLI/debug escape hatch). Inside an agent turn a missing identity
+         means the context was dropped, not that the caller opted out, so the
+         request is refused (#915).
 
-    If an agent_id is resolved AND ``required_scopes`` is provided, the
-    per-agent grant is verified before calling the handler.
+    ``required_scopes`` defaults to the connector's own ceiling when the caller
+    omits it — the credential a handler hands back is the whole capability, so
+    "no scopes named" must not mean "nothing to check".
     """
     spec = REGISTRY.get(connector_id)
     resolved_agent = agent_id or current_agent_id()
 
-    if resolved_agent and required_scopes:
-        if not check_agent_grant(connector_id, resolved_agent, required_scopes):
+    if resolved_agent is None and agent_runtime_active():
+        raise AuthRequiredError(
+            AuthRequiredError.Reason.AGENT_NOT_GRANTED,
+            provider=connector_id,
+            agent_id=None,
+            missing_scopes=list(required_scopes or spec.scope_ceiling()),
+        )
+
+    if resolved_agent:
+        effective_scopes = list(required_scopes or spec.scope_ceiling())
+        if not effective_scopes:
+            # An empty scope list satisfies check_agent_grant vacuously, which
+            # would turn "the catalog names no scopes" into "everyone passes".
+            raise ConfigurationError(
+                f"Connector {connector_id!r} publishes no scopes, so the "
+                f"per-agent grant for {resolved_agent!r} cannot be verified. "
+                "Add an 'available_scopes' entry to its catalog spec under "
+                "gaia/connectors/catalog/, or pass required_scopes explicitly."
+            )
+        if not check_agent_grant(connector_id, resolved_agent, effective_scopes):
             granted = set(list_agent_grants(connector_id).get(resolved_agent, []))
-            missing = [s for s in required_scopes if s not in granted]
+            missing = [s for s in effective_scopes if s not in granted]
             raise AuthRequiredError(
                 AuthRequiredError.Reason.AGENT_NOT_GRANTED,
                 provider=connector_id,

--- a/src/gaia/connectors/spec.py
+++ b/src/gaia/connectors/spec.py
@@ -27,6 +27,12 @@ _VALID_KINDS = frozenset(
 )
 _VALID_TYPES: frozenset[str] = frozenset({"oauth_pkce", "mcp_server"})
 
+# The implicit scope an ``mcp_server`` connector carries. MCP servers have no
+# OAuth-style scope list — holding the credential IS the capability — so the
+# grant ledger records a single "may use this server" scope for them. Agents
+# declare it as ``ConnectorRequirement(connector_id="mcp-…", scopes=("use",))``.
+MCP_SERVER_SCOPES: tuple[str, ...] = ("use",)
+
 
 @dataclass(frozen=True)
 class ConfigField:
@@ -123,6 +129,24 @@ class ConnectorSpec:
     mcp_command: str | None = None
     mcp_args: tuple[str, ...] = field(default_factory=tuple)
     mcp_env_keys: tuple[str, ...] = field(default_factory=tuple)
+
+    def scope_ceiling(self) -> tuple[str, ...]:
+        """Every scope a grant for this connector is allowed to carry.
+
+        ``available_scopes`` is the ceiling whenever a spec declares one — the
+        same list ``flow._reject_scopes_outside_catalog`` enforces on the OAuth
+        authorize path. An ``mcp_server`` spec that declares none falls back to
+        the implicit ``MCP_SERVER_SCOPES`` rather than to a deny-all empty
+        tuple, so adding an MCP connector to the catalog cannot accidentally
+        ship a connector nobody can be granted. An ``oauth_pkce`` spec with no
+        ``available_scopes`` IS deny-all: #3247 already requires OAuth entries
+        to publish their list, and guessing one would defeat the ceiling.
+        """
+        if self.available_scopes:
+            return self.available_scopes
+        if self.type == "mcp_server":
+            return MCP_SERVER_SCOPES
+        return ()
 
     def __post_init__(self) -> None:
         if not self.id or not self.id.strip():

--- a/src/gaia/ui/routers/connectors.py
+++ b/src/gaia/ui/routers/connectors.py
@@ -61,6 +61,7 @@ from gaia.connectors.errors import (
     ScopeMismatchError,
     ScopeNotAllowedError,
     UnknownAgentError,
+    UnknownConnectorError,
 )
 from gaia.connectors.events import set_emitter
 from gaia.connectors.flow import _pending as _flow_pending
@@ -252,6 +253,14 @@ set_emitter(_emitter)
 
 
 def _raise_http_for(exc: ConnectorsError) -> HTTPException:
+    if isinstance(exc, UnknownConnectorError):
+        return HTTPException(
+            status_code=404,
+            detail={
+                "error": "unknown_connector",
+                "connector_id": exc.connector_id,
+            },
+        )
     if isinstance(exc, ConfigurationError):
         return HTTPException(status_code=503, detail=str(exc))
     if isinstance(exc, ScopeNotAllowedError):
@@ -982,15 +991,13 @@ async def put_grant(
 
     ``grants.grant_agent`` owns both authorization gates — unknown connector
     and out-of-ceiling scopes — so this route and the CLI cannot drift. Here we
-    only translate them: 404 for the unknown id, and the same 400
-    ``scope_not_allowed`` body the authorize route already returns.
+    only translate them, via ``_raise_http_for``: 404 ``unknown_connector`` for
+    an id the catalog does not publish (matching ``_require_mcp_server`` two
+    routes down), and the same 400 ``scope_not_allowed`` body the authorize
+    route already returns.
     """
     try:
         grant_agent(connector_id, agent_id, body.scopes)
-    except KeyError as e:
-        raise HTTPException(
-            status_code=404, detail=f"Unknown connector: {connector_id!r}"
-        ) from e
     except ConnectorsError as e:
         raise _raise_http_for(e) from e
     await _emitter.emit(

--- a/src/gaia/ui/routers/connectors.py
+++ b/src/gaia/ui/routers/connectors.py
@@ -978,7 +978,21 @@ async def cancel_flow_endpoint(flow_id: str) -> Response:
 async def put_grant(
     connector_id: str, agent_id: str, body: GrantRequest
 ) -> Dict[str, Any]:
-    grant_agent(connector_id, agent_id, body.scopes)
+    """Write the per-agent grant ledger for ``(connector_id, agent_id)``.
+
+    ``grants.grant_agent`` owns both authorization gates — unknown connector
+    and out-of-ceiling scopes — so this route and the CLI cannot drift. Here we
+    only translate them: 404 for the unknown id, and the same 400
+    ``scope_not_allowed`` body the authorize route already returns.
+    """
+    try:
+        grant_agent(connector_id, agent_id, body.scopes)
+    except KeyError as e:
+        raise HTTPException(
+            status_code=404, detail=f"Unknown connector: {connector_id!r}"
+        ) from e
+    except ConnectorsError as e:
+        raise _raise_http_for(e) from e
     await _emitter.emit(
         "connector.grant.changed",
         {"connector_id": connector_id, "agent_id": agent_id, "scopes": body.scopes},

--- a/src/gaia/web/tavily.py
+++ b/src/gaia/web/tavily.py
@@ -112,17 +112,29 @@ def _load_api_key() -> Optional[str]:
     module doesn't pull in ``keyring``; if ``keyring`` isn't installed at all
     (it lives in the ``[ui]`` extras), the connector can't have been configured,
     so we treat that as "not configured" rather than crashing.
+
+    A CONFIGURED connector the calling agent has no grant for is a different
+    thing entirely and raises ``AuthRequiredError`` naming the missing scope —
+    the user has to grant it, and quietly downgrading to DuckDuckGo would hide
+    that. Outside an agent turn (``gaia knowledge``) there is no identity to
+    check and the key resolves as before.
     """
     try:
+        from gaia.connectors import current_agent_id
         from gaia.connectors.handler import get_credential_sync
         from gaia.connectors.mcp_server import is_mcp_server_configured
+        from gaia.connectors.spec import MCP_SERVER_SCOPES
     except ImportError as e:
         log.info("Connector subsystem unavailable (%s); using DuckDuckGo.", e)
         return None
 
     if not is_mcp_server_configured(_CONNECTOR_ID):
         return None
-    cred = get_credential_sync(_CONNECTOR_ID)
+    cred = get_credential_sync(
+        _CONNECTOR_ID,
+        agent_id=current_agent_id(),
+        required_scopes=list(MCP_SERVER_SCOPES),
+    )
     return cred["env"][_API_KEY_ENV]
 
 
@@ -134,15 +146,21 @@ async def _load_api_key_async() -> Optional[str]:
     async client uses this so its constructor never blocks the loop.
     """
     try:
+        from gaia.connectors import current_agent_id
         from gaia.connectors.handler import get_credential
         from gaia.connectors.mcp_server import is_mcp_server_configured
+        from gaia.connectors.spec import MCP_SERVER_SCOPES
     except ImportError as e:
         log.info("Connector subsystem unavailable (%s); using DuckDuckGo.", e)
         return None
 
     if not is_mcp_server_configured(_CONNECTOR_ID):
         return None
-    cred = await get_credential(_CONNECTOR_ID)
+    cred = await get_credential(
+        _CONNECTOR_ID,
+        agent_id=current_agent_id(),
+        required_scopes=list(MCP_SERVER_SCOPES),
+    )
     return cred["env"][_API_KEY_ENV]
 
 

--- a/tests/integration/test_multi_caller_equivalence.py
+++ b/tests/integration/test_multi_caller_equivalence.py
@@ -51,7 +51,7 @@ def _seed_connection(google_provider):
         provider="google",
         account_email="multi-caller@example.com",
         refresh_token="multi-caller-refresh",
-        scopes=["gmail.readonly"],
+        scopes=["https://www.googleapis.com/auth/gmail.readonly"],
         client_id_hash=google_provider.client_id_hash,
     )
 
@@ -71,11 +71,17 @@ class TestSdkPath:
         _seed_connection(google)
 
         # SDK: grant_agent.
-        connections.grant_agent("google", "builtin:multi-test", ["gmail.readonly"])
+        connections.grant_agent(
+            "google",
+            "builtin:multi-test",
+            ["https://www.googleapis.com/auth/gmail.readonly"],
+        )
 
         # CLI sees the same grant.
         listing = connections.list_agent_grants("google")
-        assert listing == {"builtin:multi-test": ["gmail.readonly"]}
+        assert listing == {
+            "builtin:multi-test": ["https://www.googleapis.com/auth/gmail.readonly"]
+        }
 
         # UI sees the same connection metadata via the public API.
         rows = connections.list_connections()
@@ -85,7 +91,7 @@ class TestSdkPath:
         token = asyncio.run(
             connections.get_access_token(
                 provider="google",
-                scopes=["gmail.readonly"],
+                scopes=["https://www.googleapis.com/auth/gmail.readonly"],
                 agent_id="builtin:multi-test",
             )
         )
@@ -108,20 +114,22 @@ class TestCliPath:
                 "google",
                 "builtin:cli-test",
                 "--scopes",
-                "gmail.readonly",
+                "https://www.googleapis.com/auth/gmail.readonly",
             ]
         )
         assert rc == 0
 
         # SDK sees the grant the CLI wrote.
         listing = connections.list_agent_grants("google")
-        assert listing == {"builtin:cli-test": ["gmail.readonly"]}
+        assert listing == {
+            "builtin:cli-test": ["https://www.googleapis.com/auth/gmail.readonly"]
+        }
 
         # SDK can fetch a token under that agent_id.
         token = asyncio.run(
             connections.get_access_token(
                 provider="google",
-                scopes=["gmail.readonly"],
+                scopes=["https://www.googleapis.com/auth/gmail.readonly"],
                 agent_id="builtin:cli-test",
             )
         )
@@ -139,19 +147,21 @@ class TestUiPath:
         # UI: PUT /api/connectors/google/grants/builtin:ui-test
         resp = ui_api_client.put(
             "/api/connectors/google/grants/builtin:ui-test",
-            json={"scopes": ["gmail.readonly"]},
+            json={"scopes": ["https://www.googleapis.com/auth/gmail.readonly"]},
         )
         assert resp.status_code == 200, resp.text
 
         # CLI sees the grant.
         listing = connections.list_agent_grants("google")
-        assert listing == {"builtin:ui-test": ["gmail.readonly"]}
+        assert listing == {
+            "builtin:ui-test": ["https://www.googleapis.com/auth/gmail.readonly"]
+        }
 
         # SDK can fetch a token under the same agent_id.
         token = asyncio.run(
             connections.get_access_token(
                 provider="google",
-                scopes=["gmail.readonly"],
+                scopes=["https://www.googleapis.com/auth/gmail.readonly"],
                 agent_id="builtin:ui-test",
             )
         )
@@ -159,7 +169,11 @@ class TestUiPath:
 
         # And the UI status endpoint reflects it.
         status = ui_api_client.get("/api/connectors/google/grants").json()
-        assert status == {"grants": {"builtin:ui-test": ["gmail.readonly"]}}
+        assert status == {
+            "grants": {
+                "builtin:ui-test": ["https://www.googleapis.com/auth/gmail.readonly"]
+            }
+        }
 
 
 class TestThreeCallersAgreeOnConnection:

--- a/tests/unit/connectors/conftest.py
+++ b/tests/unit/connectors/conftest.py
@@ -45,6 +45,33 @@ def make_fake_agent_registry(nsid: str, connector_id: str, scopes: list[str]):
     )
 
 
+@pytest.fixture
+def register_ephemeral_spec(monkeypatch):
+    """Publish a test-local ``ConnectorSpec`` in the catalog for one test.
+
+    ``grants.grant_agent`` resolves the catalog before writing (#915), so a
+    test that grants against a spec it constructed in-line has to publish it
+    first — an id nothing publishes is exactly the phantom-ledger-key case the
+    guard exists to reject.
+
+    A copy of the real registry is swapped in, so the ephemeral entry cannot
+    leak into another test through the process-level singleton.
+    """
+    import gaia.connectors.catalog  # noqa: F401  # pylint: disable=unused-import
+    from gaia.connectors.registry import REGISTRY, ConnectorRegistry
+
+    fresh = ConnectorRegistry()
+    for spec in REGISTRY.all():
+        fresh.register(spec)
+    monkeypatch.setattr("gaia.connectors.registry.REGISTRY", fresh)
+
+    def _register(spec):
+        fresh.register(spec)
+        return spec
+
+    return _register
+
+
 @pytest.fixture(autouse=True)
 def _autouse_in_memory_keyring(in_memory_keyring):  # noqa: F811
     """

--- a/tests/unit/connectors/test_activation_api.py
+++ b/tests/unit/connectors/test_activation_api.py
@@ -49,6 +49,10 @@ def mcp_test_spec(monkeypatch):
             tier=1,
             type="mcp_server",
             description="Stub MCP server for api tests",
+            # Declared so grant_agent's ceiling (#915) accepts both scopes the
+            # auto-grant test asserts; a spec that declares none gets the
+            # implicit ("use",) default instead.
+            available_scopes=("use", "use:write"),
             mcp_command="true",
             mcp_args=(),
         )

--- a/tests/unit/connectors/test_agent_bridge.py
+++ b/tests/unit/connectors/test_agent_bridge.py
@@ -53,7 +53,7 @@ def seeded(google_provider):
         provider="google",
         account_email="alice@example.com",
         refresh_token="seed-rt",
-        scopes=["gmail.readonly"],
+        scopes=["https://www.googleapis.com/auth/gmail.readonly"],
         client_id_hash=google_provider.client_id_hash,
     )
     return google_provider
@@ -73,7 +73,9 @@ class TestThreadPoolBridge:
     @respx.mock
     def test_contextvar_propagates_via_asyncio_run(self, seeded):
         respx.post("https://oauth2.googleapis.com/token").mock(return_value=_ok_token())
-        grant_agent("google", "builtin:chat", ["gmail.readonly"])
+        grant_agent(
+            "google", "builtin:chat", ["https://www.googleapis.com/auth/gmail.readonly"]
+        )
 
         results: dict = {}
 
@@ -82,7 +84,8 @@ class TestThreadPoolBridge:
                 # Sanity: the ctx is set in this thread.
                 results["before"] = current_agent_id()
                 results["token"] = get_access_token_sync(
-                    provider="google", scopes=["gmail.readonly"]
+                    provider="google",
+                    scopes=["https://www.googleapis.com/auth/gmail.readonly"],
                 )
 
         with ThreadPoolExecutor(max_workers=2) as pool:
@@ -101,7 +104,10 @@ class TestThreadPoolBridge:
         def worker():
             with _agent_context("builtin:chat"):
                 try:
-                    get_access_token_sync(provider="google", scopes=["gmail.readonly"])
+                    get_access_token_sync(
+                        provider="google",
+                        scopes=["https://www.googleapis.com/auth/gmail.readonly"],
+                    )
                 except AuthRequiredError as e:
                     captured["err"] = e
 
@@ -118,7 +124,11 @@ class TestThreadPoolBridge:
     def test_kwarg_overrides_contextvar(self, seeded):
         # Plan: kwarg agent_id wins over the contextvar (explicit over implicit).
         respx.post("https://oauth2.googleapis.com/token").mock(return_value=_ok_token())
-        grant_agent("google", "explicit:agent", ["gmail.readonly"])
+        grant_agent(
+            "google",
+            "explicit:agent",
+            ["https://www.googleapis.com/auth/gmail.readonly"],
+        )
 
         results = {}
 
@@ -127,7 +137,7 @@ class TestThreadPoolBridge:
                 # Pass an explicit different agent_id — it must win.
                 results["token"] = get_access_token_sync(
                     provider="google",
-                    scopes=["gmail.readonly"],
+                    scopes=["https://www.googleapis.com/auth/gmail.readonly"],
                     agent_id="explicit:agent",
                 )
 
@@ -172,12 +182,15 @@ class TestSequentialAgentInvocations:
     @respx.mock
     def test_two_sequential_invocations_in_thread_pool(self, seeded):
         respx.post("https://oauth2.googleapis.com/token").mock(return_value=_ok_token())
-        grant_agent("google", "builtin:chat", ["gmail.readonly"])
+        grant_agent(
+            "google", "builtin:chat", ["https://www.googleapis.com/auth/gmail.readonly"]
+        )
 
         def worker():
             with _agent_context("builtin:chat"):
                 return get_access_token_sync(
-                    provider="google", scopes=["gmail.readonly"]
+                    provider="google",
+                    scopes=["https://www.googleapis.com/auth/gmail.readonly"],
                 )
 
         with ThreadPoolExecutor(max_workers=1) as pool:

--- a/tests/unit/connectors/test_agent_identity_boundary.py
+++ b/tests/unit/connectors/test_agent_identity_boundary.py
@@ -1,0 +1,245 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""
+The per-agent connector grant control (#915), end to end.
+
+Three regressions, one boundary. Each was independently enough to make the
+control do nothing:
+
+1. **Identity never reached the tool body.** ``Agent._call_tool_bounded``
+   runs every tool in a ``threading.Thread``, and a new thread starts with an
+   empty context — so the agent id ``process_query`` binds was ``None`` inside
+   every tool, and both credential paths read ``None`` as "no agent, skip the
+   check".
+2. **The ledger the check reads had no ceiling.** ``grants.grant_agent`` wrote
+   whatever scopes it was handed, for whatever connector id, so a check that
+   started working could be answered with scopes the connector never
+   advertised. Same ceiling ``flow._reject_scopes_outside_catalog`` applies to
+   the OAuth authorize path (#3247), pushed down so the CLI and the Agent UI
+   route cannot drift.
+3. **Tavily asked for nothing.** ``web/tavily.py`` named neither an agent nor
+   any scopes, and the dispatcher skips the check when scopes are missing — so
+   the API key stayed ungated even with (1) fixed.
+"""
+
+from __future__ import annotations
+
+import threading
+
+import pytest
+
+import gaia.connectors.catalog  # noqa: F401  # pylint: disable=unused-import
+from gaia.agents.base.agent import Agent
+from gaia.connectors.context import _agent_context, current_agent_id
+from gaia.connectors.errors import AuthRequiredError, ScopeNotAllowedError
+from gaia.connectors.grants import grant_agent, list_agent_grants
+from gaia.connectors.registry import REGISTRY
+
+_NSID = "builtin:grant-boundary-probe"
+_GMAIL_READ = "https://www.googleapis.com/auth/gmail.readonly"
+
+
+# ---------------------------------------------------------------------------
+# 1. Identity survives the tool-execution thread
+# ---------------------------------------------------------------------------
+
+
+class _ProbeAgent(Agent):
+    """Minimal stand-in: real ``process_query`` and real ``_execute_tool``,
+    with the LLM turn replaced by a single tool call."""
+
+    AGENT_ID = _NSID
+
+    def _get_system_prompt(self):
+        return "test"
+
+    def _register_tools(self):
+        pass
+
+
+def _make_probe_agent(tool_body):
+    agent = _ProbeAgent.__new__(_ProbeAgent)
+    # ``_tools_registry`` is a read-only property over ``_instance_tools``.
+    agent._instance_tools = {
+        "probe": {"function": tool_body, "description": "identity probe"}
+    }
+    agent._policy_refusal = lambda name, args: None
+    agent._tool_requires_confirmation = lambda name, args: False
+    agent._on_tool_invoked = lambda name: None
+    agent._fold_tool_usage = lambda name, result: None
+    agent._resolve_tool_timeout = lambda name: 10.0
+    agent._finish_turn_record = lambda answer, steps: None
+    agent._turn_recorder = None
+    return agent
+
+
+def test_tool_body_sees_the_identity_process_query_bound():
+    """The C1 regression. Before the fix this read ``None``: the tool ran in a
+    bare ``threading.Thread``, which starts with an empty context."""
+    seen = {}
+
+    def probe():
+        seen["agent_id"] = current_agent_id()
+        seen["thread"] = threading.current_thread().name
+        return {"status": "ok"}
+
+    agent = _make_probe_agent(probe)
+    agent._process_query_impl = lambda *a, **kw: agent._execute_tool("probe", {})
+
+    result = agent.process_query("go")
+
+    assert result == {"status": "ok"}
+    # Guard the guard: if the tool ever stops running in a worker thread this
+    # test would pass for the wrong reason.
+    assert seen["thread"] == "tool:probe"
+    assert seen["agent_id"] == _NSID
+
+
+def test_identity_is_unbound_again_after_the_turn():
+    """The context must not leak past ``process_query`` — a later CLI call
+    would otherwise be checked against a stale agent."""
+    agent = _make_probe_agent(lambda: {"status": "ok"})
+    agent._process_query_impl = lambda *a, **kw: agent._execute_tool("probe", {})
+    agent.process_query("go")
+    assert current_agent_id() is None
+
+
+# ---------------------------------------------------------------------------
+# 2. The ledger has a ceiling
+# ---------------------------------------------------------------------------
+
+
+class TestGrantScopeCeiling:
+    def test_scope_outside_available_scopes_is_rejected(self, tmp_path, monkeypatch):
+        monkeypatch.setattr("gaia.connectors.grants.Path.home", lambda: tmp_path)
+        outside = "https://mail.google.com/"
+        assert outside not in REGISTRY.get("google").available_scopes
+
+        with pytest.raises(ScopeNotAllowedError) as exc:
+            grant_agent("google", "installed:email", [outside])
+
+        assert exc.value.scopes == [outside]
+        assert exc.value.connector_id == "google"
+        # Nothing was persisted — a rejected grant must not half-write.
+        assert list_agent_grants("google") == {}
+
+    def test_scope_inside_available_scopes_is_written(self, tmp_path, monkeypatch):
+        monkeypatch.setattr("gaia.connectors.grants.Path.home", lambda: tmp_path)
+        grant_agent("google", "installed:email", [_GMAIL_READ])
+        assert list_agent_grants("google") == {"installed:email": [_GMAIL_READ]}
+
+    def test_unknown_connector_id_is_rejected(self, tmp_path, monkeypatch):
+        """A typo-d id used to return success and persist a phantom key."""
+        monkeypatch.setattr("gaia.connectors.grants.Path.home", lambda: tmp_path)
+        with pytest.raises(KeyError):
+            grant_agent("gooogle", "installed:email", [_GMAIL_READ])
+        assert list_agent_grants("gooogle") == {}
+
+    def test_mcp_server_ceiling_is_the_implicit_use_scope(self, tmp_path, monkeypatch):
+        monkeypatch.setattr("gaia.connectors.grants.Path.home", lambda: tmp_path)
+        grant_agent("mcp-tavily", _NSID, ["use"])
+        with pytest.raises(ScopeNotAllowedError):
+            grant_agent("mcp-tavily", _NSID, ["use", "admin"])
+
+
+class TestPutGrantRouteTranslation:
+    """The Agent UI route's half of the ceiling. ``test_router_connectors.py``
+    covers the same two cases through the real HTTP stack; those need a
+    ``TestClient``, which cannot start on Windows (review C41), so the handler
+    is called directly here to keep the contract verifiable on both platforms.
+    """
+
+    @staticmethod
+    def _put(connector_id, agent_id, scopes):
+        import asyncio
+
+        from gaia.ui.routers.connectors import GrantRequest, put_grant
+
+        return asyncio.run(
+            put_grant(connector_id, agent_id, GrantRequest(scopes=scopes))
+        )
+
+    @pytest.mark.allow_network
+    def test_out_of_ceiling_scope_is_400_scope_not_allowed(self, tmp_path, monkeypatch):
+        monkeypatch.setattr("gaia.connectors.grants.Path.home", lambda: tmp_path)
+        from fastapi import HTTPException
+
+        with pytest.raises(HTTPException) as exc:
+            self._put("google", "installed:email", ["https://mail.google.com/"])
+
+        assert exc.value.status_code == 400
+        assert exc.value.detail["error"] == "scope_not_allowed"
+        assert exc.value.detail["scopes"] == ["https://mail.google.com/"]
+        assert list_agent_grants("google") == {}
+
+    @pytest.mark.allow_network
+    def test_unknown_connector_is_404(self, tmp_path, monkeypatch):
+        monkeypatch.setattr("gaia.connectors.grants.Path.home", lambda: tmp_path)
+        from fastapi import HTTPException
+
+        with pytest.raises(HTTPException) as exc:
+            self._put("gooogle", "builtin:chat", [_GMAIL_READ])
+        assert exc.value.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# 3. Tavily's credential fetch is grant-checked
+# ---------------------------------------------------------------------------
+
+
+class TestTavilyKeyIsGated:
+    """``_load_api_key`` must hand the dispatcher an identity AND scopes —
+    the dispatcher skips the grant check when either is missing (I14)."""
+
+    @pytest.fixture
+    def configured_tavily(self, monkeypatch, tmp_path):
+        monkeypatch.setattr("gaia.connectors.grants.Path.home", lambda: tmp_path)
+        monkeypatch.setattr(
+            "gaia.connectors.mcp_server.is_mcp_server_configured", lambda cid: True
+        )
+
+        async def _fake_get_credential(spec, *, required_scopes=None, account_id=None):
+            return {"env": {"TAVILY_API_KEY": "tvly-secret"}}
+
+        from gaia.connectors import handler as handler_mod
+
+        class _FakeHandler:
+            get_credential = staticmethod(_fake_get_credential)
+
+            async def configure(self, spec, config):
+                return {}
+
+            async def disconnect(self, spec, *, account_id=None):
+                return None
+
+            async def health_check(self, spec):
+                return {"ok": True}
+
+        monkeypatch.setitem(handler_mod._HANDLER_REGISTRY, "mcp_server", _FakeHandler())
+
+    # asyncio's ProactorEventLoop self-pipe needs socket.socketpair(), which
+    # tests/unit/conftest.py's network guard blocks on Windows (review C41).
+    @pytest.mark.allow_network
+    def test_ungranted_agent_is_refused(self, configured_tavily):
+        from gaia.web.tavily import _load_api_key
+
+        with _agent_context(_NSID):
+            with pytest.raises(AuthRequiredError) as exc:
+                _load_api_key()
+        assert exc.value.reason is AuthRequiredError.Reason.AGENT_NOT_GRANTED
+        assert exc.value.provider == "mcp-tavily"
+
+    @pytest.mark.allow_network
+    def test_granted_agent_gets_the_key(self, configured_tavily):
+        from gaia.web.tavily import _load_api_key
+
+        grant_agent("mcp-tavily", _NSID, ["use"])
+        with _agent_context(_NSID):
+            assert _load_api_key() == "tvly-secret"
+
+    @pytest.mark.allow_network
+    def test_cli_caller_outside_an_agent_turn_is_unaffected(self, configured_tavily):
+        """``gaia knowledge`` has no agent identity and stays ungated."""
+        from gaia.web.tavily import _load_api_key
+
+        assert _load_api_key() == "tvly-secret"

--- a/tests/unit/connectors/test_agent_identity_boundary.py
+++ b/tests/unit/connectors/test_agent_identity_boundary.py
@@ -25,14 +25,24 @@ control do nothing:
 from __future__ import annotations
 
 import threading
+from types import SimpleNamespace
 
 import pytest
 
 import gaia.connectors.catalog  # noqa: F401  # pylint: disable=unused-import
 from gaia.agents.base.agent import Agent
 from gaia.connectors.context import _agent_context, current_agent_id
-from gaia.connectors.errors import AuthRequiredError, ScopeNotAllowedError
-from gaia.connectors.grants import grant_agent, list_agent_grants
+from gaia.connectors.errors import (
+    AuthRequiredError,
+    ScopeNotAllowedError,
+    UnknownConnectorError,
+)
+from gaia.connectors.grants import (
+    grant_agent,
+    list_agent_grants,
+    revoke_agent_grant,
+    revoke_all_grants_for,
+)
 from gaia.connectors.registry import REGISTRY
 
 _NSID = "builtin:grant-boundary-probe"
@@ -131,7 +141,7 @@ class TestGrantScopeCeiling:
     def test_unknown_connector_id_is_rejected(self, tmp_path, monkeypatch):
         """A typo-d id used to return success and persist a phantom key."""
         monkeypatch.setattr("gaia.connectors.grants.Path.home", lambda: tmp_path)
-        with pytest.raises(KeyError):
+        with pytest.raises(UnknownConnectorError):
             grant_agent("gooogle", "installed:email", [_GMAIL_READ])
         assert list_agent_grants("gooogle") == {}
 
@@ -140,6 +150,59 @@ class TestGrantScopeCeiling:
         grant_agent("mcp-tavily", _NSID, ["use"])
         with pytest.raises(ScopeNotAllowedError):
             grant_agent("mcp-tavily", _NSID, ["use", "admin"])
+
+
+class TestRevokeIsNeverCatalogGated:
+    """Only WIDENING is gated. Taking authority away has to work even for a
+    connector the catalog no longer publishes — otherwise dropping a connector
+    from the catalog strands grants that can never be cleared, which is a
+    security regression pointing the other way.
+    """
+
+    @pytest.fixture
+    def stranded_grant(self, tmp_path, monkeypatch):
+        """A ledger row for a connector that is no longer in the catalog."""
+        monkeypatch.setattr("gaia.connectors.grants.Path.home", lambda: tmp_path)
+        grant_agent("mcp-tavily", _NSID, ["use"])
+        grant_agent("mcp-github", "builtin:chat", ["use"])
+
+        from gaia.connectors.registry import REGISTRY as _REAL
+        from gaia.connectors.registry import ConnectorRegistry
+
+        # Drop mcp-tavily from the catalog, keeping everything else.
+        shrunk = ConnectorRegistry()
+        for spec in _REAL.all():
+            if spec.id != "mcp-tavily":
+                shrunk.register(spec)
+        monkeypatch.setattr("gaia.connectors.registry.REGISTRY", shrunk)
+
+        with pytest.raises(UnknownConnectorError):
+            grant_agent("mcp-tavily", _NSID, ["use"])  # widening IS refused
+
+    def test_revoke_agent_grant_still_clears_it(self, stranded_grant):
+        revoke_agent_grant("mcp-tavily", _NSID)
+        assert list_agent_grants("mcp-tavily") == {}
+
+    def test_revoke_all_grants_for_still_clears_it(self, stranded_grant):
+        assert revoke_all_grants_for("mcp-tavily") == [_NSID]
+        assert list_agent_grants("mcp-tavily") == {}
+        # And an unrelated connector is untouched.
+        assert list_agent_grants("mcp-github") == {"builtin:chat": ["use"]}
+
+
+class TestUnknownConnectorIsStructured:
+    """A bare ``KeyError`` from the registry reaches HTTP as a 500 and a CLI as
+    a traceback. Grant writes raise a typed error every surface can translate.
+    """
+
+    def test_grant_agent_raises_the_typed_error(self, tmp_path, monkeypatch):
+        monkeypatch.setattr("gaia.connectors.grants.Path.home", lambda: tmp_path)
+        with pytest.raises(UnknownConnectorError) as exc:
+            grant_agent("gooogle", "builtin:chat", [_GMAIL_READ])
+        assert exc.value.connector_id == "gooogle"
+        assert "google" in exc.value.known_ids
+        # Actionable: names the id, the catalog, and the command to inspect it.
+        assert "gaia connectors list" in str(exc.value)
 
 
 class TestPutGrantRouteTranslation:
@@ -180,6 +243,119 @@ class TestPutGrantRouteTranslation:
         with pytest.raises(HTTPException) as exc:
             self._put("gooogle", "builtin:chat", [_GMAIL_READ])
         assert exc.value.status_code == 404
+        # Structured, not a bare string — a raw KeyError here would be a 500.
+        assert exc.value.detail == {
+            "error": "unknown_connector",
+            "connector_id": "gooogle",
+        }
+
+
+class TestEveryCredentialDoorIsGuarded:
+    """Both entry points into the credential layer, checked the same way.
+
+    ``handler.get_credential`` covers the MCP/dispatcher path;
+    ``api._authorize_access`` covers the OAuth token path
+    (``get_access_token`` / ``_with_expiry`` and their sync wrappers all
+    funnel through it). Fixing one and leaving the other is how a control
+    stays bypassable: an agent that simply names no scopes would satisfy
+    ``check_agent_grant`` vacuously and get a full-capability token.
+    """
+
+    def test_token_path_refuses_a_scope_less_request(self, tmp_path, monkeypatch):
+        from gaia.connectors.api import _authorize_access
+        from gaia.connectors.errors import ConfigurationError
+
+        monkeypatch.setattr("gaia.connectors.grants.Path.home", lambda: tmp_path)
+        with pytest.raises(ConfigurationError) as exc:
+            _authorize_access(
+                provider="google",
+                scopes=[],
+                agent_id="builtin:chat",
+                account_email="default",
+            )
+        assert "named no scopes" in str(exc.value)
+
+    def test_token_path_still_checks_a_named_scope(self, tmp_path, monkeypatch):
+        from gaia.connectors.api import _authorize_access
+
+        monkeypatch.setattr("gaia.connectors.grants.Path.home", lambda: tmp_path)
+        with pytest.raises(AuthRequiredError) as exc:
+            _authorize_access(
+                provider="google",
+                scopes=[_GMAIL_READ],
+                agent_id="builtin:chat",
+                account_email="default",
+            )
+        assert exc.value.reason is AuthRequiredError.Reason.AGENT_NOT_GRANTED
+
+    def test_token_path_outside_a_turn_keeps_the_cli_escape_hatch(
+        self, tmp_path, monkeypatch
+    ):
+        """No agent id and no agent turn: the documented ungated path. It must
+        fail on the missing CONNECTION, never on the grant check."""
+        from gaia.connectors.api import _authorize_access
+
+        monkeypatch.setattr("gaia.connectors.grants.Path.home", lambda: tmp_path)
+        monkeypatch.setattr(
+            "gaia.connectors.api.get_provider",
+            lambda p: SimpleNamespace(client_id_hash="h", tenant=None),
+        )
+        monkeypatch.setattr(
+            "gaia.connectors.api.load_connection", lambda *a, **kw: None
+        )
+        with pytest.raises(AuthRequiredError) as exc:
+            _authorize_access(
+                provider="google",
+                scopes=[],
+                agent_id=None,
+                account_email="default",
+            )
+        assert exc.value.reason is AuthRequiredError.Reason.NOT_CONNECTED
+
+    def test_token_path_fails_closed_with_no_identity_in_a_turn(
+        self, tmp_path, monkeypatch
+    ):
+        from gaia.connectors.api import _authorize_access
+
+        monkeypatch.setattr("gaia.connectors.grants.Path.home", lambda: tmp_path)
+        with _agent_context(None):
+            with pytest.raises(AuthRequiredError) as exc:
+                _authorize_access(
+                    provider="google",
+                    scopes=[_GMAIL_READ],
+                    agent_id=None,
+                    account_email="default",
+                )
+        assert exc.value.reason is AuthRequiredError.Reason.AGENT_NOT_GRANTED
+        assert exc.value.agent_id is None
+
+    def test_identity_missing_error_does_not_tell_you_to_grant_nothing(self):
+        """ "Open Settings and grant it" is unfollowable when there is no agent
+        to grant TO — that branch names the dropped context instead."""
+        from gaia.connectors.formatting import format_connector_error
+
+        msg = format_connector_error(
+            AuthRequiredError(
+                AuthRequiredError.Reason.AGENT_NOT_GRANTED,
+                provider="google",
+                agent_id=None,
+                missing_scopes=[_GMAIL_READ],
+            )
+        )
+        assert "AGENT_IDENTITY_MISSING" in msg
+        assert "Per-agent grants" not in msg
+        assert "agent_id=" in msg  # names the actual remedy
+
+        # A real agent still gets the grant-me instruction.
+        granted_msg = format_connector_error(
+            AuthRequiredError(
+                AuthRequiredError.Reason.AGENT_NOT_GRANTED,
+                provider="google",
+                agent_id="builtin:chat",
+                missing_scopes=[_GMAIL_READ],
+            )
+        )
+        assert "Per-agent grants" in granted_msg
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/connectors/test_api.py
+++ b/tests/unit/connectors/test_api.py
@@ -160,12 +160,17 @@ class TestScopeCoverage:
 
 class TestPublicSurface:
     def test_grant_round_trip_via_public_api(self, google_provider):
-        grant_agent("google", "builtin:chat", ["gmail.readonly"])
+        # Full scope URLs: grant_agent enforces google's catalog ceiling
+        # (#915), so the short "gmail.readonly" shorthand is not grantable.
+        scope = "https://www.googleapis.com/auth/gmail.readonly"
+        grant_agent("google", "builtin:chat", [scope])
         listing = list_agent_grants("google")
-        assert listing["builtin:chat"] == ["gmail.readonly"]
+        assert listing["builtin:chat"] == [scope]
 
     def test_revoke_agent_grant_via_public_api(self, google_provider):
-        grant_agent("google", "builtin:chat", ["s"])
+        grant_agent(
+            "google", "builtin:chat", ["https://www.googleapis.com/auth/gmail.send"]
+        )
         revoke_agent_grant("google", "builtin:chat")
         assert list_agent_grants("google") == {}
 

--- a/tests/unit/connectors/test_api.py
+++ b/tests/unit/connectors/test_api.py
@@ -54,7 +54,7 @@ def seeded(google_provider):
         provider="google",
         account_email="alice@example.com",
         refresh_token="seed-rt",
-        scopes=["gmail.readonly"],
+        scopes=["https://www.googleapis.com/auth/gmail.readonly"],
         client_id_hash=google_provider.client_id_hash,
     )
     return google_provider
@@ -71,10 +71,12 @@ class TestGetAccessTokenAgentResolution:
     @respx.mock
     async def test_explicit_agent_id_kwarg_used_directly(self, seeded):
         respx.post("https://oauth2.googleapis.com/token").mock(return_value=_ok_token())
-        grant_agent("google", "builtin:chat", ["gmail.readonly"])
+        grant_agent(
+            "google", "builtin:chat", ["https://www.googleapis.com/auth/gmail.readonly"]
+        )
         token = await get_access_token(
             provider="google",
-            scopes=["gmail.readonly"],
+            scopes=["https://www.googleapis.com/auth/gmail.readonly"],
             agent_id="builtin:chat",
         )
         assert token == "ACCESS-1"
@@ -82,9 +84,14 @@ class TestGetAccessTokenAgentResolution:
     @respx.mock
     async def test_agent_id_resolved_from_contextvar(self, seeded):
         respx.post("https://oauth2.googleapis.com/token").mock(return_value=_ok_token())
-        grant_agent("google", "builtin:chat", ["gmail.readonly"])
+        grant_agent(
+            "google", "builtin:chat", ["https://www.googleapis.com/auth/gmail.readonly"]
+        )
         with _agent_context("builtin:chat"):
-            token = await get_access_token(provider="google", scopes=["gmail.readonly"])
+            token = await get_access_token(
+                provider="google",
+                scopes=["https://www.googleapis.com/auth/gmail.readonly"],
+            )
         assert token == "ACCESS-1"
 
     @respx.mock
@@ -94,7 +101,9 @@ class TestGetAccessTokenAgentResolution:
         # it's documented and tested.
         respx.post("https://oauth2.googleapis.com/token").mock(return_value=_ok_token())
         token = await get_access_token(
-            provider="google", scopes=["gmail.readonly"], agent_id=None
+            provider="google",
+            scopes=["https://www.googleapis.com/auth/gmail.readonly"],
+            agent_id=None,
         )
         assert token == "ACCESS-1"
 
@@ -106,7 +115,7 @@ class TestGrantEnforcement:
         with pytest.raises(AuthRequiredError) as exc:
             await get_access_token(
                 provider="google",
-                scopes=["gmail.readonly"],
+                scopes=["https://www.googleapis.com/auth/gmail.readonly"],
                 agent_id="builtin:chat",
             )
         assert exc.value.reason is AuthRequiredError.Reason.AGENT_NOT_GRANTED
@@ -117,11 +126,13 @@ class TestGrantEnforcement:
     async def test_partial_grant_raises_agent_not_granted(self, seeded):
         # Agent granted only readonly; tool requests send too.
         respx.post("https://oauth2.googleapis.com/token").mock(return_value=_ok_token())
-        grant_agent("google", "builtin:chat", ["gmail.readonly"])
+        grant_agent(
+            "google", "builtin:chat", ["https://www.googleapis.com/auth/gmail.readonly"]
+        )
         with pytest.raises(AuthRequiredError) as exc:
             await get_access_token(
                 provider="google",
-                scopes=["gmail.send"],
+                scopes=["https://www.googleapis.com/auth/gmail.send"],
                 agent_id="builtin:chat",
             )
         assert exc.value.reason is AuthRequiredError.Reason.AGENT_NOT_GRANTED
@@ -135,33 +146,38 @@ class TestScopeCoverage:
             provider="google",
             account_email="a@example.com",
             refresh_token="rt",
-            scopes=["gmail.readonly"],
+            scopes=["https://www.googleapis.com/auth/gmail.readonly"],
             client_id_hash=google_provider.client_id_hash,
         )
         # Agent IS granted gmail.send, but the OAuth connection is not.
-        grant_agent("google", "builtin:chat", ["gmail.send"])
+        grant_agent(
+            "google", "builtin:chat", ["https://www.googleapis.com/auth/gmail.send"]
+        )
 
         respx.post("https://oauth2.googleapis.com/token").mock(return_value=_ok_token())
         with pytest.raises(AuthRequiredError) as exc:
             await get_access_token(
                 provider="google",
-                scopes=["gmail.send"],
+                scopes=["https://www.googleapis.com/auth/gmail.send"],
                 agent_id="builtin:chat",
             )
         assert exc.value.reason is AuthRequiredError.Reason.CONNECTION_MISSING_SCOPES
-        assert "gmail.send" in exc.value.missing_scopes
+        assert "https://www.googleapis.com/auth/gmail.send" in exc.value.missing_scopes
         # #2730 D0/AC-9a: the remedy command must be the connection's real
         # current scopes UNIONED with what's missing — never just the
         # missing subset (--scopes replaces rather than adds) and never a
         # <scope> placeholder.
-        assert set(exc.value.full_scopes) == {"gmail.readonly", "gmail.send"}
+        assert set(exc.value.full_scopes) == {
+            "https://www.googleapis.com/auth/gmail.readonly",
+            "https://www.googleapis.com/auth/gmail.send",
+        }
         assert "<scope" not in str(exc.value)
 
 
 class TestPublicSurface:
     def test_grant_round_trip_via_public_api(self, google_provider):
         # Full scope URLs: grant_agent enforces google's catalog ceiling
-        # (#915), so the short "gmail.readonly" shorthand is not grantable.
+        # (#915), so the short "https://www.googleapis.com/auth/gmail.readonly" shorthand is not grantable.
         scope = "https://www.googleapis.com/auth/gmail.readonly"
         grant_agent("google", "builtin:chat", [scope])
         listing = list_agent_grants("google")
@@ -203,7 +219,7 @@ class TestPublicSurface:
             provider="microsoft",
             account_email="user@outlook.com",
             refresh_token="ms-rt",
-            scopes=["Mail.ReadWrite"],
+            scopes=["https://graph.microsoft.com/Mail.ReadWrite"],
             client_id_hash=ms.client_id_hash,
         )
 
@@ -226,7 +242,7 @@ class TestPublicSurface:
             provider="microsoft",
             account_email="user@outlook.com",
             refresh_token="ms-rt",
-            scopes=["Mail.ReadWrite"],
+            scopes=["https://graph.microsoft.com/Mail.ReadWrite"],
             client_id_hash=ms.client_id_hash,
         )
         providers = {row["provider"] for row in list_connections()}
@@ -249,7 +265,7 @@ class TestTenantMismatchThreading:
             provider="microsoft",
             account_email="user@outlook.com",
             refresh_token="ms-rt",
-            scopes=["Mail.ReadWrite"],
+            scopes=["https://graph.microsoft.com/Mail.ReadWrite"],
             client_id_hash=ms.client_id_hash,
             tenant=tenant,
         )
@@ -260,9 +276,16 @@ class TestTenantMismatchThreading:
             monkeypatch, tmp_path, "organizations"
         )
         with _agent_context("installed:email"):
-            grant_agent("microsoft", "installed:email", ["Mail.ReadWrite"])
+            grant_agent(
+                "microsoft",
+                "installed:email",
+                ["https://graph.microsoft.com/Mail.ReadWrite"],
+            )
             with pytest.raises(AuthRequiredError) as exc:
-                await get_access_token(provider="microsoft", scopes=["Mail.ReadWrite"])
+                await get_access_token(
+                    provider="microsoft",
+                    scopes=["https://graph.microsoft.com/Mail.ReadWrite"],
+                )
         assert exc.value.reason is AuthRequiredError.Reason.TENANT_MISMATCH
 
     def test_authorize_access_itself_raises_eagerly(self, monkeypatch, tmp_path):
@@ -278,7 +301,7 @@ class TestTenantMismatchThreading:
         with pytest.raises(AuthRequiredError) as exc:
             _authorize_access(
                 provider="microsoft",
-                scopes=["Mail.ReadWrite"],
+                scopes=["https://graph.microsoft.com/Mail.ReadWrite"],
                 agent_id=None,
                 account_email="default",
             )

--- a/tests/unit/connectors/test_cli.py
+++ b/tests/unit/connectors/test_cli.py
@@ -376,14 +376,14 @@ class TestGrants:
             "google",
             "builtin:chat",
             "--scopes",
-            "gmail.readonly",
+            "https://www.googleapis.com/auth/gmail.readonly",
         )
         assert rc == 0
 
         rc2, out2, _err2 = _run("connectors", "grants", "list", "google")
         assert rc2 == 0
         assert "builtin:chat" in out2
-        assert "gmail.readonly" in out2
+        assert "https://www.googleapis.com/auth/gmail.readonly" in out2
 
     def test_grants_revoke(self):
         _run(
@@ -393,7 +393,7 @@ class TestGrants:
             "google",
             "builtin:chat",
             "--scopes",
-            "gmail.readonly",
+            "https://www.googleapis.com/auth/gmail.readonly",
         )
         rc, _out, _err = _run(
             "connectors", "grants", "revoke", "google", "builtin:chat"

--- a/tests/unit/connectors/test_disconnect_clears_activations.py
+++ b/tests/unit/connectors/test_disconnect_clears_activations.py
@@ -68,7 +68,9 @@ def test_revoke_all_activations_for_unknown_id_is_noop(home_in_tmp):
 
 
 @pytest.mark.asyncio
-async def test_mcp_server_disconnect_clears_activations(home_in_tmp, tmp_path):
+async def test_mcp_server_disconnect_clears_activations(
+    home_in_tmp, tmp_path, register_ephemeral_spec
+):
     """
     End-to-end: configure → grant → activate → disconnect → assert both
     grants and activations are empty. Re-configure with the same id and
@@ -97,6 +99,9 @@ async def test_mcp_server_disconnect_clears_activations(home_in_tmp, tmp_path):
             ),
         ),
     )
+    # Published in the catalog for this test: grant_agent resolves the
+    # connector before writing (#915).
+    register_ephemeral_spec(spec)
 
     with patch("gaia.connectors.mcp_server._mcp_servers_path") as mock_path:
         mock_path.return_value = tmp_path / ".gaia" / "mcp_servers.json"
@@ -132,7 +137,9 @@ async def test_mcp_server_disconnect_clears_activations(home_in_tmp, tmp_path):
 
 
 @pytest.mark.asyncio
-async def test_oauth_pkce_disconnect_clears_activations(home_in_tmp, monkeypatch):
+async def test_oauth_pkce_disconnect_clears_activations(
+    home_in_tmp, monkeypatch, register_ephemeral_spec
+):
     """OAuth-pkce disconnect must wipe activations alongside grants."""
     from gaia.connectors.oauth_pkce import OAuthPkceHandler
 
@@ -155,8 +162,14 @@ async def test_oauth_pkce_disconnect_clears_activations(home_in_tmp, monkeypatch
         tier=1,
         type="oauth_pkce",
         description="ephemeral",
+        # An OAuth spec's ceiling IS its available_scopes, so it has to
+        # advertise the scope the test grants (#915).
+        available_scopes=("scope.read",),
         oauth_provider_ref="oauth-activation-test",
     )
+    # Published in the catalog for this test: grant_agent resolves the
+    # connector before writing (#915).
+    register_ephemeral_spec(spec)
 
     grant_agent(spec.id, "agent-A", ["scope.read"])
     activate_agent(spec.id, "agent-A")

--- a/tests/unit/connectors/test_disconnect_clears_grants.py
+++ b/tests/unit/connectors/test_disconnect_clears_grants.py
@@ -65,7 +65,9 @@ def test_revoke_all_grants_for_unknown_id_is_noop(grants_in_tmp):
 
 
 @pytest.mark.asyncio
-async def test_mcp_server_disconnect_revokes_grants(grants_in_tmp, tmp_path):
+async def test_mcp_server_disconnect_revokes_grants(
+    grants_in_tmp, tmp_path, register_ephemeral_spec
+):
     """
     End-to-end: configure → grant → disconnect → assert grants empty.
     Re-configure with the same id and assert grants are still empty
@@ -94,6 +96,9 @@ async def test_mcp_server_disconnect_revokes_grants(grants_in_tmp, tmp_path):
             ),
         ),
     )
+    # Published in the catalog for this test: grant_agent resolves the
+    # connector before writing (#915).
+    register_ephemeral_spec(spec)
 
     # Redirect ~/.gaia for the mcp_server module too.
     monkey_home = tmp_path
@@ -123,7 +128,9 @@ async def test_mcp_server_disconnect_revokes_grants(grants_in_tmp, tmp_path):
 
 
 @pytest.mark.asyncio
-async def test_oauth_pkce_disconnect_revokes_grants(grants_in_tmp, monkeypatch):
+async def test_oauth_pkce_disconnect_revokes_grants(
+    grants_in_tmp, monkeypatch, register_ephemeral_spec
+):
     """OAuth-pkce disconnect must also wipe grants for the connector_id."""
     from gaia.connectors.oauth_pkce import OAuthPkceHandler
 
@@ -150,8 +157,14 @@ async def test_oauth_pkce_disconnect_revokes_grants(grants_in_tmp, monkeypatch):
         tier=1,
         type="oauth_pkce",
         description="ephemeral",
+        # An OAuth spec's ceiling IS its available_scopes, so it has to
+        # advertise the scope the test grants (#915).
+        available_scopes=("scope.read",),
         oauth_provider_ref="oauth-test",
     )
+    # Published in the catalog for this test: grant_agent resolves the
+    # connector before writing (#915).
+    register_ephemeral_spec(spec)
 
     grant_agent(spec.id, "agent-A", ["scope.read"])
     grant_agent(spec.id, "agent-B", ["scope.read"])

--- a/tests/unit/connectors/test_disconnect_clears_grants.py
+++ b/tests/unit/connectors/test_disconnect_clears_grants.py
@@ -42,26 +42,26 @@ def grants_in_tmp(tmp_path, monkeypatch):
 
 
 def test_revoke_all_grants_for_clears_every_agent(grants_in_tmp):
-    grant_agent("mcp-test", "agent-A", ["use"])
-    grant_agent("mcp-test", "agent-B", ["use"])
-    grant_agent("mcp-other", "agent-A", ["use"])
+    grant_agent("mcp-github", "agent-A", ["use"])
+    grant_agent("mcp-github", "agent-B", ["use"])
+    grant_agent("mcp-git", "agent-A", ["use"])
 
-    revoked = revoke_all_grants_for("mcp-test")
+    revoked = revoke_all_grants_for("mcp-github")
     assert sorted(revoked) == ["agent-A", "agent-B"]
 
-    # mcp-test grants are gone.
-    assert list_agent_grants("mcp-test") == {}
-    # mcp-other is unaffected.
-    assert list_agent_grants("mcp-other") == {"agent-A": ["use"]}
+    # mcp-github grants are gone.
+    assert list_agent_grants("mcp-github") == {}
+    # mcp-git is unaffected.
+    assert list_agent_grants("mcp-git") == {"agent-A": ["use"]}
 
 
 def test_revoke_all_grants_for_unknown_id_is_noop(grants_in_tmp):
-    grant_agent("mcp-test", "agent-A", ["use"])
+    grant_agent("mcp-github", "agent-A", ["use"])
 
     revoked = revoke_all_grants_for("nonexistent")
     assert revoked == []
-    # mcp-test untouched.
-    assert list_agent_grants("mcp-test") == {"agent-A": ["use"]}
+    # mcp-github untouched.
+    assert list_agent_grants("mcp-github") == {"agent-A": ["use"]}
 
 
 @pytest.mark.asyncio

--- a/tests/unit/connectors/test_grants.py
+++ b/tests/unit/connectors/test_grants.py
@@ -33,6 +33,13 @@ from gaia.connectors.grants import (
     revoke_agent_grant,
 )
 
+# Real catalog scopes. ``grant_agent`` enforces the connector's own ceiling
+# (#915), so a synthetic S1 is no longer a grantable scope anywhere — these
+# ledger tests need three distinct scopes google actually advertises.
+S1 = "https://www.googleapis.com/auth/gmail.readonly"
+S2 = "https://www.googleapis.com/auth/gmail.send"
+S3 = "https://www.googleapis.com/auth/gmail.modify"
+
 
 @pytest.fixture
 def fake_home(tmp_path, monkeypatch):
@@ -46,20 +53,20 @@ def _grants_path(home):
 
 class TestPathAndMode:
     def test_grant_creates_file_at_correct_path(self, fake_home):
-        grant_agent("google", "builtin:chat", ["s1"])
+        grant_agent("google", "builtin:chat", [S1])
         path = _grants_path(fake_home)
         assert path.exists()
 
     @pytest.mark.skipif(sys.platform == "win32", reason="POSIX modes only")
     def test_file_mode_0600(self, fake_home):
-        grant_agent("google", "builtin:chat", ["s1"])
+        grant_agent("google", "builtin:chat", [S1])
         path = _grants_path(fake_home)
         mode = os.stat(path).st_mode & 0o777
         assert mode == 0o600
 
     @pytest.mark.skipif(sys.platform == "win32", reason="POSIX modes only")
     def test_parent_dir_mode_0700(self, fake_home):
-        grant_agent("google", "builtin:chat", ["s1"])
+        grant_agent("google", "builtin:chat", [S1])
         path = _grants_path(fake_home)
         mode = os.stat(path.parent).st_mode & 0o777
         assert mode == 0o700
@@ -74,34 +81,34 @@ class TestPathAndMode:
 
 class TestRoundTrip:
     def test_grant_then_list(self, fake_home):
-        grant_agent("google", "builtin:chat", ["s1", "s2"])
+        grant_agent("google", "builtin:chat", [S1, S2])
         listing = list_agent_grants("google")
-        assert listing == {"builtin:chat": ["s1", "s2"]}
+        assert listing == {"builtin:chat": [S1, S2]}
 
     def test_two_agents_independent(self, fake_home):
-        grant_agent("google", "builtin:chat", ["s1"])
-        grant_agent("google", "custom:abc:inbox", ["s2"])
+        grant_agent("google", "builtin:chat", [S1])
+        grant_agent("google", "custom:abc:inbox", [S2])
         listing = list_agent_grants("google")
         assert listing == {
-            "builtin:chat": ["s1"],
-            "custom:abc:inbox": ["s2"],
+            "builtin:chat": [S1],
+            "custom:abc:inbox": [S2],
         }
 
     def test_revoke_removes_only_target(self, fake_home):
-        grant_agent("google", "builtin:chat", ["s1"])
-        grant_agent("google", "custom:abc:inbox", ["s2"])
+        grant_agent("google", "builtin:chat", [S1])
+        grant_agent("google", "custom:abc:inbox", [S2])
         revoke_agent_grant("google", "builtin:chat")
         listing = list_agent_grants("google")
-        assert listing == {"custom:abc:inbox": ["s2"]}
+        assert listing == {"custom:abc:inbox": [S2]}
 
     def test_revoke_unknown_is_idempotent(self, fake_home):
         revoke_agent_grant("google", "nonexistent")  # must not raise
 
     def test_grant_overwrites_prior_scopes(self, fake_home):
-        grant_agent("google", "builtin:chat", ["s1"])
-        grant_agent("google", "builtin:chat", ["s2", "s3"])
+        grant_agent("google", "builtin:chat", [S1])
+        grant_agent("google", "builtin:chat", [S2, S3])
         listing = list_agent_grants("google")
-        assert listing == {"builtin:chat": ["s2", "s3"]}
+        assert listing == {"builtin:chat": [S2, S3]}
 
     def test_load_grants_empty_when_no_file(self, fake_home):
         assert load_grants() == {}
@@ -109,26 +116,26 @@ class TestRoundTrip:
 
 class TestCheckGrant:
     def test_no_grant_returns_false(self, fake_home):
-        assert check_agent_grant("google", "builtin:chat", ["s1"]) is False
+        assert check_agent_grant("google", "builtin:chat", [S1]) is False
 
     def test_exact_scope_match_returns_true(self, fake_home):
-        grant_agent("google", "builtin:chat", ["s1"])
-        assert check_agent_grant("google", "builtin:chat", ["s1"]) is True
+        grant_agent("google", "builtin:chat", [S1])
+        assert check_agent_grant("google", "builtin:chat", [S1]) is True
 
     def test_superset_grant_covers_subset_required(self, fake_home):
-        grant_agent("google", "builtin:chat", ["s1", "s2"])
-        assert check_agent_grant("google", "builtin:chat", ["s1"]) is True
+        grant_agent("google", "builtin:chat", [S1, S2])
+        assert check_agent_grant("google", "builtin:chat", [S1]) is True
 
     def test_missing_one_scope_returns_false(self, fake_home):
-        grant_agent("google", "builtin:chat", ["s1"])
-        assert check_agent_grant("google", "builtin:chat", ["s1", "s2"]) is False
+        grant_agent("google", "builtin:chat", [S1])
+        assert check_agent_grant("google", "builtin:chat", [S1, S2]) is False
 
 
 class TestAtomicity:
     def test_atomic_replace_does_not_leave_tempfile(self, fake_home):
         # tempfile.mkstemp + os.replace must not leave any .grants_*.tmp
         # files in the connections dir after a successful write.
-        grant_agent("google", "builtin:chat", ["s1"])
+        grant_agent("google", "builtin:chat", [S1])
         connections_dir = _grants_path(fake_home).parent
         leftovers = [p.name for p in connections_dir.iterdir() if p.suffix == ".tmp"]
         assert leftovers == [], f"unexpected tempfile leftovers: {leftovers}"
@@ -178,17 +185,17 @@ class TestNamespacedAgentIds:
     (``builtin:chat`` vs ``custom:abc:chat``)."""
 
     def test_builtin_and_custom_with_same_aid_are_separate(self, fake_home):
-        grant_agent("google", "builtin:chat", ["builtin-scope"])
-        grant_agent("google", "custom:abc:chat", ["custom-scope"])
+        grant_agent("google", "builtin:chat", [S1])
+        grant_agent("google", "custom:abc:chat", [S2])
         listing = list_agent_grants("google")
         assert listing == {
-            "builtin:chat": ["builtin-scope"],
-            "custom:abc:chat": ["custom-scope"],
+            "builtin:chat": [S1],
+            "custom:abc:chat": [S2],
         }
 
     def test_revoke_one_does_not_affect_other(self, fake_home):
-        grant_agent("google", "builtin:chat", ["b"])
-        grant_agent("google", "custom:abc:chat", ["c"])
+        grant_agent("google", "builtin:chat", [S1])
+        grant_agent("google", "custom:abc:chat", [S2])
         revoke_agent_grant("google", "custom:abc:chat")
         listing = list_agent_grants("google")
         assert "builtin:chat" in listing

--- a/tests/unit/connectors/test_grants.py
+++ b/tests/unit/connectors/test_grants.py
@@ -143,21 +143,27 @@ class TestAtomicity:
     def test_concurrent_grants_do_not_corrupt(self, fake_home):
         # Run many grants concurrently from one event loop. The per-process
         # asyncio.Lock prevents interleaved writes from clobbering each other.
+        # Scopes cycle through google's real catalog entry — grant_agent
+        # enforces the connector's ceiling (#915), and what this test needs is
+        # 20 distinct AGENTS, not 20 distinct scopes.
+        import gaia.connectors.catalog  # noqa: F401  # pylint: disable=unused-import
+        from gaia.connectors.registry import REGISTRY
+
+        catalog_scopes = list(REGISTRY.get("google").available_scopes)
+        expected = {
+            f"agent_{i}": [catalog_scopes[i % len(catalog_scopes)]] for i in range(20)
+        }
+
         async def driver():
             await asyncio.gather(
                 *[
-                    asyncio.to_thread(
-                        grant_agent, "google", f"agent_{i}", [f"scope_{i}"]
-                    )
-                    for i in range(20)
+                    asyncio.to_thread(grant_agent, "google", agent_id, scopes)
+                    for agent_id, scopes in expected.items()
                 ]
             )
 
         asyncio.run(driver())
-        listing = list_agent_grants("google")
-        assert len(listing) == 20
-        for i in range(20):
-            assert listing[f"agent_{i}"] == [f"scope_{i}"]
+        assert list_agent_grants("google") == expected
 
 
 class TestCorruptedFileRecovery:

--- a/tests/unit/connectors/test_handler.py
+++ b/tests/unit/connectors/test_handler.py
@@ -8,6 +8,7 @@ Tests cover:
 - Dispatcher raises ConnectorsError when no handler is registered
 - Dispatcher routes to registered handler
 - Grant check blocks unauthorized agents
+- Grant check FAILS CLOSED inside an agent turn with no resolvable identity
 - get_credential_sync raises in a running event loop
 """
 
@@ -15,6 +16,7 @@ from __future__ import annotations
 
 import pytest
 
+from gaia.connectors.context import _agent_context
 from gaia.connectors.errors import AuthRequiredError, ConnectorsError
 from gaia.connectors.handler import (
     _HANDLER_REGISTRY,
@@ -56,6 +58,9 @@ def google_spec(isolated_registries):
         type="oauth_pkce",
         description="Google OAuth",
         default_scopes=("openid",),
+        # The grant ceiling (#915). Without it the dispatcher cannot verify a
+        # scope-less request and refuses it outright.
+        available_scopes=("openid",),
     )
     isolated_registries.register(spec)
     return spec
@@ -158,10 +163,44 @@ class TestGetCredentialDispatcher:
         assert "openid" in exc_info.value.missing_scopes
 
     @pytest.mark.asyncio
-    async def test_no_agent_id_skips_grant_check(self, google_spec):
+    async def test_no_agent_id_outside_an_agent_turn_skips_grant_check(
+        self, google_spec
+    ):
+        """The documented CLI/SDK escape hatch: no agent turn, no identity to
+        check, credential returned."""
         register_handler("oauth_pkce", FakeOAuthHandler())
         result = await get_credential("google", required_scopes=["openid"])
         assert result["access_token"] == "fake-token"
+
+    # asyncio's ProactorEventLoop self-pipe needs socket.socketpair(), which
+    # tests/unit/conftest.py's network guard blocks on Windows (review C41).
+    @pytest.mark.allow_network
+    @pytest.mark.asyncio
+    async def test_no_agent_id_inside_an_agent_turn_fails_closed(self, google_spec):
+        """#915: inside an agent turn a missing identity means the context was
+        dropped (the pre-fix bare-thread bug), NOT that the caller opted out.
+        Returning the credential there is what made the grant control dead."""
+        register_handler("oauth_pkce", FakeOAuthHandler())
+        with _agent_context(None):
+            with pytest.raises(AuthRequiredError) as exc_info:
+                await get_credential("google", required_scopes=["openid"])
+        assert exc_info.value.reason is AuthRequiredError.Reason.AGENT_NOT_GRANTED
+        assert exc_info.value.agent_id is None
+
+    # asyncio's ProactorEventLoop self-pipe needs socket.socketpair(), which
+    # tests/unit/conftest.py's network guard blocks on Windows (review C41).
+    @pytest.mark.allow_network
+    @pytest.mark.asyncio
+    async def test_omitted_required_scopes_still_checks_the_grant(
+        self, google_spec, monkeypatch, tmp_path
+    ):
+        """A caller that names no scopes must not thereby skip the check —
+        the ceiling stands in, so an ungranted agent is still refused (#915)."""
+        monkeypatch.setattr("gaia.connectors.grants.Path.home", lambda: tmp_path)
+        register_handler("oauth_pkce", FakeOAuthHandler())
+        with pytest.raises(AuthRequiredError) as exc_info:
+            await get_credential("google", agent_id="builtin:chat")
+        assert exc_info.value.reason is AuthRequiredError.Reason.AGENT_NOT_GRANTED
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/connectors/test_loop_bridge.py
+++ b/tests/unit/connectors/test_loop_bridge.py
@@ -58,7 +58,7 @@ def seeded(google_provider):
         provider="google",
         account_email="alice@example.com",
         refresh_token="seed-rt",
-        scopes=["gmail.readonly"],
+        scopes=["https://www.googleapis.com/auth/gmail.readonly"],
         client_id_hash=google_provider.client_id_hash,
     )
     return google_provider
@@ -94,7 +94,9 @@ class TestNoLockBoundToOtherLoop:
         """Force two refreshes from worker threads — each expires the cache
         between calls.  Must succeed on both, no cross-loop RuntimeError."""
         respx.post("https://oauth2.googleapis.com/token").mock(return_value=_ok_token())
-        grant_agent("google", "builtin:chat", ["gmail.readonly"])
+        grant_agent(
+            "google", "builtin:chat", ["https://www.googleapis.com/auth/gmail.readonly"]
+        )
 
         errors: list[Exception] = []
         tokens: list[str] = []
@@ -103,7 +105,8 @@ class TestNoLockBoundToOtherLoop:
             with _agent_context("builtin:chat"):
                 try:
                     tok = get_access_token_sync(
-                        provider="google", scopes=["gmail.readonly"]
+                        provider="google",
+                        scopes=["https://www.googleapis.com/auth/gmail.readonly"],
                     )
                     tokens.append(tok)
                 except Exception as exc:
@@ -225,7 +228,9 @@ class TestContextvarPreserved:
         thread and can read the contextvar there.
         """
         respx.post("https://oauth2.googleapis.com/token").mock(return_value=_ok_token())
-        grant_agent("google", "builtin:chat", ["gmail.readonly"])
+        grant_agent(
+            "google", "builtin:chat", ["https://www.googleapis.com/auth/gmail.readonly"]
+        )
 
         observed_in_refresh: list[Optional[str]] = []
 
@@ -251,7 +256,8 @@ class TestContextvarPreserved:
                 with _agent_context("builtin:chat"):
                     try:
                         tok = get_access_token_sync(
-                            provider="google", scopes=["gmail.readonly"]
+                            provider="google",
+                            scopes=["https://www.googleapis.com/auth/gmail.readonly"],
                         )
                         results.append(tok)
                     except Exception as exc:

--- a/tests/unit/connectors/test_router_connectors.py
+++ b/tests/unit/connectors/test_router_connectors.py
@@ -798,13 +798,22 @@ class TestGrantsEndpoints:
         assert "installed:email" not in listing
 
     def test_put_grant_for_an_unknown_connector_is_404(self, ui_api_client):
-        """A typo'd id used to return 200 and persist a phantom ledger key."""
+        """A typo'd id used to return 200 and persist a phantom ledger key.
+
+        404 (not 400) matches ``_require_mcp_server`` two routes down, which
+        already answers an unknown connector id that way. The body is
+        structured — a bare registry ``KeyError`` here would surface as a 500.
+        """
         resp = ui_api_client.put(
             "/api/connectors/gooogle/grants/builtin:chat",
             json={"scopes": ["openid"]},
             headers=UI_HEADER,
         )
         assert resp.status_code == 404, resp.text
+        assert resp.json()["detail"] == {
+            "error": "unknown_connector",
+            "connector_id": "gooogle",
+        }
 
 
 # ---------------------------------------------------------------------------
@@ -1069,7 +1078,7 @@ class TestActivationsEndpoints:
     def test_put_activation_with_no_grant_and_scopes_auto_grants(self, ui_api_client):
         resp = ui_api_client.put(
             "/api/connectors/mcp-test/activations/builtin:chat",
-            json={"scopes": ["use", "read"]},
+            json={"scopes": ["use"]},
             headers=UI_HEADER,
         )
         assert resp.status_code == 200
@@ -1078,7 +1087,33 @@ class TestActivationsEndpoints:
         assert body["active"] is True
         # Grant landed too.
         grants = ui_api_client.get("/api/connectors/mcp-test/grants").json()
-        assert grants == {"grants": {"builtin:chat": ["use", "read"]}}
+        assert grants == {"grants": {"builtin:chat": ["use"]}}
+
+    def test_put_activation_auto_grant_cannot_exceed_the_ceiling(self, ui_api_client):
+        """This route is the OTHER unceilinged ledger write (#915).
+
+        ``body.scopes`` went from the request straight into ``grant_agent``,
+        so activating an agent could mint a grant for a scope the connector
+        never advertised — the same hole as ``put_grant``, reached through the
+        activation door. ``mcp-test`` declares no ``available_scopes``, so its
+        ceiling is the implicit ``("use",)`` and ``read`` is outside it.
+
+        This test previously asserted the write SUCCEEDED, pinning the
+        vulnerable behaviour.
+        """
+        resp = ui_api_client.put(
+            "/api/connectors/mcp-test/activations/builtin:chat",
+            json={"scopes": ["use", "read"]},
+            headers=UI_HEADER,
+        )
+        assert resp.status_code == 400, resp.text
+        assert resp.json()["detail"]["error"] == "scope_not_allowed"
+
+        # Neither ledger was touched — no grant, and no activation either.
+        grants = ui_api_client.get("/api/connectors/mcp-test/grants").json()
+        assert grants == {"grants": {}}
+        activations = ui_api_client.get("/api/connectors/mcp-test/activations").json()
+        assert activations == {"activations": {}}
 
     def test_put_activation_with_no_grant_and_no_scopes_is_400(self, ui_api_client):
         resp = ui_api_client.put(

--- a/tests/unit/connectors/test_router_connectors.py
+++ b/tests/unit/connectors/test_router_connectors.py
@@ -778,6 +778,34 @@ class TestGrantsEndpoints:
         )
         assert resp.status_code == 204
 
+    def test_put_grant_outside_the_ceiling_is_rejected(self, ui_api_client):
+        """#915: this route wrote the authorization ledger with no ceiling, so
+        a scope the connector never advertised became a grant the credential
+        check would then honour. Same 400 shape /authorize returns (#3247)."""
+        resp = ui_api_client.put(
+            "/api/connectors/google/grants/installed:email",
+            json={"scopes": ["https://mail.google.com/"]},
+            headers=UI_HEADER,
+        )
+        assert resp.status_code == 400, resp.text
+        detail = resp.json()["detail"]
+        assert detail["error"] == "scope_not_allowed"
+        assert detail["connector_id"] == "google"
+        assert detail["scopes"] == ["https://mail.google.com/"]
+
+        # And nothing was written.
+        listing = ui_api_client.get("/api/connectors/google/grants").json()["grants"]
+        assert "installed:email" not in listing
+
+    def test_put_grant_for_an_unknown_connector_is_404(self, ui_api_client):
+        """A typo'd id used to return 200 and persist a phantom ledger key."""
+        resp = ui_api_client.put(
+            "/api/connectors/gooogle/grants/builtin:chat",
+            json={"scopes": ["openid"]},
+            headers=UI_HEADER,
+        )
+        assert resp.status_code == 404, resp.text
+
 
 # ---------------------------------------------------------------------------
 # POST /api/connectors/{connector_id}/enable | /disable  (#1004)

--- a/tests/unit/connectors/test_secret_hygiene.py
+++ b/tests/unit/connectors/test_secret_hygiene.py
@@ -164,7 +164,11 @@ class TestFiles:
         # carry tokens at all; this guards against regressions.)
         from gaia.connectors.grants import grant_agent
 
-        grant_agent("google", "builtin:chat", ["gmail.readonly"])
+        grant_agent(
+            "google",
+            "builtin:chat",
+            ["https://www.googleapis.com/auth/gmail.readonly"],
+        )
         for path in tmp_path.rglob("*"):
             if path.is_file():
                 content = path.read_text(encoding="utf-8", errors="ignore")

--- a/tests/unit/test_proactive_hooks.py
+++ b/tests/unit/test_proactive_hooks.py
@@ -14,6 +14,8 @@ All tests use temp-file GoalStore — no real ~/.gaia directory touched.
 
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 from gaia.agents.base.agent import Agent
 from gaia.agents.base.console import SilentConsole
 from gaia.agents.base.goal_store import Proposal
@@ -225,11 +227,48 @@ class TestRegression:
 
 
 class TestIdentityContext:
+    """``_agent_identity_context`` marks an agent turn, and binds an identity
+    to it when there is one.
 
-    def test_agent_identity_context_returns_none_for_no_ns_id(self):
+    It used to return ``None`` for an agent with no namespaced id, and
+    ``process_query`` then ran that turn outside any context at all. That is
+    precisely the state the connectors layer reads as "no agent — take the
+    ungated CLI path", so an unregistered agent got credentials without any
+    grant check (#915). The block is now entered either way: no identity
+    inside an agent turn means REFUSED, not unrestricted.
+    """
+
+    def test_no_ns_id_still_enters_an_agent_turn(self):
+        from gaia.connectors.context import agent_runtime_active, current_agent_id
+
         agent = _make_test_agent()
-        result = agent._agent_identity_context(None)
-        assert result is None
+        with agent._agent_identity_context(None):
+            # An agent turn is in progress...
+            assert agent_runtime_active() is True
+            # ...but it carries no identity to check a grant against.
+            assert current_agent_id() is None
+        assert agent_runtime_active() is False
+
+    def test_credential_access_inside_that_turn_is_refused(self, tmp_path, monkeypatch):
+        """The reason the block is entered at all. Before, this call returned a
+        token; the grant check never ran because there was no context to read.
+        """
+        import gaia.connectors.catalog  # noqa: F401  # pylint: disable=unused-import
+        from gaia.connectors.api import _authorize_access
+        from gaia.connectors.errors import AuthRequiredError
+
+        monkeypatch.setattr("gaia.connectors.grants.Path.home", lambda: tmp_path)
+        agent = _make_test_agent()
+
+        with agent._agent_identity_context(None):
+            with pytest.raises(AuthRequiredError) as exc:
+                _authorize_access(
+                    provider="google",
+                    scopes=["https://www.googleapis.com/auth/gmail.readonly"],
+                    agent_id=None,
+                    account_email="default",
+                )
+        assert exc.value.reason is AuthRequiredError.Reason.AGENT_NOT_GRANTED
 
     def test_agent_identity_context_returns_cm_for_ns_id(self):
         agent = _make_test_agent()
@@ -238,6 +277,15 @@ class TestIdentityContext:
         # Should be a context manager (has __enter__ and __exit__)
         assert hasattr(result, "__enter__")
         assert hasattr(result, "__exit__")
+
+    def test_ns_id_is_readable_inside_the_block(self):
+        from gaia.connectors.context import agent_runtime_active, current_agent_id
+
+        agent = _make_test_agent()
+        with agent._agent_identity_context("agent:test-id"):
+            assert current_agent_id() == "agent:test-id"
+            assert agent_runtime_active() is True
+        assert current_agent_id() is None
 
 
 # ===========================================================================

--- a/tests/unit/test_turn_metrics_wire.py
+++ b/tests/unit/test_turn_metrics_wire.py
@@ -9,6 +9,7 @@ wire path that carries it out — the ``answer`` event, then the canonical
 what it was before any of this existed.
 """
 
+import contextlib
 import json
 import logging
 import time
@@ -394,7 +395,10 @@ class TestTimingHoldsUpOnTheUnhappyPaths:
         monkeypatch.setenv("GAIA_TURN_LOG", str(log))
         agent = _bare_agent()
         agent._namespaced_agent_id = lambda: "test"
-        agent._agent_identity_context = lambda ns: None
+        # A real (no-op) context manager: process_query always enters this
+        # block now, so that a turn with no namespaced id still counts as an
+        # agent turn and fails credential access closed (#915).
+        agent._agent_identity_context = lambda ns: contextlib.nullcontext()
 
         def _boom(*a, **kw):
             agent._turn_recorder = self._recorder(tmp_path)


### PR DESCRIPTION
## Summary

The per-agent connector permission has never actually run. Every tool executed by the agent loop lost its agent identity before it reached the credential layer, so every check was skipped — and the ledger those checks read would accept any scope for any connector id. This makes the check real and puts a ceiling on the ledger it reads.

## Why

If you toggle a scope off for an agent in Settings → Connections today, nothing happens: the agent still gets the credential. Tool bodies run in a worker thread, a new Python thread starts with an empty context, and the agent identity bound for the turn never crosses that boundary — so the credential layer sees "no agent" and takes the ungated CLI path. Separately, `PUT /api/connectors/google/grants/installed:email` with `{"scopes": ["https://mail.google.com/"]}` returned 200 and wrote it, giving an agent full-mailbox authority Google never advertised for that connector; a typo'd connector id also returned 200 and persisted a key nothing reads.

Both halves have to land together. Enforcing the check while the ledger still takes arbitrary scopes just turns a dead control into a forgeable one.

After this, a scope you did not grant is a scope the agent cannot use, and a scope the connector never advertised is a scope you cannot grant.

## Linked issue

Closes #3362

## Changes

- **Identity survives the tool thread** — `_call_tool_bounded` snapshots the caller's context and runs the worker inside it. Copying inside the worker (the intuitive spot) is a no-op; it would copy the worker's own empty context.
- **Credential access fails closed** — a request made inside an agent turn with no resolvable identity is refused instead of falling through ungated. Outside a turn (CLI, scripts, SDK embedding) the documented ungated escape hatch is unchanged.
- **A request that names no scopes is refused on both credential doors**, not one. Naming nothing satisfies the check vacuously, so it must not mean "nothing to check" — see the entry-point table below.
- **One scope ceiling for the ledger** — both gates live in `grants.grant_agent`, so the Agent UI route, the CLI and the SDK cannot drift. This is the ceiling #3247 added to the OAuth *authorize* path, extended to the two direct ledger writes it left uncovered (`put_grant` and the activation auto-grant), returning the same `scope_not_allowed` 400.
- **Revoking is never ceiling-gated.** Only widening is. A connector dropped from the catalog must still be clearable, or removing it would strand grants forever — a regression pointing the other way. Guarded by its own test.
- **Unknown connector id is a typed error**, not a bare `KeyError` — which reached HTTP as a 500 and the CLI as a traceback.
- **Tavily's key is gated** — it named neither an agent nor any scopes, so the dispatcher had nothing to verify.
- Docs: the SDK connectors guide now covers the ceiling, the fail-closed rule, and when an SDK author must pass `agent_id` explicitly (their own threads, queued work, foreign callbacks); the security page gains the two threat rows.

### Every door into the credential/token layer

Enumerated rather than assumed, after review found the first pass had closed one and left its twin open:

| Entry point | Public? | Identity gate | Empty-scope gate | Grant check |
|---|---|---|---|---|
| `api.get_access_token` | yes | ✅ | ✅ | ✅ |
| `api.get_access_token_with_expiry` | no | ✅ | ✅ | ✅ |
| `api.get_access_token_sync` | yes | ✅ delegates | ✅ | ✅ |
| `api.get_access_token_with_expiry_sync` | no | ✅ delegates | ✅ | ✅ |
| `handler.get_credential` | no (tool-facing) | ✅ | ✅ | ✅ |
| `handler.get_credential_sync` | no (tool-facing) | ✅ delegates | ✅ | ✅ |
| `oauth_pkce.…get_credential` | no | reached only via `handler.get_credential` | " | " |
| `mcp_server.…get_credential` | no | reached only via `handler.get_credential` | " | " |
| `tokens.get_or_refresh` / `…_sync` / `get_token_with_expiry` | **no** | **deliberately exempt** | — | — |
| `store.load_connection` / keyring | **no** | **deliberately exempt** | — | — |

The last two rows are the raw refresh and storage primitives. They are not in `gaia.connectors.__all__` or its lazy `_API_NAMES`, so reaching them means importing a private module — which is no different from reading the keyring directly, and sits on the trusted-code side of the threat model this repo already documents (`docs/security/connections.mdx`: custom agents "run in the same process as GAIA — they are trusted code you install yourself"). Guarding them would be theatre, not defence. Every *sanctioned* way to obtain a credential is in the guarded rows.

## Test plan

- [x] `python -m pytest tests/unit/ -q` — **full directory**, not the subfolders. This is what the first round got wrong: I ran only the folders I changed, and stale tests outside them slipped through. Result: **100 failed, 10386 passed, 15 errors**. Re-running only those 20 failing files against unmodified `upstream/main` gives a **byte-identical 114-line failure list** — every one is pre-existing Windows breakage (installer / eval / lemonade / daemon / CLI), and **none is in a module this PR touches**.
- [x] `python -m pytest tests/unit/connectors/ -q` — 792 passed
- [x] `python -m pytest tests/unit/test_proactive_hooks.py tests/unit/test_turn_metrics_wire.py -q` — 40 passed (the two stale tests review found)
- [x] `python util/check_doc_code.py --lang python` — 418 blocks OK; `python util/check_doc_links.py --internal-only` — 958 links OK
- [x] `python -m pytest tests/unit/connectors/test_agent_identity_boundary.py -q` — 19 passed (new file)
- [x] Same file against the unpatched sources → **5 failed**, including `assert None == 'builtin:grant-boundary-probe'` — the tests fail for the right reason
- [x] `python util/lint.py --black --isort --flake8` — all pass
- [ ] `python util/lint.py --all` — red at `upstream/main` too: 29 pre-existing mypy errors in files this PR does not touch. Identical set before and after.
- [ ] Agent eval — **not applicable**: no LLM-affecting surface changed (no prompts, tool registration or docstrings, tool schema, error classification, or default model).

<details>
<summary>🔍 How the local run was made trustworthy on Windows</summary>

`tests/unit/conftest.py`'s network guard breaks `socket.socketpair()` on Windows, so every `TestClient`/asyncio test **errors in setup** rather than running. My first round compared failure lists and got "identical to baseline" — true, and meaningless, because ~240 of those tests never executed. That is what let 16 real failures reach CI.

For this round I temporarily allowed loopback connects in that guard locally so the tests actually run (`tests/unit/connectors/` went from 535 to 792 executed). **That change is not committed** — `tests/unit/conftest.py` is untouched in this PR. Linux CI needs no such patch.
</details>

## Evidence

**The bypass review found, closed.** The OAuth token path is the one the Google connector uses:

```
grants ledger for google: {}
check_agent_grant(google, builtin:chat, []) -> True   <- vacuously True

get_access_token(provider='google', scopes=[], agent_id='builtin:chat'):
  refused: ConfigurationError
    get_access_token('google') named no scopes, so the per-agent grant for
    'builtin:chat' cannot be verified and no token will be issued. Pass the
    scopes the caller actually needs.
```

Before, that call returned a full-capability token with the ledger never consulted.

**CLI** — `gaia connectors grants grant`, isolated `HOME`:

```
$ gaia connectors grants grant gooogle builtin:chat --scopes "openid"
gaia connectors grants grant: Unknown connector 'gooogle'. Known ids: google,
mcp-git, mcp-github, mcp-memory, mcp-tavily, microsoft, microsoft_work. Run
'gaia connectors list' to see the catalog, or check the id for a typo.
exit=1

$ gaia connectors grants grant google installed:email --scopes "https://mail.google.com/"
gaia connectors grants grant: Agent 'installed:email' declares scope(s)
https://mail.google.com/ for connector 'google' that are outside its
available_scopes catalog entry. File a bug rather than widening the request.
exit=1

$ gaia connectors grants grant google installed:email --scopes ".../gmail.readonly"
Granted google → installed:email: https://www.googleapis.com/auth/gmail.readonly
exit=0

$ gaia connectors grants revoke google installed:email     # never ceiling-gated
Revoked grant for google → installed:email.
exit=0
```

**HTTP API** — real server (`python -m gaia.ui.server --port 4207`), real requests. Before this PR all three returned `200 OK` and wrote the ledger:

```
PUT /api/connectors/google/grants/installed:email  {"scopes":["https://mail.google.com/"]}
→ 400  {"detail":{"error":"scope_not_allowed","agent_id":"installed:email",
        "connector_id":"google","scopes":["https://mail.google.com/"]}}

PUT /api/connectors/gooogle/grants/builtin:chat    {"scopes":["openid"]}
→ 404  {"detail":{"error":"unknown_connector","connector_id":"gooogle"}}

PUT /api/connectors/google/grants/installed:email  {"scopes":[".../gmail.readonly"]}
→ 200  {"connector_id":"google","agent_id":"installed:email","scopes":[".../gmail.readonly"]}

GET /api/connectors/google/grants
→ {"grants":{"installed:email":["https://www.googleapis.com/auth/gmail.readonly"]}}
```

**Agent identity across the tool thread** — the real `process_query` → `_execute_tool` → worker-thread path:

```
before:  AssertionError: assert None == 'builtin:grant-boundary-probe'
after:   thread == "tool:probe", current_agent_id() == "builtin:grant-boundary-probe"
```

- **Agent exposed in the Agent UI** — N/A for screenshots: no UI component or rendering changed. The route the Settings → Connections toggles call is covered by the live HTTP transcript above.
- **MCP tools / servers** — N/A: no MCP tool, server, or bridge behaviour changed. `mcp_server` connectors are affected only as a grant *ceiling* (the implicit `use` scope).

## Checklist

- [x] I have linked a GitHub issue above (`Closes #3362`).
- [x] I have described **why** this change is being made, not just what changed.
- [x] I have run linting and tests locally (see Test plan, including the two caveats).
- [x] I have attached **real-world evidence matched to the surface I changed**, or marked each surface N/A.
- [x] I have updated documentation (`docs/sdk/infrastructure/connectors.mdx`, `docs/security/connections.mdx`).

<details>
<summary>🔍 The three tests that changed behaviour — real contract, or the bug written down?</summary>

**`test_put_activation_with_no_grant_and_scopes_auto_grants` — the bug written down.** `put_activation` passed `body.scopes` from the HTTP request straight into `grant_agent`, so activating an agent could mint a grant for a scope the connector never advertised. The test asserted `{"scopes": ["use", "read"]}` **landed in the ledger** for a connector whose ceiling is `use`. That is the same hole as `put_grant`, reached through the activation door. Kept as a passing case with an in-ceiling scope, and a new test asserts the out-of-ceiling one is refused with neither ledger touched.

**`test_agent_identity_context_returns_none_for_no_ns_id` — the bug written down.** It asserted that an agent with no namespaced id gets `None` instead of a context block, which meant `process_query` ran that turn outside any context — precisely the state the connectors layer reads as "no agent, take the ungated path". Rewritten to assert the new contract (the turn is entered either way; a credential request inside it with no identity is refused), with a docstring naming what it now guards so it doesn't read as a regression.

**`test_turn_metrics_wire.py`'s identity stub — neither.** It replaced `_agent_identity_context` with `lambda ns: None` because `None` used to be a legal return; it asserts nothing about identity, only about recorder sealing. A test double that went stale, fixed by returning `contextlib.nullcontext()`.

**Test-fixture churn (no behaviour change).** Several tests seeded grants with shorthand scope names (`gmail.readonly`, `Mail.ReadWrite`, `scope_0`) that are not real catalog scopes — harmless before the ceiling existed. They now use catalog-real scopes. Four disconnect tests granted against `ConnectorSpec`s they built in-line and never published; they now register them via a `register_ephemeral_spec` fixture, since "an id nothing publishes" is exactly the phantom-key case the guard rejects. No assertion was weakened.
</details>
