### PR TITLE
fix(chat): load complete transcripts across message pages

### DIFF
--- a/src/gaia/apps/webui/src/components/ChatView.tsx
+++ b/src/gaia/apps/webui/src/components/ChatView.tsx
@@ -333,37 +333,46 @@ export function ChatView({ sessionId, onCreateAgent, onAgentChange }: ChatViewPr
         const t = log.chat.time();
         setLoadingMessages(true);
         let cancelled = false;
+        let loading = false;
 
-        const loadMessages = (isInitial = false) => {
-            api.getMessages(sessionId)
-                .then((data) => {
-                    if (cancelled) return;
-                    const msgs = (data.messages || []).map((m: any) => ({
-                        ...m,
-                        // Map snake_case agent_steps from API to camelCase agentSteps
-                        agentSteps: m.agentSteps || m.agent_steps || undefined,
-                        // Map inference_stats from API to stats field
-                        stats: m.stats || m.inference_stats || undefined,
-                    }));
-                    if (isInitial) {
-                        setMessages(msgs);
-                        lastMsgCountRef.current = msgs.length;
-                        log.chat.timed(`Loaded ${msgs.length} message(s) for session=${sessionId}`, t);
-                    } else if (msgs.length !== lastMsgCountRef.current && !useChatStore.getState().isStreaming) {
-                        // New messages from external source (MCP, API) — refresh
-                        log.chat.info(`Messages changed externally: ${lastMsgCountRef.current} -> ${msgs.length}`);
-                        setMessages(msgs);
-                        lastMsgCountRef.current = msgs.length;
-                    }
-                })
-                .catch((err) => {
-                    if (cancelled) return;
-                    if (isInitial) {
-                        log.chat.error(`Failed to load messages for session=${sessionId}`, err);
-                        setMessages([]);
-                    }
-                })
-                .finally(() => { if (!cancelled && isInitial) setLoadingMessages(false); });
+        const loadMessages = async (isInitial = false) => {
+            if (cancelled || loading) return;
+            loading = true;
+            try {
+                if (!isInitial) {
+                    if (useChatStore.getState().isStreaming) return;
+                    const total = await api.getMessageCount(sessionId);
+                    if (cancelled || total === lastMsgCountRef.current || useChatStore.getState().isStreaming) return;
+                }
+                const data = await api.getMessages(sessionId);
+                if (cancelled) return;
+                const msgs = (data.messages || []).map((m: any) => ({
+                    ...m,
+                    // Map snake_case agent_steps from API to camelCase agentSteps
+                    agentSteps: m.agentSteps || m.agent_steps || undefined,
+                    // Map inference_stats from API to stats field
+                    stats: m.stats || m.inference_stats || undefined,
+                }));
+                if (isInitial) {
+                    setMessages(msgs);
+                    lastMsgCountRef.current = msgs.length;
+                    log.chat.timed(`Loaded ${msgs.length} message(s) for session=${sessionId}`, t);
+                } else if (msgs.length !== lastMsgCountRef.current && !useChatStore.getState().isStreaming) {
+                    // New messages from external source (MCP, API) — refresh
+                    log.chat.info(`Messages changed externally: ${lastMsgCountRef.current} -> ${msgs.length}`);
+                    setMessages(msgs);
+                    lastMsgCountRef.current = msgs.length;
+                }
+            } catch (err) {
+                if (cancelled) return;
+                if (isInitial) {
+                    log.chat.error(`Failed to load messages for session=${sessionId}`, err);
+                    setMessages([]);
+                }
+            } finally {
+                loading = false;
+                if (!cancelled && isInitial) setLoadingMessages(false);
+            }
         };
 
         loadMessages(true);

--- a/src/gaia/apps/webui/src/components/__tests__/ChatView.transcript.test.tsx
+++ b/src/gaia/apps/webui/src/components/__tests__/ChatView.transcript.test.tsx
@@ -1,0 +1,81 @@
+// Copyright(C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+import { act, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, expect, it, vi } from 'vitest';
+import { ChatView } from '../ChatView';
+import { useChatStore } from '../../stores/chatStore';
+import type { Message, Session } from '../../types';
+
+const session: Session = {
+    id: 'long-chat', title: 'Existing chat', model: 'qwen', agent_type: 'chat',
+    created_at: '2026-09-11T00:00:00Z', updated_at: '2026-09-11T00:00:00Z',
+    system_prompt: null, message_count: 105, document_ids: [],
+};
+let messages: Message[];
+let offsets: number[];
+
+beforeEach(() => {
+    messages = Array.from({ length: 105 }, (_, index) => ({
+        id: index + 1, session_id: session.id, role: index % 2 ? 'assistant' : 'user',
+        content: `Transcript entry ${index + 1}`, created_at: session.created_at, rag_sources: null,
+    }));
+    offsets = [];
+    // Keep the real API service, store, ChatView and message rendering. Only
+    // HTTP responses are substituted, using the server's limit/offset contract.
+    vi.stubGlobal('fetch', vi.fn(async (input: string) => {
+        const url = new URL(input, 'http://localhost');
+        let body: unknown;
+        if (url.pathname === `/api/sessions/${session.id}/messages`) {
+            const offset = Number(url.searchParams.get('offset') || 0);
+            const limit = Number(url.searchParams.get('limit') || 100);
+            offsets.push(offset);
+            body = { messages: messages.slice(offset, offset + limit), total: messages.length };
+        } else if (url.pathname === '/api/chat/active') {
+            body = { session_ids: [] };
+        } else if (url.pathname === '/api/documents') {
+            body = { documents: [], total: 0, total_size_bytes: 0, total_chunks: 0 };
+        } else {
+            throw new Error(`Unexpected request: ${url}`);
+        }
+        return new Response(JSON.stringify(body), { headers: { 'content-type': 'application/json' } });
+    }));
+    Object.defineProperty(HTMLElement.prototype, 'scrollIntoView', {
+        configurable: true, value: vi.fn(),
+    });
+    useChatStore.setState({
+        agents: [], activeAgentId: 'chat', sessions: [session], currentSessionId: session.id,
+        messages: [], documents: [], isStreaming: false, streamingContent: '', agentSteps: [],
+        isLoadingMessages: false, pendingPrompt: null, systemStatus: null, runningSessionIds: [],
+    });
+});
+
+afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+});
+
+it('renders the latest message after closing and reopening a long conversation', async () => {
+    const view = render(<ChatView sessionId={session.id} />);
+    await waitFor(() => expect(screen.getByText('Transcript entry 105')).toBeInTheDocument());
+    expect(screen.getByText('Transcript entry 1')).toBeInTheDocument();
+    expect(useChatStore.getState().messages).toHaveLength(105);
+    view.unmount();
+
+    messages.push({ ...messages[104], id: 106, role: 'assistant', content: 'Latest reply after reopening' });
+    act(() => useChatStore.setState({ messages: [] }));
+    render(<ChatView sessionId={session.id} />);
+    await waitFor(() => expect(screen.getByText('Latest reply after reopening')).toBeInTheDocument());
+    await waitFor(() => expect(useChatStore.getState().messages).toHaveLength(106));
+    expect(offsets).toEqual([0, 100, 0, 100]);
+});
+
+it('refreshes external messages beyond the first page during normal polling', async () => {
+    render(<ChatView sessionId={session.id} />);
+    await waitFor(() => expect(screen.getByText('Transcript entry 105')).toBeInTheDocument());
+    messages.push({ ...messages[104], id: 106, role: 'assistant', content: 'External reply after page 1' });
+    await waitFor(() => expect(screen.getByText('External reply after page 1')).toBeInTheDocument(), {
+        timeout: 5000,
+    });
+    expect(useChatStore.getState().messages).toHaveLength(106);
+});

