### PR TITLE
ci(release): let the backend test step fail the release

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -285,9 +285,20 @@ jobs:
           fi
 
       - name: Run backend tests
+        # No silent fallback (CLAUDE.md "No Silent Fallbacks"): this is the only
+        # pytest run on the release path -- test_unit.yml triggers on pushes to
+        # main, not on a v* tag -- so a swallowed failure here publishes a broken
+        # build. The `|| echo` and `2>/dev/null` this replaces made the step green
+        # whether the tests passed, failed, or never ran at all.
+        #
+        # [api] as well as [dev]: gaia.ui imports fastapi, which only the api/ui
+        # extras declare, so `pip install -e ".[dev]"` cannot even collect these
+        # tests. That is what the old `|| pip install -e .` fallback was papering
+        # over -- it dropped pytest itself, and the pytest failure was swallowed
+        # in turn.
         run: |
-          pip install -e ".[dev]" 2>/dev/null || pip install -e .
-          python -m pytest tests/unit/chat/ui/ -x --tb=short 2>/dev/null || echo "Backend tests skipped (dependencies not available)"
+          pip install -e ".[dev,api]"
+          python -m pytest tests/unit/chat/ui/ -x --tb=short
 
       - name: Upload built frontend
         uses: actions/upload-artifact@v7

--- a/tests/unit/test_publish_workflow_contract.py
+++ b/tests/unit/test_publish_workflow_contract.py
@@ -1,0 +1,81 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""
+The backend-test step in publish.yml is the release's only pytest gate — assert
+it can actually fail.
+
+``test_unit.yml`` triggers on pushes to ``main``, not on the ``v*`` tag that
+starts a release, so this one step in ``build-npm`` is the whole Python test
+coverage between a tag and PyPI/npm. It shipped with ``2>/dev/null || echo
+"Backend tests skipped"``, which made it green whether the tests passed, failed,
+or never ran (issue #3508).
+
+These are configuration assertions, not behaviour tests. They exist because the
+failure mode is silent: the step still runs and still goes green, it just stops
+gating anything.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+WORKFLOW = REPO_ROOT / ".github" / "workflows" / "publish.yml"
+
+STEP_NAME = "Run backend tests"
+
+
+@pytest.fixture(scope="module")
+def backend_test_step() -> dict:
+    assert WORKFLOW.is_file(), f"{WORKFLOW} is missing"
+    workflow = yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))
+    steps = [
+        step
+        for step in workflow["jobs"]["build-npm"]["steps"]
+        if step.get("name") == STEP_NAME
+    ]
+    assert steps, f"build-npm no longer has a {STEP_NAME!r} step"
+    return steps[0]
+
+
+def test_the_backend_tests_can_fail_the_release(backend_test_step):
+    """No ``||`` fallback and no discarded stderr — the step must be able to go red."""
+    run = backend_test_step["run"]
+    assert "||" not in run, (
+        f"{STEP_NAME!r} swallows a failure with '||'. This is the only pytest run "
+        "on the release path, so a fallback here publishes an untested build "
+        "(CLAUDE.md 'No Silent Fallbacks')."
+    )
+    assert "2>/dev/null" not in run, (
+        f"{STEP_NAME!r} discards stderr, which hides why a step failed even when "
+        "it does fail."
+    )
+
+
+def test_the_backend_tests_install_the_extras_they_import(backend_test_step):
+    """``gaia.ui`` imports fastapi, which only the api/ui extras declare.
+
+    ``pip install -e ".[dev]"`` alone cannot collect ``tests/unit/chat/ui/`` —
+    ``gaia/ui/_chat_helpers.py`` does ``from fastapi import HTTPException`` at
+    import time. Without the extra, a loud step fails on every release instead of
+    on a real regression.
+    """
+    run = backend_test_step["run"]
+    assert "pytest tests/unit/chat/ui/" in run, (
+        f"{STEP_NAME!r} no longer runs the UI backend suite — the release would "
+        "publish with no Python test coverage at all."
+    )
+    assert "api" in _install_extras(run), (
+        f"{STEP_NAME!r} must install the api extra; tests/unit/chat/ui/ imports "
+        "fastapi through gaia.ui."
+    )
+
+
+def _install_extras(run: str) -> set[str]:
+    """Extras named in the step's ``pip install -e ".[...]"`` line."""
+    _, _, tail = run.partition('pip install -e ".[')
+    extras, _, _ = tail.partition("]")
+    return {extra.strip() for extra in extras.split(",")}


