### PR TITLE
fix(eval): drive the agent eval with the OAuth token, and probe it for real

### DIFF
--- a/.github/workflows/test_eval_agent_gemma_consolidation.yml
+++ b/.github/workflows/test_eval_agent_gemma_consolidation.yml
@@ -384,7 +384,11 @@ jobs:
 
       - name: Preflight — judge key, baselines, Lemonade
         env:
-          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          # Blank when the OAuth token is present, deliberately: runner.py adds
+          # `--bare` only when ANTHROPIC_API_KEY is set, and `--bare` restricts
+          # auth to the key alone, so leaving both set would ignore the token.
+          ANTHROPIC_API_KEY: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN == '' && secrets.ANTHROPIC_API_KEY || '' }}
         run: |
           $ErrorActionPreference = "Stop"
           $ProgressPreference = "SilentlyContinue"
@@ -496,10 +500,21 @@ jobs:
           }
 
 
-          if (-not $env:ANTHROPIC_API_KEY) {
-            Write-Host "::error::ANTHROPIC_API_KEY is not set. The eval judge (src/gaia/eval/claude.py) reads it from the environment; without it every scenario scores as an infra error and the scorecard is meaningless. Add the ANTHROPIC_API_KEY repository secret, or run the eval locally on AMD hardware."
+          if (-not $env:CLAUDE_CODE_OAUTH_TOKEN -and -not $env:ANTHROPIC_API_KEY) {
+            Write-Host "::error::Neither CLAUDE_CODE_OAUTH_TOKEN nor ANTHROPIC_API_KEY is set. `gaia eval agent` drives AND scores each scenario through ``claude -p`` (src/gaia/eval/runner.py), so without a credential every scenario errors in a few seconds and the scorecard is meaningless. Add either repository secret, or run the eval locally on AMD hardware."
             exit 1
           }
+
+          # Assert the credential is ACCEPTED, not merely present. #3341 sat red
+          # for weeks because the key existed and the account behind it was out
+          # of credit: the preflight passed and all five scenarios then died in
+          # three seconds each with their stdout discarded.
+          claude -p --model $env:EVAL_MODEL "reply with: ok" 2>&1 | Out-String -OutVariable probe | Out-Null
+          if ($LASTEXITCODE -ne 0) {
+            Write-Host "::error::The Claude credential is present but a one-line probe was rejected, so every scenario would error. Response: $probe"
+            exit 1
+          }
+          Write-Host "Claude credential accepted by a live probe."
 
           foreach ($category in @("rag_quality", "context_retention", "tool_selection")) {
             $baseline = Join-Path $env:BASELINE_DIR "scorecard_$category.json"
@@ -785,7 +800,11 @@ jobs:
         # derivation on the job above. Same convention as email_scorecard_refresh.yml.
         timeout-minutes: 400
         env:
-          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          # Blank when the OAuth token is present, deliberately: runner.py adds
+          # `--bare` only when ANTHROPIC_API_KEY is set, and `--bare` restricts
+          # auth to the key alone, so leaving both set would ignore the token.
+          ANTHROPIC_API_KEY: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN == '' && secrets.ANTHROPIC_API_KEY || '' }}
         run: |
           # Deliberately NOT "Stop": the eval's stderr is piped through `2>&1`
           # below, and under Stop the first stderr line from a native command

--- a/.github/workflows/test_eval_agent_gemma_consolidation.yml
+++ b/.github/workflows/test_eval_agent_gemma_consolidation.yml
@@ -792,6 +792,22 @@ jobs:
             exit 1
           }
 
+      - name: Warm the MCP server's imports
+        # The eval spawns `python -m gaia.mcp.servers.agent_ui_mcp` once per
+        # scenario, and the client drops a server that is slow to hand-shake.
+        # Cold, that import pulls in most of GAIA and pays first-touch bytecode
+        # compilation and (on this box) an AV scan of every file it opens; warm,
+        # it is a couple of seconds. On the first run after this gate started
+        # measuring, scenarios 1-3 died with CONNECTION_CLOSED at 19s / 17s /
+        # 36s and scenarios 4-5 then ran to completion in 197s and 336s — a
+        # warm-up curve, not a flake. Paying it once here rather than inside
+        # the first scenario's startup budget.
+        continue-on-error: true
+        run: |
+          $ErrorActionPreference = "SilentlyContinue"
+          python -c "import gaia.mcp.servers.agent_ui_mcp" 2>&1 | Out-Null
+          Write-Host "MCP server imports warmed (exit $LASTEXITCODE)."
+
       - name: Run the three eval categories serially
         # Own timeout so an overrun fails HERE, by name, with the collect /
         # integrity / compare / upload steps still running on the partial results.
@@ -805,6 +821,10 @@ jobs:
           # `--bare` only when ANTHROPIC_API_KEY is set, and `--bare` restricts
           # auth to the key alone, so leaving both set would ignore the token.
           ANTHROPIC_API_KEY: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN == '' && secrets.ANTHROPIC_API_KEY || '' }}
