### PR TITLE
fix(eval): make the agent eval gate's report mode actually report

### DIFF
--- a/.github/workflows/test_eval_agent_gemma_consolidation.yml
+++ b/.github/workflows/test_eval_agent_gemma_consolidation.yml
@@ -49,16 +49,29 @@
 # bars are trustworthy. Same idea, inverted default: report unless asked to
 # enforce.
 #
-# REPORT MODE SOFTENS "WORSE", NEVER "DIDN'T MEASURE". `--compare` scores only
-# scenarios present on BOTH sides: scenarios that vanish from the current run land
-# in an `only_in_baseline` bucket that is NOT part of its exit-2 verdict
-# (runner.py::compare_scorecards). Verified: dropping 6 of 7 rag_quality scenarios
-# still exits 0. So a broken harness would otherwise sail through as "no
-# regression". The integrity gate below therefore runs UNCONDITIONALLY — ignoring
-# `enforce` entirely — and fails the job if a baseline scenario is missing or any
-# scenario failed to produce a measurement (infra_error / errored / timeout /
-# blocked / budget_exceeded). Report mode is for "we measured and it got worse",
-# never for "we did not measure".
+# REPORT MODE COVERS "WORSE" AND "DIDN'T MEASURE" ALIKE — VISIBLY. `--compare`
+# scores only scenarios present on BOTH sides: scenarios that vanish from the
+# current run land in an `only_in_baseline` bucket that is NOT part of its exit-2
+# verdict (runner.py::compare_scorecards). Verified: dropping 6 of 7 rag_quality
+# scenarios still exits 0. So a broken harness would otherwise sail through as "no
+# regression". The integrity gate below is what refuses that: it fails if a
+# baseline scenario is missing or any scenario produced no measurement
+# (infra_error / errored / timeout / blocked / budget_exceeded / skipped).
+#
+# That gate used to ignore `enforce` and fail unconditionally, on the reasoning
+# that report mode may soften "worse" but never "did not measure". The reasoning
+# is sound and the outcome was not: the embedder cannot load on this runner
+# (#3016), which is an environment defect no PR can fix, so the gate was red on
+# every PR touching the path filter — including seven whose diffs never went near
+# the eval — while this same job printed "report mode ... build stays green". A
+# check that is always red gates nothing, and one that advertises non-blocking
+# while blocking is worse than either honest posture.
+#
+# So `enforce` now decides the EXIT CODE for an incomplete run as well as a worse
+# one. It never decides VISIBILITY: in report mode every finding is still a
+# `::warning::` annotation AND a block in the job summary, so an incomplete run
+# cannot be mistaken for a complete one. `enforce: true` restores blocking for
+# both.
 #
 # TIME REGRESSIONS ARE NOT COMPARABLE TO THIS BASELINE. `--compare` folds a >2x
 # per-scenario wall-clock delta into the same exit 2 as a quality regression, but
@@ -706,28 +719,36 @@ jobs:
           # repeat on every PR now that it is known (#3016) - it adds ~7 min and
           # leaves the next job on this shared box paying for a cold reload.
           # Re-dispatch with deep_diagnostics: true to run the full ladder.
-          # ...and do NOT kill the job here. Only rag_quality and context_retention
-          # answer out of embedder-produced chunks; tool_selection's four scenarios
-          # (known_path_read, multi_step_plan, no_tools_needed, smart_discovery)
-          # carry no corpus at all, so a dead embedder costs two categories, not
-          # three. Exiting cost the third for free and left PRs with no regression
-          # signal whatsoever. Record the state, let the run measure what it can,
-          # and let the integrity gate render the honest verdict - the job still
-          # fails, because two of three were not measured.
+          # ...and do NOT kill the job here. Exiting left PRs with no regression
+          # signal whatsoever; record the state, let the run measure what it can,
+          # and let the integrity gate render the honest verdict.
+          #
+          # How much tool_selection survives a dead embedder is LESS than an
+          # earlier revision of this comment claimed. It asserted the category
+          # "carries no corpus at all"; three of its five scenarios
+          # (data_vs_recall_disambiguation, known_path_read, multi_step_plan) index
+          # corpus documents in their `setup:`, so they need the embedder too. Only
+          # no_tools_needed and smart_discovery are genuinely corpus-free. Running
+          # the category anyway is still worth it - two measured scenarios beat
+          # zero - but do not read a green tool_selection here as full coverage;
+          # the integrity gate names exactly what was and was not measured.
           #
           # `exit 0` is what makes both of those true, and it is load-bearing:
           # without it this block only PRINTED the promise. Execution fell through
           # into the rungs below and ended at their terminal `exit 1`, which failed
           # the step, which skipped the eval step entirely - so tool_selection was
           # never measured either and the gate blocked PRs while reporting nothing
