### PR TITLE
feat(shell): adaptive timeouts and a wait-for-condition primitive

### DIFF
--- a/docs/guides/gaia.mdx
+++ b/docs/guides/gaia.mdx
@@ -85,7 +85,7 @@ It answers **200** when ready and **503** when not, with a `hint` naming the fix
 
 ## Tool surface
 
-The default construction registers **67 tools** — the 55 of the Chat agent's `full` profile, plus 7 skill-library tools, 4 code-search tools, and the `load_tools` escape hatch. Grouped by what they're for:
+The default construction registers **68 tools** — the 56 of the Chat agent's `full` profile, plus 7 skill-library tools, 4 code-search tools, and the `load_tools` escape hatch. Grouped by what they're for:
 
 | Area | Tools |
 |---|---|
@@ -95,7 +95,7 @@ The default construction registers **67 tools** — the 55 of the Chat agent's `
 | Web | `search_web`, `fetch_page`, `fetch_webpage`, `open_url`, `download_file`, `bookmark`, `search_documentation` |
 | Memory | `remember`, `recall`, `forget`, `update_memory`, `search_past_conversations` |
 | Images | `analyze_image`, `answer_question_about_image` |
-| Desktop & system | `take_screenshot`, `list_windows`, `get_system_info`, `notify_desktop`, `read_clipboard`, `write_clipboard`, `text_to_speech`, `run_shell_command` |
+| Desktop & system | `take_screenshot`, `list_windows`, `get_system_info`, `notify_desktop`, `read_clipboard`, `write_clipboard`, `text_to_speech`, `run_shell_command`, `wait_for_condition` |
 | Skills | `list_skills`, `search_skill_hub`, `install_skill`, `remove_skill`, `load_skill`, `unload_skill`, `skill_status` |
 | Code search | `index_codebase`, `search_code_index`, `get_index_status`, `clear_code_index` |
 | Run control | `request_user_input`, `set_loop_state`, `load_tools` |
@@ -104,14 +104,16 @@ That count is what the agent *can* do, not what it sees at once: per-turn tool s
 
 `run_shell_command` is restricted to a read-only command allowlist (`ls`, `cat`, `grep`, `find`, `stat`, `df`, `uname`, and similar) and rate-limited. Anything that writes, installs, or executes an arbitrary binary is refused.
 
