### PR TITLE
fix(vscode): preserve split streaming tool calls

### DIFF
--- a/.github/workflows/test_vscode.yml
+++ b/.github/workflows/test_vscode.yml
@@ -1,0 +1,47 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+name: VS Code Extension Tests
+
+on:
+  push:
+    branches: [ main ]
+    paths:
+      - 'src/vscode/**'
+      - '.github/workflows/test_vscode.yml'
+  pull_request:
+    branches: [ main ]
+    types: [opened, synchronize, reopened, ready_for_review]
+    paths:
+      - 'src/vscode/**'
+      - '.github/workflows/test_vscode.yml'
+  merge_group:
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  test-vscode:
+    name: Build & Test VS Code extension
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false || contains(github.event.pull_request.labels.*.name, 'ready_for_ci')
+    defaults:
+      run:
+        working-directory: src/vscode/gaia
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: src/vscode/gaia/package-lock.json
+      - name: Install dependencies
+        run: npm ci
+      - name: Compile and test
+        run: npm test

--- a/src/vscode/gaia/.vscodeignore
+++ b/src/vscode/gaia/.vscodeignore
@@ -1,6 +1,7 @@
 .vscode/**
 .vscode-test/**
 src/**
+test/**
 .gitignore
 tsconfig.json
 node_modules/**

--- a/src/vscode/gaia/package.json
+++ b/src/vscode/gaia/package.json
@@ -32,7 +32,7 @@
     "compile": "tsc -p ./",
     "watch": "tsc -watch -p ./",
     "pretest": "npm run compile",
-    "test": "node ./out/test/runTest.js",
+    "test": "node --test test/text-tool-stream.test.cjs",
     "package": "vsce package",
     "publish": "vsce publish"
   },

--- a/src/vscode/gaia/src/provider.ts
+++ b/src/vscode/gaia/src/provider.ts
@@ -475,9 +475,15 @@ export class GaiaChatModelProvider implements LanguageModelChatProvider {
                     if (data === "[DONE]") {
                         // Do not throw on [DONE]; any incomplete/empty buffers are ignored.
                         await this.flushToolCallBuffers(progress, /*throwOnInvalid*/ false);
-                        // Flush any in-progress text-embedded tool call (silent if incomplete)
-                        await this.flushActiveTextToolCall(progress);
-                        continue;
+                        await this.finishStreamingText(progress);
+                        try {
+                            await reader.cancel();
+                        } catch (error) {
+                            // Completion already succeeded; report cleanup failure
+                            // without replacing it with a later transport error.
+                            console.error("[GAIA Model Provider] Failed to close completed stream", error);
+                        }
+                        return;
                     }
 
 					try {
@@ -487,6 +493,9 @@ export class GaiaChatModelProvider implements LanguageModelChatProvider {
                         // Silently ignore malformed SSE lines temporarily
                     }
                 }
