### PR TITLE
fix(api,mcp,web): refuse foreign origins and internal fetch targets

### DIFF
--- a/docs/integrations/mcp.mdx
+++ b/docs/integrations/mcp.mdx
@@ -455,8 +455,8 @@ For production deployments, always implement these security measures:
   <Card title="Agent Access" icon="robot">
     Direct access to all GAIA agents
   </Card>
-  <Card title="CORS Enabled" icon="browser">
-    Works with browser-based applications
+  <Card title="Loopback Browser Origins" icon="browser">
+    Browser apps on localhost work; other origins need `GAIA_MCP_ALLOWED_ORIGINS`
   </Card>
 </CardGroup>
 

--- a/docs/integrations/n8n.mdx
+++ b/docs/integrations/n8n.mdx
@@ -584,7 +584,8 @@ Each endpoint returns different data structures:
     **Solutions**:
     - **First try**: Ensure MCP server is running and use `http://localhost:8765`
     - Verify n8n can reach the MCP bridge
-    - Check CORS settings if using browser-based n8n
+    - Browser-based n8n on another origin is refused (403) by the bridge; add that
+      origin to `GAIA_MCP_ALLOWED_ORIGINS` (comma-separated) before `gaia mcp start`
     - Test with curl first to isolate issues
   </Accordion>
 </AccordionGroup>

--- a/docs/reference/api-spec.mdx
+++ b/docs/reference/api-spec.mdx
@@ -325,14 +325,17 @@ All errors follow OpenAI's error format.
 </Warning>
 
 **Current Implementation:**
