### PR TITLE
feat(shell): --bypass-permissions lifts the shell guardrails too

### DIFF
--- a/docs/plans/security-model.mdx
+++ b/docs/plans/security-model.mdx
@@ -219,6 +219,79 @@ The `risk_tier` parameter is stored in `_TOOL_REGISTRY[tool_name]["risk_tier"]`.
 The `_execute_tool` method in `src/gaia/agents/base/agent.py` checks the tier
 before execution and gates on confirmation if required.
 
+### 4.5 Bypass permissions and the shell guardrails
+
+**Status:** Shipped. **GitHub issues:** #3373, #3374.
+
+The flagship sidecar's `--bypass-permissions` (and the TUI's `/bypass`) is the
+one sanctioned place session-wide trust lives — see
+`src/gaia/agents/base/tool_grants.py`. It has always turned the confirmation
+prompt off. It now also lifts the shell tool's **own** guardrails, because
+turning off the prompt alone left the agent unable to do the work the user had
+just consented to: compound commands were refused before they parsed, and there
+was no interpreter, test runner or package manager in the allowlist.
+
+**What comes off, together, and only under bypass:**
+
+| Gate | Default | Under bypass |
+|------|---------|--------------|
+| Shell operator block (`&&`, `\|\|`, `;`, `>`, `>>`, `<`, `` ` ``, `$()`) | refused before parsing | parsed and executed |
+| Confirmation prompts | asked every call | pre-approved (unchanged behaviour) |
+| Per-binary read-only policy | `ALLOWED_COMMANDS` + the git / PowerShell / `find` / `sort` / `uniq` sub-guards | replaced by `DEVELOPER_COMMANDS` |
+| Shell rate limit (10/min, 3/10s) | enforced | lifted |
+
+Pipes were never blocked and are unaffected.
+
+**Blast radius: arbitrary code execution.** The developer set adds `node`,
+`npm`, `make`, `cmake`, `go`, `cargo`, `sed`, `awk`, `curl`, `sleep`, `timeout`,
+`export`, `cp` and `mv`. It also names `python`, `python3`, `pytest` and `gh`,
+which are **consolidation rather than new reach** — those already have paths
+today (`execute_python_file` for the `generic_file_ops` profiles, a
+`shell:execute:<binary>` skill grant for `pytest` and `gh`). Listing them here
+means bypass has one answer to "may this binary run" instead of three. The
+per-skill grant path is untouched and still works with bypass off.
+
+`rm` is deliberately excluded. This is not a security boundary — anything in the
+set can delete a file — it is a tripwire against an accidental recursive delete.
+`cp` and `mv` are in, because a build or test run reasonably needs them.
+
+`ALLOWED_COMMANDS` is **unchanged**. The developer set is a separate frozenset,
+so the read-only tier keeps claiming exactly what it claims and #2768's
+hardening of it never has to reason about these entries.
+
+**Stdio transport only.** Bypass exists on the sidecar's stdio transport, which
+is one local parent process on a private pipe. It is not reachable on the HTTP
+transport (`hub/agents/gaia/python/gaia_agent/server.py`): that is a bound
+socket, and an unguarded shell reachable over it is remote code execution rather
+than a relaxed permission model. The HTTP handler pins `bypass_permissions =
+False`, the request model forbids unknown fields so a client cannot ask for it,
+and there is no HTTP equivalent of the `gaia_control` bypass verb. Token auth
+and `HostOriginMiddleware` (`caller_auth.py`) continue to guard that surface for
+everything else.
+
+**It still audits.** Skipping the confirmation *prompt* does not skip the
+*record*. Every command executed under bypass is written to
+`~/.gaia/cache/file_audit.log` with its full arguments and its per-segment
+breakdown, so `cd build && make` is two auditable invocations rather than one
+opaque string. Arguments are recorded verbatim, so a secret passed on a command
+line lands in that file — treat it as sensitive.
+
+Command substitution is the one thing bypass cannot audit precisely: the body of
+a `$(...)` is not a segment and is not individually validated. It runs because
+the shell runs it.
+
+<Note>
+`bypass_permissions` is a **separate** handler attribute from
+`auto_approve_gated_tools`, and only `PermissionState` sets both. An unattended
+harness that merely pre-approves prompts — `GAIA_AUTO_APPROVE_TOOLS=1`, or a
+library host passing `auto_approve_gated_tools=True` — does **not** inherit an
+unguarded shell.
+
+Bypass is toggleable mid-session over the control channel, so the shell gates
+read it live rather than caching it: `/bypass off` puts the guardrails back on
+the very next command.
+</Note>
+
 ---
 
 ## 5. MCP Security

--- a/docs/spec/shell-tools-mixin.mdx
+++ b/docs/spec/shell-tools-mixin.mdx
@@ -237,6 +237,36 @@ if cmd_base not in ALLOWED_COMMANDS:
     }
 ```
 
+### Bypass Permissions
+
+Off by default. Turned on only by the flagship sidecar's `--bypass-permissions`
+launch flag or the TUI's `/bypass`, both of which set `bypass_permissions` on
+the session's output handler. `bypass_gates_active()` reads that attribute live,
+so a mid-session toggle takes effect on the next command.
+
+When on, `_validate_command` short-circuits the whole read-only policy above and
+answers one question instead: is the binary in
+`ALLOWED_COMMANDS | DEVELOPER_COMMANDS`?
+
+```python
+DEVELOPER_COMMANDS = frozenset({
+    "node", "npm", "make", "cmake", "go", "cargo",
+    "sed", "awk", "curl", "sleep", "timeout", "export", "cp", "mv",
+    # consolidation, not new reach — these already have their own paths
+    "python", "python3", "pytest", "gh",
+})   # "rm" deliberately excluded
+```
+
+`ALLOWED_COMMANDS` is unchanged — the developer set is separate, so the
+read-only tier keeps meaning what it says. The operator block and the rate limit
+come off with it, and the per-segment `_split_pipeline` + `_validate_command`
+walk stays intact so every invocation is still audited to
+`~/.gaia/cache/file_audit.log`.
+
+This permits arbitrary code execution, and is reachable on the stdio transport
+only. See [Security Model](/plans/security-model) §4.5 for the full blast radius
+and why the HTTP transport is excluded.
+
 ### Git Command Filtering
 
 ```python

--- a/docs/spec/shell-tools-mixin.mdx
+++ b/docs/spec/shell-tools-mixin.mdx
@@ -263,6 +263,11 @@ come off with it, and the per-segment `_split_pipeline` + `_validate_command`
 walk stays intact so every invocation is still audited to
 `~/.gaia/cache/file_audit.log`.
 
+Segment separators include the newline, not just `&&`, `||`, `;`, `&` and `|` —
+the shell running the string treats a line break as a command separator, so the
+walk has to as well, or a second command rides in unvalidated and unaudited. A
+newline inside quotes stays ordinary data.
+
 This permits arbitrary code execution, and is reachable on the stdio transport
 only. See [Security Model](/plans/security-model) §4.5 for the full blast radius
 and why the HTTP transport is excluded.

--- a/hub/agents/gaia/npm/CHANGELOG.md
+++ b/hub/agents/gaia/npm/CHANGELOG.md
@@ -14,6 +14,18 @@ the terminal UI meant building it from source.
 
 ### Added
 
+- **`--bypass-permissions` now lifts the shell guardrails too.** It used to skip
+  only the confirmation prompt, which left the agent unable to run a build or a
+  test suite even with the user's blanket consent: compound commands were
+  refused before they parsed, and no interpreter, test runner or package manager
+  was reachable. Under bypass, `&&` / `||` / `;` / `>` now parse and run, the
+  read-only allowlist is replaced by a developer set (`node`, `npm`, `make`,
+  `cmake`, `go`, `cargo`, `sed`, `awk`, `curl`, `sleep`, `timeout`, `export`,
+  `cp`, `mv`, plus `python` / `python3` / `pytest` / `gh`), and the shell rate
+  limit is dropped. Off by default and byte-identical to before when off. `rm`
+  stays excluded. Every command run this way is audit-logged with its full
+  arguments. Stdio only — the HTTP transport cannot be put in bypass, and the
+  request body cannot ask for it. See SPEC §5.5.
 - **`503` from `/query` at session capacity.** When every retained session
   slot is busy and none is idle enough to evict, starting a new session
   returns `503` with the reason in `detail` — retryable, distinct from a

--- a/hub/agents/gaia/npm/SKILL.md
+++ b/hub/agents/gaia/npm/SKILL.md
@@ -345,6 +345,13 @@ then cancels the run. There is no `confirm_url`, no resume, and no
 `/query/{run_id}/confirm` endpoint — it is a deliberate deny-by-default stub, not
 an oversight.
 
+There is also no way to turn the gating off over HTTP. The stdio transport's
+`--bypass-permissions` runs gated tools unasked *and* lifts the shell tool's
+guardrails (compound operators, the read-only binary allowlist, the rate limit),
+which is arbitrary code execution — appropriate for one local parent on a
+private pipe, not for a bound socket. The request body rejects unknown fields,
+so a client cannot ask for it. See SPEC §5.5.
+
 Concretely, your client sees:
 
 ```

--- a/hub/agents/gaia/npm/SPEC.md
+++ b/hub/agents/gaia/npm/SPEC.md
@@ -376,6 +376,24 @@ in flight. It also takes `--bypass-permissions` (start with gating off) and
 local Lemonade; embeddings stay on Lemonade either way). None of that is
 reachable over `/v1/gaia/query`.
 