+            }
+            if (!token.isCancellationRequested) {
+                await this.finishStreamingText(progress);
             }
         } finally {
             reader.releaseLock();
@@ -501,6 +510,21 @@ export class GaiaChatModelProvider implements LanguageModelChatProvider {
 			this._emittedTextToolCallIds.clear();
 			this._controlTokenBuffer = "";
         }
+    }
+
+    /** Flush visible suffixes on normal completion, never on cancellation/error. */
+    private async finishStreamingText(
+        progress: vscode.Progress<vscode.LanguageModelResponsePart>,
+    ): Promise<void> {
+        // Check before flushing the active call: its pending END prefix belongs
+        // to the tool protocol even if flushing clears the active-call state.
+        if (!this._textToolActive) {
+            const text = this._controlTokenBuffer + this._textToolParserBuffer;
+            this._controlTokenBuffer = "";
+            this._textToolParserBuffer = "";
+            if (text) { progress.report(new vscode.LanguageModelTextPart(text)); }
+        }
+        await this.flushActiveTextToolCall(progress);
     }
 
 	/**

--- a/src/vscode/gaia/src/provider.ts
+++ b/src/vscode/gaia/src/provider.ts
@@ -701,6 +701,12 @@ export class GaiaChatModelProvider implements LanguageModelChatProvider {
         const BEGIN = "<|tool_call_begin|>";
         const ARG_BEGIN = "<|tool_call_argument_begin|>";
         const END = "<|tool_call_end|>";
+        const partialSuffixLength = (text: string, token: string): number => {
+            for (let k = Math.min(token.length - 1, text.length); k > 0; k--) {
+                if (text.endsWith(token.slice(0, k))) { return k; }
+            }
+            return 0;
+        };
 
         let data = this._textToolParserBuffer + input;
         let emittedText = false;
@@ -712,17 +718,11 @@ export class GaiaChatModelProvider implements LanguageModelChatProvider {
                 const b = data.indexOf(BEGIN);
                 if (b === -1) {
                     // No tool-call start: emit visible portion, but keep any partial BEGIN prefix as buffer
-                    const longestPartialPrefix = ((): number => {
-                        for (let k = Math.min(BEGIN.length - 1, data.length - 1); k > 0; k--) {
-                            if (data.endsWith(BEGIN.slice(0, k))) { return k; }
-                        }
-                        return 0;
-                    })();
+                    const longestPartialPrefix = partialSuffixLength(data, BEGIN);
                     if (longestPartialPrefix > 0) {
                         const visible = data.slice(0, data.length - longestPartialPrefix);
                         if (visible) { visibleOut += this.stripControlTokensWithBuffering(visible); }
-                        this._textToolParserBuffer = data.slice(data.length - longestPartialPrefix);
-                        data = "";
+                        data = data.slice(data.length - longestPartialPrefix);
                         break;
                     } else {
                         // All visible, clean other control tokens with buffering
@@ -748,8 +748,7 @@ export class GaiaChatModelProvider implements LanguageModelChatProvider {
                 else if (e !== -1) { delimIdx = e; delimKind = "end"; }
                 else {
                     // Incomplete header; keep for next chunk (re-add BEGIN so we don't lose it)
-                    this._textToolParserBuffer = BEGIN + data;
-                    data = "";
+                    data = BEGIN + data;
                     break;
                 }
 
@@ -777,8 +776,10 @@ export class GaiaChatModelProvider implements LanguageModelChatProvider {
             // We are inside arguments, collect until END and emit as soon as JSON becomes valid
             const e2 = data.indexOf(END);
             if (e2 === -1) {
-                // No end marker yet, accumulate and check for early valid JSON
-                this._textToolActive.argBuffer += data;
+                // Keep a partial terminator out of arguments until the next chunk.
+                const partialEnd = partialSuffixLength(data, END);
+                this._textToolActive.argBuffer += data.slice(0, data.length - partialEnd);
+                data = data.slice(data.length - partialEnd);
                 // Early emit when JSON becomes valid and we haven't emitted yet
                 if (!this._textToolActive.emitted) {
                     const did = this.emitTextToolCallIfValid(progress, this._textToolActive, this._textToolActive.argBuffer);
@@ -787,7 +788,6 @@ export class GaiaChatModelProvider implements LanguageModelChatProvider {
                         emittedAny = true;
                     }
                 }
-                data = "";
                 break;
             } else {
                 this._textToolActive.argBuffer += data.slice(0, e2);

--- a/src/vscode/gaia/test/text-tool-stream.test.cjs
+++ b/src/vscode/gaia/test/text-tool-stream.test.cjs
@@ -1,0 +1,127 @@
+/*
+Copyright(C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+SPDX-License-Identifier: MIT
+*/
+
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const vm = require('node:vm');
+const { createRequire } = require('node:module');
+const { test } = require('node:test');
+
+// Load the compiled production provider and utilities. Only the VSCode output
+// objects are substituted; parsing and state transitions execute unchanged.
+class LanguageModelTextPart {
+    constructor(value) { this.value = value; }
+}
+class LanguageModelToolCallPart {
+    constructor(callId, name, input) { Object.assign(this, { callId, name, input }); }
+}
+const vscode = { LanguageModelTextPart, LanguageModelToolCallPart };
+const modules = new Map();
+function loadCompiled(filename) {
+    if (modules.has(filename)) { return modules.get(filename).exports; }
+    const module = { exports: {} };
+    modules.set(filename, module);
+    const nativeRequire = createRequire(filename);
+    const injectedRequire = (name) => {
+        if (name === 'vscode') { return vscode; }
+        if (name.startsWith('.')) { return loadCompiled(nativeRequire.resolve(name)); }
+        return nativeRequire(name);
+    };
+    const wrapper = vm.runInThisContext(
+        `(function(require, module, exports) {\n${fs.readFileSync(filename, 'utf8')}\n})`,
+        { filename },
+    );
+    wrapper(injectedRequire, module, module.exports);
+    return module.exports;
+}
+const { GaiaChatModelProvider } = loadCompiled(path.resolve(__dirname, '../out/provider.js'));
+
+const BEGIN = '<|tool_call_begin|>';
+const ARG = '<|tool_call_argument_begin|>';
+const END = '<|tool_call_end|>';
+const invocation = `${BEGIN}read_file:0${ARG}{"path":"README.md"}${END}`;
+
+function parse(chunks) {
+    const provider = new GaiaChatModelProvider({}, 'parser-regression');
+    const parts = [];
+    const progress = { report: (part) => parts.push(part) };
+    for (const chunk of chunks) { provider.processTextContent(chunk, progress); }
+    return {
+        text: parts.filter((part) => part instanceof LanguageModelTextPart)
+            .map((part) => part.value).join(''),
+        calls: parts.filter((part) => part instanceof LanguageModelToolCallPart)
+            .map(({ name, input }) => ({ name, input })),
+        pending: provider._textToolParserBuffer,
+        active: provider._textToolActive,
+    };
+}
+
+const fixtures = [
+    { name: 'single invocation', input: invocation, text: '',
+        calls: [{ name: 'read_file', input: { path: 'README.md' } }] },
+    { name: 'surrounding prose', input: `Before. ${invocation} After.`, text: 'Before.  After.',
+        calls: [{ name: 'read_file', input: { path: 'README.md' } }] },
+    { name: 'multiple invocations', input: `${invocation} then ${BEGIN}list_files:1${END} Done.`,
+        text: ' then  Done.', calls: [
+            { name: 'read_file', input: { path: 'README.md' } },
+            { name: 'list_files', input: {} },
+        ] },
+    { name: 'nested and escaped arguments',
+        input: `${BEGIN}write_file${ARG}${JSON.stringify({ path: 'a.txt', content: 'a "quote" < and é', nested: { ok: true } })}${END} Saved.`,
+        text: ' Saved.', calls: [{ name: 'write_file', input: {
+            path: 'a.txt', content: 'a "quote" < and é', nested: { ok: true },
+        } }] },
+    { name: 'ordinary angle brackets', input: 'Use <x> and 2 < 3.', text: 'Use <x> and 2 < 3.', calls: [] },
+];
+
+for (const fixture of fixtures) {
+    const expected = { text: fixture.text, calls: fixture.calls, pending: '', active: undefined };
+    test(`${fixture.name}: unsplit`, () => assert.deepEqual(parse([fixture.input]), expected));
+    test(`${fixture.name}: every two-chunk boundary`, () => {
+        for (let at = 0; at <= fixture.input.length; at++) {
+            assert.deepEqual(parse([fixture.input.slice(0, at), fixture.input.slice(at)]), expected, `split at ${at}`);
+        }
+    });
+    test(`${fixture.name}: every fixed chunk width`, () => {
+        for (let width = 1; width <= fixture.input.length; width++) {
+            const chunks = [];
+            for (let at = 0; at < fixture.input.length; at += width) {
+                chunks.push(fixture.input.slice(at, at + width));
+            }
+            assert.deepEqual(parse(chunks), expected, `chunk width ${width}`);
+        }
+    });
+}
+
+test('complete arguments emit before the terminator, exactly once', () => {
+    const provider = new GaiaChatModelProvider({}, 'parser-regression');
+    const parts = [];
+    const progress = { report: (part) => parts.push(part) };
+    provider.processTextContent(`${BEGIN}read_file${ARG}{"path":"README.md"}`, progress);
+    assert.equal(parts.filter((part) => part instanceof LanguageModelToolCallPart).length, 1);
+    for (const char of END) { provider.processTextContent(char, progress); }
+    assert.equal(parts.filter((part) => part instanceof LanguageModelToolCallPart).length, 1);
+    assert.equal(provider._textToolActive, undefined);
+});
+
+test('SSE content deltas dispatch a split invocation and subsequent answer', async (t) => {
+    t.mock.method(console, 'log', () => {});
+    const provider = new GaiaChatModelProvider({}, 'parser-regression');
+    const parts = [];
+    const progress = { report: (part) => parts.push(part) };
+    const chunks = ['Before. <|tool_', 'call_begin|>read_',
+        'file:0<|tool_call_argument_', 'begin|>{"path":"README.md"}<|tool_call_',
+        'end|> After.'];
+    for (const content of chunks) {
+        await provider.processDelta({ choices: [{ delta: { content } }] }, progress);
+    }
+    await provider.processDelta({ choices: [{ delta: {}, finish_reason: 'stop' }] }, progress);
+    assert.deepEqual(parts.filter((part) => part instanceof LanguageModelToolCallPart)
+        .map(({ name, input }) => ({ name, input })),
+    [{ name: 'read_file', input: { path: 'README.md' } }]);
+    assert.equal(parts.filter((part) => part instanceof LanguageModelTextPart)
+        .map((part) => part.value).join(''), 'Before.  After.');
+});

