### PR TITLE
fix(ci): run the full suite on stacked PRs, not just PRs into main

### DIFF
--- a/.github/workflows/build-electron-apps.yml
+++ b/.github/workflows/build-electron-apps.yml
@@ -15,7 +15,7 @@ on:
   push:
     branches: [main]
   pull_request:
-    branches: [main]
+    # No `branches:` filter: it matches the PR base, so `[ main ]` skipped stacked PRs (#2767).
     types: [opened, synchronize, reopened, ready_for_review]
   merge_group:
   workflow_dispatch:

--- a/.github/workflows/build_agents.yml
+++ b/.github/workflows/build_agents.yml
@@ -26,7 +26,7 @@ on:
       - 'cpp/**'
       - '.github/workflows/build_agents.yml'
   pull_request:
-    branches: [ main ]
+    # No `branches:` filter: it matches the PR base, so `[ main ]` skipped stacked PRs (#2767).
     types: [opened, synchronize, reopened, ready_for_review]
     paths:
       - 'cpp/**'

--- a/.github/workflows/build_cpp.yml
+++ b/.github/workflows/build_cpp.yml
@@ -25,7 +25,7 @@ on:
       - '.github/workflows/build_cpp.yml'
       - '.github/workflows/benchmark_cpp.yml'
   pull_request:
-    branches: [ main ]
+    # No `branches:` filter: it matches the PR base, so `[ main ]` skipped stacked PRs (#2767).
     types: [opened, synchronize, reopened, ready_for_review]
     paths:
       - 'src/gaia/version.py'

--- a/.github/workflows/build_cpp_email.yml
+++ b/.github/workflows/build_cpp_email.yml
@@ -34,7 +34,7 @@ on:
     paths:
       - 'cpp/agents/email/**'
   pull_request:
-    branches: [ main ]
+    # No `branches:` filter: it matches the PR base, so `[ main ]` skipped stacked PRs (#2767).
     types: [opened, synchronize, reopened, ready_for_review]
     paths:
       - 'cpp/agents/email/**'

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -9,7 +9,7 @@ name: Dependency Review
 
 on:
   pull_request:
-    branches: [ main ]
+    # No `branches:` filter: it matches the PR base, so `[ main ]` skipped stacked PRs (#2767).
     types: [opened, synchronize, reopened, ready_for_review]
   merge_group:
   workflow_dispatch:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -22,9 +22,11 @@ on:
       - 'util/check_*.py'
       - '.security-suppressions.json'
       - '.github/dependabot.yml'
-      - '.github/workflows/lint.yml'
+      # `util/check_workflow_triggers.py` validates these, same as
+      # `check_dependabot.py` validates `.github/dependabot.yml` above.
+      - '.github/workflows/**'
   pull_request:
-    branches: [ main ]
+    # No `branches:` filter: it matches the PR base, so `[ main ]` skipped stacked PRs (#2767).
     types: [opened, synchronize, reopened, ready_for_review]
     paths:
       - 'src/**'
@@ -36,7 +38,9 @@ on:
       - 'util/check_*.py'
       - '.security-suppressions.json'
       - '.github/dependabot.yml'
-      - '.github/workflows/lint.yml'
+      # `util/check_workflow_triggers.py` validates these, same as
+      # `check_dependabot.py` validates `.github/dependabot.yml` above.
+      - '.github/workflows/**'
   merge_group:
   workflow_dispatch:
 

--- a/.github/workflows/skill_audit.yml
+++ b/.github/workflows/skill_audit.yml
@@ -47,7 +47,7 @@ name: Skill Audit
 
 on:
   pull_request:
-    branches: [ main ]
+    # No `branches:` filter: it matches the PR base, so `[ main ]` skipped stacked PRs (#2767).
     # `labeled`/`unlabeled` are here so applying the sign-off label re-runs the
     # gate instead of needing a manual re-run.
     types: [opened, synchronize, reopened, ready_for_review, labeled, unlabeled]

--- a/.github/workflows/test_agent_email_npm.yml
+++ b/.github/workflows/test_agent_email_npm.yml
@@ -15,7 +15,7 @@ on:
       - 'hub/agents/email/npm/**'
       - '.github/workflows/test_agent_email_npm.yml'
   pull_request:
-    branches: [ main ]
+    # No `branches:` filter: it matches the PR base, so `[ main ]` skipped stacked PRs (#2767).
     types: [opened, synchronize, reopened, ready_for_review]
     paths:
       - 'hub/agents/email/npm/**'

