### PR TITLE
fix(ci): report runner outages in minutes, not as a silent cancel a day later

### DIFF
--- a/.github/workflows/monitor_selfhosted_runners.yml
+++ b/.github/workflows/monitor_selfhosted_runners.yml
@@ -78,8 +78,11 @@ jobs:
             age=$(( now - $(date -d "$ts" +%s) ))
             echo "  last heartbeat: $ts (${age}s ago)"
 
-            if [ "$age" -gt 691200 ]; then   # 8 days (weekly + 1 day buffer)
-              echo "  STALE — older than 8 days"
+            # 3 days: healthy is ~1 day (beat Sunday, check Monday), one missed
+            # beat is ~8 days. Must stay well under 8 — an 8-day limit decided
+            # that case by seconds and passed runners that were already dead.
+            if [ "$age" -gt 259200 ]; then
+              echo "  STALE — no heartbeat in over 3 days"
               missing="$missing $r"
             fi
           done

--- a/.github/workflows/runner_heartbeat.yml
+++ b/.github/workflows/runner_heartbeat.yml
@@ -32,9 +32,9 @@ jobs:
           - sjlab-stx-3
       fail-fast: false  # Continue even if one runner fails
     runs-on: [self-hosted, "${{ matrix.runner }}"]
-    # Fail fast if a runner is offline. Without this the job waits the full 24h
-    # queue timeout, so an outage surfaces a day late and reports `cancelled`
-    # (ambiguous) instead of a clean failure.
+    # Caps execution only — GitHub starts this clock when a runner picks the job
+    # up, so it does NOT bound queue time. An offline runner still waits the full
+    # 24h queue limit; the `watchdog` job below is what makes that loud.
     timeout-minutes: 10
     steps:
       - name: Create heartbeat file (Windows)
@@ -59,3 +59,60 @@ jobs:
           name: heartbeat-${{ runner.name }}
           path: heartbeat-${{ runner.name }}.txt
           retention-days: 14
+
+  # Turns "no runner ever picked the job up" into a named failure in ~10 minutes
+  # instead of an unexplained `cancelled` 24h later. Runs on GitHub-hosted infra
+  # so it reports even when every self-hosted runner is down.
+  watchdog:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Fail if any heartbeat job never got a runner
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          # A healthy runner claims its job in seconds; 10 min is pure headroom.
+          deadline=$(( $(date -u +%s) + 600 ))
+          stuck=""
+
+          while :; do
+            if ! gh api "/repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/jobs?per_page=100" > jobs.json; then
+              echo "ERROR: could not list jobs for this run — cannot tell whether the" >&2
+              echo "heartbeat jobs were picked up. Check the Actions API status." >&2
+              exit 1
+            fi
+
+            stuck=$(jq -r '[.jobs[] | select(.name | startswith("heartbeat ")) | select(.status == "queued") | .name] | join(", ")' jobs.json)
+
+            if [ -z "$stuck" ]; then
+              break
+            fi
+            if [ "$(date -u +%s)" -ge "$deadline" ]; then
+              break
+            fi
+            echo "still queued: $stuck"
+            sleep 30
+          done
+
+          if [ -n "$stuck" ]; then
+            echo "::error::No self-hosted runner picked up: $stuck"
+            echo "" >&2
+            echo "These heartbeat jobs sat queued for 10 minutes, which means no ONLINE" >&2
+            echo "runner carries the requested label. Left alone they stay queued until" >&2
+            echo "GitHub cancels them at the 24h limit, which is why this shows up as a" >&2
+            echo "bare \`cancelled\` run with no explanation." >&2
+            echo "" >&2
+            echo "This is a runner-box outage, not a workflow bug. To fix:" >&2
+            echo "  1. Confirm the outage — Settings > Actions > Runners, or:" >&2
+            echo "       gh api repos/${{ github.repository }}/actions/runners \\" >&2
+            echo "         --jq '.runners[] | \"\\(.name) \\(.status)\"'" >&2
+            echo "  2. On the affected box, restart the GitHub Actions runner service" >&2
+            echo "     (it runs as 'actions.runner.*'), then re-run this workflow." >&2
+            echo "  3. If the box is retired, remove it from the matrix in" >&2
+            echo "     .github/workflows/runner_heartbeat.yml — that matrix is the single" >&2
+            echo "     source of truth for which runners are monitored." >&2
+            exit 1
+          fi
+
+          echo "All heartbeat jobs were picked up by a runner."


### PR DESCRIPTION
Two self-hosted runner boxes went offline in late August and neither health workflow said so usefully. The heartbeat runs showed up as a bare `cancelled` 24 hours after the fact, naming nothing, and the Monday monitor gave one of the dead boxes a passing grade for a full extra week. Whoever looked at either signal would have concluded things were mostly fine. After this change a dead runner is named in a failed job within ~10 minutes.

**This does not fix the outage.** `sjlab-stx-1` and `sjlab-stx-3` are both genuinely offline and still need someone with box access to restart the runner service. Neither runner is removed from the matrix — that would hide the problem, which is what this PR is trying to stop.

Two bugs the outage exposed:

- **`timeout-minutes: 10` never did what its comment claimed.** GitHub starts that clock when a runner picks the job up, so it does not bound queue time at all. Runs 33285375430 and 34003614956 each sat queued for exactly 24h before GitHub cancelled them. A new GitHub-hosted `watchdog` job now polls the run's own jobs and fails loudly with the runner name and the steps to fix it. Failure also outranks cancelled, so the run stops looking like a clean cancel.
- **The monitor's 8-day staleness limit decided by seconds.** It sat exactly on the "missed one weekly beat" boundary, so it passed runners that were already dead: on 2026-08-31 `sjlab-stx-1` measured 690454s against the 691200s limit and passed, hiding its outage for a week; on 2026-09-07 `sjlab-stx-3` passed by 104s, so that alert named only one of the two dead boxes. Now 3 days.

### Test plan

- [ ] Run `gh workflow run runner_heartbeat.yml` while the runners are still offline. The `watchdog` job should fail in ~10 min naming `heartbeat (sjlab-stx-1)` and `heartbeat (sjlab-stx-3)`, and the run should end `failure`, not `cancelled`.
- [ ] Run `gh workflow run monitor_selfhosted_runners.yml`. It should report **both** runners as stale, where the 2026-09-07 run reported only `sjlab-stx-1`.
- [ ] After the boxes are restarted, re-run both. Heartbeat should be all-green with the watchdog reporting "All heartbeat jobs were picked up by a runner"; monitor should pass with ages around 86000s, well inside the 259200s limit.

<details>
<summary>🔍 Technical details</summary>

Watchdog logic was exercised locally against real `/actions/runs/{id}/jobs` payloads from run 34003614956, mutated into four states — all heartbeat jobs queued, all completed, one of each (the actual 2026-08-30 scenario), and an API failure. It correctly names only the stuck jobs in the mixed case, excludes itself via the `heartbeat ` name prefix, and exits 1 with an actionable message when the API call fails rather than assuming health.

The runners API can't be used for this check: `administration: read` is not a grantable `permissions:` key for `GITHUB_TOKEN`, which is why the monitor reads heartbeat artifacts instead. The watchdog therefore reads job status via `actions: read`, already covered by the workflow's `actions: write`.

Threshold arithmetic: healthy artifacts measured 86270–86330s across the 2026-08-17, 08-24 and 08-31 runs. 259200s is 3x that, and half the ~691200s a single missed beat produces.
</details>