### PR TITLE
fix(chat): retain admission slots for detached runs

### DIFF
--- a/src/gaia/ui/routers/chat.py
+++ b/src/gaia/ui/routers/chat.py
@@ -91,12 +91,8 @@ async def send_message(
     # asyncio.Lock held by another coroutine is unsafe because the lock
     # has no ownership tracking.
     #
-    # The lock guards the synchronous request window; ``run_manager`` guards
-    # the *background tail* — a streaming run keeps going (and persisting)
-    # after the client disconnects and the HTTP lock is released (#1580), so
-    # a new turn for the same session must also be rejected while that
-    # background run is still active, or it would corrupt the cached agent's
-    # conversation state.
+    # The session lock and run registry cover the entire producer lifetime,
+    # including detached runs, to protect the cached agent's conversation state.
     if session_lock.locked() or run_manager.is_running(sid):
         raise HTTPException(
             status_code=409,
@@ -118,6 +114,9 @@ async def send_message(
             detail="The server is busy processing other chat requests. "
             "Please try again in a few moments.",
         )
+    except asyncio.CancelledError:
+        session_lock.release()
+        raise
 
     # Both session_lock and chat_semaphore are now held by this coroutine.
     # Track whether ownership was transferred to the streaming generator.

--- a/src/gaia/ui/routers/chat.py
+++ b/src/gaia/ui/routers/chat.py
@@ -129,27 +129,34 @@ async def send_message(
 
     try:
         if request.stream:
-            # Use BackgroundTask to ensure locks are released even if the client
-            # disconnects mid-stream (async generator finally block is unreliable
-            # when FastAPI/Starlette drops the connection before first yield).
+            stream_resources_released = False
+
+            def _release_stream_locks(_task=None):
+                nonlocal stream_resources_released
+                if stream_resources_released:
+                    return
+                stream_resources_released = True
+                session_lock.release()
+                chat_semaphore.release()
+
             async def _release_stream_resources():
-                try:
-                    session_lock.release()
-                except RuntimeError:
-                    pass
-                try:
-                    chat_semaphore.release()
-                except ValueError:
-                    pass
+                # A disconnected subscriber must not admit a second producer.
+                run = run_manager.get(sid)
+                if run is not None and run.task is not None and not run.done.is_set():
+                    run.task.add_done_callback(_release_stream_locks)
+                else:
+                    # Includes disconnect/failure before the producer started.
+                    _release_stream_locks()
 
             async def _stream():
-                db.add_message(request.session_id, "user", request.message)
-                # The run's detached lifecycle owns producer + persistence and
-                # fires the AgentLoop notify on real completion; this subscriber
-                # just relays buffered + live events to the browser. Detaching
-                # (client disconnect) no longer cancels the run (#1580).
-                async for chunk in srv._stream_chat_response(db, session, request):
-                    yield chunk
+                try:
+                    db.add_message(request.session_id, "user", request.message)
+                    # The detached lifecycle owns producer + persistence;
+                    # this subscriber only relays buffered and live events.
+                    async for chunk in srv._stream_chat_response(db, session, request):
+                        yield chunk
+                finally:
+                    await _release_stream_resources()
 
             sem_released = True
             return StreamingResponse(

--- a/tests/unit/chat/ui/test_detached_run_gate.py
+++ b/tests/unit/chat/ui/test_detached_run_gate.py
@@ -126,3 +126,33 @@ async def test_stream_failure_before_run_start_releases_slot(runtime):
     # from reaching the response's BackgroundTask.
     assert not http_request.app.state.chat_semaphore.locked()
     assert not http_request.app.state.session_locks[sid].locked()
+
+
+async def test_cancelled_queued_request_releases_only_its_session_lock(runtime):
+    db, _manager, http_request = runtime
+    sid = db.create_session()["id"]
+    gate = http_request.app.state.chat_semaphore
+    await gate.acquire()
+    queued = asyncio.create_task(
+        chat.send_message(
+            ChatRequest(session_id=sid, message="queued", stream=True), http_request, db
+        )
+    )
+    try:
+        await asyncio.sleep(0.01)
+        assert http_request.app.state.session_locks[sid].locked()
+        queued.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await queued
+        assert not http_request.app.state.session_locks[sid].locked()
+        assert gate.locked()
+    finally:
+        queued.cancel()
+        await asyncio.gather(queued, return_exceptions=True)
+        gate.release()
+
+    retry = await chat.send_message(
+        ChatRequest(session_id=sid, message="retry", stream=True), http_request, db
+    )
+    await retry.background()
+    assert not gate.locked()

--- a/tests/unit/chat/ui/test_detached_run_gate.py
+++ b/tests/unit/chat/ui/test_detached_run_gate.py
@@ -1,0 +1,128 @@
+# Copyright(C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+"""Admission slots belong to producers, not their SSE subscribers."""
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+from fastapi import HTTPException
+
+from gaia.ui import _chat_helpers as helpers
+from gaia.ui.database import ChatDatabase
+from gaia.ui.models import ChatRequest
+from gaia.ui.routers import chat
+from gaia.ui.run_manager import RunManager
+
+pytestmark = [pytest.mark.asyncio, pytest.mark.allow_network]
+
+
+@pytest.fixture
+def runtime():
+    db = ChatDatabase(":memory:")
+    manager = RunManager()
+    state = SimpleNamespace(
+        session_locks={}, chat_semaphore=asyncio.BoundedSemaphore(1)
+    )
+    request = SimpleNamespace(app=SimpleNamespace(state=state))
+    server = SimpleNamespace(_stream_chat_response=helpers._stream_chat_response)
+    with (
+        patch.object(chat, "run_manager", manager),
+        patch("gaia.ui.run_manager.run_manager", manager),
+        patch.object(chat, "_server_mod", return_value=server),
+    ):
+        yield db, manager, request
+    db.close()
+
+
+@pytest.mark.parametrize("outcome", ["complete", "error", "cancel"])
+async def test_disconnect_keeps_slot_until_producer_finishes(runtime, outcome):
+    db, manager, http_request = runtime
+    a = db.create_session()["id"]
+    b = db.create_session()["id"]
+    finish = asyncio.Event()
+
+    async def lifecycle(run, _db, _session, _request):
+        run.emit('data: {"type":"status","content":"started"}\n\n')
+        await finish.wait()
+        if outcome == "error":
+            raise RuntimeError("controlled producer failure")
+
+    with patch.object(helpers, "_run_chat_lifecycle", lifecycle):
+        response = await chat.send_message(
+            ChatRequest(session_id=a, message="A", stream=True), http_request, db
+        )
+        disconnected = asyncio.Event()
+
+        async def receive():
+            await disconnected.wait()
+            return {"type": "http.disconnect"}
+
+        async def send(message):
+            if message["type"] == "http.response.body" and message.get("body"):
+                disconnected.set()
+
+        await response({"type": "http", "asgi": {"spec_version": "2.0"}}, receive, send)
+        run = manager.get(a)
+        second = None
+        try:
+            assert manager.is_running(a)
+            assert http_request.app.state.chat_semaphore.locked()
+
+            with pytest.raises(HTTPException) as conflict:
+                await chat.send_message(
+                    ChatRequest(session_id=a, message="duplicate", stream=True),
+                    http_request,
+                    db,
+                )
+            assert conflict.value.status_code == 409
+
+            attached = helpers._attach_chat_stream(a)
+            assert "started" in await anext(attached)
+            await attached.aclose()
+
+            second = asyncio.create_task(
+                chat.send_message(
+                    ChatRequest(session_id=b, message="B", stream=True),
+                    http_request,
+                    db,
+                )
+            )
+            await asyncio.sleep(0.01)
+            assert not second.done()
+            if outcome == "cancel":
+                run.task.cancel()
+            else:
+                finish.set()
+            await asyncio.gather(run.task, return_exceptions=True)
+            next_response = await asyncio.wait_for(second, timeout=1)
+            # No subscriber consumed B yet, so it has no producer to own its slot.
+            await next_response.background()
+            await response.background()
+            assert not http_request.app.state.chat_semaphore.locked()
+            assert not http_request.app.state.session_locks[a].locked()
+            assert not http_request.app.state.session_locks[b].locked()
+        finally:
+            finish.set()
+            run.task.cancel()
+            await asyncio.gather(run.task, return_exceptions=True)
+            if second is not None and not second.done():
+                second.cancel()
+                await asyncio.gather(second, return_exceptions=True)
+
+
+async def test_stream_failure_before_run_start_releases_slot(runtime):
+    db, _manager, http_request = runtime
+    sid = db.create_session()["id"]
+    response = await chat.send_message(
+        ChatRequest(session_id=sid, message="A", stream=True), http_request, db
+    )
+    with patch.object(db, "add_message", side_effect=RuntimeError("write failed")):
+        with pytest.raises(RuntimeError, match="write failed"):
+            await anext(response.body_iterator)
+    # Generator cleanup must work even when an exception prevents Starlette
+    # from reaching the response's BackgroundTask.
+    assert not http_request.app.state.chat_semaphore.locked()
+    assert not http_request.app.state.session_locks[sid].locked()


### PR DESCRIPTION
Disconnecting an SSE client released the inference slot while its agent kept running, allowing excess concurrent producers. Admission now lasts until the producer finishes; cancellation while queued also releases the waiting session lock. Closes #3640.

## Test plan

- [x] 27 tests passed: test_detached_run_gate.py, test_run_manager.py, test_chat_concurrency.py and test_chat_active_attach.py. Three initial disconnect cases failed against baseline. Scoped Black, isort, flake8, pylint and whitespace checks passed.
- [x] Changes read back for scope and correctness.
- [ ] Maintainer review and CI completion.

<details>
<summary>🔍 Evidence and limits</summary>

The actual StreamingResponse receives an ASGI disconnect while a real RunManager producer continues. A second session waits, duplicate turns return 409, reconnect replays, and completion/error/cancellation release exactly once. Deterministic producer control replaces inference; rendered screenshot pending the hardware lane.
</details>
