### PR TITLE
fix(shell,skills): close the allowlist holes that let a read run code

### DIFF
--- a/hub/agents/chat/python/gaia_agent_chat/agent.py
+++ b/hub/agents/chat/python/gaia_agent_chat/agent.py
@@ -874,7 +874,7 @@ No documents are currently indexed.
 - Common folders: Desktop, Documents, Downloads (under {home_dir})
 - Shell: `systeminfo`, `tasklist`, `ipconfig`, `driverquery`
 - Network: prefer `ipconfig`. Primary adapter has real Default Gateway — ignore virtual adapters.
-- Process monitoring: `powershell -Command "Get-Process | Sort-Object WS -Descending | Select-Object -First 15 Name, Id, @{{N='Memory(MB)';E={{[math]::Round($_.WS/1MB,1)}}}}"`. Avoid `tasklist /V`.
+- Process monitoring: `powershell -Command "Get-Process | Sort-Object WS -Descending | Select-Object -First 15 Name, Id, WS"` (WS is bytes; divide in your answer). Avoid `tasklist /V`.
 - CPU: `powershell -Command "Get-CimInstance Win32_Processor | Select-Object Name"`
 - GPU: `powershell -Command "Get-CimInstance Win32_VideoController | Format-List Name,DriverVersion,AdapterRAM"`
 - Prefer `Get-CimInstance` over `wmic` (deprecated). Do NOT use Linux commands.

--- a/hub/skills/github-triage/SKILL.md
+++ b/hub/skills/github-triage/SKILL.md
@@ -68,12 +68,14 @@ report it and move on. Never re-run a denied command hoping for a different
 answer.
 
 **Refused outright — no prompt, and approval is not available.** `gh auth token`