-          # (run 33286140041: 12 min of preflight, three categories skipped). It is
-          # not a green light: EMBEDDER_OK=false above routes the integrity gate to
-          # mark rag_quality and context_retention NOT MEASURED and fail the job
-          # there, on its own terms, with tool_selection genuinely compared.
+          # (run 33286140041: 12 min of preflight, three categories skipped).
+          #
+          # The annotation level tracks `enforce` for the same reason the integrity
+          # gate's does: #3016 is an environment defect, so on a report-mode PR run
+          # a red ::error:: on a green job is noise that trains people to ignore the
+          # check. The text is identical either way - only its severity moves.
           if (-not $embedOk -and $env:DEEP_DIAG -ne 'true') {
             Show-LemonadeTaskLog | Out-Null
             "EMBEDDER_OK=false" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
-            Write-Host "::error::The RAG embedder $embeddingModel will not load on this runner - a known Strix Halo limitation tracked in #3016, NOT a fault in this PR. The chat model loaded and served over the same llama-server binary earlier in this step, and the same embedder loads fine on the Strix Point boxes, so llama-server works here and the gap is specific to the embeddings path on this SoC. Re-running this gate will not clear it. rag_quality and context_retention cannot be measured; tool_selection does not need the embedder and WILL still run, so this job continues and still gates that category. The deeper rungs (purge the model from disk, load without --ubatch-size 2048, load with everything else unloaded) are skipped on PR runs on purpose because they disturb other jobs on this shared box - re-dispatch with deep_diagnostics: true if you need the full elimination ladder."
+            $level = if ($env:ENFORCE -eq 'true') { 'error' } else { 'warning' }
+            Write-Host "::${level}::The RAG embedder $embeddingModel will not load on this runner - a known Strix Halo limitation tracked in #3016, NOT a fault in this PR. The chat model loaded and served over the same llama-server binary earlier in this step, and the same embedder loads fine on the Strix Point boxes, so llama-server works here and the gap is specific to the embeddings path on this SoC. Re-running this gate will not clear it. rag_quality and context_retention cannot be measured at all; tool_selection WILL still run, but only its two corpus-free scenarios (no_tools_needed, smart_discovery) can produce a measurement - the other three index documents and need the same embedder. The deeper rungs (purge the model from disk, load without --ubatch-size 2048, load with everything else unloaded) are skipped on PR runs on purpose because they disturb other jobs on this shared box - re-dispatch with deep_diagnostics: true if you need the full elimination ladder."
             exit 0
           }
 
@@ -913,7 +934,7 @@ jobs:
             # backend default (their `config` records only backend_url/model/budget),
             # so passing one here would compare against a different agent.
             $categories = if ($env:EMBEDDER_OK -eq 'false') { @("tool_selection") } else { @("rag_quality", "context_retention", "tool_selection") }