--- a/.github/workflows/test_agent_gaia_npm.yml
+++ b/.github/workflows/test_agent_gaia_npm.yml
@@ -21,7 +21,7 @@ on:
       - 'hub/agents/gaia/npm/**'
       - '.github/workflows/test_agent_gaia_npm.yml'
   pull_request:
-    branches: [ main ]
+    # No `branches:` filter: it matches the PR base, so `[ main ]` skipped stacked PRs (#2767).
     types: [opened, synchronize, reopened, ready_for_review]
     paths:
       - 'hub/agents/gaia/npm/**'

--- a/.github/workflows/test_agent_mcp_server.yml
+++ b/.github/workflows/test_agent_mcp_server.yml
@@ -18,7 +18,7 @@ on:
       - 'setup.py'
       - '.github/workflows/test_agent_mcp_server.yml'
   pull_request:
-    branches: [ main ]
+    # No `branches:` filter: it matches the PR base, so `[ main ]` skipped stacked PRs (#2767).
     types: [opened, synchronize, reopened, ready_for_review]
     paths:
       - 'src/gaia/version.py'

--- a/.github/workflows/test_agent_sdk.yml
+++ b/.github/workflows/test_agent_sdk.yml
@@ -19,7 +19,7 @@ on:
       - "installer/scripts/**"
       - ".github/workflows/test_agent_sdk.yml"
   pull_request:
-    branches: ["main"]
+    # No `branches:` filter: it matches the PR base, so `[ main ]` skipped stacked PRs (#2767).
     types: [opened, synchronize, reopened, ready_for_review]
     paths:
       - 'src/gaia/version.py'

--- a/.github/workflows/test_api.yml
+++ b/.github/workflows/test_api.yml
@@ -22,7 +22,7 @@ on:
       - 'setup.py'
       - '.github/workflows/test_api.yml'
   pull_request:
-    branches: ["main"]
+    # No `branches:` filter: it matches the PR base, so `[ main ]` skipped stacked PRs (#2767).
     types: [opened, synchronize, reopened, ready_for_review]
     paths:
       - 'src/gaia/version.py'

--- a/.github/workflows/test_chat_agent.yml
+++ b/.github/workflows/test_chat_agent.yml
@@ -22,7 +22,7 @@ on:
       - 'setup.py'
       - '.github/workflows/test_chat_agent.yml'
   pull_request:
-    branches: [ main ]
+    # No `branches:` filter: it matches the PR base, so `[ main ]` skipped stacked PRs (#2767).
     types: [opened, synchronize, reopened, ready_for_review]
     paths:
       - 'hub/agents/chat/python/**'

--- a/.github/workflows/test_connectors_demo.yml
+++ b/.github/workflows/test_connectors_demo.yml
@@ -17,7 +17,7 @@ on:
       - 'setup.py'
       - '.github/workflows/test_connectors_demo.yml'
   pull_request:
-    branches: [ main ]
+    # No `branches:` filter: it matches the PR base, so `[ main ]` skipped stacked PRs (#2767).
     types: [opened, synchronize, reopened, ready_for_review]
     paths:
       - 'hub/agents/connectors-demo/python/**'

--- a/.github/workflows/test_distributed_seams.yml
+++ b/.github/workflows/test_distributed_seams.yml
@@ -29,7 +29,7 @@ on:
       - 'tests/unit/test_sidecar_harness.py'
       - '.github/workflows/test_distributed_seams.yml'
   pull_request:
-    branches: [ main ]
+    # No `branches:` filter: it matches the PR base, so `[ main ]` skipped stacked PRs (#2767).
     types: [opened, synchronize, reopened, ready_for_review]
     paths:
       - 'src/gaia/daemon/**'

--- a/.github/workflows/test_electron.yml
+++ b/.github/workflows/test_electron.yml
@@ -14,7 +14,7 @@ on:
       - 'tests/electron/**'
       - '.github/workflows/test_electron.yml'
   pull_request:
-    branches: ["main"]
+    # No `branches:` filter: it matches the PR base, so `[ main ]` skipped stacked PRs (#2767).
     types: [opened, synchronize, reopened, ready_for_review]
     paths:
       - 'src/gaia/electron/**'

--- a/.github/workflows/test_email_agent.yml
+++ b/.github/workflows/test_email_agent.yml
@@ -28,7 +28,7 @@ on:
       - 'tests/integration/test_email_corpus_alignment.py'
       - '.github/workflows/test_email_agent.yml'
   pull_request:
-    branches: [ main ]
+    # No `branches:` filter: it matches the PR base, so `[ main ]` skipped stacked PRs (#2767).
     types: [opened, synchronize, reopened, ready_for_review]
     paths:
       - 'hub/agents/email/python/**'

--- a/.github/workflows/test_email_agent_eval.yml
+++ b/.github/workflows/test_email_agent_eval.yml
@@ -139,7 +139,7 @@ on:
   # (report mode) by default; `ready_for_review` is in `types` so undrafting a PR
   # triggers the run that the draft state skipped.
   pull_request:
-    branches: [ main ]
+    # No `branches:` filter: it matches the PR base, so `[ main ]` skipped stacked PRs (#2767).
     types: [opened, synchronize, reopened, ready_for_review]
     paths:
       # The agent itself — prompts, tools, triage/condense, bundled skills, and

--- a/.github/workflows/test_email_agent_unit.yml
+++ b/.github/workflows/test_email_agent_unit.yml
@@ -48,7 +48,7 @@ on:
       - 'pyproject.toml'
       - '.github/workflows/test_email_agent_unit.yml'
   pull_request:
-    branches: [ main ]
+    # No `branches:` filter: it matches the PR base, so `[ main ]` skipped stacked PRs (#2767).
     types: [opened, synchronize, reopened, ready_for_review]
     paths:
       - 'hub/agents/email/python/**'

--- a/.github/workflows/test_embeddings.yml
+++ b/.github/workflows/test_embeddings.yml
@@ -16,7 +16,7 @@ on:
       - 'setup.py'
       - '.github/workflows/test_embeddings.yml'
   pull_request:
-    branches: [ main ]
+    # No `branches:` filter: it matches the PR base, so `[ main ]` skipped stacked PRs (#2767).
     types: [opened, synchronize, reopened, ready_for_review]
     paths:
       - 'src/gaia/version.py'

--- a/.github/workflows/test_eval.yml
+++ b/.github/workflows/test_eval.yml
@@ -20,7 +20,7 @@ on:
       - 'setup.py'
       - '.github/workflows/test_eval.yml'
   pull_request:
-    branches: ["main"]
+    # No `branches:` filter: it matches the PR base, so `[ main ]` skipped stacked PRs (#2767).
     types: [opened, synchronize, reopened, ready_for_review]
     paths:
       - 'src/gaia/eval/**'

--- a/.github/workflows/test_eval_agent_gemma_consolidation.yml
+++ b/.github/workflows/test_eval_agent_gemma_consolidation.yml
@@ -156,7 +156,7 @@ on:
   # `hub/agents/*/python/**`, so 18 hub packages newly qualify for a
   # single-slot pool — scoping to the PR diff is what keeps that affordable.
   pull_request:
-    branches: [ main ]
+    # No `branches:` filter: it matches the PR base, so `[ main ]` skipped stacked PRs (#2767).
     types: [opened, synchronize, reopened, ready_for_review]
     paths:
       # The consolidation itself.

--- a/.github/workflows/test_examples.yml
+++ b/.github/workflows/test_examples.yml
@@ -26,7 +26,7 @@ on:
       - 'setup.py'
       - '.github/workflows/test_examples.yml'
   pull_request:
-    branches: [ main ]
+    # No `branches:` filter: it matches the PR base, so `[ main ]` skipped stacked PRs (#2767).
     types: [opened, synchronize, reopened, ready_for_review]
     paths:
       - 'src/gaia/version.py'

--- a/.github/workflows/test_gaia_agent.yml
+++ b/.github/workflows/test_gaia_agent.yml
@@ -23,7 +23,7 @@ on:
       - 'setup.py'
       - '.github/workflows/test_gaia_agent.yml'
   pull_request:
-    branches: [ main ]
+    # No `branches:` filter: it matches the PR base, so `[ main ]` skipped stacked PRs (#2767).
     types: [opened, synchronize, reopened, ready_for_review]
     paths:
       - 'hub/agents/gaia/python/**'

--- a/.github/workflows/test_gaia_cli_linux.yml
+++ b/.github/workflows/test_gaia_cli_linux.yml
@@ -12,7 +12,7 @@ on:
   push:
     branches: [ main ]
   pull_request:
-    branches: [ main ]
+    # No `branches:` filter: it matches the PR base, so `[ main ]` skipped stacked PRs (#2767).
     types: [opened, synchronize, reopened, ready_for_review]
   merge_group:
   workflow_dispatch:

--- a/.github/workflows/test_gaia_cli_windows.yml
+++ b/.github/workflows/test_gaia_cli_windows.yml
@@ -21,7 +21,7 @@ on:
       - "installer/scripts/**"
       - ".github/workflows/test_gaia_cli_windows.yml"
   pull_request:
-    branches: ["main"]
+    # No `branches:` filter: it matches the PR base, so `[ main ]` skipped stacked PRs (#2767).
     types: [opened, synchronize, reopened, ready_for_review]
     paths:
       - 'src/gaia/version.py'

--- a/.github/workflows/test_hub_agents.yml
+++ b/.github/workflows/test_hub_agents.yml
@@ -23,7 +23,7 @@ on:
       - 'setup.py'
       - '.github/workflows/test_hub_agents.yml'
   pull_request:
-    branches: [ main ]
+    # No `branches:` filter: it matches the PR base, so `[ main ]` skipped stacked PRs (#2767).
     types: [opened, synchronize, reopened, ready_for_review]
     paths:
       - 'hub/agents/hello-world/python/**'

--- a/.github/workflows/test_lemonade_server.yml
+++ b/.github/workflows/test_lemonade_server.yml
@@ -18,7 +18,7 @@ on:
       - 'installer/**'
       - 'tests/test_lemonade*.py'
   pull_request:
-    branches: [ main ]
+    # No `branches:` filter: it matches the PR base, so `[ main ]` skipped stacked PRs (#2767).
     types: [opened, synchronize, reopened, ready_for_review]
     paths:
       - 'src/gaia/version.py'

--- a/.github/workflows/test_mcp.yml
+++ b/.github/workflows/test_mcp.yml
@@ -18,7 +18,7 @@ on:
       - 'setup.py'
       - '.github/workflows/test_mcp.yml'
   pull_request:
-    branches: [ main ]
+    # No `branches:` filter: it matches the PR base, so `[ main ]` skipped stacked PRs (#2767).
     types: [opened, synchronize, reopened, ready_for_review]
     paths:
       - 'src/gaia/mcp/**'

--- a/.github/workflows/test_npu_embedder.yml
+++ b/.github/workflows/test_npu_embedder.yml
@@ -29,7 +29,7 @@ on:
       - 'tests/test_npu_flm_embedder_hw.py'
       - '.github/workflows/test_npu_embedder.yml'
   pull_request:
-    branches: [ main ]
+    # No `branches:` filter: it matches the PR base, so `[ main ]` skipped stacked PRs (#2767).
     types: [opened, synchronize, reopened, ready_for_review]
     paths:
       - 'src/gaia/agents/registry.py'

--- a/.github/workflows/test_rag.yml
+++ b/.github/workflows/test_rag.yml
@@ -18,7 +18,7 @@ on:
       - 'setup.py'
       - '.github/workflows/test_rag.yml'
   pull_request:
-    branches: [ main ]
+    # No `branches:` filter: it matches the PR base, so `[ main ]` skipped stacked PRs (#2767).
     types: [opened, synchronize, reopened, ready_for_review]
     paths:
       - 'src/gaia/version.py'

--- a/.github/workflows/test_sd.yml
+++ b/.github/workflows/test_sd.yml
@@ -21,7 +21,7 @@ on:
       - "tests/integration/test_sd_integration.py"
       - "tests/unit/test_sd_mixin.py"
   pull_request:
-    branches: ["main"]
+    # No `branches:` filter: it matches the PR base, so `[ main ]` skipped stacked PRs (#2767).
     types: [opened, synchronize, reopened, ready_for_review]
     paths:
       - 'src/gaia/version.py'

--- a/.github/workflows/test_security.yml
+++ b/.github/workflows/test_security.yml
@@ -18,7 +18,7 @@ on:
       - 'setup.py'
       - '.github/workflows/test_security.yml'
   pull_request:
-    branches: [ main ]
+    # No `branches:` filter: it matches the PR base, so `[ main ]` skipped stacked PRs (#2767).
     types: [opened, synchronize, reopened, ready_for_review]
     paths:
       - 'src/gaia/agents/**'

--- a/.github/workflows/test_unit.yml
+++ b/.github/workflows/test_unit.yml
@@ -25,7 +25,7 @@ on:
       # blocks, so a docs-only change can still break the guard.
       - 'docs/guides/custom-agent.mdx'
   pull_request:
-    branches: [ main ]
+    # No `branches:` filter: it matches the PR base, so `[ main ]` skipped stacked PRs (#2767).
     types: [opened, synchronize, reopened, ready_for_review]
     paths:
       - 'src/**'

--- a/docs/reference/dev.mdx
+++ b/docs/reference/dev.mdx
@@ -284,8 +284,18 @@ python util/lint.py --flake8      # flake8
 python util/lint.py --mypy        # type checking
 python util/lint.py --bandit      # security scan
 python util/lint.py --imports     # custom import-cycle check
+python util/lint.py --workflow-triggers # reject on.pull_request.branches filters
 python util/lint.py --doc-versions # verify versions in docs match src/gaia/version.py
 ```
+
+<Note>
+`--workflow-triggers` blocks a `branches:` filter under a workflow's
+`on.pull_request`. That key matches the PR's **base** branch, so `branches: [ main ]`
+means "only when merging into main" — every PR stacked on a feature branch skips the
+workflow, with nothing on its checks page to say so
+([#2767](https://github.com/amd/gaia/issues/2767)). Scope a workflow with `paths:`
+instead.
+</Note>
 
 ### Running Tests
 

--- a/tests/unit/test_check_workflow_triggers.py
+++ b/tests/unit/test_check_workflow_triggers.py
@@ -1,0 +1,124 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+"""Unit tests for util/check_workflow_triggers.py (#2767).
+
+Most tests write ephemeral workflow files to a tmp_path and monkeypatch
+WORKFLOW_DIR. The last class runs the check against the REAL
+.github/workflows/ — that is the regression test for the bug itself.
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+# Ensure util/ is importable regardless of where pytest is invoked from.
+REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT / "util"))
+
+import check_workflow_triggers  # noqa: E402
+
+
+def _write(tmp_path: Path, name: str, body: str) -> None:
+    (tmp_path / name).write_text(body, encoding="utf-8")
+
+
+@pytest.fixture
+def workflow_dir(tmp_path, monkeypatch):
+    monkeypatch.setattr(check_workflow_triggers, "WORKFLOW_DIR", tmp_path)
+    return tmp_path
+
+
+class TestAccepted:
+    def test_pull_request_without_branches(self, workflow_dir):
+        _write(
+            workflow_dir,
+            "ok.yml",
+            "on:\n  pull_request:\n    types: [opened]\n    paths: ['src/**']\njobs: {}\n",
+        )
+        assert check_workflow_triggers.run_check() == 0
+
+    def test_push_branches_filter_is_untouched(self, workflow_dir):
+        """The bug is base-branch filtering on PRs; push filters are legitimate."""
+        _write(
+            workflow_dir,
+            "ok.yml",
+            "on:\n  push:\n    branches: [ main ]\n  pull_request:\n    types: [opened]\njobs: {}\n",
+        )
+        assert check_workflow_triggers.run_check() == 0
+
+    def test_workflow_with_no_pull_request_trigger(self, workflow_dir):
+        _write(
+            workflow_dir,
+            "ok.yml",
+            "on:\n  schedule:\n    - cron: '0 0 * * 0'\njobs: {}\n",
+        )
+        assert check_workflow_triggers.run_check() == 0
+
+    def test_bare_pull_request_trigger(self, workflow_dir):
+        """`pull_request:` with no mapping parses to None, not a dict."""
+        _write(workflow_dir, "ok.yml", "on:\n  pull_request:\njobs: {}\n")
+        assert check_workflow_triggers.run_check() == 0
+
+    def test_quoted_on_key(self, workflow_dir):
+        """`\"on\":` stays a string instead of resolving to the boolean True."""
+        _write(
+            workflow_dir,
+            "ok.yml",
+            '"on":\n  pull_request:\n    types: [opened]\njobs: {}\n',
+        )
+        assert check_workflow_triggers.run_check() == 0
+
+
+class TestRejected:
+    def test_inline_branches_filter(self, workflow_dir):
+        _write(
+            workflow_dir,
+            "bad.yml",
+            "on:\n  pull_request:\n    branches: [ main ]\n    types: [opened]\njobs: {}\n",
+        )
+        assert check_workflow_triggers.run_check() == 1
+
+    def test_block_sequence_branches_filter(self, workflow_dir):
+        _write(
+            workflow_dir,
+            "bad.yml",
+            "on:\n  pull_request:\n    branches:\n      - main\n      - release\njobs: {}\n",
+        )
+        assert check_workflow_triggers.run_check() == 1
+
+    def test_quoted_on_key_with_branches_filter(self, workflow_dir):
+        _write(
+            workflow_dir,
+            "bad.yml",
+            '"on":\n  pull_request:\n    branches: [ main ]\njobs: {}\n',
+        )
+        assert check_workflow_triggers.run_check() == 1
+
+    def test_error_names_the_file_and_the_issue(self, workflow_dir, capsys):
+        _write(
+            workflow_dir,
+            "bad.yml",
+            "on:\n  pull_request:\n    branches: [ main ]\njobs: {}\n",
+        )
+        check_workflow_triggers.run_check()
+        stderr = capsys.readouterr().err
+        assert "bad.yml" in stderr
+        assert "#2767" in stderr
+
+    def test_unparseable_workflow_rejected(self, workflow_dir):
+        _write(workflow_dir, "bad.yml", "on:\n  pull_request: [\n    invalid")
+        assert check_workflow_triggers.run_check() == 1
+
+    def test_missing_workflow_dir(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(
+            check_workflow_triggers, "WORKFLOW_DIR", tmp_path / "nonexistent"
+        )
+        assert check_workflow_triggers.run_check() == 1
+
+
+class TestRealRepository:
+    def test_no_workflow_filters_on_base_branch(self):
+        """Regression guard for #2767 against the repo's actual workflows."""
+        assert check_workflow_triggers.run_check() == 0

--- a/util/check_workflow_triggers.py
+++ b/util/check_workflow_triggers.py
@@ -1,0 +1,89 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+"""Reject `on.pull_request.branches:` filters in .github/workflows/*.yml.
+
+Per #2767, `on.pull_request.branches` matches the PR's BASE branch, not its head.
+`branches: [ main ]` therefore means "only when merging into main" — every stacked
+PR (one opened against another feature branch) falls outside the filter and the
+job is never created. Nothing shows failed or skipped; the checks page is simply
+missing it. That is how #2599 merged email-agent code with zero email tests, zero
+unit tests and zero lint behind a green checks page.
+
+Use `paths:` to scope a workflow to the code it covers. Never `branches:`.
+
+Runs as part of `python util/lint.py --all`. Run directly with
+`python util/check_workflow_triggers.py`.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Any, Dict
+
+import yaml
+
+# Anchor to the repo root so the script works regardless of CWD — matches the
+# convention in util/check_dependabot.py and util/check_doc_versions.py.
+REPO_ROOT = Path(__file__).resolve().parents[1]
+WORKFLOW_DIR = REPO_ROOT / ".github" / "workflows"
+
+
+def _pull_request_trigger(workflow: Any) -> Dict[str, Any] | None:
+    """Return the `on.pull_request` mapping, or None if there isn't one.
+
+    PyYAML resolves the bare `on:` key to the boolean True (YAML 1.1), so both
+    spellings have to be probed.
+    """
+    if not isinstance(workflow, dict):
+        return None
+    triggers = workflow.get("on", workflow.get(True))
+    if not isinstance(triggers, dict):
+        return None
+    trigger = triggers.get("pull_request")
+    return trigger if isinstance(trigger, dict) else None
+
+
+def run_check() -> int:
+    """Validate every workflow's pull_request trigger. 0 on success, 1 on error."""
+    if not WORKFLOW_DIR.is_dir():
+        print(f"[!] {WORKFLOW_DIR} not found", file=sys.stderr)
+        return 1
+
+    errors: list[str] = []
+    checked = 0
+
+    workflows = sorted(
+        p for p in WORKFLOW_DIR.iterdir() if p.suffix in (".yml", ".yaml")
+    )
+
+    for path in workflows:
+        try:
+            workflow = yaml.safe_load(path.read_text(encoding="utf-8"))
+        except yaml.YAMLError as exc:
+            errors.append(f"{path.name}: failed to parse: {exc}")
+            continue
+
+        checked += 1
+        trigger = _pull_request_trigger(workflow)
+        if trigger is not None and "branches" in trigger:
+            errors.append(
+                f"{path.name}: `on.pull_request.branches: "
+                f"{trigger['branches']}` filters on the PR's BASE branch, so this "
+                f"workflow never runs on a stacked PR. Drop the filter; scope the "
+                f"workflow with `paths:` instead (#2767)."
+            )
+
+    if errors:
+        print("[!] Workflow trigger issues found:", file=sys.stderr)
+        for err in errors:
+            print(f"    - {err}", file=sys.stderr)
+        return 1
+
+    print(f"[OK] {checked} workflow pull_request triggers validated.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(run_check())

--- a/util/lint.py
+++ b/util/lint.py
@@ -110,7 +110,7 @@ def check_black(fix: bool = False) -> CheckResult:
     if fix:
         print("\n[1/2] Fixing code formatting with Black...")
     else:
-        print("\n[1/11] Checking code formatting with Black...")
+        print("\n[1/12] Checking code formatting with Black...")
     print("-" * 40)
 
     if fix:
@@ -184,7 +184,7 @@ def check_isort(fix: bool = False) -> CheckResult:
     if fix:
         print("\n[2/2] Fixing import sorting with isort...")
     else:
-        print("\n[2/11] Checking import sorting with isort...")
+        print("\n[2/12] Checking import sorting with isort...")
     print("-" * 40)
 
     if fix:
@@ -241,7 +241,7 @@ def check_isort(fix: bool = False) -> CheckResult:
 
 def check_pylint() -> CheckResult:
     """Run Pylint (errors only)."""
-    print("\n[3/11] Running Pylint (errors only)...")
+    print("\n[3/12] Running Pylint (errors only)...")
     print("-" * 40)
 
     cmd = uvx(
@@ -266,7 +266,7 @@ def check_pylint() -> CheckResult:
 
 def check_flake8() -> CheckResult:
     """Run Flake8."""
-    print("\n[4/11] Running Flake8...")
+    print("\n[4/12] Running Flake8...")
     print("-" * 40)
 
     cmd = uvx(
@@ -299,7 +299,7 @@ def check_flake8() -> CheckResult:
 
 def check_mypy() -> CheckResult:
     """Run MyPy type checking (warning only)."""
-    print("\n[5/11] Running MyPy type checking (warning only)...")
+    print("\n[5/12] Running MyPy type checking (warning only)...")
     print("-" * 40)
 
     cmd = uvx("mypy", SRC_DIR, "--ignore-missing-imports")
@@ -339,7 +339,7 @@ def check_bandit() -> CheckResult:
     ``.bandit-baseline.json`` fails the check. MEDIUM/LOW findings are still
     reported (warning-only) so they stay visible without blocking the build.
     """
-    print("\n[6/11] Running security check with Bandit (HIGH = blocking)...")
+    print("\n[6/12] Running security check with Bandit (HIGH = blocking)...")
     print("-" * 40)
 
     from check_security_gates import (
@@ -390,7 +390,7 @@ def check_bandit() -> CheckResult:
 
 def check_security_suppressions() -> CheckResult:
     """Every '# noqa: S<n>' / '# nosec' must be reviewed in .security-suppressions.json."""
-    print("\n[7/11] Checking security suppressions are reviewed...")
+    print("\n[7/12] Checking security suppressions are reviewed...")
     print("-" * 40)
     gates = _import_security_gates()
     try:
@@ -407,7 +407,7 @@ def check_security_suppressions() -> CheckResult:
 
 def check_imports() -> CheckResult:
     """Test comprehensive SDK imports."""
-    print("\n[8/11] Testing comprehensive SDK imports...")
+    print("\n[8/12] Testing comprehensive SDK imports...")
     print("-" * 40)
 
     # Pre-check: verify gaia is installed
@@ -513,7 +513,7 @@ def check_imports() -> CheckResult:
 
 def check_agents() -> CheckResult:
     """Check GAIA agent conventions — inheritance, tests, docs, registry wiring."""
-    print("\n[9/11] Checking agent conventions...")
+    print("\n[9/12] Checking agent conventions...")
     print("-" * 40)
 
     # Import lazily so the check is self-contained and testable standalone.
@@ -549,7 +549,7 @@ def check_agents() -> CheckResult:
 
 def check_dependabot() -> CheckResult:
     """Validate .github/dependabot.yml (no soft-disabled entries, npm groups present)."""
-    print("\n[10/11] Validating .github/dependabot.yml...")
+    print("\n[10/12] Validating .github/dependabot.yml...")
     print("-" * 40)
 
     try:
@@ -578,9 +578,40 @@ def check_dependabot() -> CheckResult:
     return CheckResult("Dependabot Config", True, False, 0, "")
 
 
+def check_workflow_triggers() -> CheckResult:
+    """Reject `on.pull_request.branches:` filters, which silence stacked PRs."""
+    print("\n[11/12] Validating workflow pull_request triggers...")
+    print("-" * 40)
+
+    try:
+        from check_workflow_triggers import run_check
+    except ImportError:
+        util_dir = str(Path(__file__).parent)
+        if util_dir not in sys.path:
+            sys.path.insert(0, util_dir)
+        try:
+            from check_workflow_triggers import run_check
+        except ImportError as exc:
+            print(f"[!] Could not import check_workflow_triggers.py: {exc}")
+            return CheckResult("Workflow Triggers", False, False, 1, str(exc))
+
+    exit_code = run_check()
+
+    if exit_code != 0:
+        return CheckResult(
+            "Workflow Triggers",
+            False,
+            False,
+            1,
+            "See output above; drop the base-branch filter per #2767.",
+        )
+
+    return CheckResult("Workflow Triggers", True, False, 0, "")
+
+
 def check_doc_versions() -> CheckResult:
     """Check documentation version consistency."""
-    print("\n[11/11] Checking documentation version consistency...")
+    print("\n[12/12] Checking documentation version consistency...")
     print("-" * 40)
 
     # Import and run the check
@@ -759,6 +790,11 @@ def main():
         help="Validate .github/dependabot.yml (no soft-disabled entries, npm groups present)",
     )
     parser.add_argument(
+        "--workflow-triggers",
+        action="store_true",
+        help="Reject on.pull_request.branches filters, which silence stacked PRs",
+    )
+    parser.add_argument(
         "--doc-versions",
         action="store_true",
         help="Check doc version consistency",
@@ -782,6 +818,7 @@ def main():
             args.imports,
             args.agents,
             args.dependabot,
+            args.workflow_triggers,
             args.doc_versions,
             args.all,
         ]
@@ -836,6 +873,9 @@ def main():
 
     if args.dependabot or run_all:
         results.append(check_dependabot())
+
+    if args.workflow_triggers or run_all:
+        results.append(check_workflow_triggers())
 
     if args.doc_versions or run_all:
         results.append(check_doc_versions())


### PR DESCRIPTION
Before: a pull request based on any branch other than `main` ran no unit tests, no lint and no agent suites, and its checks page looked healthy the whole time — nothing failed, nothing showed as skipped, the jobs simply never existed. #2599 merged email-agent changes that way, with zero email tests, zero unit tests and zero lint behind a green page. After: those workflows run on every pull request regardless of base, so a stacked PR is held to the same bar as one opened against `main`. This matters right now because 42 open PRs are sitting on CI results that can't be trusted until it lands.

The cause is that `on.pull_request.branches` matches the PR's **base** branch, not its head, so `branches: [ main ]` meant "only when merging into main". 34 workflows carried it, including `lint`, `test_unit`, `test_security` and `dependency-review`.

Nothing is left main-only. Scoping stays where it belongs — every `paths:` filter is preserved byte-for-byte, so a workflow still only runs for the code it covers, and the 5 workflows whose `branches:` filter sits under `push:` are untouched, since restricting *pushes* to `main` is correct. A PR into the `release` branch would now run CI too; that is the desired behaviour and costs nothing today, because `release` is force-pushed from a tag by `update-release-branch.yml` and has never once been a PR target. Excluding it would just recreate this bug for the first backport anyone opens.

To stop it regressing, `util/check_workflow_triggers.py` fails the build if the filter reappears, and `lint.yml` now watches `.github/workflows/**` so a workflows-only PR actually runs that gate — without it the guard would itself be invisible on the change most likely to trip it.

Fixes #2767

## Test plan

- [x] Stacked-PR A/B on a throwaway base branch, same touched file in both arms. Control (no fix, #3303): 10 checks, none of them lint, unit or email. Treatment (this fix, #3304): 56 checks including `Run Code Quality Checks`, `Unit Tests`, `Test Email Agent`, `Skill Audit` and `Dependency Review`. Both were drafts, so every job then short-circuited on its existing `draft == false` guard — the point is that the check runs exist at all, which in the control they do not.
- [x] `python util/check_workflow_triggers.py` passes on all 72 workflows, and fails with the file name and issue number when the filter is reintroduced.
- [x] `python -m pytest tests/unit/test_check_workflow_triggers.py` — 12 passed.
- [x] `python util/lint.py` — black, isort, flake8, security suppressions, agent conventions, dependabot, workflow triggers, doc versions all pass. (Pylint reports 9 pre-existing `os.killpg`/`os.geteuid` no-member errors on untouched files; those are Windows-only false positives and CI runs Linux.)
- [x] Every touched workflow re-parsed with `yaml.safe_load`; confirmed all 35 `push:` triggers are still scoped to `main` and no `paths:` filter changed.
