### PR TITLE
test(lemonade): assert four external contracts the mocks were faking

### DIFF
--- a/audit_reports/_partials/hub-agents.md
+++ b/audit_reports/_partials/hub-agents.md
@@ -1,0 +1,178 @@
+# Audit slice: hub agent packages (`hub/agents/*/`)
+
+**Headline: the hub agents are the best-tested surface in the repo, and the one real
+contract bug I found is a published-doc drift, not a mocked-payload bug.**
+
+The email agent already does the thing the Lemonade `{"spec": "flm:npu"}` bug needed:
+it regenerates its OpenAPI document from the real FastAPI app and fails CI if the
+committed artifact drifts (`test_rest_contract.py:210`), and it asserts an *exact* set
+equality on the documented route list (`test_rest_contract.py:175`). Most "mocks" here
+are hand-written **fakes injected through `app.dependency_overrides`**, with the real
+handler, real pydantic validation, and real HTTP status mapping running underneath —
+that is a genuinely different thing from mocking `_send_request`.
+
+But one shipped spec surface is guarded only against *itself*, and it has already
+drifted: **`POST /v1/email/agent/autonomy/undo` is a real, documented endpoint that the
+shipped `specification.html` does not mention at all.** That is the #1841 pattern
+CLAUDE.md warns about, and a self-referential drift guard is exactly what let it through.
+
+Scope read: `hub/agents/{email,gaia,chat,connectors-demo,hello-world,word-count}/python/tests/`
+(149 files) plus `hub/agents/{email,gaia}/npm/test/` (19 files).
+
+---
+
+## 1. Findings table
+
+### DANGEROUS
+
+| # | file:line | test / artifact | evidence | why it is dangerous | proposed replacement |
+|---|---|---|---|---|---|
+| D1 | `hub/agents/email/python/tests/test_spec_html_artifact.py:26` | `test_committed_spec_html_artifact_is_up_to_date` | `assert spec_html.check_artifact()` — regenerates `specification.html` from `spec_html.py` and byte-compares | The guard only proves **generator == artifact**. It never enumerates the real router. `agent_routes.py:648` registers `@router.post("/autonomy/undo")`; `SPEC.md` documents it (2 hits) and `SKILL.md` documents it (1 hit); `spec_html.py` and `specification.html` mention it **0 times**. The HTML spec served live at `GET /v1/email/spec` omits a real endpoint, and this test is green. | Enumerate the real routers and assert the rendered spec covers every non-`include_in_schema=False` path: `assert {r.path for r in agent_routes.router.routes} <= rendered_paths`. One assertion closes the whole class. |
+| D2 | `hub/agents/email/python/tests/test_outlook_graph_query_shape.py:39` and `:53` | `test_list_messages_search_escapes_inner_quotes`, `..._escapes_backslash` | `assert captured["params"].get("$search") == '"from:\\"Acme Corp\\""'` | The request-building **is** real (`httpx.MockTransport` captures what `LiveOutlookBackend` actually emitted), so a regression *would* be caught — this is not a hollow assertion. The danger is narrower and real: the expected KQL escaping is a **hand-derived literal with no external ground truth**. Nothing has confirmed Microsoft Graph accepts `\"` as an inner-quote escape inside `$search`. If the escaping convention is wrong, the test enshrines it. Exactly #1655: self-consistent, never validated against the server. | `NEEDS-LIVE-CHECK:` one integration test against a real Graph tenant asserting the escaped query returns 200 rather than `400 InvalidRequest`. Gate it like `require_lemonade`. |
+| D3 | `hub/agents/email/npm/test/client.test.ts:350` and `:483` | `archive + unarchive paths and types`, calendar preview→create | `expect(seen).toEqual(["http://x/v1/email/confirm", "http://x/v1/email/archive", "http://x/v1/email/unarchive"])` | The typed npm client's **URL paths are asserted against a hand-written list under a `vi.fn()` fake fetch**. `openapi.email.json` sits in the same repo listing the authoritative paths, and nothing cross-checks the two. A server-side path rename regenerates the OpenAPI artifact (D-guard passes), leaves the TS client pointing at the old path, and this test still passes. The one npm test that spawns the real sidecar (`query-integration.test.ts`) covers **only `/query`** — not confirm/archive/unarchive/calendar. | Import `openapi.email.json` in the vitest suite and assert every path the client emits is a key in `spec.paths`. Cheap, no server needed, and kills the whole drift class. |
+| D4 | `hub/agents/gaia/python/tests/test_stdio.py:1142` | `test_the_parser_accepts_the_spellings_the_go_side_pins` | `stdio.build_parser().parse_args(["--use-claude","--claude-model",...,"--bypass-permissions","--json-events","--dev"])` | A **cross-language argv contract asserted on one side only.** Go pins the same strings as independent literals (`tui/internal/client/factory.go:43` `const BypassPermissionsFlag = "--bypass-permissions"`, `:53` `ClaudeModelFlag`). Neither side reads the other. The test's own docstring (`:1136-1139`) names the failure — "a rename passes every other Python test here and fails at spawn as a generic `exited (code 2)`" — then asserts against a literal the test itself typed. Renaming in `stdio.py` forces an edit here; nothing forces the Go edit. | Emit the flag names from one source (a small generated JSON both sides read), or add a test that greps `factory.go` for each `build_parser()` option string. The latter is ~15 lines and needs no build changes. |
+
+### JUSTIFIED (leave alone — reasons stated)
+
+| file | why justified |
+|---|---|
+| `email/python/tests/test_rest_contract.py` (~69 hits) | Not mocks in the risky sense. Fakes (`_FakeSearchBackend`, `_FakeMailbox`, `_FolderMailbox`, `_FakeSendBackend`) are injected via `app.dependency_overrides` / module seams; the **real** FastAPI app, real pydantic `_Strict` validation, and real status-code mapping all run. Critically the fakes **record outgoing calls and the tests assert their shape** — `assert fake.calls == [{"query": None, "label_ids": ["INBOX"], ...}]` (`:374`) — with a comment naming the divergence it guards (live Gmail with no `labelIds` returns ALL mail). This is the boundary-validity discipline the Lemonade bug lacked. |
+| `email/.../test_gmail_batch_429_retry_2716.py`, `test_gmail_metadata_batch_2643.py`, `test_outlook_metadata_2643.py` | `httpx.MockTransport` at the socket layer; the real request builders produce the captured URL/params/body. Live Gmail/Graph 429 and batch-multipart scenarios are impractical to trigger on demand. |
+| `email/.../test_doc_consistency.py` | No mocks. Reads `SCORECARD.md` front-matter and greps `README.md`/`EVALUATION.md` prose for score claims — a real cross-doc drift guard, and the model D1 should follow. Deliberately excludes `CHANGELOG.md` with a stated reason (historical record). |
+| `gaia/.../test_caller_auth.py`, `email/.../test_caller_auth.py` | Real `build_app()` over `TestClient`; bearer gate, Host allowlist (DNS rebinding), and Origin rejection genuinely exercised. Not a mocked gate. |
+| `gaia|email/.../test_publish_to_r2_by_reference.py` | Mocks boto3/HTTP transport only. Digest encoding, `Key` construction, and `request_checksum_calculation` config are produced by real code and asserted on the received payload. |
+| `gaia/.../test_gen_binaries_lock.py` | Validates the generator against the **real committed** `binaries.lock.json` read from disk, not a literal. |
+| `connectors-demo/.../test_connectors_demo.py` | The strongest pattern in the slice: `_CapturingGet` records real outgoing headers/params and asserts `Authorization: Bearer`, `maxResults`, `per_page`, RFC3339 stamps. A dropped bearer token would fail. |
+| `hello-world`, `word-count` | Teaching templates. Tool logic tested for real; only the LLM client is stubbed. Appropriate. |
+| `chat/.../test_chat_agent.py`, `test_*dependency_floor.py` | No mocks — real imports, manifest/pyproject read from disk and cross-validated. |
+
+### MASKING / UNNECESSARY
+
+**None I can ground.** I went looking and the email agent has explicit cold-state coverage:
+`test_zero_connector_construction_2418.py` (agent must construct with **no** mailbox
+connected and no injected fake), `test_google_access_not_configured.py` (fresh BYO Google
+Cloud project, Gmail API not enabled → actionable 403), `test_mailbox_onboarding_2469.py`,
+`test_connection_status_2401.py`. Route-level resolvers are tested from empty:
+`test_get_search_backend_no_mailbox_fails_loud_503` (`test_rest_contract.py:466`),
+`test_prescan_no_mailbox_connected_fails_loud` (`:1179`). On the gaia side the Lemonade-down
+path is tested (`test_stdio.py:740`, `:794`), not just the healthy stub.
+
+Reporting zero here rather than padding the count. The sibling audit slices cover the
+in-core code where I'd expect the cold-state gaps to actually live.
+
+---
+
+## 2. Contract-vs-doc drift check
+
+| agent | shipped spec artifacts | machine-checked? | verdict |
+|---|---|---|---|
+| **email** | `openapi.email.json`, `specification.html`, `CONTRACT.md`, npm `SPEC.md` / `SKILL.md` / `README.md` / `SCORECARD.md` | Partly | See below |
+| **gaia** | npm `SPEC.md`, `SKILL.md`, `binaries.lock.json` | lock only | `SPEC.md` (523 lines) has **no** drift guard. Same class as D1, not yet demonstrated to have drifted. |
+| chat / connectors-demo / hello-world / word-count | `README.md` only | n/a | No published request/response contract to drift. |
+
+**Email — what is guarded:** `API_VERSION == SCHEMA_VERSION` (`:111`); `AGENT_VERSION` vs
+installed dist metadata (`:122`); every contract pydantic model's property + required set
+vs the exported spec (`:161`); the committed `openapi.email.json` byte-identical to a fresh
+export (`:210`); `specification.html` byte-identical to its generator (`test_spec_html_artifact.py:26`);
+eval score consistent across `SCORECARD.md`/`README.md`/`EVALUATION.md`.
+
+**Email — the hole (D1), confirmed drift:** the stateful `/v1/email/agent/*` surface is
+mounted by `agent_routes.py` but deliberately excluded from `export_openapi.build_app()`
+(`export_openapi.py:56-71` mounts only `api_routes` + `connection_intake_routes`), and
+`test_documented_routes_match_expected_set` asserts **exact** set equality, so the OpenAPI
+artifact provably contains zero `/agent/*` paths. That leaves `SPEC.md` and
+`specification.html` as the only integrator-facing description of 12 endpoints — and they
+disagree:
+
+```
+SPEC.md agent endpoints (12):  session, session/{id}, session/{id}/history, memory,
+                               memory/{id}, autonomy, autonomy/{id}, autonomy/run,
+                               autonomy/undo, confirm-tool, cancel, query
+specification.html (11):       ...same, MINUS autonomy/undo
+real router (12):              agent_routes.py:648 -> @router.post("/autonomy/undo")
+```
+
+Mitigating fact worth stating plainly: the `/agent/*` **behaviour** is well tested.
+`test_email_agent_routes.py` drives the real routes through `TestClient` with a fake agent
+that exercises the real `SSEOutputHandler`, and it asserts the exact status codes `SPEC.md`
+claims — overlapping turn 409 (`:266`), bad autonomy level 400 (`:472`), autonomy-off 409
+(`:495`), uninitialised memory 409 (`:415`). I checked those four claims and **`SPEC.md` is
+currently accurate on all of them.** The drift is in the *endpoint list*, not the semantics.
+So: one real bug, not a rotten surface.
+
+---
+
+## 3. Coverage gaps — does anything start the real agent?
+
+| agent | real end-to-end test? | where |
+|---|---|---|
+| **email** | **Yes, several.** | `tests/integration/test_email_rest_api_e2e.py`, `test_email_thin_client.py`, `test_email_rest_http_corpus.py`, `test_email_agent_live_gmail.py`, `test_email_agent_triage.py`, `test_email_corpus_alignment.py`, `test_email_bench_throughput.py`. Plus `hub/agents/email/npm/test/query-integration.test.ts`, which **spawns the real Python sidecar** and drives the typed client over real HTTP (version handshake, bearer gate, canonical event sequence, mid-run cancel). It correctly randomises to port 8200–8700 with an explicit `// never 4001`. |
+| **gaia** | Partial. | `tests/integration/test_daemon_sidecars.py` covers sidecar supervision. No test spawns `gaia_agent.stdio` as a real child process and drives a turn over the pipe — the transport is tested in-process via `io.StringIO` only. That is why D4 (the Go argv contract) has no backstop. |
+| **chat** | Yes. | `tests/integration/test_chat_hub_wheel_journey.py`, `test_chat_rag_pdf_e2e.py`, `test_chat_rag_pdf_chat_e2e.py`, `test_chat_ui_integration.py`. |
+| connectors-demo / hello-world / word-count | No, and fine. | Teaching templates. |
+
+**The one gap that matters:** no test spawns the real `gaia` stdio agent as a subprocess with
+the argv the Go TUI actually passes. `query-integration.test.ts` proves the pattern is
+affordable — the email agent already does exactly this.
+
+---
+
+## 4. Remediation, cheapest first
+
+1. **D1 — one assertion, fixes a live bug.** In `test_spec_html_artifact.py`, enumerate
+   `agent_routes.router.routes` + `api_routes.router.routes` and assert the rendered HTML
+   covers every schema-visible path. Then add the missing `/autonomy/undo` section to
+   `spec_html.py` and regenerate. *This is a real shipped-doc defect, not a test smell.*
+2. **D3 — one shared fixture converts the whole npm suite.** Load `openapi.email.json` once
+   in vitest setup; assert every URL the client emits is a key in `spec.paths`. No server,
+   no new dependency.
+3. **D4 — ~15 lines.** A test that greps `tui/internal/client/factory.go` for every option
+   string `stdio.build_parser()` defines. Add a subprocess smoke test that spawns the real
+   stdio agent with the Go argv and asserts one JSON event comes back.
+4. **D2 — needs live access.** Gate a Graph integration test the way `require_lemonade`
+   gates Lemonade. Lowest priority: the request-building is genuinely exercised, so this
+   only closes the "is our escaping convention actually right" question.
+5. **Shared-fixture leverage:** items 1 and 2 are both "assert the doc against the code that
+   generates it" — the pattern `test_doc_consistency.py` already established. Extending that
+   one file's approach to the spec artifacts converts D1 and D3 together.
+
+**`NEEDS-LIVE-CHECK:` commands (not run — no servers started):**
+
+```bash
+# D1 — confirm the shipped HTML spec omits the endpoint (static, safe to run)
+grep -c "autonomy/undo" hub/agents/email/python/specification.html   # observed: 0
+grep -n "autonomy/undo" hub/agents/email/python/gaia_agent_email/agent_routes.py  # observed: 648
+
+# D2 — requires a real Microsoft Graph tenant + token
+#   assert LiveOutlookBackend.list_messages(query='from:"Acme Corp"') returns 200, not 400
+# D4 — spawn the real stdio agent with the Go argv
+python -m gaia_agent.stdio --json-events --bypass-permissions   # then write one query line to stdin
+```
+
+---
+
+## Summary
+
+**Counts:** DANGEROUS 4 · MASKING 0 · UNNECESSARY 0 · JUSTIFIED 9 file-groups
+(~500+ of the ~714 mock hits in this slice).
+
+The hub agents largely already practise what CLAUDE.md preaches — fakes injected behind
+real handlers, outgoing call shapes asserted, OpenAPI regenerated and byte-compared, cold
+states (no mailbox, no connector, API not enabled, Lemonade down) explicitly tested. I did
+not find a second `{"spec": "flm:npu"}`-style locked-in wrong payload, and I am not going to
+invent MASKING findings to balance the table.
+
+**Top 3 DANGEROUS:**
+
+1. **D1 — `specification.html` ships without `/v1/email/agent/autonomy/undo`.** A real,
+   documented, implemented endpoint is missing from the HTML spec served to integrators at
+   `GET /v1/email/spec`. `test_spec_html_artifact.py:26` is green because it only compares
+   the generator to its own output — it never asks the router what exists. **This is a live
+   defect, not a hypothetical.**
+2. **D3 — the npm client's REST URLs are asserted against a hand-written list under a fake
+   fetch** (`client.test.ts:350`, `:483`), while `openapi.email.json` sits unread in the same
+   repo. A path rename passes both sides' tests and breaks integrators. Only `/query` has a
+   real-sidecar test.
+3. **D4 — the Go↔Python argv contract is pinned twice, checked never.**
+   `factory.go:43` and `test_stdio.py:1142` each assert their own literal; a one-sided rename
+   surfaces as `exited (code 2)` at spawn. The test's docstring predicts this exact failure.