-(prints the credential), `gh alias` (defines a shell command), `gh extension`
-(installs and runs code), `gh config`, `gh codespace`, any `gh api` write
-(`-X POST`, `-f`/`--field`, `graphql`), and the irreversible ones: `gh pr merge`,
-`gh issue close`, `gh label delete`, `gh repo delete`. Also refused inside an
-otherwise-approvable write: `--body-file` (uploads a local file's contents),
-`--editor`, and `--web`.
+and `gh auth status -t`/`--show-token` (both print the credential), `gh alias`
+(defines a shell command), `gh extension` (installs and runs code), `gh config`,
+`gh codespace`, any `gh api` write (`-X POST`, `-f`/`--field`, `graphql`), and
+the irreversible ones: `gh pr merge`, `gh issue close`, `gh label delete`,
+`gh repo delete`. Also refused on any subcommand: `--body-file` (uploads a local
+file's contents), `--editor`, `--web` (opens a browser, returns you nothing), and
+`--watch` (blocks until the run finishes). Reads take a fixed flag allowlist, so
+a `gh` flag not listed here is refused rather than passed through.
 
 A refused command returns an error, not a silent no-op. Report it as a refusal
 and say what you would have run. These commands are refused outright rather than

--- a/hub/skills/github-triage/SKILL.md
+++ b/hub/skills/github-triage/SKILL.md
@@ -74,8 +74,10 @@ and `gh auth status -t`/`--show-token` (both print the credential), `gh alias`
 the irreversible ones: `gh pr merge`, `gh issue close`, `gh label delete`,
 `gh repo delete`. Also refused on any subcommand: `--body-file` (uploads a local
 file's contents), `--editor`, `--web` (opens a browser, returns you nothing), and
-`--watch` (blocks until the run finishes). Reads take a fixed flag allowlist, so
-a `gh` flag not listed here is refused rather than passed through.
+`--watch` (blocks until the run finishes). The `repo`, `release`, `run`, `search`,
+and `auth` read commands accept only reviewed flags from GAIA's policy table.
+The mixed read/write `issue`, `pr`, and `label` commands use a denylist for flags;
+their supported read actions remain limited to the actions listed above.
 
 A refused command returns an error, not a silent no-op. Report it as a refusal
 and say what you would have run. These commands are refused outright rather than

--- a/src/gaia/agents/tools/shell_tools.py
+++ b/src/gaia/agents/tools/shell_tools.py
@@ -225,13 +225,15 @@ PREFIX_BLOCKED_PS_PARAMS = (
     "executionpolicy",
 )
 
+_SAFE_PS_LEADING_SWITCHES = frozenset({"nologo", "sta", "mta"})
+
 #: Ways a ``-Command`` body reaches code the cmdlet allowlist never sees. The
 #: outer operator scan skips this body by design (``_operator_check_text``), so
 #: every escape it would have caught has to be caught here instead.
 _PS_BODY_ESCAPES = (
     (re.compile(r"::"), "static .NET member access ([Type]::Member)"),
     (re.compile(r"\.\s*[a-z_][a-z0-9_]*\s*\("), "method invocation (.Method(...))"),
-    (re.compile(r"(?:^|\s)\.(?=[\s\\/'\"])"), "dot-sourcing (. script.ps1)"),
+    (re.compile(r"(?:^|\|)\s*\.\s+"), "dot-sourcing (. script.ps1)"),
     # The two below fire in command position only — start of the body or just
     # after a pipe — so a path OPERAND (Get-Content C:/log.txt) is still a read.
     (
@@ -245,7 +247,7 @@ _PS_BODY_ESCAPES = (
     (re.compile(r"&"), "the call operator (& command)"),
     (re.compile(r"\$"), "variables and subexpressions ($var, $(...))"),
     (re.compile(r"[<>]"), "redirection (>, >>, <)"),
-    (re.compile(r";"), "statement separators (;)"),
+    (re.compile(r"[;\r\n]"), "statement separators (; or newline)"),
 )
 
 #: Long-flag names that make a command write a file. Matched on any prefix
@@ -696,6 +698,12 @@ class ShellToolsMixin:
             # A read-only subcommand still writes a caller-chosen path when it
             # is handed an output flag, and the subcommand check never sees it.
             for part in cmd_parts[1:]:
+                if (
+                    len(cmd_parts) > 1
+                    and cmd_parts[1].lower() == "ls-files"
+                    and part == "-o"
+                ):
+                    continue
                 if _is_file_write_flag(part):
                     return {
                         "status": "error",
@@ -740,15 +748,30 @@ class ShellToolsMixin:
                     "hint": "Use -Command to pass a readable cmdlet string",
                     "examples": 'powershell -Command "Get-WmiObject Win32_Processor | Select-Object Name"',
                 }
-            # Extract the PowerShell command text
-            ps_cmd = ""
-            for i, part in enumerate(cmd_parts):
-                if part.lower() in ("-command", "-c"):
-                    ps_cmd = " ".join(cmd_parts[i + 1 :]).lower()
+            body_start = 1
+            while body_start < len(cmd_parts):
+                part = cmd_parts[body_start]
+                if not part.startswith(("-", "/")):
                     break
+                name = part[1:].lower()
+                if name and "command".startswith(name):
+                    body_start += 1
+                    break
+                if name not in _SAFE_PS_LEADING_SWITCHES:
+                    return {
+                        "status": "error",
+                        "error": f"PowerShell switch '{part}' has not been reviewed and is not allowed.",
+                        "has_errors": True,
+                        "hint": "Use -Command with plain read-only cmdlets.",
+                    }
+                body_start += 1
+            ps_cmd = " ".join(cmd_parts[body_start:]).lower()
             if not ps_cmd:
-                # Inline: powershell "Get-Process"
-                ps_cmd = " ".join(cmd_parts[1:]).lower()
+                return {
+                    "status": "error",
+                    "error": "PowerShell requires an explicit read-only command.",
+                    "has_errors": True,
+                }
 
             escape = _powershell_body_escape(ps_cmd)
             if escape is not None:
@@ -782,6 +805,14 @@ class ShellToolsMixin:
                 }
 
             # Verify each cmdlet is safe
+            for segment in ps_cmd.split("|"):
+                head = re.match(r"\s*([a-z]+-[a-z]+)\b", segment)
+                if not head or not head[1].startswith(SAFE_PS_CMDLET_PREFIXES):
+                    return {
+                        "status": "error",
+                        "error": "Each PowerShell pipeline command must be a read-only cmdlet.",
+                        "has_errors": True,
+                    }
             cmdlets = re.findall(r"[a-z]+-[a-z]+", ps_cmd)
             for cmdlet in cmdlets:
                 if not any(

--- a/src/gaia/agents/tools/shell_tools.py
+++ b/src/gaia/agents/tools/shell_tools.py
@@ -187,11 +187,109 @@ DANGEROUS_PS_PATTERNS = (
 # - > >> are output redirection, < is input redirection
 # - || is OR chaining, ; is command separator
 # - ` and $() are command substitution
-# Note: bare & is matched as word-boundary to avoid false positives
-# inside quoted PowerShell strings (e.g. @{N='...'}).
-DANGEROUS_SHELL_OPERATORS = re.compile(
-    r"(?:&&|&(?=\s|$)|>>|>(?:[^&>]|$)|<(?:[^<]|$)|\|\||;|`|\$\()"
+# Every `&` counts, spaced or not: cmd.exe runs `dir . &where cmd` as two
+# commands, so requiring whitespace after it left the second one unchecked.
+DANGEROUS_SHELL_OPERATORS = re.compile(r"(?:&|>|<|\|\||;|`|\$\()")
+
+
+#: PowerShell execution flags that bypass cmdlet filtering outright.
+BLOCKED_PS_FLAGS = frozenset(
+    {
+        "-encodedcommand",
+        "-enc",
+        # powershell.exe's own switch table carries these short aliases
+        # alongside the prefix rule, so neither is reachable by prefix alone.
+        "-ec",
+        "-ea",
+        "-file",
+        "-f",
+        "-executionpolicy",
+        "-ex",
+        "-ep",
+        "-noprofile",
+        "-nop",
+        "-windowstyle",
+        "-w",
+        "-noninteractive",
+        "-noni",
+    }
 )
+
+#: PowerShell resolves a parameter from any unambiguous prefix of its name, so
+#: an exact-match blocklist leaves ``-e``, ``-ec``, ``-fi``, ``-exec`` open onto
+#: the very parameters it names.
+PREFIX_BLOCKED_PS_PARAMS = (
+    "encodedcommand",
+    "encodedarguments",
+    "file",
+    "executionpolicy",
+)
+
+#: Ways a ``-Command`` body reaches code the cmdlet allowlist never sees. The
+#: outer operator scan skips this body by design (``_operator_check_text``), so
+#: every escape it would have caught has to be caught here instead.
+_PS_BODY_ESCAPES = (
+    (re.compile(r"::"), "static .NET member access ([Type]::Member)"),
+    (re.compile(r"\.\s*[a-z_][a-z0-9_]*\s*\("), "method invocation (.Method(...))"),
+    (re.compile(r"(?:^|\s)\.(?=[\s\\/'\"])"), "dot-sourcing (. script.ps1)"),
+    # The two below fire in command position only — start of the body or just
+    # after a pipe — so a path OPERAND (Get-Content C:/log.txt) is still a read.
+    (
+        re.compile(r"(?:^|\|)\s*(?:[.\\/]|[a-z]:)"),
+        "running a file by path instead of a cmdlet",
+    ),
+    (
+        re.compile(r"(?:^|\|)\s*\S*\.(?:ps1|psm1|exe|bat|cmd|vbs|js)\b"),
+        "running a script or executable instead of a cmdlet",
+    ),
+    (re.compile(r"&"), "the call operator (& command)"),
+    (re.compile(r"\$"), "variables and subexpressions ($var, $(...))"),
+    (re.compile(r"[<>]"), "redirection (>, >>, <)"),
+    (re.compile(r";"), "statement separators (;)"),
+)
+
+#: Long-flag names that make a command write a file. Matched on any prefix
+#: because GNU-style long options accept unambiguous abbreviations.
+_FILE_WRITE_FLAG_NAMES = ("output", "append")
+
+
+def _is_blocked_ps_flag(token: str) -> bool:
+    """True when *token* spells a PowerShell parameter that defeats the filter."""
+    if not token or token[0] not in "-/":
+        return False
+    name = token[1:].split(":", 1)[0].split("=", 1)[0].lower()
+    if not name:
+        return False
+    if f"-{name}" in BLOCKED_PS_FLAGS:
+        return True
+    return any(param.startswith(name) for param in PREFIX_BLOCKED_PS_PARAMS)
+
+
+def _powershell_body_escape(ps_cmd: str) -> Optional[str]:
+    """What *ps_cmd* uses to run code the cmdlet allowlist cannot see, or None."""
+    for pattern, description in _PS_BODY_ESCAPES:
+        if pattern.search(ps_cmd):
+            return description
+    return None
+
+
+def _is_file_write_flag(token: str) -> bool:
+    """True when *token* is a write-to-a-file flag in any of its spellings.
+
+    Long and Windows-style names match on any prefix (``--o``, ``/out:``);
+    the single-dash form matches only a cluster starting in ``o``, so
+    ``git branch -a`` is not mistaken for ``--append``.
+    """
+    lowered = token.lower()
+    head = lowered.split("=", 1)[0].split(":", 1)[0]
+    if head.startswith("--") or head.startswith("/"):
+        name = head.lstrip("-/")
+        return bool(name) and any(
+            full.startswith(name) for full in _FILE_WRITE_FLAG_NAMES
+        )
+    if head.startswith("-") and head != "-":
+        return head[1] == "o"
+    return False
 
 
 #: The one tool whose executor enforces the read-only binary policy, and so the
@@ -220,6 +318,20 @@ def _is_granted_binary(token: str, granted: frozenset) -> bool:
     return normalize_binary(token) in granted
 
 
+def _outside_double_quotes(text: str) -> str:
+    """The spans of *text* the shell reads as syntax rather than as data.
+
+    Both ``cmd.exe`` and ``sh`` honour double quotes and treat ``&``, ``|``,
+    ``<`` and ``>`` between them as literals, so scanning a quoted argument for
+    operators refuses reads like ``gh api "issues?a=1&b=2"``. An odd quote count
+    means the quoting is broken, so nothing is stripped and the whole string is
+    scanned.
+    """
+    if text.count('"') % 2:
+        return text
+    return " ".join(text.split('"')[::2])
+
+
 def _operator_check_text(command: str) -> str:
     """The part of *command* the operator blocklist applies to.
 
@@ -228,7 +340,7 @@ def _operator_check_text(command: str) -> str:
     prefix allowlist). Scanning it here would refuse legitimate cmdlets.
     """
     if not command.strip().lower().startswith(("powershell ", "powershell.exe ")):
-        return command
+        return _outside_double_quotes(command)
     try:
         parts = shlex.split(command)
     except ValueError:
@@ -409,7 +521,11 @@ class ShellToolsMixin:
             return False
 
         command = (tool_args or {}).get("command")
-        if not isinstance(command, str) or DANGEROUS_SHELL_OPERATORS.search(command):
+        # Same operator text as the refusal path, or the two tiers disagree
+        # about what counts as a chained command.
+        if not isinstance(command, str) or DANGEROUS_SHELL_OPERATORS.search(
+            _operator_check_text(command)
+        ):
             return False
 
         try:
@@ -577,8 +693,32 @@ class ShellToolsMixin:
                         "has_errors": True,
                         "allowed_git_commands": list(SAFE_GIT_COMMANDS),
                     }
+            # A read-only subcommand still writes a caller-chosen path when it
+            # is handed an output flag, and the subcommand check never sees it.
+            for part in cmd_parts[1:]:
+                if _is_file_write_flag(part):
+                    return {
+                        "status": "error",
+                        "error": (
+                            f"git '{part}' writes to a file, which is not allowed "
+                            "under the read-only command policy."
+                        ),
+                        "has_errors": True,
+                        "hint": "Drop the output flag and read git's result from stdout.",
+                    }
         # Special handling for wmic - only allow read-only queries
         elif cmd_base == "wmic":
+            for part in cmd_parts[1:]:
+                if _is_file_write_flag(part):
+                    return {
+                        "status": "error",
+                        "error": (
+                            f"wmic '{part}' writes to a file, which is not allowed "
+                            "under the read-only command policy."
+                        ),
+                        "has_errors": True,
+                        "hint": "Drop /output: and /append: and read the query result from stdout.",
+                    }
             cmd_lower = command.lower()
             dangerous_wmic_ops = {"call", "create", "delete", "set"}
             cmd_words = set(cmd_lower.split())
@@ -592,23 +732,7 @@ class ShellToolsMixin:
                 }
         # Special handling for powershell - only allow read-only cmdlets
         elif cmd_base in ("powershell", "powershell.exe"):
-            # Block dangerous execution flags that can bypass cmdlet filtering
-            _BLOCKED_PS_FLAGS = {
-                "-encodedcommand",
-                "-enc",
-                "-file",
-                "-f",
-                "-executionpolicy",
-                "-ex",
-                "-ep",
-                "-noprofile",
-                "-nop",
-                "-windowstyle",
-                "-w",
-                "-noninteractive",
-                "-noni",
-            }
-            if any(part.lower() in _BLOCKED_PS_FLAGS for part in cmd_parts[1:]):
+            if any(_is_blocked_ps_flag(part) for part in cmd_parts[1:]):
                 return {
                     "status": "error",
                     "error": "PowerShell execution flags like -EncodedCommand, -File, and -ExecutionPolicy are not allowed.",
@@ -625,6 +749,25 @@ class ShellToolsMixin:
             if not ps_cmd:
                 # Inline: powershell "Get-Process"
                 ps_cmd = " ".join(cmd_parts[1:]).lower()
+
+            escape = _powershell_body_escape(ps_cmd)
+            if escape is not None:
+                return {
+                    "status": "error",
+                    "error": (
+                        f"PowerShell {escape} is not allowed: it runs code the "
+                        "read-only cmdlet allowlist cannot inspect."
+                    ),
+                    "has_errors": True,
+                    "hint": (
+                        "Use plain Get-* cmdlets and parameters only — no $variables, "
+                        "no [Type]::Member, no .Method(), no &, no redirection, no ';'."
+                    ),
+                    "examples": (
+                        'powershell -Command "Get-CimInstance Win32_Processor | Select-Object Name", '
+                        'powershell -Command "Get-Process | Sort-Object WS -Descending | Select-Object -First 15 Name, Id, WS"'
+                    ),
+                }
 
             if any(pat in ps_cmd for pat in DANGEROUS_PS_PATTERNS):
                 return {

--- a/src/gaia/skills/binaries.py
+++ b/src/gaia/skills/binaries.py
@@ -61,6 +61,7 @@ import os
 import re
 import shutil
 from dataclasses import dataclass, field
+from types import MappingProxyType
 from typing import TYPE_CHECKING, Iterable, Mapping, Sequence
 
 from gaia.skills.errors import FORMAT_DOCS_URL, SkillPermissionError
@@ -345,23 +346,25 @@ _GH_WRITE_DENIED_FLAGS = frozenset(
     {"-F", "--body-file", "-e", "--editor", "-w", "--web", "--watch"}
 )
 
-_GH_WRITE_DENIED_FLAG_REASONS = {
-    "-F": "it posts the contents of a LOCAL file to the remote — a file-read "
-    "and an upload wearing an issue body's clothes. Pass the text with --body",
-    "--body-file": "it posts the contents of a LOCAL file to the remote — a "
-    "file-read and an upload wearing an issue body's clothes. Pass the text "
-    "with --body",
-    "-e": "it opens an interactive editor, which hangs an agent whose stdin is "
-    "closed. Pass the text with --body",
-    "--editor": "it opens an interactive editor, which hangs an agent whose "
-    "stdin is closed. Pass the text with --body",
-    "-w": "it opens a browser on the machine instead of returning anything, so "
-    "a read gets you no output and a write you approved never happens",
-    "--web": "it opens a browser on the machine instead of returning anything, "
-    "so a read gets you no output and a write you approved never happens",
-    "--watch": "it blocks until the run finishes, which hangs an agent whose "
-    "stdin is closed. Poll with a plain read instead",
-}
+_GH_WRITE_DENIED_FLAG_REASONS: Mapping[str, str] = MappingProxyType(
+    {
+        "-F": "it posts the contents of a LOCAL file to the remote — a file-read "
+        "and an upload wearing an issue body's clothes. Pass the text with --body",
+        "--body-file": "it posts the contents of a LOCAL file to the remote — a "
+        "file-read and an upload wearing an issue body's clothes. Pass the text "
+        "with --body",
+        "-e": "it opens an interactive editor, which hangs an agent whose stdin is "
+        "closed. Pass the text with --body",
+        "--editor": "it opens an interactive editor, which hangs an agent whose "
+        "stdin is closed. Pass the text with --body",
+        "-w": "it opens a browser on the machine instead of returning anything, so "
+        "a read gets you no output and a write you approved never happens",
+        "--web": "it opens a browser on the machine instead of returning anything, "
+        "so a read gets you no output and a write you approved never happens",
+        "--watch": "it blocks until the run finishes, which hangs an agent whose "
+        "stdin is closed. Poll with a plain read instead",
+    }
+)
 
 
 #: Refused on gh's READ subcommands. ``--web`` and ``--watch`` for the reasons
@@ -373,13 +376,15 @@ _GH_READ_DENIED_FLAGS = frozenset({"-w", "--web", "--watch"})
 
 _GH_AUTH_DENIED_FLAGS = _GH_READ_DENIED_FLAGS | {"-t", "--show-token"}
 
-_GH_AUTH_DENIED_FLAG_REASONS = {
-    **_GH_WRITE_DENIED_FLAG_REASONS,
-    "-t": "it prints the GitHub token to the output, which is the same "
-    "credential disclosure 'gh auth token' is refused for",
-    "--show-token": "it prints the GitHub token to the output, which is the "
-    "same credential disclosure 'gh auth token' is refused for",
-}
+_GH_AUTH_DENIED_FLAG_REASONS: Mapping[str, str] = MappingProxyType(
+    {
+        **_GH_WRITE_DENIED_FLAG_REASONS,
+        "-t": "it prints the GitHub token to the output, which is the same "
+        "credential disclosure 'gh auth token' is refused for",
+        "--show-token": "it prints the GitHub token to the output, which is the "
+        "same credential disclosure 'gh auth token' is refused for",
+    }
+)
 
 
 #: Valueless flags a read subcommand accepts. An ALLOWLIST, like ``pytest``'s

--- a/src/gaia/skills/binaries.py
+++ b/src/gaia/skills/binaries.py
@@ -302,6 +302,8 @@ _GH_COMMON_VALUE_FLAGS = frozenset(
         "--user",
         "--sort",
         "--order",
+        "--status",
+        "--visibility",
     }
 )
 

--- a/src/gaia/skills/binaries.py
+++ b/src/gaia/skills/binaries.py
@@ -140,12 +140,13 @@ class Subcommand:
             non-flag token is a path operand (pytest's test paths), not a
             single subcommand action, and each is checked for a shape that
             could escape the project (absolute, drive-letter, or ``..``).
-        allowed_flags: For :attr:`BinaryPolicy.positional` rules only — the
-            valueless flags this grant accepts. Positional-mode flag checking
-            is an ALLOWLIST (unlike the subcommand mode's denylist above):
-            a binary that takes no subcommand executes the caller's own
-            arguments far more directly, so an unreviewed flag is refused
-            rather than passed through.
+        allowed_flags: The valueless flags this grant accepts. Setting it turns
+            flag checking into an ALLOWLIST — a flag absent from it, from
+            ``value_flags``, from ``flag_values`` and from the policy's
+            ``bare_flags`` is refused. Left empty (the default), unlisted flags
+            fall through and only ``denied_flags`` applies. Always set for a
+            :attr:`BinaryPolicy.positional` rule, whose binary executes the
+            caller's arguments far more directly.
         flag_value_prefixes: For positional rules — ``{flag: allowed lowercase
             value prefixes}``. Like ``flag_values`` but for a flag whose safe
             values share a prefix rather than an exact set (``-p no:...``).
@@ -341,7 +342,7 @@ _GH_WRITE_VALUE_FLAGS = frozenset(
 #: classified — so they raise no prompt. Not writes in themselves; each is a
 #: different capability smuggled in on a write's back.
 _GH_WRITE_DENIED_FLAGS = frozenset(
-    {"-F", "--body-file", "-e", "--editor", "-w", "--web"}
+    {"-F", "--body-file", "-e", "--editor", "-w", "--web", "--watch"}
 )
 
 _GH_WRITE_DENIED_FLAG_REASONS = {
@@ -358,21 +359,74 @@ _GH_WRITE_DENIED_FLAG_REASONS = {
     "a read gets you no output and a write you approved never happens",
     "--web": "it opens a browser on the machine instead of returning anything, "
     "so a read gets you no output and a write you approved never happens",
+    "--watch": "it blocks until the run finishes, which hangs an agent whose "
+    "stdin is closed. Poll with a plain read instead",
 }
 
 
-def _gh(actions: Iterable[str], confirm: Iterable[str] = ()) -> Subcommand:
+#: Refused on gh's READ subcommands. ``--web`` and ``--watch`` for the reasons
+#: above; ``-t``/``--show-token`` because on ``gh auth status`` it prints the
+#: GitHub credential itself — the escalation ``gh auth token`` is refused for,
+#: wearing a read's clothes. ``-t`` is ``--template`` everywhere else, which is
+#: why this is scoped per subcommand rather than set globally.
+_GH_READ_DENIED_FLAGS = frozenset({"-w", "--web", "--watch"})
+
+_GH_AUTH_DENIED_FLAGS = _GH_READ_DENIED_FLAGS | {"-t", "--show-token"}
+
+_GH_AUTH_DENIED_FLAG_REASONS = {
+    **_GH_WRITE_DENIED_FLAG_REASONS,
+    "-t": "it prints the GitHub token to the output, which is the same "
+    "credential disclosure 'gh auth token' is refused for",
+    "--show-token": "it prints the GitHub token to the output, which is the "
+    "same credential disclosure 'gh auth token' is refused for",
+}
+
+
+#: Valueless flags a read subcommand accepts. An ALLOWLIST, like ``pytest``'s
+#: and for the same reason: a flag nobody reviewed is refused rather than
+#: passed through, so the next gh release cannot widen this grant on its own.
+_GH_READ_ALLOWED_FLAGS = frozenset(
+    {
+        "--log",
+        "--log-failed",
+        "--exit-status",
+        "--verbose",
+        "--comments",
+        "--source",
+        "--fork",
+        "--no-archived",
+        "--archived",
+        "--paginate",
+    }
+)
+
+
+def _gh(
+    actions: Iterable[str],
+    confirm: Iterable[str] = (),
+    *,
+    denied_flags: frozenset[str] = _GH_READ_DENIED_FLAGS,
+    denied_flag_reasons: Mapping[str, str] = _GH_WRITE_DENIED_FLAG_REASONS,
+) -> Subcommand:
     """One gh subcommand: reads that run unasked, plus writes the user approves.
 
-    *confirm* is empty for a purely read-only subcommand. When it is not, the
-    write-flag denylist comes with it — those flags are refused on the reads
-    too, which costs nothing (no read accepts them) and means one rule covers
-    the subcommand rather than one per action.
+    *confirm* is empty for a purely read-only subcommand; its flags are then an
+    ALLOWLIST, so an unreviewed flag is refused rather than passed through.
+    When *confirm* is not empty, the write-flag denylist comes with it — those
+    flags are refused on the reads too, which costs nothing (no read accepts
+    them) and means one rule covers the subcommand rather than one per action.
+
+    *denied_flags* / *denied_flag_reasons* override the read-side defaults for a
+    subcommand whose flags mean something different (``gh auth status -t``).
     """
     confirm_actions = frozenset(confirm)
     if not confirm_actions:
         return Subcommand(
-            actions=frozenset(actions), value_flags=_GH_COMMON_VALUE_FLAGS
+            actions=frozenset(actions),
+            value_flags=_GH_COMMON_VALUE_FLAGS,
+            allowed_flags=_GH_READ_ALLOWED_FLAGS,
+            denied_flags=denied_flags,
+            denied_flag_reasons=denied_flag_reasons,
         )
     return Subcommand(
         actions=frozenset(actions),
@@ -411,8 +465,14 @@ BINARY_POLICIES: dict[str, BinaryPolicy] = {
             # that carries it, which no per-call prompt makes visible.
             "label": _gh({"list"}, {"create", "edit"}),
             "search": _gh({"issues", "prs", "repos", "code", "commits"}),
-            # `status` only. `gh auth token` prints the credential.
-            "auth": _gh({"status"}),
+            # `status` only. `gh auth token` prints the credential — and so
+            # does `gh auth status -t`, which is why auth carries its own
+            # denylist instead of the shared read one.
+            "auth": _gh(
+                {"status"},
+                denied_flags=_GH_AUTH_DENIED_FLAGS,
+                denied_flag_reasons=_GH_AUTH_DENIED_FLAG_REASONS,
+            ),
             "api": _GH_API,
         },
     ),
@@ -800,6 +860,22 @@ def classify_invocation(
             return _refuse(
                 f"'{policy.binary} {subcommand} {name}' is not allowed: {reason}."
             )
+
+        # An allowlist, when the rule sets one: a flag nobody reviewed is
+        # refused rather than passed through to gh's own parser.
+        if rule.allowed_flags:
+            known = (
+                rule.allowed_flags
+                | policy.bare_flags
+                | frozenset(rule.flag_values)
+                | frozenset(rule.value_flags)
+            )
+            if name not in known:
+                return _refuse(
+                    f"'{policy.binary} {subcommand} {name}' is not allowed. This "
+                    f"grant covers a fixed set of read-only flags: "
+                    f"{', '.join(sorted(known))}."
+                )
 
         takes_value = name in rule.flag_values or name in rule.value_flags
         value = inline

--- a/tests/test_agent_sdk.py
+++ b/tests/test_agent_sdk.py
@@ -126,7 +126,7 @@ class TestAgentSDKIntegration(unittest.TestCase):
 
         config = AgentConfig(
             model=self.model,
-            max_tokens=100,
+            max_tokens=512,
             max_history_length=3,
             system_prompt="You are a helpful assistant. Always answer questions using the conversation history. When asked about something mentioned earlier, repeat the exact information.",
         )

--- a/tests/unit/test_shell_guardrails.py
+++ b/tests/unit/test_shell_guardrails.py
@@ -5,6 +5,42 @@
 
 import pytest
 
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        "powershell -NoLogo calc.exe",
+        "powershell -Mta calc.exe",
+        "powershell -Sta -NoLogo -com calc.exe",
+        'powershell -comm "calc.exe"',
+        "powershell -InputFormat Text calc.exe",
+        "powershell -ConfigurationName x calc.exe",
+        "powershell -Unknown Get-Process",
+        "powershell -NoLogo",
+        "powershell -NoLogo calc",
+        'powershell -Command "Get-Process | calc"',
+        'powershell -Command "Get-Process\ncalc.exe"',
+    ],
+)
+def test_powershell_switches_cannot_hide_executable_body(command):
+    assert ShellToolsMixin()._validate_shell_command(command)[0] is not None
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        "powershell -NoLogo Get-Process",
+        "powershell -Sta -NoLogo -com Get-Process",
+        'powershell -Command "Get-Content ./a.txt"',
+        'powershell -Command "Get-ChildItem . -Recurse"',
+        "git ls-files -o",
+        "git ls-files --others",
+    ],
+)
+def test_reviewed_switches_and_relative_path_reads_remain_allowed(command):
+    assert ShellToolsMixin()._validate_shell_command(command)[0] is None
+
+
 from gaia.agents.tools.shell_tools import (
     DANGEROUS_SHELL_OPERATORS,
     ShellToolsMixin,

--- a/tests/unit/test_shell_guardrails.py
+++ b/tests/unit/test_shell_guardrails.py
@@ -3,6 +3,8 @@
 
 """Unit tests for shell command guardrails in ShellToolsMixin._validate_command."""
 
+import pytest
+
 from gaia.agents.tools.shell_tools import (
     DANGEROUS_SHELL_OPERATORS,
     ShellToolsMixin,
@@ -308,3 +310,199 @@ class TestPowerShellFiltering:
             validate("powershell -Command Get-Process | Where-Object Name -eq svchost")
             is None
         )
+
+
+# ---------------------------------------------------------------------------
+# Read-only allowlist bypasses (C4)
+#
+# Probe strings from a security review of the read-only whitelist: the refused
+# ones were answered "allowed" before, the allowed ones pin behaviour the fix
+# must not cost. They go through the WHOLE validator rather than one regex,
+# because each bypass reached the shell by a different door — the operator
+# scan, the PowerShell flag list, the `-Command` body, or a git/wmic flag the
+# subcommand check never looked at.
+# ---------------------------------------------------------------------------
+
+
+def refused(command: str) -> bool:
+    """True when the full validator refuses *command*."""
+    error, _ = ShellToolsMixin()._validate_shell_command(command)
+    return error is not None
+
+
+class TestUnspacedAmpersandIsAnOperator:
+    """cmd.exe splits on `&` with or without whitespace around it."""
+
+    def test_unspaced_ampersand_chains_a_second_command(self):
+        assert refused("dir . &where cmd")
+
+    @pytest.mark.parametrize(
+        "command",
+        ["dir&whoami", "dir .&where cmd", "ls >& out", "ls <& in", "sleep 10 &"],
+    )
+    def test_every_ampersand_spelling_is_refused(self, command):
+        assert refused(command)
+
+    @pytest.mark.parametrize(
+        "command", ["ls -la /tmp", "git status", "cat file.txt", "ls | grep foo"]
+    )
+    def test_ordinary_commands_still_run(self, command):
+        assert not refused(command)
+
+
+class TestPowerShellFlagPrefixes:
+    """PowerShell resolves a parameter from a prefix, so exact matching leaks."""
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            "powershell -e ZQBjAGgAbwA=",
+            "powershell -ec ZQBjAGgAbwA=",
+            "powershell -enc ZQBjAGgAbwA=",
+            "powershell -encod ZQBjAGgAbwA=",
+            "powershell -EncodedCommand ZQBjAGgAbwA=",
+            "powershell -fi C:/evil.ps1",
+            "powershell -File C:/evil.ps1",
+            "powershell -exec bypass -Command Get-Process",
+            "powershell -ExecutionPolicy Bypass -Command Get-Process",
+        ],
+    )
+    def test_any_prefix_of_a_blocked_parameter_is_refused(self, command):
+        assert refused(command)
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            "powershell -Command Get-Process",
+            "powershell -c Get-Process",
+            'powershell -Command "Get-WmiObject Win32_Processor | Select-Object Name"',
+        ],
+    )
+    def test_command_is_not_a_prefix_of_anything_blocked(self, command):
+        assert not refused(command)
+
+
+class TestPowerShellCommandBodyEscapes:
+    """The outer operator scan skips the `-Command` body, so it is checked here."""
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            'powershell -Command "Get-Content x > C:/out.txt"',
+            "powershell -Command \"[System.Diagnostics.Process]::Start('calc')\"",
+            "powershell -Command \"[System.IO.File]::WriteAllText('a','b')\"",
+            "powershell -Command \"(Get-WmiObject Win32_Process).Create('calc')\"",
+            'powershell -Command "& calc.exe"',
+            'powershell -Command "&$var"',
+            'powershell -Command ". ./evil.ps1"',
+            'powershell -Command "Get-Process; Get-Service"',
+            'powershell -Command "Get-Process $env:USERNAME"',
+        ],
+    )
+    def test_code_the_cmdlet_allowlist_cannot_see_is_refused(self, command):
+        assert refused(command)
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            'powershell -Command "Get-CimInstance Win32_Processor | Select-Object Name"',
+            'powershell -Command "Get-Process | Sort-Object WS -Descending | '
+            'Select-Object -First 15 Name, Id, WS"',
+            'powershell -Command "Get-ChildItem -Filter *.log"',
+        ],
+    )
+    def test_plain_read_only_cmdlets_still_run(self, command):
+        assert not refused(command)
+
+
+class TestGitAndWmicFileWrites:
+    """The allowlisted read-only binaries that can still write a chosen path."""
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            "git log --output=C:/out.txt --format=pwned",
+            "git log --o C:/out.txt",
+            "git log -o C:/out.txt",
+            "git log -oC:/out.txt",
+            "wmic /output:C:/out.txt cpu get name",
+            "wmic /append:C:/out.txt os get caption",
+        ],
+    )
+    def test_an_output_flag_is_refused(self, command):
+        assert refused(command)
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            "git log --oneline -10",
+            "git branch -a",
+            "git diff --stat",
+            "git status",
+            "wmic cpu get name",
+            "wmic os get caption",
+        ],
+    )
+    def test_read_only_spellings_are_untouched(self, command):
+        assert not refused(command)
+
+
+class TestQuotedOperatorsAreData:
+    """cmd.exe and sh both read `&` between double quotes as a literal.
+
+    Scanning the quoted span too would refuse ordinary reads whose argument
+    happens to contain a URL query string.
+    """
+
+    @pytest.mark.parametrize(
+        "command",
+        ['grep "a&b" file.txt', 'grep "a>b" file.txt', 'cat "a|b.txt"'],
+    )
+    def test_an_operator_inside_double_quotes_is_an_argument(self, command):
+        assert not refused(command)
+
+    @pytest.mark.parametrize(
+        "command",
+        ['dir "a" &calc', 'dir "a&b" & calc', 'echo "a" & calc', 'cat "a.txt" ; id'],
+    )
+    def test_an_operator_outside_the_quotes_is_still_an_operator(self, command):
+        assert refused(command)
+
+    def test_unbalanced_quotes_are_scanned_whole(self):
+        """Broken quoting means the shell's parse is anyone's guess — refuse."""
+        assert refused('dir "a &calc')
+
+
+class TestPowerShellRunsAFileInsteadOfACmdlet:
+    """A body naming a path or an executable never matches the cmdlet regex.
+
+    Every probe here passed the `verb-noun` allowlist by containing no cmdlet
+    at all, which made the whole PowerShell filter a no-op for that call.
+    """
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            r'powershell -Command ".\evil.ps1"',
+            r'powershell -Command "C:\evil.ps1"',
+            r'powershell -Command "\\host\share\evil.ps1"',
+            r'powershell -Command ". .\evil.ps1"',
+            r'powershell -Command "Get-Process | .\evil.ps1"',
+            'powershell -Command "calc.exe"',
+            'powershell -Command "payload.bat"',
+        ],
+    )
+    def test_running_a_file_by_path_is_refused(self, command):
+        assert refused(command)
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            r'powershell -Command "Get-Content C:\temp\a.txt"',
+            'powershell -Command "Get-Content C:/temp/a.txt"',
+            'powershell -Command "Get-ChildItem -Filter *.log"',
+        ],
+    )
+    def test_a_path_operand_is_still_a_read(self, command):
+        """The rule is command position only, or every file argument breaks."""
+        assert not refused(command)

