### PR TITLE
fix(cpp): preserve serialized session content parts

### DIFF
--- a/cpp/include/gaia/session.h
+++ b/cpp/include/gaia/session.h
@@ -52,7 +52,7 @@ public:
 
     /// Load conversation history from a session file.
     /// @param id Session identifier.
-    /// @return The persisted conversation messages.
+    /// @return The persisted conversation messages, preserving ordered text/image parts.
     /// @throws std::runtime_error if the session file doesn't exist or is malformed.
     /// @throws std::invalid_argument if the session ID contains invalid characters.
     std::vector<Message> load(const std::string& id) const;

--- a/cpp/src/session.cpp
+++ b/cpp/src/session.cpp
@@ -124,21 +124,40 @@ Message SessionStore::messageFromJson(const json& j) {
     }
     m.role = roleFromString(j["role"].get<std::string>());
 
-    // Content — accept string only (parts/array content not round-tripped)
+    // Preserve the wire representation, including ordered vision content parts.
     if (j.contains("content")) {
         if (j["content"].is_string()) {
             m.content = j["content"].get<std::string>();
         } else if (j["content"].is_array()) {
-            // Flatten array content to text-only for simplicity
-            std::string combined;
+            m.parts.emplace();
+            m.parts->reserve(j["content"].size());
             for (const auto& part : j["content"]) {
-                if (part.is_object() && part.value("type", "") == "text" &&
-                    part.contains("text") && part["text"].is_string()) {
-                    if (!combined.empty()) combined += "\n";
-                    combined += part["text"].get<std::string>();
+                if (!part.is_object() || !part.contains("type") ||
+                    !part["type"].is_string()) {
+                    throw std::runtime_error("Message content part missing 'type' string field");
+                }
+                const auto type = part["type"].get<std::string>();
+                if (type == "text") {
+                    if (!part.contains("text") || !part["text"].is_string()) {
+                        throw std::runtime_error("Text content part missing 'text' string field");
+                    }
+                    const auto text = part["text"].get<std::string>();
+                    m.parts->push_back(ContentPart::makeText(text));
+                    // Keep the existing text view for callers that read content.
+                    if (!m.content.empty()) m.content += "\n";
+                    m.content += text;
+                } else if (type == "image_url") {
+                    if (!part.contains("image_url") || !part["image_url"].is_object() ||
+                        !part["image_url"].contains("url") ||
+                        !part["image_url"]["url"].is_string()) {
+                        throw std::runtime_error("Image content part missing 'image_url.url' string field");
+                    }
+                    m.parts->push_back(ContentPart::makeImageUrl(
+                        part["image_url"]["url"].get<std::string>()));
+                } else {
+                    throw std::runtime_error("Unsupported message content part type: " + type);
                 }
             }
-            m.content = combined;
         }
     }
 

--- a/cpp/tests/test_session.cpp
+++ b/cpp/tests/test_session.cpp
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 #include <gtest/gtest.h>
+#include <gaia/agent.h>
 #include <gaia/session.h>
 #include <gaia/types.h>
 
@@ -10,6 +11,8 @@
 #include <string>
 
 #include <nlohmann/json.hpp>
+
+#include "support/mock_llm_server.h"
 
 using json = nlohmann::json;
 
@@ -321,4 +324,107 @@ TEST_F(SessionStoreTest, EmptyHistory) {
 
     auto loaded = store->load("empty-session");
     EXPECT_TRUE(loaded.empty());
+}
+
+TEST_F(SessionStoreTest, MultimodalHistorySurvivesRepeatedSaveLoad) {
+    const std::vector<std::vector<ContentPart>> examples = {
+        {ContentPart::makeText("text only")},
+        {ContentPart::makeImageUrl("data:image/png;base64,aGVsbG8=")},
+        {ContentPart::makeText("first"),
+         ContentPart::makeImageUrl("https://example.test/image.png"),
+         ContentPart::makeText("second"),
+         ContentPart::makeImageUrl("data:image/jpeg;base64,d29ybGQ=")},
+        {}
+    };
+    for (const auto& parts : examples) {
+        Message original;
+        original.role = MessageRole::USER;
+        original.parts = parts;
+        store->save("vision", {original});
+        for (int cycle = 0; cycle < 2; ++cycle) {
+            auto loaded = store->load("vision");
+            ASSERT_EQ(loaded.size(), 1u);
+            ASSERT_TRUE(loaded[0].parts.has_value());
+            EXPECT_EQ(loaded[0].toJson(), original.toJson());
+            store->save("vision", loaded);
+        }
+    }
+}
+
+TEST_F(SessionStoreTest, LegacyTextAndNativeToolHistoryRemainCompatible) {
+    const json messages = json::array({
+        {{"role", "user"}, {"content", "hello"}},
+        {{"role", "assistant"}, {"content", nullptr}, {"tool_calls", json::array({
+            {{"id", "call_1"}, {"type", "function"},
+             {"function", {{"name", "read_file"}, {"arguments", "{}"}}}}
+        })}},
+        {{"role", "tool"}, {"content", "contents"},
+         {"name", "read_file"}, {"tool_call_id", "call_1"}}
+    });
+    fs::create_directories(storeDir);
+    {
+        // Old session envelopes need no version to remain readable.
+        std::ofstream file(storeDir / "legacy.json");
+        file << json{{"messages", messages}}.dump();
+    }
+    auto loaded = store->load("legacy");
+    ASSERT_EQ(loaded.size(), messages.size());
+    for (size_t i = 0; i < loaded.size(); ++i) {
+        EXPECT_FALSE(loaded[i].parts.has_value());
+        EXPECT_EQ(loaded[i].toJson(), messages[i]);
+    }
+}
+
+TEST_F(SessionStoreTest, ResumedVisionHistoryReachesCompletionRequest) {
+    Message original;
+    original.role = MessageRole::USER;
+    original.parts = std::vector<ContentPart>{
+        ContentPart::makeText("first"),
+        ContentPart::makeImageUrl("data:image/png;base64,aGVsbG8="),
+        ContentPart::makeText("second")
+    };
+    store->save("resume-vision", {original});
+    auto loaded = store->load("resume-vision");
+    ASSERT_EQ(loaded.size(), 1u);
+    EXPECT_EQ(loaded[0].content, "first\nsecond");
+
+    bench::MockLlmServer server;
+    server.pushResponse(R"({"choices":[{"message":{"content":"{\"thought\":\"t\",\"goal\":\"g\",\"answer\":\"done\"}"}}]})");
+    AgentConfig config;
+    config.baseUrl = server.baseUrl();
+    config.modelId = "";
+    config.silentMode = true;
+    class Bare : public Agent { public: using Agent::Agent; };
+    Bare agent(config);
+    agent.setHistory(std::move(loaded));
+    EXPECT_EQ(agent.processQuery("What was in that image?")["result"], "done");
+
+    ASSERT_FALSE(server.receivedBodies().empty());
+    const auto request = json::parse(server.receivedBodies().back());
+    bool found = false;
+    for (const auto& message : request["messages"]) {
+        if (message == original.toJson()) found = true;
+    }
+    EXPECT_TRUE(found) << request.dump();
+}
+
+TEST_F(SessionStoreTest, RejectMalformedContentParts) {
+    const std::vector<json> invalid = {
+        nullptr, "text", json::object(), {{"type", 1}},
+        {{"type", "text"}}, {{"type", "text"}, {"text", 7}},
+        {{"type", "image_url"}}, {{"type", "image_url"}, {"image_url", "url"}},
+        {{"type", "image_url"}, {"image_url", {{"url", 7}}}},
+        {{"type", "audio"}, {"audio", "unsupported"}}
+    };
+    fs::create_directories(storeDir);
+    for (const auto& part : invalid) {
+        const json session = {{"messages", json::array({{
+            {"role", "user"}, {"content", json::array({part})}
+        }})}};
+        {
+            std::ofstream file(storeDir / "malformed.json");
+            file << session.dump();
+        }
+        EXPECT_THROW(store->load("malformed"), std::runtime_error) << part.dump();
+    }
 }


### PR DESCRIPTION
The C++ `SessionStore` saved image-bearing messages but discarded their images on load, so anything that handed it multimodal history got text back. Its save/load round trip now preserves ordered text and image parts and rejects malformed ones, while legacy text and tool histories stay readable.

**This is the loader half of #3642, not the whole issue.** The agent strips image parts from its own history at the end of every turn, so a session saved straight from `agent.history()` still has no images in it to reload. Retaining them across turns means carrying base64 into every subsequent request, which is the trade the stripping contract was written to avoid — worth deciding on its own rather than inside this fix. #3642 stays open for that.

## Test plan

- [x] 104 native session, vision, message and REPL tests pass in the Visual Studio build; the two new cases fail on baseline.
- [x] Real disk save/load cycles preserve image-only and mixed/multiple-image messages, and a resumed Agent sends the preserved history to a real localhost HTTP server.
- [ ] Maintainer review and CI completion.