--- a/audit_reports/_partials/lemonade-http.md
+++ b/audit_reports/_partials/lemonade-http.md
@@ -1,0 +1,192 @@
+# Audit slice: the Lemonade HTTP client boundary
+
+**Scope:** `src/gaia/llm/lemonade_client.py` (18 endpoints) and every test that mocks it.
+**Method:** read-only. No server started, no test run, no file changed outside this report.
+
+## The headline
+
+Ten of the eighteen Lemonade endpoints the client calls have **no test anywhere that
+would fail if the request shape changed** — including `/install`, `/uninstall`,
+`/delete`, `/unload`, `/system-info` and the SSE `/pull` stream. `/install` is the one
+that already bit us; the other nine are the same trap, not yet sprung.
+
+Two structural patterns cause it, and both are worth fixing above any individual test:
+
+1. **Payload shape is asserted against a stub.** `test_npu_device_support.py` pins
+   `{"spec": "flm:npu"}` — a body real Lemonade 400s. Ten more assertions across
+   `test_llamacpp_backend.py` and `test_lemonade_client.py` pin `/load`, `/pull` and
+   `/unload` bodies the same way. They are correct today only because someone
+   hand-checked them once.
+2. **The `/health` response shape is invented in ~25 tests and verified in none.** Every
+   ctx-pinning test builds `LemonadeStatus(loaded_models=[{"id":…, "recipe_options":
+   {"ctx_size":…}}])` by hand. That field *already moved once* (Lemonade 9.1.4 relocated
+   it from top-level `context_size`), and the one live test that looks at it wraps every
+   assertion in an `if`, so it prints a warning and passes when the field vanishes.
+
+The fix for both is one shared fixture, not 35 test edits — see §3.
+
+---
+
+## 1. Findings table
+
+Bucket key: **DANGEROUS** = mocks a contract boundary *and* asserts an outgoing
+payload/argv shape. **MASKING** = hides the cold/empty starting state. **UNNECESSARY** =
+doubles pure local logic. **JUSTIFIED** = leave it alone.
+
+### DANGEROUS
+
+| file:line | test | risk | evidence | proposed replacement |
+|---|---|---|---|---|
+| `tests/unit/test_npu_device_support.py:181` | `TestLemonadeClientBackendMethods::test_install_backend` | **Critical — this is the shipped bug.** | `client._send_request.assert_called_once_with("post", ".../install", {"spec": "flm:npu"}, timeout=300)` — real Lemonade replies `400 {"error":"Both 'recipe' and 'backend' are required"}`. Broke `gaia init --profile npu` while NPU CI stayed green. | Delete the payload pin; replace with `tests/integration/test_lemonade_backend_contract.py` (already written on `fix/npu-flm-backend-install`). Keep a unit test only for `_split_backend_spec` (pure function, no doubles needed). |
+| `tests/unit/test_npu_device_support.py:198` | `test_install_backend_with_force` | Critical (same contract) | `assert call_args[0][2] == {"spec": "llamacpp:rocm", "force": True}` — pins the wrong body *and* asserts `force` sits alongside it. `NEEDS-LIVE-CHECK:` does the server accept `force` as a sibling of `recipe`/`backend`? `curl -sS -X POST localhost:13305/api/v1/install -H 'Content-Type: application/json' -d '{"recipe":"llamacpp","backend":"rocm","force":true}'` | Same as above — assert `force` survives the split in the contract test. |
+| `tests/unit/test_npu_device_support.py:221` | `test_uninstall_backend` | Critical | `assert_called_once_with("post", ".../uninstall", {"spec": "flm:npu"}, timeout=120)`. `/uninstall` takes the same split fields; nothing has ever exercised it live. | Contract test. Uninstall is destructive, so drive it as *assert-the-400-on-combined-spec* (as the fix branch does) rather than actually uninstalling. |
+| `tests/unit/test_npu_device_support.py:174` | (all four above) | Amplifier | `client = LemonadeClient.__new__(LemonadeClient)` then hand-sets `base_url`/`log`. Bypassing `__init__` means the tests are also blind to how `base_url` is really composed — a `/api/v1` prefix change passes. | Construct the client normally (`LemonadeClient(host=…, port=…)`); it makes no network calls at construction. |
+| `tests/unit/test_llamacpp_backend.py:127` | `TestLoadModelRequestConstruction::test_full_payload_with_all_params` | High | `assert payload == {"model_name":…, "llamacpp_args":…, "ctx_size":2048, "save_options":True}` — an exact-equality pin on the `/load` body, asserted against `@patch.object(LemonadeClient, "_send_request")`. Identical failure mode to `install_backend`; only luck says these four field names are right. | Keep as a *plumbing* test but drop the `==` to a subset check, and add one live `/load` round-trip with all four fields (see §3 gap table row `/load`). |
+| `tests/unit/test_llamacpp_backend.py:69, 80, 91, 108` | `test_llamacpp_args_included_in_payload`, `test_ctx_size_included_in_payload`, `test_ctx_size_zero_is_included`, `test_save_options_included_when_true` | High | Each does `payload = mock_send.call_args[0][2]` then pins a field name. `ctx_size=0` in particular is asserted to be *sent* — nothing proves the server accepts 0 rather than 400-ing on it. `NEEDS-LIVE-CHECK:` `curl -sS -X POST localhost:13305/api/v1/load -H 'Content-Type: application/json' -d '{"model_name":"Qwen3-0.6B-GGUF","ctx_size":0}'` | Fold into the one live `/load` test; these five unit tests collapse to a single parametrized live case. |
+| `tests/unit/test_llamacpp_backend.py:52-56` | `test_basic_load_sends_model_name_only` | Medium | Asserts *absence*: `assert "ctx_size" not in payload`. Negative shape pins are the same class of claim — they encode a belief about what the server tolerates. | Same live test; assert the minimal body is accepted. |
+| `tests/test_lemonade_client.py:1032-1037` | `test_pull_embedding_model_request_shape` | Medium-high | Asserts the `/pull` body carries `user.` prefix + `checkpoint` + `recipe=llamacpp` + `embedding=True`, read off a `responses`-stubbed endpoint. The docstring explicitly claims it proves validity ("mocks prove validity, not just invocation") — **it does not**; `responses` accepts any body. Lower likelihood than `/install` because the shape came out of a real #1745 incident, but the enforcement is fictional. | Promote to `require_lemonade`. Registering a `user.`-namespaced model is idempotent on a live server, so the round-trip is safe to run for real. |
+| `tests/test_lemonade_client.py:873-876, 885` | `test_unload_model_scoped_vs_global` | Medium-high | `assert json.loads(responses.calls[-1].request.body) == {"model_name": embed_model}` and `assertIsNone(...request.body)` for the global form. The *no-body-means-unload-everything* claim is a pure server-side behaviour assertion made entirely against a stub. | `require_lemonade` integration test: load two models, scoped-unload one, assert via `/health` that the other is still resident. That is the actual #1544 guarantee. |
+| `tests/unit/installer/test_init_ctx_size.py:104-128, 161, 202-212, 248-253` | `test_linux_legacy_auto_start_includes_ctx_size` and siblings | Medium — **circular** | The test sets `mock_build_cmd.return_value = StartSpec(argv=[…,"--ctx-size","32768"])`, then asserts `"--ctx-size" in argv`. It is asserting the stub's own return value survived the trip to `Popen`. It proves argv plumbing and env-merge (genuinely useful — `GAIA_TEST_SENTINEL`/`PATH` retention is a real bug class), but proves nothing about whether the installed `lemonade-server` accepts `--ctx-size`. | Keep the plumbing/env-merge assertions. Move flag *validity* into a test that calls the real `build_start_command` against a resolved tooling record, plus one CLI smoke test that actually launches and reads back ctx from `/health`. The parametrized profile test at :290-306 is better (its `side_effect` echoes `ctx_size`) — model the others on it. |
+| `tests/unit/test_llamacpp_backend.py:363-365, 386` | `TestLaunchServerCtxSize` | Medium | Same circularity for the legacy path: `cmd = mock_popen.call_args[0][0]; assert "--ctx-size" in cmd`. Honest docstring admits it is pinned to legacy tooling that modern Lemonade no longer uses. | Consider deleting — it pins a path the docstring says is superseded. If kept, mark it explicitly as a legacy-compat regression guard. |
+
+### MASKING
+
+| file:line | test | risk | evidence | proposed replacement |
+|---|---|---|---|---|
+| `tests/test_lemonade_client.py:2559` | `test_integration_pull_model` | **Critical — this is the only live `/pull` test and it cannot fail.** | Runs against a real server, then: `except LemonadeClientError as e: … print(f"❌ Unexpected error during model pull: {error_str}")` with the comment `# Don't fail the test - pull might fail for various reasons in test environment`. No `self.fail`. It also pulls `TEST_MODEL`, which CI has already downloaded — the warm cache from #1655, exactly. | Make it fail. Split into (a) already-present pull → assert `status in {success, ok}` and *raise* otherwise; (b) a cold registration of a tiny `user.`-namespaced model to exercise the checkpoint+recipe branch. |
+| `tests/test_lemonade_client.py:2183-2295` | `test_integration_health_check_914_format` | **Critical — conditional assertions.** | Every meaningful check is inside `if "all_models_loaded" in health:` / `if "ctx_size" in recipe_options:`, with `print("⚠️ …")` on the else. If Lemonade moves `ctx_size` again the test prints a warning and **passes** — while ~25 mocked tests that hand-build that shape also pass. The whole ctx-pinning feature would silently break. | Assert unconditionally: `all_models_loaded` present, first entry has `recipe_options.ctx_size` as a positive int. If the legacy fallback still needs support, make it two tests gated on the server version, not one test gated on the response. |
+| `tests/test_lemonade_client.py:2516` | `test_integration_load_model` | High | Loads `TEST_MODEL` with the minimal body only. The fields the ctx feature depends on (`ctx_size`, `llamacpp_args`, `save_options`) are never sent to a real server by any test. | Extend to send all four and read the resulting ctx back from `/health`. One test closes both this row and five `test_llamacpp_backend.py` rows. |
+| `tests/unit/test_chat_preflight.py:31-52` and all 8 tests | `_health_ok()` / `_model()` helpers | High | The preflight's entire input is a hand-authored `{"all_models_loaded": [{"type":…, "model_name":…, "recipe_options": {"ctx_size":…}}]}`. `httpx.get` is patched. A field rename passes every test here *and* in `test_llamacpp_backend.py` *and* in `test_lemonade_client_ctx_override.py` simultaneously. | Don't rewrite these — they're testing decision logic and mocking is right. Instead add **one** live schema test (§3) that asserts real `/health` matches the shape these helpers assume. That converts 8 fictional tests into 8 grounded ones. |
+| `tests/unit/test_llamacpp_backend.py:171-314` (9 tests) | `TestEnsureModelLoadedCtxResolution` | High (same root cause) | `LemonadeStatus(loaded_models=[{"id":…, "recipe_options": {"ctx_size": 4096}}])` invented in every case. | Same shared live schema test. |
+| `tests/unit/test_lemonade_client_ctx_override.py:64-88` + all 15 tests | `_status()/_present()/_absent()` | High (same root cause) | Same invented shape, plus an invented *async settling* model (`/load` no-ops with success while leaving stale ctx). That behavioural claim is the entire justification for the unload→poll→load→poll sequence and is asserted only against `side_effect` lists. | Same shared live schema test for the shape. For the settling behaviour: `NEEDS-LIVE-CHECK:` load at 65536, then `POST /load` again with `ctx_size=16384` and read `/health` — `curl -sS -X POST localhost:13305/api/v1/load -d '{"model_name":"Gemma-4-E4B-it-GGUF","ctx_size":16384}' -H 'Content-Type: application/json' && curl -sS localhost:13305/api/v1/health \| python -m json.tool`. If the ctx *does* change, the whole settle machinery is over-engineering. |
+| `tests/unit/test_init_command.py:765-855, 2000-2045` | `_download_models` / `_install_backend` step tests | Medium | `mock_client.ensure_model_downloaded.return_value = True` — asserts *which model names* are requested (a genuinely useful decision test, and `mock_client.pull_model.assert_not_called()` is a real #1655 guard), but never touches a download. `_patch_common_steps` stubs `_install_backend` entirely, so `gaia init --profile npu` has no end-to-end coverage at all. | Keep the decision tests. Add one CLI-level test: `gaia init --profile npu --force-models` on an NPU runner, asserting the backend reaches `state == "installed"` in `/system-info`. |
+| `tests/unit/test_init_command.py:1265-1295` | `test_skip_install_when_probe_succeeds`, `…env_var_set…` | Medium | `mock_client._send_request.return_value = {"status": "ok"}` — the whole client is a `MagicMock`, so a probe pointed at a wrong URL or method still "succeeds". Tests the branch, not the probe. | Narrow the patch to `requests.get` (or use `responses`) so the probe's real URL/method is exercised. |
+| `tests/unit/test_lemonade_manager_preload.py:55-160` | `test_idle_server_triggers_preload_with_ctx_size` etc. | Medium | Fully stubbed `LemonadeClient`; `auto_download=True` is asserted as a kwarg. The docstring says the point is "first-run users (no model on disk) get a download instead of a silent failure" — but no test starts from no-model-on-disk. | Keep the kwarg assertion. Cover the actual first-run claim in the `gaia init` cold-start CLI test above. |
+| `tests/unit/test_lemonade_error_classification.py` (whole file) | `_classify_lemonade_response` cases | Medium | Every error envelope (`{"error": {"type": "exceed_context_size", "n_ctx": 4096}}`, `details.response.error` nesting) is hand-authored. Nothing captures a real Lemonade error body. If the server renames `n_ctx`, retry classification silently degrades to "not retryable" and long-context chats stop self-healing. | Add one live test that *provokes* an overflow (send a prompt past the loaded ctx) and asserts the raw envelope contains `type` and `n_ctx`. Then the mocked matrix is grounded. |
+| `tests/test_lemonade_client.py:2083-2170` | `TestLemonadeClientIntegration.setUpClass` | Low-medium (hygiene) | Does not use `require_lemonade`. If no server is up it constructs the client with `auto_start=True`, i.e. a "unit" file can spawn a real Lemonade on a developer's box. | Gate the class on `require_lemonade` (or an equivalent `setUpClass` skip) instead of auto-starting. |
+| `tests/test_lemonade_embeddings.py`, `tests/test_lemonade_health.py` | whole files | Low (hygiene) | Live tests with no `pytest.mark.integration` and no `require_lemonade`; they hard-fail rather than skip off a server. They *are* the only real `/embeddings` coverage, so they're valuable — just ungated. | Add `pytestmark = pytest.mark.integration` and the `require_lemonade` fixture. |
+
+### UNNECESSARY
+
+| file:line | test | evidence | replacement |
+|---|---|---|---|
+| `tests/unit/test_npu_device_support.py:228-257` | `test_get_recipe_status_found/_not_found` | `client.get_system_info = MagicMock(return_value={"recipes": {"flm": {"backends": {"npu": {"state":"installed"}}}}})`. The method under test is a two-line dict lookup; the mock is doing all the work, and the `recipes` shape it asserts is unverified (see gap table `/system-info`). | Keep the dict-lookup unit test, but source the fixture payload from a recorded live `/system-info` response rather than inventing it. |
+| `tests/unit/test_lemonade_client_ctx_override.py:162, 209, 241` etc. | `mock_load.assert_called_once_with(model, auto_download=True, prompt=False, ctx_size=…)` | These pin an *internal* Python seam, not a wire contract, so they're not DANGEROUS. But `patch.object(LemonadeClient, "load_model")` without `autospec=True` means the mock accepts any signature. | Add `autospec=True` to these patches. Cheap, mechanical, catches signature drift. |
+
+### JUSTIFIED
+
+| file:line | test | why it's fine |
+|---|---|---|
+| `tests/unit/test_llamacpp_backend.py:398-472` | `TestParamSeparation` | Mocks the OpenAI SDK client to assert `repeat_penalty` lands in `extra_body` and `frequency_penalty` stays top-level. This is a *client-side routing* decision; the SDK's typed surface is the contract and it's stable. `NEEDS-LIVE-CHECK:` only whether Lemonade honours `extra_body.repeat_penalty` at all — `curl -sS -X POST localhost:13305/api/v1/chat/completions -H 'Content-Type: application/json' -d '{"model":"Gemma-4-E4B-it-GGUF","messages":[{"role":"user","content":"hi"}],"repeat_penalty":1.2}'`. |
+| `tests/unit/test_lemonade_model_loading.py:361-397` | `TestPromptUserForDeleteNonInteractive` | Patches `sys.stdin.isatty` / `builtins.input`. Interactive TTY state is exactly what you must fake. |
+| `tests/unit/test_lemonade_model_loading.py:403-565`, `tests/unit/test_lemonade_error_classification.py:473-570` | corrupt-download repair routing | Mocks `_send_request` to *raise*, and mocks `pull_model_stream`. These assert control flow (exactly one delete, exactly two pulls, no prompts, actionable message) — no outgoing payload is pinned, and provoking a genuinely corrupt model download is destructive and slow. Correct use of doubles. |
+| `tests/test_lemonade_client.py:707-853` | transient-retry tests | Mock `time.sleep` and force a transient error. Retry/backoff timing is exactly what should be faked. |
+| `tests/test_lemonade_client.py:1605-1760` | auth-header tests | Use `responses` and assert on the *outgoing header* the client controls. `Bearer <key>` is a fixed HTTP standard, not a Lemonade-specific contract. Also: `test_401_response_does_not_leak_authorization_header_in_error_message` is a genuinely good security regression guard. |
+| `tests/unit/test_llamacpp_backend.py:478-717` | `_classify_lemonade_response` + `TestModelsRegistry` | The registry tests use zero doubles and assert real invariants (`min_ctx_size > 0`, embedding models can't claim tool_calling). Model for the rest of the file. |
+| `tests/unit/test_npu_device_support.py:14-105, 263-281, 392-429` | `DeviceConfig`, `INIT_PROFILES`, `profile_ctx_size` | No doubles, real constants, real functions. Nothing to fix. |
+
+---
+
+## 2. Coverage gaps — every endpoint the client calls
+
+"Real test?" = would a test **fail** if the outgoing request shape changed, without any
+double in the path. `responses`-stubbed and `_send_request`-patched tests answer **no**.
+
+| endpoint | client method(s) | real test? | risk if shape drifts |
+|---|---|---|---|
+| `POST /install` | `install_backend` | **NO** (mocked at `test_npu_device_support.py:181`) | **Already realised.** `gaia init --profile npu` fails at setup; NPU CI green throughout. Fix branch adds `tests/integration/test_lemonade_backend_contract.py`. |
+| `POST /uninstall` | `uninstall_backend` | **NO** | Backend removal silently 400s. Reachable via `gaia lemonade backends` CLI. |
+| `GET /system-info[?verbose=]` | `get_system_info`, `get_recipe_status` | **NO** — mocked only | High. `init._install_backend` reads `recipes[r].backends[b].state == "installed"` to skip install. If `recipes` moves, init either re-installs every run or skips a missing backend and fails later at load. Also drives the NPU device-availability gate. |
+| `POST /delete` | `delete_model` | **NO** — `test_delete_model` uses `responses` | Medium-high. `delete_model` is called *inside the corrupt-model auto-repair path*: a rejected delete turns a recoverable corrupt download into a hard failure. |
+| `POST /unload` | `unload_model` (scoped + global) | **NO** — `responses` only | High. The whole #1544 guarantee (scoped unload doesn't evict the co-resident chat model) is asserted against a stub. Also load-bearing in the ctx re-pin sequence. |
+| `POST /pull` (SSE) | `pull_model_stream` | **NO** — hand-written SSE bodies | High. This is the first-run download path. Event names (`progress`/`complete`/`error`) and field names (`percent`, `bytes_downloaded`) are invented; a rename gives a silent no-progress hang, which users read as a freeze. |
+| `POST /pull` (JSON) | `pull_model`, `ensure_model_downloaded` | **effectively NO** — `test_integration_pull_model` swallows every error | Realised once as #1655. `checkpoint`/`recipe`/`embedding`/`mmproj`/`reasoning` field names have zero live enforcement. |
+| `POST /load` | `load_model`, `_ensure_model_loaded` | **PARTIAL** — `test_integration_load_model` sends `{model_name}` only | High for the optional fields. `ctx_size` / `llamacpp_args` / `save_options` are never sent live, and the entire ctx-pinning feature rides on them. |
+| `POST /params` | `set_params` | **NO** — the integration test is `@pytest.mark.skip("still in development")` | Low. No production caller found. |
+| `GET /models/{id}` | `get_model_details` | **NO test at all**, mocked or live | Low-medium. Dead-ish code today; if a caller appears it is untested. |
+| `GET /models?show_all=true` | `list_models(show_all=True)` | **NO** — live test calls the bare form | Medium. The `downloaded` boolean drives `ensure_model_downloaded`'s "is it already there" check; a query-param rename means every run re-pulls. |
+| `POST /embeddings` | `embeddings` | **YES** — `tests/test_lemonade_embeddings.py`, run live by `test_embeddings.yml` | Low. Best-covered endpoint in the file. Should be marked `integration`. |
+| `POST /chat/completions` | `chat_completions` (non-stream + OpenAI stream) | **YES** for the base body — `test_integration_chat_completion`, `…_streaming`, `…hybrid_npu_validation` | Medium residual: `tools=` payload and `extra_body` llama.cpp params have no live coverage, and tool-calling is core to every agent. |
+| `POST /completions` | `completions` | **NO** live test (`test_completions` uses `responses`) | Low. Legacy endpoint; agents use `/chat/completions`. |
+| `POST /responses` | `responses` | **YES** — `test_integration_responses_endpoint` | Low. |
+| `GET /health` | `health_check`, `get_status`, `ready`, `validate_context_size` | **request YES, response NO** | **High** — `test_integration_health_check_914_format` asserts the response shape only inside `if` blocks, so a `recipe_options.ctx_size` move passes silently while invalidating ~25 mocked tests. |
+| `GET /stats` | `get_stats` | **YES** (weak) — `test_integration_get_stats` | Low. |
+| `POST /images/generations` | `generate_image`, `list_sd_models` | **PARTIAL** — `tests/integration/test_sd_integration.py` runs live but skips when the server is absent | Low-medium. |
+
+---
+
+## 3. Remediation — one fixture converts most of this
+
+Everything above collapses into **four** pieces of work. Ordered by value.
+
+**A. `/install` + `/uninstall` contract test — integration, `require_lemonade`.**
+Already written on `fix/npu-flm-backend-install`. Land it, delete the three payload pins
+in `test_npu_device_support.py`, keep a pure unit test for `_split_backend_spec`. This is
+the fix for the shipped bug.
+
+**B. One live `/health` schema test — the single highest-leverage change.**
+`tests/integration/test_lemonade_health_schema.py`, gated on `require_lemonade`, with
+**unconditional** assertions:
+
+- `all_models_loaded` is present and a list
+- when non-empty, entry 0 has `model_name`, `recipe`, `device`, and
+  `recipe_options.ctx_size` as a positive int
+
+That one test grounds roughly **32 mocked tests** that currently invent this shape:
+8 in `test_chat_preflight.py`, 9 in `test_llamacpp_backend.py::TestEnsureModelLoadedCtxResolution`,
+15 in `test_lemonade_client_ctx_override.py`. None of those need rewriting — they stay
+mocked, which is right for decision logic. They just stop being fiction. Pair it with
+fixing `test_integration_health_check_914_format` to assert instead of print-and-pass.
+
+**C. Make the live `/pull` and `/load` tests capable of failing.**
+- `test_integration_pull_model`: remove the `# Don't fail the test` swallow; `self.fail`
+  on an unexpected error. Add a cold-registration case for a small `user.`-namespaced
+  model so the `checkpoint`+`recipe`+`embedding` branch is exercised for real — that is
+  the #1655 shape and the `test_pull_embedding_model_request_shape` claim.
+- `test_integration_load_model`: send `ctx_size` + `llamacpp_args` + `save_options`, then
+  read the ctx back from `/health`. Closes five DANGEROUS rows in
+  `test_llamacpp_backend.py` at once, and empirically settles whether the ctx-override
+  settle machinery is needed.
+
+**D. Cheap mechanical passes.**
+- Add `require_lemonade` / `pytest.mark.integration` to `test_lemonade_embeddings.py`,
+  `test_lemonade_health.py`, and `TestLemonadeClientIntegration` (which currently
+  auto-starts a real server on a dev box).
+- Add `autospec=True` to `patch.object(LemonadeClient, "load_model" | "get_status")`
+  across `test_lemonade_client_ctx_override.py` and `test_lemonade_model_loading.py`.
+- Construct `LemonadeClient` normally in `test_npu_device_support.py` instead of
+  `__new__` + hand-set attributes.
+
+**Not worth doing:** rewriting the error-classification matrix or the corrupt-repair
+routing tests. They assert control flow, not wire shape, and mocking is the right tool
+there. The one addition worth making is a single live overflow-provocation test so the
+`n_ctx` field name in that matrix is grounded.
+
+---
+
+## Live checks I did not run
+
+Marked `NEEDS-LIVE-CHECK:` inline. Consolidated:
+
+```bash
+# 1. Does /install accept `force` alongside the split recipe/backend?
+curl -sS -X POST localhost:13305/api/v1/install -H 'Content-Type: application/json' \
+  -d '{"recipe":"llamacpp","backend":"rocm","force":true}'
+
+# 2. Is ctx_size=0 accepted on /load, or a 400?
+curl -sS -X POST localhost:13305/api/v1/load -H 'Content-Type: application/json' \
+  -d '{"model_name":"Qwen3-0.6B-GGUF","ctx_size":0}'
+
+# 3. Does a plain /load re-pin the ctx of an already-loaded model?
+#    If yes, the unload->poll->load->poll settle machinery is over-engineering.
+curl -sS -X POST localhost:13305/api/v1/load -H 'Content-Type: application/json' \
+  -d '{"model_name":"Gemma-4-E4B-it-GGUF","ctx_size":16384}'
+curl -sS localhost:13305/api/v1/health | python -m json.tool
+
+# 4. Does Lemonade honour llama.cpp-native repeat_penalty via extra_body?
+curl -sS -X POST localhost:13305/api/v1/chat/completions -H 'Content-Type: application/json' \
+  -d '{"model":"Gemma-4-E4B-it-GGUF","messages":[{"role":"user","content":"hi"}],"repeat_penalty":1.2}'
+
+# 5. Real /system-info `recipes` shape — the init skip-if-installed logic depends on it.
+curl -sS localhost:13305/api/v1/system-info | python -m json.tool
+```

--- a/audit_reports/_partials/subprocess-ipc.md
+++ b/audit_reports/_partials/subprocess-ipc.md
@@ -1,0 +1,160 @@
+# Audit slice: subprocess argv, process launch, daemon/sidecar IPC
+
+**Headline:** two outgoing contracts are asserted by tests against values the real target
+does not use — `LEMONADE_CTX_SIZE` (which the installed Lemonade 11.5.0 binary never
+reads) and MCP `protocolVersion: "1.0.0"` (not a valid MCP protocol version). Both are the
+`{"spec": "flm:npu"}` failure mode exactly: a mock proves we sent it, nothing proves it is
+accepted.
+
+The rest of this slice is healthier than expected. `test_broker_wiring.py`,
+`test_daemon_remedy_commands.py`, `test_sidecar_alive_but_not_serving.py` and
+`test_external_mcp_executable.py` already drive real processes and real argparse surfaces —
+they are the pattern the rest should copy, not problems.
+
+Evidence for the empirical claims below came from the Lemonade install on this machine
+(`%LOCALAPPDATA%\lemonade_server\bin`, client reports `lemonade version 11.5.0`) and from
+Launchpad's published-binaries API for `ppa:lemonade-team/stable`. No servers were started;
+port 4001 was not touched.
+
+---
+
+## 1. Findings table
+
+### DANGEROUS
+
+| file:line | test | risk | evidence | proposed replacement |
+|---|---|---|---|---|
+| `tests/unit/test_lemonade_launcher.py:205` | `test_build_start_command_modern_windows` | **High.** Locks in `LEMONADE_CTX_SIZE` as the modern ctx-size channel. The installed Lemonade 11.5.0 server binary contains **no such string**: `grep -o -a -E "LEMONADE_[A-Z_]+" LemonadeServer.exe` yields only `MCP_IMAGE_DIR, API_KEY, ADMIN_API_KEY, DEFAULTS_PATH, CI_MODE, CACHE_DIR, BACKEND_WATCHDOG*, ALLOWED_ORIGINS`. `ctx_size` is instead a config-file key (`resources/defaults.json` → `"ctx_size": -1`, set via `lemonade config set`). If the var is ignored, issue #839 (auto-started server must come up at the profile ctx) is silently unfixed on the modern path — which is every current Windows user. | `assert spec.env == {"LEMONADE_CTX_SIZE": "32768"}` | Contract test modelled on `tests/integration/test_lemonade_backend_contract.py`: start the resolved launcher with `LEMONADE_CTX_SIZE=8192`, then assert `GET /api/v1/system-info` (or a `/load` + model-info round-trip) reports 8192. If the var is dead, replace the env channel with `lemonade config set ctx_size=N` and delete the assertion everywhere. |
+| `tests/unit/installer/test_init_ctx_size.py:211,253` | `test_windows_modern_auto_start_passes_ctx_size_via_env_not_argv`, `test_linux_modern_auto_start_passes_ctx_size_via_env` | **High.** Same wrong contract, one layer up — and worse, `build_start_command` is *itself* mocked (line 175/225), so the test supplies the `StartSpec` it then asserts. The only non-tautological assertion is the env merge. | `assert env.get("LEMONADE_CTX_SIZE") == "32768", f"expected LEMONADE_CTX_SIZE=32768 in Popen env, got: {env}"` | Stop mocking `build_start_command` — it is pure and stdlib-only; call it for real with a fabricated `LemonadeTooling` (as `test_lemonade_launcher.py` already does). Keep the env-merge and `GAIA_TEST_SENTINEL`/`PATH` assertions (those are genuinely valuable). Move the ctx-actually-took-effect claim to the integration test above. |
+| `tests/test_lemonade_client.py:1972,1992` | `TestLaunchServerModernLegacyDispatch` (modern branch) | **High.** Third copy of the same locked-in env contract, at the `launch_server` Popen seam — and `build_start_command` is mocked here too, so the argv equality at `:1990` is again asserting the test's own fixture. | `env={"LEMONADE_CTX_SIZE": "32768"}` … `self.assertEqual(env.get("LEMONADE_CTX_SIZE"), "32768")` | Converges with the two above once one integration test owns the claim. Keep the Popen-level test for the merge semantics only (`GAIA_TEST_SENTINEL` / `PATH` retention), and unmock `build_start_command`. |
+| `tests/unit/mcp/client/test_mcp_client.py:281` | `test_connect_sends_initialize_request` | **High.** Asserts GAIA sends `protocolVersion: "1.0.0"` on MCP `initialize`. MCP protocol versions are date strings — the published set is `2024-11-05, 2025-03-26, 2025-06-18, 2025-11-25`; `"1.0.0"` is not one of them. The transport is a `Mock`, so the test can only ever confirm we send the wrong value. Servers that validate strictly will reject the handshake; servers that fall back mask it until one doesn't. | `assert call_args[0][1]["protocolVersion"] == "1.0.0"` | Add a real-stdio contract test: launch a trivial in-repo MCP server over `StdioTransport` and assert the negotiated `result.protocolVersion` comes back non-empty and equal to something the client declared. Fix `src/gaia/mcp/client/mcp_client.py:447` and `transports/http.py:50` to a real version and negotiate the response, then let the unit test assert *the constant*, not a literal. |
+| `tests/unit/test_llamacpp_backend.py:363-365` | `TestLaunchServerCtxSize::test_ctx_size_appended_to_command` | **Medium-high.** You asked me to judge this one specifically: **yes, it now asserts a flag no shipped binary on this machine accepts.** There is no `lemonade-server` / `lemonade-server-dev` anywhere on PATH here; the only install is modern (11.5.0), whose client has no `serve` subcommand at all (`lemonade --help` lists `run/launch/chat/status/pull/load/…`, no `serve`). The test is honest about it — the docstring says "Pinned to LEGACY tooling" — and it does force `resolve_lemonade` to return legacy tooling, so it is not *lying*. But it is guarding a code path that only fires for an install GAIA can no longer produce: `gaia init` on Linux installs from `ppa:lemonade-team/stable`, whose current published binaries are `lemonade-server 11.8.1~24.04` / `11.0.0~25.10` — i.e. the *package* is still called `lemonade-server` but ships the modern `lemonade`/`lemond` tooling. So the legacy branch is dead-ish weight, and the second test in the class asserts a flag's *absence*, which is even cheaper. | `cmd = mock_popen.call_args[0][0]`<br>`assert "--ctx-size" in cmd`<br>`assert "65536" in cmd` | Don't delete — legacy installs still exist in the field. Do two things: (a) demote it to a pure `build_start_command` unit test (no Popen mock needed — the argv is built by a stdlib-only pure function); (b) `NEEDS-LIVE-CHECK` whether the legacy branch is still reachable at all, and if the answer is "only via `LEMONADE_SERVER_PATH` pointing at an archived binary," say so in the docstring and stop treating it as a primary path. |
+
+### MASKING
+
+| file:line | test | risk | evidence | proposed replacement |
+|---|---|---|---|---|
+| `tests/unit/mcp/client/test_transports.py:68-70` | `test_send_request_sends_json_rpc` | **Medium.** `stdout` is a `StringIO` holding exactly one line that is exactly the matching response. Real MCP stdio servers interleave notifications and (badly-behaved ones) log noise on stdout. `StdioTransport.send_request` does a bare `readline()` and **never correlates the response `id`** (`stdio.py:338-345`) — the first line back is returned as the answer regardless of what it is. The mock guarantees that never happens. | `mock_process.stdout = StringIO('{"jsonrpc": "2.0", "id": 0, "result": {"status": "ok"}}\n')` | Feed a `StringIO` containing a notification line *before* the response and assert the transport skips it. That is a cheap unit test that fails today and would force id-correlation into the production code. |
+| `tests/unit/mcp/client/test_transports.py` (whole module) | — | **Medium.** No test anywhere exercises the MCP handshake sequence. `MCPClient.connect` sends `initialize` and never sends `notifications/initialized`, which the spec requires before normal operation. Every test mocks the transport, so a server that enforces the sequence is never met. | absence of any `notifications/initialized` reference in `src/gaia/mcp/client/` | One integration test against an in-repo stdio MCP server: connect → `tools/list` → assert tools come back. Would catch both the missing notification and the bad `protocolVersion` in one shot. |
+| `tests/unit/test_lemonade_launcher.py:80,94,114,127,144,294` | six `resolve_lemonade` tests | **Low-medium, but worth naming.** `mocker.patch("pathlib.Path.exists", return_value=True/False)` is a blanket override — every `Path.exists()` in the process returns the same answer, so the test cannot distinguish "the Windows canonical path exists" from "every path exists." The macOS tests in the same file already fixed this with the `only_these_paths_exist` helper (line 34). | `mocker.patch("pathlib.Path.exists", return_value=True)` | Mechanical: route the six blanket patches through the existing `only_these_paths_exist` helper. No new infrastructure needed. |
+
+### UNNECESSARY
+
+| file:line | test | risk | evidence | proposed replacement |
+|---|---|---|---|---|
+| `tests/unit/installer/test_init_ctx_size.py:93,134,175,225,277` | all five `@patch("gaia.installer.init_command.build_start_command")` | **Low risk, real waste.** `build_start_command` is a pure stdlib function over a dataclass. Mocking it means the argv assertions in the same tests are asserting the test's own fixture data. | `mock_build_cmd.return_value = StartSpec(argv=[...], env={...})` then `assert "--ctx-size" in argv` | Drop the patch; let the real function build the argv from a fabricated `LemonadeTooling`. Same test, now non-circular. |
+| `tests/unit/test_lemonade_launcher.py:527,549,571,593,617,707,728` | seven `describe_start_hint` tests | **Low.** They patch `resolve_lemonade` wholesale, so only the rendering half is under test. The file's own better tests (`test_start_hint_macos_names_the_daemon_via_real_detection:637`) drive the real probe and say why: *"no mocking of resolve_lemonade, which would only prove we called it."* | `mocker.patch("gaia.llm.lemonade_launcher.resolve_lemonade", return_value=LemonadeTooling(...))` | Same treatment as the macOS ones — patch `platform.system` + `only_these_paths_exist` and let the real resolver run. |
+
+### JUSTIFIED
+
+| file:line | test | why leave it alone |
+|---|---|---|
+| `tests/unit/mcp/client/test_transports.py:19-548` — the ~25 `subprocess.Popen` patches | Spawning `npx`/`uvx` per test would pull the network and take seconds each. Critically, the *assertion target* is `_build_argv`'s tokenizer output, which is pure local logic — the Popen mock is just the observation point, not a contract stand-in. The shell-injection rejection tests (`:298`, `:338`) assert `mock_popen.assert_not_called()`, which is the correct shape for a security guard. |
+| `tests/unit/test_webui_build.py` — all `gaia.ui.build.subprocess.run` patches | A real `npm install && npm run build` is a multi-minute network operation. `npm run build` and `node --version` are argv that have been stable for a decade; there is no realistic contract drift. The tests additionally assert `shell=False` on every call (`:163`) and that only the version probe runs when Node is too old (`:310`) — both are real invariants. |
+| `tests/unit/test_daemon_dev_anchor_spec.py` — `subprocess.run` seam for `git` | Deliberately isolates the suite from the ambient checkout's git state, and the module docstring says exactly that. `git rev-parse` argv is not going to move. |
+| `tests/unit/test_agent_sidecar_manager.py:408-413` — the fake `Popen` | The alternative is spawning a real uvicorn per test. The fake captures argv and kwargs, and the surrounding tests assert things a mock genuinely can prove: log-file redirection rather than `PIPE` (`:440`), the 0600 secret file and that the token appears in **neither** env nor argv (`:467-470`). That last one is a real security invariant that only a Popen-level observation can check. |
+| `tests/unit/test_daemon_remedy_commands.py:193-230` | **Not a mock at all** — spawns a real `python -c "time.sleep(120)"` and executes the remedy command against it. This is the pattern the rest of the slice should copy. |
+| `tests/unit/test_sidecar_alive_but_not_serving.py:50,91` | Same — real subprocesses, real ports. |
+| `tests/unit/test_external_mcp_executable.py` | Asserts `shutil.which` is applied so `npx.cmd` resolves on Windows, driven by the real PATHEXT behaviour. Exactly the "is the call valid" test this audit is asking for. |
+| `tests/unit/test_broker_wiring.py` (entire module) | Runs a **real** `ModelSlotBroker` and, at `:599`, a real daemon over HTTP. Its docstring cites the CLAUDE.md rule verbatim: *"a mock that merely records 'a lease was requested' would prove invocation, not mutual exclusion."* Nothing to fix; cite it as the house style. |
+
+---
+
+## 2. Coverage gaps — per external process
+
+| Target | Argv/contract GAIA sends | Would any test fail if the contract moved? | Cheap probe available? |
+|---|---|---|---|
+| `LemonadeServer.exe` (modern Windows) | `[exe, "--silent"]` + `LEMONADE_CTX_SIZE` env | **No.** `--silent` is at least present in the binary's flag table (verified by string scan). The env var is not, and nothing would catch that. | Partly. `--silent` is confirmable by inspection. The ctx claim needs a live server. |
+| `lemond` (modern Linux/macOS) | `[lemond]` or `["systemctl","--user","start","lemond"]` | **No.** Pure argv-construction tests only. Neither binary exists on any CI runner GAIA uses. | No — needs a Linux/macOS box with the PPA package installed. |
+| `lemonade-server serve` (legacy) | `["lemonade-server","serve","--ctx-size",N]` (+`--no-tray` on Windows) | Only against a hand-built `LemonadeTooling`. No binary on this machine, none on PATH. | Yes if a legacy binary is obtainable — `lemonade-server --help` would settle whether `serve --ctx-size` still parses. |
+| `lemonade` client (`pull`/`load`) | `[client, "pull"|"load", model]` — `describe_client_hint` | **No test at all.** But I verified by probe: `lemonade --help` lists both `pull` and `load`, so this one is currently **correct**. | Yes, and I ran it. Cheap to automate as a skipif-guarded `--help` grep. |
+| `apt-get install -y lemonade-server` (PPA) | package name `lemonade-server` from `ppa:lemonade-team/stable` | Tests assert the literal string is in the argv (`test_init_command.py:1485`), which is invocation-only. | Verified externally: Launchpad's `getPublishedBinaries` confirms `lemonade-server` **is** a published binary name (source package `lemonade`, versions `11.8.1~24.04`, `11.0.0~25.10`). **This is correct — not a finding.** Worth noting only that the deb now ships *modern* tooling, so the package name and the binary names diverge. |
+| Email sidecar frozen binary | `[binary, "--host", H, "--port", P]` (`manager.py:319`) | **No.** The sidecar's own argparse (`gaia_agent_email/server.py:316`, `_add_serve_args`) is in this repo and currently accepts both flags — but nothing cross-checks them. A rename in `_add_serve_args` breaks the daemon with a fully green suite. | **Yes, and it is free** — see remediation R3. |
+| Dev-mode sidecar (uvicorn) | `[sys.executable,"-m","uvicorn",module,"--app-dir",dir,"--host",H,"--port",P]` | **Partly, and well.** `test_agent_sidecar_manager.py:108-115` asserts the app-dir actually exists on disk and contains `server.py`. That is real state validation. uvicorn's flags are stable. | n/a |
+| `python -m gaia.daemon` | `[sys.executable,"-m","gaia.daemon"]` | **Yes** — `tests/integration/test_daemon.py` and `test_daemon_sidecars.py` spawn it for real. | n/a |
+| MCP stdio servers (`npx`/`uvx`/`python`) | JSON-RPC over newline-delimited stdio, `initialize` first | **No.** Every test mocks the transport. The `protocolVersion` and the missing `notifications/initialized` are both invisible. | Yes — an in-repo stdio MCP server fixture, no network. |
+| `npm` / `node` | `["npm","run","build"]`, `["node","--version"]` | No, but the contract is stable enough that it doesn't matter. | Yes, trivially, but low value. |
+
+**The gap that matters most and costs least:** the email sidecar argv. Both sides of that
+contract live in this repo, so a real test is a five-line import — no service, no network,
+no hardware.
+
+**Windows blind spot:** `tests/integration/test_daemon_sidecars.py` is `skipif` POSIX-only
+(`:46`) *and* drives a toy sidecar rather than the real one. So on Windows — the primary
+GAIA platform — no test in this slice launches a real supervised sidecar at all.
+
+---
+
+## 3. Remediation, ordered by value per unit of work
+
+**R1 — one integration test retires three DANGEROUS findings.**
+`tests/integration/test_lemonade_ctx_contract.py`, gated on `require_lemonade`
+(`tests/conftest.py:183`). Launch via the resolved tooling with a distinctive ctx (8192,
+not the profile default), then assert the running server reports it. One test settles
+`test_lemonade_launcher.py:205`, `test_init_ctx_size.py:211,253`, and
+`test_lemonade_client.py:1970` — after which those three become pure argv-shape unit
+tests, which is all they were ever able to be.
+
+`NEEDS-LIVE-CHECK:` on a machine with Lemonade 11.5+, from
+`%LOCALAPPDATA%\lemonade_server\bin`:
+```
+LEMONADE_CTX_SIZE=8192 ./LemonadeServer.exe --silent   # then, from another shell:
+curl -s http://localhost:13305/api/v1/system-info
+./lemonade.exe config          # compare against the config-file ctx_size path
+```
+If 8192 does not surface, the env channel is dead and `build_start_command` should switch
+to `lemonade config set ctx_size=N` (or drop the ctx claim and rely on the per-request
+`/load` `ctx_size`, which `test_llamacpp_backend.py:74` shows already works).
+
+**R2 — one stdio MCP fixture retires the MCP findings.**
+Add `tests/fixtures/toy_mcp_server.py` (a ~40-line newline-delimited JSON-RPC responder,
+mirroring the existing `tests/fixtures/toy_sidecar.py` pattern). Drive it through the real
+`StdioTransport` + `MCPClient.connect`. Catches the invalid `protocolVersion`, the missing
+`notifications/initialized`, and the uncorrelated `readline()`. No network, no skip
+condition, runs everywhere.
+
+**R3 — free, do it today.** A unit test in `tests/unit/test_agent_sidecar_manager.py` that
+takes `build_spawn_command(port=…)` output in user mode and feeds it to the sidecar's own
+parser:
+```python
+from gaia_agent_email.server import main  # or the parser factory
+argv, _ = m.build_spawn_command(port=9123)
+# argv[0] is the binary path; the rest must parse against the sidecar's own argparse
+```
+Both halves are in-repo. Turns an untested cross-process contract into a compile-time-ish
+check.
+
+**R4 — mechanical, one commit.** Convert the six blanket `Path.exists` patches in
+`test_lemonade_launcher.py` to the file's own `only_these_paths_exist` helper, and drop the
+five `build_start_command` mocks in `test_init_ctx_size.py`. Pure subtraction; no new
+fixtures.
+
+**R5 — `NEEDS-LIVE-CHECK` on the legacy branch.** On an Ubuntu 24.04 box:
+`sudo add-apt-repository -y ppa:lemonade-team/stable && sudo apt-get install -y
+lemonade-server && lemonade-server --help 2>&1 | head`. If that binary does not exist after
+install (only `/usr/bin/lemonade` + `lemond` do), then `TestLaunchServerCtxSize` and the two
+`_legacy_tooling()` cases in `test_init_ctx_size.py` guard a path `gaia init` can no longer
+reach on any supported platform, and their docstrings should say so.
+
+**One shared fixture, many conversions:** a `lemonade_tooling(kind, platform)` factory would
+let R1's integration test and the argv unit tests in `test_lemonade_launcher.py`,
+`test_init_ctx_size.py`, `test_llamacpp_backend.py` and `test_lemonade_client.py` share one
+definition of each tooling shape — today each file rolls its own `_legacy_tooling()` /
+`_modern_tooling_windows()` helper, four near-identical copies.
+
+---
+
+## Notes on scope and honesty
+
+- Nothing was modified. The only write is this file.
+- The `apt-get install lemonade-server` package name looked wrong from the Launchpad
+  *source*-package list and turned out to be **correct** on the binary list. Reported as a
+  non-finding rather than padding the count.
+- The `LEMONADE_CTX_SIZE` claim rests on a string scan of a shipped binary plus the
+  presence of `ctx_size` as a config key. That is strong but not proof — an env name built
+  by concatenation would evade the scan. Hence `NEEDS-LIVE-CHECK` rather than a flat
+  assertion.
+- `test_broker_wiring.py`, `test_daemon_remedy_commands.py`,
+  `test_sidecar_alive_but_not_serving.py` and `test_external_mcp_executable.py` need no
+  changes. They already do what this audit is asking for, and three of them say so in
+  their docstrings.

--- a/audit_reports/_partials/ui-connectors-mcp.md
+++ b/audit_reports/_partials/ui-connectors-mcp.md
@@ -1,0 +1,138 @@
+# Audit slice: UI routers, connectors, hub, MCP, SQL
+
+**Headline: this slice is in better shape than the mock counts suggest.** The two
+boundaries most likely to repeat the `{"spec": "flm:npu"}` failure — SQLite and the
+OAuth keyring — are exercised for real, not mocked. The genuine exposure is elsewhere:
+three places pin a hand-written third-party payload behind a mock, and nothing in the
+repo ever re-checks that payload against the real peer.
+
+- SQL: `tests/unit/chat/ui/test_database.py:16` builds a real `ChatDatabase(":memory:")`.
+  No SQL is mocked anywhere in this slice.
+- Keyring: `tests/unit/connectors/conftest.py` installs a real in-memory keyring backend
+  (autouse), so the serialize/deserialize + `client_id_hash` tripwire contract runs for real.
+- OAuth flow: `tests/unit/connectors/test_flow.py` drives the real `start_authorization`,
+  extracts `code_challenge`/`state`/`redirect_uri` from the returned URL, and completes a
+  real loopback callback — respx mocks only the token endpoint. This is the pattern the
+  rest of the repo should copy.
+- UI routers: `tests/unit/chat/ui/test_server.py` and `tests/unit/test_hub_router.py` use a
+  real `TestClient` against a real in-process app + `:memory:` DB. Request/response shape
+  changes on those routes **would** be caught.
+
+---
+
+## 1. Findings
+
+### DANGEROUS
+
+| file:line | test | evidence | why it's dangerous | replacement |
+|---|---|---|---|---|
+| `tests/unit/eval/test_claude_judge.py:245-252` | `TestGetCompletionTemperature::test_temperature_pinned_when_set` | `kwargs = client.client.messages.create.call_args.kwargs` / `assert kwargs["temperature"] == 0.0` | Mocks the Anthropic SDK and asserts `temperature` reaches `messages.create`. The production judge default is `claude-opus-5` (`src/gaia/eval/config.py:16`), whose family **rejects sampling params with a 400** — the client's own docstring says so (`src/gaia/eval/claude.py:38-41`: *"they reject sampling params with a 400, so pinning a value fails the call outright"*). The test also builds the client with `model="claude-sonnet-4-6"` (`:27`), a model the product never uses, so the fixture quietly picks the one model family where the assertion could hold. This is the exact `{"spec": ...}` shape: the mock accepts a request the real server refuses. **Mitigation, stated honestly:** no production caller passes `temperature` — every construction site is `ClaudeClient()` or `ClaudeClient(model=...)` (`cli.py:4044`, `eval/{action_item,briefing,draft}_quality.py`, `pdf_document_generator.py:34`). It is a live trap for the next caller, not a live bug. | Delete the pin, or convert it to an assertion that the param is **rejected** for the default model. If the `temperature=` constructor arg has no caller, the honest fix is to drop the arg. |
+| `tests/unit/chat/ui/test_server.py:166-760` (13 tests, e.g. `test_system_status_context_size_insufficient:214`, `test_system_status_model_loaded_derived_from_all_models_loaded:539`) | `TestSystemStatus::*` | `@patch("httpx.AsyncClient")` + hand-written body `{"all_models_loaded": [{"model_name": ..., "recipe_options": {"ctx_size": 4096}}]}`; `assert data["model_context_size"] == 4096` | Pins Lemonade's `/health` and `/models` response shape from memory. Four production files parse that exact path — `ui/routers/system.py:492,507,528,827`, `ui/server.py:324,347`, `ui/_chat_helpers.py:1207,1217,1271,1276`. If Lemonade renames `recipe_options.ctx_size` or drops `all_models_loaded`, all 13 tests stay green while the UI silently reports the wrong context size and fires (or suppresses) the "context too small" banner. Direction is inbound rather than outbound, but the failure mode is identical: a hand-written peer payload nobody re-validates. | Keep the unit tests for the branch logic, and add **one** `require_lemonade` integration test that hits the real `/health` and asserts the keys the parser depends on exist. Model it on `tests/integration/test_lemonade_backend_contract.py`. |
+| `tests/unit/test_browser_tools.py:305-336` | `test_parse_ddg_results` | `mock_html = """...<div class="result"><a class="result__a" href="...uddg=...">"""` + `patch.object(self.client, "_request", ...)`; `assert results[0]["url"] == "https://example.com/page"` | Hand-written DuckDuckGo HTML matching the exact selectors in `src/gaia/web/client.py:855-857` (`.result`, `.result__title a, .result__a`, `.result__snippet`). DuckDuckGo changes its scraped HTML without notice; when it does, web search silently returns zero results and this test still passes. It is the only test that exercises the parse at all — every other `search_duckduckgo` test mocks the method wholesale. | Record a real `html.duckduckgo.com` response as a checked-in fixture with a dated header, and add a `@pytest.mark.integration` test that fetches live and asserts ≥1 result — so the fixture's staleness is detectable. |
+
+### MASKING
+
+| file:line | test | evidence | what's hidden | replacement |
+|---|---|---|---|---|
+| `tests/unit/connectors/test_router_connectors.py:287-298, 316-339, ~648` | `TestConfigureEndpoint::test_configure_dispatches_to_handler`, `TestAuthorizeGrantAgents::*`, `TestAuthorizeDeviceEndpoint::*` | `monkeypatch.setattr("gaia.ui.routers.connectors.configure", AsyncMock(...))`; `monkeypatch.setattr("gaia.connectors.start_authorization", mock_start)` | The route is real (`TestClient`, real registry, real grants dir — good), but the flow never runs. No test drives **"user has never connected"** through the HTTP route: empty keyring → `POST /api/connectors/google/authorize` → real `start_authorization` → real authorization URL. That cold path is covered only at function level in `test_flow.py`. A regression in how the router marshals `scopes`/`grant_agents` into the real flow would pass. | One route-level test with an empty keyring and respx mocking only `oauth2.googleapis.com/token`, asserting the returned `authorization_url` carries `code_challenge_method=S256` and the requested scopes. |
+| `tests/unit/test_browser_tools.py:840-845` | `test_search_web_no_results` | `self.agent._web_client.search_duckduckgo.return_value = []` / `assert "No results found" in result` | Tests the tool's *formatting* of an empty list. The real zero-results path — DDG returns HTML with no `.result` divs — is never exercised, so a selector break presents as an empty list here and as a silent failure in production. | Feed the empty case through `search_duckduckgo` with a no-results HTML fixture instead of stubbing the method. |
+| `tests/unit/chat/ui/test_indexing_errors.py:36-112` | `TestIndexingErrors::*` | `mock_rag = MagicMock()` + `patch("gaia.rag.sdk.RAGSDK", return_value=mock_rag)` | The empty-index / first-document-ever path is a `MagicMock`, so "index does not exist yet" is whatever the mock returns. Borderline — these tests target error *classification*, which is legitimate unit work. Listed for completeness, not as an action item. | Leave as-is unless RAG cold-start bugs recur. |
+
+### UNNECESSARY
+
+| file:line | test | evidence | why | replacement |
+|---|---|---|---|---|
+| `tests/unit/test_hub_router.py:29` | app fixture | `app.state.agent_registry = MagicMock(spec=AgentRegistry)` | The registry is a `MagicMock` while everything else in the fixture is real. `spec=` limits the blast radius, and the offline path *is* covered (`test_catalog_offline_503_when_no_cache:81` raises a real `CatalogError`), so this is low priority. | Swap in a small real registry seeded from a temp dir when one becomes cheap to build. |
+| `tests/unit/connectors/test_mcp_server.py:91-431` | `McpServerHandler` suite | `patch("gaia.connectors.mcp_server.keyring.set_password")` (×9) | Patches `keyring.set_password` directly even though `tests/unit/connectors/conftest.py` already installs a real in-memory keyring backend for this package. The patch is redundant and weaker than the fixture the file already gets. | Drop the patches; the autouse in-memory backend already isolates them. |
+
+### JUSTIFIED
+
+| file:line | what | why it's fine |
+|---|---|---|
+| `tests/unit/connectors/conftest.py:48-70` | in-memory keyring backend | A real backend, not a `MagicMock` — the JSON blob contract runs for real. Correct call. |
+| `tests/unit/connectors/test_tokens.py` (respx, all) | mocks `oauth2.googleapis.com/token` responses | Live Google OAuth is unmockable in CI (real refresh tokens, rate limits, side effects). `@respx.mock` defaults to `assert_all_called`, so the URL is pinned. Only the **response** is fabricated; that is the right boundary. See the gap below about the request body. |
+| `tests/unit/connectors/test_router_forwarded.py:171-203` | captures the refresh body | Actually asserts the outgoing body (`assert FWD_CLIENT_ID in captured["body"]`) — the only place in this slice that does. Worth extending, not replacing. |
+| `tests/unit/test_security_edge_cases.py` (e.g. `:61`) | `patch("os.path.realpath")` | OS primitives, not a service contract. Constructing a real symlink-into-a-blocked-dir is platform-specific and flaky on Windows CI. |
+| `tests/unit/chat/ui/test_server.py:1194+` | `@patch("gaia.ui.server._get_chat_response")` | Mocks the LLM, not the HTTP layer. Everything around it (routes, DB, response models) is real. |
+
+---
+
+## 2. Coverage gaps
+
+**Per UI router — is the real route exercised?**
+
+| Router | Real `TestClient` + real DB? | Would a response-shape change be caught? |
+|---|---|---|
+| sessions, documents, files, system, chat (`test_server.py`) | Yes | Yes — field-presence assertions, e.g. `:99-112`, `:1314-1327` |
+| hub (`test_hub_router.py`) | Yes (registry is a `MagicMock`) | Yes for status codes; partially for bodies |
+| connectors (`test_router_connectors.py`) | Yes, but handlers mocked | Route wiring yes; flow-produced fields no |
+| tunnel, goals, memory, mcp, schedules, onboarding, agents | Not in this slice's files | Unknown — flag for the next pass |
+
+**Frontend ↔ backend shape.** No test cross-checks them. TS types in
+`src/gaia/apps/webui/src/types/index.ts` are hand-written, not generated, and there is no
+OpenAPI snapshot for the UI backend (`grep -rn openapi tests/unit/chat/ui/` → nothing).
+The email agent has exactly the right thing — `tests/test_email_openapi_conformance.py`,
+which asserts responses conform to a committed schema and that no undocumented fields
+leak. Nothing equivalent guards `/api/*`. Reported drift (from a scan, not hand-verified
+end to end): backend defaults several fields to non-null (`title_is_custom`, `private`,
+`agent_type`, `device` on `SessionResponse`; `detected_devices` on `SystemStatus`) that
+the TS side declares optional — harmless today, but exactly the drift a conformance test
+exists to catch.
+
+**MCP.** `tests/mcp/` is genuinely mock-free — verified, zero `unittest.mock` hits — but
+thin where it matters. No test validates a tool's `inputSchema` against a real client
+handshake. `test_email_mcp_stdio_parity.py` spawns a real stdio server and calls
+`initialize` + `list_tools` + `call_tool`, but only asserts tool *names*
+(`:259-268`). `test_agent_mcp_server_stdio.py:88-100` asserts the schema→signature
+translation in-process. The HTTP JSON-RPC tests (`test_mcp_http_validation.py`,
+`test_mcp_integration.py`) assume a server is already listening on :8765 and are not in
+default CI. Net: a tool whose `inputSchema` drifts from its handler ships uncaught.
+
+**Connectors — the OAuth request body.** The provider body-builders are unit-tested for
+real (`test_providers.py:261-268`, `test_microsoft_provider.py:370-376` assert
+`grant_type`, `refresh_token`, `client_id`, absence of `client_secret`). What is *not*
+pinned anywhere is how `_refresh_token` puts that body on the wire —
+`src/gaia/connectors/tokens.py:236` uses `client.post(url, data=body)`, i.e.
+form-encoded, which is what Google and Microsoft require. Switch that to `json=body` and
+every test in this slice still passes while every real refresh 400s. That is the
+`{"spec": ...}` bug with the encoding rather than the field names.
+`NEEDS-LIVE-CHECK:` cannot be validated against a live provider in CI; the cheap fix is a
+respx `side_effect` that asserts
+`request.headers["content-type"] == "application/x-www-form-urlencoded"` and
+`parse_qs(request.content)` contains `grant_type=refresh_token`.
+
+---
+
+## 3. Highest-leverage recommendation
+
+**One shared fixture would fix the connectors gap, and it already exists.**
+`tests/unit/connectors/test_flow.py` is the template: real flow + real in-memory keyring +
+respx on the token endpoint only + a real loopback callback. Lifting that into a shared
+fixture and pointing `test_router_connectors.py` at it converts every
+`monkeypatch.setattr("gaia.connectors.start_authorization", AsyncMock(...))` in one move,
+and gets the cold "never connected" path covered through the HTTP route for free.
+
+Ranked follow-ups:
+
+1. **Assert the outgoing OAuth body at the wire.** One respx `side_effect` in
+   `test_tokens.py` closes the highest-similarity gap to the motivating bug. Cheapest fix
+   in this report.
+2. **One `require_lemonade` health-shape test.** Retires the risk behind 13 mocked
+   `TestSystemStatus` tests at once.
+3. **A UI-backend OpenAPI conformance test**, copying
+   `tests/test_email_openapi_conformance.py`. Only ~31 of ~57 `/api/*` routes declare a
+   `response_model`, so this needs the response models filled in first — real work, real
+   payoff.
+4. **Drop the `temperature` pin** in `test_claude_judge.py`, and drop the constructor arg
+   if it stays caller-less.
+5. **Extend the MCP stdio parity test** from names to `inputSchema` shape — the server is
+   already running in that test; the assertion is a few lines.
+
+## Verification notes
+
+Read directly: `test_tokens.py`, `connectors/tokens.py`, `providers/google.py`,
+`test_server.py` (1–1561), `ui/routers/system.py` (parse sites), `eval/claude.py`,
+`test_claude_judge.py`, `test_router_connectors.py` (fixtures + configure/authorize),
+`test_browser_tools.py` (DDG parse), `web/client.py:836-857`, `test_database.py`,
+`test_mcp_server.py`. Router inventory and the frontend/backend field comparison came
+from a scan and are labelled as such above. No files were modified; no servers started.

--- a/audit_reports/mock-test-audit.md
+++ b/audit_reports/mock-test-audit.md
@@ -1,0 +1,302 @@
+# Mock-test audit
+
+**Date:** 2026-09-02 · **Scope:** `tests/` (678 test files) and `hub/agents/*/python/tests/`
+· **Method:** static read of every heavy-mock file, plus live probes against Lemonade
+11.5.0 and a string scan of the shipped server binary. No production code changed.
+
+**Issues filed:** [#3318](https://github.com/amd/gaia/issues/3318) install/uninstall payload ·
+[#3319](https://github.com/amd/gaia/issues/3319) `set_params` dead code ·
+[#3320](https://github.com/amd/gaia/issues/3320) `LEMONADE_CTX_SIZE` inert ·
+[#3321](https://github.com/amd/gaia/issues/3321) email spec omits an endpoint ·
+[#3322](https://github.com/amd/gaia/issues/3322) MCP `protocolVersion` ·
+[#3323](https://github.com/amd/gaia/issues/3323) live tests that cannot fail ·
+[#3324](https://github.com/amd/gaia/issues/3324) Lemonade endpoint coverage ·
+[#3325](https://github.com/amd/gaia/issues/3325) cross-process argv contracts ·
+[#3326](https://github.com/amd/gaia/issues/3326) OAuth body encoding ·
+[#3327](https://github.com/amd/gaia/issues/3327) UI/TS conformance ·
+[#3328](https://github.com/amd/gaia/issues/3328) CI lint checks
+
+Per-slice detail (file-by-file, beyond what this summary compresses) is in `_partials/`.
+
+---
+
+## The conclusion
+
+**Four things GAIA sends to an external peer today are rejected or ignored by that peer,
+and a mocked test asserts each one is correct.** All four were found by asking one
+question the test suite never asks: *would the real thing accept this?*
+
+| What GAIA sends | What actually happens | The test that says it's fine |
+|---|---|---|
+| `POST /install {"spec":"flm:npu"}` | `400 Both 'recipe' and 'backend' are required` | `test_npu_device_support.py:181` |
+| `POST /uninstall {"spec":"flm:npu"}` | `400` — same | `test_npu_device_support.py:221` |
+| `POST /params {"temperature":…,"top_k":…}` | `400 Unknown config key` on **every** key | `test_lemonade_client.py:920` |
+| `LEMONADE_CTX_SIZE` env var at server launch | string absent from the entire Lemonade 11.5.0 install | 3 tests, in 3 files |
+
+The `install` case is the bug that prompted this audit. The other three were found the
+same way and had been sitting green.
+
+Two structural causes, both worth fixing above any individual test:
+
+1. **Payload shape is asserted against a stub.** A mock accepts whatever GAIA sends, so
+   pinning the payload only records what we *believe*. 22 sites do this.
+2. **Some tests cannot fail.** `test_integration_pull_model` runs against a real server
+   and then swallows every error with the comment `# Don't fail the test`.
+   `test_integration_health_check_914_format` wraps every response assertion in an `if`,
+   so a renamed field prints ⚠️ and passes. These are worse than mocked tests — they read
+   as real coverage.
+
+The ratio behind it: **3,935 mock hits in `tests/unit/` against 22 uses of the
+`require_lemonade` fixture across the whole repo.**
+
+**The single highest-leverage change** is one live `/health` schema test. Roughly 32
+mocked tests hand-build `{"all_models_loaded":[{"recipe_options":{"ctx_size":N}}]}` and
+none verify it. That field *already moved once* (Lemonade 9.1.4). One unconditional live
+assertion grounds all 32 without rewriting any of them.
+
+**What is *not* broken:** the hub agents, the connectors OAuth flow, the UI routers, and
+the daemon/broker tests are in good shape — several already do exactly what this audit
+asks and say so in their docstrings. Details in §5.
+
+---
+
+## 1. Counts survey
+
+Files containing `test_*`, counted for `mocker.patch`, `unittest.mock`, `MagicMock`,
+`patch(`, `monkeypatch.setattr`, `respx`, `assert_called*_with`, `@patch`.
+
+| directory | test files | files with mocks | total mock hits |
+|---|---:|---:|---:|
+| `tests/unit/` | 462 | 275 | **3,935** |
+| `hub/agents/*/python/tests/` | 149 | 70 | 714 |
+| `tests/` (root) | 17 | 10 | 258 |
+| `tests/integration/` | 44 | 11 | 169 |
+| `tests/installer/` | 2 | 1 | 1 |
+| `tests/mcp/` | 9 | 0 | **0** |
+| `tests/stress/`, `tests/fixtures/` | 3 | 0 | 0 |
+
+By pattern: `monkeypatch.setattr` 1,580 · `patch(` 1,469 · `MagicMock` 927 · `@patch`
+472 · `unittest.mock` imports 231 · `mocker.patch` 163 · `respx` 137 ·
+`assert_called_once_with` 93 · `assert_called_with` 5.
+
+**HTTP-layer mocks are concentrated in one file.** Of 63 `responses.add` calls in the
+repo, **60 are in `tests/test_lemonade_client.py`** — the client for the largest contract
+surface GAIA has is validated almost entirely against a fake server GAIA programs itself.
+
+Heaviest files: `test_init_command.py` (366) · `mcp/client/test_transports.py` (98) ·
+`test_lemonade_launcher.py` (88) · `test_lemonade_client.py` (82) ·
+`agents/test_builder_agent.py` (77) · `test_rag.py` (76) · `test_llamacpp_backend.py` (72).
+
+**A CI note that matters:** no workflow runs `tests/test_lemonade_client.py` without
+`-k "Integration"`. Its ~60 mocked HTTP tests **never execute in CI at all** — they cost
+maintenance and return no signal.
+
+---
+
+## 2. Findings
+
+Bucket key — **DANGEROUS**: mocks a contract boundary *and* pins an outgoing
+payload/argv/schema shape. **MASKING**: hides the cold/empty starting state, or cannot
+fail. **UNNECESSARY**: doubles pure local logic. **JUSTIFIED**: leave alone.
+
+Totals: **21 DANGEROUS · 15 MASKING · 6 UNNECESSARY · 26 JUSTIFIED file-groups.**
+
+### DANGEROUS — verified against the real peer
+
+These four are not suspicions. Each carries a real response captured during this audit.
+
+| # | file:line | test | evidence | replacement |
+|---|---|---|---|---|
+| **D1** | `tests/unit/test_npu_device_support.py:181` | `test_install_backend` | `assert_called_once_with("post", ".../install", {"spec":"flm:npu"}, timeout=300)`. **Live:** `400 {"error":"Both 'recipe' and 'backend' are required"}`. Split form returns `200 {"recipe":"flm","backend":"npu","status":"success"}`. Broke `gaia init --profile npu`; NPU CI green throughout. | Fix exists on `fix/npu-flm-backend-install` — land it, delete the pin, keep a pure unit test for `_split_backend_spec`. |
+| **D2** | `tests/unit/test_npu_device_support.py:221` | `test_uninstall_backend` | `{"spec":"flm:npu"}` to `/uninstall`. **Live:** identical `400`. Never exercised live. | Same contract test. Assert the 400-on-combined-spec rather than actually uninstalling. |
+| **D3** | `tests/test_lemonade_client.py:920` | `test_set_params` | `responses.add(POST /params, json={...fabricated echo...}, status=200)`. **Live:** *every* key `set_params()` can send is rejected — `temperature`, `top_p`, `top_k`, `min_length`, `max_length`, `do_sample` each return `400 {"error":"Unknown config key: 'X'"}`. The method is 100% dead. The one integration test that would have caught it is `@pytest.mark.skip("Parameter setting API is still in development")` (`:2470`). **No production caller exists.** | Delete `set_params` and both tests. This is dead code with a fake test proving it works. |
+| **D4** | `tests/unit/test_lemonade_launcher.py:205`<br>`tests/unit/installer/test_init_ctx_size.py:211,253`<br>`tests/test_lemonade_client.py:1972,1992` | `test_build_start_command_modern_windows` + 4 siblings | All assert `LEMONADE_CTX_SIZE` is the modern ctx channel. **Verified:** the string appears **nowhere** in the Lemonade 11.5.0 install tree; the binary's env table is `MCP_IMAGE_DIR, API_KEY, ADMIN_API_KEY, DEFAULTS_PATH, CI_MODE, CACHE_DIR, BACKEND_WATCHDOG*, ALLOWED_ORIGINS`. ctx is a **config-file key** (`resources/defaults.json → "ctx_size": -1`). So the #839 fix (auto-started server must come up at profile ctx) is inert — masked because the per-request `/load ctx_size` path works. Two of the three tests also mock `build_start_command` itself, so they assert their own fixture. | One `require_lemonade` test: launch with a distinctive ctx (8192), assert the server reports it. Then switch the channel to `lemonade config set ctx_size=N`. |
+
+### DANGEROUS — verified in-repo (both sides of the contract are here)
+
+| # | file:line | test | evidence | replacement |
+|---|---|---|---|---|
+| **D5** | `hub/agents/email/python/tests/test_spec_html_artifact.py:26` | `test_committed_spec_html_artifact_is_up_to_date` | **A live shipped-doc defect.** `agent_routes.py:648` registers `POST /autonomy/undo`; `SPEC.md` documents it (2 hits), `SKILL.md` (1 hit), `specification.html` and `spec_html.py` **0 hits** — independently confirmed. The HTML spec served at `GET /v1/email/spec` omits a real endpoint. The test is green because it only compares the generator to its own output. | Enumerate `agent_routes.router.routes` and assert every schema-visible path appears in the rendered spec. Then add the missing section. |
+| **D6** | `src/gaia/mcp/client/mcp_client.py:447`, `transports/http.py:50`, `mcp_bridge.py:411` — pinned by `tests/unit/mcp/client/test_mcp_client.py:281` | `test_connect_sends_initialize_request` | GAIA declares `protocolVersion: "1.0.0"`. MCP protocol versions are **date strings** (`2024-11-05`, `2025-03-26`, `2025-06-18`, `2025-11-25`); `"1.0.0"` is not one. The transport is a `Mock`, so the test can only ever confirm we send the wrong value. Also verified: GAIA **never** sends `notifications/initialized`, which the spec requires before normal operation. | A toy in-repo stdio MCP server + real `StdioTransport`. Catches the bad version and the missing notification together. No network. |
+| **D7** | `hub/agents/email/npm/test/client.test.ts:350,483` | archive/unarchive + calendar path tests | `expect(seen).toEqual([".../confirm", ".../archive", ".../unarchive"])` — the typed client's URLs asserted against a hand-written list under a `vi.fn()` fake fetch, while `openapi.email.json` sits unread in the same repo. A server-side rename regenerates the OpenAPI artifact, leaves the TS client stale, and both suites pass. Only `/query` has a real-sidecar test. | Import `openapi.email.json` in vitest; assert every emitted URL is a key in `spec.paths`. No server needed. |
+| **D8** | `hub/agents/gaia/python/tests/test_stdio.py:1142` | `test_the_parser_accepts_the_spellings_the_go_side_pins` | A cross-language argv contract pinned on **one side only**. Go declares the same strings as independent literals (`tui/internal/client/factory.go:43,53`). Neither side reads the other; the test's own docstring predicts the failure (`exited (code 2)` at spawn) then asserts a literal it typed itself. | ~15 lines: grep `factory.go` for every option string `build_parser()` defines. Plus one subprocess smoke test. |
+| **D9** | `tests/unit/eval/test_claude_judge.py:245` | `test_temperature_pinned_when_set` | Asserts `temperature=0.0` reaches `messages.create`. The default judge is `claude-opus-5` (`eval/config.py:16`), and `eval/claude.py:38-41` documents that current models **reject sampling params with a 400**. The fixture builds with `model="claude-sonnet-4-6"` — a model the product never uses — quietly selecting the one family where the assertion could hold. Mitigation: no production caller passes `temperature`. A trap for the next caller, not a live bug. | Drop the pin. If the constructor arg stays caller-less, drop the arg. |
+
+### DANGEROUS — payload pins not yet sprung
+
+Correct today only because someone hand-checked them once.
+
+| # | file:line | evidence | replacement |
+|---|---|---|---|
+| D10 | `tests/unit/test_llamacpp_backend.py:52-132` (6 tests) | Exact-equality pins on the `/load` body (`model_name`, `ctx_size`, `llamacpp_args`, `save_options`, plus `ctx_size=0` asserted as sent and `ctx_size` asserted *absent*) against a patched `_send_request`. **Live check:** `/load` does **not** reject unknown fields — a field could be silently ignored and nothing here would notice. | One live `/load` round-trip sending all four fields, then read ctx back from `/health`. Collapses 6 unit tests into 1 real one. |
+| D11 | `tests/test_lemonade_client.py:1032-1037` | `test_pull_embedding_model_request_shape` asserts `user.` prefix + `checkpoint` + `recipe` + `embedding=true` off a `responses` stub. Its docstring claims it proves validity "per CLAUDE.md" — **it does not**; `responses` accepts any body. (The rule *was* independently confirmed live: `/pull` returns `400 "the model name must include the user. prefix"`.) | Promote to `require_lemonade`. Registering a `user.` model is idempotent. |
+| D12 | `tests/test_lemonade_client.py:873-885` | `test_unload_model_scoped_vs_global` asserts the body and that *no body means unload-everything* — a pure server-side behaviour claim made entirely against a stub. This is the whole #1544 guarantee. | Live: load two models, scoped-unload one, assert the other is still resident in `/health`. |
+| D13 | `tests/unit/chat/ui/test_server.py:166-760` (13 tests) | `@patch("httpx.AsyncClient")` + hand-written `/health` body; `assert data["model_context_size"] == 4096`. Four production files parse that path (`ui/routers/system.py:492,507,528,827`, `ui/server.py:324,347`, `ui/_chat_helpers.py:1207+`). A rename leaves all 13 green while the UI reports the wrong ctx. | Covered by the shared `/health` schema test (P1). |
+| D14 | `tests/unit/test_browser_tools.py:305` | `test_parse_ddg_results` — hand-written DuckDuckGo HTML matching the exact selectors in `web/client.py:855-857`. DDG changes scraped HTML without notice; web search then silently returns zero results and this passes. Only test that exercises the parse at all. | Checked-in dated fixture + a `@pytest.mark.integration` live fetch asserting ≥1 result, so staleness is detectable. |
+| D15 | `tests/unit/test_npu_device_support.py:174` | Amplifier, not a finding on its own: `LemonadeClient.__new__(LemonadeClient)` bypasses `__init__`, so the tests are also blind to how `base_url` is composed — an `/api/v1` prefix change passes. | Construct normally; it makes no network calls at construction. |
+
+### MASKING — the tests that cannot fail
+
+| file:line | test | evidence |
+|---|---|---|
+| `tests/test_lemonade_client.py:2559` | `test_integration_pull_model` | **The only live `/pull` test, and it cannot fail.** `except LemonadeClientError as e: print(...)` with the literal comment `# Don't fail the test - pull might fail for various reasons in test environment`. No `self.fail`. It also pulls `TEST_MODEL`, which CI has already cached — the warm-cache trap from #1655, verbatim. |
+| `tests/test_lemonade_client.py:2183` | `test_integration_health_check_914_format` | Every meaningful check sits inside `if "all_models_loaded" in health:` / `if "ctx_size" in recipe_options:` with `print("⚠️ …")` on the else. If Lemonade moves `ctx_size` again, this prints a warning and **passes** — while the ~32 mocked tests that invent the shape also pass. |
+| `tests/test_lemonade_client.py:2516` | `test_integration_load_model` | Sends the minimal body only. The fields the entire ctx feature rides on are never sent to a real server by any test. |
+| `tests/unit/test_chat_preflight.py` (8) · `test_llamacpp_backend.py:171-314` (9) · `test_lemonade_client_ctx_override.py` (15) | ctx-resolution suites | All hand-build the same unverified `/health` shape. **These are correct as unit tests** — they test decision logic, and mocking is right. They just aren't grounded. One live schema test fixes all 32 without touching them. |
+| `tests/unit/test_init_command.py:765-855, 2000-2045` | init step tests | `_patch_common_steps` stubs `_install_backend` entirely, so `gaia init --profile npu` has **no** end-to-end coverage. (The decision tests around it, incl. `pull_model.assert_not_called()`, are a real #1655 guard — keep those.) |
+| `tests/unit/mcp/client/test_transports.py:68` | `test_send_request_sends_json_rpc` | `stdout` is a `StringIO` with exactly one line that is exactly the matching response. **Verified:** `stdio.py:338` does a bare `readline()` and never correlates the response `id` — the first line back is returned regardless. Real servers interleave notifications. |
+| `tests/unit/connectors/test_router_connectors.py:287-339` | configure/authorize routes | Route is real (`TestClient`, real registry, real grants dir) but the flow is `monkeypatch`ed away. Nobody drives *"user has never connected"* through the HTTP route. |
+| `tests/unit/test_browser_tools.py:840` | `test_search_web_no_results` | Stubs `search_duckduckgo` to return `[]`. The real zero-results path (HTML with no `.result` divs) is never exercised — so a selector break looks identical to "no matches." |
+| `tests/test_lemonade_client.py:2083` · `tests/test_lemonade_embeddings.py` · `tests/test_lemonade_health.py` | gating hygiene | `TestLemonadeClientIntegration` doesn't use `require_lemonade`; with no server up it sets `auto_start=True` and **spawns a real Lemonade on a developer's box**. The other two hard-fail rather than skip. |
+
+### UNNECESSARY
+
+| file:line | evidence |
+|---|---|
+| `tests/unit/installer/test_init_ctx_size.py:93,134,175,225,277` | Five `@patch(... build_start_command)` on a pure stdlib function, then assertions on its return value — asserting the test's own fixture. Drop the patch; call it for real. |
+| `tests/unit/test_lemonade_launcher.py:80,94,114,127,144,294` | `mocker.patch("pathlib.Path.exists", return_value=True)` — a blanket override, so the test cannot distinguish "the canonical path exists" from "every path exists." The macOS tests in the same file already fixed this with `only_these_paths_exist` (`:34`). |
+| `tests/unit/test_lemonade_launcher.py:527-728` (7) | `describe_start_hint` tests patch `resolve_lemonade` wholesale, testing only the rendering half. The file's own better test (`:637`) drives the real probe and explains why. |
+| `tests/unit/test_npu_device_support.py:228-257` | `get_recipe_status` is a two-line dict lookup; the mock does all the work, over an invented `recipes` shape. (**Live-verified:** the real shape *is* `recipes[r].backends[b].state` — source the fixture from a recorded response.) |
+| `tests/unit/connectors/test_mcp_server.py:91-431` | Nine `patch(keyring.set_password)` in a package whose `conftest.py` already installs a real in-memory keyring backend. Redundant and weaker than the fixture it already gets. |
+| `tests/unit/test_lemonade_client_ctx_override.py` | `patch.object(LemonadeClient, "load_model")` without `autospec=True` — the mock accepts any signature. Mechanical fix, catches signature drift. |
+
+### JUSTIFIED — leave alone
+
+Named so nobody "fixes" them: transient-retry tests that mock `time.sleep`; corrupt-download
+repair routing (destructive to provoke, and it asserts control flow, not wire shape);
+`prompt_user_for_delete` patching `isatty`/`input`; `_classify_lemonade_response` and
+`MODELS` registry tests (zero doubles, real invariants); auth-header tests (`Bearer` is an
+HTTP standard, and the no-leak-on-401 test is a real security guard); `test_webui_build.py`
+(a real `npm run build` is multi-minute, and it asserts `shell=False` on every call);
+`test_daemon_dev_anchor_spec.py` (isolates from ambient git state, says so);
+`test_agent_sidecar_manager.py`'s fake `Popen` (asserts the token appears in *neither* env
+nor argv — a security invariant only observable at that seam); `test_transports.py`'s
+Popen patches (the assertion target is `_build_argv`'s tokenizer, which is pure);
+`connectors/test_tokens.py` respx (live Google OAuth is unmockable in CI; only the
+*response* is faked, which is the right boundary); `test_security_edge_cases.py` patching
+`os.path.realpath` (OS primitive, not a service contract).
+
+**The house style already exists — cite these, don't change them:** `test_broker_wiring.py`
+runs a real broker and a real daemon over HTTP and quotes the CLAUDE.md rule verbatim;
+`test_daemon_remedy_commands.py` and `test_sidecar_alive_but_not_serving.py` spawn real
+processes; `test_external_mcp_executable.py` drives real PATHEXT resolution;
+`connectors/test_flow.py` runs the real OAuth flow with a real in-memory keyring and respx
+on the token endpoint only; `hub/agents/email` regenerates its OpenAPI from the real app
+and byte-compares; `connectors-demo`'s `_CapturingGet` asserts real outgoing headers.
+
+---
+
+## 3. Coverage gaps — boundaries with no real test at all
+
+### Lemonade HTTP (18 endpoints)
+
+"Real test?" = would it **fail** if the request shape changed, with no double in the path.
+
+| endpoint | method(s) | real test? | risk if it drifts |
+|---|---|---|---|
+| `POST /install` | `install_backend` | **NO** | **Already realised.** Fix on `fix/npu-flm-backend-install`. |
+| `POST /uninstall` | `uninstall_backend` | **NO** | Backend removal silently 400s. |
+| `GET /system-info` | `get_system_info`, `get_recipe_status` | **NO** | High — `init._install_backend` reads `recipes[r].backends[b].state` to skip install. A move means re-installing every run, or skipping a missing backend and failing later. |
+| `POST /unload` | `unload_model` | **NO** | High — the whole #1544 scoped-unload guarantee is stub-asserted. |
+| `POST /pull` (SSE) | `pull_model_stream` | **NO** | High — the first-run download path. Event/field names are invented; a rename is a silent no-progress hang, which users read as a freeze. |
+| `POST /pull` (JSON) | `pull_model`, `ensure_model_downloaded` | **effectively NO** | Realised once as #1655. |
+| `POST /delete` | `delete_model` | **NO** | Called inside corrupt-model auto-repair; a rejected delete turns a recoverable download into a hard failure. |
+| `POST /load` | `load_model` | **PARTIAL** — minimal body only | High for `ctx_size`/`llamacpp_args`/`save_options`. |
+| `GET /health` | `health_check`, `get_status`, `validate_context_size` | **request yes, response NO** | **High** — see MASKING. |
+| `GET /models?show_all` | `list_models` | **NO** | The `downloaded` flag drives the "already there?" check; a rename means re-pulling every run. |
+| `GET /models/{id}` | `get_model_details` | **no test at all** | Low. |
+| `POST /params` | `set_params` | integration test is `@skip` | **D3 — dead code.** |
+| `POST /completions` | `completions` | **NO** live | Low — legacy. |
+| `POST /embeddings` | `embeddings` | **YES** | Best-covered endpoint in the file. |
+| `POST /chat/completions` | `chat_completions` | **YES** for the base body | Medium residual: `tools=` and `extra_body` have no live coverage — and tool-calling is core to every agent. |
+| `POST /responses`, `GET /stats` | — | **YES** (weak) | Low. |
+| `POST /images/generations` | `generate_image` | **PARTIAL** | Low-medium. |
+
+### Other boundaries
+
+- **Subprocess / argv.** No test would catch a contract change for `LemonadeServer.exe`
+  (D4), `lemond`, or legacy `lemonade-server serve`. **The cheapest gap by far:** the email
+  sidecar argv — the daemon builds `[binary, "--host", H, "--port", P]` (`manager.py:319`)
+  and the sidecar's own argparse (`gaia_agent_email/server.py:316`) is in the same repo.
+  Nothing cross-checks them; a rename breaks the daemon with a fully green suite. A real
+  test is a five-line import.
+- **Windows blind spot.** `tests/integration/test_daemon_sidecars.py` is POSIX-only
+  (`skipif`, `:46`) *and* drives a toy sidecar. On Windows — GAIA's primary platform — no
+  test launches a real supervised sidecar.
+- **MCP.** `tests/mcp/` is genuinely mock-free (verified: zero `unittest.mock` hits) but
+  thin. No test validates a tool's `inputSchema` against a real handshake — the stdio
+  parity test asserts tool *names* only. A tool whose schema drifts from its handler ships
+  uncaught. The HTTP JSON-RPC tests assume a server on :8765 and aren't in default CI.
+- **Connectors — OAuth wire encoding.** The body *builders* are unit-tested for real. What
+  is pinned nowhere is how `tokens.py:236` puts it on the wire: `client.post(url,
+  data=body)` — form-encoded, which Google and Microsoft require. **Change `data=` to
+  `json=` and every test still passes while every real refresh 400s.** That is the
+  `{"spec":…}` bug with the encoding instead of the field names.
+- **UI backend ↔ frontend.** No conformance test. TS types in
+  `apps/webui/src/types/index.ts` are hand-written; only ~31 of ~57 `/api/*` routes declare
+  a `response_model`. The email agent has exactly the right thing
+  (`test_email_openapi_conformance.py`); nothing equivalent guards `/api/*`.
+- **`hub/agents/gaia`.** Its 523-line npm `SPEC.md` has no drift guard, and no test spawns
+  the real stdio agent as a subprocess with the argv the Go TUI passes.
+
+---
+
+## 4. Prioritized top 10
+
+Effort is one engineer, including review.
+
+| # | Action | Fixes | Effort |
+|---|---|---|---|
+| **P1** | **One live `/health` schema test** (`require_lemonade`, unconditional assertions on `all_models_loaded[0].recipe_options.ctx_size`). Also make `test_integration_health_check_914_format` assert instead of print-and-pass. | Grounds **~32 + 13 = 45** mocked tests without rewriting one. D13, 4 MASKING rows. | **2h** |
+| **P2** | **Land the `/install` + `/uninstall` contract test**; delete the payload pins in `test_npu_device_support.py`; keep a pure unit test for `_split_backend_spec`. | D1, D2. Already written. | **1h** |
+| **P3** | **Delete `set_params` and its two tests.** Dead code with a fake test proving it works; no production caller. | D3. | **30m** |
+| **P4** | **Resolve the `LEMONADE_CTX_SIZE` channel.** Confirm on a clean box, then switch to `lemonade config set ctx_size=N` and delete the assertion in all 3 files. #839 is currently inert. | D4 (×3 files, ×5 tests). | **4h** |
+| **P5** | **Add `/autonomy/undo` to the email spec**, and make `test_spec_html_artifact.py` enumerate the real router instead of comparing the generator to itself. | D5 — a live shipped-doc defect. | **2h** |
+| **P6** | **Toy in-repo stdio MCP server fixture** (~40 lines, mirroring `tests/fixtures/toy_sidecar.py`); drive real `StdioTransport` + `MCPClient.connect`. Fix `protocolVersion` to a real date string; send `notifications/initialized`; correlate response `id`. | D6, 2 MASKING rows, the MCP coverage gap. No network, no skip. | **1d** |
+| **P7** | **Make the live `/pull` and `/load` tests capable of failing.** Remove the `# Don't fail the test` swallow; add a cold `user.`-model registration; send all four `/load` fields and read ctx back. | D10, D11, D12, 3 MASKING rows. Also settles empirically whether the ctx-settle machinery is needed. | **4h** |
+| **P8** | **Assert the OAuth body at the wire** — one respx `side_effect` checking `content-type: application/x-www-form-urlencoded` and `parse_qs` contents. Cheapest fix in this report relative to blast radius. | The `data=`/`json=` gap. | **1h** |
+| **P9** | **Cross-check the two in-repo argv contracts** — email sidecar (`build_spawn_command` → the sidecar's own parser) and Go↔Python TUI flags (grep `factory.go`). Both sides are in-repo; no service needed. | D8, the sidecar argv gap. | **3h** |
+| **P10** | **Mechanical pass:** `require_lemonade`/`integration` markers on the three ungated live files (one currently spawns a real server on dev boxes); drop the 5 `build_start_command` mocks; route the 6 blanket `Path.exists` patches through `only_these_paths_exist`; add `autospec=True`; drop the 9 redundant keyring patches. Pure subtraction. | 6 UNNECESSARY rows + gating hygiene. | **3h** |
+
+**Deliberately not recommended:** rewriting the error-classification matrix, the
+corrupt-repair routing tests, or the ctx-resolution decision suites. They assert control
+flow, and mocking is the right tool. The only addition worth making there is one live
+overflow-provocation test so the `n_ctx` field name is grounded.
+
+---
+
+## 5. Would a lint rule stop the next one? Partly — and the obvious rule is too narrow.
+
+**The narrow rule is cheap and nearly noise-free, but has a low ceiling.** Flagging
+`assert_called*_with(...)` that passes a **dict literal** matches exactly **6 sites in 3
+files** across the whole repo — and `test_npu_device_support.py` is two of them. Near-zero
+false positives, and it would have caught the motivating bug.
+
+But it would have caught **only** that one. D10 uses `payload = mock_send.call_args[0][2]`
+then subscripts; D4 asserts an env dict; D3 hides in a `responses.add` fixture. None match.
+
+**The obvious widening is unusable.** Flagging any `.call_args` introspection hits **231
+sites in 66 files**; any `assert_called*` hits **372 in 80**. Gating CI on either means 200+
+suppressions on day one, and a suppression comment nobody reads is worse than no rule.
+
+**Honest recommendation — ship the narrow rule, but don't expect much of it:**
+
+1. **Do add** the dict-literal rule as a CI check now. 6 sites, ~1h, and it names the
+   exact anti-pattern in its error message with a link to the CLAUDE.md section.
+2. **Do add** a cheap structural check with real teeth: any test module that patches a
+   known wire seam (`_send_request`, `responses.add`, `subprocess.Popen`, `httpx.AsyncClient`)
+   **and** asserts an outgoing shape must name a paired contract test in a module-level
+   `CONTRACT_TEST = "tests/integration/..."` constant. Mechanical to enforce, and it puts
+   the burden where it belongs — on the author who knows whether a real test exists.
+3. **Don't** try to lint for MASKING. "This mock hides the cold-start path" is a judgment
+   about what the code *does*, and no AST rule reaches it.
+4. **The highest-value control is not a linter — it's making the existing live tests able
+   to fail.** `# Don't fail the test` and `if "field" in response:` are greppable in about
+   ten seconds and account for the two worst findings in this report. A CI check that
+   rejects a bare `except` without a re-raise or `self.fail` inside `tests/integration/`
+   would be narrow, low-noise, and directly on target.
+
+The durable fix is cultural and already half-landed: the repo has *internalized the
+language* of the rule — `test_pull_embedding_model_request_shape`'s docstring cites
+CLAUDE.md while asserting against a stub — but applied the wrong remedy. Asserting a shape
+harder against a mock is not the fix. Asserting it against the real peer is.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -181,8 +181,19 @@ def lemonade_available():
     Returns:
         bool: True if Lemonade server is available and responding to health checks
     """
+    # Authenticated servers 401 an unauthenticated probe, which reads as "not
+    # running" and silently skips every integration test that asks for one.
+    from gaia.llm.lemonade_client import (
+        lemonade_auth_headers,
+        resolve_lemonade_api_key,
+    )
+
     try:
-        response = requests.get("http://localhost:13305/api/v1/health", timeout=5)
+        response = requests.get(
+            "http://localhost:13305/api/v1/health",
+            timeout=5,
+            headers=lemonade_auth_headers(resolve_lemonade_api_key()),
+        )
         return response.status_code == 200
     except (requests.RequestException, requests.ConnectionError):
         return False

--- a/tests/integration/test_lemonade_health_schema.py
+++ b/tests/integration/test_lemonade_health_schema.py
@@ -1,0 +1,78 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""The ``/health`` response schema, checked against a live server.
+
+Roughly 45 unit tests hand-build Lemonade's health payload and none verify it:
+8 in ``tests/unit/test_chat_preflight.py``, 9 in
+``tests/unit/test_llamacpp_backend.py::TestEnsureModelLoadedCtxResolution``,
+15 in ``tests/unit/test_lemonade_client_ctx_override.py``, and 13 in
+``tests/unit/chat/ui/test_server.py::TestSystemStatus``. Those are fine as unit
+tests -- they exercise decision logic, which is what mocks are for. What was
+missing is anything proving the shape they invent is the shape Lemonade sends.
+
+``ctx_size`` already moved once (Lemonade 9.1.4 relocated it from a top-level
+``context_size`` into ``all_models_loaded[].recipe_options``). If it moves again,
+all 45 stay green while the UI reports the wrong context size and the ctx-pinning
+feature silently breaks.
+
+The pre-existing live test
+(``tests/test_lemonade_client.py::test_integration_health_check_914_format``)
+cannot catch that: every assertion in it sits inside an ``if field in response``
+guard, so a rename prints a warning and passes. This file asserts unconditionally,
+and *skips loudly* rather than passing vacuously when there is nothing to inspect.
+"""
+
+import pytest
+
+from gaia.llm.lemonade_client import LemonadeClient
+
+pytestmark = pytest.mark.integration
+
+# The path every ctx-aware caller walks: ui/routers/system.py, ui/server.py,
+# ui/_chat_helpers.py, and LemonadeClient._ensure_model_loaded.
+CTX_PATH = "all_models_loaded[].recipe_options.ctx_size"
+
+
+@pytest.fixture
+def health(require_lemonade):
+    return LemonadeClient().health_check()
+
+
+def test_health_reports_ok_status(health):
+    assert health.get("status") == "ok", health
+
+
+def test_all_models_loaded_is_present_and_a_list(health):
+    """The 9.1.4+ container the mocked tests assume exists."""
+    assert "all_models_loaded" in health, (
+        f"'all_models_loaded' is gone -- {CTX_PATH} no longer resolves. "
+        f"Every ctx-resolution unit test invents this key. Got: {sorted(health)}"
+    )
+    assert isinstance(health["all_models_loaded"], list), health["all_models_loaded"]
+
+
+def test_loaded_model_entry_carries_the_fields_callers_read(health):
+    """A loaded entry must expose model identity and its context size.
+
+    ``_ensure_model_loaded`` matches on ``id`` *or* ``model_name``, so either is
+    acceptable -- but at least one must be there.
+    """
+    models = health["all_models_loaded"]
+    if not models:
+        pytest.skip("no model resident -- load one to exercise the entry schema")
+
+    entry = models[0]
+    assert "id" in entry or "model_name" in entry, (
+        f"neither 'id' nor 'model_name' present; _ensure_model_loaded matches on "
+        f"these and would reload on every call. Got: {sorted(entry)}"
+    )
+    assert "recipe_options" in entry, (
+        f"'recipe_options' is gone -- {CTX_PATH} no longer resolves. "
+        f"Got: {sorted(entry)}"
+    )
+
+    ctx = entry["recipe_options"].get("ctx_size")
+    assert isinstance(ctx, int) and ctx > 0, (
+        f"{CTX_PATH} is {ctx!r}, expected a positive int. The UI reports this as "
+        f"the context size and the preflight gates on it."
+    )


### PR DESCRIPTION
Four things GAIA sends to an external peer today are rejected or ignored by that peer, and a mocked test asserts each one is correct. `POST /install` and `POST /uninstall` both 400 on a missing `recipe`/`backend`; `POST /params` 400s on every key; `LEMONADE_CTX_SIZE` does not appear anywhere in the shipped Lemonade 11.5.0 install. All four sat green because no test ever asked the only question that matters at a boundary — *would the real thing accept this?*

This lands the audit that found them (already filed as #3318–#3328), plus the two test fixes it produced. The `/health` schema test is the direct guard: roughly 45 unit tests hand-build that payload and none verify it, so when `ctx_size` moved in Lemonade 9.1.4 all 45 stayed green while the UI read the wrong context size.

The third commit is a bug found while verifying this PR. The `lemonade_available` probe sent no `Authorization` header, so an authenticated Lemonade answered 401, the fixture concluded "not running", and all 27 `require_lemonade` usages across 14 files skipped silently. The new schema test skipped vacuously on a machine with a healthy server until this was fixed — the same class of defect as the audit's subject, one step earlier.

## Test plan

- [x] `pytest tests/integration/test_lemonade_health_schema.py` against live Lemonade 11.5.0 on :13305 → **3 passed** (was 3 skipped before the probe fix)
- [x] Same file with no API key → 3 skipped, loudly, not a false pass
- [x] `pytest tests/unit/test_lemonade_client_ctx_override.py tests/unit/test_chat_preflight.py tests/unit/test_no_real_browser_launch.py` — 42 passed
- [x] `pytest tests/unit/connectors tests/unit/eval` — identical results with and without the conftest change (71F/1000P/220E both ways, all pre-existing on main)
- [x] `python util/lint.py --black --isort` — clean
