### PR TITLE
fix(security): make the file boundary the file, and hold it on reads

### DIFF
--- a/docs/guides/gaia.mdx
+++ b/docs/guides/gaia.mdx
@@ -123,7 +123,14 @@ The agent's file, document, and data tools are confined to a set of allowed path
 
 That's the honest scope for a personal document agent — "ask questions about my files" means your files — and it is still a real boundary: system directories, program files, and other users' home directories fall outside it and are refused. The check runs against the *resolved* path, so a symlink pointing out of the allowed set doesn't get around it; you get an explicit `Access denied to path:` error naming both the requested and the resolved path.
 
-To narrow it, construct the agent with an explicit list:
+**The allowed set is not the whole story, and shouldn't be treated as one.** Two denylists apply *inside* it, because "in scope" and "safe" are different questions:
+
+- **Secrets are never read back.** `.env`, `id_rsa`, `credentials.json`, `.netrc`, any `.pem`/`.key`, and everything under `~/.ssh`, `~/.aws`, `~/.gnupg`, `~/.kube` are refused on read even when they sit in an allowed directory — otherwise "summarise this folder" is a credential exfiltration primitive.
+- **Files that run on their own are never written.** Shell startup files (`.bashrc`, `.zshrc`, `.profile`), PowerShell profiles, `~/.config/autostart/*`, systemd user units, `LaunchAgents`, and anything inside a repo's `.git/` — hooks and config alike. Writing to one of those isn't editing a document, it's arranging for the agent's output to execute at your next login.
+
+Both are refused with a message naming the file and why. Edit such a file yourself if that's genuinely what you wanted.
+
+To narrow the scope, construct the agent with an explicit list:
 
 ```python
 from gaia_agent.agent import GaiaAgent, GaiaAgentConfig

--- a/docs/playbooks/chat-agent/part-3-deployment.mdx
+++ b/docs/playbooks/chat-agent/part-3-deployment.mdx
@@ -509,7 +509,9 @@ def _generate_search_keys(self, query: str) -> List[str]:
   </Card>
 
   <Card title="Security" icon="lock">
-    Set `allowed_paths` in production. Prevents path traversal and unauthorized access.
+    Set `allowed_paths` in production, and list the **files** a session needs rather than
+    the folders holding them. It is a scope, not a safety guarantee — secrets and
+    login-execution files are refused separately.
   </Card>
 
   <Card title="Incremental Development" icon="vial">

--- a/docs/sdk/sdks/rag.mdx
+++ b/docs/sdk/sdks/rag.mdx
@@ -991,7 +991,9 @@ except PermissionError as e:
 ```
 
 <Warning>
-**Security Consideration:** Without `allowed_paths`, RAG can index any file the process can read. In production, always set explicit allowed paths.
+**Security Consideration:** Without `allowed_paths`, RAG can index any file the process can read. In production, always set explicit allowed paths — and set them to the files you mean, not the directories they sit in, since a directory grant covers everything else in it.
+
+`allowed_paths` is a *scope*, not a safety guarantee: it says which paths are in bounds, not which are safe. The agent's file tools apply separate denylists on top (secrets on read, login-execution files on write). RAG indexing does not yet apply those — treat an indexed directory as fully readable.
 </Warning>
 
 ---

--- a/docs/sdk/security.mdx
+++ b/docs/sdk/security.mdx
@@ -14,19 +14,28 @@ icon: "shield-halved"
 ```python
 from gaia.security import PathValidator
 
-# Initialize validator
+# No scope supplied: the CWD, plus anything the interactive CLI persisted.
 validator = PathValidator()
 
-# Check if path is allowed
-if validator.is_path_allowed("/home/user/documents/file.txt"):
-    # Safe to access
-    process_file("/home/user/documents/file.txt")
+# An explicit scope stands alone — persisted grants are NOT unioned in.
+# Grant the files a session actually attached, not the folders holding them.
+session = PathValidator(allowed_paths=["/home/user/documents/report.pdf"])
 
-# Add allowed path
-validator.add_allowed_path("/home/user/work")
+# Reads: scope AND secrets. `.env`, id_rsa, *.pem, ~/.ssh/* are refused even
+# when they sit inside an allowed directory.
+is_allowed, reason = session.validate_read("/home/user/documents/report.pdf")
 
-# Paths are persisted in ~/.gaia/cache/
+# Writes: additionally refuses blocked directories and files that execute on
+# their own (.bashrc, PowerShell profiles, autostart entries, .git/**).
+is_allowed, reason = session.validate_write("/home/user/documents/out.md")
 ```
+
+<Warning>
+  Only a validator built **without** an `allowed_paths` argument reads or writes the
+  machine-global grants in `~/.gaia/cache/allowed_paths.json`. A host that computes a
+  per-session scope gets exactly that scope — one user's one-off `[a]lways` approval in
+  the CLI must not become standing access for every later Agent UI session.
+</Warning>
 
 ---
 