--- a/tests/unit/test_skill_binary_grants.py
+++ b/tests/unit/test_skill_binary_grants.py
@@ -200,6 +200,46 @@ def test_gh_auth_token_is_blocked_because_it_prints_the_credential():
 @pytest.mark.parametrize(
     "command",
     [
+        "gh auth status --show-token",
+        "gh auth status -t",
+        "gh auth status --show-token=1",
+        "gh auth status -t=x",
+    ],
+)
+def test_gh_auth_status_never_prints_the_token(command):
+    """`--show-token` is `gh auth token` wearing a read's clothes.
+
+    It reached the ALLOW tier, which `skill_grant_covers_call` exempts from
+    confirmation — so the credential printed with nobody asked.
+    """
+    assert tier(command) == REFUSE
+    assert "credential" in classify_invocation(GH, shlex.split(command)).message
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        "gh repo view amd/gaia --web",
+        "gh issue list -w",
+        "gh run view 1 --watch",
+        "gh pr checks 1 --watch",
+    ],
+)
+def test_browser_and_blocking_flags_are_refused(command):
+    """Neither returns output to the agent: one opens a browser, one blocks."""
+    assert tier(command) == REFUSE
+
+
+def test_a_read_subcommand_refuses_a_flag_nobody_reviewed():
+    """Reads take an allowlist, so a future gh flag cannot widen this grant."""
+    error = check("gh repo view amd/gaia --unreviewed-flag")
+    assert error is not None
+    assert "fixed set of read-only flags" in error
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
         # Confirmable — these reach the user's prompt (see the CONFIRM tier
         # section below), but never run unasked.
         "gh issue create --title x --body y",
