### PR TITLE
fix(tools): reject stale whole-file writes

### DIFF
--- a/docs/spec/file-io-tools-mixin.mdx
+++ b/docs/spec/file-io-tools-mixin.mdx
@@ -33,8 +33,8 @@ After a file has been read, `write_file`, `write_python_file`,
 `write_markdown_file`, `update_gaia_md`, `replace_function`, and `edit_file`
 reject changes if the current file content differs from the recorded generation.
 The error includes `stale: true`, content hashes, and a bounded `current_content`
-excerpt. Review the current file before retrying; large files may require another
-read. Rejection leaves the file and backups untouched and re-anchors the ledger
+excerpt. Read the current file in full before retrying a whole-file write; the
+excerpt must never be used as its complete replacement. Rejection leaves the file and backups untouched and re-anchors the ledger
 to the returned generation. Successful writes record their new content so a later
 edit accepts the agent's own changes. New files and files without a prior read
 remain writable, subject to the existing path and write policies.

--- a/docs/spec/file-io-tools-mixin.mdx
+++ b/docs/spec/file-io-tools-mixin.mdx
@@ -27,6 +27,18 @@ FileIOToolsMixin provides comprehensive file I/O operations with intelligent fil
 - Generic file operations without validation
 - Security through path validation
 
+### Concurrent file changes
+
+After a file has been read, `write_file`, `write_python_file`,
+`write_markdown_file`, `update_gaia_md`, `replace_function`, and `edit_file`
+reject changes if the current file content differs from the recorded generation.
+The error includes `stale: true`, content hashes, and a bounded `current_content`
+excerpt. Review the current file before retrying; large files may require another
+read. Rejection leaves the file and backups untouched and re-anchors the ledger
+to the returned generation. Successful writes record their new content so a later
+edit accepts the agent's own changes. New files and files without a prior read
+remain writable, subject to the existing path and write policies.
+
 ---
 
 ## Tool Specifications

--- a/docs/spec/file-search-mixin.mdx
+++ b/docs/spec/file-search-mixin.mdx
@@ -24,6 +24,10 @@ FileSearchToolsMixin provides agent-agnostic file search and management operatio
 - Directory search with depth control
 - Generic file writing with directory creation
 
+`write_file` and `edit_file` share the [file-state guard](/spec/file-io-tools-mixin#concurrent-file-changes):
+after a prior read, external content changes return a stale error before writing
+or creating a backup. Successful writes become the baseline for later edits.
+
 **Search Strategy:**
 - Phase 0: Deep search current working directory (unlimited depth)
 - Phase 1: Search common locations (Documents, Downloads, Desktop) with depth limit

--- a/src/gaia/agents/tools/file_edit.py
+++ b/src/gaia/agents/tools/file_edit.py
@@ -285,7 +285,7 @@ def _excerpt(current_content: str, old_content: str) -> Dict[str, Any]:
         "current_content_start_line": start,
         "current_content_end_line": end,
         "current_content_total_lines": total,
-        "current_content_truncated": truncated,
+        "current_content_truncated": truncated or start > 1 or end < total,
         "current_content_anchored_on": anchored_on,
     }
 
