### PR TITLE
fix(npm): resolve Windows shims before launching the TUI

### DIFF
--- a/.github/workflows/test_agent_gaia_npm.yml
+++ b/.github/workflows/test_agent_gaia_npm.yml
@@ -39,11 +39,16 @@ permissions:
 jobs:
   test-agent-gaia-npm:
     name: Build & Test gaia npm package
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest]
     timeout-minutes: 15
     if: github.event_name != 'pull_request' || github.event.pull_request.draft == false || contains(github.event.pull_request.labels.*.name, 'ready_for_ci')
     defaults:
       run:
+        shell: bash
         working-directory: hub/agents/gaia/npm
 
     steps:

--- a/hub/agents/gaia/npm/CHANGELOG.md
+++ b/hub/agents/gaia/npm/CHANGELOG.md
@@ -12,6 +12,11 @@ into the terminal UI. Before this there was no packaged path at all — the flag
 agent had to be run from a repo checkout with a Python environment, and reaching
 the terminal UI meant building it from source.
 
+### Fixed
+
+- Windows npm launchers now find the Python daemon CLI even when npm passes the
+  package script as argv[1], preserving unrelated tools in shared PATH directories.
+
 ### Added
 
 - **A project map at task start.** In a code repository the agent now opens

--- a/hub/agents/gaia/npm/src/cli.ts
+++ b/hub/agents/gaia/npm/src/cli.ts
@@ -14,7 +14,7 @@
  * "continue anyway" path.
  */
 
-import { readdirSync, realpathSync } from "node:fs";
+import { readFileSync, readdirSync, realpathSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -265,13 +265,40 @@ export function pathWithoutOwnShim(
       : resolved === ownBinDir;
   };
   const entries = rawPath.split(sep).filter((d) => d !== "");
-  const kept = entries.filter((d) => !same(d));
-  if (kept.length === entries.length) return kept.join(sep);
-  // A dir holding nothing but our own shim (an npx temp dir, node_modules/.bin)
-  // costs nothing to drop. A SHARED bin dir must NOT be dropped — that is where
-  // python3 / lemonade-server / the real `gaia` live — so it moves to the end
-  // instead, letting any other `gaia` on PATH win while its siblings survive.
-  return (isExclusivelyOurs(ownBinDir, ownName) ? kept : [...kept, ownBinDir]).join(sep);
+  const ours = entries.filter((d) => same(d) || shimTargetsScript(d, argv1));
+  const kept = entries.filter((d) => !ours.includes(d));
+  const shared = ours.filter((d) => !isExclusivelyOurs(d, same(d) ? ownName : "gaia"));
+  return [...kept, ...shared].join(sep);
+}
+
+/** Match npm's symlink or generated cmd/PowerShell wrapper to this script. */
+function shimTargetsScript(dir: string, script: string): boolean {
+  const canonical = (file: string): string | undefined => {
+    try {
+      const resolved = realpathSync(file);
+      return process.platform === "win32" ? resolved.toLowerCase() : resolved;
+    } catch {
+      return undefined; // no resolvable executable at this candidate
+    }
+  };
+  const expected = canonical(script);
+  if (!expected) return false;
+  for (const name of ["gaia", "gaia.cmd", "gaia.ps1"]) {
+    const shim = path.join(dir, name);
+    if (canonical(shim) === expected) return true;
+    if (!name.includes(".")) continue;
+    let contents: string;
+    try {
+      contents = readFileSync(shim, "utf8");
+    } catch {
+      continue; // this PATH directory does not contain a readable wrapper
+    }
+    for (const match of contents.matchAll(/["'](?:%dp0%|\$basedir)[\\/]([^"']+)["']/gi)) {
+      const target = path.resolve(dir, match[1]!.replace(/[\\/]/g, path.sep));
+      if (canonical(target) === expected) return true;
+    }
+  }
+  return false;
 }
 
 /** True when every file in `dir` is a shim for `name` (`gaia`, `gaia.cmd`, …). */

--- a/hub/agents/gaia/npm/test/cli.test.ts
+++ b/hub/agents/gaia/npm/test/cli.test.ts
@@ -4,6 +4,7 @@
 
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
+import { execSync } from "node:child_process";
 import fs from "node:fs";
 import fsp from "node:fs/promises";
 import os from "node:os";
