### PR TITLE
fix(rag): preserve indexed documents when persistence fails

### DIFF
--- a/docs/sdk/sdks/rag.mdx
+++ b/docs/sdk/sdks/rag.mdx
@@ -173,6 +173,11 @@ print(response.text)
 
 **Key advantage:** Documents are indexed once, then you can query as many times as you want without re-processing.
 
+Check the `success` field returned by `index_document()`. A failed cache write
+leaves the searchable index unchanged, so retrying does not duplicate chunks.
+Use `reindex_document(path)` after changing a document; if replacement fails,
+the previously indexed version remains available for queries.
+
 ---
 
 ## Understanding Chunks

--- a/src/gaia/rag/sdk.py
+++ b/src/gaia/rag/sdk.py
@@ -2427,6 +2427,23 @@ These positions indicate where to split the text."""
         """
         file_path = str(Path(file_path).absolute())
         with self._state_lock:
+            previous_state = {
+                name: getattr(self, name).copy()
+                for name in (
+                    "chunks",
+                    "indexed_files",
+                    "chunk_to_file",
+                    "file_to_chunk_indices",
+                    "file_indices",
+                    "file_embeddings",
+                    "file_metadata",
+                    "file_access_times",
+                    "file_index_times",
+                )
+            }
+            previous_state.update(
+                index=self.index, _access_counter=self._access_counter
+            )
             # Keep remove+reindex under the same lock so readers never observe a
             # gap where the document disappeared between generations. Query
             # paths snapshot state quickly under this same lock and then do the
@@ -2443,10 +2460,22 @@ These positions indicate where to split the text."""
 
             # Index the new version
             self.log.info(f"Indexing new version of {file_path}")
-            result = self.index_document(file_path)
-            if result.get("success"):
-                result["reindexed"] = True
-            return result
+            succeeded = False
+            result = None
+            try:
+                result = self.index_document(file_path)
+                succeeded = bool(result.get("success"))
+                if succeeded:
+                    result["reindexed"] = True
+                return result
+            finally:
+                if not succeeded:
+                    # Removal builds a fresh index, so the old generation is intact.
+                    for name, value in previous_state.items():
+                        setattr(self, name, value)
+                    if result is not None:
+                        result["total_indexed_files"] = len(self.indexed_files)
+                        result["total_chunks"] = len(self.chunks)
 
     def _evict_lru_document(self) -> bool:
         """
@@ -2948,6 +2977,17 @@ These positions indicate where to split the text."""
 
                 file_index = self._create_faiss_index(file_embeddings)
 
+                # Persist before publishing any searchable state or ownership maps.
+                if self.config.show_stats:
+                    print("💾 Caching processed chunks...")
+                cache_data = {
+                    "chunks": new_chunks,
+                    "full_text": text,
+                    "metadata": file_metadata,
+                }
+                self._save_cache(cache_path, cache_data)
+                self._save_extracted_markdown(file_path, text, file_metadata)
+
                 if self.index is None:
                     self.index = new_index
                 else:
@@ -2959,23 +2999,6 @@ These positions indicate where to split the text."""
                 self.file_indices[file_path] = file_index
                 self.file_embeddings[file_path] = file_embeddings
 
