### PR TITLE
fix(broker): wake queued requests at lease expiry

### DIFF
--- a/src/gaia/daemon/broker.py
+++ b/src/gaia/daemon/broker.py
@@ -34,6 +34,7 @@ its queue logic is deterministic under test.
 
 from __future__ import annotations
 
+import math
 import secrets
 import threading
 import time
@@ -193,22 +194,29 @@ class ModelSlotBroker:
                 if not notified_wait and on_wait is not None:
                     on_wait(self._wait_reason_locked(waiter))
                 notified_wait = True
-                if deadline is None:
-                    self._cv.wait()
-                else:
-                    remaining = deadline - self._now()
-                    if remaining <= 0:
-                        self._waiters.remove(waiter)
-                        self._cv.notify_all()
-                        raise LeaseTimeoutError(
-                            f"model-slot lease for '{model}' (holder '{holder}', "
-                            f"priority {priority.name.lower()}) was not granted "
-                            f"within {timeout}s. The slot is held by "
-                            f"'{self._active.model if self._active else '?'}'. "
-                            "Another load is taking longer than expected — check "
-                            "the Lemonade server log, then retry."
+                remaining = None if deadline is None else deadline - self._now()
+                if remaining is not None and remaining <= 0:
+                    self._waiters.remove(waiter)
+                    self._cv.notify_all()
+                    raise LeaseTimeoutError(
+                        f"model-slot lease for '{model}' (holder '{holder}', "
+                        f"priority {priority.name.lower()}) was not granted "
+                        f"within {timeout}s. The slot is held by "
+                        f"'{self._active.model if self._active else '?'}'. "
+                        "Another load is taking longer than expected — check "
+                        "the Lemonade server log, then retry."
+                    )
+                if self._active is not None:
+                    expires_in = max(
+                        0.0, self._active.granted_at + self._ttl - self._now()
+                    )
+                    if math.isfinite(expires_in):
+                        remaining = (
+                            expires_in
+                            if remaining is None
+                            else min(remaining, expires_in)
                         )
-                    self._cv.wait(remaining)
+                self._cv.wait(remaining)
 
     def release(self, lease_id: str) -> None:
         """Release the slot held by *lease_id* and wake the next waiter.
@@ -320,10 +328,10 @@ class ModelSlotBroker:
         if self._active is None:
             return
         held_for = self._now() - self._active.granted_at
-        if held_for > self._ttl:
+        if held_for >= self._ttl:
             logger.warning(
                 "broker: reclaiming lease %s (model '%s', holder '%s') held "
-                "for %.0fs > TTL %.0fs — the holder likely crashed without "
+                "for %.0fs >= TTL %.0fs — the holder likely crashed without "
                 "releasing. This is a leaked lease; investigate the holder.",
                 self._active.lease_id,
                 self._active.model,

--- a/tests/unit/test_daemon_broker.py
+++ b/tests/unit/test_daemon_broker.py
@@ -284,6 +284,66 @@ def test_default_ttl_is_generous():
     assert DEFAULT_LEASE_TTL_S >= 300.0
 
 
+@pytest.mark.parametrize("timeout", [None, 10.0])
+def test_queued_waiter_wakes_at_lease_expiry_without_a_release(timeout):
+    broker = ModelSlotBroker(lease_ttl_s=0.05)
+    held = broker.acquire("model-a", holder="crashed-holder")
+    granted = threading.Event()
+    result = []
+
+    def acquire_next():
+        result.append(broker.acquire("model-b", timeout=timeout))
+        granted.set()
+
+    waiter = threading.Thread(target=acquire_next, daemon=True)
+    waiter.start()
+    try:
+        assert granted.wait(1.0), "a queued request slept past the lease expiry"
+        assert result[0].model == "model-b"
+    finally:
+        active = broker.snapshot()["active"]
+        if active is not None:
+            broker.release(active["lease_id"])
+        waiter.join(1.0)
+    with pytest.raises(LeaseNotHeldError):
+        broker.release(held.lease_id)
+
+
+@pytest.mark.parametrize("timeout,expected_wait", [(None, 30.0), (10.0, 10.0)])
+def test_wait_uses_the_earlier_of_lease_expiry_and_request_deadline(
+    monkeypatch, timeout, expected_wait
+):
+    clock = [1000.0]
+    broker = ModelSlotBroker(lease_ttl_s=30.0, time_fn=lambda: clock[0])
+    broker.acquire("model-a")
+    waits = []
+
+    def advance_to_wakeup(duration=None):
+        waits.append(duration)
+        assert duration == expected_wait
+        clock[0] += duration
+
+    monkeypatch.setattr(broker._cv, "wait", advance_to_wakeup)
+    if timeout is None:
+        assert broker.acquire("model-b").model == "model-b"
+    else:
+        with pytest.raises(LeaseTimeoutError):
+            broker.acquire("model-b", timeout=timeout)
+    assert waits == [expected_wait]
+
+
+def test_infinite_lease_waits_for_explicit_release(monkeypatch):
+    broker = ModelSlotBroker(lease_ttl_s=float("inf"))
+    held = broker.acquire("model-a")
+
+    def release_on_wait(duration=None):
+        assert duration is None
+        broker.release(held.lease_id)
+
+    monkeypatch.setattr(broker._cv, "wait", release_on_wait)
+    assert broker.acquire("model-b").model == "model-b"
+
+
 # ---------------------------------------------------------------------------
 # helpers
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
A queued model request could wait forever after the current lease expired unless another API call woke the broker. Waiters now wake at lease expiration or their own deadline, whichever comes first. Closes #3645.

## Test plan

- [x] 30 broker tests passed, including three new baseline failures. Scoped Black, isort, pylint and whitespace checks passed. Independent code and architecture review found no blocking issue.
- [x] Changes read back for scope and correctness.
- [ ] Maintainer review and CI completion.

<details>
<summary>🔍 Evidence and limits</summary>

Tests use real waiting threads plus controlled exact-expiry/deadline cases, infinite TTL, priority and timeout controls. No inference or lease API contract change.
</details>
