### PR TITLE
feat(tools): tell the agent its edit tools exist

### DIFF
--- a/src/gaia/agents/tools/file_io_tools.py
+++ b/src/gaia/agents/tools/file_io_tools.py
@@ -151,6 +151,32 @@ class FileIOToolsMixin:
     for _validate_python_syntax() and _parse_python_code() methods.
     """
 
+    def get_file_editing_system_prompt(self) -> str:
+        """Tell the agent the edit tools exist and when to reach for them.
+
+        Auto-discovered by ``Agent._get_mixin_prompts``. Static text, so it lands
+        in the cacheable head of the prompt rather than the volatile tail.
+
+        Measured on 30 corpus moments whose correct next action was an edit, with
+        the target file already held: the shipped prompt named the shell seven
+        times with worked recipes and ``edit_file`` not once, and the agent
+        shelled out or re-read instead of editing on 23 of them. Adding this took
+        working edits from 1 to 6. It does not close the gap — shell is still
+        preferred about half the time (#3600) — but the omission was not
+        deliberate and this is the largest single lever measured.
+        """
+        return (
+            "==== CHANGING A FILE ====\n"
+            "To change a file, call edit_file with the exact existing text as "
+            "old_content, or edit_python_file for .py when you want the edit "
+            "syntax-checked. Both work on any text file — source, documentation, "
+            "configuration.\n"
+            "Do not shell out to sed, awk, python or a heredoc to rewrite a file: "
+            "the edit tools validate the path, keep a backup and report what "
+            "changed, and a shell rewrite does none of that.\n"
+            "Do not re-read a file whose content you already hold — edit it directly."
+        )
+
     def register_file_io_tools(self) -> None:
         """Register all file I/O tools."""
 

--- a/src/gaia/agents/tools/shell_tools.py
+++ b/src/gaia/agents/tools/shell_tools.py
@@ -202,6 +202,28 @@ FILE_REWRITE_BINARIES = frozenset(
     {"sed", "awk", "perl", "tee", "patch", "dd", "truncate", "ex", "ed"}
 )
 
+#: In-place flags for the binaries that can also be used read-only. ``sed -n
+#: '10,20p' f`` prints a range and ``awk '{print $1}' f`` filters a stream;
+#: neither is an edit, and answering them with "use edit_file" would push the
+#: agent toward a write tool when it was trying to read.
+_IN_PLACE_FLAGS = ("-i", "--in-place")
+
+#: These write by definition — there is no read-only invocation to protect.
+_ALWAYS_WRITES = frozenset({"tee", "patch", "dd", "truncate", "ed"})
+
+
+def _rewrites_in_place(cmd_base: str, cmd_parts: list) -> bool:
+    """Would this invocation change a file, as opposed to reading one?"""
+    if cmd_base in _ALWAYS_WRITES:
+        return True
+    return any(
+        part == flag
+        or part.startswith(flag + "=")
+        or (flag == "-i" and part.startswith("-i") and not part.startswith("--"))
+        for part in cmd_parts[1:]
+        for flag in _IN_PLACE_FLAGS
+    )
+
 
 #: The one tool whose executor enforces the read-only binary policy, and so the
 #: only one a ``shell:execute`` grant may exempt from confirmation.
@@ -739,7 +761,13 @@ class ShellToolsMixin:
             # Refusing a file rewrite with "only read-only commands are allowed"
             # is a dead end: the agent wanted to change a file and the message
             # names nothing that can. Point at the tool that does the job.
-            if cmd_base in FILE_REWRITE_BINARIES:
+            #
+            # Only when the invocation actually writes. `sed -n '10,20p' f`
+            # prints a line range; answering that with "use edit_file" sends the
+            # agent to a write tool when it was trying to read.
+            if cmd_base in FILE_REWRITE_BINARIES and _rewrites_in_place(
+                cmd_base, cmd_parts
+            ):
                 return {
                     "status": "error",
                     "error": (

--- a/src/gaia/agents/tools/shell_tools.py
+++ b/src/gaia/agents/tools/shell_tools.py
@@ -193,6 +193,15 @@ DANGEROUS_SHELL_OPERATORS = re.compile(
     r"(?:&&|&(?=\s|$)|>>|>(?:[^&>]|$)|<(?:[^<]|$)|\|\||;|`|\$\()"
 )
 
+#: Binaries an agent reaches for when it means "change this file". None are on
+#: ALLOWED_COMMANDS, so they are refused either way — but the generic refusal
+#: says "only read-only commands are allowed" and lists read-only examples,
+#: which leaves no route to the thing the agent was trying to do. Naming these
+#: lets the refusal point at edit_file instead of dead-ending (#3600).
+FILE_REWRITE_BINARIES = frozenset(
+    {"sed", "awk", "perl", "tee", "patch", "dd", "truncate", "ex", "ed"}
+)
+
 
 #: The one tool whose executor enforces the read-only binary policy, and so the
 #: only one a ``shell:execute`` grant may exempt from confirmation.
@@ -727,6 +736,24 @@ class ShellToolsMixin:
                     "hint": "Use a single input (or stdin) and read stdout, e.g. 'uniq file' or 'sort file | uniq'.",
                 }
         elif cmd_base not in ALLOWED_COMMANDS:
+            # Refusing a file rewrite with "only read-only commands are allowed"
+            # is a dead end: the agent wanted to change a file and the message
+            # names nothing that can. Point at the tool that does the job.
+            if cmd_base in FILE_REWRITE_BINARIES:
+                return {
+                    "status": "error",
+                    "error": (
+                        f"'{cmd_base}' rewrites files and is not available. Use the "
+                        f"edit tools instead — they are not blocked."
+                    ),
+                    "has_errors": True,
+                    "hint": (
+                        "Call edit_file with the exact existing text as old_content, "
+                        "or edit_python_file for .py to have the edit syntax-checked. "
+                        "Use write_file to create a file that does not exist yet."
+                    ),
+                    "examples": "edit_file(file_path=..., old_content=..., new_content=...)",
+                }
             return {
                 "status": "error",
                 "error": f"Command '{cmd_base}' is not in the allowed list for security reasons",

--- a/tests/unit/test_file_editing_prompt.py
+++ b/tests/unit/test_file_editing_prompt.py
@@ -1,0 +1,58 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+"""The edit tools have to be mentioned in the prompt, or the agent shells out.
+
+Measured on 30 corpus moments whose correct next action was an edit, with the
+target file already held: the shipped prompt named the shell seven times with
+worked recipes and ``edit_file`` not once. The agent shelled out or re-read
+instead of editing on 23 of them. Adding the fragment took working edits from
+1 to 6 and shell fallbacks from 19 to 12.
+
+These tests pin the fragment's existence and its discovery, not its wording —
+the wording should stay tunable.
+"""
+
+from gaia.agents.tools.file_io_tools import FileIOToolsMixin
+
+
+class _Bare(FileIOToolsMixin):
+    """The mixin alone — no agent, no registry, no LLM."""
+
+
+class TestTheFragmentExists:
+    def test_it_names_the_edit_tools(self):
+        text = _Bare().get_file_editing_system_prompt()
+        assert "edit_file" in text
+        assert "edit_python_file" in text
+
+    def test_it_steers_away_from_rewriting_files_through_the_shell(self):
+        text = _Bare().get_file_editing_system_prompt().lower()
+        # The failure mode this exists to prevent: sed/awk/heredoc rewrites.
+        assert "sed" in text and "awk" in text
+        assert "heredoc" in text
+
+    def test_it_says_not_to_re_read_held_content(self):
+        text = _Bare().get_file_editing_system_prompt().lower()
+        assert "already hold" in text
+
+    def test_it_stays_small(self):
+        """It rides on every call; the prompt is already ~15K chars."""
+        assert len(_Bare().get_file_editing_system_prompt()) < 800
+
+
+class TestAutoDiscovery:
+    def test_the_name_matches_the_pattern_the_agent_scans_for(self):
+        """``_get_mixin_prompts`` collects ``get_*_system_prompt`` off the instance.
+
+        A rename that breaks the pattern silently drops the fragment, and the
+        only symptom is the agent quietly going back to shelling out.
+        """
+        name = "get_file_editing_system_prompt"
+        assert name.startswith("get_") and name.endswith("_system_prompt")
+        assert callable(getattr(_Bare(), name))
+
+    def test_it_is_reachable_on_an_agent_that_composes_the_mixin(self):
+        from gaia.agents.tools.file_io_tools import FileIOToolsMixin as M
+
+        assert hasattr(M, "get_file_editing_system_prompt")

--- a/tests/unit/test_shell_rewrite_redirect.py
+++ b/tests/unit/test_shell_rewrite_redirect.py
@@ -22,11 +22,24 @@ validate = ShellToolsMixin._validate_command
 
 class TestARefusedRewritePointsAtTheEditTools:
     @pytest.mark.parametrize("binary", sorted(FILE_REWRITE_BINARIES))
-    def test_every_rewrite_binary_names_edit_file(self, binary):
-        result = validate(binary, [binary, "x"], f"{binary} x")
-        assert result is not None, f"{binary} should still be refused"
+    def test_every_rewrite_binary_is_still_refused(self, binary):
+        assert validate(binary, [binary, "x"], f"{binary} x") is not None
+
+    @pytest.mark.parametrize(
+        "parts",
+        [
+            ["sed", "-i", "s/a/b/", "f.py"],
+            ["sed", "-i.bak", "s/a/b/", "f.py"],
+            ["perl", "-i", "-pe", "s/a/b/", "f"],
+            ["awk", "-i", "inplace", "{print}", "f"],
+            ["tee", "out.txt"],
+            ["patch", "-p1"],
+        ],
+    )
+    def test_an_in_place_rewrite_names_edit_file(self, parts):
+        result = validate(parts[0], parts, " ".join(parts))
         blob = " ".join(str(v) for v in result.values())
-        assert "edit_file" in blob, f"{binary}'s refusal must name edit_file"
+        assert "edit_file" in blob, f"{parts} should point at the edit tools"
 
     def test_it_mentions_the_python_variant_and_file_creation(self):
         result = validate("sed", ["sed", "-i", "s/a/b/", "f.py"], "sed -i s/a/b/ f.py")
@@ -39,6 +52,25 @@ class TestARefusedRewritePointsAtTheEditTools:
         result = validate("sed", ["sed", "-i", "s/a/b/", "f"], "sed -i s/a/b/ f")
         assert result["status"] == "error"
         assert result["has_errors"] is True
+
+
+class TestAReadIsNotARewrite:
+    """`sed -n '10,20p' f` prints a range. Answering that with "use edit_file"
+    sends the agent to a write tool when it was trying to read — caught by
+    re-running the corpus after the first version of this guard shipped."""
+
+    @pytest.mark.parametrize(
+        "parts",
+        [
+            ["sed", "-n", "288,294p", "f.md"],
+            ["awk", "{print $1}", "f.csv"],
+            ["perl", "-pe", "s/a/b/", "f"],
+        ],
+    )
+    def test_a_read_only_invocation_does_not_point_at_edit_file(self, parts):
+        result = validate(parts[0], parts, " ".join(parts))
+        blob = " ".join(str(v) for v in (result or {}).values())
+        assert "edit_file" not in blob, f"{parts} is a read, not an edit"
 
 
 class TestNothingElseChanged:

--- a/tests/unit/test_shell_rewrite_redirect.py
+++ b/tests/unit/test_shell_rewrite_redirect.py
@@ -1,0 +1,58 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+"""A refused file rewrite has to name the tool that can do the job.
+
+`sed`, `awk`, `tee` and friends are not on ALLOWED_COMMANDS, so an agent that
+reaches for one to change a file is refused either way. The problem was the
+message: "only read-only, informational commands are allowed", followed by
+read-only examples. That is a dead end — the agent wanted to change a file and
+nothing in the refusal points at anything that can.
+
+Measured on 30 corpus moments whose correct next action was an edit: the agent
+shelled out on 19 of them (#3600).
+"""
+
+import pytest
+
+from gaia.agents.tools.shell_tools import FILE_REWRITE_BINARIES, ShellToolsMixin
+
+validate = ShellToolsMixin._validate_command
+
+
+class TestARefusedRewritePointsAtTheEditTools:
+    @pytest.mark.parametrize("binary", sorted(FILE_REWRITE_BINARIES))
+    def test_every_rewrite_binary_names_edit_file(self, binary):
+        result = validate(binary, [binary, "x"], f"{binary} x")
+        assert result is not None, f"{binary} should still be refused"
+        blob = " ".join(str(v) for v in result.values())
+        assert "edit_file" in blob, f"{binary}'s refusal must name edit_file"
+
+    def test_it_mentions_the_python_variant_and_file_creation(self):
+        result = validate("sed", ["sed", "-i", "s/a/b/", "f.py"], "sed -i s/a/b/ f.py")
+        blob = " ".join(str(v) for v in result.values())
+        assert "edit_python_file" in blob
+        assert "write_file" in blob
+
+    def test_it_is_still_a_refusal_not_a_pass(self):
+        """The command must not become runnable — only better explained."""
+        result = validate("sed", ["sed", "-i", "s/a/b/", "f"], "sed -i s/a/b/ f")
+        assert result["status"] == "error"
+        assert result["has_errors"] is True
+
+
+class TestNothingElseChanged:
+    def test_an_unrelated_blocked_command_keeps_the_generic_message(self):
+        result = validate("nmap", ["nmap", "-p", "80", "h"], "nmap -p 80 h")
+        assert result is not None
+        assert "not in the allowed list" in result["error"]
+        assert "edit_file" not in " ".join(str(v) for v in result.values())
+
+    def test_an_allowed_command_still_passes(self):
+        assert validate("ls", ["ls", "-la"], "ls -la") is None
+
+    def test_no_rewrite_binary_was_accidentally_allowlisted(self):
+        """This guard only changes the message; it must never grant the binary."""
+        from gaia.agents.tools.shell_tools import ALLOWED_COMMANDS
+
+        assert not (FILE_REWRITE_BINARIES & ALLOWED_COMMANDS)


### PR DESCRIPTION
Asked to change a file it was already holding, GAIA shelled out or re-read the file instead of editing it on **23 of 30** real moments. The system prompt named the shell seven times with worked recipes (`systeminfo`, `tasklist`, powershell one-liners) and mentioned `edit_file` **zero times** — so the agent had never been told the tool exists.

Measured on the same 30 moments, against a build of this branch:

| | Proposed an edit | **Working edits** | Shelled out |
|---|--:|--:|--:|
| main | 7 / 30 | **1** | 19 |
| this branch | 10 / 30 | **6** | 12 |

A working edit is one whose `old_content` appears verbatim in the file — checked deterministically, no LLM judge.

## Needs sign-off: 15 golden prompts drift

`tests/unit/test_profilespec_characterization.py` fails on 15 of 17 rows — every profile that composes `FileIOToolsMixin`. **I have not regenerated the goldens**, because that test says not to:

> If this drift is an INTENTIONAL part of the ProfileSpec refactor, it is not behavior-preserving and needs sign-off, not a golden update.

This drift is intentional and is *not* part of that refactor: it is a deliberate prompt addition. Regenerating silently would defeat the guard. A maintainer should confirm the change is wanted, then the goldens can be recaptured in a follow-up commit.

## Test plan

- [ ] `pytest tests/unit/test_file_editing_prompt.py` — 6 pass
- [ ] `python util/lint.py --all`
- [ ] Confirm the fragment lands in the cacheable head: build a flagship agent and check `_compose_system_prompt()` contains `CHANGING A FILE` near the start, not in the volatile tail
- [ ] Decide on the 15 golden rows above
- [ ] Agent eval before merge — this is an LLM-affecting change

<details>
<summary>🔍 Technical details</summary>

**What it adds.** `FileIOToolsMixin.get_file_editing_system_prompt()` — auto-discovered by `Agent._get_mixin_prompts`, which collects any `get_*_system_prompt` off the instance. Static text, so `_compose_system_prompt` keeps it in the head; the volatile tail is reserved for fragments that change mid-session and would invalidate the KV cache.

**Cost.** 556 chars, roughly 139 tokens on every call. The prompt goes 14,747 → 15,303. Worth stating given #3073 is trying to shrink it.

**Three explanations tested and rejected first**, each with one variable changed and everything else held:

| Hypothesis | Effect on working edits |
|---|---|
| The tool description names the wrong file types (#3601) | 1 → 2 |
| The edit tools sit at position 33 of 67 | 1 → 4 |
| The agent cannot quote content it was never shown | 1 → 3 (fixes anchors, not tool choice) |
| **The prompt never mentions the tool** | **1 → 6** |

**The gap is not closed.** 10 of 30 is still far from the reference's 30 of 30, and the agent prefers the shell on 12 moments even when told directly not to. That residual is tracked in #3600 and looks like a loop problem rather than a prompt one.

Closes nothing outright; advances #3600, relates to #3584 and #3601.
</details>