-            if self.config.show_stats:
-                print(f"✅ Cached per-file index with {len(new_chunks)} chunks")
-
-            # Cache the results for this specific document
-            if self.config.show_stats:
-                print("💾 Caching processed chunks...")
-            cache_data = {
-                "chunks": new_chunks,  # Cache only new chunks for this document
-                "full_text": text,  # Cache full extracted text (for /dump)
-                "metadata": file_metadata,  # Cache metadata (num_pages, vlm_pages, etc.)
-            }
-            self._save_cache(cache_path, cache_data)
-
-            # Auto-save markdown version to cache directory for easy access
-            self._save_extracted_markdown(file_path, text, file_metadata)
-
-            with self._state_lock:
                 # Store metadata in memory for fast access
                 self.file_metadata[file_path] = {
                     "full_text": text,

--- a/tests/unit/rag/test_index_transactions.py
+++ b/tests/unit/rag/test_index_transactions.py
@@ -1,0 +1,132 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""Real-index regression tests for failed document indexing and replacement."""
+
+import errno
+import threading
+from concurrent.futures import ThreadPoolExecutor
+from unittest.mock import patch
+
+import numpy as np
+import pytest
+
+from gaia.rag.sdk import RAGSDK, RAGConfig
+
+
+@pytest.fixture
+def rag(tmp_path):
+    pytest.importorskip("faiss", reason="Real vector-index tests require faiss-cpu")
+    with patch("gaia.rag.sdk.AgentSDK"):
+        sdk = RAGSDK(
+            RAGConfig(cache_dir=str(tmp_path / "cache"), allowed_paths=[str(tmp_path)])
+        )
+    sdk._load_embedder = lambda: None
+    sdk._encode_texts = lambda texts, **kwargs: np.ones(
+        (len(texts), 4), dtype="float32"
+    )
+    sdk._get_hmac_key = lambda: b"test-index-key" * 3
+    return sdk
+
+
+def _assert_documents(rag, expected):
+    assert rag.indexed_files == {str(path) for path in expected}
+    assert len(rag.chunks) == len(expected)
+    assert (rag.index.ntotal if rag.index is not None else 0) == len(expected)
+    assert set(rag.chunk_to_file.values()) == rag.indexed_files
+    assert set(rag.file_to_chunk_indices) == rag.indexed_files
+    assert set(rag.file_indices) == rag.indexed_files
+    assert set(rag.file_embeddings) == rag.indexed_files
+    assert set(rag.file_metadata) == rag.indexed_files
+    assert set(rag.file_access_times) == rag.indexed_files
+    assert set(rag.file_index_times) == rag.indexed_files
+    for path, text in expected.items():
+        positions = rag.file_to_chunk_indices[str(path)]
+        assert len(positions) == 1
+        assert text in rag.chunks[positions[0]]
+
+
+@pytest.mark.parametrize("with_existing", [False, True])
+@pytest.mark.parametrize("failure", ["_save_cache", "_save_extracted_markdown"])
+def test_cache_failure_retry_and_remove_leave_no_orphan_vectors(
+    rag, tmp_path, with_existing, failure
+):
+    expected = {}
+    if with_existing:
+        existing = tmp_path / "existing.txt"
+        existing.write_text("Keep the existing document.", encoding="utf-8")
+        assert rag.index_document(str(existing))["success"]
+        expected[existing] = "Keep the existing document."
+    document = tmp_path / "new.txt"
+    document.write_text("The new document.", encoding="utf-8")
+    with patch.object(rag, failure, side_effect=OSError(errno.ENOSPC, "disk full")):
+        assert not rag.index_document(str(document))["success"]
+    _assert_documents(rag, expected)
+    assert rag.index_document(str(document))["success"]
+    _assert_documents(rag, {**expected, document: "The new document."})
+    assert rag.remove_document(str(document))
+    _assert_documents(rag, expected)
+
+
+def test_cache_failure_at_capacity_does_not_evict_existing_document(rag, tmp_path):
+    existing = tmp_path / "existing.txt"
+    existing.write_text("Keep this document.", encoding="utf-8")
+    assert rag.index_document(str(existing))["success"]
+    rag.config.max_indexed_files = 1
+    document = tmp_path / "new.txt"
+    document.write_text("New document content.", encoding="utf-8")
+    with patch.object(rag, "_save_cache", side_effect=OSError("disk full")):
+        assert not rag.index_document(str(document))["success"]
+    _assert_documents(rag, {existing: "Keep this document."})
+
+
+@pytest.mark.parametrize("failure", ["cache", "extraction"])
+@pytest.mark.parametrize("with_existing", [False, True])
+def test_failed_replacement_preserves_previous_document(
+    rag, tmp_path, failure, with_existing
+):
+    expected = {}
+    document = tmp_path / "replace.txt"
+    expected[document] = "Original document content."
+    if with_existing:
+        expected[tmp_path / "other.txt"] = "Unrelated document content."
+    for path, text in expected.items():
+        path.write_text(text, encoding="utf-8")
+        assert rag.index_document(str(path))["success"]
+    document.write_text("Replacement document content.", encoding="utf-8")
+    method = "_save_cache" if failure == "cache" else "_extract_text_from_file"
+    with patch.object(rag, method, side_effect=OSError("injected replacement failure")):
+        result = rag.reindex_document(str(document))
+    assert not result["success"]
+    assert result["total_indexed_files"] == len(expected)
+    assert result["total_chunks"] == len(expected)
+    _assert_documents(rag, expected)
+    assert rag.reindex_document(str(document))["success"]
+    expected[document] = "Replacement document content."
+    _assert_documents(rag, expected)
+
+
+def test_concurrent_same_document_publishes_once_after_persistence(rag, tmp_path):
+    document = tmp_path / "shared.txt"
+    document.write_text("Shared document content.", encoding="utf-8")
+    extracting = threading.Barrier(2)
+    extract = rag._extract_text_from_file
+    save = rag._save_cache
+
+    def extract_together(path):
+        result = extract(path)
+        extracting.wait(timeout=5)
+        return result
+
+    def save_before_publication(path, data):
+        _assert_documents(rag, {})
+        save(path, data)
+
+    with (
+        patch.object(rag, "_extract_text_from_file", side_effect=extract_together),
+        patch.object(rag, "_save_cache", side_effect=save_before_publication),
+        ThreadPoolExecutor(max_workers=2) as executor,
+    ):
+        results = list(executor.map(rag.index_document, [str(document)] * 2))
+    assert all(result["success"] for result in results)
+    assert sum(bool(result.get("already_indexed")) for result in results) == 1
+    _assert_documents(rag, {document: "Shared document content."})


### PR DESCRIPTION
## Summary

Failed document-cache persistence no longer leaves orphan search chunks, and failed replacements preserve the previous document.

## Why

Indexing could report failure while leaving vectors that retries duplicated and removal could not delete.

## Linked issue

Closes #3641

## Changes

Completes persistence before publishing searchable state and restores the prior generation on failed replacement. The SDK guide documents retry behavior.

## Test plan

- [x] `python -m pytest tests/unit/rag/test_index_transactions.py tests/test_rag.py -q` — 53 passed.
- [x] Ten new real-index regressions cover persistence errors, retry/removal, capacity boundaries, replacement and concurrent same-file indexing.
- [x] Scoped Black, isort, pylint and diff checks passed.

## Evidence

The original six regressions failed against the baseline. Tests use real FAISS, extraction, temporary files and caches with deterministic embeddings. Cache failure now leaves index ownership and vector counts unchanged; retry indexes once and removal leaves no orphan. Optional markdown-export error handling remains unchanged. Process-crash atomicity and arbitrary FAISS allocation failures are outside this fix.

## Checklist

- [x] Linked the issue and explained the impact.
- [x] Ran targeted regression tests and lint; read back the changes.
- [x] Updated relevant documentation where behavior is described.
- [ ] Maintainer review and CI completion.

