### PR TITLE
fix(electron): block file links, per-chat grants, tray crash, cold-start links

### DIFF
--- a/docs/guides/mcp/client.mdx
+++ b/docs/guides/mcp/client.mdx
@@ -421,7 +421,7 @@ you chose to install.
 
 <Note>
 The Agent UI shows a permission modal, where **Allow this tool for the rest of
-this chat** stops the prompting for that tool in that chat until GAIA restarts —
+this chat** stops the prompting for that tool in that chat until you reload or restart GAIA —
 the grant is never saved, and **Settings → Tools & Permissions** lists every
 active grant so you can revoke it. The CLI asks on the terminal and defaults to no.
 A run with no terminal to ask — piped, CI, or otherwise unattended — refuses the

--- a/docs/guides/mcp/client.mdx
+++ b/docs/guides/mcp/client.mdx
@@ -420,8 +420,10 @@ you chose to install.
 </Warning>
 
 <Note>
-The Agent UI shows a permission modal, where **Always allow** stops the
-prompting for a specific tool. The CLI asks on the terminal and defaults to no.
+The Agent UI shows a permission modal, where **Allow this tool for the rest of
+this chat** stops the prompting for that tool in that chat until GAIA restarts —
+the grant is never saved, and **Settings → Tools & Permissions** lists every
+active grant so you can revoke it. The CLI asks on the terminal and defaults to no.
 A run with no terminal to ask — piped, CI, or otherwise unattended — refuses the
 tool rather than approving it.
 </Note>

--- a/src/gaia/apps/webui/main.cjs
+++ b/src/gaia/apps/webui/main.cjs
@@ -70,6 +70,12 @@ const {
   dispatchDeepLink,
   buildInstallPrompt,
 } = require("./services/deep-link.cjs");
+const {
+  isAllowedExternalUrl,
+  isInAppNavigation,
+  describeBlockedUrl,
+} = require("./services/link-policy.cjs");
+const { createStartupDeepLinkQueue } = require("./services/deep-link-queue.cjs");
 
 // ── F7: Ozone hint (issue #782) ─────────────────────────────────────────────
 // Electron-recommended switch for distro-agnostic Linux behaviour: picks
@@ -492,6 +498,27 @@ function findDistPath() {
   return null;
 }
 