@@ -167,6 +168,51 @@ describe("pathWithoutOwnShim", () => {
     const raw = [path.resolve("/usr/local/bin"), path.resolve("/usr/bin")].join(sep);
     const argv1 = path.resolve("/elsewhere/bin/gaia");
     expect(pathWithoutOwnShim(raw, argv1)!.split(sep).length).toBe(2);
+  });
+
+  it("finds npm wrappers when argv1 names the package script", () => {
+    const bin = path.join(tmp, "node_modules", ".bin");
+    const script = path.join(tmp, "node_modules", "@amd-gaia", "gaia", "dist", "cli.js");
+    fs.mkdirSync(bin, { recursive: true });
+    fs.mkdirSync(path.dirname(script), { recursive: true });
+    fs.writeFileSync(script, "");
+    fs.writeFileSync(path.join(bin, "gaia.cmd"), '@node "%dp0%/../@amd-gaia/gaia/dist/cli.js" %*');
+    const pythonBin = path.join(tmp, "python", "Scripts");
+    expect(pathWithoutOwnShim([bin, pythonBin].join(sep), script)).toBe(pythonBin);
+  });
+
+  it("recognizes PowerShell wrappers and keeps their shared tools", () => {
+    const bin = path.join(tmp, "global npm");
+    const script = path.join(bin, "node_modules", "@amd-gaia", "gaia", "dist", "cli.js");
+    fs.mkdirSync(path.dirname(script), { recursive: true });
+    fs.writeFileSync(script, "");
+    fs.writeFileSync(path.join(bin, "gaia.ps1"), '& node "$basedir/node_modules/@amd-gaia/gaia/dist/cli.js" $args');
+    fs.writeFileSync(path.join(bin, "unrelated.cmd"), "");
+    const pythonBin = path.join(tmp, "python");
+    expect(pathWithoutOwnShim([bin, pythonBin].join(sep), script)).toBe([pythonBin, bin].join(sep));
+  });
+
+  it.runIf(process.platform === "win32")("launches a real npm cmd wrapper and selects the Python CLI", () => {
+    const bin = path.join(tmp, "node_modules", ".bin");
+    const script = path.join(tmp, "node_modules", "@amd-gaia", "gaia", "dist", "cli.js");
+    const pythonBin = path.join(tmp, "python", "Scripts");
+    fs.mkdirSync(bin, { recursive: true });
+    fs.mkdirSync(path.dirname(script), { recursive: true });
+    fs.mkdirSync(pythonBin, { recursive: true });
+    fs.writeFileSync(script, "console.log(JSON.stringify(process.argv[1]))");
+    const wrapper = path.join(bin, "gaia.cmd");
+    fs.writeFileSync(wrapper, [
+      "@echo off", 'set "dp0=%~dp0"',
+      `"${process.execPath}" "%dp0%\\..\\@amd-gaia\\gaia\\dist\\cli.js" %*`,
+    ].join("\r\n"));
+    fs.writeFileSync(path.join(pythonBin, "gaia.cmd"), "@echo python-daemon-ok\r\n");
+    const actualArgv1 = JSON.parse(execSync(`"${wrapper}"`, { encoding: "utf8" }));
+    expect(actualArgv1).toBe(script);
+    const childPath = pathWithoutOwnShim([bin, pythonBin].join(sep), actualArgv1)!;
+    const output = execSync("gaia daemon start", {
+      encoding: "utf8", env: { ...process.env, PATH: childPath, Path: childPath },
+    });
+    expect(output.trim()).toBe("python-daemon-ok");
   });
 
   it("survives an unset PATH or an unknown argv[1]", () => {


### PR DESCRIPTION
## Summary

The npm launcher now identifies its Windows wrapper correctly before starting the TUI, so daemon startup reaches the Python CLI.

## Why

Windows npm passes the package's JavaScript entry point as argv, not the shim path. The old PATH filtering left npm's own `gaia` first, causing daemon startup to invoke it recursively.

## Linked issue

Closes #3637

## Changes

Resolve npm symlinks and generated wrappers to the running script while preserving unrelated programs in shared PATH directories. Includes a changelog entry.

## Test plan

- [x] `npm run build` — passed.
- [x] `npm test` — 148 passed; six existing POSIX-only lifecycle cases skipped on Windows.
- [x] Two realistic argv/PATH regressions failed before the fix.
- [x] Diff whitespace check and independent code review.

## Evidence

A generated Windows `gaia.cmd` invokes Node at `dist/cli.js`, then launches `gaia daemon start` through the filtered PATH. A distinguishable stand-in for the Python CLI responds `python-daemon-ok`; the npm shim is not invoked again. This exercises Windows wrapper resolution without starting or replacing the user's daemon.

## Checklist

- [x] Linked the issue and explained the impact.
- [x] Ran package build, tests and actual Windows wrapper evidence.
- [x] Updated the changelog.
- [ ] Maintainer review and CI completion.

The npm CI lane now runs on Linux and Windows, so the Windows-only shim regression executes in CI. Local Windows verification: `npm run build` passed, `npm test` reported 148 passed / 6 existing POSIX-only skips. The exact CI Bash tarball check reported `Thin-package invariant holds — 39 files, no binaries.` The generated Windows shim smoke returned `python-daemon-ok`.
