### PR TITLE
feat(tui): add --trace to record what the agent actually did

### DIFF
--- a/docs/reference/cli.mdx
+++ b/docs/reference/cli.mdx
@@ -2978,9 +2978,12 @@ Each line wraps the event with the two things the payload itself does not carry
 {"at":"2026-09-08T18:39:32.547Z","seq":189,"event":{"type":"tool_result","tool":"find_files","data":{"success":true,"summary":"Found 25 result(s)…","summary_truncated":true}}}
 ```
 
-A frame the TUI could not parse is still recorded, under `unparsed` instead of
-`event` — that is the frame a trace is most wanted for. Events are flushed one
-at a time, so a run that crashes mid-turn still leaves everything it received.
+A frame the TUI could not parse is still recorded — that is the frame a trace is
+most wanted for. It carries `unparsed` (the raw text) instead of `event`, or
+`unparsed_b64` when the bytes are not valid UTF-8, since encoding those as a
+JSON string would replace each bad byte with `U+FFFD` and lose what went wrong.
+A reader must check all three keys. Events are flushed one at a time, so a run
+that crashes mid-turn still leaves everything it received.
 
 `--trace` and `--dev` are independent: `--dev` chooses what is rendered on
 screen, `--trace` chooses what is written to disk. Use both together to watch a

--- a/docs/reference/cli.mdx
+++ b/docs/reference/cli.mdx
@@ -2941,6 +2941,71 @@ Most callers should not speak this API directly — the
 
 ---
 
+### TUI Event Trace
+
+`--trace` writes down what the agent actually did, so a wrong answer can be
+diagnosed from a file instead of from a screenshot. Every event the TUI receives
+is appended to a JSONL file — one JSON object per line, in arrival order, with
+tool calls carrying **their arguments** and tool results carrying **their
+payloads**.
+
+```bash
+gaia tui --trace                       # ~/.gaia/traces/<timestamp>-<agent>.jsonl
+gaia tui --trace=run.jsonl             # a path you choose
+gaia tui --trace --dev                 # record to a file AND show it on screen
+```
+
+The path is printed on startup (`trace → …`). An unwritable path is a startup
+error, not a warning: a trace that is silently not being written looks exactly
+like an agent that did nothing.
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--trace` | string | off | Record every agent event to a JSONL file. Bare `--trace` picks `~/.gaia/traces/<timestamp>-<agent>.jsonl`. |
+
+<Note>
+  The path must be **attached** — `--trace=run.jsonl`, not `--trace run.jsonl`.
+  A spaced value is read as a command name (the flag is legal with no value, so
+  it never consumes the next argument); the TUI says so and names the working
+  form.
+</Note>
+
+Each line wraps the event with the two things the payload itself does not carry
+— when it arrived, and where it sits in the run:
+
+```json
+{"at":"2026-09-08T18:39:32.455Z","seq":188,"event":{"type":"tool_call","tool":"find_files","args":{"query":"*.go","scope":"smart"}}}
+{"at":"2026-09-08T18:39:32.547Z","seq":189,"event":{"type":"tool_result","tool":"find_files","data":{"success":true,"summary":"Found 25 result(s)…","summary_truncated":true}}}
+```
+
+A frame the TUI could not parse is still recorded, under `unparsed` instead of
+`event` — that is the frame a trace is most wanted for. Events are flushed one
+at a time, so a run that crashes mid-turn still leaves everything it received.
+
+`--trace` and `--dev` are independent: `--dev` chooses what is rendered on
+screen, `--trace` chooses what is written to disk. Use both together to watch a
+run and keep it.
+
+<Note>
+  This records the agent's externally visible behaviour — tool calls, arguments,
+  results, errors, and timings. It does **not** capture prompt size or token
+  accounting, which exist only in the agent's own per-turn recorder
+  (`GAIA_TURN_LOG`).
+</Note>
+
+<Warning>
+  A trace contains verbatim tool results — file contents, shell output, email,
+  whatever the agent read on your behalf. The file is written `0600` under a
+  `0700` directory, but attaching one to a bug report shares all of it. Read it
+  before you send it.
+</Warning>
+
+A launch that fails before the agent says anything (a refused port, an unmet
+precondition) removes its own empty trace rather than leaving a 0-byte file
+behind. `~/.gaia/traces` is never pruned otherwise — delete old runs yourself.
+
+---
+
 ### Cache Command
 
 Inspect or clear GAIA's on-disk caches (document-Q7 metadata, chat history,

--- a/tui/internal/cli/agents.go
+++ b/tui/internal/cli/agents.go
@@ -48,7 +48,15 @@ var runCmd = &cobra.Command{
 		"on a model server that is not there. The turn itself is bounded too, so an " +
 		"agent that accepts the query and then goes quiet is reported, never waited " +
 		"on forever — raise or lower that bound with --timeout.",
-	Args:         cobra.ExactArgs(1),
+	// ExactArgs(1) alone reports "accepts 1 arg(s), received 2" for
+	// `run <agent> --trace out.jsonl`, which never mentions the flag that
+	// caused it.
+	Args: func(cmd *cobra.Command, args []string) error {
+		if err := traceArgAdvice(args, 1); err != nil {
+			return err
+		}
+		return cobra.ExactArgs(1)(cmd, args)
+	},
 	SilenceUsage: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if err := checkModelSupported(args[0], runModel); err != nil {

--- a/tui/internal/cli/agents.go
+++ b/tui/internal/cli/agents.go
@@ -58,12 +58,20 @@ var runCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
+		trace, err := openTrace(args[0])
+		if err != nil {
+			return err
+		}
+		defer closeTrace(trace)
 		code, err := ui.RunAgent(args[0], runQuery, runModel, dev, runTimeout, ctrl,
-			bypassPermissions, useClaude, claudeModelArg(), mockAgent)
+			bypassPermissions, useClaude, claudeModelArg(), mockAgent, trace)
 		if err != nil {
 			return err
 		}
 		if code != 0 {
+			// Closed explicitly: os.Exit runs no deferred function, so the
+			// trace would never report a recording that stopped early.
+			closeTrace(trace)
 			// The failure was already rendered to stderr; exit without letting
 			// cobra print a second, less useful message.
 			os.Exit(code)

--- a/tui/internal/cli/chat.go
+++ b/tui/internal/cli/chat.go
@@ -25,6 +25,15 @@ var chatCmd = &cobra.Command{
 		"(--agent, which uses the transport that agent declares) or by spawning a " +
 		"binary directly (--subprocess).",
 	SilenceUsage: true,
+	// Everything this command takes is a flag. Without this, a stray argument
+	// was accepted and dropped — and `chat --trace out.jsonl` recorded to the
+	// default path while the file the user named never appeared.
+	Args: func(cmd *cobra.Command, args []string) error {
+		if err := traceArgAdvice(args, 0); err != nil {
+			return err
+		}
+		return cobra.NoArgs(cmd, args)
+	},
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if agentID != "" && subprocess != "" {
 			return fmt.Errorf("--agent and --subprocess are mutually exclusive: pick one")

--- a/tui/internal/cli/chat.go
+++ b/tui/internal/cli/chat.go
@@ -47,35 +47,54 @@ var chatCmd = &cobra.Command{
 				}
 			}
 		}
+		if agentID == "" && subprocess == "" {
+			return fmt.Errorf("one of --agent or --subprocess is required\n\n" +
+				"Usage: gaia tui chat --agent email\n" +
+				"       gaia tui chat --agent email --query \"triage my inbox\"\n" +
+				"       gaia tui chat --subprocess \"./gaia-bash --json-events\"")
+		}
+		// Opened only once the command is known to be runnable, so a refused
+		// launch never announces a trace it is not going to write.
+		trace, err := openTrace(orSubprocess(agentID))
+		if err != nil {
+			return err
+		}
+		defer closeTrace(trace)
 		if agentID != "" {
 			ctrl, err := controlOptionsForAgentRun(cmd, query != "")
 			if err != nil {
 				return err
 			}
 			code, err := ui.RunAgent(agentID, query, chatModel, dev, chatTimeout, ctrl,
-				bypassPermissions, useClaude, claudeModelArg(), mockAgent)
+				bypassPermissions, useClaude, claudeModelArg(), mockAgent, trace)
 			if err != nil {
 				return err
 			}
 			if code != 0 {
+				// Closed explicitly: os.Exit runs no deferred function, so the
+				// trace would never report a recording that stopped early.
+				closeTrace(trace)
 				// The failure was already rendered to stderr; exit without
 				// letting cobra print a second, less useful message.
 				os.Exit(code)
 			}
 			return nil
 		}
-		if subprocess == "" {
-			return fmt.Errorf("one of --agent or --subprocess is required\n\n" +
-				"Usage: gaia tui chat --agent email\n" +
-				"       gaia tui chat --agent email --query \"triage my inbox\"\n" +
-				"       gaia tui chat --subprocess \"./gaia-bash --json-events\"")
-		}
 		ctrl, err := controlOptionsFor(cmd)
 		if err != nil {
 			return err
 		}
-		return ui.RunChat(subprocess, query, dev, ctrl)
+		return ui.RunChat(subprocess, query, dev, ctrl, trace)
 	},