+`--bypass-permissions` turns off more than the prompt. It also lifts the shell
+tool's own guardrails for the session: compound operators (`&&`, `||`, `;`, `>`)
+parse and run, the read-only binary allowlist is replaced by a developer set
+(`node`, `npm`, `make`, `cmake`, `go`, `cargo`, `sed`, `awk`, `curl`, `sleep`,
+`timeout`, `export`, `cp`, `mv`, plus `python`/`python3`/`pytest`/`gh`, which
+already had their own paths), and the shell rate limit is dropped. That is
+arbitrary code execution in the working directory, which is why it exists only
+on this transport: one local parent process on a private pipe. It is **not**
+reachable over HTTP, and the request body cannot ask for it. `rm` is excluded
+from the developer set — not a boundary, since anything in the set can delete a
+file, but a tripwire against an accidental recursive delete.
+
+Every shell command run under bypass is recorded with its full arguments and its
+per-segment breakdown in `~/.gaia/cache/file_audit.log` — skipping the prompt
+does not skip the record. Treat that file as sensitive; arguments are verbatim.
+The host can toggle bypass mid-session over `gaia_control`, and the shell gates
+follow on the very next command.
+
 `--use-claude` is the one with a reach beyond the machine, and it cannot be
 turned on for what this package delivers: the terminal UI **refuses** it for a
 daemon-transport agent, with an error saying so, because the daemon relay has no

--- a/hub/agents/gaia/python/gaia_agent/server.py
+++ b/hub/agents/gaia/python/gaia_agent/server.py
@@ -509,6 +509,13 @@ async def query(request: QueryRequest):
         )
 
     handler = SSEOutputHandler()
+    # Bypass permissions are a stdio-transport affordance and must stay one
+    # (#3373). The stdio parent is one local process on a private pipe; this
+    # endpoint is a bound socket, and an unguarded shell reachable over it is
+    # remote code execution rather than a relaxed permission model. There is no
+    # request field that could ask for it — this pins that, so adding one
+    # without also revisiting the reasoning fails a test instead of shipping.
+    handler.bypass_permissions = False
     session = None
     #: Set only on the one-shot path. A session agent belongs to the registry
     #: and must never be closed here.

--- a/hub/agents/gaia/python/gaia_agent/stdio.py
+++ b/hub/agents/gaia/python/gaia_agent/stdio.py
@@ -147,12 +147,26 @@ class PermissionState:
         if bypass:
             # Starting unattended is the same security event as toggling it on
             # mid-session, and it never went through set_bypass.
-            audit.warning("Bypass permissions ENABLED at launch")
+            audit.warning("Bypass permissions ENABLED at launch (shell gates off)")
 
     @property
     def bypass(self) -> bool:
         with self._lock:
             return self._bypass
+
+    @staticmethod
+    def _apply(handler: Any, enabled: bool) -> None:
+        """Write this session's bypass decision onto one handler.
+
+        Two attributes, because they are two different grants that happen to be
+        turned on together. ``auto_approve_gated_tools`` skips the confirmation
+        prompt; ``bypass_permissions`` additionally lifts the shell guardrails —
+        the operator block, the read-only binary policy and the rate limit
+        (#3373, #3374). An unattended harness that only pre-approves prompts
+        sets the first and must not inherit the second.
+        """
+        handler.auto_approve_gated_tools = enabled
+        handler.bypass_permissions = enabled
 
     def set_bypass(self, enabled: bool) -> None:
         """Turn bypass on or off, taking effect on the very next gated tool.
@@ -163,13 +177,17 @@ class PermissionState:
         with self._lock:
             self._bypass = enabled
             if self._handler is not None:
-                self._handler.auto_approve_gated_tools = enabled
-        audit.warning("Bypass permissions %s", "ENABLED" if enabled else "disabled")
+                self._apply(self._handler, enabled)
+        audit.warning(
+            "Bypass permissions %s (shell gates %s)",
+            "ENABLED" if enabled else "disabled",
+            "off" if enabled else "on",
+        )
 
     def attach(self, handler: Any) -> None:
         """Hand a turn's handler the session's accumulated permission state."""
         with self._lock:
-            handler.auto_approve_gated_tools = self._bypass
+            self._apply(handler, self._bypass)
             handler.session_grants().update(self._grants)
             # A human is on the other end of this pipe with a modal on screen,
             # so the wait is theirs to end — see confirm_tool_execution.
@@ -1115,9 +1133,13 @@ def build_parser() -> "argparse.ArgumentParser":
     parser.add_argument(
         "--bypass-permissions",
         action="store_true",
-        help="Start with confirmation prompts OFF: every gated tool runs "
-        "without asking. Off unless passed, and the host can toggle it at any "
-        "time over the control channel.",
+        help="Start with the permission gates OFF: every gated tool runs "
+        "without asking, shell operators (&&, ||, ;, >) parse and run, the "
+        "read-only binary policy is replaced by the developer set (node, npm, "
+        "make, cmake, go, cargo, sed, awk, curl, python, pytest, gh) and the "
+        "shell rate limit is lifted. This is arbitrary code execution. Off "
+        "unless passed, and the host can toggle it at any time over the "
+        "control channel. Every shell command run this way is audit-logged.",
     )
     return parser
 

--- a/hub/agents/gaia/python/tests/test_server_query.py
+++ b/hub/agents/gaia/python/tests/test_server_query.py
@@ -198,10 +198,14 @@ def test_the_http_transport_exposes_no_bypass_control():
     route, and must not grow one without revisiting the reasoning above."""
     paths = _all_route_paths(server_mod.build_app())
 
-    # Guard the guard. This assertion is only worth anything if the walk
-    # actually reached the mounted routes — a version bump that changed the
-    # route tree again would otherwise leave it passing on an empty set.
-    assert "/v1/gaia/query" in paths, f"route walk found no API routes: {sorted(paths)}"
+    # Guard the guard: assert the walk reached the mounted API namespace, or a
+    # route-tree change would leave the check below passing on an empty set.
+    # Keyed on the prefix, not one endpoint — which endpoints `build_app` mounts
+    # varies by environment, and pinning a specific one made this fail on CI
+    # while passing locally.
+    assert [
+        p for p in paths if p.startswith("/v1/gaia/")
+    ], f"route walk reached no /v1/gaia/ routes: {sorted(paths)}"
 
     assert not [p for p in paths if "bypass" in p.lower()]
 

--- a/hub/agents/gaia/python/tests/test_server_query.py
+++ b/hub/agents/gaia/python/tests/test_server_query.py
@@ -175,12 +175,63 @@ def test_the_request_body_cannot_ask_for_bypass(built):
     assert r.status_code == 422, r.text
 
 
+def _all_route_paths(router) -> set:
+    """Every path reachable under *router*, descending into sub-routers.
+
+    The route list is not flat on every FastAPI version: ``include_router`` can
+    leave an ``_IncludedRouter`` wrapper that carries ``.routes`` but no
+    ``.path``. Reading ``.path`` off each entry raises there, and skipping the
+    entries that lack one would walk right past the mounted API.
+    """
+    paths = set()
+    for route in getattr(router, "routes", ()):
+        path = getattr(route, "path", None)
+        if path is not None:
+            paths.add(path)
+        if hasattr(route, "routes"):
+            paths |= _all_route_paths(route)
+    return paths
+
+
 def test_the_http_transport_exposes_no_bypass_control():
     """The stdio control channel carries a bypass verb; HTTP has no equivalent
     route, and must not grow one without revisiting the reasoning above."""
