### PR TITLE
ci(gaia): cover shared flagship dependencies

### DIFF
--- a/.github/workflows/test_gaia_agent.yml
+++ b/.github/workflows/test_gaia_agent.yml
@@ -16,11 +16,13 @@ on:
     paths:
       - 'hub/agents/gaia/python/**'
       - 'hub/agents/chat/python/**'
-      - 'src/gaia/agents/base/**'
-      - 'src/gaia/agents/tools/**'
-      - 'src/gaia/skills/**'
-      - 'src/gaia/code_index/**'
+      # The flagship composes providers, RAG, connectors and the UI's stdio
+      # adapters; restricting this to agent modules misses runtime regressions.
+      - 'src/gaia/**'
+      - 'hub/skills/**'
+      - 'tests/**'
       - 'setup.py'
+      - 'pyproject.toml'
       - '.github/workflows/test_gaia_agent.yml'
   pull_request:
     branches: [ main ]
@@ -28,11 +30,11 @@ on:
     paths:
       - 'hub/agents/gaia/python/**'
       - 'hub/agents/chat/python/**'
-      - 'src/gaia/agents/base/**'
-      - 'src/gaia/agents/tools/**'
-      - 'src/gaia/skills/**'
-      - 'src/gaia/code_index/**'
+      - 'src/gaia/**'
+      - 'hub/skills/**'
+      - 'tests/**'
       - 'setup.py'
+      - 'pyproject.toml'
       - '.github/workflows/test_gaia_agent.yml'
   merge_group:
   workflow_dispatch:
@@ -95,6 +97,7 @@ jobs:
           # the starter-pack honesty guards, and the binary policies — run
           # their framework-side suites in the same environment.
           python -m pytest \
+            tests/unit/test_flagship_ci.py \
             tests/unit/test_skill_loader.py \
             tests/unit/test_agent_lazy_skill_prompt.py \
             tests/unit/test_starter_skills.py \

--- a/tests/unit/test_flagship_ci.py
+++ b/tests/unit/test_flagship_ci.py
@@ -2,13 +2,24 @@
 # SPDX-License-Identifier: MIT
 """Keep the flagship regression lane active for its shared dependencies."""
 
-from fnmatch import fnmatchcase
+import re
 from pathlib import Path
 
 import pytest
 import yaml
 
 ROOT = Path(__file__).resolve().parents[2]
+
+
+def matches_path(path, pattern):
+    """Match the literal, * and ** filters used by this workflow."""
+    assert not any(char in pattern for char in "?![]+"), pattern
+    tokens = re.split(r"(\*\*|\*)", pattern)
+    expression = "".join(
+        ".*" if token == "**" else "[^/]*" if token == "*" else re.escape(token)
+        for token in tokens
+    )
+    return re.fullmatch(expression, path) is not None
 
 
 @pytest.fixture
@@ -38,13 +49,19 @@ def triggers():
 )
 def test_dependency_changes_run_flagship_tests(triggers, event, changed_path):
     assert any(
-        fnmatchcase(changed_path, pattern) for pattern in triggers[event]["paths"]
+        matches_path(changed_path, pattern) for pattern in triggers[event]["paths"]
     ), f"{event} does not run flagship tests for {changed_path}"
 
 
 @pytest.mark.parametrize("event", ["push", "pull_request"])
 def test_unrelated_docs_do_not_run_flagship_tests(triggers, event):
     assert not any(
-        fnmatchcase("docs/guides/talk.mdx", pattern)
+        matches_path("docs/guides/talk.mdx", pattern)
         for pattern in triggers[event]["paths"]
     )
+
+
+def test_single_star_cannot_hide_narrowed_dependency_coverage():
+    assert matches_path("src/gaia/agent.py", "src/gaia/*")
+    assert not matches_path("src/gaia/agents/base/agent.py", "src/gaia/*")
+    assert matches_path("src/gaia/agents/base/agent.py", "src/gaia/**")

--- a/tests/unit/test_flagship_ci.py
+++ b/tests/unit/test_flagship_ci.py
@@ -1,0 +1,50 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""Keep the flagship regression lane active for its shared dependencies."""
+
+from fnmatch import fnmatchcase
+from pathlib import Path
+
+import pytest
+import yaml
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+@pytest.fixture
+def triggers():
+    workflow = ROOT / ".github/workflows/test_gaia_agent.yml"
+    return yaml.load(workflow.read_text(encoding="utf-8"), Loader=yaml.BaseLoader)["on"]
+
+
+@pytest.mark.parametrize("event", ["push", "pull_request"])
+@pytest.mark.parametrize(
+    "changed_path",
+    [
+        "hub/agents/gaia/python/gaia_agent/stdio.py",
+        "hub/agents/chat/python/gaia_agent_chat/agent.py",
+        "src/gaia/ui/sse_translation.py",
+        "src/gaia/ui/sse_handler.py",
+        "src/gaia/llm/lemonade_client.py",
+        "src/gaia/logger.py",
+        "src/gaia/rag/sdk.py",
+        "src/gaia/connectors/catalog/google.py",
+        "hub/skills/coding/SKILL.md",
+        "tests/unit/test_flagship_ci.py",
+        "tests/unit/test_skill_loader.py",
+        "tests/conftest.py",
+        "pyproject.toml",
+    ],
+)
+def test_dependency_changes_run_flagship_tests(triggers, event, changed_path):
+    assert any(
+        fnmatchcase(changed_path, pattern) for pattern in triggers[event]["paths"]
+    ), f"{event} does not run flagship tests for {changed_path}"
+
+
+@pytest.mark.parametrize("event", ["push", "pull_request"])
+def test_unrelated_docs_do_not_run_flagship_tests(triggers, event):
+    assert not any(
+        fnmatchcase("docs/guides/talk.mdx", pattern)
+        for pattern in triggers[event]["paths"]
+    )


### PR DESCRIPTION
Changes to shared providers, chat streaming, and other flagship dependencies could bypass the flagship test lane. The lane now watches its shared runtime, skills, tests and dependency metadata, with a regression guard for these triggers. Closes #3643.

## Test plan

- [x] 28 workflow-filter tests passed; 22 failed on baseline. Scoped Black, isort, pylint and whitespace checks passed. Independent code and architecture review found no blocking issue.
- [x] Changes read back for scope and correctness.
- [ ] Maintainer review and CI completion.

<details>
<summary>🔍 Evidence and limits</summary>

Representative runtime dependency edits trigger the lane, unrelated documentation does not, and the guard runs in the lane itself. This fixes CI selection, not a claim of model-quality parity.
</details>

Follow-up: workflow matching distinguishes `*` from recursive `**`, so narrowing the path filter cannot falsely pass the guard. The expanded 29-test suite and scoped lint passed.

## CI infrastructure failure

The Windows Lemonade integration runner lost communication before executing any steps (run 34635520515, job 103382323810). GitHub provides no job log; its failure annotation identifies the disconnected self-hosted runner. Other checks completed successfully. A failed-job rerun was attempted but GitHub requires repository admin rights; a maintainer must retry [that run](https://github.com/amd/gaia/actions/runs/34635520515).
