### PR TITLE
fix(talk,ui): mic echo, dropped talk flags, server stdin hang

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,7 +11,7 @@ PERPLEXITY_API_KEY=
 # MCP Server Configuration
 # Base URL for Lemonade LLM server (used by all agents: code, jira, blender)
 # Include the /api/v1 suffix in the URL
-LEMONADE_BASE_URL=http://localhost:8000/api/v1
+LEMONADE_BASE_URL=http://localhost:13305/api/v1
 # API key for an authenticated remote Lemonade Server
 # (see https://lemonade-server.ai/docs/guide/configuration/#api-key-and-security).
 # Leave empty for local unauthenticated servers.

--- a/docs/guides/talk.mdx
+++ b/docs/guides/talk.mdx
@@ -76,7 +76,9 @@ GAIA's talk mode enables natural voice-based interaction with LLMs using Whisper
     ⠴ Listening...
     ```
 
-    Say "exit" or "quit" to end the session
+    Say "stop" to end the session, or press Ctrl+C.
+
+    <Note>GAIA mutes the microphone while it is speaking, so it never answers its own reply. Wait for it to finish before you speak.</Note>
   </Step>
 </Steps>
 
@@ -84,7 +86,7 @@ GAIA's talk mode enables natural voice-based interaction with LLMs using Whisper
 
 <CardGroup cols={2}>
   <Card title="Exit Session" icon="door-open">
-    Say **"exit"** or **"quit"**
+    Say **"stop"** (or press Ctrl+C)
   </Card>
 
   <Card title="Clear History" icon="rotate-right">
@@ -92,11 +94,11 @@ GAIA's talk mode enables natural voice-based interaction with LLMs using Whisper
   </Card>
 
   <Card title="Trigger Response" icon="pause">
-    Natural pauses (>1 second)
+    Pause longer than `--silence-threshold` (default 0.5 seconds)
   </Card>
 
   <Card title="Stop Playback" icon="stop">
-    Press **Enter** during audio
+    Press **Enter** while GAIA is speaking (terminal only)
   </Card>
 </CardGroup>
 
@@ -138,9 +140,25 @@ Customize your voice interaction experience:
     <Note>If voice detection is not picking up your speech, try lowering the threshold. If it triggers on background noise, raise it.</Note>
   </Tab>
 
+  <Tab title="Model & Backend">
+    ```bash
+    # Use a specific local model and a longer reply budget
+    gaia talk --model Qwen3-Coder-30B-A3B-Instruct-GGUF --max-tokens 1024
+
+    # Point at a Lemonade Server on another host or port
+    gaia talk --base-url http://192.168.1.20:13305/api/v1
+
+    # Use a cloud provider instead of local Lemonade
+    gaia talk --use-claude --claude-model claude-sonnet-4-20250514
+    gaia talk --use-chatgpt --model gpt-4o
+    ```
+
+    <Note>Defaults: `Gemma-4-E4B-it-GGUF`, 512 tokens, local Lemonade. `--use-claude` needs `ANTHROPIC_API_KEY`; `--use-chatgpt` needs `OPENAI_API_KEY` and an explicit `--model`.</Note>
+  </Tab>
+
   <Tab title="Performance Stats">
     ```bash
-    # Show performance statistics
+    # Print performance statistics after each reply (--show-stats also works)
     gaia talk --stats
     ```
   </Tab>

--- a/docs/guides/talk.mdx
+++ b/docs/guides/talk.mdx
@@ -104,6 +104,11 @@ GAIA's talk mode enables natural voice-based interaction with LLMs using Whisper
 
 ## Configuration Options
 
+The microphone stays paused throughout playback. If the output device stalls
+beyond the synthesized audio duration plus five seconds, voice chat reports an
+error and keeps capture paused. Check the output device, then restart voice chat;
+`gaia talk --no-tts` disables spoken output.
+
 Customize your voice interaction experience:
 
 <Tabs>

--- a/docs/reference/cli.mdx
+++ b/docs/reference/cli.mdx
@@ -973,15 +973,21 @@ gaia talk [OPTIONS]
 
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
-| `--model` | string | auto | Model ID to use (default: auto-selected by each agent) |
-| `--max-tokens` | integer | 512 | Maximum tokens to generate |
+| `--model` | string | `Gemma-4-E4B-it-GGUF` | Model for the conversation (also what the Lemonade pre-flight loads). Required with `--use-chatgpt` |
+| `--max-tokens` | integer | 512 | Maximum tokens per reply |
+| `--use-claude` | flag | false | Use the Claude API instead of local Lemonade (needs `ANTHROPIC_API_KEY`) |
+| `--use-chatgpt` | flag | false | Use the OpenAI API instead of local Lemonade (needs `OPENAI_API_KEY` and `--model`) |
+| `--claude-model` | string | claude-sonnet-4-20250514 | Claude model, used with `--use-claude` |
+| `--base-url` | string | `LEMONADE_BASE_URL` or `http://localhost:13305/api/v1` | Lemonade server URL |
 | `--no-tts` | flag | false | Disable text-to-speech |
 | `--audio-device-index` | integer | auto-detect | Audio input device index |
 | `--whisper-model-size` | string | base | Whisper model [tiny, base, small, medium, large] |
-| `--silence-threshold` | float | 0.5 | Silence threshold in seconds |
+| `--silence-threshold` | float | 0.5 | Seconds of silence that end your turn |
 | `--mic-threshold` | float | 0.003 | Microphone amplitude threshold for voice detection (lower = more sensitive) |
-| `--stats` | flag | false | Show performance statistics |
+| `--stats`, `--show-stats` | flag | false | Print performance statistics after each reply |
 | `--index, -i` | path | - | PDF document for voice Q&A |
+
+The microphone is muted while GAIA speaks. Say "stop" or press Ctrl+C to end the session; `gaia talk` exits non-zero if the voice loop or microphone fails.
 
 **Examples:**
 
@@ -996,6 +1002,10 @@ gaia talk --index manual.pdf
 
 ```bash No TTS
 gaia talk -i guide.pdf --no-tts
+```
+
+```bash Model
+gaia talk --model Qwen3-Coder-30B-A3B-Instruct-GGUF --max-tokens 1024
 ```
 </CodeGroup>
 

--- a/docs/spec/audio-client.mdx
+++ b/docs/spec/audio-client.mdx
@@ -124,6 +124,9 @@ class AudioClient:
         """
         Process transcribed voice input and get AI response.
 
+        Capture stays paused until streamed playback has fully finished;
+        transcriptions queued meanwhile are discarded before capture resumes.
+
         Args:
             text: Transcribed text to process
             get_stats_callback: Optional callback for performance stats
@@ -136,6 +139,9 @@ class AudioClient:
         Returns once playback has finished. The microphone is paused for the
         whole utterance and anything transcribed meanwhile is discarded, so
         the assistant never hears its own reply as the next user turn.
+        Playback cleanup is bounded by synthesized audio duration plus five
+        seconds. On a device timeout, the call raises and capture stays paused;
+        restart voice chat after checking the output device.
         """
         pass
 

--- a/docs/spec/audio-client.mdx
+++ b/docs/spec/audio-client.mdx
@@ -82,6 +82,9 @@ class AudioClient:
         use_claude=False,
         use_chatgpt=False,
         system_prompt=None,
+        model=None,
+        claude_model="claude-sonnet-5",
+        base_url=None,
     ):
         """
         Initialize audio client.
@@ -97,6 +100,9 @@ class AudioClient:
             use_claude: Use Claude API for LLM
             use_chatgpt: Use ChatGPT API for LLM
             system_prompt: Default system prompt for LLM
+            model: Model ID for the local/OpenAI provider (None = provider default)
+            claude_model: Claude model ID, used when use_claude=True
+            base_url: Lemonade server URL (None = LEMONADE_BASE_URL or default)
         """
         pass
 
@@ -125,7 +131,12 @@ class AudioClient:
         pass
 
     async def speak_text(self, text: str):
-        """Speak text using TTS."""
+        """Speak text using TTS.
+
+        Returns once playback has finished. The microphone is paused for the
+        whole utterance and anything transcribed meanwhile is discarded, so
+        the assistant never hears its own reply as the next user turn.
+        """
         pass
 
     async def halt_generation(self):

--- a/docs/spec/talk-sdk.mdx
+++ b/docs/spec/talk-sdk.mdx
@@ -134,6 +134,8 @@ class TalkConfig:
     # General settings
     use_claude: bool = False
     use_chatgpt: bool = False
+    claude_model: str = "claude-sonnet-5"  # Used when use_claude=True
+    base_url: Optional[str] = None         # Lemonade URL (None = LEMONADE_BASE_URL)
     show_stats: bool = False
     logging_level: str = "INFO"
 
@@ -414,6 +416,8 @@ def __init__(self, config: Optional[TalkConfig] = None):
         logging_level=self.config.logging_level,
         use_claude=self.config.use_claude,
         use_chatgpt=self.config.use_chatgpt,
+        claude_model=self.config.claude_model,
+        base_url=self.config.base_url,
     )
     self.chat_sdk = AgentSDK(chat_config)
 
@@ -422,11 +426,15 @@ def __init__(self, config: Optional[TalkConfig] = None):
         whisper_model_size=self.config.whisper_model_size,
         audio_device_index=self.config.audio_device_index,
         silence_threshold=self.config.silence_threshold,
+        mic_threshold=self.config.mic_threshold,
         enable_tts=self.config.enable_tts,
         logging_level=self.config.logging_level,
         use_claude=self.config.use_claude,
         use_chatgpt=self.config.use_chatgpt,
         system_prompt=self.config.system_prompt,
+        model=self.config.model,
+        claude_model=self.config.claude_model,
+        base_url=self.config.base_url,
     )
 
     self.show_stats = self.config.show_stats

--- a/hub/agents/chat/python/gaia_agent_chat/agent.py
+++ b/hub/agents/chat/python/gaia_agent_chat/agent.py
@@ -247,6 +247,7 @@ class ChatAgent(
             config.allowed_paths,
             on_prompt_start=lambda: self.console.pause_progress(),  # pylint: disable=unnecessary-lambda
             on_prompt_end=lambda: self.console.resume_progress(),  # pylint: disable=unnecessary-lambda
+            interactive_check=self._console_accepts_stdin_prompts,
         )
 
         # Store config for access in other methods

--- a/src/gaia/agents/base/agent.py
+++ b/src/gaia/agents/base/agent.py
@@ -1301,6 +1301,16 @@ Do NOT wrap conversational replies in JSON.
             return SilentConsole(silence_final_answer=silence_final_answer)
         return AgentConsole()
 