+}
+
+// orSubprocess names the run for the default trace filename. --subprocess has
+// no catalog id, so it gets the transport's name rather than another agent's.
+func orSubprocess(agentID string) string {
+	if agentID != "" {
+		return agentID
+	}
+	return "subprocess"
 }
 
 func init() {

--- a/tui/internal/cli/root.go
+++ b/tui/internal/cli/root.go
@@ -5,10 +5,13 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/spf13/cobra"
 
+	"github.com/amd/gaia/tui/internal/catalog"
 	"github.com/amd/gaia/tui/internal/client"
+	"github.com/amd/gaia/tui/internal/event"
 	"github.com/amd/gaia/tui/internal/ui"
 )
 
@@ -82,6 +85,47 @@ func binaryName(argv0 string) string {
 // point that honours it reads the same variable.
 var mockAgent string
 
+// tracePath is --trace's raw value: "" (off), traceAutoPath (bare --trace), or
+// the path the user gave. Resolved by openTrace.
+var tracePath string
+
+// traceAutoPath is what bare --trace parses to: cobra needs a NoOptDefVal for
+// the flag to be legal without a value, and "" already means "off".
+//
+// A WORD, not an unprintable sentinel — pflag prints NoOptDefVal verbatim in
+// --help, so a control character lands in the flag listing. As a side effect
+// `--trace=auto` is the same as bare `--trace`, which is what it reads like.
+// A file genuinely named "auto" is still reachable as `--trace=./auto`.
+const traceAutoPath = "auto"
+
+// openTrace turns --trace into a writer, or nil when the flag was not passed.
+// agentID names the run in the default filename, so a trace can be told apart
+// from another agent's without opening it.
+//
+// It returns an error rather than warning and continuing: a trace that is not
+// being written is indistinguishable from an agent that did nothing, which is
+// the exact confusion the flag exists to remove.
+func openTrace(agentID string) (*event.TraceWriter, error) {
+	if tracePath == "" {
+		return nil, nil
+	}
+	path := tracePath
+	if path == traceAutoPath {
+		auto, err := event.DefaultTracePath(agentID, time.Now())
+		if err != nil {
+			return nil, err
+		}
+		path = auto
+	}
+	w, err := event.NewTraceWriter(path)
+	if err != nil {
+		return nil, err
+	}
+	// A recorder the user cannot find is a recorder that does not exist.
+	fmt.Fprintf(os.Stderr, "trace → %s\n", w.Path())
+	return w, nil
+}
+
 var rootCmd = &cobra.Command{
 	Use:   defaultBinaryName,
 	Short: "GAIA in your terminal",
@@ -95,8 +139,21 @@ var rootCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		return ui.RunFlagship(dev, mockAgent, ctrl, bypassPermissions, useClaude, claudeModelArg())
+		trace, err := openTrace(catalog.FlagshipID)
+		if err != nil {
+			return err
+		}
+		defer closeTrace(trace)
+		return ui.RunFlagship(dev, mockAgent, ctrl, bypassPermissions, useClaude, claudeModelArg(), trace)
 	},
+}
+
+// closeTrace flushes and closes the trace, reporting a recording that stopped
+// early. Silence here would let a truncated trace read as a complete one.
+func closeTrace(w *event.TraceWriter) {
+	if err := w.Close(); err != nil {
+		fmt.Fprintf(os.Stderr, "trace: %v\n", err)
+	}
 }
 
 func init() {
@@ -110,7 +167,8 @@ func init() {
 
 	rootCmd.PersistentFlags().BoolVar(&dev, "dev", false,
 		"developer mode: show per-turn timings, steps, and tool arguments and output "+
-			"(agents the TUI spawns itself also log at DEBUG to ~/.gaia/logs/)")
+			"(agents the TUI spawns itself also log at DEBUG to ~/.gaia/logs/). "+
+			"This is what is on SCREEN; --trace writes the same events to a file")
 	// Same variable as --dev, hidden: the previous name for this mode. Kept so
 	// existing scripts and docs do not break, out of --help so the two spellings
 	// never read as two features.
@@ -158,6 +216,45 @@ func init() {
 	// substituted a stand-in.
 	rootCmd.PersistentFlags().StringVar(&mockAgent, "mock", "",
 		"path to a stand-in agent binary, for tests (overrides the agent being launched)")
+	rootCmd.PersistentFlags().StringVar(&tracePath, "trace", "",
+		"record every agent event — tool calls WITH their arguments, results, errors "+
+			"and timings — to a JSONL file, one event per line, for later inspection. "+
+			"Bare --trace writes ~/.gaia/traces/<timestamp>-<agent>.jsonl; --trace=<path> "+
+			"picks the file (the path must be attached with =, not spaced). Independent "+
+			"of --dev, which shows the same events on screen instead. The file holds "+
+			"whatever the agent read — file contents, shell output, email — so review "+
+			"it before sharing. Does NOT capture prompt size or token accounting — "+
+			"those live only in the agent's own recorder (GAIA_TURN_LOG)")
+	// Without this, bare --trace is a parse error ("flag needs an argument").
+	rootCmd.PersistentFlags().Lookup("trace").NoOptDefVal = traceAutoPath
+	// pflag will not attach a spaced value to a NoOptDefVal flag, so
+	// `--trace out.jsonl` leaves out.jsonl as a positional and would otherwise
+	// be reported as an unknown command — with the real fix nowhere in sight.
+	//
+	// Cobra's own unknown-command path defaults this lazily; the exported
+	// SuggestionsFor does not, and a zero distance matches nothing.
+	rootCmd.SuggestionsMinimumDistance = 2
+	rootCmd.Args = func(cmd *cobra.Command, args []string) error {
+		if len(args) == 0 {
+			return nil
+		}
+		// Cobra's own legacyArgs message, suggestions included — this hook
+		// replaced it, so it owes the same help for an ordinary typo.
+		near := cmd.SuggestionsFor(args[0])
+		// The trace advice only when nothing else explains the stray argument:
+		// with --trace on, `gaia-tui --trace chatt` is a misspelled command,
+		// not a misplaced path, and must still be told so.
+		if tracePath == traceAutoPath && len(near) == 0 {
+			return fmt.Errorf(
+				"--trace takes its path attached, not spaced: write --trace=%s "+
+					"(as written, %q was read as a command name)", args[0], args[0])
+		}
+		msg := fmt.Sprintf("unknown command %q for %q", args[0], cmd.CommandPath())
+		if len(near) > 0 {
+			msg += "\n\nDid you mean this?\n\t" + strings.Join(near, "\n\t")
+		}
+		return fmt.Errorf("%s", msg)
+	}
 }
 
 // Execute runs the CLI.

--- a/tui/internal/cli/root.go
+++ b/tui/internal/cli/root.go
@@ -98,6 +98,26 @@ var tracePath string
 // A file genuinely named "auto" is still reachable as `--trace=./auto`.
 const traceAutoPath = "auto"
 
+// traceArgAdvice explains a stray positional that is really a spaced --trace
+// path, and returns nil when --trace does not explain it.
+//
+// want is how many positionals the command legitimately takes. pflag refuses to
+// attach a spaced value to a flag that is legal without one, so
+// `… --trace out.jsonl` leaves out.jsonl as an argument and records to the
+// DEFAULT path — the exact "recording somewhere you did not ask for" this flag
+// exists to remove. Every command that accepts --trace has to say so, not just
+// the root one.
+func traceArgAdvice(args []string, want int) error {
+	if tracePath != traceAutoPath || len(args) <= want {
+		return nil
+	}
+	stray := args[want]
+	return fmt.Errorf(
+		"--trace takes its path attached, not spaced: write --trace=%s "+
+			"(as written, %q was read as an argument, and the trace would have gone "+
+			"to the default path instead)", stray, stray)
+}
+
 // openTrace turns --trace into a writer, or nil when the flag was not passed.
 // agentID names the run in the default filename, so a trace can be told apart
 // from another agent's without opening it.
@@ -241,13 +261,12 @@ func init() {
 		// Cobra's own legacyArgs message, suggestions included — this hook
 		// replaced it, so it owes the same help for an ordinary typo.
 		near := cmd.SuggestionsFor(args[0])
-		// The trace advice only when nothing else explains the stray argument:
-		// with --trace on, `gaia-tui --trace chatt` is a misspelled command,
-		// not a misplaced path, and must still be told so.
-		if tracePath == traceAutoPath && len(near) == 0 {
-			return fmt.Errorf(
-				"--trace takes its path attached, not spaced: write --trace=%s "+
-					"(as written, %q was read as a command name)", args[0], args[0])
+		// A near-miss is a misspelled COMMAND, not a misplaced path: with
+		// --trace on, `gaia-tui --trace chatt` still has to suggest `chat`.
+		if len(near) == 0 {
+			if err := traceArgAdvice(args, 0); err != nil {
+				return err
+			}
 		}
 		msg := fmt.Sprintf("unknown command %q for %q", args[0], cmd.CommandPath())
 		if len(near) > 0 {

--- a/tui/internal/cli/traceflag_test.go
+++ b/tui/internal/cli/traceflag_test.go
@@ -7,6 +7,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/spf13/cobra"
 )
 
 // parseTraceFlag runs argv through the root command's flag set and returns what
@@ -90,6 +92,74 @@ func TestTraceFlagRejectsASpacedPathWithTheFix(t *testing.T) {
 	if strings.Contains(typo.Error(), "--trace=") {
 		t.Errorf("a misspelled command was reported as a misplaced trace path: %v", typo)
 	}
+}
+
+// --trace is a PERSISTENT flag, so the spaced-path trap exists on every
+// subcommand too. It used to be caught only on the root command: `chat --trace
+// out.jsonl` silently recorded to the default path and never created the file
+// the user named, and `run <agent> --trace out.jsonl` said only "accepts 1
+// arg(s), received 2".
+func TestTraceSpacedPathIsCaughtOnEverySubcommand(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		cmd  *cobra.Command
+		args []string
+	}{
+		{"root", rootCmd, []string{"out.jsonl"}},
+		{"chat", chatCmd, []string{"out.jsonl"}},
+		{"run", runCmd, []string{"email", "out.jsonl"}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, err := parseTraceFlag(t, "--trace"); err != nil {
+				t.Fatalf("parse: %v", err)
+			}
+			if tc.cmd.Args == nil {
+				t.Fatalf("%s declares no Args hook, so a stray --trace path is swallowed", tc.name)
+			}
+			err := tc.cmd.Args(tc.cmd, tc.args)
+			if err == nil {
+				t.Fatalf("%s accepted a spaced --trace path; it would record to the default path", tc.name)
+			}
+			if !strings.Contains(err.Error(), "--trace=out.jsonl") {
+				t.Errorf("%s does not name the working form: %v", tc.name, err)
+			}
+		})
+	}
+}
+
+// The advice must not fire on arguments the command legitimately takes, nor
+// when --trace was given a real path.
+func TestTraceArgAdviceStaysOutOfTheWay(t *testing.T) {
+	t.Run("run keeps its agent id", func(t *testing.T) {
+		if _, err := parseTraceFlag(t, "--trace"); err != nil {
+			t.Fatalf("parse: %v", err)
+		}
+		if err := runCmd.Args(runCmd, []string{"email"}); err != nil {
+			t.Errorf("`run email --trace` was rejected: %v", err)
+		}
+	})
+
+	t.Run("an attached path leaves a stray arg to the normal error", func(t *testing.T) {
+		if _, err := parseTraceFlag(t, "--trace=/tmp/run.jsonl"); err != nil {
+			t.Fatalf("parse: %v", err)
+		}
+		err := chatCmd.Args(chatCmd, []string{"nonsense"})
+		if err == nil {
+			t.Fatal("a stray argument was accepted")
+		}
+		if strings.Contains(err.Error(), "--trace=") {
+			t.Errorf("an unrelated stray argument was blamed on --trace: %v", err)
+		}
+	})
+
+	t.Run("no --trace at all", func(t *testing.T) {
+		if _, err := parseTraceFlag(t); err != nil {
+			t.Fatalf("parse: %v", err)
+		}
+		if err := traceArgAdvice([]string{"whatever"}, 0); err != nil {
+			t.Errorf("advice fired without --trace: %v", err)
+		}
+	})
 }
 
 // Without --trace, a stray argument is still a bad command and must say so —

--- a/tui/internal/cli/traceflag_test.go
+++ b/tui/internal/cli/traceflag_test.go
@@ -1,0 +1,194 @@
+// Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+package cli
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// parseTraceFlag runs argv through the root command's flag set and returns what
+// --trace resolved to. It parses only; nothing is launched.
+func parseTraceFlag(t *testing.T, argv ...string) (string, error) {
+	t.Helper()
+	tracePath = ""
+	t.Cleanup(func() { tracePath = "" })
+	flags := rootCmd.PersistentFlags()
+	err := flags.Parse(argv)
+	return tracePath, err
+}
+
+func TestTraceFlagFormsResolve(t *testing.T) {
+	t.Run("absent means off", func(t *testing.T) {
+		got, err := parseTraceFlag(t)
+		if err != nil {
+			t.Fatalf("parse: %v", err)
+		}
+		if got != "" {
+			t.Errorf("--trace = %q with the flag absent, want \"\" (tracing off)", got)
+		}
+	})
+
+	t.Run("bare picks the default path", func(t *testing.T) {
+		got, err := parseTraceFlag(t, "--trace")
+		if err != nil {
+			t.Fatalf("bare --trace was rejected: %v", err)
+		}
+		if got != traceAutoPath {
+			t.Errorf("bare --trace = %q, want the auto sentinel", got)
+		}
+	})
+
+	// pflag prints NoOptDefVal verbatim in --help, so the sentinel has to be a
+	// word. An unprintable one lands in the flag listing.
+	t.Run("the sentinel is printable", func(t *testing.T) {
+		for _, r := range traceAutoPath {
+			if r < 0x20 || r == 0x7f {
+				t.Fatalf("traceAutoPath contains %q, which --help will render raw", r)
+			}
+		}
+	})
+
+	t.Run("attached path wins", func(t *testing.T) {
+		got, err := parseTraceFlag(t, "--trace=/tmp/run.jsonl")
+		if err != nil {
+			t.Fatalf("parse: %v", err)
+		}
+		if got != "/tmp/run.jsonl" {
+			t.Errorf("--trace=<path> = %q, want the path", got)
+		}
+	})
+}
+
+// pflag will not attach a SPACED value to a NoOptDefVal flag, so
+// `--trace out.jsonl` silently records to the default path and leaves
+// out.jsonl to be reported as an unknown command. The root command's Args
+// hook has to name the real fix instead.
+func TestTraceFlagRejectsASpacedPathWithTheFix(t *testing.T) {
+	if _, err := parseTraceFlag(t, "--trace"); err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	err := rootCmd.Args(rootCmd, []string{"out.jsonl"})
+	if err == nil {
+		t.Fatal("a spaced --trace path was accepted; it would have recorded to the default path instead")
+	}
+	if !strings.Contains(err.Error(), "--trace=out.jsonl") {
+		t.Errorf("the error does not show the working form: %v", err)
+	}
+
+	// A misspelled COMMAND is still a misspelled command with --trace on. The
+	// trace advice must not swallow the suggestion it deserves.
+	typo := rootCmd.Args(rootCmd, []string{"chatt"})
+	if typo == nil {
+		t.Fatal("a misspelled subcommand was accepted")
+	}
+	if !strings.Contains(typo.Error(), "Did you mean") {
+		t.Errorf("--trace swallowed the typo suggestion: %v", typo)
+	}
+	if strings.Contains(typo.Error(), "--trace=") {
+		t.Errorf("a misspelled command was reported as a misplaced trace path: %v", typo)
+	}
+}
+
+// Without --trace, a stray argument is still a bad command and must say so —
+// the Args hook replaced cobra's own check, so it owns this case too.
+func TestStrayArgumentIsStillRejected(t *testing.T) {
+	if _, err := parseTraceFlag(t); err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	err := rootCmd.Args(rootCmd, []string{"nonsense"})
+	if err == nil {
+		t.Fatal("a stray argument was accepted")
+	}
+	if !strings.Contains(err.Error(), "unknown command") {
+		t.Errorf("unexpected message: %v", err)
+	}
+	// The hook replaced cobra's legacyArgs, so it owes the same typo help.
+	near := rootCmd.Args(rootCmd, []string{"chatt"})
+	if near == nil || !strings.Contains(near.Error(), "Did you mean") {
+		t.Errorf("a near-miss command lost its suggestion: %v", near)
+	}
+	if rootCmd.Args(rootCmd, nil) != nil {
+		t.Error("a bare launch with no arguments was rejected")
+	}
+}
+
+func TestOpenTraceIsOffUnlessAsked(t *testing.T) {
+	tracePath = ""
+	t.Cleanup(func() { tracePath = "" })
+	w, err := openTrace("gaia")
+	if err != nil {
+		t.Fatalf("openTrace: %v", err)
+	}
+	if w != nil {
+		w.Close()
+		t.Error("a writer was opened without --trace")
+	}
+}
+
+func TestOpenTraceHonoursAnExplicitPath(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "nested", "run.jsonl")
+	tracePath = path
+	t.Cleanup(func() { tracePath = "" })
+
+	w, err := openTrace("gaia")
+	if err != nil {
+		t.Fatalf("openTrace: %v", err)
+	}
+	defer w.Close()
+	if w.Path() != path {
+		t.Errorf("Path() = %q, want %q", w.Path(), path)
+	}
+}
+
+// An unwritable --trace has to stop the launch. A TUI that opens anyway records
+// nothing, and "the agent did nothing" is indistinguishable from "nothing was
+// recorded" — which is the confusion this flag exists to remove.
+func TestOpenTraceFailsOnAnUnwritablePath(t *testing.T) {
+	dir := t.TempDir()
+	tracePath = dir // a directory can never be opened as the trace FILE
+	t.Cleanup(func() { tracePath = "" })
+
+	if w, err := openTrace("gaia"); err == nil {
+		w.Close()
+		t.Fatal("an unwritable --trace was accepted")
+	}
+}
+
+// --dev and --trace are orthogonal: one renders, the other records. Cross-linked
+// in help so they are discoverable together, but never bound to each other.
+func TestTraceAndDevAreIndependent(t *testing.T) {
+	flags := rootCmd.PersistentFlags()
+	traceFlag := flags.Lookup("trace")
+	if traceFlag == nil {
+		t.Fatal("--trace is not registered")
+	}
+	if traceFlag.Hidden {
+		t.Error("--trace is hidden; a recorder nobody can find does not exist")
+	}
+	if !strings.Contains(flags.Lookup("dev").Usage, "--trace") {
+		t.Error("--dev's help does not mention --trace, so the two are not discoverable together")
+	}
+	// The scope limit belongs in --help: this records behaviour, not tokens.
+	if !strings.Contains(traceFlag.Usage, "GAIA_TURN_LOG") {
+		t.Error("--trace's help does not say what it cannot capture")
+	}
+
+	dev = false
+	tracePath = ""
+	t.Cleanup(func() { dev = false; tracePath = "" })
+	if err := flags.Set("trace", "/tmp/x.jsonl"); err != nil {
+		t.Fatalf("set --trace: %v", err)
+	}
+	if dev {
+		t.Error("--trace turned on developer mode")
+	}
+	if err := flags.Set("dev", "true"); err != nil {
+		t.Fatalf("set --dev: %v", err)
+	}
+	if tracePath != "/tmp/x.jsonl" {
+		t.Error("--dev changed the trace path")
+	}
+}