+How long a command may run depends on what it is — a test run gets 15 minutes, a build or install 30, a network call 5, and everything else the usual 30 seconds. `wait_for_condition` covers the other half of waiting: give it a command that succeeds once the thing you are waiting for is ready (a file written, a server answering) and the agent waits in one step instead of re-checking in a loop.
+
 **Image *generation* is deliberately off.** Drawing a picture would pull a second model into Lemonade and evict the resident chat model mid-conversation — not a trade a document agent should make silently. A custom agent can still compose the [`sd` tool mixin](/sdk/mixins/tool-mixins#95-stable-diffusion-mixin) when that trade-off is acceptable.
 
 ### Tools that need your approval
 
-Six tools mutate your machine and are gated behind an explicit confirmation: **`write_file`**, **`edit_file`**, **`run_shell_command`**, **`execute_python_file`**, and — because installing a skill writes third-party code under `~/.gaia/skills` and removing one deletes it — **`install_skill`** and **`remove_skill`**. Everything else — reading, indexing, querying, web fetching, memory — runs without asking.
+Seven tools mutate your machine and are gated behind an explicit confirmation: **`write_file`**, **`edit_file`**, **`run_shell_command`**, **`wait_for_condition`** (it re-runs a shell command until it succeeds), **`execute_python_file`**, and — because installing a skill writes third-party code under `~/.gaia/skills` and removing one deletes it — **`install_skill`** and **`remove_skill`**. Everything else — reading, indexing, querying, web fetching, memory — runs without asking.
 
 <Warning>
-  **Over the sidecar's `/query` stream, all six are refused rather than prompted.** That
+  **Over the sidecar's `/query` stream, all seven are refused rather than prompted.** That
   surface has no way to collect an approval, so instead of pretending to, the run stops
   with a message saying which action it declined. If your workflow depends on the agent
   writing files, drive it from a surface that can prompt you, or perform the write yourself.
@@ -227,5 +229,5 @@ The daemon redirects the sidecar's output to `~/.gaia/agents/gaia/logs/sidecar-<
 
 - **No skill sets declared** — the skill machinery is wired and tested, and `gaia-voice` ships always-on, but no *set* does; see [Skills](#skills).
 - **Narrowing file scope requires embedding the agent** — no sidecar flag for `allowed_paths` yet.
-- **No server-side confirmation flow** — over `/query`, all six [confirmation-gated tools](#tools-that-need-your-approval) end the run with a refusal instead of prompting over the stream.
+- **No server-side confirmation flow** — over `/query`, all seven [confirmation-gated tools](#tools-that-need-your-approval) end the run with a refusal instead of prompting over the stream.
 - **No image generation** — deliberately, so the chat model is never evicted mid-conversation.

--- a/docs/sdk/mixins/tool-mixins.mdx
+++ b/docs/sdk/mixins/tool-mixins.mdx
@@ -121,7 +121,11 @@ class MyAgent(Agent, ShellToolsMixin):
         super()._register_tools()
         self.register_shell_tools()
         # Registers:
-        # - run_shell_command(command, working_directory=None, timeout=30)
+        # - run_shell_command(command, working_directory=None, timeout=None)
+        #     timeout=None picks the default for the command's class:
+        #     test 900s, build 1800s, network 300s, everything else 30s
+        # - wait_for_condition(command, working_directory=None,
+        #                      timeout=120, poll_interval=5)
 ```
 
 ---

--- a/docs/spec/shell-tools-mixin.mdx
+++ b/docs/spec/shell-tools-mixin.mdx
@@ -41,7 +41,7 @@ ShellToolsMixin provides secure shell command execution with comprehensive rate 
    - Blacklist dangerous commands (rm, chmod, sudo, etc.)
    - Git read-only subcommands only
    - Working directory support
-   - Timeout protection (default: 30s)
+   - Timeout protection, scaled to the kind of command (see below)
 
 2. **Rate Limiting**
    - Max 10 commands per minute (sustained)
@@ -106,6 +106,7 @@ class ShellToolsMixin:
 
     Tools provided:
     - run_shell_command: Execute safe shell commands with security checks
+    - wait_for_condition: Poll a predicate until it succeeds, or hit a deadline
     """
 
     def __init__(self, *args, **kwargs):
@@ -136,7 +137,7 @@ class ShellToolsMixin:
     def run_shell_command(
         command: str,
         working_directory: Optional[str] = None,
-        timeout: int = 30
+        timeout: Optional[int] = None
     ) -> Dict[str, Any]:
         """
         Execute a shell command and return output.
@@ -152,7 +153,8 @@ class ShellToolsMixin:
         Args:
             command: Shell command to execute (e.g., 'ls -la')
             working_directory: Optional directory to run in
-            timeout: Max execution time in seconds (default: 30)
+            timeout: Max execution time in seconds. None (the default) picks
+                the default for the command's class — see Adaptive Timeouts.
 
         Returns:
             {
@@ -163,7 +165,8 @@ class ShellToolsMixin:
                 "return_code": int,
                 "has_errors": bool,
                 "duration_seconds": float,
-                "timeout": int,
+                "timeout": int,           # The applied timeout
+                "timeout_class": str,     # Which class it came from
                 "cwd": str,
                 "output_truncated": bool,
                 "rate_limited": bool,  # If rate limited
@@ -179,7 +182,72 @@ class ShellToolsMixin:
             Path utils: which, basename, dirname
         """
         pass
+
+    @tool
+    def wait_for_condition(
+        command: str,
+        working_directory: Optional[str] = None,
+        timeout: int = 120,
+        poll_interval: int = 5
+    ) -> Dict[str, Any]:
+        """
+        Block until `command` exits 0, or until the deadline passes.
+
+        Args:
+            command: The predicate — exits 0 once the condition holds. Runs
+                through run_shell_command, so the same guardrails apply.
+            working_directory: Optional directory to run the predicate in
+            timeout: Give up after this many seconds (max 600)
+            poll_interval: Seconds between checks (5-60)
+
+        Returns:
+            {
+                "status": "success" | "error",
+                "condition_met": bool,
+                "command": str,
+                "elapsed_seconds": float,
+                "polls": int,
+                "poll_interval_seconds": int,
+                "timeout": int,
+                "stdout": str,
+                "stderr": str,
+                "timed_out": bool,          # Deadline expired
+                "last_return_code": int,    # On expiry
+                "cancelled": bool           # Agent cancel signal fired
+            }
+        """
+        pass
 ```
+
+### Adaptive Timeouts
+
+A flat 30s timeout kills the commands that legitimately take minutes. The
+default now comes from the command itself — `src/gaia/agents/tools/command_timeouts.py`
+classifies it and applies the class default. An explicit `timeout=` always wins.
+
+| Class | Default | Matches |
+|-------|---------|---------|
+| `test` | 900s | pytest, tox, jest/vitest, `cargo test`, `go test`, `npm test`, `mvn test`, `gaia eval` |
+| `build` | 1800s | pip/uv/poetry/conda/apt installs, make, cmake, ninja, msbuild, tsc, `cargo build`, `npm ci`, `docker build` |
+| `network` | 300s | `git clone/fetch/pull/push`, gh, curl, wget, ssh/scp/rsync, `docker pull` |
+| `default` | 30s | everything else — the read-only allowlist (ls, cat, grep, `git status`) |
+
+A pipeline takes the longest class of any segment: `pytest -q \| tail` is a test
+run whose output happens to be filtered. Wrappers are transparent, so
+`python -m pytest`, `uv run pytest` and `npx jest` all classify as `test`.
+
+A timeout above the 3600s ceiling is **refused, not clamped** — a command killed
+at a limit its caller never chose is a failure with no visible cause.
+
+### Waiting Without Spinning
+
+`wait_for_condition` exists so the agent never sleeps-and-rechecks. Polling
+happens inside one call against a monotonic deadline, so a five-minute wait
+costs one step of the agent's loop budget rather than sixty. It is bounded by
+construction (600s ceiling, 5-60s poll interval), charged **once** against the
+shell rate limit rather than once per probe, and waits on the agent's cancel
+event so Stop takes effect immediately. Deadline expiry is an error carrying the
+last probe's output — never a quiet `False`.
 
 ---
 

--- a/hub/agents/chat/python/gaia-agent.yaml
+++ b/hub/agents/chat/python/gaia-agent.yaml
@@ -11,7 +11,7 @@ icon: message-circle
 # Real registered-tool count for entry_class's default config (prompt_profile
 # defaults to "full") — introspected, drift-guarded by
 # tests/unit/test_chat_fix_contracts.py.
-tools_count: 54
+tools_count: 55
 
 language: python
 min_gaia_version: "0.22.0"

--- a/hub/agents/chat/python/gaia_agent_chat/tool_bundles.py
+++ b/hub/agents/chat/python/gaia_agent_chat/tool_bundles.py
@@ -351,11 +351,15 @@ FULL_BUNDLES = [
         members=frozenset(
             {
                 "run_shell_command",
+                "wait_for_condition",
                 "execute_python_file",
                 "get_system_info",
             }
         ),
-        description="Run shell commands and Python scripts, and query the system.",
+        description=(
+            "Run shell commands and Python scripts, wait for a condition to "
+            "become true, and query the system."
+        ),
     ),
     ToolBundle(
         name="clipboard",

--- a/hub/agents/chat/python/gaia_agent_chat/tool_bundles.py
+++ b/hub/agents/chat/python/gaia_agent_chat/tool_bundles.py
@@ -124,8 +124,13 @@ DOC_BUNDLES = [
     ),
     ToolBundle(
         name="shell",
-        members=frozenset({"run_shell_command", "get_system_info"}),
-        description="Run shell commands and query the system.",
+        members=frozenset(
+            {"run_shell_command", "wait_for_condition", "get_system_info"}
+        ),
+        description=(
+            "Run shell commands, wait for a condition to become true, and "
+            "query the system."
+        ),
     ),
     ToolBundle(
         name="clipboard",

--- a/hub/agents/gaia/python/gaia-agent.yaml
+++ b/hub/agents/gaia/python/gaia-agent.yaml
@@ -20,7 +20,7 @@ icon: sparkles
 # + the load_tools escape hatch, which registers because dynamic_tools is on.
 # This is the REGISTERED size — what the agent can do. Dynamic tool loading
 # means a single turn only shows the model a subset of it.
-tools_count: 67
+tools_count: 68
 
 language: python
 min_gaia_version: "0.23.0"

--- a/hub/agents/gaia/python/gaia_agent/__init__.py
+++ b/hub/agents/gaia/python/gaia_agent/__init__.py
@@ -74,7 +74,7 @@ def build_gaia():
         icon="sparkles",
         # Must equal the real registry size for the default construction, and
         # the manifest's own tools_count. Drift-guarded by tests/test_gaia_agent.py.
-        tools_count=67,
+        tools_count=68,
         # ChatAgent loads MCP servers dynamically, so the Settings "Active for"
         # panel must list this agent for MCP-server connectors.
         consumes_mcp_servers=True,

--- a/src/gaia/agents/base/agent.py
+++ b/src/gaia/agents/base/agent.py
@@ -198,6 +198,9 @@ class ToolExecutionTimeout(Exception):
 TOOLS_REQUIRING_CONFIRMATION = {
     "run_shell_command",
     "run_cli_command",
+    # Re-runs a shell command until it succeeds; gated for the same reason as
+    # the command it polls with.
+    "wait_for_condition",
     # Runs a .py file in a subprocess — arbitrary code execution, and unlike
     # run_shell_command there is no read-only allowlist behind it.
     "execute_python_file",

--- a/src/gaia/agents/base/tool_grants.py
+++ b/src/gaia/agents/base/tool_grants.py
@@ -87,9 +87,7 @@ _MAX_SHELL_SCOPE_WORDS = 2
 #: ``wait_for_condition`` belongs here because its ``command`` is a shell
 #: command like any other — scoping the grant to it keeps "always" from becoming
 #: "any command, as long as you poll with it".
-_SHELL_TOOLS = frozenset(
-    {"run_shell_command", "run_cli_command", "wait_for_condition"}
-)
+_SHELL_TOOLS = frozenset({"run_shell_command", "run_cli_command", "wait_for_condition"})
 
 #: Tools whose blast radius is one path. The grant is that exact path — not its
 #: directory: the prompt named a file, so the grant covers a file.

--- a/src/gaia/agents/base/tool_grants.py
+++ b/src/gaia/agents/base/tool_grants.py
@@ -84,7 +84,12 @@ _UNBOUNDED_BINARIES = frozenset(
 #: ``git remote add``) and stops well short of the arguments.
 _MAX_SHELL_SCOPE_WORDS = 2
 
-_SHELL_TOOLS = frozenset({"run_shell_command", "run_cli_command"})
+#: ``wait_for_condition`` belongs here because its ``command`` is a shell
+#: command like any other — scoping the grant to it keeps "always" from becoming
+#: "any command, as long as you poll with it".
+_SHELL_TOOLS = frozenset(
+    {"run_shell_command", "run_cli_command", "wait_for_condition"}
+)
 
 #: Tools whose blast radius is one path. The grant is that exact path — not its
 #: directory: the prompt named a file, so the grant covers a file.

--- a/src/gaia/agents/tools/command_timeouts.py
+++ b/src/gaia/agents/tools/command_timeouts.py
@@ -1,0 +1,315 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""How long a shell command is allowed to run, by what kind of command it is.
+
+One flat 30s default kills test suites, builds and installs — the commands that
+legitimately take minutes. The model *can* pass ``timeout=`` itself, but nothing
+tells it how long the command it is about to run should take, so it rarely does.
+
+This module answers that question up front: classify the command text, apply the
+class default. Four classes, no hidden heuristics, table below.
+
++----------------+---------+------------------------------------------------+
+| class          | default | matches                                        |
++================+=========+================================================+
+| ``test``       |   900 s | pytest/tox/nox, jest/vitest/mocha/playwright,  |
+|                |         | ``cargo test``, ``go test``, ``npm test``,     |
+|                |         | ``mvn test``, ``gaia eval``                    |
++----------------+---------+------------------------------------------------+
+| ``build``      |  1800 s | pip/uv/poetry/conda/apt/brew installs, make,   |
+|                |         | cmake, ninja, msbuild, tsc, webpack,           |
+|                |         | ``cargo build``, ``npm ci``, ``docker build``  |
++----------------+---------+------------------------------------------------+
+| ``network``    |   300 s | ``git clone/fetch/pull/push``, gh, curl, wget, |
+|                |         | ssh/scp/rsync, ``docker pull``, hf downloads   |
++----------------+---------+------------------------------------------------+
+| ``default``    |    30 s | everything else — the read-only allowlist      |
+|                |         | (ls, cat, grep, stat, git status …)            |
++----------------+---------+------------------------------------------------+
+
+An explicit ``timeout=`` argument always wins; this is only the default.
+"""
+
+import shlex
+from dataclasses import dataclass
+from typing import Dict, List, Optional, Tuple
+
+#: A timeout a caller may never exceed. Above this, ``run_shell_command``
+#: refuses rather than clamping — a silently shortened timeout is a command
+#: killed for a reason the caller cannot see.
+MAX_COMMAND_TIMEOUT = 3600
+
+
+@dataclass(frozen=True)
+class TimeoutClass:
+    """A named command class and the timeout every command in it gets."""
+
+    name: str
+    seconds: int
+    summary: str
+
+
+TEST = TimeoutClass("test", 900, "test runners")
+BUILD = TimeoutClass("build", 1800, "builds, compiles and package installs")
+NETWORK = TimeoutClass("network", 300, "VCS and network calls")
+DEFAULT = TimeoutClass("default", 30, "everything else")
+
+#: Every class, keyed by name. The enumerated set the tool description states.
+TIMEOUT_CLASSES: Dict[str, TimeoutClass] = {
+    cls.name: cls for cls in (TEST, BUILD, NETWORK, DEFAULT)
+}
+
+# Tokens that front a real command without changing what it is.
+# ``python -m pytest`` is pytest; ``sudo make install`` is make.
+_WRAPPERS = frozenset(
+    {"python", "python3", "py", "pypy", "sudo", "env", "nohup", "time", "npx", "uvx"}
+)
+
+# ``<wrapper> run <the actual command>`` — classify the remainder instead.
+_DELEGATING = frozenset({("uv", "run"), ("poetry", "run"), ("pipx", "run")})
+
+# Binaries whose name alone settles the class.
+_BINARY_CLASS: Dict[str, TimeoutClass] = {
+    # test runners
+    "pytest": TEST,
+    "py.test": TEST,
+    "tox": TEST,
+    "nox": TEST,
+    "nosetests": TEST,
+    "jest": TEST,
+    "vitest": TEST,
+    "mocha": TEST,
+    "karma": TEST,
+    "playwright": TEST,
+    "cypress": TEST,
+    "ctest": TEST,
+    "rspec": TEST,
+    "phpunit": TEST,
+    # builds / installs
+    "make": BUILD,
+    "gmake": BUILD,
+    "nmake": BUILD,
+    "cmake": BUILD,
+    "ninja": BUILD,
+    "meson": BUILD,
+    "msbuild": BUILD,
+    "bazel": BUILD,
+    "tsc": BUILD,
+    "webpack": BUILD,
+    "rollup": BUILD,
+    "esbuild": BUILD,
+    "vite": BUILD,
+    "gcc": BUILD,
+    "g++": BUILD,
+    "clang": BUILD,
+    "clang++": BUILD,
+    "cl": BUILD,
+    "rustc": BUILD,
+    "javac": BUILD,
+    # VCS / network
+    "curl": NETWORK,
+    "wget": NETWORK,
+    "ssh": NETWORK,
+    "scp": NETWORK,
+    "sftp": NETWORK,
+    "rsync": NETWORK,
+    "gh": NETWORK,
+    "glab": NETWORK,
+    "hg": NETWORK,
+    "svn": NETWORK,
+    "hf": NETWORK,
+    "huggingface-cli": NETWORK,
+    "aws": NETWORK,
+    "az": NETWORK,
+    "gcloud": NETWORK,
+    "kubectl": NETWORK,
+    "helm": NETWORK,
+    "ping": NETWORK,
+}
+
+# Multiplexers: the subcommand decides. Anything not listed for a binary falls
+# through to ``default`` — ``git status`` stays a 30s command.
+_SUBCOMMAND_CLASS: Dict[str, Dict[str, TimeoutClass]] = {
+    "git": {
+        "clone": NETWORK,
+        "fetch": NETWORK,
+        "pull": NETWORK,
+        "push": NETWORK,
+        "submodule": NETWORK,
+        "ls-remote": NETWORK,
+        "lfs": NETWORK,
+    },
+    "pip": {"install": BUILD, "download": BUILD, "wheel": BUILD, "uninstall": BUILD},
+    "pip3": {"install": BUILD, "download": BUILD, "wheel": BUILD, "uninstall": BUILD},
+    "uv": {
+        "pip": BUILD,
+        "sync": BUILD,
+        "add": BUILD,
+        "remove": BUILD,
+        "build": BUILD,
+        "venv": BUILD,
+        "tool": BUILD,
+    },
+    "poetry": {"install": BUILD, "add": BUILD, "build": BUILD, "update": BUILD},
+    "conda": {"install": BUILD, "create": BUILD, "update": BUILD, "env": BUILD},
+    "mamba": {"install": BUILD, "create": BUILD, "update": BUILD, "env": BUILD},
+    "npm": {"install": BUILD, "ci": BUILD, "i": BUILD, "add": BUILD, "test": TEST},
+    "pnpm": {"install": BUILD, "i": BUILD, "add": BUILD, "test": TEST},
+    "yarn": {"install": BUILD, "add": BUILD, "test": TEST},
+    "cargo": {
+        "test": TEST,
+        "bench": TEST,
+        "build": BUILD,
+        "install": BUILD,
+        "check": BUILD,
+        "clippy": BUILD,
+        "fetch": NETWORK,
+    },
+    "go": {"test": TEST, "build": BUILD, "install": BUILD, "get": NETWORK},
+    "dotnet": {"test": TEST, "build": BUILD, "restore": BUILD, "publish": BUILD},
+    "mvn": {"test": TEST, "verify": TEST, "install": BUILD, "package": BUILD},
+    "gradle": {"test": TEST, "check": TEST, "build": BUILD, "assemble": BUILD},
+    "gradlew": {"test": TEST, "check": TEST, "build": BUILD, "assemble": BUILD},
+    "docker": {"build": BUILD, "compose": BUILD, "pull": NETWORK, "push": NETWORK},
+    "podman": {"build": BUILD, "pull": NETWORK, "push": NETWORK},
+    "apt": {"install": BUILD, "upgrade": BUILD, "update": NETWORK},
+    "apt-get": {"install": BUILD, "upgrade": BUILD, "update": NETWORK},
+    "brew": {"install": BUILD, "upgrade": BUILD, "update": NETWORK},
+    "choco": {"install": BUILD, "upgrade": BUILD},
+    "winget": {"install": BUILD, "upgrade": BUILD},
+    "scoop": {"install": BUILD, "update": BUILD},
+    "gaia": {"eval": TEST, "test": TEST, "init": BUILD, "install": BUILD},
+}
+
+# ``npm run <script>`` / ``pnpm run`` / ``yarn run`` — the script name decides.
+_RUN_SCRIPT_BINARIES = frozenset({"npm", "pnpm", "yarn"})
+
+
+def normalize_binary(token: str) -> str:
+    """``C:\\Tools\\PyTest.EXE`` -> ``pytest``: basename, no suffix, lowercase."""
+    name = token.replace("\\", "/").rsplit("/", 1)[-1].lower()
+    for suffix in (".exe", ".cmd", ".bat", ".ps1"):
+        if name.endswith(suffix):
+            return name[: -len(suffix)]
+    return name
+
+
+def _classify_tokens(tokens: List[str]) -> TimeoutClass:
+    """The class of one already-split command, wrappers peeled off."""
+    index = 0
+    while index < len(tokens):
+        token = tokens[index]
+        if token.startswith("-"):  # a flag, incl. python's -m
+            index += 1
+            continue
+        binary = normalize_binary(token)
+        if binary in _WRAPPERS:
+            index += 1
+            continue
+        break
+    else:
+        return DEFAULT
+
+    binary = normalize_binary(tokens[index])
+    operands = [
+        (position, normalize_binary(token))
+        for position, token in enumerate(tokens[index + 1 :], start=index + 1)
+        if not token.startswith("-")
+    ]
+    subcommand = operands[0][1] if operands else ""
+
+    if (binary, subcommand) in _DELEGATING:
+        return _classify_tokens(tokens[operands[0][0] + 1 :])
+
+    if binary in _RUN_SCRIPT_BINARIES and subcommand == "run":
+        script = operands[1][1] if len(operands) > 1 else ""
+        return TEST if script.startswith("test") else BUILD
+
+    subcommands = _SUBCOMMAND_CLASS.get(binary)
+    if subcommands is not None:
+        return subcommands.get(subcommand, DEFAULT)
+
+    return _BINARY_CLASS.get(binary, DEFAULT)
+
+
+def _split_segments(command: str) -> List[List[str]]:
+    """Split *command* into pipeline segments of tokens."""
+    try:
+        parts = shlex.split(command)
+    except ValueError:
+        parts = command.split()
+    segments: List[List[str]] = []
+    current: List[str] = []
+    for part in parts:
+        if part == "|":
+            if current:
+                segments.append(current)
+            current = []
+        else:
+            current.append(part)
+    if current:
+        segments.append(current)
+    return segments
+
+
+def classify_command(command: str) -> TimeoutClass:
+    """The timeout class *command* falls into.
+
+    A pipeline takes the longest class of any segment: ``pytest -q | tail`` is a
+    test run whose output happens to be filtered, and the shell waits for the
+    whole pipeline anyway.
+    """
+    segments = _split_segments(command)
+    if not segments:
+        return DEFAULT
+    return max(
+        (_classify_tokens(segment) for segment in segments),
+        key=lambda cls: cls.seconds,
+    )
+
+
+def resolve_timeout(command: str, requested: Optional[int]) -> Tuple[int, str]:
+    """``(seconds, class_name)`` to run *command* under.
+
+    *requested* is the caller's explicit ``timeout=`` and always wins — the
+    class default only fills the gap when it is None.
+
+    Raises:
+        ValueError: *requested* is not a positive number of seconds, or exceeds
+            ``MAX_COMMAND_TIMEOUT``. Refused rather than clamped so the caller
+            never gets a command killed at a limit it did not ask for.
+    """
+    command_class = classify_command(command)
+    if requested is None:
+        return command_class.seconds, command_class.name
+
+    try:
+        seconds = int(requested)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(
+            f"timeout must be a whole number of seconds, got {requested!r}. "
+            f"Omit it to use the {command_class.name} default "
+            f"({command_class.seconds}s)."
+        ) from exc
+
+    if seconds <= 0:
+        raise ValueError(
+            f"timeout must be a positive number of seconds, got {seconds}. "
+            f"Omit it to use the {command_class.name} default "
+            f"({command_class.seconds}s)."
+        )
+    if seconds > MAX_COMMAND_TIMEOUT:
+        raise ValueError(
+            f"timeout of {seconds}s exceeds the {MAX_COMMAND_TIMEOUT}s ceiling "
+            f"for a single shell command. Run the work in the background and "
+            f"poll it with wait_for_condition, or split it into shorter steps."
+        )
+    return seconds, command_class.name
+
+
+def timeout_table() -> str:
+    """The class table as one line per class, for a tool description."""
+    return "; ".join(
+        f"{cls.name}={cls.seconds}s ({cls.summary})"
+        for cls in (TEST, BUILD, NETWORK, DEFAULT)
+    )

--- a/src/gaia/agents/tools/command_timeouts.py
+++ b/src/gaia/agents/tools/command_timeouts.py
@@ -305,11 +305,3 @@ def resolve_timeout(command: str, requested: Optional[int]) -> Tuple[int, str]:
             f"poll it with wait_for_condition, or split it into shorter steps."
         )
     return seconds, command_class.name
-
-
-def timeout_table() -> str:
-    """The class table as one line per class, for a tool description."""
-    return "; ".join(
-        f"{cls.name}={cls.seconds}s ({cls.summary})"
-        for cls in (TEST, BUILD, NETWORK, DEFAULT)
-    )

--- a/src/gaia/agents/tools/shell_tools.py
+++ b/src/gaia/agents/tools/shell_tools.py
@@ -11,12 +11,32 @@ import os
 import re
 import shlex
 import subprocess
+import threading
 import time
 from collections import deque
 from pathlib import Path
 from typing import Any, Dict, Optional
 
+from gaia.agents.tools.command_timeouts import (
+    MAX_COMMAND_TIMEOUT,
+    resolve_timeout,
+    timeout_table,
+)
+
 logger = logging.getLogger(__name__)
+
+#: ``wait_for_condition`` bounds. The maximum wait is a ceiling, not a default:
+#: a wait that could run unbounded is the spinning the primitive replaces.
+WAIT_DEFAULT_TIMEOUT = 120
+WAIT_MAX_TIMEOUT = 600
+WAIT_DEFAULT_POLL_INTERVAL = 5
+#: Poll floor. At 5s the probe rate stays near the 10-commands-per-minute shell
+#: rate limit the wait is exempt from (it counts as one command, not one per poll).
+WAIT_MIN_POLL_INTERVAL = 5
+WAIT_MAX_POLL_INTERVAL = 60
+#: A predicate is a quick check, not the work. Each probe is capped here, and by
+#: whatever is left of the deadline.
+WAIT_PROBE_TIMEOUT = 30
 
 # Security: WHITELIST approach - only allow explicitly safe commands
 # This is much safer than a blacklist which always misses dangerous commands
@@ -198,6 +218,11 @@ DANGEROUS_SHELL_OPERATORS = re.compile(
 #: only one a ``shell:execute`` grant may exempt from confirmation.
 _POLICY_GATED_SHELL_TOOL = "run_shell_command"
 
+#: Runs its predicate through ``run_shell_command``, so the same guardrails
+#: apply and a refused predicate is refused before anyone is prompted. It is
+#: NOT grant-exempt: consent for a binary is not consent to poll with it.
+_WAIT_TOOL = "wait_for_condition"
+
 
 def skill_granted_binaries(host: Any) -> frozenset:
     """CLIs *host*'s loaded skills granted via ``shell:execute:<binary>``.
@@ -268,10 +293,12 @@ class ShellToolsMixin:
 
     Tools provided:
     - run_shell_command: Execute terminal commands with timeout and safety checks
+    - wait_for_condition: Poll a command until it succeeds, or hit a deadline
 
     Rate Limiting:
     - Max 10 commands per minute to prevent DOS
     - Max 3 commands per 10 seconds for burst prevention
+    - A wait_for_condition call is one command; its probes are not metered again
     """
 
     def __init__(self, *args, **kwargs):
@@ -358,7 +385,7 @@ class ShellToolsMixin:
         Duck-typed rather than an override — ``Agent`` precedes this mixin in
         ``ChatAgent``'s MRO, so a same-named method here would never be reached.
         """
-        if tool_name != _POLICY_GATED_SHELL_TOOL:
+        if tool_name not in (_POLICY_GATED_SHELL_TOOL, _WAIT_TOOL):
             return None
         command = (tool_args or {}).get("command")
         if not isinstance(command, str):
@@ -455,6 +482,12 @@ class ShellToolsMixin:
             self.max_commands_per_minute = 10
             self.max_commands_per_10_seconds = 3
 
+        # A wait's probes are one command's worth of budget, charged once when
+        # the wait starts. Metering each poll separately would trip the burst
+        # limit on the second probe and turn the primitive into an error.
+        if getattr(self, "_shell_polling", False):
+            return True, "", 0.0
+
         current_time = time.time()
 
         # Remove old timestamps outside the window
@@ -495,8 +528,27 @@ class ShellToolsMixin:
 
         return True, "", 0.0
 
+    def _wait_interrupt_signal(self) -> threading.Event:
+        """The event ``wait_for_condition`` sleeps on between probes.
+
+        Waiting on the agent's cancel signal rather than sleeping blind is what
+        makes Stop take effect during a wait; without it the user's click is
+        honoured only once the deadline runs out, up to ten minutes later.
+        Falls back to a never-set event for consumers that have no cancel
+        channel (plain CLI runs), where the deadline is the only exit.
+        """
+        for source in (
+            getattr(self, "_cancel_event", None),
+            getattr(getattr(self, "console", None), "cancelled", None),
+        ):
+            if isinstance(source, threading.Event):
+                return source
+        return threading.Event()
+
     def _record_command_execution(self):
         """Record command execution timestamp for rate limiting."""
+        if getattr(self, "_shell_polling", False):
+            return  # already charged once, when the wait started
         self.shell_command_times.append(time.time())
 
     @staticmethod
@@ -744,13 +796,19 @@ class ShellToolsMixin:
         @tool(
             atomic=True,
             name="run_shell_command",
+            # The agent-level guard must outlast the longest command class, or a
+            # build would be abandoned by the loop while the subprocess is still
+            # inside its own (correct) timeout.
+            timeout=MAX_COMMAND_TIMEOUT + 60,
             description=(
                 "Execute a shell/terminal command. Useful for listing directories (ls/dir), "
                 "checking files (cat, stat), finding files (find), text processing (grep, head, tail), "
                 "navigation (pwd), and system information. "
                 'On Windows use: systeminfo, powershell -Command "Get-WmiObject Win32_Processor", '
                 'powershell -Command "Get-CimInstance Win32_VideoController | Format-List Name,DriverVersion,AdapterRAM". '
-                "On Linux use: lscpu, lspci, free -h. Pipes (|) are supported."
+                "On Linux use: lscpu, lspci, free -h. Pipes (|) are supported. "
+                "The timeout adapts to what the command is, so leave it unset unless you "
+                f"know better: {timeout_table()}."
             ),
             parameters={
                 "command": {
@@ -765,13 +823,19 @@ class ShellToolsMixin:
                 },
                 "timeout": {
                     "type": "int",
-                    "description": "Timeout in seconds (default: 30)",
+                    "description": (
+                        "Timeout in seconds. Omit it to get the default for this kind of "
+                        f"command ({timeout_table()}); the applied value and its class come "
+                        f"back in the result. Maximum {MAX_COMMAND_TIMEOUT}."
+                    ),
                     "required": False,
                 },
             },
         )
         def run_shell_command(
-            command: str, working_directory: Optional[str] = None, timeout: int = 30
+            command: str,
+            working_directory: Optional[str] = None,
+            timeout: Optional[int] = None,
         ) -> Dict[str, Any]:
             """
             Execute a shell command and return the output.
@@ -779,12 +843,23 @@ class ShellToolsMixin:
             Args:
                 command: Shell command to execute
                 working_directory: Directory to run command in
-                timeout: Maximum execution time in seconds
+                timeout: Maximum execution time in seconds. None picks the
+                    default for the command's class (see ``command_timeouts``).
 
             Returns:
                 Dictionary with status, output, and error information
             """
             try:
+                try:
+                    timeout, timeout_class = resolve_timeout(command, timeout)
+                except ValueError as exc:
+                    return {
+                        "status": "error",
+                        "error": str(exc),
+                        "command": command,
+                        "has_errors": True,
+                    }
+
                 # Check rate limits first to prevent DOS
                 allowed, reason, wait_time = self._check_rate_limit()
                 if not allowed:
@@ -1053,15 +1128,26 @@ class ShellToolsMixin:
 
                     return {
                         "status": "error",
-                        "error": f"Command timed out after {timeout} seconds",
+                        "error": (
+                            f"Command timed out after {timeout} seconds: {command}. "
+                            f"That is the '{timeout_class}' class default; the "
+                            f"command was killed, so its work is incomplete."
+                        ),
                         "command": command,
                         "stdout": stdout_str,
                         "stderr": stderr_str,
                         "has_errors": True,
                         "timed_out": True,
                         "timeout": timeout,
+                        "timeout_class": timeout_class,
                         "duration_seconds": duration,
                         "cwd": cwd,
+                        "hint": (
+                            "Whatever the command printed before it was killed is in "
+                            "'stdout'/'stderr' above. Either narrow the command (one "
+                            "test file rather than the whole suite) or re-run it with a "
+                            f"larger timeout, up to {MAX_COMMAND_TIMEOUT}s."
+                        ),
                     }
 
                 # Capture and truncate output if too long
@@ -1093,6 +1179,7 @@ class ShellToolsMixin:
                     "has_errors": result.returncode != 0,
                     "duration_seconds": duration,
                     "timeout": timeout,
+                    "timeout_class": timeout_class,
                     "cwd": cwd,
                     "output_truncated": truncated,
                 }
@@ -1100,3 +1187,210 @@ class ShellToolsMixin:
             except Exception as exc:
                 logger.error(f"Error executing shell command: {exc}")
                 return {"status": "error", "error": str(exc), "has_errors": True}
+
+        @tool(
+            atomic=True,
+            name="wait_for_condition",
+            # Outlast the longest wait the tool itself permits, so the agent
+            # loop never abandons a wait that is still inside its deadline.
+            timeout=WAIT_MAX_TIMEOUT + 60,
+            description=(
+                "Wait until a shell command succeeds (exit code 0), or give up at a "
+                "deadline. Use this instead of sleeping and re-checking: waiting for a "
+                "server to answer, a file to appear, a log line to be written, or a CI "
+                "run to finish is ONE call, not one call per check. "
+                f"Polls every {WAIT_DEFAULT_POLL_INTERVAL}s by default "
+                f"({WAIT_MIN_POLL_INTERVAL}-{WAIT_MAX_POLL_INTERVAL}s), waits "
+                f"{WAIT_DEFAULT_TIMEOUT}s by default and {WAIT_MAX_TIMEOUT}s at most. "
+                "Examples: 'ls build/output.bin' (file exists), "
+                "'grep -q \"Server started\" server.log' (log line written)."
+            ),
+            parameters={
+                "command": {
+                    "type": "str",
+                    "description": (
+                        "The predicate: a shell command that exits 0 once the condition "
+                        "holds and non-zero until then. Same allowlist as run_shell_command."
+                    ),
+                    "required": True,
+                },
+                "working_directory": {
+                    "type": "str",
+                    "description": "Directory to run the predicate in (defaults to current directory)",
+                    "required": False,
+                },
+                "timeout": {
+                    "type": "int",
+                    "description": (
+                        f"Give up after this many seconds (default {WAIT_DEFAULT_TIMEOUT}, "
+                        f"maximum {WAIT_MAX_TIMEOUT})."
+                    ),
+                    "required": False,
+                },
+                "poll_interval": {
+                    "type": "int",
+                    "description": (
+                        f"Seconds between checks (default {WAIT_DEFAULT_POLL_INTERVAL}, "
+                        f"{WAIT_MIN_POLL_INTERVAL}-{WAIT_MAX_POLL_INTERVAL})."
+                    ),
+                    "required": False,
+                },
+            },
+        )
+        def wait_for_condition(
+            command: str,
+            working_directory: Optional[str] = None,
+            timeout: int = WAIT_DEFAULT_TIMEOUT,
+            poll_interval: int = WAIT_DEFAULT_POLL_INTERVAL,
+        ) -> Dict[str, Any]:
+            """Block until *command* exits 0, or until the deadline passes.
+
+            One agent step covers the whole wait. The polling happens inside
+            this call against a monotonic deadline, so the loop's step budget is
+            spent on work rather than on re-asking whether the thing is ready.
+
+            Returns:
+                A result dict carrying ``condition_met``, how many probes ran and
+                the last probe's output. Deadline expiry is an error, not a
+                quiet False.
+            """
+            try:
+                timeout = int(timeout)
+                poll_interval = int(poll_interval)
+            except (TypeError, ValueError):
+                return {
+                    "status": "error",
+                    "error": (
+                        f"timeout and poll_interval must be whole seconds, got "
+                        f"timeout={timeout!r}, poll_interval={poll_interval!r}."
+                    ),
+                    "has_errors": True,
+                }
+
+            if not 0 < timeout <= WAIT_MAX_TIMEOUT:
+                return {
+                    "status": "error",
+                    "error": (
+                        f"timeout must be between 1 and {WAIT_MAX_TIMEOUT} seconds, "
+                        f"got {timeout}. A longer wait than {WAIT_MAX_TIMEOUT}s is the "
+                        f"agent hanging, not waiting — report progress to the user and "
+                        f"wait again if the condition is still worth waiting for."
+                    ),
+                    "has_errors": True,
+                }
+            if not WAIT_MIN_POLL_INTERVAL <= poll_interval <= WAIT_MAX_POLL_INTERVAL:
+                return {
+                    "status": "error",
+                    "error": (
+                        f"poll_interval must be between {WAIT_MIN_POLL_INTERVAL} and "
+                        f"{WAIT_MAX_POLL_INTERVAL} seconds, got {poll_interval}. The "
+                        f"floor keeps a wait from hammering the machine with probes."
+                    ),
+                    "has_errors": True,
+                }
+
+            # The wait is charged as one command up front; its probes are then
+            # exempt (see _check_rate_limit) rather than each tripping the limit.
+            allowed, reason, wait_time = self._check_rate_limit()
+            if not allowed:
+                return {
+                    "status": "error",
+                    "error": f"{reason}. Please wait {wait_time:.1f} seconds.",
+                    "has_errors": True,
+                    "rate_limited": True,
+                    "wait_time_seconds": wait_time,
+                }
+            self._record_command_execution()
+
+            interrupt = self._wait_interrupt_signal()
+            start = time.monotonic()
+            deadline = start + timeout
+            polls = 0
+            last: Dict[str, Any] = {}
+
+            while True:
+                remaining = deadline - time.monotonic()
+                probe_timeout = max(1, min(int(remaining), WAIT_PROBE_TIMEOUT))
+                self._shell_polling = True
+                try:
+                    last = run_shell_command(command, working_directory, probe_timeout)
+                finally:
+                    self._shell_polling = False
+                polls += 1
+
+                # No return_code means the predicate never ran — refused by the
+                # guardrails, bad working directory, unparseable. Polling a
+                # command that cannot run just burns the deadline, so stop now
+                # and hand back the reason it was refused.
+                if "return_code" not in last and not last.get("timed_out"):
+                    return {
+                        **last,
+                        "condition_met": False,
+                        "command": command,
+                        "polls": polls,
+                        "hint": (
+                            "The predicate itself could not run, so the wait stopped "
+                            "immediately. Fix the command above, then wait again."
+                        ),
+                    }
+
+                if last.get("return_code") == 0:
+                    elapsed = time.monotonic() - start
+                    return {
+                        "status": "success",
+                        "condition_met": True,
+                        "command": command,
+                        "elapsed_seconds": elapsed,
+                        "polls": polls,
+                        "poll_interval_seconds": poll_interval,
+                        "timeout": timeout,
+                        "stdout": last.get("stdout", ""),
+                        "stderr": last.get("stderr", ""),
+                        "cwd": last.get("cwd"),
+                        "has_errors": False,
+                    }
+
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    break
+                if interrupt.wait(min(poll_interval, remaining)):
+                    return {
+                        "status": "error",
+                        "error": (
+                            f"Wait for '{command}' was cancelled after {polls} "
+                            f"check(s); the condition was never met."
+                        ),
+                        "condition_met": False,
+                        "cancelled": True,
+                        "command": command,
+                        "polls": polls,
+                        "has_errors": True,
+                    }
+
+            elapsed = time.monotonic() - start
+            return {
+                "status": "error",
+                "error": (
+                    f"Condition '{command}' was still not true {elapsed:.0f}s later "
+                    f"(deadline {timeout}s, checked {polls} time(s) every "
+                    f"{poll_interval}s). Last exit code: {last.get('return_code')}."
+                ),
+                "condition_met": False,
+                "timed_out": True,
+                "has_errors": True,
+                "command": command,
+                "elapsed_seconds": elapsed,
+                "polls": polls,
+                "poll_interval_seconds": poll_interval,
+                "timeout": timeout,
+                "last_return_code": last.get("return_code"),
+                "stdout": last.get("stdout", ""),
+                "stderr": last.get("stderr", ""),
+                "cwd": last.get("cwd"),
+                "hint": (
+                    "The last check's output is above — read it before waiting again. "
+                    "Whatever you are waiting for is slow, stuck, or never going to "
+                    f"happen; tell the user which. A single wait is capped at "
+                    f"{WAIT_MAX_TIMEOUT}s."
+                ),
+            }

--- a/src/gaia/agents/tools/shell_tools.py
+++ b/src/gaia/agents/tools/shell_tools.py
@@ -17,11 +17,7 @@ from collections import deque
 from pathlib import Path
 from typing import Any, Dict, Optional
 
-from gaia.agents.tools.command_timeouts import (
-    MAX_COMMAND_TIMEOUT,
-    resolve_timeout,
-    timeout_table,
-)
+from gaia.agents.tools.command_timeouts import MAX_COMMAND_TIMEOUT, resolve_timeout
 
 logger = logging.getLogger(__name__)
 
@@ -806,9 +802,7 @@ class ShellToolsMixin:
                 "navigation (pwd), and system information. "
                 'On Windows use: systeminfo, powershell -Command "Get-WmiObject Win32_Processor", '
                 'powershell -Command "Get-CimInstance Win32_VideoController | Format-List Name,DriverVersion,AdapterRAM". '
-                "On Linux use: lscpu, lspci, free -h. Pipes (|) are supported. "
-                "The timeout adapts to what the command is, so leave it unset unless you "
-                f"know better: {timeout_table()}."
+                "On Linux use: lscpu, lspci, free -h. Pipes (|) are supported."
             ),
             parameters={
                 "command": {
@@ -824,9 +818,8 @@ class ShellToolsMixin:
                 "timeout": {
                     "type": "int",
                     "description": (
-                        "Timeout in seconds. Omit it to get the default for this kind of "
-                        f"command ({timeout_table()}); the applied value and its class come "
-                        f"back in the result. Maximum {MAX_COMMAND_TIMEOUT}."
+                        "Timeout in seconds. Omit it for the default that suits this "
+                        f"kind of command. Maximum {MAX_COMMAND_TIMEOUT}."
                     ),
                     "required": False,
                 },
@@ -835,19 +828,31 @@ class ShellToolsMixin:
         def run_shell_command(
             command: str,
             working_directory: Optional[str] = None,
-            timeout: Optional[int] = None,
+            # Annotated int, not Optional[int]: the registry infers the JSON
+            # schema type from this annotation and renders anything it cannot
+            # read as a string, so Optional[int] would tell a tool-calling model
+            # to send "60". None still means "use the class default".
+            timeout: int = None,
         ) -> Dict[str, Any]:
-            """
-            Execute a shell command and return the output.
+            """Execute a shell command. Leave timeout unset: it defaults to what the command needs — 900s for test runners, 1800s for builds and installs, 300s for git/network calls, 30s for everything else.
+
+            The class table leads because the prompt renders a tool by the FIRST
+            LINE of its docstring; anything below is seen only by models using
+            native tool calls. ``test_the_docstring_states_every_class`` keeps
+            that line honest when the table changes.
 
             Args:
                 command: Shell command to execute
                 working_directory: Directory to run command in
-                timeout: Maximum execution time in seconds. None picks the
-                    default for the command's class (see ``command_timeouts``).
+                timeout: Maximum execution time in seconds. Omit it for the
+                    class default above. Above the 3600s ceiling it is refused,
+                    not clamped.
 
             Returns:
-                Dictionary with status, output, and error information
+                Dictionary with status, output, and error information. The
+                applied timeout and the class it came from are in ``timeout``
+                and ``timeout_class``; a command killed at the limit carries
+                ``timed_out`` plus whatever it printed first.
             """
             try:
                 try:
@@ -1243,11 +1248,18 @@ class ShellToolsMixin:
             timeout: int = WAIT_DEFAULT_TIMEOUT,
             poll_interval: int = WAIT_DEFAULT_POLL_INTERVAL,
         ) -> Dict[str, Any]:
-            """Block until *command* exits 0, or until the deadline passes.
+            """Wait until a shell command succeeds, instead of sleeping and re-checking: give it a command that exits 0 once the thing you are waiting for is ready (a file written, a server answering, a run finished) and it polls every 5s until then, giving up at 120s by default and 600s at most.
 
             One agent step covers the whole wait. The polling happens inside
             this call against a monotonic deadline, so the loop's step budget is
             spent on work rather than on re-asking whether the thing is ready.
+
+            Args:
+                command: The predicate — exits 0 once the condition holds,
+                    non-zero until then. Same allowlist as run_shell_command.
+                working_directory: Directory to run the predicate in
+                timeout: Give up after this many seconds (max 600)
+                poll_interval: Seconds between checks (5-60)
 
             Returns:
                 A result dict carrying ``condition_met``, how many probes ran and

--- a/tests/unit/test_shell_adaptive_timeouts.py
+++ b/tests/unit/test_shell_adaptive_timeouts.py
@@ -1,0 +1,446 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+"""A shell command gets a timeout that suits what it is, and waits are one step.
+
+Two behaviours are under test:
+
+* ``run_shell_command`` picks its default timeout from the command's class —
+  test runners, builds/installs, VCS/network calls, everything else — instead of
+  killing every command at a flat 30s.
+* ``wait_for_condition`` polls a predicate against a deadline inside a single
+  call, so waiting for a server or a build costs one agent step, not one per
+  check.
+
+Three behaviours that already worked are pinned here as well, because the
+timeout rework runs straight through them: the applied timeout comes back in the
+result, a timed-out command is flagged, and partial output survives the kill.
+"""
+
+import subprocess
+
+import pytest
+
+from gaia.agents.tools.command_timeouts import (
+    MAX_COMMAND_TIMEOUT,
+    TIMEOUT_CLASSES,
+    classify_command,
+    resolve_timeout,
+)
+from gaia.agents.tools.shell_tools import (
+    WAIT_MAX_POLL_INTERVAL,
+    WAIT_MAX_TIMEOUT,
+    WAIT_MIN_POLL_INTERVAL,
+    ShellToolsMixin,
+)
+
+
+class _Host(ShellToolsMixin):
+    """Minimal host: the mixin only needs its own __init__ for rate limiting."""
+
+
+def _shell_tools():
+    """The registered tool callables, by name."""
+    captured = {}
+    import gaia.agents.base.tools as tools_module
+
+    original = tools_module.tool
+
+    def spy(**kwargs):
+        def decorate(fn):
+            captured[kwargs.get("name")] = fn
+            return original(**kwargs)(fn)
+
+        return decorate
+
+    tools_module.tool = spy
+    try:
+        host = _Host()
+        host.register_shell_tools()
+    finally:
+        tools_module.tool = original
+    return host, captured
+
+
+class _Completed:
+    def __init__(self, returncode=0, stdout="", stderr=""):
+        self.returncode = returncode
+        self.stdout = stdout
+        self.stderr = stderr
+
+
+@pytest.fixture
+def unrestricted(monkeypatch):
+    """Run with the read-only allowlist stood down.
+
+    The allowlist is not what these tests are about, and it refuses `pytest` and
+    `pip install` outright today — so with it in place only the ``default`` class
+    would ever be reachable. Guardrail coverage lives in
+    ``test_shell_guardrails.py``.
+    """
+    monkeypatch.setattr(
+        ShellToolsMixin, "_validate_command", staticmethod(lambda *a, **k: None)
+    )
+
+
+# ---------------------------------------------------------------------------
+# The class table
+# ---------------------------------------------------------------------------
+
+
+class TestTimeoutClasses:
+    """Every class in the table is named, enumerated, and has a stated default."""
+
+    def test_the_four_classes_and_their_defaults(self):
+        assert {name: cls.seconds for name, cls in TIMEOUT_CLASSES.items()} == {
+            "test": 900,
+            "build": 1800,
+            "network": 300,
+            "default": 30,
+        }
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            "pytest tests/unit -q",
+            "python -m pytest tests/",
+            "uv run pytest -x",
+            "npx jest --coverage",
+            "npm test",
+            "npm run test:e2e",
+            "cargo test --all",
+            "go test ./...",
+            "mvn test",
+            "tox -e py311",
+            "gaia eval agent --category rag_quality",
+            "pytest -q | tail -20",
+        ],
+    )
+    def test_test_runners(self, command):
+        assert classify_command(command).name == "test"
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            "pip install -e .",
+            "python -m pip install requests",
+            "uv pip install -e .[dev]",
+            "npm install",
+            "npm ci",
+            "npm run build",
+            "poetry install",
+            "make -j8",
+            "cmake --build build",
+            "cargo build --release",
+            "docker build -t gaia .",
+            "apt-get install -y ffmpeg",
+            "tsc -p tsconfig.json",
+        ],
+    )
+    def test_builds_and_installs(self, command):
+        assert classify_command(command).name == "build"
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            "git clone https://github.com/amd/gaia",
+            "git fetch origin",
+            "git push origin main",
+            "gh issue list --repo amd/gaia",
+            "curl -sf http://localhost:8000/health",
+            "wget https://example.com/model.gguf",
+            "docker pull ubuntu:24.04",
+            "huggingface-cli download amd/model",
+        ],
+    )
+    def test_vcs_and_network(self, command):
+        assert classify_command(command).name == "network"
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            "ls -la",
+            "cat README.md",
+            "grep -r foo src/",
+            "git status",
+            "git log --oneline -10",
+            "systeminfo",
+            "",
+        ],
+    )
+    def test_everything_else(self, command):
+        assert classify_command(command).name == "default"
+
+    def test_a_pipeline_takes_its_longest_segment(self):
+        # The shell waits for the whole pipeline, so `grep` does not make a
+        # 15-minute test run a 30-second command.
+        assert classify_command("pytest -q | grep FAILED").seconds == 900
+
+
+class TestResolveTimeout:
+    def test_class_default_fills_the_gap(self):
+        assert resolve_timeout("pytest tests/", None) == (900, "test")
+        assert resolve_timeout("ls", None) == (30, "default")
+
+    def test_an_explicit_timeout_wins(self):
+        assert resolve_timeout("pytest tests/", 45) == (45, "test")
+
+    @pytest.mark.parametrize("bad", [0, -1, MAX_COMMAND_TIMEOUT + 1, "soon"])
+    def test_an_impossible_timeout_is_refused_not_clamped(self, bad):
+        # Clamping would kill a command at a limit its caller never chose, with
+        # nothing in the result to say why.
+        with pytest.raises(ValueError):
+            resolve_timeout("ls", bad)
+
+
+# ---------------------------------------------------------------------------
+# The class default reaches subprocess
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "command,expected_timeout,expected_class",
+    [
+        ("pytest tests/unit", 900, "test"),
+        ("pip install -e .", 1800, "build"),
+        ("git clone https://github.com/amd/gaia", 300, "network"),
+        ("ls -la", 30, "default"),
+    ],
+)
+def test_each_class_reaches_subprocess_with_its_default(
+    monkeypatch, unrestricted, command, expected_timeout, expected_class
+):
+    _, tools = _shell_tools()
+    seen = {}
+
+    def fake_run(*_args, **kwargs):
+        seen["timeout"] = kwargs["timeout"]
+        return _Completed(stdout="ok")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    result = tools["run_shell_command"](command)
+
+    assert seen["timeout"] == expected_timeout
+    assert result["timeout"] == expected_timeout
+    assert result["timeout_class"] == expected_class
+
+
+def test_an_explicit_timeout_still_overrides_the_class(monkeypatch, unrestricted):
+    _, tools = _shell_tools()
+    seen = {}
+
+    def fake_run(*_args, **kwargs):
+        seen["timeout"] = kwargs["timeout"]
+        return _Completed()
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    result = tools["run_shell_command"]("pytest tests/", timeout=60)
+
+    assert seen["timeout"] == 60
+    assert result["timeout"] == 60
+
+
+def test_an_out_of_range_timeout_is_refused_with_an_actionable_error(monkeypatch):
+    _, tools = _shell_tools()
+
+    def fake_run(*_args, **_kwargs):  # pragma: no cover - must not be reached
+        raise AssertionError("the command should never have run")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    result = tools["run_shell_command"]("ls", timeout=MAX_COMMAND_TIMEOUT * 2)
+
+    assert result["status"] == "error"
+    assert str(MAX_COMMAND_TIMEOUT) in result["error"]
+    assert "wait_for_condition" in result["error"]
+
+
+# ---------------------------------------------------------------------------
+# Already true — must not regress
+# ---------------------------------------------------------------------------
+
+
+def _timing_out(monkeypatch, stdout="partial out", stderr="partial err"):
+    def fake_run(*_args, **kwargs):
+        raise subprocess.TimeoutExpired(
+            cmd="ls", timeout=kwargs["timeout"], output=stdout, stderr=stderr
+        )
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+
+class TestNoRegression:
+    def test_the_applied_timeout_comes_back_in_the_result(self, monkeypatch):
+        _, tools = _shell_tools()
+        monkeypatch.setattr(subprocess, "run", lambda *a, **k: _Completed())
+
+        assert tools["run_shell_command"]("ls", timeout=17)["timeout"] == 17
+
+    def test_a_timed_out_command_is_flagged(self, monkeypatch):
+        _, tools = _shell_tools()
+        _timing_out(monkeypatch)
+
+        result = tools["run_shell_command"]("ls", timeout=5)
+
+        assert result["timed_out"] is True
+        assert result["status"] == "error"
+        assert result["timeout"] == 5
+
+    def test_partial_output_survives_the_kill(self, monkeypatch):
+        _, tools = _shell_tools()
+        _timing_out(monkeypatch, stdout="ran 3 tests", stderr="still going")
+
+        result = tools["run_shell_command"]("ls", timeout=5)
+
+        assert result["stdout"] == "ran 3 tests"
+        assert result["stderr"] == "still going"
+
+    def test_the_timeout_error_says_what_to_do(self, monkeypatch):
+        _, tools = _shell_tools()
+        _timing_out(monkeypatch)
+
+        error = tools["run_shell_command"]("ls", timeout=5)
+
+        assert "timed out after 5 seconds" in error["error"]
+        assert "default" in error["error"]  # names the class it came from
+        assert str(MAX_COMMAND_TIMEOUT) in error["hint"]
+
+
+# ---------------------------------------------------------------------------
+# wait_for_condition
+# ---------------------------------------------------------------------------
+
+
+class TestWaitForCondition:
+    def test_it_returns_as_soon_as_the_predicate_succeeds(self, monkeypatch):
+        _, tools = _shell_tools()
+        monkeypatch.setattr(subprocess, "run", lambda *a, **k: _Completed(stdout="up"))
+
+        result = tools["wait_for_condition"]("ls build/output.bin", timeout=30)
+
+        assert result["condition_met"] is True
+        assert result["status"] == "success"
+        assert result["polls"] == 1
+        assert result["stdout"] == "up"
+
+    def test_the_deadline_expires_loudly(self, monkeypatch):
+        _, tools = _shell_tools()
+        monkeypatch.setattr(
+            subprocess, "run", lambda *a, **k: _Completed(returncode=1, stderr="no")
+        )
+
+        result = tools["wait_for_condition"]("ls build/output.bin", timeout=1)
+
+        assert result["condition_met"] is False
+        assert result["timed_out"] is True
+        assert result["status"] == "error"
+        assert result["has_errors"] is True
+        assert result["polls"] >= 1
+        assert result["last_return_code"] == 1
+        # Actionable: names the predicate, the deadline, and the last check.
+        assert "ls build/output.bin" in result["error"]
+        assert "deadline 1s" in result["error"]
+        assert result["stderr"] == "no"
+
+    def test_a_predicate_that_cannot_run_stops_the_wait_immediately(self, monkeypatch):
+        _, tools = _shell_tools()
+
+        def fake_run(*_args, **_kwargs):  # pragma: no cover - must not be reached
+            raise AssertionError("a refused predicate should never execute")
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+
+        result = tools["wait_for_condition"]("rm -rf /", timeout=600)
+
+        assert result["condition_met"] is False
+        assert result["status"] == "error"
+        assert result["polls"] == 1
+
+    def test_a_cancel_signal_ends_the_wait(self, monkeypatch):
+        import threading
+
+        host, tools = _shell_tools()
+        host._cancel_event = threading.Event()
+        host._cancel_event.set()
+        monkeypatch.setattr(
+            subprocess, "run", lambda *a, **k: _Completed(returncode=1)
+        )
+
+        result = tools["wait_for_condition"]("ls nope", timeout=WAIT_MAX_TIMEOUT)
+
+        assert result["cancelled"] is True
+        assert result["condition_met"] is False
+
+    @pytest.mark.parametrize("timeout", [0, -5, WAIT_MAX_TIMEOUT + 1])
+    def test_an_unbounded_wait_is_refused(self, timeout):
+        _, tools = _shell_tools()
+
+        result = tools["wait_for_condition"]("ls", timeout=timeout)
+
+        assert result["status"] == "error"
+        assert str(WAIT_MAX_TIMEOUT) in result["error"]
+
+    @pytest.mark.parametrize(
+        "poll_interval", [0, WAIT_MIN_POLL_INTERVAL - 1, WAIT_MAX_POLL_INTERVAL + 1]
+    )
+    def test_the_poll_interval_is_bounded(self, poll_interval):
+        _, tools = _shell_tools()
+
+        result = tools["wait_for_condition"]("ls", poll_interval=poll_interval)
+
+        assert result["status"] == "error"
+        assert str(WAIT_MIN_POLL_INTERVAL) in result["error"]
+
+    def test_probes_are_not_metered_as_separate_commands(self):
+        """A wait is charged once, not once per poll.
+
+        Without the exemption the second probe trips the 3-per-10-seconds burst
+        limit and the primitive returns a rate-limit error instead of waiting.
+        """
+        host = _Host()
+        for _ in range(host.max_commands_per_minute):
+            host._record_command_execution()
+        assert host._check_rate_limit()[0] is False
+
+        host._shell_polling = True
+        try:
+            assert host._check_rate_limit()[0] is True
+            before = len(host.shell_command_times)
+            host._record_command_execution()
+            assert len(host.shell_command_times) == before
+        finally:
+            host._shell_polling = False
+
+    def test_the_wait_tool_is_gated_and_grant_scoped(self):
+        from gaia.agents.base.agent import TOOLS_REQUIRING_CONFIRMATION
+        from gaia.agents.base.tool_grants import grant_scope
+
+        assert "wait_for_condition" in TOOLS_REQUIRING_CONFIRMATION
+        # "Always allow" is scoped to the command, never to the tool.
+        scope = grant_scope("wait_for_condition", {"command": "ls build"})
+        assert scope is not None and scope.label == "ls build"
+
+    def test_a_refused_predicate_is_refused_before_the_prompt(self):
+        host = _Host()
+
+        refusal = host.policy_refusal_for_call(
+            "wait_for_condition", {"command": "rm -rf /"}
+        )
+
+        assert refusal is not None and refusal["status"] == "error"
+
+
+def test_the_tool_guard_outlasts_the_longest_command(monkeypatch):
+    """The agent-level tool timeout must not fire before the command's own.
+
+    A 30-minute build under a 180s tool guard is abandoned by the loop while the
+    subprocess is still inside its (correct) window — the feature would be inert.
+    """
+    from gaia.agents.base.tools import _TOOL_REGISTRY
+
+    _Host().register_shell_tools()
+
+    assert _TOOL_REGISTRY["run_shell_command"]["timeout"] > MAX_COMMAND_TIMEOUT
+    assert _TOOL_REGISTRY["wait_for_condition"]["timeout"] > WAIT_MAX_TIMEOUT

--- a/tests/unit/test_shell_adaptive_timeouts.py
+++ b/tests/unit/test_shell_adaptive_timeouts.py
@@ -432,6 +432,48 @@ class TestWaitForCondition:
         assert refusal is not None and refusal["status"] == "error"
 
 
+class TestWhatTheModelIsTold:
+    """The table is worthless if the model never sees it.
+
+    The registry takes a tool's description from its ``__doc__`` — the
+    ``description=``/``parameters=`` kwargs on ``@tool`` are swallowed and
+    ignored — and the non-native prompt path renders only the FIRST LINE of it.
+    So the class defaults have to be in that first line, and stay there.
+    """
+
+    def _first_line(self, tool_name):
+        from gaia.agents.base.tools import _TOOL_REGISTRY
+
+        _Host().register_shell_tools()
+        return _TOOL_REGISTRY[tool_name]["description"].splitlines()[0]
+
+    def test_the_docstring_states_every_class(self):
+        first_line = self._first_line("run_shell_command")
+
+        for command_class in TIMEOUT_CLASSES.values():
+            assert f"{command_class.seconds}s" in first_line, (
+                f"the {command_class.name} default is not in the one line of "
+                f"run_shell_command the model actually sees"
+            )
+
+    def test_timeout_is_still_declared_as_an_integer(self):
+        """An unreadable annotation is rendered as a string to the model."""
+        from gaia.agents.base.tools import _TOOL_REGISTRY
+
+        _Host().register_shell_tools()
+
+        for tool_name in ("run_shell_command", "wait_for_condition"):
+            params = _TOOL_REGISTRY[tool_name]["parameters"]
+            assert params["timeout"]["type"] == "integer"
+            assert params["timeout"]["required"] is False
+
+    def test_the_wait_tool_states_its_bounds(self):
+        first_line = self._first_line("wait_for_condition")
+
+        assert str(WAIT_MAX_TIMEOUT) in first_line
+        assert str(WAIT_MIN_POLL_INTERVAL) in first_line
+
+
 def test_the_tool_guard_outlasts_the_longest_command(monkeypatch):
     """The agent-level tool timeout must not fire before the command's own.
 

--- a/tests/unit/test_shell_adaptive_timeouts.py
+++ b/tests/unit/test_shell_adaptive_timeouts.py
@@ -364,9 +364,7 @@ class TestWaitForCondition:
         host, tools = _shell_tools()
         host._cancel_event = threading.Event()
         host._cancel_event.set()
-        monkeypatch.setattr(
-            subprocess, "run", lambda *a, **k: _Completed(returncode=1)
-        )
+        monkeypatch.setattr(subprocess, "run", lambda *a, **k: _Completed(returncode=1))
 
         result = tools["wait_for_condition"]("ls nope", timeout=WAIT_MAX_TIMEOUT)
 


### PR DESCRIPTION
Waiting was the agent's most common way to fail. Every shell command got the same 30-second budget, which is far below what a test suite, a build or an install needs — so long commands were killed rather than finished, and the agent had no way to tell "this failed" from "this was still working". Timeouts now scale to the kind of command being run, and there is a wait-for-condition primitive so the agent stops sleeping in a loop and burning steps to poll.

Closes #3382.

### Test plan

- [ ] `python -m pytest tests/unit/test_shell_adaptive_timeouts.py -q` — one case per timeout class, plus deadline expiry for the wait primitive
- [ ] `python -m pytest tests/unit/test_shell_guardrails.py -q` — guardrails unchanged
- [ ] By hand: run a command that takes longer than 30s and confirm it now completes rather than being killed

### Notes for the reviewer

- Three behaviours were **already** correct and are covered by regression assertions rather than reimplemented: the applied timeout is returned in the result, a timed-out command carries a dedicated flag, and partial stdout/stderr survives a timeout.
- `timeout` was already a caller-settable parameter, so the defect was a bad default with nothing telling the model what a given command should cost — not an unexpressible limit. The class table is the fix for that, and it is documented where the model reads it rather than only in the spec.
- **Needs a rebase once #3394 and #3398 land** — all three touch `shell_tools.py`. Cut from `main` deliberately; the diff is kept as small as the change allows to limit the conflict surface.
- A red `rag_quality + context_retention + tool_selection` check is expected on every PR right now: #3341, where I have posted evidence that the API account behind `ANTHROPIC_API_KEY` is out of credit.