+    def _console_accepts_stdin_prompts(self) -> bool:
+        """True when a blocking ``input()`` on this process reaches the requester.
+
+        Server-side consoles (SSE, API) share the operator's stdin but not the
+        user, so prompting there hangs the request instead of asking anyone.
+        """
+        return bool(
+            getattr(getattr(self, "console", None), "supports_stdin_prompts", False)
+        )
+
     @abc.abstractmethod
     def _register_tools(self):
         """
@@ -6787,10 +6797,14 @@ Do NOT wrap conversational replies in JSON.
                 self.console.print_warning(max_steps_msg)
 
                 # Ask user if they want to continue (skip in silent mode OR if stdin is not available)
-                # IMPORTANT: Never call input() in API/CI contexts to avoid blocking threads
+                # A server's TTY says nothing about the requester; ask the console.
                 import sys
 
-                has_stdin = sys.stdin and sys.stdin.isatty()
+                has_stdin = (
+                    self._console_accepts_stdin_prompts()
+                    and sys.stdin
+                    and sys.stdin.isatty()
+                )
                 if has_stdin and not (
                     hasattr(self, "silent_mode") and self.silent_mode
                 ):

--- a/src/gaia/agents/base/console.py
+++ b/src/gaia/agents/base/console.py
@@ -693,6 +693,8 @@ class TerminalConfirmationMixin:
     ``auto_approve_confirmations_enabled`` / progress hooks this relies on.
     """
 
+    supports_stdin_prompts: bool = True
+
     CONFIRMATION_PROMPT = "Allow this? [y]es / [N]o / [a]lways for this tool: "
     CONFIRMATION_PROMPT_NO_ALWAYS = "Allow this? [y]es / [N]o: "
 
@@ -850,8 +852,6 @@ class AgentConsole(TerminalConfirmationMixin, OutputHandler):
     Confirmation-gated tools prompt on the terminal when stdin is interactive and
     are denied otherwise (#2210) — see ``confirm_tool_execution``.
     """
-
-    supports_stdin_prompts: bool = True
 
     def __init__(self, auto_approve_gated_tools: bool = False):
         """Initialize the AgentConsole with appropriate display capabilities.

--- a/src/gaia/agents/base/console.py
+++ b/src/gaia/agents/base/console.py
@@ -199,6 +199,14 @@ class OutputHandler(ABC):
     blocking_confirmation: bool = False
     """Whether ``confirm_tool_execution`` waits for an explicit user decision."""
 
+    supports_stdin_prompts: bool = False
+    """Whether the person driving this handler is on the *process's* stdin.
+
+    A server-side handler shares the process stdin with the operator but not
+    with the requester, so a blocking ``input()`` there hangs the request
+    forever while stealing the operator's keystrokes.
+    """
+
     auto_approve_gated_tools: bool = False
     """Explicit opt-in: approve confirmation-gated tools with no human present.
 
@@ -842,6 +850,8 @@ class AgentConsole(TerminalConfirmationMixin, OutputHandler):
     Confirmation-gated tools prompt on the terminal when stdin is interactive and
     are denied otherwise (#2210) — see ``confirm_tool_execution``.
     """
+
+    supports_stdin_prompts: bool = True
 
     def __init__(self, auto_approve_gated_tools: bool = False):
         """Initialize the AgentConsole with appropriate display capabilities.

--- a/src/gaia/audio/audio_client.py
+++ b/src/gaia/audio/audio_client.py
@@ -3,6 +3,7 @@
 
 import asyncio
 import queue
+import sys
 import threading
 import time
 
@@ -49,6 +50,9 @@ class AudioClient:
         use_claude=False,
         use_chatgpt=False,
         system_prompt=None,
+        model=None,
+        claude_model="claude-sonnet-5",
+        base_url=None,
     ):
         self.log = get_logger(__name__)
         self.log.setLevel(getattr(__import__("logging"), logging_level))
@@ -66,11 +70,17 @@ class AudioClient:
         self.whisper_asr = None
         self.transcription_queue = queue.Queue()
         self.tts = None
+        # One Enter-to-interrupt listener per process, shared by every reply.
+        self._playback_interrupt = threading.Event()
+        self._stdin_listener = None
+        self._voice_loop_error = None
 
         # Initialize LLM client - factory auto-detects provider from flags
         self.llm_client = create_client(
             use_claude=use_claude,
             use_openai=use_chatgpt,
+            model=claude_model if use_claude else model,
+            base_url=base_url,
             system_prompt=system_prompt,
         )
 
@@ -80,12 +90,15 @@ class AudioClient:
         """Start a voice-based chat session."""
         try:
             self.log.debug("Initializing voice chat...")
-            print(
+            self._voice_loop_error = None
+            banner = (
                 "Starting voice chat.\n"
                 "Say 'stop' to quit application "
-                "or 'restart' to clear the chat history.\n"
-                "Press Enter key to stop during audio playback."
+                "or 'restart' to clear the chat history."
             )
+            if self.enable_tts and self._start_stdin_listener():
+                banner += "\nPress Enter to stop audio playback."
+            print(banner)
 
             # Initialize TTS before starting voice chat
             self.initialize_tts()
@@ -141,6 +154,17 @@ class AudioClient:
                         break
                     await asyncio.sleep(0.1)
 
+                if (
+                    self._voice_loop_error is None
+                    and self.whisper_asr
+                    and self.whisper_asr.capture_failed is True
+                ):
+                    self._voice_loop_error = RuntimeError(
+                        "Microphone capture stopped unexpectedly. List devices with "
+                        "`gaia test --test-type asr-list-audio-devices`, then pick one "
+                        "with `gaia talk --audio-device-index <N>`."
+                    )
+
             except KeyboardInterrupt:
                 self.log.info("Received keyboard interrupt")
                 print("\nStopping voice chat...")
@@ -167,13 +191,17 @@ class AudioClient:
                 self.whisper_asr.stop_recording()
                 self.log.info("Voice recording stopped")
 
+        if self._voice_loop_error is not None:
+            raise self._voice_loop_error
+
     async def process_voice_input(self, text, get_stats_callback=None):
         """Process transcribed voice input and get AI response"""
 
         # Initialize TTS streaming
         text_queue = None
         tts_finished = threading.Event()  # Add event to track TTS completion
-        interrupt_event = threading.Event()  # Add event for keyboard interrupts
+        interrupt_event = self._playback_interrupt
+        interrupt_event.clear()
 
         try:
             # Check if we're currently generating and halt if needed
@@ -191,24 +219,8 @@ class AudioClient:
             self.log.debug(f"Sending message to LLM: {text[:50]}...")
             print("\nGaia: ", end="", flush=True)
 
-            # Keyboard listener thread for both generation and playback
-            def keyboard_listener():
-                input()  # Wait for any input
-
-                # Use LLMClient to halt generation
-                if self.llm_client.halt_generation():
-                    print("\nGeneration interrupted.")
-                else:
-                    print("\nInterrupt requested.")
-
-                interrupt_event.set()
-                if text_queue:
-                    text_queue.put("__HALT__")  # Signal TTS to stop immediately
-
-            # Start keyboard listener thread
-            keyboard_thread = threading.Thread(target=keyboard_listener)
-            keyboard_thread.daemon = True
-            keyboard_thread.start()
+            # Enter interrupts generation and playback (one listener per session).
+            self._start_stdin_listener()
 
             if self.enable_tts:
                 text_queue = queue.Queue(maxsize=100)
@@ -295,7 +307,6 @@ class AudioClient:
             finally:
                 if self.tts_thread and self.tts_thread.is_alive():
                     self.tts_thread.join(timeout=1.0)  # Add timeout to thread join
-                keyboard_thread.join(timeout=1.0)  # Add timeout to keyboard thread join
 
             print("\n")
             # Get performance stats from LLMClient
@@ -342,27 +353,112 @@ class AudioClient:
                     f'Failed to initialize TTS:\n{e}\nInstall talk dependencies with: uv pip install ".[talk]"\nYou can also use --no-tts option to disable TTS'
                 )
 
+    def _start_stdin_listener(self) -> bool:
+        """Start the session's single Enter-to-interrupt listener (terminal only)."""
+        if self._stdin_listener is not None:
+            return True
+        try:
+            interactive = sys.stdin is not None and sys.stdin.isatty()
+        except (AttributeError, ValueError):
+            interactive = False
+        if not interactive:
+            return False
+
+        def listen():
+            while True:
+                try:
+                    input()
+                except (EOFError, OSError):
+                    self.log.debug("stdin closed; Enter-to-interrupt disabled")
+                    return
+                self._playback_interrupt.set()
+                if (
+                    self.llm_client.is_generating()
+                    and self.llm_client.halt_generation()
+                ):
+                    print("\nGeneration interrupted.")
+
+        self._stdin_listener = threading.Thread(
+            target=listen, name="gaia-talk-stdin", daemon=True
+        )
+        self._stdin_listener.start()
+        return True
+
+    def _drain_transcription_queue(self) -> None:
+        """Discard whatever was transcribed while the assistant was speaking."""
+        dropped = 0
+        while True:
+            try:
+                self.transcription_queue.get_nowait()
+                dropped += 1
+            except queue.Empty:
+                break
+        if dropped:
+            self.log.debug(
+                "Dropped %d transcription(s) captured during playback", dropped
+            )
+
     async def speak_text(self, text: str) -> None:
-        """Speak text using initialized TTS, if available."""
+        """Speak text using initialized TTS, if available.
+
+        Returns only once playback has finished. The microphone stays paused
+        for the whole utterance and anything transcribed meanwhile is dropped
+        -- otherwise the assistant hears itself and answers its own reply.
+        """
         if not self.enable_tts:
             return
         if not getattr(self, "tts", None):
             self.log.debug("TTS is not initialized; skipping speak_text")
             return
+
         # Reuse the streaming path used in process_voice_input
         text_queue = queue.Queue(maxsize=100)
-        interrupt_event = threading.Event()
-        tts_thread = threading.Thread(
-            target=self.tts.generate_speech_streaming,
-            args=(text_queue,),
-            kwargs={"interrupt_event": interrupt_event},
-            daemon=True,
-        )
-        tts_thread.start()
-        # Send the whole text and end
-        text_queue.put(text)
-        text_queue.put("__END__")
-        tts_thread.join(timeout=5.0)
+        interrupt_event = self._playback_interrupt
+        interrupt_event.clear()  # drop an Enter pressed between replies
+
+        def tts_status_callback(is_speaking: bool) -> None:
+            # Resuming is left to the finally below, after the queue is drained.
+            self.is_speaking = is_speaking
+
+        tts_errors = []
+
+        def run_tts() -> None:
+            try:
+                self.tts.generate_speech_streaming(
+                    text_queue,
+                    status_callback=tts_status_callback,
+                    interrupt_event=interrupt_event,
+                )
+            except Exception as e:  # re-raised on the caller's thread below
+                tts_errors.append(e)
+
+        # Pause before the thread starts: synthesis latency would otherwise
+        # leave the mic live with the reply already queued.
+        if self.whisper_asr:
+            self.whisper_asr.pause_recording()
+        self.is_speaking = True
+        try:
+            tts_thread = threading.Thread(target=run_tts, daemon=True)
+            self.tts_thread = tts_thread
+            tts_thread.start()
+            # Send the whole text and end
+            text_queue.put(text)
+            text_queue.put("__END__")
+            # Full join. A timeout here resumes the mic mid-sentence, which is
+            # exactly the self-transcription this method exists to prevent.
+            tts_thread.join()
+            if tts_errors:
+                raise RuntimeError(
+                    f"Text-to-speech failed while speaking: {tts_errors[0]}. "
+                    "Run `gaia test --test-type tts-streaming` to check audio "
+                    "output, or use `gaia talk --no-tts`."
+                ) from tts_errors[0]
+        finally:
+            # Always resume -- a crash here must not leave the microphone dead.
+            self.is_speaking = False
+            self._drain_transcription_queue()
+            if self.whisper_asr:
+                self.whisper_asr.resume_recording()
 
     def _check_mic_levels(self):
         """Brief microphone level check at startup to verify audio capture."""
@@ -514,7 +610,13 @@ class AudioClient:
                         )
 
         except Exception as e:
-            self.log.error(f"Error in process_audio_wrapper: {str(e)}")
+            self.log.error(f"Error in process_audio_wrapper: {e}", exc_info=True)
+            error = RuntimeError(
+                f"Voice chat stopped: the voice loop crashed ({type(e).__name__}: {e}). "
+                "See the log above for the full traceback."
+            )
+            error.__cause__ = e
+            self._voice_loop_error = error
         finally:
             if self.whisper_asr:
                 self.whisper_asr.stop_recording()

--- a/src/gaia/audio/audio_client.py
+++ b/src/gaia/audio/audio_client.py
@@ -199,7 +199,8 @@ class AudioClient:
 
         # Initialize TTS streaming
         text_queue = None
-        tts_finished = threading.Event()  # Add event to track TTS completion
+        tts_thread = None
+        tts_errors = []
         interrupt_event = self._playback_interrupt
         interrupt_event.clear()
 
@@ -223,30 +224,26 @@ class AudioClient:
             self._start_stdin_listener()
 
             if self.enable_tts:
-                text_queue = queue.Queue(maxsize=100)
+                text_queue = queue.Queue()
 
                 # Define status callback to update speaking state
                 def tts_status_callback(is_speaking):
                     self.is_speaking = is_speaking
-                    if not is_speaking:  # When TTS finishes speaking
-                        tts_finished.set()
-                        if self.whisper_asr:
-                            self.whisper_asr.resume_recording()
-                    else:  # When TTS starts speaking
-                        if self.whisper_asr:
-                            self.whisper_asr.pause_recording()
                     self.log.debug(f"TTS speaking state: {is_speaking}")
 
-                self.tts_thread = threading.Thread(
-                    target=self.tts.generate_speech_streaming,
-                    args=(text_queue,),
-                    kwargs={
-                        "status_callback": tts_status_callback,
-                        "interrupt_event": interrupt_event,
-                    },
-                    daemon=True,
-                )
-                self.tts_thread.start()
+                def run_tts():
+                    try:
+                        self.tts.generate_speech_streaming(
+                            text_queue,
+                            status_callback=tts_status_callback,
+                            interrupt_event=interrupt_event,
+                        )
+                    except Exception as error:
+                        tts_errors.append(error)
+
+                tts_thread = threading.Thread(target=run_tts, daemon=True)
+                self.tts_thread = tts_thread
+                tts_thread.start()
 
             # Use LLMClient streaming instead of WebSocket
             accumulated_response = ""
@@ -304,9 +301,6 @@ class AudioClient:
                 if text_queue:
                     text_queue.put("__END__")
                 raise e
-            finally:
-                if self.tts_thread and self.tts_thread.is_alive():
-                    self.tts_thread.join(timeout=1.0)  # Add timeout to thread join
 
             print("\n")
             # Get performance stats from LLMClient
@@ -331,14 +325,22 @@ class AudioClient:
                 text_queue.put("__END__")
             raise e
         finally:
-            if self.tts_thread and self.tts_thread.is_alive():
-                # Wait for TTS to finish before resuming recording
-                tts_finished.wait(timeout=2.0)  # Add reasonable timeout
-                self.tts_thread.join(timeout=1.0)
-
-            # Only resume recording after TTS is completely finished
-            if self.whisper_asr:
+            if tts_thread and tts_thread.is_alive():
+                text_queue.put("__END__")
+                tts_thread.join()
+            self.is_speaking = False
+            self._drain_transcription_queue()
+            # A timed-out device may still be playing; keep capture muted.
+            if self.whisper_asr and not any(
+                isinstance(error, TimeoutError) for error in tts_errors
+            ):
                 self.whisper_asr.resume_recording()
+            if tts_errors:
+                raise RuntimeError(
+                    f"Text-to-speech failed: {tts_errors[0]}. "
+                    "Run `gaia test --test-type tts-streaming` to check audio "
+                    "output, or use `gaia talk --no-tts`."
+                ) from tts_errors[0]
 
     def initialize_tts(self):
         """Initialize TTS if enabled."""
@@ -454,10 +456,11 @@ class AudioClient:
                     "output, or use `gaia talk --no-tts`."
                 ) from tts_errors[0]
         finally:
-            # Always resume -- a crash here must not leave the microphone dead.
             self.is_speaking = False
             self._drain_transcription_queue()
-            if self.whisper_asr:
+            if self.whisper_asr and not any(
+                isinstance(error, TimeoutError) for error in tts_errors
+            ):
                 self.whisper_asr.resume_recording()
 
     def _check_mic_levels(self):

--- a/src/gaia/audio/audio_recorder.py
+++ b/src/gaia/audio/audio_recorder.py
@@ -44,7 +44,7 @@ class AudioRecorder:
         self.device_index = (
             self._get_default_input_device() if device_index is None else device_index
         )
-        self.is_recording = False
+        self._is_recording = False
         self.audio_queue = queue.Queue()
         self.stream = None  # Add stream as class attribute
 
@@ -56,6 +56,31 @@ class AudioRecorder:
         # New attributes for pause functionality
         self.is_paused = False
         self.pause_lock = threading.Lock()
+
+    @property
+    def is_recording(self) -> bool:
+        """True only while the capture thread is actually alive.
+
+        A device error breaks out of ``_record_audio`` without unsetting the
+        flag, so callers polling a plain attribute wait on "Listening..."
+        forever after the microphone dies.
+        """
+        if not self._is_recording:
+            return False
+        return self.record_thread is None or self.record_thread.is_alive()
+
+    @is_recording.setter
+    def is_recording(self, value: bool) -> None:
+        self._is_recording = bool(value)
+
+    @property
+    def capture_failed(self) -> bool:
+        """True when capture was never asked to stop but its thread has died."""
+        return (
+            self._is_recording
+            and self.record_thread is not None
+            and not self.record_thread.is_alive()
+        )
 
     def _get_default_input_device(self):
         """Get the default input device index."""
@@ -100,11 +125,17 @@ class AudioRecorder:
 
             while self.is_recording:
                 try:
-                    # Skip recording if paused
                     with self.pause_lock:
-                        if self.is_paused:
-                            time.sleep(0.1)
-                            continue
+                        paused = self.is_paused
+                    if paused:
+                        # Keep draining the device and throw the frames away.
+                        # Not reading lets the input ring buffer hand us the
+                        # assistant's own speech the moment we resume.
+                        self.stream.read(self.CHUNK)
+                        speech_buffer = np.array([], dtype=np.float32)
+                        self.is_speaking = False
+                        silence_counter = 0
+                        continue
 
                     frames, _ = self.stream.read(self.CHUNK)
                     data = frames[:, 0].copy()  # Extract mono channel
@@ -207,6 +238,9 @@ class AudioRecorder:
             self.log.warning("Recording is already in progress")
             return
 
+        # Drop the previous session's dead thread before arming the flag --
+        # ``is_recording`` reads thread liveness.
+        self.record_thread = None
         # Set recording flag before starting threads
         self.is_recording = True
 

--- a/src/gaia/audio/kokoro_tts.py
+++ b/src/gaia/audio/kokoro_tts.py
@@ -343,25 +343,26 @@ class KokoroTTS:
 
         # Playback thread function
         def audio_playback_thread():
+            playing = True
             try:
                 while True:
                     try:
                         audio_chunk = audio_buffer.get(timeout=0.1)
-                        if audio_chunk is None:  # Exit signal
-                            if status_callback:
-                                status_callback(False)
-                            break
-                        if interrupt_event and interrupt_event.is_set():
-                            break
-                        if status_callback:
-                            status_callback(True)
-                        stream.write(np.array(audio_chunk, dtype=np.float32))
                     except queue.Empty:
                         continue
-            except Exception as e:
-                self.log.error(f"Error in playback thread: {e}")
-                if status_callback:
-                    status_callback(False)
+                    if audio_chunk is None:  # Exit signal
+                        break
+                    # Keep draining after an interrupt or device error: the
+                    # synthesis side blocks on a full buffer otherwise.
+                    if not playing or (interrupt_event and interrupt_event.is_set()):
+                        continue
+                    if status_callback:
+                        status_callback(True)
+                    try:
+                        stream.write(np.array(audio_chunk, dtype=np.float32))
+                    except Exception as e:
+                        self.log.error(f"Error in playback thread: {e}", exc_info=True)
+                        playing = False
             finally:
                 stream.stop()
                 stream.close()
@@ -415,7 +416,8 @@ class KokoroTTS:
             self.log.error(f"Error in streaming: {e}")
         finally:
             audio_buffer.put(None)  # Ensure playback thread exits
-            playback_thread.join(timeout=2.0)
+            # Synthesis outruns playback; return only once the audio has played.
+            playback_thread.join()
 
     def set_voice(self, voice_name: str) -> None:
         """Change the current voice."""

--- a/src/gaia/audio/kokoro_tts.py
+++ b/src/gaia/audio/kokoro_tts.py
@@ -28,6 +28,7 @@ from gaia.logger import get_logger
 
 class KokoroTTS:
     log = get_logger(__name__)
+    PLAYBACK_TIMEOUT_SLACK = 5.0
 
     def __init__(self):
         # Check for required dependencies
@@ -329,6 +330,21 @@ class KokoroTTS:
         self.log.debug("Starting speech streaming")
         buffer = ""
         audio_buffer = queue.Queue(maxsize=100)  # Buffer for processed audio chunks