--- a/src/vscode/gaia/test/text-tool-stream.test.cjs
+++ b/src/vscode/gaia/test/text-tool-stream.test.cjs
@@ -125,3 +125,118 @@ test('SSE content deltas dispatch a split invocation and subsequent answer', asy
     assert.equal(parts.filter((part) => part instanceof LanguageModelTextPart)
         .map((part) => part.value).join(''), 'Before.  After.');
 });
+
+async function streamResponse(chunks, ending, {
+    token = { isCancellationRequested: false }, fail = false, keepOpen = false, cancelError = false,
+} = {}) {
+    const provider = new GaiaChatModelProvider({}, 'stream-completion-regression');
+    const parts = [];
+    const frames = chunks.map((content) => `data: ${JSON.stringify({ choices: [{ delta: { content } }] })}\n\n`);
+    if (ending === 'stop') {
+        frames.push('data: {"choices":[{"delta":{},"finish_reason":"stop"}]}\n\n');
+    }
+    if (ending === 'done') { frames.push('data: [DONE]\n\n'); }
+    let index = 0;
+    let cancelled = false;
+    const body = new ReadableStream({
+        pull(controller) {
+            if (index < frames.length) { controller.enqueue(new TextEncoder().encode(frames[index++])); }
+            else if (fail) { controller.error(new Error('stream disconnected')); }
+            else if (keepOpen) { return new Promise(() => {}); }
+            else { controller.close(); }
+        },
+        cancel() {
+            cancelled = true;
+            if (cancelError) { throw new Error('cleanup failed'); }
+        },
+    });
+    let error;
+    try {
+        await provider.processStreamingResponse(body, { report: (part) => parts.push(part) }, token);
+    } catch (caught) { error = caught; }
+    assert.equal(body.locked, false);
+    assert.equal(provider._textToolParserBuffer, '');
+    assert.equal(provider._controlTokenBuffer, '');
+    assert.equal(provider._textToolActive, undefined);
+    return {
+        text: parts.filter((part) => part instanceof LanguageModelTextPart).map((part) => part.value).join(''),
+        calls: parts.filter((part) => part instanceof LanguageModelToolCallPart),
+        error,
+        cancelled,
+    };
+}
+
+for (const ending of ['eof', 'stop', 'done']) {
+    test(`full SSE ${ending} completion preserves visible partial marker suffixes`, async (t) => {
+        t.mock.method(console, 'log', () => {});
+        for (const chunks of [['Compare a ', '<'], ['done <|tool'], ['literal <function=x'], ['<function=x', '<|tool']]) {
+            const result = await streamResponse(chunks, ending);
+            assert.equal(result.error, undefined);
+            assert.equal(result.text, chunks.join(''));
+            assert.equal(result.calls.length, 0);
+        }
+    });
+}
+
+test('full SSE completion does not expose active tool arguments or terminator prefixes', async (t) => {
+    t.mock.method(console, 'log', () => {});
+    for (const ending of ['eof', 'done']) {
+        for (const args of ['{"path":"README.md"}', '{"path":']) {
+            const result = await streamResponse([`${BEGIN}read_file${ARG}${args}<|tool_call_`], ending);
+            assert.equal(result.error, undefined);
+            assert.equal(result.text, '');
+            assert.equal(result.calls.length, args.endsWith('}') ? 1 : 0);
+        }
+    }
+});
+
+test('full SSE response emits tool call and final partial text exactly once', async (t) => {
+    t.mock.method(console, 'log', () => {});
+    const result = await streamResponse([invocation, ' Compare <'], 'done');
+    assert.equal(result.error, undefined);
+    assert.equal(result.text, ' Compare <');
+    assert.equal(result.calls.length, 1);
+});
+
+test('stream errors do not flush a pending suffix as successful completion', async (t) => {
+    t.mock.method(console, 'log', () => {});
+    const result = await streamResponse(['Compare <'], 'eof', { fail: true });
+    assert.match(result.error.message, /stream disconnected/);
+    assert.equal(result.text, 'Compare ');
+});
+
+test('[DONE] completes without waiting for a later transport error', async (t) => {
+    t.mock.method(console, 'log', () => {});
+    t.mock.method(console, 'error', () => {});
+    const result = await streamResponse(['Compare <'], 'done', { fail: true });
+    assert.equal(result.error, undefined);
+    assert.equal(result.text, 'Compare <');
+});
+
+test('[DONE] cancels the undrained response body', async (t) => {
+    t.mock.method(console, 'log', () => {});
+    const result = await streamResponse(['Compare <'], 'done', { keepOpen: true });
+    assert.equal(result.error, undefined);
+    assert.equal(result.text, 'Compare <');
+    assert.equal(result.cancelled, true);
+});
+
+test('[DONE] reports cleanup errors without failing a completed response', async (t) => {
+    t.mock.method(console, 'log', () => {});
+    const logged = t.mock.method(console, 'error', () => {});
+    const result = await streamResponse(['Compare <'], 'done', { keepOpen: true, cancelError: true });
+    assert.equal(result.error, undefined);
+    assert.equal(result.text, 'Compare <');
+    assert.equal(result.cancelled, true);
+    assert.equal(logged.mock.callCount(), 1);
+    assert.match(logged.mock.calls[0].arguments[0], /Failed to close completed stream/);
+});
+
+test('cancellation cleans up pending suffixes without completion output', async (t) => {
+    t.mock.method(console, 'log', () => {});
+    let checks = 0;
+    const token = { get isCancellationRequested() { return checks++ > 0; } };
+    const result = await streamResponse(['Compare <'], 'eof', { token });
+    assert.equal(result.error, undefined);
+    assert.equal(result.text, 'Compare ');
+});


### PR DESCRIPTION
The VSCode provider lost tool calls when their opening markers, headers or terminators crossed stream chunks. It now preserves partial protocol data until the next chunk, so tool calls and surrounding answer text match unsplit input. Closes #3647.

## Test plan

- [x] npm test compiles the extension and runs 17 passing production-parser tests. Eleven initial cases failed on baseline. Strict TypeScript compilation and whitespace checks passed.
- [x] Changes read back for scope and correctness.
- [ ] Maintainer review and CI completion.

<details>
<summary>🔍 Evidence and limits</summary>

Tests execute the compiled provider and its actual SSE delta dispatch, varying every two-chunk boundary and fixed chunk width. Only VSCode response DTOs are substituted. This validates provider output; no live extension-host/model session was run.
</details>

Follow-up validation: 27 tests pass, including full ReadableStream SSE completion, trailing literal marker prefixes, active tool boundaries, errors/cancellation and exactly-once stream cleanup. Five new completion regressions failed the prior provider. The new VSCode CI lane runs locked installation and `npm test` (which compiles first) for extension and workflow edits.
