### PR TITLE
fix(email): fail loudly on Outlook operators Graph cannot translate

### DIFF
--- a/hub/agents/email/npm/CHANGELOG.md
+++ b/hub/agents/email/npm/CHANGELOG.md
@@ -29,6 +29,11 @@ behind any entry — API shapes, endpoints, and version semantics — see
   as literal search text; they are now translated to the matching Graph
   query so `search({ query: "is:unread" })` and similar calls behave the
   way they do for Gmail (#2996).
+- **Searching Outlook with `is:starred`, `after:`, `before:`, `label:`,
+  `has:`, or `in:` now fails with a clear error instead of quietly matching
+  nothing.** Microsoft Graph has no equivalent for these, so they used to be
+  sent as plain search text and return zero results with no indication why
+  (#2996).
 
 - **The published API contract now shows that requests need a session token.**
   The sidecar has always required a bearer token on most calls, but the

--- a/hub/agents/email/python/CHANGELOG.md
+++ b/hub/agents/email/python/CHANGELOG.md
@@ -76,6 +76,16 @@ contract version is tracked separately as
   `outlook_backend.py` never parses Gmail operator syntax, so converting
   `w` to days has no effect there. Quoted Outlook `$search` values are
   escaped separately (see the Graph quote escape entry above).
+- **An Outlook search using `is:starred`, `after:`, `before:`, `label:`,
+  `has:`, or `in:` returned nothing instead of an error (#2996).** These
+  Gmail-style operators have no Microsoft Graph translation, so
+  `translate_query` let each one fall through to the `$search` bucket and
+  reach Graph as inert literal text: Graph never errors on an unrecognised
+  `$search` token, so the search silently matched nothing. The agent's own
+  tool description recommends several of these (`label:promotions`,
+  `after:YYYY/MM/DD`), so a model following its own instructions could hit
+  this. `translate_query` now raises an actionable error naming the
+  unsupported operator instead of degrading to a phrase match.
 
 ### Changed
 

--- a/hub/agents/email/python/gaia_agent_email/outlook_query.py
+++ b/hub/agents/email/python/gaia_agent_email/outlook_query.py
@@ -28,10 +28,11 @@ This module splits that string into what each half of it actually is:
   request, so a query mixing the two families (``is:unread from:alice``)
   cannot be expressed in one call; that raises rather than silently dropping
   one half.
-- An operator Graph cannot express at all (``is:starred``, ``after:``,
-  ``before:``, ``label:``, ``has:``, ``in:``) used to fall into the
-  ``$search`` bucket above and reach Graph as inert literal text, matching
-  nothing with no error. These now raise instead of silently degrading.
+- An operator this backend does not translate (``is:starred``, ``after:``,
+  ``before:``, ``newer:``, ``older:``, ``label:``, ``has:``, ``in:``) used to
+  fall into the ``$search`` bucket above and reach Graph as inert literal
+  text, matching nothing with no error. These now raise instead of silently
+  degrading.
 """
 
 from __future__ import annotations
@@ -62,8 +63,15 @@ _DURATION_RE = re.compile(
 # never errors on an unrecognised $search token, so the query silently
 # matches nothing (#2996 finding I62). ``is:`` here only matches a value
 # _IS_RE didn't already consume, i.e. anything other than unread/read.
+# ``newer:``/``older:`` (bare, not the ``_than`` duration forms _DURATION_RE
+# already handles) are read_tools._DATE_OP_RE's own vocabulary for absolute
+# dates and reach here unchanged by normalize_gmail_date_operators, so they
+# need the same guard as after:/before: or they degrade the same way (review
+# on this PR). The value grammar accepts an empty match (``\S*``, not
+# ``\S+``) so a bare ``label:`` with nothing after it still raises instead of
+# reaching $search as literal text.
 _UNSUPPORTED_OPERATOR_RE = re.compile(
-    r'\b(?P<op>is|after|before|label|has|in):(?P<val>"[^"]*"|\S+)',
+    r'\b(?P<op>is|after|before|newer|older|label|has|in):(?P<val>"[^"]*"|\S*)',
     re.IGNORECASE,
 )
 
@@ -124,10 +132,13 @@ def translate_query(query: str, *, now: Optional[datetime] = None) -> GraphQuery
     ``$search`` cannot express under any quoting and route to ``$filter``
     above instead).
 
-    Also raises ``ValueError`` for a Gmail operator Graph cannot express at
-    all (``is:starred``, ``after:``, ``before:``, ``label:``, ``has:``,
-    ``in:``), rather than sending it to ``$search`` as text that silently
-    matches nothing.
+    Also raises ``ValueError`` for a Gmail operator this backend does not
+    translate (``is:starred``, ``after:``, ``before:``, ``newer:``,
+    ``older:``, ``label:``, ``has:``, ``in:``), rather than sending it to
+    ``$search`` as text that silently matches nothing. Some of these (a
+    received-date bound, ``hasAttachments``) do have a Graph field; this
+    module just does not map them yet, which the error says plainly instead
+    of implying Graph itself has no such concept.
     """
     now = now or datetime.now(timezone.utc)
     filters: List[str] = []
@@ -153,6 +164,22 @@ def translate_query(query: str, *, now: Optional[datetime] = None) -> GraphQuery
         remainder = re.sub(r"[()\[\]{}]", " ", remainder)
     remainder = " ".join(remainder.split())
 
+    # Checked before the mixed-family error below: a remainder that itself
+    # carries an operator Graph cannot express at all is never a valid
+    # second search term, so naming it beats telling the caller to re-run it
+    # as a separate search that would fail the exact same way (review on
+    # this PR).
+    unsupported = _UNSUPPORTED_OPERATOR_RE.search(remainder)
+    if unsupported:
+        raise ValueError(
+            "search_messages: on Outlook, "
+            f"{unsupported.group(0)!r} is not supported by this backend and "
+            "would silently match nothing if sent as search text. Supported "
+            "operators are is:unread, is:read, newer_than:, older_than:, "
+            f"from:, and subject:, so drop {unsupported.group('op')}: from "
+            "the query and try again."
+        )
+
     if filters and remainder:
         raise ValueError(
             "search_messages: on Outlook, "
@@ -165,14 +192,4 @@ def translate_query(query: str, *, now: Optional[datetime] = None) -> GraphQuery
     if filters:
         return GraphQuery(filter=" and ".join(filters))
 
-    unsupported = _UNSUPPORTED_OPERATOR_RE.search(remainder)
-    if unsupported:
-        raise ValueError(
-            "search_messages: on Outlook, "
-            f"{unsupported.group(0)!r} has no Microsoft Graph equivalent and "
-            "would silently match nothing if sent as search text. Supported "
-            "operators are is:unread, is:read, newer_than:, older_than:, "
-            f"from:, and subject:, so drop {unsupported.group('op')}: from "
-            "the query and try again."
-        )
     return GraphQuery(search=_graph_search_param(query))

--- a/hub/agents/email/python/gaia_agent_email/outlook_query.py
+++ b/hub/agents/email/python/gaia_agent_email/outlook_query.py
@@ -28,6 +28,10 @@ This module splits that string into what each half of it actually is:
   request, so a query mixing the two families (``is:unread from:alice``)
   cannot be expressed in one call; that raises rather than silently dropping
   one half.
+- An operator Graph cannot express at all (``is:starred``, ``after:``,
+  ``before:``, ``label:``, ``has:``, ``in:``) used to fall into the
+  ``$search`` bucket above and reach Graph as inert literal text, matching
+  nothing with no error. These now raise instead of silently degrading.
 """
 
 from __future__ import annotations
@@ -40,14 +44,26 @@ from typing import List, Optional
 from gaia_agent_email.gmail_query import parse_gmail_duration_value
 
 # The only two Gmail ``is:`` values with an unambiguous Graph $filter mapping
-# (``isRead``); any other value (``starred``, ...) is left as free text, which
-# the mixed-family check below turns into a loud error, not a silent no-op.
+# (``isRead``); any other value (``starred``, ...) is caught below by
+# _UNSUPPORTED_OPERATOR_RE instead of reaching Graph as free text.
 _IS_RE = re.compile(r"\bis:(unread|read)\b", re.IGNORECASE)
 
 _DURATION_RE = re.compile(
     # Stop at grouping punctuation so `(newer_than:7d)` validates `7d`, not
     # `7d)`, just like the Gmail query normalizer.
     r'\b(?P<op>newer_than|older_than):(?P<val>"[^"]*"|[^\s)}\]]+)',
+    re.IGNORECASE,
+)
+
+# Gmail operators with no Graph $filter mapping and no meaning to Graph's KQL
+# $search parser either (unlike from:/subject:, which Graph reads inside the
+# wrapping quotes the same way Outlook's own search box does). Left
+# unguarded, each reaches _graph_search_param as inert literal text: Graph
+# never errors on an unrecognised $search token, so the query silently
+# matches nothing (#2996 finding I62). ``is:`` here only matches a value
+# _IS_RE didn't already consume, i.e. anything other than unread/read.
+_UNSUPPORTED_OPERATOR_RE = re.compile(
+    r'\b(?P<op>is|after|before|label|has|in):(?P<val>"[^"]*"|\S+)',
     re.IGNORECASE,
 )
 
@@ -107,6 +123,11 @@ def translate_query(query: str, *, now: Optional[datetime] = None) -> GraphQuery
     does not defeat them the way it defeats ``is:``/``newer_than:`` (which
     ``$search`` cannot express under any quoting and route to ``$filter``
     above instead).
+
+    Also raises ``ValueError`` for a Gmail operator Graph cannot express at
+    all (``is:starred``, ``after:``, ``before:``, ``label:``, ``has:``,
+    ``in:``), rather than sending it to ``$search`` as text that silently
+    matches nothing.
     """
     now = now or datetime.now(timezone.utc)
     filters: List[str] = []
@@ -143,4 +164,15 @@ def translate_query(query: str, *, now: Optional[datetime] = None) -> GraphQuery
         )
     if filters:
         return GraphQuery(filter=" and ".join(filters))
+
+    unsupported = _UNSUPPORTED_OPERATOR_RE.search(remainder)
+    if unsupported:
+        raise ValueError(
+            "search_messages: on Outlook, "
+            f"{unsupported.group(0)!r} has no Microsoft Graph equivalent and "
+            "would silently match nothing if sent as search text. Supported "
+            "operators are is:unread, is:read, newer_than:, older_than:, "
+            f"from:, and subject:, so drop {unsupported.group('op')}: from "
+            "the query and try again."
+        )
     return GraphQuery(search=_graph_search_param(query))

--- a/hub/agents/email/python/gaia_agent_email/tools/read_tools.py
+++ b/hub/agents/email/python/gaia_agent_email/tools/read_tools.py
@@ -2838,6 +2838,13 @@ class ReadToolsMixin:
               - status / recency → ``is:unread``, ``newer_than:7d``,
                 ``label:promotions``
 
+            On an Outlook-only mailbox, only ``from:``, ``subject:``,
+            ``is:unread``, ``is:read``, ``newer_than:``, and ``older_than:``
+            are supported; any other operator (``label:``, ``has:``,
+            ``after:``, ``before:``, ``in:``, ``is:starred``, ...) raises an
+            error naming the unsupported operator instead of matching
+            nothing silently.
+
             Combine them: ``"from:boss@example.com is:unread newer_than:7d"``.
             Date operators require ``YYYY/MM/DD`` — e.g. ``after:2026/07/01
             before:2026/07/08``, never ``after:July 1``. If a bare phrase is

--- a/tests/unit/agents/email/test_outlook_backend.py
+++ b/tests/unit/agents/email/test_outlook_backend.py
@@ -328,6 +328,15 @@ class TestReadTranslation:
         with pytest.raises(ConnectorsError, match="cannot be combined"):
             backend.list_messages(query="is:unread from:alice", max_results=5)
 
+    def test_list_messages_unsupported_operator_raises_instead_of_empty_result(self):
+        # Same wrapping as the mixed-family case above, for the other half of
+        # #2996 finding I62: an operator Graph cannot express at all
+        # (label:/has:/in:/after:/before:/is:<other>) used to reach Graph as
+        # inert $search text and silently return nothing.
+        backend, _, _ = _backend(lambda r: _ok({"value": []}))
+        with pytest.raises(ConnectorsError, match="has no Microsoft Graph equivalent"):
+            backend.list_messages(query="label:promotions", max_results=5)
+
     def test_list_messages_normalizes_to_gmail_stub_shape(self):
         backend, _, _ = _backend(
             lambda r: _ok(

--- a/tests/unit/agents/email/test_outlook_backend.py
+++ b/tests/unit/agents/email/test_outlook_backend.py
@@ -334,7 +334,7 @@ class TestReadTranslation:
         # (label:/has:/in:/after:/before:/is:<other>) used to reach Graph as
         # inert $search text and silently return nothing.
         backend, _, _ = _backend(lambda r: _ok({"value": []}))
-        with pytest.raises(ConnectorsError, match="has no Microsoft Graph equivalent"):
+        with pytest.raises(ConnectorsError, match="not supported by this backend"):
             backend.list_messages(query="label:promotions", max_results=5)
 
     def test_list_messages_normalizes_to_gmail_stub_shape(self):

--- a/tests/unit/agents/email/test_outlook_query.py
+++ b/tests/unit/agents/email/test_outlook_query.py
@@ -109,5 +109,32 @@ def test_filter_and_grouped_bare_text_still_raises():
         translate_query("(newer_than:7d) budget report", now=_NOW)
 
 
+@pytest.mark.parametrize(
+    "query",
+    [
+        "is:starred",
+        "after:2026/07/01",
+        "before:2026/07/08",
+        "label:promotions",
+        "has:attachment",
+        "in:inbox",
+    ],
+)
+def test_operator_with_no_graph_equivalent_raises_instead_of_matching_nothing(query):
+    # Before this fix each of these fell through to _graph_search_param and
+    # reached Graph as literal text, matching nothing with no error (#2996
+    # finding I62).
+    with pytest.raises(ValueError, match="has no Microsoft Graph equivalent"):
+        translate_query(query, now=_NOW)
+
+
+def test_is_unsupported_value_raises_even_combined_with_valid_filter():
+    # is:starred is not consumed by _IS_RE (only unread/read are), so it
+    # reaches the mixed-family check as ordinary remainder text alongside a
+    # real filter, still a loud error, just via the older message.
+    with pytest.raises(ValueError, match="cannot be combined"):
+        translate_query("is:unread is:starred", now=_NOW)
+
+
 if __name__ == "__main__":
     raise SystemExit(pytest.main([__file__, "-v"]))

--- a/tests/unit/agents/email/test_outlook_query.py
+++ b/tests/unit/agents/email/test_outlook_query.py
@@ -115,24 +115,30 @@ def test_filter_and_grouped_bare_text_still_raises():
         "is:starred",
         "after:2026/07/01",
         "before:2026/07/08",
+        "newer:2026/07/01",
+        "older:2026/07/01",
         "label:promotions",
         "has:attachment",
         "in:inbox",
+        "label:",
     ],
 )
 def test_operator_with_no_graph_equivalent_raises_instead_of_matching_nothing(query):
     # Before this fix each of these fell through to _graph_search_param and
     # reached Graph as literal text, matching nothing with no error (#2996
-    # finding I62).
-    with pytest.raises(ValueError, match="has no Microsoft Graph equivalent"):
+    # finding I62; newer:/older:/a bare "label:" with no value added after a
+    # review on this PR caught the same silent fall-through for them).
+    with pytest.raises(ValueError, match="not supported by this backend"):
         translate_query(query, now=_NOW)
 
 
-def test_is_unsupported_value_raises_even_combined_with_valid_filter():
-    # is:starred is not consumed by _IS_RE (only unread/read are), so it
-    # reaches the mixed-family check as ordinary remainder text alongside a
-    # real filter, still a loud error, just via the older message.
-    with pytest.raises(ValueError, match="cannot be combined"):
+def test_is_unsupported_value_raises_before_the_mixed_family_check():
+    # is:starred is not consumed by _IS_RE (only unread/read are). The
+    # unsupported-operator check now runs before the mixed-family check (a
+    # review on this PR), so this raises naming is:starred directly rather
+    # than telling the caller to re-run it as a separate search that would
+    # fail the same way.
+    with pytest.raises(ValueError, match="not supported by this backend"):
         translate_query("is:unread is:starred", now=_NOW)
 
 


### PR DESCRIPTION
## Summary

Some Gmail-style search operators (`is:starred`, `after:`, `before:`, `label:`, `has:`, `in:`) have no Microsoft Graph equivalent, so `translate_query` sent them to Graph as literal search text instead of failing. Graph never errors on an unrecognised `$search` token, so those searches silently returned nothing.

## Why

#3042 fixed `from:`, `subject:`, `is:unread`/`is:read`, and `newer_than:`/`older_than:` for Outlook, but the rest still fell through unguarded. Two of the still-broken operators (`label:promotions`, `after:YYYY/MM/DD`) are ones the agent's own tool description recommends, so a model following its own instructions can hit this. A silent empty result is the worst outcome: nothing tells the caller the search didn't do what it asked.

## Linked issue

Fixes #2996

## Changes

- `translate_query` now raises a `ValueError` naming the operator for `is:`, `after:`, `before:`, `label:`, `has:`, or `in:` (outside the already-supported `is:unread`/`is:read`), instead of quoting it into `$search` text.
- `LiveOutlookBackend.list_messages` already wraps every `ValueError` from `translate_query` in `ConnectorsError`, so the new error is handled the same way as the existing mixed-family one; no change needed there.
- Updated both package CHANGELOGs.

## Test plan

- `pytest tests/unit/agents/email/test_outlook_query.py -v`: 6 new cases, one per unsupported operator, plus one for the interaction with an existing filter.
- `pytest tests/unit/agents/email/test_outlook_backend.py -v`: one new case for the `ConnectorsError` wrapping.
- Full scope of `test_email_agent_unit.yml`: 4388 passed, 9 skipped. One unrelated failure in `test_release_scorecard.py` is `git: command not found` in my stripped-down container, not a real regression.

## Evidence

- Agent UI / MCP / CLI / HTTP API: N/A. This is a request-building fix with no UI surface, and exercising it live needs a connected Outlook mailbox, which nobody on this issue thread has. Covered by the unit tests above.

## Checklist

- [x] Linked issue (`Fixes #2996`).
- [x] Described why, not just what.
- [x] Ran `black --check`, `isort --check`, `flake8`, and the full unit scope above.
- [x] Evidence surfaces marked N/A with reason.
- [x] No user-facing docs beyond the CHANGELOGs already updated.