### PR DESCRIPTION
## Summary

Make the `Run backend tests` step in `publish.yml` able to fail, and give it the extras it actually needs to run.

## Why

The step piped its own failure into an echo:

```yaml
pip install -e ".[dev]" 2>/dev/null || pip install -e .
python -m pytest tests/unit/chat/ui/ -x --tb=short 2>/dev/null || echo "Backend tests skipped (dependencies not available)"
```

Both lines are silent fallbacks (CLAUDE.md "No Silent Fallbacks"). The step went green whether the tests passed, failed, or never ran at all, and `build-pypi` and `approve-publish` both depend on `build-npm`, so this sat on the critical path of every release.

Repairing it rather than deleting it, because `test_unit.yml` triggers on `push: branches: [main]` and `pull_request` — a `v*` tag push matches neither, so this step is the whole Python test coverage between a tag and PyPI/npm.

**The literal fix would leave the release red instead.** `src/gaia/ui/_chat_helpers.py:26` does `from fastapi import HTTPException` at import time, and `fastapi` is declared only in the `[api]`/`[ui]` extras — not in `install_requires` and not in `[dev]`. With `[dev]` alone, collection dies:

```
tests/unit/chat/ui/test_agent_unavailable.py:11: in <module>
    from gaia.ui._chat_helpers import _agent_unavailable_message
src/gaia/ui/_chat_helpers.py:26: in <module>
    from fastapi import HTTPException
E   ModuleNotFoundError: No module named 'fastapi'
```

That missing extra is what the `|| pip install -e .` fallback was papering over: the retry dropped pytest itself, and the resulting "no module named pytest" was swallowed in turn by the second `|| echo`. So the step could print "skipped" and go green whether the tests failed, were never installed, or never ran. `[dev,api]` matches what `test_unit.yml` installs for the same suite.

## Changes

- `publish.yml`: `pip install -e ".[dev,api]"` + `python -m pytest tests/unit/chat/ui/ -x --tb=short`, no `||`, no `2>/dev/null`. Comment explains why the extra and why the step stays.
- `tests/unit/test_publish_workflow_contract.py`: a small contract test in the style of `test_skill_audit_workflow_contract.py` — asserts the step has no `||` / `2>/dev/null`, still runs the suite, and still installs the `api` extra. The failure mode here is silent, so a config assertion is the only thing that catches a re-introduction.

## Test plan

- [x] `pytest tests/unit/test_publish_workflow_contract.py` — 2 passed; both fail against the pre-fix `publish.yml` (verified by stashing the workflow change: `assert '||' not in run` and `assert 'api' in {'dev'}`).
- [x] The step's own command, in a clean 3.11 venv: `pip install -e ".[dev,api]" && python -m pytest tests/unit/chat/ui/ -x --tb=short` → **869 passed, 11 skipped in ~30s**.
- [x] Same venv with `[dev]` only → `ModuleNotFoundError: No module named 'fastapi'` at collection (quoted above).
- [x] `black --check`, `isort --check-only`, `flake8` (repo flags from `util/lint.py`) clean on the new file.

## Linked issue

Fixes #3508

## Checklist

- [x] I have linked a GitHub issue above (`Closes #N` / `Fixes #N` / `Refs #N`).
- [x] I have described **why** this change is being made, not just what changed.
- [x] I have run linting and tests locally (`python util/lint.py --all`, `pytest tests/unit/`).
- [x] Evidence section deleted per the template — pure CI change, no user-facing surface.
- [x] I have updated documentation if user-visible behavior changed — N/A.

---

One note on the alternative in the issue thread (call `test_unit.yml` from `publish.yml` and add it to `approve-publish`'s `needs`): it would put a 3-version matrix plus six network-dependent integration steps (live Lemonade asset resolution, live TLS SNI, Codecov upload) on the tag path, so a flaky upstream would block a release. Happy to switch to that shape if you'd rather have the wider coverage — this PR takes the narrower repair the issue lists first, which keeps the gate at ~30s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
