### PR TITLE
fix(llm): preserve Claude tool history

### DIFF
--- a/src/gaia/agents/base/agent.py
+++ b/src/gaia/agents/base/agent.py
@@ -5938,6 +5938,7 @@ Do NOT wrap conversational replies in JSON.
                 any_error = False
                 last_error = None
                 fanout_repeat_break = False
+                post_tool_messages = []
 
                 for fan_idx, tc in enumerate(tc_list):
                     tool_name = tc["name"]
@@ -6016,7 +6017,9 @@ Do NOT wrap conversational replies in JSON.
                                 "relevant data, OR state that the "
                                 "information was not found in the document."
                             )
-                            messages.append({"role": "user", "content": dedup_msg})
+                            post_tool_messages.append(
+                                {"role": "user", "content": dedup_msg}
+                            )
 
                     # Input-based dedup for mutation tools (#1317): catch an
                     # identical mutation re-issue at the first repeat. Errored
@@ -6026,7 +6029,7 @@ Do NOT wrap conversational replies in JSON.
                         tool_name,
                         tool_args,
                         mutation_call_cache,
-                        messages,
+                        post_tool_messages,
                         tool_result,
                     )
 
@@ -6105,6 +6108,11 @@ Do NOT wrap conversational replies in JSON.
                             # (#2515, the archive_message_batch repro).
                             self.console.print_error(last_error, recoverable=True)
                         any_error = True
+
+                # Anthropic and other spec-strict providers require all native
+                # tool results to immediately follow the assistant tool-call
+                # turn. Dedup guidance belongs after the complete result group.
+                messages.extend(post_tool_messages)
 
                 if fanout_repeat_break:
                     break  # break outer while

--- a/src/gaia/chat/sdk.py
+++ b/src/gaia/chat/sdk.py
@@ -166,28 +166,39 @@ class AgentSDK:
         """
         Ensure messages are safe to send to the LLM.
 
-        Tool messages are converted to user-role messages in send_messages /
-        send_messages_stream, so no extra "continue" sentinel is needed here —
-        the tool result itself already forms a valid user turn for the LLM to
-        respond to.
+        Tool messages become provider-appropriate history in send_messages /
+        send_messages_stream, so no extra "continue" sentinel is needed here.
         """
         if not messages:
             return []
 
         return list(messages)
 
-    def _flatten_tool_call_turn(self, msg: Dict[str, Any]) -> str:
-        """Textual stand-in for an assistant turn that only called tools.
-
-        Without it the flattened history shows ``None`` where the model called
-        a tool, so it can't correlate the tool results that follow.
-        """
-        calls = ", ".join(
-            f"{(tc.get('function') or {}).get('name', 'tool')}"
-            f"({(tc.get('function') or {}).get('arguments') or ''})"
-            for tc in msg.get("tool_calls", [])
-        )
-        return f"[Called tools: {calls}]"
+    def _structure_history_message(self, msg: Dict[str, Any]) -> Dict[str, Any]:
+        """Convert one history entry to the active provider's message shape."""
+        role = msg.get("role", "user")
+        content = self._normalize_message_content(msg.get("content", ""))
+        if self.config.use_claude and role == "assistant" and msg.get("tool_calls"):
+            return {
+                "role": "assistant",
+                "content": content if msg.get("content") else None,
+                "tool_calls": msg["tool_calls"],
+            }
+        if self.config.use_claude and role == "tool":
+            return {
+                "role": "tool",
+                "content": content,
+                "name": msg.get("name", "tool"),
+                "tool_call_id": msg.get("tool_call_id"),
+            }
+        if role == "tool":
+            # Local/OpenAI-compatible backends receive tool results as user text.
+            # The native Claude path above preserves the IDs Anthropic requires.
+            return {
+                "role": "user",
+                "content": f"[Tool result: {msg.get('name', 'tool')}] {content}",
+            }
+        return {"role": role, "content": content}
 
     # ── per-turn performance recording (dev mode, opt-in) ──────────────────
     #
@@ -280,34 +291,7 @@ class AgentSDK:
                         "system prompt already prepended."
                     )
                     continue
