### PR TITLE
fix(api,web): repair gaia api chat completions, HTTPS SNI, and download overwrite

### DIFF
--- a/.github/workflows/test_unit.yml
+++ b/.github/workflows/test_unit.yml
@@ -169,6 +169,17 @@ jobs:
           echo ""
           pytest tests/integration/test_lemonade_release_assets.py -v --tb=short
 
+      - name: Run live web-fetch TLS test
+        env:
+          GAIA_MEMORY_DISABLED: "1"
+        run: |
+          echo "=== Fetching CDN-fronted HTTPS hosts through WebClient ==="
+          echo "The IP-pinning adapter can pass every unit test and still fail"
+          echo "every real handshake; only a live TLS peer proves the SNI is"
+          echo "acceptable. Skips itself when the runner has no network."
+          echo ""
+          pytest tests/integration/test_web_client_live_sni.py -v --tb=short --timeout=300
+
       - name: Run embedded Lemonade checksum pinning test
         env:
           GAIA_MEMORY_DISABLED: "1"

--- a/docs/spec/api-server.mdx
+++ b/docs/spec/api-server.mdx
@@ -71,7 +71,6 @@ The GAIA API Server provides an OpenAI-compatible REST API for exposing GAIA age
 1. **Message Handling**
    - OpenAI message format
    - System/user/assistant roles
-   - GitHub Copilot workspace extraction
    - Prompt formatting
 
 2. **Response Generation**
