### PR TITLE
fix(chat): restore recent context in long sessions

### DIFF
--- a/src/gaia/ui/_chat_helpers.py
+++ b/src/gaia/ui/_chat_helpers.py
@@ -1347,7 +1347,7 @@ async def _get_chat_response(
 
     def _do_chat():
         # Build conversation history from database
-        messages = db.get_messages(request.session_id, limit=20)
+        messages = db.get_recent_messages(request.session_id, limit=20)
         history_pairs = _build_history_pairs(messages)
 
         # Resolve document IDs to file paths.
@@ -1745,7 +1745,7 @@ async def _stream_chat_impl(run, db: ChatDatabase, session: dict, request: ChatR
         )
 
         # Build conversation history
-        messages = db.get_messages(request.session_id, limit=20)
+        messages = db.get_recent_messages(request.session_id, limit=20)
         history_pairs = _build_history_pairs(messages)
 
         # Resolve document IDs to file paths.

--- a/src/gaia/ui/agent_loop.py
+++ b/src/gaia/ui/agent_loop.py
@@ -416,7 +416,7 @@ class AgentLoop:
                     agent.console = sse_handler
 
                 # Inject conversation history (capped for autonomous ticks)
-                messages = db.get_messages(session_id, limit=10)
+                messages = db.get_recent_messages(session_id, limit=10)
                 history_pairs = _helpers._build_history_pairs(messages)
                 agent.conversation_history = []
                 for u, a in history_pairs[-3:]:  # 3-pair rolling window for ticks

--- a/src/gaia/ui/database.py
+++ b/src/gaia/ui/database.py
@@ -675,11 +675,29 @@ class ChatDatabase:
             rows = self._conn.execute(
                 """SELECT * FROM messages
                    WHERE session_id = ?
-                   ORDER BY created_at ASC
+                   ORDER BY created_at ASC, id ASC
                    LIMIT ? OFFSET ?""",
                 (session_id, limit, offset),
             ).fetchall()
 
+        return self._decode_messages(rows)
+
+    def get_recent_messages(
+        self, session_id: str, limit: int = 100
+    ) -> List[Dict[str, Any]]:
+        """Get the newest messages in chronological order for agent context."""
+        with self._lock:
+            rows = self._conn.execute(
+                """SELECT * FROM (
+                       SELECT * FROM messages WHERE session_id = ?
+                       ORDER BY created_at DESC, id DESC LIMIT ?
+                   ) ORDER BY created_at ASC, id ASC""",
+                (session_id, limit),
+            ).fetchall()
+        return self._decode_messages(rows)
+
+    @staticmethod
+    def _decode_messages(rows) -> List[Dict[str, Any]]:
         messages = []
         for row in rows:
             msg = dict(row)

--- a/tests/unit/chat/ui/test_chat_helpers_model_resolution.py
+++ b/tests/unit/chat/ui/test_chat_helpers_model_resolution.py
@@ -40,7 +40,7 @@ def _make_session(model=_DB_DEFAULT, agent_type="bot"):
 
 def _make_db(custom_model=None):
     db = MagicMock()
-    db.get_messages.return_value = []
+    db.get_recent_messages.return_value = []
     db.get_setting.return_value = custom_model
     db.list_documents.return_value = []
     db.update_session.return_value = None
@@ -315,7 +315,7 @@ class TestDynamicToolsContractShape:
     @staticmethod
     def _db_with_settings(settings: dict):
         db = MagicMock()
-        db.get_messages.return_value = []
+        db.get_recent_messages.return_value = []
         db.list_documents.return_value = []
         db.update_session.return_value = None
         db.get_session.return_value = {}

--- a/tests/unit/chat/ui/test_history_limits.py
+++ b/tests/unit/chat/ui/test_history_limits.py
@@ -33,7 +33,7 @@ def _make_messages(n_pairs: int, msg_len: int = 10) -> list:
 
 def _make_mock_db(messages: list, session_id: str = "sess-1") -> MagicMock:
     db = MagicMock()
-    db.get_messages.return_value = messages
+    db.get_recent_messages.return_value = messages
     db.get_session.return_value = {"session_id": session_id, "document_ids": []}
     db.list_documents.return_value = []
     return db

--- a/tests/unit/chat/ui/test_recent_chat_history.py
+++ b/tests/unit/chat/ui/test_recent_chat_history.py
@@ -1,0 +1,172 @@
+# Copyright(C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+"""History reconstruction must read the end of the persisted transcript."""
+
+import sys
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from gaia.ui import _chat_helpers as helpers
+from gaia.ui.database import ChatDatabase
+from gaia.ui.models import ChatRequest
+
+
+@pytest.fixture
+def transcript():
+    db = ChatDatabase(":memory:")
+    session = db.create_session()
+    # Equal timestamps exercise the insertion-order tiebreaker as well.
+    with patch.object(db, "_now", return_value="2026-09-11T12:00:00+00:00"):
+        for i in range(12):
+            db.add_message(session["id"], "user", f"USER_{i}")
+            db.add_message(session["id"], "assistant", f"ASST_{i}")
+        db.add_message(session["id"], "user", "failed user turn")
+        db.add_message(session["id"], "user", "current follow-up")
+    yield db, session
+    db.close()
+
+
+def test_recent_messages_preserve_order_and_transcript_pagination(transcript):
+    db, session = transcript
+    recent = db.get_recent_messages(session["id"], limit=4)
+    assert [m["content"] for m in recent] == [
+        "USER_11",
+        "ASST_11",
+        "failed user turn",
+        "current follow-up",
+    ]
+    assert [m["content"] for m in db.get_messages(session["id"], limit=2)] == [
+        "USER_0",
+        "ASST_0",
+    ]
+    assert db.get_recent_messages("missing", limit=4) == []
+
+
+@pytest.mark.asyncio
+@pytest.mark.allow_network  # Windows asyncio creates a local socket pair.
+@pytest.mark.parametrize("stream", [False, True])
+async def test_chat_dispatch_receives_latest_completed_exchanges(transcript, stream):
+    db, session = transcript
+    captured = []
+
+    class Agent:
+        model_id = None
+        indexed_files = set()
+
+        def _register_tools(self):
+            pass
+
+        def process_query(self, _message):
+            captured.extend(self.conversation_history)
+            return {"result": "latest history received"}
+
+    request = ChatRequest(
+        session_id=session["id"], message="current follow-up", stream=stream
+    )
+    with (
+        patch.object(helpers, "_agent_registry", None),
+        patch.object(helpers, "_get_cached_agent", return_value=Agent()),
+        patch.object(helpers, "_maybe_load_expected_model"),
+        patch.object(helpers, "_maybe_update_session_title", new_callable=AsyncMock),
+        patch(
+            "gaia.llm.lemonade_manager.LemonadeManager.get_base_url",
+            return_value="http://localhost:13305/api/v1",
+        ),
+        patch("httpx.AsyncClient.get", new_callable=AsyncMock) as stats,
+    ):
+        stats.return_value.status_code = 503
+        if stream:
+            events = [
+                event
+                async for event in helpers._stream_chat_impl(
+                    SimpleNamespace(handler=None), db, session, request
+                )
+            ]
+            assert any('"type": "done"' in event for event in events)
+        else:
+            assert await helpers._get_chat_response(db, session, request) == (
+                "latest history received"
+            )
+
+    assert [entry["content"] for entry in captured] == [
+        content for i in range(7, 12) for content in (f"USER_{i}", f"ASST_{i}")
+    ]
+
+
+@pytest.mark.allow_network  # TestClient uses a local asyncio socket pair on Windows.
+@pytest.mark.parametrize("stream", [False, True])
+def test_http_follow_up_uses_latest_exchange(transcript, stream):
+    from fastapi.testclient import TestClient
+
+    from gaia.ui.server import create_app
+
+    db, session = transcript
+
+    class HistoryEchoAgent:
+        model_id = None
+        indexed_files = set()
+
+        def _register_tools(self):
+            pass
+
+        def process_query(self, _message):
+            return {"result": self.conversation_history[-1]["content"]}
+
+    app = create_app(db_path=":memory:")
+    app.state.db.close()
+    app.state.db = db
+    with (
+        patch.object(helpers, "_agent_registry", None),
+        patch.object(helpers, "_get_cached_agent", return_value=HistoryEchoAgent()),
+        patch.object(helpers, "_maybe_load_expected_model"),
+        patch.object(helpers, "_maybe_update_session_title", new_callable=AsyncMock),
+        patch(
+            "gaia.llm.lemonade_manager.LemonadeManager.get_base_url",
+            return_value="http://localhost:13305/api/v1",
+        ),
+        patch("httpx.AsyncClient.get", new_callable=AsyncMock) as stats,
+    ):
+        stats.return_value.status_code = 503
+        response = TestClient(app).post(
+            "/api/chat/send",
+            json={
+                "session_id": session["id"],
+                "message": "What was that?",
+                "stream": stream,
+            },
+        )
+    assert response.status_code == 200
+    assert "ASST_11" in response.text
+    assert "ASST_9" not in response.text
+
+
+@pytest.mark.asyncio
+@pytest.mark.allow_network  # Windows asyncio creates a local socket pair.
+async def test_background_tick_uses_latest_completed_exchanges(transcript):
+    from gaia.ui.agent_loop import AgentLoop
+
+    db, session = transcript
+    captured = []
+
+    class Agent:
+        def _register_tools(self):
+            pass
+
+        def process_query(self, _message):
+            captured.extend(self.conversation_history)
+
+    loop = AgentLoop()
+    loop._db = db
+    module = SimpleNamespace(ChatAgent=Agent, ChatAgentConfig=object)
+    with (
+        patch.dict(sys.modules, {"gaia_agent_chat.agent": module}),
+        patch.object(helpers, "_get_cached_agent", return_value=Agent()),
+        patch.object(loop, "_get_actionable_goals", return_value=[]),
+    ):
+        await loop._execute_tick(session["id"], session, [])
+    assert [entry["content"] for entry in captured] == [
+        content for i in range(9, 12) for content in (f"USER_{i}", f"ASST_{i}")
+    ]


### PR DESCRIPTION
## Summary

Long conversations now reconstruct context from the newest stored messages in chronological order.

## Why

After ten exchanges, streaming, non-streaming and background turns repeatedly read the first page of history and missed later conversation.

## Linked issue

Closes #3639

## Changes

Adds a latest-message reader with deterministic ordering while retaining the existing context limits and ordinary transcript pagination.

## Test plan

- [x] `python -m pytest tests/unit/chat/ui/test_database.py tests/unit/chat/ui/test_recent_chat_history.py -q` — 98 database and new boundary tests passed.
- [x] 39 adjacent history, model and agent-loop tests passed (137 total).
- [x] Scoped Black, isort, flake8, pylint and diff checks passed.

## Evidence

Six new regressions cover real database pagination, equal timestamps, unmatched user messages, background ticks, and both HTTP streaming modes. The real chat endpoint returns 200 and the latest ASST_11 context with inference and stats controlled. Baseline dispatch instead injected USER_5. This fixes pagination, not the broader tool-history retention gap in #3628.

## Checklist

- [x] Linked the issue and explained the impact.
- [x] Ran targeted regression tests and lint; read back the changes.
- [x] Updated relevant documentation where behavior is described.
- [ ] Maintainer review and CI completion.
