### PR TITLE
fix(email): don't treat a colon word inside a quoted phrase as an Outlook operator

### DIFF
--- a/hub/agents/email/npm/CHANGELOG.md
+++ b/hub/agents/email/npm/CHANGELOG.md
@@ -48,6 +48,10 @@ behind any entry — API shapes, endpoints, and version semantics — see
   nothing.** Microsoft Graph has no equivalent for these, so they used to be
   sent as plain search text and return zero results with no indication why
   (#2996).
+- **An ordinary Outlook search like `search({ query: 'subject:"check in:
+  monday"' })` no longer fails with the error above.** The colon word was
+  inside the quoted phrase, not an operator, and is now recognized as such
+  (#3592).
 
 - **The published API contract now shows that requests need a session token.**
   The sidecar has always required a bearer token on most calls, but the

--- a/hub/agents/email/python/CHANGELOG.md
+++ b/hub/agents/email/python/CHANGELOG.md
@@ -104,6 +104,12 @@ contract version is tracked separately as
   `after:YYYY/MM/DD`), so a model following its own instructions could hit
   this. `translate_query` now raises an actionable error naming the
   unsupported operator instead of degrading to a phrase match.
+- **An Outlook search on an ordinary quoted phrase containing a colon word
+  (`subject:"check in: monday"`) no longer raises the unsupported-operator
+  error above (#3592).** The guard matched `is:`/`after:`/`has:`/etc.
+  anywhere in the query with no notion of quoting, so a colon word inside a
+  quoted value was mistaken for an operator. It now only matches outside a
+  quoted span; a real unsupported operator that follows one still raises.
 
 ### Changed
 

--- a/hub/agents/email/python/gaia_agent_email/outlook_query.py
+++ b/hub/agents/email/python/gaia_agent_email/outlook_query.py
@@ -75,6 +75,11 @@ _UNSUPPORTED_OPERATOR_RE = re.compile(
     re.IGNORECASE,
 )
 
+# A colon word inside a quoted phrase (``subject:"check in: monday"``) is
+# not an operator (#3592); _UNSUPPORTED_OPERATOR_RE is searched against a
+# copy with quoted spans blanked (length preserved) instead of ``remainder``.
+_QUOTED_SPAN_RE = re.compile(r'"[^"]*"')
+
 # Graph has no calendar-aware relative-date filter, so a month is 30 days
 # and a year is 365, the same approximation Gmail's own "1 month ago"
 # reading makes, and precise enough for a recency window, not a ledger.
@@ -169,11 +174,14 @@ def translate_query(query: str, *, now: Optional[datetime] = None) -> GraphQuery
     # second search term, so naming it beats telling the caller to re-run it
     # as a separate search that would fail the exact same way (review on
     # this PR).
-    unsupported = _UNSUPPORTED_OPERATOR_RE.search(remainder)
+    unsupported = _UNSUPPORTED_OPERATOR_RE.search(
+        _QUOTED_SPAN_RE.sub(lambda m: "#" * len(m.group(0)), remainder)
+    )
     if unsupported:
+        start, end = unsupported.span()
         raise ValueError(
             "search_messages: on Outlook, "
-            f"{unsupported.group(0)!r} is not supported by this backend and "
+            f"{remainder[start:end]!r} is not supported by this backend and "
             "would silently match nothing if sent as search text. Supported "
             "operators are is:unread, is:read, newer_than:, older_than:, "
             f"from:, and subject:, so drop {unsupported.group('op')}: from "

--- a/tests/unit/agents/email/test_outlook_query.py
+++ b/tests/unit/agents/email/test_outlook_query.py
@@ -163,5 +163,13 @@ def test_unsupported_operator_after_a_quoted_phrase_still_raises():
         translate_query('subject:"check in: monday" has:attachment', now=_NOW)
 
 
+def test_unsupported_operator_with_a_quoted_value_names_the_original_text():
+    # The guard matches against a masked copy, so the error has to slice the
+    # unmasked remainder or it reports the mask characters instead of the
+    # operator's real quoted value.
+    with pytest.raises(ValueError, match=r"'has:\"my file\"' is not supported"):
+        translate_query('has:"my file"', now=_NOW)
+
+
 if __name__ == "__main__":
     raise SystemExit(pytest.main([__file__, "-v"]))

--- a/tests/unit/agents/email/test_outlook_query.py
+++ b/tests/unit/agents/email/test_outlook_query.py
@@ -143,16 +143,19 @@ def test_is_unsupported_value_raises_before_the_mixed_family_check():
 
 
 @pytest.mark.parametrize(
-    "query",
+    ("query", "expected_search"),
     [
-        'subject:"check in: monday"',
-        'subject:"Q3 has: numbers"',
+        ('subject:"check in: monday"', '"subject:\\"check in: monday\\""'),
+        ('subject:"Q3 has: numbers"', '"subject:\\"Q3 has: numbers\\""'),
     ],
 )
-def test_colon_word_inside_quoted_phrase_is_not_an_operator(query):
+def test_colon_word_inside_quoted_phrase_is_not_an_operator(query, expected_search):
     # #3592: the colon word is part of the quoted phrase's text, not an
-    # operator, so the guard above must not fire on it.
+    # operator, so the guard above must not fire on it. Asserting the
+    # $search value too, so masking the guard's copy can never start
+    # mangling the phrase the user actually typed.
     result = translate_query(query, now=_NOW)
+    assert result.search == expected_search
     assert result.filter is None
 
 

--- a/tests/unit/agents/email/test_outlook_query.py
+++ b/tests/unit/agents/email/test_outlook_query.py
@@ -142,5 +142,26 @@ def test_is_unsupported_value_raises_before_the_mixed_family_check():
         translate_query("is:unread is:starred", now=_NOW)
 
 
+@pytest.mark.parametrize(
+    "query",
+    [
+        'subject:"check in: monday"',
+        'subject:"Q3 has: numbers"',
+    ],
+)
+def test_colon_word_inside_quoted_phrase_is_not_an_operator(query):
+    # #3592: the colon word is part of the quoted phrase's text, not an
+    # operator, so the guard above must not fire on it.
+    result = translate_query(query, now=_NOW)
+    assert result.filter is None
+
+
+def test_unsupported_operator_after_a_quoted_phrase_still_raises():
+    # A quoted colon word must not blind the guard to a real one that
+    # follows outside the quotes.
+    with pytest.raises(ValueError, match="'has:attachment' is not supported"):
+        translate_query('subject:"check in: monday" has:attachment', now=_NOW)
+
+
 if __name__ == "__main__":
     raise SystemExit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
## Summary

`translate_query` raised on a colon word sitting inside a quoted search phrase (`subject:"check in: monday"`), even though it was never meant as an Outlook operator.

## Why

`_UNSUPPORTED_OPERATOR_RE` (#3562) has no notion of quoting, so `\bhas:`/`\bin:`/etc. matched anywhere in the query, including inside a quoted value. The nine new tests from #3562 all assert a raise; none assert that a legitimate quoted query still passes, so nothing caught this.

## Linked issue

Fixes #3592

## Changes

- `translate_query` now searches a copy of the remainder with quoted spans blanked out, so the guard can't match inside quotes. The real match text for the error message still comes from the unquoted remainder.
- Added two pass-through tests for the reported queries, plus one confirming a real unsupported operator after a quoted phrase still raises.
- Noted in both package CHANGELOGs.

## Test plan

- `pytest tests/unit/agents/email/test_outlook_query.py -v`: 29 passed, including the 3 new cases. Reverting just the guard change makes 3 fail (2 pass-through cases raise, `has:attachment` gets blamed on the wrong operator) with the rest unaffected.
- `pytest tests/unit/agents/email/ hub/agents/email/python/tests/ -v` on python:3.12-slim: 2738 passed, 2 skipped.
- `black --check`, `isort --check` (pinned 8.0.1), `flake8` on both changed files: clean.

## Evidence

Agent UI / MCP / CLI / HTTP API: N/A, same as #3562. This is a request-building fix with no UI surface, and exercising it live needs a connected Outlook mailbox nobody on this issue has offered.

## Checklist

- [x] Linked issue (`Fixes #3592`).
- [x] Described why, not just what.
- [x] Ran lint and the test suites above.
- [x] Evidence surfaces marked N/A with reason.
- [x] CHANGELOGs updated (both packages).