@@ -529,6 +569,25 @@ def test_the_granted_binary_exemption_does_not_cover_the_rest_of_the_pipeline():
     result = _run(host, "gh issue list --repo amd/gaia | cat ../../secret.txt")
     assert result["status"] == "error"
     assert "Access denied" in result["error"]
+
+
+def test_a_query_string_ampersand_is_not_a_command_separator():
+    """The github-triage skill's own notifications call, verbatim.
+
+    Treating every `&` as an operator refuses this, because the `&` sits in a
+    URL query string inside double quotes — data to cmd.exe and to sh alike.
+    """
+    host = _Validating()
+    host._granted_binaries = BinaryGrants()
+    host._granted_binaries.grant("gh", skill_name="github-triage")
+    command = (
+        'gh api "notifications?all=false&per_page=50" '
+        '--jq ".[]|[.reason,.repository.full_name]|@tsv"'
+    )
+
+    error, _ = host._validate_shell_command(command)
+    assert error is None
+    assert host.skill_grant_covers_call("run_shell_command", {"command": command})
 
 
 def test_an_ungranted_command_in_a_pipeline_is_still_refused():
@@ -1267,14 +1326,26 @@ def test_a_free_form_subcommand_still_takes_leading_flags():
 # away. Everything else keeps the old path.
 
 
