### PR TITLE
fix(schedule): honor day constraints in recurring timers

### DIFF
--- a/src/gaia/ui/scheduler.py
+++ b/src/gaia/ui/scheduler.py
@@ -931,7 +931,11 @@ class Scheduler:
                 if task.schedule_config
                 else None
             )
-            if config and (config.time_of_day or config.start_hour is not None):
+            if config and (
+                config.time_of_day
+                or config.start_hour is not None
+                or config.days_of_week
+            ):
                 next_run = compute_next_run(config)
             else:
                 next_run = datetime.now(timezone.utc) + timedelta(
@@ -1027,7 +1031,11 @@ class Scheduler:
                     if task.schedule_config
                     else None
                 )
-                if config and (config.time_of_day or config.start_hour is not None):
+                if config and (
+                    config.time_of_day
+                    or config.start_hour is not None
+                    or config.days_of_week
+                ):
                     next_dt = compute_next_run(config)
                     sleep_secs = max(
                         0, (next_dt - datetime.now(timezone.utc)).total_seconds()

--- a/tests/unit/test_scheduler_weekdays.py
+++ b/tests/unit/test_scheduler_weekdays.py
@@ -1,0 +1,110 @@
+# Copyright(C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+"""The displayed schedule and its actual timer must honor the same days."""
+
+from datetime import datetime, timedelta, timezone
+
+import httpx
+import pytest
+from fastapi import FastAPI
+
+from gaia.ui import scheduler as scheduler_module
+from gaia.ui.database import ChatDatabase
+from gaia.ui.routers.schedules import router
+from gaia.ui.scheduler import Scheduler
+
+pytestmark = [pytest.mark.asyncio, pytest.mark.allow_network]
+
+
+@pytest.fixture
+def clock(monkeypatch):
+    class Clock(datetime):
+        instant = datetime(2026, 9, 12, 10, tzinfo=timezone.utc)
+
+        @classmethod
+        def now(cls, tz=None):
+            return cls.instant
+
+    monkeypatch.setattr(scheduler_module, "datetime", Clock)
+    return Clock
+
+
+@pytest.mark.parametrize(
+    "schedule,start,expected",
+    [
+        ("every hour on weekdays", "2026-09-11T23:30", "2026-09-14T00:30"),
+        ("every hour on weekdays", "2026-09-12T10:00", "2026-09-14T11:00"),
+        ("every hour on weekdays", "2026-09-10T10:00", "2026-09-10T11:00"),
+        ("every hour on weekends", "2026-09-14T10:00", "2026-09-19T11:00"),
+        ("every hour", "2026-09-12T10:00", "2026-09-12T11:00"),
+        ("daily at 9am", "2026-09-12T10:00", "2026-09-13T09:00"),
+    ],
+)
+async def test_timer_fires_when_the_schedule_says(
+    clock, monkeypatch, schedule, start, expected
+):
+    clock.instant = datetime.fromisoformat(start).replace(tzinfo=timezone.utc)
+    expected_time = datetime.fromisoformat(expected).replace(tzinfo=timezone.utc)
+    db = ChatDatabase(":memory:")
+    fired = []
+
+    async def executor(prompt):
+        fired.append((clock.now(), prompt))
+        scheduler._running = False
+        return "ran"
+
+    async def advance(seconds):
+        clock.instant += timedelta(seconds=seconds)
+
+    scheduler = Scheduler(db, executor=executor)
+    monkeypatch.setattr(scheduler_module.asyncio, "sleep", advance)
+    try:
+        created = await scheduler.create_task("test", schedule, "scheduled prompt")
+        assert datetime.fromisoformat(created["next_run_at"]) == expected_time
+        await scheduler.start()
+        await scheduler.tasks["test"]._timer_task
+        assert fired == [(expected_time, "scheduled prompt")]
+        assert scheduler.get_task("test")["run_count"] == 1
+        assert scheduler.get_task_results("test")[0]["result"] == "ran"
+    finally:
+        await scheduler.shutdown()
+        db.close()
+
+
+async def test_http_resume_keeps_weekday_constraint(clock):
+    db = ChatDatabase(":memory:")
+
+    async def executor(_prompt):
+        raise AssertionError("The scheduler is not started in this API test")
+
+    scheduler = Scheduler(db, executor=executor)
+    app = FastAPI()
+    app.include_router(router)
+    app.state.scheduler = scheduler
+    try:
+        async with httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=app), base_url="http://testserver"
+        ) as client:
+            created = await client.post(
+                "/api/schedules",
+                json={
+                    "name": "weekdays",
+                    "interval": "every hour on weekdays",
+                    "prompt": "test",
+                },
+            )
+            assert created.status_code == 200
+            paused = await client.put(
+                "/api/schedules/weekdays", json={"status": "paused"}
+            )
+            assert paused.status_code == 200
+            resumed = await client.put(
+                "/api/schedules/weekdays", json={"status": "active"}
+            )
+            assert resumed.status_code == 200
+            assert resumed.json()["next_run_at"] == created.json()["next_run_at"]
+            assert resumed.json()["next_run_at"] == "2026-09-14T11:00:00+00:00"
+    finally:
+        await scheduler.shutdown()
+        db.close()


### PR DESCRIPTION
## Summary

Interval schedules now honor their weekday or weekend restrictions when arming timers and resuming paused tasks.

## Why

“Every hour on weekdays” displayed a Monday next-run time on Saturday but actually fired an hour later on Saturday. Resume had the same mismatch.

## Linked issue

Closes #3646

## Changes

Includes day-of-week constraints in the existing calendar-aware timer and resume paths.

## Test plan

- [x] New weekday regressions plus existing scheduler and API suites — 85 passed.
- [x] Four new regression cases failed against the original implementation.
- [x] Scoped Black, isort, flake8, pylint and diff checks passed.

## Evidence

Tests use real in-memory persistence and the actual scheduled executor with an advancing fake clock. Friday/Saturday weekday schedules and a Monday weekend schedule fire at their displayed due times. HTTP create, pause and resume return the correct Monday 11:00 UTC value. Plain intervals, valid weekdays and fixed-time schedules remain covered.

## Checklist

- [x] Linked the issue and explained the impact.
- [x] Added runnable regressions and reviewed the two changed conditions.
- [x] Existing documented schedule semantics now match execution.
- [ ] Maintainer review and CI completion.
