### PR TITLE
fix(tui): reject unsupported daemon permission bypass

### DIFF
--- a/tui/README.md
+++ b/tui/README.md
@@ -124,6 +124,10 @@ gaia-tui status             # is the background service running, and what do I h
 gaia-tui version
 ```
 
+`--bypass-permissions` is available only for agents launched as subprocesses.
+Daemon-backed agents, including a Hub-installed flagship, reject it before
+readiness checks; omit the flag to run with confirmation prompts enabled.
+
 Full command reference: <https://amd-gaia.ai/docs/reference/cli>
 
 ---

--- a/tui/internal/cli/chat.go
+++ b/tui/internal/cli/chat.go
@@ -47,6 +47,7 @@ var chatCmd = &cobra.Command{
 				{"timeout", "nothing bounds an interactive session; press ctrl+c to leave it"},
 				{"use-claude", "you own the command line here — append --use-claude to it yourself"},
 				{"claude-model", "you own the command line here — append --claude-model to it yourself"},
+				{"bypass-permissions", "you own the command line here — pass permission options in that command if it supports them"},
 			} {
 				if cmd.Flags().Changed(f.name) {
 					return fmt.Errorf(

--- a/tui/internal/cli/chat.go
+++ b/tui/internal/cli/chat.go
@@ -39,6 +39,11 @@ var chatCmd = &cobra.Command{
 			return fmt.Errorf("--agent and --subprocess are mutually exclusive: pick one")
 		}
 		if subprocess != "" {
+			if cmd.Flags().Changed("bypass-permissions") {
+				return fmt.Errorf("--bypass-permissions is not supported with --subprocess: " +
+					"pass permission options inside the subprocess command if it supports them, " +
+					"or drop --bypass-permissions")
+			}
 			// Both were accepted and then silently dropped here — RunChat is
 			// given neither. (--query IS honoured: it opens the chat and sends
 			// that first message.)
@@ -47,7 +52,6 @@ var chatCmd = &cobra.Command{
 				{"timeout", "nothing bounds an interactive session; press ctrl+c to leave it"},
 				{"use-claude", "you own the command line here — append --use-claude to it yourself"},
 				{"claude-model", "you own the command line here — append --claude-model to it yourself"},
-				{"bypass-permissions", "you own the command line here — pass permission options in that command if it supports them"},
 			} {
 				if cmd.Flags().Changed(f.name) {
 					return fmt.Errorf(

--- a/tui/internal/cli/root.go
+++ b/tui/internal/cli/root.go
@@ -197,7 +197,7 @@ func init() {
 		panic(err) // only fails on a flag name that was never registered
 	}
 	rootCmd.PersistentFlags().BoolVar(&bypassPermissions, "bypass-permissions", false,
-		"run every tool without asking for confirmation — the agent acts fully "+
+		"subprocess agents only: run every tool without asking for confirmation — the agent acts fully "+
 			"autonomously. Off by default; the TUI shows a persistent warning "+
 			"while it is on, and /bypass off turns it off mid-session")
 	rootCmd.PersistentFlags().BoolVar(&useClaude, "use-claude", false,

--- a/tui/internal/client/factory.go
+++ b/tui/internal/client/factory.go
@@ -65,6 +65,9 @@ const ClaudeModelFlag = "--claude-model"
 // finding every launch site. It deliberately lives here rather than on a Bubble
 // Tea model — the headless CLI paths need it without a UI.
 func ForAgent(agent catalog.Agent, opts ForAgentOptions) (AgentClient, error) {
+	if err := CheckBypassSupported(agent, opts.BypassPermissions); err != nil {
+		return nil, err
+	}
 	// A model with no backend switch would be accepted and then change nothing.
 	if opts.ClaudeModel != "" && !opts.UseClaude {
 		return nil, fmt.Errorf(
@@ -128,4 +131,12 @@ func ForAgent(agent catalog.Agent, opts ForAgentOptions) (AgentClient, error) {
 			"agent %q declares transport %d, which this build does not know how to reach — "+
 				"upgrade GAIA or fix the catalog entry", agent.ID, int(agent.Transport))
 	}
+}
+
+// CheckBypassSupported validates launch options before readiness can connect.
+func CheckBypassSupported(agent catalog.Agent, enabled bool) error {
+	if enabled && agent.Transport == catalog.TransportDaemon {
+		return fmt.Errorf("--bypass-permissions is not supported for agent %q over the daemon transport. Drop --bypass-permissions to keep confirmation prompts enabled", agent.ID)
+	}
+	return nil
 }

--- a/tui/internal/client/factory_test.go
+++ b/tui/internal/client/factory_test.go
@@ -275,3 +275,29 @@ func TestForwardingDevArgsDoesNotMutateTheCatalogEntry(t *testing.T) {
 		t.Errorf("the catalog entry now carries %q; --dev leaked into it", got)
 	}
 }
+
+func TestDaemonBypassFailsBeforeConnection(t *testing.T) {
+	for _, id := range []string{"gaia", "email"} {
+		c, err := ForAgent(catalog.Agent{ID: id, Transport: catalog.TransportDaemon}, ForAgentOptions{BypassPermissions: true})
+		if c != nil {
+			c.Close()
+		}
+		if err == nil || !strings.Contains(err.Error(), "--bypass-permissions") || !strings.Contains(err.Error(), "Drop") {
+			t.Fatalf("%s ignored bypass: client=%T err=%v", id, c, err)
+		}
+	}
+}
+func TestSubprocessBypassStillReachesAgent(t *testing.T) {
+	self, err := os.Executable()
+	if err != nil {
+		t.Fatal(err)
+	}
+	c, err := ForAgent(catalog.Agent{ID: "gaia", Transport: catalog.TransportSubprocess, BinaryPath: self}, ForAgentOptions{BypassPermissions: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer c.Close()
+	if !c.(*SubprocessClient).BypassAtLaunch() {
+		t.Fatal("subprocess bypass was dropped")
+	}
+}

--- a/tui/internal/ui/app.go
+++ b/tui/internal/ui/app.go
@@ -60,6 +60,9 @@ func RunFlagship(dev bool, mockAgent string, ctrl *control.Options, bypassPermis
 		return fmt.Errorf("the catalog has no %q entry, so there is nothing to launch. "+
 			"Report this with GAIA diagnostics", catalog.FlagshipID)
 	}
+	if err := client.CheckBypassSupported(*agent, bypassPermissions); err != nil {
+		return err
+	}
 	m := root.NewFlagshipModel(*agent, dev).
 		WithBypassPermissions(bypassPermissions).
 		WithClaude(useClaude, claudeModel).
@@ -221,6 +224,10 @@ func RunAgent(agentID, query, model string, dev bool, timeout time.Duration, ctr
 	agent := cat.Get(agentID)
 	if agent == nil {
 		return 1, fmt.Errorf("no agent %q in the catalog. %s", agentID, knownIDs(cat))
+	}
+
+	if err := client.CheckBypassSupported(*agent, bypassPermissions); err != nil {
+		return 1, err
 	}
 
 	// A one-shot is always bounded — that is the whole point — so an unbounded

--- a/tui/test/bypass_transport_test.go
+++ b/tui/test/bypass_transport_test.go
@@ -37,6 +37,9 @@ func TestInstalledFlagshipRejectsBypassBeforeReadiness(t *testing.T) {
 		if strings.Contains(string(output), altScreenEnter) {
 			t.Fatal("invalid flag opened the UI")
 		}
+		if len(args) > 1 && args[0] == "chat" && strings.Contains(string(output), "--agent <id>") {
+			t.Fatalf("bypass refusal recommended an unsupported agent launch: %s", output)
+		}
 		if _, err := os.Stat(filepath.Join(home, ".gaia", "daemon", "instance.json")); !os.IsNotExist(err) {
 			t.Fatalf("invalid option launched a daemon: %v", err)
 		}

--- a/tui/test/bypass_transport_test.go
+++ b/tui/test/bypass_transport_test.go
@@ -1,0 +1,43 @@
+package test
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestInstalledFlagshipRejectsBypassBeforeReadiness(t *testing.T) {
+	bin, _ := buildBinaries(t)
+	home := t.TempDir()
+	installed := filepath.Join(home, ".gaia", "agents", "gaia")
+	if err := os.MkdirAll(installed, 0700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(installed, ".installed"), []byte(`{"id":"gaia","version":"0.1.1","artifact_kind":"binary"}`), 0600); err != nil {
+		t.Fatal(err)
+	}
+	for _, args := range [][]string{
+		{"--bypass-permissions"},
+		{"run", "gaia", "--bypass-permissions", "--query", "hello"},
+		{"run", "email", "--bypass-permissions", "--query", "hello"},
+	} {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		cmd := exec.CommandContext(ctx, bin, args...)
+		cmd.Env = append(os.Environ(), "HOME="+home, "USERPROFILE="+home)
+		output, err := cmd.CombinedOutput()
+		cancel()
+		if err == nil || !strings.Contains(string(output), "--bypass-permissions is not supported") {
+			t.Fatalf("%v did not reject bypass: %v %s", args, err, output)
+		}
+		if strings.Contains(string(output), altScreenEnter) {
+			t.Fatal("invalid flag opened the UI")
+		}
+		if _, err := os.Stat(filepath.Join(home, ".gaia", "daemon", "instance.json")); !os.IsNotExist(err) {
+			t.Fatalf("invalid option launched a daemon: %v", err)
+		}
+	}
+}

--- a/tui/test/bypass_transport_test.go
+++ b/tui/test/bypass_transport_test.go
@@ -24,6 +24,7 @@ func TestInstalledFlagshipRejectsBypassBeforeReadiness(t *testing.T) {
 		{"--bypass-permissions"},
 		{"run", "gaia", "--bypass-permissions", "--query", "hello"},
 		{"run", "email", "--bypass-permissions", "--query", "hello"},
+		{"chat", "--subprocess", "missing-agent-binary", "--bypass-permissions", "--query", "hello"},
 	} {
 		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		cmd := exec.CommandContext(ctx, bin, args...)


### PR DESCRIPTION
## Summary

The TUI explicitly refuses permission bypass for daemon-backed agents before attempting startup.

## Why

The installed flagship silently ignored `--bypass-permissions`, so users requesting unattended operation received normal permission gates without an explanation.

## Linked issue

Closes #3638

## Changes

Validates the transport at the factory and UI entry points, with matching CLI help and TUI documentation. Subprocess agents retain their existing bypass behavior.

## Test plan

- [x] `go test ./internal/client ./internal/cli ./internal/ui` — passed.
- [x] Relevant `go vet` checks — passed.
- [x] New factory regression failed before the fix.
- [x] Real compiled CLI refusal tests for the installed flagship and explicit agent runs.

## Evidence

The compiled CLI rejects the bare installed flagship, `run gaia --query`, and `run email --query` when bypass is requested. Refusal happens before readiness checks or alternate-screen entry. Daemon launch without bypass and subprocess option forwarding remain covered. This does not add bypass to HTTP transports.

## Checklist

- [x] Linked the issue and explained the impact.
- [x] Ran focused tests, lint and CLI evidence; independently reviewed the change.
- [x] Updated help and documentation.
- [ ] Maintainer review and CI completion.

Explicit `chat --subprocess ... --bypass-permissions` also refuses instead of dropping the flag. The compiled CLI regression verifies refusal before starting an agent or entering the UI, with advice to supply supported options inside the subprocess command or remove the flag. Full CLI/integration suites and adjacent client/UI suites passed; go vet passed.