-            if ($env:EMBEDDER_OK -eq 'false') { Write-Host "::warning::Embedder unavailable (#3016) - measuring tool_selection only. rag_quality and context_retention answer out of embedder-produced chunks and cannot be measured; the integrity gate below still fails the job for them." }
+            if ($env:EMBEDDER_OK -eq 'false') { Write-Host "::warning::Embedder unavailable (#3016) - measuring tool_selection only. rag_quality and context_retention answer out of embedder-produced chunks and cannot be measured; the integrity gate below reports them as NOT MEASURED (and fails the job when enforce=true)." }
             foreach ($category in $categories) {
               Write-Host "=================================================================="
               Write-Host "  gaia eval agent --category $category"
@@ -968,14 +989,19 @@ jobs:
         if: ${{ !cancelled() }}
         run: |
           $ErrorActionPreference = "Stop"
-          $missing = $false
+          # This step COLLECTS; it does not judge. A category with no scorecard is
+          # reported here and lands in the integrity gate below as "no scorecard
+          # produced", which is where the enforce policy is applied - once, in one
+          # place. Exiting non-zero here as well would re-introduce a second,
+          # enforce-blind blocking decision, which is exactly the bug being fixed.
+          # A genuine harness crash still fails at the eval step itself.
+          $level = if ($env:ENFORCE -eq 'true') { 'error' } else { 'warning' }
 
           $categories = if ($env:EMBEDDER_OK -eq 'false') { @("tool_selection") } else { @("rag_quality", "context_retention", "tool_selection") }
           foreach ($category in $categories) {
             $log = "eval-out\$category.log"
             if (-not (Test-Path $log)) {
-              Write-Host "::error::No log for $category - the chain stopped before it ran."
-              $missing = $true
+              Write-Host "::${level}::No log for $category - the chain stopped before it ran."
               continue
             }
             # The runner prints an ABSOLUTE `Output: <run-dir>` line
@@ -987,8 +1013,7 @@ jobs:
             $scorecard = if ($runDir) { Join-Path $runDir "scorecard.json" } else { $null }
             if (-not $runDir -or -not (Test-Path $scorecard)) {
               $shown = if ($runDir) { $runDir } else { "<none>" }
-              Write-Host "::error::Could not resolve a scorecard for $category (parsed run dir: '$shown'). The eval did not print an 'Output:' line, or it did not write scorecard.json - see eval-out\$category.log."
-              $missing = $true
+              Write-Host "::${level}::Could not resolve a scorecard for $category (parsed run dir: '$shown'). The eval did not print an 'Output:' line, or it did not write scorecard.json - see eval-out\$category.log."
               continue
             }
             New-Item -ItemType Directory -Force -Path "eval-out\$category" | Out-Null
@@ -1008,84 +1033,59 @@ jobs:
             Write-Host "${category}: $runDir"
           }
 
-          if ($missing) { exit 1 }
-
-      - name: Integrity gate — did we actually measure? (ignores `enforce`)
+      - name: Integrity gate — did we actually measure?
         if: ${{ !cancelled() }}
         run: |
           $ErrorActionPreference = "Stop"
-          # UNCONDITIONAL. `--compare` only scores scenarios present on both sides,
-          # so a run whose scenarios vanished exits 0 and would pass as "no
-          # regression" (verified: 6 of 7 dropped -> exit 0). `enforce` decides
-          # whether a WORSE result blocks; it must never decide whether a
-          # NON-EXISTENT result blocks.
+          # `--compare` only scores scenarios present on BOTH sides, so a run whose
+          # scenarios vanished exits 0 and reads as "no regression" (verified: 6 of
+          # 7 dropped -> exit 0). This gate asks the other question - is there a
+          # measurement at all - and is the only thing between an empty run and a
+          # green check. The logic lives in gaia.eval.integrity_gate so it is unit
+          # tested (tests/unit/eval/test_integrity_gate.py) rather than being
+          # seventy lines of untestable PowerShell.
           #
-          # Statuses that mean "no measurement was produced", as distinct from
-          # "measured and failed" (FAIL is a legitimate, comparable outcome).
+          # IT HONORS `enforce`, and that is the fix for the state this gate was in.
+          # An earlier revision failed UNCONDITIONALLY on the reasoning that report
+          # mode may soften "worse" but never "did not measure". Sound in principle;
+          # in practice the embedder cannot load on this runner (#3016, an
+          # environment defect no PR can fix), so the gate went red on every PR
+          # touching its path filter while the job's own summary printed "report
+          # mode ... build stays green". A workflow that advertises non-blocking and
+          # blocks anyway is worse than either posture: it blocked 7 PRs whose diffs
+          # had nothing to do with the eval, and people stop reading a check that is
+          # always red. So `enforce` now decides the EXIT CODE for both incomplete
+          # and worse-than-baseline; it never decides VISIBILITY. In report mode
+          # every finding is still a ::warning:: annotation and still lands in the
+          # job summary, so an incomplete run is impossible to mistake for a
+          # complete one - it just does not veto an unrelated PR.
           #
-          # `skipped` (SKIPPED_NO_DOCUMENT, corpus file absent from disk) is the
-          # subtlest of these and the reason this list is not just the obvious
-          # errors: those scenarios KEEP their ids, so the missing-scenario check
-          # below stays clean, and compare_scorecards files them under
-          # `corpus_changed` = "not a quality signal" -> exit 0. A runner whose
-          # corpus never materialised would otherwise go green having measured
-          # nothing. All three committed baselines have skipped=0.
-          $noMeasurement = @("infra_error", "errored", "timeout", "blocked", "budget_exceeded", "skipped")
-          $problems = @()
-
-          $categories = if ($env:EMBEDDER_OK -eq 'false') { @("tool_selection") } else { @("rag_quality", "context_retention", "tool_selection") }
-          $skipped = if ($env:EMBEDDER_OK -eq 'false') { @("rag_quality", "context_retention") } else { @() }
-          foreach ($category in $categories) {
-            $current = "eval-out\$category\scorecard.json"
-            if (-not (Test-Path $current)) {
-              $problems += "${category}: no scorecard produced"
-              continue
-            }
-
-            $card = Get-Content $current -Raw -Encoding UTF8 | ConvertFrom-Json
-            $baseline = Get-Content (Join-Path $env:BASELINE_DIR "scorecard_$category.json") -Raw -Encoding UTF8 | ConvertFrom-Json
-
-            $got = @(@($card.scenarios) | ForEach-Object { $_.scenario_id })
-            $want = @(@($baseline.scenarios) | ForEach-Object { $_.scenario_id })
-            $absent = @($want | Where-Object { $got -notcontains $_ })
-            if ($absent.Count -gt 0) {
-              $problems += "${category}: $($absent.Count) baseline scenario(s) missing from the run: $(($absent | Sort-Object) -join ', ')"
-            }
-
-            $unmeasured = @()
-            foreach ($status in $noMeasurement) {
-              $count = $card.summary.$status
-              if ($count) { $unmeasured += "${status}=$count" }
-            }
-            if ($unmeasured.Count -gt 0) {
-              $problems += "${category}: scenarios without a measurement: $($unmeasured -join ', ')"
-            }
-
-            $shown = if ($unmeasured.Count -gt 0) { $unmeasured -join ', ' } else { "none" }
-            Write-Host "${category}: $($got.Count) scenario(s) run, $($want.Count) in baseline, unmeasured=$shown"
+          # `skipped` (SKIPPED_NO_DOCUMENT) counts as unmeasured for a subtle reason
+          # documented in the module: those scenarios keep their ids, so the
+          # missing-scenario check stays clean, and compare files them under
+          # "not a quality signal". All three committed baselines have skipped=0.
+          $gateArgs = @(
+            "--baseline-dir", $env:BASELINE_DIR,
+            "--results-dir", "eval-out"
+          )
+          if ($env:EMBEDDER_OK -eq 'false') {
+            $gateArgs += @("--category", "tool_selection")
+            $gateArgs += @("--not-measured", "rag_quality", "--not-measured", "context_retention")
+            $gateArgs += @("--not-measured-reason", "the RAG embedder will not load on this runner (#3016), and this category answers out of embedder-produced chunks")
+          } else {
+            $gateArgs += @("--category", "rag_quality", "--category", "context_retention", "--category", "tool_selection")
           }
+          if ($env:ENFORCE -eq 'true') { $gateArgs += "--enforce" }
 
-          # A category the embedder made impossible is still an unmeasured
-          # category. It is named with its cause rather than silently dropped,
-          # and it still fails the job: this gate's whole job is refusing to
-          # render a verdict over measurements that do not exist, and "we knew
-          # why" is not the same as "we measured it".
-          foreach ($sk in $skipped) {
-            $problems += "${sk}: NOT MEASURED - the RAG embedder will not load on this runner (#3016), and this category answers out of embedder-produced chunks"
-          }
-
-          if ($problems.Count -gt 0) {
-            foreach ($p in $problems) { Write-Host "::error::Integrity: $p" }
-            Write-Host ""
-            if ($skipped.Count -gt 0) {
-              Write-Host "NOTE: $($categories -join ', ') still ran and IS compared below - read that verdict, it is a real regression signal. What this job cannot tell you today is anything about $($skipped -join ' or '), and it will keep failing until #3016 is fixed."
-              Write-Host ""
-            }
-            Write-Host "The eval did not produce a complete set of measurements, so the baseline comparison below is not trustworthy. This fails regardless of ``enforce`` - report mode softens a WORSE score, never a MISSING one. Check the backend/Lemonade logs in the artifact, then re-run."
+          # Reset first: a command that fails to LAUNCH leaves $LASTEXITCODE at its
+          # previous value, so a stale 0 would read as a complete run.
+          $global:LASTEXITCODE = 0
+          python -m gaia.eval.integrity_gate @gateArgs
+          $code = $LASTEXITCODE
+          if ($code -ne 0) {
+            Write-Host "::error::Integrity gate failed (exit $code) with enforce=$env:ENFORCE. Check the backend/Lemonade logs in the artifact, then re-run."
             exit 1
           }
-          Write-Host ""
-          Write-Host "Integrity OK - every baseline scenario ran and produced a measurement."
 
       - name: Compare each category against its committed Gemma baseline
         if: ${{ !cancelled() }}
@@ -1102,8 +1102,10 @@ jobs:
             Write-Host "  ${category}: $baseline  ->  $current"
             Write-Host "=================================================================="
             if (-not (Test-Path $current)) {
-              Write-Host "::warning::${category}: no scorecard produced - nothing to compare."
-              $failedCompare = $true
+              # NOT $failedCompare: "we did not measure" is the integrity gate's
+              # verdict and it has already rendered it under the enforce policy.
+              # Counting it again here would fail the job regardless of enforce.
+              Write-Host "::warning::${category}: no scorecard produced - nothing to compare (already reported by the integrity gate)."
               continue
             }
             # `--compare` exits 2 on status/score/time regressions, 0 otherwise
@@ -1148,9 +1150,11 @@ jobs:
           Write-Host "on this runner."
           Write-Host "=================================================================="
 
-          # A harness/IO error is never tolerated - it means we did not actually measure.
+          # A compare that exits with something other than 0 or 2 is the TOOL
+          # failing, not a verdict - `enforce` governs what a measurement is
+          # allowed to say, never whether the tool ran. Always fatal.
           if ($failedCompare) {
-            Write-Host "::error::One or more comparisons could not be performed. Failing regardless of enforce."
+            Write-Host "::error::One or more comparisons could not be performed - 'gaia eval agent --compare' itself failed. This is a harness/IO error, not a regression verdict, so it fails regardless of enforce."
             exit 1
           }
           if ($regressed.Count -gt 0) {

--- a/src/gaia/cli.py
+++ b/src/gaia/cli.py
@@ -3906,10 +3906,22 @@ Let me know your answer!
                         print("[ERROR] --compare accepts 1 or 2 paths")
                         sys.exit(1)
 
-                    # If compare detected regressions or significant score drops, fail non-zero
+                    # If compare detected regressions or significant score drops, fail non-zero.
+                    # Scenarios with no measurement are deliberately NOT counted:
+                    # an infra failure is not a quality regression. Completeness
+                    # is the integrity gate's verdict (gaia.eval.integrity_gate),
+                    # so it is surfaced here and blocks there.
                     regressed = result.get("regressed", [])
                     score_regressed = result.get("score_regressed", [])
                     time_regressed = result.get("time_regressed", [])
+                    unmeasured = result.get("unmeasured", [])
+                    if unmeasured:
+                        ids = ", ".join(e["scenario_id"] for e in unmeasured)
+                        print(
+                            f"[WARN] {len(unmeasured)} scenario(s) had no measurement and were "
+                            f"excluded from this verdict: {ids}. Run "
+                            "`python -m gaia.eval.integrity_gate --help` for the completeness check."
+                        )
                     total_issues = (
                         len(regressed) + len(score_regressed) + len(time_regressed)
                     )

--- a/src/gaia/eval/integrity_gate.py
+++ b/src/gaia/eval/integrity_gate.py
@@ -1,0 +1,263 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""
+CI completeness gate: did the agent eval actually MEASURE what it claims to?
+
+**Distinct from** ``compare_scorecards`` (``gaia.eval.runner``), which answers
+"did quality get worse". That comparison scores only scenarios present on both
+sides, so a run whose scenarios vanished or died in the harness exits 0 and reads
+as "no regression". This gate answers the other question — "is there a
+measurement at all" — and is the only thing standing between an empty run and a
+green check.
+
+Two failure classes, both reported:
+
+* **Missing** — a scenario in the baseline never appeared in the run.
+* **Unmeasured** — a scenario ran but produced no score (``infra_error``,
+  ``errored``, ``timeout``, ``blocked``, ``budget_exceeded``, ``skipped``), plus
+  any category named via ``--not-measured`` because the environment could not run
+  it at all.
+
+``skipped`` (``SKIPPED_NO_DOCUMENT``) is the subtle one and the reason this list
+is not just the obvious errors: those scenarios keep their ids, so the missing
+check stays clean, and ``compare_scorecards`` files them under ``corpus_changed``
+= "not a quality signal". A runner whose corpus never materialised would
+otherwise go green having measured nothing.
+
+Usage::
+
+    python -m gaia.eval.integrity_gate \\
+        --baseline-dir tests/fixtures/eval_baselines/gemma-4-e4b-d71cd914 \\
+        --results-dir eval-out \\
+        --category tool_selection \\
+        --not-measured rag_quality --not-measured context_retention \\
+        --not-measured-reason "the RAG embedder will not load on this runner (#3016)" \\
+        --enforce
+
+Exit codes:
+    0 — complete, OR incomplete in report mode (``--enforce`` absent).
+    1 — incomplete and ``--enforce`` was passed.
+
+``--enforce`` is what makes the gate BLOCKING. Without it the same findings are
+emitted as ``::warning::`` annotations and written to the job summary, and the
+job stays green — because the workflow that calls this advertises report mode by
+default, and a gate that is red on every PR for a known environment defect gates
+nothing. The signal is never suppressed in either mode; only the exit code moves.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+
+# Summary counters meaning "a scenario produced no measurement", as distinct
+# from `failed` (FAIL is a legitimate, comparable outcome). Mirrors
+# gaia.eval.runner._NO_MEASUREMENT_STATUSES, expressed in the scorecard summary's
+# own key names (scorecard.py::build_scorecard).
+NO_MEASUREMENT_COUNTERS = (
+    "infra_error",
+    "errored",
+    "timeout",
+    "blocked",
+    "budget_exceeded",
+    "skipped",
+)
+
+
+def _load(path: Path) -> dict:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _scenario_ids(scorecard: dict) -> list:
+    return [
+        s.get("scenario_id")
+        for s in scorecard.get("scenarios") or []
+        if s.get("scenario_id")
+    ]
+
+
+def check_category(baseline_path: Path, current_path: Path, category: str):
+    """Return ``(problems, status_line)`` for one category.
+
+    ``problems`` is a list of human-readable strings; empty means complete.
+    """
+    problems = []
+    if not current_path.exists():
+        return (
+            [f"{category}: no scorecard produced ({current_path})"],
+            f"{category}: no scorecard at {current_path}",
+        )
+    if not baseline_path.exists():
+        return (
+            [f"{category}: baseline scorecard not found ({baseline_path})"],
+            f"{category}: no baseline at {baseline_path}",
+        )
+
+    current = _load(current_path)
+    baseline = _load(baseline_path)
+
+    got = _scenario_ids(current)
+    want = _scenario_ids(baseline)
+    absent = sorted(set(want) - set(got))
+    if absent:
+        problems.append(
+            f"{category}: {len(absent)} baseline scenario(s) missing from the run: "
+            f"{', '.join(absent)}"
+        )
+
+    summary = current.get("summary") or {}
+    unmeasured = [
+        f"{key}={summary[key]}" for key in NO_MEASUREMENT_COUNTERS if summary.get(key)
+    ]
+    if unmeasured:
+        problems.append(
+            f"{category}: scenarios without a measurement: {', '.join(unmeasured)}"
+        )
+
+    shown = ", ".join(unmeasured) if unmeasured else "none"
+    status_line = (
+        f"{category}: {len(got)} scenario(s) run, {len(want)} in baseline, "
+        f"unmeasured={shown}"
+    )
+    return problems, status_line
+
+
+def _write_summary(lines) -> None:
+    """Append to the GitHub step summary. Visible in BOTH modes on purpose."""
+    path = os.environ.get("GITHUB_STEP_SUMMARY")
+    if not path:
+        return
+    with open(path, "a", encoding="utf-8") as handle:
+        handle.write("\n".join(lines) + "\n")
+
+
+def main(argv=None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="python -m gaia.eval.integrity_gate",
+        description="Fail a CI eval run that did not actually measure what it compares.",
+    )
+    parser.add_argument(
+        "--baseline-dir",
+        required=True,
+        help="Directory holding scorecard_<category>.json baselines.",
+    )
+    parser.add_argument(
+        "--results-dir",
+        required=True,
+        help="Directory holding <category>/scorecard.json from this run.",
+    )
+    parser.add_argument(
+        "--category",
+        action="append",
+        default=[],
+        dest="categories",
+        help="Category that was run and must be complete. Repeatable.",
+    )
+    parser.add_argument(
+        "--not-measured",
+        action="append",
+        default=[],
+        dest="not_measured",
+        help=(
+            "Category the environment could not run at all. Reported as "
+            "unmeasured with --not-measured-reason. Repeatable."
+        ),
+    )
+    parser.add_argument(
+        "--not-measured-reason",
+        default="the environment could not run this category",
+        help="Why the --not-measured categories could not run (goes in the annotation).",
+    )
+    parser.add_argument(
+        "--enforce",
+        action="store_true",
+        help=(
+            "Block on an incomplete run (exit 1). Without it the same findings "
+            "are emitted as ::warning:: annotations and the job stays green."
+        ),
+    )
+    args = parser.parse_args(argv)
+
+    if not args.categories and not args.not_measured:
+        # Nothing to check is not "complete" — it is a miswired workflow.
+        print(
+            "::error::integrity_gate: no --category and no --not-measured given; "
+            "nothing was checked. Pass the categories this run was supposed to measure.",
+        )
+        return 1
+
+    baseline_dir = Path(args.baseline_dir)
+    results_dir = Path(args.results_dir)
+
+    problems = []
+    for category in args.categories:
+        cat_problems, status_line = check_category(
+            baseline_dir / f"scorecard_{category}.json",
+            results_dir / category / "scorecard.json",
+            category,
+        )
+        print(status_line)
+        problems.extend(cat_problems)
+
+    # A category the environment made impossible is still an unmeasured category.
+    # Named with its cause rather than silently dropped.
+    for category in args.not_measured:
+        problems.append(f"{category}: NOT MEASURED - {args.not_measured_reason}")
+
+    if not problems:
+        print("")
+        print("Integrity OK - every baseline scenario ran and produced a measurement.")
+        _write_summary(
+            [
+                "",
+                "### Eval integrity: OK",
+                "",
+                f"Every baseline scenario ran and produced a measurement "
+                f"({', '.join(args.categories)}).",
+            ]
+        )
+        return 0
+
+    level = "error" if args.enforce else "warning"
+    for problem in problems:
+        print(f"::{level}::Integrity: {problem}")
+
+    print("")
+    print(
+        "The eval did not produce a complete set of measurements, so the baseline "
+        "comparison is not trustworthy for the categories named above."
+    )
+
+    # The summary block is written in BOTH modes. In report mode it is the only
+    # durable record that the run measured less than it appears to.
+    summary = [
+        "",
+        f"### Eval integrity: INCOMPLETE ({len(problems)} finding(s))",
+        "",
+    ]
+    summary += [f"- {problem}" for problem in problems]
+    summary += [""]
+
+    if args.enforce:
+        print("enforce=true - failing the build.")
+        summary.append("**enforce=true — this failed the build.**")
+        _write_summary(summary)
+        return 1
+
+    print(
+        "enforce=false - reported as warnings, build stays green. Re-run with "
+        "enforce=true (or put [eval-enforce] in the PR title) to make this blocking."
+    )
+    summary.append(
+        "**enforce=false — reported only; the build stays green.** Re-run with "
+        "`enforce: true` (or put `[eval-enforce]` in the PR title) to make this blocking."
+    )
+    _write_summary(summary)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/gaia/eval/runner.py
+++ b/src/gaia/eval/runner.py
@@ -587,6 +587,15 @@ _SCORE_WEIGHTS = {
 # Significant score drop within the same pass/fail status warrants a warning
 _SCORE_REGRESSION_THRESHOLD = 2.0
 
+# Statuses meaning the scenario produced NO measurement, as distinct from
+# "measured and failed" — FAIL is a legitimate, comparable outcome. A harness
+# death scores 0.0 (or null), which is indistinguishable from a model that
+# answered badly, so comparing the two reports infrastructure as a regression.
+# Kept in sync with the buckets in scorecard.py::build_scorecard.
+_NO_MEASUREMENT_STATUSES = frozenset(
+    {"INFRA_ERROR", "SETUP_ERROR", "TIMEOUT", "BUDGET_EXCEEDED", "ERRORED"}
+)
+
 
 @functools.lru_cache(maxsize=1)
 def _load_simulator_content() -> str:
@@ -1488,6 +1497,11 @@ def compare_scorecards(baseline_path, current_path):
     # corpus_changed: one side is SKIPPED_NO_DOCUMENT — corpus availability changed,
     # not a quality regression or improvement.  Reported separately to avoid noise.
     corpus_changed = []
+    # unmeasured: the CURRENT run has a _NO_MEASUREMENT_STATUSES status — the
+    # harness never produced a score, so there is nothing to compare.  Excluded
+    # from the verdict and reported separately; the CI integrity gate
+    # (gaia.eval.integrity_gate) is what blocks on a run that measured nothing.
+    unmeasured = []
 
     for sid in all_ids:
         if sid in base_map and sid not in curr_map:
@@ -1501,6 +1515,12 @@ def compare_scorecards(baseline_path, current_path):
         c = curr_map[sid]
         b_skipped = b.get("status") == "SKIPPED_NO_DOCUMENT"
         c_skipped = c.get("status") == "SKIPPED_NO_DOCUMENT"
+        # Current side only. A baseline that never measured and a current run
+        # that did is strictly more information than before, and cannot produce a
+        # false regression: an unmeasured scenario scores 0, so every delta out of
+        # it is non-negative. Treating it as unmeasured would only discard the
+        # improvement.
+        c_unmeasured = c.get("status") in _NO_MEASUREMENT_STATUSES
         b_pass = b.get("status") == "PASS"
         c_pass = c.get("status") == "PASS"
         b_score = (
@@ -1539,6 +1559,10 @@ def compare_scorecards(baseline_path, current_path):
         # Corpus availability change — not a quality signal
         if b_skipped or c_skipped:
             corpus_changed.append(entry)
+        # This run produced no measurement — nothing to compare, including the
+        # wall clock, so this is checked ahead of the time-regression branch.
+        elif c_unmeasured:
+            unmeasured.append(entry)
         elif entry.get("time_regressed"):
             # Time regressions reported separately from score regressions
             time_regressed.append(entry)
@@ -1660,7 +1684,25 @@ def compare_scorecards(baseline_path, current_path):
                 f"    {e['scenario_id']:<40} {e['baseline_status']} → {e['current_status']}"
             )
 
+    if unmeasured:
+        print(
+            f"\n[?] NOT MEASURED ({len(unmeasured)} scenario(s)) — the harness produced "
+            "no score in this run; EXCLUDED from the verdict below:"
+        )
+        for e in unmeasured:
+            print(
+                f"    {e['scenario_id']:<40} {e['baseline_status']} → {e['current_status']}"
+            )
+
     print(f"\n{'='*70}")
+    if unmeasured:
+        # Loud on purpose: this verdict is silent about these scenarios, and a
+        # clean verdict over an incomplete run is the one way this comparison can
+        # mislead. Blocking on it belongs to the integrity gate, not here.
+        print(
+            f"[WARN] {len(unmeasured)} scenario(s) produced NO measurement and are "
+            "excluded below — a clean verdict does NOT mean they passed."
+        )
     if regressed:
         print(f"[WARN] {len(regressed)} regression(s) detected!")
     if score_regressed:
@@ -1671,12 +1713,15 @@ def compare_scorecards(baseline_path, current_path):
         print(
             f"[WARN] {len(time_regressed)} time regression(s) detected (elapsed time > 2x baseline)!"
         )
-    if not regressed and not score_regressed and improved:
-        print(
-            f"[OK]   Net improvement: {len(improved)} scenario(s) fixed, 0 regressions."
-        )
-    elif not regressed and not score_regressed and not improved:
-        print("[OK]   No status changes between runs.")
+    # An [OK] over an incomplete run is the misleading line; the WARN above says
+    # what is missing, so do not follow it with a clean bill of health.
+    if not regressed and not score_regressed and not unmeasured:
+        if improved:
+            print(
+                f"[OK]   Net improvement: {len(improved)} scenario(s) fixed, 0 regressions."
+            )
+        else:
+            print("[OK]   No status changes between runs.")
     print(f"{'='*70}\n")
 
     return {
@@ -1688,6 +1733,7 @@ def compare_scorecards(baseline_path, current_path):
         "only_in_baseline": only_in_baseline,
         "only_in_current": only_in_current,
         "corpus_changed": corpus_changed,
+        "unmeasured": unmeasured,
     }
 
 

--- a/tests/test_eval.py
+++ b/tests/test_eval.py
@@ -432,6 +432,90 @@ class TestAgentEvalRunner:
         assert len(diff["score_regressed"]) == 0
         assert len(diff["unchanged"]) == 1
 
+    @pytest.mark.parametrize(
+        "status",
+        ["INFRA_ERROR", "SETUP_ERROR", "TIMEOUT", "BUDGET_EXCEEDED", "ERRORED"],
+    )
+    def test_unmeasured_scenario_is_not_a_regression(self, tmp_path, status):
+        """A harness failure scores 0.0; that must not read as PASS -> FAIL.
+
+        Run 34163958523 reported ``multi_step_plan 7.3 -> 0.0`` as a PASS -> FAIL
+        regression when the scenario had actually ended in SETUP_ERROR and was
+        never scored at all. "We could not measure" and "it got worse" are
+        different findings; only the second is a regression.
+        """
+        from gaia.eval.runner import compare_scorecards
+        from gaia.eval.scorecard import build_scorecard
+
+        def _sc(results, name):
+            sc = build_scorecard("run", results, {})
+            p = tmp_path / f"sc_{name}_{status}.json"
+            p.write_text(json.dumps(sc))
+            return p
+
+        baseline_results = [
+            {
+                "scenario_id": "multi_step_plan",
+                "status": "PASS",
+                "overall_score": 7.3,
+                "category": "tool_selection",
+                "cost_estimate": {"estimated_usd": 0},
+            },
+        ]
+        current_results = [
+            {
+                "scenario_id": "multi_step_plan",
+                "status": status,
+                "overall_score": 0.0,
+                "category": "tool_selection",
+                "cost_estimate": {"estimated_usd": 0},
+            },
+        ]
+        diff = compare_scorecards(
+            _sc(baseline_results, "base"), _sc(current_results, "curr")
+        )
+        assert len(diff["unmeasured"]) == 1
+        assert diff["unmeasured"][0]["scenario_id"] == "multi_step_plan"
+        assert diff["unmeasured"][0]["current_status"] == status
+        # Excluded from every bucket the CLI turns into a non-zero exit code.
+        assert diff["regressed"] == []
+        assert diff["score_regressed"] == []
+        assert diff["time_regressed"] == []
+
+    def test_unmeasured_does_not_mask_a_real_regression(self, tmp_path):
+        """The scenarios that DID get measured are still judged normally."""
+        from gaia.eval.runner import compare_scorecards
+        from gaia.eval.scorecard import build_scorecard
+
+        def _sc(results, name):
+            sc = build_scorecard("run", results, {})
+            p = tmp_path / f"mixed_{name}.json"
+            p.write_text(json.dumps(sc))
+            return p
+
+        def _r(sid, status, score):
+            return {
+                "scenario_id": sid,
+                "status": status,
+                "overall_score": score,
+                "category": "tool_selection",
+                "cost_estimate": {"estimated_usd": 0},
+            }
+
+        baseline_results = [
+            _r("multi_step_plan", "PASS", 7.3),
+            _r("smart_discovery", "PASS", 9.4),
+        ]
+        current_results = [
+            _r("multi_step_plan", "SETUP_ERROR", 0.0),
+            _r("smart_discovery", "FAIL", 3.4),
+        ]
+        diff = compare_scorecards(
+            _sc(baseline_results, "base"), _sc(current_results, "curr")
+        )
+        assert [e["scenario_id"] for e in diff["unmeasured"]] == ["multi_step_plan"]
+        assert [e["scenario_id"] for e in diff["regressed"]] == ["smart_discovery"]
+
 
 class TestScoreValidation:
     """Tests for post-hoc score validation helpers."""

--- a/tests/unit/eval/test_integrity_gate.py
+++ b/tests/unit/eval/test_integrity_gate.py
@@ -1,0 +1,159 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""Tests for the CI eval completeness gate (``gaia.eval.integrity_gate``).
+
+The gate's whole contract is that ``--enforce`` moves the EXIT CODE and nothing
+else — the findings stay visible in both modes. Both halves are asserted here:
+report mode must exit 0 while still emitting the annotation and the job-summary
+block, and enforce mode must exit 1 on the same input.
+"""
+
+import json
+
+import pytest
+
+from gaia.eval.integrity_gate import main
+from gaia.eval.scorecard import build_scorecard
+
+
+def _result(scenario_id, status, score=9.0):
+    return {
+        "scenario_id": scenario_id,
+        "status": status,
+        "overall_score": score,
+        "category": "tool_selection",
+        "cost_estimate": {"estimated_usd": 0},
+    }
+
+
+@pytest.fixture
+def workspace(tmp_path):
+    """A baseline dir + results dir shaped like the workflow's `eval-out`."""
+    baseline_dir = tmp_path / "baselines"
+    results_dir = tmp_path / "eval-out"
+    baseline_dir.mkdir()
+    (results_dir / "tool_selection").mkdir(parents=True)
+
+    def write(kind, results):
+        card = build_scorecard("run", results, {})
+        if kind == "baseline":
+            path = baseline_dir / "scorecard_tool_selection.json"
+        else:
+            path = results_dir / "tool_selection" / "scorecard.json"
+        path.write_text(json.dumps(card), encoding="utf-8")
+
+    write(
+        "baseline",
+        [_result("known_path_read", "PASS"), _result("multi_step_plan", "PASS")],
+    )
+    return baseline_dir, results_dir, write
+
+
+def _argv(baseline_dir, results_dir, *extra):
+    return [
+        "--baseline-dir",
+        str(baseline_dir),
+        "--results-dir",
+        str(results_dir),
+        "--category",
+        "tool_selection",
+        *extra,
+    ]
+
+
+def test_complete_run_passes_in_both_modes(workspace):
+    baseline_dir, results_dir, write = workspace
+    write(
+        "current",
+        [_result("known_path_read", "PASS"), _result("multi_step_plan", "FAIL", 3.0)],
+    )
+
+    # FAIL is a measurement, not a gap — completeness is indifferent to quality.
+    assert main(_argv(baseline_dir, results_dir)) == 0
+    assert main(_argv(baseline_dir, results_dir, "--enforce")) == 0
+
+
+@pytest.mark.parametrize("status", ["INFRA_ERROR", "SETUP_ERROR", "TIMEOUT"])
+def test_unmeasured_scenario_blocks_only_under_enforce(workspace, status, capsys):
+    baseline_dir, results_dir, write = workspace
+    write(
+        "current",
+        [_result("known_path_read", "PASS"), _result("multi_step_plan", status, 0.0)],
+    )
+
+    assert main(_argv(baseline_dir, results_dir)) == 0
+    reported = capsys.readouterr().out
+    assert "::warning::Integrity:" in reported
+    assert "without a measurement" in reported
+    assert "::error::" not in reported
+
+    assert main(_argv(baseline_dir, results_dir, "--enforce")) == 1
+    enforced = capsys.readouterr().out
+    assert "::error::Integrity:" in enforced
+
+
+def test_missing_baseline_scenario_blocks_only_under_enforce(workspace):
+    baseline_dir, results_dir, write = workspace
+    write("current", [_result("known_path_read", "PASS")])
+
+    assert main(_argv(baseline_dir, results_dir)) == 0
+    assert main(_argv(baseline_dir, results_dir, "--enforce")) == 1
+
+
+def test_missing_scorecard_blocks_only_under_enforce(workspace, capsys):
+    baseline_dir, results_dir, _ = workspace  # never write a current scorecard
+
+    assert main(_argv(baseline_dir, results_dir)) == 0
+    assert "no scorecard produced" in capsys.readouterr().out
+    assert main(_argv(baseline_dir, results_dir, "--enforce")) == 1
+
+
+def test_not_measured_category_is_reported_with_its_cause(workspace, capsys):
+    baseline_dir, results_dir, write = workspace
+    write(
+        "current",
+        [_result("known_path_read", "PASS"), _result("multi_step_plan", "PASS")],
+    )
+
+    argv = _argv(
+        baseline_dir,
+        results_dir,
+        "--not-measured",
+        "rag_quality",
+        "--not-measured-reason",
+        "the RAG embedder will not load on this runner (#3016)",
+    )
+    assert main(argv) == 0
+    out = capsys.readouterr().out
+    assert "rag_quality: NOT MEASURED" in out
+    assert "#3016" in out
+
+    assert main(argv + ["--enforce"]) == 1
+
+
+def test_findings_reach_the_job_summary_in_report_mode(
+    workspace, tmp_path, monkeypatch
+):
+    """Report mode must leave a durable record, not just a console line."""
+    baseline_dir, results_dir, write = workspace
+    write(
+        "current",
+        [
+            _result("known_path_read", "PASS"),
+            _result("multi_step_plan", "INFRA_ERROR", 0.0),
+        ],
+    )
+    summary = tmp_path / "summary.md"
+    monkeypatch.setenv("GITHUB_STEP_SUMMARY", str(summary))
+
+    assert main(_argv(baseline_dir, results_dir)) == 0
+
+    written = summary.read_text(encoding="utf-8")
+    assert "Eval integrity: INCOMPLETE" in written
+    assert "without a measurement" in written
+    assert "the build stays green" in written
+
+
+def test_no_categories_is_a_miswired_workflow(tmp_path):
+    """Checking nothing is a configuration error, never a pass."""
+    assert main(["--baseline-dir", str(tmp_path), "--results-dir", str(tmp_path)]) == 1


### PR DESCRIPTION
Every PR that touched this gate's path filter wore a red X that no PR could fix. The agent eval gate advertised `enforce: false` as non-blocking, then hard-failed anyway — its own summary printed "report mode … build stays green" in the same run it had already exited 1 two steps earlier. Seven PRs with diffs that never went near the eval got flagged. The cause is an environment defect (#3016 — the RAG embedder can't load on the Strix Halo runner), so the gate could only ever be red, and a check that is always red gates nothing.

Now `enforce` decides the exit code for an incomplete run as well as a worse one, and it never decides visibility: report mode still emits every finding as a `::warning::` and writes it to the job summary, so an incomplete run can't be mistaken for a complete one. `enforce: true` restores blocking for both.

The tradeoff is real and deliberate: a genuinely empty run now shows green until someone reads the annotations. Restoring an always-blocking gate is the right end state once #3016 is fixed — PR #3577 is the fix for that, and is complementary to this one.

## Test plan

- [x] `pytest tests/unit/eval/test_integrity_gate.py` — 9 passed
- [x] `pytest tests/test_eval.py` — 146 passed
- [x] `python util/lint.py --black --isort` — clean
- [x] Report mode, 6 of 7 baseline scenarios missing → exits 0, names the 6 in a `::warning::`
- [x] Report mode, all 7 scenarios `INFRA_ERROR` → exits 0, reports `unmeasured=infra_error=7`
- [x] Same broken run with `--enforce` → exits 1, findings raised to `::error::`
- [x] Healthy run with `--enforce` → exits 0, "Integrity OK"