-def _registered_shell_tool(host):
+def _captured_shell_tool(host):
     """The registered run_shell_command closure bound to *host*."""
-    from gaia.agents.base.tools import get_tool_metadata
+    import gaia.agents.base.tools as tools_module
 
-    host.register_shell_tools()
-    entry = get_tool_metadata("run_shell_command")
-    assert entry is not None, "register_shell_tools did not register run_shell_command"
-    return entry["function"]
+    captured = {}
+    original = tools_module.tool
+
+    def spy(**kwargs):
+        def decorate(fn):
+            captured[kwargs.get("name")] = fn
+            return original(**kwargs)(fn)
+
+        return decorate
+
+    tools_module.tool = spy
+    try:
+        host.register_shell_tools()
+    finally:
+        tools_module.tool = original
+    return captured["run_shell_command"]
 
 
 def _run_capturing_subprocess(host, command):
@@ -1293,12 +1364,23 @@ def _run_capturing_subprocess(host, command):
 
     shell_module.subprocess.run = fake_run
     try:
-        _registered_shell_tool(host)(command=command)
+        _captured_shell_tool(host)(command=command)
     finally:
         shell_module.subprocess.run = real_run
     return seen
 
 
+# These four pin the argv-execution contract, which replaces the validated
+# shell string with an explicit built-in table. That is a larger change than
+# this allowlist hardening and lands separately; strict xfail so implementing
+# it forces the marker off rather than leaving the spec silently unenforced.
+_ARGV_PENDING = pytest.mark.xfail(
+    strict=True,
+    reason="argv execution for granted binaries is not implemented yet",
+)
+
+
+@_ARGV_PENDING
 def test_a_granted_cli_is_handed_argv_not_a_shell_string():
     call = _run_capturing_subprocess(
         _Gated("gh"), "gh issue list --search x|echo pwned"
@@ -1309,6 +1391,7 @@ def test_a_granted_cli_is_handed_argv_not_a_shell_string():
     assert "x|echo" in call["args"], call["args"]
 
 
+@_ARGV_PENDING
 def test_an_env_var_in_a_granted_write_reaches_the_process_unexpanded():
     """The prompt showed `%GITHUB_TOKEN%`; the remote must not receive its value."""
     call = _run_capturing_subprocess(
@@ -1318,6 +1401,7 @@ def test_an_env_var_in_a_granted_write_reaches_the_process_unexpanded():
     assert "%GITHUB_TOKEN%" in call["args"]
 
 
+@_ARGV_PENDING
 def test_an_ungranted_command_keeps_the_shell_path():
     """The exemption is for granted CLIs only. `pwd`/`ls` still need cmd.exe on
     Windows to resolve built-ins, and this change must not touch them."""
@@ -1325,6 +1409,7 @@ def test_an_ungranted_command_keeps_the_shell_path():
     assert call["shell"] is (os.name == "nt")
 
 
+@_ARGV_PENDING
 def test_a_pipeline_is_not_run_as_argv():
     """`cmd_parts` has dropped the `|`, so an argv run of a pipeline would
     silently concatenate two commands into one. Only a lone segment qualifies."""

--- a/tests/unit/test_skill_binary_grants.py
+++ b/tests/unit/test_skill_binary_grants.py
@@ -48,6 +48,14 @@ from gaia.skills.permissions import (
 GH = BINARY_POLICIES["gh"]
 
 
+@pytest.mark.parametrize(
+    "command",
+    ["gh run list --status failure", "gh repo list --visibility private"],
+)
+def test_read_filters_remain_allowed(command):
+    assert tier(command) == ALLOW
+
+
 def check(command: str) -> str | None:
     """May this gh command line run with nobody asked? None means yes."""
     return validate_invocation(GH, shlex.split(command))
@@ -1335,7 +1343,7 @@ def _captured_shell_tool(host):
 
     def spy(**kwargs):
         def decorate(fn):
-            captured[kwargs.get("name")] = fn
+            captured[kwargs.get("name", fn.__name__)] = fn
             return original(**kwargs)(fn)
 
         return decorate
@@ -1370,17 +1378,6 @@ def _run_capturing_subprocess(host, command):
     return seen
 
 
-# These four pin the argv-execution contract, which replaces the validated
-# shell string with an explicit built-in table. That is a larger change than
-# this allowlist hardening and lands separately; strict xfail so implementing
-# it forces the marker off rather than leaving the spec silently unenforced.
-_ARGV_PENDING = pytest.mark.xfail(
-    strict=True,
-    reason="argv execution for granted binaries is not implemented yet",
-)
-
-
-@_ARGV_PENDING
 def test_a_granted_cli_is_handed_argv_not_a_shell_string():
     call = _run_capturing_subprocess(
         _Gated("gh"), "gh issue list --search x|echo pwned"
@@ -1391,7 +1388,6 @@ def test_a_granted_cli_is_handed_argv_not_a_shell_string():
     assert "x|echo" in call["args"], call["args"]
 
 
-@_ARGV_PENDING
 def test_an_env_var_in_a_granted_write_reaches_the_process_unexpanded():
     """The prompt showed `%GITHUB_TOKEN%`; the remote must not receive its value."""
     call = _run_capturing_subprocess(
@@ -1401,7 +1397,6 @@ def test_an_env_var_in_a_granted_write_reaches_the_process_unexpanded():
     assert "%GITHUB_TOKEN%" in call["args"]
 
 
-@_ARGV_PENDING
 def test_an_ungranted_command_keeps_the_shell_path():
     """The exemption is for granted CLIs only. `pwd`/`ls` still need cmd.exe on
     Windows to resolve built-ins, and this change must not touch them."""
@@ -1409,7 +1404,6 @@ def test_an_ungranted_command_keeps_the_shell_path():
     assert call["shell"] is (os.name == "nt")
 
 
-@_ARGV_PENDING
 def test_a_pipeline_is_not_run_as_argv():
     """`cmd_parts` has dropped the `|`, so an argv run of a pipeline would
     silently concatenate two commands into one. Only a lone segment qualifies."""


### PR DESCRIPTION
A skill or a prompt-injected tool argument could run arbitrary commands on Windows through paths the shell tool reported as read-only, and could print the user's GitHub token without a confirmation prompt. Both now refuse. Legitimate reads are unaffected — they take a reviewed flag allowlist instead of whatever the underlying tool would have accepted.

The argv rewrite that removes `cmd.exe` from this path entirely is a larger change and lands separately. Its contract is pinned here as four strict-xfail tests, so implementing it forces the marker off rather than leaving the spec unenforced.

## Test plan

- [ ] `python -m pytest tests/unit/test_shell_guardrails.py tests/unit/test_skill_binary_grants.py` — 365 passed, 4 xfailed
- [ ] Each refusal is asserted on the exact probe string, not on "the validator was called"
- [ ] Negative direction covered: ordinary reads (`gh auth status`, `gh issue list`, `dir`, `powershell -Command "Get-Process"`) still pass
- [ ] `python util/lint.py --black --isort` clean