-    paths = {route.path for route in server_mod.build_app().routes}
+    paths = _all_route_paths(server_mod.build_app())
+
+    # Guard the guard. This assertion is only worth anything if the walk
+    # actually reached the mounted routes — a version bump that changed the
+    # route tree again would otherwise leave it passing on an empty set.
+    assert "/v1/gaia/query" in paths, f"route walk found no API routes: {sorted(paths)}"
 
     assert not [p for p in paths if "bypass" in p.lower()]
+
+
+def test_the_route_walk_descends_into_included_routers():
+    """Covers the shape this repo's pinned FastAPI does not produce locally.
+
+    On the CI version, ``include_router`` leaves a wrapper carrying ``.routes``
+    and no ``.path``. Without a real one to test against, the walk is asserted
+    on a stand-in of that shape — otherwise the guard above would be a fix
+    nobody had run.
+    """
+
+    class _Leaf:
+        def __init__(self, path):
+            self.path = path
+
+    class _IncludedRouterLike:
+        """No .path, only .routes — what broke the flat comprehension."""
+
+        def __init__(self, routes):
+            self.routes = routes
+
+    class _App:
+        routes = [
+            _Leaf("/health"),
+            _IncludedRouterLike([_Leaf("/v1/gaia/query"), _Leaf("/v1/gaia/init")]),
+        ]
+
+    assert _all_route_paths(_App()) == {"/health", "/v1/gaia/query", "/v1/gaia/init"}
 
 
 # ---------------------------------------------------------------------------

--- a/hub/agents/gaia/python/tests/test_server_query.py
+++ b/hub/agents/gaia/python/tests/test_server_query.py
@@ -146,6 +146,44 @@ def _wait_until(predicate, timeout=5.0):
 
 
 # ---------------------------------------------------------------------------
+# Bypass permissions never reach this transport (#3373)
+#
+# Bypass lifts the shell guardrails as well as the confirmation prompt, so an
+# HTTP-reachable agent running under it is remote code execution rather than a
+# relaxed permission model. It is a stdio affordance — one local parent on a
+# private pipe — and must stay one.
+# ---------------------------------------------------------------------------
+
+
+def test_a_query_runs_with_the_shell_gates_on(built):
+    client, agents = built
+
+    r = client.post("/v1/gaia/query", json=_body())
+
+    assert r.status_code == 200, r.text
+    assert agents[0].console is not None
+    assert agents[0].console.bypass_permissions is False
+
+
+def test_the_request_body_cannot_ask_for_bypass(built):
+    """extra='forbid' is what makes this unreachable; pin it, so adding a
+    bypass field fails here instead of shipping."""
+    client, _agents = built
+
+    r = client.post("/v1/gaia/query", json=_body(bypass_permissions=True))
+
+    assert r.status_code == 422, r.text
+
+
+def test_the_http_transport_exposes_no_bypass_control():
+    """The stdio control channel carries a bypass verb; HTTP has no equivalent
+    route, and must not grow one without revisiting the reasoning above."""
+    paths = {route.path for route in server_mod.build_app().routes}
+
+    assert not [p for p in paths if "bypass" in p.lower()]
+
+
+# ---------------------------------------------------------------------------
 # One-shot teardown
 # ---------------------------------------------------------------------------
 

--- a/hub/agents/gaia/python/tests/test_stdio.py
+++ b/hub/agents/gaia/python/tests/test_stdio.py
@@ -176,6 +176,79 @@ def test_launching_unattended_is_recorded_too(configure_logging):
     assert "Bypass permissions ENABLED at launch" in _log_text(path)
 
 
+# ---------------------------------------------------------------------------
+# Bypass reaches the SHELL gates, not just the confirmation prompt (#3373).
+#
+# The two are separate attributes on purpose: an unattended harness that only
+# pre-approves prompts (GAIA_AUTO_APPROVE_TOOLS) must not inherit an unguarded
+# shell. Only PermissionState sets both.
+# ---------------------------------------------------------------------------
+
+
+class _Handler:
+    """The slice of SSEOutputHandler that PermissionState writes to."""
+
+    def __init__(self):
+        self.auto_approve_gated_tools = False
+        self.bypass_permissions = False
+        self.confirm_timeout_seconds = 0
+        self._grants = set()
+
+    def session_grants(self):
+        return self._grants
+
+
+def test_attach_hands_the_turn_both_halves_of_bypass():
+    handler = _Handler()
+
+    stdio.PermissionState(bypass=True).attach(handler)
+
+    assert handler.auto_approve_gated_tools is True
+    assert handler.bypass_permissions is True
+
+
+def test_attach_leaves_a_normal_session_fully_gated():
+    handler = _Handler()
+
+    stdio.PermissionState().attach(handler)
+
+    assert handler.auto_approve_gated_tools is False
+    assert handler.bypass_permissions is False
+
+
+def test_toggling_bypass_mid_turn_reaches_the_shell_gates():
+    handler = _Handler()
+    state = stdio.PermissionState()
+    state.attach(handler)
+
+    state.set_bypass(True)
+    assert handler.bypass_permissions is True
+
+    # /bypass off must put the shell guardrails back on the next command, not
+    # at the next turn boundary.
+    state.set_bypass(False)
+    assert handler.bypass_permissions is False
+
+
+def test_the_shell_mixin_reads_the_attached_handler():
+    """End to end through the real predicate, not a re-implementation of it."""
+    from gaia.agents.tools.shell_tools import ShellToolsMixin
+
+    class _Agent(ShellToolsMixin):
+        def __init__(self):
+            self.console = _Handler()
+
+    agent = _Agent()
+    assert agent.bypass_gates_active() is False
+    # A compound command and an ungranted developer binary: both refused.
+    assert agent._validate_shell_command("cd . && make build")[0] is not None
+
+    stdio.PermissionState(bypass=True).attach(agent.console)
+
+    assert agent.bypass_gates_active() is True
+    assert agent._validate_shell_command("cd . && make build")[0] is None
+
+
 def test_a_denied_and_dropped_decision_is_recorded_at_the_default_level(
     configure_logging,
 ):

