### PR TITLE
fix(code-index): clear stale indexes after empty rebuilds

### DIFF
--- a/docs/sdk/sdks/code-index.mdx
+++ b/docs/sdk/sdks/code-index.mdx
@@ -62,6 +62,10 @@ sdk = CodeIndexSDK(config)
 
 ### `index_repository() -> IndexResult`
 
+A successful rebuild with no source chunks clears any previous index, including
+its disk cache. If discovered files cannot be read or used and no chunks remain,
+the rebuild raises an error and retains the previous index instead.
+
 Discover source files, parse them, embed via Lemonade, and persist a FAISS index. Re-runs are incremental — unchanged files (matched by SHA-256) reuse their existing embeddings.
 
 ```python

--- a/docs/sdk/sdks/code-index.mdx
+++ b/docs/sdk/sdks/code-index.mdx
@@ -65,6 +65,8 @@ sdk = CodeIndexSDK(config)
 A successful rebuild with no source chunks clears any previous index, including
 its disk cache. If discovered files cannot be read or used and no chunks remain,
 the rebuild raises an error and retains the previous index instead.
+Directory traversal or file metadata errors also abort the rebuild and retain
+the previous index, rather than treating an unavailable repository as empty.
 
 Discover source files, parse them, embed via Lemonade, and persist a FAISS index. Re-runs are incremental — unchanged files (matched by SHA-256) reuse their existing embeddings.
 

--- a/docs/sdk/sdks/code-index.mdx
+++ b/docs/sdk/sdks/code-index.mdx
@@ -62,13 +62,14 @@ sdk = CodeIndexSDK(config)
 
 ### `index_repository() -> IndexResult`
 
-A successful rebuild with no source chunks clears any previous index, including
-its disk cache. If discovered files cannot be read or used and no chunks remain,
-the rebuild raises an error and retains the previous index instead.
-Directory traversal or file metadata errors also abort the rebuild and retain
-the previous index, rather than treating an unavailable repository as empty.
-
 Discover source files, parse them, embed via Lemonade, and persist a FAISS index. Re-runs are incremental — unchanged files (matched by SHA-256) reuse their existing embeddings.
+
+A complete rebuild with no source chunks clears any previous index and disk
+cache. Binary, out-of-scope, and vanished files are intentionally skipped. An
+empty result after a read failure or scan limit raises an actionable error and
+retains the previous index. Directory traversal and file metadata errors also
+abort the rebuild, except missing files (including dangling symlinks), which are
+skipped. A scan limit still permits indexing the nonempty results found so far.
 
 ```python
 result = sdk.index_repository()

--- a/src/gaia/code_index/sdk.py
+++ b/src/gaia/code_index/sdk.py
@@ -634,7 +634,11 @@ class CodeIndexSDK:
         # max_files cap below, and the truncation is logged loudly.
         entries_seen = 0
 
-        for root, dirs, files in os.walk(str(self._repo_root)):
+        def fail_discovery(error: OSError) -> None:
+            # An incomplete scan cannot establish that the index is empty.
+            raise error
+
+        for root, dirs, files in os.walk(str(self._repo_root), onerror=fail_discovery):
             rel_root = Path(root).relative_to(self._repo_root)
 
             # Filter out skipped directories in-place
@@ -677,10 +681,7 @@ class CodeIndexSDK:
                     continue
 
                 # Check size
-                try:
-                    size = os.path.getsize(abs_path)
-                except OSError:
-                    continue
+                size = os.path.getsize(abs_path)
                 if size > max_size_bytes:
                     self.log.debug(f"Skipping large file ({size} bytes): {rel_path}")
                     continue

--- a/src/gaia/code_index/sdk.py
+++ b/src/gaia/code_index/sdk.py
@@ -208,11 +208,13 @@ class CodeIndexSDK:
         new_chunks: List[CodeChunk] = []
         new_file_hashes: Dict[str, str] = {}
         files_indexed = 0