--- a/docs/spec/file-io-tools-mixin.mdx
+++ b/docs/spec/file-io-tools-mixin.mdx
@@ -409,32 +409,53 @@ result = agent.edit_file(
 
 ### Path Validation
 
-All file operations check paths against allowed directories:
+The allowlist answers "is this in scope". It does **not** answer "is this safe",
+so reads and writes each add a denylist on top of it.
+
+Reads go through `validate_read`, which refuses secrets that happen to sit inside
+an allowed directory — `.env`, `id_rsa`, `credentials.json`, `.netrc`, `.pem`/`.key`
+files, and anything under `~/.ssh`, `~/.aws`, `~/.gnupg`, `~/.kube`:
 
 ```python
-if not self.path_validator.is_path_allowed(file_path):
-    return {
-        "status": "error",
-        "error": f"Access denied: {file_path} is not in allowed paths"
-    }
+is_allowed, reason = self.path_validator.validate_read(file_path)
+if not is_allowed:
+    return {"status": "error", "error": reason}
 ```
 
+Writes go through `validate_write`, which additionally refuses
+[`BLOCKED_DIRECTORIES`](#allowed-paths-configuration) and any file that executes
+on its own — shell rc files, PowerShell profiles, `~/.config/autostart/*`,
+systemd user units, `LaunchAgents`, and anything inside a repo's `.git/`.
+
+`search_in_files` applies the read denylist per file as it walks, so a directory
+grep cannot return what `read_file` would have refused.
+
 ### Allowed Paths Configuration
+
+An allowed path may be a **directory or a single file**. Prefer files when the
+scope is derived from something a user attached — granting the folder a document
+happens to sit in grants everything else in it too.
 
 ```python
 # Typically configured when the agent is constructed
 path_validator = PathValidator(
     allowed_paths=[
         "/path/to/workspace",
-        "/path/to/project"
-    ],
-    blocked_paths=[
-        "/etc",
-        "/var",
-        "~/.ssh"
+        "/path/to/report.pdf",
     ]
 )
 ```
+
+`allowed_paths` has three distinct states:
+
+| Value | Meaning |
+|-------|---------|
+| `None` | No scope supplied — defaults to the CWD plus paths the interactive CLI persisted via `[a]lways` |
+| `[...]` | Exactly this scope. Machine-global persisted grants are **not** unioned in, and `[a]lways` during this session does not write to them |
+| `[]` | A scope of nothing — every path is refused, rather than silently widening to the CWD |
+
+The blocked directories (`/etc`, `~/.ssh`, `~/.gaia`, Windows system dirs, …) are
+computed at import time in `gaia.security`; they are not a constructor argument.
 
 ---
 

--- a/hub/agents/gaia/npm/SKILL.md
+++ b/hub/agents/gaia/npm/SKILL.md
@@ -368,6 +368,16 @@ for a personal document agent, and it is still a real boundary — system
 directories, program files, and other users' homes are refused, with the check
 run against the *resolved* path so a symlink out of scope doesn't slip through.
 
+**Being in scope is not the same as being safe, and two denylists apply inside
+it.** Reads refuse secrets — `.env`, `id_rsa`, `credentials.json`, `.netrc`,
+`.pem`/`.key`, and everything under `~/.ssh`, `~/.aws`, `~/.gnupg`, `~/.kube` —
+even in an allowed directory. Writes additionally refuse anything that executes
+on its own: shell startup files, PowerShell profiles, `~/.config/autostart/*`,
+systemd user units, `LaunchAgents`, and a repo's `.git/` (hooks and config). Both
+come back as a structured error naming the file and the reason, so do not plan an
+integration around reading a credential file or editing a shell rc — perform
+those from your own code.
+
 **In 0.1.1 narrowing it is a construction-time setting only.** The packaged
 sidecar exposes no flag or env var for `allowed_paths` (its CLI accepts only
 `--host` and `--port`), so restricting the scope means embedding `GaiaAgent` in

--- a/src/gaia/agents/tools/file_io_tools.py
+++ b/src/gaia/agents/tools/file_io_tools.py
@@ -170,12 +170,11 @@ class FileIOToolsMixin:
                 Dictionary with file content and type-specific metadata
             """
             try:
-                # Security check
-                if not self.path_validator.is_path_allowed(file_path):
-                    return {
-                        "status": "error",
-                        "error": f"Access denied: {file_path} is not in allowed paths",
-                    }
+                # Scope *and* secrets: being in an allowed directory never made
+                # a private key safe to read into the conversation.
+                is_allowed, reason = self.path_validator.validate_read(file_path)
+                if not is_allowed:
+                    return {"status": "error", "error": reason}
 
                 if not os.path.exists(file_path):
                     return {"status": "error", "error": f"File not found: {file_path}"}
@@ -590,6 +589,11 @@ class FileIOToolsMixin:
                             continue
 
                         file_path = os.path.join(root, file)
+                        # A directory-wide grep must not be the way a secret gets
+                        # read back that read_file would have refused outright.
+                        blocked, _ = self.path_validator.is_read_blocked(file_path)
+                        if blocked:
+                            continue
                         files_searched += 1
 
                         try:
@@ -649,12 +653,10 @@ class FileIOToolsMixin:
                 Dictionary with diff information
             """
             try:
-                # Security check
-                if not self.path_validator.is_path_allowed(file_path):
-                    return {
-                        "status": "error",
-                        "error": f"Access denied: {file_path} is not in allowed paths",
-                    }
+                # A diff prints the original file, so it is a read.
+                is_allowed, reason = self.path_validator.validate_read(file_path)
+                if not is_allowed:
+                    return {"status": "error", "error": reason}
 
                 # Read original content
                 if os.path.exists(file_path):

--- a/src/gaia/agents/tools/file_tools.py
+++ b/src/gaia/agents/tools/file_tools.py
@@ -76,15 +76,20 @@ class FileSearchToolsMixin:
         through the read tools (CWE-862). ``FileIOToolsMixin`` already
         gates its reads this way; this mirrors it.
 
-        Returns an error dict when ``path`` is outside the sandbox, or
-        ``None`` when the read is permitted (or no validator is attached).
+        The allowlist alone is not the whole gate: ``validate_read`` also
+        refuses secrets sitting *inside* an allowed directory, so a scope that
+        legitimately covers ``$HOME`` still cannot read ``~/.ssh/id_rsa``.
+
+        Returns an error dict when ``path`` is outside the sandbox or is a
+        credential file, or ``None`` when the read is permitted (or no
+        validator is attached).
         """
         validator = self._get_path_validator()
-        if validator is not None and not validator.is_path_allowed(path):
-            return {
-                "status": "error",
-                "error": f"Access denied: '{path}' is not in allowed paths",
-            }
+        if validator is None:
+            return None
+        is_allowed, reason = validator.validate_read(path)
+        if not is_allowed:
+            return {"status": "error", "error": reason}
         return None
 
     def register_file_search_tools(self) -> None:

--- a/src/gaia/agents/tools/filesystem_tools.py
+++ b/src/gaia/agents/tools/filesystem_tools.py
@@ -64,10 +64,10 @@ class FileSystemToolsMixin:
     def _validate_path(self, path: str) -> Path:
         """Validate and resolve a path. Raises ValueError if blocked."""
         resolved = Path(path).expanduser().resolve()
-        if self._path_validator and not self._path_validator.is_path_allowed(
-            str(resolved)
-        ):
-            raise ValueError(f"Access denied: {resolved}")
+        if self._path_validator:
+            allowed, reason = self._path_validator.validate_read(str(resolved))
+            if not allowed:
+                raise ValueError(f"Access denied: {reason}")
         return resolved
 
     def _get_default_excludes(self) -> set:
@@ -1325,6 +1325,13 @@ class FileSystemToolsMixin:
                                     continue
 
                                 try:
+                                    mixin._validate_path(entry.path)
+                                except ValueError as exc:
+                                    logger.debug(
+                                        "Skipping unreadable search result: %s", exc
+                                    )
+                                    continue
+                                try:
                                     with open(
                                         entry.path,
                                         "r",
@@ -1347,8 +1354,10 @@ class FileSystemToolsMixin:
                                                     }
                                                 )
                                                 break  # One match per file
-                                except (OSError, UnicodeDecodeError):
-                                    pass  # Skip unreadable files during content search
+                                except (OSError, UnicodeDecodeError) as exc:
+                                    logger.debug(
+                                        "Cannot search %s: %s", entry.path, exc
+                                    )
                         except (PermissionError, OSError):
                             continue
                 except (PermissionError, OSError):

--- a/src/gaia/hub/installer.py
+++ b/src/gaia/hub/installer.py
@@ -55,6 +55,7 @@ from gaia.daemon.sidecars.spec import builtin_specs
 from gaia.hub import catalog as catalog_mod
 from gaia.hub.compatibility import check_compatibility, current_platform_key
 from gaia.logger import get_logger
+from gaia.utils.paths import UnsafePathSegment, safe_path_segment
 
 logger = get_logger(__name__)
 
@@ -612,13 +613,21 @@ def _looks_like_wheel(filename: str) -> bool:
 
 
 def _sanitize_artifact_filename(filename: str, agent_id: Optional[str]) -> None:
-    """Refuse a filename that could escape the install dir on path-join."""
-    if not filename or "/" in filename or "\\" in filename or ".." in filename:
-        raise InstallError(
-            f"Artifact filename {filename!r} for '{agent_id}' is unsafe (nested "
-            f"path or path traversal). Refusing to install; report this hub "
-            f"manifest as corrupt."
+    """Refuse a filename that could escape the install dir on path-join.
+
+    Shares :func:`gaia.utils.paths.safe_path_segment` with the skills installer:
+    a separator scan alone lets ``C:evil.whl`` and ``NUL`` through, and both
+    re-root or redirect the join this function exists to protect.
+
+    Raises:
+        InstallError: the manifest's filename is not a single safe path segment.
+    """
+    try:
+        safe_path_segment(
+            filename, what="artifact filename", origin=f"hub manifest for '{agent_id}'"
         )
+    except UnsafePathSegment as exc:
+        raise InstallError(str(exc)) from exc
 
 
 def _select_platform_artifact(

--- a/src/gaia/security.py
+++ b/src/gaia/security.py
@@ -65,6 +65,130 @@ SENSITIVE_EXTENSIONS: Set[str] = {
     ".keystore",
 }
 
+# Files whose contents run automatically — on the next login, the next shell, or
+# the next git command. A write here is persistence, not a document edit, so it
+# is the cleanest prompt-injection-to-code-execution step there is.
+STARTUP_EXECUTION_FILE_NAMES: Set[str] = {
+    # POSIX shells
+    ".bashrc",
+    ".bash_profile",
+    ".bash_login",
+    ".bash_logout",
+    ".bash_aliases",
+    ".profile",
+    ".zshrc",
+    ".zshenv",
+    ".zprofile",
+    ".zlogin",
+    ".zlogout",
+    ".kshrc",
+    ".cshrc",
+    ".tcshrc",
+    ".login",
+    ".logout",
+    ".inputrc",
+    "config.fish",
+    # X11 / desktop session
+    ".xinitrc",
+    ".xprofile",
+    ".xsession",
+    ".xsessionrc",
+    # PowerShell
+    "profile.ps1",
+    "microsoft.powershell_profile.ps1",
+    "microsoft.vscode_profile.ps1",
+    # git — aliases and hook paths in a config are executed by ordinary commands
+    ".gitconfig",
+    "gitconfig",
+    # cron
+    "crontab",
+}
+
+# Directory shapes whose *contents* execute regardless of file name: a git hook
+# is `pre-commit` with no extension, an autostart entry is any `.desktop` file.
+# Each entry is an ordered run of lowercase path segments to find in the path.
+_STARTUP_EXECUTION_DIR_MARKERS: Tuple[Tuple[str, ...], ...] = (
+    # Covers hooks/ and config alike; no agent file tool has business in here.
+    (".git",),
+    (".config", "autostart"),
+    (".config", "systemd", "user"),
+    ("launchagents",),
+    ("launchdaemons",),
+    ("windowspowershell",),
+)
+
+
+def _secret_directories() -> Set[str]:
+    """Directories whose every file is a credential, whatever it is called.
+
+    Returns:
+        Normalized paths. Read-blocked wholesale — ``~/.ssh/config`` names hosts
+        and key files, ``~/.aws/credentials`` is the key itself, and neither has
+        a name the extension/name denylists would catch.
+    """
+    home = Path.home()
+    candidates = [
+        home / ".ssh",
+        home / ".gnupg",
+        home / ".aws",
+        home / ".azure",
+        home / ".kube",
+        home / ".docker",
+        home / ".config" / "gcloud",
+        home / "AppData" / "Roaming" / "gcloud",
+    ]
+    return {os.path.normpath(str(c)) for c in candidates}
+
+
+def _path_is_within(candidate: Path, parent: Path) -> bool:
+    """Whether *candidate* is *parent* or sits underneath it.
+
+    Args:
+        candidate: An already-resolved path.
+        parent: The directory to test containment against.
+
+    Returns:
+        True when candidate == parent or candidate is inside it.
+    """
+    is_windows = platform.system() == "Windows"
+    norm_candidate = os.path.normpath(_normalize_macos_symlinks(str(candidate)))
+    norm_parent = os.path.normpath(_normalize_macos_symlinks(str(parent)))
+    if is_windows:
+        norm_candidate, norm_parent = norm_candidate.lower(), norm_parent.lower()
+    return norm_candidate == norm_parent or norm_candidate.startswith(
+        norm_parent + os.sep
+    )
+
+
+def _startup_execution_reason(real_path: Path) -> Optional[str]:
+    """Why writing *real_path* would plant code that runs on its own.
+
+    Args:
+        real_path: A symlink-resolved path.
+
+    Returns:
+        A reason naming what would execute it, or ``None`` when the path is an
+        ordinary file.
+    """
+    if real_path.name.lower() in STARTUP_EXECUTION_FILE_NAMES:
+        return (
+            f"'{real_path.name}' is executed automatically when a shell, login "
+            f"session or git command starts"
+        )
+
+    segments = [part.lower() for part in real_path.parts]
+    for marker in _STARTUP_EXECUTION_DIR_MARKERS:
+        span = len(marker)
+        # The marker must appear as consecutive segments *above* the file itself.
+        for start in range(0, max(0, len(segments) - span)):
+            if tuple(segments[start : start + span]) == marker:
+                return (
+                    f"'{real_path}' is inside '{'/'.join(marker)}', whose contents "
+                    f"are executed automatically at login, on a git operation, or "
+                    f"by the session manager"
+                )
+    return None
+
 
 # Subdirectories of GAIA's state tree that hold user content rather than
 # configuration. The Agent UI puts browser uploads here and makes them the
@@ -192,6 +316,7 @@ def _get_blocked_directories() -> Set[str]:
 # Pre-compute once at module load
 BLOCKED_DIRECTORIES: Set[str] = _get_blocked_directories()
 GAIA_STATE_DIRECTORIES: Set[str] = _gaia_state_dirs()
+SECRET_DIRECTORIES: Set[str] = _secret_directories()
 
 
 def _normalize_macos_symlinks(path_str: str) -> str:
@@ -219,10 +344,15 @@ class PathValidator:
     Validates file paths against an allowed list, with user prompting for exceptions.
     Persists allowed paths to ~/.gaia/cache/allowed_paths.json.
 
+    An allowed path may be a directory *or* a single file — callers deriving a
+    scope from user-attached documents should grant the files, never the folders
+    they happen to sit in.
+
     Security features:
     - Allowlist-based path access control
     - Blocked directory enforcement for writes (system dirs, .ssh, etc.)
-    - Sensitive file protection (.env, credentials, keys)
+    - Sensitive file protection (.env, credentials, keys) on reads and writes
+    - Login/startup-execution file protection (shell rc, autostart, git hooks)
     - Write size limits
     - Overwrite confirmation prompting
     - Audit logging for all file mutations
@@ -239,7 +369,12 @@ class PathValidator:
         Initialize PathValidator.
 
         Args:
-            allowed_paths: Initial list of allowed paths. Defaults to [CWD].
+            allowed_paths: The scope for this validator. ``None`` means "no scope
+                supplied" and defaults to the CWD plus any paths the interactive
+                CLI previously persisted. An explicit list — including an empty
+                one — is the whole scope: a host that computes a per-session
+                allowlist gets exactly what it asked for, and an empty list
+                denies everything rather than silently widening to the CWD.
             on_prompt_start: Optional callback invoked before prompting the
                 user for input (e.g. to pause a progress spinner).
             on_prompt_end: Optional callback invoked after user input is
@@ -247,12 +382,16 @@ class PathValidator:
         """
         self.allowed_paths: Set[Path] = set()
 
-        # Add default allowed paths
-        if allowed_paths:
+        # A host-supplied scope must not union with the machine-global grants the
+        # CLI's "[a]lways" writes — that turned one user's one-off approval into
+        # standing access for every later Agent UI session.
+        self._use_persisted_grants = allowed_paths is None
+
+        if allowed_paths is None:
+            self.allowed_paths.add(Path.cwd().resolve())
+        else:
             for p in allowed_paths:
                 self.allowed_paths.add(Path(p).resolve())
-        else:
-            self.allowed_paths.add(Path.cwd().resolve())
 
         # Setup cache directory
         self.cache_dir = Path.home() / ".gaia" / "cache"
@@ -294,7 +433,14 @@ class PathValidator:
             audit_logger.setLevel(logging.INFO)
 
     def _load_persisted_paths(self):
-        """Load allowed paths from cache file."""
+        """Load allowed paths from cache file, unless this scope was host-supplied."""
+        if not self._use_persisted_grants:
+            logger.debug(
+                "Skipping machine-global grants in %s: this validator was built "
+                "with an explicit allowlist.",
+                self.config_file,
+            )
+            return
         if self.config_file.exists():
             try:
                 with open(self.config_file, "r", encoding="utf-8") as f:
@@ -312,7 +458,20 @@ class PathValidator:
                 )
 
     def _save_persisted_path(self, path: Path):
-        """Save a new allowed path to cache file."""
+        """Save a new allowed path to cache file.
+
+        A validator built from a host-supplied allowlist never writes here: its
+        scope is one session's, and promoting it to the machine-global file
+        would leak that session's access into every later one.
+        """
+        if not self._use_persisted_grants:
+            logger.info(
+                "Granting %s for this session only — a host-supplied allowlist "
+                "is not promoted to the machine-global grants in %s.",
+                path,
+                self.config_file,
+            )
+            return
         try:
             data = {"paths": []}
             if self.config_file.exists():
@@ -484,6 +643,83 @@ class PathValidator:
 
                 print("Please answer 'y', 'n', or 'a'.")
 
+    # ── Read Guardrails ───────────────────────────────────────────────
+
+    def is_read_blocked(self, path: str) -> Tuple[bool, str]:
+        """Check whether a path holds secrets the agent must not read back.
+
+        The allowlist answers "is this in scope"; it cannot answer "is this a
+        private key". Being inside an allowed directory has never made
+        ``id_rsa`` or ``.env`` safe to read into a prompt that a model — and
+        whatever the model is told to do with it — then sees.
+
+        Args:
+            path: File path to check for read permission.
+
+        Returns:
+            Tuple of (is_blocked, reason). If blocked, reason explains why.
+        """
+        try:
+            real_path = Path(os.path.realpath(path))
+            file_name = real_path.name.lower()
+            file_ext = real_path.suffix.lower()
+
+            if file_name in {s.lower() for s in SENSITIVE_FILE_NAMES}:
+                return (
+                    True,
+                    f"Read blocked: '{real_path.name}' holds credentials, keys or "
+                    f"secrets. Open it yourself if you need its contents — the "
+                    f"agent is not allowed to read it into the conversation.",
+                )
+
+            if file_ext in SENSITIVE_EXTENSIONS:
+                return (
+                    True,
+                    f"Read blocked: files with extension '{file_ext}' are "
+                    f"certificates or private keys. The agent is not allowed to "
+                    f"read them into the conversation.",
+                )
+
+            for secret_dir in SECRET_DIRECTORIES:
+                if _path_is_within(real_path, Path(secret_dir)):
+                    return (
+                        True,
+                        f"Read blocked: '{real_path}' is inside '{secret_dir}', "
+                        f"which holds credentials. The agent is not allowed to "
+                        f"read from it.",
+                    )
+
+            return (False, "")
+
+        except Exception as e:
+            logger.error(f"Error checking read block for {path}: {e}")
+            # Fail-closed: refuse if we can't determine safety.
+            return (True, f"Read blocked: unable to validate path safety: {e}")
+
+    def validate_read(self, path: str, prompt_user: bool = True) -> Tuple[bool, str]:
+        """Allowlist + sensitive-file check for a read.
+
+        Args:
+            path: File path to validate for reading.
+            prompt_user: Whether to prompt the user when the path is out of scope.
+
+        Returns:
+            Tuple of (is_allowed, reason). If not allowed, reason explains why.
+        """
+        if not self.is_path_allowed(path, prompt_user=prompt_user):
+            return (
+                False,
+                f"Access denied: '{path}' is not in allowed paths. Attach the "
+                f"file to this session, or start the agent with an "
+                f"allowed_paths list that covers it.",
+            )
+
+        is_blocked, reason = self.is_read_blocked(path)
+        if is_blocked:
+            return (False, reason)
+
+        return (True, "")
+
     # ── Write Guardrails ──────────────────────────────────────────────
 
     def is_write_blocked(self, path: str) -> Tuple[bool, str]:
@@ -493,6 +729,8 @@ class PathValidator:
         1. System/blocked directories (Windows, /etc, .ssh, ~/.gaia, etc.)
         2. Sensitive file names (.env, credentials, keys, etc.)
         3. Sensitive file extensions (.pem, .key, .crt, etc.)
+        4. Files that execute on their own (shell rc, PowerShell profile,
+           autostart entries, git hooks and config)
 
         Args:
             path: File path to check for write permission.
@@ -548,6 +786,15 @@ class PathValidator:
                     True,
                     f"Write blocked: files with extension '{file_ext}' are "
                     f"sensitive (certificates/keys). Writing is not allowed.",
+                )
+
+            startup_reason = _startup_execution_reason(real_path)
+            if startup_reason:
+                return (
+                    True,
+                    f"Write blocked: {startup_reason}. Writing to it would make "
+                    f"the agent's content run on your machine without you asking. "
+                    f"Edit it yourself if that is what you intended.",
                 )
 
             return (False, "")