--- a/src/gaia/agents/base/console.py
+++ b/src/gaia/agents/base/console.py
@@ -207,6 +207,20 @@ class OutputHandler(ABC):
     trusted unattended harness. Every approval taken this way is logged.
     """
 
+    bypass_permissions: bool = False
+    """Session-wide trust granted by ``--bypass-permissions`` / TUI ``/bypass``.
+
+    Strictly narrower in origin than ``auto_approve_gated_tools`` and wider in
+    effect. Only ``PermissionState`` sets it — an unattended harness that merely
+    pre-approves prompts must not also get an unguarded shell — and in exchange
+    it lifts the shell guardrails too: the operator block, the read-only binary
+    policy (replaced by ``DEVELOPER_COMMANDS``) and the rate limit. See
+    ``gaia.agents.tools.shell_tools.ShellToolsMixin.bypass_gates_active``.
+
+    Mutable for the life of the session: the host can toggle it mid-run over the
+    control channel, and the next gated call sees the new value.
+    """
+
     _last_denial: Optional[Tuple[str, str]] = None
     """``(tool_name, reason)`` for the most recent denial (#2210).
 

--- a/src/gaia/agents/tools/shell_tools.py
+++ b/src/gaia/agents/tools/shell_tools.py
@@ -107,6 +107,54 @@ DANGEROUS_FIND_ACTIONS = {
     "-fls",
 }
 
+# The binaries a developer session needs and a read-only session must not have
+# (#3374). Active ONLY under bypass permissions; ALLOWED_COMMANDS above is
+# untouched so the read-only tier keeps claiming exactly what it claims, and
+# #2768's sweep of it never has to reason about these entries.
+#
+# This set permits ARBITRARY CODE EXECUTION — node, make and the interpreters
+# each run whatever the working tree tells them to. That is why it is reachable
+# only from the mode the user turned on deliberately.
+#
+# python/python3/pytest and gh are listed for CONSOLIDATION, not new reach: all
+# four already have a path today (``execute_python_file`` for the
+# generic_file_ops profiles, a ``shell:execute:`` skill grant for pytest and
+# gh). Naming them here means bypass has one answer to "may this binary run"
+# instead of three. The per-skill grant path is unchanged and still works with
+# bypass off.
+DEVELOPER_COMMANDS = frozenset(
+    {
+        # Interpreters and test runners
+        "python",
+        "python3",
+        "pytest",
+        "node",
+        # Build and package tooling
+        "npm",
+        "make",
+        "cmake",
+        "go",
+        "cargo",
+        # Forge
+        "gh",
+        # Text processing that writes
+        "sed",
+        "awk",
+        # Network
+        "curl",
+        # Process control
+        "sleep",
+        "timeout",
+        "export",
+        # File shuffling. `cp` and `mv` are in; `rm` is deliberately NOT — see
+        # docs/plans/security-model.mdx. Not a boundary (anything above can
+        # delete a file), just a tripwire against an accidental recursive
+        # delete.
+        "cp",
+        "mv",
+    }
+)
+
 # Safe read-only git subcommands
 SAFE_GIT_COMMANDS = {
     "status",
@@ -246,12 +294,41 @@ def _operator_check_text(command: str) -> str:
     return " ".join(outer)
 
 
+#: Tokens that end one command and begin the next. Only ``|`` can appear
+#: outside bypass mode — ``DANGEROUS_SHELL_OPERATORS`` refuses the rest before
+#: tokenisation — so extending the set leaves default behaviour untouched.
+_SEGMENT_SEPARATORS = frozenset({"|", "||", "&&", ";", "&"})
+
+
+def _tokenize(command: str, bypass_gates: bool = False) -> list:
+    """Split *command* into argv tokens.
+
+    Default mode uses ``shlex.split``, unchanged. Bypass mode asks shlex to
+    treat ``;&|<>`` as punctuation instead, so ``cd build && make`` yields a
+    standalone ``&&`` for ``_split_pipeline`` to break on. Parentheses stay out
+    of the punctuation set: making them tokens would mangle ordinary operands
+    like ``find . -name "(draft)*"``.
+    """
+    if not bypass_gates:
+        return shlex.split(command)
+    lexer = shlex.shlex(command, posix=True, punctuation_chars=";&|<>")
+    lexer.whitespace_split = True
+    lexer.commenters = ""  # same as shlex.split: '#' is data, not a comment
+    return list(lexer)
+
+
 def _split_pipeline(cmd_parts: list) -> list:
-    """Split a shlex-split command on ``|`` into its non-empty segments."""
+    """Split tokenised *cmd_parts* on shell separators into non-empty segments.
+
+    Every segment is validated and audited on its own, which is what keeps a
+    refused binary in ``a && b`` from riding in on an allowed one — and what
+    keeps the audit record honest under bypass mode, where the separators
+    actually reach a shell.
+    """
     segments: list = []
     current: list = []
     for part in cmd_parts:
-        if part == "|":
+        if part in _SEGMENT_SEPARATORS:
             if current:
                 segments.append(current)
             current = []
@@ -296,7 +373,11 @@ class ShellToolsMixin:
             directory, path traversal) stay with the caller, so a command this
             clears may still be refused later; one it rejects never runs.
         """
-        if DANGEROUS_SHELL_OPERATORS.search(_operator_check_text(command)):
+        bypass = self.bypass_gates_active()
+
+        if not bypass and DANGEROUS_SHELL_OPERATORS.search(
+            _operator_check_text(command)
+        ):
             return (
                 {
                     "status": "error",
@@ -308,7 +389,7 @@ class ShellToolsMixin:
             )
 
         try:
-            cmd_parts = shlex.split(command)
+            cmd_parts = _tokenize(command, bypass_gates=bypass)
         except ValueError as exc:
             return (
                 {
@@ -333,11 +414,36 @@ class ShellToolsMixin:
                 segment,
                 command if len(segments) == 1 else " ".join(segment),
                 granted_binaries=granted,
+                bypass_gates=bypass,
             )
             if error:
                 return error, segments
 
         return None, segments
+
+    def bypass_gates_active(self) -> bool:
+        """Whether this session is running under bypass permissions (#3373).
+
+        One source of truth, read live: the session's output handler carries
+        ``bypass_permissions``, set only by the sidecar's ``PermissionState``
+        from ``--bypass-permissions`` or the TUI's ``/bypass``. Every gate reads
+        this — ``_validate_shell_command``, ``skill_grant_covers_call``, the
+        tool description, the executor — so they cannot hold different opinions
+        about whether a command is legal.
+
+        Read live rather than resolved once because bypass is toggleable
+        mid-session over the control channel; caching it would leave `/bypass
+        off` half-applied. Each ``run_shell_command`` reads it once and threads
+        that value through its own pre-flight and execution, so a toggle landing
+        mid-call cannot split the two.
+
+        Answers False for any host that never set it — a plain console, the
+        HTTP transport, a library embedding — which is what keeps the shipped
+        default byte-identical.
+        """
+        return bool(
+            getattr(getattr(self, "console", None), "bypass_permissions", False)
+        )
 
     def policy_refusal_for_call(
         self, tool_name: str, tool_args: Dict[str, Any]
@@ -404,6 +510,13 @@ class ShellToolsMixin:
             # anything else would skip the modal without enforcing the policy.
             return False
 
+        bypass = self.bypass_gates_active()
+        if bypass:
+            # Every gated tool is pre-approved in bypass mode; saying so here
+            # keeps this answer aligned with the console's, rather than leaving
+            # two predicates to disagree about whether the call was consented to.
+            return True
+
         granted = skill_granted_binaries(self)
         if not granted:
             return False
@@ -413,7 +526,7 @@ class ShellToolsMixin:
             return False
 
         try:
-            segments = _split_pipeline(shlex.split(command))
+            segments = _split_pipeline(_tokenize(command))
         except ValueError:
             return False
         if not segments:
@@ -505,6 +618,7 @@ class ShellToolsMixin:
         cmd_parts: list,
         command: str,
         granted_binaries: frozenset = frozenset(),
+        bypass_gates: bool = False,
     ) -> Optional[Dict[str, Any]]:
         """
         Validate a command against the whitelist and subcommand rules.
@@ -516,6 +630,10 @@ class ShellToolsMixin:
             granted_binaries: Skill-granted CLIs for *this* agent instance. Passed
                 in rather than read from module state so the grant can never be
                 global.
+            bypass_gates: This session's ``--bypass-permissions`` state. When
+                True the read-only policy is replaced wholesale by
+                ``DEVELOPER_COMMANDS`` (#3374); the default path below is left
+                exactly as it was.
 
         Returns None if the command is allowed, or an error dict if blocked.
 
@@ -526,6 +644,9 @@ class ShellToolsMixin:
         would refuse a write before anyone could approve it, which is the dead
         end this tier removes.
         """
+        if bypass_gates:
+            return ShellToolsMixin._validate_bypass_command(cmd_base)
+
         # Skill-granted CLIs are gated by their own policy table instead of
         # ALLOWED_COMMANDS; anything ungranted is still refused.
         # Imported here — gaia.skills pulls in the connector stack.
@@ -737,6 +858,49 @@ class ShellToolsMixin:
 
         return None  # Command is allowed
 
+    @staticmethod
+    def _validate_bypass_command(cmd_base: str) -> Optional[Dict[str, Any]]:
+        """The whole binary policy under bypass permissions.
+
+        Membership in ``ALLOWED_COMMANDS | DEVELOPER_COMMANDS`` and nothing
+        else: the read-only sub-guards (git subcommands, PowerShell cmdlets,
+        ``find -exec``, ``sort -o``, ``uniq`` output) all encode "this binary
+        may not write", which is precisely the assumption bypass mode drops.
+
+        Still a set, not an open door — ``rm`` and anything unrecognised are
+        refused, and every segment lands in the audit record either way.
+        """
+        from gaia.skills.binaries import normalize_binary
+
+        candidates = {cmd_base, normalize_binary(cmd_base)}
+        if candidates & (ALLOWED_COMMANDS | DEVELOPER_COMMANDS):
+            return None
+        return {
+            "status": "error",
+            "error": (
+                f"Command '{cmd_base}' is not in the developer command set, "
+                "even with bypass permissions active."
+            ),
+            "has_errors": True,
+            "hint": (
+                "Bypass permissions swap the read-only allowlist for a "
+                "developer set (python, python3, pytest, node, npm, make, "
+                "cmake, go, cargo, gh, sed, awk, curl, sleep, timeout, export, "
+                "cp, mv). 'rm' is deliberately excluded."
+            ),
+        }
+
+    def _audit_shell_execution(self, command: str, cwd: str, segments: list) -> None:
+        """Record a command run under bypass mode, arguments and all.
+
+        Skipping the confirmation *prompt* must not mean skipping the *record*:
+        consent was granted in advance, which is exactly when the audit trail is
+        the only evidence of what the agent did.
+        """
+        from gaia.security import audit_shell_command
+
+        audit_shell_command(command=command, cwd=cwd, segments=segments, mode="bypass")
+
     def register_shell_tools(self) -> None:
         """Register shell command execution tools."""
         from gaia.agents.base.tools import tool
@@ -785,8 +949,12 @@ class ShellToolsMixin:
                 Dictionary with status, output, and error information
             """
             try:
+                bypass = self.bypass_gates_active()
+
                 # Check rate limits first to prevent DOS
-                allowed, reason, wait_time = self._check_rate_limit()
+                allowed, reason, wait_time = (
+                    (True, "", 0.0) if bypass else self._check_rate_limit()
+                )
                 if not allowed:
                     return {
                         "status": "error",
@@ -908,15 +1076,21 @@ class ShellToolsMixin:
                 cmd_base = cmd_parts[0].lower()
 
                 # Validate every command in the pipeline, not just the first.
+                # The walk stays intact in bypass mode: it is what produces the
+                # per-segment audit record below.
                 for seg in segments:
                     error = self._validate_command(
                         seg[0].lower(),
                         seg,
                         command if len(segments) == 1 else " ".join(seg),
                         granted_binaries=granted,
+                        bypass_gates=bypass,
                     )
                     if error:
                         return error
+
+                if bypass:
+                    self._audit_shell_execution(command, cwd, segments)
 
                 # Log command execution (debug mode)
                 if hasattr(self, "debug") and self.debug:
@@ -941,12 +1115,17 @@ class ShellToolsMixin:
                 # One segment only: a pipeline needs a shell to be a pipeline,
                 # and `cmd_parts` has already dropped the `|` tokens, so an argv
                 # run of one would silently concatenate the two commands.
+                #
+                # Bypass mode needs a shell everywhere, not just on Windows: the
+                # operators it unblocks ARE the shell. argv-only execution would
+                # drop the separators `_split_pipeline` stripped and silently
+                # concatenate `a && b` into one bogus command line.
                 lone_granted_segment = (
                     len(segments) == 1
                     and bool(granted)
                     and _is_granted_binary(segments[0][0], granted)
                 )
-                use_shell = os.name == "nt" and not lone_granted_segment
+                use_shell = (os.name == "nt" or bypass) and not lone_granted_segment
 
                 # Build the command string for execution
                 # On Windows with shell=True, use the ORIGINAL command string
@@ -967,7 +1146,7 @@ class ShellToolsMixin:
                         "cp": "copy",
                         "mv": "move",
                     }
-                    if cmd_base in _UNIX_TO_WIN:
+                    if os.name == "nt" and cmd_base in _UNIX_TO_WIN:
                         import shutil
 
                         if not shutil.which(cmd_base):
@@ -1030,8 +1209,11 @@ class ShellToolsMixin:
                     )
                     duration = time.monotonic() - start_time
 
-                    # Record successful command execution for rate limiting
-                    self._record_command_execution()
+                    # Record successful command execution for rate limiting.
+                    # Skipped under bypass: the limit is lifted, and the deque
+                    # is created by _check_rate_limit, which never ran.
+                    if not bypass:
+                        self._record_command_execution()
                 except subprocess.TimeoutExpired as exc:
                     duration = time.monotonic() - start_time
 

--- a/src/gaia/agents/tools/shell_tools.py
+++ b/src/gaia/agents/tools/shell_tools.py
@@ -299,22 +299,49 @@ def _operator_check_text(command: str) -> str:
 #: tokenisation — so extending the set leaves default behaviour untouched.
 _SEGMENT_SEPARATORS = frozenset({"|", "||", "&&", ";", "&"})
 
+#: Characters shlex is asked to lex as punctuation in bypass mode. A newline is
+#: one of them because the shell that ultimately runs the string treats it as a
+#: command separator, so the segment walk has to as well.
+_BYPASS_PUNCTUATION = ";&|<>\n"
+
 
 def _tokenize(command: str, bypass_gates: bool = False) -> list:
     """Split *command* into argv tokens.
 
     Default mode uses ``shlex.split``, unchanged. Bypass mode asks shlex to
-    treat ``;&|<>`` as punctuation instead, so ``cd build && make`` yields a
-    standalone ``&&`` for ``_split_pipeline`` to break on. Parentheses stay out
-    of the punctuation set: making them tokens would mangle ordinary operands
-    like ``find . -name "(draft)*"``.
+    treat ``;&|<>`` and the newline as punctuation instead, so ``cd build &&
+    make`` yields a standalone ``&&`` for ``_split_pipeline`` to break on.
+    Parentheses stay out of the punctuation set: making them tokens would
+    mangle ordinary operands like ``find . -name "(draft)*"``.
+
+    The newline is dropped from ``whitespace`` so it survives as a token rather
+    than being eaten as a space. Inside quotes it is still ordinary data, so
+    ``echo "a<newline>b"`` remains one operand.
     """
     if not bypass_gates:
         return shlex.split(command)
-    lexer = shlex.shlex(command, posix=True, punctuation_chars=";&|<>")
+    lexer = shlex.shlex(command, posix=True, punctuation_chars=_BYPASS_PUNCTUATION)
     lexer.whitespace_split = True
     lexer.commenters = ""  # same as shlex.split: '#' is data, not a comment
+    lexer.whitespace = " \t\r"
     return list(lexer)
+
+
+def _is_segment_separator(token: str) -> bool:
+    """Whether *token* ends one command and begins the next.
+
+    shlex emits a *run* of adjacent punctuation as a single token, so a newline
+    reaches here fused to whatever preceded it — ``;\\n``, ``&&\\n``, ``\\n|\\n``.
+    Any all-punctuation run containing a newline therefore separates, which is
+    what stops ``ls\\nrm -rf /tmp/x`` from being walked as one ``ls`` segment.
+    """
+    if token in _SEGMENT_SEPARATORS:
+        return True
+    return (
+        bool(token)
+        and "\n" in token
+        and all(char in _BYPASS_PUNCTUATION for char in token)
+    )
 
 
 def _split_pipeline(cmd_parts: list) -> list:
@@ -328,7 +355,7 @@ def _split_pipeline(cmd_parts: list) -> list:
     segments: list = []
     current: list = []
     for part in cmd_parts:
-        if part in _SEGMENT_SEPARATORS:
+        if _is_segment_separator(part):
             if current:
                 segments.append(current)
             current = []

--- a/src/gaia/security.py
+++ b/src/gaia/security.py
@@ -22,6 +22,57 @@ logger = logging.getLogger(__name__)
 # Audit logger — separate from main logger for file operation tracking
 audit_logger = logging.getLogger("gaia.security.audit")
 
+
+def ensure_audit_log_handler(cache_dir: Optional[Path] = None) -> None:
+    """Attach the rotating audit-log handler once, creating the file if needed.
+
+    Uses ``RotatingFileHandler`` (10 MB x 3 backups) so the audit log cannot
+    grow unbounded on a developer's machine over months of use. Total cap:
+    ~40 MB of audit history.
+    """
+    if audit_logger.handlers:
+        return
+
+    from logging.handlers import RotatingFileHandler
+
+    cache_dir = cache_dir or (Path.home() / ".gaia" / "cache")
+    cache_dir.mkdir(parents=True, exist_ok=True)
+    handler = RotatingFileHandler(
+        str(cache_dir / "file_audit.log"),
+        maxBytes=10 * 1024 * 1024,  # 10 MB per file
+        backupCount=3,
+        encoding="utf-8",
+    )
+    handler.setFormatter(logging.Formatter("%(asctime)s | %(levelname)s | %(message)s"))
+    audit_logger.addHandler(handler)
+    audit_logger.setLevel(logging.INFO)
+
+
+def audit_shell_command(
+    command: str, cwd: str, segments: List[List[str]], mode: str
+) -> None:
+    """Record a shell command the agent executed, with its full arguments.
+
+    Called on the bypass path, where the confirmation prompt is skipped: consent
+    was granted in advance, which is exactly when this record is the only
+    evidence of what the agent actually ran. Every pipeline/sequence segment is
+    listed separately, so ``a && b`` is two auditable invocations rather than
+    one opaque string.
+
+    Arguments are recorded verbatim, so a secret passed on a command line lands
+    in ``~/.gaia/cache/file_audit.log``. That is the trade the audit trail
+    makes; treat the file as sensitive.
+    """
+    ensure_audit_log_handler()
+    audit_logger.info(
+        "SHELL | %s | cwd=%s | %s | segments=%s",
+        mode,
+        cwd,
+        command,
+        json.dumps(segments),
+    )
+
+
 # Maximum file size the agent is allowed to write (10 MB)
 MAX_WRITE_SIZE_BYTES = 10 * 1024 * 1024
 
@@ -271,27 +322,8 @@ class PathValidator:
         self._load_persisted_paths()
 
     def _setup_audit_logging(self):
-        """Configure audit logging to file for write operations.
-
-        Uses ``RotatingFileHandler`` (10 MB x 3 backups) so the audit
-        log cannot grow unbounded on a developer's machine over months
-        of use.  Total cap: ~40 MB of audit history.
-        """
-        from logging.handlers import RotatingFileHandler
-
-        audit_log_file = self.cache_dir / "file_audit.log"
-        if not audit_logger.handlers:
-            handler = RotatingFileHandler(
-                str(audit_log_file),
-                maxBytes=10 * 1024 * 1024,  # 10 MB per file
-                backupCount=3,
-                encoding="utf-8",
-            )
-            handler.setFormatter(
-                logging.Formatter("%(asctime)s | %(levelname)s | %(message)s")
-            )
-            audit_logger.addHandler(handler)
-            audit_logger.setLevel(logging.INFO)
+        """Configure audit logging to file for write operations."""
+        ensure_audit_log_handler(self.cache_dir)
 
     def _load_persisted_paths(self):
         """Load allowed paths from cache file."""

--- a/tests/unit/test_shell_guardrails.py
+++ b/tests/unit/test_shell_guardrails.py
@@ -3,8 +3,12 @@
 
 """Unit tests for shell command guardrails in ShellToolsMixin._validate_command."""
 
+import pytest
+
 from gaia.agents.tools.shell_tools import (
+    ALLOWED_COMMANDS,
     DANGEROUS_SHELL_OPERATORS,
+    DEVELOPER_COMMANDS,
     ShellToolsMixin,
 )
 
@@ -17,6 +21,31 @@ def validate(command: str):
     """Return the validation error dict, or None if allowed."""
     parts = command.split()
     return ShellToolsMixin._validate_command(parts[0], parts, command)
+
+
+class _Console:
+    """The one attribute the shell gates read off a session's output handler."""
+
+    def __init__(self, bypass: bool):
+        self.bypass_permissions = bypass
+
+
+class _Shell(ShellToolsMixin):
+    """A bare host for the mixin, wired to a console in a known bypass state."""
+
+    def __init__(self, bypass: bool):
+        self.console = _Console(bypass)
+
+
+def check(command: str, *, bypass: bool):
+    """Run the full text-level validation for one mode. None means allowed."""
+    error, _segments = _Shell(bypass)._validate_shell_command(command)
+    return error
+
+
+def segments_for(command: str, *, bypass: bool):
+    _error, segments = _Shell(bypass)._validate_shell_command(command)
+    return segments
 
 
 # ---------------------------------------------------------------------------
@@ -308,3 +337,369 @@ class TestPowerShellFiltering:
             validate("powershell -Command Get-Process | Where-Object Name -eq svchost")
             is None
         )
+
+
+# ---------------------------------------------------------------------------
+# Bypass permissions: shell gates (#3373, #3374)
+#
+# The switch is the sidecar's existing --bypass-permissions / TUI /bypass, which
+# already turned confirmation prompts off; these tests cover the shell gates it
+# now lifts with them.
+#
+# Every case asserts BOTH states. The default tier is what ships; the bypass
+# tier is what the user turned on deliberately. A test that only covered the
+# bypass side could not catch a new binary leaking into the default set.
+# ---------------------------------------------------------------------------
+
+#: The developer set's headline entries, named individually so a future edit
+#: cannot quietly move one into ALLOWED_COMMANDS unnoticed (#3374).
+DEVELOPER_BINARY_SAMPLES = [
+    "python",
+    "python3",
+    "pytest",
+    "npm",
+    "node",
+    "make",
+    "cmake",
+    "go",
+    "cargo",
+    "gh",
+    "sed",
+    "awk",
+    "curl",
+    "sleep",
+    "timeout",
+    "export",
+    "cp",
+    "mv",
+]
+
+
+class TestDeveloperSetIsSeparate:
+    def test_allowed_commands_carries_no_developer_binary(self):
+        # #2768 hardens ALLOWED_COMMANDS as a read-only tier; the developer set
+        # must stay beside it, never merged into it.
+        assert ALLOWED_COMMANDS.isdisjoint(DEVELOPER_COMMANDS)
+
+    def test_rm_is_in_neither_set(self):
+        # Deliberate: not a security boundary (python can delete), an accident
+        # tripwire. Adding it later is cheaper than taking it back.
+        assert "rm" not in ALLOWED_COMMANDS
+        assert "rm" not in DEVELOPER_COMMANDS
+
+    @pytest.mark.parametrize("binary", DEVELOPER_BINARY_SAMPLES)
+    def test_developer_binary_declared(self, binary):
+        assert binary in DEVELOPER_COMMANDS
+
+
+class TestDeveloperBinariesRefusedByDefault:
+    """With the flag OFF every developer binary is still refused, as today."""
+
+    @pytest.mark.parametrize("binary", DEVELOPER_BINARY_SAMPLES)
+    def test_refused_with_bypass_off(self, binary):
+        result = check(f"{binary} --version", bypass=False)
+        assert result is not None, f"{binary} leaked into the default tier"
+        assert result["status"] == "error"
+
+    @pytest.mark.parametrize("binary", DEVELOPER_BINARY_SAMPLES)
+    def test_allowed_with_bypass_on(self, binary):
+        assert check(f"{binary} --version", bypass=True) is None
+
+    def test_default_refusal_text_unchanged(self):
+        # The existing wording, asserted so bypass mode cannot alter the
+        # message a normal user sees.
+        result = check("make build", bypass=False)
+        assert "not in the allowed list for security reasons" in result["error"]
+
+    def test_gh_default_refusal_still_points_at_the_skill_grant(self):
+        # gh has a BINARY_POLICIES entry, so its refusal is the grant message,
+        # not the allowlist one. Bypass is an additional path to gh, not a
+        # replacement for skill_granted_binaries.
+        result = check("gh issue list", bypass=False)
+        assert "shell:execute:gh" in result["error"]
+
+
+class TestBypassIsStillASet:
+    @pytest.mark.parametrize("command", ["rm -rf /tmp/foo", "evil_binary --flag"])
+    def test_refused_in_both_modes(self, command):
+        assert check(command, bypass=False) is not None
+        assert check(command, bypass=True) is not None
+
+    def test_bypass_refusal_names_the_developer_set(self):
+        result = check("rm -rf /tmp/foo", bypass=True)
+        assert "developer command set" in result["error"]
+
+    def test_read_only_commands_still_allowed_under_bypass(self):
+        assert check("ls -la", bypass=True) is None
+        assert check("grep -r foo src/", bypass=True) is None
+
+
+class TestOperatorsUnderBypass:
+    def test_compound_refused_by_default(self):
+        result = check("cd . && ls", bypass=False)
+        assert result is not None
+        assert "Shell operators" in result["error"]
+
+    def test_compound_allowed_under_bypass(self):
+        assert check("cd . && ls | head -3", bypass=True) is None
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            "cd build && cmake ..",
+            "pytest -q || echo failed",
+            "echo one ; echo two",
+            "pytest -q | tail -20",
+            "make build > out.txt",
+        ],
+    )
+    def test_sequences_parse_under_bypass(self, command):
+        assert check(command, bypass=True) is None
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            "cd build && cmake ..",
+            "pytest -q || echo failed",
+            "echo one ; echo two",
+        ],
+    )
+    def test_same_sequences_refused_by_default(self, command):
+        result = check(command, bypass=False)
+        assert result is not None
+        assert "Shell operators" in result["error"]
+
+    def test_a_pipe_is_refused_for_its_binary_not_for_the_pipe(self):
+        # Pipes were never blocked. `pytest -q | tail -20` is refused with
+        # bypass off because pytest is ungranted, NOT by the operator block —
+        # #3373 cites it as an operator case and is wrong about that.
+        result = check("pytest -q | tail -20", bypass=False)
+        assert result is not None
+        assert "Shell operators" not in result["error"]
+        assert "shell:execute:pytest" in result["error"]
+
+
+class TestPerSegmentWalkSurvivesBypass:
+    """The per-segment walk is what produces the audit record; it must not be
+    short-circuited just because the operators now parse."""
+
+    def test_denied_binary_in_segment_two_refuses_the_whole_command_by_default(self):
+        # Refused for the operator, before the binary is even reached — the
+        # ordering documented in #3373.
+        result = check("ls && rm -rf /tmp/foo", bypass=False)
+        assert result is not None
+        assert "Shell operators" in result["error"]
+
+    def test_denied_binary_in_segment_two_refuses_the_whole_command_under_bypass(self):
+        result = check("ls && rm -rf /tmp/foo", bypass=True)
+        assert result is not None
+        assert "rm" in result["error"]
+
+    def test_denied_binary_in_pipe_segment_two_refused_in_both_modes(self):
+        # No operator involved, so both modes reach the per-segment walk.
+        assert check("ls | rm -rf /tmp/foo", bypass=False) is not None
+        assert check("ls | rm -rf /tmp/foo", bypass=True) is not None
+
+    def test_every_segment_is_recorded_under_bypass(self):
+        segments = segments_for("cd . && ls | head -3", bypass=True)
+        assert [seg[0] for seg in segments] == ["cd", "ls", "head"]
+
+    def test_pipe_segments_recorded_by_default(self):
+        segments = segments_for("ls | grep foo | head -3", bypass=False)
+        assert [seg[0] for seg in segments] == ["ls", "grep", "head"]
+
+
+class TestReadOnlySubGuardsLiftUnderBypassOnly:
+    """The find/sort/uniq/git/PowerShell guards all encode "this binary may not
+    write" — the exact assumption bypass mode drops. Each must still hold with
+    the flag off."""
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            "git commit -m msg",
+            "find /tmp -name x -delete",
+            "sort -o /tmp/canary /etc/hostname",
+            "uniq in.txt out.txt",
+            "powershell -Command Remove-Item C:/important",
+        ],
+    )
+    def test_refused_by_default(self, command):
+        assert check(command, bypass=False) is not None
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            "git commit -m msg",
+            "find /tmp -name x -delete",
+            "sort -o /tmp/canary /etc/hostname",
+            "uniq in.txt out.txt",
+            "powershell -Command Remove-Item C:/important",
+        ],
+    )
+    def test_allowed_under_bypass(self, command):
+        assert check(command, bypass=True) is None
+
+
+class TestBypassIsOffByDefault:
+    def test_host_with_no_console_is_not_bypassed(self):
+        class Bare:
+            bypass_gates_active = ShellToolsMixin.bypass_gates_active
+
+        assert Bare().bypass_gates_active() is False
+
+    def test_stock_output_handler_is_not_bypassed(self):
+        from gaia.agents.base.console import OutputHandler
+
+        assert OutputHandler.bypass_permissions is False
+
+    def test_auto_approve_alone_does_not_lift_the_shell_gates(self):
+        # An unattended harness that pre-approves prompts (GAIA_AUTO_APPROVE_TOOLS
+        # or auto_approve_gated_tools) must NOT also inherit an unguarded shell.
+        class ApproveOnly:
+            auto_approve_gated_tools = True
+
+        host = _Shell(bypass=False)
+        host.console = ApproveOnly()
+        assert host.bypass_gates_active() is False
+        assert host._validate_shell_command("make build")[0] is not None
+
+    def test_toggling_the_console_flips_the_gates_live(self):
+        # /bypass off mid-session must take effect on the next command, which is
+        # why the mode is read live rather than cached on the agent.
+        host = _Shell(bypass=False)
+        assert host._validate_shell_command("make build")[0] is not None
+        host.console.bypass_permissions = True
+        assert host._validate_shell_command("make build")[0] is None
+        host.console.bypass_permissions = False
+        assert host._validate_shell_command("make build")[0] is not None
+
+    def test_validate_command_defaults_to_the_read_only_tier(self):
+        # The three-positional-argument call every existing test uses.
+        assert ShellToolsMixin._validate_command("pytest", ["pytest"], "pytest")
+
+
+# ---------------------------------------------------------------------------
+# The executor, for real (#3373)
+#
+# Everything above stops at validation. These run the tool end to end and
+# actually spawn a process, because validation passing is not the same as the
+# command working: the operators only reach a shell if the executor asks for
+# one, and the rate-limit deque is created lazily by a check bypass skips.
+# ---------------------------------------------------------------------------
+
+
+class _ExecHost(ShellToolsMixin):
+    """A host with a real tool registry, so run_shell_command can be called."""
+
+    def __init__(self, bypass: bool):
+        self.console = _Console(bypass)
+        self.debug = False
+        self.registered = {}
+
+    def register(self, fn, name):
+        self.registered[name] = fn
+
+
+@pytest.fixture
+def shell_tool(monkeypatch):
+    """Return a factory for the real ``run_shell_command`` closure."""
+
+    def build(bypass: bool):
+        host = _ExecHost(bypass)
+        captured = {}
+
+        def fake_tool(**kwargs):
+            def wrap(fn):
+                captured[kwargs["name"]] = fn
+                return fn
+
+            return wrap
+
+        import gaia.agents.base.tools as tools_mod
+
+        monkeypatch.setattr(tools_mod, "tool", fake_tool)
+        host.register_shell_tools()
+        return captured["run_shell_command"]
+
+    return build
+
+
+class TestExecutorUnderBypass:
+    def test_a_compound_command_actually_runs(self, shell_tool, tmp_path):
+        """The whole point of #3373: `a && b` reaches a shell and succeeds."""
+        run = shell_tool(bypass=True)
+
+        result = run(
+            "cd . && echo first && echo second", working_directory=str(tmp_path)
+        )
+
+        assert result["status"] == "success", result
+        assert result["return_code"] == 0
+        assert "first" in result["stdout"]
+        assert "second" in result["stdout"]
+
+    def test_the_same_command_never_reaches_a_shell_by_default(
+        self, shell_tool, tmp_path
+    ):
+        run = shell_tool(bypass=False)
+
+        result = run(
+            "cd . && echo first && echo second", working_directory=str(tmp_path)
+        )
+
+        assert result["status"] == "error"
+        assert "Shell operators" in result["error"]
+
+    def test_the_rate_limit_is_lifted(self, shell_tool, tmp_path):
+        """More than max_commands_per_10_seconds back to back, no refusal.
+
+        Also covers the deque: _check_rate_limit is what lazily creates it, and
+        bypass skips that call — recording into it anyway raised AttributeError
+        on the very first command.
+        """
+        run = shell_tool(bypass=True)
+
+        for i in range(5):
+            result = run(f"echo run{i}", working_directory=str(tmp_path))
+            assert result["status"] == "success", result
+            assert not result.get("rate_limited")
+
+    def test_the_rate_limit_still_applies_by_default(self, shell_tool, tmp_path):
+        run = shell_tool(bypass=False)
+
+        results = [run("echo hi", working_directory=str(tmp_path)) for _ in range(5)]
+
+        assert any(r.get("rate_limited") for r in results)
+
+    def test_every_execution_is_audited_with_its_arguments(
+        self, shell_tool, tmp_path, monkeypatch
+    ):
+        records = []
+        monkeypatch.setattr(
+            "gaia.security.audit_shell_command",
+            lambda **kw: records.append(kw),
+        )
+        run = shell_tool(bypass=True)
+
+        run("cd . && echo audited", working_directory=str(tmp_path))
+
+        assert len(records) == 1
+        assert records[0]["command"] == "cd . && echo audited"
+        assert records[0]["segments"] == [["cd", "."], ["echo", "audited"]]
+        assert records[0]["mode"] == "bypass"
+
+    def test_a_refused_binary_is_never_executed_or_audited(
+        self, shell_tool, tmp_path, monkeypatch
+    ):
+        records = []
+        monkeypatch.setattr(
+            "gaia.security.audit_shell_command",
+            lambda **kw: records.append(kw),
+        )
+        run = shell_tool(bypass=True)
+
+        result = run("echo hi && rm -rf nope", working_directory=str(tmp_path))
+
+        assert result["status"] == "error"
+        assert records == [], "a refused command must not reach the audit trail"