+        audio_duration = 0.0
+        playback_errors = []
+        stop_playback = threading.Event()
+
+        def enqueue_audio(audio):
+            nonlocal audio_duration
+            audio_duration += len(audio) / 24000
+            try:
+                audio_buffer.put(
+                    audio, timeout=audio_duration + self.PLAYBACK_TIMEOUT_SLACK
+                )
+            except queue.Full as error:
+                raise TimeoutError(
+                    "Audio output stalled while buffering playback"
+                ) from error
 
         # Initialize audio stream
         stream = sd.OutputStream(
@@ -345,7 +361,7 @@ class KokoroTTS:
         def audio_playback_thread():
             playing = True
             try:
-                while True:
+                while not stop_playback.is_set():
                     try:
                         audio_chunk = audio_buffer.get(timeout=0.1)
                     except queue.Empty:
@@ -361,13 +377,22 @@ class KokoroTTS:
                     try:
                         stream.write(np.array(audio_chunk, dtype=np.float32))
                     except Exception as e:
-                        self.log.error(f"Error in playback thread: {e}", exc_info=True)
+                        playback_errors.append(e)
                         playing = False
+            except Exception as e:
+                playback_errors.append(e)
             finally:
-                stream.stop()
-                stream.close()
-                if status_callback:
-                    status_callback(False)
+                try:
+                    stream.stop()
+                except Exception as e:
+                    playback_errors.append(e)
+                finally:
+                    try:
+                        stream.close()
+                        if status_callback:
+                            status_callback(False)
+                    except Exception as e:
+                        playback_errors.append(e)
 
         # Start playback thread
         playback_thread = threading.Thread(target=audio_playback_thread)
@@ -377,6 +402,8 @@ class KokoroTTS:
         try:
             while True:
                 try:
+                    if interrupt_event and interrupt_event.is_set():
+                        break
                     chunk = text_queue.get(timeout=0.1)
 
                     if chunk == "__END__" or (
@@ -387,9 +414,8 @@ class KokoroTTS:
                             processed_text = self.preprocess_text(buffer.strip())
                             if processed_text:  # Only process if there's actual text
                                 self.generate_speech(
-                                    processed_text, stream_callback=audio_buffer.put
+                                    processed_text, stream_callback=enqueue_audio
                                 )
-                        audio_buffer.put(None)  # Signal playback thread to exit
                         break
 
                     buffer += chunk
@@ -405,19 +431,34 @@ class KokoroTTS:
                             processed_text = self.preprocess_text(text_to_process)
                             if processed_text:  # Double check after preprocessing
                                 self.generate_speech(
-                                    processed_text, stream_callback=audio_buffer.put
+                                    processed_text, stream_callback=enqueue_audio
                                 )
                         buffer = sentences[-1]
 
                 except queue.Empty:
                     continue
 
-        except Exception as e:
-            self.log.error(f"Error in streaming: {e}")
         finally:
-            audio_buffer.put(None)  # Ensure playback thread exits
-            # Synthesis outruns playback; return only once the audio has played.
-            playback_thread.join()
+            deadline = time.monotonic() + audio_duration + self.PLAYBACK_TIMEOUT_SLACK
+            try:
+                audio_buffer.put(None, timeout=max(0, deadline - time.monotonic()))
+            except queue.Full as error:
+                stop_playback.set()
+                raise TimeoutError(
+                    "Audio output stalled while finishing playback"
+                ) from error
+            playback_thread.join(timeout=max(0, deadline - time.monotonic()))
+            if playback_thread.is_alive():
+                stop_playback.set()
+                raise TimeoutError(
+                    "Audio playback exceeded its duration plus cleanup allowance; "
+                    "microphone remains paused. Restart voice chat after checking "
+                    "the output device."
+                )
+            if playback_errors:
+                raise RuntimeError(
+                    f"Audio playback failed: {playback_errors[0]}"
+                ) from playback_errors[0]
 
     def set_voice(self, voice_name: str) -> None:
         """Change the current voice."""

--- a/src/gaia/audio/whisper_asr.py
+++ b/src/gaia/audio/whisper_asr.py
@@ -134,6 +134,10 @@ class WhisperAsr(AudioRecorder):
             while self.is_recording:
                 try:
                     frames, _ = self.stream.read(self.CHUNK)
+                    with self.pause_lock:
+                        if self.is_paused:
+                            audio_buffer = np.array([], dtype=np.float32)
+                            continue
                     data = frames[:, 0].copy()  # Extract mono channel
                     audio_buffer = np.concatenate((audio_buffer, data))
 
@@ -163,7 +167,7 @@ class WhisperAsr(AudioRecorder):
                     break
 
             # Process any remaining audio
-            if len(audio_buffer) > self.RATE * 0.5:  # At least 0.5 seconds
+            if not self.is_paused and len(audio_buffer) > self.RATE * 0.5:
                 self.audio_queue.put(audio_buffer.copy())
 
         finally:

--- a/src/gaia/audio/whisper_asr.py
+++ b/src/gaia/audio/whisper_asr.py
@@ -173,6 +173,7 @@ class WhisperAsr(AudioRecorder):
 
     def start_recording_streaming(self):
         """Start recording in streaming mode."""
+        self.record_thread = None
         self.is_recording = True
         self.record_thread = threading.Thread(target=self._record_audio_streaming)
         self.record_thread.start()

--- a/src/gaia/cli.py
+++ b/src/gaia/cli.py
@@ -763,6 +763,13 @@ async def async_main(action, **kwargs):
         index_file = kwargs.get("index")
         rag_documents = [index_file] if index_file else None
 
+        if kwargs.get("use_chatgpt") and not kwargs.get("model"):
+            raise ValueError(
+                "gaia talk --use-chatgpt needs --model <openai-model-id> "
+                "(for example --model gpt-4o); the default model is a local "
+                "Lemonade model the OpenAI API does not serve."
+            )
+
         config = TalkConfig(
             whisper_model_size=kwargs.get("whisper_model_size", "base"),
             audio_device_index=kwargs.get(
@@ -772,10 +779,18 @@ async def async_main(action, **kwargs):
             mic_threshold=kwargs.get("mic_threshold", 0.003),
             enable_tts=not kwargs.get("no_tts", False),
             system_prompt=None,  # Could add this as a parameter later
-            show_stats=kwargs.get("stats", False),
+            # ``--stats``/``--show-stats`` land on dest ``show_stats``.
+            show_stats=kwargs.get("show_stats", False),
             logging_level=kwargs.get(
                 "logging_level", "INFO"
             ),  # Back to INFO now that issues are fixed
+            # LLM backend selection (#124)
+            model=kwargs.get("model") or DEFAULT_MODEL_NAME,
+            max_tokens=kwargs.get("max_tokens", 512),
+            use_claude=kwargs.get("use_claude", False),
+            use_chatgpt=kwargs.get("use_chatgpt", False),
+            claude_model=kwargs.get("claude_model", "claude-sonnet-5"),
+            base_url=lemonade_base_url,
             # RAG configuration
             rag_documents=rag_documents,
         )

--- a/src/gaia/cli.py
+++ b/src/gaia/cli.py
@@ -789,7 +789,7 @@ async def async_main(action, **kwargs):
             max_tokens=kwargs.get("max_tokens", 512),
             use_claude=kwargs.get("use_claude", False),
             use_chatgpt=kwargs.get("use_chatgpt", False),
-            claude_model=kwargs.get("claude_model", "claude-sonnet-5"),
+            claude_model=kwargs.get("claude_model", "claude-sonnet-4-20250514"),
             base_url=lemonade_base_url,
             # RAG configuration
             rag_documents=rag_documents,

--- a/src/gaia/logger.py
+++ b/src/gaia/logger.py
@@ -4,8 +4,23 @@
 import logging
 import subprocess
 import sys
+import tempfile
 import warnings
 from pathlib import Path
+
+
+def _home_log_file():
+    """Return ``~/.gaia/gaia.log``, or ``None`` when the home dir is unresolvable.
+
+    ``Path.home()`` raises ``RuntimeError`` on Windows when neither ``USERPROFILE``
+    nor ``HOMEDRIVE``+``HOMEPATH`` is set -- common for services, scheduled tasks
+    and curated ``subprocess`` environments, which would otherwise fail to
+    ``import gaia`` at all.
+    """
+    try:
+        return Path.home() / ".gaia" / "gaia.log"
+    except RuntimeError:
+        return None
 
 
 def configure_console_encoding():
@@ -47,7 +62,16 @@ class GaiaLogger:
         # current working directory with gaia.log files and don't crash
         # when CWD is not writable (e.g. /, system dirs, read-only mounts).
         if log_file is None:
-            log_file = Path.home() / ".gaia" / "gaia.log"
+            log_file = _home_log_file()
+            if log_file is None:
+                # No resolvable home dir -- use the tempdir the handler
+                # fallback below would have picked anyway.
+                log_file = Path(tempfile.gettempdir()) / "gaia.log"
+                print(
+                    "[gaia] Home directory is not resolvable; "
+                    f"writing logs to: {log_file}",
+                    file=sys.stderr,
+                )
             try:
                 log_file.parent.mkdir(parents=True, exist_ok=True)
             except (PermissionError, OSError):
@@ -104,16 +128,14 @@ class GaiaLogger:
         except (PermissionError, OSError) as primary_err:
             fallback_candidates = []
 
-            home_fallback = Path.home() / ".gaia" / "gaia.log"
-            if Path(self.log_file).resolve() != home_fallback.resolve():
+            home_fallback = _home_log_file()
+            if (
+                home_fallback is not None
+                and Path(self.log_file).resolve() != home_fallback.resolve()
+            ):
                 fallback_candidates.append(home_fallback)
 
-            try:
-                import tempfile
-
-                fallback_candidates.append(Path(tempfile.gettempdir()) / "gaia.log")
-            except Exception:
-                pass
+            fallback_candidates.append(Path(tempfile.gettempdir()) / "gaia.log")
 
             print(
                 f"[gaia] Cannot write to {self.log_file} ({primary_err}).",

--- a/src/gaia/rag/sdk.py
+++ b/src/gaia/rag/sdk.py
@@ -634,6 +634,18 @@ class RAGSDK:
                     except Exception as e:
                         self.log.warning(f"   ⚠️  Single embedding failed: {e}")
 
+            # Callers pair chunk i with vector i; a short batch returns wrong text.
+            usable = sum(1 for emb in batch_embeddings if emb)
+            if len(batch_embeddings) != len(batch_texts) or usable != len(batch_texts):
+                raise RuntimeError(
+                    f"Embedding backend returned {usable}/{len(batch_texts)} usable "
+                    f"vectors for batch {batch_num} against "
+                    f"{self.config.embedding_model!r}; refusing to index chunks "
+                    "against misaligned vectors. Verify Lemonade Server is "
+                    "reachable and the embedding model is fully loaded, then "
+                    "re-index."
+                )
+
             all_embeddings.extend(batch_embeddings)
 
             if show_progress or self.config.show_stats:

--- a/src/gaia/security.py
+++ b/src/gaia/security.py
@@ -234,6 +234,7 @@ class PathValidator:
         allowed_paths: Optional[List[str]] = None,
         on_prompt_start: Optional[Callable[[], None]] = None,
         on_prompt_end: Optional[Callable[[], None]] = None,
+        interactive_check: Optional[Callable[[], bool]] = None,
     ):
         """
         Initialize PathValidator.
@@ -244,6 +245,11 @@ class PathValidator:
                 user for input (e.g. to pause a progress spinner).
             on_prompt_end: Optional callback invoked after user input is
                 collected (e.g. to resume a progress spinner).
+            interactive_check: Optional predicate answering "is the *requester*
+                reachable on this process's stdin?". A TTY alone does not mean
+                yes — a server launched from a terminal has one, but its users
+                are on HTTP. Evaluated per prompt, so a host that swaps the
+                agent's console mid-session is honoured.
         """
         self.allowed_paths: Set[Path] = set()
 
@@ -266,6 +272,7 @@ class PathValidator:
         # indicators that would otherwise race with ``input()`` on stdout).
         self._on_prompt_start = on_prompt_start
         self._on_prompt_end = on_prompt_end
+        self._interactive_check = interactive_check
 
         # Load persisted paths
         self._load_persisted_paths()
@@ -372,6 +379,14 @@ class PathValidator:
         self.allowed_paths.add(Path(path).resolve())
         logger.debug(f"Added allowed path: {path}")
 
+    def _can_prompt(self) -> bool:
+        """True when a blocking ``input()`` would actually reach the requester."""
+        if not _is_interactive():
+            return False
+        if self._interactive_check is None:
+            return True
+        return bool(self._interactive_check())
+
     def is_path_allowed(self, path: str, prompt_user: bool = True) -> bool:
         """
         Check if a path is allowed. If not, optionally prompt the user.
@@ -442,10 +457,11 @@ class PathValidator:
         agent surfaces a clean "access denied" error instead of hanging.
         Interactive CLI usage (TTY) still prompts normally.
         """
-        if not _is_interactive():
+        if not self._can_prompt():
             logger.warning(
-                "Path %s outside allowlist; auto-denying (non-interactive "
-                "context — no TTY). Configure allowed_paths to grant access.",
+                "Path %s outside allowlist; auto-denying (no interactive "
+                "requester on this process's stdin). Configure allowed_paths "
+                "to grant access.",
                 path,
             )
             return False
@@ -636,7 +652,7 @@ class PathValidator:
         Returns:
             True if user approves overwrite (or non-interactive), False otherwise.
         """
-        if not _is_interactive():
+        if not self._can_prompt():
             logger.info(
                 "Auto-approving overwrite of %s (non-interactive context, "
                 "backup will be created)",

--- a/src/gaia/security.py
+++ b/src/gaia/security.py
@@ -654,7 +654,8 @@ class PathValidator:
         """
         if not self._can_prompt():
             logger.info(
-                "Auto-approving overwrite of %s (non-interactive context, "
+                "Auto-approving overwrite of %s (no interactive requester on "
+                "this process's stdin, "
                 "backup will be created)",
                 path,
             )

--- a/src/gaia/talk/sdk.py
+++ b/src/gaia/talk/sdk.py
@@ -47,6 +47,10 @@ class TalkConfig:
     # General settings
     use_claude: bool = False  # Use Claude API
     use_chatgpt: bool = False  # Use ChatGPT/OpenAI API
+    claude_model: str = "claude-sonnet-5"  # Claude model when use_claude=True
+    base_url: Optional[str] = (
+        None  # Lemonade server base URL (None = use LEMONADE_BASE_URL env var)
+    )
     show_stats: bool = False
     logging_level: str = "INFO"
 
@@ -121,6 +125,8 @@ class TalkSDK:
             logging_level=self.config.logging_level,
             use_claude=self.config.use_claude,
             use_chatgpt=self.config.use_chatgpt,
+            claude_model=self.config.claude_model,
+            base_url=self.config.base_url,
         )
         self.chat_sdk = AgentSDK(chat_config)
 
@@ -135,6 +141,9 @@ class TalkSDK:
             use_claude=self.config.use_claude,
             use_chatgpt=self.config.use_chatgpt,
             system_prompt=self.config.system_prompt,
+            model=self.config.model,
+            claude_model=self.config.claude_model,
+            base_url=self.config.base_url,
         )
 
         self.show_stats = self.config.show_stats

--- a/tests/unit/test_audio_playback_cleanup.py
+++ b/tests/unit/test_audio_playback_cleanup.py
@@ -1,0 +1,98 @@
+# Copyright(C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+"""Playback must finish or fail explicitly before capture can resume."""
+
+import queue
+import threading
+from unittest.mock import MagicMock, patch
+
+import numpy as np
+import pytest
+
+from gaia.audio.kokoro_tts import KokoroTTS
+
+
+def _tts_and_text():
+    tts = KokoroTTS.__new__(KokoroTTS)
+    tts.preprocess_text = lambda text: text
+
+    def generate(_text, stream_callback):
+        stream_callback(np.ones(24, dtype=np.float32))
+
+    tts.generate_speech = generate
+    text_queue = queue.Queue()
+    text_queue.put("hello.")
+    text_queue.put("__END__")
+    return tts, text_queue
+
+
+def test_streaming_waits_for_playback_and_closes_stream():
+    tts, text_queue = _tts_and_text()
+    stream = MagicMock()
+    wrote = threading.Event()
+    release = threading.Event()
+    status = []
+    errors = []
+
+    def write(_audio):
+        wrote.set()
+        assert release.wait(2)
+
+    stream.write.side_effect = write
+
+    def run():
+        try:
+            tts.generate_speech_streaming(text_queue, status_callback=status.append)
+        except Exception as error:
+            errors.append(error)
+
+    with patch("gaia.audio.kokoro_tts.sd") as sd:
+        sd.OutputStream.return_value = stream
+        runner = threading.Thread(target=run)
+        runner.start()
+        try:
+            assert wrote.wait(2)
+            assert runner.is_alive()
+            assert status == [True]
+            stream.close.assert_not_called()
+        finally:
+            release.set()
+            runner.join(2)
+    assert not runner.is_alive()
+    assert not errors
+    assert status == [True, False]
+    stream.close.assert_called_once()
+
+
+def test_stalled_device_times_out_instead_of_hanging():
+    tts, text_queue = _tts_and_text()
+    tts.PLAYBACK_TIMEOUT_SLACK = 0.05
+    release = threading.Event()
+    closed = threading.Event()
+    stream = MagicMock()
+    stream.write.side_effect = lambda _audio: release.wait(2)
+    stream.close.side_effect = closed.set
+    try:
+        with patch("gaia.audio.kokoro_tts.sd") as sd:
+            sd.OutputStream.return_value = stream
+            with pytest.raises(TimeoutError, match="microphone remains paused"):
+                tts.generate_speech_streaming(text_queue)
+    finally:
+        release.set()
+        assert closed.wait(2)
+
+
+@pytest.mark.parametrize("stage", ["write", "stop", "close", "synthesis"])
+def test_streaming_reports_output_and_synthesis_errors(stage):
+    tts, text_queue = _tts_and_text()
+    stream = MagicMock()
+    if stage == "synthesis":
+        tts.generate_speech = MagicMock(side_effect=OSError("synthesis failed"))
+    else:
+        getattr(stream, stage).side_effect = OSError(f"{stage} failed")
+    with patch("gaia.audio.kokoro_tts.sd") as sd:
+        sd.OutputStream.return_value = stream
+        with pytest.raises((RuntimeError, OSError), match=f"{stage} failed"):
+            tts.generate_speech_streaming(text_queue)
+    stream.close.assert_called_once()

--- a/tests/unit/test_audio_recorder_sd.py
+++ b/tests/unit/test_audio_recorder_sd.py
@@ -184,3 +184,38 @@ class TestRecording:
         assert not recorder.is_paused
 
         recorder.stop_recording()
+
+
+class TestPauseAndCaptureFailure:
+    def test_pause_discards_mic_audio_but_keeps_draining(self, recorder, mock_sd):
+        """While paused the device is read and thrown away, never queued."""
+        mock_stream = mock_sd.InputStream.return_value
+        loud_audio = np.full((2048, 1), 0.1, dtype=np.float32)
+        mock_stream.read.return_value = (loud_audio, False)
+
+        recorder.pause_recording()
+        recorder.is_recording = True
+        recorder.record_thread = threading.Thread(target=recorder._record_audio)
+        recorder.record_thread.start()
+        try:
+            time.sleep(0.5)
+        finally:
+            recorder.is_recording = False
+            recorder.record_thread.join(timeout=2.0)
+
+        assert mock_stream.read.call_count > 1
+        assert recorder.audio_queue.empty()
+
+    def test_dead_capture_thread_reads_as_not_recording(self, recorder, mock_sd):
+        """A device error must not leave callers waiting on 'Listening...'."""
+        mock_stream = mock_sd.InputStream.return_value
+        mock_stream.read.side_effect = OSError("device unplugged")
+
+        recorder.start_recording()
+        try:
+            recorder.record_thread.join(timeout=2.0)
+            assert not recorder.is_recording
+            assert recorder.capture_failed
+        finally:
+            recorder.stop_recording()  # also ends the non-daemon process thread
+        assert not recorder.capture_failed

--- a/tests/unit/test_audio_recorder_sd.py
+++ b/tests/unit/test_audio_recorder_sd.py
@@ -11,6 +11,39 @@ import numpy as np
 import pytest
 
 
+@pytest.mark.parametrize("resume", [False, True])
+def test_streaming_asr_drains_paused_audio_and_discards_overlap(mock_sd, resume):
+    from gaia.audio.audio_recorder import AudioRecorder
+    from gaia.audio.whisper_asr import WhisperAsr
+
+    asr = WhisperAsr.__new__(WhisperAsr)
+    AudioRecorder.__init__(asr, device_index=0)
+    asr.RATE = 10
+    asr.CHUNK = 10
+    asr.is_recording = True
+    reads = 0
+
+    def read(_size):
+        nonlocal reads
+        reads += 1
+        if reads == 2:
+            asr.pause_recording()
+        if reads == 3:
+            if resume:
+                asr.resume_recording()
+            asr.is_recording = False
+        return np.full((10, 1), reads, dtype=np.float32), False
+
+    mock_sd.InputStream.return_value.read.side_effect = read
+    with patch("gaia.audio.whisper_asr.sd", mock_sd):
+        asr._record_audio_streaming()
+
+    assert reads == 3, "paused capture must drain the device instead of sleeping"
+    if resume:
+        np.testing.assert_array_equal(asr.audio_queue.get_nowait(), np.full(10, 3))
+    assert asr.audio_queue.empty()
+
+
 @pytest.fixture
 def mock_sd():
     """Mock sounddevice module."""

--- a/tests/unit/test_cli_talk_flags.py
+++ b/tests/unit/test_cli_talk_flags.py
@@ -90,6 +90,8 @@ def test_defaults_without_backend_flags(monkeypatch):
     chat_config = agent_sdk.call_args[0][0]
     assert chat_config.model == DEFAULT_MODEL_NAME
     assert chat_config.max_tokens == 512
+    assert chat_config.claude_model == "claude-sonnet-4-20250514"
+    assert audio_client.call_args[1]["claude_model"] == "claude-sonnet-4-20250514"
     assert chat_config.show_stats is False
     assert chat_config.use_claude is False and chat_config.use_chatgpt is False
     assert chat_config.base_url is None

--- a/tests/unit/test_cli_talk_flags.py
+++ b/tests/unit/test_cli_talk_flags.py
@@ -1,0 +1,104 @@
+# Copyright(C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+"""Every `gaia talk` model/backend flag must reach the client that uses it (#124).
+
+These drive the real CLI parser and entry point and build a real TalkSDK; only
+the two clients that consume the flags (AgentSDK for the conversation,
+AudioClient for voice) are replaced, so an unwired flag fails its own case.
+"""
+
+import sys
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from gaia.llm.lemonade_client import DEFAULT_MODEL_NAME
+from gaia.talk.sdk import TalkSDK
+
+# asyncio uses a local socketpair for its Windows event-loop wakeup.
+pytestmark = pytest.mark.allow_network
+
+BASE_URL = "http://10.0.0.5:13305/api/v1"
+
+
+def _run_talk(argv, monkeypatch):
+    """Run `gaia talk <argv>`; return (AgentSDK mock, AudioClient mock)."""
+    monkeypatch.setattr(sys, "argv", ["gaia", "talk", "--no-lemonade-check", *argv])
+    with (
+        patch("gaia.talk.sdk.AgentSDK") as agent_sdk,
+        patch("gaia.talk.sdk.AudioClient") as audio_client,
+        patch.object(TalkSDK, "start_voice_session", AsyncMock()),
+    ):
+        from gaia.cli import main
+
+        main()
+    return agent_sdk, audio_client
+
+
+FLAG_CASES = [
+    pytest.param(
+        ["--model", "Qwen3-Coder-30B-A3B-Instruct-GGUF"],
+        {"model": "Qwen3-Coder-30B-A3B-Instruct-GGUF"},
+        {"model": "Qwen3-Coder-30B-A3B-Instruct-GGUF"},
+        id="--model",
+    ),
+    pytest.param(["--max-tokens", "9"], {"max_tokens": 9}, {}, id="--max-tokens"),
+    pytest.param(
+        ["--use-claude"], {"use_claude": True}, {"use_claude": True}, id="--use-claude"
+    ),
+    pytest.param(
+        ["--use-chatgpt", "--model", "gpt-4o"],
+        {"use_chatgpt": True, "model": "gpt-4o"},
+        {"use_chatgpt": True, "model": "gpt-4o"},
+        id="--use-chatgpt",
+    ),
+    pytest.param(
+        ["--claude-model", "claude-x"],
+        {"claude_model": "claude-x"},
+        {"claude_model": "claude-x"},
+        id="--claude-model",
+    ),
+    pytest.param(
+        ["--base-url", BASE_URL],
+        {"base_url": BASE_URL},
+        {"base_url": BASE_URL},
+        id="--base-url",
+    ),
+    pytest.param(["--stats"], {"show_stats": True}, {}, id="--stats"),
+    pytest.param(["--show-stats"], {"show_stats": True}, {}, id="--show-stats"),
+]
+
+
+@pytest.mark.parametrize("argv, chat_expected, audio_expected", FLAG_CASES)
+def test_each_talk_flag_reaches_the_client_that_uses_it(
+    argv, chat_expected, audio_expected, monkeypatch
+):
+    agent_sdk, audio_client = _run_talk(argv, monkeypatch)
+
+    chat_config = agent_sdk.call_args[0][0]
+    for field, value in chat_expected.items():
+        assert getattr(chat_config, field) == value, f"AgentConfig.{field}"
+    audio_kwargs = audio_client.call_args[1]
+    for field, value in audio_expected.items():
+        assert audio_kwargs[field] == value, f"AudioClient({field}=)"
+
+
+def test_defaults_without_backend_flags(monkeypatch):
+    agent_sdk, audio_client = _run_talk([], monkeypatch)
+
+    chat_config = agent_sdk.call_args[0][0]
+    assert chat_config.model == DEFAULT_MODEL_NAME
+    assert chat_config.max_tokens == 512
+    assert chat_config.show_stats is False
+    assert chat_config.use_claude is False and chat_config.use_chatgpt is False
+    assert chat_config.base_url is None
+    assert audio_client.call_args[1]["model"] == DEFAULT_MODEL_NAME
+
+
+def test_use_chatgpt_without_model_is_refused(monkeypatch, capsys):
+    """The local default model id would only produce a confusing OpenAI 404."""
+    with pytest.raises(SystemExit) as exc:
+        _run_talk(["--use-chatgpt"], monkeypatch)
+    assert exc.value.code != 0
+    assert "--use-chatgpt needs --model" in capsys.readouterr().out

--- a/tests/unit/test_logger_home_unresolvable.py
+++ b/tests/unit/test_logger_home_unresolvable.py
@@ -1,0 +1,107 @@
+# Copyright(C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+"""`import gaia` must survive a process with no resolvable home directory."""
+
+import logging
+import os
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from gaia import logger as gaia_logger
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+# Runs in a fresh interpreter so the import-time logger is really exercised.
+_IMPORT_AND_LOG = (
+    "from gaia.logger import get_logger, log_manager\n"
+    "get_logger('gaia.probe').warning('probe-c38')\n"
+    "print(log_manager.log_file)\n"
+)
+_HOME_RAISES = (
+    "import pathlib\n"
+    "def _no_home(cls):\n"
+    "    raise RuntimeError('Could not determine home directory.')\n"
+    "pathlib.Path.home = classmethod(_no_home)\n"
+    "import gaia\n"
+)
+
+
+@pytest.fixture()
+def clean_root():
+    root = logging.getLogger()
+    before = root.handlers[:]
+    yield root
+    for handler in root.handlers[:]:
+        if handler not in before:
+            handler.close()
+    root.handlers[:] = before
+
+
+def _no_home(cls):
+    raise RuntimeError("Could not determine home directory.")
+
+
+def _same_path(a, b):
+    return os.path.normcase(os.path.realpath(a)) == os.path.normcase(
+        os.path.realpath(b)
+    )
+
+
+def _run_child(code, tmp_path, drop_home_vars=False):
+    env = dict(os.environ)
+    if drop_home_vars:
+        for key in list(env):
+            if key.upper() in {"USERPROFILE", "HOMEDRIVE", "HOMEPATH", "HOME"}:
+                del env[key]
+    for key in ("TMP", "TEMP", "TMPDIR"):
+        env[key] = str(tmp_path)
+    env["PYTHONPATH"] = os.pathsep.join(
+        filter(None, [str(REPO_ROOT / "src"), env.get("PYTHONPATH")])
+    )
+    return subprocess.run(
+        [sys.executable, "-c", code],
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=120,
+        check=False,
+    )
+
+
+def _assert_logged_to_tempdir(result, tmp_path):
+    assert result.returncode == 0, result.stderr
+    reported = result.stdout.strip().splitlines()[-1]
+    assert _same_path(reported, tmp_path / "gaia.log"), reported
+    assert "probe-c38" in (tmp_path / "gaia.log").read_text(encoding="utf-8")
+    assert "Home directory is not resolvable" in result.stderr
+
+
+def test_home_log_file_is_none_when_home_unresolvable(monkeypatch):
+    monkeypatch.setattr(Path, "home", classmethod(_no_home))
+    assert gaia_logger._home_log_file() is None
+
+
+def test_logger_writes_to_tempdir_and_says_so(monkeypatch, clean_root, capsys):
+    monkeypatch.setattr(Path, "home", classmethod(_no_home))
+    gl = gaia_logger.GaiaLogger()
+    assert gl.log_file == Path(tempfile.gettempdir()) / "gaia.log"
+    assert "Home directory is not resolvable" in capsys.readouterr().err
+
+
+def test_import_gaia_succeeds_when_path_home_raises(tmp_path):
+    result = _run_child(_HOME_RAISES + _IMPORT_AND_LOG, tmp_path)
+    _assert_logged_to_tempdir(result, tmp_path)
+
+
+@pytest.mark.skipif(
+    sys.platform != "win32", reason="POSIX resolves home from pwd without env vars"
+)
+def test_import_gaia_without_windows_home_env_vars(tmp_path):
+    """The real-world trigger: a service or curated subprocess environment."""
+    result = _run_child("import gaia\n" + _IMPORT_AND_LOG, tmp_path, True)
+    _assert_logged_to_tempdir(result, tmp_path)

--- a/tests/unit/test_rag_encode_alignment.py
+++ b/tests/unit/test_rag_encode_alignment.py
@@ -1,0 +1,57 @@
+# Copyright(C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+"""A short embedding batch must fail loudly, not pair chunks with wrong vectors."""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from gaia.rag.sdk import RAGSDK
+
+
+def _sdk(embeddings):
+    sdk = RAGSDK.__new__(RAGSDK)  # skip heavy __init__
+    sdk.config = MagicMock()
+    sdk.config.embedding_model = "nomic-embed-text-v2-moe-GGUF"
+    sdk.config.show_stats = False
+    sdk.log = MagicMock()
+    sdk.embedder = MagicMock()
+    sdk.embedder.embeddings.side_effect = embeddings
+    return sdk
+
+
+def _vectors(texts):
+    return {"data": [{"embedding": [float(len(t)), 1.0]} for t in texts]}
+
+
+def test_full_batch_stays_aligned():
+    out = _sdk(lambda texts, **kw: _vectors(texts))._encode_texts(["a", "bb", "ccc"])
+    assert out.shape == (3, 2)
+    assert list(out[:, 0]) == [1.0, 2.0, 3.0]
+
+
+def test_short_batch_raises():
+    sdk = _sdk(lambda texts, **kw: _vectors(texts[:-1]))
+    with pytest.raises(RuntimeError, match="2/3 usable"):
+        sdk._encode_texts(["a", "bb", "ccc"])
+
+
+def test_hollow_vector_raises():
+    def embeddings(texts, **kw):
+        data = _vectors(texts)
+        data["data"][1]["embedding"] = []
+        return data
+
+    with pytest.raises(RuntimeError, match="2/3 usable"):
+        _sdk(embeddings)._encode_texts(["a", "bb", "ccc"])
+
+
+def test_one_by_one_skip_raises_instead_of_shifting_chunks():
+    def embeddings(texts, **kw):
+        if len(texts) > 1:
+            return {"data": []}  # whole batch came back empty
+        return {"data": []} if texts == ["bb"] else _vectors(texts)
+
+    with pytest.raises(RuntimeError, match="2/3 usable"):
+        _sdk(embeddings)._encode_texts(["a", "bb", "ccc"])

--- a/tests/unit/test_talk_config.py
+++ b/tests/unit/test_talk_config.py
@@ -46,3 +46,59 @@ def test_audio_client_default_mic_threshold():
     with patch("gaia.audio.audio_client.create_client"):
         client = AudioClient()
         assert client.mic_threshold == 0.003
+
+
+def test_talk_sdk_threads_backend_selection_to_both_clients():
+    """model, claude_model and base_url reach AgentSDK and AudioClient."""
+    with (
+        patch("gaia.talk.sdk.AudioClient") as MockAudioClient,
+        patch("gaia.talk.sdk.AgentSDK") as MockAgentSDK,
+    ):
+        TalkSDK(
+            TalkConfig(
+                model="local-m",
+                max_tokens=9,
+                use_claude=True,
+                claude_model="claude-x",
+                base_url="http://h:1/api/v1",
+                show_stats=True,
+                enable_tts=False,
+            )
+        )
+        chat_config = MockAgentSDK.call_args[0][0]
+        assert chat_config.model == "local-m"
+        assert chat_config.max_tokens == 9
+        assert chat_config.use_claude is True
+        assert chat_config.claude_model == "claude-x"
+        assert chat_config.base_url == "http://h:1/api/v1"
+        assert chat_config.show_stats is True
+
+        audio_kwargs = MockAudioClient.call_args[1]
+        assert audio_kwargs["model"] == "local-m"
+        assert audio_kwargs["claude_model"] == "claude-x"
+        assert audio_kwargs["base_url"] == "http://h:1/api/v1"
+
+
+def test_audio_client_passes_model_and_base_url_to_provider():
+    with patch("gaia.audio.audio_client.create_client") as mock_create:
+        AudioClient(model="local-m", base_url="http://h:1/api/v1")
+        kwargs = mock_create.call_args[1]
+        assert kwargs["model"] == "local-m"
+        assert kwargs["base_url"] == "http://h:1/api/v1"
+
+
+def test_audio_client_uses_claude_model_with_claude():
+    with patch("gaia.audio.audio_client.create_client") as mock_create:
+        AudioClient(use_claude=True, model="local-m", claude_model="claude-x")
+        assert mock_create.call_args[1]["model"] == "claude-x"
+
+
+def test_agent_sdk_passes_model_and_base_url_to_provider():
+    """The conversation client is built with the model and URL talk hands it."""
+    from gaia.chat.sdk import AgentConfig, AgentSDK
+
+    with patch("gaia.chat.sdk.create_client") as mock_create:
+        AgentSDK(AgentConfig(model="local-m", base_url="http://h:1/api/v1"))
+        kwargs = mock_create.call_args[1]
+        assert kwargs["model"] == "local-m"
+        assert kwargs["base_url"] == "http://h:1/api/v1"

--- a/tests/unit/test_talk_playback_mute.py
+++ b/tests/unit/test_talk_playback_mute.py
@@ -72,20 +72,24 @@ class _PlayingTTS:
         status_callback(False)
 
 
-def _speak_in_background(client, text):
-    runner = threading.Thread(target=lambda: _run(client.speak_text(text)))
+def _speak_in_background(client, text, method="speak_text"):
+    client.llm_client.is_generating.return_value = False
+    client.llm_client.generate.return_value = [text]
+    client.llm_client.get_performance_stats.return_value = None
+    runner = threading.Thread(target=lambda: _run(getattr(client, method)(text)))
     runner.start()
     return runner
 
 
-def test_mic_is_paused_for_the_whole_utterance_and_resumes_after():
+@pytest.mark.parametrize("method", ["speak_text", "process_voice_input"])
+def test_mic_is_paused_for_the_whole_utterance_and_resumes_after(method):
     client = _client(enable_tts=True)
     mic = _Mic()
     client.whisper_asr = mic
     tts = _PlayingTTS(mic)
     client.tts = tts
 
-    runner = _speak_in_background(client, "hello there")
+    runner = _speak_in_background(client, "hello there", method)
     try:
         time.sleep(0.3)
         assert runner.is_alive(), "speak_text returned while audio was still playing"
@@ -102,6 +106,53 @@ def test_mic_is_paused_for_the_whole_utterance_and_resumes_after():
     assert mic.is_paused is False and mic.resumes == 1
     assert client.transcription_queue.empty(), "self-transcription was not dropped"
     assert client.is_speaking is False
+
+
+def test_voice_processor_does_not_resume_on_early_status_callback():
+    client = _client(enable_tts=True)
+    mic = _Mic()
+    client.whisper_asr = mic
+    callback_sent = threading.Event()
+
+    class EarlyStatusTTS(_PlayingTTS):
+        def generate_speech_streaming(
+            self, text_queue, status_callback, interrupt_event
+        ):
+            status_callback(False)
+            callback_sent.set()
+            super().generate_speech_streaming(
+                text_queue, status_callback, interrupt_event
+            )
+
+    tts = EarlyStatusTTS(mic)
+    client.tts = tts
+    runner = _speak_in_background(client, "hello", "process_voice_input")
+    try:
+        assert callback_sent.wait(2)
+        assert mic.is_paused
+        assert mic.resumes == 0
+    finally:
+        tts.release.set()
+        runner.join(5)
+    assert not runner.is_alive()
+    assert mic.resumes == 1
+
+
+@pytest.mark.parametrize("method", ["speak_text", "process_voice_input"])
+@pytest.mark.parametrize("error_cls, paused", [(OSError, False), (TimeoutError, True)])
+def test_playback_failure_propagates_and_timeout_keeps_mic_muted(
+    method, error_cls, paused
+):
+    client = _client(enable_tts=True)
+    client.whisper_asr = _Mic()
+    client.llm_client.is_generating.return_value = False
+    client.llm_client.generate.return_value = ["hello"]
+    client.llm_client.get_performance_stats.return_value = None
+    client.tts = MagicMock()
+    client.tts.generate_speech_streaming.side_effect = error_cls("output stalled")
+    with pytest.raises(RuntimeError, match="output stalled"):
+        _run(getattr(client, method)("hello"))
+    assert client.whisper_asr.is_paused is paused
 
 
 @pytest.mark.filterwarnings("ignore::pytest.PytestUnhandledThreadExceptionWarning")

--- a/tests/unit/test_talk_playback_mute.py
+++ b/tests/unit/test_talk_playback_mute.py
@@ -1,0 +1,276 @@
+# Copyright(C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+"""`gaia talk` must not hear itself, and must exit non-zero when the loop dies.
+
+No real audio device is involved: TTS and the recorder are stand-ins that keep
+the same pause/resume state the real WhisperAsr exposes.
+"""
+
+import asyncio
+import sys
+import threading
+import time
+import types
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from gaia.audio.audio_client import AudioClient
+
+# asyncio uses a local socketpair for its Windows event-loop wakeup.
+pytestmark = pytest.mark.allow_network
+
+
+def _run(coro):
+    loop = asyncio.SelectorEventLoop()
+    try:
+        return loop.run_until_complete(coro)
+    finally:
+        loop.close()
+
+
+def _client(**kwargs):
+    with patch("gaia.audio.audio_client.create_client"):
+        return AudioClient(**kwargs)
+
+
+class _Mic:
+    """WhisperAsr's pause interface with real state instead of a mock."""
+
+    def __init__(self):
+        self.is_paused = False
+        self.resumes = 0
+
+    def pause_recording(self):
+        self.is_paused = True
+
+    def resume_recording(self):
+        self.is_paused = False
+        self.resumes += 1
+
+
+class _PlayingTTS:
+    """Consumes text like KokoroTTS, then plays until released, sampling the mic."""
+
+    def __init__(self, mic):
+        self.mic = mic
+        self.release = threading.Event()
+        self.mic_paused_samples = []
+        self.text = ""
+
+    def generate_speech_streaming(
+        self, text_queue, status_callback=None, interrupt_event=None
+    ):
+        self.mic_paused_samples.append(self.mic.is_paused)
+        while (chunk := text_queue.get(timeout=5)) != "__END__":
+            self.text += chunk
+        status_callback(True)
+        while not self.release.wait(0.02):
+            self.mic_paused_samples.append(self.mic.is_paused)
+        self.mic_paused_samples.append(self.mic.is_paused)
+        status_callback(False)
+
+
+def _speak_in_background(client, text):
+    runner = threading.Thread(target=lambda: _run(client.speak_text(text)))
+    runner.start()
+    return runner
+
+
+def test_mic_is_paused_for_the_whole_utterance_and_resumes_after():
+    client = _client(enable_tts=True)
+    mic = _Mic()
+    client.whisper_asr = mic
+    tts = _PlayingTTS(mic)
+    client.tts = tts
+
+    runner = _speak_in_background(client, "hello there")
+    try:
+        time.sleep(0.3)
+        assert runner.is_alive(), "speak_text returned while audio was still playing"
+        assert mic.is_paused is True
+        client.transcription_queue.put("hello there")  # the mic heard the speaker
+    finally:
+        tts.release.set()
+        runner.join(timeout=5)
+
+    assert not runner.is_alive()
+    assert tts.text == "hello there"
+    assert len(tts.mic_paused_samples) > 3
+    assert all(tts.mic_paused_samples), "mic was live during playback"
+    assert mic.is_paused is False and mic.resumes == 1
+    assert client.transcription_queue.empty(), "self-transcription was not dropped"
+    assert client.is_speaking is False
+
+
+@pytest.mark.filterwarnings("ignore::pytest.PytestUnhandledThreadExceptionWarning")
+def test_tts_crash_mid_speech_resumes_mic_and_is_reported():
+    client = _client(enable_tts=True)
+    mic = _Mic()
+    client.whisper_asr = mic
+
+    class _CrashingTTS:
+        def generate_speech_streaming(self, text_queue, **_kwargs):
+            text_queue.get(timeout=5)
+            raise OSError("audio output device lost")
+
+    client.tts = _CrashingTTS()
+
+    with pytest.raises(RuntimeError, match="audio output device lost"):
+        _run(client.speak_text("hello"))
+    assert mic.is_paused is False, "a TTS crash left the microphone dead"
+    assert client.is_speaking is False
+
+
+def test_crash_before_playback_starts_resumes_mic():
+    client = _client(enable_tts=True)
+    mic = _Mic()
+    client.whisper_asr = mic
+    client.tts = MagicMock()
+
+    with (
+        patch.object(
+            threading.Thread, "start", side_effect=RuntimeError("can't start thread")
+        ),
+        pytest.raises(RuntimeError, match="can't start thread"),
+    ):
+        _run(client.speak_text("hello"))
+    assert mic.is_paused is False, "a failed start left the microphone dead"
+    assert client.is_speaking is False
+
+
+def test_tts_that_fails_before_speaking_resumes_mic_and_is_reported():
+    """Resolving the TTS entry point used to happen outside the try/finally."""
+    client = _client(enable_tts=True)
+    mic = _Mic()
+    client.whisper_asr = mic
+
+    class _UnloadedTTS:
+        @property
+        def generate_speech_streaming(self):
+            raise RuntimeError("kokoro pipeline not loaded")
+
+    client.tts = _UnloadedTTS()
+
+    with pytest.raises(RuntimeError, match="kokoro pipeline not loaded"):
+        _run(client.speak_text("hello"))
+    assert mic.is_paused is False, "a TTS that never started left the mic dead"
+    assert client.is_speaking is False
+
+
+def test_stale_enter_press_does_not_cut_off_the_next_reply():
+    client = _client(enable_tts=True)
+    client.whisper_asr = _Mic()
+    seen = {}
+
+    class _InterruptibleTTS:
+        def generate_speech_streaming(
+            self, text_queue, status_callback=None, interrupt_event=None
+        ):
+            seen["event"] = interrupt_event
+            while text_queue.get(timeout=5) != "__END__":
+                pass
+            interrupt_event.wait(timeout=5)
+
+    client.tts = _InterruptibleTTS()
+    client._playback_interrupt.set()  # Enter pressed while idle
+
+    runner = _speak_in_background(client, "hi")
+    try:
+        time.sleep(0.3)
+        assert runner.is_alive(), "a press from before the reply interrupted it"
+    finally:
+        client._playback_interrupt.set()  # Enter pressed during playback
+        runner.join(timeout=5)
+    assert not runner.is_alive()
+    assert seen["event"] is client._playback_interrupt
+
+
+def test_one_stdin_listener_per_session():
+    client = _client(enable_tts=True)
+    client.llm_client.is_generating.return_value = False
+    presses = iter(["", EOFError()])
+
+    def fake_input():
+        item = next(presses)
+        if isinstance(item, BaseException):
+            raise item
+        return item
+
+    fake_stdin = MagicMock()
+    fake_stdin.isatty.return_value = True
+    with (
+        patch("gaia.audio.audio_client.sys.stdin", fake_stdin),
+        patch("builtins.input", side_effect=fake_input),
+    ):
+        assert client._start_stdin_listener() is True
+        first = client._stdin_listener
+        assert client._start_stdin_listener() is True
+        assert client._stdin_listener is first
+        assert client._playback_interrupt.wait(timeout=2)
+        first.join(timeout=2)
+
+
+def test_no_listener_without_a_terminal():
+    client = _client(enable_tts=True)
+    fake_stdin = MagicMock()
+    fake_stdin.isatty.return_value = False
+    with patch("gaia.audio.audio_client.sys.stdin", fake_stdin):
+        assert client._start_stdin_listener() is False
+    assert client._stdin_listener is None
+
+
+def _fake_asr(recording=True, capture_failed=False):
+    asr = MagicMock()
+    asr.is_recording = recording
+    asr.capture_failed = capture_failed
+    asr.SILENCE_THRESHOLD = 0.003
+    asr.MIN_AUDIO_LENGTH = 8000.0
+    asr.RATE = 16000
+    asr.device_index = 0
+    asr.get_device_name.return_value = "Test Mic"
+    return asr
+
+
+def _prepared_client(asr):
+    """AudioClient wired to a fake WhisperAsr module (no real audio stack)."""
+    client = _client(enable_tts=False, silence_threshold=0.05)
+    client._check_mic_levels = MagicMock()
+    module = types.ModuleType("gaia.audio.whisper_asr")
+    module.WhisperAsr = MagicMock(return_value=asr)
+    return client, patch.dict(sys.modules, {"gaia.audio.whisper_asr": module})
+
+
+def test_voice_loop_crash_propagates_instead_of_exiting_zero():
+    asr = _fake_asr()
+    client, fake_module = _prepared_client(asr)
+    client.transcription_queue.put("hello")
+
+    async def failing_processor(_text):
+        raise ConnectionError("404 from /api/v1/completions")
+
+    with fake_module, pytest.raises(RuntimeError, match="voice loop crashed"):
+        _run(client.start_voice_chat(failing_processor))
+
+
+def test_dead_microphone_propagates_with_device_hint():
+    asr = _fake_asr(recording=False, capture_failed=True)
+    client, fake_module = _prepared_client(asr)
+
+    async def processor(_text):
+        return None
+
+    with fake_module, pytest.raises(RuntimeError, match="audio-device-index"):
+        _run(client.start_voice_chat(processor))
+
+
+def test_clean_stop_does_not_raise():
+    asr = _fake_asr(recording=False, capture_failed=False)
+    client, fake_module = _prepared_client(asr)
+
+    async def processor(_text):
+        return None
+
+    with fake_module:
+        _run(client.start_voice_chat(processor))

--- a/tests/unit/test_ui_no_stdin_prompts.py
+++ b/tests/unit/test_ui_no_stdin_prompts.py
@@ -20,7 +20,7 @@ from gaia.ui.sse_handler import SSEOutputHandler as UiSSEOutputHandler
     "console_cls, expected",
     [
         (AgentConsole, True),
-        (SilentConsole, False),
+        (SilentConsole, True),
         (UiSSEOutputHandler, False),
         (ApiSSEOutputHandler, False),
     ],
@@ -129,9 +129,10 @@ def test_ui_turn_is_denied_without_prompting_the_server_tty(project_layout):
     assert allowed is False
 
 
-def test_cli_turn_still_prompts_and_the_answer_is_honoured(project_layout):
+@pytest.mark.parametrize("console_cls", [AgentConsole, SilentConsole])
+def test_cli_turn_still_prompts_and_the_answer_is_honoured(project_layout, console_cls):
     project, outside = project_layout
-    validator = _agent_validator(project, AgentConsole)
+    validator = _agent_validator(project, console_cls)
     prompts = []
     with (
         patch("gaia.security._is_interactive", return_value=True),

--- a/tests/unit/test_ui_no_stdin_prompts.py
+++ b/tests/unit/test_ui_no_stdin_prompts.py
@@ -1,0 +1,165 @@
+# Copyright(C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+"""A UI turn must never block on input() printed to the server's terminal."""
+
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from gaia.agents.base.agent import Agent
+from gaia.agents.base.console import AgentConsole, SilentConsole
+from gaia.api.sse_handler import SSEOutputHandler as ApiSSEOutputHandler
+from gaia.security import PathValidator
+from gaia.ui.sse_handler import SSEOutputHandler as UiSSEOutputHandler
+
+
+@pytest.mark.parametrize(
+    "console_cls, expected",
+    [
+        (AgentConsole, True),
+        (SilentConsole, False),
+        (UiSSEOutputHandler, False),
+        (ApiSSEOutputHandler, False),
+    ],
+)
+def test_only_the_terminal_console_accepts_stdin_prompts(console_cls, expected):
+    agent = SimpleNamespace(console=console_cls.__new__(console_cls))
+    assert Agent._console_accepts_stdin_prompts(agent) is expected
+
+
+def test_no_console_means_no_prompt():
+    assert Agent._console_accepts_stdin_prompts(SimpleNamespace()) is False
+
+
+def _validator(tmp_path, requester_on_stdin):
+    return PathValidator(
+        allowed_paths=[str(tmp_path)],
+        interactive_check=requester_on_stdin,
+    )
+
+
+def test_server_console_auto_denies_even_when_server_has_a_tty(tmp_path):
+    validator = _validator(tmp_path, lambda: False)
+    with (
+        patch("gaia.security._is_interactive", return_value=True),
+        patch("builtins.input", side_effect=AssertionError("prompted the server")),
+    ):
+        assert validator._prompt_user_for_access(tmp_path / "elsewhere") is False
+
+
+def test_server_console_overwrite_does_not_prompt(tmp_path):
+    existing = tmp_path / "f.txt"
+    existing.write_text("x")
+    validator = _validator(tmp_path, lambda: False)
+    with (
+        patch("gaia.security._is_interactive", return_value=True),
+        patch("builtins.input", side_effect=AssertionError("prompted the server")),
+    ):
+        assert validator._prompt_overwrite(existing, 1) is True
+
+
+def test_terminal_console_still_prompts(tmp_path):
+    validator = _validator(tmp_path, lambda: True)
+    with (
+        patch("gaia.security._is_interactive", return_value=True),
+        patch("builtins.input", return_value="y"),
+    ):
+        assert validator._prompt_user_for_access(tmp_path / "elsewhere") is True
+
+
+def test_no_tty_never_prompts_even_for_terminal_console(tmp_path):
+    validator = _validator(tmp_path, lambda: True)
+    with (
+        patch("gaia.security._is_interactive", return_value=False),
+        patch("builtins.input", side_effect=AssertionError("prompted without a tty")),
+    ):
+        assert validator._prompt_user_for_access(tmp_path / "elsewhere") is False
+
+
+def test_console_swap_is_honoured_per_prompt(tmp_path):
+    """The UI cache-hit path swaps agent.console after the validator exists."""
+    agent = SimpleNamespace(console=AgentConsole.__new__(AgentConsole))
+    validator = _validator(
+        tmp_path, lambda: Agent._console_accepts_stdin_prompts(agent)
+    )
+    agent.console = UiSSEOutputHandler.__new__(UiSSEOutputHandler)
+    with (
+        patch("gaia.security._is_interactive", return_value=True),
+        patch("builtins.input", side_effect=AssertionError("prompted the server")),
+    ):
+        assert validator._prompt_user_for_access(tmp_path / "elsewhere") is False
+
+
+# End-to-end through is_path_allowed. It swallows exceptions, so prompting is
+# detected by recording input() calls (and answering "y"), not by raising.
+
+
+@pytest.fixture()
+def project_layout(tmp_path, monkeypatch):
+    """A project dir, a path outside it, and a private ~ for persisted grants."""
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: home))
+    project = tmp_path / "project"
+    project.mkdir()
+    return project, tmp_path / "outside" / "secret.txt"
+
+
+def _agent_validator(project, console_cls):
+    agent = SimpleNamespace(console=console_cls.__new__(console_cls))
+    return PathValidator(
+        allowed_paths=[str(project)],
+        interactive_check=lambda: Agent._console_accepts_stdin_prompts(agent),
+    )
+
+
+def test_ui_turn_is_denied_without_prompting_the_server_tty(project_layout):
+    project, outside = project_layout
+    validator = _agent_validator(project, UiSSEOutputHandler)
+    prompts = []
+    with (
+        patch("gaia.security._is_interactive", return_value=True),
+        patch("builtins.input", side_effect=lambda *a: prompts.append(a) or "y"),
+    ):
+        allowed = validator.is_path_allowed(str(outside))
+    assert prompts == [], "the UI turn blocked on the server's stdin"
+    assert allowed is False
+
+
+def test_cli_turn_still_prompts_and_the_answer_is_honoured(project_layout):
+    project, outside = project_layout
+    validator = _agent_validator(project, AgentConsole)
+    prompts = []
+    with (
+        patch("gaia.security._is_interactive", return_value=True),
+        patch("builtins.input", side_effect=lambda *a: prompts.append(a) or "y"),
+    ):
+        allowed = validator.is_path_allowed(str(outside))
+    assert len(prompts) == 1
+    assert allowed is True
+
+
+def test_chat_agent_validator_asks_its_console_before_prompting(monkeypatch):
+    """The UI fix only holds if ChatAgent hands its validator the hook."""
+    chat = pytest.importorskip("gaia_agent_chat")
+    config = chat.ChatAgentConfig(
+        silent_mode=True,
+        enable_browser=False,
+        enable_filesystem=False,
+        enable_scratchpad=False,
+    )
+    with (
+        patch("gaia_agent_chat.agent.RAGSDK"),
+        patch("gaia_agent_chat.agent.RAGConfig"),
+    ):
+        agent = chat.ChatAgent(config)
+    monkeypatch.setattr("gaia.security._is_interactive", lambda: True)
+
+    agent.console = SimpleNamespace(supports_stdin_prompts=False)
+    assert agent.path_validator._can_prompt() is False
+
+    agent.console = SimpleNamespace(supports_stdin_prompts=True)
+    assert agent.path_validator._can_prompt() is True