-                content = self._normalize_message_content(msg.get("content", ""))
-                if role == "tool":
-                    # Tool results are surfaced as user messages so that the LLM
-                    # receives a proper user turn to reply to.  Converting them to
-                    # "assistant" caused the previously-injected "continue" sentinel
-                    # to become the visible user message, making the model think it
-                    # was asked to "continue" rather than respond to the real query.
-                    tool_name = msg.get("name", "tool")
-                    structured.append(
-                        {
-                            "role": "user",
-                            "content": f"[Tool result: {tool_name}] {content}",
-                        }
-                    )
-                elif (
-                    self.config.use_claude
-                    and role == "assistant"
-                    and not msg.get("content")
-                    and msg.get("tool_calls")
-                ):
-                    structured.append(
-                        {
-                            "role": "assistant",
-                            "content": self._flatten_tool_call_turn(msg),
-                        }
-                    )
-                else:
-                    structured.append({"role": role, "content": content})
+                structured.append(self._structure_history_message(msg))
 
             # Debug logging
             self.log.debug(f"Structured messages: {len(structured)} entries")
@@ -400,31 +384,7 @@ class AgentSDK:
                         "system prompt already prepended."
                     )
                     continue
-                content = self._normalize_message_content(msg.get("content", ""))
-                if role == "tool":
-                    # Tool results are surfaced as user messages — same reasoning
-                    # as in send_messages above.
-                    tool_name = msg.get("name", "tool")
-                    structured.append(
-                        {
-                            "role": "user",
-                            "content": f"[Tool result: {tool_name}] {content}",
-                        }
-                    )
-                elif (
-                    self.config.use_claude
-                    and role == "assistant"
-                    and not msg.get("content")
-                    and msg.get("tool_calls")
-                ):
-                    structured.append(
-                        {
-                            "role": "assistant",
-                            "content": self._flatten_tool_call_turn(msg),
-                        }
-                    )
-                else:
-                    structured.append({"role": role, "content": content})
+                structured.append(self._structure_history_message(msg))
 
             # Debug logging
             self.log.debug(f"Structured messages: {len(structured)} entries")

--- a/src/gaia/llm/providers/claude.py
+++ b/src/gaia/llm/providers/claude.py
@@ -269,6 +269,9 @@ class ClaudeProvider(LLMClient):
                     "Claude tool-call history requires a complete, immediately "
                     "adjacent result group; missing tool_call_id(s): "
                     + ", ".join(sorted(expected_ids))