--- a/tests/unit/test_shell_guardrails.py
+++ b/tests/unit/test_shell_guardrails.py
@@ -509,6 +509,49 @@ class TestPerSegmentWalkSurvivesBypass:
         assert [seg[0] for seg in segments] == ["ls", "grep", "head"]
 
 
+class TestNewlineSeparatesSegmentsUnderBypass:
+    """A newline reaches the shell as a command separator, so the segment walk
+    has to treat it as one. While it did not, `ls\\nrm -rf /tmp/x` was walked as
+    a single `ls` — the refused binary never checked, and the audit record
+    showing one invocation where two ran."""
+
+    def test_newline_does_not_smuggle_a_refused_binary(self):
+        result = check("ls\nrm -rf /tmp/x", bypass=True)
+        assert result is not None
+        assert "rm" in result["error"]
+
+    def test_each_line_is_recorded_as_its_own_segment(self):
+        segments = segments_for("ls\necho hi", bypass=True)
+        assert [seg[0] for seg in segments] == ["ls", "echo"]
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            "ls;\nrm -rf /tmp/x",
+            "ls &&\nrm -rf /tmp/x",
+            "ls |\nrm -rf /tmp/x",
+            "ls\n;rm -rf /tmp/x",
+        ],
+    )
+    def test_newline_fused_to_another_operator_still_separates(self, command):
+        # shlex emits a run of adjacent punctuation as ONE token, so these
+        # arrive as ';\n', '&&\n', '|\n', '\n;' rather than two tokens.
+        result = check(command, bypass=True)
+        assert result is not None
+        assert "rm" in result["error"]
+
+    def test_blank_lines_do_not_create_empty_segments(self):
+        segments = segments_for("ls\n\n\necho hi\n", bypass=True)
+        assert [seg[0] for seg in segments] == ["ls", "echo"]
+
+    def test_a_quoted_newline_is_data_not_a_separator(self):
+        # The regression guard for the fix: quoting must still work, or
+        # `echo "a<newline>b"` would be walked as a bogus `b` command.
+        segments = segments_for('echo "a\nb"', bypass=True)
+        assert segments == [["echo", "a\nb"]]
+        assert check('echo "a\nb"', bypass=True) is None
+
+
 class TestReadOnlySubGuardsLiftUnderBypassOnly:
     """The find/sort/uniq/git/PowerShell guards all encode "this binary may not
     write" — the exact assumption bypass mode drops. Each must still hold with

--- a/tui/internal/cli/root.go
+++ b/tui/internal/cli/root.go
@@ -23,8 +23,10 @@ import (
 // (see init) — old scripts and docs keep working, help lists one flag.
 var dev bool
 
-// bypassPermissions starts agents with confirmation prompts off: every gated
-// tool — shell commands, file writes — runs without asking.
+// bypassPermissions starts agents with the permission gates off: every gated
+// tool — shell commands, file writes — runs without asking, and the shell's own
+// guardrails come off with them (compound operators parse, the read-only binary
+// allowlist is replaced by a developer set, the rate limit is lifted).
 //
 // Off unless passed, and only for this launch. Nothing persists it, so there
 // is no way to land in this mode without having typed it, and the TUI carries
@@ -119,8 +121,9 @@ func init() {
 		panic(err) // only fails on a flag name that was never registered
 	}
 	rootCmd.PersistentFlags().BoolVar(&bypassPermissions, "bypass-permissions", false,
-		"run every tool without asking for confirmation — the agent acts fully "+
-			"autonomously. Off by default; the TUI shows a persistent warning "+
+		"run every tool without asking for confirmation, with the shell "+
+			"guardrails off — the agent acts fully autonomously and can execute "+
+			"arbitrary code. Off by default; the TUI shows a persistent warning "+
 			"while it is on, and /bypass off turns it off mid-session")
 	rootCmd.PersistentFlags().BoolVar(&useClaude, "use-claude", false,
 		"run the agent against Anthropic's Claude API instead of the local Lemonade "+

--- a/tui/internal/ui/chat/bypass.go
+++ b/tui/internal/ui/chat/bypass.go
@@ -31,7 +31,7 @@ import (
 
 const (
 	bypassBannerText = "BYPASS PERMISSIONS — the agent runs every tool " +
-		"without asking. /bypass off to stop."
+		"without asking, shell guardrails off. /bypass off to stop."
 	// Shown when the terminal is too narrow for the sentence. Still says the
 	// two things that matter: what is on, and that it is dangerous.
 	bypassBannerShort = "BYPASS PERMISSIONS ON"
@@ -73,6 +73,10 @@ func (m ChatModel) armBypass() (tea.Model, tea.Cmd) {
 		Content: "[!] Bypass permissions would let " + m.agentName +
 			" run every tool with no prompt — shell commands, file writes, " +
 			"anything it decides to do — for the rest of this session.\n" +
+			"    It also takes the shell guardrails off: compound commands " +
+			"run, and the read-only allowlist is replaced by a developer set " +
+			"(node, npm, make, go, cargo, python, pytest, gh) that can execute " +
+			"arbitrary code in this directory.\n" +
 			"    Type /bypass confirm to turn it on, or /bypass off at any " +
 			"time to turn it back off.",
 	})


### PR DESCRIPTION
Bypass permissions turned off the confirmation prompt and nothing else. A user who had already granted blanket consent still could not get the agent to run a build or a test suite: compound commands like `cd build && cmake ..` were refused before they parsed, and no interpreter, test runner or package manager was in the allowlist. "Verify your work before claiming it is done" was not something the agent could do, however well it was prompted. Now `--bypass-permissions` (and the TUI's `/bypass`) takes the shell's own gates off with the prompt — operators run, a developer binary set replaces the read-only policy, and the rate limit lifts.

Nothing changes with bypass off. `ALLOWED_COMMANDS` is untouched and the read-only tier keeps claiming exactly what it claims, so #2768's hardening of it stays meaningful. No new flag: this extends the switch that already ships.

Three decisions the issues left open or got wrong, called out for review:

- **`rm` stays out; `cp` and `mv` are in.** Not a boundary — anything in the set can delete a file — just a tripwire against an accidental recursive delete. Cheaper to add later than to take back.
- **`python`/`pytest`/`gh` are in the set for consolidation, not new reach.** All three already had paths (`execute_python_file`, `shell:execute:` skill grants). Listing them gives bypass one answer to "may this binary run" instead of three; the per-skill grant path is unchanged.
- **#3373 cites `pytest -q | tail -20` as blocked by the operator block. It is not** — pipes were never blocked; it is refused later for the ungranted binary. There is a test pinning the real reason.

Closes #3373. Closes #3374.

<details>
<summary>🔍 Technical details</summary>

**Where the mode lives.** `PermissionState` sets `bypass_permissions` on the turn's output handler alongside `auto_approve_gated_tools`; `ShellToolsMixin.bypass_gates_active()` reads it live. Two attributes on purpose — an unattended harness that only pre-approves prompts (`GAIA_AUTO_APPROVE_TOOLS`) must not inherit an unguarded shell. Read live rather than cached because bypass is toggleable mid-session over the control channel; each `run_shell_command` reads it once and threads that value through its own pre-flight and execution, so a toggle landing mid-call cannot split the two.

**Stdio only.** The HTTP transport is a bound socket, so the handler pins `bypass_permissions = False` and `QueryRequest` (`extra="forbid"`) cannot ask for it. Narrowed from the issue's "refuse on any bound socket", which would have forbidden the sidecar's own designed configuration.

**Tokenisation.** Bypass uses `shlex.shlex(punctuation_chars=";&|<>")` so `&&` becomes its own token for `_split_pipeline` to break on; the default path still uses `shlex.split` unchanged. Parens stay out of the punctuation set so operands like `-name "(draft)*"` survive. `commenters` is cleared to match `shlex.split`.

**Audit.** `gaia.security.audit_shell_command` appends to the existing `file_audit.log`, called only on the bypass path so the default path is untouched. Command substitution is the one thing it cannot audit precisely — a `$(...)` body is not a segment.

</details>

## Test plan

- [ ] `python -m pytest tests/unit/test_shell_guardrails.py -q` — 164 pass. Every bypass case asserts **both** states, so a binary leaking into the default tier fails here.
- [ ] `python -m pytest hub/agents/gaia/python/tests/test_stdio.py hub/agents/gaia/python/tests/test_server_query.py -q` — bypass reaches the shell gates through the real `PermissionState`; the HTTP transport cannot be put in bypass. `test_the_parser_defaults_to_local_and_prompting` is unmodified and green.
- [ ] Refusal, real CLI: `printf 'Run this shell command: cd . && echo HI\n' | python -m gaia_agent.stdio` → refused with the existing operator message.
- [ ] Execution, real CLI: same command with `--bypass-permissions` → runs, `return_code: 0`.
- [ ] `tail -2 ~/.gaia/cache/file_audit.log` after the run shows `SHELL | bypass | … | segments=[["cd", "."], ["echo", "BYPASS_WORKS"]]`.
- [ ] `cd tui && go build ./... && go test ./internal/ui/chat/... ./internal/cli/...`
- [ ] Full `tests/unit/` diffed against a clean `main` worktree: identical failure and error sets (658/488 — all pre-existing on this box), +93 passing.
