### PR TITLE
fix(tools): reject ambiguous edits instead of silently editing the first match

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -277,7 +277,7 @@ tests/unit/eval/test_mcp_tool_reliability_scenarios.py
 # Private working reports — analysis, competitive research, benchmark logs.
 # These are internal notes, not project documentation, and several were
 # published to a public fork and a public PR before this rule existed. They
-# live outside the repo now (../gaia-private-reports/). Project docs belong in
+# live outside the repo now (~/Work/gaia-private/). Project docs belong in
 # docs/ and are reviewed like any other change; anything matching these
 # patterns is assumed to be private working material.
 /BENCHMARK_ANALYSIS.md
@@ -298,3 +298,13 @@ tests/unit/eval/test_mcp_tool_reliability_scenarios.py
 /context.md
 /savings.md
 /labels.txt
+
+# Local working scratch. Same rule as the private-reports block above: these are
+# agent-run artifacts and datasets, not project material, and `git add -A` would
+# otherwise commit a mailbox corpus. The material itself lives in
+# ~/Work/gaia-private/{plans,presentations,audits,recovered,datasets}.
+/email-dataset/
+/audit_reports/
+/.playwright-mcp/
+/*.png
+/*.pdf

--- a/cpp/include/gaia/file_tools.h
+++ b/cpp/include/gaia/file_tools.h
@@ -158,11 +158,15 @@ public:
 
     /// file_edit: Surgical string replacement in a file.
     /// Args: {"path": string, "old_string": string, "new_string": string}
-    /// Returns: {"success": true, "path": string, "replacements": int,
+    /// Returns: {"success": true, "path": string, "replacements": 1,
     ///           "content_hash": string}
-    /// Rejected with {"error": ..., "stale": true} when the file changed
-    /// since it was read; a non-matching old_string returns an actionable
-    /// error rather than reporting success on a no-op.
+    /// old_string must match exactly one place. Matching several is rejected
+    /// with {"error": ..., "ambiguous": true, "match_lines": [int]} — picking
+    /// one of them would edit a region the caller never named, and it would
+    /// look like a success. Matching nothing is likewise an error rather than
+    /// a reported no-op. Rejected with {"error": ..., "stale": true} when the
+    /// file changed since it was read. Every rejection carries
+    /// "current_content" and its line range so the retry needs no extra read.
     /// On error: {"error": string}
     static ToolInfo fileEdit();
 

--- a/cpp/src/file_tools.cpp
+++ b/cpp/src/file_tools.cpp
@@ -404,6 +404,79 @@ json staleRejection(const std::string& path,
     };
 }
 
+/// 1-based line number of a character offset.
+int lineOfOffset(const std::string& content, std::string::size_type offset) {
+    return 1 + static_cast<int>(
+                   std::count(content.begin(),
+                              content.begin() + static_cast<std::ptrdiff_t>(offset),
+                              '\n'));
+}
+
+/// Every offset at which `needle` occurs, non-overlapping.
+std::vector<std::string::size_type> matchOffsets(const std::string& content,
+                                                 const std::string& needle) {
+    std::vector<std::string::size_type> offsets;
+    if (needle.empty()) return offsets;
+    for (std::string::size_type pos = content.find(needle); pos != std::string::npos;
+         pos = content.find(needle, pos + needle.size())) {
+        offsets.push_back(pos);
+    }
+    return offsets;
+}
+
+/// Line the caller was most likely aiming at: the first non-blank line of
+/// `oldStr`, matched ignoring indentation — a wrong indent is the commonest
+/// reason a match fails, and the excerpt is useless if it lands on line 1 of a
+/// thousand-line file. Falls back to the top when nothing resembles it.
+int anchorLineFor(const std::string& content, const std::string& oldStr) {
+    std::istringstream probeStream(oldStr);
+    std::string line;
+    std::string probe;
+    while (std::getline(probeStream, line)) {
+        const auto first = line.find_first_not_of(" \t\r");
+        if (first == std::string::npos) continue;
+        const auto last = line.find_last_not_of(" \t\r");
+        probe = line.substr(first, last - first + 1);
+        break;
+    }
+    if (probe.empty()) return 1;
+
+    const auto pos = content.find(probe);
+    return pos == std::string::npos ? 1 : lineOfOffset(content, pos);
+}
+
+/// Lines around `centerLine` (1-based), so a rejected edit hands back the
+/// current text instead of costing the model a second read to find it.
+json excerptAround(const std::string& content, int centerLine) {
+    constexpr int kRadius = 12;
+    constexpr std::size_t kMaxChars = 4000;
+
+    std::vector<std::string> lines;
+    std::string line;
+    std::istringstream stream(content);
+    while (std::getline(stream, line)) lines.push_back(line);
+
+    const int total = static_cast<int>(lines.size());
+    const int start = std::max(1, centerLine - kRadius);
+    const int end = std::min(total, centerLine + kRadius);
+
+    std::string excerpt;
+    for (int i = start; i <= end; ++i) {
+        if (!excerpt.empty()) excerpt += "\n";
+        excerpt += lines[static_cast<std::size_t>(i - 1)];
+    }
+    const bool truncated = excerpt.size() > kMaxChars;
+    if (truncated) excerpt.resize(kMaxChars);
+
+    return json{
+        {"current_content", excerpt},
+        {"current_content_start_line", start},
+        {"current_content_end_line", end},
+        {"current_content_total_lines", total},
+        {"current_content_truncated", truncated},
+    };
+}
+
 } // namespace
 
 // ---------------------------------------------------------------------------
@@ -635,10 +708,11 @@ ToolInfo FileIOTools::fileEdit() {
     ToolInfo info;
     info.name = "file_edit";
     info.description =
-        "Perform surgical string replacement in a file. Finds all occurrences "
-        "of old_string and replaces them with new_string. Rejected if the file "
-        "changed on disk after the last file_read, or if old_string does not "
-        "appear verbatim — in both cases the file is left untouched.";
+        "Perform surgical string replacement in a file. old_string must match "
+        "exactly one place — include enough surrounding lines to make it "
+        "unique. Rejected if it matches nowhere, if it matches more than once, "
+        "or if the file changed on disk after the last file_read — in every "
+        "case the file is left untouched.";
     info.policy = ToolPolicy::CONFIRM;
     info.parameters = {
         {"path", ToolParamType::STRING, /*required=*/true,