@@ -342,9 +342,11 @@ def check_file_state(
         return None
     error = _error(
         f"{operation} rejected: {file_path} changed on disk after it was read — "
-        f"{divergence.reason}. Nothing was written. The file's current "
-        "content is included as `current_content`; reissue the edit against "
-        "that, not against what you read earlier.",
+        f"{divergence.reason}. Nothing was written. A bounded excerpt of the "
+        "current file is included as `current_content`. Read the current file "
+        "in full before retrying a whole-file write; never use this excerpt "
+        "as the complete replacement. Base any edit on the current content, "
+        "not on what you read earlier.",
         file_path,
         len(_match_offsets(current_content, old_content)) if old_content else 0,
         {

--- a/src/gaia/agents/tools/file_edit.py
+++ b/src/gaia/agents/tools/file_edit.py
@@ -321,6 +321,44 @@ def _error(
     return payload
 
 
+def check_file_state(
+    file_path: str,
+    current_content: Optional[str] = None,
+    *,
+    old_content: str = "",
+    operation: str = "Write",
+) -> Optional[Dict[str, Any]]:
+    """Reject a stale mutation after the caller has validated path access."""
+    tracker = FileStateTracker.instance()
+    if not tracker.has_record(file_path):
+        return None
+    if current_content is None:
+        if not os.path.exists(file_path):
+            return None
+        with open(file_path, "r", encoding="utf-8") as source:
+            current_content = source.read()
+    divergence = tracker.check(file_path, current_content)
+    if not divergence.diverged:
+        return None
+    error = _error(
+        f"{operation} rejected: {file_path} changed on disk after it was read — "
+        f"{divergence.reason}. Nothing was written. The file's current "
+        "content is included as `current_content`; reissue the edit against "
+        "that, not against what you read earlier.",
+        file_path,
+        len(_match_offsets(current_content, old_content)) if old_content else 0,
+        {
+            "stale": True,
+            "hash_at_read": divergence.hash_at_read,
+            "hash_now": divergence.hash_now,
+            **_excerpt(current_content, old_content),
+        },
+    )
+    # The returned content anchors a corrected retry to this generation.
+    tracker.record_read(file_path, current_content)
+    return error
+
+
 def apply_unique_replacement(
     file_path: str,
     current_content: str,
@@ -350,26 +388,10 @@ def apply_unique_replacement(
             {},
         )
 
-    divergence = FileStateTracker.instance().check(file_path, current_content)
-    if divergence.diverged:
-        error = _error(
-            f"Edit rejected: {file_path} changed on disk after it was read — "
-            f"{divergence.reason}. Nothing was written. The file's current "
-            "content is included as `current_content`; reissue the edit against "
-            "that, not against what you read earlier.",
-            file_path,
-            len(_match_offsets(current_content, old_content)),
-            {
-                "stale": True,
-                "hash_at_read": divergence.hash_at_read,
-                "hash_now": divergence.hash_now,
-                **_excerpt(current_content, old_content),
-            },
-        )
-        # Returning the content *is* a read, so re-anchor. Without this the
-        # ledger still holds the superseded hash and the corrected retry is
-        # rejected as stale too — forever.
-        FileStateTracker.instance().record_read(file_path, current_content)
+    error = check_file_state(
+        file_path, current_content, old_content=old_content, operation="Edit"
+    )
+    if error is not None:
         return None, error
 
     offsets = _match_offsets(current_content, old_content)

--- a/src/gaia/agents/tools/file_io_tools.py
+++ b/src/gaia/agents/tools/file_io_tools.py
@@ -16,6 +16,7 @@ from typing import Any, Dict, Optional
 from gaia.agents.base.tools import tool
 from gaia.agents.tools.file_edit import (
     apply_unique_replacement,
+    check_file_state,
     record_read,
     record_write,
 )
@@ -360,10 +361,12 @@ class FileIOToolsMixin:
                         )
                         return {"status": "error", "error": reason}
 
-                    # Backup existing file before overwrite
-                    backup_path = None
-                    if os.path.exists(file_path):
-                        backup_path = path_validator.create_backup(str(file_path))
+                stale_error = check_file_state(str(file_path))
+                if stale_error is not None:
+                    return stale_error
+                backup_path = None
+                if path_validator is not None and os.path.exists(file_path):
+                    backup_path = path_validator.create_backup(str(file_path))
 
                 # Create parent directories if needed
                 if create_dirs and os.path.dirname(file_path):
@@ -729,10 +732,12 @@ class FileIOToolsMixin:
                         )
                         return {"status": "error", "error": reason}
 
-                    # Backup existing file before overwrite
-                    backup_path = None
-                    if os.path.exists(file_path):
-                        backup_path = path_validator.create_backup(str(file_path))
+                stale_error = check_file_state(str(file_path))
+                if stale_error is not None:
+                    return stale_error
+                backup_path = None
+                if path_validator is not None and os.path.exists(file_path):
+                    backup_path = path_validator.create_backup(str(file_path))
 
                 # Create parent directories if needed
                 if create_dirs:
@@ -812,10 +817,12 @@ class FileIOToolsMixin:
                         )
                         return {"status": "error", "error": reason}
 
-                    # Backup existing file before overwrite
-                    backup_path = None
-                    if path.exists():
-                        backup_path = path_validator.create_backup(str(path))
+                stale_error = check_file_state(str(path))
+                if stale_error is not None:
+                    return stale_error
+                backup_path = None
+                if path_validator is not None and path.exists():
+                    backup_path = path_validator.create_backup(str(path))
 
                 # Create parent directories if requested
                 if create_dirs and not path.parent.exists():
@@ -1088,9 +1095,13 @@ class FileIOToolsMixin:
                 # Check existence BEFORE writing for accurate created/updated msg
                 is_new_file = not os.path.exists(gaia_path)
 
+                stale_error = check_file_state(gaia_path)
+                if stale_error is not None:
+                    return stale_error
                 # Write the file
                 with open(gaia_path, "w", encoding="utf-8") as f:
                     f.write(content)
+                record_write(gaia_path, content)
 
                 return {
                     "status": "success",
@@ -1168,6 +1179,9 @@ class FileIOToolsMixin:
                 with open(file_path, "r", encoding="utf-8") as f:
                     content = f.read()
 
+                stale_error = check_file_state(str(file_path), content)
+                if stale_error is not None:
+                    return stale_error
                 # Parse the file to find the function
                 try:
                     tree = ast.parse(content)
@@ -1232,6 +1246,7 @@ class FileIOToolsMixin:
                 # Write the modified content
                 with open(file_path, "w", encoding="utf-8") as f:
                     f.write(modified_content)
+                record_write(str(file_path), modified_content)
 
                 # Generate diff
                 diff = "\n".join(

--- a/src/gaia/agents/tools/file_tools.py
+++ b/src/gaia/agents/tools/file_tools.py
@@ -21,6 +21,7 @@ from typing import Any, Dict, List
 
 from gaia.agents.tools.file_edit import (
     apply_unique_replacement,
+    check_file_state,
     record_read,
     record_write,
 )
@@ -938,7 +939,10 @@ class FileSearchToolsMixin:
                             "operation": "write_file",
                         }
 
-                    # Create backup of existing file before overwriting
+                stale_error = check_file_state(str(resolved_path))
+                if stale_error is not None:
+                    return stale_error
+                if path_validator is not None:
                     if resolved_path.exists():
                         backup_path = path_validator.create_backup(str(resolved_path))
                 else:

--- a/tests/unit/agents/test_file_write_state.py
+++ b/tests/unit/agents/test_file_write_state.py
@@ -118,3 +118,19 @@ def test_missing_file_retains_create_or_replace_behavior(writer):
         tracker = FileStateTracker.instance()
         assert tracker.has_record(str(path))
         assert not tracker.check(str(path), path.read_text(encoding="utf-8")).diverged
+
+
+def test_long_stale_file_identifies_excerpt_and_requires_full_read(writer):
+    path, call, host, _ = writer
+    path.write_text(ORIGINAL, encoding="utf-8")
+    record_read(str(path), ORIGINAL)
+    current = EXTERNAL + "".join(f"# external line {number}\n" for number in range(60))
+    path.write_text(current, encoding="utf-8")
+    result = call()
+    assert result["stale"] is True
+    assert result["current_content_truncated"] is True
+    assert result["current_content_end_line"] < result["current_content_total_lines"]
+    assert "Read the current file in full" in result["error"]
+    assert "never use this excerpt as the complete replacement" in result["error"]
+    assert path.read_text(encoding="utf-8") == current
+    host.path_validator.create_backup.assert_not_called()

--- a/tests/unit/agents/test_file_write_state.py
+++ b/tests/unit/agents/test_file_write_state.py
@@ -1,0 +1,120 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""Every file mutation honors the read ledger and records its own changes."""
+
+from unittest.mock import Mock, patch
+
+import pytest
+
+from gaia.agents.base.tools import _TOOL_REGISTRY
+from gaia.agents.tools.file_edit import FileStateTracker, record_read
+from gaia.agents.tools.file_io_tools import FileIOToolsMixin
+from gaia.agents.tools.file_tools import FileSearchToolsMixin
+
+ORIGINAL = "def target():\n    return 1\n"
+EXTERNAL = "def target():\n    return 2\n"
+REPLACEMENT = "def target():\n    return 3\n"
+
+
+@pytest.fixture(
+    params=[
+        "write_file",
+        "write_python_file",
+        "write_markdown_file",
+        "update_gaia_md",
+        "replace_function",
+        "search_write_file",
+    ]
+)
+def writer(request, tmp_path):
+    tracker = FileStateTracker.instance()
+    tracker.clear()
+    saved = dict(_TOOL_REGISTRY)
+    kind = request.param
+    host = FileSearchToolsMixin() if kind == "search_write_file" else FileIOToolsMixin()
+    # Permission policy is orthogonal to the ledger; assert it still precedes reads.
+    host.path_validator = Mock()
+    host.path_validator.validate_write.return_value = (True, "")
+    host.path_validator.is_write_blocked.return_value = (False, "")
+    host.path_validator.is_path_allowed.return_value = True
+    host.path_validator.create_backup.return_value = None
+    if kind == "search_write_file":
+        host.register_file_search_tools()
+    else:
+        host.register_file_io_tools()
+    tool_name = "write_file" if kind == "search_write_file" else kind
+    function = _TOOL_REGISTRY[tool_name]["function"]
+    path = tmp_path / ("GAIA.md" if kind == "update_gaia_md" else "sample.py")
+
+    def call():
+        if kind == "update_gaia_md":
+            return function(str(tmp_path), project_name="Ledger test")
+        if kind == "replace_function":
+            return function(str(path), "target", REPLACEMENT, backup=False)
+        return function(str(path), REPLACEMENT)
+
+    yield path, call, host, kind
+    tracker.clear()
+    _TOOL_REGISTRY.clear()
+    _TOOL_REGISTRY.update(saved)
+
+
+def test_stale_write_preserves_external_content_and_reanchors_retry(writer):
+    path, call, host, _ = writer
+    path.write_text(ORIGINAL, encoding="utf-8")
+    record_read(str(path), ORIGINAL)
+    path.write_text(EXTERNAL, encoding="utf-8")
+    result = call()
+    assert result["status"] == "error"
+    assert result["stale"] is True
+    assert "current_content" in result
+    assert path.read_text(encoding="utf-8") == EXTERNAL
+    host.path_validator.create_backup.assert_not_called()
+    assert call()["status"] == "success"
+
+
+def test_successful_write_records_new_contents_for_later_edits(writer):
+    path, call, _, _ = writer
+    path.write_text(ORIGINAL, encoding="utf-8")
+    record_read(str(path), ORIGINAL)
+    assert call()["status"] == "success"
+    current = path.read_text(encoding="utf-8")
+    assert not FileStateTracker.instance().check(str(path), current).diverged
+    edit = _TOOL_REGISTRY["edit_file"]["function"]
+    assert edit(str(path), current, current + "\n")["status"] == "success"
+
+
+def test_unread_existing_file_still_writes_and_records_state(writer):
+    path, call, _, _ = writer
+    path.write_text(ORIGINAL, encoding="utf-8")
+    assert call()["status"] == "success"
+    tracker = FileStateTracker.instance()
+    assert tracker.has_record(str(path))
+    assert not tracker.check(str(path), path.read_text(encoding="utf-8")).diverged
+
+
+def test_denied_write_does_not_read_current_contents(writer):
+    path, call, host, kind = writer
+    path.write_text(EXTERNAL, encoding="utf-8")
+    record_read(str(path), ORIGINAL)
+    host.path_validator.validate_write.return_value = (False, "denied")
+    host.path_validator.is_path_allowed.return_value = False
+    module = "file_tools" if kind == "search_write_file" else "file_io_tools"
+    with patch(f"gaia.agents.tools.{module}.check_file_state") as check:
+        assert call()["status"] == "error"
+        check.assert_not_called()
+    assert path.read_text(encoding="utf-8") == EXTERNAL
+
+
+def test_missing_file_retains_create_or_replace_behavior(writer):
+    path, call, _, kind = writer
+    result = call()
+    if kind == "replace_function":
+        assert result["status"] == "error"
+        assert "File not found" in result["error"]
+        assert not path.exists()
+    else:
+        assert result["status"] == "success"
+        tracker = FileStateTracker.instance()
+        assert tracker.has_record(str(path))
+        assert not tracker.check(str(path), path.read_text(encoding="utf-8")).diverged


### PR DESCRIPTION
Whole-file writes could overwrite changes made after an agent read a file. The existing stale-edit guard now covers every shared file mutation path, returning current content before any backup or write. Closes #3568.

## Test plan

- [x] 444 tests passed across file write-state, edit semantics, write guardrails and filesystem mixins; three existing Unix-only skips on Windows. Scoped Black, isort, pylint and whitespace checks passed.
- [x] Changes read back for scope and correctness.
- [ ] Maintainer review and CI completion.

<details>
<summary>🔍 Evidence and limits</summary>

Real temporary files exercise external edits, rejected writes without side effects, corrected retries and ordinary creation. This reuses the existing process-local tracker; it does not claim cross-process atomic check-and-write.
</details>

Follow-up: stale-write errors explicitly identify bounded excerpts and require a full read before rewriting. Six new long-file cases pass; the relevant rerun reported 298 passed and 3 existing platform skips.