-- ❌ No authentication
+- ⚠️ Optional API key: set `GAIA_API_KEY` and every chat completion must send
+  `Authorization: Bearer <key>` (401 otherwise). Unset, loopback callers are
+  allowed with a startup warning, and binding beyond loopback is refused. See
+  [Authentication](/sdk/infrastructure/api-server#authentication).
+- ✅ CORS limited to loopback origins; add others with `GAIA_API_CORS_ORIGINS`.
+  Browser requests from any other origin are refused with 403.
 - ❌ No rate limiting
-- ✅ CORS enabled (all origins)
 
 **For Production Deployment:**
-- Implement API key authentication
+- Set `GAIA_API_KEY`
 - Add rate limiting middleware
-- Configure CORS restrictions
 - Use HTTPS with valid certificates
 
 ---

--- a/docs/reference/cli.mdx
+++ b/docs/reference/cli.mdx
@@ -1081,8 +1081,11 @@ curl http://localhost:8080/health
     gaia api start --debug
     ```
 
-    Custom host/port:
+    Custom host/port. Binding beyond loopback is refused unless
+    `GAIA_API_KEY` is set, since the agent loop would otherwise be open to the
+    network ([Authentication](/sdk/infrastructure/api-server#authentication)):
     ```bash
+    export GAIA_API_KEY=$(openssl rand -hex 32)
     gaia api start --host 0.0.0.0 --port 8888
     ```
 
@@ -1249,6 +1252,15 @@ gaia mcp test --query "Hello from GAIA MCP!"
 | `--log-file` | stdout | Write logs to this path (useful with `--background`) |
 | `--verbose` | off | Verbose logging |
 | `--ctx-size` | `32768` | Context window hint passed to Lemonade for loaded models |
+
+##### Browser origins
+
+A web page can reach `http://localhost:8765` from the user's own browser, so
+the bridge refuses any request whose `Origin` is not loopback (`localhost`,
+`127.0.0.1`, `[::1]`) with **403**, and never answers
+`Access-Control-Allow-Origin: *`. Clients that send no `Origin` — curl, MCP
+clients, n8n — are unaffected. To allow a browser app on another origin, list
+it in `GAIA_MCP_ALLOWED_ORIGINS` (comma-separated).
 
 ##### Authentication
 

--- a/docs/sdk/infrastructure/api-server.mdx
+++ b/docs/sdk/infrastructure/api-server.mdx
@@ -21,8 +21,9 @@ title: "API Server"
 from gaia.api.openai_server import app
 import uvicorn
 
-# Run server (app is a module-level FastAPI instance)
-uvicorn.run(app, host="0.0.0.0", port=8080)
+# Run server (app is a module-level FastAPI instance). Keep it on loopback;
+# see "Authentication" below before binding anything wider.
+uvicorn.run(app, host="127.0.0.1", port=8080)
 
 # Now accessible via the OpenAI SDK. The flagship ships registered as "gaia";
 # add more in AGENT_MODELS (see below):
@@ -51,6 +52,38 @@ Setting the variable to `*` opens the API to all origins but disables
 credentialed requests — wildcard origins combined with credentials are
 forbidden by the Fetch spec and would let any website the user visits call
 the local API.
+
+### Authentication
+
+`POST /v1/chat/completions` runs the agent loop, so a caller that reaches it can
+make the agent read files and call tools. Set `GAIA_API_KEY` to require a key:
+
+```bash
+export GAIA_API_KEY=$(openssl rand -hex 32)
+gaia api start
+curl -H "Authorization: Bearer $GAIA_API_KEY" http://localhost:8080/v1/chat/completions ...
+```
+
+| `GAIA_API_KEY` | Bind | Behaviour |
+|---|---|---|
+| set | any | Every chat completion must send `Authorization: Bearer <key>`; otherwise **401** |
+| unset | loopback (`localhost`, `127.0.0.1`) | Allowed, with one startup warning. A future release will require a key |
+| unset | anything else (`0.0.0.0`, a LAN IP) | **Refused at startup** — the agent loop would be open to the network |
+
+Browser requests from an origin outside the CORS allowlist are refused with
+**403** before the agent runs, whether or not a key is set.
+
+The `/v1/<agent>/*` relay is stricter: it is disabled (**503**) until
+`GAIA_API_KEY` is set.
+
+Agents served with `--api` through the framework's generic server
+(`gaia.agents.base.server.AgentServer`) apply the same policy to every route
+except `/health`.
+
+<Note>
+The VSCode extension sends a fixed key (`Bearer gaia`). It keeps working while
+`GAIA_API_KEY` is unset; once you set a key, the extension's requests get 401.
+</Note>
 
 ### High-risk tools are refused
 

--- a/docs/spec/agent-hub-restructure.mdx
+++ b/docs/spec/agent-hub-restructure.mdx
@@ -261,6 +261,7 @@ Replace ~16 direct agent imports in `cli.py`, `ui/_chat_helpers.py`, `ui/agent_l
 </Step>
 <Step title="Add framework generic server">
 `src/gaia/agents/base/server.py` wraps any Agent into REST API + MCP server. Enables `gaia agent run <id> --api` and `--mcp`, and serves the agent's [inherited init](#inherited-init) routes.
+The REST API admits loopback browser origins only and enforces `GAIA_API_KEY` on every route but `/health` when it is set; `--api` on a non-loopback `--host` is refused without one (see [API server authentication](/sdk/infrastructure/api-server#authentication)).
 </Step>
 <Step title="Add CI/CD workflow">
 `.github/workflows/build_agents.yml` matrix-builds the C++ agent binaries;

--- a/docs/spec/api-server.mdx
+++ b/docs/spec/api-server.mdx
@@ -206,16 +206,15 @@ app = FastAPI(
     version="1.0.0",
 )
 
-# CORS middleware
-app.add_middleware(
-    CORSMiddleware,
-    allow_origins=["*"],
-    allow_credentials=True,
-    allow_methods=["*"],
-    allow_headers=["*"],
+# CORS: loopback origins only, plus GAIA_API_CORS_ORIGINS (gaia/api/local_http.py)
+app.add_middleware(CORSMiddleware, **cors_config())
+
+# Foreign browser origins -> 403; GAIA_API_KEY enforced when set
+_chat_completions_guard = build_caller_guard(
+    "POST /v1/chat/completions", public_paths=frozenset()
 )
 
-@app.post("/v1/chat/completions")
+@app.post("/v1/chat/completions", dependencies=[Depends(_chat_completions_guard)])
 async def create_chat_completion(request: ChatCompletionRequest):
     """
     Create chat completion (OpenAI-compatible endpoint).
@@ -696,8 +695,8 @@ gaia api start
 # Background
 gaia api start --background
 
-# Custom host/port
-gaia api start --host 0.0.0.0 --port 9090
+# Custom host/port (binding beyond loopback requires GAIA_API_KEY)
+GAIA_API_KEY=$(openssl rand -hex 32) gaia api start --host 0.0.0.0 --port 9090
 
 # With debug
 gaia api start --debug --show-prompts

--- a/docs/spec/api-server.mdx
+++ b/docs/spec/api-server.mdx
@@ -196,9 +196,10 @@ class ModelListResponse(BaseModel):
 ### API Endpoints
 
 ```python
-from fastapi import FastAPI, HTTPException
+from fastapi import Depends, FastAPI, HTTPException
 from fastapi.responses import StreamingResponse
 from fastapi.middleware.cors import CORSMiddleware
+from gaia.api.local_http import build_caller_guard, cors_config
 
 app = FastAPI(
     title="GAIA OpenAI-Compatible API",
@@ -881,3 +882,10 @@ Copyright(C) 2024-2026 Advanced Micro Devices, Inc. All rights reserved.
 SPDX-License-Identifier: MIT
 
 </small>
+
+### VS Code client authentication
+
+Run **GAIA: Set API Key** from the VS Code command palette and enter the same value
+as the server's `GAIA_API_KEY`. The extension stores it in VS Code SecretStorage and
+uses it for model discovery and chat completions. Leave the input blank to clear
+it; cancelling preserves the existing key. Keyless loopback servers continue to work.

--- a/hub/agents/chat/python/gaia_agent_chat/agent.py
+++ b/hub/agents/chat/python/gaia_agent_chat/agent.py
@@ -366,6 +366,9 @@ class ChatAgent(
 
         # Initialize web client for browser tools (optional)
         self._web_client = None
+        # Guarded client for the inline open_url/fetch_webpage tools; built on
+        # first use (see _inline_web_client).
+        self._inline_web = None
         if config.enable_browser:
             try:
                 from gaia.web.client import WebClient
@@ -560,6 +563,24 @@ class ChatAgent(
     @session_manager.setter
     def session_manager(self, value: SessionManager) -> None:
         self._session_manager = value
+
+    def _inline_web_client(self):
+        """The SSRF-guarded ``WebClient`` behind ``open_url``/``fetch_webpage``.
+
+        Built on first use so profiles without web tools never pay for it.
+        Kept apart from ``self._web_client`` (the opt-in browser mixin's
+        client) so using these tools does not also switch ``fetch_page`` on.
+        """
+        # getattr: tests build agents via __new__ and skip __init__.
+        if getattr(self, "_inline_web", None) is None:
+            from gaia.web.client import WebClient
+
+            self._inline_web = WebClient(
+                timeout=self.config.browser_timeout,
+                max_download_size=self.config.browser_max_download_size,
+                rate_limit=self.config.browser_rate_limit,
+            )
+        return self._inline_web
 
     def _ensure_tool_loader_reset(self) -> None:
         """Bootstrap a session for a just-created agent, if none exists yet.
@@ -1517,11 +1538,13 @@ No documents are currently indexed.
                 """
                 import webbrowser
 
-                if not url.startswith(("http://", "https://")):
-                    return {
-                        "status": "error",
-                        "error": "URL must start with http:// or https://",
-                    }
+                try:
+                    # Same SSRF screen as fetch_webpage: an injected link to a
+                    # loopback admin page would open with the user's cookies.
+                    self._inline_web_client().validate_url(url)
+                except ValueError as e:
+                    logger.warning("open_url refused %s: %s", url, e)
+                    return {"status": "error", "url": url, "error": str(e)}
                 try:
                     webbrowser.open(url)
                     return {
@@ -1542,15 +1565,10 @@ No documents are currently indexed.
                 Returns:
                     Dictionary with status, content (or html), and url
                 """
-                import httpx
-
-                if not url.startswith(("http://", "https://")):
-                    return {
-                        "status": "error",
-                        "error": "URL must start with http:// or https://",
-                    }
                 try:
-                    resp = httpx.get(url, timeout=15, follow_redirects=True)
+                    # WebClient refuses private/loopback/link-local targets,
+                    # re-checks after DNS and on every redirect hop.
+                    resp = self._inline_web_client().get(url)
                     resp.raise_for_status()
                     if extract_text:
                         try:
@@ -1576,7 +1594,8 @@ No documents are currently indexed.
                         "html": resp.text[:8000],
                         "truncated": len(resp.text) > 8000,
                     }
-                except Exception as e:
+                except Exception as e:  # tool boundary -> structured error
+                    logger.warning("fetch_webpage failed for %s: %s", url, e)
                     return {"status": "error", "url": url, "error": str(e)}
 
         @tool

--- a/hub/agents/chat/python/gaia_agent_chat/agent.py
+++ b/hub/agents/chat/python/gaia_agent_chat/agent.py
@@ -1528,10 +1528,12 @@ No documents are currently indexed.
 
             @tool
             def open_url(url: str) -> dict:
-                """Open a URL in the system's default web browser.
+                """Open a public URL in the system's default web browser.
+
+                Refuses private, loopback, and link-local addresses.
 
                 Args:
-                    url: The URL to open (must start with http:// or https://)
+                    url: Public http:// or https:// URL to open
 
                 Returns:
                     Dictionary with status and confirmation message
@@ -1542,7 +1544,7 @@ No documents are currently indexed.
                     # Same SSRF screen as fetch_webpage: an injected link to a
                     # loopback admin page would open with the user's cookies.
                     self._inline_web_client().validate_url(url)
-                except ValueError as e:
+                except (ValueError, OSError, ImportError) as e:
                     logger.warning("open_url refused %s: %s", url, e)
                     return {"status": "error", "url": url, "error": str(e)}
                 try:
@@ -2397,6 +2399,11 @@ No documents are currently indexed.
                 self._web_client.close()
         except Exception as e:
             logger.error(f"Error closing web client during cleanup: {e}")
+        try:
+            if getattr(self, "_inline_web", None):
+                self._inline_web.close()
+        except Exception as e:
+            logger.error(f"Error closing inline web client during cleanup: {e}")
         try:
             if self._fs_index:
                 self._fs_index.close_db()

--- a/src/gaia/agents/base/server.py
+++ b/src/gaia/agents/base/server.py
@@ -419,10 +419,11 @@ class AgentServer:
         """
         self._ensure_interface(INTERFACE_API)
 
-        from fastapi import FastAPI, HTTPException
+        from fastapi import Depends, FastAPI, HTTPException
         from fastapi.middleware.cors import CORSMiddleware
         from fastapi.responses import StreamingResponse
 
+        from gaia.api.local_http import build_caller_guard, cors_config
         from gaia.api.schemas import (
             ChatCompletionChoice,
             ChatCompletionRequest,
@@ -433,18 +434,15 @@ class AgentServer:
             UsageInfo,
         )
 
+        # App-wide, so a route mounted later (``/v1/<id>/init``) is guarded too.
+        caller_guard = build_caller_guard(self.api_surface)
         app = FastAPI(
             title=f"GAIA {self.name} API",
             description=f"OpenAI-compatible API for the {self.name} agent",
             version="1.0.0",
+            dependencies=[Depends(caller_guard)],
         )
-        app.add_middleware(
-            CORSMiddleware,
-            allow_origins=["*"],
-            allow_credentials=True,
-            allow_methods=["*"],
-            allow_headers=["*"],
-        )
+        app.add_middleware(CORSMiddleware, **cors_config())
 
         def _estimate_tokens(text: str) -> int:
             if isinstance(self.agent, ApiAgent):
@@ -638,6 +636,11 @@ class AgentServer:
                 status_code=200,
             )
 
+    @property
+    def api_surface(self) -> str:
+        """Human-readable name of this agent's REST surface, for logs/errors."""
+        return f"the {self.name} REST API (--api)"
+
     def _sse_stream(self, prompt: str):
         """Minimal OpenAI-compatible SSE: role chunk, content chunk, done."""
         completion_id = f"chatcmpl-{uuid.uuid4().hex[:24]}"
@@ -666,6 +669,9 @@ class AgentServer:
         self._ensure_interface(INTERFACE_API)
         import uvicorn
 
+        from gaia.api.local_http import assert_bind_is_authenticated
+
+        assert_bind_is_authenticated(host, self.api_surface)
         app = self.build_api_app()
         print(
             f"🚀 Serving {self.name} on http://{host}:{port} (model: {self.model_id})"

--- a/src/gaia/api/agent_proxy.py
+++ b/src/gaia/api/agent_proxy.py
@@ -30,27 +30,25 @@ from __future__ import annotations
 
 import asyncio
 import json
-import os
-import secrets
-from typing import Optional
 
 # Module-level import (matches gaia.daemon.relay): the endpoint annotation
 # ``request: Request`` below must resolve from module globals under PEP 563.
 import httpx
-from fastapi import APIRouter, Depends, Header, HTTPException, Request
+from fastapi import APIRouter, Depends, HTTPException, Request
 from fastapi.responses import Response, StreamingResponse
 from starlette.convertors import Convertor, register_url_convertor
 
+from gaia.api import local_http
 from gaia.daemon.errors import DaemonError
 from gaia.daemon.timeouts import DEFAULT_AGENT_READ_TIMEOUT, agent_read_timeout
 from gaia.logger import get_logger
 
 logger = get_logger(__name__)
 
-#: Environment variable holding the API key that gates the agent query surface.
-API_KEY_ENV = "GAIA_API_KEY"
-#: Auth scheme for the API key (mirrors the daemon's Bearer contract).
-AUTH_SCHEME = "Bearer"
+#: Re-exported from the shared local-HTTP policy so callers of this module
+#: keep working and there is still one definition.
+API_KEY_ENV = local_http.API_KEY_ENV
+AUTH_SCHEME = local_http.AUTH_SCHEME
 
 #: Connect timeout — a dead daemon should fail fast on TCP connect.
 CONNECT_TIMEOUT = 10.0
@@ -185,55 +183,14 @@ def _synthetic_error_frame(detail: str) -> bytes:
 def build_require_api_key():
     """FastAPI dependency enforcing the ``GAIA_API_KEY`` on the agent surface.
 
-    No silent fallback: an unset key disables the surface with a loud 503 naming
-    the remedy (rather than allowing unauthenticated access to the agentic loop);
-    a missing/malformed/invalid key is a 401 naming what to send.
+    ``required=True``: an unset key disables the surface with a loud 503 naming
+    the remedy, rather than allowing unauthenticated access to the agentic
+    loop. The check itself lives in :mod:`gaia.api.local_http`, shared with
+    every other GAIA local HTTP server.
     """
-
-    def require_api_key(authorization: Optional[str] = Header(default=None)) -> None:
-        expected = os.environ.get(API_KEY_ENV)
-        if not expected:
-            raise HTTPException(
-                status_code=503,
-                detail=(
-                    "The agent query surface (POST /v1/<agent>/query) is disabled: "
-                    f"no API key is configured. Set {API_KEY_ENV} in the API "
-                    "server's environment (e.g. "
-                    f"`export {API_KEY_ENV}=$(openssl rand -hex 32)`), restart "
-                    "`gaia api`, and send it as "
-                    f"'Authorization: {AUTH_SCHEME} <key>'."
-                ),
-            )
-        if not authorization:
-            raise HTTPException(
-                status_code=401,
-                detail=(
-                    f"Missing API key. Send 'Authorization: {AUTH_SCHEME} <key>' "
-                    f"matching {API_KEY_ENV} on the API server."
-                ),
-                headers={"WWW-Authenticate": AUTH_SCHEME},
-            )
-        scheme, _, credential = authorization.partition(" ")
-        if scheme.lower() != AUTH_SCHEME.lower() or not credential:
-            raise HTTPException(
-                status_code=401,
-                detail=(
-                    f"Malformed Authorization header. Expected "
-                    f"'{AUTH_SCHEME} <key>'."
-                ),
-                headers={"WWW-Authenticate": AUTH_SCHEME},
-            )
-        if not secrets.compare_digest(credential, expected):
-            raise HTTPException(
-                status_code=401,
-                detail=(
-                    f"Invalid API key. It must match {API_KEY_ENV} on the API "
-                    "server."
-                ),
-                headers={"WWW-Authenticate": AUTH_SCHEME},
-            )
-
-    return require_api_key
+    return local_http.build_require_api_key(
+        "The agent query surface (POST /v1/<agent>/query)", required=True
+    )
 
 
 async def _acquire_daemon():

--- a/src/gaia/api/app.py
+++ b/src/gaia/api/app.py
@@ -18,6 +18,7 @@ import subprocess
 import sys
 from pathlib import Path
 
+from gaia.api.local_http import assert_bind_is_authenticated
 from gaia.api.sse_handler import warn_if_unconfirmed_tools_allowed
 
 logger = logging.getLogger(__name__)
@@ -51,6 +52,9 @@ def start_server(
         ✅ GAIA API server started with debug mode enabled
     """
     warn_if_unconfirmed_tools_allowed()
+    # A LAN-reachable bind with no caller auth puts the agent loop on the
+    # network for anyone who can route to the port.
+    assert_bind_is_authenticated(host, "the GAIA API server")
 
     # Set environment variables for agent configuration
     # These will be read by agent_registry.py when agents are instantiated

--- a/src/gaia/api/local_http.py
+++ b/src/gaia/api/local_http.py
@@ -1,0 +1,339 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+"""One cross-origin and caller-auth policy for GAIA's local HTTP servers.
+
+Three servers bind loopback on this machine and each answered the same two
+questions differently: *which browser origins may read a response*, and *who
+may call at all*. ``gaia api`` got CORS right and auth wrong; the generic
+``AgentServer`` (``--api``) reflected every requesting Origin back with
+credentials; the MCP bridge answered every origin ``*``. Loopback is not a
+boundary against any of that -- the attacker is a page in the user's own
+browser reaching ``http://localhost:<port>``.
+
+This module is the single copy of the answer, so the next server inherits the
+policy instead of inventing a fourth one. It deliberately imports no web
+framework at module scope: the MCP bridge runs on ``http.server`` and has to
+ask the same questions.
+
+Related: :mod:`gaia.ui.security` enforces the equivalent rules for the Agent
+UI backend, which additionally has an ``X-Gaia-UI`` CSRF header that all of
+its first-party clients send.
+"""
+
+import ipaddress
+import os
+import re
+import secrets
+from typing import List, Optional, Tuple
+
+from gaia.logger import get_logger
+
+logger = get_logger(__name__)
+
+# -- Origins -----------------------------------------------------------------
+
+#: Browser origins allowed by default: localhost / 127.0.0.1 / [::1] on any
+#: port. GAIA's own local pages (the example app's dev server on :3000, a
+#: notebook) live here; a page on the open web does not.
+LOCAL_ORIGIN_REGEX = r"^https?://(localhost|127\.0\.0\.1|\[::1\])(:\d+)?$"
+_LOCAL_ORIGIN_RE = re.compile(LOCAL_ORIGIN_REGEX)
+
+#: Comma-separated extra origins, e.g. ``https://myapp.example.com``.
+CORS_ORIGINS_ENV = "GAIA_API_CORS_ORIGINS"
+
+
+def extra_origins(env_var: str = CORS_ORIGINS_ENV) -> List[str]:
+    """Operator-configured origins from *env_var*. Empty by default."""
+    raw = os.environ.get(env_var, "")
+    return [o.strip() for o in raw.split(",") if o.strip()]
+
+
+def is_local_origin(origin: str) -> bool:
+    """Whether *origin* is a loopback origin on this machine."""
+    return bool(origin) and bool(_LOCAL_ORIGIN_RE.match(origin.strip()))
+
+
+def is_allowed_origin(origin: str, env_var: str = CORS_ORIGINS_ENV) -> bool:
+    """Whether a browser at *origin* may read this server's responses.
+
+    A request with no ``Origin`` is not a browser request and is not this
+    function's business -- callers decide that separately.
+    """
+    origin = (origin or "").strip()
+    if not origin:
+        return False
+    allowed = extra_origins(env_var)
+    if "*" in allowed:
+        return True
+    return is_local_origin(origin) or origin in allowed
+
+
+def cors_config(env_var: str = CORS_ORIGINS_ENV) -> dict:
+    """Build a Starlette ``CORSMiddleware`` policy: localhost-only by default.
+
+    *env_var* (comma-separated) adds extra allowed origins. A literal ``*``
+    opts into open CORS, which the Fetch spec forbids combining with
+    credentials -- so the wildcard also disables credentialed requests.
+    Wildcard origins WITH credentials are never configured: Starlette reflects
+    any request Origin back in that combination, which is exactly what lets
+    any website the user visits read this local, unauthenticated API.
+    """
+    origins = extra_origins(env_var)
+    if "*" in origins:
+        logger.warning(
+            "%s='*': allowing all origins WITHOUT credentials. To allow "
+            "credentialed cross-origin calls, list explicit origins instead "
+            "of '*'.",
+            env_var,
+        )
+        return {
+            "allow_origins": ["*"],
+            "allow_credentials": False,
+            "allow_methods": ["*"],
+            "allow_headers": ["*"],
+        }
+    return {
+        "allow_origins": origins,
+        "allow_origin_regex": LOCAL_ORIGIN_REGEX,
+        "allow_credentials": True,
+        "allow_methods": ["*"],
+        "allow_headers": ["*"],
+    }
+
+
+def origin_is_rejected(origin: str, env_var: str = CORS_ORIGINS_ENV) -> bool:
+    """Whether a request carrying *origin* must be refused outright.
+
+    A request with no ``Origin`` header is not from a browser (curl, an MCP
+    client, the Electron main process) and is left alone -- there is no
+    cross-site attack to mount without one. A request that names an origin
+    this server does not trust is refused before it reaches a handler, so a
+    CORS misconfiguration is never the only thing standing between a random
+    web page and the agent loop.
+    """
+    return bool((origin or "").strip()) and not is_allowed_origin(origin, env_var)
+
+
+# -- Binds -------------------------------------------------------------------
+
+
+def is_loopback_bind(host: str) -> bool:
+    """Whether binding *host* keeps the server on this machine.
+
+    An empty host, ``0.0.0.0`` and ``::`` all listen on every interface.
+    """
+    host = (host or "").strip().lower()
+    if not host:
+        return False
+    if host == "localhost" or host.endswith(".localhost"):
+        return True
+    if host.startswith("[") and host.endswith("]"):
+        host = host[1:-1]
+    try:
+        return ipaddress.ip_address(host).is_loopback
+    except ValueError:
+        # A name we cannot classify. Treat as non-loopback: assuming the safe
+        # answer for an unknown name is how an exposed bind slips through.
+        return False
+
+
+# -- Caller auth -------------------------------------------------------------
+
+#: Environment variable holding the API key that gates the agent surfaces.
+API_KEY_ENV = "GAIA_API_KEY"
+#: Auth scheme for the API key (mirrors the daemon's Bearer contract).
+AUTH_SCHEME = "Bearer"
+
+#: Surfaces that have already logged their "running unauthenticated" warning,
+#: so a per-request dependency does not repeat it on every call.
+_WARNED_SURFACES: set = set()
+
+
+def api_key_configured() -> bool:
+    """Whether an API key is set. An empty value counts as unset."""
+    return bool(os.environ.get(API_KEY_ENV))
+
+
+def warn_if_unauthenticated(surface: str) -> None:
+    """Say once, loudly, that *surface* answers anyone who can reach it."""
+    if api_key_configured() or surface in _WARNED_SURFACES:
+        return
+    _WARNED_SURFACES.add(surface)
+    logger.warning(
+        "%s is running with NO caller authentication: any process on this "
+        "machine -- including a web page the user happens to be visiting -- "
+        "can drive the agent loop. Set %s to require 'Authorization: %s "
+        "<key>'. A future release will make this mandatory.",
+        surface,
+        API_KEY_ENV,
+        AUTH_SCHEME,
+    )
+
+
+class UnauthenticatedBindError(ValueError):
+    """A server was asked to listen beyond loopback with no caller auth."""
+
+
+def assert_bind_is_authenticated(host: str, surface: str) -> None:
+    """Refuse a network-facing bind that no caller has to authenticate to.
+
+    Loopback without a key is allowed and warned about once -- making a key
+    mandatory there would break every existing ``gaia api`` / ``--api``
+    consumer overnight. Binding beyond loopback without one is refused: it
+    puts an agent loop that reads and writes the user's files on the network
+    for anyone who can route to the port.
+    """
+    if api_key_configured() or is_loopback_bind(host):
+        warn_if_unauthenticated(surface)
+        return
+    raise UnauthenticatedBindError(
+        f"Refusing to serve {surface} on {host!r} with no caller "
+        f"authentication. That address is reachable from the network, and the "
+        f"agent surface runs tools on this machine. Set {API_KEY_ENV} in the "
+        f"server's environment (e.g. "
+        f"`export {API_KEY_ENV}=$(openssl rand -hex 32)`) and send it as "
+        f"'Authorization: {AUTH_SCHEME} <key>', or bind localhost instead. "
+        f"See https://amd-gaia.ai/docs/sdk/infrastructure/api-server."
+    )
+
+
+def check_api_key(
+    authorization: Optional[str], *, surface: str, required: bool
+) -> Optional[Tuple[int, str]]:
+    """Validate an ``Authorization`` header against ``GAIA_API_KEY``.
+
+    Returns ``None`` when the request may proceed, otherwise an
+    ``(http_status, detail)`` pair. Framework-free so the FastAPI dependency
+    below and any non-FastAPI handler share one implementation.
+
+    *required* distinguishes the two postures. ``True`` (the ``/v1/<agent>/*``
+    relay) means an unset key disables the surface entirely. ``False`` (chat
+    completions, the ``AgentServer`` REST API) means an unset key leaves the
+    surface open for backward compatibility, warned about once -- but a key
+    that IS set is enforced on every request.
+    """
+    expected = os.environ.get(API_KEY_ENV)
+    if not expected:
+        if not required:
+            warn_if_unauthenticated(surface)
+            return None
+        return (
+            503,
+            f"{surface} is disabled: no API key is configured. Set "
+            f"{API_KEY_ENV} in the server's environment (e.g. "
+            f"`export {API_KEY_ENV}=$(openssl rand -hex 32)`), restart it, "
+            f"and send the key as 'Authorization: {AUTH_SCHEME} <key>'.",
+        )
+    if not authorization:
+        return (
+            401,
+            f"Missing API key. Send 'Authorization: {AUTH_SCHEME} <key>' "
+            f"matching {API_KEY_ENV} on the server.",
+        )
+    scheme, _, credential = authorization.partition(" ")
+    if scheme.lower() != AUTH_SCHEME.lower() or not credential:
+        return (
+            401,
+            f"Malformed Authorization header. Expected '{AUTH_SCHEME} <key>'.",
+        )
+    # Bytes, not str: str compare_digest raises TypeError on non-ASCII input.
+    if not secrets.compare_digest(
+        credential.encode("utf-8", "surrogateescape"),
+        expected.encode("utf-8", "surrogateescape"),
+    ):
+        return (
+            401,
+            f"Invalid API key. It must match {API_KEY_ENV} on the server.",
+        )
+    return None
+
+
+def build_require_api_key(surface: str, required: bool = True):
+    """FastAPI dependency wrapping :func:`check_api_key`.
+
+    No silent fallback in either posture: every rejection is an HTTP error
+    naming what failed, what to send, and where the key comes from.
+    """
+    from fastapi import Header, HTTPException
+
+    def require_api_key(authorization: Optional[str] = Header(default=None)) -> None:
+        failure = check_api_key(authorization, surface=surface, required=required)
+        if failure is None:
+            return
+        status, detail = failure
+        headers = {"WWW-Authenticate": AUTH_SCHEME} if status == 401 else None
+        raise HTTPException(status_code=status, detail=detail, headers=headers)
+
+    setattr(require_api_key, CALLER_GUARD_MARKER, True)
+    return require_api_key
+
+
+#: Methods a page can trigger cross-site that do not change state. OPTIONS
+#: never reaches a route -- ``CORSMiddleware`` answers preflights first.
+SAFE_METHODS = frozenset({"GET", "HEAD", "OPTIONS"})
+
+#: Attribute stamped on every guard :func:`build_caller_guard` returns, so a
+#: route-table test can prove a route carries one without importing it.
+CALLER_GUARD_MARKER = "__gaia_caller_guard__"
+
+
+#: Paths :func:`build_caller_guard` leaves open by default: liveness only.
+DEFAULT_PUBLIC_PATHS = frozenset({"/health"})
+
+
+def build_caller_guard(
+    surface: str,
+    *,
+    public_paths: Optional[frozenset] = None,
+    origins_env: str = CORS_ORIGINS_ENV,
+):
+    """FastAPI dependency: refuse foreign browser origins, then check the key.
+
+    Attach it app-wide (``FastAPI(dependencies=[Depends(guard)])``) so a route
+    added later is covered without its author doing anything.
+
+    1. A mutating request whose ``Origin`` is not allowed is a 403 -- before
+       any handler runs, whatever the CORS headers would have said.
+    2. Every non-public path goes through :func:`check_api_key` with
+       ``required=False``: enforced when ``GAIA_API_KEY`` is set, warned
+       about once when it is not.
+    """
+    from fastapi import HTTPException, Request
+
+    if public_paths is None:
+        public_paths = DEFAULT_PUBLIC_PATHS
+
+    def caller_guard(request: Request) -> None:
+        origin = request.headers.get("origin", "")
+        if request.method not in SAFE_METHODS and origin_is_rejected(
+            origin, origins_env
+        ):
+            logger.warning(
+                "Rejecting %s %s on %s: cross-origin request from %r",
+                request.method,
+                request.url.path,
+                surface,
+                origin,
+            )
+            raise HTTPException(
+                status_code=403,
+                detail=(
+                    f"Cross-origin request from {origin!r} rejected. Only "
+                    f"loopback origins may call {surface}; add yours to "
+                    f"{origins_env} (comma-separated) to allow it."
+                ),
+            )
+        if request.url.path in public_paths:
+            return
+        failure = check_api_key(
+            request.headers.get("authorization"), surface=surface, required=False
+        )
+        if failure is None:
+            return
+        status, detail = failure
+        headers = {"WWW-Authenticate": AUTH_SCHEME} if status == 401 else None
+        raise HTTPException(status_code=status, detail=detail, headers=headers)
+
+    setattr(caller_guard, CALLER_GUARD_MARKER, True)
+    return caller_guard

--- a/src/gaia/api/openai_server.py
+++ b/src/gaia/api/openai_server.py
@@ -22,7 +22,7 @@ import uuid
 from typing import AsyncGenerator
 
 import httpx
-from fastapi import FastAPI, HTTPException, Request
+from fastapi import Depends, FastAPI, HTTPException, Request
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import StreamingResponse
 
@@ -30,6 +30,7 @@ from gaia.agents.base.api_agent import ApiAgent
 
 from .agent_proxy import build_agent_proxy_router
 from .agent_registry import registry
+from .local_http import build_caller_guard, cors_config
 from .schemas import (
     ChatCompletionChoice,
     ChatCompletionRequest,
@@ -119,45 +120,10 @@ app = FastAPI(
     version="1.0.0",
 )
 
-# Browser origins allowed by default: localhost/127.0.0.1 on any port.
-_LOCAL_ORIGIN_REGEX = r"^https?://(localhost|127\.0\.0\.1)(:\d+)?$"
+# Cross-origin and caller-auth policy live in one place for every GAIA local
+# HTTP server -- see gaia/api/local_http.py.
+app.add_middleware(CORSMiddleware, **cors_config())
 
-
-def _cors_config() -> dict:
-    """Build the CORS policy: localhost-only by default.
-
-    ``GAIA_API_CORS_ORIGINS`` (comma-separated) adds extra allowed origins,
-    e.g. ``https://myapp.example.com``. A literal ``*`` opts into open CORS
-    for all origins, which the Fetch spec forbids combining with credentials
-    — so the wildcard also disables credentialed requests. Wildcard origins
-    WITH credentials are never configured: Starlette would reflect any
-    request Origin, letting any website the user visits call this local,
-    unauthenticated API with credentials.
-    """
-    raw = os.environ.get("GAIA_API_CORS_ORIGINS", "")
-    origins = [o.strip() for o in raw.split(",") if o.strip()]
-    if "*" in origins:
-        logger.warning(
-            "GAIA_API_CORS_ORIGINS='*': allowing all origins WITHOUT "
-            "credentials. To allow credentialed cross-origin calls, list "
-            "explicit origins instead of '*'."
-        )
-        return {
-            "allow_origins": ["*"],
-            "allow_credentials": False,
-            "allow_methods": ["*"],
-            "allow_headers": ["*"],
-        }
-    return {
-        "allow_origins": origins,
-        "allow_origin_regex": _LOCAL_ORIGIN_REGEX,
-        "allow_credentials": True,
-        "allow_methods": ["*"],
-        "allow_headers": ["*"],
-    }
-
-
-app.add_middleware(CORSMiddleware, **_cors_config())
 
 # The email agent's REST surface (POST /v1/email/*) is no longer mounted
 # in-process (#2176). It was the last in-process agent mount after the v2
@@ -213,7 +179,14 @@ async def log_raw_requests(request: Request, call_next):
     return response
 
 
-@app.post("/v1/chat/completions")
+#: Foreign browser origins are refused; the API key is enforced when set and
+#: warned about once when not (mandatory would break every consumer at once).
+_chat_completions_guard = build_caller_guard(
+    "POST /v1/chat/completions", public_paths=frozenset()
+)
+
+
+@app.post("/v1/chat/completions", dependencies=[Depends(_chat_completions_guard)])
 async def create_chat_completion(request: ChatCompletionRequest):
     """
     Create chat completion (OpenAI-compatible endpoint).

--- a/src/gaia/cli.py
+++ b/src/gaia/cli.py
@@ -4858,6 +4858,19 @@ def handle_api_command(args):
             if getattr(args, "step_through", False):
                 os.environ["GAIA_API_STEP_THROUGH"] = "1"
 
+            from gaia.api.local_http import (
+                UnauthenticatedBindError,
+                assert_bind_is_authenticated,
+            )
+
+            # A LAN-reachable bind with no API key puts the agent loop on the
+            # network; refuse it before the app (and its agents) load.
+            try:
+                assert_bind_is_authenticated(args.host, "the GAIA API server")
+            except UnauthenticatedBindError as e:
+                print(f"❌ Error: {e}")
+                sys.exit(1)
+
             # Now import the app (agent_registry will see the env vars)
             from gaia.api.openai_server import app
             from gaia.api.sse_handler import warn_if_unconfirmed_tools_allowed

--- a/src/gaia/mcp/mcp_bridge.py
+++ b/src/gaia/mcp/mcp_bridge.py
@@ -22,6 +22,10 @@ sys.path.insert(
     0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 )
 
+from gaia.api.local_http import (  # pylint: disable=wrong-import-position
+    is_allowed_origin,
+    origin_is_rejected,
+)
 from gaia.llm import create_client  # pylint: disable=wrong-import-position
 from gaia.logger import get_logger  # pylint: disable=wrong-import-position
 
@@ -42,6 +46,10 @@ AUTH_TOKEN_ENV_VAR = "GAIA_MCP_AUTH_TOKEN"
 # including unknown ones, is authenticated. (CORS preflight is also exempt, but
 # via do_OPTIONS: browsers never send Authorization on a preflight.)
 PUBLIC_PATHS = frozenset({"/health"})
+
+# Extra browser origins allowed to call the bridge (comma-separated). Loopback
+# origins are always allowed; everything else is refused, token or not.
+ALLOWED_ORIGINS_ENV_VAR = "GAIA_MCP_ALLOWED_ORIGINS"
 
 
 class GAIAMCPBridge:
@@ -238,6 +246,45 @@ class MCPHTTPHandler(BaseHTTPRequestHandler):
 
         return None
 
+    def _request_origin(self):
+        return self.headers.get("Origin", "") if self.headers else ""
+
+    def _send_cors_headers(self):
+        """Echo the caller's Origin only when it is allow-listed. Never ``*``."""
+        origin = self._request_origin()
+        if origin and is_allowed_origin(origin, ALLOWED_ORIGINS_ENV_VAR):
+            self.send_header("Access-Control-Allow-Origin", origin)
+            self.send_header("Vary", "Origin")
+
+    def _reject_foreign_origin(self):
+        """Send 403 for a request from an untrusted browser origin. True when rejected.
+
+        Requests with no Origin (curl, MCP clients, n8n) are not browser
+        requests and pass. A page elsewhere on the web is refused before any
+        tool runs, whether or not an auth token is configured.
+        """
+        origin = self._request_origin()
+        if not origin_is_rejected(origin, ALLOWED_ORIGINS_ENV_VAR):
+            return False
+        logger.warning(
+            "Rejected cross-origin MCP request: %s %s from origin %r",
+            self.command,
+            self.path,
+            origin,
+        )
+        self._drain_request_body()
+        self.send_json(
+            403,
+            {
+                "error": (
+                    f"Cross-origin request from {origin!r} rejected. Only "
+                    f"loopback origins may call the MCP bridge; add yours to "
+                    f"{ALLOWED_ORIGINS_ENV_VAR} (comma-separated) to allow it."
+                )
+            },
+        )
+        return True
+
     def _drain_request_body(self):
         """Consume any pending request body so the client can read our reply."""
         try:
@@ -277,6 +324,8 @@ class MCPHTTPHandler(BaseHTTPRequestHandler):
         self.log_request_details("GET", self.path)
         parsed = urlparse(self.path)
 
+        if self._reject_foreign_origin():
+            return
         if self._reject_unauthenticated(parsed.path):
             return
 
@@ -337,7 +386,9 @@ class MCPHTTPHandler(BaseHTTPRequestHandler):
         """Handle POST requests - main MCP endpoint."""
         parsed = urlparse(self.path)
 
-        # Authenticate before the body is read or any tool runs.
+        # Origin and auth are checked before the body is read or any tool runs.
+        if self._reject_foreign_origin():
+            return
         if self._reject_unauthenticated(parsed.path):
             return
 
@@ -436,8 +487,10 @@ class MCPHTTPHandler(BaseHTTPRequestHandler):
     def do_OPTIONS(self):
         """Handle OPTIONS for CORS."""
         self.log_request_details("OPTIONS", self.path)
+        if self._reject_foreign_origin():
+            return
         self.send_response(200)
-        self.send_header("Access-Control-Allow-Origin", "*")
+        self._send_cors_headers()
         self.send_header("Access-Control-Allow-Methods", "GET, POST, OPTIONS")
         self.send_header("Access-Control-Allow-Headers", "Authorization, Content-Type")
         self.end_headers()
@@ -450,7 +503,7 @@ class MCPHTTPHandler(BaseHTTPRequestHandler):
 
         self.send_response(status)
         self.send_header("Content-Type", "application/json")
-        self.send_header("Access-Control-Allow-Origin", "*")
+        self._send_cors_headers()
         self.end_headers()
         self.wfile.write(json.dumps(data).encode("utf-8"))
 
@@ -536,6 +589,23 @@ def start_server(
         print("Auth: 🔒 Bearer token required (/health stays public)")
     else:
         print("Auth: ⚠️  none - every endpoint is open to any client that can reach it")
+        print(
+            f"      Set --auth-token or ${AUTH_TOKEN_ENV_VAR} to require a Bearer token."
+        )
+        logger.warning(
+            "MCP bridge is running with NO authentication: any local process can "
+            "call its tools and share its one conversation. Pass --auth-token "
+            "or set %s.",
+            AUTH_TOKEN_ENV_VAR,
+        )
+    print(
+        "Browser origins: loopback only"
+        + (
+            f" + ${ALLOWED_ORIGINS_ENV_VAR}"
+            if os.environ.get(ALLOWED_ORIGINS_ENV_VAR)
+            else ""
+        )
+    )
     if verbose:
         print("\n🔍 Verbose Mode: ENABLED")
         print("   All requests will be logged to console and gaia.log")

--- a/src/gaia/mcp/mcp_bridge.py
+++ b/src/gaia/mcp/mcp_bridge.py
@@ -254,7 +254,7 @@ class MCPHTTPHandler(BaseHTTPRequestHandler):
         origin = self._request_origin()
         if origin and is_allowed_origin(origin, ALLOWED_ORIGINS_ENV_VAR):
             self.send_header("Access-Control-Allow-Origin", origin)
-            self.send_header("Vary", "Origin")
+        self.send_header("Vary", "Origin")
 
     def _reject_foreign_origin(self):
         """Send 403 for a request from an untrusted browser origin. True when rejected.

--- a/src/gaia/web/client.py
+++ b/src/gaia/web/client.py
@@ -41,14 +41,24 @@ ALLOWED_SCHEMES = {"http", "https"}
 BLOCKED_PORTS = {22, 23, 25, 445, 3306, 5432, 6379, 27017}
 
 
+#: Carrier-grade NAT (RFC 6598). ``ipaddress`` does not call it private, but
+#: Tailscale addresses every machine on the user's mesh from it.
+CGNAT_NETWORK = ipaddress.ip_network("100.64.0.0/10")
+
+
 def _is_blocked_ip(ip: "ipaddress._BaseAddress") -> bool:
     """Return True if ``ip`` points at a private/internal range we must not fetch."""
+    # ::ffff:10.0.0.1 reaches 10.0.0.1 -- judge the IPv4 address it carries.
+    mapped = getattr(ip, "ipv4_mapped", None)
+    if mapped is not None:
+        ip = mapped
     return (
         ip.is_private
         or ip.is_loopback
         or ip.is_link_local
         or ip.is_reserved
         or ip.is_multicast
+        or (ip.version == 4 and ip in CGNAT_NETWORK)
     )
 
 

--- a/src/vscode/gaia/package.json
+++ b/src/vscode/gaia/package.json
@@ -24,6 +24,10 @@
       {
         "command": "gaia.manage",
         "title": "GAIA: Manage API Server"
+      },
+      {
+        "command": "gaia.setApiKey",
+        "title": "GAIA: Set API Key"
       }
     ]
   },
@@ -34,7 +38,8 @@
     "pretest": "npm run compile",
     "test": "node ./out/test/runTest.js",
     "package": "vsce package",
-    "publish": "vsce publish"
+    "publish": "vsce publish",
+    "test:unit": "npm run compile && node --test test/*.test.cjs"
   },
   "devDependencies": {
     "@types/node": "^18.0.0",

--- a/src/vscode/gaia/src/extension.ts
+++ b/src/vscode/gaia/src/extension.ts
@@ -40,6 +40,25 @@ export function activate(context: vscode.ExtensionContext) {
 			vscode.window.showInformationMessage("GAIA server URL saved.");
 		})
 	);
+	context.subscriptions.push(
+		vscode.commands.registerCommand("gaia.setApiKey", async () => {
+			const apiKey = await vscode.window.showInputBox({
+				title: "GAIA API Key",
+				prompt: "Enter the server's GAIA_API_KEY. Leave blank to clear the saved key.",
+				password: true,
+				ignoreFocusOut: true,
+			});
+			if (apiKey === undefined) {
+				return;
+			}
+			if (apiKey.trim()) {
+				await context.secrets.store("gaia.apiKey", apiKey.trim());
+			} else {
+				await context.secrets.delete("gaia.apiKey");
+			}
+			vscode.window.showInformationMessage("GAIA API key updated.");
+		})
+	);
 }
 
 export function deactivate() {}

--- a/src/vscode/gaia/src/provider.ts
+++ b/src/vscode/gaia/src/provider.ts
@@ -20,7 +20,6 @@ import type { GaiaModel, GaiaModelsResponse } from "./types";
 const DEFAULT_BASE_URL = "http://localhost:8080";
 const DEFAULT_MAX_OUTPUT_TOKENS = 16000;
 const DEFAULT_CONTEXT_LENGTH = 128000;
-const HARDCODED_API_KEY = "gaia";
 
 /**
  * VS Code Chat provider backed by GAIA local LLM server.
@@ -227,7 +226,7 @@ export class GaiaChatModelProvider implements LanguageModelChatProvider {
 			const response = await fetch(`${baseUrl}/v1/models`, {
 				method: "GET",
 				headers: {
-					Authorization: `Bearer ${HARDCODED_API_KEY}`,
+					Authorization: `Bearer ${(await this.secrets.get("gaia.apiKey")) || "gaia"}`,
 					"User-Agent": this.userAgent,
 				},
 			});
@@ -385,7 +384,7 @@ export class GaiaChatModelProvider implements LanguageModelChatProvider {
 			const response = await fetch(`${baseUrl}/v1/chat/completions`, {
                 method: "POST",
                 headers: {
-                    Authorization: `Bearer ${HARDCODED_API_KEY}`,
+                    Authorization: `Bearer ${(await this.secrets.get("gaia.apiKey")) || "gaia"}`,
                     "Content-Type": "application/json",
 					"User-Agent": this.userAgent,
                 },

--- a/src/vscode/gaia/test/api-key.test.cjs
+++ b/src/vscode/gaia/test/api-key.test.cjs
@@ -1,0 +1,71 @@
+/* Copyright(C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ * SPDX-License-Identifier: MIT */
+const assert = require('node:assert/strict');
+const { test } = require('node:test');
+const Module = require('node:module');
+const commands = new Map();
+let input;
+let inputOptions;
+const vscode = {
+  extensions: { getExtension: () => ({ packageJSON: { version: 'test' } }) },
+  lm: { registerLanguageModelChatProvider() {} },
+  version: 'test',
+  workspace: {},
+  LanguageModelTextPart: class {},
+  commands: { registerCommand: (name, fn) => { commands.set(name, fn); return {}; } },
+  window: {
+    showInputBox: async (options) => { inputOptions = options; return input; },
+    showInformationMessage() {},
+  },
+};
+const originalLoad = Module._load;
+Module._load = function(name, parent, main) {
+  if (name === 'vscode') return vscode;
+  if (name === './utils') return {
+    convertMessages: () => [], convertTools: () => ({}), validateRequest() {},
+  };
+  return originalLoad.call(this, name, parent, main);
+};
+const { activate } = require('../out/extension');
+const { GaiaChatModelProvider } = require('../out/provider');
+Module._load = originalLoad;
+function storage() {
+  const values = new Map();
+  return { values, get: async key => values.get(key), store: async (key,value) => values.set(key,value), delete: async key => values.delete(key) };
+}
+
+test('API key command stores securely, cancel preserves, and blank clears', async () => {
+  const secrets = storage();
+  activate({ secrets, subscriptions: [] });
+  input = ' test-private-key ';
+  await commands.get('gaia.setApiKey')();
+  assert.equal(inputOptions.password, true);
+  assert.equal(secrets.values.get('gaia.apiKey'), 'test-private-key');
+  assert.equal(inputOptions.value, undefined);
+  input = undefined;
+  await commands.get('gaia.setApiKey')();
+  assert.equal(secrets.values.get('gaia.apiKey'), 'test-private-key');
+  input = '';
+  await commands.get('gaia.setApiKey')();
+  assert.equal(secrets.values.has('gaia.apiKey'), false);
+});
+
+test('model discovery and chat send the saved API key, keyless stays compatible', async t => {
+  const secrets = storage();
+  const provider = new GaiaChatModelProvider(secrets, 'test');
+  const requests = [];
+  t.mock.method(globalThis, 'fetch', async (url, options) => {
+    requests.push({ url, options });
+    return { ok: true, json: async () => ({ data: [] }), body: new ReadableStream({ start(controller) { controller.close(); } }) };
+  });
+  t.mock.method(console, 'log', () => {});
+  await provider.fetchModels();
+  assert.equal(requests[0].options.headers.Authorization, 'Bearer gaia');
+  await secrets.store('gaia.apiKey', 'custom-private-key');
+  await provider.fetchModels();
+  await provider.provideLanguageModelChatResponse({ id: 'model', maxInputTokens: 1000 }, [], {}, { report() {} }, { isCancellationRequested: false });
+  assert.equal(requests[1].options.headers.Authorization, 'Bearer custom-private-key');
+  assert.equal(requests[2].options.headers.Authorization, 'Bearer custom-private-key');
+  assert.equal(requests[2].options.method, 'POST');
+  assert.match(requests[2].url, /\/v1\/chat\/completions$/);
+});

--- a/tests/mcp/test_mcp_http_validation.py
+++ b/tests/mcp/test_mcp_http_validation.py
@@ -217,15 +217,52 @@ def test_direct_llm():
     return True
 
 
-@test("CORS Headers", "Verify CORS support for browser clients")
+@test(
+    "CORS Headers",
+    "Loopback origins are echoed; an Origin-less request gets no wildcard",
+)
 def test_cors():
-    # Test OPTIONS request
-    req = urllib.request.Request(f"{BASE_URL}/", method="OPTIONS")
+    origin = "http://localhost:3000"
+    req = urllib.request.Request(
+        f"{BASE_URL}/", method="OPTIONS", headers={"Origin": origin}
+    )
     with urllib.request.urlopen(req) as response:
         headers = response.headers
-        assert "Access-Control-Allow-Origin" in headers, "Missing CORS origin header"
+        echoed = headers.get("Access-Control-Allow-Origin")
+        assert echoed == origin, f"Loopback origin not echoed: {echoed!r}"
         assert "Access-Control-Allow-Methods" in headers, "Missing CORS methods header"
-        print(f"   🌐 CORS enabled: {headers['Access-Control-Allow-Origin']}")
+        print(f"   🌐 Loopback origin echoed: {origin}")
+
+    # No Origin means no browser cross-origin call (curl, MCP clients, n8n):
+    # it is served, and must never be answered with a wildcard.
+    req = urllib.request.Request(f"{BASE_URL}/", method="OPTIONS")
+    with urllib.request.urlopen(req) as response:
+        acao = response.headers.get("Access-Control-Allow-Origin")
+        assert (
+            acao is None
+        ), f"Origin-less request got Access-Control-Allow-Origin: {acao!r}"
+    return True
+
+
+@test(
+    "CORS - Foreign Origin",
+    "A non-loopback browser origin is refused before any tool runs",
+)
+def test_cors_foreign_origin_refused():
+    req = urllib.request.Request(
+        f"{BASE_URL}/", method="OPTIONS", headers={"Origin": "https://attacker.example"}
+    )
+    try:
+        with urllib.request.urlopen(req) as response:
+            raise AssertionError(
+                f"Foreign origin was served with HTTP {response.status}"
+            )
+    except urllib.error.HTTPError as e:
+        assert e.code == 403, f"Foreign origin got HTTP {e.code}, expected 403"
+        assert (
+            e.headers.get("Access-Control-Allow-Origin") is None
+        ), "Foreign origin was echoed"
+        print("   🛡️  Foreign origin refused with 403")
     return True
 
 
@@ -264,6 +301,8 @@ def run_all_tests():
     test_error_unknown_tool()
     test_direct_llm()
     test_cors()
+
+    test_cors_foreign_origin_refused()
     test_performance()
 
     # Generate report

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -740,7 +740,7 @@ class TestApiCorsPolicy:
             assert response.headers.get("access-control-allow-origin") == origin
 
     def test_env_var_adds_explicit_origin(self, monkeypatch):
-        from gaia.api.openai_server import _cors_config
+        from gaia.api.local_http import cors_config as _cors_config
 
         monkeypatch.setenv(
             "GAIA_API_CORS_ORIGINS", "https://myapp.example.com, https://other.example"
@@ -753,7 +753,7 @@ class TestApiCorsPolicy:
         assert cfg["allow_credentials"] is True
 
     def test_blank_env_var_does_not_become_wildcard(self, monkeypatch):
-        from gaia.api.openai_server import _cors_config
+        from gaia.api.local_http import cors_config as _cors_config
 
         monkeypatch.setenv("GAIA_API_CORS_ORIGINS", "")
         cfg = _cors_config()
@@ -761,7 +761,7 @@ class TestApiCorsPolicy:
         assert cfg["allow_origin_regex"]
 
     def test_explicit_wildcard_disables_credentials(self, monkeypatch):
-        from gaia.api.openai_server import _cors_config
+        from gaia.api.local_http import cors_config as _cors_config
 
         monkeypatch.setenv("GAIA_API_CORS_ORIGINS", "*")
         cfg = _cors_config()

--- a/tests/unit/test_api_agent_proxy.py
+++ b/tests/unit/test_api_agent_proxy.py
@@ -241,13 +241,15 @@ def test_openai_routes_not_shadowed_by_relay(api_client, with_api_key):
     assert r.status_code == 200
     assert r.json()["object"] == "list"
     # /v1/chat/completions is declared before the relay → its handler wins; an
-    # unknown model is the OpenAI handler's own 404, not the relay's.
+    # unknown model is the OpenAI handler's own 404, not the relay's. With a key
+    # configured the endpoint enforces it, so send it.
     r = api_client.post(
         "/v1/chat/completions",
         json={
             "model": "does-not-exist",
             "messages": [{"role": "user", "content": "x"}],
         },
+        headers={"Authorization": f"Bearer {_API_KEY}"},
     )
     assert r.status_code == 404
     assert "not found" in r.json()["detail"].lower()

--- a/tests/unit/test_chat_inline_web_ssrf.py
+++ b/tests/unit/test_chat_inline_web_ssrf.py
@@ -1,0 +1,186 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+"""``fetch_webpage`` / ``open_url`` must honour the same SSRF guard as ``fetch_page``.
+
+Both are registered in the flagship's default ``full`` profile. They used a
+bare ``httpx.get`` with only a scheme check, so a prompt-injected document
+could make the agent fetch the Lemonade API, the daemon's loopback API, or
+cloud metadata at 169.254.169.254.
+"""
+
+import io
+import ipaddress
+from unittest.mock import patch
+
+import pytest
+import requests
+import requests.adapters
+
+from gaia.web import client as web_client
+from gaia.web.client import WebClient
+from tests.unit.test_profilespec_characterization import chat_agent_build_context
+
+
+@pytest.fixture
+def full_profile_tools():
+    with chat_agent_build_context("full") as agent:
+        agent._register_tools()
+        yield agent, agent._tools_registry
+
+
+def _tool(registry, name):
+    return registry[name]["function"]
+
+
+BLOCKED_URLS = [
+    "http://127.0.0.1:13305/api/v1/models",  # Lemonade
+    "http://localhost:4200/api/sessions",  # Agent UI backend
+    "http://169.254.169.254/latest/meta-data/",  # cloud metadata
+    "http://10.0.0.5/admin",
+    "http://100.64.0.1/",  # CGNAT (I49)
+    "http://100.100.100.100/",  # Tailscale's MagicDNS address (CGNAT)
+    "http://[::1]:8000/v1/models",
+    "file:///etc/passwd",
+]
+
+
+@pytest.mark.parametrize("url", BLOCKED_URLS)
+def test_fetch_webpage_refuses_internal_targets(full_profile_tools, url, monkeypatch):
+    monkeypatch.delenv("GAIA_WEB_ALLOWED_HOSTS", raising=False)
+    _, registry = full_profile_tools
+    with patch("httpx.get") as bare_httpx:
+        result = _tool(registry, "fetch_webpage")(url)
+    assert result["status"] == "error"
+    assert "Blocked" in result["error"]
+    bare_httpx.assert_not_called()
+
+
+@pytest.mark.parametrize("url", BLOCKED_URLS)
+def test_open_url_refuses_internal_targets(full_profile_tools, url, monkeypatch):
+    monkeypatch.delenv("GAIA_WEB_ALLOWED_HOSTS", raising=False)
+    _, registry = full_profile_tools
+    with patch("webbrowser.open") as opener:
+        result = _tool(registry, "open_url")(url)
+    assert result["status"] == "error"
+    opener.assert_not_called()
+
+
+PUBLIC_IP = "93.184.216.34"
+
+
+def _public_dns(host, port, *args, **kwargs):
+    """Resolve names to one public address; IP literals resolve to themselves.
+
+    Mirrors real ``getaddrinfo``: a literal like ``127.0.0.1`` is not looked
+    up, so the guard still sees it as loopback.
+    """
+    import socket
+
+    try:
+        literal = ipaddress.ip_address(host)
+    except ValueError:
+        return [(socket.AF_INET, socket.SOCK_STREAM, 6, "", (PUBLIC_IP, port or 0))]
+    family = socket.AF_INET6 if literal.version == 6 else socket.AF_INET
+    return [(family, socket.SOCK_STREAM, 6, "", (str(literal), port or 0))]
+
+
+def _fake_transport(sent):
+    """Stand in for the socket layer *below* PinnedIPAdapter, recording requests."""
+
+    def send(adapter, request, **kwargs):
+        sent.append(request)
+        resp = requests.Response()
+        resp.status_code = 200
+        resp.headers["Content-Type"] = "text/html; charset=utf-8"
+        resp.raw = io.BytesIO(b"<html><body><p>hello</p></body></html>")
+        resp.url = request.url
+        resp.request = request
+        return resp
+
+    return send
+
+
+@pytest.mark.parametrize(
+    "url,wire_url",
+    [
+        # http: the dialed address is the validated, pinned IP.
+        ("http://example.com/page?q=1", f"http://{PUBLIC_IP}:80/page?q=1"),
+        # https: host rides in userinfo so #3364's SNI hook can name it in TLS.
+        ("https://example.com/page", f"https://example.com@{PUBLIC_IP}:443/page"),
+    ],
+)
+def test_fetch_webpage_public_url_request_shape(full_profile_tools, url, wire_url):
+    agent, registry = full_profile_tools
+    sent = []
+    with (
+        patch("socket.getaddrinfo", side_effect=_public_dns),
+        patch.object(requests.adapters.HTTPAdapter, "send", _fake_transport(sent)),
+        patch("httpx.get") as bare_httpx,
+    ):
+        result = _tool(registry, "fetch_webpage")(url)
+
+    assert result == {
+        "status": "success",
+        "url": url,
+        "content": "hello",
+        "truncated": False,
+    }
+    bare_httpx.assert_not_called()
+    assert len(sent) == 1
+    request = sent[0]
+    assert request.method == "GET"
+    assert request.url == wire_url
+    assert request.headers["Host"] == "example.com"
+    assert request.headers["User-Agent"].startswith("GAIA-Agent/")
+    # Separate from the opt-in browser mixin's client: fetch_page stays off.
+    assert agent._web_client is None
+
+
+def test_redirect_to_loopback_is_refused_after_the_first_hop(full_profile_tools):
+    """A public page that 302s to 127.0.0.1 must not be followed."""
+    _, registry = full_profile_tools
+    sent = []
+
+    def redirecting(adapter, request, **kwargs):
+        sent.append(request)
+        resp = requests.Response()
+        resp.status_code = 302
+        resp.headers["Location"] = "http://127.0.0.1:13305/api/v1/models"
+        resp.raw = io.BytesIO(b"")
+        resp.url = request.url
+        resp.request = request
+        return resp
+
+    with (
+        patch("socket.getaddrinfo", side_effect=_public_dns),
+        patch.object(requests.adapters.HTTPAdapter, "send", redirecting),
+    ):
+        result = _tool(registry, "fetch_webpage")("http://example.com/")
+    assert result["status"] == "error"
+    assert "Blocked" in result["error"]
+    assert len(sent) == 1  # the loopback hop was never sent
+
+
+def test_open_url_opens_a_public_url(full_profile_tools):
+    _, registry = full_profile_tools
+    with (
+        patch.object(WebClient, "validate_url", return_value=None),
+        patch("webbrowser.open") as opener,
+    ):
+        result = _tool(registry, "open_url")("https://example.com/")
+    assert result["status"] == "success"
+    opener.assert_called_once_with("https://example.com/")
+
+
+@pytest.mark.parametrize(
+    "ip",
+    ["100.64.0.1", "100.127.255.254", "::ffff:100.64.0.1", "::ffff:10.0.0.1"],
+)
+def test_cgnat_and_mapped_private_ranges_are_blocked(ip):
+    assert web_client._is_blocked_ip(ipaddress.ip_address(ip))
+
+
+@pytest.mark.parametrize("ip", ["100.63.255.255", "100.128.0.1", "93.184.216.34"])
+def test_neighbouring_public_ranges_stay_reachable(ip):
+    assert not web_client._is_blocked_ip(ipaddress.ip_address(ip))

--- a/tests/unit/test_chat_inline_web_ssrf.py
+++ b/tests/unit/test_chat_inline_web_ssrf.py
@@ -46,8 +46,7 @@ BLOCKED_URLS = [
 
 
 @pytest.mark.parametrize("url", BLOCKED_URLS)
-def test_fetch_webpage_refuses_internal_targets(full_profile_tools, url, monkeypatch):
-    monkeypatch.delenv("GAIA_WEB_ALLOWED_HOSTS", raising=False)
+def test_fetch_webpage_refuses_internal_targets(full_profile_tools, url):
     _, registry = full_profile_tools
     with patch("httpx.get") as bare_httpx:
         result = _tool(registry, "fetch_webpage")(url)
@@ -57,8 +56,7 @@ def test_fetch_webpage_refuses_internal_targets(full_profile_tools, url, monkeyp
 
 
 @pytest.mark.parametrize("url", BLOCKED_URLS)
-def test_open_url_refuses_internal_targets(full_profile_tools, url, monkeypatch):
-    monkeypatch.delenv("GAIA_WEB_ALLOWED_HOSTS", raising=False)
+def test_open_url_refuses_internal_targets(full_profile_tools, url):
     _, registry = full_profile_tools
     with patch("webbrowser.open") as opener:
         result = _tool(registry, "open_url")(url)
@@ -184,3 +182,26 @@ def test_cgnat_and_mapped_private_ranges_are_blocked(ip):
 @pytest.mark.parametrize("ip", ["100.63.255.255", "100.128.0.1", "93.184.216.34"])
 def test_neighbouring_public_ranges_stay_reachable(ip):
     assert not web_client._is_blocked_ip(ipaddress.ip_address(ip))
+
+
+def test_inline_web_client_is_closed_during_agent_cleanup(full_profile_tools):
+    agent, _ = full_profile_tools
+    client = agent._inline_web_client()
+    with patch.object(client, "close") as close:
+        agent.__del__()
+    close.assert_called_once()
+
+
+@pytest.mark.parametrize(
+    "failure", [OSError("certificate config failed"), ImportError("missing dependency")]
+)
+def test_open_url_reports_client_initialization_failure(full_profile_tools, failure):
+    agent, registry = full_profile_tools
+    with (
+        patch.object(agent, "_inline_web_client", side_effect=failure),
+        patch("webbrowser.open") as opener,
+    ):
+        result = _tool(registry, "open_url")("https://example.com")
+    assert result["status"] == "error"
+    assert str(failure) in result["error"]
+    opener.assert_not_called()

--- a/tests/unit/test_local_http_guard.py
+++ b/tests/unit/test_local_http_guard.py
@@ -1,0 +1,360 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+"""Cross-origin and caller-auth guard for GAIA's local REST servers.
+
+The review's theme was that GAIA had these primitives and call sites skipped
+them. So the core tests here walk each app's route table and fail if any
+route -- including one added next month -- ships without the guard, rather
+than spot-checking the routes that exist today.
+"""
+
+import pytest
+
+pytest.importorskip("fastapi")
+
+from fastapi.routing import APIRoute  # noqa: E402
+from fastapi.testclient import TestClient  # noqa: E402
+
+from gaia.agents.base.agent import Agent  # noqa: E402
+from gaia.agents.base.readiness import AgentRequirements  # noqa: E402
+from gaia.agents.base.server import AgentServer  # noqa: E402
+from gaia.api import local_http  # noqa: E402
+
+# TestClient needs socketpair() for its event loop, which the unit-suite
+# network guard breaks on Windows. Nothing here leaves the process.
+pytestmark = pytest.mark.allow_network
+
+KEY = "k3y-for-tests"
+EVIL = "https://evil.example"
+LOCAL = "http://localhost:3000"
+_MUTATING = frozenset({"POST", "PUT", "PATCH", "DELETE"})
+
+
+class _EchoAgent(Agent):
+    """Agent that skips the LLM-bound ``Agent.__init__``."""
+
+    def __init__(self):  # noqa: D401 - deliberately skip super().__init__
+        self.calls = []
+
+    def _register_tools(self):
+        pass
+
+    def process_query(self, user_input, **kwargs):
+        self.calls.append(user_input)
+        return {"status": "success", "result": f"echo: {user_input}"}
+
+    def get_tools_info(self):
+        return {}
+
+
+@pytest.fixture(autouse=True)
+def _no_key(monkeypatch):
+    monkeypatch.delenv(local_http.API_KEY_ENV, raising=False)
+    monkeypatch.delenv(local_http.CORS_ORIGINS_ENV, raising=False)
+
+
+def _agent_server():
+    # Declared requirements mount POST /v1/<id>/init -- the route that can
+    # start a multi-GB model pull -- so the walk below sees it too.
+    return AgentServer(
+        _EchoAgent(),
+        name="Echo",
+        model_id="echo",
+        agent_id="echo",
+        requirements=AgentRequirements(model_id="Test-Model"),
+    )
+
+
+def _is_guard(dep) -> bool:
+    return bool(getattr(dep.call, local_http.CALLER_GUARD_MARKER, False))
+
+
+def _guarded(route: APIRoute) -> bool:
+    """Whether the route's resolved dependency tree contains a caller guard."""
+    stack = list(route.dependant.dependencies)
+    while stack:
+        dep = stack.pop()
+        if _is_guard(dep):
+            return True
+        stack.extend(dep.dependencies)
+    return False
+
+
+def _api_routes(app):
+    """Every APIRoute reachable from ``app``, included routers too.
+
+    Reuses the Agent UI guard's walker, which already copes with FastAPI
+    versions that include routers lazily.
+    """
+    from tests.unit.chat.ui.test_ui_request_guard import _all_api_routes
+
+    routes = [getattr(r, "original_route", r) for r in _all_api_routes(app).values()]
+    return [r for r in routes if isinstance(r, APIRoute)]
+
+
+def _chat(client, **headers):
+    return client.post(
+        "/v1/chat/completions",
+        json={"model": "echo", "messages": [{"role": "user", "content": "hi"}]},
+        headers=headers,
+    )
+
+
+# -- Route-table introspection (enforce by construction) ---------------------
+
+
+def test_every_agent_server_route_carries_the_guard():
+    """A route added to AgentServer tomorrow is covered without anyone remembering."""
+    app = _agent_server().build_api_app()
+    routes = _api_routes(app)
+    paths = {r.path for r in routes}
+    # Guard the guard: an empty walk would pass trivially.
+    assert {"/v1/chat/completions", "/v1/echo/init", "/v1/models"} <= paths
+    unguarded = [f"{sorted(r.methods)} {r.path}" for r in routes if not _guarded(r)]
+    assert unguarded == []
+
+
+def test_every_mutating_openai_server_route_carries_a_guard():
+    """Chat completions and the whole /v1/<agent>/* relay must be gated."""
+    from gaia.api.openai_server import app
+
+    mutating = [r for r in _api_routes(app) if r.methods & _MUTATING]
+    assert any(r.path == "/v1/chat/completions" for r in mutating)
+    assert len(mutating) >= 4, "route walk found too little to be meaningful"
+    unguarded = [f"{sorted(r.methods)} {r.path}" for r in mutating if not _guarded(r)]
+    assert unguarded == []
+
+
+def test_no_server_configures_wildcard_origins_with_credentials():
+    """``*`` + credentials makes Starlette reflect any Origin -- the C10 bug."""
+    from gaia.api.openai_server import app as openai_app
+
+    for app in (openai_app, _agent_server().build_api_app()):
+        cors = [m for m in app.user_middleware if m.cls.__name__ == "CORSMiddleware"]
+        assert len(cors) == 1
+        kwargs = cors[0].kwargs
+        assert not ("*" in kwargs["allow_origins"] and kwargs["allow_credentials"])
+
+
+# -- AgentServer behaviour ---------------------------------------------------
+
+
+@pytest.fixture
+def agent_client():
+    return TestClient(_agent_server().build_api_app())
+
+
+def test_foreign_origin_cannot_drive_the_agent(agent_client):
+    resp = _chat(agent_client, Origin=EVIL)
+    assert resp.status_code == 403
+    assert local_http.CORS_ORIGINS_ENV in resp.json()["detail"]
+
+
+def test_foreign_origin_preflight_is_not_approved(agent_client):
+    resp = agent_client.options(
+        "/v1/chat/completions",
+        headers={"Origin": EVIL, "Access-Control-Request-Method": "POST"},
+    )
+    assert "access-control-allow-origin" not in resp.headers
+
+
+def test_foreign_origin_read_is_not_reflected(agent_client):
+    resp = agent_client.get("/v1/models", headers={"Origin": EVIL})
+    assert "access-control-allow-origin" not in resp.headers
+
+
+def test_loopback_origin_still_works(agent_client):
+    resp = _chat(agent_client, Origin=LOCAL)
+    assert resp.status_code == 200
+    assert resp.headers["access-control-allow-origin"] == LOCAL
+
+
+def test_no_key_keeps_existing_consumers_working_and_warns(agent_client, caplog):
+    """Backward compatible: unset key -> allowed, with one loud warning."""
+    local_http._WARNED_SURFACES.clear()
+    with caplog.at_level("WARNING"):
+        assert _chat(agent_client).status_code == 200
+        assert _chat(agent_client).status_code == 200
+    warnings = [
+        r for r in caplog.records if "NO caller authentication" in r.getMessage()
+    ]
+    assert len(warnings) == 1
+    assert local_http.API_KEY_ENV in warnings[0].getMessage()
+
+
+def test_configured_key_is_enforced(agent_client, monkeypatch):
+    monkeypatch.setenv(local_http.API_KEY_ENV, KEY)
+    assert _chat(agent_client).status_code == 401
+    assert _chat(agent_client, Authorization="Bearer nope").status_code == 401
+    assert _chat(agent_client, Authorization=KEY).status_code == 401
+    assert _chat(agent_client, Authorization=f"Bearer {KEY}").status_code == 200
+    # Readiness endpoints are guarded too; only /health is public.
+    assert agent_client.get("/v1/models").status_code == 401
+    assert agent_client.get("/health").status_code == 200
+
+
+def test_credentialed_cross_origin_read_gets_no_permissive_cors(agent_client):
+    """The C10 bug: ``*`` + credentials reflected any Origin with ACAC: true."""
+    resp = agent_client.get(
+        "/v1/models", headers={"Origin": EVIL, "Cookie": "session=abc"}
+    )
+    # Starlette still emits ACAC: true, but without a matching ACAO the
+    # browser's CORS check fails and the response stays unreadable.
+    assert "access-control-allow-origin" not in resp.headers
+
+
+def test_credentialed_preflight_from_unlisted_origin_is_not_approved(agent_client):
+    resp = agent_client.options(
+        "/v1/chat/completions",
+        headers={
+            "Origin": EVIL,
+            "Access-Control-Request-Method": "POST",
+            "Access-Control-Request-Headers": "authorization,content-type",
+        },
+    )
+    assert resp.status_code == 400
+    assert "access-control-allow-origin" not in resp.headers
+
+
+def test_operator_listed_origin_works_with_credentials(monkeypatch):
+    listed = "https://app.example"
+    monkeypatch.setenv(local_http.CORS_ORIGINS_ENV, listed)
+    client = TestClient(_agent_server().build_api_app())
+    resp = _chat(client, Origin=listed)
+    assert resp.status_code == 200
+    assert resp.headers["access-control-allow-origin"] == listed
+    assert resp.headers["access-control-allow-credentials"] == "true"
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason="Caller auth for --api consumers is a breaking change; this release "
+    "only warns when GAIA_API_KEY is unset (report section 10 item 7).",
+)
+def test_unauthenticated_loopback_call_is_refused_once_auth_is_mandatory(
+    agent_client,
+):
+    assert _chat(agent_client).status_code == 401
+
+
+# -- gaia api (openai_server) chat completions --------------------------------
+
+
+@pytest.fixture
+def openai_client():
+    from gaia.api.openai_server import app
+
+    return TestClient(app, raise_server_exceptions=False)
+
+
+def _openai_chat(client, **headers):
+    return client.post(
+        "/v1/chat/completions",
+        json={
+            "model": "does-not-exist",
+            "messages": [{"role": "user", "content": "hi"}],
+        },
+        headers=headers,
+    )
+
+
+def test_chat_completions_without_a_key_is_401_when_a_key_is_configured(
+    openai_client, monkeypatch
+):
+    monkeypatch.setenv(local_http.API_KEY_ENV, KEY)
+    resp = _openai_chat(openai_client)
+    assert resp.status_code == 401
+    assert resp.headers["www-authenticate"] == "Bearer"
+    assert local_http.API_KEY_ENV in resp.json()["detail"]
+    assert _openai_chat(openai_client, Authorization="Bearer wrong").status_code == 401
+
+
+def test_chat_completions_with_the_key_reaches_the_handler(openai_client, monkeypatch):
+    monkeypatch.setenv(local_http.API_KEY_ENV, KEY)
+    resp = _openai_chat(openai_client, Authorization=f"Bearer {KEY}")
+    assert resp.status_code == 404  # the handler's own unknown-model answer
+
+
+def test_chat_completions_refuses_a_foreign_origin_even_with_the_key(
+    openai_client, monkeypatch
+):
+    monkeypatch.setenv(local_http.API_KEY_ENV, KEY)
+    resp = _openai_chat(openai_client, Origin=EVIL, Authorization=f"Bearer {KEY}")
+    assert resp.status_code == 403
+
+
+def test_chat_completions_stays_open_on_loopback_without_a_key(openai_client):
+    """Backward compatible: no key configured -> the handler still runs."""
+    assert _openai_chat(openai_client).status_code == 404
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason="Mandatory caller auth on gaia api is deferred; unset GAIA_API_KEY "
+    "only warns in this release (report section 10 item 7).",
+)
+def test_chat_completions_requires_a_key_once_auth_is_mandatory(openai_client):
+    assert _openai_chat(openai_client).status_code == 401
+
+
+def test_run_api_refuses_lan_bind_without_a_key(monkeypatch):
+    started = []
+    monkeypatch.setattr("uvicorn.run", lambda *a, **k: started.append(k))
+    with pytest.raises(local_http.UnauthenticatedBindError) as exc:
+        _agent_server().run_api(host="0.0.0.0", port=8123)  # nosec B104
+    assert local_http.API_KEY_ENV in str(exc.value)
+    assert started == []
+
+    monkeypatch.setenv(local_http.API_KEY_ENV, KEY)
+    _agent_server().run_api(host="0.0.0.0", port=8123)  # nosec B104
+    assert started
+
+
+# -- Shared helpers ----------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "host,loopback",
+    [
+        ("localhost", True),
+        ("127.0.0.1", True),
+        ("::1", True),
+        ("[::1]", True),
+        ("0.0.0.0", False),  # nosec B104
+        ("::", False),
+        ("", False),
+        ("192.168.1.20", False),
+        ("my-workstation", False),
+    ],
+)
+def test_is_loopback_bind(host, loopback):
+    assert local_http.is_loopback_bind(host) is loopback
+
+
+@pytest.mark.parametrize(
+    "origin,allowed",
+    [
+        ("http://localhost:3000", True),
+        ("http://127.0.0.1:4200", True),
+        ("http://[::1]:8080", True),
+        ("https://evil.example", False),
+        ("http://localhost.evil.example", False),
+        ("http://127.0.0.1.evil.example", False),
+        ("null", False),
+    ],
+)
+def test_is_allowed_origin(origin, allowed):
+    assert local_http.is_allowed_origin(origin) is allowed
+
+
+def test_missing_origin_is_not_rejected():
+    """curl and SDK clients send no Origin; they must keep working."""
+    assert local_http.origin_is_rejected("") is False
+    assert local_http.origin_is_rejected(EVIL) is True
+
+
+def test_required_surface_is_disabled_without_a_key():
+    status, detail = local_http.check_api_key(None, surface="relay", required=True)
+    assert status == 503
+    assert local_http.API_KEY_ENV in detail

--- a/tests/unit/test_mcp_bridge_auth.py
+++ b/tests/unit/test_mcp_bridge_auth.py
@@ -425,3 +425,12 @@ class TestConfigurationContract:
         bridge_mod.start_server(host="localhost", port=0)
 
         assert captured["auth_token"] == "from-env"
+
+
+@pytest.mark.parametrize(
+    "origin", [None, "https://foreign.example", "http://localhost:4200"]
+)
+def test_cors_responses_always_vary_by_origin(server_factory, origin):
+    base, _ = server_factory(auth_token=None)
+    _, headers, _ = _raw(f"{base}/health", origin=origin)
+    assert headers.get("vary") == "Origin"

--- a/tests/unit/test_mcp_bridge_auth.py
+++ b/tests/unit/test_mcp_bridge_auth.py
@@ -101,6 +101,30 @@ def _request(url, token=None, method="GET", payload=None, raw_header=None):
         return e.code, json.loads(e.read().decode())
 
 
+def _raw(url, method="GET", origin=None, payload=None):
+    """Perform a request, returning (status, lowercased headers, body bytes)."""
+    headers = {}
+    if origin is not None:
+        headers["Origin"] = origin
+    data = None
+    if payload is not None:
+        data = json.dumps(payload).encode("utf-8")
+        headers["Content-Type"] = "application/json"
+    req = urllib.request.Request(url, data=data, headers=headers, method=method)
+    try:
+        with urllib.request.urlopen(req, timeout=10) as response:
+            return (
+                response.status,
+                {k.lower(): v for k, v in response.headers.items()},
+                response.read(),
+            )
+    except urllib.error.HTTPError as e:
+        return e.code, {k.lower(): v for k, v in e.headers.items()}, e.read()
+
+
+LOCAL_ORIGIN = "http://localhost:3000"  # the example app's dev server
+EVIL_ORIGIN = "https://evil.example"
+
 PROTECTED_GETS = ["/status", "/tools"]
 JSONRPC_LIST = {"jsonrpc": "2.0", "id": 1, "method": "tools/list"}
 JSONRPC_CALL = {
@@ -224,14 +248,17 @@ class TestTokenConfigured:
         _, authed = _request(f"{base}/status", token=TOKEN)
         assert "gaia.query" in json.dumps(authed)
 
-    def test_cors_preflight_stays_open_and_allows_authorization(self, server_factory):
-        """Browsers never send Authorization on preflight."""
+    def test_loopback_preflight_is_approved_and_allows_authorization(
+        self, server_factory
+    ):
+        """Browsers never send Authorization on preflight, so it stays unauthenticated."""
         base, _ = server_factory(auth_token=TOKEN)
-        req = urllib.request.Request(f"{base}/status", method="OPTIONS")
-        with urllib.request.urlopen(req, timeout=10) as response:
-            assert response.status == 200
-            allowed = response.headers.get("Access-Control-Allow-Headers", "")
-        assert "Authorization" in allowed
+        status, headers, _ = _raw(
+            f"{base}/status", method="OPTIONS", origin=LOCAL_ORIGIN
+        )
+        assert status == 200
+        assert "Authorization" in headers.get("access-control-allow-headers", "")
+        assert headers.get("access-control-allow-origin") == LOCAL_ORIGIN
 
 
 class TestNoTokenConfigured:
@@ -253,6 +280,110 @@ class TestNoTokenConfigured:
         base, _ = server_factory(auth_token="")
         status, _ = _request(f"{base}/status")
         assert status == 200
+
+
+class TestBrowserOrigins:
+    """A web page elsewhere must not be able to drive or read the bridge.
+
+    Loopback is no boundary here: the attacker is a page in the user's own
+    browser fetching ``http://localhost:<port>``. What stops it is refusing a
+    foreign ``Origin`` outright and never answering ``Access-Control-Allow-Origin: *``.
+    """
+
+    @pytest.mark.parametrize("auth_token", [None, TOKEN])
+    def test_foreign_origin_post_is_refused_before_any_tool_runs(
+        self, server_factory, auth_token
+    ):
+        base, bridge = server_factory(auth_token=auth_token)
+        status, headers, body = _raw(
+            f"{base}/chat", method="POST", origin=EVIL_ORIGIN, payload={"query": "x"}
+        )
+        assert status == 403
+        assert bridge.executed == []
+        assert "access-control-allow-origin" not in headers
+        assert b"GAIA_MCP_ALLOWED_ORIGINS" in body
+
+    @pytest.mark.parametrize("path", ["/", "/chat", "/llm", "/rpc", "/v1/messages"])
+    def test_every_post_route_refuses_a_foreign_origin(self, server_factory, path):
+        base, bridge = server_factory(auth_token=None)
+        status, _, _ = _raw(
+            f"{base}{path}", method="POST", origin=EVIL_ORIGIN, payload=JSONRPC_CALL
+        )
+        assert status == 403
+        assert bridge.executed == []
+
+    def test_foreign_origin_cannot_read_inventory(self, server_factory):
+        base, _ = server_factory(auth_token=None)
+        status, headers, body = _raw(f"{base}/status", origin=EVIL_ORIGIN)
+        assert status == 403
+        assert b"gaia.query" not in body
+        assert "access-control-allow-origin" not in headers
+
+    def test_foreign_origin_preflight_is_refused(self, server_factory):
+        base, _ = server_factory(auth_token=None)
+        status, headers, _ = _raw(f"{base}/chat", method="OPTIONS", origin=EVIL_ORIGIN)
+        assert status == 403
+        assert "access-control-allow-origin" not in headers
+
+    def test_loopback_origin_is_echoed_never_wildcard(self, server_factory):
+        base, bridge = server_factory(auth_token=None)
+        status, headers, _ = _raw(
+            f"{base}/chat", method="POST", origin=LOCAL_ORIGIN, payload={"query": "x"}
+        )
+        assert status == 200
+        assert headers.get("access-control-allow-origin") == LOCAL_ORIGIN
+        assert bridge.executed == [("gaia.chat", {"query": "x"})]
+
+    def test_non_browser_client_gets_no_cors_header(self, server_factory):
+        """curl / MCP clients send no Origin: they work, and get no ACAO at all."""
+        base, _ = server_factory(auth_token=None)
+        status, headers, _ = _raw(f"{base}/status")
+        assert status == 200
+        assert "access-control-allow-origin" not in headers
+
+    def test_env_var_admits_an_extra_origin(self, server_factory, monkeypatch):
+        monkeypatch.setenv("GAIA_MCP_ALLOWED_ORIGINS", "https://n8n.internal")
+        base, _ = server_factory(auth_token=None)
+        status, headers, _ = _raw(f"{base}/status", origin="https://n8n.internal")
+        assert status == 200
+        assert headers.get("access-control-allow-origin") == "https://n8n.internal"
+
+
+class TestNoWildcardEver:
+    """No response the bridge sends may carry ``Access-Control-Allow-Origin: *``."""
+
+    @pytest.mark.parametrize("origin", [EVIL_ORIGIN, "null", LOCAL_ORIGIN, None])
+    @pytest.mark.parametrize(
+        "method,path,payload",
+        [
+            ("GET", "/health", None),
+            ("GET", "/status", None),
+            ("OPTIONS", "/chat", None),
+            ("POST", "/chat", {"query": "x"}),
+            ("POST", "/", JSONRPC_LIST),
+        ],
+    )
+    def test_no_wildcard_acao(self, server_factory, origin, method, path, payload):
+        base, _ = server_factory(auth_token=None)
+        _, headers, _ = _raw(
+            f"{base}{path}", method=method, origin=origin, payload=payload
+        )
+        acao = headers.get("access-control-allow-origin")
+        assert acao != "*"
+        if origin != LOCAL_ORIGIN:
+            assert acao is None
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason="Requiring a token by default would break every existing gaia mcp "
+    "consumer; the bridge still defaults to no auth and warns at startup.",
+)
+def test_bridge_requires_a_token_by_default(server_factory):
+    base, bridge = server_factory(auth_token=None)
+    status, _, _ = _raw(f"{base}/chat", method="POST", payload={"query": "x"})
+    assert status == 401
+    assert bridge.executed == []
 
 
 class TestConfigurationContract:


### PR DESCRIPTION
Any web page open in your browser could drive GAIA's local servers and read the answers, and a link injected into a document could make the chat agent fetch internal addresses — the Lemonade API, the daemon's loopback API, or cloud metadata. Now every local server refuses foreign browser origins, the chat agent's web tools refuse private and loopback targets on every redirect hop, and an API key is enforced wherever one is configured.

Two configurations behave differently after this:

- **`GAIA_API_KEY` now applies to `gaia api` chat completions too.** A client with a hard-coded key gets 401 once a key is set — the VS Code extension sends `Bearer gaia`, so its key should become a setting.
- **`--api` bound beyond loopback with no key is refused at startup.** On loopback, keyless callers keep working and the server logs a warning that a key will become mandatory.

## Test plan

- [ ] `python -m pytest tests/unit/test_local_http_guard.py tests/unit/test_chat_inline_web_ssrf.py tests/unit/test_mcp_bridge_auth.py tests/unit/test_api_agent_proxy.py tests/test_api.py tests/unit/test_web_client_ip_pinning.py tests/unit/test_web_client_edge_cases.py tests/unit/test_browser_tools.py` — 352 passed, 3 xfailed; the xfails pin the deferred mandatory-auth behaviour as strict. The same pre-existing files pass 258/258 on `main`.
- [ ] Route-table tests fail if any `AgentServer` route or mutating `gaia api` route ships without a caller guard
- [ ] `gaia mcp serve` still reaches the Agent UI backend with its CSRF header, and gets 403 without it — verified in-process
- [ ] Electron shell and TUI unaffected — verified by reading every mutating call site; neither app was launched