+        skipped_files = []
 
         for file_path in source_files:
             rel_path = str(Path(file_path).relative_to(self._repo_root))
             content = self._read_file_safe(file_path)
             if content is None:
+                skipped_files.append(rel_path)
                 continue
 
             file_hash = hashlib.sha256(
@@ -242,6 +244,13 @@ class CodeIndexSDK:
 
         all_chunks = reused_chunks + new_chunks
         if not all_chunks:
+            if skipped_files:
+                raise RuntimeError(
+                    "Cannot confirm an empty code index: source files could not "
+                    "be read or used. The previous index was retained. Check "
+                    f"permissions and file contents: {', '.join(skipped_files[:5])}"
+                )
+            self.clear_index()
             self.log.warning("No chunks to index")
             return IndexResult(
                 files_indexed=0,

--- a/src/gaia/code_index/sdk.py
+++ b/src/gaia/code_index/sdk.py
@@ -15,7 +15,7 @@ import os
 import time
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Tuple
 
 from gaia.llm.lemonade_client import DEFAULT_EMBEDDING_MODEL
 from gaia.llm.lemonade_launcher import describe_client_hint, describe_start_hint
@@ -197,7 +197,7 @@ class CodeIndexSDK:
                 ]
 
         # Discover source files
-        source_files = self._discover_files()
+        source_files, discovery_truncated = self._discover_files()
         self.log.info(f"Discovered {len(source_files)} source files")
 
         # Lazy import parsers
@@ -208,13 +208,17 @@ class CodeIndexSDK:
         new_chunks: List[CodeChunk] = []
         new_file_hashes: Dict[str, str] = {}
         files_indexed = 0
-        skipped_files = []
+        unreadable_files = []
 
         for file_path in source_files:
             rel_path = str(Path(file_path).relative_to(self._repo_root))
-            content = self._read_file_safe(file_path)
+            try:
+                content = self._read_file_safe(file_path)
+            except OSError as error:
+                unreadable_files.append(f"{rel_path}: {error}")
+                self.log.warning(f"Could not read {rel_path}: {error}")
+                continue
             if content is None:
-                skipped_files.append(rel_path)
                 continue
 
             file_hash = hashlib.sha256(
@@ -244,11 +248,17 @@ class CodeIndexSDK:
 
         all_chunks = reused_chunks + new_chunks
         if not all_chunks:
-            if skipped_files:
+            if unreadable_files:
                 raise RuntimeError(
                     "Cannot confirm an empty code index: source files could not "
-                    "be read or used. The previous index was retained. Check "
-                    f"permissions and file contents: {', '.join(skipped_files[:5])}"
+                    "be read. The previous index was retained. Check "
+                    f"permissions and retry: {', '.join(unreadable_files[:5])}"
+                )
+            if discovery_truncated:
+                raise RuntimeError(
+                    "Cannot confirm an empty code index: discovery reached its "
+                    "scan limit. The previous index was retained. Raise "
+                    "max_walk_entries or max_files, or narrow repo_path, and retry."
                 )
             self.clear_index()
             self.log.warning("No chunks to index")
@@ -559,10 +569,10 @@ class CodeIndexSDK:
         """SHA-256 of the resolved repo path — used as cache subdirectory."""
         return hashlib.sha256(str(self._repo_root).encode()).hexdigest()[:16]
 
-    def _discover_files(self) -> List[str]:
+    def _discover_files(self) -> Tuple[List[str], bool]:
         """
         Walk the repository, respecting .gitignore patterns and size/binary limits.
-        Returns list of absolute file paths.
+        Returns absolute file paths and whether a scan limit stopped the walk.
         """
         import fnmatch
 
@@ -633,10 +643,15 @@ class CodeIndexSDK:
         # giant assets/ subtree indexes what was found, exactly like the
         # max_files cap below, and the truncation is logged loudly.
         entries_seen = 0
+        truncated = False
 
         def fail_discovery(error: OSError) -> None:
             # An incomplete scan cannot establish that the index is empty.
-            raise error
+            raise RuntimeError(
+                f"Code index scan of {self._repo_root} failed: {error}. "
+                "The previous index was retained. Check that the repository "
+                "is available and readable, then retry."
+            ) from error
 
         for root, dirs, files in os.walk(str(self._repo_root), onerror=fail_discovery):
             rel_root = Path(root).relative_to(self._repo_root)
@@ -659,6 +674,7 @@ class CodeIndexSDK:
             entries_seen += len(dirs) + len(files)
 
             if len(result) >= self.config.max_files:
+                truncated = True
                 break
 
             for fname in files:
@@ -681,7 +697,13 @@ class CodeIndexSDK:
                     continue
 
                 # Check size
-                size = os.path.getsize(abs_path)
+                try:
+                    size = os.path.getsize(abs_path)
+                except FileNotFoundError:
+                    # Vanished files and dangling symlinks are genuinely absent.
+                    continue
+                except OSError as error:
+                    fail_discovery(error)
                 if size > max_size_bytes:
                     self.log.debug(f"Skipping large file ({size} bytes): {rel_path}")
                     continue
@@ -689,6 +711,7 @@ class CodeIndexSDK:
                 result.append(abs_path)
 
             if entries_seen > self.config.max_walk_entries:
+                truncated = True
                 self.log.warning(
                     f"discovery stopped after {entries_seen} directory "
                     f"entries under {self._repo_root} (max_walk_entries="
@@ -699,7 +722,7 @@ class CodeIndexSDK:
                 )
                 break
 
-        return result
+        return result, truncated
 
     def _read_gitignore_patterns(self) -> List[str]:
         """Read .gitignore patterns from repo root."""
@@ -716,7 +739,7 @@ class CodeIndexSDK:
         return patterns
 
     def _read_file_safe(self, file_path: str) -> Optional[str]:
-        """Read a file, returning None on error or binary content."""
+        """Read text; return None for absent/policy-skipped files, raise I/O errors."""
         # Validate the path is within the repo root
         if self._path_validator is not None:
             if not self._path_validator.is_path_allowed(file_path, prompt_user=False):
@@ -733,7 +756,7 @@ class CodeIndexSDK:
                 return Path(file_path).read_text(encoding="utf-8")
             except UnicodeDecodeError:
                 return Path(file_path).read_text(encoding="latin-1")
-        except OSError:
+        except FileNotFoundError:
             return None
 
     def _chunk_to_embed_text(self, chunk: CodeChunk) -> str:

--- a/tests/unit/test_code_index_empty.py
+++ b/tests/unit/test_code_index_empty.py
@@ -70,9 +70,80 @@ def test_failed_reindex_keeps_the_existing_generation(indexed_repo, failure):
             sdk, "_encode_texts_with_sync", side_effect=RuntimeError("embed")
         )
     else:
-        failing_call = patch.object(sdk, "_read_file_safe", return_value=None)
+        failing_call = patch.object(
+            sdk, "_read_file_safe", side_effect=PermissionError("access denied")
+        )
     with failing_call, pytest.raises((OSError, RuntimeError)):
         sdk.index_repository()
+    assert sdk._meta_path.read_bytes() == before
+    assert sdk._faiss_index.ntotal == 1
+    assert CodeIndexSDK(sdk.config).get_status()["total_chunks"] == 1
+
+
+@pytest.mark.parametrize(
+    "change", ["binary", "policy", "vanished_stat", "vanished_read"]
+)
+def test_intentional_skips_can_establish_an_empty_index(indexed_repo, change):
+    sdk, source = indexed_repo
+    if change == "binary":
+        source.write_bytes(b"\x00binary content")
+        context = patch.object(
+            sdk, "_load_embedder", side_effect=AssertionError("no model")
+        )
+    elif change == "policy":
+        context = patch.object(
+            sdk._path_validator, "is_path_allowed", return_value=False
+        )
+    else:
+        target = "os.path.getsize" if change == "vanished_stat" else "builtins.open"
+        original = os.path.getsize if change == "vanished_stat" else open
+
+        def disappear(path, *args, **kwargs):
+            if Path(path) == source:
+                source.unlink(missing_ok=True)
+            return original(path, *args, **kwargs)
+
+        context = patch(target, side_effect=disappear)
+    with context:
+        assert sdk.index_repository().chunks_created == 0
+    assert not sdk.is_indexed()
+    assert not sdk._meta_path.exists()
+    assert not sdk._index_path.exists()
+
+
+@pytest.mark.parametrize("candidate", ["no_files", "binary", "empty_text"])
+@pytest.mark.parametrize("limit", ["max_walk_entries", "max_files"])
+def test_truncated_scan_cannot_establish_empty_index(indexed_repo, candidate, limit):
+    sdk, source = indexed_repo
+    source.unlink()
+    nested = source.parent / "nested"
+    nested.mkdir()
+    (nested / "hidden.py").write_text("def hidden(): pass\n", encoding="utf-8")
+    if candidate == "binary":
+        source.write_bytes(b"\x00binary")
+    elif candidate == "empty_text":
+        source.write_text("", encoding="utf-8")
+    setattr(sdk.config, limit, 0)
+    before = sdk._meta_path.read_bytes()
+    with pytest.raises(RuntimeError, match="max_walk_entries"):
+        sdk.index_repository()
+    assert sdk._meta_path.read_bytes() == before
+    assert sdk._faiss_index.ntotal == 1
+
+
+def test_actual_read_permission_error_retains_cache(indexed_repo):
+    sdk, source = indexed_repo
+    original = open
+
+    def deny_source(path, *args, **kwargs):
+        if Path(path) == source:
+            raise PermissionError("source locked")
+        return original(path, *args, **kwargs)
+
+    before = sdk._meta_path.read_bytes()
+    with patch("builtins.open", side_effect=deny_source):
+        with pytest.raises(RuntimeError, match="permissions and retry"):
+            sdk.index_repository()
     assert sdk._meta_path.read_bytes() == before
     assert sdk._faiss_index.ntotal == 1
     assert CodeIndexSDK(sdk.config).get_status()["total_chunks"] == 1
@@ -94,7 +165,7 @@ def test_discovery_errors_do_not_erase_previous_index(indexed_repo, failure):
     index_before = sdk._index_path.read_bytes()
     if failure == "missing_root":
         source.parent.rename(source.parent.with_name("temporarily-unavailable"))
-        with pytest.raises(OSError):
+        with pytest.raises(RuntimeError, match="available and readable"):
             sdk.index_repository()
     else:
         target = "os.scandir" if failure == "walk" else "os.path.getsize"
@@ -106,7 +177,7 @@ def test_discovery_errors_do_not_erase_previous_index(indexed_repo, failure):
             return original(path)
 
         with patch(target, side_effect=deny_repository_access):
-            with pytest.raises(OSError, match="access denied"):
+            with pytest.raises(RuntimeError, match="access denied"):
                 sdk.index_repository()
     assert sdk._meta_path.read_bytes() == metadata_before
     assert sdk._index_path.read_bytes() == index_before

--- a/tests/unit/test_code_index_empty.py
+++ b/tests/unit/test_code_index_empty.py
@@ -2,6 +2,8 @@
 # SPDX-License-Identifier: MIT
 """Rebuilding an empty repository must not leave searchable deleted code."""
 
+import os
+from pathlib import Path
 from unittest.mock import patch
 
 import numpy as np
@@ -83,3 +85,29 @@ def test_fresh_empty_repository_needs_no_model(tmp_path):
     with patch.object(sdk, "_load_embedder", side_effect=AssertionError("no model")):
         assert sdk.index_repository().chunks_created == 0
         assert sdk.search("anything") == []
+
+
+@pytest.mark.parametrize("failure", ["missing_root", "walk", "stat"])
+def test_discovery_errors_do_not_erase_previous_index(indexed_repo, failure):
+    sdk, source = indexed_repo
+    metadata_before = sdk._meta_path.read_bytes()
+    index_before = sdk._index_path.read_bytes()
+    if failure == "missing_root":
+        source.parent.rename(source.parent.with_name("temporarily-unavailable"))
+        with pytest.raises(OSError):
+            sdk.index_repository()
+    else:
+        target = "os.scandir" if failure == "walk" else "os.path.getsize"
+        original = os.scandir if failure == "walk" else os.path.getsize
+
+        def deny_repository_access(path):
+            if Path(path) in (source, source.parent):
+                raise PermissionError("access denied")
+            return original(path)
+
+        with patch(target, side_effect=deny_repository_access):
+            with pytest.raises(OSError, match="access denied"):
+                sdk.index_repository()
+    assert sdk._meta_path.read_bytes() == metadata_before
+    assert sdk._index_path.read_bytes() == index_before
+    assert sdk._faiss_index.ntotal == 1

--- a/tests/unit/test_code_index_empty.py
+++ b/tests/unit/test_code_index_empty.py
@@ -1,0 +1,85 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""Rebuilding an empty repository must not leave searchable deleted code."""
+
+from unittest.mock import patch
+
+import numpy as np
+import pytest
+
+from gaia.code_index.sdk import CodeIndexConfig, CodeIndexSDK
+
+
+@pytest.fixture
+def indexed_repo(tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    source = repo / "old.py"
+    source.write_text("def obsolete_function():\n    return 1\n", encoding="utf-8")
+    config = CodeIndexConfig(repo_path=str(repo), cache_dir=str(tmp_path / "cache"))
+    sdk = CodeIndexSDK(config)
+    with patch.object(
+        sdk,
+        "_encode_texts_with_sync",
+        side_effect=lambda texts, chunks: (
+            np.ones((len(chunks), 4), dtype=np.float32),
+            chunks,
+        ),
+    ):
+        assert sdk.index_repository().chunks_created == 1
+    assert sdk.is_indexed()
+    return sdk, source
+
+
+@pytest.mark.parametrize("change", ["empty", "delete", "exclude"])
+def test_successful_empty_reindex_clears_memory_and_disk(indexed_repo, change):
+    sdk, source = indexed_repo
+    if change == "empty":
+        source.write_text("", encoding="utf-8")
+    elif change == "delete":
+        source.unlink()
+    else:
+        (source.parent / ".gitignore").write_text("old.py\n", encoding="utf-8")
+
+    with patch.object(sdk, "_load_embedder", side_effect=AssertionError("no model")):
+        assert sdk.index_repository().chunks_created == 0
+        assert sdk.search("obsolete_function") == []
+        assert not sdk.is_indexed()
+        assert not sdk.get_status()["indexed"]
+
+    reopened = CodeIndexSDK(sdk.config)
+    assert not reopened.get_status()["indexed"]
+    assert reopened.search("obsolete_function") == []
+
+
+@pytest.mark.parametrize("failure", ["scan", "parse", "embed", "unreadable"])
+def test_failed_reindex_keeps_the_existing_generation(indexed_repo, failure):
+    sdk, source = indexed_repo
+    source.write_text("def replacement():\n    return 2\n", encoding="utf-8")
+    before = sdk._meta_path.read_bytes()
+    if failure == "scan":
+        failing_call = patch.object(sdk, "_discover_files", side_effect=OSError("scan"))
+    elif failure == "parse":
+        failing_call = patch(
+            "gaia.code_index.parsers.chunk_code_file", side_effect=RuntimeError("parse")
+        )
+    elif failure == "embed":
+        failing_call = patch.object(
+            sdk, "_encode_texts_with_sync", side_effect=RuntimeError("embed")
+        )
+    else:
+        failing_call = patch.object(sdk, "_read_file_safe", return_value=None)
+    with failing_call, pytest.raises((OSError, RuntimeError)):
+        sdk.index_repository()
+    assert sdk._meta_path.read_bytes() == before
+    assert sdk._faiss_index.ntotal == 1
+    assert CodeIndexSDK(sdk.config).get_status()["total_chunks"] == 1
+
+
+def test_fresh_empty_repository_needs_no_model(tmp_path):
+    sdk = CodeIndexSDK(
+        CodeIndexConfig(repo_path=str(tmp_path), cache_dir=str(tmp_path / "cache"))
+    )
+    with patch.object(sdk, "_load_embedder", side_effect=AssertionError("no model")):
+        assert sdk.index_repository().chunks_created == 0
+        assert sdk.search("anything") == []

--- a/tests/unit/test_code_index_sdk.py
+++ b/tests/unit/test_code_index_sdk.py
@@ -681,9 +681,8 @@ class TestFilesystemFailureModes:
 
         assert result is None
 
-    def test_unreadable_file_is_skipped_not_crashed(self, tmp_path):
-        """A permission error while reading must be caught, not propagated —
-        one unreadable file must not abort the whole index."""
+    def test_unreadable_file_is_distinct_from_policy_skip(self, tmp_path):
+        """The caller must distinguish failed reads from intentionally skipped files."""
         skip_if_unavailable()
         sdk = make_sdk(tmp_path)
         f = tmp_path / "locked.py"
@@ -692,9 +691,8 @@ class TestFilesystemFailureModes:
         with patch(
             "pathlib.Path.read_text", side_effect=PermissionError("access denied")
         ):
-            result = sdk._read_file_safe(str(f))
-
-        assert result is None
+            with pytest.raises(PermissionError, match="access denied"):
+                sdk._read_file_safe(str(f))
 
 
 class TestDroppedChunksAreRetriedNextIndex:
@@ -770,9 +768,10 @@ class TestWalkBound:
         import logging
 
         with caplog.at_level(logging.WARNING):
-            files = sdk._discover_files()
+            files, truncated = sdk._discover_files()
 
         assert 0 < len(files) < 30
+        assert truncated
         assert any("max_walk_entries" in r.message for r in caplog.records)
 
     def test_default_budget_does_not_touch_a_normal_repo(self, tmp_path):
@@ -782,4 +781,6 @@ class TestWalkBound:
         for i in range(5):
             (repo / f"f{i}.py").write_text("x = 1\n", encoding="utf-8")
         sdk = make_sdk(tmp_path)
-        assert len(sdk._discover_files()) == 5
+        files, truncated = sdk._discover_files()
+        assert len(files) == 5
+        assert not truncated


### PR DESCRIPTION
A successful rebuild with no remaining source chunks left deleted code searchable from memory and disk. Empty rebuilds now clear the old index; unreadable sources or failed discovery abort and retain the previous generation. Closes #3644.

## Test plan

- [x] 62 code-index regression, SDK and mixin tests passed using real FAISS, parsing and cache files with controlled embeddings.
- [x] Four empty-index cases failed on baseline; three actual discovery-error cases failed on the initial fix and now pass.
- [x] Black, isort and whitespace checks passed. Tests pass scoped pylint; SDK retains the same pre-existing FAISS E1120 diagnostic.
- [x] Independent review finding on missing/denied repository scans resolved and read back.
- [ ] Maintainer review and CI completion.

A missing root, denied traversal or failed file stat preserves both cache files and the in-memory generation. The SDK guide documents successful emptiness versus incomplete rebuilds.

Follow-up: vanished files and policy-skipped/binary content can establish genuine emptiness. Permission failures and scans stopped by entry/file limits cannot erase the previous index. Eight added cases failed the previous fix; the final suite includes additional file-cap controls. Discovery errors name the repository and recovery step.