### PR DESCRIPTION
`gaia talk` heard itself: the microphone stayed live while it spoke, so its own voice came back as the next request. It also accepted `--model`, `--max-tokens`, `--use-claude`, `--use-chatgpt`, `--claude-model`, `--base-url` and `--stats`, then ran without them. Now capture pauses for the whole of playback and every flag reaches the component that uses it.

Outside voice, an Agent UI chat turn could hang forever on an `input()` prompt printed to the server's own terminal — a server-side console now never prompts, while the CLI still does — and `import gaia` crashed in any process without a resolvable home directory. Also fixes the wrong port in `.env.example` and a length mismatch that could misalign RAG chunks with their embeddings.

Fixes #124

## Test plan

- [ ] `python -m pytest tests/unit/test_audio_recorder_sd.py tests/unit/test_cli_talk_flags.py tests/unit/test_logger_home_unresolvable.py tests/unit/test_rag_encode_alignment.py tests/unit/test_talk_config.py tests/unit/test_talk_playback_mute.py tests/unit/test_ui_no_stdin_prompts.py` — 63 passed; the two of these files that exist on `main` pass 16/16 there
- [ ] `python -m pytest hub/agents/chat/python/tests` — 14 passed in 1.70s
- [ ] The `ChatAgent` wiring test fails if the validator's `interactive_check` hook is removed — checked by removing it
- [ ] `gaia talk --help` lists every flag, and `gaia talk --use-chatgpt` refuses and exits 1
- [ ] `import gaia` in a subprocess with the home-directory variables removed succeeds
- [ ] With a real microphone and speaker: talk over playback and confirm it is not transcribed (not run on the author's machine)
- [ ] Agent UI started from a terminal: a turn that needs a path outside the allowlist is denied without prompting the server's stdin (not run end to end)