+                    + ". Append every role='tool' result directly after the "
+                    "assistant turn that requested it — any user/system message "
+                    "injected between them must come after the group."
                 )
             if role == "tool":
                 cleaned.append(
@@ -337,7 +340,7 @@ class ClaudeProvider(LLMClient):
         block = {
             "type": "tool_result",
             "tool_use_id": tool_call_id,
-            "content": message.get("content", ""),
+            "content": message.get("content") or "[tool returned no output]",
         }
         if (
             cleaned

--- a/src/gaia/llm/providers/claude.py
+++ b/src/gaia/llm/providers/claude.py
@@ -229,23 +229,128 @@ class ClaudeProvider(LLMClient):
         return converted
 
     def _split_system(self, messages: List[dict]) -> tuple:
-        """Hoist role=system entries out of the array into the ``system`` param."""
+        """Hoist system text and translate OpenAI tool history for Anthropic."""
         system_parts: List[str] = []
         cleaned: List[dict] = []
-        for msg in messages:
+        index = 0
+        while index < len(messages):
+            msg = messages[index]
             role = msg.get("role", "user")
             content = msg.get("content")
             if role == "system":
                 if content:
                     system_parts.append(str(content))
+                index += 1
+                continue
+            if role == "assistant" and msg.get("tool_calls"):
+                blocks = self._tool_use_content(msg)
+                expected_ids = {
+                    block["id"] for block in blocks if block["type"] == "tool_use"
+                }
+                result_messages = []
+                result_index = index + 1
+                while result_index < len(messages) and expected_ids:
+                    result = messages[result_index]
+                    if result.get("role") != "tool":
+                        break
+                    tool_call_id = result.get("tool_call_id")
+                    if tool_call_id not in expected_ids:
+                        break
+                    result_messages.append(result)
+                    expected_ids.remove(tool_call_id)
+                    result_index += 1
+                if not expected_ids:
+                    cleaned.append({"role": "assistant", "content": blocks})
+                    for result in result_messages:
+                        self._append_tool_result(cleaned, result)
+                    index = result_index
+                    continue
+                raise ValueError(
+                    "Claude tool-call history requires a complete, immediately "
+                    "adjacent result group; missing tool_call_id(s): "
+                    + ", ".join(sorted(expected_ids))
+                )
+            if role == "tool":
+                cleaned.append(
+                    {
+                        "role": "user",
+                        "content": (
+                            f"[Tool result: {msg.get('name', 'tool')}] "
+                            f"{msg.get('content', '')}"
+                        ),
+                    }
+                )
+                index += 1
                 continue
             if content is None or content == "":
                 # Anthropic rejects empty message content outright.
                 logger.debug("Dropping empty %s message for Claude request", role)
+                index += 1
                 continue
             cleaned.append({"role": role, "content": content})
+            index += 1
         system = "\n\n".join(system_parts) if system_parts else self._system_prompt
         return system, cleaned
+
+    @staticmethod
+    def _tool_use_content(message: dict) -> List[dict]:
+        content = message.get("content")
+        blocks = []
+        if content:
+            if isinstance(content, list):
+                blocks.extend(content)
+            else:
+                blocks.append({"type": "text", "text": str(content)})
+        for tool_call in message["tool_calls"]:
+            function = tool_call.get("function") or {}
+            tool_call_id = tool_call.get("id")
+            name = function.get("name")
+            if not tool_call_id or not name:
+                raise ValueError("Claude tool calls require both an id and a name.")
+            arguments = function.get("arguments") or "{}"
+            if isinstance(arguments, str):
+                try:
+                    arguments = json.loads(arguments)
+                except json.JSONDecodeError as exc:
+                    raise ValueError(
+                        f"Claude tool call {tool_call_id!r} has invalid JSON arguments."
+                    ) from exc
+            if not isinstance(arguments, dict):
+                raise ValueError(
+                    f"Claude tool call {tool_call_id!r} arguments must decode to an object."
+                )
+            blocks.append(
+                {
+                    "type": "tool_use",
+                    "id": tool_call_id,
+                    "name": name,
+                    "input": arguments,
+                }
+            )
+        return blocks
+
+    @staticmethod
+    def _append_tool_result(cleaned: List[dict], message: dict) -> None:
+        tool_call_id = message.get("tool_call_id")
+        if not tool_call_id:
+            raise ValueError("Claude tool results require a tool_call_id.")
+        block = {
+            "type": "tool_result",
+            "tool_use_id": tool_call_id,
+            "content": message.get("content", ""),
+        }
+        if (
+            cleaned
+            and cleaned[-1]["role"] == "user"
+            and isinstance(cleaned[-1]["content"], list)
+            and all(
+                isinstance(item, dict) and item.get("type") == "tool_result"
+                for item in cleaned[-1]["content"]
+            )
+        ):
+            cleaned[-1]["content"].append(block)
+            return
+        cleaned.append({"role": "user", "content": [block]})
 
     def _build_params(
         self,

--- a/tests/unit/agents/test_parallel_tool_calls.py
+++ b/tests/unit/agents/test_parallel_tool_calls.py
@@ -259,6 +259,30 @@ class TestParallelCallsExecuteAndCorrelate:
         assert {m["tool_call_id"] for m in tool_msgs} == {"id-A", "id-B"}
         assert {m["name"] for m in tool_msgs} == {"tool_a", "tool_b"}
 
+    def test_native_dedup_guidance_follows_tool_result(self, agent):
+        def mark_read(**kwargs):  # pylint: disable=unused-argument
+            return {"status": "success"}
+
+        _register_tool("mark_read", mark_read)
+        first = _native_envelope(("id-1", "mark_read", {"message_id": "same"}))
+        second = _native_envelope(("id-2", "mark_read", {"message_id": "same"}))
+        final = json.dumps({"thought": "done", "answer": "Done."})
+        chat = _stub_chat(agent, first, second, final)
+
+        agent.process_query("mark it read", max_steps=5)
+
+        third_call = chat.send_messages.call_args_list[2]
+        messages = third_call.kwargs.get("messages") or third_call.args[0]
+        assistant_index = max(
+            index
+            for index, message in enumerate(messages)
+            if message.get("role") == "assistant" and message.get("tool_calls")
+        )
+        assert messages[assistant_index + 1]["role"] == "tool"
+        assert messages[assistant_index + 1]["tool_call_id"] == "id-2"
+        assert messages[assistant_index + 2]["role"] == "user"
+        assert "[SYSTEM]" in messages[assistant_index + 2]["content"]
+
 
 class TestParallelCallsWithError:
     """Acceptance criterion (b): three parallel calls, one errors —

--- a/tests/unit/agents/test_parallel_tool_calls.py
+++ b/tests/unit/agents/test_parallel_tool_calls.py
@@ -283,6 +283,38 @@ class TestParallelCallsExecuteAndCorrelate:
         assert messages[assistant_index + 2]["role"] == "user"
         assert "[SYSTEM]" in messages[assistant_index + 2]["content"]
 
+    def test_native_dedup_guidance_follows_both_results_in_one_envelope(self, agent):
+        """Dedup firing on call 2 of 2 *within a single envelope* must not
+        split the tool_result pair — both role='tool' entries stay adjacent
+        to the assistant turn, and the [SYSTEM] guidance lands after both."""
+
+        def mark_read(**kwargs):  # pylint: disable=unused-argument
+            return {"status": "success"}
+
+        _register_tool("mark_read", mark_read)
+        parallel = _native_envelope(
+            ("id-1", "mark_read", {"message_id": "same"}),
+            ("id-2", "mark_read", {"message_id": "same"}),
+        )
+        final = json.dumps({"thought": "done", "answer": "Done."})
+        chat = _stub_chat(agent, parallel, final)
+
+        agent.process_query("mark it read twice", max_steps=5)
+
+        second_call = chat.send_messages.call_args_list[1]
+        messages = second_call.kwargs.get("messages") or second_call.args[0]
+        assistant_index = max(
+            index
+            for index, message in enumerate(messages)
+            if message.get("role") == "assistant" and message.get("tool_calls")
+        )
+        assert messages[assistant_index + 1]["role"] == "tool"
+        assert messages[assistant_index + 1]["tool_call_id"] == "id-1"
+        assert messages[assistant_index + 2]["role"] == "tool"
+        assert messages[assistant_index + 2]["tool_call_id"] == "id-2"
+        assert messages[assistant_index + 3]["role"] == "user"
+        assert "[SYSTEM]" in messages[assistant_index + 3]["content"]
+
 
 class TestParallelCallsWithError:
     """Acceptance criterion (b): three parallel calls, one errors —

--- a/tests/unit/test_claude_provider.py
+++ b/tests/unit/test_claude_provider.py
@@ -252,6 +252,168 @@ def test_empty_messages_after_hoist_fail_loudly(fake_anthropic):
         provider.chat([{"role": "system", "content": "only a system prompt"}])
 
 
+def test_tool_history_translated_to_anthropic_blocks(fake_anthropic):
+    provider = _provider(fake_anthropic)
+    provider._client.messages.create.return_value = _response([_text_block("done")])
+    provider.chat(
+        [
+            {"role": "user", "content": "compare these files"},
+            {
+                "role": "assistant",
+                "content": "I'll inspect both.",
+                "tool_calls": [
+                    {
+                        "id": "toolu_a",
+                        "type": "function",
+                        "function": {
+                            "name": "read_file",
+                            "arguments": '{"path": "a.txt"}',
+                        },
+                    },
+                    {
+                        "id": "toolu_b",
+                        "type": "function",
+                        "function": {
+                            "name": "read_file",
+                            "arguments": '{"path": "b.txt"}',
+                        },
+                    },
+                ],
+            },
+            {"role": "tool", "tool_call_id": "toolu_a", "content": "alpha"},
+            {"role": "tool", "tool_call_id": "toolu_b", "content": "beta"},
+        ],
+        tools=OPENAI_TOOLS,
+    )
+    call = provider._client.messages.create.call_args.kwargs
+    assert call["messages"] == [
+        {"role": "user", "content": "compare these files"},
+        {
+            "role": "assistant",
+            "content": [
+                {"type": "text", "text": "I'll inspect both."},
+                {
+                    "type": "tool_use",
+                    "id": "toolu_a",
+                    "name": "read_file",
+                    "input": {"path": "a.txt"},
+                },
+                {
+                    "type": "tool_use",
+                    "id": "toolu_b",
+                    "name": "read_file",
+                    "input": {"path": "b.txt"},
+                },
+            ],
+        },
+        {
+            "role": "user",
+            "content": [
+                {
+                    "type": "tool_result",
+                    "tool_use_id": "toolu_a",
+                    "content": "alpha",
+                },
+                {
+                    "type": "tool_result",
+                    "tool_use_id": "toolu_b",
+                    "content": "beta",
+                },
+            ],
+        },
+    ]
+
+
+def test_tool_call_only_assistant_turn_is_not_dropped(fake_anthropic):
+    provider = _provider(fake_anthropic)
+    provider._client.messages.create.return_value = _response([_text_block("done")])
+    provider.chat(
+        [
+            {"role": "user", "content": "list files"},
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [
+                    {
+                        "id": "toolu_1",
+                        "type": "function",
+                        "function": {
+                            "name": "read_file",
+                            "arguments": '{"path": "a.txt"}',
+                        },
+                    }
+                ],
+            },
+            {"role": "tool", "tool_call_id": "toolu_1", "content": "alpha"},
+        ],
+        tools=OPENAI_TOOLS,
+    )
+    call = provider._client.messages.create.call_args.kwargs
+    assert call["messages"][1]["content"] == [
+        {
+            "type": "tool_use",
+            "id": "toolu_1",
+            "name": "read_file",
+            "input": {"path": "a.txt"},
+        }
+    ]
+
+
+def test_unmatched_tool_result_remains_plain_user_text(fake_anthropic):
+    provider = _provider(fake_anthropic)
+    provider._client.messages.create.return_value = _response([_text_block("done")])
+    provider.chat(
+        [
+            {"role": "user", "content": "follow the plan"},
+            {"role": "assistant", "content": "Running the planned step."},
+            {
+                "role": "tool",
+                "name": "plan_step",
+                "tool_call_id": "synthetic-id",
+                "content": "complete",
+            },
+        ]
+    )
+    call = provider._client.messages.create.call_args.kwargs
+    assert call["messages"][-1] == {
+        "role": "user",
+        "content": "[Tool result: plan_step] complete",
+    }
+
+
+def test_interrupted_native_tool_history_fails_loudly(fake_anthropic):
+    provider = _provider(fake_anthropic)
+    provider._client.messages.create.return_value = _response([_text_block("done")])
+    with pytest.raises(ValueError, match="immediately adjacent.*toolu_1"):
+        provider.chat(
+            [
+                {"role": "user", "content": "read it"},
+                {
+                    "role": "assistant",
+                    "content": None,
+                    "tool_calls": [
+                        {
+                            "id": "toolu_1",
+                            "type": "function",
+                            "function": {
+                                "name": "read_file",
+                                "arguments": '{"path": "a.txt"}',
+                            },
+                        }
+                    ],
+                },
+                {"role": "user", "content": "Actually use b.txt."},
+                {
+                    "role": "tool",
+                    "name": "read_file",
+                    "tool_call_id": "toolu_1",
+                    "content": "alpha",
+                },
+            ],
+            tools=OPENAI_TOOLS,
+        )
+
+
 # ── response → sentinel envelope ────────────────────────────────────────
 
 
@@ -598,38 +760,52 @@ def test_sdk_no_chatml_stop_tokens_for_claude(monkeypatch):
     assert "stop" not in fake.calls[-1]["kwargs"]
 
 
-def test_sdk_flattens_assistant_tool_call_turn(claude_sdk):
+@pytest.mark.parametrize("stream", [False, True])
+def test_sdk_preserves_claude_tool_history(claude_sdk, stream):
     sdk, fake = claude_sdk
-    sdk.send_messages(
-        [
-            {"role": "user", "content": "list my files"},
-            {
-                "role": "assistant",
-                "content": None,
-                "tool_calls": [
-                    {
-                        "id": "toolu_1",
-                        "type": "function",
-                        "function": {
-                            "name": "list_directory",
-                            "arguments": '{"path": "C:/"}',
-                        },
-                    }
-                ],
-            },
-            {"role": "tool", "name": "list_directory", "content": "a.txt"},
-        ]
-    )
-    sent = fake.calls[-1]["messages"]
-    assistant_turns = [m for m in sent if m["role"] == "assistant"]
-    assert assistant_turns == [
+    messages = [
+        {"role": "user", "content": "list my files"},
         {
             "role": "assistant",
-            "content": '[Called tools: list_directory({"path": "C:/"})]',
-        }
+            "content": "Checking now.",
+            "tool_calls": [
+                {
+                    "id": "toolu_1",
+                    "type": "function",
+                    "function": {
+                        "name": "list_directory",
+                        "arguments": '{"path": "C:/"}',
+                    },
+                }
+            ],
+        },
+        {
+            "role": "tool",
+            "name": "list_directory",
+            "tool_call_id": "toolu_1",
+            "content": "a.txt",
+        },
     ]
-    # The flattened history never shows the "None" placeholder.
-    assert all(m["content"] != "None" for m in sent)
+    if stream:
+        list(sdk.send_messages_stream(messages))
+    else:
+        sdk.send_messages(messages)
+    sent = fake.calls[-1]["messages"]
+    assert sent[1:] == [
+        {
+            "role": "assistant",
+            "content": "Checking now.",
+            "tool_calls": messages[1]["tool_calls"],
+        },
+        {
+            "role": "tool",
+            "content": "a.txt",
+            "name": "list_directory",
+            "tool_call_id": "toolu_1",
+        },
+    ]
+    assert "[Called tools:" not in str(sent)
+    assert "[Tool result:" not in str(sent)
 
 
 # ── stdio transport flag contract ───────────────────────────────────────


### PR DESCRIPTION
## Why this matters

Any GAIA agent talking to a Claude model was losing its own tool history on the way out. The provider rebuilt every outbound message as `{role, content}`, so assistant `tool_calls` were stripped, a tool-call-only turn was dropped entirely, and results were forwarded as `role="tool"` — a shape Anthropic rejects. Nothing errored: the request just succeeded with a quietly truncated history, so the model could not tell what it had already run, re-did work, and lost the thread on multi-step tasks. Tool calls and their results now survive as native Anthropic `tool_use` / `tool_result` blocks, with every parallel call id preserved.

Closes #3389.

## Test plan

- [x] `PYTHONPATH=src python -m pytest tests/unit/test_claude_provider.py tests/unit/test_sdk_tool_messages.py tests/unit/agents/ -q` — 765 passed, 50 skipped
- [x] Outbound payload asserted against every static acceptance criterion in #3389: a mixed text + parallel tool-call turn keeps both ids, a tool-call-only assistant turn is no longer dropped, and `role="tool"` becomes a `user` turn whose `tool_result` blocks reference the originating `tool_use_id` — with all results merged into a single user message, as Anthropic requires
- [x] Synthetic/legacy tool results with no originating call still take the prose path; an interrupted native group fails loudly rather than emitting a payload Anthropic would reject
- [x] Black, isort, and Flake8 clean on the changed files using the repo's own flags. The single Pylint `E1125` in `claude.py` is pre-existing on `main` and unrelated.
- [ ] **Live multi-step Claude agent run — cannot be done in this environment.** `ANTHROPIC_API_KEY` is the literal placeholder `dummy`, and there is no Anthropic OAuth profile or `ant` credential on the machine, so `--use-claude` can only return 401. This needs a reviewer holding a real credential; it is the one criterion in #3389 that unit tests cannot stand in for.

## Evidence

- [ ] **Agent exposed in the Agent UI** — pending the credential-backed run above. No synthetic screenshot is attached for what is an internal request-payload change.
- [x] **MCP tools / servers** — N/A; no MCP surface changed
- [x] **CLI** — N/A; no CLI contract changed
- [x] **HTTP API / REST** — N/A; no GAIA HTTP endpoint changed

## Checklist

- [x] I have linked a GitHub issue above (`Closes #3389`).
- [x] I have described **why** this change is being made, not just what changed.
- [x] I have run linting and tests locally. `util/lint.py --all` cannot run here, for two unrelated reasons: it shells out to `uvx` to fetch its tools and the network blocks that, and its own diff printer then crashes with a `UnicodeEncodeError` on this Windows `cp1252` console. The already-installed Black, isort, Flake8, and Pylint were run directly on the changed files instead, with the flags `util/lint.py` passes (note it sets `--max-line-length=88` and ignores `E501`, so a bare `flake8` run reports false positives).
- [ ] I have attached **real-world evidence matched to the surface I changed**. Live Claude evidence remains outstanding for the reason given in the test plan.
- [x] I have updated documentation if user-visible behavior changed. N/A; this corrects internal provider history encoding without changing a documented contract.

## Known gap (follow-up, not addressed here)

`_shrink_messages_for_overflow` rebuilds long assistant turns as `{role, content}` and drops `tool_calls`, so the context-overflow retry path silently reverts to the old lossy encoding for that one turn. It degrades to prose rather than failing, and fixing it is out of scope for this change.