--- a/src/gaia/skills/hub.py
+++ b/src/gaia/skills/hub.py
@@ -45,6 +45,7 @@ from gaia.hub.catalog import (
 )
 from gaia.logger import get_logger
 from gaia.skills.errors import SkillError, SkillNotFoundError, SkillValidationError
+from gaia.skills.naming import artifact_path, validated_artifact_filename
 from gaia.skills.versions import resolve as resolve_version_spec
 from gaia.skills.versions import validate_spec as validate_version_spec
 
@@ -274,7 +275,11 @@ class RemoteSkill:
                 "version; GAIA will not install an unverifiable artifact."
             )
         return RemoteArtifact(
-            filename=str(raw["filename"]),
+            # Validate at the parse boundary: everything downstream joins this
+            # onto a directory GAIA chose, before any signature or tier gate.
+            filename=validated_artifact_filename(
+                str(raw["filename"]), origin=f"hub manifest for '{self.name}' {version}"
+            ),
             sha256=str(raw["sha256"]),
             size_bytes=int(raw.get("size_bytes") or 0),
             path=str(raw.get("path") or ""),
@@ -386,10 +391,18 @@ def download_artifact(
 
     Raises:
         SkillHubError: on a transport failure or a checksum mismatch.
+        SkillValidationError: the manifest's filename, or the destination built
+            from it, is not a single safe path segment inside its own parent.
     """
     import hashlib
 
     get = fetcher or fetch_bytes
+    origin = f"hub manifest for '{name}' {version}"
+    # Re-checked here, not only where the manifest is parsed: download_artifact
+    # is public, and the write below is what a bad name actually buys.
+    validated_artifact_filename(artifact.filename, origin=origin)
+    destination = Path(destination)
+    artifact_path(destination.parent, destination.name, origin=origin)
     url = skill_artifact_url(name, version, artifact.filename, base_url)
     try:
         payload = get(url)
@@ -409,7 +422,6 @@ def download_artifact(
             "skill name and version."
         )
 
-    destination = Path(destination)
     destination.parent.mkdir(parents=True, exist_ok=True)
     destination.write_bytes(payload)
     log.info(

--- a/src/gaia/skills/install.py
+++ b/src/gaia/skills/install.py
@@ -60,7 +60,7 @@ from gaia.skills.hub import (
 )
 from gaia.skills.lock import SOURCE_HUB, LockEntry, SkillLock
 from gaia.skills.manager import SkillManager
-from gaia.skills.naming import skill_directory
+from gaia.skills.naming import artifact_path, skill_directory
 from gaia.skills.permissions import refuse_unbridged_permissions
 from gaia.skills.signing import (
     SIGNATURE_FILENAME,
@@ -212,7 +212,11 @@ def install_skill(
             name,
             version,
             artifact,
-            workdir / artifact.filename,
+            artifact_path(
+                workdir,
+                artifact.filename,
+                origin=f"hub manifest for '{name}' {version}",
+            ),
             base_url=base_url,
             fetcher=fetcher,
         )

--- a/src/gaia/skills/naming.py
+++ b/src/gaia/skills/naming.py
@@ -14,6 +14,14 @@ name against the canonical :data:`gaia.skills.format.NAME_PATTERN` *and* asserts
 the resolved target is a direct child of the resolved root — the second half is
 the load-bearing one, because it catches the symlink and ``\\\\?\\`` shapes the
 pattern never sees.
+
+A hub manifest's ``artifact.filename`` is the same problem one layer out: it is
+joined onto a temp workdir *before* the signature, tier and grant gates run, so
+a hostile origin's ``'../autorun.zip'`` lands wherever it likes and the
+manifest's own SHA-256 attests to the bytes, never to the destination.
+:func:`artifact_path` is the join for that; it shares
+:func:`gaia.utils.paths.safe_path_segment` with the agent-hub installer so there
+is one rule rather than two that drift.
 """
 
 from __future__ import annotations
@@ -22,8 +30,14 @@ from pathlib import Path
 
 from gaia.skills.errors import FORMAT_DOCS_URL, SkillValidationError
 from gaia.skills.format import MAX_NAME_LENGTH, NAME_PATTERN
+from gaia.utils.paths import UnsafePathSegment, safe_path_segment
 
-__all__ = ["validated_skill_name", "skill_directory"]
+__all__ = [
+    "validated_skill_name",
+    "skill_directory",
+    "validated_artifact_filename",
+    "artifact_path",
+]
 
 
 def validated_skill_name(name: str, *, source: str = "skill name") -> str:
@@ -81,5 +95,43 @@ def skill_directory(root: Path | str, name: str, *, source: str = "skill name") 
             f"root {root_path} (it resolves to {target.resolve()}). Refusing to "
             "touch it. If the skill directory is a symlink, delete the link "
             "yourself — this command only manages real directories inside the root."
+        )
+    return target
+
+
+def validated_artifact_filename(name: str, *, origin: str = "") -> str:
+    """Return *name*, or raise if it is not usable as a bundle file name.
+
+    Args:
+        name: ``artifact.filename`` exactly as the hub manifest declared it.
+        origin: The hub URL or skill/version the manifest came from, quoted back
+            in the error so a bad manifest is attributable.
+
+    Raises:
+        SkillValidationError: the name is not a single safe path segment.
+    """
+    try:
+        return safe_path_segment(name, what="artifact filename", origin=origin)
+    except UnsafePathSegment as exc:
+        raise SkillValidationError(str(exc)) from exc
+
+
+def artifact_path(workdir: Path | str, name: str, *, origin: str = "") -> Path:
+    """``workdir/<name>`` for a hub-supplied artifact filename, asserted contained.
+
+    Raises:
+        SkillValidationError: the name is not a single safe path segment, or the
+            join does not resolve to a direct child of *workdir*.
+    """
+    validated = validated_artifact_filename(name, origin=origin)
+    root = Path(workdir)
+    target = root / validated
+    if target.resolve().parent != root.resolve():
+        raise SkillValidationError(
+            f"Refusing to download artifact {name!r}"
+            + (f" (from {origin})" if origin else "")
+            + f": {target} does not resolve to a direct child of the download "
+            f"directory {root} (it resolves to {target.resolve()}). Nothing was "
+            "written — report the hub manifest as malformed."
         )
     return target

--- a/src/gaia/ui/_chat_helpers.py
+++ b/src/gaia/ui/_chat_helpers.py
@@ -947,9 +947,11 @@ def _unsafe_directory_grant_reason(directory: Path) -> str:
     if directory == Path.home().resolve():
         return "it is your home directory"
     for blocked in BLOCKED_DIRECTORIES:
-        blocked_path = Path(blocked)
+        blocked_path = Path(blocked).resolve()
         if directory == blocked_path or blocked_path.is_relative_to(directory):
             return f"it contains the protected directory '{blocked}'"
+        if directory.is_relative_to(blocked_path):
+            return f"it is inside the protected directory '{blocked}'"
     return ""
 
 
@@ -967,15 +969,14 @@ def _compute_allowed_paths(rag_file_paths: list) -> list:
     surfaces, rather than whichever of the user's folders a document came from.
 
     Falls back to the current working directory only when nothing is attached,
-    and refuses even that when the CWD is a root, ``$HOME``, or an ancestor of a
+    and refuses even that when the CWD is a root, ``$HOME``, or overlaps a
     protected directory — a scope that broad is not a scope.
 
     Args:
         rag_file_paths: Paths of the documents attached to this session.
 
     Returns:
-        The allowlist, possibly empty. An empty list means no file access, which
-        ``PathValidator`` enforces as such rather than widening to the CWD.
+        The allowlist, always including the managed documents directory.
     """
     allowed = set()
     for fp in rag_file_paths:
@@ -985,22 +986,23 @@ def _compute_allowed_paths(rag_file_paths: list) -> list:
             allowed.add(str(Path(fp).resolve()))
         except (OSError, ValueError) as exc:
             logger.warning("Skipping unresolvable document path %r: %s", fp, exc)
+    managed = str(_managed_documents_dir())
     if allowed:
-        allowed.add(str(_managed_documents_dir()))
+        allowed.add(managed)
         return sorted(allowed)
 
     cwd = Path.cwd().resolve()
     reason = _unsafe_directory_grant_reason(cwd)
     if reason:
-        logger.error(
+        logger.warning(
             "Refusing to grant this session file access to %s because %s. The "
-            "session has no attached documents, so it gets no file scope. Attach "
+            "session keeps only the managed documents directory. Attach "
             "a document, or start the Agent UI backend from a project directory.",
             cwd,
             reason,
         )
-        return []
-    return [str(cwd)]
+        return [managed]
+    return sorted({managed, str(cwd)})
 
 
 def _session_agent_kwargs(

--- a/src/gaia/ui/_chat_helpers.py
+++ b/src/gaia/ui/_chat_helpers.py
@@ -27,6 +27,7 @@ from fastapi import HTTPException
 
 from gaia.agents.install_hints import agent_not_installed_message
 from gaia.daemon.broker_client import BrokerUnavailableError
+from gaia.security import BLOCKED_DIRECTORIES
 
 from .database import PLACEHOLDER_TITLES, SESSION_DEFAULT_MODEL, ChatDatabase
 from .models import ChatRequest
@@ -923,20 +924,83 @@ def _resolve_rag_paths(db: ChatDatabase, document_ids: list) -> tuple:
         return [], []
 
 
-def _compute_allowed_paths(rag_file_paths: list) -> list:
-    """Derive allowed filesystem paths from document locations.
+def _managed_documents_dir() -> Path:
+    """The Agent UI's own documents folder — the session's writable scratch space.
 
-    Collects the unique parent directories of all RAG document paths.
-    Falls back to the current working directory when no document paths
-    are provided, to avoid granting unnecessarily broad access across
-    unrelated projects on the same machine.
+    Resolved late rather than imported as a constant so a test that relocates
+    ``Path.home()`` gets the relocated directory.
     """
-    dirs = set()
+    return (Path.home() / ".gaia" / "documents").resolve()
+
+
+def _unsafe_directory_grant_reason(directory: Path) -> str:
+    """Why *directory* is too broad to hand a session, or ``""`` if it is fine.
+
+    Args:
+        directory: A resolved directory being considered as a session scope.
+
+    Returns:
+        A reason naming what the grant would expose, empty when it is safe.
+    """
+    if directory == Path(directory.anchor):
+        return "it is a filesystem root"
+    if directory == Path.home().resolve():
+        return "it is your home directory"
+    for blocked in BLOCKED_DIRECTORIES:
+        blocked_path = Path(blocked)
+        if directory == blocked_path or blocked_path.is_relative_to(directory):
+            return f"it contains the protected directory '{blocked}'"
+    return ""
+
+
+def _compute_allowed_paths(rag_file_paths: list) -> list:
+    """Derive a session's filesystem scope from its attached documents.
+
+    Grants each document **file**, never the directory it sits in.
+    ``PathValidator`` matches exact paths, so a session that attached
+    ``~/notes.txt`` gets ``~/notes.txt`` — granting ``Path.home()`` because a
+    document happened to be saved there handed the whole home tree to an agent
+    with ``write_file`` and shell tools.
+
+    Always adds GAIA's own managed documents directory so the agent still has
+    somewhere to *write* — a bounded, GAIA-owned folder the Agent UI already
+    surfaces, rather than whichever of the user's folders a document came from.
+
+    Falls back to the current working directory only when nothing is attached,
+    and refuses even that when the CWD is a root, ``$HOME``, or an ancestor of a
+    protected directory — a scope that broad is not a scope.
+
+    Args:
+        rag_file_paths: Paths of the documents attached to this session.
+
+    Returns:
+        The allowlist, possibly empty. An empty list means no file access, which
+        ``PathValidator`` enforces as such rather than widening to the CWD.
+    """
+    allowed = set()
     for fp in rag_file_paths:
-        dirs.add(str(Path(fp).parent))
-    if not dirs:
-        dirs.add(str(Path.cwd()))
-    return list(dirs)
+        if not fp:
+            continue
+        try:
+            allowed.add(str(Path(fp).resolve()))
+        except (OSError, ValueError) as exc:
+            logger.warning("Skipping unresolvable document path %r: %s", fp, exc)
+    if allowed:
+        allowed.add(str(_managed_documents_dir()))
+        return sorted(allowed)
+
+    cwd = Path.cwd().resolve()
+    reason = _unsafe_directory_grant_reason(cwd)
+    if reason:
+        logger.error(
+            "Refusing to grant this session file access to %s because %s. The "
+            "session has no attached documents, so it gets no file scope. Attach "
+            "a document, or start the Agent UI backend from a project directory.",
+            cwd,
+            reason,
+        )
+        return []
+    return [str(cwd)]
 
 
 def _session_agent_kwargs(

--- a/src/gaia/utils/paths.py
+++ b/src/gaia/utils/paths.py
@@ -1,0 +1,98 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""One safe way to turn an untrusted string into a single path segment.
+
+Anywhere GAIA joins a name it did not choose — a hub manifest's
+``artifact.filename``, an archive member, a caller-supplied basename — onto a
+directory it did choose, ``Path(dir) / name`` is a write primitive, not a join.
+``pathlib`` collapses ``.`` back to the directory, leaves ``..`` at its parent,
+and lets an absolute name (or a bare Windows drive prefix such as ``C:evil.zip``)
+replace the directory outright.
+
+:func:`safe_path_segment` is the one check those call sites should share. It is
+deliberately stricter than "no slashes": it also refuses drive-relative and UNC
+shapes, NT device names, control characters, and the trailing dots/spaces
+Windows silently strips — all of which survive a naive separator scan.
+"""
+
+from __future__ import annotations
+
+from pathlib import PureWindowsPath
+
+__all__ = ["UnsafePathSegment", "safe_path_segment"]
+
+#: Longest segment most filesystems accept.
+MAX_SEGMENT_LENGTH = 255
+
+#: NT device names. ``open("NUL")`` succeeds on Windows in any directory.
+_WINDOWS_DEVICE_NAMES = frozenset(
+    {"con", "prn", "aux", "nul"}
+    | {f"com{i}" for i in range(1, 10)}
+    | {f"lpt{i}" for i in range(1, 10)}
+)
+
+
+class UnsafePathSegment(ValueError):
+    """A caller-supplied name is not usable as a single path segment.
+
+    Callers translate this into their own boundary error (``SkillValidationError``,
+    ``InstallError``, an HTTP 400) rather than letting it escape as a bare
+    ``ValueError``.
+    """
+
+
+def safe_path_segment(value: str, *, what: str = "filename", origin: str = "") -> str:
+    """Return *value* unchanged, or raise if it is not one safe path segment.
+
+    Args:
+        value: The untrusted name.
+        what: What the name is, quoted back in the error (e.g. ``"artifact filename"``).
+        origin: Optional "who supplied it" clause for the error (e.g. a hub URL).
+
+    Returns:
+        The name, safe to join onto a directory GAIA chose.
+
+    Raises:
+        UnsafePathSegment: the name is empty, over-long, carries a path
+            separator, drive or root, is ``.``/``..``, names an NT device, or
+            contains a character the filesystem would rewrite.
+    """
+    source = f" (from {origin})" if origin else ""
+
+    def refuse(why: str) -> "UnsafePathSegment":
+        return UnsafePathSegment(
+            f"Refusing to use {what} {value!r}{source}: {why}. It must be a single "
+            "file name — no directory separators, no '.', no '..', no drive letter "
+            "and no leading '/' or ''. Nothing was written. If this came from a "
+            "hub or catalog, report the manifest as malformed."
+        )
+
+    if not isinstance(value, str) or not value:
+        raise refuse("it is empty")
+    if len(value) > MAX_SEGMENT_LENGTH:
+        raise refuse(
+            f"it is {len(value)} characters and the limit is {MAX_SEGMENT_LENGTH}"
+        )
+    if value in (".", ".."):
+        raise refuse("it names a directory rather than a file")
+    if "/" in value or "\\" in value:
+        raise refuse("it contains a directory separator")
+    if any(ord(ch) < 32 or ord(ch) == 127 for ch in value):
+        raise refuse("it contains a control character")
+    if ":" in value:
+        # 'C:evil.zip' has no separator but still re-roots the join on Windows.
+        raise refuse("it contains ':', which names a drive or an NTFS data stream")
+    if value != value.strip() or value.endswith("."):
+        raise refuse(
+            "it has leading/trailing whitespace or a trailing dot, which Windows strips"
+        )
+    if value.split(".", 1)[0].lower() in _WINDOWS_DEVICE_NAMES:
+        raise refuse("it names a Windows device")
+
+    # Belt and braces: whatever the character-level rules missed, pathlib must
+    # still read this as one relative component.
+    pure = PureWindowsPath(value)
+    if pure.drive or pure.root or len(pure.parts) != 1:
+        raise refuse("it does not resolve to a single relative path component")
+
+    return value

--- a/tests/unit/chat/ui/test_chat_helpers.py
+++ b/tests/unit/chat/ui/test_chat_helpers.py
@@ -24,6 +24,7 @@ from gaia.ui._chat_helpers import (
     _compute_allowed_paths,
     _empty_answer_outcome,
     _find_last_tool_step,
+    _managed_documents_dir,
     _resolve_rag_paths,
     set_agent_registry,
 )
@@ -227,27 +228,48 @@ class TestResolveRagPaths:
 
 
 class TestComputeAllowedPaths:
-    """Tests for _compute_allowed_paths()."""
+    """Tests for _compute_allowed_paths().
+
+    The scope is the attached documents themselves. These tests used to assert
+    the opposite — that each document's *parent directory* was granted — which
+    pinned the bug: attaching one file from ``$HOME`` allowlisted the whole home
+    tree for a session that also holds ``write_file`` and shell tools.
+    """
 
     def test_empty_paths_returns_cwd(self):
         result = _compute_allowed_paths([])
         assert len(result) == 1
-        assert result[0] == str(Path.cwd())
+        assert result[0] == str(Path.cwd().resolve())
 
-    def test_single_file_returns_parent_dir(self):
-        result = _compute_allowed_paths(["/docs/project/report.pdf"])
-        assert len(result) == 1
-        assert Path(result[0]) == Path("/docs/project")
+    def test_single_file_grants_the_file_not_its_directory(self):
+        result = {Path(p) for p in _compute_allowed_paths(["/docs/project/report.pdf"])}
+        assert result == {
+            Path("/docs/project/report.pdf").resolve(),
+            _managed_documents_dir(),
+        }
 
-    def test_multiple_files_same_dir_deduped(self):
+    def test_siblings_of_an_attached_file_are_not_granted(self):
+        result = _compute_allowed_paths(["/docs/project/a.pdf"])
+        assert Path("/docs/project") not in {Path(p) for p in result}
+
+    def test_multiple_files_same_dir_each_granted(self):
         result = _compute_allowed_paths(
             [
                 "/docs/project/a.pdf",
                 "/docs/project/b.pdf",
             ]
         )
-        assert len(result) == 1
-        assert Path(result[0]) == Path("/docs/project")
+        assert {Path(p) for p in result} == {
+            Path("/docs/project/a.pdf").resolve(),
+            Path("/docs/project/b.pdf").resolve(),
+            _managed_documents_dir(),
+        }
+
+    def test_the_agent_keeps_a_place_to_write(self):
+        """Grant the files, not their folders — but not nowhere to save output."""
+        result = {Path(p) for p in _compute_allowed_paths(["/docs/project/a.pdf"])}
+
+        assert _managed_documents_dir() in result
 
     def test_multiple_files_different_dirs(self):
         result = _compute_allowed_paths(
@@ -257,8 +279,23 @@ class TestComputeAllowedPaths:
             ]
         )
         result_set = {Path(p) for p in result}
-        assert Path("/docs/project") in result_set
-        assert Path("/home/user/data") in result_set
+        assert Path("/docs/project/a.pdf").resolve() in result_set
+        assert Path("/home/user/data/b.csv").resolve() in result_set
+
+    def test_a_document_saved_in_home_does_not_allowlist_home(self):
+        """The exact shape of the bug: one attachment, whole home tree granted."""
+        attached = Path.home() / "notes.txt"
+
+        result = {Path(p) for p in _compute_allowed_paths([str(attached)])}
+
+        assert Path.home().resolve() not in result
+        assert attached.resolve() in result
+
+    def test_no_documents_and_an_unsafe_cwd_grants_nothing(self, monkeypatch):
+        """An empty scope, not a silent widening to $HOME."""
+        monkeypatch.setattr(Path, "cwd", classmethod(lambda cls: Path.home()))
+
+        assert _compute_allowed_paths([]) == []
 
     def test_returns_list_type(self):
         result = _compute_allowed_paths(["/some/path/file.txt"])

--- a/tests/unit/chat/ui/test_chat_helpers.py
+++ b/tests/unit/chat/ui/test_chat_helpers.py
@@ -238,8 +238,7 @@ class TestComputeAllowedPaths:
 
     def test_empty_paths_returns_cwd(self):
         result = _compute_allowed_paths([])
-        assert len(result) == 1
-        assert result[0] == str(Path.cwd().resolve())
+        assert set(result) == {str(Path.cwd().resolve()), str(_managed_documents_dir())}
 
     def test_single_file_grants_the_file_not_its_directory(self):
         result = {Path(p) for p in _compute_allowed_paths(["/docs/project/report.pdf"])}
@@ -291,11 +290,23 @@ class TestComputeAllowedPaths:
         assert Path.home().resolve() not in result
         assert attached.resolve() in result
 
-    def test_no_documents_and_an_unsafe_cwd_grants_nothing(self, monkeypatch):
-        """An empty scope, not a silent widening to $HOME."""
+    def test_no_documents_and_an_unsafe_cwd_keeps_managed_documents(self, monkeypatch):
         monkeypatch.setattr(Path, "cwd", classmethod(lambda cls: Path.home()))
 
-        assert _compute_allowed_paths([]) == []
+        assert _compute_allowed_paths([]) == [str(_managed_documents_dir())]
+
+    def test_cwd_inside_a_protected_directory_is_not_granted(
+        self, tmp_path, monkeypatch
+    ):
+        protected = tmp_path / "protected"
+        child = protected / "service"
+        child.mkdir(parents=True)
+        monkeypatch.setattr(
+            "gaia.ui._chat_helpers.BLOCKED_DIRECTORIES", {str(protected)}
+        )
+        monkeypatch.chdir(child)
+
+        assert _compute_allowed_paths([]) == [str(_managed_documents_dir())]
 
     def test_returns_list_type(self):
         result = _compute_allowed_paths(["/some/path/file.txt"])

--- a/tests/unit/test_file_access_scope.py
+++ b/tests/unit/test_file_access_scope.py
@@ -170,6 +170,7 @@ class TestReadToolsRefuseThePrivateKey:
 
         instance = type("_Stub", (mixin_cls,), {})()
         instance.path_validator = validator
+        instance._path_validator = validator
         getattr(instance, register)()
         return _TOOL_REGISTRY["read_file"]["function"]
 
@@ -212,6 +213,36 @@ class TestReadToolsRefuseThePrivateKey:
 
         assert result["status"] == "success"
         assert "attached notes" in result["content"]
+
+    def test_filesystem_read_file_refuses_the_key(self, sandbox):
+        from gaia.agents.tools.filesystem_tools import FileSystemToolsMixin
+
+        validator, key, _ = sandbox
+        read_file = self._read_file_tool(
+            FileSystemToolsMixin, "register_filesystem_tools", validator
+        )
+
+        result = read_file(str(key))
+
+        assert "Access denied" in str(result)
+        assert "PRIVATE KEY" not in str(result)
+
+    def test_filesystem_content_search_refuses_credentials(self, validator, tmp_path):
+        from gaia.agents.base.tools import _TOOL_REGISTRY
+        from gaia.agents.tools.filesystem_tools import FileSystemToolsMixin
+
+        (tmp_path / "credentials.json").write_text('{"secret": "hidden-marker"}')
+        (tmp_path / "notes.txt").write_text("visible-marker")
+        self._read_file_tool(
+            FileSystemToolsMixin, "register_filesystem_tools", validator
+        )
+        find_files = _TOOL_REGISTRY["find_files"]["function"]
+
+        result = find_files(query="marker", search_type="content", scope=str(tmp_path))
+
+        assert "visible-marker" in result
+        assert "hidden-marker" not in result
+        assert "credentials.json" not in result
 
 
 # ── Writes: files that execute on their own ──────────────────────────────

--- a/tests/unit/test_file_access_scope.py
+++ b/tests/unit/test_file_access_scope.py
@@ -1,0 +1,206 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""The file-access boundary is the *file*, and it holds on reads too.
+
+Three separate holes, one chain: a session's allowlist silently widened from an
+attached document to the directory it sat in (``$HOME`` included); reads were
+gated on the allowlist alone, so anything in scope could be read back including
+private keys; and the write guard covered ``~/.ssh`` and ``LaunchAgents`` but not
+``~/.bashrc``, autostart entries or git hooks — the shortest path there is from a
+prompt injection to code that runs on the next login.
+"""
+
+from pathlib import Path
+
+import pytest
+
+from gaia.security import PathValidator
+
+
+@pytest.fixture
+def validator(tmp_path):
+    return PathValidator(allowed_paths=[str(tmp_path)])
+
+
+# ── Scope: grant the file, not its parent ─────────────────────────────────
+
+
+class TestSessionScopeIsTheFile:
+    def test_granting_a_file_does_not_grant_its_siblings(self, tmp_path):
+        attached = tmp_path / "report.pdf"
+        attached.write_text("report", encoding="utf-8")
+        sibling = tmp_path / "tax-return.pdf"
+        sibling.write_text("private", encoding="utf-8")
+
+        scoped = PathValidator(allowed_paths=[str(attached)])
+
+        assert scoped.is_path_allowed(str(attached), prompt_user=False)
+        assert not scoped.is_path_allowed(str(sibling), prompt_user=False)
+
+    def test_an_empty_allowlist_denies_rather_than_widening_to_cwd(self, tmp_path):
+        """`[]` is a scope of nothing; only `None` means "no scope supplied"."""
+        scoped = PathValidator(allowed_paths=[])
+
+        assert scoped.allowed_paths == set()
+        assert not scoped.is_path_allowed(str(tmp_path / "x.txt"), prompt_user=False)
+
+    def test_no_allowlist_still_defaults_to_cwd(self):
+        assert PathValidator().allowed_paths == {Path.cwd().resolve()}
+
+
+# ── I13: a host-supplied scope is not the machine-global grant list ───────
+
+
+class TestHostSuppliedScopeStandsAlone:
+    def test_persisted_grants_are_not_unioned_into_a_host_scope(
+        self, tmp_path, monkeypatch
+    ):
+        """The CLI's "[a]lways" must not become standing access for the UI."""
+        fake_home = tmp_path / "home"
+        (fake_home / ".gaia" / "cache").mkdir(parents=True)
+        elsewhere = tmp_path / "someone-elses-project"
+        elsewhere.mkdir()
+        (fake_home / ".gaia" / "cache" / "allowed_paths.json").write_text(
+            '{"paths": ["%s"]}' % elsewhere.as_posix(), encoding="utf-8"
+        )
+        monkeypatch.setattr(Path, "home", classmethod(lambda cls: fake_home))
+
+        session = PathValidator(allowed_paths=[str(tmp_path / "doc.pdf")])
+        cli = PathValidator()
+
+        assert not session.is_path_allowed(str(elsewhere), prompt_user=False)
+        assert cli.is_path_allowed(str(elsewhere), prompt_user=False)
+
+    def test_a_host_scope_never_writes_to_the_machine_global_file(
+        self, tmp_path, monkeypatch
+    ):
+        fake_home = tmp_path / "home"
+        (fake_home / ".gaia" / "cache").mkdir(parents=True)
+        monkeypatch.setattr(Path, "home", classmethod(lambda cls: fake_home))
+
+        session = PathValidator(allowed_paths=[str(tmp_path)])
+        session._save_persisted_path(tmp_path / "sneaky")
+
+        assert not (fake_home / ".gaia" / "cache" / "allowed_paths.json").exists()
+
+
+# ── Reads: in-scope is not the same as safe-to-read ──────────────────────
+
+
+class TestSensitiveReadsAreRefused:
+    @pytest.mark.parametrize(
+        "name", [".env", "id_rsa", "credentials.json", ".netrc", "server.pem", "a.key"]
+    )
+    def test_a_secret_inside_the_allowlist_is_still_refused(
+        self, validator, tmp_path, name
+    ):
+        secret = tmp_path / name
+        secret.write_text("PRIVATE KEY", encoding="utf-8")
+
+        allowed, reason = validator.validate_read(str(secret), prompt_user=False)
+
+        assert not allowed
+        assert "Read blocked" in reason
+
+    def test_an_ordinary_document_still_reads(self, validator, tmp_path):
+        doc = tmp_path / "notes.md"
+        doc.write_text("hello", encoding="utf-8")
+
+        assert validator.validate_read(str(doc), prompt_user=False) == (True, "")
+
+    def test_out_of_scope_reads_say_what_to_do(self, validator, tmp_path):
+        allowed, reason = validator.validate_read("/somewhere/else.txt", False)
+
+        assert not allowed
+        assert "allowed_paths" in reason
+
+    def test_a_credential_directory_is_refused_whatever_the_file_is_called(
+        self, tmp_path, monkeypatch
+    ):
+        fake_home = tmp_path / "home"
+        ssh = fake_home / ".ssh"
+        ssh.mkdir(parents=True)
+        (ssh / "config").write_text("Host prod", encoding="utf-8")
+        monkeypatch.setattr(Path, "home", classmethod(lambda cls: fake_home))
+
+        import gaia.security as security
+
+        monkeypatch.setattr(
+            security, "SECRET_DIRECTORIES", security._secret_directories()
+        )
+        scoped = PathValidator(allowed_paths=[str(fake_home)])
+
+        blocked, reason = scoped.is_read_blocked(str(ssh / "config"))
+
+        assert blocked
+        assert ".ssh" in reason
+
+
+# ── Writes: files that execute on their own ──────────────────────────────
+
+
+class TestStartupExecutionWritesAreBlocked:
+    @pytest.mark.parametrize(
+        "relative",
+        [
+            ".bashrc",
+            ".zshrc",
+            ".profile",
+            ".bash_profile",
+            ".gitconfig",
+            "config.fish",
+            ".config/autostart/evil.desktop",
+            ".config/systemd/user/evil.service",
+            "project/.git/hooks/pre-commit",
+            "project/.git/config",
+            "Documents/WindowsPowerShell/Microsoft.PowerShell_profile.ps1",
+            "Library/LaunchAgents/evil.plist",
+        ],
+    )
+    def test_write_is_blocked(self, tmp_path, relative):
+        target = tmp_path / relative
+        target.parent.mkdir(parents=True, exist_ok=True)
+        validator = PathValidator(allowed_paths=[str(tmp_path)])
+
+        blocked, reason = validator.is_write_blocked(str(target))
+
+        assert blocked, f"{relative} should be write-blocked"
+        assert "run" in reason or "execut" in reason
+
+    @pytest.mark.parametrize(
+        "relative",
+        [
+            "notes.md",
+            "report.pdf",
+            "src/startup/main.py",
+            "src/profile.py",
+            "docs/gitconfig.md",
+        ],
+    )
+    def test_ordinary_files_stay_writable(self, tmp_path, relative):
+        target = tmp_path / relative
+        target.parent.mkdir(parents=True, exist_ok=True)
+        validator = PathValidator(allowed_paths=[str(tmp_path)])
+
+        blocked, reason = validator.is_write_blocked(str(target))
+
+        assert not blocked, f"{relative} should stay writable: {reason}"
+
+    def test_the_injection_chain_is_closed_end_to_end(self, tmp_path, monkeypatch):
+        """`write_file("~/.bashrc", "curl … | sh")` from an attached document."""
+        fake_home = tmp_path / "home"
+        fake_home.mkdir()
+        attached = fake_home / "notes.txt"
+        attached.write_text("notes", encoding="utf-8")
+        monkeypatch.setattr(Path, "home", classmethod(lambda cls: fake_home))
+
+        from gaia.ui._chat_helpers import _compute_allowed_paths
+
+        scope = _compute_allowed_paths([str(attached)])
+        validator = PathValidator(allowed_paths=scope)
+
+        allowed, _ = validator.validate_write(
+            str(fake_home / ".bashrc"), prompt_user=False
+        )
+
+        assert not allowed

--- a/tests/unit/test_file_access_scope.py
+++ b/tests/unit/test_file_access_scope.py
@@ -136,6 +136,84 @@ class TestSensitiveReadsAreRefused:
         assert ".ssh" in reason
 
 
+# ── The report's probe, driven through the tools a model actually calls ──
+
+
+class TestReadToolsRefuseThePrivateKey:
+    """``read_file("~/.ssh/id_rsa")`` returned the key. Both mixins define a
+    ``read_file``; the flagship registers the ``file_search`` one, so a fix that
+    only covered ``FileIOToolsMixin`` would have left the live path open."""
+
+    @pytest.fixture
+    def sandbox(self, tmp_path, monkeypatch):
+        import gaia.security as security
+
+        fake_home = tmp_path / "home"
+        ssh = fake_home / ".ssh"
+        ssh.mkdir(parents=True)
+        key = ssh / "id_rsa"
+        key.write_text("-----BEGIN OPENSSH PRIVATE KEY-----", encoding="utf-8")
+        doc = fake_home / "notes.md"
+        doc.write_text("attached notes", encoding="utf-8")
+
+        monkeypatch.setattr(Path, "home", classmethod(lambda cls: fake_home))
+        monkeypatch.setattr(security, "_is_interactive", lambda: False)
+        monkeypatch.setattr(
+            security, "SECRET_DIRECTORIES", security._secret_directories()
+        )
+        # A scope deliberately wider than the fix's own advice, so the denylist
+        # is what refuses the key rather than the allowlist doing it by accident.
+        return PathValidator(allowed_paths=[str(fake_home)]), key, doc
+
+    def _read_file_tool(self, mixin_cls, register, validator):
+        from gaia.agents.base.tools import _TOOL_REGISTRY
+
+        instance = type("_Stub", (mixin_cls,), {})()
+        instance.path_validator = validator
+        getattr(instance, register)()
+        return _TOOL_REGISTRY["read_file"]["function"]
+
+    def test_file_search_read_file_refuses_the_key(self, sandbox):
+        from gaia.agents.tools.file_tools import FileSearchToolsMixin
+
+        validator, key, _ = sandbox
+        read_file = self._read_file_tool(
+            FileSearchToolsMixin, "register_file_search_tools", validator
+        )
+
+        result = read_file(str(key))
+
+        assert result["status"] == "error"
+        assert "PRIVATE KEY" not in str(result)
+
+    def test_file_io_read_file_refuses_the_key(self, sandbox):
+        from gaia.agents.tools.file_io_tools import FileIOToolsMixin
+
+        validator, key, _ = sandbox
+        read_file = self._read_file_tool(
+            FileIOToolsMixin, "register_file_io_tools", validator
+        )
+
+        result = read_file(str(key))
+
+        assert result["status"] == "error"
+        assert "PRIVATE KEY" not in str(result)
+
+    def test_an_attached_document_is_still_readable(self, sandbox):
+        """The positive control — the fix must not break the actual use case."""
+        from gaia.agents.tools.file_io_tools import FileIOToolsMixin
+
+        validator, _, doc = sandbox
+        read_file = self._read_file_tool(
+            FileIOToolsMixin, "register_file_io_tools", validator
+        )
+
+        result = read_file(str(doc))
+
+        assert result["status"] == "success"
+        assert "attached notes" in result["content"]
+
+
 # ── Writes: files that execute on their own ──────────────────────────────
 
 

--- a/tests/unit/test_filesystem_tools_mixin.py
+++ b/tests/unit/test_filesystem_tools_mixin.py
@@ -207,7 +207,7 @@ class TestValidatePath:
     def test_validate_path_blocked_by_validator(self, tmp_path):
         """PathValidator can block access to a path."""
         mock_validator = MagicMock()
-        mock_validator.is_path_allowed.return_value = False
+        mock_validator.validate_read.return_value = (False, "blocked by policy")
         self.agent._path_validator = mock_validator
 
         with pytest.raises(ValueError, match="Access denied"):
@@ -216,7 +216,7 @@ class TestValidatePath:
     def test_validate_path_allowed_by_validator(self, tmp_path):
         """PathValidator allows the path through."""
         mock_validator = MagicMock()
-        mock_validator.is_path_allowed.return_value = True
+        mock_validator.validate_read.return_value = (True, "")
         self.agent._path_validator = mock_validator
 
         result = self.agent._validate_path(str(tmp_path))
@@ -373,7 +373,7 @@ class TestBrowseDirectory:
     def test_browse_path_validation_denied(self, tmp_path):
         """Path validator denial is returned as error string."""
         mock_validator = MagicMock()
-        mock_validator.is_path_allowed.return_value = False
+        mock_validator.validate_read.return_value = (False, "blocked by policy")
         self.agent._path_validator = mock_validator
 
         result = self.browse(path=str(tmp_path))
@@ -925,7 +925,7 @@ class TestReadFile:
         f = tmp_path / "secret.txt"
         f.write_text("classified")
         mock_validator = MagicMock()
-        mock_validator.is_path_allowed.return_value = False
+        mock_validator.validate_read.return_value = (False, "blocked by policy")
         self.agent._path_validator = mock_validator
 
         result = self.read(file_path=str(f))

--- a/tests/unit/test_hub_artifact_filename.py
+++ b/tests/unit/test_hub_artifact_filename.py
@@ -1,0 +1,120 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""A hub-supplied artifact filename must never steer the write it names.
+
+``install_skill`` downloads to ``workdir / artifact.filename`` *before* the
+signature, tier, ``--allow-experimental`` and dangerous-grant gates run, and the
+SHA-256 in the same manifest attests to the bytes, never to the destination. A
+manifest from an attacker-controlled origin — a compromised bucket, or
+``GAIA_HUB_URL`` pointed elsewhere — therefore got a pre-consent arbitrary file
+write out of a field nobody validated.
+"""
+
+import pytest
+
+from gaia.hub.installer import InstallError, _sanitize_artifact_filename
+from gaia.skills.errors import SkillValidationError
+from gaia.skills.hub import RemoteArtifact, RemoteSkill, download_artifact
+from gaia.skills.naming import artifact_path
+from gaia.utils.paths import UnsafePathSegment, safe_path_segment
+
+#: The four shapes the review named, plus the Windows drive-relative form that a
+#: separator scan alone lets through.
+HOSTILE_NAMES = [
+    ".",
+    "..",
+    "../x",
+    "/etc/cron.d/gaia",
+    "..\\x",
+    "sub/dir.zip",
+    "C:evil.zip",
+    "\\\\server\\share\\evil.zip",
+    "NUL",
+    "",
+]
+
+
+@pytest.mark.parametrize("hostile", HOSTILE_NAMES)
+def test_safe_path_segment_refuses(hostile):
+    with pytest.raises(UnsafePathSegment):
+        safe_path_segment(hostile, what="artifact filename")
+
+
+@pytest.mark.parametrize("ordinary", ["web-research-1.2.0.zip", "a.zip", "x.tar.gz"])
+def test_safe_path_segment_passes_an_ordinary_bundle_name(ordinary):
+    assert safe_path_segment(ordinary) == ordinary
+
+
+def test_the_error_says_what_to_do():
+    with pytest.raises(UnsafePathSegment) as exc:
+        safe_path_segment("../x", what="artifact filename", origin="hub manifest")
+
+    message = str(exc.value)
+    assert "artifact filename" in message
+    assert "hub manifest" in message
+    assert "Nothing was written" in message
+
+
+@pytest.mark.parametrize("hostile", HOSTILE_NAMES)
+def test_the_manifest_parser_refuses_a_hostile_filename(hostile):
+    """Refused at the parse boundary, so nothing downstream ever sees it."""
+    remote = RemoteSkill(
+        name="victim",
+        latest_version="1.0.0",
+        versions={"1.0.0": {"artifact": {"filename": hostile, "sha256": "ab" * 32}}},
+    )
+
+    with pytest.raises(SkillValidationError):
+        remote.artifact("1.0.0")
+
+
+def test_the_manifest_parser_accepts_a_published_bundle_name():
+    remote = RemoteSkill(
+        name="web-research",
+        latest_version="1.2.0",
+        versions={
+            "1.2.0": {
+                "artifact": {"filename": "web-research-1.2.0.zip", "sha256": "ab" * 32}
+            }
+        },
+    )
+
+    assert remote.artifact("1.2.0").filename == "web-research-1.2.0.zip"
+
+
+@pytest.mark.parametrize("hostile", [".", "..", "../x", "/etc/passwd"])
+def test_artifact_path_refuses_the_join(tmp_path, hostile):
+    with pytest.raises(SkillValidationError):
+        artifact_path(tmp_path / "work", hostile)
+
+
+def test_download_writes_nothing_outside_the_workdir(tmp_path):
+    """The probe from the review: '../outside-marker.zip' must not land."""
+    workdir = tmp_path / "work"
+    workdir.mkdir()
+    artifact = RemoteArtifact(
+        filename="ok.zip", sha256="ab" * 32, size_bytes=0, path="", content_type=""
+    )
+    object.__setattr__(artifact, "filename", "../outside-marker.zip")
+
+    with pytest.raises(SkillValidationError):
+        download_artifact(
+            "victim",
+            "1.0.0",
+            artifact,
+            workdir / ".." / "outside-marker.zip",
+            fetcher=lambda url: b"payload",
+        )
+
+    assert not (tmp_path / "outside-marker.zip").exists()
+
+
+@pytest.mark.parametrize("hostile", HOSTILE_NAMES)
+def test_the_agent_hub_installer_shares_the_same_rule(hostile):
+    """One helper, not two that drift — the agent hub joins the same way."""
+    with pytest.raises(InstallError):
+        _sanitize_artifact_filename(hostile, "some-agent")
+
+
+def test_the_agent_hub_installer_accepts_a_wheel_name():
+    _sanitize_artifact_filename("gaia_agent-0.1.0-py3-none-any.whl", "some-agent")


### PR DESCRIPTION
Attaching a document quietly widened the agent's file scope to the entire directory that document sat in — attach something from your home folder and the agent could read anything under it, a scope you never granted and were never shown. Being inside that scope was also treated as being safe: reads had no secret denylist at all, so a credential in an allowed folder came back as ordinary text, and the write denylist missed the files that execute on their own. Now the grant is the file you attached, reads refuse credentials through both read tools, and writes refuse shell rc files, PowerShell profiles, autostart entries and a repo's git hooks — each as an error naming the file and the reason, not a silent skip. A session with no attachments no longer silently falls back to whatever directory the backend was started in when that directory is your home folder.

It also closes a pre-consent write: a hub package chose the filename its artifact landed under with no validation, so a hostile hub origin could place a file outside the temp workdir before you agreed to anything, ahead of every signature and consent gate. One shared name check now covers the hub installer and all three skill entry points.

## Test plan

- [ ] `python -m pytest tests/unit/test_file_access_scope.py tests/unit/test_hub_artifact_filename.py` — 76 new tests, all green
- [ ] Artifact names refused: `.`, `..`, `../x`, an absolute path, and a name containing a separator; a normal `web-research-1.2.0.zip` still installs
- [ ] Reads refused: `~/.ssh/id_rsa`, `.env`, `credentials.json`, `.netrc`, `*.pem`/`*.key`, and anything under `~/.aws`, `~/.gnupg`, `~/.kube` — exercised through both `read_file` tools, since the flagship registers the file-search one
- [ ] Writes refused: `~/.bashrc`, `~/.config/autostart/*.desktop`, `.git/hooks/*`, PowerShell profiles, systemd user units, `LaunchAgents`
- [ ] Still works: an attached document reads normally, and ordinary files (`notes.md`, `src/startup/main.py`, `src/profile.py`) stay writable
- [ ] `python -m pytest tests/unit/test_file_tools.py tests/unit/test_file_write_guardrails.py tests/unit/test_security_edge_cases.py tests/unit/test_skills_name_containment.py tests/unit/test_skills_install.py` — no regressions
- [ ] `tests/unit/chat/ui/test_chat_helpers.py` shows 4 failures that also fail on a pristine `upstream/main` checkout (Windows asyncio in `conftest`), and 2 in `test_hub_installer.py` from this venv lacking `pip`/`uv` — neither introduced here
