### PR TITLE
fix(ui): stop any web page from driving the Agent UI backend

### DIFF
--- a/docs/guides/email-integration.mdx
+++ b/docs/guides/email-integration.mdx
@@ -356,9 +356,11 @@ Key rules the endpoint enforces (all fail loudly):
 - **`grant_agents` must include `installed:email`.** Without this grant the connection
   exists but the email agent can't resolve it at send time, and you'll hit a "no grant"
   dead end. (Ties to #1592.)
-- **`X-Gaia-UI: 1` header is required** on the POST and DELETE. It's a CSRF guard — a
-  custom header forces a CORS preflight, so a drive-by form POST can't forge it. Missing
-  header → **403**.
+- **`X-Gaia-UI: 1` header is required** on the POST and DELETE — and now on *every*
+  mutating request to `/api/*` and `/v1/*`, the whole of `/v1/email/*` included. It's a
+  CSRF guard: a custom header forces a CORS preflight, so a page the user happens to be
+  visiting can't forge it. Missing header → **403 `missing X-Gaia-UI header`**. A request
+  whose `Origin` is neither this server nor loopback is refused the same way.
 - **Empty `client_id` / `refresh_token` → 422.** Missing required scopes for the granted
   agent → **403** with a `missing_scopes` detail. GAIA cannot widen scope at refresh
   time, so forward everything the agent needs up front.
@@ -382,6 +384,7 @@ unavailable on it — triage returns **HTTP 502** naming the URL and the fix.
 
 ```bash
 curl -s -X POST http://127.0.0.1:4200/v1/email/triage \
+  -H "X-Gaia-UI: 1" \
   -H "Content-Type: application/json" \
   -d '{
     "payload": {
@@ -487,6 +490,7 @@ Answer it out of band; the **original** stream resumes — do not issue a second
 
 ```bash
 curl -s -X POST http://127.0.0.1:4200/v1/email/query/$RUN_ID/respond \
+  -H 'X-Gaia-UI: 1' \
   -H 'content-type: application/json' \
   -d '{"request_id": "8c21…", "value": "yes"}'
 # {"run_id":"0f9c…","request_id":"8c21…","accepted":true,"status":"ok"}
@@ -515,6 +519,7 @@ token. This is a safety invariant, not a preference.
 
 ```bash
 curl -s -X POST http://127.0.0.1:4200/v1/email/draft \
+  -H "X-Gaia-UI: 1" \
   -H "Content-Type: application/json" \
   -d '{
     "to": [{ "email": "sarah@example.com" }],
@@ -541,6 +546,7 @@ approval, and only echo the token back on an approved send.
 
 ```bash
 curl -s -o /dev/null -w "%{http_code}\n" -X POST http://127.0.0.1:4200/v1/email/send \
+  -H "X-Gaia-UI: 1" \
   -H "Content-Type: application/json" \
   -d '{ "to": [{ "email": "sarah@example.com" }],
         "subject": "Re: Prod incident follow-up",
@@ -555,6 +561,7 @@ The 403 body explains the gate: call `/v1/email/draft` for a token bound to this
 
 ```bash
 curl -s -X POST http://127.0.0.1:4200/v1/email/send \
+  -H "X-Gaia-UI: 1" \
   -H "Content-Type: application/json" \
   -d '{
     "to": [{ "email": "sarah@example.com" }],

--- a/docs/spec/agent-ui-server.mdx
+++ b/docs/spec/agent-ui-server.mdx
@@ -81,7 +81,7 @@ def create_app(db_path: str = None, webui_dist: str = None) -> FastAPI:
 ```
 
 Creates a configured FastAPI application with:
-- CORS middleware (allows all origins for local use)
+- Request guard + CORS middleware (see [Security Considerations](#security-considerations))
 - Database initialization and shared `AgentRegistry`
 - Router registration (`include_router` for each module above)
 - Static file serving (for web frontend, when `dist/` build exists)
@@ -248,7 +248,10 @@ All 14 Pydantic models:
 
 ## Security Considerations
 
-- **CORS:** Uses an allowlist of localhost origins plus ngrok regex. The standalone server (`python -m gaia.ui.server`) binds to `localhost` by default. Note: `gaia chat --ui` binds to `0.0.0.0` for Electron/browser access
+- **CSRF:** Every mutating (`POST`/`PUT`/`PATCH`/`DELETE`) request to `/api/*` or `/v1/*` must carry `X-Gaia-UI: 1`. A page cannot set a custom header cross-origin without a CORS preflight, and preflights are approved only from GAIA's own origins — so a site the user visits cannot drive the backend. Enforced in `UIRequestGuardMiddleware` (`gaia/ui/security.py`), not per route, so a new route is covered on the day it lands
+- **Origin:** A mutating request whose `Origin` is neither this server, loopback, nor the live tunnel is refused with 403. Extend with `GAIA_UI_ALLOWED_ORIGINS` (comma-separated) when fronting the backend with a proxy
+- **Host:** A request whose `Host` is a name the server does not know is refused with 400, which blocks DNS rebinding. IP literals and loopback names always pass, so `--host 0.0.0.0` LAN access keeps working; add named hosts with `GAIA_UI_ALLOWED_HOSTS`
+- **CORS:** An allowlist of localhost dev origins. No tunnel origin is listed: the mobile flow serves the SPA *from* the tunnel, so those requests are same-origin and CORS never applies. The standalone server (`python -m gaia.ui.server`) binds to `localhost` by default
 - **No authentication:** Designed for single-user local use. Do not expose to untrusted networks
 - **File path validation:** The `upload-path` endpoint sanitizes all user-provided paths:
   - Null byte rejection (prevents path injection)

--- a/src/gaia/apps/webui/services/agent-process-manager.cjs
+++ b/src/gaia/apps/webui/services/agent-process-manager.cjs
@@ -69,7 +69,7 @@ const INSTALL_POLL_INTERVAL = 750;
  */
 const INSTALL_TIMEOUT = 15 * 60 * 1000;
 
-/** Header the UI backend requires on state-changing hub routes (see hub.py). */
+/** Header the UI backend requires on every mutating route (see gaia/ui/security.py). */
 const UI_HEADER = { "X-Gaia-UI": "1" };
 
 // ── AgentProcessManager ──────────────────────────────────────────────────

--- a/src/gaia/apps/webui/src/services/api.ts
+++ b/src/gaia/apps/webui/src/services/api.ts
@@ -27,6 +27,17 @@ function getFriendlyError(status: number, detail: string): string {
     }
 }
 
+/**
+ * CSRF marker required by the backend on every mutating request.
+ *
+ * A cross-origin page cannot set a custom header without a CORS
+ * preflight, and the backend approves preflights only from its own
+ * origins — so this is what stops a page the user visits from driving
+ * the Agent UI. Sent on reads too: a few read routes require it, and one
+ * unconditional rule is one fewer thing to forget.
+ */
+export const UI_HEADER = { 'x-gaia-ui': '1' };
+
 /** Fetch wrapper with logging, timing, and error handling. */
 async function apiFetch<T>(
     method: string,
@@ -44,9 +55,9 @@ async function apiFetch<T>(
         : {};
     const init: RequestInit = {
         method,
-        // extraHeaders first so Content-Type cannot be accidentally overridden
-        // by a caller for body requests.
-        headers: { ...extraHeaders, ...baseHeaders },
+        // UI_HEADER first so no caller can drop it; extraHeaders next so
+        // Content-Type cannot be accidentally overridden for body requests.
+        headers: { ...UI_HEADER, ...extraHeaders, ...baseHeaders },
         body: body !== undefined ? JSON.stringify(body) : undefined,
     };
 
@@ -216,7 +227,6 @@ export async function rollbackAgent(agentId: string): Promise<InstallStatus> {
 import type { AgentMcpServer, ConnectorRow } from '../types';
 
 // New framework endpoints (T-8b) — /api/connectors
-const UI_HEADER = { 'x-gaia-ui': '1' };
 
 export async function listConnectors(): Promise<{ connectors: ConnectorRow[] }> {
     return apiFetch('GET', '/connectors');
@@ -515,7 +525,7 @@ export function sendMessageStream(
 
     fetch(`${API_BASE}/chat/send`, {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+        headers: { ...UI_HEADER, 'Content-Type': 'application/json' },
         body: JSON.stringify({
             session_id: sessionId,
             message,
@@ -729,7 +739,7 @@ export async function uploadDocumentBlob(file: File): Promise<Document> {
 
     let res: Response;
     try {
-        res = await fetch(url, { method: 'POST', body: formData });
+        res = await fetch(url, { method: 'POST', headers: UI_HEADER, body: formData });
     } catch (err) {
         log.api.error(`POST ${url} - network error`, err);
         throw err;
@@ -810,6 +820,7 @@ export async function uploadFile(file: File): Promise<{
 
     const res = await fetch(url, {
         method: 'POST',
+        headers: UI_HEADER,
         body: formData,
     });
 

--- a/src/gaia/eval/behavior_harness.py
+++ b/src/gaia/eval/behavior_harness.py
@@ -234,7 +234,11 @@ class BehaviorHarness:
         import requests  # local import — only needed when the harness actually runs
 
         url = f"{self._base_url}{path}"
-        resp = requests.post(url, json=body, timeout=self._timeout)
+        # The backend refuses mutating /api requests without this header
+        # (gaia/ui/security.py) — a browser cannot forge it cross-origin.
+        resp = requests.post(
+            url, json=body, timeout=self._timeout, headers={"X-Gaia-UI": "1"}
+        )
         resp.raise_for_status()
         return resp.json()
 

--- a/src/gaia/eval/runner.py
+++ b/src/gaia/eval/runner.py
@@ -782,7 +782,7 @@ def _probe_memory_admin(backend_url: str) -> Optional[str]:
     req = urllib.request.Request(
         f"{backend_url}/api/memory/admin/seed",
         data=b'{"items":[]}',
-        headers={"Content-Type": "application/json"},
+        headers={"Content-Type": "application/json", "X-Gaia-UI": "1"},
         method="POST",
     )
     try:

--- a/src/gaia/mcp/servers/agent_ui_mcp.py
+++ b/src/gaia/mcp/servers/agent_ui_mcp.py
@@ -39,6 +39,12 @@ logger = logging.getLogger(__name__)
 
 # Default GAIA Agent UI backend URL
 DEFAULT_BACKEND = "http://localhost:4200"
+
+# The backend refuses any mutating /api request that does not carry this
+# header — it is what stops a web page the user visits from driving the
+# Agent UI (see gaia/ui/security.py). Sent on reads too so no call site
+# has to decide.
+UI_HEADER = {"X-Gaia-UI": "1"}
 MCP_DEFAULT_PORT = 8765
 MCP_DEFAULT_HOST = "localhost"
 
@@ -78,8 +84,9 @@ def _normalize_error(
 def _api(base_url: str, method: str, path: str, **kwargs) -> Dict[str, Any]:
     """Make an API request to the GAIA Agent UI backend."""
     url = f"{base_url}/api{path}"
+    headers = {**UI_HEADER, **kwargs.pop("headers", {})}
     try:
-        r = getattr(requests, method)(url, timeout=120, **kwargs)
+        r = getattr(requests, method)(url, timeout=120, headers=headers, **kwargs)
         r.raise_for_status()
         return r.json()
     except requests.exceptions.ConnectionError as e:
@@ -112,7 +119,9 @@ def _stream_chat(base_url: str, session_id: str, message: str) -> Dict[str, Any]
     }
 
     try:
-        r = requests.post(url, json=payload, stream=True, timeout=180)
+        r = requests.post(
+            url, json=payload, stream=True, timeout=180, headers=UI_HEADER
+        )
         r.raise_for_status()
     except requests.exceptions.ConnectionError as e:
         return _normalize_error(e, base_url)
@@ -288,7 +297,11 @@ def create_agent_ui_mcp(backend_url: str = DEFAULT_BACKEND) -> "MCPServer":
     def delete_session(session_id: str) -> Dict[str, Any]:
         """Delete a chat session and all its messages."""
         try:
-            r = requests.delete(f"{backend_url}/api/sessions/{session_id}", timeout=30)
+            r = requests.delete(
+                f"{backend_url}/api/sessions/{session_id}",
+                timeout=30,
+                headers=UI_HEADER,
+            )
             r.raise_for_status()
             return {"deleted": True, "session_id": session_id}
         except Exception as e:

--- a/src/gaia/ui/routers/agents.py
+++ b/src/gaia/ui/routers/agents.py
@@ -26,6 +26,7 @@ from fastapi.responses import FileResponse
 from gaia.logger import get_logger
 
 from ..models import AgentInfo, AgentListResponse, DiskAgentInfo, DiskAgentListResponse
+from ..security import require_ui_header as _require_ui_header
 
 logger = get_logger(__name__)
 
@@ -53,16 +54,6 @@ def _require_localhost(request: Request) -> None:
         raise HTTPException(
             status_code=403, detail="endpoint only available on localhost"
         )
-
-
-def _require_ui_header(request: Request) -> None:
-    """Require the custom ``X-Gaia-UI: 1`` header as a lightweight CSRF guard.
-
-    Custom headers trigger a CORS preflight in browsers, so drive-by form
-    POSTs from malicious tabs cannot supply this header.
-    """
-    if request.headers.get("x-gaia-ui") != "1":
-        raise HTTPException(status_code=403, detail="missing X-Gaia-UI header")
 
 
 def _require_tunnel_inactive(request: Request) -> None:

--- a/src/gaia/ui/routers/connectors.py
+++ b/src/gaia/ui/routers/connectors.py
@@ -83,6 +83,8 @@ from gaia.connectors.mcp_server import (
 from gaia.connectors.registry import REGISTRY
 from gaia.connectors.store import peek_connection, peek_provider_credentials
 
+from ..security import require_ui_header as _require_ui_header
+
 logger = logging.getLogger(__name__)
 
 
@@ -101,16 +103,6 @@ forwarded_router = APIRouter(prefix="/v1/connections", tags=["connections"])
 # ─────────────────────────────────────────────────────────────────
 # CSRF guard (plan amendment A8)
 # ─────────────────────────────────────────────────────────────────
-
-
-def _require_ui_header(request: Request) -> None:
-    """Require ``X-Gaia-UI: 1`` header on mutating routes.
-
-    Custom request headers trigger a CORS preflight in browsers, so
-    drive-by form POSTs from malicious pages cannot forge this header.
-    """
-    if request.headers.get("x-gaia-ui") != "1":
-        raise HTTPException(status_code=403, detail="missing X-Gaia-UI header")
 
 
 def _require_mcp_server(connector_id: str) -> None:

--- a/src/gaia/ui/routers/hub.py
+++ b/src/gaia/ui/routers/hub.py
@@ -28,6 +28,8 @@ from gaia.hub import installer as installer_mod
 from gaia.hub import lifecycle as lifecycle_mod
 from gaia.logger import get_logger
 
+from ..security import require_ui_header as _require_ui_header
+
 logger = get_logger(__name__)
 
 router = APIRouter(tags=["hub"])
@@ -48,11 +50,6 @@ def _require_localhost(request: Request) -> None:
         raise HTTPException(
             status_code=403, detail="endpoint only available on localhost"
         )
-
-
-def _require_ui_header(request: Request) -> None:
-    if request.headers.get("x-gaia-ui") != "1":
-        raise HTTPException(status_code=403, detail="missing X-Gaia-UI header")
 
 
 def _shutdown_email_sidecar(agent_id: str) -> None:

--- a/src/gaia/ui/routers/memory.py
+++ b/src/gaia/ui/routers/memory.py
@@ -11,7 +11,7 @@ import uuid
 from datetime import datetime
 from typing import Any, Dict, List, Optional, Tuple
 
-from fastapi import APIRouter, Depends, HTTPException, Query, Request
+from fastapi import APIRouter, Depends, HTTPException, Query
 from pydantic import BaseModel, field_validator
 
 # Single source of truth imported from the data layer so that all three
@@ -21,6 +21,7 @@ from gaia.agents.base.memory_store import VALID_CATEGORIES as _VALID_CATEGORIES
 
 from ..database import ChatDatabase
 from ..dependencies import get_db
+from ..security import require_ui_header as _require_ui_header
 
 logger = logging.getLogger(__name__)
 
@@ -36,12 +37,6 @@ def _log_server_error(context: str, exc: Exception) -> str:
     correlation_id = uuid.uuid4().hex[:8]
     logger.error("[memory router] %s (id=%s)", context, correlation_id, exc_info=exc)
     return correlation_id
-
-
-def _require_ui_header(request: Request) -> None:
-    """Require ``X-Gaia-UI: 1`` header as a lightweight CSRF guard."""
-    if request.headers.get("x-gaia-ui") != "1":
-        raise HTTPException(status_code=403, detail="missing X-Gaia-UI header")
 
 
 # Safe defaults returned when the data-layer lacks v2 methods.

--- a/src/gaia/ui/security.py
+++ b/src/gaia/ui/security.py
@@ -1,0 +1,261 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+"""Cross-origin request defenses for the Agent UI backend.
+
+The backend binds loopback and has no authentication while the tunnel is
+off, so any web page the user visits could drive it. Three layers close
+that off, all applied in middleware so a route added tomorrow is covered
+without its author remembering anything:
+
+1. **CSRF header** -- every mutating (non-GET/HEAD/OPTIONS) request to
+   ``/api/*`` or ``/v1/*`` must carry ``X-Gaia-UI: 1``. A page cannot set
+   a custom header on a cross-origin request without a CORS preflight,
+   and the app's CORS policy approves preflights only from its own
+   first-party dev origins.
+2. **Origin allowlist** -- a mutating request whose ``Origin`` names
+   somewhere other than this server, loopback, or the live tunnel is
+   refused outright, so a CORS misconfiguration alone is not enough.
+3. **Host allowlist** -- DNS rebinding needs a *hostname* that resolves
+   to loopback, so a ``Host`` that is neither an IP literal, nor
+   loopback, nor the live tunnel is refused.
+
+``Origin: null`` and a missing ``Origin`` are accepted: the packaged
+Electron shell serves the SPA from ``file://`` (an opaque origin) and
+non-browser callers send no ``Origin`` at all. Neither can be produced by
+a cross-site page that *also* carries ``X-Gaia-UI`` -- layer 1 stops
+those, and a sandboxed iframe's ``null``-origin preflight is refused by
+CORS before the real request is ever sent.
+"""
+
+from __future__ import annotations
+
+import ipaddress
+import json
+import logging
+import os
+from typing import Optional
+from urllib.parse import urlsplit
+
+from fastapi import HTTPException, Request
+from starlette.datastructures import Headers
+from starlette.types import ASGIApp, Receive, Scope, Send
+
+logger = logging.getLogger(__name__)
+
+# ── Constants ───────────────────────────────────────────────────────────────
+
+#: Header every first-party Agent UI client sends on mutating requests.
+UI_HEADER_NAME = "x-gaia-ui"
+UI_HEADER_VALUE = "1"
+
+#: Path prefixes the guards apply to -- everything a client calls.
+GUARDED_PREFIXES = ("/api/", "/v1/")
+
+#: Methods a cross-site page can trigger without a preflight but that do
+#: not change state. ``OPTIONS`` must pass through so ``CORSMiddleware``
+#: can answer preflights.
+SAFE_METHODS = frozenset({"GET", "HEAD", "OPTIONS"})
+
+#: Mutating paths exempt from the CSRF header.
+#:
+#: Deliberately empty. The OAuth loopback callback -- the one flow that
+#: cannot send a custom header, because the provider redirects the
+#: browser to it -- is a ``GET`` served by its own aiohttp server in
+#: ``gaia.connectors.flow``, not by this app. An entry here is a hole, so
+#: ``tests/unit/chat/ui/test_ui_request_guard.py`` asserts it stays empty.
+CSRF_EXEMPT_PATHS: frozenset = frozenset()
+
+#: Hostnames that always denote this machine.
+_LOOPBACK_NAMES = frozenset({"localhost", "::1"})
+
+#: Explicit opt-in for deployments behind a proxy or a named host.
+#: Comma-separated. Never populated by default.
+ENV_ALLOWED_ORIGINS = "GAIA_UI_ALLOWED_ORIGINS"
+ENV_ALLOWED_HOSTS = "GAIA_UI_ALLOWED_HOSTS"
+
+
+# ── Helpers ─────────────────────────────────────────────────────────────────
+
+
+def _env_values(name: str) -> tuple:
+    """Comma-separated, lowercased values of an allowlist env var."""
+    return tuple(
+        v.strip().lower() for v in os.environ.get(name, "").split(",") if v.strip()
+    )
+
+
+def _hostname(authority: str) -> str:
+    """Lowercased hostname of a ``host[:port]`` authority.
+
+    IPv6 authorities keep their brackets in ``Host``/``Origin``; strip
+    them so the result compares equal to ``ipaddress`` output.
+    """
+    host = authority.strip().lower()
+    if host.startswith("["):
+        end = host.find("]")
+        if end != -1:
+            return host[1:end]
+    return host.rsplit(":", 1)[0] if ":" in host else host
+
+
+def _is_ip_literal(hostname: str) -> bool:
+    try:
+        ipaddress.ip_address(hostname)
+        return True
+    except ValueError:
+        return False
+
+
+def _is_loopback_name(hostname: str) -> bool:
+    if hostname in _LOOPBACK_NAMES or hostname.endswith(".localhost"):
+        return True
+    try:
+        return ipaddress.ip_address(hostname).is_loopback
+    except ValueError:
+        return False
+
+
+def _tunnel_host(app) -> Optional[str]:
+    """Hostname of the live tunnel, or ``None`` when no tunnel is up."""
+    tunnel = getattr(getattr(app, "state", None), "tunnel", None)
+    if tunnel is None or not getattr(tunnel, "active", False):
+        return None
+    url = (tunnel.get_status() or {}).get("url")
+    return _hostname(urlsplit(url).netloc) if url else None
+
+
+def is_allowed_host(host_header: str, app) -> bool:
+    """Whether ``Host`` may address this server.
+
+    Any IP literal passes: DNS rebinding needs a *name* to re-point, so a
+    literal cannot be used for it, and rejecting literals would break
+    ``--host 0.0.0.0`` LAN access. Names must be loopback, the live
+    tunnel, or listed in ``GAIA_UI_ALLOWED_HOSTS``.
+    """
+    if not host_header:
+        # HTTP/1.0 and some local probes omit Host entirely; with no name
+        # there is nothing to rebind.
+        return True
+    hostname = _hostname(host_header)
+    if _is_ip_literal(hostname) or _is_loopback_name(hostname):
+        return True
+    if hostname == _tunnel_host(app):
+        return True
+    allowed = _env_values(ENV_ALLOWED_HOSTS)
+    return hostname in allowed or host_header.strip().lower() in allowed
+
+
+def is_allowed_origin(origin: str, host_header: str, app) -> bool:
+    """Whether a mutating request's ``Origin`` is first-party.
+
+    ``null`` and absent origins pass -- see the module docstring. Anything
+    else must be same-origin with the request's own ``Host``, loopback,
+    the live tunnel, or listed in ``GAIA_UI_ALLOWED_ORIGINS``.
+    """
+    if not origin or origin.strip().lower() == "null":
+        return True
+    if origin.strip().lower() in _env_values(ENV_ALLOWED_ORIGINS):
+        return True
+    hostname = _hostname(urlsplit(origin).netloc)
+    if not hostname:
+        return False
+    if host_header and hostname == _hostname(host_header):
+        return True
+    if _is_loopback_name(hostname):
+        return True
+    return hostname == _tunnel_host(app)
+
+
+def require_ui_header(request: Request) -> None:
+    """Require ``X-Gaia-UI: 1`` -- the single copy of the route-level guard.
+
+    Kept as a dependency for the few *read* routes that opt into it
+    explicitly (``GET /api/agents/disk`` and friends). Every mutating
+    route is covered by :class:`UIRequestGuardMiddleware` whether or not
+    its decorator names this.
+    """
+    if request.headers.get(UI_HEADER_NAME) != UI_HEADER_VALUE:
+        raise HTTPException(status_code=403, detail="missing X-Gaia-UI header")
+
+
+# ── Middleware ──────────────────────────────────────────────────────────────
+
+
+async def _send_rejection(send: Send, status: int, detail: str) -> None:
+    body = json.dumps({"detail": detail}).encode()
+    await send(
+        {
+            "type": "http.response.start",
+            "status": status,
+            "headers": [
+                (b"content-type", b"application/json"),
+                (b"content-length", str(len(body)).encode()),
+            ],
+        }
+    )
+    await send({"type": "http.response.body", "body": body})
+
+
+class UIRequestGuardMiddleware:
+    """Enforce the Host, Origin, and ``X-Gaia-UI`` rules for the whole app.
+
+    Pure ASGI rather than ``BaseHTTPMiddleware`` so it adds no task-group
+    hop around the SSE streams it sits in front of.
+
+    Registered last in ``create_app`` so it is the *outermost* middleware:
+    a rejection then carries no CORS headers, and no route or auth
+    shortcut downstream can skip it.
+    """
+
+    def __init__(self, app: ASGIApp) -> None:
+        self.app = app
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if scope["type"] != "http":
+            await self.app(scope, receive, send)
+            return
+
+        headers = Headers(scope=scope)
+        app = scope.get("app")
+        host_header = headers.get("host", "")
+        method = scope.get("method", "")
+        path = scope.get("path", "")
+
+        if not is_allowed_host(host_header, app):
+            logger.warning(
+                "Rejecting %s %s: untrusted Host %r (possible DNS rebinding)",
+                method,
+                path,
+                host_header,
+            )
+            await _send_rejection(send, 400, "Invalid Host header")
+            return
+
+        if (
+            method not in SAFE_METHODS
+            and path.startswith(GUARDED_PREFIXES)
+            and path not in CSRF_EXEMPT_PATHS
+        ):
+            origin = headers.get("origin", "")
+            if not is_allowed_origin(origin, host_header, app):
+                logger.warning(
+                    "Rejecting %s %s: cross-origin request from %r",
+                    method,
+                    path,
+                    origin,
+                )
+                await _send_rejection(send, 403, "Cross-origin request rejected")
+                return
+            if headers.get(UI_HEADER_NAME) != UI_HEADER_VALUE:
+                logger.warning(
+                    "Rejecting %s %s: missing %s header (origin=%r)",
+                    method,
+                    path,
+                    UI_HEADER_NAME,
+                    origin,
+                )
+                await _send_rejection(send, 403, "missing X-Gaia-UI header")
+                return
+
+        await self.app(scope, receive, send)

--- a/src/gaia/ui/security.py
+++ b/src/gaia/ui/security.py
@@ -122,7 +122,10 @@ def _tunnel_host(app) -> Optional[str]:
     if tunnel is None or not getattr(tunnel, "active", False):
         return None
     url = (tunnel.get_status() or {}).get("url")
-    return _hostname(urlsplit(url).netloc) if url else None
+    # A tunnel can be flagged active a beat before its URL is minted.
+    if not isinstance(url, str) or not url:
+        return None
+    return _hostname(urlsplit(url).netloc)
 
 
 def is_allowed_host(host_header: str, app) -> bool:

--- a/src/gaia/ui/security.py
+++ b/src/gaia/ui/security.py
@@ -96,6 +96,11 @@ def _hostname(authority: str) -> str:
         end = host.find("]")
         if end != -1:
             return host[1:end]
+    if host.count(":") > 1:
+        # Bare IPv6 with no brackets. RFC 3986 requires them, so nothing
+        # correct sends this -- but splitting on the last colon would turn
+        # "::1" into ":" and quietly fail the loopback check.
+        return host
     return host.rsplit(":", 1)[0] if ":" in host else host
 
 
@@ -232,7 +237,14 @@ class UIRequestGuardMiddleware:
                 path,
                 host_header,
             )
-            await _send_rejection(send, 400, "Invalid Host header")
+            await _send_rejection(
+                send,
+                400,
+                f"Invalid Host header: {host_header!r} is not a name this "
+                f"server answers to. Reach the Agent UI on localhost or its "
+                f"IP address, or set {ENV_ALLOWED_HOSTS} to a comma-separated "
+                f"list of hostnames to allow.",
+            )
             return
 
         if (

--- a/src/gaia/ui/server.py
+++ b/src/gaia/ui/server.py
@@ -66,6 +66,7 @@ from .routers import schedules as schedules_router_mod
 from .routers import sessions as sessions_router_mod
 from .routers import system as system_router_mod
 from .routers import tunnel as tunnel_router_mod
+from .security import UIRequestGuardMiddleware
 from .tunnel import TunnelManager
 from .utils import ALLOWED_EXTENSIONS as _ALLOWED_EXTENSIONS  # noqa: F401
 from .utils import compute_file_hash as _compute_file_hash  # noqa: F401
@@ -545,7 +546,14 @@ def create_app(db_path: str = None, webui_dist: str = None) -> FastAPI:
         lifespan=lifespan,
     )
 
-    # CORS - allow local origins and tunnel URLs for mobile access
+    # CORS - first-party dev origins only.
+    #
+    # No tunnel origin is listed: the mobile flow serves the SPA *from*
+    # the tunnel, so those requests are same-origin and CORS never
+    # applies. A wildcard over a shared self-service namespace
+    # (*.ngrok-free.app, *.use.devtunnels.ms) would hand every tenant of
+    # those namespaces an approved preflight -- including for the
+    # X-Gaia-UI header the CSRF guard depends on.
     app.add_middleware(
         CORSMiddleware,
         allow_origins=[
@@ -556,7 +564,6 @@ def create_app(db_path: str = None, webui_dist: str = None) -> FastAPI:
             "http://localhost:5173",
             "http://127.0.0.1:5173",
         ],
-        allow_origin_regex=r"https://[a-zA-Z0-9-]+\.(ngrok-free\.app|use\.devtunnels\.ms)",
         allow_credentials=True,
         allow_methods=["*"],
         allow_headers=["*"],
@@ -566,6 +573,12 @@ def create_app(db_path: str = None, webui_dist: str = None) -> FastAPI:
     # the ngrok tunnel is active.  Must be added *after* CORSMiddleware so
     # that CORS preflight (OPTIONS) responses are handled first.
     app.add_middleware(TunnelAuthMiddleware)
+
+    # Host / Origin / X-Gaia-UI guard. Added last so it is the OUTERMOST
+    # middleware: it runs before tunnel auth (which passes everything
+    # through while the tunnel is off) and its rejections carry no CORS
+    # headers, so a cross-site page cannot read why it failed.
+    app.add_middleware(UIRequestGuardMiddleware)
 
     # Store shared state on app.state so routers can access via Depends
     app.state.db = db

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -28,12 +28,21 @@ To add new fixtures for other test suites, define them in this file and they'll
 be automatically available to all test files.
 """
 
+import os
 import subprocess
 import time
 import webbrowser
 
 import pytest
 import requests
+
+# ── Agent UI request guard (gaia.ui.security) ───────────────────────────────
+# The backend rejects a request whose ``Host`` is a name it does not know, so
+# that a page on ``attacker.example`` cannot rebind DNS to loopback and drive
+# it. Starlette's TestClient sends ``Host: testserver``, so name it here once
+# rather than rewriting every TestClient's ``base_url``. The guard's own tests
+# exercise the rejection path directly and do not rely on this.
+os.environ.setdefault("GAIA_UI_ALLOWED_HOSTS", "testserver")
 
 _BROWSER_LAUNCHERS = ("open", "open_new", "open_new_tab")
 
@@ -452,6 +461,39 @@ def in_memory_keyring():
         keyring.set_keyring(previous)
 
 
+@pytest.fixture(scope="session", autouse=True)
+def _testclient_sends_ui_header():
+    """Make every ``TestClient`` carry ``X-Gaia-UI``, as real clients do.
+
+    ``gaia.ui.security.UIRequestGuardMiddleware`` refuses mutating
+    ``/api``/``/v1`` requests without it. Over a hundred call sites across
+    ~40 modules build their own ``TestClient``, so defaulting the header
+    here keeps the guard from turning all of them into header plumbing.
+
+    Tests that assert the guard *rejects* an unheadered request opt out by
+    popping the default — see ``ui_api_client`` below. A future negative
+    test that forgets fails loudly on its own 403 assertion rather than
+    passing for the wrong reason.
+    """
+    try:
+        from starlette.testclient import TestClient
+    except ImportError:
+        yield
+        return
+
+    original_init = TestClient.__init__
+
+    def _init_with_ui_header(self, *args, **kwargs):
+        original_init(self, *args, **kwargs)
+        self.headers.setdefault("x-gaia-ui", "1")
+
+    TestClient.__init__ = _init_with_ui_header
+    try:
+        yield
+    finally:
+        TestClient.__init__ = original_init
+
+
 @pytest.fixture
 def ui_api_client():
     """
@@ -463,6 +505,10 @@ def ui_api_client():
     on UI-server routes (see plan amendment A12).
 
     Skips the test if the [ui] extras are not installed.
+
+    Deliberately carries no ``X-Gaia-UI`` default: the connectors and
+    agents suites use this client to assert that an unheadered mutating
+    request is refused, so a per-call header is how a test here opts *in*.
     """
     try:
         from starlette.testclient import TestClient
@@ -473,4 +519,5 @@ def ui_api_client():
 
     app = create_app()
     with TestClient(app) as client:
+        client.headers.pop("x-gaia-ui", None)
         yield client

--- a/tests/integration/test_chat_ui_integration.py
+++ b/tests/integration/test_chat_ui_integration.py
@@ -1167,38 +1167,34 @@ class TestCORSIntegration:
             "http://localhost:4200"
         )
 
-    def test_cors_allows_tunnel_origin(self, client):
-        """CORS allows the ngrok / devtunnels origins used for mobile access."""
-        origin = "https://gaia-test.ngrok-free.app"
-        resp = client.get("/api/health", headers={"Origin": origin})
-        assert resp.status_code == 200
-        assert resp.headers.get("access-control-allow-origin") == origin
+    def test_cors_rejects_shared_tunnel_namespace_origin(self, client):
+        """A tenant of a shared tunnel namespace is not a trusted origin.
+
+        ``*.ngrok-free.app`` and ``*.use.devtunnels.ms`` are self-service:
+        anyone can rent a subdomain, so trusting the namespace trusted every
+        attacker who signs up. It bought users nothing either -- the mobile
+        flow serves the SPA *from* the tunnel, so those requests are
+        same-origin and CORS never applies.
+        """
+        for origin in (
+            "https://gaia-test.ngrok-free.app",
+            "https://attacker.use.devtunnels.ms",
+        ):
+            resp = client.get("/api/health", headers={"Origin": origin})
+            assert "access-control-allow-origin" not in resp.headers, origin
 
     def test_cors_rejects_unknown_origin(self, client):
         """An origin outside the allowlist gets no allow-origin header.
 
         The server sends credentials (``allow_credentials=True``), so the
-        origin list is deliberately an allowlist -- localhost dev ports plus
-        the tunnel domains -- never a wildcard. A page on any other origin
-        must not be able to read authenticated responses, which the browser
-        enforces by the *absence* of ``access-control-allow-origin``.
+        origin list is deliberately an allowlist of localhost dev ports,
+        never a wildcard. A page on any other origin must not be able to
+        read authenticated responses, which the browser enforces by the
+        *absence* of ``access-control-allow-origin``.
         """
         resp = client.get(
             "/api/health",
             headers={"Origin": "http://some-other-origin.com"},
-        )
-        assert "access-control-allow-origin" not in resp.headers
-
-    def test_cors_rejects_tunnel_lookalike_origin(self, client):
-        """An attacker domain that merely *starts* with a tunnel host is refused.
-
-        The tunnel regex is unanchored and only safe because Starlette applies
-        it with ``fullmatch``. This pins that: a prefix-match implementation
-        would hand credentialed responses to ``*.ngrok-free.app.evil.com``.
-        """
-        resp = client.get(
-            "/api/health",
-            headers={"Origin": "https://gaia-test.ngrok-free.app.evil.com"},
         )
         assert "access-control-allow-origin" not in resp.headers
 

--- a/tests/stress/test_agent_ui_stress.py
+++ b/tests/stress/test_agent_ui_stress.py
@@ -1356,7 +1356,9 @@ async def main():
     report = StressReport()
     report.start_time = time.time()
 
-    async with httpx.AsyncClient() as client:
+    # The backend refuses mutating /api requests without this header
+    # (gaia/ui/security.py) — session create, chat send and delete all need it.
+    async with httpx.AsyncClient(headers={"X-Gaia-UI": "1"}) as client:
         # ── Phase 1: Infrastructure Tests ──
         print("\n--- Phase 1: Infrastructure ---")
         await test_health_check(client, report)

--- a/tests/unit/chat/ui/test_agents_router.py
+++ b/tests/unit/chat/ui/test_agents_router.py
@@ -387,6 +387,7 @@ class TestExportImportSecurityGuards:
         app_with_registry.dependency_overrides[_require_localhost] = lambda: None
         try:
             client = TestClient(app_with_registry)
+            client.headers.pop("x-gaia-ui", None)  # opt out of the conftest default
             resp = client.post("/api/agents/export")  # no X-Gaia-UI header
             assert resp.status_code == 403
         finally:
@@ -398,6 +399,7 @@ class TestExportImportSecurityGuards:
         app_with_registry.dependency_overrides[_require_localhost] = lambda: None
         try:
             client = TestClient(app_with_registry)
+            client.headers.pop("x-gaia-ui", None)  # opt out of the conftest default
             resp = client.post(
                 "/api/agents/import",
                 files={"bundle": ("x.zip", b"", "application/zip")},

--- a/tests/unit/chat/ui/test_ui_request_guard.py
+++ b/tests/unit/chat/ui/test_ui_request_guard.py
@@ -39,6 +39,16 @@ def app():
     return create_app(db_path=":memory:")
 
 
+#: Route the guard tests fire at. ``POST /api/sessions`` writes only to the
+#: in-memory database this module's ``app`` fixture builds, and an empty body
+#: 422s before it writes at all -- so if the guard ever regresses, the test
+#: fails instead of doing something. The routes the review actually exploited
+#: (``/api/tunnel/start``, ``/api/memory/prune``) have real side effects on the
+#: developer's machine; ``test_high_value_routes_are_in_the_covered_set`` pins
+#: their coverage from the route table instead of firing at them.
+_INERT_ROUTE = "/api/sessions"
+
+
 # ── Raw ASGI driver ─────────────────────────────────────────────────────────
 
 
@@ -199,7 +209,7 @@ async def test_preflight_from_a_rented_ngrok_subdomain_is_rejected(stack, app):
         stack,
         app,
         "OPTIONS",
-        "/api/memory/prune",
+        _INERT_ROUTE,
         {
             "host": "127.0.0.1:4200",
             "origin": "https://someone-else.ngrok-free.app",
@@ -224,7 +234,7 @@ async def test_preflight_from_other_untrusted_origins_is_rejected(stack, app, or
         stack,
         app,
         "OPTIONS",
-        "/api/memory/prune",
+        _INERT_ROUTE,
         {
             "host": "127.0.0.1:4200",
             "origin": origin,
@@ -242,7 +252,7 @@ async def test_preflight_from_the_dev_origin_is_still_approved(stack, app):
         stack,
         app,
         "OPTIONS",
-        "/api/memory/prune",
+        _INERT_ROUTE,
         {
             "host": "127.0.0.1:4200",
             "origin": "http://localhost:5174",
@@ -260,10 +270,13 @@ _ATTACKER = {"host": "127.0.0.1:4200", "origin": "https://evil.example"}
 
 
 async def test_body_less_cross_origin_post_is_rejected(stack, app):
-    """C11's live proof, as a test: ``POST /api/tunnel/start`` took no body."""
-    status, headers, body = await _request(
-        stack, app, "POST", "/api/tunnel/start", _ATTACKER
-    )
+    """The shape that worked live: no body, so a plain form POST reached it.
+
+    ``POST /api/tunnel/start`` was the review's proof -- it returned 200 and
+    published the machine to the internet. Fired here at ``_INERT_ROUTE``,
+    which is body-less in exactly the same way and does nothing if it lands.
+    """
+    status, headers, body = await _request(stack, app, "POST", _INERT_ROUTE, _ATTACKER)
     assert status == 403
     assert b"Cross-origin" in body
     # A rejection must not be readable cross-origin either.
@@ -273,7 +286,7 @@ async def test_body_less_cross_origin_post_is_rejected(stack, app):
 async def test_cross_origin_post_is_rejected_even_with_the_header(stack, app):
     """Origin is checked independently, so a forged header is not enough."""
     status, _, body = await _request(
-        stack, app, "POST", "/api/memory/prune", {**_ATTACKER, "x-gaia-ui": "1"}
+        stack, app, "POST", _INERT_ROUTE, {**_ATTACKER, "x-gaia-ui": "1"}
     )
     assert status == 403
     assert b"Cross-origin" in body
@@ -285,7 +298,7 @@ async def test_same_origin_post_without_the_header_is_rejected(stack, app):
         stack,
         app,
         "POST",
-        "/api/memory/prune",
+        _INERT_ROUTE,
         {"host": "127.0.0.1:4200", "origin": "http://localhost:9999"},
     )
     assert status == 403
@@ -298,10 +311,10 @@ async def test_first_party_post_passes_the_guard(stack, app):
         stack,
         app,
         "POST",
-        "/api/memory/prune",
+        _INERT_ROUTE,
         {"host": "127.0.0.1:4200", "origin": "http://127.0.0.1:4200", "x-gaia-ui": "1"},
     )
-    assert status != 403
+    assert status == 422  # reached the handler; empty body is what it rejects
 
 
 async def test_opaque_origin_with_the_header_passes(stack, app):
@@ -310,10 +323,10 @@ async def test_opaque_origin_with_the_header_passes(stack, app):
         stack,
         app,
         "POST",
-        "/api/memory/prune",
+        _INERT_ROUTE,
         {"host": "127.0.0.1:4200", "origin": "null", "x-gaia-ui": "1"},
     )
-    assert status != 403
+    assert status == 422  # reached the handler; empty body is what it rejects
 
 
 async def test_non_browser_client_with_the_header_passes(stack, app):
@@ -322,10 +335,10 @@ async def test_non_browser_client_with_the_header_passes(stack, app):
         stack,
         app,
         "POST",
-        "/api/memory/prune",
+        _INERT_ROUTE,
         {"host": "127.0.0.1:4200", "x-gaia-ui": "1"},
     )
-    assert status != 403
+    assert status == 422  # reached the handler; empty body is what it rejects
 
 
 async def test_reads_are_not_blocked(stack, app):

--- a/tests/unit/chat/ui/test_ui_request_guard.py
+++ b/tests/unit/chat/ui/test_ui_request_guard.py
@@ -1,0 +1,399 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+"""Regression tests for the Agent UI cross-origin request guard.
+
+Covers the two holes that let any web page the user visited drive the
+backend:
+
+* a mutating route shipping without the ``X-Gaia-UI`` CSRF check, and
+* a CORS policy that trusted every ``*.ngrok-free.app`` /
+  ``*.use.devtunnels.ms`` subdomain -- shared, self-service namespaces --
+  with credentials and ``allow_headers=["*"]``, which handed an attacker
+  an approved preflight for the very header the CSRF check relies on.
+
+Everything here drives the ASGI stack directly rather than through
+``TestClient``: ``tests/unit/conftest.py``'s network guard breaks
+``socket.socketpair()`` on Windows, so a ``TestClient`` in this directory
+errors during setup on that platform (review finding C41). Raw ASGI needs
+no sockets and exercises the same middleware.
+"""
+
+from __future__ import annotations
+
+import pytest
+from fastapi.routing import APIRoute
+
+from gaia.ui import security
+from gaia.ui.server import create_app
+
+#: ``tests/unit/conftest.py`` monkeypatches ``socket.connect`` to keep unit
+#: tests offline, which also breaks the ``socketpair()`` the Windows asyncio
+#: loop opens for itself. Nothing here touches the network -- only the event
+#: loop needs the opt-out.
+pytestmark = pytest.mark.allow_network
+
+
+@pytest.fixture(scope="module")
+def app():
+    return create_app(db_path=":memory:")
+
+
+# ── Raw ASGI driver ─────────────────────────────────────────────────────────
+
+
+def _scope(app, method: str, path: str, headers: dict) -> dict:
+    return {
+        "type": "http",
+        "asgi": {"version": "3.0", "spec_version": "2.3"},
+        "http_version": "1.1",
+        "method": method,
+        "scheme": "http",
+        "path": path,
+        "raw_path": path.encode(),
+        "root_path": "",
+        "query_string": b"",
+        "headers": [
+            (k.lower().encode(), v.encode())
+            for k, v in headers.items()
+            if v is not None
+        ],
+        "client": ("127.0.0.1", 54321),
+        "server": ("127.0.0.1", 4200),
+        "app": app,
+    }
+
+
+async def _request(stack, app, method, path, headers, body: bytes = b""):
+    """Drive an ASGI app and return ``(status, headers_dict, body)``."""
+    sent = []
+
+    async def receive():
+        return {"type": "http.request", "body": body, "more_body": False}
+
+    async def send(message):
+        sent.append(message)
+
+    await stack(_scope(app, method, path, headers), receive, send)
+
+    start = next(m for m in sent if m["type"] == "http.response.start")
+    payload = b"".join(
+        m.get("body", b"") for m in sent if m["type"] == "http.response.body"
+    )
+    resp_headers = {k.decode().lower(): v.decode() for k, v in start["headers"]}
+    return start["status"], resp_headers, payload
+
+
+@pytest.fixture(scope="module")
+def stack(app):
+    """The app's real middleware stack, without a running lifespan."""
+    return app.build_middleware_stack()
+
+
+# ── Route-table introspection ───────────────────────────────────────────────
+
+
+def _all_api_routes(router):
+    """Every ``APIRoute`` reachable from ``app``, materialising lazy includes.
+
+    FastAPI defers ``include_router`` into ``_IncludedRouter`` wrappers, so
+    a naive ``for r in app.routes`` finds a single route on this version --
+    which is exactly how a coverage test like this silently passes while
+    asserting nothing. ``test_route_walk_finds_the_whole_surface`` pins the
+    walk itself.
+    """
+    from fastapi.routing import _EffectiveRouteContext, _IncludedRouter
+
+    found = {}
+
+    def walk(routes):
+        for route in routes:
+            if isinstance(route, _IncludedRouter):
+                walk(route.effective_candidates())
+                walk(route.effective_low_priority_routes())
+            elif isinstance(route, _EffectiveRouteContext):
+                if isinstance(route.original_route, APIRoute):
+                    found[(route.path, frozenset(route.methods))] = route
+            elif isinstance(route, APIRoute):
+                found[(route.path, frozenset(route.methods))] = route
+
+    walk(router.routes)
+    return found
+
+
+def _mutating_paths(app):
+    mutating = {"POST", "PUT", "PATCH", "DELETE"}
+    return sorted(
+        {
+            path
+            for (path, methods), _ in _all_api_routes(app).items()
+            if methods & mutating
+        }
+    )
+
+
+def test_route_walk_finds_the_whole_surface(app):
+    """Guard the guard: a walk that finds nothing would pass every test below."""
+    assert len(_all_api_routes(app)) > 100
+    assert len(_mutating_paths(app)) > 50
+
+
+def test_every_mutating_route_is_covered_by_the_guard(app):
+    """No mutating route may sit outside the middleware's reach.
+
+    A router mounted at a new prefix -- ``/agents/...`` rather than
+    ``/api/agents/...`` -- would silently escape the CSRF and Origin
+    checks. Fail here rather than in production: either move the route
+    under a guarded prefix, or widen ``GUARDED_PREFIXES``.
+    """
+    uncovered = [
+        path
+        for path in _mutating_paths(app)
+        if not path.startswith(security.GUARDED_PREFIXES)
+    ]
+    assert (
+        uncovered == []
+    ), f"mutating routes outside {security.GUARDED_PREFIXES}: {uncovered}"
+
+
+def test_no_mutating_route_is_exempted(app):
+    """The exemption list must stay empty -- every entry is a hole.
+
+    The OAuth loopback callback, the one flow that cannot send a custom
+    header, is a GET on its own aiohttp server in ``gaia.connectors.flow``.
+    """
+    assert security.CSRF_EXEMPT_PATHS == frozenset()
+    assert not set(_mutating_paths(app)) & security.CSRF_EXEMPT_PATHS
+
+
+def test_high_value_routes_are_in_the_covered_set(app):
+    """Spot-check the routes the review found forgeable."""
+    paths = set(_mutating_paths(app))
+    for path in (
+        "/api/tunnel/start",
+        "/api/memory/prune",
+        "/api/documents/upload",
+        "/api/files/upload",
+        "/v1/email/send",
+        "/api/chat/send",
+    ):
+        assert path in paths, f"{path} disappeared from the route table"
+        assert path.startswith(security.GUARDED_PREFIXES)
+
+
+# ── CORS policy ─────────────────────────────────────────────────────────────
+
+
+def test_cors_has_no_wildcard_origin_regex(app):
+    """No regex over a namespace anyone can rent a subdomain in."""
+    cors = [m for m in app.user_middleware if m.cls.__name__ == "CORSMiddleware"]
+    assert len(cors) == 1
+    assert cors[0].kwargs.get("allow_origin_regex") is None
+    for origin in cors[0].kwargs["allow_origins"]:
+        assert "ngrok" not in origin and "devtunnels" not in origin
+
+
+async def test_preflight_from_a_rented_ngrok_subdomain_is_rejected(stack, app):
+    """The exact attack C12 describes: someone else's free ngrok subdomain."""
+    status, headers, _ = await _request(
+        stack,
+        app,
+        "OPTIONS",
+        "/api/memory/prune",
+        {
+            "host": "127.0.0.1:4200",
+            "origin": "https://someone-else.ngrok-free.app",
+            "access-control-request-method": "POST",
+            "access-control-request-headers": "x-gaia-ui,content-type",
+        },
+    )
+    assert status == 400
+    assert "access-control-allow-origin" not in headers
+
+
+@pytest.mark.parametrize(
+    "origin",
+    [
+        "https://attacker.use.devtunnels.ms",
+        "https://evil.example",
+        "http://localhost.evil.example",
+    ],
+)
+async def test_preflight_from_other_untrusted_origins_is_rejected(stack, app, origin):
+    status, headers, _ = await _request(
+        stack,
+        app,
+        "OPTIONS",
+        "/api/memory/prune",
+        {
+            "host": "127.0.0.1:4200",
+            "origin": origin,
+            "access-control-request-method": "POST",
+            "access-control-request-headers": "x-gaia-ui",
+        },
+    )
+    assert status == 400
+    assert "access-control-allow-origin" not in headers
+
+
+async def test_preflight_from_the_dev_origin_is_still_approved(stack, app):
+    """The vite dev server must keep working."""
+    status, headers, _ = await _request(
+        stack,
+        app,
+        "OPTIONS",
+        "/api/memory/prune",
+        {
+            "host": "127.0.0.1:4200",
+            "origin": "http://localhost:5174",
+            "access-control-request-method": "POST",
+            "access-control-request-headers": "x-gaia-ui,content-type",
+        },
+    )
+    assert status == 200
+    assert headers["access-control-allow-origin"] == "http://localhost:5174"
+
+
+# ── CSRF header ─────────────────────────────────────────────────────────────
+
+_ATTACKER = {"host": "127.0.0.1:4200", "origin": "https://evil.example"}
+
+
+async def test_body_less_cross_origin_post_is_rejected(stack, app):
+    """C11's live proof, as a test: ``POST /api/tunnel/start`` took no body."""
+    status, headers, body = await _request(
+        stack, app, "POST", "/api/tunnel/start", _ATTACKER
+    )
+    assert status == 403
+    assert b"Cross-origin" in body
+    # A rejection must not be readable cross-origin either.
+    assert "access-control-allow-origin" not in headers
+
+
+async def test_cross_origin_post_is_rejected_even_with_the_header(stack, app):
+    """Origin is checked independently, so a forged header is not enough."""
+    status, _, body = await _request(
+        stack, app, "POST", "/api/memory/prune", {**_ATTACKER, "x-gaia-ui": "1"}
+    )
+    assert status == 403
+    assert b"Cross-origin" in body
+
+
+async def test_same_origin_post_without_the_header_is_rejected(stack, app):
+    """A form POST from a page on another local port still needs the header."""
+    status, _, body = await _request(
+        stack,
+        app,
+        "POST",
+        "/api/memory/prune",
+        {"host": "127.0.0.1:4200", "origin": "http://localhost:9999"},
+    )
+    assert status == 403
+    assert b"X-Gaia-UI" in body
+
+
+async def test_first_party_post_passes_the_guard(stack, app):
+    """The Electron/SPA shape must reach its handler."""
+    status, _, _ = await _request(
+        stack,
+        app,
+        "POST",
+        "/api/memory/prune",
+        {"host": "127.0.0.1:4200", "origin": "http://127.0.0.1:4200", "x-gaia-ui": "1"},
+    )
+    assert status != 403
+
+
+async def test_opaque_origin_with_the_header_passes(stack, app):
+    """The packaged Electron shell serves the SPA from ``file://``."""
+    status, _, _ = await _request(
+        stack,
+        app,
+        "POST",
+        "/api/memory/prune",
+        {"host": "127.0.0.1:4200", "origin": "null", "x-gaia-ui": "1"},
+    )
+    assert status != 403
+
+
+async def test_non_browser_client_with_the_header_passes(stack, app):
+    """``gaia mcp`` and the eval harness send no Origin at all."""
+    status, _, _ = await _request(
+        stack,
+        app,
+        "POST",
+        "/api/memory/prune",
+        {"host": "127.0.0.1:4200", "x-gaia-ui": "1"},
+    )
+    assert status != 403
+
+
+async def test_reads_are_not_blocked(stack, app):
+    """``EventSource`` cannot set headers, so GET must stay open."""
+    status, _, _ = await _request(
+        stack, app, "GET", "/api/health", {"host": "127.0.0.1:4200"}
+    )
+    assert status == 200
+
+
+# ── Host allowlist (DNS rebinding) ──────────────────────────────────────────
+
+
+async def test_rebinding_host_is_rejected(stack, app):
+    """``evil.example`` re-pointed at 127.0.0.1 must not reach any route."""
+    status, _, body = await _request(
+        stack, app, "GET", "/api/health", {"host": "evil.example"}
+    )
+    assert status == 400
+    assert b"Invalid Host" in body
+
+
+@pytest.mark.parametrize(
+    "host",
+    [
+        "127.0.0.1:4200",
+        "localhost:4200",
+        "[::1]:4200",
+        "192.168.1.9:4200",
+        "0.0.0.0:4200",
+    ],
+)
+async def test_local_and_ip_literal_hosts_are_accepted(stack, app, host):
+    """LAN access via ``--host 0.0.0.0`` must keep working.
+
+    An IP literal cannot be the target of DNS rebinding -- that needs a
+    name whose resolution can be changed.
+    """
+    status, _, _ = await _request(stack, app, "GET", "/api/health", {"host": host})
+    assert status == 200
+
+
+def test_env_allowlist_admits_a_named_host(monkeypatch):
+    monkeypatch.setenv(security.ENV_ALLOWED_HOSTS, "gaia.internal, other.example")
+    assert security.is_allowed_host("gaia.internal:4200", None)
+    assert security.is_allowed_host("other.example", None)
+    assert not security.is_allowed_host("evil.example", None)
+
+
+# ── Tunnel origin ───────────────────────────────────────────────────────────
+
+
+class _FakeTunnel:
+    active = True
+
+    def get_status(self):
+        return {"url": "https://mine-abc123.ngrok-free.dev"}
+
+
+def test_live_tunnel_host_and_origin_are_accepted(app, monkeypatch):
+    """The mobile SPA is served *from* the tunnel, so it is same-origin."""
+    monkeypatch.setattr(app.state, "tunnel", _FakeTunnel(), raising=False)
+    assert security.is_allowed_host("mine-abc123.ngrok-free.dev", app)
+    assert security.is_allowed_origin(
+        "https://mine-abc123.ngrok-free.dev", "mine-abc123.ngrok-free.dev", app
+    )
+    # A different tenant of the same namespace is not this session's tunnel.
+    assert not security.is_allowed_host("someone-else.ngrok-free.dev", app)
+    assert not security.is_allowed_origin(
+        "https://someone-else.ngrok-free.dev", "mine-abc123.ngrok-free.dev", app
+    )

--- a/tests/unit/chat/ui/test_ui_request_guard.py
+++ b/tests/unit/chat/ui/test_ui_request_guard.py
@@ -21,6 +21,8 @@ no sockets and exercises the same middleware.
 
 from __future__ import annotations
 
+import re
+
 import pytest
 from fastapi.routing import APIRoute
 
@@ -103,41 +105,63 @@ def stack(app):
 # ── Route-table introspection ───────────────────────────────────────────────
 
 
-def _all_api_routes(router):
-    """Every ``APIRoute`` reachable from ``app``, materialising lazy includes.
+#: Methods that can change state.
+_MUTATING = frozenset({"POST", "PUT", "PATCH", "DELETE"})
 
-    FastAPI defers ``include_router`` into ``_IncludedRouter`` wrappers, so
-    a naive ``for r in app.routes`` finds a single route on this version --
-    which is exactly how a coverage test like this silently passes while
-    asserting nothing. ``test_route_walk_finds_the_whole_surface`` pins the
-    walk itself.
+
+def _all_api_routes(app):
+    """Every route reachable from ``app``, as ``{(path, methods)}``.
+
+    Deliberately free of ``fastapi.routing`` private imports. The shape of
+    ``app.routes`` differs by version: through 0.115 ``include_router``
+    copies routes in eagerly and they sit there as ``APIRoute``s, while
+    newer releases defer each include behind a lazy wrapper that
+    materialises its children through ``effective_candidates()``. Probing
+    for those methods by name covers both and simply finds nothing extra
+    on a version that has neither, instead of raising ``ImportError`` and
+    taking every test below down with it.
+
+    ``test_route_walk_finds_the_whole_surface`` and
+    ``test_walk_covers_everything_openapi_knows_about`` both fail loudly
+    if a future version breaks this walk, so it cannot degrade quietly
+    into checking nothing.
     """
-    from fastapi.routing import _EffectiveRouteContext, _IncludedRouter
-
     found = {}
 
-    def walk(routes):
+    def visit(routes):
         for route in routes:
-            if isinstance(route, _IncludedRouter):
-                walk(route.effective_candidates())
-                walk(route.effective_low_priority_routes())
-            elif isinstance(route, _EffectiveRouteContext):
-                if isinstance(route.original_route, APIRoute):
-                    found[(route.path, frozenset(route.methods))] = route
-            elif isinstance(route, APIRoute):
-                found[(route.path, frozenset(route.methods))] = route
+            materialised = False
+            for name in ("effective_candidates", "effective_low_priority_routes"):
+                method = getattr(route, name, None)
+                if callable(method):
+                    visit(method())
+                    materialised = True
+            if materialised:
+                continue
+            path, methods = getattr(route, "path", None), getattr(
+                route, "methods", None
+            )
+            if isinstance(route, APIRoute) or hasattr(route, "original_route"):
+                if path and methods:
+                    found[(path, frozenset(methods))] = route
+            elif hasattr(route, "routes"):
+                visit(route.routes)
 
-    walk(router.routes)
+    visit(app.routes)
     return found
 
 
+def _drop_convertors(path: str) -> str:
+    """``/x/{id:path}`` -> ``/x/{id}``, the form ``openapi()`` reports."""
+    return re.sub(r"\{([^}:]+):[^}]+\}", r"{\1}", path)
+
+
 def _mutating_paths(app):
-    mutating = {"POST", "PUT", "PATCH", "DELETE"}
     return sorted(
         {
             path
             for (path, methods), _ in _all_api_routes(app).items()
-            if methods & mutating
+            if methods & _MUTATING
         }
     )
 
@@ -146,6 +170,26 @@ def test_route_walk_finds_the_whole_surface(app):
     """Guard the guard: a walk that finds nothing would pass every test below."""
     assert len(_all_api_routes(app)) > 100
     assert len(_mutating_paths(app)) > 50
+
+
+def test_walk_covers_everything_openapi_knows_about(app):
+    """Cross-check the walk against FastAPI's own public route inventory.
+
+    ``app.openapi()`` is stable public API across every supported version.
+    It is not sufficient on its own -- a route with
+    ``include_in_schema=False`` never appears in it -- but if the walk ever
+    stops seeing a route the schema knows about, this says so instead of
+    letting the coverage test below pass on a shrunken set.
+    """
+    walked = {_drop_convertors(p) for p in _mutating_paths(app)}
+    from_schema = {
+        path
+        for path, ops in app.openapi().get("paths", {}).items()
+        if {m.upper() for m in ops} & _MUTATING
+        if path.startswith(("/api", "/v1"))
+    }
+    assert from_schema, "openapi() reported no mutating routes -- cross-check is inert"
+    assert from_schema <= walked, f"walk missed: {sorted(from_schema - walked)}"
 
 
 def test_every_mutating_route_is_covered_by_the_guard(app):
@@ -359,6 +403,31 @@ async def test_rebinding_host_is_rejected(stack, app):
     )
     assert status == 400
     assert b"Invalid Host" in body
+
+
+async def test_host_rejection_names_the_setting_that_fixes_it(stack, app):
+    """Someone reaching the UI by machine name needs the remedy, not just a 400.
+
+    CLAUDE.md: an actionable error says what failed, what to do, and where
+    to look.
+    """
+    _, _, body = await _request(
+        stack, app, "GET", "/api/health", {"host": "my-workstation:4200"}
+    )
+    detail = body.decode()
+    assert "my-workstation" in detail
+    assert security.ENV_ALLOWED_HOSTS in detail
+
+
+@pytest.mark.parametrize("host", ["::1", "[::1]:4200", "[2001:db8::1]:4200"])
+def test_ipv6_authority_is_parsed_whole(host):
+    """A bare IPv6 ``Host`` must not be split on its own colons.
+
+    Brackets are required by RFC 3986 so nothing correct sends the bare
+    form, but ``rsplit(":", 1)`` turned ``"::1"`` into ``":"`` -- which
+    failed the loopback check for a value that plainly is loopback.
+    """
+    assert security.is_allowed_host(host, None)
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/test_hub_router.py
+++ b/tests/unit/test_hub_router.py
@@ -37,6 +37,18 @@ def client(app):
     return TestClient(app)
 
 
+@pytest.fixture
+def client_no_ui_header(app):
+    """Client that opts out of ``tests/conftest.py``'s ``X-Gaia-UI`` default.
+
+    Used by the tests that assert the CSRF guard refuses an unheadered
+    request -- they would otherwise pass for the wrong reason.
+    """
+    client = TestClient(app)
+    client.headers.pop("x-gaia-ui", None)
+    return client
+
+
 @pytest.fixture(autouse=True)
 def _clean():
     installer_mod.clear_progress()
@@ -161,8 +173,8 @@ def test_install_duplicate_returns_409(client, monkeypatch):
     assert resp.status_code == 409
 
 
-def test_install_requires_ui_header(client):
-    resp = client.post("/api/agents/install", json={"id": "demo"})
+def test_install_requires_ui_header(client_no_ui_header):
+    resp = client_no_ui_header.post("/api/agents/install", json={"id": "demo"})
     assert resp.status_code == 403
 
 
@@ -208,8 +220,8 @@ def test_uninstall_not_installed_404(client, monkeypatch):
     assert resp.status_code == 404
 
 
-def test_uninstall_requires_ui_header(client):
-    resp = client.delete("/api/agents/demo")
+def test_uninstall_requires_ui_header(client_no_ui_header):
+    resp = client_no_ui_header.delete("/api/agents/demo")
     assert resp.status_code == 403
 
 
@@ -277,8 +289,8 @@ def test_set_config_replace_flag(client, monkeypatch):
     assert captured["merge"] is False
 
 
-def test_set_config_requires_ui_header(client):
-    resp = client.post("/api/agents/demo/config", json={"config": {"a": 1}})
+def test_set_config_requires_ui_header(client_no_ui_header):
+    resp = client_no_ui_header.post("/api/agents/demo/config", json={"config": {"a": 1}})
     assert resp.status_code == 403
 
 
@@ -344,8 +356,8 @@ def test_setup_empty_ids_400(client):
     assert resp.status_code == 400
 
 
-def test_setup_requires_ui_header(client):
-    resp = client.post("/api/agents/setup", json={"ids": ["a"]})
+def test_setup_requires_ui_header(client_no_ui_header):
+    resp = client_no_ui_header.post("/api/agents/setup", json={"ids": ["a"]})
     assert resp.status_code == 403
 
 

--- a/tests/unit/test_hub_router.py
+++ b/tests/unit/test_hub_router.py
@@ -290,7 +290,9 @@ def test_set_config_replace_flag(client, monkeypatch):
 
 
 def test_set_config_requires_ui_header(client_no_ui_header):
-    resp = client_no_ui_header.post("/api/agents/demo/config", json={"config": {"a": 1}})
+    resp = client_no_ui_header.post(
+        "/api/agents/demo/config", json={"config": {"a": 1}}
+    )
     assert resp.status_code == 403
 
 


### PR DESCRIPTION
## Summary

Any web page the user visited could drive their local Agent UI backend. This closes that
with one middleware over every mutating route, deletes a CORS rule that trusted two
rent-a-subdomain namespaces, and adds `Host`/`Origin` checks behind both.

## Why

The Agent UI backend binds loopback and has no authentication while the tunnel is off, so
the only thing standing between it and a page in another tab was the `X-Gaia-UI` CSRF
header — and that header was opt-in per route. Four copies of the same guard function,
applied to 24 decorators out of **92 mutating routes**. 41 of the remaining ones take no
JSON body, so a plain cross-origin form POST reached them: `POST /api/tunnel/start`
published the machine to the public internet, `POST /api/documents/upload` indexed attacker
content into the user's RAG (persistent prompt injection), and the whole `/v1/email/*`
surface including `send` was open. The rest were protected only because FastAPI happens to
422 a `text/plain` body — a parser, not a security control.

Fixing that alone would not have held. CORS trusted every `*.ngrok-free.app` and
`*.use.devtunnels.ms` origin with `allow_credentials=True` and `allow_headers=["*"]`. Those
are self-service namespaces: anyone can rent a subdomain, and their preflight was approved
*including* `X-Gaia-UI` — the header the guard is built on. It was also dead config; the
tunnel GAIA starts issues `*.ngrok-free.**dev**`, which the regex never matched, and the
mobile flow serves the SPA *from* the tunnel origin, so those requests are same-origin and
CORS never applies. It granted a capability to attackers and nothing to users.

After this, a route added tomorrow is covered on the day it lands, and a route-table test
fails the build if a mutating route ever ships outside the guarded prefixes.

## Linked issue

Closes #3365

## Changes

- **The guard is now a middleware, not a decorator you have to remember.**
  `UIRequestGuardMiddleware` (`src/gaia/ui/security.py`) enforces `X-Gaia-UI: 1` on every
  non-GET `/api`/`/v1` request. Registered outermost, so it runs before `TunnelAuthMiddleware`'s
  tunnel-inactive passthrough and its rejections carry no CORS headers. The four duplicate
  guard functions collapse into one import.
- **Two layers behind it.** A mutating request whose `Origin` is neither this server,
  loopback, nor the live tunnel is refused, so a future CORS mistake is not sufficient on
  its own. A request whose `Host` is a name the server does not know is refused, which
  closes DNS rebinding against the read side (`GET /api/files/preview`). IP literals still
  pass, so `--host 0.0.0.0` LAN access is unaffected; `GAIA_UI_ALLOWED_{HOSTS,ORIGINS}` are
  there for a proxied deployment.
- **`allow_origin_regex` deleted.** Nothing needed it.
- **Every non-browser client updated to send the header**: the React renderer (set in
  `apiFetch` so no call site can forget, plus the three raw `fetch` sites that bypass it),
  `gaia mcp`'s `agent_ui_mcp` server, both eval-harness callers, and the Agent UI stress
  suite. The Electron main process already sent it. The Go TUI does not talk to this backend
  at all — it reaches the daemon and Lemonade on their own ports.

  **Correction:** the first version of this PR said the inventory was complete, and it was
  not — review found `tests/stress/test_agent_ui_stress.py`, whose single `httpx.AsyncClient`
  carried no headers, so its session-create, chat-send and delete calls would all have 403'd.
  My sweep covered `src/`, `tui/`, and the unit and integration test trees but never looked
  at `tests/stress/`, and that suite needs a live model backend so no test run would have
  caught it. I have since re-swept every file in the repo that names port 4200 or builds a
  backend URL, checking each for a mutating call: `tests/stress` was the only miss.
- **Breaking for third-party `/v1/email` integrators.** Those routes now require
  `X-Gaia-UI: 1` like the rest; `docs/guides/email-integration.mdx` says so and its curl
  examples carry it. Exempting them was the alternative, and "send mail as the user" was the
  most alarming entry on the forgeable list.

## Test plan

- [x] `pytest tests/unit/chat/ui/test_ui_request_guard.py -v` — 25 new tests: route-table
      coverage, the rented-ngrok preflight, the four rejection paths, and every first-party
      client shape. Run in a venv built exactly like the CI lane
      (`.github/workflows/test_unit.yml`, `Unit Tests (py3.12)`, `.[api]` extras,
      `GAIA_MEMORY_DISABLED=1`) to confirm they *run* there rather than skip — the lane's
      `paths` filter matches on both `src/**` and `tests/**`.
- [x] The same 25 tests against the unfixed `server.py`: **7 fail**, including both
      preflight tests and every rejection path. They are regression tests, not assertions
      that pass either way.
- [x] **The route-coverage tests were verified on the declared FastAPI floor, not just my
      venv.** `fastapi==0.115.0` (`setup.py`): **30 passed**, no collection error. Same 30 on
      `0.141.1`. And with a mutating route temporarily mounted at `/agents/rogue-action`,
      outside the guarded prefixes, `test_every_mutating_route_is_covered_by_the_guard` goes
      red on **both** versions:
      `AssertionError: mutating routes outside ('/api/', '/v1/'): ['/agents/rogue-action']`.
      Reverted after. The walk no longer imports FastAPI private names; a new
      `test_walk_covers_everything_openapi_knows_about` cross-checks it against `app.openapi()`,
      which is public and stable on every supported version — it caught a real gap while being
      written.
- [x] `pytest tests/unit/connectors tests/unit/chat/ui tests/unit/test_hub_router.py
      tests/unit/test_memory_router.py tests/unit/test_goals_router.py
      tests/unit/test_scheduler_api.py tests/unit/test_onboarding_router.py` — 1860 passed.

      **Read this before trusting any Windows-local result on these files.** The unit
      conftest's `_block_network` guard patches `socket.connect`, which also breaks the
      `socketpair()` the Windows asyncio loop opens for itself. Every `TestClient` in these
      directories therefore *errors in setup* on Windows — so the files appear to run while
      executing nothing, and a plain local run reports the same failure count before and
      after a change that broke four tests. I only found those four by re-running with the
      guard lifted, which is the shape Linux CI actually runs. **The Linux lane is the real
      signal for these files; a green Windows run here is not evidence.** (Review finding C41
      — pre-existing, not fixed in this PR.)
- [x] `pytest tests/unit` in full — 10385 passed, 100 failed, 15 errors. Every one of those
      failures reproduces unchanged on `upstream/main` (macOS-installer, launcher, scorecard
      and packaging suites that do not run on this box), verified by reverting the patch and
      re-running the affected files: identical 76-line failure list before and after.
- [x] `pytest tests/integration/test_chat_ui_integration.py tests/integration/test_documents_router.py
      tests/integration/test_files_router.py tests/integration/test_folder_indexing.py`
      — 200 passed, 2 failed. Both failures reproduce on `upstream/main` unchanged (the
      embedding model is unreachable on this box), verified by reverting the patch and
      re-running.
- [x] `npm run build`, `tsc --noEmit`, and `vitest run` in `src/gaia/apps/webui` — 279 tests
      passed, clean typecheck, build succeeds. `npx jest test_agent_process_manager.js` in
      `tests/electron` — 114 passed.
- [x] `python util/lint.py --all` — Black, isort, Flake8, Bandit, agent conventions all
      pass. The one failure is a pre-existing Windows-only Pylint false positive
      (`os.killpg` in `src/gaia/daemon/sidecars/`), in files this PR does not touch.
- [ ] Not run: `gaia eval agent`. This PR touches no LLM-affecting surface — no system
      prompts, tool registration, tool docstrings, JSON tool schema, error classification,
      or default model. It changes HTTP request admission only.

## Evidence

- [ ] **Agent exposed in the Agent UI** — N/A for a screenshot: this change adds no UI. Its
      user-visible effect is that the SPA keeps working unchanged, which the "first-party
      clients" block below exercises directly against the real server.
- [ ] **MCP tools / servers** — N/A: `agent_ui_mcp.py` now sends the header on every call;
      covered by the "no Origin + header" row below, which is the exact request shape it
      issues.
- [ ] **CLI** — N/A: no `gaia` subcommand changed.
- [x] **HTTP API / REST** — real requests against a real `gaia.ui.server` on a scratch port
      with a throwaway `HOME`, before and after. `POST /api/memory/prune` stands in for
      `POST /api/tunnel/start`: same body-less shape, and demonstrating the tunnel route
      would have opened a real public tunnel.

**Before** (`upstream/main` @ `abe87edc`):

```
$ curl -i -X OPTIONS $B/api/memory/prune -H "Origin: https://someone-else.ngrok-free.app" \
       -H "Access-Control-Request-Method: POST" -H "Access-Control-Request-Headers: x-gaia-ui,content-type"
HTTP/1.1 200 OK
access-control-allow-credentials: true
access-control-allow-origin: https://someone-else.ngrok-free.app
access-control-allow-headers: x-gaia-ui,content-type          <-- the CSRF header, approved

$ curl -i -X POST "$B/api/memory/prune?days=7" -H "Origin: https://evil.example" -H "Content-Type: text/plain"
HTTP/1.1 200 OK
{"tool_history_deleted":0,"conversations_deleted":0,"knowledge_deleted":0}

$ curl -o /dev/null -w "%{http_code}\n" $B/api/health -H "Host: evil.example"
200
```

**After:**

```
$ curl -i -X OPTIONS $B/api/memory/prune -H "Origin: https://someone-else.ngrok-free.app" ...
HTTP/1.1 400 Bad Request                       (no access-control-allow-origin)

$ curl -i -X POST "$B/api/memory/prune?days=7" -H "Origin: https://evil.example" -H "Content-Type: text/plain"
HTTP/1.1 403 Forbidden
{"detail": "Cross-origin request rejected"}

$ curl -i -X POST "$B/api/memory/prune?days=7" -H "Origin: https://evil.example" -H "X-Gaia-UI: 1"
HTTP/1.1 403 Forbidden                         (a forged header is not enough)
{"detail": "Cross-origin request rejected"}

$ curl $B/api/health -H "Host: evil.example"
HTTP/1.1 400 Bad Request
{"detail": "Invalid Host header"}
```

**Every first-party client path still works** — the part that matters for not breaking users:

```
SPA          Origin http://127.0.0.1:4277 + header   POST /api/memory/prune -> 200
Electron     Origin null (file://) + header          POST /api/memory/prune -> 200
gaia mcp     no Origin + header                      POST /api/memory/prune -> 200
vite dev     Origin http://localhost:5174            OPTIONS preflight      -> 200
EventSource  GET, no header (it cannot send one)     GET  /api/health       -> 200
LAN access   Host 192.168.1.9:4277                   GET  /api/health       -> 200

$ curl -X POST "$B/api/memory/prune?days=7" -H "Origin: http://127.0.0.1:4277" -H "X-Gaia-UI: 1"
{"tool_history_deleted":0,"conversations_deleted":0,"knowledge_deleted":0}
```

**Adjacent paths checked**, since the header is only a defence if nothing re-widens the
origin set and nothing routes around the middleware:

```
middleware order (outermost first): UIRequestGuardMiddleware, TunnelAuthMiddleware, CORSMiddleware
CORS config: 6 localhost origins, allow_origin_regex absent, no wildcard, no runtime mutation
X-Gaia-UI is CORS-safelisted? False  -> a cross-origin request carrying it must preflight
websocket routes: 0                  -> nothing reaches a route on a non-HTTP scope
mounts: /api/files/uploads (StaticFiles, GET/HEAD only, still behind the Host check)
mutating /api|/v1 routes outside GUARDED_PREFIXES: none (asserted by the route-table test)
CSRF_EXEMPT_PATHS: empty (asserted) — the OAuth loopback callback is a GET on its own
                   aiohttp server in gaia.connectors.flow, so it needs no entry
```

### Known-flaky, unrelated

`Test GAIA CLI on Linux (Full Integration)` failed on an earlier push because Hugging Face
returned `429` pulling `unsloth/Qwen3-0.6B-GGUF`, so Lemonade never started and the rest of
the log is retries against a server that never came up. Nothing in it reaches CSRF, CORS or
this middleware. Deliberately not "fixed" — a retry or fallback around the model pull is the
silent-degradation patch CLAUDE.md forbids, and it is out of scope here.

## Checklist

- [x] I have linked a GitHub issue above (`Closes #3365`).
- [x] I have described **why** this change is being made, not just what changed.
- [x] I have run linting and tests locally (`python util/lint.py --all`, `pytest tests/unit/`).
- [x] I have attached **real-world evidence matched to the surface I changed**, or marked each surface N/A.
- [x] I have updated documentation if user-visible behavior changed
      (`docs/guides/email-integration.mdx`, `docs/spec/agent-ui-server.mdx`).