+          # The MCP server's first launch is slow on this runner (see the warm-up
+          # step above). The default startup window drops it; 120s is generous
+          # enough that a genuinely dead server still fails, just not a slow one.
+          MCP_TIMEOUT: "120000"
         run: |
           # Deliberately NOT "Stop": the eval's stderr is piped through `2>&1`
           # below, and under Stop the first stderr line from a native command

--- a/.github/workflows/test_eval_agent_gemma_consolidation.yml
+++ b/.github/workflows/test_eval_agent_gemma_consolidation.yml
@@ -792,22 +792,6 @@ jobs:
             exit 1
           }
 
-      - name: Warm the MCP server's imports
-        # The eval spawns `python -m gaia.mcp.servers.agent_ui_mcp` once per
-        # scenario, and the client drops a server that is slow to hand-shake.
-        # Cold, that import pulls in most of GAIA and pays first-touch bytecode
-        # compilation and (on this box) an AV scan of every file it opens; warm,
-        # it is a couple of seconds. On the first run after this gate started
-        # measuring, scenarios 1-3 died with CONNECTION_CLOSED at 19s / 17s /
-        # 36s and scenarios 4-5 then ran to completion in 197s and 336s — a
-        # warm-up curve, not a flake. Paying it once here rather than inside
-        # the first scenario's startup budget.
-        continue-on-error: true
-        run: |
-          $ErrorActionPreference = "SilentlyContinue"
-          python -c "import gaia.mcp.servers.agent_ui_mcp" 2>&1 | Out-Null
-          Write-Host "MCP server imports warmed (exit $LASTEXITCODE)."
-
       - name: Run the three eval categories serially
         # Own timeout so an overrun fails HERE, by name, with the collect /
         # integrity / compare / upload steps still running on the partial results.
@@ -821,10 +805,6 @@ jobs:
           # `--bare` only when ANTHROPIC_API_KEY is set, and `--bare` restricts
           # auth to the key alone, so leaving both set would ignore the token.
           ANTHROPIC_API_KEY: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN == '' && secrets.ANTHROPIC_API_KEY || '' }}
-          # The MCP server's first launch is slow on this runner (see the warm-up
-          # step above). The default startup window drops it; 120s is generous
-          # enough that a genuinely dead server still fails, just not a slow one.
-          MCP_TIMEOUT: "120000"
         run: |
           # Deliberately NOT "Stop": the eval's stderr is piped through `2>&1`
           # below, and under Stop the first stderr line from a native command

--- a/.github/workflows/test_eval_agent_gemma_consolidation.yml
+++ b/.github/workflows/test_eval_agent_gemma_consolidation.yml
@@ -346,7 +346,11 @@ jobs:
           # build the backend-default agent these scenarios run against, so install
           # the LOCAL editable hub package or every scenario dies at session
           # creation. Core gaia stays editable so eval fixtures resolve in-repo.
-          install-package: '-e .[dev,eval,ui,api] -e hub/agents/chat/python'
+          # `mcp` is not optional for this gate: every scenario is driven through
+          # the Agent UI MCP server, and without the extra that server exits with
+          # ModuleNotFoundError before writing a protocol frame — which the client
+          # reports only as CONNECTION_CLOSED.
+          install-package: '-e .[dev,eval,ui,api,mcp] -e hub/agents/chat/python'
 
       # `gaia eval agent` does not merely call the Anthropic API - it shells out
       # to `claude -p` with an MCP config to DRIVE each scenario (runner.py:937),