--- a/tui/internal/client/factory.go
+++ b/tui/internal/client/factory.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/amd/gaia/tui/internal/catalog"
 	"github.com/amd/gaia/tui/internal/daemon"
+	"github.com/amd/gaia/tui/internal/event"
 )
 
 // ForAgentOptions configures the transport built by ForAgent.
@@ -35,6 +36,11 @@ type ForAgentOptions struct {
 	// ClaudeModel picks which Claude model UseClaude uses; empty lets the
 	// agent pick its default. Meaningless without UseClaude, and refused.
 	ClaudeModel string
+	// Trace records every event the transport receives to a JSONL file
+	// (the TUI's --trace). Nil means tracing is off. Honoured by BOTH
+	// transports: the flagship's is chosen by install state, so tracing only
+	// one of them would leave --trace silently recording nothing.
+	Trace *event.TraceWriter
 }
 
 // BypassPermissionsFlag is the argument that starts a subprocess agent with
@@ -80,6 +86,7 @@ func ForAgent(agent catalog.Agent, opts ForAgentOptions) (AgentClient, error) {
 			MaxSteps:    opts.MaxSteps,
 			Logf:        opts.Logf,
 			Interactive: opts.Interactive,
+			Trace:       opts.Trace,
 		}), nil
 
 	case catalog.TransportSubprocess:
@@ -112,9 +119,9 @@ func ForAgent(agent catalog.Agent, opts ForAgentOptions) (AgentClient, error) {
 			args = append(append([]string{}, args...), extra...)
 		}
 		if agent.CanonicalEvents {
-			return NewCanonicalSubprocessClient(bin, args, opts.Dev), nil
+			return NewCanonicalSubprocessClient(bin, args, opts.Dev).WithTrace(opts.Trace), nil
 		}
-		return NewSubprocessClient(bin, args, opts.Dev), nil
+		return NewSubprocessClient(bin, args, opts.Dev).WithTrace(opts.Trace), nil
 
 	default:
 		return nil, fmt.Errorf(

--- a/tui/internal/client/sse.go
+++ b/tui/internal/client/sse.go
@@ -53,6 +53,9 @@ type SSEOptions struct {
 	Interactive bool
 	// Logf receives progress and best-effort-failure notes. Never given a token.
 	Logf func(format string, args ...any)
+	// Trace records every canonical event this client receives, verbatim. Nil
+	// means tracing is off (--trace not passed).
+	Trace *event.TraceWriter
 }
 
 // SSEClient drives one agent through the GAIA daemon's relay: it ensures the
@@ -370,6 +373,11 @@ func (s *SSEClient) consume(
 		payload, ok := reader.Next()
 		if !ok {
 			break
+		}
+		// Traced BEFORE parsing, so the file keeps the bytes that actually
+		// arrived and an unparseable frame is recorded rather than lost.
+		if err := s.opts.Trace.Write(payload); err != nil {
+			s.opts.Logf("trace: %v", err)
 		}
 		evt := event.ParseCanonicalEvent(payload)
 		if malformed, bad := evt.(event.CanonicalMalformedEvent); bad {

--- a/tui/internal/client/subprocess.go
+++ b/tui/internal/client/subprocess.go
@@ -81,6 +81,9 @@ type SubprocessClient struct {
 	// canonical selects the event dialect read off the pipe: the frozen legacy
 	// vocabulary (false) or the canonical one (true).
 	canonical bool
+	// trace records every event line this client reads, verbatim. Nil means
+	// tracing is off (--trace not passed).
+	trace *event.TraceWriter
 
 	mu      sync.Mutex
 	proc    *procHandle
@@ -118,6 +121,13 @@ func NewCanonicalSubprocessClient(path string, args []string, debug bool) *Subpr
 	c := NewSubprocessClient(path, args, debug)
 	c.canonical = true
 	return c
+}
+
+// WithTrace records every event line this client reads to w, verbatim. A nil w
+// leaves tracing off. Returns the client so it can be chained onto a constructor.
+func (s *SubprocessClient) WithTrace(w *event.TraceWriter) *SubprocessClient {
+	s.trace = w
+	return s
 }
 
 // turnState is everything one turn needs, captured under a single lock so it can
@@ -264,6 +274,17 @@ func (s *SubprocessClient) Send(ctx context.Context, query string) (<-chan inter
 			line := st.scanner.Bytes()
 			if len(line) == 0 {
 				continue
+			}
+
+			// Traced BEFORE parsing, so the file keeps the bytes that actually
+			// arrived and an unreadable line is recorded rather than lost.
+			//
+			// A failure is not printed HERE: the alt screen owns the terminal
+			// mid-turn, so a raw stderr write would land on top of the UI. The
+			// writer keeps the first failure and Close() reports it once the
+			// event loop has stopped.
+			if terr := s.trace.Write(line); terr != nil && debug {
+				fmt.Fprintf(os.Stderr, "[DEBUG] trace: %v\n", terr)
 			}
 
 			var evt interface{}

--- a/tui/internal/client/trace_tap_test.go
+++ b/tui/internal/client/trace_tap_test.go
@@ -1,0 +1,187 @@
+package client
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/amd/gaia/tui/internal/event"
+)
+
+// newTestTrace opens a trace writer at path, closed by the test if the test
+// itself does not get that far.
+func newTestTrace(t *testing.T, path string) *event.TraceWriter {
+	t.Helper()
+	w, err := event.NewTraceWriter(path)
+	if err != nil {
+		t.Fatalf("NewTraceWriter: %v", err)
+	}
+	t.Cleanup(func() { _ = w.Close() })
+	return w
+}
+
+// tracedLines returns the `event` object of every record in a trace file, as
+// compact JSON text.
+func tracedLines(t *testing.T, path string) []string {
+	t.Helper()
+	f, err := os.Open(path) // #nosec G304 -- test-owned temp path
+	if err != nil {
+		t.Fatalf("open trace: %v", err)
+	}
+	defer f.Close()
+
+	var out []string
+	sc := bufio.NewScanner(f)
+	sc.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	for sc.Scan() {
+		var rec struct {
+			Event    json.RawMessage `json:"event"`
+			Unparsed string          `json:"unparsed"`
+		}
+		if err := json.Unmarshal(sc.Bytes(), &rec); err != nil {
+			t.Fatalf("trace line is not JSON: %v (%s)", err, sc.Text())
+		}
+		if len(rec.Event) > 0 {
+			out = append(out, string(rec.Event))
+			continue
+		}
+		out = append(out, rec.Unparsed)
+	}
+	if err := sc.Err(); err != nil {
+		t.Fatalf("scan trace: %v", err)
+	}
+	return out
+}
+
+// TestSSEClientTracesEveryFrame is the acceptance shape of #3576: a tool that
+// reports success while finding nothing has to be visible in the trace, with
+// its ARGUMENTS and its result payload — neither of which the agent-side
+// recorder keeps.
+func TestSSEClientTracesEveryFrame(t *testing.T) {
+	relay := newFakeRelay(t)
+	relay.stream = func(w http.ResponseWriter, flush func(), _ queryRequest) {
+		frame(w, `{"type":"status","message":"Searching"}`)
+		frame(w, `{"type":"tool_call","tool":"find_files","args":{"pattern":"*.go","path":"tui/internal"}}`)
+		frame(w, `{"type":"tool_result","tool":"find_files","data":{"status":"success","count":0}}`)
+		frame(w, `{"type":"final","answer":"Zero"}`)
+		flush()
+	}
+
+	path := filepath.Join(t.TempDir(), "run.jsonl")
+	tw := newTestTrace(t, path)
+	c := relay.client(t)
+	c.opts.Trace = tw
+
+	ch, err := c.Send(context.Background(), "How many Go files are in tui/internal?")
+	if err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+	collect(t, ch)
+	if err := tw.Close(); err != nil {
+		t.Fatalf("close trace: %v", err)
+	}
+
+	lines := tracedLines(t, path)
+	if len(lines) != 4 {
+		t.Fatalf("traced %d frames, want 4: %v", len(lines), lines)
+	}
+	joined := strings.Join(lines, "\n")
+	for _, want := range []string{
+		`"tool":"find_files"`,
+		`"path":"tui/internal"`, // the ARGUMENTS turn_metrics never records
+		`"count":0`,             // the payload that makes "Zero" a bug, not an answer
+		`"status":"success"`,    // ...while the tool still calls itself successful
+	} {
+		if !strings.Contains(joined, want) {
+			t.Errorf("the trace does not carry %s:\n%s", want, joined)
+		}
+	}
+}
+
+// A frame the parser cannot read is exactly the frame a trace is wanted for, so
+// the tap runs BEFORE parsing.
+func TestSSEClientTracesUnparseableFrames(t *testing.T) {
+	relay := newFakeRelay(t)
+	relay.stream = func(w http.ResponseWriter, flush func(), _ queryRequest) {
+		frame(w, `{"type":"tool_call",`)
+		frame(w, `{"type":"final","answer":"done"}`)
+		flush()
+	}
+
+	path := filepath.Join(t.TempDir(), "run.jsonl")
+	tw := newTestTrace(t, path)
+	c := relay.client(t)
+	c.opts.Trace = tw
+
+	ch, err := c.Send(context.Background(), "hi")
+	if err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+	collect(t, ch)
+	if err := tw.Close(); err != nil {
+		t.Fatalf("close trace: %v", err)
+	}
+
+	lines := tracedLines(t, path)
+	if len(lines) != 2 {
+		t.Fatalf("traced %d frames, want 2 — the bad frame was dropped: %v", len(lines), lines)
+	}
+	if lines[0] != `{"type":"tool_call",` {
+		t.Errorf("the unparseable frame was not preserved verbatim: %q", lines[0])
+	}
+}
+
+// The flagship's transport is chosen by install state, so the subprocess half
+// has to record too — otherwise --trace writes an empty file on the very launch
+// the acceptance test uses.
+func TestSubprocessClientTracesEveryLine(t *testing.T) {
+	bin := buildMockAgent(t)
+	path := filepath.Join(t.TempDir(), "run.jsonl")
+	tw := newTestTrace(t, path)
+
+	c := NewSubprocessClient(bin, nil, false).WithTrace(tw)
+	defer c.Close()
+
+	ch, err := c.Send(context.Background(), "hello")
+	if err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+	for range ch {
+	}
+	if err := tw.Close(); err != nil {
+		t.Fatalf("close trace: %v", err)
+	}
+
+	lines := tracedLines(t, path)
+	if len(lines) != 5 {
+		t.Fatalf("traced %d lines, want the mock agent's 5: %v", len(lines), lines)
+	}
+	if !strings.Contains(strings.Join(lines, "\n"), `"tool":"bash"`) {
+		t.Errorf("the tool line was not traced: %v", lines)
+	}
+}
+
+// Tracing off is the default, and every tap must accept it without a nil check
+// at the call site.
+func TestTransportsRunUntracedByDefault(t *testing.T) {
+	bin := buildMockAgent(t)
+	c := NewSubprocessClient(bin, nil, false)
+	defer c.Close()
+
+	ch, err := c.Send(context.Background(), "hello")
+	if err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+	var n int
+	for range ch {
+		n++
+	}
+	if n == 0 {
+		t.Error("no events were delivered with tracing off")
+	}
+}

--- a/tui/internal/event/trace.go
+++ b/tui/internal/event/trace.go
@@ -1,0 +1,220 @@
+package event
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+	"unicode/utf8"
+)
+
+// TraceWriter appends every canonical event the TUI receives to a JSONL file,
+// verbatim, in arrival order.
+//
+// It exists because the TUI is the only process that sees the whole trajectory:
+// tool calls WITH their arguments and tool results WITH their payloads. The
+// agent-side recorder (src/gaia/agents/base/turn_metrics.py) records neither, so
+// a tool that returns `status: "success"` and zero results reads as a healthy
+// turn there and as a broken one here (#3576).
+//
+// A nil *TraceWriter is the "tracing off" state and every method accepts it, so
+// call sites tap the stream unconditionally.
+type TraceWriter struct {
+	path string
+
+	mu  sync.Mutex
+	f   *os.File
+	buf *bufio.Writer
+	seq int
+	// err is the FIRST write failure. Sticky, and returned by Close: a trace
+	// that stopped recording halfway must not be mistaken for a complete one.
+	err error
+	// fresh records that this open found no existing content, so Close may
+	// remove a file it created and never wrote to. A launch can fail after the
+	// trace opens — a refused port, an unmet precondition — and ~/.gaia/traces
+	// has no rotation, so empty files would just pile up there forever.
+	fresh bool
+	// now is injected by tests. Production leaves it nil and uses time.Now.
+	now func() time.Time
+}
+
+// traceRecord is one line of the trace.
+//
+// At and Seq are the point of the wrapper: ordering and wall-clock time are what
+// make a trajectory analysable, and the SSE payload carries neither. Exactly one
+// of Event / Unparsed / UnparsedB64 is set — the latter two keep a payload the
+// parser could not read, which is precisely the case a trace is most needed for.
+type traceRecord struct {
+	At       string          `json:"at"`
+	Seq      int             `json:"seq"`
+	Event    json.RawMessage `json:"event,omitempty"`
+	Unparsed string          `json:"unparsed,omitempty"`
+	// UnparsedB64 carries a payload that is not valid UTF-8. Encoding a Go
+	// string to JSON replaces every bad byte with U+FFFD, so a subprocess
+	// emitting binary garbage would be recorded as mangled text — losing the
+	// bytes that explain what went wrong.
+	UnparsedB64 string `json:"unparsed_b64,omitempty"`
+}
+
+// NewTraceWriter opens path for appending, creating its parent directory.
+//
+// It fails rather than degrades: a trace nobody can write is the exact silent
+// non-recording this whole feature exists to remove, so the caller must treat
+// this error as fatal to the launch.
+func NewTraceWriter(path string) (*TraceWriter, error) {
+	if strings.TrimSpace(path) == "" {
+		return nil, fmt.Errorf("no trace path was given, so there is nowhere to record")
+	}
+	if dir := filepath.Dir(path); dir != "" {
+		if err := os.MkdirAll(dir, 0o700); err != nil {
+			return nil, fmt.Errorf("cannot create the trace directory %s: %w "+
+				"(pass --trace=<path> to record somewhere writable)", dir, err)
+		}
+	}
+	// Whether this open CREATED the file, so Close can clean up after a launch
+	// that recorded nothing without ever deleting an earlier run's trace.
+	fresh := false
+	if info, statErr := os.Stat(path); os.IsNotExist(statErr) {
+		fresh = true
+	} else if statErr == nil && info.Size() == 0 {
+		fresh = true
+	}
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o600) // #nosec G304 -- the path is the user's own --trace argument
+	if err != nil {
+		return nil, fmt.Errorf("cannot open the trace file %s: %w "+
+			"(pass --trace=<path> to record somewhere writable)", path, err)
+	}
+	return &TraceWriter{path: path, f: f, buf: bufio.NewWriter(f), fresh: fresh}, nil
+}
+
+// Path is where the trace is being written. "" when tracing is off.
+func (t *TraceWriter) Path() string {
+	if t == nil {
+		return ""
+	}
+	return t.path
+}
+
+// Write records one raw event payload as a single JSON line.
+//
+// Flushed per event: a run that crashes or is killed mid-turn must still leave
+// behind everything it had received, which is the run a trace is most wanted for.
+func (t *TraceWriter) Write(raw []byte) error {
+	if t == nil {
+		return nil
+	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if t.f == nil {
+		return t.err
+	}
+
+	t.seq++
+	rec := traceRecord{At: t.timestamp(), Seq: t.seq}
+	// Compact both validates and normalises: a payload that arrived pretty-printed
+	// still has to occupy exactly one line.
+	var compact bytes.Buffer
+	switch {
+	case json.Compact(&compact, raw) == nil:
+		rec.Event = compact.Bytes()
+	case utf8.Valid(raw):
+		rec.Unparsed = string(raw)
+	default:
+		rec.UnparsedB64 = base64.StdEncoding.EncodeToString(raw)
+	}
+
+	line, err := json.Marshal(rec)
+	if err != nil {
+		return t.failLocked(fmt.Errorf("cannot encode trace record %d: %w", t.seq, err))
+	}
+	if _, err := t.buf.Write(append(line, '\n')); err != nil {
+		return t.failLocked(fmt.Errorf("cannot write to the trace file %s: %w", t.path, err))
+	}
+	if err := t.buf.Flush(); err != nil {
+		return t.failLocked(fmt.Errorf("cannot flush the trace file %s: %w", t.path, err))
+	}
+	return nil
+}
+
+// Close flushes and closes the file, returning the first write failure if there
+// was one. Safe to call twice.
+func (t *TraceWriter) Close() error {
+	if t == nil {
+		return nil
+	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if t.f == nil {
+		return t.err
+	}
+	f := t.f
+	t.f = nil
+	if err := t.buf.Flush(); err != nil && t.err == nil {
+		t.err = fmt.Errorf("cannot flush the trace file %s: %w", t.path, err)
+	}
+	if err := f.Close(); err != nil && t.err == nil {
+		t.err = fmt.Errorf("cannot close the trace file %s: %w", t.path, err)
+	}
+	// Nothing was ever recorded and this open created the file: the launch died
+	// before the agent said anything. Leave no 0-byte trace behind.
+	if t.seq == 0 && t.fresh && t.err == nil {
+		if err := os.Remove(t.path); err != nil && !os.IsNotExist(err) {
+			t.err = fmt.Errorf("cannot remove the empty trace file %s: %w", t.path, err)
+		}
+	}
+	return t.err
+}
+
+// failLocked records the first failure and returns it. Caller holds t.mu.
+func (t *TraceWriter) failLocked(err error) error {
+	if t.err == nil {
+		t.err = err
+	}
+	return err
+}
+
+func (t *TraceWriter) timestamp() string {
+	clock := time.Now
+	if t.now != nil {
+		clock = t.now
+	}
+	return clock().UTC().Format(time.RFC3339Nano)
+}
+
+// DefaultTracePath is where a bare --trace records: one file per launch under
+// ~/.gaia/traces, named so runs sort chronologically and name their agent.
+func DefaultTracePath(agentID string, at time.Time) (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("cannot locate the home directory to place the trace in: %w "+
+			"(pass --trace=<path> to choose one explicitly)", err)
+	}
+	name := fmt.Sprintf("%s-%s.jsonl", at.Format("20060102-150405"), traceSlug(agentID))
+	return filepath.Join(home, ".gaia", "traces", name), nil
+}
+
+// traceSlug reduces an agent id to something safe in a filename on every
+// platform GAIA ships to.
+func traceSlug(agentID string) string {
+	var b strings.Builder
+	for _, r := range strings.ToLower(strings.TrimSpace(agentID)) {
+		switch {
+		case r >= 'a' && r <= 'z', r >= '0' && r <= '9':
+			b.WriteRune(r)
+		case r == '-' || r == '_':
+			b.WriteRune(r)
+		default:
+			b.WriteRune('-')
+		}
+	}
+	if b.Len() == 0 {
+		return "agent"
+	}
+	return b.String()
+}

--- a/tui/internal/event/trace_test.go
+++ b/tui/internal/event/trace_test.go
@@ -1,0 +1,363 @@
+package event
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/base64"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// readTrace parses a trace file into its records, failing the test on any line
+// that is not a single valid JSON object — one-event-per-line is the format's
+// whole contract.
+func readTrace(t *testing.T, path string) []traceRecord {
+	t.Helper()
+	f, err := os.Open(path) // #nosec G304 -- test-owned temp path
+	if err != nil {
+		t.Fatalf("open trace: %v", err)
+	}
+	defer f.Close()
+
+	var out []traceRecord
+	sc := bufio.NewScanner(f)
+	for sc.Scan() {
+		var rec traceRecord
+		if err := json.Unmarshal(sc.Bytes(), &rec); err != nil {
+			t.Fatalf("trace line is not valid JSON: %v (line: %s)", err, sc.Text())
+		}
+		out = append(out, rec)
+	}
+	if err := sc.Err(); err != nil {
+		t.Fatalf("scan trace: %v", err)
+	}
+	return out
+}
+
+func TestTraceWriterRoundTripsCanonicalEvents(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "run.jsonl")
+	w, err := NewTraceWriter(path)
+	if err != nil {
+		t.Fatalf("NewTraceWriter: %v", err)
+	}
+
+	// The exact trajectory #3576 needed and could not produce: the call with its
+	// ARGUMENTS, and the result payload showing it found nothing.
+	frames := []string{
+		`{"type":"status","message":"Searching"}`,
+		`{"type":"tool_call","tool":"find_files","args":{"pattern":"*.go","path":"tui/internal"}}`,
+		`{"type":"tool_result","tool":"find_files","data":{"status":"success","count":0,"files":[]}}`,
+		`{"type":"final","answer":"Zero"}`,
+	}
+	for _, f := range frames {
+		if err := w.Write([]byte(f)); err != nil {
+			t.Fatalf("Write(%s): %v", f, err)
+		}
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	recs := readTrace(t, path)
+	if len(recs) != len(frames) {
+		t.Fatalf("got %d records, want %d", len(recs), len(frames))
+	}
+	for i, rec := range recs {
+		if rec.Seq != i+1 {
+			t.Errorf("record %d: seq = %d, want %d", i, rec.Seq, i+1)
+		}
+		if _, err := time.Parse(time.RFC3339Nano, rec.At); err != nil {
+			t.Errorf("record %d: at %q is not RFC3339: %v", i, rec.At, err)
+		}
+		if rec.Unparsed != "" {
+			t.Errorf("record %d: valid JSON was filed as unparsed: %s", i, rec.Unparsed)
+		}
+	}
+
+	// The payload must survive verbatim, not just structurally — the arguments
+	// and the zero count are the evidence.
+	var call struct {
+		Tool string            `json:"tool"`
+		Args map[string]string `json:"args"`
+	}
+	if err := json.Unmarshal(recs[1].Event, &call); err != nil {
+		t.Fatalf("decode tool_call: %v", err)
+	}
+	if call.Tool != "find_files" || call.Args["path"] != "tui/internal" || call.Args["pattern"] != "*.go" {
+		t.Errorf("tool_call arguments lost: %+v", call)
+	}
+
+	var result struct {
+		Data struct {
+			Status string `json:"status"`
+			Count  int    `json:"count"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(recs[2].Event, &result); err != nil {
+		t.Fatalf("decode tool_result: %v", err)
+	}
+	if result.Data.Status != "success" || result.Data.Count != 0 {
+		t.Errorf("tool_result payload lost: %+v", result.Data)
+	}
+}
+
+func TestTraceWriterRecordsMalformedPayloads(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "run.jsonl")
+	w, err := NewTraceWriter(path)
+	if err != nil {
+		t.Fatalf("NewTraceWriter: %v", err)
+	}
+	// Neither of these parses as a canonical event. Dropping them would hide
+	// exactly the frame a trace is most wanted for.
+	bad := []string{`{"type":"tool_call",`, `not json at all`}
+	for _, b := range bad {
+		if err := w.Write([]byte(b)); err != nil {
+			t.Fatalf("Write(%q): %v", b, err)
+		}
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	recs := readTrace(t, path)
+	if len(recs) != len(bad) {
+		t.Fatalf("got %d records, want %d — a bad frame was dropped", len(recs), len(bad))
+	}
+	for i, rec := range recs {
+		if rec.Unparsed != bad[i] {
+			t.Errorf("record %d: unparsed = %q, want %q", i, rec.Unparsed, bad[i])
+		}
+		if len(rec.Event) != 0 {
+			t.Errorf("record %d: unreadable payload was filed as an event: %s", i, rec.Event)
+		}
+	}
+}
+
+// Encoding a Go string to JSON turns every bad byte into U+FFFD, so a payload
+// that is not valid UTF-8 has to go out base64 — an agent emitting binary
+// garbage is exactly the failure a trace is supposed to explain.
+func TestTraceWriterPreservesNonUTF8Payloads(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "run.jsonl")
+	w, err := NewTraceWriter(path)
+	if err != nil {
+		t.Fatalf("NewTraceWriter: %v", err)
+	}
+	raw := []byte{'g', 'a', 'r', 'b', 0xff, 0xfe, '{', '"'}
+	if err := w.Write(raw); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	recs := readTrace(t, path)
+	if len(recs) != 1 {
+		t.Fatalf("got %d records, want 1", len(recs))
+	}
+	if recs[0].Unparsed != "" {
+		t.Errorf("bad bytes went through the string field and were mangled: %q", recs[0].Unparsed)
+	}
+	got, err := base64.StdEncoding.DecodeString(recs[0].UnparsedB64)
+	if err != nil {
+		t.Fatalf("unparsed_b64 is not base64: %v", err)
+	}
+	if !bytes.Equal(got, raw) {
+		t.Errorf("payload changed: got %x, want %x", got, raw)
+	}
+}
+
+// A launch can die after the trace opens — a refused port, an unmet
+// precondition — and ~/.gaia/traces is never pruned, so an empty file must not
+// be left behind.
+func TestTraceWriterRemovesItsOwnEmptyFile(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "run.jsonl")
+	w, err := NewTraceWriter(path)
+	if err != nil {
+		t.Fatalf("NewTraceWriter: %v", err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Errorf("a trace that recorded nothing was left on disk (stat err: %v)", err)
+	}
+}
+
+// ...but only a file it created. Reopening an EXISTING trace and writing
+// nothing must never delete the earlier run's records.
+func TestTraceWriterKeepsAnExistingTraceItDidNotWriteTo(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "run.jsonl")
+	first, err := NewTraceWriter(path)
+	if err != nil {
+		t.Fatalf("NewTraceWriter: %v", err)
+	}
+	if err := first.Write([]byte(`{"type":"final","answer":"kept"}`)); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	if err := first.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	second, err := NewTraceWriter(path)
+	if err != nil {
+		t.Fatalf("reopen: %v", err)
+	}
+	if err := second.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	if recs := readTrace(t, path); len(recs) != 1 {
+		t.Fatalf("the earlier run's trace was destroyed: %d records left", len(recs))
+	}
+}
+
+func TestTraceWriterKeepsOneEventPerLine(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "run.jsonl")
+	w, err := NewTraceWriter(path)
+	if err != nil {
+		t.Fatalf("NewTraceWriter: %v", err)
+	}
+	pretty := "{\n  \"type\": \"status\",\n  \"message\": \"line\\nbreak\"\n}"
+	if err := w.Write([]byte(pretty)); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	if err := w.Write([]byte(`{"type":"final","answer":"done"}`)); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	raw, err := os.ReadFile(path) // #nosec G304 -- test-owned temp path
+	if err != nil {
+		t.Fatalf("read trace: %v", err)
+	}
+	if got := strings.Count(strings.TrimRight(string(raw), "\n"), "\n"); got != 1 {
+		t.Errorf("a pretty-printed frame was not compacted: %d newlines between 2 records\n%s", got, raw)
+	}
+	if len(readTrace(t, path)) != 2 {
+		t.Errorf("want 2 records")
+	}
+}
+
+func TestTraceWriterFlushesPerEvent(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "run.jsonl")
+	w, err := NewTraceWriter(path)
+	if err != nil {
+		t.Fatalf("NewTraceWriter: %v", err)
+	}
+	defer w.Close()
+	if err := w.Write([]byte(`{"type":"status","message":"still running"}`)); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	// Read WITHOUT closing: a run that crashes mid-turn must still leave behind
+	// everything it had received.
+	if recs := readTrace(t, path); len(recs) != 1 {
+		t.Fatalf("got %d records before Close, want 1 — the event was still buffered", len(recs))
+	}
+}
+
+func TestTraceWriterAppendsAcrossOpens(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "run.jsonl")
+	for i := 0; i < 2; i++ {
+		w, err := NewTraceWriter(path)
+		if err != nil {
+			t.Fatalf("NewTraceWriter #%d: %v", i, err)
+		}
+		if err := w.Write([]byte(`{"type":"status"}`)); err != nil {
+			t.Fatalf("Write #%d: %v", i, err)
+		}
+		if err := w.Close(); err != nil {
+			t.Fatalf("Close #%d: %v", i, err)
+		}
+	}
+	if recs := readTrace(t, path); len(recs) != 2 {
+		t.Errorf("got %d records, want 2 — reopening truncated the trace", len(recs))
+	}
+}
+
+func TestNewTraceWriterFailsRatherThanDegrades(t *testing.T) {
+	// A regular file where a directory has to be: MkdirAll cannot make it, on
+	// any platform GAIA ships to.
+	blocker := filepath.Join(t.TempDir(), "not-a-dir")
+	if err := os.WriteFile(blocker, []byte("x"), 0o600); err != nil {
+		t.Fatalf("setup: %v", err)
+	}
+	w, err := NewTraceWriter(filepath.Join(blocker, "run.jsonl"))
+	if err == nil {
+		w.Close()
+		t.Fatal("an unwritable trace path was accepted — a trace nobody can write must be a startup error")
+	}
+	if !strings.Contains(err.Error(), "--trace") {
+		t.Errorf("the error does not say how to fix it: %v", err)
+	}
+}
+
+func TestNewTraceWriterRejectsEmptyPath(t *testing.T) {
+	if _, err := NewTraceWriter("   "); err == nil {
+		t.Fatal("an empty trace path was accepted")
+	}
+}
+
+func TestNilTraceWriterIsTracingOff(t *testing.T) {
+	var w *TraceWriter
+	if err := w.Write([]byte(`{"type":"status"}`)); err != nil {
+		t.Errorf("Write on a nil writer: %v", err)
+	}
+	if err := w.Close(); err != nil {
+		t.Errorf("Close on a nil writer: %v", err)
+	}
+	if got := w.Path(); got != "" {
+		t.Errorf("Path() on a nil writer = %q, want \"\"", got)
+	}
+}
+
+func TestTraceWriterCloseIsIdempotent(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "run.jsonl")
+	w, err := NewTraceWriter(path)
+	if err != nil {
+		t.Fatalf("NewTraceWriter: %v", err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("first Close: %v", err)
+	}
+	if err := w.Close(); err != nil {
+		t.Errorf("second Close: %v", err)
+	}
+	// A write after close is a no-op, not a panic on a closed file.
+	if err := w.Write([]byte(`{"type":"status"}`)); err != nil {
+		t.Errorf("Write after Close: %v", err)
+	}
+}
+
+func TestDefaultTracePathNamesTheRunAndAgent(t *testing.T) {
+	at := time.Date(2026, 9, 8, 18, 4, 19, 0, time.UTC)
+	got, err := DefaultTracePath("gaia", at)
+	if err != nil {
+		t.Fatalf("DefaultTracePath: %v", err)
+	}
+	if base := filepath.Base(got); base != "20260908-180419-gaia.jsonl" {
+		t.Errorf("filename = %q, want %q", base, "20260908-180419-gaia.jsonl")
+	}
+	if dir := filepath.Base(filepath.Dir(got)); dir != "traces" {
+		t.Errorf("parent directory = %q, want \"traces\"", dir)
+	}
+}
+
+func TestTraceSlugIsFilenameSafe(t *testing.T) {
+	for _, tc := range []struct{ in, want string }{
+		{"gaia", "gaia"},
+		{"Email", "email"},
+		{"doc/qa", "doc-qa"},
+		{"a b:c", "a-b-c"},
+		{"", "agent"},
+		{"///", "---"},
+	} {
+		if got := traceSlug(tc.in); got != tc.want {
+			t.Errorf("traceSlug(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}

--- a/tui/internal/ui/app.go
+++ b/tui/internal/ui/app.go
@@ -17,6 +17,7 @@ import (
 	"github.com/amd/gaia/tui/internal/client"
 	"github.com/amd/gaia/tui/internal/control"
 	"github.com/amd/gaia/tui/internal/daemon"
+	"github.com/amd/gaia/tui/internal/event"
 	"github.com/amd/gaia/tui/internal/ui/chat"
 	"github.com/amd/gaia/tui/internal/ui/components"
 	"github.com/amd/gaia/tui/internal/ui/preflight"
@@ -45,8 +46,9 @@ func prepareTerminal() {
 // testing. A non-nil ctrl starts the loopback control API against this very
 // program. bypassPermissions starts the agent with confirmation prompts off.
 // useClaude/claudeModel run it against Anthropic's Claude API instead of the
-// local Lemonade backend.
-func RunFlagship(dev bool, mockAgent string, ctrl *control.Options, bypassPermissions bool, useClaude bool, claudeModel string) error {
+// local Lemonade backend. A non-nil trace records every agent event to a JSONL
+// file; the caller owns it and closes it after this returns.
+func RunFlagship(dev bool, mockAgent string, ctrl *control.Options, bypassPermissions bool, useClaude bool, claudeModel string, trace *event.TraceWriter) error {
 	cat := catalog.NewCatalog()
 	if mockAgent != "" {
 		cat.SetMockBinary(mockAgent)
@@ -61,6 +63,7 @@ func RunFlagship(dev bool, mockAgent string, ctrl *control.Options, bypassPermis
 	m := root.NewFlagshipModel(*agent, dev).
 		WithBypassPermissions(bypassPermissions).
 		WithClaude(useClaude, claudeModel).
+		WithTrace(trace).
 		WithLocalPreflight(preflight.LocalOptions{
 			// The gate has to answer about the binary this launch will actually
 			// spawn — with --mock that is the mock, not the name the seed carries.
@@ -73,7 +76,7 @@ func RunFlagship(dev bool, mockAgent string, ctrl *control.Options, bypassPermis
 //
 // subprocess is a command line, so it is split with quoting honoured — a binary
 // path containing a space must be quoted, not silently torn in two.
-func RunChat(subprocess string, query string, dev bool, ctrl *control.Options) error {
+func RunChat(subprocess string, query string, dev bool, ctrl *control.Options, trace *event.TraceWriter) error {
 	argv, err := client.SplitCommandLine(subprocess)
 	if err != nil {
 		return fmt.Errorf("invalid --subprocess command: %w", err)
@@ -85,7 +88,7 @@ func RunChat(subprocess string, query string, dev bool, ctrl *control.Options) e
 		return fmt.Errorf("cannot start --subprocess %q: %w", argv[0], err)
 	}
 
-	c := client.NewSubprocessClient(bin, argv[1:], dev)
+	c := client.NewSubprocessClient(bin, argv[1:], dev).WithTrace(trace)
 	defer c.Close()
 
 	return run(chat.NewChatModel(c, agentNameFromPath(argv[0]), query, dev), dev, ctrl)
@@ -207,7 +210,7 @@ func run(model tea.Model, dev bool, ctrl *control.Options) error {
 // that overrode the binary for one entry point and not the other let a test
 // spawn the real agent while believing it had substituted a stand-in.
 // Returns the process exit code.
-func RunAgent(agentID, query, model string, dev bool, timeout time.Duration, ctrl *control.Options, bypassPermissions bool, useClaude bool, claudeModel, mockAgent string) (int, error) {
+func RunAgent(agentID, query, model string, dev bool, timeout time.Duration, ctrl *control.Options, bypassPermissions bool, useClaude bool, claudeModel, mockAgent string, trace *event.TraceWriter) (int, error) {
 	cat := catalog.NewCatalog()
 	if mockAgent != "" {
 		cat.SetMockBinary(mockAgent)
@@ -277,6 +280,7 @@ func RunAgent(agentID, query, model string, dev bool, timeout time.Duration, ctr
 			BypassPermissions: bypassPermissions,
 			UseClaude:         useClaude,
 			ClaudeModel:       claudeModel,
+			Trace:             trace,
 		})
 		if err != nil {
 			return 1, err
@@ -297,7 +301,8 @@ func RunAgent(agentID, query, model string, dev bool, timeout time.Duration, ctr
 	m := root.NewFlagshipModel(*agent, dev).
 		WithBypassPermissions(bypassPermissions).
 		WithClaude(useClaude, claudeModel).
-		WithModel(model)
+		WithModel(model).
+		WithTrace(trace)
 	if err := run(m, dev, ctrl); err != nil {
 		return 1, err
 	}

--- a/tui/internal/ui/root/model.go
+++ b/tui/internal/ui/root/model.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/amd/gaia/tui/internal/catalog"
 	"github.com/amd/gaia/tui/internal/client"
+	"github.com/amd/gaia/tui/internal/event"
 	"github.com/amd/gaia/tui/internal/ui/chat"
 	"github.com/amd/gaia/tui/internal/ui/components"
 	"github.com/amd/gaia/tui/internal/ui/preflight"
@@ -60,6 +61,9 @@ type FlagshipModel struct {
 	// model overrides the agent's own default (--model). Only a daemon-backed
 	// agent can honour it; cli.checkModelSupported refuses it for the rest.
 	model string
+	// trace records every agent event to a JSONL file (--trace). Nil when off.
+	// Owned by the caller of RunFlagship, which closes it after the event loop.
+	trace *event.TraceWriter
 
 	// preflight is the gate currently on screen, nil when there is none.
 	preflight *preflight.Model
@@ -185,6 +189,14 @@ func (m FlagshipModel) WithClaude(enabled bool, model string) FlagshipModel {
 // shape the rules forbid.
 func (m FlagshipModel) WithModel(model string) FlagshipModel {
 	m.model = model
+	return m
+}
+
+// WithTrace records every agent event to w (--trace). The caller keeps
+// ownership and closes w once the event loop has stopped, so a copy of this
+// model made by Bubble Tea can never close the file out from under a live turn.
+func (m FlagshipModel) WithTrace(w *event.TraceWriter) FlagshipModel {
+	m.trace = w
 	return m
 }
 
@@ -358,6 +370,7 @@ func (m FlagshipModel) launchAgent(agent catalog.Agent, setupVerified bool) (tea
 	c, err := client.ForAgent(agent, client.ForAgentOptions{
 		Dev: m.dev, Logf: m.logf, Interactive: true,
 		Model:             m.model,
+		Trace:             m.trace,
 		BypassPermissions: m.bypassPermissions,
 		UseClaude:         m.useClaude,
 		ClaudeModel:       m.claudeModel,


### PR DESCRIPTION
When GAIA gives a wrong answer, the only evidence today is what was on the terminal — which is how #3576 got reported as a screenshot of the word "Zero" and nothing else. `--trace` writes down what the agent actually did: every tool call with its arguments, every result with its payload, every error, in arrival order with timestamps. Re-running that same question against a trace now shows the tool, the arguments it was handed, and the result that contradicts the answer it produced.

The recorder lives in the TUI rather than the agent because that is where the data already is. The agent's own per-turn recorder (`turn_metrics.py`) keeps only step/name/duration/ok — no arguments, no error text — so a tool that returns `status: "success"` with zero results shows up there as a healthy turn. It also cannot be switched on in practice: the daemon spawns the sidecar, so `GAIA_TURN_LOG` has to be set on the daemon rather than on the command you are running. Adding arguments and error text to that recorder is #3392 and stays separate; this PR does not touch token or prompt accounting.

```bash
gaia tui --trace                 # ~/.gaia/traces/<timestamp>-<agent>.jsonl
gaia tui --trace=run.jsonl       # a path you choose
```

Two things worth a reviewer's attention:

- **Both transports are tapped**, not just the daemon relay. The flagship's transport is decided by install state — subprocess from the seed catalog, daemon once a binary artifact is registered — so recording only one would have written an empty file on the exact launch this feature exists for. That is not hypothetical: it is what this machine does.
- **An unwritable path fails the launch.** A trace that is silently not being written looks identical to an agent that did nothing, which is the confusion the flag removes.

## Test plan

- [ ] `cd tui && go build ./... && go vet ./... && go test ./internal/...`
- [ ] Round-trip, malformed frames, non-UTF-8 payloads, empty-file cleanup: `go test ./internal/event/ -run Trace -v`
- [ ] The tap fires on both transports: `go test ./internal/client/ -run Trace -v`
- [ ] Flag forms: `go test ./internal/cli/ -run 'Trace|StrayArgument' -v`
- [ ] Bare `--trace` announces its path and records a real turn:
      `gaia tui --trace`, ask any question, then read the file it named — the `tool_call` lines carry `args`, the `tool_result` lines carry `data`.
- [ ] `--trace` does not change what is on screen; `--dev` does. Run with each and with both.
- [ ] `gaia-tui --trace chatt` still suggests `chat` (the flag must not swallow a plain typo); `gaia-tui --trace out.jsonl` names the `--trace=out.jsonl` form.
- [ ] A launch that is refused (`gaia tui chat --agent email --query hi --trace` with no email sidecar) leaves no 0-byte file in `~/.gaia/traces`.

Motivating context: #3576 (the answer this makes diagnosable), #3392 (the agent-side recorder's missing fields, deliberately out of scope).
