### PR TITLE
fix(tui): clear flagship conversation context over stdio

### DIFF
--- a/hub/agents/gaia/npm/CHANGELOG.md
+++ b/hub/agents/gaia/npm/CHANGELOG.md
@@ -12,6 +12,11 @@ into the terminal UI. Before this there was no packaged path at all — the flag
 agent had to be run from a repo checkout with a Python environment, and reaching
 the terminal UI meant building it from source.
 
+### Fixed
+
+- Clearing a TUI conversation now also clears the flagship stdio agent’s prior
+  conversation context, while preserving the selected model, skills, and permissions.
+
 ### Added
 
 - **A project map at task start.** In a code repository the agent now opens

--- a/hub/agents/gaia/python/gaia_agent/stdio.py
+++ b/hub/agents/gaia/python/gaia_agent/stdio.py
@@ -1054,6 +1054,9 @@ def run_turn(
         agent.console = previous_console
 
 
+CLEAR_CONVERSATION_QUERY = "\x00gaia:clear_conversation\x00"
+
+
 def dispatch_query(
     agent: Any,
     query: str,
@@ -1067,6 +1070,10 @@ def dispatch_query(
     the LLM and are never recorded as chat turns (see _record_turn's docstring
     on why a turn's own answer is what gets kept).
     """
+    if query == CLEAR_CONVERSATION_QUERY:
+        agent.conversation_history.clear()
+        _write({"type": "final", "answer": "conversation_cleared"}, out)
+        return
     if query == MEMORY_DUMP_QUERY:
         _write(_memory_dump_event(agent), out)
         return

--- a/hub/agents/gaia/python/tests/test_stdio.py
+++ b/hub/agents/gaia/python/tests/test_stdio.py
@@ -13,6 +13,7 @@ import json
 import logging
 import os
 import queue
+import subprocess
 import sys
 
 import pytest
@@ -1323,3 +1324,68 @@ def test_main_reports_a_crashed_turn_and_keeps_going(monkeypatch):
     events = [json.loads(line) for line in _lines(wire)]
     assert events[-1]["type"] == "error"
     assert "dispatch bug" in events[-1]["detail"]
+
+
+def test_clear_conversation_resets_only_history(monkeypatch):
+    agent = _FakeAgent()
+    agent.conversation_history = []
+    agent.model_id = "chosen-model"
+    agent.loaded_skills = {"coding": "loaded"}
+    state = stdio.PermissionState(bypass=True)
+    seen = []
+
+    def turn(agent, query, out, **kwargs):
+        seen.append(list(agent.conversation_history))
+        stdio._record_turn(agent, query, "answer")
+        stdio._write({"type": "final", "answer": "answer"}, out)
+
+    monkeypatch.setattr(stdio, "run_turn", turn)
+    wire = io.StringIO()
+    stdio.dispatch_query(agent, "first", wire, state=state)
+    stdio.dispatch_query(agent, "\x00gaia:clear_conversation\x00", wire, state=state)
+    stdio.dispatch_query(agent, "second", wire, state=state)
+    assert seen == [[], []]
+    assert agent.model_id == "chosen-model"
+    assert agent.loaded_skills == {"coding": "loaded"}
+    assert state.bypass
+    assert json.loads(_lines(wire)[1]) == {
+        "type": "final",
+        "answer": "conversation_cleared",
+    }
+    stdio.dispatch_query(agent, "\x00gaia:clear_conversation\x00", wire, state=state)
+    stdio.dispatch_query(agent, "\x00gaia:clear_conversation\x00", wire, state=state)
+    assert agent.conversation_history == []
+
+
+def test_clear_conversation_over_real_stdio_process():
+    script = r"""
+import json
+import sys
+from gaia_agent import stdio
+class Agent:
+    console = None
+    conversation_history = []
+    loaded_skills = {"coding": "loaded"}
+    def process_query(self, query):
+        return {"answer": json.dumps(self.conversation_history)}
+agent = Agent()
+for line in sys.stdin:
+    stdio.dispatch_query(agent, stdio.parse_query(line.strip()), sys.stdout)
+"""
+    queries = ["first", "followup", "\x00gaia:clear_conversation\x00", "fresh"]
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        input="".join(json.dumps({"gaia_query": query}) + "\n" for query in queries),
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=True,
+    )
+    events = [
+        json.loads(line) for line in result.stdout.splitlines() if line.startswith("{")
+    ]
+    finals = [e["answer"] for e in events if e["type"] == "final"]
+    assert len(finals) == 4, result.stdout
+    assert json.loads(finals[1])[0]["content"] == "first"
+    assert finals[2] == "conversation_cleared"
+    assert json.loads(finals[3]) == []

--- a/tui/README.md
+++ b/tui/README.md
@@ -265,6 +265,14 @@ HOME="$TMPHOME" gaia daemon stop
 rm -rf "$TMPHOME"
 ```
 
+## Clearing a conversation
+
+`/clear` clears the conversation context as well as the visible transcript. The
+flagship keeps its running process, selected model, loaded skills, and permission
+settings. If the agent cannot acknowledge the reset, the transcript remains visible
+with an error. Stored long-term memories are unaffected.
+
+
 ## The `tui` prefix
 
 A leading `tui` word is accepted and dropped — `gaia-tui tui status` and

--- a/tui/README.md
+++ b/tui/README.md
@@ -271,6 +271,8 @@ rm -rf "$TMPHOME"
 flagship keeps its running process, selected model, loaded skills, and permission
 settings. If the agent cannot acknowledge the reset, the transcript remains visible
 with an error. Stored long-term memories are unaffected.
+Legacy `--subprocess` and `--mock` connections clear the view with a visible note
+that their agent-side context is unchanged, because their protocol has no reset.
 
 
 ## The `tui` prefix

--- a/tui/internal/client/clear.go
+++ b/tui/internal/client/clear.go
@@ -10,10 +10,14 @@ import (
 // ConversationResetter clears agent-owned context with an acknowledged round trip.
 // Calls must be serialized with Send.
 type ConversationResetter interface {
+	SupportsConversationReset() bool
 	ClearConversation(context.Context) error
 }
 
+// Must match CLEAR_CONVERSATION_QUERY in gaia_agent/stdio.py.
 const clearConversationQuery = "\x00gaia:clear_conversation\x00"
+
+func (s *SubprocessClient) SupportsConversationReset() bool { return s.canonical }
 
 func (s *SubprocessClient) ClearConversation(ctx context.Context) error {
 	if !s.canonical {

--- a/tui/internal/client/clear.go
+++ b/tui/internal/client/clear.go
@@ -1,0 +1,50 @@
+package client
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/amd/gaia/tui/internal/event"
+)
+
+// ConversationResetter clears agent-owned context with an acknowledged round trip.
+// Calls must be serialized with Send.
+type ConversationResetter interface {
+	ClearConversation(context.Context) error
+}
+
+const clearConversationQuery = "\x00gaia:clear_conversation\x00"
+
+func (s *SubprocessClient) ClearConversation(ctx context.Context) error {
+	if !s.canonical {
+		return fmt.Errorf("this subprocess does not support clearing conversation context")
+	}
+	s.mu.Lock()
+	started := s.started
+	s.mu.Unlock()
+	if !started {
+		return nil
+	}
+	ch, err := s.Send(ctx, clearConversationQuery)
+	if err != nil {
+		return err
+	}
+	acknowledged := false
+	for evt := range ch {
+		switch e := evt.(type) {
+		case event.CanonicalFinalEvent:
+			acknowledged = e.Answer == "conversation_cleared"
+		case event.CanonicalErrorEvent:
+			return fmt.Errorf("%s", e.Detail)
+		case event.AgentErrorEvent:
+			return fmt.Errorf("%s", e.Content)
+		}
+	}
+	if ctx.Err() != nil {
+		return ctx.Err()
+	}
+	if !acknowledged {
+		return fmt.Errorf("the agent did not acknowledge clearing its conversation; upgrade the flagship agent")
+	}
+	return nil
+}

--- a/tui/internal/client/clear_test.go
+++ b/tui/internal/client/clear_test.go
@@ -1,0 +1,121 @@
+package client
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/amd/gaia/tui/internal/event"
+)
+
+func TestClearWireHelper(t *testing.T) {
+	mode := os.Getenv("GAIA_TEST_CLEAR_HELPER")
+	if mode == "" {
+		return
+	}
+	history := []string{}
+	scanner := bufio.NewScanner(os.Stdin)
+	for scanner.Scan() {
+		var wrapper map[string]string
+		if err := json.Unmarshal(scanner.Bytes(), &wrapper); err != nil {
+			os.Exit(2)
+		}
+		query := wrapper[queryKey]
+		answer := ""
+		if query == clearConversationQuery {
+			switch mode {
+			case "error":
+				fmt.Println(`{"type":"error","detail":"reset refused"}`)
+				continue
+			case "old":
+				answer = "unrecognized"
+			default:
+				history = nil
+				answer = "conversation_cleared"
+			}
+		} else {
+			answer = strings.Join(history, ",")
+			history = append(history, query)
+		}
+		line, _ := json.Marshal(map[string]string{"type": "final", "answer": answer})
+		fmt.Println(string(line))
+	}
+	os.Exit(0)
+}
+
+func TestClearConversationAcrossSubprocessTurns(t *testing.T) {
+	t.Setenv("GAIA_TEST_CLEAR_HELPER", "ok")
+	self, err := os.Executable()
+	if err != nil {
+		t.Fatal(err)
+	}
+	c := NewCanonicalSubprocessClient(self, []string{"-test.run=^TestClearWireHelper$"}, false)
+	defer c.Close()
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	if err := c.ClearConversation(ctx); err != nil {
+		t.Fatal(err)
+	}
+	if c.started {
+		t.Fatal("clearing an unused conversation spawned a child")
+	}
+	turn := func(q string) string {
+		ch, err := c.Send(ctx, q)
+		if err != nil {
+			t.Fatal(err)
+		}
+		answer := "missing terminal"
+		for evt := range ch {
+			if final, ok := evt.(event.CanonicalFinalEvent); ok {
+				answer = final.Answer
+			}
+		}
+		return answer
+	}
+	turn("first")
+	if got := turn("followup"); got != "first" {
+		t.Fatalf("history did not accumulate: %q", got)
+	}
+	proc := c.proc
+	for i := 0; i < 2; i++ {
+		if err := c.ClearConversation(ctx); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if got := turn("fresh"); got != "" {
+		t.Fatalf("cleared history leaked: %q", got)
+	}
+	if proc != c.proc {
+		t.Fatal("clear restarted the agent")
+	}
+}
+
+func TestClearConversationRequiresAcknowledgment(t *testing.T) {
+	for _, mode := range []string{"error", "old"} {
+		t.Run(mode, func(t *testing.T) {
+			t.Setenv("GAIA_TEST_CLEAR_HELPER", mode)
+			self, err := os.Executable()
+			if err != nil {
+				t.Fatal(err)
+			}
+			c := NewCanonicalSubprocessClient(self, []string{"-test.run=^TestClearWireHelper$"}, false)
+			defer c.Close()
+			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+			defer cancel()
+			ch, err := c.Send(ctx, "hello")
+			if err != nil {
+				t.Fatal(err)
+			}
+			for range ch {
+			}
+			if err := c.ClearConversation(ctx); err == nil {
+				t.Fatal("unacknowledged reset was accepted")
+			}
+		})
+	}
+}

--- a/tui/internal/ui/chat/clear.go
+++ b/tui/internal/ui/chat/clear.go
@@ -14,22 +14,31 @@ type conversationClearedMsg struct {
 }
 
 func (m ChatModel) clearConversation() (tea.Model, tea.Cmd) {
-	if resetter, ok := m.client.(client.ConversationResetter); ok {
+	if resetter, ok := m.client.(client.ConversationResetter); ok && resetter.SupportsConversationReset() {
 		ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
 		m.cancelFn = cancel
 		m.streaming = true
+		m.activity = []ActivityItem{{Kind: "status", Content: "Clearing conversation"}}
+		m.logPeakRows = 0
+		m.buffer = ""
+		m.followTail = true
+		m.queryStart = time.Now()
+		m.firstToken = false
+		m.ttft = 0
+		m.totalSteps = 0
+		m.updateViewport()
 		m.turnSeq++
 		seq := m.turnSeq
-		return m, func() tea.Msg {
+		return m, tea.Batch(m.spinner.Tick, func() tea.Msg {
 			defer cancel()
 			return conversationClearedMsg{turnSeq: seq, err: resetter.ClearConversation(ctx)}
-		}
+		})
 	}
 	if resetter, ok := m.client.(client.TranscriptResetter); ok {
 		resetter.ResetTranscript()
 		m.messages = nil
 	} else {
-		m.messages = append(m.messages, Message{Role: RoleError, Content: "This agent connection cannot clear conversation context."})
+		m.messages = []Message{{Role: RoleStatus, Content: "View cleared. This connection cannot reset the agent's conversation context; that context is unchanged."}}
 	}
 	m.updateViewport()
 	return m, nil

--- a/tui/internal/ui/chat/clear.go
+++ b/tui/internal/ui/chat/clear.go
@@ -1,0 +1,51 @@
+package chat
+
+import (
+	"context"
+	"time"
+
+	"github.com/amd/gaia/tui/internal/client"
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+type conversationClearedMsg struct {
+	turnSeq int
+	err     error
+}
+
+func (m ChatModel) clearConversation() (tea.Model, tea.Cmd) {
+	if resetter, ok := m.client.(client.ConversationResetter); ok {
+		ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+		m.cancelFn = cancel
+		m.streaming = true
+		m.turnSeq++
+		seq := m.turnSeq
+		return m, func() tea.Msg {
+			defer cancel()
+			return conversationClearedMsg{turnSeq: seq, err: resetter.ClearConversation(ctx)}
+		}
+	}
+	if resetter, ok := m.client.(client.TranscriptResetter); ok {
+		resetter.ResetTranscript()
+		m.messages = nil
+	} else {
+		m.messages = append(m.messages, Message{Role: RoleError, Content: "This agent connection cannot clear conversation context."})
+	}
+	m.updateViewport()
+	return m, nil
+}
+
+func (m ChatModel) handleConversationCleared(msg conversationClearedMsg) (tea.Model, tea.Cmd) {
+	if msg.turnSeq != m.turnSeq {
+		return m, nil
+	}
+	m.streaming = false
+	m.settleTurn()
+	if msg.err != nil {
+		m.messages = append(m.messages, Message{Role: RoleError, Content: "Could not clear conversation: " + msg.err.Error()})
+	} else {
+		m.messages = nil
+	}
+	m.updateViewport()
+	return m, nil
+}

--- a/tui/internal/ui/chat/clear_test.go
+++ b/tui/internal/ui/chat/clear_test.go
@@ -1,0 +1,47 @@
+package chat
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+)
+
+type clearClient struct {
+	nullClient
+	err    error
+	clears int
+}
+
+func (c *clearClient) ClearConversation(context.Context) error { c.clears++; return c.err }
+
+func TestClearWaitsForAgentAcknowledgment(t *testing.T) {
+	for _, fail := range []bool{false, true} {
+		c := &clearClient{}
+		if fail {
+			c.err = errors.New("agent refused")
+		}
+		m := NewChatModel(c, "gaia", "GAIA", false)
+		m.messages = []Message{{Role: RoleUser, Content: "prior instruction"}}
+		next, cmd := m.submit("/clear")
+		m = next.(ChatModel)
+		if !m.streaming || len(m.messages) != 1 {
+			t.Fatal("history cleared before acknowledgment")
+		}
+		if c.clears != 0 {
+			t.Fatal("reset blocked the UI update")
+		}
+		updated, _ := m.Update(cmd())
+		m = updated.(ChatModel)
+		if m.streaming || c.clears != 1 {
+			t.Fatal("reset did not settle")
+		}
+		if fail {
+			if len(m.messages) != 2 || !strings.Contains(m.messages[1].Content, "agent refused") {
+				t.Fatalf("failure erased history or was hidden: %+v", m.messages)
+			}
+		} else if len(m.messages) != 0 {
+			t.Fatal("acknowledged reset did not clear history")
+		}
+	}
+}

--- a/tui/internal/ui/chat/clear_test.go
+++ b/tui/internal/ui/chat/clear_test.go
@@ -5,6 +5,11 @@ import (
 	"errors"
 	"strings"
 	"testing"
+	"time"
+
+	"github.com/amd/gaia/tui/internal/client"
+	"github.com/charmbracelet/bubbles/spinner"
+	tea "github.com/charmbracelet/bubbletea"
 )
 
 type clearClient struct {
@@ -14,6 +19,7 @@ type clearClient struct {
 }
 
 func (c *clearClient) ClearConversation(context.Context) error { c.clears++; return c.err }
+func (c *clearClient) SupportsConversationReset() bool         { return true }
 
 func TestClearWaitsForAgentAcknowledgment(t *testing.T) {
 	for _, fail := range []bool{false, true} {
@@ -31,7 +37,11 @@ func TestClearWaitsForAgentAcknowledgment(t *testing.T) {
 		if c.clears != 0 {
 			t.Fatal("reset blocked the UI update")
 		}
-		updated, _ := m.Update(cmd())
+		batch, ok := cmd().(tea.BatchMsg)
+		if !ok || len(batch) != 2 {
+			t.Fatal("reset did not schedule progress and acknowledgment")
+		}
+		updated, _ := m.Update(batch[1]())
 		m = updated.(ChatModel)
 		if m.streaming || c.clears != 1 {
 			t.Fatal("reset did not settle")
@@ -44,4 +54,51 @@ func TestClearWaitsForAgentAcknowledgment(t *testing.T) {
 			t.Fatal("acknowledged reset did not clear history")
 		}
 	}
+}
+
+func TestClearLegacyAndMockTransportsKeepsViewClearAvailable(t *testing.T) {
+	// Both --subprocess and --mock use the legacy SubprocessClient constructor.
+	for _, mode := range []string{"subprocess", "mock"} {
+		t.Run(mode, func(t *testing.T) {
+			c := client.NewSubprocessClient("unused-"+mode, nil, false)
+			m := NewChatModel(c, "legacy", "Legacy", false)
+			m.messages = []Message{{Role: RoleUser, Content: "old visible text"}}
+			next, cmd := m.submit("/clear")
+			m = next.(ChatModel)
+			if cmd != nil || m.streaming || len(m.messages) != 1 {
+				t.Fatal("unsupported reset started an agent command or kept the transcript")
+			}
+			if m.messages[0].Role != RoleStatus || !strings.Contains(m.messages[0].Content, "context is unchanged") {
+				t.Fatalf("missing explicit context limitation: %+v", m.messages)
+			}
+		})
+	}
+}
+
+func TestClearShowsFreshProgressWhileAwaitingAcknowledgment(t *testing.T) {
+	m := NewChatModel(&clearClient{}, "gaia", "GAIA", false)
+	m.width, m.height = 100, 30
+	m.activity = []ActivityItem{{Kind: "tool", Content: "old work"}}
+	m.buffer = "old partial output"
+	m.queryStart = time.Now().Add(-time.Hour)
+	m.logPeakRows = 20
+	m.firstToken, m.totalSteps = true, 12
+	started := time.Now()
+	next, cmd := m.submit("/clear")
+	m = next.(ChatModel)
+	if m.queryStart.Before(started) || m.buffer != "" || m.firstToken || m.totalSteps != 0 {
+		t.Fatal("clear retained timing or output from the previous turn")
+	}
+	view := m.View()
+	if !strings.Contains(view, "Clearing conversation") || strings.Contains(view, "old work") || strings.Contains(view, "old partial output") {
+		t.Fatalf("clear progress missing or stale: %s", view)
+	}
+	batch, ok := cmd().(tea.BatchMsg)
+	if !ok || len(batch) != 2 {
+		t.Fatal("missing spinner command")
+	}
+	if _, ok := batch[0]().(spinner.TickMsg); !ok {
+		t.Fatal("clear did not start the spinner")
+	}
+	m.cancelFn()
 }

--- a/tui/internal/ui/chat/model.go
+++ b/tui/internal/ui/chat/model.go
@@ -606,6 +606,9 @@ func (m ChatModel) update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.resize()
 		return m, nil
 
+	case conversationClearedMsg:
+		return m.handleConversationCleared(msg)
+
 	case sendQueryMsg:
 		return m.sendQuery(msg.query)
 
@@ -1291,15 +1294,7 @@ func (m ChatModel) submit(query string) (tea.Model, tea.Cmd) {
 		return m, func() tea.Msg { return ToggleHelpMsg{} }
 
 	case "/clear":
-		m.messages = nil
-		// Daemon-transport agents are stateless per turn: the host pushes the
-		// transcript back as `context`, so clearing the view must clear that
-		// too or the "cleared" history keeps being sent.
-		if r, ok := m.client.(client.TranscriptResetter); ok {
-			r.ResetTranscript()
-		}
-		m.updateViewport()
-		return m, nil
+		return m.clearConversation()
 
 	case "/memory":
 		return m.startMemoryFetch()


### PR DESCRIPTION
## Summary

The TUI now clears the flagship's actual conversation and waits for acknowledgment before removing the visible transcript.

## Why

Previously `/clear` erased only the screen; prior instructions still influenced the next task.

## Linked issue

Closes #3636

## Changes

Adds an acknowledged stdio reset while preserving the running process, model, skills and permission state. Failed resets retain the transcript and show an error.

## Test plan

- [x] `python -m pytest hub/agents/gaia/python/tests/test_stdio.py -q` — 67 passed.
- [x] `go test ./internal/client ./internal/ui/chat` and `go vet ./internal/client ./internal/ui/chat` — passed.
- [x] Black, isort and diff checks passed.

## Evidence

The new regression failed before the fix because prior instructions remained in context. A real Python stdin/stdout subprocess handles two turns, a reset and a fresh turn; the fresh turn sees no old history. Go tests cover the transport acknowledgment and UI success/failure state. Inference is deterministic in this contract test; live model quality and rendered terminal screenshots were not evaluated.

## Checklist

- [x] Linked the issue and explained the impact.
- [x] Ran targeted regression tests and lint; read back the changes.
- [x] Updated relevant documentation where behavior is described.
- [ ] Maintainer review and CI completion.


## Compatibility follow-up

Legacy subprocess and mock connections retain screen clearing with an explicit notice that agent context is unchanged. Canonical resets show progress while awaiting acknowledgement.

- [x] New UI regressions fail on the prior implementation; client/chat suites and go vet pass.
- [x] Live compiled TUI: `gaia-clear.exe chat --subprocess mock-clear.exe --query before-clear-marker --control-port 8819`, followed by `/clear` via the control API, displayed:

```text
View cleared. This connection cannot reset the agent's conversation
context; that context is unchanged.
```

The process exited cleanly via Ctrl+C. Canonical context-reset evidence remains the real Python stdio round trip described above.