+/** Refuse a link loudly — the user clicked it, so they get told why nothing happened. */
+function reportBlockedLink(url) {
+  const message = describeBlockedUrl(url);
+  console.error(`[main] ${message}`);
+  // Non-blocking and parented: showErrorBox would freeze the main process.
+  dialog
+    .showMessageBox(mainWindow && !mainWindow.isDestroyed() ? mainWindow : null, {
+      type: "warning",
+      title: "Link blocked",
+      message: "Link blocked",
+      detail: message,
+      buttons: ["OK"],
+      noLink: true,
+    })
+    .catch((err) =>
+      console.error(
+        `[main] Could not show the link-blocked dialog: ${err && err.message ? err.message : err}`
+      )
+    );
+}
+
 function createWindow() {
   mainWindow = new BrowserWindow({
     width: windowConfig.width,
@@ -511,10 +538,29 @@ function createWindow() {
   // Remove default menu bar
   mainWindow.setMenuBarVisibility(false);
 
-  // Open external links in the default browser
+  // Open external links in the default browser. The URL here is already
+  // RESOLVED against the file:// document, so a scheme-less markdown link
+  // arrives as file:///C:/… — check the scheme before handing it to the OS.
   mainWindow.webContents.setWindowOpenHandler(({ url }) => {
-    shell.openExternal(url);
+    if (isAllowedExternalUrl(url)) {
+      shell.openExternal(url);
+    } else {
+      reportBlockedLink(url);
+    }
     return { action: "deny" };
+  });
+
+  // Nothing may navigate the app window away from its own document. In-page
+  // anchors pass; web links open in the browser; everything else is refused.
+  mainWindow.webContents.on("will-navigate", (event, url) => {
+    const currentUrl = mainWindow.webContents.getURL();
+    if (isInAppNavigation(url, currentUrl)) return;
+    event.preventDefault();
+    if (isAllowedExternalUrl(url)) {
+      shell.openExternal(url);
+      return;
+    }
+    reportBlockedLink(url);
   });
 
   // ── Minimize-to-tray on close (C4 fix) ──────────────────────────────
@@ -751,8 +797,15 @@ async function bootstrapBackend() {
 // A malformed/unsupported link surfaces a loud error dialog — never a silent
 // no-op (deep-link.cjs throws with an actionable message).
 
-/** Holds a deep link that arrived before services were ready. */
-let pendingDeepLinkUrl = null;
+// Holds gaia:// links until startup has waited for the backend (the install
+// gate verifies the agent through its catalog API), then dispatches each once.
+const startupDeepLinks = createStartupDeepLinkQueue({
+  dispatch: (rawUrl) => {
+    void runDeepLink(parseDeepLink(rawUrl));
+  },
+  reportNotReady: reportDeepLinksNotReady,
+  logger: console,
+});
 
 /**
  * Register this app as the handler for the gaia:// scheme. In dev (`electron .`)
@@ -785,13 +838,13 @@ function registerProtocolHandler() {
 }
 
 /**
- * Entry point for any inbound deep link. Queues the URL if services aren't up
- * yet, otherwise dispatches immediately. Parse failures are surfaced loudly.
+ * Entry point for any inbound deep link. Validates it now (a bad link is
+ * refused loudly and immediately), then hands it to the startup queue, which
+ * holds it until the backend is ready and dispatches it immediately after.
  */
 function handleDeepLink(rawUrl) {
-  let command;
   try {
-    command = parseDeepLink(rawUrl);
+    parseDeepLink(rawUrl);
   } catch (err) {
     const message = err && err.message ? err.message : String(err);
     console.error(`[main] Rejected deep link: ${message}`);
@@ -803,14 +856,7 @@ function handleDeepLink(rawUrl) {
     return;
   }
 
-  // If services aren't wired yet (cold start still bootstrapping), stash it.
-  if (!agentProcessManager) {
-    console.log("[main] Deep link received before services ready — queuing");
-    pendingDeepLinkUrl = rawUrl;
-    return;
-  }
-
-  void runDeepLink(command);
+  startupDeepLinks.accept(rawUrl);
 }
 
 /**
@@ -889,16 +935,32 @@ async function runDeepLink(command) {
   }
 }
 
-/** Drain a queued deep link, plus any gaia:// URL present in the cold-start argv. */
-function processStartupDeepLinks() {
-  if (pendingDeepLinkUrl) {
-    const url = pendingDeepLinkUrl;
-    pendingDeepLinkUrl = null;
-    handleDeepLink(url);
-    return;
+/**
+ * Release queued deep links, plus any gaia:// URL in the cold-start argv. Call
+ * once, after startup has waited for the backend.
+ *
+ * @param {boolean} backendReady Whether the backend API answered its health check.
+ */
+function processStartupDeepLinks(backendReady) {
+  startupDeepLinks.drain({ backendReady, argvUrl: extractDeepLinkFromArgv(process.argv) });
+}
+
+/** The backend never came up: tell the user instead of dispatching blind. */
+function reportDeepLinksNotReady(urls) {
+  const why = backendProcess
+    ? `did not answer within ${Math.round(STARTUP_TIMEOUT / 1000)}s`
+    : "could not be started";
+  const message =
+    `GAIA could not open ${urls.map((u) => `"${u}"`).join(", ")} because ` +
+    `its backend ${why}, so the agent cannot be verified before install. ` +
+    `Check ${_MAIN_LOG_PATH} for the startup error, then click the link ` +
+    "again once GAIA is running.";
+  console.error(`[main] ${message}`);
+  try {
+    dialog.showErrorBox("GAIA is not ready yet", message);
+  } catch {
+    /* best-effort */
   }
-  const fromArgv = extractDeepLinkFromArgv(process.argv);
-  if (fromArgv) handleDeepLink(fromArgv);
 }
 
 // macOS delivers deep links via this event; it can fire before whenReady, so
@@ -1029,10 +1091,6 @@ app.whenReady().then(async () => {
   // Setup Windows Jump List (T11)
   setupJumpList();
 
-  // Act on any gaia:// deep link that arrived during bootstrap or via the
-  // cold-start command line (issue #1725). Services are now wired.
-  processStartupDeepLinks();
-
   // Show loading state
   await loadApp();
 
@@ -1041,15 +1099,21 @@ app.whenReady().then(async () => {
   // API becomes available and dismisses its "Cannot connect" banner.
   // We do NOT reload the window with http://localhost:4200/ because
   // the pip-installed backend has no frontend files — only the API.
+  let backendReady = false;
   if (backendProcess) {
     console.log("Waiting for backend to start...");
-    const ready = await waitForBackend(STARTUP_TIMEOUT);
-    if (ready) {
+    backendReady = await waitForBackend(STARTUP_TIMEOUT);
+    if (backendReady) {
       console.log("Backend API is ready on port", backendPort);
     } else {
       console.warn("Backend did not respond within timeout.");
     }
   }
+
+  // Act on any gaia:// deep link that arrived during bootstrap or via the
+  // cold-start command line (issue #1725) — after the backend is listening,
+  // because the install gate queries its catalog API.
+  processStartupDeepLinks(backendReady);
 
   // Auto-start enabled agents (T2)
   if (agentProcessManager) {

--- a/src/gaia/apps/webui/services/backend-installer.cjs
+++ b/src/gaia/apps/webui/services/backend-installer.cjs
@@ -1456,9 +1456,8 @@ async function installBackend(opts = {}) {
     "--python",
     GAIA_PYTHON_BIN,
   ];
-  // Linux/macOS: use CPU-only PyTorch to avoid huge CUDA wheels.
-  // Skip when installing from a local wheel — PyPI index not needed.
-  if (!IS_WINDOWS && !localWheel) {
+  // A local GAIA wheel still downloads PyTorch and its transitive dependencies.
+  if (!IS_WINDOWS) {
     pipArgs.push("--extra-index-url", "https://download.pytorch.org/whl/cpu");
   }
 

--- a/src/gaia/apps/webui/services/deep-link-queue.cjs
+++ b/src/gaia/apps/webui/services/deep-link-queue.cjs
@@ -1,0 +1,77 @@
+// Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+/**
+ * deep-link-queue.cjs — hold gaia:// links until the backend can verify them.
+ *
+ * A cold-start "Open in GAIA" link reaches the app long before the backend
+ * listens, and the install gate resolves the agent through the backend's
+ * catalog API (failing closed). This queue holds every link that arrives
+ * before startup has waited for the backend, then dispatches each exactly
+ * once. Electron-free so the ordering can be unit-tested.
+ */
+
+"use strict";
+
+/**
+ * @param {object} deps
+ * @param {(rawUrl: string) => void} deps.dispatch Act on one validated link.
+ * @param {(rawUrls: string[]) => void} deps.reportNotReady Tell the user the
+ *   queued links could not be opened because the backend never came up.
+ * @param {{log: Function}} [deps.logger]
+ */
+function createStartupDeepLinkQueue({ dispatch, reportNotReady, logger = console }) {
+  if (typeof dispatch !== "function" || typeof reportNotReady !== "function") {
+    throw new Error("createStartupDeepLinkQueue requires dispatch and reportNotReady functions");
+  }
+  const pending = [];
+  let drained = false;
+
+  return {
+    /**
+     * Accept a validated link: queue it until drain(), dispatch it after.
+     * @returns {"queued" | "duplicate" | "dispatched"}
+     */
+    accept(rawUrl) {
+      if (drained) {
+        dispatch(rawUrl);
+        return "dispatched";
+      }
+      if (pending.includes(rawUrl)) return "duplicate";
+      pending.push(rawUrl);
+      logger.log(`[deep-link] Queued until the backend is ready: ${rawUrl}`);
+      return "queued";
+    },
+
+    /**
+     * Release the queue once, after startup has waited for the backend.
+     * Later calls are no-ops, so nothing is dispatched twice.
+     *
+     * @param {{backendReady: boolean, argvUrl?: string|null}} opts
+     * @returns {string[]} The links dispatched by this call.
+     */
+    drain({ backendReady, argvUrl = null }) {
+      if (drained) return [];
+      drained = true;
+      const urls = pending.splice(0);
+      if (argvUrl && !urls.includes(argvUrl)) urls.push(argvUrl);
+      if (urls.length === 0) return [];
+      if (!backendReady) {
+        reportNotReady(urls);
+        return [];
+      }
+      for (const url of urls) dispatch(url);
+      return urls;
+    },
+
+    get isDrained() {
+      return drained;
+    },
+
+    get pendingCount() {
+      return pending.length;
+    },
+  };
+}
+
+module.exports = { createStartupDeepLinkQueue };

--- a/src/gaia/apps/webui/services/link-policy.cjs
+++ b/src/gaia/apps/webui/services/link-policy.cjs
@@ -1,0 +1,90 @@
+// Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+/**
+ * link-policy.cjs — which URLs the shell is allowed to hand to the OS.
+ *
+ * The renderer is loaded from `file://`, so a scheme-less link in
+ * LLM-rendered markdown (`/Windows/System32/calc.exe`, `//host/share/x.exe`)
+ * RESOLVES to `file:///C:/…` / `file://host/…` before Electron hands it to
+ * `setWindowOpenHandler`. Passing that to `shell.openExternal` is a
+ * ShellExecute on a local binary or an SMB fetch. The check therefore runs on
+ * the resolved URL and allows only web/mail schemes.
+ *
+ * Electron-free so it can be unit-tested without a running app; main.cjs owns
+ * the window handlers that call it.
+ */
+
+"use strict";
+
+/** The only schemes `shell.openExternal` may ever receive. */
+const ALLOWED_EXTERNAL_SCHEMES = new Set(["http:", "https:", "mailto:"]);
+
+/**
+ * @param {string} rawUrl A URL already resolved by Electron/Chromium.
+ * @returns {boolean} True when it is safe to hand to `shell.openExternal`.
+ */
+function isAllowedExternalUrl(rawUrl) {
+  if (typeof rawUrl !== "string" || rawUrl === "") return false;
+  let parsed;
+  try {
+    parsed = new URL(rawUrl);
+  } catch {
+    return false; // Unresolvable/relative — never openExternal it.
+  }
+  return ALLOWED_EXTERNAL_SCHEMES.has(parsed.protocol.toLowerCase());
+}
+
+/**
+ * True when `targetUrl` is the document already loaded, differing only by
+ * fragment or query — i.e. an in-app anchor, not a navigation away.
+ *
+ * @param {string} targetUrl
+ * @param {string} currentUrl
+ * @returns {boolean}
+ */
+function isInAppNavigation(targetUrl, currentUrl) {
+  if (typeof targetUrl !== "string" || typeof currentUrl !== "string") return false;
+  let target;
+  let current;
+  try {
+    target = new URL(targetUrl);
+    current = new URL(currentUrl);
+  } catch {
+    return false;
+  }
+  return (
+    target.protocol === current.protocol &&
+    target.host === current.host &&
+    target.pathname === current.pathname
+  );
+}
+
+/**
+ * A one-line, user-facing reason a URL was refused. Never silently dropped —
+ * the caller logs this and shows it, so a blocked click is explainable.
+ *
+ * @param {string} rawUrl
+ * @returns {string}
+ */
+function describeBlockedUrl(rawUrl) {
+  const shown = typeof rawUrl === "string" && rawUrl ? rawUrl : String(rawUrl);
+  let scheme = "no scheme";
+  try {
+    scheme = new URL(shown).protocol.replace(/:$/, "");
+  } catch {
+    /* keep "no scheme" */
+  }
+  return (
+    `GAIA refused to open "${shown.slice(0, 300)}" (${scheme}). ` +
+    "Only http, https and mailto links open outside the app — a link that " +
+    "resolves to a local file or network share is never launched."
+  );
+}
+
+module.exports = {
+  ALLOWED_EXTERNAL_SCHEMES,
+  isAllowedExternalUrl,
+  isInAppNavigation,
+  describeBlockedUrl,
+};

--- a/src/gaia/apps/webui/services/notification-service.cjs
+++ b/src/gaia/apps/webui/services/notification-service.cjs
@@ -330,34 +330,56 @@ class NotificationService extends EventEmitter {
     // Listen for agent notifications via the EventEmitter
     this.agentProcessManager.on(
       "agent-notification",
-      (agentId, params) => {
+      this._guardListener("agent-notification", (agentId, params) => {
         this.handleAgentNotification(agentId, params);
-      }
+      })
     );
 
     // Agent crash → generate error notification
-    this.agentProcessManager.on("status-change", (payload) => {
-      if (payload.status === "stopped" && payload.detail) {
-        // Only notify on unexpected stops (crashes)
-        this.handleAgentNotification(payload.agentId, {
-          type: "error",
-          title: "Agent Crashed",
-          message: payload.detail || `Agent ${payload.agentId} stopped unexpectedly`,
-        });
-      }
-    });
+    this.agentProcessManager.on(
+      "status-change",
+      this._guardListener("status-change", (payload) => {
+        if (payload.status === "stopped" && payload.detail) {
+          // Only notify on unexpected stops (crashes)
+          this.handleAgentNotification(payload.agentId, {
+            type: "error",
+            title: "Agent Crashed",
+            message: payload.detail || `Agent ${payload.agentId} stopped unexpectedly`,
+          });
+        }
+      })
+    );
 
     // Crash limit reached → generate error notification
     this.agentProcessManager.on(
       "agent-crash-limit",
-      (agentId, crashCount) => {
+      this._guardListener("agent-crash-limit", (agentId, crashCount) => {
         this.handleAgentNotification(agentId, {
           type: "error",
           title: "Agent Crash Limit Reached",
           message: `Agent ${agentId} crashed ${crashCount} times — automatic restart disabled`,
         });
-      }
+      })
     );
+  }
+
+  /**
+   * Wrap an EventEmitter listener so a throw inside it is logged instead of
+   * escaping as an uncaughtException — these fire from a child-process `exit`
+   * handler, where an unhandled throw takes the whole app down with the
+   * backend and sidecars still running.
+   */
+  _guardListener(eventName, fn) {
+    return (...args) => {
+      try {
+        fn(...args);
+      } catch (err) {
+        console.error(
+          `[notif] Listener for "${eventName}" threw and was contained: ` +
+            `${err && err.stack ? err.stack : err}`
+        );
+      }
+    };
   }
 
   // ── Private: Persistence ─────────────────────────────────────────────

--- a/src/gaia/apps/webui/services/tray-manager.cjs
+++ b/src/gaia/apps/webui/services/tray-manager.cjs
@@ -53,6 +53,9 @@ class TrayManager {
     /** @type {Electron.Tray | null} */
     this.tray = null;
 
+    /** @type {number} Unread notifications reflected in the tooltip/badge. */
+    this._notificationCount = 0;
+
     /** @type {object} */
     this.config = this._loadConfig();
 
@@ -69,7 +72,8 @@ class TrayManager {
     if (this.tray) return;
 
     this.tray = new Tray(this._icon);
-    this.tray.setToolTip("GAIA");
+    // Re-apply any count that arrived before the tray existed.
+    this.setNotificationCount(this._notificationCount);
 
     // Single-click: show/focus window
     this.tray.on("click", () => this._showWindow());
@@ -93,6 +97,45 @@ class TrayManager {
   /** Update the context menu. */
   refresh() {
     this._rebuildContextMenu();
+  }
+
+  /**
+   * Reflect the unread-notification count in the tray tooltip (and the dock /
+   * launcher badge where the platform has one).
+   *
+   * @param {number} count Unread notifications; negative/NaN is treated as 0.
+   */
+  setNotificationCount(count) {
+    const unread =
+      typeof count === "number" && Number.isFinite(count) && count > 0
+        ? Math.floor(count)
+        : 0;
+    if (unread !== this._notificationCount) {
+      console.log(`[tray] Unread notifications: ${unread}`);
+    }
+    this._notificationCount = unread;
+
+    const trayAlive =
+      this.tray &&
+      !(typeof this.tray.isDestroyed === "function" && this.tray.isDestroyed());
+    if (trayAlive) {
+      this.tray.setToolTip(
+        unread > 0
+          ? `GAIA — ${unread} unread notification${unread === 1 ? "" : "s"}`
+          : "GAIA"
+      );
+    }
+
+    // Dock (macOS) / Unity launcher (Linux) badge. Windows has no
+    // app.setBadgeCount equivalent — the tooltip above is the badge there.
+    if (process.platform !== "win32" && typeof app.setBadgeCount === "function") {
+      app.setBadgeCount(unread);
+    }
+  }
+
+  /** @returns {number} The unread count last passed to setNotificationCount. */
+  get notificationCount() {
+    return this._notificationCount || 0;
   }
 
   /** @returns {boolean} Whether minimize-to-tray is enabled. */

--- a/src/gaia/apps/webui/src/components/ChatView.tsx
+++ b/src/gaia/apps/webui/src/components/ChatView.tsx
@@ -5,7 +5,7 @@ import { useEffect, useRef, useCallback, useState, useMemo } from 'react';
 import { Bell, Edit3, Paperclip, Download, Send, Upload, MessageSquare, Square, ArrowDown, Lock, FileText, FolderSearch, CheckCircle2, X, Brain, EyeOff, Bot, ChevronDown, Plus } from 'lucide-react';
 import { MessageBubble } from './MessageBubble';
 import { useChatStore } from '../stores/chatStore';
-import { useNotificationStore, ALWAYS_ALLOW_TOOLS_KEY, selectUnreadCount } from '../stores/notificationStore';
+import { useNotificationStore, selectUnreadCount } from '../stores/notificationStore';
 import type { GaiaNotification } from '../types/agent';
 import * as api from '../services/api';
 import { log } from '../utils/logger';
@@ -790,10 +790,8 @@ export function ChatView({ sessionId, onCreateAgent, onAgentChange }: ChatViewPr
                         return;
                     }
                     const toolName = event.tool || '';
-                    const alwaysAllowed: string[] = JSON.parse(
-                        localStorage.getItem(ALWAYS_ALLOW_TOOLS_KEY) || '[]'
-                    );
-                    if (alwaysAllowed.includes(toolName)) {
+                    // Granted for this chat only (revocable in Settings → Tools & Permissions).
+                    if (useNotificationStore.getState().isAlwaysAllowed(sessionId, toolName)) {
                         // Auto-approve without showing the modal
                         api.confirmToolExecution(sessionId, event.confirm_id, 'allow', false).catch(
                             (err) => console.error('[ChatView] auto-confirm failed:', err)
@@ -805,6 +803,7 @@ export function ChatView({ sessionId, onCreateAgent, onAgentChange }: ChatViewPr
                         id: event.confirm_id,
                         type: 'permission_request',
                         agentId: 'chat',
+                        sessionId,
                         agentName: 'GAIA',
                         title: `Allow ${toolName}?`,
                         message: `The agent wants to execute: ${toolName}`,
@@ -824,10 +823,7 @@ export function ChatView({ sessionId, onCreateAgent, onAgentChange }: ChatViewPr
                 // notification store for the PermissionPrompt overlay.
                 if (event.type === 'permission_request') {
                     const toolName = event.tool || '';
-                    const alwaysAllowed: string[] = JSON.parse(
-                        localStorage.getItem(ALWAYS_ALLOW_TOOLS_KEY) || '[]'
-                    );
-                    if (alwaysAllowed.includes(toolName)) {
+                    if (useNotificationStore.getState().isAlwaysAllowed(sessionId, toolName)) {
                         api.confirmTool(sessionId, true).catch(
                             (err) => console.error('[ChatView] auto-confirm failed:', err)
                         );
@@ -838,6 +834,7 @@ export function ChatView({ sessionId, onCreateAgent, onAgentChange }: ChatViewPr
                         id: event.confirm_id ?? `perm-${Date.now()}`,
                         type: 'permission_request',
                         agentId: sessionId,
+                        sessionId,
                         agentName: 'GAIA',
                         title: `Allow ${toolName}?`,
                         message: `The agent wants to execute: ${toolName}`,

--- a/src/gaia/apps/webui/src/components/ChatView.tsx
+++ b/src/gaia/apps/webui/src/components/ChatView.tsx
@@ -783,42 +783,6 @@ export function ChatView({ sessionId, onCreateAgent, onAgentChange }: ChatViewPr
                 // Ignore events from a stream the user navigated away from so its
                 // steps don't leak into the new session's view (#1580).
                 if (isStale()) return;
-                // ── Tool confirmation popup ──────────────────────────────
-                if (event.type === 'tool_confirm') {
-                    if (!event.confirm_id) {
-                        console.error('[ChatView] tool_confirm event missing confirm_id, ignoring');
-                        return;
-                    }
-                    const toolName = event.tool || '';
-                    // Granted for this chat only (revocable in Settings → Tools & Permissions).
-                    if (useNotificationStore.getState().isAlwaysAllowed(sessionId, toolName)) {
-                        // Auto-approve without showing the modal
-                        api.confirmToolExecution(sessionId, event.confirm_id, 'allow', false).catch(
-                            (err) => console.error('[ChatView] auto-confirm failed:', err)
-                        );
-                        return;
-                    }
-                    // Show the PermissionPrompt modal via notificationStore
-                    const notification: GaiaNotification = {
-                        id: event.confirm_id,
-                        type: 'permission_request',
-                        agentId: 'chat',
-                        sessionId,
-                        agentName: 'GAIA',
-                        title: `Allow ${toolName}?`,
-                        message: `The agent wants to execute: ${toolName}`,
-                        timestamp: Date.now(),
-                        read: false,
-                        dismissed: false,
-                        priority: 'high',
-                        tool: toolName,
-                        toolArgs: event.args as Record<string, unknown> | undefined,
-                        timeoutSeconds: event.timeout_seconds ?? 60,
-                    };
-                    addNotification(notification);
-                    return;
-                }
-
                 // Permission request — check always-allow list, then push to
                 // notification store for the PermissionPrompt overlay.
                 if (event.type === 'permission_request') {

--- a/src/gaia/apps/webui/src/components/PermissionManager.tsx
+++ b/src/gaia/apps/webui/src/components/PermissionManager.tsx
@@ -15,6 +15,7 @@ import {
   Info,
 } from 'lucide-react';
 import { useAgentStore } from '../stores/agentStore';
+import { SessionToolGrants } from './SessionToolGrants';
 import type { PermissionTier, ToolPermission } from '../types/agent';
 import './PermissionManager.css';
 
@@ -276,6 +277,9 @@ export function PermissionManager({ agentId }: PermissionManagerProps) {
           </button>
         )}
       </div>
+
+      {/* Session always-allow grants — revocable here and in Settings */}
+      <SessionToolGrants />
 
       {/* Tier legend */}
       <div className="perm-legend">

--- a/src/gaia/apps/webui/src/components/PermissionManager.tsx
+++ b/src/gaia/apps/webui/src/components/PermissionManager.tsx
@@ -15,7 +15,6 @@ import {
   Info,
 } from 'lucide-react';
 import { useAgentStore } from '../stores/agentStore';
-import { SessionToolGrants } from './SessionToolGrants';
 import type { PermissionTier, ToolPermission } from '../types/agent';
 import './PermissionManager.css';
 
@@ -277,9 +276,6 @@ export function PermissionManager({ agentId }: PermissionManagerProps) {
           </button>
         )}
       </div>
-
-      {/* Session always-allow grants — revocable here and in Settings */}
-      <SessionToolGrants />
 
       {/* Tier legend */}
       <div className="perm-legend">

--- a/src/gaia/apps/webui/src/components/PermissionPrompt.css
+++ b/src/gaia/apps/webui/src/components/PermissionPrompt.css
@@ -193,7 +193,7 @@
 /* ── Remember Checkbox ───────────────────────────────────────────────── */
 .permission-remember {
   display: flex;
-  align-items: center;
+  align-items: flex-start;
   gap: 8px;
   padding: 10px 20px;
   font-size: 13px;
@@ -210,6 +210,12 @@
   height: 16px;
   accent-color: var(--accent);
   cursor: pointer;
+}
+.permission-remember-hint {
+  display: block;
+  margin-top: 2px;
+  font-size: 11px;
+  color: var(--text-tertiary, var(--text-secondary));
 }
 .permission-remember code {
   font-family: var(--font-mono);

--- a/src/gaia/apps/webui/src/components/PermissionPrompt.tsx
+++ b/src/gaia/apps/webui/src/components/PermissionPrompt.tsx
@@ -202,7 +202,7 @@ function PermissionPromptInner({ notification, onRespond }: PromptInnerProps) {
           <span>
             Allow this tool for the rest of this chat
             <small className="permission-remember-hint">
-              Only in this chat, until GAIA restarts. Revoke any time in Settings → Tools &amp; Permissions.
+              Only in this chat, until you reload or restart GAIA. Revoke any time in Settings → Tools &amp; Permissions.
             </small>
           </span>
         </label>

--- a/src/gaia/apps/webui/src/components/PermissionPrompt.tsx
+++ b/src/gaia/apps/webui/src/components/PermissionPrompt.tsx
@@ -199,7 +199,12 @@ function PermissionPromptInner({ notification, onRespond }: PromptInnerProps) {
             onChange={(e) => setRemember(e.target.checked)}
             disabled={isResponding}
           />
-          <span>Always allow this tool</span>
+          <span>
+            Allow this tool for the rest of this chat
+            <small className="permission-remember-hint">
+              Only in this chat, until GAIA restarts. Revoke any time in Settings → Tools &amp; Permissions.
+            </small>
+          </span>
         </label>
       </div>
 

--- a/src/gaia/apps/webui/src/components/SessionToolGrants.css
+++ b/src/gaia/apps/webui/src/components/SessionToolGrants.css
@@ -1,0 +1,76 @@
+/* Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved. */
+/* SPDX-License-Identifier: MIT */
+/* ── Session always-allow grants ──────────────────────────────────────── */
+.perm-session-grants {
+  margin: 0 0 14px;
+  padding: 12px 14px;
+  border: 1px solid var(--border-light);
+  border-radius: var(--radius-sm, 6px);
+  background: var(--bg-secondary);
+}
+.perm-session-grants-head {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+.perm-session-grants-icon {
+  color: #f59e0b;
+  flex-shrink: 0;
+}
+.perm-session-grants-title {
+  margin: 0;
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text-primary);
+}
+.perm-session-revoke-all {
+  margin-left: auto;
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+}
+.perm-session-grants-empty {
+  margin: 8px 0 0;
+  font-size: 12px;
+  line-height: 1.5;
+  color: var(--text-secondary);
+}
+.perm-session-grant-list {
+  list-style: none;
+  margin: 10px 0 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+.perm-session-grant {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+.perm-session-grant-note {
+  font-size: 11px;
+  color: var(--text-secondary);
+}
+.perm-session-grant-revoke {
+  margin-left: auto;
+  padding: 3px 10px;
+  font-size: 12px;
+  border-radius: var(--radius-xs, 4px);
+  border: 1px solid rgba(239, 68, 68, 0.35);
+  background: rgba(239, 68, 68, 0.08);
+  color: #ef4444;
+  cursor: pointer;
+}
+.perm-session-grant-revoke:hover {
+  background: rgba(239, 68, 68, 0.16);
+}
+
+.perm-session-grants .perm-tool-name {
+  font-family: var(--font-mono);
+  font-size: 12px;
+  padding: 1px 6px;
+  border-radius: var(--radius-xs, 4px);
+  background: var(--bg-tertiary);
+  color: var(--text-primary);
+}

--- a/src/gaia/apps/webui/src/components/SessionToolGrants.tsx
+++ b/src/gaia/apps/webui/src/components/SessionToolGrants.tsx
@@ -41,7 +41,7 @@ export function SessionToolGrants() {
                 <p className="perm-session-grants-empty">
                     No tools are auto-approved. Ticking &ldquo;Allow this tool for the rest of
                     this chat&rdquo; on a permission prompt adds one here. A grant covers only that
-                    chat and ends when GAIA restarts.
+                    chat and ends when you reload or restart GAIA.
                 </p>
             ) : (
                 <ul className="perm-session-grant-list">
@@ -51,7 +51,7 @@ export function SessionToolGrants() {
                             <li key={`${sessionId}:${tool}`} className="perm-session-grant">
                                 <code className="perm-tool-name">{tool}</code>
                                 <span className="perm-session-grant-note">
-                                    in &ldquo;{title}&rdquo; until restart
+                                    in &ldquo;{title}&rdquo; until reload or restart
                                 </span>
                                 <button
                                     className="perm-session-grant-revoke"

--- a/src/gaia/apps/webui/src/components/SessionToolGrants.tsx
+++ b/src/gaia/apps/webui/src/components/SessionToolGrants.tsx
@@ -1,0 +1,70 @@
+// Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+/**
+ * Session tool grants — every tool the user allowed "for the rest of this
+ * chat", and the place to revoke them. Grants live in `notificationStore`
+ * only, so the list is empty again after a reload or restart.
+ */
+
+import { ShieldCheck, RotateCcw } from 'lucide-react';
+import { useNotificationStore, selectAlwaysAllowGrants } from '../stores/notificationStore';
+import { useChatStore } from '../stores/chatStore';
+import './SessionToolGrants.css';
+
+export function SessionToolGrants() {
+    const grants = useNotificationStore(selectAlwaysAllowGrants);
+    const revokeAlwaysAllow = useNotificationStore((s) => s.revokeAlwaysAllow);
+    const revokeAllAlwaysAllow = useNotificationStore((s) => s.revokeAllAlwaysAllow);
+    const sessions = useChatStore((s) => s.sessions);
+    const chatTitle = (sessionId: string) =>
+        sessions.find((s) => s.id === sessionId)?.title || sessionId;
+
+    return (
+        <section className="perm-session-grants" aria-labelledby="perm-session-grants-title">
+            <div className="perm-session-grants-head">
+                <ShieldCheck size={14} className="perm-session-grants-icon" />
+                <h4 id="perm-session-grants-title" className="perm-session-grants-title">
+                    Tools allowed without asking
+                </h4>
+                {grants.length > 0 && (
+                    <button
+                        className="btn-secondary perm-session-revoke-all"
+                        onClick={revokeAllAlwaysAllow}
+                    >
+                        <RotateCcw size={13} />
+                        Revoke All
+                    </button>
+                )}
+            </div>
+            {grants.length === 0 ? (
+                <p className="perm-session-grants-empty">
+                    No tools are auto-approved. Ticking &ldquo;Allow this tool for the rest of
+                    this chat&rdquo; on a permission prompt adds one here. A grant covers only that
+                    chat and ends when GAIA restarts.
+                </p>
+            ) : (
+                <ul className="perm-session-grant-list">
+                    {grants.map(({ sessionId, tool }) => {
+                        const title = chatTitle(sessionId);
+                        return (
+                            <li key={`${sessionId}:${tool}`} className="perm-session-grant">
+                                <code className="perm-tool-name">{tool}</code>
+                                <span className="perm-session-grant-note">
+                                    in &ldquo;{title}&rdquo; until restart
+                                </span>
+                                <button
+                                    className="perm-session-grant-revoke"
+                                    onClick={() => revokeAlwaysAllow(sessionId, tool)}
+                                    aria-label={`Revoke ${tool} in ${title}`}
+                                >
+                                    Revoke
+                                </button>
+                            </li>
+                        );
+                    })}
+                </ul>
+            )}
+        </section>
+    );
+}

--- a/src/gaia/apps/webui/src/components/SettingsPage.tsx
+++ b/src/gaia/apps/webui/src/components/SettingsPage.tsx
@@ -13,6 +13,7 @@ import type { SystemStatus, MCPServerStatus } from '../types';
 import { CustomAgentsSection } from './CustomAgentsSection';
 import { ConnectorsSection } from './ConnectorsSection';
 import { VersionPicker } from './VersionPicker';
+import { SessionToolGrants } from './SessionToolGrants';
 import './ConnectorsSection.css';
 import './SettingsModal.css';
 import './SettingsPage.css';
@@ -606,6 +607,12 @@ export function SettingsPage() {
                 {showVersionPicker && (
                     <VersionPicker onClose={() => setShowVersionPicker(false)} />
                 )}
+
+                {/* Tools & Permissions */}
+                <section className="settings-section">
+                    <h4>Tools &amp; Permissions</h4>
+                    <SessionToolGrants />
+                </section>
 
                 {/* Privacy & Data */}
                 <section className="settings-section">

--- a/src/gaia/apps/webui/src/components/__tests__/ChatView.alwaysAllow.test.tsx
+++ b/src/gaia/apps/webui/src/components/__tests__/ChatView.alwaysAllow.test.tsx
@@ -1,0 +1,168 @@
+// Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+/**
+ * ChatView's client-side auto-approve for `tool_confirm`: only an explicit
+ * "allow for the rest of this chat" grant skips the prompt, only in the chat
+ * that granted it, and a one-off (remember=false) allow never does.
+ */
+
+import { act, fireEvent, render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { ChatView } from '../ChatView';
+import { useChatStore } from '../../stores/chatStore';
+import { useNotificationStore } from '../../stores/notificationStore';
+import type { AgentInfo, Session, StreamEvent } from '../../types';
+import * as api from '../../services/api';
+
+vi.mock('../../services/api');
+const mockedApi = vi.mocked(api);
+
+function session(id: string, title: string): Session {
+    return {
+        id,
+        title,
+        created_at: '2026-06-10T00:00:00Z',
+        updated_at: '2026-06-10T00:00:00Z',
+        model: 'qwen',
+        system_prompt: null,
+        message_count: 0,
+        document_ids: [],
+        agent_type: 'doc',
+    };
+}
+const CHAT_A = session('chat-A', 'Chat A');
+const CHAT_B = session('chat-B', 'Chat B');
+
+const DOC_AGENT: AgentInfo = {
+    id: 'doc',
+    name: 'Doc Agent',
+    description: 'Search and answer questions from indexed documents.',
+    source: 'builtin',
+    conversation_starters: [],
+    models: [],
+    tags: [],
+    icon: 'file-text',
+    tools_count: 3,
+};
+
+const toolConfirm = (confirmId: string, tool = 'run_shell_command') =>
+    ({ type: 'tool_confirm', confirm_id: confirmId, tool, args: { command: 'dir' } }) as unknown as StreamEvent;
+
+let captured: api.StreamCallbacks | null = null;
+
+beforeEach(() => {
+    vi.clearAllMocks();
+    captured = null;
+    mockedApi.getMessages.mockResolvedValue({ messages: [], total: 0 });
+    mockedApi.getActiveRuns.mockResolvedValue({ session_ids: [] });
+    mockedApi.listDocuments.mockResolvedValue({
+        documents: [],
+        total: 0,
+        total_size_bytes: 0,
+        total_chunks: 0,
+    });
+    mockedApi.cancelStream.mockResolvedValue(undefined as never);
+    mockedApi.updateSession.mockResolvedValue(undefined as never);
+    mockedApi.confirmTool.mockResolvedValue(undefined as never);
+    mockedApi.confirmToolExecution.mockResolvedValue(undefined as never);
+    mockedApi.sendMessageStream.mockImplementation((_sid, _msg, cbs) => {
+        captured = cbs as api.StreamCallbacks;
+        return new AbortController();
+    });
+    Object.defineProperty(HTMLElement.prototype, 'scrollIntoView', {
+        configurable: true,
+        value: vi.fn(),
+    });
+    useNotificationStore.setState({
+        notifications: [],
+        showPanel: false,
+        typeFilter: null,
+        alwaysAllowGrants: [],
+    });
+});
+
+async function openChat(chat: Session) {
+    useChatStore.setState({
+        agents: [DOC_AGENT],
+        activeAgentId: 'doc',
+        sessions: [CHAT_A, CHAT_B],
+        currentSessionId: chat.id,
+        messages: [],
+        documents: [],
+        isStreaming: false,
+        streamingContent: '',
+        agentSteps: [],
+        cards: [],
+        isLoadingMessages: false,
+        pendingPrompt: null,
+        systemStatus: null,
+    });
+    const view = render(<ChatView sessionId={chat.id} />);
+    await act(async () => {
+        fireEvent.change(screen.getByLabelText('Message input'), { target: { value: 'list files' } });
+        fireEvent.click(screen.getByLabelText('Send message'));
+    });
+    expect(captured).not.toBeNull();
+    return view;
+}
+
+function emit(event: StreamEvent) {
+    act(() => {
+        captured!.onAgentEvent(event);
+    });
+}
+
+const pendingPrompts = () =>
+    useNotificationStore
+        .getState()
+        .notifications.filter((n) => n.type === 'permission_request' && !n.response);
+
+describe('ChatView tool_confirm auto-approve', () => {
+    it('a remember=false allow is never auto-approved later', async () => {
+        await openChat(CHAT_A);
+
+        emit(toolConfirm('c1'));
+        expect(pendingPrompts().map((n) => n.id)).toEqual(['c1']);
+        expect(pendingPrompts()[0].sessionId).toBe('chat-A');
+        await act(() => useNotificationStore.getState().respondToPermission('c1', 'allow', false));
+
+        emit(toolConfirm('c2'));
+        expect(mockedApi.confirmToolExecution).not.toHaveBeenCalled();
+        expect(pendingPrompts().map((n) => n.id)).toEqual(['c2']);
+    });
+
+    it('an "allow for the rest of this chat" grant auto-approves the next call in that chat', async () => {
+        await openChat(CHAT_A);
+
+        emit(toolConfirm('c1'));
+        await act(() => useNotificationStore.getState().respondToPermission('c1', 'allow', true));
+
+        emit(toolConfirm('c2'));
+        expect(mockedApi.confirmToolExecution).toHaveBeenCalledWith('chat-A', 'c2', 'allow', false);
+        expect(pendingPrompts()).toEqual([]);
+    });
+
+    it('a grant from one chat still prompts in another chat', async () => {
+        useNotificationStore.setState({
+            alwaysAllowGrants: [{ sessionId: 'chat-A', tool: 'run_shell_command', grantedAt: 1 }],
+        });
+        await openChat(CHAT_B);
+
+        emit(toolConfirm('c9'));
+        expect(mockedApi.confirmToolExecution).not.toHaveBeenCalled();
+        expect(pendingPrompts().map((n) => n.id)).toEqual(['c9']);
+    });
+
+    it('a revoked grant prompts again', async () => {
+        useNotificationStore.setState({
+            alwaysAllowGrants: [{ sessionId: 'chat-A', tool: 'run_shell_command', grantedAt: 1 }],
+        });
+        await openChat(CHAT_A);
+        useNotificationStore.getState().revokeAlwaysAllow('chat-A', 'run_shell_command');
+
+        emit(toolConfirm('c3'));
+        expect(mockedApi.confirmToolExecution).not.toHaveBeenCalled();
+        expect(pendingPrompts().map((n) => n.id)).toEqual(['c3']);
+    });
+});

--- a/src/gaia/apps/webui/src/components/__tests__/ChatView.alwaysAllow.test.tsx
+++ b/src/gaia/apps/webui/src/components/__tests__/ChatView.alwaysAllow.test.tsx
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 /**
- * ChatView's client-side auto-approve for `tool_confirm`: only an explicit
+ * ChatView's client-side auto-approve for `permission_request`: only an explicit
  * "allow for the rest of this chat" grant skips the prompt, only in the chat
  * that granted it, and a one-off (remember=false) allow never does.
  */
@@ -46,8 +46,8 @@ const DOC_AGENT: AgentInfo = {
     tools_count: 3,
 };
 
-const toolConfirm = (confirmId: string, tool = 'run_shell_command') =>
-    ({ type: 'tool_confirm', confirm_id: confirmId, tool, args: { command: 'dir' } }) as unknown as StreamEvent;
+const permissionRequest = (confirmId: string, tool = 'run_shell_command') =>
+    ({ type: 'permission_request', confirm_id: confirmId, tool, args: { command: 'dir' } }) as unknown as StreamEvent;
 
 let captured: api.StreamCallbacks | null = null;
 
@@ -65,7 +65,6 @@ beforeEach(() => {
     mockedApi.cancelStream.mockResolvedValue(undefined as never);
     mockedApi.updateSession.mockResolvedValue(undefined as never);
     mockedApi.confirmTool.mockResolvedValue(undefined as never);
-    mockedApi.confirmToolExecution.mockResolvedValue(undefined as never);
     mockedApi.sendMessageStream.mockImplementation((_sid, _msg, cbs) => {
         captured = cbs as api.StreamCallbacks;
         return new AbortController();
@@ -118,28 +117,29 @@ const pendingPrompts = () =>
         .getState()
         .notifications.filter((n) => n.type === 'permission_request' && !n.response);
 
-describe('ChatView tool_confirm auto-approve', () => {
+describe('ChatView permission_request auto-approve', () => {
     it('a remember=false allow is never auto-approved later', async () => {
         await openChat(CHAT_A);
 
-        emit(toolConfirm('c1'));
+        emit(permissionRequest('c1'));
         expect(pendingPrompts().map((n) => n.id)).toEqual(['c1']);
         expect(pendingPrompts()[0].sessionId).toBe('chat-A');
         await act(() => useNotificationStore.getState().respondToPermission('c1', 'allow', false));
 
-        emit(toolConfirm('c2'));
-        expect(mockedApi.confirmToolExecution).not.toHaveBeenCalled();
+        emit(permissionRequest('c2'));
+        expect(mockedApi.confirmTool).toHaveBeenCalledTimes(1);
         expect(pendingPrompts().map((n) => n.id)).toEqual(['c2']);
     });
 
     it('an "allow for the rest of this chat" grant auto-approves the next call in that chat', async () => {
         await openChat(CHAT_A);
 
-        emit(toolConfirm('c1'));
+        emit(permissionRequest('c1'));
         await act(() => useNotificationStore.getState().respondToPermission('c1', 'allow', true));
 
-        emit(toolConfirm('c2'));
-        expect(mockedApi.confirmToolExecution).toHaveBeenCalledWith('chat-A', 'c2', 'allow', false);
+        emit(permissionRequest('c2'));
+        expect(mockedApi.confirmTool).toHaveBeenCalledTimes(2);
+        expect(mockedApi.confirmTool).toHaveBeenLastCalledWith('chat-A', true);
         expect(pendingPrompts()).toEqual([]);
     });
 
@@ -149,8 +149,8 @@ describe('ChatView tool_confirm auto-approve', () => {
         });
         await openChat(CHAT_B);
 
-        emit(toolConfirm('c9'));
-        expect(mockedApi.confirmToolExecution).not.toHaveBeenCalled();
+        emit(permissionRequest('c9'));
+        expect(mockedApi.confirmTool).not.toHaveBeenCalled();
         expect(pendingPrompts().map((n) => n.id)).toEqual(['c9']);
     });
 
@@ -161,8 +161,8 @@ describe('ChatView tool_confirm auto-approve', () => {
         await openChat(CHAT_A);
         useNotificationStore.getState().revokeAlwaysAllow('chat-A', 'run_shell_command');
 
-        emit(toolConfirm('c3'));
-        expect(mockedApi.confirmToolExecution).not.toHaveBeenCalled();
+        emit(permissionRequest('c3'));
+        expect(mockedApi.confirmTool).not.toHaveBeenCalled();
         expect(pendingPrompts().map((n) => n.id)).toEqual(['c3']);
     });
 });

--- a/src/gaia/apps/webui/src/components/__tests__/ChatView.confirmation.test.tsx
+++ b/src/gaia/apps/webui/src/components/__tests__/ChatView.confirmation.test.tsx
@@ -13,7 +13,7 @@
  *     coexists with the terminal `final` answer that follows.
  *   - It is a separate, non-blocking surface: dispatching it must NEVER
  *     touch `notificationStore`'s permission-request path or any
- *     `confirm_id`-keyed state (unlike `tool_confirm` / `permission_request`
+ *     `confirm_id`-keyed state (unlike `permission_request`
  *     handled a few lines above in ChatView's `onAgentEvent`).
  *
  * `needs_confirmation` is not yet in `StreamEventType` (types/index.ts) nor
@@ -249,7 +249,7 @@ describe('ChatView needs_confirmation wiring (#2109, stateless D1)', () => {
         expect(selectActivePermissionPrompt(useNotificationStore.getState())).toBeNull();
     });
 
-    it('does not call confirmTool/confirmToolExecution for a needs_confirmation event', async () => {
+    it('does not call confirmTool for a needs_confirmation event', async () => {
         await driveSend();
 
         act(() => {
@@ -257,6 +257,5 @@ describe('ChatView needs_confirmation wiring (#2109, stateless D1)', () => {
         });
 
         expect(mockedApi.confirmTool).not.toHaveBeenCalled();
-        expect(mockedApi.confirmToolExecution).not.toHaveBeenCalled();
     });
 });

--- a/src/gaia/apps/webui/src/components/__tests__/SessionToolGrants.test.tsx
+++ b/src/gaia/apps/webui/src/components/__tests__/SessionToolGrants.test.tsx
@@ -1,0 +1,64 @@
+// Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+import { fireEvent, render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { SessionToolGrants } from '../SessionToolGrants';
+import { useNotificationStore } from '../../stores/notificationStore';
+import { useChatStore } from '../../stores/chatStore';
+import type { Session } from '../../types';
+
+const chat = (id: string, title: string) =>
+    ({ id, title, created_at: '', updated_at: '', model: 'qwen', system_prompt: null,
+       message_count: 0, document_ids: [], agent_type: 'doc' }) as Session;
+
+beforeEach(() => {
+    useChatStore.setState({ sessions: [chat('chat-A', 'Quarterly report'), chat('chat-B', 'Scratch')] });
+    useNotificationStore.setState({ alwaysAllowGrants: [] });
+});
+
+describe('SessionToolGrants', () => {
+    it('says nothing is auto-approved when there are no grants', () => {
+        render(<SessionToolGrants />);
+        expect(screen.getByText(/No tools are auto-approved/)).toBeTruthy();
+        expect(screen.queryByText('Revoke All')).toBeNull();
+    });
+
+    it('lists each grant with the chat it belongs to', () => {
+        useNotificationStore.setState({
+            alwaysAllowGrants: [
+                { sessionId: 'chat-A', tool: 'run_shell_command', grantedAt: 1 },
+                { sessionId: 'chat-B', tool: 'web_search', grantedAt: 2 },
+            ],
+        });
+        render(<SessionToolGrants />);
+        expect(screen.getByLabelText('Revoke run_shell_command in Quarterly report')).toBeTruthy();
+        expect(screen.getByLabelText('Revoke web_search in Scratch')).toBeTruthy();
+    });
+
+    it('Revoke removes that grant from the store and the list', () => {
+        useNotificationStore.setState({
+            alwaysAllowGrants: [
+                { sessionId: 'chat-A', tool: 'run_shell_command', grantedAt: 1 },
+                { sessionId: 'chat-B', tool: 'web_search', grantedAt: 2 },
+            ],
+        });
+        render(<SessionToolGrants />);
+
+        fireEvent.click(screen.getByLabelText('Revoke run_shell_command in Quarterly report'));
+
+        expect(useNotificationStore.getState().isAlwaysAllowed('chat-A', 'run_shell_command')).toBe(false);
+        expect(useNotificationStore.getState().isAlwaysAllowed('chat-B', 'web_search')).toBe(true);
+        expect(screen.queryByLabelText('Revoke run_shell_command in Quarterly report')).toBeNull();
+    });
+
+    it('Revoke All clears every grant', () => {
+        useNotificationStore.setState({
+            alwaysAllowGrants: [{ sessionId: 'chat-A', tool: 'run_shell_command', grantedAt: 1 }],
+        });
+        render(<SessionToolGrants />);
+        fireEvent.click(screen.getByText('Revoke All'));
+        expect(useNotificationStore.getState().alwaysAllowGrants).toEqual([]);
+        expect(screen.getByText(/No tools are auto-approved/)).toBeTruthy();
+    });
+});

--- a/src/gaia/apps/webui/src/main.tsx
+++ b/src/gaia/apps/webui/src/main.tsx
@@ -4,7 +4,12 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import App from './App';
+import { purgeLegacyAlwaysAllow } from './stores/notificationStore';
 import './styles/index.css';
+
+// Always-allow tool grants are session-scoped; drop anything an older build
+// persisted so a past tick cannot silently approve tools in this session.
+purgeLegacyAlwaysAllow();
 
 // Apply saved theme (default to dark)
 const savedTheme = localStorage.getItem('gaia-chat-theme');

--- a/src/gaia/apps/webui/src/services/api.ts
+++ b/src/gaia/apps/webui/src/services/api.ts
@@ -492,7 +492,7 @@ export interface StreamCallbacks {
 /** Agent event types that represent activity rather than content. */
 const AGENT_EVENT_TYPES = new Set([
     'status', 'step', 'thinking', 'plan',
-    'tool_start', 'tool_end', 'tool_result', 'tool_args', 'tool_confirm', 'agent_error',
+    'tool_start', 'tool_end', 'tool_result', 'tool_args', 'agent_error',
     'permission_request', 'needs_confirmation', 'policy_alert',
 ]);
 
@@ -686,16 +686,6 @@ export async function getActiveRuns(): Promise<{ session_ids: string[] }> {
 }
 
 // -- Tool Confirmation ---------------------------------------------------------
-
-/** Resolve a pending tool execution confirmation (Allow or Deny). */
-export async function confirmToolExecution(
-    sessionId: string,
-    confirmId: string,
-    action: 'allow' | 'deny',
-    remember: boolean,
-): Promise<void> {
-    return apiFetch('POST', '/chat/confirm', { session_id: sessionId, confirm_id: confirmId, action, remember });
-}
 
 /** Confirm or deny a tool execution (simplified API for permission_request events). */
 export async function confirmTool(sessionId: string, approved: boolean): Promise<{ status: string; approved: boolean }> {

--- a/src/gaia/apps/webui/src/stores/__tests__/notificationStore.routing.test.ts
+++ b/src/gaia/apps/webui/src/stores/__tests__/notificationStore.routing.test.ts
@@ -1,0 +1,89 @@
+// Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { useNotificationStore } from '../notificationStore';
+import type { GaiaNotification } from '../../types/agent';
+
+const respondPermission = vi.fn();
+
+function request(sessionId?: string): GaiaNotification {
+    return {
+        id: 'permission-1',
+        type: 'permission_request',
+        agentId: 'agent-1',
+        sessionId,
+        agentName: 'GAIA',
+        title: 'Allow write_file?',
+        message: 'Write a file',
+        timestamp: 1,
+        read: false,
+        dismissed: false,
+        priority: 'high',
+        tool: 'write_file',
+    };
+}
+
+beforeEach(() => {
+    useNotificationStore.setState({ notifications: [], alwaysAllowGrants: [] });
+    respondPermission.mockReset().mockResolvedValue(undefined);
+    vi.stubGlobal('gaiaAPI', { notification: { respondPermission } });
+    vi.stubGlobal('fetch', vi.fn(async () => new Response(
+        JSON.stringify({ status: 'ok', approved: true }),
+        { headers: { 'content-type': 'application/json' } },
+    )));
+});
+
+afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+});
+
+describe('permission response ownership in the desktop renderer', () => {
+    it.each(['allow', 'deny'] as const)('sends chat %s to the real API client even with IPC available', async (action) => {
+        useNotificationStore.getState().addNotification(request('chat-1'));
+        await useNotificationStore.getState().respondToPermission('permission-1', action, true);
+
+        expect(fetch).toHaveBeenCalledExactlyOnceWith('/api/chat/confirm-tool', {
+            method: 'POST',
+            headers: { 'x-gaia-ui': '1', 'Content-Type': 'application/json' },
+            body: JSON.stringify({ session_id: 'chat-1', approved: action === 'allow' }),
+        });
+        expect(respondPermission).not.toHaveBeenCalled();
+        expect(useNotificationStore.getState().notifications[0].response).toBe(action);
+        expect(useNotificationStore.getState().isAlwaysAllowed('chat-1', 'write_file')).toBe(action === 'allow');
+    });
+
+    it('delivers OS-agent answers through IPC without a chat grant', async () => {
+        useNotificationStore.getState().addNotification(request());
+        await useNotificationStore.getState().respondToPermission('permission-1', 'allow', true);
+
+        expect(respondPermission).toHaveBeenCalledExactlyOnceWith('permission-1', 'allow', true);
+        expect(fetch).not.toHaveBeenCalled();
+        expect(useNotificationStore.getState().alwaysAllowGrants).toEqual([]);
+        expect(useNotificationStore.getState().notifications[0].response).toBe('allow');
+    });
+
+    it('keeps a rejected chat response actionable without granting or trying IPC', async () => {
+        vi.mocked(fetch).mockResolvedValueOnce(new Response('No active chat session', { status: 404 }));
+        const error = vi.spyOn(console, 'error').mockImplementation(() => {});
+        useNotificationStore.getState().addNotification(request('chat-1'));
+        await useNotificationStore.getState().respondToPermission('permission-1', 'allow', true);
+
+        expect(error).toHaveBeenCalled();
+        expect(respondPermission).not.toHaveBeenCalled();
+        expect(useNotificationStore.getState().notifications[0].response).toBeUndefined();
+        expect(useNotificationStore.getState().alwaysAllowGrants).toEqual([]);
+    });
+
+    it('keeps an OS-agent request pending when IPC is unavailable', async () => {
+        vi.stubGlobal('gaiaAPI', undefined);
+        const error = vi.spyOn(console, 'error').mockImplementation(() => {});
+        useNotificationStore.getState().addNotification(request());
+        await useNotificationStore.getState().respondToPermission('permission-1', 'allow', true);
+
+        expect(error).toHaveBeenCalled();
+        expect(fetch).not.toHaveBeenCalled();
+        expect(useNotificationStore.getState().notifications[0].response).toBeUndefined();
+    });
+});

--- a/src/gaia/apps/webui/src/stores/__tests__/notificationStore.test.ts
+++ b/src/gaia/apps/webui/src/stores/__tests__/notificationStore.test.ts
@@ -1,0 +1,143 @@
+// Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+vi.mock('../../services/api', () => ({
+    confirmTool: vi.fn(() => Promise.resolve()),
+}));
+
+import { confirmTool } from '../../services/api';
+import {
+    useNotificationStore,
+    purgeLegacyAlwaysAllow,
+    LEGACY_ALWAYS_ALLOW_TOOLS_KEY,
+} from '../notificationStore';
+import type { GaiaNotification } from '../../types/agent';
+
+function permissionRequest(id: string, tool: string, sessionId?: string): GaiaNotification {
+    return {
+        id,
+        type: 'permission_request',
+        agentId: sessionId ?? 'os-agent',
+        sessionId,
+        agentName: 'GAIA',
+        title: `Allow ${tool}?`,
+        message: `The agent wants to execute: ${tool}`,
+        timestamp: Date.now(),
+        read: false,
+        dismissed: false,
+        priority: 'high',
+        tool,
+    };
+}
+
+async function allow(id: string, tool: string, sessionId: string | undefined, remember: boolean) {
+    useNotificationStore.getState().addNotification(permissionRequest(id, tool, sessionId));
+    await useNotificationStore.getState().respondToPermission(id, 'allow', remember);
+}
+
+describe('always-allow grants are scoped to one chat session', () => {
+    beforeEach(() => {
+        localStorage.clear();
+        useNotificationStore.setState({ notifications: [], alwaysAllowGrants: [] });
+        vi.mocked(confirmTool).mockClear();
+    });
+
+    it('grants the tool in the chat that asked, and only there', async () => {
+        await allow('p1', 'run_shell_command', 'chat-A', true);
+
+        const { isAlwaysAllowed } = useNotificationStore.getState();
+        expect(isAlwaysAllowed('chat-A', 'run_shell_command')).toBe(true);
+        expect(isAlwaysAllowed('chat-B', 'run_shell_command')).toBe(false);
+        expect(isAlwaysAllowed('chat-A', 'write_file')).toBe(false);
+    });
+
+    it('never writes a grant to localStorage', async () => {
+        await allow('p1', 'run_shell_command', 'chat-A', true);
+        expect(localStorage.length).toBe(0);
+    });
+
+    it('a remember=false allow creates no grant', async () => {
+        await allow('p1', 'write_file', 'chat-A', false);
+        expect(useNotificationStore.getState().alwaysAllowGrants).toEqual([]);
+        expect(useNotificationStore.getState().isAlwaysAllowed('chat-A', 'write_file')).toBe(false);
+    });
+
+    it('a deny with remember ticked creates no grant', async () => {
+        useNotificationStore.getState().addNotification(permissionRequest('p1', 'delete_file', 'chat-A'));
+        await useNotificationStore.getState().respondToPermission('p1', 'deny', true);
+        expect(useNotificationStore.getState().alwaysAllowGrants).toEqual([]);
+    });
+
+    it('a request with no chat session (an OS agent) creates no renderer grant', async () => {
+        await allow('p1', 'read_file', undefined, true);
+        expect(useNotificationStore.getState().alwaysAllowGrants).toEqual([]);
+    });
+
+    it('does not grant when the answer never reached the agent', async () => {
+        vi.mocked(confirmTool).mockRejectedValueOnce(new Error('offline'));
+        const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+        await allow('p1', 'run_shell_command', 'chat-A', true);
+        expect(useNotificationStore.getState().alwaysAllowGrants).toEqual([]);
+        errorSpy.mockRestore();
+    });
+
+    it('granting twice keeps one grant', async () => {
+        await allow('p1', 'web_search', 'chat-A', true);
+        await allow('p2', 'web_search', 'chat-A', true);
+        expect(useNotificationStore.getState().alwaysAllowGrants).toHaveLength(1);
+    });
+
+    it('revoking removes exactly that grant; Revoke All removes the rest', async () => {
+        await allow('p1', 'run_shell_command', 'chat-A', true);
+        await allow('p2', 'run_shell_command', 'chat-B', true);
+        await allow('p3', 'web_search', 'chat-A', true);
+
+        useNotificationStore.getState().revokeAlwaysAllow('chat-A', 'run_shell_command');
+        const s = useNotificationStore.getState();
+        expect(s.isAlwaysAllowed('chat-A', 'run_shell_command')).toBe(false);
+        expect(s.isAlwaysAllowed('chat-B', 'run_shell_command')).toBe(true);
+        expect(s.isAlwaysAllowed('chat-A', 'web_search')).toBe(true);
+
+        useNotificationStore.getState().revokeAllAlwaysAllow();
+        expect(useNotificationStore.getState().alwaysAllowGrants).toEqual([]);
+    });
+});
+
+describe('grants do not survive a reload', () => {
+    it('a freshly loaded store (page reload / restart) starts with no grants', async () => {
+        localStorage.clear();
+        await allow('p1', 'run_shell_command', 'chat-A', true);
+        expect(useNotificationStore.getState().alwaysAllowGrants).toHaveLength(1);
+
+        vi.resetModules();
+        const reloaded = await import('../notificationStore');
+        expect(reloaded.useNotificationStore.getState().alwaysAllowGrants).toEqual([]);
+        expect(
+            reloaded.useNotificationStore.getState().isAlwaysAllowed('chat-A', 'run_shell_command')
+        ).toBe(false);
+    });
+});
+
+describe('purgeLegacyAlwaysAllow', () => {
+    beforeEach(() => localStorage.clear());
+
+    it('deletes a list persisted by an earlier build and says so', () => {
+        localStorage.setItem(LEGACY_ALWAYS_ALLOW_TOOLS_KEY, '["run_shell_command"]');
+        const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+        purgeLegacyAlwaysAllow();
+
+        expect(localStorage.getItem(LEGACY_ALWAYS_ALLOW_TOOLS_KEY)).toBeNull();
+        expect(warnSpy).toHaveBeenCalledOnce();
+        warnSpy.mockRestore();
+    });
+
+    it('is silent when there is nothing to purge', () => {
+        const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+        purgeLegacyAlwaysAllow();
+        expect(warnSpy).not.toHaveBeenCalled();
+        warnSpy.mockRestore();
+    });
+});

--- a/src/gaia/apps/webui/src/stores/notificationStore.ts
+++ b/src/gaia/apps/webui/src/stores/notificationStore.ts
@@ -39,7 +39,7 @@ export function purgeLegacyAlwaysAllow(): void {
             localStorage.removeItem(LEGACY_ALWAYS_ALLOW_TOOLS_KEY);
             console.warn(
                 '[notificationStore] Discarded a persisted "always allow" tool list from an ' +
-                'earlier version — grants now cover one chat until GAIA restarts and are ' +
+                'earlier version — grants now cover one chat until you reload or restart GAIA and are ' +
                 'revocable in Settings → Tools & Permissions.'
             );
         }
@@ -132,13 +132,19 @@ export const useNotificationStore = create<NotificationState>((set, get) => ({
   setTypeFilter: (type) => set({ typeFilter: type }),
 
   respondToPermission: async (id, action, remember) => {
-    // Find the notification to get the session ID for the REST call
     const notification = get().notifications.find((n) => n.id === id);
-    const sessionId = notification?.agentId;
+    const chatSessionId = notification?.sessionId;
 
-    // Try Electron IPC first, then fall back to REST API
+    // Chat prompts belong to the backend even when Electron IPC is available.
     const electronApi = window.gaiaAPI;
-    if (electronApi?.notification?.respondPermission) {
+    if (chatSessionId) {
+      try {
+        await confirmTool(chatSessionId, action === 'allow');
+      } catch (err) {
+        console.error('[notificationStore] Failed to send permission response via REST:', err);
+        return;
+      }
+    } else if (notification && electronApi?.notification?.respondPermission) {
       try {
         await electronApi.notification.respondPermission(id, action, remember);
       } catch (err) {
@@ -147,19 +153,13 @@ export const useNotificationStore = create<NotificationState>((set, get) => ({
         // The permission prompt remains actionable so the user can retry.
         return;
       }
-    } else if (sessionId) {
-      // Web browser mode — call the REST endpoint
-      try {
-        await confirmTool(sessionId, action === 'allow');
-      } catch (err) {
-        console.error('[notificationStore] Failed to send permission response via REST:', err);
-        return;
-      }
+    } else {
+      console.error('[notificationStore] No permission response destination for notification:', id);
+      return;
     }
     // Grant only within the chat that asked. A request with no chat session
     // (an OS agent) has nothing to auto-approve here; its remember flag
     // already went to the agent above.
-    const chatSessionId = notification?.sessionId;
     const tool = notification?.tool;
     if (action === 'allow' && remember && chatSessionId && tool) {
       set((state) =>

--- a/src/gaia/apps/webui/src/stores/notificationStore.ts
+++ b/src/gaia/apps/webui/src/stores/notificationStore.ts
@@ -18,8 +18,42 @@ import { confirmTool } from '../services/api';
 /** Maximum notifications kept in the center to prevent unbounded growth. */
 const MAX_NOTIFICATIONS = 500;
 
-/** localStorage key for the "always allow" tool list. */
-export const ALWAYS_ALLOW_TOOLS_KEY = 'gaia_always_allow_tools';
+/**
+ * Legacy localStorage key for the "always allow" tool list.
+ *
+ * Always-allow grants now live in this store only, scoped to one chat
+ * session: a tick on `run_shell_command` must not silently approve every
+ * shell command in every chat for the life of the browser profile. The key
+ * is still named here so `purgeLegacyAlwaysAllow()` can delete any list a
+ * previous build persisted.
+ */
+export const LEGACY_ALWAYS_ALLOW_TOOLS_KEY = 'gaia_always_allow_tools';
+
+/**
+ * Drop any always-allow list persisted by an older build. Called once at app
+ * start; grants from a previous run are not carried into this one.
+ */
+export function purgeLegacyAlwaysAllow(): void {
+    try {
+        if (localStorage.getItem(LEGACY_ALWAYS_ALLOW_TOOLS_KEY) !== null) {
+            localStorage.removeItem(LEGACY_ALWAYS_ALLOW_TOOLS_KEY);
+            console.warn(
+                '[notificationStore] Discarded a persisted "always allow" tool list from an ' +
+                'earlier version — grants now cover one chat until GAIA restarts and are ' +
+                'revocable in Settings → Tools & Permissions.'
+            );
+        }
+    } catch (err) {
+        console.error('[notificationStore] Could not clear the legacy always-allow list:', err);
+    }
+}
+
+/** A tool the user allowed for the rest of one chat session. In memory only. */
+export interface SessionToolGrant {
+  sessionId: string;
+  tool: string;
+  grantedAt: number;
+}
 
 // ── State Interface ──────────────────────────────────────────────────────
 
@@ -30,6 +64,12 @@ interface NotificationState {
   showPanel: boolean;
   /** Active type filter for the notification center (null = all). */
   typeFilter: NotificationType | null;
+
+  /**
+   * "Allow for the rest of this chat" grants, keyed by chat session + tool.
+   * Never persisted — a reload or restart starts empty.
+   */
+  alwaysAllowGrants: SessionToolGrant[];
 
   // ── Actions ─────────────────────────────────────────────────────────
   addNotification: (notification: GaiaNotification) => void;
@@ -42,6 +82,15 @@ interface NotificationState {
 
   /** Respond to a permission request notification. */
   respondToPermission: (id: string, action: 'allow' | 'deny', remember: boolean) => Promise<void>;
+
+  /** Whether `tool` carries an always-allow grant in chat session `sessionId`. */
+  isAlwaysAllowed: (sessionId: string, tool: string) => boolean;
+
+  /** Revoke one grant. */
+  revokeAlwaysAllow: (sessionId: string, tool: string) => void;
+
+  /** Revoke every grant in every chat. */
+  revokeAllAlwaysAllow: () => void;
 }
 
 // ── Store Implementation ─────────────────────────────────────────────────
@@ -50,6 +99,7 @@ export const useNotificationStore = create<NotificationState>((set, get) => ({
   notifications: [],
   showPanel: false,
   typeFilter: null,
+  alwaysAllowGrants: [],
 
   addNotification: (notification) =>
     set((state) => ({
@@ -106,15 +156,22 @@ export const useNotificationStore = create<NotificationState>((set, get) => ({
         return;
       }
     }
-    // Persist "always allow" preference in localStorage
-    if (action === 'allow' && remember) {
-      if (notification?.tool) {
-        const existing: string[] = JSON.parse(localStorage.getItem(ALWAYS_ALLOW_TOOLS_KEY) || '[]');
-        if (!existing.includes(notification.tool)) {
-          existing.push(notification.tool);
-          localStorage.setItem(ALWAYS_ALLOW_TOOLS_KEY, JSON.stringify(existing));
-        }
-      }
+    // Grant only within the chat that asked. A request with no chat session
+    // (an OS agent) has nothing to auto-approve here; its remember flag
+    // already went to the agent above.
+    const chatSessionId = notification?.sessionId;
+    const tool = notification?.tool;
+    if (action === 'allow' && remember && chatSessionId && tool) {
+      set((state) =>
+        state.alwaysAllowGrants.some((g) => g.sessionId === chatSessionId && g.tool === tool)
+          ? state
+          : {
+              alwaysAllowGrants: [
+                ...state.alwaysAllowGrants,
+                { sessionId: chatSessionId, tool, grantedAt: Date.now() },
+              ],
+            }
+      );
     }
     // Update local state after response is delivered
     set((state) => ({
@@ -125,6 +182,18 @@ export const useNotificationStore = create<NotificationState>((set, get) => ({
       ),
     }));
   },
+
+  isAlwaysAllowed: (sessionId, tool) =>
+    get().alwaysAllowGrants.some((g) => g.sessionId === sessionId && g.tool === tool),
+
+  revokeAlwaysAllow: (sessionId, tool) =>
+    set((state) => ({
+      alwaysAllowGrants: state.alwaysAllowGrants.filter(
+        (g) => !(g.sessionId === sessionId && g.tool === tool)
+      ),
+    })),
+
+  revokeAllAlwaysAllow: () => set({ alwaysAllowGrants: [] }),
 
 }));
 
@@ -148,6 +217,10 @@ export const selectVisibleNotifications = (state: NotificationState): GaiaNotifi
   }
   return visible;
 };
+
+/** Every active "allow for the rest of this chat" grant. */
+export const selectAlwaysAllowGrants = (state: NotificationState): SessionToolGrant[] =>
+  state.alwaysAllowGrants;
 
 /** Get the first pending permission request (reactive selector for PermissionPrompt). */
 export const selectActivePermissionPrompt = (state: NotificationState): GaiaNotification | null =>

--- a/src/gaia/apps/webui/src/types/agent.ts
+++ b/src/gaia/apps/webui/src/types/agent.ts
@@ -118,6 +118,8 @@ export interface GaiaNotification {
   /** For permission_request type. */
   tool?: string;
   toolArgs?: Record<string, unknown>;
+  /** Chat session that raised the request; "always allow" grants are scoped to it. */
+  sessionId?: string;
   /** For policy_alert type. */
   decision?: string;
   reason?: string;

--- a/src/gaia/apps/webui/src/types/index.ts
+++ b/src/gaia/apps/webui/src/types/index.ts
@@ -714,7 +714,6 @@ export type StreamEventType =
     | 'tool_end'     // Tool execution completed
     | 'tool_result'  // Tool result summary
     | 'tool_args'    // Tool arguments detail
-    | 'tool_confirm' // Tool requires user confirmation (blocking)
     | 'answer'       // Final answer from agent
     | 'agent_error'  // Agent-level error (non-fatal)
     | 'permission_request' // Tool confirmation request
@@ -759,11 +758,11 @@ export interface StreamEvent {
     };
     /** Agent ID of the newly created agent (for agent_created events). */
     agent_id?: string;
-    /** Confirmation ID (for tool_confirm events). */
+    /** Confirmation ID (for permission_request events). */
     confirm_id?: string;
     /** Machine tool name a confirmation is about (for needs_confirmation events). */
     action?: string;
-    /** Timeout in seconds (for tool_confirm events). */
+    /** Timeout in seconds (for permission_request events). */
     timeout_seconds?: number;
     /** MCP server name (for tool_start of MCP tools). */
     mcp_server?: string;

--- a/src/gaia/apps/webui/src/utils/__tests__/markdown.test.ts
+++ b/src/gaia/apps/webui/src/utils/__tests__/markdown.test.ts
@@ -1,0 +1,36 @@
+// Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+import { describe, it, expect } from 'vitest';
+import { safeUrlTransform } from '../markdown';
+
+describe('safeUrlTransform', () => {
+    it.each([
+        'https://amd-gaia.ai/docs',
+        'http://localhost:4200',
+        'HTTPS://AMD-GAIA.AI',
+        'mailto:someone@example.com',
+        '#section-2',
+    ])('keeps %s', (url) => {
+        expect(safeUrlTransform(url)).toBe(url);
+    });
+
+    it.each([
+        // Root-relative — resolves to file:///C:/Windows/System32/calc.exe
+        '/Windows/System32/calc.exe',
+        // Protocol-relative / UNC — resolves to an SMB fetch
+        '//attacker/share/x.exe',
+        '\\\\attacker\\share\\x.exe',
+        // Plain relative — resolves next to the file:// index.html
+        'x.exe',
+        '../../x.exe',
+        'C:/Windows/System32/calc.exe',
+        'file:///C:/Windows/System32/calc.exe',
+        'javascript:alert(1)',
+        'data:text/html,<b>x</b>',
+        'vbscript:msgbox(1)',
+        '',
+    ])('neutralises %s', (url) => {
+        expect(safeUrlTransform(url)).toBe('');
+    });
+});

--- a/src/gaia/apps/webui/src/utils/__tests__/markdown.test.ts
+++ b/src/gaia/apps/webui/src/utils/__tests__/markdown.test.ts
@@ -6,7 +6,7 @@ import { safeUrlTransform } from '../markdown';
 
 describe('safeUrlTransform', () => {
     it.each([
-        'https://amd-gaia.ai/docs',
+        'https://amd-gaia.ai/docs/guides/chat',
         'http://localhost:4200',
         'HTTPS://AMD-GAIA.AI',
         'mailto:someone@example.com',

--- a/src/gaia/apps/webui/src/utils/markdown.ts
+++ b/src/gaia/apps/webui/src/utils/markdown.ts
@@ -41,19 +41,21 @@ export const SAFE_DISALLOWED_ELEMENTS: ReadonlyArray<string> = [
  * Returns the URL untouched if its scheme is in the allow list, otherwise
  * returns an empty string (renders an inert anchor).
  *
- * Schemes are matched case-insensitively. Relative URLs (no scheme) and
- * fragment-only URLs (`#anchor`) pass through unchanged — they cannot
- * navigate cross-origin.
+ * Schemes are matched case-insensitively. Only fragment-only URLs (`#anchor`)
+ * pass through without a scheme: the renderer is loaded from `file://`, so a
+ * root-relative (`/Windows/System32/calc.exe`), UNC (`//host/share/x.exe`) or
+ * plain relative href resolves to a `file:` URL that the shell would hand to
+ * ShellExecute. Those are inert here.
  */
 export function safeUrlTransform(url: string): string {
     if (!url) return '';
 
-    // Allow fragment-only links and same-page anchors.
-    if (url.startsWith('#') || url.startsWith('/')) return url;
+    // Allow same-page anchors only.
+    if (url.startsWith('#')) return url;
 
     // Extract scheme (case-insensitive). RFC 3986: scheme = ALPHA *(ALPHA / DIGIT / "+" / "-" / ".")
     const colonIdx = url.indexOf(':');
-    if (colonIdx === -1) return url; // relative URL
+    if (colonIdx === -1) return ''; // scheme-less — resolves against file://
 
     const scheme = url.slice(0, colonIdx).toLowerCase();
     if (scheme === 'https' || scheme === 'http' || scheme === 'mailto') {

--- a/tests/electron/backend-installer-package.test.cjs
+++ b/tests/electron/backend-installer-package.test.cjs
@@ -1,0 +1,71 @@
+// Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+const fs = require("fs");
+const path = require("path");
+const vm = require("vm");
+const { EventEmitter } = require("events");
+
+const installerPath = path.resolve(__dirname, "../../src/gaia/apps/webui/services/backend-installer.cjs");
+
+function loadInstaller(platform, localWheel) {
+  const spawn = jest.fn(() => {
+    const child = new EventEmitter();
+    child.stdout = new EventEmitter();
+    child.stderr = new EventEmitter();
+    queueMicrotask(() => child.emit("exit", 0));
+    return child;
+  });
+  const fakeFs = {
+    ...fs,
+    existsSync: (file) => String(file).includes("/venv"),
+    mkdirSync: jest.fn(),
+    writeFileSync: jest.fn(),
+  };
+  const context = {
+    module: { exports: {} },
+    __dirname: path.dirname(installerPath),
+    console: { log: jest.fn(), error: jest.fn(), warn: jest.fn() },
+    process: { platform, arch: "x64", env: localWheel ? { GAIA_LOCAL_WHEEL: localWheel } : {} },
+    require: (name) => {
+      if (name === "fs") return fakeFs;
+      if (name === "path") return path.posix;
+      if (name === "os") return { ...require("os"), homedir: () => "/fixture" };
+      if (name === "child_process") return {
+        spawn,
+        execSync: jest.fn(),
+        spawnSync: jest.fn(() => ({ status: 0, stdout: "GAIA version 0.23.1" })),
+      };
+      return require(name);
+    },
+  };
+  vm.runInNewContext(fs.readFileSync(installerPath, "utf8"), context, { filename: installerPath });
+  return { installer: context.module.exports, spawn };
+}
+
+describe("backend installation package sources", () => {
+  test.each(["linux", "darwin"])("%s local wheels keep CPU-only PyTorch dependencies", async (platform) => {
+    const { installer, spawn } = loadInstaller(platform, "/work/amd_gaia-0.23.1-py3-none-any.whl");
+    await installer.installBackend({ skipGaiaInit: true, isPackaged: false });
+
+    const [command, args] = spawn.mock.calls.find(([, argv]) => argv[0] === "pip");
+    expect(command).toBe("uv");
+    expect(args).toContain("/work/amd_gaia-0.23.1-py3-none-any.whl[ui]");
+    expect(args.slice(-2)).toEqual(["--extra-index-url", "https://download.pytorch.org/whl/cpu"]);
+  });
+
+  test("Linux PyPI installs retain the CPU-only index", async () => {
+    const { installer, spawn } = loadInstaller("linux");
+    await installer.installBackend({ version: "0.23.1", skipGaiaInit: true, isPackaged: false });
+    const [, args] = spawn.mock.calls.find(([, argv]) => argv[0] === "pip");
+    expect(args).toContain("amd-gaia[ui]==0.23.1");
+    expect(args).toContain("https://download.pytorch.org/whl/cpu");
+  });
+
+  test("Windows keeps its existing dependency source", async () => {
+    const { installer, spawn } = loadInstaller("win32", "/work/amd_gaia-0.23.1-py3-none-any.whl");
+    await installer.installBackend({ skipGaiaInit: true, isPackaged: false });
+    const [, args] = spawn.mock.calls.find(([, argv]) => argv[0] === "pip");
+    expect(args).not.toContain("--extra-index-url");
+  });
+});

--- a/tests/electron/crash-loop-notification.test.cjs
+++ b/tests/electron/crash-loop-notification.test.cjs
@@ -1,0 +1,137 @@
+// Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+/**
+ * An agent crash loop, end to end in the main process: the REAL
+ * AgentProcessManager restarts a crashing agent until it hits the crash
+ * limit, the REAL NotificationService turns that into a notification, and
+ * the count lands on the REAL TrayManager. Before the fix, the crash-limit
+ * notification called a TrayManager method that did not exist, the throw
+ * escaped the child's `exit` handler, and the app exited.
+ */
+
+const { EventEmitter } = require("events");
+
+const mockChildren = [];
+function mockMakeChild() {
+  const child = new EventEmitter();
+  child.stdin = { write: jest.fn(), destroyed: false };
+  child.stdout = new EventEmitter();
+  child.stderr = new EventEmitter();
+  child.pid = 40000 + mockChildren.length;
+  child.exitCode = null;
+  child.kill = jest.fn();
+  mockChildren.push(child);
+  return child;
+}
+jest.mock("child_process", () => ({ spawn: jest.fn(() => mockMakeChild()) }));
+
+const mockManifest = JSON.stringify({
+  manifest_version: 1,
+  agents: [
+    {
+      id: "crashy",
+      name: "Crashy",
+      binaries: { win32: "crashy.exe", darwin: "crashy", linux: "crashy" },
+    },
+  ],
+});
+const mockConfig = JSON.stringify({
+  agents: { crashy: { autoStart: false, restartOnCrash: true } },
+  tray: { minimizeToTray: false },
+});
+jest.mock("fs", () => ({
+  existsSync: jest.fn((p) => {
+    const s = String(p);
+    return /agent-manifest\.json|tray-config\.json|crashy|tray-icon/.test(s);
+  }),
+  readFileSync: jest.fn((p) => {
+    const s = String(p);
+    if (s.includes("agent-manifest.json")) return mockManifest;
+    if (s.includes("tray-config.json")) return mockConfig;
+    return "[]";
+  }),
+  writeFileSync: jest.fn(),
+  mkdirSync: jest.fn(),
+}));
+
+const electronMock = require("electron");
+class MockNotification extends EventEmitter {
+  constructor(opts = {}) {
+    super();
+    this.opts = opts;
+  }
+  show() {}
+}
+MockNotification.isSupported = jest.fn(() => true);
+electronMock.Notification = MockNotification;
+
+const { spawn } = require("child_process");
+const AgentProcessManager = require("../../src/gaia/apps/webui/services/agent-process-manager.cjs");
+const TrayManager = require("../../src/gaia/apps/webui/services/tray-manager.cjs");
+const NotificationService = require("../../src/gaia/apps/webui/services/notification-service.cjs");
+
+async function flushMicrotasks() {
+  for (let i = 0; i < 5; i++) await Promise.resolve();
+}
+
+describe("agent crash loop -> notification -> tray", () => {
+  let manager;
+  let tray;
+  let service;
+  let logSpy;
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+    mockChildren.length = 0;
+    spawn.mockClear();
+    electronMock.ipcMain._handlers.clear();
+    logSpy = jest.spyOn(console, "log").mockImplementation(() => {});
+    jest.spyOn(console, "warn").mockImplementation(() => {});
+
+    const win = new electronMock.BrowserWindow();
+    win.isMinimized = jest.fn(() => false);
+    win.restore = jest.fn();
+    manager = new AgentProcessManager(win);
+    tray = new TrayManager(win);
+    tray.create();
+    service = new NotificationService(win, manager, tray);
+  });
+
+  afterEach(() => {
+    service.destroy();
+    jest.clearAllTimers();
+    jest.useRealTimers();
+    jest.restoreAllMocks();
+  });
+
+  test("the crash-limit notification does not throw, and its count reaches the tray", async () => {
+    const crashLimit = jest.fn();
+    manager.on("agent-crash-limit", crashLimit);
+
+    await manager.startAgent("crashy");
+
+    // Three crashes are restarted (2 s apart); the fourth trips the limit.
+    for (let crash = 1; crash <= 4; crash++) {
+      const child = mockChildren[mockChildren.length - 1];
+      expect(() => child.emit("exit", 1, null)).not.toThrow();
+      if (crash < 4) {
+        jest.advanceTimersByTime(2001);
+        await flushMicrotasks();
+      }
+    }
+
+    expect(spawn).toHaveBeenCalledTimes(4); // first start + three restarts
+    expect(crashLimit).toHaveBeenCalledWith("crashy", 4);
+
+    const limitNotice = service.notifications.find(
+      (n) => n.title === "Agent Crash Limit Reached"
+    );
+    expect(limitNotice).toBeDefined();
+    expect(limitNotice.message).toContain("crashy");
+
+    expect(tray.notificationCount).toBe(1);
+    expect(tray.tray._toolTip).toBe("GAIA — 1 unread notification");
+    expect(logSpy.mock.calls.map((c) => c.join(" "))).toContain("[tray] Unread notifications: 1");
+  });
+});

--- a/tests/electron/deep-link-queue.test.cjs
+++ b/tests/electron/deep-link-queue.test.cjs
@@ -1,0 +1,99 @@
+// Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+/**
+ * Cold-start gaia:// links must wait for the backend: a link that arrives
+ * before it is ready is dispatched exactly once afterwards — not early, not lost.
+ */
+
+const {
+  createStartupDeepLinkQueue,
+} = require("../../src/gaia/apps/webui/services/deep-link-queue.cjs");
+
+const LINK = "gaia://hub/install/email";
+const OTHER = "gaia://hub/install/gaia";
+
+function makeQueue() {
+  const dispatch = jest.fn();
+  const reportNotReady = jest.fn();
+  const queue = createStartupDeepLinkQueue({
+    dispatch,
+    reportNotReady,
+    logger: { log: jest.fn() },
+  });
+  return { queue, dispatch, reportNotReady };
+}
+
+describe("startup deep-link queue", () => {
+  test("a link that arrives before the backend is ready is not dispatched early", () => {
+    const { queue, dispatch } = makeQueue();
+    expect(queue.accept(LINK)).toBe("queued");
+    expect(dispatch).not.toHaveBeenCalled();
+    expect(queue.pendingCount).toBe(1);
+  });
+
+  test("...and is dispatched exactly once once the backend is ready", () => {
+    const { queue, dispatch } = makeQueue();
+    queue.accept(LINK);
+    expect(queue.drain({ backendReady: true })).toEqual([LINK]);
+    expect(dispatch).toHaveBeenCalledTimes(1);
+    expect(dispatch).toHaveBeenCalledWith(LINK);
+  });
+
+  test("the same link from a second launch and from argv is still dispatched once", () => {
+    const { queue, dispatch } = makeQueue();
+    queue.accept(LINK);
+    expect(queue.accept(LINK)).toBe("duplicate");
+    queue.drain({ backendReady: true, argvUrl: LINK });
+    expect(dispatch).toHaveBeenCalledTimes(1);
+  });
+
+  test("a cold-start argv link with nothing queued is dispatched once", () => {
+    const { queue, dispatch } = makeQueue();
+    queue.drain({ backendReady: true, argvUrl: LINK });
+    expect(dispatch.mock.calls).toEqual([[LINK]]);
+  });
+
+  test("distinct links are all kept, in arrival order", () => {
+    const { queue, dispatch } = makeQueue();
+    queue.accept(LINK);
+    queue.accept(OTHER);
+    queue.drain({ backendReady: true });
+    expect(dispatch.mock.calls).toEqual([[LINK], [OTHER]]);
+  });
+
+  test("draining again never re-dispatches", () => {
+    const { queue, dispatch } = makeQueue();
+    queue.accept(LINK);
+    queue.drain({ backendReady: true });
+    expect(queue.drain({ backendReady: true, argvUrl: LINK })).toEqual([]);
+    expect(dispatch).toHaveBeenCalledTimes(1);
+  });
+
+  test("after the drain, new links dispatch immediately, once each", () => {
+    const { queue, dispatch } = makeQueue();
+    queue.drain({ backendReady: true });
+    expect(queue.accept(OTHER)).toBe("dispatched");
+    expect(dispatch.mock.calls).toEqual([[OTHER]]);
+  });
+
+  test("if the backend never comes up, the user is told — nothing is dispatched blind", () => {
+    const { queue, dispatch, reportNotReady } = makeQueue();
+    queue.accept(LINK);
+    queue.drain({ backendReady: false, argvUrl: OTHER });
+    expect(dispatch).not.toHaveBeenCalled();
+    expect(reportNotReady).toHaveBeenCalledWith([LINK, OTHER]);
+  });
+
+  test("with nothing queued, a failed startup reports nothing", () => {
+    const { queue, reportNotReady } = makeQueue();
+    queue.drain({ backendReady: false });
+    expect(reportNotReady).not.toHaveBeenCalled();
+  });
+
+  test("refuses to build without its collaborators", () => {
+    expect(() => createStartupDeepLinkQueue({ dispatch: jest.fn() })).toThrow(
+      /dispatch and reportNotReady/
+    );
+  });
+});

--- a/tests/electron/link-policy.test.cjs
+++ b/tests/electron/link-policy.test.cjs
@@ -1,0 +1,85 @@
+// Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+/**
+ * Tests for the external-link policy (services/link-policy.cjs).
+ *
+ * The renderer is loaded from file://, so Chromium resolves a scheme-less
+ * markdown link against that document BEFORE main.cjs sees it. The cases
+ * below are the resolved forms an LLM-rendered link produces.
+ */
+
+const {
+  isAllowedExternalUrl,
+  isInAppNavigation,
+  describeBlockedUrl,
+} = require("../../src/gaia/apps/webui/services/link-policy.cjs");
+
+const APP_URL =
+  "file:///C:/app/resources/app.asar/dist/index.html?api=http%3A%2F%2Flocalhost%3A4200";
+
+describe("isAllowedExternalUrl", () => {
+  test.each([
+    "https://amd-gaia.ai/docs",
+    "http://localhost:4200/api/health",
+    "HTTPS://AMD-GAIA.AI",
+    "mailto:someone@example.com",
+  ])("allows web/mail URL %s", (url) => {
+    expect(isAllowedExternalUrl(url)).toBe(true);
+  });
+
+  test.each([
+    // `/Windows/System32/calc.exe` in markdown resolves to this.
+    "file:///C:/Windows/System32/calc.exe",
+    // `//attacker/share/x.exe` resolves to a UNC fetch.
+    "file://attacker/share/x.exe",
+    "javascript:alert(1)",
+    "data:text/html,<script>alert(1)</script>",
+    "vbscript:msgbox(1)",
+    "ms-msdt:/id",
+    "smb://attacker/share/x.exe",
+    "gaia://hub/install/evil",
+  ])("refuses %s", (url) => {
+    expect(isAllowedExternalUrl(url)).toBe(false);
+  });
+
+  test.each([
+    [""],
+    [null],
+    [undefined],
+    [42],
+    ["/Windows/System32/calc.exe"],
+    ["//host/share/x.exe"],
+  ])("refuses unresolvable input %p", (url) => {
+    expect(isAllowedExternalUrl(url)).toBe(false);
+  });
+});
+
+describe("isInAppNavigation", () => {
+  test("a fragment on the loaded document is in-app", () => {
+    expect(isInAppNavigation(`${APP_URL}#section`, APP_URL)).toBe(true);
+  });
+
+  test("a different path in the app bundle is NOT in-app", () => {
+    expect(
+      isInAppNavigation("file:///C:/app/resources/app.asar/dist/other.html", APP_URL)
+    ).toBe(false);
+  });
+
+  test("a local binary is never in-app", () => {
+    expect(isInAppNavigation("file:///C:/Windows/System32/calc.exe", APP_URL)).toBe(false);
+  });
+
+  test("a web URL is never in-app", () => {
+    expect(isInAppNavigation("https://amd-gaia.ai", APP_URL)).toBe(false);
+  });
+});
+
+describe("describeBlockedUrl", () => {
+  test("names the URL and its scheme so the refusal is actionable", () => {
+    const msg = describeBlockedUrl("file:///C:/Windows/System32/calc.exe");
+    expect(msg).toContain("calc.exe");
+    expect(msg).toContain("file");
+    expect(msg).toMatch(/http, https and mailto/);
+  });
+});

--- a/tests/electron/main-startup-order.test.cjs
+++ b/tests/electron/main-startup-order.test.cjs
@@ -39,9 +39,8 @@ describe("main.cjs routes gaia:// links through the startup queue", () => {
     expect(drain).toBeGreaterThan(wait);
   });
 
-  test("the queue is released in exactly one place", () => {
-    expect(MAIN.match(/processStartupDeepLinks\(/g)).toHaveLength(2); // definition + call
-    expect(MAIN.match(/startupDeepLinks\.drain\(/g)).toHaveLength(1);
+  test("the startup release delegates to the queue drain", () => {
+    expect(functionBody("processStartupDeepLinks")).toContain("startupDeepLinks.drain(");
   });
 
   test("every inbound link goes through the queue, never straight to dispatch", () => {

--- a/tests/electron/main-startup-order.test.cjs
+++ b/tests/electron/main-startup-order.test.cjs
@@ -1,0 +1,96 @@
+// Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+/**
+ * Source-level contracts for main.cjs, which cannot be required without
+ * launching Electron. The deep-link queue's behaviour is tested in
+ * deep-link-queue.test.cjs; these pin that main.cjs actually uses it, and
+ * uses it in the right order.
+ */
+
+const fs = require("fs");
+const path = require("path");
+
+const MAIN = fs.readFileSync(
+  path.resolve(__dirname, "..", "..", "src", "gaia", "apps", "webui", "main.cjs"),
+  "utf8"
+);
+
+function whenReadyBody() {
+  const start = MAIN.indexOf("app.whenReady().then(async () => {");
+  expect(start).toBeGreaterThan(-1);
+  return MAIN.slice(start);
+}
+
+function functionBody(name) {
+  const start = MAIN.indexOf(`function ${name}(`);
+  expect(start).toBeGreaterThan(-1);
+  const ends = [MAIN.indexOf("\nfunction ", start + 1), MAIN.indexOf("\nasync function ", start + 1)]
+    .filter((i) => i > -1);
+  return MAIN.slice(start, ends.length ? Math.min(...ends) : undefined);
+}
+
+describe("main.cjs routes gaia:// links through the startup queue", () => {
+  test("startup releases the queue only after waitForBackend resolves", () => {
+    const body = whenReadyBody();
+    const wait = body.indexOf("backendReady = await waitForBackend(");
+    const drain = body.indexOf("processStartupDeepLinks(backendReady)");
+    expect(wait).toBeGreaterThan(-1);
+    expect(drain).toBeGreaterThan(wait);
+  });
+
+  test("the queue is released in exactly one place", () => {
+    expect(MAIN.match(/processStartupDeepLinks\(/g)).toHaveLength(2); // definition + call
+    expect(MAIN.match(/startupDeepLinks\.drain\(/g)).toHaveLength(1);
+  });
+
+  test("every inbound link goes through the queue, never straight to dispatch", () => {
+    const body = functionBody("handleDeepLink");
+    expect(body).toContain("startupDeepLinks.accept(rawUrl)");
+    expect(body).not.toContain("runDeepLink(");
+    // The old gate released links as soon as services existed — before the backend listened.
+    expect(body).not.toMatch(/agentProcessManager/);
+  });
+
+  test("the queue dispatches through the confirm-gated install path", () => {
+    const start = MAIN.indexOf("createStartupDeepLinkQueue({");
+    const block = MAIN.slice(start, MAIN.indexOf("});", start));
+    expect(block).toContain("runDeepLink(parseDeepLink(rawUrl))");
+    expect(block).toContain("reportNotReady: reportDeepLinksNotReady");
+  });
+
+  test("a backend that never came up is reported loudly", () => {
+    expect(functionBody("reportDeepLinksNotReady")).toMatch(
+      /dialog\.showErrorBox\("GAIA is not ready yet"/
+    );
+  });
+});
+
+describe("external links go through the scheme allow-list", () => {
+  test("setWindowOpenHandler checks the resolved URL before openExternal", () => {
+    const start = MAIN.indexOf("setWindowOpenHandler(");
+    const handler = MAIN.slice(start, MAIN.indexOf("});", start));
+    expect(handler.indexOf("isAllowedExternalUrl(url)")).toBeGreaterThan(-1);
+    expect(handler.indexOf("isAllowedExternalUrl(url)")).toBeLessThan(
+      handler.indexOf("shell.openExternal(url)")
+    );
+    expect(handler).toContain('return { action: "deny" }');
+  });
+
+  test("a will-navigate guard prevents navigation away from the app", () => {
+    const start = MAIN.indexOf('webContents.on("will-navigate"');
+    expect(start).toBeGreaterThan(-1);
+    const handler = MAIN.slice(start, MAIN.indexOf("\n  });", start));
+    expect(handler).toContain("event.preventDefault()");
+    expect(handler.indexOf("isAllowedExternalUrl(url)")).toBeLessThan(
+      handler.indexOf("shell.openExternal(url)")
+    );
+  });
+
+  test("every openExternal in main.cjs is behind the allow-list", () => {
+    const calls = MAIN.match(/shell\.openExternal\(/g) || [];
+    const guarded =
+      MAIN.match(/if \(isAllowedExternalUrl\(url\)\) \{\s*shell\.openExternal\(url\)/g) || [];
+    expect(calls.length).toBe(guarded.length);
+  });
+});

--- a/tests/electron/mocks/electron.js
+++ b/tests/electron/mocks/electron.js
@@ -96,6 +96,11 @@ class MockApp extends EventEmitter {
     super();
     this._isReady = false;
     this._isQuitting = false;
+    this._badgeCount = 0;
+    this.setBadgeCount = jest.fn((count) => {
+      this._badgeCount = count;
+      return true;
+    });
   }
 
   whenReady() {
@@ -240,7 +245,21 @@ module.exports = {
     buildFromTemplate: jest.fn(() => ({})),
   },
   
-  Tray: jest.fn(),
+  // A usable fake, not a bare jest.fn(): TrayManager calls setToolTip/
+  // setContextMenu/isDestroyed on the instance, and a `{}` would make every
+  // one of those a TypeError inside the code under test.
+  Tray: jest.fn().mockImplementation(function Tray(icon) {
+    this._icon = icon;
+    this._toolTip = null;
+    this._contextMenu = null;
+    this._destroyed = false;
+    this._handlers = {};
+    this.setToolTip = jest.fn(function (text) { this._toolTip = text; });
+    this.setContextMenu = jest.fn(function (menu) { this._contextMenu = menu; });
+    this.on = jest.fn(function (event, fn) { this._handlers[event] = fn; });
+    this.destroy = jest.fn(function () { this._destroyed = true; });
+    this.isDestroyed = jest.fn(function () { return this._destroyed; });
+  }),
 
   nativeImage: {
     createFromPath: jest.fn((p) => ({

--- a/tests/electron/notification-tray-integration.test.cjs
+++ b/tests/electron/notification-tray-integration.test.cjs
@@ -1,0 +1,127 @@
+// Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+/**
+ * NotificationService wired to the REAL TrayManager (not a stub that happens
+ * to have setNotificationCount). The existing unit suite mocked the tray with
+ * the method the real class lacked, so the missing-method crash never showed.
+ */
+
+const { EventEmitter } = require("events");
+const electronMock = require("electron");
+
+class MockNotification extends EventEmitter {
+  constructor(opts = {}) {
+    super();
+    this.opts = opts;
+  }
+  show() {}
+}
+MockNotification.isSupported = jest.fn(() => true);
+electronMock.Notification = MockNotification;
+
+// Only the tray-icon assets "exist" — no persisted notifications or tray config.
+jest.mock("fs", () => ({
+  existsSync: jest.fn((p) => /tray-icon/.test(String(p))),
+  readFileSync: jest.fn(() => "[]"),
+  writeFileSync: jest.fn(),
+  mkdirSync: jest.fn(),
+}));
+
+const TrayManager = require("../../src/gaia/apps/webui/services/tray-manager.cjs");
+const NotificationService = require("../../src/gaia/apps/webui/services/notification-service.cjs");
+
+const ORIGINAL_PLATFORM = process.platform;
+function setPlatform(platform) {
+  Object.defineProperty(process, "platform", { value: platform });
+}
+
+function createMockWindow() {
+  const win = new electronMock.BrowserWindow();
+  win.isMinimized = jest.fn(() => false);
+  win.restore = jest.fn();
+  return win;
+}
+
+describe("NotificationService + real TrayManager", () => {
+  let tray;
+  let apm;
+  let service;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    setPlatform("win32");
+    electronMock.ipcMain._handlers.clear();
+    const win = createMockWindow();
+    tray = new TrayManager(win);
+    tray.create();
+    apm = new EventEmitter();
+    apm._sendJsonRpcRaw = jest.fn();
+    service = new NotificationService(win, apm, tray);
+  });
+
+  afterEach(() => {
+    service.destroy();
+    setPlatform(ORIGINAL_PLATFORM);
+  });
+
+  test("the real TrayManager implements the method NotificationService calls", () => {
+    expect(typeof tray.setNotificationCount).toBe("function");
+  });
+
+  test("an agent crash-limit event updates the tray tooltip instead of throwing", () => {
+    expect(() => apm.emit("agent-crash-limit", "crashy", 6)).not.toThrow();
+    expect(tray.notificationCount).toBe(1);
+    expect(tray.tray._toolTip).toBe("GAIA — 1 unread notification");
+  });
+
+  test("a crash loop accumulates the count, and markAllRead clears it", () => {
+    apm.emit("status-change", { agentId: "a", status: "stopped", detail: "exit 1" });
+    apm.emit("status-change", { agentId: "a", status: "stopped", detail: "exit 1" });
+    apm.emit("agent-crash-limit", "a", 6);
+    expect(tray.notificationCount).toBe(3);
+    expect(tray.tray._toolTip).toBe("GAIA — 3 unread notifications");
+
+    service.markAllRead();
+    expect(tray.notificationCount).toBe(0);
+    expect(tray.tray._toolTip).toBe("GAIA");
+  });
+});
+
+describe("NotificationService listener containment", () => {
+  let apm;
+  let service;
+  let errorSpy;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    electronMock.ipcMain._handlers.clear();
+    apm = new EventEmitter();
+    apm._sendJsonRpcRaw = jest.fn();
+    const brokenTray = {
+      setNotificationCount: jest.fn(() => {
+        throw new TypeError("tray exploded");
+      }),
+    };
+    service = new NotificationService(createMockWindow(), apm, brokenTray);
+    errorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    service.destroy();
+    errorSpy.mockRestore();
+  });
+
+  test.each([
+    ["agent-crash-limit", ["crashy", 6]],
+    ["status-change", [{ agentId: "a", status: "stopped", detail: "boom" }]],
+    ["agent-notification", ["a", { type: "info", message: "hi" }]],
+  ])("a throw inside the %s listener is logged, not escaped", (event, args) => {
+    // Unguarded, EventEmitter.emit rethrows synchronously — from a child
+    // `exit` handler that is an uncaughtException and the app exits.
+    expect(() => apm.emit(event, ...args)).not.toThrow();
+    const logged = errorSpy.mock.calls.map((c) => c.join(" ")).join("\n");
+    expect(logged).toContain(`Listener for "${event}" threw`);
+    expect(logged).toContain("tray exploded");
+  });
+});

--- a/tests/electron/tray-manager.test.cjs
+++ b/tests/electron/tray-manager.test.cjs
@@ -96,3 +96,64 @@ describe("TrayManager icon loading", () => {
     expect(electronMock.nativeImage.createEmpty).not.toHaveBeenCalled();
   });
 });
+
+describe("TrayManager.setNotificationCount", () => {
+  test("reflects the unread count in the tray tooltip", () => {
+    setPlatform("win32");
+    const mgr = new TrayManager(createMockWindow());
+    mgr.create();
+
+    mgr.setNotificationCount(1);
+    expect(mgr.tray._toolTip).toBe("GAIA — 1 unread notification");
+    mgr.setNotificationCount(4);
+    expect(mgr.tray._toolTip).toBe("GAIA — 4 unread notifications");
+    mgr.setNotificationCount(0);
+    expect(mgr.tray._toolTip).toBe("GAIA");
+  });
+
+  test("does not call app.setBadgeCount on Windows", () => {
+    setPlatform("win32");
+    const mgr = new TrayManager(createMockWindow());
+    mgr.setNotificationCount(3);
+    expect(electronMock.app.setBadgeCount).not.toHaveBeenCalled();
+  });
+
+  test("sets the dock badge on macOS", () => {
+    setPlatform("darwin");
+    const mgr = new TrayManager(createMockWindow());
+    mgr.setNotificationCount(2);
+    expect(electronMock.app.setBadgeCount).toHaveBeenCalledWith(2);
+  });
+
+  test("a count set before create() is applied when the tray appears", () => {
+    setPlatform("win32");
+    const mgr = new TrayManager(createMockWindow());
+    mgr.setNotificationCount(5);
+    mgr.create();
+    expect(mgr.tray._toolTip).toBe("GAIA — 5 unread notifications");
+  });
+
+  test.each([[-1], [NaN], [Infinity], [undefined], ["3"]])(
+    "treats %p as zero",
+    (bad) => {
+      setPlatform("win32");
+      const mgr = new TrayManager(createMockWindow());
+      mgr.create();
+      mgr.setNotificationCount(bad);
+      expect(mgr.notificationCount).toBe(0);
+      expect(mgr.tray._toolTip).toBe("GAIA");
+    }
+  );
+
+  test("is a no-op on the tooltip after the tray is destroyed", () => {
+    setPlatform("win32");
+    const mgr = new TrayManager(createMockWindow());
+    mgr.create();
+    const destroyed = mgr.tray;
+    destroyed._destroyed = true;
+    destroyed.setToolTip.mockClear();
+    mgr.setNotificationCount(2);
+    expect(destroyed.setToolTip).not.toHaveBeenCalled();
+    expect(mgr.notificationCount).toBe(2);
+  });
+});


### PR DESCRIPTION
One click on a link in a chat answer could launch a program on your machine: Electron handed unvalidated URLs to the OS, and the renderer's link check let `/…` and `//host/…` through — Chromium turns `/Windows/System32/calc.exe` into a `file:` URL and runs it. Links now open only for web schemes, and the window can't be navigated away from the app.

Three more fixes: "Always allow this tool" no longer persists forever keyed by tool name — it lasts one chat and can be revoked in Settings; the app no longer crash-exits during an agent crash loop, where it called a tray method that didn't exist; and "Open in GAIA" from the website now works when GAIA was closed, because the link waits for the backend instead of being dispatched before anything is listening.

## Test plan

- [ ] `cd tests/electron && npm ci && npm test` — 24 passed, 24 total;       1 skipped, 693 passed, 694 total
- [ ] `cd src/gaia/apps/webui && npx vitest run && npx tsc --noEmit` — Tests  314 passed (314); typecheck clean
- [ ] Launched the app: the link attacks are refused and no program starts; four agent crashes leave the tray count at 1 and the app running; a cold-start `gaia://hub/install/email` opens the install dialog once the backend is up
- [ ] Settings → Tools & Permissions: tick "always allow" on a tool prompt, revoke it, and the next call prompts again; after a restart the list is empty (checked by dialog text, not screenshot)
- [ ] macOS dock badge, and a real click on an `https` link (not checked)