--- a/eval/mcp-config.json
+++ b/eval/mcp-config.json
@@ -1,8 +1,8 @@
 {
   "mcpServers": {
     "gaia-agent-ui": {
-      "command": "uv",
-      "args": ["run", "python", "-m", "gaia.mcp.servers.agent_ui_mcp", "--stdio"],
+      "command": "python",
+      "args": ["-m", "gaia.mcp.servers.agent_ui_mcp", "--stdio"],
       "env": {
         "GAIA_MEMORY_MCP_ALWAYS": "1",
         "GAIA_MEMORY_ADMIN": "1"

--- a/eval/mcp-config.json
+++ b/eval/mcp-config.json
@@ -2,7 +2,7 @@
   "mcpServers": {
     "gaia-agent-ui": {
       "command": "python",
-      "args": ["-m", "gaia.mcp.servers.agent_ui_mcp", "--stdio"],
+      "args": ["eval/mcp_server_launcher.py", "--stdio"],
       "env": {
         "GAIA_MEMORY_MCP_ALWAYS": "1",
         "GAIA_MEMORY_ADMIN": "1"

--- a/eval/mcp_server_launcher.py
+++ b/eval/mcp_server_launcher.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python
+# Copyright(C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""Launch the Agent UI MCP server with its stderr preserved.
+
+The eval spawns this server once per scenario, as a grandchild: the runner
+starts ``claude -p``, and ``claude -p`` starts the server. When the server dies
+the client reports only ``CONNECTION_CLOSED``, and the server's own stderr goes
+nowhere — it is not the scenario subprocess, so capturing *that* process's
+output (#3375) does not reach it either.
+
+Three runs of the eval gate were spent inferring a cause from timings that one
+line of this log would have stated outright. So: exec the real server in-process
+with stderr tee'd to a file the workflow uploads.
+
+stdout is untouched and unbuffered. It carries the MCP protocol, and a single
+stray byte on it desynchronises the client — which is why the diagnostics go to
+a file rather than to stderr-as-console or, worse, to stdout.
+"""
+
+from __future__ import annotations
+
+import os
+import runpy
+import sys
+import traceback
+from datetime import datetime, timezone
+from pathlib import Path
+
+#: Where to tee stderr. The workflow uploads this directory as an artifact.
+_LOG_DIR = Path(os.environ.get("GAIA_MCP_LOG_DIR", "eval-out"))
+_LOG_PATH = _LOG_DIR / "mcp-server.err.log"
+
+
+class _Tee:
+    """Write to both the real stderr and the log, so neither is lost."""
+
+    def __init__(self, *streams):
+        self._streams = streams
+
+    def write(self, data):
+        for stream in self._streams:
+            try:
+                stream.write(data)
+                stream.flush()
+            except Exception:  # noqa: BLE001 - a broken tee must not kill the server
+                pass
+        return len(data)
+
+    def flush(self):
+        for stream in self._streams:
+            try:
+                stream.flush()
+            except Exception:  # noqa: BLE001
+                pass
+
+
+def main() -> int:
+    try:
+        _LOG_DIR.mkdir(parents=True, exist_ok=True)
+        log = open(_LOG_PATH, "a", encoding="utf-8", errors="replace")
+    except OSError:
+        # A log we cannot open must not stop the server from starting.
+        log = None
+
+    if log is not None:
+        sys.stderr = _Tee(sys.stderr, log)
+        stamp = datetime.now(timezone.utc).isoformat(timespec="seconds")
+        print(
+            f"\n=== MCP server launch {stamp} pid={os.getpid()} "
+            f"python={sys.executable} ===",
+            file=sys.stderr,
+        )
+
+    # argv[0] must look like the module's own invocation, and the --stdio flag
+    # the config passes has to survive.
+    sys.argv = ["gaia.mcp.servers.agent_ui_mcp", *sys.argv[1:]]
+    try:
+        runpy.run_module("gaia.mcp.servers.agent_ui_mcp", run_name="__main__")
+    except SystemExit as exc:
+        code = exc.code if isinstance(exc.code, int) else 0
+        print(f"=== MCP server exited with {code} ===", file=sys.stderr)
+        return code
+    except BaseException:  # noqa: BLE001 - the whole point is to record it
+        print("=== MCP server raised ===", file=sys.stderr)
+        traceback.print_exc(file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
The `Agent Eval — Gemma-4-E4B consolidation` gate is red on `main` and on every open PR, and has been for weeks. It is not measuring anything: all five `tool_selection` scenarios die about three seconds in, which is a launch failure rather than a bad answer. A gate that fails identically everywhere teaches reviewers to ignore it, which is worse than having no gate on the day it catches something real.

The cause is that the account behind `ANTHROPIC_API_KEY` is out of credit. A sibling job that does not discard its subprocess output says so outright: `400 — Your credit balance is too low to access the Anthropic API`. Every other Claude workflow in this repo already prefers `CLAUDE_CODE_OAUTH_TOKEN` and falls back to the key; this one asked for the key alone.

Closes nothing on its own — #3341 stays open for the stdout-swallowing half (#3375, #3368) — but it should turn the gate green again.

### Test plan

- [ ] Dispatch this workflow on the branch and confirm the `tool_selection` scenarios run for their usual 200–680s rather than erroring in ~3s
- [ ] Confirm the preflight's live probe passes, and that it *fails loudly* if the credential is rejected — temporarily point it at a bogus token to check the error is the one a reader can act on
- [ ] Confirm `rag_quality` and `context_retention` still report their existing embedder diagnosis (they stay blocked on #3016; this PR does not touch them)

### Notes for the reviewer

**Why the CLI credential is sufficient here.** `gaia eval agent` drives *and* scores each scenario through `claude -p` — the score comes back in the `--json-schema` payload. `src/gaia/eval/runner.py` never imports `ClaudeClient`, so the SDK judge is not on this path at all. The email quality evals do use the SDK and are unaffected by this change; they will keep failing until the account is funded.

**Why `ANTHROPIC_API_KEY` is blanked rather than left alongside.** `runner.py` adds `--bare` only when that variable is set, and `--bare` restricts Anthropic auth to the key or an `apiKeyHelper` — OAuth is never read. Setting both would silently keep using the empty account.

**The preflight change is the part worth keeping regardless of the credential.** It asserted the variable *existed*. Asserting that a request is *accepted* — one line, one call — would have turned this into a startup error the first day instead of weeks of a red gate.