--- a/src/gaia/apps/webui/src/components/__tests__/ChatView.transcript.test.tsx
+++ b/src/gaia/apps/webui/src/components/__tests__/ChatView.transcript.test.tsx
@@ -10,17 +10,23 @@ import type { Message, Session } from '../../types';
 const session: Session = {
     id: 'long-chat', title: 'Existing chat', model: 'qwen', agent_type: 'chat',
     created_at: '2026-09-11T00:00:00Z', updated_at: '2026-09-11T00:00:00Z',
-    system_prompt: null, message_count: 105, document_ids: [],
+    system_prompt: null, message_count: 205, document_ids: [],
 };
 let messages: Message[];
 let offsets: number[];
+let requests: Array<{ limit: number; offset: number }>;
+let beforeMessages: ((url: URL) => Promise<void>) | undefined;
 
 beforeEach(() => {
-    messages = Array.from({ length: 105 }, (_, index) => ({
+    // Advance polling deterministically without replacing waitFor's timers.
+    vi.useFakeTimers({ toFake: ['setInterval', 'clearInterval'] });
+    messages = Array.from({ length: 205 }, (_, index) => ({
         id: index + 1, session_id: session.id, role: index % 2 ? 'assistant' : 'user',
         content: `Transcript entry ${index + 1}`, created_at: session.created_at, rag_sources: null,
     }));
     offsets = [];
+    requests = [];
+    beforeMessages = undefined;
     // Keep the real API service, store, ChatView and message rendering. Only
     // HTTP responses are substituted, using the server's limit/offset contract.
     vi.stubGlobal('fetch', vi.fn(async (input: string) => {
@@ -30,6 +36,8 @@ beforeEach(() => {
             const offset = Number(url.searchParams.get('offset') || 0);
             const limit = Number(url.searchParams.get('limit') || 100);
             offsets.push(offset);
+            requests.push({ limit, offset });
+            await beforeMessages?.(url);
             body = { messages: messages.slice(offset, offset + limit), total: messages.length };
         } else if (url.pathname === '/api/chat/active') {
             body = { session_ids: [] };
@@ -51,31 +59,121 @@ beforeEach(() => {
 });
 
 afterEach(() => {
+    vi.useRealTimers();
     vi.unstubAllGlobals();
     vi.restoreAllMocks();
 });
 
 it('renders the latest message after closing and reopening a long conversation', async () => {
     const view = render(<ChatView sessionId={session.id} />);
-    await waitFor(() => expect(screen.getByText('Transcript entry 105')).toBeInTheDocument());
+    await waitFor(() => expect(screen.getByText('Transcript entry 205')).toBeInTheDocument());
     expect(screen.getByText('Transcript entry 1')).toBeInTheDocument();
-    expect(useChatStore.getState().messages).toHaveLength(105);
+    expect(useChatStore.getState().messages).toHaveLength(205);
     view.unmount();
 
-    messages.push({ ...messages[104], id: 106, role: 'assistant', content: 'Latest reply after reopening' });
+    messages.push({ ...messages[204], id: 206, role: 'assistant', content: 'Latest reply after reopening' });
     act(() => useChatStore.setState({ messages: [] }));
     render(<ChatView sessionId={session.id} />);
     await waitFor(() => expect(screen.getByText('Latest reply after reopening')).toBeInTheDocument());
-    await waitFor(() => expect(useChatStore.getState().messages).toHaveLength(106));
-    expect(offsets).toEqual([0, 100, 0, 100]);
+    await waitFor(() => expect(useChatStore.getState().messages).toHaveLength(206));
+    expect(offsets).toEqual([0, 100, 200, 0, 100, 200]);
 });
 
 it('refreshes external messages beyond the first page during normal polling', async () => {
     render(<ChatView sessionId={session.id} />);
-    await waitFor(() => expect(screen.getByText('Transcript entry 105')).toBeInTheDocument());
-    messages.push({ ...messages[104], id: 106, role: 'assistant', content: 'External reply after page 1' });
-    await waitFor(() => expect(screen.getByText('External reply after page 1')).toBeInTheDocument(), {
-        timeout: 5000,
-    });
-    expect(useChatStore.getState().messages).toHaveLength(106);
+    await waitFor(() => expect(screen.getByText('Transcript entry 205')).toBeInTheDocument());
+    messages.push({ ...messages[204], id: 206, role: 'assistant', content: 'External reply after page 1' });
+    requests = [];
+    await act(async () => vi.advanceTimersByTimeAsync(3000));
+    await waitFor(() => expect(screen.getByText('External reply after page 1')).toBeInTheDocument());
+    expect(useChatStore.getState().messages).toHaveLength(206);
+    expect(requests).toEqual([
+        { limit: 1, offset: 0 }, { limit: 100, offset: 0 },
+        { limit: 100, offset: 100 }, { limit: 6, offset: 200 },
+    ]);
+});
+
+it('probes unchanged long transcripts once per tick without reloading their pages', async () => {
+    render(<ChatView sessionId={session.id} />);
+    await waitFor(() => expect(screen.getByText('Transcript entry 205')).toBeInTheDocument());
+    requests = [];
+    await act(async () => vi.advanceTimersByTimeAsync(6000));
+    expect(requests).toEqual([{ limit: 1, offset: 0 }, { limit: 1, offset: 0 }]);
+    expect(useChatStore.getState().messages).toHaveLength(205);
+});
+
+function deferred() {
+    let resolve!: () => void;
+    const promise = new Promise<void>((done) => { resolve = done; });
+    return { promise, resolve };
+}
+
+it('does not overlap a slow count probe with later polls', async () => {
+    render(<ChatView sessionId={session.id} />);
+    await waitFor(() => expect(screen.getByText('Transcript entry 205')).toBeInTheDocument());
+    const gate = deferred();
+    beforeMessages = () => gate.promise;
+    requests = [];
+    await act(async () => vi.advanceTimersByTimeAsync(9000));
+    expect(requests).toEqual([{ limit: 1, offset: 0 }]);
+    await act(async () => gate.resolve());
+    beforeMessages = undefined;
+    await act(async () => vi.advanceTimersByTimeAsync(3000));
+    expect(requests).toEqual([{ limit: 1, offset: 0 }, { limit: 1, offset: 0 }]);
+});
+
+it('does not start polling while the initial paged load is in flight', async () => {
+    const gate = deferred();
+    beforeMessages = () => gate.promise;
+    render(<ChatView sessionId={session.id} />);
+    await act(async () => vi.advanceTimersByTimeAsync(9000));
+    expect(requests).toEqual([{ limit: 100, offset: 0 }]);
+    beforeMessages = undefined;
+    await act(async () => gate.resolve());
+    await waitFor(() => expect(screen.getByText('Transcript entry 205')).toBeInTheDocument());
+    expect(requests).toHaveLength(3);
+});
+
+it('keeps the transcript after a failed count probe and retries the next tick', async () => {
+    render(<ChatView sessionId={session.id} />);
+    await waitFor(() => expect(screen.getByText('Transcript entry 205')).toBeInTheDocument());
+    beforeMessages = async () => { throw new Error('Count probe failed'); };
+    requests = [];
+    await act(async () => vi.advanceTimersByTimeAsync(3000));
+    expect(useChatStore.getState().messages).toHaveLength(205);
+    beforeMessages = undefined;
+    messages.push({ ...messages[204], id: 206, content: 'Reply after count retry' });
+    await act(async () => vi.advanceTimersByTimeAsync(3000));
+    await waitFor(() => expect(screen.getByText('Reply after count retry')).toBeInTheDocument());
+    expect(requests.filter(({ limit }) => limit === 1)).toHaveLength(2);
+});
+
+it('does not start an old session reload when its count probe completes after switching', async () => {
+    const view = render(<ChatView sessionId={session.id} />);
+    await waitFor(() => expect(screen.getByText('Transcript entry 205')).toBeInTheDocument());
+    const gate = deferred();
+    beforeMessages = () => gate.promise;
+    requests = [];
+    await act(async () => vi.advanceTimersByTimeAsync(3000));
+
+    const other = { ...session, id: 'other-chat' };
+    const otherMessage = { ...messages[0], session_id: other.id, content: 'Other session reply' };
+    const oldFetch = fetch;
+    vi.stubGlobal('fetch', vi.fn(async (input: string, init?: RequestInit) => {
+        if (new URL(input, 'http://localhost').pathname === `/api/sessions/${other.id}/messages`) {
+            return new Response(JSON.stringify({ messages: [otherMessage], total: 1 }), {
+                headers: { 'content-type': 'application/json' },
+            });
+        }
+        return oldFetch(input, init);
+    }));
+    act(() => useChatStore.setState({ sessions: [session, other], currentSessionId: other.id }));
+    view.rerender(<ChatView sessionId={other.id} />);
+    await waitFor(() => expect(screen.getByText('Other session reply')).toBeInTheDocument());
+    // A changed count would trigger an old-session load without the cancellation check.
+    messages.push({ ...messages[204], id: 206, content: 'Old session late reply' });
+    beforeMessages = undefined;
+    await act(async () => gate.resolve());
+    expect(requests).toEqual([{ limit: 1, offset: 0 }]);
+    expect(useChatStore.getState().messages.map((message) => message.content)).toEqual(['Other session reply']);
 });

--- a/src/gaia/apps/webui/src/services/__tests__/api.messages.test.ts
+++ b/src/gaia/apps/webui/src/services/__tests__/api.messages.test.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { getMessages } from '../api';
+import { getMessageCount, getMessages } from '../api';
 
 function jsonResponse(body: unknown, status = 200): Response {
     return new Response(JSON.stringify(body), {
@@ -36,6 +36,14 @@ afterEach(() => {
 });
 
 describe('complete transcript retrieval', () => {
+    it('probes the count with one minimal page request', async () => {
+        const requests = serveTranscript(transcript(205));
+        expect(await getMessageCount('long-chat')).toBe(205);
+        expect(requests).toHaveLength(1);
+        expect(requests[0].searchParams.get('limit')).toBe('1');
+        expect(requests[0].searchParams.get('offset')).toBe('0');
+    });
+
     it.each([0, 1, 100, 101, 205])('loads all %i messages in order with metadata intact', async (count) => {
         const messages = transcript(count);
         const requests = serveTranscript(messages);

--- a/src/gaia/apps/webui/src/services/__tests__/api.messages.test.ts
+++ b/src/gaia/apps/webui/src/services/__tests__/api.messages.test.ts
@@ -1,0 +1,81 @@
+// Copyright(C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { getMessages } from '../api';
+
+function jsonResponse(body: unknown, status = 200): Response {
+    return new Response(JSON.stringify(body), {
+        status, headers: { 'content-type': 'application/json' },
+    });
+}
+
+function transcript(count: number) {
+    return Array.from({ length: count }, (_, index) => ({
+        id: index + 1, session_id: 'long-chat', role: index % 2 ? 'assistant' : 'user',
+        content: `Message ${index + 1}`, created_at: '2026-09-11T00:00:00Z',
+        agent_steps: [{ type: 'tool_call', tool: 'read_file', args: { path: 'README.md' } }],
+    }));
+}
+
+function serveTranscript(messages: ReturnType<typeof transcript>) {
+    const requests: URL[] = [];
+    vi.stubGlobal('fetch', vi.fn(async (input: string) => {
+        const url = new URL(input, 'http://localhost');
+        requests.push(url);
+        const offset = Number(url.searchParams.get('offset') || 0);
+        const limit = Number(url.searchParams.get('limit') || 100);
+        return jsonResponse({ messages: messages.slice(offset, offset + limit), total: messages.length });
+    }));
+    return requests;
+}
+
+afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+});
+
+describe('complete transcript retrieval', () => {
+    it.each([0, 1, 100, 101, 205])('loads all %i messages in order with metadata intact', async (count) => {
+        const messages = transcript(count);
+        const requests = serveTranscript(messages);
+        expect(await getMessages('long-chat')).toEqual({ messages, total: count });
+        expect(requests).toHaveLength(Math.max(1, Math.ceil(count / 100)));
+        expect(requests.map((url) => Number(url.searchParams.get('offset') || 0)))
+            .toEqual(Array.from({ length: requests.length }, (_, index) => index * 100));
+    });
+
+    it('bounds a retrieval to the initial count when new messages arrive during paging', async () => {
+        const messages = transcript(250);
+        const requests: URL[] = [];
+        vi.stubGlobal('fetch', vi.fn(async (input: string) => {
+            const url = new URL(input, 'http://localhost');
+            requests.push(url);
+            const offset = Number(url.searchParams.get('offset') || 0);
+            const limit = Number(url.searchParams.get('limit') || 100);
+            return jsonResponse({
+                messages: messages.slice(offset, offset + limit),
+                total: requests.length === 1 ? 150 : 250,
+            });
+        }));
+        expect(await getMessages('long-chat')).toEqual({ messages: messages.slice(0, 150), total: 150 });
+        expect(requests).toHaveLength(2);
+        expect(requests[1].searchParams.get('limit')).toBe('50');
+    });
+
+    it('surfaces a later page failure instead of returning a partial transcript', async () => {
+        vi.stubGlobal('fetch', vi.fn()
+            .mockResolvedValueOnce(jsonResponse({ messages: transcript(100), total: 101 }))
+            .mockResolvedValueOnce(jsonResponse({ detail: 'unavailable' }, 503)));
+        await expect(getMessages('long-chat')).rejects.toThrow('unavailable');
+    });
+
+    it('fails on an empty page before the reported end instead of looping forever', async () => {
+        const request = vi.fn()
+            .mockResolvedValueOnce(jsonResponse({ messages: transcript(100), total: 101 }))
+            .mockResolvedValueOnce(jsonResponse({ messages: [], total: 101 }));
+        vi.stubGlobal('fetch', request);
+        await expect(getMessages('long-chat')).rejects.toThrow(/incomplete transcript/i);
+        expect(request).toHaveBeenCalledTimes(2);
+    });
+});

--- a/src/gaia/apps/webui/src/services/api.ts
+++ b/src/gaia/apps/webui/src/services/api.ts
@@ -453,7 +453,26 @@ export async function toggleSessionPrivacy(id: string): Promise<Session> {
 }
 
 export async function getMessages(sessionId: string): Promise<{ messages: Message[]; total: number }> {
-    return apiFetch('GET', `/sessions/${sessionId}/messages`);
+    const pageSize = 100;
+    const path = `/sessions/${sessionId}/messages`;
+    const first = await apiFetch<{ messages: Message[]; total: number }>(
+        'GET', `${path}?limit=${pageSize}&offset=0`,
+    );
+    const messages = [...first.messages];
+    // Bound this load to its initial count; a running agent may keep appending.
+    // The next refresh retrieves those newer messages.
+    const total = first.total;
+    while (messages.length < total) {
+        const limit = Math.min(pageSize, total - messages.length);
+        const page = await apiFetch<{ messages: Message[]; total: number }>(
+            'GET', `${path}?limit=${limit}&offset=${messages.length}`,
+        );
+        if (page.messages.length === 0) {
+            throw new Error('Incomplete transcript received. Please reload the conversation.');
+        }
+        messages.push(...page.messages);
+    }
+    return { messages, total };
 }
 
 export async function exportSession(sessionId: string): Promise<{ content: string }> {

--- a/src/gaia/apps/webui/src/services/api.ts
+++ b/src/gaia/apps/webui/src/services/api.ts
@@ -452,6 +452,13 @@ export async function toggleSessionPrivacy(id: string): Promise<Session> {
     return apiFetch('PATCH', `/sessions/${id}/private`);
 }
 
+export async function getMessageCount(sessionId: string): Promise<number> {
+    const { total } = await apiFetch<{ messages: Message[]; total: number }>(
+        'GET', `/sessions/${sessionId}/messages?limit=1&offset=0`,
+    );
+    return total;
+}
+
 export async function getMessages(sessionId: string): Promise<{ messages: Message[]; total: number }> {
     const pageSize = 100;
     const path = `/sessions/${sessionId}/messages`;


### PR DESCRIPTION
Reopening a chat with more than 100 messages showed only the beginning of the transcript, and polling missed later replies. The shared client now loads all pages up to the first response's count, preserving message order and metadata and surfacing incomplete responses. Closes #3662.

## Test plan

- [x] 34 distinct API and ChatView tests passed, including real component/store/client reload and polling beyond the first page.
- [x] Six baseline regressions failed before the fix.
- [x] TypeScript typecheck, production build and whitespace checks passed; no dependency or lockfile changes.
- [x] Independent readback/review completed.
- [ ] Maintainer review and CI completion. Rendered screenshot pending hardware lane.

<details>
<summary>🔍 Route evidence and limits</summary>

The actual FastAPI messages endpoint with a real SQLite transcript returned HTTP 200 pages of 100, 100, 5 messages at offsets 0, 100, 200; total 205 and ranges 1–100,101–200,201–205. A missing session returned 404. Client tests execute real apiFetch with controlled HTTP responses; React tests execute the real ChatView and store.

Retrieval is bounded to the initial total so a running agent cannot extend the loop forever. Existing offset pagination is not atomic against concurrent deletion/reordering. No live model inference or rendered screenshot is claimed.
</details>

Polling follow-up: unchanged long chats now fetch one count probe per tick instead of every transcript page. Changed counts trigger a full load. An in-flight guard prevents overlapping requests and stale session completions are ignored. 40 API/ChatView tests and the production build pass; three new regressions failed the previous commit. Count-probe failures retain the displayed transcript and retry on the next tick.