@@ -674,19 +748,22 @@ json FileIOTools::doFileEdit(const json& args) {
         FileStateTracker& tracker = FileStateTracker::instance();
         const auto divergence = tracker.check(path, content);
         if (divergence.diverged) {
-            return staleRejection(path, "file_edit", divergence);
+            json rejection = staleRejection(path, "file_edit", divergence);
+            rejection.update(excerptAround(content, anchorLineFor(content, oldStr)));
+            // Handing the content back is a read, so re-anchor — otherwise the
+            // ledger keeps the superseded hash and the corrected retry is
+            // rejected as stale too. file_write stays strict: it names no
+            // old_string, so a blind retry would clobber the newer contents.
+            tracker.recordRead(path, content);
+            return rejection;
         }
 
-        // Replace all occurrences
-        int replacements = 0;
-        std::string::size_type pos = 0;
-        while ((pos = content.find(oldStr, pos)) != std::string::npos) {
-            content.replace(pos, oldStr.size(), newStr);
-            pos += newStr.size();
-            ++replacements;
-        }
+        // old_string must identify exactly one place. Replacing the first of
+        // several edits the wrong region; replacing all of them edits regions
+        // the model never named. Both report success, so ambiguity is an error.
+        const auto offsets = matchOffsets(content, oldStr);
 
-        if (replacements == 0) {
+        if (offsets.empty()) {
             // A silent no-op is the failure mode this tool exists to avoid:
             // say what did not match and what to do about it.
             std::string hint;
@@ -696,16 +773,48 @@ json FileIOTools::doFileEdit(const json& args) {
                        "indentation, tabs-vs-spaces, or line endings in "
                        "old_string differ from the file.";
             }
-            return json{
+            json result = json{
                 {"error", "old_string not found in file: " + path +
                               " — no replacement was made and the file is "
                               "unchanged." + hint +
-                              " Re-read the file with file_read and copy "
-                              "old_string verbatim from its contents."},
+                              " The current content is included as "
+                              "current_content; copy old_string verbatim "
+                              "from it."},
                 {"path", path},
                 {"replacements", 0},
             };
+            result.update(excerptAround(content, anchorLineFor(content, oldStr)));
+            return result;
         }
+
+        if (offsets.size() > 1) {
+            std::string lineList;
+            json matchLines = json::array();
+            for (const auto offset : offsets) {
+                const int lineNo = lineOfOffset(content, offset);
+                matchLines.push_back(lineNo);
+                if (!lineList.empty()) lineList += ", ";
+                lineList += std::to_string(lineNo);
+            }
+            json result = json{
+                {"error", "Ambiguous edit: old_string matches " +
+                              std::to_string(offsets.size()) + " locations in " +
+                              path + " (lines " + lineList +
+                              ") — nothing was written, because there is no way "
+                              "to tell which one you meant. Extend old_string "
+                              "with enough surrounding lines to match exactly "
+                              "one location, then reissue the edit."},
+                {"ambiguous", true},
+                {"path", path},
+                {"replacements", 0},
+                {"match_lines", matchLines},
+            };
+            result.update(excerptAround(content, lineOfOffset(content, offsets[0])));
+            return result;
+        }
+
+        content.replace(offsets[0], oldStr.size(), newStr);
+        const int replacements = 1;
 
         // Write back
         std::ofstream outFile(path, std::ios::binary);

--- a/cpp/tests/test_file_tools.cpp
+++ b/cpp/tests/test_file_tools.cpp
@@ -159,7 +159,7 @@ TEST_F(FileToolsTest, FileWrite_MissingContent) {
 // ---------------------------------------------------------------------------
 
 TEST_F(FileToolsTest, FileEdit_BasicReplacement) {
-    std::string path = writeFile("edit_me.txt", "foo bar baz foo");
+    std::string path = writeFile("edit_me.txt", "foo bar baz");
 
     ToolInfo tool = FileIOTools::fileEdit();
     ASSERT_TRUE(tool.callback);
@@ -167,10 +167,101 @@ TEST_F(FileToolsTest, FileEdit_BasicReplacement) {
     json result = tool.callback({{"path", path}, {"old_string", "foo"}, {"new_string", "qux"}});
     EXPECT_FALSE(result.contains("error"));
     EXPECT_EQ(result["success"], true);
-    EXPECT_EQ(result["replacements"], 2);
+    EXPECT_EQ(result["replacements"], 1);
     EXPECT_EQ(result["path"], path);
 
-    EXPECT_EQ(readFile(path), "qux bar baz qux");
+    EXPECT_EQ(readFile(path), "qux bar baz");
+}
+
+TEST_F(FileToolsTest, FileEdit_AmbiguousOldStringIsRejected) {
+    // Two matches: neither "edit the first" nor "edit both" is what the caller
+    // asked for, and both report success. Refuse instead (#3377).
+    std::string path = writeFile("ambiguous.txt", "foo bar baz foo");
+
+    json result = FileIOTools::fileEdit().callback(
+        {{"path", path}, {"old_string", "foo"}, {"new_string", "qux"}});
+
+    ASSERT_TRUE(result.contains("error")) << result.dump();
+    EXPECT_EQ(result["ambiguous"], true);
+    EXPECT_EQ(result["replacements"], 0);
+    EXPECT_NE(result["error"].get<std::string>().find("2 locations"), std::string::npos);
+
+    // Untouched — an ambiguous edit must not be a partial edit.
+    EXPECT_EQ(readFile(path), "foo bar baz foo");
+}
+
+TEST_F(FileToolsTest, FileEdit_AmbiguityNamesEveryMatchingLine) {
+    std::string path = writeFile("ambiguous_lines.txt", "alpha\nvalue\nbeta\nvalue\ngamma\n");
+
+    json result = FileIOTools::fileEdit().callback(
+        {{"path", path}, {"old_string", "value"}, {"new_string", "other"}});
+
+    ASSERT_TRUE(result.contains("match_lines")) << result.dump();
+    EXPECT_EQ(result["match_lines"], (json::array({2, 4})));
+}
+
+TEST_F(FileToolsTest, FileEdit_UniqueMatchStillWorksWithContext) {
+    // The documented recovery from an ambiguity error: add surrounding lines.
+    std::string path = writeFile("recover.txt", "alpha\nvalue\nbeta\nvalue\ngamma\n");
+
+    json result = FileIOTools::fileEdit().callback(
+        {{"path", path}, {"old_string", "alpha\nvalue"}, {"new_string", "alpha\nother"}});
+
+    ASSERT_FALSE(result.contains("error")) << result.dump();
+    EXPECT_EQ(result["replacements"], 1);
+    EXPECT_EQ(readFile(path), "alpha\nother\nbeta\nvalue\ngamma\n");
+}
+
+TEST_F(FileToolsTest, FileEdit_StaleRejectionIsNotADeadEnd) {
+    // Rejecting forever is as broken as clobbering: the rejection hands the
+    // current content back, so it counts as a read and the retry goes through.
+    std::string path = writeFile("relock.txt", "alpha\nbeta\n");
+    FileStateTracker::instance().recordRead(path, "something older");
+
+    json rejected = FileIOTools::fileEdit().callback(
+        {{"path", path}, {"old_string", "alpha"}, {"new_string", "gamma"}});
+    ASSERT_TRUE(rejected.contains("error")) << rejected.dump();
+    EXPECT_EQ(rejected["stale"], true);
+    EXPECT_TRUE(rejected.contains("current_content"));
+
+    json retry = FileIOTools::fileEdit().callback(
+        {{"path", path}, {"old_string", "alpha"}, {"new_string", "gamma"}});
+    ASSERT_FALSE(retry.contains("error")) << retry.dump();
+    EXPECT_EQ(readFile(path), "gamma\nbeta\n");
+}
+
+TEST_F(FileToolsTest, FileEdit_RejectionCarriesCurrentContent) {
+    // A rejected edit must hand back the text, or the retry costs a re-read.
+    std::string path = writeFile("carry.txt", "alpha\nbeta\ngamma\n");
+
+    json result = FileIOTools::fileEdit().callback(
+        {{"path", path}, {"old_string", "nowhere"}, {"new_string", "x"}});
+
+    ASSERT_TRUE(result.contains("current_content")) << result.dump();
+    EXPECT_NE(result["current_content"].get<std::string>().find("alpha"),
+              std::string::npos);
+    EXPECT_EQ(result["current_content_total_lines"], 3);
+}
+
+TEST_F(FileToolsTest, FileEdit_ExcerptFollowsTheIntendedRegion) {
+    // Getting a later line's indentation wrong is the commonest miss. The
+    // excerpt must land where the caller was aiming, not on line 1 of a long
+    // file — the anchor is the first line of old_string, matched without its
+    // own indentation.
+    std::string body;
+    for (int i = 1; i <= 200; ++i) body += "filler line " + std::to_string(i) + "\n";
+    body += "def target_function():\n    inner = 1\n";
+    std::string path = writeFile("long.py", body);
+
+    json result = FileIOTools::fileEdit().callback(
+        {{"path", path},
+         {"old_string", "def target_function():\n        inner = 1"},  // wrong indent
+         {"new_string", "def target_function():\n    inner = 2"}});
+
+    ASSERT_TRUE(result.contains("error")) << result.dump();
+    EXPECT_NE(result["current_content"].get<std::string>().find("target_function"),
+              std::string::npos);
+    EXPECT_GT(result["current_content_start_line"].get<int>(), 150);
 }
 
 TEST_F(FileToolsTest, FileEdit_StringNotFound) {
@@ -545,7 +636,10 @@ TEST_F(FileToolsHardeningTest, FileEdit_NonMatchingOldStringIsActionable) {
     const std::string message = result["error"].get<std::string>();
     EXPECT_NE(message.find("not found"), std::string::npos);
     EXPECT_NE(message.find("no replacement was made"), std::string::npos);
-    EXPECT_NE(message.find("file_read"), std::string::npos);
+    // The error hands the text back rather than sending the model to re-read.
+    EXPECT_NE(message.find("current_content"), std::string::npos);
+    EXPECT_NE(result["current_content"].get<std::string>().find("quick brown"),
+              std::string::npos);
     EXPECT_EQ(result["replacements"], 0);
     EXPECT_EQ(readFile(path), before);
 }

--- a/docs/plans/email-eval-node-frontend.mdx
+++ b/docs/plans/email-eval-node-frontend.mdx
@@ -1,0 +1,208 @@
+---
+title: "Email Eval — Node Frontend"
+description: "Drive the existing email evals through the npm email agent's sidecar client to get an internal read on the shipped surface, without publishing a second score"
+icon: "gauge"
+---
+
+# Email Eval — Node Frontend
+
+> **Date:** 2026-08-12
+>
+> **Status:** Planning (0% implemented)
+>
+> **Agent:** `@amd-gaia/agent-email` ([`hub/agents/email/npm/`](https://github.com/amd/gaia/tree/main/hub/agents/email/npm))
+>
+> **Related plans:** [Email Triage Agent](/plans/email-triage-agent) (parent), [Email Agent Packaging](/plans/email-agent-packaging)
+
+---
+
+## Goal, and the one thing this is not
+
+**Goal:** get an internal read on how good the Node email agent actually is, by running
+the committed email corpus through the sidecar over the same HTTP surface an npm
+consumer uses.
+
+**Not a goal — and this is load-bearing:** publishing. No `SCORECARD.md` edit, no
+`EVALUATION.md` number change, no npm release, no CI gate. This produces a number *we*
+look at to decide what to do next. See [Publishing guardrails](#publishing-guardrails)
+for why that separation has to be enforced mechanically rather than remembered.
+
+## Why bother — the gap this closes
+
+The Python eval imports Python **source**. The npm package's published claims
+(84.53 within-one-bucket) describe the **frozen PyInstaller binary**. Nothing today
+tests the artifact that actually ships.
+
+A PyInstaller freeze bug, a contract-schema drift between `types.ts` and `contract.py`,
+a broken bearer-token path, or a missing model would all pass Python CI green and break
+every npm consumer on first call. That blind spot is the entire justification for this
+work — the accuracy number is almost a side effect.
+
+## What is reachable over HTTP today
+
+The good news is that the headline metric needs **no sidecar changes at all**.
+
+`POST /v1/email/triage/batch` accepts 1–100 **inline** `SingleEmailInput` items. It
+requires no mailbox connector, and its response carries everything the deterministic
+triage scorer needs:
+
+| Response field | Feeds metric |
+|---|---|
+| `category` | category accuracy, within-one-bucket, urgent/personal recall |
+| `is_spam` / `is_phishing` | spam precision, phishing detection |
+| `action_items` | action-item P/R/F1 |
+| `suggested_action` | suggested-action agreement |
+
+The corpus is already committed and needs no regeneration —
+`tests/fixtures/email/vendor_corpus_seed.jsonl` holds the bodies, and
+`tests/fixtures/email/ground_truth.json` holds labels keyed by message id. A Node
+harness reads both directly; no Python in the scoring loop.
+
+**No LLM judge is required** for any of the above. Triage scoring is exact-label
+matching against ground truth.
+
+## The parity trap — read before trusting any number
+
+The Python benchmark and the HTTP surface are **not the same code path**. Treating the
+resulting numbers as comparable is the most likely way this effort produces a wrong
+conclusion.
+
+| | Python eval (today) | Node via sidecar |
+|---|---|---|
+| Entry | `agent.process_query("Call triage_inbox for up to N…")` | `POST /v1/email/triage/batch` |
+| Internal path | agent loop → `triage_inbox` tool → mailbox backend | `EmailTriageService.triage_request` on inline payload |
+| Also exercises | inbox fetch, attention cache, memory/preferences, body normalization, `GAIA_EMAIL_TRIAGE_MAX_MESSAGES` ceiling | none of it |
+| Corpus seam | `EmailAgentConfig(gmail_backend=FakeGmailBackend(mbox))` — **an in-process Python object** | inline in the request body |
+
+They share classification internals (`EmailTriageService`), but they are different
+entry points with different context assembly.
+
+**Consequences to hold onto:**
+
+1. The Node number **will not equal 84.53**, and a delta is not automatically a bug —
+   it may just be the missing loop context. Do not "fix" the harness until it matches.
+2. The agent-loop path is **unreachable from Node today**. `gmail_backend` is a
+   constructor argument, and `gaia-agent-email serve` has no flag to inject a fixture
+   mailbox. Anything mailbox-backed — `prescan`/briefing, `search`, follow-ups,
+   `triage_inbox` — is out of reach until Phase B below.
+3. Therefore Phase A measures the **batch-API contract path**, and must be labelled that
+   way in every artifact it emits.
+
+## Phase A — internal read (the actual ask)
+
+Target: a number on the screen, fast. Estimated ~2–3 days.
+
+**Location:** `hub/agents/email/npm/eval/` — excluded from the published package (see
+[guardrails](#publishing-guardrails)).
+
+**Pieces:**
+
+1. **Corpus loader** — read `vendor_corpus_seed.jsonl` + `ground_truth.json` from the
+   repo, map each row to a `SingleEmailInput`. Fail loudly on an id present in one file
+   and absent from the other; a silently-dropped row inflates accuracy.
+2. **Batch driver** — chunk to ≤100 items (`MAX_BATCH_SIZE`), drive through the existing
+   typed `EmailClient.triageBatch()`. Per-item errors are already isolated by the
+   endpoint; count them as an explicit `ERRORED` bucket rather than letting them vanish.
+3. **Deterministic scorer** — port the metric math from `src/gaia/eval/quality_metrics.py`:
+   category accuracy, within-one-bucket (ordinal `URGENT > NEEDS_RESPONSE > FYI >
+   PROMOTIONAL`), urgent recall, personal recall, FP/FN rates, spam precision. Read the
+   bars from the **existing** `tests/fixtures/email/quality_gate_thresholds.json` — do
+   not fork a second copy of the thresholds.
+4. **Runner** — `npm run eval`, writing `eval-out/node-scorecard.json` plus a
+   human-readable console summary (headline metric, per-category breakdown, top
+   confusions, error count).
+5. **Logging** — request/response capture behind `DEBUG`, and every failed item logged
+   with its id, expected label, and actual label. Debugging a bad number without the
+   per-item trail is the main way this becomes a time sink.
+
+**Explicitly out of Phase A:** judge-scored dimensions (drafting, briefing), performance
+metrics (TTFT/TPS are already better measured Python-side), CI wiring, docs updates.
+
+### Running it locally
+
+The npm package's `binaries.lock.json` currently has **all-`PENDING` sha256
+placeholders**, so `fetchBinary()` correctly refuses to produce a binary. Phase A must
+therefore drive a **dev-mode sidecar** via `connectSidecar()` rather than
+`startSidecar()`:
+
+```bash
+# Terminal 1 — Lemonade (canonical discovery port is 13305, NOT 8000)
+lemonade-server serve
+
+# Terminal 2 — email sidecar from source
+GAIA_EMAIL_AGENT_MODE=dev PYTHONPATH=$(pwd)/src \
+  python -m gaia_agent_email.server serve --dev --port 8131
+
+# Terminal 3 — the eval
+cd hub/agents/email/npm && npm run eval
+```
+
+Two environment gotchas that will otherwise cost an afternoon:
+
+- **Lemonade is on `13305`**, not the `8765`/`8000` some docs imply.
+- `gaia-agent-email` may be editable-installed into a *different worktree*; set
+  `PYTHONPATH` explicitly or the eval silently measures the wrong checkout.
+- Port **4001 is reserved** — the server already rejects it at startup, so nothing to do
+  beyond not choosing it.
+
+Because this runs against a dev sidecar built from source, Phase A does **not** yet close
+the frozen-binary blind spot that motivates the work. It closes the *contract-surface*
+blind spot. The freeze gap only closes once real binaries publish and the same harness is
+pointed at `startSidecar()` — a one-line change, deliberately designed for.
+
+## Phase B — fixture-mailbox seam (only if Phase A justifies it)
+
+Deferred by default. Estimated ~2 days if pulled in.
+
+Add a dev-gated `--fixture-mailbox <path>` flag (plus env equivalent) to
+`gaia-agent-email serve` that wires `FakeGmailBackend` into `EmailAgentConfig`. That
+single seam makes the agent-loop path, `prescan`/briefing, `search`, and follow-ups all
+drivable over HTTP — at which point Node reproduces the *same* metric as Python, and a
+divergence between the two becomes a precise signal that the shipped surface drifted from
+source.
+
+It must be loudly dev-gated and impossible to activate in a shipped sidecar; a fixture
+mailbox silently active in production would serve fabricated email as real. Gate it on
+the same `--dev` posture that already prints the caller-token-off banner, and refuse the
+flag outright when the process looks like a frozen binary.
+
+## Phase C — judge-scored dimensions (not scheduled)
+
+Drafting and briefing quality need an Anthropic judge. If these are ever wanted in Node,
+the cheaper path is: Node emits transcripts, and the existing
+`eval_drafting_report.py` / `eval_briefing_report.py` score them. One judge
+implementation, not two. Reimplementing judge prompts in TypeScript would fork the
+scoring rubric — the same drift hazard as forking the thresholds.
+
+## Publishing guardrails
+
+The whole point is an internal read, so the separation is enforced in code, not by
+memory:
+
+- `eval/` is added to `.npmignore` (or omitted from `package.json` `files`) so it never
+  ships to consumers.
+- The output file is `node-scorecard.json`, a distinct name from the published
+  `SCORECARD.md`, and its JSON carries an explicit
+  `"surface": "batch-api-contract-path"` field plus a `"published": false` marker.
+- No edits to `SCORECARD.md`, `EVALUATION.md`, `README.md`, or `SPEC.md` in this work.
+
+That last one matters more than it looks: the eval claim is repeated across **all four**
+of those files. If a Node-derived number is ever promoted to published status, all four
+have to change in the same commit or the package ships self-contradicting documentation.
+
+## Risks
+
+| Risk | Mitigation |
+|---|---|
+| Node number read as comparable to 84.53 | Distinct metric name + `surface` field in output; parity table above stated in the runner's console header |
+| Thresholds forked into TypeScript, then drift | Read `quality_gate_thresholds.json` at runtime; never transcribe the values |
+| Dev sidecar measures the wrong worktree | Explicit `PYTHONPATH`; runner logs the resolved agent version + source path at startup |
+| Corpus/ground-truth id mismatch silently shrinks the denominator | Fail loudly on any unmatched id; report scored-item count next to the headline |
+| Phase A mistaken for closing the frozen-binary gap | Stated explicitly above; revisit when `binaries.lock.json` has real hashes |
+
+## Open question
+
+Whether the batch-API contract path is the metric we *want* long term. For npm consumers
+it is arguably more honest than the agent-loop number, because it is the surface they
+actually call. Phase A gives us the data to decide that, which is the point of doing it
+before committing to Phase B.

--- a/docs/plans/email-inbox-cleanup.mdx
+++ b/docs/plans/email-inbox-cleanup.mdx
@@ -1,0 +1,277 @@
+---
+title: "Email Inbox Cleanup"
+description: "Bulk inbox cleanup for the GAIA email agent — sender-level bulk actions, unsubscribe, batch trash + undo, and a cleanup orchestration flow, split into skill-deliverable vs. prerequisite core work"
+icon: "broom"
+---
+
+# Email Inbox Cleanup
+
+> **Date:** 2026-07-29
+>
+> **Status:** Planning (0% implemented)
+>
+> **Agent:** `gaia-agent-email` ([`hub/agents/email/python/`](https://github.com/amd/gaia/tree/main/hub/agents/email/python))
+>
+> **Related plans:** [Email Triage Agent](/plans/email-triage-agent) (parent), [Skill Format](/plans/skill-format), [Skill Synthesis](/plans/skill-synthesis)
+
+---
+
+## Relationship to the parent plan (read first)
+
+The [Email Triage Agent](/plans/email-triage-agent) plan already scopes two items
+this document covers, and this plan **re-scopes them against the shipped code**
+rather than duplicating them:
+
+- **Bulk unsubscribe.** The parent puts it in the MVT tier at **~20 LOC**, RFC
+  8058, T0-deterministic (§1.3, §5). That estimate assumes the `List-Unsubscribe`
+  header is available — but it **never shipped**, and the code that did ship
+  (`_format_message_for_llm`, `read_tools.py`) strips messages to a fixed field
+  set that excludes it. The realistic cost is higher than ~20 LOC once you add
+  header exposure, the mailto fallback, per-sender grouping, the frozen-contract
+  bump, an eval, and docs. This plan owns the **grounded** re-estimate (#3).
+- **Inbox-Zero mode.** The parent's §12.7 guided-cleanup UX is the front-end for
+  the cleanup flow (#1) here. This plan owns the **agent/backend capability**;
+  the parent owns the **UX**. Neither supersedes the other.
+
+Everything else here is net-new against both the parent plan and the code.
+
+---
+
+## TL;DR
+
+The email agent already ships ~70% of the primitives inbox cleanup needs — batch
+archive/label/move/star, soft-delete (trash) + undo, permanent-delete with
+confirmation, an action-log undo ledger, triage/pre-scan classification,
+per-sender profiles, and Gmail-operator search. "Inbox cleanup" is mostly an
+**orchestration layer plus a few missing primitives** on top of that — not a
+from-scratch build.
+
+The work splits cleanly along a **skill vs. core** line:
+
+- **Core (must ship first):** batch-trash + bulk-undo, backend bulk APIs, a
+  confirmed-cleanup threshold path, and raw-header exposure for unsubscribe.
+  These touch the mailbox mutation path, the undo ledger, and the safety
+  guardrails — they belong in the trusted agent/backend, not a dropped-in skill.
+- **Skill (portable, on top):** the cleanup *policy* — what to clean, in what
+  order, per-sender rules. Once the [skill runtime](/plans/skill-format) lands,
+  this is a recipe skill composing the core tools, tunable without a fork.
+
+**Design defaults to decide up front:** cleanup defaults to **archive**
+(reversible), with **trash** as an explicit opt-in; large batches surface a
+**single** batch-confirm prompt rather than per-op prompts.
+
+---
+
+## Why this exists
+
+Users mean several distinct things by "clean up my inbox": archive or delete old
+promotional/newsletter mail, unsubscribe from senders, and bulk-act on everything
+from one sender. (Note: archive and trash do **not** reclaim mailbox quota —
+trashed mail counts against storage for 30 days, and only `permanent_delete`
+frees it; genuine storage reclamation is a separate, permanent-delete path, not
+the default cleanup action.) The agent can do
+the individual mutations today, but there is **no cleanup flow** that finds
+candidates, groups them, proposes bulk actions with counts, and executes them
+with a single undo handle. Worse, the batch-threshold guardrail — correct for
+preventing accidental blasts — is the *default failure mode* of an intentional
+cleanup, because it refuses large multi-sender batches without confirmation and
+there is no confirmed-cleanup path to satisfy it.
+
+---
+
+## Current state — what already exists (reuse, don't rebuild)
+
+Grounded on the code on `main`. These are the primitives a cleanup layer composes.
+
+| Capability | Symbol / tool | `file` | State |
+|---|---|---|---|
+| Bulk archive | `archive_message_batch` (shared `batch_id`, partial-failure collection) | [`tools/organize_tools.py`](https://github.com/amd/gaia/blob/main/hub/agents/email/python/gaia_agent_email/tools/organize_tools.py) | **Exists** |
+| Bulk move / label / read / star | `move_to_label_batch`, `label_message_batch`, `mark_read_batch`, `mark_unread_batch`, `add_star_batch`, `remove_star_batch` | `tools/organize_tools.py` | **Exists** |
+| Bulk-archive undo | `undo_archive_batch` | `tools/organize_tools.py`, `action_store.py` | **Exists** |
+| Soft delete + undo | `trash_message` → `restore_message` (undo window) | [`tools/delete_tools.py`](https://github.com/amd/gaia/blob/main/hub/agents/email/python/gaia_agent_email/tools/delete_tools.py) | **Exists** |
+| Permanent delete (guarded) | `permanent_delete` (in `CONFIRMATION_REQUIRED_TOOLS`) | `tools/delete_tools.py` | **Exists** |
+| Undo ledger | `record_action`, `batch_id`, `fetch_batch_undoable` | `action_store.py` | **Exists** |
+| Classification | `triage_inbox`, `pre_scan_inbox` (URGENT / NEEDS_RESPONSE / FYI / PROMOTIONAL / PERSONAL + `is_spam` / `is_phishing`) | [`tools/read_tools.py`](https://github.com/amd/gaia/blob/main/hub/agents/email/python/gaia_agent_email/tools/read_tools.py) | **Exists** |
+| Candidate search | `search_messages` (Gmail operators incl. `older_than:`, `larger:`) | `tools/read_tools.py` | **Exists** |
+| Per-sender profile | frequency + dominant category, sorted by volume | [`tools/profile_tools.py`](https://github.com/amd/gaia/blob/main/hub/agents/email/python/gaia_agent_email/tools/profile_tools.py) | **Exists** |
+| Session prefs | low-priority senders, `category_defaults → archive` | `tools/preference_tools.py`, `tools/read_tools.py` | **Exists** |
+
+---
+
+## The gaps
+
+Seven gaps stand between today's primitives and a coherent cleanup feature. The
+final column marks whether each is **skill-deliverable** or **prerequisite core
+work** (see [Skill vs. core](#skill-vs-core-what-can-live-where)). Effort is a
+rough S/M/L T-shirt size for relative sequencing, not a costed estimate.
+
+| # | Gap | Impact | Effort | Home |
+|---|-----|--------|--------|------|
+| 1 | **No cleanup orchestration flow** | The LLM must hand-chain search→batch. Nothing finds bulk/promo/old mail, groups by sender, proposes N actions with counts, and executes-with-undo. `pre_scan.suggested_archives` is capped at 10 and inbox-front only (`PRE_SCAN_ARCHIVE_CAP`, `read_tools.py`). | L | **Skill** (recipe) |
+| 2 | **Batch threshold blocks big cleanups** | `_organize_batch_threshold_exceeded` refuses >5 ops across >3 senders per turn (`agent.py`). Correct for accidents, but it is the default failure mode of an intentional cleanup — no confirmed-cleanup bypass exists. | S–M | **Core** |
+| 3 | **No unsubscribe** | No `List-Unsubscribe` handling anywhere. `_format_message_for_llm` strips messages to a fixed field set (`read_tools.py`), so the header is not even exposed. Needs header parsing (mailto + RFC 8058 one-click POST), a tool, and confirmation. | M–L | **Core** (header exposure) + **Skill/core** (the tool) |
+| 4 | **No trash-batch / bulk trash-undo** | Only single `trash_message` / `restore_message`. Bulk delete needs `trash_message_batch` + `undo_trash_batch` (the `batch_id` schema already supports it; mirror `undo_archive_batch`). | S–M | **Core** |
+| 5 | **Backends loop one-at-a-time** | `gmail_backend` / `outlook_backend` have no `batchModify` / `batchDelete` — every mutation is a per-message API call. Fine for 10 messages, painful for "archive 800 promos." | M | **Core** (backend) |
+| 6 | **No sender-level bulk verb** | Profile data exists but nothing ties profile → search → bulk action ("archive everything from X / all newsletters"). | M (mostly #1) | **Skill** (recipe) |
+| 7 | **REST/MCP + eval + docs surface** | No `cleanup`/`unsubscribe` REST verb or MCP tool; frozen-contract update; no eval suite for cleanup precision (false-archive is the risky failure); README/SPEC/SKILL/CHANGELOG/CAPABILITY_MATRIX must update together (repo rule). | M | **Core** + docs |
+
+---
+
+## Skill vs. core — what can live where
+
+Per the [Skill Format](/plans/skill-format) contract, a GAIA skill is one of:
+an **instruction-only** procedure, a **recipe** that composes existing registry
+tools (`metadata.gaia.tools_required`), or a skill that ships its **own `@tool`
+code** (`metadata.gaia.tools`).
+
+**The rule of thumb:** a skill can *orchestrate* mailbox mutations, but the
+mutation primitives, the undo ledger, and the safety thresholds must live in the
+trusted core. A sandboxed skill tool does not get handles to the agent's private
+`_backends` / `_backend_for_message` routing or the `action_store` ledger.
+
+- **Skill-deliverable (composition only):** the cleanup flow (#1) and
+  sender-level cleanup (#6) are textbook recipe skills — pure composition of
+  `triage_inbox` → `search_messages` → `archive_message_batch` / `trash_message_batch`.
+- **Core, non-negotiable:** batch-trash + bulk-undo (#4), backend bulk APIs
+  (#5), and the threshold/confirmation policy (#2) require privileged agent
+  internals or backend code. Unsubscribe (#3) needs raw-header exposure in core
+  before any skill tool can read `List-Unsubscribe`.
+
+### Two caveats that gate the skill path
+
+1. **The skill runtime does not exist yet — and it targets the core framework,
+   not the sidecar.** The `gaia.skills` loader, `gaia skill` CLI, and
+   `_TOOL_REGISTRY` skill registration are all **PROPOSED / greenfield** in the
+   [Skill Format](/plans/skill-format) plan. That runtime is designed against the
+   in-core agent framework, but the email agent ships as a **frozen-binary
+   sidecar** (PyInstaller wheel + npm). Dynamically loading a skill's `tools.py`
+   into a frozen binary is unsolved — recipe / instruction-only skills (no code)
+   are far more plausible in the sidecar than code-carrying skills.
+2. **Trust tier gates destructive email ops.** Trash, permanent-delete, and
+   unsubscribe-POST are exactly the actions the tier system flags as dangerous —
+   they would require `verified` (AMD-signed) tier, never the default
+   `experimental`. "Define it in a skill" must not mean "any community skill can
+   nuke an inbox."
+
+---
+
+## Phased build
+
+Each phase holds the prior floor. Core primitives land first so the skill layer
+has something to compose.
+
+### Phase 1 — Core primitives (unlocks "trash all these" today)
+
+**Ships:**
+- `trash_message_batch` + `undo_trash_batch`, mirroring the archive-batch pattern
+  and reusing the `batch_id` ledger (#4).
+- A **confirmed-cleanup path** through the batch threshold: one batch-confirm
+  prompt that, once satisfied, lets a large multi-sender cleanup proceed without
+  per-op re-prompts (#2). The flow already emits a batch-confirm sentinel; this
+  makes it satisfiable.
+
+**Success criteria:**
+- A 50-message, 10-sender trash executes after a single confirmation and is
+  fully reversible via `undo_trash_batch` inside the undo window.
+- The threshold still blocks an *unconfirmed* multi-sender blast.
+
+### Phase 2 — Cleanup flow + backend bulk (the core feature)
+
+**Ships:**
+- Backend bulk mutation for Gmail (`batchModify` / `batchDelete`) so bulk ops are
+  O(1) API calls, not O(N) (#5). **Outlook is separate work, not a drop-in
+  equivalent** — it is folder-based, not label-based, and its batch API differs;
+  scope it as its own investigation rather than assuming parity.
+- The cleanup orchestration: find candidates (promotional / old / large / by
+  low-priority sender), **group by sender**, propose bulk actions with counts,
+  execute with a single undo handle (#1, #6). Authored as a **recipe skill** if
+  the skill runtime is available in the sidecar by then; otherwise as an
+  agent-loop flow that the skill later wraps.
+
+**Success criteria:**
+- "Clean up my promotions" returns a grouped, counted proposal and executes as
+  one reversible batch.
+- Bulk archive of 500 messages completes without per-message API fan-out.
+
+### Phase 3 — Unsubscribe (candidate to pull forward; see design decision 3)
+
+**Ships:**
+- Raw-header exposure in core (`List-Unsubscribe`, `List-Unsubscribe-Post`)
+  without widening the untrusted-body surface (#3).
+- An `unsubscribe` tool: mailto and RFC 8058 one-click POST (`network:write`),
+  gated by confirmation.
+
+**Success criteria:**
+- Unsubscribe succeeds via one-click POST where offered, falls back to mailto,
+  and **fails loudly** (never silently no-ops) when neither is available.
+
+### Cross-cutting — surface, eval, docs
+
+- REST `cleanup` / `unsubscribe` verb + frozen-contract bump; MCP tool only if a
+  host LLM needs it as a verb (per the CAPABILITY_MATRIX MCP-scope rule).
+- **Eval suite** for cleanup precision — false-archive / false-trash is the
+  dangerous error; measure precision on the suggested-cleanup set, not just recall.
+- Docs sync **together**: README, SPEC, SKILL, CHANGELOG, CAPABILITY_MATRIX
+  (regenerate via `packaging/capability_matrix.py`).
+
+---
+
+## Non-negotiable safety invariant
+
+**Cleanup must never make spam or phishing disappear before the user sees it.**
+The shipped code enforces this deliberately: `pre_scan_inbox_impl` forces
+`is_spam` / `is_phishing` mail into the `actionable` bucket (never
+`suggested_archives`), and `_apply_session_preferences` refuses to let a
+low-priority-sender preference silently archive a flagged message
+([`read_tools.py`](https://github.com/amd/gaia/blob/main/hub/agents/email/python/gaia_agent_email/tools/read_tools.py)).
+The cleanup flow (#1, #6) **inherits this invariant** — a bulk-archive/trash of
+the promotional bucket must exclude anything flagged, or cleanup becomes a
+phishing-hiding vector. This is a hard constraint on the flow, not a preference.
+
+## Design decisions to pin down first
+
+1. **Default cleanup action** — **archive** (reversible, keeps mail) as the
+   default; **trash** as explicit opt-in. Aligns with the repo's no-silent-
+   destructive-fallback posture.
+2. **Confirmation model at scale** — a **single** "confirm N messages from M
+   senders" prompt, not per-op prompts. The batch-confirm sentinel already
+   exists; Phase 1 makes it satisfiable.
+3. **Phase ordering of unsubscribe** — unsubscribe is arguably the
+   highest-value cleanup action (see the gap table), yet the phasing below puts
+   it last. Decide whether to pull it forward: its only hard prerequisite is
+   raw-header exposure (a small core change), so it *could* land in Phase 1–2
+   ahead of the full flow. Left as an explicit decision rather than silently
+   fixed.
+
+**Undo horizon is a Phase 1 requirement, not an open question.** The current
+undo window is **30 seconds** (`undo_window_seconds: int = 30`,
+[`config.py`](https://github.com/amd/gaia/blob/main/hub/agents/email/python/gaia_agent_email/config.py)).
+A 30-second window makes a *reviewed* bulk cleanup effectively unusable — the
+user cannot inspect 200 archived messages and undo within 30s. Phase 1 must
+either give cleanup batches an extended, explicit undo handle or rely on the
+provider Trash's native 30-day recovery as the documented undo path. Shipping
+cleanup on the 30s window would be a false-safety claim.
+
+---
+
+## KPIs
+
+| KPI | Type | Target |
+|---|---|---|
+| Cleanup precision | Headline (safety) | False-archive / false-trash rate on the suggested-cleanup set below an agreed bar before enforce. |
+| Reversibility | Correctness | Every non-permanent cleanup batch is fully reversible via one undo handle inside the window. |
+| Bulk efficiency | Perf | Bulk ops use backend batch APIs — no O(N) per-message fan-out for N > threshold. |
+| Fail-loudly | Correctness | Unsubscribe and bulk ops raise actionable errors on partial/total failure; never silent no-op. |
+| Docs coherence | Grounding | README / SPEC / SKILL / CHANGELOG / CAPABILITY_MATRIX updated in the same change; matrix regenerated. |
+
+---
+
+## Dependencies
+
+- **Blocking for the skill layer:** the [Skill Format](/plans/skill-format)
+  runtime (loader, CLI, `_TOOL_REGISTRY` registration) — **PROPOSED**, and its
+  loadability into the frozen email sidecar is an open integration question.
+- **Non-blocking for core:** Phases 1–3 core work depends only on existing
+  email-agent internals and the Gmail/Outlook backends.
+- **Connector scope:** unsubscribe one-click POST needs `network:write`; the
+  Google/Microsoft connector grant model already gates mailbox access.

--- a/docs/plans/email-triage-skill.mdx
+++ b/docs/plans/email-triage-skill.mdx
@@ -1,0 +1,363 @@
+---
+title: "Email Triage as a Flagship Skill"
+description: "Replace the standalone Email Triage Agent with an email tool mixin plus an inbox-triage skill on the flagship GAIA agent, so the custom agent can be decommissioned"
+icon: "inbox"
+---
+
+<Info>
+  **Issue draft.** Proposed for `amd/gaia`, labels `enhancement` + `agent` + `p1`.
+  Cross-links [#2672](https://github.com/amd/gaia/issues/2672),
+  [#2683](https://github.com/amd/gaia/issues/2683),
+  [#2863](https://github.com/amd/gaia/issues/2863),
+  [#2982](https://github.com/amd/gaia/issues/2982).
+</Info>
+
+## The problem
+
+Ask the flagship GAIA agent to triage your inbox and it cannot. It has no Gmail
+tool, no Outlook tool, and no Google or Microsoft connector grant — 67 registered
+tools and not one of them touches mail. Email lives in a separate installable
+agent with its own sidecar process, its own REST API, its own npm package, and its
+own 66-tool surface. A user who wants "read my mail and tell me what needs me"
+alongside "search my documents" has to run two agents and cannot ask one question
+that spans both.
+
+After this change, `triage my inbox` works in the Go TUI against the same flagship
+agent that already does documents, web, shell, and memory — and the standalone
+email agent becomes redundant rather than load-bearing.
+
+This is the architectural direction CLAUDE.md already states: per-task agents were
+deleted and their capability became the flagship's tool surface driven by a
+`SKILL.md` in `hub/skills/`. Email is the last major holdout.
+
+## Position against the prior art
+
+Four issues touch this area. This proposal is deliberately narrower than all of them.
+
+| Issue | What it wants | Relationship |
+|---|---|---|
+| [#2672](https://github.com/amd/gaia/issues/2672) | Email's ~59 tools become **portable skills installable into any agent** | Same mechanism, different goal. Explicitly keeps email agent behaviour unchanged — it does not decommission. Blocked on #2863. |
+| [#2683](https://github.com/amd/gaia/issues/2683) | Email agent as the **adaptive-skills (skills-v2) reference example** | Assumes the email agent keeps existing. Orthogonal; would retarget onto the flagship if this lands. |
+| [#2863](https://github.com/amd/gaia/issues/2863) | Phase 2 **local-capability sandbox** | Blocks #2672. **Does not block this proposal** — see below. |
+| [#2982](https://github.com/amd/gaia/issues/2982) | Collapse example agents into flagship + skills | Same direction, but names the email agent as an explicit **non-goal** ("reference sidecar product — stays"). **This proposal contradicts that.** Needs an owner decision. |
+
+**File this as a new issue narrowing #2672, not as an amendment.** #2672's goal is
+portability of email capability *into arbitrary agents*; its acceptance test is
+literally "a non-email agent installs an extracted skill and uses its tools", and
+it is blocked on a sandbox that does not exist. This proposal has one consumer (the
+flagship), needs no sandbox, and its success condition is the *deletion* of a
+package. Folding a decommission plan into a portability issue would bury it behind
+a blocker it does not have.
+
+## The constraint that picks the architecture — verified, and it is not what it looks like
+
+The premise that local-capability permissions are refused is **true but does not
+apply here**, for two independent reasons. Both were verified in code.
+
+**1. `shell` is no longer a local-capability domain.** It was, when #2672 was
+written. It is now binary-bridged:
+
+```python
+# src/gaia/skills/permissions.py:63-73
+CONNECTOR_BRIDGED_DOMAINS = frozenset({"network", "mcp"})
+BINARY_BRIDGED_DOMAINS = frozenset({"shell"})
+LOCAL_CAPABILITY_DOMAINS = (
+    frozenset(DOMAIN_LEVELS) - CONNECTOR_BRIDGED_DOMAINS - BINARY_BRIDGED_DOMAINS
+)
+```
+
+So the refused set today is `filesystem`, `database`, `desktop`, `env` — **not**
+`shell`. That is why `hub/skills/github-triage/SKILL.md` can declare
+`shell:execute:gh` and load: a scoped binary grant resolves against
+`BINARY_POLICIES` in `src/gaia/skills/binaries.py` (only `gh` and `pytest` have
+policies today). Unscoped `shell:execute` is still refused, because that asks for
+the whole shell. There is no allowlist exception and no bundled-vs-installed
+distinction — the gate is the same for every skill.
+
+**2. The gate only ever runs on skill permissions, never on agent code.** Every
+call site of `refuse_unbridged_permissions` passes `skill.parsed_permissions()`
+(`agent.py:1619`, `loader.py:62`, `install.py:353`, `publish.py:137`,
+`migrate.py:821`). A tool mixin composed into an agent class is ordinary Python in
+the agent — it is not a skill, declares no permissions, and is never gated.
+
+**Consequence:** a first-class email tool mixin is available **now**. The sandbox
+in #2863 is not on its critical path. What #2863 blocks is shipping email tools as
+a *skill-provided* `tools.py`, because the reversible-action ledger needs
+`database:write` — and that is precisely why #2672 is stuck.
+
+## Recommended architecture — A: tool mixin + skill
+
+**A new `gaia.agents.tools.email_tools.EmailToolsMixin`, registered in
+`KNOWN_TOOLS`, orchestrated by `hub/skills/inbox-triage/SKILL.md`.**
+
+The skill carries judgment (what "urgent" means, when to escalate, how to word a
+digest). The mixin carries capability (authenticated Gmail/Graph calls). This is
+exactly the split every shipped starter skill already uses — `document-brief`
+names `RAGToolsMixin`'s tools in `tools_required` without any code coupling.
+
+### Why not the alternatives
+
+**B — MCP connector.** Available today via `mcp:connect`, but there is no
+Gmail or Outlook server in `src/gaia/connectors/catalog/mcp_servers.py` (only
+`mcp-github`, `mcp-tavily`, `mcp-memory`, `mcp-git`). Adopting it means handing a
+third-party `npx` subprocess standing access to the user's entire mailbox, and
+moving OAuth credentials out of the OS keyring into subprocess env vars — wrong
+for a local-first product, and it discards `gmail_backend.py` / `outlook_backend.py`,
+which are tested and already authenticate through `gaia.connectors.api`. Keep MCP
+as a bring-your-own-provider escape hatch, not the primary path.
+
+**C — skill drives the email agent's REST API.** Hides the agent instead of
+retiring it, so it fails the stated goal. It is not even cheap: the flagship has no
+HTTP POST tool, and `shell:execute:curl` has no binary policy, so it needs new
+plumbing to deliver strictly less.
+
+**D — a `gaia-mail` CLI plus a binary policy, mirroring `gh`.** Structurally the
+closest analogue to `github-triage`, but it means building the same Gmail client and
+then wrapping it in argv parsing and a second permission layer. Strictly more work
+than A for the same result.
+
+### Why A is cheaper than it looks
+
+The connector plumbing is already shared. `gmail_backend.py` and
+`outlook_backend.py` obtain tokens via
+`gaia.connectors.api.get_access_token_sync(provider=..., scopes=..., agent_id=...)`
+— the same call a core mixin makes. Grants are enforced centrally by
+`check_agent_grant()`. Moving the backends into `src/gaia/agents/tools/` is largely
+a relocation, not a rewrite.
+
+### New and changed files
+
+| Path | Change |
+|---|---|
+| `src/gaia/agents/tools/email_tools.py` | New — `EmailToolsMixin`, ~19 tools |
+| `src/gaia/agents/tools/_email/gmail.py` | New — relocated from `gaia_agent_email/gmail_backend.py` |
+| `src/gaia/agents/tools/_email/graph.py` | New — relocated from `outlook_backend.py` (Phase 4) |
+| `src/gaia/agents/tools/_email/scopes.py` | New — relocated; keeps the `https://mail.google.com/` exclusion (#2533) |
+| `src/gaia/agents/registry.py` | Add `"email"` to `KNOWN_TOOLS` |
+| `hub/skills/inbox-triage/SKILL.md` | New — the judgment layer |
+| `hub/agents/gaia/python/gaia-agent.yaml` | Bump `tools_count` (drift-guarded by `test_gaia_agent.py`) |
+
+## Capability parity
+
+A decommission is only credible if parity is explicit. Two views: the 27 externally
+exposed operations from `hub/agents/email/python/CAPABILITY_MATRIX.md`, and the
+66 internal agent-loop tools.
+
+### The 27 exposed operations
+
+| Op | Surface | Verdict | Note |
+|---|---|---|---|
+| `triage` | REST | **Must survive** | The headline capability |
+| `triage/batch` | REST | **Must survive** | Batch classification |
+| `triage_email` | MCP | **Must survive** | Duplicate of `triage` |
+| `triage_email_batch` | MCP | **Must survive** | Duplicate of `triage/batch` |
+| `prescan` | REST | **Must survive** | Cheap scan; feeds triage without per-message classification |
+| `search` | REST | **Must survive** | Gmail query operators |
+| `archive` | REST | **Must survive** | Core reversible action |
+| `unarchive` | REST | **Must survive** | Undo — safety-critical, not optional |
+| `attention` | REST | **Must survive** | "What needs you"; real dedup machinery (`attention_cache.py`) |
+| `briefing` | REST | **Must survive** (Phase 3) | Needs the scheduler |
+| `draft` | REST | **Must survive** | Judged by the `drafting` eval |
+| `draft_reply` | MCP | **Must survive** | Duplicate of `draft` |
+| `send` | REST | **Must survive** | Highest-stakes op; hard confirmation gate |
+| `send_email` | MCP | **Must survive** | Duplicate of `send` |
+| `confirm` | REST | **Must survive, reshaped** | Exists because a sidecar cannot prompt. On the flagship it becomes `console.confirm_tool_execution`, not an endpoint |
+| `calendar/events (GET)` | REST | Defer | Calendar is a separate capability; own scopes |
+| `calendar/events (POST)` | REST | Defer | |
+| `calendar/events/preview` | REST | Defer | |
+| `calendar/events/respond` | REST | Defer | RSVP |
+| `quarantine` | REST | Defer | Phishing SLM; carries the `specific-ai-tools` dependency |
+| `unquarantine` | REST | Defer | Pairs with `quarantine` |
+| `query` | REST | Drop | This *is* the agent loop — on the flagship the user just talks to the agent |
+| `query/{run_id}/cancel` | REST | Drop | TUI already cancels runs |
+| `query/{run_id}/respond` | REST | Drop | TUI already handles `needs_input` |
+| `/v1/connections` | REST | Drop | Covered by the connectors framework |
+| `/v1/connections/{provider} (POST)` | REST | Drop | Covered by `gaia connectors` |
+| `/v1/connections/{provider} (DELETE)` | REST | Drop | Covered by `gaia connectors` |
+
+**Headline: 15 must survive, 6 defer, 6 drop.** The 15 collapse to **11 distinct
+capabilities** once the four MCP tools fold into their REST twins.
+
+### The 66 internal tools → ~19
+
+Do not port 66 tools. The flagship already registers 67; adding 66 more would give
+it 133 and wreck `ToolLoader`'s per-turn selection — which is the same problem
+[#2835](https://github.com/amd/gaia/issues/2835) and
+[#2836](https://github.com/amd/gaia/issues/2836) are already solving *inside* the
+email agent. Parity is at the operation level, not the tool level.
+
+| Group | Email agent | Flagship mixin | How |
+|---|---|---|---|
+| Read | 9 (`read_tools`) | 5 | `list_inbox`, `search_messages`, `get_message`, `get_thread`, `list_labels` |
+| Triage | 3 | 3 | `triage_inbox`, `pre_scan_inbox`, `list_waiting_on_you` |
+| Organize | 15 (`organize_tools`) | 2 | Collapse the 7 single + 7 batch variants into one `organize_messages(ids, action)`; add `undo_last_action` |
+| Write | 5 (`reply_tools`) + 4 (`delete_tools`) | 3 | `draft_reply`, `send_draft`, `trash_message` |
+| Briefing / tasks | 3 | 3 | `get_briefing`, `extract_action_items`, `list_tasks` |
+| Preferences | 8 | 2 | `set_sender_priority`, `get_preferences` |
+| Connection | 3 | 1 | `check_mailbox_access` |
+| Calendar | 6 | 0 | Deferred |
+| Phishing | 2 | 0 | Deferred |
+| Voice / profile / misc | 5 | 0 | Deferred |
+| **Total** | **66** | **~19** | |
+
+### The hard parts
+
+These are not prompt-shaped and a `SKILL.md` cannot replicate them. Each needs real
+code in the mixin:
+
+- **Classification pipeline** — two-tier heuristic → LLM escalation
+  (`triage_heuristics.py`, `llm_triage.py`, `triage_condense.py`), 5-category
+  taxonomy tied to Gmail label semantics. Must move as code.
+- **Batch safety gate** — `ORGANIZE_BATCH_OP_THRESHOLD = 5` /
+  `ORGANIZE_BATCH_SENDER_THRESHOLD = 3` (`agent.py:782-783`): more than 5 organize
+  mutations across more than 3 distinct senders in one turn forces confirmation.
+  Must move verbatim.
+- **Undo ledger** — `action_store.py` persists `email_actions` / `email_drafts` to
+  `~/.gaia/email/state.db` with a 120s default window, and enforces the ordering
+  invariant that the API call succeeds *before* the row is recorded (a phantom undo
+  row is state corruption). This is the `database:write` dependency that blocks
+  #2672; as agent code it is unblocked.
+- **Context budgeting** — `context_budget.py`, `thread_fold.py`,
+  `body_normalize.py`. Partly generic, but the flagship's prompt is larger, so the
+  budget needs recalculating, not copying.
+- **Attention dedup** — `attention_cache.py` dedupes signals across four sources.
+- **Briefing scheduling** — `scheduler.py` / `schedule_store.py` are daemon-managed.
+  This is why briefing is Phase 3, not Phase 0.
+
+## Permission and connector model
+
+### Reads: one consent, then silent
+
+The mixin declares `REQUIRED_CONNECTORS` on the flagship agent class, mirroring the
+email agent's existing declaration (`gaia_agent_email/agent.py:748-760`). The user
+consents once when connecting the account; reads then run without prompting —
+the same shape as `gh issue list` running silently under `shell:execute:gh`.
+
+Scopes stay exactly as the email agent requests them, including the deliberate
+exclusion of `https://mail.google.com/` (full-mailbox permanent delete,
+[#2533](https://github.com/amd/gaia/issues/2533)). **Do not widen scopes during the
+move.** `build_tui.yml` already path-triggers on `scopes.py` as a drift guard; that
+guard must follow the file to its new home.
+
+### Writes: confirmation, and a higher bar than `gh`
+
+`gh issue comment` is public and retractable. Sending mail is private and
+irreversible. The gate must be stricter, not equivalent.
+
+The mechanism already exists and is wired: `TOOLS_REQUIRING_CONFIRMATION`
+(`agent.py:198`) is unioned at runtime with the agent's own
+`CONFIRMATION_REQUIRED_TOOLS` ClassVar (`agent.py:3184-3193`), and a listed tool
+causes `_execute_tool` to call `console.confirm_tool_execution` and block
+(`agent.py:3436`).
+
+| Action | Gate |
+|---|---|
+| `send_draft`, `send_now`, `forward_message`, `schedule_send` | **Always confirm**, showing literal to / subject / body preview |
+| `trash_message` | **Always confirm** — reversible only while the message stays in Trash |
+| `organize_messages` (archive, label, mark-read, star) | Silent below the batch threshold; **confirm** above 5 ops across more than 3 senders |
+| `undo_last_action` | Silent — it only ever reduces effect |
+| All reads | Silent after connector consent |
+
+**Do not route this through `src/gaia/governance/`.** The layer exists and is
+well-designed, but it has zero consumers: `@govern` appears only inside its own
+docstring, and `GovernedAgentMixin` is mixed into no agent in the repo. Wiring
+email writes into an unexercised path would be the first real user of a layer with
+no production evidence. Use the confirmation mechanism that already ships. If
+governance is later adopted, email writes are the obvious first
+`@govern(risk="review")` case — as a follow-up, not a prerequisite.
+
+## Acceptance bar
+
+**Blocker first:** [#2983](https://github.com/amd/gaia/issues/2983) — the flagship
+has no scorecard and no release eval gate. Committed baselines exist only for
+`rag_quality`, `tool_selection`, and `context_retention`
+(`tests/fixtures/eval_baselines/gemma-4-e4b-d71cd914/`). An email category for the
+flagship has to exist before "no regression" means anything.
+
+To justify decommissioning, the flagship plus skill must:
+
+| Suite | Bar |
+|---|---|
+| `quality` | **Meet or beat** the email agent's committed baseline on the acceptance-enforced within-one-bucket categorization metric. This is the release gate today; it stays the gate. |
+| `drafting` | **Meet or beat** `approval_min` 0.70 |
+| `briefing` | Run and report. Enforcement is off in the fixture; do not silently tighten or loosen it |
+| `action_items` | Run and report |
+| `perf` | Fresh Strix Halo baseline required. The flagship's prompt is larger, so a TTFT regression is *expected* — it must be quantified and accepted explicitly, not waved through |
+| `followups` | Out of scope — CI-unwired, tracked by [#2040](https://github.com/amd/gaia/issues/2040) |
+
+**The sleeper risk, and the one nobody would think to test:** adding ~19 tools to a
+67-tool agent can degrade selection for *non-email* work. Every phase must re-run
+`gaia eval agent --category tool_selection` against the flagship's existing
+committed baseline. A win on email that costs document Q&A is not a win.
+
+Evals run **serially** — never two `gaia eval agent` processes at once. Confirm
+`ps aux | grep "gaia eval" | grep -v grep | wc -l` prints `0` before starting.
+
+## Phased plan
+
+**Phase 0 — read-only Gmail triage from the TUI.** One PR. `EmailToolsMixin` with
+5 read tools plus `triage_inbox`, registered in `KNOWN_TOOLS`; `inbox-triage`
+skill; Google connector requirement with read scopes only. No writes, no state DB,
+no Outlook, no calendar. Acceptance: `triage my inbox` works end-to-end in
+`gaia tui` against a real Gmail account, and `tool_selection` does not regress
+against the committed baseline.
+
+**Phase 1** — organize + undo. Brings the action ledger and the batch threshold.
+
+**Phase 2** — draft, send, trash, behind confirmation.
+
+**Phase 3** — briefing, tasks, scheduling. Needs daemon-managed jobs.
+
+**Phase 4** — Outlook / Microsoft Graph.
+
+**Phase 5** — deprecate. Not before Phases 0–4 have shipped and the eval bar is met.
+
+## Decommission blast radius
+
+**This is a multi-release effort, and the removal is larger than the build.**
+
+| Surface | Scale |
+|---|---|
+| Tests | **174 files** — 130 in-package, 44 repo-wide |
+| CI workflows | **11** referencing email; **7** email-only (`release_agent_email.yml`, `test_email_agent{,_unit,_eval}.yml`, `test_agent_email_npm.yml`, `email_scorecard_refresh.yml`, `build_cpp_email.yml`) |
+| Package docs | ~332 KB across README / SPEC / SKILL / CHANGELOG / CAPABILITY_MATRIX / CONTRACT / `openapi.email.json` / `specification.html` — all must move together per CLAUDE.md |
+| npm | `@amd-gaia/agent-email` **published at 0.6.0** — needs `npm deprecate`, not deletion |
+| PyPI | `gaia-agent-email` in `setup.py:30` `AGENT_WHEEL_PACKAGES` |
+| Daemon | **9 modules** in `src/gaia/daemon/sidecars/` with email-specific paths, ports, and scope literals |
+| UI proxy | `src/gaia/ui/email_sidecar/` — 6 files, entirely an email proxy |
+| Eval framework | **5 modules** import `gaia_agent_email` directly (`benchmark.py`, `draft_quality.py`, `briefing_quality.py`, `followup_quality.py`, `action_item_quality.py`) |
+| CLI | `gaia email` + `gaia email autonomy` (`cli.py:1424-1489`, handlers at `4542-4825`) |
+| Go TUI | Catalog seed entry with `Transport: TransportDaemon` + tests |
+| Docs site | `docs/docs.json` lines 102-103, 398-399, 410; `guides/email.mdx`, `guides/email-integration.mdx`, 3 plan docs |
+
+**The cost nobody has priced:** the email agent is the *only* proven sidecar. It is
+the reference implementation for the entire daemon-supervised sidecar
+architecture — frozen binaries on four platforms, SSE translation, caller auth,
+forwarded credentials. Deleting it deletes that reference. A defensible middle
+path is to move the *capability* to the flagship and keep the package as an
+architectural reference, unlisted on the hub. That would also resolve the conflict
+with #2982's non-goal without abandoning either position.
+
+## Non-goals
+
+- Not delivering the Phase 2 sandbox (#2863). This proposal routes around it.
+- Not skills-v2 adaptive learning (#2683).
+- Not the C++ runtime (#1543, #2799).
+- Not calendar, phishing SLM, or voice-profile capability in Phases 0–4.
+- Not deleting the sidecar architecture — only this consumer of it.
+- Not widening OAuth scopes. The `https://mail.google.com/` exclusion is permanent.
+
+## Open questions for the owner
+
+1. **#2982 conflict.** It names the email agent a permanent non-goal. Does this
+   proposal supersede that, or does the package survive as an unlisted reference?
+2. **Move or duplicate?** #2672 asks the same question and never settled it.
+   Duplicating creates two implementations to drift; moving is a breaking change
+   for anyone importing `gaia_agent_email`. Recommendation: **move**, with the
+   package retained at a frozen version until Phase 5.
+3. **Does #2672 get closed, narrowed, or left alone** once this lands? Its
+   portability goal survives independently, but its email framing would be stale.
+4. **Eval decoupling.** Five eval modules import the email package directly. Do
+   they retarget to the flagship in Phase 0, or keep dual baselines through Phase 4?
+5. **npm consumers.** Is `@amd-gaia/agent-email` known to have external users? That
+   decides deprecation-window length.

--- a/docs/plans/github-agent.mdx
+++ b/docs/plans/github-agent.mdx
@@ -1,0 +1,1057 @@
+---
+title: "GitHub Agent"
+description: "Consolidated scope for the GAIA GitHub Agent: event-driven CI bot + maintainer pull tooling across Agent UI / TUI / CI / service surfaces (milestone #43)."
+icon: "github"
+---
+
+# GAIA GitHub Agent — Scope
+
+**Status:** Draft scope · **Owner:** @kovtcharov-amd · **Date:** 2026-07-27
+
+A single GAIA agent (`gaia-agent-github`) that performs the AI-driven repository tasks
+`amd/gaia` currently runs as bespoke Claude GitHub Actions — PR review, PR re-review, issue
+triage, issue/PR conversation, auto-fix, release notes, PR postmortems, and the proactive
+weekly audit — plus the new capabilities Jeremy and Kalin want (PR triage, issue triage,
+issue review). (The auth canary is a 2-line liveness probe, not agent work; the live
+doc-walkthrough is repo-specific and deferred — both are out of scope, see §2.) It **consolidates
+the pre-existing milestone [#43 "GitHub Agent"](https://github.com/amd/gaia/milestone/43)** and its
+15 issues (the maintainer-side pull tooling) with this event-driven-bot half into one agent (§13).
+It ships as an installable package that drops into any repo's GitHub workflows
+with **one config file and one workflow file**, and it runs the same way on GitHub-hosted CI,
+a self-hosted runner, or as a standing webhook service (the shape `lemonade-sdk/repo-manager`
+already deploys).
+
+> **This revision incorporates two things the first draft only gestured at:** (1) GAIA's
+> **Agent Skills** work — milestone [#60](https://github.com/amd/gaia/milestone/60), format
+> locked (#691), Phase-1 loader planned (#888) — so the agent's behaviours are authored as
+> portable `SKILL.md` files, not hardcoded prompts (§8); and (2) an actual source analysis of
+> [`lemonade-sdk/repo-manager`](https://github.com/lemonade-sdk/repo-manager), which turns out
+> to be **already skill-driven** (agentskills.io `SKILL.md` + bundled scripts, run through Pi),
+> so its skills are directly loadable by GAIA and its orchestration code is concrete evidence
+> for the framework argument (§8.3–8.4).
+
+> **Plain English.** Today `amd/gaia` has ~1,600 lines of hand-written YAML across five Claude
+> workflow files that call the raw Claude Code action with giant inline prompts. It works, but
+> every prompt, every security guard, and every retry is copy-pasted and repo-specific. This
+> scope replaces that with a *packaged agent*: the prompts, tools, safety rails, and retry logic
+> live inside a versioned, tested Python package, and a repo turns the whole thing on by adding a
+> short config file. Upgrades are a version bump, not a YAML rewrite. And because it's a real GAIA
+> agent, it gets the reliability machinery (timeouts, fail-loud errors, loop-breaking, a
+> regression eval) that a hand-written prompt doesn't have.
+
+---
+
+## 1. Why an agent instead of more workflow YAML
+
+The current design is a set of prompts glued to `anthropics/claude-code-action` by YAML. That
+has three structural problems this scope fixes:
+
+1. **No reuse across repos.** `lemonade`, `repo-manager`, and `gaia` each need their own copy of
+   the 1,600-line prompt/YAML corpus. A packaged agent is `pip install` + config.
+2. **No runtime safety net.** The raw action runs Claude with `Bash` and a credential in scope
+   and trusts the model to behave. A GAIA agent wraps every action in a bounded loop with
+   per-tool timeouts, fail-loud structured errors, loop/dedup breakers, and typed tool calls
+   (see §6) — the difference between "works while watched" and "safe unattended at scale."
+3. **No regression signal.** Prompt tweaks ship on vibes today. A GAIA agent carries an eval
+   harness (§7) that turns real, already-labeled workflow history into a pass/fail tripwire — no
+   synthetic data required.
+
+> **Plain English.** The pitch to a skeptic is *not* "our prompt is smarter than yours." A
+> hand-written prompt is a fine spec. The value is everything *around* the prompt: it can't hang,
+> it won't double-post (once the GitHub write tools are wired into the base agent's existing
+> dedup/timeout machinery — §6), it fails with a clear error instead of silently, it's the same
+> code in every repo, and when you change a prompt you find out in seconds whether you broke
+> something — instead of three weeks later in production.
+
+---
+
+## 2. Capability catalog — everything it must do
+
+Mapped from the five current Claude workflows (`docs/reference/claude-ci-workflows.md`) plus the
+Jeremy/Kalin list. Each capability becomes a **task mode** of the one agent (§4), selected by the
+triggering event.
+
+| # | Capability | Trigger today | Source | Notes |
+|---|-----------|---------------|--------|-------|
+| 1 | **PR review** (full, deep) | PR opened/reopened/ready | `claude.yml` pr-review | Two-part output (visible summary + collapsed technical), security escalation, suggestion blocks |
+| 2 | **PR re-review** (light, delta) | push to PR (`synchronize`) | `claude.yml` pr-rereview | Flags only *new* regressions; silent otherwise |
+| 3 | **PR triage** *(new)* | PR opened | Jeremy/Kalin | Label, size, area routing, reviewer suggestion, "needs tests/docs" flags |
+| 4 | **Issue triage** *(new)* | issue opened | Jeremy/Kalin | Label (bug/feature/question/dup), severity, area, dedup-search, ask-for-repro |
+| 5 | **Issue review** *(new)* | issue opened / labeled | Jeremy/Kalin | Deeper "is this actionable / is root cause locatable" assessment |
+| 6 | **Issue & PR conversation** | new issue, `@agent` mention | `claude.yml` issue-handler + pr-comment | Conversational Q&A; docs-aware |
+| 7 | **Auto-fix** | `bug` label added | `claude.yml` auto-fix | Branch → fix → validate (lint+unit) → PR (draft if unvalidatable) → comment |
+| 8 | **Release notes** | release tag published | `claude.yml` release-notes | Generate notes + MDX, bump version, update nav |
+| 9 | **PR postmortem** | PR merged | repo-manager (existing) | Retrospective analysis of merged work |
+| 10 | **Proactive audit** | weekly/monthly cron | `claude-weekly-audit.yml` | 5-dimension fan-out → ranked triage issues, human-gated, dedup keys |
+| 11 | **Live doc walkthrough** | weekly cron | `claude-weekly-doc-walkthrough.yml` | Runs the product for real on a self-hosted runner (out of scope v1 — see §11) |
+| 12 | **Auth/health canary** | monthly cron | `claude-auth-canary.yml` | Cheap liveness probe; opens issue if auth broken |
+
+> **Plain English.** Think of it as one worker that knows how to do a dozen repo chores. Which
+> chore it does is decided by what just happened on GitHub: a new PR → review it; a push → quick
+> re-check; a new issue → triage and answer it; a `bug` label → try to fix it; a merge → write the
+> postmortem; a Monday → sweep the whole repo for rot. Same worker, same install, twelve jobs.
+
+---
+
+## 3. High-level architecture
+
+```
+  ┌──────────────────────────── Usage surfaces (§9) ────────────────────────────┐
+  │ INTERACTIVE                                    HEADLESS                       │
+  │  Agent UI (browser) ─┐                          CI workflow.yml ─┐           │
+  │  Go TUI (gaia-tui) ──┤─▶ daemon /api/chat/send  Webhook service ─┤─▶ gaia-   │
+  │                       │   → registry.create_agent  Local CLI ─────┘  github  │
+  └───────────────────────┼──────────────────────────────────────────┼──────────┘
+                          └───────────────┬──────────────────────────┘
+                          all converge on  │  agent.process_query(...)
+                                           ▼
+                    ┌─────────────────────────────────────────────┐
+                    │      GaiaGitHubAgent (Agent subclass)        │
+                    │  · task modes (review / triage / fix / …)    │
+                    │  · skills (SKILL.md, §8) + GitHub @tools     │
+                    │  · policy layer (dry-run, write-gating §3.3) │
+                    └───────────────────┬─────────────────────────┘
+                                        │  base Agent runtime
+                    ┌───────────────────┼─────────────────────────┐
+                    ▼                   ▼                         ▼
+          bounded agent loop     LLM provider(s)          GitHub REST API
+          timeouts / fail-loud   Lemonade / Claude /      (GITHUB_TOKEN or
+          dedup / structured     OpenAI via factory       PAT connector)
+          output (§6)            + escalation (§5)
+```
+
+The two interactive surfaces reach the agent through the **daemon** (never the legacy `gaia` CLI);
+the headless surfaces reach it through the **`gaia-github` single-shot CLI**. Both endpoints call
+the identical `process_query` — see §9 for the full surface-by-surface scope.
+
+The agent is a normal `Agent` subclass (`src/gaia/agents/base/agent.py`) — it inherits the whole
+reliability runtime for free (§6) and adds three things: **GitHub tools**, **task modes**, and a
+**write-policy layer**.
+
+### 3.1 The agent class
+
+`GaiaGitHubAgent(ApiAgent, Agent)` with `AGENT_ID = "github"`, shipped at
+`hub/agents/github/python/gaia_agent_github/agent.py`. It composes a new `github` tool mixin
+(§3.2) and selects a **task mode** at `process_query` time from the event context.
+
+> ⚠️ **See §14.1 (authoritative):** packaged/run as a **daemon HTTP sidecar** (the email pattern),
+> not an in-process wheel. The class + tools + modes below are unchanged; only the process boundary
+> moves out-of-process, and the sidecar wraps `process_query` behind `POST /v1/github/agent/query`.
+
+### 3.2 GitHub tool mixin (`GitHubToolsMixin`)
+
+GAIA ships **zero** GitHub tools today — this is the main net-new code. A thin `@tool` layer over
+GitHub REST (via `httpx`), registered in `KNOWN_TOOLS` (`src/gaia/agents/registry.py`) as
+`github` so any agent can reuse it. Auth token comes from the environment (`GITHUB_TOKEN` in CI)
+or the `mcp-github` PAT connector (service/local mode — see §9). Tools split into read and write,
+with every write gated by the policy layer (§3.3):
+
+- **Read:** `get_pr_diff`, `get_pr_files`, `list_pr_comments`, `get_issue`, `search_issues`,
+  `get_commit_history`, `compare_refs`, `read_repo_file`.
+- **Write (policy-gated):** `post_pr_review`, `post_issue_comment`, `reply_to_review_comment`,
+  `add_labels`, `remove_labels`, `assign_reviewers`, `create_branch`, `commit_files`,
+  `open_pr`, `edit_release`.
+
+> **Plain English.** Right now the workflows let Claude shell out to the `gh` CLI to do all this.
+> That works but it's unstructured — the model builds a raw command as text. Turning each action
+> into a typed tool (`add_labels(["bug"])` instead of a free-text `gh` string) means the framework
+> can validate it, time it out, refuse it under policy, and stop it from firing twice. It's the
+> same actions, but on rails.
+
+### 3.3 Write-policy layer
+
+The base agent **auto-approves** tool confirmations when running unattended
+(`console.py:225`). For an agent with destructive GitHub tools that is unsafe by default, so the
+GitHub agent adds an explicit policy gate around every write tool:
+
+- **`dry_run`** — writes are logged, not executed (default for a first rollout in a new repo).
+- **`allow` / `deny` per tool** — e.g. allow `post_pr_review` + `add_labels`, deny `commit_files`
+  until a repo opts in to auto-fix.
+- **Human-gate mirror** — the audit's "findings only, never commits; a human applies `bug` to
+  trigger a fix" rule (from `claude-weekly-audit.yml`) is encoded here, not re-implemented per repo.
+
+---
+
+## 4. Task modes
+
+Each capability in §2 is a **mode**: a system-prompt fragment + an allowed-tool set + a policy
+profile. The mode is chosen from the GitHub event, so the *same* agent process handles any event.
+
+```python
+# illustrative — not final API
+MODES = {
+    "pr_review":     Mode(prompt=PR_REVIEW, tools=READ + ["post_pr_review"],       policy="comment_only"),
+    "pr_rereview":   Mode(prompt=PR_REREVIEW, tools=READ + ["post_pr_review"],     policy="comment_only_silent_default"),
+    "pr_triage":     Mode(prompt=PR_TRIAGE, tools=READ + ["add_labels","assign_reviewers"], policy="label_only"),
+    "issue_triage":  Mode(prompt=ISSUE_TRIAGE, tools=READ + ["add_labels","post_issue_comment"], policy="label_and_comment"),
+    "issue_review":  Mode(prompt=ISSUE_REVIEW, tools=READ + ["post_issue_comment"], policy="comment_only"),
+    "converse":      Mode(prompt=CONVERSE, tools=READ + ["post_issue_comment","reply_to_review_comment"], policy="comment_only"),
+    "auto_fix":      Mode(prompt=AUTO_FIX, tools=READ + WRITE_CODE,               policy="branch_pr_gated"),
+    "release_notes": Mode(prompt=RELEASE_NOTES, tools=READ + ["commit_files","edit_release"], policy="release_gated"),
+    "postmortem":    Mode(prompt=POSTMORTEM, tools=READ + ["post_issue_comment"], policy="comment_only"),
+    "audit":         Mode(prompt=AUDIT, tools=READ_ONLY,                          policy="findings_only"),
+}
+```
+
+The prompts are **ported from the existing workflows** (they are already battle-tested and encode
+the two-part output format, the untrusted-input rules, the security-escalation protocol, the nit
+caps). The port moves them out of YAML into the package as prompt fragments, so they are versioned,
+diffable, and eval-tested — and shared across repos instead of copy-pasted.
+
+> **Plain English.** We are not throwing away the good prompts we already have — they took a lot of
+> tuning. We are lifting them out of the giant YAML files and into the agent package, where they can
+> be tested and reused. A mode is just "which prompt + which tools + what it's allowed to write."
+
+### 4.1 Choosing the mode — event-driven vs. eventless surfaces
+
+Two resolution paths, because the surfaces differ:
+
+- **Event-driven (CI / webhook):** the GitHub event *is* the selector — `pull_request_target
+  opened → pr_review`, `issues opened → issue_triage`, `bug label → auto_fix`. Deterministic; no
+  LLM needed to pick the mode.
+- **Eventless (Agent UI / TUI / `gaia-github "<nl>"`):** there is **no event** — the agent must
+  turn free text ("review PR 123 in amd/gaia") into `(mode, params)`. This needs an
+  **intent-classification front-half**, modeled on the existing `RoutingAgent`
+  (`hub/agents/routing/python/gaia_agent_routing/agent.py` — an LLM pass inside `process_query`
+  that maps NL → a target). The explicit CLI form (`gaia-github run pr-review --pr 123`) bypasses
+  it for scripts.
+
+> ⚠️ **This was a real gap in the first draft** — it assumed "mode from the event" everywhere, but
+> the interactive surfaces have no event. The NL→mode classifier is required work for §9.2/9.3, not
+> free.
+
+---
+
+## 5. LLM provider & escalation
+
+The agent talks to the LLM through GAIA's provider factory (`src/gaia/llm/factory.py`), so the
+same code runs on any GAIA LLM provider (Lemonade / Claude / OpenAI) without change:
+
+- **CI mode (GitHub-hosted runner):** Claude via `CLAUDE_CODE_OAUTH_TOKEN` (subscription) or
+  `ANTHROPIC_API_KEY`, matching today's auth. No local model — GitHub runners have no NPU.
+- **Self-hosted / service mode:** local Lemonade (NPU/GPU) for cheap high-volume triage, escalate
+  the genuinely hard cases (deep review, auto-fix) to Claude.
+
+**Escalation** is not built today; the clean seam (from the LLM analysis) is a new
+`EscalatingProvider(LLMClient)` composite registered in the factory: it *is* an `LLMClient`, so no
+call sites change. It runs the cheap model, inspects a confidence/complexity signal, and re-calls
+the strong model only when needed.
+
+> **Plain English.** On GitHub's own runners there's no AMD chip, so it uses Claude in the cloud
+> like today. But when it runs on Kalin's own hardware or the repo-manager server, it can do the
+> cheap, high-volume work (labeling issues, first-pass triage) on the local Ryzen AI model and only
+> pay for Claude on the hard stuff (a deep review, writing a fix). That's a real cost and privacy
+> lever the current all-cloud setup can't offer — and it's the natural argument for running this on
+> Lemonade hardware.
+
+> ⚠️ **Honest gap.** The provider abstraction supports this cleanly, but the escalation composite
+> and a cross-provider tool-call normalization (Lemonade returns native tool-calls as a
+> sentinel-keyed JSON string; Claude/OpenAI return plain text) are net-new work. Text-only
+> escalation is easy; tool-calling escalation needs the normalization layer.
+
+> ⚠️ **Subscription rate-limit budgeting (do not skip).** The current workflows hand-tune around a
+> hard constraint this spec must inherit: all Claude jobs draw on **one Max-subscription OAuth
+> token with a rolling 5-hour rate limit**. `claude-weekly-audit.yml` runs its five dimensions at
+> `max-parallel: 1` *specifically* to stay under it. A packaged agent fanning out review + triage +
+> audit across *multiple repos* on one token will hit that ceiling and silently start failing runs.
+> So the CI surface (§9.5) needs a **subscription-aware serialization / budget** (concurrency cap,
+> per-repo throttle, or a billed-key fallback — Open Decision #1), and the config must expose it.
+> Local-model triage (§5) is the main pressure valve: keep cheap high-volume work off the shared
+> Claude quota.
+
+---
+
+## 6. Reliability foundations (inherited from the base Agent)
+
+These are the concrete reasons a packaged agent beats a raw prompt for unattended work. All exist
+in `src/gaia/agents/base/agent.py` today:
+
+- **Bounded, self-terminating loop** — step-capped (`DEFAULT_MAX_STEPS`, env-tunable) and it
+  **never blocks on `input()` off a TTY**, so a CI run stops instead of hanging.
+- **Per-tool hard timeout** — every tool runs in a daemon thread under a 180s (tunable) timeout
+  (`_call_tool_bounded` → `ToolExecutionTimeout`). A flaky GitHub API call can't wedge the run.
+- **Fail-loud structured errors** — tool exceptions return structured error objects (never
+  swallowed), backend errors are classified, and the run reports a full trace.
+- **Loop & duplicate-action breakers** — consecutive-repeat detection with an honest failure
+  summary, plus input-based mutation dedup so a label/comment/PR action can't fire twice. The
+  mutation set is email-centric today and **must be extended** with the GitHub write tools.
+- **Bounded, no-hidden-retry recovery** — one context-overflow retry, no blind retry loops
+  (matches the "no silent fallbacks" rule).
+
+> **Plain English.** This is the "it won't do something dumb at 3am" layer. It can't run forever,
+> it can't get stuck on a hung network call, it doesn't hide errors, and it won't post the same
+> comment five times because it looped. A hand-written prompt in a YAML file has none of this — you
+> get it for free by building on the agent base class.
+
+> ⚠️ **Honest gaps to close (from the code analysis):** (a) the base does argument *presence*
+> checks but not type/enum validation — validate inside each GitHub tool body; (b) run `status`
+> flips to `"failed"` on *any* recovered error, so success gating must inspect error *types*, not
+> `status`; (c) extend the mutation-dedup set; (d) add the write-policy deny layer (§3.3) since the
+> base auto-approves unattended.
+
+---
+
+## 7. Quality: the eval harness as a regression tripwire
+
+This is the direct answer to "measure health via vibes." GAIA's `gaia eval agent` framework
+(`src/gaia/eval/`) needs **no synthetic data** and runs on a **handful of hand-labeled scenarios**:
+
+- A scenario is one YAML file; ground truth can be a plain-English `success_criteria` string
+  ("PASS if labeled `bug` and routed to backend; FAIL if labeled `enhancement`").
+- `--compare` diffs two scorecards and **exits non-zero on any regression** → drops straight into
+  CI as a gate on prompt changes.
+- `--capture-session` turns a *real* conversation into a scenario — the opposite of synthetic.
+- `--fix` runs a Claude loop that tunes the prompt until the eval passes, with a guard that blocks
+  fixes which regress other scenarios.
+- The judge's score is recomputed deterministically, so it can't hallucinate a pass.
+
+**Kalin already has the data:** the merged-PR postmortems and existing Claude-workflow history are
+real, labeled examples — exactly the input this wants. No synthetic generation anywhere.
+
+> **Plain English.** The worry with "just write a Skill and eyeball it" is that once you have five
+> skills, tweaking one silently breaks another and you won't notice until a user does. The eval is
+> a cheap safety net: you write a dozen real examples with the answer you expect, and one command
+> tells you — in seconds — whether a prompt change made anything worse. It uses your real PR/issue
+> history, not made-up data.
+
+> ⚠️ **Honest gap.** The eval runner currently drives agents through the *Agent-UI backend over
+> MCP*. The GitHub agent has a different interface (GitHub events), so a transport adapter is needed
+> so the runner can drive it directly — **budget this as medium** (the runner is structurally
+> coupled to a UI-MCP session; see §13.7), not the "small" the first draft implied.
+
+---
+
+## 8. Skills — the authoring layer (grounds on milestone #60 + repo-manager)
+
+The agent's behaviours (review, triage, postmortem, announce) are authored as **portable
+`SKILL.md` files**, not hardcoded Python prompts. This is not greenfield invention — it sits on
+GAIA's in-flight Agent Skills work and mirrors how `repo-manager` already works.
+
+### 8.1 What already exists (milestone #60)
+
+| Piece | Issue | Status | What it gives us |
+|-------|-------|--------|------------------|
+| `SKILL.md` format (agentskills.io base + `metadata.gaia`) | #691 | **locked** | The on-disk contract — the *same format Claude Code / repo-manager use* |
+| Phase-1 runtime loader (`gaia.skills`, discovery, `gaia skill` CLI, `<skill>/<tool>` namespacing) | **#888** | **not started — critical path** | Load an authored `SKILL.md` into an agent at runtime |
+| Reference consumer: email agent bundled skills + **`skill_sets:`** (per-context, mutually-exclusive skill bundles) | #2466 | planned, blocked on #888 | The pattern for per-repo / per-mode capability selection |
+| Procedural memory / auto-synthesis | #887/#1451 | **shipped, separate corpus** | Learned skills from the agent's own runs — do **not** unify with authored skills |
+
+**The load-bearing constraints from #888 that this spec must respect:**
+- v1 discovery = three roots (agent-bundled `skills/<name>/`, `~/.gaia/skills/`, `.claude/skills/`
+  read-only). We use the **agent-bundled** root to ship the GitHub agent's default skills.
+- v1 permissions are **connector-bridged only** (`network`/`mcp`). Local-capability permissions
+  (`filesystem`/`shell`/…) are **refused with a clear error**, not sandboxed. So the GitHub
+  agent's *write actions stay in typed Python `@tool`s* (§3.2) — skills carry the *procedure*,
+  tools carry the *action*. This division is exactly what the milestone intends.
+
+> **Plain English.** GAIA is already building the machinery to load hand-written skill files —
+> the format is finalized and the loader is the next thing on the skills roadmap. We don't build
+> a skill system; we become its second showcase (after the email agent). Each of the agent's jobs
+> becomes a small Markdown file a human can read and edit, and a repo can override one without
+> touching code.
+
+### 8.2 The GitHub agent as the second reference consumer
+
+Ship the task modes (§4) as bundled skills at `hub/agents/github/python/skills/<mode>/SKILL.md`,
+and use #2466's `skill_sets:` to select per context:
+
+```yaml
+# gaia-agent.yaml (excerpt) — reuses the #2466 skill_sets mechanism
+skills:              # always on
+  - github-common
+skill_sets:
+  review:   { skills: [pr-review, pr-rereview] }
+  triage:   { skills: [pr-triage, issue-triage, issue-review] }
+  release:  { skills: [release-review, release-announcement, postmortem] }
+```
+
+Per-repo override then means dropping a `SKILL.md` in a **trusted base-ref path** (never the PR
+working tree — §10) to replace or extend a default skill. That is the "dead simple integration"
+promise (§9) expressed through the skill layer, and it is Jeremy's exact authoring model.
+
+### 8.3 repo-manager, analyzed — it is already an agentskills.io runner
+
+Source read of [`lemonade-sdk/repo-manager`](https://github.com/lemonade-sdk/repo-manager)
+(`repo_manager/cli.py`, `skills/*/SKILL.md`). Its architecture:
+
+- **A deterministic Python CLI + SQLite orchestrator** that shells out to **Pi**:
+  `pi --mode json --skill <path>/SKILL.md` with the prompt on stdin, streaming JSON events
+  (`cli.py:189`). The skill writes a JSON/Markdown **artifact to a caller-supplied path**; the
+  CLI reads it back and stores parsed fields to SQLite (`store_commit_review`, `cli.py:707`).
+- **Three hand-authored agentskills.io skills** with bundled `gh`/`git` bash `scripts/`:
+  `commit-review`, `release-review`, `release-announcement` — each a `SKILL.md` frontmatter
+  (`name`/`description`) + body + JSON output contract.
+- **SQLite = source of truth; GitHub issues = sync target** (checklist issue with checkboxes,
+  release-notes + announcement issues); a **static dashboard published to GitHub Pages**; a
+  cross-machine **`pull` merge** for onboarding.
+- Maintainer-in-the-loop: it stores only the *proposed* announcement and feeds maintainer issue
+  comments back into regeneration.
+
+**These three skills map 1:1 onto our task modes** — the *frontmatter* is portable, but the
+**bodies are not drop-in runnable**:
+
+| repo-manager skill | GAIA GitHub agent mode (§4) |
+|--------------------|------------------------------|
+| `commit-review` | `postmortem` |
+| `release-review` | `release-review` (new) |
+| `release-announcement` | `release_notes` / announce |
+
+> ⚠️ **Correction (verified — supersedes any "load unchanged" claim).** repo-manager's skills do
+> their real work through **bundled `gh`/`git` bash `scripts/`**. Two facts break a drop-in:
+> (1) a bare agentskills.io `SKILL.md` (no `metadata.gaia`) loads **instruction-only** — no tools,
+> no permissions — so the scripts that touch GitHub have no execution path; and (2) **#888 Phase 1
+> doesn't bridge or even refuse `shell`/`filesystem` — that's Phase 2** (`skill-format.mdx`),
+> unbuilt. So real parity requires: the `GitHubToolsMixin` (§3.2) exists, **each skill body is
+> re-pointed from bash scripts to those typed tools**, and #888 has landed. It is a *body rewrite*,
+> not a copy — budget it as such. The win that survives: the *procedure* text and the format are
+> portable, and the switch pitch (§8.4) still holds.
+
+### 8.4 The framework argument, now evidenced from Jeremy's own code
+
+repo-manager hand-builds in Python exactly the reliability GAIA's base agent + eval provide as
+primitives. This is the concrete "framework vs. barebones-agent-plus-skills" case, against real code:
+
+| What repo-manager hand-codes | Why (Pi output is untyped) | GAIA primitive that subsumes it |
+|------------------------------|----------------------------|---------------------------------|
+| `extract_todo_list` + `TODO_LIST_KEY_HINTS` — liberal key-matching because "Pi does not reliably emit the documented keys" (`cli.py:479`) | Untyped free-text output | **Typed `@tool` / structured-output schema** — the shape is validated, so this whole class of parsing code disappears |
+| `normalize_release_review_data` recomputes the verdict from the to-do list so the model can't contradict itself (`cli.py:549`) | Can't trust the LLM's own verdict | Same pattern GAIA's **eval judge** uses (deterministic score recompute) — and a `@tool` returns already-validated data |
+| `announce` validation + **3× auto-retry** with resumable pending feedback | No built-in retry loop | **Agent structured-output retry** + eval **`--fix`** loop |
+| False-green regex guards ("empty to-do list but prose says 'blocker'", `cli.py:578`) | No error classification | **Fail-loud** structured errors + the reliability layer (§6) |
+| Rubric-versioned re-review; artifact→SQLite; issue sync | Bespoke orchestration | GAIA **service mode** (§9.4) + the eval **`--compare`** regression gate (§7) |
+
+> **Plain English.** repo-manager is genuinely good engineering — but a big share of its code
+> exists only to babysit an untyped agent: guessing which key the answer landed under, recomputing
+> the verdict so the model can't lie about it, retrying three times when the output is malformed.
+> A GAIA agent gets those for free from typed tools, structured output, and the eval loop. That's
+> the switch pitch in one line: *keep your skills, delete the babysitting code.*
+
+### 8.5 Integration path with repo-manager (the "deploy it anyway" offer)
+
+Two concrete options, in increasing ambition — both let Jeremy keep his orchestrator and skills:
+
+1. **GAIA as the skill engine (drop-in for Pi).** Replace `pi --mode json --skill X` with the
+   GAIA GitHub agent loading skill `X`. repo-manager's CLI, SQLite, issue-sync, and Pages
+   dashboard are unchanged; only the inference engine swaps — now with the §6 reliability runtime
+   and local-model/escalation (§5). Lowest-friction; proves parity fast.
+2. **GAIA service mode absorbs the orchestrator (§9.4).** The GitHub agent's webhook service
+   provides the artifact-store + issue-sync + dashboard equivalents natively, and repo-manager's
+   skills run on it directly. Higher ambition; the endpoint of "I may just deploy that in my gaia
+   repo anyway."
+
+> ⚠️ **Honest dependency.** Everything in §8 rides on **#888 landing**. Until it does, the GitHub
+> agent ships its mode prompts as in-package fragments (§4) behind a thin interim loader, authored
+> in the `SKILL.md` shape so the switch to the real loader is a no-op. The `skill_sets` selection
+> (§8.2) additionally depends on #2466. Don't claim skill portability before #888 is merged.
+
+## 9. Usage surfaces — as easy as Pi
+
+This is the core UX requirement: the agent must be equally usable **(A) interactively via the
+Agent UI and the Go TUI** and **(B) as a one-liner in a repo's `workflow.yml`**. Both must be as
+frictionless as Pi (`/skill:commit-review OWNER/REPO SHA` interactively; `repo-manager
+review-commit SHA` in scripts).
+
+### 9.1 One core, five surfaces (the design invariant)
+
+There is exactly **one** agent implementation. Every surface converges on the same
+`agent.process_query(...)` call; only the shell that wraps it differs. Nothing is
+surface-specific except the adapter that turns an event/keystroke into a query and the sink that
+carries the output.
+
+| Surface | Reaches the agent via | Output sink | Auth |
+|---------|----------------------|-------------|------|
+| **Agent UI** (browser) | daemon `POST /api/chat/send` → `registry.create_agent` → `process_query` | SSE events (`SSEOutputHandler`) | `mcp-github` PAT connector (per-agent grant) |
+| **Go TUI** (`gaia-tui`) | daemon HTTP/SSE *(target)* or subprocess JSONL *(today)* | terminal render of the same events | same connector |
+| **CI `workflow.yml`** | reusable action → `gaia-github` single-shot CLI → `process_query` | posts comment/label/PR via GitHub tools | `GITHUB_TOKEN` |
+| **Local CLI / service** | `gaia-github "<nl>"` · webhook → dispatch | stdout / GitHub API | PAT connector / `GITHUB_TOKEN` |
+| **Chat app** (Slack/Teams, opt · §9.8) | outbound: `sinks.py` POST · inbound: messaging adapter → `process_query` | channel message / threaded reply | webhook (out) · bot/app token (in) |
+
+> **Plain English.** Build the brain once; give it many mouths. Whether a request arrives from a
+> browser click, a terminal, a CI event, or a webhook, it runs the *same* code and behaves the
+> same way. That's what keeps "works in the UI" and "works in CI" from drifting into two agents.
+
+### 9.2 Interactive — Agent UI (browser, through the daemon)
+
+**This surface is nearly free** given how the daemon already exposes agents. Ship
+`gaia-agent-github` as a wheel with a `gaia.agent` entry point (an `Agent` subclass or
+`build_registration()`), and:
+
+- It is **auto-discovered** — `registry.discover()` scans the `gaia.agent` entry-point group, no
+  allowlist — and appears in `GET /api/agents` as a selectable card.
+- A session created with `agent_type: "github"` is instantiated per turn via
+  `registry.create_agent("github", …)` through the generic dispatch branch in `_chat_helpers.py`
+  — the same path `browse`/`analyze`/`jira` already use. No UI-specific code.
+- Tool calls, steps, thinking, and the final answer stream to the UI through `SSEOutputHandler`
+  automatically (`tool_start` / `tool_result` / `answer` events); cancel and re-attach work for free.
+- Ship hub card metadata (name, icon, category, and `conversation_starters` like *"Review PR #123
+  in amd/gaia"*, *"Triage the new issues"*) so the card is self-explanatory.
+
+**Interactive write-gating comes built in.** A destructive tool raises the SSE `permission_request`
+event, which the UI answers via `POST /api/chat/confirm-tool` — so in the UI a write (post review,
+add label, open PR) *asks the user*, while in CI the same tool is governed by the policy layer
+(§3.3). Same tool, surface-appropriate gate.
+
+**UX target:** pick the GitHub Agent card → type *"review PR 123 in amd/gaia"* → watch the tools
+stream → approve the post. That is the Pi `/skill:` experience, in the browser.
+
+### 9.3 Interactive — Go TUI (`gaia-tui`)
+
+> ⚠️ **Updated by §14.2:** the email pattern is HTTP/SSE, so path (b) `--json-events` is dropped —
+> do the shared daemon→SSE `AgentClient` in the TUI (path a), which is the only pattern-faithful
+> route and lights up email in the TUI too. No sidecar (email included) runs in the TUI today.
+
+**Honest current-state gap.** The TUI today does **not** talk HTTP to the daemon: it spawns agent
+*binaries* as subprocesses and reads newline-delimited JSON from stdout (`SubprocessClient`). Its
+`AgentClient` interface anticipates an "API (SSE) mode," but **that client doesn't exist yet** —
+the Python agents in its catalog are placeholders marked *"need API client mode"*; only the C++
+bash agent is launchable. So neither the GitHub agent nor any Python agent works in the TUI today.
+
+Two paths make the GitHub agent work there:
+
+- **(a) Preferred — add the daemon HTTP/SSE client to the TUI (shared infra).** Implement the
+  missing `AgentClient` against the daemon's `POST /api/chat/send` SSE stream. Once it lands,
+  **every** daemon-registered agent — GitHub included — works in the TUI with zero per-agent code,
+  and the TUI stops shelling out (matching the target architecture: daemon backend + two HTTP
+  front-ends). This is the right fix and it unblocks all Python agents, not just this one.
+- **(b) Interim bridge — a new `--json-events` subprocess emitter (verified: cheaper than a rewrite,
+  but NOT free today).** The good news, confirmed against the code: the TUI parser's 13 event types
+  are **snake_case and already identical** to what `SSEOutputHandler` emits (`tool_start`,
+  `tool_args`, `tool_result`, `step`, `thinking`, `plan`, `chunk`, `answer`, `agent_error` —
+  `tui/internal/event/types.go`, `src/gaia/ui/sse_handler.py`). **No schema/case translation is
+  needed.** The gap is plumbing, and it is real: `src/gaia/agents/base/server.py` has `--pipe`
+  (final **plain-text** answer only) and **no `--json-events` mode**, and `SSEOutputHandler` writes
+  to an in-process queue for HTTP, not to stdout. So path (b) requires: (i) a new `--json-events`
+  entry that reads one query line from stdin (`subprocess.go` sends `query\n`), runs the agent with
+  an `SSEOutputHandler`, and drains its queue to stdout as one JSON object per line; (ii) a terminal
+  `answer`/`done` line (the TUI ends a turn on `answer`/`agent_error`/`done` — the current `None`
+  queue sentinel is not JSON); (iii) **auto-deny/background mode for `permission_request` /
+  `user_input_request`** (the TUI parser doesn't recognize them and would hang the agent waiting on
+  a frontend that isn't there); plus a TUI catalog entry with a resolvable `BinaryPath` (`gaia-github
+  --json-events`).
+
+**Recommendation:** do (a) — it's the architecture the memory/roadmap already commits to and it's
+strictly more valuable. Path (b) is a viable stopgap **because the event vocabulary already lines
+up** — but it is a small new emitter + auto-confirm shim, not a config flag; don't promise "works
+today" until that shim ships. Either way the agent core is unchanged; this is TUI-side plumbing.
+
+### 9.4 Service / webhook mode (repo-manager parity)
+
+For Kalin's existing `lemonade-server.ai/repo-manager` deployment, the same agent runs as a
+long-lived webhook service: GitHub App/webhook → event → same task-mode dispatch → same tools.
+This reuses the `mcp-github` connector **for the token only** (`get_credential_sync` vends
+`GITHUB_TOKEN`; we do *not* run its bundled MCP server) — keyring-stored, per-agent grants — instead
+of the CI `GITHUB_TOKEN`. **No agent logic changes** between any surface — only the shell and the
+auth source differ.
+
+> ⚠️ **Concurrency gap.** `Agent.process_query` is **synchronous/blocking**. The daemon surfaces
+> already serialize per session (per-session lock + global semaphore in the chat router), and CI is
+> one process per job — both fine. But a webhook service fielding bursts of events must add its own
+> **thread/process pool with a bounded worker count** (each agent instance ≈ 50–100 MB + model
+> context), or events queue head-of-line behind a slow review. Size it like the messaging plan's
+> `max_concurrent_sessions`; don't assume the single-process model scales to a busy repo.
+
+### 9.5 CI — the `workflow.yml` surface (as easy as Pi's CI)
+
+Ship a **reusable workflow** `amd/gaia/.github/workflows/gaia-github-agent.yml` (and/or a
+composite/Docker action `amd/gaia-github-agent@v1`) that generalizes what `claude-run.yml` does:
+
+1. Installs the wheel (`pip install gaia-agent-github`).
+2. Reads a single repo config file (`.github/gaia-github-agent.yml`) **from the base ref** (the
+   same fork-safety trick `claude-run.yml` uses for the review rubric — §10).
+3. Maps the triggering event → task mode and builds context (diff, issue body, …).
+4. Invokes the **`gaia-github` single-shot CLI** (§9.6) — the *same* entry the local/CLI surface
+   uses — and posts the result via the GitHub tools.
+
+A consumer repo's **entire** integration is one thin workflow file:
+
+```yaml
+# .github/workflows/gaia.yml  — the whole integration
+name: GAIA GitHub Agent
+on:
+  pull_request_target: { types: [opened, reopened, ready_for_review, synchronize] }
+  issues:              { types: [opened, labeled, reopened] }
+  issue_comment:       { types: [created] }
+jobs:
+  gaia:
+    uses: amd/gaia/.github/workflows/gaia-github-agent.yml@v1
+    secrets: inherit
+```
+
+…plus a short config that toggles capabilities and models:
+
+```yaml
+# .github/gaia-github-agent.yml  — the whole policy
+capabilities:
+  pr_review:    { enabled: true,  model: claude-opus-4-8 }
+  pr_rereview:  { enabled: true,  model: claude-sonnet-4-6 }
+  pr_triage:    { enabled: true,  model: local }     # cheap model on self-hosted
+  issue_triage: { enabled: true,  model: local }
+  auto_fix:     { enabled: true,  policy: draft_pr_only }
+  audit:        { enabled: true,  schedule: "0 6 * * 1" }
+escalation:
+  from: local
+  to:   claude-opus-4-8
+  when: low_confidence
+security:
+  fork_prs: review_only          # never run fork code; never write on fork events
+  escalate_security_to: "@kovtcharov-amd"
+```
+
+### 9.6 The `gaia-github` CLI single-shot (the shared primitive)
+
+The wheel ships a `gaia-github` console entry following the proven hub-agent pattern (`gaia-code`):
+a single positional query mapped straight to `process_query`, so it works both headless (CI) and
+by hand:
+
+```bash
+gaia-github "review PR 123 in amd/gaia"        # natural language → process_query
+gaia-github run pr-review --pr 123 --repo amd/gaia   # explicit mode, for CI
+gaia-github init                               # scaffold workflow.yml + config into a repo
+gaia-github --json-events                      # subprocess mode for the TUI (§9.3 path b)
+```
+
+> **Naming (resolved).** Everything is the **`gaia-github` console script**, never a `gaia github`
+> subparser — the Python `gaia` CLI is legacy/being phased out, and the Go TUI binary is *also*
+> named `gaia`, so a `gaia github` subcommand would collide. One `console_scripts` entry
+> (`gaia-github`), several verbs.
+
+The reusable action (§9.5) calls exactly this CLI; the daemon calls `process_query` directly. **One
+code path, five surfaces.** `gaia-github init` is the one-command onboarding (writes both files in
+§9.5), so a repo goes from zero to reviewed PRs without hand-copying YAML.
+
+### 9.7 "As easy as Pi" — side by side
+
+| Task | Pi / repo-manager | GAIA GitHub agent |
+|------|-------------------|-------------------|
+| Install | `pi install …` | `pip install gaia-agent-github` (or `gaia hub install github`) |
+| Interactive, one job | `/skill:commit-review owner/repo SHA` | select the card → *"review PR 123 in amd/gaia"* (UI/TUI) |
+| Scripted / CI | `repo-manager review-commit SHA` | `uses: amd/gaia/.github/workflows/gaia-github-agent.yml@v1` + config |
+| Local one-off | `repo-manager …` | `gaia-github "review PR 123 in amd/gaia"` |
+| Add a capability | author a new `skills/<name>/SKILL.md` | author a new `skills/<name>/SKILL.md` (§8) — identical |
+
+> **Plain English.** Four ways in, one brain. In the app or the terminal you pick the GitHub Agent
+> and talk to it in plain English, approving any write it wants to make. In CI you add ~10 lines of
+> YAML and a short config file — done. Turning a capability on or swapping a model is a one-line
+> config edit; adding a new capability is writing one Markdown skill file — the *same* file whether
+> you run it interactively or in CI. That is the bar: no harder than Pi, in more places.
+
+### 9.8 Chat-app surfaces (Slack / Teams / Discord) — optional, split by cost
+
+A chat-app integration is just **another shell** under the §9.1 invariant (a message →
+`process_query` → a reply), so the agent core needs no changes. But it splits into two halves with
+very different cost and value — and it rides GAIA's broader messaging work, not GitHub-agent code.
+
+> ⚠️ **Reality check on GAIA messaging (verified).** Do not assume messaging is a solved
+> foundation. The **only** shipped code is (1) the `schedule/sinks.py` outbound helper (a plain
+> `requests.post`, real and used by `gaia schedule`) and (2) a **Telegram adapter that is
+> Phase-0 *scaffold*, not working support** — its own docstring says "minimal scaffolding for
+> v0.18.2," its optional extra is never installed in CI, and its lone unit test passes *even when
+> the dependency is missing and the adapter is non-functional* (asserts an attribute exists, never
+> connects or routes a message). It's documented in `docs/guides/telegram-adapter.mdx` as if
+> supported — that claim is overstated. Treat Telegram as prototype, not precedent; the inbound
+> messaging framework is genuinely greenfield.
+
+**(a) Outbound notification — cheap, high value, do first.** Post review summaries, triage
+verdicts, weekly-audit digests, and **release announcements** to a channel. This reuses the one
+genuinely-real piece — the outbound dispatch in `src/gaia/schedule/sinks.py` (the `_to_telegram`
+`requests.post` pattern, wired into `gaia schedule` with tests); adding `_to_slack` (incoming
+webhook) and `_to_teams` (connector-card / workflow webhook) is a small, self-contained change in
+the same shape. In the repo config it's one block:
+
+```yaml
+notify:
+  slack:  { webhook: "${SLACK_WEBHOOK}",  on: [pr_review, audit, release_notes] }
+  teams:  { webhook: "${TEAMS_WEBHOOK}",  on: [release_notes] }
+```
+
+> **This directly generalizes what repo-manager already does** — its `release-announcement` skill
+> writes Discord markdown that a maintainer posts. The GitHub agent *produces* that announcement
+> (§8.3) and can *deliver* it in the same run, collapsing two steps into one.
+
+**(b) Inbound interactive — `@gaia review PR 123` from a channel — separate track.** This is a real
+usage surface (message → `process_query` → threaded reply), but there is **no reusable messaging
+framework today**: the Telegram adapter is scaffold-grade (see the reality check above), and the
+`MessagingAdapter` ABC / `MessageRouter` / `SessionManager` are **planned, not built** (messaging
+plan, #635, P2). So inbound means building that shared framework first *or* a bespoke
+~500–800-line/platform adapter — not something the
+GitHub agent should carry alone.
+
+**Honest constraints (from the analysis):**
+- **Teams is the hardest and isn't in the plan.** Its Bot Framework inbound needs a **public
+  webhook URL**, which conflicts with GAIA's local-first model. **Slack Socket Mode needs no public
+  URL** — so Slack is the better first inbound target; Teams inbound realistically wants the service
+  mode (§9.4) or a tunnel. (Teams *outbound* via a workflow/incoming webhook is fine and cheap.)
+- **Auth:** no Slack/Teams connector exists yet (Slack = bot + app token for Socket Mode; Teams
+  could later ride the existing Microsoft/Graph connector). Tokens via env/connector, never config.
+- **Target the daemon, not the legacy `gaia telegram` PID-file process** — new adapters should be
+  daemon-integrated per the go-forward architecture.
+- **Untrusted input:** a channel message is external input — apply the §10 posture (restricted
+  default tools, channel/user allow-lists, confirm-first writes via platform buttons, rate limits).
+
+**Recommendation:** ship **(a) outbound now** — it's small, reuses `sinks.py`, and delivers the
+repo-manager-style announcement end-to-end. Treat **(b) inbound** as a fast-follow that lands with
+the shared messaging framework (#635), **Slack (Socket Mode) before Teams**. Neither is v1-critical
+for the GitHub agent; the Agent UI / TUI / CI surfaces (§9.2–9.6) are the ones that must ship first.
+
+---
+
+## 10. Security model (carried over, not reinvented)
+
+The current workflows encode hard-won fork-safety lessons. The agent and its reusable action must
+preserve every one — this is non-negotiable and is a big part of why a *shared, reviewed* package
+beats per-repo YAML that can drift:
+
+- **Never execute PR code.** Read the diff, post comments; no `pip/npm install`, no build, no
+  running checked-out code. (`claude.yml` header rule.)
+- **Untrusted input is data, not instructions.** Diffs, issue/PR bodies, and any working-tree
+  `REVIEW.md`/`CLAUDE.md` on a fork are attacker-controlled — the agent treats them as content and
+  flags injection attempts. Policy/config is read **only from the base ref**.
+- **Fork PRs run under base-repo permissions** (`pull_request_target`) with least-privilege scopes
+  and **review-only** writes; code-writing modes (auto-fix) never run on fork events.
+- **Secret scrubbing** in any subprocess; credentials never echoed.
+- **Security findings stay private** — never post exploit detail publicly; count + run-log pointer
+  + `@kovtcharov-amd` tag, mirroring the audit's protocol.
+- **Human-gated writes** — the audit files findings only; a maintainer applies `bug` to trigger a
+  fix; branch protection + mandatory review bound the auto-fix blast radius.
+
+> **Plain English.** A bot that reads pull requests from strangers and holds a credential is a
+> juicy target. The current workflows have carefully-tuned guardrails against that (don't run the
+> stranger's code, treat their text as untrusted, keep security findings private, require a human
+> to approve any code change). Packaging *helps* here: those guardrails get written once, reviewed
+> once, and reused — instead of being re-typed (and subtly weakened) in every repo's YAML.
+
+---
+
+## 11. Phasing
+
+| Phase | Deliverable | Capabilities |
+|-------|-------------|--------------|
+| **0** | `GitHubToolsMixin` + `GaiaGitHubAgent` skeleton + `gaia-github` single-shot CLI (§9.6); mode prompts authored as `SKILL.md` behind a thin interim loader; run one mode locally against a real repo via PAT | read tools + `issue_triage` (dry-run) |
+| **1** | Reusable action + config schema + base-ref config load + write-policy layer | `pr_review`, `pr_rereview`, `issue_triage`, `pr_triage`, `converse` |
+| **1-UI** | **Agent UI surface (§9.2):** ship the `gaia.agent` entry point + hub card metadata (icon, category, conversation_starters) → auto-appears, runs via the generic registry branch, streams over SSE, interactive write-approval via `permission_request` | interactive use in the browser |
+| **2** | Eval transport adapter + seed scenarios from real history (incl. repo-manager's data); wire `--compare` CI gate | quality gate on all Phase-1 prompts |
+| **3** | `auto_fix`, `release_notes`, `postmortem`, `audit` (findings-only); load repo-manager's `commit-review`/`release-review`/`release-announcement` skills | full parity with `claude.yml` + weekly audit + repo-manager |
+| **3-TUI** | **Go TUI surface (§9.3):** preferred — add the daemon HTTP/SSE `AgentClient` to `gaia-tui` (shared infra, unblocks all Python agents); bridge — `--json-events` `AgentServer` pipe + catalog entry | interactive use in the terminal |
+| **4** | `EscalatingProvider` + service/webhook mode + `gaia-github init` scaffolder | local-triage/cloud-escalate; repo-manager parity |
+| **skills** | Swap the interim loader for the real `gaia.skills` loader (#888) + `skill_sets` (#2466); enables per-repo skill override + portability | *gated on #888 / #2466 landing* |
+| **notify** | **Outbound chat-app notifications (§9.8a):** add `_to_slack`/`_to_teams` to `sinks.py` + a `notify:` config block; deliver review/audit/announcement to a channel | reuses `schedule/sinks.py`; small |
+| **later** | Inbound chat-app surface (§9.8b, Slack Socket Mode → Teams) — rides the shared messaging framework (#635); Live doc-walkthrough mode (self-hosted runner) | capabilities #11 + chat inbound |
+
+> **Plain English.** Prove it on the cheapest, safest task first (label issues, in dry-run, on one
+> repo), with the eval net in place before we trust it to write anything. Then widen to reviews and
+> triage, then to fixes and release notes, then to the cost-saving local-model path and the
+> always-on server. The skills work runs on its own track (#888) and slots in without reworking the
+> agent — we author in the skill shape from day one. Each phase is independently useful and reversible.
+
+---
+
+## 12. Open decisions
+
+1. **Auth in CI:** rely on the same `CLAUDE_CODE_OAUTH_TOKEN` subscription model as today, or a
+   billed API key? (Affects the escalation cost story.)
+2. **GitHub App vs PAT for service mode:** a GitHub App gives finer-grained, per-repo, revocable
+   permissions than a PAT — worth it for a multi-repo deployment, more setup up front.
+3. **Where does the shared package live** — inside `amd/gaia` hub (`hub/agents/github/`) or its own
+   repo so `lemonade`/`repo-manager` can consume it without depending on all of GAIA?
+4. **Postmortem/audit overlap:** repo-manager's existing postmortems vs. GAIA's weekly audit —
+   merge into one proactive mode or keep distinct (postmortem = per-merge retrospective, audit =
+   whole-repo sweep)?
+5. **Tool layer:** thin `httpx` GitHub REST tools (full control, we own coverage) vs. leaning on
+   the upstream GitHub MCP server (less code, coverage outside our control). Recommend REST for the
+   write path, MCP optional for exotic reads.
+6. **repo-manager integration depth (§8.5):** drop-in Pi replacement (fast parity, keep his
+   orchestrator) vs. GAIA service mode absorbing the SQLite/issue-sync/Pages orchestrator. The
+   drop-in is the right *first* step regardless — it's the cheapest way to prove parity on his data.
+7. **Interim loader vs. wait for #888:** ship Phase 0–3 now with a thin in-package loader authored
+   in the `SKILL.md` shape (recommended — unblocks the agent), or gate the whole agent on the #888
+   loader landing? Recommend not blocking; the switch is designed to be a no-op.
+8. **Sequencing with the email reference (#2466):** the email agent is #888's first consumer and
+   owns the `skill_sets` mechanism. Do we wait for it to land `skill_sets`, or co-develop it so the
+   GitHub agent is the second consumer in the same cycle?
+9. **TUI enablement (§9.3):** invest in the shared daemon HTTP/SSE `AgentClient` for `gaia-tui`
+   (fixes the TUI for *every* Python agent, aligns with the "no shell-out" target) vs. a new
+   per-agent `--json-events` subprocess emitter (a small shim — the event vocabulary already matches
+   `SSEOutputHandler`, but it must be written + auto-deny confirmations; **it does not work today**).
+   Recommend the shared client — bigger, cross-team; confirm ownership. Neither exists yet, so **the
+   TUI surface (G9) is not shippable until one lands** — the MVP (§13.4) ships on CLI + Agent UI.
+10. **Interactive auth:** the daemon surfaces (UI/TUI) authenticate GitHub via the `mcp-github` PAT
+    connector, but that's a **classic PAT, not a GitHub App** (no fine-grained/OAuth today). Is a
+    PAT acceptable for interactive local use, or do we need the App path (decision #2) first?
+11. **Chat-app surface (§9.8):** confirm outbound-first (reuse `sinks.py`) and whether inbound is
+    worth pulling the shared messaging framework (#635, currently P2/unbuilt) forward, or left as a
+    fast-follow. Slack (Socket Mode, no public URL) before Teams (needs webhooks / service mode)?
+    Note Teams isn't in the current messaging plan — adding it is net-new scope on that track.
+12. **API client design (§13.2, reconciles #1123):** typed `httpx` `@tool`s for the write/act path
+    (required for the base agent's dedup/timeout/policy/validation) vs. `gh`-CLI shell-out (existing
+    #1123) for bulk reads. **RESOLVED (2026-07): both** — typed `@tool`s for the write/act path,
+    `gh`/REST for bulk reads. #1123 to be updated accordingly; typed write tools tracked in G1.
+
+---
+
+## 13. Consolidation with milestone #43 (the existing GitHub Agent)
+
+**Milestone [#43 "GitHub Agent"](https://github.com/amd/gaia/milestone/43) already exists** with 15
+issues (#1123–#1137) and a referenced plan doc `docs/plans/github-agent.mdx` that **is not in the
+repo** (dangling reference). This spec **converges into #43**, not a new milestone.
+
+### 13.1 The two halves are complementary, not competing
+
+| | Existing #43 (issues #1123–1137) | This spec |
+|---|---|---|
+| Framing | Maintainer-side **pull tool** — "help the human review faster" | Event-driven **CI bot** — "act on GitHub" + interactive surfaces |
+| Verbs | rank, brief, digest, cluster, analyze (read/analyze) | review, triage, comment, label, fix, announce (**write-back**) |
+| Trigger | `gaia-github <cmd>` + background poller | GitHub event / `@mention` / UI/TUI chat |
+| Examples | review *queue*, re-review *briefing*, community dashboard, upstream intel, Q&A | post a *full review*, auto-fix a bug, proactive audit issues |
+
+They share a foundation (API client, hub packaging, SQLite store, profile config, MCP surface) and
+are **one agent with many surfaces** (§9). Convergence = keep the 15, add the write-back + surfaces
+gaps, and reconcile the overlaps below.
+
+### 13.2 Reconciliation of overlaps (edits/comments on existing issues — not new issues)
+
+- **#1123 API client (`gh` CLI + REST fallback)** vs this spec's **typed `httpx` `@tool` mixin.**
+  Decision needed (Open Decision #12): the **write/act path needs typed tools** (the base agent's
+  dedup / timeout / policy / validation only work on typed `@tool`s, not free-text `gh` strings —
+  §3.2, §6); `gh`-CLI/bulk-REST is fine for the **read/analyze** path (#1124/#1130). Recommend:
+  typed tools for writes, `gh`/REST for bulk reads; update #1123 to say both.
+- **#1126 hub packaging** — path is written `hub/agents/python/github/` (segments reversed); the
+  real convention is **`hub/agents/github/python/`**. Also add the `gaia.agent` entry point (UI
+  auto-discovery, §9.2) and the NL single-shot + `init` (§9.6). Edit #1126.
+- **#1135 MCP surface**, **#1133 situational Q&A**, **#1136 ambient autonomy** overlap this spec's
+  surfaces / converse / audit. Keep them; cross-reference so they aren't rebuilt (converse =
+  respond *on an issue/PR*; #1133 = *repo-state* Q&A — genuinely distinct).
+
+### 13.3 Gap issues to create under #43 (the write-back + surfaces half)
+
+Proposed NEW issues (conventional-commit titles). None duplicate #1123–1137.
+
+| Key | Title | Deps | Tier |
+|-----|-------|------|------|
+| G1 | `feat(github): typed write tools + write-policy layer (dry_run/allow-deny/human-gate)` | #1123 | core |
+| G2 | `fix(agent): extend mutation-dedup + error-type success-gating for GitHub writes` | G1 | core |
+| G3 | `feat(github): triage modes — issue_triage + pr_triage (label/route, dry-run first)` | #1123, G1 | **MVP** |
+| G4 | `feat(github): review modes — pr_review + pr_rereview (two-part output, security escalation, suggestions)` | G1 | core |
+| G5 | `feat(github): converse + issue_review modes (@mention Q&A, actionability)` | G1 | core |
+| G6 | `feat(github): auto_fix mode (bug label → branch → lint+unit → draft PR)` | G1, G4 | later |
+| G7 | `feat(github): proactive audit mode (findings-only, human-gated)` | G1 | later |
+| G8 | `feat(ci): reusable gaia-github-agent.yml + base-ref config + fork-safety + rate-limit budget` | G3/G4 | core |
+| G9 | `feat(github): interactive surfaces — Agent UI card + NL→mode classifier + gaia-github NL CLI + TUI` | #1126 | core |
+| G10 | `feat(github): security model & fork-safety carry-over (untrusted input, base-ref policy, no-code-exec, private security findings)` | G8 | core |
+| G11 | `feat(eval): GitHub-agent eval tripwire — transport adapter + seed scenarios + --compare CI gate` | G3/G4 | core |
+| G12 | `feat(github): skills track — modes as SKILL.md + skill_sets + port repo-manager skill bodies to typed tools` | G4/G7, **#888**, **#2466** | later (infra-gated) |
+
+**Created (2026-07, all in milestone #43):** G1 #2552 · G2 #2553 · G3 #2554 (MVP) · G4 #2555 ·
+G5 #2556 · G6 #2557 · G7 #2558 · G8 #2559 · G9 #2560 · G10 #2561 · G11 #2562 · G12 #2563.
+Existing reconciled: #1123 (typed-writes note), #1126 (hub-path fix + UI entry point).
+
+Deferred (mention, don't create yet): `EscalatingProvider` (local→Claude), outbound chat notify
+(`_to_slack`/`_to_teams`, §9.8a), inbound chat (**#635**), live doc-walkthrough (§2 #11).
+
+### 13.4 MVP — the smallest slice that delivers value
+
+> ⚠️ **Superseded by §14.4:** the handoff MVP flagship is **PR Review** end-to-end via the sidecar.
+> `issue_triage` (below) remains the cheapest *fallback* MVP if we de-risk writes first.
+
+**G3 `issue_triage` in dry-run, on one repo.** It's net-new (Jeremy/Kalin asked for it), the
+cheapest/safest (label/route, no code execution), dry-run = zero write risk, and its dependency
+chain is minimal and **entirely in-milestone**: #1123 (read client) → G1 (write tools + dry-run
+policy) → G3 — all net-new but self-contained. **It needs no unbuilt GAIA-core infra** (no
+#888/#2466/#635, no eval adapter, no escalation, no TUI client): it runs today via the `gaia-github`
+CLI (§9.6) and the Agent UI (§9.2, "nearly free"). The TUI surface (G9) is *not* on the MVP path —
+it depends on the TUI-side work in §9.3. Ship G3, watch it in dry-run, then flip writes on.
+
+### 13.5 Testing (the #1655 boundary rule — required, was missing)
+
+- **Unit:** each GitHub `@tool` asserts the *shape of the outgoing REST call* (path, required
+  fields, allowed value combos) — not just "the client was called." Mocking `requests`/`httpx`
+  proves invocation, never validity.
+- **Integration:** a `require_github` fixture (mirroring `require_lemonade`) exercises the read
+  tools against a real repo (public, read-only) so the contract is verified once for real.
+- **Eval (G11):** hand-labeled scenarios from real workflow/postmortem history + `--compare` as a
+  CI gate on any prompt/skill change (LLM-affecting → eval required per CLAUDE.md).
+- **Cold-start:** run each mode from empty state (no cache, no prior review) — the hidden-state
+  masking rule.
+
+### 13.6 Coexistence with `claude.yml` (de-risk the cutover — was missing)
+
+Do **not** delete the 1,600 lines of battle-tested `claude.yml` on day one. Per capability:
+**shadow → compare → cut over.** Run the new mode alongside the existing job (posting to a scratch
+label or a dry-run channel), diff the outputs on real PRs/issues via G11's eval, and only then
+disable the corresponding `claude.yml` job. `pr_review` is the highest-value first cutover;
+`auto_fix` is the last (highest blast radius). Keep the auth-canary until the agent has its own
+health signal.
+
+### 13.7 Dependency-risk summary (the honest one-look view)
+
+Most of the *interesting* capability is gated on infra owned by other tracks. A reader should see
+this in one place, not scattered:
+
+| This agent needs | State | Blocks | Fallback |
+|------------------|-------|--------|----------|
+| #888 skills loader | **unbuilt** (Phase 1 not started) | G12, per-repo skill override, repo-manager port | interim in-package loader (§8) |
+| #2466 `skill_sets` | **unbuilt** | G12 per-context selection | single skill set |
+| TUI HTTP/SSE client | **unbuilt** (`tui/` is subprocess-only) | TUI surface (G9, path a) | path b: new `--json-events` stdout shim (event vocab already matches `SSEOutputHandler` — no schema mapping — but must add the emitter + auto-deny confirmations; §9.3) |
+| `EscalatingProvider` | **unbuilt** | local→Claude escalation | pick one model per capability |
+| eval transport adapter | **unbuilt** (runner is Agent-UI-MCP-coupled) | G11 | manual spot-check (weaker) |
+| #635 messaging framework | **unbuilt** | inbound chat (§9.8b) | outbound-only notify |
+
+**MVP (G3) depends on none of these.** Everything in the "core" tier except G9's TUI path and G11's
+adapter is buildable today on shipped GAIA.
+
+---
+
+## 14. 2026-07 re-scope — email-sidecar packaging, Pi parity, MVP & phases
+
+This section is **authoritative** and supersedes the packaging framing in §3.1/§9.2, the TUI framing
+in §9.3, and the MVP/phasing in §11/§13.4 where they differ. Two inputs drove it: (1) the decision
+to package/run the agent **exactly like the email agent**, and (2) the full Pi/Lemonade
+Quality-Assurance working-group scope this agent must reach parity with (and beat).
+
+### 14.1 Packaging = daemon HTTP sidecar (the verified email pattern)
+
+The email agent is **not** an in-process wheel — it's a **daemon-supervised HTTP sidecar** (verified
+against `hub/agents/email/`, `src/gaia/daemon/sidecars/`, `src/gaia/ui/`). The GitHub agent copies it:
+
+| Piece | Path | Requirement |
+|-------|------|-------------|
+| Sidecar server | `hub/agents/github/python/gaia_agent_github/server.py` | `build_app()` → `GET /health` (`{"status":"ok","service":"gaia-agent-github"}`), `GET /version` (`{apiVersion,agentVersion}`), token-gated `POST /v1/github/agent/query` (SSE), `/session`, `/cancel`, `/confirm-tool` |
+| Agent + tools | `.../gaia_agent_github/agent.py` + `tools/` | `GaiaGitHubAgent` + typed GitHub `@tool`s (§3.2) |
+| Freeze shim | `.../packaging/server.py` | re-export `app`/`main`; **no `__init__.py`** (loads as top-level `server`) |
+| Manifest | `.../gaia-agent.yaml` | `id: github`, `language: python`, `npm_package`, `interfaces`, `requirements.platforms` |
+| npm client + binary | `hub/agents/github/npm/{package.json,binaries.lock.json,src/}` | `bin: agent-github`; per-platform frozen-binary manifest |
+| **Daemon registration** | `src/gaia/daemon/sidecars/spec.py` `builtin_specs()` | **the ONE mandatory core change** — add a `"github"` `AgentSidecarSpec` (`service_id="gaia-agent-github"`, token env vars, `mode_env_var="GAIA_GITHUB_AGENT_MODE"`, `dev_src_dir`, and — for GitHub OAuth — `forward_providers=("github",)`). Manager/registry/relay/routes/install are already generic. |
+| Agent UI dispatch | `src/gaia/ui/_chat_helpers.py` | add `"github"` to `_SIDECAR_AGENT_TYPES` + a `_dispatch_github_query` (generalize `_dispatch_email_query`; `email_sidecar/daemon_client.py` is already `agent_id`-keyed) |
+| Install / picker | `src/gaia/hub/installer.py`, `routers/agents.py` | **no change** — `install("github")`, `fetch_binary`, and `_installed_sidecar_agents` are generic once the spec + `.installed` sentinel exist |
+
+Dev mode (Jeremy's handoff): `GAIA_GITHUB_AGENT_MODE=dev` on the daemon runs the sidecar from source
+via uvicorn — no binary publish needed to test (mirrors `GAIA_EMAIL_AGENT_MODE=dev`).
+
+> **Plain English.** We build the GitHub agent as its own little web service that the GAIA daemon
+> starts, supervises, and proxies to — the same shape as the email agent. The only change to GAIA's
+> core to "plug it in" is one entry in a registry file; the daemon already knows how to launch,
+> health-check, token-secure, and route to a sidecar. To run it from source for testing, set one
+> env var.
+
+> ⚠️ **Supersedes §3.1/§9.2.** Earlier text described an in-process wheel auto-discovered via a
+> `gaia.agent` entry point + the generic `_chat_helpers` branch. That path *works*, but the chosen
+> pattern is the **sidecar** (isolation, own model lifecycle, install-as-binary, OAuth forwarding —
+> exactly why email is a sidecar). The typed tools, task modes, policy layer, and reliability
+> arguments (§3–§7) are unchanged; only the process/packaging boundary moves out-of-process.
+
+### 14.2 TUI reality (honest) — the email pattern doesn't run in the TUI *yet*
+
+Verified: **no sidecar agent — email included — is reachable from the Go TUI today.** The TUI's only
+launch path is a stdin/stdout **JSONL subprocess** (`tui/internal/ui/root/model.go` → `SubprocessClient`);
+the email catalog entry has no `BinaryPath` and is non-launchable; the npm client is HTTP/SSE, not
+JSONL. So "run via the TUI like email" is a **pending capability for email too**. The correct,
+shared fix (recipe option 1): add an **HTTP/SSE `AgentClient`** to `tui/internal/client/` that
+ensures the sidecar (`POST /daemon/v1/agents/github/ensure`), POSTs `/v1/github/agent/query` through
+the daemon relay, and maps the SSE contract → the TUI's `event.*` types. **This one addition lights
+up every sidecar agent in the TUI (email + github).**
+
+> ⚠️ **Supersedes §9.3.** The `--json-events` subprocess shim (old path b) is *not* the email
+> pattern — email is HTTP/SSE. Drop it; do the shared TUI→daemon SSE client instead (it's the same
+> §9.3 path a, now confirmed as the only pattern-faithful route, and it fixes email in the TUI too).
+> Own this as shared TUI infra (milestone #45 / #55), not github-only work.
+
+### 14.3 Pi parity capability map (what we must match, then beat)
+
+From the QA working-group scope. Mapped to GAIA capabilities/issues; ✅ = maps to an existing/created
+issue, ➕ = new.
+
+**PR Review Agent** (runs in CI, Lemonade-backed):
+- Alignment vs `contribute.md` + `philosophy.md` ➕ · docs coverage vs `documentation.md` ➕ (both fold into `pr_review`, G4 #2555)
+- Major-new-scope → require 2nd core-maintainer review ➕
+- Breaking API/UX change → must be documented **and** core-maintainer-approved ➕ (gate)
+- Reviewer suggestion from the maintainer table in `contribute.md` ➕ (shared maintainer-table parser)
+
+**Issue Review Agent:**
+- Duplicate detection ✅ #1134 (issue clustering)
+- Hot issues → Discord `#dev` notification ➕ (Discord integration)
+- Relevance: still-valid / resolved-in-release / obsoleted ➕
+- "Goodness" (reproducible, clear, philosophy-aligned) + auto-reply guidance + Discord redirect ➕ (extends `issue_triage` G3 #2554 / `issue_review` G5 #2556)
+- Auto-assign good issues to maintainers per the table + Discord `#dev` tag ➕ (maintainer-table parser + Discord)
+
+**Adjacent working-group tracks** (related, not the agent's core — note, don't rebuild here):
+- Performance Regression Suite → a perf DB + CI system; the agent can *read* it (an "upstream/perf intelligence" mode like #1132), but the DB/CI is separate infra.
+- CI Enhancements (runner filtering, Radeon emulation, GPU pool) → CI infra, out of agent scope.
+- Release Process (date-based versioning, auto release branches, release-notes copy injection) → maps to release-prep #1128 + `release_notes`; branch/versioning automation is CI infra.
+- Community Dashboard (Discord activity alerts) → #1129 + the Discord integration.
+
+**New foundations the parity scope forces:**
+1. ➕ **Discord integration** (connector + notify to `#dev`) — the common thread across hot-issues, auto-assign, community alerts. (Pi uses Discord; supersedes the Slack/Teams framing in §9.8 as the *first* chat target.)
+2. ➕ **Maintainer-table parser** (`contribute.md`) — powers reviewer suggestion + auto-assign.
+
+### 14.4 MVP — the end-to-end pipeline to hand Jeremy
+
+**Goal:** one capability, *fully wired end-to-end* on lemonade — installable/runnable by Jeremy,
+posting a real result — not feature-complete. **Flagship = PR Review** (the working-group's #1, runs
+in CI, self-contained). MVP PR review does a *subset* well and is **comment/dry-run only** (safe):
+read the PR diff + `contribute.md`/`philosophy.md`/`documentation.md` + the maintainer table → post a
+review that flags alignment/doc gaps and suggests reviewers.
+
+**The full pipeline the MVP must light up (this is "end-to-end"):**
+1. Sidecar package (§14.1) — `server.py` + `agent.py` + a few read tools (`get_pr_diff`, `read_repo_file`) + `post_pr_review` (dry-run default).
+2. Daemon `builtin_specs()` entry for `github`.
+3. Agent UI dispatch branch (`_dispatch_github_query`) → runnable in the browser.
+4. CI reusable workflow (`gaia-github-agent.yml`) on `pull_request` → posts the review.
+5. `GAIA_GITHUB_AGENT_MODE=dev` so Jeremy runs it from source against lemonade.
+6. Eval tripwire seeded with a few real lemonade PRs (so prompt changes are gated from day one).
+
+**What Jeremy can do on handoff:** run it in dev mode, open a lemonade PR, see a posted (or dry-run)
+PR review with reviewer suggestions — in CI **and** in the Agent UI. TUI is explicitly a fast-follow
+(needs §14.2). This is the "runs end-to-end, not feature-complete" bar.
+
+> ⚠️ **Supersedes §13.4.** The earlier MVP was `issue_triage` dry-run (cheapest). Per the handoff
+> goal, the flagship MVP is **PR Review** end-to-end — but `issue_triage` remains the cheapest
+> *fallback* MVP if we want to de-risk writes first. (Decision surfaced below.)
+
+### 14.5 Phases (layer on the MVP)
+
+| Phase | Theme | Contents |
+|-------|-------|----------|
+| **MVP** | PR Review, end-to-end | sidecar + daemon spec + UI dispatch + CI + `pr_review` subset (doc-alignment + reviewer suggestion), dry-run; eval seeded |
+| **P1** | PR Review complete + re-review | scope→2nd-review, breaking-change gate, `pr_rereview`; security/fork-safety carry-over (G10); write-policy live (G1/G5) |
+| **P2** | Issue Review | `issue_triage`/`issue_review` (goodness + auto-guidance), duplicate detection (#1134), relevance/resolved/obsoleted |
+| **P3** | Discord + maintainer-table automation | Discord `#dev` hot-issue notify, auto-assign from maintainer table + Discord tag, community-activity alerts (#1129) |
+| **P4** | Release + proactive | release-prep/notes (#1128), proactive audit (G7), digest/poller (#1130/#1131), perf-intelligence read |
+| **TUI** | Shared surface | daemon→SSE `AgentClient` in `gaia-tui` (§14.2) — lights up email + github |
+| **Skills** | Milestone **#60** (separate) | if it lands first, author modes as `SKILL.md` from the start (G12); else interim in-package |
+
+### 14.6 Skills = milestone #60 (separate; may go first)
+
+Skills (`SKILL.md` loader #888, `skill_sets` #2466) live in **milestone #60**, not #43. If #60 lands
+first, the MVP authors its `pr_review` behaviour directly as a bundled `SKILL.md` (G12 pattern) and
+we get per-repo override for free; otherwise the MVP ships the prompt in-package and G12 swaps it
+later — a no-op switch (§8). Either way the sidecar/daemon/CI pipeline is independent of #60.
+
+### 14.7 Issue-set delta for this re-scope
+
+Existing G1–G12 (#2552–2563) and #1123–1137 mostly stand. Deltas:
+- **Edit** #1126 (packaging) → sidecar package (email pattern), not wheel.
+- **Edit/retarget** G9 #2560 → Agent-UI sidecar dispatch + the shared TUI SSE client (§14.2).
+- **New (➕):** daemon `builtin_specs()` registration · sidecar server (FastAPI health/version/query-SSE) · PR-review doc-alignment dimensions · reviewer-suggestion + auto-assign (maintainer-table parser) · PR scope + breaking-change gate · issue relevance/goodness/auto-guidance · Discord integration (notify #dev + hot-issue + community alerts).
+- **Reuse:** #1134 (dedupe), #1128 (release), #1129 (community), #1132 (perf-intelligence read).
+
+---
+
+## Appendix — file map
+
+| Concern | Where |
+|--------|-------|
+| Agent class | `hub/agents/github/python/gaia_agent_github/agent.py` (new) |
+| GitHub tools | `src/gaia/agents/tools/github_tools.py` (new) + register in `src/gaia/agents/registry.py` `KNOWN_TOOLS` |
+| Single-shot CLI | `gaia_agent_github/cli.py` (new, `gaia-github` console entry; positional query → `process_query`) |
+| Reusable action | `.github/workflows/gaia-github-agent.yml` (new) |
+| Consumer config | `.github/gaia-github-agent.yml` (per repo) |
+| Agent UI exposure | reuses `src/gaia/ui/routers/agents.py` + `_chat_helpers.py` generic branch + `sse_handler.py` — **no new UI code**; agent just ships hub card metadata |
+| Go TUI client (new) | `tui/internal/client/` — add an HTTP/SSE `AgentClient` against the daemon (§9.3 path a); or `--json-events` bridge via `src/gaia/agents/base/server.py` (path b) |
+| Chat-app outbound (§9.8a) | `src/gaia/schedule/sinks.py` — add `_to_slack`/`_to_teams` alongside `_to_telegram`; `notify:` block in the repo config |
+| Chat-app inbound (§9.8b) | shared messaging framework `src/gaia/messaging/` (`MessagingAdapter` ABC — **#635, planned/unbuilt**); Slack Socket Mode adapter, daemon-integrated |
+| Bundled skills | `hub/agents/github/python/skills/<mode>/SKILL.md` (+ optional `scripts/`) — authored in the agentskills.io shape (from `claude.yml`, `claude-weekly-audit.yml`, and repo-manager's skills) |
+| Skills loader (dependency) | `src/gaia/skills/` (`format.py`, `manager.py`) — **#888, not yet built**; interim in-package loader until then |
+| `skill_sets` selection (dependency) | base `Agent` + `gaia-agent.yaml` — **#2466, not yet built** |
+| Provider/escalation | `src/gaia/llm/providers/escalating.py` (new) + `factory.py` |
+| Eval scenarios | `eval/scenarios/github_*/` + transport adapter in `src/gaia/eval/` |
+| Base runtime (reused) | `src/gaia/agents/base/agent.py`, `tools.py`, `errors.py`, `console.py` |
+| Connector (service mode) | `src/gaia/connectors/catalog/mcp_servers.py` (`mcp-github`, existing) |
+| repo-manager reference | [`lemonade-sdk/repo-manager`](https://github.com/lemonade-sdk/repo-manager) — `repo_manager/cli.py`, `skills/{commit-review,release-review,release-announcement}/SKILL.md` |

--- a/docs/plans/pr-queue-closeout.md
+++ b/docs/plans/pr-queue-closeout.md
@@ -1,0 +1,157 @@
+# PR queue closeout — sequencing plan
+
+State as of 2026-08-24, **after #2995 merged** (`fdd9f18`, 17:39 UTC). 48 PRs remain open.
+
+Working document. Not wired into `docs/docs.json`; delete once the queue is drained.
+
+---
+
+## What changed today
+
+1. **#2995 merged** — 286 files deleted, twelve per-task agents collapsed into flagship
+   skills. Six PRs went `dirty` (conflicting) as a direct result: **#3047, #2957, #2601,
+   #2550, #2872, #2870**.
+2. **Fork CI unblocked** — 163 workflow runs approved across the 20 external PRs. They
+   had been sitting at `action_required` since they were opened; the full suite is now
+   executing for the first time on every one of them.
+
+Two structural problems from the earlier audit are **still open**:
+
+- **`main` requires nothing to merge.** `required_status_checks.contexts = []`,
+  `required_approving_review_count = 0`. Every green check below is advisory. `strict:
+  true` is set but inert, because it only gates on required checks and there are none.
+- **Twelve maintainer PRs are one hidden stack**, not twelve independent changes:
+  `#3026 ⊇ #3006 ⊇ #3005 ⊇ #3039`, plus `#3004` and `#3022`; near-contains `#3007`
+  (34/35 files), `#3024` (16/17), `#3008` (9/10). `#3006`'s branch is a strict git
+  ancestor of `#3026`'s.
+
+---
+
+## Sequence
+
+### Wave 1 — decide the stack strategy, then merge it (biggest value, all green)
+
+Nothing else in the queue is worth touching first: twelve PRs, ~28k lines, all `clean`,
+all green, all conflict-free today. They will start conflicting with each other the
+moment anything else lands.
+
+**Pick one before merging anything:**
+
+- **Option A (fast, 6 merges instead of 12):** merge #3026 as a unit → close #3006,
+  #3005, #3004, #3039, #3022 as "landed in #3026" → rebase and merge the remainder,
+  which shrink substantially.
+- **Option B (correct):** re-cut as an explicit chain, each PR based on its predecessor
+  rather than on `main`, so each diff shows only its own change. Costs ~a day of
+  rebasing; buys reviewable units.
+
+Option A means 8224 lines land on one approval. That is the same governance gap #2995
+had. Worth naming out loud rather than pretending six merges reviewed twelve PRs.
+
+Bottom-up merge order if you skip the roll-up: `3039 → 3004 → 3005 → 3006 → 3022 →
+3026 → 3008 → 3007 → 3024 → 3009 → 3010 → 3023`.
+
+| PR | Status | Ready? |
+|---|---|---|
+| 3026 | `clean`, 64 pass, 0 fail | ✅ superset — merging it lands 5 others |
+| 3007 | `clean`, 60 pass | ✅ |
+| 3009 | `clean`, 60 pass | ✅ |
+| 3024 | `clean`, 59 pass | ✅ |
+| 3010 | `clean`, 47 pass | ✅ |
+| 3008 | `clean`, 45 pass | ✅ |
+| 3006 | `clean`, 27 pass | ✅ (inside 3026) |
+| 3005 | `clean`, 27 pass | ✅ (inside 3006) |
+| 3004 | `clean`, 23 pass | ✅ (inside 3006) |
+| 3022 | `clean`, 14 pass | ✅ (inside 3026) |
+| 3039 | `clean`, 23 pass | ✅ (inside 3005) |
+| 3023 | `unstable`, 48 pass, **1 fail** | ❌ `Example Agents Integration Tests (stx)` |
+
+### Wave 2 — free wins, merge alongside Wave 1
+
+| PR | Status | Ready? |
+|---|---|---|
+| 3053 | 18 pass, 0 fail — scheduled-audit CI fix | ✅ merge |
+| 3028 | Lemonade 11.7.0, 6 pass | ✅ merge |
+| 2929 | skill-lock drift, 34 pass, 0 fail | ✅ merge (no review yet) |
+| 2978 | 59 pass, 0 fail, but GitHub reports `blocked` + `rebaseable: false` | ⚠️ open the merge box and find out why — no ruleset explains it |
+
+**Close immediately, no analysis needed:**
+
+| PR | Why |
+|---|---|
+| 2714 | Lemonade 11.5.1 — file set ⊂ #2861 ⊂ #3028 |
+| 2861 | Lemonade 11.5.2 — superseded by #3028 |
+| 2872 | electron bump in `hub/agents/emr/.../electron/` — **both files deleted by #2995**, now `dirty` |
+| 2870 | electron bump in `src/gaia/apps/jira/webui/` — **both files deleted by #2995**, now `dirty` |
+| 2868 | itomek draft, 1 file, 16 days idle |
+
+### Wave 3 — the six PRs #2995 broke
+
+These need a rebase before anything else can be said about them.
+
+| PR | Status | Action |
+|---|---|---|
+| 3047 | `dirty` + 3 fails (`Test MCPAgent` ×2, `GAIA CLI Linux`) | rebase, then fix — **it gates #2980** |
+| 2957 | `dirty`, docs only | trivial rebase |
+| 2601 | `dirty`, 1 fail, **26 days old** | ask the author to rebase or close |
+| 2550 | `dirty`, 2 fails, `CHANGES_REQUESTED`, **27 days old** | **close** — it adds You.com search to `hub/agents/browser`, which no longer exists |
+| 2872 / 2870 | `dirty` | close (Wave 2) |
+
+### Wave 4 — external contributors, now that CI actually runs
+
+Full suites are executing for the first time. Re-read these once they settle.
+
+| PR | Status now | Ready? |
+|---|---|---|
+| 2954 | 44 pass, 0 fail | ✅ likely merge |
+| 3042 | 15 pass, 5 running | ⏳ wait |
+| 3021 | 15 pass, 4 running | ⏳ wait |
+| 3045 | 13 pass, 3 running | ⏳ wait |
+| 3041 | 14 pass, 0 fail | ✅ likely merge |
+| 3027 | 14 pass, 4 running | ⏳ wait |
+| 3020 | 13 pass, 1 running | ⏳ wait |
+| 3046 | 9 pass, 5 running | ⏳ wait |
+| 3052 | 6 pass, 9 running | ⏳ wait |
+| 3051 | 6 pass, 10 running | ⏳ wait |
+| 3050 | 7 pass, **1 fail** (`pr-review / run`) | ⚠️ the review workflow is broken, not the PR |
+| 2976 | 14 pass, **1 fail** (`GAIA CLI Linux`) | ❌ fix first |
+| 2876 | 29 pass, **1 fail** (`validate`) | ❌ + needs a security read (third-party LLM provider) |
+| 3014 | **0 checks — approval did not take** | ⚠️ re-approve; + security read (third-party LLM provider) |
+| 3032 | 13 pass, `blocked`, `CHANGES_REQUESTED` | ❌ author action |
+| 2980 | 39 pass, **2 fails** (`Unit Tests py3.11/3.12`) | ❌ blocked on #3047 |
+
+### Wave 5 — the ones with real regressions
+
+| PR | Status | Action |
+|---|---|---|
+| 3003 | **fails the Gemma baseline eval** + `GAIA CLI Linux` | per CLAUDE.md an eval regression is a merge blocker — fix the prompt/clamp and re-run, don't waive |
+| 2930 | fails `Email Triage Eval` + Gemma baselines | same — and it's a PR that *changes* eval CI, so a failing eval is signal not noise |
+| 2931 | **all four C++ jobs failing**, 11 days | fix or close |
+| 2871 | 5 fails (example-app build + electron runtime) | re-run dependabot after the app tree settles post-#2995 |
+| 2869 | 29 pass, 1 running | ⏳ wait |
+| 3048 | 28 pass, 5 running | ⏳ wait |
+| 3049 | 62 pass, 1 fail (`Publish SARIF`) | likely a matrix-expression bug in the skill-audit workflow |
+
+### Wave 6 — governance (do not skip)
+
+1. **Set required status checks on `main`.** At minimum `Lint`, `Unit Tests (py3.10)`,
+   `Unit Tests (py3.12)`, `Security Tests`. Today a red PR merges as easily as a green one.
+2. **Decide the fork-CI policy.** Flip to "Require approval for first-time contributors
+   only", or keep the manual gate and put it on the review checklist. The state we just
+   cleared — 221 runs parked indefinitely with nobody watching — is the worst of both.
+   Note that a meaningful share of these workflows run on **self-hosted AMD hardware**
+   (`[self-hosted, strix-halo]`, `[self-hosted, Windows, lemonade-eval]`,
+   `[self-hosted, Windows, stx]`), so auto-approving forks means running untrusted
+   contributor code on your own machines. That is the reason to choose deliberately.
+3. **Fix `pr-review / run`** — failing on #3050 and previously on #3048/#3049 alike.
+4. **Stop empty-body rubber-stamp approvals.** Most external PRs carried an `APPROVED`
+   review from `itomek` with no body, given while zero tests had ever run on the code.
+
+---
+
+## Honest risks
+
+- Wave 1 Option A trades review depth for throughput. Choose it knowingly.
+- Wave 6 item 1 will turn several currently-mergeable PRs red on the day it lands. That
+  is the point, but it will not feel like progress.
+- Every "✅ ready" below rests on CI that is **not** required to pass. Until Wave 6 item 1
+  ships, green is a courtesy, not a gate.

--- a/docs/plans/skill-bound-task-execution.md
+++ b/docs/plans/skill-bound-task-execution.md
@@ -1,0 +1,138 @@
+# Skill-bound task execution
+
+**Status:** architecture design. Nothing built.
+**The requirement:** run an independent task, on a skill, bound to a specific backend/model.
+
+**Why a work plane rather than sub-agent delegation.** Agent delegation scales *context*; it does not scale *compute*. A sub-agent is a second LLM conversation — it has no resource requirement, no queue, no retry, no cancel, no resume, and no way to outlive the session that spawned it, so pointing one at a GPU does not give it those properties. When the bottleneck is device-seconds rather than window size, the right shape is typed, resource-tagged, asynchronous jobs that the agent *submits and monitors* rather than *becomes*. Placement is then a scheduler decision, not an agent decision — which is why the binding below lives on the skill and the resolver, never in an agent definition.
+
+## The shape
+
+**`DeviceConfig` is already the binding you want.** It exists today at `src/gaia/agents/registry.py:283` and carries exactly the fields the requirement names:
+
+```python
+device: Literal["cpu", "gpu", "npu"]
+model: str        # "gemma4-it-e2b-FLM"
+recipe: str       # "flm" | "llamacpp"
+backend: str      # "flm:npu" | "llamacpp:vulkan"
+ctx_size: int
+embedding_model: str
+verified: bool
+```
+
+It is scoped **per agent, one active per machine** ("a machine runs exactly one profile"). The whole design is: **promote that record from machine-scoped to task-scoped, and let a skill declare which one it needs.**
+
+Nothing new is invented. Four things change:
+
+| # | Change | Where |
+|---|---|---|
+| 1 | Skills declare a runtime requirement | `SKILL.md` frontmatter |
+| 2 | A resolver maps requirement → `DeviceConfig`, with loud admission checks | new, small |
+| 3 | The model broker gets N slots instead of 1 | `src/gaia/daemon/broker.py` |
+| 4 | The daemon gains a task runner + async task contract | new |
+
+### 1. Skill declares its runtime
+
+Additive under the existing `metadata.gaia` block — same place as `tools_required` and `permissions`, so no new file format:
+
+```yaml
+metadata:
+  gaia:
+    tools_required: [read_file, summarize_document]
+    runtime:
+      requires:
+        class: small-fast      # small-fast | general | reasoning | vision
+        ctx: 8192
+        tools: true            # needs native tool-calling
+      prefer_device: npu       # hint, not a mandate
+      pin: gemma4-it-e2b-FLM   # escape hatch: exact model, no substitution
+```
+
+**Declare a requirement; let the scheduler resolve a placement.** `requires` is portable — the same skill runs on a laptop NPU and a cluster dGPU. `pin` is the escape hatch for when a skill genuinely needs one checkpoint (a fine-tune, a specific quantization whose output differs) and must fail rather than substitute.
+
+This is the one place the "never bind placement into a definition" rule bends, and only here. It holds for *agents* — binding a device to an agent identity means every new placement needs a new agent. But a **skill is the capability**, and the model requirement is a genuine property of the capability: summarization wants small-and-fast, image generation wants a GPU node, screenshot extraction wants a VLM. Binding at the skill is correct; binding at the agent is not.
+
+### 2. Resolution, with loud admission
+
+`requires` + detected hardware → a `DeviceConfig`. Because Lemonade's device targeting *is* the model registration (recipe = device), resolving to a `DeviceConfig` **is** choosing the backend. The existing record already encodes what Lemonade needs.
+
+Admission runs at **submit**, not at run. Every one of these is a `CLAUDE.md`-style actionable error naming what failed, what to do, and where to look:
+
+| Check | Why it must be a hard reject |
+|---|---|
+| Skill needs tools, resolved model has `tool_calling=False` | The FLM/NPU server **500-errors on an OpenAI `tools` payload** — verified on hardware (`lemonade_client.py:349-360`). A tool-heavy skill physically cannot bind to `gemma4-it-e2b-FLM`. |
+| `requires.ctx` exceeds the device ceiling | FLM cannot load above `NPU_CTX_SIZE` (32768); handing it 65536 fails the load outright. |
+| `pin`ned model not installed | Fresh-machine failure (#1655 class). Name the install command. |
+| No `verified` config for detected hardware | Warn-and-degrade or reject — a product decision, but never silent. |
+
+That first row is the sharpest constraint in the whole design and it is easy to miss: **the NPU model is not a general-purpose target.** It is right for classification, triage, summarization, and embedded-JSON work; it is wrong for anything tool-driven.
+
+### 3. Multi-slot broker
+
+Today `broker.py:128-152` arbitrates **one** slot, because Lemonade was treated as single-tenant. It isn't — `max_loaded_models` defaults to `1` but is config, and FLM-on-NPU can be resident and inferencing alongside llama.cpp-on-GPU (see the companion doc).
+
+The broker becomes N slots keyed by `(device, model)`. Everything it already does carries over and gets *more* valuable: priority queueing (interactive > background), hot-model affinity (avoid needless evict+reload), TTL reclaim at 900s.
+
+One addition it needs: **budget bytes, not slots.** On a shared-memory APU like Strix Halo the NPU and iGPU draw from one pool, and Lemonade does no VRAM-pressure detection on Windows/AMD. Counting slots will OOM the box. Admission has to know memory.
+
+### 4. Task runner and the async contract
+
+The blocker is small and absolute: **every tool call is synchronous, capped at 180s** (`DEFAULT_TOOL_TIMEOUT`, `agent.py:140`). Until a tool can return a handle, none of this runs.
+
+```python
+task = run_skill_task("summarize", inputs={...})   # returns immediately
+task_status(task)    # queued | running | done | failed  (+ progress)
+task_result(task)    # an artifact handle, not a payload
+```
+
+The runner, daemon-owned: resolve `DeviceConfig` → acquire the slot lease → construct a minimal agent with `model_id` from the resolved config, exactly one skill loaded, and only that skill's `tools_required` → run → write the result to the artifact store → release the lease.
+
+The parent's transcript holds a task id and a status line. That is what lets a 32K window drive work of unbounded size.
+
+## Why this is not sub-agent delegation
+
+The distinction is load-bearing, and it is the reason this design works where delegation didn't.
+
+| | Sub-agent delegation | Skill-bound task |
+|---|---|---|
+| Input | Free-text prompt the **parent model writes** | **Typed arguments** to an authored procedure |
+| Procedure | Improvised by the child | Fixed in `SKILL.md`, human-authored and reviewed |
+| Quality depends on | The parent's prompt-writing ability | The skill author |
+| Failure mode | Vague prompt → wasted run, unrecoverable | Bad inputs → rejected at submit |
+
+The fatal objection to delegation was that a 4B model must write a good cold-start prompt for a child that sees no conversation. **That objection is absent here** — nobody generates a prompt. The parent supplies arguments; the procedure is already written. This is why the same constraint that killed delegation leaves this design untouched.
+
+## What already exists
+
+More than half of it:
+
+- **`DeviceConfig` + `DEFAULT_DEVICE_CONFIGS`** — the binding record, with per-device `embedding_model` already encoding the NPU co-residency lesson (#1744).
+- **`ModelTier` / `build_model_tiers`** — precedent for "a capability declares a model preference list," which `requires.class` can reuse rather than reinvent.
+- **The broker** — priority, hot-model affinity, TTL reclaim. Single-slot, but the arbitration is written.
+- **Skills as the capability unit** with `tools_required` and `permissions` (#2995).
+- **`is_tool_calling_model()`** (`lemonade_client.py:494`) — the admission check already has its predicate.
+- **Sidecar supervision** — spawn, health-poll, tree-kill, ephemeral ports.
+
+Missing: the async task contract, the multi-slot broker, the `runtime` frontmatter field, the resolver, and the artifact store.
+
+## Build order
+
+1. **Async task contract + task store.** The unblocking primitive; nothing works before it.
+2. **`runtime` frontmatter + resolver + admission checks.** Pure logic, unit-testable with no hardware — and the admission rules are where the user-visible quality lives.
+3. **Multi-slot, memory-budgeted broker.** Raise `max_loaded_models`; place by resolved config.
+4. **Artifact store** (#1973, generalized) so results never enter the transcript.
+
+Steps 1-2 are independently useful and testable on one device. Step 3 is where the parallelism arrives.
+
+## Risks worth naming
+
+- **Memory on unified-memory parts is unmeasured.** Two resident models contend for one pool and nothing detects the pressure. Bench it on the target box before step 3 ships.
+- **`--parallel 1`.** Lemonade launches llama.cpp with one slot, so concurrent calls to the *same* model queue. Raising `-np N` without `-kvu` silently divides `ctx_size` — the #1030 failure mode. Different models on different devices are genuinely parallel; the same model is not.
+- **Verified-matrix growth.** `DeviceConfig.verified` is per (agent, device) today. Skill-bound execution makes it per (skill, device), and `CLAUDE.md` requires an eval for LLM-affecting surfaces. Decide what "verified" means for a skill-runtime pair before shipping a matrix nobody can run.
+- **Fresh-machine failure.** A skill pinning a model `gaia init` never pulled fails only on a cold box — exactly #1655. Skill install must reconcile against installed models, and the admission check must run before the task is accepted.
+
+## Open questions
+
+- **Does `requires.class` resolve against a static table or detected hardware?** A static table is predictable; hardware detection is portable. `DEFAULT_DEVICE_CONFIGS` suggests static, with detection filtering it.
+- **Can a task chain?** A skill that submits another skill's task is a job DAG, not delegation — but it needs cycle detection and a depth cap before it's safe.
+- **Where do remote/cluster targets appear?** Cleanest is a `DeviceConfig` whose device is a cluster queue, so the resolver is unchanged and only the runner differs.
+- **Does a task inherit the caller's permissions?** The skill declares `permissions`; the caller has grants. Deny-only inheritance is the safe default — a task can never exceed the grants of whoever submitted it.

--- a/docs/plans/subagent-context-isolation.md
+++ b/docs/plans/subagent-context-isolation.md
@@ -1,0 +1,172 @@
+# Sub-agents as a context-isolation primitive
+
+> **Superseded by [`skill-bound-task-execution.md`](skill-bound-task-execution.md).** That
+> document reframes the problem around a work plane (async jobs + artifact handles) and
+> reaches the same "don't build sub-agent delegation" conclusion for stronger reasons.
+>
+> **One claim below is corrected there:** Lemonade *does* support concurrent multi-model,
+> multi-device residency (`max_loaded_models` defaults to 1 — a config default, not a
+> hardware limit), so "one resident model, no parallelism" described GAIA's own single-slot
+> broker, not a real ceiling.
+>
+> Still accurate and not repeated in the newer doc: the context arithmetic below, the
+> empirical tool-registry isolation test, and the licensing finding.
+
+**Status:** scoping / recommendation. Nothing built.
+**Relationship to #674:** narrower and different — see [What this is not](#what-this-is-not).
+
+## Recommendation
+
+**Don't build sub-agents yet. Build the cheap fix first, then run one eval that decides whether sub-agents are worth it at all.**
+
+The problem is real and measured: a retrieval-heavy turn runs out of context after roughly **five large tool results**, and buying a bigger GPU does not raise that number. But sub-agents are the most expensive of three fixes for it, and their value depends entirely on a question nobody has tested — whether a 4B model can write a good cold-start prompt for a child that sees none of the conversation. If it can't, delegation is strictly worse than not delegating.
+
+Order of work:
+
+1. **Ship #1973 (artifact store) regardless.** It caps a single oversized payload. Orthogonal to everything below, already scoped, already has a design PR.
+2. **Make the existing overflow shrink proactive** — a few days, reuses shipped code, captures most of the benefit. Details in [Alternative C](#alternative-c--proactive-result-eviction).
+3. **Time-box a `delegate` prototype and run the cold-start-prompt eval.** If Gemma-4-E4B writes usable child prompts, the design in [If we build it](#if-we-build-it) is sound and the plumbing already exists. If it doesn't, close this and keep the shrink.
+
+Sub-agents should never become an architecture here — only an opt-in tool the flagship may call. That distinction is the whole reason this isn't #674.
+
+## The problem, measured
+
+GAIA pins context per device and has **no compaction by policy** (`CLAUDE.md`). So the window is a hard budget, and the only lever is what goes into it.
+
+The flagship's composed system prompt measures **28,957 chars / 6,757 tokens** (`src/gaia/agents/base/turn_metrics.py:52-53` — measured against the real prompt, not estimated). Large tool results are truncated to a target that *scales with the window* (`src/gaia/llm/lemonade_client.py:191-192`): 20,000 chars on NPU, 40,000 on GPU.
+
+That scaling is the trap:
+
+| | NPU (32,768) | GPU (65,536) |
+|---|---|---|
+| Fixed prompt | 6,757 tok (21%) | 6,757 tok (10%) |
+| Left for history | 26,011 tok | 58,779 tok |
+| One max-size tool result | 4,673 tok | 9,346 tok |
+| **Results before overflow** | **~5** | **~6** |
+
+Because the truncation budget scales with `ctx_size` by design, **doubling the context window buys about one extra tool result.** Hardware does not fix this.
+
+Two honest caveats: these are *max-size* results, and typical results are smaller — this is a ceiling for retrieval-heavy work, not a typical chat. And assistant reasoning also accumulates, so the real number is a little worse. The workloads that hit it are exactly the ones skills like `research-report`, `data-explore`, and `document-brief` describe.
+
+**What happens at the ceiling is the actual bug.** The recovery path (`_shrink_messages_for_overflow`, `agent.py:3934`) stubs out *every* older tool result, keeping only the latest, and retries. So a research turn that read five sources silently continues with one. The user sees a confident answer built on 20% of the evidence and blames the model. That is a quality failure disguised as a successful turn — worse than a loud error, and it violates the spirit of the no-silent-fallbacks rule.
+
+## Why most of the Claude Code value doesn't transfer
+
+Three GAIA constraints remove the majority of the upside. These are not objections to the design; they are limits on how much it can ever pay back.
+
+- **One resident `(model, ctx)` pair.** The child runs the same Gemma-4-E4B. No "cheap model for grunt work" — Claude Code's single biggest lever is unavailable, and opencode's per-agent `model` field would trigger an eviction and a ~100s cold reload.
+- **Lemonade is single-tenant per model slot.** No parallel fan-out. The canonical Claude Code pattern — twenty explorers at once — is off the table. Delegation is serial, so it buys context but never wall-clock.
+- **KV cache.** GAIA deliberately keeps the prompt prefix stable so the backend's KV cache survives — `llama.cpp reuses the KV cache only up to the first differing token` (`agent.py:1005-1009`), which is why volatile fragments are pinned to the tail. A child whose prompt diverges early pays a cold prefill. Every delegation costs one.
+
+What survives is narrow but real: **the parent's transcript never sees the child's intermediate junk.** On a window where five results is the ceiling, that is worth something.
+
+## What this is not
+
+#674 was closed 2026-09-02 with "sub-agent orchestration is not the architecture," and that call was right. This proposal is a different object:
+
+| | #674 (closed) | This |
+|---|---|---|
+| Shape | Permanent mesh of specialist agents, 0.6B router, all-to-all comms | One tool the flagship may call |
+| Lifetime | Architectural, always on | One task, then discarded |
+| Problem | Prompt size + tool-selection accuracy | Transcript accumulation |
+| Status of that problem | **Solved** by #3008 (12,164 → 4,654 tok/call) | Unsolved; recovery is lossy |
+| User-visible | Yes — specialists, narration | No — one tool call |
+
+If this ships, the flagship stays the flagship, one agent, one model, one prompt. Nothing is decomposed. If the design starts growing named specialist agents, a routing layer, or agent-to-agent messaging, it has become #674 and should be closed again.
+
+## If we build it
+
+### Feasibility: the plumbing already exists
+
+The extension points are in place, and one of them was built for exactly this:
+
+```python
+# hub/agents/chat/python/gaia_agent_chat/agent.py:1958
+# Snapshot: freeze this agent's tool set so mutations by other agents
+# in the same process do not leak in.
+self._snapshot_tools()
+```
+
+I verified the isolation empirically rather than trusting the comment. Two live agent instances in one process, both registering a same-named closure-bound tool: the parent keeps its own binding, because `@tool` *replaces* the whole registry entry rather than mutating it, so the parent's shallow copy still points at the parent's function. Parent and child do not cross-bind.
+
+One residual hazard: `_tools_registry` falls back to the process-global dict when `_instance_tools is None` (`agent.py:1181-1183`). Any agent that never snapshots *would* pick up the child's bindings. Narrow, and a test pins it.
+
+Also available: `_active_tool_filter` / `_apply_tool_filter` for the child's tool subset, `_compose_system_prompt` for its prompt, and `default_max_steps()` for its step cap. The embedder/chat-model eviction risk is retired — Lemonade holds both simultaneously (#1544, `src/gaia/rag/sdk.py:459-468`).
+
+`process_query` mutates instance state (`_current_query`, `_turn_recorder`, `_tool_reported_usage`) and is not re-entrant, so the child **must** be a distinct instance. That is a constraint, not a blocker.
+
+### Shape
+
+One tool. Not a config format, not a `.gaia/agents/` directory — GAIA already has `SKILL.md` for scoped prompts and tools, and shipping a second authoring format for the same job would be a mistake.
+
+```python
+@tool
+def delegate(task: str, tools: str = "") -> str:
+    """Run a self-contained sub-task in a fresh context and return only its answer.
+
+    Use when a sub-task will produce many intermediate results you don't need —
+    searching a large codebase, reading several documents, checking many pages.
+    The child sees NONE of this conversation, so `task` must be fully
+    self-contained: state the goal, the constraints, and exactly what to return.
+    """
+```
+
+Design rules, each earning its place:
+
+- **Child inherits the parent's model.** Not configurable. Anything else evicts.
+- **Prompt built as parent-prefix + child-suffix.** The child's persona and rules stay byte-identical to the parent's; only the trailing tool block differs. `_compose_system_prompt` **already enforces exactly this ordering** — static head, volatile tail, filtered tool block last, explicitly to protect the KV prefix (`agent.py:995-1013`). A child that differs only in its tool filter therefore shares the entire cached static head, turning a full cold prefill into a partial one. This is the single strongest feasibility signal in the codebase: the discipline the design needs is already load-bearing for a shipped feature.
+- **Deny-only inheritance**, lifted from opencode (`subagent-permissions.ts`): the child inherits the parent's *denials* and path scope, never its grants. A permissive parent cannot escalate a child; a restrictive one cannot be escaped. One pure function, trivially unit-tested.
+- **No nesting.** `delegate` is excluded from the child's tool set, full stop. opencode defaults to depth 1 and Claude Code to 3; on a single-tenant serial backend, depth 1 is the only defensible number.
+- **Only the final text crosses back.** Tool calls, file contents, and reasoning stay in the child. This is the entire point.
+- **Failure is loud.** A child that errors or hits its step cap returns an actionable error naming the cause — never a partial answer dressed as a complete one, which is the failure mode we're trying to remove.
+- **Serial and bounded.** One child at a time; child step cap well below `DEFAULT_MAX_STEPS` (50). A child that needs 50 steps was mis-delegated.
+
+### The eval that decides it
+
+The design above is sound. Whether the *feature* works is one empirical question:
+
+> Can Gemma-4-E4B write a `task` string good enough for a cold-start child to succeed?
+
+opencode's own `task` tool prompt warns the parent to give a highly detailed instruction *because the subagent starts cold* — and that warning is aimed at a frontier model. A 4B model summarizing enough context into one string is a genuinely hard generative task, and it is cheap to test.
+
+Per `CLAUDE.md`, tool-schema and prompt changes are an LLM-affecting surface, so this needs `gaia eval agent` against the committed baseline regardless — run serially, one eval process at a time.
+
+Pass condition, decided before running: on retrieval-heavy scenarios, delegation must **improve** answer quality against the baseline, not merely avoid overflow. If it comes out neutral, the added latency and complexity aren't paid for and this closes.
+
+## Alternatives compared
+
+### Alternative B — #1973 artifact store
+
+Size-gates a single large tool result into a handle plus preview. **Ship regardless.** It solves *one oversized payload*; sub-agents solve *many accumulated payloads*. Different axes, both real, no overlap.
+
+### Alternative C — proactive result eviction
+
+The overflow recovery at `agent.py:3934` already stubs old tool results and retries. Today it fires *reactively*, after the backend has already rejected the request, and bluntly — everything but the latest result.
+
+Make it proactive and selective: evict results the model has already consumed, before the ceiling, keeping a one-line summary and (with B) an artifact handle to re-read on demand.
+
+- **Cost:** days. Extends shipped, tested code.
+- **Captures:** most of the benefit for the common case.
+- **Tension:** it is compaction, which `CLAUDE.md` forbids. But the reactive path *already does this*, worse and later. The policy is defending against silently rewriting history; this is worth an explicit decision rather than an assumption either way.
+
+### Comparison
+
+| | A: sub-agents | B: artifact store | C: proactive eviction |
+|---|---|---|---|
+| Solves | Accumulated junk | One huge payload | Accumulated junk |
+| Cost | Weeks + eval risk | Scoped (#1973) | Days |
+| Latency | +1 prefill per delegation | Neutral | Neutral |
+| Risk | 4B can't write child prompts | Low | Needs a compaction-policy call |
+| Verdict | **Prototype, gate on eval** | **Ship** | **Do first** |
+
+## Licensing
+
+opencode (`sst/opencode`, now `anomalyco/opencode`) is stock **MIT** — verified in `LICENSE` and the `package.json` license field. Not copyleft, not source-available, no non-compete. Reading it for reference is unrestricted; re-implementing the design in Python carries no obligation. If any non-trivial TypeScript is lifted, the MIT notice must ship with it — but nothing here requires that.
+
+The ideas borrowed above (deny-only inheritance, final-text-only return, depth capping) are architecture, not code.
+
+## Open questions
+
+- Does the compaction ban extend to Alternative C, or was it aimed only at summarizing *conversation* turns? This blocks the cheapest fix and is a one-line decision.
+- Should `delegate` be exposed to skills, or reserved for the flagship's own turn planning?
+- Is there production telemetry appetite? `GAIA_TURN_LOG` already records per-turn prefill and history size (`turn_metrics.py:162-172`) but is dev-only and off by default — so nobody knows how often overflow actually fires. That number would settle this argument better than any of the reasoning above.

--- a/docs/reference/claude-ci-workflows.md
+++ b/docs/reference/claude-ci-workflows.md
@@ -1,0 +1,77 @@
+# Claude CI Workflows — Helper Guide
+
+Quick reference to the Claude-powered GitHub Actions in `amd/gaia`. Five workflow files:
+one reactive assistant, its shared runner, two scheduled reviewers, and an auth canary.
+
+All links point to `main`:
+
+| Workflow | File |
+|----------|------|
+| Claude AI Assistant (main) | [`.github/workflows/claude.yml`](https://github.com/amd/gaia/blob/main/.github/workflows/claude.yml) |
+| Reusable runner | [`.github/workflows/claude-run.yml`](https://github.com/amd/gaia/blob/main/.github/workflows/claude-run.yml) |
+| Weekly Audit (static) | [`.github/workflows/claude-weekly-audit.yml`](https://github.com/amd/gaia/blob/main/.github/workflows/claude-weekly-audit.yml) |
+| Weekly Doc Walkthrough (live) | [`.github/workflows/claude-weekly-doc-walkthrough.yml`](https://github.com/amd/gaia/blob/main/.github/workflows/claude-weekly-doc-walkthrough.yml) |
+| Auth Canary | [`.github/workflows/claude-auth-canary.yml`](https://github.com/amd/gaia/blob/main/.github/workflows/claude-auth-canary.yml) |
+
+Related config the workflows depend on:
+[`REVIEW.md`](https://github.com/amd/gaia/blob/main/REVIEW.md) (the PR-review rubric) and the
+"Issue Response Guidelines" section of [`CLAUDE.md`](https://github.com/amd/gaia/blob/main/CLAUDE.md)
+(shared tone/format).
+
+---
+
+## 1. `claude.yml` — "Claude AI Assistant" (the main, reactive one)
+
+Reacts to issue/PR activity. Six jobs:
+
+| Job | Fires when | What it does |
+|-----|-----------|--------------|
+| **pr-review** | PR opened / reopened / marked ready | Full diff review (works on fork PRs too) |
+| **pr-rereview** | New commits pushed to a PR (`synchronize`) | Lightweight Sonnet re-check; flags only *new* regressions, silent otherwise |
+| **issue-handler** | New issue opened, or `@claude` in an issue/PR comment | Conversational reply |
+| **pr-comment** | Review comment left on a PR | Responds (non-fork PRs only — GitHub hides secrets from forks on this event) |
+| **auto-fix** | Issue gets the `bug` label (or a bug issue is reopened) | Attempts the fix: creates branch, opens a PR (draft + manual test plan if it can't self-validate), comments on the issue with test steps |
+| **release-notes** | "Publish Release" workflow succeeds on a `v*` tag | Generates GH release notes + docs, bumps version, updates `docs.json` |
+
+## 2. `claude-run.yml` — reusable runner (not triggered directly)
+
+Called by the three *conversational* jobs (pr-review, pr-comment, issue-handler). Centralizes
+checkout + diff generation, **retries** the intermittent upstream install crash, and verifies
+Claude produced output. Kept in a separate file for security: on fork PRs GitHub reads it from
+trusted `main`, so a malicious PR can't tamper with the credential-holding step.
+
+## 3. `claude-weekly-audit.yml` — proactive static review (scheduled)
+
+Weekly (deeper whole-codebase sweep monthly). Fans out one **read-only** Claude job per
+dimension — **security, correctness (the "fail loudly" rule), docs, tests, features** — then
+files one ranked triage issue + per-finding child issues. **Human-gated**: reports findings
+only; a maintainer adds the `bug` label to hand one to the auto-fix job. Runs on Opus.
+
+## 4. `claude-weekly-doc-walkthrough.yml` — live "act like a real user" (scheduled)
+
+The audit only *reads* code; this one *runs* GAIA. On a self-hosted Windows/STX runner it walks
+each doc guide's commands for real (fresh venv, isolated config, dedicated Lemonade port) to
+catch cold-start bugs invisible to source review (import errors on a plain PyPI install, agents
+falling back to an uninstalled model). Sonnet executes, Opus judges. Files its own parent issue.
+
+## 5. `claude-auth-canary.yml` — monthly health check
+
+All Claude jobs use an OAuth token that expires ~yearly and fails *silently* (jobs go green but
+post nothing). Once a month this runs a trivial Haiku prompt; if auth is broken it opens a
+tracking issue with fix steps — turning a silent multi-week outage into a notification.
+
+---
+
+## Key facts worth knowing
+
+- **Auth:** all jobs prefer a subscription OAuth token (`CLAUDE_CODE_OAUTH_TOKEN`) over a billed
+  API key; they fall back to `ANTHROPIC_API_KEY` if the token is missing/expired. (The eval
+  judge in `test_eval_rag.yml` still needs `ANTHROPIC_API_KEY` — OAuth tokens can't
+  authenticate direct API/SDK calls.)
+- **Fork safety:** fork-facing jobs run under `pull_request_target` (base-repo permissions).
+  Safe because they only *read* code and *post* comments — **never execute PR code** (no
+  `pip install` / `npm install` / build). Don't add steps that run checked-out code.
+- **Modes:** jobs run in *automation* mode (`prompt` input), not tag mode (which has an
+  upstream bug that silently ignores `--model`).
+- **Shape overall:** `claude.yml` = reactive assistant → `claude-run.yml` = shared secure
+  runner → two `weekly-*` = proactive coverage → canary = keeps it all from dying silently.

--- a/docs/spec/file-io-tools-mixin.mdx
+++ b/docs/spec/file-io-tools-mixin.mdx
@@ -89,7 +89,8 @@ Edit a Python file by replacing content with validation.
 
 **Parameters:**
 - `file_path` (str, required): Path to the file
-- `old_content` (str, required): Content to find and replace
+- `old_content` (str, required): Content to find and replace. Must match
+  exactly one location — see [Edit semantics](#edit-semantics).
 - `new_content` (str, required): New content to insert
 - `backup` (bool, optional): Create backup (default: True)
 - `dry_run` (bool, optional): Only simulate (default: False)
@@ -181,7 +182,8 @@ Edit any file by replacing content without validation.
 
 **Parameters:**
 - `file_path` (str, required): Path to file
-- `old_content` (str, required): Exact content to find and replace
+- `old_content` (str, required): Exact content to find and replace. Must match
+  exactly one location — see [Edit semantics](#edit-semantics).
 - `new_content` (str, required): New content to replace with
 - `project_dir` (str, optional): Project root for resolving paths
 
@@ -196,6 +198,44 @@ Edit any file by replacing content without validation.
     "diff": str
 }
 ```
+
+### Edit semantics
+
+`edit_file` and `edit_python_file` share one match-and-replace implementation,
+[`gaia.agents.tools.file_edit`](https://github.com/amd/gaia/blob/main/src/gaia/agents/tools/file_edit.py),
+so the two cannot drift apart. Three rules:
+
+**`old_content` must match exactly one location.** Matching several is an
+error, not a first-match replacement — picking one edits a region the caller
+never named while reporting success, and the resulting diff looks plausible.
+Extend `old_content` with surrounding lines until it is unique.
+
+**A rejection carries the file's current content**, so the retry does not need
+a separate read.
+
+**An edit against a file that changed since it was read is rejected.** Reads and
+writes record a content hash; a mismatch means the file moved under the agent.
+The rejection hands back the current content and re-anchors, so the corrected
+retry proceeds. A file with no recorded read is not blocked.
+
+**Rejection shape:**
+```python
+{
+    "status": "error",
+    "error": str,           # names the cause and the fix
+    "match_count": int,     # 0 = not found, >1 = ambiguous
+    "match_lines": [int],   # ambiguous only
+    "matches": [dict],      # ambiguous only: line + surrounding context
+    "stale": bool,          # changed-on-disk only
+    "current_content": str, # excerpt around the target region
+    "current_content_start_line": int,
+    "current_content_end_line": int,
+    "current_content_total_lines": int
+}
+```
+
+The C++ `file_edit` tool (`cpp/src/file_tools.cpp`) follows the same three
+rules, so an agent behaves identically on either tree.
 
 ### 8. replace_function
 

--- a/docs/spec/file-search-mixin.mdx
+++ b/docs/spec/file-search-mixin.mdx
@@ -230,15 +230,23 @@ class FileSearchToolsMixin:
         """
         Edit a file by replacing old content with new content.
 
-        Partial string replacement (first occurrence only) rather than a full
-        overwrite — like Claude Code's Edit tool. Runs the same security
-        guardrails as write_file (PathValidator allowlist, blocked-dir and
-        sensitive-file checks, backup creation, audit logging). The target file
-        must already exist and contain old_content verbatim.
+        Partial string replacement rather than a full overwrite — like Claude
+        Code's Edit tool. Runs the same security guardrails as write_file
+        (PathValidator allowlist, blocked-dir and sensitive-file checks, backup
+        creation, audit logging). The target file must already exist.
+
+        old_content must match exactly one location. Matching several is an
+        error, not a first-match replacement: picking one would edit a region
+        the caller never named while reporting success. Matching nothing, and
+        editing a file that changed since it was read, are errors too. Every
+        rejection carries the file's current content so the retry needs no
+        separate read. The semantics live in `gaia.agents.tools.file_edit`,
+        shared by every edit tool.
 
         Args:
             file_path: File to edit
-            old_content: Exact text to find and replace
+            old_content: Exact text to find and replace; must be unique in the
+                file — include surrounding lines until it is
             new_content: Replacement text
 
         Returns:
@@ -249,6 +257,19 @@ class FileSearchToolsMixin:
                 "new_size": int,   # chars after edit
                 "diff": str,       # unified diff
                 "backup_path": str # only when a backup was created
+            }
+
+            On rejection:
+            {
+                "status": "error",
+                "error": str,           # names the cause and the fix
+                "match_count": int,     # 0 = not found, >1 = ambiguous
+                "match_lines": [int],   # ambiguous only
+                "stale": bool,          # changed-on-disk only
+                "current_content": str, # excerpt around the target region
+                "current_content_start_line": int,
+                "current_content_end_line": int,
+                "current_content_total_lines": int
             }
         """
         pass

--- a/docs/testing/memory-manual-testing.md
+++ b/docs/testing/memory-manual-testing.md
@@ -1,0 +1,261 @@
+# Memory System — Manual Testing Guide
+
+The magic of memory is when GAIA feels like it truly *knows* you — your preferences,
+your projects, your patterns. This guide walks through realistic workflows where
+memory transforms a stateless chatbot into a personalized assistant.
+
+## Setup
+
+```powershell
+$env:GAIA_MEMORY_ADMIN="1"; $env:GAIA_MEMORY_MCP_ALWAYS="1"; gaia chat --ui
+```
+
+Open the Memory Dashboard between scenarios to watch knowledge accumulate.
+
+---
+
+## Scenario 1: First-Time Setup
+
+**The magic:** GAIA learns who you are and remembers it forever.
+
+1. Open Memory Dashboard > Settings
+2. Toggle "System discovery" ON — watch it learn your hardware, OS, software
+3. Start a new chat session:
+   - "Hi, I'm Alex. I'm a backend engineer working on microservices at Acme Corp"
+   - "I mainly work with Python and Go, and I prefer VS Code with vim keybindings"
+   - "I like concise answers with code examples, no fluff"
+4. **Close the session. Open a new one.**
+5. "What do you know about me?"
+6. **Magic moment:** GAIA should recall your name, role, languages, editor, and communication preference — without being told again.
+
+**Dashboard check:** Look for preference, fact, and note items with entity tags.
+
+---
+
+## Scenario 2: Project Context + File Work
+
+**The magic:** GAIA remembers your project context while helping with files.
+
+1. "I'm working on project Atlas — it's a REST API for inventory management using FastAPI"
+2. "Create a file called `inventory.py` with a basic FastAPI app that has GET /items and POST /items endpoints"
+3. Verify the file was created and looks correct
+4. "Read the file back and add input validation with Pydantic models"
+5. "Take a note: Atlas API uses PostgreSQL 15 on port 5433, not the default"
+6. **New session:**
+7. "What database does project Atlas use?"
+8. **Magic moment:** Recalls PostgreSQL 15 on port 5433 without you re-explaining.
+9. "Read inventory.py and add a database connection using the right port"
+10. **Magic moment:** Uses port 5433 from memory, not the default 5432.
+
+**Dashboard check:** Note items about Atlas, file operations in tool history.
+
+---
+
+## Scenario 3: Research + Web Search + Notes
+
+**The magic:** GAIA captures research findings as persistent knowledge.
+
+1. "Search the web for the latest FastAPI best practices in 2026"
+2. "Take a note on the key findings from that search"
+3. "Search for how to structure a large FastAPI project with multiple routers"
+4. "Note: Based on my research, we should use the domain-driven folder structure for Atlas"
+5. **New session:**
+6. "What architecture decision did I make for the Atlas project?"
+7. **Magic moment:** Recalls the domain-driven structure decision from your research session.
+
+**Dashboard check:** Notes should have meaningful content, not just "user searched for X".
+
+---
+
+## Scenario 4: Todo List Across Sessions
+
+**The magic:** A persistent todo list that survives session boundaries.
+
+1. "Add to my todo: implement JWT authentication for Atlas"
+2. "Add to my todo: write integration tests for the /items endpoints"
+3. "Add to my todo: set up CI/CD pipeline with GitHub Actions"
+4. "Add to my todo: review PR #42 from Sarah"
+5. "What's on my todo list?"
+6. Verify all 4 items listed
+7. "I finished the JWT auth, mark it done"
+8. **New session:**
+9. "What's still on my todo list?"
+10. **Magic moment:** Shows 3 remaining items, JWT auth is gone.
+11. "Actually, Sarah's PR was already merged. Remove that from my list"
+12. "Show my todos"
+13. Should show 2 remaining items
+
+**Dashboard check:** Knowledge items with category "todo", updated timestamps.
+
+---
+
+## Scenario 5: Reminders with Due Dates
+
+**The magic:** GAIA proactively surfaces upcoming deadlines.
+
+1. "Remind me to renew the SSL certificate by June 15th"
+2. "Remind me about the team demo next Friday"
+3. "Remind me to submit the expense report by end of month"
+4. "What's coming up?"
+5. Should list all 3 with due dates
+6. **New session:**
+7. "Do I have any upcoming deadlines?"
+8. **Magic moment:** Proactively mentions the SSL cert, demo, and expense report with dates.
+
+**Dashboard check:** Temporal tab shows upcoming items. Knowledge items have `due_at` set.
+
+---
+
+## Scenario 6: Learning Your Preferences Through Conversation
+
+**The magic:** GAIA picks up on implicit preferences, not just explicit "remember this" commands.
+
+1. "Can you write a Python function that checks if a number is prime?"
+2. (Agent writes a function)
+3. "I prefer type hints on everything and Google-style docstrings"
+4. "Rewrite it with those conventions"
+5. **New session:**
+6. "Write a function that calculates fibonacci numbers"
+7. **Magic moment:** Should use type hints and Google-style docstrings automatically, without being asked.
+
+**Dashboard check:** Preference items about type hints and docstring style.
+
+---
+
+## Scenario 7: Contact Profiles
+
+**The magic:** GAIA builds profiles of people you mention.
+
+1. "Sarah Chen is our DevOps lead. She prefers Terraform over Pulumi"
+2. "Marcus handles the frontend — he's the React expert on the team"
+3. "Sarah's on PTO next week, so I need to handle the deploy myself"
+4. **New session:**
+5. "Who should I ask about our Terraform setup?"
+6. **Magic moment:** Recommends Sarah Chen, mentions she's the DevOps lead who prefers Terraform.
+7. "What do I know about my team?"
+8. Should compile profiles for Sarah and Marcus.
+
+**Dashboard check:** Entity-linked items (person:sarah_chen, person:marcus).
+
+---
+
+## Scenario 8: Error Learning
+
+**The magic:** GAIA remembers mistakes and avoids them next time.
+
+1. "Run `python -c \"import pandas\"`" (assume it fails — pandas not installed)
+2. "Note: On this machine, we use polars instead of pandas"
+3. **New session:**
+4. "Read the CSV file at data/sales.csv and show me a summary"
+5. **Magic moment:** Should reach for polars (not pandas) based on the stored preference.
+
+**Dashboard check:** Tool history shows the failed pandas command; knowledge has the polars preference.
+
+---
+
+## Scenario 9: Data Analysis with Scratchpad
+
+**The magic:** Memory retains context about your datasets across sessions.
+
+1. "Create a scratchpad table called 'sales' with columns: date, product, revenue, region"
+2. "Insert some sample data: 3 rows of Q1 sales for Widget A in US, EU, APAC"
+3. "Query: what's the total revenue by region?"
+4. "Take a note: Widget A performs best in APAC region based on Q1 data"
+5. **New session:**
+6. "What did I learn about Widget A sales?"
+7. **Magic moment:** Recalls the APAC insight from the data analysis session.
+
+**Dashboard check:** Note about Widget A, tool history showing scratchpad operations.
+
+---
+
+## Scenario 10: Conflict Resolution
+
+**The magic:** GAIA handles corrections gracefully, not stubbornly.
+
+1. "Our API gateway runs on port 8080 with basic HTTP auth"
+2. (Later) "We migrated the gateway to port 443 with OAuth 2.0"
+3. "What port does our API gateway use?"
+4. **Magic moment:** Says 443 with OAuth 2.0, not the old 8080/basic auth.
+5. **Dashboard check:** Old fact should be marked as superseded.
+
+---
+
+## Scenario 11: Screenshot + Memory
+
+**The magic:** GAIA remembers what it saw in screenshots.
+
+1. Take a screenshot of a dashboard or error dialog
+2. "Take a screenshot and analyze what you see"
+3. "Note: The monitoring dashboard shows 3 alerts for high CPU on prod-web-02"
+4. **New session:**
+5. "What was the last issue I noticed on the monitoring dashboard?"
+6. **Magic moment:** Recalls the CPU alerts on prod-web-02.
+
+---
+
+## Scenario 12: Journaling / Meeting Notes
+
+**The magic:** GAIA becomes your meeting secretary.
+
+1. "Meeting notes from today's standup:"
+2. "- Discussed Atlas v2 timeline, targeting July 1st launch"
+3. "- Sarah needs 2 more days for the Terraform migration"
+4. "- Marcus found a React hydration bug in the dashboard"
+5. "- Action item: I need to review the security audit by Wednesday"
+6. **New session, days later:**
+7. "What happened in my last standup?"
+8. **Magic moment:** Recalls the meeting notes with key points.
+9. "What action items do I have from meetings?"
+10. Should surface the security audit review.
+
+---
+
+## Scenario 13: Privacy Controls
+
+**The magic:** Users stay in control of their data.
+
+1. Toggle a session to "private" mode
+2. Share sensitive info: "The staging DB password is hunter2"
+3. End session. New non-private session:
+4. "What's the staging DB password?"
+5. **Magic moment:** GAIA doesn't know — private sessions don't write to memory.
+6. Non-private session: "Remember my AWS account ID: 123456789"
+7. "Forget my AWS account ID"
+8. "What's my AWS account ID?"
+9. **Magic moment:** Cleanly forgotten — not recalled.
+
+**Dashboard check:** Knowledge browser should not contain the deleted item.
+
+---
+
+## Scenario 14: Re-initialize Memory
+
+**The magic:** Clean slate, but the system rebuilds intelligently.
+
+1. Verify dashboard shows accumulated knowledge from all previous tests
+2. Go to Settings > click "Re-initialize"
+3. Confirm the dialog
+4. Dashboard should show empty knowledge (except system items if discovery is ON)
+5. Start a new chat: "Hi, I'm Alex, the backend engineer at Acme"
+6. **Magic moment:** Starts fresh — no remnants of previous identity or preferences.
+
+---
+
+## What to Watch For
+
+### Good Signs
+- Memory recalls are relevant and timely (not dumping everything it knows)
+- Preferences are applied silently (no "based on your preference for..." preamble)
+- Contradictions are resolved cleanly (new info supersedes old)
+- Cross-session recall feels natural, not robotic
+- The agent uses memory to inform tool usage (right port, right library, right style)
+
+### Red Flags
+- Agent says "I don't have memory" or "I can't remember across sessions"
+- Agent recalls deleted/forgotten items
+- Agent stores every trivial statement as a memory
+- Agent mentions "based on your stored preference" excessively (should be invisible)
+- Private session content leaks into non-private recall
+- System discovery runs without consent toggle being ON
+- Stale/superseded facts appear in responses instead of updated ones

--- a/src/gaia/agents/tools/file_edit.py
+++ b/src/gaia/agents/tools/file_edit.py
@@ -1,0 +1,425 @@
+#!/usr/bin/env python
+# Copyright(C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""Shared match-and-replace semantics for GAIA's file-editing tools.
+
+Every ``edit_*`` tool routes its match-and-replace through
+:func:`apply_unique_replacement`, so the separate implementations in
+``file_io_tools`` and ``file_tools`` cannot drift apart.
+
+The contract:
+
+- ``old_content`` must match **exactly once**. Two matches is an error naming
+  the count and the line of each, not a first-match replacement — the model
+  cannot tell a wrong-region edit from the one it asked for, and neither can
+  the human reading the diff.
+- A rejected edit carries the file's current content around the region the
+  caller was aiming at, so the retry lands without a separate re-read.
+- An edit against a file that changed since the agent read it is rejected by
+  :class:`FileStateTracker` rather than clobbering the newer contents.
+
+``FileStateTracker`` is a port of the C++ tracker in
+``cpp/include/gaia/file_tools.h``; the two trees keep the same ledger
+semantics deliberately.
+"""
+
+import difflib
+import hashlib
+import os
+import re
+import threading
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional, Tuple
+
+# Lines of surrounding context returned with a rejected edit.
+CONTEXT_RADIUS = 12
+
+# Lines of context shown per location in an ambiguity report.
+MATCH_CONTEXT_RADIUS = 2
+
+# Locations described individually before an ambiguity report stops listing them.
+MAX_REPORTED_MATCHES = 5
+
+# Ceiling on a returned excerpt, so a rejection cannot flood the context window.
+MAX_EXCERPT_CHARS = 4000
+
+# Similarity a line needs against the probe line to anchor a not-found excerpt.
+_ANCHOR_THRESHOLD = 0.6
+
+_SHORT_HASH_CHARS = 12
+
+
+def hash_content(content: str) -> str:
+    """Lowercase hex SHA-256 of ``content``."""
+    return hashlib.sha256(content.encode("utf-8")).hexdigest()
+
+
+def short_hash(content_hash: str) -> str:
+    """First ``_SHORT_HASH_CHARS`` of a hash, for human-readable messages."""
+    return content_hash[:_SHORT_HASH_CHARS]
+
+
+def _key(file_path: str) -> str:
+    """Ledger key: one entry per file however the caller spelled the path."""
+    return os.path.normcase(os.path.realpath(str(file_path)))
+
+
+@dataclass
+class Divergence:
+    """Result of comparing a file's current contents to what was read."""
+
+    diverged: bool = False
+    hash_at_read: str = ""
+    hash_now: str = ""
+    size_at_read: int = 0
+    size_now: int = 0
+    reason: str = ""
+
+
+@dataclass
+class _Record:
+    content_hash: str
+    size: int
+
+
+class FileStateTracker:
+    """Content-hash ledger of every file an agent has read.
+
+    A later write can then tell "the model is editing what it saw" from "the
+    file moved under it". No system prompt can prevent a stale write: by the
+    time the model emits an edit, the read that justified it may be many turns
+    old and a build step, a formatter, another agent, or the user may have
+    changed the file since.
+
+    Semantics (matching the C++ tracker):
+
+    - A read records the SHA-256 of the file's **full** contents, so a
+      line-range read still anchors the whole file.
+    - An edit is rejected when a record exists and the contents now hash
+      differently.
+    - A file with **no** record is not blocked. Requiring a prior read would
+      make the tools unusable for creating files, and an agent that never read
+      the file has nothing stale to be wrong about.
+    - A successful edit re-records the new contents, so consecutive edits work
+      without an intervening read.
+    """
+
+    _instance = None
+    _instance_lock = threading.Lock()
+
+    def __init__(self) -> None:
+        self._records: Dict[str, _Record] = {}
+        self._lock = threading.RLock()
+
+    @classmethod
+    def instance(cls) -> "FileStateTracker":
+        """Process-wide tracker shared by every file tool."""
+        with cls._instance_lock:
+            if cls._instance is None:
+                cls._instance = cls()
+            return cls._instance
+
+    def record_read(self, file_path: str, content: str) -> str:
+        """Record the contents an agent has just seen. Returns the hash."""
+        digest = hash_content(content)
+        with self._lock:
+            self._records[_key(file_path)] = _Record(
+                digest, len(content.encode("utf-8"))
+            )
+        return digest
+
+    def record_write(self, file_path: str, content: str) -> str:
+        """Record contents an agent has just written.
+
+        Identical to :meth:`record_read` but named for the call site so intent
+        stays readable.
+        """
+        return self.record_read(file_path, content)
+
+    def check(self, file_path: str, current_content: str) -> Divergence:
+        """Compare ``current_content`` against the recorded read.
+
+        Returns ``diverged=False`` when there is no record for the path.
+        """
+        with self._lock:
+            record = self._records.get(_key(file_path))
+        if record is None:
+            return Divergence()
+
+        digest = hash_content(current_content)
+        size_now = len(current_content.encode("utf-8"))
+        if digest == record.content_hash:
+            return Divergence(
+                hash_at_read=short_hash(record.content_hash),
+                hash_now=short_hash(digest),
+                size_at_read=record.size,
+                size_now=size_now,
+            )
+
+        return Divergence(
+            diverged=True,
+            hash_at_read=short_hash(record.content_hash),
+            hash_now=short_hash(digest),
+            size_at_read=record.size,
+            size_now=size_now,
+            reason=(
+                f"contents hashed {short_hash(record.content_hash)} when read "
+                f"and {short_hash(digest)} now "
+                f"({record.size} -> {size_now} bytes)"
+            ),
+        )
+
+    def has_record(self, file_path: str) -> bool:
+        with self._lock:
+            return _key(file_path) in self._records
+
+    def forget(self, file_path: str) -> None:
+        """Drop the record for a path (e.g. the file was deleted or renamed)."""
+        with self._lock:
+            self._records.pop(_key(file_path), None)
+
+    def clear(self) -> None:
+        """Drop every record. Intended for tests and session resets."""
+        with self._lock:
+            self._records.clear()
+
+    def size(self) -> int:
+        with self._lock:
+            return len(self._records)
+
+
+def record_read(file_path: str, content: str) -> str:
+    """Record a read against the process-wide tracker."""
+    return FileStateTracker.instance().record_read(file_path, content)
+
+
+def record_write(file_path: str, content: str) -> str:
+    """Record a write against the process-wide tracker."""
+    return FileStateTracker.instance().record_write(file_path, content)
+
+
+def _line_of(content: str, offset: int) -> int:
+    """1-based line number of a character offset."""
+    return content.count("\n", 0, offset) + 1
+
+
+def _match_offsets(content: str, needle: str) -> List[int]:
+    offsets = []
+    start = 0
+    while True:
+        found = content.find(needle, start)
+        if found == -1:
+            return offsets
+        offsets.append(found)
+        start = found + len(needle)
+
+
+def _collapse_whitespace(text: str) -> str:
+    return re.sub(r"\s+", " ", text).strip()
+
+
+def _clip(text: str) -> Tuple[str, bool]:
+    if len(text) <= MAX_EXCERPT_CHARS:
+        return text, False
+    return text[:MAX_EXCERPT_CHARS], True
+
+
+def _slice_lines(lines: List[str], center: int, radius: int) -> Tuple[str, int, int]:
+    """Excerpt around a 0-based line index. Returns (text, start_1based, end_1based)."""
+    start = max(0, center - radius)
+    end = min(len(lines), center + radius + 1)
+    return "\n".join(lines[start:end]), start + 1, end
+
+
+def _anchor_line(lines: List[str], old_content: str) -> Optional[int]:
+    """0-based index of the line most like the first real line of ``old_content``."""
+    probe = next((ln.strip() for ln in old_content.splitlines() if ln.strip()), "")
+    if not probe:
+        return None
+
+    best_index: Optional[int] = None
+    best_score = _ANCHOR_THRESHOLD
+    matcher = difflib.SequenceMatcher(b=probe, autojunk=False)
+    for index, line in enumerate(lines):
+        stripped = line.strip()
+        if not stripped:
+            continue
+        matcher.set_seq1(stripped)
+        # real_quick_ratio/quick_ratio are cheap upper bounds — skip the O(n*m)
+        # ratio() for lines that cannot clear the threshold.
+        if matcher.real_quick_ratio() <= best_score:
+            continue
+        if matcher.quick_ratio() <= best_score:
+            continue
+        score = matcher.ratio()
+        if score > best_score:
+            best_score = score
+            best_index = index
+    return best_index
+
+
+def _excerpt(current_content: str, old_content: str) -> Dict[str, Any]:
+    """Current content around the region the caller was most likely aiming at.
+
+    Centres on ``old_content`` when it occurs, on the closest fuzzy line match
+    otherwise, and falls back to the head of the file when nothing resembles it.
+    """
+    lines = current_content.splitlines()
+    total = len(lines)
+
+    offsets = _match_offsets(current_content, old_content) if old_content else []
+    if offsets:
+        center = _line_of(current_content, offsets[0]) - 1
+        anchored_on = "match"
+    else:
+        anchor = _anchor_line(lines, old_content)
+        if anchor is None:
+            center, anchored_on = min(CONTEXT_RADIUS, total), "file_start"
+        else:
+            center, anchored_on = anchor, "closest_line"
+
+    text, start, end = _slice_lines(lines, center, CONTEXT_RADIUS)
+    text, truncated = _clip(text)
+    return {
+        "current_content": text,
+        "current_content_start_line": start,
+        "current_content_end_line": end,
+        "current_content_total_lines": total,
+        "current_content_truncated": truncated,
+        "current_content_anchored_on": anchored_on,
+    }
+
+
+def _describe_matches(current_content: str, offsets: List[int]) -> List[Dict[str, Any]]:
+    lines = current_content.splitlines()
+    described = []
+    for offset in offsets[:MAX_REPORTED_MATCHES]:
+        line_no = _line_of(current_content, offset)
+        context, start, end = _slice_lines(lines, line_no - 1, MATCH_CONTEXT_RADIUS)
+        clipped, _ = _clip(context)
+        described.append(
+            {
+                "line": line_no,
+                "context": clipped,
+                "context_start_line": start,
+                "context_end_line": end,
+            }
+        )
+    return described
+
+
+def _error(
+    message: str, file_path: str, match_count: int, extra: Dict[str, Any]
+) -> Dict[str, Any]:
+    payload = {
+        "status": "error",
+        "error": message,
+        "file_path": str(file_path),
+        "match_count": match_count,
+    }
+    payload.update(extra)
+    return payload
+
+
+def apply_unique_replacement(
+    file_path: str,
+    current_content: str,
+    old_content: str,
+    new_content: str,
+) -> Tuple[Optional[str], Optional[Dict[str, Any]]]:
+    """Replace the single occurrence of ``old_content``, or explain why not.
+
+    Returns ``(updated_content, None)`` on success and ``(None, error)`` on
+    every rejection. The error dict always carries ``status``, ``error``,
+    ``file_path`` and ``match_count``; rejections that a retry could fix also
+    carry ``current_content`` and its line range, so the caller does not have
+    to re-read the file to try again.
+
+    Callers own their own security checks (path allowlist, size limits,
+    backups) — this function only decides *what* the new contents should be.
+    """
+    file_path = str(file_path)
+
+    if not old_content:
+        return None, _error(
+            f"old_content is empty, so there is nothing to find in {file_path} — "
+            "nothing was written. Pass the exact text to replace, or use "
+            "write_file to replace the whole file.",
+            file_path,
+            0,
+            {},
+        )
+
+    divergence = FileStateTracker.instance().check(file_path, current_content)
+    if divergence.diverged:
+        error = _error(
+            f"Edit rejected: {file_path} changed on disk after it was read — "
+            f"{divergence.reason}. Nothing was written. The file's current "
+            "content is included as `current_content`; reissue the edit against "
+            "that, not against what you read earlier.",
+            file_path,
+            len(_match_offsets(current_content, old_content)),
+            {
+                "stale": True,
+                "hash_at_read": divergence.hash_at_read,
+                "hash_now": divergence.hash_now,
+                **_excerpt(current_content, old_content),
+            },
+        )
+        # Returning the content *is* a read, so re-anchor. Without this the
+        # ledger still holds the superseded hash and the corrected retry is
+        # rejected as stale too — forever.
+        FileStateTracker.instance().record_read(file_path, current_content)
+        return None, error
+
+    offsets = _match_offsets(current_content, old_content)
+
+    if not offsets:
+        hint = ""
+        if _collapse_whitespace(old_content) in _collapse_whitespace(current_content):
+            hint = (
+                " A whitespace-insensitive match does exist, so the indentation, "
+                "tabs-vs-spaces, or line endings in old_content differ from the file."
+            )
+        excerpt = _excerpt(current_content, old_content)
+        return None, _error(
+            f"Content to replace not found in {file_path} — nothing was written."
+            f"{hint} The file's current content around the closest region is "
+            f"included as `current_content` (lines "
+            f"{excerpt['current_content_start_line']}-"
+            f"{excerpt['current_content_end_line']} of "
+            f"{excerpt['current_content_total_lines']}); copy old_content "
+            "verbatim from it.",
+            file_path,
+            0,
+            excerpt,
+        )
+
+    if len(offsets) > 1:
+        line_numbers = [_line_of(current_content, offset) for offset in offsets]
+        shown = ", ".join(str(n) for n in line_numbers[:MAX_REPORTED_MATCHES])
+        if len(line_numbers) > MAX_REPORTED_MATCHES:
+            shown += ", ..."
+        return None, _error(
+            f"Ambiguous edit: old_content matches {len(offsets)} locations in "
+            f"{file_path} (lines {shown}) — nothing was written, because there "
+            "is no way to tell which one you meant. Extend old_content with "
+            "enough surrounding lines to match exactly one location, then "
+            "reissue the edit. The candidate locations are listed in `matches`.",
+            file_path,
+            len(offsets),
+            {
+                "ambiguous": True,
+                "match_lines": line_numbers,
+                "matches": _describe_matches(current_content, offsets),
+                **_excerpt(current_content, old_content),
+            },
+        )
+
+    offset = offsets[0]
+    updated = (
+        current_content[:offset]
+        + new_content
+        + current_content[offset + len(old_content) :]
+    )
+    return updated, None

--- a/src/gaia/agents/tools/file_io_tools.py
+++ b/src/gaia/agents/tools/file_io_tools.py
@@ -14,6 +14,11 @@ import os
 from typing import Any, Dict, Optional
 
 from gaia.agents.base.tools import tool
+from gaia.agents.tools.file_edit import (
+    apply_unique_replacement,
+    record_read,
+    record_write,
+)
 
 
 class FileIOToolsMixin:
@@ -76,6 +81,9 @@ class FileIOToolsMixin:
                         "is_binary": True,
                         "size_bytes": len(content_bytes),
                     }
+
+                # Anchor later edits to what the agent actually saw.
+                record_read(file_path, content)
 
                 # Detect file type by extension
                 ext = os.path.splitext(file_path)[1].lower()
@@ -249,6 +257,7 @@ class FileIOToolsMixin:
                 # Write the file
                 with open(file_path, "w", encoding="utf-8") as f:
                     f.write(content)
+                record_write(str(file_path), content)
 
                 # Audit successful write
                 if path_validator is not None:
@@ -285,9 +294,13 @@ class FileIOToolsMixin:
             Includes security guardrails: path validation, blocked directory enforcement,
             sensitive file protection, size limits, backup creation, and audit logging.
 
+            old_content must match exactly one location. Zero or several matches
+            are errors that carry the file's current content, so a retry does not
+            need a separate read.
+
             Args:
                 file_path: Path to the file to edit
-                old_content: Content to find and replace
+                old_content: Content to find and replace; must be unique in the file
                 new_content: New content to insert
                 backup: Whether to create a backup
                 dry_run: Whether to only simulate the edit
@@ -338,15 +351,15 @@ class FileIOToolsMixin:
                 with open(file_path, "r", encoding="utf-8") as f:
                     current_content = f.read()
 
-                # Check if old content exists
-                if old_content not in current_content:
-                    return {
-                        "status": "error",
-                        "error": "Content to replace not found in file",
-                    }
-
-                # Create new content
-                modified_content = current_content.replace(old_content, new_content, 1)
+                modified_content, edit_error = apply_unique_replacement(
+                    str(file_path), current_content, old_content, new_content
+                )
+                if edit_error is not None:
+                    if path_validator is not None:
+                        path_validator.audit_write(
+                            "edit", str(file_path), 0, "denied", edit_error["error"]
+                        )
+                    return edit_error
 
                 # Validate new content (graceful degradation: stdlib ast if no mixin)
                 if hasattr(self, "_validate_python_syntax"):
@@ -395,6 +408,7 @@ class FileIOToolsMixin:
                 # Write the modified content
                 with open(file_path, "w", encoding="utf-8") as f:
                     f.write(modified_content)
+                record_write(str(file_path), modified_content)
 
                 # Audit successful edit
                 if path_validator is not None:
@@ -614,6 +628,7 @@ class FileIOToolsMixin:
                 # Write the file
                 with open(file_path, "w", encoding="utf-8") as f:
                     f.write(content)
+                record_write(str(file_path), content)
 
                 # Audit successful write
                 if path_validator is not None:
@@ -693,6 +708,7 @@ class FileIOToolsMixin:
 
                 # Write content to file
                 path.write_text(content, encoding="utf-8")
+                record_write(str(path), content)
 
                 console = getattr(self, "console", None)
                 if console:
@@ -743,9 +759,14 @@ class FileIOToolsMixin:
             Includes security guardrails: path validation, blocked directory enforcement,
             sensitive file protection, backup creation, and audit logging.
 
+            old_content must match exactly one location. Zero or several matches
+            are errors that carry the file's current content, so a retry does not
+            need a separate read.
+
             Args:
                 file_path: Path to the file to edit
-                old_content: Exact content to find and replace
+                old_content: Exact content to find and replace; must be unique
+                    in the file
                 new_content: New content to replace with
                 project_dir: Project root directory for resolving relative paths
 
@@ -806,20 +827,20 @@ class FileIOToolsMixin:
                 # Read current content
                 current_content = path.read_text(encoding="utf-8")
 
-                # Check if old_content exists in file
-                if old_content not in current_content:
-                    return {
-                        "status": "error",
-                        "error": f"Content to replace not found in {file_path}",
-                    }
+                updated_content, edit_error = apply_unique_replacement(
+                    str(path), current_content, old_content, new_content
+                )
+                if edit_error is not None:
+                    if path_validator is not None:
+                        path_validator.audit_write(
+                            "edit", str(path), 0, "denied", edit_error["error"]
+                        )
+                    return edit_error
 
                 # Backup before editing
                 backup_path = None
                 if path_validator is not None:
                     backup_path = path_validator.create_backup(str(path))
-
-                # Replace content
-                updated_content = current_content.replace(old_content, new_content, 1)
 
                 # Generate diff before writing
                 diff = "\n".join(
@@ -834,6 +855,7 @@ class FileIOToolsMixin:
 
                 # Write updated content
                 path.write_text(updated_content, encoding="utf-8")
+                record_write(str(path), updated_content)
 
                 console = getattr(self, "console", None)
                 if console:

--- a/src/gaia/agents/tools/file_tools.py
+++ b/src/gaia/agents/tools/file_tools.py
@@ -19,6 +19,12 @@ from datetime import datetime, timedelta
 from pathlib import Path, PureWindowsPath
 from typing import Any, Dict, List
 
+from gaia.agents.tools.file_edit import (
+    apply_unique_replacement,
+    record_read,
+    record_write,
+)
+
 logger = logging.getLogger(__name__)
 
 
@@ -672,6 +678,9 @@ class FileSearchToolsMixin:
                         "size_bytes": len(content_bytes),
                     }
 
+                # Anchor later edits to what the agent actually saw.
+                record_read(file_path, content)
+
                 # Detect file type by extension
                 ext = os.path.splitext(file_path)[1].lower()
 
@@ -1056,6 +1065,7 @@ class FileSearchToolsMixin:
                 # Write the file
                 with open(resolved_path, "w", encoding="utf-8") as f:
                     f.write(content)
+                record_write(str(resolved_path), content)
 
                 # Audit the successful write
                 if path_validator is not None:
@@ -1306,7 +1316,7 @@ class FileSearchToolsMixin:
         @tool(
             atomic=True,
             name="edit_file",
-            description="Edit a file by replacing specific content. Finds old_content in the file and replaces it with new_content. Creates a backup before editing.",
+            description="Edit a file by replacing specific content. old_content must match exactly one place in the file — if it matches more than one, the edit is rejected rather than guessing. Creates a backup before editing.",
             parameters={
                 "file_path": {
                     "type": "str",
@@ -1315,7 +1325,11 @@ class FileSearchToolsMixin:
                 },
                 "old_content": {
                     "type": "str",
-                    "description": "Exact content to find and replace in the file",
+                    "description": (
+                        "Exact content to find and replace. Must appear exactly "
+                        "once in the file — include enough surrounding lines to "
+                        "make it unique, or the edit is rejected as ambiguous."
+                    ),
                     "required": True,
                 },
                 "new_content": {
@@ -1333,6 +1347,10 @@ class FileSearchToolsMixin:
 
             Similar to Claude Code's Edit tool — performs a partial string replacement
             rather than overwriting the entire file. Includes all security guardrails.
+
+            old_content must match exactly one location. Zero or several matches
+            are errors that carry the file's current content, so a retry does not
+            need a separate read.
 
             Security checks performed:
             1. Path allowlist validation (PathValidator)
@@ -1395,21 +1413,20 @@ class FileSearchToolsMixin:
                 # Read current content
                 current_content = resolved_path.read_text(encoding="utf-8")
 
-                # Check if old_content exists in file
-                if old_content not in current_content:
-                    return {
-                        "status": "error",
-                        "error": f"Content to replace not found in {resolved_path}",
-                        "operation": "edit_file",
-                    }
+                updated_content, edit_error = apply_unique_replacement(
+                    str(resolved_path), current_content, old_content, new_content
+                )
+                if edit_error is not None:
+                    if path_validator is not None:
+                        path_validator.audit_write(
+                            "edit", str(resolved_path), 0, "denied", edit_error["error"]
+                        )
+                    return {**edit_error, "operation": "edit_file"}
 
                 # Create backup before editing
                 backup_path = None
                 if path_validator is not None:
                     backup_path = path_validator.create_backup(str(resolved_path))
-
-                # Replace content (first occurrence only)
-                updated_content = current_content.replace(old_content, new_content, 1)
 
                 # Generate diff for logging/display
                 diff = "\n".join(
@@ -1423,6 +1440,7 @@ class FileSearchToolsMixin:
 
                 # Write updated content
                 resolved_path.write_text(updated_content, encoding="utf-8")
+                record_write(str(resolved_path), updated_content)
 
                 # Audit the edit
                 edit_size = len(updated_content.encode("utf-8"))

--- a/tests/unit/agents/test_file_edit_semantics.py
+++ b/tests/unit/agents/test_file_edit_semantics.py
@@ -1,0 +1,335 @@
+# Copyright(C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+"""
+Tests for the shared match-and-replace semantics of GAIA's file-editing tools.
+
+Purpose: an ``old_content`` that matches more than one place in a file used to
+be replaced at the *first* match and reported as a success, so the agent
+believed it had changed one region while the diff touched another (#3377).
+These tests pin the replacement contract for every ``edit_*`` tool:
+
+- exactly one match replaces; zero or several is an error and writes nothing
+- a rejected edit carries the file's current content, so the retry needs no
+  extra read
+- an edit against a file that changed since it was read is rejected
+
+The behaviour table is parametrized over all three implementations, so the
+suite fails if any one of them drifts from the others.
+
+No LLM or external service required.
+"""
+
+import importlib
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from gaia.agents.base.tools import _TOOL_REGISTRY
+from gaia.agents.tools.file_edit import FileStateTracker, apply_unique_replacement
+
+# Valid Python (edit_python_file rejects edits that break the parse) with a
+# body line that deliberately appears twice.
+SAMPLE = '''"""Module."""
+
+
+def alpha():
+    value = 1
+    return value
+
+
+def beta():
+    value = 1
+    return value
+'''
+
+DUPLICATED = "    value = 1"
+UNIQUE_OLD = "def alpha():\n    value = 1"
+UNIQUE_NEW = "def alpha():\n    value = 99"
+
+# (id, module, mixin class, registrar, tool name)
+EDIT_TOOLS = [
+    (
+        "file_io_tools.edit_file",
+        "gaia.agents.tools.file_io_tools",
+        "FileIOToolsMixin",
+        "register_file_io_tools",
+        "edit_file",
+    ),
+    (
+        "file_io_tools.edit_python_file",
+        "gaia.agents.tools.file_io_tools",
+        "FileIOToolsMixin",
+        "register_file_io_tools",
+        "edit_python_file",
+    ),
+    (
+        "file_tools.edit_file",
+        "gaia.agents.tools.file_tools",
+        "FileSearchToolsMixin",
+        "register_file_search_tools",
+        "edit_file",
+    ),
+]
+
+EDIT_TOOL_IDS = [entry[0] for entry in EDIT_TOOLS]
+
+
+@pytest.fixture(autouse=True)
+def clean_tracker():
+    """The tracker is process-wide; no test may inherit another's ledger."""
+    FileStateTracker.instance().clear()
+    yield
+    FileStateTracker.instance().clear()
+
+
+@pytest.fixture(params=EDIT_TOOLS, ids=EDIT_TOOL_IDS)
+def edit_tool(request):
+    """Every edit tool, behind one ``(path, old, new) -> dict`` signature.
+
+    The two ``edit_file`` implementations register under the same name and
+    overwrite each other in the registry, so each is registered and captured
+    on its own.
+    """
+    _, module_name, class_name, registrar, tool_name = request.param
+    module = importlib.import_module(module_name)
+    mixin = getattr(module, class_name)()
+
+    saved = dict(_TOOL_REGISTRY)
+    try:
+        getattr(mixin, registrar)()
+        entry = _TOOL_REGISTRY.get(tool_name)
+        assert entry is not None, f"{tool_name} was not registered by {registrar}"
+        function = entry["function"]
+
+        def call(path, old, new):
+            return function(str(path), old, new)
+
+        call.module_name = module_name
+        call.tool_name = tool_name
+        yield call
+    finally:
+        _TOOL_REGISTRY.clear()
+        _TOOL_REGISTRY.update(saved)
+
+
+@pytest.fixture
+def sample_file(tmp_path) -> Path:
+    path = tmp_path / "sample.py"
+    path.write_text(SAMPLE, encoding="utf-8")
+    return path
+
+
+# ============================================================================
+# 1. AMBIGUITY IS AN ERROR, NOT A FIRST-MATCH REPLACEMENT
+# ============================================================================
+
+
+class TestAmbiguousOldContent:
+    """A non-unique old_content must be refused, with the count named."""
+
+    def test_ambiguous_edit_is_rejected(self, edit_tool, sample_file):
+        result = edit_tool(sample_file, DUPLICATED, "    value = 2")
+        assert result["status"] == "error"
+
+    def test_ambiguous_edit_writes_nothing(self, edit_tool, sample_file):
+        edit_tool(sample_file, DUPLICATED, "    value = 2")
+        assert sample_file.read_text(encoding="utf-8") == SAMPLE
+
+    def test_ambiguous_error_states_the_match_count(self, edit_tool, sample_file):
+        result = edit_tool(sample_file, DUPLICATED, "    value = 2")
+        assert result["match_count"] == 2
+        assert "2" in result["error"]
+
+    def test_ambiguous_error_locates_every_match(self, edit_tool, sample_file):
+        result = edit_tool(sample_file, DUPLICATED, "    value = 2")
+        # SAMPLE puts the duplicated line on lines 5 and 10.
+        assert result["match_lines"] == [5, 10]
+        assert [m["line"] for m in result["matches"]] == [5, 10]
+
+    def test_ambiguous_error_says_how_to_retry(self, edit_tool, sample_file):
+        result = edit_tool(sample_file, DUPLICATED, "    value = 2")
+        assert "surrounding lines" in result["error"]
+
+
+# ============================================================================
+# 2. A REJECTED EDIT CARRIES CURRENT CONTENT
+# ============================================================================
+
+
+class TestNotFoundCarriesContent:
+    """The retry must not need a separate re-read to succeed."""
+
+    def test_not_found_is_an_error_with_zero_matches(self, edit_tool, sample_file):
+        result = edit_tool(sample_file, "def gamma():", "def delta():")
+        assert result["status"] == "error"
+        assert result["match_count"] == 0
+
+    def test_not_found_error_carries_file_content(self, edit_tool, sample_file):
+        result = edit_tool(sample_file, "def gamma():", "def delta():")
+        excerpt = result["current_content"]
+        assert excerpt, "not-found error returned no current content"
+        assert excerpt in SAMPLE, "excerpt is not verbatim from the file"
+
+    def test_not_found_error_gives_the_excerpt_line_range(self, edit_tool, sample_file):
+        result = edit_tool(sample_file, "def gamma():", "def delta():")
+        assert result["current_content_start_line"] >= 1
+        assert (
+            result["current_content_end_line"] <= result["current_content_total_lines"]
+        )
+
+    def test_whitespace_only_mismatch_is_called_out(self, edit_tool, sample_file):
+        """The commonest not-found cause deserves naming, not guessing."""
+        result = edit_tool(sample_file, "def  alpha():", "def gamma():")
+        assert "whitespace-insensitive" in result["error"]
+
+    def test_empty_old_content_is_rejected(self, edit_tool, sample_file):
+        result = edit_tool(sample_file, "", "anything")
+        assert result["status"] == "error"
+        assert sample_file.read_text(encoding="utf-8") == SAMPLE
+
+
+# ============================================================================
+# 3. STALENESS
+# ============================================================================
+
+
+class TestStalenessRejection:
+    """An edit against a file that moved under the agent must not clobber it."""
+
+    def test_stale_edit_is_rejected(self, edit_tool, sample_file):
+        FileStateTracker.instance().record_read(str(sample_file), "something older")
+        result = edit_tool(sample_file, UNIQUE_OLD, UNIQUE_NEW)
+        assert result["status"] == "error"
+        assert result["stale"] is True
+
+    def test_stale_edit_writes_nothing(self, edit_tool, sample_file):
+        FileStateTracker.instance().record_read(str(sample_file), "something older")
+        edit_tool(sample_file, UNIQUE_OLD, UNIQUE_NEW)
+        assert sample_file.read_text(encoding="utf-8") == SAMPLE
+
+    def test_stale_rejection_carries_current_content(self, edit_tool, sample_file):
+        FileStateTracker.instance().record_read(str(sample_file), "something older")
+        result = edit_tool(sample_file, UNIQUE_OLD, UNIQUE_NEW)
+        assert result["current_content"] in SAMPLE
+
+    def test_stale_rejection_names_both_hashes(self, edit_tool, sample_file):
+        FileStateTracker.instance().record_read(str(sample_file), "something older")
+        result = edit_tool(sample_file, UNIQUE_OLD, UNIQUE_NEW)
+        assert result["hash_at_read"] != result["hash_now"]
+        assert result["hash_at_read"] in result["error"]
+
+    def test_matching_read_does_not_block_the_edit(self, edit_tool, sample_file):
+        FileStateTracker.instance().record_read(str(sample_file), SAMPLE)
+        result = edit_tool(sample_file, UNIQUE_OLD, UNIQUE_NEW)
+        assert result["status"] == "success"
+
+    def test_unread_file_is_not_blocked(self, edit_tool, sample_file):
+        """No record means nothing stale to be wrong about."""
+        assert not FileStateTracker.instance().has_record(str(sample_file))
+        result = edit_tool(sample_file, UNIQUE_OLD, UNIQUE_NEW)
+        assert result["status"] == "success"
+
+    def test_consecutive_edits_need_no_intervening_read(self, edit_tool, sample_file):
+        """A successful edit re-anchors the ledger to what it just wrote."""
+        first = edit_tool(sample_file, UNIQUE_OLD, UNIQUE_NEW)
+        assert first["status"] == "success"
+        second = edit_tool(sample_file, "def beta():", "def gamma():")
+        assert second["status"] == "success"
+
+    def test_stale_rejection_is_not_a_dead_end(self, edit_tool, sample_file):
+        """Rejecting forever is as broken as clobbering.
+
+        The rejection hands the current content back, so it counts as a read:
+        the corrected retry must go through instead of hitting the superseded
+        hash again.
+        """
+        FileStateTracker.instance().record_read(str(sample_file), "something older")
+        rejected = edit_tool(sample_file, UNIQUE_OLD, UNIQUE_NEW)
+        assert rejected["status"] == "error"
+
+        retry = edit_tool(sample_file, UNIQUE_OLD, UNIQUE_NEW)
+        assert retry["status"] == "success", "stale rejection livelocked the agent"
+
+
+# ============================================================================
+# 4. THE HAPPY PATH STILL WORKS
+# ============================================================================
+
+
+class TestUniqueReplacement:
+    def test_unique_old_content_is_replaced(self, edit_tool, sample_file):
+        result = edit_tool(sample_file, UNIQUE_OLD, UNIQUE_NEW)
+        assert result["status"] == "success"
+        assert sample_file.read_text(encoding="utf-8") == SAMPLE.replace(
+            UNIQUE_OLD, UNIQUE_NEW
+        )
+
+    def test_only_the_matched_region_changes(self, edit_tool, sample_file):
+        edit_tool(sample_file, UNIQUE_OLD, UNIQUE_NEW)
+        updated = sample_file.read_text(encoding="utf-8")
+        assert "def alpha():\n    value = 99" in updated
+        assert "def beta():\n    value = 1" in updated
+
+
+# ============================================================================
+# 5. THE IMPLEMENTATIONS CANNOT DIVERGE
+# ============================================================================
+
+
+class TestImplementationsCannotDiverge:
+    """Every edit site must decide *what* to replace in exactly one place.
+
+    The behaviour classes above already run against all three tools; these
+    tests stop a future edit from quietly reintroducing a private
+    match-and-replace that passes those by accident.
+    """
+
+    def test_every_edit_tool_delegates_to_the_shared_helper(
+        self, edit_tool, sample_file
+    ):
+        target = f"{edit_tool.module_name}.apply_unique_replacement"
+        with patch(target, wraps=apply_unique_replacement) as spy:
+            edit_tool(sample_file, UNIQUE_OLD, UNIQUE_NEW)
+        assert spy.call_count == 1, (
+            f"{edit_tool.tool_name} did not route its replacement through "
+            "apply_unique_replacement"
+        )
+
+    @pytest.mark.parametrize(
+        "module_file",
+        [
+            "src/gaia/agents/tools/file_io_tools.py",
+            "src/gaia/agents/tools/file_tools.py",
+        ],
+    )
+    def test_no_edit_site_keeps_a_first_match_replace(self, module_file):
+        """``.replace(old_content, ..., 1)`` is the bug; it must not come back."""
+        repo_root = Path(__file__).resolve().parents[3]
+        source = (repo_root / module_file).read_text(encoding="utf-8")
+        assert (
+            "replace(old_content" not in source
+        ), f"{module_file} still does its own old_content replacement"
+
+    def test_the_three_tools_agree_on_the_error_shape(self, tmp_path):
+        """Same input, same keys — a caller can handle one shape, not three."""
+        shapes = {}
+        for tool_id, module_name, class_name, registrar, tool_name in EDIT_TOOLS:
+            module = importlib.import_module(module_name)
+            mixin = getattr(module, class_name)()
+            saved = dict(_TOOL_REGISTRY)
+            try:
+                getattr(mixin, registrar)()
+                function = _TOOL_REGISTRY[tool_name]["function"]
+                path = tmp_path / f"{tool_id.replace('.', '_')}.py"
+                path.write_text(SAMPLE, encoding="utf-8")
+                result = function(str(path), DUPLICATED, "    value = 2")
+            finally:
+                _TOOL_REGISTRY.clear()
+                _TOOL_REGISTRY.update(saved)
+            # ``operation`` is file_tools' own pre-existing extra key.
+            shapes[tool_id] = frozenset(result) - {"operation"}
+
+        distinct = set(shapes.values())
+        assert len(distinct) == 1, f"edit tools disagree on error keys: {shapes}"


### PR DESCRIPTION
Closes #3377.

When the text an edit was replacing appeared more than once in a file, GAIA edited the **first** occurrence and reported success. The agent believed it had changed the thing it named, and the user reviewed a diff that touched a different region of the file. It is the failure mode least likely to be caught in review, because the diff is a real edit, of the right shape, in the wrong place. Now a non-unique match is an error that names how many places matched and where, and nothing is written. Two related costs go away with it: a failed edit hands back the file's current content instead of a bare "not found", so the retry no longer burns a round trip re-reading; and an edit issued against a file that changed since the agent read it is rejected rather than clobbering the newer version.

### Threads

- **One implementation, three tools.** `file_io_tools.edit_file`, `file_io_tools.edit_python_file` and `file_tools.edit_file` each had the defect independently. They now share `gaia.agents.tools.file_edit`, and the test table runs against all three so they cannot drift apart again.
- **The C++ tree converges rather than staying a third semantic.** Its `file_edit` replaced *all* occurrences — worse than first-match, since it corrupts every region the model did not name. It now requires a unique match and carries current content on rejection, so an agent behaves the same on either tree.
- **Staleness rejection is recoverable, not a dead end.** The first draft rejected the stale edit but left the superseded hash in the ledger, so the corrected retry was rejected forever. Returning the content counts as a read, so the edit path re-anchors; `file_write` stays strict, because it names no `old_string` and a blind retry would clobber.

No caller relies on first-match semantics. These tools are model-invoked; grepping `edit_file(` / `edit_python_file(` across `src/`, `hub/` and `tests/` returns no call sites, only registration and grant lists.

### Test plan

- [ ] `python -m pytest tests/unit/agents/test_file_edit_semantics.py -q` — 66 pass. Parametrized over all three tools: ambiguity errors and writes nothing, not-found carries verbatim content, stale rejection carries content and the retry then succeeds, unique match still replaces.
- [ ] Confirm the tests catch the original bug, not just pass: stub `apply_unique_replacement` back to `if old not in c: error; else c.replace(old, new, 1)` and re-run — 42 of the 63 then-existing tests fail.
- [ ] `python -m pytest tests/unit/ -q` — no regressions. Against clean `main` as a baseline: 616 failed / 488 errors / 9621 passed → 614 / 488 / 9686. Pre-existing failures are environmental (no network in the sandbox; an editable install resolving `gaia_agent_email` to another worktree causes 24 collection errors, excluded from both runs).
- [ ] `python -m pytest` on every test touching the changed modules (`test_file_tools`, `test_file_write_guardrails`, `test_builder_agent`, `test_tool_grants`, `test_confirmation_required_tools`, `test_chat_agent_integration`, `test_skill_binary_grants`, `test_starter_skills`, `test_mcp_tool_risk_classification`) — 900 pass, 0 fail.
- [ ] C++: `cmake --build <dir> --target tests_mock && tests_mock.exe` — 1068 pass, 0 fail. `--gtest_filter='FileTools*'` covers the new ambiguity, recovery, and excerpt-anchoring cases.
- [ ] Lint: `black`, `isort`, `flake8`, `pylint` clean on the changed files (`util/lint.py --all` cannot fetch its tools via `uvx` in this sandbox, so each was run from the local env with the same project config).