@@ -497,63 +496,23 @@ async def stream_chat_completion(
 
 ## Implementation Details
 
-### Workspace Root Extraction
-
-```python
-def extract_workspace_root(messages):
-    """
-    Extract workspace root path from GitHub Copilot messages.
-
-    GitHub Copilot includes workspace info in messages like:
-    <workspace_info>
-    I am working in a workspace with the following folders:
-    - /Users/username/path/to/workspace
-    </workspace_info>
-
-    Args:
-        messages: List of ChatMessage objects
-
-    Returns:
-        str: Workspace root path, or None if not found
-    """
-    import re
-
-    for msg in messages:
-        if msg.role == "user" and msg.content:
-            workspace_match = re.search(
-                r"<workspace_info>.*?following folders:\s*\n\s*-\s*([^\s\n]+)",
-                msg.content,
-                re.DOTALL,
-            )
-            if workspace_match:
-                return workspace_match.group(1).strip()
-
-    return None
-```
-
 ### Request Processing Flow
 
 ```python
 async def create_chat_completion(request: ChatCompletionRequest):
-    # 1. Extract workspace root (carried in the last user message's metadata).
-    workspace_root = extract_workspace_root(request.messages)
-
-    # 2. Resolve the agent. `get_agent()` takes only model_id; workspace_root
-    #    is applied afterwards (e.g., via agent.config or a per-request setter).
+    # 1. Resolve the agent. `get_agent()` takes only model_id.
     try:
         agent = registry.get_agent(request.model)
     except KeyError:
         raise HTTPException(404, f"Model not found: {request.model}")
-    if workspace_root and hasattr(agent, "set_workspace_root"):
-        agent.set_workspace_root(workspace_root)
 
-    # 3. Extract user message
+    # 2. Extract user message
     user_messages = [m for m in request.messages if m.role == "user"]
     if not user_messages:
         raise HTTPException(400, "No user message in request")
     user_message = user_messages[-1].content
 
-    # 4. Generate response
+    # 3. Generate response
     if request.stream:
         # Streaming response
         return StreamingResponse(

--- a/docs/spec/browser-tools.mdx
+++ b/docs/spec/browser-tools.mdx
@@ -179,6 +179,9 @@ def download_file(
     PDFs, CSVs, images, or any file from the web for local analysis.
     After downloading, use read_file or index_document to process it.
 
+    Never replaces a file that already exists: if the destination is
+    taken the download fails, so pass filename= to choose a free name.
+
     Args:
         url: Direct URL to the file to download
         save_to: Local directory to save the file (default: ~/Downloads)
@@ -189,8 +192,18 @@ def download_file(
 **Limits:**
 - Max file size: 100 MB (configurable)
 - Streams download to disk (doesn't load into memory)
-- Validates path with `PathValidator` before writing
+- Validates the directory *and* the resolved destination with `PathValidator`
+  before any bytes are written
+- Refuses to overwrite an existing file, and refuses to start when a `.part`
+  file for the same name is already present
+- Writes to `<name>.part` and renames into place, so an interrupted download
+  never leaves a truncated file under the real name
 - Returns file path + size for follow-up tool use
+
+**Why the overwrite refusal:** the filename can come from the remote
+`Content-Disposition` header, which the server chooses. Without the check, a
+page serving `filename=report.pdf` would replace the user's own
+`~/Downloads/report.pdf`.
 
 **Output format:**
 ```

--- a/setup.py
+++ b/setup.py
@@ -128,7 +128,12 @@ setup(
         "python-dotenv",
         "aiohttp",
         "rich",
-        "requests",
+        # 2.32.3 added HTTPAdapter.build_connection_pool_key_attributes, which
+        # PinnedIPAdapter overrides to set the TLS SNI while pinning the IP.
+        # 2.32.2 is specifically unusable: it routes through
+        # get_connection_with_tls_context but has no such hook, so the SNI
+        # would silently revert to the pinned IP.
+        "requests>=2.32.3",
         "beautifulsoup4",
         "watchdog>=2.1.0",
         "pillow>=9.0.0",

--- a/src/gaia/agents/tools/browser_tools.py
+++ b/src/gaia/agents/tools/browser_tools.py
@@ -248,6 +248,9 @@ class BrowserToolsMixin:
             PDFs, CSVs, images, or any file from the web for local analysis.
             After downloading, use read_file or index_document to process it.
 
+            Never replaces a file that already exists: if the destination is
+            taken the download fails, so pass filename= to choose a free name.
+
             Args:
                 url: Direct URL to the file to download
                 save_to: Local directory to save the file (default: ~/Downloads)
@@ -273,36 +276,35 @@ class BrowserToolsMixin:
                 if is_blocked:
                     return f"Error: {reason}"
 
+            # Screen the *resolved file path* (not just the directory) against
+            # the sensitive-filename guardrail before a single byte is written.
+            # The directory check above catches blocked dirs, but the final
+            # filename (from Content-Disposition or URL) could be something
+            # like `credentials.json` that is_write_blocked would reject for
+            # write_file. WebClient.download calls this before creating the
+            # file, so a blocked download leaves the filesystem untouched.
+            def _screen_destination(dest_path: Path) -> None:
+                validator = getattr(mixin, "_path_validator", None)
+                if not validator:
+                    return
+                is_blocked, reason = validator.is_write_blocked(str(dest_path))
+                if is_blocked:
+                    raise ValueError(
+                        f"Downloaded file blocked by security policy: {reason}"
+                    )
+
             try:
                 result = mixin._web_client.download(
                     url=url,
                     save_dir=save_to,
                     filename=filename,
+                    on_path_resolved=_screen_destination,
                 )
             except ValueError as e:
                 return f"Error: {e}"
             except Exception as e:
                 logger.error(f"Error downloading {url}: {e}")
                 return f"Error downloading file: {e}"
-
-            # Post-download: check the *resolved file path* (not just the
-            # directory) against the sensitive-filename guardrail. The
-            # directory check above catches blocked dirs, but the final
-            # filename (from Content-Disposition or URL) could be something
-            # like `credentials.json` or `.env` that is_write_blocked
-            # would reject for write_file.  Delete the file if blocked.
-            if hasattr(mixin, "_path_validator") and mixin._path_validator:
-                saved_path = result.get("path", "")
-                is_blocked, reason = mixin._path_validator.is_write_blocked(saved_path)
-                if is_blocked:
-                    try:
-                        Path(saved_path).unlink(missing_ok=True)
-                    except OSError:
-                        pass
-                    return (
-                        f"Error: Downloaded file blocked by security policy: "
-                        f"{reason}"
-                    )
 
             # Format file size
             size_bytes = result["size"]

--- a/src/gaia/api/openai_server.py
+++ b/src/gaia/api/openai_server.py
@@ -112,38 +112,6 @@ def _prepend_tool_denials(agent, content: str) -> str:
     return "\n".join(list(denials.values()) + ([content] if content else []))
 
 
-def extract_workspace_root(messages):
-    """
-    Extract workspace root path from GitHub Copilot messages.
-
-    GitHub Copilot includes workspace info in messages like:
-    <workspace_info>
-    I am working in a workspace with the following folders:
-    - /Users/username/path/to/workspace
-    </workspace_info>
-
-    Args:
-        messages: List of ChatMessage objects
-
-    Returns:
-        str: Workspace root path, or None if not found
-    """
-    import re
-
-    for msg in messages:
-        if msg.role == "user" and msg.content:
-            # Look for workspace_info section
-            workspace_match = re.search(
-                r"<workspace_info>.*?following folders:\s*\n\s*-\s*([^\s\n]+)",
-                msg.content,
-                re.DOTALL,
-            )
-            if workspace_match:
-                return workspace_match.group(1).strip()
-
-    return None
-
-
 # Initialize FastAPI app
 app = FastAPI(
     title="GAIA OpenAI-Compatible API",
@@ -307,11 +275,6 @@ async def create_chat_completion(request: ChatCompletionRequest):
             status_code=404, detail=f"Model '{request.model}' not found"
         )
 
-    # Extract workspace root from messages (for converting relative paths to absolute)
-    workspace_root = extract_workspace_root(request.messages)
-    if _api_debug_enabled() and workspace_root:
-        logger.debug("📁 Extracted workspace root: %s", _REDACTED_LOG_VALUE)
-
     # Extract user query from messages (get last user message)
     user_message = next(
         (m.content for m in reversed(request.messages) if m.role == "user"), None
@@ -345,9 +308,7 @@ async def create_chat_completion(request: ChatCompletionRequest):
             logger.debug("🌊 Using STREAMING mode")
 
         return StreamingResponse(
-            create_sse_stream(
-                agent, user_message, request.model, workspace_root=workspace_root
-            ),
+            create_sse_stream(agent, user_message, request.model),
             media_type="text/event-stream",
             headers={
                 "Cache-Control": "no-cache",
@@ -360,8 +321,7 @@ async def create_chat_completion(request: ChatCompletionRequest):
         if _api_debug_enabled():
             logger.debug("📦 Using NON-STREAMING mode")
 
-        # Process query synchronously with workspace root
-        result = agent.process_query(user_message, workspace_root=workspace_root)
+        result = agent.process_query(user_message)
 
         # Debug logging: show what agent returned
         if _api_debug_enabled():
@@ -430,9 +390,7 @@ async def create_chat_completion(request: ChatCompletionRequest):
         )
 
 
-async def create_sse_stream(
-    agent, query: str, model: str, workspace_root: str = None
-) -> AsyncGenerator[str, None]:
+async def create_sse_stream(agent, query: str, model: str) -> AsyncGenerator[str, None]:
     """
     Create Server-Sent Events stream for chat completion.
 
@@ -443,7 +401,6 @@ async def create_sse_stream(
         agent: Agent instance (with SSEOutputHandler)
         query: User query string
         model: Model ID
-        workspace_root: Optional workspace root path for absolute file paths
 
     Yields:
         SSE-formatted chunks with "data: " prefix
@@ -492,9 +449,7 @@ async def create_sse_stream(
 
     try:
         # Start processing in background
-        task = loop.run_in_executor(
-            None, lambda: agent.process_query(query, workspace_root=workspace_root)
-        )
+        task = loop.run_in_executor(None, lambda: agent.process_query(query))
 
         # Stream events as they are generated
         while not task.done():

--- a/src/gaia/web/client.py
+++ b/src/gaia/web/client.py
@@ -100,49 +100,49 @@ REMOVE_TAGS = [
 class PinnedIPAdapter(HTTPAdapter):
     """HTTPAdapter that pins the resolved IP address for a hostname.
 
-    On ``send()``, the adapter resolves the request hostname once via
-    ``socket.getaddrinfo``, replaces the request URL netloc with the
-    resolved IP:port, and sets the ``Host`` header to the original
-    hostname.  The resolved IP is cached per ``(host, port)`` tuple so
-    subsequent requests to the same origin reuse the same IP — preventing
-    DNS-rebind attacks between ``WebClient.validate_url`` and the actual
-    TCP connect.
+        On ``send()``, the adapter resolves the request hostname once via
+        ``socket.getaddrinfo``, replaces the request URL netloc with the
+        resolved IP:port, and sets the ``Host`` header to the original
+        hostname.  The resolved IP is cached per ``(host, port)`` tuple so
+        subsequent requests to the same origin reuse the same IP — preventing
+        DNS-rebind attacks between ``WebClient.validate_url`` and the actual
+        TCP connect.
 
-    Crucially, the pinned IP is itself validated (``_assert_ip_allowed``)
-    before it is cached or connected to. ``validate_url`` runs a *separate*
-    pre-flight ``getaddrinfo``; an attacker controlling DNS could answer that
-    lookup with a public IP and answer the adapter's lookup with a private
-    one. Validating the exact address the adapter is about to dial closes
-    that residual rebind window for BOTH http and https.
+        Crucially, the pinned IP is itself validated (``_assert_ip_allowed``)
+        before it is cached or connected to. ``validate_url`` runs a *separate*
+        pre-flight ``getaddrinfo``; an attacker controlling DNS could answer that
+        lookup with a public IP and answer the adapter's lookup with a private
+        one. Validating the exact address the adapter is about to dial closes
+        that residual rebind window for BOTH http and https.
 
-    For HTTPS, the original hostname is encoded in the URL's userinfo
-    section (``originalhostname@pinnedip:port``) so that urllib3 creates
-    separate connection-pool keys per original hostname.  This avoids a
-    race where two threads requesting different hostnames that resolve to
-    the same IP would overwrite each other's ``assert_hostname`` on a
-    shared pool.
+        For HTTPS the connect address and the TLS identity are decoupled, so
+        pinning the IP does not break SNI-based virtual hosting (most of the
+        web). The original hostname is carried in the URL's userinfo section
+        (``originalhostname@pinnedip:port``) and
+        ``build_connection_pool_key_attributes`` — the extension point
+        ``requests`` documents for exactly this — turns it into two urllib3
+        pool arguments:
 
-    Residual HTTPS limitation (documented, not silently ignored):
-    Because ``requests`` derives the urllib3 pool host — and therefore the
-    TLS SNI ``server_hostname`` — from the request URL's hostname (which we
-    rewrote to the pinned IP), the ClientHello SNI is sent as the IP, not the
-    original hostname. ``assert_hostname`` still forces certificate-name
-    verification against the real hostname (so verification is NOT disabled
-    and we never trust a cert for the bare IP), but servers that rely on SNI
-    for virtual hosting (most CDNs / shared hosts) may return the wrong
-    certificate or reject the handshake, surfacing as a TLS error rather than
-    a silent downgrade. This affects whether legitimate HTTPS *succeeds* — it
-    does not weaken the SSRF block, which fires on the validated IP before any
-    bytes are sent. Fixing SNI cleanly requires a custom urllib3
-    ``PoolManager``/``HTTPSConnection`` that decouples ``server_hostname``
-    from the connect address; that is intentionally out of scope here in
-    favour of a correct, narrower guarantee.
+    ``server_hostname``, which
+        urllib3 uses both as the ClientHello SNI and as the name OpenSSL verifies
+        the certificate against, so a certificate valid only for the bare IP is
+        never accepted. It is a ``PoolKey`` field, so two hostnames that resolve
+        to the same IP get distinct connection pools rather than sharing one.
+
+        ``assert_hostname`` is deliberately NOT set: it would move name checking
+        out of the handshake into urllib3's post-hoc matcher by setting
+        ``check_hostname = False`` on the SSL context — which ``requests`` shares
+        process-wide on some versions, silently weakening every other caller.
+
+        The socket still connects to the validated, pinned IP: the URL host is
+        the IP, and ``server_hostname`` changes only what is *named* in the
+        handshake, never what is dialed. The SSRF block is unaffected — it fires
+        on the validated IP before any bytes are sent.
     """
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self._pinned_cache: Dict[Tuple[str, int], str] = {}
-        self._warned_https_sni = False
 
     def _resolve_first_ip(self, host: str, port: int) -> str:
         key = (host, port)
@@ -209,22 +209,9 @@ class PinnedIPAdapter(HTTPAdapter):
             url_ip = self._format_ip_for_url(pinned_ip)
 
             if parsed.scheme == "https":
-                # Encode original hostname in userinfo for unique pool keys.
-                # See class docstring: SNI is sent as the pinned IP, so
-                # SNI-vhosted servers may fail the handshake. Cert-name
-                # verification still binds to the real hostname.
-                if not getattr(self, "_warned_https_sni", False):
-                    log.warning(
-                        "PinnedIPAdapter: HTTPS request to %s is pinned to %s; "
-                        "TLS SNI will be sent as the IP. Servers using "
-                        "SNI-based virtual hosting may return the wrong "
-                        "certificate or reject the handshake. Certificate-name "
-                        "verification still validates against %s.",
-                        host,
-                        pinned_ip,
-                        host,
-                    )
-                    self._warned_https_sni = True
+                # Carry the original hostname in userinfo; it is read back in
+                # build_connection_pool_key_attributes to set the TLS SNI and
+                # the certificate-name assertion. Never sent on the wire.
                 new_netloc = f"{host}@{url_ip}:{port}"
             else:
                 new_netloc = f"{url_ip}:{port}"
@@ -244,24 +231,21 @@ class PinnedIPAdapter(HTTPAdapter):
 
         return super().send(request, **kwargs)
 
-    def get_connection(self, url, proxies=None):
-        clean_url, tls_hostname = self._strip_tls_host(url)
-        pool = super().get_connection(clean_url, proxies)
-        if tls_hostname:
-            pool.assert_hostname = tls_hostname
-        return pool
+    def build_connection_pool_key_attributes(self, request, verify, cert=None):
+        """Pin the connect address to the IP while keeping the TLS identity.
 
-    def get_connection_with_tls_context(self, request, verify, proxies=None, cert=None):
-        original_url = request.url
-        clean_url, tls_hostname = self._strip_tls_host(original_url)
-        request.url = clean_url
-        pool = super().get_connection_with_tls_context(
-            request, verify, proxies=proxies, cert=cert
+        ``requests`` documents this as the hook for customising urllib3 pool
+        arguments. ``host_params["host"]`` is already the pinned IP (urlparse
+        drops the userinfo), so the only thing left is to name the real host
+        in TLS terms via ``server_hostname``.
+        """
+        host_params, pool_kwargs = super().build_connection_pool_key_attributes(
+            request, verify, cert
         )
-        request.url = original_url
-        if tls_hostname:
-            pool.assert_hostname = tls_hostname
-        return pool
+        _, tls_hostname = self._strip_tls_host(request.url)
+        if tls_hostname and host_params.get("scheme") == "https":
+            pool_kwargs["server_hostname"] = tls_hostname
+        return host_params, pool_kwargs
 
 
 class WebClient:

--- a/src/gaia/web/client.py
+++ b/src/gaia/web/client.py
@@ -711,17 +711,30 @@ class WebClient:
         save_dir: str,
         filename: str = None,
         max_size: int = None,
+        on_path_resolved=None,
     ) -> dict:
         """Download a file from URL to local disk.
 
-        Streams to disk to handle large files. Returns dict with
-        path, size, and content_type.
+                Streams to disk to handle large files. Returns dict with
+                path, size, and content_type.
 
-        Args:
-            url: URL to download
-            save_dir: Directory to save file in
-            filename: Override filename (default: from URL/headers)
-            max_size: Max file size in bytes (default: self._max_download_size)
+        Refuses to overwrite an existing file: the destination is checked (and
+                handed to ``on_path_resolved`` for policy screening) *before* any bytes
+                are written, and the body is streamed to a sibling ``.part`` file that
+                is renamed into place only on success. The filename can come from an
+                attacker-controlled ``Content-Disposition`` header, so a failed policy
+                check must not have already clobbered the user's file. The check is
+                repeated immediately before the rename; a file created in that last
+                instant by another local process is still replaced.
+
+                Args:
+                    url: URL to download
+                    save_dir: Directory to save file in
+                    filename: Override filename (default: from URL/headers)
+                    max_size: Max file size in bytes (default: self._max_download_size)
+                    on_path_resolved: Optional callable invoked with the resolved
+                        destination ``Path`` before the file is created. Raise from it
+                        to refuse the download.
         """
         max_size = max_size or self._max_download_size
 
@@ -808,21 +821,65 @@ class WebClient:
         # access is fragile (future requests versions may clear them).
         content_type = response.headers.get("Content-Type", "unknown")
 
-        # Stream to disk
-        downloaded = 0
-        with open(save_path, "wb") as f:
-            for chunk in response.iter_content(chunk_size=8192):
-                downloaded += len(chunk)
-                if downloaded > max_size:
-                    f.close()
-                    save_path.unlink(missing_ok=True)
-                    response.close()
-                    raise ValueError(
-                        f"Download exceeded max size: {downloaded} bytes (max: {max_size})"
-                    )
-                f.write(chunk)
+        # Refuse to clobber an existing file. The name may come straight from
+        # a remote Content-Disposition header, so `report.pdf` from a hostile
+        # page must not be able to replace the user's own ~/Downloads/report.pdf.
+        if save_path.exists():
+            response.close()
+            raise ValueError(
+                f"Refusing to overwrite existing file: {save_path}. "
+                f"Pass an explicit filename= to download under a different name."
+            )
 
-        response.close()
+        # Policy screening happens before the file is created, not after —
+        # a blocked download must leave the filesystem untouched.
+        if on_path_resolved is not None:
+            try:
+                on_path_resolved(save_path)
+            except BaseException:
+                response.close()
+                raise
+
+        # Stream to a sibling .part file and rename into place, so an
+        # interrupted download never leaves a truncated file under the real
+        # name. Exclusive create means a concurrent download of the same name,
+        # or a .part left by a crashed one, fails loudly rather than having
+        # two writers interleave into one file.
+        part_path = save_path.with_name(save_path.name + ".part")
+        try:
+            part_file = open(part_path, "xb")
+        except FileExistsError:
+            response.close()
+            raise ValueError(
+                f"Cannot download to {save_path.name}: {part_path.name} already "
+                f"exists, so another download of this name is either in flight "
+                f"or was interrupted. Delete it, or pass a different filename=."
+            ) from None
+
+        # Only ever clean up the .part this call created — unlinking on any
+        # failure would delete a concurrent download's file.
+        downloaded = 0
+        try:
+            with part_file as f:
+                for chunk in response.iter_content(chunk_size=8192):
+                    downloaded += len(chunk)
+                    if downloaded > max_size:
+                        raise ValueError(
+                            f"Download exceeded max size: {downloaded} bytes "
+                            f"(max: {max_size})"
+                        )
+                    f.write(chunk)
+            if save_path.exists():
+                raise ValueError(
+                    f"Refusing to overwrite existing file: {save_path}. "
+                    f"It appeared while the download was in flight."
+                )
+            os.replace(part_path, save_path)
+        except BaseException:
+            part_path.unlink(missing_ok=True)
+            raise
+        finally:
+            response.close()
 
         return {
             "path": str(save_path),

--- a/src/gaia/web/client.py
+++ b/src/gaia/web/client.py
@@ -100,47 +100,57 @@ REMOVE_TAGS = [
 class PinnedIPAdapter(HTTPAdapter):
     """HTTPAdapter that pins the resolved IP address for a hostname.
 
-        On ``send()``, the adapter resolves the request hostname once via
-        ``socket.getaddrinfo``, replaces the request URL netloc with the
-        resolved IP:port, and sets the ``Host`` header to the original
-        hostname.  The resolved IP is cached per ``(host, port)`` tuple so
-        subsequent requests to the same origin reuse the same IP — preventing
-        DNS-rebind attacks between ``WebClient.validate_url`` and the actual
-        TCP connect.
+    On ``send()``, the adapter resolves the request hostname once via
+    ``socket.getaddrinfo``, replaces the request URL netloc with the
+    resolved IP:port, and sets the ``Host`` header to the original
+    hostname. The resolved IP is cached per ``(host, port)`` tuple so
+    subsequent requests to the same origin reuse the same IP — preventing
+    DNS-rebind attacks between ``WebClient.validate_url`` and the actual
+    TCP connect.
 
-        Crucially, the pinned IP is itself validated (``_assert_ip_allowed``)
-        before it is cached or connected to. ``validate_url`` runs a *separate*
-        pre-flight ``getaddrinfo``; an attacker controlling DNS could answer that
-        lookup with a public IP and answer the adapter's lookup with a private
-        one. Validating the exact address the adapter is about to dial closes
-        that residual rebind window for BOTH http and https.
+    Crucially, the pinned IP is itself validated (``_assert_ip_allowed``)
+    before it is cached or connected to. ``validate_url`` runs a *separate*
+    pre-flight ``getaddrinfo``; an attacker controlling DNS could answer that
+    lookup with a public IP and answer the adapter's lookup with a private
+    one. Validating the exact address the adapter is about to dial closes
+    that residual rebind window for BOTH http and https.
 
-        For HTTPS the connect address and the TLS identity are decoupled, so
-        pinning the IP does not break SNI-based virtual hosting (most of the
-        web). The original hostname is carried in the URL's userinfo section
-        (``originalhostname@pinnedip:port``) and
-        ``build_connection_pool_key_attributes`` — the extension point
-        ``requests`` documents for exactly this — turns it into two urllib3
-        pool arguments:
+    For HTTPS the connect address and the TLS identity are decoupled, so
+    pinning the IP does not break SNI-based virtual hosting (most of the
+    web). The original hostname is carried in the URL's userinfo section
+    (``originalhostname@pinnedip:port``) and
+    ``build_connection_pool_key_attributes`` — the extension point
+    ``requests`` documents for exactly this — turns it into
+    ``server_hostname``, which urllib3 uses both as the ClientHello SNI and
+    as the name OpenSSL verifies the certificate against, so a certificate
+    valid only for the bare IP is never accepted. It is a ``PoolKey`` field,
+    so two hostnames that resolve to the same IP get distinct connection
+    pools rather than sharing one.
 
-    ``server_hostname``, which
-        urllib3 uses both as the ClientHello SNI and as the name OpenSSL verifies
-        the certificate against, so a certificate valid only for the bare IP is
-        never accepted. It is a ``PoolKey`` field, so two hostnames that resolve
-        to the same IP get distinct connection pools rather than sharing one.
+    ``assert_hostname`` is deliberately NOT set: it would move name checking
+    out of the handshake into urllib3's post-hoc matcher by setting
+    ``check_hostname = False`` on the SSL context — which ``requests`` shares
+    process-wide on some versions, silently weakening every other caller.
 
-        ``assert_hostname`` is deliberately NOT set: it would move name checking
-        out of the handshake into urllib3's post-hoc matcher by setting
-        ``check_hostname = False`` on the SSL context — which ``requests`` shares
-        process-wide on some versions, silently weakening every other caller.
-
-        The socket still connects to the validated, pinned IP: the URL host is
-        the IP, and ``server_hostname`` changes only what is *named* in the
-        handshake, never what is dialed. The SSRF block is unaffected — it fires
-        on the validated IP before any bytes are sent.
+    The socket still connects to the validated, pinned IP: the URL host is
+    the IP, and ``server_hostname`` changes only what is *named* in the
+    handshake, never what is dialed. The SSRF block is unaffected — it fires
+    on the validated IP before any bytes are sent.
     """
 
     def __init__(self, *args, **kwargs):
+        # Without this hook the SNI override below is never called and TLS
+        # silently names the pinned IP again. A capability check rather than a
+        # version parse: requests 2.32.2 also routes through
+        # get_connection_with_tls_context without providing the hook.
+        if not hasattr(HTTPAdapter, "build_connection_pool_key_attributes"):
+            raise RuntimeError(
+                "PinnedIPAdapter needs requests>=2.32.3 to send the correct TLS "
+                f"SNI while pinning the IP, but requests {requests.__version__} "
+                "is installed. Without it every HTTPS fetch names the pinned IP "
+                "in the handshake and CDN-fronted hosts reject the connection. "
+                "Upgrade with: pip install --upgrade 'requests>=2.32.3'"
+            )
         super().__init__(*args, **kwargs)
         self._pinned_cache: Dict[Tuple[str, int], str] = {}
 
@@ -699,26 +709,27 @@ class WebClient:
     ) -> dict:
         """Download a file from URL to local disk.
 
-                Streams to disk to handle large files. Returns dict with
-                path, size, and content_type.
+        Streams to disk to handle large files. Returns dict with
+        path, size, and content_type.
 
         Refuses to overwrite an existing file: the destination is checked (and
-                handed to ``on_path_resolved`` for policy screening) *before* any bytes
-                are written, and the body is streamed to a sibling ``.part`` file that
-                is renamed into place only on success. The filename can come from an
-                attacker-controlled ``Content-Disposition`` header, so a failed policy
-                check must not have already clobbered the user's file. The check is
-                repeated immediately before the rename; a file created in that last
-                instant by another local process is still replaced.
+        handed to ``on_path_resolved`` for policy screening) *before* any bytes
+        are written, and the body is streamed to a sibling ``.part`` file that
+        is renamed into place only on success. The filename can come from an
+        attacker-controlled ``Content-Disposition`` header, so a failed policy
+        check must not have already clobbered the user's file. The check is
+        repeated immediately before the rename, leaving only the sub-microsecond
+        window between that check and ``os.replace`` in which a file created by
+        another local process would still be replaced.
 
-                Args:
-                    url: URL to download
-                    save_dir: Directory to save file in
-                    filename: Override filename (default: from URL/headers)
-                    max_size: Max file size in bytes (default: self._max_download_size)
-                    on_path_resolved: Optional callable invoked with the resolved
-                        destination ``Path`` before the file is created. Raise from it
-                        to refuse the download.
+        Args:
+            url: URL to download
+            save_dir: Directory to save file in
+            filename: Override filename (default: from URL/headers)
+            max_size: Max file size in bytes (default: self._max_download_size)
+            on_path_resolved: Optional callable invoked with the resolved
+                destination ``Path`` before the file is created. Raise from it
+                to refuse the download.
         """
         max_size = max_size or self._max_download_size
 

--- a/tests/integration/test_web_client_live_sni.py
+++ b/tests/integration/test_web_client_live_sni.py
@@ -85,13 +85,26 @@ def test_matches_plain_requests(web_client):
     ), "WebClient failed where plain requests succeeded:\n" + "\n".join(regressions)
 
 
+def _assert_rejected(web_client, url):
+    """The fetch must fail with SSLError, or skip if the host is unreachable.
+
+    "badssl.com is down" and "certificate verification regressed" must not
+    look the same: only the second should turn a lane red.
+    """
+    try:
+        response = web_client.get(url, timeout=30)
+    except requests.exceptions.SSLError:
+        return
+    except (requests.exceptions.ConnectionError, requests.exceptions.Timeout) as exc:
+        pytest.skip(f"{url} unreachable: {exc}")
+    pytest.fail(f"{url} was accepted (HTTP {response.status_code}) instead of rejected")
+
+
 def test_certificate_name_is_still_verified(web_client):
     """Pinning the IP must not disable certificate-name verification."""
-    with pytest.raises(requests.exceptions.SSLError):
-        web_client.get("https://wrong.host.badssl.com/", timeout=30)
+    _assert_rejected(web_client, "https://wrong.host.badssl.com/")
 
 
 def test_expired_certificate_is_still_rejected(web_client):
     """Chain verification is untouched by the SNI change."""
-    with pytest.raises(requests.exceptions.SSLError):
-        web_client.get("https://expired.badssl.com/", timeout=30)
+    _assert_rejected(web_client, "https://expired.badssl.com/")

--- a/tests/integration/test_web_client_live_sni.py
+++ b/tests/integration/test_web_client_live_sni.py
@@ -1,0 +1,97 @@
+# Copyright(C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""Live HTTPS checks for WebClient's IP-pinning adapter.
+
+These need a real server: the IP-pinning adapter can look correct in every
+unit test and still fail every handshake, because only a live TLS peer proves
+the ClientHello it sent was acceptable. Before the SNI fix, 9 of 11 real hosts
+failed through WebClient while succeeding through plain `requests`.
+
+Lives in tests/integration/ because tests/unit/conftest.py blocks sockets.
+"""
+
+import socket
+
+import pytest
+import requests
+
+from gaia.web.client import WebClient
+
+# CDN-fronted hosts that REQUIRE SNI to complete a handshake. Each of these
+# failed through WebClient before the fix (wrong certificate or handshake
+# refusal) while plain `requests` succeeded.
+SNI_FRONTED_HOSTS = [
+    "https://example.com",
+    "https://github.com/amd/gaia",
+    "https://pypi.org/simple/",
+    "https://amd-gaia.ai",
+]
+
+
+def _network_available() -> bool:
+    try:
+        socket.create_connection(("1.1.1.1", 443), timeout=3).close()
+        return True
+    except OSError:
+        return False
+
+
+@pytest.fixture(scope="module")
+def web_client():
+    if not _network_available():
+        pytest.skip("no network access")
+    client = WebClient(rate_limit=0.01)
+    yield client
+    client.close()
+
+
+@pytest.mark.parametrize("url", SNI_FRONTED_HOSTS)
+def test_fetches_sni_fronted_host(web_client, url):
+    """WebClient completes a TLS handshake with a CDN-fronted host."""
+    try:
+        response = web_client.get(url, timeout=30)
+    except requests.exceptions.SSLError as exc:
+        pytest.fail(f"TLS handshake failed for {url} — SNI regression? {exc}")
+    except (requests.exceptions.ConnectionError, requests.exceptions.Timeout) as exc:
+        pytest.skip(f"{url} unreachable: {exc}")
+
+    # 403 still proves the handshake succeeded (bot-blocking page).
+    assert response.status_code in (200, 403), response.status_code
+
+
+def test_matches_plain_requests(web_client):
+    """WebClient must not fail where plain `requests` succeeds.
+
+    This is the shape of the original measurement: the pinning adapter should
+    cost nothing in reachability.
+    """
+    regressions = []
+    for url in SNI_FRONTED_HOSTS:
+        try:
+            web_client.get(url, timeout=30)
+        except requests.exceptions.RequestException as exc:
+            try:
+                requests.get(
+                    url,
+                    timeout=30,
+                    headers={"User-Agent": WebClient.DEFAULT_USER_AGENT},
+                )
+            except requests.exceptions.RequestException:
+                continue  # Unreachable for both — not our regression.
+            regressions.append(f"{url}: {type(exc).__name__}: {exc}")
+
+    assert (
+        not regressions
+    ), "WebClient failed where plain requests succeeded:\n" + "\n".join(regressions)
+
+
+def test_certificate_name_is_still_verified(web_client):
+    """Pinning the IP must not disable certificate-name verification."""
+    with pytest.raises(requests.exceptions.SSLError):
+        web_client.get("https://wrong.host.badssl.com/", timeout=30)
+
+
+def test_expired_certificate_is_still_rejected(web_client):
+    """Chain verification is untouched by the SNI change."""
+    with pytest.raises(requests.exceptions.SSLError):
+        web_client.get("https://expired.badssl.com/", timeout=30)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -564,6 +564,132 @@ class TestApiUnitValidation:
         assert "detail" in error_data
 
 
+class TestRealAgentCallShape:
+    """Drive the endpoint with a REAL Agent subclass, not a MagicMock.
+
+    Regression guard for the class of bug where the server passes a keyword
+    argument no agent accepts. A ``MagicMock`` agent swallows any signature,
+    so mock-based tests stay green while every real request raises
+    ``TypeError``. These tests bind against the actual
+    ``MemoryMixin.process_query`` -> ``Agent.process_query`` chain that the
+    shipped agents use, so a bad call shape fails here.
+    """
+
+    @pytest.fixture(autouse=True)
+    def setup(self, monkeypatch):
+        if not API_AVAILABLE:
+            pytest.skip(f"API dependencies not available: {IMPORT_ERROR}")
+        # Keep the agent off the user's real ~/.gaia memory store.
+        monkeypatch.setenv("GAIA_MEMORY_DISABLED", "1")
+        self.client = TestClient(app)
+
+    def _real_agent(self, monkeypatch, captured):
+        """A real Agent subclass with the shipped mixin chain, no LLM.
+
+        Only ``_process_query_impl`` (the step loop, which needs a live model)
+        is stubbed. Everything above it -- including the real
+        ``process_query`` signatures the server actually calls -- is genuine,
+        so an unexpected kwarg raises ``TypeError`` exactly as in production.
+        """
+        from gaia.agents.base.agent import Agent
+        from gaia.agents.base.memory import MemoryMixin
+
+        class _ProbeAgent(MemoryMixin, Agent):
+            def _register_tools(self):
+                pass
+
+        def fake_impl(self, user_input, max_steps=None, trace=False, filename=None):
+            captured["user_input"] = user_input
+            captured["max_steps"] = max_steps
+            return {"status": "success", "result": "probe answer"}
+
+        monkeypatch.setattr(_ProbeAgent, "_process_query_impl", fake_impl)
+        return _ProbeAgent(skip_lemonade=True, silent_mode=True)
+
+    def test_non_streaming_accepts_real_agent_signature(self, monkeypatch, mocker):
+        """POST /v1/chat/completions succeeds against a real Agent."""
+        captured = {}
+        agent = self._real_agent(monkeypatch, captured)
+
+        from gaia.api.openai_server import registry as server_registry
+
+        mocker.patch.object(server_registry, "get_agent", return_value=agent)
+
+        response = self.client.post(
+            "/v1/chat/completions",
+            json={
+                "model": "gaia",
+                "messages": [{"role": "user", "content": "what is 2+2"}],
+                "stream": False,
+            },
+        )
+
+        assert response.status_code == 200, response.text
+        data = response.json()
+        assert data["choices"][0]["message"]["content"] == "probe answer"
+        # The real agent received the user's message (MemoryMixin may prepend
+        # dynamic context, so match on the tail).
+        assert captured["user_input"].endswith("what is 2+2")
+
+    def test_streaming_accepts_real_agent_signature(self, monkeypatch, mocker):
+        """The streaming branch calls the agent with the same shape."""
+        captured = {}
+        agent = self._real_agent(monkeypatch, captured)
+
+        from gaia.api.openai_server import registry as server_registry
+
+        mocker.patch.object(server_registry, "get_agent", return_value=agent)
+
+        with self.client.stream(
+            "POST",
+            "/v1/chat/completions",
+            json={
+                "model": "gaia",
+                "messages": [{"role": "user", "content": "what is 2+2"}],
+                "stream": True,
+            },
+        ) as response:
+            assert response.status_code == 200, response.text
+            body = "".join(response.iter_text())
+
+        assert "data: [DONE]" in body
+        assert '"error"' not in body, body
+        assert captured["user_input"].endswith("what is 2+2")
+
+    def test_workspace_info_message_does_not_change_the_call(self, monkeypatch, mocker):
+        """A Copilot <workspace_info> block is just message text now.
+
+        The server used to parse it into a ``workspace_root`` kwarg that no
+        agent accepted. Nothing consumes it, so it must not reappear as an
+        extra argument.
+        """
+        captured = {}
+        agent = self._real_agent(monkeypatch, captured)
+
+        from gaia.api.openai_server import registry as server_registry
+
+        mocker.patch.object(server_registry, "get_agent", return_value=agent)
+
+        workspace_msg = (
+            "<workspace_info>\n"
+            "I am working in a workspace with the following folders:\n"
+            "- /home/user/project\n"
+            "</workspace_info>\n"
+            "explain this repo"
+        )
+        response = self.client.post(
+            "/v1/chat/completions",
+            json={
+                "model": "gaia",
+                "messages": [{"role": "user", "content": workspace_msg}],
+                "stream": False,
+            },
+        )
+
+        assert response.status_code == 200, response.text
+        assert response.json()["choices"][0]["message"]["content"] == "probe answer"
+
+
 class TestApiCorsPolicy:
     """CORS must never allow wildcard origins together with credentials."""
 

--- a/tests/unit/test_browser_tools.py
+++ b/tests/unit/test_browser_tools.py
@@ -5,6 +5,7 @@
 
 import os
 import tempfile
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -392,6 +393,248 @@ class TestWebClientDownload:
                 # Should not contain path traversal
                 assert ".." not in result["filename"]
                 assert "/" not in result["filename"]
+
+
+class TestWebClientDownloadDoesNotOverwrite:
+    """A download must never clobber a file the user already has.
+
+    The filename can come straight from a remote, attacker-controlled
+    Content-Disposition header, so `credentials.json` or `report.pdf` from a
+    hostile page must not be able to replace the user's own file -- and a
+    download refused by policy must not have already destroyed it.
+    """
+
+    def setup_method(self):
+        self.client = WebClient()
+
+    def teardown_method(self):
+        self.client.close()
+
+    def _response(self, body=b"hostile payload", disposition=None):
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        headers = {"Content-Type": "application/octet-stream"}
+        if disposition:
+            headers["Content-Disposition"] = disposition
+        mock_response.headers = headers
+        mock_response.iter_content.return_value = [body]
+        return mock_response
+
+    def _patched(self, client, response):
+        return (
+            patch.object(client, "validate_url"),
+            patch.object(client, "_rate_limit_wait"),
+            patch.object(client._session, "get", return_value=response),
+        )
+
+    def test_refuses_to_overwrite_existing_file(self):
+        """An existing file survives a download that would land on it."""
+        response = self._response(disposition='attachment; filename="report.pdf"')
+        v, r, g = self._patched(self.client, response)
+        with v, r, g, tempfile.TemporaryDirectory() as tmpdir:
+            existing = Path(tmpdir) / "report.pdf"
+            existing.write_bytes(b"the user own report")
+
+            with pytest.raises(ValueError, match="Refusing to overwrite"):
+                self.client.download("https://evil.example/x", save_dir=tmpdir)
+
+            # Original content intact; no stray .part left behind.
+            assert existing.read_bytes() == b"the user own report"
+            assert [p.name for p in Path(tmpdir).iterdir()] == ["report.pdf"]
+
+    def test_content_disposition_cannot_target_an_existing_file(self):
+        """The remote header picks the name; it still cannot overwrite."""
+        response = self._response(disposition='attachment; filename="credentials.json"')
+        v, r, g = self._patched(self.client, response)
+        with v, r, g, tempfile.TemporaryDirectory() as tmpdir:
+            secret = Path(tmpdir) / "credentials.json"
+            secret.write_bytes(b'{"token": "real-secret"}')
+
+            with pytest.raises(ValueError, match="Refusing to overwrite"):
+                self.client.download("https://evil.example/x", save_dir=tmpdir)
+
+            assert secret.read_bytes() == b'{"token": "real-secret"}'
+
+    def test_policy_screen_runs_before_the_file_is_created(self):
+        """on_path_resolved refuses BEFORE any bytes hit the disk."""
+        response = self._response(disposition='attachment; filename="blocked.json"')
+        seen = {}
+
+        def screen(dest_path):
+            seen["path"] = dest_path
+            seen["existed_at_screen_time"] = dest_path.exists()
+            raise ValueError("blocked by security policy")
+
+        v, r, g = self._patched(self.client, response)
+        with v, r, g, tempfile.TemporaryDirectory() as tmpdir:
+            with pytest.raises(ValueError, match="blocked by security policy"):
+                self.client.download(
+                    "https://evil.example/x",
+                    save_dir=tmpdir,
+                    on_path_resolved=screen,
+                )
+
+            assert seen["path"].name == "blocked.json"
+            assert seen["existed_at_screen_time"] is False
+            assert list(Path(tmpdir).iterdir()) == []
+
+    def test_successful_download_leaves_no_part_file(self):
+        """The .part file is renamed into place, not left alongside."""
+        response = self._response(disposition='attachment; filename="ok.bin"')
+        v, r, g = self._patched(self.client, response)
+        with v, r, g, tempfile.TemporaryDirectory() as tmpdir:
+            result = self.client.download("https://example.com/x", save_dir=tmpdir)
+            assert Path(result["path"]).read_bytes() == b"hostile payload"
+            assert [p.name for p in Path(tmpdir).iterdir()] == ["ok.bin"]
+
+    def test_existing_part_file_is_reported_not_deleted(self):
+        """A .part in the way is an actionable error, not a silent takeover.
+
+        Deleting it would destroy a concurrent download's in-flight file, so
+        the cleanup path must only remove the .part this call created.
+        """
+        response = self._response(disposition='attachment; filename="x.bin"')
+        v, r, g = self._patched(self.client, response)
+        with v, r, g, tempfile.TemporaryDirectory() as tmpdir:
+            # Another download is mid-flight under the same name.
+            inflight = Path(tmpdir) / "x.bin.part"
+            inflight.write_bytes(b"another download's bytes")
+
+            with pytest.raises(ValueError, match="already"):
+                self.client.download("https://example.com/x", save_dir=tmpdir)
+
+            # The other download's file is untouched.
+            assert inflight.read_bytes() == b"another download's bytes"
+
+    def test_aborted_download_leaves_nothing_behind(self):
+        """A download aborted mid-stream leaves no truncated file."""
+        client = WebClient(max_download_size=10)
+        response = self._response(
+            body=b"x" * 50, disposition='attachment; filename="big.bin"'
+        )
+        v, r, g = self._patched(client, response)
+        try:
+            with v, r, g, tempfile.TemporaryDirectory() as tmpdir:
+                with pytest.raises(ValueError, match="exceeded max size"):
+                    client.download("https://example.com/x", save_dir=tmpdir)
+                assert list(Path(tmpdir).iterdir()) == []
+        finally:
+            client.close()
+
+
+class TestDownloadFileToolScreensBeforeWriting:
+    """download_file screens the destination before the write, not after.
+
+    The old order downloaded first and reacted to a blocked filename by
+    deleting the file -- and only when a _path_validator was attached, so a
+    mixin composed without one kept the overwritten file.
+    """
+
+    def _agent_with_tools(self, validator):
+        from gaia.agents.tools.browser_tools import BrowserToolsMixin
+
+        class MockAgent(BrowserToolsMixin):
+            def __init__(self):
+                self._web_client = MagicMock()
+                self._path_validator = validator
+                self._tools = {}
+
+        registered = {}
+
+        def mock_tool(atomic=True):
+            def decorator(func):
+                registered[func.__name__] = func
+                return func
+
+            return decorator
+
+        with patch("gaia.agents.base.tools.tool", mock_tool):
+            agent = MockAgent()
+            agent.register_browser_tools()
+        return agent, registered
+
+    def test_blocked_filename_is_refused_without_writing(self):
+        """A blocked destination is rejected via the pre-write screen."""
+        validator = MagicMock()
+        validator.is_path_allowed.return_value = True
+        # The directory is fine; the FILENAME is what gets blocked.
+        validator.is_write_blocked.side_effect = lambda p: (
+            (True, "sensitive filename: credentials.json")
+            if p.replace("\\", "/").endswith("credentials.json")
+            else (False, "")
+        )
+        agent, tools = self._agent_with_tools(validator)
+
+        captured = {}
+
+        def fake_download(url, save_dir, filename=None, on_path_resolved=None):
+            captured["screen"] = on_path_resolved
+            # WebClient calls the screen once it has resolved the name, before
+            # it creates the file.
+            on_path_resolved(Path(save_dir) / "credentials.json")
+            raise AssertionError("download must not proceed past the screen")
+
+        agent._web_client.download.side_effect = fake_download
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            result = tools["download_file"]("https://evil.example/x", save_to=tmpdir)
+
+        assert callable(captured["screen"])
+        assert "Error" in result
+        assert "blocked by security policy" in result
+
+    def test_allowed_filename_passes_the_screen(self):
+        """An ordinary filename is not blocked."""
+        validator = MagicMock()
+        validator.is_path_allowed.return_value = True
+        validator.is_write_blocked.return_value = (False, "")
+        agent, tools = self._agent_with_tools(validator)
+
+        def fake_download(url, save_dir, filename=None, on_path_resolved=None):
+            on_path_resolved(Path(save_dir) / "report.pdf")
+            return {
+                "path": str(Path(save_dir) / "report.pdf"),
+                "size": 2048,
+                "content_type": "application/pdf",
+                "filename": "report.pdf",
+            }
+
+        agent._web_client.download.side_effect = fake_download
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            result = tools["download_file"]("https://example.com/x", save_to=tmpdir)
+
+        assert "Downloaded: report.pdf" in result
+        assert "Error" not in result
+
+    def test_screen_is_passed_even_without_a_path_validator(self):
+        """A mixin with no validator still gets the overwrite protection.
+
+        WebClient's own exists() check is unconditional, so an agent that
+        composes BrowserToolsMixin without a _path_validator is protected too.
+        """
+        agent, tools = self._agent_with_tools(None)
+
+        captured = {}
+
+        def fake_download(url, save_dir, filename=None, on_path_resolved=None):
+            captured["screen"] = on_path_resolved
+            # No validator -> the screen is a no-op, not an error.
+            on_path_resolved(Path(save_dir) / "anything.bin")
+            return {
+                "path": str(Path(save_dir) / "anything.bin"),
+                "size": 1,
+                "content_type": "application/octet-stream",
+                "filename": "anything.bin",
+            }
+
+        agent._web_client.download.side_effect = fake_download
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            result = tools["download_file"]("https://example.com/x", save_to=tmpdir)
+
+        assert callable(captured["screen"])
+        assert "Downloaded: anything.bin" in result
 
 
 # ===== BrowserToolsMixin Tests =====

--- a/tests/unit/test_web_client_ip_pinning.py
+++ b/tests/unit/test_web_client_ip_pinning.py
@@ -82,8 +82,8 @@ def test_ip_pinning_prevents_dns_rebind(monkeypatch):
 
 
 def test_https_pinning_preserves_tls_hostname(monkeypatch):
-    """HTTPS requests encode the original hostname in URL userinfo so
-    get_connection sets assert_hostname on the pool."""
+    """HTTPS requests encode the original hostname in URL userinfo so the
+    pool is built with server_hostname set to it."""
 
     def fake_getaddrinfo(host, port, *args, **kwargs):
         return [(socket.AF_INET, socket.SOCK_STREAM, 6, "", ("93.184.216.34", port))]
@@ -105,13 +105,12 @@ def test_https_pinning_preserves_tls_hostname(monkeypatch):
     # URL should contain userinfo with original hostname
     assert "example.com@93.184.216.34:443" in req.url
 
-    # get_connection should strip userinfo and set assert_hostname
-    mock_pool = MagicMock()
-    with patch.object(
-        PinnedIPAdapter.__bases__[0], "get_connection", return_value=mock_pool
-    ):
-        pool = adapter.get_connection(req.url)
-    assert pool.assert_hostname == "example.com"
+    # The pool is keyed on the pinned IP but names the real host in TLS.
+    host_params, pool_kwargs = adapter.build_connection_pool_key_attributes(
+        req, True, None
+    )
+    assert host_params["host"] == "93.184.216.34"
+    assert pool_kwargs["server_hostname"] == "example.com"
 
 
 def test_http_pinning_does_not_set_tls_hostname(monkeypatch):
@@ -169,7 +168,7 @@ def test_ip_pinning_brackets_ipv6_literals(monkeypatch, scheme, port):
 
 
 def test_concurrent_https_requests_use_correct_tls_hostname(monkeypatch):
-    """Each thread's HTTPS request gets the correct assert_hostname on its pool."""
+    """Each thread's HTTPS request gets the correct server_hostname."""
 
     def fake_getaddrinfo(host, port, *args, **kwargs):
         ips = {
@@ -193,24 +192,17 @@ def test_concurrent_https_requests_use_correct_tls_hostname(monkeypatch):
         try:
             req = requests.Request("GET", f"https://{hostname}/path").prepare()
             adapter.send(req)
-            pool = adapter.get_connection(req.url)
-            results[hostname] = pool.assert_hostname
+            _, pool_kwargs = adapter.build_connection_pool_key_attributes(
+                req, True, None
+            )
+            results[hostname] = pool_kwargs["server_hostname"]
         except Exception as exc:
             errors.append(exc)
 
-    # Install the transport + pool-factory patches ONCE around both threads.
-    # Patching a shared class method inside each thread races on install/
-    # teardown and can leak a real network call; a single install is safe.
-    # get_connection returns a FRESH mock per call so each request gets its
-    # own pool — the per-hostname isolation under test.
-    with (
-        patch.object(PinnedIPAdapter.__bases__[0], "send", return_value=mock_resp),
-        patch.object(
-            PinnedIPAdapter.__bases__[0],
-            "get_connection",
-            side_effect=lambda *a, **k: MagicMock(),
-        ),
-    ):
+    # Install the transport patch ONCE around both threads. Patching a shared
+    # class method inside each thread races on install/teardown and can leak a
+    # real network call; a single install is safe.
+    with patch.object(PinnedIPAdapter.__bases__[0], "send", return_value=mock_resp):
         threads = [
             threading.Thread(target=make_request, args=("alpha.example.com",)),
             threading.Thread(target=make_request, args=("beta.example.com",)),
@@ -226,8 +218,8 @@ def test_concurrent_https_requests_use_correct_tls_hostname(monkeypatch):
 
 
 def test_concurrent_same_ip_different_hosts(monkeypatch):
-    """Two hosts resolving to the SAME pinned IP get separate pools with
-    correct assert_hostname — the key race condition this design prevents."""
+    """Two hosts resolving to the SAME pinned IP keep separate TLS identities
+    — the race this design exists to prevent."""
 
     SHARED_IP = "93.184.216.34"
 
@@ -250,26 +242,19 @@ def test_concurrent_same_ip_different_hosts(monkeypatch):
             req = requests.Request("GET", f"https://{hostname}/path").prepare()
             adapter.send(req)
 
-            # Synchronize so both threads call get_connection concurrently
+            # Synchronize so both threads resolve the pool key concurrently.
             barrier.wait()
 
-            pool = adapter.get_connection(req.url)
-            results[hostname] = pool.assert_hostname
+            _, pool_kwargs = adapter.build_connection_pool_key_attributes(
+                req, True, None
+            )
+            results[hostname] = pool_kwargs["server_hostname"]
         except Exception as exc:
             errors.append(exc)
 
-    # Single install of the patches (see sibling test): per-thread context
-    # managers race on teardown and can leak a real connection. A fresh mock
-    # pool per get_connection call proves each host keeps its own
-    # assert_hostname even though both resolve to the same pinned IP.
-    with (
-        patch.object(PinnedIPAdapter.__bases__[0], "send", return_value=mock_resp),
-        patch.object(
-            PinnedIPAdapter.__bases__[0],
-            "get_connection",
-            side_effect=lambda *a, **k: MagicMock(),
-        ),
-    ):
+    # Single install of the patch (see sibling test): per-thread context
+    # managers race on teardown and can leak a real connection.
+    with patch.object(PinnedIPAdapter.__bases__[0], "send", return_value=mock_resp):
         threads = [
             threading.Thread(target=make_request, args=("site-a.example.com",)),
             threading.Thread(target=make_request, args=("site-b.example.com",)),
@@ -416,3 +401,97 @@ def test_full_request_succeeds_for_public_host(monkeypatch):
         )
     finally:
         client.close()
+
+
+# ---------------------------------------------------------------------------
+# SNI: the pinned IP must not become the TLS server name
+#
+# The adapter connects to a validated, pinned IP but must still NAME the real
+# hostname in the TLS ClientHello, or every SNI-vhosted host (most CDNs)
+# returns the wrong certificate or refuses the handshake.
+# ---------------------------------------------------------------------------
+
+
+def _pinned_https_request(monkeypatch, hostname, ip):
+    """Build the PreparedRequest the adapter produces for an HTTPS URL."""
+    monkeypatch.setattr(
+        socket,
+        "getaddrinfo",
+        lambda host, port, *a, **k: [(socket.AF_INET, 1, 6, "", (ip, port))],
+    )
+    adapter = PinnedIPAdapter()
+    req = requests.Request("GET", f"https://{hostname}/page").prepare()
+    with patch.object(PinnedIPAdapter.__bases__[0], "send", return_value=MagicMock()):
+        adapter.send(req)
+    return adapter, req
+
+
+def test_https_pool_kwargs_set_sni_server_hostname(monkeypatch):
+    """The TLS pool is built with server_hostname = the real hostname.
+
+    Without this the ClientHello carries the IP and SNI-vhosted servers fail.
+    """
+    adapter, req = _pinned_https_request(monkeypatch, "example.com", "93.184.216.34")
+
+    host_params, pool_kwargs = adapter.build_connection_pool_key_attributes(
+        req, True, None
+    )
+
+    # Connect address stays the validated, pinned IP...
+    assert host_params["host"] == "93.184.216.34"
+    assert host_params["scheme"] == "https"
+    # ...while the TLS identity is the real hostname. server_hostname is what
+    # urllib3 puts in the ClientHello AND what OpenSSL verifies the cert
+    # against, so this one key covers both.
+    assert pool_kwargs["server_hostname"] == "example.com"
+
+
+def test_http_pool_kwargs_have_no_tls_hostname(monkeypatch):
+    """Plain HTTP carries no userinfo, so no TLS pool arguments are added."""
+    monkeypatch.setattr(
+        socket,
+        "getaddrinfo",
+        lambda host, port, *a, **k: [
+            (socket.AF_INET, 1, 6, "", ("93.184.216.34", port))
+        ],
+    )
+    adapter = PinnedIPAdapter()
+    req = requests.Request("GET", "http://example.com/page").prepare()
+    with patch.object(PinnedIPAdapter.__bases__[0], "send", return_value=MagicMock()):
+        adapter.send(req)
+
+    host_params, pool_kwargs = adapter.build_connection_pool_key_attributes(
+        req, True, None
+    )
+    assert host_params["host"] == "93.184.216.34"
+    assert "server_hostname" not in pool_kwargs
+
+
+def test_same_ip_different_hosts_get_separate_pools(monkeypatch):
+    """Two hostnames on one IP must not share a TLS connection pool.
+
+    server_hostname is a urllib3 PoolKey field, so distinct hostnames key
+    distinct pools instead of racing to overwrite each other's TLS identity.
+    """
+    shared_ip = "93.184.216.34"
+    adapter = PinnedIPAdapter()
+    pools = {}
+    for hostname in ("alpha.example", "beta.example"):
+        monkeypatch.setattr(
+            socket,
+            "getaddrinfo",
+            lambda host, port, *a, **k: [(socket.AF_INET, 1, 6, "", (shared_ip, port))],
+        )
+        req = requests.Request("GET", f"https://{hostname}/").prepare()
+        with patch.object(
+            PinnedIPAdapter.__bases__[0], "send", return_value=MagicMock()
+        ):
+            adapter.send(req)
+        pools[hostname] = adapter.get_connection_with_tls_context(req, True)
+
+    assert pools["alpha.example"] is not pools["beta.example"]
+    assert pools["alpha.example"].conn_kw["server_hostname"] == "alpha.example"
+    assert pools["beta.example"].conn_kw["server_hostname"] == "beta.example"
+    # Both still dial the same pinned IP.
+    assert pools["alpha.example"].host == shared_ip
+    assert pools["beta.example"].host == shared_ip

--- a/tests/unit/test_web_client_ip_pinning.py
+++ b/tests/unit/test_web_client_ip_pinning.py
@@ -495,3 +495,35 @@ def test_same_ip_different_hosts_get_separate_pools(monkeypatch):
     # Both still dial the same pinned IP.
     assert pools["alpha.example"].host == shared_ip
     assert pools["beta.example"].host == shared_ip
+
+
+def test_adapter_refuses_to_start_without_the_sni_hook(monkeypatch):
+    """An old requests must fail loudly, not silently revert to IP-as-SNI.
+
+    build_connection_pool_key_attributes arrived in requests 2.32.3. Without
+    it the override never runs and every HTTPS fetch names the pinned IP in
+    the handshake again — the exact bug the adapter exists to avoid. A pin in
+    setup.py only covers fresh installs, so the check has to be at runtime.
+    """
+    monkeypatch.delattr(
+        requests.adapters.HTTPAdapter,
+        "build_connection_pool_key_attributes",
+        raising=True,
+    )
+
+    with pytest.raises(RuntimeError) as excinfo:
+        PinnedIPAdapter()
+
+    message = str(excinfo.value)
+    # The error has to name the requirement, the actual state, and the fix.
+    assert "2.32.3" in message
+    assert requests.__version__ in message
+    assert "pip install" in message
+
+
+def test_adapter_constructs_on_a_supported_requests():
+    """The guard is a capability check, so it passes on the pinned floor."""
+    assert hasattr(
+        requests.adapters.HTTPAdapter, "build_connection_pool_key_attributes"
+    ), "test environment predates requests 2.32.3"
+    assert PinnedIPAdapter() is not None


### PR DESCRIPTION
## Summary

Fixes three shipped features that are broken in ordinary use: `gaia api` returned HTTP 500 on every chat completion, web fetch failed on most HTTPS sites, and a download could silently replace a file the user already had.

## Why

`POST /v1/chat/completions` failed on *every* request, streaming or not — the server passed a `workspace_root=` keyword that no agent accepts, so the call raised before reaching the model. The whole endpoint was dead for anyone running the flagship agent.

Web fetch was failing on most of the web. The IP-pinning adapter closed a DNS-rebinding window by rewriting the request URL's host to the resolved IP, which meant every HTTPS request went out with no SNI — so any host that picks its certificate by SNI returned the wrong one or refused the handshake. Measured live, 9 of 11 hosts failed through `WebClient` while succeeding through plain `requests`, including GitHub, PyPI, Hugging Face and GAIA's own `amd-gaia.ai`. "Summarise this GitHub URL" returned an SSL error.

The third is the reason the first two ship together. `download_file` took its filename from the remote `Content-Disposition` header and opened the destination with no existence check, so a page serving `filename=report.pdf` replaced the user's own `~/Downloads/report.pdf`. Today the handshake usually fails first, so the write path is rarely reached — fixing SNI *un-gates* it. It is fixed in the earlier commit on purpose.

## Linked issue

Closes #3360

## Changes

- **API** — dropped the `workspace_root` kwarg and the `extract_workspace_root` helper that fed it. Nothing consumed it: its only consumer was a deleted agent, and no agent implements the `set_workspace_root` hook the spec described. A Copilot `<workspace_info>` block is now ordinary message text.
- **Web fetch** — SNI is set via `build_connection_pool_key_attributes`, the extension point `requests` documents for this, so the socket still dials the validated pinned IP while TLS names the real host. `assert_hostname` is deliberately *not* set: it moves name checking out of the handshake and flips `check_hostname = False` on an SSL context `requests` shares process-wide on some versions. `requests` is pinned `>=2.32.3` — **2.32.2 is specifically unusable**, it routes through `get_connection_with_tls_context` but has no such hook, so SNI would silently revert to the IP.
- **Download** — the destination is checked, and handed to the caller's policy screen, *before* anything is created; the body streams to a `.part` file renamed into place only on success. The sensitive-filename blocklist moved from after the write (where it reacted by deleting the file, and only when a `_path_validator` was attached) to before it.
- The live TLS test is wired into the unit-tests workflow — an adapter like this can pass every offline test and still fail every real handshake.

The rebinding defence is unchanged and re-verified: `validate_url` still rejects a hostname if *any* answer is private, the adapter still re-validates the exact IP it dials, and each redirect hop is still re-validated.

## Test plan

- [x] `python util/lint.py --all` — Black / isort / Flake8 / Bandit pass. Pylint reports 9 pre-existing errors, all `os.killpg`/`geteuid` Windows false positives in `daemon/sidecars/*` and `installer/lemonade_installer.py`; none in a file this PR touches.
- [x] `pytest tests/unit/test_browser_tools.py` — 73 passed
- [x] `pytest tests/unit/test_web_client_ip_pinning.py tests/integration/test_web_client_live_sni.py` — 24 passed
- [x] `pytest tests/test_api.py` — 57 passed, 22 skipped (skips are `gaia_agent_email`-gated)
- [x] Every unit/integration test file that imports the three changed modules — **462 passed, 0 failed**.
- [x] Pre-existing baseline, so a reviewer is not surprised: on Windows the full `pytest tests/unit/` has ~1000 failures/errors from the known `socket.socketpair()` / `_block_network` guard, and `tests/test_sdk.py` fails 17 tests. Both reproduce identically with this branch's source files reverted to `upstream/main`. None are in a file this PR touches. CI runs these on ubuntu, where the socket guard does not fire.
- [x] **New tests fail against the previous code**, which is the point: 3/3 API tests fail with `TypeError: Agent.process_query() got an unexpected keyword argument 'workspace_root'`; 5/7 live TLS tests fail with `SSLError`; 6/8 download tests fail.
- [x] **CI lanes confirmed to actually run them, not skip them.** `tests/unit/**` → `test_unit.yml` (`pytest tests/unit/`, installs `.[api]` + `pytest-mock`). `tests/test_api.py` → `test_api.yml` (triggers on `src/gaia/api/**` and `tests/test_api.py`, installs `.[dev,api]`, so `fastapi` is present and the new class runs rather than skipping). `tests/integration/test_web_client_live_sni.py` had **no** lane — added as a step to `test_unit.yml`, alongside the existing live-upstream Lemonade asset test. Verified with `-v` that every new test reports `PASSED`, none `SKIPPED`.

### Agent eval — `tool_selection`, no regressions

This touches an LLM-affecting surface (two lines added to `download_file`'s `@tool` docstring), so per CLAUDE.md an eval is required. It ran **against this branch at `87b9479c`** — the Agent UI backend on `:4200` was started from this worktree's own venv, so the numbers describe this PR's code, not an installed release. Lemonade served `Gemma-4-E4B-it-GGUF` on GPU at `ctx_size=32768`. `tool_selection` is the category the changed tool docstring feeds.

```
gaia eval agent --category tool_selection
→ Results: 4/5 passed (80% all, 80% judged), Avg score: 8.7/10
  Output: eval/results/eval-20260904-210550/

gaia eval agent --compare \
  tests/fixtures/eval_baselines/gemma-4-e4b-d71cd914/scorecard_tool_selection.json \
  eval/results/eval-20260904-210550/scorecard.json
```

<details>
<summary>🔍 `gaia eval agent --compare` — the tool's own output</summary>

```
SCORECARD COMPARISON
  Baseline : tests\fixtures\eval_baselines\gemma-4-e4b-d71cd914\scorecard_tool_selection.json
  Current  : eval\results\eval-20260904-210550\scorecard.json
======================================================================

METRIC                           BASELINE    CURRENT      DELTA
--------------------------------------------------------------
Pass rate (all)                       75%        80%        +5%
Pass rate (judged)                    75%        80%        +5%
Avg score                             8.4        8.7       +0.3
Scenarios                               4          5

[+] IMPROVED (1 scenario(s)) — FAIL → PASS:
    known_path_read                          6.7 → 9.6 (+2.9)

[~] TIME REGRESSION (1 scenario(s)) — elapsed > 2x baseline:
    smart_discovery                          179.1s → 417.2s

[~] SCORE CHANGED, STATUS SAME (1 scenario(s)):
    multi_step_plan                          PASS  7.3 → 9.8 (+2.5)

[=] UNCHANGED (1 scenario(s)):
    no_tools_needed                          PASS  10.0

[+] ONLY IN CURRENT (1 scenario(s)) — new scenarios:
    data_vs_recall_disambiguation

======================================================================
[WARN] 1 time regression(s) detected (elapsed time > 2x baseline)!
[OK]   Net improvement: 1 scenario(s) fixed, 0 regressions.
======================================================================

[ERROR] Detected 1 issue(s) (status regressions, score regressions, or time regressions); failing.
```

</details>

| Metric | Baseline | Current | Δ |
|---|---|---|---|
| Pass rate (all) | 75% | **80%** | +5% |
| Pass rate (judged) | 75% | **80%** | +5% |
| Avg score | 8.4 | **8.7** | +0.3 |
| Scenarios | 4 | 5 | +1 |

Per scenario:

| Scenario | Baseline | Current |
|---|---|---|
| `known_path_read` | FAIL 6.7 | **PASS 9.6** |
| `multi_step_plan` | PASS 7.3 | PASS 9.8 |
| `no_tools_needed` | PASS 10.0 | PASS 10.0 |
| `smart_discovery` | PASS 9.5 | PASS 8.1 |
| `data_vs_recall_disambiguation` | *not in baseline* | FAIL 6.4 |

**No status or score regressions.** The baseline's one failing scenario now passes.

Three caveats, so the numbers are not read for more than they are worth:

- **The score deltas are not purely behavioural.** The baseline was judged by `claude-sonnet-4-6`, this run by `claude-opus-5`; the compare tool warns about exactly this. Treat "no regression" as the signal, not the `+2.5` on `multi_step_plan`.
- **`data_vs_recall_disambiguation` has no baseline entry** because it did not exist yet: it was added 2026-06-25 in #1844, two months after the baseline was captured (2026-04-24). The extra scenario is not a discrepancy. On the 4 overlapping scenarios the result is 4/4 pass vs the baseline's 3/4.
- **Zero scenarios errored.** The same command errored all 5 at 0 turns before the auth cause below was found (run `eval-20260904-210157`), so the clean run is itself the confirmation that the diagnosis was right.
- **The one flagged "time regression" is hardware, not this change.** `smart_discovery` went 179s → 417s, but the baseline machine sustained 109–115 tok/s where this one runs at 38–45 tok/s — ~2.7× slower, which accounts for the gap on the token-heaviest scenario (8335→2083 tokens). The other three scenarios are *faster* in wall-clock despite that. The docstring addition is ~25 tokens on one tool description, 0.3% of that prompt.

<details>
<summary>🔍 Two pre-existing eval-harness defects found while getting this to run</summary>

Both are untouched by this PR and are filed separately as #3367 and #3368:

- **`runner.py:949` adds `--bare` whenever `ANTHROPIC_API_KEY` is non-empty**, and `--bare` restricts auth to that key — OAuth and keychain are never consulted. Because `load_dotenv()` walks up parent directories, a `.env` anywhere above the checkout injects a key into the process even when the shell has none, silently disabling working subscription auth. A stale key then surfaces as HTTP 400 `"Credit balance is too low"`, which points at billing rather than at the override. This is the "no silent fallbacks" rule in CLAUDE.md: it should fail loudly on an auth error, or prefer OAuth when the key is rejected.
- **The runner discards the judge subprocess body on failure**, recording `"error": ""`. The real cause above was invisible until the call was instrumented by hand.

</details>

## Evidence

**HTTP API / REST** — real requests against `gaia api start --port 8199` with the flagship agent installed and Lemonade serving `Gemma-4-E4B-it-GGUF`.

Before (this commit's parent):

```
$ curl -sS -X POST http://127.0.0.1:8199/v1/chat/completions -H 'Content-Type: application/json' \
    -d '{"model":"gaia","messages":[{"role":"user","content":"What is 17 * 23? Answer with just the number."}],"stream":false}' -w '\nHTTP_STATUS=%{http_code}\n'
Internal Server Error
HTTP_STATUS=500

# server log:
result = agent.process_query(user_message, workspace_root=workspace_root)
TypeError: Agent.process_query() got an unexpected keyword argument 'workspace_root'
```

After — same request, same server:

```
{"id":"chatcmpl-675e7b945f51450595107565","object":"chat.completion","created":1788546133,"model":"gaia",
 "choices":[{"index":0,"message":{"role":"assistant","content":"391","tool_calls":null},"finish_reason":"stop"}],
 "usage":{"prompt_tokens":11,"completion_tokens":0,"total_tokens":11}}
HTTP_STATUS=200
```

Streaming path — 7 chunks, terminates with `data: [DONE]`, no `"error"` in the body. A Copilot `<workspace_info>` payload also returns 200 (`5 plus 6` → `11`).

<details>
<summary>🔍 Web fetch — before/after probe across 11 hosts</summary>

Same script, same machine, only `client.py` differing. `www.amd.com` times out identically both ways and through plain `requests`, so it is not an SNI failure.

| Host | `WebClient` before | `WebClient` after | plain `requests` |
|---|---|---|---|
| example.com | FAIL SSLError | **OK 200** | OK 200 |
| github.com/amd/gaia | FAIL SSLError | **OK 200** | OK 200 |
| pypi.org | FAIL SSLError (cert `*.python.org`) | **OK 200** | OK 200 |
| huggingface.co | FAIL SSLError | **OK 200** | OK 200 |
| amd-gaia.ai | FAIL SSLError | **OK 200** | OK 200 |
| lemonade-server.ai | FAIL SSLError | **OK 200** | OK 200 |
| arxiv.org | FAIL SSLError (cert `s.sni-810-default.ssl.fastly.net`) | **OK 200** | OK 200 |
| stackoverflow.com | FAIL SSLError | **OK 403** | OK 403 |
| www.amd.com | FAIL ReadTimeout | FAIL ReadTimeout | FAIL ReadTimeout |
| en.wikipedia.org | OK 200 | OK 200 | OK 200 |
| duckduckgo.com | OK 200 | OK 200 | OK 200 |

**9 of 11 failed → 1 of 11 fails**, and the one remaining failure is identical under plain `requests`.

Security posture re-verified after the change:

```
PASS  validate_url still checks EVERY answer   (127.0.0.1 in the answer set -> blocked)
PASS  adapter still re-validates the exact dialed IP  (169.254.169.254 -> blocked)
PASS  scheme guard rejects file:// and ftp://;  port guard rejects :22
PASS  _request and download both re-validate each redirect hop
PASS  host_params={'scheme':'https','host':'104.20.23.154'}, server_hostname='example.com'
PASS  wrong.host.badssl.com / expired.badssl.com / self-signed.badssl.com all rejected (SSLError)
```

</details>

<details>
<summary>🔍 Download — live run of the download_file tool</summary>

Live run of the **tool** (not `WebClient` directly), into a directory that already holds a `README.md`:

```
=== BEFORE (upstream/main) ===
$ cat README.md
MY OWN IMPORTANT NOTES

>>> download_file("https://raw.githubusercontent.com/amd/gaia/main/README.md", save_to=...)
Downloaded: README.md
  Size: 7.3 KB
  Type: text/plain; charset=utf-8

$ cat README.md
# <img src="https://raw.githubusercontent.com/amd/gaia/main/     <-- user's notes destroyed,
                                                                     tool reported success

=== AFTER (this branch) ===
$ cat README.md
MY OWN IMPORTANT NOTES

>>> download_file("https://raw.githubusercontent.com/amd/gaia/main/README.md", save_to=...)
Error: Refusing to overwrite existing file: ...\README.md.
       Pass an explicit filename= to download under a different name.

$ cat README.md
MY OWN IMPORTANT NOTES                                            <-- intact
$ ls
['README.md']

>>> same tool, a free filename
Downloaded: gaia-readme.md
  Size: 7.3 KB
$ ls
['README.md', 'gaia-readme.md']
```

</details>

<details>
<summary>🔍 Runtime guard against an older requests</summary>

`build_connection_pool_key_attributes` only exists in requests >= 2.32.3, so on anything older the SNI override silently never runs. `PinnedIPAdapter` now refuses to construct. Verified against real wheels:

| requests | result |
|---|---|
| 2.31.0 | refused |
| 2.32.2 | refused (routes through `get_connection_with_tls_context` but ships no hook) |
| 2.32.3 | constructs |
| 2.34.2 | constructs |

```
RuntimeError: PinnedIPAdapter needs requests>=2.32.3 to send the correct TLS SNI while
pinning the IP, but requests 2.31.0 is installed. Without it every HTTPS fetch names the
pinned IP in the handshake and CDN-fronted hosts reject the connection.
Upgrade with: pip install --upgrade 'requests>=2.32.3'
```

</details>

<details>
<summary>🔍 Download — WebClient-level before/after</summary>

A directory containing the user's own `README.md`, then downloading a URL whose name resolves to `README.md`:

```
=== BEFORE ===
before:  README.md = b'MY OWN IMPORTANT NOTES'
download returned: 7463 bytes
after:   README.md = b'# <img src="https://raw.githubuserconten'   <-- user's file destroyed

=== AFTER ===
before:  README.md = b'MY OWN IMPORTANT NOTES'
download refused: ValueError: Refusing to overwrite existing file: ...\README.md.
                  Pass an explicit filename= to download under a different name.
after:   README.md = b'MY OWN IMPORTANT NOTES'   <-- intact
dir now: ['README.md']
fresh download OK: 7463 bytes, dir now: ['README.md', 'fresh.md']   <-- a free name still works
```

</details>

- [x] **HTTP API / REST** — real request and response above.
- [x] **CLI** — `gaia api start` used to produce the evidence above.
- [ ] **Agent exposed in the Agent UI** — N/A, no Agent UI surface changed.
- [ ] **MCP tools / servers** — N/A, no MCP surface changed.

## Checklist

- [x] I have linked a GitHub issue above (`Closes #3360`).
- [x] I have described **why** this change is being made, not just what changed.
- [x] I have run linting and tests locally (`python util/lint.py --all`, `pytest tests/unit/`).
- [x] I have attached **real-world evidence matched to the surface I changed**, or marked each surface N/A.
- [x] I have updated documentation if user-visible behavior changed — `docs/spec/api-server.mdx` (removed the workspace-root section and renumbered the flow) and `docs/spec/browser-tools.mdx` + the `@tool` docstring (the new overwrite refusal, so the model learns the rule instead of discovering it from an error).





